### PR TITLE
deps(android): bump org.jetbrains.kotlin.android from 2.1.0 to 2.2.21

### DIFF
--- a/app/android/settings.gradle.kts
+++ b/app/android/settings.gradle.kts
@@ -20,7 +20,7 @@ pluginManagement {
 plugins {
     id("dev.flutter.flutter-plugin-loader") version "1.0.0"
     id("com.android.application") version "8.13.1" apply false
-    id("org.jetbrains.kotlin.android") version "2.1.0" apply false
+    id("org.jetbrains.kotlin.android") version "2.2.21" apply false
 }
 
 include(":app")


### PR DESCRIPTION
Bumps org.jetbrains.kotlin.android from 2.1.0 to 2.2.21

This is a direct fix since the Dependabot PR #37 had merge conflicts.