### PR TITLE
fix: Replace mock Gemini Nano with real ML Kit GenAI API integration

### DIFF
--- a/app/android/app/build.gradle.kts
+++ b/app/android/app/build.gradle.kts
@@ -54,12 +54,15 @@ dependencies {
     // Core library desugaring for flutter_local_notifications
     coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.1.5")
 
-    // Gemini Nano (AI Core) dependencies for on-device AI
-    // Based on: https://developer.android.com/ai/gemini-nano
-    // Note: Actual AI Core SDK integration pending - currently using mock responses
+    // ML Kit GenAI Prompt API for on-device Gemini Nano
+    // Based on: https://developers.google.com/ml-kit/genai/prompt/android/get-started
+    implementation("com.google.mlkit:genai-prompt:1.0.0-beta1")
+
+    // Coroutines and lifecycle dependencies for async operations
     implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.10.0")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.10.2")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.10.2")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-play-services:1.10.2")
 }
 
 flutter {

--- a/packages/core_ai/lib/src/llm/gemini_nano_client.dart
+++ b/packages/core_ai/lib/src/llm/gemini_nano_client.dart
@@ -25,10 +25,8 @@ class GeminiNanoClient implements LLMClient {
   }) : _config = config ?? LLMConfig.geminiNano,
        _memoryBudgetManager = memoryBudgetManager ?? MemoryBudgetManager();
 
-  static const _channel = MethodChannel('com.airo.superapp/gemini_nano');
-  static const _eventChannel = EventChannel(
-    'com.airo.superapp/gemini_nano_stream',
-  );
+  static const _channel = MethodChannel('com.airo.gemini_nano');
+  static const _eventChannel = EventChannel('com.airo.gemini_nano/stream');
 
   /// Estimated Gemini Nano model size in bytes (~2.5GB).
   /// This is used for memory budget calculations.
@@ -177,8 +175,8 @@ class GeminiNanoClient implements LLMClient {
     }
 
     try {
-      // Start streaming generation
-      await _channel.invokeMethod('startStreamGeneration', {'prompt': prompt});
+      // Start streaming generation (method name matches Android plugin)
+      await _channel.invokeMethod('generateContentStream', {'prompt': prompt});
 
       // Listen to stream
       await for (final chunk in _eventChannel.receiveBroadcastStream()) {


### PR DESCRIPTION
- Add ML Kit GenAI Prompt dependency (com.google.mlkit:genai-prompt:1.0.0-beta1)
- Fix channel name mismatch in GeminiNanoClient (com.airo.gemini_nano)
- Fix method name mismatch (generateContentStream instead of startStreamGeneration)
- Update GeminiNanoPlugin to use correct ML Kit GenAI API patterns:
  - checkStatus() returns int directly (no await needed)
  - download() returns Flow<DownloadStatus> with correct subclasses
  - generateContent() is a suspend function (no await needed)
  - generateContentStream() returns Flow<GenerateContentResponse>
- Tested successfully on Pixel 9 with real AI responses