### PR TITLE
fix(agent-skills): add iOS calendar read connector

### DIFF
--- a/app/ios/Runner/AppDelegate.swift
+++ b/app/ios/Runner/AppDelegate.swift
@@ -25,6 +25,19 @@ import UIKit
         binaryMessenger: controller.binaryMessenger
       ).setMethodCallHandler { [weak self] call, result in
         switch call.method {
+        case "readCalendarEvents":
+          guard
+            let arguments = call.arguments as? [String: Any],
+            let date = arguments["date"] as? String,
+            !date.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+          else {
+            result([
+              "error": "missing_date",
+              "message": "Calendar lookup requires a date.",
+            ])
+            return
+          }
+          self?.readCalendarEvents(date: date, result: result)
         case "createCalendarEvent":
           guard let arguments = call.arguments as? [String: Any] else {
             result([
@@ -41,6 +54,62 @@ import UIKit
     }
 
     return super.application(application, didFinishLaunchingWithOptions: launchOptions)
+  }
+
+  private func readCalendarEvents(date: String, result: @escaping FlutterResult) {
+    requestCalendarAccess { [weak self] granted in
+      guard let self else { return }
+      guard granted else {
+        result([
+          "error": "calendar_permission_denied",
+          "message": "Calendar permission is required to check your schedule.",
+        ])
+        return
+      }
+
+      guard let startDate = self.dayStart(from: date) else {
+        result([
+          "error": "invalid_date",
+          "message": "Calendar date must use YYYY-MM-DD.",
+        ])
+        return
+      }
+
+      guard let endDate = Calendar.current.date(byAdding: .day, value: 1, to: startDate) else {
+        result([
+          "error": "invalid_date",
+          "message": "Calendar date must use YYYY-MM-DD.",
+        ])
+        return
+      }
+
+      let predicate = self.eventStore.predicateForEvents(
+        withStart: startDate,
+        end: endDate,
+        calendars: nil
+      )
+      let formatter = ISO8601DateFormatter()
+      formatter.formatOptions = [.withInternetDateTime, .withColonSeparatorInTimeZone]
+
+      let events = self.eventStore.events(matching: predicate)
+        .sorted { $0.startDate < $1.startDate }
+        .map { event in
+          var payload = [
+            "title": event.title ?? "Untitled event",
+            "start": formatter.string(from: event.startDate),
+            "end": formatter.string(from: event.endDate),
+          ] as [String: Any]
+          if let calendarTitle = event.calendar?.title {
+            payload["calendar"] = calendarTitle
+          }
+          return payload
+        }
+
+      result([
+        "date": date,
+        "events": events,
+      ])
+    }
   }
 
   private func createCalendarEvent(arguments: [String: Any], result: @escaping FlutterResult) {
@@ -111,6 +180,17 @@ import UIKit
         ])
       }
     }
+  }
+
+  private func dayStart(from date: String) -> Date? {
+    let formatter = DateFormatter()
+    formatter.calendar = Calendar(identifier: .gregorian)
+    formatter.locale = Locale(identifier: "en_US_POSIX")
+    formatter.timeZone = .current
+    formatter.dateFormat = "yyyy-MM-dd"
+    formatter.isLenient = false
+    guard let parsedDate = formatter.date(from: date) else { return nil }
+    return Calendar.current.startOfDay(for: parsedDate)
   }
 
   private func requestCalendarAccess(completion: @escaping (Bool) -> Void) {

--- a/app/pubspec_ios_spm.yaml
+++ b/app/pubspec_ios_spm.yaml
@@ -75,7 +75,8 @@ dependencies:
   share_plus: ^10.0.0
   url_launcher: 6.3.2
   file_picker: 10.3.10
-  flutter_local_notifications: 19.5.0
+  pdfx: 2.9.2
+  flutter_local_notifications: 20.1.0
   timezone: 0.10.1
   audioplayers: 6.5.1
   cached_network_image: 3.4.1
@@ -143,6 +144,12 @@ dependency_overrides:
     path: ../packages/stubs/flutter_contacts_stub
   permission_handler:
     path: ../packages/stubs/permission_handler_stub
+  flutter_local_notifications:
+    path: ../packages/stubs/flutter_local_notifications_stub
+  timezone:
+    path: ../packages/stubs/timezone_stub
+  pdfx:
+    path: ../packages/stubs/pdfx_stub
 
 flutter:
   uses-material-design: true

--- a/app/test/features/agent_chat/data/connectors/calendar_connector_test.dart
+++ b/app/test/features/agent_chat/data/connectors/calendar_connector_test.dart
@@ -1,0 +1,69 @@
+import 'package:airo_app/features/agent_chat/data/connectors/calendar_connector.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('NativeCalendarConnector', () {
+    test('reads events through the native calendar method channel', () async {
+      TestWidgetsFlutterBinding.ensureInitialized();
+      const channel = MethodChannel('test.agent_connectors.calendar_read');
+      final calls = <MethodCall>[];
+
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(channel, (call) async {
+            calls.add(call);
+            return {
+              'date': call.arguments['date'],
+              'events': [
+                {
+                  'title': 'Design review',
+                  'start': '2026-06-22T10:00:00+05:30',
+                  'end': '2026-06-22T10:30:00+05:30',
+                  'calendar': 'Work',
+                },
+              ],
+            };
+          });
+      addTearDown(() {
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .setMockMethodCallHandler(channel, null);
+      });
+
+      final connector = NativeCalendarConnector(channel: channel);
+
+      final result = await connector.execute({'date': '2026-06-22'});
+
+      expect(result.isError, isFalse);
+      expect(result.data['date'], '2026-06-22');
+      expect(result.data['events'], isA<List>());
+      expect(calls.single.method, 'readCalendarEvents');
+      expect(calls.single.arguments, {'date': '2026-06-22'});
+    });
+
+    test('maps native calendar errors to connector errors', () async {
+      TestWidgetsFlutterBinding.ensureInitialized();
+      const channel = MethodChannel('test.agent_connectors.calendar_error');
+
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(channel, (_) async {
+            return {
+              'error': 'calendar_permission_denied',
+              'message':
+                  'Calendar permission is required to check your schedule.',
+            };
+          });
+      addTearDown(() {
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .setMockMethodCallHandler(channel, null);
+      });
+
+      final connector = NativeCalendarConnector(channel: channel);
+
+      final result = await connector.execute({'date': '2026-06-22'});
+
+      expect(result.isError, isTrue);
+      expect(result.errorCode, 'calendar_permission_denied');
+      expect(result.message, contains('permission'));
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- implement the iOS readCalendarEvents method-channel handler for Agent Skills calendar reads
- align the local iOS simulator pubspec with existing reduced-variant stubs
- add focused Dart connector tests for native calendar read success/error mapping

## Verification
- flutter test test/features/agent_chat/data/connectors/calendar_connector_test.dart test/features/agent_chat/domain/services/agent_skill_orchestrator_test.dart
- flutter analyze test/features/agent_chat/data/connectors/calendar_connector_test.dart lib/features/agent_chat/data/connectors/calendar_connector.dart
- make build-ios-simulator-local