### PR TITLE
fix(ci): remove duplicate reduced pubspec entries

### DIFF
--- a/app/pubspec_streaming.yaml
+++ b/app/pubspec_streaming.yaml
@@ -96,12 +96,9 @@ dependencies:
   file_picker: 10.3.10
   share_plus: 10.1.4
   url_launcher: 6.3.2
-  flutter_local_notifications: ^22.0.1
-  timezone: ^0.11.0
   flutter_image_compress: 2.4.0
   flutter_contacts: 1.1.9+2
   permission_handler: 12.0.0+1
-  pdfx: ^2.9.2
 
 dev_dependencies:
   flutter_test:
@@ -127,8 +124,6 @@ dependency_overrides:
     path: ../packages/stubs/file_picker_stub
   share_plus:
     path: ../packages/stubs/share_plus_stub
-  pdfx:
-    path: ../packages/stubs/pdfx_stub
   flutter_image_compress:
     path: ../packages/stubs/flutter_image_compress_stub
   flutter_contacts:

--- a/app/pubspec_tv.yaml
+++ b/app/pubspec_tv.yaml
@@ -97,12 +97,9 @@ dependencies:
   file_picker: 10.3.10
   share_plus: 10.1.4
   url_launcher: 6.3.2
-  flutter_local_notifications: ^22.0.1
-  timezone: ^0.11.0
   flutter_image_compress: 2.4.0
   flutter_contacts: 1.1.9+2
   permission_handler: 12.0.0+1
-  pdfx: ^2.9.2
 
   # EXCLUDED for TV builds (heavy dependencies):
   # - flame: 1.35.0 (game engine - not needed)
@@ -160,8 +157,6 @@ dependency_overrides:
     path: ../packages/stubs/file_picker_stub
   share_plus:
     path: ../packages/stubs/share_plus_stub
-  pdfx:
-    path: ../packages/stubs/pdfx_stub
   flutter_image_compress:
     path: ../packages/stubs/flutter_image_compress_stub
   flutter_contacts:


### PR DESCRIPTION
## Summary
- remove duplicate pdfx/flutter_local_notifications/timezone entries from reduced streaming and TV pubspecs
- keep the existing stub-backed entries used by lean Android variants

## Verification
- validated pubspec_streaming.yaml via temporary pubspec swap + flutter pub get
- validated pubspec_tv.yaml via temporary pubspec swap + flutter pub get