### PR TITLE
chore: repair version health checks

### DIFF
--- a/.github/issues/maintenance-20260627-version-health-check.md
+++ b/.github/issues/maintenance-20260627-version-health-check.md
@@ -1,0 +1,76 @@
+## Feature Packet
+
+**Primary owner agent:** Release and DevEx Agent
+**Review agents:** QA Automation Agent
+**Layer:** Framework
+**Sprint:** Maintenance
+**Parent roadmap:** Daily Project Health Monitor
+
+### Critical Agent Gate
+
+**Problem:** The local version consistency health check is stale and reports
+false failures after the repository moved to Flutter 3.41.4 and Dart 3.11.1.
+It also misparses Flutter environment constraints, local path dependencies, and
+comments as dependency versions.
+**User / actor:** Maintainers and CI operators running repository health checks.
+**Framework or application layer:** Framework/dev tooling.
+**Owning agent:** Release and DevEx Agent.
+**Reviewing agents:** QA Automation Agent.
+**Impacted modules/files:** `Makefile`, `scripts/check-versions.sh`,
+`app/pubspec.yaml`, `packages/core_data`.
+**Open questions:** None for this scoped DevEx repair.
+**Decision:** Ready.
+
+### Cross-Agent Contract
+
+**Provider agent:** Release and DevEx Agent.
+**Consumer agent:** QA Automation Agent.
+**Interface/API:** `scripts/check-versions.sh`.
+**Input shape:** Repository checkout containing pubspec files, GitHub workflows,
+and Android Gradle configuration.
+**Output shape:** Human-readable version consistency report and exit status.
+**State changes:** No runtime state changes; Android secure storage now uses the
+current `storageNamespace` option with the existing namespace value.
+**Errors:** Non-zero exit for true version inconsistencies.
+**Permissions:** Local repository read-only execution.
+**Privacy/redaction:** No secrets or user data read.
+**Persistence:** None.
+**Versioning/migration:** Update expected Flutter/Dart baselines to current
+repository minimums and align `path_provider` constraints.
+**Tests required:** Run `bash scripts/check-versions.sh` and targeted Flutter
+package validation.
+
+### Deterministic Use Cases
+
+#### UC-001: Current Flutter Baseline Passes
+
+**Actor:** Maintainer.
+**Preconditions:** Repo requires Flutter 3.41.4 and Dart 3.11.1.
+**Trigger:** Maintainer runs `bash scripts/check-versions.sh`.
+**Happy path:** Makefile and CI workflow versions are compared against 3.41.4.
+**Alternate paths:** Packages with older minimums are warned but do not block.
+**Failure paths:** Real mismatches produce errors and a non-zero exit.
+**Data created/updated/deleted:** None by the script; secure storage keeps the
+same namespace string under the current Android option.
+**Privacy expectations:** No repository secrets are inspected.
+
+### Automation Flow
+
+#### AUTO-001: Version Health Script
+
+**Given:** A clean checkout on the maintenance branch.
+**When:** `bash scripts/check-versions.sh` is executed.
+**Then:** The report reflects the current Flutter/Dart baseline, ignores comments
+and path dependency internals, and exits according to true inconsistencies.
+**Fixtures:** Existing repository files.
+**Mocks/stubs:** None.
+**Assertions:** Exit status and report output.
+**Cleanup:** None.
+
+### Implementation Boundaries
+
+- Framework files: `scripts/check-versions.sh`, `Makefile`,
+  `packages/core_data`
+- Application files: `app/pubspec.yaml`
+- Tests: run the version script and targeted Flutter validation
+- Docs: this issue packet

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 # Cross-platform build and development automation
 
 # Variables
-FLUTTER_VERSION := 3.35.7
+FLUTTER_VERSION := 3.41.4
 APP_DIR := app
 ANDROID_DIR := $(APP_DIR)/android
 IOS_DIR := $(APP_DIR)/ios

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -45,7 +45,7 @@ dependencies:
   hive: 2.2.3
   hive_flutter: 1.1.0
   path: 1.9.1
-  path_provider: ^2.1.5
+  path_provider: ^2.1.6
 
   # Connectivity
   connectivity_plus: ^7.1.1

--- a/packages/core_data/lib/core_data.dart
+++ b/packages/core_data/lib/core_data.dart
@@ -1,8 +1,6 @@
-/// Core data layer for Airo
-///
-/// Contains API clients, database access, and repository implementations.
-library core_data;
-
+// Core data layer for Airo.
+//
+// Contains API clients, database access, and repository implementations.
 // HTTP Client
 export 'src/http/api_client.dart';
 export 'src/http/api_exception.dart';

--- a/packages/core_data/lib/src/http/api_client.dart
+++ b/packages/core_data/lib/src/http/api_client.dart
@@ -1,8 +1,6 @@
 import 'package:core_domain/core_domain.dart';
 import 'package:dio/dio.dart';
 
-import 'api_exception.dart';
-
 /// HTTP API client wrapper around Dio
 class ApiClient {
   ApiClient({

--- a/packages/core_data/lib/src/storage/flutter_secure_store.dart
+++ b/packages/core_data/lib/src/storage/flutter_secure_store.dart
@@ -27,7 +27,7 @@ class FlutterSecureStore implements SecureStore {
         aOptions: AndroidOptions(
           // v10+: encryptedSharedPreferences removed, using new secure ciphers
           // Auto-migration from old storage happens automatically
-          sharedPreferencesName: 'airo_secure_prefs',
+          storageNamespace: 'airo_secure_prefs',
           preferencesKeyPrefix: 'airo_',
         ),
         iOptions: IOSOptions(

--- a/packages/core_data/pubspec.yaml
+++ b/packages/core_data/pubspec.yaml
@@ -1,6 +1,7 @@
 name: core_data
 description: "Core data layer: database, API clients, and repository implementations"
 version: 0.0.1
+publish_to: 'none'
 
 environment:
   sdk: ">=3.11.1 <4.0.0"
@@ -16,7 +17,7 @@ dependencies:
   flutter_secure_storage: ^10.3.1
   connectivity_plus: ^7.1.1
   path: 1.9.1
-  path_provider: ^2.1.5
+  path_provider: ^2.1.6
   meta: ^1.16.0
 
 dev_dependencies:

--- a/scripts/check-versions.sh
+++ b/scripts/check-versions.sh
@@ -20,9 +20,9 @@ YELLOW='\033[1;33m'
 BLUE='\033[0;34m'
 NC='\033[0m' # No Color
 
-# Expected versions (from LTS strategy)
-EXPECTED_FLUTTER="3.35.7"
-EXPECTED_DART_MIN="3.9.2"
+# Expected versions (from the current repository baseline)
+EXPECTED_FLUTTER="3.41.4"
+EXPECTED_DART_MIN="3.11.1"
 EXPECTED_DART_MAX="4.0.0"
 
 # Counters
@@ -78,12 +78,41 @@ echo ""
 echo "Expected Dart SDK: >=${EXPECTED_DART_MIN} <${EXPECTED_DART_MAX}"
 echo ""
 
-# Find all pubspec.yaml files
-find . -name "pubspec.yaml" -not -path "*/.*" -not -path "*/build/*" | while read -r pubspec; do
+PUBSPECS=()
+while IFS= read -r pubspec; do
+    PUBSPECS+=("$pubspec")
+done < <(find . -name "pubspec.yaml" -not -path "*/.*" -not -path "*/build/*" | sort)
+
+extract_pubspec_value() {
+    local key="$1"
+    local pubspec="$2"
+    awk -v key="$key" '
+        $0 ~ "^  " key ":[[:space:]]*" {
+            value = $0
+            sub(/^[[:space:]]*[^:]+:[[:space:]]*/, "", value)
+            sub(/[[:space:]]+#.*$/, "", value)
+            gsub(/["'\'']/, "", value)
+            print value
+            exit
+        }
+    ' "$pubspec"
+}
+
+for pubspec in "${PUBSPECS[@]}"; do
     echo -n "Checking $(dirname $pubspec)... "
-    
-    # Extract SDK constraint
-    SDK_CONSTRAINT=$(grep "sdk:" "$pubspec" | grep -v "flutter:" | sed 's/.*sdk: //' | tr -d '"' | tr -d "'")
+
+    SDK_CONSTRAINT=$(awk '
+        /^[[:space:]]*environment:[[:space:]]*$/ { in_environment = 1; next }
+        in_environment && /^[^[:space:]]/ { in_environment = 0 }
+        in_environment && /^[[:space:]]*sdk:/ {
+            value = $0
+            sub(/^[[:space:]]*sdk:[[:space:]]*/, "", value)
+            sub(/[[:space:]]+#.*$/, "", value)
+            gsub(/["'\'']/, "", value)
+            print value
+            exit
+        }
+    ' "$pubspec")
     
     if [[ "$SDK_CONSTRAINT" =~ ^\^?${EXPECTED_DART_MIN} ]] || [[ "$SDK_CONSTRAINT" =~ \>=${EXPECTED_DART_MIN} ]]; then
         echo -e "${GREEN}✓ $SDK_CONSTRAINT${NC}"
@@ -105,7 +134,7 @@ echo "Caret constraints allow automatic minor updates and should be avoided in p
 echo ""
 
 CARET_COUNT=0
-find . -name "pubspec.yaml" -not -path "*/.*" -not -path "*/build/*" | while read -r pubspec; do
+for pubspec in "${PUBSPECS[@]}"; do
     CARETS=$(grep -c "^\s*[a-z_]*: \^" "$pubspec" || true)
     if [ "$CARETS" -gt 0 ]; then
         echo -e "${YELLOW}⚠ $(dirname $pubspec): $CARETS caret constraints found${NC}"
@@ -135,10 +164,11 @@ COMMON_PACKAGES=("flutter_lints" "mocktail" "equatable" "meta" "path" "path_prov
 for package in "${COMMON_PACKAGES[@]}"; do
     echo -n "Checking $package... "
     
-    # Find all versions of this package
-    VERSIONS=$(find . -name "pubspec.yaml" -not -path "*/.*" -not -path "*/build/*" -exec grep -H "^\s*$package:" {} \; | sed "s/.*$package: //" | tr -d '"' | tr -d "'" | sort -u)
+    VERSIONS=$(for pubspec in "${PUBSPECS[@]}"; do
+        extract_pubspec_value "$package" "$pubspec"
+    done | sed '/^$/d' | sed 's/^\^//' | sort -u)
     
-    VERSION_COUNT=$(echo "$VERSIONS" | wc -l)
+    VERSION_COUNT=$(printf "%s\n" "$VERSIONS" | sed '/^$/d' | wc -l | tr -d ' ')
     
     if [ "$VERSION_COUNT" -eq 1 ]; then
         echo -e "${GREEN}✓ Consistent ($VERSIONS)${NC}"
@@ -162,15 +192,21 @@ echo ""
 BETA_COUNT=0
 
 # Check Dart packages
-find . -name "pubspec.yaml" -not -path "*/.*" -not -path "*/build/*" -exec grep -H "beta\|alpha\|rc\|dev" {} \; | while read -r line; do
-    echo -e "${YELLOW}⚠ Beta/unstable dependency: $line${NC}"
-    ((BETA_COUNT++))
+for pubspec in "${PUBSPECS[@]}"; do
+    while IFS= read -r line; do
+        echo -e "${YELLOW}⚠ Beta/unstable dependency: $pubspec:$line${NC}"
+        ((BETA_COUNT++))
+    done < <(awk '
+        /^[[:space:]]*(dependencies|dev_dependencies|dependency_overrides):[[:space:]]*$/ { in_dependencies = 1; next }
+        in_dependencies && /^[^[:space:]]/ { in_dependencies = 0 }
+        in_dependencies && /^[[:space:]]*[A-Za-z0-9_]+:[[:space:]]*[^#]*(alpha|beta|rc|dev)/ { print }
+    ' "$pubspec")
 done
 
 # Check Android dependencies
-if grep -q "beta\|alpha\|rc" app/android/app/build.gradle.kts; then
+if grep -Eq '("[^"]*(alpha|beta|rc)[0-9][^"]*"|'\''[^'\'']*(alpha|beta|rc)[0-9][^'\'']*'\'')' app/android/app/build.gradle.kts; then
     echo -e "${YELLOW}⚠ Beta/unstable Android dependencies found:${NC}"
-    grep "beta\|alpha\|rc" app/android/app/build.gradle.kts | sed 's/^/    /'
+    grep -E '("[^"]*(alpha|beta|rc)[0-9][^"]*"|'\''[^'\'']*(alpha|beta|rc)[0-9][^'\'']*'\'')' app/android/app/build.gradle.kts | sed 's/^/    /'
     ((BETA_COUNT++))
 fi
 
@@ -210,4 +246,3 @@ else
     echo ""
     exit 1
 fi
-


### PR DESCRIPTION
## Summary
- Update the local Flutter baseline in `Makefile` and `scripts/check-versions.sh` to `3.41.4`, matching CI and pubspec requirements.
- Fix `scripts/check-versions.sh` parsing so it reads Dart SDK constraints, dependency versions, caret warnings, and beta dependency warnings without false positives from nested `path:` entries or comments.
- Align `path_provider` constraints to `^2.1.6` in `app` and `core_data`.
- Clean up `core_data` analyzer issues: mark it unpublished, remove an unused import/library declaration, and switch Android secure storage to `storageNamespace` using the existing namespace value.
- Add a local policy packet under `.github/issues/maintenance-20260627-version-health-check.md` for the required agent lifecycle gate.

## Root Cause
The repository moved to Flutter `3.41.4` / Dart `3.11.1`, but the local version health script and Makefile still used older baselines. The script also parsed pubspecs with broad grep patterns, which caused false version mismatches and unstable dependency warnings.

## Validation
- `bash -n scripts/check-versions.sh && bash scripts/check-versions.sh` passed with warnings only for existing policy concerns.
- `flutter analyze` passed in `packages/core_data`.
- `flutter test --reporter=compact` passed in `packages/core_data`.
- `flutter analyze --no-fatal-infos --no-fatal-warnings` passed in `app`.
- `flutter test --reporter=compact` passed in `app` with 728 tests.
- `npm audit --audit-level=high` passed in `e2e` with 0 vulnerabilities.
- `flutter pub outdated` checked in `packages/core_data`; newer latest packages are not currently resolvable under constraints.
- `git diff --check` passed.

## Risks
- `scripts/check-versions.sh` still reports existing warnings for older package SDK floors, caret constraints, and the current ML Kit beta dependency; those are not new blockers in this PR.
- Android secure storage keeps the same namespace string but uses the newer API option, so reviewers should sanity-check persisted secure storage behavior if older app builds already shipped with the deprecated option.
