### PR TITLE
feat(ai): warm Gemini Nano on chat load

### DIFF
--- a/app/android/app/src/main/kotlin/io/airo/app/GeminiNanoPlugin.kt
+++ b/app/android/app/src/main/kotlin/io/airo/app/GeminiNanoPlugin.kt
@@ -100,12 +100,39 @@ class GeminiNanoPlugin(private val context: Context) : MethodChannel.MethodCallH
         when (call.method) {
             "isAvailable" -> checkAvailability(result)
             "initialize" -> initialize(call, result)
+            "warmup" -> warmup(result)
             "generateContent" -> generateContent(call, result)
             "generateContentStream" -> generateContentStream(call, result)
             "getDeviceInfo" -> getDeviceInfo(result)
             "getMemoryInfo" -> getMemoryInfo(result)
             "getCapabilities" -> getCapabilities(result)
             else -> result.notImplemented()
+        }
+    }
+
+    /**
+     * Warm up Gemini Nano by issuing a lightweight local inference request.
+     *
+     * ML Kit does not expose a dedicated preload API, so a whitespace prompt is
+     * used to force the runtime to load the model weights before the first
+     * user-visible request.
+     */
+    private fun warmup(result: MethodChannel.Result) {
+        coroutineScope.launch {
+            try {
+                if (!ensureInitialized()) {
+                    result.error("NOT_INITIALIZED", "Gemini Nano not initialized", null)
+                    return@launch
+                }
+
+                val request = GenerateContentRequest.Builder(TextPart(" ")).build()
+                generativeModel!!.generateContent(request)
+                Log.d(TAG, "Gemini Nano warmup complete")
+                result.success(true)
+            } catch (e: Exception) {
+                Log.e(TAG, "Warmup failed: ${e.message}", e)
+                result.error("WARMUP_FAILED", e.message, null)
+            }
         }
     }
     

--- a/app/lib/core/services/gemini_nano_service.dart
+++ b/app/lib/core/services/gemini_nano_service.dart
@@ -132,6 +132,31 @@ class GeminiNanoService {
     }
   }
 
+  /// Warm the model with a lightweight native inference request.
+  ///
+  /// This is intended to hide the first-request cold start after the chat
+  /// screen loads on supported Android devices.
+  Future<bool> warmup() async {
+    if (kIsWeb) {
+      return false;
+    }
+
+    try {
+      if (!_isInitialized) {
+        final initialized = await initialize();
+        if (!initialized) {
+          return false;
+        }
+      }
+
+      final warmed = await _channel.invokeMethod<bool>('warmup');
+      return warmed ?? false;
+    } catch (e) {
+      debugPrint('Error warming up Gemini Nano: $e');
+      return false;
+    }
+  }
+
   /// Generate content from a prompt
   /// Returns the generated text response, or fallback message on web/uninitialized
   Future<String> generateContent(String prompt) async {

--- a/app/lib/features/agent_chat/presentation/screens/chat_screen.dart
+++ b/app/lib/features/agent_chat/presentation/screens/chat_screen.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart' hide Intent;
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
@@ -112,6 +114,9 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
       if (isSupported) {
         final initialized = await _geminiNano.initialize();
         debugPrint('Gemini Nano initialized: $initialized');
+        if (initialized) {
+          unawaited(_warmupGeminiNano());
+        }
       }
 
       // Show bottom banner popup
@@ -121,6 +126,11 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
     } catch (e) {
       debugPrint('Error initializing AI: $e');
     }
+  }
+
+  Future<void> _warmupGeminiNano() async {
+    final warmed = await _geminiNano.warmup();
+    debugPrint('Gemini Nano warmed up: $warmed');
   }
 
   void _showBottomBanner() {

--- a/packages/core_ai/lib/src/llm/gemini_nano_client.dart
+++ b/packages/core_ai/lib/src/llm/gemini_nano_client.dart
@@ -22,11 +22,13 @@ class GeminiNanoClient implements LLMClient {
   GeminiNanoClient({
     LLMConfig? config,
     MemoryBudgetManager? memoryBudgetManager,
+    MethodChannel? channel,
+    EventChannel? eventChannel,
   }) : _config = config ?? LLMConfig.geminiNano,
-       _memoryBudgetManager = memoryBudgetManager ?? MemoryBudgetManager();
-
-  static const _channel = MethodChannel('com.airo.gemini_nano');
-  static const _eventChannel = EventChannel('com.airo.gemini_nano/stream');
+       _memoryBudgetManager = memoryBudgetManager ?? MemoryBudgetManager(),
+       _channel = channel ?? const MethodChannel('com.airo.gemini_nano'),
+       _eventChannel =
+           eventChannel ?? const EventChannel('com.airo.gemini_nano/stream');
 
   /// Estimated Gemini Nano model size in bytes (~2.5GB).
   /// This is used for memory budget calculations.
@@ -34,6 +36,8 @@ class GeminiNanoClient implements LLMClient {
 
   final LLMConfig _config;
   final MemoryBudgetManager _memoryBudgetManager;
+  final MethodChannel _channel;
+  final EventChannel _eventChannel;
   bool _isInitialized = false;
   MemoryCheckResult? _lastMemoryCheck;
 
@@ -119,6 +123,29 @@ class GeminiNanoClient implements LLMClient {
       final result = await _channel.invokeMethod<bool>('isAvailable');
       return result ?? false;
     } catch (e) {
+      return false;
+    }
+  }
+
+  /// Warms the model by issuing a lightweight native inference request.
+  ///
+  /// This ensures Gemini Nano has loaded its weights before the first
+  /// user-visible prompt.
+  Future<bool> warmup() async {
+    final initialized = _isInitialized || await initialize();
+    if (!initialized) {
+      return false;
+    }
+
+    try {
+      final result = await _channel.invokeMethod<bool>('warmup');
+      return result ?? false;
+    } catch (e) {
+      developer.log(
+        'Gemini Nano warmup failed: $e',
+        name: 'GeminiNanoClient',
+        error: e,
+      );
       return false;
     }
   }

--- a/packages/core_ai/test/llm/gemini_nano_client_test.dart
+++ b/packages/core_ai/test/llm/gemini_nano_client_test.dart
@@ -1,0 +1,66 @@
+import 'package:core_ai/core_ai.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('GeminiNanoClient', () {
+    test(
+      'warmup initializes the client and invokes the native warmup hook',
+      () async {
+        const channel = MethodChannel('test.gemini_nano');
+        final calls = <MethodCall>[];
+
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .setMockMethodCallHandler(channel, (call) async {
+              calls.add(call);
+              return switch (call.method) {
+                'initialize' => true,
+                'warmup' => true,
+                'isAvailable' => true,
+                _ => null,
+              };
+            });
+        addTearDown(() {
+          TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+              .setMockMethodCallHandler(channel, null);
+        });
+
+        final client = GeminiNanoClient(channel: channel);
+
+        final warmed = await client.warmup();
+
+        expect(warmed, isTrue);
+        expect(
+          calls.map((call) => call.method),
+          containsAllInOrder(<String>['initialize', 'warmup']),
+        );
+      },
+    );
+
+    test('warmup returns false when the native hook throws', () async {
+      const channel = MethodChannel('test.gemini_nano.error');
+
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(channel, (call) async {
+            return switch (call.method) {
+              'initialize' => true,
+              'warmup' => throw PlatformException(
+                code: 'WARMUP_FAILED',
+                message: 'boom',
+              ),
+              _ => null,
+            };
+          });
+      addTearDown(() {
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .setMockMethodCallHandler(channel, null);
+      });
+
+      final client = GeminiNanoClient(channel: channel);
+
+      expect(await client.warmup(), isFalse);
+    });
+  });
+}


### PR DESCRIPTION
# Summary

Closes #360.

This PR pre-warms Gemini Nano when the agent chat screen loads so the first visible prompt avoids the model cold-start delay on supported Android devices.

Core outcome:

- adds a `warmup()` hook to the framework Gemini Nano client and the app Gemini Nano service
- implements a native Android warmup handler that performs a lightweight dummy inference to load model weights
- triggers warmup asynchronously after chat-screen initialization so the UI stays responsive
- adds a focused `core_ai` method-channel test for the warmup path

# Changes

### Code

- Updated:
  - `packages/core_ai/lib/src/llm/gemini_nano_client.dart`
  - `app/lib/core/services/gemini_nano_service.dart`
  - `app/lib/features/agent_chat/presentation/screens/chat_screen.dart`
  - `app/android/app/src/main/kotlin/io/airo/app/GeminiNanoPlugin.kt`
- Added:
  - `packages/core_ai/test/llm/gemini_nano_client_test.dart`

### Logic

- `GeminiNanoClient.warmup()` now guarantees initialization before invoking the native warmup hook
- `GeminiNanoService.warmup()` exposes the same behavior to the app layer and fails safely on unsupported platforms
- chat initialization fires `warmup()` with `unawaited(...)` after a successful Gemini Nano init so the banner/UI path stays non-blocking
- the Android plugin handles `warmup` by issuing a whitespace `GenerateContentRequest` to force model loading before the first real prompt

# Risks

- low risk; the change only touches the Gemini Nano startup path on supported Android devices
- unsupported devices continue to skip Gemini Nano initialization as before

# Testing

- `cd packages/core_ai && flutter test --reporter=compact test/llm/gemini_nano_client_test.dart`
- `cd packages/core_ai && flutter analyze`
- `cd app && flutter test --reporter=compact test/features/agent_chat/data/services/assistant_runtime_service_test.dart`
- `cd app && flutter analyze --no-fatal-infos --no-fatal-warnings`

# Notes

Reviewers should focus on the native warmup call and the non-blocking chat-screen startup behavior.
