### PR TITLE
fix(ci): enforce wiki docs completeness

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -31,6 +31,10 @@ Every PR must keep the Airo public capability wiki accurate.
 - [ ] No `docs/wiki` update is needed because this PR has no user-visible
       behavior or documentation impact.
 
+Docs bypass for intentional exceptions:
+use the `docs-not-needed` PR label or include `docs-not-needed` in the commit
+message.
+
 ## Plugin and Size Impact
 
 - [ ] This PR adds new dependencies

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -47,6 +47,17 @@ jobs:
             docs:
               - '**.md'
 
+      - name: Enforce docs completeness
+        env:
+          AIRO_DOCS_BYPASS: ${{ contains(join(github.event.pull_request.labels.*.name, ' '), 'docs-not-needed') && 'true' || 'false' }}
+          AIRO_DOCS_BASE: ${{ github.event.pull_request.base.sha }}
+          AIRO_DOCS_HEAD: ${{ github.event.pull_request.head.sha }}
+        run: |
+          chmod +x scripts/check-docs-completeness.sh
+          scripts/check-docs-completeness.sh \
+            --base "$AIRO_DOCS_BASE" \
+            --head "$AIRO_DOCS_HEAD"
+
   # ============================================
   # Code Quality (analyze, format) - ~2 minutes
   # ============================================

--- a/scripts/check-docs-completeness.sh
+++ b/scripts/check-docs-completeness.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: check-docs-completeness.sh [--base <ref>] [--head <ref>]
+
+Fails when user-visible feature changes are present without a matching
+docs/wiki update, unless an explicit docs bypass is declared.
+
+Bypass options:
+- set AIRO_DOCS_BYPASS=true
+- include "docs-not-needed" in a commit message within the diff range
+EOF
+}
+
+base_ref=""
+head_ref="HEAD"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --base)
+      base_ref="${2:-}"
+      shift 2
+      ;;
+    --head)
+      head_ref="${2:-}"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ -z "$base_ref" ]]; then
+  if git rev-parse --verify HEAD~1 >/dev/null 2>&1; then
+    base_ref="HEAD~1"
+  else
+    echo "Unable to infer a base ref. Pass --base <ref>." >&2
+    exit 2
+  fi
+fi
+
+if ! git rev-parse --verify "$base_ref" >/dev/null 2>&1; then
+  echo "Base ref does not exist: $base_ref" >&2
+  exit 2
+fi
+
+if ! git rev-parse --verify "$head_ref" >/dev/null 2>&1; then
+  echo "Head ref does not exist: $head_ref" >&2
+  exit 2
+fi
+
+range="$base_ref...$head_ref"
+changed_files=()
+while IFS= read -r file; do
+  changed_files+=("$file")
+done < <(git diff --name-only "$range")
+
+if [[ ${#changed_files[@]} -eq 0 ]]; then
+  echo "No changed files detected for $range."
+  exit 0
+fi
+
+if [[ "${AIRO_DOCS_BYPASS:-false}" == "true" ]]; then
+  echo "Docs completeness bypassed via AIRO_DOCS_BYPASS=true."
+  exit 0
+fi
+
+if git log --format=%B "$range" | grep -qi 'docs-not-needed'; then
+  echo "Docs completeness bypassed via commit message marker."
+  exit 0
+fi
+
+triggered_files=()
+wiki_touched=false
+
+for file in "${changed_files[@]}"; do
+  case "$file" in
+    docs/wiki/*)
+      wiki_touched=true
+      ;;
+    app/lib/features/*|app/lib/core/routing/*|README.md)
+      triggered_files+=("$file")
+      ;;
+  esac
+done
+
+if [[ ${#triggered_files[@]} -eq 0 ]]; then
+  echo "No docs-gated feature changes detected."
+  exit 0
+fi
+
+if [[ "$wiki_touched" == "true" ]]; then
+  echo "docs/wiki updated alongside docs-gated feature changes."
+  exit 0
+fi
+
+echo "docs/wiki update required for these changed files:" >&2
+for file in "${triggered_files[@]}"; do
+  echo "  - $file" >&2
+done
+echo >&2
+echo "Add a matching docs/wiki update, apply a docs-not-needed PR label," >&2
+echo "or include 'docs-not-needed' in the commit message when the bypass is intentional." >&2
+exit 1


### PR DESCRIPTION
# Summary

Closes #246.

This PR adds a lightweight PR gate that requires `docs/wiki` updates when user-visible feature files change, while still allowing explicit bypasses for internal-only work.

Core outcome:

- adds `scripts/check-docs-completeness.sh` to inspect the PR diff
- runs the check in `PR Checks`
- documents the bypass path in the PR template
- honors intentional bypasses through a `docs-not-needed` label or commit-message marker

# Changes

### Code

- Added:
  - `scripts/check-docs-completeness.sh`
- Updated:
  - `.github/workflows/pr-checks.yml`
  - `.github/PULL_REQUEST_TEMPLATE.md`

### Logic

- the gate watches `app/lib/features/**`, `app/lib/core/routing/**`, and `README.md`
- when those paths change, at least one `docs/wiki/**` file must change too
- bypass stays explicit instead of silent: PR authors can use a `docs-not-needed` label or include `docs-not-needed` in the commit message

# Risks

- low risk; this only changes pull-request verification behavior
- the main failure mode is false positives, which is why the bypass path is explicit and documented

# Testing

- `bash -n scripts/check-docs-completeness.sh`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/pr-checks.yml"); puts "ok"'`
- temp-repo dry run covering:
  - feature change without `docs/wiki` update -> fails
  - feature change with `docs/wiki` update -> passes
  - feature change with `docs-not-needed` commit marker -> passes

# Notes

Reviewers should focus on whether the trigger paths and bypass mechanism match the current wiki-as-source-of-truth policy.
