### PR TITLE
fix: wire model learn more links to source pages

### DIFF
--- a/app/lib/core/ai/model_learn_more_launcher.dart
+++ b/app/lib/core/ai/model_learn_more_launcher.dart
@@ -1,0 +1,40 @@
+import 'package:core_ai/core_ai.dart';
+import 'package:flutter/material.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+typedef LaunchModelUrl = Future<bool> Function(Uri uri, {LaunchMode mode});
+
+Future<void> launchModelLearnMore(
+  BuildContext context,
+  OfflineModelInfo model, {
+  LaunchModelUrl? launchUrlCallback,
+}) async {
+  final uri = model.learnMoreUri;
+  if (uri == null) {
+    if (!context.mounted) return;
+    ScaffoldMessenger.of(context).showSnackBar(
+      const SnackBar(content: Text('No official model page is available yet.')),
+    );
+    return;
+  }
+
+  final launch = launchUrlCallback ?? launchUrl;
+
+  try {
+    final opened = await launch(uri, mode: LaunchMode.externalApplication);
+    if (!opened && context.mounted) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text('Could not open the model page for ${model.name}.'),
+        ),
+      );
+    }
+  } catch (_) {
+    if (!context.mounted) return;
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text('Could not open the model page for ${model.name}.'),
+      ),
+    );
+  }
+}

--- a/app/lib/features/agent_chat/presentation/screens/model_library_screen.dart
+++ b/app/lib/features/agent_chat/presentation/screens/model_library_screen.dart
@@ -7,6 +7,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 import '../../../../core/services/gemini_api_service.dart';
 import '../../../../core/services/gemini_nano_service.dart';
 import '../../../../core/services/litert_lm_service.dart';
+import '../../../../core/ai/model_learn_more_launcher.dart';
 import '../../domain/models/assistant_runtime_ids.dart';
 
 const String _selectedAssistantModelKey = 'selected_assistant_model_id';
@@ -572,6 +573,14 @@ class _ModelLibraryContent extends ConsumerWidget {
               selected:
                   selectedModelId == state.recommendedFor(template.task).id,
               onStart: () => _handleStartProject(context, ref, template),
+              onLearnMore: () {
+                final model =
+                    state.packageFor(template.task) ??
+                    state.recommendedFor(template.task).package;
+                if (model != null) {
+                  launchModelLearnMore(context, model);
+                }
+              },
             ),
           ),
         const SizedBox(height: 8),
@@ -670,6 +679,11 @@ class _ModelLibraryContent extends ConsumerWidget {
           ],
         ),
         actions: [
+          if (selectedPackage?.learnMoreUri != null)
+            TextButton(
+              onPressed: () => launchModelLearnMore(context, selectedPackage!),
+              child: const Text('Learn more'),
+            ),
           TextButton(
             onPressed: () => Navigator.pop(context, false),
             child: const Text('Not now'),
@@ -763,6 +777,7 @@ class _ProjectTemplateCard extends StatelessWidget {
     required this.package,
     required this.selected,
     required this.onStart,
+    required this.onLearnMore,
   });
 
   final AssistantProjectTemplate template;
@@ -770,6 +785,7 @@ class _ProjectTemplateCard extends StatelessWidget {
   final OfflineModelInfo? package;
   final bool selected;
   final VoidCallback onStart;
+  final VoidCallback onLearnMore;
 
   @override
   Widget build(BuildContext context) {
@@ -886,18 +902,29 @@ class _ProjectTemplateCard extends StatelessWidget {
             const SizedBox(height: 12),
             Align(
               alignment: Alignment.centerRight,
-              child: FilledButton.icon(
-                onPressed: onStart,
-                icon: Icon(
-                  candidate.opensModelManager
-                      ? Icons.settings_outlined
-                      : Icons.play_arrow,
-                ),
-                label: Text(
-                  candidate.opensModelManager
-                      ? 'Download package'
-                      : template.primaryAction,
-                ),
+              child: Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  if ((package ?? candidate.package)?.learnMoreUri != null)
+                    TextButton(
+                      onPressed: onLearnMore,
+                      child: const Text('Learn more'),
+                    ),
+                  const SizedBox(width: 8),
+                  FilledButton.icon(
+                    onPressed: onStart,
+                    icon: Icon(
+                      candidate.opensModelManager
+                          ? Icons.settings_outlined
+                          : Icons.play_arrow,
+                    ),
+                    label: Text(
+                      candidate.opensModelManager
+                          ? 'Download package'
+                          : template.primaryAction,
+                    ),
+                  ),
+                ],
               ),
             ),
           ],

--- a/app/lib/features/settings/presentation/screens/ai_models_screen.dart
+++ b/app/lib/features/settings/presentation/screens/ai_models_screen.dart
@@ -5,6 +5,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:core_ai/core_ai.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
+import '../../../../core/ai/model_learn_more_launcher.dart';
 import '../../../../features/iptv/application/providers/iptv_providers.dart'
     show sharedPreferencesProvider;
 import '../widgets/model_card.dart';
@@ -295,6 +296,9 @@ class _AIModelsScreenState extends ConsumerState<AIModelsScreen>
               : null,
           onCancelDownload: isDownloading
               ? () => _cancelDownload(model.id)
+              : null,
+          onLearnMore: model.learnMoreUri != null
+              ? () => launchModelLearnMore(context, model)
               : null,
         );
       },

--- a/app/lib/features/settings/presentation/screens/model_detail_screen.dart
+++ b/app/lib/features/settings/presentation/screens/model_detail_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:core_ai/core_ai.dart';
 
+import '../../../../core/ai/model_learn_more_launcher.dart';
 import '../widgets/credibility_badge.dart';
 
 /// Detail screen for viewing and managing a single AI model.
@@ -9,9 +10,14 @@ import '../widgets/credibility_badge.dart';
 /// Shows comprehensive model information, compatibility details,
 /// and provides download/delete actions.
 class ModelDetailScreen extends ConsumerWidget {
-  const ModelDetailScreen({super.key, required this.model});
+  const ModelDetailScreen({
+    super.key,
+    required this.model,
+    this.launchUrlCallback,
+  });
 
   final OfflineModelInfo model;
+  final LaunchModelUrl? launchUrlCallback;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -19,11 +25,11 @@ class ModelDetailScreen extends ConsumerWidget {
       appBar: AppBar(
         title: Text(model.name),
         actions: [
-          if (model.huggingFaceId != null)
+          if (model.learnMoreUri != null)
             IconButton(
               icon: const Icon(Icons.open_in_new),
-              tooltip: 'View on HuggingFace',
-              onPressed: () => _openHuggingFace(context),
+              tooltip: 'Learn more',
+              onPressed: () => _openLearnMore(context),
             ),
         ],
       ),
@@ -255,11 +261,12 @@ class ModelDetailScreen extends ConsumerWidget {
     return '${mb.toStringAsFixed(0)} MB';
   }
 
-  void _openHuggingFace(BuildContext context) {
-    // TODO: Launch URL to HuggingFace
-    ScaffoldMessenger.of(
+  Future<void> _openLearnMore(BuildContext context) {
+    return launchModelLearnMore(
       context,
-    ).showSnackBar(SnackBar(content: Text('Opening ${model.huggingFaceId}')));
+      model,
+      launchUrlCallback: launchUrlCallback,
+    );
   }
 
   void _setActive(BuildContext context) {

--- a/app/lib/features/settings/presentation/widgets/model_card.dart
+++ b/app/lib/features/settings/presentation/widgets/model_card.dart
@@ -22,6 +22,7 @@ class ModelCard extends StatelessWidget {
     this.onDelete,
     this.onSetActive,
     this.onCancelDownload,
+    this.onLearnMore,
   });
 
   /// The model to display.
@@ -59,6 +60,9 @@ class ModelCard extends StatelessWidget {
 
   /// Callback to cancel an in-progress download.
   final VoidCallback? onCancelDownload;
+
+  /// Callback to open the model source page.
+  final VoidCallback? onLearnMore;
 
   @override
   Widget build(BuildContext context) {
@@ -105,6 +109,13 @@ class ModelCard extends StatelessWidget {
                     credibility: model.credibility,
                     size: CredibilityBadgeSize.small,
                   ),
+                  if (onLearnMore != null)
+                    IconButton(
+                      onPressed: onLearnMore,
+                      icon: const Icon(Icons.open_in_new, size: 18),
+                      visualDensity: VisualDensity.compact,
+                      tooltip: 'Learn more',
+                    ),
                 ],
               ),
               const SizedBox(height: 12),

--- a/app/test/features/settings/presentation/screens/model_detail_screen_test.dart
+++ b/app/test/features/settings/presentation/screens/model_detail_screen_test.dart
@@ -1,0 +1,79 @@
+import 'package:airo_app/features/settings/presentation/screens/model_detail_screen.dart';
+import 'package:core_ai/core_ai.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+void main() {
+  Widget buildScreen(
+    OfflineModelInfo model, {
+    Future<bool> Function(Uri uri, {LaunchMode mode})? launchUrlCallback,
+  }) {
+    return ProviderScope(
+      child: MaterialApp(
+        home: ModelDetailScreen(
+          model: model,
+          launchUrlCallback: launchUrlCallback,
+        ),
+      ),
+    );
+  }
+
+  group('ModelDetailScreen', () {
+    testWidgets('shows learn more action when source URL exists', (
+      tester,
+    ) async {
+      const model = OfflineModelInfo(
+        id: 'gemma',
+        name: 'Gemma',
+        family: ModelFamily.gemma,
+        fileSizeBytes: 1024,
+        huggingFaceId: 'litert-community/gemma-4-E2B-it-litert-lm',
+      );
+
+      await tester.pumpWidget(buildScreen(model));
+
+      expect(find.byTooltip('Learn more'), findsOneWidget);
+    });
+
+    testWidgets('hides learn more action when source URL is unavailable', (
+      tester,
+    ) async {
+      const model = OfflineModelInfo(
+        id: 'local-only',
+        name: 'Local Only',
+        family: ModelFamily.gemma,
+        fileSizeBytes: 1024,
+      );
+
+      await tester.pumpWidget(buildScreen(model));
+
+      expect(find.byTooltip('Learn more'), findsNothing);
+    });
+
+    testWidgets('shows snackbar when external launch fails', (tester) async {
+      const model = OfflineModelInfo(
+        id: 'gemma',
+        name: 'Gemma',
+        family: ModelFamily.gemma,
+        fileSizeBytes: 1024,
+        huggingFaceId: 'litert-community/gemma-4-E2B-it-litert-lm',
+      );
+
+      await tester.pumpWidget(
+        buildScreen(
+          model,
+          launchUrlCallback: (uri, {mode = LaunchMode.platformDefault}) async {
+            return false;
+          },
+        ),
+      );
+
+      await tester.tap(find.byTooltip('Learn more'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Could not open the model page for Gemma.'), findsOne);
+    });
+  });
+}

--- a/packages/core_ai/lib/src/models/offline_model_info.dart
+++ b/packages/core_ai/lib/src/models/offline_model_info.dart
@@ -142,6 +142,7 @@ class OfflineModelInfo {
     this.version,
     this.author,
     this.license,
+    this.learnMoreUrl,
     this.huggingFaceId,
     this.sha256,
     this.tags = const [],
@@ -215,6 +216,9 @@ class OfflineModelInfo {
   /// License type (e.g., 'Apache-2.0', 'MIT', 'Llama 2 Community').
   final String? license;
 
+  /// Human-readable source or model detail page.
+  final String? learnMoreUrl;
+
   /// HuggingFace model ID (e.g., 'google/gemma-2b-it-GGUF').
   final String? huggingFaceId;
 
@@ -276,6 +280,21 @@ class OfflineModelInfo {
     return (fileSizeBytes * 1.5).round();
   }
 
+  /// Safe external page for learning more about the model.
+  ///
+  /// Rejects direct artifact URLs and only allows HTTPS pages.
+  Uri? get learnMoreUri {
+    final explicit = _parseLearnMoreUri(learnMoreUrl);
+    if (explicit != null) return explicit;
+
+    final trimmedHuggingFaceId = huggingFaceId?.trim();
+    if (trimmedHuggingFaceId == null || trimmedHuggingFaceId.isEmpty) {
+      return null;
+    }
+
+    return _parseLearnMoreUri('https://huggingface.co/$trimmedHuggingFaceId');
+  }
+
   /// Creates a copy with modified fields.
   OfflineModelInfo copyWith({
     String? id,
@@ -300,6 +319,7 @@ class OfflineModelInfo {
     String? version,
     String? author,
     String? license,
+    String? learnMoreUrl,
     String? huggingFaceId,
     String? sha256,
     List<String>? tags,
@@ -330,6 +350,7 @@ class OfflineModelInfo {
       version: version ?? this.version,
       author: author ?? this.author,
       license: license ?? this.license,
+      learnMoreUrl: learnMoreUrl ?? this.learnMoreUrl,
       huggingFaceId: huggingFaceId ?? this.huggingFaceId,
       sha256: sha256 ?? this.sha256,
       tags: tags ?? this.tags,
@@ -363,6 +384,7 @@ class OfflineModelInfo {
     'version': version,
     'author': author,
     'license': license,
+    'learnMoreUrl': learnMoreUrl,
     'huggingFaceId': huggingFaceId,
     'sha256': sha256,
     'tags': tags,
@@ -432,6 +454,7 @@ class OfflineModelInfo {
       version: json['version'] as String?,
       author: json['author'] as String?,
       license: json['license'] as String?,
+      learnMoreUrl: json['learnMoreUrl'] as String?,
       huggingFaceId: json['huggingFaceId'] as String?,
       sha256: json['sha256'] as String?,
       tags: List<String>.from(json['tags'] ?? []),
@@ -453,4 +476,22 @@ class OfflineModelInfo {
   String toString() =>
       'OfflineModelInfo($name, ${quantization.displayName}, '
       '$fileSizeDisplay)';
+
+  static Uri? _parseLearnMoreUri(String? candidate) {
+    final value = candidate?.trim();
+    if (value == null || value.isEmpty) return null;
+
+    final uri = Uri.tryParse(value);
+    if (uri == null || uri.scheme != 'https' || uri.host.isEmpty) {
+      return null;
+    }
+
+    final path = uri.path.toLowerCase();
+    if (path.contains('/resolve/')) return null;
+
+    const artifactExtensions = ['.litertlm', '.gguf', '.bin', '.task', '.onnx'];
+    if (artifactExtensions.any(path.endsWith)) return null;
+
+    return uri;
+  }
 }

--- a/packages/core_ai/test/registry/model_registry_test.dart
+++ b/packages/core_ai/test/registry/model_registry_test.dart
@@ -115,6 +115,52 @@ void main() {
       );
       expect(model7B.parameterCountDisplay, '7.0B');
     });
+
+    test('should derive learn more URL from huggingFaceId', () {
+      const model = OfflineModelInfo(
+        id: 'gemma',
+        name: 'Gemma',
+        family: ModelFamily.gemma,
+        fileSizeBytes: 1024,
+        huggingFaceId: 'litert-community/gemma-4-E2B-it-litert-lm',
+      );
+
+      expect(
+        model.learnMoreUri,
+        Uri.parse(
+          'https://huggingface.co/litert-community/gemma-4-E2B-it-litert-lm',
+        ),
+      );
+    });
+
+    test('should prefer explicit learn more URL when it is safe', () {
+      const model = OfflineModelInfo(
+        id: 'gemma',
+        name: 'Gemma',
+        family: ModelFamily.gemma,
+        fileSizeBytes: 1024,
+        learnMoreUrl: 'https://example.com/models/gemma-4-e2b-it',
+        huggingFaceId: 'litert-community/gemma-4-E2B-it-litert-lm',
+      );
+
+      expect(
+        model.learnMoreUri,
+        Uri.parse('https://example.com/models/gemma-4-e2b-it'),
+      );
+    });
+
+    test('should reject raw artifact URLs for learn more', () {
+      const model = OfflineModelInfo(
+        id: 'gemma',
+        name: 'Gemma',
+        family: ModelFamily.gemma,
+        fileSizeBytes: 1024,
+        learnMoreUrl:
+            'https://huggingface.co/litert-community/gemma-4-E2B-it-litert-lm/resolve/main/gemma-4-E2B-it.litertlm',
+      );
+
+      expect(model.learnMoreUri, isNull);
+    });
   });
 
   group('ModelCredibility', () {


### PR DESCRIPTION
# Summary

This PR closes `#265` by wiring the model `Learn more` affordance to safe human-readable source pages.
Goal: let users open an official/source model page without reusing raw artifact download URLs.

Core outcome:

* added a safe `learnMoreUri` derivation path on `OfflineModelInfo`
* exposed `Learn more` actions in model settings and Brain package-selection flows
* added focused tests for URL derivation and launch failure handling

# Changes

### Code

* Added:
  * `app/lib/core/ai/model_learn_more_launcher.dart`
  * `app/test/features/settings/presentation/screens/model_detail_screen_test.dart`
* Updated:
  * `packages/core_ai/lib/src/models/offline_model_info.dart`
  * `packages/core_ai/test/registry/model_registry_test.dart`
  * `app/lib/features/settings/presentation/screens/model_detail_screen.dart`
  * `app/lib/features/settings/presentation/screens/ai_models_screen.dart`
  * `app/lib/features/settings/presentation/widgets/model_card.dart`
  * `app/lib/features/agent_chat/presentation/screens/model_library_screen.dart`

### Logic

* derives `https://huggingface.co/<id>` when an explicit source URL is absent
* rejects raw artifact URLs such as `/resolve/.../*.litertlm` for `Learn more`
* uses external browser launching with readable snackbar failures
* surfaces the action from model detail, model cards, and Brain package setup/chooser UI

# API Changes (if any)

* None.

# Database Changes (if any)

* None.

# Observability / Logging

* None.

# Performance Impact

* Negligible.

# Risks

* Low risk: UI and metadata-only behavior change.
* Rollback plan:
  * revert this PR if the new external-link affordances behave unexpectedly on a target platform

# Testing

* Unit tests:
  * `cd packages/core_ai && flutter test --reporter=compact test/registry/model_registry_test.dart`
* Widget tests:
  * `cd app && flutter test --reporter=compact test/features/settings/presentation/screens/model_detail_screen_test.dart`
* Analysis:
  * `cd packages/core_ai && flutter analyze`
  * `cd app && flutter analyze --no-fatal-infos --no-fatal-warnings`

# Deployment Notes

* None.

# Related Commits

* `fix(models): wire learn more links to source pages`

# Notes

* Closes #265.
