### PR TITLE
fix(chess): restore randomized side assignment

### DIFF
--- a/app/lib/features/games/domain/services/chess_tts_manager.dart
+++ b/app/lib/features/games/domain/services/chess_tts_manager.dart
@@ -3,9 +3,17 @@ import '../../../../core/audio/audio_context_manager.dart';
 import '../models/chess_models.dart';
 import 'move_event_dispatcher.dart';
 
+abstract class ChessVoicePlayer {
+  Future<void> initialize();
+
+  Future<String> playMoveVoice(MoveEvent event, {required bool isPlayerMove});
+
+  Future<void> dispose();
+}
+
 /// Text-to-Speech manager for chess game voice lines
 /// Generates real-time DotA-style voice responses using TTS
-class ChessTTSManager {
+class ChessTTSManager implements ChessVoicePlayer {
   final FlutterTts _tts = FlutterTts();
   final AudioContextManager _audioContext;
   bool _isInitialized = false;
@@ -15,6 +23,7 @@ class ChessTTSManager {
     : _audioContext = audioContext ?? AudioContextManager();
 
   /// Initialize TTS with custom settings
+  @override
   Future<void> initialize() async {
     if (_isInitialized) return;
 
@@ -92,6 +101,7 @@ class ChessTTSManager {
   }
 
   /// Dispose TTS resources
+  @override
   Future<void> dispose() async {
     if (_isInitialized) {
       await _tts.stop();
@@ -102,6 +112,7 @@ class ChessTTSManager {
   }
 
   /// Play move voice line based on move event
+  @override
   Future<String> playMoveVoice(
     MoveEvent event, {
     required bool isPlayerMove,

--- a/app/lib/features/games/presentation/flame/chess_game.dart
+++ b/app/lib/features/games/presentation/flame/chess_game.dart
@@ -1,3 +1,5 @@
+import 'dart:math';
+
 import 'package:flame/game.dart';
 import 'package:flame/events.dart';
 import 'package:flutter/material.dart';
@@ -10,11 +12,27 @@ import '../../domain/services/move_event_dispatcher.dart';
 
 /// Flame-based chess game
 class ChessGameFlame extends FlameGame with TapCallbacks {
+  ChessGameFlame({
+    required this.difficulty,
+    this.engineOverride,
+    this.audioManagerOverride,
+    this.voicePlayerOverride,
+    this.initialPlayerColor,
+    this.aiThinkingDelayOverride,
+    Random? random,
+  }) : _random = random ?? Random();
+
   late ChessEngine engine;
   late ChessAudioManager audioManager;
-  late ChessTTSManager ttsManager;
+  late ChessVoicePlayer ttsManager;
   late MoveEventDispatcher dispatcher;
   late ChessDifficulty difficulty;
+  final ChessEngine? engineOverride;
+  final ChessAudioManager? audioManagerOverride;
+  final ChessVoicePlayer? voicePlayerOverride;
+  final ChessColor? initialPlayerColor;
+  final Duration? aiThinkingDelayOverride;
+  final Random _random;
 
   // Player color (randomly assigned)
   late ChessColor playerColor;
@@ -43,30 +61,39 @@ class ChessGameFlame extends FlameGame with TapCallbacks {
   late double squareSize;
   late Offset boardOffset;
 
-  ChessGameFlame({required this.difficulty}) : super();
+  static ChessColor pickPlayerColor(Random random) {
+    return random.nextBool() ? ChessColor.white : ChessColor.black;
+  }
+
+  static ChessColor oppositeColor(ChessColor color) {
+    return color == ChessColor.white ? ChessColor.black : ChessColor.white;
+  }
+
+  static int displayRowForPlayerPerspective(int row, ChessColor playerColor) {
+    return playerColor == ChessColor.white ? 7 - row : row;
+  }
 
   @override
   Future<void> onLoad() async {
     await super.onLoad();
 
-    // Player is always white (white moves first in chess)
-    playerColor = ChessColor.white;
-    aiColor = ChessColor.black;
+    playerColor = initialPlayerColor ?? pickPlayerColor(_random);
+    aiColor = oppositeColor(playerColor);
 
     print(
       '[CHESS] Player is ${playerColor.name.toUpperCase()}, AI is ${aiColor.name.toUpperCase()}',
     );
 
     // Initialize engine and audio (using factory for platform compatibility)
-    engine = ChessEngineFactory.create();
+    engine = engineOverride ?? ChessEngineFactory.create();
 
     // Wait for engine to be ready (on native platforms, this waits for Stockfish)
     if (engine is ChessEngineAsync) {
       await (engine as ChessEngineAsync).waitForReady();
     }
 
-    audioManager = FakeChessAudioManager();
-    ttsManager = ChessTTSManager();
+    audioManager = audioManagerOverride ?? FakeChessAudioManager();
+    ttsManager = voicePlayerOverride ?? ChessTTSManager();
     dispatcher = MoveEventDispatcher();
 
     // Setup paints
@@ -90,8 +117,9 @@ class ChessGameFlame extends FlameGame with TapCallbacks {
     // Play background music
     await audioManager.playBackgroundMusic(engine.getBoardState());
 
-    // Player is always white, so player moves first
-    // No need to trigger AI move here
+    if (playerColor == ChessColor.black) {
+      await _makeAIMove();
+    }
   }
 
   @override
@@ -121,7 +149,7 @@ class ChessGameFlame extends FlameGame with TapCallbacks {
     // Convert display row back to actual board row based on player's perspective
     // If player is white, flip board (white at bottom)
     // If player is black, don't flip (black at bottom)
-    final row = playerColor == ChessColor.white ? 7 - displayRow : displayRow;
+    final row = displayRowForPlayerPerspective(displayRow, playerColor);
     final index = row * 8 + col;
 
     print('[CHESS] Tap at col=$col, row=$row, index=$index');
@@ -206,12 +234,14 @@ class ChessGameFlame extends FlameGame with TapCallbacks {
     gameStatus = 'AI is thinking...';
 
     // Add delay based on difficulty (harder = longer thinking time)
-    final thinkingDelay = switch (difficulty) {
-      ChessDifficulty.easy => const Duration(milliseconds: 800),
-      ChessDifficulty.medium => const Duration(milliseconds: 1200),
-      ChessDifficulty.hard => const Duration(milliseconds: 1800),
-      ChessDifficulty.expert => const Duration(milliseconds: 2500),
-    };
+    final thinkingDelay =
+        aiThinkingDelayOverride ??
+        switch (difficulty) {
+          ChessDifficulty.easy => const Duration(milliseconds: 800),
+          ChessDifficulty.medium => const Duration(milliseconds: 1200),
+          ChessDifficulty.hard => const Duration(milliseconds: 1800),
+          ChessDifficulty.expert => const Duration(milliseconds: 2500),
+        };
 
     await Future.delayed(thinkingDelay);
 
@@ -314,7 +344,7 @@ class ChessGameFlame extends FlameGame with TapCallbacks {
         // Flip the board based on player's perspective
         // If player is white, flip board (white at bottom)
         // If player is black, don't flip (black at bottom)
-        final displayRow = playerColor == ChessColor.white ? 7 - row : row;
+        final displayRow = displayRowForPlayerPerspective(row, playerColor);
         final index = row * 8 + col;
 
         // Chess board: a1 (bottom-left for white) is dark square
@@ -479,7 +509,7 @@ class ChessGameFlame extends FlameGame with TapCallbacks {
       // Flip the board based on player's perspective
       // If player is white, flip board (white at bottom)
       // If player is black, don't flip (black at bottom)
-      final displayRow = playerColor == ChessColor.white ? 7 - row : row;
+      final displayRow = displayRowForPlayerPerspective(row, playerColor);
 
       // Get the correct symbol based on piece color
       final symbol = piece.color == ChessColor.white
@@ -532,7 +562,7 @@ class ChessGameFlame extends FlameGame with TapCallbacks {
     final col = speakingPieceIndex! % 8;
 
     // Calculate display position based on player's perspective
-    final displayRow = playerColor == ChessColor.white ? 7 - row : row;
+    final displayRow = displayRowForPlayerPerspective(row, playerColor);
 
     // Position bubble above the piece
     final pieceX = col * squareSize + squareSize / 2;

--- a/app/test/features/games/presentation/flame/chess_game_test.dart
+++ b/app/test/features/games/presentation/flame/chess_game_test.dart
@@ -1,0 +1,198 @@
+import 'package:airo_app/features/games/domain/models/chess_models.dart';
+import 'package:airo_app/features/games/domain/services/chess_audio_manager.dart';
+import 'package:airo_app/features/games/domain/services/chess_engine.dart';
+import 'package:airo_app/features/games/domain/services/chess_tts_manager.dart';
+import 'package:airo_app/features/games/domain/services/move_event_dispatcher.dart';
+import 'package:airo_app/features/games/presentation/flame/chess_game.dart';
+import 'package:flame/components.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('ChessGameFlame startup', () {
+    test('keeps the player turn when white starts', () async {
+      final engine = _TestChessEngine();
+      final game = ChessGameFlame(
+        difficulty: ChessDifficulty.easy,
+        engineOverride: engine,
+        audioManagerOverride: _NoopAudioManager(),
+        voicePlayerOverride: _NoopVoicePlayer(),
+        initialPlayerColor: ChessColor.white,
+        aiThinkingDelayOverride: Duration.zero,
+      );
+
+      game.onGameResize(Vector2(800, 800));
+      await game.onLoad();
+
+      expect(game.playerColor, ChessColor.white);
+      expect(game.aiColor, ChessColor.black);
+      expect(game.isPlayerTurn, isTrue);
+      expect(engine.moveCount, 0);
+    });
+
+    test('lets the AI open when the player starts as black', () async {
+      final engine = _TestChessEngine();
+      final game = ChessGameFlame(
+        difficulty: ChessDifficulty.easy,
+        engineOverride: engine,
+        audioManagerOverride: _NoopAudioManager(),
+        voicePlayerOverride: _NoopVoicePlayer(),
+        initialPlayerColor: ChessColor.black,
+        aiThinkingDelayOverride: Duration.zero,
+      );
+
+      game.onGameResize(Vector2(800, 800));
+      await game.onLoad();
+
+      expect(game.playerColor, ChessColor.black);
+      expect(game.aiColor, ChessColor.white);
+      expect(game.isPlayerTurn, isTrue);
+      expect(engine.moveCount, 1);
+      expect(
+        game.lastMove,
+        const ChessMove(from: ChessSquare(12), to: ChessSquare(28)),
+      );
+    });
+
+    test('flips display rows for white perspective only', () {
+      expect(
+        ChessGameFlame.displayRowForPlayerPerspective(0, ChessColor.white),
+        7,
+      );
+      expect(
+        ChessGameFlame.displayRowForPlayerPerspective(7, ChessColor.white),
+        0,
+      );
+      expect(
+        ChessGameFlame.displayRowForPlayerPerspective(0, ChessColor.black),
+        0,
+      );
+      expect(
+        ChessGameFlame.displayRowForPlayerPerspective(7, ChessColor.black),
+        7,
+      );
+    });
+  });
+}
+
+class _NoopAudioManager implements ChessAudioManager {
+  @override
+  Future<void> dispose() async {}
+
+  @override
+  Future<void> playBackgroundMusic(ChessBoardState board) async {}
+
+  @override
+  Future<void> playCaptureStinger() async {}
+
+  @override
+  Future<void> playCheckStinger() async {}
+
+  @override
+  Future<void> playCheckmateStinger() async {}
+
+  @override
+  Future<void> playVoiceLine(ChessAudioEvent event) async {}
+
+  @override
+  void setMusicEnabled(bool enabled) {}
+
+  @override
+  void setVoiceLinesEnabled(bool enabled) {}
+
+  @override
+  void setVolume(double volume) {}
+
+  @override
+  Future<void> stopBackgroundMusic() async {}
+}
+
+class _NoopVoicePlayer implements ChessVoicePlayer {
+  @override
+  Future<void> dispose() async {}
+
+  @override
+  Future<void> initialize() async {}
+
+  @override
+  Future<String> playMoveVoice(
+    MoveEvent event, {
+    required bool isPlayerMove,
+  }) async {
+    return '';
+  }
+}
+
+class _TestChessEngine with ChessEngineAsync implements ChessEngine {
+  ChessBoardState _state = ChessBoardState.initial();
+  int moveCount = 0;
+
+  @override
+  List<ChessMove> getLegalMoves() {
+    return const [
+      ChessMove(from: ChessSquare(12), to: ChessSquare(28)),
+      ChessMove(from: ChessSquare(52), to: ChessSquare(36)),
+    ];
+  }
+
+  @override
+  bool makeMove(ChessMove move) {
+    final squares = List<ChessPiece?>.from(_state.squares);
+    final piece = squares[move.from.index];
+    squares[move.from.index] = null;
+    squares[move.to.index] = piece;
+    moveCount += 1;
+    _state = ChessBoardState(
+      squares: squares,
+      toMove: _state.toMove == ChessColor.white
+          ? ChessColor.black
+          : ChessColor.white,
+      whiteCanCastleKingside: _state.whiteCanCastleKingside,
+      whiteCanCastleQueenside: _state.whiteCanCastleQueenside,
+      blackCanCastleKingside: _state.blackCanCastleKingside,
+      blackCanCastleQueenside: _state.blackCanCastleQueenside,
+      enPassantSquare: _state.enPassantSquare,
+      halfmoveClock: _state.halfmoveClock,
+      fullmoveNumber: _state.fullmoveNumber,
+      moveHistory: [..._state.moveHistory, move],
+    );
+    return true;
+  }
+
+  @override
+  bool undoMove() => false;
+
+  @override
+  Future<ChessMove?> getBestMove({required ChessDifficulty difficulty}) async {
+    return const ChessMove(from: ChessSquare(12), to: ChessSquare(28));
+  }
+
+  @override
+  int evaluatePosition() => 0;
+
+  @override
+  void fromFEN(String fen) {}
+
+  @override
+  ChessBoardState getBoardState() => _state;
+
+  @override
+  bool isCheck() => false;
+
+  @override
+  bool isCheckmate() => false;
+
+  @override
+  bool isStalemate() => false;
+
+  @override
+  void reset() {
+    _state = ChessBoardState.initial();
+    moveCount = 0;
+  }
+
+  @override
+  String toFEN() => '';
+
+  @override
+  Future<void> waitForReady() async {}
+}


### PR DESCRIPTION
# PR Title
fix(chess): restore randomized side assignment

---

# Summary

This PR fixes the remaining player-vs-CPU startup gap in the chess experience.
Goal: make the chess match start correctly for either side so the user can play as white or black and the AI opens when needed.

Core outcome:

* randomizes player side instead of hardcoding white
* lets the AI take the first move when the player starts as black
* adds focused startup coverage for side assignment and board orientation

---

# Changes

### Code

* Added:
  * focused Flame startup test coverage in `app/test/features/games/presentation/flame/chess_game_test.dart`
* Updated:
  * `app/lib/features/games/presentation/flame/chess_game.dart` to support randomized side assignment, AI opening turns, and test injection points
  * `app/lib/features/games/domain/services/chess_tts_manager.dart` to expose a small voice-player contract for testing

### Logic

* startup now picks the player side randomly unless a test override is supplied
* AI opening move runs automatically when the player is assigned black
* display-row conversion is centralized so white/black perspective stays consistent in rendering and tap mapping

---

# API Changes (if any)

* No external API changes.

---

# Database Changes (if any)

* None.

---

# Observability / Logging

* No new logs beyond existing chess debug output.

---

# Performance Impact

* Latency: unchanged in production flow
* Throughput: none
* Memory/CPU: negligible

---

# Risks

* Chess startup now depends on randomized side selection, so any UI copy that implicitly assumes white-first may need later polish.
* Voice playback remains best-effort when platform TTS is unavailable.
* Rollback plan:
  * revert this PR to restore the previous white-only startup behavior

---

# Testing

* Unit tests:
  * `flutter test test/features/games/presentation/flame/chess_game_test.dart`
  * `flutter test test/features/games/domain/services/chess_engine_test.dart`
* Manual testing:
  * not run

---

# Deployment Notes

* No config changes.
* No deployment ordering constraints.

---

# Related Commits

* `fix(chess): restore randomized side assignment`

---

# Notes

* This is the smallest issue-18 slice that satisfies the missing player/AI opening behavior while keeping the rest of the chess feature unchanged.
