### PR TITLE
docs(agents): retire stale coordination tracker

### DIFF
--- a/docs/agents/index.md
+++ b/docs/agents/index.md
@@ -7,7 +7,6 @@
 | Resource | Description |
 |----------|-------------|
 | [📋 Project Board](https://github.com/orgs/DevelopersCoffee/projects/2) | Live task tracking |
-| [🎯 Coordination Issue](https://github.com/DevelopersCoffee/airo/issues/17) | Central status tracker |
 | [📜 Rules](./RULES.md) | Agent operating rules |
 | [🧭 Agent Policy](./AGENT_POLICY.md) | Ownership, lifecycle gates, contracts, and Critical Agent workflow |
 | [🧪 Kaggle Adoption](./KAGGLE_VIBE_CODING_ADOPTION.md) | Spec-driven, skills, tools, security, and evaluation adoption plan |
@@ -16,22 +15,20 @@
 
 ---
 
-## 📊 Agent Overview
+## 📊 Current Planning Model
 
-| # | Agent | Issue | Priority | Phase |
-|---|-------|-------|----------|-------|
-| 01 | 🏗️ Core Architecture | [#5](https://github.com/DevelopersCoffee/airo/issues/5) | P0 | Foundation |
-| 02 | 🔄 Offline & Sync | [#6](https://github.com/DevelopersCoffee/airo/issues/6) | P0 | Infrastructure |
-| 03 | 🤖 AI / LLM | [#7](https://github.com/DevelopersCoffee/airo/issues/7) | P0 | Features |
-| 04 | 📱 Mobile UI | [#11](https://github.com/DevelopersCoffee/airo/issues/11) | P1 | Features |
-| 05 | 💰 Finance | [#8](https://github.com/DevelopersCoffee/airo/issues/8) | P0 | Features |
-| 06 | 🔒 Security | [#9](https://github.com/DevelopersCoffee/airo/issues/9) | P0 | Foundation |
-| 07 | 🚀 CI/CD | [#10](https://github.com/DevelopersCoffee/airo/issues/10) | P0 | Foundation |
-| 08 | 🧪 QA Testing | [#12](https://github.com/DevelopersCoffee/airo/issues/12) | P1 | Quality |
-| 09 | 📊 Observability | [#15](https://github.com/DevelopersCoffee/airo/issues/15) | P2 | Polish |
-| 10 | 🛠️ DevEx | [#13](https://github.com/DevelopersCoffee/airo/issues/13) | P1 | Infrastructure |
-| 11 | 📦 Release | [#14](https://github.com/DevelopersCoffee/airo/issues/14) | P1 | Quality |
-| 12 | 📚 Docs | [#16](https://github.com/DevelopersCoffee/airo/issues/16) | P2 | Polish |
+Agent ownership and activation no longer depend on one long-lived coordination
+issue. Current work is routed through:
+
+- the GitHub Project Board for queue state and sequencing
+- [AGENT_POLICY.md](./AGENT_POLICY.md) for ownership, readiness gates, and
+  cross-agent contracts
+- [RULES.md](./RULES.md) and [SEQUENCE.md](./SEQUENCE.md) for operating
+  constraints and rough activation order
+
+Historical bootstrap issues such as `#7`, `#11`, `#12`, `#13`, and `#16` were
+useful during the initial repo setup, but they are no longer the canonical map
+of current agent work.
 
 ---
 
@@ -49,9 +46,10 @@
 ### For Project Maintainers
 
 1. **Review Project Board:** https://github.com/orgs/DevelopersCoffee/projects/2
-2. **Check Coordination Issue:** #17
+2. **Check readiness gates:** [AGENT_POLICY.md](./AGENT_POLICY.md)
 3. **Assign Agents:** Move issues to "Ready" when dependencies met
-4. **Update Phases:** Mark checkboxes in #17 when issues close
+4. **Track status in GitHub issues/PRs and the board**, not in a separate
+   coordination tracker
 
 ---
 

--- a/docs/agents/index.md
+++ b/docs/agents/index.md
@@ -40,7 +40,7 @@ of current agent work.
 2. **Complete the Agent Policy gates:** [AGENT_POLICY.md](./AGENT_POLICY.md)
 3. **Understand the Process:** [SDLC.md](./SDLC.md)
 4. **Check the Sequence:** [SEQUENCE.md](./SEQUENCE.md)
-5. **Find your Issue:** Check the table above
+5. **Find your Issue:** Use the GitHub Project Board and current issue queue
 6. **Start Working:** Follow the SDLC workflow
 
 ### For Project Maintainers


### PR DESCRIPTION
# PR Title
docs(agents): retire stale coordination tracker

---

# Summary

This PR removes the last docs dependency on issue `#17` as the central coordination tracker.
Goal: make agent onboarding point to the current sources of truth instead of the obsolete bootstrap tracker.

Core outcome:

* removes the direct docs link to issue `#17`
* replaces the stale issue table with current planning guidance
* updates onboarding copy to point to the project board and agent policy

---

# Changes

### Code

* Updated:
  * `docs/agents/index.md`

### Logic

* maintainers and agents are now directed to the GitHub Project Board plus `AGENT_POLICY.md`
* obsolete bootstrap issue references are no longer presented as the canonical coordination model

---

# API Changes (if any)

* None.

---

# Database Changes (if any)

* None.

---

# Observability / Logging

* None.

---

# Performance Impact

* None.

---

# Risks

* Very low risk; docs-only change.
* Rollback plan:
  * revert this PR to restore the old tracker link

---

# Testing

* Manual review:
  * verified the updated markdown content in `docs/agents/index.md`

---

# Deployment Notes

* No config changes.

---

# Related Commits

* `docs(agents): retire stale coordination tracker`
* `docs(agents): fix onboarding reference`

---

# Notes

* This PR is intended to unblock clean closure of issue `#17`, which is no longer the active coordination mechanism.
