### PR TITLE
feat(devex): add AI Edge quantization helper

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,8 @@ IPTV_DIR := iptv-data
 IPTV_PYTHON ?= python3
 IPTV_CONFIG ?= config/default.yaml
 IPTV_SKIP_VALIDATION ?= false
+QUANTIZE_PYTHON ?= python3
+QUANTIZE_ARGS ?=
 
 # Local simulator targets. Override any of these from the shell when your
 # installed Android/Xcode runtimes use different names.
@@ -90,6 +92,13 @@ help: ## Show this help message
 	@echo ""
 	@echo "$(YELLOW)IPTV Data Commands:$(NC)"
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | grep -E '^iptv-' | awk 'BEGIN {FS = ":.*?## "}; {printf "  $(GREEN)%-20s$(NC) %s\n", $$1, $$2}'
+	@echo ""
+	@echo "$(YELLOW)Model Tooling:$(NC)"
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | grep -E '^quantize-model' | awk 'BEGIN {FS = ":.*?## "}; {printf "  $(GREEN)%-20s$(NC) %s\n", $$1, $$2}'
+
+.PHONY: quantize-model
+quantize-model: ## Run the model quantization helper; set QUANTIZE_ARGS="..."
+	@$(QUANTIZE_PYTHON) scripts/quantize_model.py $(if $(HELP),--help,$(QUANTIZE_ARGS))
 
 # Setup Commands
 .PHONY: setup

--- a/docs/guides/MODEL_QUANTIZATION.md
+++ b/docs/guides/MODEL_QUANTIZATION.md
@@ -1,0 +1,136 @@
+# Model Quantization
+
+This guide documents the small developer workflow added for issue `#359`.
+
+The repository wrapper does two things:
+
+1. Quantize an existing LiteRT/TFLite artifact with Google AI Edge Quantizer.
+2. Forward a supported Hugging Face or local checkpoint export to `litert-torch`.
+
+The repo does not vendor model conversion dependencies. Install them into an
+isolated Python environment first.
+
+## Prerequisites
+
+- Python 3.10+
+- `pip`
+- Enough free disk for the source checkpoint and exported artifact
+
+Recommended virtual environment:
+
+```bash
+python3 -m venv .venv
+source .venv/bin/activate
+python3 -m pip install --upgrade pip
+```
+
+Install the upstream tools:
+
+```bash
+python3 -m pip install ai-edge-quantizer litert-torch
+```
+
+If the source model is private on Hugging Face, authenticate through the
+standard Hugging Face CLI or environment variables. Do not pass tokens on the
+command line.
+
+## Quick Start
+
+Show help:
+
+```bash
+python3 scripts/quantize_model.py --help
+make quantize-model HELP=1
+```
+
+## Quantize An Existing LiteRT/TFLite Model
+
+Use the built-in `dynamic_wi8_afp32` recipe from Google AI Edge Quantizer:
+
+```bash
+python3 scripts/quantize_model.py quantize-tflite \
+  --input-tflite /tmp/model_fp32.tflite \
+  --output-tflite /tmp/model_int8.tflite
+```
+
+Dry-run the same command first:
+
+```bash
+python3 scripts/quantize_model.py quantize-tflite \
+  --input-tflite /tmp/model_fp32.tflite \
+  --output-tflite /tmp/model_int8.tflite \
+  --dry-run
+```
+
+## Export A Supported Hugging Face Model
+
+The wrapper forwards to the upstream `litert-torch export_hf` CLI:
+
+```bash
+python3 scripts/quantize_model.py export-hf \
+  --model google/gemma-3-270m-it \
+  --output-dir /tmp/gemma3-export
+```
+
+Pass through exporter-specific flags after `--`:
+
+```bash
+python3 scripts/quantize_model.py export-hf \
+  --model google/gemma-3-270m-it \
+  --output-dir /tmp/gemma3-export \
+  -- \
+  --prefill_seq_lens 512,1024 \
+  --kv_cache_max_len 1024
+```
+
+Use the Makefile handoff:
+
+```bash
+make quantize-model QUANTIZE_ARGS="export-hf --model google/gemma-3-270m-it --output-dir /tmp/gemma3-export"
+```
+
+## How To Check Quantized Model Perplexity
+
+Perplexity should be compared against the original source checkpoint before the
+artifact is adopted into Airo's model catalog.
+
+Recommended baseline workflow:
+
+1. Evaluate the source checkpoint with a reproducible harness such as
+   [`lm-evaluation-harness`](https://github.com/EleutherAI/lm-evaluation-harness).
+2. Record the baseline perplexity or downstream task score.
+3. Export or quantize the model.
+4. Re-run the same evaluation on the quantized/runtime-compatible artifact if
+   your runtime exposes perplexity directly.
+5. If the target runtime does not expose perplexity yet, use the same held-out
+   prompts plus Airo's benchmark/import flow as a temporary gate and record the
+   limitation in the PR.
+
+Example source-checkpoint baseline:
+
+```bash
+python3 -m pip install lm-eval
+python3 -m lm_eval \
+  --model hf \
+  --model_args pretrained=google/gemma-3-270m-it \
+  --tasks wikitext \
+  --batch_size auto
+```
+
+Until Airo exposes direct perplexity measurement for imported LiteRT artifacts,
+do not treat quantization as complete without:
+
+- a saved baseline metric from the source checkpoint
+- a small held-out prompt regression check
+- an import smoke test in Airo or the target LiteRT runtime
+
+## Troubleshooting
+
+- `Missing dependency ai-edge-quantizer`: install the Python package in the
+  active virtual environment.
+- `Could not find litert-torch`: install `litert-torch` or point
+  `--litert-torch-bin` at the correct binary.
+- `Unknown recipe`: run the script with the documented built-in recipe or
+  inspect the installed `ai_edge_quantizer.recipe_manager` module.
+- Export failure from `litert-torch`: retry with the exact upstream flags for
+  the chosen architecture and confirm the model is supported by LiteRT Torch.

--- a/scripts/quantize_model.py
+++ b/scripts/quantize_model.py
@@ -1,0 +1,254 @@
+#!/usr/bin/env python3
+"""Developer wrapper for Google AI Edge quantization flows.
+
+This script intentionally keeps repository-side logic thin:
+- `quantize-tflite` wraps the AI Edge Quantizer for existing LiteRT/TFLite files.
+- `export-hf` forwards to the upstream `litert-torch export_hf` CLI for
+  Hugging Face or local checkpoints that the upstream exporter supports.
+
+Run `python scripts/quantize_model.py --help` for usage.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import Callable
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Google AI Edge quantization helper for Airo developers.",
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    quantize_parser = subparsers.add_parser(
+        "quantize-tflite",
+        help="Quantize an existing LiteRT/TFLite file with AI Edge Quantizer.",
+    )
+    quantize_parser.add_argument(
+        "--input-tflite",
+        required=True,
+        help="Path to the source .tflite or .litert model.",
+    )
+    quantize_parser.add_argument(
+        "--output-tflite",
+        required=True,
+        help="Path for the quantized output artifact.",
+    )
+    quantize_parser.add_argument(
+        "--recipe",
+        default="dynamic_wi8_afp32",
+        help=(
+            "Built-in AI Edge Quantizer recipe. "
+            "Default: dynamic_wi8_afp32."
+        ),
+    )
+    quantize_parser.add_argument(
+        "--overwrite",
+        action="store_true",
+        help="Allow overwriting an existing output file.",
+    )
+    quantize_parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Validate arguments and print the intended action without running it.",
+    )
+    quantize_parser.set_defaults(func=run_quantize_tflite)
+
+    export_parser = subparsers.add_parser(
+        "export-hf",
+        help="Export a supported Hugging Face or local checkpoint via litert-torch.",
+    )
+    export_parser.add_argument(
+        "--model",
+        required=True,
+        help="Hugging Face model id or local checkpoint directory.",
+    )
+    export_parser.add_argument(
+        "--output-dir",
+        required=True,
+        help="Directory where litert-torch should write the exported artifacts.",
+    )
+    export_parser.add_argument(
+        "--litert-torch-bin",
+        default="litert-torch",
+        help="Binary to use for the upstream exporter. Default: litert-torch.",
+    )
+    export_parser.add_argument(
+        "--overwrite",
+        action="store_true",
+        help="Allow exporting into a non-empty output directory.",
+    )
+    export_parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Validate arguments and print the intended action without running it.",
+    )
+    export_parser.add_argument(
+        "extra_args",
+        nargs=argparse.REMAINDER,
+        help=(
+            "Additional arguments forwarded to `litert-torch export_hf`. "
+            "Prefix them with `--`, for example: "
+            "`... export-hf --model ... --output-dir ... -- "
+            "--prefill_seq_lens 512,1024`"
+        ),
+    )
+    export_parser.set_defaults(func=run_export_hf)
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    try:
+        return args.func(args)
+    except QuantizationToolError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+
+
+class QuantizationToolError(RuntimeError):
+    """Raised for actionable user-facing CLI errors."""
+
+
+def run_quantize_tflite(args: argparse.Namespace) -> int:
+    input_path = _existing_file(args.input_tflite, flag="--input-tflite")
+    output_path = Path(args.output_tflite).expanduser().resolve()
+    _prepare_output_path(output_path, overwrite=args.overwrite, is_dir=False)
+
+    recipe_factory = _resolve_recipe(args.recipe)
+    if args.dry_run:
+        print("Dry run: quantize-tflite")
+        print(f"  input:   {input_path}")
+        print(f"  output:  {output_path}")
+        print(f"  recipe:  {args.recipe}")
+        return 0
+
+    try:
+        quantizer_module = importlib.import_module("ai_edge_quantizer")
+    except ImportError as exc:
+        raise QuantizationToolError(
+            "Missing dependency `ai-edge-quantizer`. Install it first, for "
+            "example: `python3 -m pip install ai-edge-quantizer`."
+        ) from exc
+
+    quantizer = quantizer_module.Quantizer(model_path=str(input_path))
+    recipe = recipe_factory()
+    quantizer.quantize(recipe=recipe, save_path=str(output_path))
+
+    print("Quantization complete.")
+    print(f"  output: {output_path}")
+    print("Suggested next step:")
+    print(f"  file {output_path}")
+    return 0
+
+
+def run_export_hf(args: argparse.Namespace) -> int:
+    output_dir = Path(args.output_dir).expanduser().resolve()
+    _prepare_output_path(output_dir, overwrite=args.overwrite, is_dir=True)
+
+    binary = shutil.which(args.litert_torch_bin)
+    if binary is None:
+        raise QuantizationToolError(
+            f"Could not find `{args.litert_torch_bin}` in PATH. Install the "
+            "LiteRT Torch exporter first, then retry."
+        )
+
+    extra_args = list(args.extra_args)
+    if extra_args[:1] == ["--"]:
+        extra_args = extra_args[1:]
+
+    command = [
+        binary,
+        "export_hf",
+        "--model_name",
+        args.model,
+        "--output_dir",
+        str(output_dir),
+        *extra_args,
+    ]
+
+    if args.dry_run:
+        print("Dry run: export-hf")
+        print(f"  model:      {args.model}")
+        print(f"  output_dir: {output_dir}")
+        print("  command:")
+        print(f"    {' '.join(command)}")
+        return 0
+
+    try:
+        subprocess.run(command, check=True)
+    except subprocess.CalledProcessError as exc:
+        raise QuantizationToolError(
+            f"`{args.litert_torch_bin} export_hf` failed with exit code "
+            f"{exc.returncode}."
+        ) from exc
+
+    print("Export complete.")
+    print(f"  output_dir: {output_dir}")
+    print("Suggested next steps:")
+    print(f"  ls -lah {output_dir}")
+    print(
+        "  Import the generated artifact into Airo and compare prompt quality "
+        "against the source checkpoint before committing to distribution."
+    )
+    return 0
+
+
+def _resolve_recipe(name: str) -> Callable[[], object]:
+    try:
+        recipe_module = importlib.import_module("ai_edge_quantizer.recipe_manager")
+    except ImportError as exc:
+        raise QuantizationToolError(
+            "Missing dependency `ai-edge-quantizer`. Install it first, for "
+            "example: `python3 -m pip install ai-edge-quantizer`."
+        ) from exc
+
+    recipe_name = f"{name}_recipe"
+    recipe_factory = getattr(recipe_module, recipe_name, None)
+    if recipe_factory is None:
+        available = sorted(
+            attribute.removesuffix("_recipe")
+            for attribute in dir(recipe_module)
+            if attribute.endswith("_recipe")
+        )
+        raise QuantizationToolError(
+            f"Unknown recipe `{name}`. Available recipes: {', '.join(available)}."
+        )
+    return recipe_factory
+
+
+def _existing_file(path_text: str, *, flag: str) -> Path:
+    path = Path(path_text).expanduser().resolve()
+    if not path.is_file():
+        raise QuantizationToolError(f"{flag} file does not exist: {path}")
+    return path
+
+
+def _prepare_output_path(path: Path, *, overwrite: bool, is_dir: bool) -> None:
+    if path.exists() and not overwrite:
+        if is_dir and path.is_dir() and not any(path.iterdir()):
+            return
+        raise QuantizationToolError(
+            f"Refusing to overwrite existing {'directory' if is_dir else 'file'} "
+            f"without --overwrite: {path}"
+        )
+
+    if is_dir:
+        path.mkdir(parents=True, exist_ok=True)
+        if path.exists() and overwrite and not path.is_dir():
+            raise QuantizationToolError(f"Output path is not a directory: {path}")
+        return
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tests/test_quantize_model.py
+++ b/scripts/tests/test_quantize_model.py
@@ -1,0 +1,60 @@
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "scripts" / "quantize_model.py"
+
+
+class QuantizeModelScriptTests(unittest.TestCase):
+    def run_script(self, *args: str) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [sys.executable, str(SCRIPT), *args],
+            cwd=REPO_ROOT,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+    def test_help_succeeds(self) -> None:
+        result = self.run_script("--help")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("quantize-tflite", result.stdout)
+        self.assertIn("export-hf", result.stdout)
+
+    def test_quantize_tflite_requires_existing_input(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            output = Path(tempdir) / "output.tflite"
+            result = self.run_script(
+                "quantize-tflite",
+                "--input-tflite",
+                str(Path(tempdir) / "missing.tflite"),
+                "--output-tflite",
+                str(output),
+            )
+
+        self.assertEqual(result.returncode, 2)
+        self.assertIn("--input-tflite file does not exist", result.stderr)
+
+    def test_export_hf_dry_run_requires_exporter_binary(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            result = self.run_script(
+                "export-hf",
+                "--model",
+                "google/gemma-3-270m-it",
+                "--output-dir",
+                tempdir,
+                "--litert-torch-bin",
+                "definitely-not-a-real-binary",
+                "--dry-run",
+            )
+
+        self.assertEqual(result.returncode, 2)
+        self.assertIn("Could not find `definitely-not-a-real-binary`", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
# Summary

This PR introduces changes to the DevEx model tooling flow.
Goal: give contributors one repo-supported entrypoint for AI Edge quantization and LiteRT export tasks.

Core outcome:

* adds a Python wrapper for AI Edge Quantizer and LiteRT Torch export flows
* documents the workflow and adds smoke coverage for help/validation paths

# Changes

### Code

* Added:
  * `scripts/quantize_model.py`
  * `scripts/tests/test_quantize_model.py`
  * `docs/guides/MODEL_QUANTIZATION.md`
* Updated:
  * `Makefile` with a `quantize-model` entrypoint

### Logic

* wraps `quantize-tflite` for existing LiteRT/TFLite artifacts
* forwards `export-hf` work to upstream `litert-torch export_hf`
* keeps CI expectations lightweight by testing CLI validation paths, not real model conversion

# Observability / Logging

* command failures are surfaced as explicit actionable CLI errors

# Risks

* upstream `litert-torch` flags may evolve, so the wrapper intentionally stays thin and supports passthrough args
* real conversion still depends on developers installing external Python tooling locally
* Rollback plan:
  * revert this PR to remove the helper, docs, and Make target

# Testing

* Unit tests:
  * `python3 -m unittest scripts/tests/test_quantize_model.py`
* Manual testing:
  * `python3 -m py_compile scripts/quantize_model.py`
  * `make quantize-model HELP=1`

# Deployment Notes

* no app/runtime deployment changes
* no schema or config migration

# Notes

* Closes #359