### PR TITLE
fix(shell): split beats and stream tabs

### DIFF
--- a/app/lib/core/app/app_shell.dart
+++ b/app/lib/core/app/app_shell.dart
@@ -73,7 +73,7 @@ class AppShell extends ConsumerWidget {
           actions: [
             IconButton(
               tooltip: 'Notifications',
-              onPressed: () => context.push('/agent/notifications'),
+              onPressed: () => context.push('/mind/notifications'),
               icon: const Icon(Icons.notifications_outlined),
             ),
             // User profile avatar with menu
@@ -121,7 +121,7 @@ class AppShell extends ConsumerWidget {
                     context.go(RouteNames.login);
                   }
                 } else if (value == 'profile') {
-                  context.push('/agent/profile');
+                  context.push('/mind/profile');
                 }
               },
               itemBuilder: (context) => [
@@ -204,7 +204,7 @@ class AppShell extends ConsumerWidget {
   }
 }
 
-/// Context-aware mini players that hide on their owning media tabs.
+/// Context-aware mini players shown only on their owning media tabs.
 class _ContextAwareMiniPlayers extends ConsumerWidget {
   final int currentIndex;
   final Widget child;

--- a/app/lib/core/providers/navigation_provider.dart
+++ b/app/lib/core/providers/navigation_provider.dart
@@ -3,31 +3,37 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 enum AppNavigationTab {
   coins(
-    label: 'Dashboard',
+    label: 'Coins',
     path: '/money',
     icon: Icons.monetization_on_outlined,
     selectedIcon: Icons.monetization_on,
   ),
   mind(
-    label: 'Assistant',
-    path: '/agent',
-    icon: Icons.smart_toy_outlined,
-    selectedIcon: Icons.smart_toy,
+    label: 'Mind',
+    path: '/mind',
+    icon: Icons.psychology_outlined,
+    selectedIcon: Icons.psychology,
   ),
-  entertainment(
-    label: 'Entertainment',
-    path: '/live',
+  beats(
+    label: 'Beats',
+    path: '/music',
     icon: Icons.subscriptions_outlined,
     selectedIcon: Icons.subscriptions,
   ),
+  stream(
+    label: 'Stream',
+    path: '/iptv',
+    icon: Icons.live_tv_outlined,
+    selectedIcon: Icons.live_tv,
+  ),
   arena(
-    label: 'Games',
+    label: 'Arena',
     path: '/games',
     icon: Icons.sports_esports_outlined,
     selectedIcon: Icons.sports_esports,
   ),
   quest(
-    label: 'Tasks',
+    label: 'Quest',
     path: '/quest',
     icon: Icons.workspace_premium_outlined,
     selectedIcon: Icons.workspace_premium,
@@ -48,7 +54,7 @@ enum AppNavigationTab {
 
 /// Current navigation tab index.
 ///
-/// Order: Dashboard | Assistant | Entertainment | Games | Tasks
+/// Order: Coins | Mind | Beats | Stream | Arena | Quest
 final currentNavigationTabProvider = StateProvider<int>(
   (ref) => AppNavigationTab.coins.index,
 );
@@ -70,8 +76,8 @@ class MiniPlayerVisibility {
 final miniPlayerVisibilityProvider = Provider.family<MiniPlayerVisibility, int>(
   (ref, currentIndex) {
     return MiniPlayerVisibility(
-      showMusicPlayer: currentIndex != AppNavigationTab.entertainment.index,
-      showIptvPlayer: currentIndex != AppNavigationTab.entertainment.index,
+      showMusicPlayer: currentIndex == AppNavigationTab.beats.index,
+      showIptvPlayer: currentIndex == AppNavigationTab.stream.index,
     );
   },
 );

--- a/app/lib/core/routing/app_router.dart
+++ b/app/lib/core/routing/app_router.dart
@@ -6,8 +6,10 @@ import '../../features/agent_chat/presentation/screens/chat_screen.dart';
 import '../../features/agent_chat/presentation/screens/model_library_screen.dart';
 import '../../features/agent_chat/presentation/screens/notifications_screen.dart';
 import '../../features/agent_chat/presentation/screens/profile_screen.dart';
-import '../../features/live/presentation/screens/live_screen.dart';
+import '../../features/iptv/presentation/screens/iptv_screen.dart';
 import '../../features/games/presentation/screens/games_hub_screen.dart';
+import '../../features/money/presentation/screens/money_overview_screen.dart';
+import '../../features/music/presentation/screens/music_screen.dart';
 import '../../features/quest/presentation/screens/quest_chat_screen.dart';
 import '../../features/quest/presentation/screens/quest_list_screen.dart';
 import '../../features/quest/presentation/screens/quest_upload_screen.dart';
@@ -52,8 +54,24 @@ class AppRouter {
     routes: [
       // Redirect root to finance dashboard.
       GoRoute(path: '/', redirect: (context, state) => '/money'),
-      GoRoute(path: '/beats', redirect: (context, state) => '/live/music'),
-      GoRoute(path: '/stream', redirect: (context, state) => '/live/tv'),
+      GoRoute(path: '/agent', redirect: (context, state) => '/mind'),
+      GoRoute(
+        path: '/agent/notifications',
+        redirect: (context, state) => '/mind/notifications',
+      ),
+      GoRoute(
+        path: '/agent/profile',
+        redirect: (context, state) => '/mind/profile',
+      ),
+      GoRoute(
+        path: '/agent/models',
+        redirect: (context, state) => '/mind/models',
+      ),
+      GoRoute(path: '/beats', redirect: (context, state) => '/music'),
+      GoRoute(path: '/stream', redirect: (context, state) => '/iptv'),
+      GoRoute(path: '/live', redirect: (context, state) => '/music'),
+      GoRoute(path: '/live/music', redirect: (context, state) => '/music'),
+      GoRoute(path: '/live/tv', redirect: (context, state) => '/iptv'),
       GoRoute(
         path: RouteNames.login,
         name: RouteNames.login,
@@ -74,8 +92,8 @@ class AppRouter {
             routes: [
               GoRoute(
                 path: '/money',
-                name: 'Dashboard',
-                builder: (context, state) => const CoinsDashboardScreen(),
+                name: 'Coins',
+                builder: (context, state) => const MoneyOverviewScreen(),
                 routes: [
                   GoRoute(
                     path: 'split',
@@ -127,12 +145,12 @@ class AppRouter {
               ),
             ],
           ),
-          // Agent Chat branch
+          // Mind branch
           StatefulShellBranch(
             routes: [
               GoRoute(
-                path: '/agent',
-                name: 'Assistant',
+                path: '/mind',
+                name: 'Mind',
                 builder: (context, state) => const ChatScreen(),
                 routes: [
                   GoRoute(
@@ -150,10 +168,10 @@ class AppRouter {
                     name: 'assistant_models',
                     builder: (context, state) => ModelLibraryScreen(
                       onModelSelected: (candidate) {
-                        context.go('/agent');
+                        context.go('/mind');
                       },
                       onOpenModelManager: () {
-                        context.push('/agent/profile');
+                        context.push('/mind/profile');
                       },
                     ),
                   ),
@@ -161,28 +179,23 @@ class AppRouter {
               ),
             ],
           ),
-          // Entertainment branch: Music + TV in one bottom tab
+          // Beats branch
           StatefulShellBranch(
             routes: [
               GoRoute(
-                path: '/live',
-                name: 'Entertainment',
-                builder: (context, state) =>
-                    const LiveScreen(mode: LiveMode.music),
-                routes: [
-                  GoRoute(
-                    path: 'music',
-                    name: 'EntertainmentMusic',
-                    builder: (context, state) =>
-                        const LiveScreen(mode: LiveMode.music),
-                  ),
-                  GoRoute(
-                    path: 'tv',
-                    name: 'EntertainmentTV',
-                    builder: (context, state) =>
-                        const LiveScreen(mode: LiveMode.tv),
-                  ),
-                ],
+                path: '/music',
+                name: 'Beats',
+                builder: (context, state) => const MusicScreen(),
+              ),
+            ],
+          ),
+          // Stream branch
+          StatefulShellBranch(
+            routes: [
+              GoRoute(
+                path: '/iptv',
+                name: 'Stream',
+                builder: (context, state) => const IPTVScreen(),
               ),
             ],
           ),
@@ -191,7 +204,7 @@ class AppRouter {
             routes: [
               GoRoute(
                 path: '/games',
-                name: 'Games',
+                name: 'Arena',
                 builder: (context, state) => const GamesHubScreen(),
               ),
             ],
@@ -201,7 +214,7 @@ class AppRouter {
             routes: [
               GoRoute(
                 path: '/quest',
-                name: 'Tasks',
+                name: 'Quest',
                 builder: (context, state) => const QuestListScreen(),
                 routes: [
                   GoRoute(

--- a/app/lib/features/auth/screens/login_screen.dart
+++ b/app/lib/features/auth/screens/login_screen.dart
@@ -59,8 +59,8 @@ class _LoginScreenState extends State<LoginScreen> {
 
       if (result.success) {
         if (mounted) {
-          // Navigate to main app (agent tab)
-          context.go('/agent');
+          // Navigate to main app (mind tab)
+          context.go('/mind');
         }
       } else {
         setState(() {
@@ -111,7 +111,7 @@ class _LoginScreenState extends State<LoginScreen> {
 
       if (result.success) {
         if (mounted) {
-          context.go('/agent');
+          context.go('/mind');
         }
       } else {
         setState(() {

--- a/app/lib/features/iptv/presentation/widgets/iptv_mini_player.dart
+++ b/app/lib/features/iptv/presentation/widgets/iptv_mini_player.dart
@@ -18,8 +18,7 @@ class IPTVMiniPlayer extends ConsumerWidget {
     final streamingState = ref.watch(streamingStateProvider);
     final currentTab = ref.watch(currentNavigationTabProvider);
 
-    final isOnEntertainmentTab =
-        currentTab == AppNavigationTab.entertainment.index;
+    final isOnStreamTab = currentTab == AppNavigationTab.stream.index;
 
     return streamingState.when(
       data: (state) {
@@ -28,17 +27,17 @@ class IPTVMiniPlayer extends ConsumerWidget {
           return const SizedBox.shrink();
         }
 
-        // Don't show if on Entertainment tab (video player is visible there)
+        // Don't show if on Stream tab (video player is visible there)
         // unless it's an audio-only channel
-        if (isOnEntertainmentTab && !state.currentChannel!.isAudioOnly) {
+        if (isOnStreamTab && !state.currentChannel!.isAudioOnly) {
           return const SizedBox.shrink();
         }
 
         return GestureDetector(
           onTap: () {
             ref.read(currentNavigationTabProvider.notifier).state =
-                AppNavigationTab.entertainment.index;
-            context.go('/live/tv');
+                AppNavigationTab.stream.index;
+            context.go('/iptv');
           },
           child: Container(
             height: 64,

--- a/app/lib/features/music/presentation/widgets/mini_player.dart
+++ b/app/lib/features/music/presentation/widgets/mini_player.dart
@@ -20,7 +20,7 @@ class MiniPlayer extends ConsumerWidget {
 
         return GestureDetector(
           onTap: () {
-            context.go('/live/music');
+            context.go('/music');
           },
           child: Container(
             decoration: BoxDecoration(

--- a/app/test/core/providers/navigation_provider_test.dart
+++ b/app/test/core/providers/navigation_provider_test.dart
@@ -4,13 +4,14 @@ import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   group('AppNavigationTab', () {
-    test('uses the five-tab information architecture order', () {
+    test('uses the six-tab information architecture order', () {
       expect(AppNavigationTab.values.map((tab) => tab.label), [
-        'Dashboard',
-        'Assistant',
-        'Entertainment',
-        'Games',
-        'Tasks',
+        'Coins',
+        'Mind',
+        'Beats',
+        'Stream',
+        'Arena',
+        'Quest',
       ]);
     });
 
@@ -27,27 +28,24 @@ void main() {
     test('uses stable root paths for each tab', () {
       expect(AppNavigationTab.values.map((tab) => tab.path), [
         '/money',
-        '/agent',
-        '/live',
+        '/mind',
+        '/music',
+        '/iptv',
         '/games',
         '/quest',
       ]);
     });
 
-    test('keeps music and tv inside the entertainment architecture', () {
+    test('separates beats and stream into distinct primary tabs', () {
       final rootLabels = AppNavigationTab.values.map((tab) => tab.label);
       final rootPaths = AppNavigationTab.values.map((tab) => tab.path);
 
-      expect(AppNavigationTab.values.length, 5);
-      expect(rootLabels, contains('Entertainment'));
-      expect(rootLabels, isNot(contains('Music')));
-      expect(rootLabels, isNot(contains('TV')));
-      expect(rootPaths, contains('/live'));
-      expect(rootPaths, isNot(contains('/beats')));
-      expect(rootPaths, isNot(contains('/stream')));
+      expect(AppNavigationTab.values.length, 6);
+      expect(rootLabels, containsAll(['Beats', 'Stream']));
+      expect(rootPaths, containsAll(['/music', '/iptv']));
     });
 
-    test('hides persistent mini players on the owning media tab', () {
+    test('shows each persistent mini player only on its owning media tab', () {
       final container = ProviderContainer();
       addTearDown(container.dispose);
 
@@ -58,12 +56,12 @@ void main() {
 
         expect(
           visibility.showMusicPlayer,
-          tab != AppNavigationTab.entertainment,
+          tab == AppNavigationTab.beats,
           reason: '${tab.label} music mini player visibility',
         );
         expect(
           visibility.showIptvPlayer,
-          tab != AppNavigationTab.entertainment,
+          tab == AppNavigationTab.stream,
           reason: '${tab.label} IPTV mini player visibility',
         );
       }


### PR DESCRIPTION
# Summary

This PR introduces changes to the app shell and routing.
Goal: align navigation with the six-tab UX structure and stop mini-player leakage across unrelated tabs.

Core outcome:

* splits the old combined entertainment tab into distinct Beats and Stream tabs
* restricts music/IPTV mini players to their owning tabs while preserving legacy route aliases

# Changes

### Code

* Updated:
  * `app/lib/core/providers/navigation_provider.dart`
  * `app/lib/core/app/app_shell.dart`
  * `app/lib/core/routing/app_router.dart`
  * `app/lib/features/music/presentation/widgets/mini_player.dart`
  * `app/lib/features/iptv/presentation/widgets/iptv_mini_player.dart`
  * `app/lib/features/auth/screens/login_screen.dart`
  * `app/test/core/providers/navigation_provider_test.dart`

### Logic

* changes the primary nav to Coins, Mind, Beats, Stream, Arena, Quest
* routes `/mind`, `/music`, and `/iptv` as primary roots while keeping `/agent`, `/live/music`, and `/live/tv` as redirects
* shows the music mini player only on Beats and the IPTV mini player only on Stream

# Risks

* older code still targeting legacy aliases depends on redirects remaining intact
* broader routing/widget integration was not exhaustively retested beyond the focused nav/provider slice
* Rollback plan:
  * revert this PR to restore the 5-tab shell

# Testing

* Unit tests:
  * `flutter test test/core/providers/navigation_provider_test.dart`
* Manual testing:
  * `flutter analyze lib/core/providers/navigation_provider.dart lib/core/app/app_shell.dart lib/core/routing/app_router.dart lib/features/music/presentation/widgets/mini_player.dart lib/features/iptv/presentation/widgets/iptv_mini_player.dart lib/features/auth/screens/login_screen.dart test/core/providers/navigation_provider_test.dart`

# Notes

* `flutter test` initially hit a Flutter tooling crash from pre-existing ephemeral plugin symlinks in the worktree; after clearing those generated symlinks, the focused test passed.
* Closes #195
* Closes #196