### PR TITLE
fix: align Coins FAB copy with issue #188

### DIFF
--- a/app/lib/features/money/presentation/screens/money_overview_screen.dart
+++ b/app/lib/features/money/presentation/screens/money_overview_screen.dart
@@ -58,9 +58,9 @@ class MoneyOverviewScreen extends ConsumerWidget {
           ? null
           : FloatingActionButton.extended(
               onPressed: () => _navigateToAddExpense(context),
-              tooltip: 'Add Expense',
+              tooltip: 'Add Money',
               icon: const Icon(Icons.add),
-              label: const Text('Add Expense'),
+              label: const Text('Add Money'),
             ),
     );
   }

--- a/app/test/features/money/money_overview_screen_test.dart
+++ b/app/test/features/money/money_overview_screen_test.dart
@@ -90,7 +90,7 @@ void main() {
       expect(find.textContaining('music', findRichText: true), findsNothing);
     });
 
-    testWidgets('labels the primary FAB for the expense form it opens', (
+    testWidgets('labels the primary FAB as Add Money for the Coins tab', (
       tester,
     ) async {
       await tester.pumpWidget(buildScreen());
@@ -99,13 +99,16 @@ void main() {
       final fab = find.byType(FloatingActionButton);
 
       expect(fab, findsOneWidget);
-      expect(find.byTooltip('Add Expense'), findsOneWidget);
+      expect(find.byTooltip('Add Money'), findsOneWidget);
       expect(
-        find.descendant(of: fab, matching: find.text('Add Expense')),
+        find.descendant(of: fab, matching: find.text('Add Money')),
         findsOneWidget,
       );
-      expect(find.byTooltip('Add Money'), findsNothing);
-      expect(find.text('Add Money'), findsNothing);
+      expect(find.byTooltip('Add Expense'), findsNothing);
+      expect(
+        find.descendant(of: fab, matching: find.text('Add Expense')),
+        findsNothing,
+      );
     });
   });
 }


### PR DESCRIPTION
# Summary
This PR closes issue #188 by aligning the desktop Coins FAB copy with the requested hub action.

# Testing
- flutter analyze lib/features/money/presentation/screens/money_overview_screen.dart test/features/money/money_overview_screen_test.dart
- flutter test test/features/money/money_overview_screen_test.dart

Closes #188