### PR TITLE
fix: complete Arena category sections for issue #193

### DIFF
--- a/app/lib/features/games/domain/models/game_info.dart
+++ b/app/lib/features/games/domain/models/game_info.dart
@@ -5,7 +5,7 @@ enum GameCategory {
   card('Card Games', Icons.casino),
   board('Board Games', Icons.grid_on),
   puzzle('Puzzle Games', Icons.extension),
-  strategy('Strategy Games', Icons.psychology),
+  strategy('Strategy', Icons.psychology),
   arcade('Arcade Games', Icons.sports_esports),
   casual('Casual Games', Icons.games);
 
@@ -256,7 +256,7 @@ class GameRegistry {
     description:
         'Classic strategy board game where you checkmate your opponent\'s king.',
     shortDescription: 'Checkmate the king',
-    category: GameCategory.board,
+    category: GameCategory.strategy,
     minPlayers: 2,
     maxPlayers: 2,
     difficulty: GameDifficulty.hard,
@@ -282,6 +282,64 @@ class GameRegistry {
     routePath: '/games/chess',
   );
 
+  static const checkers = GameInfo(
+    id: 'checkers',
+    name: 'Checkers',
+    description:
+        'Classic tactical board game focused on captures, positioning, and promotion to kings.',
+    shortDescription: 'Capture pieces and control the board',
+    category: GameCategory.strategy,
+    minPlayers: 2,
+    maxPlayers: 2,
+    difficulty: GameDifficulty.medium,
+    objective:
+        'Capture all opposing pieces or block your opponent from making a legal move.',
+    rules: [
+      'Pieces move diagonally on dark squares only',
+      'Regular pieces move forward one space diagonally',
+      'Captures are made by jumping over an opposing piece',
+      'If a capture is available, it must be taken',
+      'Reach the opposite edge to crown a king',
+    ],
+    howToPlay: [
+      '1. Players alternate turns moving one piece diagonally',
+      '2. Jump over opponent pieces to capture them',
+      '3. Chain captures when multiple jumps are available',
+      '4. Reach the far edge to create a king',
+      '5. Win by removing or trapping all opposing pieces',
+    ],
+    isAvailable: false,
+  );
+
+  static const wordQuest = GameInfo(
+    id: 'word_quest',
+    name: 'Word Quest',
+    description:
+        'A relaxed word puzzle where you connect letters into themed chains before the timer runs out.',
+    shortDescription: 'Connect letters into themed words',
+    category: GameCategory.puzzle,
+    minPlayers: 1,
+    maxPlayers: 1,
+    difficulty: GameDifficulty.easy,
+    objective:
+        'Create valid words from the letter board and clear your target score before time expires.',
+    rules: [
+      'Letters can only be connected to adjacent tiles',
+      'Each tile can be used once per word',
+      'Longer words grant bonus points',
+      'Theme rounds unlock multipliers for matching words',
+      'The round ends when the timer expires',
+    ],
+    howToPlay: [
+      '1. Drag across adjacent letters to form a word',
+      '2. Release to submit the word',
+      '3. Build longer chains for score boosts',
+      '4. Complete theme goals to unlock bonuses',
+      '5. Reach the target score before time runs out',
+    ],
+    isAvailable: false,
+  );
+
   // ============================================================================
   // ALL GAMES REGISTRY
   // ============================================================================
@@ -296,15 +354,23 @@ class GameRegistry {
 
     // Board Games
     chess,
+
+    // Coming Soon
+    checkers,
+    wordQuest,
   ];
 
   static final List<GameInfo> available = all
       .where((game) => game.isAvailable)
       .toList();
 
-  static Map<GameCategory, List<GameInfo>> get byCategory {
+  static final List<GameInfo> comingSoon = all
+      .where((game) => !game.isAvailable)
+      .toList();
+
+  static Map<GameCategory, List<GameInfo>> get availableByCategory {
     final map = <GameCategory, List<GameInfo>>{};
-    for (final game in all) {
+    for (final game in available) {
       map.putIfAbsent(game.category, () => []).add(game);
     }
     return map;

--- a/app/lib/features/games/presentation/screens/game_coming_soon_screen.dart
+++ b/app/lib/features/games/presentation/screens/game_coming_soon_screen.dart
@@ -34,137 +34,141 @@ class GameComingSoonScreen extends StatelessWidget {
             ],
           ),
         ),
-        child: Center(
-          child: Padding(
-            padding: const EdgeInsets.all(24.0),
-            child: Column(
-              mainAxisAlignment: MainAxisAlignment.center,
-              children: [
-                // Game icon
-                Container(
-                  padding: const EdgeInsets.all(32),
-                  decoration: BoxDecoration(
-                    color: game.difficulty.color.withValues(alpha: 0.2),
-                    shape: BoxShape.circle,
-                  ),
-                  child: Icon(
-                    game.icon,
-                    size: 80,
-                    color: game.difficulty.color,
-                  ),
-                ),
-                const SizedBox(height: 32),
-
-                // Game name
-                Text(
-                  game.name,
-                  style: Theme.of(context).textTheme.headlineMedium?.copyWith(
-                    fontWeight: FontWeight.bold,
-                  ),
-                  textAlign: TextAlign.center,
-                ),
-                const SizedBox(height: 16),
-
-                // Description
-                Text(
-                  game.description,
-                  style: Theme.of(
-                    context,
-                  ).textTheme.bodyLarge?.copyWith(color: Colors.grey[600]),
-                  textAlign: TextAlign.center,
-                ),
-                const SizedBox(height: 32),
-
-                // Coming soon badge
-                Container(
-                  padding: const EdgeInsets.symmetric(
-                    horizontal: 24,
-                    vertical: 12,
-                  ),
-                  decoration: BoxDecoration(
-                    color: Colors.orange.withValues(alpha: 0.2),
-                    borderRadius: BorderRadius.circular(24),
-                    border: Border.all(color: Colors.orange, width: 2),
-                  ),
-                  child: Row(
-                    mainAxisSize: MainAxisSize.min,
-                    children: [
-                      const Icon(
-                        Icons.construction,
-                        color: Colors.orange,
-                        size: 20,
+        child: SafeArea(
+          child: SingleChildScrollView(
+            padding: const EdgeInsets.all(24),
+            child: Center(
+              child: ConstrainedBox(
+                constraints: const BoxConstraints(maxWidth: 720),
+                child: Column(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                    // Game icon
+                    Container(
+                      padding: const EdgeInsets.all(32),
+                      decoration: BoxDecoration(
+                        color: game.difficulty.color.withValues(alpha: 0.2),
+                        shape: BoxShape.circle,
                       ),
-                      const SizedBox(width: 8),
-                      Text(
-                        'Full Gameplay Coming Soon',
-                        style: TextStyle(
-                          color: Colors.orange[800],
-                          fontWeight: FontWeight.bold,
-                          fontSize: 16,
+                      child: Icon(
+                        game.icon,
+                        size: 80,
+                        color: game.difficulty.color,
+                      ),
+                    ),
+                    const SizedBox(height: 32),
+
+                    // Game name
+                    Text(
+                      game.name,
+                      style: Theme.of(context).textTheme.headlineMedium
+                          ?.copyWith(fontWeight: FontWeight.bold),
+                      textAlign: TextAlign.center,
+                    ),
+                    const SizedBox(height: 16),
+
+                    // Description
+                    Text(
+                      game.description,
+                      style: Theme.of(
+                        context,
+                      ).textTheme.bodyLarge?.copyWith(color: Colors.grey[600]),
+                      textAlign: TextAlign.center,
+                    ),
+                    const SizedBox(height: 32),
+
+                    // Coming soon badge
+                    Container(
+                      padding: const EdgeInsets.symmetric(
+                        horizontal: 24,
+                        vertical: 12,
+                      ),
+                      decoration: BoxDecoration(
+                        color: Colors.orange.withValues(alpha: 0.2),
+                        borderRadius: BorderRadius.circular(24),
+                        border: Border.all(color: Colors.orange, width: 2),
+                      ),
+                      child: Row(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          const Icon(
+                            Icons.construction,
+                            color: Colors.orange,
+                            size: 20,
+                          ),
+                          const SizedBox(width: 8),
+                          Text(
+                            'Full Gameplay Coming Soon',
+                            style: TextStyle(
+                              color: Colors.orange[800],
+                              fontWeight: FontWeight.bold,
+                              fontSize: 16,
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                    const SizedBox(height: 32),
+
+                    // Game info
+                    Card(
+                      child: Padding(
+                        padding: const EdgeInsets.all(16),
+                        child: Column(
+                          children: [
+                            _buildInfoRow(
+                              Icons.people,
+                              'Players',
+                              game.playerCountDisplay,
+                            ),
+                            const Divider(),
+                            _buildInfoRow(
+                              Icons.speed,
+                              'Difficulty',
+                              game.difficulty.displayName,
+                            ),
+                            const Divider(),
+                            _buildInfoRow(
+                              Icons.category,
+                              'Category',
+                              game.category.displayName,
+                            ),
+                          ],
                         ),
                       ),
-                    ],
-                  ),
-                ),
-                const SizedBox(height: 32),
-
-                // Game info
-                Card(
-                  child: Padding(
-                    padding: const EdgeInsets.all(16),
-                    child: Column(
-                      children: [
-                        _buildInfoRow(
-                          Icons.people,
-                          'Players',
-                          game.playerCountDisplay,
-                        ),
-                        const Divider(),
-                        _buildInfoRow(
-                          Icons.speed,
-                          'Difficulty',
-                          game.difficulty.displayName,
-                        ),
-                        const Divider(),
-                        _buildInfoRow(
-                          Icons.category,
-                          'Category',
-                          game.category.displayName,
-                        ),
-                      ],
                     ),
-                  ),
-                ),
-                const SizedBox(height: 24),
+                    const SizedBox(height: 24),
 
-                // View rules button
-                ElevatedButton.icon(
-                  onPressed: () {
-                    UnifiedGameRulesDialog.show(context, game);
-                  },
-                  icon: const Icon(Icons.menu_book),
-                  label: const Text('View Rules & How to Play'),
-                  style: ElevatedButton.styleFrom(
-                    padding: const EdgeInsets.symmetric(
-                      horizontal: 24,
-                      vertical: 16,
+                    // View rules button
+                    ElevatedButton.icon(
+                      onPressed: () {
+                        UnifiedGameRulesDialog.show(context, game);
+                      },
+                      icon: const Icon(Icons.menu_book),
+                      label: const Text('View Rules & How to Play'),
+                      style: ElevatedButton.styleFrom(
+                        padding: const EdgeInsets.symmetric(
+                          horizontal: 24,
+                          vertical: 16,
+                        ),
+                        backgroundColor: game.difficulty.color,
+                        foregroundColor: Colors.white,
+                      ),
                     ),
-                    backgroundColor: game.difficulty.color,
-                    foregroundColor: Colors.white,
-                  ),
-                ),
-                const SizedBox(height: 16),
+                    const SizedBox(height: 16),
 
-                // Status message
-                Text(
-                  'This game is currently under development.\nCheck back soon for the full experience!',
-                  style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                    color: Colors.grey[500],
-                    fontStyle: FontStyle.italic,
-                  ),
-                  textAlign: TextAlign.center,
+                    // Status message
+                    Text(
+                      'This game is currently under development.\nCheck back soon for the full experience!',
+                      style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                        color: Colors.grey[500],
+                        fontStyle: FontStyle.italic,
+                      ),
+                      textAlign: TextAlign.center,
+                    ),
+                  ],
                 ),
-              ],
+              ),
             ),
           ),
         ),

--- a/app/lib/features/games/presentation/screens/games_hub_screen.dart
+++ b/app/lib/features/games/presentation/screens/games_hub_screen.dart
@@ -15,7 +15,21 @@ class GamesHubScreen extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final gamesByCategory = GameRegistry.byCategory;
+    final sections = [
+      ...GameRegistry.availableByCategory.entries.map(
+        (entry) => _GameSection(
+          title: entry.key.displayName,
+          icon: entry.key.icon,
+          games: entry.value,
+        ),
+      ),
+      if (GameRegistry.comingSoon.isNotEmpty)
+        _GameSection(
+          title: 'Coming Soon',
+          icon: Icons.construction,
+          games: GameRegistry.comingSoon,
+        ),
+    ];
 
     // No AppBar here - global AppBar is in AppShell
     return Scaffold(
@@ -43,24 +57,21 @@ class GamesHubScreen extends ConsumerWidget {
               const SizedBox(height: 24),
 
               // Game categories in grid
-              ...gamesByCategory.entries.map((entry) {
-                final category = entry.key;
-                final games = entry.value;
-
+              ...sections.map((section) {
                 return Column(
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
                     // Category header
                     Row(
                       children: [
-                        Icon(category.icon, size: 20),
+                        Icon(section.icon, size: 20),
                         const SizedBox(width: 8),
                         Text(
-                          category.displayName,
+                          section.title,
                           style: Theme.of(context).textTheme.titleLarge,
                         ),
                         const Spacer(),
-                        if (games.length > 4)
+                        if (section.games.length > 4)
                           TextButton(
                             onPressed: () {
                               // TODO: View all in category
@@ -90,9 +101,13 @@ class GamesHubScreen extends ConsumerWidget {
                                 mainAxisSpacing: 12,
                                 childAspectRatio: columns <= 2 ? 0.92 : 1.12,
                               ),
-                          itemCount: games.length,
+                          itemCount: section.games.length,
                           itemBuilder: (context, index) {
-                            return _buildGameTile(context, ref, games[index]);
+                            return _buildGameTile(
+                              context,
+                              ref,
+                              section.games[index],
+                            );
                           },
                         );
                       },
@@ -142,7 +157,7 @@ class GamesHubScreen extends ConsumerWidget {
       child: Material(
         color: Colors.transparent,
         child: InkWell(
-          onTap: game.isAvailable ? () => _playGame(context, ref, game) : null,
+          onTap: () => _playGame(context, ref, game),
           child: Container(
             padding: const EdgeInsets.all(12),
             decoration: BoxDecoration(
@@ -296,6 +311,15 @@ class GamesHubScreen extends ConsumerWidget {
   }
 
   void _playGame(BuildContext context, WidgetRef ref, GameInfo game) {
+    if (!game.isAvailable) {
+      Navigator.of(context).push(
+        MaterialPageRoute(
+          builder: (context) => GameComingSoonScreen(game: game),
+        ),
+      );
+      return;
+    }
+
     switch (game.id) {
       case 'blackjack':
         _playBlackjack(context, ref);
@@ -346,4 +370,16 @@ class GamesHubScreen extends ConsumerWidget {
       ),
     );
   }
+}
+
+class _GameSection {
+  const _GameSection({
+    required this.title,
+    required this.icon,
+    required this.games,
+  });
+
+  final String title;
+  final IconData icon;
+  final List<GameInfo> games;
 }

--- a/app/test/features/games/presentation/screens/games_hub_screen_test.dart
+++ b/app/test/features/games/presentation/screens/games_hub_screen_test.dart
@@ -1,0 +1,46 @@
+import 'package:airo_app/features/games/presentation/screens/game_coming_soon_screen.dart';
+import 'package:airo_app/features/games/presentation/screens/games_hub_screen.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  Widget buildScreen() {
+    return const ProviderScope(child: MaterialApp(home: GamesHubScreen()));
+  }
+
+  group('GamesHubScreen', () {
+    testWidgets('shows the Arena sections requested by issue 193', (
+      tester,
+    ) async {
+      await tester.pumpWidget(buildScreen());
+      await tester.pumpAndSettle();
+
+      expect(find.text('Arena'), findsOneWidget);
+      expect(find.text('Choose your game and start playing'), findsOneWidget);
+      expect(find.text('Card Games'), findsOneWidget);
+      expect(find.text('Strategy'), findsOneWidget);
+      expect(find.text('Coming Soon'), findsOneWidget);
+    });
+
+    testWidgets(
+      'opens the coming soon screen when an unavailable card is tapped',
+      (tester) async {
+        await tester.pumpWidget(buildScreen());
+        await tester.pumpAndSettle();
+
+        await tester.scrollUntilVisible(
+          find.text('Checkers').first,
+          300,
+          scrollable: find.byType(Scrollable).first,
+        );
+        await tester.tap(find.text('Checkers').first);
+        await tester.pumpAndSettle();
+
+        expect(find.byType(GameComingSoonScreen), findsOneWidget);
+        expect(find.text('Full Gameplay Coming Soon'), findsOneWidget);
+        expect(find.text('Checkers'), findsWidgets);
+      },
+    );
+  });
+}


### PR DESCRIPTION
# Summary
This PR completes the remaining Arena work from issue #193.

- adds a dedicated `Coming Soon` section in Arena
- exposes unavailable game cards as fully tappable placeholders
- fixes the coming-soon screen overflow on smaller viewports
- adds a focused widget test for Arena sections and unavailable-card navigation

# Testing
- flutter analyze lib/features/games/domain/models/game_info.dart lib/features/games/presentation/screens/games_hub_screen.dart lib/features/games/presentation/screens/game_coming_soon_screen.dart test/features/games/presentation/screens/games_hub_screen_test.dart
- flutter test test/features/games/presentation/screens/games_hub_screen_test.dart

Closes #193