### PR TITLE
Improve Beats music discovery hub

### DIFF
--- a/app/lib/features/music/presentation/screens/music_screen.dart
+++ b/app/lib/features/music/presentation/screens/music_screen.dart
@@ -3,6 +3,8 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../application/providers/music_provider.dart';
 import '../../application/providers/music_tracks_provider.dart';
 import '../../domain/services/music_service.dart';
+import '../widgets/beats_search_bar.dart';
+import '../widgets/beats_search_results.dart';
 import '../../../../shared/widgets/responsive_center.dart';
 
 /// Music player screen with Spotify Top 20 India
@@ -21,10 +23,17 @@ class MusicScreen extends ConsumerWidget {
         centerTitle: true,
         actions: [
           IconButton(
-            icon: const Icon(Icons.refresh),
-            onPressed: () {
-              // ignore: unused_result
-              ref.refresh(musicTracksProvider);
+            icon: const Icon(Icons.search),
+            tooltip: 'Search music',
+            onPressed: () => _showSearchSheet(context),
+          ),
+          IconButton(
+            icon: const Icon(Icons.queue_music),
+            tooltip: 'Open queue',
+            onPressed: () async {
+              final state = await ref.read(musicPlayerStateProvider.future);
+              if (!context.mounted) return;
+              _showQueueSheet(context, state);
             },
           ),
         ],
@@ -103,13 +112,17 @@ class MusicScreen extends ConsumerWidget {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            // Now playing card
             Card(
               child: Padding(
                 padding: const EdgeInsets.all(16),
                 child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
-                    // Album art with aspect ratio
+                    Text(
+                      'Now Playing',
+                      style: Theme.of(context).textTheme.titleLarge,
+                    ),
+                    const SizedBox(height: 16),
                     AspectRatio(
                       aspectRatio: 1.0,
                       child: Container(
@@ -133,7 +146,6 @@ class MusicScreen extends ConsumerWidget {
                       ),
                     ),
                     const SizedBox(height: 16),
-                    // Track info
                     Text(
                       state.currentTrack?.title ?? 'No track playing',
                       style: const TextStyle(
@@ -149,7 +161,24 @@ class MusicScreen extends ConsumerWidget {
                       textAlign: TextAlign.center,
                     ),
                     const SizedBox(height: 16),
-                    // Progress bar
+                    Wrap(
+                      spacing: 8,
+                      runSpacing: 8,
+                      alignment: WrapAlignment.center,
+                      children: [
+                        _InfoChip(
+                          icon: Icons.high_quality,
+                          label: 'Streaming Quality',
+                          value: _qualityLabel(state.currentTrack),
+                        ),
+                        _InfoChip(
+                          icon: Icons.queue_music,
+                          label: 'Queue',
+                          value: '${state.queue.length} tracks',
+                        ),
+                      ],
+                    ),
+                    const SizedBox(height: 16),
                     if (state.currentTrack != null)
                       Column(
                         children: [
@@ -176,7 +205,6 @@ class MusicScreen extends ConsumerWidget {
                         ],
                       ),
                     const SizedBox(height: 16),
-                    // Player controls
                     Row(
                       mainAxisAlignment: MainAxisAlignment.center,
                       children: [
@@ -216,7 +244,41 @@ class MusicScreen extends ConsumerWidget {
               ),
             ),
             const SizedBox(height: 24),
-            // Playlist section
+            Text('Playlists', style: Theme.of(context).textTheme.titleLarge),
+            const SizedBox(height: 12),
+            _PlaylistSection(
+              tracks: tracks,
+              onPlaylistSelected: (playlistTracks) {
+                if (playlistTracks.isNotEmpty) {
+                  musicController.playQueue(playlistTracks);
+                }
+              },
+            ),
+            const SizedBox(height: 24),
+            Text('Artists', style: Theme.of(context).textTheme.titleLarge),
+            const SizedBox(height: 12),
+            _ArtistSection(
+              tracks: tracks,
+              onArtistSelected: (artist) {
+                final artistTracks = tracks
+                    .where((track) => track.artist == artist)
+                    .toList();
+                if (artistTracks.isNotEmpty) {
+                  musicController.playQueue(artistTracks);
+                }
+              },
+            ),
+            const SizedBox(height: 24),
+            Text(
+              'Recently Played',
+              style: Theme.of(context).textTheme.titleLarge,
+            ),
+            const SizedBox(height: 12),
+            _RecentlyPlayedSection(
+              tracks: _recentTracks(state, tracks),
+              onTrackSelected: musicController.playTrack,
+            ),
+            const SizedBox(height: 24),
             Text('Top 20 India', style: Theme.of(context).textTheme.titleLarge),
             const SizedBox(height: 12),
             ListView.separated(
@@ -264,6 +326,286 @@ class MusicScreen extends ConsumerWidget {
           ],
         ),
       ),
+    );
+  }
+
+  String _formatDuration(Duration duration) {
+    final minutes = duration.inMinutes;
+    final seconds = duration.inSeconds % 60;
+    return '$minutes:${seconds.toString().padLeft(2, '0')}';
+  }
+
+  String _qualityLabel(MusicTrack? track) {
+    if (track?.streamUrl?.contains('.m3u8') ?? false) {
+      return 'Adaptive HQ';
+    }
+    return 'High';
+  }
+
+  List<MusicTrack> _recentTracks(
+    MusicPlayerState state,
+    List<MusicTrack> tracks,
+  ) {
+    if (state.queue.isNotEmpty) {
+      return state.queue.reversed.take(4).toList();
+    }
+    return tracks.take(4).toList();
+  }
+
+  Future<void> _showSearchSheet(BuildContext context) {
+    return showModalBottomSheet<void>(
+      context: context,
+      isScrollControlled: true,
+      showDragHandle: true,
+      builder: (context) {
+        return SafeArea(
+          child: SizedBox(
+            height: MediaQuery.of(context).size.height * 0.82,
+            child: const SingleChildScrollView(
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [BeatsSearchBar(), BeatsSearchResults()],
+              ),
+            ),
+          ),
+        );
+      },
+    );
+  }
+
+  Future<void> _showQueueSheet(BuildContext context, MusicPlayerState state) {
+    return showModalBottomSheet<void>(
+      context: context,
+      showDragHandle: true,
+      builder: (context) {
+        return SafeArea(
+          child: state.queue.isEmpty
+              ? const Padding(
+                  padding: EdgeInsets.all(24),
+                  child: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Icon(Icons.queue_music, size: 48, color: Colors.grey),
+                      SizedBox(height: 12),
+                      Text('Queue'),
+                      SizedBox(height: 8),
+                      Text(
+                        'Your queue will appear here once tracks are added.',
+                        textAlign: TextAlign.center,
+                      ),
+                    ],
+                  ),
+                )
+              : Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    const Padding(
+                      padding: EdgeInsets.fromLTRB(24, 8, 24, 12),
+                      child: Text('Queue', style: TextStyle(fontSize: 18)),
+                    ),
+                    Flexible(
+                      child: ListView.separated(
+                        shrinkWrap: true,
+                        itemCount: state.queue.length,
+                        separatorBuilder: (_, _) => const Divider(height: 0),
+                        itemBuilder: (context, index) {
+                          final track = state.queue[index];
+                          return ListTile(
+                            leading: CircleAvatar(child: Text('${index + 1}')),
+                            title: Text(track.title),
+                            subtitle: Text(track.artist),
+                            trailing: index == state.currentIndex
+                                ? const Icon(Icons.equalizer)
+                                : null,
+                          );
+                        },
+                      ),
+                    ),
+                  ],
+                ),
+        );
+      },
+    );
+  }
+}
+
+class _InfoChip extends StatelessWidget {
+  const _InfoChip({
+    required this.icon,
+    required this.label,
+    required this.value,
+  });
+
+  final IconData icon;
+  final String label;
+  final String value;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+      decoration: BoxDecoration(
+        color: Theme.of(context).colorScheme.surfaceContainerHighest,
+        borderRadius: BorderRadius.circular(999),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(icon, size: 16),
+          const SizedBox(width: 8),
+          Text('$label: $value'),
+        ],
+      ),
+    );
+  }
+}
+
+class _PlaylistSection extends StatelessWidget {
+  const _PlaylistSection({
+    required this.tracks,
+    required this.onPlaylistSelected,
+  });
+
+  final List<MusicTrack> tracks;
+  final ValueChanged<List<MusicTrack>> onPlaylistSelected;
+
+  @override
+  Widget build(BuildContext context) {
+    final playlists =
+        <({String title, String subtitle, List<MusicTrack> tracks})>[
+          (
+            title: 'Morning Boost',
+            subtitle: 'Start fast with chart openers',
+            tracks: tracks.take(5).toList(),
+          ),
+          (
+            title: 'Focus Flow',
+            subtitle: 'Steady picks for deep work',
+            tracks: tracks.skip(5).take(5).toList(),
+          ),
+          (
+            title: 'Replay Mix',
+            subtitle: 'Quick favorites on repeat',
+            tracks: tracks.reversed.take(5).toList(),
+          ),
+        ].where((playlist) => playlist.tracks.isNotEmpty).toList();
+
+    return SizedBox(
+      height: 176,
+      child: ListView.separated(
+        scrollDirection: Axis.horizontal,
+        itemCount: playlists.length,
+        separatorBuilder: (_, _) => const SizedBox(width: 12),
+        itemBuilder: (context, index) {
+          final playlist = playlists[index];
+          return SizedBox(
+            width: 220,
+            child: Card(
+              child: InkWell(
+                borderRadius: BorderRadius.circular(12),
+                onTap: () => onPlaylistSelected(playlist.tracks),
+                child: Padding(
+                  padding: const EdgeInsets.all(16),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Row(
+                        children: [
+                          Icon(
+                            Icons.library_music,
+                            color: Theme.of(context).colorScheme.primary,
+                          ),
+                          const SizedBox(width: 8),
+                          Expanded(
+                            child: Text(
+                              playlist.title,
+                              style: Theme.of(context).textTheme.titleMedium,
+                              maxLines: 1,
+                              overflow: TextOverflow.ellipsis,
+                            ),
+                          ),
+                        ],
+                      ),
+                      const SizedBox(height: 12),
+                      Text(
+                        playlist.subtitle,
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                      const SizedBox(height: 12),
+                      Text(
+                        '${playlist.tracks.length} tracks ready',
+                        style: Theme.of(context).textTheme.bodySmall,
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            ),
+          );
+        },
+      ),
+    );
+  }
+}
+
+class _ArtistSection extends StatelessWidget {
+  const _ArtistSection({required this.tracks, required this.onArtistSelected});
+
+  final List<MusicTrack> tracks;
+  final ValueChanged<String> onArtistSelected;
+
+  @override
+  Widget build(BuildContext context) {
+    final artists = tracks
+        .map((track) => track.artist)
+        .toSet()
+        .take(8)
+        .toList();
+
+    return Wrap(
+      spacing: 8,
+      runSpacing: 8,
+      children: [
+        for (final artist in artists)
+          ActionChip(
+            avatar: const Icon(Icons.person, size: 18),
+            label: Text(artist),
+            onPressed: () => onArtistSelected(artist),
+          ),
+      ],
+    );
+  }
+}
+
+class _RecentlyPlayedSection extends StatelessWidget {
+  const _RecentlyPlayedSection({
+    required this.tracks,
+    required this.onTrackSelected,
+  });
+
+  final List<MusicTrack> tracks;
+  final ValueChanged<MusicTrack> onTrackSelected;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        for (final track in tracks)
+          ListTile(
+            contentPadding: EdgeInsets.zero,
+            leading: CircleAvatar(
+              backgroundColor: Theme.of(context).colorScheme.surfaceContainer,
+              child: const Icon(Icons.history),
+            ),
+            title: Text(track.title),
+            subtitle: Text(
+              '${track.artist} • ${_formatDuration(track.duration)}',
+            ),
+            trailing: const Icon(Icons.play_arrow),
+            onTap: () => onTrackSelected(track),
+          ),
+      ],
     );
   }
 

--- a/app/test/features/music/presentation/screens/music_screen_test.dart
+++ b/app/test/features/music/presentation/screens/music_screen_test.dart
@@ -1,0 +1,130 @@
+import 'package:airo_app/features/music/application/providers/music_provider.dart';
+import 'package:airo_app/features/music/application/providers/music_tracks_provider.dart';
+import 'package:airo_app/features/music/domain/services/music_service.dart';
+import 'package:airo_app/features/music/presentation/screens/music_screen.dart';
+import 'package:airo_app/features/music/presentation/widgets/beats_search_bar.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+class _TestMusicService implements MusicService {
+  _TestMusicService(this._state);
+
+  final MusicPlayerState _state;
+
+  @override
+  Future<void> dispose() async {}
+
+  @override
+  Stream<MusicPlayerState> getStateStream() async* {
+    yield _state;
+  }
+
+  @override
+  Future<void> initialize() async {}
+
+  @override
+  Future<void> next() async {}
+
+  @override
+  Future<void> pause() async {}
+
+  @override
+  Future<void> playQueue(List<MusicTrack> tracks, {int startIndex = 0}) async {}
+
+  @override
+  Future<void> playTrack(MusicTrack track) async {}
+
+  @override
+  Future<void> previous() async {}
+
+  @override
+  Future<void> resume() async {}
+
+  @override
+  Future<void> seek(Duration position) async {}
+
+  @override
+  Future<void> setVolume(double volume) async {}
+
+  @override
+  Future<void> stop() async {}
+}
+
+void main() {
+  const tracks = [
+    MusicTrack(
+      id: '1',
+      title: 'Calm Start',
+      artist: 'Asha',
+      duration: Duration(minutes: 3, seconds: 12),
+      streamUrl: 'https://example.com/stream1.m3u8',
+    ),
+    MusicTrack(
+      id: '2',
+      title: 'Focus Lane',
+      artist: 'Ravi',
+      duration: Duration(minutes: 2, seconds: 58),
+      streamUrl: 'https://example.com/stream2.mp3',
+    ),
+    MusicTrack(
+      id: '3',
+      title: 'Night Echo',
+      artist: 'Asha',
+      duration: Duration(minutes: 4, seconds: 4),
+      streamUrl: 'https://example.com/stream3.m3u8',
+    ),
+  ];
+
+  Widget createWidget() {
+    final playerState = MusicPlayerState(
+      currentTrack: tracks[0],
+      isPlaying: true,
+      position: const Duration(minutes: 1),
+      duration: const Duration(minutes: 3, seconds: 12),
+      queue: tracks,
+      currentIndex: 0,
+    );
+
+    return ProviderScope(
+      overrides: [
+        musicTracksProvider.overrideWith((ref) async => tracks),
+        musicServiceProvider.overrideWithValue(_TestMusicService(playerState)),
+      ],
+      child: const MaterialApp(home: MusicScreen()),
+    );
+  }
+
+  testWidgets('renders new beats browse sections and actions', (tester) async {
+    await tester.pumpWidget(createWidget());
+    await tester.pumpAndSettle();
+
+    expect(find.text('Beats'), findsOneWidget);
+    expect(find.byIcon(Icons.search), findsOneWidget);
+    expect(find.byIcon(Icons.queue_music), findsWidgets);
+    expect(find.text('Now Playing'), findsOneWidget);
+    expect(find.text('Playlists'), findsOneWidget);
+    expect(find.text('Artists'), findsOneWidget);
+    expect(find.text('Recently Played'), findsOneWidget);
+    expect(find.text('Streaming Quality: Adaptive HQ'), findsOneWidget);
+  });
+
+  testWidgets('opens search and queue sheets', (tester) async {
+    await tester.pumpWidget(createWidget());
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byTooltip('Search music'));
+    await tester.pumpAndSettle();
+    expect(find.text('Search or paste YouTube URL...'), findsOneWidget);
+
+    Navigator.of(tester.element(find.byType(BeatsSearchBar))).pop();
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byTooltip('Open queue'));
+    await tester.pumpAndSettle();
+    expect(find.text('Queue'), findsOneWidget);
+    expect(find.text('Calm Start'), findsWidgets);
+    expect(find.text('Focus Lane'), findsWidgets);
+    expect(find.text('Night Echo'), findsWidgets);
+  });
+}


### PR DESCRIPTION
# Summary

This PR introduces changes to the Beats music screen.
Goal: align the tab with the discovery-focused UI requested in issue #190.

Core outcome:

* adds search and queue entry points in the Beats app bar
* expands the tab with playlists, artists, recently played, and now-playing metadata
* adds a widget test covering the new browse sections and bottom sheets

# Changes

### Code

* Added:
  * a screen-level widget test for `MusicScreen`
* Updated:
  * `app/lib/features/music/presentation/screens/music_screen.dart` to add discovery sections and bottom sheets

### Logic

* reuses existing Beats search widgets inside a modal sheet
* derives playlist, artist, and recent sections from existing track and queue data
* exposes current queue content in a bottom sheet without changing storage or playback contracts

# API Changes (if any)

* None.

# Database Changes (if any)

* None.

# Observability / Logging

* None.

# Performance Impact

* Latency: neutral
* Throughput: neutral
* Memory/CPU: negligible extra widget work on the Beats screen

# Risks

* derived playlist labels are presentational and based on current sample track ordering
* search and queue live in modal sheets, so future navigation redesigns may want a dedicated route
* Rollback plan:
  * revert this PR

# Testing

* Unit tests:
  * none
* Integration tests:
  * none
* Manual testing:
  * `flutter analyze lib/features/music/presentation/screens/music_screen.dart test/features/music/presentation/screens/music_screen_test.dart`
  * `flutter test test/features/music/presentation/screens/music_screen_test.dart`

# Deployment Notes

* Config changes:
  * none
* Order of deployment:
  * normal app release flow

# Related Commits

* feat(beats): expand music discovery hub

# Notes

* Closes #190.
