### PR TITLE
fix(ci): cap Android Gradle memory for hosted runners

### DIFF
--- a/app/android/gradle.properties
+++ b/app/android/gradle.properties
@@ -1,4 +1,5 @@
-org.gradle.jvmargs=-Xmx8G -XX:MaxMetaspaceSize=4G -XX:ReservedCodeCacheSize=512m -XX:+HeapDumpOnOutOfMemoryError
+org.gradle.jvmargs=-Xmx4G -XX:MaxMetaspaceSize=2G -XX:ReservedCodeCacheSize=512m -XX:+HeapDumpOnOutOfMemoryError
+org.gradle.workers.max=2
 android.useAndroidX=true
 android.enableJetifier=true
 # Flutter and several plugin modules still require AGP 9 compatibility opt-outs.


### PR DESCRIPTION
## Summary

Closes #381.

- Reduces Android Gradle heap from 8GB to 4GB.
- Reduces Gradle metaspace from 4GB to 2GB.
- Caps Gradle workers at 2 to avoid memory pressure on GitHub-hosted runners during the `mobile-full` release build.

## Root cause

The merged PR #362 left one failed CI job: the `mobile-full` Android release build. GitHub did not expose the failed job log through `gh`, but the job died during the release APK build step while the `tv` and `mobile-streaming` variants passed. Local reproduction of the exact workflow command succeeded but showed the full variant is resource-heavy: it took about 9 minutes and produced a 461.4MB APK. The current Gradle config advertised an 8GB heap, which is risky on hosted CI runners and consistent with a resource-pressure failure.

## Validation

- Reproduced the CI setup locally with placeholder Firebase config, CI signing config, package gets, Gradle plugin patching, and build_runner generation.
- Ran exact mobile-full command successfully before the fix: `flutter build apk --release --target=lib/main.dart --target-platform=android-arm64 --dart-define=APP_VARIANT=full --dart-define=APP_PLATFORM=mobileFull --tree-shake-icons --split-debug-info=build/debug-info-mobile-full --obfuscate`
- Ran the same mobile-full release build successfully after this fix with the lower Gradle heap/worker cap.

## Risk

Low. This changes build resource limits only. The full release APK still builds locally with the new settings.