### PR TITLE
Require fresh main when creating worktrees

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,23 @@ For every feature, bug fix, or architecture change:
 3. Define the cross-agent contract if more than one module is touched.
 4. Add deterministic use cases and automation flows to the GitHub issue.
 5. Confirm whether the work belongs in framework code, application code, or both.
-6. Only then start implementation.
+6. Sync the task branch or worktree from the latest `origin/main` before writing code.
+7. Only then start implementation.
+
+## Worktree Sync Rule
+
+When an LLM, agent, or human starts a new task, creates a branch, or creates a
+worktree, the starting point must be the latest `origin/main`, not a stale
+local branch or an older worktree snapshot.
+
+Minimum requirement:
+
+1. `git fetch origin main`
+2. create the branch or worktree from `origin/main`
+3. verify the task branch/worktree is based on the fetched `origin/main`
+
+If this sync step is skipped, implementation must stop until the worktree is
+rebased, recreated, or reset onto the current `origin/main`.
 
 Framework agents own reusable contracts, runtime boundaries, storage schemas,
 security rules, and platform abstractions. Application agents own product

--- a/docs/agents/AGENT_POLICY.md
+++ b/docs/agents/AGENT_POLICY.md
@@ -177,6 +177,18 @@ The issue must state:
 - known constraints
 - links to parent roadmap issues
 
+Before any branch, worktree, or implementation starts, the task owner must
+sync against the latest `origin/main`. No agent may start from an older local
+branch tip, a stale worktree, or an unverified checkout.
+
+Required bootstrap sequence:
+- `git fetch origin main`
+- create the task branch or worktree from `origin/main`
+- verify the task branch/worktree base matches the fetched `origin/main`
+
+If new commits land on `main` before implementation starts, the agent must
+repeat this sync step and restack or recreate the worktree as needed.
+
 ### 2. Critical Agent Clarity Gate
 
 Before coding, add a comment or issue section:
@@ -190,6 +202,7 @@ Before coding, add a comment or issue section:
 **Owning agent:** ...
 **Reviewing agents:** ...
 **Impacted modules/files:** ...
+**Base branch/worktree:** <confirmed from latest origin/main: yes/no>
 **Open questions:** ...
 **Decision:** Ready / Blocked
 ```


### PR DESCRIPTION
# Summary

This PR updates the agent policy docs.
Goal: require every new task branch or worktree to start from the latest `origin/main` so agents do not implement against stale state.

Core outcome:

* adds an explicit worktree sync rule to the repo entry policy
* adds bootstrap steps to the detailed multi-agent policy
* extends the Critical Agent Gate to record whether the task base was confirmed from latest `origin/main`

# Changes

### Code

* Updated:
  * `AGENTS.md` with a required worktree sync step and a dedicated Worktree Sync Rule section
  * `docs/agents/AGENT_POLICY.md` with mandatory bootstrap steps and a new gate field for base verification

### Logic

* every new task must fetch `origin/main` first
* every new branch or worktree must be created from `origin/main`
* implementation must stop if the worktree base is stale or unverified

# API Changes (if any)

* None.

# Database Changes (if any)

* None.

# Observability / Logging

* None.

# Performance Impact

* Latency: none
* Throughput: none
* Memory/CPU: none

# Risks

* none beyond normal documentation drift if future workflow changes are not reflected here
* Rollback plan:
  * revert this PR

# Testing

* Unit tests:
  * none
* Integration tests:
  * none
* Manual testing:
  * reviewed policy diff in `AGENTS.md` and `docs/agents/AGENT_POLICY.md`

# Deployment Notes

* Config changes:
  * none
* Order of deployment:
  * normal merge to `main`

# Related Commits

* docs(agents): require fresh main for worktrees

# Notes

* This is a docs-only policy update.
