### PR TITLE
Improve Stream live TV tab

### DIFF
--- a/app/lib/features/iptv/presentation/screens/iptv_screen.dart
+++ b/app/lib/features/iptv/presentation/screens/iptv_screen.dart
@@ -5,6 +5,7 @@ import '../../application/providers/iptv_providers.dart';
 import '../../domain/models/iptv_channel.dart';
 import '../../domain/models/streaming_state.dart';
 import '../widgets/channel_list_widget.dart';
+import '../widgets/iptv_mini_player.dart';
 import '../widgets/video_player_widget.dart';
 
 /// IPTV Screen with YouTube-like streaming experience
@@ -56,10 +57,94 @@ class _IPTVScreenState extends ConsumerState<IPTVScreen> {
     ref.read(addToRecentlyWatchedProvider(channel));
   }
 
+  Future<void> _showSearchSheet() async {
+    final controller = TextEditingController(
+      text: ref.read(channelSearchQueryProvider),
+    );
+
+    await showModalBottomSheet<void>(
+      context: context,
+      isScrollControlled: true,
+      showDragHandle: true,
+      builder: (context) {
+        return SafeArea(
+          child: Padding(
+            padding: EdgeInsets.fromLTRB(
+              24,
+              12,
+              24,
+              24 + MediaQuery.of(context).viewInsets.bottom,
+            ),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  'Search channels',
+                  style: Theme.of(context).textTheme.titleLarge,
+                ),
+                const SizedBox(height: 8),
+                const Text('Find live channels by name or group.'),
+                const SizedBox(height: 16),
+                TextField(
+                  controller: controller,
+                  autofocus: true,
+                  decoration: InputDecoration(
+                    hintText: 'News, sports, music...',
+                    prefixIcon: const Icon(Icons.search),
+                    suffixIcon: controller.text.isNotEmpty
+                        ? IconButton(
+                            icon: const Icon(Icons.clear),
+                            onPressed: () {
+                              controller.clear();
+                              ref
+                                      .read(channelSearchQueryProvider.notifier)
+                                      .state =
+                                  '';
+                            },
+                          )
+                        : null,
+                  ),
+                  onChanged: (value) =>
+                      ref.read(channelSearchQueryProvider.notifier).state =
+                          value,
+                ),
+                const SizedBox(height: 16),
+                Row(
+                  children: [
+                    TextButton(
+                      onPressed: () {
+                        controller.clear();
+                        ref.read(channelSearchQueryProvider.notifier).state =
+                            '';
+                      },
+                      child: const Text('Clear'),
+                    ),
+                    const Spacer(),
+                    FilledButton(
+                      onPressed: () => Navigator.of(context).pop(),
+                      child: const Text('Done'),
+                    ),
+                  ],
+                ),
+              ],
+            ),
+          ),
+        );
+      },
+    );
+  }
+
+  void _showCastMessage() {
+    ScaffoldMessenger.of(context).showSnackBar(
+      const SnackBar(
+        content: Text('Cast controls are being prepared for the Stream tab.'),
+      ),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
-    final channelsAsync = ref.watch(iptvChannelsProvider);
-    final streamingState = ref.watch(streamingStateProvider);
     final isFullscreen = ref.watch(isFullscreenModeProvider);
 
     if (isFullscreen) {
@@ -74,227 +159,23 @@ class _IPTVScreenState extends ConsumerState<IPTVScreen> {
 
     return Scaffold(
       appBar: AppBar(
-        title: const Text('IPTV'),
+        title: const Text('Stream'),
         actions: [
           IconButton(
-            icon: const Icon(Icons.refresh),
-            onPressed: () => ref.refresh(iptvChannelsProvider),
-            tooltip: 'Refresh channels',
+            icon: const Icon(Icons.search),
+            tooltip: 'Search channels',
+            onPressed: _showSearchSheet,
+          ),
+          IconButton(
+            icon: const Icon(Icons.cast_connected),
+            tooltip: 'Cast',
+            onPressed: _showCastMessage,
           ),
         ],
       ),
-      body: channelsAsync.when(
-        data: (channels) => _buildContent(context, channels, streamingState),
-        loading: () => const Center(child: CircularProgressIndicator()),
-        error: (error, stack) => _buildError(error.toString()),
-      ),
-    );
-  }
-
-  Widget _buildContent(
-    BuildContext context,
-    List<IPTVChannel> channels,
-    AsyncValue<StreamingState> streamingState,
-  ) {
-    final screenWidth = MediaQuery.of(context).size.width;
-    final isWideScreen = screenWidth > 800;
-
-    if (isWideScreen) {
-      // Web/Desktop: Side-by-side layout
-      return Row(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          // Left: Video player and info - constrain width and align to top
-          Expanded(
-            flex: 3,
-            child: Align(
-              alignment: Alignment.topCenter,
-              child: Column(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  // Video player section with constrained height
-                  ConstrainedBox(
-                    constraints: const BoxConstraints(maxHeight: 400),
-                    child: AspectRatio(
-                      aspectRatio: 16 / 9,
-                      child: streamingState.when(
-                        data: (state) => state.currentChannel != null
-                            ? VideoPlayerWidget(
-                                showControls: true,
-                                onFullscreenToggle: _toggleFullscreen,
-                              )
-                            : _buildPlayerPlaceholder(),
-                        loading: () => _buildPlayerPlaceholder(),
-                        error: (_, _) => _buildPlayerPlaceholder(),
-                      ),
-                    ),
-                  ),
-                  // Quality selector and info bar
-                  _buildInfoBar(streamingState),
-                ],
-              ),
-            ),
-          ),
-          // Right: Channel list
-          Expanded(
-            flex: 2,
-            child: ChannelListWidget(
-              onChannelTap: _playChannel,
-              showCategories: true,
-            ),
-          ),
-        ],
-      );
-    }
-
-    // Mobile: Vertical layout
-    return Column(
-      children: [
-        // Video player section
-        AspectRatio(
-          aspectRatio: 16 / 9,
-          child: streamingState.when(
-            data: (state) => state.currentChannel != null
-                ? VideoPlayerWidget(
-                    showControls: true,
-                    onFullscreenToggle: _toggleFullscreen,
-                  )
-                : _buildPlayerPlaceholder(),
-            loading: () => _buildPlayerPlaceholder(),
-            error: (_, _) => _buildPlayerPlaceholder(),
-          ),
-        ),
-
-        // Quality selector and info bar
-        _buildInfoBar(streamingState),
-
-        // Channel list
-        Expanded(
-          child: ChannelListWidget(
-            onChannelTap: _playChannel,
-            showCategories: true,
-          ),
-        ),
-      ],
-    );
-  }
-
-  Widget _buildPlayerPlaceholder() {
-    final colorScheme = Theme.of(context).colorScheme;
-    return Container(
-      decoration: BoxDecoration(
-        color: colorScheme.surface.withValues(alpha: 0.42),
-        border: Border.all(color: colorScheme.outlineVariant),
-      ),
-      child: Center(
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            Icon(
-              Icons.live_tv,
-              size: 64,
-              color: colorScheme.primary.withValues(alpha: 0.7),
-            ),
-            const SizedBox(height: 16),
-            Text(
-              'Select a channel to start watching',
-              style: TextStyle(
-                color: colorScheme.primary.withValues(alpha: 0.7),
-              ),
-            ),
-          ],
-        ),
-      ),
-    );
-  }
-
-  Widget _buildInfoBar(AsyncValue<StreamingState> streamingState) {
-    return streamingState.when(
-      data: (state) {
-        if (state.currentChannel == null) return const SizedBox.shrink();
-        return Container(
-          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-          color: Theme.of(context).colorScheme.surface.withValues(alpha: 0.42),
-          child: Row(
-            children: [
-              Expanded(
-                child: Text(
-                  state.currentChannel!.name,
-                  style: const TextStyle(fontWeight: FontWeight.bold),
-                  overflow: TextOverflow.ellipsis,
-                ),
-              ),
-              _buildQualityDropdown(state),
-            ],
-          ),
-        );
-      },
-      loading: () => const SizedBox.shrink(),
-      error: (_, _) => const SizedBox.shrink(),
-    );
-  }
-
-  Widget _buildQualityDropdown(StreamingState state) {
-    return PopupMenuButton<VideoQuality>(
-      initialValue: state.selectedQuality,
-      onSelected: (quality) {
-        ref.read(iptvStreamingServiceProvider).setQuality(quality);
-      },
-      itemBuilder: (context) => VideoQuality.values
-          .map(
-            (q) => PopupMenuItem(
-              value: q,
-              child: Row(
-                children: [
-                  if (q == state.selectedQuality)
-                    const Icon(Icons.check, size: 16)
-                  else
-                    const SizedBox(width: 16),
-                  const SizedBox(width: 8),
-                  Text(q.label),
-                ],
-              ),
-            ),
-          )
-          .toList(),
-      child: Container(
-        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 4),
-        decoration: BoxDecoration(
-          border: Border.all(
-            color: Theme.of(context).colorScheme.outlineVariant,
-          ),
-          borderRadius: BorderRadius.circular(999),
-        ),
-        child: Row(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            Text(
-              state.currentQuality.label,
-              style: const TextStyle(fontSize: 12),
-            ),
-            const SizedBox(width: 4),
-            const Icon(Icons.arrow_drop_down, size: 16),
-          ],
-        ),
-      ),
-    );
-  }
-
-  Widget _buildError(String message) {
-    return Center(
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          const Icon(Icons.error, size: 64, color: Colors.red),
-          const SizedBox(height: 16),
-          Text(message, textAlign: TextAlign.center),
-          const SizedBox(height: 16),
-          ElevatedButton.icon(
-            onPressed: () => ref.refresh(iptvChannelsProvider),
-            icon: const Icon(Icons.refresh),
-            label: const Text('Retry'),
-          ),
-        ],
+      body: _StreamTabContent(
+        onChannelTap: _playChannel,
+        onFullscreenToggle: _toggleFullscreen,
       ),
     );
   }
@@ -349,8 +230,6 @@ class _IPTVScreenBodyState extends ConsumerState<IPTVScreenBody> {
 
   @override
   Widget build(BuildContext context) {
-    final channelsAsync = ref.watch(iptvChannelsProvider);
-    final streamingState = ref.watch(streamingStateProvider);
     final isFullscreen = ref.watch(isFullscreenModeProvider);
 
     // Use AnimatedSwitcher with fade to black for seamless fullscreen transition
@@ -372,160 +251,126 @@ class _IPTVScreenBodyState extends ConsumerState<IPTVScreenBody> {
             )
           : KeyedSubtree(
               key: const ValueKey('normal'),
-              child: channelsAsync.when(
-                data: (channels) =>
-                    _buildContent(context, channels, streamingState),
-                loading: () => const Center(child: CircularProgressIndicator()),
-                error: (error, stack) => _buildError(error.toString()),
+              child: _StreamTabContent(
+                onChannelTap: _playChannel,
+                onFullscreenToggle: _toggleFullscreen,
               ),
             ),
+    );
+  }
+}
+
+class _StreamTabContent extends ConsumerWidget {
+  const _StreamTabContent({
+    required this.onChannelTap,
+    required this.onFullscreenToggle,
+  });
+
+  final ValueChanged<IPTVChannel> onChannelTap;
+  final VoidCallback onFullscreenToggle;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final channelsAsync = ref.watch(iptvChannelsProvider);
+    final streamingState = ref.watch(streamingStateProvider);
+
+    return channelsAsync.when(
+      data: (channels) => _buildContent(context, ref, channels, streamingState),
+      loading: () => const Center(child: CircularProgressIndicator()),
+      error: (error, stack) => _buildError(context, ref, error.toString()),
     );
   }
 
   Widget _buildContent(
     BuildContext context,
+    WidgetRef ref,
     List<IPTVChannel> channels,
     AsyncValue<StreamingState> streamingState,
   ) {
     final screenWidth = MediaQuery.of(context).size.width;
     final isWideScreen = screenWidth > 800;
 
-    if (isWideScreen) {
-      // Web/Desktop: Side-by-side layout
-      return Row(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          // Left: Video player and info - constrain width and align to top
-          Expanded(
-            flex: 3,
-            child: Align(
-              alignment: Alignment.topCenter,
-              child: Column(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  // Video player section with constrained height
-                  ConstrainedBox(
-                    constraints: const BoxConstraints(maxHeight: 400),
-                    child: AspectRatio(
-                      aspectRatio: 16 / 9,
-                      child: streamingState.when(
-                        data: (state) => state.currentChannel != null
-                            ? VideoPlayerWidget(
-                                showControls: true,
-                                onFullscreenToggle: _toggleFullscreen,
-                              )
-                            : _buildPlayerPlaceholder(),
-                        loading: () => _buildPlayerPlaceholder(),
-                        error: (_, _) => _buildPlayerPlaceholder(),
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const SizedBox(height: 12),
+        const _PrimaryCategoryBar(),
+        const SizedBox(height: 12),
+        Expanded(
+          child: isWideScreen
+              ? Row(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Expanded(
+                      flex: 3,
+                      child: Padding(
+                        padding: const EdgeInsets.only(left: 16, right: 8),
+                        child: _FeaturedPlayerPanel(
+                          streamingState: streamingState,
+                          onFullscreenToggle: onFullscreenToggle,
+                          buildQualityDropdown: (state) =>
+                              _buildQualityDropdown(context, ref, state),
+                        ),
                       ),
                     ),
-                  ),
-                  // Quality selector and info bar
-                  _buildInfoBar(streamingState),
-                ],
-              ),
-            ),
-          ),
-          // Right: Channel list
-          Expanded(
-            flex: 2,
-            child: ChannelListWidget(
-              onChannelTap: _playChannel,
-              showCategories: true,
-            ),
-          ),
-        ],
-      );
-    }
-
-    // Mobile: Vertical layout - always show channel list
-    return Column(
-      children: [
-        // Video player section
-        AspectRatio(
-          aspectRatio: 16 / 9,
-          child: streamingState.when(
-            data: (state) => state.currentChannel != null
-                ? VideoPlayerWidget(
-                    showControls: true,
-                    onFullscreenToggle: _toggleFullscreen,
-                  )
-                : _buildPlayerPlaceholder(),
-            loading: () => _buildPlayerPlaceholder(),
-            error: (_, _) => _buildPlayerPlaceholder(),
-          ),
-        ),
-
-        // Quality selector and info bar
-        _buildInfoBar(streamingState),
-
-        // Channel list - always visible
-        Expanded(
-          child: ChannelListWidget(
-            onChannelTap: _playChannel,
-            showCategories: true,
-          ),
+                    Expanded(
+                      flex: 2,
+                      child: Padding(
+                        padding: const EdgeInsets.only(left: 8, right: 16),
+                        child: _ChannelPanel(
+                          channels: channels,
+                          onChannelTap: onChannelTap,
+                        ),
+                      ),
+                    ),
+                  ],
+                )
+              : Column(
+                  children: [
+                    Expanded(
+                      child: CustomScrollView(
+                        slivers: [
+                          SliverToBoxAdapter(
+                            child: Padding(
+                              padding: const EdgeInsets.symmetric(
+                                horizontal: 16,
+                              ),
+                              child: _FeaturedPlayerPanel(
+                                streamingState: streamingState,
+                                onFullscreenToggle: onFullscreenToggle,
+                                buildQualityDropdown: (state) =>
+                                    _buildQualityDropdown(context, ref, state),
+                              ),
+                            ),
+                          ),
+                          const SliverToBoxAdapter(child: SizedBox(height: 12)),
+                          SliverFillRemaining(
+                            hasScrollBody: true,
+                            child: Padding(
+                              padding: const EdgeInsets.symmetric(
+                                horizontal: 16,
+                              ),
+                              child: _ChannelPanel(
+                                channels: channels,
+                                onChannelTap: onChannelTap,
+                              ),
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                  ],
+                ),
         ),
       ],
     );
   }
 
-  Widget _buildPlayerPlaceholder() {
-    final colorScheme = Theme.of(context).colorScheme;
-    return Container(
-      decoration: BoxDecoration(
-        color: colorScheme.surface.withValues(alpha: 0.42),
-        border: Border.all(color: colorScheme.outlineVariant),
-      ),
-      child: Center(
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            Icon(
-              Icons.live_tv,
-              size: 64,
-              color: colorScheme.primary.withValues(alpha: 0.7),
-            ),
-            const SizedBox(height: 16),
-            Text(
-              'Select a channel to start watching',
-              style: TextStyle(
-                color: colorScheme.primary.withValues(alpha: 0.7),
-              ),
-            ),
-          ],
-        ),
-      ),
-    );
-  }
-
-  Widget _buildInfoBar(AsyncValue<StreamingState> streamingState) {
-    return streamingState.when(
-      data: (state) {
-        if (state.currentChannel == null) return const SizedBox.shrink();
-        return Container(
-          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-          color: Colors.grey[100],
-          child: Row(
-            children: [
-              Expanded(
-                child: Text(
-                  state.currentChannel!.name,
-                  style: const TextStyle(fontWeight: FontWeight.bold),
-                  overflow: TextOverflow.ellipsis,
-                ),
-              ),
-              _buildQualityDropdown(state),
-            ],
-          ),
-        );
-      },
-      loading: () => const SizedBox.shrink(),
-      error: (_, _) => const SizedBox.shrink(),
-    );
-  }
-
-  Widget _buildQualityDropdown(StreamingState state) {
+  Widget _buildQualityDropdown(
+    BuildContext context,
+    WidgetRef ref,
+    StreamingState state,
+  ) {
     return PopupMenuButton<VideoQuality>(
       initialValue: state.selectedQuality,
       onSelected: (quality) {
@@ -569,7 +414,7 @@ class _IPTVScreenBodyState extends ConsumerState<IPTVScreenBody> {
     );
   }
 
-  Widget _buildError(String message) {
+  Widget _buildError(BuildContext context, WidgetRef ref, String message) {
     return Center(
       child: Column(
         mainAxisSize: MainAxisSize.min,
@@ -584,6 +429,215 @@ class _IPTVScreenBodyState extends ConsumerState<IPTVScreenBody> {
             label: const Text('Retry'),
           ),
         ],
+      ),
+    );
+  }
+}
+
+class _PrimaryCategoryBar extends ConsumerWidget {
+  const _PrimaryCategoryBar();
+
+  static const _categories = [
+    ChannelCategory.all,
+    ChannelCategory.news,
+    ChannelCategory.sports,
+    ChannelCategory.entertainment,
+    ChannelCategory.music,
+  ];
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final selectedCategory = ref.watch(selectedCategoryProvider);
+    final counts = ref.watch(categoryCounts);
+
+    return SizedBox(
+      height: 42,
+      child: ListView.separated(
+        scrollDirection: Axis.horizontal,
+        padding: const EdgeInsets.symmetric(horizontal: 16),
+        itemCount: _categories.length,
+        separatorBuilder: (_, _) => const SizedBox(width: 8),
+        itemBuilder: (context, index) {
+          final category = _categories[index];
+          return ChoiceChip(
+            label: Text('${category.label} (${counts[category] ?? 0})'),
+            selected: selectedCategory == category,
+            onSelected: (_) =>
+                ref.read(selectedCategoryProvider.notifier).state = category,
+          );
+        },
+      ),
+    );
+  }
+}
+
+class _FeaturedPlayerPanel extends StatelessWidget {
+  const _FeaturedPlayerPanel({
+    required this.streamingState,
+    required this.onFullscreenToggle,
+    required this.buildQualityDropdown,
+  });
+
+  final AsyncValue<StreamingState> streamingState;
+  final VoidCallback onFullscreenToggle;
+  final Widget Function(StreamingState state) buildQualityDropdown;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Container(
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: theme.colorScheme.surface.withValues(alpha: 0.6),
+        borderRadius: BorderRadius.circular(20),
+        border: Border.all(color: theme.colorScheme.outlineVariant),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text('Featured Player', style: theme.textTheme.titleLarge),
+          const SizedBox(height: 4),
+          Text(
+            'Jump straight into live news, sports, entertainment, and music.',
+            style: theme.textTheme.bodyMedium,
+          ),
+          const SizedBox(height: 16),
+          AspectRatio(
+            aspectRatio: 16 / 9,
+            child: streamingState.when(
+              data: (state) => state.currentChannel != null
+                  ? VideoPlayerWidget(
+                      showControls: true,
+                      onFullscreenToggle: onFullscreenToggle,
+                    )
+                  : const _PlayerPlaceholder(),
+              loading: () => const _PlayerPlaceholder(),
+              error: (_, _) => const _PlayerPlaceholder(),
+            ),
+          ),
+          const SizedBox(height: 12),
+          streamingState.when(
+            data: (state) {
+              if (state.currentChannel == null) {
+                return const Text('Choose a live channel to begin streaming.');
+              }
+
+              return Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Row(
+                    children: [
+                      Expanded(
+                        child: Text(
+                          state.currentChannel!.name,
+                          style: theme.textTheme.titleMedium?.copyWith(
+                            fontWeight: FontWeight.w700,
+                          ),
+                          overflow: TextOverflow.ellipsis,
+                        ),
+                      ),
+                      buildQualityDropdown(state),
+                    ],
+                  ),
+                  const SizedBox(height: 6),
+                  Text(
+                    state.currentChannel!.group,
+                    style: theme.textTheme.bodyMedium,
+                  ),
+                  const SizedBox(height: 12),
+                  const IPTVMiniPlayer(forceVisible: true),
+                ],
+              );
+            },
+            loading: () => const SizedBox.shrink(),
+            error: (_, _) => const SizedBox.shrink(),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _ChannelPanel extends ConsumerWidget {
+  const _ChannelPanel({required this.channels, required this.onChannelTap});
+
+  final List<IPTVChannel> channels;
+  final ValueChanged<IPTVChannel> onChannelTap;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final searchQuery = ref.watch(channelSearchQueryProvider);
+
+    return Container(
+      decoration: BoxDecoration(
+        color: Theme.of(context).colorScheme.surface.withValues(alpha: 0.35),
+        borderRadius: BorderRadius.circular(20),
+        border: Border.all(color: Theme.of(context).colorScheme.outlineVariant),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Padding(
+            padding: const EdgeInsets.fromLTRB(16, 16, 16, 8),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  'Live Channels',
+                  style: Theme.of(context).textTheme.titleLarge,
+                ),
+                const SizedBox(height: 4),
+                Text(
+                  searchQuery.isEmpty
+                      ? '${channels.length} channels ready'
+                      : 'Showing results for "$searchQuery"',
+                ),
+              ],
+            ),
+          ),
+          Expanded(
+            child: ChannelListWidget(
+              onChannelTap: onChannelTap,
+              showCategories: false,
+              showSearchBar: false,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _PlayerPlaceholder extends StatelessWidget {
+  const _PlayerPlaceholder();
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    return Container(
+      decoration: BoxDecoration(
+        color: colorScheme.surface.withValues(alpha: 0.42),
+        border: Border.all(color: colorScheme.outlineVariant),
+      ),
+      child: Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(
+              Icons.live_tv,
+              size: 64,
+              color: colorScheme.primary.withValues(alpha: 0.7),
+            ),
+            const SizedBox(height: 16),
+            Text(
+              'Select a channel to start watching',
+              style: TextStyle(
+                color: colorScheme.primary.withValues(alpha: 0.7),
+              ),
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/app/lib/features/iptv/presentation/widgets/channel_list_widget.dart
+++ b/app/lib/features/iptv/presentation/widgets/channel_list_widget.dart
@@ -8,11 +8,13 @@ import '../../domain/models/iptv_channel.dart';
 class ChannelListWidget extends ConsumerWidget {
   final Function(IPTVChannel) onChannelTap;
   final bool showCategories;
+  final bool showSearchBar;
 
   const ChannelListWidget({
     super.key,
     required this.onChannelTap,
     this.showCategories = true,
+    this.showSearchBar = true,
   });
 
   @override
@@ -27,40 +29,41 @@ class ChannelListWidget extends ConsumerWidget {
     return Column(
       children: [
         // Search bar - compact to prevent overflow
-        Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
-          child: SizedBox(
-            height: 44,
-            child: TextField(
-              decoration: InputDecoration(
-                hintText: 'Search channels...',
-                prefixIcon: const Icon(Icons.search, size: 20),
-                border: OutlineInputBorder(
-                  borderRadius: BorderRadius.circular(0),
+        if (showSearchBar)
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+            child: SizedBox(
+              height: 44,
+              child: TextField(
+                decoration: InputDecoration(
+                  hintText: 'Search channels...',
+                  prefixIcon: const Icon(Icons.search, size: 20),
+                  border: OutlineInputBorder(
+                    borderRadius: BorderRadius.circular(0),
+                  ),
+                  contentPadding: const EdgeInsets.symmetric(
+                    horizontal: 12,
+                    vertical: 8,
+                  ),
+                  isDense: true,
+                  suffixIcon: searchQuery.isNotEmpty
+                      ? IconButton(
+                          icon: const Icon(Icons.clear, size: 18),
+                          onPressed: () =>
+                              ref
+                                      .read(channelSearchQueryProvider.notifier)
+                                      .state =
+                                  '',
+                          padding: EdgeInsets.zero,
+                          constraints: const BoxConstraints(),
+                        )
+                      : null,
                 ),
-                contentPadding: const EdgeInsets.symmetric(
-                  horizontal: 12,
-                  vertical: 8,
-                ),
-                isDense: true,
-                suffixIcon: searchQuery.isNotEmpty
-                    ? IconButton(
-                        icon: const Icon(Icons.clear, size: 18),
-                        onPressed: () =>
-                            ref
-                                    .read(channelSearchQueryProvider.notifier)
-                                    .state =
-                                '',
-                        padding: EdgeInsets.zero,
-                        constraints: const BoxConstraints(),
-                      )
-                    : null,
+                onChanged: (value) =>
+                    ref.read(channelSearchQueryProvider.notifier).state = value,
               ),
-              onChanged: (value) =>
-                  ref.read(channelSearchQueryProvider.notifier).state = value,
             ),
           ),
-        ),
 
         // Category tabs with counts - compact height
         if (showCategories)
@@ -409,6 +412,8 @@ class _ChannelListTile extends ConsumerWidget {
       trailing: Row(
         mainAxisSize: MainAxisSize.min,
         children: [
+          if (!channel.isAudioOnly) const _LiveStatusPill(),
+          if (!channel.isAudioOnly) const SizedBox(width: 8),
           // Playing indicator with animation
           if (isPlaying)
             Icon(
@@ -425,5 +430,35 @@ class _ChannelListTile extends ConsumerWidget {
   Widget _buildDefaultIcon() {
     // Use shared AppIconPlaceholder for brand consistency and optimized caching
     return AppIconPlaceholder.channel(isAudioOnly: channel.isAudioOnly);
+  }
+}
+
+class _LiveStatusPill extends StatelessWidget {
+  const _LiveStatusPill();
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 3),
+      decoration: BoxDecoration(
+        color: Colors.red.shade700,
+        borderRadius: BorderRadius.circular(999),
+      ),
+      child: const Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(Icons.circle, size: 6, color: Colors.white),
+          SizedBox(width: 4),
+          Text(
+            'LIVE',
+            style: TextStyle(
+              color: Colors.white,
+              fontSize: 10,
+              fontWeight: FontWeight.w700,
+            ),
+          ),
+        ],
+      ),
+    );
   }
 }

--- a/app/lib/features/iptv/presentation/widgets/iptv_mini_player.dart
+++ b/app/lib/features/iptv/presentation/widgets/iptv_mini_player.dart
@@ -11,7 +11,9 @@ import '../../domain/models/streaming_state.dart';
 /// - Playing audio-only channels (always visible)
 /// - Playing any channel when user navigates away from Stream tab
 class IPTVMiniPlayer extends ConsumerWidget {
-  const IPTVMiniPlayer({super.key});
+  const IPTVMiniPlayer({super.key, this.forceVisible = false});
+
+  final bool forceVisible;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -29,7 +31,7 @@ class IPTVMiniPlayer extends ConsumerWidget {
 
         // Don't show if on Stream tab (video player is visible there)
         // unless it's an audio-only channel
-        if (isOnStreamTab && !state.currentChannel!.isAudioOnly) {
+        if (isOnStreamTab && !forceVisible) {
           return const SizedBox.shrink();
         }
 

--- a/app/test/features/iptv/presentation/screens/iptv_screen_test.dart
+++ b/app/test/features/iptv/presentation/screens/iptv_screen_test.dart
@@ -1,0 +1,105 @@
+import 'package:airo_app/features/iptv/application/providers/iptv_providers.dart';
+import 'package:airo_app/features/iptv/domain/models/iptv_channel.dart';
+import 'package:airo_app/features/iptv/domain/models/streaming_state.dart';
+import 'package:airo_app/features/iptv/presentation/screens/iptv_screen.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  final channels = [
+    const IPTVChannel(
+      id: 'news-1',
+      name: 'City News Live',
+      streamUrl: 'https://example.com/news.m3u8',
+      group: 'News',
+      category: ChannelCategory.news,
+    ),
+    const IPTVChannel(
+      id: 'sports-1',
+      name: 'Stadium Sports',
+      streamUrl: 'https://example.com/sports.m3u8',
+      group: 'Sports',
+      category: ChannelCategory.sports,
+    ),
+    const IPTVChannel(
+      id: 'music-1',
+      name: 'Music Box',
+      streamUrl: 'https://example.com/music.m3u8',
+      group: 'Music',
+      category: ChannelCategory.music,
+    ),
+  ];
+
+  Widget createWidget() {
+    SharedPreferences.setMockInitialValues({});
+    return FutureBuilder<SharedPreferences>(
+      future: SharedPreferences.getInstance(),
+      builder: (context, snapshot) {
+        if (!snapshot.hasData) {
+          return const MaterialApp(
+            home: Scaffold(body: CircularProgressIndicator()),
+          );
+        }
+
+        return ProviderScope(
+          overrides: [
+            sharedPreferencesProvider.overrideWithValue(snapshot.data!),
+            iptvChannelsProvider.overrideWith((ref) async => channels),
+            recentlyWatchedChannelsProvider.overrideWith(
+              (ref) async => const [],
+            ),
+            streamingStateProvider.overrideWith(
+              (ref) => Stream.value(
+                const StreamingState(
+                  playbackState: PlaybackState.idle,
+                  isLiveStream: true,
+                  liveDelay: Duration(seconds: 1),
+                ),
+              ),
+            ),
+          ],
+          child: const MaterialApp(home: IPTVScreen()),
+        );
+      },
+    );
+  }
+
+  testWidgets('renders Stream app bar, category filters, and live list', (
+    tester,
+  ) async {
+    await tester.pumpWidget(createWidget());
+    await tester.pumpAndSettle();
+
+    expect(find.text('Stream'), findsOneWidget);
+    expect(find.byTooltip('Search channels'), findsOneWidget);
+    expect(find.byTooltip('Cast'), findsOneWidget);
+    expect(find.text('All (3)'), findsOneWidget);
+    expect(find.text('News (1)'), findsOneWidget);
+    expect(find.text('Sports (1)'), findsOneWidget);
+    expect(find.text('Entertainment (0)'), findsOneWidget);
+    expect(find.text('Music (1)'), findsOneWidget);
+    expect(find.text('Featured Player'), findsOneWidget);
+    expect(find.text('Select a channel to start watching'), findsOneWidget);
+
+    await tester.drag(find.byType(CustomScrollView), const Offset(0, -320));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Live Channels'), findsOneWidget);
+    expect(find.text('City News Live'), findsOneWidget);
+    expect(find.text('LIVE'), findsWidgets);
+  });
+
+  testWidgets('opens search sheet from app bar action', (tester) async {
+    await tester.pumpWidget(createWidget());
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byTooltip('Search channels'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Search channels'), findsOneWidget);
+    expect(find.text('Find live channels by name or group.'), findsOneWidget);
+    expect(find.text('Done'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
# Summary

This PR introduces changes to the Stream live TV screen.
Goal: align the tab with the discovery-first UI requested in issue #191.

Core outcome:

* updates the Stream app bar with search and cast actions
* adds the required primary category filters and a more prominent featured player section
* adds live indicators in the channel list and inline mini-player availability within the tab
* adds a focused widget test for the Stream screen

# Changes

### Code

* Added:
  * `app/test/features/iptv/presentation/screens/iptv_screen_test.dart`
* Updated:
  * `app/lib/features/iptv/presentation/screens/iptv_screen.dart`
  * `app/lib/features/iptv/presentation/widgets/channel_list_widget.dart`
  * `app/lib/features/iptv/presentation/widgets/iptv_mini_player.dart`

### Logic

* exposes only `All`, `News`, `Sports`, `Entertainment`, and `Music` as primary filters at the screen level
* moves search to an app-bar driven sheet while keeping existing provider-based filtering
* embeds a force-visible IPTV mini player in the Stream tab when playback exists
* adds static live badges to channel rows for live TV discovery clarity

# API Changes (if any)

* None.

# Database Changes (if any)

* None.

# Observability / Logging

* None.

# Performance Impact

* Latency: neutral
* Throughput: neutral
* Memory/CPU: negligible extra widget composition on the Stream screen

# Risks

* cast action is a UX entry point only and currently surfaces a placeholder snack bar
* inline mini-player behavior now depends on the new `forceVisible` flag in the IPTV mini player widget
* Rollback plan:
  * revert this PR

# Testing

* Unit tests:
  * none
* Integration tests:
  * none
* Manual testing:
  * `flutter analyze lib/features/iptv/presentation/screens/iptv_screen.dart lib/features/iptv/presentation/widgets/channel_list_widget.dart lib/features/iptv/presentation/widgets/iptv_mini_player.dart test/features/iptv/presentation/screens/iptv_screen_test.dart`
  * `flutter test test/features/iptv/presentation/screens/iptv_screen_test.dart`

# Deployment Notes

* Config changes:
  * none
* Order of deployment:
  * normal merge to `main`

# Related Commits

* feat(stream): refine live tv discovery tab

# Notes

* Closes #191.
