### PR TITLE
ci(android): reduce APK guardrail runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,13 @@ on:
     branches: [ main, master, develop ]
   pull_request:
     branches: [ main, master, develop ]
+  workflow_dispatch:
+    inputs:
+      build_full_android:
+        description: 'Build the mobile-full Android APK even for manual runs'
+        required: false
+        default: true
+        type: boolean
 
 # Cancel any in-progress runs for the same branch/PR
 concurrency:
@@ -72,6 +79,11 @@ jobs:
         run: |
           cd app
           find lib -name "*.dart" ! -name "*.g.dart" ! -name "*.freezed.dart" -print0 | xargs -0 dart format --set-exit-if-changed
+
+      - name: Enforce bundled model artifact guardrail
+        run: |
+          chmod +x scripts/check-bundled-model-artifacts.sh
+          scripts/check-bundled-model-artifacts.sh
 
   # ============================================
   # Core Package Tests (runs on all events - fast)
@@ -184,7 +196,7 @@ jobs:
   # ============================================
   build-android:
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' || github.event_name == 'pull_request'
+    if: github.event_name == 'push' || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
     strategy:
       fail-fast: false
       matrix:
@@ -218,13 +230,44 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Resolve Android build scope
+        id: android_scope
+        env:
+          PR_LABELS: ${{ github.event_name == 'pull_request' && join(github.event.pull_request.labels.*.name, ' ') || '' }}
+          BUILD_FULL_ANDROID: ${{ github.event.inputs.build_full_android }}
+        run: |
+          should_build=true
+          reason="required for this event"
+
+          if [ "${{ github.event_name }}" = "pull_request" ] && [ "${{ matrix.platform.name }}" = "mobile-full" ]; then
+            if [[ " $PR_LABELS " == *" full-android-build "* ]]; then
+              reason="PR has full-android-build label"
+            else
+              should_build=false
+              reason="mobile-full is skipped on PRs; add full-android-build label to run it"
+            fi
+          fi
+
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && \
+             [ "${{ matrix.platform.name }}" = "mobile-full" ] && \
+             [ "$BUILD_FULL_ANDROID" != "true" ]; then
+            should_build=false
+            reason="manual run disabled mobile-full"
+          fi
+
+          echo "should_build=$should_build" >> "$GITHUB_OUTPUT"
+          echo "reason=$reason" >> "$GITHUB_OUTPUT"
+          echo "$reason"
+
       - name: Setup Java
+        if: steps.android_scope.outputs.should_build == 'true'
         uses: actions/setup-java@v5
         with:
           java-version: '17'
           distribution: 'temurin'
 
       - name: Setup Flutter
+        if: steps.android_scope.outputs.should_build == 'true'
         uses: subosito/flutter-action@v2
         with:
           flutter-version: ${{ env.FLUTTER_VERSION }}
@@ -232,6 +275,7 @@ jobs:
           cache: true
 
       - name: Cache pub dependencies
+        if: steps.android_scope.outputs.should_build == 'true'
         uses: actions/cache@v5
         with:
           path: |
@@ -243,6 +287,7 @@ jobs:
             pub-${{ runner.os }}-
 
       - name: Cache Gradle
+        if: steps.android_scope.outputs.should_build == 'true'
         uses: actions/cache@v5
         with:
           path: |
@@ -255,6 +300,7 @@ jobs:
       # Firebase Configuration Setup
       # ===========================================
       - name: Create Firebase Config
+        if: steps.android_scope.outputs.should_build == 'true'
         env:
           GOOGLE_SERVICES_JSON: ${{ secrets.GOOGLE_SERVICES_JSON }}
         run: |
@@ -302,6 +348,7 @@ jobs:
           echo "✅ Firebase configuration created successfully"
 
       - name: Create CI validation signing config
+        if: steps.android_scope.outputs.should_build == 'true'
         run: |
           cd app/android
           keytool -genkeypair \
@@ -327,7 +374,7 @@ jobs:
       # Apply Platform-Specific Pubspec (if using stubs)
       # ===========================================
       - name: Apply platform-specific pubspec
-        if: matrix.platform.use_stubs
+        if: steps.android_scope.outputs.should_build == 'true' && matrix.platform.use_stubs
         run: |
           cd app
           echo "📦 Applying ${{ matrix.platform.pubspec }} for ${{ matrix.platform.name }} build..."
@@ -336,6 +383,7 @@ jobs:
           echo "✅ Platform-specific pubspec applied"
 
       - name: Get dependencies
+        if: steps.android_scope.outputs.should_build == 'true'
         run: |
           cd packages/core_domain && flutter pub get
           cd ../core_ui && flutter pub get
@@ -345,16 +393,18 @@ jobs:
           cd ../../app && flutter pub get
 
       - name: Patch Android plugin Gradle files
+        if: steps.android_scope.outputs.should_build == 'true'
         run: scripts/patch-android-plugin-gradle.sh
 
       - name: Run code generation
-        if: matrix.platform.name == 'mobile-full'
+        if: steps.android_scope.outputs.should_build == 'true' && matrix.platform.name == 'mobile-full'
         run: |
           cd app
           dart run build_runner clean
           dart run build_runner build --delete-conflicting-outputs
 
       - name: Build APK (Release) - ${{ matrix.platform.description }}
+        if: steps.android_scope.outputs.should_build == 'true'
         run: |
           cd app
           echo "🔨 Building ${{ matrix.platform.name }} APK..."
@@ -374,6 +424,7 @@ jobs:
       # Verify APK Size Targets
       # ===========================================
       - name: Check APK sizes
+        if: steps.android_scope.outputs.should_build == 'true'
         id: apk_sizes
         continue-on-error: ${{ matrix.platform.enforce_size == false }}
         env:
@@ -384,7 +435,7 @@ jobs:
           scripts/check-apk-size.sh
 
       - name: Upload APK size report
-        if: github.event_name == 'pull_request' && always()
+        if: github.event_name == 'pull_request' && steps.android_scope.outputs.should_build == 'true' && always()
         uses: actions/upload-artifact@v7
         with:
           name: apk-size-report-${{ matrix.platform.name }}
@@ -393,7 +444,7 @@ jobs:
           retention-days: 7
 
       - name: Generate APK baseline update
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && steps.android_scope.outputs.should_build == 'true'
         env:
           APK_SIZE_COMPONENT: ${{ matrix.platform.name }}
           APK_SIZE_BUDGET_MB: ${{ matrix.platform.size_target_mb }}
@@ -409,7 +460,7 @@ jobs:
           done
 
       - name: Upload APK baseline update
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && steps.android_scope.outputs.should_build == 'true'
         uses: actions/upload-artifact@v7
         with:
           name: apk-size-baseline-${{ matrix.platform.name }}
@@ -420,7 +471,7 @@ jobs:
       # Restore Original Pubspec (if using stubs)
       # ===========================================
       - name: Restore original pubspec
-        if: matrix.platform.use_stubs && always()
+        if: steps.android_scope.outputs.should_build == 'true' && matrix.platform.use_stubs && always()
         run: |
           cd app
           if [ -f pubspec.yaml.backup ]; then
@@ -429,6 +480,7 @@ jobs:
           fi
 
       - name: Upload Release APKs
+        if: steps.android_scope.outputs.should_build == 'true'
         uses: actions/upload-artifact@v7
         with:
           name: android-${{ matrix.platform.name }}-release
@@ -436,6 +488,7 @@ jobs:
           retention-days: 14
 
       - name: Upload Debug Info
+        if: steps.android_scope.outputs.should_build == 'true'
         uses: actions/upload-artifact@v7
         with:
           name: android-${{ matrix.platform.name }}-debug-info

--- a/.github/workflows/iptv_sanity.yml
+++ b/.github/workflows/iptv_sanity.yml
@@ -1,10 +1,6 @@
 name: IPTV Sanity Pipeline
 
 on:
-  # Scheduled: Run daily at 00:00 UTC
-  schedule:
-    - cron: '0 0 * * *'
-
   # Manual trigger
   workflow_dispatch:
     inputs:
@@ -13,15 +9,6 @@ on:
         required: false
         default: 'false'
         type: boolean
-
-  # On push to iptv-data changes
-  push:
-    branches:
-      - main
-    paths:
-      - 'iptv-data/config/**'
-      - 'iptv-data/rules/**'
-      - 'iptv-data/src/**'
 
 env:
   PYTHON_VERSION: '3.11'
@@ -153,4 +140,3 @@ jobs:
         run: |
           echo "IPTV Pipeline failed! Manual intervention may be required."
           echo "Check the pipeline logs for details."
-

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -58,6 +58,11 @@ jobs:
             --base "$AIRO_DOCS_BASE" \
             --head "$AIRO_DOCS_HEAD"
 
+      - name: Enforce bundled model artifact guardrail
+        run: |
+          chmod +x scripts/check-bundled-model-artifacts.sh
+          scripts/check-bundled-model-artifacts.sh
+
   # ============================================
   # Code Quality (analyze, format) - ~2 minutes
   # ============================================
@@ -177,7 +182,7 @@ jobs:
 
             | Check | Status | Description |
             |-------|--------|-------------|
-            | PR Validation | ${getEmoji(prValidation)} ${prValidation} | Title format, file changes |
+            | PR Validation | ${getEmoji(prValidation)} ${prValidation} | Title format, docs, bundled model guardrail |
             | Code Quality | ${getEmoji(codeQuality)} ${codeQuality} | Analyze, formatting |
             | Core Tests | ${getEmoji(tests)} ${tests} | Core package unit tests |
 

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -11,8 +11,6 @@ on:
         options:
           - staging
           - production
-  release:
-    types: [published]
 
 jobs:
   smoke-test-web:

--- a/docs/architecture/MODEL_DELIVERY_AND_SIZE_GUARDRAILS.md
+++ b/docs/architecture/MODEL_DELIVERY_AND_SIZE_GUARDRAILS.md
@@ -1,0 +1,54 @@
+# Model Delivery and Size Guardrails
+
+Issue `#253` tracks reducing the full Android APK footprint before production.
+The default policy is that large AI model artifacts must not be bundled into
+APK, AAB, IPA, or web release bundles.
+
+## Delivery Policy
+
+- Large LLM and embedding artifacts must be delivered at runtime after install.
+- The app may keep only tiny pinned classifiers or heuristics assets in the
+  bundle when they are below the CI cap and intentionally reviewed.
+- Runtime model downloads must verify metadata before activation, including
+  size, checksum, runtime compatibility, and version.
+- Users must be able to remove downloaded models to recover storage.
+- Streaming and TV variants must continue excluding full AI runtime binaries.
+
+## Android Release Shape
+
+Use Android App Bundle or ABI-split artifacts for store release so users only
+receive binaries for their device architecture. CI still builds arm64 APKs for
+guardrail validation because those builds are deterministic and easy to compare.
+
+The full mobile variant is allowed to produce a size report while issue `#253`
+is open. Lean variants remain enforced against their size budgets.
+
+## CI Guardrails
+
+`scripts/check-bundled-model-artifacts.sh` scans release-bearing source paths
+for common model binary extensions:
+
+- `.gguf`, `.ggml`, `.safetensors`
+- `.pt`, `.pth`, `.onnx`
+- `.tflite`, `.litert`, `.task`
+- `.mlmodel`, `.mlpackage`
+
+Artifacts above `AIRO_MAX_BUNDLED_MODEL_BYTES` fail CI. The default cap is
+5 MiB. Smaller artifacts pass with a warning so intentionally tiny classifiers
+can be reviewed without blocking unrelated work.
+
+`scripts/check-apk-size.sh` reports both high-level archive areas and the
+largest APK entries. Use the largest-entry table to identify whether APK growth
+comes from native libraries, Dart/Flutter assets, resources, or accidentally
+bundled model files.
+
+## Operational Checklist
+
+Before adding a new local model capability:
+
+1. Add the model to runtime delivery metadata, not to app assets.
+2. Define checksum and expected byte size.
+3. Add download, verify, activate, and delete flows.
+4. Run the bundled model artifact guardrail.
+5. Run APK size checks for the impacted Android variants.
+6. Document any intentionally bundled tiny model and its reason in the PR.

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -21,6 +21,12 @@ Technical architecture and design decisions for Airo Super App.
 - Model optimization
 - Integration points
 
+### [MODEL_DELIVERY_AND_SIZE_GUARDRAILS.md](./MODEL_DELIVERY_AND_SIZE_GUARDRAILS.md)
+**Release bundle size policy**:
+- Runtime delivery for large AI model artifacts
+- CI checks that prevent accidental model bundling
+- APK size investigation workflow
+
 ---
 
 ## 🎯 Key Components
@@ -88,4 +94,3 @@ Technical architecture and design decisions for Airo Super App.
 ---
 
 **Ready?** → [Read Technical Architecture](./TECHNICAL_ARCHITECTURE.md)
-

--- a/scripts/check-apk-size.sh
+++ b/scripts/check-apk-size.sh
@@ -133,7 +133,7 @@ write_breakdown() {
       NR > 3 && $1 ~ /^[0-9]+$/ && NF >= 4 && $4 != "" {
         printf "%d\t%s\n", $1, $4
       }
-    ' | sort -k1,1nr | head -n "$TOP_ENTRIES" | awk -F '\t' '{ printf "| %s | %.2f MB |\n", $2, $1 / 1048576 }'
+    ' | sort -k1,1nr | awk -F '\t' -v limit="$TOP_ENTRIES" 'NR <= limit { printf "| %s | %.2f MB |\n", $2, $1 / 1048576 }'
   } >>"$REPORT_FILE"
 }
 

--- a/scripts/check-apk-size.sh
+++ b/scripts/check-apk-size.sh
@@ -10,6 +10,7 @@ MAX_MB="${APK_SIZE_MAX_MB:-35}"
 MAX_BYTES="${APK_SIZE_MAX_BYTES:-}"
 MAX_INCREASE_PERCENT="${APK_SIZE_MAX_INCREASE_PERCENT:-5}"
 REPORT_FILE="${APK_SIZE_REPORT_FILE:-apk-size-report.md}"
+TOP_ENTRIES="${APK_SIZE_TOP_ENTRIES:-20}"
 
 cd "$ROOT_DIR"
 
@@ -120,6 +121,19 @@ write_breakdown() {
         }
       }
     ' | sort -k2,2nr | awk -F '\t' '{ printf "| %s | %.2f MB |\n", $1, $2 / 1048576 }'
+  } >>"$REPORT_FILE"
+
+  {
+    echo ""
+    echo "#### Largest APK entries"
+    echo ""
+    echo "| Entry | Size |"
+    echo "|-------|------|"
+    unzip -l "$apk" | awk '
+      NR > 3 && $1 ~ /^[0-9]+$/ && NF >= 4 && $4 != "" {
+        printf "%d\t%s\n", $1, $4
+      }
+    ' | sort -k1,1nr | head -n "$TOP_ENTRIES" | awk -F '\t' '{ printf "| %s | %.2f MB |\n", $2, $1 / 1048576 }'
   } >>"$REPORT_FILE"
 }
 

--- a/scripts/check-bundled-model-artifacts.sh
+++ b/scripts/check-bundled-model-artifacts.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+MAX_BYTES="${AIRO_MAX_BUNDLED_MODEL_BYTES:-5242880}"
+SCAN_PATHS="${AIRO_MODEL_ARTIFACT_SCAN_PATHS:-app packages}"
+REPORT_FILE="${AIRO_MODEL_ARTIFACT_REPORT_FILE:-model-artifact-report.md}"
+ALLOWLIST="${AIRO_MODEL_ARTIFACT_ALLOWLIST:-}"
+
+cd "$ROOT_DIR"
+
+stat_bytes() {
+  local file="$1"
+  if stat -c%s "$file" >/dev/null 2>&1; then
+    stat -c%s "$file"
+  else
+    stat -f%z "$file"
+  fi
+}
+
+format_bytes() {
+  awk -v bytes="$1" 'BEGIN { printf "%.2f MB", bytes / 1048576 }'
+}
+
+is_allowlisted() {
+  local file="$1"
+  [ -z "$ALLOWLIST" ] && return 1
+
+  local pattern
+  IFS=',' read -ra patterns <<< "$ALLOWLIST"
+  for pattern in "${patterns[@]}"; do
+    pattern="${pattern#"${pattern%%[![:space:]]*}"}"
+    pattern="${pattern%"${pattern##*[![:space:]]}"}"
+    [ -z "$pattern" ] && continue
+    if [[ "$file" == $pattern ]]; then
+      return 0
+    fi
+  done
+
+  return 1
+}
+
+{
+  echo "# Bundled Model Artifact Guardrail"
+  echo ""
+  echo "Max allowed bundled model artifact size: $(format_bytes "$MAX_BYTES")"
+  echo ""
+} > "$REPORT_FILE"
+
+find_args=()
+for path in $SCAN_PATHS; do
+  [ -e "$path" ] || continue
+  find_args+=("$path")
+done
+
+if [ "${#find_args[@]}" -eq 0 ]; then
+  echo "No configured scan paths exist: $SCAN_PATHS" >> "$REPORT_FILE"
+  cat "$REPORT_FILE"
+  exit 0
+fi
+
+candidates=()
+while IFS= read -r candidate; do
+  candidates+=("$candidate")
+done < <(
+  find "${find_args[@]}" \
+    \( -path '*/build/*' -o -path '*/.dart_tool/*' -o -path '*/.gradle/*' -o -path '*/Pods/*' \) -prune \
+    -o -type f \
+    \( \
+      -iname '*.gguf' -o -iname '*.ggml' -o -iname '*.safetensors' \
+      -o -iname '*.pt' -o -iname '*.pth' -o -iname '*.onnx' \
+      -o -iname '*.tflite' -o -iname '*.litert' -o -iname '*.task' \
+      -o -iname '*.mlmodel' -o -iname '*.mlpackage' \
+    \) -print | sort
+)
+
+if [ "${#candidates[@]}" -eq 0 ]; then
+  echo "No bundled model artifacts found in release-bearing paths." >> "$REPORT_FILE"
+  cat "$REPORT_FILE"
+  exit 0
+fi
+
+failed=0
+{
+  echo "| File | Size | Status |"
+  echo "|------|------|--------|"
+} >> "$REPORT_FILE"
+
+for file in "${candidates[@]}"; do
+  size="$(stat_bytes "$file")"
+  status="OK: below small pinned-model cap"
+
+  if is_allowlisted "$file"; then
+    status="OK: allowlisted"
+  elif [ "$size" -gt "$MAX_BYTES" ]; then
+    status="FAIL: bundled model exceeds cap"
+    echo "::error file=$file::$file is $(format_bytes "$size"); models larger than $(format_bytes "$MAX_BYTES") must be delivered at runtime."
+    failed=1
+  else
+    echo "::warning file=$file::$file is a bundled model artifact below the cap. Prefer runtime delivery unless this is an intentional tiny classifier."
+  fi
+
+  echo "| $file | $(format_bytes "$size") | $status |" >> "$REPORT_FILE"
+done
+
+cat "$REPORT_FILE"
+
+if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+  cat "$REPORT_FILE" >> "$GITHUB_STEP_SUMMARY"
+fi
+
+exit "$failed"

--- a/scripts/test-check-apk-size.sh
+++ b/scripts/test-check-apk-size.sh
@@ -100,4 +100,30 @@ run_case "fails-missing-baseline" 1 \
     "$SCRIPT"
 grep -q "No APK size baseline" "$TMP_DIR/fails-missing-baseline.out"
 
+if command -v zip >/dev/null 2>&1; then
+  zip_root="$TMP_DIR/zip-root"
+  mkdir -p "$zip_root/lib/arm64-v8a" "$zip_root/assets"
+  make_file "$zip_root/lib/arm64-v8a/liblitertlm_jni.so" 2048
+  make_file "$zip_root/assets/flutter_assets.bin" 1024
+  zip_apk="$TMP_DIR/zipped.apk"
+  (cd "$zip_root" && zip -qr "$zip_apk" .)
+
+  zip_size="$(wc -c < "$zip_apk" | tr -d ' ')"
+  cat >>"$baseline_file" <<EOF
+demo	zipped.apk	$zip_size	1
+EOF
+
+  run_case "reports-largest-apk-entries" 0 \
+    env APK_SIZE_APK_GLOB="$zip_apk" \
+      APK_SIZE_COMPONENT=demo \
+      APK_SIZE_BASELINE_FILE="$baseline_file" \
+      APK_SIZE_REPORT_FILE="$TMP_DIR/zip-report.md" \
+      APK_SIZE_MAX_BYTES=200000 \
+      APK_SIZE_MAX_INCREASE_PERCENT=5 \
+      APK_SIZE_TOP_ENTRIES=2 \
+      "$SCRIPT"
+  grep -q "Largest APK entries" "$TMP_DIR/zip-report.md"
+  grep -q "liblitertlm_jni.so" "$TMP_DIR/zip-report.md"
+fi
+
 echo "check-apk-size tests passed"

--- a/scripts/test-check-bundled-model-artifacts.sh
+++ b/scripts/test-check-bundled-model-artifacts.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT="$ROOT_DIR/scripts/check-bundled-model-artifacts.sh"
+TMP_DIR="$(mktemp -d)"
+
+cleanup() {
+  rm -rf "$TMP_DIR"
+}
+trap cleanup EXIT
+
+make_file() {
+  local path="$1"
+  local bytes="$2"
+  mkdir -p "$(dirname "$path")"
+  dd if=/dev/zero of="$path" bs=1 count="$bytes" status=none
+}
+
+run_case() {
+  local name="$1"
+  local expected_status="$2"
+  shift 2
+
+  set +e
+  "$@" > "$TMP_DIR/$name.out" 2>&1
+  local actual_status=$?
+  set -e
+
+  if [ "$expected_status" -ne "$actual_status" ]; then
+    echo "FAIL: $name expected exit $expected_status, got $actual_status"
+    cat "$TMP_DIR/$name.out"
+    exit 1
+  fi
+}
+
+clean_app="$TMP_DIR/clean/app"
+mkdir -p "$clean_app/lib"
+run_case "passes-without-model-artifacts" 0 \
+  env AIRO_MODEL_ARTIFACT_SCAN_PATHS="$clean_app" \
+    AIRO_MODEL_ARTIFACT_REPORT_FILE="$TMP_DIR/clean-report.md" \
+    "$SCRIPT"
+grep -q "No bundled model artifacts" "$TMP_DIR/passes-without-model-artifacts.out"
+
+small_model="$TMP_DIR/small/app/assets/classifier.tflite"
+make_file "$small_model" 1024
+run_case "warns-for-small-pinned-model" 0 \
+  env AIRO_MODEL_ARTIFACT_SCAN_PATHS="$TMP_DIR/small/app" \
+    AIRO_MAX_BUNDLED_MODEL_BYTES=2048 \
+    AIRO_MODEL_ARTIFACT_REPORT_FILE="$TMP_DIR/small-report.md" \
+    "$SCRIPT"
+grep -q "below small pinned-model cap" "$TMP_DIR/warns-for-small-pinned-model.out"
+
+large_model="$TMP_DIR/large/app/assets/offline.gguf"
+make_file "$large_model" 4096
+run_case "fails-for-large-bundled-model" 1 \
+  env AIRO_MODEL_ARTIFACT_SCAN_PATHS="$TMP_DIR/large/app" \
+    AIRO_MAX_BUNDLED_MODEL_BYTES=2048 \
+    AIRO_MODEL_ARTIFACT_REPORT_FILE="$TMP_DIR/large-report.md" \
+    "$SCRIPT"
+grep -q "models larger than" "$TMP_DIR/fails-for-large-bundled-model.out"
+
+run_case "passes-allowlisted-large-model" 0 \
+  env AIRO_MODEL_ARTIFACT_SCAN_PATHS="$TMP_DIR/large/app" \
+    AIRO_MAX_BUNDLED_MODEL_BYTES=2048 \
+    AIRO_MODEL_ARTIFACT_ALLOWLIST="$large_model" \
+    AIRO_MODEL_ARTIFACT_REPORT_FILE="$TMP_DIR/allowlist-report.md" \
+    "$SCRIPT"
+grep -q "allowlisted" "$TMP_DIR/passes-allowlisted-large-model.out"
+
+echo "check-bundled-model-artifacts tests passed"


### PR DESCRIPTION
# Summary

This PR reduces routine GitHub Actions runtime while preserving required release and security guardrails for issue #253.

Goal: prevent accidental APK/model bloat and avoid spending PR build time on the known-heavy full Android variant unless it is explicitly requested.

Core outcome:

* `mobile-full` Android APK builds are skipped on PRs by default and run when the PR has the `full-android-build` label.
* Streaming and TV Android APK size guardrails remain active on PRs.
* Large bundled model artifacts are blocked in release-bearing app/package paths.

# Changes

### Code

* Added `scripts/check-bundled-model-artifacts.sh` and regression coverage.
* Updated `scripts/check-apk-size.sh` to include largest APK entries in reports.
* Added runtime model delivery and size guardrail documentation.

### CI

* Added manual dispatch support to `ci.yml`, including `build_full_android` control.
* Wired the model artifact guardrail into PR checks and CI analysis.
* Made IPTV sanity and smoke tests manual-only to reduce nonessential Actions usage.
* Kept security scans, lint, PR checks, core tests, and lean APK guardrails enabled.

# Risks

* Full Android APK regressions on PRs are now report-on-demand unless the PR is labeled `full-android-build`; push-to-main still runs the full matrix.
* IPTV and smoke workflows no longer run automatically; they must be triggered manually while Actions spend is being controlled.

Rollback plan:

* Re-enable the removed workflow triggers or remove the `mobile-full` skip gate from `ci.yml`.

# Testing

* `scripts/test-check-bundled-model-artifacts.sh`
* `scripts/test-check-apk-size.sh`
* `scripts/test-check-module-sizes.sh`
* `scripts/check-bundled-model-artifacts.sh`
* `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "OK #{f}" }' .github/workflows/ci.yml .github/workflows/pr-checks.yml .github/workflows/iptv_sanity.yml .github/workflows/smoke-tests.yml`
* `bash -n scripts/check-bundled-model-artifacts.sh scripts/test-check-bundled-model-artifacts.sh scripts/check-apk-size.sh scripts/test-check-apk-size.sh`
* `git diff --check`

Closes #253 only after the full APK footprint is brought under the production target; this PR is a guardrail/runtime reduction step under that issue.
