### PR TITLE
test(agent-chat): close bounded orchestrator coverage gaps

### DIFF
--- a/app/test/features/agent_chat/domain/services/agent_skill_orchestrator_test.dart
+++ b/app/test/features/agent_chat/domain/services/agent_skill_orchestrator_test.dart
@@ -10,6 +10,33 @@ import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   group('AgentSkillOrchestrator', () {
+    test('parses selected skill ids from json and rejects malformed input', () {
+      expect(
+        parseSelectedSkillId('{"skill_id":"read-calendar-events"}'),
+        'read-calendar-events',
+      );
+      expect(parseSelectedSkillId('{"skill_id":null}'), isNull);
+      expect(parseSelectedSkillId('not json'), isNull);
+    });
+
+    test(
+      'parses tool calls from json and rejects malformed action payloads',
+      () {
+        final toolCall = parseSkillModelAction(
+          '```json\n{"type":"tool_call","tool":"open_route","arguments":{"feature":"money"}}\n```',
+        );
+        expect(toolCall?.type, SkillModelActionType.toolCall);
+        expect(toolCall?.tool, 'open_route');
+        expect(toolCall?.arguments, {'feature': 'money'});
+
+        expect(
+          parseSkillModelAction('{"type":"final","message":"Done"}')?.message,
+          'Done',
+        );
+        expect(parseSkillModelAction('not json'), isNull);
+      },
+    );
+
     test('does not handle prompts when no skill applies', () async {
       final orchestrator = _buildOrchestrator();
 
@@ -243,6 +270,38 @@ void main() {
       expect(result.message, contains('unsupported action'));
     });
 
+    test('returns an error when model output is unusable without fallback', () async {
+      final orchestrator = _buildOrchestrator(
+        modelClient: _NullActionModelClient(),
+        useFallbackModelClient: false,
+      );
+
+      final result = await orchestrator.run('Check my schedule for today');
+
+      expect(result.handled, true);
+      expect(result.isError, true);
+      expect(result.message, contains('could not complete'));
+      expect(result.traces.map((trace) => trace.detail), ['read-calendar-events']);
+    });
+
+    test('stops runs that exceed the bounded step limit', () async {
+      final orchestrator = _buildOrchestrator(
+        modelClient: _LoopingToolModelClient(),
+        useFallbackModelClient: false,
+        maxSteps: 2,
+      );
+
+      final result = await orchestrator.run('Check my schedule for today');
+
+      expect(result.handled, true);
+      expect(result.isError, true);
+      expect(result.message, contains('too many steps'));
+      expect(
+        result.traces.where((trace) => trace.detail == 'get_current_date_time'),
+        hasLength(2),
+      );
+    });
+
     test(
       'normalizes route tool typo and executes open route connector',
       () async {
@@ -270,6 +329,8 @@ AgentSkillOrchestrator _buildOrchestrator({
   Map<String, List<CalendarEventData>>? events,
   InMemoryNotificationScheduler? notificationScheduler,
   AgentSkillModelClient? modelClient,
+  bool useFallbackModelClient = true,
+  int maxSteps = 4,
 }) {
   return AgentSkillOrchestrator(
     skillRegistry: AgentSkillRegistry(),
@@ -285,6 +346,8 @@ AgentSkillOrchestrator _buildOrchestrator({
       ],
     ),
     modelClient: modelClient,
+    useFallbackModelClient: useFallbackModelClient,
+    maxSteps: maxSteps,
   );
 }
 
@@ -326,5 +389,43 @@ class _OpenRouteTypoModelClient implements AgentSkillModelClient {
       tool: 'Open_root',
       arguments: {'feature': 'money'},
     );
+  }
+}
+
+class _NullActionModelClient implements AgentSkillModelClient {
+  @override
+  Future<String?> selectSkill({
+    required String prompt,
+    required List<AgentSkill> enabledSkills,
+  }) async {
+    return 'read-calendar-events';
+  }
+
+  @override
+  Future<SkillModelAction?> nextAction({
+    required String prompt,
+    required AgentSkill skill,
+    required List<Map<String, dynamic>> toolResults,
+  }) async {
+    return null;
+  }
+}
+
+class _LoopingToolModelClient implements AgentSkillModelClient {
+  @override
+  Future<String?> selectSkill({
+    required String prompt,
+    required List<AgentSkill> enabledSkills,
+  }) async {
+    return 'read-calendar-events';
+  }
+
+  @override
+  Future<SkillModelAction?> nextAction({
+    required String prompt,
+    required AgentSkill skill,
+    required List<Map<String, dynamic>> toolResults,
+  }) async {
+    return const SkillModelAction.toolCall(tool: 'get_current_date_time');
   }
 }


### PR DESCRIPTION
# PR Title

test(agent-chat): close bounded orchestrator coverage gaps

---

# Summary

This PR introduces changes to the agent skill orchestrator test coverage.
Goal: finish the remaining deterministic verification needed to close issue `#231`.

Core outcome:

* adds parser coverage for valid and malformed skill/model output
* verifies the orchestrator fails safely on unusable model output and stops at the configured step limit
* closes `#231`

---

# Changes

### Code

* Updated:
  * `app/test/features/agent_chat/domain/services/agent_skill_orchestrator_test.dart` to cover malformed output handling and bounded-step behavior

### Logic

* validates `parseSelectedSkillId` against valid and malformed payloads
* validates `parseSkillModelAction` against valid and malformed payloads
* confirms unusable model output returns an error when fallback is disabled
* confirms looping tool runs stop after the configured max step count

---

# Risks

* low risk: test-only change
* no runtime behavior changed in production code
* Rollback plan:
  * revert this PR if the new deterministic expectations prove incorrect

---

# Testing

* Unit tests:
  * `flutter test test/features/agent_chat/domain/services/agent_skill_orchestrator_test.dart`
* Manual testing:
  * `flutter analyze lib/features/agent_chat/domain/services/agent_skill_orchestrator.dart test/features/agent_chat/domain/services/agent_skill_orchestrator_test.dart`

---

# Notes

* Closes #231
