### PR TITLE
test(agent-chat): add skill ui coverage

### DIFF
--- a/app/test/features/agent_chat/presentation/widgets/manage_skills_sheet_test.dart
+++ b/app/test/features/agent_chat/presentation/widgets/manage_skills_sheet_test.dart
@@ -1,0 +1,54 @@
+import 'package:airo_app/features/agent_chat/domain/services/agent_skill_registry.dart';
+import 'package:airo_app/features/agent_chat/presentation/widgets/manage_skills_sheet.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('manage skills sheet searches visible skills', (tester) async {
+    final registry = AgentSkillRegistry();
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: ManageSkillsSheet(registry: registry, onChanged: () {}),
+        ),
+      ),
+    );
+
+    expect(find.text('Manage Skills'), findsOneWidget);
+    expect(find.text('4 skills'), findsOneWidget);
+    expect(find.text('read-calendar-events'), findsOneWidget);
+
+    await tester.enterText(find.byType(TextField), 'Open Airo');
+    await tester.pump();
+
+    expect(find.text('open-airo-feature'), findsOneWidget);
+    expect(find.text('read-calendar-events'), findsNothing);
+  });
+
+  testWidgets('manage skills sheet toggles registry state and notifies changes', (
+    tester,
+  ) async {
+    final registry = AgentSkillRegistry();
+    var changedCount = 0;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: ManageSkillsSheet(
+            registry: registry,
+            onChanged: () => changedCount++,
+          ),
+        ),
+      ),
+    );
+
+    expect(registry.getById('create-calendar-event')?.enabled, false);
+
+    await tester.tap(find.byType(Switch).at(1));
+    await tester.pump();
+
+    expect(registry.getById('create-calendar-event')?.enabled, true);
+    expect(changedCount, 1);
+  });
+}

--- a/app/test/features/agent_chat/presentation/widgets/skill_action_trace_card_test.dart
+++ b/app/test/features/agent_chat/presentation/widgets/skill_action_trace_card_test.dart
@@ -1,0 +1,64 @@
+import 'package:airo_app/features/agent_chat/domain/models/agent_skill.dart';
+import 'package:airo_app/features/agent_chat/presentation/widgets/skill_action_trace_card.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('trace card renders success and failure states clearly', (
+    tester,
+  ) async {
+    const traces = [
+      AgentActionTrace(
+        title: 'Load skill',
+        detail: 'read-calendar-events',
+      ),
+      AgentActionTrace(
+        title: 'Blocked action',
+        detail: 'delete_calendar_events',
+        success: false,
+      ),
+    ];
+
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(body: SkillActionTraceCard(traces: traces)),
+      ),
+    );
+
+    expect(find.text('Performed action'), findsOneWidget);
+    expect(find.text('Load skill'), findsOneWidget);
+    expect(find.text('Blocked action'), findsOneWidget);
+    expect(find.byIcon(Icons.error_outline), findsOneWidget);
+    expect(find.byIcon(Icons.circle), findsOneWidget);
+  });
+
+  testWidgets('trace card renders parameters and hides itself for empty traces', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(
+          body: SkillActionTraceCard(
+            traces: [
+              AgentActionTrace(
+                title: 'Execute action',
+                detail: 'open_route',
+                parameters: {'feature': 'money'},
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    expect(find.textContaining('Parameters: {feature: money}'), findsOneWidget);
+
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(body: SkillActionTraceCard(traces: [])),
+      ),
+    );
+
+    expect(find.text('Performed action'), findsNothing);
+  });
+}


### PR DESCRIPTION
# PR Title

test(agent-chat): add skill ui coverage

---

# Summary

This PR introduces changes to the agent skill UI verification surface.
Goal: close the remaining acceptance gap in issue `#232` by adding deterministic widget coverage for the existing skill management sheet and action trace card.

Core outcome:

* verifies skill search and toggle behavior in the existing skills sheet
* verifies success/failure trace rendering and parameter display in the existing trace card
* closes `#232`

---

# Changes

### Code

* Added:
  * widget tests for `ManageSkillsSheet`
  * widget tests for `SkillActionTraceCard`

### Logic

* confirms skill search filters visible results
* confirms toggling a skill updates registry state and triggers change notification
* confirms trace card renders distinct success and failure icons/states
* confirms trace card renders parameters and hides itself for empty traces

---

# Risks

* low risk: test-only change
* no production runtime behavior changed
* Rollback plan:
  * revert this PR if the current widget expectations no longer match intended UI

---

# Testing

* Unit tests:
  * `flutter test test/features/agent_chat/presentation/widgets/manage_skills_sheet_test.dart test/features/agent_chat/presentation/widgets/skill_action_trace_card_test.dart`
* Manual testing:
  * `flutter analyze lib/features/agent_chat/presentation/widgets/manage_skills_sheet.dart lib/features/agent_chat/presentation/widgets/skill_action_trace_card.dart test/features/agent_chat/presentation/widgets/manage_skills_sheet_test.dart test/features/agent_chat/presentation/widgets/skill_action_trace_card_test.dart`

---

# Notes

* Closes #232
