### PR TITLE
feat(agent-chat): finish calendar connector coverage

### DIFF
--- a/app/android/app/src/main/kotlin/io/airo/app/MainActivity.kt
+++ b/app/android/app/src/main/kotlin/io/airo/app/MainActivity.kt
@@ -25,6 +25,7 @@ class MainActivity : FlutterActivity() {
 
     private var pendingCalendarResult: MethodChannel.Result? = null
     private var pendingCalendarDate: String? = null
+    private var pendingCalendarEndDate: String? = null
     private var pendingCalendarCreateResult: MethodChannel.Result? = null
     private var pendingCalendarCreateArguments: Map<String, Any?>? = null
 
@@ -50,13 +51,14 @@ class MainActivity : FlutterActivity() {
                 when (call.method) {
                     "readCalendarEvents" -> {
                         val date = call.argument<String>("date")
+                        val endDate = call.argument<String>("end_date")
                         if (date.isNullOrBlank()) {
                             result.success(mapOf(
                                 "error" to "missing_date",
                                 "message" to "Calendar lookup requires a date."
                             ))
                         } else {
-                            readCalendarEvents(date, result)
+                            readCalendarEvents(date, endDate, result)
                         }
                     }
                     "createCalendarEvent" -> {
@@ -86,13 +88,15 @@ class MainActivity : FlutterActivity() {
             CALENDAR_READ_PERMISSION_REQUEST -> {
                 val result = pendingCalendarResult
                 val date = pendingCalendarDate
+                val endDate = pendingCalendarEndDate
                 pendingCalendarResult = null
                 pendingCalendarDate = null
+                pendingCalendarEndDate = null
 
                 if (result == null || date == null) return
 
                 if (grantResults.isNotEmpty() && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
-                    readCalendarEvents(date, result)
+                    readCalendarEvents(date, endDate, result)
                 } else {
                     result.success(mapOf(
                         "error" to "calendar_permission_denied",
@@ -120,37 +124,66 @@ class MainActivity : FlutterActivity() {
         }
     }
 
-    private fun readCalendarEvents(date: String, result: MethodChannel.Result) {
+    private fun readCalendarEvents(date: String, endDate: String?, result: MethodChannel.Result) {
         if (checkSelfPermission(Manifest.permission.READ_CALENDAR) != PackageManager.PERMISSION_GRANTED) {
             pendingCalendarResult = result
             pendingCalendarDate = date
+            pendingCalendarEndDate = endDate
             requestPermissions(arrayOf(Manifest.permission.READ_CALENDAR), CALENDAR_READ_PERMISSION_REQUEST)
             return
         }
 
         val dateFormat = SimpleDateFormat("yyyy-MM-dd", Locale.US)
         dateFormat.isLenient = false
-        val parsedDate = try {
+        val parsedStartDate = try {
             dateFormat.parse(date)
         } catch (_: Exception) {
             null
         }
-        if (parsedDate == null) {
+        if (parsedStartDate == null) {
             result.success(mapOf(
                 "error" to "invalid_date",
                 "message" to "Calendar date must use YYYY-MM-DD."
             ))
             return
         }
+        val parsedEndDate = if (endDate.isNullOrBlank()) {
+            parsedStartDate
+        } else {
+            try {
+                dateFormat.parse(endDate)
+            } catch (_: Exception) {
+                null
+            }
+        }
+        if (parsedEndDate == null) {
+            result.success(mapOf(
+                "error" to "invalid_end_date",
+                "message" to "Calendar end_date must use YYYY-MM-DD."
+            ))
+            return
+        }
+        if (parsedEndDate.before(parsedStartDate)) {
+            result.success(mapOf(
+                "error" to "invalid_date_range",
+                "message" to "Calendar end_date must be on or after date."
+            ))
+            return
+        }
 
         val start = Calendar.getInstance()
-        start.time = parsedDate
+        start.time = parsedStartDate
         start.set(Calendar.HOUR_OF_DAY, 0)
         start.set(Calendar.MINUTE, 0)
         start.set(Calendar.SECOND, 0)
         start.set(Calendar.MILLISECOND, 0)
 
-        val end = start.clone() as Calendar
+        val end = Calendar.getInstance()
+        end.time = parsedEndDate
+        end.set(Calendar.HOUR_OF_DAY, 0)
+        end.set(Calendar.MINUTE, 0)
+        end.set(Calendar.SECOND, 0)
+        end.set(Calendar.MILLISECOND, 0)
         end.add(Calendar.DAY_OF_MONTH, 1)
 
         val builder = CalendarContract.Instances.CONTENT_URI.buildUpon()
@@ -193,7 +226,15 @@ class MainActivity : FlutterActivity() {
                     ))
                 }
             }
-            result.success(mapOf("date" to date, "events" to events))
+            result.success(
+                buildMap<String, Any?> {
+                    put("date", date)
+                    if (!endDate.isNullOrBlank()) {
+                        put("end_date", endDate)
+                    }
+                    put("events", events)
+                }
+            )
         } catch (error: Exception) {
             result.success(mapOf(
                 "error" to "calendar_read_failed",

--- a/app/ios/Runner/AppDelegate.swift
+++ b/app/ios/Runner/AppDelegate.swift
@@ -37,7 +37,11 @@ import UIKit
             ])
             return
           }
-          self?.readCalendarEvents(date: date, result: result)
+          self?.readCalendarEvents(
+            date: date,
+            endDate: arguments["end_date"] as? String,
+            result: result
+          )
         case "createCalendarEvent":
           guard let arguments = call.arguments as? [String: Any] else {
             result([
@@ -56,7 +60,11 @@ import UIKit
     return super.application(application, didFinishLaunchingWithOptions: launchOptions)
   }
 
-  private func readCalendarEvents(date: String, result: @escaping FlutterResult) {
+  private func readCalendarEvents(
+    date: String,
+    endDate: String?,
+    result: @escaping FlutterResult
+  ) {
     requestCalendarAccess { [weak self] granted in
       guard let self else { return }
       guard granted else {
@@ -75,7 +83,28 @@ import UIKit
         return
       }
 
-      guard let endDate = Calendar.current.date(byAdding: .day, value: 1, to: startDate) else {
+      let inclusiveEndDate: Date
+      if let endDate, !endDate.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+        guard let parsedEndDate = self.dayStart(from: endDate) else {
+          result([
+            "error": "invalid_end_date",
+            "message": "Calendar end_date must use YYYY-MM-DD.",
+          ])
+          return
+        }
+        guard parsedEndDate >= startDate else {
+          result([
+            "error": "invalid_date_range",
+            "message": "Calendar end_date must be on or after date.",
+          ])
+          return
+        }
+        inclusiveEndDate = parsedEndDate
+      } else {
+        inclusiveEndDate = startDate
+      }
+
+      guard let queryEndDate = Calendar.current.date(byAdding: .day, value: 1, to: inclusiveEndDate) else {
         result([
           "error": "invalid_date",
           "message": "Calendar date must use YYYY-MM-DD.",
@@ -85,7 +114,7 @@ import UIKit
 
       let predicate = self.eventStore.predicateForEvents(
         withStart: startDate,
-        end: endDate,
+        end: queryEndDate,
         calendars: nil
       )
       let formatter = ISO8601DateFormatter()
@@ -105,10 +134,14 @@ import UIKit
           return payload
         }
 
-      result([
+      var payload: [String: Any] = [
         "date": date,
         "events": events,
-      ])
+      ]
+      if let endDate, !endDate.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+        payload["end_date"] = endDate
+      }
+      result(payload)
     }
   }
 

--- a/app/lib/features/agent_chat/data/connectors/calendar_connector.dart
+++ b/app/lib/features/agent_chat/data/connectors/calendar_connector.dart
@@ -49,11 +49,29 @@ class InMemoryCalendarConnector implements AgentConnector {
         message: 'read_calendar_events requires a date.',
       );
     }
+    final endDate = arguments['end_date'] as String?;
+    if (endDate != null &&
+        endDate.isNotEmpty &&
+        !_isValidIsoDate(endDate)) {
+      return const ConnectorResult.error(
+        code: 'invalid_end_date',
+        message: 'read_calendar_events end_date must be YYYY-MM-DD.',
+      );
+    }
 
+    final requestedDates = _expandRequestedDates(date, endDate);
+    if (requestedDates == null) {
+      return const ConnectorResult.error(
+        code: 'invalid_date_range',
+        message: 'read_calendar_events end_date must be on or after date.',
+      );
+    }
     return ConnectorResult(
       data: {
         'date': date,
-        'events': (_events[date] ?? const [])
+        if (endDate != null && endDate.isNotEmpty) 'end_date': endDate,
+        'events': requestedDates
+            .expand((requestedDate) => _events[requestedDate] ?? const [])
             .map((event) => event.toJson())
             .toList(),
       },
@@ -112,7 +130,12 @@ class NativeCalendarConnector implements AgentConnector {
     try {
       final response = await _channel.invokeMapMethod<String, dynamic>(
         'readCalendarEvents',
-        {'date': date},
+        {
+          'date': date,
+          if (arguments['end_date'] case final String endDate
+              when endDate.isNotEmpty)
+            'end_date': endDate,
+        },
       );
       if (response == null) {
         return ConnectorResult(data: {'date': date, 'events': const []});
@@ -243,4 +266,28 @@ int? _readInt(Object? value) {
   if (value is num) return value.toInt();
   if (value is String) return int.tryParse(value);
   return null;
+}
+
+bool _isValidIsoDate(String value) {
+  return RegExp(r'^\d{4}-\d{2}-\d{2}$').hasMatch(value);
+}
+
+List<String>? _expandRequestedDates(String date, String? endDate) {
+  if (!_isValidIsoDate(date)) return null;
+  if (endDate == null || endDate.isEmpty) return [date];
+  if (!_isValidIsoDate(endDate)) return null;
+
+  final start = DateTime.tryParse(date);
+  final end = DateTime.tryParse(endDate);
+  if (start == null || end == null || end.isBefore(start)) return null;
+
+  final dates = <String>[];
+  for (
+    var current = start;
+    !current.isAfter(end);
+    current = current.add(const Duration(days: 1))
+  ) {
+    dates.add(current.toIso8601String().substring(0, 10));
+  }
+  return dates;
 }

--- a/app/test/features/agent_chat/data/connectors/calendar_connector_test.dart
+++ b/app/test/features/agent_chat/data/connectors/calendar_connector_test.dart
@@ -3,67 +3,168 @@ import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
-  group('NativeCalendarConnector', () {
-    test('reads events through the native calendar method channel', () async {
-      TestWidgetsFlutterBinding.ensureInitialized();
-      const channel = MethodChannel('test.agent_connectors.calendar_read');
-      final calls = <MethodCall>[];
+  TestWidgetsFlutterBinding.ensureInitialized();
 
-      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-          .setMockMethodCallHandler(channel, (call) async {
-            calls.add(call);
-            return {
-              'date': call.arguments['date'],
-              'events': [
-                {
-                  'title': 'Design review',
-                  'start': '2026-06-22T10:00:00+05:30',
-                  'end': '2026-06-22T10:30:00+05:30',
-                  'calendar': 'Work',
-                },
-              ],
-            };
-          });
-      addTearDown(() {
-        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-            .setMockMethodCallHandler(channel, null);
+  const channelName = 'com.airo.agent_connectors';
+  const methodChannel = MethodChannel(channelName);
+
+  tearDown(() async {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(methodChannel, null);
+  });
+
+  group('InMemoryCalendarConnector', () {
+    test('returns events for a requested date range', () async {
+      final connector = InMemoryCalendarConnector(
+        events: {
+          '2026-06-20': const [
+            CalendarEventData(
+              title: 'Team standup',
+              start: '2026-06-20T10:00:00+05:30',
+              end: '2026-06-20T10:30:00+05:30',
+              calendar: 'Work',
+            ),
+          ],
+          '2026-06-21': const [
+            CalendarEventData(
+              title: 'Doctor visit',
+              start: '2026-06-21T09:00:00+05:30',
+              end: '2026-06-21T09:30:00+05:30',
+              calendar: 'Personal',
+            ),
+          ],
+        },
+      );
+
+      final result = await connector.execute({
+        'date': '2026-06-20',
+        'end_date': '2026-06-21',
       });
 
-      final connector = NativeCalendarConnector(channel: channel);
-
-      final result = await connector.execute({'date': '2026-06-22'});
-
-      expect(result.isError, isFalse);
-      expect(result.data['date'], '2026-06-22');
-      expect(result.data['events'], isA<List>());
-      expect(calls.single.method, 'readCalendarEvents');
-      expect(calls.single.arguments, {'date': '2026-06-22'});
+      expect(result.isError, false);
+      expect(result.data['date'], '2026-06-20');
+      expect(result.data['end_date'], '2026-06-21');
+      expect((result.data['events'] as List), hasLength(2));
     });
 
-    test('maps native calendar errors to connector errors', () async {
-      TestWidgetsFlutterBinding.ensureInitialized();
-      const channel = MethodChannel('test.agent_connectors.calendar_error');
+    test('rejects missing or inverted date ranges', () async {
+      final connector = InMemoryCalendarConnector();
 
-      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-          .setMockMethodCallHandler(channel, (_) async {
-            return {
-              'error': 'calendar_permission_denied',
-              'message':
-                  'Calendar permission is required to check your schedule.',
-            };
-          });
-      addTearDown(() {
-        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-            .setMockMethodCallHandler(channel, null);
+      final missingDate = await connector.execute({});
+      final invertedRange = await connector.execute({
+        'date': '2026-06-21',
+        'end_date': '2026-06-20',
       });
 
-      final connector = NativeCalendarConnector(channel: channel);
+      expect(missingDate.isError, true);
+      expect(missingDate.errorCode, 'missing_date');
+      expect(invertedRange.isError, true);
+      expect(invertedRange.errorCode, 'invalid_date_range');
+    });
+  });
 
-      final result = await connector.execute({'date': '2026-06-22'});
+  group('InMemoryCreateCalendarEventConnector', () {
+    test('records validated events', () async {
+      final connector = InMemoryCreateCalendarEventConnector();
 
-      expect(result.isError, isTrue);
+      final result = await connector.execute({
+        'title': 'Bills review',
+        'date': '2026-06-20',
+        'hour': 19,
+        'minute': 15,
+      });
+
+      expect(result.isError, false);
+      expect(connector.createdEvents, hasLength(1));
+      expect(connector.createdEvents.single['title'], 'Bills review');
+      expect(result.data['created'], true);
+    });
+  });
+
+  group('NativeCalendarConnector', () {
+    test('passes date range arguments to the platform channel', () async {
+      late MethodCall capturedCall;
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(methodChannel, (call) async {
+            capturedCall = call;
+            return {
+              'date': '2026-06-20',
+              'end_date': '2026-06-21',
+              'events': [],
+            };
+          });
+
+      final connector = NativeCalendarConnector(channel: methodChannel);
+      final result = await connector.execute({
+        'date': '2026-06-20',
+        'end_date': '2026-06-21',
+      });
+
+      expect(result.isError, false);
+      expect(capturedCall.method, 'readCalendarEvents');
+      expect(capturedCall.arguments, {
+        'date': '2026-06-20',
+        'end_date': '2026-06-21',
+      });
+    });
+
+    test('surfaces permission denied responses', () async {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(methodChannel, (_) async {
+            return {
+              'error': 'calendar_permission_denied',
+              'message': 'Calendar permission is required to check your schedule.',
+            };
+          });
+
+      final connector = NativeCalendarConnector(channel: methodChannel);
+      final result = await connector.execute({'date': '2026-06-20'});
+
+      expect(result.isError, true);
       expect(result.errorCode, 'calendar_permission_denied');
-      expect(result.message, contains('permission'));
+    });
+
+    test('falls back cleanly when the platform channel is unavailable', () async {
+      final connector = NativeCalendarConnector(channel: methodChannel);
+
+      final result = await connector.execute({'date': '2026-06-20'});
+
+      expect(result.isError, false);
+      expect(result.data['source'], 'calendar_channel_unavailable');
+    });
+  });
+
+  group('NativeCreateCalendarEventConnector', () {
+    test('surfaces permission denied responses', () async {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(methodChannel, (_) async {
+            return {
+              'error': 'calendar_permission_denied',
+              'message': 'Calendar permission is required to add this event.',
+            };
+          });
+
+      final connector = NativeCreateCalendarEventConnector(channel: methodChannel);
+      final result = await connector.execute({
+        'title': 'Bills review',
+        'date': '2026-06-20',
+        'hour': 19,
+      });
+
+      expect(result.isError, true);
+      expect(result.errorCode, 'calendar_permission_denied');
+    });
+
+    test('returns unavailable error when the platform channel is missing', () async {
+      final connector = NativeCreateCalendarEventConnector(channel: methodChannel);
+      final result = await connector.execute({
+        'title': 'Bills review',
+        'date': '2026-06-20',
+        'hour': 19,
+      });
+
+      expect(result.isError, true);
+      expect(result.errorCode, 'calendar_write_unavailable');
     });
   });
 }


### PR DESCRIPTION
# PR Title

feat(agent-chat): finish calendar connector coverage

---

# Summary

This PR introduces changes to the agent calendar connector stack.
Goal: finish the remaining connector/runtime slice needed to close issue `#230`.

Core outcome:

* adds optional date-range support for calendar reads while preserving single-date behavior
* keeps native permission-denied and unavailable paths deterministic
* adds connector tests for fake adapters and native error handling

---

# Changes

### Code

* Updated:
  * `app/lib/features/agent_chat/data/connectors/calendar_connector.dart`
  * `app/android/app/src/main/kotlin/io/airo/app/MainActivity.kt`
  * `app/ios/Runner/AppDelegate.swift`
* Added:
  * `app/test/features/agent_chat/data/connectors/calendar_connector_test.dart`

### Logic

* supports optional `end_date` for calendar reads in in-memory, Android, and iOS connectors
* validates invalid or inverted date ranges deterministically
* verifies fake calendar connectors and create-event adapter behavior
* verifies permission-denied and channel-unavailable native connector behavior

---

# Risks

* low-to-moderate risk: small runtime change in calendar channel handling on Android/iOS
* rollout risk is limited to calendar read/create connector paths
* Rollback plan:
  * revert this PR if native calendar range handling causes platform regressions

---

# Testing

* Unit tests:
  * `flutter test test/features/agent_chat/data/connectors/calendar_connector_test.dart`
* Manual testing:
  * `flutter analyze lib/features/agent_chat/data/connectors/calendar_connector.dart test/features/agent_chat/data/connectors/calendar_connector_test.dart`

---

# Notes

* Closes #230
