### PR TITLE
feat(meeting): add native channel contracts

### DIFF
--- a/app/lib/features/meeting/domain/entities/meeting_segment.dart
+++ b/app/lib/features/meeting/domain/entities/meeting_segment.dart
@@ -1,0 +1,71 @@
+import 'transcript_chunk.dart';
+
+class MeetingSegment {
+  const MeetingSegment({
+    required this.id,
+    required this.meetingId,
+    required this.text,
+    required this.startMs,
+    required this.endMs,
+    required this.isFinal,
+    this.speakerLabel,
+    this.confidence,
+  });
+
+  factory MeetingSegment.fromTranscriptChunk(TranscriptChunk chunk) {
+    return MeetingSegment(
+      id: chunk.id,
+      meetingId: chunk.meetingId,
+      text: chunk.text,
+      startMs: chunk.startMs,
+      endMs: chunk.endMs,
+      isFinal: chunk.isFinal,
+      speakerLabel: chunk.speakerLabel,
+      confidence: chunk.confidence,
+    );
+  }
+
+  final String id;
+  final String meetingId;
+  final String text;
+  final int startMs;
+  final int endMs;
+  final bool isFinal;
+  final String? speakerLabel;
+  final double? confidence;
+
+  TranscriptChunk toTranscriptChunk() {
+    return TranscriptChunk(
+      id: id,
+      meetingId: meetingId,
+      text: text,
+      startMs: startMs,
+      endMs: endMs,
+      isFinal: isFinal,
+      speakerLabel: speakerLabel,
+      confidence: confidence,
+    );
+  }
+
+  MeetingSegment copyWith({
+    String? id,
+    String? meetingId,
+    String? text,
+    int? startMs,
+    int? endMs,
+    bool? isFinal,
+    String? speakerLabel,
+    double? confidence,
+  }) {
+    return MeetingSegment(
+      id: id ?? this.id,
+      meetingId: meetingId ?? this.meetingId,
+      text: text ?? this.text,
+      startMs: startMs ?? this.startMs,
+      endMs: endMs ?? this.endMs,
+      isFinal: isFinal ?? this.isFinal,
+      speakerLabel: speakerLabel ?? this.speakerLabel,
+      confidence: confidence ?? this.confidence,
+    );
+  }
+}

--- a/app/lib/features/meeting/infrastructure/platform/native_meeting_contracts.dart
+++ b/app/lib/features/meeting/infrastructure/platform/native_meeting_contracts.dart
@@ -1,0 +1,239 @@
+import 'package:flutter/services.dart';
+
+import '../../domain/entities/meeting_audio_metadata.dart';
+import '../../domain/entities/meeting_record.dart';
+import '../../domain/entities/transcript_chunk.dart';
+
+const meetingRecorderChannelName = 'com.airo.meeting/recorder';
+const meetingTranscriptionChannelName = 'com.airo.meeting/transcription';
+const meetingTranscriptionEventsChannelName =
+    'com.airo.meeting/transcription_events';
+
+class NativeMeetingRecorderContract {
+  NativeMeetingRecorderContract({
+    MethodChannel channel = const MethodChannel(meetingRecorderChannelName),
+  }) : _channel = channel;
+
+  final MethodChannel _channel;
+
+  Future<void> startRecording({required MeetingRecord meeting}) async {
+    await _channel.invokeMethod<void>('startMeeting', {
+      'meetingId': meeting.id,
+      'title': meeting.title,
+      'startedAt': meeting.startedAt.toUtc().toIso8601String(),
+      if (meeting.languageCode case final String languageCode)
+        'languageCode': languageCode,
+    });
+  }
+
+  Future<void> pauseRecording({required String meetingId}) async {
+    await _channel.invokeMethod<void>('pauseMeeting', {'meetingId': meetingId});
+  }
+
+  Future<void> resumeRecording({required String meetingId}) async {
+    await _channel.invokeMethod<void>('resumeMeeting', {
+      'meetingId': meetingId,
+    });
+  }
+
+  Future<MeetingAudioMetadata> stopRecording({
+    required String meetingId,
+  }) async {
+    final response = await _channel.invokeMapMethod<String, Object?>(
+      'stopMeeting',
+      {'meetingId': meetingId},
+    );
+    return _audioMetadataFromMap(response, fallbackMeetingId: meetingId);
+  }
+
+  Future<void> cancelRecording({required String meetingId}) async {
+    await _channel.invokeMethod<void>('cancelMeeting', {
+      'meetingId': meetingId,
+    });
+  }
+}
+
+class NativeMeetingTranscriptionContract {
+  NativeMeetingTranscriptionContract({
+    MethodChannel channel = const MethodChannel(
+      meetingTranscriptionChannelName,
+    ),
+    EventChannel eventChannel = const EventChannel(
+      meetingTranscriptionEventsChannelName,
+    ),
+    Stream<Object?> Function(EventChannel channel)? eventStreamFactory,
+  }) : _channel = channel,
+       _eventChannel = eventChannel,
+       _eventStreamFactory = eventStreamFactory ?? _defaultEventStreamFactory;
+
+  final MethodChannel _channel;
+  final EventChannel _eventChannel;
+  final Stream<Object?> Function(EventChannel channel) _eventStreamFactory;
+
+  Stream<TranscriptChunk> transcriptEvents() {
+    return _eventStreamFactory(
+      _eventChannel,
+    ).map((event) => _transcriptChunkFromMap(_requireMap(event, 'event')));
+  }
+
+  Future<void> startRealtimeTranscription({
+    required String meetingId,
+    required String languageCode,
+  }) async {
+    await _channel.invokeMethod<void>('startRealtimeTranscription', {
+      'meetingId': meetingId,
+      'languageCode': languageCode,
+    });
+  }
+
+  Future<void> pauseRealtimeTranscription({required String meetingId}) async {
+    await _channel.invokeMethod<void>('pauseRealtimeTranscription', {
+      'meetingId': meetingId,
+    });
+  }
+
+  Future<void> resumeRealtimeTranscription({required String meetingId}) async {
+    await _channel.invokeMethod<void>('resumeRealtimeTranscription', {
+      'meetingId': meetingId,
+    });
+  }
+
+  Future<void> stopRealtimeTranscription({required String meetingId}) async {
+    await _channel.invokeMethod<void>('stopRealtimeTranscription', {
+      'meetingId': meetingId,
+    });
+  }
+
+  static Stream<Object?> _defaultEventStreamFactory(EventChannel channel) {
+    return channel.receiveBroadcastStream();
+  }
+}
+
+MeetingAudioMetadata _audioMetadataFromMap(
+  Map<String, Object?>? payload, {
+  required String fallbackMeetingId,
+}) {
+  final map = _requireMap(payload, 'audio metadata');
+  return MeetingAudioMetadata(
+    meetingId:
+        _optionalString(map, 'meetingId') ??
+        _optionalString(map, 'meeting_id') ??
+        fallbackMeetingId,
+    filePath: _requiredString(map, 'filePath', aliases: const ['file_path']),
+    codec: _requiredString(map, 'codec'),
+    sampleRateHz: _requiredInt(
+      map,
+      'sampleRateHz',
+      aliases: const ['sample_rate_hz'],
+    ),
+    channelCount: _requiredInt(
+      map,
+      'channelCount',
+      aliases: const ['channel_count'],
+    ),
+    sizeBytes: _requiredInt(map, 'sizeBytes', aliases: const ['size_bytes']),
+    sha256: _requiredString(map, 'sha256'),
+  );
+}
+
+TranscriptChunk _transcriptChunkFromMap(Map<String, Object?> map) {
+  return TranscriptChunk(
+    id: _requiredString(map, 'id'),
+    meetingId: _requiredString(map, 'meetingId', aliases: const ['meeting_id']),
+    text: _requiredString(map, 'text'),
+    startMs: _requiredInt(map, 'startMs', aliases: const ['start_ms']),
+    endMs: _requiredInt(map, 'endMs', aliases: const ['end_ms']),
+    isFinal: _requiredBool(map, 'isFinal', aliases: const ['is_final']),
+    speakerLabel: _optionalString(
+      map,
+      'speakerLabel',
+      aliases: const ['speaker_label'],
+    ),
+    confidence: _optionalDouble(map, 'confidence'),
+  );
+}
+
+Map<String, Object?> _requireMap(Object? payload, String label) {
+  if (payload is Map<Object?, Object?>) {
+    return payload.map((key, value) => MapEntry('$key', value));
+  }
+  throw FormatException('Expected $label payload to be a map.');
+}
+
+Object? _lookup(
+  Map<String, Object?> map,
+  String key, {
+  List<String> aliases = const [],
+}) {
+  if (map.containsKey(key)) {
+    return map[key];
+  }
+  for (final alias in aliases) {
+    if (map.containsKey(alias)) {
+      return map[alias];
+    }
+  }
+  return null;
+}
+
+String _requiredString(
+  Map<String, Object?> map,
+  String key, {
+  List<String> aliases = const [],
+}) {
+  final value = _lookup(map, key, aliases: aliases);
+  if (value is String && value.isNotEmpty) {
+    return value;
+  }
+  throw FormatException('Expected "$key" to be a non-empty string.');
+}
+
+String? _optionalString(
+  Map<String, Object?> map,
+  String key, {
+  List<String> aliases = const [],
+}) {
+  final value = _lookup(map, key, aliases: aliases);
+  if (value == null) {
+    return null;
+  }
+  if (value is String && value.isNotEmpty) {
+    return value;
+  }
+  throw FormatException('Expected "$key" to be a non-empty string.');
+}
+
+int _requiredInt(
+  Map<String, Object?> map,
+  String key, {
+  List<String> aliases = const [],
+}) {
+  final value = _lookup(map, key, aliases: aliases);
+  if (value is int) {
+    return value;
+  }
+  throw FormatException('Expected "$key" to be an int.');
+}
+
+bool _requiredBool(
+  Map<String, Object?> map,
+  String key, {
+  List<String> aliases = const [],
+}) {
+  final value = _lookup(map, key, aliases: aliases);
+  if (value is bool) {
+    return value;
+  }
+  throw FormatException('Expected "$key" to be a bool.');
+}
+
+double? _optionalDouble(Map<String, Object?> map, String key) {
+  final value = map[key];
+  if (value == null) {
+    return null;
+  }
+  if (value is num) {
+    return value.toDouble();
+  }
+  throw FormatException('Expected "$key" to be numeric.');
+}

--- a/app/test/features/meeting/native_meeting_contracts_test.dart
+++ b/app/test/features/meeting/native_meeting_contracts_test.dart
@@ -1,0 +1,180 @@
+import 'package:airo_app/features/meeting/domain/entities/meeting_record.dart';
+import 'package:airo_app/features/meeting/domain/entities/meeting_segment.dart';
+import 'package:airo_app/features/meeting/domain/entities/transcript_chunk.dart';
+import 'package:airo_app/features/meeting/infrastructure/platform/native_meeting_contracts.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const recorderChannel = MethodChannel(meetingRecorderChannelName);
+  const transcriptionChannel = MethodChannel(meetingTranscriptionChannelName);
+
+  tearDown(() async {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(recorderChannel, null);
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(transcriptionChannel, null);
+  });
+
+  group('NativeMeetingRecorderContract', () {
+    test('sends a strict typed payload when starting a recording', () async {
+      late MethodCall capturedCall;
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(recorderChannel, (call) async {
+            capturedCall = call;
+            return null;
+          });
+
+      final contract = NativeMeetingRecorderContract(channel: recorderChannel);
+      await contract.startRecording(
+        meeting: MeetingRecord.started(
+          id: 'meeting-239',
+          title: 'Live Notes foundation',
+          startedAt: DateTime.utc(2026, 6, 27, 5, 0),
+          languageCode: 'en-IN',
+        ),
+      );
+
+      expect(capturedCall.method, 'startMeeting');
+      expect(capturedCall.arguments, {
+        'meetingId': 'meeting-239',
+        'title': 'Live Notes foundation',
+        'startedAt': '2026-06-27T05:00:00.000Z',
+        'languageCode': 'en-IN',
+      });
+    });
+
+    test('parses strict typed audio metadata from stop responses', () async {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(recorderChannel, (call) async {
+            expect(call.method, 'stopMeeting');
+            return {
+              'meetingId': 'meeting-239',
+              'filePath': '/tmp/meeting-239.wav',
+              'codec': 'wav',
+              'sampleRateHz': 16000,
+              'channelCount': 1,
+              'sizeBytes': 4096,
+              'sha256': 'abc123',
+            };
+          });
+
+      final contract = NativeMeetingRecorderContract(channel: recorderChannel);
+      final metadata = await contract.stopRecording(meetingId: 'meeting-239');
+
+      expect(metadata.meetingId, 'meeting-239');
+      expect(metadata.filePath, '/tmp/meeting-239.wav');
+      expect(metadata.sampleRateHz, 16000);
+    });
+
+    test('rejects malformed recorder payloads deterministically', () async {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(recorderChannel, (_) async {
+            return {
+              'filePath': '/tmp/meeting-239.wav',
+              'codec': 'wav',
+              'sampleRateHz': '16000',
+              'channelCount': 1,
+              'sizeBytes': 4096,
+              'sha256': 'abc123',
+            };
+          });
+
+      final contract = NativeMeetingRecorderContract(channel: recorderChannel);
+
+      await expectLater(
+        () => contract.stopRecording(meetingId: 'meeting-239'),
+        throwsA(isA<FormatException>()),
+      );
+    });
+  });
+
+  group('NativeMeetingTranscriptionContract', () {
+    test('sends strict start args to the transcription channel', () async {
+      late MethodCall capturedCall;
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(transcriptionChannel, (call) async {
+            capturedCall = call;
+            return null;
+          });
+
+      final contract = NativeMeetingTranscriptionContract(
+        channel: transcriptionChannel,
+      );
+      await contract.startRealtimeTranscription(
+        meetingId: 'meeting-239',
+        languageCode: 'en-IN',
+      );
+
+      expect(capturedCall.method, 'startRealtimeTranscription');
+      expect(capturedCall.arguments, {
+        'meetingId': 'meeting-239',
+        'languageCode': 'en-IN',
+      });
+    });
+
+    test('parses transcript events into strict typed chunks', () async {
+      final contract = NativeMeetingTranscriptionContract(
+        channel: transcriptionChannel,
+        eventStreamFactory: (_) => Stream<Object?>.value({
+          'id': 'chunk-1',
+          'meetingId': 'meeting-239',
+          'text': 'Action: ship strict contracts.',
+          'startMs': 0,
+          'endMs': 1200,
+          'isFinal': true,
+          'confidence': 0.98,
+        }),
+      );
+
+      final chunk = await contract.transcriptEvents().single;
+      final segment = MeetingSegment.fromTranscriptChunk(chunk);
+
+      expect(chunk.meetingId, 'meeting-239');
+      expect(chunk.isFinal, true);
+      expect(
+        segment.toTranscriptChunk().text,
+        'Action: ship strict contracts.',
+      );
+    });
+
+    test('rejects malformed transcript events deterministically', () async {
+      final contract = NativeMeetingTranscriptionContract(
+        channel: transcriptionChannel,
+        eventStreamFactory: (_) => Stream<Object?>.value({
+          'id': 'chunk-1',
+          'meetingId': 'meeting-239',
+          'text': 'Action: ship strict contracts.',
+          'startMs': '0',
+          'endMs': 1200,
+          'isFinal': true,
+        }),
+      );
+
+      await expectLater(
+        contract.transcriptEvents(),
+        emitsError(isA<FormatException>()),
+      );
+    });
+  });
+
+  test('MeetingSegment round-trips with TranscriptChunk', () {
+    const chunk = TranscriptChunk.partial(
+      id: 'chunk-2',
+      meetingId: 'meeting-239',
+      text: 'Partial transcript',
+      startMs: 10,
+      endMs: 40,
+      speakerLabel: 'Speaker 1',
+      confidence: 0.8,
+    );
+
+    final segment = MeetingSegment.fromTranscriptChunk(chunk);
+
+    expect(segment.meetingId, chunk.meetingId);
+    expect(segment.toTranscriptChunk().speakerLabel, 'Speaker 1');
+    expect(segment.toTranscriptChunk().confidence, 0.8);
+  });
+}


### PR DESCRIPTION
# Summary

This PR introduces changes to the Meeting Intelligence foundation.
Goal: define the Flutter-side recorder/transcription contract layer requested by #239 without coupling it to later native recorder implementations.

Core outcome:

* adds typed recorder and transcription platform channel contracts
* adds deterministic parsing coverage and preserves in-memory meeting scaffolding coverage

# Changes

### Code

* Added:

  * `MeetingSegment` domain entity for transcript scaffolding
  * `NativeMeetingRecorderContract` and `NativeMeetingTranscriptionContract`
  * focused contract tests for strict method payloads and malformed native responses

### Logic

* defines `com.airo.meeting/recorder` and `com.airo.meeting/transcription` channel wrappers in Flutter
* validates required payload fields instead of allowing dynamic maps to leak across the contract boundary
* verifies the in-memory meeting slice still passes alongside the new channel tests

# API Changes (if any)

* Platform channels:

  * `com.airo.meeting/recorder`
  * `com.airo.meeting/transcription`
  * `com.airo.meeting/transcription_events`

# Risks

* Native Android/iOS handlers are still follow-up work in the platform integration tickets.
* The contract is intentionally strict, so malformed native payloads will now fail fast.
* Rollback plan:

  * revert this PR to remove the new contract layer and tests

# Testing

* Unit tests:

  * `flutter test test/features/meeting/native_meeting_contracts_test.dart test/features/meeting/meeting_intelligence_local_slice_test.dart`
* Manual testing:

  * not run; this PR is contract/test-only

# Notes

* `flutter analyze` reported no code issues, but the Flutter tool crashed afterward in local iOS plugin symlink generation. The code was additionally verified with the passing test suite above.

Closes #239
