### PR TITLE
docs(mobile-ui): add shell governance packet

### DIFF
--- a/docs/adr/0006-mobile-ui-governance-and-shell-ownership.md
+++ b/docs/adr/0006-mobile-ui-governance-and-shell-ownership.md
@@ -1,0 +1,77 @@
+# ADR-0006: Mobile UI Governance and Shell Ownership
+
+## Status
+
+Accepted
+
+## Date
+
+2026-06-27
+
+## Context
+
+Airo's shell currently mixes shared and local UI responsibilities. Root shell
+surfaces own global chrome, but feature screens can still render local `AppBar`
+instances, hardcode destination behavior, and reference shell imagery directly.
+This leads to duplicate headers, inconsistent navigation behavior, and repeated
+visual decisions across unrelated features.
+
+The repo also needs a durable governance layer so future UI changes do not
+reopen the same shell ownership questions.
+
+## Decision
+
+We establish Mobile UI governance with the following rules:
+
+1. Shared shell code owns global chrome, route-to-header behavior, and primary
+   destination metadata.
+2. Feature screens own content presentation, but not shell-level header or
+   navigation policy.
+3. For any route state, exactly one layer owns the visible top header:
+   shell-owned, route-owned, or intentionally hidden for immersive flows.
+4. Shared token roles, navigation metadata, and shell asset references must be
+   centralized before feature-level UI changes are accepted.
+5. Governance docs must exist in the repo so follow-up execution issues can
+   implement shell/header, token/navigation, and asset work against a stable
+   contract.
+
+## Consequences
+
+### Positive
+
+- reduces duplicate header regressions
+- gives feature teams a clear shell boundary
+- centralizes navigation and shared visual decisions
+- lets implementation work be split into smaller focused issues
+
+### Negative
+
+- adds upfront process for UI work that previously changed screens directly
+- may require migration work across legacy screens before consistency improves
+
+### Risks
+
+- governance can drift if follow-up UI work does not update the shared docs
+- partial migration may temporarily leave mixed old and new shell behavior
+
+## Alternatives Considered
+
+### Alternative 1: Let each feature own its own header and nav affordances
+
+Rejected because it preserves duplicate app bars, inconsistent shell behavior,
+and repeated route-level decisions.
+
+### Alternative 2: Solve only the current duplicate header bug without docs
+
+Rejected because the repo has repeated shell, token, and asset governance gaps,
+not just one header bug.
+
+## Related Decisions
+
+- [ADR-0001](0001-package-structure.md) - Modular package ownership boundaries
+
+## References
+
+- [Mobile UI Agent Packet](../agents/mobile-ui-agent/README.md)
+- [Mobile UI / UX Standards](../standards/mobile-ui-ux-standards.md)
+- [Issue #397](https://github.com/DevelopersCoffee/airo/issues/397)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -11,9 +11,7 @@ An Architecture Decision Record (ADR) captures an important architectural decisi
 | ID | Title | Status | Date |
 |----|-------|--------|------|
 | [0001](0001-package-structure.md) | Modular Package Structure | Accepted | 2025-11-30 |
-| [0002](0002-state-management.md) | Riverpod for State Management | Accepted | 2025-11-30 |
-| [0003](0003-offline-first.md) | Offline-First Architecture | Accepted | 2025-11-30 |
-| [0004](0004-ai-abstraction.md) | AI Provider Abstraction Layer | Accepted | 2025-11-30 |
+| [0006](0006-mobile-ui-governance-and-shell-ownership.md) | Mobile UI Governance and Shell Ownership | Accepted | 2026-06-27 |
 
 ## Creating a New ADR
 

--- a/docs/agents/index.md
+++ b/docs/agents/index.md
@@ -10,6 +10,7 @@
 | [📜 Rules](./RULES.md) | Agent operating rules |
 | [🧭 Agent Policy](./AGENT_POLICY.md) | Ownership, lifecycle gates, contracts, and Critical Agent workflow |
 | [🧪 Kaggle Adoption](./KAGGLE_VIBE_CODING_ADOPTION.md) | Spec-driven, skills, tools, security, and evaluation adoption plan |
+| [📱 Mobile UI Agent](./mobile-ui-agent/README.md) | Shell ownership, header governance, UI standards, and execution tasks |
 | [🔄 SDLC](./SDLC.md) | Development workflow |
 | [📅 Sequence](./SEQUENCE.md) | Agent activation order |
 

--- a/docs/agents/mobile-ui-agent/README.md
+++ b/docs/agents/mobile-ui-agent/README.md
@@ -1,0 +1,55 @@
+# Mobile UI Agent
+
+The Mobile UI Agent owns shell chrome, navigation presentation, header
+ownership policy, shared mobile layout standards, and the governance documents
+that keep feature teams from making independent shell decisions.
+
+## Scope
+
+The Mobile UI Agent is the primary owner for:
+
+- shell-level app chrome in `app/lib/core/app/*`
+- shared route presentation and destination affordances
+- mobile header ownership rules
+- shared mobile visual standards and density guardrails
+- shared asset usage rules for shell imagery and iconography
+
+The Mobile UI Agent reviews, but does not solely own:
+
+- shared theme token foundations in `packages/core_ui`
+- cross-cutting shell/runtime contracts with `agent/core-architecture`
+- docs updates that change repo-wide workflow guidance
+
+## Boundaries
+
+Feature screens own feature content and local task flows. They do not own:
+
+- the global shell header
+- the primary destination model
+- shell branding asset selection
+- breakpoint-wide navigation behavior
+
+If a feature needs contextual chrome, it must declare that need through the
+shared shell configuration and ADR-backed route ownership rules.
+
+## Required Inputs Before Implementation
+
+Every Mobile UI issue must include:
+
+- a completed Critical Agent Gate
+- route ownership impact and affected shell surfaces
+- deterministic use cases for mobile and large-screen behavior
+- widget or route-flow automation coverage expectations
+- explicit ownership when shell code and feature screens both change
+
+## Governance Artifacts
+
+- UI standards: [../../standards/mobile-ui-ux-standards.md](../../standards/mobile-ui-ux-standards.md)
+- ADR: [../../adr/0006-mobile-ui-governance-and-shell-ownership.md](../../adr/0006-mobile-ui-governance-and-shell-ownership.md)
+- Task tracker: [./TASKS.md](./TASKS.md)
+
+## Current Execution Issues
+
+- `#398` UIUX-002: Consolidate shell and page header ownership
+- `#399` UIUX-003: Centralize theme tokens and navigation configuration
+- `#400` UIUX-004: Centralize shell asset management and chrome hygiene

--- a/docs/agents/mobile-ui-agent/TASKS.md
+++ b/docs/agents/mobile-ui-agent/TASKS.md
@@ -1,0 +1,48 @@
+# Mobile UI Agent Tasks
+
+**Context**: Airo shell chrome and navigation decisions need a shared mobile UI
+governance layer before more feature screens keep evolving independently.
+
+**Goal**: Document shell/header ownership, standards, and execution sequencing
+for mobile UI work.
+
+## Governance Deliverables
+
+### 1. Mobile UI agent packet - [x] DONE
+
+- [x] Define ownership boundaries for shell chrome, navigation, and shared
+  mobile presentation
+- [x] Document required issue inputs before implementation
+- [x] Link the governing standards and ADR artifacts
+
+### 2. Shell/header ADR - [x] DONE
+
+- [x] Record the shell-versus-route ownership rule
+- [x] Define when fullscreen and contextual headers are allowed
+- [x] Capture the consequences and rollout expectations
+
+### 3. Shared UI standards - [x] DONE
+
+- [x] Define token, header, navigation, and asset governance rules
+- [x] Clarify feature-team constraints versus shared-shell ownership
+- [x] Provide verification expectations for follow-up UI work
+
+### 4. Child implementation queue - [x] READY
+
+- [x] `#398` header ownership consolidation
+- [x] `#399` theme tokens and navigation centralization
+- [x] `#400` shell asset registry and chrome hygiene
+
+## Verification
+
+- Governance docs exist under `docs/agents/mobile-ui-agent/`
+- ADR exists under `docs/adr/`
+- Standards doc exists under `docs/standards/`
+- Agent index links to the Mobile UI Agent packet
+- ADR index includes the new shell/header governance decision
+
+## Notes
+
+- This packet is governance-only. It intentionally does not implement the shell
+  changes tracked by `#398`, `#399`, or `#400`.
+- Future Mobile UI issues should update this task list as execution work lands.

--- a/docs/standards/mobile-ui-ux-standards.md
+++ b/docs/standards/mobile-ui-ux-standards.md
@@ -1,0 +1,106 @@
+# Mobile UI / UX Standards
+
+## Purpose
+
+This document defines the default ownership and implementation standards for
+mobile shell UI in Airo. Shared shell concerns must be configured centrally so
+feature screens do not create their own competing navigation, header, token, or
+branding rules.
+
+## Ownership Rules
+
+Shared UI code owns:
+
+- shell chrome
+- route-to-header configuration
+- primary destination metadata
+- responsive navigation behavior
+- shared shell asset registration
+- shared design token roles
+
+Feature screens own:
+
+- screen body content
+- local task interactions
+- contextual subviews inside their content area
+- feature-specific empty states and copy
+
+Feature screens must not:
+
+- add a competing shell app bar on a shell-managed route
+- hardcode new primary destinations outside shared navigation config
+- invent shared shell asset paths locally
+- redefine shared spacing, color, or typography roles ad hoc
+
+## Header Ownership Standard
+
+For any visible route state, exactly one layer owns the top header:
+
+- shell-owned header for root destinations
+- route-owned contextual header for approved nested flows
+- no visible header for immersive/fullscreen flows
+
+A route must explicitly opt into contextual or immersive behavior through
+shared configuration. Feature widgets should not silently render their own top
+app bars when mounted under shell-owned destinations.
+
+## Navigation Standard
+
+Navigation metadata must come from one source of truth that includes:
+
+- route id
+- label
+- icon pair or token reference
+- destination path
+- shell visibility behavior
+- overflow eligibility on narrow screens
+
+Primary destination overflow on phones must be handled centrally. Feature code
+must consume the shared navigation model instead of constructing its own bottom
+navigation items.
+
+## Token Standard
+
+Shared visual roles belong in centralized tokens, including:
+
+- background surfaces
+- text emphasis levels
+- accent and status colors
+- spacing scale
+- corner radius scale
+- shell elevation and divider treatments
+
+Application code may compose these tokens, but should not mint new shell-wide
+roles unless the shared token contract is updated first.
+
+## Asset Standard
+
+Shell-level logos, icons, illustrations, and shared imagery must be referenced
+through a shared registry, constant set, or equivalent accessor layer.
+
+Allowed behavior:
+
+- feature code consumes named shared assets
+- shell branding updates happen in one shared location
+
+Disallowed behavior:
+
+- duplicate raw asset paths spread across widgets
+- feature-local copies of shell iconography
+- ad hoc branding changes inside screen files
+
+## Verification Expectations
+
+Follow-up Mobile UI implementation issues should include:
+
+- widget or route tests for header ownership behavior
+- widget tests for navigation overflow or destination rendering
+- static verification that shared assets are resolved through central accessors
+- documentation updates when the shared contract changes
+
+## Related Work
+
+- Governance epic: `#397`
+- Header ownership implementation: `#398`
+- Theme and navigation centralization: `#399`
+- Shell asset centralization: `#400`


### PR DESCRIPTION
# Summary

This PR introduces changes to the Mobile UI governance layer.
Goal: satisfy #397 by adding the shared documentation contract for shell/header ownership, mobile UI standards, and execution routing before implementation work lands.

Core outcome:

* adds the Mobile UI Agent packet and task tracker
* adds an ADR and standards doc for shell/header, navigation, token, and asset governance

# Changes

### Code

* Added:

  * `docs/agents/mobile-ui-agent/README.md`
  * `docs/agents/mobile-ui-agent/TASKS.md`
  * `docs/standards/mobile-ui-ux-standards.md`
  * `docs/adr/0006-mobile-ui-governance-and-shell-ownership.md`
* Updated:

  * `docs/adr/README.md`
  * `docs/agents/index.md`

### Logic

* establishes shell-versus-route header ownership as a shared architectural decision
* defines the default governance rules for shared tokens, navigation metadata, and shell assets
* links the child execution issues `#398`, `#399`, and `#400` from the new Mobile UI agent packet

# Risks

* This is governance-only and does not implement the UI execution work yet.
* Follow-up issues must keep these docs current as shell behavior evolves.
* Rollback plan:

  * revert this PR to remove the governance packet and ADR

# Testing

* Manual verification:

  * confirmed required files exist and indexes reference them
  * ran `git diff --check` clean for the docs changes

Closes #397
