### PR TITLE
refactor(shell): centralize shared asset paths

### DIFF
--- a/app/lib/core/app/app_shell.dart
+++ b/app/lib/core/app/app_shell.dart
@@ -12,6 +12,7 @@ import '../../features/music/presentation/widgets/mini_player.dart';
 import '../../features/iptv/presentation/widgets/iptv_mini_player.dart';
 import '../../features/iptv/application/providers/iptv_providers.dart'
     hide currentNavigationTabProvider;
+import '../../shared/widgets/app_icon_placeholder.dart';
 
 /// Get initials from a name (e.g., "Uday Chauhan" -> "UC", "Uday" -> "U")
 String _getInitials(String name) {
@@ -59,10 +60,8 @@ class AppShell extends ConsumerWidget {
             borderRadius: BorderRadius.circular(20),
             child: Padding(
               padding: const EdgeInsets.all(8.0),
-              child: Image.asset(
-                'assets/images/app_icon.png',
-                width: 32,
-                height: 32,
+              child: AppIconPlaceholder(
+                size: 32,
                 errorBuilder: (_, _, _) => const Icon(Icons.home),
               ),
             ),

--- a/app/lib/core/app/tv_shell.dart
+++ b/app/lib/core/app/tv_shell.dart
@@ -8,6 +8,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
+import '../../shared/widgets/app_icon_placeholder.dart';
 import '../tv/tv.dart';
 import 'tv_router.dart';
 
@@ -109,10 +110,8 @@ class _TvNavigationRail extends ConsumerWidget {
     return Column(
       mainAxisSize: MainAxisSize.min,
       children: [
-        Image.asset(
-          'assets/images/app_icon.png',
-          width: 48,
-          height: 48,
+        AppIconPlaceholder(
+          size: 48,
           errorBuilder: (_, _, _) => const Icon(Icons.tv, size: 48),
         ),
         const SizedBox(height: 8),

--- a/app/lib/shared/assets/shell_asset_registry.dart
+++ b/app/lib/shared/assets/shell_asset_registry.dart
@@ -1,0 +1,9 @@
+/// Central registry for shell-owned branding and shared chrome imagery.
+///
+/// Shell-level widgets should depend on these identifiers instead of embedding
+/// raw asset paths in individual widgets.
+abstract final class ShellAssetRegistry {
+  static const String appIconRaster = 'assets/airo_icon.png';
+  static const String appIconVector = 'assets/airo_icon.svg';
+  static const String shellBackdrop = 'assets/hermes/images/filler-bg0.jpg';
+}

--- a/app/lib/shared/widgets/app_icon_placeholder.dart
+++ b/app/lib/shared/widgets/app_icon_placeholder.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 
+import '../assets/shell_asset_registry.dart';
+
 /// A shared widget that displays the Airo app icon as a placeholder.
 ///
 /// This widget centralizes app icon usage to:
@@ -28,8 +30,11 @@ class AppIconPlaceholder extends StatelessWidget {
   /// Use fallbackIcon directly instead of loading the app icon asset.
   final bool forceFallback;
 
+  /// Optional builder for asset load failures.
+  final ImageErrorWidgetBuilder? errorBuilder;
+
   /// Path to the app icon asset
-  static const String assetPath = 'assets/airo_icon.png';
+  static const String assetPath = ShellAssetRegistry.appIconRaster;
 
   const AppIconPlaceholder({
     super.key,
@@ -38,6 +43,7 @@ class AppIconPlaceholder extends StatelessWidget {
     this.fallbackIcon,
     this.fit = BoxFit.contain,
     this.forceFallback = false,
+    this.errorBuilder,
   });
 
   /// Creates a placeholder with padding and optional size constraints
@@ -48,6 +54,7 @@ class AppIconPlaceholder extends StatelessWidget {
     this.fallbackIcon,
     this.fit = BoxFit.contain,
     this.forceFallback = false,
+    this.errorBuilder,
   });
 
   /// Creates a placeholder for channel icons (with standard channel size)
@@ -85,8 +92,11 @@ class AppIconPlaceholder extends StatelessWidget {
         // Cache the image for better performance
         cacheWidth: size != null ? (size! * 2).toInt() : null,
         cacheHeight: size != null ? (size! * 2).toInt() : null,
-        errorBuilder: (_, _, _) =>
-            fallbackIcon ?? Icon(Icons.image, color: Colors.grey, size: size),
+        errorBuilder:
+            errorBuilder ??
+            (_, _, _) =>
+                fallbackIcon ??
+                Icon(Icons.image, color: Colors.grey, size: size),
       ),
     );
   }

--- a/app/test/shared/assets/shell_asset_registry_test.dart
+++ b/app/test/shared/assets/shell_asset_registry_test.dart
@@ -1,0 +1,18 @@
+import 'package:airo_app/shared/assets/shell_asset_registry.dart';
+import 'package:airo_app/shared/widgets/app_icon_placeholder.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('shell asset registry exposes shell-owned branding assets', () {
+    expect(ShellAssetRegistry.appIconRaster, 'assets/airo_icon.png');
+    expect(ShellAssetRegistry.appIconVector, 'assets/airo_icon.svg');
+    expect(
+      ShellAssetRegistry.shellBackdrop,
+      'assets/hermes/images/filler-bg0.jpg',
+    );
+  });
+
+  test('app icon placeholder consumes the shared shell asset registry', () {
+    expect(AppIconPlaceholder.assetPath, ShellAssetRegistry.appIconRaster);
+  });
+}

--- a/app/test/shared/widgets/app_icon_placeholder_test.dart
+++ b/app/test/shared/widgets/app_icon_placeholder_test.dart
@@ -1,0 +1,41 @@
+import 'package:airo_app/shared/widgets/app_icon_placeholder.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('renders the shared icon fallback when asset loading fails', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(
+          body: AppIconPlaceholder(
+            size: 32,
+            errorBuilder: _failingErrorBuilder,
+          ),
+        ),
+      ),
+    );
+
+    expect(find.byType(Image), findsOneWidget);
+
+    final image = tester.widget<Image>(find.byType(Image));
+    final errorWidget = image.errorBuilder?.call(
+      tester.element(find.byType(Image)),
+      FlutterError('boom'),
+      StackTrace.empty,
+    );
+
+    expect(errorWidget, isA<Icon>());
+  });
+}
+
+Widget _failingErrorBuilder(
+  BuildContext context,
+  Object error,
+  StackTrace? stackTrace,
+) {
+  return const Icon(Icons.broken_image);
+}


### PR DESCRIPTION
# Summary

This PR introduces changes to the shell asset contract.
Goal: satisfy #400 by centralizing shell-owned branding paths and removing raw shell asset strings from shared shell widgets.

Core outcome:

* adds a shared shell asset registry
* routes app and TV shell icon usage through the shared placeholder/registry contract

# Changes

### Code

* Added:

  * `app/lib/shared/assets/shell_asset_registry.dart`
  * `app/test/shared/assets/shell_asset_registry_test.dart`
  * `app/test/shared/widgets/app_icon_placeholder_test.dart`
* Updated:

  * `app/lib/shared/widgets/app_icon_placeholder.dart`
  * `app/lib/core/app/app_shell.dart`
  * `app/lib/core/app/tv_shell.dart`

### Logic

* centralizes shell-owned app icon and shared shell imagery identifiers
* removes scattered raw shell icon asset paths from the app and TV shell widgets
* keeps shared icon fallback behavior testable through `AppIconPlaceholder`

# Risks

* This only centralizes shell-level icon and imagery identifiers; feature-local imagery remains follow-up work if needed.
* Rollback plan:

  * revert this PR to restore direct asset path usage

# Testing

* Unit/widget tests:

  * `flutter test test/shared/assets/shell_asset_registry_test.dart test/shared/widgets/app_icon_placeholder_test.dart`
* Analysis:

  * `flutter analyze lib/shared/assets/shell_asset_registry.dart lib/shared/widgets/app_icon_placeholder.dart lib/core/app/app_shell.dart lib/core/app/tv_shell.dart test/shared/assets/shell_asset_registry_test.dart test/shared/widgets/app_icon_placeholder_test.dart`

Closes #400
