### PR TITLE
feat(coins): add undo and review status ui

### DIFF
--- a/app/lib/features/agent_chat/presentation/screens/chat_screen.dart
+++ b/app/lib/features/agent_chat/presentation/screens/chat_screen.dart
@@ -633,6 +633,7 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
       setState(() {
         _messages.add(ChatMessage(text: response, isUser: false));
       });
+      _showFinanceIngestionUndo(result);
       return true;
     } catch (e) {
       debugPrint('Finance SMS ingestion failed: $e');
@@ -647,6 +648,41 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
     ref.invalidate(spentThisMonthProvider);
     ref.invalidate(monthlySpendingByCategoryProvider);
     ref.invalidate(dashboardDataProvider);
+  }
+
+  void _showFinanceIngestionUndo(FinanceChatIngestionResult result) {
+    final transaction = result.transaction;
+    if (transaction == null ||
+        result.status != FinanceChatIngestionStatus.created ||
+        !mounted) {
+      return;
+    }
+
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text('Added ${transaction.description} to Coins.'),
+        action: SnackBarAction(
+          label: 'Undo',
+          onPressed: () async {
+            final deleteResult = await ref
+                .read(transactionRepositoryProvider)
+                .delete(transaction.id);
+            if (deleteResult.error != null || !mounted) {
+              return;
+            }
+            _refreshCoinsProviders();
+            setState(() {
+              _messages.add(
+                ChatMessage(
+                  text: 'Removed ${transaction.description} from Coins.',
+                  isUser: false,
+                ),
+              );
+            });
+          },
+        ),
+      ),
+    );
   }
 
   String _financeIngestionResponse(FinanceChatIngestionResult result) {

--- a/app/lib/features/coins/domain/entities/transaction.dart
+++ b/app/lib/features/coins/domain/entities/transaction.dart
@@ -10,6 +10,15 @@ enum TransactionType {
   const TransactionType(this.displayName);
 }
 
+enum TransactionReviewStatus {
+  reviewed('Reviewed'),
+  pendingReview('Pending Review');
+
+  const TransactionReviewStatus(this.label);
+
+  final String label;
+}
+
 /// Transaction entity representing a financial transaction
 ///
 /// Core business entity for expense tracking in Coins feature.
@@ -50,6 +59,14 @@ class Transaction extends Equatable {
 
   /// Get amount in major currency unit (rupees/dollars)
   double get amount => amountCents / 100;
+
+  bool get isChatIngested => tags.contains('source:chat');
+
+  TransactionReviewStatus get reviewStatus {
+    return isChatIngested
+        ? TransactionReviewStatus.pendingReview
+        : TransactionReviewStatus.reviewed;
+  }
 
   /// Create a copy with updated fields
   Transaction copyWith({

--- a/app/lib/features/coins/presentation/screens/coins_dashboard_screen.dart
+++ b/app/lib/features/coins/presentation/screens/coins_dashboard_screen.dart
@@ -6,6 +6,7 @@ import '../../domain/entities/transaction.dart';
 import '../../domain/models/budget_status.dart';
 import '../../domain/services/finance_insight_service.dart';
 import '../../domain/services/quick_add_expense_parser.dart';
+import '../widgets/expense_card.dart';
 import 'add_expense_screen.dart';
 import 'groups_list_screen.dart';
 
@@ -572,19 +573,7 @@ class _RecentTransactionsSection extends StatelessWidget {
               const Text('Add your first expense to begin tracking spending.')
             else
               ...transactions.take(5).map((transaction) {
-                return ListTile(
-                  contentPadding: EdgeInsets.zero,
-                  leading: const Icon(Icons.payments_outlined),
-                  title: Text(transaction.description),
-                  subtitle: Text(
-                    '${transaction.transactionDate.day}/'
-                    '${transaction.transactionDate.month}/'
-                    '${transaction.transactionDate.year}',
-                  ),
-                  trailing: _FormattedAmount(
-                    amountCents: transaction.amountCents,
-                  ),
-                );
+                return ExpenseCard(transaction: transaction);
               }),
           ],
         ),
@@ -728,17 +717,5 @@ class _FinanceInsightsSection extends StatelessWidget {
       FinanceInsightSeverity.danger => theme.colorScheme.error,
       FinanceInsightSeverity.info => theme.colorScheme.primary,
     };
-  }
-}
-
-class _FormattedAmount extends ConsumerWidget {
-  final int amountCents;
-
-  const _FormattedAmount({required this.amountCents});
-
-  @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final formatter = ref.watch(currencyFormatterProvider);
-    return Text(formatter.formatCentsWithSign(amountCents));
   }
 }

--- a/app/lib/features/coins/presentation/widgets/expense_card.dart
+++ b/app/lib/features/coins/presentation/widgets/expense_card.dart
@@ -67,6 +67,8 @@ class ExpenseCard extends ConsumerWidget {
                         color: theme.colorScheme.onSurfaceVariant,
                       ),
                     ),
+                    const SizedBox(height: 6),
+                    _ReviewStatusBadge(status: transaction.reviewStatus),
                   ],
                 ),
               ),
@@ -99,5 +101,37 @@ class ExpenseCard extends ConsumerWidget {
     } else {
       return '${date.day}/${date.month}/${date.year}';
     }
+  }
+}
+
+class _ReviewStatusBadge extends StatelessWidget {
+  const _ReviewStatusBadge({required this.status});
+
+  final TransactionReviewStatus status;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final isPending = status == TransactionReviewStatus.pendingReview;
+    final foreground = isPending
+        ? theme.colorScheme.secondary
+        : theme.colorScheme.primary;
+
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        color: foreground.withValues(alpha: 0.10),
+        borderRadius: BorderRadius.circular(999),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+        child: Text(
+          status.label,
+          style: theme.textTheme.labelSmall?.copyWith(
+            color: foreground,
+            fontWeight: FontWeight.w700,
+          ),
+        ),
+      ),
+    );
   }
 }

--- a/app/test/features/agent_chat/presentation/screens/chat_screen_finance_ingestion_test.dart
+++ b/app/test/features/agent_chat/presentation/screens/chat_screen_finance_ingestion_test.dart
@@ -68,6 +68,13 @@ void main() {
     expect(repository.transactions.single.amountCents, -45000);
     expect(repository.transactions.single.categoryId, 'food');
     expect(find.textContaining('Added to Coins: Swiggy'), findsOneWidget);
+    expect(find.text('Undo'), findsOneWidget);
+
+    await tester.tap(find.text('Undo'));
+    await tester.pumpAndSettle();
+
+    expect(repository.transactions, isEmpty);
+    expect(find.textContaining('Removed Swiggy from Coins.'), findsOneWidget);
   });
 }
 
@@ -105,7 +112,10 @@ class _InMemoryTransactionRepository implements TransactionRepository {
   }
 
   @override
-  Future<Result<void>> delete(String id) async => (data: null, error: null);
+  Future<Result<void>> delete(String id) async {
+    transactions.removeWhere((transaction) => transaction.id == id);
+    return (data: null, error: null);
+  }
 
   @override
   Future<Result<List<Transaction>>> findByAccount(String accountId) async =>

--- a/app/test/features/coins/presentation/screens/coins_dashboard_screen_test.dart
+++ b/app/test/features/coins/presentation/screens/coins_dashboard_screen_test.dart
@@ -1,6 +1,7 @@
 import 'package:airo_app/core/utils/currency_formatter.dart';
 import 'package:airo_app/core/utils/locale_settings.dart';
 import 'package:airo_app/features/coins/application/providers/dashboard_providers.dart';
+import 'package:airo_app/features/coins/domain/entities/transaction.dart';
 import 'package:airo_app/features/coins/domain/models/safe_to_spend.dart';
 import 'package:airo_app/features/coins/presentation/screens/add_expense_screen.dart';
 import 'package:airo_app/features/coins/presentation/screens/coins_dashboard_screen.dart';
@@ -135,5 +136,48 @@ void main() {
     expect(find.text('Split with Alex'), findsOneWidget);
     expect(find.widgetWithText(TextFormField, 'Pizza'), findsOneWidget);
     expect(find.widgetWithText(TextFormField, '420.00'), findsOneWidget);
+  });
+
+  testWidgets('shows reviewed and pending review badges in recent expenses', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          dashboardDataProvider.overrideWith(
+            (ref) async => DashboardData(
+              recentExpenses: [
+                Transaction(
+                  id: 'manual-1',
+                  description: 'Coffee',
+                  amountCents: -450,
+                  type: TransactionType.expense,
+                  categoryId: 'food',
+                  accountId: 'cash',
+                  transactionDate: DateTime(2026, 6, 27),
+                  createdAt: DateTime(2026, 6, 27),
+                ),
+                Transaction(
+                  id: 'chat-1',
+                  description: 'Swiggy',
+                  amountCents: -1200,
+                  type: TransactionType.expense,
+                  categoryId: 'food',
+                  accountId: 'cash',
+                  transactionDate: DateTime(2026, 6, 27),
+                  tags: const ['source:chat'],
+                  createdAt: DateTime(2026, 6, 27),
+                ),
+              ],
+            ),
+          ),
+        ],
+        child: const MaterialApp(home: CoinsDashboardScreen()),
+      ),
+    );
+    await tester.pump();
+
+    expect(find.text('Reviewed'), findsOneWidget);
+    expect(find.text('Pending Review'), findsOneWidget);
   });
 }


### PR DESCRIPTION
# Summary

This PR introduces changes to the Coins ingestion UX.
Goal: satisfy #244 by adding undo controls for chat-ingested transactions and deterministic review status badges in transaction lists.

Core outcome:

* chat-created Coins transactions can be undone from a snackbar
* recent expense cards now surface Reviewed vs Pending Review state

# Changes

### Code

* Updated:

  * `app/lib/features/agent_chat/presentation/screens/chat_screen.dart`
  * `app/lib/features/coins/domain/entities/transaction.dart`
  * `app/lib/features/coins/presentation/widgets/expense_card.dart`
  * `app/lib/features/coins/presentation/screens/coins_dashboard_screen.dart`
  * `app/test/features/agent_chat/presentation/screens/chat_screen_finance_ingestion_test.dart`
  * `app/test/features/coins/presentation/screens/coins_dashboard_screen_test.dart`

### Logic

* adds an Undo snackbar for newly created chat-ingested transactions and soft-deletes them when the action is used
* derives transaction review status from transaction metadata so chat-ingested entries show Pending Review while manual entries show Reviewed
* reuses the shared expense card in recent transactions so status badges render consistently

# Risks

* This does not add a full transaction editor yet; it covers the undo and status slice only.
* Rollback plan:

  * revert this PR to remove the snackbar flow and status badges

# Testing

* Widget tests:

  * `flutter test test/features/agent_chat/presentation/screens/chat_screen_finance_ingestion_test.dart`
  * `flutter test test/features/coins/presentation/screens/coins_dashboard_screen_test.dart`
* Analysis:

  * `flutter analyze lib/features/coins/domain/entities/transaction.dart lib/features/agent_chat/presentation/screens/chat_screen.dart lib/features/coins/presentation/widgets/expense_card.dart lib/features/coins/presentation/screens/coins_dashboard_screen.dart test/features/agent_chat/presentation/screens/chat_screen_finance_ingestion_test.dart test/features/coins/presentation/screens/coins_dashboard_screen_test.dart`

Closes #244
