### PR TITLE
chore(core-domain): resolve analysis doc lints

### DIFF
--- a/packages/core_domain/lib/core_domain.dart
+++ b/packages/core_domain/lib/core_domain.dart
@@ -1,8 +1,7 @@
-/// Core domain layer for Airo
-///
-/// Contains entities, repository interfaces, value objects, and use cases
-/// that define the business logic of the application.
-library core_domain;
+// Core domain layer for Airo.
+//
+// Contains entities, repository interfaces, value objects, and use cases
+// that define the business logic of the application.
 
 // Entities
 export 'src/entities/entity.dart';

--- a/packages/core_domain/lib/src/value_objects/result.dart
+++ b/packages/core_domain/lib/src/value_objects/result.dart
@@ -2,8 +2,9 @@ import 'package:meta/meta.dart';
 
 import 'failure.dart' as failures;
 
-/// Type alias for the base Failure class from failure.dart
-/// This distinguishes it from the Failure<T> result wrapper class
+/// Type alias for the base Failure class from failure.dart.
+///
+/// This distinguishes it from the `Failure<T>` result wrapper class.
 typedef BaseFailure = failures.Failure;
 
 /// A Result type that represents either a success value or a failure.


### PR DESCRIPTION
# Summary

This PR introduces changes to `packages/core_domain`.
Goal: clear the package-local analyzer noise blocking repository health.

Core outcome:

* removes the obsolete library directive that triggers an analyzer info
* fixes the `Failure<T>` doc comment formatting so `dart analyze` is clean

---

# Changes

### Code

* Updated:

  * `packages/core_domain/lib/core_domain.dart` to remove the unnecessary library declaration
  * `packages/core_domain/lib/src/value_objects/result.dart` to escape the generic type in docs

### Logic

* no runtime behavior changes
* public exports remain unchanged

---

# API Changes (if any)

* None.

---

# Database Changes (if any)

* None.

---

# Observability / Logging

* None.

---

# Performance Impact

* None.

---

# Risks

* Low risk: documentation-only cleanup.
* Rollback plan:

  * revert the PR commit if needed

---

# Testing

* Unit tests:

  * not applicable
* Integration tests:

  * not applicable
* Manual testing:

  * ran `dart analyze` in `packages/core_domain`

---

# Deployment Notes

* None.

---

# Related Commits

* `chore(core-domain): resolve analysis doc lints`

---

# Notes

* Closes #405.
