### PR TITLE
Fix finance chat review queue for low-confidence imports

### DIFF
--- a/app/lib/core/services/gemini_nano_service.dart
+++ b/app/lib/core/services/gemini_nano_service.dart
@@ -48,22 +48,6 @@ class GeminiNanoService {
 
   bool get isInitialized => _isInitialized;
 
-  /// Pre-warm Gemini Nano in the native runtime with a local dummy inference.
-  ///
-  /// This is best-effort and safe for app startup: unsupported platforms,
-  /// low-memory native refusals, and channel failures return false.
-  Future<bool> warmup() async {
-    if (kIsWeb) return false;
-
-    try {
-      final bool warmed = await _channel.invokeMethod('warmup');
-      return warmed;
-    } catch (e) {
-      debugPrint('Gemini Nano warmup skipped: $e');
-      return false;
-    }
-  }
-
   /// Check if device is supported (Pixel 9 with AICore)
   /// Returns false on web platform
   Future<bool> isSupported() async {

--- a/app/lib/features/agent_chat/domain/services/agent_skill_orchestrator.dart
+++ b/app/lib/features/agent_chat/domain/services/agent_skill_orchestrator.dart
@@ -548,8 +548,6 @@ Map<String, dynamic>? _calendarEventFromNotificationResult(
     'source': 'reminder_confirmation',
   };
 }
-}
-
 SkillModelAction? parseSkillModelAction(String text) {
   try {
     final decoded = jsonDecode(_stripCodeFence(text));

--- a/app/lib/features/agent_chat/presentation/screens/chat_screen.dart
+++ b/app/lib/features/agent_chat/presentation/screens/chat_screen.dart
@@ -55,6 +55,16 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
   final List<ChatMessage> _messages = [];
   final ToolRegistry _toolRegistry = ToolRegistry();
   AgentSkillRegistry _skillRegistry = AgentSkillRegistry();
+  final AgentConnectorRegistry _connectorRegistry = AgentConnectorRegistry(
+    connectors: [
+      DateTimeConnector(),
+      NativeCalendarPermissionConnector(),
+      NativeCalendarConnector(),
+      NativeCreateCalendarEventConnector(),
+      ScheduleNotificationConnector(),
+      RouteConnector(),
+    ],
+  );
   final GeminiNanoService _geminiNano = GeminiNanoService();
   final LiteRtLmService _liteRtLm = LiteRtLmService();
   late final AssistantRuntimeService _assistantRuntime;
@@ -86,16 +96,7 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
   AgentSkillOrchestrator _buildSkillOrchestrator(AgentSkillRegistry registry) {
     return AgentSkillOrchestrator(
       skillRegistry: registry,
-      connectorRegistry: AgentConnectorRegistry(
-        connectors: [
-          DateTimeConnector(),
-          NativeCalendarPermissionConnector(),
-          NativeCalendarConnector(),
-          NativeCreateCalendarEventConnector(),
-          ScheduleNotificationConnector(),
-          RouteConnector(),
-        ],
-      ),
+      connectorRegistry: _connectorRegistry,
       modelClient: SelectedRuntimeAgentSkillModelClient(
         runtimeService: _assistantRuntime,
         selectedModelId: () => ref.read(selectedAssistantModelIdProvider),

--- a/app/lib/features/coins/application/services/finance_chat_ingestion_service.dart
+++ b/app/lib/features/coins/application/services/finance_chat_ingestion_service.dart
@@ -54,14 +54,6 @@ class FinanceChatIngestionService {
       );
     }
 
-    if (!parsed.isHighConfidence) {
-      return FinanceChatIngestionResult(
-        status: FinanceChatIngestionStatus.needsReview,
-        parsed: parsed,
-        message: 'I found a possible transaction, but it needs review.',
-      );
-    }
-
     final existingResult = await _repository.findByTag(parsed.sourceTag);
     if (existingResult.error != null) {
       return FinanceChatIngestionResult(
@@ -96,7 +88,9 @@ class FinanceChatIngestionService {
         status: FinanceChatIngestionStatus.needsReview,
         parsed: parsed,
         transaction: updateResult.data,
-        message: 'Queued imported transaction for review.',
+        message: parsed.isHighConfidence
+            ? 'Queued imported transaction for review.'
+            : 'Queued possible transaction for review.',
       );
     }
 
@@ -124,7 +118,9 @@ class FinanceChatIngestionService {
       status: FinanceChatIngestionStatus.needsReview,
       parsed: parsed,
       transaction: createResult.data,
-      message: 'Queued imported transaction for review.',
+      message: parsed.isHighConfidence
+          ? 'Queued imported transaction for review.'
+          : 'Queued possible transaction for review.',
     );
   }
 

--- a/app/test/features/agent_chat/presentation/screens/chat_screen_finance_ingestion_test.dart
+++ b/app/test/features/agent_chat/presentation/screens/chat_screen_finance_ingestion_test.dart
@@ -80,6 +80,66 @@ void main() {
     expect(repository.transactions, isEmpty);
     expect(find.textContaining('Removed Swiggy from Coins.'), findsOneWidget);
   });
+
+  testWidgets('low-confidence finance text is still queued for Coins review', (
+    tester,
+  ) async {
+    tester.view.devicePixelRatio = 1.0;
+    tester.view.physicalSize = const Size(1200, 1000);
+    addTearDown(() {
+      tester.view.resetDevicePixelRatio();
+      tester.view.resetPhysicalSize();
+    });
+
+    SharedPreferences.setMockInitialValues({
+      'selected_assistant_model_id': geminiNanoAssistantModelId,
+    });
+
+    final repository = _InMemoryTransactionRepository();
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          currencyFormatterProvider.overrideWithValue(
+            CurrencyFormatter.fromCode('INR'),
+          ),
+          selectedAssistantModelIdProvider.overrideWith(
+            (ref) => _SelectedAssistantModelNotifier(),
+          ),
+          transactionRepositoryProvider.overrideWithValue(repository),
+          expenseAccountOptionsProvider.overrideWith(
+            (ref) async => [
+              Account(
+                id: 'cash_default',
+                name: 'Cash',
+                type: AccountType.cash,
+                balanceCents: 0,
+                currencyCode: 'INR',
+                isDefault: true,
+                createdAt: DateTime(2026, 6, 20),
+              ),
+            ],
+          ),
+        ],
+        child: const MaterialApp(home: ChatScreen()),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.enterText(find.byKey(const Key('agent_chat_input')), 'Rs 299 spent');
+    await tester.tap(find.byIcon(Icons.send));
+    await tester.pumpAndSettle();
+
+    expect(repository.transactions, hasLength(1));
+    expect(repository.transactions.single.description, 'Finance SMS transaction');
+    expect(repository.transactions.single.amountCents, -29900);
+    expect(repository.transactions.single.tags, contains('review:pending'));
+    expect(
+      find.textContaining('Queued for Coins review: Finance SMS transaction'),
+      findsOneWidget,
+    );
+    expect(find.text('Undo'), findsOneWidget);
+  });
 }
 
 class _SelectedAssistantModelNotifier extends SelectedAssistantModelNotifier {

--- a/app/test/features/coins/application/services/finance_chat_ingestion_service_test.dart
+++ b/app/test/features/coins/application/services/finance_chat_ingestion_service_test.dart
@@ -85,6 +85,30 @@ void main() {
       expect(result.status, FinanceChatIngestionStatus.ignored);
       expect(repository.transactions, isEmpty);
     });
+
+    test('queues low-confidence finance text for review instead of dropping it', () async {
+      final repository = _InMemoryTransactionRepository();
+      final service = FinanceChatIngestionService(
+        parser: FinanceMessageParser(now: () => DateTime(2026, 6, 20)),
+        repository: repository,
+      );
+
+      final result = await service.ingest(
+        'Rs 299 spent',
+        accountId: 'cash_default',
+      );
+
+      expect(result.status, FinanceChatIngestionStatus.needsReview);
+      expect(result.transaction, isNotNull);
+      expect(repository.transactions, hasLength(1));
+      expect(repository.transactions.single.description, 'Finance SMS transaction');
+      expect(repository.transactions.single.amountCents, -29900);
+      expect(repository.transactions.single.tags, contains('review:pending'));
+      expect(
+        repository.transactions.single.tags,
+        contains('confidence:0.55'),
+      );
+    });
   });
 }
 

--- a/packages/core_ai/lib/src/llm/gemini_nano_client.dart
+++ b/packages/core_ai/lib/src/llm/gemini_nano_client.dart
@@ -178,29 +178,6 @@ class GeminiNanoClient implements LLMClient {
     }
   }
 
-  /// Warms the model by issuing a lightweight native inference request.
-  ///
-  /// This ensures Gemini Nano has loaded its weights before the first
-  /// user-visible prompt.
-  Future<bool> warmup() async {
-    final initialized = _isInitialized || await initialize();
-    if (!initialized) {
-      return false;
-    }
-
-    try {
-      final result = await _channel.invokeMethod<bool>('warmup');
-      return result ?? false;
-    } catch (e) {
-      developer.log(
-        'Gemini Nano warmup failed: $e',
-        name: 'GeminiNanoClient',
-        error: e,
-      );
-      return false;
-    }
-  }
-
   @override
   Future<Result<LLMResponse>> generate(String prompt) async {
     if (!_isInitialized) {


### PR DESCRIPTION
# Summary
This PR fixes the first shippable slice of issue #243.
Goal: ensure finance messages parsed from chat are always queued into Coins for review, even when parser confidence is below the high-confidence threshold.

Core outcome:
- low-confidence finance chat imports now persist as pending-review transactions instead of being dropped
- source-tag deduplication still works for repeated imports
- chat and service tests now cover the low-confidence review path
- current compile blockers in chat runtime files are also cleaned up so the focused verification suite can run again

# Changes
### Code
* Updated:
  * app/lib/features/coins/application/services/finance_chat_ingestion_service.dart to queue low-confidence parses into the review flow
  * app/lib/features/agent_chat/presentation/screens/chat_screen.dart to restore the shared connector registry used by pending calendar actions
  * app/lib/core/services/gemini_nano_service.dart and packages/core_ai/lib/src/llm/gemini_nano_client.dart to remove duplicate warmup methods
  * app/lib/features/agent_chat/domain/services/agent_skill_orchestrator.dart to remove a stray brace blocking analysis

### Logic
* low-confidence parsed finance messages now create or update a pending-review transaction
* repeated imports still dedupe by source:chat_sms:<hash>
* review queue and Undo remain available for uncertain imports

# Risks
* this PR keeps low-confidence imports in the existing transaction/tag-based review queue rather than introducing a separate raw-record store
* parser confidence remains deterministic and may still classify sparse messages into generic descriptions until broader ingestion work lands

# Testing
* flutter analyze app/lib/features/agent_chat/domain/services/agent_skill_orchestrator.dart app/lib/features/agent_chat/presentation/screens/chat_screen.dart app/lib/core/services/gemini_nano_service.dart
* flutter test test/features/coins/application/services/finance_chat_ingestion_service_test.dart test/features/agent_chat/presentation/screens/chat_screen_finance_ingestion_test.dart
