### PR TITLE
Add Brain chat response timing metadata

### DIFF
--- a/app/lib/features/agent_chat/domain/models/agent_skill.dart
+++ b/app/lib/features/agent_chat/domain/models/agent_skill.dart
@@ -169,16 +169,18 @@ class AgentActionTrace extends Equatable {
   final String detail;
   final Map<String, dynamic> parameters;
   final bool success;
+  final int? durationMs;
 
   const AgentActionTrace({
     required this.title,
     required this.detail,
     this.parameters = const {},
     this.success = true,
+    this.durationMs,
   });
 
   @override
-  List<Object?> get props => [title, detail, parameters, success];
+  List<Object?> get props => [title, detail, parameters, success, durationMs];
 }
 
 class AgentRunResult extends Equatable {

--- a/app/lib/features/agent_chat/domain/models/chat_response_metadata.dart
+++ b/app/lib/features/agent_chat/domain/models/chat_response_metadata.dart
@@ -1,0 +1,81 @@
+import 'package:core_ai/core_ai.dart';
+import 'package:flutter/foundation.dart';
+
+import 'agent_skill.dart';
+
+@immutable
+class ChatResponseMetadata {
+  const ChatResponseMetadata({
+    required this.title,
+    required this.runtime,
+    required this.executionMode,
+    required this.recordedAt,
+    required this.totalDurationMs,
+    this.modelId,
+    this.timeToFirstTokenMs,
+    this.promptTokens,
+    this.completionTokens,
+    this.finishReason,
+    this.toolCount,
+  });
+
+  final String title;
+  final String runtime;
+  final String executionMode;
+  final DateTime recordedAt;
+  final int totalDurationMs;
+  final String? modelId;
+  final int? timeToFirstTokenMs;
+  final int? promptTokens;
+  final int? completionTokens;
+  final String? finishReason;
+  final int? toolCount;
+
+  int? get totalTokens =>
+      promptTokens != null && completionTokens != null
+          ? promptTokens! + completionTokens!
+          : null;
+}
+
+ChatResponseMetadata buildRuntimeChatResponseMetadata({
+  required String title,
+  required String runtime,
+  required String executionMode,
+  required String prompt,
+  required String response,
+  required int totalDurationMs,
+  required DateTime recordedAt,
+  String? modelId,
+  int? timeToFirstTokenMs,
+  String? finishReason,
+}) {
+  return ChatResponseMetadata(
+    title: title,
+    runtime: runtime,
+    executionMode: executionMode,
+    recordedAt: recordedAt,
+    totalDurationMs: totalDurationMs,
+    modelId: modelId,
+    timeToFirstTokenMs: timeToFirstTokenMs,
+    promptTokens: TokenCounter.estimate(prompt),
+    completionTokens: TokenCounter.estimate(response),
+    finishReason: finishReason ?? 'stop',
+  );
+}
+
+ChatResponseMetadata buildSkillChatResponseMetadata({
+  required List<AgentActionTrace> traces,
+  required int totalDurationMs,
+  DateTime? recordedAt,
+}) {
+  final toolCount = traces.where((trace) => trace.title == 'Execute action').length;
+  return ChatResponseMetadata(
+    title: 'Agent Skills',
+    runtime: 'Local skill orchestration',
+    executionMode: 'Local',
+    recordedAt: recordedAt ?? DateTime.now(),
+    totalDurationMs: totalDurationMs,
+    toolCount: toolCount,
+    finishReason: 'completed',
+  );
+}

--- a/app/lib/features/agent_chat/domain/services/agent_skill_orchestrator.dart
+++ b/app/lib/features/agent_chat/domain/services/agent_skill_orchestrator.dart
@@ -394,13 +394,16 @@ class AgentSkillOrchestrator {
         );
       }
 
+      final actionStopwatch = Stopwatch()..start();
       final result = await _connectorRegistry.execute(tool, action.arguments);
+      actionStopwatch.stop();
       traces.add(
         AgentActionTrace(
           title: 'Execute action',
           detail: tool,
           parameters: action.arguments,
           success: !result.isError,
+          durationMs: actionStopwatch.elapsedMilliseconds,
         ),
       );
       toolResults.add({

--- a/app/lib/features/agent_chat/presentation/screens/chat_screen.dart
+++ b/app/lib/features/agent_chat/presentation/screens/chat_screen.dart
@@ -13,6 +13,8 @@ import '../../../agent_chat/data/services/assistant_runtime_service.dart';
 import '../../../agent_chat/data/services/selected_runtime_agent_skill_model_client.dart';
 import '../../../agent_chat/application/assistant_model_preferences.dart';
 import '../../../agent_chat/domain/models/agent_skill.dart';
+import '../../../agent_chat/domain/models/assistant_runtime_ids.dart';
+import '../../../agent_chat/domain/models/chat_response_metadata.dart';
 import '../../../agent_chat/domain/services/agent_connector_registry.dart';
 import '../../../agent_chat/domain/services/agent_skill_orchestrator.dart';
 import '../../../agent_chat/domain/services/agent_skill_registry.dart';
@@ -33,18 +35,31 @@ class ChatMessage {
   final bool isUser;
   final DateTime timestamp;
   final List<AgentActionTrace> traces;
+  final ChatResponseMetadata? metadata;
 
   ChatMessage({
     required this.text,
     required this.isUser,
     DateTime? timestamp,
     this.traces = const [],
+    this.metadata,
   }) : timestamp = timestamp ?? DateTime.now();
 }
 
 /// Agent chat screen
 class ChatScreen extends ConsumerStatefulWidget {
-  const ChatScreen({super.key});
+  const ChatScreen({
+    super.key,
+    this.assistantRuntimeService,
+    this.skillOrchestrator,
+    this.enableAiInitialization = true,
+    this.initialMessages,
+  });
+
+  final AssistantRuntimeService? assistantRuntimeService;
+  final AgentSkillOrchestrator? skillOrchestrator;
+  final bool enableAiInitialization;
+  final List<ChatMessage>? initialMessages;
 
   @override
   ConsumerState<ChatScreen> createState() => _ChatScreenState();
@@ -76,21 +91,31 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
   void initState() {
     super.initState();
     _messageController = TextEditingController();
-    _assistantRuntime = AssistantRuntimeService(
-      geminiNano: _geminiNano,
-      liteRtLm: _liteRtLm,
-    );
-    _skillOrchestrator = _buildSkillOrchestrator(_skillRegistry);
-    _loadPersistedSkillRegistry();
+    _assistantRuntime =
+        widget.assistantRuntimeService ??
+        AssistantRuntimeService(
+          geminiNano: _geminiNano,
+          liteRtLm: _liteRtLm,
+        );
+    _skillOrchestrator =
+        widget.skillOrchestrator ?? _buildSkillOrchestrator(_skillRegistry);
+    if (widget.skillOrchestrator == null) {
+      _loadPersistedSkillRegistry();
+    }
     // Add welcome message
-    _messages.add(
-      ChatMessage(
-        text:
-            'Hi! I can chat, use enabled skills, check your schedule, split bills, draft diet plans, plan routines, and open Airo tools from here.',
-        isUser: false,
-      ),
+    _messages.addAll(
+      widget.initialMessages ??
+          [
+            ChatMessage(
+              text:
+                  'Hi! I can chat, use enabled skills, check your schedule, split bills, draft diet plans, plan routines, and open Airo tools from here.',
+              isUser: false,
+            ),
+          ],
     );
-    _initializeAI();
+    if (widget.enableAiInitialization) {
+      _initializeAI();
+    }
   }
 
   AgentSkillOrchestrator _buildSkillOrchestrator(AgentSkillRegistry registry) {
@@ -449,7 +474,7 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
     final colorScheme = Theme.of(context).colorScheme;
     final maxWidth =
         MediaQuery.of(context).size.width *
-        (message.traces.isNotEmpty ? 0.86 : 0.75);
+        (message.traces.isNotEmpty || message.metadata != null ? 0.86 : 0.75);
 
     return Align(
       alignment: message.isUser ? Alignment.centerRight : Alignment.centerLeft,
@@ -479,6 +504,28 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
                 ),
               ),
             ),
+            if (!message.isUser && message.metadata != null)
+              Padding(
+                padding: const EdgeInsets.only(bottom: 8),
+                child: Align(
+                  alignment: Alignment.centerLeft,
+                  child: OutlinedButton.icon(
+                    key: const Key('agent_chat_metadata_button'),
+                    style: OutlinedButton.styleFrom(
+                      padding: const EdgeInsets.symmetric(
+                        horizontal: 10,
+                        vertical: 6,
+                      ),
+                      minimumSize: Size.zero,
+                      tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                      visualDensity: VisualDensity.compact,
+                    ),
+                    onPressed: () => _showMetadataSheet(message),
+                    icon: const Icon(Icons.query_stats, size: 16),
+                    label: Text(_metadataSummary(message.metadata!)),
+                  ),
+                ),
+              ),
           ],
         ),
       ),
@@ -527,15 +574,22 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
       return;
     }
 
+    final skillStopwatch = Stopwatch()..start();
     final skillResult = await _skillOrchestrator.run(message);
+    skillStopwatch.stop();
     if (skillResult.handled) {
       _pendingCalendarEvent = skillResult.pendingCalendarEvent;
+      final metadata = _buildSkillMetadata(
+        traces: skillResult.traces,
+        totalDuration: skillStopwatch.elapsed,
+      );
       setState(() {
         _messages.add(
           ChatMessage(
             text: skillResult.message,
             isUser: false,
             traces: skillResult.traces,
+            metadata: metadata,
           ),
         );
       });
@@ -566,7 +620,13 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
     });
 
     try {
-      await _generateSelectedModelResponse(selectedModelId, message);
+      final metadata = await _generateSelectedModelResponse(
+        selectedModelId,
+        message,
+      );
+      if (metadata != null) {
+        _attachMetadataToLastAssistantMessage(metadata);
+      }
     } catch (e) {
       // If AI fails, show error message
       setState(() {
@@ -731,27 +791,188 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
     }
   }
 
-  Future<void> _generateSelectedModelResponse(
+  Future<ChatResponseMetadata?> _generateSelectedModelResponse(
     String selectedModelId,
     String message,
   ) async {
+    final stopwatch = Stopwatch()..start();
+    int? timeToFirstTokenMs;
+    String latestChunk = '';
     try {
       await for (final chunk in _assistantRuntime.generateTextStream(
         selectedModelId: selectedModelId,
         prompt: message,
       )) {
+        timeToFirstTokenMs ??= stopwatch.elapsedMilliseconds;
+        latestChunk = chunk;
         _replaceStreamingMessage(chunk);
       }
+      stopwatch.stop();
+      if (latestChunk.trim().isEmpty) {
+        return null;
+      }
+      return _buildRuntimeMetadata(
+        selectedModelId: selectedModelId,
+        prompt: message,
+        response: latestChunk,
+        totalDuration: stopwatch.elapsed,
+        timeToFirstTokenMs: timeToFirstTokenMs,
+      );
     } on AssistantRuntimeUnavailableException catch (e) {
+      stopwatch.stop();
       _replaceStreamingMessage(e.message);
+      return null;
     }
   }
 
   void _replaceStreamingMessage(String text) {
     if (!mounted || _messages.isEmpty) return;
     setState(() {
-      _messages[_messages.length - 1] = ChatMessage(text: text, isUser: false);
+      final current = _messages.last;
+      _messages[_messages.length - 1] = ChatMessage(
+        text: text,
+        isUser: false,
+        timestamp: current.timestamp,
+        traces: current.traces,
+        metadata: current.metadata,
+      );
     });
+  }
+
+  Future<ChatResponseMetadata> _buildRuntimeMetadata({
+    required String selectedModelId,
+    required String prompt,
+    required String response,
+    required Duration totalDuration,
+    required int? timeToFirstTokenMs,
+  }) async {
+    AssistantModelCandidate? candidate;
+    try {
+      final state = await ref.read(assistantModelLibraryProvider.future);
+      candidate = state.candidateById(selectedModelId);
+    } catch (_) {
+      candidate = null;
+    }
+
+    final title = candidate?.name ?? selectedModelId;
+    final runtime = candidate?.runtime ?? selectedModelId;
+    final isLocal =
+        candidate?.local ?? selectedModelId != geminiCloudAssistantModelId;
+
+    return buildRuntimeChatResponseMetadata(
+      title: title,
+      runtime: runtime,
+      executionMode: isLocal ? 'Local' : 'Cloud',
+      recordedAt: DateTime.now(),
+      totalDurationMs: totalDuration.inMilliseconds,
+      modelId: selectedModelId,
+      timeToFirstTokenMs: timeToFirstTokenMs,
+      prompt: prompt,
+      response: response,
+    );
+  }
+
+  ChatResponseMetadata _buildSkillMetadata({
+    required List<AgentActionTrace> traces,
+    required Duration totalDuration,
+  }) {
+    return buildSkillChatResponseMetadata(
+      traces: traces,
+      totalDurationMs: totalDuration.inMilliseconds,
+      recordedAt: DateTime.now(),
+    );
+  }
+
+  void _attachMetadataToLastAssistantMessage(ChatResponseMetadata metadata) {
+    if (!mounted || _messages.isEmpty) return;
+    setState(() {
+      final current = _messages.last;
+      _messages[_messages.length - 1] = ChatMessage(
+        text: current.text,
+        isUser: current.isUser,
+        timestamp: current.timestamp,
+        traces: current.traces,
+        metadata: metadata,
+      );
+    });
+  }
+
+  String _metadataSummary(ChatResponseMetadata metadata) {
+    final duration = _formatDuration(metadata.totalDurationMs);
+    final toolCount = metadata.toolCount;
+    if (toolCount != null && toolCount > 0) {
+      return '$toolCount ${toolCount == 1 ? 'tool' : 'tools'} · $duration';
+    }
+    return '${metadata.title} · $duration';
+  }
+
+  void _showMetadataSheet(ChatMessage message) {
+    final metadata = message.metadata;
+    if (metadata == null) return;
+
+    showModalBottomSheet<void>(
+      context: context,
+      showDragHandle: true,
+      builder: (context) {
+        final rows = <(String, String)>[
+          ('Model', metadata.title),
+          ('Runtime', metadata.runtime),
+          ('Execution', metadata.executionMode),
+          ('Total duration', _formatDuration(metadata.totalDurationMs)),
+          ('Timestamp', _formatTimestamp(metadata.recordedAt)),
+          if (metadata.timeToFirstTokenMs != null)
+            ('Time to first token', _formatDuration(metadata.timeToFirstTokenMs!)),
+          if (metadata.promptTokens != null)
+            ('Prompt tokens', '${metadata.promptTokens}'),
+          if (metadata.completionTokens != null)
+            ('Completion tokens', '${metadata.completionTokens}'),
+          if (metadata.totalTokens != null)
+            ('Total tokens', '${metadata.totalTokens}'),
+          if (metadata.toolCount != null) ('Tool calls', '${metadata.toolCount}'),
+          if (metadata.finishReason != null)
+            ('Finish reason', metadata.finishReason!),
+        ];
+
+        return SafeArea(
+          child: Padding(
+            padding: const EdgeInsets.fromLTRB(16, 8, 16, 24),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  'Response details',
+                  style: Theme.of(context).textTheme.titleLarge,
+                ),
+                const SizedBox(height: 12),
+                for (final row in rows) ...[
+                  _MetadataRow(label: row.$1, value: row.$2),
+                  const SizedBox(height: 8),
+                ],
+                if (message.traces.isNotEmpty) ...[
+                  const SizedBox(height: 8),
+                  Text(
+                    'Action timings',
+                    style: Theme.of(context).textTheme.titleMedium,
+                  ),
+                  const SizedBox(height: 8),
+                  for (final trace in message.traces)
+                    Padding(
+                      padding: const EdgeInsets.only(bottom: 8),
+                      child: _MetadataRow(
+                        label: trace.detail,
+                        value: trace.durationMs == null
+                            ? (trace.success ? 'Completed' : 'Failed')
+                            : _formatDuration(trace.durationMs!),
+                      ),
+                    ),
+                ],
+              ],
+            ),
+          ),
+        );
+      },
+    );
   }
 
   Future<void> _selectAssistantModel(AssistantModelCandidate candidate) async {
@@ -929,4 +1150,53 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
       ),
     );
   }
+}
+
+class _MetadataRow extends StatelessWidget {
+  const _MetadataRow({required this.label, required this.value});
+
+  final String label;
+  final String value;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Expanded(
+          child: Text(
+            label,
+            style: theme.textTheme.bodyMedium?.copyWith(
+              color: theme.colorScheme.onSurfaceVariant,
+            ),
+          ),
+        ),
+        const SizedBox(width: 16),
+        Flexible(
+          child: Text(
+            value,
+            textAlign: TextAlign.end,
+            style: theme.textTheme.bodyMedium?.copyWith(
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+String _formatDuration(int durationMs) {
+  if (durationMs < 1000) {
+    return '${durationMs}ms';
+  }
+  return '${(durationMs / 1000).toStringAsFixed(1)}s';
+}
+
+String _formatTimestamp(DateTime value) {
+  final local = value.toLocal();
+  String twoDigits(int number) => number.toString().padLeft(2, '0');
+  return '${local.year}-${twoDigits(local.month)}-${twoDigits(local.day)} '
+      '${twoDigits(local.hour)}:${twoDigits(local.minute)}:${twoDigits(local.second)}';
 }

--- a/app/lib/features/agent_chat/presentation/widgets/skill_action_trace_card.dart
+++ b/app/lib/features/agent_chat/presentation/widgets/skill_action_trace_card.dart
@@ -88,6 +88,14 @@ class _TraceRow extends StatelessWidget {
                     fontWeight: FontWeight.w700,
                   ),
                 ),
+                if (trace.durationMs != null)
+                  Text(
+                    _formatDuration(trace.durationMs!),
+                    style: theme.textTheme.labelSmall?.copyWith(
+                      color: theme.colorScheme.onSurfaceVariant,
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
                 const SizedBox(height: 2),
                 Text(trace.detail, style: theme.textTheme.bodySmall),
                 if (trace.parameters.isNotEmpty) ...[
@@ -106,4 +114,11 @@ class _TraceRow extends StatelessWidget {
       ),
     );
   }
+}
+
+String _formatDuration(int durationMs) {
+  if (durationMs < 1000) {
+    return '${durationMs}ms';
+  }
+  return '${(durationMs / 1000).toStringAsFixed(1)}s';
 }

--- a/app/test/features/agent_chat/domain/services/agent_skill_orchestrator_test.dart
+++ b/app/test/features/agent_chat/domain/services/agent_skill_orchestrator_test.dart
@@ -61,6 +61,7 @@ void main() {
         ]),
       );
       expect(result.traces.last.parameters['date'], '2026-06-20');
+      expect(result.traces.last.durationMs, isNotNull);
     });
 
     test('summarizes calendar events when connector returns events', () async {
@@ -110,6 +111,12 @@ void main() {
           'get_current_date_time',
           'schedule_notification',
         ]),
+      );
+      expect(
+        result.traces
+            .where((trace) => trace.title == 'Execute action')
+            .every((trace) => trace.durationMs != null),
+        isTrue,
       );
       expect(notificationScheduler.scheduled, hasLength(1));
       expect(
@@ -324,6 +331,7 @@ void main() {
           selectedSkillJson: '{"skill_id":"read-calendar-events"}',
           actionJson: 'not json',
         ),
+        useFallbackModelClient: false,
       );
 
       final result = await orchestrator.run('Check my schedule for today');
@@ -362,7 +370,10 @@ void main() {
       expect(result.handled, true);
       expect(result.isError, true);
       expect(result.message, contains('too many steps'));
-      expect(result.traces.map((trace) => trace.detail), ['read-calendar-events']);
+      expect(
+        result.traces.map((trace) => trace.detail),
+        ['read-calendar-events', 'get_current_date_time'],
+      );
     });
 
     test('stops runs that exceed the bounded step limit', () async {

--- a/app/test/features/agent_chat/presentation/screens/chat_screen_metadata_test.dart
+++ b/app/test/features/agent_chat/presentation/screens/chat_screen_metadata_test.dart
@@ -1,0 +1,190 @@
+import 'package:airo_app/features/agent_chat/application/assistant_model_preferences.dart';
+import 'package:airo_app/features/agent_chat/domain/models/agent_skill.dart';
+import 'package:airo_app/features/agent_chat/domain/models/assistant_runtime_ids.dart';
+import 'package:airo_app/features/agent_chat/domain/models/chat_response_metadata.dart';
+import 'package:airo_app/features/agent_chat/presentation/screens/chat_screen.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  test('buildRuntimeChatResponseMetadata records tokens and timings', () {
+    final metadata = buildRuntimeChatResponseMetadata(
+      title: 'Gemini Nano',
+      runtime: 'AICore on-device',
+      executionMode: 'Local',
+      prompt: 'hello',
+      response: 'Hello from Airo',
+      totalDurationMs: 2400,
+      timeToFirstTokenMs: 350,
+      recordedAt: DateTime(2026, 6, 28, 10, 0),
+      modelId: geminiNanoAssistantModelId,
+    );
+
+    expect(metadata.modelId, geminiNanoAssistantModelId);
+    expect(metadata.totalDurationMs, 2400);
+    expect(metadata.timeToFirstTokenMs, 350);
+    expect(metadata.promptTokens, isNotNull);
+    expect(metadata.completionTokens, isNotNull);
+    expect(metadata.totalTokens, isNotNull);
+    expect(metadata.finishReason, 'stop');
+  });
+
+  test('buildSkillChatResponseMetadata counts executed tools', () {
+    final metadata = buildSkillChatResponseMetadata(
+      traces: const [
+        AgentActionTrace(title: 'Load skill', detail: 'schedule-notification'),
+        AgentActionTrace(
+          title: 'Execute action',
+          detail: 'schedule_notification',
+          durationMs: 120,
+        ),
+      ],
+      totalDurationMs: 900,
+      recordedAt: DateTime(2026, 6, 28, 10, 0),
+    );
+
+    expect(metadata.toolCount, 1);
+    expect(metadata.totalDurationMs, 900);
+    expect(metadata.executionMode, 'Local');
+  });
+
+  testWidgets('runtime responses expose timing metadata details', (tester) async {
+    await _pumpChatScreen(
+      tester,
+      initialMessages: [
+        ChatMessage(
+          text: 'Hello from Airo',
+          isUser: false,
+          metadata: buildRuntimeChatResponseMetadata(
+            title: 'Gemini Nano',
+            runtime: 'AICore on-device',
+            executionMode: 'Local',
+            prompt: 'hello',
+            response: 'Hello from Airo',
+            totalDurationMs: 2400,
+            timeToFirstTokenMs: 350,
+            recordedAt: DateTime(2026, 6, 28, 10, 0),
+            modelId: geminiNanoAssistantModelId,
+          ),
+        ),
+      ],
+    );
+
+    expect(find.text('Hello from Airo'), findsOneWidget);
+    expect(find.byKey(const Key('agent_chat_metadata_button')), findsOneWidget);
+    expect(find.textContaining('Gemini Nano'), findsOneWidget);
+
+    await tester.tap(find.byKey(const Key('agent_chat_metadata_button')));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Response details'), findsOneWidget);
+    expect(find.text('Model'), findsOneWidget);
+    expect(find.text('Gemini Nano'), findsWidgets);
+    expect(find.text('Runtime'), findsOneWidget);
+    expect(find.text('AICore on-device'), findsOneWidget);
+    expect(find.text('Execution'), findsOneWidget);
+    expect(find.text('Local'), findsOneWidget);
+    expect(find.text('Time to first token'), findsOneWidget);
+    expect(find.text('Prompt tokens'), findsOneWidget);
+    expect(find.text('Completion tokens'), findsOneWidget);
+  });
+
+  testWidgets('agent skill responses show tool count and action timings', (
+    tester,
+  ) async {
+    await _pumpChatScreen(
+      tester,
+      initialMessages: [
+        ChatMessage(
+          text: 'Scheduled it.',
+          isUser: false,
+          traces: const [
+            AgentActionTrace(
+              title: 'Execute action',
+              detail: 'schedule_notification',
+              durationMs: 120,
+            ),
+          ],
+          metadata: buildSkillChatResponseMetadata(
+            traces: const [
+              AgentActionTrace(
+                title: 'Execute action',
+                detail: 'schedule_notification',
+                durationMs: 120,
+              ),
+            ],
+            totalDurationMs: 900,
+            recordedAt: DateTime(2026, 6, 28, 10, 0),
+          ),
+        ),
+      ],
+    );
+
+    expect(find.text('Scheduled it.'), findsOneWidget);
+    expect(find.text('120ms'), findsOneWidget);
+    expect(find.textContaining('1 tool'), findsOneWidget);
+
+    await tester.tap(find.byKey(const Key('agent_chat_metadata_button')));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Tool calls'), findsOneWidget);
+    expect(find.text('1'), findsWidgets);
+    expect(find.text('Action timings'), findsOneWidget);
+    expect(find.text('schedule_notification'), findsWidgets);
+  });
+
+  testWidgets('assistant messages without metadata hide the metadata affordance', (
+    tester,
+  ) async {
+    await _pumpChatScreen(
+      tester,
+      initialMessages: [
+        ChatMessage(text: geminiNanoUnavailableMessage, isUser: false),
+      ],
+    );
+
+    expect(find.text(geminiNanoUnavailableMessage), findsOneWidget);
+    expect(find.byKey(const Key('agent_chat_metadata_button')), findsNothing);
+  });
+}
+
+Future<void> _pumpChatScreen(
+  WidgetTester tester, {
+  required List<ChatMessage> initialMessages,
+}) async {
+  tester.view.devicePixelRatio = 1.0;
+  tester.view.physicalSize = const Size(1200, 1000);
+  addTearDown(() {
+    tester.view.resetDevicePixelRatio();
+    tester.view.resetPhysicalSize();
+  });
+
+  SharedPreferences.setMockInitialValues({
+    'selected_assistant_model_id': geminiNanoAssistantModelId,
+  });
+
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [
+        selectedAssistantModelIdProvider.overrideWith(
+          (ref) => _SelectedAssistantModelNotifier(),
+        ),
+      ],
+      child: MaterialApp(
+        home: ChatScreen(
+          enableAiInitialization: false,
+          initialMessages: initialMessages,
+        ),
+      ),
+    ),
+  );
+  await tester.pumpAndSettle();
+}
+
+class _SelectedAssistantModelNotifier extends SelectedAssistantModelNotifier {
+  _SelectedAssistantModelNotifier() {
+    state = geminiNanoAssistantModelId;
+  }
+}


### PR DESCRIPTION
# Summary
This PR adds response timing metadata to Brain chat assistant messages and agent skill responses.
Goal: let users see a compact timing summary under assistant responses and inspect safe inference/action metadata in an expandable details sheet.

Core outcome:
- assistant chat messages can now carry response metadata instead of relying on transient UI state
- Brain chat shows a compact metadata button under assistant responses when metadata exists
- tapping the summary opens a response details sheet with runtime, execution mode, duration, token estimates, and tool counts where available
- agent skill traces now capture per-action durations and surface them in both the trace card and the details sheet

# Changes
### Code
* Added:
  * `app/lib/features/agent_chat/domain/models/chat_response_metadata.dart`
  * `app/test/features/agent_chat/presentation/screens/chat_screen_metadata_test.dart`
* Updated:
  * `app/lib/features/agent_chat/presentation/screens/chat_screen.dart` to attach metadata to messages and render the compact/details UI
  * `app/lib/features/agent_chat/domain/models/agent_skill.dart` and `app/lib/features/agent_chat/domain/services/agent_skill_orchestrator.dart` to capture per-action durations
  * `app/lib/features/agent_chat/presentation/widgets/skill_action_trace_card.dart` to show action timing labels
  * `app/test/features/agent_chat/domain/services/agent_skill_orchestrator_test.dart` for duration-aware expectations

### Logic
* streaming chat responses record total duration and time-to-first-token where available
* non-streaming responses use the same metadata path via the runtime stream wrapper
* agent skill responses record total duration and count executed tools
* metadata sheet only shows explicit safe fields and does not expose prompts, secrets, stack traces, file paths, or raw connector internals

# Risks
* this slice targets Brain chat / agent skill responses in the current chat surface and does not expand into restored history or other future chat modes
* focused Flutter tests in this worktree must run with `--no-pub` because Flutter currently fails deleting `ios/Flutter/ephemeral/Packages/.packages` in the worktree-generated iOS tree

# Testing
* `flutter analyze lib/features/agent_chat/presentation/screens/chat_screen.dart lib/features/agent_chat/domain/services/agent_skill_orchestrator.dart lib/features/agent_chat/presentation/widgets/skill_action_trace_card.dart lib/features/agent_chat/domain/models/chat_response_metadata.dart test/features/agent_chat/presentation/screens/chat_screen_metadata_test.dart test/features/agent_chat/domain/services/agent_skill_orchestrator_test.dart`
* `flutter test --no-pub test/features/agent_chat/presentation/screens/chat_screen_metadata_test.dart test/features/agent_chat/domain/services/agent_skill_orchestrator_test.dart`
