### PR TITLE
Finish shell asset registry adoption

### DIFF
--- a/app/lib/features/money/presentation/screens/money_overview_screen.dart
+++ b/app/lib/features/money/presentation/screens/money_overview_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:airo_app/shared/assets/shell_asset_registry.dart';
 import '../../../../core/dictionary/dictionary.dart';
 import '../../application/providers/money_provider.dart';
 import '../../domain/models/money_models.dart';
@@ -454,7 +455,7 @@ class _CoinsDemoSection extends StatelessWidget {
         fit: StackFit.expand,
         children: [
           Image.asset(
-            'assets/hermes/images/filler-bg0.jpg',
+            ShellAssetRegistry.shellBackdrop,
             fit: BoxFit.cover,
             color: Theme.of(
               context,

--- a/app/test/shared/assets/shell_asset_registry_test.dart
+++ b/app/test/shared/assets/shell_asset_registry_test.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:airo_app/shared/assets/shell_asset_registry.dart';
 import 'package:airo_app/shared/widgets/app_icon_placeholder.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -14,5 +16,26 @@ void main() {
 
   test('app icon placeholder consumes the shared shell asset registry', () {
     expect(AppIconPlaceholder.assetPath, ShellAssetRegistry.appIconRaster);
+  });
+
+  test('shell backdrop path is not hardcoded in feature sources', () async {
+    final libDir = Directory('lib');
+    final offenders = <String>[];
+
+    await for (final entity in libDir.list(recursive: true)) {
+      if (entity is! File || !entity.path.endsWith('.dart')) {
+        continue;
+      }
+      if (entity.path.endsWith('shared/assets/shell_asset_registry.dart')) {
+        continue;
+      }
+
+      final contents = await entity.readAsString();
+      if (contents.contains('assets/hermes/images/filler-bg0.jpg')) {
+        offenders.add(entity.path);
+      }
+    }
+
+    expect(offenders, isEmpty, reason: 'Remaining hardcoded shell backdrop references must migrate to ShellAssetRegistry.');
   });
 }

--- a/docs/standards/mobile-ui-ux-standards.md
+++ b/docs/standards/mobile-ui-ux-standards.md
@@ -82,12 +82,14 @@ Allowed behavior:
 
 - feature code consumes named shared assets
 - shell branding updates happen in one shared location
+- feature screens import `ShellAssetRegistry` when they need shell-owned imagery
 
 Disallowed behavior:
 
 - duplicate raw asset paths spread across widgets
 - feature-local copies of shell iconography
 - ad hoc branding changes inside screen files
+- direct references such as `assets/hermes/images/filler-bg0.jpg` outside the shared asset registry
 
 ## Verification Expectations
 


### PR DESCRIPTION
# Summary
This PR completes the remaining shell asset registry adoption for the shared shell backdrop.
Goal: remove the last known raw shell-owned asset path from feature code so shell branding stays centralized.

Core outcome:
- the Coins overview screen now consumes the shared shell backdrop through `ShellAssetRegistry`
- the mobile UI standards now explicitly forbid direct shell backdrop path usage outside the registry
- a static verification test now fails if the shell backdrop path leaks back into feature sources

# Changes
### Code
* Updated:
  * `app/lib/features/money/presentation/screens/money_overview_screen.dart` to replace the raw backdrop path with `ShellAssetRegistry.shellBackdrop`
  * `app/test/shared/assets/shell_asset_registry_test.dart` to add a static scan for hardcoded shell backdrop references in feature sources
  * `docs/standards/mobile-ui-ux-standards.md` to make the registry rule explicit

### Logic
* shell-owned imagery references now stay centralized for the remaining known shell backdrop usage
* static verification records that the migrated raw reference no longer exists in `app/lib`

# Testing
* `flutter analyze lib/features/money/presentation/screens/money_overview_screen.dart test/shared/assets/shell_asset_registry_test.dart`
* `flutter test test/shared/assets/shell_asset_registry_test.dart`
* `rg -n "assets/hermes/images/filler-bg0.jpg" app/lib -g '*.dart'`

# Notes
* Verification found only the shared registry definition remaining in `app/lib`; no feature-source hardcoded backdrop paths remain.
