### PR TITLE
fix(shell): compact mobile chrome actions

### DIFF
--- a/app/lib/core/app/app_shell.dart
+++ b/app/lib/core/app/app_shell.dart
@@ -8,19 +8,11 @@ import '../providers/bedtime_mode_provider.dart';
 import '../providers/navigation_provider.dart';
 import '../routing/route_names.dart';
 import '../theme/bedtime_theme.dart';
+import 'app_shell_chrome.dart';
 import '../../features/music/presentation/widgets/mini_player.dart';
 import '../../features/iptv/presentation/widgets/iptv_mini_player.dart';
 import '../../features/iptv/application/providers/iptv_providers.dart'
     hide currentNavigationTabProvider;
-import '../../shared/widgets/app_icon_placeholder.dart';
-
-/// Get initials from a name (e.g., "Uday Chauhan" -> "UC", "Uday" -> "U")
-String _getInitials(String name) {
-  final parts = name.trim().split(' ').where((p) => p.isNotEmpty).toList();
-  if (parts.isEmpty) return 'U';
-  if (parts.length == 1) return parts[0][0].toUpperCase();
-  return '${parts[0][0]}${parts[1][0]}'.toUpperCase();
-}
 
 /// App shell with bottom navigation for the six primary feature tabs.
 class AppShell extends ConsumerWidget {
@@ -44,119 +36,31 @@ class AppShell extends ConsumerWidget {
     }
 
     final navigationTabs = ref.watch(appNavigationTabsProvider);
+    final chromeConfig = ref.watch(appNavigationChromeConfigProvider);
     final currentPageName = navigationTabs[navigationShell.currentIndex].label;
 
     return Theme(
       data: isBedtimeMode ? BedtimeTheme.bedtimeTheme : Theme.of(context),
       child: Scaffold(
-        appBar: AppBar(
-          // Airo logo/title on left - clickable to go to default page
-          leading: InkWell(
-            onTap: () {
-              // Go to first tab (Dashboard) as default/home
-              ref.read(currentNavigationTabProvider.notifier).state = 0;
-              navigationShell.goBranch(0);
-            },
-            borderRadius: BorderRadius.circular(20),
-            child: Padding(
-              padding: const EdgeInsets.all(8.0),
-              child: AppIconPlaceholder(
-                size: 32,
-                errorBuilder: (_, _, _) => const Icon(Icons.home),
-              ),
-            ),
-          ),
-          // Current page name in center
+        appBar: AppShellChrome(
           title: Text(currentPageName),
-          centerTitle: true,
-          actions: [
-            IconButton(
-              tooltip: 'Notifications',
-              onPressed: () => context.push('/mind/notifications'),
-              icon: const Icon(Icons.notifications_outlined),
-            ),
-            // User profile avatar with menu
-            PopupMenuButton<String>(
-              icon: CircleAvatar(
-                radius: 16,
-                backgroundColor: Theme.of(context).colorScheme.primaryContainer,
-                child: user?.photoUrl != null
-                    ? ClipOval(
-                        child: Image.network(
-                          user!.photoUrl!,
-                          width: 32,
-                          height: 32,
-                          fit: BoxFit.cover,
-                          errorBuilder: (_, _, _) => Text(
-                            _getInitials(user.username),
-                            style: TextStyle(
-                              fontSize: 12,
-                              fontWeight: FontWeight.bold,
-                              color: Theme.of(
-                                context,
-                              ).colorScheme.onPrimaryContainer,
-                            ),
-                          ),
-                        ),
-                      )
-                    : Text(
-                        _getInitials(user?.username ?? 'U'),
-                        style: TextStyle(
-                          fontSize: 12,
-                          fontWeight: FontWeight.bold,
-                          color: Theme.of(
-                            context,
-                          ).colorScheme.onPrimaryContainer,
-                        ),
-                      ),
-              ),
-              onSelected: (value) async {
-                if (value == 'logout') {
-                  if (user?.isGoogleUser == true) {
-                    await GoogleAuthService.instance.signOut();
-                  }
-                  await AuthService.instance.logout();
-                  if (context.mounted) {
-                    context.go(RouteNames.login);
-                  }
-                } else if (value == 'profile') {
-                  context.push('/mind/profile');
-                }
-              },
-              itemBuilder: (context) => [
-                PopupMenuItem(
-                  value: 'profile',
-                  child: Row(
-                    children: [
-                      const Icon(Icons.person),
-                      const SizedBox(width: 8),
-                      Text(user?.username ?? 'Guest'),
-                      if (user?.isGoogleUser == true) ...[
-                        const SizedBox(width: 4),
-                        Icon(
-                          Icons.verified,
-                          size: 16,
-                          color: Theme.of(context).colorScheme.primary,
-                        ),
-                      ],
-                    ],
-                  ),
-                ),
-                const PopupMenuDivider(),
-                const PopupMenuItem(
-                  value: 'logout',
-                  child: Row(
-                    children: [
-                      Icon(Icons.logout, color: Colors.red),
-                      SizedBox(width: 8),
-                      Text('Logout', style: TextStyle(color: Colors.red)),
-                    ],
-                  ),
-                ),
-              ],
-            ),
-            const SizedBox(width: 8),
-          ],
+          user: user,
+          config: chromeConfig,
+          onHomeTap: () {
+            ref.read(currentNavigationTabProvider.notifier).state = 0;
+            navigationShell.goBranch(0);
+          },
+          onNotificationsTap: () => context.push('/mind/notifications'),
+          onProfileTap: () => context.push('/mind/profile'),
+          onLogoutTap: () async {
+            if (user?.isGoogleUser == true) {
+              await GoogleAuthService.instance.signOut();
+            }
+            await AuthService.instance.logout();
+            if (context.mounted) {
+              context.go(RouteNames.login);
+            }
+          },
         ),
         body: _ContextAwareMiniPlayers(
           currentIndex: navigationShell.currentIndex,

--- a/app/lib/core/app/app_shell_chrome.dart
+++ b/app/lib/core/app/app_shell_chrome.dart
@@ -1,0 +1,218 @@
+import 'package:flutter/material.dart';
+
+import '../auth/auth_service.dart';
+import '../providers/navigation_provider.dart';
+import '../../shared/widgets/app_icon_placeholder.dart';
+
+enum _CompactShellMenuAction { profile, logout }
+
+class AppShellChrome extends StatelessWidget implements PreferredSizeWidget {
+  const AppShellChrome({
+    super.key,
+    required this.title,
+    required this.user,
+    required this.config,
+    required this.onHomeTap,
+    required this.onNotificationsTap,
+    required this.onProfileTap,
+    required this.onLogoutTap,
+  });
+
+  final Widget title;
+  final User? user;
+  final AppNavigationChromeConfig config;
+  final VoidCallback onHomeTap;
+  final VoidCallback onNotificationsTap;
+  final VoidCallback onProfileTap;
+  final VoidCallback onLogoutTap;
+
+  @override
+  Size get preferredSize => const Size.fromHeight(kToolbarHeight);
+
+  @override
+  Widget build(BuildContext context) {
+    final width = MediaQuery.sizeOf(context).width;
+    final isCompact = width < config.compactWidthBreakpoint;
+
+    return AppBar(
+      leading: InkWell(
+        key: const ValueKey('app_shell_home_button'),
+        onTap: onHomeTap,
+        borderRadius: BorderRadius.circular(20),
+        child: const Padding(
+          padding: EdgeInsets.all(8),
+          child: AppIconPlaceholder(size: 32, errorBuilder: _homeIconFallback),
+        ),
+      ),
+      title: title,
+      centerTitle: true,
+      actions: [..._buildActions(context, isCompact), const SizedBox(width: 8)],
+    );
+  }
+
+  List<Widget> _buildActions(BuildContext context, bool isCompact) {
+    final actions = <Widget>[];
+    final hasNotifications = config.enabledActions.contains(
+      AppShellAction.notifications,
+    );
+    final hasProfileMenu = config.enabledActions.contains(
+      AppShellAction.profileMenu,
+    );
+
+    if (hasNotifications) {
+      actions.add(
+        IconButton(
+          key: const ValueKey('app_shell_notifications_button'),
+          tooltip: 'Notifications',
+          onPressed: onNotificationsTap,
+          icon: const Icon(Icons.notifications_outlined),
+        ),
+      );
+    }
+
+    if (!hasProfileMenu) {
+      return actions;
+    }
+
+    if (isCompact) {
+      actions.add(_buildCompactOverflowMenu(context));
+      return actions;
+    }
+
+    actions.add(_buildProfileMenu(context));
+    return actions;
+  }
+
+  Widget _buildCompactOverflowMenu(BuildContext context) {
+    return PopupMenuButton<_CompactShellMenuAction>(
+      key: const ValueKey('app_shell_overflow_button'),
+      tooltip: 'More actions',
+      onSelected: (value) {
+        switch (value) {
+          case _CompactShellMenuAction.profile:
+            onProfileTap();
+          case _CompactShellMenuAction.logout:
+            onLogoutTap();
+        }
+      },
+      itemBuilder: (context) => const [
+        PopupMenuItem<_CompactShellMenuAction>(
+          value: _CompactShellMenuAction.profile,
+          child: Row(
+            children: [Icon(Icons.person), SizedBox(width: 8), Text('Profile')],
+          ),
+        ),
+        PopupMenuDivider(),
+        PopupMenuItem<_CompactShellMenuAction>(
+          value: _CompactShellMenuAction.logout,
+          child: Row(
+            children: [
+              Icon(Icons.logout, color: Colors.red),
+              SizedBox(width: 8),
+              Text('Logout', style: TextStyle(color: Colors.red)),
+            ],
+          ),
+        ),
+      ],
+      icon: const Icon(Icons.more_vert),
+    );
+  }
+
+  Widget _buildProfileMenu(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+
+    return PopupMenuButton<String>(
+      key: const ValueKey('app_shell_profile_menu_button'),
+      tooltip: 'Profile',
+      onSelected: (value) {
+        if (value == 'logout') {
+          onLogoutTap();
+          return;
+        }
+        if (value == 'profile') {
+          onProfileTap();
+        }
+      },
+      icon: CircleAvatar(
+        radius: 16,
+        backgroundColor: colorScheme.primaryContainer,
+        child: user?.photoUrl != null
+            ? ClipOval(
+                child: Image.network(
+                  user!.photoUrl!,
+                  width: 32,
+                  height: 32,
+                  fit: BoxFit.cover,
+                  errorBuilder: (_, _, _) =>
+                      _AvatarInitials(initials: _getInitials(user!.username)),
+                ),
+              )
+            : _AvatarInitials(initials: _getInitials(user?.username ?? 'U')),
+      ),
+      itemBuilder: (context) => [
+        PopupMenuItem<String>(
+          value: 'profile',
+          child: Row(
+            children: [
+              const Icon(Icons.person),
+              const SizedBox(width: 8),
+              Text(user?.username ?? 'Guest'),
+              if (user?.isGoogleUser == true) ...[
+                const SizedBox(width: 4),
+                Icon(Icons.verified, size: 16, color: colorScheme.primary),
+              ],
+            ],
+          ),
+        ),
+        const PopupMenuDivider(),
+        const PopupMenuItem<String>(
+          value: 'logout',
+          child: Row(
+            children: [
+              Icon(Icons.logout, color: Colors.red),
+              SizedBox(width: 8),
+              Text('Logout', style: TextStyle(color: Colors.red)),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _AvatarInitials extends StatelessWidget {
+  const _AvatarInitials({required this.initials});
+
+  final String initials;
+
+  @override
+  Widget build(BuildContext context) {
+    return Text(
+      initials,
+      style: TextStyle(
+        fontSize: 12,
+        fontWeight: FontWeight.bold,
+        color: Theme.of(context).colorScheme.onPrimaryContainer,
+      ),
+    );
+  }
+}
+
+String _getInitials(String name) {
+  final parts = name
+      .trim()
+      .split(' ')
+      .where((part) => part.isNotEmpty)
+      .toList();
+  if (parts.isEmpty) return 'U';
+  if (parts.length == 1) return parts[0][0].toUpperCase();
+  return '${parts[0][0]}${parts[1][0]}'.toUpperCase();
+}
+
+Widget _homeIconFallback(
+  BuildContext context,
+  Object error,
+  StackTrace? stackTrace,
+) {
+  return const Icon(Icons.home);
+}

--- a/app/lib/core/providers/navigation_provider.dart
+++ b/app/lib/core/providers/navigation_provider.dart
@@ -63,6 +63,24 @@ final appNavigationTabsProvider = Provider<List<AppNavigationTab>>(
   (ref) => AppNavigationTab.values,
 );
 
+enum AppShellAction { notifications, profileMenu }
+
+class AppNavigationChromeConfig {
+  const AppNavigationChromeConfig({
+    required this.enabledActions,
+    this.compactWidthBreakpoint = 600,
+  });
+
+  final List<AppShellAction> enabledActions;
+  final double compactWidthBreakpoint;
+}
+
+final appNavigationChromeConfigProvider = Provider<AppNavigationChromeConfig>(
+  (ref) => const AppNavigationChromeConfig(
+    enabledActions: [AppShellAction.notifications, AppShellAction.profileMenu],
+  ),
+);
+
 class MiniPlayerVisibility {
   const MiniPlayerVisibility({
     required this.showMusicPlayer,

--- a/app/test/core/app/app_shell_chrome_test.dart
+++ b/app/test/core/app/app_shell_chrome_test.dart
@@ -1,0 +1,138 @@
+import 'package:airo_app/core/app/app_shell_chrome.dart';
+import 'package:airo_app/core/auth/auth_service.dart';
+import 'package:airo_app/core/providers/navigation_provider.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  const config = AppNavigationChromeConfig(
+    enabledActions: [AppShellAction.notifications, AppShellAction.profileMenu],
+  );
+
+  final user = User(
+    id: 'user-1',
+    username: 'Uday Chauhan',
+    isAdmin: false,
+    createdAt: DateTime(2024),
+  );
+
+  Future<void> pumpChrome(
+    WidgetTester tester, {
+    required double width,
+    required VoidCallback onNotificationsTap,
+    required VoidCallback onProfileTap,
+    required VoidCallback onLogoutTap,
+  }) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: MediaQuery(
+          data: MediaQueryData(size: Size(width, 800)),
+          child: Scaffold(
+            appBar: AppShellChrome(
+              title: const Text('Mind'),
+              user: user,
+              config: config,
+              onHomeTap: () {},
+              onNotificationsTap: onNotificationsTap,
+              onProfileTap: onProfileTap,
+              onLogoutTap: onLogoutTap,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  testWidgets('uses overflow menu on compact widths', (tester) async {
+    var notificationsTapped = 0;
+    var profileTapped = 0;
+    var logoutTapped = 0;
+
+    await pumpChrome(
+      tester,
+      width: 420,
+      onNotificationsTap: () => notificationsTapped++,
+      onProfileTap: () => profileTapped++,
+      onLogoutTap: () => logoutTapped++,
+    );
+
+    expect(
+      find.byKey(const ValueKey('app_shell_notifications_button')),
+      findsOneWidget,
+    );
+    expect(
+      find.byKey(const ValueKey('app_shell_overflow_button')),
+      findsOneWidget,
+    );
+    expect(
+      find.byKey(const ValueKey('app_shell_profile_menu_button')),
+      findsNothing,
+    );
+
+    await tester.tap(
+      find.byKey(const ValueKey('app_shell_notifications_button')),
+    );
+    await tester.pump();
+    expect(notificationsTapped, 1);
+
+    await tester.tap(find.byKey(const ValueKey('app_shell_overflow_button')));
+    await tester.pumpAndSettle();
+    expect(find.text('Profile'), findsOneWidget);
+    expect(find.text('Logout'), findsOneWidget);
+
+    await tester.tap(find.text('Profile'));
+    await tester.pumpAndSettle();
+    expect(profileTapped, 1);
+
+    await tester.tap(find.byKey(const ValueKey('app_shell_overflow_button')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Logout'));
+    await tester.pumpAndSettle();
+    expect(logoutTapped, 1);
+  });
+
+  testWidgets('keeps profile menu visible on wider widths', (tester) async {
+    var profileTapped = 0;
+    var logoutTapped = 0;
+
+    await pumpChrome(
+      tester,
+      width: 900,
+      onNotificationsTap: () {},
+      onProfileTap: () => profileTapped++,
+      onLogoutTap: () => logoutTapped++,
+    );
+
+    expect(
+      find.byKey(const ValueKey('app_shell_notifications_button')),
+      findsOneWidget,
+    );
+    expect(
+      find.byKey(const ValueKey('app_shell_profile_menu_button')),
+      findsOneWidget,
+    );
+    expect(
+      find.byKey(const ValueKey('app_shell_overflow_button')),
+      findsNothing,
+    );
+
+    await tester.tap(
+      find.byKey(const ValueKey('app_shell_profile_menu_button')),
+    );
+    await tester.pumpAndSettle();
+    expect(find.text('Uday Chauhan'), findsOneWidget);
+    expect(find.text('Logout'), findsOneWidget);
+
+    await tester.tap(find.text('Uday Chauhan'));
+    await tester.pumpAndSettle();
+    expect(profileTapped, 1);
+
+    await tester.tap(
+      find.byKey(const ValueKey('app_shell_profile_menu_button')),
+    );
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Logout'));
+    await tester.pumpAndSettle();
+    expect(logoutTapped, 1);
+  });
+}

--- a/app/test/core/providers/navigation_provider_test.dart
+++ b/app/test/core/providers/navigation_provider_test.dart
@@ -66,5 +66,18 @@ void main() {
         );
       }
     });
+
+    test('centralizes shell chrome actions for compact and wide layouts', () {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      final chromeConfig = container.read(appNavigationChromeConfigProvider);
+
+      expect(chromeConfig.enabledActions, const [
+        AppShellAction.notifications,
+        AppShellAction.profileMenu,
+      ]);
+      expect(chromeConfig.compactWidthBreakpoint, 600);
+    });
   });
 }


### PR DESCRIPTION
# Summary

This PR introduces changes to shell chrome.
Goal: compact the mobile app shell header while keeping key actions accessible.

Core outcome:

* keeps notifications visible on narrow screens
* moves profile and logout into an overflow menu on compact layouts
* centralizes shell chrome action config and adds focused coverage

# Changes

### Code

* Added:
  *  shared shell app bar widget
  *  widget coverage for compact and wide layouts
* Updated:
  *  to use shared chrome callbacks
  *  to centralize shell chrome action config
  *  to lock the shared action contract

### Logic

* compact widths keep notifications pinned and collapse profile/logout into overflow
* wider widths keep the profile menu directly visible
* home, notifications, profile, and logout actions now route through one chrome component

# API Changes (if any)

* None.

# Database Changes (if any)

* None.

# Observability / Logging

* None.

# Performance Impact

* Latency: no meaningful change
* Throughput: no meaningful change
* Memory/CPU: negligible

# Risks

* width breakpoint may need tuning if design standards change
* menu affordances depend on popup menu behavior across platforms
* Rollback plan:
  * revert this PR

# Testing

* Unit tests:
  * provider contract coverage for shell chrome config
* Integration tests:
  * none
* Manual testing:
  * not run
* Widget tests:
  * compact overflow behavior and expanded profile menu behavior

# Deployment Notes

* Config changes:
  * none
* Order of deployment:
  * standard

# Related Commits

* fix(shell): compact mobile chrome actions

# Notes

* Focus review on compact-vs-wide action presentation and callback wiring.

Closes #409