### PR TITLE
fix(shell): prevent duplicate route headers

### DIFF
--- a/app/lib/core/app/app_shell.dart
+++ b/app/lib/core/app/app_shell.dart
@@ -16,9 +16,14 @@ import '../../features/iptv/application/providers/iptv_providers.dart'
 
 /// App shell with bottom navigation for the six primary feature tabs.
 class AppShell extends ConsumerWidget {
-  const AppShell({super.key, required this.navigationShell});
+  const AppShell({
+    super.key,
+    required this.navigationShell,
+    required this.currentLocation,
+  });
 
   final StatefulNavigationShell navigationShell;
+  final String currentLocation;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -37,31 +42,34 @@ class AppShell extends ConsumerWidget {
 
     final navigationTabs = ref.watch(appNavigationTabsProvider);
     final chromeConfig = ref.watch(appNavigationChromeConfigProvider);
+    final headerMode = ref.watch(appShellHeaderModeProvider(currentLocation));
     final currentPageName = navigationTabs[navigationShell.currentIndex].label;
 
     return Theme(
       data: isBedtimeMode ? BedtimeTheme.bedtimeTheme : Theme.of(context),
       child: Scaffold(
-        appBar: AppShellChrome(
-          title: Text(currentPageName),
-          user: user,
-          config: chromeConfig,
-          onHomeTap: () {
-            ref.read(currentNavigationTabProvider.notifier).state = 0;
-            navigationShell.goBranch(0);
-          },
-          onNotificationsTap: () => context.push('/mind/notifications'),
-          onProfileTap: () => context.push('/mind/profile'),
-          onLogoutTap: () async {
-            if (user?.isGoogleUser == true) {
-              await GoogleAuthService.instance.signOut();
-            }
-            await AuthService.instance.logout();
-            if (context.mounted) {
-              context.go(RouteNames.login);
-            }
-          },
-        ),
+        appBar: headerMode == AppShellHeaderMode.shell
+            ? AppShellChrome(
+                title: Text(currentPageName),
+                user: user,
+                config: chromeConfig,
+                onHomeTap: () {
+                  ref.read(currentNavigationTabProvider.notifier).state = 0;
+                  navigationShell.goBranch(0);
+                },
+                onNotificationsTap: () => context.push('/mind/notifications'),
+                onProfileTap: () => context.push('/mind/profile'),
+                onLogoutTap: () async {
+                  if (user?.isGoogleUser == true) {
+                    await GoogleAuthService.instance.signOut();
+                  }
+                  await AuthService.instance.logout();
+                  if (context.mounted) {
+                    context.go(RouteNames.login);
+                  }
+                },
+              )
+            : null,
         body: _ContextAwareMiniPlayers(
           currentIndex: navigationShell.currentIndex,
           child: navigationShell,

--- a/app/lib/core/providers/navigation_provider.dart
+++ b/app/lib/core/providers/navigation_provider.dart
@@ -81,6 +81,46 @@ final appNavigationChromeConfigProvider = Provider<AppNavigationChromeConfig>(
   ),
 );
 
+enum AppShellHeaderMode { shell, route }
+
+AppShellHeaderMode appShellHeaderModeForLocation(String location) {
+  final normalizedLocation = Uri.parse(location).path;
+
+  const shellOwnedExactLocations = {
+    '/money',
+    '/mind',
+    '/mind/chat',
+    '/mind/models',
+    '/games',
+  };
+  if (shellOwnedExactLocations.contains(normalizedLocation)) {
+    return AppShellHeaderMode.shell;
+  }
+
+  const routeOwnedPrefixes = [
+    '/money/',
+    '/mind/',
+    '/music',
+    '/iptv',
+    '/games/',
+    '/quest',
+  ];
+  for (final prefix in routeOwnedPrefixes) {
+    if (normalizedLocation == prefix || normalizedLocation.startsWith(prefix)) {
+      return AppShellHeaderMode.route;
+    }
+  }
+
+  return AppShellHeaderMode.shell;
+}
+
+final appShellHeaderModeProvider = Provider.family<AppShellHeaderMode, String>((
+  ref,
+  location,
+) {
+  return appShellHeaderModeForLocation(location);
+});
+
 class MiniPlayerVisibility {
   const MiniPlayerVisibility({
     required this.showMusicPlayer,

--- a/app/lib/core/routing/app_router.dart
+++ b/app/lib/core/routing/app_router.dart
@@ -85,7 +85,10 @@ class AppRouter {
       ),
       StatefulShellRoute.indexedStack(
         builder: (context, state, navigationShell) {
-          return AppShell(navigationShell: navigationShell);
+          return AppShell(
+            navigationShell: navigationShell,
+            currentLocation: state.uri.path,
+          );
         },
         branches: [
           // Money branch

--- a/app/test/core/app/app_shell_header_ownership_test.dart
+++ b/app/test/core/app/app_shell_header_ownership_test.dart
@@ -1,0 +1,151 @@
+import 'package:airo_app/core/app/app_shell.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+
+void main() {
+  Future<void> pumpShellRoute(
+    WidgetTester tester, {
+    required String initialLocation,
+  }) async {
+    final router = GoRouter(
+      initialLocation: initialLocation,
+      routes: [
+        StatefulShellRoute.indexedStack(
+          builder: (context, state, navigationShell) {
+            return ProviderScope(
+              child: AppShell(
+                navigationShell: navigationShell,
+                currentLocation: state.uri.path,
+              ),
+            );
+          },
+          branches: [
+            StatefulShellBranch(
+              routes: [
+                GoRoute(
+                  path: '/money',
+                  builder: (context, state) =>
+                      const _ShellBodyScreen(label: 'Money body'),
+                ),
+              ],
+            ),
+            StatefulShellBranch(
+              routes: [
+                GoRoute(
+                  path: '/mind',
+                  builder: (context, state) =>
+                      const _ShellBodyScreen(label: 'Mind body'),
+                  routes: [
+                    GoRoute(
+                      path: 'profile',
+                      builder: (context, state) =>
+                          const _RouteOwnedScreen(title: 'Profile'),
+                    ),
+                  ],
+                ),
+              ],
+            ),
+            StatefulShellBranch(
+              routes: [
+                GoRoute(
+                  path: '/music',
+                  builder: (context, state) =>
+                      const _RouteOwnedScreen(title: 'Beats'),
+                ),
+              ],
+            ),
+            StatefulShellBranch(
+              routes: [
+                GoRoute(
+                  path: '/iptv',
+                  builder: (context, state) =>
+                      const _RouteOwnedScreen(title: 'Stream'),
+                ),
+              ],
+            ),
+            StatefulShellBranch(
+              routes: [
+                GoRoute(
+                  path: '/games',
+                  builder: (context, state) =>
+                      const _ShellBodyScreen(label: 'Games body'),
+                ),
+              ],
+            ),
+            StatefulShellBranch(
+              routes: [
+                GoRoute(
+                  path: '/quest',
+                  builder: (context, state) =>
+                      const _RouteOwnedScreen(title: 'Quest'),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ],
+    );
+
+    await tester.pumpWidget(
+      ProviderScope(child: MaterialApp.router(routerConfig: router)),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  testWidgets('shows shell chrome on shell-owned root routes', (tester) async {
+    await pumpShellRoute(tester, initialLocation: '/mind');
+
+    expect(find.byType(AppBar), findsOneWidget);
+    expect(find.widgetWithText(AppBar, 'Mind'), findsOneWidget);
+    expect(find.byKey(const ValueKey('app_shell_home_button')), findsOneWidget);
+    expect(find.text('Mind body'), findsOneWidget);
+  });
+
+  testWidgets('hides shell chrome on route-owned root routes', (tester) async {
+    await pumpShellRoute(tester, initialLocation: '/music');
+
+    expect(find.byType(AppBar), findsOneWidget);
+    expect(find.widgetWithText(AppBar, 'Beats'), findsOneWidget);
+    expect(find.byKey(const ValueKey('app_shell_home_button')), findsNothing);
+  });
+
+  testWidgets('hides shell chrome on nested route-owned screens', (
+    tester,
+  ) async {
+    await pumpShellRoute(tester, initialLocation: '/mind/profile');
+
+    expect(find.byType(AppBar), findsOneWidget);
+    expect(find.widgetWithText(AppBar, 'Profile'), findsOneWidget);
+    expect(find.byKey(const ValueKey('app_shell_home_button')), findsNothing);
+  });
+}
+
+class _ShellBodyScreen extends StatelessWidget {
+  const _ShellBodyScreen({required this.label});
+
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: Colors.transparent,
+      body: Center(child: Text(label)),
+    );
+  }
+}
+
+class _RouteOwnedScreen extends StatelessWidget {
+  const _RouteOwnedScreen({required this.title});
+
+  final String title;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: Text(title)),
+      body: Center(child: Text('$title body')),
+    );
+  }
+}

--- a/app/test/core/providers/navigation_provider_test.dart
+++ b/app/test/core/providers/navigation_provider_test.dart
@@ -79,5 +79,45 @@ void main() {
       ]);
       expect(chromeConfig.compactWidthBreakpoint, 600);
     });
+
+    test('keeps shell-owned headers only on routes without local app bars', () {
+      expect(appShellHeaderModeForLocation('/money'), AppShellHeaderMode.shell);
+      expect(appShellHeaderModeForLocation('/mind'), AppShellHeaderMode.shell);
+      expect(
+        appShellHeaderModeForLocation('/mind/chat'),
+        AppShellHeaderMode.shell,
+      );
+      expect(
+        appShellHeaderModeForLocation('/mind/models'),
+        AppShellHeaderMode.shell,
+      );
+      expect(appShellHeaderModeForLocation('/games'), AppShellHeaderMode.shell);
+    });
+
+    test('switches custom and nested routes to route-owned headers', () {
+      expect(appShellHeaderModeForLocation('/music'), AppShellHeaderMode.route);
+      expect(appShellHeaderModeForLocation('/iptv'), AppShellHeaderMode.route);
+      expect(appShellHeaderModeForLocation('/quest'), AppShellHeaderMode.route);
+      expect(
+        appShellHeaderModeForLocation('/quest/new'),
+        AppShellHeaderMode.route,
+      );
+      expect(
+        appShellHeaderModeForLocation('/money/dashboard'),
+        AppShellHeaderMode.route,
+      );
+      expect(
+        appShellHeaderModeForLocation('/money/groups/alpha'),
+        AppShellHeaderMode.route,
+      );
+      expect(
+        appShellHeaderModeForLocation('/mind/profile'),
+        AppShellHeaderMode.route,
+      );
+      expect(
+        appShellHeaderModeForLocation('/mind/notifications'),
+        AppShellHeaderMode.route,
+      );
+    });
   });
 }

--- a/docs/wiki/3.-Navigating-Airo.md
+++ b/docs/wiki/3.-Navigating-Airo.md
@@ -7,6 +7,11 @@ Airo is organized around six primary tabs.
 The Dashboard tab opens `/money`. Use it to view financial state, add expenses,
 manage budgets, open groups, and launch bill splitting.
 
+Header behavior:
+
+- `/money` uses the shared shell header.
+- nested money routes switch to their own contextual app bars.
+
 Common routes:
 
 - `/money`
@@ -17,30 +22,55 @@ Common routes:
 
 ## Assistant
 
-The Assistant tab opens `/agent`. It includes:
+The Assistant tab opens `/mind`. Legacy `/agent` links redirect there. It
+includes:
 
 - A chat surface.
 - Gallery-style prompt cards.
 - Deterministic command routing for supported Airo actions.
 - On-device AI initialization where supported.
-- Profile and model-management access at `/agent/profile`.
+- Profile and model-management access at `/mind/profile` and `/mind/models`.
+
+Header behavior:
+
+- `/mind`, `/mind/chat`, and `/mind/models` use the shared shell header.
+- `/mind/profile` and `/mind/notifications` use their own contextual app bars.
 
 ## Music
 
-The Music tab opens `/beats`. It is the audio playback surface and controls
-music mini-player visibility.
+The Music tab opens `/music`. Legacy `/beats` links redirect there. It is the
+audio playback surface and controls music mini-player visibility.
+
+Header behavior:
+
+- `/music` keeps its own route-level app bar because Beats owns search and
+  queue actions.
 
 ## TV
 
-The TV tab opens `/stream`. It is the IPTV and video playback surface, including
-TV-friendly controls and mini-player behavior.
+The TV tab opens `/iptv`. Legacy `/stream` links redirect there. It is the IPTV
+and video playback surface, including TV-friendly controls and mini-player
+behavior.
+
+Header behavior:
+
+- `/iptv` keeps its own route-level app bar for stream search and cast actions.
 
 ## Games
 
 The Games tab opens `/games`. It contains the Arena game hub and routes users to
 available games.
 
+Header behavior:
+
+- `/games` uses the shared shell header.
+
 ## Tasks
 
 The Tasks tab opens `/quest`. Use it to create quests, upload files, and ask
 follow-up questions in a quest chat.
+
+Header behavior:
+
+- `/quest` and nested quest flows use route-level app bars so quest actions stay
+  contextual to the current task.


### PR DESCRIPTION
# Summary

This PR introduces changes to shell and route header ownership.
Goal: ensure shell-mounted routes show only one visible top header.

Core outcome:

* shell-managed routes keep the shared AppShell chrome
* custom-header and nested flows hide the shell app bar instead of rendering duplicates
* provider and router tests lock the ownership behavior

# Changes

### Code

* Added:
  * app/test/core/app/app_shell_header_ownership_test.dart router-level shell/header coverage
* Updated:
  * app/lib/core/providers/navigation_provider.dart with route-to-header ownership rules
  * app/lib/core/app/app_shell.dart to gate shell chrome by current route
  * app/lib/core/routing/app_router.dart to pass the active path into the shell
  * app/test/core/providers/navigation_provider_test.dart with shell-vs-route ownership assertions

### Logic

* `/money`, `/mind`, `/mind/chat`, `/mind/models`, and `/games` remain shell-owned
* custom-header routes like `/music`, `/iptv`, `/quest`, `/mind/profile`, and nested money flows become route-owned
* fullscreen behavior remains unchanged and still bypasses shell chrome entirely

# API Changes (if any)

* None.

# Database Changes (if any)

* None.

# Observability / Logging

* None.

# Performance Impact

* Latency: no meaningful change
* Throughput: no meaningful change
* Memory/CPU: negligible

# Risks

* route ownership depends on path classification, so new shell routes must join the config map
* any future route without a local app bar must be marked shell-owned explicitly
* Rollback plan:
  * revert this PR

# Testing

* Unit tests:
  * navigation provider route ownership coverage
* Integration tests:
  * minimal router widget test for shell-owned root, route-owned root, and nested route-owned flow
* Manual testing:
  * not run

# Deployment Notes

* Config changes:
  * none
* Order of deployment:
  * standard

# Related Commits

* fix(shell): prevent duplicate route headers

# Notes

* Review the exact ownership map in navigation_provider.dart if additional shell-mounted routes are expected.

Closes #398
