### PR TITLE
fix(agent-chat): add safe local runtime preflight

### DIFF
--- a/app/lib/core/services/litert_lm_service.dart
+++ b/app/lib/core/services/litert_lm_service.dart
@@ -106,10 +106,15 @@ class LiteRtLmService {
     if (kIsWeb) return false;
 
     try {
-      final defaultModelPath = config.hasModelPath ? config.modelPath.trim() : null;
-      if (!await _client.activeModelExists(modelPath: defaultModelPath)) return false;
+      final defaultModelPath = config.hasModelPath
+          ? config.modelPath.trim()
+          : null;
+      if (!await _client.activeModelExists(modelPath: defaultModelPath)) {
+        return false;
+      }
 
-      if (_initializedModelPath == null || _initializedModelPath != defaultModelPath) {
+      if (_initializedModelPath == null ||
+          _initializedModelPath != defaultModelPath) {
         await _client.initialize(
           huggingFaceToken: config.optionalHuggingFaceToken,
           modelPath: defaultModelPath,
@@ -126,6 +131,35 @@ class LiteRtLmService {
       return true;
     } catch (e) {
       debugPrint('LiteRT-LM warmup skipped: $e');
+      return false;
+    }
+  }
+
+  Future<bool> warmupModel(OfflineModelInfo model) async {
+    if (kIsWeb) {
+      return false;
+    }
+
+    try {
+      final hydratedModel = await hydrateDownloadedModel(model);
+      final modelPath = hydratedModel.filePath?.trim();
+      if (modelPath == null || modelPath.isEmpty) {
+        return false;
+      }
+
+      final backend = _backendFor(hydratedModel.backendPreference);
+      if (!await _ensureInitializedForRequest(
+        modelPath: modelPath,
+        backend: backend,
+        maxTokens: config.maxTokens,
+      )) {
+        return false;
+      }
+
+      await _client.generate(prompt: ' ', backend: backend, maxTokens: 1);
+      return true;
+    } catch (e) {
+      debugPrint('LiteRT-LM model warmup skipped: $e');
       return false;
     }
   }

--- a/app/lib/features/agent_chat/data/services/assistant_runtime_service.dart
+++ b/app/lib/features/agent_chat/data/services/assistant_runtime_service.dart
@@ -20,6 +20,117 @@ typedef LiteRtModelTextGenerator =
 typedef CloudInitializer = Future<void> Function();
 typedef CloudAvailabilityCheck = bool Function();
 typedef CloudTextGenerator = Future<String?> Function(String prompt);
+typedef GeminiNanoWarmup = Future<bool> Function();
+typedef LiteRtAvailabilityCheck = Future<bool> Function();
+typedef LiteRtWarmup = Future<bool> Function();
+typedef LiteRtModelWarmup = Future<bool> Function(OfflineModelInfo model);
+typedef DeviceInfoLoader = Future<Map<String, dynamic>> Function();
+typedef ModelCompatibilityCheck =
+    Future<ModelCompatibilityResult> Function(OfflineModelInfo model);
+
+enum AssistantRuntimePreparationPhase {
+  validate,
+  allocate,
+  load,
+  warmup,
+  ready,
+}
+
+enum AssistantRuntimePreparationStatus { ready, cancelled, blocked }
+
+class AssistantRuntimePreparationProgress {
+  const AssistantRuntimePreparationProgress({
+    required this.phase,
+    required this.progress,
+    required this.label,
+    required this.detail,
+  });
+
+  final AssistantRuntimePreparationPhase phase;
+  final double progress;
+  final String label;
+  final String detail;
+}
+
+class AssistantRuntimeDiagnosticEnvelope {
+  const AssistantRuntimeDiagnosticEnvelope({
+    required this.runtimeId,
+    required this.runtimeName,
+    required this.summary,
+    required this.detail,
+    required this.deviceLabel,
+    required this.platformLabel,
+    required this.repairActions,
+    this.reasonCode,
+    this.availableMemoryMB,
+    this.requiredMemoryMB,
+  });
+
+  final String runtimeId;
+  final String runtimeName;
+  final String summary;
+  final String detail;
+  final String deviceLabel;
+  final String platformLabel;
+  final List<String> repairActions;
+  final String? reasonCode;
+  final double? availableMemoryMB;
+  final double? requiredMemoryMB;
+
+  String toMarkdown() {
+    final buffer = StringBuffer()
+      ..writeln('Runtime: $runtimeName ($runtimeId)')
+      ..writeln('Summary: $summary')
+      ..writeln('Detail: $detail')
+      ..writeln('Device: $deviceLabel')
+      ..writeln('Platform: $platformLabel');
+    if (reasonCode != null) {
+      buffer.writeln('Reason code: $reasonCode');
+    }
+    if (availableMemoryMB != null || requiredMemoryMB != null) {
+      buffer.writeln(
+        'Memory MB: available=${availableMemoryMB?.toStringAsFixed(0) ?? 'n/a'}, '
+        'required=${requiredMemoryMB?.toStringAsFixed(0) ?? 'n/a'}',
+      );
+    }
+    if (repairActions.isNotEmpty) {
+      buffer.writeln('Repair actions:');
+      for (final action in repairActions) {
+        buffer.writeln('- $action');
+      }
+    }
+    return buffer.toString().trimRight();
+  }
+}
+
+class AssistantRuntimePreparationResult {
+  const AssistantRuntimePreparationResult._({
+    required this.status,
+    this.diagnostic,
+  });
+
+  final AssistantRuntimePreparationStatus status;
+  final AssistantRuntimeDiagnosticEnvelope? diagnostic;
+
+  bool get isReady => status == AssistantRuntimePreparationStatus.ready;
+
+  factory AssistantRuntimePreparationResult.ready() =>
+      const AssistantRuntimePreparationResult._(
+        status: AssistantRuntimePreparationStatus.ready,
+      );
+
+  factory AssistantRuntimePreparationResult.cancelled() =>
+      const AssistantRuntimePreparationResult._(
+        status: AssistantRuntimePreparationStatus.cancelled,
+      );
+
+  factory AssistantRuntimePreparationResult.blocked(
+    AssistantRuntimeDiagnosticEnvelope diagnostic,
+  ) => AssistantRuntimePreparationResult._(
+    status: AssistantRuntimePreparationStatus.blocked,
+    diagnostic: diagnostic,
+  );
+}
 
 class AssistantRuntimeUnavailableException implements Exception {
   AssistantRuntimeUnavailableException(this.runtimeId, this.message);
@@ -45,6 +156,12 @@ class AssistantRuntimeService {
     CloudInitializer? initializeCloud,
     CloudAvailabilityCheck? isCloudAvailable,
     CloudTextGenerator? generateCloudText,
+    GeminiNanoWarmup? warmupGeminiNano,
+    LiteRtAvailabilityCheck? isLiteRtAvailable,
+    LiteRtWarmup? warmupLiteRtInstalledModel,
+    LiteRtModelWarmup? warmupLiteRtModel,
+    DeviceInfoLoader? loadDeviceInfo,
+    ModelCompatibilityCheck? checkModelCompatibility,
     Future<AssistantModelLibraryState> Function()? loadAssistantModelLibrary,
   }) : _geminiNano = geminiNano ?? GeminiNanoService(),
        _liteRtLm = liteRtLm ?? LiteRtLmService(),
@@ -58,6 +175,12 @@ class AssistantRuntimeService {
        _initializeCloudOverride = initializeCloud,
        _isCloudAvailableOverride = isCloudAvailable,
        _generateCloudTextOverride = generateCloudText,
+       _warmupGeminiNanoOverride = warmupGeminiNano,
+       _isLiteRtAvailableOverride = isLiteRtAvailable,
+       _warmupLiteRtInstalledModelOverride = warmupLiteRtInstalledModel,
+       _warmupLiteRtModelOverride = warmupLiteRtModel,
+       _loadDeviceInfoOverride = loadDeviceInfo,
+       _checkModelCompatibilityOverride = checkModelCompatibility,
        _loadAssistantModelLibraryOverride = loadAssistantModelLibrary;
 
   final GeminiNanoService _geminiNano;
@@ -72,8 +195,257 @@ class AssistantRuntimeService {
   final CloudInitializer? _initializeCloudOverride;
   final CloudAvailabilityCheck? _isCloudAvailableOverride;
   final CloudTextGenerator? _generateCloudTextOverride;
+  final GeminiNanoWarmup? _warmupGeminiNanoOverride;
+  final LiteRtAvailabilityCheck? _isLiteRtAvailableOverride;
+  final LiteRtWarmup? _warmupLiteRtInstalledModelOverride;
+  final LiteRtModelWarmup? _warmupLiteRtModelOverride;
+  final DeviceInfoLoader? _loadDeviceInfoOverride;
+  final ModelCompatibilityCheck? _checkModelCompatibilityOverride;
   final Future<AssistantModelLibraryState> Function()?
   _loadAssistantModelLibraryOverride;
+
+  Future<AssistantRuntimePreparationResult> prepareRuntime({
+    required AssistantModelCandidate candidate,
+    void Function(AssistantRuntimePreparationProgress progress)? onProgress,
+    bool Function()? isCancelled,
+  }) async {
+    AssistantRuntimePreparationResult? cancelled() {
+      if (isCancelled?.call() ?? false) {
+        return AssistantRuntimePreparationResult.cancelled();
+      }
+      return null;
+    }
+
+    void emit(
+      AssistantRuntimePreparationPhase phase,
+      double progress,
+      String label,
+      String detail,
+    ) {
+      onProgress?.call(
+        AssistantRuntimePreparationProgress(
+          phase: phase,
+          progress: progress,
+          label: label,
+          detail: detail,
+        ),
+      );
+    }
+
+    final deviceInfo =
+        await (_loadDeviceInfoOverride?.call() ?? _geminiNano.getDeviceInfo());
+    final platformLabel =
+        (deviceInfo['platform'] as String?)?.toUpperCase() ?? 'DEVICE';
+    final deviceLabel = [
+      deviceInfo['manufacturer'],
+      deviceInfo['model'],
+    ].whereType<String>().where((part) => part.trim().isNotEmpty).join(' ');
+    final resolvedDeviceLabel = deviceLabel.isEmpty
+        ? 'Unknown device'
+        : deviceLabel;
+
+    emit(
+      AssistantRuntimePreparationPhase.validate,
+      0.15,
+      'Validate runtime',
+      'Checking whether ${candidate.name} can launch on this device.',
+    );
+    final earlyCancel = cancelled();
+    if (earlyCancel != null) return earlyCancel;
+
+    if (!candidate.local) {
+      emit(
+        AssistantRuntimePreparationPhase.ready,
+        1,
+        'Runtime ready',
+        '${candidate.name} does not require local initialization.',
+      );
+      return AssistantRuntimePreparationResult.ready();
+    }
+
+    switch (candidate.id) {
+      case geminiNanoAssistantModelId:
+        final supported =
+            await (_isGeminiNanoSupportedOverride?.call() ??
+                _geminiNano.isSupported());
+        if (!supported) {
+          return AssistantRuntimePreparationResult.blocked(
+            AssistantRuntimeDiagnosticEnvelope(
+              runtimeId: candidate.id,
+              runtimeName: candidate.name,
+              summary: 'Gemini Nano is not supported on this device.',
+              detail:
+                  'The native AICore integration reported that this runtime cannot launch safely here.',
+              deviceLabel: resolvedDeviceLabel,
+              platformLabel: platformLabel,
+              reasonCode: 'unsupported_runtime',
+              repairActions: const [
+                'Switch to a LiteRT-LM local package.',
+                'Open Profile > AI Models and download a compatible package.',
+                'Use Gemini Cloud if local runtime setup is unavailable.',
+              ],
+            ),
+          );
+        }
+
+        emit(
+          AssistantRuntimePreparationPhase.allocate,
+          0.4,
+          'Allocate runtime',
+          'Initializing Gemini Nano and validating the local runtime path.',
+        );
+        final initCancel = cancelled();
+        if (initCancel != null) return initCancel;
+
+        final initialized =
+            await (_initializeGeminiNanoOverride?.call() ??
+                _geminiNano.initialize());
+        if (!initialized) {
+          return AssistantRuntimePreparationResult.blocked(
+            AssistantRuntimeDiagnosticEnvelope(
+              runtimeId: candidate.id,
+              runtimeName: candidate.name,
+              summary: 'Gemini Nano initialization failed.',
+              detail:
+                  'AICore was detected, but initialization did not complete successfully.',
+              deviceLabel: resolvedDeviceLabel,
+              platformLabel: platformLabel,
+              reasonCode: 'init_failed',
+              repairActions: const [
+                'Retry the local runtime initialization.',
+                'Switch to a smaller local package or Gemini Cloud.',
+                'Report the diagnostics if the failure repeats.',
+              ],
+            ),
+          );
+        }
+
+        emit(
+          AssistantRuntimePreparationPhase.warmup,
+          0.82,
+          'Warm up runtime',
+          'Running a lightweight local warmup so the first response is safer.',
+        );
+        final warmCancel = cancelled();
+        if (warmCancel != null) return warmCancel;
+        await (_warmupGeminiNanoOverride?.call() ?? _geminiNano.warmup());
+
+      case litertGemmaAssistantModelId:
+      default:
+        final available =
+            await (_isLiteRtAvailableOverride?.call() ??
+                _liteRtLm.isAvailable());
+        if (!available) {
+          return AssistantRuntimePreparationResult.blocked(
+            AssistantRuntimeDiagnosticEnvelope(
+              runtimeId: candidate.id,
+              runtimeName: candidate.name,
+              summary: 'The LiteRT-LM runtime is not ready.',
+              detail:
+                  'No compatible local model path or downloadable package is available for this runtime.',
+              deviceLabel: resolvedDeviceLabel,
+              platformLabel: platformLabel,
+              reasonCode: 'runtime_unavailable',
+              repairActions: const [
+                'Open Profile > AI Models and install a compatible package.',
+                'Set LITERT_LM_MODEL_PATH or LITERT_LM_MODEL_URL when launching locally.',
+              ],
+            ),
+          );
+        }
+
+        final package = candidate.package;
+        if (package != null) {
+          final compatibility =
+              await (_checkModelCompatibilityOverride?.call(package) ??
+                  _checkCompatibility(package));
+          if (!compatibility.isCompatible) {
+            return AssistantRuntimePreparationResult.blocked(
+              AssistantRuntimeDiagnosticEnvelope(
+                runtimeId: candidate.id,
+                runtimeName: candidate.name,
+                summary:
+                    'This local package exceeds the current device budget.',
+                detail:
+                    compatibility.reason ??
+                    'The device compatibility check refused this package.',
+                deviceLabel: resolvedDeviceLabel,
+                platformLabel: platformLabel,
+                reasonCode: 'compatibility_blocked',
+                availableMemoryMB: compatibility.availableMemoryMB,
+                requiredMemoryMB: compatibility.requiredMemoryMB,
+                repairActions: const [
+                  'Choose a smaller local package.',
+                  'Switch to a cloud runtime for this task.',
+                  'Free memory and retry initialization.',
+                ],
+              ),
+            );
+          }
+        }
+
+        emit(
+          AssistantRuntimePreparationPhase.load,
+          0.55,
+          'Load runtime',
+          'Preparing the local LiteRT-LM package for first use.',
+        );
+        final loadCancel = cancelled();
+        if (loadCancel != null) return loadCancel;
+        final warmed = package != null
+            ? await (_warmupLiteRtModelOverride?.call(package) ??
+                  _liteRtLm.warmupModel(package))
+            : await (_warmupLiteRtInstalledModelOverride?.call() ??
+                  _liteRtLm.warmupInstalledModel());
+        if (!warmed) {
+          return AssistantRuntimePreparationResult.blocked(
+            AssistantRuntimeDiagnosticEnvelope(
+              runtimeId: candidate.id,
+              runtimeName: candidate.name,
+              summary: 'The LiteRT-LM package could not be prepared.',
+              detail:
+                  'The local model did not complete initialization or warmup successfully.',
+              deviceLabel: resolvedDeviceLabel,
+              platformLabel: platformLabel,
+              reasonCode: 'warmup_failed',
+              repairActions: const [
+                'Retry initialization.',
+                'Re-download the package if it appears corrupted.',
+                'Choose a different runtime if the issue persists.',
+              ],
+            ),
+          );
+        }
+
+        if (candidate.opensModelManager) {
+          return AssistantRuntimePreparationResult.blocked(
+            AssistantRuntimeDiagnosticEnvelope(
+              runtimeId: candidate.id,
+              runtimeName: candidate.name,
+              summary: 'The selected package is not installed yet.',
+              detail:
+                  'This runtime cannot initialize until its local package has been downloaded.',
+              deviceLabel: resolvedDeviceLabel,
+              platformLabel: platformLabel,
+              reasonCode: 'package_missing',
+              repairActions: const [
+                'Open Profile > AI Models and download the package.',
+              ],
+            ),
+          );
+        }
+    }
+
+    final readyCancel = cancelled();
+    if (readyCancel != null) return readyCancel;
+    emit(
+      AssistantRuntimePreparationPhase.ready,
+      1,
+      'Runtime ready',
+      '${candidate.name} finished its local preflight and is ready to launch.',
+    );
+    return AssistantRuntimePreparationResult.ready();
+  }
 
   Future<String> generateText({
     required String? selectedModelId,
@@ -245,5 +617,12 @@ class AssistantRuntimeService {
       );
     }
     return package;
+  }
+
+  Future<ModelCompatibilityResult> _checkCompatibility(
+    OfflineModelInfo package,
+  ) async {
+    final registry = ModelRegistry()..registerModel(package);
+    return registry.checkCompatibility(package);
   }
 }

--- a/app/lib/features/agent_chat/presentation/screens/model_library_screen.dart
+++ b/app/lib/features/agent_chat/presentation/screens/model_library_screen.dart
@@ -1,9 +1,11 @@
 import 'package:core_ai/core_ai.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../application/assistant_model_preferences.dart';
+import '../../data/services/assistant_runtime_service.dart';
 import '../../../../core/ai/model_learn_more_launcher.dart';
 import '../../../../core/services/gemini_api_service.dart';
 import '../../../../core/services/gemini_nano_service.dart';
@@ -462,10 +464,12 @@ class ModelLibraryScreen extends ConsumerWidget {
     super.key,
     required this.onModelSelected,
     required this.onOpenModelManager,
+    this.runtimeService,
   });
 
   final ValueChanged<AssistantModelCandidate> onModelSelected;
   final VoidCallback onOpenModelManager;
+  final AssistantRuntimeService? runtimeService;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -478,6 +482,7 @@ class ModelLibraryScreen extends ConsumerWidget {
             state: state,
             onModelSelected: onModelSelected,
             onOpenModelManager: onOpenModelManager,
+            runtimeService: runtimeService ?? AssistantRuntimeService(),
           ),
           loading: () => const Center(child: CircularProgressIndicator()),
           error: (error, _) => _ModelLibraryError(
@@ -495,11 +500,13 @@ class _ModelLibraryContent extends ConsumerWidget {
     required this.state,
     required this.onModelSelected,
     required this.onOpenModelManager,
+    required this.runtimeService,
   });
 
   final AssistantModelLibraryState state;
   final ValueChanged<AssistantModelCandidate> onModelSelected;
   final VoidCallback onOpenModelManager;
+  final AssistantRuntimeService runtimeService;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -606,10 +613,100 @@ class _ModelLibraryContent extends ConsumerWidget {
       );
       return;
     }
+    if (candidate.local) {
+      final result = await _prepareLocalRuntime(
+        context,
+        candidate: candidate,
+        template: template,
+      );
+      if (!context.mounted || !result.isReady) {
+        return;
+      }
+    }
     await ref
         .read(selectedAssistantModelIdProvider.notifier)
         .select(candidate.id);
     onModelSelected(candidate);
+  }
+
+  Future<AssistantRuntimePreparationResult> _prepareLocalRuntime(
+    BuildContext context, {
+    required AssistantModelCandidate candidate,
+    required AssistantProjectTemplate template,
+  }) async {
+    final progress = ValueNotifier(
+      const AssistantRuntimePreparationProgress(
+        phase: AssistantRuntimePreparationPhase.validate,
+        progress: 0,
+        label: 'Prepare runtime',
+        detail: 'Starting compatibility checks.',
+      ),
+    );
+    var cancelRequested = false;
+
+    final dialogFuture = showDialog<void>(
+      context: context,
+      barrierDismissible: false,
+      builder: (context) {
+        return ValueListenableBuilder<AssistantRuntimePreparationProgress>(
+          valueListenable: progress,
+          builder: (context, value, _) {
+            return AlertDialog(
+              title: Text('${template.title} setup'),
+              content: Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(value.label),
+                  const SizedBox(height: 8),
+                  LinearProgressIndicator(value: value.progress),
+                  const SizedBox(height: 12),
+                  Text(value.detail),
+                ],
+              ),
+              actions: [
+                TextButton(
+                  onPressed: () {
+                    cancelRequested = true;
+                  },
+                  child: Text(cancelRequested ? 'Stopping…' : 'Cancel'),
+                ),
+              ],
+            );
+          },
+        );
+      },
+    );
+
+    final result = await runtimeService.prepareRuntime(
+      candidate: candidate,
+      onProgress: (value) => progress.value = value,
+      isCancelled: () => cancelRequested,
+    );
+
+    progress.dispose();
+    if (context.mounted) {
+      Navigator.of(context, rootNavigator: true).pop();
+      await dialogFuture;
+    }
+
+    if (!context.mounted) {
+      return result;
+    }
+    if (result.status == AssistantRuntimePreparationStatus.cancelled) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('${candidate.name} setup cancelled.')),
+      );
+      return result;
+    }
+    if (result.diagnostic != null) {
+      await _showPreparationFailure(
+        context,
+        diagnostic: result.diagnostic!,
+        candidate: candidate,
+      );
+    }
+    return result;
   }
 
   Future<bool?> _confirmPackageSetup(
@@ -708,6 +805,78 @@ class _ModelLibraryContent extends ConsumerWidget {
             },
             child: const Text('Open Profile settings'),
           ),
+        ],
+      ),
+    );
+  }
+
+  Future<void> _showPreparationFailure(
+    BuildContext context, {
+    required AssistantRuntimeDiagnosticEnvelope diagnostic,
+    required AssistantModelCandidate candidate,
+  }) {
+    return showDialog<void>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: Text(diagnostic.summary),
+        content: SingleChildScrollView(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Text(diagnostic.detail),
+              const SizedBox(height: 12),
+              Text(
+                'Device: ${diagnostic.deviceLabel}',
+                style: Theme.of(context).textTheme.bodySmall,
+              ),
+              Text(
+                'Platform: ${diagnostic.platformLabel}',
+                style: Theme.of(context).textTheme.bodySmall,
+              ),
+              if (diagnostic.repairActions.isNotEmpty) ...[
+                const SizedBox(height: 12),
+                Text(
+                  'Repair actions',
+                  style: Theme.of(context).textTheme.titleSmall,
+                ),
+                const SizedBox(height: 8),
+                for (final action in diagnostic.repairActions)
+                  Padding(
+                    padding: const EdgeInsets.only(bottom: 6),
+                    child: Text('• $action'),
+                  ),
+              ],
+            ],
+          ),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () async {
+              await Clipboard.setData(
+                ClipboardData(text: diagnostic.toMarkdown()),
+              );
+              if (context.mounted) {
+                ScaffoldMessenger.of(context).showSnackBar(
+                  const SnackBar(content: Text('Diagnostics copied')),
+                );
+              }
+            },
+            child: const Text('Copy diagnostics'),
+          ),
+          if (candidate.opensModelManager)
+            FilledButton(
+              onPressed: () {
+                Navigator.of(context).pop();
+                onOpenModelManager();
+              },
+              child: const Text('Open model settings'),
+            )
+          else
+            FilledButton(
+              onPressed: () => Navigator.of(context).pop(),
+              child: const Text('Close'),
+            ),
         ],
       ),
     );

--- a/app/test/features/agent_chat/data/services/assistant_runtime_service_test.dart
+++ b/app/test/features/agent_chat/data/services/assistant_runtime_service_test.dart
@@ -1,5 +1,7 @@
 import 'package:airo_app/features/agent_chat/data/services/assistant_runtime_service.dart';
 import 'package:airo_app/features/agent_chat/domain/models/assistant_runtime_ids.dart';
+import 'package:airo_app/features/agent_chat/presentation/screens/model_library_screen.dart';
+import 'package:core_ai/core_ai.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
@@ -64,6 +66,113 @@ void main() {
             geminiCloudUnavailableMessage,
           ),
         ),
+      );
+    });
+
+    test(
+      'builds a blocked preparation result for unsupported Gemini Nano',
+      () async {
+        final service = AssistantRuntimeService(
+          isGeminiNanoSupported: () async => false,
+          loadDeviceInfo: () async => {
+            'manufacturer': 'Google',
+            'model': 'Pixel 8',
+            'platform': 'android',
+          },
+        );
+
+        final result = await service.prepareRuntime(
+          candidate: const AssistantModelCandidate(
+            id: geminiNanoAssistantModelId,
+            name: 'Gemini Nano',
+            runtime: 'AICore on-device',
+            description: 'Local runtime',
+            bestFor: [AssistantTask.chat],
+            tags: ['Local'],
+            privacyLabel: 'Prompt stays on device',
+            sizeLabel: 'System managed',
+            available: true,
+            actionLabel: 'Start',
+            local: true,
+          ),
+        );
+
+        expect(result.status, AssistantRuntimePreparationStatus.blocked);
+        expect(
+          result.diagnostic?.summary,
+          'Gemini Nano is not supported on this device.',
+        );
+        expect(result.diagnostic?.deviceLabel, 'Google Pixel 8');
+      },
+    );
+
+    test('cancels preparation before runtime work starts', () async {
+      final service = AssistantRuntimeService(
+        loadDeviceInfo: () async => {'manufacturer': 'Web', 'model': 'Browser'},
+      );
+
+      final result = await service.prepareRuntime(
+        candidate: const AssistantModelCandidate(
+          id: geminiCloudAssistantModelId,
+          name: 'Gemini Cloud',
+          runtime: 'Cloud',
+          description: 'Cloud runtime',
+          bestFor: [AssistantTask.chat],
+          tags: ['Cloud'],
+          privacyLabel: 'Sends prompt to API',
+          sizeLabel: 'No local download',
+          available: true,
+          actionLabel: 'Start',
+          local: false,
+        ),
+        isCancelled: () => true,
+      );
+
+      expect(result.status, AssistantRuntimePreparationStatus.cancelled);
+    });
+
+    test('blocks LiteRT packages when compatibility fails', () async {
+      final package = OfflineModelInfo(
+        id: 'gemma-4-e2b-it-litertlm',
+        name: 'Gemma 4 E2B',
+        family: ModelFamily.gemma,
+        fileSizeBytes: 2 * 1024 * 1024 * 1024,
+        backendPreference: ModelBackendPreference.gpu,
+        provider: AIProvider.gemma,
+        capabilities: const [ModelCapability.chat],
+      );
+      final service = AssistantRuntimeService(
+        isLiteRtAvailable: () async => true,
+        loadDeviceInfo: () async => {
+          'manufacturer': 'Nothing',
+          'model': 'Phone',
+          'platform': 'android',
+        },
+        checkModelCompatibility: (_) async =>
+            ModelCompatibilityResult.incompatible('Insufficient memory.'),
+      );
+
+      final result = await service.prepareRuntime(
+        candidate: AssistantModelCandidate(
+          id: litertGemmaAssistantModelId,
+          name: 'Gemma mobile package',
+          runtime: 'LiteRT-LM local model',
+          description: 'Local package',
+          bestFor: const [AssistantTask.chat],
+          tags: const ['Local'],
+          privacyLabel: 'Prompt stays on device',
+          sizeLabel: package.fileSizeDisplay,
+          available: true,
+          actionLabel: 'Start',
+          local: true,
+          package: package,
+        ),
+      );
+
+      expect(result.status, AssistantRuntimePreparationStatus.blocked);
+      expect(
+        result.diagnostic?.summary,
+        'This local package exceeds the current device budget.',
       );
     });
   });

--- a/app/test/features/agent_chat/presentation/screens/model_library_screen_test.dart
+++ b/app/test/features/agent_chat/presentation/screens/model_library_screen_test.dart
@@ -1,0 +1,86 @@
+import 'package:airo_app/features/agent_chat/application/assistant_model_preferences.dart';
+import 'package:airo_app/features/agent_chat/data/services/assistant_runtime_service.dart';
+import 'package:airo_app/features/agent_chat/domain/models/assistant_runtime_ids.dart';
+import 'package:airo_app/features/agent_chat/presentation/screens/model_library_screen.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  testWidgets(
+    'shows diagnostics instead of launching unsupported local runtime',
+    (tester) async {
+      SharedPreferences.setMockInitialValues({});
+
+      final candidate = const AssistantModelCandidate(
+        id: geminiNanoAssistantModelId,
+        name: 'Gemini Nano',
+        runtime: 'AICore on-device',
+        description: 'Local runtime',
+        bestFor: [AssistantTask.chat],
+        tags: ['Local'],
+        privacyLabel: 'Prompt stays on device',
+        sizeLabel: 'System managed',
+        available: true,
+        actionLabel: 'Start chat',
+        local: true,
+      );
+
+      final state = AssistantModelLibraryState(
+        task: AssistantTask.chat,
+        deviceLabel: 'Pixel 8',
+        platformLabel: 'ANDROID',
+        candidates: [candidate],
+        recommended: candidate,
+        defaultPackages: const {},
+      );
+
+      var selected = false;
+      final runtimeService = AssistantRuntimeService(
+        isGeminiNanoSupported: () async => false,
+        loadDeviceInfo: () async => {
+          'manufacturer': 'Google',
+          'model': 'Pixel 8',
+          'platform': 'android',
+        },
+      );
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            assistantModelLibraryProvider.overrideWith((ref) async => state),
+            selectedAssistantModelIdProvider.overrideWith(
+              (ref) => _SelectedAssistantModelNotifier(),
+            ),
+          ],
+          child: MaterialApp(
+            home: ModelLibraryScreen(
+              runtimeService: runtimeService,
+              onModelSelected: (_) => selected = true,
+              onOpenModelManager: () {},
+            ),
+          ),
+        ),
+      );
+
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Start chat'));
+      await tester.pump();
+      await tester.pumpAndSettle();
+
+      expect(
+        find.text('Gemini Nano is not supported on this device.'),
+        findsOneWidget,
+      );
+      expect(find.text('Copy diagnostics'), findsOneWidget);
+      expect(selected, isFalse);
+    },
+  );
+}
+
+class _SelectedAssistantModelNotifier extends SelectedAssistantModelNotifier {
+  _SelectedAssistantModelNotifier() {
+    state = null;
+  }
+}


### PR DESCRIPTION
# Summary

This PR introduces changes to local model launch preflight in Brain project setup.
Goal: block unsupported or crash-prone local runtime launches before chat opens.

Core outcome:

* local model launch now runs a phased preflight instead of falling straight into first-prompt initialization
* unsupported or memory-unsafe runtimes surface copyable diagnostics and repair actions
* slow setup shows progress and supports cancellation from the project picker

# Changes

### Code

* Added:
  * phased runtime preparation and diagnostic envelope types in `assistant_runtime_service.dart`
  * widget coverage for unsupported local runtime launch in `model_library_screen_test.dart`
* Updated:
  * `model_library_screen.dart` to run local runtime preflight before selecting a project runtime
  * `litert_lm_service.dart` with explicit per-model warmup support
  * `assistant_runtime_service_test.dart` with unsupported, cancelled, and compatibility-blocked preflight coverage

### Logic

* Gemini Nano preflight validates support, initializes, and warms before chat launch
* LiteRT local packages validate compatibility and warm before selection completes
* failures no longer trap the user in launch ambiguity; they stay in the picker with diagnostics they can copy into a GitHub issue

# API Changes (if any)

* None.

# Database Changes (if any)

* None.

# Observability / Logging

* Added a user-copyable diagnostic envelope for runtime launch failures.

# Performance Impact

* Latency: initial local runtime launch is now explicit and phased
* Throughput: no meaningful change
* Memory/CPU: unchanged runtime cost, but launch failures are blocked earlier

# Risks

* cancellation is cooperative between phases, not a hard native abort
* preflight only covers the runtime paths wired through the Brain project picker
* Rollback plan:
  * revert this PR

# Testing

* Unit tests:
  * assistant runtime preparation blocked/cancelled paths
* Integration tests:
  * widget coverage for unsupported runtime diagnostics in the project picker
* Manual testing:
  * not run

# Deployment Notes

* Config changes:
  * none
* Order of deployment:
  * standard

# Related Commits

* fix(agent-chat): add safe local runtime preflight

# Notes

* Focus review on preflight gating, diagnostic copy behavior, and local runtime preparation before selection.

Closes #310
