### PR TITLE
fix(shell): centralize compact navigation overflow

### DIFF
--- a/app/lib/core/app/app_shell.dart
+++ b/app/lib/core/app/app_shell.dart
@@ -41,9 +41,17 @@ class AppShell extends ConsumerWidget {
     }
 
     final navigationTabs = ref.watch(appNavigationTabsProvider);
+    final navigationPolicy = ref.watch(appNavigationPolicyProvider);
     final chromeConfig = ref.watch(appNavigationChromeConfigProvider);
     final headerMode = ref.watch(appShellHeaderModeProvider(currentLocation));
     final currentPageName = navigationTabs[navigationShell.currentIndex].label;
+    final width = MediaQuery.sizeOf(context).width;
+    final navigationLayout = navigationPolicy.layoutForWidth(width);
+    final currentTab = navigationTabs[navigationShell.currentIndex];
+    final selectedNavIndex = _selectedNavigationIndexForTab(
+      currentTab,
+      navigationLayout,
+    );
 
     return Theme(
       data: isBedtimeMode ? BedtimeTheme.bedtimeTheme : Theme.of(context),
@@ -75,28 +83,37 @@ class AppShell extends ConsumerWidget {
           child: navigationShell,
         ),
         bottomNavigationBar: NavigationBar(
-          selectedIndex: navigationShell.currentIndex,
+          selectedIndex: selectedNavIndex,
           onDestinationSelected: (index) {
-            // Reset fullscreen mode and orientation when changing tabs
-            if (ref.read(isFullscreenModeProvider)) {
-              ref.read(isFullscreenModeProvider.notifier).state = false;
-              // Restore normal UI and portrait orientation
-              SystemChrome.setEnabledSystemUIMode(SystemUiMode.edgeToEdge);
-              SystemChrome.setPreferredOrientations([
-                DeviceOrientation.portraitUp,
-              ]);
+            if (navigationLayout.usesOverflow &&
+                index == navigationLayout.persistentTabs.length) {
+              _showOverflowDestinations(
+                context,
+                ref,
+                navigationShell,
+                navigationLayout,
+                navigationTabs,
+              );
+              return;
             }
-            // Update the navigation tab provider for mini player visibility
-            ref.read(currentNavigationTabProvider.notifier).state = index;
-            navigationShell.goBranch(index);
+
+            final selectedTab = navigationLayout.persistentTabs[index];
+            _goToTab(ref, navigationShell, selectedTab.index);
           },
           destinations: [
-            for (final tab in navigationTabs)
+            for (final tab in navigationLayout.persistentTabs)
               NavigationDestination(
                 key: ValueKey('app_nav_${tab.name}'),
                 icon: Icon(tab.icon),
                 selectedIcon: Icon(tab.selectedIcon),
                 label: tab.label,
+              ),
+            if (navigationLayout.usesOverflow)
+              NavigationDestination(
+                key: const ValueKey('app_nav_overflow'),
+                icon: Icon(navigationLayout.overflow.icon),
+                selectedIcon: Icon(navigationLayout.overflow.selectedIcon),
+                label: navigationLayout.overflow.label,
               ),
           ],
         ),
@@ -112,6 +129,67 @@ class AppShell extends ConsumerWidget {
             : null,
       ),
     );
+  }
+
+  int _selectedNavigationIndexForTab(
+    AppNavigationTab currentTab,
+    AppNavigationLayoutConfig layout,
+  ) {
+    final directIndex = layout.persistentTabs.indexOf(currentTab);
+    if (directIndex != -1) {
+      return directIndex;
+    }
+    return layout.persistentTabs.length;
+  }
+
+  Future<void> _showOverflowDestinations(
+    BuildContext context,
+    WidgetRef ref,
+    StatefulNavigationShell navigationShell,
+    AppNavigationLayoutConfig layout,
+    List<AppNavigationTab> navigationTabs,
+  ) async {
+    await showModalBottomSheet<void>(
+      context: context,
+      builder: (context) {
+        final currentTab = navigationTabs[navigationShell.currentIndex];
+
+        return SafeArea(
+          child: ListView(
+            shrinkWrap: true,
+            children: [
+              for (final tab in layout.overflowTabs)
+                ListTile(
+                  key: ValueKey('app_nav_overflow_entry_${tab.name}'),
+                  leading: Icon(tab.icon),
+                  title: Text(tab.label),
+                  selected: currentTab == tab,
+                  onTap: () {
+                    Navigator.of(context).pop();
+                    _goToTab(ref, navigationShell, tab.index);
+                  },
+                ),
+            ],
+          ),
+        );
+      },
+    );
+  }
+
+  void _goToTab(
+    WidgetRef ref,
+    StatefulNavigationShell navigationShell,
+    int index,
+  ) {
+    // Reset fullscreen mode and orientation when changing tabs.
+    if (ref.read(isFullscreenModeProvider)) {
+      ref.read(isFullscreenModeProvider.notifier).state = false;
+      SystemChrome.setEnabledSystemUIMode(SystemUiMode.edgeToEdge);
+      SystemChrome.setPreferredOrientations([DeviceOrientation.portraitUp]);
+    }
+
+    ref.read(currentNavigationTabProvider.notifier).state = index;
+    navigationShell.goBranch(index);
   }
 }
 

--- a/app/lib/core/providers/navigation_provider.dart
+++ b/app/lib/core/providers/navigation_provider.dart
@@ -63,6 +63,76 @@ final appNavigationTabsProvider = Provider<List<AppNavigationTab>>(
   (ref) => AppNavigationTab.values,
 );
 
+class AppNavigationOverflowConfig {
+  const AppNavigationOverflowConfig({
+    this.label = 'More',
+    this.icon = Icons.menu,
+    this.selectedIcon = Icons.menu_open,
+  });
+
+  final String label;
+  final IconData icon;
+  final IconData selectedIcon;
+}
+
+class AppNavigationLayoutConfig {
+  const AppNavigationLayoutConfig({
+    required this.persistentTabs,
+    required this.overflowTabs,
+    required this.overflow,
+  });
+
+  final List<AppNavigationTab> persistentTabs;
+  final List<AppNavigationTab> overflowTabs;
+  final AppNavigationOverflowConfig overflow;
+
+  bool get usesOverflow => overflowTabs.isNotEmpty;
+}
+
+class AppNavigationPolicy {
+  const AppNavigationPolicy({
+    required this.compactPrimaryTabs,
+    required this.overflowTabs,
+    this.compactWidthBreakpoint = 600,
+    this.overflow = const AppNavigationOverflowConfig(),
+  });
+
+  final List<AppNavigationTab> compactPrimaryTabs;
+  final List<AppNavigationTab> overflowTabs;
+  final double compactWidthBreakpoint;
+  final AppNavigationOverflowConfig overflow;
+
+  AppNavigationLayoutConfig layoutForWidth(double width) {
+    if (width >= compactWidthBreakpoint) {
+      return AppNavigationLayoutConfig(
+        persistentTabs: AppNavigationTab.values,
+        overflowTabs: const [],
+        overflow: overflow,
+      );
+    }
+
+    return AppNavigationLayoutConfig(
+      persistentTabs: compactPrimaryTabs,
+      overflowTabs: overflowTabs,
+      overflow: overflow,
+    );
+  }
+}
+
+const appNavigationPolicy = AppNavigationPolicy(
+  compactPrimaryTabs: [
+    AppNavigationTab.coins,
+    AppNavigationTab.mind,
+    AppNavigationTab.beats,
+    AppNavigationTab.stream,
+  ],
+  overflowTabs: [AppNavigationTab.arena, AppNavigationTab.quest],
+);
+
+final appNavigationPolicyProvider = Provider<AppNavigationPolicy>(
+  (ref) => appNavigationPolicy,
+);
+
 enum AppShellAction { notifications, profileMenu }
 
 class AppNavigationChromeConfig {

--- a/app/test/core/app/app_shell_navigation_policy_test.dart
+++ b/app/test/core/app/app_shell_navigation_policy_test.dart
@@ -1,0 +1,172 @@
+import 'package:airo_app/core/app/app_shell.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+
+void main() {
+  Future<void> pumpShell(
+    WidgetTester tester, {
+    required String initialLocation,
+    required double width,
+  }) async {
+    tester.view.physicalSize = Size(width, 800);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(() {
+      tester.view.resetPhysicalSize();
+      tester.view.resetDevicePixelRatio();
+    });
+
+    final router = GoRouter(
+      initialLocation: initialLocation,
+      routes: [
+        StatefulShellRoute.indexedStack(
+          builder: (context, state, navigationShell) {
+            return ProviderScope(
+              child: AppShell(
+                navigationShell: navigationShell,
+                currentLocation: state.uri.path,
+              ),
+            );
+          },
+          branches: [
+            StatefulShellBranch(
+              routes: [
+                GoRoute(
+                  path: '/money',
+                  builder: (context, state) =>
+                      const _ShellBodyScreen(label: 'Coins body'),
+                ),
+              ],
+            ),
+            StatefulShellBranch(
+              routes: [
+                GoRoute(
+                  path: '/mind',
+                  builder: (context, state) =>
+                      const _ShellBodyScreen(label: 'Mind body'),
+                ),
+              ],
+            ),
+            StatefulShellBranch(
+              routes: [
+                GoRoute(
+                  path: '/music',
+                  builder: (context, state) =>
+                      const _RouteOwnedScreen(title: 'Beats'),
+                ),
+              ],
+            ),
+            StatefulShellBranch(
+              routes: [
+                GoRoute(
+                  path: '/iptv',
+                  builder: (context, state) =>
+                      const _RouteOwnedScreen(title: 'Stream'),
+                ),
+              ],
+            ),
+            StatefulShellBranch(
+              routes: [
+                GoRoute(
+                  path: '/games',
+                  builder: (context, state) =>
+                      const _ShellBodyScreen(label: 'Arena body'),
+                ),
+              ],
+            ),
+            StatefulShellBranch(
+              routes: [
+                GoRoute(
+                  path: '/quest',
+                  builder: (context, state) =>
+                      const _RouteOwnedScreen(title: 'Quest'),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ],
+    );
+
+    await tester.pumpWidget(
+      ProviderScope(child: MaterialApp.router(routerConfig: router)),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  testWidgets('compact phones use shared overflow for lower-frequency tabs', (
+    tester,
+  ) async {
+    await pumpShell(tester, initialLocation: '/money', width: 420);
+
+    expect(find.byKey(const ValueKey('app_nav_coins')), findsOneWidget);
+    expect(find.byKey(const ValueKey('app_nav_mind')), findsOneWidget);
+    expect(find.byKey(const ValueKey('app_nav_beats')), findsOneWidget);
+    expect(find.byKey(const ValueKey('app_nav_stream')), findsOneWidget);
+    expect(find.byKey(const ValueKey('app_nav_overflow')), findsOneWidget);
+    expect(find.byKey(const ValueKey('app_nav_arena')), findsNothing);
+    expect(find.byKey(const ValueKey('app_nav_quest')), findsNothing);
+
+    await tester.tap(find.byKey(const ValueKey('app_nav_overflow')));
+    await tester.pumpAndSettle();
+
+    expect(
+      find.byKey(const ValueKey('app_nav_overflow_entry_arena')),
+      findsOneWidget,
+    );
+    expect(
+      find.byKey(const ValueKey('app_nav_overflow_entry_quest')),
+      findsOneWidget,
+    );
+
+    await tester.tap(
+      find.byKey(const ValueKey('app_nav_overflow_entry_quest')),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('Quest body'), findsOneWidget);
+  });
+
+  testWidgets('wider layouts keep all primary destinations visible', (
+    tester,
+  ) async {
+    await pumpShell(tester, initialLocation: '/money', width: 900);
+
+    expect(find.byKey(const ValueKey('app_nav_coins')), findsOneWidget);
+    expect(find.byKey(const ValueKey('app_nav_mind')), findsOneWidget);
+    expect(find.byKey(const ValueKey('app_nav_beats')), findsOneWidget);
+    expect(find.byKey(const ValueKey('app_nav_stream')), findsOneWidget);
+    expect(find.byKey(const ValueKey('app_nav_arena')), findsOneWidget);
+    expect(find.byKey(const ValueKey('app_nav_quest')), findsOneWidget);
+    expect(find.byKey(const ValueKey('app_nav_overflow')), findsNothing);
+  });
+}
+
+class _ShellBodyScreen extends StatelessWidget {
+  const _ShellBodyScreen({required this.label});
+
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: Colors.transparent,
+      body: Center(child: Text(label)),
+    );
+  }
+}
+
+class _RouteOwnedScreen extends StatelessWidget {
+  const _RouteOwnedScreen({required this.title});
+
+  final String title;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: Text(title)),
+      body: Center(child: Text('$title body')),
+    );
+  }
+}

--- a/app/test/core/providers/navigation_provider_test.dart
+++ b/app/test/core/providers/navigation_provider_test.dart
@@ -80,6 +80,32 @@ void main() {
       expect(chromeConfig.compactWidthBreakpoint, 600);
     });
 
+    test('uses one shared compact navigation overflow policy', () {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      final policy = container.read(appNavigationPolicyProvider);
+      final compactLayout = policy.layoutForWidth(420);
+      final wideLayout = policy.layoutForWidth(900);
+
+      expect(policy.compactWidthBreakpoint, 600);
+      expect(compactLayout.persistentTabs, const [
+        AppNavigationTab.coins,
+        AppNavigationTab.mind,
+        AppNavigationTab.beats,
+        AppNavigationTab.stream,
+      ]);
+      expect(compactLayout.overflowTabs, const [
+        AppNavigationTab.arena,
+        AppNavigationTab.quest,
+      ]);
+      expect(compactLayout.usesOverflow, isTrue);
+      expect(compactLayout.overflow.label, 'More');
+      expect(wideLayout.persistentTabs, AppNavigationTab.values);
+      expect(wideLayout.overflowTabs, isEmpty);
+      expect(wideLayout.usesOverflow, isFalse);
+    });
+
     test('keeps shell-owned headers only on routes without local app bars', () {
       expect(appShellHeaderModeForLocation('/money'), AppShellHeaderMode.shell);
       expect(appShellHeaderModeForLocation('/mind'), AppShellHeaderMode.shell);

--- a/docs/standards/mobile-ui-ux-standards.md
+++ b/docs/standards/mobile-ui-ux-standards.md
@@ -59,6 +59,14 @@ Primary destination overflow on phones must be handled centrally. Feature code
 must consume the shared navigation model instead of constructing its own bottom
 navigation items.
 
+Current default compact policy:
+
+- phones under the shared compact breakpoint keep `Coins`, `Mind`, `Beats`, and
+  `Stream` in persistent bottom navigation
+- `Arena` and `Quest` move into one shared `More` overflow entry
+- larger layouts keep the full primary destination set visible without a
+  feature-level fork
+
 ## Token Standard
 
 Shared visual roles belong in centralized tokens, including:


### PR DESCRIPTION
# Summary

This PR introduces changes to shell navigation behavior.
Goal: centralize compact-phone destination overflow so root navigation density stays consistent and feature routes do not fork their own affordances.

Core outcome:

* adds one shared compact navigation policy with a four-tab phone budget
* routes lower-frequency destinations through a central `More` overflow entry on narrow screens

# Changes

### Code

* Added:
  * shared compact navigation policy and overflow layout config in `navigation_provider.dart`
  * widget coverage for overflow rendering and selection in `app_shell_navigation_policy_test.dart`
* Updated:
  * `app_shell.dart` to render direct destinations plus a shared overflow entry on compact widths
  * provider tests for compact vs wide navigation behavior
  * mobile UI standards with the default compact policy

### Logic

* phones under the shared compact breakpoint keep `Coins`, `Mind`, `Beats`, and `Stream` visible
* `Arena` and `Quest` move behind one shared `More` destination on compact layouts
* larger layouts continue to render the full primary destination set from the same shared source of truth

# API Changes (if any)

* None.

# Database Changes (if any)

* None.

# Observability / Logging

* None.

# Performance Impact

* Latency: no meaningful change expected
* Throughput: no meaningful change expected
* Memory/CPU: negligible UI-only impact

# Risks

* compact navigation now relies on the overflow sheet for `Arena` and `Quest`
* future root destinations must be added through the shared policy or the budget can drift
* Rollback plan:
  * revert this PR to restore six persistent bottom-nav destinations on phones

# Testing

* Unit tests:
  * `flutter analyze lib/core/providers/navigation_provider.dart lib/core/app/app_shell.dart test/core/providers/navigation_provider_test.dart test/core/app/app_shell_navigation_policy_test.dart`
* Integration tests:
  * none
* Manual testing:
  * not run

# Deployment Notes

* Config changes:
  * none
* Order of deployment:
  * normal app deployment

# Related Commits

* `fix(shell): centralize compact navigation overflow`

# Notes

* Closes #418
