### PR TITLE
feat(core-ai): add safe local runtime preloader

### DIFF
--- a/app/lib/core/services/local_runtime_preloader_service.dart
+++ b/app/lib/core/services/local_runtime_preloader_service.dart
@@ -1,0 +1,210 @@
+import 'package:core_ai/core_ai.dart';
+
+import '../../features/agent_chat/domain/models/assistant_runtime_ids.dart';
+import '../../features/agent_chat/presentation/screens/model_library_screen.dart';
+import 'gemini_nano_service.dart';
+import 'litert_lm_service.dart';
+
+class LocalRuntimePreloaderService {
+  factory LocalRuntimePreloaderService({
+    GeminiNanoService? geminiNano,
+    LiteRtLmService? liteRtLm,
+    ModelResidencyManager? residencyManager,
+    ModelPreloader? preloader,
+    Future<AssistantModelLibraryState> Function()? loadAssistantModelLibrary,
+    String? Function()? selectedModelId,
+    bool Function()? isGenerationActive,
+  }) {
+    final resolvedResidencyManager =
+        residencyManager ??
+        ModelResidencyManager(loadBudgetBytes: _loadDefaultBudgetBytes);
+    return LocalRuntimePreloaderService._(
+      geminiNano: geminiNano ?? GeminiNanoService(),
+      liteRtLm: liteRtLm ?? LiteRtLmService(),
+      residencyManager: resolvedResidencyManager,
+      preloader:
+          preloader ??
+          ModelPreloader(
+            residencyManager: resolvedResidencyManager,
+            isGenerationActive: isGenerationActive,
+          ),
+      loadAssistantModelLibrary:
+          loadAssistantModelLibrary ?? _defaultAssistantModelLibraryState,
+      selectedModelId: selectedModelId ?? (() => null),
+    );
+  }
+
+  LocalRuntimePreloaderService._({
+    required GeminiNanoService geminiNano,
+    required LiteRtLmService liteRtLm,
+    required ModelResidencyManager residencyManager,
+    required ModelPreloader preloader,
+    required Future<AssistantModelLibraryState> Function()
+    loadAssistantModelLibrary,
+    required String? Function() selectedModelId,
+  }) : _geminiNano = geminiNano,
+       _liteRtLm = liteRtLm,
+       _residencyManager = residencyManager,
+       _preloader = preloader,
+       _loadAssistantModelLibrary = loadAssistantModelLibrary,
+       _selectedModelId = selectedModelId;
+
+  final GeminiNanoService _geminiNano;
+  final LiteRtLmService _liteRtLm;
+  final ModelResidencyManager _residencyManager;
+  final ModelPreloader _preloader;
+  final Future<AssistantModelLibraryState> Function()
+  _loadAssistantModelLibrary;
+  final String? Function() _selectedModelId;
+
+  void abortPreload() {
+    _preloader.abortPreload();
+  }
+
+  Future<ModelPreloadReport> preloadSelectedModels() async {
+    final library = await _loadAssistantModelLibrary();
+    final adapters = await _buildAdapters(library);
+    return _preloader.preloadSelectedModels(adapters: adapters);
+  }
+
+  Future<List<ModelWarmupAdapter>> _buildAdapters(
+    AssistantModelLibraryState library,
+  ) async {
+    final selectedModelId = _selectedModelId();
+    final selectedCandidate = selectedModelId == null
+        ? null
+        : library.candidateById(selectedModelId);
+    final selectedPackage = selectedCandidate?.package;
+
+    return [
+      _GeminiNanoWarmupAdapter(_geminiNano),
+      if (selectedPackage != null &&
+          selectedCandidate?.id != geminiNanoAssistantModelId)
+        _LiteRtPackageWarmupAdapter(_liteRtLm, selectedPackage)
+      else
+        _LiteRtInstalledWarmupAdapter(_liteRtLm),
+      NoOpWarmupAdapter(
+        const ModelResidentSpec(
+          id: 'assistant-tts-hook',
+          residentType: ResidentRuntimeType.tts,
+          estimatedMemoryBytes: 192 * 1024 * 1024,
+          sidecar: true,
+        ),
+      ),
+      NoOpWarmupAdapter(
+        const ModelResidentSpec(
+          id: 'assistant-stt-hook',
+          residentType: ResidentRuntimeType.stt,
+          estimatedMemoryBytes: 384 * 1024 * 1024,
+          sidecar: true,
+        ),
+      ),
+    ];
+  }
+
+  List<ModelResidentSpec> get currentResidents => _residencyManager.residents;
+
+  static Future<AssistantModelLibraryState>
+  _defaultAssistantModelLibraryState() async {
+    const recommended = AssistantModelCandidate(
+      id: geminiCloudAssistantModelId,
+      name: 'Gemini Cloud',
+      runtime: 'Cloud',
+      description: 'Fallback cloud runtime',
+      bestFor: [AssistantTask.chat],
+      tags: ['Cloud'],
+      privacyLabel: 'Sends prompt to API',
+      sizeLabel: 'No local download',
+      available: true,
+      actionLabel: 'Start',
+      local: false,
+    );
+    return const AssistantModelLibraryState(
+      task: AssistantTask.chat,
+      deviceLabel: 'Unknown device',
+      platformLabel: 'DEVICE',
+      candidates: [recommended],
+      recommended: recommended,
+      defaultPackages: {},
+    );
+  }
+
+  static Future<int> _loadDefaultBudgetBytes() async {
+    const fallbackBudgetBytes = 4 * 1024 * 1024 * 1024;
+    final memoryBudgetManager = MemoryBudgetManager();
+    final memoryInfo = await memoryBudgetManager.getCurrentMemoryInfo(
+      forceRefresh: true,
+    );
+    if (!memoryInfo.isAvailable) {
+      return fallbackBudgetBytes;
+    }
+    final budgetBytes = memoryBudgetManager.calculateBudget(memoryInfo);
+    return budgetBytes > 0 ? budgetBytes : fallbackBudgetBytes;
+  }
+}
+
+class _GeminiNanoWarmupAdapter implements ModelWarmupAdapter {
+  _GeminiNanoWarmupAdapter(this._service);
+
+  final GeminiNanoService _service;
+
+  @override
+  ModelResidentSpec get residentSpec => const ModelResidentSpec(
+    id: geminiNanoAssistantModelId,
+    residentType: ResidentRuntimeType.text,
+    estimatedMemoryBytes: 1024 * 1024 * 1024,
+  );
+
+  @override
+  Future<bool> isAvailable() => _service.isSupported();
+
+  @override
+  Future<bool> warmup() => _service.warmup();
+}
+
+class _LiteRtInstalledWarmupAdapter implements ModelWarmupAdapter {
+  _LiteRtInstalledWarmupAdapter(this._service);
+
+  final LiteRtLmService _service;
+
+  @override
+  ModelResidentSpec get residentSpec => const ModelResidentSpec(
+    id: litertGemmaAssistantModelId,
+    residentType: ResidentRuntimeType.text,
+    estimatedMemoryBytes: 1536 * 1024 * 1024,
+  );
+
+  @override
+  Future<bool> isAvailable() => _service.isAvailable();
+
+  @override
+  Future<bool> warmup() => _service.warmupInstalledModel();
+}
+
+class _LiteRtPackageWarmupAdapter implements ModelWarmupAdapter {
+  _LiteRtPackageWarmupAdapter(this._service, this._package);
+
+  final LiteRtLmService _service;
+  final OfflineModelInfo _package;
+
+  @override
+  ModelResidentSpec get residentSpec => ModelResidentSpec(
+    id: _package.id,
+    residentType: _package.supportsVision
+        ? ResidentRuntimeType.image
+        : ResidentRuntimeType.text,
+    estimatedMemoryBytes:
+        _package.recommendedMemoryBytes ??
+        _package.minMemoryBytes ??
+        (_package.fileSizeBytes * 1.5).round(),
+  );
+
+  @override
+  Future<bool> isAvailable() async {
+    final hydrated = await _service.hydrateDownloadedModel(_package);
+    return hydrated.filePath?.trim().isNotEmpty == true;
+  }
+
+  @override
+  Future<bool> warmup() => _service.warmupModel(_package);
+}

--- a/app/lib/features/agent_chat/presentation/screens/chat_screen.dart
+++ b/app/lib/features/agent_chat/presentation/screens/chat_screen.dart
@@ -27,6 +27,7 @@ import '../../../coins/application/providers/expense_providers.dart';
 import '../../../coins/application/services/finance_chat_ingestion_service.dart';
 import '../../../../core/services/gemini_nano_service.dart';
 import '../../../../core/services/litert_lm_service.dart';
+import '../../../../core/services/local_runtime_preloader_service.dart';
 import 'model_library_screen.dart';
 
 /// Chat message model
@@ -51,12 +52,14 @@ class ChatScreen extends ConsumerStatefulWidget {
   const ChatScreen({
     super.key,
     this.assistantRuntimeService,
+    this.localRuntimePreloader,
     this.skillOrchestrator,
     this.enableAiInitialization = true,
     this.initialMessages,
   });
 
   final AssistantRuntimeService? assistantRuntimeService;
+  final LocalRuntimePreloaderService? localRuntimePreloader;
   final AgentSkillOrchestrator? skillOrchestrator;
   final bool enableAiInitialization;
   final List<ChatMessage>? initialMessages;
@@ -83,9 +86,11 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
   final GeminiNanoService _geminiNano = GeminiNanoService();
   final LiteRtLmService _liteRtLm = LiteRtLmService();
   late final AssistantRuntimeService _assistantRuntime;
+  late final LocalRuntimePreloaderService _localRuntimePreloader;
   late AgentSkillOrchestrator _skillOrchestrator;
   Map<String, dynamic>? _pendingCalendarEvent;
   bool _isDeviceSupported = false;
+  bool _isGenerating = false;
 
   @override
   void initState() {
@@ -93,9 +98,16 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
     _messageController = TextEditingController();
     _assistantRuntime =
         widget.assistantRuntimeService ??
-        AssistantRuntimeService(
+        AssistantRuntimeService(geminiNano: _geminiNano, liteRtLm: _liteRtLm);
+    _localRuntimePreloader =
+        widget.localRuntimePreloader ??
+        LocalRuntimePreloaderService(
           geminiNano: _geminiNano,
           liteRtLm: _liteRtLm,
+          loadAssistantModelLibrary: () =>
+              ref.read(assistantModelLibraryProvider.future),
+          selectedModelId: () => ref.read(selectedAssistantModelIdProvider),
+          isGenerationActive: () => _isGenerating,
         );
     _skillOrchestrator =
         widget.skillOrchestrator ?? _buildSkillOrchestrator(_skillRegistry);
@@ -150,20 +162,7 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
         });
       }
 
-      // Initialize Gemini Nano if supported
-      if (isSupported) {
-        final initialized = await _geminiNano.initialize();
-        debugPrint('Gemini Nano initialized: $initialized');
-        if (initialized) {
-          unawaited(_warmupGeminiNano());
-        }
-      }
-
-      unawaited(
-        _liteRtLm.warmupInstalledModel().then((warmed) {
-          debugPrint('LiteRT-LM warmup completed: $warmed');
-        }),
-      );
+      unawaited(_preloadLocalRuntimes());
 
       // Show bottom banner popup
       if (mounted) {
@@ -174,9 +173,12 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
     }
   }
 
-  Future<void> _warmupGeminiNano() async {
-    final warmed = await _geminiNano.warmup();
-    debugPrint('Gemini Nano warmed up: $warmed');
+  Future<void> _preloadLocalRuntimes() async {
+    final report = await _localRuntimePreloader.preloadSelectedModels();
+    debugPrint(
+      'Local preload completed: '
+      '${report.entries.map((entry) => '${entry.runtimeId}:${entry.reason}').join(', ')}',
+    );
   }
 
   void _showBottomBanner() {
@@ -231,6 +233,7 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
 
   @override
   void dispose() {
+    _localRuntimePreloader.abortPreload();
     _messageController.dispose();
     super.dispose();
   }
@@ -617,6 +620,7 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
       _messages.add(
         ChatMessage(text: '', isUser: false), // Placeholder for streaming
       );
+      _isGenerating = true;
     });
 
     try {
@@ -635,6 +639,14 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
           isUser: false,
         );
       });
+    } finally {
+      if (mounted) {
+        setState(() {
+          _isGenerating = false;
+        });
+      } else {
+        _isGenerating = false;
+      }
     }
   }
 
@@ -921,14 +933,18 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
           ('Total duration', _formatDuration(metadata.totalDurationMs)),
           ('Timestamp', _formatTimestamp(metadata.recordedAt)),
           if (metadata.timeToFirstTokenMs != null)
-            ('Time to first token', _formatDuration(metadata.timeToFirstTokenMs!)),
+            (
+              'Time to first token',
+              _formatDuration(metadata.timeToFirstTokenMs!),
+            ),
           if (metadata.promptTokens != null)
             ('Prompt tokens', '${metadata.promptTokens}'),
           if (metadata.completionTokens != null)
             ('Completion tokens', '${metadata.completionTokens}'),
           if (metadata.totalTokens != null)
             ('Total tokens', '${metadata.totalTokens}'),
-          if (metadata.toolCount != null) ('Tool calls', '${metadata.toolCount}'),
+          if (metadata.toolCount != null)
+            ('Tool calls', '${metadata.toolCount}'),
           if (metadata.finishReason != null)
             ('Finish reason', metadata.finishReason!),
         ];

--- a/app/test/core/services/local_runtime_preloader_service_test.dart
+++ b/app/test/core/services/local_runtime_preloader_service_test.dart
@@ -1,0 +1,81 @@
+import 'package:airo_app/core/services/local_runtime_preloader_service.dart';
+import 'package:airo_app/features/agent_chat/domain/models/assistant_runtime_ids.dart';
+import 'package:airo_app/features/agent_chat/presentation/screens/model_library_screen.dart';
+import 'package:core_ai/core_ai.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('builds local text adapters and no-op tts/stt hooks', () async {
+    final preloader = _RecordingPreloader();
+    final package = OfflineModelInfo(
+      id: 'gemma-local',
+      name: 'Gemma Local',
+      family: ModelFamily.gemma,
+      fileSizeBytes: 1024,
+      provider: AIProvider.gemma,
+      capabilities: const [ModelCapability.chat],
+    );
+    final candidate = AssistantModelCandidate(
+      id: litertGemmaAssistantModelId,
+      name: 'Gemma mobile package',
+      runtime: 'LiteRT-LM local model',
+      description: 'Local runtime',
+      bestFor: const [AssistantTask.chat],
+      tags: const ['Local'],
+      privacyLabel: 'Prompt stays on device',
+      sizeLabel: '1 GB',
+      available: true,
+      actionLabel: 'Start',
+      local: true,
+      package: package,
+    );
+
+    final service = LocalRuntimePreloaderService(
+      preloader: preloader,
+      loadAssistantModelLibrary: () async => AssistantModelLibraryState(
+        task: AssistantTask.chat,
+        deviceLabel: 'Pixel 9',
+        platformLabel: 'ANDROID',
+        candidates: [candidate],
+        recommended: candidate,
+        defaultPackages: {AssistantTask.chat: package},
+      ),
+      selectedModelId: () => litertGemmaAssistantModelId,
+    );
+
+    await service.preloadSelectedModels();
+
+    expect(
+      preloader.lastAdapters.map(
+        (adapter) => adapter.residentSpec.residentType,
+      ),
+      containsAll([
+        ResidentRuntimeType.text,
+        ResidentRuntimeType.tts,
+        ResidentRuntimeType.stt,
+      ]),
+    );
+  });
+}
+
+class _RecordingPreloader extends ModelPreloader {
+  _RecordingPreloader()
+    : super(
+        residencyManager: ModelResidencyManager(loadBudgetBytes: () async => 1),
+      );
+
+  List<ModelWarmupAdapter> lastAdapters = const [];
+
+  @override
+  Future<ModelPreloadReport> preloadSelectedModels({
+    required List<ModelWarmupAdapter> adapters,
+  }) async {
+    lastAdapters = adapters;
+    return ModelPreloadReport(
+      entries: const [],
+      startedAt: DateTime(2026, 6, 28),
+      finishedAt: DateTime(2026, 6, 28),
+      aborted: false,
+    );
+  }
+}

--- a/app/test/features/agent_chat/presentation/screens/chat_screen_preloader_test.dart
+++ b/app/test/features/agent_chat/presentation/screens/chat_screen_preloader_test.dart
@@ -1,0 +1,111 @@
+import 'package:airo_app/core/services/local_runtime_preloader_service.dart';
+import 'package:airo_app/features/agent_chat/application/assistant_model_preferences.dart';
+import 'package:airo_app/features/agent_chat/domain/models/assistant_runtime_ids.dart';
+import 'package:airo_app/features/agent_chat/presentation/screens/chat_screen.dart';
+import 'package:airo_app/features/agent_chat/presentation/screens/model_library_screen.dart';
+import 'package:core_ai/core_ai.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  testWidgets('chat initialization triggers the global local preloader', (
+    tester,
+  ) async {
+    SharedPreferences.setMockInitialValues({
+      'selected_assistant_model_id': geminiNanoAssistantModelId,
+    });
+    const channel = MethodChannel('com.airo.gemini_nano');
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, (call) async {
+          if (call.method == 'isAvailable') {
+            return false;
+          }
+          return null;
+        });
+    addTearDown(() {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(channel, null);
+    });
+
+    final preloader = _RecordingPreloader();
+    const recommended = AssistantModelCandidate(
+      id: geminiNanoAssistantModelId,
+      name: 'Gemini Nano',
+      runtime: 'AICore on-device',
+      description: 'Local runtime',
+      bestFor: [AssistantTask.chat],
+      tags: ['Local'],
+      privacyLabel: 'Prompt stays on device',
+      sizeLabel: 'System managed',
+      available: true,
+      actionLabel: 'Start',
+      local: true,
+    );
+
+    final localPreloader = LocalRuntimePreloaderService(
+      preloader: preloader,
+      loadAssistantModelLibrary: () async => const AssistantModelLibraryState(
+        task: AssistantTask.chat,
+        deviceLabel: 'Pixel 9',
+        platformLabel: 'ANDROID',
+        candidates: [recommended],
+        recommended: recommended,
+        defaultPackages: {},
+      ),
+      selectedModelId: () => geminiNanoAssistantModelId,
+    );
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          selectedAssistantModelIdProvider.overrideWith(
+            (ref) => _SelectedAssistantModelNotifier(),
+          ),
+        ],
+        child: MaterialApp(
+          home: ChatScreen(
+            localRuntimePreloader: localPreloader,
+            enableAiInitialization: true,
+          ),
+        ),
+      ),
+    );
+
+    await tester.pump();
+    await tester.pumpAndSettle();
+    await tester.pump(const Duration(milliseconds: 10));
+
+    expect(preloader.invoked, isTrue);
+  });
+}
+
+class _SelectedAssistantModelNotifier extends SelectedAssistantModelNotifier {
+  _SelectedAssistantModelNotifier() {
+    state = geminiNanoAssistantModelId;
+  }
+}
+
+class _RecordingPreloader extends ModelPreloader {
+  _RecordingPreloader()
+    : super(
+        residencyManager: ModelResidencyManager(loadBudgetBytes: () async => 1),
+      );
+
+  bool invoked = false;
+
+  @override
+  Future<ModelPreloadReport> preloadSelectedModels({
+    required List<ModelWarmupAdapter> adapters,
+  }) async {
+    invoked = true;
+    return ModelPreloadReport(
+      entries: const [],
+      startedAt: DateTime(2026, 6, 28),
+      finishedAt: DateTime(2026, 6, 28),
+      aborted: false,
+    );
+  }
+}

--- a/packages/core_ai/lib/core_ai.dart
+++ b/packages/core_ai/lib/core_ai.dart
@@ -10,6 +10,8 @@ export 'src/provider/ai_provider.dart';
 export 'src/device/device_capability_service.dart';
 export 'src/device/memory_budget_manager.dart';
 export 'src/device/memory_severity.dart';
+export 'src/residency/model_residency_manager.dart';
+export 'src/preload/model_preloader.dart';
 
 // LLM Client
 export 'src/llm/llm_client.dart';

--- a/packages/core_ai/lib/src/preload/model_preloader.dart
+++ b/packages/core_ai/lib/src/preload/model_preloader.dart
@@ -1,0 +1,220 @@
+import 'dart:async';
+
+import 'package:meta/meta.dart';
+
+import '../residency/model_residency_manager.dart';
+
+enum ModelPreloadEntryStatus { warmed, skipped, failed }
+
+@immutable
+class ModelPreloadReportEntry {
+  const ModelPreloadReportEntry({
+    required this.runtimeId,
+    required this.residentType,
+    required this.status,
+    required this.reason,
+    required this.duration,
+  });
+
+  final String runtimeId;
+  final ResidentRuntimeType residentType;
+  final ModelPreloadEntryStatus status;
+  final String reason;
+  final Duration duration;
+}
+
+@immutable
+class ModelPreloadReport {
+  const ModelPreloadReport({
+    required this.entries,
+    required this.startedAt,
+    required this.finishedAt,
+    required this.aborted,
+  });
+
+  final List<ModelPreloadReportEntry> entries;
+  final DateTime startedAt;
+  final DateTime finishedAt;
+  final bool aborted;
+}
+
+abstract class ModelWarmupAdapter {
+  ModelResidentSpec get residentSpec;
+
+  Future<bool> isAvailable();
+
+  Future<bool> warmup();
+}
+
+class NoOpWarmupAdapter implements ModelWarmupAdapter {
+  NoOpWarmupAdapter(this.residentSpec, {this.available = false});
+
+  @override
+  final ModelResidentSpec residentSpec;
+
+  final bool available;
+
+  @override
+  Future<bool> isAvailable() async => available;
+
+  @override
+  Future<bool> warmup() async => available;
+}
+
+typedef ActiveGenerationCheck = bool Function();
+
+class ModelPreloader {
+  ModelPreloader({
+    required ModelResidencyManager residencyManager,
+    ActiveGenerationCheck? isGenerationActive,
+  }) : _residencyManager = residencyManager,
+       _isGenerationActive = isGenerationActive;
+
+  final ModelResidencyManager _residencyManager;
+  final ActiveGenerationCheck? _isGenerationActive;
+  bool _abortRequested = false;
+
+  void abortPreload() {
+    _abortRequested = true;
+  }
+
+  Future<ModelPreloadReport> preloadSelectedModels({
+    required List<ModelWarmupAdapter> adapters,
+  }) async {
+    _abortRequested = false;
+    final startedAt = DateTime.now();
+    final entries = <ModelPreloadReportEntry>[];
+    var aborted = false;
+
+    final orderedAdapters = [...adapters]
+      ..sort(
+        (left, right) => _typeOrder(
+          left.residentSpec.residentType,
+        ).compareTo(_typeOrder(right.residentSpec.residentType)),
+      );
+
+    for (final adapter in orderedAdapters) {
+      final stepStartedAt = DateTime.now();
+      final resident = adapter.residentSpec;
+
+      if (_abortRequested) {
+        aborted = true;
+        entries.add(
+          ModelPreloadReportEntry(
+            runtimeId: resident.id,
+            residentType: resident.residentType,
+            status: ModelPreloadEntryStatus.skipped,
+            reason: 'aborted',
+            duration: DateTime.now().difference(stepStartedAt),
+          ),
+        );
+        continue;
+      }
+
+      if (_isGenerationActive?.call() ?? false) {
+        aborted = true;
+        entries.add(
+          ModelPreloadReportEntry(
+            runtimeId: resident.id,
+            residentType: resident.residentType,
+            status: ModelPreloadEntryStatus.skipped,
+            reason: 'generation_active',
+            duration: DateTime.now().difference(stepStartedAt),
+          ),
+        );
+        continue;
+      }
+
+      if (resident.residentType == ResidentRuntimeType.image) {
+        entries.add(
+          ModelPreloadReportEntry(
+            runtimeId: resident.id,
+            residentType: resident.residentType,
+            status: ModelPreloadEntryStatus.skipped,
+            reason: 'image_models_preload_disabled',
+            duration: DateTime.now().difference(stepStartedAt),
+          ),
+        );
+        continue;
+      }
+
+      final available = await adapter.isAvailable();
+      if (!available) {
+        entries.add(
+          ModelPreloadReportEntry(
+            runtimeId: resident.id,
+            residentType: resident.residentType,
+            status: ModelPreloadEntryStatus.skipped,
+            reason: 'runtime_unavailable',
+            duration: DateTime.now().difference(stepStartedAt),
+          ),
+        );
+        continue;
+      }
+
+      final canLoadWithoutEviction = await _residencyManager
+          .canLoadWithoutEviction(resident);
+      if (!canLoadWithoutEviction) {
+        entries.add(
+          ModelPreloadReportEntry(
+            runtimeId: resident.id,
+            residentType: resident.residentType,
+            status: ModelPreloadEntryStatus.skipped,
+            reason: 'would_require_eviction',
+            duration: DateTime.now().difference(stepStartedAt),
+          ),
+        );
+        continue;
+      }
+
+      final result = await _residencyManager.ensureResident(
+        resident,
+        allowEviction: false,
+        onLoad: adapter.warmup,
+      );
+      final status = switch (result.status) {
+        EnsureResidentStatus.loaded ||
+        EnsureResidentStatus.alreadyResident => ModelPreloadEntryStatus.warmed,
+        EnsureResidentStatus.blocked => ModelPreloadEntryStatus.skipped,
+        EnsureResidentStatus.failed => ModelPreloadEntryStatus.failed,
+      };
+      final reason = switch (result.status) {
+        EnsureResidentStatus.loaded => 'warmed',
+        EnsureResidentStatus.alreadyResident => 'already_resident',
+        EnsureResidentStatus.blocked => 'would_require_eviction',
+        EnsureResidentStatus.failed => 'warmup_failed',
+      };
+      entries.add(
+        ModelPreloadReportEntry(
+          runtimeId: resident.id,
+          residentType: resident.residentType,
+          status: status,
+          reason: reason,
+          duration: DateTime.now().difference(stepStartedAt),
+        ),
+      );
+    }
+
+    return ModelPreloadReport(
+      entries: entries,
+      startedAt: startedAt,
+      finishedAt: DateTime.now(),
+      aborted: aborted,
+    );
+  }
+
+  int _typeOrder(ResidentRuntimeType type) {
+    switch (type) {
+      case ResidentRuntimeType.text:
+        return 0;
+      case ResidentRuntimeType.tts:
+        return 1;
+      case ResidentRuntimeType.stt:
+        return 2;
+      case ResidentRuntimeType.classifier:
+        return 3;
+      case ResidentRuntimeType.image:
+        return 4;
+    }
+  }
+}

--- a/packages/core_ai/lib/src/residency/model_residency_manager.dart
+++ b/packages/core_ai/lib/src/residency/model_residency_manager.dart
@@ -1,0 +1,298 @@
+import 'dart:async';
+
+import 'package:meta/meta.dart';
+
+import '../device/memory_budget_manager.dart';
+
+enum ResidentRuntimeType { text, image, stt, tts, classifier }
+
+@immutable
+class ModelResidentSpec {
+  const ModelResidentSpec({
+    required this.id,
+    required this.residentType,
+    required this.estimatedMemoryBytes,
+    this.pinned = false,
+    this.sidecar = false,
+  });
+
+  final String id;
+  final ResidentRuntimeType residentType;
+  final int estimatedMemoryBytes;
+  final bool pinned;
+  final bool sidecar;
+
+  bool get isGenerationModel =>
+      residentType == ResidentRuntimeType.text ||
+      residentType == ResidentRuntimeType.image;
+}
+
+@immutable
+class ModelResidencyPlanResult {
+  const ModelResidencyPlanResult({
+    required this.incoming,
+    required this.budgetBytes,
+    required this.currentUsageBytes,
+    required this.projectedUsageBytes,
+    required this.residentsToEvict,
+    required this.fits,
+    this.refusalReason,
+  });
+
+  final ModelResidentSpec incoming;
+  final int budgetBytes;
+  final int currentUsageBytes;
+  final int projectedUsageBytes;
+  final List<ModelResidentSpec> residentsToEvict;
+  final bool fits;
+  final String? refusalReason;
+}
+
+class ModelResidencyPolicy {
+  const ModelResidencyPolicy();
+
+  ModelResidencyPlanResult plan({
+    required List<ModelResidentSpec> currentResidents,
+    required ModelResidentSpec incoming,
+    required int budgetBytes,
+  }) {
+    final currentUsageBytes = currentResidents.fold<int>(
+      0,
+      (sum, resident) => sum + resident.estimatedMemoryBytes,
+    );
+    final projectedUsageBytes =
+        currentUsageBytes + incoming.estimatedMemoryBytes;
+
+    if (projectedUsageBytes <= budgetBytes) {
+      return ModelResidencyPlanResult(
+        incoming: incoming,
+        budgetBytes: budgetBytes,
+        currentUsageBytes: currentUsageBytes,
+        projectedUsageBytes: projectedUsageBytes,
+        residentsToEvict: const [],
+        fits: true,
+      );
+    }
+
+    final candidates = [...currentResidents]
+      ..sort(
+        (left, right) => _evictionPriority(
+          left,
+          incoming,
+        ).compareTo(_evictionPriority(right, incoming)),
+      );
+
+    final evictions = <ModelResidentSpec>[];
+    var reclaimedBytes = 0;
+
+    for (final resident in candidates) {
+      if (resident.pinned) {
+        continue;
+      }
+
+      evictions.add(resident);
+      reclaimedBytes += resident.estimatedMemoryBytes;
+
+      if (projectedUsageBytes - reclaimedBytes <= budgetBytes) {
+        return ModelResidencyPlanResult(
+          incoming: incoming,
+          budgetBytes: budgetBytes,
+          currentUsageBytes: currentUsageBytes,
+          projectedUsageBytes: projectedUsageBytes - reclaimedBytes,
+          residentsToEvict: evictions,
+          fits: true,
+        );
+      }
+    }
+
+    return ModelResidencyPlanResult(
+      incoming: incoming,
+      budgetBytes: budgetBytes,
+      currentUsageBytes: currentUsageBytes,
+      projectedUsageBytes: projectedUsageBytes - reclaimedBytes,
+      residentsToEvict: evictions,
+      fits: false,
+      refusalReason:
+          'Incoming runtime does not fit within the current device budget.',
+    );
+  }
+
+  int _evictionPriority(
+    ModelResidentSpec resident,
+    ModelResidentSpec incoming,
+  ) {
+    if (_isOppositeGenerationModel(resident, incoming)) {
+      return 0;
+    }
+    if (resident.sidecar) {
+      return 2;
+    }
+    if (resident.pinned) {
+      return 3;
+    }
+    return 1;
+  }
+
+  bool _isOppositeGenerationModel(
+    ModelResidentSpec resident,
+    ModelResidentSpec incoming,
+  ) {
+    if (!resident.isGenerationModel || !incoming.isGenerationModel) {
+      return false;
+    }
+
+    return resident.residentType != incoming.residentType;
+  }
+}
+
+enum EnsureResidentStatus { loaded, alreadyResident, blocked, failed }
+
+@immutable
+class EnsureResidentResult {
+  const EnsureResidentResult({
+    required this.status,
+    required this.spec,
+    this.plan,
+  });
+
+  final EnsureResidentStatus status;
+  final ModelResidentSpec spec;
+  final ModelResidencyPlanResult? plan;
+}
+
+typedef ResidencyBudgetLoader = Future<int> Function();
+typedef ResidentEvictionCallback =
+    Future<void> Function(ModelResidentSpec resident);
+typedef ResidentLoadCallback = Future<bool> Function();
+
+class ModelResidencyManager {
+  ModelResidencyManager({
+    ResidencyBudgetLoader? loadBudgetBytes,
+    ModelResidencyPolicy policy = const ModelResidencyPolicy(),
+  }) : _loadBudgetBytes = loadBudgetBytes ?? _defaultBudgetBytes,
+       _policy = policy;
+
+  final ResidencyBudgetLoader _loadBudgetBytes;
+  final ModelResidencyPolicy _policy;
+  final Map<String, ModelResidentSpec> _residents =
+      <String, ModelResidentSpec>{};
+  Future<void> _exclusiveTail = Future<void>.value();
+
+  List<ModelResidentSpec> get residents => List.unmodifiable(_residents.values);
+
+  bool isResident(String id) => _residents.containsKey(id);
+
+  void markResident(ModelResidentSpec spec) {
+    _residents[spec.id] = spec;
+  }
+
+  void removeResident(String id) {
+    _residents.remove(id);
+  }
+
+  Future<ModelResidencyPlanResult> planFor(ModelResidentSpec incoming) async {
+    final budgetBytes = await _loadBudgetBytes();
+    return _policy.plan(
+      currentResidents: residents,
+      incoming: incoming,
+      budgetBytes: budgetBytes,
+    );
+  }
+
+  Future<bool> canLoadWithoutEviction(ModelResidentSpec incoming) async {
+    final plan = await planFor(incoming);
+    return plan.fits && plan.residentsToEvict.isEmpty;
+  }
+
+  Future<ModelResidencyPlanResult> makeRoomFor(
+    ModelResidentSpec incoming, {
+    ResidentEvictionCallback? onEvict,
+  }) async {
+    return runExclusive<ModelResidencyPlanResult>(
+      'makeRoomFor:${incoming.id}',
+      () async {
+        final plan = await planFor(incoming);
+        if (!plan.fits) {
+          return plan;
+        }
+
+        for (final resident in plan.residentsToEvict) {
+          if (onEvict != null) {
+            await onEvict(resident);
+          }
+          removeResident(resident.id);
+        }
+
+        return plan;
+      },
+    );
+  }
+
+  Future<EnsureResidentResult> ensureResident(
+    ModelResidentSpec incoming, {
+    required ResidentLoadCallback onLoad,
+    ResidentEvictionCallback? onEvict,
+    bool allowEviction = true,
+  }) {
+    return runExclusive<EnsureResidentResult>(
+      'ensureResident:${incoming.id}',
+      () async {
+        if (isResident(incoming.id)) {
+          return EnsureResidentResult(
+            status: EnsureResidentStatus.alreadyResident,
+            spec: incoming,
+          );
+        }
+
+        ModelResidencyPlanResult? plan;
+        if (!await canLoadWithoutEviction(incoming)) {
+          if (!allowEviction) {
+            plan = await planFor(incoming);
+            return EnsureResidentResult(
+              status: EnsureResidentStatus.blocked,
+              spec: incoming,
+              plan: plan,
+            );
+          }
+
+          plan = await makeRoomFor(incoming, onEvict: onEvict);
+          if (!plan.fits) {
+            return EnsureResidentResult(
+              status: EnsureResidentStatus.blocked,
+              spec: incoming,
+              plan: plan,
+            );
+          }
+        }
+
+        final loaded = await onLoad();
+        if (!loaded) {
+          return EnsureResidentResult(
+            status: EnsureResidentStatus.failed,
+            spec: incoming,
+            plan: plan,
+          );
+        }
+
+        markResident(incoming);
+        return EnsureResidentResult(
+          status: EnsureResidentStatus.loaded,
+          spec: incoming,
+          plan: plan,
+        );
+      },
+    );
+  }
+
+  Future<T> runExclusive<T>(String label, Future<T> Function() action) {
+    final operation = _exclusiveTail.then((_) => action());
+    _exclusiveTail = operation.then<void>((_) {}, onError: (_, _) {});
+    return operation;
+  }
+
+  static Future<int> _defaultBudgetBytes() async {
+    final manager = MemoryBudgetManager();
+    final memoryInfo = await manager.getCurrentMemoryInfo(forceRefresh: true);
+    return manager.calculateBudget(memoryInfo);
+  }
+}

--- a/packages/core_ai/test/preload/model_preloader_test.dart
+++ b/packages/core_ai/test/preload/model_preloader_test.dart
@@ -1,0 +1,167 @@
+import 'package:core_ai/core_ai.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('ModelPreloader', () {
+    late ModelResidencyManager residencyManager;
+
+    setUp(() {
+      residencyManager = ModelResidencyManager(
+        loadBudgetBytes: () async => 4096,
+      );
+    });
+
+    test('warms text, then tts, then stt in order', () async {
+      final order = <String>[];
+      final preloader = ModelPreloader(residencyManager: residencyManager);
+
+      final report = await preloader.preloadSelectedModels(
+        adapters: [
+          _FakeWarmupAdapter(
+            spec: const ModelResidentSpec(
+              id: 'stt',
+              residentType: ResidentRuntimeType.stt,
+              estimatedMemoryBytes: 256,
+              sidecar: true,
+            ),
+            onWarmup: () => order.add('stt'),
+          ),
+          _FakeWarmupAdapter(
+            spec: const ModelResidentSpec(
+              id: 'text',
+              residentType: ResidentRuntimeType.text,
+              estimatedMemoryBytes: 512,
+            ),
+            onWarmup: () => order.add('text'),
+          ),
+          _FakeWarmupAdapter(
+            spec: const ModelResidentSpec(
+              id: 'tts',
+              residentType: ResidentRuntimeType.tts,
+              estimatedMemoryBytes: 128,
+              sidecar: true,
+            ),
+            onWarmup: () => order.add('tts'),
+          ),
+        ],
+      );
+
+      expect(order, ['text', 'tts', 'stt']);
+      expect(
+        report.entries.map((entry) => entry.status),
+        everyElement(ModelPreloadEntryStatus.warmed),
+      );
+    });
+
+    test('skips image runtimes during background preload', () async {
+      final preloader = ModelPreloader(residencyManager: residencyManager);
+
+      final report = await preloader.preloadSelectedModels(
+        adapters: [
+          _FakeWarmupAdapter(
+            spec: const ModelResidentSpec(
+              id: 'image',
+              residentType: ResidentRuntimeType.image,
+              estimatedMemoryBytes: 1024,
+            ),
+          ),
+        ],
+      );
+
+      expect(report.entries.single.status, ModelPreloadEntryStatus.skipped);
+      expect(report.entries.single.reason, 'image_models_preload_disabled');
+    });
+
+    test('aborts remaining warmups after abortPreload is requested', () async {
+      late ModelPreloader preloader;
+      final warmed = <String>[];
+      preloader = ModelPreloader(residencyManager: residencyManager);
+
+      final report = await preloader.preloadSelectedModels(
+        adapters: [
+          _FakeWarmupAdapter(
+            spec: const ModelResidentSpec(
+              id: 'text',
+              residentType: ResidentRuntimeType.text,
+              estimatedMemoryBytes: 512,
+            ),
+            onWarmup: () {
+              warmed.add('text');
+              preloader.abortPreload();
+            },
+          ),
+          _FakeWarmupAdapter(
+            spec: const ModelResidentSpec(
+              id: 'tts',
+              residentType: ResidentRuntimeType.tts,
+              estimatedMemoryBytes: 128,
+              sidecar: true,
+            ),
+            onWarmup: () => warmed.add('tts'),
+          ),
+        ],
+      );
+
+      expect(warmed, ['text']);
+      expect(report.aborted, isTrue);
+      expect(report.entries.last.reason, 'aborted');
+    });
+
+    test('stops new warmups when generation becomes active', () async {
+      var generationActive = false;
+      final warmed = <String>[];
+      final preloader = ModelPreloader(
+        residencyManager: residencyManager,
+        isGenerationActive: () => generationActive,
+      );
+
+      final report = await preloader.preloadSelectedModels(
+        adapters: [
+          _FakeWarmupAdapter(
+            spec: const ModelResidentSpec(
+              id: 'text',
+              residentType: ResidentRuntimeType.text,
+              estimatedMemoryBytes: 512,
+            ),
+            onWarmup: () {
+              warmed.add('text');
+              generationActive = true;
+            },
+          ),
+          _FakeWarmupAdapter(
+            spec: const ModelResidentSpec(
+              id: 'stt',
+              residentType: ResidentRuntimeType.stt,
+              estimatedMemoryBytes: 256,
+              sidecar: true,
+            ),
+            onWarmup: () => warmed.add('stt'),
+          ),
+        ],
+      );
+
+      expect(warmed, ['text']);
+      expect(report.aborted, isTrue);
+      expect(report.entries.last.reason, 'generation_active');
+    });
+  });
+}
+
+class _FakeWarmupAdapter implements ModelWarmupAdapter {
+  _FakeWarmupAdapter({required this.spec, this.onWarmup});
+
+  final ModelResidentSpec spec;
+  final void Function()? onWarmup;
+
+  @override
+  ModelResidentSpec get residentSpec => spec;
+
+  @override
+  Future<bool> isAvailable() async => true;
+
+  @override
+  Future<bool> warmup() async {
+    onWarmup?.call();
+    return true;
+  }
+}

--- a/packages/core_ai/test/residency/model_residency_manager_test.dart
+++ b/packages/core_ai/test/residency/model_residency_manager_test.dart
@@ -1,0 +1,209 @@
+import 'package:core_ai/core_ai.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('ModelResidencyPolicy', () {
+    const policy = ModelResidencyPolicy();
+
+    test('evicts opposite generation models before other residents', () {
+      const currentResidents = [
+        ModelResidentSpec(
+          id: 'image-xl',
+          residentType: ResidentRuntimeType.image,
+          estimatedMemoryBytes: 900,
+        ),
+        ModelResidentSpec(
+          id: 'classifier',
+          residentType: ResidentRuntimeType.classifier,
+          estimatedMemoryBytes: 200,
+          pinned: true,
+        ),
+        ModelResidentSpec(
+          id: 'tts-sidecar',
+          residentType: ResidentRuntimeType.tts,
+          estimatedMemoryBytes: 250,
+          sidecar: true,
+        ),
+      ];
+      const incoming = ModelResidentSpec(
+        id: 'text-primary',
+        residentType: ResidentRuntimeType.text,
+        estimatedMemoryBytes: 700,
+      );
+
+      final plan = policy.plan(
+        currentResidents: currentResidents,
+        incoming: incoming,
+        budgetBytes: 1500,
+      );
+
+      expect(plan.fits, isTrue);
+      expect(plan.residentsToEvict.map((resident) => resident.id), [
+        'image-xl',
+      ]);
+    });
+
+    test(
+      'keeps pinned classifier resident and uses sidecars as last resort',
+      () {
+        const currentResidents = [
+          ModelResidentSpec(
+            id: 'helper-text',
+            residentType: ResidentRuntimeType.text,
+            estimatedMemoryBytes: 600,
+          ),
+          ModelResidentSpec(
+            id: 'tts-sidecar',
+            residentType: ResidentRuntimeType.tts,
+            estimatedMemoryBytes: 300,
+            sidecar: true,
+          ),
+          ModelResidentSpec(
+            id: 'classifier',
+            residentType: ResidentRuntimeType.classifier,
+            estimatedMemoryBytes: 100,
+            pinned: true,
+          ),
+        ];
+        const incoming = ModelResidentSpec(
+          id: 'image-xl',
+          residentType: ResidentRuntimeType.image,
+          estimatedMemoryBytes: 1000,
+        );
+
+        final plan = policy.plan(
+          currentResidents: currentResidents,
+          incoming: incoming,
+          budgetBytes: 1200,
+        );
+
+        expect(plan.fits, isTrue);
+        expect(plan.residentsToEvict.map((resident) => resident.id), [
+          'helper-text',
+          'tts-sidecar',
+        ]);
+        expect(
+          plan.residentsToEvict.map((resident) => resident.id),
+          isNot(contains('classifier')),
+        );
+      },
+    );
+
+    test('refuses loads that still cannot fit after allowed evictions', () {
+      const currentResidents = [
+        ModelResidentSpec(
+          id: 'classifier',
+          residentType: ResidentRuntimeType.classifier,
+          estimatedMemoryBytes: 400,
+          pinned: true,
+        ),
+      ];
+      const incoming = ModelResidentSpec(
+        id: 'huge-image',
+        residentType: ResidentRuntimeType.image,
+        estimatedMemoryBytes: 1600,
+      );
+
+      final plan = policy.plan(
+        currentResidents: currentResidents,
+        incoming: incoming,
+        budgetBytes: 1200,
+      );
+
+      expect(plan.fits, isFalse);
+      expect(plan.refusalReason, isNotEmpty);
+    });
+  });
+
+  group('ModelResidencyManager', () {
+    late ModelResidencyManager manager;
+
+    setUp(() {
+      manager = ModelResidencyManager(loadBudgetBytes: () async => 1500);
+    });
+
+    test('canLoadWithoutEviction gates background warmups', () async {
+      manager.markResident(
+        const ModelResidentSpec(
+          id: 'existing-text',
+          residentType: ResidentRuntimeType.text,
+          estimatedMemoryBytes: 1100,
+        ),
+      );
+
+      final canLoad = await manager.canLoadWithoutEviction(
+        const ModelResidentSpec(
+          id: 'stt-sidecar',
+          residentType: ResidentRuntimeType.stt,
+          estimatedMemoryBytes: 500,
+          sidecar: true,
+        ),
+      );
+
+      expect(canLoad, isFalse);
+      expect(manager.residents.map((resident) => resident.id), [
+        'existing-text',
+      ]);
+    });
+
+    test('ensureResident loads and tracks a new resident', () async {
+      final result = await manager.ensureResident(
+        const ModelResidentSpec(
+          id: 'text-primary',
+          residentType: ResidentRuntimeType.text,
+          estimatedMemoryBytes: 700,
+        ),
+        onLoad: () async => true,
+      );
+
+      expect(result.status, EnsureResidentStatus.loaded);
+      expect(manager.isResident('text-primary'), isTrue);
+    });
+
+    test(
+      'makeRoomFor does not evict when the incoming runtime cannot fit',
+      () async {
+        manager.markResident(
+          const ModelResidentSpec(
+            id: 'classifier',
+            residentType: ResidentRuntimeType.classifier,
+            estimatedMemoryBytes: 500,
+            pinned: true,
+          ),
+        );
+
+        final evicted = <String>[];
+        final plan = await manager.makeRoomFor(
+          const ModelResidentSpec(
+            id: 'huge-image',
+            residentType: ResidentRuntimeType.image,
+            estimatedMemoryBytes: 1600,
+          ),
+          onEvict: (resident) async => evicted.add(resident.id),
+        );
+
+        expect(plan.fits, isFalse);
+        expect(evicted, isEmpty);
+        expect(manager.residents.map((resident) => resident.id), [
+          'classifier',
+        ]);
+      },
+    );
+
+    test('runExclusive serializes concurrent work', () async {
+      final events = <String>[];
+
+      Future<void> task(String id) {
+        return manager.runExclusive<void>(id, () async {
+          events.add('start:$id');
+          await Future<void>.delayed(const Duration(milliseconds: 10));
+          events.add('end:$id');
+        });
+      }
+
+      await Future.wait([task('a'), task('b')]);
+
+      expect(events, ['start:a', 'end:a', 'start:b', 'end:b']);
+    });
+  });
+}


### PR DESCRIPTION
# Summary

This PR introduces changes to the local runtime orchestration layer.
Goal: centralize safe local model warmup so chat startup can reduce first-use latency without background evictions or duplicated runtime-specific startup logic.

Core outcome:

* adds a residency policy and manager for safe local runtime loading decisions
* adds a global preloader with abort, generation gating, and no-eviction background warmup
* wires chat startup through the shared preloader instead of separate Gemini Nano and LiteRT warmups

# Changes

### Code

* Added:
  * `packages/core_ai/lib/src/residency/model_residency_manager.dart`
  * `packages/core_ai/lib/src/preload/model_preloader.dart`
  * `app/lib/core/services/local_runtime_preloader_service.dart`
  * focused residency, preloader, service, and widget tests
* Updated:
  * `packages/core_ai/lib/core_ai.dart` exports for the new shared runtime orchestration primitives
  * `app/lib/features/agent_chat/presentation/screens/chat_screen.dart` to trigger shared preload asynchronously and abort when the screen is disposed or generation starts

### Logic

* background preload now checks `canLoadWithoutEviction` before warming a runtime
* active/user-triggered runtime work can use `makeRoomFor`, `ensureResident`, and `runExclusive` through the shared manager
* image-capable packages are explicitly skipped during background preload
* STT/TTS hooks exist as no-op adapters so future local runtimes can plug into the same flow

# API Changes (if any)

* None externally.

# Database Changes (if any)

* None.

# Observability / Logging

* Added preload completion logging in chat startup with per-runtime result reasons.

# Performance Impact

* Latency: expected improvement for repeat chat initialization and first local response after preload
* Throughput: no meaningful change expected
* Memory/CPU: background warmup now uses a no-eviction gate and shared serialization to reduce unsafe concurrent load pressure

# Risks

* runtime memory estimates are conservative and may skip some optional warmups on constrained devices
* STT/TTS remain extension hooks only until concrete local assistant runtimes are added
* Rollback plan:
  * revert this PR to restore the prior direct Gemini Nano and LiteRT warmup behavior

# Testing

* Unit tests:
  * `cd packages/core_ai && flutter analyze lib/core_ai.dart lib/src/residency/model_residency_manager.dart lib/src/preload/model_preloader.dart test/residency/model_residency_manager_test.dart test/preload/model_preloader_test.dart`
  * `cd packages/core_ai && flutter test test/residency/model_residency_manager_test.dart test/preload/model_preloader_test.dart`
  * `cd app && flutter analyze lib/core/services/local_runtime_preloader_service.dart lib/features/agent_chat/presentation/screens/chat_screen.dart test/core/services/local_runtime_preloader_service_test.dart test/features/agent_chat/presentation/screens/chat_screen_preloader_test.dart`
  * `cd app && flutter test --no-pub test/core/services/local_runtime_preloader_service_test.dart test/features/agent_chat/presentation/screens/chat_screen_preloader_test.dart`
* Integration tests:
  * none
* Manual testing:
  * device verification instructions added to #391 comment for cold vs warm latency and memory behavior

# Deployment Notes

* Config changes:
  * none
* Order of deployment:
  * normal app deployment

# Related Commits

* `feat(core-ai): add safe local runtime preloader`

# Notes

* Closes #391
