### PR TITLE
fix(core-ai): adopt LiteRT-LM as swappable runtime adapter

### DIFF
--- a/app/lib/core/services/litert_lm_service.dart
+++ b/app/lib/core/services/litert_lm_service.dart
@@ -1,369 +1,64 @@
+export 'package:core_ai/core_ai.dart'
+    show
+        LiteRtLmBackend,
+        LiteRtLmClient,
+        LiteRtLmConfig,
+        LiteRtLmModelKind,
+        LiteRtLmRuntimeAdapter,
+        MethodChannelLiteRtLmClient;
+
 import 'package:core_ai/core_ai.dart';
-import 'package:flutter/foundation.dart';
-import 'package:flutter/services.dart';
 
-/// Supported LiteRT-LM model families used for model installation metadata.
-enum LiteRtLmModelKind {
-  gemmaIt,
-  gemma4,
-  functionGemma,
-  qwen,
-  qwen3,
-  phi,
-  deepSeek,
-  general,
-}
-
-/// Runtime backend preference for LiteRT-LM inference.
-enum LiteRtLmBackend { cpu, gpu, npu }
-
-/// Configuration for Airo's LiteRT-LM integration.
-class LiteRtLmConfig {
-  final String modelPath;
-  final String modelUrl;
-  final String huggingFaceToken;
-  final LiteRtLmModelKind modelKind;
-  final LiteRtLmBackend backend;
-  final int maxTokens;
-
-  const LiteRtLmConfig({
-    this.modelPath = const String.fromEnvironment('LITERT_LM_MODEL_PATH'),
-    this.modelUrl = const String.fromEnvironment('LITERT_LM_MODEL_URL'),
-    this.huggingFaceToken = const String.fromEnvironment('HUGGINGFACE_TOKEN'),
-    this.modelKind = LiteRtLmModelKind.gemmaIt,
-    this.backend = LiteRtLmBackend.gpu,
-    this.maxTokens = 2048,
-  });
-
-  bool get hasModelPath => modelPath.trim().isNotEmpty;
-  bool get hasModelUrl => modelUrl.trim().isNotEmpty;
-  String? get optionalHuggingFaceToken =>
-      huggingFaceToken.trim().isEmpty ? null : huggingFaceToken.trim();
-}
-
-/// Thin boundary around the concrete LiteRT-LM runtime implementation.
-abstract class LiteRtLmClient {
-  Future<void> initialize({
-    String? huggingFaceToken,
-    String? modelPath,
-    LiteRtLmBackend? backend,
-    int? maxTokens,
-  });
-
-  Future<bool> activeModelExists({String? modelPath});
-
-  Future<void> installModel({
-    required String url,
-    required LiteRtLmModelKind modelKind,
-    String? huggingFaceToken,
-  });
-
-  Future<String> generate({
-    required String prompt,
-    required LiteRtLmBackend backend,
-    required int maxTokens,
-    String? systemPrompt,
-  });
-}
-
-/// App-facing LiteRT-LM service.
+/// Transitional app-facing shim around the framework-owned LiteRT-LM adapter.
+///
+/// Feature code should continue to inject/use this service until all call sites
+/// move directly to the `core_ai` runtime contracts.
 class LiteRtLmService {
   LiteRtLmService({
     LiteRtLmClient? client,
     this.config = const LiteRtLmConfig(),
     ModelDownloadService? downloadService,
-  }) : _client = client ?? MethodChannelLiteRtLmClient(config: config),
-       _downloadService = downloadService ?? ModelDownloadService();
+    LiteRtLmRuntimeAdapter? adapter,
+  }) : _adapter =
+           adapter ??
+           LiteRtLmRuntimeAdapter(
+             client: client,
+             runtimeConfig: config,
+             downloadService: downloadService,
+           );
 
-  final LiteRtLmClient _client;
   final LiteRtLmConfig config;
-  final ModelDownloadService _downloadService;
-  String? _initializedModelPath;
+  final LiteRtLmRuntimeAdapter _adapter;
 
-  Future<bool> isAvailable() async {
-    if (kIsWeb) return false;
-    if (await _client.activeModelExists()) return true;
-    return config.hasModelUrl;
-  }
+  Future<bool> isAvailable() => _adapter.isAvailable();
 
-  Future<String?> generateText(String prompt, {String? systemPrompt}) async {
-    if (prompt.trim().isEmpty) return null;
-    if (!await _ensureDefaultInitialized()) return null;
-
-    return _client.generate(
-      prompt: prompt,
-      systemPrompt: systemPrompt,
-      backend: config.backend,
-      maxTokens: config.maxTokens,
+  Future<String?> generateText(String prompt, {String? systemPrompt}) {
+    return _adapter.generateText(
+      RuntimeGenerationRequest(prompt: prompt, systemPrompt: systemPrompt),
     );
   }
 
-  /// Pre-warm an already-installed LiteRT-LM model with a private dummy prompt.
-  ///
-  /// This method intentionally does not install or download a model. It only
-  /// warms the local runtime when an active model file already exists.
-  Future<bool> warmupInstalledModel() async {
-    if (kIsWeb) return false;
+  Future<bool> warmupInstalledModel() => _adapter.warmupInstalledModel();
 
-    try {
-      final defaultModelPath = config.hasModelPath
-          ? config.modelPath.trim()
-          : null;
-      if (!await _client.activeModelExists(modelPath: defaultModelPath)) {
-        return false;
-      }
-
-      if (_initializedModelPath == null ||
-          _initializedModelPath != defaultModelPath) {
-        await _client.initialize(
-          huggingFaceToken: config.optionalHuggingFaceToken,
-          modelPath: defaultModelPath,
-          backend: config.backend,
-          maxTokens: config.maxTokens,
-        );
-        _initializedModelPath = defaultModelPath;
-      }
-      await _client.generate(
-        prompt: ' ',
-        backend: config.backend,
-        maxTokens: 1,
-      );
-      return true;
-    } catch (e) {
-      debugPrint('LiteRT-LM warmup skipped: $e');
-      return false;
-    }
-  }
-
-  Future<bool> warmupModel(OfflineModelInfo model) async {
-    if (kIsWeb) {
-      return false;
-    }
-
-    try {
-      final hydratedModel = await hydrateDownloadedModel(model);
-      final modelPath = hydratedModel.filePath?.trim();
-      if (modelPath == null || modelPath.isEmpty) {
-        return false;
-      }
-
-      final backend = _backendFor(hydratedModel.backendPreference);
-      if (!await _ensureInitializedForRequest(
-        modelPath: modelPath,
-        backend: backend,
-        maxTokens: config.maxTokens,
-      )) {
-        return false;
-      }
-
-      await _client.generate(prompt: ' ', backend: backend, maxTokens: 1);
-      return true;
-    } catch (e) {
-      debugPrint('LiteRT-LM model warmup skipped: $e');
-      return false;
-    }
-  }
+  Future<bool> warmupModel(OfflineModelInfo model) =>
+      _adapter.warmupModel(model);
 
   Future<String?> generateTextForModel(
     OfflineModelInfo model,
     String prompt, {
     String? systemPrompt,
-  }) async {
-    if (kIsWeb || prompt.trim().isEmpty) return null;
-
-    final hydratedModel = await hydrateDownloadedModel(model);
-    final modelPath = hydratedModel.filePath?.trim();
-    if (modelPath == null || modelPath.isEmpty) {
-      return null;
-    }
-
-    final backend = _backendFor(hydratedModel.backendPreference);
-    if (!await _ensureInitializedForRequest(
-      modelPath: modelPath,
-      backend: backend,
-      maxTokens: config.maxTokens,
-    )) {
-      return null;
-    }
-
-    return _client.generate(
-      prompt: prompt,
-      systemPrompt: systemPrompt,
-      backend: backend,
-      maxTokens: config.maxTokens,
+  }) {
+    return _adapter.generateText(
+      RuntimeGenerationRequest(prompt: prompt, systemPrompt: systemPrompt),
+      model: model,
     );
   }
 
-  Future<OfflineModelInfo> hydrateDownloadedModel(
-    OfflineModelInfo model,
-  ) async {
-    if (kIsWeb) return model;
-    if (model.filePath?.trim().isNotEmpty == true) {
-      return model;
-    }
-
-    final modelPath = await downloadedModelPath(model.id);
-    if (modelPath == null) {
-      return model;
-    }
-    return model.copyWith(filePath: modelPath);
+  Future<OfflineModelInfo> hydrateDownloadedModel(OfflineModelInfo model) {
+    return _adapter.hydrateDownloadedModel(model);
   }
 
-  Future<String?> downloadedModelPath(String modelId) async {
-    if (kIsWeb) return null;
-    final isDownloaded = await _downloadService.isModelDownloaded(modelId);
-    if (!isDownloaded) return null;
-    return _downloadService.getModelPath(modelId);
-  }
-
-  Future<bool> _ensureDefaultInitialized() async {
-    return _ensureInitializedForRequest(
-      modelPath: config.hasModelPath ? config.modelPath.trim() : null,
-      backend: config.backend,
-      maxTokens: config.maxTokens,
-      installUrl: config.hasModelUrl ? config.modelUrl.trim() : null,
-      modelKind: config.modelKind,
-    );
-  }
-
-  Future<bool> _ensureInitializedForRequest({
-    String? modelPath,
-    LiteRtLmBackend? backend,
-    int? maxTokens,
-    String? installUrl,
-    LiteRtLmModelKind? modelKind,
-  }) async {
-    final trimmedModelPath = modelPath?.trim();
-    if (_initializedModelPath != null &&
-        trimmedModelPath != null &&
-        _initializedModelPath == trimmedModelPath) {
-      return true;
-    }
-
-    var resolvedModelPath = trimmedModelPath;
-
-    if (!await _client.activeModelExists(modelPath: resolvedModelPath)) {
-      final resolvedInstallUrl = installUrl?.trim();
-      if (resolvedInstallUrl == null || resolvedInstallUrl.isEmpty) {
-        return false;
-      }
-      await _client.installModel(
-        url: resolvedInstallUrl,
-        modelKind: modelKind ?? config.modelKind,
-        huggingFaceToken: config.optionalHuggingFaceToken,
-      );
-      resolvedModelPath = null;
-    }
-    await _client.initialize(
-      huggingFaceToken: config.optionalHuggingFaceToken,
-      modelPath: resolvedModelPath,
-      backend: backend ?? config.backend,
-      maxTokens: maxTokens ?? config.maxTokens,
-    );
-    _initializedModelPath =
-        resolvedModelPath ??
-        installUrl?.trim() ??
-        (config.hasModelPath ? config.modelPath.trim() : null);
-    return true;
-  }
-
-  LiteRtLmBackend _backendFor(ModelBackendPreference preference) {
-    return switch (preference) {
-      ModelBackendPreference.cpu => LiteRtLmBackend.cpu,
-      ModelBackendPreference.gpu => LiteRtLmBackend.gpu,
-      ModelBackendPreference.npu ||
-      ModelBackendPreference.aiCore => LiteRtLmBackend.npu,
-      ModelBackendPreference.auto => config.backend,
-    };
-  }
-}
-
-/// MethodChannel client backed by native LiteRT-LM integrations.
-class MethodChannelLiteRtLmClient implements LiteRtLmClient {
-  MethodChannelLiteRtLmClient({
-    required LiteRtLmConfig config,
-    MethodChannel channel = const MethodChannel('com.airo.litert_lm'),
-  }) : _config = config,
-       _channel = channel;
-
-  final LiteRtLmConfig _config;
-  final MethodChannel _channel;
-  String? _installedModelPath;
-
-  String? get _activeModelPath {
-    final installedPath = _installedModelPath?.trim();
-    if (installedPath != null && installedPath.isNotEmpty) {
-      return installedPath;
-    }
-    return _config.hasModelPath ? _config.modelPath : null;
-  }
-
-  @override
-  Future<bool> activeModelExists({String? modelPath}) async {
-    final resolvedModelPath = (modelPath?.trim().isNotEmpty ?? false)
-        ? modelPath!.trim()
-        : _activeModelPath;
-    if (resolvedModelPath == null) return false;
-    try {
-      final available = await _channel.invokeMethod<bool>('isAvailable', {
-        'modelPath': resolvedModelPath,
-      });
-      return available ?? false;
-    } on PlatformException catch (e) {
-      debugPrint('LiteRT-LM availability check failed: ${e.message}');
-      return false;
-    } on MissingPluginException {
-      return false;
-    }
-  }
-
-  @override
-  Future<String> generate({
-    required String prompt,
-    required LiteRtLmBackend backend,
-    required int maxTokens,
-    String? systemPrompt,
-  }) async {
-    final response = await _channel.invokeMethod<String>('generateContent', {
-      'prompt': prompt,
-      'systemPrompt': systemPrompt,
-      'backend': backend.name,
-      'maxTokens': maxTokens,
-    });
-    return response ?? '';
-  }
-
-  @override
-  Future<void> initialize({
-    String? huggingFaceToken,
-    String? modelPath,
-    LiteRtLmBackend? backend,
-    int? maxTokens,
-  }) async {
-    final resolvedModelPath = (modelPath?.trim().isNotEmpty ?? false)
-        ? modelPath!.trim()
-        : _activeModelPath;
-    if (resolvedModelPath == null) {
-      throw StateError('LiteRT-LM model path is not configured');
-    }
-
-    await _channel.invokeMethod<bool>('initialize', {
-      'modelPath': resolvedModelPath,
-      'backend': (backend ?? _config.backend).name,
-      'maxTokens': maxTokens ?? _config.maxTokens,
-    });
-  }
-
-  @override
-  Future<void> installModel({
-    required String url,
-    required LiteRtLmModelKind modelKind,
-    String? huggingFaceToken,
-  }) async {
-    _installedModelPath = await _channel.invokeMethod<String>('installModel', {
-      'url': url,
-      'modelKind': modelKind.name,
-      'huggingFaceToken': huggingFaceToken,
-    });
+  Future<String?> downloadedModelPath(String modelId) {
+    return _adapter.downloadedModelPath(modelId);
   }
 }

--- a/app/test/core/services/litert_lm_service_warmup_test.dart
+++ b/app/test/core/services/litert_lm_service_warmup_test.dart
@@ -55,9 +55,11 @@ class _FakeLiteRtLmClient implements LiteRtLmClient {
   int initializeCalls = 0;
   int installCalls = 0;
   final generatedPrompts = <String>[];
+  final initializeModelPaths = <String?>[];
 
   @override
-  Future<bool> activeModelExists({String? modelPath}) async => activeModelExistsValue;
+  Future<bool> activeModelExists({String? modelPath}) async =>
+      activeModelExistsValue;
 
   @override
   Future<void> initialize({
@@ -67,6 +69,7 @@ class _FakeLiteRtLmClient implements LiteRtLmClient {
     int? maxTokens,
   }) async {
     initializeCalls += 1;
+    initializeModelPaths.add(modelPath);
   }
 
   @override

--- a/packages/core_ai/lib/core_ai.dart
+++ b/packages/core_ai/lib/core_ai.dart
@@ -12,6 +12,8 @@ export 'src/device/memory_budget_manager.dart';
 export 'src/device/memory_severity.dart';
 export 'src/residency/model_residency_manager.dart';
 export 'src/preload/model_preloader.dart';
+export 'src/runtime/local_inference_runtime_adapter.dart';
+export 'src/litert/litert_lm_runtime_adapter.dart';
 
 // LLM Client
 export 'src/llm/llm_client.dart';

--- a/packages/core_ai/lib/src/litert/litert_lm_runtime_adapter.dart
+++ b/packages/core_ai/lib/src/litert/litert_lm_runtime_adapter.dart
@@ -1,0 +1,560 @@
+import 'package:core_domain/core_domain.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+
+import '../download/model_download_service.dart';
+import '../llm/active_model_service.dart';
+import '../llm/llm_config.dart';
+import '../llm/llm_response.dart';
+import '../models/offline_model_info.dart';
+import '../runtime/local_inference_runtime_adapter.dart';
+import '../utils/token_counter.dart';
+
+enum LiteRtLmModelKind {
+  gemmaIt,
+  gemma4,
+  functionGemma,
+  qwen,
+  qwen3,
+  phi,
+  deepSeek,
+  general,
+}
+
+enum LiteRtLmBackend { cpu, gpu, npu }
+
+class LiteRtLmConfig {
+  final String modelPath;
+  final String modelUrl;
+  final String huggingFaceToken;
+  final LiteRtLmModelKind modelKind;
+  final LiteRtLmBackend backend;
+  final int maxTokens;
+
+  const LiteRtLmConfig({
+    this.modelPath = const String.fromEnvironment('LITERT_LM_MODEL_PATH'),
+    this.modelUrl = const String.fromEnvironment('LITERT_LM_MODEL_URL'),
+    this.huggingFaceToken = const String.fromEnvironment('HUGGINGFACE_TOKEN'),
+    this.modelKind = LiteRtLmModelKind.gemmaIt,
+    this.backend = LiteRtLmBackend.gpu,
+    this.maxTokens = 2048,
+  });
+
+  bool get hasModelPath => modelPath.trim().isNotEmpty;
+  bool get hasModelUrl => modelUrl.trim().isNotEmpty;
+  String? get optionalHuggingFaceToken =>
+      huggingFaceToken.trim().isEmpty ? null : huggingFaceToken.trim();
+}
+
+abstract class LiteRtLmClient {
+  Future<void> initialize({
+    String? huggingFaceToken,
+    String? modelPath,
+    LiteRtLmBackend? backend,
+    int? maxTokens,
+  });
+
+  Future<bool> activeModelExists({String? modelPath});
+
+  Future<void> installModel({
+    required String url,
+    required LiteRtLmModelKind modelKind,
+    String? huggingFaceToken,
+  });
+
+  Future<String> generate({
+    required String prompt,
+    required LiteRtLmBackend backend,
+    required int maxTokens,
+    String? systemPrompt,
+  });
+}
+
+class LiteRtLmRuntimeAdapter implements LocalInferenceRuntimeAdapter {
+  LiteRtLmRuntimeAdapter({
+    LiteRtLmClient? client,
+    this.runtimeConfig = const LiteRtLmConfig(),
+    ModelDownloadService? downloadService,
+    ActiveModelService? activeModelService,
+    Set<RuntimeBackend>? supportedBackends,
+  }) : _client = client ?? MethodChannelLiteRtLmClient(config: runtimeConfig),
+       _downloadService = downloadService ?? ModelDownloadService(),
+       _activeModelService = activeModelService ?? ActiveModelService.instance,
+       _supportedBackends =
+           supportedBackends ??
+           const {RuntimeBackend.cpu, RuntimeBackend.gpu, RuntimeBackend.npu};
+
+  final LiteRtLmClient _client;
+  final LiteRtLmConfig runtimeConfig;
+  final ModelDownloadService _downloadService;
+  final ActiveModelService _activeModelService;
+  final Set<RuntimeBackend> _supportedBackends;
+  String? _initializedModelPath;
+
+  @override
+  LocalRuntimeKind get runtimeKind => LocalRuntimeKind.liteRtLm;
+
+  @override
+  LLMConfig get config => LLMConfig(
+    provider: 'litert-lm',
+    modelName: 'LiteRT-LM',
+    maxOutputTokens: runtimeConfig.maxTokens,
+  );
+
+  @override
+  int get maxContextLength => 32768;
+
+  @override
+  RuntimeCapabilities capabilitiesForModel(OfflineModelInfo model) {
+    return RuntimeCapabilities(
+      supportedBackends: _supportedBackends,
+      supportsStreaming: false,
+      supportsImages: model.supportsVision,
+      supportsAudio: model.supportsAudio,
+      supportsToolCalling: model.supportsFunctionCalling,
+      supportsSystemPrompt: true,
+      supportsSpeculativeDecoding: false,
+    );
+  }
+
+  @override
+  Future<void> prepareModel({OfflineModelInfo? model}) async {
+    if (kIsWeb) {
+      throw UnsupportedError('LiteRT-LM is not available on web.');
+    }
+
+    final resolvedModel = model == null
+        ? null
+        : await hydrateDownloadedModel(model);
+    final modelPath = resolvedModel?.filePath?.trim();
+    final backend = resolvedModel == null
+        ? runtimeConfig.backend
+        : _backendFor(resolvedModel.backendPreference);
+    final initialized = await _ensureInitializedForRequest(
+      modelPath:
+          modelPath ??
+          (runtimeConfig.hasModelPath ? runtimeConfig.modelPath.trim() : null),
+      backend: backend,
+      maxTokens: runtimeConfig.maxTokens,
+      installUrl: resolvedModel == null && runtimeConfig.hasModelUrl
+          ? runtimeConfig.modelUrl.trim()
+          : resolvedModel?.downloadUrl,
+      modelKind: runtimeConfig.modelKind,
+    );
+    if (!initialized) {
+      throw StateError('LiteRT-LM runtime could not initialize.');
+    }
+
+    final activeModelId = resolvedModel?.id ?? 'litert-default';
+    final activePath =
+        modelPath ?? _initializedModelPath ?? runtimeConfig.modelPath.trim();
+    await _activeModelService.activateRuntime(
+      runtimeKind: ActiveRuntimeKind.liteRtLm,
+      runtimeId: 'litert-lm',
+      modelId: activeModelId,
+      modelPath: activePath,
+      displayName: resolvedModel?.name ?? 'LiteRT-LM',
+      estimatedMemoryBytes:
+          resolvedModel?.recommendedMemoryBytes ??
+          resolvedModel?.minMemoryBytes ??
+          (resolvedModel?.fileSizeBytes ?? 1024 * 1024 * 1024),
+    );
+  }
+
+  @override
+  Future<Result<LLMResponse>> generate(String prompt) async {
+    final text = await generateText(RuntimeGenerationRequest(prompt: prompt));
+    if (text == null) {
+      return Failure(
+        ServerFailure(
+          message: 'LiteRT-LM runtime is unavailable for the requested prompt.',
+        ),
+      );
+    }
+    return Success(
+      LLMResponse(
+        text: text,
+        provider: 'litert-lm',
+        promptTokens: estimateTokens(prompt),
+        completionTokens: estimateTokens(text),
+      ),
+    );
+  }
+
+  @override
+  Stream<String> generateStream(String prompt) async* {
+    final text = await generateText(RuntimeGenerationRequest(prompt: prompt));
+    if (text == null) {
+      return;
+    }
+    yield text;
+  }
+
+  @override
+  Future<String?> generateText(
+    RuntimeGenerationRequest request, {
+    OfflineModelInfo? model,
+  }) async {
+    if (request.prompt.trim().isEmpty) return null;
+    if (model != null) {
+      _validateCapabilityRequest(model, request);
+      await prepareModel(model: model);
+      final hydratedModel = await hydrateDownloadedModel(model);
+      final modelPath = hydratedModel.filePath?.trim();
+      if (modelPath == null || modelPath.isEmpty) {
+        return null;
+      }
+
+      return _client.generate(
+        prompt: request.prompt,
+        systemPrompt: request.systemPrompt,
+        backend: _backendFor(hydratedModel.backendPreference),
+        maxTokens: runtimeConfig.maxTokens,
+      );
+    }
+
+    final initialized = await _ensureInitializedForRequest(
+      modelPath: runtimeConfig.hasModelPath
+          ? runtimeConfig.modelPath.trim()
+          : null,
+      backend: runtimeConfig.backend,
+      maxTokens: runtimeConfig.maxTokens,
+      installUrl: runtimeConfig.hasModelUrl
+          ? runtimeConfig.modelUrl.trim()
+          : null,
+      modelKind: runtimeConfig.modelKind,
+    );
+    if (!initialized) {
+      return null;
+    }
+
+    await _activeModelService.activateRuntime(
+      runtimeKind: ActiveRuntimeKind.liteRtLm,
+      runtimeId: 'litert-lm',
+      modelId: 'litert-default',
+      modelPath: _initializedModelPath ?? runtimeConfig.modelPath.trim(),
+      displayName: 'LiteRT-LM',
+      estimatedMemoryBytes: 1024 * 1024 * 1024,
+    );
+
+    return _client.generate(
+      prompt: request.prompt,
+      systemPrompt: request.systemPrompt,
+      backend: runtimeConfig.backend,
+      maxTokens: runtimeConfig.maxTokens,
+    );
+  }
+
+  @override
+  Future<bool> isAvailable() async {
+    if (kIsWeb) return false;
+    if (await _client.activeModelExists()) return true;
+    return runtimeConfig.hasModelUrl;
+  }
+
+  @override
+  int estimateTokens(String text) => TokenCounter.estimate(text);
+
+  @override
+  Future<void> dispose() async {}
+
+  @override
+  Future<bool> supportsModel(OfflineModelInfo model) async {
+    final filePath = model.filePath?.toLowerCase();
+    final downloadUrl = model.downloadUrl?.toLowerCase();
+    final tags = model.tags.map((tag) => tag.toLowerCase());
+
+    final looksLikeLiteRt =
+        (filePath?.endsWith('.litertlm') ?? false) ||
+        (filePath?.endsWith('.task') ?? false) ||
+        (downloadUrl?.endsWith('.litertlm') ?? false) ||
+        (downloadUrl?.endsWith('.task') ?? false) ||
+        tags.contains('litert-lm');
+
+    return looksLikeLiteRt;
+  }
+
+  Future<bool> warmupInstalledModel() async {
+    if (kIsWeb) return false;
+
+    try {
+      final defaultModelPath = runtimeConfig.hasModelPath
+          ? runtimeConfig.modelPath.trim()
+          : null;
+      if (!await _client.activeModelExists(modelPath: defaultModelPath)) {
+        return false;
+      }
+
+      if (_initializedModelPath == null ||
+          _initializedModelPath != defaultModelPath) {
+        await _client.initialize(
+          huggingFaceToken: runtimeConfig.optionalHuggingFaceToken,
+          modelPath: defaultModelPath,
+          backend: runtimeConfig.backend,
+          maxTokens: runtimeConfig.maxTokens,
+        );
+        _initializedModelPath = defaultModelPath;
+      }
+      await _client.generate(
+        prompt: ' ',
+        backend: runtimeConfig.backend,
+        maxTokens: 1,
+      );
+      await _activeModelService.activateRuntime(
+        runtimeKind: ActiveRuntimeKind.liteRtLm,
+        runtimeId: 'litert-lm',
+        modelId: 'litert-default',
+        modelPath: _initializedModelPath ?? defaultModelPath ?? '',
+        displayName: 'LiteRT-LM',
+        estimatedMemoryBytes: 1024 * 1024 * 1024,
+      );
+      return true;
+    } catch (e) {
+      debugPrint('LiteRT-LM warmup skipped: $e');
+      return false;
+    }
+  }
+
+  Future<bool> warmupModel(OfflineModelInfo model) async {
+    if (kIsWeb) return false;
+
+    try {
+      final hydratedModel = await hydrateDownloadedModel(model);
+      final modelPath = hydratedModel.filePath?.trim();
+      if (modelPath == null || modelPath.isEmpty) {
+        return false;
+      }
+
+      final backend = _backendFor(hydratedModel.backendPreference);
+      if (!await _ensureInitializedForRequest(
+        modelPath: modelPath,
+        backend: backend,
+        maxTokens: runtimeConfig.maxTokens,
+      )) {
+        return false;
+      }
+
+      await _client.generate(prompt: ' ', backend: backend, maxTokens: 1);
+      await _activeModelService.activateRuntime(
+        runtimeKind: ActiveRuntimeKind.liteRtLm,
+        runtimeId: 'litert-lm',
+        modelId: hydratedModel.id,
+        modelPath: modelPath,
+        displayName: hydratedModel.name,
+        estimatedMemoryBytes:
+            hydratedModel.recommendedMemoryBytes ??
+            hydratedModel.minMemoryBytes ??
+            hydratedModel.fileSizeBytes,
+      );
+      return true;
+    } catch (e) {
+      debugPrint('LiteRT-LM model warmup skipped: $e');
+      return false;
+    }
+  }
+
+  Future<OfflineModelInfo> hydrateDownloadedModel(
+    OfflineModelInfo model,
+  ) async {
+    if (kIsWeb) return model;
+    if (model.filePath?.trim().isNotEmpty == true) {
+      return model;
+    }
+
+    final modelPath = await downloadedModelPath(model.id);
+    if (modelPath == null) {
+      return model;
+    }
+    return model.copyWith(filePath: modelPath);
+  }
+
+  Future<String?> downloadedModelPath(String modelId) async {
+    if (kIsWeb) return null;
+    final isDownloaded = await _downloadService.isModelDownloaded(modelId);
+    if (!isDownloaded) return null;
+    return _downloadService.getModelPath(modelId);
+  }
+
+  Future<bool> _ensureInitializedForRequest({
+    String? modelPath,
+    LiteRtLmBackend? backend,
+    int? maxTokens,
+    String? installUrl,
+    LiteRtLmModelKind? modelKind,
+  }) async {
+    final trimmedModelPath = modelPath?.trim();
+    if (_initializedModelPath != null &&
+        trimmedModelPath != null &&
+        _initializedModelPath == trimmedModelPath) {
+      return true;
+    }
+
+    var resolvedModelPath = trimmedModelPath;
+    if (!await _client.activeModelExists(modelPath: resolvedModelPath)) {
+      final resolvedInstallUrl = installUrl?.trim();
+      if (resolvedInstallUrl == null || resolvedInstallUrl.isEmpty) {
+        return false;
+      }
+      await _client.installModel(
+        url: resolvedInstallUrl,
+        modelKind: modelKind ?? runtimeConfig.modelKind,
+        huggingFaceToken: runtimeConfig.optionalHuggingFaceToken,
+      );
+      resolvedModelPath = null;
+    }
+
+    await _client.initialize(
+      huggingFaceToken: runtimeConfig.optionalHuggingFaceToken,
+      modelPath: resolvedModelPath,
+      backend: backend ?? runtimeConfig.backend,
+      maxTokens: maxTokens ?? runtimeConfig.maxTokens,
+    );
+
+    _initializedModelPath =
+        resolvedModelPath ??
+        installUrl?.trim() ??
+        (runtimeConfig.hasModelPath ? runtimeConfig.modelPath.trim() : null);
+    return true;
+  }
+
+  LiteRtLmBackend _backendFor(ModelBackendPreference preference) {
+    return switch (preference) {
+      ModelBackendPreference.cpu => LiteRtLmBackend.cpu,
+      ModelBackendPreference.gpu => LiteRtLmBackend.gpu,
+      ModelBackendPreference.npu ||
+      ModelBackendPreference.aiCore => LiteRtLmBackend.npu,
+      ModelBackendPreference.auto => runtimeConfig.backend,
+    };
+  }
+
+  void _validateCapabilityRequest(
+    OfflineModelInfo model,
+    RuntimeGenerationRequest request,
+  ) {
+    final capabilities = capabilitiesForModel(model);
+    final backend = _runtimeBackendFor(model.backendPreference);
+    if (!capabilities.supportedBackends.contains(backend)) {
+      throw UnsupportedError(
+        'LiteRT-LM backend ${backend.name} is not supported on this device.',
+      );
+    }
+    if (request.requiresVision && !capabilities.supportsImages) {
+      throw UnsupportedError(
+        'LiteRT-LM model ${model.id} does not support vision input.',
+      );
+    }
+    if (request.requiresAudio && !capabilities.supportsAudio) {
+      throw UnsupportedError(
+        'LiteRT-LM model ${model.id} does not support audio input.',
+      );
+    }
+    if (request.requiresToolCalling && !capabilities.supportsToolCalling) {
+      throw UnsupportedError(
+        'LiteRT-LM model ${model.id} does not support tool calling.',
+      );
+    }
+  }
+
+  RuntimeBackend _runtimeBackendFor(ModelBackendPreference preference) {
+    return switch (preference) {
+      ModelBackendPreference.cpu => RuntimeBackend.cpu,
+      ModelBackendPreference.gpu => RuntimeBackend.gpu,
+      ModelBackendPreference.npu ||
+      ModelBackendPreference.aiCore => RuntimeBackend.npu,
+      ModelBackendPreference.auto => switch (runtimeConfig.backend) {
+        LiteRtLmBackend.cpu => RuntimeBackend.cpu,
+        LiteRtLmBackend.gpu => RuntimeBackend.gpu,
+        LiteRtLmBackend.npu => RuntimeBackend.npu,
+      },
+    };
+  }
+}
+
+class MethodChannelLiteRtLmClient implements LiteRtLmClient {
+  MethodChannelLiteRtLmClient({
+    required LiteRtLmConfig config,
+    MethodChannel channel = const MethodChannel('com.airo.litert_lm'),
+  }) : _config = config,
+       _channel = channel;
+
+  final LiteRtLmConfig _config;
+  final MethodChannel _channel;
+  String? _installedModelPath;
+
+  String? get _activeModelPath {
+    final installedPath = _installedModelPath?.trim();
+    if (installedPath != null && installedPath.isNotEmpty) {
+      return installedPath;
+    }
+    return _config.hasModelPath ? _config.modelPath : null;
+  }
+
+  @override
+  Future<bool> activeModelExists({String? modelPath}) async {
+    final resolvedModelPath = (modelPath?.trim().isNotEmpty ?? false)
+        ? modelPath!.trim()
+        : _activeModelPath;
+    if (resolvedModelPath == null) return false;
+    try {
+      final available = await _channel.invokeMethod<bool>('isAvailable', {
+        'modelPath': resolvedModelPath,
+      });
+      return available ?? false;
+    } on PlatformException catch (e) {
+      debugPrint('LiteRT-LM availability check failed: ${e.message}');
+      return false;
+    } on MissingPluginException {
+      return false;
+    }
+  }
+
+  @override
+  Future<String> generate({
+    required String prompt,
+    required LiteRtLmBackend backend,
+    required int maxTokens,
+    String? systemPrompt,
+  }) async {
+    final response = await _channel.invokeMethod<String>('generateContent', {
+      'prompt': prompt,
+      'systemPrompt': systemPrompt,
+      'backend': backend.name,
+      'maxTokens': maxTokens,
+    });
+    return response ?? '';
+  }
+
+  @override
+  Future<void> initialize({
+    String? huggingFaceToken,
+    String? modelPath,
+    LiteRtLmBackend? backend,
+    int? maxTokens,
+  }) async {
+    final resolvedModelPath = (modelPath?.trim().isNotEmpty ?? false)
+        ? modelPath!.trim()
+        : _activeModelPath;
+    if (resolvedModelPath == null) {
+      throw StateError('LiteRT-LM model path is not configured');
+    }
+
+    await _channel.invokeMethod<bool>('initialize', {
+      'modelPath': resolvedModelPath,
+      'backend': (backend ?? _config.backend).name,
+      'maxTokens': maxTokens ?? _config.maxTokens,
+    });
+  }
+
+  @override
+  Future<void> installModel({
+    required String url,
+    required LiteRtLmModelKind modelKind,
+    String? huggingFaceToken,
+  }) async {
+    _installedModelPath = await _channel.invokeMethod<String>('installModel', {
+      'url': url,
+      'modelKind': modelKind.name,
+      'huggingFaceToken': huggingFaceToken,
+    });
+  }
+}

--- a/packages/core_ai/lib/src/llm/active_model_service.dart
+++ b/packages/core_ai/lib/src/llm/active_model_service.dart
@@ -32,6 +32,48 @@ enum ActiveModelState {
   unloading,
 }
 
+enum ActiveRuntimeKind { gguf, liteRtLm }
+
+class ActiveRuntimeInfo {
+  const ActiveRuntimeInfo({
+    required this.runtimeKind,
+    required this.runtimeId,
+    required this.modelId,
+    required this.modelPath,
+    required this.displayName,
+    required this.state,
+    this.memoryUsageBytes,
+  });
+
+  final ActiveRuntimeKind runtimeKind;
+  final String runtimeId;
+  final String modelId;
+  final String modelPath;
+  final String displayName;
+  final ActiveModelState state;
+  final int? memoryUsageBytes;
+
+  bool get isReady => state == ActiveModelState.ready;
+
+  ActiveRuntimeInfo copyWith({
+    ActiveRuntimeKind? runtimeKind,
+    String? runtimeId,
+    String? modelId,
+    String? modelPath,
+    String? displayName,
+    ActiveModelState? state,
+    int? memoryUsageBytes,
+  }) => ActiveRuntimeInfo(
+    runtimeKind: runtimeKind ?? this.runtimeKind,
+    runtimeId: runtimeId ?? this.runtimeId,
+    modelId: modelId ?? this.modelId,
+    modelPath: modelPath ?? this.modelPath,
+    displayName: displayName ?? this.displayName,
+    state: state ?? this.state,
+    memoryUsageBytes: memoryUsageBytes ?? this.memoryUsageBytes,
+  );
+}
+
 /// Information about the currently active model.
 class ActiveModelInfo {
   const ActiveModelInfo({
@@ -118,7 +160,11 @@ class ActiveModelService {
   final MemoryBudgetManager _memoryBudgetManager;
 
   ActiveModelInfo? _activeModel;
+  ActiveRuntimeInfo? _activeRuntime;
+  Future<void> Function()? _activeRuntimeDispose;
   final _stateController = StreamController<ActiveModelInfo?>.broadcast();
+  final _runtimeStateController =
+      StreamController<ActiveRuntimeInfo?>.broadcast();
 
   /// Stream of active model state changes.
   Stream<ActiveModelInfo?> get stateStream => _stateController.stream;
@@ -126,9 +172,19 @@ class ActiveModelService {
   /// Gets the currently active model info, or null if no model is loaded.
   ActiveModelInfo? get activeModel => _activeModel;
 
+  /// Stream of generic runtime lifecycle changes.
+  Stream<ActiveRuntimeInfo?> get runtimeStateStream =>
+      _runtimeStateController.stream;
+
+  /// Gets the currently active runtime, including non-GGUF runtimes.
+  ActiveRuntimeInfo? get activeRuntime => _activeRuntime;
+
   /// Whether a model is currently loaded and ready.
   bool get hasActiveModel =>
       _activeModel != null && _activeModel!.state == ActiveModelState.ready;
+
+  bool get hasActiveRuntime =>
+      _activeRuntime != null && _activeRuntime!.state == ActiveModelState.ready;
 
   /// Whether a model is currently loading.
   bool get isLoading =>
@@ -173,6 +229,17 @@ class ActiveModelService {
       onMemoryWarning?.call(memoryCheck);
     }
 
+    _activeRuntime = ActiveRuntimeInfo(
+      runtimeKind: ActiveRuntimeKind.gguf,
+      runtimeId: 'gguf',
+      modelId: config.modelPath,
+      modelPath: config.modelPath,
+      displayName: config.modelName,
+      state: ActiveModelState.loading,
+      memoryUsageBytes: config.estimatedMemoryBytes,
+    );
+    _runtimeStateController.add(_activeRuntime);
+
     // Update state to loading
     _activeModel = ActiveModelInfo(
       config: config,
@@ -200,6 +267,8 @@ class ActiveModelService {
         loadedAt: DateTime.now(),
         memoryUsageBytes: config.estimatedMemoryBytes,
       );
+      _activeRuntime = _activeRuntime?.copyWith(state: ActiveModelState.ready);
+      _runtimeStateController.add(_activeRuntime);
       _stateController.add(_activeModel);
       onProgress?.call(1.0, 'Model ready');
 
@@ -223,6 +292,11 @@ class ActiveModelService {
         state: ActiveModelState.error,
         errorMessage: e.toString(),
       );
+      _activeRuntime = _activeRuntime?.copyWith(
+        state: ActiveModelState.error,
+        memoryUsageBytes: config.estimatedMemoryBytes,
+      );
+      _runtimeStateController.add(_activeRuntime);
       _stateController.add(_activeModel);
 
       return Err(e, stack);
@@ -231,22 +305,33 @@ class ActiveModelService {
 
   /// Unloads the currently active model.
   Future<void> unloadModel() async {
-    if (_activeModel == null) return;
+    if (_activeModel == null && _activeRuntime == null) return;
 
-    developer.log(
-      'Unloading model: ${_activeModel!.config.modelName}',
-      name: 'ActiveModelService',
-    );
+    developer.log('Unloading active runtime', name: 'ActiveModelService');
 
-    _activeModel = _activeModel!.copyWith(state: ActiveModelState.unloading);
-    _stateController.add(_activeModel);
+    if (_activeModel != null) {
+      _activeModel = _activeModel!.copyWith(state: ActiveModelState.unloading);
+      _stateController.add(_activeModel);
+    }
+    if (_activeRuntime != null) {
+      _activeRuntime = _activeRuntime!.copyWith(
+        state: ActiveModelState.unloading,
+      );
+      _runtimeStateController.add(_activeRuntime);
+    }
 
     try {
+      if (_activeRuntimeDispose != null) {
+        await _activeRuntimeDispose!.call();
+      }
       // TODO: Replace with actual llama.cpp FFI cleanup
       await Future.delayed(const Duration(milliseconds: 50));
 
       _activeModel = null;
       _stateController.add(null);
+      _activeRuntime = null;
+      _activeRuntimeDispose = null;
+      _runtimeStateController.add(null);
 
       developer.log('Model unloaded', name: 'ActiveModelService');
     } catch (e, stack) {
@@ -260,7 +345,45 @@ class ActiveModelService {
       // Force unload even on error
       _activeModel = null;
       _stateController.add(null);
+      _activeRuntime = null;
+      _activeRuntimeDispose = null;
+      _runtimeStateController.add(null);
     }
+  }
+
+  Future<void> activateRuntime({
+    required ActiveRuntimeKind runtimeKind,
+    required String runtimeId,
+    required String modelId,
+    required String modelPath,
+    required String displayName,
+    required int estimatedMemoryBytes,
+    Future<void> Function()? onDeactivate,
+  }) async {
+    final shouldReuseCurrent =
+        _activeRuntime != null &&
+        _activeRuntime!.runtimeKind == runtimeKind &&
+        _activeRuntime!.modelId == modelId &&
+        _activeRuntime!.state == ActiveModelState.ready;
+    if (shouldReuseCurrent) {
+      return;
+    }
+
+    if (_activeModel != null || _activeRuntime != null) {
+      await unloadModel();
+    }
+
+    _activeRuntime = ActiveRuntimeInfo(
+      runtimeKind: runtimeKind,
+      runtimeId: runtimeId,
+      modelId: modelId,
+      modelPath: modelPath,
+      displayName: displayName,
+      state: ActiveModelState.ready,
+      memoryUsageBytes: estimatedMemoryBytes,
+    );
+    _activeRuntimeDispose = onDeactivate;
+    _runtimeStateController.add(_activeRuntime);
   }
 
   /// Switches to a different model.
@@ -296,5 +419,6 @@ class ActiveModelService {
   Future<void> dispose() async {
     await unloadModel();
     await _stateController.close();
+    await _runtimeStateController.close();
   }
 }

--- a/packages/core_ai/lib/src/llm/llm_client.dart
+++ b/packages/core_ai/lib/src/llm/llm_client.dart
@@ -41,6 +41,9 @@ enum LLMProvider {
   /// GGUF model via llama.cpp
   gguf,
 
+  /// LiteRT-LM on-device runtime
+  liteRtLm,
+
   /// Fallback/mock for testing
   mock,
 }

--- a/packages/core_ai/lib/src/llm/llm_router_impl.dart
+++ b/packages/core_ai/lib/src/llm/llm_router_impl.dart
@@ -7,9 +7,12 @@ import 'gemini_api_client.dart';
 import 'gemini_nano_client.dart';
 import 'gguf_model_client.dart';
 import 'gguf_model_config.dart';
+import '../litert/litert_lm_runtime_adapter.dart';
 import 'llm_client.dart';
 import 'llm_config.dart';
 import 'llm_response.dart';
+import '../models/offline_model_info.dart';
+import '../runtime/local_inference_runtime_adapter.dart';
 import '../utils/token_counter.dart';
 
 /// Callback for memory-related events during LLM routing.
@@ -22,17 +25,26 @@ class LLMRouterImpl implements LLMRouter {
   LLMRouterImpl({
     this.geminiNanoClient,
     this.geminiApiClient,
+    this.liteRtLmAdapter,
     this.mockClient,
     this.preferOnDevice = true,
     this.onMemoryWarning,
+    LocalInferenceRuntimeRegistry? localRuntimeRegistry,
     ActiveModelService? activeModelService,
-  }) : _activeModelService = activeModelService ?? ActiveModelService.instance;
+  }) : _activeModelService = activeModelService ?? ActiveModelService.instance,
+       _localRuntimeRegistry =
+           localRuntimeRegistry ??
+           LocalInferenceRuntimeRegistry(
+             adapters: liteRtLmAdapter == null ? const [] : [liteRtLmAdapter],
+           );
 
   final GeminiNanoClient? geminiNanoClient;
   final GeminiApiClient? geminiApiClient;
+  final LiteRtLmRuntimeAdapter? liteRtLmAdapter;
   final LLMClient? mockClient;
   final bool preferOnDevice;
   final ActiveModelService _activeModelService;
+  final LocalInferenceRuntimeRegistry _localRuntimeRegistry;
 
   /// Currently loaded GGUF client (managed by ActiveModelService).
   GGUFModelClient? _ggufClient;
@@ -130,6 +142,7 @@ class LLMRouterImpl implements LLMRouter {
     LLMProvider.geminiNano => geminiNanoClient,
     LLMProvider.geminiApi => geminiApiClient,
     LLMProvider.gguf => _ggufClient,
+    LLMProvider.liteRtLm => liteRtLmAdapter,
     LLMProvider.mock => mockClient,
   };
 
@@ -150,8 +163,48 @@ class LLMRouterImpl implements LLMRouter {
     }
 
     results[LLMProvider.mock] = mockClient != null;
+    results[LLMProvider.liteRtLm] = liteRtLmAdapter != null
+        ? await liteRtLmAdapter!.isAvailable()
+        : false;
 
     return results;
+  }
+
+  Future<LLMClient> routeForOfflineModel({
+    required OfflineModelInfo model,
+    required RuntimeGenerationRequest request,
+  }) async {
+    final supportedAdapters = await _localRuntimeRegistry
+        .supportedAdaptersForModel(model);
+    for (final adapter in supportedAdapters) {
+      final capabilities = adapter.capabilitiesForModel(model);
+      if (request.requiresVision && !capabilities.supportsImages) {
+        throw UnsupportedError(
+          '${adapter.runtimeKind.name} does not support vision for ${model.id}.',
+        );
+      }
+      if (request.requiresToolCalling && !capabilities.supportsToolCalling) {
+        throw UnsupportedError(
+          '${adapter.runtimeKind.name} does not support tool calling for ${model.id}.',
+        );
+      }
+
+      if (await adapter.isAvailable()) {
+        return adapter;
+      }
+    }
+
+    if (request.localOnly) {
+      throw StateError(
+        'No local runtime adapter is available for ${model.id}. Cloud fallback is disabled.',
+      );
+    }
+
+    if (geminiApiClient != null) {
+      return geminiApiClient!;
+    }
+
+    throw StateError('No LLM client available');
   }
 
   /// Disposes all clients.

--- a/packages/core_ai/lib/src/runtime/local_inference_runtime_adapter.dart
+++ b/packages/core_ai/lib/src/runtime/local_inference_runtime_adapter.dart
@@ -1,0 +1,95 @@
+import 'package:meta/meta.dart';
+
+import '../llm/llm_client.dart';
+import '../models/offline_model_info.dart';
+
+enum LocalRuntimeKind { geminiNano, liteRtLm, gguf }
+
+enum RuntimeBackend { cpu, gpu, npu }
+
+@immutable
+class RuntimeCapabilities {
+  const RuntimeCapabilities({
+    required this.supportedBackends,
+    this.supportsStreaming = false,
+    this.supportsImages = false,
+    this.supportsAudio = false,
+    this.supportsToolCalling = false,
+    this.supportsSystemPrompt = true,
+    this.supportsSpeculativeDecoding = false,
+  });
+
+  final Set<RuntimeBackend> supportedBackends;
+  final bool supportsStreaming;
+  final bool supportsImages;
+  final bool supportsAudio;
+  final bool supportsToolCalling;
+  final bool supportsSystemPrompt;
+  final bool supportsSpeculativeDecoding;
+}
+
+@immutable
+class RuntimeGenerationRequest {
+  const RuntimeGenerationRequest({
+    required this.prompt,
+    this.systemPrompt,
+    this.requiresVision = false,
+    this.requiresAudio = false,
+    this.requiresToolCalling = false,
+    this.localOnly = false,
+  });
+
+  final String prompt;
+  final String? systemPrompt;
+  final bool requiresVision;
+  final bool requiresAudio;
+  final bool requiresToolCalling;
+  final bool localOnly;
+}
+
+abstract class LocalInferenceRuntimeAdapter implements LLMClient {
+  LocalRuntimeKind get runtimeKind;
+
+  Future<bool> supportsModel(OfflineModelInfo model);
+
+  RuntimeCapabilities capabilitiesForModel(OfflineModelInfo model);
+
+  Future<void> prepareModel({OfflineModelInfo? model});
+
+  Future<String?> generateText(
+    RuntimeGenerationRequest request, {
+    OfflineModelInfo? model,
+  });
+}
+
+class LocalInferenceRuntimeRegistry {
+  LocalInferenceRuntimeRegistry({
+    Iterable<LocalInferenceRuntimeAdapter>? adapters,
+  }) : _adapters = [...?adapters];
+
+  final List<LocalInferenceRuntimeAdapter> _adapters;
+
+  List<LocalInferenceRuntimeAdapter> get adapters =>
+      List.unmodifiable(_adapters);
+
+  void register(LocalInferenceRuntimeAdapter adapter) {
+    _adapters.removeWhere(
+      (existing) => existing.runtimeKind == adapter.runtimeKind,
+    );
+    _adapters.add(adapter);
+  }
+}
+
+extension LocalInferenceRuntimeRegistryAsync on LocalInferenceRuntimeRegistry {
+  Future<List<LocalInferenceRuntimeAdapter>> supportedAdaptersForModel(
+    OfflineModelInfo model,
+  ) async {
+    final supported = <LocalInferenceRuntimeAdapter>[];
+    for (final adapter in adapters) {
+      if (await adapter.supportsModel(model)) {
+        supported.add(adapter);
+      }
+    }
+    return supported;
+  }
+}

--- a/packages/core_ai/test/litert/litert_lm_runtime_adapter_test.dart
+++ b/packages/core_ai/test/litert/litert_lm_runtime_adapter_test.dart
@@ -1,0 +1,115 @@
+import 'package:core_ai/core_ai.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('LiteRtLmRuntimeAdapter', () {
+    late ActiveModelService activeModelService;
+
+    setUp(() {
+      ActiveModelService.resetInstance();
+      activeModelService = ActiveModelService.forTesting();
+    });
+
+    tearDown(() async {
+      await activeModelService.dispose();
+      ActiveModelService.resetInstance();
+    });
+
+    test('supports LiteRT model packages by extension and tag', () async {
+      final adapter = LiteRtLmRuntimeAdapter(
+        client: _FakeLiteRtLmClient(hasActiveModel: true),
+        activeModelService: activeModelService,
+      );
+
+      final supported = await adapter.supportsModel(
+        const OfflineModelInfo(
+          id: 'gemma-4-e2b-it-litertlm',
+          name: 'Gemma 4 E2B',
+          family: ModelFamily.gemma,
+          fileSizeBytes: 1024,
+          downloadUrl: 'https://example.com/gemma-4-e2b-it.litertlm',
+          provider: AIProvider.gemma,
+          tags: ['litert-lm'],
+        ),
+      );
+
+      expect(supported, isTrue);
+    });
+
+    test('surfaces unsupported tool-calling requests explicitly', () async {
+      final adapter = LiteRtLmRuntimeAdapter(
+        client: _FakeLiteRtLmClient(hasActiveModel: true),
+        activeModelService: activeModelService,
+      );
+
+      expect(
+        () => adapter.generateText(
+          const RuntimeGenerationRequest(
+            prompt: 'call a tool',
+            requiresToolCalling: true,
+          ),
+          model: const OfflineModelInfo(
+            id: 'gemma-basic',
+            name: 'Gemma Basic',
+            family: ModelFamily.gemma,
+            fileSizeBytes: 1024,
+            filePath: '/models/gemma-basic.litertlm',
+            provider: AIProvider.gemma,
+          ),
+        ),
+        throwsA(isA<UnsupportedError>()),
+      );
+    });
+
+    test('activates LiteRT as the current runtime after warmup', () async {
+      final adapter = LiteRtLmRuntimeAdapter(
+        client: _FakeLiteRtLmClient(hasActiveModel: true),
+        activeModelService: activeModelService,
+        runtimeConfig: const LiteRtLmConfig(modelPath: '/models/gemma.task'),
+      );
+
+      final warmed = await adapter.warmupInstalledModel();
+
+      expect(warmed, isTrue);
+      expect(
+        activeModelService.activeRuntime?.runtimeKind,
+        ActiveRuntimeKind.liteRtLm,
+      );
+      expect(activeModelService.activeRuntime?.runtimeId, 'litert-lm');
+    });
+  });
+}
+
+class _FakeLiteRtLmClient implements LiteRtLmClient {
+  _FakeLiteRtLmClient({required this.hasActiveModel});
+
+  bool hasActiveModel;
+
+  @override
+  Future<bool> activeModelExists({String? modelPath}) async => hasActiveModel;
+
+  @override
+  Future<String> generate({
+    required String prompt,
+    required LiteRtLmBackend backend,
+    required int maxTokens,
+    String? systemPrompt,
+  }) async => 'ok';
+
+  @override
+  Future<void> initialize({
+    String? huggingFaceToken,
+    String? modelPath,
+    LiteRtLmBackend? backend,
+    int? maxTokens,
+  }) async {}
+
+  @override
+  Future<void> installModel({
+    required String url,
+    required LiteRtLmModelKind modelKind,
+    String? huggingFaceToken,
+  }) async {
+    hasActiveModel = true;
+  }
+}

--- a/packages/core_ai/test/llm/active_model_service_test.dart
+++ b/packages/core_ai/test/llm/active_model_service_test.dart
@@ -145,6 +145,34 @@ void main() {
       service.updateMetrics(tokensPerSecond: 25.5);
       expect(service.activeModel, isNull);
     });
+
+    test('activateRuntime tracks non-GGUF runtimes and unloads them', () async {
+      final runtimeStates = <ActiveRuntimeInfo?>[];
+      final subscription = service.runtimeStateStream.listen(runtimeStates.add);
+      var deactivated = 0;
+
+      await service.activateRuntime(
+        runtimeKind: ActiveRuntimeKind.liteRtLm,
+        runtimeId: 'litert-lm',
+        modelId: 'gemma-4-e2b-it-litertlm',
+        modelPath: '/models/gemma-4-e2b-it.litertlm',
+        displayName: 'Gemma 4 E2B',
+        estimatedMemoryBytes: 1024,
+        onDeactivate: () async => deactivated++,
+      );
+
+      expect(service.hasActiveRuntime, isTrue);
+      expect(service.activeRuntime?.runtimeKind, ActiveRuntimeKind.liteRtLm);
+      expect(service.activeRuntime?.modelId, 'gemma-4-e2b-it-litertlm');
+
+      await service.unloadModel();
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+      await subscription.cancel();
+
+      expect(deactivated, 1);
+      expect(service.activeRuntime, isNull);
+      expect(runtimeStates.any((state) => state == null), isTrue);
+    });
   });
 
   group('ActiveModelInfo', () {

--- a/packages/core_ai/test/llm/llm_router_impl_litert_test.dart
+++ b/packages/core_ai/test/llm/llm_router_impl_litert_test.dart
@@ -1,0 +1,114 @@
+import 'package:core_ai/core_ai.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('LLMRouterImpl LiteRT routing', () {
+    late ActiveModelService activeModelService;
+
+    setUp(() {
+      ActiveModelService.resetInstance();
+      activeModelService = ActiveModelService.forTesting();
+    });
+
+    tearDown(() async {
+      await activeModelService.dispose();
+      ActiveModelService.resetInstance();
+    });
+
+    test('selects LiteRT adapter for compatible local packages', () async {
+      final adapter = LiteRtLmRuntimeAdapter(
+        client: _FakeLiteRtLmClient(hasActiveModel: true),
+        activeModelService: activeModelService,
+        runtimeConfig: const LiteRtLmConfig(
+          modelPath: '/models/gemma.litertlm',
+        ),
+      );
+      final router = LLMRouterImpl(
+        liteRtLmAdapter: adapter,
+        activeModelService: activeModelService,
+      );
+
+      final client = await router.routeForOfflineModel(
+        model: const OfflineModelInfo(
+          id: 'gemma-4-e2b-it-litertlm',
+          name: 'Gemma 4 E2B',
+          family: ModelFamily.gemma,
+          fileSizeBytes: 1024,
+          filePath: '/models/gemma-4-e2b-it.litertlm',
+          provider: AIProvider.gemma,
+          supportsVision: true,
+        ),
+        request: const RuntimeGenerationRequest(
+          prompt: 'Describe this receipt',
+          localOnly: true,
+        ),
+      );
+
+      expect(client, same(adapter));
+    });
+
+    test(
+      'fails explicitly when local-only LiteRT routing is unavailable',
+      () async {
+        final adapter = LiteRtLmRuntimeAdapter(
+          client: _FakeLiteRtLmClient(hasActiveModel: false),
+          activeModelService: activeModelService,
+        );
+        final router = LLMRouterImpl(
+          liteRtLmAdapter: adapter,
+          activeModelService: activeModelService,
+        );
+
+        expect(
+          () => router.routeForOfflineModel(
+            model: const OfflineModelInfo(
+              id: 'gemma-4-e2b-it-litertlm',
+              name: 'Gemma 4 E2B',
+              family: ModelFamily.gemma,
+              fileSizeBytes: 1024,
+              filePath: '/models/gemma-4-e2b-it.litertlm',
+              provider: AIProvider.gemma,
+            ),
+            request: const RuntimeGenerationRequest(
+              prompt: 'hello',
+              localOnly: true,
+            ),
+          ),
+          throwsA(isA<StateError>()),
+        );
+      },
+    );
+  });
+}
+
+class _FakeLiteRtLmClient implements LiteRtLmClient {
+  _FakeLiteRtLmClient({required this.hasActiveModel});
+
+  final bool hasActiveModel;
+
+  @override
+  Future<bool> activeModelExists({String? modelPath}) async => hasActiveModel;
+
+  @override
+  Future<String> generate({
+    required String prompt,
+    required LiteRtLmBackend backend,
+    required int maxTokens,
+    String? systemPrompt,
+  }) async => 'ok';
+
+  @override
+  Future<void> initialize({
+    String? huggingFaceToken,
+    String? modelPath,
+    LiteRtLmBackend? backend,
+    int? maxTokens,
+  }) async {}
+
+  @override
+  Future<void> installModel({
+    required String url,
+    required LiteRtLmModelKind modelKind,
+    String? huggingFaceToken,
+  }) async {}
+}


### PR DESCRIPTION
# Summary

This PR moves LiteRT-LM into `core_ai` as a reusable local runtime adapter and routes compatible offline packages through that contract.
Goal: close issue #388 by making LiteRT a framework-owned, swappable runtime instead of an app-only service.

Core outcome:

* added a generic local inference runtime adapter contract and LiteRT-LM implementation in `packages/core_ai`
* generalized active runtime tracking and offline routing so LiteRT packages can be selected explicitly
* reduced the app-side LiteRT service to a thin shim over the framework adapter

# Changes

### Code

* Added:
  * LiteRT runtime adapter and runtime registry contracts in `packages/core_ai`
  * focused LiteRT adapter and router tests
* Updated:
  * `ActiveModelService` to track non-GGUF runtimes
  * `LLMRouterImpl` to route compatible offline models through LiteRT
  * app `LiteRtLmService` to delegate to the framework adapter

### Logic

* LiteRT-compatible offline packages are now detectable by file extension or `litert-lm` tag and routable through a local runtime registry
* local-only offline routing now fails explicitly when no compatible runtime is available
* installed LiteRT models can be warmed up and marked as the active runtime through the shared lifecycle service

# API Changes

* No external API endpoint changes.

# Database Changes

* None.

# Observability / Logging

* No new persistent telemetry.

# Performance Impact

* No expected regression in cloud paths.
* Moves LiteRT warmup/routing responsibilities into framework code for reuse across product flows.

# Risks

* LiteRT routing currently recognizes compatible packages by file extension or `litert-lm` tag.
* Focused verification requires `--enable-experiment=dot-shorthands` with the current local Flutter toolchain.
* Rollback plan:
  * revert this PR to restore the previous app-owned LiteRT service implementation

# Testing

* Unit tests:
  * `flutter --no-version-check analyze --no-pub ...` in `packages/core_ai`
  * `flutter --no-version-check analyze --no-pub ...` in `app`
  * `flutter --no-version-check test --no-pub --enable-experiment=dot-shorthands test/litert/litert_lm_runtime_adapter_test.dart test/llm/active_model_service_test.dart test/llm/llm_router_impl_litert_test.dart`
  * `flutter --no-version-check test --no-pub --enable-experiment=dot-shorthands test/core/services/litert_lm_service_test.dart test/core/services/litert_lm_service_warmup_test.dart`

# Deployment Notes

* None.

# Related Commits

* `fix(core-ai): add LiteRT runtime adapter`

# Notes

* Fixes #388.
