### PR TITLE
fix(agent-chat): prefer downloaded LiteRT packages

### DIFF
--- a/app/lib/features/agent_chat/data/services/assistant_runtime_service.dart
+++ b/app/lib/features/agent_chat/data/services/assistant_runtime_service.dart
@@ -332,7 +332,13 @@ class AssistantRuntimeService {
 
       case litertGemmaAssistantModelId:
       default:
+        final downloadedPackage = await _resolveDownloadedLiteRtPackage(
+          candidate.id,
+          preferredPackage: candidate.package,
+        );
+        final package = downloadedPackage ?? candidate.package;
         final available =
+            downloadedPackage != null ||
             await (_isLiteRtAvailableOverride?.call() ??
                 _liteRtLm.isAvailable());
         if (!available) {
@@ -354,7 +360,6 @@ class AssistantRuntimeService {
           );
         }
 
-        final package = candidate.package;
         if (package != null) {
           final compatibility =
               await (_checkModelCompatibilityOverride?.call(package) ??
@@ -392,7 +397,10 @@ class AssistantRuntimeService {
         );
         final loadCancel = cancelled();
         if (loadCancel != null) return loadCancel;
-        final warmed = package != null
+        final warmed = downloadedPackage != null
+            ? await (_warmupLiteRtModelOverride?.call(downloadedPackage) ??
+                  _liteRtLm.warmupModel(downloadedPackage))
+            : package != null
             ? await (_warmupLiteRtModelOverride?.call(package) ??
                   _liteRtLm.warmupModel(package))
             : await (_warmupLiteRtInstalledModelOverride?.call() ??
@@ -466,6 +474,23 @@ class AssistantRuntimeService {
         );
 
       case litertGemmaAssistantModelId:
+        final package = await _resolveDownloadedLiteRtPackage(runtimeId);
+        if (package != null) {
+          return _nonEmptyOrUnavailable(
+            runtimeId,
+            await (_generateLiteRtModelTextOverride?.call(
+                  package,
+                  prompt,
+                  systemPrompt: systemPrompt,
+                ) ??
+                _liteRtLm.generateTextForModel(
+                  package,
+                  prompt,
+                  systemPrompt: systemPrompt,
+                )),
+            litertGemmaUnavailableMessage,
+          );
+        }
         return _nonEmptyOrUnavailable(
           runtimeId,
           await (_generateLiteRtTextOverride?.call(
@@ -624,5 +649,34 @@ class AssistantRuntimeService {
   ) async {
     final registry = ModelRegistry()..registerModel(package);
     return registry.checkCompatibility(package);
+  }
+
+  Future<OfflineModelInfo?> _resolveDownloadedLiteRtPackage(
+    String runtimeId, {
+    OfflineModelInfo? preferredPackage,
+  }) async {
+    if (runtimeId != litertGemmaAssistantModelId) {
+      return null;
+    }
+
+    final package =
+        preferredPackage ?? await _resolveOfflinePackageOrNull(runtimeId);
+    if (package == null || !package.isDownloaded) {
+      return null;
+    }
+    return package;
+  }
+
+  Future<OfflineModelInfo?> _resolveOfflinePackageOrNull(
+    String runtimeId,
+  ) async {
+    try {
+      final library =
+          await (_loadAssistantModelLibraryOverride?.call() ??
+              AssistantModelLibraryState.load(task: AssistantTask.chat));
+      return library.candidateById(runtimeId)?.package;
+    } catch (_) {
+      return null;
+    }
   }
 }

--- a/app/lib/features/agent_chat/presentation/screens/model_library_screen.dart
+++ b/app/lib/features/agent_chat/presentation/screens/model_library_screen.dart
@@ -159,6 +159,8 @@ class AssistantModelLibraryState {
     final cloudAvailable = geminiApiService.isAvailable;
     final defaultPackages = await _defaultPackages(liteRtService);
     final balancedPackage = defaultPackages[AssistantTask.reasoning];
+    final hasDownloadedBalancedPackage = balancedPackage?.isDownloaded ?? false;
+    final liteRtReady = liteRtAvailable || hasDownloadedBalancedPackage;
 
     final platformLabel = kIsWeb
         ? 'Web'
@@ -214,13 +216,13 @@ class AssistantModelLibraryState {
         tags: const ['Local', 'Downloadable', 'Gemma'],
         privacyLabel: 'Prompt stays on device',
         sizeLabel: balancedPackage?.fileSizeDisplay ?? '2 GB to 4 GB typical',
-        available: liteRtAvailable,
-        actionLabel: liteRtAvailable ? 'Start' : 'Download package',
-        unavailableReason: liteRtAvailable
+        available: liteRtReady,
+        actionLabel: liteRtReady ? 'Start' : 'Download package',
+        unavailableReason: liteRtReady
             ? null
             : 'Set LITERT_LM_MODEL_PATH or LITERT_LM_MODEL_URL, or install a compatible local model.',
         local: true,
-        opensModelManager: !liteRtAvailable,
+        opensModelManager: !liteRtReady,
         package: balancedPackage,
       ),
     );
@@ -591,9 +593,10 @@ class _ModelLibraryContent extends ConsumerWidget {
     AssistantProjectTemplate template,
   ) async {
     final candidate = state.recommendedFor(template.task);
+    final hasDownloadedPackage = candidate.package?.isDownloaded ?? false;
     ref.read(selectedAssistantTaskProvider.notifier).state = template.task;
 
-    if (candidate.opensModelManager) {
+    if (candidate.opensModelManager && !hasDownloadedPackage) {
       final confirmed = await _confirmPackageSetup(
         context,
         template: template,
@@ -605,7 +608,7 @@ class _ModelLibraryContent extends ConsumerWidget {
       }
       return;
     }
-    if (!candidate.available) {
+    if (!candidate.available && !hasDownloadedPackage) {
       await _showUnavailablePackage(
         context,
         template: template,

--- a/app/test/features/agent_chat/data/services/assistant_runtime_service_test.dart
+++ b/app/test/features/agent_chat/data/services/assistant_runtime_service_test.dart
@@ -5,6 +5,8 @@ import 'package:core_ai/core_ai.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
   group('AssistantRuntimeService', () {
     test(
       'reports Gemini Nano unavailable instead of using canned fallback',
@@ -46,6 +48,73 @@ void main() {
 
       expect(text, 'skill planner :: pick a tool');
     });
+
+    test(
+      'routes generic LiteRT runtime through a downloaded package when available',
+      () async {
+        final package = OfflineModelInfo(
+          id: 'gemma-4-e2b-it-litertlm',
+          name: 'Gemma 4 E2B',
+          family: ModelFamily.gemma,
+          fileSizeBytes: 2 * 1024 * 1024 * 1024,
+          filePath: '/models/gemma-4-e2b-it-litertlm.task',
+          backendPreference: ModelBackendPreference.gpu,
+          provider: AIProvider.gemma,
+          capabilities: const [ModelCapability.chat, ModelCapability.reasoning],
+        );
+        final service = AssistantRuntimeService(
+          generateLiteRtText: (_, {systemPrompt}) async =>
+              'generic ${systemPrompt ?? ''}'.trim(),
+          generateLiteRtModelText: (model, prompt, {systemPrompt}) async {
+            return '${model.id} :: ${systemPrompt ?? 'no-system'} :: $prompt';
+          },
+          loadAssistantModelLibrary: () async => AssistantModelLibraryState(
+            task: AssistantTask.chat,
+            deviceLabel: 'Pixel 9',
+            platformLabel: 'ANDROID',
+            candidates: [
+              AssistantModelCandidate(
+                id: litertGemmaAssistantModelId,
+                name: 'Gemma mobile package',
+                runtime: 'LiteRT-LM local model',
+                description: 'Local package',
+                bestFor: const [AssistantTask.chat, AssistantTask.reasoning],
+                tags: const ['Local'],
+                privacyLabel: 'Prompt stays on device',
+                sizeLabel: package.fileSizeDisplay,
+                available: true,
+                actionLabel: 'Start',
+                local: true,
+                package: package,
+              ),
+            ],
+            recommended: AssistantModelCandidate(
+              id: litertGemmaAssistantModelId,
+              name: 'Gemma mobile package',
+              runtime: 'LiteRT-LM local model',
+              description: 'Local package',
+              bestFor: const [AssistantTask.chat, AssistantTask.reasoning],
+              tags: const ['Local'],
+              privacyLabel: 'Prompt stays on device',
+              sizeLabel: package.fileSizeDisplay,
+              available: true,
+              actionLabel: 'Start',
+              local: true,
+              package: package,
+            ),
+            defaultPackages: {AssistantTask.chat: package},
+          ),
+        );
+
+        final text = await service.generateText(
+          selectedModelId: litertGemmaAssistantModelId,
+          systemPrompt: 'planner',
+          prompt: 'pick a tool',
+        );
+
+        expect(text, 'gemma-4-e2b-it-litertlm :: planner :: pick a tool');
+      },
+    );
 
     test('reports Gemini Cloud configuration errors explicitly', () async {
       final service = AssistantRuntimeService(
@@ -175,5 +244,60 @@ void main() {
         'This local package exceeds the current device budget.',
       );
     });
+
+    test(
+      'prepares generic LiteRT runtime from a downloaded package when default runtime is unavailable',
+      () async {
+        final package = OfflineModelInfo(
+          id: 'gemma-4-e2b-it-litertlm',
+          name: 'Gemma 4 E2B',
+          family: ModelFamily.gemma,
+          fileSizeBytes: 2 * 1024 * 1024 * 1024,
+          filePath: '/models/gemma-4-e2b-it-litertlm.task',
+          backendPreference: ModelBackendPreference.gpu,
+          provider: AIProvider.gemma,
+          capabilities: const [ModelCapability.chat, ModelCapability.reasoning],
+        );
+        var warmedPackageId = '';
+        var warmedInstalled = false;
+        final service = AssistantRuntimeService(
+          isLiteRtAvailable: () async => false,
+          warmupLiteRtInstalledModel: () async {
+            warmedInstalled = true;
+            return true;
+          },
+          warmupLiteRtModel: (model) async {
+            warmedPackageId = model.id;
+            return true;
+          },
+          loadDeviceInfo: () async => {
+            'manufacturer': 'Google',
+            'model': 'Pixel 9',
+            'platform': 'android',
+          },
+        );
+
+        final result = await service.prepareRuntime(
+          candidate: AssistantModelCandidate(
+            id: litertGemmaAssistantModelId,
+            name: 'Gemma mobile package',
+            runtime: 'LiteRT-LM local model',
+            description: 'Local package',
+            bestFor: const [AssistantTask.chat, AssistantTask.reasoning],
+            tags: const ['Local'],
+            privacyLabel: 'Prompt stays on device',
+            sizeLabel: package.fileSizeDisplay,
+            available: true,
+            actionLabel: 'Start',
+            local: true,
+            package: package,
+          ),
+        );
+
+        expect(result.status, AssistantRuntimePreparationStatus.ready);
+        expect(warmedPackageId, 'gemma-4-e2b-it-litertlm');
+        expect(warmedInstalled, isFalse);
+      },
+    );
   });
 }


### PR DESCRIPTION
# Summary

This PR fixes the local chat/project startup path when a compatible LiteRT package has already been downloaded from Model Manager.
Goal: make the generic `litert-gemma-mobile` runtime resolve to an installed package instead of getting stuck on the default runtime check.

Core outcome:

* generic LiteRT startup now treats a downloaded recommended package as ready
* generic LiteRT generation routes through the downloaded package-specific path
* added deterministic runtime tests for the downloaded-package path

# Changes

### Code

* Added:
  * helper logic in `AssistantRuntimeService` to resolve a downloaded LiteRT package for the generic runtime
* Updated:
  * `app/lib/features/agent_chat/data/services/assistant_runtime_service.dart` to prefer downloaded packages during prepare and text generation
  * `app/lib/features/agent_chat/presentation/screens/model_library_screen.dart` so the generic LiteRT project card starts when its recommended package is already downloaded
  * `app/test/features/agent_chat/data/services/assistant_runtime_service_test.dart` with coverage for the downloaded-package flow

### Logic

* `prepareRuntime()` no longer reports the generic LiteRT runtime unavailable when the recommended package is already downloaded
* `generateText()` for `litert-gemma-mobile` now uses the resolved downloaded package when present
* preserves the existing fallback to the installed/default LiteRT runtime when no downloaded package exists

# API Changes (if any)

* None

# Database Changes (if any)

* None

# Observability / Logging

* None

# Performance Impact

* Latency: first-launch local runtime avoids a failed generic runtime path when a package is already present
* Throughput: none
* Memory/CPU: none beyond the existing model warmup path

# Risks

* generic LiteRT resolution currently uses the recommended downloaded package from the assistant model library
* fallback behavior still depends on the existing default LiteRT runtime availability path
* Rollback plan:
  * revert this PR

# Testing

* Unit tests:
  * `flutter test test/features/agent_chat/data/services/assistant_runtime_service_test.dart`
* Integration tests:
  * none
* Manual testing:
  * not run

# Deployment Notes

* Config changes:
  * none
* Order of deployment:
  * normal merge

# Related Commits

* `fix(agent-chat): prefer downloaded LiteRT packages`

# Notes

* Closes #461
