### PR TITLE
feat(media-hub): add unified discovery content models

### DIFF
--- a/app/lib/features/media_hub/application/providers/discovery_provider.dart
+++ b/app/lib/features/media_hub/application/providers/discovery_provider.dart
@@ -1,0 +1,25 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../iptv/application/providers/iptv_providers.dart';
+import '../../../music/application/providers/music_tracks_provider.dart';
+import '../../domain/models/media_mode.dart';
+import '../../domain/models/unified_media_content.dart';
+
+final mediaHubDiscoveryProvider =
+    Provider.family<AsyncValue<List<UnifiedMediaContent>>, MediaMode>((
+      ref,
+      mode,
+    ) {
+      switch (mode) {
+        case MediaMode.music:
+          final tracks = ref.watch(musicTracksProvider);
+          return tracks.whenData(
+            (items) => items.map(UnifiedMediaContent.fromTrack).toList(),
+          );
+        case MediaMode.tv:
+          final channels = ref.watch(iptvChannelsProvider);
+          return channels.whenData(
+            (items) => items.map(UnifiedMediaContent.fromChannel).toList(),
+          );
+      }
+    });

--- a/app/lib/features/media_hub/domain/models/media_category.dart
+++ b/app/lib/features/media_hub/domain/models/media_category.dart
@@ -1,0 +1,56 @@
+import '../../../iptv/domain/models/iptv_channel.dart';
+
+enum MediaCategory {
+  all,
+  music,
+  news,
+  entertainment,
+  sports,
+  movies,
+  kids,
+  documentary,
+  regional,
+  international,
+  lifestyle,
+  devotional,
+  business,
+  general,
+}
+
+extension MediaCategoryX on MediaCategory {
+  String get label => switch (this) {
+    MediaCategory.all => 'All',
+    MediaCategory.music => 'Music',
+    MediaCategory.news => 'News',
+    MediaCategory.entertainment => 'Entertainment',
+    MediaCategory.sports => 'Sports',
+    MediaCategory.movies => 'Movies',
+    MediaCategory.kids => 'Kids',
+    MediaCategory.documentary => 'Documentary',
+    MediaCategory.regional => 'Regional',
+    MediaCategory.international => 'International',
+    MediaCategory.lifestyle => 'Lifestyle',
+    MediaCategory.devotional => 'Devotional',
+    MediaCategory.business => 'Business',
+    MediaCategory.general => 'General',
+  };
+
+  static MediaCategory fromChannelCategory(ChannelCategory category) {
+    return switch (category) {
+      ChannelCategory.all => MediaCategory.all,
+      ChannelCategory.news => MediaCategory.news,
+      ChannelCategory.entertainment => MediaCategory.entertainment,
+      ChannelCategory.sports => MediaCategory.sports,
+      ChannelCategory.music => MediaCategory.music,
+      ChannelCategory.movies => MediaCategory.movies,
+      ChannelCategory.kids => MediaCategory.kids,
+      ChannelCategory.documentary => MediaCategory.documentary,
+      ChannelCategory.regional => MediaCategory.regional,
+      ChannelCategory.international => MediaCategory.international,
+      ChannelCategory.lifestyle => MediaCategory.lifestyle,
+      ChannelCategory.devotional => MediaCategory.devotional,
+      ChannelCategory.business => MediaCategory.business,
+      ChannelCategory.general => MediaCategory.general,
+    };
+  }
+}

--- a/app/lib/features/media_hub/domain/models/media_mode.dart
+++ b/app/lib/features/media_hub/domain/models/media_mode.dart
@@ -1,0 +1,19 @@
+import 'package:equatable/equatable.dart';
+
+enum MediaMode { music, tv }
+
+extension MediaModeX on MediaMode {
+  String get label => switch (this) {
+    MediaMode.music => 'Music',
+    MediaMode.tv => 'TV',
+  };
+}
+
+class MediaModeSelection extends Equatable {
+  const MediaModeSelection(this.mode);
+
+  final MediaMode mode;
+
+  @override
+  List<Object?> get props => [mode];
+}

--- a/app/lib/features/media_hub/domain/models/unified_media_content.dart
+++ b/app/lib/features/media_hub/domain/models/unified_media_content.dart
@@ -1,0 +1,98 @@
+import 'package:equatable/equatable.dart';
+
+import '../../../iptv/domain/models/iptv_channel.dart';
+import '../../../music/domain/services/music_service.dart';
+import 'media_category.dart';
+import 'media_mode.dart';
+
+class UnifiedMediaContent extends Equatable {
+  const UnifiedMediaContent({
+    required this.id,
+    required this.mode,
+    required this.category,
+    required this.title,
+    required this.subtitle,
+    required this.imageUrl,
+    required this.streamUrl,
+    this.duration = Duration.zero,
+    this.lastPosition = Duration.zero,
+    this.isLive = false,
+    this.viewerCount,
+    this.tags = const [],
+  });
+
+  factory UnifiedMediaContent.fromTrack(
+    MusicTrack track, {
+    Duration lastPosition = Duration.zero,
+    List<String> tags = const [],
+  }) {
+    return UnifiedMediaContent(
+      id: track.id,
+      mode: MediaMode.music,
+      category: MediaCategory.music,
+      title: track.title,
+      subtitle: track.artist,
+      imageUrl: track.albumArt,
+      streamUrl: track.streamUrl,
+      duration: track.duration,
+      lastPosition: lastPosition,
+      tags: tags,
+    );
+  }
+
+  factory UnifiedMediaContent.fromChannel(
+    IPTVChannel channel, {
+    Duration lastPosition = Duration.zero,
+    int? viewerCount,
+    List<String> tags = const [],
+  }) {
+    return UnifiedMediaContent(
+      id: channel.id,
+      mode: MediaMode.tv,
+      category: MediaCategoryX.fromChannelCategory(channel.category),
+      title: channel.name,
+      subtitle: channel.group,
+      imageUrl: channel.logoUrl,
+      streamUrl: channel.streamUrl,
+      lastPosition: lastPosition,
+      isLive: !channel.isAudioOnly,
+      viewerCount: viewerCount,
+      tags: tags.isEmpty ? channel.languages : tags,
+    );
+  }
+
+  final String id;
+  final MediaMode mode;
+  final MediaCategory category;
+  final String title;
+  final String subtitle;
+  final String? imageUrl;
+  final String? streamUrl;
+  final Duration duration;
+  final Duration lastPosition;
+  final bool isLive;
+  final int? viewerCount;
+  final List<String> tags;
+
+  bool get canResume =>
+      !isLive &&
+      lastPosition > Duration.zero &&
+      duration > Duration.zero &&
+      lastPosition < duration;
+
+  @override
+  List<Object?> get props => [
+    id,
+    mode,
+    category,
+    title,
+    subtitle,
+    imageUrl,
+    streamUrl,
+    duration,
+    lastPosition,
+    isLive,
+    viewerCount,
+    tags,
+  ];
+}

--- a/app/test/features/media_hub/application/providers/discovery_provider_test.dart
+++ b/app/test/features/media_hub/application/providers/discovery_provider_test.dart
@@ -1,0 +1,58 @@
+import 'package:airo_app/features/iptv/application/providers/iptv_providers.dart';
+import 'package:airo_app/features/iptv/domain/models/iptv_channel.dart';
+import 'package:airo_app/features/media_hub/application/providers/discovery_provider.dart';
+import 'package:airo_app/features/media_hub/domain/models/media_mode.dart';
+import 'package:airo_app/features/music/application/providers/music_tracks_provider.dart';
+import 'package:airo_app/features/music/domain/services/music_service.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('maps music tracks into unified discovery content', () async {
+    const tracks = [
+      MusicTrack(
+        id: 'track-1',
+        title: 'Track',
+        artist: 'Artist',
+        duration: Duration(minutes: 3),
+        streamUrl: 'https://example.com/audio.mp3',
+      ),
+    ];
+    final container = ProviderContainer(
+      overrides: [musicTracksProvider.overrideWith((ref) async => tracks)],
+    );
+    addTearDown(container.dispose);
+
+    await container.read(musicTracksProvider.future);
+    final data =
+        container.read(mediaHubDiscoveryProvider(MediaMode.music)).value ?? [];
+
+    expect(data, hasLength(1));
+    expect(data.first.mode, MediaMode.music);
+    expect(data.first.title, 'Track');
+  });
+
+  test('maps tv channels into unified discovery content', () async {
+    const channels = [
+      IPTVChannel(
+        id: 'tv-1',
+        name: 'Airo TV',
+        streamUrl: 'https://example.com/live.m3u8',
+        group: 'General',
+        category: ChannelCategory.general,
+      ),
+    ];
+    final container = ProviderContainer(
+      overrides: [iptvChannelsProvider.overrideWith((ref) async => channels)],
+    );
+    addTearDown(container.dispose);
+
+    await container.read(iptvChannelsProvider.future);
+    final data =
+        container.read(mediaHubDiscoveryProvider(MediaMode.tv)).value ?? [];
+
+    expect(data, hasLength(1));
+    expect(data.first.mode, MediaMode.tv);
+    expect(data.first.title, 'Airo TV');
+  });
+}

--- a/app/test/features/media_hub/domain/models/media_category_test.dart
+++ b/app/test/features/media_hub/domain/models/media_category_test.dart
@@ -1,0 +1,28 @@
+import 'package:airo_app/features/iptv/domain/models/iptv_channel.dart';
+import 'package:airo_app/features/media_hub/domain/models/media_category.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('MediaCategory', () {
+    test('maps IPTV categories into shared media categories', () {
+      expect(
+        MediaCategoryX.fromChannelCategory(ChannelCategory.news),
+        MediaCategory.news,
+      );
+      expect(
+        MediaCategoryX.fromChannelCategory(ChannelCategory.movies),
+        MediaCategory.movies,
+      );
+      expect(
+        MediaCategoryX.fromChannelCategory(ChannelCategory.business),
+        MediaCategory.business,
+      );
+    });
+
+    test('exposes user-facing labels', () {
+      expect(MediaCategory.music.label, 'Music');
+      expect(MediaCategory.documentary.label, 'Documentary');
+      expect(MediaCategory.international.label, 'International');
+    });
+  });
+}

--- a/app/test/features/media_hub/domain/models/unified_media_content_test.dart
+++ b/app/test/features/media_hub/domain/models/unified_media_content_test.dart
@@ -1,0 +1,88 @@
+import 'package:airo_app/features/iptv/domain/models/iptv_channel.dart';
+import 'package:airo_app/features/media_hub/domain/models/media_category.dart';
+import 'package:airo_app/features/media_hub/domain/models/media_mode.dart';
+import 'package:airo_app/features/media_hub/domain/models/unified_media_content.dart';
+import 'package:airo_app/features/music/domain/services/music_service.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('UnifiedMediaContent', () {
+    test('creates music content from a track with resume support', () {
+      const track = MusicTrack(
+        id: 'track-1',
+        title: 'Blinding Lights',
+        artist: 'The Weeknd',
+        albumArt: 'https://example.com/art.jpg',
+        duration: Duration(minutes: 3, seconds: 20),
+        streamUrl: 'https://example.com/audio.mp3',
+      );
+
+      final content = UnifiedMediaContent.fromTrack(
+        track,
+        lastPosition: const Duration(minutes: 1),
+        tags: const ['pop'],
+      );
+
+      expect(content.mode, MediaMode.music);
+      expect(content.category, MediaCategory.music);
+      expect(content.title, 'Blinding Lights');
+      expect(content.subtitle, 'The Weeknd');
+      expect(content.imageUrl, 'https://example.com/art.jpg');
+      expect(content.streamUrl, 'https://example.com/audio.mp3');
+      expect(content.canResume, isTrue);
+      expect(content.tags, ['pop']);
+    });
+
+    test('creates tv content from a channel without resume support', () {
+      const channel = IPTVChannel(
+        id: 'tv-1',
+        name: 'Airo Sports',
+        streamUrl: 'https://example.com/live.m3u8',
+        logoUrl: 'https://example.com/logo.png',
+        group: 'Live Sports',
+        category: ChannelCategory.sports,
+        languages: ['en', 'hi'],
+      );
+
+      final content = UnifiedMediaContent.fromChannel(
+        channel,
+        lastPosition: const Duration(minutes: 10),
+        viewerCount: 4200,
+      );
+
+      expect(content.mode, MediaMode.tv);
+      expect(content.category, MediaCategory.sports);
+      expect(content.title, 'Airo Sports');
+      expect(content.subtitle, 'Live Sports');
+      expect(content.imageUrl, 'https://example.com/logo.png');
+      expect(content.canResume, isFalse);
+      expect(content.isLive, isTrue);
+      expect(content.viewerCount, 4200);
+      expect(content.tags, ['en', 'hi']);
+    });
+
+    test('supports equatable comparisons', () {
+      const first = UnifiedMediaContent(
+        id: 'same',
+        mode: MediaMode.music,
+        category: MediaCategory.music,
+        title: 'Track',
+        subtitle: 'Artist',
+        imageUrl: null,
+        streamUrl: 'https://example.com/audio.mp3',
+      );
+      const second = UnifiedMediaContent(
+        id: 'same',
+        mode: MediaMode.music,
+        category: MediaCategory.music,
+        title: 'Track',
+        subtitle: 'Artist',
+        imageUrl: null,
+        streamUrl: 'https://example.com/audio.mp3',
+      );
+
+      expect(first, second);
+      expect(first.props, second.props);
+    });
+  });
+}


### PR DESCRIPTION
# Summary

This PR implements the missing Media Hub foundation for a unified content model across Music and TV.
Goal: add the shared model/enums promised by #428 and verify them with deterministic tests plus a narrow discovery-provider adapter.

Core outcome:

* adds `UnifiedMediaContent`, `MediaMode`, and `MediaCategory`
* maps existing Music and IPTV content into one shared discovery shape
* adds unit/provider tests for the factories, category mapping, resume semantics, and provider integration

# Changes

### Code

* Added:
  * `app/lib/features/media_hub/domain/models/unified_media_content.dart`
  * `app/lib/features/media_hub/domain/models/media_mode.dart`
  * `app/lib/features/media_hub/domain/models/media_category.dart`
  * `app/lib/features/media_hub/application/providers/discovery_provider.dart`
* Added tests:
  * `app/test/features/media_hub/domain/models/unified_media_content_test.dart`
  * `app/test/features/media_hub/domain/models/media_category_test.dart`
  * `app/test/features/media_hub/application/providers/discovery_provider_test.dart`

### Logic

* `UnifiedMediaContent.fromTrack()` adapts `MusicTrack` into the shared model
* `UnifiedMediaContent.fromChannel()` adapts `IPTVChannel` into the shared model
* resume support is encoded through `lastPosition` and `canResume`
* `mediaHubDiscoveryProvider` bridges the existing music and IPTV providers into unified discovery content

# API Changes (if any)

* None

# Database Changes (if any)

* None

# Observability / Logging

* None

# Performance Impact

* Latency: negligible provider mapping work only
* Throughput: none
* Memory/CPU: negligible

# Risks

* discovery integration is intentionally narrow and does not implement the later pagination/personalization roadmap work
* Rollback plan:
  * revert this PR

# Testing

* Unit tests:
  * `flutter test test/features/media_hub`
* Integration tests:
  * provider-level adapter coverage in `discovery_provider_test.dart`
* Manual testing:
  * not run

# Deployment Notes

* Config changes:
  * none
* Order of deployment:
  * normal merge

# Related Commits

* `feat(media-hub): add unified discovery content models`

# Notes

* Closes #428
