### PR TITLE
feat(media-hub): add discovery state management

### DIFF
--- a/app/lib/features/media_hub/application/providers/discovery_provider.dart
+++ b/app/lib/features/media_hub/application/providers/discovery_provider.dart
@@ -1,25 +1,148 @@
+import 'dart:async';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../iptv/application/providers/iptv_providers.dart';
 import '../../../music/application/providers/music_tracks_provider.dart';
+import '../../domain/models/discovery_state.dart';
+import '../../domain/models/media_category.dart';
 import '../../domain/models/media_mode.dart';
 import '../../domain/models/unified_media_content.dart';
 
-final mediaHubDiscoveryProvider =
-    Provider.family<AsyncValue<List<UnifiedMediaContent>>, MediaMode>((
+final mediaHubDiscoveryPageSizeProvider = Provider<int>((ref) => 12);
+
+final mediaHubDiscoverySourceProvider =
+    FutureProvider.family<List<UnifiedMediaContent>, MediaMode>((
       ref,
       mode,
-    ) {
+    ) async {
       switch (mode) {
         case MediaMode.music:
-          final tracks = ref.watch(musicTracksProvider);
-          return tracks.whenData(
-            (items) => items.map(UnifiedMediaContent.fromTrack).toList(),
-          );
+          final tracks = await ref.watch(musicTracksProvider.future);
+          return tracks.map(UnifiedMediaContent.fromTrack).toList();
         case MediaMode.tv:
-          final channels = ref.watch(iptvChannelsProvider);
-          return channels.whenData(
-            (items) => items.map(UnifiedMediaContent.fromChannel).toList(),
-          );
+          final channels = await ref.watch(iptvChannelsProvider.future);
+          return channels.map(UnifiedMediaContent.fromChannel).toList();
       }
     });
+
+final mediaHubDiscoveryProvider =
+    AsyncNotifierProvider.family<DiscoveryNotifier, DiscoveryState, MediaMode>(
+      DiscoveryNotifier.new,
+    );
+
+class DiscoveryNotifier extends FamilyAsyncNotifier<DiscoveryState, MediaMode> {
+  late MediaMode _mode;
+
+  @override
+  FutureOr<DiscoveryState> build(MediaMode arg) async {
+    _mode = arg;
+    final items = await ref.watch(mediaHubDiscoverySourceProvider(arg).future);
+    final pageSize = ref.watch(mediaHubDiscoveryPageSizeProvider);
+    return DiscoveryState.initial(mode: arg, items: items, pageSize: pageSize);
+  }
+
+  void setSearchQuery(String query) {
+    final current = state.valueOrNull;
+    if (current == null) return;
+    state = AsyncData(
+      _rebuild(current, searchQuery: query.trim(), currentPage: 1),
+    );
+  }
+
+  void setCategory(MediaCategory category) {
+    final current = state.valueOrNull;
+    if (current == null) return;
+    state = AsyncData(
+      _rebuild(current, selectedCategory: category, currentPage: 1),
+    );
+  }
+
+  void loadNextPage() {
+    final current = state.valueOrNull;
+    if (current == null || !current.hasMore) return;
+    state = AsyncData(_rebuild(current, currentPage: current.currentPage + 1));
+  }
+
+  Future<void> refresh() async {
+    final previous = state.valueOrNull;
+    state = const AsyncLoading();
+    final items = await ref.refresh(
+      mediaHubDiscoverySourceProvider(_mode).future,
+    );
+    final pageSize = ref.read(mediaHubDiscoveryPageSizeProvider);
+    final base = DiscoveryState.initial(
+      mode: _mode,
+      items: items,
+      pageSize: pageSize,
+    );
+    state = AsyncData(
+      previous == null
+          ? base
+          : _rebuild(
+              base,
+              searchQuery: previous.searchQuery,
+              selectedCategory: previous.selectedCategory,
+              currentPage: previous.currentPage == 0 ? 1 : previous.currentPage,
+            ),
+    );
+  }
+
+  DiscoveryState _rebuild(
+    DiscoveryState current, {
+    List<UnifiedMediaContent>? items,
+    String? searchQuery,
+    MediaCategory? selectedCategory,
+    int? currentPage,
+  }) {
+    final nextItems = List<UnifiedMediaContent>.unmodifiable(
+      items ?? current.items,
+    );
+    final nextQuery = searchQuery ?? current.searchQuery;
+    final nextCategory = selectedCategory ?? current.selectedCategory;
+    final filtered = nextItems
+        .where((item) {
+          final matchesCategory =
+              nextCategory == MediaCategory.all ||
+              item.category == nextCategory;
+          if (!matchesCategory) {
+            return false;
+          }
+          if (nextQuery.isEmpty) {
+            return true;
+          }
+          final normalizedQuery = nextQuery.toLowerCase();
+          return item.title.toLowerCase().contains(normalizedQuery) ||
+              item.subtitle.toLowerCase().contains(normalizedQuery) ||
+              item.tags.any(
+                (tag) => tag.toLowerCase().contains(normalizedQuery),
+              );
+        })
+        .toList(growable: false);
+
+    final requestedPage = currentPage ?? current.currentPage;
+    final effectivePage = filtered.isEmpty
+        ? 0
+        : requestedPage.clamp(1, _maxPage(filtered.length, current.pageSize));
+    final visibleCount = effectivePage == 0
+        ? 0
+        : (effectivePage * current.pageSize).clamp(0, filtered.length);
+    final visibleItems = List<UnifiedMediaContent>.unmodifiable(
+      filtered.take(visibleCount),
+    );
+
+    return current.copyWith(
+      items: nextItems,
+      visibleItems: visibleItems,
+      searchQuery: nextQuery,
+      selectedCategory: nextCategory,
+      currentPage: effectivePage,
+      filteredCount: filtered.length,
+      hasMore: visibleCount < filtered.length,
+    );
+  }
+
+  int _maxPage(int totalItems, int pageSize) {
+    return ((totalItems + pageSize - 1) / pageSize).floor();
+  }
+}

--- a/app/lib/features/media_hub/domain/models/discovery_state.dart
+++ b/app/lib/features/media_hub/domain/models/discovery_state.dart
@@ -1,0 +1,84 @@
+import 'package:equatable/equatable.dart';
+
+import 'media_category.dart';
+import 'media_mode.dart';
+import 'unified_media_content.dart';
+
+class DiscoveryState extends Equatable {
+  const DiscoveryState({
+    required this.mode,
+    required this.items,
+    required this.visibleItems,
+    required this.searchQuery,
+    required this.selectedCategory,
+    required this.currentPage,
+    required this.pageSize,
+    required this.filteredCount,
+    required this.hasMore,
+  });
+
+  factory DiscoveryState.initial({
+    required MediaMode mode,
+    required List<UnifiedMediaContent> items,
+    int pageSize = 12,
+  }) {
+    return DiscoveryState(
+      mode: mode,
+      items: List.unmodifiable(items),
+      visibleItems: List.unmodifiable(items.take(pageSize)),
+      searchQuery: '',
+      selectedCategory: MediaCategory.all,
+      currentPage: items.isEmpty ? 0 : 1,
+      pageSize: pageSize,
+      filteredCount: items.length,
+      hasMore: items.length > pageSize,
+    );
+  }
+
+  final MediaMode mode;
+  final List<UnifiedMediaContent> items;
+  final List<UnifiedMediaContent> visibleItems;
+  final String searchQuery;
+  final MediaCategory selectedCategory;
+  final int currentPage;
+  final int pageSize;
+  final int filteredCount;
+  final bool hasMore;
+
+  DiscoveryState copyWith({
+    MediaMode? mode,
+    List<UnifiedMediaContent>? items,
+    List<UnifiedMediaContent>? visibleItems,
+    String? searchQuery,
+    MediaCategory? selectedCategory,
+    int? currentPage,
+    int? pageSize,
+    int? filteredCount,
+    bool? hasMore,
+  }) {
+    return DiscoveryState(
+      mode: mode ?? this.mode,
+      items: items ?? this.items,
+      visibleItems: visibleItems ?? this.visibleItems,
+      searchQuery: searchQuery ?? this.searchQuery,
+      selectedCategory: selectedCategory ?? this.selectedCategory,
+      currentPage: currentPage ?? this.currentPage,
+      pageSize: pageSize ?? this.pageSize,
+      filteredCount: filteredCount ?? this.filteredCount,
+      hasMore: hasMore ?? this.hasMore,
+    );
+  }
+
+  @override
+  List<Object?> get props => [
+    mode,
+    items,
+    visibleItems,
+    searchQuery,
+    selectedCategory,
+    currentPage,
+    pageSize,
+    filteredCount,
+    hasMore,
+  ];
+}

--- a/app/test/features/media_hub/application/providers/discovery_provider_test.dart
+++ b/app/test/features/media_hub/application/providers/discovery_provider_test.dart
@@ -1,6 +1,7 @@
 import 'package:airo_app/features/iptv/application/providers/iptv_providers.dart';
 import 'package:airo_app/features/iptv/domain/models/iptv_channel.dart';
 import 'package:airo_app/features/media_hub/application/providers/discovery_provider.dart';
+import 'package:airo_app/features/media_hub/domain/models/media_category.dart';
 import 'package:airo_app/features/media_hub/domain/models/media_mode.dart';
 import 'package:airo_app/features/music/application/providers/music_tracks_provider.dart';
 import 'package:airo_app/features/music/domain/services/music_service.dart';
@@ -19,17 +20,21 @@ void main() {
       ),
     ];
     final container = ProviderContainer(
-      overrides: [musicTracksProvider.overrideWith((ref) async => tracks)],
+      overrides: [
+        musicTracksProvider.overrideWith((ref) async => tracks),
+        mediaHubDiscoveryPageSizeProvider.overrideWith((ref) => 1),
+      ],
     );
     addTearDown(container.dispose);
 
-    await container.read(musicTracksProvider.future);
-    final data =
-        container.read(mediaHubDiscoveryProvider(MediaMode.music)).value ?? [];
+    final data = await container.read(
+      mediaHubDiscoveryProvider(MediaMode.music).future,
+    );
 
-    expect(data, hasLength(1));
-    expect(data.first.mode, MediaMode.music);
-    expect(data.first.title, 'Track');
+    expect(data.visibleItems, hasLength(1));
+    expect(data.visibleItems.first.mode, MediaMode.music);
+    expect(data.visibleItems.first.title, 'Track');
+    expect(data.hasMore, isFalse);
   });
 
   test('maps tv channels into unified discovery content', () async {
@@ -47,12 +52,76 @@ void main() {
     );
     addTearDown(container.dispose);
 
-    await container.read(iptvChannelsProvider.future);
-    final data =
-        container.read(mediaHubDiscoveryProvider(MediaMode.tv)).value ?? [];
+    final data = await container.read(
+      mediaHubDiscoveryProvider(MediaMode.tv).future,
+    );
 
-    expect(data, hasLength(1));
-    expect(data.first.mode, MediaMode.tv);
-    expect(data.first.title, 'Airo TV');
+    expect(data.visibleItems, hasLength(1));
+    expect(data.visibleItems.first.mode, MediaMode.tv);
+    expect(data.visibleItems.first.title, 'Airo TV');
+  });
+
+  test('supports search, category filtering, and pagination', () async {
+    final channels = [
+      const IPTVChannel(
+        id: 'tv-1',
+        name: 'Airo News',
+        streamUrl: 'https://example.com/news.m3u8',
+        group: 'News',
+        category: ChannelCategory.news,
+      ),
+      const IPTVChannel(
+        id: 'tv-2',
+        name: 'Airo Sports',
+        streamUrl: 'https://example.com/sports.m3u8',
+        group: 'Sports',
+        category: ChannelCategory.sports,
+      ),
+      const IPTVChannel(
+        id: 'tv-3',
+        name: 'Airo Movies',
+        streamUrl: 'https://example.com/movies.m3u8',
+        group: 'Movies',
+        category: ChannelCategory.movies,
+      ),
+    ];
+    final container = ProviderContainer(
+      overrides: [
+        iptvChannelsProvider.overrideWith((ref) async => channels),
+        mediaHubDiscoveryPageSizeProvider.overrideWith((ref) => 1),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    final initial = await container.read(
+      mediaHubDiscoveryProvider(MediaMode.tv).future,
+    );
+    expect(initial.visibleItems, hasLength(1));
+    expect(initial.hasMore, isTrue);
+
+    final notifier = container.read(
+      mediaHubDiscoveryProvider(MediaMode.tv).notifier,
+    );
+    notifier.loadNextPage();
+    final paged = container
+        .read(mediaHubDiscoveryProvider(MediaMode.tv))
+        .value!;
+    expect(paged.visibleItems, hasLength(2));
+    expect(paged.hasMore, isTrue);
+
+    notifier.setCategory(MediaCategory.sports);
+    final filtered = container
+        .read(mediaHubDiscoveryProvider(MediaMode.tv))
+        .value!;
+    expect(filtered.visibleItems, hasLength(1));
+    expect(filtered.visibleItems.first.title, 'Airo Sports');
+    expect(filtered.hasMore, isFalse);
+
+    notifier.setSearchQuery('movies');
+    final searched = container
+        .read(mediaHubDiscoveryProvider(MediaMode.tv))
+        .value!;
+    expect(searched.visibleItems, isEmpty);
+    expect(searched.filteredCount, 0);
   });
 }

--- a/app/test/features/media_hub/domain/models/discovery_state_test.dart
+++ b/app/test/features/media_hub/domain/models/discovery_state_test.dart
@@ -1,0 +1,54 @@
+import 'package:airo_app/features/media_hub/domain/models/discovery_state.dart';
+import 'package:airo_app/features/media_hub/domain/models/media_category.dart';
+import 'package:airo_app/features/media_hub/domain/models/media_mode.dart';
+import 'package:airo_app/features/media_hub/domain/models/unified_media_content.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('DiscoveryState', () {
+    test('initial state applies first page and hasMore metadata', () {
+      final items = List.generate(
+        3,
+        (index) => UnifiedMediaContent(
+          id: 'item-$index',
+          mode: MediaMode.music,
+          category: MediaCategory.music,
+          title: 'Track $index',
+          subtitle: 'Artist',
+          imageUrl: null,
+          streamUrl: 'https://example.com/$index.mp3',
+        ),
+      );
+
+      final state = DiscoveryState.initial(
+        mode: MediaMode.music,
+        items: items,
+        pageSize: 2,
+      );
+
+      expect(state.visibleItems, hasLength(2));
+      expect(state.filteredCount, 3);
+      expect(state.currentPage, 1);
+      expect(state.hasMore, isTrue);
+    });
+
+    test('copyWith preserves immutable values', () {
+      final state = DiscoveryState.initial(mode: MediaMode.tv, items: const []);
+
+      final updated = state.copyWith(
+        searchQuery: 'sports',
+        selectedCategory: MediaCategory.sports,
+        currentPage: 2,
+        filteredCount: 5,
+        hasMore: true,
+      );
+
+      expect(updated.searchQuery, 'sports');
+      expect(updated.selectedCategory, MediaCategory.sports);
+      expect(updated.currentPage, 2);
+      expect(updated.filteredCount, 5);
+      expect(updated.hasMore, isTrue);
+      expect(updated.mode, MediaMode.tv);
+    });
+  });
+}


### PR DESCRIPTION
# Summary

This PR adds the missing Media Hub discovery state layer on top of the unified content model from #428.
Goal: introduce a `DiscoveryState` model plus a notifier/provider that integrates existing Music and IPTV sources with filtering and pagination.

Core outcome:

* adds `DiscoveryState` for unified browsing state
* upgrades the Media Hub discovery provider into a notifier-backed state layer
* verifies search, category filtering, and pagination with focused tests

# Changes

### Code

* Added:
  * `app/lib/features/media_hub/domain/models/discovery_state.dart`
* Updated:
  * `app/lib/features/media_hub/application/providers/discovery_provider.dart`
  * `app/test/features/media_hub/application/providers/discovery_provider_test.dart`
* Added tests:
  * `app/test/features/media_hub/domain/models/discovery_state_test.dart`

### Logic

* `DiscoveryNotifier` now loads unified music/tv content from existing providers
* search and category filtering reset pagination deterministically
* pagination exposes `visibleItems`, `filteredCount`, and `hasMore`
* refresh rehydrates from the source providers while preserving the active filters when possible

# API Changes (if any)

* None

# Database Changes (if any)

* None

# Observability / Logging

* None

# Performance Impact

* Latency: minimal in-memory filtering/pagination only
* Throughput: none
* Memory/CPU: negligible for current local lists

# Risks

* pagination is stateful but still in-memory only; it does not implement remote/infinite-scroll behavior beyond the current source lists
* Rollback plan:
  * revert this PR

# Testing

* Unit tests:
  * `flutter test test/features/media_hub`
* Integration tests:
  * provider-level discovery behavior in `discovery_provider_test.dart`
* Manual testing:
  * not run

# Deployment Notes

* Config changes:
  * none
* Order of deployment:
  * normal merge

# Related Commits

* `feat(media-hub): add discovery state management`

# Notes

* Closes #435
