### PR TITLE
feat(media-hub): add personalization state

### DIFF
--- a/app/lib/features/media_hub/application/providers/personalization_provider.dart
+++ b/app/lib/features/media_hub/application/providers/personalization_provider.dart
@@ -1,0 +1,107 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../iptv/application/providers/iptv_providers.dart'
+    show sharedPreferencesProvider;
+import '../../domain/models/personalization_state.dart';
+import '../../domain/models/unified_media_content.dart';
+
+const mediaHubPersonalizationStorageKey = 'media_hub_personalization_state';
+
+final personalizationProvider =
+    AsyncNotifierProvider<PersonalizationNotifier, PersonalizationState>(
+      PersonalizationNotifier.new,
+    );
+
+class PersonalizationNotifier extends AsyncNotifier<PersonalizationState> {
+  @override
+  Future<PersonalizationState> build() async {
+    final prefs = ref.watch(sharedPreferencesProvider);
+    final raw = prefs.getString(mediaHubPersonalizationStorageKey);
+    if (raw == null || raw.trim().isEmpty) {
+      return const PersonalizationState();
+    }
+    return PersonalizationState.fromStorageValue(raw);
+  }
+
+  Future<void> toggleFavorite(UnifiedMediaContent item) async {
+    final current = state.valueOrNull ?? await future;
+    final nextFavorites = List<UnifiedMediaContent>.from(current.favorites);
+    final index = nextFavorites.indexWhere((entry) => entry.id == item.id);
+    if (index >= 0) {
+      nextFavorites.removeAt(index);
+    } else {
+      nextFavorites.insert(0, item);
+      _trim(nextFavorites, PersonalizationState.maxFavorites);
+    }
+    await _persist(
+      current.copyWith(favorites: List.unmodifiable(nextFavorites)),
+    );
+  }
+
+  Future<void> addRecent(UnifiedMediaContent item) async {
+    final current = state.valueOrNull ?? await future;
+    final nextRecent = _upsertAtFront(current.recentlyPlayed, item);
+    _trim(nextRecent, PersonalizationState.maxRecentlyPlayed);
+    await _persist(
+      current.copyWith(recentlyPlayed: List.unmodifiable(nextRecent)),
+    );
+  }
+
+  Future<void> updateProgress(
+    UnifiedMediaContent item,
+    Duration position, {
+    Duration? duration,
+  }) async {
+    final current = state.valueOrNull ?? await future;
+    final updatedItem = item.copyWith(
+      duration: duration ?? item.duration,
+      lastPosition: position,
+    );
+    final nextRecent = _upsertAtFront(current.recentlyPlayed, updatedItem);
+    _trim(nextRecent, PersonalizationState.maxRecentlyPlayed);
+
+    final nextContinue = List<UnifiedMediaContent>.from(
+      current.continueWatching,
+    )..removeWhere((entry) => entry.id == updatedItem.id);
+    if (updatedItem.canResume) {
+      nextContinue.insert(0, updatedItem);
+      _trim(nextContinue, PersonalizationState.maxContinueWatching);
+    }
+
+    await _persist(
+      current.copyWith(
+        recentlyPlayed: List.unmodifiable(nextRecent),
+        continueWatching: List.unmodifiable(nextContinue),
+      ),
+    );
+  }
+
+  Future<void> clearAll() async {
+    await _persist(const PersonalizationState());
+  }
+
+  List<UnifiedMediaContent> _upsertAtFront(
+    List<UnifiedMediaContent> current,
+    UnifiedMediaContent item,
+  ) {
+    final next = List<UnifiedMediaContent>.from(current)
+      ..removeWhere((entry) => entry.id == item.id)
+      ..insert(0, item);
+    return next;
+  }
+
+  void _trim(List<UnifiedMediaContent> items, int maxLength) {
+    while (items.length > maxLength) {
+      items.removeLast();
+    }
+  }
+
+  Future<void> _persist(PersonalizationState next) async {
+    state = AsyncData(next);
+    final prefs = ref.read(sharedPreferencesProvider);
+    await prefs.setString(
+      mediaHubPersonalizationStorageKey,
+      next.toStorageValue(),
+    );
+  }
+}

--- a/app/lib/features/media_hub/domain/models/personalization_state.dart
+++ b/app/lib/features/media_hub/domain/models/personalization_state.dart
@@ -1,0 +1,78 @@
+import 'dart:convert';
+
+import 'package:equatable/equatable.dart';
+
+import 'unified_media_content.dart';
+
+class PersonalizationState extends Equatable {
+  const PersonalizationState({
+    this.favorites = const [],
+    this.recentlyPlayed = const [],
+    this.continueWatching = const [],
+  });
+
+  static const maxFavorites = 50;
+  static const maxRecentlyPlayed = 20;
+  static const maxContinueWatching = 20;
+
+  final List<UnifiedMediaContent> favorites;
+  final List<UnifiedMediaContent> recentlyPlayed;
+  final List<UnifiedMediaContent> continueWatching;
+
+  PersonalizationState copyWith({
+    List<UnifiedMediaContent>? favorites,
+    List<UnifiedMediaContent>? recentlyPlayed,
+    List<UnifiedMediaContent>? continueWatching,
+  }) {
+    return PersonalizationState(
+      favorites: favorites ?? this.favorites,
+      recentlyPlayed: recentlyPlayed ?? this.recentlyPlayed,
+      continueWatching: continueWatching ?? this.continueWatching,
+    );
+  }
+
+  bool isFavorite(String contentId) {
+    return favorites.any((item) => item.id == contentId);
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'favorites': favorites.map((item) => item.toJson()).toList(),
+      'recentlyPlayed': recentlyPlayed.map((item) => item.toJson()).toList(),
+      'continueWatching': continueWatching
+          .map((item) => item.toJson())
+          .toList(),
+    };
+  }
+
+  String toStorageValue() => jsonEncode(toJson());
+
+  factory PersonalizationState.fromJson(Map<String, dynamic> json) {
+    List<UnifiedMediaContent> readList(String key) {
+      final raw = json[key] as List<dynamic>? ?? const [];
+      return List<UnifiedMediaContent>.unmodifiable(
+        raw
+            .map(
+              (item) =>
+                  UnifiedMediaContent.fromJson(item as Map<String, dynamic>),
+            )
+            .toList(),
+      );
+    }
+
+    return PersonalizationState(
+      favorites: readList('favorites'),
+      recentlyPlayed: readList('recentlyPlayed'),
+      continueWatching: readList('continueWatching'),
+    );
+  }
+
+  factory PersonalizationState.fromStorageValue(String raw) {
+    return PersonalizationState.fromJson(
+      jsonDecode(raw) as Map<String, dynamic>,
+    );
+  }
+
+  @override
+  List<Object?> get props => [favorites, recentlyPlayed, continueWatching];
+}

--- a/app/lib/features/media_hub/domain/models/unified_media_content.dart
+++ b/app/lib/features/media_hub/domain/models/unified_media_content.dart
@@ -74,6 +74,70 @@ class UnifiedMediaContent extends Equatable {
   final int? viewerCount;
   final List<String> tags;
 
+  UnifiedMediaContent copyWith({
+    String? id,
+    MediaMode? mode,
+    MediaCategory? category,
+    String? title,
+    String? subtitle,
+    String? imageUrl,
+    String? streamUrl,
+    Duration? duration,
+    Duration? lastPosition,
+    bool? isLive,
+    int? viewerCount,
+    List<String>? tags,
+  }) {
+    return UnifiedMediaContent(
+      id: id ?? this.id,
+      mode: mode ?? this.mode,
+      category: category ?? this.category,
+      title: title ?? this.title,
+      subtitle: subtitle ?? this.subtitle,
+      imageUrl: imageUrl ?? this.imageUrl,
+      streamUrl: streamUrl ?? this.streamUrl,
+      duration: duration ?? this.duration,
+      lastPosition: lastPosition ?? this.lastPosition,
+      isLive: isLive ?? this.isLive,
+      viewerCount: viewerCount ?? this.viewerCount,
+      tags: tags ?? this.tags,
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'id': id,
+      'mode': mode.name,
+      'category': category.name,
+      'title': title,
+      'subtitle': subtitle,
+      'imageUrl': imageUrl,
+      'streamUrl': streamUrl,
+      'durationMs': duration.inMilliseconds,
+      'lastPositionMs': lastPosition.inMilliseconds,
+      'isLive': isLive,
+      'viewerCount': viewerCount,
+      'tags': tags,
+    };
+  }
+
+  factory UnifiedMediaContent.fromJson(Map<String, dynamic> json) {
+    return UnifiedMediaContent(
+      id: json['id'] as String,
+      mode: MediaMode.values.byName(json['mode'] as String),
+      category: MediaCategory.values.byName(json['category'] as String),
+      title: json['title'] as String,
+      subtitle: json['subtitle'] as String,
+      imageUrl: json['imageUrl'] as String?,
+      streamUrl: json['streamUrl'] as String?,
+      duration: Duration(milliseconds: json['durationMs'] as int? ?? 0),
+      lastPosition: Duration(milliseconds: json['lastPositionMs'] as int? ?? 0),
+      isLive: json['isLive'] as bool? ?? false,
+      viewerCount: json['viewerCount'] as int?,
+      tags: (json['tags'] as List<dynamic>? ?? const []).cast<String>(),
+    );
+  }
+
   bool get canResume =>
       !isLive &&
       lastPosition > Duration.zero &&

--- a/app/test/features/media_hub/application/providers/personalization_provider_test.dart
+++ b/app/test/features/media_hub/application/providers/personalization_provider_test.dart
@@ -1,0 +1,79 @@
+import 'package:airo_app/features/iptv/application/providers/iptv_providers.dart';
+import 'package:airo_app/features/media_hub/application/providers/personalization_provider.dart';
+import 'package:airo_app/features/media_hub/domain/models/media_category.dart';
+import 'package:airo_app/features/media_hub/domain/models/media_mode.dart';
+import 'package:airo_app/features/media_hub/domain/models/personalization_state.dart';
+import 'package:airo_app/features/media_hub/domain/models/unified_media_content.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  const track = UnifiedMediaContent(
+    id: 'track-1',
+    mode: MediaMode.music,
+    category: MediaCategory.music,
+    title: 'Track',
+    subtitle: 'Artist',
+    imageUrl: null,
+    streamUrl: 'https://example.com/audio.mp3',
+    duration: Duration(minutes: 3),
+  );
+
+  test(
+    'loads personalization state from shared preferences on startup',
+    () async {
+      SharedPreferences.setMockInitialValues({
+        mediaHubPersonalizationStorageKey: const PersonalizationState(
+          favorites: [track],
+        ).toStorageValue(),
+      });
+      final prefs = await SharedPreferences.getInstance();
+      final container = ProviderContainer(
+        overrides: [sharedPreferencesProvider.overrideWithValue(prefs)],
+      );
+      addTearDown(container.dispose);
+
+      final state = await container.read(personalizationProvider.future);
+
+      expect(state.favorites, [track]);
+    },
+  );
+
+  test('toggleFavorite persists favorite state', () async {
+    SharedPreferences.setMockInitialValues({});
+    final prefs = await SharedPreferences.getInstance();
+    final container = ProviderContainer(
+      overrides: [sharedPreferencesProvider.overrideWithValue(prefs)],
+    );
+    addTearDown(container.dispose);
+
+    final notifier = container.read(personalizationProvider.notifier);
+    await notifier.toggleFavorite(track);
+    final updated = container.read(personalizationProvider).value!;
+
+    expect(updated.favorites, [track]);
+    expect(prefs.getString(mediaHubPersonalizationStorageKey), isNotNull);
+  });
+
+  test('updateProgress tracks recents and continue watching', () async {
+    SharedPreferences.setMockInitialValues({});
+    final prefs = await SharedPreferences.getInstance();
+    final container = ProviderContainer(
+      overrides: [sharedPreferencesProvider.overrideWithValue(prefs)],
+    );
+    addTearDown(container.dispose);
+
+    final notifier = container.read(personalizationProvider.notifier);
+    await notifier.updateProgress(track, const Duration(minutes: 1));
+    final updated = container.read(personalizationProvider).value!;
+
+    expect(updated.recentlyPlayed, hasLength(1));
+    expect(updated.continueWatching, hasLength(1));
+    expect(updated.continueWatching.first.canResume, isTrue);
+    expect(
+      updated.continueWatching.first.lastPosition,
+      const Duration(minutes: 1),
+    );
+  });
+}

--- a/app/test/features/media_hub/domain/models/personalization_state_test.dart
+++ b/app/test/features/media_hub/domain/models/personalization_state_test.dart
@@ -1,0 +1,43 @@
+import 'package:airo_app/features/media_hub/domain/models/media_category.dart';
+import 'package:airo_app/features/media_hub/domain/models/media_mode.dart';
+import 'package:airo_app/features/media_hub/domain/models/personalization_state.dart';
+import 'package:airo_app/features/media_hub/domain/models/unified_media_content.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('PersonalizationState', () {
+    const item = UnifiedMediaContent(
+      id: 'track-1',
+      mode: MediaMode.music,
+      category: MediaCategory.music,
+      title: 'Track',
+      subtitle: 'Artist',
+      imageUrl: null,
+      streamUrl: 'https://example.com/audio.mp3',
+      duration: Duration(minutes: 3),
+      lastPosition: Duration(minutes: 1),
+    );
+
+    test('serializes and restores personalization lists', () {
+      const state = PersonalizationState(
+        favorites: [item],
+        recentlyPlayed: [item],
+        continueWatching: [item],
+      );
+
+      final restored = PersonalizationState.fromStorageValue(
+        state.toStorageValue(),
+      );
+
+      expect(restored, state);
+      expect(restored.isFavorite('track-1'), isTrue);
+    });
+
+    test('reports favorites by content id', () {
+      const state = PersonalizationState(favorites: [item]);
+
+      expect(state.isFavorite('track-1'), isTrue);
+      expect(state.isFavorite('missing'), isFalse);
+    });
+  });
+}


### PR DESCRIPTION
# Summary

This PR adds the missing Media Hub personalization state on top of the unified content/discovery work.
Goal: persist favorites, recently played items, and continue-watching resume positions through a single SharedPreferences-backed state provider.

Core outcome:

* adds `PersonalizationState` for favorites, recents, and continue watching
* adds a notifier-backed provider that loads on startup and persists mutations
* adds serialization support for `UnifiedMediaContent` and focused provider/model tests

# Changes

### Code

* Added:
  * `app/lib/features/media_hub/domain/models/personalization_state.dart`
  * `app/lib/features/media_hub/application/providers/personalization_provider.dart`
* Updated:
  * `app/lib/features/media_hub/domain/models/unified_media_content.dart`
* Added tests:
  * `app/test/features/media_hub/domain/models/personalization_state_test.dart`
  * `app/test/features/media_hub/application/providers/personalization_provider_test.dart`

### Logic

* startup load reads a single Media Hub personalization payload from SharedPreferences
* `toggleFavorite()` persists favorite state deterministically
* `addRecent()` maintains a bounded recent list
* `updateProgress()` persists both recents and continue-watching resume positions when the content can resume

# API Changes (if any)

* None

# Database Changes (if any)

* None

# Observability / Logging

* None

# Performance Impact

* Latency: negligible local JSON encode/decode only
* Throughput: none
* Memory/CPU: negligible

# Risks

* this provider currently maintains a unified Media Hub payload instead of reconciling older feature-specific history stores
* Rollback plan:
  * revert this PR

# Testing

* Unit tests:
  * `flutter test test/features/media_hub`
* Integration tests:
  * provider-level startup load and persistence behavior in `personalization_provider_test.dart`
* Manual testing:
  * not run

# Deployment Notes

* Config changes:
  * none
* Order of deployment:
  * normal merge

# Related Commits

* `feat(media-hub): add personalization state`

# Notes

* Closes #430
