### PR TITLE
feat(media-hub): add recently played carousel

### DIFF
--- a/app/lib/features/media/presentation/screens/media_hub_screen.dart
+++ b/app/lib/features/media/presentation/screens/media_hub_screen.dart
@@ -1,21 +1,47 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
+import '../../../media_hub/application/providers/personalization_provider.dart';
+import '../../../media_hub/domain/models/media_mode.dart';
+import '../../../media_hub/domain/models/personalization_state.dart';
+import '../../../media_hub/domain/models/unified_media_content.dart';
+import '../../../media_hub/presentation/widgets/personalization_carousel.dart';
 import '../../../iptv/presentation/screens/iptv_screen.dart';
 import '../../../music/presentation/screens/music_screen.dart';
 
 enum MediaSection { music, tv }
 
-class MediaHubScreen extends StatelessWidget {
+List<UnifiedMediaContent> recentItemsForSection(
+  PersonalizationState state,
+  MediaSection section,
+) {
+  final mode = switch (section) {
+    MediaSection.music => MediaMode.music,
+    MediaSection.tv => MediaMode.tv,
+  };
+  return state.recentlyPlayed
+      .where((item) => item.mode == mode)
+      .take(20)
+      .toList();
+}
+
+class MediaHubScreen extends ConsumerWidget {
   const MediaHubScreen({super.key, required this.section});
 
   final MediaSection section;
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
+    final personalization = ref.watch(personalizationProvider);
+    final recentItems = personalization.valueOrNull == null
+        ? const <UnifiedMediaContent>[]
+        : recentItemsForSection(personalization.valueOrNull!, section);
+
     return Column(
       children: [
         _MediaModeBar(section: section),
+        PersonalizationCarousel(title: 'Recently Played', items: recentItems),
         Expanded(
           child: AnimatedSwitcher(
             duration: const Duration(milliseconds: 180),

--- a/app/lib/features/media_hub/presentation/widgets/personalization_carousel.dart
+++ b/app/lib/features/media_hub/presentation/widgets/personalization_carousel.dart
@@ -1,0 +1,125 @@
+import 'package:flutter/material.dart';
+
+import '../../domain/models/media_mode.dart';
+import '../../domain/models/unified_media_content.dart';
+
+class PersonalizationCarousel extends StatelessWidget {
+  const PersonalizationCarousel({
+    super.key,
+    required this.title,
+    required this.items,
+    this.emptyMessage,
+    this.onSelected,
+  });
+
+  final String title;
+  final List<UnifiedMediaContent> items;
+  final String? emptyMessage;
+  final ValueChanged<UnifiedMediaContent>? onSelected;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    if (items.isEmpty) {
+      return const SizedBox.shrink();
+    }
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Padding(
+          padding: const EdgeInsets.fromLTRB(12, 10, 12, 8),
+          child: Text(
+            title,
+            style: theme.textTheme.titleMedium?.copyWith(
+              fontWeight: FontWeight.w700,
+            ),
+          ),
+        ),
+        SizedBox(
+          height: 118,
+          child: ListView.separated(
+            scrollDirection: Axis.horizontal,
+            padding: const EdgeInsets.symmetric(horizontal: 12),
+            itemCount: items.length,
+            separatorBuilder: (_, _) => const SizedBox(width: 10),
+            itemBuilder: (context, index) {
+              final item = items[index];
+              return _PersonalizationTile(
+                item: item,
+                onTap: onSelected == null ? null : () => onSelected!(item),
+              );
+            },
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _PersonalizationTile extends StatelessWidget {
+  const _PersonalizationTile({required this.item, this.onTap});
+
+  final UnifiedMediaContent item;
+  final VoidCallback? onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+    return SizedBox(
+      width: 210,
+      child: Material(
+        color: colorScheme.surfaceContainerHighest,
+        borderRadius: BorderRadius.circular(16),
+        child: InkWell(
+          borderRadius: BorderRadius.circular(16),
+          onTap: onTap,
+          child: Padding(
+            padding: const EdgeInsets.all(12),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Row(
+                  children: [
+                    Icon(
+                      item.isLive ? Icons.live_tv : Icons.history,
+                      size: 18,
+                      color: colorScheme.primary,
+                    ),
+                    const SizedBox(width: 8),
+                    Expanded(
+                      child: Text(
+                        item.title,
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                        style: theme.textTheme.titleSmall?.copyWith(
+                          fontWeight: FontWeight.w700,
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 8),
+                Text(
+                  item.subtitle,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: theme.textTheme.bodySmall,
+                ),
+                const Spacer(),
+                Text(
+                  item.mode.label,
+                  style: theme.textTheme.labelMedium?.copyWith(
+                    color: colorScheme.primary,
+                    fontWeight: FontWeight.w700,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/app/test/features/media/presentation/screens/media_hub_screen_test.dart
+++ b/app/test/features/media/presentation/screens/media_hub_screen_test.dart
@@ -1,0 +1,33 @@
+import 'package:airo_app/features/media/presentation/screens/media_hub_screen.dart';
+import 'package:airo_app/features/media_hub/domain/models/media_category.dart';
+import 'package:airo_app/features/media_hub/domain/models/media_mode.dart';
+import 'package:airo_app/features/media_hub/domain/models/personalization_state.dart';
+import 'package:airo_app/features/media_hub/domain/models/unified_media_content.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('recentItemsForSection filters content by active media section', () {
+    const musicItem = UnifiedMediaContent(
+      id: 'track-1',
+      mode: MediaMode.music,
+      category: MediaCategory.music,
+      title: 'Track',
+      subtitle: 'Artist',
+      imageUrl: null,
+      streamUrl: 'https://example.com/audio.mp3',
+    );
+    const tvItem = UnifiedMediaContent(
+      id: 'tv-1',
+      mode: MediaMode.tv,
+      category: MediaCategory.news,
+      title: 'News',
+      subtitle: 'TV',
+      imageUrl: null,
+      streamUrl: 'https://example.com/live.m3u8',
+    );
+    const state = PersonalizationState(recentlyPlayed: [musicItem, tvItem]);
+
+    expect(recentItemsForSection(state, MediaSection.music), [musicItem]);
+    expect(recentItemsForSection(state, MediaSection.tv), [tvItem]);
+  });
+}

--- a/app/test/features/media_hub/presentation/widgets/personalization_carousel_test.dart
+++ b/app/test/features/media_hub/presentation/widgets/personalization_carousel_test.dart
@@ -1,0 +1,58 @@
+import 'package:airo_app/features/media_hub/domain/models/media_category.dart';
+import 'package:airo_app/features/media_hub/domain/models/media_mode.dart';
+import 'package:airo_app/features/media_hub/domain/models/unified_media_content.dart';
+import 'package:airo_app/features/media_hub/presentation/widgets/personalization_carousel.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('renders recently played items in a horizontal carousel', (
+    tester,
+  ) async {
+    const items = [
+      UnifiedMediaContent(
+        id: 'track-1',
+        mode: MediaMode.music,
+        category: MediaCategory.music,
+        title: 'Track One',
+        subtitle: 'Artist One',
+        imageUrl: null,
+        streamUrl: 'https://example.com/one.mp3',
+      ),
+      UnifiedMediaContent(
+        id: 'track-2',
+        mode: MediaMode.music,
+        category: MediaCategory.music,
+        title: 'Track Two',
+        subtitle: 'Artist Two',
+        imageUrl: null,
+        streamUrl: 'https://example.com/two.mp3',
+      ),
+    ];
+
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(
+          body: PersonalizationCarousel(title: 'Recently Played', items: items),
+        ),
+      ),
+    );
+
+    expect(find.text('Recently Played'), findsOneWidget);
+    expect(find.text('Track One'), findsOneWidget);
+    expect(find.text('Track Two'), findsOneWidget);
+    expect(find.byType(ListView), findsOneWidget);
+  });
+
+  testWidgets('hides itself when there are no items', (tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(
+          body: PersonalizationCarousel(title: 'Recently Played', items: []),
+        ),
+      ),
+    );
+
+    expect(find.text('Recently Played'), findsNothing);
+  });
+}


### PR DESCRIPTION
# Summary

This PR adds the first Media Hub personalization surface on top of the merged discovery/personalization state.
Goal: show a recently played carousel filtered by the active media mode.

Core outcome:

* adds a reusable `PersonalizationCarousel` widget
* surfaces the last 20 recently played items above the Media Hub body
* filters the section by active Music/TV mode

# Changes

### Code

* Added:
  * `app/lib/features/media_hub/presentation/widgets/personalization_carousel.dart`
  * `app/test/features/media_hub/presentation/widgets/personalization_carousel_test.dart`
  * `app/test/features/media/presentation/screens/media_hub_screen_test.dart`
* Updated:
  * `app/lib/features/media/presentation/screens/media_hub_screen.dart`

### Logic

* `MediaHubScreen` now reads `personalizationProvider` and shows recent items for the active section only
* `recentItemsForSection()` provides a deterministic mode filter for recents
* the carousel hides itself when there are no recent items

# API Changes (if any)

* None

# Database Changes (if any)

* None

# Observability / Logging

* None

# Performance Impact

* Latency: negligible; reads already-loaded personalization state
* Throughput: none
* Memory/CPU: negligible widget/render cost only

# Risks

* this uses a lightweight tile view and defers richer media-card visuals to the later card widget task
* Rollback plan:
  * revert this PR

# Testing

* Unit tests:
  * `flutter test test/features/media/presentation/screens/media_hub_screen_test.dart test/features/media_hub/presentation/widgets/personalization_carousel_test.dart test/features/media_hub`
* Integration tests:
  * screen-level mode filtering in `media_hub_screen_test.dart`
* Manual testing:
  * not run

# Deployment Notes

* Config changes:
  * none
* Order of deployment:
  * normal merge

# Related Commits

* `feat(media-hub): add recently played carousel`

# Notes

* Closes #432
