### PR TITLE
feat(media-hub): add favorites carousel

### DIFF
--- a/app/lib/features/media/presentation/screens/media_hub_screen.dart
+++ b/app/lib/features/media/presentation/screens/media_hub_screen.dart
@@ -26,6 +26,17 @@ List<UnifiedMediaContent> recentItemsForSection(
       .toList();
 }
 
+List<UnifiedMediaContent> favoriteItemsForSection(
+  PersonalizationState state,
+  MediaSection section,
+) {
+  final mode = switch (section) {
+    MediaSection.music => MediaMode.music,
+    MediaSection.tv => MediaMode.tv,
+  };
+  return state.favorites.where((item) => item.mode == mode).toList();
+}
+
 class MediaHubScreen extends ConsumerWidget {
   const MediaHubScreen({super.key, required this.section});
 
@@ -34,6 +45,11 @@ class MediaHubScreen extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final personalization = ref.watch(personalizationProvider);
+    final personalizationNotifier = ref.read(personalizationProvider.notifier);
+    final state = personalization.valueOrNull;
+    final favoriteItems = state == null
+        ? const <UnifiedMediaContent>[]
+        : favoriteItemsForSection(state, section);
     final recentItems = personalization.valueOrNull == null
         ? const <UnifiedMediaContent>[]
         : recentItemsForSection(personalization.valueOrNull!, section);
@@ -41,6 +57,15 @@ class MediaHubScreen extends ConsumerWidget {
     return Column(
       children: [
         _MediaModeBar(section: section),
+        PersonalizationCarousel(
+          title: 'Favorites',
+          items: favoriteItems,
+          showFavoriteButton: true,
+          isFavorite: (_) => true,
+          onFavoriteToggle: (item) {
+            personalizationNotifier.toggleFavorite(item);
+          },
+        ),
         PersonalizationCarousel(title: 'Recently Played', items: recentItems),
         Expanded(
           child: AnimatedSwitcher(

--- a/app/lib/features/media_hub/presentation/widgets/personalization_carousel.dart
+++ b/app/lib/features/media_hub/presentation/widgets/personalization_carousel.dart
@@ -10,12 +10,18 @@ class PersonalizationCarousel extends StatelessWidget {
     required this.items,
     this.emptyMessage,
     this.onSelected,
+    this.showFavoriteButton = false,
+    this.isFavorite,
+    this.onFavoriteToggle,
   });
 
   final String title;
   final List<UnifiedMediaContent> items;
   final String? emptyMessage;
   final ValueChanged<UnifiedMediaContent>? onSelected;
+  final bool showFavoriteButton;
+  final bool Function(UnifiedMediaContent item)? isFavorite;
+  final ValueChanged<UnifiedMediaContent>? onFavoriteToggle;
 
   @override
   Widget build(BuildContext context) {
@@ -48,6 +54,11 @@ class PersonalizationCarousel extends StatelessWidget {
               return _PersonalizationTile(
                 item: item,
                 onTap: onSelected == null ? null : () => onSelected!(item),
+                showFavoriteButton: showFavoriteButton,
+                isFavorite: isFavorite?.call(item) ?? false,
+                onFavoriteToggle: onFavoriteToggle == null
+                    ? null
+                    : () => onFavoriteToggle!(item),
               );
             },
           ),
@@ -58,10 +69,19 @@ class PersonalizationCarousel extends StatelessWidget {
 }
 
 class _PersonalizationTile extends StatelessWidget {
-  const _PersonalizationTile({required this.item, this.onTap});
+  const _PersonalizationTile({
+    required this.item,
+    this.onTap,
+    this.showFavoriteButton = false,
+    this.isFavorite = false,
+    this.onFavoriteToggle,
+  });
 
   final UnifiedMediaContent item;
   final VoidCallback? onTap;
+  final bool showFavoriteButton;
+  final bool isFavorite;
+  final VoidCallback? onFavoriteToggle;
 
   @override
   Widget build(BuildContext context) {
@@ -98,6 +118,24 @@ class _PersonalizationTile extends StatelessWidget {
                         ),
                       ),
                     ),
+                    if (showFavoriteButton)
+                      IconButton(
+                        tooltip: isFavorite
+                            ? 'Remove from favorites'
+                            : 'Add to favorites',
+                        onPressed: onFavoriteToggle,
+                        icon: AnimatedSwitcher(
+                          duration: const Duration(milliseconds: 200),
+                          child: Icon(
+                            isFavorite ? Icons.favorite : Icons.favorite_border,
+                            key: ValueKey(isFavorite),
+                            color: isFavorite
+                                ? colorScheme.error
+                                : colorScheme.onSurfaceVariant,
+                            size: 20,
+                          ),
+                        ),
+                      ),
                   ],
                 ),
                 const SizedBox(height: 8),

--- a/app/test/features/media/presentation/screens/media_hub_screen_test.dart
+++ b/app/test/features/media/presentation/screens/media_hub_screen_test.dart
@@ -30,4 +30,29 @@ void main() {
     expect(recentItemsForSection(state, MediaSection.music), [musicItem]);
     expect(recentItemsForSection(state, MediaSection.tv), [tvItem]);
   });
+
+  test('favoriteItemsForSection filters favorites by active media section', () {
+    const musicItem = UnifiedMediaContent(
+      id: 'track-1',
+      mode: MediaMode.music,
+      category: MediaCategory.music,
+      title: 'Track',
+      subtitle: 'Artist',
+      imageUrl: null,
+      streamUrl: 'https://example.com/audio.mp3',
+    );
+    const tvItem = UnifiedMediaContent(
+      id: 'tv-1',
+      mode: MediaMode.tv,
+      category: MediaCategory.news,
+      title: 'News',
+      subtitle: 'TV',
+      imageUrl: null,
+      streamUrl: 'https://example.com/live.m3u8',
+    );
+    const state = PersonalizationState(favorites: [musicItem, tvItem]);
+
+    expect(favoriteItemsForSection(state, MediaSection.music), [musicItem]);
+    expect(favoriteItemsForSection(state, MediaSection.tv), [tvItem]);
+  });
 }

--- a/app/test/features/media_hub/presentation/widgets/personalization_carousel_test.dart
+++ b/app/test/features/media_hub/presentation/widgets/personalization_carousel_test.dart
@@ -55,4 +55,38 @@ void main() {
 
     expect(find.text('Recently Played'), findsNothing);
   });
+
+  testWidgets('shows filled heart for favorited items and handles toggle', (
+    tester,
+  ) async {
+    const item = UnifiedMediaContent(
+      id: 'track-1',
+      mode: MediaMode.music,
+      category: MediaCategory.music,
+      title: 'Favorite Track',
+      subtitle: 'Artist',
+      imageUrl: null,
+      streamUrl: 'https://example.com/one.mp3',
+    );
+    var tapped = false;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: PersonalizationCarousel(
+            title: 'Favorites',
+            items: const [item],
+            showFavoriteButton: true,
+            isFavorite: (_) => true,
+            onFavoriteToggle: (_) => tapped = true,
+          ),
+        ),
+      ),
+    );
+
+    expect(find.byIcon(Icons.favorite), findsOneWidget);
+    await tester.tap(find.byIcon(Icons.favorite));
+    await tester.pumpAndSettle();
+    expect(tapped, isTrue);
+  });
 }


### PR DESCRIPTION
# Summary
This PR adds a favorites carousel to the Media Hub so favorited music and TV items are visible and can be unfavorited inline.
Goal: close issue #433 with a low-effort personalization improvement.

Core outcome:
- adds a Favorites section above Recently Played
- reuses personalization state and supports inline unfavorite actions

# Changes
### Code
- Added:
  - favorites filtering helper for the active media section
- Updated:
  - media hub screen to render a Favorites carousel
  - personalization carousel to optionally show a favorite toggle button

### Logic
- filters favorites by the active media mode
- toggles favorite state from the carousel heart button
- keeps Recently Played behavior unchanged

# API Changes (if any)
- None

# Database Changes (if any)
- None

# Observability / Logging
- None

# Performance Impact
- Latency: negligible
- Throughput: none
- Memory/CPU: negligible

# Risks
- favorites list order still follows provider state order
- rollback plan:
  - revert this PR

# Testing
- Unit tests:
  - added favorites filtering coverage for media hub screen helpers
  - added favorite-toggle widget coverage for personalization carousel
- Manual testing:
  - not run

# Deployment Notes
- Config changes:
  - none
- Order of deployment:
  - normal

# Related Commits
- feat(media-hub): add favorites carousel

# Notes
- Closes #433