### PR TITLE
feat(media-hub): add continue watching carousel

### DIFF
--- a/app/lib/features/media/presentation/screens/media_hub_screen.dart
+++ b/app/lib/features/media/presentation/screens/media_hub_screen.dart
@@ -7,7 +7,10 @@ import '../../../media_hub/domain/models/media_mode.dart';
 import '../../../media_hub/domain/models/personalization_state.dart';
 import '../../../media_hub/domain/models/unified_media_content.dart';
 import '../../../media_hub/presentation/widgets/personalization_carousel.dart';
+import '../../../iptv/application/providers/iptv_providers.dart';
 import '../../../iptv/presentation/screens/iptv_screen.dart';
+import '../../../music/application/providers/music_provider.dart';
+import '../../../music/application/providers/music_tracks_provider.dart';
 import '../../../music/presentation/screens/music_screen.dart';
 
 enum MediaSection { music, tv }
@@ -37,6 +40,25 @@ List<UnifiedMediaContent> favoriteItemsForSection(
   return state.favorites.where((item) => item.mode == mode).toList();
 }
 
+List<UnifiedMediaContent> continueWatchingItemsForSection(
+  PersonalizationState state,
+  MediaSection section,
+) {
+  final mode = switch (section) {
+    MediaSection.music => MediaMode.music,
+    MediaSection.tv => MediaMode.tv,
+  };
+  return state.continueWatching
+      .where(
+        (item) =>
+            item.mode == mode &&
+            item.canResume &&
+            item.lastPosition > const Duration(seconds: 10),
+      )
+      .take(20)
+      .toList();
+}
+
 class MediaHubScreen extends ConsumerWidget {
   const MediaHubScreen({super.key, required this.section});
 
@@ -50,6 +72,9 @@ class MediaHubScreen extends ConsumerWidget {
     final favoriteItems = state == null
         ? const <UnifiedMediaContent>[]
         : favoriteItemsForSection(state, section);
+    final continueWatchingItems = state == null
+        ? const <UnifiedMediaContent>[]
+        : continueWatchingItemsForSection(state, section);
     final recentItems = personalization.valueOrNull == null
         ? const <UnifiedMediaContent>[]
         : recentItemsForSection(personalization.valueOrNull!, section);
@@ -64,6 +89,13 @@ class MediaHubScreen extends ConsumerWidget {
           isFavorite: (_) => true,
           onFavoriteToggle: (item) {
             personalizationNotifier.toggleFavorite(item);
+          },
+        ),
+        PersonalizationCarousel(
+          title: 'Continue Watching',
+          items: continueWatchingItems,
+          onSelected: (item) async {
+            await _resumeItem(ref, item);
           },
         ),
         PersonalizationCarousel(title: 'Recently Played', items: recentItems),
@@ -83,6 +115,35 @@ class MediaHubScreen extends ConsumerWidget {
       ],
     );
   }
+}
+
+Future<void> _resumeItem(WidgetRef ref, UnifiedMediaContent item) async {
+  switch (item.mode) {
+    case MediaMode.music:
+      final tracks = await ref.read(musicTracksProvider.future);
+      final track = _findById(tracks, item.id);
+      if (track == null) return;
+      final controller = ref.read(musicControllerProvider);
+      await controller.playTrack(track);
+      await controller.seek(item.lastPosition);
+    case MediaMode.tv:
+      final channels = await ref.read(iptvChannelsProvider.future);
+      final channel = _findById(channels, item.id);
+      if (channel == null) return;
+      final service = ref.read(iptvStreamingServiceProvider);
+      await service.playChannel(channel);
+      await service.seek(item.lastPosition);
+  }
+}
+
+T? _findById<T>(Iterable<T> items, String id) {
+  for (final item in items) {
+    final dynamic value = item;
+    if (value.id == id) {
+      return item;
+    }
+  }
+  return null;
 }
 
 class _MediaModeBar extends StatelessWidget {

--- a/app/lib/features/media_hub/presentation/widgets/personalization_carousel.dart
+++ b/app/lib/features/media_hub/presentation/widgets/personalization_carousel.dart
@@ -87,6 +87,12 @@ class _PersonalizationTile extends StatelessWidget {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final colorScheme = theme.colorScheme;
+    final showProgress =
+        item.canResume && item.lastPosition > const Duration(seconds: 10);
+    final progress = item.duration.inMilliseconds == 0
+        ? 0.0
+        : (item.lastPosition.inMilliseconds / item.duration.inMilliseconds)
+              .clamp(0.0, 1.0);
     return SizedBox(
       width: 210,
       child: Material(
@@ -146,6 +152,15 @@ class _PersonalizationTile extends StatelessWidget {
                   style: theme.textTheme.bodySmall,
                 ),
                 const Spacer(),
+                if (showProgress) ...[
+                  LinearProgressIndicator(value: progress),
+                  const SizedBox(height: 6),
+                  Text(
+                    '${_formatDuration(item.lastPosition)} / ${_formatDuration(item.duration)}',
+                    style: theme.textTheme.labelSmall,
+                  ),
+                  const SizedBox(height: 6),
+                ],
                 Text(
                   item.mode.label,
                   style: theme.textTheme.labelMedium?.copyWith(
@@ -159,5 +174,15 @@ class _PersonalizationTile extends StatelessWidget {
         ),
       ),
     );
+  }
+
+  String _formatDuration(Duration value) {
+    final minutes = value.inMinutes.remainder(60).toString().padLeft(2, '0');
+    final seconds = value.inSeconds.remainder(60).toString().padLeft(2, '0');
+    if (value.inHours > 0) {
+      final hours = value.inHours.toString().padLeft(2, '0');
+      return '$hours:$minutes:$seconds';
+    }
+    return '$minutes:$seconds';
   }
 }

--- a/app/test/features/media/presentation/screens/media_hub_screen_test.dart
+++ b/app/test/features/media/presentation/screens/media_hub_screen_test.dart
@@ -55,4 +55,51 @@ void main() {
     expect(favoriteItemsForSection(state, MediaSection.music), [musicItem]);
     expect(favoriteItemsForSection(state, MediaSection.tv), [tvItem]);
   });
+
+  test(
+    'continueWatchingItemsForSection keeps resumable items over 10 seconds',
+    () {
+      const resumableMusic = UnifiedMediaContent(
+        id: 'track-1',
+        mode: MediaMode.music,
+        category: MediaCategory.music,
+        title: 'Track',
+        subtitle: 'Artist',
+        imageUrl: null,
+        streamUrl: 'https://example.com/audio.mp3',
+        duration: Duration(minutes: 3),
+        lastPosition: Duration(seconds: 42),
+      );
+      const tooShort = UnifiedMediaContent(
+        id: 'track-2',
+        mode: MediaMode.music,
+        category: MediaCategory.music,
+        title: 'Short',
+        subtitle: 'Artist',
+        imageUrl: null,
+        streamUrl: 'https://example.com/audio-2.mp3',
+        duration: Duration(minutes: 3),
+        lastPosition: Duration(seconds: 9),
+      );
+      const liveTv = UnifiedMediaContent(
+        id: 'tv-1',
+        mode: MediaMode.tv,
+        category: MediaCategory.news,
+        title: 'News',
+        subtitle: 'TV',
+        imageUrl: null,
+        streamUrl: 'https://example.com/live.m3u8',
+        isLive: true,
+        lastPosition: Duration(minutes: 1),
+      );
+      const state = PersonalizationState(
+        continueWatching: [resumableMusic, tooShort, liveTv],
+      );
+
+      expect(continueWatchingItemsForSection(state, MediaSection.music), [
+        resumableMusic,
+      ]);
+      expect(continueWatchingItemsForSection(state, MediaSection.tv), isEmpty);
+    },
+  );
 }

--- a/app/test/features/media_hub/presentation/widgets/personalization_carousel_test.dart
+++ b/app/test/features/media_hub/presentation/widgets/personalization_carousel_test.dart
@@ -89,4 +89,32 @@ void main() {
     await tester.pumpAndSettle();
     expect(tapped, isTrue);
   });
+
+  testWidgets('shows playback progress for resumable items', (tester) async {
+    const item = UnifiedMediaContent(
+      id: 'track-1',
+      mode: MediaMode.music,
+      category: MediaCategory.music,
+      title: 'Resume Track',
+      subtitle: 'Artist',
+      imageUrl: null,
+      streamUrl: 'https://example.com/one.mp3',
+      duration: Duration(minutes: 4),
+      lastPosition: Duration(minutes: 1, seconds: 30),
+    );
+
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(
+          body: PersonalizationCarousel(
+            title: 'Continue Watching',
+            items: [item],
+          ),
+        ),
+      ),
+    );
+
+    expect(find.text('01:30 / 04:00'), findsOneWidget);
+    expect(find.byType(LinearProgressIndicator), findsOneWidget);
+  });
 }

--- a/docs/wiki/3.-Navigating-Airo.md
+++ b/docs/wiki/3.-Navigating-Airo.md
@@ -41,6 +41,12 @@ Header behavior:
 The Music tab opens `/music`. Legacy `/beats` links redirect there. It is the
 audio playback surface and controls music mini-player visibility.
 
+Media Hub discovery on the music side now includes:
+
+- Favorites for saved tracks.
+- Continue Watching/Listening for resumable items with saved playback progress.
+- Recently Played for quick return to prior content.
+
 Header behavior:
 
 - `/music` keeps its own route-level app bar because Beats owns search and
@@ -51,6 +57,10 @@ Header behavior:
 The TV tab opens `/iptv`. Legacy `/stream` links redirect there. It is the IPTV
 and video playback surface, including TV-friendly controls and mini-player
 behavior.
+
+When TV content is resumable, the shared Media Hub surface can show it in
+Continue Watching with stored progress, alongside Favorites and Recently Played
+sections filtered to the active mode.
 
 Header behavior:
 


### PR DESCRIPTION
# Summary
This PR adds a Continue Watching/Listening section to the Media Hub so users can resume partially consumed content from their saved position.
Goal: close issue #431 with a minimal complete resume flow.

Core outcome:
- adds a Continue Watching carousel above Recently Played
- shows saved playback progress and resumes from the stored position on tap

# Changes
### Code
- Added:
  - continue-watching filtering helper for the active media section
- Updated:
  - media hub screen to render a Continue Watching carousel and resume items
  - personalization carousel to show progress for resumable items

### Logic
- filters to resumable items with more than 10 seconds played
- keeps mode-specific filtering for Music and TV
- resumes content from saved playback position when selected

# API Changes (if any)
- None

# Database Changes (if any)
- None

# Observability / Logging
- None

# Performance Impact
- Latency: negligible
- Throughput: none
- Memory/CPU: negligible

# Risks
- TV resume is best-effort and depends on the item mapping back to a current channel entry
- rollback plan:
  - revert this PR

# Testing
- Unit tests:
  - added continue-watching helper coverage
  - added widget coverage for progress display in the personalization carousel
- Manual testing:
  - not run

# Deployment Notes
- Config changes:
  - none
- Order of deployment:
  - normal

# Related Commits
- feat(media-hub): add continue watching carousel

# Notes
- Closes #431