### PR TITLE
feat(media-hub): add discovery content cards

### DIFF
--- a/app/lib/features/media/presentation/screens/media_hub_screen.dart
+++ b/app/lib/features/media/presentation/screens/media_hub_screen.dart
@@ -2,6 +2,10 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
+import '../../../media_hub/application/providers/discovery_provider.dart';
+import '../../../media_hub/domain/models/discovery_state.dart';
+import '../../../media_hub/presentation/widgets/content_carousel.dart';
+import '../../../media_hub/presentation/widgets/content_grid.dart';
 import '../../../media_hub/application/providers/personalization_provider.dart';
 import '../../../media_hub/domain/models/media_mode.dart';
 import '../../../media_hub/domain/models/personalization_state.dart';
@@ -78,6 +82,8 @@ class MediaHubScreen extends ConsumerWidget {
     final recentItems = personalization.valueOrNull == null
         ? const <UnifiedMediaContent>[]
         : recentItemsForSection(personalization.valueOrNull!, section);
+    final discoveryMode = mediaModeForSection(section);
+    final discovery = ref.watch(mediaHubDiscoveryProvider(discoveryMode));
 
     return Column(
       children: [
@@ -99,6 +105,18 @@ class MediaHubScreen extends ConsumerWidget {
           },
         ),
         PersonalizationCarousel(title: 'Recently Played', items: recentItems),
+        _DiscoverySection(
+          section: section,
+          discovery: discovery,
+          onSelected: (item) async {
+            await _openItem(ref, item);
+          },
+          onLoadMore: () {
+            ref
+                .read(mediaHubDiscoveryProvider(discoveryMode).notifier)
+                .loadNextPage();
+          },
+        ),
         Expanded(
           child: AnimatedSwitcher(
             duration: const Duration(milliseconds: 180),
@@ -115,6 +133,13 @@ class MediaHubScreen extends ConsumerWidget {
       ],
     );
   }
+}
+
+MediaMode mediaModeForSection(MediaSection section) {
+  return switch (section) {
+    MediaSection.music => MediaMode.music,
+    MediaSection.tv => MediaMode.tv,
+  };
 }
 
 Future<void> _resumeItem(WidgetRef ref, UnifiedMediaContent item) async {
@@ -136,6 +161,22 @@ Future<void> _resumeItem(WidgetRef ref, UnifiedMediaContent item) async {
   }
 }
 
+Future<void> _openItem(WidgetRef ref, UnifiedMediaContent item) async {
+  await ref.read(personalizationProvider.notifier).addRecent(item);
+  switch (item.mode) {
+    case MediaMode.music:
+      final tracks = await ref.read(musicTracksProvider.future);
+      final track = _findById(tracks, item.id);
+      if (track == null) return;
+      await ref.read(musicControllerProvider).playTrack(track);
+    case MediaMode.tv:
+      final channels = await ref.read(iptvChannelsProvider.future);
+      final channel = _findById(channels, item.id);
+      if (channel == null) return;
+      await ref.read(iptvStreamingServiceProvider).playChannel(channel);
+  }
+}
+
 T? _findById<T>(Iterable<T> items, String id) {
   for (final item in items) {
     final dynamic value = item;
@@ -144,6 +185,80 @@ T? _findById<T>(Iterable<T> items, String id) {
     }
   }
   return null;
+}
+
+class _DiscoverySection extends StatelessWidget {
+  const _DiscoverySection({
+    required this.section,
+    required this.discovery,
+    required this.onSelected,
+    required this.onLoadMore,
+  });
+
+  final MediaSection section;
+  final AsyncValue<DiscoveryState> discovery;
+  final ValueChanged<UnifiedMediaContent> onSelected;
+  final VoidCallback onLoadMore;
+
+  @override
+  Widget build(BuildContext context) {
+    final title = section == MediaSection.music
+        ? 'Browse Music'
+        : 'Browse Live TV';
+    return discovery.when(
+      loading: () => Padding(
+        padding: const EdgeInsets.only(bottom: 8),
+        child: section == MediaSection.music
+            ? ContentCarousel.skeleton(title: title)
+            : ContentGrid.skeleton(title: title),
+      ),
+      error: (error, _) => Padding(
+        padding: const EdgeInsets.fromLTRB(12, 6, 12, 12),
+        child: Card(
+          child: ListTile(
+            title: Text(title),
+            subtitle: Text('Unable to load discovery right now: $error'),
+          ),
+        ),
+      ),
+      data: (state) {
+        final items = switch (section) {
+          MediaSection.music => state.visibleItems.take(8).toList(),
+          MediaSection.tv => state.visibleItems.take(4).toList(),
+        };
+        if (items.isEmpty) {
+          return const SizedBox.shrink();
+        }
+        return Column(
+          children: [
+            section == MediaSection.music
+                ? ContentCarousel(
+                    title: title,
+                    items: items,
+                    onSelected: onSelected,
+                  )
+                : ContentGrid(
+                    title: title,
+                    items: items,
+                    onSelected: onSelected,
+                  ),
+            if (state.hasMore)
+              Padding(
+                padding: const EdgeInsets.fromLTRB(12, 0, 12, 8),
+                child: Align(
+                  alignment: Alignment.centerRight,
+                  child: TextButton.icon(
+                    onPressed: onLoadMore,
+                    icon: const Icon(Icons.expand_more),
+                    label: const Text('Load more'),
+                  ),
+                ),
+              ),
+          ],
+        );
+      },
+    );
+  }
 }
 
 class _MediaModeBar extends StatelessWidget {

--- a/app/lib/features/media_hub/presentation/widgets/content_carousel.dart
+++ b/app/lib/features/media_hub/presentation/widgets/content_carousel.dart
@@ -1,0 +1,70 @@
+import 'package:flutter/material.dart';
+
+import '../../domain/models/unified_media_content.dart';
+import 'media_content_card.dart';
+
+class ContentCarousel extends StatelessWidget {
+  const ContentCarousel({
+    super.key,
+    required this.items,
+    required this.onSelected,
+    this.title,
+  }) : skeletonCount = 0;
+
+  const ContentCarousel.skeleton({
+    super.key,
+    this.title,
+    this.skeletonCount = 4,
+  }) : items = const [],
+       onSelected = _noop;
+
+  final String? title;
+  final List<UnifiedMediaContent> items;
+  final ValueChanged<UnifiedMediaContent> onSelected;
+  final int skeletonCount;
+
+  static void _noop(UnifiedMediaContent _) {}
+
+  @override
+  Widget build(BuildContext context) {
+    if (items.isEmpty && skeletonCount == 0) {
+      return const SizedBox.shrink();
+    }
+
+    final count = skeletonCount > 0 ? skeletonCount : items.length;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        if (title != null)
+          Padding(
+            padding: const EdgeInsets.fromLTRB(12, 6, 12, 10),
+            child: Text(
+              title!,
+              style: Theme.of(
+                context,
+              ).textTheme.titleMedium?.copyWith(fontWeight: FontWeight.w700),
+            ),
+          ),
+        SizedBox(
+          height: 220,
+          child: ListView.separated(
+            scrollDirection: Axis.horizontal,
+            padding: const EdgeInsets.symmetric(horizontal: 12),
+            itemCount: count,
+            separatorBuilder: (_, _) => const SizedBox(width: 12),
+            itemBuilder: (context, index) {
+              if (skeletonCount > 0) {
+                return const MediaContentCard.skeleton();
+              }
+              final item = items[index];
+              return MediaContentCard(
+                item: item,
+                onTap: () => onSelected(item),
+              );
+            },
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/app/lib/features/media_hub/presentation/widgets/content_grid.dart
+++ b/app/lib/features/media_hub/presentation/widgets/content_grid.dart
@@ -1,0 +1,73 @@
+import 'package:flutter/material.dart';
+
+import '../../domain/models/unified_media_content.dart';
+import 'media_content_card.dart';
+
+class ContentGrid extends StatelessWidget {
+  const ContentGrid({
+    super.key,
+    required this.items,
+    required this.onSelected,
+    this.title,
+  }) : skeletonCount = 0;
+
+  const ContentGrid.skeleton({super.key, this.title, this.skeletonCount = 4})
+    : items = const [],
+      onSelected = _noop;
+
+  final String? title;
+  final List<UnifiedMediaContent> items;
+  final ValueChanged<UnifiedMediaContent> onSelected;
+  final int skeletonCount;
+
+  static void _noop(UnifiedMediaContent _) {}
+
+  @override
+  Widget build(BuildContext context) {
+    if (items.isEmpty && skeletonCount == 0) {
+      return const SizedBox.shrink();
+    }
+
+    final count = skeletonCount > 0 ? skeletonCount : items.length;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        if (title != null)
+          Padding(
+            padding: const EdgeInsets.fromLTRB(12, 6, 12, 10),
+            child: Text(
+              title!,
+              style: Theme.of(
+                context,
+              ).textTheme.titleMedium?.copyWith(fontWeight: FontWeight.w700),
+            ),
+          ),
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 12),
+          child: GridView.builder(
+            shrinkWrap: true,
+            physics: const NeverScrollableScrollPhysics(),
+            gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+              crossAxisCount: 2,
+              crossAxisSpacing: 12,
+              mainAxisSpacing: 12,
+              childAspectRatio: 0.86,
+            ),
+            itemCount: count,
+            itemBuilder: (context, index) {
+              if (skeletonCount > 0) {
+                return const MediaContentCard.skeleton();
+              }
+              final item = items[index];
+              return MediaContentCard(
+                item: item,
+                width: double.infinity,
+                onTap: () => onSelected(item),
+              );
+            },
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/app/lib/features/media_hub/presentation/widgets/media_content_card.dart
+++ b/app/lib/features/media_hub/presentation/widgets/media_content_card.dart
@@ -1,0 +1,248 @@
+import 'package:flutter/material.dart';
+
+import '../../domain/models/media_category.dart';
+import '../../domain/models/unified_media_content.dart';
+
+class MediaContentCard extends StatelessWidget {
+  const MediaContentCard({
+    super.key,
+    required this.item,
+    this.onTap,
+    this.width = 190,
+    this.height = 220,
+  }) : isSkeleton = false;
+
+  const MediaContentCard.skeleton({
+    super.key,
+    this.width = 190,
+    this.height = 220,
+  }) : item = null,
+       onTap = null,
+       isSkeleton = true;
+
+  final UnifiedMediaContent? item;
+  final VoidCallback? onTap;
+  final double width;
+  final double height;
+  final bool isSkeleton;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+
+    return SizedBox(
+      width: width,
+      height: height,
+      child: Material(
+        color: colorScheme.surfaceContainerLow,
+        borderRadius: BorderRadius.circular(20),
+        clipBehavior: Clip.antiAlias,
+        child: InkWell(
+          onTap: isSkeleton ? null : onTap,
+          child: isSkeleton
+              ? _CardSkeleton(colorScheme: colorScheme)
+              : _CardBody(item: item!, theme: theme),
+        ),
+      ),
+    );
+  }
+}
+
+class _CardBody extends StatelessWidget {
+  const _CardBody({required this.item, required this.theme});
+
+  final UnifiedMediaContent item;
+  final ThemeData theme;
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = theme.colorScheme;
+    final tag = item.tags.isNotEmpty ? item.tags.first : item.category.label;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Expanded(
+          child: Stack(
+            fit: StackFit.expand,
+            children: [
+              DecoratedBox(
+                decoration: BoxDecoration(
+                  gradient: LinearGradient(
+                    begin: Alignment.topLeft,
+                    end: Alignment.bottomRight,
+                    colors: [
+                      colorScheme.primaryContainer,
+                      colorScheme.secondaryContainer,
+                    ],
+                  ),
+                ),
+                child: item.imageUrl == null || item.imageUrl!.isEmpty
+                    ? Icon(
+                        item.isLive ? Icons.live_tv : Icons.album,
+                        size: 44,
+                        color: colorScheme.onPrimaryContainer,
+                      )
+                    : Image.network(
+                        item.imageUrl!,
+                        fit: BoxFit.cover,
+                        frameBuilder: (context, child, frame, wasLoaded) {
+                          return AnimatedOpacity(
+                            opacity: frame == null && !wasLoaded ? 0 : 1,
+                            duration: const Duration(milliseconds: 200),
+                            curve: Curves.easeOut,
+                            child: child,
+                          );
+                        },
+                        errorBuilder: (context, _, _) {
+                          return Icon(
+                            item.isLive ? Icons.live_tv : Icons.album,
+                            size: 44,
+                            color: colorScheme.onPrimaryContainer,
+                          );
+                        },
+                      ),
+              ),
+              Positioned(
+                top: 10,
+                left: 10,
+                child: Wrap(
+                  spacing: 8,
+                  runSpacing: 8,
+                  children: [
+                    if (item.isLive)
+                      _Pill(
+                        label: 'LIVE',
+                        backgroundColor: colorScheme.error,
+                        foregroundColor: colorScheme.onError,
+                      ),
+                    _Pill(
+                      label: tag.toUpperCase(),
+                      backgroundColor: colorScheme.surface.withValues(
+                        alpha: 0.88,
+                      ),
+                      foregroundColor: colorScheme.onSurface,
+                    ),
+                  ],
+                ),
+              ),
+              if (item.viewerCount != null)
+                Positioned(
+                  right: 10,
+                  bottom: 10,
+                  child: _Pill(
+                    label: '${item.viewerCount} watching',
+                    icon: Icons.visibility_outlined,
+                    backgroundColor: Colors.black.withValues(alpha: 0.68),
+                    foregroundColor: Colors.white,
+                  ),
+                ),
+            ],
+          ),
+        ),
+        Padding(
+          padding: const EdgeInsets.fromLTRB(12, 12, 12, 14),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                item.title,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                style: theme.textTheme.titleSmall?.copyWith(
+                  fontWeight: FontWeight.w700,
+                ),
+              ),
+              const SizedBox(height: 4),
+              Text(
+                item.subtitle,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                style: theme.textTheme.bodySmall?.copyWith(
+                  color: theme.colorScheme.onSurfaceVariant,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _Pill extends StatelessWidget {
+  const _Pill({
+    required this.label,
+    required this.backgroundColor,
+    required this.foregroundColor,
+    this.icon,
+  });
+
+  final String label;
+  final IconData? icon;
+  final Color backgroundColor;
+  final Color foregroundColor;
+
+  @override
+  Widget build(BuildContext context) {
+    final labelStyle = Theme.of(context).textTheme.labelSmall?.copyWith(
+      color: foregroundColor,
+      fontWeight: FontWeight.w700,
+      letterSpacing: 0.3,
+    );
+
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        color: backgroundColor,
+        borderRadius: BorderRadius.circular(999),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            if (icon != null) ...[
+              Icon(icon, size: 12, color: foregroundColor),
+              const SizedBox(width: 4),
+            ],
+            Text(label, style: labelStyle),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _CardSkeleton extends StatelessWidget {
+  const _CardSkeleton({required this.colorScheme});
+
+  final ColorScheme colorScheme;
+
+  @override
+  Widget build(BuildContext context) {
+    final shimmer = colorScheme.surfaceContainerHighest;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Expanded(
+          child: ColoredBox(
+            key: const ValueKey('media-card-skeleton-image'),
+            color: shimmer,
+          ),
+        ),
+        Padding(
+          padding: const EdgeInsets.all(12),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Container(height: 12, width: 120, color: shimmer),
+              const SizedBox(height: 8),
+              Container(height: 10, width: 80, color: shimmer),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/app/test/features/media/presentation/screens/media_hub_screen_test.dart
+++ b/app/test/features/media/presentation/screens/media_hub_screen_test.dart
@@ -102,4 +102,9 @@ void main() {
       expect(continueWatchingItemsForSection(state, MediaSection.tv), isEmpty);
     },
   );
+
+  test('mediaModeForSection maps sections to discovery modes', () {
+    expect(mediaModeForSection(MediaSection.music), MediaMode.music);
+    expect(mediaModeForSection(MediaSection.tv), MediaMode.tv);
+  });
 }

--- a/app/test/features/media_hub/presentation/widgets/content_layouts_test.dart
+++ b/app/test/features/media_hub/presentation/widgets/content_layouts_test.dart
@@ -1,0 +1,60 @@
+import 'package:airo_app/features/media_hub/domain/models/media_category.dart';
+import 'package:airo_app/features/media_hub/domain/models/media_mode.dart';
+import 'package:airo_app/features/media_hub/domain/models/unified_media_content.dart';
+import 'package:airo_app/features/media_hub/presentation/widgets/content_carousel.dart';
+import 'package:airo_app/features/media_hub/presentation/widgets/content_grid.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  const item = UnifiedMediaContent(
+    id: 'track-1',
+    mode: MediaMode.music,
+    category: MediaCategory.music,
+    title: 'Track One',
+    subtitle: 'Artist',
+    imageUrl: null,
+    streamUrl: 'https://example.com/track.mp3',
+    tags: ['Chill'],
+  );
+
+  testWidgets('music discovery uses horizontal carousel layout', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(
+          body: ContentCarousel(
+            title: 'Browse Music',
+            items: [item],
+            onSelected: _noop,
+          ),
+        ),
+      ),
+    );
+
+    expect(find.text('Browse Music'), findsOneWidget);
+    expect(find.byType(ListView), findsOneWidget);
+    expect(find.text('Track One'), findsOneWidget);
+  });
+
+  testWidgets('tv discovery uses two-column grid layout', (tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(
+          body: ContentGrid(
+            title: 'Browse Live TV',
+            items: [item, item],
+            onSelected: _noop,
+          ),
+        ),
+      ),
+    );
+
+    expect(find.text('Browse Live TV'), findsOneWidget);
+    expect(find.byType(GridView), findsOneWidget);
+    expect(find.text('Track One'), findsNWidgets(2));
+  });
+}
+
+void _noop(UnifiedMediaContent _) {}

--- a/app/test/features/media_hub/presentation/widgets/media_content_card_test.dart
+++ b/app/test/features/media_hub/presentation/widgets/media_content_card_test.dart
@@ -1,0 +1,52 @@
+import 'package:airo_app/features/media_hub/domain/models/media_category.dart';
+import 'package:airo_app/features/media_hub/domain/models/media_mode.dart';
+import 'package:airo_app/features/media_hub/domain/models/unified_media_content.dart';
+import 'package:airo_app/features/media_hub/presentation/widgets/media_content_card.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('renders content metadata, live badge, and viewers', (
+    tester,
+  ) async {
+    const item = UnifiedMediaContent(
+      id: 'tv-1',
+      mode: MediaMode.tv,
+      category: MediaCategory.news,
+      title: 'Airo News',
+      subtitle: 'News',
+      imageUrl: null,
+      streamUrl: 'https://example.com/live.m3u8',
+      isLive: true,
+      viewerCount: 1200,
+      tags: ['Hindi'],
+    );
+
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(
+          body: Center(child: MediaContentCard(item: item)),
+        ),
+      ),
+    );
+
+    expect(find.text('Airo News'), findsOneWidget);
+    expect(find.text('News'), findsOneWidget);
+    expect(find.text('LIVE'), findsOneWidget);
+    expect(find.text('1200 watching'), findsOneWidget);
+    expect(find.text('HINDI'), findsOneWidget);
+  });
+
+  testWidgets('renders skeleton state', (tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(body: Center(child: MediaContentCard.skeleton())),
+      ),
+    );
+
+    expect(
+      find.byKey(const ValueKey('media-card-skeleton-image')),
+      findsOneWidget,
+    );
+  });
+}

--- a/docs/wiki/3.-Navigating-Airo.md
+++ b/docs/wiki/3.-Navigating-Airo.md
@@ -46,6 +46,7 @@ Media Hub discovery on the music side now includes:
 - Favorites for saved tracks.
 - Continue Watching/Listening for resumable items with saved playback progress.
 - Recently Played for quick return to prior content.
+- Visual discovery cards with artwork, tags, and horizontal browsing.
 
 Header behavior:
 
@@ -61,6 +62,9 @@ behavior.
 When TV content is resumable, the shared Media Hub surface can show it in
 Continue Watching with stored progress, alongside Favorites and Recently Played
 sections filtered to the active mode.
+
+TV discovery in the shared Media Hub now uses visual cards in a two-column grid
+with live/status cues when available.
 
 Header behavior:
 


### PR DESCRIPTION
# Summary
This PR adds visual discovery content cards to the Media Hub for both Music and TV.
Goal: close issue #427 with a low-risk discovery upgrade built on the existing unified media model.

Core outcome:
- adds visual cards with artwork, live/status badges, tags, and optional viewer counts
- uses a horizontal carousel for Music and a two-column grid for TV

# Changes
### Code
- Added:
  - `MediaContentCard` with image/placeholder, live badge, tag pill, viewer count, and skeleton state
  - `ContentCarousel` for horizontal music discovery cards
  - `ContentGrid` for two-column TV discovery cards
- Updated:
  - Media Hub screen to render discovery cards from the existing unified discovery provider
  - Media Hub tests and wiki navigation notes

### Logic
- preserves the current Music/IPTV route bodies below the new discovery layer
- uses the existing discovery provider for unified content mapping and load-more behavior
- adds recent-play tracking when a discovery card is opened

# API Changes (if any)
- None

# Database Changes (if any)
- None

# Observability / Logging
- None

# Performance Impact
- Latency: negligible
- Throughput: none
- Memory/CPU: small additional UI cost for discovery card rendering

# Risks
- discovery cards are additive, so duplicate browsing surfaces remain for now
- rollback plan:
  - revert this PR

# Testing
- Unit tests:
  - updated Media Hub screen helper coverage
- Widget tests:
  - added card metadata/skeleton coverage
  - added carousel and grid layout coverage
- Manual testing:
  - not run

# Deployment Notes
- Config changes:
  - none
- Order of deployment:
  - normal

# Related Commits
- feat(media-hub): add discovery content cards

# Notes
- Closes #427