### PR TITLE
fix(android): avoid cached audio engine crash

### DIFF
--- a/app/android/app/src/androidTest/java/io/airo/app/MainActivityStartupContractTest.java
+++ b/app/android/app/src/androidTest/java/io/airo/app/MainActivityStartupContractTest.java
@@ -1,0 +1,28 @@
+package io.airo.app;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+import com.ryanheise.audioservice.AudioServiceActivity;
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import org.junit.Test;
+
+public class MainActivityStartupContractTest {
+    @Test
+    public void mainActivityUsesAudioServiceActivityBaseClass() {
+        assertEquals(AudioServiceActivity.class, MainActivity.class.getSuperclass());
+    }
+
+    @Test
+    public void mainActivityDoesNotOverrideCachedEngineLookup() {
+        boolean overridesCachedEngineId =
+                Arrays.stream(MainActivity.class.getDeclaredMethods())
+                        .map(Method::getName)
+                        .anyMatch("getCachedEngineId"::equals);
+
+        assertFalse(
+                "MainActivity must not hardcode a cached Flutter engine id on cold start.",
+                overridesCachedEngineId);
+    }
+}

--- a/app/android/app/src/main/kotlin/io/airo/app/MainActivity.kt
+++ b/app/android/app/src/main/kotlin/io/airo/app/MainActivity.kt
@@ -3,15 +3,12 @@ package io.airo.app
 import android.Manifest
 import android.content.ContentUris
 import android.content.ContentValues
-import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
 import android.net.Uri
 import android.provider.CalendarContract
 import android.provider.Settings
 import com.ryanheise.audioservice.AudioServiceActivity
-import com.ryanheise.audioservice.AudioServicePlugin
-import io.flutter.embedding.engine.FlutterEngine
 import io.flutter.plugin.common.EventChannel
 import io.flutter.plugin.common.MethodChannel
 import java.text.SimpleDateFormat
@@ -32,14 +29,6 @@ class MainActivity : AudioServiceActivity() {
     private var pendingCalendarEndDate: String? = null
     private var pendingCalendarCreateResult: MethodChannel.Result? = null
     private var pendingCalendarCreateArguments: Map<String, Any?>? = null
-
-    override fun provideFlutterEngine(context: Context): FlutterEngine {
-        return AudioServicePlugin.getFlutterEngine(context)
-    }
-
-    override fun getCachedEngineId(): String {
-        return AudioServicePlugin.getFlutterEngineId()
-    }
 
     override fun shouldDestroyEngineWithHost(): Boolean {
         return false


### PR DESCRIPTION
# Summary
This PR fixes the Android cold-start crash caused by forcing `MainActivity` to request a cached `audio_service_engine` before it exists.
Goal: close issue #469 by letting the shared audio engine contract create or reuse the engine safely on startup.

Core outcome:
- removes the hard cached-engine lookup from `MainActivity`
- keeps shared audio engine ownership with `audio_service` while avoiding the cold-start cache miss

# Changes
### Code
- Updated:
  - `MainActivity` to stop overriding `getCachedEngineId()` and the redundant `provideFlutterEngine()` path
- Added:
  - Android startup contract test to guard against reintroducing a hard cached-engine lookup

### Logic
- relies on `AudioServiceActivity`'s built-in `provideFlutterEngine()` implementation
- preserves `shouldDestroyEngineWithHost = false` so the shared engine remains activity-independent

# API Changes (if any)
- None

# Database Changes (if any)
- None

# Observability / Logging
- None

# Performance Impact
- Latency: none expected beyond normal cold-start engine creation
- Throughput: none
- Memory/CPU: unchanged shared engine model

# Risks
- audio service startup still depends on the upstream plugin contract remaining stable
- rollback plan:
  - revert this PR

# Testing
- Android regression coverage:
  - added `MainActivityStartupContractTest` for the engine contract
- Manual/local verification:
  - source diff verified against `audio_service` plugin contract
  - `flutter build apk --debug -t lib/main.dart` was blocked locally by missing `app/android/app/google-services.json`, not by Kotlin compilation errors from this change

# Deployment Notes
- Config changes:
  - none
- Order of deployment:
  - normal

# Related Commits
- fix(android): avoid cached audio engine crash

# Notes
- Closes #469