### PR TITLE
chore: align flutter sdk baseline

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -16,7 +16,7 @@ on:
         type: boolean
 
 env:
-  FLUTTER_VERSION: '3.41.4'
+  FLUTTER_VERSION: '3.44.4'
 
 jobs:
   # ============================================

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  FLUTTER_VERSION: '3.41.4'
+  FLUTTER_VERSION: '3.44.4'
 
 jobs:
   # ============================================

--- a/.github/workflows/local-checks.yml
+++ b/.github/workflows/local-checks.yml
@@ -19,7 +19,7 @@ on:
   # Can also be triggered manually via act
 
 env:
-  FLUTTER_VERSION: '3.41.4'
+  FLUTTER_VERSION: '3.44.4'
 
 jobs:
   local-checks:

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -17,7 +17,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  FLUTTER_VERSION: '3.41.4'
+  FLUTTER_VERSION: '3.44.4'
 
 jobs:
   # ============================================

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Setup Flutter
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: '3.41.4'
+          flutter-version: '3.44.4'
           channel: 'stable'
 
       - name: Get dependencies
@@ -91,7 +91,7 @@ jobs:
       - name: Setup Flutter
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: '3.41.4'
+          flutter-version: '3.44.4'
           channel: 'stable'
       
       - name: Get dependencies

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 # Cross-platform build and development automation
 
 # Variables
-FLUTTER_VERSION := 3.41.4
+FLUTTER_VERSION := 3.44.4
 APP_DIR := app
 ANDROID_DIR := $(APP_DIR)/android
 IOS_DIR := $(APP_DIR)/ios

--- a/app/pubspec_ios_spm.yaml
+++ b/app/pubspec_ios_spm.yaml
@@ -8,8 +8,8 @@ publish_to: 'none'
 version: 1.0.0+1
 
 environment:
-  sdk: ">=3.11.1 <4.0.0"
-  flutter: ">=3.41.4"
+  sdk: ">=3.12.2 <4.0.0"
+  flutter: ">=3.44.4"
 
 dependencies:
   flutter:

--- a/app/pubspec_streaming.yaml
+++ b/app/pubspec_streaming.yaml
@@ -14,8 +14,8 @@ publish_to: 'none'
 version: 1.0.0+1
 
 environment:
-  sdk: ">=3.11.1 <4.0.0"
-  flutter: ">=3.41.4"
+  sdk: ">=3.12.2 <4.0.0"
+  flutter: ">=3.44.4"
 
 dependencies:
   flutter:

--- a/app/pubspec_tv.yaml
+++ b/app/pubspec_tv.yaml
@@ -14,8 +14,8 @@ publish_to: 'none'
 version: 1.0.0+1
 
 environment:
-  sdk: ">=3.11.1 <4.0.0"
-  flutter: ">=3.41.4"
+  sdk: ">=3.12.2 <4.0.0"
+  flutter: ">=3.44.4"
 
 dependencies:
   flutter:

--- a/docs/DEPENDENCY_UPDATE_RUNBOOK.md
+++ b/docs/DEPENDENCY_UPDATE_RUNBOOK.md
@@ -72,7 +72,7 @@ grep "flutter:" app/pubspec.yaml
 flutter upgrade
 
 # Or install specific version
-git clone https://github.com/flutter/flutter.git -b 3.35.7
+git clone https://github.com/flutter/flutter.git -b 3.44.4
 
 # Verify version
 flutter --version
@@ -82,16 +82,17 @@ flutter doctor -v
 ### 3. Update Project Configuration
 
 **Files to update:**
-- `Makefile` (line 5)
-- `.github/workflows/ci.yml` (line 21)
-- `.github/workflows/build-and-release.yml` (line 19)
-- `.github/workflows/pr-checks.yml` (line 20)
-- `.github/workflows/smoke-tests.yml` (line 64, 96)
-- `.github/workflows/local-checks.yml` (line 22)
+- `Makefile` (Flutter baseline for local commands)
+- `.github/workflows/ci.yml`
+- `.github/workflows/build-and-release.yml`
+- `.github/workflows/pr-checks.yml`
+- `.github/workflows/smoke-tests.yml`
+- `.github/workflows/local-checks.yml`
+- alternate app pubspec entry points such as `app/pubspec_ios_spm.yaml`
 
 ```bash
 # Use sed to update all at once (Linux/macOS)
-NEW_VERSION="3.35.7"
+NEW_VERSION="3.44.4"
 find .github/workflows -name "*.yml" -exec sed -i "s/FLUTTER_VERSION: '[0-9.]*'/FLUTTER_VERSION: '$NEW_VERSION'/g" {} \;
 sed -i "s/FLUTTER_VERSION := [0-9.]*/FLUTTER_VERSION := $NEW_VERSION/" Makefile
 ```
@@ -119,8 +120,8 @@ make build-web
 
 ```yaml
 environment:
-  sdk: ">=3.9.2 <4.0.0"  # Explicit range
-  flutter: ">=3.35.7"     # Minimum Flutter version
+  sdk: ">=3.12.2 <4.0.0"  # Explicit range
+  flutter: ">=3.44.4"     # Minimum Flutter version
 ```
 
 ---
@@ -422,7 +423,7 @@ grep -r "uses:" .github/workflows/
 # Setup Flutter
 - uses: subosito/flutter-action@v2
   with:
-    flutter-version: '3.35.7'
+    flutter-version: '3.44.4'
     channel: 'stable'
     cache: true
 
@@ -694,5 +695,3 @@ flutter pub deps --style=tree
 For questions or issues, contact:
 - Tech Lead: @ucguy4u
 - DevOps Team: TBD
-
-

--- a/docs/superpowers/plans/2026-06-29-flutter-sdk-baseline-alignment.md
+++ b/docs/superpowers/plans/2026-06-29-flutter-sdk-baseline-alignment.md
@@ -1,0 +1,36 @@
+# Flutter SDK Baseline Alignment
+
+## Critical Agent Gate
+
+**Problem:** The workspace packages already require Flutter `>=3.44.4` and Dart `>=3.12.2`, but several build entry points still declare Flutter `3.41.4` and Dart `3.11.1`, creating a mismatched local/CI contract.
+**User / actor:** Release and DevEx maintainers, CI runners, local contributors.
+**Framework or application layer:** Framework/build infrastructure.
+**Owning agent:** Release and DevEx Agent.
+**Reviewing agents:** Framework Agent, QA Automation Agent.
+**Impacted modules/files:** `Makefile`, `.github/workflows/*`, `scripts/check-versions.sh`, `app/pubspec_streaming.yaml`, `app/pubspec_tv.yaml`, `app/pubspec_ios_spm.yaml`, `docs/DEPENDENCY_UPDATE_RUNBOOK.md`.
+**Base branch/worktree:** confirmed from latest `origin/main`: yes (`e8096cbf670d418cab2c43115b1f0ca9049da112` at worktree creation).
+**Open questions:** None for this alignment pass; no runtime behavior or public API changes are planned.
+**Decision:** Ready
+
+## Cross-Agent Contract
+
+**Provider agent:** Release and DevEx Agent
+**Consumer agent:** Framework Agent and app/package maintainers
+**Interface/API:** Repository-wide SDK/toolchain baseline declarations
+**Input shape:** Declared Flutter and Dart minimum versions in workflow env, local tooling, and alternate pubspec entry points
+**Output shape:** Consistent Flutter `3.44.4` and Dart `>=3.12.2 <4.0.0` declarations across supported entry points
+**State changes:** Tooling metadata only; no product runtime behavior changes
+**Errors:** Version guard script should fail when a file drifts from the baseline
+**Permissions:** None beyond repository file edits
+
+## Deterministic Use Cases
+
+1. A CI job using the declared Flutter version can resolve workspace dependencies without conflicting with package-level Flutter constraints.
+2. A developer using `make` sees the same Flutter baseline documented in the app README and enforced by the version check script.
+3. Alternate app pubspecs for iOS simulator, streaming, and TV builds resolve against the same Dart/Flutter baseline as `app/pubspec.yaml`.
+
+## Automation Flow
+
+1. Update all stale baseline declarations to the current workspace SDK versions.
+2. Run `bash scripts/check-versions.sh` and verify the baseline passes.
+3. Re-run host validations already used in this maintenance session: `flutter analyze` in `app`, plus representative core package tests.

--- a/packages/stubs/audio_service_stub/pubspec.lock
+++ b/packages/stubs/audio_service_stub/pubspec.lock
@@ -60,5 +60,5 @@ packages:
     source: hosted
     version: "2.2.0"
 sdks:
-  dart: ">=3.10.0-0 <4.0.0"
-  flutter: ">=3.35.7"
+  dart: ">=3.12.2 <4.0.0"
+  flutter: ">=3.44.4"

--- a/packages/stubs/audio_service_stub/pubspec.yaml
+++ b/packages/stubs/audio_service_stub/pubspec.yaml
@@ -4,8 +4,8 @@ version: 0.18.18
 publish_to: none
 
 environment:
-  sdk: '>=3.9.2 <4.0.0'
-  flutter: '>=3.35.7'
+  sdk: '>=3.12.2 <4.0.0'
+  flutter: '>=3.44.4'
 
 dependencies:
   flutter:

--- a/packages/stubs/audio_stubs/pubspec.lock
+++ b/packages/stubs/audio_stubs/pubspec.lock
@@ -52,5 +52,5 @@ packages:
     source: hosted
     version: "2.2.0"
 sdks:
-  dart: ">=3.10.0-0 <4.0.0"
-  flutter: ">=3.35.7"
+  dart: ">=3.12.2 <4.0.0"
+  flutter: ">=3.44.4"

--- a/packages/stubs/audio_stubs/pubspec.yaml
+++ b/packages/stubs/audio_stubs/pubspec.yaml
@@ -4,8 +4,8 @@ version: 0.0.1
 publish_to: none
 
 environment:
-  sdk: '>=3.9.2 <4.0.0'
-  flutter: '>=3.35.7'
+  sdk: '>=3.12.2 <4.0.0'
+  flutter: '>=3.44.4'
 
 dependencies:
   flutter:

--- a/packages/stubs/audioplayers_stub/pubspec.lock
+++ b/packages/stubs/audioplayers_stub/pubspec.lock
@@ -2,5 +2,5 @@
 # See https://dart.dev/tools/pub/glossary#lockfile
 packages: {}
 sdks:
-  dart: ">=3.9.2 <4.0.0"
-  flutter: ">=3.35.7"
+  dart: ">=3.12.2 <4.0.0"
+  flutter: ">=3.44.4"

--- a/packages/stubs/audioplayers_stub/pubspec.yaml
+++ b/packages/stubs/audioplayers_stub/pubspec.yaml
@@ -4,5 +4,5 @@ version: 6.5.1
 publish_to: none
 
 environment:
-  sdk: '>=3.9.2 <4.0.0'
-  flutter: '>=3.35.7'
+  sdk: '>=3.12.2 <4.0.0'
+  flutter: '>=3.44.4'

--- a/packages/stubs/chess_stub/pubspec.lock
+++ b/packages/stubs/chess_stub/pubspec.lock
@@ -2,5 +2,5 @@
 # See https://dart.dev/tools/pub/glossary#lockfile
 packages: {}
 sdks:
-  dart: ">=3.9.2 <4.0.0"
-  flutter: ">=3.35.7"
+  dart: ">=3.12.2 <4.0.0"
+  flutter: ">=3.44.4"

--- a/packages/stubs/chess_stub/pubspec.yaml
+++ b/packages/stubs/chess_stub/pubspec.yaml
@@ -4,5 +4,5 @@ version: 0.8.1
 publish_to: none
 
 environment:
-  sdk: '>=3.9.2 <4.0.0'
-  flutter: '>=3.35.7'
+  sdk: '>=3.12.2 <4.0.0'
+  flutter: '>=3.44.4'

--- a/packages/stubs/file_picker_stub/pubspec.lock
+++ b/packages/stubs/file_picker_stub/pubspec.lock
@@ -2,5 +2,5 @@
 # See https://dart.dev/tools/pub/glossary#lockfile
 packages: {}
 sdks:
-  dart: ">=3.9.2 <4.0.0"
-  flutter: ">=3.35.7"
+  dart: ">=3.12.2 <4.0.0"
+  flutter: ">=3.44.4"

--- a/packages/stubs/file_picker_stub/pubspec.yaml
+++ b/packages/stubs/file_picker_stub/pubspec.yaml
@@ -4,5 +4,5 @@ version: 10.3.10
 publish_to: none
 
 environment:
-  sdk: '>=3.9.2 <4.0.0'
-  flutter: '>=3.35.7'
+  sdk: '>=3.12.2 <4.0.0'
+  flutter: '>=3.44.4'

--- a/packages/stubs/flame_stub/pubspec.lock
+++ b/packages/stubs/flame_stub/pubspec.lock
@@ -52,5 +52,5 @@ packages:
     source: hosted
     version: "2.2.0"
 sdks:
-  dart: ">=3.10.0-0 <4.0.0"
-  flutter: ">=3.35.7"
+  dart: ">=3.12.2 <4.0.0"
+  flutter: ">=3.44.4"

--- a/packages/stubs/flame_stub/pubspec.yaml
+++ b/packages/stubs/flame_stub/pubspec.yaml
@@ -4,8 +4,8 @@ version: 1.35.0
 publish_to: none
 
 environment:
-  sdk: '>=3.9.2 <4.0.0'
-  flutter: '>=3.35.7'
+  sdk: '>=3.12.2 <4.0.0'
+  flutter: '>=3.44.4'
 
 dependencies:
   flutter:

--- a/packages/stubs/flutter_contacts_stub/pubspec.lock
+++ b/packages/stubs/flutter_contacts_stub/pubspec.lock
@@ -2,5 +2,5 @@
 # See https://dart.dev/tools/pub/glossary#lockfile
 packages: {}
 sdks:
-  dart: ">=3.9.2 <4.0.0"
-  flutter: ">=3.35.7"
+  dart: ">=3.12.2 <4.0.0"
+  flutter: ">=3.44.4"

--- a/packages/stubs/flutter_contacts_stub/pubspec.yaml
+++ b/packages/stubs/flutter_contacts_stub/pubspec.yaml
@@ -4,5 +4,5 @@ version: 1.1.9+2
 publish_to: none
 
 environment:
-  sdk: '>=3.9.2 <4.0.0'
-  flutter: '>=3.35.7'
+  sdk: '>=3.12.2 <4.0.0'
+  flutter: '>=3.44.4'

--- a/packages/stubs/flutter_image_compress_stub/pubspec.lock
+++ b/packages/stubs/flutter_image_compress_stub/pubspec.lock
@@ -2,5 +2,5 @@
 # See https://dart.dev/tools/pub/glossary#lockfile
 packages: {}
 sdks:
-  dart: ">=3.9.2 <4.0.0"
-  flutter: ">=3.35.7"
+  dart: ">=3.12.2 <4.0.0"
+  flutter: ">=3.44.4"

--- a/packages/stubs/flutter_image_compress_stub/pubspec.yaml
+++ b/packages/stubs/flutter_image_compress_stub/pubspec.yaml
@@ -4,5 +4,5 @@ version: 2.4.0
 publish_to: none
 
 environment:
-  sdk: '>=3.9.2 <4.0.0'
-  flutter: '>=3.35.7'
+  sdk: '>=3.12.2 <4.0.0'
+  flutter: '>=3.44.4'

--- a/packages/stubs/flutter_tts_stub/pubspec.lock
+++ b/packages/stubs/flutter_tts_stub/pubspec.lock
@@ -2,5 +2,5 @@
 # See https://dart.dev/tools/pub/glossary#lockfile
 packages: {}
 sdks:
-  dart: ">=3.9.2 <4.0.0"
-  flutter: ">=3.35.7"
+  dart: ">=3.12.2 <4.0.0"
+  flutter: ">=3.44.4"

--- a/packages/stubs/flutter_tts_stub/pubspec.yaml
+++ b/packages/stubs/flutter_tts_stub/pubspec.yaml
@@ -4,5 +4,5 @@ version: 4.2.5
 publish_to: none
 
 environment:
-  sdk: '>=3.9.2 <4.0.0'
-  flutter: '>=3.35.7'
+  sdk: '>=3.12.2 <4.0.0'
+  flutter: '>=3.44.4'

--- a/packages/stubs/image_picker_stub/pubspec.lock
+++ b/packages/stubs/image_picker_stub/pubspec.lock
@@ -2,5 +2,5 @@
 # See https://dart.dev/tools/pub/glossary#lockfile
 packages: {}
 sdks:
-  dart: ">=3.9.2 <4.0.0"
-  flutter: ">=3.35.7"
+  dart: ">=3.12.2 <4.0.0"
+  flutter: ">=3.44.4"

--- a/packages/stubs/image_picker_stub/pubspec.yaml
+++ b/packages/stubs/image_picker_stub/pubspec.yaml
@@ -4,5 +4,5 @@ version: 1.2.1
 publish_to: none
 
 environment:
-  sdk: '>=3.9.2 <4.0.0'
-  flutter: '>=3.35.7'
+  sdk: '>=3.12.2 <4.0.0'
+  flutter: '>=3.44.4'

--- a/packages/stubs/just_audio_stub/pubspec.lock
+++ b/packages/stubs/just_audio_stub/pubspec.lock
@@ -2,5 +2,5 @@
 # See https://dart.dev/tools/pub/glossary#lockfile
 packages: {}
 sdks:
-  dart: ">=3.9.2 <4.0.0"
-  flutter: ">=3.35.7"
+  dart: ">=3.12.2 <4.0.0"
+  flutter: ">=3.44.4"

--- a/packages/stubs/just_audio_stub/pubspec.yaml
+++ b/packages/stubs/just_audio_stub/pubspec.yaml
@@ -4,5 +4,5 @@ version: 0.10.5
 publish_to: none
 
 environment:
-  sdk: '>=3.9.2 <4.0.0'
-  flutter: '>=3.35.7'
+  sdk: '>=3.12.2 <4.0.0'
+  flutter: '>=3.44.4'

--- a/packages/stubs/mlkit_stub/pubspec.lock
+++ b/packages/stubs/mlkit_stub/pubspec.lock
@@ -2,5 +2,5 @@
 # See https://dart.dev/tools/pub/glossary#lockfile
 packages: {}
 sdks:
-  dart: ">=3.9.2 <4.0.0"
-  flutter: ">=3.35.7"
+  dart: ">=3.12.2 <4.0.0"
+  flutter: ">=3.44.4"

--- a/packages/stubs/mlkit_stub/pubspec.yaml
+++ b/packages/stubs/mlkit_stub/pubspec.yaml
@@ -4,5 +4,5 @@ version: 0.15.1
 publish_to: none
 
 environment:
-  sdk: '>=3.9.2 <4.0.0'
-  flutter: '>=3.35.7'
+  sdk: '>=3.12.2 <4.0.0'
+  flutter: '>=3.44.4'

--- a/packages/stubs/pdfx_stub/pubspec.lock
+++ b/packages/stubs/pdfx_stub/pubspec.lock
@@ -2,5 +2,5 @@
 # See https://dart.dev/tools/pub/glossary#lockfile
 packages: {}
 sdks:
-  dart: ">=3.9.2 <4.0.0"
-  flutter: ">=3.35.7"
+  dart: ">=3.12.2 <4.0.0"
+  flutter: ">=3.44.4"

--- a/packages/stubs/pdfx_stub/pubspec.yaml
+++ b/packages/stubs/pdfx_stub/pubspec.yaml
@@ -4,5 +4,5 @@ version: 2.9.2
 publish_to: none
 
 environment:
-  sdk: '>=3.9.2 <4.0.0'
-  flutter: '>=3.35.7'
+  sdk: '>=3.12.2 <4.0.0'
+  flutter: '>=3.44.4'

--- a/packages/stubs/permission_handler_stub/pubspec.lock
+++ b/packages/stubs/permission_handler_stub/pubspec.lock
@@ -2,5 +2,5 @@
 # See https://dart.dev/tools/pub/glossary#lockfile
 packages: {}
 sdks:
-  dart: ">=3.9.2 <4.0.0"
-  flutter: ">=3.35.7"
+  dart: ">=3.12.2 <4.0.0"
+  flutter: ">=3.44.4"

--- a/packages/stubs/permission_handler_stub/pubspec.yaml
+++ b/packages/stubs/permission_handler_stub/pubspec.yaml
@@ -4,5 +4,5 @@ version: 12.0.0+1
 publish_to: none
 
 environment:
-  sdk: '>=3.9.2 <4.0.0'
-  flutter: '>=3.35.7'
+  sdk: '>=3.12.2 <4.0.0'
+  flutter: '>=3.44.4'

--- a/packages/stubs/share_plus_stub/pubspec.lock
+++ b/packages/stubs/share_plus_stub/pubspec.lock
@@ -2,5 +2,5 @@
 # See https://dart.dev/tools/pub/glossary#lockfile
 packages: {}
 sdks:
-  dart: ">=3.9.2 <4.0.0"
-  flutter: ">=3.35.7"
+  dart: ">=3.12.2 <4.0.0"
+  flutter: ">=3.44.4"

--- a/packages/stubs/share_plus_stub/pubspec.yaml
+++ b/packages/stubs/share_plus_stub/pubspec.yaml
@@ -4,5 +4,5 @@ version: 10.1.4
 publish_to: none
 
 environment:
-  sdk: '>=3.9.2 <4.0.0'
-  flutter: '>=3.35.7'
+  sdk: '>=3.12.2 <4.0.0'
+  flutter: '>=3.44.4'

--- a/packages/stubs/stockfish_stub/pubspec.lock
+++ b/packages/stubs/stockfish_stub/pubspec.lock
@@ -2,5 +2,5 @@
 # See https://dart.dev/tools/pub/glossary#lockfile
 packages: {}
 sdks:
-  dart: ">=3.9.2 <4.0.0"
-  flutter: ">=3.35.7"
+  dart: ">=3.12.2 <4.0.0"
+  flutter: ">=3.44.4"

--- a/packages/stubs/stockfish_stub/pubspec.yaml
+++ b/packages/stubs/stockfish_stub/pubspec.yaml
@@ -4,5 +4,5 @@ version: 1.8.1
 publish_to: none
 
 environment:
-  sdk: '>=3.9.2 <4.0.0'
-  flutter: '>=3.35.7'
+  sdk: '>=3.12.2 <4.0.0'
+  flutter: '>=3.44.4'

--- a/packages/template_feature/pubspec.yaml
+++ b/packages/template_feature/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: none
 version: 0.0.1
 
 environment:
-  sdk: ^3.9.2
+  sdk: ">=3.12.2 <4.0.0"
   flutter: ">=3.44.4"
 
 dependencies:
@@ -19,7 +19,7 @@ dependencies:
   flutter_riverpod: ^3.3.2
   riverpod: ^3.3.2
 
-  meta: any
+  meta: ^1.16.0
 dev_dependencies:
   flutter_test:
     sdk: flutter

--- a/scripts/check-versions.sh
+++ b/scripts/check-versions.sh
@@ -21,8 +21,8 @@ BLUE='\033[0;34m'
 NC='\033[0m' # No Color
 
 # Expected versions (from the current repository baseline)
-EXPECTED_FLUTTER="3.41.4"
-EXPECTED_DART_MIN="3.11.1"
+EXPECTED_FLUTTER="3.44.4"
+EXPECTED_DART_MIN="3.12.2"
 EXPECTED_DART_MAX="4.0.0"
 
 # Counters


### PR DESCRIPTION
## Summary
- align the repository Flutter baseline to 3.44.4 across local tooling and CI workflows
- align alternate app entry-point pubspecs, stub packages, and the template package to Dart >=3.12.2 and Flutter >=3.44.4
- add the required agent-policy planning artifact and update the dependency update runbook to match the current baseline

## Root Cause
The workspace packages had already moved to Flutter 3.44.4 and Dart 3.12.2, but several build entry points still declared older SDK baselines. That drift made the repo advertise incompatible toolchains depending on whether contributors used CI, Make, or alternate pubspec variants.

## Validation
- `cd app && flutter analyze --no-fatal-infos --no-fatal-warnings`
- `cd packages/core_domain && flutter test --reporter=compact`
- `cd packages/core_ai && flutter test --reporter=compact`
- `cd packages/core_data && flutter test --reporter=compact`
- `bash scripts/check-versions.sh`

## Risks
- does not address the remaining warning-level dependency debt reported by `scripts/check-versions.sh`
- stub package lockfiles were refreshed to match the new SDK floor
