### PR TITLE
docs(community): improve contributor onboarding

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,64 @@
+# Code of Conduct
+
+## Our Standard
+
+We want Airo to be a place where contributors can discuss ideas, ship scoped
+work, and review each other rigorously without hostility.
+
+Examples of expected behavior:
+
+- Assume good intent and stay specific about technical concerns.
+- Challenge ideas with evidence, not people with contempt.
+- Keep feedback actionable and tied to code, docs, tests, or product behavior.
+- Respect repo policy, reviewer time, and user safety constraints.
+- Help newer contributors understand process instead of gatekeeping it.
+
+Examples of unacceptable behavior:
+
+- Harassment, insults, or personal attacks.
+- Dismissive or exclusionary language.
+- Deliberate misrepresentation of test results, source state, or review status.
+- Sharing private information without permission.
+- Spam, trolling, or repeated bad-faith derailment.
+
+## Scope
+
+This code of conduct applies in:
+
+- GitHub issues
+- pull requests
+- review comments
+- discussions tied to project collaboration
+
+## Enforcement
+
+Project maintainers may remove, edit, or reject contributions and comments that
+violate these standards.
+
+Possible maintainer actions include:
+
+- asking for behavior changes
+- locking or moderating a thread
+- closing a contribution that cannot proceed constructively
+- blocking repeat abusive behavior
+
+## Reporting
+
+If you experience or observe conduct problems, report them to project
+maintainers through a private GitHub maintainer contact path or an issue/PR
+thread when the matter is operational rather than personal.
+
+When reporting, include:
+
+- where the problem occurred
+- links or screenshots if relevant
+- what outcome you are seeking
+
+## Practical Review Norms
+
+For this repository specifically:
+
+- Be precise about blockers and risks.
+- State what you ran and what you did not run.
+- Do not claim a feature works without evidence.
+- Do not pressure reviewers to merge unclear or unverified changes.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,138 @@
+# Contributing to Airo
+
+This repository expects scoped, verifiable contributions. The goal is fast
+review, low surprise, and clean work stacked on the latest `origin/main`.
+
+## Before You Start
+
+Read these first:
+
+- [README.md](README.md)
+- [AGENTS.md](AGENTS.md)
+- [docs/agents/AGENT_POLICY.md](docs/agents/AGENT_POLICY.md)
+- [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)
+
+Pick an issue before writing code. Prefer tickets that already include:
+
+- a completed Critical Agent Gate
+- owning agent and impacted modules
+- deterministic use cases and automation notes
+
+If those artifacts are missing, add them to the issue first.
+
+## Create a Fresh Worktree
+
+Every new task must start from the latest `origin/main`.
+
+```bash
+git fetch origin main
+git worktree add ../airo-my-task -b codex/my-task origin/main
+cd ../airo-my-task
+```
+
+Do not branch from a stale local checkout or an older worktree snapshot.
+
+## Local Setup
+
+Use the repository `Makefile` where possible:
+
+```bash
+make setup
+make analyze
+make test
+```
+
+For narrower work, run the smallest honest verification that matches the
+change. Examples:
+
+```bash
+make analyze
+make test
+flutter test path/to/specific_test.dart
+```
+
+If something is blocked by local environment state, report the exact blocker in
+the PR. Example: missing signing files, missing `google-services.json`, or
+device-only prerequisites.
+
+## Contribution Types
+
+### Code changes
+
+- Keep changes scoped to one issue or one concern.
+- Respect framework/application boundaries from `AGENTS.md`.
+- Do not invent APIs, product behavior, or migration steps not grounded in the
+  issue or codebase.
+- Update docs/wiki when user-facing behavior changes.
+
+### Docs-only changes
+
+Docs-only contributors do not need to run the full app matrix. At minimum, run
+host-only checks:
+
+```bash
+test -f README.md
+test -f CONTRIBUTING.md
+test -f CODE_OF_CONDUCT.md
+rg "make setup|make analyze|make test|git worktree|pull request" README.md CONTRIBUTING.md
+```
+
+Then do a quick placeholder scan over the edited docs and confirm no unfinished
+markers remain.
+
+### Native or platform work
+
+- Keep Android/iOS changes narrow and reproducible.
+- Prefer targeted verification over broad claims.
+- If local platform builds are blocked by unrelated machine setup, say so
+  explicitly in the PR.
+
+## Pull Request Checklist
+
+Before opening a PR:
+
+1. Link the issue.
+2. Rebase or restack on the latest `origin/main` if needed.
+3. Run the narrowest honest verification.
+4. Update docs if behavior changed.
+5. Fill out the PR template with summary, risks, testing, and notes for
+   reviewers.
+
+Maintainers will look for:
+
+- issue linkage
+- Critical Agent Gate presence
+- verification evidence
+- correct scope discipline
+- docs impact when applicable
+
+## First Contributions
+
+Good first contribution categories in this repo:
+
+- docs/wiki clarity fixes
+- contributor tooling and repo hygiene
+- scoped widget or test fixes with deterministic validation
+- policy/completeness gaps called out by CI
+
+Avoid starting with broad architecture or multi-module runtime issues unless
+the issue already has a clear contract and verification plan.
+
+## Secrets and Release Materials
+
+Never commit:
+
+- keystores
+- `key.properties`
+- signing secrets
+- personal tokens
+- generated credentials
+
+If a task depends on release secrets or store assets, document the blocker
+instead of fabricating a local workaround.
+
+## License Status
+
+The repository currently does not include a root `LICENSE` file. Do not invent
+license terms in docs or PRs. If contribution or redistribution questions
+depend on licensing, ask maintainers in the linked issue or PR thread.

--- a/README.md
+++ b/README.md
@@ -2,10 +2,62 @@
 
 [![Download APK](https://img.shields.io/github/v/release/DevelopersCoffee/airo?label=Download%20APK&color=success)](https://github.com/DevelopersCoffee/airo/releases/latest/download/app-release.apk)
 [![GitHub Release](https://img.shields.io/github/v/release/DevelopersCoffee/airo)](https://github.com/DevelopersCoffee/airo/releases)
-[![License](https://img.shields.io/github/license/DevelopersCoffee/airo)](LICENSE)
 [![Flutter](https://img.shields.io/badge/Flutter-3.44.4+-blue.svg)](https://flutter.dev/)
 
-A Flutter-based super app combining AI-powered features and financial management tools.
+Airo is a local-first Flutter app exploring an on-device "LLM OS" direction:
+AI chat, media workflows, finance tooling, routines, and native mobile
+capabilities in one repo.
+
+This repository is meant to be understandable by contributors, not only end
+users downloading a release build.
+
+## Open Source Contributor Start
+
+- Contribution guide: [CONTRIBUTING.md](CONTRIBUTING.md)
+- Community standards: [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)
+- Agent workflow policy: [AGENTS.md](AGENTS.md)
+- User and operator docs: [docs/wiki/README.md](docs/wiki/README.md)
+- Scoped engineering tickets: [.github/issues](.github/issues)
+
+Why developers care:
+
+- The repo mixes Flutter UI, native Android/iOS integration, Riverpod state,
+  and deterministic repo policy around issues, contracts, and tests.
+- Airo is intentionally local-first, so on-device constraints and privacy
+  boundaries matter in real implementation work.
+- Many tasks are already decomposed into scoped tickets that can be landed
+  independently from fresh worktrees.
+
+Quick contributor bootstrap:
+
+```bash
+git fetch origin main
+git worktree add ../airo-my-task -b codex/my-task origin/main
+cd ../airo-my-task
+make setup
+make analyze
+make test
+```
+
+Before writing code, confirm the linked issue has a Critical Agent Gate and any
+required Feature Packet content. If it does not, add that policy context first.
+
+## Contribution Paths
+
+- Docs and onboarding: improve README, wiki pages, setup instructions, or
+  release/developer guidance.
+- Focused product work: pick a scoped issue with ownership and deterministic
+  verification already described.
+- Native/runtime fixes: keep the change narrow, report exact validation, and
+  avoid cross-boundary edits without the required contract.
+
+## Pull Request Expectations
+
+- Link the issue being addressed.
+- Start from the latest `origin/main` in a fresh branch or worktree.
+- Run the narrowest honest verification locally and report what was blocked.
+- Update docs/wiki when user-facing behavior changes.
+- Use the existing PR template and keep the branch scoped to one concern.
 
 ## 📥 Download
 
@@ -50,6 +102,19 @@ make run-chrome     # Chrome browser specifically
 make run-pixel9     # Optimized for Pixel 9
 make run-iphone13   # iPhone 13 Pro Max simulator
 ```
+
+## Contributor Workflow
+
+1. Choose an issue with clear scope.
+2. Create a fresh worktree from `origin/main`.
+3. Run `make setup`, then relevant verification such as `make analyze` and
+   `make test`.
+4. Follow [AGENTS.md](AGENTS.md) for Critical Agent Gate and cross-agent policy
+   requirements.
+5. Open a PR with summary, risks, verification, and docs impact.
+
+For the complete process, including docs-only contributions and maintainer
+expectations, see [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## 📱 Platform Support
 


### PR DESCRIPTION
# Summary
This PR improves Airo's GitHub-facing contributor surface so new developers can understand the project, choose work, and prepare a scoped PR faster.
Goal: close issue #475 with documentation-only onboarding improvements.

Core outcome:
- README now includes a contributor-first project framing and worktree-based contribution funnel
- root community files define contribution flow and community standards

# Changes
### Code
- Added:
  - `CONTRIBUTING.md`
  - `CODE_OF_CONDUCT.md`
- Updated:
  - `README.md` to be contributor-first rather than release-only

### Logic
- aligns contributor docs with existing `AGENTS.md` policy and `Makefile` commands
- avoids inventing a project license while explicitly noting that the root `LICENSE` file is currently absent
- keeps verification host-only and deterministic for docs work

# API Changes (if any)
- None

# Database Changes (if any)
- None

# Observability / Logging
- None

# Performance Impact
- None

# Risks
- README is now more contributor-oriented, which changes the first impression for casual release visitors
- rollback plan:
  - revert this PR

# Testing
- Host-only docs checks:
  - verified `README.md`, `CONTRIBUTING.md`, and `CODE_OF_CONDUCT.md` exist
  - verified contributor command discoverability via repo text search
  - verified no unfinished placeholder markers remain in the new community docs
- Manual review:
  - reviewed the README first-screen contributor funnel against the issue goals

# Deployment Notes
- Config changes:
  - none
- Order of deployment:
  - normal

# Related Commits
- docs(community): improve contributor onboarding

# Notes
- Closes #475