### PR TITLE
fix(agent-chat): surface model memory compatibility

### DIFF
--- a/app/lib/features/agent_chat/presentation/screens/model_library_screen.dart
+++ b/app/lib/features/agent_chat/presentation/screens/model_library_screen.dart
@@ -161,6 +161,10 @@ class AssistantModelLibraryState {
     final balancedPackage = defaultPackages[AssistantTask.reasoning];
     final hasDownloadedBalancedPackage = balancedPackage?.isDownloaded ?? false;
     final liteRtReady = liteRtAvailable || hasDownloadedBalancedPackage;
+    final compatibilityByModelId = await _loadCompatibilityByModelId(
+      liteRtService,
+      defaultPackages,
+    );
 
     final platformLabel = kIsWeb
         ? 'Web'
@@ -224,6 +228,9 @@ class AssistantModelLibraryState {
         local: true,
         opensModelManager: !liteRtReady,
         package: balancedPackage,
+        compatibility: balancedPackage == null
+            ? null
+            : compatibilityByModelId[balancedPackage.id],
       ),
     );
     addCandidate(
@@ -253,6 +260,7 @@ class AssistantModelLibraryState {
       addCandidate(
         AssistantModelCandidate.fromOfflineModel(
           await liteRtService.hydrateDownloadedModel(model),
+          compatibilityByModelId: compatibilityByModelId,
         ),
       );
     }
@@ -263,7 +271,12 @@ class AssistantModelLibraryState {
     ]) {
       final model = defaultPackages[task];
       if (model != null) {
-        addCandidate(AssistantModelCandidate.fromOfflineModel(model));
+        addCandidate(
+          AssistantModelCandidate.fromOfflineModel(
+            model,
+            compatibilityByModelId: compatibilityByModelId,
+          ),
+        );
       }
     }
     final candidates = candidatesById.values.toList();
@@ -380,6 +393,34 @@ class AssistantModelLibraryState {
       AssistantTask.actions: functionGemma,
     };
   }
+
+  static Future<Map<String, ModelCompatibilityResult>>
+  _loadCompatibilityByModelId(
+    LiteRtLmService liteRtService,
+    Map<AssistantTask, OfflineModelInfo> defaultPackages,
+  ) async {
+    final registry = ModelRegistry();
+    final modelsById = <String, OfflineModelInfo>{};
+
+    void addModel(OfflineModelInfo model) {
+      modelsById[model.id] = model;
+    }
+
+    for (final model in defaultPackages.values) {
+      addModel(model);
+    }
+    for (final model in ModelCatalog.mobileRecommended.take(3)) {
+      addModel(await liteRtService.hydrateDownloadedModel(model));
+    }
+
+    final compatibilityByModelId = <String, ModelCompatibilityResult>{};
+    for (final entry in modelsById.entries) {
+      compatibilityByModelId[entry.key] = await registry.checkCompatibility(
+        entry.value,
+      );
+    }
+    return compatibilityByModelId;
+  }
 }
 
 class AssistantModelCandidate {
@@ -398,9 +439,13 @@ class AssistantModelCandidate {
     this.unavailableReason,
     this.opensModelManager = false,
     this.package,
+    this.compatibility,
   });
 
-  factory AssistantModelCandidate.fromOfflineModel(OfflineModelInfo model) {
+  factory AssistantModelCandidate.fromOfflineModel(
+    OfflineModelInfo model, {
+    Map<String, ModelCompatibilityResult> compatibilityByModelId = const {},
+  }) {
     return AssistantModelCandidate(
       id: assistantModelIdForOfflineModel(model.id),
       name: model.name,
@@ -424,6 +469,7 @@ class AssistantModelCandidate {
       local: true,
       opensModelManager: !model.isDownloaded,
       package: model,
+      compatibility: compatibilityByModelId[model.id],
     );
   }
 
@@ -441,6 +487,7 @@ class AssistantModelCandidate {
   final String? unavailableReason;
   final bool opensModelManager;
   final OfflineModelInfo? package;
+  final ModelCompatibilityResult? compatibility;
 
   int scoreFor(AssistantTask task) {
     var score = 0;
@@ -1047,6 +1094,10 @@ class _ProjectTemplateCard extends StatelessWidget {
                   _StatusPill(label: tag, color: Colors.grey.shade700),
               ],
             ),
+            if (candidate.local && candidate.compatibility != null) ...[
+              const SizedBox(height: 12),
+              _CompatibilityPanel(compatibility: candidate.compatibility!),
+            ],
             if (candidate.unavailableReason != null) ...[
               const SizedBox(height: 10),
               Text(
@@ -1089,6 +1140,81 @@ class _ProjectTemplateCard extends StatelessWidget {
         ),
       ),
     );
+  }
+}
+
+class _CompatibilityPanel extends StatelessWidget {
+  const _CompatibilityPanel({required this.compatibility});
+
+  final ModelCompatibilityResult compatibility;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final severity = compatibility.memorySeverity;
+    final color = switch (severity) {
+      MemorySeverity.safe => Colors.green.shade700,
+      MemorySeverity.warning => Colors.orange.shade700,
+      MemorySeverity.critical => Colors.deepOrange.shade700,
+      MemorySeverity.blocked => theme.colorScheme.error,
+    };
+    final detail = compatibility.reason ?? severity.description;
+    final memoryLine =
+        compatibility.availableMemoryMB > 0 &&
+            compatibility.requiredMemoryMB > 0
+        ? 'Needs ${compatibility.requiredMemoryMB.toStringAsFixed(0)} MB, '
+              'device has ${compatibility.availableMemoryMB.toStringAsFixed(0)} MB free.'
+        : 'Device memory estimate unavailable. Runtime checks will verify before launch.';
+
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        color: color.withValues(alpha: 0.08),
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(color: color.withValues(alpha: 0.3)),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.all(10),
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Icon(_iconFor(severity), color: color, size: 18),
+            const SizedBox(width: 8),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    'Device fit: ${severity.title}',
+                    style: theme.textTheme.labelLarge?.copyWith(
+                      color: color,
+                      fontWeight: FontWeight.w700,
+                    ),
+                  ),
+                  const SizedBox(height: 4),
+                  Text(detail, style: theme.textTheme.bodySmall),
+                  const SizedBox(height: 4),
+                  Text(
+                    memoryLine,
+                    style: theme.textTheme.bodySmall?.copyWith(
+                      color: theme.colorScheme.onSurfaceVariant,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  IconData _iconFor(MemorySeverity severity) {
+    return switch (severity) {
+      MemorySeverity.safe => Icons.verified_outlined,
+      MemorySeverity.warning => Icons.warning_amber_rounded,
+      MemorySeverity.critical => Icons.report_problem_outlined,
+      MemorySeverity.blocked => Icons.block_outlined,
+    };
   }
 }
 

--- a/app/test/features/agent_chat/presentation/screens/model_library_screen_test.dart
+++ b/app/test/features/agent_chat/presentation/screens/model_library_screen_test.dart
@@ -153,6 +153,143 @@ void main() {
     expect(find.text('Download package'), findsWidgets);
     expect(tester.takeException(), isNull);
   });
+
+  testWidgets('shows safe device-fit details for local packages', (
+    tester,
+  ) async {
+    SharedPreferences.setMockInitialValues({});
+
+    final package = OfflineModelInfo(
+      id: 'gemma-4-e2b-it-litertlm',
+      name: 'Gemma 4 E2B',
+      family: ModelFamily.gemma,
+      fileSizeBytes: 2 * 1024 * 1024 * 1024,
+      backendPreference: ModelBackendPreference.gpu,
+      provider: AIProvider.gemma,
+      capabilities: const [ModelCapability.chat],
+      filePath: '/models/gemma-4-e2b-it.litertlm',
+    );
+    final candidate = AssistantModelCandidate(
+      id: litertGemmaAssistantModelId,
+      name: 'Gemma mobile package',
+      runtime: 'LiteRT-LM local model',
+      description: 'Local package',
+      bestFor: const [AssistantTask.chat],
+      tags: const ['Local'],
+      privacyLabel: 'Prompt stays on device',
+      sizeLabel: package.fileSizeDisplay,
+      available: true,
+      actionLabel: 'Start',
+      local: true,
+      package: package,
+      compatibility: const ModelCompatibilityResult(
+        isCompatible: true,
+        memorySeverity: MemorySeverity.safe,
+        availableMemoryMB: 6144,
+        requiredMemoryMB: 2048,
+      ),
+    );
+    final state = AssistantModelLibraryState(
+      task: AssistantTask.chat,
+      deviceLabel: 'Pixel 9',
+      platformLabel: 'ANDROID',
+      candidates: [candidate],
+      recommended: candidate,
+      defaultPackages: {AssistantTask.chat: package},
+    );
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          assistantModelLibraryProvider.overrideWith((ref) async => state),
+          selectedAssistantModelIdProvider.overrideWith(
+            (ref) => _SelectedAssistantModelNotifier(),
+          ),
+        ],
+        child: MaterialApp(
+          home: ModelLibraryScreen(
+            onModelSelected: (_) {},
+            onOpenModelManager: () {},
+          ),
+        ),
+      ),
+    );
+
+    await tester.pumpAndSettle();
+
+    expect(find.text('Device fit: Safe to load'), findsWidgets);
+    expect(find.text('Plenty of memory available'), findsWidgets);
+    expect(find.text('Needs 2048 MB, device has 6144 MB free.'), findsWidgets);
+  });
+
+  testWidgets('shows blocked device-fit details for incompatible packages', (
+    tester,
+  ) async {
+    SharedPreferences.setMockInitialValues({});
+
+    final package = OfflineModelInfo(
+      id: 'gemma-4-e2b-it-litertlm',
+      name: 'Gemma 4 E2B',
+      family: ModelFamily.gemma,
+      fileSizeBytes: 2 * 1024 * 1024 * 1024,
+      backendPreference: ModelBackendPreference.gpu,
+      provider: AIProvider.gemma,
+      capabilities: const [ModelCapability.chat],
+    );
+    final candidate = AssistantModelCandidate(
+      id: litertGemmaAssistantModelId,
+      name: 'Gemma mobile package',
+      runtime: 'LiteRT-LM local model',
+      description: 'Local package',
+      bestFor: const [AssistantTask.chat],
+      tags: const ['Local'],
+      privacyLabel: 'Prompt stays on device',
+      sizeLabel: package.fileSizeDisplay,
+      available: false,
+      actionLabel: 'Download package',
+      local: true,
+      opensModelManager: true,
+      package: package,
+      compatibility: const ModelCompatibilityResult(
+        isCompatible: false,
+        memorySeverity: MemorySeverity.blocked,
+        reason: 'Insufficient memory.',
+        availableMemoryMB: 1024,
+        requiredMemoryMB: 4096,
+      ),
+    );
+    final state = AssistantModelLibraryState(
+      task: AssistantTask.chat,
+      deviceLabel: 'Small Phone',
+      platformLabel: 'ANDROID',
+      candidates: [candidate],
+      recommended: candidate,
+      defaultPackages: {AssistantTask.chat: package},
+    );
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          assistantModelLibraryProvider.overrideWith((ref) async => state),
+          selectedAssistantModelIdProvider.overrideWith(
+            (ref) => _SelectedAssistantModelNotifier(),
+          ),
+        ],
+        child: MaterialApp(
+          home: ModelLibraryScreen(
+            onModelSelected: (_) {},
+            onOpenModelManager: () {},
+          ),
+        ),
+      ),
+    );
+
+    await tester.pumpAndSettle();
+
+    expect(find.text('Device fit: Cannot load'), findsWidgets);
+    expect(find.text('Insufficient memory.'), findsWidgets);
+    expect(find.text('Needs 4096 MB, device has 1024 MB free.'), findsWidgets);
+  });
 }
 
 class _SelectedAssistantModelNotifier extends SelectedAssistantModelNotifier {


### PR DESCRIPTION
# PR Title
fix(agent-chat): surface model memory compatibility

---

# Summary

This PR introduces changes to the Brain model library flow.
Goal: expose the existing memory-budget compatibility checks before users try to launch a local model.

Core outcome:

* local model cards now show a device-fit panel using `ModelCompatibilityResult`
* users can see safe / caution / blocked memory states before runtime launch

---

# Changes

### Code

* Added:
  * compatibility loading for offline candidates during model-library state hydration
  * local model compatibility panel in the model library UI
* Updated:
  * `app/lib/features/agent_chat/presentation/screens/model_library_screen.dart`
  * `app/test/features/agent_chat/presentation/screens/model_library_screen_test.dart`

### Logic

* reuses `core_ai` registry compatibility checks instead of duplicating memory rules in UI
* degrades gracefully when only an unknown/warning memory estimate is available
* keeps runtime-level blocked-path checks unchanged as the enforcement layer

---

# API Changes (if any)

* None.

---

# Database Changes (if any)

* None.

---

# Observability / Logging

* None.

---

# Performance Impact

* Latency: minor extra async compatibility checks during model-library loading
* Throughput: none
* Memory/CPU: negligible for this screen

---

# Risks

* model cards may show repeated compatibility messaging when the same recommended package is reused across multiple project templates
* compatibility remains advisory in UI; runtime blocking still owns final enforcement
* Rollback plan:
  * revert this PR to remove the UI panel while keeping existing runtime protection intact

---

# Testing

* Unit tests:
  * existing runtime preparation blocked-path coverage remains green
* Integration tests:
  * none added
* Manual testing:
  * not run
* Commands performed:
  * `flutter test test/features/agent_chat/presentation/screens/model_library_screen_test.dart test/features/agent_chat/data/services/assistant_runtime_service_test.dart`
  * `flutter analyze lib/features/agent_chat/presentation/screens/model_library_screen.dart test/features/agent_chat/presentation/screens/model_library_screen_test.dart test/features/agent_chat/data/services/assistant_runtime_service_test.dart`

---

# Deployment Notes

* No config changes.
* No deployment ordering required.

---

# Related Commits

* `fix(agent-chat): surface model memory compatibility`

---

# Notes

* Closes #442.
