### PR TITLE
feat(settings): add AI model preferences section

### DIFF
--- a/app/lib/features/agent_chat/presentation/screens/profile_screen.dart
+++ b/app/lib/features/agent_chat/presentation/screens/profile_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
+import 'package:core_ai/core_ai.dart';
 import 'package:core_ui/core_ui.dart';
 import '../../../../core/auth/auth_service.dart';
 import '../../../../core/auth/google_auth_service.dart';
@@ -13,6 +14,7 @@ import '../../../../core/utils/currency_formatter.dart';
 import '../../../../core/utils/locale_settings.dart';
 import '../../../../shared/widgets/bug_report_dialog.dart';
 import '../../../quotes/presentation/widgets/daily_quote_card.dart';
+import '../../../settings/application/ai_preferences_settings.dart';
 import '../../../settings/application/ai_model_management.dart';
 import '../../../settings/presentation/screens/ai_models_screen.dart';
 import '../../../settings/presentation/screens/audio_settings_screen.dart';
@@ -147,23 +149,8 @@ class ProfileScreen extends ConsumerWidget {
               },
             ),
 
-            // AI Models
-            ListTile(
-              leading: const Icon(Icons.model_training),
-              title: const Text('AI Models'),
-              subtitle: const Text('Browse and manage offline models'),
-              trailing: const Icon(Icons.arrow_forward_ios, size: 16),
-              onTap: () {
-                Navigator.of(context).push(
-                  MaterialPageRoute(
-                    builder: (context) => const AIModelsScreen(),
-                  ),
-                );
-              },
-            ),
-
-            // Active Model Selection Dropdown
-            _ActiveModelSelector(),
+            const SizedBox(height: 24),
+            const _AIPreferencesSection(),
 
             const SizedBox(height: 32),
 
@@ -375,6 +362,235 @@ class ProfileScreen extends ConsumerWidget {
   }
 }
 
+class _AIPreferencesSection extends ConsumerWidget {
+  const _AIPreferencesSection();
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final theme = Theme.of(context);
+    final settings = ref.watch(aiPreferencesSettingsProvider);
+    final selectedModel = ref.watch(selectedModelProvider);
+    final storageUsage = ref.watch(aiModelStorageUsageBytesProvider);
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          'AI Model Preferences',
+          style: Theme.of(context).textTheme.titleMedium,
+        ),
+        const SizedBox(height: 8),
+        Card(
+          child: Column(
+            children: [
+              ListTile(
+                leading: const Icon(Icons.smart_toy_outlined),
+                title: const Text('Active Model'),
+                subtitle: Text(
+                  selectedModel?.name ?? 'Browse or download a local model',
+                ),
+                trailing: const Icon(Icons.arrow_forward_ios, size: 16),
+                onTap: () {
+                  Navigator.of(context).push(
+                    MaterialPageRoute(
+                      builder: (context) => const AIModelsScreen(),
+                    ),
+                  );
+                },
+              ),
+              ListTile(
+                leading: const Icon(Icons.alt_route_outlined),
+                title: const Text('Routing Strategy'),
+                subtitle: Text(
+                  _routingStrategyLabel(settings.routingStrategy),
+                  key: const Key('ai-routing-strategy-subtitle'),
+                ),
+                trailing: DropdownButtonHideUnderline(
+                  child: DropdownButton<AIRoutingStrategy>(
+                    key: const Key('ai-routing-strategy-dropdown'),
+                    value: settings.routingStrategy,
+                    items: AIRoutingStrategy.values.map((strategy) {
+                      return DropdownMenuItem(
+                        value: strategy,
+                        child: Text(_routingStrategyLabel(strategy)),
+                      );
+                    }).toList(),
+                    onChanged: (value) {
+                      if (value == null) return;
+                      ref
+                          .read(aiPreferencesSettingsProvider.notifier)
+                          .update(settings.copyWith(routingStrategy: value));
+                    },
+                  ),
+                ),
+              ),
+              SwitchListTile(
+                key: const Key('ai-auto-fallback-switch'),
+                secondary: const Icon(Icons.swap_horiz_outlined),
+                title: const Text('Enable Auto-Fallback'),
+                subtitle: const Text(
+                  'Automatically use the backup runtime when the preferred one is unavailable.',
+                ),
+                value: settings.autoFallback,
+                onChanged: (value) {
+                  ref
+                      .read(aiPreferencesSettingsProvider.notifier)
+                      .update(settings.copyWith(autoFallback: value));
+                },
+              ),
+              ListTile(
+                leading: const Icon(Icons.low_priority_outlined),
+                title: const Text('Fallback Order'),
+                subtitle: Text(_fallbackOrderLabel(settings.routingStrategy)),
+              ),
+              ExpansionTile(
+                leading: const Icon(Icons.speed_outlined),
+                title: const Text('Performance'),
+                subtitle: Text(
+                  '${settings.accelerationPreference.label} • '
+                  '${settings.threadCount} threads • '
+                  '${settings.contextLength} tokens',
+                ),
+                children: [
+                  _SettingDropdownRow<AIAccelerationPreference>(
+                    label: 'GPU Acceleration',
+                    value: settings.accelerationPreference,
+                    items: AIAccelerationPreference.values,
+                    itemLabel: (value) => value.label,
+                    onChanged: (value) {
+                      ref
+                          .read(aiPreferencesSettingsProvider.notifier)
+                          .update(
+                            settings.copyWith(accelerationPreference: value),
+                          );
+                    },
+                  ),
+                  _SettingDropdownRow<int>(
+                    label: 'Thread Count',
+                    value: settings.threadCount,
+                    items: const [1, 2, 4, 6, 8],
+                    itemLabel: (value) => '$value',
+                    onChanged: (value) {
+                      ref
+                          .read(aiPreferencesSettingsProvider.notifier)
+                          .update(settings.copyWith(threadCount: value));
+                    },
+                  ),
+                  _SettingDropdownRow<int>(
+                    label: 'Context Length',
+                    value: settings.contextLength,
+                    items: const [1024, 2048, 4096, 8192],
+                    itemLabel: (value) => '$value tokens',
+                    onChanged: (value) {
+                      ref
+                          .read(aiPreferencesSettingsProvider.notifier)
+                          .update(settings.copyWith(contextLength: value));
+                    },
+                  ),
+                ],
+              ),
+              ExpansionTile(
+                leading: const Icon(Icons.storage_outlined),
+                title: const Text('Storage'),
+                subtitle: Text(
+                  storageUsage.when(
+                    data: (bytes) => '${_formatBytes(bytes)} used',
+                    loading: () => 'Checking storage usage',
+                    error: (_, _) => 'Storage usage unavailable',
+                  ),
+                ),
+                children: [
+                  _SettingDropdownRow<AIDownloadLocationPreference>(
+                    label: 'Download Location',
+                    value: settings.downloadLocation,
+                    items: AIDownloadLocationPreference.values,
+                    itemLabel: (value) => value.label,
+                    onChanged: (value) {
+                      ref
+                          .read(aiPreferencesSettingsProvider.notifier)
+                          .update(settings.copyWith(downloadLocation: value));
+                    },
+                  ),
+                  ListTile(
+                    title: const Text('Clear Model Cache'),
+                    subtitle: const Text(
+                      'Remove orphaned partial files and refresh storage usage.',
+                    ),
+                    trailing: TextButton(
+                      onPressed: () async {
+                        final removed = await ref
+                            .read(aiPreferencesSettingsProvider.notifier)
+                            .clearModelCache();
+                        if (context.mounted) {
+                          ScaffoldMessenger.of(context).showSnackBar(
+                            SnackBar(
+                              content: Text(
+                                removed == 0
+                                    ? 'No cached model files needed cleanup.'
+                                    : 'Cleared $removed cached model file(s).',
+                              ),
+                            ),
+                          );
+                        }
+                      },
+                      child: const Text('Clear'),
+                    ),
+                  ),
+                ],
+              ),
+              ExpansionTile(
+                leading: const Icon(Icons.tune_outlined),
+                title: const Text('Advanced'),
+                subtitle: Text(
+                  '${settings.memoryBudgetPercent}% memory budget • '
+                  '${settings.debugLogging ? 'Debug logging on' : 'Debug logging off'}',
+                ),
+                children: [
+                  _SettingDropdownRow<int>(
+                    label: 'Memory Budget',
+                    value: settings.memoryBudgetPercent,
+                    items: const [40, 50, 60, 70, 80],
+                    itemLabel: (value) => '$value%',
+                    onChanged: (value) {
+                      ref
+                          .read(aiPreferencesSettingsProvider.notifier)
+                          .update(
+                            settings.copyWith(memoryBudgetPercent: value),
+                          );
+                    },
+                  ),
+                  SwitchListTile(
+                    key: const Key('ai-debug-logging-switch'),
+                    title: const Text('Debug Logging'),
+                    subtitle: const Text(
+                      'Keep local runtime diagnostics available for troubleshooting.',
+                    ),
+                    value: settings.debugLogging,
+                    onChanged: (value) {
+                      ref
+                          .read(aiPreferencesSettingsProvider.notifier)
+                          .update(settings.copyWith(debugLogging: value));
+                    },
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ),
+        Padding(
+          padding: const EdgeInsets.only(top: 8, left: 16, right: 16),
+          child: Text(
+            'Use the model manager to browse downloads, set an active local model, and inspect device-specific readiness.',
+            style: theme.textTheme.bodySmall?.copyWith(
+              color: theme.colorScheme.onSurfaceVariant,
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
 class _CurrencySelector extends ConsumerWidget {
   const _CurrencySelector();
 
@@ -418,66 +634,72 @@ class _CurrencySelector extends ConsumerWidget {
   }
 }
 
-/// Widget for selecting the active offline AI model.
-class _ActiveModelSelector extends ConsumerWidget {
+class _SettingDropdownRow<T> extends StatelessWidget {
+  const _SettingDropdownRow({
+    required this.label,
+    required this.value,
+    required this.items,
+    required this.itemLabel,
+    required this.onChanged,
+  });
+
+  final String label;
+  final T value;
+  final List<T> items;
+  final String Function(T value) itemLabel;
+  final ValueChanged<T> onChanged;
+
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final registry = ref.watch(modelRegistryProvider);
-    final downloadedModels = registry.downloadedModels;
-    final selectedModelId = ref.watch(selectedModelIdProvider);
-    final selectedModel = ref.watch(selectedModelProvider);
-
-    if (downloadedModels.isEmpty) {
-      return ListTile(
-        leading: const Icon(Icons.smart_toy_outlined, color: Colors.grey),
-        title: const Text('Active Model'),
-        subtitle: const Text('No models downloaded'),
-        enabled: false,
-      );
-    }
-
+  Widget build(BuildContext context) {
     return ListTile(
-      leading: const Icon(Icons.smart_toy),
-      title: const Text('Active Model'),
-      subtitle: Text(
-        selectedModel?.name ?? 'Select a model',
-        style: TextStyle(
-          color: selectedModel != null
-              ? Theme.of(context).colorScheme.primary
-              : Theme.of(context).colorScheme.onSurfaceVariant,
-        ),
-      ),
-      trailing: DropdownButton<String>(
-        value: selectedModelId,
-        hint: const Text('Select'),
-        underline: const SizedBox(),
-        items: downloadedModels.map((model) {
-          return DropdownMenuItem<String>(
-            value: model.id,
-            child: SizedBox(
-              width: 120,
-              child: Text(
-                model.name,
-                overflow: TextOverflow.ellipsis,
-                style: Theme.of(context).textTheme.bodyMedium,
-              ),
-            ),
-          );
-        }).toList(),
-        onChanged: (String? modelId) {
-          if (modelId != null) {
-            ref
-                .read(selectedModelIdProvider.notifier)
-                .setSelectedModel(modelId);
-            ScaffoldMessenger.of(context).showSnackBar(
-              SnackBar(
-                content: Text('Model switched'),
-                duration: const Duration(seconds: 1),
-              ),
+      title: Text(label),
+      trailing: DropdownButtonHideUnderline(
+        child: DropdownButton<T>(
+          value: value,
+          items: items.map((item) {
+            return DropdownMenuItem<T>(
+              value: item,
+              child: Text(itemLabel(item)),
             );
-          }
-        },
+          }).toList(),
+          onChanged: (next) {
+            if (next != null) {
+              onChanged(next);
+            }
+          },
+        ),
       ),
     );
   }
+}
+
+String _routingStrategyLabel(AIRoutingStrategy strategy) {
+  return switch (strategy) {
+    AIRoutingStrategy.onDeviceOnly => 'On-device only',
+    AIRoutingStrategy.cloudOnly => 'Cloud only',
+    AIRoutingStrategy.onDevicePreferred => 'On-device preferred',
+    AIRoutingStrategy.cloudPreferred => 'Cloud preferred',
+    AIRoutingStrategy.userChoice => 'User choice',
+  };
+}
+
+String _fallbackOrderLabel(AIRoutingStrategy strategy) {
+  return switch (strategy) {
+    AIRoutingStrategy.onDeviceOnly => 'On-device only',
+    AIRoutingStrategy.cloudOnly => 'Cloud only',
+    AIRoutingStrategy.onDevicePreferred => 'On-device first, then cloud',
+    AIRoutingStrategy.cloudPreferred => 'Cloud first, then on-device',
+    AIRoutingStrategy.userChoice => 'User-selected runtime, then fallback',
+  };
+}
+
+String _formatBytes(int bytes) {
+  if (bytes < 1024) return '$bytes B';
+  if (bytes < 1024 * 1024) {
+    return '${(bytes / 1024).toStringAsFixed(1)} KB';
+  }
+  if (bytes < 1024 * 1024 * 1024) {
+    return '${(bytes / (1024 * 1024)).toStringAsFixed(1)} MB';
+  }
+  return '${(bytes / (1024 * 1024 * 1024)).toStringAsFixed(1)} GB';
 }

--- a/app/lib/features/settings/application/ai_preferences_settings.dart
+++ b/app/lib/features/settings/application/ai_preferences_settings.dart
@@ -1,0 +1,176 @@
+import 'package:core_ai/core_ai.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../../iptv/application/providers/iptv_providers.dart'
+    show sharedPreferencesProvider;
+import 'ai_model_management.dart';
+
+enum AIAccelerationPreference {
+  auto('Auto'),
+  gpuPreferred('GPU preferred'),
+  cpuOnly('CPU only');
+
+  const AIAccelerationPreference(this.label);
+
+  final String label;
+}
+
+enum AIDownloadLocationPreference {
+  internal('Internal'),
+  appManaged('App managed');
+
+  const AIDownloadLocationPreference(this.label);
+
+  final String label;
+}
+
+class AIPreferencesSettings {
+  const AIPreferencesSettings({
+    this.routingStrategy = AIRoutingStrategy.onDevicePreferred,
+    this.autoFallback = true,
+    this.accelerationPreference = AIAccelerationPreference.auto,
+    this.threadCount = 4,
+    this.contextLength = 2048,
+    this.memoryBudgetPercent = 60,
+    this.debugLogging = false,
+    this.downloadLocation = AIDownloadLocationPreference.internal,
+  });
+
+  final AIRoutingStrategy routingStrategy;
+  final bool autoFallback;
+  final AIAccelerationPreference accelerationPreference;
+  final int threadCount;
+  final int contextLength;
+  final int memoryBudgetPercent;
+  final bool debugLogging;
+  final AIDownloadLocationPreference downloadLocation;
+
+  AIPreferencesSettings copyWith({
+    AIRoutingStrategy? routingStrategy,
+    bool? autoFallback,
+    AIAccelerationPreference? accelerationPreference,
+    int? threadCount,
+    int? contextLength,
+    int? memoryBudgetPercent,
+    bool? debugLogging,
+    AIDownloadLocationPreference? downloadLocation,
+  }) {
+    return AIPreferencesSettings(
+      routingStrategy: routingStrategy ?? this.routingStrategy,
+      autoFallback: autoFallback ?? this.autoFallback,
+      accelerationPreference:
+          accelerationPreference ?? this.accelerationPreference,
+      threadCount: threadCount ?? this.threadCount,
+      contextLength: contextLength ?? this.contextLength,
+      memoryBudgetPercent: memoryBudgetPercent ?? this.memoryBudgetPercent,
+      debugLogging: debugLogging ?? this.debugLogging,
+      downloadLocation: downloadLocation ?? this.downloadLocation,
+    );
+  }
+}
+
+final aiPreferencesSettingsProvider =
+    StateNotifierProvider<AIPreferencesSettingsNotifier, AIPreferencesSettings>(
+      (ref) {
+        return AIPreferencesSettingsNotifier(ref);
+      },
+    );
+
+final aiModelStorageUsageBytesProvider = FutureProvider<int>((ref) async {
+  final service = ref.watch(modelDownloadServiceProvider);
+  return service.getStorageUsed();
+});
+
+class AIPreferencesSettingsNotifier
+    extends StateNotifier<AIPreferencesSettings> {
+  AIPreferencesSettingsNotifier(this._ref)
+    : super(const AIPreferencesSettings()) {
+    _load();
+  }
+
+  static const routingStrategyKey = 'ai_settings.routing_strategy';
+  static const autoFallbackKey = 'ai_settings.auto_fallback';
+  static const accelerationKey = 'ai_settings.acceleration';
+  static const threadCountKey = 'ai_settings.thread_count';
+  static const contextLengthKey = 'ai_settings.context_length';
+  static const memoryBudgetKey = 'ai_settings.memory_budget_percent';
+  static const debugLoggingKey = 'ai_settings.debug_logging';
+  static const downloadLocationKey = 'ai_settings.download_location';
+
+  final Ref _ref;
+
+  Future<void> _load() async {
+    final prefs = await _prefs();
+    state = AIPreferencesSettings(
+      routingStrategy: _routingStrategyFromName(
+        prefs.getString(routingStrategyKey),
+      ),
+      autoFallback: prefs.getBool(autoFallbackKey) ?? true,
+      accelerationPreference: _accelerationFromName(
+        prefs.getString(accelerationKey),
+      ),
+      threadCount: prefs.getInt(threadCountKey) ?? 4,
+      contextLength: prefs.getInt(contextLengthKey) ?? 2048,
+      memoryBudgetPercent: prefs.getInt(memoryBudgetKey) ?? 60,
+      debugLogging: prefs.getBool(debugLoggingKey) ?? false,
+      downloadLocation: _downloadLocationFromName(
+        prefs.getString(downloadLocationKey),
+      ),
+    );
+  }
+
+  Future<void> update(AIPreferencesSettings settings) async {
+    state = settings;
+    final prefs = await _prefs();
+    await prefs.setString(routingStrategyKey, settings.routingStrategy.name);
+    await prefs.setBool(autoFallbackKey, settings.autoFallback);
+    await prefs.setString(
+      accelerationKey,
+      settings.accelerationPreference.name,
+    );
+    await prefs.setInt(threadCountKey, settings.threadCount);
+    await prefs.setInt(contextLengthKey, settings.contextLength);
+    await prefs.setInt(memoryBudgetKey, settings.memoryBudgetPercent);
+    await prefs.setBool(debugLoggingKey, settings.debugLogging);
+    await prefs.setString(downloadLocationKey, settings.downloadLocation.name);
+  }
+
+  Future<int> clearModelCache() async {
+    final manager = ModelStorageManager();
+    final deleted = await manager.cleanupOrphanedFiles(
+      ModelCatalog.bundledModels,
+    );
+    _ref.invalidate(aiModelStorageUsageBytesProvider);
+    return deleted.length;
+  }
+
+  Future<SharedPreferences> _prefs() async {
+    try {
+      return _ref.read(sharedPreferencesProvider);
+    } catch (_) {
+      return SharedPreferences.getInstance();
+    }
+  }
+
+  static AIRoutingStrategy _routingStrategyFromName(String? raw) {
+    return AIRoutingStrategy.values.firstWhere(
+      (value) => value.name == raw,
+      orElse: () => AIRoutingStrategy.onDevicePreferred,
+    );
+  }
+
+  static AIAccelerationPreference _accelerationFromName(String? raw) {
+    return AIAccelerationPreference.values.firstWhere(
+      (value) => value.name == raw,
+      orElse: () => AIAccelerationPreference.auto,
+    );
+  }
+
+  static AIDownloadLocationPreference _downloadLocationFromName(String? raw) {
+    return AIDownloadLocationPreference.values.firstWhere(
+      (value) => value.name == raw,
+      orElse: () => AIDownloadLocationPreference.internal,
+    );
+  }
+}

--- a/app/test/features/agent_chat/presentation/screens/profile_theme_picker_test.dart
+++ b/app/test/features/agent_chat/presentation/screens/profile_theme_picker_test.dart
@@ -1,5 +1,7 @@
 import 'package:airo_app/core/providers/app_theme_provider.dart';
 import 'package:airo_app/features/agent_chat/presentation/screens/profile_screen.dart';
+import 'package:airo_app/features/iptv/application/providers/iptv_providers.dart';
+import 'package:airo_app/features/settings/application/ai_preferences_settings.dart';
 import 'package:core_ui/core_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -28,5 +30,46 @@ void main() {
 
     expect(notifier.state, AppThemeId.classic);
     expect(prefs.getString(AppThemeNotifier.storageKey), 'classic');
+  });
+
+  testWidgets('profile shows AI preferences and persists fallback changes', (
+    tester,
+  ) async {
+    SharedPreferences.setMockInitialValues({
+      AIPreferencesSettingsNotifier.routingStrategyKey: 'cloudPreferred',
+      AIPreferencesSettingsNotifier.autoFallbackKey: false,
+    });
+    final prefs = await SharedPreferences.getInstance();
+    final notifier = AppThemeNotifier.withPreferences(prefs);
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          appThemeProvider.overrideWith((ref) => notifier),
+          sharedPreferencesProvider.overrideWithValue(prefs),
+          aiModelStorageUsageBytesProvider.overrideWith((ref) async {
+            return 512 * 1024 * 1024;
+          }),
+        ],
+        child: const MaterialApp(home: ProfileScreen()),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('AI Model Preferences'), findsOneWidget);
+    final subtitle = tester.widget<Text>(
+      find.byKey(const Key('ai-routing-strategy-subtitle')),
+    );
+    expect(subtitle.data, 'Cloud preferred');
+    expect(find.text('512.0 MB used'), findsOneWidget);
+
+    await tester.ensureVisible(find.byKey(const Key('ai-auto-fallback-switch')));
+    await tester.tap(find.byKey(const Key('ai-auto-fallback-switch')));
+    await tester.pumpAndSettle();
+
+    expect(
+      prefs.getBool(AIPreferencesSettingsNotifier.autoFallbackKey),
+      isTrue,
+    );
   });
 }

--- a/app/test/features/settings/application/ai_preferences_settings_test.dart
+++ b/app/test/features/settings/application/ai_preferences_settings_test.dart
@@ -1,0 +1,67 @@
+import 'package:airo_app/features/settings/application/ai_preferences_settings.dart';
+import 'package:airo_app/features/iptv/application/providers/iptv_providers.dart';
+import 'package:core_ai/core_ai.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  test('persists AI preferences updates', () async {
+    SharedPreferences.setMockInitialValues({});
+    final prefs = await SharedPreferences.getInstance();
+    final container = ProviderContainer(
+      overrides: [sharedPreferencesProvider.overrideWithValue(prefs)],
+    );
+    addTearDown(container.dispose);
+
+    final notifier = container.read(aiPreferencesSettingsProvider.notifier);
+    await Future<void>.delayed(Duration.zero);
+
+    await notifier.update(
+      const AIPreferencesSettings(
+        routingStrategy: AIRoutingStrategy.cloudPreferred,
+        autoFallback: false,
+        accelerationPreference: AIAccelerationPreference.cpuOnly,
+        threadCount: 6,
+        contextLength: 4096,
+        memoryBudgetPercent: 70,
+        debugLogging: true,
+        downloadLocation: AIDownloadLocationPreference.appManaged,
+      ),
+    );
+
+    final state = container.read(aiPreferencesSettingsProvider);
+    expect(state.routingStrategy, AIRoutingStrategy.cloudPreferred);
+    expect(state.autoFallback, isFalse);
+    expect(state.accelerationPreference, AIAccelerationPreference.cpuOnly);
+    expect(state.threadCount, 6);
+    expect(state.contextLength, 4096);
+    expect(state.memoryBudgetPercent, 70);
+    expect(state.debugLogging, isTrue);
+    expect(state.downloadLocation, AIDownloadLocationPreference.appManaged);
+
+    expect(
+      prefs.getString(AIPreferencesSettingsNotifier.routingStrategyKey),
+      AIRoutingStrategy.cloudPreferred.name,
+    );
+    expect(
+      prefs.getBool(AIPreferencesSettingsNotifier.autoFallbackKey),
+      isFalse,
+    );
+    expect(
+      prefs.getString(AIPreferencesSettingsNotifier.accelerationKey),
+      AIAccelerationPreference.cpuOnly.name,
+    );
+    expect(prefs.getInt(AIPreferencesSettingsNotifier.threadCountKey), 6);
+    expect(prefs.getInt(AIPreferencesSettingsNotifier.contextLengthKey), 4096);
+    expect(prefs.getInt(AIPreferencesSettingsNotifier.memoryBudgetKey), 70);
+    expect(
+      prefs.getBool(AIPreferencesSettingsNotifier.debugLoggingKey),
+      isTrue,
+    );
+    expect(
+      prefs.getString(AIPreferencesSettingsNotifier.downloadLocationKey),
+      AIDownloadLocationPreference.appManaged.name,
+    );
+  });
+}

--- a/packages/core_ai/lib/core_ai.dart
+++ b/packages/core_ai/lib/core_ai.dart
@@ -22,6 +22,7 @@ export 'src/llm/llm_config.dart';
 export 'src/llm/gemini_nano_client.dart';
 export 'src/llm/gemini_api_client.dart';
 export 'src/llm/llm_router_impl.dart';
+export 'src/router/ai_router.dart';
 
 // GGUF Model Support
 export 'src/llm/gguf_model_config.dart';


### PR DESCRIPTION
# PR Title
feat(settings): add AI model preferences section

---

# Summary

This PR introduces changes to the Profile/Settings AI configuration surface.
Goal: centralize AI model configuration into one persisted section instead of scattering it across profile and model-management entry points.

Core outcome:

* adds a unified `AI Model Preferences` section to Profile
* persists routing, fallback, performance, storage, and advanced AI settings

---

# Changes

### Code

* Added:
  * `app/lib/features/settings/application/ai_preferences_settings.dart`
  * `app/test/features/settings/application/ai_preferences_settings_test.dart`
* Updated:
  * `app/lib/features/agent_chat/presentation/screens/profile_screen.dart`
  * `app/test/features/agent_chat/presentation/screens/profile_theme_picker_test.dart`
  * `packages/core_ai/lib/core_ai.dart`

### Logic

* reuses existing model-management and storage services instead of inventing parallel AI settings plumbing
* exposes routing strategy and fallback order in a single settings surface
* surfaces storage usage and orphaned-cache cleanup with user feedback
* keeps settings persisted locally for future runtime consumption

---

# API Changes (if any)

* `core_ai` now publicly exports `src/router/ai_router.dart`.

---

# Database Changes (if any)

* None.

---

# Observability / Logging

* None.

---

# Performance Impact

* Latency: negligible
* Throughput: none
* Memory/CPU: small additional settings/provider state only

---

# Risks

* some settings are preference-layer controls today and are not yet enforced by every runtime path
* download location remains a persisted preference ahead of deeper storage backend wiring
* Rollback plan:
  * revert this PR to remove the settings surface while keeping existing model management intact

---

# Testing

* Unit tests:
  * `flutter test test/features/settings/application/ai_preferences_settings_test.dart`
* Widget tests:
  * `flutter test test/features/agent_chat/presentation/screens/profile_theme_picker_test.dart`
* Static analysis:
  * `flutter analyze lib/features/settings/application/ai_preferences_settings.dart lib/features/agent_chat/presentation/screens/profile_screen.dart test/features/settings/application/ai_preferences_settings_test.dart test/features/agent_chat/presentation/screens/profile_theme_picker_test.dart`

---

# Deployment Notes

* No config changes.
* No deployment ordering required.

---

# Related Commits

* `feat(settings): add AI model preferences section`

---

# Notes

* Closes #445.
