### PR TITLE
fix(ui): compact mobile hub layouts and launch init timing

### DIFF
--- a/app/lib/features/games/presentation/screens/games_hub_screen.dart
+++ b/app/lib/features/games/presentation/screens/games_hub_screen.dart
@@ -13,6 +13,8 @@ import '../../../../shared/widgets/responsive_center.dart';
 class GamesHubScreen extends ConsumerWidget {
   const GamesHubScreen({super.key});
 
+  static const int _sectionPreviewLimit = 4;
+
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final sections = [
@@ -58,6 +60,9 @@ class GamesHubScreen extends ConsumerWidget {
 
               // Game categories in grid
               ...sections.map((section) {
+                final previewGames = section.games.length > _sectionPreviewLimit
+                    ? section.games.take(_sectionPreviewLimit).toList()
+                    : section.games;
                 return Column(
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
@@ -71,11 +76,13 @@ class GamesHubScreen extends ConsumerWidget {
                           style: Theme.of(context).textTheme.titleLarge,
                         ),
                         const Spacer(),
-                        if (section.games.length > 4)
+                        if (section.games.length > _sectionPreviewLimit)
                           TextButton(
-                            onPressed: () {
-                              // TODO: View all in category
-                            },
+                            key: ValueKey(
+                              'games_view_all_${_sectionKey(section.title)}',
+                            ),
+                            onPressed: () =>
+                                _showSectionSheet(context, ref, section),
                             child: const Text('View All'),
                           ),
                       ],
@@ -101,12 +108,12 @@ class GamesHubScreen extends ConsumerWidget {
                                 mainAxisSpacing: 12,
                                 childAspectRatio: columns <= 2 ? 0.92 : 1.12,
                               ),
-                          itemCount: section.games.length,
+                          itemCount: previewGames.length,
                           itemBuilder: (context, index) {
                             return _buildGameTile(
                               context,
                               ref,
-                              section.games[index],
+                              previewGames[index],
                             );
                           },
                         );
@@ -370,6 +377,103 @@ class GamesHubScreen extends ConsumerWidget {
       ),
     );
   }
+
+  void _showSectionSheet(
+    BuildContext context,
+    WidgetRef ref,
+    _GameSection section,
+  ) {
+    showModalBottomSheet<void>(
+      context: context,
+      isScrollControlled: true,
+      useSafeArea: true,
+      builder: (sheetContext) {
+        final theme = Theme.of(sheetContext);
+        return FractionallySizedBox(
+          heightFactor: 0.9,
+          child: Padding(
+            padding: const EdgeInsets.fromLTRB(16, 12, 16, 24),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Center(
+                  child: Container(
+                    width: 40,
+                    height: 4,
+                    decoration: BoxDecoration(
+                      color: theme.colorScheme.outlineVariant,
+                      borderRadius: BorderRadius.circular(999),
+                    ),
+                  ),
+                ),
+                const SizedBox(height: 16),
+                Row(
+                  children: [
+                    Icon(section.icon, size: 20),
+                    const SizedBox(width: 8),
+                    Expanded(
+                      child: Text(
+                        section.title,
+                        style: theme.textTheme.titleLarge,
+                      ),
+                    ),
+                    Text(
+                      '${section.games.length} games',
+                      style: theme.textTheme.bodySmall?.copyWith(
+                        color: theme.colorScheme.onSurfaceVariant,
+                      ),
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 8),
+                Text(
+                  'Choose a game without leaving the Arena hub.',
+                  style: theme.textTheme.bodyMedium?.copyWith(
+                    color: theme.colorScheme.onSurfaceVariant,
+                  ),
+                ),
+                const SizedBox(height: 16),
+                Expanded(
+                  child: LayoutBuilder(
+                    builder: (context, constraints) {
+                      final columns = ResponsiveBreakpoints.getGridColumns(
+                        constraints.maxWidth,
+                        mobile: 2,
+                        tablet: 3,
+                        desktop: 4,
+                      );
+                      return GridView.builder(
+                        key: ValueKey(
+                          'games_section_sheet_${_sectionKey(section.title)}',
+                        ),
+                        gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+                          crossAxisCount: columns,
+                          crossAxisSpacing: 12,
+                          mainAxisSpacing: 12,
+                          childAspectRatio: columns <= 2 ? 0.92 : 1.12,
+                        ),
+                        itemCount: section.games.length,
+                        itemBuilder: (context, index) {
+                          return _buildGameTile(
+                            context,
+                            ref,
+                            section.games[index],
+                          );
+                        },
+                      );
+                    },
+                  ),
+                ),
+              ],
+            ),
+          ),
+        );
+      },
+    );
+  }
+
+  String _sectionKey(String title) =>
+      title.toLowerCase().replaceAll(RegExp(r'[^a-z0-9]+'), '_');
 }
 
 class _GameSection {

--- a/app/lib/features/money/presentation/screens/money_overview_screen.dart
+++ b/app/lib/features/money/presentation/screens/money_overview_screen.dart
@@ -147,14 +147,14 @@ class _CoinsHeroSection extends StatelessWidget {
     final colorScheme = theme.colorScheme;
     final isCompact = MediaQuery.sizeOf(context).width < 600;
     return _HermesSection(
-      minHeight: isCompact ? 340 : 360,
+      minHeight: isCompact ? 220 : 320,
       child: Center(
         child: ConstrainedBox(
           constraints: const BoxConstraints(maxWidth: 620),
           child: Padding(
             padding: EdgeInsets.symmetric(
               horizontal: isCompact ? 16 : 24,
-              vertical: isCompact ? 28 : 40,
+              vertical: isCompact ? 20 : 36,
             ),
             child: Column(
               mainAxisAlignment: MainAxisAlignment.center,
@@ -166,28 +166,59 @@ class _CoinsHeroSection extends StatelessWidget {
                   ),
                   textAlign: TextAlign.center,
                 ),
-                const SizedBox(height: 20),
+                SizedBox(height: isCompact ? 12 : 20),
                 Text(
-                  'THE MONEY THAT\nWORKS WITH YOU.',
+                  isCompact
+                      ? 'Money that works with you.'
+                      : 'THE MONEY THAT\nWORKS WITH YOU.',
                   style: isCompact
-                      ? theme.textTheme.displayLarge?.copyWith(
-                          fontSize: 46,
-                          height: 0.92,
-                        )
+                      ? theme.textTheme.headlineLarge?.copyWith(height: 1.0)
                       : theme.textTheme.displayLarge,
                   textAlign: TextAlign.center,
                 ),
-                SizedBox(height: isCompact ? 18 : 28),
+                SizedBox(height: isCompact ? 10 : 18),
+                Text(
+                  'Accounts, ledger, and budgets stay in one place.',
+                  style: theme.textTheme.bodyMedium?.copyWith(
+                    color: colorScheme.primary.withValues(alpha: 0.64),
+                  ),
+                  textAlign: TextAlign.center,
+                ),
+                SizedBox(height: isCompact ? 16 : 24),
                 totalBalance.when(
                   data: (balance) {
                     final dollars = balance ~/ 100;
                     final cents = (balance % 100).abs();
-                    return Text(
-                      'Available balance: \$$dollars.${cents.toString().padLeft(2, '0')}',
-                      style: theme.textTheme.bodyLarge?.copyWith(
-                        color: colorScheme.primary.withValues(alpha: 0.64),
+                    return Container(
+                      padding: EdgeInsets.symmetric(
+                        horizontal: isCompact ? 14 : 18,
+                        vertical: isCompact ? 10 : 12,
                       ),
-                      textAlign: TextAlign.center,
+                      decoration: BoxDecoration(
+                        color: colorScheme.surface.withValues(alpha: 0.28),
+                        border: Border.all(color: colorScheme.outlineVariant),
+                      ),
+                      child: Wrap(
+                        alignment: WrapAlignment.center,
+                        crossAxisAlignment: WrapCrossAlignment.center,
+                        spacing: 10,
+                        runSpacing: 6,
+                        children: [
+                          const Icon(Icons.account_balance_wallet_outlined),
+                          Text(
+                            'Available balance',
+                            style: theme.textTheme.labelLarge?.copyWith(
+                              color: colorScheme.primary.withValues(
+                                alpha: 0.72,
+                              ),
+                            ),
+                          ),
+                          Text(
+                            '\$$dollars.${cents.toString().padLeft(2, '0')}',
+                            style: theme.textTheme.titleMedium,
+                          ),
+                        ],
+                      ),
                     );
                   },
                   loading: () => const CircularProgressIndicator(),
@@ -240,83 +271,96 @@ class _CoinsDashboardSection extends StatelessWidget {
             LayoutBuilder(
               builder: (context, constraints) {
                 final columns = constraints.maxWidth >= 900 ? 3 : 1;
+                final panels = [
+                  _StatusPanel(
+                    title: 'Accounts',
+                    value: accounts.when(
+                      data: (items) => items.isEmpty
+                          ? 'No accounts'
+                          : '${items.length} active',
+                      loading: () => 'Loading',
+                      error: (_, _) => 'Unavailable',
+                    ),
+                    detail: accounts.when(
+                      data: (items) => items.isEmpty
+                          ? 'Add checking, savings, or cards.'
+                          : items
+                                .take(2)
+                                .map((a) => '${a.name}: ${a.balanceFormatted}')
+                                .join('\n'),
+                      loading: () => 'Fetching balances...',
+                      error: (_, _) => 'Account data failed to load.',
+                    ),
+                    isCompact: columns == 1,
+                  ),
+                  _StatusPanel(
+                    title: 'Ledger',
+                    value: transactionsStream.when(
+                      data: (items) => items.isEmpty
+                          ? 'No entries'
+                          : '${items.length} entries',
+                      loading: () => 'Loading',
+                      error: (_, _) => 'Unavailable',
+                    ),
+                    detail: transactionsStream.when(
+                      data: (items) => items.isEmpty
+                          ? 'Create the first expense to start tracking.'
+                          : items
+                                .take(2)
+                                .map(
+                                  (t) =>
+                                      '${t.description}: ${t.amountFormatted}',
+                                )
+                                .join('\n'),
+                      loading: () => 'Opening recent activity...',
+                      error: (_, _) => 'Recent activity failed to load.',
+                    ),
+                    isCompact: columns == 1,
+                  ),
+                  _StatusPanel(
+                    title: 'Budgets',
+                    value: budgetsStream.when(
+                      data: (items) =>
+                          items.isEmpty ? 'Not set' : '${items.length} active',
+                      loading: () => 'Loading',
+                      error: (_, _) => 'Unavailable',
+                    ),
+                    detail: budgetsStream.when(
+                      data: (items) => items.isEmpty
+                          ? 'Create dining, travel, and recurring limits.'
+                          : items
+                                .take(2)
+                                .map(
+                                  (b) =>
+                                      '${b.tag}: ${b.usedFormatted} / ${b.limitFormatted}',
+                                )
+                                .join('\n'),
+                      loading: () => 'Checking guardrails...',
+                      error: (_, _) => 'Budget data failed to load.',
+                    ),
+                    isCompact: columns == 1,
+                  ),
+                ];
+
+                if (columns == 1) {
+                  return Column(
+                    children: [
+                      for (var i = 0; i < panels.length; i++) ...[
+                        panels[i],
+                        if (i < panels.length - 1) const SizedBox(height: 12),
+                      ],
+                    ],
+                  );
+                }
+
                 return GridView.count(
                   crossAxisCount: columns,
-                  childAspectRatio: columns == 1 ? 3.6 : 2.4,
+                  childAspectRatio: 2.4,
                   crossAxisSpacing: 12,
                   mainAxisSpacing: 12,
                   shrinkWrap: true,
                   physics: const NeverScrollableScrollPhysics(),
-                  children: [
-                    _StatusPanel(
-                      title: 'Accounts',
-                      value: accounts.when(
-                        data: (items) => items.isEmpty
-                            ? 'No accounts'
-                            : '${items.length} active',
-                        loading: () => 'Loading',
-                        error: (_, _) => 'Unavailable',
-                      ),
-                      detail: accounts.when(
-                        data: (items) => items.isEmpty
-                            ? 'Add checking, savings, or cards.'
-                            : items
-                                  .take(2)
-                                  .map(
-                                    (a) => '${a.name}: ${a.balanceFormatted}',
-                                  )
-                                  .join('\n'),
-                        loading: () => 'Fetching balances...',
-                        error: (_, _) => 'Account data failed to load.',
-                      ),
-                    ),
-                    _StatusPanel(
-                      title: 'Ledger',
-                      value: transactionsStream.when(
-                        data: (items) => items.isEmpty
-                            ? 'No entries'
-                            : '${items.length} entries',
-                        loading: () => 'Loading',
-                        error: (_, _) => 'Unavailable',
-                      ),
-                      detail: transactionsStream.when(
-                        data: (items) => items.isEmpty
-                            ? 'Create the first expense to start tracking.'
-                            : items
-                                  .take(2)
-                                  .map(
-                                    (t) =>
-                                        '${t.description}: ${t.amountFormatted}',
-                                  )
-                                  .join('\n'),
-                        loading: () => 'Opening recent activity...',
-                        error: (_, _) => 'Recent activity failed to load.',
-                      ),
-                    ),
-                    _StatusPanel(
-                      title: 'Budgets',
-                      value: budgetsStream.when(
-                        data: (items) => items.isEmpty
-                            ? 'Not set'
-                            : '${items.length} active',
-                        loading: () => 'Loading',
-                        error: (_, _) => 'Unavailable',
-                      ),
-                      detail: budgetsStream.when(
-                        data: (items) => items.isEmpty
-                            ? 'Create dining, travel, and recurring limits.'
-                            : items
-                                  .take(2)
-                                  .map(
-                                    (b) =>
-                                        '${b.tag}: ${b.usedFormatted} / ${b.limitFormatted}',
-                                  )
-                                  .join('\n'),
-                        loading: () => 'Checking guardrails...',
-                        error: (_, _) => 'Budget data failed to load.',
-                      ),
-                    ),
-                  ],
+                  children: panels,
                 );
               },
             ),
@@ -361,11 +405,13 @@ class _StatusPanel extends StatelessWidget {
     required this.title,
     required this.value,
     required this.detail,
+    this.isCompact = false,
   });
 
   final String title;
   final String value;
   final String detail;
+  final bool isCompact;
 
   @override
   Widget build(BuildContext context) {
@@ -379,19 +425,19 @@ class _StatusPanel extends StatelessWidget {
       ),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
+        mainAxisSize: MainAxisSize.min,
         children: [
           Text(title.toUpperCase(), style: theme.textTheme.labelLarge),
           const SizedBox(height: 8),
           Text(value, style: theme.textTheme.headlineSmall),
-          const SizedBox(height: 8),
-          Expanded(
-            child: Text(
-              detail,
-              style: theme.textTheme.bodyMedium?.copyWith(
-                color: colorScheme.primary.withValues(alpha: 0.72),
-              ),
-              overflow: TextOverflow.fade,
+          SizedBox(height: isCompact ? 6 : 8),
+          Text(
+            detail,
+            style: theme.textTheme.bodyMedium?.copyWith(
+              color: colorScheme.primary.withValues(alpha: 0.72),
             ),
+            maxLines: isCompact ? 2 : 4,
+            overflow: TextOverflow.ellipsis,
           ),
         ],
       ),

--- a/app/lib/main.dart
+++ b/app/lib/main.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
@@ -77,18 +79,6 @@ void main() async {
   // Initialize AuthService
   await AuthService.instance.initialize();
 
-  // Initialize audio service for background music playback
-  // This must be done before runApp() for audio_service to work properly
-  if (!kIsWeb) {
-    try {
-      await initAudioService();
-      debugPrint('✅ Audio service initialized for background playback');
-    } catch (e) {
-      debugPrint('⚠️ Audio service initialization failed: $e');
-      debugPrint('📝 Background music playback may not work');
-    }
-  }
-
   // Initialize SharedPreferences for IPTV caching
   final prefs = await SharedPreferences.getInstance();
 
@@ -98,4 +88,22 @@ void main() async {
       child: const AiroApp(),
     ),
   );
+
+  _scheduleAudioServiceInitialization();
+}
+
+void _scheduleAudioServiceInitialization() {
+  if (kIsWeb) return;
+
+  WidgetsBinding.instance.addPostFrameCallback((_) {
+    unawaited(() async {
+      try {
+        await initAudioService();
+        debugPrint('✅ Audio service initialized for background playback');
+      } catch (e) {
+        debugPrint('⚠️ Audio service initialization failed: $e');
+        debugPrint('📝 Background music playback may not work');
+      }
+    }());
+  });
 }

--- a/app/lib/main_mobile_streaming.dart
+++ b/app/lib/main_mobile_streaming.dart
@@ -13,6 +13,8 @@
 /// ```
 library;
 
+import 'dart:async';
+
 import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -65,16 +67,6 @@ void main() async {
   // Initialize AuthService
   await AuthService.instance.initialize();
 
-  // Initialize audio service for background music playback
-  // This must be done before runApp() for audio_service to work properly
-  try {
-    await initAudioService();
-    debugPrint('✅ Audio service initialized for background playback');
-  } catch (e) {
-    debugPrint('⚠️ Audio service initialization failed: $e');
-    debugPrint('📝 Background music playback may not work');
-  }
-
   // Initialize SharedPreferences for caching
   final prefs = await SharedPreferences.getInstance();
 
@@ -96,4 +88,20 @@ void main() async {
       child: const AiroApp(),
     ),
   );
+
+  _scheduleAudioServiceInitialization();
+}
+
+void _scheduleAudioServiceInitialization() {
+  WidgetsBinding.instance.addPostFrameCallback((_) {
+    unawaited(() async {
+      try {
+        await initAudioService();
+        debugPrint('✅ Audio service initialized for background playback');
+      } catch (e) {
+        debugPrint('⚠️ Audio service initialization failed: $e');
+        debugPrint('📝 Background music playback may not work');
+      }
+    }());
+  });
 }

--- a/app/test/features/games/presentation/screens/games_hub_screen_test.dart
+++ b/app/test/features/games/presentation/screens/games_hub_screen_test.dart
@@ -23,6 +23,26 @@ void main() {
       expect(find.text('Coming Soon'), findsOneWidget);
     });
 
+    testWidgets('shows a compact preview and opens the full category sheet', (
+      tester,
+    ) async {
+      await tester.pumpWidget(buildScreen());
+      await tester.pumpAndSettle();
+
+      expect(find.text('Solitaire'), findsNothing);
+      expect(find.text('View All'), findsOneWidget);
+
+      await tester.tap(find.byKey(const ValueKey('games_view_all_card_games')));
+      await tester.pumpAndSettle();
+
+      expect(
+        find.byKey(const ValueKey('games_section_sheet_card_games')),
+        findsOneWidget,
+      );
+      expect(find.text('5 games'), findsOneWidget);
+      expect(find.text('Solitaire'), findsOneWidget);
+    });
+
     testWidgets(
       'opens the coming soon screen when an unavailable card is tapped',
       (tester) async {

--- a/app/test/features/money/money_overview_screen_test.dart
+++ b/app/test/features/money/money_overview_screen_test.dart
@@ -44,14 +44,29 @@ void main() {
   }
 
   group('MoneyOverviewScreen', () {
-    testWidgets('shows Hermes-style Coins hero without command actions', (
+    testWidgets('shows a compact Coins hero without command actions', (
       tester,
     ) async {
+      tester.view.physicalSize = const Size(390, 844);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
       await tester.pumpWidget(buildScreen());
       await tester.pump();
 
       expect(find.text('OPEN FINANCE • AIRO COINS'), findsOneWidget);
-      expect(find.text('THE MONEY THAT\nWORKS WITH YOU.'), findsOneWidget);
+      expect(find.textContaining('Money that works with you'), findsOneWidget);
+      expect(
+        find.text('Accounts, ledger, and budgets stay in one place.'),
+        findsOneWidget,
+      );
+      expect(find.text('Available balance'), findsOneWidget);
+      expect(find.text('\$1250.00'), findsOneWidget);
+      expect(find.text('ACCOUNTS'), findsWidgets);
+      expect(find.text('LEDGER'), findsWidgets);
+      expect(find.text('BUDGETS'), findsWidgets);
+      expect(find.text('THE MONEY THAT\nWORKS WITH YOU.'), findsNothing);
       expect(find.text('1.  CREATE'), findsNothing);
       expect(find.text('2.  REVIEW'), findsNothing);
       expect(


### PR DESCRIPTION
# Compact mobile hub layouts and launch init timing

---

# Summary

This PR carries the remaining validated UI/UX work from the thread onto the latest `main`.
Goal: reduce mobile layout waste in Coins and Games while keeping app startup work off the first frame.

Core outcome:

* compacts the Coins mobile hero and finance status layout
* adds a `View All` flow for larger Games sections
* defers audio service initialization until after first frame in both app entrypoints

---

# Changes

### Code

* Added:
  * Games category bottom-sheet expansion flow for compact previews
  * focused widget coverage for the updated Coins and Games behavior
* Updated:
  * Coins overview mobile layout density and status panel behavior
  * app startup initialization ordering in `main.dart` and `main_mobile_streaming.dart`
* Removed:
  * none

### Logic

* large game sections now preview a small subset on the hub and expose the full list on demand
* Coins status panels collapse into a readable single-column stack on narrow screens
* audio service initialization is scheduled after first frame instead of blocking app bootstrap

---

# API Changes

* None.

---

# Database Changes

* None.

---

# Observability / Logging

* No new logs or metrics.

---

# Performance Impact

* Latency: reduces first-frame startup blocking from audio service initialization
* Throughput: none
* Memory/CPU: no material change expected

---

# Risks

* compact Coins copy and spacing should still be visually checked on a physical narrow device
* deferred audio initialization changes app startup timing and should be sanity-checked on Android launch
* Rollback plan:
  * revert commit `96582c0`

---

# Testing

* Unit tests:
  * `flutter test test/features/money/money_overview_screen_test.dart`
  * `flutter test test/features/games/presentation/screens/games_hub_screen_test.dart`
* Manual testing:
  * `flutter analyze lib/main.dart lib/main_mobile_streaming.dart lib/features/money/presentation/screens/money_overview_screen.dart lib/features/games/presentation/screens/games_hub_screen.dart`

---

# Deployment Notes

* No config changes.
* No deployment ordering requirements.

---

# Related Commits

* `96582c0 fix(ui): compact mobile hub layouts`

---

# Notes

* This branch was recreated from the latest `origin/main` per repository worktree policy before applying the thread's remaining local diff.
