### PR TITLE
docs(ui): finalize mobile governance packet

### DIFF
--- a/docs/adr/0006-mobile-ui-governance-and-shell-ownership.md
+++ b/docs/adr/0006-mobile-ui-governance-and-shell-ownership.md
@@ -31,7 +31,12 @@ We establish Mobile UI governance with the following rules:
    shell-owned, route-owned, or intentionally hidden for immersive flows.
 4. Shared token roles, navigation metadata, and shell asset references must be
    centralized before feature-level UI changes are accepted.
-5. Governance docs must exist in the repo so follow-up execution issues can
+5. Global shell header and native/platform header behavior must converge on one
+   visible top-chrome surface rather than stacking duplicate bars.
+6. Narrow-screen primary navigation must use a constrained action budget, with
+   lower-frequency destinations routed through centrally owned overflow or
+   hamburger patterns.
+7. Governance docs must exist in the repo so follow-up execution issues can
    implement shell/header, token/navigation, and asset work against a stable
    contract.
 
@@ -42,6 +47,8 @@ We establish Mobile UI governance with the following rules:
 - reduces duplicate header regressions
 - gives feature teams a clear shell boundary
 - centralizes navigation and shared visual decisions
+- protects vertical space on phones
+- encourages native-first interaction patterns
 - lets implementation work be split into smaller focused issues
 
 ### Negative
@@ -53,6 +60,8 @@ We establish Mobile UI governance with the following rules:
 
 - governance can drift if follow-up UI work does not update the shared docs
 - partial migration may temporarily leave mixed old and new shell behavior
+- aggressive consolidation can hide feature actions if overflow behavior is not
+  tested carefully
 
 ## Alternatives Considered
 
@@ -74,4 +83,5 @@ not just one header bug.
 
 - [Mobile UI Agent Packet](../agents/mobile-ui-agent/README.md)
 - [Mobile UI / UX Standards](../standards/mobile-ui-ux-standards.md)
+- [Mobile UI Agent Phase Plan](../agents/mobile-ui-agent/UIUX_PHASE_PLAN_2026-06.md)
 - [Issue #397](https://github.com/DevelopersCoffee/airo/issues/397)

--- a/docs/agents/index.md
+++ b/docs/agents/index.md
@@ -10,7 +10,7 @@
 | [📜 Rules](./RULES.md) | Agent operating rules |
 | [🧭 Agent Policy](./AGENT_POLICY.md) | Ownership, lifecycle gates, contracts, and Critical Agent workflow |
 | [🧪 Kaggle Adoption](./KAGGLE_VIBE_CODING_ADOPTION.md) | Spec-driven, skills, tools, security, and evaluation adoption plan |
-| [📱 Mobile UI Agent](./mobile-ui-agent/README.md) | Shell ownership, header governance, UI standards, and execution tasks |
+| [📱 Mobile UI Agent](./mobile-ui-agent/README.md) | Canonical UI/UX owner for shell ownership, header governance, standards, and execution tasks |
 | [🔄 SDLC](./SDLC.md) | Development workflow |
 | [📅 Sequence](./SEQUENCE.md) | Agent activation order |
 

--- a/docs/agents/mobile-ui-agent/README.md
+++ b/docs/agents/mobile-ui-agent/README.md
@@ -1,8 +1,9 @@
 # Mobile UI Agent
 
-The Mobile UI Agent owns shell chrome, navigation presentation, header
-ownership policy, shared mobile layout standards, and the governance documents
-that keep feature teams from making independent shell decisions.
+The Mobile UI Agent is the canonical UI/UX owner for Airo mobile shell
+surfaces. It owns shell chrome, navigation presentation, header ownership
+policy, shared mobile layout standards, and the governance documents that keep
+feature teams from making independent shell decisions.
 
 ## Scope
 
@@ -13,6 +14,8 @@ The Mobile UI Agent is the primary owner for:
 - mobile header ownership rules
 - shared mobile visual standards and density guardrails
 - shared asset usage rules for shell imagery and iconography
+- native-first interaction standards for Android and iOS shell behavior
+- narrow-screen overflow and hamburger/menu policy
 
 The Mobile UI Agent reviews, but does not solely own:
 
@@ -25,12 +28,28 @@ The Mobile UI Agent reviews, but does not solely own:
 Feature screens own feature content and local task flows. They do not own:
 
 - the global shell header
+- a second native or local header layered beneath the global shell header
 - the primary destination model
 - shell branding asset selection
 - breakpoint-wide navigation behavior
 
 If a feature needs contextual chrome, it must declare that need through the
 shared shell configuration and ADR-backed route ownership rules.
+
+## UX Direction
+
+The shared mobile UX direction is:
+
+- AI-first productivity, not chat-first novelty
+- calm, professional, and dense without clutter
+- progressive disclosure instead of stacked controls
+- one clear header owner per route state
+- centralized navigation and asset decisions
+- native Android and iOS interaction patterns before custom chrome
+
+Google AI Edge Gallery-style usability, accessibility, and platform alignment
+are the preferred foundation. Deliberately harsh or brutalist treatments are
+not the default for product surfaces.
 
 ## Required Inputs Before Implementation
 
@@ -47,9 +66,11 @@ Every Mobile UI issue must include:
 - UI standards: [../../standards/mobile-ui-ux-standards.md](../../standards/mobile-ui-ux-standards.md)
 - ADR: [../../adr/0006-mobile-ui-governance-and-shell-ownership.md](../../adr/0006-mobile-ui-governance-and-shell-ownership.md)
 - Task tracker: [./TASKS.md](./TASKS.md)
+- Phase plan: [./UIUX_PHASE_PLAN_2026-06.md](./UIUX_PHASE_PLAN_2026-06.md)
 
 ## Current Execution Issues
 
-- `#398` UIUX-002: Consolidate shell and page header ownership
-- `#399` UIUX-003: Centralize theme tokens and navigation configuration
-- `#400` UIUX-004: Centralize shell asset management and chrome hygiene
+- `#415` UIUX-005: Native-first mobile shell UX rollout
+- `#417` UIUX-006: Enforce single-header ownership and compact shell chrome
+- `#418` UIUX-007: Centralize navigation overflow and hamburger policy
+- `#416` UIUX-008: Centralize shell assets and route density hygiene

--- a/docs/agents/mobile-ui-agent/TASKS.md
+++ b/docs/agents/mobile-ui-agent/TASKS.md
@@ -1,37 +1,62 @@
 # Mobile UI Agent Tasks
 
-**Context**: Airo shell chrome and navigation decisions need a shared mobile UI
-governance layer before more feature screens keep evolving independently.
+**Context**: The initial governance packet exists, but the next UI/UX phase
+needs tighter standards around native-first shell patterns, top-space
+efficiency, centralized asset management, and narrow-screen overflow behavior.
 
-**Goal**: Document shell/header ownership, standards, and execution sequencing
-for mobile UI work.
+**Goal**: Keep future UI work aligned to one shared shell contract so feature
+teams stop re-solving headers, navigation, and branding inside screen files.
 
-## Governance Deliverables
+## Completed Governance Foundation
 
 ### 1. Mobile UI agent packet - [x] DONE
 
-- [x] Define ownership boundaries for shell chrome, navigation, and shared
+- [x] Ownership boundaries defined for shell chrome, navigation, and shared
   mobile presentation
-- [x] Document required issue inputs before implementation
-- [x] Link the governing standards and ADR artifacts
+- [x] Required issue inputs documented before implementation
+- [x] Governing standards and ADR artifacts linked
 
 ### 2. Shell/header ADR - [x] DONE
 
-- [x] Record the shell-versus-route ownership rule
-- [x] Define when fullscreen and contextual headers are allowed
-- [x] Capture the consequences and rollout expectations
+- [x] Shell-versus-route ownership rule recorded
+- [x] Fullscreen and contextual header cases defined
+- [x] Consequences and rollout expectations captured
 
 ### 3. Shared UI standards - [x] DONE
 
-- [x] Define token, header, navigation, and asset governance rules
-- [x] Clarify feature-team constraints versus shared-shell ownership
-- [x] Provide verification expectations for follow-up UI work
+- [x] Token, header, navigation, and asset governance rules defined
+- [x] Feature-team constraints versus shared-shell ownership clarified
+- [x] Verification expectations for follow-up UI work documented
 
-### 4. Child implementation queue - [x] READY
+## Current Phase Work
 
-- [x] `#398` header ownership consolidation
-- [x] `#399` theme tokens and navigation centralization
-- [x] `#400` shell asset registry and chrome hygiene
+### 4. Native-first header and chrome standards - [ ] PLANNED
+
+- [ ] remove duplicate global/local/native header stacking
+- [ ] define compact action budgets and overflow rules
+- [ ] audit routes that still consume unnecessary top space
+- [ ] `#417` single-header and compact chrome execution
+
+### 5. Navigation and unified configuration - [ ] PLANNED
+
+- [ ] keep primary navigation in one shared destination model
+- [ ] define when bottom nav, navigation rail, drawer, or hamburger applies
+- [ ] prevent feature-local destination invention
+- [ ] `#418` shared navigation overflow and hamburger policy execution
+
+### 6. Asset and visual system hygiene - [ ] PLANNED
+
+- [ ] centralize shell asset references
+- [ ] tighten token usage and spacing consistency
+- [ ] remove decorative shell clutter that does not improve task completion
+- [ ] `#416` shell asset and density hygiene execution
+
+### 7. Verification rollout - [ ] PLANNED
+
+- [ ] add deterministic route/header ownership tests
+- [ ] add overflow navigation and asset registry verification
+- [ ] split execution into focused child issues
+- [ ] `#415` parent rollout tracking and sequencing
 
 ## Verification
 
@@ -39,10 +64,12 @@ for mobile UI work.
 - ADR exists under `docs/adr/`
 - Standards doc exists under `docs/standards/`
 - Agent index links to the Mobile UI Agent packet
-- ADR index includes the new shell/header governance decision
+- ADR index includes the shell/header governance decision
+- Phase plan exists for the current UI/UX rollout
 
 ## Notes
 
-- This packet is governance-only. It intentionally does not implement the shell
-  changes tracked by `#398`, `#399`, or `#400`.
-- Future Mobile UI issues should update this task list as execution work lands.
+- The Mobile UI Agent remains the canonical UI/UX owner for shell behavior.
+- Do not create a second parallel UI ownership packet unless the repo-wide
+  ownership map changes.
+- Current phase issue queue: `#415`, `#417`, `#418`, `#416`

--- a/docs/agents/mobile-ui-agent/UIUX_PHASE_PLAN_2026-06.md
+++ b/docs/agents/mobile-ui-agent/UIUX_PHASE_PLAN_2026-06.md
@@ -1,0 +1,86 @@
+# Mobile UI Agent Phase Plan
+
+## Objective
+
+Standardize Airo mobile UI/UX so shell decisions do not get re-litigated in
+feature work. The rollout should enforce one header owner, centralized
+navigation and asset configuration, and native-first space-efficient patterns.
+
+## Planning Frame
+
+**Problem:** Duplicate header surfaces, uneven use of local `AppBar`s,
+overcrowded top-level navigation, and ad hoc shell asset usage reduce usable
+space and create inconsistent behavior.
+
+**User / actor:** Mobile users across core Airo destinations and engineers
+shipping UI changes.
+
+**Framework or application layer:** Mixed
+
+**Owning agent:** agent/mobile-ui
+
+**Reviewing agents:** agent/core-architecture, agent/qa-testing, agent/docs
+
+**Base branch/worktree:** Must start from latest `origin/main`
+
+## Issue Queue
+
+- `#415` Parent rollout and sequencing
+- `#417` Single-header ownership and compact shell chrome
+- `#418` Shared navigation overflow and hamburger policy
+- `#416` Shell assets and route density hygiene
+
+## Workstreams
+
+### 1. Header and Chrome Consolidation
+
+- remove duplicate global and local header stacking
+- define shell-owned, route-owned, and immersive route states
+- reduce top chrome height where actions can move to overflow
+- verify auth/profile/system actions remain reachable
+
+### 2. Navigation and Overflow Governance
+
+- centralize primary destination metadata
+- cap narrow-screen primary navigation to a sustainable action budget
+- route lower-frequency destinations through shared overflow or hamburger entry
+- preserve large-screen adaptations without forking route ownership rules
+
+### 3. Visual Token and Density Governance
+
+- define spacing, radius, color, and typography roles centrally
+- remove shell-level magic numbers from product surfaces
+- keep the UI professional, calm, and information-dense
+- favor speed and clarity over decorative motion
+
+### 4. Asset and Iconography Governance
+
+- route shell imagery through a single registry
+- prevent duplicate raw asset paths across features
+- define when logos, illustrations, and badges are allowed in shell surfaces
+- align icons with native conventions before custom treatments
+
+### 5. Verification and Rollout
+
+- add widget or route tests for header ownership and overflow behavior
+- add static checks or audits for centralized asset usage
+- migrate feature surfaces incrementally instead of redesigning the whole app at once
+- track follow-up work as focused child issues, not one long-running mega-task
+
+## Definition of Ready
+
+Before implementation work starts, each issue must include:
+
+- Critical Agent Gate
+- explicit owner and reviewing agents
+- deterministic use cases for phone and larger-screen layouts
+- automation flows for the changed shell behavior
+- rollback or migration notes
+
+## Definition of Done
+
+- UX behavior is driven by centralized config, not feature-local shell widgets
+- exactly one top header is visible for every route state
+- primary navigation is consistent across the app at the same breakpoint
+- shell assets resolve through shared accessors
+- tests cover route ownership and overflow behavior

--- a/docs/standards/mobile-ui-ux-standards.md
+++ b/docs/standards/mobile-ui-ux-standards.md
@@ -7,6 +7,23 @@ mobile shell UI in Airo. Shared shell concerns must be configured centrally so
 feature screens do not create their own competing navigation, header, token, or
 branding rules.
 
+The product direction is AI-first productivity, not chat-first novelty. The UI
+should feel calm, professional, trustworthy, and fast.
+
+## Design Principles
+
+- simplicity over decoration
+- speed over animations
+- information density without clutter
+- progressive disclosure instead of stacked controls
+- native Android and iOS interaction patterns first
+- accessibility by default
+- offline-first user experience
+
+Google AI Edge Gallery-style usability and platform alignment are the preferred
+baseline. Experimental visual treatments may exist in isolated surfaces, but
+they do not define shared shell behavior.
+
 ## Ownership Rules
 
 Shared UI code owns:
@@ -28,6 +45,7 @@ Feature screens own:
 Feature screens must not:
 
 - add a competing shell app bar on a shell-managed route
+- layer a Flutter header beneath a native header or vice versa
 - hardcode new primary destinations outside shared navigation config
 - invent shared shell asset paths locally
 - redefine shared spacing, color, or typography roles ad hoc
@@ -44,6 +62,19 @@ A route must explicitly opt into contextual or immersive behavior through
 shared configuration. Feature widgets should not silently render their own top
 app bars when mounted under shell-owned destinations.
 
+Global and native top chrome must resolve to one visible surface. The app must
+not consume vertical space with both a shell header and a second local or
+platform header unless the route is explicitly designed as a split-pane or
+stacked editing flow.
+
+Header action rules:
+
+- root destinations keep a compact action budget
+- secondary actions move to shared overflow before header height increases
+- auth/profile/system actions remain reachable from shared shell affordances
+- feature-specific actions should prefer contextual menus, sheets, or inline
+  actions over permanently expanding top chrome
+
 ## Navigation Standard
 
 Navigation metadata must come from one source of truth that includes:
@@ -59,13 +90,18 @@ Primary destination overflow on phones must be handled centrally. Feature code
 must consume the shared navigation model instead of constructing its own bottom
 navigation items.
 
-Current default compact policy:
+Navigation rules by breakpoint:
 
-- phones under the shared compact breakpoint keep `Coins`, `Mind`, `Beats`, and
-  `Stream` in persistent bottom navigation
-- `Arena` and `Quest` move into one shared `More` overflow entry
-- larger layouts keep the full primary destination set visible without a
-  feature-level fork
+- phones: use bottom navigation only for the highest-frequency destinations
+- phones: move lower-frequency primary destinations into shared overflow or
+  hamburger entry when the action budget is exceeded
+- tablets and large screens: adapt with rail or drawer, but keep the same
+  destination registry and ownership rules
+- all breakpoints: avoid nested navigation deeper than three levels unless the
+  route is a clearly bounded task flow
+
+The shell should prefer one predictable overflow model over multiple competing
+menus.
 
 ## Token Standard
 
@@ -80,6 +116,21 @@ Shared visual roles belong in centralized tokens, including:
 
 Application code may compose these tokens, but should not mint new shell-wide
 roles unless the shared token contract is updated first.
+
+Do not hardcode shell typography sizes or spacing values in screen files.
+Platform typography should be used by role, not by ad hoc number selection.
+
+Minimum shared hierarchy:
+
+- screen title
+- section header
+- body
+- secondary description
+- metadata
+- caption
+
+Monospace is reserved for logs, code, technical metadata, and terminal-like
+surfaces. It is not a default product typeface.
 
 ## Asset Standard
 
@@ -99,6 +150,40 @@ Disallowed behavior:
 - ad hoc branding changes inside screen files
 - direct references such as `assets/hermes/images/filler-bg0.jpg` outside the shared asset registry
 
+Shell imagery rules:
+
+- decorative artwork must justify the space it consumes
+- shell surfaces should prefer icons and hierarchy over large banners
+- icons should follow native platform expectations before custom illustration
+- shared branding changes must be achievable from one registry layer
+
+## Space and Density Standard
+
+The shell must treat vertical space as constrained on phones.
+
+Required behavior:
+
+- avoid double headers
+- avoid redundant section titles that repeat the shell title
+- move infrequent actions into overflow before adding more persistent chrome
+- use tokenized spacing scales instead of one-off padding values
+- prefer sheets, drawers, and expandable sections for secondary controls
+
+Disallowed behavior:
+
+- permanent top-level banners without strong product value
+- six or more equal-priority bottom tabs on phones
+- route roots that repeat title, subtitle, and actions already shown in shell
+
+## Platform Adaptation Standard
+
+- Android should align to Material 3 tokens and interaction patterns
+- iOS should align to Human Interface Guidelines and native navigation
+  expectations
+- light and dark mode should respect system appearance by default
+- platform adaptation must not fork the information architecture without a
+  shared contract decision
+
 ## Verification Expectations
 
 Follow-up Mobile UI implementation issues should include:
@@ -110,7 +195,6 @@ Follow-up Mobile UI implementation issues should include:
 
 ## Related Work
 
-- Governance epic: `#397`
-- Header ownership implementation: `#398`
-- Theme and navigation centralization: `#399`
-- Shell asset centralization: `#400`
+- Governance docs: `docs/agents/mobile-ui-agent/README.md`
+- ADR: `docs/adr/0006-mobile-ui-governance-and-shell-ownership.md`
+- Phase plan: `docs/agents/mobile-ui-agent/UIUX_PHASE_PLAN_2026-06.md`


### PR DESCRIPTION
# docs(ui): finalize mobile governance packet

---

# Summary

This PR lands the remaining governance artifacts from the UI/UX thread.
Goal: keep future shell and mobile UI work aligned to one accepted standards packet instead of repeated local redesign decisions.

Core outcome:

* promotes the Mobile UI Agent as the canonical UI/UX owner for shell work
* extends the ADR and standards with single-header, overflow, density, and native-first rules
* adds the current phase plan tied to the existing GitHub issue queue

---

# Changes

### Code

* Added:
  * `docs/agents/mobile-ui-agent/UIUX_PHASE_PLAN_2026-06.md`
* Updated:
  * `docs/adr/0006-mobile-ui-governance-and-shell-ownership.md`
  * `docs/agents/index.md`
  * `docs/agents/mobile-ui-agent/README.md`
  * `docs/agents/mobile-ui-agent/TASKS.md`
  * `docs/standards/mobile-ui-ux-standards.md`
* Removed:
  * none

### Logic

* defines one-header ownership and compact action budget expectations
* centralizes navigation overflow and hamburger governance at the standards layer
* records the issue-sequenced rollout plan for the accepted Mobile UI packet

---

# API Changes

* None.

---

# Database Changes

* None.

---

# Observability / Logging

* None.

---

# Performance Impact

* None. Documentation-only.

---

# Risks

* the plan references the current issue queue and should be updated if issue ownership changes later
* Rollback plan:
  * revert commit `4a0e5d0`

---

# Testing

* Manual review of ADR, standards, agent packet, and phase-plan consistency.

---

# Deployment Notes

* No config or deployment changes.

---

# Related Commits

* `4a0e5d0 docs(ui): finalize mobile governance packet`

---

# Notes

* The draft issue markdown from the stale worktree was intentionally not carried over because the corresponding GitHub issues already exist.
