### PR TITLE
fix(core-ai): LiteRT device-fit gate for low free RAM

### DIFF
--- a/app/test/features/agent_chat/data/services/assistant_runtime_service_test.dart
+++ b/app/test/features/agent_chat/data/services/assistant_runtime_service_test.dart
@@ -266,6 +266,62 @@ void main() {
     });
 
     test(
+      'does not block LiteRT packages when only transient free RAM is low',
+      () async {
+        final package = OfflineModelInfo(
+          id: 'gemma-4-e2b-it-litertlm',
+          name: 'Gemma 4 E2B',
+          family: ModelFamily.gemma,
+          fileSizeBytes: 2 * 1024 * 1024 * 1024,
+          backendPreference: ModelBackendPreference.gpu,
+          provider: AIProvider.gemma,
+          capabilities: const [ModelCapability.chat],
+        );
+        var warmed = false;
+        final service = AssistantRuntimeService(
+          isLiteRtAvailable: () async => true,
+          warmupLiteRtModel: (_) async {
+            warmed = true;
+            return true;
+          },
+          loadDeviceInfo: () async => {
+            'manufacturer': 'Google',
+            'model': 'Pixel 9',
+            'platform': 'android',
+          },
+          checkModelCompatibility: (_) async => const ModelCompatibilityResult(
+            isCompatible: true,
+            memorySeverity: MemorySeverity.critical,
+            reason:
+                'This package fits the device budget, but only 885 MB is currently free. It needs 2.4 GB available to warm up cleanly.',
+            availableMemoryMB: 885,
+            requiredMemoryMB: 2458,
+          ),
+        );
+
+        final result = await service.prepareRuntime(
+          candidate: AssistantModelCandidate(
+            id: litertGemmaAssistantModelId,
+            name: 'Gemma mobile package',
+            runtime: 'LiteRT-LM local model',
+            description: 'Local package',
+            bestFor: const [AssistantTask.chat],
+            tags: const ['Local'],
+            privacyLabel: 'Prompt stays on device',
+            sizeLabel: package.fileSizeDisplay,
+            available: true,
+            actionLabel: 'Start',
+            local: true,
+            package: package,
+          ),
+        );
+
+        expect(result.status, AssistantRuntimePreparationStatus.ready);
+        expect(warmed, isTrue);
+      },
+    );
+
+    test(
       'prepares generic LiteRT runtime from a downloaded package when default runtime is unavailable',
       () async {
         final package = OfflineModelInfo(

--- a/packages/core_ai/lib/src/device/memory_budget_manager.dart
+++ b/packages/core_ai/lib/src/device/memory_budget_manager.dart
@@ -99,14 +99,17 @@ class MemoryBudgetManager {
     }
 
     final budget = calculateBudget(memoryInfo);
+    final usagePercent = estimatedUsageBytes / budget;
 
-    // Check if model would exceed available memory
-    if (estimatedUsageBytes > memoryInfo.availableBytes) {
+    if (usagePercent > 1.0) {
       return MemorySeverity.blocked;
     }
 
-    // Check against budget thresholds
-    final usagePercent = estimatedUsageBytes / budget;
+    // Low transient free RAM should warn, not hard-block, when the device
+    // budget still fits the model.
+    if (estimatedUsageBytes > memoryInfo.availableBytes) {
+      return MemorySeverity.critical;
+    }
 
     if (usagePercent <= warningThresholdPercent) {
       return MemorySeverity.safe;

--- a/packages/core_ai/lib/src/registry/model_registry.dart
+++ b/packages/core_ai/lib/src/registry/model_registry.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:developer' as developer;
 
 import '../device/device_capability_service.dart';
+import '../device/memory_budget_manager.dart';
 import '../device/memory_severity.dart';
 import '../models/model_credibility.dart';
 import '../models/offline_model_info.dart';
@@ -55,10 +56,22 @@ class ModelCompatibilityResult {
 /// - Check device compatibility
 /// - Track downloaded vs available models
 class ModelRegistry {
-  ModelRegistry({DeviceCapabilityService? deviceCapabilityService})
-    : _deviceService = deviceCapabilityService ?? DeviceCapabilityService();
+  ModelRegistry({
+    DeviceCapabilityService? deviceCapabilityService,
+    Future<MemoryInfo> Function()? loadMemoryInfo,
+    MemoryBudgetManager? memoryBudgetManager,
+  }) : _deviceService = deviceCapabilityService ?? DeviceCapabilityService(),
+       _loadMemoryInfo = loadMemoryInfo,
+       _memoryBudgetManager =
+           memoryBudgetManager ??
+           MemoryBudgetManager(
+             deviceCapability:
+                 deviceCapabilityService ?? DeviceCapabilityService(),
+           );
 
   final DeviceCapabilityService _deviceService;
+  final Future<MemoryInfo> Function()? _loadMemoryInfo;
+  final MemoryBudgetManager _memoryBudgetManager;
   final Map<String, OfflineModelInfo> _models = {};
   final _changeController = StreamController<ModelRegistryEvent>.broadcast();
 
@@ -174,40 +187,52 @@ class ModelRegistry {
     OfflineModelInfo model,
   ) async {
     try {
-      final memoryInfo = await _deviceService.getMemoryInfo();
+      final memoryInfo =
+          await (_loadMemoryInfo?.call() ?? _deviceService.getMemoryInfo());
+      final requiredBytes = model.estimatedMinMemoryBytes;
 
       if (!memoryInfo.isAvailable) {
-        return ModelCompatibilityResult.compatible(MemorySeverity.warning);
-      }
-
-      final requiredBytes = model.estimatedMinMemoryBytes;
-      final availableBytes = memoryInfo.availableBytes;
-
-      if (availableBytes < requiredBytes) {
         return ModelCompatibilityResult(
-          isCompatible: false,
-          memorySeverity: MemorySeverity.blocked,
-          reason:
-              'Insufficient memory. Need ${model.fileSizeDisplay}, '
-              'but only ${memoryInfo.availableGB.toStringAsFixed(1)} GB available.',
-          availableMemoryMB: memoryInfo.availableMB,
+          isCompatible: true,
+          memorySeverity: MemorySeverity.warning,
           requiredMemoryMB: requiredBytes / (1024 * 1024),
         );
       }
 
-      // Calculate severity based on usage percentage
-      final usageRatio = requiredBytes / availableBytes;
-      final severity = switch (usageRatio) {
-        < 0.5 => MemorySeverity.safe,
-        < 0.8 => MemorySeverity.warning,
-        _ => MemorySeverity.critical,
-      };
+      final severity = _memoryBudgetManager.checkMemoryForModel(
+        requiredBytes,
+        memoryInfo,
+      );
+      final requiredMemoryMB = requiredBytes / (1024 * 1024);
+      final availableMemoryMB = memoryInfo.availableMB;
+
+      if (severity == MemorySeverity.blocked) {
+        final budgetBytes = _memoryBudgetManager.calculateBudget(memoryInfo);
+        return ModelCompatibilityResult(
+          isCompatible: false,
+          memorySeverity: severity,
+          reason:
+              'Insufficient device memory budget. Need '
+              '${_formatMemory(requiredBytes)}, but this device budget is '
+              '${_formatMemory(budgetBytes)}.',
+          availableMemoryMB: availableMemoryMB,
+          requiredMemoryMB: requiredMemoryMB,
+        );
+      }
+
+      final lowTransientMemory = memoryInfo.availableBytes < requiredBytes;
+      final reason = lowTransientMemory
+          ? 'This package fits the device budget, but only '
+                '${_formatMemory(memoryInfo.availableBytes)} is currently free. '
+                'It needs ${_formatMemory(requiredBytes)} available to warm up cleanly.'
+          : null;
 
       return ModelCompatibilityResult(
         isCompatible: true,
         memorySeverity: severity,
-        availableMemoryMB: memoryInfo.availableMB,
-        requiredMemoryMB: requiredBytes / (1024 * 1024),
+        reason: reason,
+        availableMemoryMB: availableMemoryMB,
+        requiredMemoryMB: requiredMemoryMB,
       );
     } catch (e) {
       developer.log(
@@ -218,6 +243,14 @@ class ModelRegistry {
       // Return compatible with warning on error
       return ModelCompatibilityResult.compatible(MemorySeverity.warning);
     }
+  }
+
+  String _formatMemory(int bytes) {
+    final megabytes = bytes / (1024 * 1024);
+    if (megabytes >= 1024) {
+      return '${(megabytes / 1024).toStringAsFixed(1)} GB';
+    }
+    return '${megabytes.toStringAsFixed(0)} MB';
   }
 
   /// Gets compatible models for the current device.

--- a/packages/core_ai/test/device/memory_budget_manager_test.dart
+++ b/packages/core_ai/test/device/memory_budget_manager_test.dart
@@ -140,20 +140,23 @@ void main() {
       expect(severity, equals(MemorySeverity.blocked));
     });
 
-    test('returns blocked when exceeds available memory', () {
-      const memoryInfo = MemoryInfo(
-        totalBytes: totalBytes,
-        availableBytes: 2147483648, // Only 2GB available
-      );
+    test(
+      'returns critical when budget fits but free memory is transiently low',
+      () {
+        const memoryInfo = MemoryInfo(
+          totalBytes: totalBytes,
+          availableBytes: 2147483648, // Only 2GB available
+        );
 
-      // Try to use 3GB when only 2GB available
-      final severity = manager.checkMemoryForModel(
-        3221225472, // 3GB
-        memoryInfo,
-      );
+        // 3GB fits the 4.8GB device budget but exceeds current free memory.
+        final severity = manager.checkMemoryForModel(
+          3221225472, // 3GB
+          memoryInfo,
+        );
 
-      expect(severity, equals(MemorySeverity.blocked));
-    });
+        expect(severity, equals(MemorySeverity.critical));
+      },
+    );
 
     test('returns warning when memory info unavailable', () {
       final memoryInfo = MemoryInfo.unknown();

--- a/packages/core_ai/test/registry/model_registry_test.dart
+++ b/packages/core_ai/test/registry/model_registry_test.dart
@@ -391,6 +391,55 @@ void main() {
       expect(registry.getModel('test')?.isDownloaded, true);
       expect(registry.getModel('test')?.filePath, '/path/to/model.gguf');
     });
+
+    test(
+      'does not hard block when total budget fits but transient free RAM is low',
+      () async {
+        final registry = ModelRegistry(
+          loadMemoryInfo: () async =>
+              MemoryInfo.fromMegabytes(totalMB: 11848, availableMB: 885),
+        );
+        const model = OfflineModelInfo(
+          id: 'pixel-9-fit',
+          name: 'Gemma 4 E2B',
+          family: ModelFamily.gemma,
+          fileSizeBytes: 2 * 1024 * 1024 * 1024,
+        );
+
+        final result = await registry.checkCompatibility(model);
+
+        expect(result.isCompatible, isTrue);
+        expect(result.memorySeverity, MemorySeverity.critical);
+        expect(result.reason, contains('fits the device budget'));
+        expect(result.reason, contains('2.4 GB'));
+        registry.dispose();
+      },
+    );
+
+    test(
+      'blocks when the device memory budget is genuinely too small',
+      () async {
+        final registry = ModelRegistry(
+          loadMemoryInfo: () async =>
+              MemoryInfo.fromMegabytes(totalMB: 3072, availableMB: 2048),
+        );
+        const model = OfflineModelInfo(
+          id: 'too-large',
+          name: 'Gemma 4 E2B',
+          family: ModelFamily.gemma,
+          fileSizeBytes: 2 * 1024 * 1024 * 1024,
+        );
+
+        final result = await registry.checkCompatibility(model);
+
+        expect(result.isCompatible, isFalse);
+        expect(result.memorySeverity, MemorySeverity.blocked);
+        expect(result.reason, contains('device memory budget'));
+        expect(result.reason, contains('2.4 GB'));
+        expect(result.reason, isNot(contains(model.fileSizeDisplay)));
+        registry.dispose();
+      },
+    );
   });
 
   group('ModelCatalog', () {


### PR DESCRIPTION
# Summary

This PR fixes the LiteRT device-fit compatibility gate so supported devices are no longer hard-blocked when only transient free RAM is low.
Goal: use the safe device budget derived from total RAM for hard blocks while preserving warning/critical messaging for low free memory.

Core outcome:

* supported devices like Pixel 9 are no longer falsely blocked for LiteRT packages that fit the device budget
* compatibility messaging now reports actual required memory instead of package file size

# Changes

### Code

* Added:
  * targeted regression tests for ModelRegistry, MemoryBudgetManager, and AssistantRuntimeService
* Updated:
  * packages/core_ai/lib/src/device/memory_budget_manager.dart to block on budget overflow instead of transient free RAM
  * packages/core_ai/lib/src/registry/model_registry.dart to classify low free RAM as compatible-but-critical and improve memory messaging
* Removed:
  * false incompatibility path based on availableBytes < requiredBytes

### Logic

* hard blocks now use the 60% total-RAM model budget
* low transient free RAM downgrades severity to critical instead of blocking supported devices
* blocked reasons now cite actual required memory rather than file size

# API Changes (if any)

* None.

# Database Changes (if any)

* None.

# Observability / Logging

* None.

# Performance Impact

* Latency: no meaningful change
* Throughput: no meaningful change
* Memory/CPU: no meaningful change

# Risks

* devices may still fail warmup under extreme live memory pressure even when the budget fits
* compatibility now errs toward launch with warning/critical instead of a conservative block
* Rollback plan:
  * revert this PR if runtime warmup failures increase on supported devices

# Testing

* Unit tests:
  * flutter test test/device/memory_budget_manager_test.dart test/registry/model_registry_test.dart in packages/core_ai
* Integration tests:
  * none
* Manual testing:
  * not run
* App test:
  * flutter test test/features/agent_chat/data/services/assistant_runtime_service_test.dart

# Deployment Notes

* Config changes:
  * none
* Order of deployment:
  * normal release flow

# Related Commits

* fix(core-ai): use device budget for LiteRT fit gate

# Notes

* Closes #481.
