### PR TITLE
fix(core-ai): enforce local-only router policy

### DIFF
--- a/packages/core_ai/lib/src/litert/litert_lm_runtime_adapter.dart
+++ b/packages/core_ai/lib/src/litert/litert_lm_runtime_adapter.dart
@@ -472,10 +472,9 @@ class LiteRtLmRuntimeAdapter implements LocalInferenceRuntimeAdapter {
 
 class MethodChannelLiteRtLmClient implements LiteRtLmClient {
   MethodChannelLiteRtLmClient({
-    required LiteRtLmConfig config,
-    MethodChannel channel = const MethodChannel('com.airo.litert_lm'),
-  }) : _config = config,
-       _channel = channel;
+    required this._config,
+    this._channel = const MethodChannel('com.airo.litert_lm'),
+  });
 
   final LiteRtLmConfig _config;
   final MethodChannel _channel;

--- a/packages/core_ai/lib/src/registry/model_registry.dart
+++ b/packages/core_ai/lib/src/registry/model_registry.dart
@@ -57,11 +57,10 @@ class ModelCompatibilityResult {
 /// - Track downloaded vs available models
 class ModelRegistry {
   ModelRegistry({
+    this._loadMemoryInfo,
     DeviceCapabilityService? deviceCapabilityService,
-    Future<MemoryInfo> Function()? loadMemoryInfo,
     MemoryBudgetManager? memoryBudgetManager,
   }) : _deviceService = deviceCapabilityService ?? DeviceCapabilityService(),
-       _loadMemoryInfo = loadMemoryInfo,
        _memoryBudgetManager =
            memoryBudgetManager ??
            MemoryBudgetManager(

--- a/packages/core_ai/lib/src/router/ai_router.dart
+++ b/packages/core_ai/lib/src/router/ai_router.dart
@@ -1,4 +1,5 @@
 import 'package:core_domain/core_domain.dart';
+
 import '../client/llm_client.dart';
 import '../provider/ai_provider.dart';
 
@@ -18,6 +19,19 @@ enum AIRoutingStrategy {
 
   /// Let user choose.
   userChoice,
+}
+
+/// Explicit local-only policy for privacy-sensitive companion requests.
+class LocalOnlyAiPolicy {
+  const LocalOnlyAiPolicy({this.onDeviceMaxPromptLength = 1024});
+
+  final int onDeviceMaxPromptLength;
+
+  AIRouterConfig toRouterConfig() {
+    return AIRouterConfig.localOnly(
+      onDeviceMaxPromptLength: onDeviceMaxPromptLength,
+    );
+  }
 }
 
 /// Configuration for AI routing.
@@ -41,6 +55,13 @@ class AIRouterConfig {
     this.onDeviceMaxPromptLength = 1024,
     this.autoFallback = true,
   });
+
+  const AIRouterConfig.localOnly({this.onDeviceMaxPromptLength = 1024})
+    : defaultStrategy = AIRoutingStrategy.onDeviceOnly,
+      userPreference = null,
+      autoFallback = false;
+
+  bool get isLocalOnly => defaultStrategy == AIRoutingStrategy.onDeviceOnly;
 }
 
 /// Routes AI requests to appropriate provider based on strategy.
@@ -54,6 +75,15 @@ class AIRouter implements LLMClient {
     this.cloudClient,
     this.config = const AIRouterConfig(),
   });
+
+  AppError _unavailableError() {
+    if (config.isLocalOnly) {
+      return AIError(
+        'Local-only AI is active, but no on-device model is available.',
+      );
+    }
+    return UnknownError('No AI provider available');
+  }
 
   /// Get the appropriate client based on strategy and availability.
   Future<LLMClient?> _selectClient({String? prompt}) async {
@@ -139,13 +169,13 @@ class AIRouter implements LLMClient {
   }) async {
     final client = await _selectClient(prompt: prompt);
     if (client == null) {
-      return Err(UnknownError('No AI provider available'), StackTrace.current);
+      return Err(_unavailableError(), StackTrace.current);
     }
 
     final result = await client.generateText(prompt, config: config);
 
-    // Try fallback on error
-    if (result.isErr && this.config.autoFallback) {
+    // Try fallback on error unless the request is explicitly local-only.
+    if (result.isErr && this.config.autoFallback && !this.config.isLocalOnly) {
       final fallback = client == onDeviceClient ? cloudClient : onDeviceClient;
       if (fallback != null && await fallback.isAvailable()) {
         return fallback.generateText(prompt, config: config);
@@ -162,7 +192,7 @@ class AIRouter implements LLMClient {
   }) async* {
     final client = await _selectClient(prompt: prompt);
     if (client == null) {
-      yield Err(UnknownError('No AI provider available'), StackTrace.current);
+      yield Err(_unavailableError(), StackTrace.current);
       return;
     }
 
@@ -177,7 +207,7 @@ class AIRouter implements LLMClient {
     final prompt = messages.map((m) => m.content).join(' ');
     final client = await _selectClient(prompt: prompt);
     if (client == null) {
-      return Err(UnknownError('No AI provider available'), StackTrace.current);
+      return Err(_unavailableError(), StackTrace.current);
     }
     return client.chat(messages, config: config);
   }
@@ -190,7 +220,7 @@ class AIRouter implements LLMClient {
     final prompt = messages.map((m) => m.content).join(' ');
     final client = await _selectClient(prompt: prompt);
     if (client == null) {
-      yield Err(UnknownError('No AI provider available'), StackTrace.current);
+      yield Err(_unavailableError(), StackTrace.current);
       return;
     }
     yield* client.chatStream(messages, config: config);
@@ -204,7 +234,7 @@ class AIRouter implements LLMClient {
   }) async {
     final client = await _selectClient(prompt: text);
     if (client == null) {
-      return Err(UnknownError('No AI provider available'), StackTrace.current);
+      return Err(_unavailableError(), StackTrace.current);
     }
     return client.classify(text, categories, config: config);
   }
@@ -217,7 +247,7 @@ class AIRouter implements LLMClient {
   }) async {
     final client = await _selectClient(prompt: text);
     if (client == null) {
-      return Err(UnknownError('No AI provider available'), StackTrace.current);
+      return Err(_unavailableError(), StackTrace.current);
     }
     return client.summarize(text, maxLength: maxLength, config: config);
   }

--- a/packages/core_ai/test/router/ai_router_test.dart
+++ b/packages/core_ai/test/router/ai_router_test.dart
@@ -1,0 +1,111 @@
+import 'package:core_ai/core_ai.dart';
+import 'package:core_ai/src/client/fake_llm_client.dart';
+import 'package:core_ai/src/client/llm_client.dart';
+import 'package:core_domain/core_domain.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('AIRouter local-only policy', () {
+    test('local-only config disables cloud fallback by default', () {
+      const config = AIRouterConfig.localOnly();
+
+      expect(config.defaultStrategy, AIRoutingStrategy.onDeviceOnly);
+      expect(config.autoFallback, isFalse);
+      expect(config.isLocalOnly, isTrue);
+    });
+
+    test('policy converts into local-only router config', () {
+      const policy = LocalOnlyAiPolicy(onDeviceMaxPromptLength: 2048);
+      final config = policy.toRouterConfig();
+
+      expect(config.defaultStrategy, AIRoutingStrategy.onDeviceOnly);
+      expect(config.onDeviceMaxPromptLength, 2048);
+      expect(config.autoFallback, isFalse);
+    });
+
+    test(
+      'never invokes cloud generation when local-only policy is active',
+      () async {
+        final onDevice = FakeLLMClient(simulateError: true);
+        final cloud = FakeLLMClient(defaultResponse: 'cloud response');
+        final router = AIRouter(
+          onDeviceClient: onDevice,
+          cloudClient: cloud,
+          config: const AIRouterConfig.localOnly(),
+        );
+
+        final result = await router.generateText('hello');
+
+        expect(result.isErr, isTrue);
+        expect(onDevice.generateTextCalls, ['hello']);
+        expect(cloud.generateTextCalls, isEmpty);
+        expect(result.getErrorOrNull(), isA<UnknownError>());
+      },
+    );
+
+    test(
+      'returns a local-only capability error when no on-device model is available',
+      () async {
+        final onDevice = FakeLLMClient(simulateUnavailable: true);
+        final cloud = FakeLLMClient(defaultResponse: 'cloud response');
+        final router = AIRouter(
+          onDeviceClient: onDevice,
+          cloudClient: cloud,
+          config: const AIRouterConfig.localOnly(),
+        );
+
+        final result = await router.generateText('hello');
+
+        expect(result.isErr, isTrue);
+        expect(onDevice.generateTextCalls, isEmpty);
+        expect(cloud.generateTextCalls, isEmpty);
+        expect(
+          (result.getErrorOrNull() as AIError).message,
+          'Local-only AI is active, but no on-device model is available.',
+        );
+      },
+    );
+
+    test('chat never invokes cloud when local-only policy is active', () async {
+      final onDevice = FakeLLMClient(simulateUnavailable: true);
+      final cloud = FakeLLMClient(defaultResponse: 'cloud response');
+      final router = AIRouter(
+        onDeviceClient: onDevice,
+        cloudClient: cloud,
+        config: const AIRouterConfig.localOnly(),
+      );
+
+      final result = await router.chat([ChatMessage.user('hello')]);
+
+      expect(result.isErr, isTrue);
+      expect(onDevice.chatCalls, isEmpty);
+      expect(cloud.chatCalls, isEmpty);
+      expect(
+        (result.getErrorOrNull() as AIError).message,
+        'Local-only AI is active, but no on-device model is available.',
+      );
+    });
+
+    test(
+      'on-device-only routing still avoids cloud fallback even if autoFallback is true',
+      () async {
+        final onDevice = FakeLLMClient(simulateError: true);
+        final cloud = FakeLLMClient(defaultResponse: 'cloud response');
+        final router = AIRouter(
+          onDeviceClient: onDevice,
+          cloudClient: cloud,
+          config: const AIRouterConfig(
+            defaultStrategy: AIRoutingStrategy.onDeviceOnly,
+            autoFallback: true,
+          ),
+        );
+
+        final result = await router.generateText('hello');
+
+        expect(result.isErr, isTrue);
+        expect(onDevice.generateTextCalls, ['hello']);
+        expect(cloud.generateTextCalls, isEmpty);
+      },
+    );
+  });
+}


### PR DESCRIPTION
# PR Title
fix(core-ai): enforce local-only router policy

---

# Summary

This PR introduces changes to the core AI router.
Goal: prevent companion/local-only requests from silently falling back to cloud providers.

Core outcome:

* added an explicit local-only router policy/config surface
* blocked cloud fallback when on-device-only routing is active
* surfaced a clear local-capability error when no on-device model is available

---

# Changes

### Code

* Added:
  * `LocalOnlyAiPolicy` in `packages/core_ai/lib/src/router/ai_router.dart`
  * router regression tests in `packages/core_ai/test/router/ai_router_test.dart`
* Updated:
  * `AIRouterConfig` with a `localOnly` constructor and `isLocalOnly`
  * `AIRouter` to avoid cloud fallback under local-only/on-device-only routing
  * minor analyzer-clean constructor cleanups in LiteRT/model registry touched by this package

### Logic

* local-only requests now return a local capability error instead of generic cloud fallback behavior
* cloud clients are not invoked when local-only routing is active, even if `autoFallback` is true on an on-device-only config
* chat path is covered alongside generate-text path

---

# API Changes (if any)

* Added `LocalOnlyAiPolicy`
* Added `AIRouterConfig.localOnly(...)`

---

# Risks

* low risk: change is isolated to the framework router
* rollback plan:
  * revert this PR to restore previous routing behavior

---

# Testing

* Unit tests:
  * `cd packages/core_ai && flutter test test/router/ai_router_test.dart`
* Additional verification:
  * `cd packages/core_ai && flutter analyze`

---

# Related Commits

* `fix(core-ai): enforce local-only router policy`
