### PR TITLE
Add LifeTrack domain entities

### DIFF
--- a/packages/core_domain/lib/core_domain.dart
+++ b/packages/core_domain/lib/core_domain.dart
@@ -6,6 +6,10 @@
 // Entities
 export 'src/entities/entity.dart';
 export 'src/entities/user.dart';
+export 'src/entities/life_track.dart';
+export 'src/entities/milestone.dart';
+export 'src/entities/action_item.dart';
+export 'src/entities/input_requirement.dart';
 
 // Result Type - Ok/Err pattern for functional error handling
 export 'src/result/result.dart';
@@ -19,6 +23,7 @@ export 'src/errors/app_error.dart';
 
 // Repository Interfaces
 export 'src/repositories/repository.dart';
+export 'src/repositories/life_track_repository.dart';
 
 // Use Cases
 export 'src/use_cases/use_case.dart';

--- a/packages/core_domain/lib/src/entities/action_item.dart
+++ b/packages/core_domain/lib/src/entities/action_item.dart
@@ -1,0 +1,129 @@
+import 'package:meta/meta.dart';
+
+import 'input_requirement.dart';
+import 'life_track.dart';
+
+@immutable
+class ActionItem {
+  const ActionItem({
+    required this.id,
+    required this.milestoneId,
+    required this.summary,
+    required this.status,
+    required this.requirements,
+    required this.createdAt,
+    required this.updatedAt,
+    this.description,
+    this.dueDate,
+    this.notes,
+  });
+
+  final String id;
+  final String milestoneId;
+  final String summary;
+  final String? description;
+  final ItemStatus status;
+  final List<InputRequirement> requirements;
+  final DateTime? dueDate;
+  final String? notes;
+  final DateTime createdAt;
+  final DateTime updatedAt;
+
+  factory ActionItem.fromJson(Map<String, dynamic> json) => ActionItem(
+    id: json['id'] as String,
+    milestoneId: json['milestone_id'] as String,
+    summary: json['summary'] as String,
+    description: json['description'] as String?,
+    status: _itemStatusFromJson(json['status'] as String),
+    requirements: ((json['requirements'] as List?) ?? const [])
+        .map((item) => InputRequirement.fromJson(item as Map<String, dynamic>))
+        .toList(growable: false),
+    dueDate: json['due_date'] == null
+        ? null
+        : DateTime.parse(json['due_date'] as String),
+    notes: json['notes'] as String?,
+    createdAt: DateTime.parse(json['created_at'] as String),
+    updatedAt: DateTime.parse(json['updated_at'] as String),
+  );
+
+  Map<String, dynamic> toJson() => {
+    'id': id,
+    'milestone_id': milestoneId,
+    'summary': summary,
+    'description': description,
+    'status': status.name,
+    'requirements': requirements
+        .map((item) => item.toJson())
+        .toList(growable: false),
+    'due_date': dueDate?.toIso8601String(),
+    'notes': notes,
+    'created_at': createdAt.toIso8601String(),
+    'updated_at': updatedAt.toIso8601String(),
+  };
+
+  ActionItem copyWith({
+    String? id,
+    String? milestoneId,
+    String? summary,
+    String? description,
+    ItemStatus? status,
+    List<InputRequirement>? requirements,
+    DateTime? dueDate,
+    String? notes,
+    DateTime? createdAt,
+    DateTime? updatedAt,
+  }) => ActionItem(
+    id: id ?? this.id,
+    milestoneId: milestoneId ?? this.milestoneId,
+    summary: summary ?? this.summary,
+    description: description ?? this.description,
+    status: status ?? this.status,
+    requirements: requirements ?? this.requirements,
+    dueDate: dueDate ?? this.dueDate,
+    notes: notes ?? this.notes,
+    createdAt: createdAt ?? this.createdAt,
+    updatedAt: updatedAt ?? this.updatedAt,
+  );
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is ActionItem &&
+          runtimeType == other.runtimeType &&
+          id == other.id &&
+          milestoneId == other.milestoneId &&
+          summary == other.summary &&
+          description == other.description &&
+          status == other.status &&
+          _listEquals(requirements, other.requirements) &&
+          dueDate == other.dueDate &&
+          notes == other.notes &&
+          createdAt == other.createdAt &&
+          updatedAt == other.updatedAt;
+
+  @override
+  int get hashCode => Object.hash(
+    id,
+    milestoneId,
+    summary,
+    description,
+    status,
+    Object.hashAll(requirements),
+    dueDate,
+    notes,
+    createdAt,
+    updatedAt,
+  );
+}
+
+ItemStatus _itemStatusFromJson(String value) =>
+    ItemStatus.values.firstWhere((item) => item.name == value);
+
+bool _listEquals<T>(List<T> left, List<T> right) {
+  if (identical(left, right)) return true;
+  if (left.length != right.length) return false;
+  for (var i = 0; i < left.length; i++) {
+    if (left[i] != right[i]) return false;
+  }
+  return true;
+}

--- a/packages/core_domain/lib/src/entities/input_requirement.dart
+++ b/packages/core_domain/lib/src/entities/input_requirement.dart
@@ -1,0 +1,83 @@
+import 'package:meta/meta.dart';
+
+import 'life_track.dart';
+
+@immutable
+class InputRequirement {
+  const InputRequirement({
+    required this.id,
+    required this.actionItemId,
+    required this.label,
+    required this.fieldType,
+    required this.isRequired,
+    this.value,
+    this.hint,
+  });
+
+  final String id;
+  final String actionItemId;
+  final String label;
+  final FieldType fieldType;
+  final String? value;
+  final bool isRequired;
+  final String? hint;
+
+  factory InputRequirement.fromJson(Map<String, dynamic> json) =>
+      InputRequirement(
+        id: json['id'] as String,
+        actionItemId: json['action_item_id'] as String,
+        label: json['label'] as String,
+        fieldType: _fieldTypeFromJson(json['field_type'] as String),
+        value: json['value'] as String?,
+        isRequired: json['is_required'] as bool,
+        hint: json['hint'] as String?,
+      );
+
+  Map<String, dynamic> toJson() => {
+    'id': id,
+    'action_item_id': actionItemId,
+    'label': label,
+    'field_type': fieldType.name,
+    'value': value,
+    'is_required': isRequired,
+    'hint': hint,
+  };
+
+  InputRequirement copyWith({
+    String? id,
+    String? actionItemId,
+    String? label,
+    FieldType? fieldType,
+    String? value,
+    bool? isRequired,
+    String? hint,
+  }) => InputRequirement(
+    id: id ?? this.id,
+    actionItemId: actionItemId ?? this.actionItemId,
+    label: label ?? this.label,
+    fieldType: fieldType ?? this.fieldType,
+    value: value ?? this.value,
+    isRequired: isRequired ?? this.isRequired,
+    hint: hint ?? this.hint,
+  );
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is InputRequirement &&
+          runtimeType == other.runtimeType &&
+          id == other.id &&
+          actionItemId == other.actionItemId &&
+          label == other.label &&
+          fieldType == other.fieldType &&
+          value == other.value &&
+          isRequired == other.isRequired &&
+          hint == other.hint;
+
+  @override
+  int get hashCode =>
+      Object.hash(id, actionItemId, label, fieldType, value, isRequired, hint);
+}
+
+FieldType _fieldTypeFromJson(String value) =>
+    FieldType.values.firstWhere((item) => item.name == value);

--- a/packages/core_domain/lib/src/entities/life_track.dart
+++ b/packages/core_domain/lib/src/entities/life_track.dart
@@ -1,0 +1,118 @@
+import 'package:meta/meta.dart';
+
+import 'entity.dart';
+import 'milestone.dart';
+
+enum LifeTrackCategory {
+  realEstate,
+  education,
+  medical,
+  insurance,
+  finance,
+  travel,
+  carPurchase,
+  legal,
+  custom,
+}
+
+enum TrackStatus { draft, active, completed, archived, postponed }
+
+enum ItemStatus { todo, inProgress, blocked, done, skipped }
+
+enum FieldType { text, date, document, link, boolean, number }
+
+@immutable
+class LifeTrack extends Entity {
+  const LifeTrack({
+    required super.id,
+    required this.title,
+    required this.category,
+    required this.status,
+    required this.milestones,
+    required this.createdAt,
+    required this.updatedAt,
+    this.templateId,
+  });
+
+  final String title;
+  final LifeTrackCategory category;
+  final TrackStatus status;
+  final List<Milestone> milestones;
+  final DateTime createdAt;
+  final DateTime updatedAt;
+  final String? templateId;
+
+  double get progress {
+    if (milestones.isEmpty) return 0;
+    final total = milestones.fold<double>(
+      0,
+      (sum, milestone) => sum + milestone.progress,
+    );
+    return total / milestones.length;
+  }
+
+  factory LifeTrack.fromJson(Map<String, dynamic> json) => LifeTrack(
+    id: json['id'] as String,
+    title: json['title'] as String,
+    category: _lifeTrackCategoryFromJson(json['category'] as String),
+    status: _trackStatusFromJson(json['status'] as String),
+    milestones: ((json['milestones'] as List?) ?? const [])
+        .map((item) => Milestone.fromJson(item as Map<String, dynamic>))
+        .toList(growable: false),
+    createdAt: DateTime.parse(json['created_at'] as String),
+    updatedAt: DateTime.parse(json['updated_at'] as String),
+    templateId: json['template_id'] as String?,
+  );
+
+  Map<String, dynamic> toJson() => {
+    'id': id,
+    'title': title,
+    'category': category.name,
+    'status': status.name,
+    'milestones': milestones
+        .map((milestone) => milestone.toJson())
+        .toList(growable: false),
+    'created_at': createdAt.toIso8601String(),
+    'updated_at': updatedAt.toIso8601String(),
+    'template_id': templateId,
+    'progress': progress,
+  };
+
+  LifeTrack copyWith({
+    String? id,
+    String? title,
+    LifeTrackCategory? category,
+    TrackStatus? status,
+    List<Milestone>? milestones,
+    DateTime? createdAt,
+    DateTime? updatedAt,
+    String? templateId,
+  }) => LifeTrack(
+    id: id ?? this.id,
+    title: title ?? this.title,
+    category: category ?? this.category,
+    status: status ?? this.status,
+    milestones: milestones ?? this.milestones,
+    createdAt: createdAt ?? this.createdAt,
+    updatedAt: updatedAt ?? this.updatedAt,
+    templateId: templateId ?? this.templateId,
+  );
+
+  @override
+  List<Object?> get props => [
+    ...super.props,
+    title,
+    category,
+    status,
+    milestones,
+    createdAt,
+    updatedAt,
+    templateId,
+  ];
+}
+
+LifeTrackCategory _lifeTrackCategoryFromJson(String value) =>
+    LifeTrackCategory.values.firstWhere((item) => item.name == value);
+
+TrackStatus _trackStatusFromJson(String value) =>
+    TrackStatus.values.firstWhere((item) => item.name == value);

--- a/packages/core_domain/lib/src/entities/milestone.dart
+++ b/packages/core_domain/lib/src/entities/milestone.dart
@@ -1,0 +1,116 @@
+import 'package:meta/meta.dart';
+
+import 'action_item.dart';
+import 'life_track.dart';
+
+@immutable
+class Milestone {
+  const Milestone({
+    required this.id,
+    required this.trackId,
+    required this.name,
+    required this.objective,
+    required this.sortOrder,
+    required this.status,
+    required this.actionItems,
+  });
+
+  final String id;
+  final String trackId;
+  final String name;
+  final String objective;
+  final int sortOrder;
+  final ItemStatus status;
+  final List<ActionItem> actionItems;
+
+  double get progress {
+    if (actionItems.isEmpty) return 0;
+    final activeItems = actionItems
+        .where((item) => item.status != ItemStatus.skipped)
+        .toList(growable: false);
+    if (activeItems.isEmpty) return 0;
+    final completed = activeItems
+        .where((item) => item.status == ItemStatus.done)
+        .length;
+    return completed / activeItems.length;
+  }
+
+  factory Milestone.fromJson(Map<String, dynamic> json) => Milestone(
+    id: json['id'] as String,
+    trackId: json['track_id'] as String,
+    name: json['name'] as String,
+    objective: json['objective'] as String,
+    sortOrder: json['sort_order'] as int,
+    status: _itemStatusFromJson(json['status'] as String),
+    actionItems: ((json['action_items'] as List?) ?? const [])
+        .map((item) => ActionItem.fromJson(item as Map<String, dynamic>))
+        .toList(growable: false),
+  );
+
+  Map<String, dynamic> toJson() => {
+    'id': id,
+    'track_id': trackId,
+    'name': name,
+    'objective': objective,
+    'sort_order': sortOrder,
+    'status': status.name,
+    'action_items': actionItems
+        .map((item) => item.toJson())
+        .toList(growable: false),
+    'progress': progress,
+  };
+
+  Milestone copyWith({
+    String? id,
+    String? trackId,
+    String? name,
+    String? objective,
+    int? sortOrder,
+    ItemStatus? status,
+    List<ActionItem>? actionItems,
+  }) => Milestone(
+    id: id ?? this.id,
+    trackId: trackId ?? this.trackId,
+    name: name ?? this.name,
+    objective: objective ?? this.objective,
+    sortOrder: sortOrder ?? this.sortOrder,
+    status: status ?? this.status,
+    actionItems: actionItems ?? this.actionItems,
+  );
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is Milestone &&
+          runtimeType == other.runtimeType &&
+          id == other.id &&
+          trackId == other.trackId &&
+          name == other.name &&
+          objective == other.objective &&
+          sortOrder == other.sortOrder &&
+          status == other.status &&
+          _listEquals(actionItems, other.actionItems);
+
+  @override
+  int get hashCode => Object.hash(
+    id,
+    trackId,
+    name,
+    objective,
+    sortOrder,
+    status,
+    Object.hashAll(actionItems),
+  );
+}
+
+ItemStatus _itemStatusFromJson(String value) =>
+    ItemStatus.values.firstWhere((item) => item.name == value);
+
+bool _listEquals<T>(List<T> left, List<T> right) {
+  if (identical(left, right)) return true;
+  if (left.length != right.length) return false;
+  for (var i = 0; i < left.length; i++) {
+    if (left[i] != right[i]) return false;
+  }
+  return true;
+}

--- a/packages/core_domain/lib/src/repositories/life_track_repository.dart
+++ b/packages/core_domain/lib/src/repositories/life_track_repository.dart
@@ -1,0 +1,28 @@
+import 'dart:async';
+
+import '../entities/action_item.dart';
+import '../entities/life_track.dart';
+import '../entities/milestone.dart';
+import '../result/result.dart';
+
+abstract class LifeTrackRepository {
+  Future<Result<LifeTrack>> createTrack(LifeTrack track);
+
+  Future<Result<LifeTrack>> getTrack(String id);
+
+  Future<Result<List<LifeTrack>>> listTracks({TrackStatus? status});
+
+  Future<Result<void>> updateTrack(LifeTrack track);
+
+  Future<Result<void>> deleteTrack(String id);
+
+  Stream<List<LifeTrack>> watchTracks({TrackStatus? status});
+
+  Future<Result<void>> updateMilestone(Milestone milestone);
+
+  Future<Result<void>> updateActionItem(ActionItem item);
+
+  Future<Result<void>> updateItemStatus(String itemId, ItemStatus status);
+
+  Future<Result<void>> saveInputValue(String requirementId, String value);
+}

--- a/packages/core_domain/test/entities/life_track_repository_test.dart
+++ b/packages/core_domain/test/entities/life_track_repository_test.dart
@@ -1,0 +1,76 @@
+import 'package:core_domain/core_domain.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test(
+    'LifeTrackRepository interface is implementable with Result signatures',
+    () async {
+      final repository = _FakeLifeTrackRepository();
+      final track = LifeTrack(
+        id: 'track-1',
+        title: 'Track',
+        category: LifeTrackCategory.finance,
+        status: TrackStatus.draft,
+        milestones: const [],
+        createdAt: DateTime.utc(2026, 6, 29),
+        updatedAt: DateTime.utc(2026, 6, 29),
+      );
+
+      expect((await repository.createTrack(track)).value, track);
+      expect((await repository.getTrack('track-1')).value.id, 'track-1');
+      expect((await repository.listTracks()).value, [track]);
+      expect(await repository.watchTracks().first, [track]);
+    },
+  );
+}
+
+class _FakeLifeTrackRepository implements LifeTrackRepository {
+  LifeTrack? _track;
+
+  @override
+  Future<Result<LifeTrack>> createTrack(LifeTrack track) async {
+    _track = track;
+    return Ok(track);
+  }
+
+  @override
+  Future<Result<void>> deleteTrack(String id) async => const Ok(null);
+
+  @override
+  Future<Result<LifeTrack>> getTrack(String id) async => Ok(_track!);
+
+  @override
+  Future<Result<List<LifeTrack>>> listTracks({TrackStatus? status}) async =>
+      Ok(_track == null ? const [] : [_track!]);
+
+  @override
+  Future<Result<void>> saveInputValue(
+    String requirementId,
+    String value,
+  ) async => const Ok(null);
+
+  @override
+  Future<Result<void>> updateActionItem(ActionItem item) async =>
+      const Ok(null);
+
+  @override
+  Future<Result<void>> updateItemStatus(
+    String itemId,
+    ItemStatus status,
+  ) async => const Ok(null);
+
+  @override
+  Future<Result<void>> updateMilestone(Milestone milestone) async =>
+      const Ok(null);
+
+  @override
+  Future<Result<void>> updateTrack(LifeTrack track) async {
+    _track = track;
+    return const Ok(null);
+  }
+
+  @override
+  Stream<List<LifeTrack>> watchTracks({TrackStatus? status}) async* {
+    if (_track != null) yield [_track!];
+  }
+}

--- a/packages/core_domain/test/entities/life_track_test.dart
+++ b/packages/core_domain/test/entities/life_track_test.dart
@@ -1,0 +1,159 @@
+import 'package:core_domain/core_domain.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  final requirement = InputRequirement(
+    id: 'req-1',
+    actionItemId: 'item-1',
+    label: 'Commencement Certificate PDF',
+    fieldType: FieldType.document,
+    value: null,
+    isRequired: true,
+    hint: 'Upload the latest certificate',
+  );
+
+  final actionItem = ActionItem(
+    id: 'item-1',
+    milestoneId: 'milestone-1',
+    summary: 'Check Builder RERA Registration',
+    description: 'Verify the builder on MahaRERA.',
+    status: ItemStatus.done,
+    requirements: [requirement],
+    dueDate: DateTime.utc(2026, 7, 1),
+    notes: 'Verified successfully',
+    createdAt: DateTime.utc(2026, 6, 29, 10),
+    updatedAt: DateTime.utc(2026, 6, 29, 11),
+  );
+
+  final blockedItem = ActionItem(
+    id: 'item-2',
+    milestoneId: 'milestone-1',
+    summary: 'Check lender list',
+    status: ItemStatus.blocked,
+    requirements: const [],
+    createdAt: DateTime.utc(2026, 6, 29, 10),
+    updatedAt: DateTime.utc(2026, 6, 29, 11),
+  );
+
+  final skippedItem = ActionItem(
+    id: 'item-3',
+    milestoneId: 'milestone-2',
+    summary: 'Optional paperwork',
+    status: ItemStatus.skipped,
+    requirements: const [],
+    createdAt: DateTime.utc(2026, 6, 29, 10),
+    updatedAt: DateTime.utc(2026, 6, 29, 11),
+  );
+
+  final secondDoneItem = ActionItem(
+    id: 'item-4',
+    milestoneId: 'milestone-2',
+    summary: 'Collect agreement copy',
+    status: ItemStatus.done,
+    requirements: const [],
+    createdAt: DateTime.utc(2026, 6, 29, 10),
+    updatedAt: DateTime.utc(2026, 6, 29, 11),
+  );
+
+  final milestoneOne = Milestone(
+    id: 'milestone-1',
+    trackId: 'track-1',
+    name: 'Phase 1',
+    objective: 'Legal verification',
+    sortOrder: 1,
+    status: ItemStatus.inProgress,
+    actionItems: [actionItem, blockedItem],
+  );
+
+  final milestoneTwo = Milestone(
+    id: 'milestone-2',
+    trackId: 'track-1',
+    name: 'Phase 2',
+    objective: 'Agreement checks',
+    sortOrder: 2,
+    status: ItemStatus.todo,
+    actionItems: [skippedItem, secondDoneItem],
+  );
+
+  final track = LifeTrack(
+    id: 'track-1',
+    title: 'Buy Under-Construction Flat',
+    category: LifeTrackCategory.realEstate,
+    status: TrackStatus.active,
+    milestones: [milestoneOne, milestoneTwo],
+    createdAt: DateTime.utc(2026, 6, 29, 9),
+    updatedAt: DateTime.utc(2026, 6, 29, 12),
+    templateId: 'real_estate_under_construction_v1',
+  );
+
+  group('LifeTrack entities', () {
+    test('round-trips nested entity JSON', () {
+      final encoded = track.toJson();
+      final decoded = LifeTrack.fromJson(encoded);
+
+      expect(decoded, track);
+      expect(
+        decoded.milestones.first.actionItems.first.requirements.first,
+        requirement,
+      );
+    });
+
+    test('computes milestone progress with skipped items excluded', () {
+      expect(milestoneOne.progress, 0.5);
+      expect(milestoneTwo.progress, 1.0);
+    });
+
+    test('computes track progress as average milestone progress', () {
+      expect(track.progress, 0.75);
+    });
+
+    test(
+      'returns zero progress for empty milestones and skipped-only milestones',
+      () {
+        const emptyMilestone = Milestone(
+          id: 'm-empty',
+          trackId: 'track-empty',
+          name: 'Empty',
+          objective: 'Nothing yet',
+          sortOrder: 0,
+          status: ItemStatus.todo,
+          actionItems: [],
+        );
+        final skippedOnly = Milestone(
+          id: 'm-skipped',
+          trackId: 'track-empty',
+          name: 'Skipped',
+          objective: 'All optional',
+          sortOrder: 1,
+          status: ItemStatus.skipped,
+          actionItems: [skippedItem],
+        );
+        final emptyTrack = LifeTrack(
+          id: 'track-empty',
+          title: 'Empty Track',
+          category: LifeTrackCategory.custom,
+          status: TrackStatus.draft,
+          milestones: const [],
+          createdAt: DateTime.utc(2026, 6, 29),
+          updatedAt: DateTime.utc(2026, 6, 29),
+        );
+
+        expect(emptyMilestone.progress, 0);
+        expect(skippedOnly.progress, 0);
+        expect(emptyTrack.progress, 0);
+      },
+    );
+
+    test('copyWith preserves and replaces selected fields', () {
+      final updated = track.copyWith(
+        title: 'Updated title',
+        status: TrackStatus.completed,
+      );
+
+      expect(updated.title, 'Updated title');
+      expect(updated.status, TrackStatus.completed);
+      expect(updated.milestones, track.milestones);
+      expect(updated.templateId, track.templateId);
+    });
+  });
+}


### PR DESCRIPTION
# Summary

This PR introduces changes to the LifeTrack domain model.
Goal: establish the deterministic core entities and repository contract required before LifeTrack storage and application workflows can build on top.

Core outcome:

* adds LifeTrack, Milestone, ActionItem, and InputRequirement domain entities
* adds LifeTrack enums, JSON serialization, progress computation, and repository contract
* adds unit tests for nested round-trip serialization and progress edge cases

Closes #332

---

# Changes

### Code

* Added:
  * LifeTrack domain entities and enums in `packages/core_domain/lib/src/entities/`
  * `LifeTrackRepository` interface in `packages/core_domain/lib/src/repositories/`
  * focused entity/repository tests in `packages/core_domain/test/entities/`
* Updated:
  * `packages/core_domain/lib/core_domain.dart` exports for the new domain surface

### Logic

* Track progress is computed as the average milestone progress
* Milestone progress excludes skipped items from its denominator
* Entities serialize to/from JSON so later template/storage layers can share one schema

---

# API Changes (if any)

* New exported domain types:
  * `LifeTrack`
  * `Milestone`
  * `ActionItem`
  * `InputRequirement`
  * `LifeTrackRepository`

---

# Database Changes (if any)

* None.

---

# Observability / Logging

* None.

---

# Performance Impact

* Negligible. Pure in-memory domain/model logic.

---

# Risks

* The progress rules are now codified in `core_domain`; later storage/UI layers must align to these semantics.
* Rollback plan:
  * revert this PR before LifeTrack storage/UI layers depend on the new exports

---

# Testing

* Unit tests:
  * `flutter test`
* Manual testing:
  * `flutter analyze`

---

# Deployment Notes

* No config or migration changes.

---

# Related Commits

* `feat(core-domain): add LifeTrack domain entities`

---

# Notes

* This PR intentionally stops at the domain layer. SQLite persistence and state machine behavior remain on follow-up LifeTrack issues.
