### PR TITLE
Add LifeTrack SQLite persistence

### DIFF
--- a/packages/core_data/lib/core_data.dart
+++ b/packages/core_data/lib/core_data.dart
@@ -11,6 +11,7 @@ export 'src/storage/key_value_store.dart';
 export 'src/storage/preferences_store.dart';
 export 'src/storage/secure_store.dart';
 export 'src/storage/flutter_secure_store.dart';
+export 'src/storage/life_track_local_data_source.dart';
 
 // Connectivity
 export 'src/connectivity/connectivity_service.dart';
@@ -26,6 +27,7 @@ export 'src/sync/outbox_repository.dart';
 
 // Base Repository
 export 'src/repositories/base_repository.dart';
+export 'src/repositories/life_track_repository_impl.dart';
 
 // Plugin Storage and Runtime Controls
 export 'src/plugins/local_plugin_storage.dart';

--- a/packages/core_data/lib/src/repositories/life_track_repository_impl.dart
+++ b/packages/core_data/lib/src/repositories/life_track_repository_impl.dart
@@ -1,0 +1,113 @@
+import 'package:core_data/src/storage/life_track_local_data_source.dart';
+import 'package:core_domain/core_domain.dart';
+
+class LifeTrackRepositoryImpl implements LifeTrackRepository {
+  LifeTrackRepositoryImpl({required this._localDataSource});
+
+  final LifeTrackLocalDataSource _localDataSource;
+
+  @override
+  Future<Result<LifeTrack>> createTrack(LifeTrack track) async {
+    try {
+      return Ok(await _localDataSource.createTrack(track));
+    } catch (error, stack) {
+      return Err(error, stack);
+    }
+  }
+
+  @override
+  Future<Result<void>> deleteTrack(String id) async {
+    try {
+      await _localDataSource.deleteTrack(id);
+      return const Ok(null);
+    } catch (error, stack) {
+      return Err(error, stack);
+    }
+  }
+
+  @override
+  Future<Result<LifeTrack>> getTrack(String id) async {
+    try {
+      final track = await _localDataSource.getTrack(id);
+      if (track == null) {
+        return Err(
+          NotFoundError('LifeTrack not found: $id'),
+          StackTrace.current,
+        );
+      }
+      return Ok(track);
+    } catch (error, stack) {
+      return Err(error, stack);
+    }
+  }
+
+  @override
+  Future<Result<List<LifeTrack>>> listTracks({TrackStatus? status}) async {
+    try {
+      return Ok(await _localDataSource.listTracks(status: status));
+    } catch (error, stack) {
+      return Err(error, stack);
+    }
+  }
+
+  @override
+  Future<Result<void>> saveInputValue(
+    String requirementId,
+    String value,
+  ) async {
+    try {
+      await _localDataSource.saveInputValue(requirementId, value);
+      return const Ok(null);
+    } catch (error, stack) {
+      return Err(error, stack);
+    }
+  }
+
+  @override
+  Future<Result<void>> updateActionItem(ActionItem item) async {
+    try {
+      await _localDataSource.updateActionItem(item);
+      return const Ok(null);
+    } catch (error, stack) {
+      return Err(error, stack);
+    }
+  }
+
+  @override
+  Future<Result<void>> updateItemStatus(
+    String itemId,
+    ItemStatus status,
+  ) async {
+    try {
+      await _localDataSource.updateItemStatus(itemId, status);
+      return const Ok(null);
+    } catch (error, stack) {
+      return Err(error, stack);
+    }
+  }
+
+  @override
+  Future<Result<void>> updateMilestone(Milestone milestone) async {
+    try {
+      await _localDataSource.updateMilestone(milestone);
+      return const Ok(null);
+    } catch (error, stack) {
+      return Err(error, stack);
+    }
+  }
+
+  @override
+  Future<Result<void>> updateTrack(LifeTrack track) async {
+    try {
+      await _localDataSource.updateTrack(track);
+      return const Ok(null);
+    } catch (error, stack) {
+      return Err(error, stack);
+    }
+  }
+
+  @override
+  Stream<List<LifeTrack>> watchTracks({TrackStatus? status}) {
+    return _localDataSource.watchTracks(status: status);
+  }
+}

--- a/packages/core_data/lib/src/storage/life_track_local_data_source.dart
+++ b/packages/core_data/lib/src/storage/life_track_local_data_source.dart
@@ -1,0 +1,521 @@
+import 'dart:async';
+
+import 'package:core_domain/core_domain.dart';
+import 'package:path/path.dart' as path;
+import 'package:sqflite/sqflite.dart';
+
+class LifeTrackLocalDataSource {
+  LifeTrackLocalDataSource({
+    DatabaseFactory? databaseFactory,
+    this._databasePath,
+    this._databaseName = 'life_track.db',
+  }) : _databaseFactory = databaseFactory ?? databaseFactorySqflitePlugin;
+
+  static const schemaVersion = 1;
+
+  static const lifeTracksTable = 'life_tracks';
+  static const milestonesTable = 'milestones';
+  static const actionItemsTable = 'action_items';
+  static const inputRequirementsTable = 'input_requirements';
+
+  final DatabaseFactory _databaseFactory;
+  final String? _databasePath;
+  final String _databaseName;
+  final StreamController<void> _changes = StreamController<void>.broadcast();
+
+  Database? _database;
+
+  Future<void> initialize() async {
+    if (_database != null && _database!.isOpen) return;
+
+    final resolvedPath =
+        _databasePath ?? path.join(await getDatabasesPath(), _databaseName);
+    _database = await _databaseFactory.openDatabase(
+      resolvedPath,
+      options: OpenDatabaseOptions(
+        version: schemaVersion,
+        onConfigure: (db) async {
+          await db.execute('PRAGMA foreign_keys = ON');
+        },
+        onCreate: (db, version) async {
+          await _createSchema(db);
+        },
+        onUpgrade: (db, oldVersion, newVersion) async {
+          if (oldVersion < 1) {
+            await _createSchema(db);
+          }
+        },
+      ),
+    );
+  }
+
+  Future<LifeTrack> createTrack(LifeTrack track) async {
+    final db = await _requireDatabase();
+    await _insertTrackGraph(db, track);
+    await _notifyChanged();
+    return track;
+  }
+
+  Future<LifeTrack?> getTrack(String id) async {
+    final db = await _requireDatabase();
+    final rows = await db.query(
+      lifeTracksTable,
+      where: 'id = ?',
+      whereArgs: [id],
+      limit: 1,
+    );
+    if (rows.isEmpty) return null;
+    return _hydrateTrack(db, rows.single);
+  }
+
+  Future<List<LifeTrack>> listTracks({TrackStatus? status}) async {
+    final db = await _requireDatabase();
+    final rows = await db.query(
+      lifeTracksTable,
+      where: status == null ? null : 'status = ?',
+      whereArgs: status == null ? null : [status.name],
+      orderBy: 'updated_at DESC',
+    );
+    return Future.wait(rows.map((row) => _hydrateTrack(db, row)));
+  }
+
+  Stream<List<LifeTrack>> watchTracks({TrackStatus? status}) async* {
+    yield await listTracks(status: status);
+    yield* _changes.stream.asyncMap((_) => listTracks(status: status));
+  }
+
+  Future<void> updateTrack(LifeTrack track) async {
+    final db = await _requireDatabase();
+    await db.transaction((txn) async {
+      await txn.update(
+        lifeTracksTable,
+        {
+          'title': track.title,
+          'category': track.category.name,
+          'status': track.status.name,
+          'template_id': track.templateId,
+          'created_at': track.createdAt.millisecondsSinceEpoch,
+          'updated_at': track.updatedAt.millisecondsSinceEpoch,
+        },
+        where: 'id = ?',
+        whereArgs: [track.id],
+      );
+      await _replaceMilestones(txn, track.id, track.milestones);
+    });
+    await _notifyChanged();
+  }
+
+  Future<void> deleteTrack(String id) async {
+    final db = await _requireDatabase();
+    await db.delete(lifeTracksTable, where: 'id = ?', whereArgs: [id]);
+    await _notifyChanged();
+  }
+
+  Future<void> updateMilestone(Milestone milestone) async {
+    final db = await _requireDatabase();
+    await db.update(
+      milestonesTable,
+      {
+        'track_id': milestone.trackId,
+        'name': milestone.name,
+        'objective': milestone.objective,
+        'sort_order': milestone.sortOrder,
+        'status': milestone.status.name,
+      },
+      where: 'id = ?',
+      whereArgs: [milestone.id],
+    );
+    await _replaceActionItems(db, milestone.id, milestone.actionItems);
+    await _notifyChanged();
+  }
+
+  Future<void> updateActionItem(ActionItem item) async {
+    final db = await _requireDatabase();
+    await db.update(
+      actionItemsTable,
+      {
+        'milestone_id': item.milestoneId,
+        'summary': item.summary,
+        'description': item.description,
+        'status': item.status.name,
+        'due_date': item.dueDate?.millisecondsSinceEpoch,
+        'notes': item.notes,
+        'created_at': item.createdAt.millisecondsSinceEpoch,
+        'updated_at': item.updatedAt.millisecondsSinceEpoch,
+      },
+      where: 'id = ?',
+      whereArgs: [item.id],
+    );
+    await _replaceRequirements(db, item.id, item.requirements);
+    await _notifyChanged();
+  }
+
+  Future<void> updateItemStatus(String itemId, ItemStatus status) async {
+    final db = await _requireDatabase();
+    await db.update(
+      actionItemsTable,
+      {
+        'status': status.name,
+        'updated_at': DateTime.now().millisecondsSinceEpoch,
+      },
+      where: 'id = ?',
+      whereArgs: [itemId],
+    );
+    await _notifyChanged();
+  }
+
+  Future<void> saveInputValue(String requirementId, String value) async {
+    final db = await _requireDatabase();
+    await db.update(
+      inputRequirementsTable,
+      {'value': value},
+      where: 'id = ?',
+      whereArgs: [requirementId],
+    );
+    await _notifyChanged();
+  }
+
+  Future<LifeTrack> hydrateTemplate(LifeTrack track) async {
+    final db = await _requireDatabase();
+    await db.transaction((txn) async {
+      await _insertTrackGraph(txn, track);
+    });
+    await _notifyChanged();
+    return track;
+  }
+
+  Future<void> close() async {
+    await _database?.close();
+    _database = null;
+  }
+
+  Future<Database> _requireDatabase() async {
+    await initialize();
+    return _database!;
+  }
+
+  Future<void> _createSchema(DatabaseExecutor db) async {
+    await db.execute('''
+      CREATE TABLE $lifeTracksTable (
+        id TEXT PRIMARY KEY,
+        title TEXT NOT NULL,
+        category TEXT NOT NULL,
+        status TEXT NOT NULL DEFAULT 'draft',
+        template_id TEXT,
+        created_at INTEGER NOT NULL,
+        updated_at INTEGER NOT NULL
+      )
+    ''');
+    await db.execute('''
+      CREATE TABLE $milestonesTable (
+        id TEXT PRIMARY KEY,
+        track_id TEXT NOT NULL REFERENCES $lifeTracksTable(id) ON DELETE CASCADE,
+        name TEXT NOT NULL,
+        objective TEXT NOT NULL DEFAULT '',
+        sort_order INTEGER NOT NULL DEFAULT 0,
+        status TEXT NOT NULL DEFAULT 'todo'
+      )
+    ''');
+    await db.execute('''
+      CREATE TABLE $actionItemsTable (
+        id TEXT PRIMARY KEY,
+        milestone_id TEXT NOT NULL REFERENCES $milestonesTable(id) ON DELETE CASCADE,
+        summary TEXT NOT NULL,
+        description TEXT,
+        status TEXT NOT NULL DEFAULT 'todo',
+        due_date INTEGER,
+        notes TEXT,
+        created_at INTEGER NOT NULL,
+        updated_at INTEGER NOT NULL
+      )
+    ''');
+    await db.execute('''
+      CREATE TABLE $inputRequirementsTable (
+        id TEXT PRIMARY KEY,
+        action_item_id TEXT NOT NULL REFERENCES $actionItemsTable(id) ON DELETE CASCADE,
+        label TEXT NOT NULL,
+        field_type TEXT NOT NULL,
+        value TEXT,
+        is_required INTEGER NOT NULL DEFAULT 0,
+        hint TEXT
+      )
+    ''');
+    await db.execute(
+      'CREATE INDEX idx_milestones_track_id ON $milestonesTable(track_id)',
+    );
+    await db.execute(
+      'CREATE INDEX idx_action_items_milestone_id ON $actionItemsTable(milestone_id)',
+    );
+    await db.execute(
+      'CREATE INDEX idx_input_requirements_action_item_id ON $inputRequirementsTable(action_item_id)',
+    );
+  }
+
+  Future<void> _insertTrackGraph(DatabaseExecutor db, LifeTrack track) async {
+    await db.insert(lifeTracksTable, {
+      'id': track.id,
+      'title': track.title,
+      'category': track.category.name,
+      'status': track.status.name,
+      'template_id': track.templateId,
+      'created_at': track.createdAt.millisecondsSinceEpoch,
+      'updated_at': track.updatedAt.millisecondsSinceEpoch,
+    });
+
+    for (final milestone in track.milestones) {
+      await db.insert(milestonesTable, {
+        'id': milestone.id,
+        'track_id': milestone.trackId,
+        'name': milestone.name,
+        'objective': milestone.objective,
+        'sort_order': milestone.sortOrder,
+        'status': milestone.status.name,
+      });
+      for (final item in milestone.actionItems) {
+        await db.insert(actionItemsTable, {
+          'id': item.id,
+          'milestone_id': item.milestoneId,
+          'summary': item.summary,
+          'description': item.description,
+          'status': item.status.name,
+          'due_date': item.dueDate?.millisecondsSinceEpoch,
+          'notes': item.notes,
+          'created_at': item.createdAt.millisecondsSinceEpoch,
+          'updated_at': item.updatedAt.millisecondsSinceEpoch,
+        });
+        for (final requirement in item.requirements) {
+          await db.insert(inputRequirementsTable, {
+            'id': requirement.id,
+            'action_item_id': requirement.actionItemId,
+            'label': requirement.label,
+            'field_type': requirement.fieldType.name,
+            'value': requirement.value,
+            'is_required': requirement.isRequired ? 1 : 0,
+            'hint': requirement.hint,
+          });
+        }
+      }
+    }
+  }
+
+  Future<void> _replaceMilestones(
+    DatabaseExecutor db,
+    String trackId,
+    List<Milestone> milestones,
+  ) async {
+    await db.delete(
+      milestonesTable,
+      where: 'track_id = ?',
+      whereArgs: [trackId],
+    );
+    for (final milestone in milestones) {
+      await db.insert(milestonesTable, {
+        'id': milestone.id,
+        'track_id': milestone.trackId,
+        'name': milestone.name,
+        'objective': milestone.objective,
+        'sort_order': milestone.sortOrder,
+        'status': milestone.status.name,
+      });
+      for (final item in milestone.actionItems) {
+        await db.insert(actionItemsTable, {
+          'id': item.id,
+          'milestone_id': item.milestoneId,
+          'summary': item.summary,
+          'description': item.description,
+          'status': item.status.name,
+          'due_date': item.dueDate?.millisecondsSinceEpoch,
+          'notes': item.notes,
+          'created_at': item.createdAt.millisecondsSinceEpoch,
+          'updated_at': item.updatedAt.millisecondsSinceEpoch,
+        });
+        for (final requirement in item.requirements) {
+          await db.insert(inputRequirementsTable, {
+            'id': requirement.id,
+            'action_item_id': requirement.actionItemId,
+            'label': requirement.label,
+            'field_type': requirement.fieldType.name,
+            'value': requirement.value,
+            'is_required': requirement.isRequired ? 1 : 0,
+            'hint': requirement.hint,
+          });
+        }
+      }
+    }
+  }
+
+  Future<void> _replaceActionItems(
+    DatabaseExecutor db,
+    String milestoneId,
+    List<ActionItem> items,
+  ) async {
+    await db.delete(
+      actionItemsTable,
+      where: 'milestone_id = ?',
+      whereArgs: [milestoneId],
+    );
+    for (final item in items) {
+      await db.insert(actionItemsTable, {
+        'id': item.id,
+        'milestone_id': item.milestoneId,
+        'summary': item.summary,
+        'description': item.description,
+        'status': item.status.name,
+        'due_date': item.dueDate?.millisecondsSinceEpoch,
+        'notes': item.notes,
+        'created_at': item.createdAt.millisecondsSinceEpoch,
+        'updated_at': item.updatedAt.millisecondsSinceEpoch,
+      });
+      for (final requirement in item.requirements) {
+        await db.insert(inputRequirementsTable, {
+          'id': requirement.id,
+          'action_item_id': requirement.actionItemId,
+          'label': requirement.label,
+          'field_type': requirement.fieldType.name,
+          'value': requirement.value,
+          'is_required': requirement.isRequired ? 1 : 0,
+          'hint': requirement.hint,
+        });
+      }
+    }
+  }
+
+  Future<void> _replaceRequirements(
+    DatabaseExecutor db,
+    String actionItemId,
+    List<InputRequirement> requirements,
+  ) async {
+    await db.delete(
+      inputRequirementsTable,
+      where: 'action_item_id = ?',
+      whereArgs: [actionItemId],
+    );
+    for (final requirement in requirements) {
+      await db.insert(inputRequirementsTable, {
+        'id': requirement.id,
+        'action_item_id': requirement.actionItemId,
+        'label': requirement.label,
+        'field_type': requirement.fieldType.name,
+        'value': requirement.value,
+        'is_required': requirement.isRequired ? 1 : 0,
+        'hint': requirement.hint,
+      });
+    }
+  }
+
+  Future<LifeTrack> _hydrateTrack(
+    DatabaseExecutor db,
+    Map<String, Object?> row,
+  ) async {
+    final milestonesRows = await db.query(
+      milestonesTable,
+      where: 'track_id = ?',
+      whereArgs: [row['id']],
+      orderBy: 'sort_order ASC',
+    );
+
+    final milestones = <Milestone>[];
+    for (final milestoneRow in milestonesRows) {
+      final actionItemRows = await db.query(
+        actionItemsTable,
+        where: 'milestone_id = ?',
+        whereArgs: [milestoneRow['id']],
+        orderBy: 'created_at ASC',
+      );
+      final actionItems = <ActionItem>[];
+      for (final actionItemRow in actionItemRows) {
+        final requirementRows = await db.query(
+          inputRequirementsTable,
+          where: 'action_item_id = ?',
+          whereArgs: [actionItemRow['id']],
+          orderBy: 'label ASC',
+        );
+        final requirements = requirementRows
+            .map(_mapRequirement)
+            .toList(growable: false);
+        actionItems.add(_mapActionItem(actionItemRow, requirements));
+      }
+      milestones.add(_mapMilestone(milestoneRow, actionItems));
+    }
+
+    return LifeTrack(
+      id: row['id']! as String,
+      title: row['title']! as String,
+      category: LifeTrackCategory.values.firstWhere(
+        (item) => item.name == row['category'],
+      ),
+      status: TrackStatus.values.firstWhere(
+        (item) => item.name == row['status'],
+      ),
+      milestones: milestones,
+      createdAt: DateTime.fromMillisecondsSinceEpoch(
+        row['created_at']! as int,
+        isUtc: true,
+      ),
+      updatedAt: DateTime.fromMillisecondsSinceEpoch(
+        row['updated_at']! as int,
+        isUtc: true,
+      ),
+      templateId: row['template_id'] as String?,
+    );
+  }
+
+  Milestone _mapMilestone(
+    Map<String, Object?> row,
+    List<ActionItem> actionItems,
+  ) => Milestone(
+    id: row['id']! as String,
+    trackId: row['track_id']! as String,
+    name: row['name']! as String,
+    objective: row['objective']! as String,
+    sortOrder: row['sort_order']! as int,
+    status: ItemStatus.values.firstWhere((item) => item.name == row['status']),
+    actionItems: actionItems,
+  );
+
+  ActionItem _mapActionItem(
+    Map<String, Object?> row,
+    List<InputRequirement> requirements,
+  ) => ActionItem(
+    id: row['id']! as String,
+    milestoneId: row['milestone_id']! as String,
+    summary: row['summary']! as String,
+    description: row['description'] as String?,
+    status: ItemStatus.values.firstWhere((item) => item.name == row['status']),
+    requirements: requirements,
+    dueDate: row['due_date'] == null
+        ? null
+        : DateTime.fromMillisecondsSinceEpoch(
+            row['due_date']! as int,
+            isUtc: true,
+          ),
+    notes: row['notes'] as String?,
+    createdAt: DateTime.fromMillisecondsSinceEpoch(
+      row['created_at']! as int,
+      isUtc: true,
+    ),
+    updatedAt: DateTime.fromMillisecondsSinceEpoch(
+      row['updated_at']! as int,
+      isUtc: true,
+    ),
+  );
+
+  InputRequirement _mapRequirement(Map<String, Object?> row) =>
+      InputRequirement(
+        id: row['id']! as String,
+        actionItemId: row['action_item_id']! as String,
+        label: row['label']! as String,
+        fieldType: FieldType.values.firstWhere(
+          (item) => item.name == row['field_type'],
+        ),
+        value: row['value'] as String?,
+        isRequired: (row['is_required']! as int) == 1,
+        hint: row['hint'] as String?,
+      );
+
+  Future<void> _notifyChanged() async {
+    if (!_changes.isClosed) {
+      _changes.add(null);
+    }
+  }
+}

--- a/packages/core_data/pubspec.yaml
+++ b/packages/core_data/pubspec.yaml
@@ -19,9 +19,11 @@ dependencies:
   path: 1.9.1
   path_provider: ^2.1.6
   meta: ^1.16.0
+  sqflite: ^2.4.2
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
   flutter_lints: 6.0.0
   mocktail: ^1.0.5
+  sqflite_common_ffi: ^2.3.6

--- a/packages/core_data/test/repositories/life_track_repository_impl_test.dart
+++ b/packages/core_data/test/repositories/life_track_repository_impl_test.dart
@@ -1,0 +1,61 @@
+import 'package:core_data/src/repositories/life_track_repository_impl.dart';
+import 'package:core_data/src/storage/life_track_local_data_source.dart';
+import 'package:core_domain/core_domain.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sqflite_common_ffi/sqflite_ffi.dart';
+
+void main() {
+  late LifeTrackLocalDataSource dataSource;
+  late LifeTrackRepositoryImpl repository;
+
+  setUpAll(() {
+    sqfliteFfiInit();
+  });
+
+  setUp(() async {
+    dataSource = LifeTrackLocalDataSource(
+      databaseFactory: databaseFactoryFfi,
+      databasePath: inMemoryDatabasePath,
+    );
+    await dataSource.initialize();
+    repository = LifeTrackRepositoryImpl(localDataSource: dataSource);
+  });
+
+  tearDown(() async {
+    await dataSource.close();
+  });
+
+  test('returns not found error for missing track', () async {
+    final result = await repository.getTrack('missing');
+
+    expect(result.isErr, isTrue);
+    expect(result.getErrorOrNull(), isA<NotFoundError>());
+  });
+
+  test('creates, lists, updates, and watches tracks', () async {
+    final track = LifeTrack(
+      id: 'track-1',
+      title: 'Track',
+      category: LifeTrackCategory.finance,
+      status: TrackStatus.draft,
+      milestones: const [],
+      createdAt: DateTime.utc(2026, 6, 29),
+      updatedAt: DateTime.utc(2026, 6, 29),
+    );
+
+    final created = await repository.createTrack(track);
+    expect(created.value.id, 'track-1');
+
+    final listed = await repository.listTracks();
+    expect(listed.value, hasLength(1));
+
+    final watched = repository.watchTracks();
+    final updatedTrack = track.copyWith(title: 'Updated');
+    await repository.updateTrack(updatedTrack);
+    final values = await watched.firstWhere(
+      (items) => items.any((item) => item.title == 'Updated'),
+    );
+
+    expect(values.single.title, 'Updated');
+  });
+}

--- a/packages/core_data/test/storage/life_track_local_data_source_test.dart
+++ b/packages/core_data/test/storage/life_track_local_data_source_test.dart
@@ -1,0 +1,188 @@
+import 'package:core_data/src/storage/life_track_local_data_source.dart';
+import 'package:core_domain/core_domain.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sqflite_common_ffi/sqflite_ffi.dart';
+
+void main() {
+  late DatabaseFactory databaseFactory;
+  late LifeTrackLocalDataSource dataSource;
+
+  setUpAll(() {
+    sqfliteFfiInit();
+  });
+
+  setUp(() async {
+    databaseFactory = databaseFactoryFfi;
+    dataSource = LifeTrackLocalDataSource(
+      databaseFactory: databaseFactory,
+      databasePath: inMemoryDatabasePath,
+    );
+    await dataSource.initialize();
+  });
+
+  tearDown(() async {
+    await dataSource.close();
+  });
+
+  test('creates and hydrates a full LifeTrack graph', () async {
+    final track = _sampleTrack();
+
+    await dataSource.createTrack(track);
+    final stored = await dataSource.getTrack(track.id);
+
+    expect(stored, isNotNull);
+    expect(stored, track);
+    expect(stored!.progress, closeTo(0.75, 0.0001));
+  });
+
+  test('filters tracks by status', () async {
+    await dataSource.createTrack(_sampleTrack());
+    await dataSource.createTrack(
+      _sampleTrack(id: 'track-2').copyWith(status: TrackStatus.completed),
+    );
+
+    final active = await dataSource.listTracks(status: TrackStatus.active);
+    final completed = await dataSource.listTracks(
+      status: TrackStatus.completed,
+    );
+
+    expect(active, hasLength(1));
+    expect(completed.single.id, 'track-2');
+  });
+
+  test('watchTracks emits after mutation', () async {
+    final events = <List<LifeTrack>>[];
+    final subscription = dataSource.watchTracks().listen(events.add);
+
+    await dataSource.createTrack(_sampleTrack());
+    await Future<void>.delayed(Duration.zero);
+
+    expect(events, isNotEmpty);
+    expect(events.last.single.id, 'track-1');
+    await subscription.cancel();
+  });
+
+  test('cascade delete removes nested rows', () async {
+    final track = _sampleTrack();
+    await dataSource.createTrack(track);
+
+    await dataSource.deleteTrack(track.id);
+
+    expect(await dataSource.getTrack(track.id), isNull);
+    expect(await dataSource.listTracks(), isEmpty);
+  });
+
+  test('batch hydrate inserts 50 items under performance budget', () async {
+    final milestone = Milestone(
+      id: 'milestone-batch',
+      trackId: 'track-batch',
+      name: 'Batch',
+      objective: 'Perf',
+      sortOrder: 0,
+      status: ItemStatus.todo,
+      actionItems: List.generate(
+        50,
+        (index) => ActionItem(
+          id: 'item-$index',
+          milestoneId: 'milestone-batch',
+          summary: 'Item $index',
+          status: ItemStatus.todo,
+          requirements: const [],
+          createdAt: DateTime.utc(2026, 6, 29),
+          updatedAt: DateTime.utc(2026, 6, 29),
+        ),
+      ),
+    );
+    final track = LifeTrack(
+      id: 'track-batch',
+      title: 'Batch Track',
+      category: LifeTrackCategory.custom,
+      status: TrackStatus.active,
+      milestones: [milestone],
+      createdAt: DateTime.utc(2026, 6, 29),
+      updatedAt: DateTime.utc(2026, 6, 29),
+    );
+
+    final stopwatch = Stopwatch()..start();
+    await dataSource.hydrateTemplate(track);
+    stopwatch.stop();
+
+    expect(stopwatch.elapsedMilliseconds, lessThan(100));
+  });
+}
+
+LifeTrack _sampleTrack({String id = 'track-1'}) {
+  final suffix = id.replaceAll(RegExp(r'[^a-zA-Z0-9]'), '_');
+  final requirement = InputRequirement(
+    id: 'req_$suffix',
+    actionItemId: 'item1_$suffix',
+    label: 'Document',
+    fieldType: FieldType.document,
+    isRequired: true,
+  );
+  final first = ActionItem(
+    id: 'item1_$suffix',
+    milestoneId: 'milestone1_$suffix',
+    summary: 'Check docs',
+    status: ItemStatus.done,
+    requirements: [requirement],
+    createdAt: DateTime.utc(2026, 6, 29, 9),
+    updatedAt: DateTime.utc(2026, 6, 29, 10),
+  );
+  final second = ActionItem(
+    id: 'item2_$suffix',
+    milestoneId: 'milestone1_$suffix',
+    summary: 'Call bank',
+    status: ItemStatus.blocked,
+    requirements: const [],
+    createdAt: DateTime.utc(2026, 6, 29, 9),
+    updatedAt: DateTime.utc(2026, 6, 29, 10),
+  );
+  final skipped = ActionItem(
+    id: 'item3_$suffix',
+    milestoneId: 'milestone2_$suffix',
+    summary: 'Optional',
+    status: ItemStatus.skipped,
+    requirements: const [],
+    createdAt: DateTime.utc(2026, 6, 29, 9),
+    updatedAt: DateTime.utc(2026, 6, 29, 10),
+  );
+  final done = ActionItem(
+    id: 'item4_$suffix',
+    milestoneId: 'milestone2_$suffix',
+    summary: 'Collect copy',
+    status: ItemStatus.done,
+    requirements: const [],
+    createdAt: DateTime.utc(2026, 6, 29, 9),
+    updatedAt: DateTime.utc(2026, 6, 29, 10),
+  );
+
+  return LifeTrack(
+    id: id,
+    title: 'LifeTrack',
+    category: LifeTrackCategory.realEstate,
+    status: TrackStatus.active,
+    milestones: [
+      Milestone(
+        id: 'milestone1_$suffix',
+        trackId: id,
+        name: 'Phase 1',
+        objective: 'Verify',
+        sortOrder: 0,
+        status: ItemStatus.inProgress,
+        actionItems: [first, second],
+      ),
+      Milestone(
+        id: 'milestone2_$suffix',
+        trackId: id,
+        name: 'Phase 2',
+        objective: 'Close',
+        sortOrder: 1,
+        status: ItemStatus.todo,
+        actionItems: [skipped, done],
+      ),
+    ],
+    createdAt: DateTime.utc(2026, 6, 29, 8),
+    updatedAt: DateTime.utc(2026, 6, 29, 11),
+  );
+}


### PR DESCRIPTION
# Summary

This PR introduces changes to the LifeTrack framework data layer.
Goal: add deterministic offline persistence for LifeTrack entities in `core_data`.

Core outcome:

* adds SQLite-backed storage for tracks, milestones, action items, and input requirements
* exposes a concrete `LifeTrackRepository` implementation for application flows

# Changes

### Code

* Added:
  * `LifeTrackLocalDataSource` for raw SQLite CRUD, watchers, and transactional hydration
  * `LifeTrackRepositoryImpl` to bridge `core_domain` contracts to local persistence
  * in-memory SQLite tests for datasource and repository behavior
* Updated:
  * `packages/core_data/lib/core_data.dart` exports for the new storage and repository types
  * `packages/core_data/pubspec.yaml` to include `sqflite` and `sqflite_common_ffi`

### Logic

* creates the four-table LifeTrack schema with foreign keys and supporting indexes
* wraps graph creation and template hydration in transactions
* emits `watchTracks()` updates after track, milestone, action item, and input value mutations
* preserves cascade delete semantics across the full LifeTrack graph
* hydrates persisted timestamps as UTC to keep entity equality stable in tests and runtime

# API Changes (if any)

* None

# Database Changes (if any)

* Table: `life_tracks`
* Table: `milestones`
* Table: `action_items`
* Table: `input_requirements`
* Migration:
  * schema version `1` in `LifeTrackLocalDataSource`
  * forward-only initial schema creation for local SQLite storage

# Observability / Logging

* None

# Performance Impact

* Latency: batch hydration for 50 items is covered by a sub-100ms test budget
* Throughput: local-only CRUD path for offline lifecycle state
* Memory/CPU: negligible for this slice

# Risks

* schema evolution beyond v1 will require explicit migration handling in follow-up work
* `watchTracks()` is in-process only and assumes all writes go through the datasource instance
* Rollback plan:
  * revert this PR before dependent application wiring lands

# Testing

* Unit tests:
  * added datasource CRUD, filtering, watcher, cascade delete, and performance coverage
  * added repository success/error coverage
* Integration tests:
  * none
* Manual testing:
  * `flutter analyze`
  * `flutter test`

# Deployment Notes

* Config changes:
  * none
* Order of deployment:
  * safe to merge before application-layer consumers

# Related Commits

* `feat(core_data): add LifeTrack SQLite persistence`

# Notes

* Closes #333
