### PR TITLE
Add bundled LifeTrack templates

### DIFF
--- a/packages/core_data/lib/core_data.dart
+++ b/packages/core_data/lib/core_data.dart
@@ -12,6 +12,7 @@ export 'src/storage/preferences_store.dart';
 export 'src/storage/secure_store.dart';
 export 'src/storage/flutter_secure_store.dart';
 export 'src/storage/life_track_local_data_source.dart';
+export 'src/storage/templates/template_registry.dart';
 
 // Connectivity
 export 'src/connectivity/connectivity_service.dart';

--- a/packages/core_data/lib/src/storage/templates/car_purchase.json
+++ b/packages/core_data/lib/src/storage/templates/car_purchase.json
@@ -1,0 +1,92 @@
+{
+  "template_id": "car_purchase_v1",
+  "title": "Car Purchase Decision Template",
+  "description": "A bundled template for verifying prerequisites, researching vehicles, and planning financing before purchase.",
+  "category": "carPurchase",
+  "version": "1.0",
+  "milestones": [
+    {
+      "name": "Phase 1: Prerequisites & Documentation",
+      "objective": "Confirm license, fitness, and required personal documents",
+      "tasks": [
+        {
+          "summary": "Verify driving license validity",
+          "requirements": [
+            {
+              "label": "Driving License Copy",
+              "type": "document",
+              "is_required": true
+            }
+          ]
+        },
+        {
+          "summary": "Confirm physical fitness and parking readiness",
+          "requirements": [
+            {
+              "label": "Physical Fitness Notes",
+              "type": "text",
+              "is_required": false
+            },
+            {
+              "label": "Parking Plan",
+              "type": "text",
+              "is_required": true
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Phase 2: Car Research & Selection",
+      "objective": "Compare shortlisted vehicles against budget and needs",
+      "tasks": [
+        {
+          "summary": "Compare shortlisted cars",
+          "requirements": [
+            {
+              "label": "Shortlisted Cars",
+              "type": "text",
+              "is_required": true
+            },
+            {
+              "label": "Test Drive Notes",
+              "type": "text",
+              "is_required": false
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Phase 3: Financial Planning & Loan Pre-approval",
+      "objective": "Secure budget clarity, insurance estimates, and pre-approved financing",
+      "tasks": [
+        {
+          "summary": "Evaluate total ownership cost",
+          "requirements": [
+            {
+              "label": "Budget Range",
+              "type": "number",
+              "is_required": true
+            },
+            {
+              "label": "Insurance Estimate",
+              "type": "number",
+              "is_required": false
+            }
+          ]
+        },
+        {
+          "summary": "Collect loan pre-approval options",
+          "requirements": [
+            {
+              "label": "Loan Offers",
+              "type": "text",
+              "is_required": true
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/packages/core_data/lib/src/storage/templates/insurance_claim.json
+++ b/packages/core_data/lib/src/storage/templates/insurance_claim.json
@@ -1,0 +1,73 @@
+{
+  "template_id": "insurance_claim_v1",
+  "title": "Insurance Claim Tracking Template",
+  "description": "A bundled skeleton for documenting an incident, filing the claim, following up, and settling.",
+  "category": "insurance",
+  "version": "1.0",
+  "milestones": [
+    {
+      "name": "Phase 1: Incident Documentation",
+      "objective": "Capture evidence and timeline details",
+      "tasks": [
+        {
+          "summary": "Collect incident evidence",
+          "requirements": [
+            {
+              "label": "Evidence Notes",
+              "type": "text",
+              "is_required": true
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Phase 2: Claim Filing",
+      "objective": "Submit the claim package with required forms",
+      "tasks": [
+        {
+          "summary": "Submit claim form",
+          "requirements": [
+            {
+              "label": "Claim Submission Reference",
+              "type": "text",
+              "is_required": true
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Phase 3: Follow-up",
+      "objective": "Track adjuster communication and pending documents",
+      "tasks": [
+        {
+          "summary": "Log insurer follow-up requests",
+          "requirements": [
+            {
+              "label": "Follow-up Log",
+              "type": "text",
+              "is_required": true
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Phase 4: Settlement",
+      "objective": "Confirm payout and close pending actions",
+      "tasks": [
+        {
+          "summary": "Record settlement outcome",
+          "requirements": [
+            {
+              "label": "Settlement Notes",
+              "type": "text",
+              "is_required": true
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/packages/core_data/lib/src/storage/templates/medical_surgery.json
+++ b/packages/core_data/lib/src/storage/templates/medical_surgery.json
@@ -1,0 +1,73 @@
+{
+  "template_id": "medical_surgery_v1",
+  "title": "Medical Surgery Preparation Template",
+  "description": "A bundled skeleton for pre-surgery tests, insurance approval, surgery prep, and recovery planning.",
+  "category": "medical",
+  "version": "1.0",
+  "milestones": [
+    {
+      "name": "Phase 1: Pre-surgery Tests",
+      "objective": "Complete required diagnostics and specialist consultations",
+      "tasks": [
+        {
+          "summary": "Track required pre-op tests",
+          "requirements": [
+            {
+              "label": "Required Tests List",
+              "type": "text",
+              "is_required": true
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Phase 2: Insurance Approval",
+      "objective": "Confirm coverage and pre-authorization requirements",
+      "tasks": [
+        {
+          "summary": "Collect pre-authorization details",
+          "requirements": [
+            {
+              "label": "Insurance Authorization Reference",
+              "type": "text",
+              "is_required": true
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Phase 3: Surgery Preparation",
+      "objective": "Prepare documents, logistics, and doctor instructions",
+      "tasks": [
+        {
+          "summary": "Review hospital preparation checklist",
+          "requirements": [
+            {
+              "label": "Hospital Checklist",
+              "type": "text",
+              "is_required": true
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Phase 4: Post-op Recovery",
+      "objective": "Plan medicines, follow-ups, and recovery support",
+      "tasks": [
+        {
+          "summary": "Create recovery follow-up plan",
+          "requirements": [
+            {
+              "label": "Recovery Notes",
+              "type": "text",
+              "is_required": true
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/packages/core_data/lib/src/storage/templates/real_estate_under_construction.json
+++ b/packages/core_data/lib/src/storage/templates/real_estate_under_construction.json
@@ -1,0 +1,189 @@
+{
+  "template_id": "real_estate_under_construction_v1",
+  "title": "Under-Construction Flat Purchase Checklist",
+  "description": "7 critical verification steps before buying an under-construction flat",
+  "category": "realEstate",
+  "version": "1.0",
+  "milestones": [
+    {
+      "name": "Phase 1: RERA & Legal Verification",
+      "objective": "Verify builder legitimacy and project approvals",
+      "tasks": [
+        {
+          "summary": "Check Builder's RERA Registration",
+          "description": "Look into the builder's past delivery history and track record on the RERA website.",
+          "requirements": [
+            {
+              "label": "RERA Registration Number",
+              "type": "text",
+              "is_required": true,
+              "hint": "Found on the official RERA portal"
+            },
+            {
+              "label": "Builder Track Record Notes",
+              "type": "text",
+              "is_required": false,
+              "hint": "Delayed projects count, pending projects count"
+            },
+            {
+              "label": "RERA Verification Screenshot",
+              "type": "document",
+              "is_required": false
+            }
+          ]
+        },
+        {
+          "summary": "Verify Commencement Certificate Stage",
+          "description": "Check up to which floor the builder has approval and compare it with your target floor.",
+          "requirements": [
+            {
+              "label": "CC Approved Up To Floor",
+              "type": "number",
+              "is_required": true
+            },
+            {
+              "label": "Your Target Floor",
+              "type": "number",
+              "is_required": true
+            },
+            {
+              "label": "Commencement Certificate Copy",
+              "type": "document",
+              "is_required": false
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Phase 2: Financial Health Check",
+      "objective": "Assess the builder's and project's financial backing",
+      "tasks": [
+        {
+          "summary": "Review List of Approved Lenders",
+          "description": "Check which banks offer home loans for the project and treat an NBFC-only list as a warning sign.",
+          "requirements": [
+            {
+              "label": "Associated Banks List",
+              "type": "text",
+              "is_required": true,
+              "hint": "List all banks offering loans for this project"
+            },
+            {
+              "label": "Any NBFCs Only?",
+              "type": "boolean",
+              "is_required": true,
+              "hint": "Red flag if only NBFCs, no major banks"
+            }
+          ]
+        },
+        {
+          "summary": "Check Land Encumbrance Certificate",
+          "description": "Verify whether the builder has taken a loan against the plot itself.",
+          "requirements": [
+            {
+              "label": "Encumbrance Certificate Document",
+              "type": "document",
+              "is_required": true
+            },
+            {
+              "label": "Land Loan Status",
+              "type": "text",
+              "is_required": true,
+              "hint": "Clear or outstanding, with amount if outstanding"
+            },
+            {
+              "label": "Land Loan Clearance Date",
+              "type": "date",
+              "is_required": false
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Phase 3: Layout & Space Verification",
+      "objective": "Verify actual usable space matches what is promised",
+      "tasks": [
+        {
+          "summary": "Examine Carpet Area Layout",
+          "description": "Ask for structural layout drawings and note losses to ducts, lobbies, lifts, and columns.",
+          "requirements": [
+            {
+              "label": "Advertised Carpet Area (sq ft)",
+              "type": "number",
+              "is_required": true
+            },
+            {
+              "label": "Structural Layout Drawing",
+              "type": "document",
+              "is_required": true,
+              "hint": "Ask the builder explicitly for this"
+            },
+            {
+              "label": "Actual Usable Area Notes",
+              "type": "text",
+              "is_required": false,
+              "hint": "Space lost to lifts, ducts, columns, or lobbies"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Phase 4: Legal Agreement Verification",
+      "objective": "Ensure all protections are in the buyer agreement",
+      "tasks": [
+        {
+          "summary": "Look for Escrow Account Clause",
+          "description": "Confirm the agreement explicitly references the mandated project escrow account.",
+          "requirements": [
+            {
+              "label": "Escrow Clause Present in Agreement?",
+              "type": "boolean",
+              "is_required": true
+            },
+            {
+              "label": "Escrow Account Details",
+              "type": "text",
+              "is_required": false,
+              "hint": "Bank name or account reference if available"
+            },
+            {
+              "label": "Buyer Agreement Document",
+              "type": "document",
+              "is_required": false
+            }
+          ]
+        },
+        {
+          "summary": "Confirm Timeline for Promised Amenities",
+          "description": "Check the legal agreement for definitive delivery dates on every amenity shown in brochures.",
+          "requirements": [
+            {
+              "label": "Amenities Delivery Date in Contract?",
+              "type": "boolean",
+              "is_required": true
+            },
+            {
+              "label": "Promised Amenities List",
+              "type": "text",
+              "is_required": true,
+              "hint": "Clubhouse, gym, garden, pool, and similar amenities"
+            },
+            {
+              "label": "Contract Delivery Date",
+              "type": "date",
+              "is_required": false
+            },
+            {
+              "label": "Brochure vs Agreement Comparison Notes",
+              "type": "text",
+              "is_required": false
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/packages/core_data/lib/src/storage/templates/template_registry.dart
+++ b/packages/core_data/lib/src/storage/templates/template_registry.dart
@@ -1,0 +1,135 @@
+import 'dart:convert';
+
+import 'package:core_domain/core_domain.dart';
+import 'package:flutter/services.dart';
+
+class TemplateRegistry {
+  TemplateRegistry._(this._templates);
+
+  static const bundledAssetPaths = <String>[
+    'packages/core_data/lib/src/storage/templates/real_estate_under_construction.json',
+    'packages/core_data/lib/src/storage/templates/university_admission.json',
+    'packages/core_data/lib/src/storage/templates/medical_surgery.json',
+    'packages/core_data/lib/src/storage/templates/insurance_claim.json',
+    'packages/core_data/lib/src/storage/templates/car_purchase.json',
+  ];
+
+  final List<LifeTrackTemplate> _templates;
+
+  static Future<TemplateRegistry> loadBundled({AssetBundle? bundle}) async {
+    final assetBundle = bundle ?? rootBundle;
+    final templates = <LifeTrackTemplate>[];
+
+    for (final assetPath in bundledAssetPaths) {
+      final rawJson = await assetBundle.loadString(assetPath);
+      final decoded = jsonDecode(rawJson);
+      if (decoded is! Map<String, dynamic>) {
+        throw ParseError(
+          'Template asset must decode to a JSON object: $assetPath',
+        );
+      }
+      final result = validate(decoded);
+      if (result case Ok(value: final template)) {
+        templates.add(template);
+      } else if (result case Err(error: final error, stack: final stack)) {
+        throw ParseError(
+          'Bundled template failed validation: $assetPath',
+          originalError: error,
+          originalStack: stack,
+        );
+      }
+    }
+
+    return TemplateRegistry._(List.unmodifiable(templates));
+  }
+
+  List<LifeTrackTemplate> getAll() => List.unmodifiable(_templates);
+
+  List<LifeTrackTemplate> getByCategory(LifeTrackCategory category) =>
+      _templates
+          .where((template) => template.category == category)
+          .toList(growable: false);
+
+  LifeTrackTemplate? getById(String templateId) {
+    for (final template in _templates) {
+      if (template.templateId == templateId) return template;
+    }
+    return null;
+  }
+
+  static Result<LifeTrackTemplate> validate(Map<String, dynamic> json) {
+    try {
+      final template = LifeTrackTemplate.fromJson(json);
+      final fieldErrors = <String, String>{};
+
+      if (template.templateId.trim().isEmpty) {
+        fieldErrors['template_id'] = 'Template ID is required.';
+      }
+      if (template.title.trim().isEmpty) {
+        fieldErrors['title'] = 'Title is required.';
+      }
+      if (template.description.trim().isEmpty) {
+        fieldErrors['description'] = 'Description is required.';
+      }
+      if (template.version.trim().isEmpty) {
+        fieldErrors['version'] = 'Version is required.';
+      }
+      if (template.milestones.isEmpty) {
+        fieldErrors['milestones'] = 'At least one milestone is required.';
+      }
+
+      for (
+        var milestoneIndex = 0;
+        milestoneIndex < template.milestones.length;
+        milestoneIndex++
+      ) {
+        final milestone = template.milestones[milestoneIndex];
+        if (milestone.name.trim().isEmpty) {
+          fieldErrors['milestones[$milestoneIndex].name'] =
+              'Milestone name is required.';
+        }
+        if (milestone.objective.trim().isEmpty) {
+          fieldErrors['milestones[$milestoneIndex].objective'] =
+              'Milestone objective is required.';
+        }
+        if (milestone.tasks.isEmpty) {
+          fieldErrors['milestones[$milestoneIndex].tasks'] =
+              'At least one task is required.';
+        }
+
+        for (
+          var taskIndex = 0;
+          taskIndex < milestone.tasks.length;
+          taskIndex++
+        ) {
+          final task = milestone.tasks[taskIndex];
+          if (task.summary.trim().isEmpty) {
+            fieldErrors['milestones[$milestoneIndex].tasks[$taskIndex].summary'] =
+                'Task summary is required.';
+          }
+        }
+      }
+
+      if (fieldErrors.isNotEmpty) {
+        return Err(
+          ValidationError(
+            'Invalid LifeTrack template payload',
+            fieldErrors: fieldErrors,
+          ),
+          StackTrace.current,
+        );
+      }
+
+      return Ok(template);
+    } catch (error, stack) {
+      return Err(
+        ParseError(
+          'Failed to parse LifeTrack template payload',
+          originalError: error,
+          originalStack: stack,
+        ),
+        stack,
+      );
+    }
+  }
+}

--- a/packages/core_data/lib/src/storage/templates/university_admission.json
+++ b/packages/core_data/lib/src/storage/templates/university_admission.json
@@ -1,0 +1,74 @@
+{
+  "template_id": "university_admission_v1",
+  "title": "University Admission Planning Template",
+  "description": "A bundled skeleton for shortlisting programs, preparing documents, applying, and completing enrollment.",
+  "category": "education",
+  "version": "1.0",
+  "milestones": [
+    {
+      "name": "Phase 1: Shortlisting",
+      "objective": "Identify target programs and deadlines",
+      "tasks": [
+        {
+          "summary": "Build university shortlist",
+          "description": "List target, reach, and safety programs with deadlines.",
+          "requirements": [
+            {
+              "label": "University Shortlist",
+              "type": "text",
+              "is_required": true
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Phase 2: Document Preparation",
+      "objective": "Prepare transcripts, test scores, essays, and recommendations",
+      "tasks": [
+        {
+          "summary": "Collect required application documents",
+          "requirements": [
+            {
+              "label": "Document Checklist",
+              "type": "text",
+              "is_required": true
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Phase 3: Applications",
+      "objective": "Submit applications and track results",
+      "tasks": [
+        {
+          "summary": "Submit applications before deadlines",
+          "requirements": [
+            {
+              "label": "Submitted Programs",
+              "type": "text",
+              "is_required": true
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Phase 4: Visa & Enrollment",
+      "objective": "Complete admission acceptance and relocation steps",
+      "tasks": [
+        {
+          "summary": "Prepare visa and enrollment confirmations",
+          "requirements": [
+            {
+              "label": "Visa or Enrollment Notes",
+              "type": "text",
+              "is_required": true
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/packages/core_data/pubspec.yaml
+++ b/packages/core_data/pubspec.yaml
@@ -27,3 +27,11 @@ dev_dependencies:
   flutter_lints: 6.0.0
   mocktail: ^1.0.5
   sqflite_common_ffi: ^2.3.6
+
+flutter:
+  assets:
+    - lib/src/storage/templates/real_estate_under_construction.json
+    - lib/src/storage/templates/university_admission.json
+    - lib/src/storage/templates/medical_surgery.json
+    - lib/src/storage/templates/insurance_claim.json
+    - lib/src/storage/templates/car_purchase.json

--- a/packages/core_data/test/storage/template_registry_test.dart
+++ b/packages/core_data/test/storage/template_registry_test.dart
@@ -1,0 +1,72 @@
+import 'package:core_data/core_data.dart';
+import 'package:core_domain/core_domain.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('TemplateRegistry', () {
+    test('loads bundled templates and validates their structure', () async {
+      final registry = await TemplateRegistry.loadBundled();
+
+      final templates = registry.getAll();
+      expect(templates, hasLength(5));
+      expect(
+        templates.map((template) => template.templateId),
+        contains('real_estate_under_construction_v1'),
+      );
+      expect(
+        templates.map((template) => template.templateId),
+        contains('car_purchase_v1'),
+      );
+    });
+
+    test(
+      'returns the real estate template by id with expected milestone/task counts',
+      () async {
+        final registry = await TemplateRegistry.loadBundled();
+
+        final template = registry.getById('real_estate_under_construction_v1');
+
+        expect(template, isNotNull);
+        expect(template!.milestones, hasLength(4));
+        final taskCount = template.milestones.fold<int>(
+          0,
+          (count, milestone) => count + milestone.tasks.length,
+        );
+        expect(taskCount, 7);
+      },
+    );
+
+    test('filters templates by category', () async {
+      final registry = await TemplateRegistry.loadBundled();
+
+      final educationTemplates = registry.getByCategory(
+        LifeTrackCategory.education,
+      );
+
+      expect(educationTemplates, hasLength(1));
+      expect(educationTemplates.single.templateId, 'university_admission_v1');
+    });
+
+    test('validate returns field errors for invalid payloads', () {
+      final result = TemplateRegistry.validate({
+        'template_id': '',
+        'title': '',
+        'description': '',
+        'category': 'custom',
+        'version': '',
+        'milestones': const [],
+      });
+
+      expect(result, isA<Err<LifeTrackTemplate>>());
+      final error = (result as Err<LifeTrackTemplate>).error;
+      expect(error, isA<ValidationError>());
+      expect(
+        (error as ValidationError).fieldErrors.keys,
+        contains('milestones'),
+      );
+      expect(error.fieldErrors.keys, contains('title'));
+    });
+  });
+}

--- a/packages/core_domain/lib/core_domain.dart
+++ b/packages/core_domain/lib/core_domain.dart
@@ -7,6 +7,7 @@
 export 'src/entities/entity.dart';
 export 'src/entities/user.dart';
 export 'src/entities/life_track.dart';
+export 'src/entities/life_track_template.dart';
 export 'src/entities/milestone.dart';
 export 'src/entities/action_item.dart';
 export 'src/entities/input_requirement.dart';

--- a/packages/core_domain/lib/src/entities/life_track_template.dart
+++ b/packages/core_domain/lib/src/entities/life_track_template.dart
@@ -1,0 +1,213 @@
+import 'package:meta/meta.dart';
+
+import 'life_track.dart';
+
+@immutable
+class LifeTrackTemplate {
+  const LifeTrackTemplate({
+    required this.templateId,
+    required this.title,
+    required this.description,
+    required this.category,
+    required this.version,
+    required this.milestones,
+  });
+
+  final String templateId;
+  final String title;
+  final String description;
+  final LifeTrackCategory category;
+  final String version;
+  final List<MilestoneTemplate> milestones;
+
+  factory LifeTrackTemplate.fromJson(Map<String, dynamic> json) =>
+      LifeTrackTemplate(
+        templateId: json['template_id'] as String,
+        title: json['title'] as String,
+        description: json['description'] as String,
+        category: LifeTrackCategory.values.firstWhere(
+          (item) => item.name == json['category'],
+        ),
+        version: json['version'] as String,
+        milestones: ((json['milestones'] as List?) ?? const [])
+            .map(
+              (item) =>
+                  MilestoneTemplate.fromJson(item as Map<String, dynamic>),
+            )
+            .toList(growable: false),
+      );
+
+  Map<String, dynamic> toJson() => {
+    'template_id': templateId,
+    'title': title,
+    'description': description,
+    'category': category.name,
+    'version': version,
+    'milestones': milestones
+        .map((item) => item.toJson())
+        .toList(growable: false),
+  };
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is LifeTrackTemplate &&
+          runtimeType == other.runtimeType &&
+          templateId == other.templateId &&
+          title == other.title &&
+          description == other.description &&
+          category == other.category &&
+          version == other.version &&
+          _listEquals(milestones, other.milestones);
+
+  @override
+  int get hashCode => Object.hash(
+    templateId,
+    title,
+    description,
+    category,
+    version,
+    Object.hashAll(milestones),
+  );
+}
+
+@immutable
+class MilestoneTemplate {
+  const MilestoneTemplate({
+    required this.name,
+    required this.objective,
+    required this.tasks,
+  });
+
+  final String name;
+  final String objective;
+  final List<ActionItemTemplate> tasks;
+
+  factory MilestoneTemplate.fromJson(Map<String, dynamic> json) =>
+      MilestoneTemplate(
+        name: json['name'] as String,
+        objective: json['objective'] as String,
+        tasks: ((json['tasks'] as List?) ?? const [])
+            .map(
+              (item) =>
+                  ActionItemTemplate.fromJson(item as Map<String, dynamic>),
+            )
+            .toList(growable: false),
+      );
+
+  Map<String, dynamic> toJson() => {
+    'name': name,
+    'objective': objective,
+    'tasks': tasks.map((item) => item.toJson()).toList(growable: false),
+  };
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is MilestoneTemplate &&
+          runtimeType == other.runtimeType &&
+          name == other.name &&
+          objective == other.objective &&
+          _listEquals(tasks, other.tasks);
+
+  @override
+  int get hashCode => Object.hash(name, objective, Object.hashAll(tasks));
+}
+
+@immutable
+class ActionItemTemplate {
+  const ActionItemTemplate({
+    required this.summary,
+    this.description,
+    required this.requirements,
+  });
+
+  final String summary;
+  final String? description;
+  final List<InputRequirementTemplate> requirements;
+
+  factory ActionItemTemplate.fromJson(Map<String, dynamic> json) =>
+      ActionItemTemplate(
+        summary: json['summary'] as String,
+        description: json['description'] as String?,
+        requirements: ((json['requirements'] as List?) ?? const [])
+            .map(
+              (item) => InputRequirementTemplate.fromJson(
+                item as Map<String, dynamic>,
+              ),
+            )
+            .toList(growable: false),
+      );
+
+  Map<String, dynamic> toJson() => {
+    'summary': summary,
+    'description': description,
+    'requirements': requirements
+        .map((item) => item.toJson())
+        .toList(growable: false),
+  };
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is ActionItemTemplate &&
+          runtimeType == other.runtimeType &&
+          summary == other.summary &&
+          description == other.description &&
+          _listEquals(requirements, other.requirements);
+
+  @override
+  int get hashCode =>
+      Object.hash(summary, description, Object.hashAll(requirements));
+}
+
+@immutable
+class InputRequirementTemplate {
+  const InputRequirementTemplate({
+    required this.label,
+    required this.type,
+    required this.isRequired,
+    this.hint,
+  });
+
+  final String label;
+  final FieldType type;
+  final bool isRequired;
+  final String? hint;
+
+  factory InputRequirementTemplate.fromJson(Map<String, dynamic> json) =>
+      InputRequirementTemplate(
+        label: json['label'] as String,
+        type: FieldType.values.firstWhere((item) => item.name == json['type']),
+        isRequired: json['is_required'] as bool? ?? false,
+        hint: json['hint'] as String?,
+      );
+
+  Map<String, dynamic> toJson() => {
+    'label': label,
+    'type': type.name,
+    'is_required': isRequired,
+    'hint': hint,
+  };
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is InputRequirementTemplate &&
+          runtimeType == other.runtimeType &&
+          label == other.label &&
+          type == other.type &&
+          isRequired == other.isRequired &&
+          hint == other.hint;
+
+  @override
+  int get hashCode => Object.hash(label, type, isRequired, hint);
+}
+
+bool _listEquals<T>(List<T> left, List<T> right) {
+  if (left.length != right.length) return false;
+  for (var index = 0; index < left.length; index++) {
+    if (left[index] != right[index]) return false;
+  }
+  return true;
+}

--- a/packages/core_domain/test/entities/life_track_template_test.dart
+++ b/packages/core_domain/test/entities/life_track_template_test.dart
@@ -1,0 +1,78 @@
+import 'package:core_domain/core_domain.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  final template = LifeTrackTemplate(
+    templateId: 'real_estate_under_construction_v1',
+    title: 'Under-Construction Flat Purchase Checklist',
+    description:
+        '7 critical verification steps before buying an under-construction flat',
+    category: LifeTrackCategory.realEstate,
+    version: '1.0',
+    milestones: const [
+      MilestoneTemplate(
+        name: 'Phase 1: RERA & Legal Verification',
+        objective: 'Verify builder legitimacy and project approvals',
+        tasks: [
+          ActionItemTemplate(
+            summary: 'Check Builder\'s RERA Registration',
+            description: 'Look into the builder\'s track record.',
+            requirements: [
+              InputRequirementTemplate(
+                label: 'RERA Registration Number',
+                type: FieldType.text,
+                isRequired: true,
+                hint: 'Found on the RERA website',
+              ),
+            ],
+          ),
+        ],
+      ),
+    ],
+  );
+
+  test('round-trips template JSON', () {
+    final encoded = template.toJson();
+    final decoded = LifeTrackTemplate.fromJson(encoded);
+
+    expect(decoded, template);
+    expect(
+      decoded.milestones.single.tasks.single.requirements.single.type,
+      FieldType.text,
+    );
+  });
+
+  test('parses template schema keys used by bundled and LLM blueprints', () {
+    final decoded = LifeTrackTemplate.fromJson({
+      'template_id': 'car_purchase_v1',
+      'title': 'Car Purchase',
+      'description': 'Template',
+      'category': 'carPurchase',
+      'version': '1.0',
+      'milestones': [
+        {
+          'name': 'Documents',
+          'objective': 'Prepare first',
+          'tasks': [
+            {
+              'summary': 'Verify license',
+              'requirements': [
+                {
+                  'label': 'Driving License',
+                  'type': 'document',
+                  'is_required': true,
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(decoded.category, LifeTrackCategory.carPurchase);
+    expect(
+      decoded.milestones.single.tasks.single.requirements.single.type,
+      FieldType.document,
+    );
+  });
+}


### PR DESCRIPTION
# Summary

This PR introduces changes to the LifeTrack framework foundation.
Goal: add bundled offline template packs and a typed registry so common tracks can be created without network or LLM generation.

Core outcome:

* adds `LifeTrackTemplate` entities that match the intended blueprint JSON schema
* ships bundled real-estate, university, medical, insurance, and car-purchase templates with registry lookup and validation

# Changes

### Code

* Added:
  * `LifeTrackTemplate`, `MilestoneTemplate`, `ActionItemTemplate`, and `InputRequirementTemplate` in `core_domain`
  * `TemplateRegistry` in `core_data` for bundled asset loading, lookup, filtering, and validation
  * five bundled JSON templates for offline template-first track creation
  * unit tests for template entity parsing and registry behavior
* Updated:
  * `packages/core_domain/lib/core_domain.dart` export surface
  * `packages/core_data/lib/core_data.dart` export surface
  * `packages/core_data/pubspec.yaml` asset declarations

### Logic

* uses blueprint-compatible JSON keys such as `template_id`, `type`, and `is_required`
* validates required metadata plus milestone and task structure before accepting template payloads
* keeps registry reads synchronous after one async bundled-load step
* verifies all bundled templates parse cleanly and the primary real-estate template contains 4 milestones and 7 tasks

# API Changes (if any)

* None

# Database Changes (if any)

* None

# Observability / Logging

* None

# Performance Impact

* Latency: one-time local asset load during registry initialization
* Throughput: negligible
* Memory/CPU: negligible for five bundled templates

# Risks

* asset paths must stay aligned with package bundling rules
* future schema expansion will require coordinated updates across JSON assets and template parsing
* Rollback plan:
  * revert this PR before application-layer template consumers land

# Testing

* Unit tests:
  * added template entity JSON round-trip coverage
  * added bundled asset load, category filter, and validation error coverage
* Integration tests:
  * none
* Manual testing:
  * `flutter analyze` in `packages/core_domain`
  * `flutter test` in `packages/core_domain`
  * `flutter analyze` in `packages/core_data`
  * `flutter test` in `packages/core_data`

# Deployment Notes

* Config changes:
  * none
* Order of deployment:
  * safe to merge before LifeTrack application-layer consumers

# Related Commits

* `feat(life_track): add bundled track templates`

# Notes

* Closes #334
