### PR TITLE
Fix LiteRT artifact path resolution

### DIFF
--- a/app/test/core/services/litert_lm_service_test.dart
+++ b/app/test/core/services/litert_lm_service_test.dart
@@ -186,12 +186,23 @@ class _FakeModelDownloadService extends ModelDownloadService {
   final Map<String, String> downloadedPaths;
 
   @override
-  Future<String> getModelPath(String modelId) async {
+  Future<String> getModelPath(String modelId, {OfflineModelInfo? model}) async {
     return downloadedPaths[modelId] ?? '/missing/$modelId';
   }
 
   @override
-  Future<bool> isModelDownloaded(String modelId) async {
+  Future<bool> isModelDownloaded(
+    String modelId, {
+    OfflineModelInfo? model,
+  }) async {
     return downloadedPaths.containsKey(modelId);
+  }
+
+  @override
+  Future<String?> resolveExistingModelPath(
+    String modelId, {
+    OfflineModelInfo? model,
+  }) async {
+    return downloadedPaths[modelId];
   }
 }

--- a/packages/core_ai/lib/src/download/model_download_service.dart
+++ b/packages/core_ai/lib/src/download/model_download_service.dart
@@ -197,7 +197,10 @@ class ModelDownloadService {
     );
 
     try {
-      final filePath = await _storageManager.getModelPath(model.id);
+      final filePath = await _storageManager.getModelPath(
+        model.id,
+        model: model,
+      );
       await _methodChannel.invokeMethod('startDownload', {
         'modelId': model.id,
         'url': model.downloadUrl,
@@ -259,13 +262,24 @@ class ModelDownloadService {
   }
 
   /// Gets the path where a model would be stored.
-  Future<String> getModelPath(String modelId) async {
-    return _storageManager.getModelPath(modelId);
+  Future<String> getModelPath(String modelId, {OfflineModelInfo? model}) async {
+    return _storageManager.getModelPath(modelId, model: model);
+  }
+
+  Future<String?> resolveExistingModelPath(
+    String modelId, {
+    OfflineModelInfo? model,
+  }) async {
+    return _storageManager.findExistingModelPath(modelId, model: model);
   }
 
   /// Checks if a model is already downloaded.
-  Future<bool> isModelDownloaded(String modelId) async {
-    final path = await getModelPath(modelId);
+  Future<bool> isModelDownloaded(
+    String modelId, {
+    OfflineModelInfo? model,
+  }) async {
+    final path = await resolveExistingModelPath(modelId, model: model);
+    if (path == null) return false;
     final file = File(path);
     if (!await file.exists()) return false;
 
@@ -278,20 +292,21 @@ class ModelDownloadService {
   /// Returns true if deleted successfully, false if file doesn't exist.
   Future<bool> deleteModel(String modelId) async {
     await cancelDownload(modelId);
-    final filePath = await getModelPath(modelId);
-    final file = File(filePath);
-
     var deleted = false;
-    if (await file.exists()) {
-      await file.delete();
-      deleted = true;
-    }
+    for (final filePath in await _storageManager.getCandidateModelPaths(
+      modelId,
+    )) {
+      final file = File(filePath);
+      if (await file.exists()) {
+        await file.delete();
+        deleted = true;
+      }
 
-    // Also delete temp file if exists
-    final tempFile = File('$filePath.tmp');
-    if (await tempFile.exists()) {
-      await tempFile.delete();
-      deleted = true;
+      final tempFile = File('$filePath.tmp');
+      if (await tempFile.exists()) {
+        await tempFile.delete();
+        deleted = true;
+      }
     }
 
     return deleted;
@@ -304,7 +319,10 @@ class ModelDownloadService {
 
     int totalBytes = 0;
     await for (final entity in dir.list()) {
-      if (entity is File && entity.path.endsWith('.gguf')) {
+      if (entity is File &&
+          ModelStorageManager.supportedArtifactExtensions.any(
+            entity.path.endsWith,
+          )) {
         final stat = await entity.stat();
         totalBytes += stat.size;
       }

--- a/packages/core_ai/lib/src/litert/litert_lm_runtime_adapter.dart
+++ b/packages/core_ai/lib/src/litert/litert_lm_runtime_adapter.dart
@@ -361,18 +361,28 @@ class LiteRtLmRuntimeAdapter implements LocalInferenceRuntimeAdapter {
       return model;
     }
 
-    final modelPath = await downloadedModelPath(model.id);
+    final modelPath = await downloadedModelPath(model.id, model: model);
     if (modelPath == null) {
       return model;
     }
     return model.copyWith(filePath: modelPath);
   }
 
-  Future<String?> downloadedModelPath(String modelId) async {
+  Future<String?> downloadedModelPath(
+    String modelId, {
+    OfflineModelInfo? model,
+  }) async {
     if (kIsWeb) return null;
-    final isDownloaded = await _downloadService.isModelDownloaded(modelId);
+    final isDownloaded = await _downloadService.isModelDownloaded(
+      modelId,
+      model: model,
+    );
     if (!isDownloaded) return null;
-    return _downloadService.getModelPath(modelId);
+    final existingPath = await _downloadService.resolveExistingModelPath(
+      modelId,
+      model: model,
+    );
+    return existingPath ?? _downloadService.getModelPath(modelId, model: model);
   }
 
   Future<bool> _ensureInitializedForRequest({

--- a/packages/core_ai/lib/src/storage/model_storage_manager.dart
+++ b/packages/core_ai/lib/src/storage/model_storage_manager.dart
@@ -11,6 +11,14 @@ class ModelStorageManager {
   ModelStorageManager({MethodChannel? channel})
     : _channel = channel ?? const MethodChannel('com.airo.model_download');
 
+  static const supportedArtifactExtensions = <String>[
+    '.litertlm',
+    '.gguf',
+    '.bin',
+    '.task',
+    '.onnx',
+  ];
+
   final MethodChannel _channel;
 
   /// Gets the directory where models are stored.
@@ -24,9 +32,40 @@ class ModelStorageManager {
   }
 
   /// Gets the expected destination path for a given model.
-  Future<String> getModelPath(String modelId) async {
+  Future<String> getModelPath(String modelId, {OfflineModelInfo? model}) async {
     final dir = await getModelsDirectory();
-    return path.join(dir.path, '$modelId.gguf');
+    return path.join(dir.path, '$modelId${_artifactExtensionFor(model)}');
+  }
+
+  /// Returns candidate file paths for the model, preferring the expected extension first.
+  Future<List<String>> getCandidateModelPaths(
+    String modelId, {
+    OfflineModelInfo? model,
+  }) async {
+    final dir = await getModelsDirectory();
+    final expectedExtension = _artifactExtensionFor(model);
+    return [
+      path.join(dir.path, '$modelId$expectedExtension'),
+      for (final extension in supportedArtifactExtensions)
+        if (extension != expectedExtension)
+          path.join(dir.path, '$modelId$extension'),
+    ];
+  }
+
+  /// Finds an existing on-disk model artifact, including legacy incorrectly named files.
+  Future<String?> findExistingModelPath(
+    String modelId, {
+    OfflineModelInfo? model,
+  }) async {
+    for (final candidate in await getCandidateModelPaths(
+      modelId,
+      model: model,
+    )) {
+      if (await File(candidate).exists()) {
+        return candidate;
+      }
+    }
+    return null;
   }
 
   /// Calculates the SHA-256 hash of a file in a streaming fashion.
@@ -41,7 +80,10 @@ class ModelStorageManager {
 
   /// Verifies a model file's integrity using its expected SHA-256 hash.
   Future<bool> verifyModelIntegrity(OfflineModelInfo model) async {
-    final filePath = model.filePath ?? await getModelPath(model.id);
+    final filePath =
+        model.filePath ??
+        await findExistingModelPath(model.id, model: model) ??
+        await getModelPath(model.id, model: model);
     final file = File(filePath);
     if (!await file.exists()) {
       return false;
@@ -80,7 +122,7 @@ class ModelStorageManager {
   }
 
   /// Scans the models directory and deletes any files that are not registered in [catalogModels].
-  /// This detects and cleans up old temporary `.tmp` files and orphaned `.gguf` files.
+  /// This detects and cleans up old temporary files and orphaned model artifacts.
   Future<List<String>> cleanupOrphanedFiles(
     List<OfflineModelInfo> catalogModels,
   ) async {
@@ -94,12 +136,21 @@ class ModelStorageManager {
       if (entity is File) {
         final fileName = path.basename(entity.path);
 
-        // Match both final files (<id>.gguf) and temp files (<id>.gguf.tmp)
+        // Match both final files (<id>.<ext>) and temp files (<id>.<ext>.tmp)
         String? modelId;
-        if (fileName.endsWith('.gguf')) {
-          modelId = fileName.substring(0, fileName.length - 5);
-        } else if (fileName.endsWith('.gguf.tmp')) {
-          modelId = fileName.substring(0, fileName.length - 9);
+        for (final extension in supportedArtifactExtensions) {
+          if (fileName.endsWith(extension)) {
+            modelId = fileName.substring(0, fileName.length - extension.length);
+            break;
+          }
+          final tempSuffix = '$extension.tmp';
+          if (fileName.endsWith(tempSuffix)) {
+            modelId = fileName.substring(
+              0,
+              fileName.length - tempSuffix.length,
+            );
+            break;
+          }
         }
 
         if (modelId != null) {
@@ -111,5 +162,25 @@ class ModelStorageManager {
       }
     }
     return deletedPaths;
+  }
+
+  String _artifactExtensionFor(OfflineModelInfo? model) {
+    final explicitPath = model?.filePath?.trim().toLowerCase();
+    if (explicitPath != null && explicitPath.isNotEmpty) {
+      for (final extension in supportedArtifactExtensions) {
+        if (explicitPath.endsWith(extension)) return extension;
+      }
+    }
+
+    final downloadPath = Uri.tryParse(
+      model?.downloadUrl ?? '',
+    )?.path.toLowerCase();
+    if (downloadPath != null && downloadPath.isNotEmpty) {
+      for (final extension in supportedArtifactExtensions) {
+        if (downloadPath.endsWith(extension)) return extension;
+      }
+    }
+
+    return '.gguf';
   }
 }

--- a/packages/core_ai/test/download/model_download_service_test.dart
+++ b/packages/core_ai/test/download/model_download_service_test.dart
@@ -76,10 +76,10 @@ void main() {
       () => mockStorageManager.hasEnoughDiskSpace(any()),
     ).thenAnswer((_) async => true);
     when(
-      () => mockStorageManager.getModelPath(modelA.id),
+      () => mockStorageManager.getModelPath(modelA.id, model: modelA),
     ).thenAnswer((_) async => '/mock/path/model_a.gguf');
     when(
-      () => mockStorageManager.getModelPath(modelB.id),
+      () => mockStorageManager.getModelPath(modelB.id, model: modelB),
     ).thenAnswer((_) async => '/mock/path/model_b.gguf');
 
     downloadService = ModelDownloadService(
@@ -190,4 +190,33 @@ void main() {
     expect(progress.error, contains('Insufficient disk space'));
     expect(methodCalls.isEmpty, isTrue);
   });
+
+  test(
+    'downloadModel preserves LiteRT destination extension from model metadata',
+    () async {
+      final litertModel = OfflineModelInfo(
+        id: 'gemma_litert',
+        name: 'Gemma LiteRT',
+        family: ModelFamily.gemma,
+        fileSizeBytes: 1000,
+        downloadUrl: 'https://example.com/gemma.litertlm',
+      );
+
+      when(
+        () => mockStorageManager.verifyModelIntegrity(litertModel),
+      ).thenAnswer((_) async => false);
+      when(
+        () =>
+            mockStorageManager.getModelPath(litertModel.id, model: litertModel),
+      ).thenAnswer((_) async => '/mock/path/gemma_litert.litertlm');
+
+      downloadService.downloadModel(litertModel);
+      await Future<void>.delayed(Duration.zero);
+
+      expect(
+        methodCalls.last.arguments['filePath'],
+        '/mock/path/gemma_litert.litertlm',
+      );
+    },
+  );
 }

--- a/packages/core_ai/test/litert/litert_lm_runtime_adapter_test.dart
+++ b/packages/core_ai/test/litert/litert_lm_runtime_adapter_test.dart
@@ -77,6 +77,35 @@ void main() {
       );
       expect(activeModelService.activeRuntime?.runtimeId, 'litert-lm');
     });
+
+    test(
+      'hydrates a legacy gguf download path for LiteRT catalog models',
+      () async {
+        final adapter = LiteRtLmRuntimeAdapter(
+          client: _FakeLiteRtLmClient(hasActiveModel: true),
+          activeModelService: activeModelService,
+          downloadService: _FakeModelDownloadService(
+            downloadedPaths: {
+              'gemma-4-e2b-it-litertlm': '/models/gemma-4-e2b-it-litertlm.gguf',
+            },
+          ),
+        );
+
+        final hydrated = await adapter.hydrateDownloadedModel(
+          const OfflineModelInfo(
+            id: 'gemma-4-e2b-it-litertlm',
+            name: 'Gemma 4 E2B',
+            family: ModelFamily.gemma,
+            fileSizeBytes: 1024,
+            downloadUrl: 'https://example.com/gemma-4-E2B-it.litertlm',
+            provider: AIProvider.gemma,
+            tags: ['litert-lm'],
+          ),
+        );
+
+        expect(hydrated.filePath, '/models/gemma-4-e2b-it-litertlm.gguf');
+      },
+    );
   });
 }
 
@@ -111,5 +140,32 @@ class _FakeLiteRtLmClient implements LiteRtLmClient {
     String? huggingFaceToken,
   }) async {
     hasActiveModel = true;
+  }
+}
+
+class _FakeModelDownloadService extends ModelDownloadService {
+  _FakeModelDownloadService({required this.downloadedPaths});
+
+  final Map<String, String> downloadedPaths;
+
+  @override
+  Future<bool> isModelDownloaded(
+    String modelId, {
+    OfflineModelInfo? model,
+  }) async {
+    return downloadedPaths.containsKey(modelId);
+  }
+
+  @override
+  Future<String?> resolveExistingModelPath(
+    String modelId, {
+    OfflineModelInfo? model,
+  }) async {
+    return downloadedPaths[modelId];
+  }
+
+  @override
+  Future<String> getModelPath(String modelId, {OfflineModelInfo? model}) async {
+    return downloadedPaths[modelId] ?? '/missing/$modelId';
   }
 }

--- a/packages/core_ai/test/storage/model_storage_manager_test.dart
+++ b/packages/core_ai/test/storage/model_storage_manager_test.dart
@@ -83,6 +83,50 @@ void main() {
     expect(isValid, isTrue);
   });
 
+  test(
+    'getModelPath preserves LiteRT artifact extension from download URL',
+    () async {
+      final modelPath = await storageManager.getModelPath(
+        'gemma-4-e2b-it-litertlm',
+        model: const OfflineModelInfo(
+          id: 'gemma-4-e2b-it-litertlm',
+          name: 'Gemma 4 E2B',
+          family: ModelFamily.gemma,
+          fileSizeBytes: 1024,
+          downloadUrl: 'https://example.com/gemma-4-E2B-it.litertlm',
+        ),
+      );
+
+      expect(modelPath, endsWith('gemma-4-e2b-it-litertlm.litertlm'));
+    },
+  );
+
+  test(
+    'findExistingModelPath resolves legacy gguf path for LiteRT models',
+    () async {
+      final modelsDir = Directory(path.join(tempDir.path, 'models'));
+      await modelsDir.create(recursive: true);
+
+      final legacyFile = File(
+        path.join(modelsDir.path, 'gemma-4-e2b-it-litertlm.gguf'),
+      );
+      await legacyFile.writeAsString('legacy content');
+
+      final resolvedPath = await storageManager.findExistingModelPath(
+        'gemma-4-e2b-it-litertlm',
+        model: const OfflineModelInfo(
+          id: 'gemma-4-e2b-it-litertlm',
+          name: 'Gemma 4 E2B',
+          family: ModelFamily.gemma,
+          fileSizeBytes: 14,
+          downloadUrl: 'https://example.com/gemma-4-E2B-it.litertlm',
+        ),
+      );
+
+      expect(resolvedPath, legacyFile.path);
+    },
+  );
+
   test('verifyModelIntegrity fails invalid file', () async {
     final modelsDir = Directory(path.join(tempDir.path, 'models'));
     await modelsDir.create(recursive: true);
@@ -111,36 +155,41 @@ void main() {
     );
   });
 
-  test('cleanupOrphanedFiles deletes unregistered files', () async {
-    final modelsDir = Directory(path.join(tempDir.path, 'models'));
-    await modelsDir.create(recursive: true);
+  test(
+    'cleanupOrphanedFiles deletes unregistered files across extensions',
+    () async {
+      final modelsDir = Directory(path.join(tempDir.path, 'models'));
+      await modelsDir.create(recursive: true);
 
-    final registeredFile = File(path.join(modelsDir.path, 'registered.gguf'));
-    await registeredFile.writeAsString('registered content');
+      final registeredFile = File(path.join(modelsDir.path, 'registered.gguf'));
+      await registeredFile.writeAsString('registered content');
 
-    final orphanedFile = File(path.join(modelsDir.path, 'orphaned.gguf'));
-    await orphanedFile.writeAsString('orphaned content');
+      final orphanedFile = File(path.join(modelsDir.path, 'orphaned.litertlm'));
+      await orphanedFile.writeAsString('orphaned content');
 
-    final orphanedTmpFile = File(path.join(modelsDir.path, 'another.gguf.tmp'));
-    await orphanedTmpFile.writeAsString('temp content');
+      final orphanedTmpFile = File(
+        path.join(modelsDir.path, 'another.task.tmp'),
+      );
+      await orphanedTmpFile.writeAsString('temp content');
 
-    final catalog = [
-      OfflineModelInfo(
-        id: 'registered',
-        name: 'Registered',
-        family: ModelFamily.gemma,
-        fileSizeBytes: 10,
-      ),
-    ];
+      final catalog = [
+        OfflineModelInfo(
+          id: 'registered',
+          name: 'Registered',
+          family: ModelFamily.gemma,
+          fileSizeBytes: 10,
+        ),
+      ];
 
-    final deleted = await storageManager.cleanupOrphanedFiles(catalog);
+      final deleted = await storageManager.cleanupOrphanedFiles(catalog);
 
-    expect(deleted, contains(orphanedFile.path));
-    expect(deleted, contains(orphanedTmpFile.path));
-    expect(deleted, isNot(contains(registeredFile.path)));
+      expect(deleted, contains(orphanedFile.path));
+      expect(deleted, contains(orphanedTmpFile.path));
+      expect(deleted, isNot(contains(registeredFile.path)));
 
-    expect(await registeredFile.exists(), isTrue);
-    expect(await orphanedFile.exists(), isFalse);
-    expect(await orphanedTmpFile.exists(), isFalse);
-  });
+      expect(await registeredFile.exists(), isTrue);
+      expect(await orphanedFile.exists(), isFalse);
+      expect(await orphanedTmpFile.exists(), isFalse);
+    },
+  );
 }


### PR DESCRIPTION
# Summary

This PR introduces changes to the local model download and LiteRT runtime path contract.
Goal: preserve the real artifact extension for LiteRT packages and keep legacy incorrectly-named downloads usable during warmup.

Core outcome:

* LiteRT catalog models now download to `.litertlm` destinations instead of synthesized `.gguf` paths
* existing legacy `.gguf` downloads for LiteRT models are still discovered and hydrated for runtime warmup

# Changes

### Code

* Updated:
  * `ModelStorageManager` to derive artifact extensions from model metadata and search candidate paths
  * `ModelDownloadService` to pass model metadata into path resolution and delete/count multiple artifact types
  * `LiteRtLmRuntimeAdapter` to hydrate downloaded paths via legacy-aware lookup before warmup
* Added tests for:
  * LiteRT destination path preservation
  * legacy `.gguf` discovery for LiteRT models
  * download service passing `.litertlm` destinations to native download start

### Logic

* preserves the artifact extension from `downloadUrl` / known model path metadata
* falls back across `.litertlm`, `.gguf`, `.bin`, `.task`, and `.onnx` when resolving existing downloads
* keeps previously-downloaded LiteRT models usable without forcing a redownload

# API Changes (if any)

* `ModelDownloadService.getModelPath` and `isModelDownloaded` now accept optional model metadata to resolve the correct artifact extension
* `ModelDownloadService.resolveExistingModelPath` added for legacy-aware path discovery

# Database Changes (if any)

* None

# Observability / Logging

* None

# Performance Impact

* Latency: negligible extra local file existence checks during path hydration
* Throughput: unchanged for normal downloads
* Memory/CPU: negligible

# Risks

* future artifact types must be added to the shared supported-extension list
* deletion and cleanup now operate across multiple known artifact types, so incorrect extension additions would broaden file matching
* Rollback plan:
  * revert this PR to return to `.gguf`-only path behavior

# Testing

* Unit tests:
  * `flutter analyze` in `packages/core_ai`
  * `flutter test` in `packages/core_ai`
  * `flutter test --no-pub test/core/services/litert_lm_service_test.dart` in `app`
  * `flutter test --no-pub test/features/agent_chat/data/services/assistant_runtime_service_test.dart` in `app`
* Integration tests:
  * none
* Manual testing:
  * none

# Deployment Notes

* Config changes:
  * none
* Order of deployment:
  * safe to merge directly

# Related Commits

* `fix(core_ai): preserve LiteRT artifact paths`

# Notes

* Closes #492
