### PR TITLE
Fix runtime fallback when selected chat model is unavailable

### DIFF
--- a/app/lib/features/agent_chat/data/services/assistant_runtime_service.dart
+++ b/app/lib/features/agent_chat/data/services/assistant_runtime_service.dart
@@ -142,6 +142,22 @@ class AssistantRuntimeUnavailableException implements Exception {
   String toString() => message;
 }
 
+class AssistantRuntimeFallbackDecision {
+  const AssistantRuntimeFallbackDecision({
+    required this.failedRuntimeId,
+    required this.failedRuntimeName,
+    required this.fallbackRuntimeId,
+    required this.fallbackRuntimeName,
+    required this.reason,
+  });
+
+  final String failedRuntimeId;
+  final String failedRuntimeName;
+  final String fallbackRuntimeId;
+  final String fallbackRuntimeName;
+  final String reason;
+}
+
 class AssistantRuntimeService {
   AssistantRuntimeService({
     GeminiNanoService? geminiNano,
@@ -675,5 +691,40 @@ class AssistantRuntimeService {
     } catch (_) {
       return null;
     }
+  }
+
+  Future<AssistantRuntimeFallbackDecision?> resolveFallback({
+    required String failedRuntimeId,
+    AssistantTask task = AssistantTask.chat,
+    Set<String> excludedRuntimeIds = const {},
+    String? reason,
+  }) async {
+    final library =
+        await (_loadAssistantModelLibraryOverride?.call() ??
+            AssistantModelLibraryState.load(task: task));
+
+    final failedCandidate = library.candidateById(failedRuntimeId);
+    final orderedCandidates = <AssistantModelCandidate>[
+      library.recommendedFor(task),
+      ...library.candidates,
+    ];
+    final seen = <String>{...excludedRuntimeIds, failedRuntimeId};
+
+    for (final candidate in orderedCandidates) {
+      if (!seen.add(candidate.id) || !candidate.available) {
+        continue;
+      }
+      return AssistantRuntimeFallbackDecision(
+        failedRuntimeId: failedRuntimeId,
+        failedRuntimeName: failedCandidate?.name ?? failedRuntimeId,
+        fallbackRuntimeId: candidate.id,
+        fallbackRuntimeName: candidate.name,
+        reason:
+            reason ??
+            'the selected runtime is unavailable on this device right now',
+      );
+    }
+
+    return null;
   }
 }

--- a/app/lib/features/agent_chat/presentation/screens/chat_screen.dart
+++ b/app/lib/features/agent_chat/presentation/screens/chat_screen.dart
@@ -20,11 +20,13 @@ import '../../../agent_chat/domain/services/agent_skill_orchestrator.dart';
 import '../../../agent_chat/domain/services/agent_skill_registry.dart';
 import '../../../agent_chat/domain/services/intent_parser.dart';
 import '../../../agent_chat/domain/services/tool_registry.dart';
+import '../../../agent_chat/presentation/widgets/fallback_notification.dart';
 import '../../../agent_chat/presentation/widgets/manage_skills_sheet.dart';
 import '../../../agent_chat/presentation/widgets/skill_action_trace_card.dart';
 import '../../../coins/application/providers/dashboard_providers.dart';
 import '../../../coins/application/providers/expense_providers.dart';
 import '../../../coins/application/services/finance_chat_ingestion_service.dart';
+import '../../../settings/application/ai_preferences_settings.dart';
 import '../../../../core/services/gemini_nano_service.dart';
 import '../../../../core/services/litert_lm_service.dart';
 import '../../../../core/services/local_runtime_preloader_service.dart';
@@ -805,11 +807,13 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
 
   Future<ChatResponseMetadata?> _generateSelectedModelResponse(
     String selectedModelId,
-    String message,
-  ) async {
+    String message, {
+    Set<String> attemptedRuntimeIds = const {},
+  }) async {
     final stopwatch = Stopwatch()..start();
     int? timeToFirstTokenMs;
     String latestChunk = '';
+    final attempted = {...attemptedRuntimeIds, selectedModelId};
     try {
       await for (final chunk in _assistantRuntime.generateTextStream(
         selectedModelId: selectedModelId,
@@ -832,6 +836,27 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
       );
     } on AssistantRuntimeUnavailableException catch (e) {
       stopwatch.stop();
+      final autoFallback = ref.read(aiPreferencesSettingsProvider).autoFallback;
+      if (autoFallback) {
+        final fallback = await _assistantRuntime.resolveFallback(
+          failedRuntimeId: e.runtimeId ?? selectedModelId,
+          excludedRuntimeIds: attempted,
+          reason: e.message,
+        );
+        if (fallback != null) {
+          await ref
+              .read(selectedAssistantModelIdProvider.notifier)
+              .select(fallback.fallbackRuntimeId);
+          if (mounted) {
+            showAssistantFallbackNotification(context, fallback);
+          }
+          return _generateSelectedModelResponse(
+            fallback.fallbackRuntimeId,
+            message,
+            attemptedRuntimeIds: attempted,
+          );
+        }
+      }
       _replaceStreamingMessage(e.message);
       return null;
     }

--- a/app/lib/features/agent_chat/presentation/screens/profile_screen.dart
+++ b/app/lib/features/agent_chat/presentation/screens/profile_screen.dart
@@ -679,6 +679,8 @@ String _routingStrategyLabel(AIRoutingStrategy strategy) {
     AIRoutingStrategy.cloudOnly => 'Cloud only',
     AIRoutingStrategy.onDevicePreferred => 'On-device preferred',
     AIRoutingStrategy.cloudPreferred => 'Cloud preferred',
+    AIRoutingStrategy.offlinePreferred => 'Offline preferred',
+    AIRoutingStrategy.specificModel => 'Specific model',
     AIRoutingStrategy.userChoice => 'User choice',
   };
 }
@@ -689,6 +691,8 @@ String _fallbackOrderLabel(AIRoutingStrategy strategy) {
     AIRoutingStrategy.cloudOnly => 'Cloud only',
     AIRoutingStrategy.onDevicePreferred => 'On-device first, then cloud',
     AIRoutingStrategy.cloudPreferred => 'Cloud first, then on-device',
+    AIRoutingStrategy.offlinePreferred => 'Offline runtimes first, then cloud',
+    AIRoutingStrategy.specificModel => 'Specific runtime first, then backup',
     AIRoutingStrategy.userChoice => 'User-selected runtime, then fallback',
   };
 }

--- a/app/lib/features/agent_chat/presentation/widgets/fallback_notification.dart
+++ b/app/lib/features/agent_chat/presentation/widgets/fallback_notification.dart
@@ -1,0 +1,17 @@
+import 'package:flutter/material.dart';
+
+import '../../data/services/assistant_runtime_service.dart';
+
+void showAssistantFallbackNotification(
+  BuildContext context,
+  AssistantRuntimeFallbackDecision fallback,
+) {
+  ScaffoldMessenger.of(context).showSnackBar(
+    SnackBar(
+      content: Text(
+        'Switched from ${fallback.failedRuntimeName} to ${fallback.fallbackRuntimeName}: ${fallback.reason}',
+      ),
+      behavior: SnackBarBehavior.floating,
+    ),
+  );
+}

--- a/app/test/features/agent_chat/data/services/assistant_runtime_service_test.dart
+++ b/app/test/features/agent_chat/data/services/assistant_runtime_service_test.dart
@@ -159,6 +159,58 @@ void main() {
     });
 
     test(
+      'resolves a cloud fallback for an unavailable local runtime',
+      () async {
+        const nano = AssistantModelCandidate(
+          id: geminiNanoAssistantModelId,
+          name: 'Gemini Nano',
+          runtime: 'AICore on-device',
+          description: 'Local runtime',
+          bestFor: [AssistantTask.chat],
+          tags: ['Local'],
+          privacyLabel: 'Prompt stays on device',
+          sizeLabel: 'System managed',
+          available: false,
+          actionLabel: 'Needs setup',
+          local: true,
+        );
+        const cloud = AssistantModelCandidate(
+          id: geminiCloudAssistantModelId,
+          name: 'Gemini Cloud',
+          runtime: 'Cloud',
+          description: 'Cloud runtime',
+          bestFor: [AssistantTask.chat],
+          tags: ['Cloud'],
+          privacyLabel: 'Sends prompt to API',
+          sizeLabel: 'No local download',
+          available: true,
+          actionLabel: 'Start',
+          local: false,
+        );
+        final service = AssistantRuntimeService(
+          loadAssistantModelLibrary: () async =>
+              const AssistantModelLibraryState(
+                task: AssistantTask.chat,
+                deviceLabel: 'Pixel 9',
+                platformLabel: 'ANDROID',
+                candidates: [nano, cloud],
+                recommended: nano,
+                defaultPackages: {},
+              ),
+        );
+
+        final fallback = await service.resolveFallback(
+          failedRuntimeId: geminiNanoAssistantModelId,
+          reason: 'Gemini Nano is not available on this device.',
+        );
+
+        expect(fallback, isNotNull);
+        expect(fallback?.fallbackRuntimeId, geminiCloudAssistantModelId);
+        expect(fallback?.failedRuntimeName, 'Gemini Nano');
+      },
+    );
+
+    test(
       'builds a blocked preparation result for unsupported Gemini Nano',
       () async {
         final service = AssistantRuntimeService(

--- a/packages/core_ai/lib/core_ai.dart
+++ b/packages/core_ai/lib/core_ai.dart
@@ -23,6 +23,8 @@ export 'src/llm/gemini_nano_client.dart';
 export 'src/llm/gemini_api_client.dart';
 export 'src/llm/llm_router_impl.dart';
 export 'src/router/ai_router.dart';
+export 'src/router/fallback_chain.dart';
+export 'src/router/model_health_checker.dart';
 
 // GGUF Model Support
 export 'src/llm/gguf_model_config.dart';

--- a/packages/core_ai/lib/src/router/ai_router.dart
+++ b/packages/core_ai/lib/src/router/ai_router.dart
@@ -2,6 +2,8 @@ import 'package:core_domain/core_domain.dart';
 
 import '../client/llm_client.dart';
 import '../provider/ai_provider.dart';
+import 'fallback_chain.dart';
+import 'model_health_checker.dart';
 
 /// Strategy for selecting which AI provider to use.
 enum AIRoutingStrategy {
@@ -16,6 +18,12 @@ enum AIRoutingStrategy {
 
   /// Prefer cloud, fallback to on-device if unavailable.
   cloudPreferred,
+
+  /// Prefer an offline-capable runtime, fallback to cloud if needed.
+  offlinePreferred,
+
+  /// Prefer a specific configured provider, then fallback to the next best.
+  specificModel,
 
   /// Let user choose.
   userChoice,
@@ -49,17 +57,27 @@ class AIRouterConfig {
   /// Whether to automatically fallback on errors.
   final bool autoFallback;
 
+  /// Specific provider to prefer when using [AIRoutingStrategy.specificModel].
+  final AIProvider? specificModel;
+
+  /// Health checker used before provider selection and fallback.
+  final ModelHealthChecker healthChecker;
+
   const AIRouterConfig({
     this.defaultStrategy = AIRoutingStrategy.onDevicePreferred,
     this.userPreference,
     this.onDeviceMaxPromptLength = 1024,
     this.autoFallback = true,
+    this.specificModel,
+    this.healthChecker = const ModelHealthChecker(),
   });
 
   const AIRouterConfig.localOnly({this.onDeviceMaxPromptLength = 1024})
     : defaultStrategy = AIRoutingStrategy.onDeviceOnly,
       userPreference = null,
-      autoFallback = false;
+      autoFallback = false,
+      specificModel = null,
+      healthChecker = const ModelHealthChecker();
 
   bool get isLocalOnly => defaultStrategy == AIRoutingStrategy.onDeviceOnly;
 }
@@ -85,57 +103,108 @@ class AIRouter implements LLMClient {
     return UnknownError('No AI provider available');
   }
 
-  /// Get the appropriate client based on strategy and availability.
-  Future<LLMClient?> _selectClient({String? prompt}) async {
-    final strategy = config.defaultStrategy;
-
-    // Check if prompt is too long for on-device
+  Future<AIProvider?> _selectProvider({String? prompt}) async {
     final promptTooLong =
         prompt != null && prompt.length > config.onDeviceMaxPromptLength;
+    final preferredOrder = switch (config.defaultStrategy) {
+      AIRoutingStrategy.onDeviceOnly => const [AIProvider.nano],
+      AIRoutingStrategy.cloudOnly => const [AIProvider.cloud],
+      AIRoutingStrategy.onDevicePreferred => [
+        if (!promptTooLong) AIProvider.nano,
+        AIProvider.cloud,
+        AIProvider.nano,
+      ],
+      AIRoutingStrategy.cloudPreferred => const [
+        AIProvider.cloud,
+        AIProvider.nano,
+      ],
+      AIRoutingStrategy.offlinePreferred => const [
+        AIProvider.nano,
+        AIProvider.cloud,
+      ],
+      AIRoutingStrategy.specificModel => [
+        if (config.specificModel != null) config.specificModel!,
+        if (config.specificModel != AIProvider.nano && !promptTooLong)
+          AIProvider.nano,
+        if (config.specificModel != AIProvider.cloud) AIProvider.cloud,
+      ],
+      AIRoutingStrategy.userChoice => [
+        if (config.userPreference != null) config.userPreference!,
+        if (!promptTooLong) AIProvider.nano,
+        AIProvider.cloud,
+      ],
+    };
 
-    switch (strategy) {
-      case AIRoutingStrategy.onDeviceOnly:
-        if (onDeviceClient != null && await onDeviceClient!.isAvailable()) {
-          return onDeviceClient;
-        }
-        return null;
-
-      case AIRoutingStrategy.cloudOnly:
-        if (cloudClient != null && await cloudClient!.isAvailable()) {
-          return cloudClient;
-        }
-        return null;
-
-      case AIRoutingStrategy.onDevicePreferred:
-        if (!promptTooLong &&
-            onDeviceClient != null &&
-            await onDeviceClient!.isAvailable()) {
-          return onDeviceClient;
-        }
-        if (cloudClient != null && await cloudClient!.isAvailable()) {
-          return cloudClient;
-        }
-        return onDeviceClient;
-
-      case AIRoutingStrategy.cloudPreferred:
-        if (cloudClient != null && await cloudClient!.isAvailable()) {
-          return cloudClient;
-        }
-        if (onDeviceClient != null && await onDeviceClient!.isAvailable()) {
-          return onDeviceClient;
-        }
-        return cloudClient;
-
-      case AIRoutingStrategy.userChoice:
-        final preferred = config.userPreference;
-        if (preferred == AIProvider.nano) {
-          return onDeviceClient ?? cloudClient;
-        } else if (preferred == AIProvider.cloud) {
-          return cloudClient ?? onDeviceClient;
-        }
-        // Default to on-device preferred
-        return onDeviceClient ?? cloudClient;
+    final fallbackChain = FallbackChain(preferredOrder);
+    for (final provider in fallbackChain.chain) {
+      final health = await config.healthChecker.check(
+        provider,
+        _clientForProvider(provider),
+      );
+      if (health.isHealthy) {
+        return provider;
+      }
     }
+    return null;
+  }
+
+  LLMClient? _clientForProvider(AIProvider? provider) {
+    if (provider == null) {
+      return null;
+    }
+    if (provider == AIProvider.cloud) {
+      return cloudClient;
+    }
+    if (provider.isOnDevice) {
+      return onDeviceClient;
+    }
+    return null;
+  }
+
+  FallbackChain _fallbackChainFor(AIProvider primary, {String? prompt}) {
+    final promptTooLong =
+        prompt != null && prompt.length > config.onDeviceMaxPromptLength;
+    return FallbackChain([
+      primary,
+      if (primary != AIProvider.nano && !promptTooLong) AIProvider.nano,
+      if (primary != AIProvider.cloud) AIProvider.cloud,
+    ]);
+  }
+
+  Future<Result<T>> _executeWithFallback<T>(
+    String prompt,
+    Future<Result<T>> Function(LLMClient client) request,
+  ) async {
+    final primaryProvider = await _selectProvider(prompt: prompt);
+    final primaryClient = _clientForProvider(primaryProvider);
+    if (primaryProvider == null || primaryClient == null) {
+      return Err(_unavailableError(), StackTrace.current);
+    }
+
+    final result = await request(primaryClient);
+    if (!result.isErr || !config.autoFallback || config.isLocalOnly) {
+      return result;
+    }
+
+    for (final provider in _fallbackChainFor(
+      primaryProvider,
+      prompt: prompt,
+    ).alternativesFor(primaryProvider)) {
+      final client = _clientForProvider(provider);
+      final health = await config.healthChecker.check(provider, client);
+      if (!health.isHealthy || client == null) {
+        continue;
+      }
+      return request(client);
+    }
+
+    return result;
+  }
+
+  /// Get the appropriate client based on strategy and availability.
+  Future<LLMClient?> _selectClient({String? prompt}) async {
+    final provider = await _selectProvider(prompt: prompt);
+    return _clientForProvider(provider);
   }
 
   @override
@@ -155,7 +224,6 @@ class AIRouter implements LLMClient {
       results.add(await cloudClient!.initialize());
     }
 
-    // Return success if at least one initialized
     if (results.any((r) => r.isOk)) {
       return Ok(null);
     }
@@ -167,22 +235,10 @@ class AIRouter implements LLMClient {
     String prompt, {
     GenerationConfig? config,
   }) async {
-    final client = await _selectClient(prompt: prompt);
-    if (client == null) {
-      return Err(_unavailableError(), StackTrace.current);
-    }
-
-    final result = await client.generateText(prompt, config: config);
-
-    // Try fallback on error unless the request is explicitly local-only.
-    if (result.isErr && this.config.autoFallback && !this.config.isLocalOnly) {
-      final fallback = client == onDeviceClient ? cloudClient : onDeviceClient;
-      if (fallback != null && await fallback.isAvailable()) {
-        return fallback.generateText(prompt, config: config);
-      }
-    }
-
-    return result;
+    return _executeWithFallback(
+      prompt,
+      (client) => client.generateText(prompt, config: config),
+    );
   }
 
   @override
@@ -205,11 +261,10 @@ class AIRouter implements LLMClient {
     GenerationConfig? config,
   }) async {
     final prompt = messages.map((m) => m.content).join(' ');
-    final client = await _selectClient(prompt: prompt);
-    if (client == null) {
-      return Err(_unavailableError(), StackTrace.current);
-    }
-    return client.chat(messages, config: config);
+    return _executeWithFallback(
+      prompt,
+      (client) => client.chat(messages, config: config),
+    );
   }
 
   @override
@@ -232,11 +287,10 @@ class AIRouter implements LLMClient {
     List<String> categories, {
     GenerationConfig? config,
   }) async {
-    final client = await _selectClient(prompt: text);
-    if (client == null) {
-      return Err(_unavailableError(), StackTrace.current);
-    }
-    return client.classify(text, categories, config: config);
+    return _executeWithFallback(
+      text,
+      (client) => client.classify(text, categories, config: config),
+    );
   }
 
   @override
@@ -245,11 +299,10 @@ class AIRouter implements LLMClient {
     int? maxLength,
     GenerationConfig? config,
   }) async {
-    final client = await _selectClient(prompt: text);
-    if (client == null) {
-      return Err(_unavailableError(), StackTrace.current);
-    }
-    return client.summarize(text, maxLength: maxLength, config: config);
+    return _executeWithFallback(
+      text,
+      (client) => client.summarize(text, maxLength: maxLength, config: config),
+    );
   }
 
   @override

--- a/packages/core_ai/lib/src/router/fallback_chain.dart
+++ b/packages/core_ai/lib/src/router/fallback_chain.dart
@@ -1,0 +1,26 @@
+import '../provider/ai_provider.dart';
+
+/// Ordered fallback providers for a routing attempt.
+class FallbackChain {
+  FallbackChain(List<AIProvider> providers) : chain = _dedupe(providers);
+
+  final List<AIProvider> chain;
+
+  List<AIProvider> alternativesFor(AIProvider current) {
+    return [
+      for (final provider in chain)
+        if (provider != current) provider,
+    ];
+  }
+
+  static List<AIProvider> _dedupe(List<AIProvider> providers) {
+    final seen = <AIProvider>{};
+    final ordered = <AIProvider>[];
+    for (final provider in providers) {
+      if (seen.add(provider)) {
+        ordered.add(provider);
+      }
+    }
+    return ordered;
+  }
+}

--- a/packages/core_ai/lib/src/router/model_health_checker.dart
+++ b/packages/core_ai/lib/src/router/model_health_checker.dart
@@ -1,0 +1,39 @@
+import '../client/llm_client.dart';
+import '../provider/ai_provider.dart';
+
+class ModelHealthStatus {
+  const ModelHealthStatus({
+    required this.provider,
+    required this.isHealthy,
+    this.reason,
+  });
+
+  final AIProvider provider;
+  final bool isHealthy;
+  final String? reason;
+}
+
+/// Checks whether a routed model target can be attempted safely.
+class ModelHealthChecker {
+  const ModelHealthChecker();
+
+  Future<ModelHealthStatus> check(
+    AIProvider provider,
+    LLMClient? client,
+  ) async {
+    if (client == null) {
+      return ModelHealthStatus(
+        provider: provider,
+        isHealthy: false,
+        reason: 'No client configured',
+      );
+    }
+
+    final available = await client.isAvailable();
+    return ModelHealthStatus(
+      provider: provider,
+      isHealthy: available,
+      reason: available ? null : 'Client unavailable',
+    );
+  }
+}

--- a/packages/core_ai/test/router/ai_router_test.dart
+++ b/packages/core_ai/test/router/ai_router_test.dart
@@ -1,7 +1,9 @@
-import 'package:core_ai/core_ai.dart';
 import 'package:core_ai/src/client/fake_llm_client.dart';
 import 'package:core_ai/src/client/llm_client.dart';
+import 'package:core_ai/src/provider/ai_provider.dart';
+import 'package:core_ai/src/router/ai_router.dart';
 import 'package:core_domain/core_domain.dart';
+import 'package:core_ai/src/router/model_health_checker.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
@@ -107,5 +109,78 @@ void main() {
         expect(cloud.generateTextCalls, isEmpty);
       },
     );
+  });
+
+  group('AIRouter', () {
+    test('offlinePreferred uses on-device when healthy', () async {
+      final local = FakeLLMClient(defaultResponse: 'local');
+      final cloud = FakeLLMClient(defaultResponse: 'cloud');
+      final router = AIRouter(
+        onDeviceClient: local,
+        cloudClient: cloud,
+        config: const AIRouterConfig(
+          defaultStrategy: AIRoutingStrategy.offlinePreferred,
+        ),
+      );
+
+      final result = await router.generateText('hi');
+
+      expect(result.getOrNull()?.content, 'local');
+      expect(local.generateTextCalls, ['hi']);
+      expect(cloud.generateTextCalls, isEmpty);
+    });
+
+    test('specificModel prefers cloud when requested', () async {
+      final local = FakeLLMClient(defaultResponse: 'local');
+      final cloud = FakeLLMClient(defaultResponse: 'cloud');
+      final router = AIRouter(
+        onDeviceClient: local,
+        cloudClient: cloud,
+        config: const AIRouterConfig(
+          defaultStrategy: AIRoutingStrategy.specificModel,
+          specificModel: AIProvider.cloud,
+        ),
+      );
+
+      final result = await router.generateText('hi');
+
+      expect(result.getOrNull()?.content, 'cloud');
+      expect(cloud.generateTextCalls, ['hi']);
+      expect(local.generateTextCalls, isEmpty);
+    });
+
+    test('falls back to cloud when the preferred client errors', () async {
+      final local = FakeLLMClient(
+        defaultResponse: 'local',
+        simulateError: true,
+      );
+      final cloud = FakeLLMClient(defaultResponse: 'cloud');
+      final router = AIRouter(
+        onDeviceClient: local,
+        cloudClient: cloud,
+        config: const AIRouterConfig(
+          defaultStrategy: AIRoutingStrategy.offlinePreferred,
+          autoFallback: true,
+        ),
+      );
+
+      final result = await router.generateText('hello');
+
+      expect(result.getOrNull()?.content, 'cloud');
+      expect(local.generateTextCalls, ['hello']);
+      expect(cloud.generateTextCalls, ['hello']);
+    });
+  });
+
+  group('ModelHealthChecker', () {
+    test('reports unavailable clients as unhealthy', () async {
+      final checker = const ModelHealthChecker();
+      final client = FakeLLMClient(simulateUnavailable: true);
+
+      final health = await checker.check(AIProvider.nano, client);
+
+      expect(health.isHealthy, isFalse);
+      expect(health.reason, 'Client unavailable');
+    });
   });
 }


### PR DESCRIPTION
# Summary

This PR introduces changes to agent chat runtime fallback and core AI routing.
Goal: keep chat working when a previously selected runtime becomes unavailable.

Core outcome:

* retries agent chat on the next healthy runtime when the selected runtime fails
* adds explicit router fallback-chain and health-check primitives for current/future routing strategies
* preserves user-facing routing preference labels for the new strategy variants

# Changes

### Code

* Added:
  * `packages/core_ai/lib/src/router/fallback_chain.dart`
  * `packages/core_ai/lib/src/router/model_health_checker.dart`
  * `app/lib/features/agent_chat/presentation/widgets/fallback_notification.dart`
* Updated:
  * `packages/core_ai/lib/src/router/ai_router.dart` to support `offlinePreferred` and `specificModel`
  * `app/lib/features/agent_chat/data/services/assistant_runtime_service.dart` with fallback resolution
  * `app/lib/features/agent_chat/presentation/screens/chat_screen.dart` to retry with the fallback runtime and persist the new selection
  * `app/lib/features/agent_chat/presentation/screens/profile_screen.dart` labels for new routing strategies
  * tests in `packages/core_ai/test/router/ai_router_test.dart`
  * tests in `app/test/features/agent_chat/data/services/assistant_runtime_service_test.dart`

### Logic

* local runtime failures now attempt the next available runtime when auto-fallback is enabled
* the fallback selection is persisted through the existing assistant runtime preference
* profile labels now explain the new routing/fallback strategy names

# Risks

* chat fallback UI coverage remains primarily service-level; widget-level fallback rendering is not directly asserted yet
* `AIRouter` still models two concrete client slots, so the new strategy values currently map into on-device vs cloud rather than a larger provider registry

# Testing

* `flutter analyze` in `packages/core_ai`
* `flutter test test/router/ai_router_test.dart` in `packages/core_ai`
* `flutter analyze` in `app`
* `flutter test --no-pub test/features/agent_chat/data/services/assistant_runtime_service_test.dart test/features/agent_chat/presentation/screens/profile_theme_picker_test.dart` in `app`

# Related Commits

* `fix(agent-chat): fallback when selected runtime is unavailable`

Closes #444.
