### PR TITLE
Fix Gemini Nano runtime preparation fallthrough

### DIFF
--- a/app/lib/features/agent_chat/data/services/assistant_runtime_service.dart
+++ b/app/lib/features/agent_chat/data/services/assistant_runtime_service.dart
@@ -345,6 +345,13 @@ class AssistantRuntimeService {
         final warmCancel = cancelled();
         if (warmCancel != null) return warmCancel;
         await (_warmupGeminiNanoOverride?.call() ?? _geminiNano.warmup());
+        emit(
+          AssistantRuntimePreparationPhase.ready,
+          1,
+          'Runtime ready',
+          '${candidate.name} finished its local preflight and is ready to launch.',
+        );
+        return AssistantRuntimePreparationResult.ready();
 
       case litertGemmaAssistantModelId:
       default:

--- a/app/test/features/agent_chat/data/services/assistant_runtime_service_test.dart
+++ b/app/test/features/agent_chat/data/services/assistant_runtime_service_test.dart
@@ -247,6 +247,62 @@ void main() {
       },
     );
 
+    test(
+      'returns ready after Gemini Nano warmup without touching LiteRT setup',
+      () async {
+        var liteRtAvailabilityChecks = 0;
+        var liteRtWarmups = 0;
+        var compatibilityChecks = 0;
+        final service = AssistantRuntimeService(
+          isGeminiNanoSupported: () async => true,
+          initializeGeminiNano: () async => true,
+          warmupGeminiNano: () async => true,
+          isLiteRtAvailable: () async {
+            liteRtAvailabilityChecks++;
+            return false;
+          },
+          warmupLiteRtInstalledModel: () async {
+            liteRtWarmups++;
+            return false;
+          },
+          warmupLiteRtModel: (_) async {
+            liteRtWarmups++;
+            return false;
+          },
+          checkModelCompatibility: (_) async {
+            compatibilityChecks++;
+            return ModelCompatibilityResult.compatible(MemorySeverity.safe);
+          },
+          loadDeviceInfo: () async => {
+            'manufacturer': 'Google',
+            'model': 'Pixel 9',
+            'platform': 'android',
+          },
+        );
+
+        final result = await service.prepareRuntime(
+          candidate: const AssistantModelCandidate(
+            id: geminiNanoAssistantModelId,
+            name: 'Gemini Nano',
+            runtime: 'AICore on-device',
+            description: 'Local runtime',
+            bestFor: [AssistantTask.chat],
+            tags: ['Local'],
+            privacyLabel: 'Prompt stays on device',
+            sizeLabel: 'System managed',
+            available: true,
+            actionLabel: 'Start',
+            local: true,
+          ),
+        );
+
+        expect(result.status, AssistantRuntimePreparationStatus.ready);
+        expect(liteRtAvailabilityChecks, 0);
+        expect(liteRtWarmups, 0);
+        expect(compatibilityChecks, 0);
+      },
+    );
+
     test('cancels preparation before runtime work starts', () async {
       final service = AssistantRuntimeService(
         loadDeviceInfo: () async => {'manufacturer': 'Web', 'model': 'Browser'},


### PR DESCRIPTION
# Summary

This PR introduces a regression fix for Gemini Nano runtime preparation.
Goal: stop successful Gemini Nano setup from falling through into LiteRT validation/warmup.

Core outcome:

* Gemini Nano preparation now returns `ready` immediately after warmup succeeds
* the app no longer drags LiteRT runtime checks into the Gemini success path
* regression coverage now fails if LiteRT collaborators are touched during Gemini prep

# Changes

### Code

* Updated:
  * `app/lib/features/agent_chat/data/services/assistant_runtime_service.dart`
  * `app/test/features/agent_chat/data/services/assistant_runtime_service_test.dart`

### Logic

* after Gemini Nano support, initialization, and warmup succeed, `prepareRuntime()` now emits `ready` and returns
* the Gemini path no longer falls through into LiteRT availability, compatibility, or warmup work

# Risks

* this is intentionally narrow and only changes the successful Gemini Nano preparation path

# Testing

* `flutter analyze --no-pub` in `app`
* `flutter test test/features/agent_chat/data/services/assistant_runtime_service_test.dart` in `app`

# Related Commits

* `fix(agent-chat): stop Gemini prep at runtime ready`

Closes #495.
