### PR TITLE
fix(settings): hydrate downloaded model registry on startup

### DIFF
--- a/app/lib/features/settings/application/ai_model_management.dart
+++ b/app/lib/features/settings/application/ai_model_management.dart
@@ -13,8 +13,28 @@ import '../../iptv/application/providers/iptv_providers.dart'
 final modelRegistryProvider = Provider<ModelRegistry>((ref) {
   final registry = ModelRegistry();
   registry.registerModels(ModelCatalog.bundledModels);
+  unawaited(
+    _hydrateDownloadedModels(registry, ref.read(modelDownloadServiceProvider)),
+  );
   return registry;
 });
+
+Future<void> _hydrateDownloadedModels(
+  ModelRegistry registry,
+  ModelDownloadService service,
+) async {
+  for (final model in ModelCatalog.bundledModels) {
+    final existingPath = await service.resolveExistingModelPath(
+      model.id,
+      model: model,
+    );
+    final trimmedPath = existingPath?.trim();
+    if (trimmedPath == null || trimmedPath.isEmpty) {
+      continue;
+    }
+    registry.markAsDownloaded(model.id, trimmedPath);
+  }
+}
 
 const String _selectedModelKey = 'selected_offline_model_id';
 

--- a/app/test/features/settings/application/ai_model_management_test.dart
+++ b/app/test/features/settings/application/ai_model_management_test.dart
@@ -1,0 +1,98 @@
+import 'package:airo_app/features/settings/application/ai_model_management.dart';
+import 'package:core_ai/core_ai.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('modelRegistryProvider', () {
+    test(
+      'hydrates downloaded models from existing litert artifact paths',
+      () async {
+        final container = ProviderContainer(
+          overrides: [
+            modelDownloadServiceProvider.overrideWithValue(
+              _FakeModelDownloadService({
+                'gemma-4-e2b-it-litertlm':
+                    '/models/gemma-4-e2b-it-litertlm.litertlm',
+              }),
+            ),
+          ],
+        );
+        addTearDown(container.dispose);
+
+        final registry = container.read(modelRegistryProvider);
+
+        await Future<void>.delayed(Duration.zero);
+
+        expect(
+          registry.downloadedModels.map((model) => model.id),
+          contains('gemma-4-e2b-it-litertlm'),
+        );
+      },
+    );
+
+    test(
+      'hydrates legacy gguf paths so existing devices remain visible',
+      () async {
+        final container = ProviderContainer(
+          overrides: [
+            modelDownloadServiceProvider.overrideWithValue(
+              _FakeModelDownloadService({
+                'gemma-4-e2b-it-litertlm':
+                    '/models/gemma-4-e2b-it-litertlm.gguf',
+              }),
+            ),
+          ],
+        );
+        addTearDown(container.dispose);
+
+        final registry = container.read(modelRegistryProvider);
+
+        await Future<void>.delayed(Duration.zero);
+
+        final hydrated = registry.downloadedModels.firstWhere(
+          (model) => model.id == 'gemma-4-e2b-it-litertlm',
+        );
+        expect(hydrated.filePath, '/models/gemma-4-e2b-it-litertlm.gguf');
+      },
+    );
+
+    test('keeps models absent when no on-disk path exists', () async {
+      final container = ProviderContainer(
+        overrides: [
+          modelDownloadServiceProvider.overrideWithValue(
+            _FakeModelDownloadService(const {}),
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      final registry = container.read(modelRegistryProvider);
+
+      await Future<void>.delayed(Duration.zero);
+
+      expect(
+        registry.downloadedModels.any(
+          (model) => model.id == 'gemma-4-e2b-it-litertlm',
+        ),
+        isFalse,
+      );
+    });
+  });
+}
+
+class _FakeModelDownloadService extends ModelDownloadService {
+  _FakeModelDownloadService(this.paths);
+
+  final Map<String, String> paths;
+
+  @override
+  Future<String?> resolveExistingModelPath(
+    String modelId, {
+    OfflineModelInfo? model,
+  }) async {
+    return paths[modelId];
+  }
+}


### PR DESCRIPTION
# PR Title
fix(settings): hydrate downloaded model registry on startup

---

# Summary

This PR introduces changes to offline model registry startup hydration.
Goal: restore downloaded model visibility by rehydrating the registry from on-disk artifacts during app startup.

Core outcome:

* hydrate bundled offline models from existing on-disk artifacts during registry bootstrap
* preserve visibility for legacy `.gguf` downloads as well as LiteRT package paths

---

# Changes

### Code

* Added:

  * startup hydration tests for model registry bootstrap behavior
* Updated:

  * settings model registry bootstrap to resolve existing model paths before first use

### Logic

* reads existing model artifacts through `resolveExistingModelPath(...)` during registry initialization
* ignores empty paths and only marks models as downloaded when a real artifact exists
* preserves legacy GGUF installs for devices that have not re-downloaded newer LiteRT packages

---

# API Changes (if any)

* None.

---

# Database Changes (if any)

* None.

---

# Observability / Logging

* None.

---

# Performance Impact

* Latency: minor async startup file-resolution work for bundled offline models
* Throughput: no material impact
* Memory/CPU: negligible impact

---

# Risks

* startup hydration now depends on `resolveExistingModelPath(...)` remaining non-throwing for missing artifacts
* rollback plan:

  * revert this PR to restore bundled-only registry bootstrap behavior

---

# Testing

* Unit tests:

  * added coverage for LiteRT path hydration, legacy GGUF hydration, and missing-artifact behavior
* Integration tests:

  * not added
* Manual testing:

  * `flutter analyze --no-pub`
  * `flutter test test/features/settings/application/ai_model_management_test.dart`

---

# Deployment Notes

* Config changes:

  * none
* Order of deployment:

  * standard deployment

---

# Related Commits

* fix(settings): hydrate downloaded model registry on startup

---

# Notes

* Closes #521
