### PR TITLE
fix(settings): preserve offline model metadata after hydration

### DIFF
--- a/app/lib/features/settings/application/ai_model_management.dart
+++ b/app/lib/features/settings/application/ai_model_management.dart
@@ -16,6 +16,7 @@ final modelRegistryProvider = Provider<ModelRegistry>((ref) {
   unawaited(
     _hydrateDownloadedModels(registry, ref.read(modelDownloadServiceProvider)),
   );
+  ref.onDispose(registry.dispose);
   return registry;
 });
 
@@ -119,7 +120,7 @@ class ActiveDownloadsNotifier
 
       if (progress.isComplete) {
         final registry = _ref.read(modelRegistryProvider);
-        final modelPath = await service.getModelPath(model.id);
+        final modelPath = await service.getModelPath(model.id, model: model);
         registry.markAsDownloaded(model.id, modelPath);
       }
 

--- a/docs/wiki/5.-AI-and-Model-Management.md
+++ b/docs/wiki/5.-AI-and-Model-Management.md
@@ -60,6 +60,15 @@ You can:
   use
 - download, delete, or activate supported offline packages from the browser
 
+Downloaded offline packages are re-discovered when the app starts, so models
+that already exist on disk appear again in the **Downloaded** tab without
+requiring a second download. This applies to both current LiteRT package
+artifacts and legacy GGUF artifacts kept on older devices.
+
+When a download finishes, Airo now preserves the concrete artifact path for the
+selected model variant instead of falling back to a generic lookup. That keeps
+the registry aligned with the actual file stored on the device.
+
 If a model is too large for the current device budget, Airo shows a compatibility
 warning directly in the model card before you try to activate it.
 


### PR DESCRIPTION
# Summary

This PR completes the valid remainder of the archived download-manager follow-up from issue #526.
Goal: keep offline model state consistent after startup hydration and after download completion on current `main`.

Core outcome:

* dispose the model registry provider cleanly with the provider lifecycle
* pass the concrete model to `getModelPath(...)` so the registry keeps the correct artifact path metadata

# Changes

### Code

* Updated:

  * `app/lib/features/settings/application/ai_model_management.dart` to dispose the registry and preserve model-specific artifact metadata when marking downloads complete

### Logic

* startup hydration already shipped on `main` via #521, so this PR keeps the missing follow-through on the completion path
* downloaded models now retain the correct artifact path for the resolved model variant instead of falling back to the generic lookup

# Performance Impact

* Latency: no material change
* Throughput: no material change
* Memory/CPU: avoids a leaked registry instance by disposing it with the provider

# Risks

* low risk because the change is isolated to the settings model-management flow
* main residual risk is device-specific download path behavior outside the covered unit path
* Rollback plan:

  * revert this PR to restore previous lifecycle and completion-path behavior

# Testing

* Unit tests:

  * `flutter test test/features/settings/application/ai_model_management_test.dart`
* Manual testing:

  * `flutter analyze lib/features/settings/application/ai_model_management.dart test/features/settings/application/ai_model_management_test.dart`

# Related Commits

* `fix(settings): rehydrate downloaded offline models`

# Notes

* The broader archived branch was re-evaluated against current `main`; most original archive changes were already superseded upstream.
* Closes #526.
