### PR TITLE
fix(agent-chat): add runtime traces and Airo context

### DIFF
--- a/app/lib/features/agent_chat/data/services/assistant_chat_context_builder.dart
+++ b/app/lib/features/agent_chat/data/services/assistant_chat_context_builder.dart
@@ -1,0 +1,75 @@
+class AssistantChatContextMessage {
+  const AssistantChatContextMessage({required this.text, required this.isUser});
+
+  final String text;
+  final bool isUser;
+}
+
+class AssistantChatContextBuilder {
+  const AssistantChatContextBuilder({
+    this.maxHistoryMessages = 6,
+    this.maxMessageChars = 280,
+  });
+
+  final int maxHistoryMessages;
+  final int maxMessageChars;
+
+  String buildSystemPrompt({
+    required String currentUserPrompt,
+    required List<AssistantChatContextMessage> history,
+  }) {
+    final normalizedPrompt = currentUserPrompt.trim();
+    final recentHistory = _recentHistory(history, normalizedPrompt);
+    final sections = <String>[
+      _airoBaseContext,
+      if (recentHistory.isNotEmpty)
+        'Recent conversation:\n${recentHistory.join('\n')}',
+      'Assume "Airo" refers to this app and assistant unless the user clearly means something else.',
+      'Use the recent conversation for continuity so the user does not need to restate prior context.',
+    ];
+    return sections.join('\n\n');
+  }
+
+  List<String> _recentHistory(
+    List<AssistantChatContextMessage> history,
+    String currentUserPrompt,
+  ) {
+    final filtered = history
+        .where((message) => message.text.trim().isNotEmpty)
+        .toList();
+    if (filtered.isEmpty) {
+      return const [];
+    }
+
+    final sliced = filtered.length <= maxHistoryMessages
+        ? filtered
+        : filtered.sublist(filtered.length - maxHistoryMessages);
+
+    return sliced
+        .map(
+          (message) =>
+              '${message.isUser ? 'User' : 'Airo'}: '
+              '${_preview(message.text.trim())}',
+        )
+        .where((entry) => entry.trim().isNotEmpty)
+        .where((entry) => entry != 'User: $currentUserPrompt')
+        .toList(growable: false);
+  }
+
+  String _preview(String value) {
+    if (value.length <= maxMessageChars) {
+      return value;
+    }
+    return '${value.substring(0, maxMessageChars)}...';
+  }
+}
+
+const String _airoBaseContext =
+    'You are Airo, the assistant inside the Airo app. '
+    'Airo is a local-first AI assistant that helps users chat, plan tasks, '
+    'reason through work, summarize notes, open Airo features, manage '
+    'reminders and notifications, help with calendar flows, capture expense '
+    'messages into Coins, split bills, and support image or audio workflows '
+    'when the selected runtime allows it. '
+    'Answer as the Airo product assistant, stay grounded in these capabilities, '
+    'and avoid acting like you have never heard of Airo.';

--- a/app/lib/features/agent_chat/data/services/assistant_runtime_service.dart
+++ b/app/lib/features/agent_chat/data/services/assistant_runtime_service.dart
@@ -1,6 +1,7 @@
 import '../../../../core/services/gemini_api_service.dart';
 import '../../../../core/services/gemini_nano_service.dart';
 import '../../../../core/services/litert_lm_service.dart';
+import 'package:flutter/foundation.dart';
 import '../../presentation/screens/model_library_screen.dart';
 import '../../domain/models/assistant_runtime_ids.dart';
 import 'package:core_ai/core_ai.dart';
@@ -27,6 +28,29 @@ typedef LiteRtModelWarmup = Future<bool> Function(OfflineModelInfo model);
 typedef DeviceInfoLoader = Future<Map<String, dynamic>> Function();
 typedef ModelCompatibilityCheck =
     Future<ModelCompatibilityResult> Function(OfflineModelInfo model);
+typedef RuntimeDebugTraceEmitter =
+    void Function(AssistantRuntimeDebugTrace trace);
+
+@immutable
+class AssistantRuntimeDebugTrace {
+  const AssistantRuntimeDebugTrace({
+    required this.runtimeId,
+    required this.stage,
+    required this.recordedAt,
+    this.systemPromptPreview,
+    this.promptPreview,
+    this.responsePreview,
+    this.detail,
+  });
+
+  final String runtimeId;
+  final String stage;
+  final DateTime recordedAt;
+  final String? systemPromptPreview;
+  final String? promptPreview;
+  final String? responsePreview;
+  final String? detail;
+}
 
 enum AssistantRuntimePreparationPhase {
   validate,
@@ -179,6 +203,7 @@ class AssistantRuntimeService {
     DeviceInfoLoader? loadDeviceInfo,
     ModelCompatibilityCheck? checkModelCompatibility,
     Future<AssistantModelLibraryState> Function()? loadAssistantModelLibrary,
+    this._debugTraceEmitter,
   }) : _geminiNano = geminiNano ?? GeminiNanoService(),
        _liteRtLm = liteRtLm ?? LiteRtLmService(),
        _geminiCloud = geminiCloud ?? geminiApiService,
@@ -219,6 +244,7 @@ class AssistantRuntimeService {
   final ModelCompatibilityCheck? _checkModelCompatibilityOverride;
   final Future<AssistantModelLibraryState> Function()?
   _loadAssistantModelLibraryOverride;
+  final RuntimeDebugTraceEmitter? _debugTraceEmitter;
 
   Future<AssistantRuntimePreparationResult> prepareRuntime({
     required AssistantModelCandidate candidate,
@@ -485,21 +511,33 @@ class AssistantRuntimeService {
   }) async {
     final runtimeId = _requireSelectedRuntime(selectedModelId);
     final fullPrompt = _withSystemPrompt(prompt, systemPrompt);
+    _emitDebugTrace(
+      AssistantRuntimeDebugTrace(
+        runtimeId: runtimeId,
+        stage: 'request',
+        recordedAt: DateTime.now(),
+        systemPromptPreview: _previewText(systemPrompt),
+        promptPreview: _previewText(prompt),
+        detail: 'generateText',
+      ),
+    );
 
     switch (runtimeId) {
       case geminiNanoAssistantModelId:
         await _ensureGeminiNanoReady();
-        return _nonEmptyOrUnavailable(
+        final response = _nonEmptyOrUnavailable(
           runtimeId,
           await (_generateGeminiNanoTextOverride?.call(fullPrompt) ??
               _geminiNano.generateContentStrict(fullPrompt)),
           geminiNanoInitializationFailedMessage,
         );
+        _emitResponseTrace(runtimeId, response, detail: 'generateText');
+        return response;
 
       case litertGemmaAssistantModelId:
         final package = await _resolveDownloadedLiteRtPackage(runtimeId);
         if (package != null) {
-          return _nonEmptyOrUnavailable(
+          final response = _nonEmptyOrUnavailable(
             runtimeId,
             await (_generateLiteRtModelTextOverride?.call(
                   package,
@@ -513,8 +551,10 @@ class AssistantRuntimeService {
                 )),
             litertGemmaUnavailableMessage,
           );
+          _emitResponseTrace(runtimeId, response, detail: package.id);
+          return response;
         }
-        return _nonEmptyOrUnavailable(
+        final response = _nonEmptyOrUnavailable(
           runtimeId,
           await (_generateLiteRtTextOverride?.call(
                 prompt,
@@ -523,6 +563,8 @@ class AssistantRuntimeService {
               _liteRtLm.generateText(prompt, systemPrompt: systemPrompt)),
           litertGemmaUnavailableMessage,
         );
+        _emitResponseTrace(runtimeId, response, detail: 'default-litert');
+        return response;
 
       case geminiCloudAssistantModelId:
         await (_initializeCloudOverride?.call() ?? _geminiCloud.initialize());
@@ -534,12 +576,14 @@ class AssistantRuntimeService {
             geminiCloudUnavailableMessage,
           );
         }
-        return _nonEmptyOrUnavailable(
+        final response = _nonEmptyOrUnavailable(
           runtimeId,
           await (_generateCloudTextOverride?.call(fullPrompt) ??
               _geminiCloud.generateText(fullPrompt)),
           geminiCloudEmptyResponseMessage,
         );
+        _emitResponseTrace(runtimeId, response, detail: 'generateText');
+        return response;
 
       default:
         final offlineModelId = offlineModelIdFromAssistantModelId(runtimeId);
@@ -550,7 +594,7 @@ class AssistantRuntimeService {
           );
         }
         final package = await _resolveOfflinePackage(runtimeId);
-        return _nonEmptyOrUnavailable(
+        final response = _nonEmptyOrUnavailable(
           runtimeId,
           await (_generateLiteRtModelTextOverride?.call(
                 package,
@@ -564,28 +608,51 @@ class AssistantRuntimeService {
               )),
           offlinePackageUnavailableMessage,
         );
+        _emitResponseTrace(runtimeId, response, detail: package.id);
+        return response;
     }
   }
 
   Stream<String> generateTextStream({
     required String? selectedModelId,
     required String prompt,
+    String? systemPrompt,
   }) async* {
     final runtimeId = _requireSelectedRuntime(selectedModelId);
 
     if (runtimeId != geminiNanoAssistantModelId) {
-      yield await generateText(selectedModelId: runtimeId, prompt: prompt);
+      yield await generateText(
+        selectedModelId: runtimeId,
+        prompt: prompt,
+        systemPrompt: systemPrompt,
+      );
       return;
     }
+
+    _emitDebugTrace(
+      AssistantRuntimeDebugTrace(
+        runtimeId: runtimeId,
+        stage: 'request',
+        recordedAt: DateTime.now(),
+        systemPromptPreview: _previewText(systemPrompt),
+        promptPreview: _previewText(prompt),
+        detail: 'generateTextStream',
+      ),
+    );
 
     await _ensureGeminiNanoReady();
     var yielded = false;
     final stream =
-        _generateGeminiNanoStreamOverride?.call(prompt) ??
-        _geminiNano.generateContentStreamStrict(prompt);
+        _generateGeminiNanoStreamOverride?.call(
+          _withSystemPrompt(prompt, systemPrompt),
+        ) ??
+        _geminiNano.generateContentStreamStrict(
+          _withSystemPrompt(prompt, systemPrompt),
+        );
     await for (final chunk in stream) {
       if (chunk.trim().isEmpty) continue;
       yielded = true;
+      _emitResponseTrace(runtimeId, chunk, detail: 'stream-chunk');
       yield chunk;
     }
     if (!yielded) {
@@ -698,6 +765,44 @@ class AssistantRuntimeService {
     } catch (_) {
       return null;
     }
+  }
+
+  void _emitResponseTrace(String runtimeId, String response, {String? detail}) {
+    _emitDebugTrace(
+      AssistantRuntimeDebugTrace(
+        runtimeId: runtimeId,
+        stage: 'response',
+        recordedAt: DateTime.now(),
+        responsePreview: _previewText(response),
+        detail: detail,
+      ),
+    );
+  }
+
+  void _emitDebugTrace(AssistantRuntimeDebugTrace trace) {
+    _debugTraceEmitter?.call(trace);
+    if (!kDebugMode) {
+      return;
+    }
+    debugPrint(
+      '[AssistantRuntimeTrace] runtime=${trace.runtimeId} '
+      'stage=${trace.stage} detail=${trace.detail ?? '-'} '
+      'system=${trace.systemPromptPreview ?? '-'} '
+      'prompt=${trace.promptPreview ?? '-'} '
+      'response=${trace.responsePreview ?? '-'}',
+    );
+  }
+
+  String? _previewText(String? value) {
+    final trimmed = value?.trim();
+    if (trimmed == null || trimmed.isEmpty) {
+      return null;
+    }
+    final normalized = trimmed.replaceAll(RegExp(r'\s+'), ' ');
+    if (normalized.length <= 220) {
+      return normalized;
+    }
+    return '${normalized.substring(0, 220)}...';
   }
 
   Future<AssistantRuntimeFallbackDecision?> resolveFallback({

--- a/app/lib/features/agent_chat/domain/models/chat_response_metadata.dart
+++ b/app/lib/features/agent_chat/domain/models/chat_response_metadata.dart
@@ -17,6 +17,9 @@ class ChatResponseMetadata {
     this.completionTokens,
     this.finishReason,
     this.toolCount,
+    this.systemPromptPreview,
+    this.promptPreview,
+    this.responsePreview,
   });
 
   final String title;
@@ -30,6 +33,9 @@ class ChatResponseMetadata {
   final int? completionTokens;
   final String? finishReason;
   final int? toolCount;
+  final String? systemPromptPreview;
+  final String? promptPreview;
+  final String? responsePreview;
 
   int? get totalTokens => promptTokens != null && completionTokens != null
       ? promptTokens! + completionTokens!
@@ -47,6 +53,9 @@ ChatResponseMetadata buildRuntimeChatResponseMetadata({
   String? modelId,
   int? timeToFirstTokenMs,
   String? finishReason,
+  String? systemPromptPreview,
+  String? promptPreview,
+  String? responsePreview,
 }) {
   return ChatResponseMetadata(
     title: title,
@@ -59,6 +68,9 @@ ChatResponseMetadata buildRuntimeChatResponseMetadata({
     promptTokens: TokenCounter.estimate(prompt),
     completionTokens: TokenCounter.estimate(response),
     finishReason: finishReason ?? 'stop',
+    systemPromptPreview: systemPromptPreview,
+    promptPreview: promptPreview,
+    responsePreview: responsePreview,
   );
 }
 

--- a/app/lib/features/agent_chat/presentation/screens/chat_screen.dart
+++ b/app/lib/features/agent_chat/presentation/screens/chat_screen.dart
@@ -9,6 +9,7 @@ import '../../../agent_chat/data/connectors/calendar_connector.dart';
 import '../../../agent_chat/data/connectors/date_time_connector.dart';
 import '../../../agent_chat/data/connectors/notification_connector.dart';
 import '../../../agent_chat/data/connectors/route_connector.dart';
+import '../../../agent_chat/data/services/assistant_chat_context_builder.dart';
 import '../../../agent_chat/data/services/assistant_runtime_service.dart';
 import '../../../agent_chat/data/services/selected_runtime_agent_skill_model_client.dart';
 import '../../../agent_chat/application/assistant_model_preferences.dart';
@@ -90,6 +91,8 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
   late final AssistantRuntimeService _assistantRuntime;
   late final LocalRuntimePreloaderService _localRuntimePreloader;
   late AgentSkillOrchestrator _skillOrchestrator;
+  final AssistantChatContextBuilder _chatContextBuilder =
+      const AssistantChatContextBuilder();
   Map<String, dynamic>? _pendingCalendarEvent;
   bool _isDeviceSupported = false;
   bool _isGenerating = false;
@@ -814,10 +817,12 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
     int? timeToFirstTokenMs;
     String latestChunk = '';
     final attempted = {...attemptedRuntimeIds, selectedModelId};
+    final systemPrompt = _buildChatSystemPrompt(message);
     try {
       await for (final chunk in _assistantRuntime.generateTextStream(
         selectedModelId: selectedModelId,
         prompt: message,
+        systemPrompt: systemPrompt,
       )) {
         timeToFirstTokenMs ??= stopwatch.elapsedMilliseconds;
         latestChunk = chunk;
@@ -831,6 +836,7 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
         selectedModelId: selectedModelId,
         prompt: message,
         response: latestChunk,
+        systemPrompt: systemPrompt,
         totalDuration: stopwatch.elapsed,
         timeToFirstTokenMs: timeToFirstTokenMs,
       );
@@ -880,6 +886,7 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
     required String selectedModelId,
     required String prompt,
     required String response,
+    String? systemPrompt,
     required Duration totalDuration,
     required int? timeToFirstTokenMs,
   }) async {
@@ -906,7 +913,37 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
       timeToFirstTokenMs: timeToFirstTokenMs,
       prompt: prompt,
       response: response,
+      systemPromptPreview: _previewForMetadata(systemPrompt),
+      promptPreview: _previewForMetadata(prompt),
+      responsePreview: _previewForMetadata(response),
     );
+  }
+
+  String _buildChatSystemPrompt(String currentPrompt) {
+    return _chatContextBuilder.buildSystemPrompt(
+      currentUserPrompt: currentPrompt,
+      history: _messages
+          .where((message) => message.text.trim().isNotEmpty)
+          .map(
+            (message) => AssistantChatContextMessage(
+              text: message.text,
+              isUser: message.isUser,
+            ),
+          )
+          .toList(growable: false),
+    );
+  }
+
+  String _previewForMetadata(String? value) {
+    final trimmed = value?.trim();
+    if (trimmed == null || trimmed.isEmpty) {
+      return '';
+    }
+    final normalized = trimmed.replaceAll(RegExp(r'\s+'), ' ');
+    if (normalized.length <= 240) {
+      return normalized;
+    }
+    return '${normalized.substring(0, 240)}...';
   }
 
   ChatResponseMetadata _buildSkillMetadata({
@@ -972,6 +1009,15 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
             ('Tool calls', '${metadata.toolCount}'),
           if (metadata.finishReason != null)
             ('Finish reason', metadata.finishReason!),
+          if (metadata.systemPromptPreview != null &&
+              metadata.systemPromptPreview!.isNotEmpty)
+            ('System context', metadata.systemPromptPreview!),
+          if (metadata.promptPreview != null &&
+              metadata.promptPreview!.isNotEmpty)
+            ('Prompt preview', metadata.promptPreview!),
+          if (metadata.responsePreview != null &&
+              metadata.responsePreview!.isNotEmpty)
+            ('Response preview', metadata.responsePreview!),
         ];
 
         return SafeArea(

--- a/app/test/features/agent_chat/data/services/assistant_chat_context_builder_test.dart
+++ b/app/test/features/agent_chat/data/services/assistant_chat_context_builder_test.dart
@@ -1,0 +1,48 @@
+import 'package:airo_app/features/agent_chat/data/services/assistant_chat_context_builder.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('AssistantChatContextBuilder', () {
+    const builder = AssistantChatContextBuilder();
+
+    test('injects stable Airo product context for fresh chats', () {
+      final prompt = builder.buildSystemPrompt(
+        currentUserPrompt: 'what does airo do',
+        history: const [],
+      );
+
+      expect(
+        prompt,
+        contains('You are Airo, the assistant inside the Airo app.'),
+      );
+      expect(prompt, contains('local-first AI assistant'));
+      expect(
+        prompt,
+        contains('avoid acting like you have never heard of Airo'),
+      );
+    });
+
+    test('includes recent conversation context for continuity', () {
+      final prompt = builder.buildSystemPrompt(
+        currentUserPrompt: 'what can it do for reminders?',
+        history: const [
+          AssistantChatContextMessage(text: 'What does Airo do?', isUser: true),
+          AssistantChatContextMessage(
+            text:
+                'Airo can help with planning, reminders, and opening app features.',
+            isUser: false,
+          ),
+        ],
+      );
+
+      expect(prompt, contains('Recent conversation:'));
+      expect(prompt, contains('User: What does Airo do?'));
+      expect(
+        prompt,
+        contains(
+          'Airo: Airo can help with planning, reminders, and opening app features.',
+        ),
+      );
+    });
+  });
+}

--- a/app/test/features/agent_chat/data/services/assistant_runtime_service_test.dart
+++ b/app/test/features/agent_chat/data/services/assistant_runtime_service_test.dart
@@ -9,6 +9,35 @@ void main() {
 
   group('AssistantRuntimeService', () {
     test(
+      'emits bounded debug traces for Gemini Nano requests and responses',
+      () async {
+        final traces = <AssistantRuntimeDebugTrace>[];
+        final service = AssistantRuntimeService(
+          isGeminiNanoSupported: () async => true,
+          initializeGeminiNano: () async => true,
+          generateGeminiNanoText: (_) async => 'Airo helps with planning.',
+          debugTraceEmitter: traces.add,
+        );
+
+        final text = await service.generateText(
+          selectedModelId: geminiNanoAssistantModelId,
+          prompt: 'what does airo do?',
+          systemPrompt: 'You are Airo.',
+        );
+
+        expect(text, 'Airo helps with planning.');
+        expect(traces.map((trace) => trace.stage), ['request', 'response']);
+        expect(traces.first.runtimeId, geminiNanoAssistantModelId);
+        expect(traces.first.systemPromptPreview, contains('You are Airo.'));
+        expect(traces.first.promptPreview, contains('what does airo do?'));
+        expect(
+          traces.last.responsePreview,
+          contains('Airo helps with planning.'),
+        );
+      },
+    );
+
+    test(
       'reports Gemini Nano unavailable instead of using canned fallback',
       () async {
         final service = AssistantRuntimeService(

--- a/app/test/features/agent_chat/presentation/screens/chat_screen_metadata_test.dart
+++ b/app/test/features/agent_chat/presentation/screens/chat_screen_metadata_test.dart
@@ -69,6 +69,10 @@ void main() {
             timeToFirstTokenMs: 350,
             recordedAt: DateTime(2026, 6, 28, 10, 0),
             modelId: geminiNanoAssistantModelId,
+            systemPromptPreview:
+                'You are Airo, the assistant inside the Airo app.',
+            promptPreview: 'hello',
+            responsePreview: 'Hello from Airo',
           ),
         ),
       ],
@@ -91,6 +95,13 @@ void main() {
     expect(find.text('Time to first token'), findsOneWidget);
     expect(find.text('Prompt tokens'), findsOneWidget);
     expect(find.text('Completion tokens'), findsOneWidget);
+    expect(find.text('System context'), findsOneWidget);
+    expect(
+      find.text('You are Airo, the assistant inside the Airo app.'),
+      findsOneWidget,
+    );
+    expect(find.text('Prompt preview'), findsOneWidget);
+    expect(find.text('Response preview'), findsOneWidget);
   });
 
   testWidgets('agent skill responses show tool count and action timings', (


### PR DESCRIPTION
# PR Title
fix(agent-chat): add runtime traces and Airo context

---

# Summary

This PR introduces changes to assistant chat runtime observability and default chat context.
Goal: make device/runtime debugging traceable and ensure fresh chats start with stable Airo product context.

Core outcome:

* injects a stable Airo system context into runtime-backed chat turns
* emits bounded request/response trace previews for runtime generations
* surfaces prompt/context previews in response metadata for debug review

---

# Changes

### Code

* Added:

  * `AssistantChatContextBuilder` and tests for stable product-context injection
* Updated:

  * assistant runtime service with additive debug trace emission hooks
  * chat metadata model and chat screen metadata sheet with preview fields
  * runtime service and metadata tests for the new behavior

### Logic

* builds a default Airo system prompt for fresh and continuing general chat turns
* emits bounded prompt/context/response previews without making tracing mandatory
* preserves existing runtime fallback behavior while adding additive debug metadata

---

# API Changes (if any)

* None.

---

# Database Changes (if any)

* None.

---

# Observability / Logging

* Added logs:

  * bounded runtime request/response traces in debug mode
* Metrics:

  * none
* Tracing:

  * additive local trace emitter callback for assistant runtime calls

---

# Performance Impact

* Latency: negligible string-building overhead per chat turn
* Throughput: no material impact
* Memory/CPU: negligible impact

---

# Risks

* debug tracing must remain bounded so previews do not grow unbounded over time
* rollback plan:

  * revert this PR to restore previous chat prompt/metadata behavior

---

# Testing

* Unit tests:

  * added context-builder and runtime trace coverage
* Integration tests:

  * verified chat metadata sheet exposes context/prompt/response previews
* Manual testing:

  * `flutter analyze --no-pub`
  * `flutter test test/features/agent_chat/data/services/assistant_chat_context_builder_test.dart test/features/agent_chat/data/services/assistant_runtime_service_test.dart test/features/agent_chat/presentation/screens/chat_screen_metadata_test.dart`

---

# Deployment Notes

* Config changes:

  * none
* Order of deployment:

  * standard deployment

---

# Related Commits

* fix(agent-chat): add runtime traces and Airo context

---

# Notes

* Closes #523
