### PR TITLE
fix(settings): show download stage in model progress

### DIFF
--- a/app/lib/features/settings/presentation/screens/ai_models_screen.dart
+++ b/app/lib/features/settings/presentation/screens/ai_models_screen.dart
@@ -214,7 +214,7 @@ class _AIModelsScreenState extends ConsumerState<AIModelsScreen>
       itemBuilder: (context, index) {
         final model = models[index];
         final downloadProgress = activeDownloads[model.id];
-        final isDownloading = downloadProgress?.isInProgress ?? false;
+        final isDownloading = downloadProgress?.isActive ?? false;
         final isActive = model.id == selectedModelId;
         final compatibility = ref.watch(modelCompatibilityProvider(model.id));
 
@@ -224,6 +224,9 @@ class _AIModelsScreenState extends ConsumerState<AIModelsScreen>
             isActive: isActive,
             isDownloading: isDownloading,
             downloadProgress: downloadProgress?.progress,
+            downloadStatus: isDownloading
+                ? downloadProgress?.statusDisplay
+                : null,
             downloadSpeed: isDownloading
                 ? downloadProgress?.speedDisplay
                 : null,
@@ -249,6 +252,9 @@ class _AIModelsScreenState extends ConsumerState<AIModelsScreen>
             isActive: isActive,
             isDownloading: isDownloading,
             downloadProgress: downloadProgress?.progress,
+            downloadStatus: isDownloading
+                ? downloadProgress?.statusDisplay
+                : null,
             downloadSpeed: isDownloading
                 ? downloadProgress?.speedDisplay
                 : null,
@@ -273,6 +279,9 @@ class _AIModelsScreenState extends ConsumerState<AIModelsScreen>
             isActive: isActive,
             isDownloading: isDownloading,
             downloadProgress: downloadProgress?.progress,
+            downloadStatus: isDownloading
+                ? downloadProgress?.statusDisplay
+                : null,
             downloadSpeed: isDownloading
                 ? downloadProgress?.speedDisplay
                 : null,

--- a/app/lib/features/settings/presentation/screens/model_detail_screen.dart
+++ b/app/lib/features/settings/presentation/screens/model_detail_screen.dart
@@ -227,7 +227,7 @@ class ModelDetailScreen extends ConsumerWidget {
     final theme = Theme.of(context);
     final activeDownloads = ref.watch(activeDownloadsProvider);
     final downloadProgress = activeDownloads[model.id];
-    final isDownloading = downloadProgress?.isInProgress ?? false;
+    final isDownloading = downloadProgress?.isActive ?? false;
 
     if (model.isDownloaded) {
       return Row(
@@ -256,7 +256,7 @@ class ModelDetailScreen extends ConsumerWidget {
       icon: Icon(isDownloading ? Icons.downloading : Icons.download),
       label: Text(
         isDownloading
-            ? 'Downloading ${downloadProgress?.progressPercent ?? 0}%'
+            ? '${downloadProgress?.statusDisplay ?? 'Downloading'} ${downloadProgress?.progressPercent ?? 0}%'
             : 'Download (${model.fileSizeDisplay})',
       ),
     );

--- a/app/lib/features/settings/presentation/widgets/model_card.dart
+++ b/app/lib/features/settings/presentation/widgets/model_card.dart
@@ -14,6 +14,7 @@ class ModelCard extends StatelessWidget {
     this.isActive = false,
     this.isDownloading = false,
     this.downloadProgress,
+    this.downloadStatus,
     this.downloadSpeed,
     this.downloadEta,
     this.isCompatible = true,
@@ -36,6 +37,9 @@ class ModelCard extends StatelessWidget {
 
   /// Download progress from 0.0 to 1.0.
   final double? downloadProgress;
+
+  /// Current stage display (e.g. "Downloading" or "Verifying").
+  final String? downloadStatus;
 
   /// Download speed display (e.g., "2.5 MB/s").
   final String? downloadSpeed;
@@ -199,10 +203,15 @@ class ModelCard extends StatelessWidget {
               ),
               const SizedBox(width: 8),
               Text(
-                '${(downloadProgress! * 100).round()}%',
+                downloadStatus ?? 'Downloading',
                 style: theme.textTheme.bodySmall?.copyWith(
                   fontWeight: FontWeight.w600,
                 ),
+              ),
+              const SizedBox(width: 8),
+              Text(
+                '${(downloadProgress! * 100).round()}%',
+                style: theme.textTheme.bodySmall,
               ),
               if (downloadSpeed != null) ...[
                 const SizedBox(width: 8),

--- a/app/test/features/settings/presentation/screens/ai_models_screen_test.dart
+++ b/app/test/features/settings/presentation/screens/ai_models_screen_test.dart
@@ -99,6 +99,58 @@ void main() {
     expect(find.text('Gemma Downloaded'), findsOneWidget);
     expect(find.text('Active'), findsOneWidget);
   });
+
+  testWidgets('shows stage, speed, eta, and percentage for active downloads', (
+    tester,
+  ) async {
+    SharedPreferences.setMockInitialValues({});
+
+    final registry =
+        _FakeModelRegistry(
+          compatibilityByModelId: {
+            'gemma-download': ModelCompatibilityResult.compatible(
+              MemorySeverity.safe,
+            ),
+          },
+        )..registerModel(
+          const OfflineModelInfo(
+            id: 'gemma-download',
+            name: 'Gemma Download',
+            family: ModelFamily.gemma,
+            fileSizeBytes: 2048,
+            provider: AIProvider.gemma,
+          ),
+        );
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          modelRegistryProvider.overrideWithValue(registry),
+          activeDownloadsProvider.overrideWith(
+            (ref) => ActiveDownloadsNotifier(ref)
+              ..state = {
+                'gemma-download': const ModelDownloadProgress(
+                  modelId: 'gemma-download',
+                  totalBytes: 300,
+                  downloadedBytes: 200,
+                  status: ModelDownloadStatus.verifying,
+                  speedBytesPerSecond: 2.5 * 1024 * 1024,
+                ),
+              },
+          ),
+        ],
+        child: const MaterialApp(home: AIModelsScreen()),
+      ),
+    );
+
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 100));
+
+    expect(find.text('Verifying'), findsOneWidget);
+    expect(find.text('67%'), findsOneWidget);
+    expect(find.textContaining('2.5 MB/s'), findsOneWidget);
+    expect(find.textContaining('remaining'), findsOneWidget);
+  });
 }
 
 class _FakeModelRegistry extends ModelRegistry {

--- a/app/test/features/settings/presentation/screens/model_detail_screen_test.dart
+++ b/app/test/features/settings/presentation/screens/model_detail_screen_test.dart
@@ -9,8 +9,10 @@ void main() {
   Widget buildScreen(
     OfflineModelInfo model, {
     Future<bool> Function(Uri uri, {LaunchMode mode})? launchUrlCallback,
+    List<Override> overrides = const [],
   }) {
     return ProviderScope(
+      overrides: overrides,
       child: MaterialApp(
         home: ModelDetailScreen(
           model: model,

--- a/packages/core_ai/lib/src/download/model_download_progress.dart
+++ b/packages/core_ai/lib/src/download/model_download_progress.dart
@@ -78,6 +78,33 @@ class ModelDownloadProgress {
   /// Whether the download is in progress.
   bool get isInProgress => status == ModelDownloadStatus.downloading;
 
+  /// Whether the download is still actively occupying the progress UI.
+  bool get isActive =>
+      status == ModelDownloadStatus.pending ||
+      status == ModelDownloadStatus.downloading ||
+      status == ModelDownloadStatus.paused ||
+      status == ModelDownloadStatus.verifying;
+
+  /// Human-readable download stage label.
+  String get statusDisplay {
+    switch (status) {
+      case ModelDownloadStatus.pending:
+        return 'Queued';
+      case ModelDownloadStatus.downloading:
+        return 'Downloading';
+      case ModelDownloadStatus.paused:
+        return 'Paused';
+      case ModelDownloadStatus.completed:
+        return 'Completed';
+      case ModelDownloadStatus.failed:
+        return 'Failed';
+      case ModelDownloadStatus.cancelled:
+        return 'Cancelled';
+      case ModelDownloadStatus.verifying:
+        return 'Verifying';
+    }
+  }
+
   /// Estimated time remaining in seconds.
   int? get estimatedSecondsRemaining {
     if (speedBytesPerSecond <= 0 || isComplete) return null;

--- a/packages/core_ai/test/download/model_download_progress_test.dart
+++ b/packages/core_ai/test/download/model_download_progress_test.dart
@@ -1,0 +1,26 @@
+import 'package:core_ai/core_ai.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('ModelDownloadProgress', () {
+    test('treats pending and verifying stages as active progress states', () {
+      const pending = ModelDownloadProgress(
+        modelId: 'model-a',
+        totalBytes: 100,
+        downloadedBytes: 0,
+        status: ModelDownloadStatus.pending,
+      );
+      const verifying = ModelDownloadProgress(
+        modelId: 'model-a',
+        totalBytes: 100,
+        downloadedBytes: 100,
+        status: ModelDownloadStatus.verifying,
+      );
+
+      expect(pending.isActive, isTrue);
+      expect(verifying.isActive, isTrue);
+      expect(pending.statusDisplay, 'Queued');
+      expect(verifying.statusDisplay, 'Verifying');
+    });
+  });
+}


### PR DESCRIPTION
# PR Title
fix(settings): show download stage in model progress

---

# Summary

This PR introduces changes to the AI model download progress UI.
Goal: complete the live download progress surface by showing the current stage/status alongside existing percentage, speed, and ETA details.

Core outcome:

* keeps model progress UI visible for queued and verifying stages, not just active byte transfer
* adds a human-readable stage label to download progress surfaces
* covers the new stage behavior in settings UI and core progress tests

---

# Changes

### Code

* Added:

  * `statusDisplay` and `isActive` helpers on `ModelDownloadProgress`
  * package test coverage for active stage semantics
* Updated:

  * AI model cards and detail download CTA to render the current stage
  * settings screen tests to verify stage, speed, ETA, and percentage rendering

### Logic

* treats `pending`, `downloading`, `paused`, and `verifying` as active progress states for UI purposes
* renders the stage label without removing existing percentage, speed, or ETA details
* preserves existing completed/failed/cancelled cleanup behavior

---

# API Changes (if any)

* None.

---

# Database Changes (if any)

* None.

---

# Observability / Logging

* None.

---

# Performance Impact

* Latency: none
* Throughput: none
* Memory/CPU: negligible

---

# Risks

* stage wording now becomes part of the tested UI surface, so future status label changes must update tests intentionally
* rollback plan:

  * revert this PR to restore percentage/speed/ETA-only progress rendering

---

# Testing

* Unit tests:

  * added `packages/core_ai/test/download/model_download_progress_test.dart`
* Integration tests:

  * verified settings model list renders stage, speed, ETA, and percentage for active downloads
* Manual testing:

  * `flutter analyze --no-pub`
  * `flutter test test/features/settings/presentation/screens/ai_models_screen_test.dart test/features/settings/presentation/screens/model_detail_screen_test.dart`
  * `flutter test test/download/model_download_progress_test.dart`

---

# Deployment Notes

* Config changes:

  * none
* Order of deployment:

  * standard deployment

---

# Related Commits

* fix(settings): show download stage in model progress

---

# Notes

* Closes #500
