### PR TITLE
chore(release): add performance benchmark workflow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -581,6 +581,30 @@ test-ui-responsive: ## Run shared responsive UI validation tests
 	@cd $(APP_DIR) && rm -rf windows/flutter/ephemeral/.plugin_symlinks ios/Flutter/ephemeral/Packages/.packages macos/Flutter/ephemeral/Packages/.packages
 	@cd $(APP_DIR) && flutter test test/shared/widgets/adaptive_layout_test.dart
 
+.PHONY: benchmark-report
+benchmark-report: ## Create a release benchmark report template
+	@./scripts/create-performance-benchmark-report.sh
+
+.PHONY: benchmark-gemini-warmup
+benchmark-gemini-warmup: ## Run the Gemini Nano warmup integration path used in release benchmarks
+	@echo "$(BLUE)Running Gemini Nano warmup benchmark path...$(NC)"
+	@cd $(APP_DIR) && rm -rf ios/Flutter/ephemeral/Packages/.packages macos/Flutter/ephemeral/Packages/.packages
+	@cd $(APP_DIR) && flutter test test/core/services/gemini_nano_service_test.dart
+
+.PHONY: benchmark-android-startup
+benchmark-android-startup: ## Capture Android startup timing on a connected device
+	@if [ ! -x "$(ADB)" ]; then \
+		echo "$(RED)adb not found at $(ADB).$(NC)"; \
+		exit 1; \
+	fi
+	@if ! "$(ADB)" devices | awk 'NR>1 && $$2=="device" { found=1 } END { exit found?0:1 }'; then \
+		echo "$(RED)No connected Android device detected.$(NC)"; \
+		echo "$(YELLOW)Use a physical device or opt in to the emulator path separately.$(NC)"; \
+		exit 1; \
+	fi
+	@"$(ADB)" shell am force-stop "$(ANDROID_PACKAGE)"
+	@"$(ADB)" shell am start -W "$(ANDROID_PACKAGE)/.MainActivity"
+
 # IPTV Data Pipeline Commands
 .PHONY: iptv-install-deps
 iptv-install-deps: ## Install local IPTV pipeline dependencies

--- a/app/test/core/services/gemini_nano_service_test.dart
+++ b/app/test/core/services/gemini_nano_service_test.dart
@@ -50,4 +50,30 @@ void main() {
       expect(warmed, isFalse);
     },
   );
+
+  test(
+    'support check, initialize, and warmup can be exercised in one host run',
+    () async {
+      final calls = <String>[];
+      messenger.setMockMethodCallHandler(channel, (call) async {
+        calls.add(call.method);
+        return switch (call.method) {
+          'isAvailable' => true,
+          'initialize' => true,
+          'warmup' => true,
+          _ => fail('Unexpected method call: ${call.method}'),
+        };
+      });
+
+      final service = GeminiNanoService();
+      final isSupported = await service.isSupported();
+      final initialized = isSupported && await service.initialize();
+      final warmed = initialized && await service.warmup();
+
+      expect(isSupported, isTrue);
+      expect(initialized, isTrue);
+      expect(warmed, isTrue);
+      expect(calls, ['isAvailable', 'isAvailable', 'initialize', 'warmup']);
+    },
+  );
 }

--- a/docs/release/PERFORMANCE_BENCHMARKS.md
+++ b/docs/release/PERFORMANCE_BENCHMARKS.md
@@ -1,0 +1,102 @@
+# Performance Benchmarks
+
+Airo release validation now requires a benchmark artifact, not just a verbal
+claim that the app feels fast.
+
+Use this runbook with issue `#520` and the release checklist in
+[`docs/release/RELEASE_CHECKLIST.md`](./RELEASE_CHECKLIST.md).
+
+## Output Artifact
+
+Create a benchmark report before release:
+
+```bash
+make benchmark-report
+```
+
+Default output:
+
+```text
+artifacts/performance/YYYY-MM-DD-release-benchmark.md
+```
+
+Fill in the measured results, attach profiler screenshots if used, and link the
+report from the release PR or release notes.
+
+## Benchmark Matrix
+
+| Metric | Why it matters | Environment | Minimum evidence |
+| --- | --- | --- | --- |
+| Cold start | Verifies startup regression | Physical Android preferred | `adb shell am start -W` result captured in report |
+| Warm start | Detects lifecycle regressions | Physical Android preferred | `adb shell am start -W` result captured in report |
+| Model loading time | Verifies on-device AI readiness | Host-only or Android | `make benchmark-gemini-warmup` output |
+| First transcript latency | Verifies meeting responsiveness | Physical Android | Manual timed run recorded in report |
+| Summary generation time | Verifies end-to-end AI flow | Physical Android | Manual timed run recorded in report |
+| Embedding speed | Verifies retrieval/indexing cost | Physical Android | Manual timed run recorded in report |
+| Speaker detection latency | Verifies meeting pipeline | Physical Android | Manual timed run recorded in report |
+| Memory usage | Detects OOM risk and retention leaks | Android | `adb shell dumpsys meminfo` snapshot |
+| CPU usage | Detects runaway loops and thermal risk | Android | profiler or `top` sample linked in report |
+| GPU/NPU utilization | Verifies on-device acceleration path | Android | profiler screenshot or tooling note |
+| Battery consumption | Detects release-unfriendly workloads | Physical Android | `batterystats` or Battery Historian export |
+| Storage growth | Verifies model/download storage impact | Android | before/after storage capture |
+
+## Host-Only Checks
+
+These are safe on a laptop CI-style host and should be run on every benchmark
+iteration:
+
+```bash
+make benchmark-gemini-warmup
+make test-integration
+```
+
+`benchmark-gemini-warmup` is the minimum host-runnable proof that the Gemini
+Nano support check, initialize path, and warmup path are still wired correctly
+without requiring a connected device.
+
+## Android Device Checks
+
+Prefer a physical Android device. Use the emulator only when the issue accepts
+`AIRO_ALLOW_ANDROID_EMULATOR=true`.
+
+### Startup timing
+
+```bash
+adb shell am force-stop io.airo.app
+adb shell am start -W io.airo.app/.MainActivity
+```
+
+Capture `TotalTime`, `WaitTime`, and `ThisTime` in the report.
+
+### Memory snapshot
+
+```bash
+adb shell dumpsys meminfo io.airo.app
+```
+
+### Battery snapshot
+
+```bash
+adb shell dumpsys batterystats --reset
+# run the benchmark scenario
+adb shell dumpsys batterystats io.airo.app
+```
+
+### Storage snapshot
+
+```bash
+adb shell run-as io.airo.app du -sh files cache 2>/dev/null
+```
+
+If `run-as` is unavailable on the target build, record the same measurement from
+the Android app info storage UI.
+
+## Release Rule
+
+Do not mark release validation complete until:
+
+1. A benchmark report exists under `artifacts/performance/` or is attached to
+   the release PR.
+2. Host-only checks have been rerun on the release candidate.
+3. Physical Android-only metrics are either captured or explicitly waived with
+   a linked reason.

--- a/docs/release/RELEASE_CHECKLIST.md
+++ b/docs/release/RELEASE_CHECKLIST.md
@@ -23,6 +23,8 @@ Pre-release verification checklist for Airo Super App releases.
 - [ ] Integration tests passing
 - [ ] E2E smoke tests passing
 - [ ] Shared UI responsiveness suite passing (`make test-ui-responsive`)
+- [ ] Performance benchmark report created (`artifacts/performance/...`)
+- [ ] Battery impact measurements attached or explicitly waived
 - [ ] Manual QA sign-off (if required)
 
 ---
@@ -35,6 +37,8 @@ Pre-release verification checklist for Airo Super App releases.
 - [ ] AAB (App Bundle) generates correctly
 - [ ] APK size within acceptable limits (<100MB)
 - [ ] ProGuard/R8 rules applied correctly
+- [ ] Cold and warm startup timings recorded
+- [ ] Android memory/storage snapshots attached
 
 ### iOS
 - [ ] Release build compiles
@@ -115,6 +119,7 @@ Pre-release verification checklist for Airo Super App releases.
 - [ ] Known issues documented
 - [ ] Migration guide (if breaking changes)
 - [ ] [UI responsiveness validation runbook](./UI_RESPONSIVENESS_VALIDATION.md) followed
+- [ ] [Performance benchmark runbook](./PERFORMANCE_BENCHMARKS.md) followed
 
 ---
 
@@ -145,3 +150,4 @@ Date: ____-__-__
 - [Rollback Procedure](./ROLLBACK_PROCEDURE.md)
 - [Store Compliance](./STORE_COMPLIANCE.md)
 - [UI Responsiveness Validation](./UI_RESPONSIVENESS_VALIDATION.md)
+- [Performance Benchmarks](./PERFORMANCE_BENCHMARKS.md)

--- a/scripts/create-performance-benchmark-report.sh
+++ b/scripts/create-performance-benchmark-report.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: create-performance-benchmark-report.sh [output-file]
+
+Creates a markdown report template for release benchmark capture.
+
+If no output file is supplied, the script writes to:
+  artifacts/performance/YYYY-MM-DD-release-benchmark.md
+EOF
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+  usage
+  exit 0
+fi
+
+report_date="$(date +%F)"
+output_file="${1:-artifacts/performance/${report_date}-release-benchmark.md}"
+mkdir -p "$(dirname "$output_file")"
+
+cat > "$output_file" <<EOF
+# Release Performance Benchmark Report
+
+- Date: ${report_date}
+- Release / branch:
+- Device class:
+- OS / build:
+- Operator:
+
+## Execution Environment
+
+- Host-only checks run:
+- Physical Android device used:
+- Android emulator used:
+- Notes:
+
+## Required Metrics
+
+| Metric | Scenario | Environment | Command / source | Result | Pass/Fail | Notes |
+| --- | --- | --- | --- | --- | --- | --- |
+| Cold start | Full app launch from terminated state | Physical Android preferred | \`adb shell am start -W ...\` | | | |
+| Warm start | Relaunch after recent open | Physical Android preferred | \`adb shell am start -W ...\` | | | |
+| Model loading time | Gemini Nano warm path | Host or Android | \`make benchmark-gemini-warmup\` | | | |
+| First transcript latency | Meeting flow sample | Physical Android | Manual scripted run | | | |
+| Summary generation time | Meeting flow sample | Physical Android | Manual scripted run | | | |
+| Embedding speed | Representative local AI task | Physical Android | Manual scripted run | | | |
+| Speaker detection latency | Meeting flow sample | Physical Android | Manual scripted run | | | |
+| Memory usage | App steady state during benchmark | Android | \`adb shell dumpsys meminfo\` | | | |
+| CPU usage | App active benchmark window | Android | Android Studio / \`top\` sample | | | |
+| GPU/NPU utilization | On-device AI workload | Android | Vendor tooling / profiler | | | |
+| Battery consumption | Full benchmark pass | Physical Android | \`adb shell dumpsys batterystats\` or Battery Historian | | | |
+| Storage growth | Before vs after model/download run | Android | \`adb shell du\` / app storage screen | | | |
+
+## Release Decision
+
+- Blocking regressions:
+- Follow-up issues:
+- Attached artifacts:
+
+## Raw Notes
+
+- 
+EOF
+
+echo "Created benchmark report template: $output_file"


### PR DESCRIPTION
# Summary

This PR adds the first concrete workflow for issue #520.
Goal: make release performance validation executable and reviewable instead of a loose checklist item.

Core outcome:

* add a benchmark runbook and release report template
* add local commands for report creation, host Gemini Nano warmup validation, and Android startup timing capture

# Changes

### Code

* Added:

  * `docs/release/PERFORMANCE_BENCHMARKS.md` to define the benchmark matrix, environments, and evidence requirements
  * `scripts/create-performance-benchmark-report.sh` to generate a benchmark artifact template under `artifacts/performance/`
* Updated:

  * `Makefile` with benchmark-oriented targets
  * `docs/release/RELEASE_CHECKLIST.md` to require benchmark and battery artifacts during release validation
  * `app/test/core/services/gemini_nano_service_test.dart` with a host-only support-check → initialize → warmup sequence used by the benchmark flow

### Logic

* release validation now has a documented benchmark artifact path
* host-only verification covers the Gemini Nano warmup sequence without requiring a device
* Android startup timing has an explicit adb-based capture command for connected devices

# Performance Impact

* Latency: no runtime behavior change
* Throughput: no runtime behavior change
* Memory/CPU: no runtime behavior change

# Risks

* this PR does not by itself produce release benchmark numbers; it establishes the workflow to collect them
* physical Android-only metrics still require a maintainer to run the documented steps on release candidates
* Rollback plan:

  * revert this PR to remove the benchmark workflow scaffolding

# Testing

* Unit tests:

  * `make benchmark-gemini-warmup`
* Manual testing:

  * `./scripts/create-performance-benchmark-report.sh /tmp/airo-benchmark-report.md`
  * `flutter analyze test/core/services/gemini_nano_service_test.dart`

# Related Commits

* `chore(release): add benchmark workflow scaffolding`

# Notes

* Addresses #520 but does not close it yet. The remaining work is to capture real release benchmark artifacts with this workflow.
