### PR TITLE
feat(core-domain): add LifeTrack state machine

### DIFF
--- a/packages/core_data/test/storage/life_track_local_data_source_test.dart
+++ b/packages/core_data/test/storage/life_track_local_data_source_test.dart
@@ -32,7 +32,7 @@ void main() {
 
     expect(stored, isNotNull);
     expect(stored, track);
-    expect(stored!.progress, closeTo(0.75, 0.0001));
+    expect(stored!.progress, closeTo(2 / 3, 0.0001));
   });
 
   test('filters tracks by status', () async {

--- a/packages/core_domain/lib/core_domain.dart
+++ b/packages/core_domain/lib/core_domain.dart
@@ -32,6 +32,7 @@ export 'src/use_cases/use_case.dart';
 // State Management
 export 'src/state/async_state.dart';
 export 'src/state/paginated_state.dart';
+export 'src/state/track_state_machine.dart';
 
 // Plugin System
 export 'src/plugins/plugin_manifest.dart';

--- a/packages/core_domain/lib/src/entities/life_track.dart
+++ b/packages/core_domain/lib/src/entities/life_track.dart
@@ -43,12 +43,21 @@ class LifeTrack extends Entity {
   final String? templateId;
 
   double get progress {
-    if (milestones.isEmpty) return 0;
-    final total = milestones.fold<double>(
-      0,
-      (sum, milestone) => sum + milestone.progress,
-    );
-    return total / milestones.length;
+    var completed = 0;
+    var total = 0;
+
+    for (final milestone in milestones) {
+      for (final item in milestone.actionItems) {
+        if (item.status == ItemStatus.skipped) continue;
+        total++;
+        if (item.status == ItemStatus.done) {
+          completed++;
+        }
+      }
+    }
+
+    if (total == 0) return 0;
+    return completed / total;
   }
 
   factory LifeTrack.fromJson(Map<String, dynamic> json) => LifeTrack(

--- a/packages/core_domain/lib/src/errors/app_error.dart
+++ b/packages/core_domain/lib/src/errors/app_error.dart
@@ -1,3 +1,5 @@
+import '../entities/life_track.dart';
+
 /// Base application error
 class AppError implements Exception {
   final String code;
@@ -64,6 +66,22 @@ class ValidationError extends AppError {
          'VALIDATION_ERROR',
          message,
          statusCode: statusCode,
+         originalError: originalError,
+         originalStack: originalStack,
+       );
+}
+
+/// Lifecycle transition errors
+class InvalidStatusTransitionError extends AppError {
+  InvalidStatusTransitionError(
+    ItemStatus from,
+    ItemStatus to, {
+    Object? originalError,
+    StackTrace? originalStack,
+  }) : super(
+         'INVALID_STATUS_TRANSITION',
+         'Cannot transition item status from ${from.name} to ${to.name}.',
+         statusCode: 400,
          originalError: originalError,
          originalStack: originalStack,
        );

--- a/packages/core_domain/lib/src/state/track_state_machine.dart
+++ b/packages/core_domain/lib/src/state/track_state_machine.dart
@@ -1,0 +1,78 @@
+import '../entities/life_track.dart';
+import '../entities/milestone.dart';
+import '../errors/app_error.dart';
+
+class TrackStateMachine {
+  const TrackStateMachine._();
+
+  static const Map<ItemStatus, Set<ItemStatus>> _transitions = {
+    ItemStatus.todo: {ItemStatus.inProgress, ItemStatus.skipped},
+    ItemStatus.inProgress: {
+      ItemStatus.done,
+      ItemStatus.blocked,
+      ItemStatus.todo,
+    },
+    ItemStatus.blocked: {
+      ItemStatus.inProgress,
+      ItemStatus.todo,
+      ItemStatus.skipped,
+    },
+    ItemStatus.done: {ItemStatus.todo},
+    ItemStatus.skipped: {ItemStatus.todo},
+  };
+
+  static bool canTransition(ItemStatus from, ItemStatus to) {
+    return _transitions[from]?.contains(to) ?? false;
+  }
+
+  static ItemStatus transition(ItemStatus from, ItemStatus to) {
+    if (!canTransition(from, to)) {
+      throw InvalidStatusTransitionError(from, to);
+    }
+    return to;
+  }
+
+  static double milestoneProgress(Milestone milestone) => milestone.progress;
+
+  static double trackProgress(LifeTrack track) {
+    var completed = 0;
+    var total = 0;
+
+    for (final milestone in track.milestones) {
+      for (final item in milestone.actionItems) {
+        if (item.status == ItemStatus.skipped) {
+          continue;
+        }
+        total++;
+        if (item.status == ItemStatus.done) {
+          completed++;
+        }
+      }
+    }
+
+    if (total == 0) return 0;
+    return completed / total;
+  }
+
+  static TrackStatus computeTrackStatus(LifeTrack track) {
+    if (track.status == TrackStatus.archived ||
+        track.status == TrackStatus.postponed) {
+      return track.status;
+    }
+
+    final items = track.milestones.expand((milestone) => milestone.actionItems);
+    if (items.isEmpty) return TrackStatus.draft;
+
+    final allResolved = items.every(
+      (item) =>
+          item.status == ItemStatus.done || item.status == ItemStatus.skipped,
+    );
+    if (allResolved) return TrackStatus.completed;
+
+    final hasStarted = items.any((item) => item.status != ItemStatus.todo);
+    return hasStarted ? TrackStatus.active : TrackStatus.draft;
+  }
+
+  static bool isSuppressed(TrackStatus status) =>
+      status == TrackStatus.postponed;
+}

--- a/packages/core_domain/test/entities/life_track_test.dart
+++ b/packages/core_domain/test/entities/life_track_test.dart
@@ -103,8 +103,8 @@ void main() {
       expect(milestoneTwo.progress, 1.0);
     });
 
-    test('computes track progress as average milestone progress', () {
-      expect(track.progress, 0.75);
+    test('computes track progress as weighted item completion', () {
+      expect(track.progress, closeTo(2 / 3, 0.0001));
     });
 
     test(

--- a/packages/core_domain/test/state/track_state_machine_test.dart
+++ b/packages/core_domain/test/state/track_state_machine_test.dart
@@ -1,0 +1,298 @@
+import 'package:core_domain/core_domain.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('TrackStateMachine.canTransition', () {
+    test('allows only the documented transitions', () {
+      const statuses = ItemStatus.values;
+      const expected = <ItemStatus, Set<ItemStatus>>{
+        ItemStatus.todo: {ItemStatus.inProgress, ItemStatus.skipped},
+        ItemStatus.inProgress: {
+          ItemStatus.done,
+          ItemStatus.blocked,
+          ItemStatus.todo,
+        },
+        ItemStatus.blocked: {
+          ItemStatus.inProgress,
+          ItemStatus.todo,
+          ItemStatus.skipped,
+        },
+        ItemStatus.done: {ItemStatus.todo},
+        ItemStatus.skipped: {ItemStatus.todo},
+      };
+
+      for (final from in statuses) {
+        for (final to in statuses) {
+          expect(
+            TrackStateMachine.canTransition(from, to),
+            expected[from]!.contains(to),
+            reason:
+                'Unexpected transition result for ${from.name} -> ${to.name}',
+          );
+        }
+      }
+    });
+  });
+
+  group('TrackStateMachine.transition', () {
+    test('returns the target status for valid transitions', () {
+      expect(
+        TrackStateMachine.transition(ItemStatus.todo, ItemStatus.inProgress),
+        ItemStatus.inProgress,
+      );
+      expect(
+        TrackStateMachine.transition(ItemStatus.blocked, ItemStatus.skipped),
+        ItemStatus.skipped,
+      );
+      expect(
+        TrackStateMachine.transition(ItemStatus.done, ItemStatus.todo),
+        ItemStatus.todo,
+      );
+    });
+
+    test('throws for invalid transitions', () {
+      expect(
+        () => TrackStateMachine.transition(
+          ItemStatus.done,
+          ItemStatus.inProgress,
+        ),
+        throwsA(isA<InvalidStatusTransitionError>()),
+      );
+      expect(
+        () => TrackStateMachine.transition(ItemStatus.todo, ItemStatus.blocked),
+        throwsA(isA<InvalidStatusTransitionError>()),
+      );
+    });
+  });
+
+  group('TrackStateMachine progress', () {
+    test('computes milestone progress with skipped items excluded', () {
+      expect(
+        TrackStateMachine.milestoneProgress(_sampleMilestoneOne),
+        closeTo(0.5, 0.0001),
+      );
+      expect(
+        TrackStateMachine.milestoneProgress(_sampleMilestoneTwo),
+        closeTo(1, 0.0001),
+      );
+    });
+
+    test('computes track progress as weighted item completion', () {
+      final track = _sampleTrack(
+        milestones: [_sampleMilestoneOne, _sampleMilestoneTwo],
+      );
+
+      expect(TrackStateMachine.trackProgress(track), closeTo(2 / 3, 0.0001));
+    });
+
+    test('returns zero for empty and skipped-only tracks', () {
+      final skippedOnly = _sampleTrack(
+        milestones: [
+          Milestone(
+            id: 'skipped-milestone',
+            trackId: 'track-skipped',
+            name: 'Skipped only',
+            objective: 'Optional steps',
+            sortOrder: 0,
+            status: ItemStatus.skipped,
+            actionItems: [
+              _item(
+                id: 'skipped-item',
+                milestoneId: 'skipped-milestone',
+                status: ItemStatus.skipped,
+              ),
+            ],
+          ),
+        ],
+      );
+
+      expect(
+        TrackStateMachine.trackProgress(_sampleTrack(milestones: const [])),
+        0,
+      );
+      expect(TrackStateMachine.trackProgress(skippedOnly), 0);
+    });
+  });
+
+  group('TrackStateMachine.computeTrackStatus', () {
+    test('keeps archived and postponed tracks suppressed', () {
+      expect(
+        TrackStateMachine.computeTrackStatus(
+          _sampleTrack(status: TrackStatus.archived),
+        ),
+        TrackStatus.archived,
+      );
+      expect(
+        TrackStateMachine.computeTrackStatus(
+          _sampleTrack(status: TrackStatus.postponed),
+        ),
+        TrackStatus.postponed,
+      );
+      expect(TrackStateMachine.isSuppressed(TrackStatus.postponed), isTrue);
+      expect(TrackStateMachine.isSuppressed(TrackStatus.active), isFalse);
+    });
+
+    test('returns draft when no work has started', () {
+      final draftTrack = _sampleTrack(
+        status: TrackStatus.draft,
+        milestones: [
+          Milestone(
+            id: 'todo-milestone',
+            trackId: 'track-draft',
+            name: 'Todo',
+            objective: 'Pending',
+            sortOrder: 0,
+            status: ItemStatus.todo,
+            actionItems: [
+              _item(
+                id: 'todo-item',
+                milestoneId: 'todo-milestone',
+                status: ItemStatus.todo,
+              ),
+            ],
+          ),
+        ],
+      );
+
+      expect(
+        TrackStateMachine.computeTrackStatus(draftTrack),
+        TrackStatus.draft,
+      );
+    });
+
+    test('returns active once any item has started or been resolved', () {
+      expect(
+        TrackStateMachine.computeTrackStatus(_sampleTrack()),
+        TrackStatus.active,
+      );
+      expect(
+        TrackStateMachine.computeTrackStatus(
+          _sampleTrack(
+            milestones: [
+              Milestone(
+                id: 'done-milestone',
+                trackId: 'track-active',
+                name: 'Started',
+                objective: 'Partially done',
+                sortOrder: 0,
+                status: ItemStatus.done,
+                actionItems: [
+                  _item(
+                    id: 'done-item',
+                    milestoneId: 'done-milestone',
+                    status: ItemStatus.done,
+                  ),
+                  _item(
+                    id: 'todo-item',
+                    milestoneId: 'done-milestone',
+                    status: ItemStatus.todo,
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ),
+        TrackStatus.active,
+      );
+    });
+
+    test('returns completed when all items are done or skipped', () {
+      final completedTrack = _sampleTrack(
+        milestones: [
+          Milestone(
+            id: 'complete-milestone',
+            trackId: 'track-complete',
+            name: 'Complete',
+            objective: 'All resolved',
+            sortOrder: 0,
+            status: ItemStatus.done,
+            actionItems: [
+              _item(
+                id: 'done-item',
+                milestoneId: 'complete-milestone',
+                status: ItemStatus.done,
+              ),
+              _item(
+                id: 'skipped-item',
+                milestoneId: 'complete-milestone',
+                status: ItemStatus.skipped,
+              ),
+            ],
+          ),
+        ],
+      );
+
+      expect(
+        TrackStateMachine.computeTrackStatus(completedTrack),
+        TrackStatus.completed,
+      );
+    });
+
+    test('returns draft for empty tracks', () {
+      expect(
+        TrackStateMachine.computeTrackStatus(
+          _sampleTrack(milestones: const []),
+        ),
+        TrackStatus.draft,
+      );
+    });
+  });
+}
+
+final _sampleMilestoneOne = Milestone(
+  id: 'milestone-1',
+  trackId: 'track-1',
+  name: 'Phase 1',
+  objective: 'Legal verification',
+  sortOrder: 0,
+  status: ItemStatus.inProgress,
+  actionItems: [
+    _item(id: 'item-1', milestoneId: 'milestone-1', status: ItemStatus.done),
+    _item(id: 'item-2', milestoneId: 'milestone-1', status: ItemStatus.blocked),
+  ],
+);
+
+final _sampleMilestoneTwo = Milestone(
+  id: 'milestone-2',
+  trackId: 'track-1',
+  name: 'Phase 2',
+  objective: 'Agreement checks',
+  sortOrder: 1,
+  status: ItemStatus.todo,
+  actionItems: [
+    _item(id: 'item-3', milestoneId: 'milestone-2', status: ItemStatus.skipped),
+    _item(id: 'item-4', milestoneId: 'milestone-2', status: ItemStatus.done),
+  ],
+);
+
+LifeTrack _sampleTrack({
+  TrackStatus status = TrackStatus.active,
+  List<Milestone>? milestones,
+}) {
+  return LifeTrack(
+    id: 'track-1',
+    title: 'Buy Under-Construction Flat',
+    category: LifeTrackCategory.realEstate,
+    status: status,
+    milestones: milestones ?? [_sampleMilestoneOne, _sampleMilestoneTwo],
+    createdAt: DateTime.utc(2026, 6, 29, 9),
+    updatedAt: DateTime.utc(2026, 6, 29, 12),
+    templateId: 'real_estate_under_construction_v1',
+  );
+}
+
+ActionItem _item({
+  required String id,
+  required String milestoneId,
+  required ItemStatus status,
+}) {
+  return ActionItem(
+    id: id,
+    milestoneId: milestoneId,
+    summary: id,
+    status: status,
+    requirements: const [],
+    createdAt: DateTime.utc(2026, 6, 29, 10),
+    updatedAt: DateTime.utc(2026, 6, 29, 11),
+  );
+}


### PR DESCRIPTION
# Summary

This PR implements the deterministic LifeTrack state machine required by #335.
Goal: enforce documented item transitions and align LifeTrack progress/status semantics with the framework rules.

Core outcome:
- adds a reusable `TrackStateMachine` API for item transitions, progress, and track status derivation
- updates `LifeTrack.progress` to use weighted item completion instead of a plain milestone average

# Changes

### Code

* Added:
* `packages/core_domain/lib/src/state/track_state_machine.dart`
* `InvalidStatusTransitionError` in `packages/core_domain/lib/src/errors/app_error.dart`
* exhaustive state-machine tests in `packages/core_domain/test/state/track_state_machine_test.dart`
* Updated:
* `packages/core_domain/lib/src/entities/life_track.dart` to use weighted progress semantics
* `packages/core_domain/lib/core_domain.dart` exports for the new API
* existing LifeTrack and persistence tests to match the documented progress rule

### Logic

* Enforces only the allowed `ItemStatus` transitions from the issue contract
* Computes track progress from non-skipped action items across all milestones
* Derives `TrackStatus` deterministically while preserving explicit `archived` and `postponed` states
* Treats skipped-only and empty tracks as zero-progress edge cases

# API Changes

* No external network/API changes.

# Database Changes

* None.

# Observability / Logging

* None.

# Performance Impact

* Negligible. Progress/status calculations are linear over in-memory action items.

# Risks

* Existing callers that assumed plain milestone averaging will now see weighted progress values.
* Rollback plan:
* revert this PR to restore previous progress semantics and remove the state-machine API.

# Testing

* Unit tests:
* `flutter test test/state/track_state_machine_test.dart test/entities/life_track_test.dart` in `packages/core_domain`
* `flutter test test/storage/life_track_local_data_source_test.dart` in `packages/core_data`
* Analyze:
* `flutter analyze lib test` in `packages/core_domain`
* `flutter analyze lib test` in `packages/core_data`

# Deployment Notes

* No config changes.

# Related Commits

* `feat(core-domain): add LifeTrack state machine`

# Notes

* Repository-root `flutter analyze` is currently noisy for unrelated workspace/package wiring outside this change, so verification was run at the affected package boundaries.

Closes #335.
