### PR TITLE
feat(core-domain): add LifeTrack use cases

### DIFF
--- a/packages/core_data/lib/src/storage/life_track_local_data_source.dart
+++ b/packages/core_data/lib/src/storage/life_track_local_data_source.dart
@@ -51,7 +51,9 @@ class LifeTrackLocalDataSource {
 
   Future<LifeTrack> createTrack(LifeTrack track) async {
     final db = await _requireDatabase();
-    await _insertTrackGraph(db, track);
+    await db.transaction((txn) async {
+      await _insertTrackGraph(txn, track);
+    });
     await _notifyChanged();
     return track;
   }

--- a/packages/core_data/test/storage/life_track_local_data_source_test.dart
+++ b/packages/core_data/test/storage/life_track_local_data_source_test.dart
@@ -51,15 +51,13 @@ void main() {
   });
 
   test('watchTracks emits after mutation', () async {
-    final events = <List<LifeTrack>>[];
-    final subscription = dataSource.watchTracks().listen(events.add);
+    final stream = dataSource.watchTracks();
+    final nextNonEmpty = stream.firstWhere((tracks) => tracks.isNotEmpty);
 
     await dataSource.createTrack(_sampleTrack());
-    await Future<void>.delayed(Duration.zero);
+    final emitted = await nextNonEmpty;
 
-    expect(events, isNotEmpty);
-    expect(events.last.single.id, 'track-1');
-    await subscription.cancel();
+    expect(emitted.single.id, 'track-1');
   });
 
   test('cascade delete removes nested rows', () async {

--- a/packages/core_domain/lib/core_domain.dart
+++ b/packages/core_domain/lib/core_domain.dart
@@ -28,6 +28,7 @@ export 'src/repositories/life_track_repository.dart';
 
 // Use Cases
 export 'src/use_cases/use_case.dart';
+export 'src/use_cases/life_track_use_cases.dart';
 
 // State Management
 export 'src/state/async_state.dart';

--- a/packages/core_domain/lib/src/use_cases/life_track_use_cases.dart
+++ b/packages/core_domain/lib/src/use_cases/life_track_use_cases.dart
@@ -1,0 +1,212 @@
+import 'dart:convert';
+
+import '../entities/action_item.dart';
+import '../entities/life_track.dart';
+import '../errors/app_error.dart';
+import '../repositories/life_track_repository.dart';
+import '../result/result.dart';
+import '../state/track_state_machine.dart';
+import 'use_case.dart';
+
+class CreateTrackUseCase implements UseCase<LifeTrack, LifeTrack> {
+  CreateTrackUseCase(this._repository);
+
+  final LifeTrackRepository _repository;
+
+  @override
+  Future<Result<LifeTrack>> call(LifeTrack input) {
+    return _repository.createTrack(input);
+  }
+}
+
+class ListTracksQuery {
+  const ListTracksQuery({this.status, this.category});
+
+  final TrackStatus? status;
+  final LifeTrackCategory? category;
+}
+
+class ListTracksUseCase implements UseCase<ListTracksQuery, List<LifeTrack>> {
+  ListTracksUseCase(this._repository);
+
+  final LifeTrackRepository _repository;
+
+  @override
+  Future<Result<List<LifeTrack>>> call(ListTracksQuery input) async {
+    final result = await _repository.listTracks(status: input.status);
+    if (result case Err<List<LifeTrack>>()) {
+      return result;
+    }
+
+    final tracks = result.value;
+    if (input.category == null) {
+      return Ok(tracks);
+    }
+
+    return Ok(
+      tracks
+          .where((track) => track.category == input.category)
+          .toList(growable: false),
+    );
+  }
+}
+
+class GetTrackDetailUseCase implements UseCase<String, LifeTrack> {
+  GetTrackDetailUseCase(this._repository);
+
+  final LifeTrackRepository _repository;
+
+  @override
+  Future<Result<LifeTrack>> call(String input) {
+    return _repository.getTrack(input);
+  }
+}
+
+class UpdateItemStatusCommand {
+  const UpdateItemStatusCommand({
+    required this.trackId,
+    required this.itemId,
+    required this.status,
+  });
+
+  final String trackId;
+  final String itemId;
+  final ItemStatus status;
+}
+
+class UpdateItemStatusUseCase
+    implements UseCase<UpdateItemStatusCommand, LifeTrack> {
+  UpdateItemStatusUseCase(this._repository);
+
+  final LifeTrackRepository _repository;
+
+  @override
+  Future<Result<LifeTrack>> call(UpdateItemStatusCommand input) async {
+    final trackResult = await _repository.getTrack(input.trackId);
+    if (trackResult case Err<LifeTrack>()) {
+      return trackResult;
+    }
+
+    try {
+      final now = DateTime.now().toUtc();
+      final updatedTrack = _updateTrackItemStatus(
+        trackResult.value,
+        input.itemId,
+        input.status,
+        now,
+      );
+      final saveResult = await _repository.updateTrack(updatedTrack);
+      if (saveResult case Err<void>(error: final error, stack: final stack)) {
+        return Err(error, stack);
+      }
+      return Ok(updatedTrack);
+    } catch (error, stack) {
+      return Err(error, stack);
+    }
+  }
+
+  LifeTrack _updateTrackItemStatus(
+    LifeTrack track,
+    String itemId,
+    ItemStatus targetStatus,
+    DateTime updatedAt,
+  ) {
+    var found = false;
+    final updatedMilestones = track.milestones
+        .map((milestone) {
+          var changed = false;
+          final updatedItems = milestone.actionItems
+              .map((item) {
+                if (item.id != itemId) return item;
+
+                found = true;
+                changed = true;
+                TrackStateMachine.transition(item.status, targetStatus);
+                return item.copyWith(
+                  status: targetStatus,
+                  updatedAt: updatedAt,
+                );
+              })
+              .toList(growable: false);
+
+          if (!changed) return milestone;
+          return milestone.copyWith(
+            actionItems: updatedItems,
+            status: _deriveMilestoneStatus(updatedItems),
+          );
+        })
+        .toList(growable: false);
+
+    if (!found) {
+      throw NotFoundError('LifeTrack action item not found: $itemId');
+    }
+
+    final updatedTrack = track.copyWith(
+      milestones: updatedMilestones,
+      updatedAt: updatedAt,
+    );
+    return updatedTrack.copyWith(
+      status: TrackStateMachine.computeTrackStatus(updatedTrack),
+    );
+  }
+
+  ItemStatus _deriveMilestoneStatus(List<ActionItem> items) {
+    if (items.isEmpty) return ItemStatus.todo;
+    if (items.every((item) => item.status == ItemStatus.skipped)) {
+      return ItemStatus.skipped;
+    }
+    if (items.every(
+      (item) =>
+          item.status == ItemStatus.done || item.status == ItemStatus.skipped,
+    )) {
+      return ItemStatus.done;
+    }
+    if (items.any((item) => item.status == ItemStatus.blocked)) {
+      return ItemStatus.blocked;
+    }
+    if (items.any((item) => item.status == ItemStatus.inProgress)) {
+      return ItemStatus.inProgress;
+    }
+    if (items.any((item) => item.status == ItemStatus.done)) {
+      return ItemStatus.inProgress;
+    }
+    return ItemStatus.todo;
+  }
+}
+
+class SaveInputValueCommand {
+  const SaveInputValueCommand({
+    required this.requirementId,
+    required this.value,
+  });
+
+  final String requirementId;
+  final Object? value;
+}
+
+class SaveInputValueUseCase implements NoOutputUseCase<SaveInputValueCommand> {
+  SaveInputValueUseCase(this._repository);
+
+  final LifeTrackRepository _repository;
+
+  @override
+  Future<Result<void>> call(SaveInputValueCommand input) {
+    return _repository.saveInputValue(
+      input.requirementId,
+      _serializeValue(input.value),
+    );
+  }
+
+  String _serializeValue(Object? value) {
+    if (value == null) return '';
+    return switch (value) {
+      String text => text,
+      bool flag => flag.toString(),
+      num number => number.toString(),
+      DateTime dateTime => dateTime.toUtc().toIso8601String(),
+      Uri uri => uri.toString(),
+      Iterable<String> values => jsonEncode(values.toList(growable: false)),
+      _ => value.toString(),
+    };
+  }
+}

--- a/packages/core_domain/test/use_cases/life_track_use_cases_test.dart
+++ b/packages/core_domain/test/use_cases/life_track_use_cases_test.dart
@@ -1,0 +1,278 @@
+import 'package:core_domain/core_domain.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('LifeTrack use cases', () {
+    late _FakeLifeTrackRepository repository;
+
+    setUp(() {
+      repository = _FakeLifeTrackRepository(_sampleTrack());
+    });
+
+    test('CreateTrackUseCase delegates to the repository', () async {
+      final useCase = CreateTrackUseCase(repository);
+      final track = _sampleTrack(id: 'new-track');
+
+      final result = await useCase(track);
+
+      expect(result.value.id, 'new-track');
+      expect(repository.createdTrack, track);
+    });
+
+    test(
+      'ListTracksUseCase filters by category after repository status query',
+      () async {
+        repository.tracks = [
+          _sampleTrack(
+            id: 'real-estate',
+            category: LifeTrackCategory.realEstate,
+          ),
+          _sampleTrack(id: 'finance', category: LifeTrackCategory.finance),
+        ];
+        final useCase = ListTracksUseCase(repository);
+
+        final result = await useCase(
+          const ListTracksQuery(
+            status: TrackStatus.active,
+            category: LifeTrackCategory.finance,
+          ),
+        );
+
+        expect(repository.lastListedStatus, TrackStatus.active);
+        expect(result.value.map((track) => track.id), ['finance']);
+      },
+    );
+
+    test('GetTrackDetailUseCase returns the hydrated track', () async {
+      final useCase = GetTrackDetailUseCase(repository);
+
+      final result = await useCase('track-1');
+
+      expect(result.value.milestones.single.actionItems, hasLength(2));
+    });
+
+    test(
+      'UpdateItemStatusUseCase rewrites the track with recomputed statuses',
+      () async {
+        final useCase = UpdateItemStatusUseCase(repository);
+
+        final result = await useCase(
+          const UpdateItemStatusCommand(
+            trackId: 'track-1',
+            itemId: 'item-2',
+            status: ItemStatus.done,
+          ),
+        );
+
+        final updatedTrack = result.value;
+        expect(updatedTrack.status, TrackStatus.completed);
+        expect(updatedTrack.milestones.single.status, ItemStatus.done);
+        expect(
+          updatedTrack.milestones.single.actionItems.map((item) => item.status),
+          [ItemStatus.done, ItemStatus.done],
+        );
+        expect(repository.updatedTrack, isNotNull);
+        expect(
+          repository.updatedTrack!.updatedAt,
+          isNot(_sampleTrack().updatedAt),
+        );
+      },
+    );
+
+    test('UpdateItemStatusUseCase rejects invalid transitions', () async {
+      final useCase = UpdateItemStatusUseCase(repository);
+
+      final result = await useCase(
+        const UpdateItemStatusCommand(
+          trackId: 'track-1',
+          itemId: 'item-1',
+          status: ItemStatus.inProgress,
+        ),
+      );
+
+      expect(result, isA<Err<LifeTrack>>());
+      expect(
+        (result as Err<LifeTrack>).error,
+        isA<InvalidStatusTransitionError>(),
+      );
+    });
+
+    test(
+      'UpdateItemStatusUseCase returns not found when the item is missing',
+      () async {
+        final useCase = UpdateItemStatusUseCase(repository);
+
+        final result = await useCase(
+          const UpdateItemStatusCommand(
+            trackId: 'track-1',
+            itemId: 'missing-item',
+            status: ItemStatus.done,
+          ),
+        );
+
+        expect(result, isA<Err<LifeTrack>>());
+        expect((result as Err<LifeTrack>).error, isA<NotFoundError>());
+      },
+    );
+
+    test(
+      'SaveInputValueUseCase serializes scalar and document values',
+      () async {
+        final useCase = SaveInputValueUseCase(repository);
+
+        await useCase(
+          const SaveInputValueCommand(
+            requirementId: 'req-text',
+            value: '/tmp/contract.pdf',
+          ),
+        );
+        expect(repository.savedValues['req-text'], '/tmp/contract.pdf');
+
+        await useCase(
+          SaveInputValueCommand(
+            requirementId: 'req-date',
+            value: DateTime.utc(2026, 7, 2, 8, 30),
+          ),
+        );
+        expect(repository.savedValues['req-date'], '2026-07-02T08:30:00.000Z');
+
+        await useCase(
+          const SaveInputValueCommand(
+            requirementId: 'req-files',
+            value: ['/tmp/a.pdf', '/tmp/b.pdf'],
+          ),
+        );
+        expect(
+          repository.savedValues['req-files'],
+          '["/tmp/a.pdf","/tmp/b.pdf"]',
+        );
+      },
+    );
+  });
+}
+
+class _FakeLifeTrackRepository implements LifeTrackRepository {
+  _FakeLifeTrackRepository(LifeTrack seedTrack) : _track = seedTrack {
+    tracks = [seedTrack];
+  }
+
+  LifeTrack _track;
+  List<LifeTrack> tracks = const [];
+  LifeTrack? createdTrack;
+  LifeTrack? updatedTrack;
+  TrackStatus? lastListedStatus;
+  final Map<String, String> savedValues = {};
+
+  @override
+  Future<Result<LifeTrack>> createTrack(LifeTrack track) async {
+    createdTrack = track;
+    _track = track;
+    tracks = [track];
+    return Ok(track);
+  }
+
+  @override
+  Future<Result<void>> deleteTrack(String id) async => const Ok(null);
+
+  @override
+  Future<Result<LifeTrack>> getTrack(String id) async => Ok(_track);
+
+  @override
+  Future<Result<List<LifeTrack>>> listTracks({TrackStatus? status}) async {
+    lastListedStatus = status;
+    if (status == null) {
+      return Ok(tracks);
+    }
+    return Ok(
+      tracks.where((track) => track.status == status).toList(growable: false),
+    );
+  }
+
+  @override
+  Future<Result<void>> saveInputValue(
+    String requirementId,
+    String value,
+  ) async {
+    savedValues[requirementId] = value;
+    return const Ok(null);
+  }
+
+  @override
+  Future<Result<void>> updateActionItem(ActionItem item) async =>
+      const Ok(null);
+
+  @override
+  Future<Result<void>> updateItemStatus(
+    String itemId,
+    ItemStatus status,
+  ) async => const Ok(null);
+
+  @override
+  Future<Result<void>> updateMilestone(Milestone milestone) async =>
+      const Ok(null);
+
+  @override
+  Future<Result<void>> updateTrack(LifeTrack track) async {
+    updatedTrack = track;
+    _track = track;
+    tracks = [track];
+    return const Ok(null);
+  }
+
+  @override
+  Stream<List<LifeTrack>> watchTracks({TrackStatus? status}) async* {
+    yield tracks;
+  }
+}
+
+LifeTrack _sampleTrack({
+  String id = 'track-1',
+  LifeTrackCategory category = LifeTrackCategory.realEstate,
+}) {
+  return LifeTrack(
+    id: id,
+    title: 'Flat Purchase',
+    category: category,
+    status: TrackStatus.active,
+    milestones: [
+      Milestone(
+        id: 'milestone-1',
+        trackId: id,
+        name: 'Verification',
+        objective: 'Finish all checks',
+        sortOrder: 0,
+        status: ItemStatus.inProgress,
+        actionItems: [
+          ActionItem(
+            id: 'item-1',
+            milestoneId: 'milestone-1',
+            summary: 'RERA check',
+            status: ItemStatus.done,
+            requirements: const [
+              InputRequirement(
+                id: 'req-1',
+                actionItemId: 'item-1',
+                label: 'Upload proof',
+                fieldType: FieldType.document,
+                isRequired: true,
+              ),
+            ],
+            createdAt: DateTime.utc(2026, 6, 29, 9),
+            updatedAt: DateTime.utc(2026, 6, 29, 10),
+          ),
+          ActionItem(
+            id: 'item-2',
+            milestoneId: 'milestone-1',
+            summary: 'Loan approval',
+            status: ItemStatus.inProgress,
+            requirements: const [],
+            createdAt: DateTime.utc(2026, 6, 29, 9),
+            updatedAt: DateTime.utc(2026, 6, 29, 10),
+          ),
+        ],
+      ),
+    ],
+    createdAt: DateTime.utc(2026, 6, 29, 8),
+    updatedAt: DateTime.utc(2026, 6, 29, 11),
+  );
+}


### PR DESCRIPTION
# Summary

This PR implements the LifeTrack application use-case layer required by #344.
Goal: decouple callers from raw repository operations while preserving deterministic status and persistence behavior.

Core outcome:
- adds the LifeTrack create/list/detail/update/save use cases in `core_domain`
- routes item-status mutations through the deterministic state machine and stores full-track updates safely

# Changes

### Code

* Added:
* `packages/core_domain/lib/src/use_cases/life_track_use_cases.dart`
* `packages/core_domain/test/use_cases/life_track_use_cases_test.dart`
* Updated:
* `packages/core_domain/lib/core_domain.dart` exports for the new use-case API
* `packages/core_data/lib/src/storage/life_track_local_data_source.dart` to create track graphs inside a SQLite transaction
* `packages/core_data/test/storage/life_track_local_data_source_test.dart` to wait for the actual watch-stream emission

### Logic

* `CreateTrackUseCase` delegates full-track creation through the repository contract
* `ListTracksUseCase` supports category filtering on top of the existing status query
* `GetTrackDetailUseCase` exposes hydrated track detail retrieval
* `UpdateItemStatusUseCase` validates transitions with `TrackStateMachine`, rewrites the affected milestone/track state, and persists the updated graph
* `SaveInputValueUseCase` serializes strings, booleans, numbers, datetimes, URIs, and iterables of file/document paths

# API Changes

* No external network/API changes.

# Database Changes

* No schema changes.
* Write behavior change:
* `createTrack()` now inserts the LifeTrack graph inside a transaction.

# Observability / Logging

* None.

# Performance Impact

* Minimal. Use-case filtering/rewrites are in-memory over a single hydrated track.
* Track creation is now transaction-wrapped for consistency.

# Risks

* Existing callers now have a higher-level use-case API available, but repository contracts remain unchanged.
* Rollback plan:
* revert this PR to remove the use-case layer and restore the previous create-track write path.

# Testing

* Unit tests:
* `flutter test test/use_cases/life_track_use_cases_test.dart` in `packages/core_domain`
* `flutter test test/storage/life_track_local_data_source_test.dart test/repositories/life_track_repository_impl_test.dart` in `packages/core_data`
* Analyze:
* `flutter analyze lib test` in `packages/core_domain`
* `flutter analyze lib test` in `packages/core_data`

# Deployment Notes

* No config changes.

# Related Commits

* `feat(core-domain): add LifeTrack use cases`

# Notes

* Verification was run at the affected package boundaries because repository-root Flutter analysis is not the correct entrypoint for this monorepo layout.

Closes #344.
