### PR TITLE
test(sync): add background processing validation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -318,14 +318,6 @@ run-android-auto: ## Run app on any connected Android device
 	@echo "$(BLUE)Running on Android (auto-detect)...$(NC)"
 	@cd $(APP_DIR) && flutter run -d android $(DART_DEFINE_ARGS)
 
-.PHONY: test-background-processing
-test-background-processing: ## Run deterministic background-processing validation suites
-	@echo "$(BLUE)Running background-processing validation suites...$(NC)"
-	@cd $(APP_DIR) && flutter test test/core/sync/background_sync_service_test.dart
-	@cd packages/core_data && flutter test test/sync/sync_service_test.dart
-	@echo "$(GREEN)Background-processing validation complete.$(NC)"
-	@echo "$(YELLOW)For device-only lifecycle checks, follow docs/release/BACKGROUND_PROCESSING_VALIDATION.md$(NC)"
-
 .PHONY: test-meeting-search
 test-meeting-search: ## Run deterministic Meeting Intelligence search validation
 	@echo "$(BLUE)Running meeting-search validation suite...$(NC)"

--- a/Makefile
+++ b/Makefile
@@ -332,7 +332,6 @@ test-meeting-search: ## Run deterministic Meeting Intelligence search validation
 	@cd $(APP_DIR) && flutter test test/features/meeting/meeting_intelligence_local_slice_test.dart
 	@echo "$(GREEN)Meeting-search validation complete.$(NC)"
 	@echo "$(YELLOW)See docs/release/MEETING_SEARCH_VALIDATION.md for scope and follow-up.$(NC)"
-
 .PHONY: run-android
 run-android: run-pixel9 ## Run app on local Pixel 9 Android emulator
 
@@ -595,6 +594,15 @@ test-ui-responsive: ## Run shared responsive UI validation tests
 	@echo "$(BLUE)Running shared UI responsiveness tests...$(NC)"
 	@cd $(APP_DIR) && rm -rf windows/flutter/ephemeral/.plugin_symlinks ios/Flutter/ephemeral/Packages/.packages macos/Flutter/ephemeral/Packages/.packages
 	@cd $(APP_DIR) && flutter test test/shared/widgets/adaptive_layout_test.dart
+
+.PHONY: test-background-processing
+test-background-processing: ## Run shared background-processing validation suites
+	@echo "$(BLUE)Running background-processing validation suites...$(NC)"
+	@cd $(APP_DIR) && rm -rf windows/flutter/ephemeral ios/Flutter/ephemeral/Packages/.packages macos/Flutter/ephemeral/Packages/.packages
+	@cd $(APP_DIR) && flutter test test/core/sync/background_sync_service_test.dart
+	@cd packages/core_data && flutter test test/sync/sync_service_test.dart
+	@echo "$(GREEN)Background-processing validation complete.$(NC)"
+	@echo "$(YELLOW)For device-only lifecycle checks, follow docs/release/BACKGROUND_PROCESSING_VALIDATION.md$(NC)"
 
 .PHONY: benchmark-report
 benchmark-report: ## Create a release benchmark report template

--- a/app/test/core/sync/background_sync_service_test.dart
+++ b/app/test/core/sync/background_sync_service_test.dart
@@ -169,11 +169,14 @@ void main() {
     expect(pending, 1);
   });
 
-  test('background sync config battery saver favors charging and slower cadence', () {
-    expect(BackgroundSyncConfig.batterySaver.intervalMinutes, 60);
-    expect(BackgroundSyncConfig.batterySaver.requiresCharging, isTrue);
-    expect(BackgroundSyncConfig.batterySaver.requiresNetwork, isTrue);
-  });
+  test(
+    'background sync config battery saver favors charging and slower cadence',
+    () {
+      expect(BackgroundSyncConfig.batterySaver.intervalMinutes, 60);
+      expect(BackgroundSyncConfig.batterySaver.requiresCharging, isTrue);
+      expect(BackgroundSyncConfig.batterySaver.requiresNetwork, isTrue);
+    },
+  );
 }
 
 class _FakeConnectivityService extends ConnectivityService {

--- a/app/test/core/sync/background_sync_service_test.dart
+++ b/app/test/core/sync/background_sync_service_test.dart
@@ -168,6 +168,12 @@ void main() {
 
     expect(pending, 1);
   });
+
+  test('background sync config battery saver favors charging and slower cadence', () {
+    expect(BackgroundSyncConfig.batterySaver.intervalMinutes, 60);
+    expect(BackgroundSyncConfig.batterySaver.requiresCharging, isTrue);
+    expect(BackgroundSyncConfig.batterySaver.requiresNetwork, isTrue);
+  });
 }
 
 class _FakeConnectivityService extends ConnectivityService {

--- a/docs/release/BACKGROUND_PROCESSING_VALIDATION.md
+++ b/docs/release/BACKGROUND_PROCESSING_VALIDATION.md
@@ -1,6 +1,8 @@
 # Background Processing Validation
 
-Deterministic validation runbook for issue `#518`.
+Deterministic validation runbook for issue `#518` and release candidates that
+depend on background sync, background downloads, or restart-safe work
+execution.
 
 This runbook separates host-runnable checks from Android/device-only lifecycle
 cases that depend on OS process management, reboot handling, and battery
@@ -8,7 +10,7 @@ policies.
 
 ## Automated Checks
 
-Run the full background-processing validation suite from the repository root:
+Run the shared background-processing validation suite from the repository root:
 
 ```sh
 make test-background-processing
@@ -21,6 +23,7 @@ This command currently covers:
   - cancel/re-register behavior
   - foreground `syncNow()` delegation
   - sync status stream exposure
+  - battery-saver configuration defaults
 - `packages/core_data/test/sync/sync_service_test.dart`
   - immediate high-priority sync while online
   - offline no-op behavior
@@ -37,6 +40,7 @@ The automated portion passes when:
 - no duplicate sync processing occurs under concurrent calls
 - offline mode leaves queued work pending instead of attempting sync
 - failed syncs record retry metadata instead of being dropped silently
+- battery-saver defaults preserve the slower charging-only cadence
 
 ## Device-Only Manual Matrix
 
@@ -53,6 +57,25 @@ emulator path because they depend on OS lifecycle behavior outside host tests.
 | Duplicate workers | Trigger sync from resume/connectivity/manual paths quickly | No duplicate processing of the same pending operation |
 | Progress persistence | Start long-running work, background app, resume | Progress/pending count remains consistent |
 
+## Suggested Android Checks
+
+Use a connected device when possible:
+
+```sh
+make run-android-auto
+```
+
+Then manually verify:
+
+1. Start a sync or download-related task, background the app, and relaunch it.
+2. Force-stop the app and confirm the next eligible launch or worker pass does
+   not duplicate the scheduled work.
+3. Reboot the device and confirm expected work is re-registered.
+4. Enable battery saver or app restrictions and record any scheduler
+   degradation.
+5. Confirm any visible progress state matches the persisted or native worker
+   state.
+
 ## Evidence to Attach Before Closing
 
 Before issue `#518` can be closed, attach:
@@ -60,3 +83,13 @@ Before issue `#518` can be closed, attach:
 - output from `make test-background-processing`
 - device notes for the manual matrix above
 - any deviations, waivers, or known platform limitations for the release
+
+## Release Rule
+
+Do not mark background-processing validation complete until:
+
+1. `make test-background-processing` passes.
+2. The relevant Android/device matrix items have been exercised for the changed
+   feature.
+3. Any skipped device-only check is explicitly waived in the PR or release
+   notes.


### PR DESCRIPTION
# Summary

This PR adds the first deterministic validation slice for issue #518.
Goal: turn background-processing verification into a repeatable workflow instead of a purely manual checklist.

Core outcome:

* add unit coverage for the background sync registration/cancel/delegation contract
* add a release runbook that separates automated checks from device-only lifecycle verification

# Changes

### Code

* Added:

  * `app/test/core/sync/background_sync_service_test.dart` for background sync contract coverage
  * `docs/release/BACKGROUND_PROCESSING_VALIDATION.md` for lifecycle validation guidance
* Updated:

  * `app/lib/core/sync/background_sync_service.dart` to use a public constructor parameter name for testable injection with no behavior change
  * `Makefile` with `make test-background-processing`
  * `docs/release/RELEASE_CHECKLIST.md` so release validation includes the background processing runbook

### Logic

* registration cadence clamping and duplicate-registration behavior are now tested
* cancel/re-register flow is now tested
* sync delegation and pending-count/status delegation are now tested
* device-only lifecycle checks are documented for kill, reboot, battery saver, restrictions, rescheduling, duplicate workers, and progress persistence

# Performance Impact

* Latency: no runtime behavior change
* Throughput: no runtime behavior change
* Memory/CPU: no runtime behavior change

# Risks

* this PR validates the shared sync contract, not every background execution path in every feature
* native OS lifecycle behavior still requires real Android/device execution
* Rollback plan:

  * revert this PR to remove the validation layer

# Testing

* Unit tests:

  * `make test-background-processing`
* Manual testing:

  * `flutter analyze lib/core/sync/background_sync_service.dart test/core/sync/background_sync_service_test.dart`

# Related Commits

* `test(sync): add background processing validation`

# Notes

* Addresses #518 but does not close it yet. The remaining work is execution of the documented device lifecycle matrix.
