### PR TITLE
test(sync): add background validation coverage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -318,6 +318,14 @@ run-android-auto: ## Run app on any connected Android device
 	@echo "$(BLUE)Running on Android (auto-detect)...$(NC)"
 	@cd $(APP_DIR) && flutter run -d android $(DART_DEFINE_ARGS)
 
+.PHONY: test-background-processing
+test-background-processing: ## Run deterministic background-processing validation suites
+	@echo "$(BLUE)Running background-processing validation suites...$(NC)"
+	@cd $(APP_DIR) && flutter test test/core/sync/background_sync_service_test.dart
+	@cd packages/core_data && flutter test test/sync/sync_service_test.dart
+	@echo "$(GREEN)Background-processing validation complete.$(NC)"
+	@echo "$(YELLOW)For device-only lifecycle checks, follow docs/release/BACKGROUND_PROCESSING_VALIDATION.md$(NC)"
+
 .PHONY: run-android
 run-android: run-pixel9 ## Run app on local Pixel 9 Android emulator
 

--- a/app/lib/core/sync/background_sync_service.dart
+++ b/app/lib/core/sync/background_sync_service.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: prefer_initializing_formals
+
 import 'dart:async';
 
 import 'package:core_data/core_data.dart';
@@ -10,7 +12,8 @@ import 'package:flutter/services.dart';
 /// - iOS: BGTaskScheduler
 /// - Web: Service Worker (if available)
 class BackgroundSyncService {
-  BackgroundSyncService({required this._syncService});
+  BackgroundSyncService({required SyncService syncService})
+    : _syncService = syncService;
 
   final SyncService _syncService;
 

--- a/app/test/core/sync/background_sync_service_test.dart
+++ b/app/test/core/sync/background_sync_service_test.dart
@@ -1,0 +1,193 @@
+import 'dart:async';
+
+import 'package:airo_app/core/sync/background_sync_service.dart';
+import 'package:core_data/core_data.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const channel = MethodChannel('com.airo.superapp/background_sync');
+
+  late _FakeConnectivityService connectivity;
+  late InMemoryOutboxRepository outboxRepository;
+  late List<SyncOperation> syncedOperations;
+  late SyncService syncService;
+  late BackgroundSyncService backgroundSyncService;
+  late TestDefaultBinaryMessenger messenger;
+
+  setUp(() {
+    messenger =
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger;
+    connectivity = _FakeConnectivityService();
+    outboxRepository = InMemoryOutboxRepository();
+    syncedOperations = <SyncOperation>[];
+    syncService = SyncService(
+      outboxRepository: outboxRepository,
+      connectivityService: connectivity,
+      onSyncOperation: (operation) async {
+        syncedOperations.add(operation);
+        return true;
+      },
+    );
+    backgroundSyncService = BackgroundSyncService(syncService: syncService);
+  });
+
+  tearDown(() async {
+    messenger.setMockMethodCallHandler(channel, null);
+    syncService.dispose();
+    connectivity.dispose();
+  });
+
+  test(
+    'register sends clamped platform arguments and ignores duplicates',
+    () async {
+      final calls = <MethodCall>[];
+      messenger.setMockMethodCallHandler(channel, (call) async {
+        calls.add(call);
+        return true;
+      });
+
+      final first = await backgroundSyncService.register(
+        interval: const Duration(minutes: 5),
+        requiresNetwork: false,
+        requiresCharging: true,
+      );
+      final second = await backgroundSyncService.register();
+
+      expect(first, isTrue);
+      expect(second, isTrue);
+      expect(calls, hasLength(1));
+      expect(calls.single.method, 'register');
+      expect(calls.single.arguments, {
+        'intervalMinutes': 15,
+        'requiresNetwork': false,
+        'requiresCharging': true,
+        'taskName': 'airo_sync',
+      });
+    },
+  );
+
+  test(
+    'cancel is a no-op until registered and clears registration state',
+    () async {
+      final calls = <MethodCall>[];
+      messenger.setMockMethodCallHandler(channel, (call) async {
+        calls.add(call);
+        return true;
+      });
+
+      await backgroundSyncService.cancel();
+      expect(calls, isEmpty);
+
+      await backgroundSyncService.register();
+      await backgroundSyncService.cancel();
+      await backgroundSyncService.register();
+
+      expect(calls.map((call) => call.method), [
+        'register',
+        'cancel',
+        'register',
+      ]);
+    },
+  );
+
+  test('register returns false when the platform throws', () async {
+    messenger.setMockMethodCallHandler(channel, (_) async {
+      throw PlatformException(code: 'unsupported', message: 'No scheduler');
+    });
+
+    final result = await backgroundSyncService.register();
+
+    expect(result, isFalse);
+  });
+
+  test('syncNow delegates to SyncService.processOutbox', () async {
+    await outboxRepository.add(
+      SyncOperation(
+        id: 'txn-1',
+        entityType: 'transaction',
+        entityId: '1',
+        operationType: SyncOperationType.create,
+        payload: '{"amount": 10}',
+        createdAt: DateTime.utc(2026, 6, 29),
+      ),
+    );
+
+    await backgroundSyncService.syncNow();
+
+    expect(syncedOperations.map((operation) => operation.id), ['txn-1']);
+    expect(backgroundSyncService.status, isA<SyncCompleted>());
+    final status = backgroundSyncService.status as SyncCompleted;
+    expect(status.synced, 1);
+    expect(status.failed, 0);
+  });
+
+  test('statusStream mirrors the sync service stream', () async {
+    final observed = <SyncStatus>[];
+    final subscription = backgroundSyncService.statusStream.listen(
+      observed.add,
+    );
+
+    await outboxRepository.add(
+      SyncOperation(
+        id: 'txn-2',
+        entityType: 'transaction',
+        entityId: '2',
+        operationType: SyncOperationType.update,
+        payload: '{"amount": 25}',
+        createdAt: DateTime.utc(2026, 6, 29),
+      ),
+    );
+
+    await backgroundSyncService.syncNow();
+    await Future<void>.delayed(Duration.zero);
+
+    expect(observed.first, isA<SyncSyncing>());
+    expect(observed.last, isA<SyncCompleted>());
+    final status = observed.last as SyncCompleted;
+    expect(status.synced, 1);
+    expect(status.failed, 0);
+    await subscription.cancel();
+  });
+
+  test('getPendingCount proxies through the sync service', () async {
+    await outboxRepository.add(
+      SyncOperation(
+        id: 'txn-3',
+        entityType: 'transaction',
+        entityId: '3',
+        operationType: SyncOperationType.delete,
+        payload: '{}',
+        createdAt: DateTime.utc(2026, 6, 29),
+      ),
+    );
+
+    final pending = await backgroundSyncService.getPendingCount();
+
+    expect(pending, 1);
+  });
+}
+
+class _FakeConnectivityService extends ConnectivityService {
+  _FakeConnectivityService() : super();
+
+  final _controller = StreamController<bool>.broadcast();
+  bool _connected = true;
+
+  @override
+  Stream<bool> get onConnectivityChanged => _controller.stream;
+
+  @override
+  Future<bool> get isConnected async => _connected;
+
+  void emit(bool connected) {
+    _connected = connected;
+    _controller.add(connected);
+  }
+
+  void dispose() {
+    _controller.close();
+  }
+}

--- a/docs/release/BACKGROUND_PROCESSING_VALIDATION.md
+++ b/docs/release/BACKGROUND_PROCESSING_VALIDATION.md
@@ -1,0 +1,62 @@
+# Background Processing Validation
+
+Deterministic validation runbook for issue `#518`.
+
+This runbook separates host-runnable checks from Android/device-only lifecycle
+cases that depend on OS process management, reboot handling, and battery
+policies.
+
+## Automated Checks
+
+Run the full background-processing validation suite from the repository root:
+
+```sh
+make test-background-processing
+```
+
+This command currently covers:
+
+- `app/test/core/sync/background_sync_service_test.dart`
+  - platform registration argument wiring
+  - cancel/re-register behavior
+  - foreground `syncNow()` delegation
+  - sync status stream exposure
+- `packages/core_data/test/sync/sync_service_test.dart`
+  - immediate high-priority sync while online
+  - offline no-op behavior
+  - failure accounting and retry metadata
+  - connectivity-triggered processing
+  - duplicate/concurrent processing suppression
+  - stopped service no longer scheduling work
+
+## Host-Runnable Acceptance
+
+The automated portion passes when:
+
+- the test command succeeds with no failing tests
+- no duplicate sync processing occurs under concurrent calls
+- offline mode leaves queued work pending instead of attempting sync
+- failed syncs record retry metadata instead of being dropped silently
+
+## Device-Only Manual Matrix
+
+These checks still require a physical Android device or an explicitly approved
+emulator path because they depend on OS lifecycle behavior outside host tests.
+
+| Scenario | Steps | Expected |
+| --- | --- | --- |
+| App killed | Queue syncable work, force-stop app, relaunch | Pending work is still present and can be processed |
+| Device reboot | Queue work, reboot device, relaunch app | Pending work survives reboot and can be processed |
+| Battery optimization | Enable battery saver / optimization | Background processing behavior matches documented constraints |
+| Background restrictions | Apply OS background restriction | App degrades safely without duplicate work or crashes |
+| Work rescheduling | Register, cancel, and register again | Only one effective registration remains |
+| Duplicate workers | Trigger sync from resume/connectivity/manual paths quickly | No duplicate processing of the same pending operation |
+| Progress persistence | Start long-running work, background app, resume | Progress/pending count remains consistent |
+
+## Evidence to Attach Before Closing
+
+Before issue `#518` can be closed, attach:
+
+- output from `make test-background-processing`
+- device notes for the manual matrix above
+- any deviations, waivers, or known platform limitations for the release

--- a/docs/release/RELEASE_CHECKLIST.md
+++ b/docs/release/RELEASE_CHECKLIST.md
@@ -23,6 +23,7 @@ Pre-release verification checklist for Airo Super App releases.
 - [ ] Integration tests passing
 - [ ] E2E smoke tests passing
 - [ ] Shared UI responsiveness suite passing (`make test-ui-responsive`)
+- [ ] Background processing validation suite passing (`make test-background-processing`)
 - [ ] Performance benchmark report created (`artifacts/performance/...`)
 - [ ] Battery impact measurements attached or explicitly waived
 - [ ] Manual QA sign-off (if required)
@@ -118,6 +119,7 @@ Pre-release verification checklist for Airo Super App releases.
 - [ ] Release notes written
 - [ ] Known issues documented
 - [ ] Migration guide (if breaking changes)
+- [ ] [Background processing validation runbook](./BACKGROUND_PROCESSING_VALIDATION.md) followed
 - [ ] [UI responsiveness validation runbook](./UI_RESPONSIVENESS_VALIDATION.md) followed
 - [ ] [Performance benchmark runbook](./PERFORMANCE_BENCHMARKS.md) followed
 
@@ -149,5 +151,6 @@ Date: ____-__-__
 - [Build & Release Workflow](/.github/workflows/build-and-release.yml)
 - [Rollback Procedure](./ROLLBACK_PROCEDURE.md)
 - [Store Compliance](./STORE_COMPLIANCE.md)
+- [Background Processing Validation](./BACKGROUND_PROCESSING_VALIDATION.md)
 - [UI Responsiveness Validation](./UI_RESPONSIVENESS_VALIDATION.md)
 - [Performance Benchmarks](./PERFORMANCE_BENCHMARKS.md)

--- a/packages/core_data/lib/src/sync/sync_service.dart
+++ b/packages/core_data/lib/src/sync/sync_service.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: prefer_initializing_formals
+
 import 'dart:async';
 
 import 'package:core_domain/core_domain.dart';
@@ -16,11 +18,12 @@ import 'sync_status.dart';
 /// - Conflict resolution
 class SyncService {
   SyncService({
-    required this._outboxRepository,
-    required this._connectivityService,
+    required OutboxRepository outboxRepository,
+    required ConnectivityService connectivityService,
     this.onSyncOperation,
     this.conflictResolver,
-  });
+  }) : _outboxRepository = outboxRepository,
+       _connectivityService = connectivityService;
 
   final OutboxRepository _outboxRepository;
   final ConnectivityService _connectivityService;

--- a/packages/core_data/test/sync/sync_service_test.dart
+++ b/packages/core_data/test/sync/sync_service_test.dart
@@ -1,0 +1,166 @@
+import 'dart:async';
+
+import 'package:core_data/core_data.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  late InMemoryOutboxRepository outboxRepository;
+  late _FakeConnectivityService connectivityService;
+  late List<SyncOperation> processed;
+  late SyncService syncService;
+
+  setUp(() {
+    outboxRepository = InMemoryOutboxRepository();
+    connectivityService = _FakeConnectivityService();
+    processed = <SyncOperation>[];
+    syncService = SyncService(
+      outboxRepository: outboxRepository,
+      connectivityService: connectivityService,
+      onSyncOperation: (operation) async {
+        processed.add(operation);
+        return true;
+      },
+    );
+  });
+
+  tearDown(() {
+    syncService.dispose();
+    connectivityService.dispose();
+  });
+
+  test(
+    'queueOperation triggers immediate sync for high-priority work when online',
+    () async {
+      final result = await syncService.queueOperation(
+        entityType: 'transaction',
+        entityId: '1',
+        operationType: SyncOperationType.create,
+        payload: '{"amount":42}',
+        priority: SyncPriority.high,
+      );
+
+      await Future<void>.delayed(Duration.zero);
+
+      expect(result.isSuccess, isTrue);
+      expect(processed.map((operation) => operation.id), [result.value.id]);
+      expect(await syncService.getPendingCount(), 0);
+      expect(syncService.status, isA<SyncCompleted>());
+    },
+  );
+
+  test('processOutbox is a no-op while offline', () async {
+    connectivityService.connected = false;
+    await outboxRepository.add(_operation(id: 'offline-op'));
+
+    await syncService.processOutbox();
+
+    expect(processed, isEmpty);
+    expect(await syncService.getPendingCount(), 1);
+    expect(syncService.status, isA<SyncIdle>());
+  });
+
+  test(
+    'processOutbox records failures when sync callback returns false',
+    () async {
+      syncService = SyncService(
+        outboxRepository: outboxRepository,
+        connectivityService: connectivityService,
+        onSyncOperation: (_) async => false,
+      );
+
+      await outboxRepository.add(_operation(id: 'failing-op'));
+      await syncService.processOutbox();
+
+      expect(syncService.status, isA<SyncCompleted>());
+      final status = syncService.status as SyncCompleted;
+      expect(status.synced, 0);
+      expect(status.failed, 1);
+
+      final pending = await outboxRepository.getPending();
+      expect(pending.value.single.retryCount, 1);
+      expect(pending.value.single.lastError, 'Sync failed');
+    },
+  );
+
+  test('connectivity change to online triggers processing', () async {
+    await outboxRepository.add(_operation(id: 'connectivity-op'));
+    syncService.start(interval: const Duration(hours: 1));
+
+    connectivityService.emit(false);
+    await Future<void>.delayed(Duration.zero);
+    expect(processed, isEmpty);
+
+    connectivityService.emit(true);
+    await Future<void>.delayed(Duration.zero);
+
+    expect(processed.map((operation) => operation.id), ['connectivity-op']);
+  });
+
+  test('concurrent processOutbox calls do not duplicate work', () async {
+    final gate = Completer<void>();
+    final started = Completer<void>();
+    syncService = SyncService(
+      outboxRepository: outboxRepository,
+      connectivityService: connectivityService,
+      onSyncOperation: (operation) async {
+        processed.add(operation);
+        started.complete();
+        await gate.future;
+        return true;
+      },
+    );
+
+    await outboxRepository.add(_operation(id: 'concurrent-op'));
+
+    final first = syncService.processOutbox();
+    await started.future;
+    final second = syncService.processOutbox();
+    gate.complete();
+    await Future.wait([first, second]);
+
+    expect(processed.map((operation) => operation.id), ['concurrent-op']);
+  });
+
+  test('cancel stops periodic registration from continuing', () async {
+    syncService.start(interval: const Duration(milliseconds: 10));
+    syncService.stop();
+
+    await outboxRepository.add(_operation(id: 'stopped-op'));
+    await Future<void>.delayed(const Duration(milliseconds: 25));
+
+    expect(processed, isEmpty);
+  });
+}
+
+SyncOperation _operation({required String id}) {
+  return SyncOperation(
+    id: id,
+    entityType: 'meeting',
+    entityId: id,
+    operationType: SyncOperationType.update,
+    payload: '{"id":"$id"}',
+    createdAt: DateTime.utc(2026, 6, 29),
+  );
+}
+
+class _FakeConnectivityService extends ConnectivityService {
+  _FakeConnectivityService() : super();
+
+  final _controller = StreamController<bool>.broadcast();
+  bool connected = true;
+
+  @override
+  Stream<bool> get onConnectivityChanged => _controller.stream;
+
+  @override
+  Future<bool> get isConnected async => connected;
+
+  void emit(bool value) {
+    connected = value;
+    _controller.add(value);
+  }
+
+  void dispose() {
+    _controller.close();
+  }
+}


### PR DESCRIPTION
# Summary

This PR adds the deterministic validation path for background processing work tracked in #518.
Goal: give the repo a single command, automated coverage, and a release runbook for background-sync lifecycle validation.

Core outcome:
- adds app/core-data test coverage for background sync registration and processing behavior
- adds a release runbook and `make` entrypoint for background-processing validation

# Changes

### Code

* Added:
* `app/test/core/sync/background_sync_service_test.dart`
* `packages/core_data/test/sync/sync_service_test.dart`
* `docs/release/BACKGROUND_PROCESSING_VALIDATION.md`
* Updated:
* `app/lib/core/sync/background_sync_service.dart` constructor shape for external testability
* `packages/core_data/lib/src/sync/sync_service.dart` constructor shape for external testability
* `Makefile` with `make test-background-processing`
* `docs/release/RELEASE_CHECKLIST.md` with background-processing validation hooks

### Logic

* verifies background sync register/cancel/manual sync/status behavior
* verifies offline no-op behavior, failure accounting, connectivity-triggered processing, duplicate processing suppression, and stop/cancel behavior
* documents the remaining Android/device-only matrix for app kill, reboot, battery optimization, restrictions, and progress persistence

# API Changes

* No external network/API changes.

# Database Changes

* None.

# Observability / Logging

* None.

# Performance Impact

* None in production paths beyond constructor signature cleanup.

# Risks

* Low risk: changes are isolated to tests, docs, Makefile wiring, and constructor parameter naming for existing services.
* Rollback plan:
* revert this PR to remove the validation path and restore the previous constructor signatures.

# Testing

* `flutter test --no-pub test/core/sync/background_sync_service_test.dart` in `app`
* `flutter analyze lib test/core/sync/background_sync_service_test.dart` in `app`
* `flutter test test/sync/sync_service_test.dart` in `packages/core_data`
* `flutter analyze lib test/sync/sync_service_test.dart` in `packages/core_data`
* `make test-background-processing`

# Deployment Notes

* No config changes.

# Related Commits

* `test(sync): add background validation coverage`

# Notes

* This PR intentionally does **not** close #518. The issue remains open until the manual/device matrix in `docs/release/BACKGROUND_PROCESSING_VALIDATION.md` is executed and attached.
