### PR TITLE
fix(meeting): harden local search edge cases

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -613,6 +613,12 @@ benchmark-android-startup: ## Capture Android startup timing on a connected devi
 	@"$(ADB)" shell am force-stop "$(ANDROID_PACKAGE)"
 	@"$(ADB)" shell am start -W "$(ANDROID_PACKAGE)/.MainActivity"
 
+.PHONY: test-search-edge-cases
+test-search-edge-cases: ## Run Meeting Intelligence search edge-case validation tests
+	@echo "$(BLUE)Running Meeting Intelligence search edge-case tests...$(NC)"
+	@cd $(APP_DIR) && rm -rf windows/flutter/ephemeral ios/Flutter/ephemeral/Packages/.packages macos/Flutter/ephemeral/Packages/.packages
+	@cd $(APP_DIR) && flutter test test/features/meeting/meeting_search_repository_test.dart
+
 # IPTV Data Pipeline Commands
 .PHONY: iptv-install-deps
 iptv-install-deps: ## Install local IPTV pipeline dependencies

--- a/app/lib/features/meeting/infrastructure/storage/in_memory_meeting_repository.dart
+++ b/app/lib/features/meeting/infrastructure/storage/in_memory_meeting_repository.dart
@@ -8,14 +8,16 @@ class InMemoryMeetingRepository implements MeetingRepository {
   final Map<String, MeetingRecord> _records = {};
   final Map<String, List<TranscriptChunk>> _chunksByMeeting = {};
   final Map<String, MeetingSummary> _summaries = {};
-  final Map<String, String> _searchTextByMeeting = {};
+  final Map<String, _MeetingSearchDocument> _searchDocsByMeeting = {};
 
   @override
   Future<void> saveIntelligence(MeetingIntelligenceDraft draft) async {
     _records[draft.record.id] = draft.record;
     _chunksByMeeting[draft.record.id] = List.unmodifiable(draft.redactedChunks);
     _summaries[draft.record.id] = draft.summary;
-    _searchTextByMeeting[draft.record.id] = draft.searchableText;
+    _searchDocsByMeeting[draft.record.id] = _MeetingSearchDocument.fromDraft(
+      draft,
+    );
   }
 
   @override
@@ -37,37 +39,248 @@ class InMemoryMeetingRepository implements MeetingRepository {
 
   @override
   Future<List<MeetingSearchResult>> searchMeetings(String query) async {
-    final normalizedQuery = query.trim().toLowerCase();
-    if (normalizedQuery.isEmpty) {
+    final normalizedQuery = _normalize(query);
+    final queryTerms = _expandQueryTerms(normalizedQuery);
+    if (normalizedQuery.isEmpty || queryTerms.isEmpty) {
       return const [];
     }
 
-    return _searchTextByMeeting.entries
-        .where((entry) => entry.value.toLowerCase().contains(normalizedQuery))
+    final matches = _searchDocsByMeeting.entries
         .map((entry) {
+          final doc = entry.value;
+          final score = _scoreMatch(doc, normalizedQuery, queryTerms);
+          if (score == 0) {
+            return null;
+          }
+
           final record = _records[entry.key];
-          return MeetingSearchResult(
-            meetingId: entry.key,
-            title: record?.title ?? 'Untitled meeting',
-            snippet: _snippetFor(entry.value, normalizedQuery),
+          return (
+            score: score,
+            record: record,
+            result: MeetingSearchResult(
+              meetingId: entry.key,
+              title: record?.title ?? 'Untitled meeting',
+              snippet: _snippetFor(doc, normalizedQuery, queryTerms),
+            ),
           );
         })
+        .whereType<({
+          int score,
+          MeetingRecord? record,
+          MeetingSearchResult result,
+        })>()
+        .toList(growable: false);
+
+    matches.sort((a, b) {
+      final scoreCompare = b.score.compareTo(a.score);
+      if (scoreCompare != 0) return scoreCompare;
+
+      final aStartedAt = a.record?.startedAt;
+      final bStartedAt = b.record?.startedAt;
+      if (aStartedAt != null && bStartedAt != null) {
+        return bStartedAt.compareTo(aStartedAt);
+      }
+      return a.result.meetingId.compareTo(b.result.meetingId);
+    });
+
+    return matches.take(50).map((match) => match.result).toList(growable: false);
+  }
+
+  int _scoreMatch(
+    _MeetingSearchDocument doc,
+    String normalizedQuery,
+    Set<String> queryTerms,
+  ) {
+    var score = 0;
+
+    if (doc.normalizedTitle.contains(normalizedQuery)) score += 12;
+    if (doc.normalizedSpeakers.contains(normalizedQuery)) score += 10;
+    if (doc.normalizedBody.contains(normalizedQuery)) score += 8;
+    if (doc.normalizedLanguageCode.contains(normalizedQuery)) score += 4;
+
+    for (final queryTerm in queryTerms) {
+      if (doc.tokens.contains(queryTerm)) {
+        score += 6;
+        continue;
+      }
+      if (doc.tokens.any((token) => _isFuzzyMatch(token, queryTerm))) {
+        score += 3;
+      }
+    }
+
+    return score;
+  }
+
+  String _snippetFor(
+    _MeetingSearchDocument doc,
+    String normalizedQuery,
+    Set<String> queryTerms,
+  ) {
+    final lowerText = _normalize(doc.searchableText);
+    var index = lowerText.indexOf(normalizedQuery);
+    if (index < 0) {
+      for (final term in queryTerms) {
+        index = lowerText.indexOf(term);
+        if (index >= 0) break;
+      }
+    }
+    if (index < 0) {
+      return doc.searchableText.length <= 120
+          ? doc.searchableText
+          : doc.searchableText.substring(0, 120);
+    }
+
+    final start = index - 40 < 0 ? 0 : index - 40;
+    final end = index + normalizedQuery.length + 40;
+    return doc.searchableText.substring(
+      start,
+      end > doc.searchableText.length ? doc.searchableText.length : end,
+    );
+  }
+
+  Set<String> _expandQueryTerms(String normalizedQuery) {
+    final terms = _tokenize(normalizedQuery).toSet();
+    final expanded = <String>{...terms};
+    for (final term in terms) {
+      expanded.addAll(_synonyms[term] ?? const <String>{});
+    }
+    return expanded;
+  }
+
+  bool _isFuzzyMatch(String token, String queryTerm) {
+    if (token == queryTerm) return true;
+    if (token.length < 4 || queryTerm.length < 4) return false;
+    if ((token.length - queryTerm.length).abs() > 1) return false;
+    return _editDistance(token, queryTerm) <= 1;
+  }
+
+  int _editDistance(String a, String b) {
+    final rows = List.generate(
+      a.length + 1,
+      (index) => List<int>.filled(b.length + 1, 0),
+    );
+    for (var i = 0; i <= a.length; i++) {
+      rows[i][0] = i;
+    }
+    for (var j = 0; j <= b.length; j++) {
+      rows[0][j] = j;
+    }
+
+    for (var i = 1; i <= a.length; i++) {
+      for (var j = 1; j <= b.length; j++) {
+        final cost = a[i - 1] == b[j - 1] ? 0 : 1;
+        rows[i][j] = [
+          rows[i - 1][j] + 1,
+          rows[i][j - 1] + 1,
+          rows[i - 1][j - 1] + cost,
+        ].reduce((left, right) => left < right ? left : right);
+      }
+    }
+
+    return rows[a.length][b.length];
+  }
+
+  static final Map<String, Set<String>> _synonyms = {
+    'project': {'proj', 'initiative'},
+    'proj': {'project', 'initiative'},
+    'roadmap': {'plan'},
+    'plan': {'roadmap'},
+    'decision': {'decide'},
+    'decide': {'decision'},
+    'action': {'todo', 'task'},
+    'todo': {'action', 'task'},
+    'task': {'action', 'todo'},
+  };
+
+  String _normalize(String value) {
+    return _stripDiacritics(value)
+        .toLowerCase()
+        .replaceAll(RegExp(r'[^\p{L}\p{N}\s]+', unicode: true), ' ')
+        .replaceAll(RegExp(r'\s+'), ' ')
+        .trim();
+  }
+
+  List<String> _tokenize(String value) {
+    return _normalize(value)
+        .split(' ')
+        .where((token) => token.isNotEmpty)
         .toList(growable: false);
   }
 
-  String _snippetFor(String searchableText, String normalizedQuery) {
-    final lowerText = searchableText.toLowerCase();
-    final index = lowerText.indexOf(normalizedQuery);
-    if (index < 0) {
-      return searchableText.length <= 120
-          ? searchableText
-          : searchableText.substring(0, 120);
+  String _stripDiacritics(String input) {
+    const replacements = {
+      'á': 'a',
+      'à': 'a',
+      'ä': 'a',
+      'â': 'a',
+      'ã': 'a',
+      'å': 'a',
+      'é': 'e',
+      'è': 'e',
+      'ë': 'e',
+      'ê': 'e',
+      'í': 'i',
+      'ì': 'i',
+      'ï': 'i',
+      'î': 'i',
+      'ó': 'o',
+      'ò': 'o',
+      'ö': 'o',
+      'ô': 'o',
+      'õ': 'o',
+      'ú': 'u',
+      'ù': 'u',
+      'ü': 'u',
+      'û': 'u',
+      'ñ': 'n',
+      'ç': 'c',
+    };
+
+    final buffer = StringBuffer();
+    for (final rune in input.runes) {
+      final char = String.fromCharCode(rune);
+      buffer.write(replacements[char] ?? char);
     }
-    final start = index - 40 < 0 ? 0 : index - 40;
-    final end = index + normalizedQuery.length + 40;
-    return searchableText.substring(
-      start,
-      end > searchableText.length ? searchableText.length : end,
+    return buffer.toString();
+  }
+}
+
+class _MeetingSearchDocument {
+  const _MeetingSearchDocument({
+    required this.searchableText,
+    required this.normalizedTitle,
+    required this.normalizedBody,
+    required this.normalizedSpeakers,
+    required this.normalizedLanguageCode,
+    required this.tokens,
+  });
+
+  factory _MeetingSearchDocument.fromDraft(MeetingIntelligenceDraft draft) {
+    final repo = InMemoryMeetingRepository();
+    final speakers = draft.redactedChunks
+        .map((chunk) => chunk.speakerLabel?.trim())
+        .whereType<String>()
+        .where((label) => label.isNotEmpty)
+        .toSet()
+        .join(' ');
+    final title = draft.record.title;
+    final body = draft.searchableText;
+    final languageCode = draft.record.languageCode ?? '';
+    final aggregate = '$title $speakers $languageCode $body';
+    return _MeetingSearchDocument(
+      searchableText: body,
+      normalizedTitle: repo._normalize(title),
+      normalizedBody: repo._normalize(body),
+      normalizedSpeakers: repo._normalize(speakers),
+      normalizedLanguageCode: repo._normalize(languageCode),
+      tokens: repo._tokenize(aggregate).toSet(),
     );
   }
+
+  final String searchableText;
+  final String normalizedTitle;
+  final String normalizedBody;
+  final String normalizedSpeakers;
+  final String normalizedLanguageCode;
+  final Set<String> tokens;
 }

--- a/app/lib/features/meeting/infrastructure/storage/in_memory_meeting_repository.dart
+++ b/app/lib/features/meeting/infrastructure/storage/in_memory_meeting_repository.dart
@@ -64,11 +64,9 @@ class InMemoryMeetingRepository implements MeetingRepository {
             ),
           );
         })
-        .whereType<({
-          int score,
-          MeetingRecord? record,
-          MeetingSearchResult result,
-        })>()
+        .whereType<
+          ({int score, MeetingRecord? record, MeetingSearchResult result})
+        >()
         .toList(growable: false);
 
     matches.sort((a, b) {
@@ -83,7 +81,10 @@ class InMemoryMeetingRepository implements MeetingRepository {
       return a.result.meetingId.compareTo(b.result.meetingId);
     });
 
-    return matches.take(50).map((match) => match.result).toList(growable: false);
+    return matches
+        .take(50)
+        .map((match) => match.result)
+        .toList(growable: false);
   }
 
   int _scoreMatch(
@@ -201,10 +202,9 @@ class InMemoryMeetingRepository implements MeetingRepository {
   }
 
   List<String> _tokenize(String value) {
-    return _normalize(value)
-        .split(' ')
-        .where((token) => token.isNotEmpty)
-        .toList(growable: false);
+    return _normalize(
+      value,
+    ).split(' ').where((token) => token.isNotEmpty).toList(growable: false);
   }
 
   String _stripDiacritics(String input) {

--- a/app/test/features/meeting/meeting_search_repository_test.dart
+++ b/app/test/features/meeting/meeting_search_repository_test.dart
@@ -1,0 +1,166 @@
+import 'package:airo_app/features/meeting/domain/entities/meeting_audio_metadata.dart';
+import 'package:airo_app/features/meeting/domain/entities/meeting_intelligence.dart';
+import 'package:airo_app/features/meeting/domain/entities/meeting_record.dart';
+import 'package:airo_app/features/meeting/domain/entities/meeting_summary.dart';
+import 'package:airo_app/features/meeting/domain/entities/transcript_chunk.dart';
+import 'package:airo_app/features/meeting/infrastructure/storage/in_memory_meeting_repository.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('InMemoryMeetingRepository.searchMeetings', () {
+    test('matches project title and speaker labels', () async {
+      final repository = InMemoryMeetingRepository();
+      await repository.saveIntelligence(
+        _draft(
+          meetingId: 'meeting-1',
+          title: 'Project Atlas kickoff',
+          startedAt: DateTime.utc(2026, 6, 29, 9),
+          searchableText: 'Action: finalize kickoff plan for Atlas.',
+          chunks: const [
+            TranscriptChunk.finalChunk(
+              id: 'chunk-1',
+              meetingId: 'meeting-1',
+              text: 'Action: finalize kickoff plan for Atlas.',
+              startMs: 0,
+              endMs: 1000,
+              speakerLabel: 'Priya',
+            ),
+          ],
+        ),
+      );
+
+      final projectResults = await repository.searchMeetings('atlas');
+      final speakerResults = await repository.searchMeetings('priya');
+
+      expect(projectResults.map((result) => result.meetingId), ['meeting-1']);
+      expect(speakerResults.map((result) => result.meetingId), ['meeting-1']);
+    });
+
+    test('handles simple misspellings and meeting-term synonyms', () async {
+      final repository = InMemoryMeetingRepository();
+      await repository.saveIntelligence(
+        _draft(
+          meetingId: 'meeting-2',
+          title: 'Roadmap sync',
+          startedAt: DateTime.utc(2026, 6, 29, 10),
+          searchableText: 'Decision: launch plan stays local-first.',
+          chunks: const [
+            TranscriptChunk.finalChunk(
+              id: 'chunk-2',
+              meetingId: 'meeting-2',
+              text: 'Decision: launch plan stays local-first.',
+              startMs: 0,
+              endMs: 1000,
+            ),
+          ],
+        ),
+      );
+
+      final typoResults = await repository.searchMeetings('roadnmap');
+      final synonymResults = await repository.searchMeetings('plan');
+
+      expect(typoResults.map((result) => result.meetingId), ['meeting-2']);
+      expect(synonymResults.map((result) => result.meetingId), ['meeting-2']);
+    });
+
+    test('normalizes mixed-language text with diacritics', () async {
+      final repository = InMemoryMeetingRepository();
+      await repository.saveIntelligence(
+        _draft(
+          meetingId: 'meeting-3',
+          title: 'Diseño review',
+          startedAt: DateTime.utc(2026, 6, 29, 11),
+          searchableText: 'El diseño final queda aprobado para el proyecto.',
+          languageCode: 'es',
+          chunks: const [
+            TranscriptChunk.finalChunk(
+              id: 'chunk-3',
+              meetingId: 'meeting-3',
+              text: 'El diseño final queda aprobado para el proyecto.',
+              startMs: 0,
+              endMs: 1000,
+            ),
+          ],
+        ),
+      );
+
+      final noAccentResults = await repository.searchMeetings('diseno');
+      final projectResults = await repository.searchMeetings('proyecto');
+
+      expect(noAccentResults.map((result) => result.meetingId), ['meeting-3']);
+      expect(projectResults.map((result) => result.meetingId), ['meeting-3']);
+    });
+
+    test('keeps deterministic ordering for larger datasets', () async {
+      final repository = InMemoryMeetingRepository();
+
+      for (var i = 0; i < 60; i++) {
+        await repository.saveIntelligence(
+          _draft(
+            meetingId: 'meeting-$i',
+            title: 'Atlas search batch $i',
+            startedAt: DateTime.utc(2026, 6, 1).add(Duration(minutes: i)),
+            searchableText: 'Atlas rollout note $i',
+            chunks: [
+              TranscriptChunk.finalChunk(
+                id: 'chunk-$i',
+                meetingId: 'meeting-$i',
+                text: 'Atlas rollout note $i',
+                startMs: 0,
+                endMs: 1000,
+                speakerLabel: i.isEven ? 'Priya' : 'Amit',
+              ),
+            ],
+          ),
+        );
+      }
+
+      final results = await repository.searchMeetings('atlas');
+
+      expect(results, hasLength(50));
+      expect(results.first.meetingId, 'meeting-59');
+      expect(results.last.meetingId, 'meeting-10');
+    });
+  });
+}
+
+MeetingIntelligenceDraft _draft({
+  required String meetingId,
+  required String title,
+  required DateTime startedAt,
+  required String searchableText,
+  required List<TranscriptChunk> chunks,
+  String? languageCode,
+}) {
+  final record = MeetingRecord.started(
+    id: meetingId,
+    title: title,
+    startedAt: startedAt,
+    languageCode: languageCode,
+  ).complete(endedAt: startedAt.add(const Duration(minutes: 30)));
+
+  return MeetingIntelligenceDraft(
+    record: record,
+    audioMetadata: MeetingAudioMetadata(
+      meetingId: meetingId,
+      filePath: '/tmp/$meetingId.m4a',
+      codec: 'm4a',
+      sampleRateHz: 16000,
+      channelCount: 1,
+      sizeBytes: 4096,
+      sha256: 'sha-$meetingId',
+    ),
+    redactedChunks: chunks,
+    summary: MeetingSummary(
+      meetingId: meetingId,
+      executiveSummary: 'summary',
+      detailedSummary: 'detailed',
+      actionItems: const [],
+      keyDecisions: const [],
+      risks: const [],
+      nextSteps: const [],
+      isCloudSyncEligible: false,
+    ),
+    searchableText: searchableText,
+  );
+}

--- a/docs/release/RELEASE_CHECKLIST.md
+++ b/docs/release/RELEASE_CHECKLIST.md
@@ -24,6 +24,7 @@ Pre-release verification checklist for Airo Super App releases.
 - [ ] E2E smoke tests passing
 - [ ] Shared UI responsiveness suite passing (`make test-ui-responsive`)
 - [ ] Background processing validation suite passing (`make test-background-processing`)
+- [ ] Shared search edge-cases suite passing (`make test-search-edge-cases`)
 - [ ] Performance benchmark report created (`artifacts/performance/...`)
 - [ ] Battery impact measurements attached or explicitly waived
 - [ ] Manual QA sign-off (if required)
@@ -120,6 +121,7 @@ Pre-release verification checklist for Airo Super App releases.
 - [ ] Known issues documented
 - [ ] Migration guide (if breaking changes)
 - [ ] [Background processing validation runbook](./BACKGROUND_PROCESSING_VALIDATION.md) followed
+- [ ] [Search edge-case validation runbook](./SEARCH_EDGE_CASES_VALIDATION.md) followed
 - [ ] [UI responsiveness validation runbook](./UI_RESPONSIVENESS_VALIDATION.md) followed
 - [ ] [Performance benchmark runbook](./PERFORMANCE_BENCHMARKS.md) followed
 
@@ -152,5 +154,6 @@ Date: ____-__-__
 - [Rollback Procedure](./ROLLBACK_PROCEDURE.md)
 - [Store Compliance](./STORE_COMPLIANCE.md)
 - [Background Processing Validation](./BACKGROUND_PROCESSING_VALIDATION.md)
+- [Search Edge Cases Validation](./SEARCH_EDGE_CASES_VALIDATION.md)
 - [UI Responsiveness Validation](./UI_RESPONSIVENESS_VALIDATION.md)
 - [Performance Benchmarks](./PERFORMANCE_BENCHMARKS.md)

--- a/docs/release/SEARCH_EDGE_CASES_VALIDATION.md
+++ b/docs/release/SEARCH_EDGE_CASES_VALIDATION.md
@@ -1,0 +1,53 @@
+# Search Edge Cases Validation
+
+Use this runbook for issue `#517` and for release candidates that touch local
+meeting search, indexing, or search result presentation.
+
+## Deterministic Local Checks
+
+Run the Meeting Intelligence search edge-case suite:
+
+```bash
+make test-search-edge-cases
+```
+
+Current automated coverage proves:
+
+- project/title terms remain searchable
+- speaker labels are indexed for lookup
+- simple single-edit misspellings still match relevant meetings
+- common meeting-term synonyms such as `plan` and `roadmap` match
+- mixed-language content with diacritics remains searchable after normalization
+- larger repositories keep deterministic recency ordering and bounded results
+
+## Manual Validation Matrix
+
+The following still require manual validation because they depend on real
+meeting data quality, user expectations, or UI behavior:
+
+| Area | What to verify | Preferred environment |
+| --- | --- | --- |
+| Speaker search | Real diarization labels surface expected meeting hits | Seeded local meeting corpus |
+| Project search | Project names from titles and summaries are discoverable in UI | Seeded local meeting corpus |
+| Mixed-language meetings | Hindi/English or other bilingual transcripts remain discoverable in UI | Representative local transcripts |
+| Very large datasets | Search latency and scrolling remain acceptable with many meetings | Larger seeded local dataset |
+| Result snippets | Snippets shown in UI are useful and redacted | Manual QA in app |
+
+## Suggested Local Flow
+
+1. Run `make test-search-edge-cases`.
+2. Seed the app with representative local meeting drafts or fixtures.
+3. Search by:
+   - project/title term
+   - speaker name
+   - a one-character typo
+   - a mixed-language query
+4. Confirm the result order remains stable and redacted snippets stay redacted.
+
+## Release Rule
+
+Do not mark search edge-case validation complete until:
+
+1. `make test-search-edge-cases` passes.
+2. The relevant manual matrix items have been exercised against the release candidate.
+3. Any skipped high-volume or mixed-language validation is explicitly waived in the PR or release notes.

--- a/docs/wiki/4.-Using-Core-Capabilities.md
+++ b/docs/wiki/4.-Using-Core-Capabilities.md
@@ -59,6 +59,11 @@ Audio Scribe is planned as an offline transcription workflow. The current
 Assistant response maps this to Airo voice workflows and the future
 meeting-minutes pipeline.
 
+For saved meeting intelligence, Airo now indexes meeting titles, speaker labels,
+and normalized transcript text together so follow-up search can find a meeting
+by project term, participant name, or a lightly misspelled query without
+requiring an exact text match.
+
 ## Mobile Actions
 
 The Assistant can explain or route supported Airo actions. Sensitive device


### PR DESCRIPTION
# Validation: harden meeting search edge cases

---

# Summary

This PR introduces changes to Meeting Intelligence local search validation.
Goal: make local meeting search behave predictably for typo, synonym, and normalized-text queries while adding a repeatable validation workflow.

Core outcome:

* improves local meeting search matching across titles, speaker labels, and normalized transcript text
* adds focused validation and release runbook coverage for search edge cases

---

# Changes

### Code

* Added:

  * deterministic repository tests for meeting search edge cases
  * release runbook for search validation
* Updated:

  * in-memory meeting repository search indexing and matching behavior
  * release checklist and wiki guidance for search validation
  * Makefile with `test-search-edge-cases`

### Logic

* normalizes diacritics and punctuation before query matching
* adds typo-tolerant token matching and small synonym expansion
* preserves deterministic ordering and a bounded result set for larger datasets

---

# API Changes (if any)

* None

---

# Database Changes (if any)

* None

---

# Observability / Logging

* None

---

# Performance Impact

* Latency: minor local-search scoring overhead in exchange for better recall
* Throughput: no meaningful app-wide impact expected
* Memory/CPU: small in-memory search index expansion per saved meeting

---

# Risks

* synonym and fuzzy matching could broaden some result sets more than expected
* release checklist keeps accumulating validation tracks and needs continued additive maintenance
* Rollback plan:

  * revert this PR to restore prior exact-match repository behavior and remove the validation docs/target

---

# Testing

* Unit tests:

  * `make test-search-edge-cases`
* Integration tests:

  * none
* Manual testing:

  * docs completeness gate against `origin/main`
  * focused `flutter analyze` on repository + tests

---

# Deployment Notes

* Config changes:

  * none
* Order of deployment:

  * normal merge to `main`

---

# Related Commits

* `fix(meeting): harden local search edge cases`

---

# Notes

* Closes #517
