### PR TITLE
feat(meeting): extend local meeting intelligence summaries

### DIFF
--- a/app/lib/features/meeting/application/services/meeting_intelligence_pipeline.dart
+++ b/app/lib/features/meeting/application/services/meeting_intelligence_pipeline.dart
@@ -38,6 +38,22 @@ class MeetingIntelligencePipeline {
         actionItems: _extractActionItems(record.id, searchableText),
         keyDecisions: _extractPrefixedLines(searchableText, 'decision:'),
         risks: _extractRiskLines(searchableText),
+        openQuestions: _extractAnyPrefixedLines(searchableText, const [
+          'open question:',
+          'question:',
+        ]),
+        followUps: _extractAnyPrefixedLines(searchableText, const [
+          'follow-up:',
+          'followup:',
+        ]),
+        blockers: _extractAnyPrefixedLines(searchableText, const [
+          'blocker:',
+          'blocked by:',
+        ]),
+        dependencies: _extractAnyPrefixedLines(searchableText, const [
+          'dependency:',
+          'depends on:',
+        ]),
         nextSteps: _extractPrefixedLines(searchableText, 'next:'),
         isCloudSyncEligible: false,
       ),
@@ -76,11 +92,23 @@ class MeetingIntelligencePipeline {
   }
 
   List<String> _extractPrefixedLines(String text, String prefix) {
+    return _extractAnyPrefixedLines(text, [prefix]);
+  }
+
+  List<String> _extractAnyPrefixedLines(String text, List<String> prefixes) {
     return text
         .split(RegExp(r'[\n.]'))
         .map((line) => line.trim())
-        .where((line) => line.toLowerCase().startsWith(prefix))
-        .map((line) => line.substring(prefix.length).trim())
+        .map((line) {
+          final normalized = line.toLowerCase();
+          for (final prefix in prefixes) {
+            if (normalized.startsWith(prefix)) {
+              return line.substring(prefix.length).trim();
+            }
+          }
+          return null;
+        })
+        .whereType<String>()
         .where((line) => line.isNotEmpty)
         .toList(growable: false);
   }

--- a/app/lib/features/meeting/domain/entities/meeting_summary.dart
+++ b/app/lib/features/meeting/domain/entities/meeting_summary.dart
@@ -24,6 +24,10 @@ class MeetingSummary {
     required this.actionItems,
     required this.keyDecisions,
     required this.risks,
+    required this.openQuestions,
+    required this.followUps,
+    required this.blockers,
+    required this.dependencies,
     required this.nextSteps,
     required this.isCloudSyncEligible,
   });
@@ -34,6 +38,10 @@ class MeetingSummary {
   final List<MeetingActionItem> actionItems;
   final List<String> keyDecisions;
   final List<String> risks;
+  final List<String> openQuestions;
+  final List<String> followUps;
+  final List<String> blockers;
+  final List<String> dependencies;
   final List<String> nextSteps;
   final bool isCloudSyncEligible;
 }

--- a/app/test/features/meeting/meeting_intelligence_local_slice_test.dart
+++ b/app/test/features/meeting/meeting_intelligence_local_slice_test.dart
@@ -47,6 +47,49 @@ void main() {
               startMs: 5000,
               endMs: 9000,
             ),
+            TranscriptChunk.finalChunk(
+              id: 'chunk-3',
+              meetingId: 'meeting-1',
+              text: 'Decision: Move the launch review to Tuesday.',
+              startMs: 9000,
+              endMs: 11000,
+            ),
+            TranscriptChunk.finalChunk(
+              id: 'chunk-4',
+              meetingId: 'meeting-1',
+              text:
+                  'Open Question: Should we send the updated card details 4242 4242 4242 4242 to the vendor?',
+              startMs: 11000,
+              endMs: 14000,
+            ),
+            TranscriptChunk.finalChunk(
+              id: 'chunk-5',
+              meetingId: 'meeting-1',
+              text: 'Follow-up: Neha to confirm the rollout checklist.',
+              startMs: 14000,
+              endMs: 16000,
+            ),
+            TranscriptChunk.finalChunk(
+              id: 'chunk-6',
+              meetingId: 'meeting-1',
+              text: 'Blocker: Waiting on legal sign-off for the launch note.',
+              startMs: 16000,
+              endMs: 18000,
+            ),
+            TranscriptChunk.finalChunk(
+              id: 'chunk-7',
+              meetingId: 'meeting-1',
+              text: 'Dependency: Finance must confirm the revised budget.',
+              startMs: 18000,
+              endMs: 20000,
+            ),
+            TranscriptChunk.finalChunk(
+              id: 'chunk-8',
+              meetingId: 'meeting-1',
+              text: 'Next: Prepare the launch checklist in the local tracker.',
+              startMs: 20000,
+              endMs: 22000,
+            ),
           ],
         );
 
@@ -71,6 +114,25 @@ void main() {
         expect(
           summary.actionItems.single.description,
           contains('Priya to share offline launch notes'),
+        );
+        expect(summary.keyDecisions, ['Move the launch review to Tuesday']);
+        expect(summary.risks.single, contains('budget risk'));
+        expect(summary.openQuestions.single, contains('[REDACTED_CARD]'));
+        expect(
+          summary.followUps.single,
+          'Neha to confirm the rollout checklist',
+        );
+        expect(
+          summary.blockers.single,
+          'Waiting on legal sign-off for the launch note',
+        );
+        expect(
+          summary.dependencies.single,
+          'Finance must confirm the revised budget',
+        );
+        expect(
+          summary.nextSteps.single,
+          'Prepare the launch checklist in the local tracker',
         );
         expect(summary.isCloudSyncEligible, isFalse);
 

--- a/docs/wiki/4.-Using-Core-Capabilities.md
+++ b/docs/wiki/4.-Using-Core-Capabilities.md
@@ -64,6 +64,10 @@ edge cases. The current in-memory contract supports title and project lookup,
 speaker-label lookup, representative typo recovery, mixed-language tokens, and
 stable deterministic ordering for repeated queries.
 
+Saved meeting intelligence also generates structured local sections for summary,
+decisions, risks, open questions, follow-ups, blockers, dependencies, and next
+steps from final redacted transcript content.
+
 ## Mobile Actions
 
 The Assistant can explain or route supported Airo actions. Sensitive device


### PR DESCRIPTION
# Summary

This PR completes the missing local Meeting Intelligence summary sections for issue #522.
Goal: ensure the local meeting-intelligence slice generates every structured section named in the issue instead of only a partial subset.

Core outcome:

* add open questions, follow-ups, blockers, and dependencies to the local `MeetingSummary` contract
* keep the existing next-steps field while extending deterministic extraction and test coverage

# Changes

### Code

* Added:
  * structured meeting summary fields for open questions, follow-ups, blockers, and dependencies
* Updated:
  * `MeetingIntelligencePipeline` extraction logic for the new sections
  * meeting local-slice tests to verify redacted deterministic generation
  * wiki documentation for the updated meeting-intelligence output contract

### Logic

* final redacted transcript content now feeds all issue-required sections
* extraction remains deterministic and prefix-based for the local slice
* existing search, persistence, and next-step behavior remain covered by the same test file

# API Changes (if any)

* Interface: `MeetingSummary`
  * Request: unchanged
  * Response: adds `openQuestions`, `followUps`, `blockers`, and `dependencies`
  * Behavior: local meeting summaries now expose the missing issue-required sections

# Database Changes (if any)

* None

# Observability / Logging

* None

# Performance Impact

* Latency: negligible additional string extraction over final transcript text
* Throughput: no network impact
* Memory/CPU: small local parsing overhead only

# Risks

* extraction is intentionally deterministic and prefix-based, not model-generated freeform reasoning
* downstream consumers of `MeetingSummary` should use the new fields explicitly if they need them
* Rollback plan:
  * revert this PR to restore the older summary shape

# Testing

* Unit tests:
  * `flutter test test/features/meeting/meeting_intelligence_local_slice_test.dart`
* Manual testing:
  * `flutter analyze lib/features/meeting test/features/meeting/meeting_intelligence_local_slice_test.dart`

# Deployment Notes

* Config changes:
  * none
* Order of deployment:
  * none

# Related Commits

* `feat(meeting): extend local meeting intelligence summaries`

# Notes

* Closes #522
