### PR TITLE
fix(database): add native reliability validation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -333,6 +333,14 @@ test-meeting-search: ## Run deterministic Meeting Intelligence search validation
 	@echo "$(GREEN)Meeting-search validation complete.$(NC)"
 	@echo "$(YELLOW)See docs/release/MEETING_SEARCH_VALIDATION.md for scope and follow-up.$(NC)"
 
+.PHONY: test-database-reliability
+test-database-reliability: ## Run deterministic native database reliability validation
+	@echo "$(BLUE)Running database-reliability validation suite...$(NC)"
+	@cd $(APP_DIR) && rm -rf windows/flutter/ephemeral ios/Flutter/ephemeral/Packages/.packages macos/Flutter/ephemeral/Packages/.packages
+	@cd $(APP_DIR) && flutter test test/core/database/app_database_reliability_test.dart
+	@echo "$(GREEN)Database-reliability validation complete.$(NC)"
+	@echo "$(YELLOW)See docs/release/DATABASE_RELIABILITY_VALIDATION.md for scope and follow-up.$(NC)"
+
 .PHONY: run-android
 run-android: run-pixel9 ## Run app on local Pixel 9 Android emulator
 

--- a/app/lib/core/database/app_database_native.dart
+++ b/app/lib/core/database/app_database_native.dart
@@ -1,10 +1,12 @@
+// ignore_for_file: prefer_initializing_formals
+
 import 'dart:io';
 
 import 'package:drift/drift.dart';
 import 'package:drift/native.dart';
-import 'package:path_provider/path_provider.dart';
-import 'package:path/path.dart' as p;
 import 'package:flutter/foundation.dart';
+import 'package:path/path.dart' as p;
+import 'package:path_provider/path_provider.dart';
 
 part 'app_database_native.g.dart';
 
@@ -239,10 +241,15 @@ class SyncMetadata extends Table {
   ],
 )
 class AppDatabase extends _$AppDatabase {
-  AppDatabase() : super(_openConnection());
+  AppDatabase({String? databasePath})
+    : _databasePath = databasePath,
+      super(_openConnection(databasePath: databasePath));
 
   /// For testing - allows injecting a custom executor
-  AppDatabase.forTesting(super.e);
+  AppDatabase.forTesting(super.e, {String? databasePath})
+    : _databasePath = databasePath;
+
+  final String? _databasePath;
 
   @override
   int get schemaVersion => 1;
@@ -265,14 +272,43 @@ class AppDatabase extends _$AppDatabase {
 
   /// Export database for backup
   Future<List<int>> exportDatabase() async {
-    final file = File(await getDatabasePath());
+    await customStatement('PRAGMA wal_checkpoint(TRUNCATE)');
+    final file = File(await resolvedDatabasePath());
     return file.readAsBytes();
+  }
+
+  /// Restore database bytes to disk without opening the restored database.
+  static Future<String> restoreBackup(
+    List<int> bytes, {
+    String? databasePath,
+  }) async {
+    final targetPath = await resolveDatabasePath(databasePath: databasePath);
+    final file = File(targetPath);
+    await file.parent.create(recursive: true);
+    await file.writeAsBytes(bytes, flush: true);
+    return targetPath;
+  }
+
+  /// Restore database bytes for this database path.
+  Future<void> restoreDatabase(List<int> bytes) async {
+    await close();
+    await restoreBackup(bytes, databasePath: _databasePath);
   }
 
   /// Get database file path
   static Future<String> getDatabasePath() async {
     final dbFolder = await getApplicationDocumentsDirectory();
     return p.join(dbFolder.path, 'airo_money.db');
+  }
+
+  /// Resolve the active database path.
+  Future<String> resolvedDatabasePath() {
+    return resolveDatabasePath(databasePath: _databasePath);
+  }
+
+  static Future<String> resolveDatabasePath({String? databasePath}) async {
+    if (databasePath != null) return databasePath;
+    return getDatabasePath();
   }
 
   /// Delete all data (for account deletion/reset)
@@ -293,10 +329,12 @@ class AppDatabase extends _$AppDatabase {
   }
 }
 
-LazyDatabase _openConnection() {
+LazyDatabase _openConnection({String? databasePath}) {
   return LazyDatabase(() async {
-    final dbFolder = await getApplicationDocumentsDirectory();
-    final file = File(p.join(dbFolder.path, 'airo_money.db'));
+    final file = File(
+      await AppDatabase.resolveDatabasePath(databasePath: databasePath),
+    );
+    await _repairMalformedDatabaseFile(file);
 
     if (DatabaseConfig.useEncryption && DatabaseConfig.encryptionKey != null) {
       return NativeDatabase.createInBackground(
@@ -309,4 +347,24 @@ LazyDatabase _openConnection() {
 
     return NativeDatabase.createInBackground(file);
   });
+}
+
+const _sqliteHeader = 'SQLite format 3';
+
+Future<void> _repairMalformedDatabaseFile(File file) async {
+  if (!await file.exists()) return;
+
+  final bytes = await file.readAsBytes();
+  if (bytes.isEmpty) return;
+
+  final headerLength = _sqliteHeader.length;
+  if (bytes.length < headerLength) {
+    await file.delete();
+    return;
+  }
+
+  final header = String.fromCharCodes(bytes.take(headerLength));
+  if (header != _sqliteHeader) {
+    await file.delete();
+  }
 }

--- a/app/test/core/database/app_database_reliability_test.dart
+++ b/app/test/core/database/app_database_reliability_test.dart
@@ -1,0 +1,122 @@
+import 'dart:io';
+
+import 'package:airo_app/core/database/app_database.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path/path.dart' as p;
+
+void main() {
+  group('AppDatabase reliability', () {
+    late Directory tempDir;
+
+    setUp(() async {
+      tempDir = await Directory.systemTemp.createTemp('airo-db-reliability-');
+    });
+
+    tearDown(() async {
+      if (await tempDir.exists()) {
+        await tempDir.delete(recursive: true);
+      }
+    });
+
+    test('applies expected sqlite pragmas on open', () async {
+      final db = AppDatabase(databasePath: _dbPath(tempDir, 'pragmas.db'));
+      addTearDown(db.close);
+
+      final foreignKeys = await db.customSelect('PRAGMA foreign_keys;').get();
+      final journalMode = await db.customSelect('PRAGMA journal_mode;').get();
+
+      expect(foreignKeys.single.data.values.single, 1);
+      expect(
+        journalMode.single.data.values.single.toString().toLowerCase(),
+        'wal',
+      );
+    });
+
+    test('exports and restores a populated database', () async {
+      final sourcePath = _dbPath(tempDir, 'source.db');
+      final restoredPath = _dbPath(tempDir, 'restored.db');
+      final source = AppDatabase(databasePath: sourcePath);
+      await _seedTransactions(source, count: 3);
+      final sourceCount = await _transactionCount(source);
+
+      final backup = await source.exportDatabase();
+      await source.close();
+
+      await AppDatabase.restoreBackup(backup, databasePath: restoredPath);
+      final restored = AppDatabase(databasePath: restoredPath);
+      addTearDown(restored.close);
+
+      expect(await _transactionCount(restored), sourceCount);
+      final restoredRows = await restored
+          .select(restored.transactionEntries)
+          .get();
+      expect(restoredRows.last.description, 'Transaction 2');
+    });
+
+    test(
+      'recreates a usable schema when the database file is malformed',
+      () async {
+        final path = _dbPath(tempDir, 'corrupted.db');
+        await File(path).writeAsBytes('not-a-sqlite-database'.codeUnits);
+
+        final db = AppDatabase(databasePath: path);
+        addTearDown(db.close);
+
+        final tables = await db
+            .customSelect(
+              "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'transaction_entries';",
+            )
+            .get();
+
+        expect(tables, hasLength(1));
+        expect(await _transactionCount(db), 0);
+      },
+    );
+
+    test('restores larger local histories without dropping rows', () async {
+      final sourcePath = _dbPath(tempDir, 'history-source.db');
+      final restoredPath = _dbPath(tempDir, 'history-restored.db');
+      final source = AppDatabase(databasePath: sourcePath);
+      await _seedTransactions(source, count: 250);
+
+      final backup = await source.exportDatabase();
+      await source.close();
+
+      await AppDatabase.restoreBackup(backup, databasePath: restoredPath);
+      final restored = AppDatabase(databasePath: restoredPath);
+      addTearDown(restored.close);
+
+      expect(await _transactionCount(restored), 250);
+      final sample = await (restored.select(
+        restored.transactionEntries,
+      )..where((tbl) => tbl.uuid.equals('txn-249'))).getSingle();
+      expect(sample.description, 'Transaction 249');
+    });
+  });
+}
+
+String _dbPath(Directory dir, String name) => p.join(dir.path, name);
+
+Future<void> _seedTransactions(AppDatabase db, {required int count}) async {
+  for (var i = 0; i < count; i++) {
+    await db
+        .into(db.transactionEntries)
+        .insert(
+          TransactionEntriesCompanion.insert(
+            uuid: 'txn-$i',
+            accountId: 'account-1',
+            timestamp: DateTime.utc(2026, 6, 29, 12, i % 60),
+            amountCents: -1000 - i,
+            description: 'Transaction $i',
+            category: 'meeting',
+          ),
+        );
+  }
+}
+
+Future<int> _transactionCount(AppDatabase db) async {
+  final countRow = await db
+      .customSelect('SELECT COUNT(*) AS count FROM transaction_entries;')
+      .getSingle();
+  return countRow.read<int>('count');
+}

--- a/docs/release/DATABASE_RELIABILITY_VALIDATION.md
+++ b/docs/release/DATABASE_RELIABILITY_VALIDATION.md
@@ -1,0 +1,68 @@
+# Database Reliability Validation
+
+Deterministic validation runbook for issue `#516`.
+
+This slice covers native database migration/open behavior, malformed-file
+recovery, backup/restore, and larger local-history durability.
+
+## Automated Checks
+
+Run the shared database-reliability suite from the repository root:
+
+```sh
+make test-database-reliability
+```
+
+Current automated coverage proves:
+
+- native database opens with expected SQLite PRAGMAs
+- malformed database files are recreated into a usable schema on open
+- exported backup bytes restore into a fresh database instance
+- larger local histories survive backup/restore round trips without row loss
+
+## Host-Runnable Acceptance
+
+The automated portion passes when:
+
+- the command succeeds with no failing tests
+- restored databases preserve the expected row count and sample records
+- malformed database files do not crash the open path
+- the recreated schema remains queryable after recovery
+
+## Manual / Device Matrix
+
+These checks still require device or manual verification because they depend on
+real user state, upgrade paths, or file transfer behavior outside host tests.
+
+| Scenario | Steps | Expected |
+| --- | --- | --- |
+| Migration | Install older app build or fixture DB, then upgrade | Existing data opens without destructive migration |
+| Crash recovery | Kill app during active DB writes, relaunch | Database remains readable and app recovers safely |
+| Corrupted database | Replace DB with malformed file on a test device, relaunch | App recreates a usable DB instead of crashing |
+| Large meeting history | Import or generate large local history, relaunch and query | Reads remain responsive and complete |
+| Search indexing | Verify persisted feature data remains queryable after restore/upgrade | Relevant search surfaces still return expected items |
+| Backup | Export native DB file | Backup artifact is produced and readable |
+| Restore | Restore backup onto device or local fixture path | App opens restored data correctly |
+
+## Suggested Android Checks
+
+Use a connected device when possible:
+
+```sh
+make run-android-auto
+```
+
+Then manually verify:
+
+1. Start with real local data, force-stop the app during active usage, and relaunch.
+2. Replace the on-device database with a backed-up copy and confirm the app opens.
+3. Exercise a large local dataset and confirm reads/search still work after relaunch.
+4. Record any upgrade, corruption, or restore deviations in the PR or release notes.
+
+## Evidence to Attach Before Closing
+
+Before issue `#516` can be closed, attach:
+
+- output from `make test-database-reliability`
+- notes for any exercised migration/crash-recovery/device restore paths
+- any waived manual checks or known platform limitations

--- a/docs/release/RELEASE_CHECKLIST.md
+++ b/docs/release/RELEASE_CHECKLIST.md
@@ -23,6 +23,7 @@ Pre-release verification checklist for Airo Super App releases.
 - [ ] Integration tests passing
 - [ ] E2E smoke tests passing
 - [ ] Shared UI responsiveness suite passing (`make test-ui-responsive`)
+- [ ] Database reliability validation suite passing (`make test-database-reliability`)
 - [ ] Background processing validation suite passing (`make test-background-processing`)
 - [ ] Meeting search validation suite passing (`make test-meeting-search`)
 - [ ] Performance benchmark report created (`artifacts/performance/...`)
@@ -120,6 +121,7 @@ Pre-release verification checklist for Airo Super App releases.
 - [ ] Release notes written
 - [ ] Known issues documented
 - [ ] Migration guide (if breaking changes)
+- [ ] [Database reliability validation runbook](./DATABASE_RELIABILITY_VALIDATION.md) followed
 - [ ] [Meeting search validation runbook](./MEETING_SEARCH_VALIDATION.md) followed
 - [ ] [Background processing validation runbook](./BACKGROUND_PROCESSING_VALIDATION.md) followed
 - [ ] [UI responsiveness validation runbook](./UI_RESPONSIVENESS_VALIDATION.md) followed
@@ -153,6 +155,7 @@ Date: ____-__-__
 - [Build & Release Workflow](/.github/workflows/build-and-release.yml)
 - [Rollback Procedure](./ROLLBACK_PROCEDURE.md)
 - [Store Compliance](./STORE_COMPLIANCE.md)
+- [Database Reliability Validation](./DATABASE_RELIABILITY_VALIDATION.md)
 - [Meeting Search Validation](./MEETING_SEARCH_VALIDATION.md)
 - [Background Processing Validation](./BACKGROUND_PROCESSING_VALIDATION.md)
 - [UI Responsiveness Validation](./UI_RESPONSIVENESS_VALIDATION.md)


### PR DESCRIPTION
# fix(database): add native reliability validation

---

# Summary

This PR introduces changes to the native database reliability contract.
Goal: make local database backup/restore and malformed-file recovery deterministic and verifiable on current main.

Core outcome:

* adds file-based backup/restore helpers plus malformed-file recovery before native Drift open
* adds a repeatable validation suite and release runbook for database reliability

---

# Changes

### Code

* Added:

  * deterministic native database reliability tests
  * release runbook for database reliability validation
  * shared `make test-database-reliability` target
* Updated:

  * native `AppDatabase` with path-based construction, backup restore helpers, WAL-aware export, and malformed-file recovery
  * release checklist to include database reliability validation

### Logic

* checkpoints WAL before reading backup bytes so exported backups include current writes
* recreates obviously malformed database files before Drift opens them
* supports restoring backup bytes to an explicit database path for deterministic recovery testing

---

# API Changes (if any)

* `AppDatabase` now accepts an optional native database path.
* `AppDatabase.restoreBackup(...)` and `restoreDatabase(...)` are added for backup restore flows.

---

# Database Changes (if any)

* No schema version bump.
* No destructive migration.
* Reliability behavior around open/export/restore is strengthened for the existing schema.

---

# Observability / Logging

* None

---

# Performance Impact

* Latency: negligible except when explicitly exporting a backup due to WAL checkpointing
* Throughput: no expected runtime regression for ordinary CRUD paths
* Memory/CPU: no meaningful steady-state change

---

# Risks

* malformed-file detection currently targets obvious non-SQLite files rather than deeper logical corruption
* backup export now performs a checkpoint, which is correct for durability but should remain limited to explicit backup paths
* Rollback plan:

  * revert this PR to restore the prior database open/export behavior and remove the validation target/docs

---

# Testing

* Unit tests:

  * `flutter test test/core/database/app_database_reliability_test.dart`
* Integration tests:

  * none
* Manual testing:

  * `adb devices -l` confirms a reachable Pixel 9 for device-only follow-up checks
  * focused docs/runbook validation and release checklist update

---

# Deployment Notes

* Config changes:

  * none
* Order of deployment:

  * normal merge to `main`

---

# Related Commits

* `fix(database): add native reliability validation`

---

# Notes

* Addresses #516
* Device-only migration/crash-recovery/restore paths remain documented in `docs/release/DATABASE_RELIABILITY_VALIDATION.md`.

