### PR TITLE
test(notifications): add scheduler validation suite

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -341,6 +341,13 @@ test-database-reliability: ## Run deterministic native database reliability vali
 	@echo "$(GREEN)Database-reliability validation complete.$(NC)"
 	@echo "$(YELLOW)See docs/release/DATABASE_RELIABILITY_VALIDATION.md for scope and follow-up.$(NC)"
 
+.PHONY: test-notification-validation
+test-notification-validation: ## Run deterministic notification validation suite
+	@echo "$(BLUE)Running notification validation suite...$(NC)"
+	@cd $(APP_DIR) && flutter test test/features/agent_chat/data/services/agent_notification_scheduler_test.dart
+	@echo "$(GREEN)Notification validation complete.$(NC)"
+	@echo "$(YELLOW)See docs/release/NOTIFICATION_VALIDATION.md for scope and follow-up.$(NC)"
+
 .PHONY: run-android
 run-android: run-pixel9 ## Run app on local Pixel 9 Android emulator
 

--- a/app/lib/features/agent_chat/data/services/agent_notification_scheduler.dart
+++ b/app/lib/features/agent_chat/data/services/agent_notification_scheduler.dart
@@ -177,9 +177,14 @@ class LocalAgentNotificationScheduler
     implements AgentNotificationSchedulingService {
   LocalAgentNotificationScheduler({
     FlutterLocalNotificationsPlugin? notificationsPlugin,
+    SharedPreferencesAsync? preferences,
+  }) : this._internal(notificationsPlugin, preferences);
+
+  LocalAgentNotificationScheduler._internal(
+    FlutterLocalNotificationsPlugin? notificationsPlugin,
     this._preferences,
-  }) : _notificationsPlugin =
-           notificationsPlugin ?? FlutterLocalNotificationsPlugin();
+  ) : _notificationsPlugin =
+          notificationsPlugin ?? FlutterLocalNotificationsPlugin();
 
   static final LocalAgentNotificationScheduler instance =
       LocalAgentNotificationScheduler();
@@ -203,6 +208,18 @@ class LocalAgentNotificationScheduler
     ScheduleAgentNotificationRequest request,
   ) async {
     _validate(request);
+    final existingNotifications = await getScheduledNotifications();
+    ScheduledAgentNotification? duplicate;
+    for (final notification in existingNotifications) {
+      if (_matchesRequest(notification, request)) {
+        duplicate = notification;
+        break;
+      }
+    }
+    if (duplicate != null) {
+      return duplicate;
+    }
+
     await _ensureInitialized();
     final hasPermission = await _requestNotificationPermission();
     if (!hasPermission) {
@@ -257,11 +274,11 @@ class LocalAgentNotificationScheduler
       matchDateTimeComponents: request.repeatDaily
           ? DateTimeComponents.time
           : null,
+      payload: _payloadFor(notification),
     );
 
-    final notifications = await getScheduledNotifications();
     await _saveScheduledNotifications([
-      ...notifications.where((item) => item.id != notification.id),
+      ...existingNotifications.where((item) => item.id != notification.id),
       notification,
     ]);
 
@@ -437,9 +454,11 @@ class LocalAgentNotificationScheduler
   Future<void> _saveScheduledNotifications(
     List<ScheduledAgentNotification> notifications,
   ) async {
+    final sorted = [...notifications]
+      ..sort((a, b) => a.scheduledAt.compareTo(b.scheduledAt));
     await _asyncPreferences.setString(
       _storageKey,
-      jsonEncode(notifications.map((item) => item.toJson()).toList()),
+      jsonEncode(sorted.map((item) => item.toJson()).toList()),
     );
   }
 
@@ -469,10 +488,63 @@ class LocalAgentNotificationScheduler
       );
     }
   }
+
+  bool _matchesRequest(
+    ScheduledAgentNotification notification,
+    ScheduleAgentNotificationRequest request,
+  ) {
+    return notification.title == request.title &&
+        notification.message == request.message &&
+        notification.hour == request.hour &&
+        notification.minute == request.minute &&
+        notification.repeatDaily == request.repeatDaily &&
+        notification.date == request.date &&
+        notification.category == request.category &&
+        notification.scheduleType == request.scheduleType &&
+        notification.requiresCompletion == request.requiresCompletion &&
+        notification.followUpPolicy == request.followUpPolicy &&
+        _canonicalJson(notification.metadata) ==
+            _canonicalJson(request.metadata);
+  }
+
+  String _payloadFor(ScheduledAgentNotification notification) {
+    final payload = <String, Object?>{
+      'version': 1,
+      'notification_id': notification.id,
+      'category': notification.category,
+      'schedule_type': notification.scheduleType,
+      'requires_completion': notification.requiresCompletion,
+      if (notification.groupId != null) 'group_id': notification.groupId,
+      if (notification.date != null) 'date': notification.date,
+      if (notification.metadata case {
+        'deep_link': final String deepLink,
+      } when deepLink.trim().isNotEmpty)
+        'deep_link': deepLink,
+      if (notification.metadata.isNotEmpty) 'metadata': notification.metadata,
+    };
+    return _canonicalJson(payload);
+  }
 }
 
 String _formatDate(DateTime value) {
   return '${value.year.toString().padLeft(4, '0')}-'
       '${value.month.toString().padLeft(2, '0')}-'
       '${value.day.toString().padLeft(2, '0')}';
+}
+
+String _canonicalJson(Object? value) {
+  return jsonEncode(_canonicalizeJson(value));
+}
+
+Object? _canonicalizeJson(Object? value) {
+  if (value is Map) {
+    final keys = value.keys.map((key) => key.toString()).toList()..sort();
+    return <String, Object?>{
+      for (final key in keys) key: _canonicalizeJson(value[key]),
+    };
+  }
+  if (value is List) {
+    return value.map(_canonicalizeJson).toList();
+  }
+  return value;
 }

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -1681,7 +1681,7 @@ packages:
     source: hosted
     version: "2.4.1"
   shared_preferences_platform_interface:
-    dependency: transitive
+    dependency: "direct dev"
     description:
       name: shared_preferences_platform_interface
       sha256: "649dc798a33931919ea356c4305c2d1f81619ea6e92244070b520187b5140ef9"

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -128,6 +128,7 @@ dev_dependencies:
   mocktail: ^1.0.5
   alchemist: ^0.14.0  # Golden testing (replaces discontinued golden_toolkit)
   patrol: ^4.1.1  # E2E testing for iOS/Android devices (updated for compileSdk 34+ support)
+  shared_preferences_platform_interface: ^2.4.1
 
   # Linting
   flutter_lints: 6.0.0

--- a/app/test/features/agent_chat/data/services/agent_notification_scheduler_test.dart
+++ b/app/test/features/agent_chat/data/services/agent_notification_scheduler_test.dart
@@ -1,0 +1,305 @@
+import 'dart:convert';
+
+import 'package:airo_app/features/agent_chat/data/services/agent_notification_scheduler.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:shared_preferences_platform_interface/shared_preferences_async_platform_interface.dart';
+import 'package:shared_preferences_platform_interface/types.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const notificationsChannel = MethodChannel(
+    'dexterous.com/flutter/local_notifications',
+  );
+
+  late SharedPreferencesAsync preferences;
+  late LocalAgentNotificationScheduler scheduler;
+  late List<MethodCall> methodCalls;
+
+  setUp(() async {
+    debugDefaultTargetPlatformOverride = TargetPlatform.android;
+    AndroidFlutterLocalNotificationsPlugin.registerWith();
+    SharedPreferences.setMockInitialValues({});
+    SharedPreferencesAsyncPlatform.instance =
+        _InMemoryPreferencesAsyncPlatform();
+    preferences = SharedPreferencesAsync();
+    await preferences.clear();
+    methodCalls = [];
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(notificationsChannel, (call) async {
+          methodCalls.add(call);
+          switch (call.method) {
+            case 'initialize':
+              return true;
+            case 'requestNotificationsPermission':
+              return true;
+            case 'zonedSchedule':
+            case 'cancel':
+              return null;
+            default:
+              return null;
+          }
+        });
+    scheduler = LocalAgentNotificationScheduler(
+      notificationsPlugin: FlutterLocalNotificationsPlugin(),
+      preferences: preferences,
+    );
+  });
+
+  tearDown(() async {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(notificationsChannel, null);
+    debugDefaultTargetPlatformOverride = null;
+  });
+
+  test(
+    'suppresses duplicate schedules and emits stable deep-link payloads',
+    () async {
+      const request = ScheduleAgentNotificationRequest(
+        title: 'Download model',
+        message: 'Open the downloads screen for progress updates.',
+        hour: 9,
+        minute: 30,
+        repeatDaily: true,
+        category: 'downloads',
+        scheduleType: 'progress',
+        metadata: {
+          'deep_link': '/mind/notifications?tab=downloads',
+          'download_id': 'gemma-3n-e4b-it',
+        },
+      );
+
+      final first = await scheduler.scheduleNotification(request);
+      final duplicate = await scheduler.scheduleNotification(request);
+
+      expect(duplicate.id, first.id);
+      expect(await scheduler.getScheduledNotifications(), hasLength(1));
+
+      final zonedCalls = methodCalls.where(
+        (call) => call.method == 'zonedSchedule',
+      );
+      expect(zonedCalls, hasLength(1));
+
+      final payload =
+          jsonDecode((zonedCalls.single.arguments as Map)['payload'] as String)
+              as Map<String, dynamic>;
+      expect(payload['version'], 1);
+      expect(payload['notification_id'], first.id);
+      expect(payload['category'], 'downloads');
+      expect(payload['schedule_type'], 'progress');
+      expect(payload['deep_link'], '/mind/notifications?tab=downloads');
+      expect(
+        payload['metadata'],
+        containsPair('download_id', 'gemma-3n-e4b-it'),
+      );
+    },
+  );
+
+  test('marks completion once and cancels daily follow-up reminders', () async {
+    final scheduled = await scheduler.scheduleNotification(
+      const ScheduleAgentNotificationRequest(
+        title: 'Finish recording',
+        message: 'Return to the recorder and complete the upload.',
+        hour: 18,
+        minute: 0,
+        repeatDaily: true,
+        category: 'recording',
+        scheduleType: 'follow_up',
+        requiresCompletion: true,
+        followUpPolicy: 'daily_until_done',
+        metadata: {'deep_link': '/mind/recordings'},
+      ),
+    );
+
+    final completed = await scheduler.markNotificationComplete(scheduled.id);
+    final repeated = await scheduler.markNotificationComplete(scheduled.id);
+
+    expect(completed, isNotNull);
+    expect(completed!.streakCount, 1);
+    expect(completed.points, 10);
+    expect(completed.completedDates, hasLength(1));
+    expect(repeated!.streakCount, 1);
+    expect(repeated.points, 10);
+
+    final cancelCalls = methodCalls.where((call) => call.method == 'cancel');
+    expect(cancelCalls, hasLength(1));
+    expect(cancelCalls.single.arguments, containsPair('id', scheduled.id));
+  });
+
+  test('recovers stored notifications in scheduled order', () async {
+    await preferences.setString(
+      'agent_scheduled_notifications_v1',
+      jsonEncode([
+        _notificationJson(
+          id: 2,
+          title: 'Later',
+          hour: 22,
+          minute: 15,
+          scheduledAt: DateTime(2026, 6, 30, 22, 15),
+        ),
+        _notificationJson(
+          id: 1,
+          title: 'Earlier',
+          hour: 8,
+          minute: 45,
+          scheduledAt: DateTime(2026, 6, 30, 8, 45),
+        ),
+      ]),
+    );
+
+    final notifications = await scheduler.getScheduledNotifications();
+
+    expect(notifications.map((item) => item.id).toList(), [1, 2]);
+    expect(notifications.first.title, 'Earlier');
+    expect(notifications.last.title, 'Later');
+  });
+}
+
+Map<String, dynamic> _notificationJson({
+  required int id,
+  required String title,
+  required int hour,
+  required int minute,
+  required DateTime scheduledAt,
+}) {
+  return {
+    'id': id,
+    'title': title,
+    'message': '$title body',
+    'hour': hour,
+    'minute': minute,
+    'repeat_daily': true,
+    'category': 'general',
+    'schedule_type': 'daily_time',
+    'requires_completion': false,
+    'follow_up_policy': 'none',
+    'completed_dates': const <String>[],
+    'streak_count': 0,
+    'points': 0,
+    'scheduled_at': scheduledAt.toIso8601String(),
+    'created_at': DateTime(2026, 6, 29, 12).toIso8601String(),
+  };
+}
+
+final class _InMemoryPreferencesAsyncPlatform
+    extends SharedPreferencesAsyncPlatform {
+  final Map<String, Object> _values = {};
+
+  @override
+  Future<void> clear(
+    ClearPreferencesParameters parameters,
+    SharedPreferencesOptions options,
+  ) async {
+    final allowList = parameters.filter.allowList;
+    if (allowList == null) {
+      _values.clear();
+      return;
+    }
+    _values.removeWhere((key, _) => allowList.contains(key));
+  }
+
+  @override
+  Future<bool?> getBool(String key, SharedPreferencesOptions options) async {
+    return _values[key] as bool?;
+  }
+
+  @override
+  Future<double?> getDouble(
+    String key,
+    SharedPreferencesOptions options,
+  ) async {
+    return _values[key] as double?;
+  }
+
+  @override
+  Future<int?> getInt(String key, SharedPreferencesOptions options) async {
+    return _values[key] as int?;
+  }
+
+  @override
+  Future<Map<String, Object>> getPreferences(
+    GetPreferencesParameters parameters,
+    SharedPreferencesOptions options,
+  ) async {
+    final allowList = parameters.filter.allowList;
+    if (allowList == null) {
+      return Map<String, Object>.from(_values);
+    }
+    return Map<String, Object>.fromEntries(
+      _values.entries.where((entry) => allowList.contains(entry.key)),
+    );
+  }
+
+  @override
+  Future<Set<String>> getKeys(
+    GetPreferencesParameters parameters,
+    SharedPreferencesOptions options,
+  ) async {
+    return (await getPreferences(parameters, options)).keys.toSet();
+  }
+
+  @override
+  Future<String?> getString(
+    String key,
+    SharedPreferencesOptions options,
+  ) async {
+    return _values[key] as String?;
+  }
+
+  @override
+  Future<List<String>?> getStringList(
+    String key,
+    SharedPreferencesOptions options,
+  ) async {
+    return (_values[key] as List<Object?>?)?.cast<String>();
+  }
+
+  @override
+  Future<void> setBool(
+    String key,
+    bool value,
+    SharedPreferencesOptions options,
+  ) async {
+    _values[key] = value;
+  }
+
+  @override
+  Future<void> setDouble(
+    String key,
+    double value,
+    SharedPreferencesOptions options,
+  ) async {
+    _values[key] = value;
+  }
+
+  @override
+  Future<void> setInt(
+    String key,
+    int value,
+    SharedPreferencesOptions options,
+  ) async {
+    _values[key] = value;
+  }
+
+  @override
+  Future<void> setString(
+    String key,
+    String value,
+    SharedPreferencesOptions options,
+  ) async {
+    _values[key] = value;
+  }
+
+  @override
+  Future<void> setStringList(
+    String key,
+    List<String> value,
+    SharedPreferencesOptions options,
+  ) async {
+    _values[key] = List<String>.from(value);
+  }
+}

--- a/docs/release/NOTIFICATION_VALIDATION.md
+++ b/docs/release/NOTIFICATION_VALIDATION.md
@@ -1,0 +1,58 @@
+# Notification Validation
+
+Deterministic validation runbook for issue `#515`.
+
+This runbook covers the framework-owned notification scheduler contract that can
+be verified on the host, and separates the remaining Android/device-only cases
+that still depend on OS presentation and tap-routing behavior.
+
+## Automated Checks
+
+Run the focused notification validation suite from the repository root:
+
+```sh
+make test-notification-validation
+```
+
+This command currently covers:
+
+- `app/test/features/agent_chat/data/services/agent_notification_scheduler_test.dart`
+  - duplicate reminder suppression at the scheduler layer
+  - stable notification payload generation for deep-link metadata
+  - completion bookkeeping for reminders that repeat until done
+  - persistence recovery and scheduled ordering
+
+## Host-Runnable Acceptance
+
+The automated portion passes when:
+
+- the test command succeeds with no failing tests
+- scheduling the same reminder twice results in one stored reminder and one
+  platform scheduling call
+- the emitted notification payload preserves the intended deep-link context
+- completion awards points once and cancels the follow-up notification when the
+  policy is `daily_until_done`
+- stored reminders reload in chronological order from persistence
+
+## Device-Only Manual Matrix
+
+These checks still require a physical Android device because they depend on OS
+notification presentation, launcher state, and notification-tap routing.
+
+| Scenario | Steps | Expected |
+| --- | --- | --- |
+| Recording notification | Start a recording flow that schedules a reminder | OS notification appears with the expected title/body |
+| Download progress | Trigger a local model download and background the app | Progress notification updates instead of duplicating |
+| Completion | Let a download or recording complete | Completion notification replaces progress state cleanly |
+| Failure | Force a failing download/recording path | Failure notification is visible and distinct from success |
+| Deep link | Tap the notification from the shade | App opens the intended screen/state for that payload |
+| Foreground suppression | Keep the app foregrounded during the same event | App does not spam duplicate visible notifications |
+
+## Evidence to Attach Before Closing
+
+Before issue `#515` can be closed, attach:
+
+- output from `make test-notification-validation`
+- `adb devices -l` output showing the Android device used for manual checks
+- notes for the device-only matrix above, including any waivers or platform
+  limitations

--- a/docs/release/RELEASE_CHECKLIST.md
+++ b/docs/release/RELEASE_CHECKLIST.md
@@ -26,6 +26,7 @@ Pre-release verification checklist for Airo Super App releases.
 - [ ] Database reliability validation suite passing (`make test-database-reliability`)
 - [ ] Background processing validation suite passing (`make test-background-processing`)
 - [ ] Meeting search validation suite passing (`make test-meeting-search`)
+- [ ] Notification validation suite passing (`make test-notification-validation`)
 - [ ] Performance benchmark report created (`artifacts/performance/...`)
 - [ ] Battery impact measurements attached or explicitly waived
 - [ ] Manual QA sign-off (if required)
@@ -124,6 +125,7 @@ Pre-release verification checklist for Airo Super App releases.
 - [ ] [Database reliability validation runbook](./DATABASE_RELIABILITY_VALIDATION.md) followed
 - [ ] [Meeting search validation runbook](./MEETING_SEARCH_VALIDATION.md) followed
 - [ ] [Background processing validation runbook](./BACKGROUND_PROCESSING_VALIDATION.md) followed
+- [ ] [Notification validation runbook](./NOTIFICATION_VALIDATION.md) followed
 - [ ] [UI responsiveness validation runbook](./UI_RESPONSIVENESS_VALIDATION.md) followed
 - [ ] [Performance benchmark runbook](./PERFORMANCE_BENCHMARKS.md) followed
 
@@ -158,5 +160,6 @@ Date: ____-__-__
 - [Database Reliability Validation](./DATABASE_RELIABILITY_VALIDATION.md)
 - [Meeting Search Validation](./MEETING_SEARCH_VALIDATION.md)
 - [Background Processing Validation](./BACKGROUND_PROCESSING_VALIDATION.md)
+- [Notification Validation](./NOTIFICATION_VALIDATION.md)
 - [UI Responsiveness Validation](./UI_RESPONSIVENESS_VALIDATION.md)
 - [Performance Benchmarks](./PERFORMANCE_BENCHMARKS.md)

--- a/docs/wiki/5.-AI-and-Model-Management.md
+++ b/docs/wiki/5.-AI-and-Model-Management.md
@@ -82,4 +82,21 @@ The Agent Skills plan extends the current card and routing system with:
 - Action traces.
 - Calendar read/create as the first end-to-end connector.
 
+## Reminder Notifications
+
+Agent-created reminder notifications now preserve stable deep-link context in
+their payloads so the app can reopen the intended reminder flow consistently.
+
+At the scheduler layer, Airo also suppresses duplicate reminder scheduling for
+the same request instead of creating repeated entries.
+
+Release validation for this path is split into:
+
+- host-runnable scheduler checks via `make test-notification-validation`
+- Android device checks for OS presentation, progress/completion behavior, and
+  notification tap routing
+
+See [Notification Validation](../release/NOTIFICATION_VALIDATION.md) for the
+current runbook and remaining manual matrix.
+
 See [Airo Agent Skills and Connectors v2 Plan](../superpowers/plans/2026-06-20-airo-agent-skills-connectors.md).


### PR DESCRIPTION
# Summary

This PR introduces changes to the notification scheduler validation path.
Goal: make issue #515 reproducible with deterministic host-runnable coverage while documenting the remaining device-only notification checks.

Core outcome:

* suppresses duplicate reminder scheduling in the shared scheduler
* emits stable deep-link payloads for notification routing context
* adds focused scheduler tests, a Make target, and a release runbook for notification validation

# Changes

### Code

* Added:
  * scheduler validation test coverage in `app/test/features/agent_chat/data/services/agent_notification_scheduler_test.dart`
  * notification validation runbook in `docs/release/NOTIFICATION_VALIDATION.md`
* Updated:
  * shared scheduler duplicate suppression and payload generation in `app/lib/features/agent_chat/data/services/agent_notification_scheduler.dart`
  * release checklist and validation entry point in `docs/release/RELEASE_CHECKLIST.md` and `Makefile`
  * app dev dependency wiring for the async preferences platform test harness in `app/pubspec.yaml`

### Logic

* duplicate reminder requests now return the existing scheduled notification instead of scheduling again
* zoned notifications now carry a stable JSON payload with category, schedule type, deep link, and metadata
* completion bookkeeping still awards points once and cancels `daily_until_done` reminders after completion
* persisted scheduled reminders are stored and reloaded in chronological order

# API Changes (if any)

* No external API changes.

# Database Changes (if any)

* None.

# Observability / Logging

* None.

# Performance Impact

* Negligible. Duplicate suppression avoids unnecessary platform schedule calls.

# Risks

* Deep-link payload structure is now standardized; downstream tap-handling code should continue to treat payloads as opaque JSON.
* Device-only OS presentation and tap-routing flows still require manual verification.
* Rollback plan:
  * revert this PR to restore prior scheduling behavior and remove the validation artifacts

# Testing

* Unit tests:
  * `make test-notification-validation`
* Integration tests:
  * none in this slice
* Manual testing:
  * `adb devices -l` confirmed a connected Pixel 9 is available for the device-only matrix
  * device-only notification scenarios are documented in `docs/release/NOTIFICATION_VALIDATION.md`

# Deployment Notes

* No config changes.

# Related Commits

* `test(notifications): add scheduler validation suite`

# Notes

* This addresses the framework-owned portion of issue #515; recording/download presentation and tap-routing still need the documented Android manual matrix before the issue can close.
