### PR TITLE
chore: regenerate drift database output

### DIFF
--- a/app/lib/core/database/app_database_native.g.dart
+++ b/app/lib/core/database/app_database_native.g.dart
@@ -12,162 +12,107 @@ class $TransactionEntriesTable extends TransactionEntries
   static const VerificationMeta _idMeta = const VerificationMeta('id');
   @override
   late final GeneratedColumn<int> id = GeneratedColumn<int>(
-    'id',
-    aliasedName,
-    false,
-    hasAutoIncrement: true,
-    type: DriftSqlType.int,
-    requiredDuringInsert: false,
-    defaultConstraints: GeneratedColumn.constraintIsAlways(
-      'PRIMARY KEY AUTOINCREMENT',
-    ),
-  );
+      'id', aliasedName, false,
+      hasAutoIncrement: true,
+      type: DriftSqlType.int,
+      requiredDuringInsert: false,
+      defaultConstraints:
+          GeneratedColumn.constraintIsAlways('PRIMARY KEY AUTOINCREMENT'));
   static const VerificationMeta _uuidMeta = const VerificationMeta('uuid');
   @override
   late final GeneratedColumn<String> uuid = GeneratedColumn<String>(
-    'uuid',
-    aliasedName,
-    false,
-    type: DriftSqlType.string,
-    requiredDuringInsert: true,
-    defaultConstraints: GeneratedColumn.constraintIsAlways('UNIQUE'),
-  );
-  static const VerificationMeta _accountIdMeta = const VerificationMeta(
-    'accountId',
-  );
+      'uuid', aliasedName, false,
+      type: DriftSqlType.string,
+      requiredDuringInsert: true,
+      defaultConstraints: GeneratedColumn.constraintIsAlways('UNIQUE'));
+  static const VerificationMeta _accountIdMeta =
+      const VerificationMeta('accountId');
   @override
   late final GeneratedColumn<String> accountId = GeneratedColumn<String>(
-    'account_id',
-    aliasedName,
-    false,
-    type: DriftSqlType.string,
-    requiredDuringInsert: true,
-  );
-  static const VerificationMeta _timestampMeta = const VerificationMeta(
-    'timestamp',
-  );
+      'account_id', aliasedName, false,
+      type: DriftSqlType.string, requiredDuringInsert: true);
+  static const VerificationMeta _timestampMeta =
+      const VerificationMeta('timestamp');
   @override
   late final GeneratedColumn<DateTime> timestamp = GeneratedColumn<DateTime>(
-    'timestamp',
-    aliasedName,
-    false,
-    type: DriftSqlType.dateTime,
-    requiredDuringInsert: true,
-  );
-  static const VerificationMeta _amountCentsMeta = const VerificationMeta(
-    'amountCents',
-  );
+      'timestamp', aliasedName, false,
+      type: DriftSqlType.dateTime, requiredDuringInsert: true);
+  static const VerificationMeta _amountCentsMeta =
+      const VerificationMeta('amountCents');
   @override
   late final GeneratedColumn<int> amountCents = GeneratedColumn<int>(
-    'amount_cents',
-    aliasedName,
-    false,
-    type: DriftSqlType.int,
-    requiredDuringInsert: true,
-  );
-  static const VerificationMeta _descriptionMeta = const VerificationMeta(
-    'description',
-  );
+      'amount_cents', aliasedName, false,
+      type: DriftSqlType.int, requiredDuringInsert: true);
+  static const VerificationMeta _descriptionMeta =
+      const VerificationMeta('description');
   @override
   late final GeneratedColumn<String> description = GeneratedColumn<String>(
-    'description',
-    aliasedName,
-    false,
-    type: DriftSqlType.string,
-    requiredDuringInsert: true,
-  );
-  static const VerificationMeta _categoryMeta = const VerificationMeta(
-    'category',
-  );
+      'description', aliasedName, false,
+      type: DriftSqlType.string, requiredDuringInsert: true);
+  static const VerificationMeta _categoryMeta =
+      const VerificationMeta('category');
   @override
   late final GeneratedColumn<String> category = GeneratedColumn<String>(
-    'category',
-    aliasedName,
-    false,
-    type: DriftSqlType.string,
-    requiredDuringInsert: true,
-  );
+      'category', aliasedName, false,
+      type: DriftSqlType.string, requiredDuringInsert: true);
   static const VerificationMeta _tagsMeta = const VerificationMeta('tags');
   @override
   late final GeneratedColumn<String> tags = GeneratedColumn<String>(
-    'tags',
-    aliasedName,
-    false,
-    type: DriftSqlType.string,
-    requiredDuringInsert: false,
-    defaultValue: const Constant('[]'),
-  );
-  static const VerificationMeta _receiptUrlMeta = const VerificationMeta(
-    'receiptUrl',
-  );
+      'tags', aliasedName, false,
+      type: DriftSqlType.string,
+      requiredDuringInsert: false,
+      defaultValue: const Constant('[]'));
+  static const VerificationMeta _receiptUrlMeta =
+      const VerificationMeta('receiptUrl');
   @override
   late final GeneratedColumn<String> receiptUrl = GeneratedColumn<String>(
-    'receipt_url',
-    aliasedName,
-    true,
-    type: DriftSqlType.string,
-    requiredDuringInsert: false,
-  );
-  static const VerificationMeta _syncStatusMeta = const VerificationMeta(
-    'syncStatus',
-  );
+      'receipt_url', aliasedName, true,
+      type: DriftSqlType.string, requiredDuringInsert: false);
+  static const VerificationMeta _syncStatusMeta =
+      const VerificationMeta('syncStatus');
   @override
   late final GeneratedColumn<String> syncStatus = GeneratedColumn<String>(
-    'sync_status',
-    aliasedName,
-    false,
-    type: DriftSqlType.string,
-    requiredDuringInsert: false,
-    defaultValue: const Constant('pending'),
-  );
-  static const VerificationMeta _createdAtMeta = const VerificationMeta(
-    'createdAt',
-  );
+      'sync_status', aliasedName, false,
+      type: DriftSqlType.string,
+      requiredDuringInsert: false,
+      defaultValue: const Constant('pending'));
+  static const VerificationMeta _createdAtMeta =
+      const VerificationMeta('createdAt');
   @override
   late final GeneratedColumn<DateTime> createdAt = GeneratedColumn<DateTime>(
-    'created_at',
-    aliasedName,
-    false,
-    type: DriftSqlType.dateTime,
-    requiredDuringInsert: false,
-    defaultValue: currentDateAndTime,
-  );
-  static const VerificationMeta _updatedAtMeta = const VerificationMeta(
-    'updatedAt',
-  );
+      'created_at', aliasedName, false,
+      type: DriftSqlType.dateTime,
+      requiredDuringInsert: false,
+      defaultValue: currentDateAndTime);
+  static const VerificationMeta _updatedAtMeta =
+      const VerificationMeta('updatedAt');
   @override
   late final GeneratedColumn<DateTime> updatedAt = GeneratedColumn<DateTime>(
-    'updated_at',
-    aliasedName,
-    true,
-    type: DriftSqlType.dateTime,
-    requiredDuringInsert: false,
-  );
+      'updated_at', aliasedName, true,
+      type: DriftSqlType.dateTime, requiredDuringInsert: false);
   @override
   List<GeneratedColumn> get $columns => [
-    id,
-    uuid,
-    accountId,
-    timestamp,
-    amountCents,
-    description,
-    category,
-    tags,
-    receiptUrl,
-    syncStatus,
-    createdAt,
-    updatedAt,
-  ];
+        id,
+        uuid,
+        accountId,
+        timestamp,
+        amountCents,
+        description,
+        category,
+        tags,
+        receiptUrl,
+        syncStatus,
+        createdAt,
+        updatedAt
+      ];
   @override
   String get aliasedName => _alias ?? actualTableName;
   @override
   String get actualTableName => $name;
   static const String $name = 'transaction_entries';
   @override
-  VerificationContext validateIntegrity(
-    Insertable<TransactionEntry> instance, {
-    bool isInserting = false,
-  }) {
+  VerificationContext validateIntegrity(Insertable<TransactionEntry> instance,
+      {bool isInserting = false}) {
     final context = VerificationContext();
     final data = instance.toColumns(true);
     if (data.containsKey('id')) {
@@ -175,87 +120,67 @@ class $TransactionEntriesTable extends TransactionEntries
     }
     if (data.containsKey('uuid')) {
       context.handle(
-        _uuidMeta,
-        uuid.isAcceptableOrUnknown(data['uuid']!, _uuidMeta),
-      );
+          _uuidMeta, uuid.isAcceptableOrUnknown(data['uuid']!, _uuidMeta));
     } else if (isInserting) {
       context.missing(_uuidMeta);
     }
     if (data.containsKey('account_id')) {
-      context.handle(
-        _accountIdMeta,
-        accountId.isAcceptableOrUnknown(data['account_id']!, _accountIdMeta),
-      );
+      context.handle(_accountIdMeta,
+          accountId.isAcceptableOrUnknown(data['account_id']!, _accountIdMeta));
     } else if (isInserting) {
       context.missing(_accountIdMeta);
     }
     if (data.containsKey('timestamp')) {
-      context.handle(
-        _timestampMeta,
-        timestamp.isAcceptableOrUnknown(data['timestamp']!, _timestampMeta),
-      );
+      context.handle(_timestampMeta,
+          timestamp.isAcceptableOrUnknown(data['timestamp']!, _timestampMeta));
     } else if (isInserting) {
       context.missing(_timestampMeta);
     }
     if (data.containsKey('amount_cents')) {
       context.handle(
-        _amountCentsMeta,
-        amountCents.isAcceptableOrUnknown(
-          data['amount_cents']!,
           _amountCentsMeta,
-        ),
-      );
+          amountCents.isAcceptableOrUnknown(
+              data['amount_cents']!, _amountCentsMeta));
     } else if (isInserting) {
       context.missing(_amountCentsMeta);
     }
     if (data.containsKey('description')) {
       context.handle(
-        _descriptionMeta,
-        description.isAcceptableOrUnknown(
-          data['description']!,
           _descriptionMeta,
-        ),
-      );
+          description.isAcceptableOrUnknown(
+              data['description']!, _descriptionMeta));
     } else if (isInserting) {
       context.missing(_descriptionMeta);
     }
     if (data.containsKey('category')) {
-      context.handle(
-        _categoryMeta,
-        category.isAcceptableOrUnknown(data['category']!, _categoryMeta),
-      );
+      context.handle(_categoryMeta,
+          category.isAcceptableOrUnknown(data['category']!, _categoryMeta));
     } else if (isInserting) {
       context.missing(_categoryMeta);
     }
     if (data.containsKey('tags')) {
       context.handle(
-        _tagsMeta,
-        tags.isAcceptableOrUnknown(data['tags']!, _tagsMeta),
-      );
+          _tagsMeta, tags.isAcceptableOrUnknown(data['tags']!, _tagsMeta));
     }
     if (data.containsKey('receipt_url')) {
       context.handle(
-        _receiptUrlMeta,
-        receiptUrl.isAcceptableOrUnknown(data['receipt_url']!, _receiptUrlMeta),
-      );
+          _receiptUrlMeta,
+          receiptUrl.isAcceptableOrUnknown(
+              data['receipt_url']!, _receiptUrlMeta));
     }
     if (data.containsKey('sync_status')) {
       context.handle(
-        _syncStatusMeta,
-        syncStatus.isAcceptableOrUnknown(data['sync_status']!, _syncStatusMeta),
-      );
+          _syncStatusMeta,
+          syncStatus.isAcceptableOrUnknown(
+              data['sync_status']!, _syncStatusMeta));
     }
     if (data.containsKey('created_at')) {
-      context.handle(
-        _createdAtMeta,
-        createdAt.isAcceptableOrUnknown(data['created_at']!, _createdAtMeta),
-      );
+      context.handle(_createdAtMeta,
+          createdAt.isAcceptableOrUnknown(data['created_at']!, _createdAtMeta));
     }
     if (data.containsKey('updated_at')) {
-      context.handle(
-        _updatedAtMeta,
-        updatedAt.isAcceptableOrUnknown(data['updated_at']!, _updatedAtMeta),
-      );
+      context.handle(_updatedAtMeta,
+          updatedAt.isAcceptableOrUnknown(data['updated_at']!, _updatedAtMeta));
     }
     return context;
   }
@@ -266,54 +191,30 @@ class $TransactionEntriesTable extends TransactionEntries
   TransactionEntry map(Map<String, dynamic> data, {String? tablePrefix}) {
     final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
     return TransactionEntry(
-      id: attachedDatabase.typeMapping.read(
-        DriftSqlType.int,
-        data['${effectivePrefix}id'],
-      )!,
-      uuid: attachedDatabase.typeMapping.read(
-        DriftSqlType.string,
-        data['${effectivePrefix}uuid'],
-      )!,
-      accountId: attachedDatabase.typeMapping.read(
-        DriftSqlType.string,
-        data['${effectivePrefix}account_id'],
-      )!,
-      timestamp: attachedDatabase.typeMapping.read(
-        DriftSqlType.dateTime,
-        data['${effectivePrefix}timestamp'],
-      )!,
-      amountCents: attachedDatabase.typeMapping.read(
-        DriftSqlType.int,
-        data['${effectivePrefix}amount_cents'],
-      )!,
-      description: attachedDatabase.typeMapping.read(
-        DriftSqlType.string,
-        data['${effectivePrefix}description'],
-      )!,
-      category: attachedDatabase.typeMapping.read(
-        DriftSqlType.string,
-        data['${effectivePrefix}category'],
-      )!,
-      tags: attachedDatabase.typeMapping.read(
-        DriftSqlType.string,
-        data['${effectivePrefix}tags'],
-      )!,
-      receiptUrl: attachedDatabase.typeMapping.read(
-        DriftSqlType.string,
-        data['${effectivePrefix}receipt_url'],
-      ),
-      syncStatus: attachedDatabase.typeMapping.read(
-        DriftSqlType.string,
-        data['${effectivePrefix}sync_status'],
-      )!,
-      createdAt: attachedDatabase.typeMapping.read(
-        DriftSqlType.dateTime,
-        data['${effectivePrefix}created_at'],
-      )!,
-      updatedAt: attachedDatabase.typeMapping.read(
-        DriftSqlType.dateTime,
-        data['${effectivePrefix}updated_at'],
-      ),
+      id: attachedDatabase.typeMapping
+          .read(DriftSqlType.int, data['${effectivePrefix}id'])!,
+      uuid: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}uuid'])!,
+      accountId: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}account_id'])!,
+      timestamp: attachedDatabase.typeMapping
+          .read(DriftSqlType.dateTime, data['${effectivePrefix}timestamp'])!,
+      amountCents: attachedDatabase.typeMapping
+          .read(DriftSqlType.int, data['${effectivePrefix}amount_cents'])!,
+      description: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}description'])!,
+      category: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}category'])!,
+      tags: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}tags'])!,
+      receiptUrl: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}receipt_url']),
+      syncStatus: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}sync_status'])!,
+      createdAt: attachedDatabase.typeMapping
+          .read(DriftSqlType.dateTime, data['${effectivePrefix}created_at'])!,
+      updatedAt: attachedDatabase.typeMapping
+          .read(DriftSqlType.dateTime, data['${effectivePrefix}updated_at']),
     );
   }
 
@@ -337,20 +238,19 @@ class TransactionEntry extends DataClass
   final String syncStatus;
   final DateTime createdAt;
   final DateTime? updatedAt;
-  const TransactionEntry({
-    required this.id,
-    required this.uuid,
-    required this.accountId,
-    required this.timestamp,
-    required this.amountCents,
-    required this.description,
-    required this.category,
-    required this.tags,
-    this.receiptUrl,
-    required this.syncStatus,
-    required this.createdAt,
-    this.updatedAt,
-  });
+  const TransactionEntry(
+      {required this.id,
+      required this.uuid,
+      required this.accountId,
+      required this.timestamp,
+      required this.amountCents,
+      required this.description,
+      required this.category,
+      required this.tags,
+      this.receiptUrl,
+      required this.syncStatus,
+      required this.createdAt,
+      this.updatedAt});
   @override
   Map<String, Expression> toColumns(bool nullToAbsent) {
     final map = <String, Expression>{};
@@ -394,10 +294,8 @@ class TransactionEntry extends DataClass
     );
   }
 
-  factory TransactionEntry.fromJson(
-    Map<String, dynamic> json, {
-    ValueSerializer? serializer,
-  }) {
+  factory TransactionEntry.fromJson(Map<String, dynamic> json,
+      {ValueSerializer? serializer}) {
     serializer ??= driftRuntimeOptions.defaultSerializer;
     return TransactionEntry(
       id: serializer.fromJson<int>(json['id']),
@@ -433,53 +331,49 @@ class TransactionEntry extends DataClass
     };
   }
 
-  TransactionEntry copyWith({
-    int? id,
-    String? uuid,
-    String? accountId,
-    DateTime? timestamp,
-    int? amountCents,
-    String? description,
-    String? category,
-    String? tags,
-    Value<String?> receiptUrl = const Value.absent(),
-    String? syncStatus,
-    DateTime? createdAt,
-    Value<DateTime?> updatedAt = const Value.absent(),
-  }) => TransactionEntry(
-    id: id ?? this.id,
-    uuid: uuid ?? this.uuid,
-    accountId: accountId ?? this.accountId,
-    timestamp: timestamp ?? this.timestamp,
-    amountCents: amountCents ?? this.amountCents,
-    description: description ?? this.description,
-    category: category ?? this.category,
-    tags: tags ?? this.tags,
-    receiptUrl: receiptUrl.present ? receiptUrl.value : this.receiptUrl,
-    syncStatus: syncStatus ?? this.syncStatus,
-    createdAt: createdAt ?? this.createdAt,
-    updatedAt: updatedAt.present ? updatedAt.value : this.updatedAt,
-  );
+  TransactionEntry copyWith(
+          {int? id,
+          String? uuid,
+          String? accountId,
+          DateTime? timestamp,
+          int? amountCents,
+          String? description,
+          String? category,
+          String? tags,
+          Value<String?> receiptUrl = const Value.absent(),
+          String? syncStatus,
+          DateTime? createdAt,
+          Value<DateTime?> updatedAt = const Value.absent()}) =>
+      TransactionEntry(
+        id: id ?? this.id,
+        uuid: uuid ?? this.uuid,
+        accountId: accountId ?? this.accountId,
+        timestamp: timestamp ?? this.timestamp,
+        amountCents: amountCents ?? this.amountCents,
+        description: description ?? this.description,
+        category: category ?? this.category,
+        tags: tags ?? this.tags,
+        receiptUrl: receiptUrl.present ? receiptUrl.value : this.receiptUrl,
+        syncStatus: syncStatus ?? this.syncStatus,
+        createdAt: createdAt ?? this.createdAt,
+        updatedAt: updatedAt.present ? updatedAt.value : this.updatedAt,
+      );
   TransactionEntry copyWithCompanion(TransactionEntriesCompanion data) {
     return TransactionEntry(
       id: data.id.present ? data.id.value : this.id,
       uuid: data.uuid.present ? data.uuid.value : this.uuid,
       accountId: data.accountId.present ? data.accountId.value : this.accountId,
       timestamp: data.timestamp.present ? data.timestamp.value : this.timestamp,
-      amountCents: data.amountCents.present
-          ? data.amountCents.value
-          : this.amountCents,
-      description: data.description.present
-          ? data.description.value
-          : this.description,
+      amountCents:
+          data.amountCents.present ? data.amountCents.value : this.amountCents,
+      description:
+          data.description.present ? data.description.value : this.description,
       category: data.category.present ? data.category.value : this.category,
       tags: data.tags.present ? data.tags.value : this.tags,
-      receiptUrl: data.receiptUrl.present
-          ? data.receiptUrl.value
-          : this.receiptUrl,
-      syncStatus: data.syncStatus.present
-          ? data.syncStatus.value
-          : this.syncStatus,
+      receiptUrl:
+          data.receiptUrl.present ? data.receiptUrl.value : this.receiptUrl,
+      syncStatus:
+          data.syncStatus.present ? data.syncStatus.value : this.syncStatus,
       createdAt: data.createdAt.present ? data.createdAt.value : this.createdAt,
       updatedAt: data.updatedAt.present ? data.updatedAt.value : this.updatedAt,
     );
@@ -506,19 +400,18 @@ class TransactionEntry extends DataClass
 
   @override
   int get hashCode => Object.hash(
-    id,
-    uuid,
-    accountId,
-    timestamp,
-    amountCents,
-    description,
-    category,
-    tags,
-    receiptUrl,
-    syncStatus,
-    createdAt,
-    updatedAt,
-  );
+      id,
+      uuid,
+      accountId,
+      timestamp,
+      amountCents,
+      description,
+      category,
+      tags,
+      receiptUrl,
+      syncStatus,
+      createdAt,
+      updatedAt);
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
@@ -577,12 +470,12 @@ class TransactionEntriesCompanion extends UpdateCompanion<TransactionEntry> {
     this.syncStatus = const Value.absent(),
     this.createdAt = const Value.absent(),
     this.updatedAt = const Value.absent(),
-  }) : uuid = Value(uuid),
-       accountId = Value(accountId),
-       timestamp = Value(timestamp),
-       amountCents = Value(amountCents),
-       description = Value(description),
-       category = Value(category);
+  })  : uuid = Value(uuid),
+        accountId = Value(accountId),
+        timestamp = Value(timestamp),
+        amountCents = Value(amountCents),
+        description = Value(description),
+        category = Value(category);
   static Insertable<TransactionEntry> custom({
     Expression<int>? id,
     Expression<String>? uuid,
@@ -613,20 +506,19 @@ class TransactionEntriesCompanion extends UpdateCompanion<TransactionEntry> {
     });
   }
 
-  TransactionEntriesCompanion copyWith({
-    Value<int>? id,
-    Value<String>? uuid,
-    Value<String>? accountId,
-    Value<DateTime>? timestamp,
-    Value<int>? amountCents,
-    Value<String>? description,
-    Value<String>? category,
-    Value<String>? tags,
-    Value<String?>? receiptUrl,
-    Value<String>? syncStatus,
-    Value<DateTime>? createdAt,
-    Value<DateTime?>? updatedAt,
-  }) {
+  TransactionEntriesCompanion copyWith(
+      {Value<int>? id,
+      Value<String>? uuid,
+      Value<String>? accountId,
+      Value<DateTime>? timestamp,
+      Value<int>? amountCents,
+      Value<String>? description,
+      Value<String>? category,
+      Value<String>? tags,
+      Value<String?>? receiptUrl,
+      Value<String>? syncStatus,
+      Value<DateTime>? createdAt,
+      Value<DateTime?>? updatedAt}) {
     return TransactionEntriesCompanion(
       id: id ?? this.id,
       uuid: uuid ?? this.uuid,
@@ -714,166 +606,113 @@ class $BudgetEntriesTable extends BudgetEntries
   static const VerificationMeta _idMeta = const VerificationMeta('id');
   @override
   late final GeneratedColumn<int> id = GeneratedColumn<int>(
-    'id',
-    aliasedName,
-    false,
-    hasAutoIncrement: true,
-    type: DriftSqlType.int,
-    requiredDuringInsert: false,
-    defaultConstraints: GeneratedColumn.constraintIsAlways(
-      'PRIMARY KEY AUTOINCREMENT',
-    ),
-  );
+      'id', aliasedName, false,
+      hasAutoIncrement: true,
+      type: DriftSqlType.int,
+      requiredDuringInsert: false,
+      defaultConstraints:
+          GeneratedColumn.constraintIsAlways('PRIMARY KEY AUTOINCREMENT'));
   static const VerificationMeta _uuidMeta = const VerificationMeta('uuid');
   @override
   late final GeneratedColumn<String> uuid = GeneratedColumn<String>(
-    'uuid',
-    aliasedName,
-    false,
-    type: DriftSqlType.string,
-    requiredDuringInsert: true,
-    defaultConstraints: GeneratedColumn.constraintIsAlways('UNIQUE'),
-  );
+      'uuid', aliasedName, false,
+      type: DriftSqlType.string,
+      requiredDuringInsert: true,
+      defaultConstraints: GeneratedColumn.constraintIsAlways('UNIQUE'));
   static const VerificationMeta _tagMeta = const VerificationMeta('tag');
   @override
   late final GeneratedColumn<String> tag = GeneratedColumn<String>(
-    'tag',
-    aliasedName,
-    false,
-    type: DriftSqlType.string,
-    requiredDuringInsert: true,
-  );
-  static const VerificationMeta _limitCentsMeta = const VerificationMeta(
-    'limitCents',
-  );
+      'tag', aliasedName, false,
+      type: DriftSqlType.string, requiredDuringInsert: true);
+  static const VerificationMeta _limitCentsMeta =
+      const VerificationMeta('limitCents');
   @override
   late final GeneratedColumn<int> limitCents = GeneratedColumn<int>(
-    'limit_cents',
-    aliasedName,
-    false,
-    type: DriftSqlType.int,
-    requiredDuringInsert: true,
-  );
-  static const VerificationMeta _usedCentsMeta = const VerificationMeta(
-    'usedCents',
-  );
+      'limit_cents', aliasedName, false,
+      type: DriftSqlType.int, requiredDuringInsert: true);
+  static const VerificationMeta _usedCentsMeta =
+      const VerificationMeta('usedCents');
   @override
   late final GeneratedColumn<int> usedCents = GeneratedColumn<int>(
-    'used_cents',
-    aliasedName,
-    false,
-    type: DriftSqlType.int,
-    requiredDuringInsert: false,
-    defaultValue: const Constant(0),
-  );
-  static const VerificationMeta _carryoverCentsMeta = const VerificationMeta(
-    'carryoverCents',
-  );
+      'used_cents', aliasedName, false,
+      type: DriftSqlType.int,
+      requiredDuringInsert: false,
+      defaultValue: const Constant(0));
+  static const VerificationMeta _carryoverCentsMeta =
+      const VerificationMeta('carryoverCents');
   @override
   late final GeneratedColumn<int> carryoverCents = GeneratedColumn<int>(
-    'carryover_cents',
-    aliasedName,
-    false,
-    type: DriftSqlType.int,
-    requiredDuringInsert: false,
-    defaultValue: const Constant(0),
-  );
-  static const VerificationMeta _periodMonthMeta = const VerificationMeta(
-    'periodMonth',
-  );
+      'carryover_cents', aliasedName, false,
+      type: DriftSqlType.int,
+      requiredDuringInsert: false,
+      defaultValue: const Constant(0));
+  static const VerificationMeta _periodMonthMeta =
+      const VerificationMeta('periodMonth');
   @override
   late final GeneratedColumn<int> periodMonth = GeneratedColumn<int>(
-    'period_month',
-    aliasedName,
-    false,
-    type: DriftSqlType.int,
-    requiredDuringInsert: true,
-  );
-  static const VerificationMeta _recurrenceMeta = const VerificationMeta(
-    'recurrence',
-  );
+      'period_month', aliasedName, false,
+      type: DriftSqlType.int, requiredDuringInsert: true);
+  static const VerificationMeta _recurrenceMeta =
+      const VerificationMeta('recurrence');
   @override
   late final GeneratedColumn<String> recurrence = GeneratedColumn<String>(
-    'recurrence',
-    aliasedName,
-    false,
-    type: DriftSqlType.string,
-    requiredDuringInsert: false,
-    defaultValue: const Constant('monthly'),
-  );
-  static const VerificationMeta _carryoverBehaviorMeta = const VerificationMeta(
-    'carryoverBehavior',
-  );
+      'recurrence', aliasedName, false,
+      type: DriftSqlType.string,
+      requiredDuringInsert: false,
+      defaultValue: const Constant('monthly'));
+  static const VerificationMeta _carryoverBehaviorMeta =
+      const VerificationMeta('carryoverBehavior');
   @override
   late final GeneratedColumn<String> carryoverBehavior =
-      GeneratedColumn<String>(
-        'carryover_behavior',
-        aliasedName,
-        false,
-        type: DriftSqlType.string,
-        requiredDuringInsert: false,
-        defaultValue: const Constant('none'),
-      );
-  static const VerificationMeta _syncStatusMeta = const VerificationMeta(
-    'syncStatus',
-  );
+      GeneratedColumn<String>('carryover_behavior', aliasedName, false,
+          type: DriftSqlType.string,
+          requiredDuringInsert: false,
+          defaultValue: const Constant('none'));
+  static const VerificationMeta _syncStatusMeta =
+      const VerificationMeta('syncStatus');
   @override
   late final GeneratedColumn<String> syncStatus = GeneratedColumn<String>(
-    'sync_status',
-    aliasedName,
-    false,
-    type: DriftSqlType.string,
-    requiredDuringInsert: false,
-    defaultValue: const Constant('pending'),
-  );
-  static const VerificationMeta _createdAtMeta = const VerificationMeta(
-    'createdAt',
-  );
+      'sync_status', aliasedName, false,
+      type: DriftSqlType.string,
+      requiredDuringInsert: false,
+      defaultValue: const Constant('pending'));
+  static const VerificationMeta _createdAtMeta =
+      const VerificationMeta('createdAt');
   @override
   late final GeneratedColumn<DateTime> createdAt = GeneratedColumn<DateTime>(
-    'created_at',
-    aliasedName,
-    false,
-    type: DriftSqlType.dateTime,
-    requiredDuringInsert: false,
-    defaultValue: currentDateAndTime,
-  );
-  static const VerificationMeta _updatedAtMeta = const VerificationMeta(
-    'updatedAt',
-  );
+      'created_at', aliasedName, false,
+      type: DriftSqlType.dateTime,
+      requiredDuringInsert: false,
+      defaultValue: currentDateAndTime);
+  static const VerificationMeta _updatedAtMeta =
+      const VerificationMeta('updatedAt');
   @override
   late final GeneratedColumn<DateTime> updatedAt = GeneratedColumn<DateTime>(
-    'updated_at',
-    aliasedName,
-    true,
-    type: DriftSqlType.dateTime,
-    requiredDuringInsert: false,
-  );
+      'updated_at', aliasedName, true,
+      type: DriftSqlType.dateTime, requiredDuringInsert: false);
   @override
   List<GeneratedColumn> get $columns => [
-    id,
-    uuid,
-    tag,
-    limitCents,
-    usedCents,
-    carryoverCents,
-    periodMonth,
-    recurrence,
-    carryoverBehavior,
-    syncStatus,
-    createdAt,
-    updatedAt,
-  ];
+        id,
+        uuid,
+        tag,
+        limitCents,
+        usedCents,
+        carryoverCents,
+        periodMonth,
+        recurrence,
+        carryoverBehavior,
+        syncStatus,
+        createdAt,
+        updatedAt
+      ];
   @override
   String get aliasedName => _alias ?? actualTableName;
   @override
   String get actualTableName => $name;
   static const String $name = 'budget_entries';
   @override
-  VerificationContext validateIntegrity(
-    Insertable<BudgetEntry> instance, {
-    bool isInserting = false,
-  }) {
+  VerificationContext validateIntegrity(Insertable<BudgetEntry> instance,
+      {bool isInserting = false}) {
     final context = VerificationContext();
     final data = instance.toColumns(true);
     if (data.containsKey('id')) {
@@ -881,86 +720,67 @@ class $BudgetEntriesTable extends BudgetEntries
     }
     if (data.containsKey('uuid')) {
       context.handle(
-        _uuidMeta,
-        uuid.isAcceptableOrUnknown(data['uuid']!, _uuidMeta),
-      );
+          _uuidMeta, uuid.isAcceptableOrUnknown(data['uuid']!, _uuidMeta));
     } else if (isInserting) {
       context.missing(_uuidMeta);
     }
     if (data.containsKey('tag')) {
       context.handle(
-        _tagMeta,
-        tag.isAcceptableOrUnknown(data['tag']!, _tagMeta),
-      );
+          _tagMeta, tag.isAcceptableOrUnknown(data['tag']!, _tagMeta));
     } else if (isInserting) {
       context.missing(_tagMeta);
     }
     if (data.containsKey('limit_cents')) {
       context.handle(
-        _limitCentsMeta,
-        limitCents.isAcceptableOrUnknown(data['limit_cents']!, _limitCentsMeta),
-      );
+          _limitCentsMeta,
+          limitCents.isAcceptableOrUnknown(
+              data['limit_cents']!, _limitCentsMeta));
     } else if (isInserting) {
       context.missing(_limitCentsMeta);
     }
     if (data.containsKey('used_cents')) {
-      context.handle(
-        _usedCentsMeta,
-        usedCents.isAcceptableOrUnknown(data['used_cents']!, _usedCentsMeta),
-      );
+      context.handle(_usedCentsMeta,
+          usedCents.isAcceptableOrUnknown(data['used_cents']!, _usedCentsMeta));
     }
     if (data.containsKey('carryover_cents')) {
       context.handle(
-        _carryoverCentsMeta,
-        carryoverCents.isAcceptableOrUnknown(
-          data['carryover_cents']!,
           _carryoverCentsMeta,
-        ),
-      );
+          carryoverCents.isAcceptableOrUnknown(
+              data['carryover_cents']!, _carryoverCentsMeta));
     }
     if (data.containsKey('period_month')) {
       context.handle(
-        _periodMonthMeta,
-        periodMonth.isAcceptableOrUnknown(
-          data['period_month']!,
           _periodMonthMeta,
-        ),
-      );
+          periodMonth.isAcceptableOrUnknown(
+              data['period_month']!, _periodMonthMeta));
     } else if (isInserting) {
       context.missing(_periodMonthMeta);
     }
     if (data.containsKey('recurrence')) {
       context.handle(
-        _recurrenceMeta,
-        recurrence.isAcceptableOrUnknown(data['recurrence']!, _recurrenceMeta),
-      );
+          _recurrenceMeta,
+          recurrence.isAcceptableOrUnknown(
+              data['recurrence']!, _recurrenceMeta));
     }
     if (data.containsKey('carryover_behavior')) {
       context.handle(
-        _carryoverBehaviorMeta,
-        carryoverBehavior.isAcceptableOrUnknown(
-          data['carryover_behavior']!,
           _carryoverBehaviorMeta,
-        ),
-      );
+          carryoverBehavior.isAcceptableOrUnknown(
+              data['carryover_behavior']!, _carryoverBehaviorMeta));
     }
     if (data.containsKey('sync_status')) {
       context.handle(
-        _syncStatusMeta,
-        syncStatus.isAcceptableOrUnknown(data['sync_status']!, _syncStatusMeta),
-      );
+          _syncStatusMeta,
+          syncStatus.isAcceptableOrUnknown(
+              data['sync_status']!, _syncStatusMeta));
     }
     if (data.containsKey('created_at')) {
-      context.handle(
-        _createdAtMeta,
-        createdAt.isAcceptableOrUnknown(data['created_at']!, _createdAtMeta),
-      );
+      context.handle(_createdAtMeta,
+          createdAt.isAcceptableOrUnknown(data['created_at']!, _createdAtMeta));
     }
     if (data.containsKey('updated_at')) {
-      context.handle(
-        _updatedAtMeta,
-        updatedAt.isAcceptableOrUnknown(data['updated_at']!, _updatedAtMeta),
-      );
+      context.handle(_updatedAtMeta,
+          updatedAt.isAcceptableOrUnknown(data['updated_at']!, _updatedAtMeta));
     }
     return context;
   }
@@ -971,54 +791,30 @@ class $BudgetEntriesTable extends BudgetEntries
   BudgetEntry map(Map<String, dynamic> data, {String? tablePrefix}) {
     final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
     return BudgetEntry(
-      id: attachedDatabase.typeMapping.read(
-        DriftSqlType.int,
-        data['${effectivePrefix}id'],
-      )!,
-      uuid: attachedDatabase.typeMapping.read(
-        DriftSqlType.string,
-        data['${effectivePrefix}uuid'],
-      )!,
-      tag: attachedDatabase.typeMapping.read(
-        DriftSqlType.string,
-        data['${effectivePrefix}tag'],
-      )!,
-      limitCents: attachedDatabase.typeMapping.read(
-        DriftSqlType.int,
-        data['${effectivePrefix}limit_cents'],
-      )!,
-      usedCents: attachedDatabase.typeMapping.read(
-        DriftSqlType.int,
-        data['${effectivePrefix}used_cents'],
-      )!,
-      carryoverCents: attachedDatabase.typeMapping.read(
-        DriftSqlType.int,
-        data['${effectivePrefix}carryover_cents'],
-      )!,
-      periodMonth: attachedDatabase.typeMapping.read(
-        DriftSqlType.int,
-        data['${effectivePrefix}period_month'],
-      )!,
-      recurrence: attachedDatabase.typeMapping.read(
-        DriftSqlType.string,
-        data['${effectivePrefix}recurrence'],
-      )!,
+      id: attachedDatabase.typeMapping
+          .read(DriftSqlType.int, data['${effectivePrefix}id'])!,
+      uuid: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}uuid'])!,
+      tag: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}tag'])!,
+      limitCents: attachedDatabase.typeMapping
+          .read(DriftSqlType.int, data['${effectivePrefix}limit_cents'])!,
+      usedCents: attachedDatabase.typeMapping
+          .read(DriftSqlType.int, data['${effectivePrefix}used_cents'])!,
+      carryoverCents: attachedDatabase.typeMapping
+          .read(DriftSqlType.int, data['${effectivePrefix}carryover_cents'])!,
+      periodMonth: attachedDatabase.typeMapping
+          .read(DriftSqlType.int, data['${effectivePrefix}period_month'])!,
+      recurrence: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}recurrence'])!,
       carryoverBehavior: attachedDatabase.typeMapping.read(
-        DriftSqlType.string,
-        data['${effectivePrefix}carryover_behavior'],
-      )!,
-      syncStatus: attachedDatabase.typeMapping.read(
-        DriftSqlType.string,
-        data['${effectivePrefix}sync_status'],
-      )!,
-      createdAt: attachedDatabase.typeMapping.read(
-        DriftSqlType.dateTime,
-        data['${effectivePrefix}created_at'],
-      )!,
-      updatedAt: attachedDatabase.typeMapping.read(
-        DriftSqlType.dateTime,
-        data['${effectivePrefix}updated_at'],
-      ),
+          DriftSqlType.string, data['${effectivePrefix}carryover_behavior'])!,
+      syncStatus: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}sync_status'])!,
+      createdAt: attachedDatabase.typeMapping
+          .read(DriftSqlType.dateTime, data['${effectivePrefix}created_at'])!,
+      updatedAt: attachedDatabase.typeMapping
+          .read(DriftSqlType.dateTime, data['${effectivePrefix}updated_at']),
     );
   }
 
@@ -1041,20 +837,19 @@ class BudgetEntry extends DataClass implements Insertable<BudgetEntry> {
   final String syncStatus;
   final DateTime createdAt;
   final DateTime? updatedAt;
-  const BudgetEntry({
-    required this.id,
-    required this.uuid,
-    required this.tag,
-    required this.limitCents,
-    required this.usedCents,
-    required this.carryoverCents,
-    required this.periodMonth,
-    required this.recurrence,
-    required this.carryoverBehavior,
-    required this.syncStatus,
-    required this.createdAt,
-    this.updatedAt,
-  });
+  const BudgetEntry(
+      {required this.id,
+      required this.uuid,
+      required this.tag,
+      required this.limitCents,
+      required this.usedCents,
+      required this.carryoverCents,
+      required this.periodMonth,
+      required this.recurrence,
+      required this.carryoverBehavior,
+      required this.syncStatus,
+      required this.createdAt,
+      this.updatedAt});
   @override
   Map<String, Expression> toColumns(bool nullToAbsent) {
     final map = <String, Expression>{};
@@ -1094,10 +889,8 @@ class BudgetEntry extends DataClass implements Insertable<BudgetEntry> {
     );
   }
 
-  factory BudgetEntry.fromJson(
-    Map<String, dynamic> json, {
-    ValueSerializer? serializer,
-  }) {
+  factory BudgetEntry.fromJson(Map<String, dynamic> json,
+      {ValueSerializer? serializer}) {
     serializer ??= driftRuntimeOptions.defaultSerializer;
     return BudgetEntry(
       id: serializer.fromJson<int>(json['id']),
@@ -1133,57 +926,53 @@ class BudgetEntry extends DataClass implements Insertable<BudgetEntry> {
     };
   }
 
-  BudgetEntry copyWith({
-    int? id,
-    String? uuid,
-    String? tag,
-    int? limitCents,
-    int? usedCents,
-    int? carryoverCents,
-    int? periodMonth,
-    String? recurrence,
-    String? carryoverBehavior,
-    String? syncStatus,
-    DateTime? createdAt,
-    Value<DateTime?> updatedAt = const Value.absent(),
-  }) => BudgetEntry(
-    id: id ?? this.id,
-    uuid: uuid ?? this.uuid,
-    tag: tag ?? this.tag,
-    limitCents: limitCents ?? this.limitCents,
-    usedCents: usedCents ?? this.usedCents,
-    carryoverCents: carryoverCents ?? this.carryoverCents,
-    periodMonth: periodMonth ?? this.periodMonth,
-    recurrence: recurrence ?? this.recurrence,
-    carryoverBehavior: carryoverBehavior ?? this.carryoverBehavior,
-    syncStatus: syncStatus ?? this.syncStatus,
-    createdAt: createdAt ?? this.createdAt,
-    updatedAt: updatedAt.present ? updatedAt.value : this.updatedAt,
-  );
+  BudgetEntry copyWith(
+          {int? id,
+          String? uuid,
+          String? tag,
+          int? limitCents,
+          int? usedCents,
+          int? carryoverCents,
+          int? periodMonth,
+          String? recurrence,
+          String? carryoverBehavior,
+          String? syncStatus,
+          DateTime? createdAt,
+          Value<DateTime?> updatedAt = const Value.absent()}) =>
+      BudgetEntry(
+        id: id ?? this.id,
+        uuid: uuid ?? this.uuid,
+        tag: tag ?? this.tag,
+        limitCents: limitCents ?? this.limitCents,
+        usedCents: usedCents ?? this.usedCents,
+        carryoverCents: carryoverCents ?? this.carryoverCents,
+        periodMonth: periodMonth ?? this.periodMonth,
+        recurrence: recurrence ?? this.recurrence,
+        carryoverBehavior: carryoverBehavior ?? this.carryoverBehavior,
+        syncStatus: syncStatus ?? this.syncStatus,
+        createdAt: createdAt ?? this.createdAt,
+        updatedAt: updatedAt.present ? updatedAt.value : this.updatedAt,
+      );
   BudgetEntry copyWithCompanion(BudgetEntriesCompanion data) {
     return BudgetEntry(
       id: data.id.present ? data.id.value : this.id,
       uuid: data.uuid.present ? data.uuid.value : this.uuid,
       tag: data.tag.present ? data.tag.value : this.tag,
-      limitCents: data.limitCents.present
-          ? data.limitCents.value
-          : this.limitCents,
+      limitCents:
+          data.limitCents.present ? data.limitCents.value : this.limitCents,
       usedCents: data.usedCents.present ? data.usedCents.value : this.usedCents,
       carryoverCents: data.carryoverCents.present
           ? data.carryoverCents.value
           : this.carryoverCents,
-      periodMonth: data.periodMonth.present
-          ? data.periodMonth.value
-          : this.periodMonth,
-      recurrence: data.recurrence.present
-          ? data.recurrence.value
-          : this.recurrence,
+      periodMonth:
+          data.periodMonth.present ? data.periodMonth.value : this.periodMonth,
+      recurrence:
+          data.recurrence.present ? data.recurrence.value : this.recurrence,
       carryoverBehavior: data.carryoverBehavior.present
           ? data.carryoverBehavior.value
           : this.carryoverBehavior,
-      syncStatus: data.syncStatus.present
-          ? data.syncStatus.value
-          : this.syncStatus,
+      syncStatus:
+          data.syncStatus.present ? data.syncStatus.value : this.syncStatus,
       createdAt: data.createdAt.present ? data.createdAt.value : this.createdAt,
       updatedAt: data.updatedAt.present ? data.updatedAt.value : this.updatedAt,
     );
@@ -1210,19 +999,18 @@ class BudgetEntry extends DataClass implements Insertable<BudgetEntry> {
 
   @override
   int get hashCode => Object.hash(
-    id,
-    uuid,
-    tag,
-    limitCents,
-    usedCents,
-    carryoverCents,
-    periodMonth,
-    recurrence,
-    carryoverBehavior,
-    syncStatus,
-    createdAt,
-    updatedAt,
-  );
+      id,
+      uuid,
+      tag,
+      limitCents,
+      usedCents,
+      carryoverCents,
+      periodMonth,
+      recurrence,
+      carryoverBehavior,
+      syncStatus,
+      createdAt,
+      updatedAt);
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
@@ -1281,10 +1069,10 @@ class BudgetEntriesCompanion extends UpdateCompanion<BudgetEntry> {
     this.syncStatus = const Value.absent(),
     this.createdAt = const Value.absent(),
     this.updatedAt = const Value.absent(),
-  }) : uuid = Value(uuid),
-       tag = Value(tag),
-       limitCents = Value(limitCents),
-       periodMonth = Value(periodMonth);
+  })  : uuid = Value(uuid),
+        tag = Value(tag),
+        limitCents = Value(limitCents),
+        periodMonth = Value(periodMonth);
   static Insertable<BudgetEntry> custom({
     Expression<int>? id,
     Expression<String>? uuid,
@@ -1315,20 +1103,19 @@ class BudgetEntriesCompanion extends UpdateCompanion<BudgetEntry> {
     });
   }
 
-  BudgetEntriesCompanion copyWith({
-    Value<int>? id,
-    Value<String>? uuid,
-    Value<String>? tag,
-    Value<int>? limitCents,
-    Value<int>? usedCents,
-    Value<int>? carryoverCents,
-    Value<int>? periodMonth,
-    Value<String>? recurrence,
-    Value<String>? carryoverBehavior,
-    Value<String>? syncStatus,
-    Value<DateTime>? createdAt,
-    Value<DateTime?>? updatedAt,
-  }) {
+  BudgetEntriesCompanion copyWith(
+      {Value<int>? id,
+      Value<String>? uuid,
+      Value<String>? tag,
+      Value<int>? limitCents,
+      Value<int>? usedCents,
+      Value<int>? carryoverCents,
+      Value<int>? periodMonth,
+      Value<String>? recurrence,
+      Value<String>? carryoverBehavior,
+      Value<String>? syncStatus,
+      Value<DateTime>? createdAt,
+      Value<DateTime?>? updatedAt}) {
     return BudgetEntriesCompanion(
       id: id ?? this.id,
       uuid: uuid ?? this.uuid,
@@ -1416,127 +1203,88 @@ class $AccountEntriesTable extends AccountEntries
   static const VerificationMeta _idMeta = const VerificationMeta('id');
   @override
   late final GeneratedColumn<int> id = GeneratedColumn<int>(
-    'id',
-    aliasedName,
-    false,
-    hasAutoIncrement: true,
-    type: DriftSqlType.int,
-    requiredDuringInsert: false,
-    defaultConstraints: GeneratedColumn.constraintIsAlways(
-      'PRIMARY KEY AUTOINCREMENT',
-    ),
-  );
+      'id', aliasedName, false,
+      hasAutoIncrement: true,
+      type: DriftSqlType.int,
+      requiredDuringInsert: false,
+      defaultConstraints:
+          GeneratedColumn.constraintIsAlways('PRIMARY KEY AUTOINCREMENT'));
   static const VerificationMeta _uuidMeta = const VerificationMeta('uuid');
   @override
   late final GeneratedColumn<String> uuid = GeneratedColumn<String>(
-    'uuid',
-    aliasedName,
-    false,
-    type: DriftSqlType.string,
-    requiredDuringInsert: true,
-    defaultConstraints: GeneratedColumn.constraintIsAlways('UNIQUE'),
-  );
+      'uuid', aliasedName, false,
+      type: DriftSqlType.string,
+      requiredDuringInsert: true,
+      defaultConstraints: GeneratedColumn.constraintIsAlways('UNIQUE'));
   static const VerificationMeta _nameMeta = const VerificationMeta('name');
   @override
   late final GeneratedColumn<String> name = GeneratedColumn<String>(
-    'name',
-    aliasedName,
-    false,
-    type: DriftSqlType.string,
-    requiredDuringInsert: true,
-  );
-  static const VerificationMeta _accountTypeMeta = const VerificationMeta(
-    'accountType',
-  );
+      'name', aliasedName, false,
+      type: DriftSqlType.string, requiredDuringInsert: true);
+  static const VerificationMeta _accountTypeMeta =
+      const VerificationMeta('accountType');
   @override
   late final GeneratedColumn<String> accountType = GeneratedColumn<String>(
-    'account_type',
-    aliasedName,
-    false,
-    type: DriftSqlType.string,
-    requiredDuringInsert: true,
-  );
-  static const VerificationMeta _currencyMeta = const VerificationMeta(
-    'currency',
-  );
+      'account_type', aliasedName, false,
+      type: DriftSqlType.string, requiredDuringInsert: true);
+  static const VerificationMeta _currencyMeta =
+      const VerificationMeta('currency');
   @override
   late final GeneratedColumn<String> currency = GeneratedColumn<String>(
-    'currency',
-    aliasedName,
-    false,
-    type: DriftSqlType.string,
-    requiredDuringInsert: false,
-    defaultValue: const Constant('INR'),
-  );
-  static const VerificationMeta _balanceCentsMeta = const VerificationMeta(
-    'balanceCents',
-  );
+      'currency', aliasedName, false,
+      type: DriftSqlType.string,
+      requiredDuringInsert: false,
+      defaultValue: const Constant('INR'));
+  static const VerificationMeta _balanceCentsMeta =
+      const VerificationMeta('balanceCents');
   @override
   late final GeneratedColumn<int> balanceCents = GeneratedColumn<int>(
-    'balance_cents',
-    aliasedName,
-    false,
-    type: DriftSqlType.int,
-    requiredDuringInsert: false,
-    defaultValue: const Constant(0),
-  );
-  static const VerificationMeta _syncStatusMeta = const VerificationMeta(
-    'syncStatus',
-  );
+      'balance_cents', aliasedName, false,
+      type: DriftSqlType.int,
+      requiredDuringInsert: false,
+      defaultValue: const Constant(0));
+  static const VerificationMeta _syncStatusMeta =
+      const VerificationMeta('syncStatus');
   @override
   late final GeneratedColumn<String> syncStatus = GeneratedColumn<String>(
-    'sync_status',
-    aliasedName,
-    false,
-    type: DriftSqlType.string,
-    requiredDuringInsert: false,
-    defaultValue: const Constant('pending'),
-  );
-  static const VerificationMeta _createdAtMeta = const VerificationMeta(
-    'createdAt',
-  );
+      'sync_status', aliasedName, false,
+      type: DriftSqlType.string,
+      requiredDuringInsert: false,
+      defaultValue: const Constant('pending'));
+  static const VerificationMeta _createdAtMeta =
+      const VerificationMeta('createdAt');
   @override
   late final GeneratedColumn<DateTime> createdAt = GeneratedColumn<DateTime>(
-    'created_at',
-    aliasedName,
-    false,
-    type: DriftSqlType.dateTime,
-    requiredDuringInsert: false,
-    defaultValue: currentDateAndTime,
-  );
-  static const VerificationMeta _updatedAtMeta = const VerificationMeta(
-    'updatedAt',
-  );
+      'created_at', aliasedName, false,
+      type: DriftSqlType.dateTime,
+      requiredDuringInsert: false,
+      defaultValue: currentDateAndTime);
+  static const VerificationMeta _updatedAtMeta =
+      const VerificationMeta('updatedAt');
   @override
   late final GeneratedColumn<DateTime> updatedAt = GeneratedColumn<DateTime>(
-    'updated_at',
-    aliasedName,
-    true,
-    type: DriftSqlType.dateTime,
-    requiredDuringInsert: false,
-  );
+      'updated_at', aliasedName, true,
+      type: DriftSqlType.dateTime, requiredDuringInsert: false);
   @override
   List<GeneratedColumn> get $columns => [
-    id,
-    uuid,
-    name,
-    accountType,
-    currency,
-    balanceCents,
-    syncStatus,
-    createdAt,
-    updatedAt,
-  ];
+        id,
+        uuid,
+        name,
+        accountType,
+        currency,
+        balanceCents,
+        syncStatus,
+        createdAt,
+        updatedAt
+      ];
   @override
   String get aliasedName => _alias ?? actualTableName;
   @override
   String get actualTableName => $name;
   static const String $name = 'account_entries';
   @override
-  VerificationContext validateIntegrity(
-    Insertable<AccountEntry> instance, {
-    bool isInserting = false,
-  }) {
+  VerificationContext validateIntegrity(Insertable<AccountEntry> instance,
+      {bool isInserting = false}) {
     final context = VerificationContext();
     final data = instance.toColumns(true);
     if (data.containsKey('id')) {
@@ -1544,63 +1292,47 @@ class $AccountEntriesTable extends AccountEntries
     }
     if (data.containsKey('uuid')) {
       context.handle(
-        _uuidMeta,
-        uuid.isAcceptableOrUnknown(data['uuid']!, _uuidMeta),
-      );
+          _uuidMeta, uuid.isAcceptableOrUnknown(data['uuid']!, _uuidMeta));
     } else if (isInserting) {
       context.missing(_uuidMeta);
     }
     if (data.containsKey('name')) {
       context.handle(
-        _nameMeta,
-        name.isAcceptableOrUnknown(data['name']!, _nameMeta),
-      );
+          _nameMeta, name.isAcceptableOrUnknown(data['name']!, _nameMeta));
     } else if (isInserting) {
       context.missing(_nameMeta);
     }
     if (data.containsKey('account_type')) {
       context.handle(
-        _accountTypeMeta,
-        accountType.isAcceptableOrUnknown(
-          data['account_type']!,
           _accountTypeMeta,
-        ),
-      );
+          accountType.isAcceptableOrUnknown(
+              data['account_type']!, _accountTypeMeta));
     } else if (isInserting) {
       context.missing(_accountTypeMeta);
     }
     if (data.containsKey('currency')) {
-      context.handle(
-        _currencyMeta,
-        currency.isAcceptableOrUnknown(data['currency']!, _currencyMeta),
-      );
+      context.handle(_currencyMeta,
+          currency.isAcceptableOrUnknown(data['currency']!, _currencyMeta));
     }
     if (data.containsKey('balance_cents')) {
       context.handle(
-        _balanceCentsMeta,
-        balanceCents.isAcceptableOrUnknown(
-          data['balance_cents']!,
           _balanceCentsMeta,
-        ),
-      );
+          balanceCents.isAcceptableOrUnknown(
+              data['balance_cents']!, _balanceCentsMeta));
     }
     if (data.containsKey('sync_status')) {
       context.handle(
-        _syncStatusMeta,
-        syncStatus.isAcceptableOrUnknown(data['sync_status']!, _syncStatusMeta),
-      );
+          _syncStatusMeta,
+          syncStatus.isAcceptableOrUnknown(
+              data['sync_status']!, _syncStatusMeta));
     }
     if (data.containsKey('created_at')) {
-      context.handle(
-        _createdAtMeta,
-        createdAt.isAcceptableOrUnknown(data['created_at']!, _createdAtMeta),
-      );
+      context.handle(_createdAtMeta,
+          createdAt.isAcceptableOrUnknown(data['created_at']!, _createdAtMeta));
     }
     if (data.containsKey('updated_at')) {
-      context.handle(
-        _updatedAtMeta,
-        updatedAt.isAcceptableOrUnknown(data['updated_at']!, _updatedAtMeta),
-      );
+      context.handle(_updatedAtMeta,
+          updatedAt.isAcceptableOrUnknown(data['updated_at']!, _updatedAtMeta));
     }
     return context;
   }
@@ -1611,42 +1343,24 @@ class $AccountEntriesTable extends AccountEntries
   AccountEntry map(Map<String, dynamic> data, {String? tablePrefix}) {
     final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
     return AccountEntry(
-      id: attachedDatabase.typeMapping.read(
-        DriftSqlType.int,
-        data['${effectivePrefix}id'],
-      )!,
-      uuid: attachedDatabase.typeMapping.read(
-        DriftSqlType.string,
-        data['${effectivePrefix}uuid'],
-      )!,
-      name: attachedDatabase.typeMapping.read(
-        DriftSqlType.string,
-        data['${effectivePrefix}name'],
-      )!,
-      accountType: attachedDatabase.typeMapping.read(
-        DriftSqlType.string,
-        data['${effectivePrefix}account_type'],
-      )!,
-      currency: attachedDatabase.typeMapping.read(
-        DriftSqlType.string,
-        data['${effectivePrefix}currency'],
-      )!,
-      balanceCents: attachedDatabase.typeMapping.read(
-        DriftSqlType.int,
-        data['${effectivePrefix}balance_cents'],
-      )!,
-      syncStatus: attachedDatabase.typeMapping.read(
-        DriftSqlType.string,
-        data['${effectivePrefix}sync_status'],
-      )!,
-      createdAt: attachedDatabase.typeMapping.read(
-        DriftSqlType.dateTime,
-        data['${effectivePrefix}created_at'],
-      )!,
-      updatedAt: attachedDatabase.typeMapping.read(
-        DriftSqlType.dateTime,
-        data['${effectivePrefix}updated_at'],
-      ),
+      id: attachedDatabase.typeMapping
+          .read(DriftSqlType.int, data['${effectivePrefix}id'])!,
+      uuid: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}uuid'])!,
+      name: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}name'])!,
+      accountType: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}account_type'])!,
+      currency: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}currency'])!,
+      balanceCents: attachedDatabase.typeMapping
+          .read(DriftSqlType.int, data['${effectivePrefix}balance_cents'])!,
+      syncStatus: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}sync_status'])!,
+      createdAt: attachedDatabase.typeMapping
+          .read(DriftSqlType.dateTime, data['${effectivePrefix}created_at'])!,
+      updatedAt: attachedDatabase.typeMapping
+          .read(DriftSqlType.dateTime, data['${effectivePrefix}updated_at']),
     );
   }
 
@@ -1666,17 +1380,16 @@ class AccountEntry extends DataClass implements Insertable<AccountEntry> {
   final String syncStatus;
   final DateTime createdAt;
   final DateTime? updatedAt;
-  const AccountEntry({
-    required this.id,
-    required this.uuid,
-    required this.name,
-    required this.accountType,
-    required this.currency,
-    required this.balanceCents,
-    required this.syncStatus,
-    required this.createdAt,
-    this.updatedAt,
-  });
+  const AccountEntry(
+      {required this.id,
+      required this.uuid,
+      required this.name,
+      required this.accountType,
+      required this.currency,
+      required this.balanceCents,
+      required this.syncStatus,
+      required this.createdAt,
+      this.updatedAt});
   @override
   Map<String, Expression> toColumns(bool nullToAbsent) {
     final map = <String, Expression>{};
@@ -1710,10 +1423,8 @@ class AccountEntry extends DataClass implements Insertable<AccountEntry> {
     );
   }
 
-  factory AccountEntry.fromJson(
-    Map<String, dynamic> json, {
-    ValueSerializer? serializer,
-  }) {
+  factory AccountEntry.fromJson(Map<String, dynamic> json,
+      {ValueSerializer? serializer}) {
     serializer ??= driftRuntimeOptions.defaultSerializer;
     return AccountEntry(
       id: serializer.fromJson<int>(json['id']),
@@ -1743,42 +1454,40 @@ class AccountEntry extends DataClass implements Insertable<AccountEntry> {
     };
   }
 
-  AccountEntry copyWith({
-    int? id,
-    String? uuid,
-    String? name,
-    String? accountType,
-    String? currency,
-    int? balanceCents,
-    String? syncStatus,
-    DateTime? createdAt,
-    Value<DateTime?> updatedAt = const Value.absent(),
-  }) => AccountEntry(
-    id: id ?? this.id,
-    uuid: uuid ?? this.uuid,
-    name: name ?? this.name,
-    accountType: accountType ?? this.accountType,
-    currency: currency ?? this.currency,
-    balanceCents: balanceCents ?? this.balanceCents,
-    syncStatus: syncStatus ?? this.syncStatus,
-    createdAt: createdAt ?? this.createdAt,
-    updatedAt: updatedAt.present ? updatedAt.value : this.updatedAt,
-  );
+  AccountEntry copyWith(
+          {int? id,
+          String? uuid,
+          String? name,
+          String? accountType,
+          String? currency,
+          int? balanceCents,
+          String? syncStatus,
+          DateTime? createdAt,
+          Value<DateTime?> updatedAt = const Value.absent()}) =>
+      AccountEntry(
+        id: id ?? this.id,
+        uuid: uuid ?? this.uuid,
+        name: name ?? this.name,
+        accountType: accountType ?? this.accountType,
+        currency: currency ?? this.currency,
+        balanceCents: balanceCents ?? this.balanceCents,
+        syncStatus: syncStatus ?? this.syncStatus,
+        createdAt: createdAt ?? this.createdAt,
+        updatedAt: updatedAt.present ? updatedAt.value : this.updatedAt,
+      );
   AccountEntry copyWithCompanion(AccountEntriesCompanion data) {
     return AccountEntry(
       id: data.id.present ? data.id.value : this.id,
       uuid: data.uuid.present ? data.uuid.value : this.uuid,
       name: data.name.present ? data.name.value : this.name,
-      accountType: data.accountType.present
-          ? data.accountType.value
-          : this.accountType,
+      accountType:
+          data.accountType.present ? data.accountType.value : this.accountType,
       currency: data.currency.present ? data.currency.value : this.currency,
       balanceCents: data.balanceCents.present
           ? data.balanceCents.value
           : this.balanceCents,
-      syncStatus: data.syncStatus.present
-          ? data.syncStatus.value
-          : this.syncStatus,
+      syncStatus:
+          data.syncStatus.present ? data.syncStatus.value : this.syncStatus,
       createdAt: data.createdAt.present ? data.createdAt.value : this.createdAt,
       updatedAt: data.updatedAt.present ? data.updatedAt.value : this.updatedAt,
     );
@@ -1801,17 +1510,8 @@ class AccountEntry extends DataClass implements Insertable<AccountEntry> {
   }
 
   @override
-  int get hashCode => Object.hash(
-    id,
-    uuid,
-    name,
-    accountType,
-    currency,
-    balanceCents,
-    syncStatus,
-    createdAt,
-    updatedAt,
-  );
+  int get hashCode => Object.hash(id, uuid, name, accountType, currency,
+      balanceCents, syncStatus, createdAt, updatedAt);
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
@@ -1858,9 +1558,9 @@ class AccountEntriesCompanion extends UpdateCompanion<AccountEntry> {
     this.syncStatus = const Value.absent(),
     this.createdAt = const Value.absent(),
     this.updatedAt = const Value.absent(),
-  }) : uuid = Value(uuid),
-       name = Value(name),
-       accountType = Value(accountType);
+  })  : uuid = Value(uuid),
+        name = Value(name),
+        accountType = Value(accountType);
   static Insertable<AccountEntry> custom({
     Expression<int>? id,
     Expression<String>? uuid,
@@ -1885,17 +1585,16 @@ class AccountEntriesCompanion extends UpdateCompanion<AccountEntry> {
     });
   }
 
-  AccountEntriesCompanion copyWith({
-    Value<int>? id,
-    Value<String>? uuid,
-    Value<String>? name,
-    Value<String>? accountType,
-    Value<String>? currency,
-    Value<int>? balanceCents,
-    Value<String>? syncStatus,
-    Value<DateTime>? createdAt,
-    Value<DateTime?>? updatedAt,
-  }) {
+  AccountEntriesCompanion copyWith(
+      {Value<int>? id,
+      Value<String>? uuid,
+      Value<String>? name,
+      Value<String>? accountType,
+      Value<String>? currency,
+      Value<int>? balanceCents,
+      Value<String>? syncStatus,
+      Value<DateTime>? createdAt,
+      Value<DateTime?>? updatedAt}) {
     return AccountEntriesCompanion(
       id: id ?? this.id,
       uuid: uuid ?? this.uuid,
@@ -1968,169 +1667,117 @@ class $CategoryEntriesTable extends CategoryEntries
   static const VerificationMeta _idMeta = const VerificationMeta('id');
   @override
   late final GeneratedColumn<int> id = GeneratedColumn<int>(
-    'id',
-    aliasedName,
-    false,
-    hasAutoIncrement: true,
-    type: DriftSqlType.int,
-    requiredDuringInsert: false,
-    defaultConstraints: GeneratedColumn.constraintIsAlways(
-      'PRIMARY KEY AUTOINCREMENT',
-    ),
-  );
+      'id', aliasedName, false,
+      hasAutoIncrement: true,
+      type: DriftSqlType.int,
+      requiredDuringInsert: false,
+      defaultConstraints:
+          GeneratedColumn.constraintIsAlways('PRIMARY KEY AUTOINCREMENT'));
   static const VerificationMeta _uuidMeta = const VerificationMeta('uuid');
   @override
   late final GeneratedColumn<String> uuid = GeneratedColumn<String>(
-    'uuid',
-    aliasedName,
-    false,
-    type: DriftSqlType.string,
-    requiredDuringInsert: true,
-    defaultConstraints: GeneratedColumn.constraintIsAlways('UNIQUE'),
-  );
+      'uuid', aliasedName, false,
+      type: DriftSqlType.string,
+      requiredDuringInsert: true,
+      defaultConstraints: GeneratedColumn.constraintIsAlways('UNIQUE'));
   static const VerificationMeta _nameMeta = const VerificationMeta('name');
   @override
   late final GeneratedColumn<String> name = GeneratedColumn<String>(
-    'name',
-    aliasedName,
-    false,
-    type: DriftSqlType.string,
-    requiredDuringInsert: true,
-  );
-  static const VerificationMeta _iconNameMeta = const VerificationMeta(
-    'iconName',
-  );
+      'name', aliasedName, false,
+      type: DriftSqlType.string, requiredDuringInsert: true);
+  static const VerificationMeta _iconNameMeta =
+      const VerificationMeta('iconName');
   @override
   late final GeneratedColumn<String> iconName = GeneratedColumn<String>(
-    'icon_name',
-    aliasedName,
-    false,
-    type: DriftSqlType.string,
-    requiredDuringInsert: false,
-    defaultValue: const Constant('category'),
-  );
-  static const VerificationMeta _colorHexMeta = const VerificationMeta(
-    'colorHex',
-  );
+      'icon_name', aliasedName, false,
+      type: DriftSqlType.string,
+      requiredDuringInsert: false,
+      defaultValue: const Constant('category'));
+  static const VerificationMeta _colorHexMeta =
+      const VerificationMeta('colorHex');
   @override
   late final GeneratedColumn<String> colorHex = GeneratedColumn<String>(
-    'color_hex',
-    aliasedName,
-    false,
-    type: DriftSqlType.string,
-    requiredDuringInsert: false,
-    defaultValue: const Constant('#808080'),
-  );
-  static const VerificationMeta _categoryTypeMeta = const VerificationMeta(
-    'categoryType',
-  );
+      'color_hex', aliasedName, false,
+      type: DriftSqlType.string,
+      requiredDuringInsert: false,
+      defaultValue: const Constant('#808080'));
+  static const VerificationMeta _categoryTypeMeta =
+      const VerificationMeta('categoryType');
   @override
   late final GeneratedColumn<String> categoryType = GeneratedColumn<String>(
-    'category_type',
-    aliasedName,
-    false,
-    type: DriftSqlType.string,
-    requiredDuringInsert: false,
-    defaultValue: const Constant('expense'),
-  );
-  static const VerificationMeta _parentIdMeta = const VerificationMeta(
-    'parentId',
-  );
+      'category_type', aliasedName, false,
+      type: DriftSqlType.string,
+      requiredDuringInsert: false,
+      defaultValue: const Constant('expense'));
+  static const VerificationMeta _parentIdMeta =
+      const VerificationMeta('parentId');
   @override
   late final GeneratedColumn<String> parentId = GeneratedColumn<String>(
-    'parent_id',
-    aliasedName,
-    true,
-    type: DriftSqlType.string,
-    requiredDuringInsert: false,
-  );
-  static const VerificationMeta _sortOrderMeta = const VerificationMeta(
-    'sortOrder',
-  );
+      'parent_id', aliasedName, true,
+      type: DriftSqlType.string, requiredDuringInsert: false);
+  static const VerificationMeta _sortOrderMeta =
+      const VerificationMeta('sortOrder');
   @override
   late final GeneratedColumn<int> sortOrder = GeneratedColumn<int>(
-    'sort_order',
-    aliasedName,
-    false,
-    type: DriftSqlType.int,
-    requiredDuringInsert: false,
-    defaultValue: const Constant(0),
-  );
-  static const VerificationMeta _isActiveMeta = const VerificationMeta(
-    'isActive',
-  );
+      'sort_order', aliasedName, false,
+      type: DriftSqlType.int,
+      requiredDuringInsert: false,
+      defaultValue: const Constant(0));
+  static const VerificationMeta _isActiveMeta =
+      const VerificationMeta('isActive');
   @override
   late final GeneratedColumn<bool> isActive = GeneratedColumn<bool>(
-    'is_active',
-    aliasedName,
-    false,
-    type: DriftSqlType.bool,
-    requiredDuringInsert: false,
-    defaultConstraints: GeneratedColumn.constraintIsAlways(
-      'CHECK ("is_active" IN (0, 1))',
-    ),
-    defaultValue: const Constant(true),
-  );
-  static const VerificationMeta _syncStatusMeta = const VerificationMeta(
-    'syncStatus',
-  );
+      'is_active', aliasedName, false,
+      type: DriftSqlType.bool,
+      requiredDuringInsert: false,
+      defaultConstraints:
+          GeneratedColumn.constraintIsAlways('CHECK ("is_active" IN (0, 1))'),
+      defaultValue: const Constant(true));
+  static const VerificationMeta _syncStatusMeta =
+      const VerificationMeta('syncStatus');
   @override
   late final GeneratedColumn<String> syncStatus = GeneratedColumn<String>(
-    'sync_status',
-    aliasedName,
-    false,
-    type: DriftSqlType.string,
-    requiredDuringInsert: false,
-    defaultValue: const Constant('pending'),
-  );
-  static const VerificationMeta _createdAtMeta = const VerificationMeta(
-    'createdAt',
-  );
+      'sync_status', aliasedName, false,
+      type: DriftSqlType.string,
+      requiredDuringInsert: false,
+      defaultValue: const Constant('pending'));
+  static const VerificationMeta _createdAtMeta =
+      const VerificationMeta('createdAt');
   @override
   late final GeneratedColumn<DateTime> createdAt = GeneratedColumn<DateTime>(
-    'created_at',
-    aliasedName,
-    false,
-    type: DriftSqlType.dateTime,
-    requiredDuringInsert: false,
-    defaultValue: currentDateAndTime,
-  );
-  static const VerificationMeta _updatedAtMeta = const VerificationMeta(
-    'updatedAt',
-  );
+      'created_at', aliasedName, false,
+      type: DriftSqlType.dateTime,
+      requiredDuringInsert: false,
+      defaultValue: currentDateAndTime);
+  static const VerificationMeta _updatedAtMeta =
+      const VerificationMeta('updatedAt');
   @override
   late final GeneratedColumn<DateTime> updatedAt = GeneratedColumn<DateTime>(
-    'updated_at',
-    aliasedName,
-    true,
-    type: DriftSqlType.dateTime,
-    requiredDuringInsert: false,
-  );
+      'updated_at', aliasedName, true,
+      type: DriftSqlType.dateTime, requiredDuringInsert: false);
   @override
   List<GeneratedColumn> get $columns => [
-    id,
-    uuid,
-    name,
-    iconName,
-    colorHex,
-    categoryType,
-    parentId,
-    sortOrder,
-    isActive,
-    syncStatus,
-    createdAt,
-    updatedAt,
-  ];
+        id,
+        uuid,
+        name,
+        iconName,
+        colorHex,
+        categoryType,
+        parentId,
+        sortOrder,
+        isActive,
+        syncStatus,
+        createdAt,
+        updatedAt
+      ];
   @override
   String get aliasedName => _alias ?? actualTableName;
   @override
   String get actualTableName => $name;
   static const String $name = 'category_entries';
   @override
-  VerificationContext validateIntegrity(
-    Insertable<CategoryEntry> instance, {
-    bool isInserting = false,
-  }) {
+  VerificationContext validateIntegrity(Insertable<CategoryEntry> instance,
+      {bool isInserting = false}) {
     final context = VerificationContext();
     final data = instance.toColumns(true);
     if (data.containsKey('id')) {
@@ -2138,76 +1785,55 @@ class $CategoryEntriesTable extends CategoryEntries
     }
     if (data.containsKey('uuid')) {
       context.handle(
-        _uuidMeta,
-        uuid.isAcceptableOrUnknown(data['uuid']!, _uuidMeta),
-      );
+          _uuidMeta, uuid.isAcceptableOrUnknown(data['uuid']!, _uuidMeta));
     } else if (isInserting) {
       context.missing(_uuidMeta);
     }
     if (data.containsKey('name')) {
       context.handle(
-        _nameMeta,
-        name.isAcceptableOrUnknown(data['name']!, _nameMeta),
-      );
+          _nameMeta, name.isAcceptableOrUnknown(data['name']!, _nameMeta));
     } else if (isInserting) {
       context.missing(_nameMeta);
     }
     if (data.containsKey('icon_name')) {
-      context.handle(
-        _iconNameMeta,
-        iconName.isAcceptableOrUnknown(data['icon_name']!, _iconNameMeta),
-      );
+      context.handle(_iconNameMeta,
+          iconName.isAcceptableOrUnknown(data['icon_name']!, _iconNameMeta));
     }
     if (data.containsKey('color_hex')) {
-      context.handle(
-        _colorHexMeta,
-        colorHex.isAcceptableOrUnknown(data['color_hex']!, _colorHexMeta),
-      );
+      context.handle(_colorHexMeta,
+          colorHex.isAcceptableOrUnknown(data['color_hex']!, _colorHexMeta));
     }
     if (data.containsKey('category_type')) {
       context.handle(
-        _categoryTypeMeta,
-        categoryType.isAcceptableOrUnknown(
-          data['category_type']!,
           _categoryTypeMeta,
-        ),
-      );
+          categoryType.isAcceptableOrUnknown(
+              data['category_type']!, _categoryTypeMeta));
     }
     if (data.containsKey('parent_id')) {
-      context.handle(
-        _parentIdMeta,
-        parentId.isAcceptableOrUnknown(data['parent_id']!, _parentIdMeta),
-      );
+      context.handle(_parentIdMeta,
+          parentId.isAcceptableOrUnknown(data['parent_id']!, _parentIdMeta));
     }
     if (data.containsKey('sort_order')) {
-      context.handle(
-        _sortOrderMeta,
-        sortOrder.isAcceptableOrUnknown(data['sort_order']!, _sortOrderMeta),
-      );
+      context.handle(_sortOrderMeta,
+          sortOrder.isAcceptableOrUnknown(data['sort_order']!, _sortOrderMeta));
     }
     if (data.containsKey('is_active')) {
-      context.handle(
-        _isActiveMeta,
-        isActive.isAcceptableOrUnknown(data['is_active']!, _isActiveMeta),
-      );
+      context.handle(_isActiveMeta,
+          isActive.isAcceptableOrUnknown(data['is_active']!, _isActiveMeta));
     }
     if (data.containsKey('sync_status')) {
       context.handle(
-        _syncStatusMeta,
-        syncStatus.isAcceptableOrUnknown(data['sync_status']!, _syncStatusMeta),
-      );
+          _syncStatusMeta,
+          syncStatus.isAcceptableOrUnknown(
+              data['sync_status']!, _syncStatusMeta));
     }
     if (data.containsKey('created_at')) {
-      context.handle(
-        _createdAtMeta,
-        createdAt.isAcceptableOrUnknown(data['created_at']!, _createdAtMeta),
-      );
+      context.handle(_createdAtMeta,
+          createdAt.isAcceptableOrUnknown(data['created_at']!, _createdAtMeta));
     }
     if (data.containsKey('updated_at')) {
-      context.handle(
-        _updatedAtMeta,
-        updatedAt.isAcceptableOrUnknown(data['updated_at']!, _updatedAtMeta),
-      );
+      context.handle(_updatedAtMeta,
+          updatedAt.isAcceptableOrUnknown(data['updated_at']!, _updatedAtMeta));
     }
     return context;
   }
@@ -2218,54 +1844,30 @@ class $CategoryEntriesTable extends CategoryEntries
   CategoryEntry map(Map<String, dynamic> data, {String? tablePrefix}) {
     final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
     return CategoryEntry(
-      id: attachedDatabase.typeMapping.read(
-        DriftSqlType.int,
-        data['${effectivePrefix}id'],
-      )!,
-      uuid: attachedDatabase.typeMapping.read(
-        DriftSqlType.string,
-        data['${effectivePrefix}uuid'],
-      )!,
-      name: attachedDatabase.typeMapping.read(
-        DriftSqlType.string,
-        data['${effectivePrefix}name'],
-      )!,
-      iconName: attachedDatabase.typeMapping.read(
-        DriftSqlType.string,
-        data['${effectivePrefix}icon_name'],
-      )!,
-      colorHex: attachedDatabase.typeMapping.read(
-        DriftSqlType.string,
-        data['${effectivePrefix}color_hex'],
-      )!,
-      categoryType: attachedDatabase.typeMapping.read(
-        DriftSqlType.string,
-        data['${effectivePrefix}category_type'],
-      )!,
-      parentId: attachedDatabase.typeMapping.read(
-        DriftSqlType.string,
-        data['${effectivePrefix}parent_id'],
-      ),
-      sortOrder: attachedDatabase.typeMapping.read(
-        DriftSqlType.int,
-        data['${effectivePrefix}sort_order'],
-      )!,
-      isActive: attachedDatabase.typeMapping.read(
-        DriftSqlType.bool,
-        data['${effectivePrefix}is_active'],
-      )!,
-      syncStatus: attachedDatabase.typeMapping.read(
-        DriftSqlType.string,
-        data['${effectivePrefix}sync_status'],
-      )!,
-      createdAt: attachedDatabase.typeMapping.read(
-        DriftSqlType.dateTime,
-        data['${effectivePrefix}created_at'],
-      )!,
-      updatedAt: attachedDatabase.typeMapping.read(
-        DriftSqlType.dateTime,
-        data['${effectivePrefix}updated_at'],
-      ),
+      id: attachedDatabase.typeMapping
+          .read(DriftSqlType.int, data['${effectivePrefix}id'])!,
+      uuid: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}uuid'])!,
+      name: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}name'])!,
+      iconName: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}icon_name'])!,
+      colorHex: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}color_hex'])!,
+      categoryType: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}category_type'])!,
+      parentId: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}parent_id']),
+      sortOrder: attachedDatabase.typeMapping
+          .read(DriftSqlType.int, data['${effectivePrefix}sort_order'])!,
+      isActive: attachedDatabase.typeMapping
+          .read(DriftSqlType.bool, data['${effectivePrefix}is_active'])!,
+      syncStatus: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}sync_status'])!,
+      createdAt: attachedDatabase.typeMapping
+          .read(DriftSqlType.dateTime, data['${effectivePrefix}created_at'])!,
+      updatedAt: attachedDatabase.typeMapping
+          .read(DriftSqlType.dateTime, data['${effectivePrefix}updated_at']),
     );
   }
 
@@ -2288,20 +1890,19 @@ class CategoryEntry extends DataClass implements Insertable<CategoryEntry> {
   final String syncStatus;
   final DateTime createdAt;
   final DateTime? updatedAt;
-  const CategoryEntry({
-    required this.id,
-    required this.uuid,
-    required this.name,
-    required this.iconName,
-    required this.colorHex,
-    required this.categoryType,
-    this.parentId,
-    required this.sortOrder,
-    required this.isActive,
-    required this.syncStatus,
-    required this.createdAt,
-    this.updatedAt,
-  });
+  const CategoryEntry(
+      {required this.id,
+      required this.uuid,
+      required this.name,
+      required this.iconName,
+      required this.colorHex,
+      required this.categoryType,
+      this.parentId,
+      required this.sortOrder,
+      required this.isActive,
+      required this.syncStatus,
+      required this.createdAt,
+      this.updatedAt});
   @override
   Map<String, Expression> toColumns(bool nullToAbsent) {
     final map = <String, Expression>{};
@@ -2345,10 +1946,8 @@ class CategoryEntry extends DataClass implements Insertable<CategoryEntry> {
     );
   }
 
-  factory CategoryEntry.fromJson(
-    Map<String, dynamic> json, {
-    ValueSerializer? serializer,
-  }) {
+  factory CategoryEntry.fromJson(Map<String, dynamic> json,
+      {ValueSerializer? serializer}) {
     serializer ??= driftRuntimeOptions.defaultSerializer;
     return CategoryEntry(
       id: serializer.fromJson<int>(json['id']),
@@ -2384,33 +1983,33 @@ class CategoryEntry extends DataClass implements Insertable<CategoryEntry> {
     };
   }
 
-  CategoryEntry copyWith({
-    int? id,
-    String? uuid,
-    String? name,
-    String? iconName,
-    String? colorHex,
-    String? categoryType,
-    Value<String?> parentId = const Value.absent(),
-    int? sortOrder,
-    bool? isActive,
-    String? syncStatus,
-    DateTime? createdAt,
-    Value<DateTime?> updatedAt = const Value.absent(),
-  }) => CategoryEntry(
-    id: id ?? this.id,
-    uuid: uuid ?? this.uuid,
-    name: name ?? this.name,
-    iconName: iconName ?? this.iconName,
-    colorHex: colorHex ?? this.colorHex,
-    categoryType: categoryType ?? this.categoryType,
-    parentId: parentId.present ? parentId.value : this.parentId,
-    sortOrder: sortOrder ?? this.sortOrder,
-    isActive: isActive ?? this.isActive,
-    syncStatus: syncStatus ?? this.syncStatus,
-    createdAt: createdAt ?? this.createdAt,
-    updatedAt: updatedAt.present ? updatedAt.value : this.updatedAt,
-  );
+  CategoryEntry copyWith(
+          {int? id,
+          String? uuid,
+          String? name,
+          String? iconName,
+          String? colorHex,
+          String? categoryType,
+          Value<String?> parentId = const Value.absent(),
+          int? sortOrder,
+          bool? isActive,
+          String? syncStatus,
+          DateTime? createdAt,
+          Value<DateTime?> updatedAt = const Value.absent()}) =>
+      CategoryEntry(
+        id: id ?? this.id,
+        uuid: uuid ?? this.uuid,
+        name: name ?? this.name,
+        iconName: iconName ?? this.iconName,
+        colorHex: colorHex ?? this.colorHex,
+        categoryType: categoryType ?? this.categoryType,
+        parentId: parentId.present ? parentId.value : this.parentId,
+        sortOrder: sortOrder ?? this.sortOrder,
+        isActive: isActive ?? this.isActive,
+        syncStatus: syncStatus ?? this.syncStatus,
+        createdAt: createdAt ?? this.createdAt,
+        updatedAt: updatedAt.present ? updatedAt.value : this.updatedAt,
+      );
   CategoryEntry copyWithCompanion(CategoryEntriesCompanion data) {
     return CategoryEntry(
       id: data.id.present ? data.id.value : this.id,
@@ -2424,9 +2023,8 @@ class CategoryEntry extends DataClass implements Insertable<CategoryEntry> {
       parentId: data.parentId.present ? data.parentId.value : this.parentId,
       sortOrder: data.sortOrder.present ? data.sortOrder.value : this.sortOrder,
       isActive: data.isActive.present ? data.isActive.value : this.isActive,
-      syncStatus: data.syncStatus.present
-          ? data.syncStatus.value
-          : this.syncStatus,
+      syncStatus:
+          data.syncStatus.present ? data.syncStatus.value : this.syncStatus,
       createdAt: data.createdAt.present ? data.createdAt.value : this.createdAt,
       updatedAt: data.updatedAt.present ? data.updatedAt.value : this.updatedAt,
     );
@@ -2453,19 +2051,18 @@ class CategoryEntry extends DataClass implements Insertable<CategoryEntry> {
 
   @override
   int get hashCode => Object.hash(
-    id,
-    uuid,
-    name,
-    iconName,
-    colorHex,
-    categoryType,
-    parentId,
-    sortOrder,
-    isActive,
-    syncStatus,
-    createdAt,
-    updatedAt,
-  );
+      id,
+      uuid,
+      name,
+      iconName,
+      colorHex,
+      categoryType,
+      parentId,
+      sortOrder,
+      isActive,
+      syncStatus,
+      createdAt,
+      updatedAt);
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
@@ -2524,8 +2121,8 @@ class CategoryEntriesCompanion extends UpdateCompanion<CategoryEntry> {
     this.syncStatus = const Value.absent(),
     this.createdAt = const Value.absent(),
     this.updatedAt = const Value.absent(),
-  }) : uuid = Value(uuid),
-       name = Value(name);
+  })  : uuid = Value(uuid),
+        name = Value(name);
   static Insertable<CategoryEntry> custom({
     Expression<int>? id,
     Expression<String>? uuid,
@@ -2556,20 +2153,19 @@ class CategoryEntriesCompanion extends UpdateCompanion<CategoryEntry> {
     });
   }
 
-  CategoryEntriesCompanion copyWith({
-    Value<int>? id,
-    Value<String>? uuid,
-    Value<String>? name,
-    Value<String>? iconName,
-    Value<String>? colorHex,
-    Value<String>? categoryType,
-    Value<String?>? parentId,
-    Value<int>? sortOrder,
-    Value<bool>? isActive,
-    Value<String>? syncStatus,
-    Value<DateTime>? createdAt,
-    Value<DateTime?>? updatedAt,
-  }) {
+  CategoryEntriesCompanion copyWith(
+      {Value<int>? id,
+      Value<String>? uuid,
+      Value<String>? name,
+      Value<String>? iconName,
+      Value<String>? colorHex,
+      Value<String>? categoryType,
+      Value<String?>? parentId,
+      Value<int>? sortOrder,
+      Value<bool>? isActive,
+      Value<String>? syncStatus,
+      Value<DateTime>? createdAt,
+      Value<DateTime?>? updatedAt}) {
     return CategoryEntriesCompanion(
       id: id ?? this.id,
       uuid: uuid ?? this.uuid,
@@ -2657,182 +2253,122 @@ class $GroupEntriesTable extends GroupEntries
   static const VerificationMeta _idMeta = const VerificationMeta('id');
   @override
   late final GeneratedColumn<int> id = GeneratedColumn<int>(
-    'id',
-    aliasedName,
-    false,
-    hasAutoIncrement: true,
-    type: DriftSqlType.int,
-    requiredDuringInsert: false,
-    defaultConstraints: GeneratedColumn.constraintIsAlways(
-      'PRIMARY KEY AUTOINCREMENT',
-    ),
-  );
+      'id', aliasedName, false,
+      hasAutoIncrement: true,
+      type: DriftSqlType.int,
+      requiredDuringInsert: false,
+      defaultConstraints:
+          GeneratedColumn.constraintIsAlways('PRIMARY KEY AUTOINCREMENT'));
   static const VerificationMeta _uuidMeta = const VerificationMeta('uuid');
   @override
   late final GeneratedColumn<String> uuid = GeneratedColumn<String>(
-    'uuid',
-    aliasedName,
-    false,
-    type: DriftSqlType.string,
-    requiredDuringInsert: true,
-    defaultConstraints: GeneratedColumn.constraintIsAlways('UNIQUE'),
-  );
+      'uuid', aliasedName, false,
+      type: DriftSqlType.string,
+      requiredDuringInsert: true,
+      defaultConstraints: GeneratedColumn.constraintIsAlways('UNIQUE'));
   static const VerificationMeta _nameMeta = const VerificationMeta('name');
   @override
   late final GeneratedColumn<String> name = GeneratedColumn<String>(
-    'name',
-    aliasedName,
-    false,
-    type: DriftSqlType.string,
-    requiredDuringInsert: true,
-  );
-  static const VerificationMeta _descriptionMeta = const VerificationMeta(
-    'description',
-  );
+      'name', aliasedName, false,
+      type: DriftSqlType.string, requiredDuringInsert: true);
+  static const VerificationMeta _descriptionMeta =
+      const VerificationMeta('description');
   @override
   late final GeneratedColumn<String> description = GeneratedColumn<String>(
-    'description',
-    aliasedName,
-    true,
-    type: DriftSqlType.string,
-    requiredDuringInsert: false,
-  );
-  static const VerificationMeta _iconUrlMeta = const VerificationMeta(
-    'iconUrl',
-  );
+      'description', aliasedName, true,
+      type: DriftSqlType.string, requiredDuringInsert: false);
+  static const VerificationMeta _iconUrlMeta =
+      const VerificationMeta('iconUrl');
   @override
   late final GeneratedColumn<String> iconUrl = GeneratedColumn<String>(
-    'icon_url',
-    aliasedName,
-    true,
-    type: DriftSqlType.string,
-    requiredDuringInsert: false,
-  );
-  static const VerificationMeta _createdByUserIdMeta = const VerificationMeta(
-    'createdByUserId',
-  );
+      'icon_url', aliasedName, true,
+      type: DriftSqlType.string, requiredDuringInsert: false);
+  static const VerificationMeta _createdByUserIdMeta =
+      const VerificationMeta('createdByUserId');
   @override
   late final GeneratedColumn<String> createdByUserId = GeneratedColumn<String>(
-    'created_by_user_id',
-    aliasedName,
-    false,
-    type: DriftSqlType.string,
-    requiredDuringInsert: true,
-  );
-  static const VerificationMeta _defaultCurrencyMeta = const VerificationMeta(
-    'defaultCurrency',
-  );
+      'created_by_user_id', aliasedName, false,
+      type: DriftSqlType.string, requiredDuringInsert: true);
+  static const VerificationMeta _defaultCurrencyMeta =
+      const VerificationMeta('defaultCurrency');
   @override
   late final GeneratedColumn<String> defaultCurrency = GeneratedColumn<String>(
-    'default_currency',
-    aliasedName,
-    false,
-    type: DriftSqlType.string,
-    requiredDuringInsert: false,
-    defaultValue: const Constant('INR'),
-  );
-  static const VerificationMeta _simplifyDebtsMeta = const VerificationMeta(
-    'simplifyDebts',
-  );
+      'default_currency', aliasedName, false,
+      type: DriftSqlType.string,
+      requiredDuringInsert: false,
+      defaultValue: const Constant('INR'));
+  static const VerificationMeta _simplifyDebtsMeta =
+      const VerificationMeta('simplifyDebts');
   @override
   late final GeneratedColumn<bool> simplifyDebts = GeneratedColumn<bool>(
-    'simplify_debts',
-    aliasedName,
-    false,
-    type: DriftSqlType.bool,
-    requiredDuringInsert: false,
-    defaultConstraints: GeneratedColumn.constraintIsAlways(
-      'CHECK ("simplify_debts" IN (0, 1))',
-    ),
-    defaultValue: const Constant(true),
-  );
-  static const VerificationMeta _isActiveMeta = const VerificationMeta(
-    'isActive',
-  );
+      'simplify_debts', aliasedName, false,
+      type: DriftSqlType.bool,
+      requiredDuringInsert: false,
+      defaultConstraints: GeneratedColumn.constraintIsAlways(
+          'CHECK ("simplify_debts" IN (0, 1))'),
+      defaultValue: const Constant(true));
+  static const VerificationMeta _isActiveMeta =
+      const VerificationMeta('isActive');
   @override
   late final GeneratedColumn<bool> isActive = GeneratedColumn<bool>(
-    'is_active',
-    aliasedName,
-    false,
-    type: DriftSqlType.bool,
-    requiredDuringInsert: false,
-    defaultConstraints: GeneratedColumn.constraintIsAlways(
-      'CHECK ("is_active" IN (0, 1))',
-    ),
-    defaultValue: const Constant(true),
-  );
-  static const VerificationMeta _inviteCodeMeta = const VerificationMeta(
-    'inviteCode',
-  );
+      'is_active', aliasedName, false,
+      type: DriftSqlType.bool,
+      requiredDuringInsert: false,
+      defaultConstraints:
+          GeneratedColumn.constraintIsAlways('CHECK ("is_active" IN (0, 1))'),
+      defaultValue: const Constant(true));
+  static const VerificationMeta _inviteCodeMeta =
+      const VerificationMeta('inviteCode');
   @override
   late final GeneratedColumn<String> inviteCode = GeneratedColumn<String>(
-    'invite_code',
-    aliasedName,
-    true,
-    type: DriftSqlType.string,
-    requiredDuringInsert: false,
-  );
-  static const VerificationMeta _syncStatusMeta = const VerificationMeta(
-    'syncStatus',
-  );
+      'invite_code', aliasedName, true,
+      type: DriftSqlType.string, requiredDuringInsert: false);
+  static const VerificationMeta _syncStatusMeta =
+      const VerificationMeta('syncStatus');
   @override
   late final GeneratedColumn<String> syncStatus = GeneratedColumn<String>(
-    'sync_status',
-    aliasedName,
-    false,
-    type: DriftSqlType.string,
-    requiredDuringInsert: false,
-    defaultValue: const Constant('pending'),
-  );
-  static const VerificationMeta _createdAtMeta = const VerificationMeta(
-    'createdAt',
-  );
+      'sync_status', aliasedName, false,
+      type: DriftSqlType.string,
+      requiredDuringInsert: false,
+      defaultValue: const Constant('pending'));
+  static const VerificationMeta _createdAtMeta =
+      const VerificationMeta('createdAt');
   @override
   late final GeneratedColumn<DateTime> createdAt = GeneratedColumn<DateTime>(
-    'created_at',
-    aliasedName,
-    false,
-    type: DriftSqlType.dateTime,
-    requiredDuringInsert: false,
-    defaultValue: currentDateAndTime,
-  );
-  static const VerificationMeta _updatedAtMeta = const VerificationMeta(
-    'updatedAt',
-  );
+      'created_at', aliasedName, false,
+      type: DriftSqlType.dateTime,
+      requiredDuringInsert: false,
+      defaultValue: currentDateAndTime);
+  static const VerificationMeta _updatedAtMeta =
+      const VerificationMeta('updatedAt');
   @override
   late final GeneratedColumn<DateTime> updatedAt = GeneratedColumn<DateTime>(
-    'updated_at',
-    aliasedName,
-    true,
-    type: DriftSqlType.dateTime,
-    requiredDuringInsert: false,
-  );
+      'updated_at', aliasedName, true,
+      type: DriftSqlType.dateTime, requiredDuringInsert: false);
   @override
   List<GeneratedColumn> get $columns => [
-    id,
-    uuid,
-    name,
-    description,
-    iconUrl,
-    createdByUserId,
-    defaultCurrency,
-    simplifyDebts,
-    isActive,
-    inviteCode,
-    syncStatus,
-    createdAt,
-    updatedAt,
-  ];
+        id,
+        uuid,
+        name,
+        description,
+        iconUrl,
+        createdByUserId,
+        defaultCurrency,
+        simplifyDebts,
+        isActive,
+        inviteCode,
+        syncStatus,
+        createdAt,
+        updatedAt
+      ];
   @override
   String get aliasedName => _alias ?? actualTableName;
   @override
   String get actualTableName => $name;
   static const String $name = 'group_entries';
   @override
-  VerificationContext validateIntegrity(
-    Insertable<GroupEntry> instance, {
-    bool isInserting = false,
-  }) {
+  VerificationContext validateIntegrity(Insertable<GroupEntry> instance,
+      {bool isInserting = false}) {
     final context = VerificationContext();
     final data = instance.toColumns(true);
     if (data.containsKey('id')) {
@@ -2840,93 +2376,69 @@ class $GroupEntriesTable extends GroupEntries
     }
     if (data.containsKey('uuid')) {
       context.handle(
-        _uuidMeta,
-        uuid.isAcceptableOrUnknown(data['uuid']!, _uuidMeta),
-      );
+          _uuidMeta, uuid.isAcceptableOrUnknown(data['uuid']!, _uuidMeta));
     } else if (isInserting) {
       context.missing(_uuidMeta);
     }
     if (data.containsKey('name')) {
       context.handle(
-        _nameMeta,
-        name.isAcceptableOrUnknown(data['name']!, _nameMeta),
-      );
+          _nameMeta, name.isAcceptableOrUnknown(data['name']!, _nameMeta));
     } else if (isInserting) {
       context.missing(_nameMeta);
     }
     if (data.containsKey('description')) {
       context.handle(
-        _descriptionMeta,
-        description.isAcceptableOrUnknown(
-          data['description']!,
           _descriptionMeta,
-        ),
-      );
+          description.isAcceptableOrUnknown(
+              data['description']!, _descriptionMeta));
     }
     if (data.containsKey('icon_url')) {
-      context.handle(
-        _iconUrlMeta,
-        iconUrl.isAcceptableOrUnknown(data['icon_url']!, _iconUrlMeta),
-      );
+      context.handle(_iconUrlMeta,
+          iconUrl.isAcceptableOrUnknown(data['icon_url']!, _iconUrlMeta));
     }
     if (data.containsKey('created_by_user_id')) {
       context.handle(
-        _createdByUserIdMeta,
-        createdByUserId.isAcceptableOrUnknown(
-          data['created_by_user_id']!,
           _createdByUserIdMeta,
-        ),
-      );
+          createdByUserId.isAcceptableOrUnknown(
+              data['created_by_user_id']!, _createdByUserIdMeta));
     } else if (isInserting) {
       context.missing(_createdByUserIdMeta);
     }
     if (data.containsKey('default_currency')) {
       context.handle(
-        _defaultCurrencyMeta,
-        defaultCurrency.isAcceptableOrUnknown(
-          data['default_currency']!,
           _defaultCurrencyMeta,
-        ),
-      );
+          defaultCurrency.isAcceptableOrUnknown(
+              data['default_currency']!, _defaultCurrencyMeta));
     }
     if (data.containsKey('simplify_debts')) {
       context.handle(
-        _simplifyDebtsMeta,
-        simplifyDebts.isAcceptableOrUnknown(
-          data['simplify_debts']!,
           _simplifyDebtsMeta,
-        ),
-      );
+          simplifyDebts.isAcceptableOrUnknown(
+              data['simplify_debts']!, _simplifyDebtsMeta));
     }
     if (data.containsKey('is_active')) {
-      context.handle(
-        _isActiveMeta,
-        isActive.isAcceptableOrUnknown(data['is_active']!, _isActiveMeta),
-      );
+      context.handle(_isActiveMeta,
+          isActive.isAcceptableOrUnknown(data['is_active']!, _isActiveMeta));
     }
     if (data.containsKey('invite_code')) {
       context.handle(
-        _inviteCodeMeta,
-        inviteCode.isAcceptableOrUnknown(data['invite_code']!, _inviteCodeMeta),
-      );
+          _inviteCodeMeta,
+          inviteCode.isAcceptableOrUnknown(
+              data['invite_code']!, _inviteCodeMeta));
     }
     if (data.containsKey('sync_status')) {
       context.handle(
-        _syncStatusMeta,
-        syncStatus.isAcceptableOrUnknown(data['sync_status']!, _syncStatusMeta),
-      );
+          _syncStatusMeta,
+          syncStatus.isAcceptableOrUnknown(
+              data['sync_status']!, _syncStatusMeta));
     }
     if (data.containsKey('created_at')) {
-      context.handle(
-        _createdAtMeta,
-        createdAt.isAcceptableOrUnknown(data['created_at']!, _createdAtMeta),
-      );
+      context.handle(_createdAtMeta,
+          createdAt.isAcceptableOrUnknown(data['created_at']!, _createdAtMeta));
     }
     if (data.containsKey('updated_at')) {
-      context.handle(
-        _updatedAtMeta,
-        updatedAt.isAcceptableOrUnknown(data['updated_at']!, _updatedAtMeta),
-      );
+      context.handle(_updatedAtMeta,
+          updatedAt.isAcceptableOrUnknown(data['updated_at']!, _updatedAtMeta));
     }
     return context;
   }
@@ -2937,58 +2449,32 @@ class $GroupEntriesTable extends GroupEntries
   GroupEntry map(Map<String, dynamic> data, {String? tablePrefix}) {
     final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
     return GroupEntry(
-      id: attachedDatabase.typeMapping.read(
-        DriftSqlType.int,
-        data['${effectivePrefix}id'],
-      )!,
-      uuid: attachedDatabase.typeMapping.read(
-        DriftSqlType.string,
-        data['${effectivePrefix}uuid'],
-      )!,
-      name: attachedDatabase.typeMapping.read(
-        DriftSqlType.string,
-        data['${effectivePrefix}name'],
-      )!,
-      description: attachedDatabase.typeMapping.read(
-        DriftSqlType.string,
-        data['${effectivePrefix}description'],
-      ),
-      iconUrl: attachedDatabase.typeMapping.read(
-        DriftSqlType.string,
-        data['${effectivePrefix}icon_url'],
-      ),
+      id: attachedDatabase.typeMapping
+          .read(DriftSqlType.int, data['${effectivePrefix}id'])!,
+      uuid: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}uuid'])!,
+      name: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}name'])!,
+      description: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}description']),
+      iconUrl: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}icon_url']),
       createdByUserId: attachedDatabase.typeMapping.read(
-        DriftSqlType.string,
-        data['${effectivePrefix}created_by_user_id'],
-      )!,
+          DriftSqlType.string, data['${effectivePrefix}created_by_user_id'])!,
       defaultCurrency: attachedDatabase.typeMapping.read(
-        DriftSqlType.string,
-        data['${effectivePrefix}default_currency'],
-      )!,
-      simplifyDebts: attachedDatabase.typeMapping.read(
-        DriftSqlType.bool,
-        data['${effectivePrefix}simplify_debts'],
-      )!,
-      isActive: attachedDatabase.typeMapping.read(
-        DriftSqlType.bool,
-        data['${effectivePrefix}is_active'],
-      )!,
-      inviteCode: attachedDatabase.typeMapping.read(
-        DriftSqlType.string,
-        data['${effectivePrefix}invite_code'],
-      ),
-      syncStatus: attachedDatabase.typeMapping.read(
-        DriftSqlType.string,
-        data['${effectivePrefix}sync_status'],
-      )!,
-      createdAt: attachedDatabase.typeMapping.read(
-        DriftSqlType.dateTime,
-        data['${effectivePrefix}created_at'],
-      )!,
-      updatedAt: attachedDatabase.typeMapping.read(
-        DriftSqlType.dateTime,
-        data['${effectivePrefix}updated_at'],
-      ),
+          DriftSqlType.string, data['${effectivePrefix}default_currency'])!,
+      simplifyDebts: attachedDatabase.typeMapping
+          .read(DriftSqlType.bool, data['${effectivePrefix}simplify_debts'])!,
+      isActive: attachedDatabase.typeMapping
+          .read(DriftSqlType.bool, data['${effectivePrefix}is_active'])!,
+      inviteCode: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}invite_code']),
+      syncStatus: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}sync_status'])!,
+      createdAt: attachedDatabase.typeMapping
+          .read(DriftSqlType.dateTime, data['${effectivePrefix}created_at'])!,
+      updatedAt: attachedDatabase.typeMapping
+          .read(DriftSqlType.dateTime, data['${effectivePrefix}updated_at']),
     );
   }
 
@@ -3005,6 +2491,8 @@ class GroupEntry extends DataClass implements Insertable<GroupEntry> {
   final String? description;
   final String? iconUrl;
   final String createdByUserId;
+
+  /// Default currency for the group.
   final String defaultCurrency;
   final bool simplifyDebts;
   final bool isActive;
@@ -3012,21 +2500,20 @@ class GroupEntry extends DataClass implements Insertable<GroupEntry> {
   final String syncStatus;
   final DateTime createdAt;
   final DateTime? updatedAt;
-  const GroupEntry({
-    required this.id,
-    required this.uuid,
-    required this.name,
-    this.description,
-    this.iconUrl,
-    required this.createdByUserId,
-    required this.defaultCurrency,
-    required this.simplifyDebts,
-    required this.isActive,
-    this.inviteCode,
-    required this.syncStatus,
-    required this.createdAt,
-    this.updatedAt,
-  });
+  const GroupEntry(
+      {required this.id,
+      required this.uuid,
+      required this.name,
+      this.description,
+      this.iconUrl,
+      required this.createdByUserId,
+      required this.defaultCurrency,
+      required this.simplifyDebts,
+      required this.isActive,
+      this.inviteCode,
+      required this.syncStatus,
+      required this.createdAt,
+      this.updatedAt});
   @override
   Map<String, Expression> toColumns(bool nullToAbsent) {
     final map = <String, Expression>{};
@@ -3080,10 +2567,8 @@ class GroupEntry extends DataClass implements Insertable<GroupEntry> {
     );
   }
 
-  factory GroupEntry.fromJson(
-    Map<String, dynamic> json, {
-    ValueSerializer? serializer,
-  }) {
+  factory GroupEntry.fromJson(Map<String, dynamic> json,
+      {ValueSerializer? serializer}) {
     serializer ??= driftRuntimeOptions.defaultSerializer;
     return GroupEntry(
       id: serializer.fromJson<int>(json['id']),
@@ -3121,43 +2606,42 @@ class GroupEntry extends DataClass implements Insertable<GroupEntry> {
     };
   }
 
-  GroupEntry copyWith({
-    int? id,
-    String? uuid,
-    String? name,
-    Value<String?> description = const Value.absent(),
-    Value<String?> iconUrl = const Value.absent(),
-    String? createdByUserId,
-    String? defaultCurrency,
-    bool? simplifyDebts,
-    bool? isActive,
-    Value<String?> inviteCode = const Value.absent(),
-    String? syncStatus,
-    DateTime? createdAt,
-    Value<DateTime?> updatedAt = const Value.absent(),
-  }) => GroupEntry(
-    id: id ?? this.id,
-    uuid: uuid ?? this.uuid,
-    name: name ?? this.name,
-    description: description.present ? description.value : this.description,
-    iconUrl: iconUrl.present ? iconUrl.value : this.iconUrl,
-    createdByUserId: createdByUserId ?? this.createdByUserId,
-    defaultCurrency: defaultCurrency ?? this.defaultCurrency,
-    simplifyDebts: simplifyDebts ?? this.simplifyDebts,
-    isActive: isActive ?? this.isActive,
-    inviteCode: inviteCode.present ? inviteCode.value : this.inviteCode,
-    syncStatus: syncStatus ?? this.syncStatus,
-    createdAt: createdAt ?? this.createdAt,
-    updatedAt: updatedAt.present ? updatedAt.value : this.updatedAt,
-  );
+  GroupEntry copyWith(
+          {int? id,
+          String? uuid,
+          String? name,
+          Value<String?> description = const Value.absent(),
+          Value<String?> iconUrl = const Value.absent(),
+          String? createdByUserId,
+          String? defaultCurrency,
+          bool? simplifyDebts,
+          bool? isActive,
+          Value<String?> inviteCode = const Value.absent(),
+          String? syncStatus,
+          DateTime? createdAt,
+          Value<DateTime?> updatedAt = const Value.absent()}) =>
+      GroupEntry(
+        id: id ?? this.id,
+        uuid: uuid ?? this.uuid,
+        name: name ?? this.name,
+        description: description.present ? description.value : this.description,
+        iconUrl: iconUrl.present ? iconUrl.value : this.iconUrl,
+        createdByUserId: createdByUserId ?? this.createdByUserId,
+        defaultCurrency: defaultCurrency ?? this.defaultCurrency,
+        simplifyDebts: simplifyDebts ?? this.simplifyDebts,
+        isActive: isActive ?? this.isActive,
+        inviteCode: inviteCode.present ? inviteCode.value : this.inviteCode,
+        syncStatus: syncStatus ?? this.syncStatus,
+        createdAt: createdAt ?? this.createdAt,
+        updatedAt: updatedAt.present ? updatedAt.value : this.updatedAt,
+      );
   GroupEntry copyWithCompanion(GroupEntriesCompanion data) {
     return GroupEntry(
       id: data.id.present ? data.id.value : this.id,
       uuid: data.uuid.present ? data.uuid.value : this.uuid,
       name: data.name.present ? data.name.value : this.name,
-      description: data.description.present
-          ? data.description.value
-          : this.description,
+      description:
+          data.description.present ? data.description.value : this.description,
       iconUrl: data.iconUrl.present ? data.iconUrl.value : this.iconUrl,
       createdByUserId: data.createdByUserId.present
           ? data.createdByUserId.value
@@ -3169,12 +2653,10 @@ class GroupEntry extends DataClass implements Insertable<GroupEntry> {
           ? data.simplifyDebts.value
           : this.simplifyDebts,
       isActive: data.isActive.present ? data.isActive.value : this.isActive,
-      inviteCode: data.inviteCode.present
-          ? data.inviteCode.value
-          : this.inviteCode,
-      syncStatus: data.syncStatus.present
-          ? data.syncStatus.value
-          : this.syncStatus,
+      inviteCode:
+          data.inviteCode.present ? data.inviteCode.value : this.inviteCode,
+      syncStatus:
+          data.syncStatus.present ? data.syncStatus.value : this.syncStatus,
       createdAt: data.createdAt.present ? data.createdAt.value : this.createdAt,
       updatedAt: data.updatedAt.present ? data.updatedAt.value : this.updatedAt,
     );
@@ -3202,20 +2684,19 @@ class GroupEntry extends DataClass implements Insertable<GroupEntry> {
 
   @override
   int get hashCode => Object.hash(
-    id,
-    uuid,
-    name,
-    description,
-    iconUrl,
-    createdByUserId,
-    defaultCurrency,
-    simplifyDebts,
-    isActive,
-    inviteCode,
-    syncStatus,
-    createdAt,
-    updatedAt,
-  );
+      id,
+      uuid,
+      name,
+      description,
+      iconUrl,
+      createdByUserId,
+      defaultCurrency,
+      simplifyDebts,
+      isActive,
+      inviteCode,
+      syncStatus,
+      createdAt,
+      updatedAt);
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
@@ -3278,9 +2759,9 @@ class GroupEntriesCompanion extends UpdateCompanion<GroupEntry> {
     this.syncStatus = const Value.absent(),
     this.createdAt = const Value.absent(),
     this.updatedAt = const Value.absent(),
-  }) : uuid = Value(uuid),
-       name = Value(name),
-       createdByUserId = Value(createdByUserId);
+  })  : uuid = Value(uuid),
+        name = Value(name),
+        createdByUserId = Value(createdByUserId);
   static Insertable<GroupEntry> custom({
     Expression<int>? id,
     Expression<String>? uuid,
@@ -3313,21 +2794,20 @@ class GroupEntriesCompanion extends UpdateCompanion<GroupEntry> {
     });
   }
 
-  GroupEntriesCompanion copyWith({
-    Value<int>? id,
-    Value<String>? uuid,
-    Value<String>? name,
-    Value<String?>? description,
-    Value<String?>? iconUrl,
-    Value<String>? createdByUserId,
-    Value<String>? defaultCurrency,
-    Value<bool>? simplifyDebts,
-    Value<bool>? isActive,
-    Value<String?>? inviteCode,
-    Value<String>? syncStatus,
-    Value<DateTime>? createdAt,
-    Value<DateTime?>? updatedAt,
-  }) {
+  GroupEntriesCompanion copyWith(
+      {Value<int>? id,
+      Value<String>? uuid,
+      Value<String>? name,
+      Value<String?>? description,
+      Value<String?>? iconUrl,
+      Value<String>? createdByUserId,
+      Value<String>? defaultCurrency,
+      Value<bool>? simplifyDebts,
+      Value<bool>? isActive,
+      Value<String?>? inviteCode,
+      Value<String>? syncStatus,
+      Value<DateTime>? createdAt,
+      Value<DateTime?>? updatedAt}) {
     return GroupEntriesCompanion(
       id: id ?? this.id,
       uuid: uuid ?? this.uuid,
@@ -3420,174 +2900,118 @@ class $GroupMemberEntriesTable extends GroupMemberEntries
   static const VerificationMeta _idMeta = const VerificationMeta('id');
   @override
   late final GeneratedColumn<int> id = GeneratedColumn<int>(
-    'id',
-    aliasedName,
-    false,
-    hasAutoIncrement: true,
-    type: DriftSqlType.int,
-    requiredDuringInsert: false,
-    defaultConstraints: GeneratedColumn.constraintIsAlways(
-      'PRIMARY KEY AUTOINCREMENT',
-    ),
-  );
+      'id', aliasedName, false,
+      hasAutoIncrement: true,
+      type: DriftSqlType.int,
+      requiredDuringInsert: false,
+      defaultConstraints:
+          GeneratedColumn.constraintIsAlways('PRIMARY KEY AUTOINCREMENT'));
   static const VerificationMeta _uuidMeta = const VerificationMeta('uuid');
   @override
   late final GeneratedColumn<String> uuid = GeneratedColumn<String>(
-    'uuid',
-    aliasedName,
-    false,
-    type: DriftSqlType.string,
-    requiredDuringInsert: true,
-    defaultConstraints: GeneratedColumn.constraintIsAlways('UNIQUE'),
-  );
-  static const VerificationMeta _groupIdMeta = const VerificationMeta(
-    'groupId',
-  );
+      'uuid', aliasedName, false,
+      type: DriftSqlType.string,
+      requiredDuringInsert: true,
+      defaultConstraints: GeneratedColumn.constraintIsAlways('UNIQUE'));
+  static const VerificationMeta _groupIdMeta =
+      const VerificationMeta('groupId');
   @override
   late final GeneratedColumn<String> groupId = GeneratedColumn<String>(
-    'group_id',
-    aliasedName,
-    false,
-    type: DriftSqlType.string,
-    requiredDuringInsert: true,
-  );
+      'group_id', aliasedName, false,
+      type: DriftSqlType.string, requiredDuringInsert: true);
   static const VerificationMeta _userIdMeta = const VerificationMeta('userId');
   @override
   late final GeneratedColumn<String> userId = GeneratedColumn<String>(
-    'user_id',
-    aliasedName,
-    false,
-    type: DriftSqlType.string,
-    requiredDuringInsert: true,
-  );
-  static const VerificationMeta _displayNameMeta = const VerificationMeta(
-    'displayName',
-  );
+      'user_id', aliasedName, false,
+      type: DriftSqlType.string, requiredDuringInsert: true);
+  static const VerificationMeta _displayNameMeta =
+      const VerificationMeta('displayName');
   @override
   late final GeneratedColumn<String> displayName = GeneratedColumn<String>(
-    'display_name',
-    aliasedName,
-    false,
-    type: DriftSqlType.string,
-    requiredDuringInsert: true,
-  );
+      'display_name', aliasedName, false,
+      type: DriftSqlType.string, requiredDuringInsert: true);
   static const VerificationMeta _emailMeta = const VerificationMeta('email');
   @override
   late final GeneratedColumn<String> email = GeneratedColumn<String>(
-    'email',
-    aliasedName,
-    true,
-    type: DriftSqlType.string,
-    requiredDuringInsert: false,
-  );
-  static const VerificationMeta _avatarUrlMeta = const VerificationMeta(
-    'avatarUrl',
-  );
+      'email', aliasedName, true,
+      type: DriftSqlType.string, requiredDuringInsert: false);
+  static const VerificationMeta _avatarUrlMeta =
+      const VerificationMeta('avatarUrl');
   @override
   late final GeneratedColumn<String> avatarUrl = GeneratedColumn<String>(
-    'avatar_url',
-    aliasedName,
-    true,
-    type: DriftSqlType.string,
-    requiredDuringInsert: false,
-  );
+      'avatar_url', aliasedName, true,
+      type: DriftSqlType.string, requiredDuringInsert: false);
   static const VerificationMeta _roleMeta = const VerificationMeta('role');
   @override
   late final GeneratedColumn<String> role = GeneratedColumn<String>(
-    'role',
-    aliasedName,
-    false,
-    type: DriftSqlType.string,
-    requiredDuringInsert: false,
-    defaultValue: const Constant('member'),
-  );
+      'role', aliasedName, false,
+      type: DriftSqlType.string,
+      requiredDuringInsert: false,
+      defaultValue: const Constant('member'));
   static const VerificationMeta _defaultSharePercentMeta =
       const VerificationMeta('defaultSharePercent');
   @override
   late final GeneratedColumn<int> defaultSharePercent = GeneratedColumn<int>(
-    'default_share_percent',
-    aliasedName,
-    false,
-    type: DriftSqlType.int,
-    requiredDuringInsert: false,
-    defaultValue: const Constant(100),
-  );
-  static const VerificationMeta _isActiveMeta = const VerificationMeta(
-    'isActive',
-  );
+      'default_share_percent', aliasedName, false,
+      type: DriftSqlType.int,
+      requiredDuringInsert: false,
+      defaultValue: const Constant(100));
+  static const VerificationMeta _isActiveMeta =
+      const VerificationMeta('isActive');
   @override
   late final GeneratedColumn<bool> isActive = GeneratedColumn<bool>(
-    'is_active',
-    aliasedName,
-    false,
-    type: DriftSqlType.bool,
-    requiredDuringInsert: false,
-    defaultConstraints: GeneratedColumn.constraintIsAlways(
-      'CHECK ("is_active" IN (0, 1))',
-    ),
-    defaultValue: const Constant(true),
-  );
-  static const VerificationMeta _syncStatusMeta = const VerificationMeta(
-    'syncStatus',
-  );
+      'is_active', aliasedName, false,
+      type: DriftSqlType.bool,
+      requiredDuringInsert: false,
+      defaultConstraints:
+          GeneratedColumn.constraintIsAlways('CHECK ("is_active" IN (0, 1))'),
+      defaultValue: const Constant(true));
+  static const VerificationMeta _syncStatusMeta =
+      const VerificationMeta('syncStatus');
   @override
   late final GeneratedColumn<String> syncStatus = GeneratedColumn<String>(
-    'sync_status',
-    aliasedName,
-    false,
-    type: DriftSqlType.string,
-    requiredDuringInsert: false,
-    defaultValue: const Constant('pending'),
-  );
-  static const VerificationMeta _joinedAtMeta = const VerificationMeta(
-    'joinedAt',
-  );
+      'sync_status', aliasedName, false,
+      type: DriftSqlType.string,
+      requiredDuringInsert: false,
+      defaultValue: const Constant('pending'));
+  static const VerificationMeta _joinedAtMeta =
+      const VerificationMeta('joinedAt');
   @override
   late final GeneratedColumn<DateTime> joinedAt = GeneratedColumn<DateTime>(
-    'joined_at',
-    aliasedName,
-    false,
-    type: DriftSqlType.dateTime,
-    requiredDuringInsert: false,
-    defaultValue: currentDateAndTime,
-  );
-  static const VerificationMeta _updatedAtMeta = const VerificationMeta(
-    'updatedAt',
-  );
+      'joined_at', aliasedName, false,
+      type: DriftSqlType.dateTime,
+      requiredDuringInsert: false,
+      defaultValue: currentDateAndTime);
+  static const VerificationMeta _updatedAtMeta =
+      const VerificationMeta('updatedAt');
   @override
   late final GeneratedColumn<DateTime> updatedAt = GeneratedColumn<DateTime>(
-    'updated_at',
-    aliasedName,
-    true,
-    type: DriftSqlType.dateTime,
-    requiredDuringInsert: false,
-  );
+      'updated_at', aliasedName, true,
+      type: DriftSqlType.dateTime, requiredDuringInsert: false);
   @override
   List<GeneratedColumn> get $columns => [
-    id,
-    uuid,
-    groupId,
-    userId,
-    displayName,
-    email,
-    avatarUrl,
-    role,
-    defaultSharePercent,
-    isActive,
-    syncStatus,
-    joinedAt,
-    updatedAt,
-  ];
+        id,
+        uuid,
+        groupId,
+        userId,
+        displayName,
+        email,
+        avatarUrl,
+        role,
+        defaultSharePercent,
+        isActive,
+        syncStatus,
+        joinedAt,
+        updatedAt
+      ];
   @override
   String get aliasedName => _alias ?? actualTableName;
   @override
   String get actualTableName => $name;
   static const String $name = 'group_member_entries';
   @override
-  VerificationContext validateIntegrity(
-    Insertable<GroupMemberEntry> instance, {
-    bool isInserting = false,
-  }) {
+  VerificationContext validateIntegrity(Insertable<GroupMemberEntry> instance,
+      {bool isInserting = false}) {
     final context = VerificationContext();
     final data = instance.toColumns(true);
     if (data.containsKey('id')) {
@@ -3595,89 +3019,65 @@ class $GroupMemberEntriesTable extends GroupMemberEntries
     }
     if (data.containsKey('uuid')) {
       context.handle(
-        _uuidMeta,
-        uuid.isAcceptableOrUnknown(data['uuid']!, _uuidMeta),
-      );
+          _uuidMeta, uuid.isAcceptableOrUnknown(data['uuid']!, _uuidMeta));
     } else if (isInserting) {
       context.missing(_uuidMeta);
     }
     if (data.containsKey('group_id')) {
-      context.handle(
-        _groupIdMeta,
-        groupId.isAcceptableOrUnknown(data['group_id']!, _groupIdMeta),
-      );
+      context.handle(_groupIdMeta,
+          groupId.isAcceptableOrUnknown(data['group_id']!, _groupIdMeta));
     } else if (isInserting) {
       context.missing(_groupIdMeta);
     }
     if (data.containsKey('user_id')) {
-      context.handle(
-        _userIdMeta,
-        userId.isAcceptableOrUnknown(data['user_id']!, _userIdMeta),
-      );
+      context.handle(_userIdMeta,
+          userId.isAcceptableOrUnknown(data['user_id']!, _userIdMeta));
     } else if (isInserting) {
       context.missing(_userIdMeta);
     }
     if (data.containsKey('display_name')) {
       context.handle(
-        _displayNameMeta,
-        displayName.isAcceptableOrUnknown(
-          data['display_name']!,
           _displayNameMeta,
-        ),
-      );
+          displayName.isAcceptableOrUnknown(
+              data['display_name']!, _displayNameMeta));
     } else if (isInserting) {
       context.missing(_displayNameMeta);
     }
     if (data.containsKey('email')) {
       context.handle(
-        _emailMeta,
-        email.isAcceptableOrUnknown(data['email']!, _emailMeta),
-      );
+          _emailMeta, email.isAcceptableOrUnknown(data['email']!, _emailMeta));
     }
     if (data.containsKey('avatar_url')) {
-      context.handle(
-        _avatarUrlMeta,
-        avatarUrl.isAcceptableOrUnknown(data['avatar_url']!, _avatarUrlMeta),
-      );
+      context.handle(_avatarUrlMeta,
+          avatarUrl.isAcceptableOrUnknown(data['avatar_url']!, _avatarUrlMeta));
     }
     if (data.containsKey('role')) {
       context.handle(
-        _roleMeta,
-        role.isAcceptableOrUnknown(data['role']!, _roleMeta),
-      );
+          _roleMeta, role.isAcceptableOrUnknown(data['role']!, _roleMeta));
     }
     if (data.containsKey('default_share_percent')) {
       context.handle(
-        _defaultSharePercentMeta,
-        defaultSharePercent.isAcceptableOrUnknown(
-          data['default_share_percent']!,
           _defaultSharePercentMeta,
-        ),
-      );
+          defaultSharePercent.isAcceptableOrUnknown(
+              data['default_share_percent']!, _defaultSharePercentMeta));
     }
     if (data.containsKey('is_active')) {
-      context.handle(
-        _isActiveMeta,
-        isActive.isAcceptableOrUnknown(data['is_active']!, _isActiveMeta),
-      );
+      context.handle(_isActiveMeta,
+          isActive.isAcceptableOrUnknown(data['is_active']!, _isActiveMeta));
     }
     if (data.containsKey('sync_status')) {
       context.handle(
-        _syncStatusMeta,
-        syncStatus.isAcceptableOrUnknown(data['sync_status']!, _syncStatusMeta),
-      );
+          _syncStatusMeta,
+          syncStatus.isAcceptableOrUnknown(
+              data['sync_status']!, _syncStatusMeta));
     }
     if (data.containsKey('joined_at')) {
-      context.handle(
-        _joinedAtMeta,
-        joinedAt.isAcceptableOrUnknown(data['joined_at']!, _joinedAtMeta),
-      );
+      context.handle(_joinedAtMeta,
+          joinedAt.isAcceptableOrUnknown(data['joined_at']!, _joinedAtMeta));
     }
     if (data.containsKey('updated_at')) {
-      context.handle(
-        _updatedAtMeta,
-        updatedAt.isAcceptableOrUnknown(data['updated_at']!, _updatedAtMeta),
-      );
+      context.handle(_updatedAtMeta,
+          updatedAt.isAcceptableOrUnknown(data['updated_at']!, _updatedAtMeta));
     }
     return context;
   }
@@ -3688,58 +3088,32 @@ class $GroupMemberEntriesTable extends GroupMemberEntries
   GroupMemberEntry map(Map<String, dynamic> data, {String? tablePrefix}) {
     final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
     return GroupMemberEntry(
-      id: attachedDatabase.typeMapping.read(
-        DriftSqlType.int,
-        data['${effectivePrefix}id'],
-      )!,
-      uuid: attachedDatabase.typeMapping.read(
-        DriftSqlType.string,
-        data['${effectivePrefix}uuid'],
-      )!,
-      groupId: attachedDatabase.typeMapping.read(
-        DriftSqlType.string,
-        data['${effectivePrefix}group_id'],
-      )!,
-      userId: attachedDatabase.typeMapping.read(
-        DriftSqlType.string,
-        data['${effectivePrefix}user_id'],
-      )!,
-      displayName: attachedDatabase.typeMapping.read(
-        DriftSqlType.string,
-        data['${effectivePrefix}display_name'],
-      )!,
-      email: attachedDatabase.typeMapping.read(
-        DriftSqlType.string,
-        data['${effectivePrefix}email'],
-      ),
-      avatarUrl: attachedDatabase.typeMapping.read(
-        DriftSqlType.string,
-        data['${effectivePrefix}avatar_url'],
-      ),
-      role: attachedDatabase.typeMapping.read(
-        DriftSqlType.string,
-        data['${effectivePrefix}role'],
-      )!,
+      id: attachedDatabase.typeMapping
+          .read(DriftSqlType.int, data['${effectivePrefix}id'])!,
+      uuid: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}uuid'])!,
+      groupId: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}group_id'])!,
+      userId: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}user_id'])!,
+      displayName: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}display_name'])!,
+      email: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}email']),
+      avatarUrl: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}avatar_url']),
+      role: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}role'])!,
       defaultSharePercent: attachedDatabase.typeMapping.read(
-        DriftSqlType.int,
-        data['${effectivePrefix}default_share_percent'],
-      )!,
-      isActive: attachedDatabase.typeMapping.read(
-        DriftSqlType.bool,
-        data['${effectivePrefix}is_active'],
-      )!,
-      syncStatus: attachedDatabase.typeMapping.read(
-        DriftSqlType.string,
-        data['${effectivePrefix}sync_status'],
-      )!,
-      joinedAt: attachedDatabase.typeMapping.read(
-        DriftSqlType.dateTime,
-        data['${effectivePrefix}joined_at'],
-      )!,
-      updatedAt: attachedDatabase.typeMapping.read(
-        DriftSqlType.dateTime,
-        data['${effectivePrefix}updated_at'],
-      ),
+          DriftSqlType.int, data['${effectivePrefix}default_share_percent'])!,
+      isActive: attachedDatabase.typeMapping
+          .read(DriftSqlType.bool, data['${effectivePrefix}is_active'])!,
+      syncStatus: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}sync_status'])!,
+      joinedAt: attachedDatabase.typeMapping
+          .read(DriftSqlType.dateTime, data['${effectivePrefix}joined_at'])!,
+      updatedAt: attachedDatabase.typeMapping
+          .read(DriftSqlType.dateTime, data['${effectivePrefix}updated_at']),
     );
   }
 
@@ -3764,21 +3138,20 @@ class GroupMemberEntry extends DataClass
   final String syncStatus;
   final DateTime joinedAt;
   final DateTime? updatedAt;
-  const GroupMemberEntry({
-    required this.id,
-    required this.uuid,
-    required this.groupId,
-    required this.userId,
-    required this.displayName,
-    this.email,
-    this.avatarUrl,
-    required this.role,
-    required this.defaultSharePercent,
-    required this.isActive,
-    required this.syncStatus,
-    required this.joinedAt,
-    this.updatedAt,
-  });
+  const GroupMemberEntry(
+      {required this.id,
+      required this.uuid,
+      required this.groupId,
+      required this.userId,
+      required this.displayName,
+      this.email,
+      this.avatarUrl,
+      required this.role,
+      required this.defaultSharePercent,
+      required this.isActive,
+      required this.syncStatus,
+      required this.joinedAt,
+      this.updatedAt});
   @override
   Map<String, Expression> toColumns(bool nullToAbsent) {
     final map = <String, Expression>{};
@@ -3811,9 +3184,8 @@ class GroupMemberEntry extends DataClass
       groupId: Value(groupId),
       userId: Value(userId),
       displayName: Value(displayName),
-      email: email == null && nullToAbsent
-          ? const Value.absent()
-          : Value(email),
+      email:
+          email == null && nullToAbsent ? const Value.absent() : Value(email),
       avatarUrl: avatarUrl == null && nullToAbsent
           ? const Value.absent()
           : Value(avatarUrl),
@@ -3828,10 +3200,8 @@ class GroupMemberEntry extends DataClass
     );
   }
 
-  factory GroupMemberEntry.fromJson(
-    Map<String, dynamic> json, {
-    ValueSerializer? serializer,
-  }) {
+  factory GroupMemberEntry.fromJson(Map<String, dynamic> json,
+      {ValueSerializer? serializer}) {
     serializer ??= driftRuntimeOptions.defaultSerializer;
     return GroupMemberEntry(
       id: serializer.fromJson<int>(json['id']),
@@ -3842,9 +3212,8 @@ class GroupMemberEntry extends DataClass
       email: serializer.fromJson<String?>(json['email']),
       avatarUrl: serializer.fromJson<String?>(json['avatarUrl']),
       role: serializer.fromJson<String>(json['role']),
-      defaultSharePercent: serializer.fromJson<int>(
-        json['defaultSharePercent'],
-      ),
+      defaultSharePercent:
+          serializer.fromJson<int>(json['defaultSharePercent']),
       isActive: serializer.fromJson<bool>(json['isActive']),
       syncStatus: serializer.fromJson<String>(json['syncStatus']),
       joinedAt: serializer.fromJson<DateTime>(json['joinedAt']),
@@ -3871,44 +3240,43 @@ class GroupMemberEntry extends DataClass
     };
   }
 
-  GroupMemberEntry copyWith({
-    int? id,
-    String? uuid,
-    String? groupId,
-    String? userId,
-    String? displayName,
-    Value<String?> email = const Value.absent(),
-    Value<String?> avatarUrl = const Value.absent(),
-    String? role,
-    int? defaultSharePercent,
-    bool? isActive,
-    String? syncStatus,
-    DateTime? joinedAt,
-    Value<DateTime?> updatedAt = const Value.absent(),
-  }) => GroupMemberEntry(
-    id: id ?? this.id,
-    uuid: uuid ?? this.uuid,
-    groupId: groupId ?? this.groupId,
-    userId: userId ?? this.userId,
-    displayName: displayName ?? this.displayName,
-    email: email.present ? email.value : this.email,
-    avatarUrl: avatarUrl.present ? avatarUrl.value : this.avatarUrl,
-    role: role ?? this.role,
-    defaultSharePercent: defaultSharePercent ?? this.defaultSharePercent,
-    isActive: isActive ?? this.isActive,
-    syncStatus: syncStatus ?? this.syncStatus,
-    joinedAt: joinedAt ?? this.joinedAt,
-    updatedAt: updatedAt.present ? updatedAt.value : this.updatedAt,
-  );
+  GroupMemberEntry copyWith(
+          {int? id,
+          String? uuid,
+          String? groupId,
+          String? userId,
+          String? displayName,
+          Value<String?> email = const Value.absent(),
+          Value<String?> avatarUrl = const Value.absent(),
+          String? role,
+          int? defaultSharePercent,
+          bool? isActive,
+          String? syncStatus,
+          DateTime? joinedAt,
+          Value<DateTime?> updatedAt = const Value.absent()}) =>
+      GroupMemberEntry(
+        id: id ?? this.id,
+        uuid: uuid ?? this.uuid,
+        groupId: groupId ?? this.groupId,
+        userId: userId ?? this.userId,
+        displayName: displayName ?? this.displayName,
+        email: email.present ? email.value : this.email,
+        avatarUrl: avatarUrl.present ? avatarUrl.value : this.avatarUrl,
+        role: role ?? this.role,
+        defaultSharePercent: defaultSharePercent ?? this.defaultSharePercent,
+        isActive: isActive ?? this.isActive,
+        syncStatus: syncStatus ?? this.syncStatus,
+        joinedAt: joinedAt ?? this.joinedAt,
+        updatedAt: updatedAt.present ? updatedAt.value : this.updatedAt,
+      );
   GroupMemberEntry copyWithCompanion(GroupMemberEntriesCompanion data) {
     return GroupMemberEntry(
       id: data.id.present ? data.id.value : this.id,
       uuid: data.uuid.present ? data.uuid.value : this.uuid,
       groupId: data.groupId.present ? data.groupId.value : this.groupId,
       userId: data.userId.present ? data.userId.value : this.userId,
-      displayName: data.displayName.present
-          ? data.displayName.value
-          : this.displayName,
+      displayName:
+          data.displayName.present ? data.displayName.value : this.displayName,
       email: data.email.present ? data.email.value : this.email,
       avatarUrl: data.avatarUrl.present ? data.avatarUrl.value : this.avatarUrl,
       role: data.role.present ? data.role.value : this.role,
@@ -3916,9 +3284,8 @@ class GroupMemberEntry extends DataClass
           ? data.defaultSharePercent.value
           : this.defaultSharePercent,
       isActive: data.isActive.present ? data.isActive.value : this.isActive,
-      syncStatus: data.syncStatus.present
-          ? data.syncStatus.value
-          : this.syncStatus,
+      syncStatus:
+          data.syncStatus.present ? data.syncStatus.value : this.syncStatus,
       joinedAt: data.joinedAt.present ? data.joinedAt.value : this.joinedAt,
       updatedAt: data.updatedAt.present ? data.updatedAt.value : this.updatedAt,
     );
@@ -3946,20 +3313,19 @@ class GroupMemberEntry extends DataClass
 
   @override
   int get hashCode => Object.hash(
-    id,
-    uuid,
-    groupId,
-    userId,
-    displayName,
-    email,
-    avatarUrl,
-    role,
-    defaultSharePercent,
-    isActive,
-    syncStatus,
-    joinedAt,
-    updatedAt,
-  );
+      id,
+      uuid,
+      groupId,
+      userId,
+      displayName,
+      email,
+      avatarUrl,
+      role,
+      defaultSharePercent,
+      isActive,
+      syncStatus,
+      joinedAt,
+      updatedAt);
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
@@ -4022,10 +3388,10 @@ class GroupMemberEntriesCompanion extends UpdateCompanion<GroupMemberEntry> {
     this.syncStatus = const Value.absent(),
     this.joinedAt = const Value.absent(),
     this.updatedAt = const Value.absent(),
-  }) : uuid = Value(uuid),
-       groupId = Value(groupId),
-       userId = Value(userId),
-       displayName = Value(displayName);
+  })  : uuid = Value(uuid),
+        groupId = Value(groupId),
+        userId = Value(userId),
+        displayName = Value(displayName);
   static Insertable<GroupMemberEntry> custom({
     Expression<int>? id,
     Expression<String>? uuid,
@@ -4059,21 +3425,20 @@ class GroupMemberEntriesCompanion extends UpdateCompanion<GroupMemberEntry> {
     });
   }
 
-  GroupMemberEntriesCompanion copyWith({
-    Value<int>? id,
-    Value<String>? uuid,
-    Value<String>? groupId,
-    Value<String>? userId,
-    Value<String>? displayName,
-    Value<String?>? email,
-    Value<String?>? avatarUrl,
-    Value<String>? role,
-    Value<int>? defaultSharePercent,
-    Value<bool>? isActive,
-    Value<String>? syncStatus,
-    Value<DateTime>? joinedAt,
-    Value<DateTime?>? updatedAt,
-  }) {
+  GroupMemberEntriesCompanion copyWith(
+      {Value<int>? id,
+      Value<String>? uuid,
+      Value<String>? groupId,
+      Value<String>? userId,
+      Value<String>? displayName,
+      Value<String?>? email,
+      Value<String?>? avatarUrl,
+      Value<String>? role,
+      Value<int>? defaultSharePercent,
+      Value<bool>? isActive,
+      Value<String>? syncStatus,
+      Value<DateTime>? joinedAt,
+      Value<DateTime?>? updatedAt}) {
     return GroupMemberEntriesCompanion(
       id: id ?? this.id,
       uuid: uuid ?? this.uuid,
@@ -4166,215 +3531,141 @@ class $SharedExpenseEntriesTable extends SharedExpenseEntries
   static const VerificationMeta _idMeta = const VerificationMeta('id');
   @override
   late final GeneratedColumn<int> id = GeneratedColumn<int>(
-    'id',
-    aliasedName,
-    false,
-    hasAutoIncrement: true,
-    type: DriftSqlType.int,
-    requiredDuringInsert: false,
-    defaultConstraints: GeneratedColumn.constraintIsAlways(
-      'PRIMARY KEY AUTOINCREMENT',
-    ),
-  );
+      'id', aliasedName, false,
+      hasAutoIncrement: true,
+      type: DriftSqlType.int,
+      requiredDuringInsert: false,
+      defaultConstraints:
+          GeneratedColumn.constraintIsAlways('PRIMARY KEY AUTOINCREMENT'));
   static const VerificationMeta _uuidMeta = const VerificationMeta('uuid');
   @override
   late final GeneratedColumn<String> uuid = GeneratedColumn<String>(
-    'uuid',
-    aliasedName,
-    false,
-    type: DriftSqlType.string,
-    requiredDuringInsert: true,
-    defaultConstraints: GeneratedColumn.constraintIsAlways('UNIQUE'),
-  );
-  static const VerificationMeta _groupIdMeta = const VerificationMeta(
-    'groupId',
-  );
+      'uuid', aliasedName, false,
+      type: DriftSqlType.string,
+      requiredDuringInsert: true,
+      defaultConstraints: GeneratedColumn.constraintIsAlways('UNIQUE'));
+  static const VerificationMeta _groupIdMeta =
+      const VerificationMeta('groupId');
   @override
   late final GeneratedColumn<String> groupId = GeneratedColumn<String>(
-    'group_id',
-    aliasedName,
-    false,
-    type: DriftSqlType.string,
-    requiredDuringInsert: true,
-  );
-  static const VerificationMeta _descriptionMeta = const VerificationMeta(
-    'description',
-  );
+      'group_id', aliasedName, false,
+      type: DriftSqlType.string, requiredDuringInsert: true);
+  static const VerificationMeta _descriptionMeta =
+      const VerificationMeta('description');
   @override
   late final GeneratedColumn<String> description = GeneratedColumn<String>(
-    'description',
-    aliasedName,
-    false,
-    type: DriftSqlType.string,
-    requiredDuringInsert: true,
-  );
-  static const VerificationMeta _totalAmountCentsMeta = const VerificationMeta(
-    'totalAmountCents',
-  );
+      'description', aliasedName, false,
+      type: DriftSqlType.string, requiredDuringInsert: true);
+  static const VerificationMeta _totalAmountCentsMeta =
+      const VerificationMeta('totalAmountCents');
   @override
   late final GeneratedColumn<int> totalAmountCents = GeneratedColumn<int>(
-    'total_amount_cents',
-    aliasedName,
-    false,
-    type: DriftSqlType.int,
-    requiredDuringInsert: true,
-  );
-  static const VerificationMeta _currencyCodeMeta = const VerificationMeta(
-    'currencyCode',
-  );
+      'total_amount_cents', aliasedName, false,
+      type: DriftSqlType.int, requiredDuringInsert: true);
+  static const VerificationMeta _currencyCodeMeta =
+      const VerificationMeta('currencyCode');
   @override
   late final GeneratedColumn<String> currencyCode = GeneratedColumn<String>(
-    'currency_code',
-    aliasedName,
-    false,
-    type: DriftSqlType.string,
-    requiredDuringInsert: false,
-    defaultValue: const Constant('INR'),
-  );
-  static const VerificationMeta _paidByUserIdMeta = const VerificationMeta(
-    'paidByUserId',
-  );
+      'currency_code', aliasedName, false,
+      type: DriftSqlType.string,
+      requiredDuringInsert: false,
+      defaultValue: const Constant('INR'));
+  static const VerificationMeta _paidByUserIdMeta =
+      const VerificationMeta('paidByUserId');
   @override
   late final GeneratedColumn<String> paidByUserId = GeneratedColumn<String>(
-    'paid_by_user_id',
-    aliasedName,
-    false,
-    type: DriftSqlType.string,
-    requiredDuringInsert: true,
-  );
-  static const VerificationMeta _categoryIdMeta = const VerificationMeta(
-    'categoryId',
-  );
+      'paid_by_user_id', aliasedName, false,
+      type: DriftSqlType.string, requiredDuringInsert: true);
+  static const VerificationMeta _categoryIdMeta =
+      const VerificationMeta('categoryId');
   @override
   late final GeneratedColumn<String> categoryId = GeneratedColumn<String>(
-    'category_id',
-    aliasedName,
-    true,
-    type: DriftSqlType.string,
-    requiredDuringInsert: false,
-  );
-  static const VerificationMeta _splitTypeMeta = const VerificationMeta(
-    'splitType',
-  );
+      'category_id', aliasedName, true,
+      type: DriftSqlType.string, requiredDuringInsert: false);
+  static const VerificationMeta _splitTypeMeta =
+      const VerificationMeta('splitType');
   @override
   late final GeneratedColumn<String> splitType = GeneratedColumn<String>(
-    'split_type',
-    aliasedName,
-    false,
-    type: DriftSqlType.string,
-    requiredDuringInsert: false,
-    defaultValue: const Constant('equal'),
-  );
+      'split_type', aliasedName, false,
+      type: DriftSqlType.string,
+      requiredDuringInsert: false,
+      defaultValue: const Constant('equal'));
   static const VerificationMeta _notesMeta = const VerificationMeta('notes');
   @override
   late final GeneratedColumn<String> notes = GeneratedColumn<String>(
-    'notes',
-    aliasedName,
-    true,
-    type: DriftSqlType.string,
-    requiredDuringInsert: false,
-  );
-  static const VerificationMeta _receiptUrlMeta = const VerificationMeta(
-    'receiptUrl',
-  );
+      'notes', aliasedName, true,
+      type: DriftSqlType.string, requiredDuringInsert: false);
+  static const VerificationMeta _receiptUrlMeta =
+      const VerificationMeta('receiptUrl');
   @override
   late final GeneratedColumn<String> receiptUrl = GeneratedColumn<String>(
-    'receipt_url',
-    aliasedName,
-    true,
-    type: DriftSqlType.string,
-    requiredDuringInsert: false,
-  );
-  static const VerificationMeta _isDeletedMeta = const VerificationMeta(
-    'isDeleted',
-  );
+      'receipt_url', aliasedName, true,
+      type: DriftSqlType.string, requiredDuringInsert: false);
+  static const VerificationMeta _isDeletedMeta =
+      const VerificationMeta('isDeleted');
   @override
   late final GeneratedColumn<bool> isDeleted = GeneratedColumn<bool>(
-    'is_deleted',
-    aliasedName,
-    false,
-    type: DriftSqlType.bool,
-    requiredDuringInsert: false,
-    defaultConstraints: GeneratedColumn.constraintIsAlways(
-      'CHECK ("is_deleted" IN (0, 1))',
-    ),
-    defaultValue: const Constant(false),
-  );
-  static const VerificationMeta _syncStatusMeta = const VerificationMeta(
-    'syncStatus',
-  );
+      'is_deleted', aliasedName, false,
+      type: DriftSqlType.bool,
+      requiredDuringInsert: false,
+      defaultConstraints:
+          GeneratedColumn.constraintIsAlways('CHECK ("is_deleted" IN (0, 1))'),
+      defaultValue: const Constant(false));
+  static const VerificationMeta _syncStatusMeta =
+      const VerificationMeta('syncStatus');
   @override
   late final GeneratedColumn<String> syncStatus = GeneratedColumn<String>(
-    'sync_status',
-    aliasedName,
-    false,
-    type: DriftSqlType.string,
-    requiredDuringInsert: false,
-    defaultValue: const Constant('pending'),
-  );
-  static const VerificationMeta _expenseDateMeta = const VerificationMeta(
-    'expenseDate',
-  );
+      'sync_status', aliasedName, false,
+      type: DriftSqlType.string,
+      requiredDuringInsert: false,
+      defaultValue: const Constant('pending'));
+  static const VerificationMeta _expenseDateMeta =
+      const VerificationMeta('expenseDate');
   @override
   late final GeneratedColumn<DateTime> expenseDate = GeneratedColumn<DateTime>(
-    'expense_date',
-    aliasedName,
-    false,
-    type: DriftSqlType.dateTime,
-    requiredDuringInsert: true,
-  );
-  static const VerificationMeta _createdAtMeta = const VerificationMeta(
-    'createdAt',
-  );
+      'expense_date', aliasedName, false,
+      type: DriftSqlType.dateTime, requiredDuringInsert: true);
+  static const VerificationMeta _createdAtMeta =
+      const VerificationMeta('createdAt');
   @override
   late final GeneratedColumn<DateTime> createdAt = GeneratedColumn<DateTime>(
-    'created_at',
-    aliasedName,
-    false,
-    type: DriftSqlType.dateTime,
-    requiredDuringInsert: false,
-    defaultValue: currentDateAndTime,
-  );
-  static const VerificationMeta _updatedAtMeta = const VerificationMeta(
-    'updatedAt',
-  );
+      'created_at', aliasedName, false,
+      type: DriftSqlType.dateTime,
+      requiredDuringInsert: false,
+      defaultValue: currentDateAndTime);
+  static const VerificationMeta _updatedAtMeta =
+      const VerificationMeta('updatedAt');
   @override
   late final GeneratedColumn<DateTime> updatedAt = GeneratedColumn<DateTime>(
-    'updated_at',
-    aliasedName,
-    true,
-    type: DriftSqlType.dateTime,
-    requiredDuringInsert: false,
-  );
+      'updated_at', aliasedName, true,
+      type: DriftSqlType.dateTime, requiredDuringInsert: false);
   @override
   List<GeneratedColumn> get $columns => [
-    id,
-    uuid,
-    groupId,
-    description,
-    totalAmountCents,
-    currencyCode,
-    paidByUserId,
-    categoryId,
-    splitType,
-    notes,
-    receiptUrl,
-    isDeleted,
-    syncStatus,
-    expenseDate,
-    createdAt,
-    updatedAt,
-  ];
+        id,
+        uuid,
+        groupId,
+        description,
+        totalAmountCents,
+        currencyCode,
+        paidByUserId,
+        categoryId,
+        splitType,
+        notes,
+        receiptUrl,
+        isDeleted,
+        syncStatus,
+        expenseDate,
+        createdAt,
+        updatedAt
+      ];
   @override
   String get aliasedName => _alias ?? actualTableName;
   @override
   String get actualTableName => $name;
   static const String $name = 'shared_expense_entries';
   @override
-  VerificationContext validateIntegrity(
-    Insertable<SharedExpenseEntry> instance, {
-    bool isInserting = false,
-  }) {
+  VerificationContext validateIntegrity(Insertable<SharedExpenseEntry> instance,
+      {bool isInserting = false}) {
     final context = VerificationContext();
     final data = instance.toColumns(true);
     if (data.containsKey('id')) {
@@ -4382,120 +3673,91 @@ class $SharedExpenseEntriesTable extends SharedExpenseEntries
     }
     if (data.containsKey('uuid')) {
       context.handle(
-        _uuidMeta,
-        uuid.isAcceptableOrUnknown(data['uuid']!, _uuidMeta),
-      );
+          _uuidMeta, uuid.isAcceptableOrUnknown(data['uuid']!, _uuidMeta));
     } else if (isInserting) {
       context.missing(_uuidMeta);
     }
     if (data.containsKey('group_id')) {
-      context.handle(
-        _groupIdMeta,
-        groupId.isAcceptableOrUnknown(data['group_id']!, _groupIdMeta),
-      );
+      context.handle(_groupIdMeta,
+          groupId.isAcceptableOrUnknown(data['group_id']!, _groupIdMeta));
     } else if (isInserting) {
       context.missing(_groupIdMeta);
     }
     if (data.containsKey('description')) {
       context.handle(
-        _descriptionMeta,
-        description.isAcceptableOrUnknown(
-          data['description']!,
           _descriptionMeta,
-        ),
-      );
+          description.isAcceptableOrUnknown(
+              data['description']!, _descriptionMeta));
     } else if (isInserting) {
       context.missing(_descriptionMeta);
     }
     if (data.containsKey('total_amount_cents')) {
       context.handle(
-        _totalAmountCentsMeta,
-        totalAmountCents.isAcceptableOrUnknown(
-          data['total_amount_cents']!,
           _totalAmountCentsMeta,
-        ),
-      );
+          totalAmountCents.isAcceptableOrUnknown(
+              data['total_amount_cents']!, _totalAmountCentsMeta));
     } else if (isInserting) {
       context.missing(_totalAmountCentsMeta);
     }
     if (data.containsKey('currency_code')) {
       context.handle(
-        _currencyCodeMeta,
-        currencyCode.isAcceptableOrUnknown(
-          data['currency_code']!,
           _currencyCodeMeta,
-        ),
-      );
+          currencyCode.isAcceptableOrUnknown(
+              data['currency_code']!, _currencyCodeMeta));
     }
     if (data.containsKey('paid_by_user_id')) {
       context.handle(
-        _paidByUserIdMeta,
-        paidByUserId.isAcceptableOrUnknown(
-          data['paid_by_user_id']!,
           _paidByUserIdMeta,
-        ),
-      );
+          paidByUserId.isAcceptableOrUnknown(
+              data['paid_by_user_id']!, _paidByUserIdMeta));
     } else if (isInserting) {
       context.missing(_paidByUserIdMeta);
     }
     if (data.containsKey('category_id')) {
       context.handle(
-        _categoryIdMeta,
-        categoryId.isAcceptableOrUnknown(data['category_id']!, _categoryIdMeta),
-      );
+          _categoryIdMeta,
+          categoryId.isAcceptableOrUnknown(
+              data['category_id']!, _categoryIdMeta));
     }
     if (data.containsKey('split_type')) {
-      context.handle(
-        _splitTypeMeta,
-        splitType.isAcceptableOrUnknown(data['split_type']!, _splitTypeMeta),
-      );
+      context.handle(_splitTypeMeta,
+          splitType.isAcceptableOrUnknown(data['split_type']!, _splitTypeMeta));
     }
     if (data.containsKey('notes')) {
       context.handle(
-        _notesMeta,
-        notes.isAcceptableOrUnknown(data['notes']!, _notesMeta),
-      );
+          _notesMeta, notes.isAcceptableOrUnknown(data['notes']!, _notesMeta));
     }
     if (data.containsKey('receipt_url')) {
       context.handle(
-        _receiptUrlMeta,
-        receiptUrl.isAcceptableOrUnknown(data['receipt_url']!, _receiptUrlMeta),
-      );
+          _receiptUrlMeta,
+          receiptUrl.isAcceptableOrUnknown(
+              data['receipt_url']!, _receiptUrlMeta));
     }
     if (data.containsKey('is_deleted')) {
-      context.handle(
-        _isDeletedMeta,
-        isDeleted.isAcceptableOrUnknown(data['is_deleted']!, _isDeletedMeta),
-      );
+      context.handle(_isDeletedMeta,
+          isDeleted.isAcceptableOrUnknown(data['is_deleted']!, _isDeletedMeta));
     }
     if (data.containsKey('sync_status')) {
       context.handle(
-        _syncStatusMeta,
-        syncStatus.isAcceptableOrUnknown(data['sync_status']!, _syncStatusMeta),
-      );
+          _syncStatusMeta,
+          syncStatus.isAcceptableOrUnknown(
+              data['sync_status']!, _syncStatusMeta));
     }
     if (data.containsKey('expense_date')) {
       context.handle(
-        _expenseDateMeta,
-        expenseDate.isAcceptableOrUnknown(
-          data['expense_date']!,
           _expenseDateMeta,
-        ),
-      );
+          expenseDate.isAcceptableOrUnknown(
+              data['expense_date']!, _expenseDateMeta));
     } else if (isInserting) {
       context.missing(_expenseDateMeta);
     }
     if (data.containsKey('created_at')) {
-      context.handle(
-        _createdAtMeta,
-        createdAt.isAcceptableOrUnknown(data['created_at']!, _createdAtMeta),
-      );
+      context.handle(_createdAtMeta,
+          createdAt.isAcceptableOrUnknown(data['created_at']!, _createdAtMeta));
     }
     if (data.containsKey('updated_at')) {
-      context.handle(
-        _updatedAtMeta,
-        updatedAt.isAcceptableOrUnknown(data['updated_at']!, _updatedAtMeta),
-      );
+      context.handle(_updatedAtMeta,
+          updatedAt.isAcceptableOrUnknown(data['updated_at']!, _updatedAtMeta));
     }
     return context;
   }
@@ -4506,70 +3768,38 @@ class $SharedExpenseEntriesTable extends SharedExpenseEntries
   SharedExpenseEntry map(Map<String, dynamic> data, {String? tablePrefix}) {
     final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
     return SharedExpenseEntry(
-      id: attachedDatabase.typeMapping.read(
-        DriftSqlType.int,
-        data['${effectivePrefix}id'],
-      )!,
-      uuid: attachedDatabase.typeMapping.read(
-        DriftSqlType.string,
-        data['${effectivePrefix}uuid'],
-      )!,
-      groupId: attachedDatabase.typeMapping.read(
-        DriftSqlType.string,
-        data['${effectivePrefix}group_id'],
-      )!,
-      description: attachedDatabase.typeMapping.read(
-        DriftSqlType.string,
-        data['${effectivePrefix}description'],
-      )!,
+      id: attachedDatabase.typeMapping
+          .read(DriftSqlType.int, data['${effectivePrefix}id'])!,
+      uuid: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}uuid'])!,
+      groupId: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}group_id'])!,
+      description: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}description'])!,
       totalAmountCents: attachedDatabase.typeMapping.read(
-        DriftSqlType.int,
-        data['${effectivePrefix}total_amount_cents'],
-      )!,
-      currencyCode: attachedDatabase.typeMapping.read(
-        DriftSqlType.string,
-        data['${effectivePrefix}currency_code'],
-      )!,
+          DriftSqlType.int, data['${effectivePrefix}total_amount_cents'])!,
+      currencyCode: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}currency_code'])!,
       paidByUserId: attachedDatabase.typeMapping.read(
-        DriftSqlType.string,
-        data['${effectivePrefix}paid_by_user_id'],
-      )!,
-      categoryId: attachedDatabase.typeMapping.read(
-        DriftSqlType.string,
-        data['${effectivePrefix}category_id'],
-      ),
-      splitType: attachedDatabase.typeMapping.read(
-        DriftSqlType.string,
-        data['${effectivePrefix}split_type'],
-      )!,
-      notes: attachedDatabase.typeMapping.read(
-        DriftSqlType.string,
-        data['${effectivePrefix}notes'],
-      ),
-      receiptUrl: attachedDatabase.typeMapping.read(
-        DriftSqlType.string,
-        data['${effectivePrefix}receipt_url'],
-      ),
-      isDeleted: attachedDatabase.typeMapping.read(
-        DriftSqlType.bool,
-        data['${effectivePrefix}is_deleted'],
-      )!,
-      syncStatus: attachedDatabase.typeMapping.read(
-        DriftSqlType.string,
-        data['${effectivePrefix}sync_status'],
-      )!,
-      expenseDate: attachedDatabase.typeMapping.read(
-        DriftSqlType.dateTime,
-        data['${effectivePrefix}expense_date'],
-      )!,
-      createdAt: attachedDatabase.typeMapping.read(
-        DriftSqlType.dateTime,
-        data['${effectivePrefix}created_at'],
-      )!,
-      updatedAt: attachedDatabase.typeMapping.read(
-        DriftSqlType.dateTime,
-        data['${effectivePrefix}updated_at'],
-      ),
+          DriftSqlType.string, data['${effectivePrefix}paid_by_user_id'])!,
+      categoryId: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}category_id']),
+      splitType: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}split_type'])!,
+      notes: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}notes']),
+      receiptUrl: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}receipt_url']),
+      isDeleted: attachedDatabase.typeMapping
+          .read(DriftSqlType.bool, data['${effectivePrefix}is_deleted'])!,
+      syncStatus: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}sync_status'])!,
+      expenseDate: attachedDatabase.typeMapping
+          .read(DriftSqlType.dateTime, data['${effectivePrefix}expense_date'])!,
+      createdAt: attachedDatabase.typeMapping
+          .read(DriftSqlType.dateTime, data['${effectivePrefix}created_at'])!,
+      updatedAt: attachedDatabase.typeMapping
+          .read(DriftSqlType.dateTime, data['${effectivePrefix}updated_at']),
     );
   }
 
@@ -4586,6 +3816,8 @@ class SharedExpenseEntry extends DataClass
   final String groupId;
   final String description;
   final int totalAmountCents;
+
+  /// Currency code for the expense.
   final String currencyCode;
   final String paidByUserId;
   final String? categoryId;
@@ -4597,24 +3829,23 @@ class SharedExpenseEntry extends DataClass
   final DateTime expenseDate;
   final DateTime createdAt;
   final DateTime? updatedAt;
-  const SharedExpenseEntry({
-    required this.id,
-    required this.uuid,
-    required this.groupId,
-    required this.description,
-    required this.totalAmountCents,
-    required this.currencyCode,
-    required this.paidByUserId,
-    this.categoryId,
-    required this.splitType,
-    this.notes,
-    this.receiptUrl,
-    required this.isDeleted,
-    required this.syncStatus,
-    required this.expenseDate,
-    required this.createdAt,
-    this.updatedAt,
-  });
+  const SharedExpenseEntry(
+      {required this.id,
+      required this.uuid,
+      required this.groupId,
+      required this.description,
+      required this.totalAmountCents,
+      required this.currencyCode,
+      required this.paidByUserId,
+      this.categoryId,
+      required this.splitType,
+      this.notes,
+      this.receiptUrl,
+      required this.isDeleted,
+      required this.syncStatus,
+      required this.expenseDate,
+      required this.createdAt,
+      this.updatedAt});
   @override
   Map<String, Expression> toColumns(bool nullToAbsent) {
     final map = <String, Expression>{};
@@ -4658,9 +3889,8 @@ class SharedExpenseEntry extends DataClass
           ? const Value.absent()
           : Value(categoryId),
       splitType: Value(splitType),
-      notes: notes == null && nullToAbsent
-          ? const Value.absent()
-          : Value(notes),
+      notes:
+          notes == null && nullToAbsent ? const Value.absent() : Value(notes),
       receiptUrl: receiptUrl == null && nullToAbsent
           ? const Value.absent()
           : Value(receiptUrl),
@@ -4674,10 +3904,8 @@ class SharedExpenseEntry extends DataClass
     );
   }
 
-  factory SharedExpenseEntry.fromJson(
-    Map<String, dynamic> json, {
-    ValueSerializer? serializer,
-  }) {
+  factory SharedExpenseEntry.fromJson(Map<String, dynamic> json,
+      {ValueSerializer? serializer}) {
     serializer ??= driftRuntimeOptions.defaultSerializer;
     return SharedExpenseEntry(
       id: serializer.fromJson<int>(json['id']),
@@ -4721,49 +3949,48 @@ class SharedExpenseEntry extends DataClass
     };
   }
 
-  SharedExpenseEntry copyWith({
-    int? id,
-    String? uuid,
-    String? groupId,
-    String? description,
-    int? totalAmountCents,
-    String? currencyCode,
-    String? paidByUserId,
-    Value<String?> categoryId = const Value.absent(),
-    String? splitType,
-    Value<String?> notes = const Value.absent(),
-    Value<String?> receiptUrl = const Value.absent(),
-    bool? isDeleted,
-    String? syncStatus,
-    DateTime? expenseDate,
-    DateTime? createdAt,
-    Value<DateTime?> updatedAt = const Value.absent(),
-  }) => SharedExpenseEntry(
-    id: id ?? this.id,
-    uuid: uuid ?? this.uuid,
-    groupId: groupId ?? this.groupId,
-    description: description ?? this.description,
-    totalAmountCents: totalAmountCents ?? this.totalAmountCents,
-    currencyCode: currencyCode ?? this.currencyCode,
-    paidByUserId: paidByUserId ?? this.paidByUserId,
-    categoryId: categoryId.present ? categoryId.value : this.categoryId,
-    splitType: splitType ?? this.splitType,
-    notes: notes.present ? notes.value : this.notes,
-    receiptUrl: receiptUrl.present ? receiptUrl.value : this.receiptUrl,
-    isDeleted: isDeleted ?? this.isDeleted,
-    syncStatus: syncStatus ?? this.syncStatus,
-    expenseDate: expenseDate ?? this.expenseDate,
-    createdAt: createdAt ?? this.createdAt,
-    updatedAt: updatedAt.present ? updatedAt.value : this.updatedAt,
-  );
+  SharedExpenseEntry copyWith(
+          {int? id,
+          String? uuid,
+          String? groupId,
+          String? description,
+          int? totalAmountCents,
+          String? currencyCode,
+          String? paidByUserId,
+          Value<String?> categoryId = const Value.absent(),
+          String? splitType,
+          Value<String?> notes = const Value.absent(),
+          Value<String?> receiptUrl = const Value.absent(),
+          bool? isDeleted,
+          String? syncStatus,
+          DateTime? expenseDate,
+          DateTime? createdAt,
+          Value<DateTime?> updatedAt = const Value.absent()}) =>
+      SharedExpenseEntry(
+        id: id ?? this.id,
+        uuid: uuid ?? this.uuid,
+        groupId: groupId ?? this.groupId,
+        description: description ?? this.description,
+        totalAmountCents: totalAmountCents ?? this.totalAmountCents,
+        currencyCode: currencyCode ?? this.currencyCode,
+        paidByUserId: paidByUserId ?? this.paidByUserId,
+        categoryId: categoryId.present ? categoryId.value : this.categoryId,
+        splitType: splitType ?? this.splitType,
+        notes: notes.present ? notes.value : this.notes,
+        receiptUrl: receiptUrl.present ? receiptUrl.value : this.receiptUrl,
+        isDeleted: isDeleted ?? this.isDeleted,
+        syncStatus: syncStatus ?? this.syncStatus,
+        expenseDate: expenseDate ?? this.expenseDate,
+        createdAt: createdAt ?? this.createdAt,
+        updatedAt: updatedAt.present ? updatedAt.value : this.updatedAt,
+      );
   SharedExpenseEntry copyWithCompanion(SharedExpenseEntriesCompanion data) {
     return SharedExpenseEntry(
       id: data.id.present ? data.id.value : this.id,
       uuid: data.uuid.present ? data.uuid.value : this.uuid,
       groupId: data.groupId.present ? data.groupId.value : this.groupId,
-      description: data.description.present
-          ? data.description.value
-          : this.description,
+      description:
+          data.description.present ? data.description.value : this.description,
       totalAmountCents: data.totalAmountCents.present
           ? data.totalAmountCents.value
           : this.totalAmountCents,
@@ -4773,21 +4000,17 @@ class SharedExpenseEntry extends DataClass
       paidByUserId: data.paidByUserId.present
           ? data.paidByUserId.value
           : this.paidByUserId,
-      categoryId: data.categoryId.present
-          ? data.categoryId.value
-          : this.categoryId,
+      categoryId:
+          data.categoryId.present ? data.categoryId.value : this.categoryId,
       splitType: data.splitType.present ? data.splitType.value : this.splitType,
       notes: data.notes.present ? data.notes.value : this.notes,
-      receiptUrl: data.receiptUrl.present
-          ? data.receiptUrl.value
-          : this.receiptUrl,
+      receiptUrl:
+          data.receiptUrl.present ? data.receiptUrl.value : this.receiptUrl,
       isDeleted: data.isDeleted.present ? data.isDeleted.value : this.isDeleted,
-      syncStatus: data.syncStatus.present
-          ? data.syncStatus.value
-          : this.syncStatus,
-      expenseDate: data.expenseDate.present
-          ? data.expenseDate.value
-          : this.expenseDate,
+      syncStatus:
+          data.syncStatus.present ? data.syncStatus.value : this.syncStatus,
+      expenseDate:
+          data.expenseDate.present ? data.expenseDate.value : this.expenseDate,
       createdAt: data.createdAt.present ? data.createdAt.value : this.createdAt,
       updatedAt: data.updatedAt.present ? data.updatedAt.value : this.updatedAt,
     );
@@ -4818,23 +4041,22 @@ class SharedExpenseEntry extends DataClass
 
   @override
   int get hashCode => Object.hash(
-    id,
-    uuid,
-    groupId,
-    description,
-    totalAmountCents,
-    currencyCode,
-    paidByUserId,
-    categoryId,
-    splitType,
-    notes,
-    receiptUrl,
-    isDeleted,
-    syncStatus,
-    expenseDate,
-    createdAt,
-    updatedAt,
-  );
+      id,
+      uuid,
+      groupId,
+      description,
+      totalAmountCents,
+      currencyCode,
+      paidByUserId,
+      categoryId,
+      splitType,
+      notes,
+      receiptUrl,
+      isDeleted,
+      syncStatus,
+      expenseDate,
+      createdAt,
+      updatedAt);
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
@@ -4910,12 +4132,12 @@ class SharedExpenseEntriesCompanion
     required DateTime expenseDate,
     this.createdAt = const Value.absent(),
     this.updatedAt = const Value.absent(),
-  }) : uuid = Value(uuid),
-       groupId = Value(groupId),
-       description = Value(description),
-       totalAmountCents = Value(totalAmountCents),
-       paidByUserId = Value(paidByUserId),
-       expenseDate = Value(expenseDate);
+  })  : uuid = Value(uuid),
+        groupId = Value(groupId),
+        description = Value(description),
+        totalAmountCents = Value(totalAmountCents),
+        paidByUserId = Value(paidByUserId),
+        expenseDate = Value(expenseDate);
   static Insertable<SharedExpenseEntry> custom({
     Expression<int>? id,
     Expression<String>? uuid,
@@ -4954,24 +4176,23 @@ class SharedExpenseEntriesCompanion
     });
   }
 
-  SharedExpenseEntriesCompanion copyWith({
-    Value<int>? id,
-    Value<String>? uuid,
-    Value<String>? groupId,
-    Value<String>? description,
-    Value<int>? totalAmountCents,
-    Value<String>? currencyCode,
-    Value<String>? paidByUserId,
-    Value<String?>? categoryId,
-    Value<String>? splitType,
-    Value<String?>? notes,
-    Value<String?>? receiptUrl,
-    Value<bool>? isDeleted,
-    Value<String>? syncStatus,
-    Value<DateTime>? expenseDate,
-    Value<DateTime>? createdAt,
-    Value<DateTime?>? updatedAt,
-  }) {
+  SharedExpenseEntriesCompanion copyWith(
+      {Value<int>? id,
+      Value<String>? uuid,
+      Value<String>? groupId,
+      Value<String>? description,
+      Value<int>? totalAmountCents,
+      Value<String>? currencyCode,
+      Value<String>? paidByUserId,
+      Value<String?>? categoryId,
+      Value<String>? splitType,
+      Value<String?>? notes,
+      Value<String?>? receiptUrl,
+      Value<bool>? isDeleted,
+      Value<String>? syncStatus,
+      Value<DateTime>? expenseDate,
+      Value<DateTime>? createdAt,
+      Value<DateTime?>? updatedAt}) {
     return SharedExpenseEntriesCompanion(
       id: id ?? this.id,
       uuid: uuid ?? this.uuid,
@@ -5079,142 +4300,97 @@ class $SplitEntryRecordsTable extends SplitEntryRecords
   static const VerificationMeta _idMeta = const VerificationMeta('id');
   @override
   late final GeneratedColumn<int> id = GeneratedColumn<int>(
-    'id',
-    aliasedName,
-    false,
-    hasAutoIncrement: true,
-    type: DriftSqlType.int,
-    requiredDuringInsert: false,
-    defaultConstraints: GeneratedColumn.constraintIsAlways(
-      'PRIMARY KEY AUTOINCREMENT',
-    ),
-  );
+      'id', aliasedName, false,
+      hasAutoIncrement: true,
+      type: DriftSqlType.int,
+      requiredDuringInsert: false,
+      defaultConstraints:
+          GeneratedColumn.constraintIsAlways('PRIMARY KEY AUTOINCREMENT'));
   static const VerificationMeta _uuidMeta = const VerificationMeta('uuid');
   @override
   late final GeneratedColumn<String> uuid = GeneratedColumn<String>(
-    'uuid',
-    aliasedName,
-    false,
-    type: DriftSqlType.string,
-    requiredDuringInsert: true,
-    defaultConstraints: GeneratedColumn.constraintIsAlways('UNIQUE'),
-  );
-  static const VerificationMeta _sharedExpenseIdMeta = const VerificationMeta(
-    'sharedExpenseId',
-  );
+      'uuid', aliasedName, false,
+      type: DriftSqlType.string,
+      requiredDuringInsert: true,
+      defaultConstraints: GeneratedColumn.constraintIsAlways('UNIQUE'));
+  static const VerificationMeta _sharedExpenseIdMeta =
+      const VerificationMeta('sharedExpenseId');
   @override
   late final GeneratedColumn<String> sharedExpenseId = GeneratedColumn<String>(
-    'shared_expense_id',
-    aliasedName,
-    false,
-    type: DriftSqlType.string,
-    requiredDuringInsert: true,
-  );
+      'shared_expense_id', aliasedName, false,
+      type: DriftSqlType.string, requiredDuringInsert: true);
   static const VerificationMeta _userIdMeta = const VerificationMeta('userId');
   @override
   late final GeneratedColumn<String> userId = GeneratedColumn<String>(
-    'user_id',
-    aliasedName,
-    false,
-    type: DriftSqlType.string,
-    requiredDuringInsert: true,
-  );
-  static const VerificationMeta _amountCentsMeta = const VerificationMeta(
-    'amountCents',
-  );
+      'user_id', aliasedName, false,
+      type: DriftSqlType.string, requiredDuringInsert: true);
+  static const VerificationMeta _amountCentsMeta =
+      const VerificationMeta('amountCents');
   @override
   late final GeneratedColumn<int> amountCents = GeneratedColumn<int>(
-    'amount_cents',
-    aliasedName,
-    false,
-    type: DriftSqlType.int,
-    requiredDuringInsert: true,
-  );
-  static const VerificationMeta _shareValueMeta = const VerificationMeta(
-    'shareValue',
-  );
+      'amount_cents', aliasedName, false,
+      type: DriftSqlType.int, requiredDuringInsert: true);
+  static const VerificationMeta _shareValueMeta =
+      const VerificationMeta('shareValue');
   @override
   late final GeneratedColumn<int> shareValue = GeneratedColumn<int>(
-    'share_value',
-    aliasedName,
-    false,
-    type: DriftSqlType.int,
-    requiredDuringInsert: false,
-    defaultValue: const Constant(100),
-  );
-  static const VerificationMeta _isSettledMeta = const VerificationMeta(
-    'isSettled',
-  );
+      'share_value', aliasedName, false,
+      type: DriftSqlType.int,
+      requiredDuringInsert: false,
+      defaultValue: const Constant(100));
+  static const VerificationMeta _isSettledMeta =
+      const VerificationMeta('isSettled');
   @override
   late final GeneratedColumn<bool> isSettled = GeneratedColumn<bool>(
-    'is_settled',
-    aliasedName,
-    false,
-    type: DriftSqlType.bool,
-    requiredDuringInsert: false,
-    defaultConstraints: GeneratedColumn.constraintIsAlways(
-      'CHECK ("is_settled" IN (0, 1))',
-    ),
-    defaultValue: const Constant(false),
-  );
-  static const VerificationMeta _syncStatusMeta = const VerificationMeta(
-    'syncStatus',
-  );
+      'is_settled', aliasedName, false,
+      type: DriftSqlType.bool,
+      requiredDuringInsert: false,
+      defaultConstraints:
+          GeneratedColumn.constraintIsAlways('CHECK ("is_settled" IN (0, 1))'),
+      defaultValue: const Constant(false));
+  static const VerificationMeta _syncStatusMeta =
+      const VerificationMeta('syncStatus');
   @override
   late final GeneratedColumn<String> syncStatus = GeneratedColumn<String>(
-    'sync_status',
-    aliasedName,
-    false,
-    type: DriftSqlType.string,
-    requiredDuringInsert: false,
-    defaultValue: const Constant('pending'),
-  );
-  static const VerificationMeta _createdAtMeta = const VerificationMeta(
-    'createdAt',
-  );
+      'sync_status', aliasedName, false,
+      type: DriftSqlType.string,
+      requiredDuringInsert: false,
+      defaultValue: const Constant('pending'));
+  static const VerificationMeta _createdAtMeta =
+      const VerificationMeta('createdAt');
   @override
   late final GeneratedColumn<DateTime> createdAt = GeneratedColumn<DateTime>(
-    'created_at',
-    aliasedName,
-    false,
-    type: DriftSqlType.dateTime,
-    requiredDuringInsert: false,
-    defaultValue: currentDateAndTime,
-  );
-  static const VerificationMeta _updatedAtMeta = const VerificationMeta(
-    'updatedAt',
-  );
+      'created_at', aliasedName, false,
+      type: DriftSqlType.dateTime,
+      requiredDuringInsert: false,
+      defaultValue: currentDateAndTime);
+  static const VerificationMeta _updatedAtMeta =
+      const VerificationMeta('updatedAt');
   @override
   late final GeneratedColumn<DateTime> updatedAt = GeneratedColumn<DateTime>(
-    'updated_at',
-    aliasedName,
-    true,
-    type: DriftSqlType.dateTime,
-    requiredDuringInsert: false,
-  );
+      'updated_at', aliasedName, true,
+      type: DriftSqlType.dateTime, requiredDuringInsert: false);
   @override
   List<GeneratedColumn> get $columns => [
-    id,
-    uuid,
-    sharedExpenseId,
-    userId,
-    amountCents,
-    shareValue,
-    isSettled,
-    syncStatus,
-    createdAt,
-    updatedAt,
-  ];
+        id,
+        uuid,
+        sharedExpenseId,
+        userId,
+        amountCents,
+        shareValue,
+        isSettled,
+        syncStatus,
+        createdAt,
+        updatedAt
+      ];
   @override
   String get aliasedName => _alias ?? actualTableName;
   @override
   String get actualTableName => $name;
   static const String $name = 'split_entry_records';
   @override
-  VerificationContext validateIntegrity(
-    Insertable<SplitEntryRecord> instance, {
-    bool isInserting = false,
-  }) {
+  VerificationContext validateIntegrity(Insertable<SplitEntryRecord> instance,
+      {bool isInserting = false}) {
     final context = VerificationContext();
     final data = instance.toColumns(true);
     if (data.containsKey('id')) {
@@ -5222,71 +4398,55 @@ class $SplitEntryRecordsTable extends SplitEntryRecords
     }
     if (data.containsKey('uuid')) {
       context.handle(
-        _uuidMeta,
-        uuid.isAcceptableOrUnknown(data['uuid']!, _uuidMeta),
-      );
+          _uuidMeta, uuid.isAcceptableOrUnknown(data['uuid']!, _uuidMeta));
     } else if (isInserting) {
       context.missing(_uuidMeta);
     }
     if (data.containsKey('shared_expense_id')) {
       context.handle(
-        _sharedExpenseIdMeta,
-        sharedExpenseId.isAcceptableOrUnknown(
-          data['shared_expense_id']!,
           _sharedExpenseIdMeta,
-        ),
-      );
+          sharedExpenseId.isAcceptableOrUnknown(
+              data['shared_expense_id']!, _sharedExpenseIdMeta));
     } else if (isInserting) {
       context.missing(_sharedExpenseIdMeta);
     }
     if (data.containsKey('user_id')) {
-      context.handle(
-        _userIdMeta,
-        userId.isAcceptableOrUnknown(data['user_id']!, _userIdMeta),
-      );
+      context.handle(_userIdMeta,
+          userId.isAcceptableOrUnknown(data['user_id']!, _userIdMeta));
     } else if (isInserting) {
       context.missing(_userIdMeta);
     }
     if (data.containsKey('amount_cents')) {
       context.handle(
-        _amountCentsMeta,
-        amountCents.isAcceptableOrUnknown(
-          data['amount_cents']!,
           _amountCentsMeta,
-        ),
-      );
+          amountCents.isAcceptableOrUnknown(
+              data['amount_cents']!, _amountCentsMeta));
     } else if (isInserting) {
       context.missing(_amountCentsMeta);
     }
     if (data.containsKey('share_value')) {
       context.handle(
-        _shareValueMeta,
-        shareValue.isAcceptableOrUnknown(data['share_value']!, _shareValueMeta),
-      );
+          _shareValueMeta,
+          shareValue.isAcceptableOrUnknown(
+              data['share_value']!, _shareValueMeta));
     }
     if (data.containsKey('is_settled')) {
-      context.handle(
-        _isSettledMeta,
-        isSettled.isAcceptableOrUnknown(data['is_settled']!, _isSettledMeta),
-      );
+      context.handle(_isSettledMeta,
+          isSettled.isAcceptableOrUnknown(data['is_settled']!, _isSettledMeta));
     }
     if (data.containsKey('sync_status')) {
       context.handle(
-        _syncStatusMeta,
-        syncStatus.isAcceptableOrUnknown(data['sync_status']!, _syncStatusMeta),
-      );
+          _syncStatusMeta,
+          syncStatus.isAcceptableOrUnknown(
+              data['sync_status']!, _syncStatusMeta));
     }
     if (data.containsKey('created_at')) {
-      context.handle(
-        _createdAtMeta,
-        createdAt.isAcceptableOrUnknown(data['created_at']!, _createdAtMeta),
-      );
+      context.handle(_createdAtMeta,
+          createdAt.isAcceptableOrUnknown(data['created_at']!, _createdAtMeta));
     }
     if (data.containsKey('updated_at')) {
-      context.handle(
-        _updatedAtMeta,
-        updatedAt.isAcceptableOrUnknown(data['updated_at']!, _updatedAtMeta),
-      );
+      context.handle(_updatedAtMeta,
+          updatedAt.isAcceptableOrUnknown(data['updated_at']!, _updatedAtMeta));
     }
     return context;
   }
@@ -5297,46 +4457,26 @@ class $SplitEntryRecordsTable extends SplitEntryRecords
   SplitEntryRecord map(Map<String, dynamic> data, {String? tablePrefix}) {
     final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
     return SplitEntryRecord(
-      id: attachedDatabase.typeMapping.read(
-        DriftSqlType.int,
-        data['${effectivePrefix}id'],
-      )!,
-      uuid: attachedDatabase.typeMapping.read(
-        DriftSqlType.string,
-        data['${effectivePrefix}uuid'],
-      )!,
+      id: attachedDatabase.typeMapping
+          .read(DriftSqlType.int, data['${effectivePrefix}id'])!,
+      uuid: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}uuid'])!,
       sharedExpenseId: attachedDatabase.typeMapping.read(
-        DriftSqlType.string,
-        data['${effectivePrefix}shared_expense_id'],
-      )!,
-      userId: attachedDatabase.typeMapping.read(
-        DriftSqlType.string,
-        data['${effectivePrefix}user_id'],
-      )!,
-      amountCents: attachedDatabase.typeMapping.read(
-        DriftSqlType.int,
-        data['${effectivePrefix}amount_cents'],
-      )!,
-      shareValue: attachedDatabase.typeMapping.read(
-        DriftSqlType.int,
-        data['${effectivePrefix}share_value'],
-      )!,
-      isSettled: attachedDatabase.typeMapping.read(
-        DriftSqlType.bool,
-        data['${effectivePrefix}is_settled'],
-      )!,
-      syncStatus: attachedDatabase.typeMapping.read(
-        DriftSqlType.string,
-        data['${effectivePrefix}sync_status'],
-      )!,
-      createdAt: attachedDatabase.typeMapping.read(
-        DriftSqlType.dateTime,
-        data['${effectivePrefix}created_at'],
-      )!,
-      updatedAt: attachedDatabase.typeMapping.read(
-        DriftSqlType.dateTime,
-        data['${effectivePrefix}updated_at'],
-      ),
+          DriftSqlType.string, data['${effectivePrefix}shared_expense_id'])!,
+      userId: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}user_id'])!,
+      amountCents: attachedDatabase.typeMapping
+          .read(DriftSqlType.int, data['${effectivePrefix}amount_cents'])!,
+      shareValue: attachedDatabase.typeMapping
+          .read(DriftSqlType.int, data['${effectivePrefix}share_value'])!,
+      isSettled: attachedDatabase.typeMapping
+          .read(DriftSqlType.bool, data['${effectivePrefix}is_settled'])!,
+      syncStatus: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}sync_status'])!,
+      createdAt: attachedDatabase.typeMapping
+          .read(DriftSqlType.dateTime, data['${effectivePrefix}created_at'])!,
+      updatedAt: attachedDatabase.typeMapping
+          .read(DriftSqlType.dateTime, data['${effectivePrefix}updated_at']),
     );
   }
 
@@ -5358,18 +4498,17 @@ class SplitEntryRecord extends DataClass
   final String syncStatus;
   final DateTime createdAt;
   final DateTime? updatedAt;
-  const SplitEntryRecord({
-    required this.id,
-    required this.uuid,
-    required this.sharedExpenseId,
-    required this.userId,
-    required this.amountCents,
-    required this.shareValue,
-    required this.isSettled,
-    required this.syncStatus,
-    required this.createdAt,
-    this.updatedAt,
-  });
+  const SplitEntryRecord(
+      {required this.id,
+      required this.uuid,
+      required this.sharedExpenseId,
+      required this.userId,
+      required this.amountCents,
+      required this.shareValue,
+      required this.isSettled,
+      required this.syncStatus,
+      required this.createdAt,
+      this.updatedAt});
   @override
   Map<String, Expression> toColumns(bool nullToAbsent) {
     final map = <String, Expression>{};
@@ -5405,10 +4544,8 @@ class SplitEntryRecord extends DataClass
     );
   }
 
-  factory SplitEntryRecord.fromJson(
-    Map<String, dynamic> json, {
-    ValueSerializer? serializer,
-  }) {
+  factory SplitEntryRecord.fromJson(Map<String, dynamic> json,
+      {ValueSerializer? serializer}) {
     serializer ??= driftRuntimeOptions.defaultSerializer;
     return SplitEntryRecord(
       id: serializer.fromJson<int>(json['id']),
@@ -5440,29 +4577,29 @@ class SplitEntryRecord extends DataClass
     };
   }
 
-  SplitEntryRecord copyWith({
-    int? id,
-    String? uuid,
-    String? sharedExpenseId,
-    String? userId,
-    int? amountCents,
-    int? shareValue,
-    bool? isSettled,
-    String? syncStatus,
-    DateTime? createdAt,
-    Value<DateTime?> updatedAt = const Value.absent(),
-  }) => SplitEntryRecord(
-    id: id ?? this.id,
-    uuid: uuid ?? this.uuid,
-    sharedExpenseId: sharedExpenseId ?? this.sharedExpenseId,
-    userId: userId ?? this.userId,
-    amountCents: amountCents ?? this.amountCents,
-    shareValue: shareValue ?? this.shareValue,
-    isSettled: isSettled ?? this.isSettled,
-    syncStatus: syncStatus ?? this.syncStatus,
-    createdAt: createdAt ?? this.createdAt,
-    updatedAt: updatedAt.present ? updatedAt.value : this.updatedAt,
-  );
+  SplitEntryRecord copyWith(
+          {int? id,
+          String? uuid,
+          String? sharedExpenseId,
+          String? userId,
+          int? amountCents,
+          int? shareValue,
+          bool? isSettled,
+          String? syncStatus,
+          DateTime? createdAt,
+          Value<DateTime?> updatedAt = const Value.absent()}) =>
+      SplitEntryRecord(
+        id: id ?? this.id,
+        uuid: uuid ?? this.uuid,
+        sharedExpenseId: sharedExpenseId ?? this.sharedExpenseId,
+        userId: userId ?? this.userId,
+        amountCents: amountCents ?? this.amountCents,
+        shareValue: shareValue ?? this.shareValue,
+        isSettled: isSettled ?? this.isSettled,
+        syncStatus: syncStatus ?? this.syncStatus,
+        createdAt: createdAt ?? this.createdAt,
+        updatedAt: updatedAt.present ? updatedAt.value : this.updatedAt,
+      );
   SplitEntryRecord copyWithCompanion(SplitEntryRecordsCompanion data) {
     return SplitEntryRecord(
       id: data.id.present ? data.id.value : this.id,
@@ -5471,16 +4608,13 @@ class SplitEntryRecord extends DataClass
           ? data.sharedExpenseId.value
           : this.sharedExpenseId,
       userId: data.userId.present ? data.userId.value : this.userId,
-      amountCents: data.amountCents.present
-          ? data.amountCents.value
-          : this.amountCents,
-      shareValue: data.shareValue.present
-          ? data.shareValue.value
-          : this.shareValue,
+      amountCents:
+          data.amountCents.present ? data.amountCents.value : this.amountCents,
+      shareValue:
+          data.shareValue.present ? data.shareValue.value : this.shareValue,
       isSettled: data.isSettled.present ? data.isSettled.value : this.isSettled,
-      syncStatus: data.syncStatus.present
-          ? data.syncStatus.value
-          : this.syncStatus,
+      syncStatus:
+          data.syncStatus.present ? data.syncStatus.value : this.syncStatus,
       createdAt: data.createdAt.present ? data.createdAt.value : this.createdAt,
       updatedAt: data.updatedAt.present ? data.updatedAt.value : this.updatedAt,
     );
@@ -5504,18 +4638,8 @@ class SplitEntryRecord extends DataClass
   }
 
   @override
-  int get hashCode => Object.hash(
-    id,
-    uuid,
-    sharedExpenseId,
-    userId,
-    amountCents,
-    shareValue,
-    isSettled,
-    syncStatus,
-    createdAt,
-    updatedAt,
-  );
+  int get hashCode => Object.hash(id, uuid, sharedExpenseId, userId,
+      amountCents, shareValue, isSettled, syncStatus, createdAt, updatedAt);
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
@@ -5566,10 +4690,10 @@ class SplitEntryRecordsCompanion extends UpdateCompanion<SplitEntryRecord> {
     this.syncStatus = const Value.absent(),
     this.createdAt = const Value.absent(),
     this.updatedAt = const Value.absent(),
-  }) : uuid = Value(uuid),
-       sharedExpenseId = Value(sharedExpenseId),
-       userId = Value(userId),
-       amountCents = Value(amountCents);
+  })  : uuid = Value(uuid),
+        sharedExpenseId = Value(sharedExpenseId),
+        userId = Value(userId),
+        amountCents = Value(amountCents);
   static Insertable<SplitEntryRecord> custom({
     Expression<int>? id,
     Expression<String>? uuid,
@@ -5596,18 +4720,17 @@ class SplitEntryRecordsCompanion extends UpdateCompanion<SplitEntryRecord> {
     });
   }
 
-  SplitEntryRecordsCompanion copyWith({
-    Value<int>? id,
-    Value<String>? uuid,
-    Value<String>? sharedExpenseId,
-    Value<String>? userId,
-    Value<int>? amountCents,
-    Value<int>? shareValue,
-    Value<bool>? isSettled,
-    Value<String>? syncStatus,
-    Value<DateTime>? createdAt,
-    Value<DateTime?>? updatedAt,
-  }) {
+  SplitEntryRecordsCompanion copyWith(
+      {Value<int>? id,
+      Value<String>? uuid,
+      Value<String>? sharedExpenseId,
+      Value<String>? userId,
+      Value<int>? amountCents,
+      Value<int>? shareValue,
+      Value<bool>? isSettled,
+      Value<String>? syncStatus,
+      Value<DateTime>? createdAt,
+      Value<DateTime?>? updatedAt}) {
     return SplitEntryRecordsCompanion(
       id: id ?? this.id,
       uuid: uuid ?? this.uuid,
@@ -5685,197 +4808,129 @@ class $SettlementEntriesTable extends SettlementEntries
   static const VerificationMeta _idMeta = const VerificationMeta('id');
   @override
   late final GeneratedColumn<int> id = GeneratedColumn<int>(
-    'id',
-    aliasedName,
-    false,
-    hasAutoIncrement: true,
-    type: DriftSqlType.int,
-    requiredDuringInsert: false,
-    defaultConstraints: GeneratedColumn.constraintIsAlways(
-      'PRIMARY KEY AUTOINCREMENT',
-    ),
-  );
+      'id', aliasedName, false,
+      hasAutoIncrement: true,
+      type: DriftSqlType.int,
+      requiredDuringInsert: false,
+      defaultConstraints:
+          GeneratedColumn.constraintIsAlways('PRIMARY KEY AUTOINCREMENT'));
   static const VerificationMeta _uuidMeta = const VerificationMeta('uuid');
   @override
   late final GeneratedColumn<String> uuid = GeneratedColumn<String>(
-    'uuid',
-    aliasedName,
-    false,
-    type: DriftSqlType.string,
-    requiredDuringInsert: true,
-    defaultConstraints: GeneratedColumn.constraintIsAlways('UNIQUE'),
-  );
-  static const VerificationMeta _groupIdMeta = const VerificationMeta(
-    'groupId',
-  );
+      'uuid', aliasedName, false,
+      type: DriftSqlType.string,
+      requiredDuringInsert: true,
+      defaultConstraints: GeneratedColumn.constraintIsAlways('UNIQUE'));
+  static const VerificationMeta _groupIdMeta =
+      const VerificationMeta('groupId');
   @override
   late final GeneratedColumn<String> groupId = GeneratedColumn<String>(
-    'group_id',
-    aliasedName,
-    false,
-    type: DriftSqlType.string,
-    requiredDuringInsert: true,
-  );
-  static const VerificationMeta _fromUserIdMeta = const VerificationMeta(
-    'fromUserId',
-  );
+      'group_id', aliasedName, false,
+      type: DriftSqlType.string, requiredDuringInsert: true);
+  static const VerificationMeta _fromUserIdMeta =
+      const VerificationMeta('fromUserId');
   @override
   late final GeneratedColumn<String> fromUserId = GeneratedColumn<String>(
-    'from_user_id',
-    aliasedName,
-    false,
-    type: DriftSqlType.string,
-    requiredDuringInsert: true,
-  );
-  static const VerificationMeta _toUserIdMeta = const VerificationMeta(
-    'toUserId',
-  );
+      'from_user_id', aliasedName, false,
+      type: DriftSqlType.string, requiredDuringInsert: true);
+  static const VerificationMeta _toUserIdMeta =
+      const VerificationMeta('toUserId');
   @override
   late final GeneratedColumn<String> toUserId = GeneratedColumn<String>(
-    'to_user_id',
-    aliasedName,
-    false,
-    type: DriftSqlType.string,
-    requiredDuringInsert: true,
-  );
-  static const VerificationMeta _amountCentsMeta = const VerificationMeta(
-    'amountCents',
-  );
+      'to_user_id', aliasedName, false,
+      type: DriftSqlType.string, requiredDuringInsert: true);
+  static const VerificationMeta _amountCentsMeta =
+      const VerificationMeta('amountCents');
   @override
   late final GeneratedColumn<int> amountCents = GeneratedColumn<int>(
-    'amount_cents',
-    aliasedName,
-    false,
-    type: DriftSqlType.int,
-    requiredDuringInsert: true,
-  );
-  static const VerificationMeta _currencyCodeMeta = const VerificationMeta(
-    'currencyCode',
-  );
+      'amount_cents', aliasedName, false,
+      type: DriftSqlType.int, requiredDuringInsert: true);
+  static const VerificationMeta _currencyCodeMeta =
+      const VerificationMeta('currencyCode');
   @override
   late final GeneratedColumn<String> currencyCode = GeneratedColumn<String>(
-    'currency_code',
-    aliasedName,
-    false,
-    type: DriftSqlType.string,
-    requiredDuringInsert: false,
-    defaultValue: const Constant('INR'),
-  );
-  static const VerificationMeta _paymentMethodMeta = const VerificationMeta(
-    'paymentMethod',
-  );
+      'currency_code', aliasedName, false,
+      type: DriftSqlType.string,
+      requiredDuringInsert: false,
+      defaultValue: const Constant('INR'));
+  static const VerificationMeta _paymentMethodMeta =
+      const VerificationMeta('paymentMethod');
   @override
   late final GeneratedColumn<String> paymentMethod = GeneratedColumn<String>(
-    'payment_method',
-    aliasedName,
-    true,
-    type: DriftSqlType.string,
-    requiredDuringInsert: false,
-  );
-  static const VerificationMeta _paymentReferenceMeta = const VerificationMeta(
-    'paymentReference',
-  );
+      'payment_method', aliasedName, true,
+      type: DriftSqlType.string, requiredDuringInsert: false);
+  static const VerificationMeta _paymentReferenceMeta =
+      const VerificationMeta('paymentReference');
   @override
   late final GeneratedColumn<String> paymentReference = GeneratedColumn<String>(
-    'payment_reference',
-    aliasedName,
-    true,
-    type: DriftSqlType.string,
-    requiredDuringInsert: false,
-  );
+      'payment_reference', aliasedName, true,
+      type: DriftSqlType.string, requiredDuringInsert: false);
   static const VerificationMeta _notesMeta = const VerificationMeta('notes');
   @override
   late final GeneratedColumn<String> notes = GeneratedColumn<String>(
-    'notes',
-    aliasedName,
-    true,
-    type: DriftSqlType.string,
-    requiredDuringInsert: false,
-  );
+      'notes', aliasedName, true,
+      type: DriftSqlType.string, requiredDuringInsert: false);
   static const VerificationMeta _statusMeta = const VerificationMeta('status');
   @override
   late final GeneratedColumn<String> status = GeneratedColumn<String>(
-    'status',
-    aliasedName,
-    false,
-    type: DriftSqlType.string,
-    requiredDuringInsert: false,
-    defaultValue: const Constant('pending'),
-  );
-  static const VerificationMeta _settledAtMeta = const VerificationMeta(
-    'settledAt',
-  );
+      'status', aliasedName, false,
+      type: DriftSqlType.string,
+      requiredDuringInsert: false,
+      defaultValue: const Constant('pending'));
+  static const VerificationMeta _settledAtMeta =
+      const VerificationMeta('settledAt');
   @override
   late final GeneratedColumn<DateTime> settledAt = GeneratedColumn<DateTime>(
-    'settled_at',
-    aliasedName,
-    true,
-    type: DriftSqlType.dateTime,
-    requiredDuringInsert: false,
-  );
-  static const VerificationMeta _syncStatusMeta = const VerificationMeta(
-    'syncStatus',
-  );
+      'settled_at', aliasedName, true,
+      type: DriftSqlType.dateTime, requiredDuringInsert: false);
+  static const VerificationMeta _syncStatusMeta =
+      const VerificationMeta('syncStatus');
   @override
   late final GeneratedColumn<String> syncStatus = GeneratedColumn<String>(
-    'sync_status',
-    aliasedName,
-    false,
-    type: DriftSqlType.string,
-    requiredDuringInsert: false,
-    defaultValue: const Constant('pending'),
-  );
-  static const VerificationMeta _createdAtMeta = const VerificationMeta(
-    'createdAt',
-  );
+      'sync_status', aliasedName, false,
+      type: DriftSqlType.string,
+      requiredDuringInsert: false,
+      defaultValue: const Constant('pending'));
+  static const VerificationMeta _createdAtMeta =
+      const VerificationMeta('createdAt');
   @override
   late final GeneratedColumn<DateTime> createdAt = GeneratedColumn<DateTime>(
-    'created_at',
-    aliasedName,
-    false,
-    type: DriftSqlType.dateTime,
-    requiredDuringInsert: false,
-    defaultValue: currentDateAndTime,
-  );
-  static const VerificationMeta _updatedAtMeta = const VerificationMeta(
-    'updatedAt',
-  );
+      'created_at', aliasedName, false,
+      type: DriftSqlType.dateTime,
+      requiredDuringInsert: false,
+      defaultValue: currentDateAndTime);
+  static const VerificationMeta _updatedAtMeta =
+      const VerificationMeta('updatedAt');
   @override
   late final GeneratedColumn<DateTime> updatedAt = GeneratedColumn<DateTime>(
-    'updated_at',
-    aliasedName,
-    true,
-    type: DriftSqlType.dateTime,
-    requiredDuringInsert: false,
-  );
+      'updated_at', aliasedName, true,
+      type: DriftSqlType.dateTime, requiredDuringInsert: false);
   @override
   List<GeneratedColumn> get $columns => [
-    id,
-    uuid,
-    groupId,
-    fromUserId,
-    toUserId,
-    amountCents,
-    currencyCode,
-    paymentMethod,
-    paymentReference,
-    notes,
-    status,
-    settledAt,
-    syncStatus,
-    createdAt,
-    updatedAt,
-  ];
+        id,
+        uuid,
+        groupId,
+        fromUserId,
+        toUserId,
+        amountCents,
+        currencyCode,
+        paymentMethod,
+        paymentReference,
+        notes,
+        status,
+        settledAt,
+        syncStatus,
+        createdAt,
+        updatedAt
+      ];
   @override
   String get aliasedName => _alias ?? actualTableName;
   @override
   String get actualTableName => $name;
   static const String $name = 'settlement_entries';
   @override
-  VerificationContext validateIntegrity(
-    Insertable<SettlementEntry> instance, {
-    bool isInserting = false,
-  }) {
+  VerificationContext validateIntegrity(Insertable<SettlementEntry> instance,
+      {bool isInserting = false}) {
     final context = VerificationContext();
     final data = instance.toColumns(true);
     if (data.containsKey('id')) {
@@ -5883,112 +4938,81 @@ class $SettlementEntriesTable extends SettlementEntries
     }
     if (data.containsKey('uuid')) {
       context.handle(
-        _uuidMeta,
-        uuid.isAcceptableOrUnknown(data['uuid']!, _uuidMeta),
-      );
+          _uuidMeta, uuid.isAcceptableOrUnknown(data['uuid']!, _uuidMeta));
     } else if (isInserting) {
       context.missing(_uuidMeta);
     }
     if (data.containsKey('group_id')) {
-      context.handle(
-        _groupIdMeta,
-        groupId.isAcceptableOrUnknown(data['group_id']!, _groupIdMeta),
-      );
+      context.handle(_groupIdMeta,
+          groupId.isAcceptableOrUnknown(data['group_id']!, _groupIdMeta));
     } else if (isInserting) {
       context.missing(_groupIdMeta);
     }
     if (data.containsKey('from_user_id')) {
       context.handle(
-        _fromUserIdMeta,
-        fromUserId.isAcceptableOrUnknown(
-          data['from_user_id']!,
           _fromUserIdMeta,
-        ),
-      );
+          fromUserId.isAcceptableOrUnknown(
+              data['from_user_id']!, _fromUserIdMeta));
     } else if (isInserting) {
       context.missing(_fromUserIdMeta);
     }
     if (data.containsKey('to_user_id')) {
-      context.handle(
-        _toUserIdMeta,
-        toUserId.isAcceptableOrUnknown(data['to_user_id']!, _toUserIdMeta),
-      );
+      context.handle(_toUserIdMeta,
+          toUserId.isAcceptableOrUnknown(data['to_user_id']!, _toUserIdMeta));
     } else if (isInserting) {
       context.missing(_toUserIdMeta);
     }
     if (data.containsKey('amount_cents')) {
       context.handle(
-        _amountCentsMeta,
-        amountCents.isAcceptableOrUnknown(
-          data['amount_cents']!,
           _amountCentsMeta,
-        ),
-      );
+          amountCents.isAcceptableOrUnknown(
+              data['amount_cents']!, _amountCentsMeta));
     } else if (isInserting) {
       context.missing(_amountCentsMeta);
     }
     if (data.containsKey('currency_code')) {
       context.handle(
-        _currencyCodeMeta,
-        currencyCode.isAcceptableOrUnknown(
-          data['currency_code']!,
           _currencyCodeMeta,
-        ),
-      );
+          currencyCode.isAcceptableOrUnknown(
+              data['currency_code']!, _currencyCodeMeta));
     }
     if (data.containsKey('payment_method')) {
       context.handle(
-        _paymentMethodMeta,
-        paymentMethod.isAcceptableOrUnknown(
-          data['payment_method']!,
           _paymentMethodMeta,
-        ),
-      );
+          paymentMethod.isAcceptableOrUnknown(
+              data['payment_method']!, _paymentMethodMeta));
     }
     if (data.containsKey('payment_reference')) {
       context.handle(
-        _paymentReferenceMeta,
-        paymentReference.isAcceptableOrUnknown(
-          data['payment_reference']!,
           _paymentReferenceMeta,
-        ),
-      );
+          paymentReference.isAcceptableOrUnknown(
+              data['payment_reference']!, _paymentReferenceMeta));
     }
     if (data.containsKey('notes')) {
       context.handle(
-        _notesMeta,
-        notes.isAcceptableOrUnknown(data['notes']!, _notesMeta),
-      );
+          _notesMeta, notes.isAcceptableOrUnknown(data['notes']!, _notesMeta));
     }
     if (data.containsKey('status')) {
-      context.handle(
-        _statusMeta,
-        status.isAcceptableOrUnknown(data['status']!, _statusMeta),
-      );
+      context.handle(_statusMeta,
+          status.isAcceptableOrUnknown(data['status']!, _statusMeta));
     }
     if (data.containsKey('settled_at')) {
-      context.handle(
-        _settledAtMeta,
-        settledAt.isAcceptableOrUnknown(data['settled_at']!, _settledAtMeta),
-      );
+      context.handle(_settledAtMeta,
+          settledAt.isAcceptableOrUnknown(data['settled_at']!, _settledAtMeta));
     }
     if (data.containsKey('sync_status')) {
       context.handle(
-        _syncStatusMeta,
-        syncStatus.isAcceptableOrUnknown(data['sync_status']!, _syncStatusMeta),
-      );
+          _syncStatusMeta,
+          syncStatus.isAcceptableOrUnknown(
+              data['sync_status']!, _syncStatusMeta));
     }
     if (data.containsKey('created_at')) {
-      context.handle(
-        _createdAtMeta,
-        createdAt.isAcceptableOrUnknown(data['created_at']!, _createdAtMeta),
-      );
+      context.handle(_createdAtMeta,
+          createdAt.isAcceptableOrUnknown(data['created_at']!, _createdAtMeta));
     }
     if (data.containsKey('updated_at')) {
-      context.handle(
-        _updatedAtMeta,
-        updatedAt.isAcceptableOrUnknown(data['updated_at']!, _updatedAtMeta),
-      );
+      context.handle(_updatedAtMeta,
+          updatedAt.isAcceptableOrUnknown(data['updated_at']!, _updatedAtMeta));
     }
     return context;
   }
@@ -5999,66 +5023,36 @@ class $SettlementEntriesTable extends SettlementEntries
   SettlementEntry map(Map<String, dynamic> data, {String? tablePrefix}) {
     final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
     return SettlementEntry(
-      id: attachedDatabase.typeMapping.read(
-        DriftSqlType.int,
-        data['${effectivePrefix}id'],
-      )!,
-      uuid: attachedDatabase.typeMapping.read(
-        DriftSqlType.string,
-        data['${effectivePrefix}uuid'],
-      )!,
-      groupId: attachedDatabase.typeMapping.read(
-        DriftSqlType.string,
-        data['${effectivePrefix}group_id'],
-      )!,
-      fromUserId: attachedDatabase.typeMapping.read(
-        DriftSqlType.string,
-        data['${effectivePrefix}from_user_id'],
-      )!,
-      toUserId: attachedDatabase.typeMapping.read(
-        DriftSqlType.string,
-        data['${effectivePrefix}to_user_id'],
-      )!,
-      amountCents: attachedDatabase.typeMapping.read(
-        DriftSqlType.int,
-        data['${effectivePrefix}amount_cents'],
-      )!,
-      currencyCode: attachedDatabase.typeMapping.read(
-        DriftSqlType.string,
-        data['${effectivePrefix}currency_code'],
-      )!,
-      paymentMethod: attachedDatabase.typeMapping.read(
-        DriftSqlType.string,
-        data['${effectivePrefix}payment_method'],
-      ),
+      id: attachedDatabase.typeMapping
+          .read(DriftSqlType.int, data['${effectivePrefix}id'])!,
+      uuid: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}uuid'])!,
+      groupId: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}group_id'])!,
+      fromUserId: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}from_user_id'])!,
+      toUserId: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}to_user_id'])!,
+      amountCents: attachedDatabase.typeMapping
+          .read(DriftSqlType.int, data['${effectivePrefix}amount_cents'])!,
+      currencyCode: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}currency_code'])!,
+      paymentMethod: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}payment_method']),
       paymentReference: attachedDatabase.typeMapping.read(
-        DriftSqlType.string,
-        data['${effectivePrefix}payment_reference'],
-      ),
-      notes: attachedDatabase.typeMapping.read(
-        DriftSqlType.string,
-        data['${effectivePrefix}notes'],
-      ),
-      status: attachedDatabase.typeMapping.read(
-        DriftSqlType.string,
-        data['${effectivePrefix}status'],
-      )!,
-      settledAt: attachedDatabase.typeMapping.read(
-        DriftSqlType.dateTime,
-        data['${effectivePrefix}settled_at'],
-      ),
-      syncStatus: attachedDatabase.typeMapping.read(
-        DriftSqlType.string,
-        data['${effectivePrefix}sync_status'],
-      )!,
-      createdAt: attachedDatabase.typeMapping.read(
-        DriftSqlType.dateTime,
-        data['${effectivePrefix}created_at'],
-      )!,
-      updatedAt: attachedDatabase.typeMapping.read(
-        DriftSqlType.dateTime,
-        data['${effectivePrefix}updated_at'],
-      ),
+          DriftSqlType.string, data['${effectivePrefix}payment_reference']),
+      notes: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}notes']),
+      status: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}status'])!,
+      settledAt: attachedDatabase.typeMapping
+          .read(DriftSqlType.dateTime, data['${effectivePrefix}settled_at']),
+      syncStatus: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}sync_status'])!,
+      createdAt: attachedDatabase.typeMapping
+          .read(DriftSqlType.dateTime, data['${effectivePrefix}created_at'])!,
+      updatedAt: attachedDatabase.typeMapping
+          .read(DriftSqlType.dateTime, data['${effectivePrefix}updated_at']),
     );
   }
 
@@ -6075,6 +5069,8 @@ class SettlementEntry extends DataClass implements Insertable<SettlementEntry> {
   final String fromUserId;
   final String toUserId;
   final int amountCents;
+
+  /// Currency code for the settlement.
   final String currencyCode;
   final String? paymentMethod;
   final String? paymentReference;
@@ -6084,23 +5080,22 @@ class SettlementEntry extends DataClass implements Insertable<SettlementEntry> {
   final String syncStatus;
   final DateTime createdAt;
   final DateTime? updatedAt;
-  const SettlementEntry({
-    required this.id,
-    required this.uuid,
-    required this.groupId,
-    required this.fromUserId,
-    required this.toUserId,
-    required this.amountCents,
-    required this.currencyCode,
-    this.paymentMethod,
-    this.paymentReference,
-    this.notes,
-    required this.status,
-    this.settledAt,
-    required this.syncStatus,
-    required this.createdAt,
-    this.updatedAt,
-  });
+  const SettlementEntry(
+      {required this.id,
+      required this.uuid,
+      required this.groupId,
+      required this.fromUserId,
+      required this.toUserId,
+      required this.amountCents,
+      required this.currencyCode,
+      this.paymentMethod,
+      this.paymentReference,
+      this.notes,
+      required this.status,
+      this.settledAt,
+      required this.syncStatus,
+      required this.createdAt,
+      this.updatedAt});
   @override
   Map<String, Expression> toColumns(bool nullToAbsent) {
     final map = <String, Expression>{};
@@ -6147,9 +5142,8 @@ class SettlementEntry extends DataClass implements Insertable<SettlementEntry> {
       paymentReference: paymentReference == null && nullToAbsent
           ? const Value.absent()
           : Value(paymentReference),
-      notes: notes == null && nullToAbsent
-          ? const Value.absent()
-          : Value(notes),
+      notes:
+          notes == null && nullToAbsent ? const Value.absent() : Value(notes),
       status: Value(status),
       settledAt: settledAt == null && nullToAbsent
           ? const Value.absent()
@@ -6162,10 +5156,8 @@ class SettlementEntry extends DataClass implements Insertable<SettlementEntry> {
     );
   }
 
-  factory SettlementEntry.fromJson(
-    Map<String, dynamic> json, {
-    ValueSerializer? serializer,
-  }) {
+  factory SettlementEntry.fromJson(Map<String, dynamic> json,
+      {ValueSerializer? serializer}) {
     serializer ??= driftRuntimeOptions.defaultSerializer;
     return SettlementEntry(
       id: serializer.fromJson<int>(json['id']),
@@ -6207,55 +5199,52 @@ class SettlementEntry extends DataClass implements Insertable<SettlementEntry> {
     };
   }
 
-  SettlementEntry copyWith({
-    int? id,
-    String? uuid,
-    String? groupId,
-    String? fromUserId,
-    String? toUserId,
-    int? amountCents,
-    String? currencyCode,
-    Value<String?> paymentMethod = const Value.absent(),
-    Value<String?> paymentReference = const Value.absent(),
-    Value<String?> notes = const Value.absent(),
-    String? status,
-    Value<DateTime?> settledAt = const Value.absent(),
-    String? syncStatus,
-    DateTime? createdAt,
-    Value<DateTime?> updatedAt = const Value.absent(),
-  }) => SettlementEntry(
-    id: id ?? this.id,
-    uuid: uuid ?? this.uuid,
-    groupId: groupId ?? this.groupId,
-    fromUserId: fromUserId ?? this.fromUserId,
-    toUserId: toUserId ?? this.toUserId,
-    amountCents: amountCents ?? this.amountCents,
-    currencyCode: currencyCode ?? this.currencyCode,
-    paymentMethod: paymentMethod.present
-        ? paymentMethod.value
-        : this.paymentMethod,
-    paymentReference: paymentReference.present
-        ? paymentReference.value
-        : this.paymentReference,
-    notes: notes.present ? notes.value : this.notes,
-    status: status ?? this.status,
-    settledAt: settledAt.present ? settledAt.value : this.settledAt,
-    syncStatus: syncStatus ?? this.syncStatus,
-    createdAt: createdAt ?? this.createdAt,
-    updatedAt: updatedAt.present ? updatedAt.value : this.updatedAt,
-  );
+  SettlementEntry copyWith(
+          {int? id,
+          String? uuid,
+          String? groupId,
+          String? fromUserId,
+          String? toUserId,
+          int? amountCents,
+          String? currencyCode,
+          Value<String?> paymentMethod = const Value.absent(),
+          Value<String?> paymentReference = const Value.absent(),
+          Value<String?> notes = const Value.absent(),
+          String? status,
+          Value<DateTime?> settledAt = const Value.absent(),
+          String? syncStatus,
+          DateTime? createdAt,
+          Value<DateTime?> updatedAt = const Value.absent()}) =>
+      SettlementEntry(
+        id: id ?? this.id,
+        uuid: uuid ?? this.uuid,
+        groupId: groupId ?? this.groupId,
+        fromUserId: fromUserId ?? this.fromUserId,
+        toUserId: toUserId ?? this.toUserId,
+        amountCents: amountCents ?? this.amountCents,
+        currencyCode: currencyCode ?? this.currencyCode,
+        paymentMethod:
+            paymentMethod.present ? paymentMethod.value : this.paymentMethod,
+        paymentReference: paymentReference.present
+            ? paymentReference.value
+            : this.paymentReference,
+        notes: notes.present ? notes.value : this.notes,
+        status: status ?? this.status,
+        settledAt: settledAt.present ? settledAt.value : this.settledAt,
+        syncStatus: syncStatus ?? this.syncStatus,
+        createdAt: createdAt ?? this.createdAt,
+        updatedAt: updatedAt.present ? updatedAt.value : this.updatedAt,
+      );
   SettlementEntry copyWithCompanion(SettlementEntriesCompanion data) {
     return SettlementEntry(
       id: data.id.present ? data.id.value : this.id,
       uuid: data.uuid.present ? data.uuid.value : this.uuid,
       groupId: data.groupId.present ? data.groupId.value : this.groupId,
-      fromUserId: data.fromUserId.present
-          ? data.fromUserId.value
-          : this.fromUserId,
+      fromUserId:
+          data.fromUserId.present ? data.fromUserId.value : this.fromUserId,
       toUserId: data.toUserId.present ? data.toUserId.value : this.toUserId,
-      amountCents: data.amountCents.present
-          ? data.amountCents.value
-          : this.amountCents,
+      amountCents:
+          data.amountCents.present ? data.amountCents.value : this.amountCents,
       currencyCode: data.currencyCode.present
           ? data.currencyCode.value
           : this.currencyCode,
@@ -6268,9 +5257,8 @@ class SettlementEntry extends DataClass implements Insertable<SettlementEntry> {
       notes: data.notes.present ? data.notes.value : this.notes,
       status: data.status.present ? data.status.value : this.status,
       settledAt: data.settledAt.present ? data.settledAt.value : this.settledAt,
-      syncStatus: data.syncStatus.present
-          ? data.syncStatus.value
-          : this.syncStatus,
+      syncStatus:
+          data.syncStatus.present ? data.syncStatus.value : this.syncStatus,
       createdAt: data.createdAt.present ? data.createdAt.value : this.createdAt,
       updatedAt: data.updatedAt.present ? data.updatedAt.value : this.updatedAt,
     );
@@ -6300,22 +5288,21 @@ class SettlementEntry extends DataClass implements Insertable<SettlementEntry> {
 
   @override
   int get hashCode => Object.hash(
-    id,
-    uuid,
-    groupId,
-    fromUserId,
-    toUserId,
-    amountCents,
-    currencyCode,
-    paymentMethod,
-    paymentReference,
-    notes,
-    status,
-    settledAt,
-    syncStatus,
-    createdAt,
-    updatedAt,
-  );
+      id,
+      uuid,
+      groupId,
+      fromUserId,
+      toUserId,
+      amountCents,
+      currencyCode,
+      paymentMethod,
+      paymentReference,
+      notes,
+      status,
+      settledAt,
+      syncStatus,
+      createdAt,
+      updatedAt);
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
@@ -6386,11 +5373,11 @@ class SettlementEntriesCompanion extends UpdateCompanion<SettlementEntry> {
     this.syncStatus = const Value.absent(),
     this.createdAt = const Value.absent(),
     this.updatedAt = const Value.absent(),
-  }) : uuid = Value(uuid),
-       groupId = Value(groupId),
-       fromUserId = Value(fromUserId),
-       toUserId = Value(toUserId),
-       amountCents = Value(amountCents);
+  })  : uuid = Value(uuid),
+        groupId = Value(groupId),
+        fromUserId = Value(fromUserId),
+        toUserId = Value(toUserId),
+        amountCents = Value(amountCents);
   static Insertable<SettlementEntry> custom({
     Expression<int>? id,
     Expression<String>? uuid,
@@ -6427,23 +5414,22 @@ class SettlementEntriesCompanion extends UpdateCompanion<SettlementEntry> {
     });
   }
 
-  SettlementEntriesCompanion copyWith({
-    Value<int>? id,
-    Value<String>? uuid,
-    Value<String>? groupId,
-    Value<String>? fromUserId,
-    Value<String>? toUserId,
-    Value<int>? amountCents,
-    Value<String>? currencyCode,
-    Value<String?>? paymentMethod,
-    Value<String?>? paymentReference,
-    Value<String?>? notes,
-    Value<String>? status,
-    Value<DateTime?>? settledAt,
-    Value<String>? syncStatus,
-    Value<DateTime>? createdAt,
-    Value<DateTime?>? updatedAt,
-  }) {
+  SettlementEntriesCompanion copyWith(
+      {Value<int>? id,
+      Value<String>? uuid,
+      Value<String>? groupId,
+      Value<String>? fromUserId,
+      Value<String>? toUserId,
+      Value<int>? amountCents,
+      Value<String>? currencyCode,
+      Value<String?>? paymentMethod,
+      Value<String?>? paymentReference,
+      Value<String?>? notes,
+      Value<String>? status,
+      Value<DateTime?>? settledAt,
+      Value<String>? syncStatus,
+      Value<DateTime>? createdAt,
+      Value<DateTime?>? updatedAt}) {
     return SettlementEntriesCompanion(
       id: id ?? this.id,
       uuid: uuid ?? this.uuid,
@@ -6546,166 +5532,110 @@ class $OutboxEntriesTable extends OutboxEntries
   static const VerificationMeta _idMeta = const VerificationMeta('id');
   @override
   late final GeneratedColumn<int> id = GeneratedColumn<int>(
-    'id',
-    aliasedName,
-    false,
-    hasAutoIncrement: true,
-    type: DriftSqlType.int,
-    requiredDuringInsert: false,
-    defaultConstraints: GeneratedColumn.constraintIsAlways(
-      'PRIMARY KEY AUTOINCREMENT',
-    ),
-  );
-  static const VerificationMeta _operationIdMeta = const VerificationMeta(
-    'operationId',
-  );
+      'id', aliasedName, false,
+      hasAutoIncrement: true,
+      type: DriftSqlType.int,
+      requiredDuringInsert: false,
+      defaultConstraints:
+          GeneratedColumn.constraintIsAlways('PRIMARY KEY AUTOINCREMENT'));
+  static const VerificationMeta _operationIdMeta =
+      const VerificationMeta('operationId');
   @override
   late final GeneratedColumn<String> operationId = GeneratedColumn<String>(
-    'operation_id',
-    aliasedName,
-    false,
-    type: DriftSqlType.string,
-    requiredDuringInsert: true,
-    defaultConstraints: GeneratedColumn.constraintIsAlways('UNIQUE'),
-  );
-  static const VerificationMeta _entityTypeMeta = const VerificationMeta(
-    'entityType',
-  );
+      'operation_id', aliasedName, false,
+      type: DriftSqlType.string,
+      requiredDuringInsert: true,
+      defaultConstraints: GeneratedColumn.constraintIsAlways('UNIQUE'));
+  static const VerificationMeta _entityTypeMeta =
+      const VerificationMeta('entityType');
   @override
   late final GeneratedColumn<String> entityType = GeneratedColumn<String>(
-    'entity_type',
-    aliasedName,
-    false,
-    type: DriftSqlType.string,
-    requiredDuringInsert: true,
-  );
-  static const VerificationMeta _entityIdMeta = const VerificationMeta(
-    'entityId',
-  );
+      'entity_type', aliasedName, false,
+      type: DriftSqlType.string, requiredDuringInsert: true);
+  static const VerificationMeta _entityIdMeta =
+      const VerificationMeta('entityId');
   @override
   late final GeneratedColumn<String> entityId = GeneratedColumn<String>(
-    'entity_id',
-    aliasedName,
-    false,
-    type: DriftSqlType.string,
-    requiredDuringInsert: true,
-  );
-  static const VerificationMeta _operationTypeMeta = const VerificationMeta(
-    'operationType',
-  );
+      'entity_id', aliasedName, false,
+      type: DriftSqlType.string, requiredDuringInsert: true);
+  static const VerificationMeta _operationTypeMeta =
+      const VerificationMeta('operationType');
   @override
   late final GeneratedColumn<String> operationType = GeneratedColumn<String>(
-    'operation_type',
-    aliasedName,
-    false,
-    type: DriftSqlType.string,
-    requiredDuringInsert: true,
-  );
-  static const VerificationMeta _payloadMeta = const VerificationMeta(
-    'payload',
-  );
+      'operation_type', aliasedName, false,
+      type: DriftSqlType.string, requiredDuringInsert: true);
+  static const VerificationMeta _payloadMeta =
+      const VerificationMeta('payload');
   @override
   late final GeneratedColumn<String> payload = GeneratedColumn<String>(
-    'payload',
-    aliasedName,
-    false,
-    type: DriftSqlType.string,
-    requiredDuringInsert: true,
-  );
-  static const VerificationMeta _priorityMeta = const VerificationMeta(
-    'priority',
-  );
+      'payload', aliasedName, false,
+      type: DriftSqlType.string, requiredDuringInsert: true);
+  static const VerificationMeta _priorityMeta =
+      const VerificationMeta('priority');
   @override
   late final GeneratedColumn<int> priority = GeneratedColumn<int>(
-    'priority',
-    aliasedName,
-    false,
-    type: DriftSqlType.int,
-    requiredDuringInsert: false,
-    defaultValue: const Constant(1),
-  );
+      'priority', aliasedName, false,
+      type: DriftSqlType.int,
+      requiredDuringInsert: false,
+      defaultValue: const Constant(1));
   static const VerificationMeta _statusMeta = const VerificationMeta('status');
   @override
   late final GeneratedColumn<String> status = GeneratedColumn<String>(
-    'status',
-    aliasedName,
-    false,
-    type: DriftSqlType.string,
-    requiredDuringInsert: false,
-    defaultValue: const Constant('pending'),
-  );
-  static const VerificationMeta _retryCountMeta = const VerificationMeta(
-    'retryCount',
-  );
+      'status', aliasedName, false,
+      type: DriftSqlType.string,
+      requiredDuringInsert: false,
+      defaultValue: const Constant('pending'));
+  static const VerificationMeta _retryCountMeta =
+      const VerificationMeta('retryCount');
   @override
   late final GeneratedColumn<int> retryCount = GeneratedColumn<int>(
-    'retry_count',
-    aliasedName,
-    false,
-    type: DriftSqlType.int,
-    requiredDuringInsert: false,
-    defaultValue: const Constant(0),
-  );
-  static const VerificationMeta _lastErrorMeta = const VerificationMeta(
-    'lastError',
-  );
+      'retry_count', aliasedName, false,
+      type: DriftSqlType.int,
+      requiredDuringInsert: false,
+      defaultValue: const Constant(0));
+  static const VerificationMeta _lastErrorMeta =
+      const VerificationMeta('lastError');
   @override
   late final GeneratedColumn<String> lastError = GeneratedColumn<String>(
-    'last_error',
-    aliasedName,
-    true,
-    type: DriftSqlType.string,
-    requiredDuringInsert: false,
-  );
-  static const VerificationMeta _createdAtMeta = const VerificationMeta(
-    'createdAt',
-  );
+      'last_error', aliasedName, true,
+      type: DriftSqlType.string, requiredDuringInsert: false);
+  static const VerificationMeta _createdAtMeta =
+      const VerificationMeta('createdAt');
   @override
   late final GeneratedColumn<DateTime> createdAt = GeneratedColumn<DateTime>(
-    'created_at',
-    aliasedName,
-    false,
-    type: DriftSqlType.dateTime,
-    requiredDuringInsert: false,
-    defaultValue: currentDateAndTime,
-  );
-  static const VerificationMeta _lastAttemptAtMeta = const VerificationMeta(
-    'lastAttemptAt',
-  );
+      'created_at', aliasedName, false,
+      type: DriftSqlType.dateTime,
+      requiredDuringInsert: false,
+      defaultValue: currentDateAndTime);
+  static const VerificationMeta _lastAttemptAtMeta =
+      const VerificationMeta('lastAttemptAt');
   @override
   late final GeneratedColumn<DateTime> lastAttemptAt =
-      GeneratedColumn<DateTime>(
-        'last_attempt_at',
-        aliasedName,
-        true,
-        type: DriftSqlType.dateTime,
-        requiredDuringInsert: false,
-      );
+      GeneratedColumn<DateTime>('last_attempt_at', aliasedName, true,
+          type: DriftSqlType.dateTime, requiredDuringInsert: false);
   @override
   List<GeneratedColumn> get $columns => [
-    id,
-    operationId,
-    entityType,
-    entityId,
-    operationType,
-    payload,
-    priority,
-    status,
-    retryCount,
-    lastError,
-    createdAt,
-    lastAttemptAt,
-  ];
+        id,
+        operationId,
+        entityType,
+        entityId,
+        operationType,
+        payload,
+        priority,
+        status,
+        retryCount,
+        lastError,
+        createdAt,
+        lastAttemptAt
+      ];
   @override
   String get aliasedName => _alias ?? actualTableName;
   @override
   String get actualTableName => $name;
   static const String $name = 'outbox_entries';
   @override
-  VerificationContext validateIntegrity(
-    Insertable<OutboxEntry> instance, {
-    bool isInserting = false,
-  }) {
+  VerificationContext validateIntegrity(Insertable<OutboxEntry> instance,
+      {bool isInserting = false}) {
     final context = VerificationContext();
     final data = instance.toColumns(true);
     if (data.containsKey('id')) {
@@ -6713,88 +5643,67 @@ class $OutboxEntriesTable extends OutboxEntries
     }
     if (data.containsKey('operation_id')) {
       context.handle(
-        _operationIdMeta,
-        operationId.isAcceptableOrUnknown(
-          data['operation_id']!,
           _operationIdMeta,
-        ),
-      );
+          operationId.isAcceptableOrUnknown(
+              data['operation_id']!, _operationIdMeta));
     } else if (isInserting) {
       context.missing(_operationIdMeta);
     }
     if (data.containsKey('entity_type')) {
       context.handle(
-        _entityTypeMeta,
-        entityType.isAcceptableOrUnknown(data['entity_type']!, _entityTypeMeta),
-      );
+          _entityTypeMeta,
+          entityType.isAcceptableOrUnknown(
+              data['entity_type']!, _entityTypeMeta));
     } else if (isInserting) {
       context.missing(_entityTypeMeta);
     }
     if (data.containsKey('entity_id')) {
-      context.handle(
-        _entityIdMeta,
-        entityId.isAcceptableOrUnknown(data['entity_id']!, _entityIdMeta),
-      );
+      context.handle(_entityIdMeta,
+          entityId.isAcceptableOrUnknown(data['entity_id']!, _entityIdMeta));
     } else if (isInserting) {
       context.missing(_entityIdMeta);
     }
     if (data.containsKey('operation_type')) {
       context.handle(
-        _operationTypeMeta,
-        operationType.isAcceptableOrUnknown(
-          data['operation_type']!,
           _operationTypeMeta,
-        ),
-      );
+          operationType.isAcceptableOrUnknown(
+              data['operation_type']!, _operationTypeMeta));
     } else if (isInserting) {
       context.missing(_operationTypeMeta);
     }
     if (data.containsKey('payload')) {
-      context.handle(
-        _payloadMeta,
-        payload.isAcceptableOrUnknown(data['payload']!, _payloadMeta),
-      );
+      context.handle(_payloadMeta,
+          payload.isAcceptableOrUnknown(data['payload']!, _payloadMeta));
     } else if (isInserting) {
       context.missing(_payloadMeta);
     }
     if (data.containsKey('priority')) {
-      context.handle(
-        _priorityMeta,
-        priority.isAcceptableOrUnknown(data['priority']!, _priorityMeta),
-      );
+      context.handle(_priorityMeta,
+          priority.isAcceptableOrUnknown(data['priority']!, _priorityMeta));
     }
     if (data.containsKey('status')) {
-      context.handle(
-        _statusMeta,
-        status.isAcceptableOrUnknown(data['status']!, _statusMeta),
-      );
+      context.handle(_statusMeta,
+          status.isAcceptableOrUnknown(data['status']!, _statusMeta));
     }
     if (data.containsKey('retry_count')) {
       context.handle(
-        _retryCountMeta,
-        retryCount.isAcceptableOrUnknown(data['retry_count']!, _retryCountMeta),
-      );
+          _retryCountMeta,
+          retryCount.isAcceptableOrUnknown(
+              data['retry_count']!, _retryCountMeta));
     }
     if (data.containsKey('last_error')) {
-      context.handle(
-        _lastErrorMeta,
-        lastError.isAcceptableOrUnknown(data['last_error']!, _lastErrorMeta),
-      );
+      context.handle(_lastErrorMeta,
+          lastError.isAcceptableOrUnknown(data['last_error']!, _lastErrorMeta));
     }
     if (data.containsKey('created_at')) {
-      context.handle(
-        _createdAtMeta,
-        createdAt.isAcceptableOrUnknown(data['created_at']!, _createdAtMeta),
-      );
+      context.handle(_createdAtMeta,
+          createdAt.isAcceptableOrUnknown(data['created_at']!, _createdAtMeta));
     }
     if (data.containsKey('last_attempt_at')) {
       context.handle(
-        _lastAttemptAtMeta,
-        lastAttemptAt.isAcceptableOrUnknown(
-          data['last_attempt_at']!,
           _lastAttemptAtMeta,
-        ),
-      );
+          lastAttemptAt.isAcceptableOrUnknown(
+              data['last_attempt_at']!, _lastAttemptAtMeta));
     }
     return context;
   }
@@ -6805,54 +5714,30 @@ class $OutboxEntriesTable extends OutboxEntries
   OutboxEntry map(Map<String, dynamic> data, {String? tablePrefix}) {
     final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
     return OutboxEntry(
-      id: attachedDatabase.typeMapping.read(
-        DriftSqlType.int,
-        data['${effectivePrefix}id'],
-      )!,
-      operationId: attachedDatabase.typeMapping.read(
-        DriftSqlType.string,
-        data['${effectivePrefix}operation_id'],
-      )!,
-      entityType: attachedDatabase.typeMapping.read(
-        DriftSqlType.string,
-        data['${effectivePrefix}entity_type'],
-      )!,
-      entityId: attachedDatabase.typeMapping.read(
-        DriftSqlType.string,
-        data['${effectivePrefix}entity_id'],
-      )!,
-      operationType: attachedDatabase.typeMapping.read(
-        DriftSqlType.string,
-        data['${effectivePrefix}operation_type'],
-      )!,
-      payload: attachedDatabase.typeMapping.read(
-        DriftSqlType.string,
-        data['${effectivePrefix}payload'],
-      )!,
-      priority: attachedDatabase.typeMapping.read(
-        DriftSqlType.int,
-        data['${effectivePrefix}priority'],
-      )!,
-      status: attachedDatabase.typeMapping.read(
-        DriftSqlType.string,
-        data['${effectivePrefix}status'],
-      )!,
-      retryCount: attachedDatabase.typeMapping.read(
-        DriftSqlType.int,
-        data['${effectivePrefix}retry_count'],
-      )!,
-      lastError: attachedDatabase.typeMapping.read(
-        DriftSqlType.string,
-        data['${effectivePrefix}last_error'],
-      ),
-      createdAt: attachedDatabase.typeMapping.read(
-        DriftSqlType.dateTime,
-        data['${effectivePrefix}created_at'],
-      )!,
+      id: attachedDatabase.typeMapping
+          .read(DriftSqlType.int, data['${effectivePrefix}id'])!,
+      operationId: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}operation_id'])!,
+      entityType: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}entity_type'])!,
+      entityId: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}entity_id'])!,
+      operationType: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}operation_type'])!,
+      payload: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}payload'])!,
+      priority: attachedDatabase.typeMapping
+          .read(DriftSqlType.int, data['${effectivePrefix}priority'])!,
+      status: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}status'])!,
+      retryCount: attachedDatabase.typeMapping
+          .read(DriftSqlType.int, data['${effectivePrefix}retry_count'])!,
+      lastError: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}last_error']),
+      createdAt: attachedDatabase.typeMapping
+          .read(DriftSqlType.dateTime, data['${effectivePrefix}created_at'])!,
       lastAttemptAt: attachedDatabase.typeMapping.read(
-        DriftSqlType.dateTime,
-        data['${effectivePrefix}last_attempt_at'],
-      ),
+          DriftSqlType.dateTime, data['${effectivePrefix}last_attempt_at']),
     );
   }
 
@@ -6875,20 +5760,19 @@ class OutboxEntry extends DataClass implements Insertable<OutboxEntry> {
   final String? lastError;
   final DateTime createdAt;
   final DateTime? lastAttemptAt;
-  const OutboxEntry({
-    required this.id,
-    required this.operationId,
-    required this.entityType,
-    required this.entityId,
-    required this.operationType,
-    required this.payload,
-    required this.priority,
-    required this.status,
-    required this.retryCount,
-    this.lastError,
-    required this.createdAt,
-    this.lastAttemptAt,
-  });
+  const OutboxEntry(
+      {required this.id,
+      required this.operationId,
+      required this.entityType,
+      required this.entityId,
+      required this.operationType,
+      required this.payload,
+      required this.priority,
+      required this.status,
+      required this.retryCount,
+      this.lastError,
+      required this.createdAt,
+      this.lastAttemptAt});
   @override
   Map<String, Expression> toColumns(bool nullToAbsent) {
     final map = <String, Expression>{};
@@ -6932,10 +5816,8 @@ class OutboxEntry extends DataClass implements Insertable<OutboxEntry> {
     );
   }
 
-  factory OutboxEntry.fromJson(
-    Map<String, dynamic> json, {
-    ValueSerializer? serializer,
-  }) {
+  factory OutboxEntry.fromJson(Map<String, dynamic> json,
+      {ValueSerializer? serializer}) {
     serializer ??= driftRuntimeOptions.defaultSerializer;
     return OutboxEntry(
       id: serializer.fromJson<int>(json['id']),
@@ -6971,44 +5853,41 @@ class OutboxEntry extends DataClass implements Insertable<OutboxEntry> {
     };
   }
 
-  OutboxEntry copyWith({
-    int? id,
-    String? operationId,
-    String? entityType,
-    String? entityId,
-    String? operationType,
-    String? payload,
-    int? priority,
-    String? status,
-    int? retryCount,
-    Value<String?> lastError = const Value.absent(),
-    DateTime? createdAt,
-    Value<DateTime?> lastAttemptAt = const Value.absent(),
-  }) => OutboxEntry(
-    id: id ?? this.id,
-    operationId: operationId ?? this.operationId,
-    entityType: entityType ?? this.entityType,
-    entityId: entityId ?? this.entityId,
-    operationType: operationType ?? this.operationType,
-    payload: payload ?? this.payload,
-    priority: priority ?? this.priority,
-    status: status ?? this.status,
-    retryCount: retryCount ?? this.retryCount,
-    lastError: lastError.present ? lastError.value : this.lastError,
-    createdAt: createdAt ?? this.createdAt,
-    lastAttemptAt: lastAttemptAt.present
-        ? lastAttemptAt.value
-        : this.lastAttemptAt,
-  );
+  OutboxEntry copyWith(
+          {int? id,
+          String? operationId,
+          String? entityType,
+          String? entityId,
+          String? operationType,
+          String? payload,
+          int? priority,
+          String? status,
+          int? retryCount,
+          Value<String?> lastError = const Value.absent(),
+          DateTime? createdAt,
+          Value<DateTime?> lastAttemptAt = const Value.absent()}) =>
+      OutboxEntry(
+        id: id ?? this.id,
+        operationId: operationId ?? this.operationId,
+        entityType: entityType ?? this.entityType,
+        entityId: entityId ?? this.entityId,
+        operationType: operationType ?? this.operationType,
+        payload: payload ?? this.payload,
+        priority: priority ?? this.priority,
+        status: status ?? this.status,
+        retryCount: retryCount ?? this.retryCount,
+        lastError: lastError.present ? lastError.value : this.lastError,
+        createdAt: createdAt ?? this.createdAt,
+        lastAttemptAt:
+            lastAttemptAt.present ? lastAttemptAt.value : this.lastAttemptAt,
+      );
   OutboxEntry copyWithCompanion(OutboxEntriesCompanion data) {
     return OutboxEntry(
       id: data.id.present ? data.id.value : this.id,
-      operationId: data.operationId.present
-          ? data.operationId.value
-          : this.operationId,
-      entityType: data.entityType.present
-          ? data.entityType.value
-          : this.entityType,
+      operationId:
+          data.operationId.present ? data.operationId.value : this.operationId,
+      entityType:
+          data.entityType.present ? data.entityType.value : this.entityType,
       entityId: data.entityId.present ? data.entityId.value : this.entityId,
       operationType: data.operationType.present
           ? data.operationType.value
@@ -7016,9 +5895,8 @@ class OutboxEntry extends DataClass implements Insertable<OutboxEntry> {
       payload: data.payload.present ? data.payload.value : this.payload,
       priority: data.priority.present ? data.priority.value : this.priority,
       status: data.status.present ? data.status.value : this.status,
-      retryCount: data.retryCount.present
-          ? data.retryCount.value
-          : this.retryCount,
+      retryCount:
+          data.retryCount.present ? data.retryCount.value : this.retryCount,
       lastError: data.lastError.present ? data.lastError.value : this.lastError,
       createdAt: data.createdAt.present ? data.createdAt.value : this.createdAt,
       lastAttemptAt: data.lastAttemptAt.present
@@ -7048,19 +5926,18 @@ class OutboxEntry extends DataClass implements Insertable<OutboxEntry> {
 
   @override
   int get hashCode => Object.hash(
-    id,
-    operationId,
-    entityType,
-    entityId,
-    operationType,
-    payload,
-    priority,
-    status,
-    retryCount,
-    lastError,
-    createdAt,
-    lastAttemptAt,
-  );
+      id,
+      operationId,
+      entityType,
+      entityId,
+      operationType,
+      payload,
+      priority,
+      status,
+      retryCount,
+      lastError,
+      createdAt,
+      lastAttemptAt);
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
@@ -7119,11 +5996,11 @@ class OutboxEntriesCompanion extends UpdateCompanion<OutboxEntry> {
     this.lastError = const Value.absent(),
     this.createdAt = const Value.absent(),
     this.lastAttemptAt = const Value.absent(),
-  }) : operationId = Value(operationId),
-       entityType = Value(entityType),
-       entityId = Value(entityId),
-       operationType = Value(operationType),
-       payload = Value(payload);
+  })  : operationId = Value(operationId),
+        entityType = Value(entityType),
+        entityId = Value(entityId),
+        operationType = Value(operationType),
+        payload = Value(payload);
   static Insertable<OutboxEntry> custom({
     Expression<int>? id,
     Expression<String>? operationId,
@@ -7154,20 +6031,19 @@ class OutboxEntriesCompanion extends UpdateCompanion<OutboxEntry> {
     });
   }
 
-  OutboxEntriesCompanion copyWith({
-    Value<int>? id,
-    Value<String>? operationId,
-    Value<String>? entityType,
-    Value<String>? entityId,
-    Value<String>? operationType,
-    Value<String>? payload,
-    Value<int>? priority,
-    Value<String>? status,
-    Value<int>? retryCount,
-    Value<String?>? lastError,
-    Value<DateTime>? createdAt,
-    Value<DateTime?>? lastAttemptAt,
-  }) {
+  OutboxEntriesCompanion copyWith(
+      {Value<int>? id,
+      Value<String>? operationId,
+      Value<String>? entityType,
+      Value<String>? entityId,
+      Value<String>? operationType,
+      Value<String>? payload,
+      Value<int>? priority,
+      Value<String>? status,
+      Value<int>? retryCount,
+      Value<String?>? lastError,
+      Value<DateTime>? createdAt,
+      Value<DateTime?>? lastAttemptAt}) {
     return OutboxEntriesCompanion(
       id: id ?? this.id,
       operationId: operationId ?? this.operationId,
@@ -7255,33 +6131,21 @@ class $SyncMetadataTable extends SyncMetadata
   static const VerificationMeta _keyMeta = const VerificationMeta('key');
   @override
   late final GeneratedColumn<String> key = GeneratedColumn<String>(
-    'key',
-    aliasedName,
-    false,
-    type: DriftSqlType.string,
-    requiredDuringInsert: true,
-  );
+      'key', aliasedName, false,
+      type: DriftSqlType.string, requiredDuringInsert: true);
   static const VerificationMeta _valueMeta = const VerificationMeta('value');
   @override
   late final GeneratedColumn<String> value = GeneratedColumn<String>(
-    'value',
-    aliasedName,
-    false,
-    type: DriftSqlType.string,
-    requiredDuringInsert: true,
-  );
-  static const VerificationMeta _updatedAtMeta = const VerificationMeta(
-    'updatedAt',
-  );
+      'value', aliasedName, false,
+      type: DriftSqlType.string, requiredDuringInsert: true);
+  static const VerificationMeta _updatedAtMeta =
+      const VerificationMeta('updatedAt');
   @override
   late final GeneratedColumn<DateTime> updatedAt = GeneratedColumn<DateTime>(
-    'updated_at',
-    aliasedName,
-    false,
-    type: DriftSqlType.dateTime,
-    requiredDuringInsert: false,
-    defaultValue: currentDateAndTime,
-  );
+      'updated_at', aliasedName, false,
+      type: DriftSqlType.dateTime,
+      requiredDuringInsert: false,
+      defaultValue: currentDateAndTime);
   @override
   List<GeneratedColumn> get $columns => [key, value, updatedAt];
   @override
@@ -7290,33 +6154,25 @@ class $SyncMetadataTable extends SyncMetadata
   String get actualTableName => $name;
   static const String $name = 'sync_metadata';
   @override
-  VerificationContext validateIntegrity(
-    Insertable<SyncMetadataData> instance, {
-    bool isInserting = false,
-  }) {
+  VerificationContext validateIntegrity(Insertable<SyncMetadataData> instance,
+      {bool isInserting = false}) {
     final context = VerificationContext();
     final data = instance.toColumns(true);
     if (data.containsKey('key')) {
       context.handle(
-        _keyMeta,
-        key.isAcceptableOrUnknown(data['key']!, _keyMeta),
-      );
+          _keyMeta, key.isAcceptableOrUnknown(data['key']!, _keyMeta));
     } else if (isInserting) {
       context.missing(_keyMeta);
     }
     if (data.containsKey('value')) {
       context.handle(
-        _valueMeta,
-        value.isAcceptableOrUnknown(data['value']!, _valueMeta),
-      );
+          _valueMeta, value.isAcceptableOrUnknown(data['value']!, _valueMeta));
     } else if (isInserting) {
       context.missing(_valueMeta);
     }
     if (data.containsKey('updated_at')) {
-      context.handle(
-        _updatedAtMeta,
-        updatedAt.isAcceptableOrUnknown(data['updated_at']!, _updatedAtMeta),
-      );
+      context.handle(_updatedAtMeta,
+          updatedAt.isAcceptableOrUnknown(data['updated_at']!, _updatedAtMeta));
     }
     return context;
   }
@@ -7327,18 +6183,12 @@ class $SyncMetadataTable extends SyncMetadata
   SyncMetadataData map(Map<String, dynamic> data, {String? tablePrefix}) {
     final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
     return SyncMetadataData(
-      key: attachedDatabase.typeMapping.read(
-        DriftSqlType.string,
-        data['${effectivePrefix}key'],
-      )!,
-      value: attachedDatabase.typeMapping.read(
-        DriftSqlType.string,
-        data['${effectivePrefix}value'],
-      )!,
-      updatedAt: attachedDatabase.typeMapping.read(
-        DriftSqlType.dateTime,
-        data['${effectivePrefix}updated_at'],
-      )!,
+      key: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}key'])!,
+      value: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}value'])!,
+      updatedAt: attachedDatabase.typeMapping
+          .read(DriftSqlType.dateTime, data['${effectivePrefix}updated_at'])!,
     );
   }
 
@@ -7353,11 +6203,8 @@ class SyncMetadataData extends DataClass
   final String key;
   final String value;
   final DateTime updatedAt;
-  const SyncMetadataData({
-    required this.key,
-    required this.value,
-    required this.updatedAt,
-  });
+  const SyncMetadataData(
+      {required this.key, required this.value, required this.updatedAt});
   @override
   Map<String, Expression> toColumns(bool nullToAbsent) {
     final map = <String, Expression>{};
@@ -7375,10 +6222,8 @@ class SyncMetadataData extends DataClass
     );
   }
 
-  factory SyncMetadataData.fromJson(
-    Map<String, dynamic> json, {
-    ValueSerializer? serializer,
-  }) {
+  factory SyncMetadataData.fromJson(Map<String, dynamic> json,
+      {ValueSerializer? serializer}) {
     serializer ??= driftRuntimeOptions.defaultSerializer;
     return SyncMetadataData(
       key: serializer.fromJson<String>(json['key']),
@@ -7396,15 +6241,13 @@ class SyncMetadataData extends DataClass
     };
   }
 
-  SyncMetadataData copyWith({
-    String? key,
-    String? value,
-    DateTime? updatedAt,
-  }) => SyncMetadataData(
-    key: key ?? this.key,
-    value: value ?? this.value,
-    updatedAt: updatedAt ?? this.updatedAt,
-  );
+  SyncMetadataData copyWith(
+          {String? key, String? value, DateTime? updatedAt}) =>
+      SyncMetadataData(
+        key: key ?? this.key,
+        value: value ?? this.value,
+        updatedAt: updatedAt ?? this.updatedAt,
+      );
   SyncMetadataData copyWithCompanion(SyncMetadataCompanion data) {
     return SyncMetadataData(
       key: data.key.present ? data.key.value : this.key,
@@ -7450,8 +6293,8 @@ class SyncMetadataCompanion extends UpdateCompanion<SyncMetadataData> {
     required String value,
     this.updatedAt = const Value.absent(),
     this.rowid = const Value.absent(),
-  }) : key = Value(key),
-       value = Value(value);
+  })  : key = Value(key),
+        value = Value(value);
   static Insertable<SyncMetadataData> custom({
     Expression<String>? key,
     Expression<String>? value,
@@ -7466,12 +6309,11 @@ class SyncMetadataCompanion extends UpdateCompanion<SyncMetadataData> {
     });
   }
 
-  SyncMetadataCompanion copyWith({
-    Value<String>? key,
-    Value<String>? value,
-    Value<DateTime>? updatedAt,
-    Value<int>? rowid,
-  }) {
+  SyncMetadataCompanion copyWith(
+      {Value<String>? key,
+      Value<String>? value,
+      Value<DateTime>? updatedAt,
+      Value<int>? rowid}) {
     return SyncMetadataCompanion(
       key: key ?? this.key,
       value: value ?? this.value,
@@ -7517,9 +6359,8 @@ abstract class _$AppDatabase extends GeneratedDatabase {
       $TransactionEntriesTable(this);
   late final $BudgetEntriesTable budgetEntries = $BudgetEntriesTable(this);
   late final $AccountEntriesTable accountEntries = $AccountEntriesTable(this);
-  late final $CategoryEntriesTable categoryEntries = $CategoryEntriesTable(
-    this,
-  );
+  late final $CategoryEntriesTable categoryEntries =
+      $CategoryEntriesTable(this);
   late final $GroupEntriesTable groupEntries = $GroupEntriesTable(this);
   late final $GroupMemberEntriesTable groupMemberEntries =
       $GroupMemberEntriesTable(this);
@@ -7536,50 +6377,50 @@ abstract class _$AppDatabase extends GeneratedDatabase {
       allSchemaEntities.whereType<TableInfo<Table, Object?>>();
   @override
   List<DatabaseSchemaEntity> get allSchemaEntities => [
-    transactionEntries,
-    budgetEntries,
-    accountEntries,
-    categoryEntries,
-    groupEntries,
-    groupMemberEntries,
-    sharedExpenseEntries,
-    splitEntryRecords,
-    settlementEntries,
-    outboxEntries,
-    syncMetadata,
-  ];
+        transactionEntries,
+        budgetEntries,
+        accountEntries,
+        categoryEntries,
+        groupEntries,
+        groupMemberEntries,
+        sharedExpenseEntries,
+        splitEntryRecords,
+        settlementEntries,
+        outboxEntries,
+        syncMetadata
+      ];
 }
 
-typedef $$TransactionEntriesTableCreateCompanionBuilder =
-    TransactionEntriesCompanion Function({
-      Value<int> id,
-      required String uuid,
-      required String accountId,
-      required DateTime timestamp,
-      required int amountCents,
-      required String description,
-      required String category,
-      Value<String> tags,
-      Value<String?> receiptUrl,
-      Value<String> syncStatus,
-      Value<DateTime> createdAt,
-      Value<DateTime?> updatedAt,
-    });
-typedef $$TransactionEntriesTableUpdateCompanionBuilder =
-    TransactionEntriesCompanion Function({
-      Value<int> id,
-      Value<String> uuid,
-      Value<String> accountId,
-      Value<DateTime> timestamp,
-      Value<int> amountCents,
-      Value<String> description,
-      Value<String> category,
-      Value<String> tags,
-      Value<String?> receiptUrl,
-      Value<String> syncStatus,
-      Value<DateTime> createdAt,
-      Value<DateTime?> updatedAt,
-    });
+typedef $$TransactionEntriesTableCreateCompanionBuilder
+    = TransactionEntriesCompanion Function({
+  Value<int> id,
+  required String uuid,
+  required String accountId,
+  required DateTime timestamp,
+  required int amountCents,
+  required String description,
+  required String category,
+  Value<String> tags,
+  Value<String?> receiptUrl,
+  Value<String> syncStatus,
+  Value<DateTime> createdAt,
+  Value<DateTime?> updatedAt,
+});
+typedef $$TransactionEntriesTableUpdateCompanionBuilder
+    = TransactionEntriesCompanion Function({
+  Value<int> id,
+  Value<String> uuid,
+  Value<String> accountId,
+  Value<DateTime> timestamp,
+  Value<int> amountCents,
+  Value<String> description,
+  Value<String> category,
+  Value<String> tags,
+  Value<String?> receiptUrl,
+  Value<String> syncStatus,
+  Value<DateTime> createdAt,
+  Value<DateTime?> updatedAt,
+});
 
 class $$TransactionEntriesTableFilterComposer
     extends Composer<_$AppDatabase, $TransactionEntriesTable> {
@@ -7591,64 +6432,40 @@ class $$TransactionEntriesTableFilterComposer
     super.$removeJoinBuilderFromRootComposer,
   });
   ColumnFilters<int> get id => $composableBuilder(
-    column: $table.id,
-    builder: (column) => ColumnFilters(column),
-  );
+      column: $table.id, builder: (column) => ColumnFilters(column));
 
   ColumnFilters<String> get uuid => $composableBuilder(
-    column: $table.uuid,
-    builder: (column) => ColumnFilters(column),
-  );
+      column: $table.uuid, builder: (column) => ColumnFilters(column));
 
   ColumnFilters<String> get accountId => $composableBuilder(
-    column: $table.accountId,
-    builder: (column) => ColumnFilters(column),
-  );
+      column: $table.accountId, builder: (column) => ColumnFilters(column));
 
   ColumnFilters<DateTime> get timestamp => $composableBuilder(
-    column: $table.timestamp,
-    builder: (column) => ColumnFilters(column),
-  );
+      column: $table.timestamp, builder: (column) => ColumnFilters(column));
 
   ColumnFilters<int> get amountCents => $composableBuilder(
-    column: $table.amountCents,
-    builder: (column) => ColumnFilters(column),
-  );
+      column: $table.amountCents, builder: (column) => ColumnFilters(column));
 
   ColumnFilters<String> get description => $composableBuilder(
-    column: $table.description,
-    builder: (column) => ColumnFilters(column),
-  );
+      column: $table.description, builder: (column) => ColumnFilters(column));
 
   ColumnFilters<String> get category => $composableBuilder(
-    column: $table.category,
-    builder: (column) => ColumnFilters(column),
-  );
+      column: $table.category, builder: (column) => ColumnFilters(column));
 
   ColumnFilters<String> get tags => $composableBuilder(
-    column: $table.tags,
-    builder: (column) => ColumnFilters(column),
-  );
+      column: $table.tags, builder: (column) => ColumnFilters(column));
 
   ColumnFilters<String> get receiptUrl => $composableBuilder(
-    column: $table.receiptUrl,
-    builder: (column) => ColumnFilters(column),
-  );
+      column: $table.receiptUrl, builder: (column) => ColumnFilters(column));
 
   ColumnFilters<String> get syncStatus => $composableBuilder(
-    column: $table.syncStatus,
-    builder: (column) => ColumnFilters(column),
-  );
+      column: $table.syncStatus, builder: (column) => ColumnFilters(column));
 
   ColumnFilters<DateTime> get createdAt => $composableBuilder(
-    column: $table.createdAt,
-    builder: (column) => ColumnFilters(column),
-  );
+      column: $table.createdAt, builder: (column) => ColumnFilters(column));
 
   ColumnFilters<DateTime> get updatedAt => $composableBuilder(
-    column: $table.updatedAt,
-    builder: (column) => ColumnFilters(column),
-  );
+      column: $table.updatedAt, builder: (column) => ColumnFilters(column));
 }
 
 class $$TransactionEntriesTableOrderingComposer
@@ -7661,64 +6478,40 @@ class $$TransactionEntriesTableOrderingComposer
     super.$removeJoinBuilderFromRootComposer,
   });
   ColumnOrderings<int> get id => $composableBuilder(
-    column: $table.id,
-    builder: (column) => ColumnOrderings(column),
-  );
+      column: $table.id, builder: (column) => ColumnOrderings(column));
 
   ColumnOrderings<String> get uuid => $composableBuilder(
-    column: $table.uuid,
-    builder: (column) => ColumnOrderings(column),
-  );
+      column: $table.uuid, builder: (column) => ColumnOrderings(column));
 
   ColumnOrderings<String> get accountId => $composableBuilder(
-    column: $table.accountId,
-    builder: (column) => ColumnOrderings(column),
-  );
+      column: $table.accountId, builder: (column) => ColumnOrderings(column));
 
   ColumnOrderings<DateTime> get timestamp => $composableBuilder(
-    column: $table.timestamp,
-    builder: (column) => ColumnOrderings(column),
-  );
+      column: $table.timestamp, builder: (column) => ColumnOrderings(column));
 
   ColumnOrderings<int> get amountCents => $composableBuilder(
-    column: $table.amountCents,
-    builder: (column) => ColumnOrderings(column),
-  );
+      column: $table.amountCents, builder: (column) => ColumnOrderings(column));
 
   ColumnOrderings<String> get description => $composableBuilder(
-    column: $table.description,
-    builder: (column) => ColumnOrderings(column),
-  );
+      column: $table.description, builder: (column) => ColumnOrderings(column));
 
   ColumnOrderings<String> get category => $composableBuilder(
-    column: $table.category,
-    builder: (column) => ColumnOrderings(column),
-  );
+      column: $table.category, builder: (column) => ColumnOrderings(column));
 
   ColumnOrderings<String> get tags => $composableBuilder(
-    column: $table.tags,
-    builder: (column) => ColumnOrderings(column),
-  );
+      column: $table.tags, builder: (column) => ColumnOrderings(column));
 
   ColumnOrderings<String> get receiptUrl => $composableBuilder(
-    column: $table.receiptUrl,
-    builder: (column) => ColumnOrderings(column),
-  );
+      column: $table.receiptUrl, builder: (column) => ColumnOrderings(column));
 
   ColumnOrderings<String> get syncStatus => $composableBuilder(
-    column: $table.syncStatus,
-    builder: (column) => ColumnOrderings(column),
-  );
+      column: $table.syncStatus, builder: (column) => ColumnOrderings(column));
 
   ColumnOrderings<DateTime> get createdAt => $composableBuilder(
-    column: $table.createdAt,
-    builder: (column) => ColumnOrderings(column),
-  );
+      column: $table.createdAt, builder: (column) => ColumnOrderings(column));
 
   ColumnOrderings<DateTime> get updatedAt => $composableBuilder(
-    column: $table.updatedAt,
-    builder: (column) => ColumnOrderings(column),
-  );
+      column: $table.updatedAt, builder: (column) => ColumnOrderings(column));
 }
 
 class $$TransactionEntriesTableAnnotationComposer
@@ -7743,14 +6536,10 @@ class $$TransactionEntriesTableAnnotationComposer
       $composableBuilder(column: $table.timestamp, builder: (column) => column);
 
   GeneratedColumn<int> get amountCents => $composableBuilder(
-    column: $table.amountCents,
-    builder: (column) => column,
-  );
+      column: $table.amountCents, builder: (column) => column);
 
   GeneratedColumn<String> get description => $composableBuilder(
-    column: $table.description,
-    builder: (column) => column,
-  );
+      column: $table.description, builder: (column) => column);
 
   GeneratedColumn<String> get category =>
       $composableBuilder(column: $table.category, builder: (column) => column);
@@ -7759,14 +6548,10 @@ class $$TransactionEntriesTableAnnotationComposer
       $composableBuilder(column: $table.tags, builder: (column) => column);
 
   GeneratedColumn<String> get receiptUrl => $composableBuilder(
-    column: $table.receiptUrl,
-    builder: (column) => column,
-  );
+      column: $table.receiptUrl, builder: (column) => column);
 
   GeneratedColumn<String> get syncStatus => $composableBuilder(
-    column: $table.syncStatus,
-    builder: (column) => column,
-  );
+      column: $table.syncStatus, builder: (column) => column);
 
   GeneratedColumn<DateTime> get createdAt =>
       $composableBuilder(column: $table.createdAt, builder: (column) => column);
@@ -7775,33 +6560,24 @@ class $$TransactionEntriesTableAnnotationComposer
       $composableBuilder(column: $table.updatedAt, builder: (column) => column);
 }
 
-class $$TransactionEntriesTableTableManager
-    extends
-        RootTableManager<
-          _$AppDatabase,
-          $TransactionEntriesTable,
-          TransactionEntry,
-          $$TransactionEntriesTableFilterComposer,
-          $$TransactionEntriesTableOrderingComposer,
-          $$TransactionEntriesTableAnnotationComposer,
-          $$TransactionEntriesTableCreateCompanionBuilder,
-          $$TransactionEntriesTableUpdateCompanionBuilder,
-          (
-            TransactionEntry,
-            BaseReferences<
-              _$AppDatabase,
-              $TransactionEntriesTable,
-              TransactionEntry
-            >,
-          ),
-          TransactionEntry,
-          PrefetchHooks Function()
-        > {
+class $$TransactionEntriesTableTableManager extends RootTableManager<
+    _$AppDatabase,
+    $TransactionEntriesTable,
+    TransactionEntry,
+    $$TransactionEntriesTableFilterComposer,
+    $$TransactionEntriesTableOrderingComposer,
+    $$TransactionEntriesTableAnnotationComposer,
+    $$TransactionEntriesTableCreateCompanionBuilder,
+    $$TransactionEntriesTableUpdateCompanionBuilder,
+    (
+      TransactionEntry,
+      BaseReferences<_$AppDatabase, $TransactionEntriesTable, TransactionEntry>
+    ),
+    TransactionEntry,
+    PrefetchHooks Function()> {
   $$TransactionEntriesTableTableManager(
-    _$AppDatabase db,
-    $TransactionEntriesTable table,
-  ) : super(
-        TableManagerState(
+      _$AppDatabase db, $TransactionEntriesTable table)
+      : super(TableManagerState(
           db: db,
           table: table,
           createFilteringComposer: () =>
@@ -7810,124 +6586,115 @@ class $$TransactionEntriesTableTableManager
               $$TransactionEntriesTableOrderingComposer($db: db, $table: table),
           createComputedFieldComposer: () =>
               $$TransactionEntriesTableAnnotationComposer(
-                $db: db,
-                $table: table,
-              ),
-          updateCompanionCallback:
-              ({
-                Value<int> id = const Value.absent(),
-                Value<String> uuid = const Value.absent(),
-                Value<String> accountId = const Value.absent(),
-                Value<DateTime> timestamp = const Value.absent(),
-                Value<int> amountCents = const Value.absent(),
-                Value<String> description = const Value.absent(),
-                Value<String> category = const Value.absent(),
-                Value<String> tags = const Value.absent(),
-                Value<String?> receiptUrl = const Value.absent(),
-                Value<String> syncStatus = const Value.absent(),
-                Value<DateTime> createdAt = const Value.absent(),
-                Value<DateTime?> updatedAt = const Value.absent(),
-              }) => TransactionEntriesCompanion(
-                id: id,
-                uuid: uuid,
-                accountId: accountId,
-                timestamp: timestamp,
-                amountCents: amountCents,
-                description: description,
-                category: category,
-                tags: tags,
-                receiptUrl: receiptUrl,
-                syncStatus: syncStatus,
-                createdAt: createdAt,
-                updatedAt: updatedAt,
-              ),
-          createCompanionCallback:
-              ({
-                Value<int> id = const Value.absent(),
-                required String uuid,
-                required String accountId,
-                required DateTime timestamp,
-                required int amountCents,
-                required String description,
-                required String category,
-                Value<String> tags = const Value.absent(),
-                Value<String?> receiptUrl = const Value.absent(),
-                Value<String> syncStatus = const Value.absent(),
-                Value<DateTime> createdAt = const Value.absent(),
-                Value<DateTime?> updatedAt = const Value.absent(),
-              }) => TransactionEntriesCompanion.insert(
-                id: id,
-                uuid: uuid,
-                accountId: accountId,
-                timestamp: timestamp,
-                amountCents: amountCents,
-                description: description,
-                category: category,
-                tags: tags,
-                receiptUrl: receiptUrl,
-                syncStatus: syncStatus,
-                createdAt: createdAt,
-                updatedAt: updatedAt,
-              ),
+                  $db: db, $table: table),
+          updateCompanionCallback: ({
+            Value<int> id = const Value.absent(),
+            Value<String> uuid = const Value.absent(),
+            Value<String> accountId = const Value.absent(),
+            Value<DateTime> timestamp = const Value.absent(),
+            Value<int> amountCents = const Value.absent(),
+            Value<String> description = const Value.absent(),
+            Value<String> category = const Value.absent(),
+            Value<String> tags = const Value.absent(),
+            Value<String?> receiptUrl = const Value.absent(),
+            Value<String> syncStatus = const Value.absent(),
+            Value<DateTime> createdAt = const Value.absent(),
+            Value<DateTime?> updatedAt = const Value.absent(),
+          }) =>
+              TransactionEntriesCompanion(
+            id: id,
+            uuid: uuid,
+            accountId: accountId,
+            timestamp: timestamp,
+            amountCents: amountCents,
+            description: description,
+            category: category,
+            tags: tags,
+            receiptUrl: receiptUrl,
+            syncStatus: syncStatus,
+            createdAt: createdAt,
+            updatedAt: updatedAt,
+          ),
+          createCompanionCallback: ({
+            Value<int> id = const Value.absent(),
+            required String uuid,
+            required String accountId,
+            required DateTime timestamp,
+            required int amountCents,
+            required String description,
+            required String category,
+            Value<String> tags = const Value.absent(),
+            Value<String?> receiptUrl = const Value.absent(),
+            Value<String> syncStatus = const Value.absent(),
+            Value<DateTime> createdAt = const Value.absent(),
+            Value<DateTime?> updatedAt = const Value.absent(),
+          }) =>
+              TransactionEntriesCompanion.insert(
+            id: id,
+            uuid: uuid,
+            accountId: accountId,
+            timestamp: timestamp,
+            amountCents: amountCents,
+            description: description,
+            category: category,
+            tags: tags,
+            receiptUrl: receiptUrl,
+            syncStatus: syncStatus,
+            createdAt: createdAt,
+            updatedAt: updatedAt,
+          ),
           withReferenceMapper: (p0) => p0
               .map((e) => (e.readTable(table), BaseReferences(db, table, e)))
               .toList(),
           prefetchHooksCallback: null,
-        ),
-      );
+        ));
 }
 
-typedef $$TransactionEntriesTableProcessedTableManager =
-    ProcessedTableManager<
-      _$AppDatabase,
-      $TransactionEntriesTable,
+typedef $$TransactionEntriesTableProcessedTableManager = ProcessedTableManager<
+    _$AppDatabase,
+    $TransactionEntriesTable,
+    TransactionEntry,
+    $$TransactionEntriesTableFilterComposer,
+    $$TransactionEntriesTableOrderingComposer,
+    $$TransactionEntriesTableAnnotationComposer,
+    $$TransactionEntriesTableCreateCompanionBuilder,
+    $$TransactionEntriesTableUpdateCompanionBuilder,
+    (
       TransactionEntry,
-      $$TransactionEntriesTableFilterComposer,
-      $$TransactionEntriesTableOrderingComposer,
-      $$TransactionEntriesTableAnnotationComposer,
-      $$TransactionEntriesTableCreateCompanionBuilder,
-      $$TransactionEntriesTableUpdateCompanionBuilder,
-      (
-        TransactionEntry,
-        BaseReferences<
-          _$AppDatabase,
-          $TransactionEntriesTable,
-          TransactionEntry
-        >,
-      ),
-      TransactionEntry,
-      PrefetchHooks Function()
-    >;
-typedef $$BudgetEntriesTableCreateCompanionBuilder =
-    BudgetEntriesCompanion Function({
-      Value<int> id,
-      required String uuid,
-      required String tag,
-      required int limitCents,
-      Value<int> usedCents,
-      Value<int> carryoverCents,
-      required int periodMonth,
-      Value<String> recurrence,
-      Value<String> carryoverBehavior,
-      Value<String> syncStatus,
-      Value<DateTime> createdAt,
-      Value<DateTime?> updatedAt,
-    });
-typedef $$BudgetEntriesTableUpdateCompanionBuilder =
-    BudgetEntriesCompanion Function({
-      Value<int> id,
-      Value<String> uuid,
-      Value<String> tag,
-      Value<int> limitCents,
-      Value<int> usedCents,
-      Value<int> carryoverCents,
-      Value<int> periodMonth,
-      Value<String> recurrence,
-      Value<String> carryoverBehavior,
-      Value<String> syncStatus,
-      Value<DateTime> createdAt,
-      Value<DateTime?> updatedAt,
-    });
+      BaseReferences<_$AppDatabase, $TransactionEntriesTable, TransactionEntry>
+    ),
+    TransactionEntry,
+    PrefetchHooks Function()>;
+typedef $$BudgetEntriesTableCreateCompanionBuilder = BudgetEntriesCompanion
+    Function({
+  Value<int> id,
+  required String uuid,
+  required String tag,
+  required int limitCents,
+  Value<int> usedCents,
+  Value<int> carryoverCents,
+  required int periodMonth,
+  Value<String> recurrence,
+  Value<String> carryoverBehavior,
+  Value<String> syncStatus,
+  Value<DateTime> createdAt,
+  Value<DateTime?> updatedAt,
+});
+typedef $$BudgetEntriesTableUpdateCompanionBuilder = BudgetEntriesCompanion
+    Function({
+  Value<int> id,
+  Value<String> uuid,
+  Value<String> tag,
+  Value<int> limitCents,
+  Value<int> usedCents,
+  Value<int> carryoverCents,
+  Value<int> periodMonth,
+  Value<String> recurrence,
+  Value<String> carryoverBehavior,
+  Value<String> syncStatus,
+  Value<DateTime> createdAt,
+  Value<DateTime?> updatedAt,
+});
 
 class $$BudgetEntriesTableFilterComposer
     extends Composer<_$AppDatabase, $BudgetEntriesTable> {
@@ -7939,64 +6706,42 @@ class $$BudgetEntriesTableFilterComposer
     super.$removeJoinBuilderFromRootComposer,
   });
   ColumnFilters<int> get id => $composableBuilder(
-    column: $table.id,
-    builder: (column) => ColumnFilters(column),
-  );
+      column: $table.id, builder: (column) => ColumnFilters(column));
 
   ColumnFilters<String> get uuid => $composableBuilder(
-    column: $table.uuid,
-    builder: (column) => ColumnFilters(column),
-  );
+      column: $table.uuid, builder: (column) => ColumnFilters(column));
 
   ColumnFilters<String> get tag => $composableBuilder(
-    column: $table.tag,
-    builder: (column) => ColumnFilters(column),
-  );
+      column: $table.tag, builder: (column) => ColumnFilters(column));
 
   ColumnFilters<int> get limitCents => $composableBuilder(
-    column: $table.limitCents,
-    builder: (column) => ColumnFilters(column),
-  );
+      column: $table.limitCents, builder: (column) => ColumnFilters(column));
 
   ColumnFilters<int> get usedCents => $composableBuilder(
-    column: $table.usedCents,
-    builder: (column) => ColumnFilters(column),
-  );
+      column: $table.usedCents, builder: (column) => ColumnFilters(column));
 
   ColumnFilters<int> get carryoverCents => $composableBuilder(
-    column: $table.carryoverCents,
-    builder: (column) => ColumnFilters(column),
-  );
+      column: $table.carryoverCents,
+      builder: (column) => ColumnFilters(column));
 
   ColumnFilters<int> get periodMonth => $composableBuilder(
-    column: $table.periodMonth,
-    builder: (column) => ColumnFilters(column),
-  );
+      column: $table.periodMonth, builder: (column) => ColumnFilters(column));
 
   ColumnFilters<String> get recurrence => $composableBuilder(
-    column: $table.recurrence,
-    builder: (column) => ColumnFilters(column),
-  );
+      column: $table.recurrence, builder: (column) => ColumnFilters(column));
 
   ColumnFilters<String> get carryoverBehavior => $composableBuilder(
-    column: $table.carryoverBehavior,
-    builder: (column) => ColumnFilters(column),
-  );
+      column: $table.carryoverBehavior,
+      builder: (column) => ColumnFilters(column));
 
   ColumnFilters<String> get syncStatus => $composableBuilder(
-    column: $table.syncStatus,
-    builder: (column) => ColumnFilters(column),
-  );
+      column: $table.syncStatus, builder: (column) => ColumnFilters(column));
 
   ColumnFilters<DateTime> get createdAt => $composableBuilder(
-    column: $table.createdAt,
-    builder: (column) => ColumnFilters(column),
-  );
+      column: $table.createdAt, builder: (column) => ColumnFilters(column));
 
   ColumnFilters<DateTime> get updatedAt => $composableBuilder(
-    column: $table.updatedAt,
-    builder: (column) => ColumnFilters(column),
-  );
+      column: $table.updatedAt, builder: (column) => ColumnFilters(column));
 }
 
 class $$BudgetEntriesTableOrderingComposer
@@ -8009,64 +6754,42 @@ class $$BudgetEntriesTableOrderingComposer
     super.$removeJoinBuilderFromRootComposer,
   });
   ColumnOrderings<int> get id => $composableBuilder(
-    column: $table.id,
-    builder: (column) => ColumnOrderings(column),
-  );
+      column: $table.id, builder: (column) => ColumnOrderings(column));
 
   ColumnOrderings<String> get uuid => $composableBuilder(
-    column: $table.uuid,
-    builder: (column) => ColumnOrderings(column),
-  );
+      column: $table.uuid, builder: (column) => ColumnOrderings(column));
 
   ColumnOrderings<String> get tag => $composableBuilder(
-    column: $table.tag,
-    builder: (column) => ColumnOrderings(column),
-  );
+      column: $table.tag, builder: (column) => ColumnOrderings(column));
 
   ColumnOrderings<int> get limitCents => $composableBuilder(
-    column: $table.limitCents,
-    builder: (column) => ColumnOrderings(column),
-  );
+      column: $table.limitCents, builder: (column) => ColumnOrderings(column));
 
   ColumnOrderings<int> get usedCents => $composableBuilder(
-    column: $table.usedCents,
-    builder: (column) => ColumnOrderings(column),
-  );
+      column: $table.usedCents, builder: (column) => ColumnOrderings(column));
 
   ColumnOrderings<int> get carryoverCents => $composableBuilder(
-    column: $table.carryoverCents,
-    builder: (column) => ColumnOrderings(column),
-  );
+      column: $table.carryoverCents,
+      builder: (column) => ColumnOrderings(column));
 
   ColumnOrderings<int> get periodMonth => $composableBuilder(
-    column: $table.periodMonth,
-    builder: (column) => ColumnOrderings(column),
-  );
+      column: $table.periodMonth, builder: (column) => ColumnOrderings(column));
 
   ColumnOrderings<String> get recurrence => $composableBuilder(
-    column: $table.recurrence,
-    builder: (column) => ColumnOrderings(column),
-  );
+      column: $table.recurrence, builder: (column) => ColumnOrderings(column));
 
   ColumnOrderings<String> get carryoverBehavior => $composableBuilder(
-    column: $table.carryoverBehavior,
-    builder: (column) => ColumnOrderings(column),
-  );
+      column: $table.carryoverBehavior,
+      builder: (column) => ColumnOrderings(column));
 
   ColumnOrderings<String> get syncStatus => $composableBuilder(
-    column: $table.syncStatus,
-    builder: (column) => ColumnOrderings(column),
-  );
+      column: $table.syncStatus, builder: (column) => ColumnOrderings(column));
 
   ColumnOrderings<DateTime> get createdAt => $composableBuilder(
-    column: $table.createdAt,
-    builder: (column) => ColumnOrderings(column),
-  );
+      column: $table.createdAt, builder: (column) => ColumnOrderings(column));
 
   ColumnOrderings<DateTime> get updatedAt => $composableBuilder(
-    column: $table.updatedAt,
-    builder: (column) => ColumnOrderings(column),
-  );
+      column: $table.updatedAt, builder: (column) => ColumnOrderings(column));
 }
 
 class $$BudgetEntriesTableAnnotationComposer
@@ -8088,37 +6811,25 @@ class $$BudgetEntriesTableAnnotationComposer
       $composableBuilder(column: $table.tag, builder: (column) => column);
 
   GeneratedColumn<int> get limitCents => $composableBuilder(
-    column: $table.limitCents,
-    builder: (column) => column,
-  );
+      column: $table.limitCents, builder: (column) => column);
 
   GeneratedColumn<int> get usedCents =>
       $composableBuilder(column: $table.usedCents, builder: (column) => column);
 
   GeneratedColumn<int> get carryoverCents => $composableBuilder(
-    column: $table.carryoverCents,
-    builder: (column) => column,
-  );
+      column: $table.carryoverCents, builder: (column) => column);
 
   GeneratedColumn<int> get periodMonth => $composableBuilder(
-    column: $table.periodMonth,
-    builder: (column) => column,
-  );
+      column: $table.periodMonth, builder: (column) => column);
 
   GeneratedColumn<String> get recurrence => $composableBuilder(
-    column: $table.recurrence,
-    builder: (column) => column,
-  );
+      column: $table.recurrence, builder: (column) => column);
 
   GeneratedColumn<String> get carryoverBehavior => $composableBuilder(
-    column: $table.carryoverBehavior,
-    builder: (column) => column,
-  );
+      column: $table.carryoverBehavior, builder: (column) => column);
 
   GeneratedColumn<String> get syncStatus => $composableBuilder(
-    column: $table.syncStatus,
-    builder: (column) => column,
-  );
+      column: $table.syncStatus, builder: (column) => column);
 
   GeneratedColumn<DateTime> get createdAt =>
       $composableBuilder(column: $table.createdAt, builder: (column) => column);
@@ -8127,27 +6838,23 @@ class $$BudgetEntriesTableAnnotationComposer
       $composableBuilder(column: $table.updatedAt, builder: (column) => column);
 }
 
-class $$BudgetEntriesTableTableManager
-    extends
-        RootTableManager<
-          _$AppDatabase,
-          $BudgetEntriesTable,
-          BudgetEntry,
-          $$BudgetEntriesTableFilterComposer,
-          $$BudgetEntriesTableOrderingComposer,
-          $$BudgetEntriesTableAnnotationComposer,
-          $$BudgetEntriesTableCreateCompanionBuilder,
-          $$BudgetEntriesTableUpdateCompanionBuilder,
-          (
-            BudgetEntry,
-            BaseReferences<_$AppDatabase, $BudgetEntriesTable, BudgetEntry>,
-          ),
-          BudgetEntry,
-          PrefetchHooks Function()
-        > {
+class $$BudgetEntriesTableTableManager extends RootTableManager<
+    _$AppDatabase,
+    $BudgetEntriesTable,
+    BudgetEntry,
+    $$BudgetEntriesTableFilterComposer,
+    $$BudgetEntriesTableOrderingComposer,
+    $$BudgetEntriesTableAnnotationComposer,
+    $$BudgetEntriesTableCreateCompanionBuilder,
+    $$BudgetEntriesTableUpdateCompanionBuilder,
+    (
+      BudgetEntry,
+      BaseReferences<_$AppDatabase, $BudgetEntriesTable, BudgetEntry>
+    ),
+    BudgetEntry,
+    PrefetchHooks Function()> {
   $$BudgetEntriesTableTableManager(_$AppDatabase db, $BudgetEntriesTable table)
-    : super(
-        TableManagerState(
+      : super(TableManagerState(
           db: db,
           table: table,
           createFilteringComposer: () =>
@@ -8156,111 +6863,108 @@ class $$BudgetEntriesTableTableManager
               $$BudgetEntriesTableOrderingComposer($db: db, $table: table),
           createComputedFieldComposer: () =>
               $$BudgetEntriesTableAnnotationComposer($db: db, $table: table),
-          updateCompanionCallback:
-              ({
-                Value<int> id = const Value.absent(),
-                Value<String> uuid = const Value.absent(),
-                Value<String> tag = const Value.absent(),
-                Value<int> limitCents = const Value.absent(),
-                Value<int> usedCents = const Value.absent(),
-                Value<int> carryoverCents = const Value.absent(),
-                Value<int> periodMonth = const Value.absent(),
-                Value<String> recurrence = const Value.absent(),
-                Value<String> carryoverBehavior = const Value.absent(),
-                Value<String> syncStatus = const Value.absent(),
-                Value<DateTime> createdAt = const Value.absent(),
-                Value<DateTime?> updatedAt = const Value.absent(),
-              }) => BudgetEntriesCompanion(
-                id: id,
-                uuid: uuid,
-                tag: tag,
-                limitCents: limitCents,
-                usedCents: usedCents,
-                carryoverCents: carryoverCents,
-                periodMonth: periodMonth,
-                recurrence: recurrence,
-                carryoverBehavior: carryoverBehavior,
-                syncStatus: syncStatus,
-                createdAt: createdAt,
-                updatedAt: updatedAt,
-              ),
-          createCompanionCallback:
-              ({
-                Value<int> id = const Value.absent(),
-                required String uuid,
-                required String tag,
-                required int limitCents,
-                Value<int> usedCents = const Value.absent(),
-                Value<int> carryoverCents = const Value.absent(),
-                required int periodMonth,
-                Value<String> recurrence = const Value.absent(),
-                Value<String> carryoverBehavior = const Value.absent(),
-                Value<String> syncStatus = const Value.absent(),
-                Value<DateTime> createdAt = const Value.absent(),
-                Value<DateTime?> updatedAt = const Value.absent(),
-              }) => BudgetEntriesCompanion.insert(
-                id: id,
-                uuid: uuid,
-                tag: tag,
-                limitCents: limitCents,
-                usedCents: usedCents,
-                carryoverCents: carryoverCents,
-                periodMonth: periodMonth,
-                recurrence: recurrence,
-                carryoverBehavior: carryoverBehavior,
-                syncStatus: syncStatus,
-                createdAt: createdAt,
-                updatedAt: updatedAt,
-              ),
+          updateCompanionCallback: ({
+            Value<int> id = const Value.absent(),
+            Value<String> uuid = const Value.absent(),
+            Value<String> tag = const Value.absent(),
+            Value<int> limitCents = const Value.absent(),
+            Value<int> usedCents = const Value.absent(),
+            Value<int> carryoverCents = const Value.absent(),
+            Value<int> periodMonth = const Value.absent(),
+            Value<String> recurrence = const Value.absent(),
+            Value<String> carryoverBehavior = const Value.absent(),
+            Value<String> syncStatus = const Value.absent(),
+            Value<DateTime> createdAt = const Value.absent(),
+            Value<DateTime?> updatedAt = const Value.absent(),
+          }) =>
+              BudgetEntriesCompanion(
+            id: id,
+            uuid: uuid,
+            tag: tag,
+            limitCents: limitCents,
+            usedCents: usedCents,
+            carryoverCents: carryoverCents,
+            periodMonth: periodMonth,
+            recurrence: recurrence,
+            carryoverBehavior: carryoverBehavior,
+            syncStatus: syncStatus,
+            createdAt: createdAt,
+            updatedAt: updatedAt,
+          ),
+          createCompanionCallback: ({
+            Value<int> id = const Value.absent(),
+            required String uuid,
+            required String tag,
+            required int limitCents,
+            Value<int> usedCents = const Value.absent(),
+            Value<int> carryoverCents = const Value.absent(),
+            required int periodMonth,
+            Value<String> recurrence = const Value.absent(),
+            Value<String> carryoverBehavior = const Value.absent(),
+            Value<String> syncStatus = const Value.absent(),
+            Value<DateTime> createdAt = const Value.absent(),
+            Value<DateTime?> updatedAt = const Value.absent(),
+          }) =>
+              BudgetEntriesCompanion.insert(
+            id: id,
+            uuid: uuid,
+            tag: tag,
+            limitCents: limitCents,
+            usedCents: usedCents,
+            carryoverCents: carryoverCents,
+            periodMonth: periodMonth,
+            recurrence: recurrence,
+            carryoverBehavior: carryoverBehavior,
+            syncStatus: syncStatus,
+            createdAt: createdAt,
+            updatedAt: updatedAt,
+          ),
           withReferenceMapper: (p0) => p0
               .map((e) => (e.readTable(table), BaseReferences(db, table, e)))
               .toList(),
           prefetchHooksCallback: null,
-        ),
-      );
+        ));
 }
 
-typedef $$BudgetEntriesTableProcessedTableManager =
-    ProcessedTableManager<
-      _$AppDatabase,
-      $BudgetEntriesTable,
+typedef $$BudgetEntriesTableProcessedTableManager = ProcessedTableManager<
+    _$AppDatabase,
+    $BudgetEntriesTable,
+    BudgetEntry,
+    $$BudgetEntriesTableFilterComposer,
+    $$BudgetEntriesTableOrderingComposer,
+    $$BudgetEntriesTableAnnotationComposer,
+    $$BudgetEntriesTableCreateCompanionBuilder,
+    $$BudgetEntriesTableUpdateCompanionBuilder,
+    (
       BudgetEntry,
-      $$BudgetEntriesTableFilterComposer,
-      $$BudgetEntriesTableOrderingComposer,
-      $$BudgetEntriesTableAnnotationComposer,
-      $$BudgetEntriesTableCreateCompanionBuilder,
-      $$BudgetEntriesTableUpdateCompanionBuilder,
-      (
-        BudgetEntry,
-        BaseReferences<_$AppDatabase, $BudgetEntriesTable, BudgetEntry>,
-      ),
-      BudgetEntry,
-      PrefetchHooks Function()
-    >;
-typedef $$AccountEntriesTableCreateCompanionBuilder =
-    AccountEntriesCompanion Function({
-      Value<int> id,
-      required String uuid,
-      required String name,
-      required String accountType,
-      Value<String> currency,
-      Value<int> balanceCents,
-      Value<String> syncStatus,
-      Value<DateTime> createdAt,
-      Value<DateTime?> updatedAt,
-    });
-typedef $$AccountEntriesTableUpdateCompanionBuilder =
-    AccountEntriesCompanion Function({
-      Value<int> id,
-      Value<String> uuid,
-      Value<String> name,
-      Value<String> accountType,
-      Value<String> currency,
-      Value<int> balanceCents,
-      Value<String> syncStatus,
-      Value<DateTime> createdAt,
-      Value<DateTime?> updatedAt,
-    });
+      BaseReferences<_$AppDatabase, $BudgetEntriesTable, BudgetEntry>
+    ),
+    BudgetEntry,
+    PrefetchHooks Function()>;
+typedef $$AccountEntriesTableCreateCompanionBuilder = AccountEntriesCompanion
+    Function({
+  Value<int> id,
+  required String uuid,
+  required String name,
+  required String accountType,
+  Value<String> currency,
+  Value<int> balanceCents,
+  Value<String> syncStatus,
+  Value<DateTime> createdAt,
+  Value<DateTime?> updatedAt,
+});
+typedef $$AccountEntriesTableUpdateCompanionBuilder = AccountEntriesCompanion
+    Function({
+  Value<int> id,
+  Value<String> uuid,
+  Value<String> name,
+  Value<String> accountType,
+  Value<String> currency,
+  Value<int> balanceCents,
+  Value<String> syncStatus,
+  Value<DateTime> createdAt,
+  Value<DateTime?> updatedAt,
+});
 
 class $$AccountEntriesTableFilterComposer
     extends Composer<_$AppDatabase, $AccountEntriesTable> {
@@ -8272,49 +6976,31 @@ class $$AccountEntriesTableFilterComposer
     super.$removeJoinBuilderFromRootComposer,
   });
   ColumnFilters<int> get id => $composableBuilder(
-    column: $table.id,
-    builder: (column) => ColumnFilters(column),
-  );
+      column: $table.id, builder: (column) => ColumnFilters(column));
 
   ColumnFilters<String> get uuid => $composableBuilder(
-    column: $table.uuid,
-    builder: (column) => ColumnFilters(column),
-  );
+      column: $table.uuid, builder: (column) => ColumnFilters(column));
 
   ColumnFilters<String> get name => $composableBuilder(
-    column: $table.name,
-    builder: (column) => ColumnFilters(column),
-  );
+      column: $table.name, builder: (column) => ColumnFilters(column));
 
   ColumnFilters<String> get accountType => $composableBuilder(
-    column: $table.accountType,
-    builder: (column) => ColumnFilters(column),
-  );
+      column: $table.accountType, builder: (column) => ColumnFilters(column));
 
   ColumnFilters<String> get currency => $composableBuilder(
-    column: $table.currency,
-    builder: (column) => ColumnFilters(column),
-  );
+      column: $table.currency, builder: (column) => ColumnFilters(column));
 
   ColumnFilters<int> get balanceCents => $composableBuilder(
-    column: $table.balanceCents,
-    builder: (column) => ColumnFilters(column),
-  );
+      column: $table.balanceCents, builder: (column) => ColumnFilters(column));
 
   ColumnFilters<String> get syncStatus => $composableBuilder(
-    column: $table.syncStatus,
-    builder: (column) => ColumnFilters(column),
-  );
+      column: $table.syncStatus, builder: (column) => ColumnFilters(column));
 
   ColumnFilters<DateTime> get createdAt => $composableBuilder(
-    column: $table.createdAt,
-    builder: (column) => ColumnFilters(column),
-  );
+      column: $table.createdAt, builder: (column) => ColumnFilters(column));
 
   ColumnFilters<DateTime> get updatedAt => $composableBuilder(
-    column: $table.updatedAt,
-    builder: (column) => ColumnFilters(column),
-  );
+      column: $table.updatedAt, builder: (column) => ColumnFilters(column));
 }
 
 class $$AccountEntriesTableOrderingComposer
@@ -8327,49 +7013,32 @@ class $$AccountEntriesTableOrderingComposer
     super.$removeJoinBuilderFromRootComposer,
   });
   ColumnOrderings<int> get id => $composableBuilder(
-    column: $table.id,
-    builder: (column) => ColumnOrderings(column),
-  );
+      column: $table.id, builder: (column) => ColumnOrderings(column));
 
   ColumnOrderings<String> get uuid => $composableBuilder(
-    column: $table.uuid,
-    builder: (column) => ColumnOrderings(column),
-  );
+      column: $table.uuid, builder: (column) => ColumnOrderings(column));
 
   ColumnOrderings<String> get name => $composableBuilder(
-    column: $table.name,
-    builder: (column) => ColumnOrderings(column),
-  );
+      column: $table.name, builder: (column) => ColumnOrderings(column));
 
   ColumnOrderings<String> get accountType => $composableBuilder(
-    column: $table.accountType,
-    builder: (column) => ColumnOrderings(column),
-  );
+      column: $table.accountType, builder: (column) => ColumnOrderings(column));
 
   ColumnOrderings<String> get currency => $composableBuilder(
-    column: $table.currency,
-    builder: (column) => ColumnOrderings(column),
-  );
+      column: $table.currency, builder: (column) => ColumnOrderings(column));
 
   ColumnOrderings<int> get balanceCents => $composableBuilder(
-    column: $table.balanceCents,
-    builder: (column) => ColumnOrderings(column),
-  );
+      column: $table.balanceCents,
+      builder: (column) => ColumnOrderings(column));
 
   ColumnOrderings<String> get syncStatus => $composableBuilder(
-    column: $table.syncStatus,
-    builder: (column) => ColumnOrderings(column),
-  );
+      column: $table.syncStatus, builder: (column) => ColumnOrderings(column));
 
   ColumnOrderings<DateTime> get createdAt => $composableBuilder(
-    column: $table.createdAt,
-    builder: (column) => ColumnOrderings(column),
-  );
+      column: $table.createdAt, builder: (column) => ColumnOrderings(column));
 
   ColumnOrderings<DateTime> get updatedAt => $composableBuilder(
-    column: $table.updatedAt,
-    builder: (column) => ColumnOrderings(column),
-  );
+      column: $table.updatedAt, builder: (column) => ColumnOrderings(column));
 }
 
 class $$AccountEntriesTableAnnotationComposer
@@ -8391,22 +7060,16 @@ class $$AccountEntriesTableAnnotationComposer
       $composableBuilder(column: $table.name, builder: (column) => column);
 
   GeneratedColumn<String> get accountType => $composableBuilder(
-    column: $table.accountType,
-    builder: (column) => column,
-  );
+      column: $table.accountType, builder: (column) => column);
 
   GeneratedColumn<String> get currency =>
       $composableBuilder(column: $table.currency, builder: (column) => column);
 
   GeneratedColumn<int> get balanceCents => $composableBuilder(
-    column: $table.balanceCents,
-    builder: (column) => column,
-  );
+      column: $table.balanceCents, builder: (column) => column);
 
   GeneratedColumn<String> get syncStatus => $composableBuilder(
-    column: $table.syncStatus,
-    builder: (column) => column,
-  );
+      column: $table.syncStatus, builder: (column) => column);
 
   GeneratedColumn<DateTime> get createdAt =>
       $composableBuilder(column: $table.createdAt, builder: (column) => column);
@@ -8415,29 +7078,24 @@ class $$AccountEntriesTableAnnotationComposer
       $composableBuilder(column: $table.updatedAt, builder: (column) => column);
 }
 
-class $$AccountEntriesTableTableManager
-    extends
-        RootTableManager<
-          _$AppDatabase,
-          $AccountEntriesTable,
-          AccountEntry,
-          $$AccountEntriesTableFilterComposer,
-          $$AccountEntriesTableOrderingComposer,
-          $$AccountEntriesTableAnnotationComposer,
-          $$AccountEntriesTableCreateCompanionBuilder,
-          $$AccountEntriesTableUpdateCompanionBuilder,
-          (
-            AccountEntry,
-            BaseReferences<_$AppDatabase, $AccountEntriesTable, AccountEntry>,
-          ),
-          AccountEntry,
-          PrefetchHooks Function()
-        > {
+class $$AccountEntriesTableTableManager extends RootTableManager<
+    _$AppDatabase,
+    $AccountEntriesTable,
+    AccountEntry,
+    $$AccountEntriesTableFilterComposer,
+    $$AccountEntriesTableOrderingComposer,
+    $$AccountEntriesTableAnnotationComposer,
+    $$AccountEntriesTableCreateCompanionBuilder,
+    $$AccountEntriesTableUpdateCompanionBuilder,
+    (
+      AccountEntry,
+      BaseReferences<_$AppDatabase, $AccountEntriesTable, AccountEntry>
+    ),
+    AccountEntry,
+    PrefetchHooks Function()> {
   $$AccountEntriesTableTableManager(
-    _$AppDatabase db,
-    $AccountEntriesTable table,
-  ) : super(
-        TableManagerState(
+      _$AppDatabase db, $AccountEntriesTable table)
+      : super(TableManagerState(
           db: db,
           table: table,
           createFilteringComposer: () =>
@@ -8446,105 +7104,102 @@ class $$AccountEntriesTableTableManager
               $$AccountEntriesTableOrderingComposer($db: db, $table: table),
           createComputedFieldComposer: () =>
               $$AccountEntriesTableAnnotationComposer($db: db, $table: table),
-          updateCompanionCallback:
-              ({
-                Value<int> id = const Value.absent(),
-                Value<String> uuid = const Value.absent(),
-                Value<String> name = const Value.absent(),
-                Value<String> accountType = const Value.absent(),
-                Value<String> currency = const Value.absent(),
-                Value<int> balanceCents = const Value.absent(),
-                Value<String> syncStatus = const Value.absent(),
-                Value<DateTime> createdAt = const Value.absent(),
-                Value<DateTime?> updatedAt = const Value.absent(),
-              }) => AccountEntriesCompanion(
-                id: id,
-                uuid: uuid,
-                name: name,
-                accountType: accountType,
-                currency: currency,
-                balanceCents: balanceCents,
-                syncStatus: syncStatus,
-                createdAt: createdAt,
-                updatedAt: updatedAt,
-              ),
-          createCompanionCallback:
-              ({
-                Value<int> id = const Value.absent(),
-                required String uuid,
-                required String name,
-                required String accountType,
-                Value<String> currency = const Value.absent(),
-                Value<int> balanceCents = const Value.absent(),
-                Value<String> syncStatus = const Value.absent(),
-                Value<DateTime> createdAt = const Value.absent(),
-                Value<DateTime?> updatedAt = const Value.absent(),
-              }) => AccountEntriesCompanion.insert(
-                id: id,
-                uuid: uuid,
-                name: name,
-                accountType: accountType,
-                currency: currency,
-                balanceCents: balanceCents,
-                syncStatus: syncStatus,
-                createdAt: createdAt,
-                updatedAt: updatedAt,
-              ),
+          updateCompanionCallback: ({
+            Value<int> id = const Value.absent(),
+            Value<String> uuid = const Value.absent(),
+            Value<String> name = const Value.absent(),
+            Value<String> accountType = const Value.absent(),
+            Value<String> currency = const Value.absent(),
+            Value<int> balanceCents = const Value.absent(),
+            Value<String> syncStatus = const Value.absent(),
+            Value<DateTime> createdAt = const Value.absent(),
+            Value<DateTime?> updatedAt = const Value.absent(),
+          }) =>
+              AccountEntriesCompanion(
+            id: id,
+            uuid: uuid,
+            name: name,
+            accountType: accountType,
+            currency: currency,
+            balanceCents: balanceCents,
+            syncStatus: syncStatus,
+            createdAt: createdAt,
+            updatedAt: updatedAt,
+          ),
+          createCompanionCallback: ({
+            Value<int> id = const Value.absent(),
+            required String uuid,
+            required String name,
+            required String accountType,
+            Value<String> currency = const Value.absent(),
+            Value<int> balanceCents = const Value.absent(),
+            Value<String> syncStatus = const Value.absent(),
+            Value<DateTime> createdAt = const Value.absent(),
+            Value<DateTime?> updatedAt = const Value.absent(),
+          }) =>
+              AccountEntriesCompanion.insert(
+            id: id,
+            uuid: uuid,
+            name: name,
+            accountType: accountType,
+            currency: currency,
+            balanceCents: balanceCents,
+            syncStatus: syncStatus,
+            createdAt: createdAt,
+            updatedAt: updatedAt,
+          ),
           withReferenceMapper: (p0) => p0
               .map((e) => (e.readTable(table), BaseReferences(db, table, e)))
               .toList(),
           prefetchHooksCallback: null,
-        ),
-      );
+        ));
 }
 
-typedef $$AccountEntriesTableProcessedTableManager =
-    ProcessedTableManager<
-      _$AppDatabase,
-      $AccountEntriesTable,
+typedef $$AccountEntriesTableProcessedTableManager = ProcessedTableManager<
+    _$AppDatabase,
+    $AccountEntriesTable,
+    AccountEntry,
+    $$AccountEntriesTableFilterComposer,
+    $$AccountEntriesTableOrderingComposer,
+    $$AccountEntriesTableAnnotationComposer,
+    $$AccountEntriesTableCreateCompanionBuilder,
+    $$AccountEntriesTableUpdateCompanionBuilder,
+    (
       AccountEntry,
-      $$AccountEntriesTableFilterComposer,
-      $$AccountEntriesTableOrderingComposer,
-      $$AccountEntriesTableAnnotationComposer,
-      $$AccountEntriesTableCreateCompanionBuilder,
-      $$AccountEntriesTableUpdateCompanionBuilder,
-      (
-        AccountEntry,
-        BaseReferences<_$AppDatabase, $AccountEntriesTable, AccountEntry>,
-      ),
-      AccountEntry,
-      PrefetchHooks Function()
-    >;
-typedef $$CategoryEntriesTableCreateCompanionBuilder =
-    CategoryEntriesCompanion Function({
-      Value<int> id,
-      required String uuid,
-      required String name,
-      Value<String> iconName,
-      Value<String> colorHex,
-      Value<String> categoryType,
-      Value<String?> parentId,
-      Value<int> sortOrder,
-      Value<bool> isActive,
-      Value<String> syncStatus,
-      Value<DateTime> createdAt,
-      Value<DateTime?> updatedAt,
-    });
-typedef $$CategoryEntriesTableUpdateCompanionBuilder =
-    CategoryEntriesCompanion Function({
-      Value<int> id,
-      Value<String> uuid,
-      Value<String> name,
-      Value<String> iconName,
-      Value<String> colorHex,
-      Value<String> categoryType,
-      Value<String?> parentId,
-      Value<int> sortOrder,
-      Value<bool> isActive,
-      Value<String> syncStatus,
-      Value<DateTime> createdAt,
-      Value<DateTime?> updatedAt,
-    });
+      BaseReferences<_$AppDatabase, $AccountEntriesTable, AccountEntry>
+    ),
+    AccountEntry,
+    PrefetchHooks Function()>;
+typedef $$CategoryEntriesTableCreateCompanionBuilder = CategoryEntriesCompanion
+    Function({
+  Value<int> id,
+  required String uuid,
+  required String name,
+  Value<String> iconName,
+  Value<String> colorHex,
+  Value<String> categoryType,
+  Value<String?> parentId,
+  Value<int> sortOrder,
+  Value<bool> isActive,
+  Value<String> syncStatus,
+  Value<DateTime> createdAt,
+  Value<DateTime?> updatedAt,
+});
+typedef $$CategoryEntriesTableUpdateCompanionBuilder = CategoryEntriesCompanion
+    Function({
+  Value<int> id,
+  Value<String> uuid,
+  Value<String> name,
+  Value<String> iconName,
+  Value<String> colorHex,
+  Value<String> categoryType,
+  Value<String?> parentId,
+  Value<int> sortOrder,
+  Value<bool> isActive,
+  Value<String> syncStatus,
+  Value<DateTime> createdAt,
+  Value<DateTime?> updatedAt,
+});
 
 class $$CategoryEntriesTableFilterComposer
     extends Composer<_$AppDatabase, $CategoryEntriesTable> {
@@ -8556,64 +7211,40 @@ class $$CategoryEntriesTableFilterComposer
     super.$removeJoinBuilderFromRootComposer,
   });
   ColumnFilters<int> get id => $composableBuilder(
-    column: $table.id,
-    builder: (column) => ColumnFilters(column),
-  );
+      column: $table.id, builder: (column) => ColumnFilters(column));
 
   ColumnFilters<String> get uuid => $composableBuilder(
-    column: $table.uuid,
-    builder: (column) => ColumnFilters(column),
-  );
+      column: $table.uuid, builder: (column) => ColumnFilters(column));
 
   ColumnFilters<String> get name => $composableBuilder(
-    column: $table.name,
-    builder: (column) => ColumnFilters(column),
-  );
+      column: $table.name, builder: (column) => ColumnFilters(column));
 
   ColumnFilters<String> get iconName => $composableBuilder(
-    column: $table.iconName,
-    builder: (column) => ColumnFilters(column),
-  );
+      column: $table.iconName, builder: (column) => ColumnFilters(column));
 
   ColumnFilters<String> get colorHex => $composableBuilder(
-    column: $table.colorHex,
-    builder: (column) => ColumnFilters(column),
-  );
+      column: $table.colorHex, builder: (column) => ColumnFilters(column));
 
   ColumnFilters<String> get categoryType => $composableBuilder(
-    column: $table.categoryType,
-    builder: (column) => ColumnFilters(column),
-  );
+      column: $table.categoryType, builder: (column) => ColumnFilters(column));
 
   ColumnFilters<String> get parentId => $composableBuilder(
-    column: $table.parentId,
-    builder: (column) => ColumnFilters(column),
-  );
+      column: $table.parentId, builder: (column) => ColumnFilters(column));
 
   ColumnFilters<int> get sortOrder => $composableBuilder(
-    column: $table.sortOrder,
-    builder: (column) => ColumnFilters(column),
-  );
+      column: $table.sortOrder, builder: (column) => ColumnFilters(column));
 
   ColumnFilters<bool> get isActive => $composableBuilder(
-    column: $table.isActive,
-    builder: (column) => ColumnFilters(column),
-  );
+      column: $table.isActive, builder: (column) => ColumnFilters(column));
 
   ColumnFilters<String> get syncStatus => $composableBuilder(
-    column: $table.syncStatus,
-    builder: (column) => ColumnFilters(column),
-  );
+      column: $table.syncStatus, builder: (column) => ColumnFilters(column));
 
   ColumnFilters<DateTime> get createdAt => $composableBuilder(
-    column: $table.createdAt,
-    builder: (column) => ColumnFilters(column),
-  );
+      column: $table.createdAt, builder: (column) => ColumnFilters(column));
 
   ColumnFilters<DateTime> get updatedAt => $composableBuilder(
-    column: $table.updatedAt,
-    builder: (column) => ColumnFilters(column),
-  );
+      column: $table.updatedAt, builder: (column) => ColumnFilters(column));
 }
 
 class $$CategoryEntriesTableOrderingComposer
@@ -8626,64 +7257,41 @@ class $$CategoryEntriesTableOrderingComposer
     super.$removeJoinBuilderFromRootComposer,
   });
   ColumnOrderings<int> get id => $composableBuilder(
-    column: $table.id,
-    builder: (column) => ColumnOrderings(column),
-  );
+      column: $table.id, builder: (column) => ColumnOrderings(column));
 
   ColumnOrderings<String> get uuid => $composableBuilder(
-    column: $table.uuid,
-    builder: (column) => ColumnOrderings(column),
-  );
+      column: $table.uuid, builder: (column) => ColumnOrderings(column));
 
   ColumnOrderings<String> get name => $composableBuilder(
-    column: $table.name,
-    builder: (column) => ColumnOrderings(column),
-  );
+      column: $table.name, builder: (column) => ColumnOrderings(column));
 
   ColumnOrderings<String> get iconName => $composableBuilder(
-    column: $table.iconName,
-    builder: (column) => ColumnOrderings(column),
-  );
+      column: $table.iconName, builder: (column) => ColumnOrderings(column));
 
   ColumnOrderings<String> get colorHex => $composableBuilder(
-    column: $table.colorHex,
-    builder: (column) => ColumnOrderings(column),
-  );
+      column: $table.colorHex, builder: (column) => ColumnOrderings(column));
 
   ColumnOrderings<String> get categoryType => $composableBuilder(
-    column: $table.categoryType,
-    builder: (column) => ColumnOrderings(column),
-  );
+      column: $table.categoryType,
+      builder: (column) => ColumnOrderings(column));
 
   ColumnOrderings<String> get parentId => $composableBuilder(
-    column: $table.parentId,
-    builder: (column) => ColumnOrderings(column),
-  );
+      column: $table.parentId, builder: (column) => ColumnOrderings(column));
 
   ColumnOrderings<int> get sortOrder => $composableBuilder(
-    column: $table.sortOrder,
-    builder: (column) => ColumnOrderings(column),
-  );
+      column: $table.sortOrder, builder: (column) => ColumnOrderings(column));
 
   ColumnOrderings<bool> get isActive => $composableBuilder(
-    column: $table.isActive,
-    builder: (column) => ColumnOrderings(column),
-  );
+      column: $table.isActive, builder: (column) => ColumnOrderings(column));
 
   ColumnOrderings<String> get syncStatus => $composableBuilder(
-    column: $table.syncStatus,
-    builder: (column) => ColumnOrderings(column),
-  );
+      column: $table.syncStatus, builder: (column) => ColumnOrderings(column));
 
   ColumnOrderings<DateTime> get createdAt => $composableBuilder(
-    column: $table.createdAt,
-    builder: (column) => ColumnOrderings(column),
-  );
+      column: $table.createdAt, builder: (column) => ColumnOrderings(column));
 
   ColumnOrderings<DateTime> get updatedAt => $composableBuilder(
-    column: $table.updatedAt,
-    builder: (column) => ColumnOrderings(column),
-  );
+      column: $table.updatedAt, builder: (column) => ColumnOrderings(column));
 }
 
 class $$CategoryEntriesTableAnnotationComposer
@@ -8711,9 +7319,7 @@ class $$CategoryEntriesTableAnnotationComposer
       $composableBuilder(column: $table.colorHex, builder: (column) => column);
 
   GeneratedColumn<String> get categoryType => $composableBuilder(
-    column: $table.categoryType,
-    builder: (column) => column,
-  );
+      column: $table.categoryType, builder: (column) => column);
 
   GeneratedColumn<String> get parentId =>
       $composableBuilder(column: $table.parentId, builder: (column) => column);
@@ -8725,9 +7331,7 @@ class $$CategoryEntriesTableAnnotationComposer
       $composableBuilder(column: $table.isActive, builder: (column) => column);
 
   GeneratedColumn<String> get syncStatus => $composableBuilder(
-    column: $table.syncStatus,
-    builder: (column) => column,
-  );
+      column: $table.syncStatus, builder: (column) => column);
 
   GeneratedColumn<DateTime> get createdAt =>
       $composableBuilder(column: $table.createdAt, builder: (column) => column);
@@ -8736,29 +7340,24 @@ class $$CategoryEntriesTableAnnotationComposer
       $composableBuilder(column: $table.updatedAt, builder: (column) => column);
 }
 
-class $$CategoryEntriesTableTableManager
-    extends
-        RootTableManager<
-          _$AppDatabase,
-          $CategoryEntriesTable,
-          CategoryEntry,
-          $$CategoryEntriesTableFilterComposer,
-          $$CategoryEntriesTableOrderingComposer,
-          $$CategoryEntriesTableAnnotationComposer,
-          $$CategoryEntriesTableCreateCompanionBuilder,
-          $$CategoryEntriesTableUpdateCompanionBuilder,
-          (
-            CategoryEntry,
-            BaseReferences<_$AppDatabase, $CategoryEntriesTable, CategoryEntry>,
-          ),
-          CategoryEntry,
-          PrefetchHooks Function()
-        > {
+class $$CategoryEntriesTableTableManager extends RootTableManager<
+    _$AppDatabase,
+    $CategoryEntriesTable,
+    CategoryEntry,
+    $$CategoryEntriesTableFilterComposer,
+    $$CategoryEntriesTableOrderingComposer,
+    $$CategoryEntriesTableAnnotationComposer,
+    $$CategoryEntriesTableCreateCompanionBuilder,
+    $$CategoryEntriesTableUpdateCompanionBuilder,
+    (
+      CategoryEntry,
+      BaseReferences<_$AppDatabase, $CategoryEntriesTable, CategoryEntry>
+    ),
+    CategoryEntry,
+    PrefetchHooks Function()> {
   $$CategoryEntriesTableTableManager(
-    _$AppDatabase db,
-    $CategoryEntriesTable table,
-  ) : super(
-        TableManagerState(
+      _$AppDatabase db, $CategoryEntriesTable table)
+      : super(TableManagerState(
           db: db,
           table: table,
           createFilteringComposer: () =>
@@ -8767,119 +7366,116 @@ class $$CategoryEntriesTableTableManager
               $$CategoryEntriesTableOrderingComposer($db: db, $table: table),
           createComputedFieldComposer: () =>
               $$CategoryEntriesTableAnnotationComposer($db: db, $table: table),
-          updateCompanionCallback:
-              ({
-                Value<int> id = const Value.absent(),
-                Value<String> uuid = const Value.absent(),
-                Value<String> name = const Value.absent(),
-                Value<String> iconName = const Value.absent(),
-                Value<String> colorHex = const Value.absent(),
-                Value<String> categoryType = const Value.absent(),
-                Value<String?> parentId = const Value.absent(),
-                Value<int> sortOrder = const Value.absent(),
-                Value<bool> isActive = const Value.absent(),
-                Value<String> syncStatus = const Value.absent(),
-                Value<DateTime> createdAt = const Value.absent(),
-                Value<DateTime?> updatedAt = const Value.absent(),
-              }) => CategoryEntriesCompanion(
-                id: id,
-                uuid: uuid,
-                name: name,
-                iconName: iconName,
-                colorHex: colorHex,
-                categoryType: categoryType,
-                parentId: parentId,
-                sortOrder: sortOrder,
-                isActive: isActive,
-                syncStatus: syncStatus,
-                createdAt: createdAt,
-                updatedAt: updatedAt,
-              ),
-          createCompanionCallback:
-              ({
-                Value<int> id = const Value.absent(),
-                required String uuid,
-                required String name,
-                Value<String> iconName = const Value.absent(),
-                Value<String> colorHex = const Value.absent(),
-                Value<String> categoryType = const Value.absent(),
-                Value<String?> parentId = const Value.absent(),
-                Value<int> sortOrder = const Value.absent(),
-                Value<bool> isActive = const Value.absent(),
-                Value<String> syncStatus = const Value.absent(),
-                Value<DateTime> createdAt = const Value.absent(),
-                Value<DateTime?> updatedAt = const Value.absent(),
-              }) => CategoryEntriesCompanion.insert(
-                id: id,
-                uuid: uuid,
-                name: name,
-                iconName: iconName,
-                colorHex: colorHex,
-                categoryType: categoryType,
-                parentId: parentId,
-                sortOrder: sortOrder,
-                isActive: isActive,
-                syncStatus: syncStatus,
-                createdAt: createdAt,
-                updatedAt: updatedAt,
-              ),
+          updateCompanionCallback: ({
+            Value<int> id = const Value.absent(),
+            Value<String> uuid = const Value.absent(),
+            Value<String> name = const Value.absent(),
+            Value<String> iconName = const Value.absent(),
+            Value<String> colorHex = const Value.absent(),
+            Value<String> categoryType = const Value.absent(),
+            Value<String?> parentId = const Value.absent(),
+            Value<int> sortOrder = const Value.absent(),
+            Value<bool> isActive = const Value.absent(),
+            Value<String> syncStatus = const Value.absent(),
+            Value<DateTime> createdAt = const Value.absent(),
+            Value<DateTime?> updatedAt = const Value.absent(),
+          }) =>
+              CategoryEntriesCompanion(
+            id: id,
+            uuid: uuid,
+            name: name,
+            iconName: iconName,
+            colorHex: colorHex,
+            categoryType: categoryType,
+            parentId: parentId,
+            sortOrder: sortOrder,
+            isActive: isActive,
+            syncStatus: syncStatus,
+            createdAt: createdAt,
+            updatedAt: updatedAt,
+          ),
+          createCompanionCallback: ({
+            Value<int> id = const Value.absent(),
+            required String uuid,
+            required String name,
+            Value<String> iconName = const Value.absent(),
+            Value<String> colorHex = const Value.absent(),
+            Value<String> categoryType = const Value.absent(),
+            Value<String?> parentId = const Value.absent(),
+            Value<int> sortOrder = const Value.absent(),
+            Value<bool> isActive = const Value.absent(),
+            Value<String> syncStatus = const Value.absent(),
+            Value<DateTime> createdAt = const Value.absent(),
+            Value<DateTime?> updatedAt = const Value.absent(),
+          }) =>
+              CategoryEntriesCompanion.insert(
+            id: id,
+            uuid: uuid,
+            name: name,
+            iconName: iconName,
+            colorHex: colorHex,
+            categoryType: categoryType,
+            parentId: parentId,
+            sortOrder: sortOrder,
+            isActive: isActive,
+            syncStatus: syncStatus,
+            createdAt: createdAt,
+            updatedAt: updatedAt,
+          ),
           withReferenceMapper: (p0) => p0
               .map((e) => (e.readTable(table), BaseReferences(db, table, e)))
               .toList(),
           prefetchHooksCallback: null,
-        ),
-      );
+        ));
 }
 
-typedef $$CategoryEntriesTableProcessedTableManager =
-    ProcessedTableManager<
-      _$AppDatabase,
-      $CategoryEntriesTable,
+typedef $$CategoryEntriesTableProcessedTableManager = ProcessedTableManager<
+    _$AppDatabase,
+    $CategoryEntriesTable,
+    CategoryEntry,
+    $$CategoryEntriesTableFilterComposer,
+    $$CategoryEntriesTableOrderingComposer,
+    $$CategoryEntriesTableAnnotationComposer,
+    $$CategoryEntriesTableCreateCompanionBuilder,
+    $$CategoryEntriesTableUpdateCompanionBuilder,
+    (
       CategoryEntry,
-      $$CategoryEntriesTableFilterComposer,
-      $$CategoryEntriesTableOrderingComposer,
-      $$CategoryEntriesTableAnnotationComposer,
-      $$CategoryEntriesTableCreateCompanionBuilder,
-      $$CategoryEntriesTableUpdateCompanionBuilder,
-      (
-        CategoryEntry,
-        BaseReferences<_$AppDatabase, $CategoryEntriesTable, CategoryEntry>,
-      ),
-      CategoryEntry,
-      PrefetchHooks Function()
-    >;
-typedef $$GroupEntriesTableCreateCompanionBuilder =
-    GroupEntriesCompanion Function({
-      Value<int> id,
-      required String uuid,
-      required String name,
-      Value<String?> description,
-      Value<String?> iconUrl,
-      required String createdByUserId,
-      Value<String> defaultCurrency,
-      Value<bool> simplifyDebts,
-      Value<bool> isActive,
-      Value<String?> inviteCode,
-      Value<String> syncStatus,
-      Value<DateTime> createdAt,
-      Value<DateTime?> updatedAt,
-    });
-typedef $$GroupEntriesTableUpdateCompanionBuilder =
-    GroupEntriesCompanion Function({
-      Value<int> id,
-      Value<String> uuid,
-      Value<String> name,
-      Value<String?> description,
-      Value<String?> iconUrl,
-      Value<String> createdByUserId,
-      Value<String> defaultCurrency,
-      Value<bool> simplifyDebts,
-      Value<bool> isActive,
-      Value<String?> inviteCode,
-      Value<String> syncStatus,
-      Value<DateTime> createdAt,
-      Value<DateTime?> updatedAt,
-    });
+      BaseReferences<_$AppDatabase, $CategoryEntriesTable, CategoryEntry>
+    ),
+    CategoryEntry,
+    PrefetchHooks Function()>;
+typedef $$GroupEntriesTableCreateCompanionBuilder = GroupEntriesCompanion
+    Function({
+  Value<int> id,
+  required String uuid,
+  required String name,
+  Value<String?> description,
+  Value<String?> iconUrl,
+  required String createdByUserId,
+  Value<String> defaultCurrency,
+  Value<bool> simplifyDebts,
+  Value<bool> isActive,
+  Value<String?> inviteCode,
+  Value<String> syncStatus,
+  Value<DateTime> createdAt,
+  Value<DateTime?> updatedAt,
+});
+typedef $$GroupEntriesTableUpdateCompanionBuilder = GroupEntriesCompanion
+    Function({
+  Value<int> id,
+  Value<String> uuid,
+  Value<String> name,
+  Value<String?> description,
+  Value<String?> iconUrl,
+  Value<String> createdByUserId,
+  Value<String> defaultCurrency,
+  Value<bool> simplifyDebts,
+  Value<bool> isActive,
+  Value<String?> inviteCode,
+  Value<String> syncStatus,
+  Value<DateTime> createdAt,
+  Value<DateTime?> updatedAt,
+});
 
 class $$GroupEntriesTableFilterComposer
     extends Composer<_$AppDatabase, $GroupEntriesTable> {
@@ -8891,69 +7487,45 @@ class $$GroupEntriesTableFilterComposer
     super.$removeJoinBuilderFromRootComposer,
   });
   ColumnFilters<int> get id => $composableBuilder(
-    column: $table.id,
-    builder: (column) => ColumnFilters(column),
-  );
+      column: $table.id, builder: (column) => ColumnFilters(column));
 
   ColumnFilters<String> get uuid => $composableBuilder(
-    column: $table.uuid,
-    builder: (column) => ColumnFilters(column),
-  );
+      column: $table.uuid, builder: (column) => ColumnFilters(column));
 
   ColumnFilters<String> get name => $composableBuilder(
-    column: $table.name,
-    builder: (column) => ColumnFilters(column),
-  );
+      column: $table.name, builder: (column) => ColumnFilters(column));
 
   ColumnFilters<String> get description => $composableBuilder(
-    column: $table.description,
-    builder: (column) => ColumnFilters(column),
-  );
+      column: $table.description, builder: (column) => ColumnFilters(column));
 
   ColumnFilters<String> get iconUrl => $composableBuilder(
-    column: $table.iconUrl,
-    builder: (column) => ColumnFilters(column),
-  );
+      column: $table.iconUrl, builder: (column) => ColumnFilters(column));
 
   ColumnFilters<String> get createdByUserId => $composableBuilder(
-    column: $table.createdByUserId,
-    builder: (column) => ColumnFilters(column),
-  );
+      column: $table.createdByUserId,
+      builder: (column) => ColumnFilters(column));
 
   ColumnFilters<String> get defaultCurrency => $composableBuilder(
-    column: $table.defaultCurrency,
-    builder: (column) => ColumnFilters(column),
-  );
+      column: $table.defaultCurrency,
+      builder: (column) => ColumnFilters(column));
 
   ColumnFilters<bool> get simplifyDebts => $composableBuilder(
-    column: $table.simplifyDebts,
-    builder: (column) => ColumnFilters(column),
-  );
+      column: $table.simplifyDebts, builder: (column) => ColumnFilters(column));
 
   ColumnFilters<bool> get isActive => $composableBuilder(
-    column: $table.isActive,
-    builder: (column) => ColumnFilters(column),
-  );
+      column: $table.isActive, builder: (column) => ColumnFilters(column));
 
   ColumnFilters<String> get inviteCode => $composableBuilder(
-    column: $table.inviteCode,
-    builder: (column) => ColumnFilters(column),
-  );
+      column: $table.inviteCode, builder: (column) => ColumnFilters(column));
 
   ColumnFilters<String> get syncStatus => $composableBuilder(
-    column: $table.syncStatus,
-    builder: (column) => ColumnFilters(column),
-  );
+      column: $table.syncStatus, builder: (column) => ColumnFilters(column));
 
   ColumnFilters<DateTime> get createdAt => $composableBuilder(
-    column: $table.createdAt,
-    builder: (column) => ColumnFilters(column),
-  );
+      column: $table.createdAt, builder: (column) => ColumnFilters(column));
 
   ColumnFilters<DateTime> get updatedAt => $composableBuilder(
-    column: $table.updatedAt,
-    builder: (column) => ColumnFilters(column),
-  );
+      column: $table.updatedAt, builder: (column) => ColumnFilters(column));
 }
 
 class $$GroupEntriesTableOrderingComposer
@@ -8966,69 +7538,46 @@ class $$GroupEntriesTableOrderingComposer
     super.$removeJoinBuilderFromRootComposer,
   });
   ColumnOrderings<int> get id => $composableBuilder(
-    column: $table.id,
-    builder: (column) => ColumnOrderings(column),
-  );
+      column: $table.id, builder: (column) => ColumnOrderings(column));
 
   ColumnOrderings<String> get uuid => $composableBuilder(
-    column: $table.uuid,
-    builder: (column) => ColumnOrderings(column),
-  );
+      column: $table.uuid, builder: (column) => ColumnOrderings(column));
 
   ColumnOrderings<String> get name => $composableBuilder(
-    column: $table.name,
-    builder: (column) => ColumnOrderings(column),
-  );
+      column: $table.name, builder: (column) => ColumnOrderings(column));
 
   ColumnOrderings<String> get description => $composableBuilder(
-    column: $table.description,
-    builder: (column) => ColumnOrderings(column),
-  );
+      column: $table.description, builder: (column) => ColumnOrderings(column));
 
   ColumnOrderings<String> get iconUrl => $composableBuilder(
-    column: $table.iconUrl,
-    builder: (column) => ColumnOrderings(column),
-  );
+      column: $table.iconUrl, builder: (column) => ColumnOrderings(column));
 
   ColumnOrderings<String> get createdByUserId => $composableBuilder(
-    column: $table.createdByUserId,
-    builder: (column) => ColumnOrderings(column),
-  );
+      column: $table.createdByUserId,
+      builder: (column) => ColumnOrderings(column));
 
   ColumnOrderings<String> get defaultCurrency => $composableBuilder(
-    column: $table.defaultCurrency,
-    builder: (column) => ColumnOrderings(column),
-  );
+      column: $table.defaultCurrency,
+      builder: (column) => ColumnOrderings(column));
 
   ColumnOrderings<bool> get simplifyDebts => $composableBuilder(
-    column: $table.simplifyDebts,
-    builder: (column) => ColumnOrderings(column),
-  );
+      column: $table.simplifyDebts,
+      builder: (column) => ColumnOrderings(column));
 
   ColumnOrderings<bool> get isActive => $composableBuilder(
-    column: $table.isActive,
-    builder: (column) => ColumnOrderings(column),
-  );
+      column: $table.isActive, builder: (column) => ColumnOrderings(column));
 
   ColumnOrderings<String> get inviteCode => $composableBuilder(
-    column: $table.inviteCode,
-    builder: (column) => ColumnOrderings(column),
-  );
+      column: $table.inviteCode, builder: (column) => ColumnOrderings(column));
 
   ColumnOrderings<String> get syncStatus => $composableBuilder(
-    column: $table.syncStatus,
-    builder: (column) => ColumnOrderings(column),
-  );
+      column: $table.syncStatus, builder: (column) => ColumnOrderings(column));
 
   ColumnOrderings<DateTime> get createdAt => $composableBuilder(
-    column: $table.createdAt,
-    builder: (column) => ColumnOrderings(column),
-  );
+      column: $table.createdAt, builder: (column) => ColumnOrderings(column));
 
   ColumnOrderings<DateTime> get updatedAt => $composableBuilder(
-    column: $table.updatedAt,
-    builder: (column) => ColumnOrderings(column),
-  );
+      column: $table.updatedAt, builder: (column) => ColumnOrderings(column));
 }
 
 class $$GroupEntriesTableAnnotationComposer
@@ -9050,40 +7599,28 @@ class $$GroupEntriesTableAnnotationComposer
       $composableBuilder(column: $table.name, builder: (column) => column);
 
   GeneratedColumn<String> get description => $composableBuilder(
-    column: $table.description,
-    builder: (column) => column,
-  );
+      column: $table.description, builder: (column) => column);
 
   GeneratedColumn<String> get iconUrl =>
       $composableBuilder(column: $table.iconUrl, builder: (column) => column);
 
   GeneratedColumn<String> get createdByUserId => $composableBuilder(
-    column: $table.createdByUserId,
-    builder: (column) => column,
-  );
+      column: $table.createdByUserId, builder: (column) => column);
 
   GeneratedColumn<String> get defaultCurrency => $composableBuilder(
-    column: $table.defaultCurrency,
-    builder: (column) => column,
-  );
+      column: $table.defaultCurrency, builder: (column) => column);
 
   GeneratedColumn<bool> get simplifyDebts => $composableBuilder(
-    column: $table.simplifyDebts,
-    builder: (column) => column,
-  );
+      column: $table.simplifyDebts, builder: (column) => column);
 
   GeneratedColumn<bool> get isActive =>
       $composableBuilder(column: $table.isActive, builder: (column) => column);
 
   GeneratedColumn<String> get inviteCode => $composableBuilder(
-    column: $table.inviteCode,
-    builder: (column) => column,
-  );
+      column: $table.inviteCode, builder: (column) => column);
 
   GeneratedColumn<String> get syncStatus => $composableBuilder(
-    column: $table.syncStatus,
-    builder: (column) => column,
-  );
+      column: $table.syncStatus, builder: (column) => column);
 
   GeneratedColumn<DateTime> get createdAt =>
       $composableBuilder(column: $table.createdAt, builder: (column) => column);
@@ -9092,27 +7629,20 @@ class $$GroupEntriesTableAnnotationComposer
       $composableBuilder(column: $table.updatedAt, builder: (column) => column);
 }
 
-class $$GroupEntriesTableTableManager
-    extends
-        RootTableManager<
-          _$AppDatabase,
-          $GroupEntriesTable,
-          GroupEntry,
-          $$GroupEntriesTableFilterComposer,
-          $$GroupEntriesTableOrderingComposer,
-          $$GroupEntriesTableAnnotationComposer,
-          $$GroupEntriesTableCreateCompanionBuilder,
-          $$GroupEntriesTableUpdateCompanionBuilder,
-          (
-            GroupEntry,
-            BaseReferences<_$AppDatabase, $GroupEntriesTable, GroupEntry>,
-          ),
-          GroupEntry,
-          PrefetchHooks Function()
-        > {
+class $$GroupEntriesTableTableManager extends RootTableManager<
+    _$AppDatabase,
+    $GroupEntriesTable,
+    GroupEntry,
+    $$GroupEntriesTableFilterComposer,
+    $$GroupEntriesTableOrderingComposer,
+    $$GroupEntriesTableAnnotationComposer,
+    $$GroupEntriesTableCreateCompanionBuilder,
+    $$GroupEntriesTableUpdateCompanionBuilder,
+    (GroupEntry, BaseReferences<_$AppDatabase, $GroupEntriesTable, GroupEntry>),
+    GroupEntry,
+    PrefetchHooks Function()> {
   $$GroupEntriesTableTableManager(_$AppDatabase db, $GroupEntriesTable table)
-    : super(
-        TableManagerState(
+      : super(TableManagerState(
           db: db,
           table: table,
           createFilteringComposer: () =>
@@ -9121,123 +7651,117 @@ class $$GroupEntriesTableTableManager
               $$GroupEntriesTableOrderingComposer($db: db, $table: table),
           createComputedFieldComposer: () =>
               $$GroupEntriesTableAnnotationComposer($db: db, $table: table),
-          updateCompanionCallback:
-              ({
-                Value<int> id = const Value.absent(),
-                Value<String> uuid = const Value.absent(),
-                Value<String> name = const Value.absent(),
-                Value<String?> description = const Value.absent(),
-                Value<String?> iconUrl = const Value.absent(),
-                Value<String> createdByUserId = const Value.absent(),
-                Value<String> defaultCurrency = const Value.absent(),
-                Value<bool> simplifyDebts = const Value.absent(),
-                Value<bool> isActive = const Value.absent(),
-                Value<String?> inviteCode = const Value.absent(),
-                Value<String> syncStatus = const Value.absent(),
-                Value<DateTime> createdAt = const Value.absent(),
-                Value<DateTime?> updatedAt = const Value.absent(),
-              }) => GroupEntriesCompanion(
-                id: id,
-                uuid: uuid,
-                name: name,
-                description: description,
-                iconUrl: iconUrl,
-                createdByUserId: createdByUserId,
-                defaultCurrency: defaultCurrency,
-                simplifyDebts: simplifyDebts,
-                isActive: isActive,
-                inviteCode: inviteCode,
-                syncStatus: syncStatus,
-                createdAt: createdAt,
-                updatedAt: updatedAt,
-              ),
-          createCompanionCallback:
-              ({
-                Value<int> id = const Value.absent(),
-                required String uuid,
-                required String name,
-                Value<String?> description = const Value.absent(),
-                Value<String?> iconUrl = const Value.absent(),
-                required String createdByUserId,
-                Value<String> defaultCurrency = const Value.absent(),
-                Value<bool> simplifyDebts = const Value.absent(),
-                Value<bool> isActive = const Value.absent(),
-                Value<String?> inviteCode = const Value.absent(),
-                Value<String> syncStatus = const Value.absent(),
-                Value<DateTime> createdAt = const Value.absent(),
-                Value<DateTime?> updatedAt = const Value.absent(),
-              }) => GroupEntriesCompanion.insert(
-                id: id,
-                uuid: uuid,
-                name: name,
-                description: description,
-                iconUrl: iconUrl,
-                createdByUserId: createdByUserId,
-                defaultCurrency: defaultCurrency,
-                simplifyDebts: simplifyDebts,
-                isActive: isActive,
-                inviteCode: inviteCode,
-                syncStatus: syncStatus,
-                createdAt: createdAt,
-                updatedAt: updatedAt,
-              ),
+          updateCompanionCallback: ({
+            Value<int> id = const Value.absent(),
+            Value<String> uuid = const Value.absent(),
+            Value<String> name = const Value.absent(),
+            Value<String?> description = const Value.absent(),
+            Value<String?> iconUrl = const Value.absent(),
+            Value<String> createdByUserId = const Value.absent(),
+            Value<String> defaultCurrency = const Value.absent(),
+            Value<bool> simplifyDebts = const Value.absent(),
+            Value<bool> isActive = const Value.absent(),
+            Value<String?> inviteCode = const Value.absent(),
+            Value<String> syncStatus = const Value.absent(),
+            Value<DateTime> createdAt = const Value.absent(),
+            Value<DateTime?> updatedAt = const Value.absent(),
+          }) =>
+              GroupEntriesCompanion(
+            id: id,
+            uuid: uuid,
+            name: name,
+            description: description,
+            iconUrl: iconUrl,
+            createdByUserId: createdByUserId,
+            defaultCurrency: defaultCurrency,
+            simplifyDebts: simplifyDebts,
+            isActive: isActive,
+            inviteCode: inviteCode,
+            syncStatus: syncStatus,
+            createdAt: createdAt,
+            updatedAt: updatedAt,
+          ),
+          createCompanionCallback: ({
+            Value<int> id = const Value.absent(),
+            required String uuid,
+            required String name,
+            Value<String?> description = const Value.absent(),
+            Value<String?> iconUrl = const Value.absent(),
+            required String createdByUserId,
+            Value<String> defaultCurrency = const Value.absent(),
+            Value<bool> simplifyDebts = const Value.absent(),
+            Value<bool> isActive = const Value.absent(),
+            Value<String?> inviteCode = const Value.absent(),
+            Value<String> syncStatus = const Value.absent(),
+            Value<DateTime> createdAt = const Value.absent(),
+            Value<DateTime?> updatedAt = const Value.absent(),
+          }) =>
+              GroupEntriesCompanion.insert(
+            id: id,
+            uuid: uuid,
+            name: name,
+            description: description,
+            iconUrl: iconUrl,
+            createdByUserId: createdByUserId,
+            defaultCurrency: defaultCurrency,
+            simplifyDebts: simplifyDebts,
+            isActive: isActive,
+            inviteCode: inviteCode,
+            syncStatus: syncStatus,
+            createdAt: createdAt,
+            updatedAt: updatedAt,
+          ),
           withReferenceMapper: (p0) => p0
               .map((e) => (e.readTable(table), BaseReferences(db, table, e)))
               .toList(),
           prefetchHooksCallback: null,
-        ),
-      );
+        ));
 }
 
-typedef $$GroupEntriesTableProcessedTableManager =
-    ProcessedTableManager<
-      _$AppDatabase,
-      $GroupEntriesTable,
-      GroupEntry,
-      $$GroupEntriesTableFilterComposer,
-      $$GroupEntriesTableOrderingComposer,
-      $$GroupEntriesTableAnnotationComposer,
-      $$GroupEntriesTableCreateCompanionBuilder,
-      $$GroupEntriesTableUpdateCompanionBuilder,
-      (
-        GroupEntry,
-        BaseReferences<_$AppDatabase, $GroupEntriesTable, GroupEntry>,
-      ),
-      GroupEntry,
-      PrefetchHooks Function()
-    >;
-typedef $$GroupMemberEntriesTableCreateCompanionBuilder =
-    GroupMemberEntriesCompanion Function({
-      Value<int> id,
-      required String uuid,
-      required String groupId,
-      required String userId,
-      required String displayName,
-      Value<String?> email,
-      Value<String?> avatarUrl,
-      Value<String> role,
-      Value<int> defaultSharePercent,
-      Value<bool> isActive,
-      Value<String> syncStatus,
-      Value<DateTime> joinedAt,
-      Value<DateTime?> updatedAt,
-    });
-typedef $$GroupMemberEntriesTableUpdateCompanionBuilder =
-    GroupMemberEntriesCompanion Function({
-      Value<int> id,
-      Value<String> uuid,
-      Value<String> groupId,
-      Value<String> userId,
-      Value<String> displayName,
-      Value<String?> email,
-      Value<String?> avatarUrl,
-      Value<String> role,
-      Value<int> defaultSharePercent,
-      Value<bool> isActive,
-      Value<String> syncStatus,
-      Value<DateTime> joinedAt,
-      Value<DateTime?> updatedAt,
-    });
+typedef $$GroupEntriesTableProcessedTableManager = ProcessedTableManager<
+    _$AppDatabase,
+    $GroupEntriesTable,
+    GroupEntry,
+    $$GroupEntriesTableFilterComposer,
+    $$GroupEntriesTableOrderingComposer,
+    $$GroupEntriesTableAnnotationComposer,
+    $$GroupEntriesTableCreateCompanionBuilder,
+    $$GroupEntriesTableUpdateCompanionBuilder,
+    (GroupEntry, BaseReferences<_$AppDatabase, $GroupEntriesTable, GroupEntry>),
+    GroupEntry,
+    PrefetchHooks Function()>;
+typedef $$GroupMemberEntriesTableCreateCompanionBuilder
+    = GroupMemberEntriesCompanion Function({
+  Value<int> id,
+  required String uuid,
+  required String groupId,
+  required String userId,
+  required String displayName,
+  Value<String?> email,
+  Value<String?> avatarUrl,
+  Value<String> role,
+  Value<int> defaultSharePercent,
+  Value<bool> isActive,
+  Value<String> syncStatus,
+  Value<DateTime> joinedAt,
+  Value<DateTime?> updatedAt,
+});
+typedef $$GroupMemberEntriesTableUpdateCompanionBuilder
+    = GroupMemberEntriesCompanion Function({
+  Value<int> id,
+  Value<String> uuid,
+  Value<String> groupId,
+  Value<String> userId,
+  Value<String> displayName,
+  Value<String?> email,
+  Value<String?> avatarUrl,
+  Value<String> role,
+  Value<int> defaultSharePercent,
+  Value<bool> isActive,
+  Value<String> syncStatus,
+  Value<DateTime> joinedAt,
+  Value<DateTime?> updatedAt,
+});
 
 class $$GroupMemberEntriesTableFilterComposer
     extends Composer<_$AppDatabase, $GroupMemberEntriesTable> {
@@ -9249,69 +7773,44 @@ class $$GroupMemberEntriesTableFilterComposer
     super.$removeJoinBuilderFromRootComposer,
   });
   ColumnFilters<int> get id => $composableBuilder(
-    column: $table.id,
-    builder: (column) => ColumnFilters(column),
-  );
+      column: $table.id, builder: (column) => ColumnFilters(column));
 
   ColumnFilters<String> get uuid => $composableBuilder(
-    column: $table.uuid,
-    builder: (column) => ColumnFilters(column),
-  );
+      column: $table.uuid, builder: (column) => ColumnFilters(column));
 
   ColumnFilters<String> get groupId => $composableBuilder(
-    column: $table.groupId,
-    builder: (column) => ColumnFilters(column),
-  );
+      column: $table.groupId, builder: (column) => ColumnFilters(column));
 
   ColumnFilters<String> get userId => $composableBuilder(
-    column: $table.userId,
-    builder: (column) => ColumnFilters(column),
-  );
+      column: $table.userId, builder: (column) => ColumnFilters(column));
 
   ColumnFilters<String> get displayName => $composableBuilder(
-    column: $table.displayName,
-    builder: (column) => ColumnFilters(column),
-  );
+      column: $table.displayName, builder: (column) => ColumnFilters(column));
 
   ColumnFilters<String> get email => $composableBuilder(
-    column: $table.email,
-    builder: (column) => ColumnFilters(column),
-  );
+      column: $table.email, builder: (column) => ColumnFilters(column));
 
   ColumnFilters<String> get avatarUrl => $composableBuilder(
-    column: $table.avatarUrl,
-    builder: (column) => ColumnFilters(column),
-  );
+      column: $table.avatarUrl, builder: (column) => ColumnFilters(column));
 
   ColumnFilters<String> get role => $composableBuilder(
-    column: $table.role,
-    builder: (column) => ColumnFilters(column),
-  );
+      column: $table.role, builder: (column) => ColumnFilters(column));
 
   ColumnFilters<int> get defaultSharePercent => $composableBuilder(
-    column: $table.defaultSharePercent,
-    builder: (column) => ColumnFilters(column),
-  );
+      column: $table.defaultSharePercent,
+      builder: (column) => ColumnFilters(column));
 
   ColumnFilters<bool> get isActive => $composableBuilder(
-    column: $table.isActive,
-    builder: (column) => ColumnFilters(column),
-  );
+      column: $table.isActive, builder: (column) => ColumnFilters(column));
 
   ColumnFilters<String> get syncStatus => $composableBuilder(
-    column: $table.syncStatus,
-    builder: (column) => ColumnFilters(column),
-  );
+      column: $table.syncStatus, builder: (column) => ColumnFilters(column));
 
   ColumnFilters<DateTime> get joinedAt => $composableBuilder(
-    column: $table.joinedAt,
-    builder: (column) => ColumnFilters(column),
-  );
+      column: $table.joinedAt, builder: (column) => ColumnFilters(column));
 
   ColumnFilters<DateTime> get updatedAt => $composableBuilder(
-    column: $table.updatedAt,
-    builder: (column) => ColumnFilters(column),
-  );
+      column: $table.updatedAt, builder: (column) => ColumnFilters(column));
 }
 
 class $$GroupMemberEntriesTableOrderingComposer
@@ -9324,69 +7823,44 @@ class $$GroupMemberEntriesTableOrderingComposer
     super.$removeJoinBuilderFromRootComposer,
   });
   ColumnOrderings<int> get id => $composableBuilder(
-    column: $table.id,
-    builder: (column) => ColumnOrderings(column),
-  );
+      column: $table.id, builder: (column) => ColumnOrderings(column));
 
   ColumnOrderings<String> get uuid => $composableBuilder(
-    column: $table.uuid,
-    builder: (column) => ColumnOrderings(column),
-  );
+      column: $table.uuid, builder: (column) => ColumnOrderings(column));
 
   ColumnOrderings<String> get groupId => $composableBuilder(
-    column: $table.groupId,
-    builder: (column) => ColumnOrderings(column),
-  );
+      column: $table.groupId, builder: (column) => ColumnOrderings(column));
 
   ColumnOrderings<String> get userId => $composableBuilder(
-    column: $table.userId,
-    builder: (column) => ColumnOrderings(column),
-  );
+      column: $table.userId, builder: (column) => ColumnOrderings(column));
 
   ColumnOrderings<String> get displayName => $composableBuilder(
-    column: $table.displayName,
-    builder: (column) => ColumnOrderings(column),
-  );
+      column: $table.displayName, builder: (column) => ColumnOrderings(column));
 
   ColumnOrderings<String> get email => $composableBuilder(
-    column: $table.email,
-    builder: (column) => ColumnOrderings(column),
-  );
+      column: $table.email, builder: (column) => ColumnOrderings(column));
 
   ColumnOrderings<String> get avatarUrl => $composableBuilder(
-    column: $table.avatarUrl,
-    builder: (column) => ColumnOrderings(column),
-  );
+      column: $table.avatarUrl, builder: (column) => ColumnOrderings(column));
 
   ColumnOrderings<String> get role => $composableBuilder(
-    column: $table.role,
-    builder: (column) => ColumnOrderings(column),
-  );
+      column: $table.role, builder: (column) => ColumnOrderings(column));
 
   ColumnOrderings<int> get defaultSharePercent => $composableBuilder(
-    column: $table.defaultSharePercent,
-    builder: (column) => ColumnOrderings(column),
-  );
+      column: $table.defaultSharePercent,
+      builder: (column) => ColumnOrderings(column));
 
   ColumnOrderings<bool> get isActive => $composableBuilder(
-    column: $table.isActive,
-    builder: (column) => ColumnOrderings(column),
-  );
+      column: $table.isActive, builder: (column) => ColumnOrderings(column));
 
   ColumnOrderings<String> get syncStatus => $composableBuilder(
-    column: $table.syncStatus,
-    builder: (column) => ColumnOrderings(column),
-  );
+      column: $table.syncStatus, builder: (column) => ColumnOrderings(column));
 
   ColumnOrderings<DateTime> get joinedAt => $composableBuilder(
-    column: $table.joinedAt,
-    builder: (column) => ColumnOrderings(column),
-  );
+      column: $table.joinedAt, builder: (column) => ColumnOrderings(column));
 
   ColumnOrderings<DateTime> get updatedAt => $composableBuilder(
-    column: $table.updatedAt,
-    builder: (column) => ColumnOrderings(column),
-  );
+      column: $table.updatedAt, builder: (column) => ColumnOrderings(column));
 }
 
 class $$GroupMemberEntriesTableAnnotationComposer
@@ -9411,9 +7885,7 @@ class $$GroupMemberEntriesTableAnnotationComposer
       $composableBuilder(column: $table.userId, builder: (column) => column);
 
   GeneratedColumn<String> get displayName => $composableBuilder(
-    column: $table.displayName,
-    builder: (column) => column,
-  );
+      column: $table.displayName, builder: (column) => column);
 
   GeneratedColumn<String> get email =>
       $composableBuilder(column: $table.email, builder: (column) => column);
@@ -9425,17 +7897,13 @@ class $$GroupMemberEntriesTableAnnotationComposer
       $composableBuilder(column: $table.role, builder: (column) => column);
 
   GeneratedColumn<int> get defaultSharePercent => $composableBuilder(
-    column: $table.defaultSharePercent,
-    builder: (column) => column,
-  );
+      column: $table.defaultSharePercent, builder: (column) => column);
 
   GeneratedColumn<bool> get isActive =>
       $composableBuilder(column: $table.isActive, builder: (column) => column);
 
   GeneratedColumn<String> get syncStatus => $composableBuilder(
-    column: $table.syncStatus,
-    builder: (column) => column,
-  );
+      column: $table.syncStatus, builder: (column) => column);
 
   GeneratedColumn<DateTime> get joinedAt =>
       $composableBuilder(column: $table.joinedAt, builder: (column) => column);
@@ -9444,33 +7912,24 @@ class $$GroupMemberEntriesTableAnnotationComposer
       $composableBuilder(column: $table.updatedAt, builder: (column) => column);
 }
 
-class $$GroupMemberEntriesTableTableManager
-    extends
-        RootTableManager<
-          _$AppDatabase,
-          $GroupMemberEntriesTable,
-          GroupMemberEntry,
-          $$GroupMemberEntriesTableFilterComposer,
-          $$GroupMemberEntriesTableOrderingComposer,
-          $$GroupMemberEntriesTableAnnotationComposer,
-          $$GroupMemberEntriesTableCreateCompanionBuilder,
-          $$GroupMemberEntriesTableUpdateCompanionBuilder,
-          (
-            GroupMemberEntry,
-            BaseReferences<
-              _$AppDatabase,
-              $GroupMemberEntriesTable,
-              GroupMemberEntry
-            >,
-          ),
-          GroupMemberEntry,
-          PrefetchHooks Function()
-        > {
+class $$GroupMemberEntriesTableTableManager extends RootTableManager<
+    _$AppDatabase,
+    $GroupMemberEntriesTable,
+    GroupMemberEntry,
+    $$GroupMemberEntriesTableFilterComposer,
+    $$GroupMemberEntriesTableOrderingComposer,
+    $$GroupMemberEntriesTableAnnotationComposer,
+    $$GroupMemberEntriesTableCreateCompanionBuilder,
+    $$GroupMemberEntriesTableUpdateCompanionBuilder,
+    (
+      GroupMemberEntry,
+      BaseReferences<_$AppDatabase, $GroupMemberEntriesTable, GroupMemberEntry>
+    ),
+    GroupMemberEntry,
+    PrefetchHooks Function()> {
   $$GroupMemberEntriesTableTableManager(
-    _$AppDatabase db,
-    $GroupMemberEntriesTable table,
-  ) : super(
-        TableManagerState(
+      _$AppDatabase db, $GroupMemberEntriesTable table)
+      : super(TableManagerState(
           db: db,
           table: table,
           createFilteringComposer: () =>
@@ -9479,136 +7938,127 @@ class $$GroupMemberEntriesTableTableManager
               $$GroupMemberEntriesTableOrderingComposer($db: db, $table: table),
           createComputedFieldComposer: () =>
               $$GroupMemberEntriesTableAnnotationComposer(
-                $db: db,
-                $table: table,
-              ),
-          updateCompanionCallback:
-              ({
-                Value<int> id = const Value.absent(),
-                Value<String> uuid = const Value.absent(),
-                Value<String> groupId = const Value.absent(),
-                Value<String> userId = const Value.absent(),
-                Value<String> displayName = const Value.absent(),
-                Value<String?> email = const Value.absent(),
-                Value<String?> avatarUrl = const Value.absent(),
-                Value<String> role = const Value.absent(),
-                Value<int> defaultSharePercent = const Value.absent(),
-                Value<bool> isActive = const Value.absent(),
-                Value<String> syncStatus = const Value.absent(),
-                Value<DateTime> joinedAt = const Value.absent(),
-                Value<DateTime?> updatedAt = const Value.absent(),
-              }) => GroupMemberEntriesCompanion(
-                id: id,
-                uuid: uuid,
-                groupId: groupId,
-                userId: userId,
-                displayName: displayName,
-                email: email,
-                avatarUrl: avatarUrl,
-                role: role,
-                defaultSharePercent: defaultSharePercent,
-                isActive: isActive,
-                syncStatus: syncStatus,
-                joinedAt: joinedAt,
-                updatedAt: updatedAt,
-              ),
-          createCompanionCallback:
-              ({
-                Value<int> id = const Value.absent(),
-                required String uuid,
-                required String groupId,
-                required String userId,
-                required String displayName,
-                Value<String?> email = const Value.absent(),
-                Value<String?> avatarUrl = const Value.absent(),
-                Value<String> role = const Value.absent(),
-                Value<int> defaultSharePercent = const Value.absent(),
-                Value<bool> isActive = const Value.absent(),
-                Value<String> syncStatus = const Value.absent(),
-                Value<DateTime> joinedAt = const Value.absent(),
-                Value<DateTime?> updatedAt = const Value.absent(),
-              }) => GroupMemberEntriesCompanion.insert(
-                id: id,
-                uuid: uuid,
-                groupId: groupId,
-                userId: userId,
-                displayName: displayName,
-                email: email,
-                avatarUrl: avatarUrl,
-                role: role,
-                defaultSharePercent: defaultSharePercent,
-                isActive: isActive,
-                syncStatus: syncStatus,
-                joinedAt: joinedAt,
-                updatedAt: updatedAt,
-              ),
+                  $db: db, $table: table),
+          updateCompanionCallback: ({
+            Value<int> id = const Value.absent(),
+            Value<String> uuid = const Value.absent(),
+            Value<String> groupId = const Value.absent(),
+            Value<String> userId = const Value.absent(),
+            Value<String> displayName = const Value.absent(),
+            Value<String?> email = const Value.absent(),
+            Value<String?> avatarUrl = const Value.absent(),
+            Value<String> role = const Value.absent(),
+            Value<int> defaultSharePercent = const Value.absent(),
+            Value<bool> isActive = const Value.absent(),
+            Value<String> syncStatus = const Value.absent(),
+            Value<DateTime> joinedAt = const Value.absent(),
+            Value<DateTime?> updatedAt = const Value.absent(),
+          }) =>
+              GroupMemberEntriesCompanion(
+            id: id,
+            uuid: uuid,
+            groupId: groupId,
+            userId: userId,
+            displayName: displayName,
+            email: email,
+            avatarUrl: avatarUrl,
+            role: role,
+            defaultSharePercent: defaultSharePercent,
+            isActive: isActive,
+            syncStatus: syncStatus,
+            joinedAt: joinedAt,
+            updatedAt: updatedAt,
+          ),
+          createCompanionCallback: ({
+            Value<int> id = const Value.absent(),
+            required String uuid,
+            required String groupId,
+            required String userId,
+            required String displayName,
+            Value<String?> email = const Value.absent(),
+            Value<String?> avatarUrl = const Value.absent(),
+            Value<String> role = const Value.absent(),
+            Value<int> defaultSharePercent = const Value.absent(),
+            Value<bool> isActive = const Value.absent(),
+            Value<String> syncStatus = const Value.absent(),
+            Value<DateTime> joinedAt = const Value.absent(),
+            Value<DateTime?> updatedAt = const Value.absent(),
+          }) =>
+              GroupMemberEntriesCompanion.insert(
+            id: id,
+            uuid: uuid,
+            groupId: groupId,
+            userId: userId,
+            displayName: displayName,
+            email: email,
+            avatarUrl: avatarUrl,
+            role: role,
+            defaultSharePercent: defaultSharePercent,
+            isActive: isActive,
+            syncStatus: syncStatus,
+            joinedAt: joinedAt,
+            updatedAt: updatedAt,
+          ),
           withReferenceMapper: (p0) => p0
               .map((e) => (e.readTable(table), BaseReferences(db, table, e)))
               .toList(),
           prefetchHooksCallback: null,
-        ),
-      );
+        ));
 }
 
-typedef $$GroupMemberEntriesTableProcessedTableManager =
-    ProcessedTableManager<
-      _$AppDatabase,
-      $GroupMemberEntriesTable,
+typedef $$GroupMemberEntriesTableProcessedTableManager = ProcessedTableManager<
+    _$AppDatabase,
+    $GroupMemberEntriesTable,
+    GroupMemberEntry,
+    $$GroupMemberEntriesTableFilterComposer,
+    $$GroupMemberEntriesTableOrderingComposer,
+    $$GroupMemberEntriesTableAnnotationComposer,
+    $$GroupMemberEntriesTableCreateCompanionBuilder,
+    $$GroupMemberEntriesTableUpdateCompanionBuilder,
+    (
       GroupMemberEntry,
-      $$GroupMemberEntriesTableFilterComposer,
-      $$GroupMemberEntriesTableOrderingComposer,
-      $$GroupMemberEntriesTableAnnotationComposer,
-      $$GroupMemberEntriesTableCreateCompanionBuilder,
-      $$GroupMemberEntriesTableUpdateCompanionBuilder,
-      (
-        GroupMemberEntry,
-        BaseReferences<
-          _$AppDatabase,
-          $GroupMemberEntriesTable,
-          GroupMemberEntry
-        >,
-      ),
-      GroupMemberEntry,
-      PrefetchHooks Function()
-    >;
-typedef $$SharedExpenseEntriesTableCreateCompanionBuilder =
-    SharedExpenseEntriesCompanion Function({
-      Value<int> id,
-      required String uuid,
-      required String groupId,
-      required String description,
-      required int totalAmountCents,
-      Value<String> currencyCode,
-      required String paidByUserId,
-      Value<String?> categoryId,
-      Value<String> splitType,
-      Value<String?> notes,
-      Value<String?> receiptUrl,
-      Value<bool> isDeleted,
-      Value<String> syncStatus,
-      required DateTime expenseDate,
-      Value<DateTime> createdAt,
-      Value<DateTime?> updatedAt,
-    });
-typedef $$SharedExpenseEntriesTableUpdateCompanionBuilder =
-    SharedExpenseEntriesCompanion Function({
-      Value<int> id,
-      Value<String> uuid,
-      Value<String> groupId,
-      Value<String> description,
-      Value<int> totalAmountCents,
-      Value<String> currencyCode,
-      Value<String> paidByUserId,
-      Value<String?> categoryId,
-      Value<String> splitType,
-      Value<String?> notes,
-      Value<String?> receiptUrl,
-      Value<bool> isDeleted,
-      Value<String> syncStatus,
-      Value<DateTime> expenseDate,
-      Value<DateTime> createdAt,
-      Value<DateTime?> updatedAt,
-    });
+      BaseReferences<_$AppDatabase, $GroupMemberEntriesTable, GroupMemberEntry>
+    ),
+    GroupMemberEntry,
+    PrefetchHooks Function()>;
+typedef $$SharedExpenseEntriesTableCreateCompanionBuilder
+    = SharedExpenseEntriesCompanion Function({
+  Value<int> id,
+  required String uuid,
+  required String groupId,
+  required String description,
+  required int totalAmountCents,
+  Value<String> currencyCode,
+  required String paidByUserId,
+  Value<String?> categoryId,
+  Value<String> splitType,
+  Value<String?> notes,
+  Value<String?> receiptUrl,
+  Value<bool> isDeleted,
+  Value<String> syncStatus,
+  required DateTime expenseDate,
+  Value<DateTime> createdAt,
+  Value<DateTime?> updatedAt,
+});
+typedef $$SharedExpenseEntriesTableUpdateCompanionBuilder
+    = SharedExpenseEntriesCompanion Function({
+  Value<int> id,
+  Value<String> uuid,
+  Value<String> groupId,
+  Value<String> description,
+  Value<int> totalAmountCents,
+  Value<String> currencyCode,
+  Value<String> paidByUserId,
+  Value<String?> categoryId,
+  Value<String> splitType,
+  Value<String?> notes,
+  Value<String?> receiptUrl,
+  Value<bool> isDeleted,
+  Value<String> syncStatus,
+  Value<DateTime> expenseDate,
+  Value<DateTime> createdAt,
+  Value<DateTime?> updatedAt,
+});
 
 class $$SharedExpenseEntriesTableFilterComposer
     extends Composer<_$AppDatabase, $SharedExpenseEntriesTable> {
@@ -9620,84 +8070,53 @@ class $$SharedExpenseEntriesTableFilterComposer
     super.$removeJoinBuilderFromRootComposer,
   });
   ColumnFilters<int> get id => $composableBuilder(
-    column: $table.id,
-    builder: (column) => ColumnFilters(column),
-  );
+      column: $table.id, builder: (column) => ColumnFilters(column));
 
   ColumnFilters<String> get uuid => $composableBuilder(
-    column: $table.uuid,
-    builder: (column) => ColumnFilters(column),
-  );
+      column: $table.uuid, builder: (column) => ColumnFilters(column));
 
   ColumnFilters<String> get groupId => $composableBuilder(
-    column: $table.groupId,
-    builder: (column) => ColumnFilters(column),
-  );
+      column: $table.groupId, builder: (column) => ColumnFilters(column));
 
   ColumnFilters<String> get description => $composableBuilder(
-    column: $table.description,
-    builder: (column) => ColumnFilters(column),
-  );
+      column: $table.description, builder: (column) => ColumnFilters(column));
 
   ColumnFilters<int> get totalAmountCents => $composableBuilder(
-    column: $table.totalAmountCents,
-    builder: (column) => ColumnFilters(column),
-  );
+      column: $table.totalAmountCents,
+      builder: (column) => ColumnFilters(column));
 
   ColumnFilters<String> get currencyCode => $composableBuilder(
-    column: $table.currencyCode,
-    builder: (column) => ColumnFilters(column),
-  );
+      column: $table.currencyCode, builder: (column) => ColumnFilters(column));
 
   ColumnFilters<String> get paidByUserId => $composableBuilder(
-    column: $table.paidByUserId,
-    builder: (column) => ColumnFilters(column),
-  );
+      column: $table.paidByUserId, builder: (column) => ColumnFilters(column));
 
   ColumnFilters<String> get categoryId => $composableBuilder(
-    column: $table.categoryId,
-    builder: (column) => ColumnFilters(column),
-  );
+      column: $table.categoryId, builder: (column) => ColumnFilters(column));
 
   ColumnFilters<String> get splitType => $composableBuilder(
-    column: $table.splitType,
-    builder: (column) => ColumnFilters(column),
-  );
+      column: $table.splitType, builder: (column) => ColumnFilters(column));
 
   ColumnFilters<String> get notes => $composableBuilder(
-    column: $table.notes,
-    builder: (column) => ColumnFilters(column),
-  );
+      column: $table.notes, builder: (column) => ColumnFilters(column));
 
   ColumnFilters<String> get receiptUrl => $composableBuilder(
-    column: $table.receiptUrl,
-    builder: (column) => ColumnFilters(column),
-  );
+      column: $table.receiptUrl, builder: (column) => ColumnFilters(column));
 
   ColumnFilters<bool> get isDeleted => $composableBuilder(
-    column: $table.isDeleted,
-    builder: (column) => ColumnFilters(column),
-  );
+      column: $table.isDeleted, builder: (column) => ColumnFilters(column));
 
   ColumnFilters<String> get syncStatus => $composableBuilder(
-    column: $table.syncStatus,
-    builder: (column) => ColumnFilters(column),
-  );
+      column: $table.syncStatus, builder: (column) => ColumnFilters(column));
 
   ColumnFilters<DateTime> get expenseDate => $composableBuilder(
-    column: $table.expenseDate,
-    builder: (column) => ColumnFilters(column),
-  );
+      column: $table.expenseDate, builder: (column) => ColumnFilters(column));
 
   ColumnFilters<DateTime> get createdAt => $composableBuilder(
-    column: $table.createdAt,
-    builder: (column) => ColumnFilters(column),
-  );
+      column: $table.createdAt, builder: (column) => ColumnFilters(column));
 
   ColumnFilters<DateTime> get updatedAt => $composableBuilder(
-    column: $table.updatedAt,
-    builder: (column) => ColumnFilters(column),
-  );
+      column: $table.updatedAt, builder: (column) => ColumnFilters(column));
 }
 
 class $$SharedExpenseEntriesTableOrderingComposer
@@ -9710,84 +8129,55 @@ class $$SharedExpenseEntriesTableOrderingComposer
     super.$removeJoinBuilderFromRootComposer,
   });
   ColumnOrderings<int> get id => $composableBuilder(
-    column: $table.id,
-    builder: (column) => ColumnOrderings(column),
-  );
+      column: $table.id, builder: (column) => ColumnOrderings(column));
 
   ColumnOrderings<String> get uuid => $composableBuilder(
-    column: $table.uuid,
-    builder: (column) => ColumnOrderings(column),
-  );
+      column: $table.uuid, builder: (column) => ColumnOrderings(column));
 
   ColumnOrderings<String> get groupId => $composableBuilder(
-    column: $table.groupId,
-    builder: (column) => ColumnOrderings(column),
-  );
+      column: $table.groupId, builder: (column) => ColumnOrderings(column));
 
   ColumnOrderings<String> get description => $composableBuilder(
-    column: $table.description,
-    builder: (column) => ColumnOrderings(column),
-  );
+      column: $table.description, builder: (column) => ColumnOrderings(column));
 
   ColumnOrderings<int> get totalAmountCents => $composableBuilder(
-    column: $table.totalAmountCents,
-    builder: (column) => ColumnOrderings(column),
-  );
+      column: $table.totalAmountCents,
+      builder: (column) => ColumnOrderings(column));
 
   ColumnOrderings<String> get currencyCode => $composableBuilder(
-    column: $table.currencyCode,
-    builder: (column) => ColumnOrderings(column),
-  );
+      column: $table.currencyCode,
+      builder: (column) => ColumnOrderings(column));
 
   ColumnOrderings<String> get paidByUserId => $composableBuilder(
-    column: $table.paidByUserId,
-    builder: (column) => ColumnOrderings(column),
-  );
+      column: $table.paidByUserId,
+      builder: (column) => ColumnOrderings(column));
 
   ColumnOrderings<String> get categoryId => $composableBuilder(
-    column: $table.categoryId,
-    builder: (column) => ColumnOrderings(column),
-  );
+      column: $table.categoryId, builder: (column) => ColumnOrderings(column));
 
   ColumnOrderings<String> get splitType => $composableBuilder(
-    column: $table.splitType,
-    builder: (column) => ColumnOrderings(column),
-  );
+      column: $table.splitType, builder: (column) => ColumnOrderings(column));
 
   ColumnOrderings<String> get notes => $composableBuilder(
-    column: $table.notes,
-    builder: (column) => ColumnOrderings(column),
-  );
+      column: $table.notes, builder: (column) => ColumnOrderings(column));
 
   ColumnOrderings<String> get receiptUrl => $composableBuilder(
-    column: $table.receiptUrl,
-    builder: (column) => ColumnOrderings(column),
-  );
+      column: $table.receiptUrl, builder: (column) => ColumnOrderings(column));
 
   ColumnOrderings<bool> get isDeleted => $composableBuilder(
-    column: $table.isDeleted,
-    builder: (column) => ColumnOrderings(column),
-  );
+      column: $table.isDeleted, builder: (column) => ColumnOrderings(column));
 
   ColumnOrderings<String> get syncStatus => $composableBuilder(
-    column: $table.syncStatus,
-    builder: (column) => ColumnOrderings(column),
-  );
+      column: $table.syncStatus, builder: (column) => ColumnOrderings(column));
 
   ColumnOrderings<DateTime> get expenseDate => $composableBuilder(
-    column: $table.expenseDate,
-    builder: (column) => ColumnOrderings(column),
-  );
+      column: $table.expenseDate, builder: (column) => ColumnOrderings(column));
 
   ColumnOrderings<DateTime> get createdAt => $composableBuilder(
-    column: $table.createdAt,
-    builder: (column) => ColumnOrderings(column),
-  );
+      column: $table.createdAt, builder: (column) => ColumnOrderings(column));
 
   ColumnOrderings<DateTime> get updatedAt => $composableBuilder(
-    column: $table.updatedAt,
-    builder: (column) => ColumnOrderings(column),
-  );
+      column: $table.updatedAt, builder: (column) => ColumnOrderings(column));
 }
 
 class $$SharedExpenseEntriesTableAnnotationComposer
@@ -9809,29 +8199,19 @@ class $$SharedExpenseEntriesTableAnnotationComposer
       $composableBuilder(column: $table.groupId, builder: (column) => column);
 
   GeneratedColumn<String> get description => $composableBuilder(
-    column: $table.description,
-    builder: (column) => column,
-  );
+      column: $table.description, builder: (column) => column);
 
   GeneratedColumn<int> get totalAmountCents => $composableBuilder(
-    column: $table.totalAmountCents,
-    builder: (column) => column,
-  );
+      column: $table.totalAmountCents, builder: (column) => column);
 
   GeneratedColumn<String> get currencyCode => $composableBuilder(
-    column: $table.currencyCode,
-    builder: (column) => column,
-  );
+      column: $table.currencyCode, builder: (column) => column);
 
   GeneratedColumn<String> get paidByUserId => $composableBuilder(
-    column: $table.paidByUserId,
-    builder: (column) => column,
-  );
+      column: $table.paidByUserId, builder: (column) => column);
 
   GeneratedColumn<String> get categoryId => $composableBuilder(
-    column: $table.categoryId,
-    builder: (column) => column,
-  );
+      column: $table.categoryId, builder: (column) => column);
 
   GeneratedColumn<String> get splitType =>
       $composableBuilder(column: $table.splitType, builder: (column) => column);
@@ -9840,22 +8220,16 @@ class $$SharedExpenseEntriesTableAnnotationComposer
       $composableBuilder(column: $table.notes, builder: (column) => column);
 
   GeneratedColumn<String> get receiptUrl => $composableBuilder(
-    column: $table.receiptUrl,
-    builder: (column) => column,
-  );
+      column: $table.receiptUrl, builder: (column) => column);
 
   GeneratedColumn<bool> get isDeleted =>
       $composableBuilder(column: $table.isDeleted, builder: (column) => column);
 
   GeneratedColumn<String> get syncStatus => $composableBuilder(
-    column: $table.syncStatus,
-    builder: (column) => column,
-  );
+      column: $table.syncStatus, builder: (column) => column);
 
   GeneratedColumn<DateTime> get expenseDate => $composableBuilder(
-    column: $table.expenseDate,
-    builder: (column) => column,
-  );
+      column: $table.expenseDate, builder: (column) => column);
 
   GeneratedColumn<DateTime> get createdAt =>
       $composableBuilder(column: $table.createdAt, builder: (column) => column);
@@ -9864,174 +8238,157 @@ class $$SharedExpenseEntriesTableAnnotationComposer
       $composableBuilder(column: $table.updatedAt, builder: (column) => column);
 }
 
-class $$SharedExpenseEntriesTableTableManager
-    extends
-        RootTableManager<
-          _$AppDatabase,
-          $SharedExpenseEntriesTable,
-          SharedExpenseEntry,
-          $$SharedExpenseEntriesTableFilterComposer,
-          $$SharedExpenseEntriesTableOrderingComposer,
-          $$SharedExpenseEntriesTableAnnotationComposer,
-          $$SharedExpenseEntriesTableCreateCompanionBuilder,
-          $$SharedExpenseEntriesTableUpdateCompanionBuilder,
-          (
-            SharedExpenseEntry,
-            BaseReferences<
-              _$AppDatabase,
-              $SharedExpenseEntriesTable,
-              SharedExpenseEntry
-            >,
-          ),
-          SharedExpenseEntry,
-          PrefetchHooks Function()
-        > {
+class $$SharedExpenseEntriesTableTableManager extends RootTableManager<
+    _$AppDatabase,
+    $SharedExpenseEntriesTable,
+    SharedExpenseEntry,
+    $$SharedExpenseEntriesTableFilterComposer,
+    $$SharedExpenseEntriesTableOrderingComposer,
+    $$SharedExpenseEntriesTableAnnotationComposer,
+    $$SharedExpenseEntriesTableCreateCompanionBuilder,
+    $$SharedExpenseEntriesTableUpdateCompanionBuilder,
+    (
+      SharedExpenseEntry,
+      BaseReferences<_$AppDatabase, $SharedExpenseEntriesTable,
+          SharedExpenseEntry>
+    ),
+    SharedExpenseEntry,
+    PrefetchHooks Function()> {
   $$SharedExpenseEntriesTableTableManager(
-    _$AppDatabase db,
-    $SharedExpenseEntriesTable table,
-  ) : super(
-        TableManagerState(
+      _$AppDatabase db, $SharedExpenseEntriesTable table)
+      : super(TableManagerState(
           db: db,
           table: table,
           createFilteringComposer: () =>
               $$SharedExpenseEntriesTableFilterComposer($db: db, $table: table),
           createOrderingComposer: () =>
               $$SharedExpenseEntriesTableOrderingComposer(
-                $db: db,
-                $table: table,
-              ),
+                  $db: db, $table: table),
           createComputedFieldComposer: () =>
               $$SharedExpenseEntriesTableAnnotationComposer(
-                $db: db,
-                $table: table,
-              ),
-          updateCompanionCallback:
-              ({
-                Value<int> id = const Value.absent(),
-                Value<String> uuid = const Value.absent(),
-                Value<String> groupId = const Value.absent(),
-                Value<String> description = const Value.absent(),
-                Value<int> totalAmountCents = const Value.absent(),
-                Value<String> currencyCode = const Value.absent(),
-                Value<String> paidByUserId = const Value.absent(),
-                Value<String?> categoryId = const Value.absent(),
-                Value<String> splitType = const Value.absent(),
-                Value<String?> notes = const Value.absent(),
-                Value<String?> receiptUrl = const Value.absent(),
-                Value<bool> isDeleted = const Value.absent(),
-                Value<String> syncStatus = const Value.absent(),
-                Value<DateTime> expenseDate = const Value.absent(),
-                Value<DateTime> createdAt = const Value.absent(),
-                Value<DateTime?> updatedAt = const Value.absent(),
-              }) => SharedExpenseEntriesCompanion(
-                id: id,
-                uuid: uuid,
-                groupId: groupId,
-                description: description,
-                totalAmountCents: totalAmountCents,
-                currencyCode: currencyCode,
-                paidByUserId: paidByUserId,
-                categoryId: categoryId,
-                splitType: splitType,
-                notes: notes,
-                receiptUrl: receiptUrl,
-                isDeleted: isDeleted,
-                syncStatus: syncStatus,
-                expenseDate: expenseDate,
-                createdAt: createdAt,
-                updatedAt: updatedAt,
-              ),
-          createCompanionCallback:
-              ({
-                Value<int> id = const Value.absent(),
-                required String uuid,
-                required String groupId,
-                required String description,
-                required int totalAmountCents,
-                Value<String> currencyCode = const Value.absent(),
-                required String paidByUserId,
-                Value<String?> categoryId = const Value.absent(),
-                Value<String> splitType = const Value.absent(),
-                Value<String?> notes = const Value.absent(),
-                Value<String?> receiptUrl = const Value.absent(),
-                Value<bool> isDeleted = const Value.absent(),
-                Value<String> syncStatus = const Value.absent(),
-                required DateTime expenseDate,
-                Value<DateTime> createdAt = const Value.absent(),
-                Value<DateTime?> updatedAt = const Value.absent(),
-              }) => SharedExpenseEntriesCompanion.insert(
-                id: id,
-                uuid: uuid,
-                groupId: groupId,
-                description: description,
-                totalAmountCents: totalAmountCents,
-                currencyCode: currencyCode,
-                paidByUserId: paidByUserId,
-                categoryId: categoryId,
-                splitType: splitType,
-                notes: notes,
-                receiptUrl: receiptUrl,
-                isDeleted: isDeleted,
-                syncStatus: syncStatus,
-                expenseDate: expenseDate,
-                createdAt: createdAt,
-                updatedAt: updatedAt,
-              ),
+                  $db: db, $table: table),
+          updateCompanionCallback: ({
+            Value<int> id = const Value.absent(),
+            Value<String> uuid = const Value.absent(),
+            Value<String> groupId = const Value.absent(),
+            Value<String> description = const Value.absent(),
+            Value<int> totalAmountCents = const Value.absent(),
+            Value<String> currencyCode = const Value.absent(),
+            Value<String> paidByUserId = const Value.absent(),
+            Value<String?> categoryId = const Value.absent(),
+            Value<String> splitType = const Value.absent(),
+            Value<String?> notes = const Value.absent(),
+            Value<String?> receiptUrl = const Value.absent(),
+            Value<bool> isDeleted = const Value.absent(),
+            Value<String> syncStatus = const Value.absent(),
+            Value<DateTime> expenseDate = const Value.absent(),
+            Value<DateTime> createdAt = const Value.absent(),
+            Value<DateTime?> updatedAt = const Value.absent(),
+          }) =>
+              SharedExpenseEntriesCompanion(
+            id: id,
+            uuid: uuid,
+            groupId: groupId,
+            description: description,
+            totalAmountCents: totalAmountCents,
+            currencyCode: currencyCode,
+            paidByUserId: paidByUserId,
+            categoryId: categoryId,
+            splitType: splitType,
+            notes: notes,
+            receiptUrl: receiptUrl,
+            isDeleted: isDeleted,
+            syncStatus: syncStatus,
+            expenseDate: expenseDate,
+            createdAt: createdAt,
+            updatedAt: updatedAt,
+          ),
+          createCompanionCallback: ({
+            Value<int> id = const Value.absent(),
+            required String uuid,
+            required String groupId,
+            required String description,
+            required int totalAmountCents,
+            Value<String> currencyCode = const Value.absent(),
+            required String paidByUserId,
+            Value<String?> categoryId = const Value.absent(),
+            Value<String> splitType = const Value.absent(),
+            Value<String?> notes = const Value.absent(),
+            Value<String?> receiptUrl = const Value.absent(),
+            Value<bool> isDeleted = const Value.absent(),
+            Value<String> syncStatus = const Value.absent(),
+            required DateTime expenseDate,
+            Value<DateTime> createdAt = const Value.absent(),
+            Value<DateTime?> updatedAt = const Value.absent(),
+          }) =>
+              SharedExpenseEntriesCompanion.insert(
+            id: id,
+            uuid: uuid,
+            groupId: groupId,
+            description: description,
+            totalAmountCents: totalAmountCents,
+            currencyCode: currencyCode,
+            paidByUserId: paidByUserId,
+            categoryId: categoryId,
+            splitType: splitType,
+            notes: notes,
+            receiptUrl: receiptUrl,
+            isDeleted: isDeleted,
+            syncStatus: syncStatus,
+            expenseDate: expenseDate,
+            createdAt: createdAt,
+            updatedAt: updatedAt,
+          ),
           withReferenceMapper: (p0) => p0
               .map((e) => (e.readTable(table), BaseReferences(db, table, e)))
               .toList(),
           prefetchHooksCallback: null,
-        ),
-      );
+        ));
 }
 
-typedef $$SharedExpenseEntriesTableProcessedTableManager =
-    ProcessedTableManager<
-      _$AppDatabase,
-      $SharedExpenseEntriesTable,
-      SharedExpenseEntry,
-      $$SharedExpenseEntriesTableFilterComposer,
-      $$SharedExpenseEntriesTableOrderingComposer,
-      $$SharedExpenseEntriesTableAnnotationComposer,
-      $$SharedExpenseEntriesTableCreateCompanionBuilder,
-      $$SharedExpenseEntriesTableUpdateCompanionBuilder,
-      (
+typedef $$SharedExpenseEntriesTableProcessedTableManager
+    = ProcessedTableManager<
+        _$AppDatabase,
+        $SharedExpenseEntriesTable,
         SharedExpenseEntry,
-        BaseReferences<
-          _$AppDatabase,
-          $SharedExpenseEntriesTable,
-          SharedExpenseEntry
-        >,
-      ),
-      SharedExpenseEntry,
-      PrefetchHooks Function()
-    >;
-typedef $$SplitEntryRecordsTableCreateCompanionBuilder =
-    SplitEntryRecordsCompanion Function({
-      Value<int> id,
-      required String uuid,
-      required String sharedExpenseId,
-      required String userId,
-      required int amountCents,
-      Value<int> shareValue,
-      Value<bool> isSettled,
-      Value<String> syncStatus,
-      Value<DateTime> createdAt,
-      Value<DateTime?> updatedAt,
-    });
-typedef $$SplitEntryRecordsTableUpdateCompanionBuilder =
-    SplitEntryRecordsCompanion Function({
-      Value<int> id,
-      Value<String> uuid,
-      Value<String> sharedExpenseId,
-      Value<String> userId,
-      Value<int> amountCents,
-      Value<int> shareValue,
-      Value<bool> isSettled,
-      Value<String> syncStatus,
-      Value<DateTime> createdAt,
-      Value<DateTime?> updatedAt,
-    });
+        $$SharedExpenseEntriesTableFilterComposer,
+        $$SharedExpenseEntriesTableOrderingComposer,
+        $$SharedExpenseEntriesTableAnnotationComposer,
+        $$SharedExpenseEntriesTableCreateCompanionBuilder,
+        $$SharedExpenseEntriesTableUpdateCompanionBuilder,
+        (
+          SharedExpenseEntry,
+          BaseReferences<_$AppDatabase, $SharedExpenseEntriesTable,
+              SharedExpenseEntry>
+        ),
+        SharedExpenseEntry,
+        PrefetchHooks Function()>;
+typedef $$SplitEntryRecordsTableCreateCompanionBuilder
+    = SplitEntryRecordsCompanion Function({
+  Value<int> id,
+  required String uuid,
+  required String sharedExpenseId,
+  required String userId,
+  required int amountCents,
+  Value<int> shareValue,
+  Value<bool> isSettled,
+  Value<String> syncStatus,
+  Value<DateTime> createdAt,
+  Value<DateTime?> updatedAt,
+});
+typedef $$SplitEntryRecordsTableUpdateCompanionBuilder
+    = SplitEntryRecordsCompanion Function({
+  Value<int> id,
+  Value<String> uuid,
+  Value<String> sharedExpenseId,
+  Value<String> userId,
+  Value<int> amountCents,
+  Value<int> shareValue,
+  Value<bool> isSettled,
+  Value<String> syncStatus,
+  Value<DateTime> createdAt,
+  Value<DateTime?> updatedAt,
+});
 
 class $$SplitEntryRecordsTableFilterComposer
     extends Composer<_$AppDatabase, $SplitEntryRecordsTable> {
@@ -10043,54 +8400,35 @@ class $$SplitEntryRecordsTableFilterComposer
     super.$removeJoinBuilderFromRootComposer,
   });
   ColumnFilters<int> get id => $composableBuilder(
-    column: $table.id,
-    builder: (column) => ColumnFilters(column),
-  );
+      column: $table.id, builder: (column) => ColumnFilters(column));
 
   ColumnFilters<String> get uuid => $composableBuilder(
-    column: $table.uuid,
-    builder: (column) => ColumnFilters(column),
-  );
+      column: $table.uuid, builder: (column) => ColumnFilters(column));
 
   ColumnFilters<String> get sharedExpenseId => $composableBuilder(
-    column: $table.sharedExpenseId,
-    builder: (column) => ColumnFilters(column),
-  );
+      column: $table.sharedExpenseId,
+      builder: (column) => ColumnFilters(column));
 
   ColumnFilters<String> get userId => $composableBuilder(
-    column: $table.userId,
-    builder: (column) => ColumnFilters(column),
-  );
+      column: $table.userId, builder: (column) => ColumnFilters(column));
 
   ColumnFilters<int> get amountCents => $composableBuilder(
-    column: $table.amountCents,
-    builder: (column) => ColumnFilters(column),
-  );
+      column: $table.amountCents, builder: (column) => ColumnFilters(column));
 
   ColumnFilters<int> get shareValue => $composableBuilder(
-    column: $table.shareValue,
-    builder: (column) => ColumnFilters(column),
-  );
+      column: $table.shareValue, builder: (column) => ColumnFilters(column));
 
   ColumnFilters<bool> get isSettled => $composableBuilder(
-    column: $table.isSettled,
-    builder: (column) => ColumnFilters(column),
-  );
+      column: $table.isSettled, builder: (column) => ColumnFilters(column));
 
   ColumnFilters<String> get syncStatus => $composableBuilder(
-    column: $table.syncStatus,
-    builder: (column) => ColumnFilters(column),
-  );
+      column: $table.syncStatus, builder: (column) => ColumnFilters(column));
 
   ColumnFilters<DateTime> get createdAt => $composableBuilder(
-    column: $table.createdAt,
-    builder: (column) => ColumnFilters(column),
-  );
+      column: $table.createdAt, builder: (column) => ColumnFilters(column));
 
   ColumnFilters<DateTime> get updatedAt => $composableBuilder(
-    column: $table.updatedAt,
-    builder: (column) => ColumnFilters(column),
-  );
+      column: $table.updatedAt, builder: (column) => ColumnFilters(column));
 }
 
 class $$SplitEntryRecordsTableOrderingComposer
@@ -10103,54 +8441,35 @@ class $$SplitEntryRecordsTableOrderingComposer
     super.$removeJoinBuilderFromRootComposer,
   });
   ColumnOrderings<int> get id => $composableBuilder(
-    column: $table.id,
-    builder: (column) => ColumnOrderings(column),
-  );
+      column: $table.id, builder: (column) => ColumnOrderings(column));
 
   ColumnOrderings<String> get uuid => $composableBuilder(
-    column: $table.uuid,
-    builder: (column) => ColumnOrderings(column),
-  );
+      column: $table.uuid, builder: (column) => ColumnOrderings(column));
 
   ColumnOrderings<String> get sharedExpenseId => $composableBuilder(
-    column: $table.sharedExpenseId,
-    builder: (column) => ColumnOrderings(column),
-  );
+      column: $table.sharedExpenseId,
+      builder: (column) => ColumnOrderings(column));
 
   ColumnOrderings<String> get userId => $composableBuilder(
-    column: $table.userId,
-    builder: (column) => ColumnOrderings(column),
-  );
+      column: $table.userId, builder: (column) => ColumnOrderings(column));
 
   ColumnOrderings<int> get amountCents => $composableBuilder(
-    column: $table.amountCents,
-    builder: (column) => ColumnOrderings(column),
-  );
+      column: $table.amountCents, builder: (column) => ColumnOrderings(column));
 
   ColumnOrderings<int> get shareValue => $composableBuilder(
-    column: $table.shareValue,
-    builder: (column) => ColumnOrderings(column),
-  );
+      column: $table.shareValue, builder: (column) => ColumnOrderings(column));
 
   ColumnOrderings<bool> get isSettled => $composableBuilder(
-    column: $table.isSettled,
-    builder: (column) => ColumnOrderings(column),
-  );
+      column: $table.isSettled, builder: (column) => ColumnOrderings(column));
 
   ColumnOrderings<String> get syncStatus => $composableBuilder(
-    column: $table.syncStatus,
-    builder: (column) => ColumnOrderings(column),
-  );
+      column: $table.syncStatus, builder: (column) => ColumnOrderings(column));
 
   ColumnOrderings<DateTime> get createdAt => $composableBuilder(
-    column: $table.createdAt,
-    builder: (column) => ColumnOrderings(column),
-  );
+      column: $table.createdAt, builder: (column) => ColumnOrderings(column));
 
   ColumnOrderings<DateTime> get updatedAt => $composableBuilder(
-    column: $table.updatedAt,
-    builder: (column) => ColumnOrderings(column),
-  );
+      column: $table.updatedAt, builder: (column) => ColumnOrderings(column));
 }
 
 class $$SplitEntryRecordsTableAnnotationComposer
@@ -10169,30 +8488,22 @@ class $$SplitEntryRecordsTableAnnotationComposer
       $composableBuilder(column: $table.uuid, builder: (column) => column);
 
   GeneratedColumn<String> get sharedExpenseId => $composableBuilder(
-    column: $table.sharedExpenseId,
-    builder: (column) => column,
-  );
+      column: $table.sharedExpenseId, builder: (column) => column);
 
   GeneratedColumn<String> get userId =>
       $composableBuilder(column: $table.userId, builder: (column) => column);
 
   GeneratedColumn<int> get amountCents => $composableBuilder(
-    column: $table.amountCents,
-    builder: (column) => column,
-  );
+      column: $table.amountCents, builder: (column) => column);
 
   GeneratedColumn<int> get shareValue => $composableBuilder(
-    column: $table.shareValue,
-    builder: (column) => column,
-  );
+      column: $table.shareValue, builder: (column) => column);
 
   GeneratedColumn<bool> get isSettled =>
       $composableBuilder(column: $table.isSettled, builder: (column) => column);
 
   GeneratedColumn<String> get syncStatus => $composableBuilder(
-    column: $table.syncStatus,
-    builder: (column) => column,
-  );
+      column: $table.syncStatus, builder: (column) => column);
 
   GeneratedColumn<DateTime> get createdAt =>
       $composableBuilder(column: $table.createdAt, builder: (column) => column);
@@ -10201,33 +8512,24 @@ class $$SplitEntryRecordsTableAnnotationComposer
       $composableBuilder(column: $table.updatedAt, builder: (column) => column);
 }
 
-class $$SplitEntryRecordsTableTableManager
-    extends
-        RootTableManager<
-          _$AppDatabase,
-          $SplitEntryRecordsTable,
-          SplitEntryRecord,
-          $$SplitEntryRecordsTableFilterComposer,
-          $$SplitEntryRecordsTableOrderingComposer,
-          $$SplitEntryRecordsTableAnnotationComposer,
-          $$SplitEntryRecordsTableCreateCompanionBuilder,
-          $$SplitEntryRecordsTableUpdateCompanionBuilder,
-          (
-            SplitEntryRecord,
-            BaseReferences<
-              _$AppDatabase,
-              $SplitEntryRecordsTable,
-              SplitEntryRecord
-            >,
-          ),
-          SplitEntryRecord,
-          PrefetchHooks Function()
-        > {
+class $$SplitEntryRecordsTableTableManager extends RootTableManager<
+    _$AppDatabase,
+    $SplitEntryRecordsTable,
+    SplitEntryRecord,
+    $$SplitEntryRecordsTableFilterComposer,
+    $$SplitEntryRecordsTableOrderingComposer,
+    $$SplitEntryRecordsTableAnnotationComposer,
+    $$SplitEntryRecordsTableCreateCompanionBuilder,
+    $$SplitEntryRecordsTableUpdateCompanionBuilder,
+    (
+      SplitEntryRecord,
+      BaseReferences<_$AppDatabase, $SplitEntryRecordsTable, SplitEntryRecord>
+    ),
+    SplitEntryRecord,
+    PrefetchHooks Function()> {
   $$SplitEntryRecordsTableTableManager(
-    _$AppDatabase db,
-    $SplitEntryRecordsTable table,
-  ) : super(
-        TableManagerState(
+      _$AppDatabase db, $SplitEntryRecordsTable table)
+      : super(TableManagerState(
           db: db,
           table: table,
           createFilteringComposer: () =>
@@ -10236,122 +8538,113 @@ class $$SplitEntryRecordsTableTableManager
               $$SplitEntryRecordsTableOrderingComposer($db: db, $table: table),
           createComputedFieldComposer: () =>
               $$SplitEntryRecordsTableAnnotationComposer(
-                $db: db,
-                $table: table,
-              ),
-          updateCompanionCallback:
-              ({
-                Value<int> id = const Value.absent(),
-                Value<String> uuid = const Value.absent(),
-                Value<String> sharedExpenseId = const Value.absent(),
-                Value<String> userId = const Value.absent(),
-                Value<int> amountCents = const Value.absent(),
-                Value<int> shareValue = const Value.absent(),
-                Value<bool> isSettled = const Value.absent(),
-                Value<String> syncStatus = const Value.absent(),
-                Value<DateTime> createdAt = const Value.absent(),
-                Value<DateTime?> updatedAt = const Value.absent(),
-              }) => SplitEntryRecordsCompanion(
-                id: id,
-                uuid: uuid,
-                sharedExpenseId: sharedExpenseId,
-                userId: userId,
-                amountCents: amountCents,
-                shareValue: shareValue,
-                isSettled: isSettled,
-                syncStatus: syncStatus,
-                createdAt: createdAt,
-                updatedAt: updatedAt,
-              ),
-          createCompanionCallback:
-              ({
-                Value<int> id = const Value.absent(),
-                required String uuid,
-                required String sharedExpenseId,
-                required String userId,
-                required int amountCents,
-                Value<int> shareValue = const Value.absent(),
-                Value<bool> isSettled = const Value.absent(),
-                Value<String> syncStatus = const Value.absent(),
-                Value<DateTime> createdAt = const Value.absent(),
-                Value<DateTime?> updatedAt = const Value.absent(),
-              }) => SplitEntryRecordsCompanion.insert(
-                id: id,
-                uuid: uuid,
-                sharedExpenseId: sharedExpenseId,
-                userId: userId,
-                amountCents: amountCents,
-                shareValue: shareValue,
-                isSettled: isSettled,
-                syncStatus: syncStatus,
-                createdAt: createdAt,
-                updatedAt: updatedAt,
-              ),
+                  $db: db, $table: table),
+          updateCompanionCallback: ({
+            Value<int> id = const Value.absent(),
+            Value<String> uuid = const Value.absent(),
+            Value<String> sharedExpenseId = const Value.absent(),
+            Value<String> userId = const Value.absent(),
+            Value<int> amountCents = const Value.absent(),
+            Value<int> shareValue = const Value.absent(),
+            Value<bool> isSettled = const Value.absent(),
+            Value<String> syncStatus = const Value.absent(),
+            Value<DateTime> createdAt = const Value.absent(),
+            Value<DateTime?> updatedAt = const Value.absent(),
+          }) =>
+              SplitEntryRecordsCompanion(
+            id: id,
+            uuid: uuid,
+            sharedExpenseId: sharedExpenseId,
+            userId: userId,
+            amountCents: amountCents,
+            shareValue: shareValue,
+            isSettled: isSettled,
+            syncStatus: syncStatus,
+            createdAt: createdAt,
+            updatedAt: updatedAt,
+          ),
+          createCompanionCallback: ({
+            Value<int> id = const Value.absent(),
+            required String uuid,
+            required String sharedExpenseId,
+            required String userId,
+            required int amountCents,
+            Value<int> shareValue = const Value.absent(),
+            Value<bool> isSettled = const Value.absent(),
+            Value<String> syncStatus = const Value.absent(),
+            Value<DateTime> createdAt = const Value.absent(),
+            Value<DateTime?> updatedAt = const Value.absent(),
+          }) =>
+              SplitEntryRecordsCompanion.insert(
+            id: id,
+            uuid: uuid,
+            sharedExpenseId: sharedExpenseId,
+            userId: userId,
+            amountCents: amountCents,
+            shareValue: shareValue,
+            isSettled: isSettled,
+            syncStatus: syncStatus,
+            createdAt: createdAt,
+            updatedAt: updatedAt,
+          ),
           withReferenceMapper: (p0) => p0
               .map((e) => (e.readTable(table), BaseReferences(db, table, e)))
               .toList(),
           prefetchHooksCallback: null,
-        ),
-      );
+        ));
 }
 
-typedef $$SplitEntryRecordsTableProcessedTableManager =
-    ProcessedTableManager<
-      _$AppDatabase,
-      $SplitEntryRecordsTable,
+typedef $$SplitEntryRecordsTableProcessedTableManager = ProcessedTableManager<
+    _$AppDatabase,
+    $SplitEntryRecordsTable,
+    SplitEntryRecord,
+    $$SplitEntryRecordsTableFilterComposer,
+    $$SplitEntryRecordsTableOrderingComposer,
+    $$SplitEntryRecordsTableAnnotationComposer,
+    $$SplitEntryRecordsTableCreateCompanionBuilder,
+    $$SplitEntryRecordsTableUpdateCompanionBuilder,
+    (
       SplitEntryRecord,
-      $$SplitEntryRecordsTableFilterComposer,
-      $$SplitEntryRecordsTableOrderingComposer,
-      $$SplitEntryRecordsTableAnnotationComposer,
-      $$SplitEntryRecordsTableCreateCompanionBuilder,
-      $$SplitEntryRecordsTableUpdateCompanionBuilder,
-      (
-        SplitEntryRecord,
-        BaseReferences<
-          _$AppDatabase,
-          $SplitEntryRecordsTable,
-          SplitEntryRecord
-        >,
-      ),
-      SplitEntryRecord,
-      PrefetchHooks Function()
-    >;
-typedef $$SettlementEntriesTableCreateCompanionBuilder =
-    SettlementEntriesCompanion Function({
-      Value<int> id,
-      required String uuid,
-      required String groupId,
-      required String fromUserId,
-      required String toUserId,
-      required int amountCents,
-      Value<String> currencyCode,
-      Value<String?> paymentMethod,
-      Value<String?> paymentReference,
-      Value<String?> notes,
-      Value<String> status,
-      Value<DateTime?> settledAt,
-      Value<String> syncStatus,
-      Value<DateTime> createdAt,
-      Value<DateTime?> updatedAt,
-    });
-typedef $$SettlementEntriesTableUpdateCompanionBuilder =
-    SettlementEntriesCompanion Function({
-      Value<int> id,
-      Value<String> uuid,
-      Value<String> groupId,
-      Value<String> fromUserId,
-      Value<String> toUserId,
-      Value<int> amountCents,
-      Value<String> currencyCode,
-      Value<String?> paymentMethod,
-      Value<String?> paymentReference,
-      Value<String?> notes,
-      Value<String> status,
-      Value<DateTime?> settledAt,
-      Value<String> syncStatus,
-      Value<DateTime> createdAt,
-      Value<DateTime?> updatedAt,
-    });
+      BaseReferences<_$AppDatabase, $SplitEntryRecordsTable, SplitEntryRecord>
+    ),
+    SplitEntryRecord,
+    PrefetchHooks Function()>;
+typedef $$SettlementEntriesTableCreateCompanionBuilder
+    = SettlementEntriesCompanion Function({
+  Value<int> id,
+  required String uuid,
+  required String groupId,
+  required String fromUserId,
+  required String toUserId,
+  required int amountCents,
+  Value<String> currencyCode,
+  Value<String?> paymentMethod,
+  Value<String?> paymentReference,
+  Value<String?> notes,
+  Value<String> status,
+  Value<DateTime?> settledAt,
+  Value<String> syncStatus,
+  Value<DateTime> createdAt,
+  Value<DateTime?> updatedAt,
+});
+typedef $$SettlementEntriesTableUpdateCompanionBuilder
+    = SettlementEntriesCompanion Function({
+  Value<int> id,
+  Value<String> uuid,
+  Value<String> groupId,
+  Value<String> fromUserId,
+  Value<String> toUserId,
+  Value<int> amountCents,
+  Value<String> currencyCode,
+  Value<String?> paymentMethod,
+  Value<String?> paymentReference,
+  Value<String?> notes,
+  Value<String> status,
+  Value<DateTime?> settledAt,
+  Value<String> syncStatus,
+  Value<DateTime> createdAt,
+  Value<DateTime?> updatedAt,
+});
 
 class $$SettlementEntriesTableFilterComposer
     extends Composer<_$AppDatabase, $SettlementEntriesTable> {
@@ -10363,79 +8656,50 @@ class $$SettlementEntriesTableFilterComposer
     super.$removeJoinBuilderFromRootComposer,
   });
   ColumnFilters<int> get id => $composableBuilder(
-    column: $table.id,
-    builder: (column) => ColumnFilters(column),
-  );
+      column: $table.id, builder: (column) => ColumnFilters(column));
 
   ColumnFilters<String> get uuid => $composableBuilder(
-    column: $table.uuid,
-    builder: (column) => ColumnFilters(column),
-  );
+      column: $table.uuid, builder: (column) => ColumnFilters(column));
 
   ColumnFilters<String> get groupId => $composableBuilder(
-    column: $table.groupId,
-    builder: (column) => ColumnFilters(column),
-  );
+      column: $table.groupId, builder: (column) => ColumnFilters(column));
 
   ColumnFilters<String> get fromUserId => $composableBuilder(
-    column: $table.fromUserId,
-    builder: (column) => ColumnFilters(column),
-  );
+      column: $table.fromUserId, builder: (column) => ColumnFilters(column));
 
   ColumnFilters<String> get toUserId => $composableBuilder(
-    column: $table.toUserId,
-    builder: (column) => ColumnFilters(column),
-  );
+      column: $table.toUserId, builder: (column) => ColumnFilters(column));
 
   ColumnFilters<int> get amountCents => $composableBuilder(
-    column: $table.amountCents,
-    builder: (column) => ColumnFilters(column),
-  );
+      column: $table.amountCents, builder: (column) => ColumnFilters(column));
 
   ColumnFilters<String> get currencyCode => $composableBuilder(
-    column: $table.currencyCode,
-    builder: (column) => ColumnFilters(column),
-  );
+      column: $table.currencyCode, builder: (column) => ColumnFilters(column));
 
   ColumnFilters<String> get paymentMethod => $composableBuilder(
-    column: $table.paymentMethod,
-    builder: (column) => ColumnFilters(column),
-  );
+      column: $table.paymentMethod, builder: (column) => ColumnFilters(column));
 
   ColumnFilters<String> get paymentReference => $composableBuilder(
-    column: $table.paymentReference,
-    builder: (column) => ColumnFilters(column),
-  );
+      column: $table.paymentReference,
+      builder: (column) => ColumnFilters(column));
 
   ColumnFilters<String> get notes => $composableBuilder(
-    column: $table.notes,
-    builder: (column) => ColumnFilters(column),
-  );
+      column: $table.notes, builder: (column) => ColumnFilters(column));
 
   ColumnFilters<String> get status => $composableBuilder(
-    column: $table.status,
-    builder: (column) => ColumnFilters(column),
-  );
+      column: $table.status, builder: (column) => ColumnFilters(column));
 
   ColumnFilters<DateTime> get settledAt => $composableBuilder(
-    column: $table.settledAt,
-    builder: (column) => ColumnFilters(column),
-  );
+      column: $table.settledAt, builder: (column) => ColumnFilters(column));
 
   ColumnFilters<String> get syncStatus => $composableBuilder(
-    column: $table.syncStatus,
-    builder: (column) => ColumnFilters(column),
-  );
+      column: $table.syncStatus, builder: (column) => ColumnFilters(column));
 
   ColumnFilters<DateTime> get createdAt => $composableBuilder(
-    column: $table.createdAt,
-    builder: (column) => ColumnFilters(column),
-  );
+      column: $table.createdAt, builder: (column) => ColumnFilters(column));
 
   ColumnFilters<DateTime> get updatedAt => $composableBuilder(
-    column: $table.updatedAt,
-    builder: (column) => ColumnFilters(column),
-  );
+      column: $table.updatedAt, builder: (column) => ColumnFilters(column));
 }
 
 class $$SettlementEntriesTableOrderingComposer
@@ -10448,79 +8712,52 @@ class $$SettlementEntriesTableOrderingComposer
     super.$removeJoinBuilderFromRootComposer,
   });
   ColumnOrderings<int> get id => $composableBuilder(
-    column: $table.id,
-    builder: (column) => ColumnOrderings(column),
-  );
+      column: $table.id, builder: (column) => ColumnOrderings(column));
 
   ColumnOrderings<String> get uuid => $composableBuilder(
-    column: $table.uuid,
-    builder: (column) => ColumnOrderings(column),
-  );
+      column: $table.uuid, builder: (column) => ColumnOrderings(column));
 
   ColumnOrderings<String> get groupId => $composableBuilder(
-    column: $table.groupId,
-    builder: (column) => ColumnOrderings(column),
-  );
+      column: $table.groupId, builder: (column) => ColumnOrderings(column));
 
   ColumnOrderings<String> get fromUserId => $composableBuilder(
-    column: $table.fromUserId,
-    builder: (column) => ColumnOrderings(column),
-  );
+      column: $table.fromUserId, builder: (column) => ColumnOrderings(column));
 
   ColumnOrderings<String> get toUserId => $composableBuilder(
-    column: $table.toUserId,
-    builder: (column) => ColumnOrderings(column),
-  );
+      column: $table.toUserId, builder: (column) => ColumnOrderings(column));
 
   ColumnOrderings<int> get amountCents => $composableBuilder(
-    column: $table.amountCents,
-    builder: (column) => ColumnOrderings(column),
-  );
+      column: $table.amountCents, builder: (column) => ColumnOrderings(column));
 
   ColumnOrderings<String> get currencyCode => $composableBuilder(
-    column: $table.currencyCode,
-    builder: (column) => ColumnOrderings(column),
-  );
+      column: $table.currencyCode,
+      builder: (column) => ColumnOrderings(column));
 
   ColumnOrderings<String> get paymentMethod => $composableBuilder(
-    column: $table.paymentMethod,
-    builder: (column) => ColumnOrderings(column),
-  );
+      column: $table.paymentMethod,
+      builder: (column) => ColumnOrderings(column));
 
   ColumnOrderings<String> get paymentReference => $composableBuilder(
-    column: $table.paymentReference,
-    builder: (column) => ColumnOrderings(column),
-  );
+      column: $table.paymentReference,
+      builder: (column) => ColumnOrderings(column));
 
   ColumnOrderings<String> get notes => $composableBuilder(
-    column: $table.notes,
-    builder: (column) => ColumnOrderings(column),
-  );
+      column: $table.notes, builder: (column) => ColumnOrderings(column));
 
   ColumnOrderings<String> get status => $composableBuilder(
-    column: $table.status,
-    builder: (column) => ColumnOrderings(column),
-  );
+      column: $table.status, builder: (column) => ColumnOrderings(column));
 
   ColumnOrderings<DateTime> get settledAt => $composableBuilder(
-    column: $table.settledAt,
-    builder: (column) => ColumnOrderings(column),
-  );
+      column: $table.settledAt, builder: (column) => ColumnOrderings(column));
 
   ColumnOrderings<String> get syncStatus => $composableBuilder(
-    column: $table.syncStatus,
-    builder: (column) => ColumnOrderings(column),
-  );
+      column: $table.syncStatus, builder: (column) => ColumnOrderings(column));
 
   ColumnOrderings<DateTime> get createdAt => $composableBuilder(
-    column: $table.createdAt,
-    builder: (column) => ColumnOrderings(column),
-  );
+      column: $table.createdAt, builder: (column) => ColumnOrderings(column));
 
   ColumnOrderings<DateTime> get updatedAt => $composableBuilder(
-    column: $table.updatedAt,
-    builder: (column) => ColumnOrderings(column),
-  );
+      column: $table.updatedAt, builder: (column) => ColumnOrderings(column));
 }
 
 class $$SettlementEntriesTableAnnotationComposer
@@ -10542,32 +8779,22 @@ class $$SettlementEntriesTableAnnotationComposer
       $composableBuilder(column: $table.groupId, builder: (column) => column);
 
   GeneratedColumn<String> get fromUserId => $composableBuilder(
-    column: $table.fromUserId,
-    builder: (column) => column,
-  );
+      column: $table.fromUserId, builder: (column) => column);
 
   GeneratedColumn<String> get toUserId =>
       $composableBuilder(column: $table.toUserId, builder: (column) => column);
 
   GeneratedColumn<int> get amountCents => $composableBuilder(
-    column: $table.amountCents,
-    builder: (column) => column,
-  );
+      column: $table.amountCents, builder: (column) => column);
 
   GeneratedColumn<String> get currencyCode => $composableBuilder(
-    column: $table.currencyCode,
-    builder: (column) => column,
-  );
+      column: $table.currencyCode, builder: (column) => column);
 
   GeneratedColumn<String> get paymentMethod => $composableBuilder(
-    column: $table.paymentMethod,
-    builder: (column) => column,
-  );
+      column: $table.paymentMethod, builder: (column) => column);
 
   GeneratedColumn<String> get paymentReference => $composableBuilder(
-    column: $table.paymentReference,
-    builder: (column) => column,
-  );
+      column: $table.paymentReference, builder: (column) => column);
 
   GeneratedColumn<String> get notes =>
       $composableBuilder(column: $table.notes, builder: (column) => column);
@@ -10579,9 +8806,7 @@ class $$SettlementEntriesTableAnnotationComposer
       $composableBuilder(column: $table.settledAt, builder: (column) => column);
 
   GeneratedColumn<String> get syncStatus => $composableBuilder(
-    column: $table.syncStatus,
-    builder: (column) => column,
-  );
+      column: $table.syncStatus, builder: (column) => column);
 
   GeneratedColumn<DateTime> get createdAt =>
       $composableBuilder(column: $table.createdAt, builder: (column) => column);
@@ -10590,33 +8815,24 @@ class $$SettlementEntriesTableAnnotationComposer
       $composableBuilder(column: $table.updatedAt, builder: (column) => column);
 }
 
-class $$SettlementEntriesTableTableManager
-    extends
-        RootTableManager<
-          _$AppDatabase,
-          $SettlementEntriesTable,
-          SettlementEntry,
-          $$SettlementEntriesTableFilterComposer,
-          $$SettlementEntriesTableOrderingComposer,
-          $$SettlementEntriesTableAnnotationComposer,
-          $$SettlementEntriesTableCreateCompanionBuilder,
-          $$SettlementEntriesTableUpdateCompanionBuilder,
-          (
-            SettlementEntry,
-            BaseReferences<
-              _$AppDatabase,
-              $SettlementEntriesTable,
-              SettlementEntry
-            >,
-          ),
-          SettlementEntry,
-          PrefetchHooks Function()
-        > {
+class $$SettlementEntriesTableTableManager extends RootTableManager<
+    _$AppDatabase,
+    $SettlementEntriesTable,
+    SettlementEntry,
+    $$SettlementEntriesTableFilterComposer,
+    $$SettlementEntriesTableOrderingComposer,
+    $$SettlementEntriesTableAnnotationComposer,
+    $$SettlementEntriesTableCreateCompanionBuilder,
+    $$SettlementEntriesTableUpdateCompanionBuilder,
+    (
+      SettlementEntry,
+      BaseReferences<_$AppDatabase, $SettlementEntriesTable, SettlementEntry>
+    ),
+    SettlementEntry,
+    PrefetchHooks Function()> {
   $$SettlementEntriesTableTableManager(
-    _$AppDatabase db,
-    $SettlementEntriesTable table,
-  ) : super(
-        TableManagerState(
+      _$AppDatabase db, $SettlementEntriesTable table)
+      : super(TableManagerState(
           db: db,
           table: table,
           createFilteringComposer: () =>
@@ -10625,132 +8841,127 @@ class $$SettlementEntriesTableTableManager
               $$SettlementEntriesTableOrderingComposer($db: db, $table: table),
           createComputedFieldComposer: () =>
               $$SettlementEntriesTableAnnotationComposer(
-                $db: db,
-                $table: table,
-              ),
-          updateCompanionCallback:
-              ({
-                Value<int> id = const Value.absent(),
-                Value<String> uuid = const Value.absent(),
-                Value<String> groupId = const Value.absent(),
-                Value<String> fromUserId = const Value.absent(),
-                Value<String> toUserId = const Value.absent(),
-                Value<int> amountCents = const Value.absent(),
-                Value<String> currencyCode = const Value.absent(),
-                Value<String?> paymentMethod = const Value.absent(),
-                Value<String?> paymentReference = const Value.absent(),
-                Value<String?> notes = const Value.absent(),
-                Value<String> status = const Value.absent(),
-                Value<DateTime?> settledAt = const Value.absent(),
-                Value<String> syncStatus = const Value.absent(),
-                Value<DateTime> createdAt = const Value.absent(),
-                Value<DateTime?> updatedAt = const Value.absent(),
-              }) => SettlementEntriesCompanion(
-                id: id,
-                uuid: uuid,
-                groupId: groupId,
-                fromUserId: fromUserId,
-                toUserId: toUserId,
-                amountCents: amountCents,
-                currencyCode: currencyCode,
-                paymentMethod: paymentMethod,
-                paymentReference: paymentReference,
-                notes: notes,
-                status: status,
-                settledAt: settledAt,
-                syncStatus: syncStatus,
-                createdAt: createdAt,
-                updatedAt: updatedAt,
-              ),
-          createCompanionCallback:
-              ({
-                Value<int> id = const Value.absent(),
-                required String uuid,
-                required String groupId,
-                required String fromUserId,
-                required String toUserId,
-                required int amountCents,
-                Value<String> currencyCode = const Value.absent(),
-                Value<String?> paymentMethod = const Value.absent(),
-                Value<String?> paymentReference = const Value.absent(),
-                Value<String?> notes = const Value.absent(),
-                Value<String> status = const Value.absent(),
-                Value<DateTime?> settledAt = const Value.absent(),
-                Value<String> syncStatus = const Value.absent(),
-                Value<DateTime> createdAt = const Value.absent(),
-                Value<DateTime?> updatedAt = const Value.absent(),
-              }) => SettlementEntriesCompanion.insert(
-                id: id,
-                uuid: uuid,
-                groupId: groupId,
-                fromUserId: fromUserId,
-                toUserId: toUserId,
-                amountCents: amountCents,
-                currencyCode: currencyCode,
-                paymentMethod: paymentMethod,
-                paymentReference: paymentReference,
-                notes: notes,
-                status: status,
-                settledAt: settledAt,
-                syncStatus: syncStatus,
-                createdAt: createdAt,
-                updatedAt: updatedAt,
-              ),
+                  $db: db, $table: table),
+          updateCompanionCallback: ({
+            Value<int> id = const Value.absent(),
+            Value<String> uuid = const Value.absent(),
+            Value<String> groupId = const Value.absent(),
+            Value<String> fromUserId = const Value.absent(),
+            Value<String> toUserId = const Value.absent(),
+            Value<int> amountCents = const Value.absent(),
+            Value<String> currencyCode = const Value.absent(),
+            Value<String?> paymentMethod = const Value.absent(),
+            Value<String?> paymentReference = const Value.absent(),
+            Value<String?> notes = const Value.absent(),
+            Value<String> status = const Value.absent(),
+            Value<DateTime?> settledAt = const Value.absent(),
+            Value<String> syncStatus = const Value.absent(),
+            Value<DateTime> createdAt = const Value.absent(),
+            Value<DateTime?> updatedAt = const Value.absent(),
+          }) =>
+              SettlementEntriesCompanion(
+            id: id,
+            uuid: uuid,
+            groupId: groupId,
+            fromUserId: fromUserId,
+            toUserId: toUserId,
+            amountCents: amountCents,
+            currencyCode: currencyCode,
+            paymentMethod: paymentMethod,
+            paymentReference: paymentReference,
+            notes: notes,
+            status: status,
+            settledAt: settledAt,
+            syncStatus: syncStatus,
+            createdAt: createdAt,
+            updatedAt: updatedAt,
+          ),
+          createCompanionCallback: ({
+            Value<int> id = const Value.absent(),
+            required String uuid,
+            required String groupId,
+            required String fromUserId,
+            required String toUserId,
+            required int amountCents,
+            Value<String> currencyCode = const Value.absent(),
+            Value<String?> paymentMethod = const Value.absent(),
+            Value<String?> paymentReference = const Value.absent(),
+            Value<String?> notes = const Value.absent(),
+            Value<String> status = const Value.absent(),
+            Value<DateTime?> settledAt = const Value.absent(),
+            Value<String> syncStatus = const Value.absent(),
+            Value<DateTime> createdAt = const Value.absent(),
+            Value<DateTime?> updatedAt = const Value.absent(),
+          }) =>
+              SettlementEntriesCompanion.insert(
+            id: id,
+            uuid: uuid,
+            groupId: groupId,
+            fromUserId: fromUserId,
+            toUserId: toUserId,
+            amountCents: amountCents,
+            currencyCode: currencyCode,
+            paymentMethod: paymentMethod,
+            paymentReference: paymentReference,
+            notes: notes,
+            status: status,
+            settledAt: settledAt,
+            syncStatus: syncStatus,
+            createdAt: createdAt,
+            updatedAt: updatedAt,
+          ),
           withReferenceMapper: (p0) => p0
               .map((e) => (e.readTable(table), BaseReferences(db, table, e)))
               .toList(),
           prefetchHooksCallback: null,
-        ),
-      );
+        ));
 }
 
-typedef $$SettlementEntriesTableProcessedTableManager =
-    ProcessedTableManager<
-      _$AppDatabase,
-      $SettlementEntriesTable,
+typedef $$SettlementEntriesTableProcessedTableManager = ProcessedTableManager<
+    _$AppDatabase,
+    $SettlementEntriesTable,
+    SettlementEntry,
+    $$SettlementEntriesTableFilterComposer,
+    $$SettlementEntriesTableOrderingComposer,
+    $$SettlementEntriesTableAnnotationComposer,
+    $$SettlementEntriesTableCreateCompanionBuilder,
+    $$SettlementEntriesTableUpdateCompanionBuilder,
+    (
       SettlementEntry,
-      $$SettlementEntriesTableFilterComposer,
-      $$SettlementEntriesTableOrderingComposer,
-      $$SettlementEntriesTableAnnotationComposer,
-      $$SettlementEntriesTableCreateCompanionBuilder,
-      $$SettlementEntriesTableUpdateCompanionBuilder,
-      (
-        SettlementEntry,
-        BaseReferences<_$AppDatabase, $SettlementEntriesTable, SettlementEntry>,
-      ),
-      SettlementEntry,
-      PrefetchHooks Function()
-    >;
-typedef $$OutboxEntriesTableCreateCompanionBuilder =
-    OutboxEntriesCompanion Function({
-      Value<int> id,
-      required String operationId,
-      required String entityType,
-      required String entityId,
-      required String operationType,
-      required String payload,
-      Value<int> priority,
-      Value<String> status,
-      Value<int> retryCount,
-      Value<String?> lastError,
-      Value<DateTime> createdAt,
-      Value<DateTime?> lastAttemptAt,
-    });
-typedef $$OutboxEntriesTableUpdateCompanionBuilder =
-    OutboxEntriesCompanion Function({
-      Value<int> id,
-      Value<String> operationId,
-      Value<String> entityType,
-      Value<String> entityId,
-      Value<String> operationType,
-      Value<String> payload,
-      Value<int> priority,
-      Value<String> status,
-      Value<int> retryCount,
-      Value<String?> lastError,
-      Value<DateTime> createdAt,
-      Value<DateTime?> lastAttemptAt,
-    });
+      BaseReferences<_$AppDatabase, $SettlementEntriesTable, SettlementEntry>
+    ),
+    SettlementEntry,
+    PrefetchHooks Function()>;
+typedef $$OutboxEntriesTableCreateCompanionBuilder = OutboxEntriesCompanion
+    Function({
+  Value<int> id,
+  required String operationId,
+  required String entityType,
+  required String entityId,
+  required String operationType,
+  required String payload,
+  Value<int> priority,
+  Value<String> status,
+  Value<int> retryCount,
+  Value<String?> lastError,
+  Value<DateTime> createdAt,
+  Value<DateTime?> lastAttemptAt,
+});
+typedef $$OutboxEntriesTableUpdateCompanionBuilder = OutboxEntriesCompanion
+    Function({
+  Value<int> id,
+  Value<String> operationId,
+  Value<String> entityType,
+  Value<String> entityId,
+  Value<String> operationType,
+  Value<String> payload,
+  Value<int> priority,
+  Value<String> status,
+  Value<int> retryCount,
+  Value<String?> lastError,
+  Value<DateTime> createdAt,
+  Value<DateTime?> lastAttemptAt,
+});
 
 class $$OutboxEntriesTableFilterComposer
     extends Composer<_$AppDatabase, $OutboxEntriesTable> {
@@ -10762,64 +8973,40 @@ class $$OutboxEntriesTableFilterComposer
     super.$removeJoinBuilderFromRootComposer,
   });
   ColumnFilters<int> get id => $composableBuilder(
-    column: $table.id,
-    builder: (column) => ColumnFilters(column),
-  );
+      column: $table.id, builder: (column) => ColumnFilters(column));
 
   ColumnFilters<String> get operationId => $composableBuilder(
-    column: $table.operationId,
-    builder: (column) => ColumnFilters(column),
-  );
+      column: $table.operationId, builder: (column) => ColumnFilters(column));
 
   ColumnFilters<String> get entityType => $composableBuilder(
-    column: $table.entityType,
-    builder: (column) => ColumnFilters(column),
-  );
+      column: $table.entityType, builder: (column) => ColumnFilters(column));
 
   ColumnFilters<String> get entityId => $composableBuilder(
-    column: $table.entityId,
-    builder: (column) => ColumnFilters(column),
-  );
+      column: $table.entityId, builder: (column) => ColumnFilters(column));
 
   ColumnFilters<String> get operationType => $composableBuilder(
-    column: $table.operationType,
-    builder: (column) => ColumnFilters(column),
-  );
+      column: $table.operationType, builder: (column) => ColumnFilters(column));
 
   ColumnFilters<String> get payload => $composableBuilder(
-    column: $table.payload,
-    builder: (column) => ColumnFilters(column),
-  );
+      column: $table.payload, builder: (column) => ColumnFilters(column));
 
   ColumnFilters<int> get priority => $composableBuilder(
-    column: $table.priority,
-    builder: (column) => ColumnFilters(column),
-  );
+      column: $table.priority, builder: (column) => ColumnFilters(column));
 
   ColumnFilters<String> get status => $composableBuilder(
-    column: $table.status,
-    builder: (column) => ColumnFilters(column),
-  );
+      column: $table.status, builder: (column) => ColumnFilters(column));
 
   ColumnFilters<int> get retryCount => $composableBuilder(
-    column: $table.retryCount,
-    builder: (column) => ColumnFilters(column),
-  );
+      column: $table.retryCount, builder: (column) => ColumnFilters(column));
 
   ColumnFilters<String> get lastError => $composableBuilder(
-    column: $table.lastError,
-    builder: (column) => ColumnFilters(column),
-  );
+      column: $table.lastError, builder: (column) => ColumnFilters(column));
 
   ColumnFilters<DateTime> get createdAt => $composableBuilder(
-    column: $table.createdAt,
-    builder: (column) => ColumnFilters(column),
-  );
+      column: $table.createdAt, builder: (column) => ColumnFilters(column));
 
   ColumnFilters<DateTime> get lastAttemptAt => $composableBuilder(
-    column: $table.lastAttemptAt,
-    builder: (column) => ColumnFilters(column),
-  );
+      column: $table.lastAttemptAt, builder: (column) => ColumnFilters(column));
 }
 
 class $$OutboxEntriesTableOrderingComposer
@@ -10832,64 +9019,42 @@ class $$OutboxEntriesTableOrderingComposer
     super.$removeJoinBuilderFromRootComposer,
   });
   ColumnOrderings<int> get id => $composableBuilder(
-    column: $table.id,
-    builder: (column) => ColumnOrderings(column),
-  );
+      column: $table.id, builder: (column) => ColumnOrderings(column));
 
   ColumnOrderings<String> get operationId => $composableBuilder(
-    column: $table.operationId,
-    builder: (column) => ColumnOrderings(column),
-  );
+      column: $table.operationId, builder: (column) => ColumnOrderings(column));
 
   ColumnOrderings<String> get entityType => $composableBuilder(
-    column: $table.entityType,
-    builder: (column) => ColumnOrderings(column),
-  );
+      column: $table.entityType, builder: (column) => ColumnOrderings(column));
 
   ColumnOrderings<String> get entityId => $composableBuilder(
-    column: $table.entityId,
-    builder: (column) => ColumnOrderings(column),
-  );
+      column: $table.entityId, builder: (column) => ColumnOrderings(column));
 
   ColumnOrderings<String> get operationType => $composableBuilder(
-    column: $table.operationType,
-    builder: (column) => ColumnOrderings(column),
-  );
+      column: $table.operationType,
+      builder: (column) => ColumnOrderings(column));
 
   ColumnOrderings<String> get payload => $composableBuilder(
-    column: $table.payload,
-    builder: (column) => ColumnOrderings(column),
-  );
+      column: $table.payload, builder: (column) => ColumnOrderings(column));
 
   ColumnOrderings<int> get priority => $composableBuilder(
-    column: $table.priority,
-    builder: (column) => ColumnOrderings(column),
-  );
+      column: $table.priority, builder: (column) => ColumnOrderings(column));
 
   ColumnOrderings<String> get status => $composableBuilder(
-    column: $table.status,
-    builder: (column) => ColumnOrderings(column),
-  );
+      column: $table.status, builder: (column) => ColumnOrderings(column));
 
   ColumnOrderings<int> get retryCount => $composableBuilder(
-    column: $table.retryCount,
-    builder: (column) => ColumnOrderings(column),
-  );
+      column: $table.retryCount, builder: (column) => ColumnOrderings(column));
 
   ColumnOrderings<String> get lastError => $composableBuilder(
-    column: $table.lastError,
-    builder: (column) => ColumnOrderings(column),
-  );
+      column: $table.lastError, builder: (column) => ColumnOrderings(column));
 
   ColumnOrderings<DateTime> get createdAt => $composableBuilder(
-    column: $table.createdAt,
-    builder: (column) => ColumnOrderings(column),
-  );
+      column: $table.createdAt, builder: (column) => ColumnOrderings(column));
 
   ColumnOrderings<DateTime> get lastAttemptAt => $composableBuilder(
-    column: $table.lastAttemptAt,
-    builder: (column) => ColumnOrderings(column),
-  );
+      column: $table.lastAttemptAt,
+      builder: (column) => ColumnOrderings(column));
 }
 
 class $$OutboxEntriesTableAnnotationComposer
@@ -10905,22 +9070,16 @@ class $$OutboxEntriesTableAnnotationComposer
       $composableBuilder(column: $table.id, builder: (column) => column);
 
   GeneratedColumn<String> get operationId => $composableBuilder(
-    column: $table.operationId,
-    builder: (column) => column,
-  );
+      column: $table.operationId, builder: (column) => column);
 
   GeneratedColumn<String> get entityType => $composableBuilder(
-    column: $table.entityType,
-    builder: (column) => column,
-  );
+      column: $table.entityType, builder: (column) => column);
 
   GeneratedColumn<String> get entityId =>
       $composableBuilder(column: $table.entityId, builder: (column) => column);
 
   GeneratedColumn<String> get operationType => $composableBuilder(
-    column: $table.operationType,
-    builder: (column) => column,
-  );
+      column: $table.operationType, builder: (column) => column);
 
   GeneratedColumn<String> get payload =>
       $composableBuilder(column: $table.payload, builder: (column) => column);
@@ -10932,9 +9091,7 @@ class $$OutboxEntriesTableAnnotationComposer
       $composableBuilder(column: $table.status, builder: (column) => column);
 
   GeneratedColumn<int> get retryCount => $composableBuilder(
-    column: $table.retryCount,
-    builder: (column) => column,
-  );
+      column: $table.retryCount, builder: (column) => column);
 
   GeneratedColumn<String> get lastError =>
       $composableBuilder(column: $table.lastError, builder: (column) => column);
@@ -10943,32 +9100,26 @@ class $$OutboxEntriesTableAnnotationComposer
       $composableBuilder(column: $table.createdAt, builder: (column) => column);
 
   GeneratedColumn<DateTime> get lastAttemptAt => $composableBuilder(
-    column: $table.lastAttemptAt,
-    builder: (column) => column,
-  );
+      column: $table.lastAttemptAt, builder: (column) => column);
 }
 
-class $$OutboxEntriesTableTableManager
-    extends
-        RootTableManager<
-          _$AppDatabase,
-          $OutboxEntriesTable,
-          OutboxEntry,
-          $$OutboxEntriesTableFilterComposer,
-          $$OutboxEntriesTableOrderingComposer,
-          $$OutboxEntriesTableAnnotationComposer,
-          $$OutboxEntriesTableCreateCompanionBuilder,
-          $$OutboxEntriesTableUpdateCompanionBuilder,
-          (
-            OutboxEntry,
-            BaseReferences<_$AppDatabase, $OutboxEntriesTable, OutboxEntry>,
-          ),
-          OutboxEntry,
-          PrefetchHooks Function()
-        > {
+class $$OutboxEntriesTableTableManager extends RootTableManager<
+    _$AppDatabase,
+    $OutboxEntriesTable,
+    OutboxEntry,
+    $$OutboxEntriesTableFilterComposer,
+    $$OutboxEntriesTableOrderingComposer,
+    $$OutboxEntriesTableAnnotationComposer,
+    $$OutboxEntriesTableCreateCompanionBuilder,
+    $$OutboxEntriesTableUpdateCompanionBuilder,
+    (
+      OutboxEntry,
+      BaseReferences<_$AppDatabase, $OutboxEntriesTable, OutboxEntry>
+    ),
+    OutboxEntry,
+    PrefetchHooks Function()> {
   $$OutboxEntriesTableTableManager(_$AppDatabase db, $OutboxEntriesTable table)
-    : super(
-        TableManagerState(
+      : super(TableManagerState(
           db: db,
           table: table,
           createFilteringComposer: () =>
@@ -10977,101 +9128,98 @@ class $$OutboxEntriesTableTableManager
               $$OutboxEntriesTableOrderingComposer($db: db, $table: table),
           createComputedFieldComposer: () =>
               $$OutboxEntriesTableAnnotationComposer($db: db, $table: table),
-          updateCompanionCallback:
-              ({
-                Value<int> id = const Value.absent(),
-                Value<String> operationId = const Value.absent(),
-                Value<String> entityType = const Value.absent(),
-                Value<String> entityId = const Value.absent(),
-                Value<String> operationType = const Value.absent(),
-                Value<String> payload = const Value.absent(),
-                Value<int> priority = const Value.absent(),
-                Value<String> status = const Value.absent(),
-                Value<int> retryCount = const Value.absent(),
-                Value<String?> lastError = const Value.absent(),
-                Value<DateTime> createdAt = const Value.absent(),
-                Value<DateTime?> lastAttemptAt = const Value.absent(),
-              }) => OutboxEntriesCompanion(
-                id: id,
-                operationId: operationId,
-                entityType: entityType,
-                entityId: entityId,
-                operationType: operationType,
-                payload: payload,
-                priority: priority,
-                status: status,
-                retryCount: retryCount,
-                lastError: lastError,
-                createdAt: createdAt,
-                lastAttemptAt: lastAttemptAt,
-              ),
-          createCompanionCallback:
-              ({
-                Value<int> id = const Value.absent(),
-                required String operationId,
-                required String entityType,
-                required String entityId,
-                required String operationType,
-                required String payload,
-                Value<int> priority = const Value.absent(),
-                Value<String> status = const Value.absent(),
-                Value<int> retryCount = const Value.absent(),
-                Value<String?> lastError = const Value.absent(),
-                Value<DateTime> createdAt = const Value.absent(),
-                Value<DateTime?> lastAttemptAt = const Value.absent(),
-              }) => OutboxEntriesCompanion.insert(
-                id: id,
-                operationId: operationId,
-                entityType: entityType,
-                entityId: entityId,
-                operationType: operationType,
-                payload: payload,
-                priority: priority,
-                status: status,
-                retryCount: retryCount,
-                lastError: lastError,
-                createdAt: createdAt,
-                lastAttemptAt: lastAttemptAt,
-              ),
+          updateCompanionCallback: ({
+            Value<int> id = const Value.absent(),
+            Value<String> operationId = const Value.absent(),
+            Value<String> entityType = const Value.absent(),
+            Value<String> entityId = const Value.absent(),
+            Value<String> operationType = const Value.absent(),
+            Value<String> payload = const Value.absent(),
+            Value<int> priority = const Value.absent(),
+            Value<String> status = const Value.absent(),
+            Value<int> retryCount = const Value.absent(),
+            Value<String?> lastError = const Value.absent(),
+            Value<DateTime> createdAt = const Value.absent(),
+            Value<DateTime?> lastAttemptAt = const Value.absent(),
+          }) =>
+              OutboxEntriesCompanion(
+            id: id,
+            operationId: operationId,
+            entityType: entityType,
+            entityId: entityId,
+            operationType: operationType,
+            payload: payload,
+            priority: priority,
+            status: status,
+            retryCount: retryCount,
+            lastError: lastError,
+            createdAt: createdAt,
+            lastAttemptAt: lastAttemptAt,
+          ),
+          createCompanionCallback: ({
+            Value<int> id = const Value.absent(),
+            required String operationId,
+            required String entityType,
+            required String entityId,
+            required String operationType,
+            required String payload,
+            Value<int> priority = const Value.absent(),
+            Value<String> status = const Value.absent(),
+            Value<int> retryCount = const Value.absent(),
+            Value<String?> lastError = const Value.absent(),
+            Value<DateTime> createdAt = const Value.absent(),
+            Value<DateTime?> lastAttemptAt = const Value.absent(),
+          }) =>
+              OutboxEntriesCompanion.insert(
+            id: id,
+            operationId: operationId,
+            entityType: entityType,
+            entityId: entityId,
+            operationType: operationType,
+            payload: payload,
+            priority: priority,
+            status: status,
+            retryCount: retryCount,
+            lastError: lastError,
+            createdAt: createdAt,
+            lastAttemptAt: lastAttemptAt,
+          ),
           withReferenceMapper: (p0) => p0
               .map((e) => (e.readTable(table), BaseReferences(db, table, e)))
               .toList(),
           prefetchHooksCallback: null,
-        ),
-      );
+        ));
 }
 
-typedef $$OutboxEntriesTableProcessedTableManager =
-    ProcessedTableManager<
-      _$AppDatabase,
-      $OutboxEntriesTable,
+typedef $$OutboxEntriesTableProcessedTableManager = ProcessedTableManager<
+    _$AppDatabase,
+    $OutboxEntriesTable,
+    OutboxEntry,
+    $$OutboxEntriesTableFilterComposer,
+    $$OutboxEntriesTableOrderingComposer,
+    $$OutboxEntriesTableAnnotationComposer,
+    $$OutboxEntriesTableCreateCompanionBuilder,
+    $$OutboxEntriesTableUpdateCompanionBuilder,
+    (
       OutboxEntry,
-      $$OutboxEntriesTableFilterComposer,
-      $$OutboxEntriesTableOrderingComposer,
-      $$OutboxEntriesTableAnnotationComposer,
-      $$OutboxEntriesTableCreateCompanionBuilder,
-      $$OutboxEntriesTableUpdateCompanionBuilder,
-      (
-        OutboxEntry,
-        BaseReferences<_$AppDatabase, $OutboxEntriesTable, OutboxEntry>,
-      ),
-      OutboxEntry,
-      PrefetchHooks Function()
-    >;
-typedef $$SyncMetadataTableCreateCompanionBuilder =
-    SyncMetadataCompanion Function({
-      required String key,
-      required String value,
-      Value<DateTime> updatedAt,
-      Value<int> rowid,
-    });
-typedef $$SyncMetadataTableUpdateCompanionBuilder =
-    SyncMetadataCompanion Function({
-      Value<String> key,
-      Value<String> value,
-      Value<DateTime> updatedAt,
-      Value<int> rowid,
-    });
+      BaseReferences<_$AppDatabase, $OutboxEntriesTable, OutboxEntry>
+    ),
+    OutboxEntry,
+    PrefetchHooks Function()>;
+typedef $$SyncMetadataTableCreateCompanionBuilder = SyncMetadataCompanion
+    Function({
+  required String key,
+  required String value,
+  Value<DateTime> updatedAt,
+  Value<int> rowid,
+});
+typedef $$SyncMetadataTableUpdateCompanionBuilder = SyncMetadataCompanion
+    Function({
+  Value<String> key,
+  Value<String> value,
+  Value<DateTime> updatedAt,
+  Value<int> rowid,
+});
 
 class $$SyncMetadataTableFilterComposer
     extends Composer<_$AppDatabase, $SyncMetadataTable> {
@@ -11083,19 +9231,13 @@ class $$SyncMetadataTableFilterComposer
     super.$removeJoinBuilderFromRootComposer,
   });
   ColumnFilters<String> get key => $composableBuilder(
-    column: $table.key,
-    builder: (column) => ColumnFilters(column),
-  );
+      column: $table.key, builder: (column) => ColumnFilters(column));
 
   ColumnFilters<String> get value => $composableBuilder(
-    column: $table.value,
-    builder: (column) => ColumnFilters(column),
-  );
+      column: $table.value, builder: (column) => ColumnFilters(column));
 
   ColumnFilters<DateTime> get updatedAt => $composableBuilder(
-    column: $table.updatedAt,
-    builder: (column) => ColumnFilters(column),
-  );
+      column: $table.updatedAt, builder: (column) => ColumnFilters(column));
 }
 
 class $$SyncMetadataTableOrderingComposer
@@ -11108,19 +9250,13 @@ class $$SyncMetadataTableOrderingComposer
     super.$removeJoinBuilderFromRootComposer,
   });
   ColumnOrderings<String> get key => $composableBuilder(
-    column: $table.key,
-    builder: (column) => ColumnOrderings(column),
-  );
+      column: $table.key, builder: (column) => ColumnOrderings(column));
 
   ColumnOrderings<String> get value => $composableBuilder(
-    column: $table.value,
-    builder: (column) => ColumnOrderings(column),
-  );
+      column: $table.value, builder: (column) => ColumnOrderings(column));
 
   ColumnOrderings<DateTime> get updatedAt => $composableBuilder(
-    column: $table.updatedAt,
-    builder: (column) => ColumnOrderings(column),
-  );
+      column: $table.updatedAt, builder: (column) => ColumnOrderings(column));
 }
 
 class $$SyncMetadataTableAnnotationComposer
@@ -11142,27 +9278,23 @@ class $$SyncMetadataTableAnnotationComposer
       $composableBuilder(column: $table.updatedAt, builder: (column) => column);
 }
 
-class $$SyncMetadataTableTableManager
-    extends
-        RootTableManager<
-          _$AppDatabase,
-          $SyncMetadataTable,
-          SyncMetadataData,
-          $$SyncMetadataTableFilterComposer,
-          $$SyncMetadataTableOrderingComposer,
-          $$SyncMetadataTableAnnotationComposer,
-          $$SyncMetadataTableCreateCompanionBuilder,
-          $$SyncMetadataTableUpdateCompanionBuilder,
-          (
-            SyncMetadataData,
-            BaseReferences<_$AppDatabase, $SyncMetadataTable, SyncMetadataData>,
-          ),
-          SyncMetadataData,
-          PrefetchHooks Function()
-        > {
+class $$SyncMetadataTableTableManager extends RootTableManager<
+    _$AppDatabase,
+    $SyncMetadataTable,
+    SyncMetadataData,
+    $$SyncMetadataTableFilterComposer,
+    $$SyncMetadataTableOrderingComposer,
+    $$SyncMetadataTableAnnotationComposer,
+    $$SyncMetadataTableCreateCompanionBuilder,
+    $$SyncMetadataTableUpdateCompanionBuilder,
+    (
+      SyncMetadataData,
+      BaseReferences<_$AppDatabase, $SyncMetadataTable, SyncMetadataData>
+    ),
+    SyncMetadataData,
+    PrefetchHooks Function()> {
   $$SyncMetadataTableTableManager(_$AppDatabase db, $SyncMetadataTable table)
-    : super(
-        TableManagerState(
+      : super(TableManagerState(
           db: db,
           table: table,
           createFilteringComposer: () =>
@@ -11171,55 +9303,52 @@ class $$SyncMetadataTableTableManager
               $$SyncMetadataTableOrderingComposer($db: db, $table: table),
           createComputedFieldComposer: () =>
               $$SyncMetadataTableAnnotationComposer($db: db, $table: table),
-          updateCompanionCallback:
-              ({
-                Value<String> key = const Value.absent(),
-                Value<String> value = const Value.absent(),
-                Value<DateTime> updatedAt = const Value.absent(),
-                Value<int> rowid = const Value.absent(),
-              }) => SyncMetadataCompanion(
-                key: key,
-                value: value,
-                updatedAt: updatedAt,
-                rowid: rowid,
-              ),
-          createCompanionCallback:
-              ({
-                required String key,
-                required String value,
-                Value<DateTime> updatedAt = const Value.absent(),
-                Value<int> rowid = const Value.absent(),
-              }) => SyncMetadataCompanion.insert(
-                key: key,
-                value: value,
-                updatedAt: updatedAt,
-                rowid: rowid,
-              ),
+          updateCompanionCallback: ({
+            Value<String> key = const Value.absent(),
+            Value<String> value = const Value.absent(),
+            Value<DateTime> updatedAt = const Value.absent(),
+            Value<int> rowid = const Value.absent(),
+          }) =>
+              SyncMetadataCompanion(
+            key: key,
+            value: value,
+            updatedAt: updatedAt,
+            rowid: rowid,
+          ),
+          createCompanionCallback: ({
+            required String key,
+            required String value,
+            Value<DateTime> updatedAt = const Value.absent(),
+            Value<int> rowid = const Value.absent(),
+          }) =>
+              SyncMetadataCompanion.insert(
+            key: key,
+            value: value,
+            updatedAt: updatedAt,
+            rowid: rowid,
+          ),
           withReferenceMapper: (p0) => p0
               .map((e) => (e.readTable(table), BaseReferences(db, table, e)))
               .toList(),
           prefetchHooksCallback: null,
-        ),
-      );
+        ));
 }
 
-typedef $$SyncMetadataTableProcessedTableManager =
-    ProcessedTableManager<
-      _$AppDatabase,
-      $SyncMetadataTable,
+typedef $$SyncMetadataTableProcessedTableManager = ProcessedTableManager<
+    _$AppDatabase,
+    $SyncMetadataTable,
+    SyncMetadataData,
+    $$SyncMetadataTableFilterComposer,
+    $$SyncMetadataTableOrderingComposer,
+    $$SyncMetadataTableAnnotationComposer,
+    $$SyncMetadataTableCreateCompanionBuilder,
+    $$SyncMetadataTableUpdateCompanionBuilder,
+    (
       SyncMetadataData,
-      $$SyncMetadataTableFilterComposer,
-      $$SyncMetadataTableOrderingComposer,
-      $$SyncMetadataTableAnnotationComposer,
-      $$SyncMetadataTableCreateCompanionBuilder,
-      $$SyncMetadataTableUpdateCompanionBuilder,
-      (
-        SyncMetadataData,
-        BaseReferences<_$AppDatabase, $SyncMetadataTable, SyncMetadataData>,
-      ),
-      SyncMetadataData,
-      PrefetchHooks Function()
-    >;
+      BaseReferences<_$AppDatabase, $SyncMetadataTable, SyncMetadataData>
+    ),
+    SyncMetadataData,
+    PrefetchHooks Function()>;
 
 class $AppDatabaseManager {
   final _$AppDatabase _db;


### PR DESCRIPTION
## Summary
- regenerate the committed Drift output after running the current repository codegen stack on `origin/main`
- keep the maintenance change scoped to generated database artifacts only

## Root cause
- `app/lib/core/database/app_database_native.g.dart` on `main` was stale relative to the current checked-in Drift/build_runner toolchain
- a clean `dart run build_runner build --delete-conflicting-outputs` rewrote the file substantially even though source schemas were unchanged

## Changes made
- committed the regenerated `app_database_native.g.dart`
- performed the work from a fresh git worktree based on the latest `origin/main`

## Validation
- `bash scripts/check-versions.sh`
- `flutter pub get` in `app/`
- `dart run build_runner build --delete-conflicting-outputs` in `app/`
- `flutter analyze --no-fatal-infos --no-fatal-warnings` in `app/`
- Dart format check across `app/lib` and `app/test`
- `flutter test --reporter=compact` in `app/`
- `flutter test --reporter=compact` in `packages/airo/`
- `flutter test --reporter=compact` in `packages/airomoney/`
- `npm audit`
- `npm audit --omit=dev`

## Risks
- low: generated-file-only change, but reviewers should confirm no unexpected schema/runtime drift is implied by the generator upgrade already present on `main`
