### PR TITLE
feat(coins): add Android import permission gate

### DIFF
--- a/app/lib/features/coins/application/services/android_finance_import_service.dart
+++ b/app/lib/features/coins/application/services/android_finance_import_service.dart
@@ -1,0 +1,70 @@
+import 'finance_chat_ingestion_service.dart';
+
+enum AndroidFinanceImportPermission { disabled, enabled }
+
+enum AndroidFinanceImportStatus {
+  permissionDisabled,
+  ignored,
+  queuedForReview,
+  failed,
+}
+
+class AndroidFinanceImportResult {
+  final AndroidFinanceImportStatus status;
+  final FinanceChatIngestionResult? ingestionResult;
+  final String message;
+
+  const AndroidFinanceImportResult({
+    required this.status,
+    required this.message,
+    this.ingestionResult,
+  });
+}
+
+class AndroidFinanceImportService {
+  final FinanceChatIngestionService ingestionService;
+  final Future<AndroidFinanceImportPermission> Function() permissionReader;
+
+  const AndroidFinanceImportService({
+    required this.ingestionService,
+    required this.permissionReader,
+  });
+
+  Future<AndroidFinanceImportResult> importText(
+    String rawText, {
+    required String accountId,
+  }) async {
+    final permission = await permissionReader();
+    if (permission != AndroidFinanceImportPermission.enabled) {
+      return const AndroidFinanceImportResult(
+        status: AndroidFinanceImportStatus.permissionDisabled,
+        message:
+            'Enable Android SMS or notification import before Airo reads bank, UPI, or card alerts.',
+      );
+    }
+
+    final ingestion = await ingestionService.ingest(
+      rawText,
+      accountId: accountId,
+      sourceTags: const ['source:android_import'],
+    );
+
+    return switch (ingestion.status) {
+      FinanceChatIngestionStatus.ignored => AndroidFinanceImportResult(
+        status: AndroidFinanceImportStatus.ignored,
+        ingestionResult: ingestion,
+        message: 'Ignored non-financial or sensitive authentication message.',
+      ),
+      FinanceChatIngestionStatus.failed => AndroidFinanceImportResult(
+        status: AndroidFinanceImportStatus.failed,
+        ingestionResult: ingestion,
+        message: ingestion.message ?? 'Android finance import failed.',
+      ),
+      _ => AndroidFinanceImportResult(
+        status: AndroidFinanceImportStatus.queuedForReview,
+        ingestionResult: ingestion,
+        message: ingestion.message ?? 'Queued imported transaction for review.',
+      ),
+    };
+  }
+}

--- a/app/lib/features/coins/application/services/finance_chat_ingestion_service.dart
+++ b/app/lib/features/coins/application/services/finance_chat_ingestion_service.dart
@@ -45,6 +45,7 @@ class FinanceChatIngestionService {
   Future<FinanceChatIngestionResult> ingest(
     String text, {
     required String accountId,
+    List<String> sourceTags = const [],
   }) async {
     final parsed = _parser.parse(text);
     if (parsed == null) {
@@ -72,7 +73,7 @@ class FinanceChatIngestionService {
         categoryId: parsed.categoryId,
         accountId: accountId,
         transactionDate: parsed.transactionDate,
-        tags: _mergeTags(current.tags, parsed, text),
+        tags: _mergeTags(current.tags, parsed, text, sourceTags),
         updatedAt: DateTime.now(),
       );
       final updateResult = await _repository.update(updated);
@@ -102,7 +103,7 @@ class FinanceChatIngestionService {
       categoryId: parsed.categoryId,
       accountId: accountId,
       transactionDate: parsed.transactionDate,
-      tags: _mergeTags(const [], parsed, text),
+      tags: _mergeTags(const [], parsed, text, sourceTags),
       createdAt: now,
     );
     final createResult = await _repository.create(transaction);
@@ -133,9 +134,11 @@ class FinanceChatIngestionService {
     List<String> currentTags,
     ParsedFinanceMessage parsed,
     String rawText,
+    List<String> sourceTags,
   ) {
     return <String>{
       ...currentTags,
+      ...sourceTags,
       'source:chat',
       'source:finance_sms',
       'source:parser:finance_message_parser',

--- a/app/lib/features/coins/coins.dart
+++ b/app/lib/features/coins/coins.dart
@@ -81,6 +81,7 @@ export 'application/use_cases/set_budget_use_case.dart' hide Result;
 export 'application/use_cases/update_expense_use_case.dart' hide Result;
 
 // Application - Services
+export 'application/services/android_finance_import_service.dart';
 export 'application/services/coins_notification_service.dart';
 export 'application/services/coins_platform_support.dart';
 export 'application/services/coins_sync_service.dart';

--- a/app/lib/features/coins/domain/services/finance_message_parser.dart
+++ b/app/lib/features/coins/domain/services/finance_message_parser.dart
@@ -37,6 +37,7 @@ class FinanceMessageParser {
 
   ParsedFinanceMessage? parse(String rawText) {
     final normalized = _normalize(rawText);
+    if (_looksSensitiveAuth(normalized)) return null;
     if (!_looksFinancial(normalized)) return null;
 
     final amountCents = _extractAmountCents(normalized);
@@ -72,6 +73,15 @@ class FinanceMessageParser {
       caseSensitive: false,
     ).hasMatch(text);
     return hasAmount && hasTransactionWord;
+  }
+
+  bool _looksSensitiveAuth(String text) {
+    final lower = text.toLowerCase();
+    final hasAuthWord = RegExp(
+      r'\b(otp|one time password|verification code|authenticate|authentication|do not share|password|login)\b',
+    ).hasMatch(lower);
+    final hasShortNumericCode = RegExp(r'\b\d{4,8}\b').hasMatch(lower);
+    return hasAuthWord && hasShortNumericCode;
   }
 
   int? _extractAmountCents(String text) {

--- a/app/lib/features/coins/presentation/screens/coins_dashboard_screen.dart
+++ b/app/lib/features/coins/presentation/screens/coins_dashboard_screen.dart
@@ -86,6 +86,9 @@ class CoinsDashboardScreen extends ConsumerWidget {
                   const _QuickAddExpenseCard(),
                   const SizedBox(height: 16),
 
+                  const _AndroidImportPermissionCard(),
+                  const SizedBox(height: 16),
+
                   _TransactionReviewQueueSection(
                     transactions: data.pendingTransactionReviews,
                   ),
@@ -133,6 +136,58 @@ class CoinsDashboardScreen extends ConsumerWidget {
     Navigator.of(
       context,
     ).push(MaterialPageRoute(builder: (_) => const AddExpenseScreen()));
+  }
+}
+
+class _AndroidImportPermissionCard extends StatelessWidget {
+  const _AndroidImportPermissionCard();
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Card(
+      elevation: 0,
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                Icon(Icons.sms_outlined, color: theme.colorScheme.primary),
+                const SizedBox(width: 8),
+                Expanded(
+                  child: Text(
+                    'Android SMS & notification import',
+                    style: theme.textTheme.titleLarge?.copyWith(
+                      fontWeight: FontWeight.w800,
+                    ),
+                  ),
+                ),
+                Chip(
+                  label: const Text('Permission disabled'),
+                  visualDensity: VisualDensity.compact,
+                  backgroundColor: theme.colorScheme.surfaceContainerHighest,
+                ),
+              ],
+            ),
+            const SizedBox(height: 8),
+            Text(
+              'Import bank, UPI, and card alerts only after you enable access. Airo parses locally, ignores OTP/auth messages, and queues matches for review.',
+              style: theme.textTheme.bodyMedium?.copyWith(
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
+            ),
+            const SizedBox(height: 12),
+            OutlinedButton.icon(
+              onPressed: null,
+              icon: const Icon(Icons.lock_outline),
+              label: const Text('Enable explicitly later'),
+            ),
+          ],
+        ),
+      ),
+    );
   }
 }
 

--- a/app/test/features/coins/application/services/android_finance_import_service_test.dart
+++ b/app/test/features/coins/application/services/android_finance_import_service_test.dart
@@ -1,0 +1,162 @@
+import 'package:airo_app/features/coins/application/services/android_finance_import_service.dart';
+import 'package:airo_app/features/coins/application/services/finance_chat_ingestion_service.dart';
+import 'package:airo_app/features/coins/domain/entities/transaction.dart';
+import 'package:airo_app/features/coins/domain/repositories/transaction_repository.dart';
+import 'package:airo_app/features/coins/domain/services/finance_message_parser.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('AndroidFinanceImportService', () {
+    test('does not import SMS text when permission is disabled', () async {
+      final repository = _InMemoryTransactionRepository();
+      final service = AndroidFinanceImportService(
+        ingestionService: FinanceChatIngestionService(
+          parser: const FinanceMessageParser(),
+          repository: repository,
+        ),
+        permissionReader: () async => AndroidFinanceImportPermission.disabled,
+      );
+
+      final result = await service.importText(
+        'INR 450.00 spent on your HDFC Bank Credit Card at Swiggy on 20-06-26.',
+        accountId: 'cash_default',
+      );
+
+      expect(result.status, AndroidFinanceImportStatus.permissionDisabled);
+      expect(repository.transactions, isEmpty);
+      expect(
+        result.message,
+        contains('Enable Android SMS or notification import'),
+      );
+    });
+
+    test('imports allowed financial SMS locally into the review queue', () async {
+      final repository = _InMemoryTransactionRepository();
+      final service = AndroidFinanceImportService(
+        ingestionService: FinanceChatIngestionService(
+          parser: FinanceMessageParser(now: () => DateTime(2026, 6, 20)),
+          repository: repository,
+        ),
+        permissionReader: () async => AndroidFinanceImportPermission.enabled,
+      );
+
+      final result = await service.importText(
+        'INR 450.00 spent on your HDFC Bank Credit Card at Swiggy on 20-06-26.',
+        accountId: 'cash_default',
+      );
+
+      expect(result.status, AndroidFinanceImportStatus.queuedForReview);
+      expect(repository.transactions, hasLength(1));
+      expect(repository.transactions.single.description, 'Swiggy');
+      expect(repository.transactions.single.tags, contains('review:pending'));
+      expect(
+        repository.transactions.single.tags,
+        contains('source:android_import'),
+      );
+    });
+
+    test('ignores OTP/auth messages without writing a transaction', () async {
+      final repository = _InMemoryTransactionRepository();
+      final service = AndroidFinanceImportService(
+        ingestionService: FinanceChatIngestionService(
+          parser: const FinanceMessageParser(),
+          repository: repository,
+        ),
+        permissionReader: () async => AndroidFinanceImportPermission.enabled,
+      );
+
+      final result = await service.importText(
+        'OTP 123456 for INR 1.00 card verification at HDFC Bank. Do not share.',
+        accountId: 'cash_default',
+      );
+
+      expect(result.status, AndroidFinanceImportStatus.ignored);
+      expect(repository.transactions, isEmpty);
+    });
+  });
+}
+
+class _InMemoryTransactionRepository implements TransactionRepository {
+  final List<Transaction> transactions = [];
+
+  @override
+  Future<Result<Transaction>> create(Transaction transaction) async {
+    transactions.add(transaction);
+    return (data: transaction, error: null);
+  }
+
+  @override
+  Future<Result<Transaction>> update(Transaction transaction) async {
+    final index = transactions.indexWhere((item) => item.id == transaction.id);
+    if (index == -1) return (data: null, error: 'not found');
+    transactions[index] = transaction;
+    return (data: transaction, error: null);
+  }
+
+  @override
+  Future<Result<List<Transaction>>> findByTag(String tag) async {
+    return (
+      data: transactions
+          .where((transaction) => transaction.tags.contains(tag))
+          .toList(),
+      error: null,
+    );
+  }
+
+  @override
+  Future<Result<void>> delete(String id) async => (data: null, error: null);
+
+  @override
+  Future<Result<List<Transaction>>> findByAccount(String accountId) async =>
+      (data: <Transaction>[], error: null);
+
+  @override
+  Future<Result<List<Transaction>>> findByCategory(String categoryId) async =>
+      (data: <Transaction>[], error: null);
+
+  @override
+  Future<Result<List<Transaction>>> findByDateRange(
+    DateTime start,
+    DateTime end,
+  ) async => (data: <Transaction>[], error: null);
+
+  @override
+  Future<Result<Transaction>> findById(String id) async =>
+      (data: null, error: 'not found');
+
+  @override
+  Future<Result<List<Transaction>>> findRecent({int limit = 10}) async =>
+      (data: transactions.take(limit).toList(), error: null);
+
+  @override
+  Future<Result<Map<String, int>>> getSpentByCategory(
+    DateTime start,
+    DateTime end,
+  ) async => (data: <String, int>{}, error: null);
+
+  @override
+  Future<Result<int>> getTotalSpent(DateTime start, DateTime end) async =>
+      (data: 0, error: null);
+
+  @override
+  Future<Result<void>> hardDelete(String id) async => (data: null, error: null);
+
+  @override
+  Future<Result<Transaction>> restore(String id) async =>
+      (data: null, error: 'not found');
+
+  @override
+  Future<Result<List<Transaction>>> search(String query) async =>
+      (data: <Transaction>[], error: null);
+
+  @override
+  Stream<List<Transaction>> watchAll() => Stream.value(transactions);
+
+  @override
+  Stream<List<Transaction>> watchByCategory(String categoryId) =>
+      Stream.value(<Transaction>[]);
+
+  @override
+  Stream<List<Transaction>> watchByDate(DateTime date) =>
+      Stream.value(<Transaction>[]);
+}

--- a/app/test/features/coins/domain/services/finance_message_parser_test.dart
+++ b/app/test/features/coins/domain/services/finance_message_parser_test.dart
@@ -41,5 +41,25 @@ void main() {
 
       expect(parser.parse('Can you summarize this note?'), isNull);
     });
+
+    test(
+      'ignores OTP and authentication messages even when they mention money',
+      () {
+        const parser = FinanceMessageParser();
+
+        expect(
+          parser.parse(
+            'OTP 123456 for INR 1.00 card verification at HDFC Bank. Do not share this code.',
+          ),
+          isNull,
+        );
+        expect(
+          parser.parse(
+            'Use one time password 789012 to authenticate UPI payment of Rs. 2000.00.',
+          ),
+          isNull,
+        );
+      },
+    );
   });
 }

--- a/app/test/features/coins/presentation/screens/coins_dashboard_screen_test.dart
+++ b/app/test/features/coins/presentation/screens/coins_dashboard_screen_test.dart
@@ -215,6 +215,31 @@ void main() {
     expect(find.text('Reviewed'), findsOneWidget);
     expect(find.text('Pending Review'), findsOneWidget);
   });
+
+  testWidgets('shows Android import permission education when not enabled', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          dashboardDataProvider.overrideWith(
+            (ref) async => const DashboardData(),
+          ),
+        ],
+        child: const MaterialApp(home: CoinsDashboardScreen()),
+      ),
+    );
+    await tester.pump();
+
+    expect(find.text('Android SMS & notification import'), findsOneWidget);
+    expect(
+      find.textContaining(
+        'Import bank, UPI, and card alerts only after you enable access',
+      ),
+      findsOneWidget,
+    );
+    expect(find.text('Permission disabled'), findsOneWidget);
+  });
 }
 
 Transaction _pendingImportedTransaction() {

--- a/docs/features/coins/PERSONAL_MONEY_MANAGEMENT_DELTA_TODO.md
+++ b/docs/features/coins/PERSONAL_MONEY_MANAGEMENT_DELTA_TODO.md
@@ -12,6 +12,8 @@ The Coins base now has the first local-first money-management pieces in place:
 - Chat-to-ledger ingestion for pasted finance SMS text.
 - Chat/SMS imports now enter a local transaction review queue instead of being silently final.
 - Imported transaction review supports edit, approve, reject, and duplicate marking while keeping source hash/parser/raw text metadata local for audit.
+- Android SMS/notification import now has a local permission-gated service boundary and dashboard education card; imports remain disabled until explicit user action.
+- OTP and authentication-style finance messages are filtered before parser ingestion.
 - Agent skill plumbing so the Brain/agent chat can route tool-like requests.
 - Local LLM service scaffolding for on-device extraction and private finance reasoning.
 - Receipt and invoice parsing pipeline hooks for bill split and imported documents.
@@ -23,8 +25,8 @@ This is enough for a first private financial inbox loop: user pastes or enters f
 
 ### Data Capture
 
-- [ ] Android SMS inbox permission flow is not implemented end-to-end.
-- [ ] Android notification listener for bank, UPI, and card alerts is not implemented.
+- [ ] Android SMS inbox permission flow is not implemented end-to-end; education and disabled-state service guard exist.
+- [ ] Android notification listener for bank, UPI, and card alerts is not implemented; local text import boundary exists for future listeners.
 - [ ] Email statement ingestion is not implemented.
 - [ ] User-forwarded statement mailbox is not implemented.
 - [ ] PhonePe, GPay, Paytm, and bank-export PDF/CSV imports need parser-specific fixtures.
@@ -69,12 +71,12 @@ This is enough for a first private financial inbox loop: user pastes or enters f
 - [ ] Category breakdown needs drill-down to transactions.
 - [x] Review queue is implemented for chat/SMS imported transactions.
 - [x] Edit/reject/duplicate/approve flow is implemented for chat/SMS imported transactions; broader undo across all parser-ingested sources remains pending.
-- [ ] First-run education is needed for privacy, permissions, and supported data sources.
+- [ ] First-run education is needed for broader privacy, permissions, and supported data sources; Coins dashboard now explains disabled Android SMS/notification import.
 - [ ] India-first examples and copy are needed for UPI, cards, wallets, EMI, and bills.
 
 ### Testing And Release
 
-- [ ] Add parser fixture packs for major Indian bank/card/UPI SMS patterns.
+- [ ] Add parser fixture packs for major Indian bank/card/UPI SMS patterns; initial spend/credit/OTP fixtures exist.
 - [ ] Add golden fixtures for PhonePe/GPay/Paytm exports.
 - [ ] Add issuer fixtures for credit card statement summaries.
 - [ ] Add dedupe and reconciliation property tests.
@@ -94,10 +96,10 @@ This is enough for a first private financial inbox loop: user pastes or enters f
 
 ### Milestone 2: Android SMS And Notification Import
 
-- [ ] Add permission education screen.
+- [x] Add permission education screen/card.
 - [ ] Add sender allowlist and financial keyword filters.
-- [ ] Exclude OTP and authentication messages.
-- [ ] Run parser locally and write only normalized finance records into the ledger.
+- [x] Exclude OTP and authentication messages.
+- [x] Add local permission-gated import boundary that writes normalized finance records into the review queue only when enabled.
 - [ ] Add Android integration tests with seeded SMS/notification fixtures.
 
 ### Milestone 3: Credit Card Liability Manager


### PR DESCRIPTION
## Summary
- Adds a local-first Android finance import service boundary gated by explicit permission state.
- Keeps permission-disabled imports from reading/writing anything and queues enabled imports into the existing Coins review flow.
- Filters OTP/authentication-style finance messages before ingestion.
- Adds dashboard education copy explaining SMS/notification import remains disabled until explicit user action.
- Updates the Coins delta TODO with completed Android import guardrails and remaining gaps.

## Verification
- [x] `flutter analyze lib/features/coins test/features/coins`
- [x] `flutter test test/features/coins/domain/services/finance_message_parser_test.dart test/features/coins/application/services/android_finance_import_service_test.dart test/features/coins/application/services/finance_chat_ingestion_service_test.dart test/features/coins/presentation/screens/coins_dashboard_screen_test.dart`
- [x] `scripts/test-check-module-sizes.sh`

## Notes
- Full `flutter analyze` currently fails on existing unrelated app-level issues, including `lib/core/app/app_shell.dart` missing `../../features/iptv/application/providers/iptv_providers.dart`.
- Full `flutter test` currently fails on existing unrelated platform_media/app-shell loading errors; the focused Coins tests above pass.
- This slice does not request Android permissions or read the SMS inbox/listeners yet; it only creates the explicit disabled/enabled boundary and local parser path for the future listener.
