### PR TITLE
feat(notifications): handle tap deep links

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -344,7 +344,10 @@ test-database-reliability: ## Run deterministic native database reliability vali
 .PHONY: test-notification-validation
 test-notification-validation: ## Run deterministic notification validation suite
 	@echo "$(BLUE)Running notification validation suite...$(NC)"
-	@cd $(APP_DIR) && flutter test test/features/agent_chat/data/services/agent_notification_scheduler_test.dart
+	@cd $(APP_DIR) && flutter test \
+		test/features/agent_chat/data/services/agent_notification_scheduler_test.dart \
+		test/features/agent_chat/data/services/notification_navigation_service_test.dart \
+		test/features/agent_chat/presentation/screens/notifications_screen_test.dart
 	@echo "$(GREEN)Notification validation complete.$(NC)"
 	@echo "$(YELLOW)See docs/release/NOTIFICATION_VALIDATION.md for scope and follow-up.$(NC)"
 

--- a/app/lib/core/app/airo_app.dart
+++ b/app/lib/core/app/airo_app.dart
@@ -1,5 +1,8 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../../features/agent_chat/data/services/notification_navigation_service.dart';
 import '../error/global_error_handler.dart';
 import '../providers/app_theme_provider.dart';
 import '../routing/app_router.dart';
@@ -20,6 +23,11 @@ class _AiroAppState extends ConsumerState<AiroApp> {
     WidgetsBinding.instance.addPostFrameCallback((_) {
       final navigatorKey = AppRouter.router.routerDelegate.navigatorKey;
       GlobalErrorHandler.setNavigatorKey(navigatorKey);
+      unawaited(
+        NotificationNavigationService.instance.bind(
+          navigate: AppRouter.router.go,
+        ),
+      );
     });
   }
 

--- a/app/lib/core/routing/app_router.dart
+++ b/app/lib/core/routing/app_router.dart
@@ -166,7 +166,9 @@ class AppRouter {
                   GoRoute(
                     path: 'notifications',
                     name: 'agent_notifications',
-                    builder: (context, state) => const NotificationsScreen(),
+                    builder: (context, state) => NotificationsScreen(
+                      initialCategory: state.uri.queryParameters['category'],
+                    ),
                   ),
                   GoRoute(
                     path: 'profile',

--- a/app/lib/features/agent_chat/data/services/agent_notification_scheduler.dart
+++ b/app/lib/features/agent_chat/data/services/agent_notification_scheduler.dart
@@ -169,12 +169,22 @@ abstract interface class AgentNotificationSchedulingService {
   Future<ScheduledAgentNotification?> markNotificationComplete(int id);
 }
 
+abstract interface class AgentNotificationRuntimeService {
+  Future<void> initialize({
+    void Function(String payload)? onNotificationPayload,
+  });
+
+  Future<String?> getLaunchPayload();
+}
+
 class NotificationPermissionDeniedException implements Exception {
   const NotificationPermissionDeniedException();
 }
 
 class LocalAgentNotificationScheduler
-    implements AgentNotificationSchedulingService {
+    implements
+        AgentNotificationSchedulingService,
+        AgentNotificationRuntimeService {
   LocalAgentNotificationScheduler({
     FlutterLocalNotificationsPlugin? notificationsPlugin,
     SharedPreferencesAsync? preferences,
@@ -198,9 +208,35 @@ class LocalAgentNotificationScheduler
   SharedPreferencesAsync? _preferences;
   bool _initialized = false;
   bool _timeZoneInitialized = false;
+  void Function(String payload)? _onNotificationPayload;
 
   SharedPreferencesAsync get _asyncPreferences {
     return _preferences ??= SharedPreferencesAsync();
+  }
+
+  @override
+  Future<void> initialize({
+    void Function(String payload)? onNotificationPayload,
+  }) async {
+    if (onNotificationPayload != null) {
+      _onNotificationPayload = onNotificationPayload;
+    }
+    await _ensureInitialized();
+  }
+
+  @override
+  Future<String?> getLaunchPayload() async {
+    await _ensureInitialized();
+    final details = await _notificationsPlugin
+        .getNotificationAppLaunchDetails();
+    if (details == null || !details.didNotificationLaunchApp) {
+      return null;
+    }
+    final payload = details.notificationResponse?.payload;
+    if (payload == null || payload.trim().isEmpty) {
+      return null;
+    }
+    return payload;
   }
 
   @override
@@ -363,7 +399,16 @@ class LocalAgentNotificationScheduler
       android: androidSettings,
       iOS: iosSettings,
     );
-    await _notificationsPlugin.initialize(settings: settings);
+    await _notificationsPlugin.initialize(
+      settings: settings,
+      onDidReceiveNotificationResponse: (response) {
+        final payload = response.payload;
+        if (payload == null || payload.trim().isEmpty) {
+          return;
+        }
+        _onNotificationPayload?.call(payload);
+      },
+    );
     _initialized = true;
   }
 

--- a/app/lib/features/agent_chat/data/services/notification_navigation_service.dart
+++ b/app/lib/features/agent_chat/data/services/notification_navigation_service.dart
@@ -1,0 +1,80 @@
+import 'dart:convert';
+
+import 'agent_notification_scheduler.dart';
+
+class NotificationNavigationService {
+  NotificationNavigationService({AgentNotificationRuntimeService? scheduler})
+    : _scheduler = scheduler ?? LocalAgentNotificationScheduler.instance;
+
+  static final NotificationNavigationService instance =
+      NotificationNavigationService();
+
+  final AgentNotificationRuntimeService _scheduler;
+  bool _launchPayloadHandled = false;
+
+  Future<void> bind({required void Function(String location) navigate}) async {
+    await _scheduler.initialize(
+      onNotificationPayload: (payload) {
+        final route = routeFromNotificationPayload(payload);
+        if (route != null) {
+          navigate(route);
+        }
+      },
+    );
+
+    if (_launchPayloadHandled) {
+      return;
+    }
+    _launchPayloadHandled = true;
+
+    final payload = await _scheduler.getLaunchPayload();
+    final route = routeFromNotificationPayload(payload);
+    if (route != null) {
+      navigate(route);
+    }
+  }
+}
+
+String? routeFromNotificationPayload(
+  String? payload, {
+  String fallbackRoute = '/mind/notifications',
+}) {
+  if (payload == null || payload.trim().isEmpty) {
+    return null;
+  }
+
+  final trimmed = payload.trim();
+  if (trimmed.startsWith('/')) {
+    return trimmed;
+  }
+
+  try {
+    final decoded = jsonDecode(trimmed);
+    if (decoded is! Map) {
+      return fallbackRoute;
+    }
+
+    final deepLink = decoded['deep_link'];
+    if (deepLink is String && deepLink.trim().startsWith('/')) {
+      return deepLink.trim();
+    }
+
+    final metadata = decoded['metadata'];
+    if (metadata is Map) {
+      final metadataDeepLink = metadata['deep_link'];
+      if (metadataDeepLink is String &&
+          metadataDeepLink.trim().startsWith('/')) {
+        return metadataDeepLink.trim();
+      }
+    }
+
+    final category = decoded['category'];
+    if (category is String && category.trim().isNotEmpty) {
+      return '$fallbackRoute?category=${Uri.encodeQueryComponent(category)}';
+    }
+
+    return fallbackRoute;
+  } catch (_) {
+    return fallbackRoute;
+  }
+}

--- a/app/lib/features/agent_chat/presentation/screens/notifications_screen.dart
+++ b/app/lib/features/agent_chat/presentation/screens/notifications_screen.dart
@@ -4,9 +4,10 @@ import 'package:go_router/go_router.dart';
 import '../../data/services/agent_notification_scheduler.dart';
 
 class NotificationsScreen extends StatefulWidget {
-  const NotificationsScreen({super.key, this._scheduler});
+  const NotificationsScreen({super.key, this.scheduler, this.initialCategory});
 
-  final AgentNotificationSchedulingService? _scheduler;
+  final AgentNotificationSchedulingService? scheduler;
+  final String? initialCategory;
 
   @override
   State<NotificationsScreen> createState() => _NotificationsScreenState();
@@ -19,7 +20,7 @@ class _NotificationsScreenState extends State<NotificationsScreen> {
   @override
   void initState() {
     super.initState();
-    _scheduler = widget._scheduler ?? LocalAgentNotificationScheduler.instance;
+    _scheduler = widget.scheduler ?? LocalAgentNotificationScheduler.instance;
     _notificationsFuture = _scheduler.getScheduledNotifications();
   }
 
@@ -28,7 +29,7 @@ class _NotificationsScreenState extends State<NotificationsScreen> {
     return FutureBuilder<List<ScheduledAgentNotification>>(
       future: _notificationsFuture,
       builder: (context, snapshot) {
-        final notifications = snapshot.data ?? const [];
+        final notifications = _filteredNotifications(snapshot.data ?? const []);
         return Scaffold(
           appBar: AppBar(
             leading: IconButton(
@@ -42,7 +43,7 @@ class _NotificationsScreenState extends State<NotificationsScreen> {
               children: [
                 const Icon(Icons.notifications_none, size: 20),
                 const SizedBox(width: 8),
-                Text('Notifications (${notifications.length})'),
+                Text(_titleFor(notifications.length)),
               ],
             ),
           ),
@@ -110,6 +111,26 @@ class _NotificationsScreenState extends State<NotificationsScreen> {
       queryParameters: prompt.isEmpty ? null : {'prefill': prompt},
     );
     context.push(uri.toString());
+  }
+
+  List<ScheduledAgentNotification> _filteredNotifications(
+    List<ScheduledAgentNotification> notifications,
+  ) {
+    final category = widget.initialCategory?.trim();
+    if (category == null || category.isEmpty) {
+      return notifications;
+    }
+    return notifications
+        .where((notification) => notification.category == category)
+        .toList();
+  }
+
+  String _titleFor(int count) {
+    final category = widget.initialCategory?.trim();
+    if (category == null || category.isEmpty) {
+      return 'Notifications ($count)';
+    }
+    return '${_categoryLabel(category)} Notifications ($count)';
   }
 }
 
@@ -230,6 +251,8 @@ String _categoryLabel(String category) {
     'billing' => 'Bills',
     'family' => 'Family',
     'habit' => 'Habit',
+    'downloads' => 'Downloads',
+    'recording' => 'Recording',
     _ => 'Reminder',
   };
 }

--- a/app/test/features/agent_chat/data/services/notification_navigation_service_test.dart
+++ b/app/test/features/agent_chat/data/services/notification_navigation_service_test.dart
@@ -1,0 +1,69 @@
+import 'package:airo_app/features/agent_chat/data/services/agent_notification_scheduler.dart';
+import 'package:airo_app/features/agent_chat/data/services/notification_navigation_service.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('routeFromNotificationPayload', () {
+    test('returns deep link from payload json when present', () {
+      final route = routeFromNotificationPayload(
+        '{"category":"downloads","deep_link":"/mind/notifications?category=downloads"}',
+      );
+
+      expect(route, '/mind/notifications?category=downloads');
+    });
+
+    test('falls back to category route when no explicit deep link exists', () {
+      final route = routeFromNotificationPayload(
+        '{"category":"recording","notification_id":42}',
+      );
+
+      expect(route, '/mind/notifications?category=recording');
+    });
+
+    test('falls back to notifications index on malformed payload', () {
+      final route = routeFromNotificationPayload('not-json');
+
+      expect(route, '/mind/notifications');
+    });
+  });
+
+  test('bind navigates for launch payload and live responses', () async {
+    final scheduler = _FakeNotificationRuntimeService(
+      launchPayload: '{"deep_link":"/mind/notifications?category=downloads"}',
+    );
+    final routes = <String>[];
+    final service = NotificationNavigationService(scheduler: scheduler);
+
+    await service.bind(navigate: routes.add);
+    scheduler.emit(
+      '{"category":"recording","deep_link":"/mind/notifications?category=recording"}',
+    );
+
+    expect(routes, [
+      '/mind/notifications?category=downloads',
+      '/mind/notifications?category=recording',
+    ]);
+  });
+}
+
+final class _FakeNotificationRuntimeService
+    implements AgentNotificationRuntimeService {
+  _FakeNotificationRuntimeService({this.launchPayload});
+
+  final String? launchPayload;
+  void Function(String payload)? _onNotificationPayload;
+
+  @override
+  Future<String?> getLaunchPayload() async => launchPayload;
+
+  @override
+  Future<void> initialize({
+    void Function(String payload)? onNotificationPayload,
+  }) async {
+    _onNotificationPayload = onNotificationPayload;
+  }
+
+  void emit(String payload) {
+    _onNotificationPayload?.call(payload);
+  }
+}

--- a/app/test/features/agent_chat/presentation/screens/notifications_screen_test.dart
+++ b/app/test/features/agent_chat/presentation/screens/notifications_screen_test.dart
@@ -41,21 +41,19 @@ void main() {
         GoRoute(
           path: '/mind/notifications',
           builder: (context, state) => NotificationsScreen(
-            scheduler: _FakeNotificationScheduler(
-              notifications: [
-                ScheduledAgentNotification(
-                  id: 1,
-                  title: 'Pay rent',
-                  message: 'Check July invoice before paying.',
-                  hour: 9,
-                  minute: 0,
-                  repeatDaily: false,
-                  date: '2026-07-01',
-                  scheduledAt: DateTime(2026, 7, 1, 9),
-                  createdAt: DateTime(2026, 6, 29, 12),
-                ),
-              ],
-            ),
+            scheduler: _FakeNotificationScheduler([
+              ScheduledAgentNotification(
+                id: 1,
+                title: 'Pay rent',
+                message: 'Check July invoice before paying.',
+                hour: 9,
+                minute: 0,
+                repeatDaily: false,
+                date: '2026-07-01',
+                scheduledAt: DateTime(2026, 7, 1, 9),
+                createdAt: DateTime(2026, 6, 29, 12),
+              ),
+            ]),
           ),
         ),
         GoRoute(
@@ -92,6 +90,49 @@ void main() {
       'Help me with this reminder: Pay rent - Check July invoice before paying. (on 2026-07-01 at 9:00 AM).',
     );
   });
+
+  testWidgets('filters notifications by initial category route state', (
+    tester,
+  ) async {
+    final scheduler = _FakeNotificationScheduler([
+      ScheduledAgentNotification(
+        id: 1,
+        title: 'Recording reminder',
+        message: 'Finish the upload.',
+        hour: 9,
+        minute: 0,
+        repeatDaily: true,
+        scheduledAt: DateTime(2026, 6, 30, 9),
+        createdAt: DateTime(2026, 6, 29, 12),
+        category: 'recording',
+      ),
+      ScheduledAgentNotification(
+        id: 2,
+        title: 'Download reminder',
+        message: 'Check model download progress.',
+        hour: 10,
+        minute: 0,
+        repeatDaily: true,
+        scheduledAt: DateTime(2026, 6, 30, 10),
+        createdAt: DateTime(2026, 6, 29, 12),
+        category: 'downloads',
+      ),
+    ]);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: NotificationsScreen(
+          scheduler: scheduler,
+          initialCategory: 'recording',
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('Recording Notifications (1)'), findsOneWidget);
+    expect(find.text('Recording reminder'), findsOneWidget);
+    expect(find.text('Download reminder'), findsNothing);
+  });
 }
 
 class _SelectedAssistantModelNotifier extends SelectedAssistantModelNotifier {
@@ -100,24 +141,25 @@ class _SelectedAssistantModelNotifier extends SelectedAssistantModelNotifier {
   }
 }
 
-class _FakeNotificationScheduler implements AgentNotificationSchedulingService {
-  _FakeNotificationScheduler({required this._notifications});
+final class _FakeNotificationScheduler
+    implements AgentNotificationSchedulingService {
+  _FakeNotificationScheduler(this.notifications);
 
-  final List<ScheduledAgentNotification> _notifications;
+  final List<ScheduledAgentNotification> notifications;
 
   @override
   Future<void> cancelNotification(int id) async {
-    _notifications.removeWhere((notification) => notification.id == id);
+    notifications.removeWhere((notification) => notification.id == id);
   }
 
   @override
   Future<List<ScheduledAgentNotification>> getScheduledNotifications() async {
-    return List<ScheduledAgentNotification>.from(_notifications);
+    return List<ScheduledAgentNotification>.from(notifications);
   }
 
   @override
   Future<ScheduledAgentNotification?> markNotificationComplete(int id) async {
-    for (final notification in _notifications) {
+    for (final notification in notifications) {
       if (notification.id == id) {
         return notification;
       }

--- a/docs/release/NOTIFICATION_VALIDATION.md
+++ b/docs/release/NOTIFICATION_VALIDATION.md
@@ -21,6 +21,12 @@ This command currently covers:
   - stable notification payload generation for deep-link metadata
   - completion bookkeeping for reminders that repeat until done
   - persistence recovery and scheduled ordering
+- `app/test/features/agent_chat/data/services/notification_navigation_service_test.dart`
+  - payload-to-route resolution for explicit deep links
+  - fallback routing for category-only payloads
+  - launch-payload and live-tap navigation handling
+- `app/test/features/agent_chat/presentation/screens/notifications_screen_test.dart`
+  - route-state filtering for category-specific notification views
 
 ## Host-Runnable Acceptance
 
@@ -30,6 +36,8 @@ The automated portion passes when:
 - scheduling the same reminder twice results in one stored reminder and one
   platform scheduling call
 - the emitted notification payload preserves the intended deep-link context
+- notification taps can be resolved into an in-app route deterministically
+- category-specific routes land on the intended notification screen state
 - completion awards points once and cancels the follow-up notification when the
   policy is `daily_until_done`
 - stored reminders reload in chronological order from persistence

--- a/docs/wiki/5.-AI-and-Model-Management.md
+++ b/docs/wiki/5.-AI-and-Model-Management.md
@@ -119,6 +119,12 @@ their payloads so the app can reopen the intended reminder flow consistently.
 At the scheduler layer, Airo also suppresses duplicate reminder scheduling for
 the same request instead of creating repeated entries.
 
+When a notification payload includes either an explicit in-app deep link or a
+category-only payload, Airo now routes notification taps into the matching
+Mind notifications view on launch and while the app is already running. The
+notifications screen also supports category-filtered routes such as download or
+recording notifications.
+
 Release validation for this path is split into:
 
 - host-runnable scheduler checks via `make test-notification-validation`


### PR DESCRIPTION
# Summary

This PR introduces the notification deep-link follow-up that missed PR #542.
Goal: complete the host-runnable portion of issue #515 by giving scheduled notification payloads an actual in-app navigation path on current `main`.

Core outcome:

* routes notification payloads into `/mind/...` locations on launch and live tap
* supports category-scoped notification screen state for deep links
* expands notification validation coverage and runbook scope for routing

# Changes

### Code

* Added:
  * `app/lib/features/agent_chat/data/services/notification_navigation_service.dart`
  * `app/test/features/agent_chat/data/services/notification_navigation_service_test.dart`
* Updated:
  * notification runtime init in `app/lib/features/agent_chat/data/services/agent_notification_scheduler.dart`
  * app bootstrap in `app/lib/core/app/airo_app.dart`
  * route/query handling in `app/lib/core/routing/app_router.dart`
  * category-aware notification presentation in `app/lib/features/agent_chat/presentation/screens/notifications_screen.dart`
  * notification runbook and Make target coverage in `Makefile` and `docs/release/NOTIFICATION_VALIDATION.md`

### Logic

* notification launch payloads and foreground tap callbacks now resolve to in-app routes
* payloads without explicit deep links fall back to category-specific notification routes
* `/mind/notifications?category=...` now renders a filtered notification list
* existing “open in chat” reminder-card flow is preserved on top of current `main`

# API Changes (if any)

* No external API changes.

# Database Changes (if any)

* None.

# Observability / Logging

* None.

# Performance Impact

* Negligible.

# Risks

* Notification tap routing now depends on payload JSON remaining stable.
* Current `main` has unrelated `feature_iptv` / platform package breakage that interferes with some app-package Flutter test invocations locally.
* Rollback plan:
  * revert this PR to restore the pre-routing behavior

# Testing

* Unit tests:
  * `flutter test --no-pub test/features/agent_chat/data/services/notification_navigation_service_test.dart`
  * `flutter test --no-pub test/features/agent_chat/data/services/agent_notification_scheduler_test.dart`
* Integration tests:
  * none in this slice
* Manual testing:
  * `adb devices -l` shows an attached Android emulator on this machine
  * `dart analyze lib/core/routing/app_router.dart` returned `No issues found!`

# Deployment Notes

* No config changes.

# Related Commits

* `feat(notifications): handle tap deep links`

# Notes

* This is the restacked follow-up that was committed after PR #542 had already merged, so it is being resubmitted as a fresh PR from current `main`.
* `notifications_screen_test.dart` is included in the diff, but local Flutter execution for that file is currently blocked by unrelated repository breakage in `feature_iptv` / `platform_*` packages on top of current `main`, not by notification code errors.
