### PR TITLE
fix(agent-chat): add accessible message copy actions

### DIFF
--- a/app/lib/features/agent_chat/presentation/screens/chat_screen.dart
+++ b/app/lib/features/agent_chat/presentation/screens/chat_screen.dart
@@ -286,7 +286,7 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
                   }
 
                   final message = _messages[index];
-                  return _buildMessage(message);
+                  return _buildMessage(message, index);
                 },
               ),
             ),
@@ -487,11 +487,12 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
     return true;
   }
 
-  Widget _buildMessage(ChatMessage message) {
+  Widget _buildMessage(ChatMessage message, int index) {
     final colorScheme = Theme.of(context).colorScheme;
     final maxWidth =
         MediaQuery.of(context).size.width *
         (message.traces.isNotEmpty || message.metadata != null ? 0.86 : 0.75);
+    final canCopy = message.text.trim().isNotEmpty;
 
     return Align(
       alignment: message.isUser ? Alignment.centerRight : Alignment.centerLeft,
@@ -514,11 +515,43 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
                 border: Border.all(color: colorScheme.outlineVariant),
                 borderRadius: BorderRadius.circular(8),
               ),
-              child: Text(
-                message.text,
-                style: TextStyle(
-                  color: colorScheme.primary.withValues(alpha: 0.9),
-                ),
+              child: Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Expanded(
+                    child: Text(
+                      message.text,
+                      style: TextStyle(
+                        color: colorScheme.primary.withValues(alpha: 0.9),
+                      ),
+                    ),
+                  ),
+                  if (canCopy) ...[
+                    const SizedBox(width: 8),
+                    PopupMenuButton<_MessageAction>(
+                      key: ValueKey('agent_chat_message_actions_$index'),
+                      tooltip: 'Message actions',
+                      onSelected: (value) {
+                        switch (value) {
+                          case _MessageAction.copy:
+                            _copyMessageText(message.text);
+                        }
+                      },
+                      itemBuilder: (context) => const [
+                        PopupMenuItem<_MessageAction>(
+                          value: _MessageAction.copy,
+                          child: Text('Copy message'),
+                        ),
+                      ],
+                      icon: const Icon(Icons.more_horiz, size: 18),
+                      padding: EdgeInsets.zero,
+                      constraints: const BoxConstraints.tightFor(
+                        width: 32,
+                        height: 32,
+                      ),
+                    ),
+                  ],
+                ],
               ),
             ),
             if (!message.isUser && message.metadata != null)
@@ -547,6 +580,14 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
         ),
       ),
     );
+  }
+
+  Future<void> _copyMessageText(String text) async {
+    await Clipboard.setData(ClipboardData(text: text));
+    if (!mounted) return;
+    ScaffoldMessenger.of(
+      context,
+    ).showSnackBar(const SnackBar(content: Text('Message copied')));
   }
 
   void _sendMessage() async {
@@ -1282,6 +1323,8 @@ class _MetadataRow extends StatelessWidget {
     );
   }
 }
+
+enum _MessageAction { copy }
 
 String _formatDuration(int durationMs) {
   if (durationMs < 1000) {

--- a/app/test/features/agent_chat/presentation/screens/chat_screen_metadata_test.dart
+++ b/app/test/features/agent_chat/presentation/screens/chat_screen_metadata_test.dart
@@ -3,6 +3,7 @@ import 'package:airo_app/features/agent_chat/domain/models/agent_skill.dart';
 import 'package:airo_app/features/agent_chat/domain/models/assistant_runtime_ids.dart';
 import 'package:airo_app/features/agent_chat/domain/models/chat_response_metadata.dart';
 import 'package:airo_app/features/agent_chat/presentation/screens/chat_screen.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -176,6 +177,55 @@ void main() {
       find.byKey(const Key('agent_chat_input')),
     );
     expect(input.controller?.text, 'Follow up on my reminder');
+  });
+
+  testWidgets('message actions copy assistant and user messages', (
+    tester,
+  ) async {
+    await _pumpChatScreen(
+      tester,
+      initialMessages: [
+        ChatMessage(text: 'Assistant answer', isUser: false),
+        ChatMessage(text: 'User prompt', isUser: true),
+      ],
+    );
+
+    await tester.tap(
+      find.byKey(const ValueKey('agent_chat_message_actions_0')),
+    );
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Copy message'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Message copied'), findsOneWidget);
+    expect(
+      (await Clipboard.getData('text/plain'))?.text,
+      equals('Assistant answer'),
+    );
+
+    await tester.tap(
+      find.byKey(const ValueKey('agent_chat_message_actions_1')),
+    );
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Copy message'));
+    await tester.pumpAndSettle();
+
+    expect(
+      (await Clipboard.getData('text/plain'))?.text,
+      equals('User prompt'),
+    );
+  });
+
+  testWidgets('empty streaming placeholder hides copy action', (tester) async {
+    await _pumpChatScreen(
+      tester,
+      initialMessages: [ChatMessage(text: '', isUser: false)],
+    );
+
+    expect(
+      find.byKey(const ValueKey('agent_chat_message_actions_0')),
+      findsNothing,
+    );
   });
 }
 

--- a/docs/wiki/5.-AI-and-Model-Management.md
+++ b/docs/wiki/5.-AI-and-Model-Management.md
@@ -21,6 +21,17 @@ Assistant messages follow this order:
    Bill.
 3. Use AI generation for general prompts that do not map to a local tool.
 
+## Chat Message Actions
+
+Brain chat now exposes a compact message-actions menu for non-empty user and
+assistant turns.
+
+You can:
+
+- open the overflow action on a chat bubble
+- use **Copy message** to copy the full rendered turn to the clipboard
+- rely on the action being hidden for empty streaming placeholders
+
 ## Current Skill Cards
 
 The Assistant currently exposes these Gallery-style cards:


### PR DESCRIPTION
# PR Title
fix(agent-chat): add accessible message copy actions

---

# Summary

This PR introduces changes to Brain chat message actions.
Goal: provide a narrow first slice for issue #305 by making chat messages copyable through an accessible overflow action.

Core outcome:

* adds `Copy message` actions for non-empty assistant and user chat bubbles
* confirms copy success with a snackbar and avoids exposing copy on empty streaming placeholders

---

# Changes

### Code

* Added:
  * message overflow action handling and clipboard copy feedback in chat bubbles
  * widget coverage for assistant/user copy actions and empty-placeholder behavior
* Updated:
  * `app/lib/features/agent_chat/presentation/screens/chat_screen.dart`
  * `app/test/features/agent_chat/presentation/screens/chat_screen_metadata_test.dart`

### Logic

* non-empty chat messages now expose a compact overflow menu with `Copy message`
* copying writes the full message text to the clipboard and shows `Message copied`
* empty placeholder assistant messages do not expose copy actions

---

# API Changes (if any)

* None.

---

# Database Changes (if any)

* None.

---

# Observability / Logging

* None.

---

# Performance Impact

* Latency: negligible
* Throughput: none
* Memory/CPU: negligible

---

# Risks

* This is a partial slice of #305; edit/regenerate/share/temp-chat/scroll recovery remain open.
* Local focused Flutter test execution is currently blocked by an existing package import problem in the IPTV packages, unrelated to these chat changes.
* Rollback plan:
  * revert this single commit if the message action UI causes regressions

---

# Testing

* Unit tests:
  * added widget assertions for assistant/user copy actions and hidden copy action for empty placeholder bubbles
* Integration tests:
  * not run
* Manual testing:
  * not run
  * attempted `flutter test test/features/agent_chat/presentation/screens/chat_screen_metadata_test.dart` from `app/`, but the run is blocked by existing IPTV package import failures outside this slice

---

# Deployment Notes

* Config changes:
  * none
* Order of deployment:
  * none

---

# Related Commits

* `fix(agent-chat): add accessible message copy actions`

---

# Notes

* Reviewers should focus on the chat bubble action placement and the empty-placeholder guard.
