### PR TITLE
feat(settings): add AI storage dashboard summary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -611,6 +611,11 @@ test-ui-responsive: ## Run shared responsive UI validation tests
 	@cd $(APP_DIR) && rm -rf windows/flutter/ephemeral/.plugin_symlinks ios/Flutter/ephemeral/Packages/.packages macos/Flutter/ephemeral/Packages/.packages
 	@cd $(APP_DIR) && flutter test test/shared/widgets/adaptive_layout_test.dart
 
+.PHONY: test-storage-dashboard
+test-storage-dashboard: ## Run deterministic storage dashboard validation tests
+	@echo "$(BLUE)Running storage dashboard validation tests...$(NC)"
+	@cd $(APP_DIR) && flutter test test/features/settings/application/ai_storage_dashboard_test.dart
+
 .PHONY: benchmark-report
 benchmark-report: ## Create a release benchmark report template
 	@./scripts/create-performance-benchmark-report.sh

--- a/app/lib/features/agent_chat/presentation/screens/profile_screen.dart
+++ b/app/lib/features/agent_chat/presentation/screens/profile_screen.dart
@@ -14,6 +14,7 @@ import '../../../../core/utils/currency_formatter.dart';
 import '../../../../core/utils/locale_settings.dart';
 import '../../../../shared/widgets/bug_report_dialog.dart';
 import '../../../quotes/presentation/widgets/daily_quote_card.dart';
+import '../../../settings/application/ai_storage_dashboard.dart';
 import '../../../settings/application/ai_preferences_settings.dart';
 import '../../../settings/application/ai_model_management.dart';
 import '../../../settings/presentation/screens/ai_models_screen.dart';
@@ -370,7 +371,7 @@ class _AIPreferencesSection extends ConsumerWidget {
     final theme = Theme.of(context);
     final settings = ref.watch(aiPreferencesSettingsProvider);
     final selectedModel = ref.watch(selectedModelProvider);
-    final storageUsage = ref.watch(aiModelStorageUsageBytesProvider);
+    final storageDashboard = ref.watch(aiStorageDashboardProvider);
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
@@ -493,13 +494,28 @@ class _AIPreferencesSection extends ConsumerWidget {
                 leading: const Icon(Icons.storage_outlined),
                 title: const Text('Storage'),
                 subtitle: Text(
-                  storageUsage.when(
-                    data: (bytes) => '${_formatBytes(bytes)} used',
+                  storageDashboard.when(
+                    data: (summary) =>
+                        '${_formatBytes(summary.totalUsedBytes)} used',
                     loading: () => 'Checking storage usage',
                     error: (_, _) => 'Storage usage unavailable',
                   ),
                 ),
                 children: [
+                  ...storageDashboard.maybeWhen(
+                    data: (summary) => summary.categories.map(
+                      (category) => ListTile(
+                        dense: true,
+                        title: Text(category.label),
+                        trailing: Text(
+                          category.available
+                              ? _formatBytes(category.bytes)
+                              : 'Unavailable',
+                        ),
+                      ),
+                    ),
+                    orElse: () => const <Widget>[],
+                  ),
                   _SettingDropdownRow<AIDownloadLocationPreference>(
                     label: 'Download Location',
                     value: settings.downloadLocation,

--- a/app/lib/features/settings/application/ai_preferences_settings.dart
+++ b/app/lib/features/settings/application/ai_preferences_settings.dart
@@ -2,8 +2,8 @@ import 'package:core_ai/core_ai.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
-import "package:feature_iptv/feature_iptv.dart"
-    show sharedPreferencesProvider;
+import 'package:feature_iptv/feature_iptv.dart' show sharedPreferencesProvider;
+import 'ai_storage_dashboard.dart';
 import 'ai_model_management.dart';
 
 enum AIAccelerationPreference {
@@ -77,11 +77,6 @@ final aiPreferencesSettingsProvider =
       },
     );
 
-final aiModelStorageUsageBytesProvider = FutureProvider<int>((ref) async {
-  final service = ref.watch(modelDownloadServiceProvider);
-  return service.getStorageUsed();
-});
-
 class AIPreferencesSettingsNotifier
     extends StateNotifier<AIPreferencesSettings> {
   AIPreferencesSettingsNotifier(this._ref)
@@ -141,7 +136,7 @@ class AIPreferencesSettingsNotifier
     final deleted = await manager.cleanupOrphanedFiles(
       ModelCatalog.bundledModels,
     );
-    _ref.invalidate(aiModelStorageUsageBytesProvider);
+    _ref.invalidate(aiStorageDashboardProvider);
     return deleted.length;
   }
 

--- a/app/lib/features/settings/application/ai_storage_dashboard.dart
+++ b/app/lib/features/settings/application/ai_storage_dashboard.dart
@@ -1,0 +1,187 @@
+import 'dart:io';
+
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:path/path.dart' as path;
+import 'package:path_provider/path_provider.dart';
+
+import '../../../core/database/app_database_native.dart';
+
+enum AIStorageCategoryKind {
+  installedModels,
+  meetingStorage,
+  embeddingStorage,
+  databaseSize,
+  audioCache,
+  availableSpace,
+}
+
+class AIStorageDashboardCategory {
+  const AIStorageDashboardCategory({
+    required this.kind,
+    required this.label,
+    required this.bytes,
+    this.available = true,
+  });
+
+  final AIStorageCategoryKind kind;
+  final String label;
+  final int bytes;
+  final bool available;
+
+  @override
+  String toString() {
+    return 'AIStorageDashboardCategory(kind: $kind, label: $label, bytes: $bytes, available: $available)';
+  }
+}
+
+class AIStorageDashboardSummary {
+  const AIStorageDashboardSummary({required this.categories});
+
+  final List<AIStorageDashboardCategory> categories;
+
+  int get totalUsedBytes => categories
+      .where(
+        (category) => category.kind != AIStorageCategoryKind.availableSpace,
+      )
+      .fold<int>(0, (total, category) => total + category.bytes);
+
+  AIStorageDashboardCategory category(AIStorageCategoryKind kind) {
+    return categories.firstWhere((category) => category.kind == kind);
+  }
+
+  @override
+  String toString() {
+    return 'AIStorageDashboardSummary(categories: $categories, totalUsedBytes: $totalUsedBytes)';
+  }
+}
+
+final aiStorageDashboardProvider = FutureProvider<AIStorageDashboardSummary>((
+  ref,
+) async {
+  return AIStorageDashboardService().loadSummary();
+});
+
+class AIStorageDashboardService {
+  AIStorageDashboardService({
+    MethodChannel? diskChannel,
+    Future<Directory> Function()? documentsDirectory,
+    Future<Directory> Function()? temporaryDirectory,
+  }) : _diskChannel =
+           diskChannel ?? const MethodChannel('com.airo.model_download'),
+       _documentsDirectory =
+           documentsDirectory ?? getApplicationDocumentsDirectory,
+       _temporaryDirectory = temporaryDirectory ?? getTemporaryDirectory;
+
+  final MethodChannel _diskChannel;
+  final Future<Directory> Function() _documentsDirectory;
+  final Future<Directory> Function() _temporaryDirectory;
+
+  Future<AIStorageDashboardSummary> loadSummary() async {
+    final documents = await _documentsDirectory();
+    final temporary = await _safeDirectory(_temporaryDirectory);
+    final databasePath = await AppDatabase.resolveDatabasePath();
+    final availableSpace = await _availableDiskSpace();
+
+    final categories = <AIStorageDashboardCategory>[
+      AIStorageDashboardCategory(
+        kind: AIStorageCategoryKind.installedModels,
+        label: 'Installed models',
+        bytes: await _directorySize(
+          Directory(path.join(documents.path, 'models')),
+        ),
+      ),
+      AIStorageDashboardCategory(
+        kind: AIStorageCategoryKind.meetingStorage,
+        label: 'Meeting storage',
+        bytes: await _sumSizes([
+          Directory(path.join(documents.path, 'meeting_audio')),
+          Directory(path.join(documents.path, 'recordings')),
+        ]),
+      ),
+      AIStorageDashboardCategory(
+        kind: AIStorageCategoryKind.embeddingStorage,
+        label: 'Embedding storage',
+        bytes: await _sumSizes([
+          Directory(path.join(documents.path, 'embeddings')),
+          Directory(path.join(documents.path, 'meeting_embeddings')),
+        ]),
+      ),
+      AIStorageDashboardCategory(
+        kind: AIStorageCategoryKind.databaseSize,
+        label: 'Database size',
+        bytes: await _sumSizes([
+          File(databasePath),
+          File('$databasePath-wal'),
+          File('$databasePath-shm'),
+        ]),
+      ),
+      AIStorageDashboardCategory(
+        kind: AIStorageCategoryKind.audioCache,
+        label: 'Audio cache',
+        bytes: await _sumSizes([
+          Directory(path.join(documents.path, 'audio_cache')),
+          if (temporary != null)
+            Directory(path.join(temporary.path, 'audio_cache')),
+        ]),
+      ),
+      AIStorageDashboardCategory(
+        kind: AIStorageCategoryKind.availableSpace,
+        label: 'Available space',
+        bytes: availableSpace ?? 0,
+        available: availableSpace != null,
+      ),
+    ];
+
+    return AIStorageDashboardSummary(categories: categories);
+  }
+
+  Future<int?> _availableDiskSpace() async {
+    try {
+      return await _diskChannel.invokeMethod<int>('getFreeDiskSpace');
+    } catch (_) {
+      return null;
+    }
+  }
+
+  Future<Directory?> _safeDirectory(Future<Directory> Function() load) async {
+    try {
+      return await load();
+    } catch (_) {
+      return null;
+    }
+  }
+
+  Future<int> _sumSizes(Iterable<FileSystemEntity> entities) async {
+    var total = 0;
+    for (final entity in entities) {
+      total += await _entitySize(entity);
+    }
+    return total;
+  }
+
+  Future<int> _entitySize(FileSystemEntity entity) async {
+    if (entity is File) {
+      if (!await entity.exists()) return 0;
+      return entity.length();
+    }
+    if (entity is Directory) {
+      return _directorySize(entity);
+    }
+    return 0;
+  }
+
+  Future<int> _directorySize(Directory directory) async {
+    if (!await directory.exists()) return 0;
+    var total = 0;
+    await for (final entity in directory.list(
+      recursive: true,
+      followLinks: false,
+    )) {
+      if (entity is File) {
+        total += await entity.length();
+      }
+    }
+    return total;
+  }
+}

--- a/app/test/features/agent_chat/presentation/screens/profile_theme_picker_test.dart
+++ b/app/test/features/agent_chat/presentation/screens/profile_theme_picker_test.dart
@@ -1,7 +1,7 @@
 import 'package:airo_app/core/providers/app_theme_provider.dart';
 import 'package:airo_app/features/agent_chat/presentation/screens/profile_screen.dart';
-import "package:feature_iptv/feature_iptv.dart";
-import "package:platform_channels/platform_channels.dart";
+import 'package:airo_app/features/settings/application/ai_storage_dashboard.dart';
+import 'package:feature_iptv/feature_iptv.dart';
 import 'package:airo_app/features/settings/application/ai_preferences_settings.dart';
 import 'package:core_ui/core_ui.dart';
 import 'package:flutter/material.dart';
@@ -48,8 +48,41 @@ void main() {
         overrides: [
           appThemeProvider.overrideWith((ref) => notifier),
           sharedPreferencesProvider.overrideWithValue(prefs),
-          aiModelStorageUsageBytesProvider.overrideWith((ref) async {
-            return 512 * 1024 * 1024;
+          aiStorageDashboardProvider.overrideWith((ref) async {
+            return const AIStorageDashboardSummary(
+              categories: [
+                AIStorageDashboardCategory(
+                  kind: AIStorageCategoryKind.installedModels,
+                  label: 'Installed models',
+                  bytes: 512 * 1024 * 1024,
+                ),
+                AIStorageDashboardCategory(
+                  kind: AIStorageCategoryKind.meetingStorage,
+                  label: 'Meeting storage',
+                  bytes: 0,
+                ),
+                AIStorageDashboardCategory(
+                  kind: AIStorageCategoryKind.embeddingStorage,
+                  label: 'Embedding storage',
+                  bytes: 0,
+                ),
+                AIStorageDashboardCategory(
+                  kind: AIStorageCategoryKind.databaseSize,
+                  label: 'Database size',
+                  bytes: 0,
+                ),
+                AIStorageDashboardCategory(
+                  kind: AIStorageCategoryKind.audioCache,
+                  label: 'Audio cache',
+                  bytes: 0,
+                ),
+                AIStorageDashboardCategory(
+                  kind: AIStorageCategoryKind.availableSpace,
+                  label: 'Available space',
+                  bytes: 2 * 1024 * 1024 * 1024,
+                ),
+              ],
+            );
           }),
         ],
         child: const MaterialApp(home: ProfileScreen()),
@@ -74,5 +107,73 @@ void main() {
       prefs.getBool(AIPreferencesSettingsNotifier.autoFallbackKey),
       isTrue,
     );
+  });
+
+  testWidgets('profile storage dashboard shows all local storage categories', (
+    tester,
+  ) async {
+    SharedPreferences.setMockInitialValues({});
+    final prefs = await SharedPreferences.getInstance();
+    final notifier = AppThemeNotifier.withPreferences(prefs);
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          appThemeProvider.overrideWith((ref) => notifier),
+          sharedPreferencesProvider.overrideWithValue(prefs),
+          aiStorageDashboardProvider.overrideWith((ref) async {
+            return const AIStorageDashboardSummary(
+              categories: [
+                AIStorageDashboardCategory(
+                  kind: AIStorageCategoryKind.installedModels,
+                  label: 'Installed models',
+                  bytes: 512 * 1024 * 1024,
+                ),
+                AIStorageDashboardCategory(
+                  kind: AIStorageCategoryKind.meetingStorage,
+                  label: 'Meeting storage',
+                  bytes: 24 * 1024 * 1024,
+                ),
+                AIStorageDashboardCategory(
+                  kind: AIStorageCategoryKind.embeddingStorage,
+                  label: 'Embedding storage',
+                  bytes: 4 * 1024 * 1024,
+                ),
+                AIStorageDashboardCategory(
+                  kind: AIStorageCategoryKind.databaseSize,
+                  label: 'Database size',
+                  bytes: 8 * 1024 * 1024,
+                ),
+                AIStorageDashboardCategory(
+                  kind: AIStorageCategoryKind.audioCache,
+                  label: 'Audio cache',
+                  bytes: 16 * 1024 * 1024,
+                ),
+                AIStorageDashboardCategory(
+                  kind: AIStorageCategoryKind.availableSpace,
+                  label: 'Available space',
+                  bytes: 2 * 1024 * 1024 * 1024,
+                ),
+              ],
+            );
+          }),
+        ],
+        child: const MaterialApp(home: ProfileScreen()),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.ensureVisible(find.text('Storage'));
+    await tester.tap(find.text('Storage'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Installed models'), findsOneWidget);
+    expect(find.text('Meeting storage'), findsOneWidget);
+    expect(find.text('Embedding storage'), findsOneWidget);
+    expect(find.text('Database size'), findsOneWidget);
+    expect(find.text('Audio cache'), findsOneWidget);
+    expect(find.text('Available space'), findsOneWidget);
+    expect(find.text('512.0 MB'), findsOneWidget);
+    expect(find.text('2.0 GB'), findsOneWidget);
   });
 }

--- a/app/test/features/settings/application/ai_storage_dashboard_test.dart
+++ b/app/test/features/settings/application/ai_storage_dashboard_test.dart
@@ -1,0 +1,102 @@
+import 'dart:io';
+
+import 'package:airo_app/features/settings/application/ai_storage_dashboard.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path/path.dart' as path;
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late Directory tempDir;
+  const diskChannel = MethodChannel('com.airo.model_download');
+  const pathProviderChannel = MethodChannel('plugins.flutter.io/path_provider');
+
+  setUp(() async {
+    tempDir = await Directory.systemTemp.createTemp(
+      'airo_storage_dashboard_test',
+    );
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(pathProviderChannel, (methodCall) async {
+          if (methodCall.method == 'getApplicationDocumentsDirectory') {
+            return tempDir.path;
+          }
+          if (methodCall.method == 'getTemporaryDirectory') {
+            return path.join(tempDir.path, 'tmp');
+          }
+          return null;
+        });
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(diskChannel, (methodCall) async {
+          if (methodCall.method == 'getFreeDiskSpace') {
+            return 2 * 1024 * 1024 * 1024;
+          }
+          return null;
+        });
+  });
+
+  tearDown(() async {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(pathProviderChannel, null);
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(diskChannel, null);
+    if (await tempDir.exists()) {
+      await tempDir.delete(recursive: true);
+    }
+  });
+
+  test(
+    'builds aggregate local storage dashboard without exposing paths',
+    () async {
+      await File(path.join(tempDir.path, 'models', 'gemma.gguf'))
+          .create(recursive: true)
+          .then((file) => file.writeAsBytes(List.filled(4, 1)));
+      await File(path.join(tempDir.path, 'meeting_audio', 'standup.m4a'))
+          .create(recursive: true)
+          .then((file) => file.writeAsBytes(List.filled(8, 1)));
+      await File(
+        path.join(tempDir.path, 'airo_money.db'),
+      ).writeAsBytes(List.filled(16, 1));
+      await File(path.join(tempDir.path, 'tmp', 'audio_cache', 'tts.wav'))
+          .create(recursive: true)
+          .then((file) => file.writeAsBytes(List.filled(32, 1)));
+
+      final summary = await AIStorageDashboardService().loadSummary();
+
+      expect(summary.categories, hasLength(6));
+      expect(summary.category(AIStorageCategoryKind.installedModels).bytes, 4);
+      expect(summary.category(AIStorageCategoryKind.meetingStorage).bytes, 8);
+      expect(summary.category(AIStorageCategoryKind.databaseSize).bytes, 16);
+      expect(summary.category(AIStorageCategoryKind.audioCache).bytes, 32);
+      expect(
+        summary.category(AIStorageCategoryKind.availableSpace).bytes,
+        2 * 1024 * 1024 * 1024,
+      );
+      expect(summary.totalUsedBytes, 60);
+      expect(summary.categories.map((category) => category.label), [
+        'Installed models',
+        'Meeting storage',
+        'Embedding storage',
+        'Database size',
+        'Audio cache',
+        'Available space',
+      ]);
+      expect(summary.toString(), isNot(contains(tempDir.path)));
+    },
+  );
+
+  test('marks unavailable metrics without failing the dashboard', () async {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(diskChannel, (methodCall) async {
+          throw PlatformException(code: 'unavailable');
+        });
+
+    final summary = await AIStorageDashboardService().loadSummary();
+
+    expect(
+      summary.category(AIStorageCategoryKind.availableSpace).available,
+      isFalse,
+    );
+    expect(summary.category(AIStorageCategoryKind.availableSpace).bytes, 0);
+  });
+}

--- a/docs/wiki/5.-AI-and-Model-Management.md
+++ b/docs/wiki/5.-AI-and-Model-Management.md
@@ -72,6 +72,24 @@ the registry aligned with the actual file stored on the device.
 If a model is too large for the current device budget, Airo shows a compatibility
 warning directly in the model card before you try to activate it.
 
+## Storage Dashboard
+
+The **Storage** section in the AI profile now exposes an aggregate local storage
+dashboard for on-device AI assets.
+
+It reports these device-local categories without exposing raw filesystem paths:
+
+- Installed models
+- Meeting storage
+- Embedding storage
+- Database size
+- Audio cache
+- Available space
+
+The section is read-only in this release. It is intended to help users inspect
+where local AI-related storage is being used before they clear model cache or
+download additional models.
+
 ## Future Agent Skills
 
 The Agent Skills plan extends the current card and routing system with:


### PR DESCRIPTION
# PR Title
Add AI storage dashboard summary

---

# Summary

This PR introduces changes to AI model settings storage visibility.
Goal: close #507 by surfacing a read-only local storage dashboard inside the AI profile.

Core outcome:

* adds an aggregate storage summary for installed models, meeting storage, embedding storage, database size, audio cache, and available space
* keeps the UI path-safe by showing category totals only, not raw filesystem locations

Closes #507.

---

# Changes

### Code

* Added:

  * `AIStorageDashboardService` and `aiStorageDashboardProvider` for deterministic local storage aggregation
  * storage dashboard service tests and a profile widget coverage slice for the expanded Storage section
* Updated:

  * AI profile storage section to render the new category breakdown and total used storage
  * AI preferences cache clearing to invalidate the new storage dashboard provider
  * Makefile with a focused storage dashboard test target

### Logic

* aggregates local AI-related storage into six user-facing categories
* handles unavailable disk-space metrics without failing the dashboard
* preserves the existing clear-cache flow while refreshing the new summary

---

# API Changes (if any)

* None.

---

# Database Changes (if any)

* None.

---

# Observability / Logging

* None.

---

# Performance Impact

* Latency: small file-system scan when the Storage section resolves
* Throughput: none
* Memory/CPU: minimal transient overhead during aggregation

---

# Risks

* local widget test coverage is currently blocked by unrelated broken IPTV/package exports in the workspace
* storage category directories are inferred from current local paths and may need adjustment if storage layout changes
* Rollback plan:

  * revert this PR to restore the previous single-number storage row

---

# Testing

* Unit tests:

  * `flutter test --no-pub test/features/settings/application/ai_storage_dashboard_test.dart`
* Integration tests:

  * none
* Manual testing:

  * not run

---

# Deployment Notes

* Config changes:

  * none
* Order of deployment:

  * normal app release flow

---

# Related Commits

* `feat(settings): add AI storage dashboard`

---

# Notes

* Reviewers should focus on the storage category mapping and whether the current directory set matches the intended local-first storage model.
