### PR TITLE
feat(agent-chat): add local LifeTrack status skill

### DIFF
--- a/app/lib/features/agent_chat/data/connectors/life_track_status_connector.dart
+++ b/app/lib/features/agent_chat/data/connectors/life_track_status_connector.dart
@@ -1,0 +1,343 @@
+import 'package:core_domain/core_domain.dart';
+
+import '../../domain/models/agent_skill.dart';
+import '../../domain/services/agent_connector.dart';
+
+class LifeTrackStatusResult {
+  const LifeTrackStatusResult({
+    required this.markdown,
+    required this.matchedTracks,
+    required this.data,
+  });
+
+  final String markdown;
+  final List<String> matchedTracks;
+  final Map<String, dynamic> data;
+}
+
+class LifeTrackStatusFormatter {
+  const LifeTrackStatusFormatter();
+
+  LifeTrackStatusResult format({
+    required String query,
+    required List<LifeTrack> tracks,
+  }) {
+    final activeTracks = tracks
+        .where((track) => track.status != TrackStatus.postponed)
+        .toList(growable: false);
+    final matchedTracks = _matchTracks(query, activeTracks);
+    if (matchedTracks.isEmpty) {
+      final label = _querySubject(query) ?? 'that request';
+      return LifeTrackStatusResult(
+        markdown:
+            'I could not find a LifeTrack matching "$label". I will not guess from incomplete local data.',
+        matchedTracks: const [],
+        data: const {'matched_tracks': <String>[]},
+      );
+    }
+
+    final wantsDocuments = _wantsDocuments(query);
+    if (wantsDocuments) {
+      return _formatDocuments(matchedTracks);
+    }
+    return _formatPendingStatus(matchedTracks);
+  }
+
+  String proactiveSummary(List<LifeTrack> tracks) {
+    final activeTracks = tracks
+        .where((track) => track.status != TrackStatus.postponed)
+        .toList(growable: false);
+    if (activeTracks.isEmpty) {
+      return 'No active LifeTrack goals need proactive prompts right now.';
+    }
+
+    final lines = activeTracks.map((track) {
+      final pending = _pendingItems(track).length;
+      final percent = (track.progress * 100).round();
+      return '- ${track.title}: $percent% complete, $pending pending item${pending == 1 ? '' : 's'}';
+    });
+    return 'Active LifeTrack goals:\n${lines.join('\n')}';
+  }
+
+  LifeTrackStatusResult _formatPendingStatus(List<LifeTrack> tracks) {
+    final buffer = StringBuffer();
+    final rows = <Map<String, dynamic>>[];
+    var pendingCount = 0;
+
+    for (final track in tracks) {
+      final pending = _pendingItems(track);
+      pendingCount += pending.length;
+      buffer.writeln('LifeTrack status for ${track.title}');
+      buffer.writeln();
+      buffer.writeln(
+        '| Milestone | Pending item | Status | Due | Missing required documents |',
+      );
+      buffer.writeln('| --- | --- | --- | --- | --- |');
+      if (pending.isEmpty) {
+        buffer.writeln('| — | No pending items | — | — | — |');
+      } else {
+        for (final entry in pending) {
+          final missingDocs = entry.item.requirements
+              .where(_isMissingRequiredDocument)
+              .map((requirement) => requirement.label)
+              .join(', ');
+          final due = _formatDate(entry.item.dueDate);
+          buffer.writeln(
+            '| ${_escapeCell(entry.milestone.name)} | ${_escapeCell(entry.item.summary)} | ${entry.item.status.name} | $due | ${_escapeCell(missingDocs.isEmpty ? '—' : missingDocs)} |',
+          );
+          rows.add({
+            'track_id': track.id,
+            'track_title': track.title,
+            'milestone': entry.milestone.name,
+            'summary': entry.item.summary,
+            'status': entry.item.status.name,
+            'due_date': entry.item.dueDate?.toIso8601String(),
+            'missing_required_documents': entry.item.requirements
+                .where(_isMissingRequiredDocument)
+                .map((requirement) => requirement.label)
+                .toList(growable: false),
+          });
+        }
+      }
+      buffer.writeln();
+    }
+
+    return LifeTrackStatusResult(
+      markdown: buffer.toString().trimRight(),
+      matchedTracks: tracks.map((track) => track.id).toList(growable: false),
+      data: {
+        'matched_tracks': tracks.map(_trackData).toList(growable: false),
+        'pending_count': pendingCount,
+        'rows': rows,
+      },
+    );
+  }
+
+  LifeTrackStatusResult _formatDocuments(List<LifeTrack> tracks) {
+    final buffer = StringBuffer();
+    final rows = <Map<String, dynamic>>[];
+
+    for (final track in tracks) {
+      buffer.writeln('Required documents for ${track.title}');
+      buffer.writeln();
+      buffer.writeln('| Document | Status | Related item |');
+      buffer.writeln('| --- | --- | --- |');
+      var foundDocument = false;
+      for (final milestone in track.milestones) {
+        for (final item in milestone.actionItems) {
+          for (final requirement in item.requirements.where(_isDocument)) {
+            foundDocument = true;
+            final status = _hasValue(requirement.value)
+                ? 'provided'
+                : 'missing';
+            buffer.writeln(
+              '| ${_escapeCell(requirement.label)} | $status | ${_escapeCell(item.summary)} |',
+            );
+            rows.add({
+              'track_id': track.id,
+              'track_title': track.title,
+              'document': requirement.label,
+              'status': status,
+              'related_item': item.summary,
+            });
+          }
+        }
+      }
+      if (!foundDocument) {
+        buffer.writeln('| — | No document requirements found | — |');
+      }
+      buffer.writeln();
+    }
+
+    return LifeTrackStatusResult(
+      markdown: buffer.toString().trimRight(),
+      matchedTracks: tracks.map((track) => track.id).toList(growable: false),
+      data: {
+        'matched_tracks': tracks.map(_trackData).toList(growable: false),
+        'documents': rows,
+      },
+    );
+  }
+
+  List<LifeTrack> _matchTracks(String query, List<LifeTrack> tracks) {
+    final normalizedQuery = _normalize(query);
+    if (normalizedQuery.isEmpty) return tracks;
+
+    final matches = tracks
+        .where((track) {
+          final haystack = _normalize(
+            [
+              track.title,
+              track.category.name,
+              track.templateId ?? '',
+            ].join(' '),
+          );
+          if (haystack.split(' ').any(normalizedQuery.split(' ').contains)) {
+            return true;
+          }
+          return _categoryAliases(track.category).any(normalizedQuery.contains);
+        })
+        .toList(growable: false);
+
+    return matches;
+  }
+
+  String? _querySubject(String query) {
+    final normalized = _normalize(query);
+    final myMatch = RegExp(
+      r'my ([a-z0-9 ]+?) (track|goal)',
+    ).firstMatch(normalized);
+    if (myMatch != null) return myMatch.group(1);
+    final onMatch = RegExp(
+      r'on ([a-z0-9 ]+?) (track|goal)',
+    ).firstMatch(normalized);
+    if (onMatch != null) return onMatch.group(1);
+    return null;
+  }
+
+  bool _wantsDocuments(String query) {
+    final normalized = _normalize(query);
+    return normalized.contains('document') ||
+        normalized.contains('documents') ||
+        normalized.contains('paperwork') ||
+        normalized.contains('driving');
+  }
+
+  List<_PendingItem> _pendingItems(LifeTrack track) {
+    final items = <_PendingItem>[];
+    for (final milestone in track.milestones) {
+      for (final item in milestone.actionItems) {
+        if (item.status == ItemStatus.done ||
+            item.status == ItemStatus.skipped) {
+          continue;
+        }
+        items.add(_PendingItem(milestone: milestone, item: item));
+      }
+    }
+    return items;
+  }
+
+  Map<String, dynamic> _trackData(LifeTrack track) => {
+    'id': track.id,
+    'title': track.title,
+    'category': track.category.name,
+    'status': track.status.name,
+    'progress': track.progress,
+  };
+
+  bool _isMissingRequiredDocument(InputRequirement requirement) {
+    return _isDocument(requirement) &&
+        requirement.isRequired &&
+        !_hasValue(requirement.value);
+  }
+
+  bool _isDocument(InputRequirement requirement) {
+    return requirement.fieldType == FieldType.document;
+  }
+
+  bool _hasValue(String? value) => value != null && value.trim().isNotEmpty;
+
+  String _formatDate(DateTime? dateTime) {
+    if (dateTime == null) return '—';
+    final utc = dateTime.toUtc();
+    return '${utc.year.toString().padLeft(4, '0')}-${utc.month.toString().padLeft(2, '0')}-${utc.day.toString().padLeft(2, '0')}';
+  }
+
+  String _escapeCell(String value) => value.replaceAll('|', '\\|').trim();
+
+  String _normalize(String value) {
+    return value
+        .toLowerCase()
+        .replaceAll(RegExp(r'[^a-z0-9]+'), ' ')
+        .trim()
+        .replaceAll(RegExp(r'\s+'), ' ');
+  }
+
+  List<String> _categoryAliases(LifeTrackCategory category) {
+    return switch (category) {
+      LifeTrackCategory.realEstate => const [
+        'flat',
+        'home',
+        'house',
+        'property',
+        'real estate',
+      ],
+      LifeTrackCategory.carPurchase => const [
+        'car',
+        'vehicle',
+        'driving',
+        'rto',
+      ],
+      LifeTrackCategory.medical => const ['medical', 'health', 'doctor'],
+      LifeTrackCategory.education => const ['education', 'study', 'college'],
+      LifeTrackCategory.insurance => const ['insurance'],
+      LifeTrackCategory.finance => const ['finance', 'money', 'loan'],
+      LifeTrackCategory.travel => const ['travel', 'trip', 'passport', 'visa'],
+      LifeTrackCategory.legal => const ['legal', 'law'],
+      LifeTrackCategory.custom => const ['custom'],
+    };
+  }
+}
+
+class LifeTrackStatusConnector implements AgentConnector {
+  LifeTrackStatusConnector({
+    required LifeTrackRepository repository,
+    LifeTrackStatusFormatter formatter = const LifeTrackStatusFormatter(),
+    Future<void> Function()? ensureInitialized,
+  }) : _repository = repository,
+       _formatter = formatter,
+       _ensureInitialized = ensureInitialized;
+
+  final LifeTrackRepository _repository;
+  final LifeTrackStatusFormatter _formatter;
+  final Future<void> Function()? _ensureInitialized;
+
+  @override
+  String get name => 'query_lifetrack_status';
+
+  @override
+  Set<SkillCapability> get requiredCapabilities => const {
+    SkillCapability.lifeTrackRead,
+  };
+
+  @override
+  Future<ConnectorResult> execute(Map<String, dynamic> arguments) async {
+    final query = arguments['query'] as String?;
+    if (query == null || query.trim().isEmpty) {
+      return const ConnectorResult.error(
+        code: 'missing_query',
+        message: 'LifeTrack status queries require a non-empty query.',
+      );
+    }
+
+    await _ensureInitialized?.call();
+
+    final tracksResult = await _repository.listTracks();
+    if (tracksResult case Err<List<LifeTrack>>(error: final error)) {
+      return ConnectorResult.error(
+        code: 'lifetrack_query_failed',
+        message: error.toString(),
+      );
+    }
+
+    final formatted = _formatter.format(
+      query: query,
+      tracks: tracksResult.value,
+    );
+    return ConnectorResult(
+      data: {
+        'source': 'local_lifetrack_repository',
+        'markdown': formatted.markdown,
+        ...formatted.data,
+      },
+      message: formatted.markdown,
+    );
+  }
+}
+
+class _PendingItem {
+  const _PendingItem({required this.milestone, required this.item});
+
+  final Milestone milestone;
+  final ActionItem item;
+}

--- a/app/lib/features/agent_chat/data/repositories/built_in_agent_skill_repository.dart
+++ b/app/lib/features/agent_chat/data/repositories/built_in_agent_skill_repository.dart
@@ -96,6 +96,19 @@ final builtInAgentSkills = <AgentSkill>[
     capabilities: const [SkillCapability.notificationsSchedule],
   ),
   AgentSkill(
+    id: 'query-lifetrack-status',
+    name: 'LifeTrack Status',
+    description:
+        'Answer questions about active LifeTrack goals from local data.',
+    instructions:
+        'Use this when the user asks what is pending, what documents are '
+        'needed, or what the status is for a LifeTrack goal. Call '
+        'query_lifetrack_status with the original query and return the '
+        'connector markdown directly without inventing missing data.',
+    tools: const ['query_lifetrack_status'],
+    capabilities: const [SkillCapability.lifeTrackRead],
+  ),
+  AgentSkill(
     id: 'open-airo-feature',
     name: 'Open Airo Feature',
     description: 'Open Money, Quest, Beats, Games, Stream, or Reader.',

--- a/app/lib/features/agent_chat/domain/models/agent_skill.dart
+++ b/app/lib/features/agent_chat/domain/models/agent_skill.dart
@@ -4,6 +4,7 @@ enum SkillCapability {
   calendarRead('calendar.read', 'Calendar read'),
   calendarWrite('calendar.write', 'Calendar write'),
   notificationsSchedule('notifications.schedule', 'Notifications'),
+  lifeTrackRead('lifetrack.read', 'LifeTrack read'),
   locationRead('location.read', 'Location read'),
   webFetch('web.fetch', 'Web fetch'),
   routeOpen('route.open', 'Open route');

--- a/app/lib/features/agent_chat/domain/services/agent_skill_orchestrator.dart
+++ b/app/lib/features/agent_chat/domain/services/agent_skill_orchestrator.dart
@@ -64,6 +64,11 @@ class RuleBasedAgentSkillModelClient implements AgentSkillModelClient {
     }
 
     final lower = prompt.toLowerCase();
+    if (_wantsLifeTrackStatus(lower) &&
+        enabledSkills.any((skill) => skill.id == 'query-lifetrack-status')) {
+      return 'query-lifetrack-status';
+    }
+
     final wantsCalendar =
         lower.contains('calendar') ||
         lower.contains('meeting') ||
@@ -90,6 +95,13 @@ class RuleBasedAgentSkillModelClient implements AgentSkillModelClient {
   }) async {
     if (skill.id == 'schedule-notification') {
       return _nextScheduleNotificationAction(
+        prompt: prompt,
+        toolResults: toolResults,
+      );
+    }
+
+    if (skill.id == 'query-lifetrack-status') {
+      return _nextLifeTrackStatusAction(
         prompt: prompt,
         toolResults: toolResults,
       );
@@ -241,6 +253,44 @@ class RuleBasedAgentSkillModelClient implements AgentSkillModelClient {
       message: _withCalendarPrompt(message),
       pendingCalendarEvent: pendingCalendarEvent,
     );
+  }
+
+  SkillModelAction _nextLifeTrackStatusAction({
+    required String prompt,
+    required List<Map<String, dynamic>> toolResults,
+  }) {
+    final statusResult = toolResults.cast<Map<String, dynamic>?>().firstWhere(
+      (result) => result?['tool'] == 'query_lifetrack_status',
+      orElse: () => null,
+    );
+    if (statusResult == null) {
+      return SkillModelAction.toolCall(
+        tool: 'query_lifetrack_status',
+        arguments: {'query': prompt},
+      );
+    }
+
+    final result = statusResult['result'] as Map<String, dynamic>? ?? const {};
+    return SkillModelAction.finalAnswer(
+      result['markdown'] as String? ??
+          'I could not read LifeTrack status from local data.',
+    );
+  }
+
+  bool _wantsLifeTrackStatus(String lowerPrompt) {
+    final mentionsLifeTrack =
+        lowerPrompt.contains('lifetrack') ||
+        lowerPrompt.contains('life track') ||
+        lowerPrompt.contains('track') ||
+        lowerPrompt.contains('goal');
+    final asksStatus =
+        lowerPrompt.contains('pending') ||
+        lowerPrompt.contains('status') ||
+        lowerPrompt.contains('progress') ||
+        lowerPrompt.contains('document') ||
+        lowerPrompt.contains('documents') ||
+        lowerPrompt.contains('need');
+    return mentionsLifeTrack && asksStatus;
   }
 }
 

--- a/app/lib/features/agent_chat/presentation/screens/chat_screen.dart
+++ b/app/lib/features/agent_chat/presentation/screens/chat_screen.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:core_data/core_data.dart';
 import 'package:flutter/material.dart' hide Intent;
+import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import '../../../../core/dictionary/dictionary.dart';

--- a/app/lib/features/agent_chat/presentation/screens/chat_screen.dart
+++ b/app/lib/features/agent_chat/presentation/screens/chat_screen.dart
@@ -84,20 +84,7 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
       LifeTrackLocalDataSource();
   late final LifeTrackRepositoryImpl _lifeTrackRepository =
       LifeTrackRepositoryImpl(localDataSource: _lifeTrackDataSource);
-  final AgentConnectorRegistry _connectorRegistry = AgentConnectorRegistry(
-    connectors: [
-      DateTimeConnector(),
-      NativeCalendarPermissionConnector(),
-      NativeCalendarConnector(),
-      NativeCreateCalendarEventConnector(),
-      ScheduleNotificationConnector(),
-      LifeTrackStatusConnector(
-        repository: _lifeTrackRepository,
-        ensureInitialized: _lifeTrackDataSource.initialize,
-      ),
-      RouteConnector(),
-    ],
-  );
+  late final AgentConnectorRegistry _connectorRegistry;
   final GeminiNanoService _geminiNano = GeminiNanoService();
   final LiteRtLmService _liteRtLm = LiteRtLmService();
   late final AssistantRuntimeService _assistantRuntime;
@@ -113,6 +100,7 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
   void initState() {
     super.initState();
     _messageController = TextEditingController(text: widget.initialDraft ?? '');
+    _connectorRegistry = _buildConnectorRegistry();
     _moveComposerCursorToEnd();
     _assistantRuntime =
         widget.assistantRuntimeService ??
@@ -147,6 +135,23 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
       _initializeAI();
     }
     unawaited(_lifeTrackDataSource.initialize());
+  }
+
+  AgentConnectorRegistry _buildConnectorRegistry() {
+    return AgentConnectorRegistry(
+      connectors: [
+        DateTimeConnector(),
+        NativeCalendarPermissionConnector(),
+        NativeCalendarConnector(),
+        NativeCreateCalendarEventConnector(),
+        ScheduleNotificationConnector(),
+        LifeTrackStatusConnector(
+          repository: _lifeTrackRepository,
+          ensureInitialized: _lifeTrackDataSource.initialize,
+        ),
+        RouteConnector(),
+      ],
+    );
   }
 
   AgentSkillOrchestrator _buildSkillOrchestrator(AgentSkillRegistry registry) {

--- a/app/lib/features/agent_chat/presentation/screens/chat_screen.dart
+++ b/app/lib/features/agent_chat/presentation/screens/chat_screen.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:core_data/core_data.dart';
 import 'package:flutter/material.dart' hide Intent;
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
@@ -7,6 +8,7 @@ import '../../../../core/dictionary/dictionary.dart';
 import '../../../../core/utils/locale_settings.dart';
 import '../../../agent_chat/data/connectors/calendar_connector.dart';
 import '../../../agent_chat/data/connectors/date_time_connector.dart';
+import '../../../agent_chat/data/connectors/life_track_status_connector.dart';
 import '../../../agent_chat/data/connectors/notification_connector.dart';
 import '../../../agent_chat/data/connectors/route_connector.dart';
 import '../../../agent_chat/data/services/assistant_chat_context_builder.dart';
@@ -78,6 +80,10 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
   final List<ChatMessage> _messages = [];
   final ToolRegistry _toolRegistry = ToolRegistry();
   AgentSkillRegistry _skillRegistry = AgentSkillRegistry();
+  final LifeTrackLocalDataSource _lifeTrackDataSource =
+      LifeTrackLocalDataSource();
+  late final LifeTrackRepositoryImpl _lifeTrackRepository =
+      LifeTrackRepositoryImpl(localDataSource: _lifeTrackDataSource);
   final AgentConnectorRegistry _connectorRegistry = AgentConnectorRegistry(
     connectors: [
       DateTimeConnector(),
@@ -85,6 +91,10 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
       NativeCalendarConnector(),
       NativeCreateCalendarEventConnector(),
       ScheduleNotificationConnector(),
+      LifeTrackStatusConnector(
+        repository: _lifeTrackRepository,
+        ensureInitialized: _lifeTrackDataSource.initialize,
+      ),
       RouteConnector(),
     ],
   );
@@ -136,6 +146,7 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
     if (widget.enableAiInitialization) {
       _initializeAI();
     }
+    unawaited(_lifeTrackDataSource.initialize());
   }
 
   AgentSkillOrchestrator _buildSkillOrchestrator(AgentSkillRegistry registry) {
@@ -242,6 +253,7 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
   @override
   void dispose() {
     _localRuntimePreloader.abortPreload();
+    unawaited(_lifeTrackDataSource.close());
     _messageController.dispose();
     super.dispose();
   }

--- a/app/test/features/agent_chat/data/connectors/life_track_status_connector_test.dart
+++ b/app/test/features/agent_chat/data/connectors/life_track_status_connector_test.dart
@@ -1,0 +1,249 @@
+import 'package:airo_app/features/agent_chat/data/connectors/life_track_status_connector.dart';
+import 'package:core_domain/core_domain.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('LifeTrackStatusFormatter', () {
+    test('formats active track status as deterministic markdown table', () {
+      final track = _track(
+        title: 'Flat purchase',
+        category: LifeTrackCategory.realEstate,
+        status: TrackStatus.active,
+        milestones: [
+          _milestone(
+            name: 'Documents',
+            items: [
+              _item(
+                summary: 'Upload sale agreement',
+                status: ItemStatus.todo,
+                dueDate: DateTime.utc(2026, 7, 20),
+                requirements: [_document('Sale agreement', value: null)],
+              ),
+              _item(summary: 'Pay booking amount', status: ItemStatus.done),
+            ],
+          ),
+        ],
+      );
+
+      final result = LifeTrackStatusFormatter().format(
+        query: 'what is pending on my flat track?',
+        tracks: [track],
+      );
+
+      expect(result.matchedTracks, ['track-flat-purchase']);
+      expect(result.markdown, contains('LifeTrack status for Flat purchase'));
+      expect(
+        result.markdown,
+        contains(
+          '| Documents | Upload sale agreement | todo | 2026-07-20 | Sale agreement |',
+        ),
+      );
+      expect(result.markdown, isNot(contains('Pay booking amount')));
+      expect(result.data['pending_count'], 1);
+    });
+
+    test('lists required documents for car goal queries', () {
+      final track = _track(
+        title: 'Car purchase',
+        category: LifeTrackCategory.carPurchase,
+        milestones: [
+          _milestone(
+            name: 'RTO',
+            items: [
+              _item(
+                summary: 'Prepare registration file',
+                requirements: [
+                  _document('Driving licence', value: ''),
+                  _document('Insurance policy', value: 'policy.pdf'),
+                ],
+              ),
+            ],
+          ),
+        ],
+      );
+
+      final result = LifeTrackStatusFormatter().format(
+        query: 'what driving documents do I need for my car goal?',
+        tracks: [track],
+      );
+
+      expect(
+        result.markdown,
+        contains('| Driving licence | missing | Prepare registration file |'),
+      );
+      expect(
+        result.markdown,
+        contains('| Insurance policy | provided | Prepare registration file |'),
+      );
+      expect(result.markdown, isNot(contains('policy.pdf')));
+    });
+
+    test('suppresses postponed tracks from proactive summaries', () {
+      final active = _track(title: 'Flat purchase');
+      final postponed = _track(
+        title: 'Medical checkup',
+        status: TrackStatus.postponed,
+      );
+
+      final result = LifeTrackStatusFormatter().proactiveSummary([
+        active,
+        postponed,
+      ]);
+
+      expect(result, contains('Flat purchase'));
+      expect(result, isNot(contains('Medical checkup')));
+    });
+
+    test('returns explicit no-match message instead of hallucinating', () {
+      final result = LifeTrackStatusFormatter().format(
+        query: 'what is pending on my passport track?',
+        tracks: [_track(title: 'Flat purchase')],
+      );
+
+      expect(result.matchedTracks, isEmpty);
+      expect(
+        result.markdown,
+        contains('I could not find a LifeTrack matching "passport"'),
+      );
+      expect(result.data['matched_tracks'], isEmpty);
+    });
+  });
+
+  group('LifeTrackStatusConnector', () {
+    test('queries repository and returns formatter data locally', () async {
+      final repository = _FakeLifeTrackRepository([
+        _track(title: 'Flat purchase'),
+      ]);
+      final connector = LifeTrackStatusConnector(repository: repository);
+
+      final result = await connector.execute({
+        'query': 'what is pending on my flat track?',
+      });
+
+      expect(result.isError, false);
+      expect(result.data['source'], 'local_lifetrack_repository');
+      expect(result.data['markdown'], contains('Flat purchase'));
+      expect(repository.listTracksCalls, 1);
+    });
+  });
+}
+
+LifeTrack _track({
+  required String title,
+  LifeTrackCategory category = LifeTrackCategory.realEstate,
+  TrackStatus status = TrackStatus.active,
+  List<Milestone>? milestones,
+}) {
+  final id =
+      'track-${title.toLowerCase().replaceAll(RegExp(r'[^a-z0-9]+'), '-').replaceAll(RegExp(r'^-+|-+$'), '')}';
+  return LifeTrack(
+    id: id,
+    title: title,
+    category: category,
+    status: status,
+    milestones:
+        milestones ??
+        [
+          _milestone(
+            name: 'Next steps',
+            items: [_item(summary: 'Confirm documents')],
+          ),
+        ],
+    createdAt: DateTime.utc(2026, 7, 1),
+    updatedAt: DateTime.utc(2026, 7, 2),
+  );
+}
+
+Milestone _milestone({required String name, required List<ActionItem> items}) {
+  return Milestone(
+    id: 'milestone-${name.toLowerCase().replaceAll(' ', '-')}',
+    trackId: 'track-id',
+    name: name,
+    objective: '',
+    sortOrder: 0,
+    status: ItemStatus.todo,
+    actionItems: items,
+  );
+}
+
+ActionItem _item({
+  required String summary,
+  ItemStatus status = ItemStatus.todo,
+  DateTime? dueDate,
+  List<InputRequirement> requirements = const [],
+}) {
+  return ActionItem(
+    id: 'item-${summary.toLowerCase().replaceAll(' ', '-')}',
+    milestoneId: 'milestone-id',
+    summary: summary,
+    status: status,
+    requirements: requirements,
+    dueDate: dueDate,
+    createdAt: DateTime.utc(2026, 7, 1),
+    updatedAt: DateTime.utc(2026, 7, 2),
+  );
+}
+
+InputRequirement _document(String label, {String? value}) {
+  return InputRequirement(
+    id: 'req-${label.toLowerCase().replaceAll(' ', '-')}',
+    actionItemId: 'item-id',
+    label: label,
+    fieldType: FieldType.document,
+    value: value,
+    isRequired: true,
+  );
+}
+
+class _FakeLifeTrackRepository implements LifeTrackRepository {
+  _FakeLifeTrackRepository(this.tracks);
+
+  final List<LifeTrack> tracks;
+  int listTracksCalls = 0;
+
+  @override
+  Future<Result<List<LifeTrack>>> listTracks({TrackStatus? status}) async {
+    listTracksCalls++;
+    return Ok(
+      tracks
+          .where((track) => status == null || track.status == status)
+          .toList(),
+    );
+  }
+
+  @override
+  Future<Result<LifeTrack>> createTrack(LifeTrack track) async => Ok(track);
+
+  @override
+  Future<Result<void>> deleteTrack(String id) async => const Ok(null);
+
+  @override
+  Future<Result<LifeTrack>> getTrack(String id) async => Ok(tracks.first);
+
+  @override
+  Future<Result<void>> saveInputValue(
+    String requirementId,
+    String value,
+  ) async => const Ok(null);
+
+  @override
+  Future<Result<void>> updateActionItem(ActionItem item) async =>
+      const Ok(null);
+
+  @override
+  Future<Result<void>> updateItemStatus(
+    String itemId,
+    ItemStatus status,
+  ) async => const Ok(null);
+
+  @override
+  Future<Result<void>> updateMilestone(Milestone milestone) async =>
+      const Ok(null);
+
+  @override
+  Future<Result<void>> updateTrack(LifeTrack track) async => const Ok(null);
+
+  @override
+  Stream<List<LifeTrack>> watchTracks({TrackStatus? status}) =>
+      Stream.value(tracks);
+}

--- a/app/test/features/agent_chat/domain/services/agent_skill_orchestrator_test.dart
+++ b/app/test/features/agent_chat/domain/services/agent_skill_orchestrator_test.dart
@@ -1,11 +1,13 @@
 import 'package:airo_app/features/agent_chat/data/connectors/calendar_connector.dart';
 import 'package:airo_app/features/agent_chat/data/connectors/date_time_connector.dart';
+import 'package:airo_app/features/agent_chat/data/connectors/life_track_status_connector.dart';
 import 'package:airo_app/features/agent_chat/data/connectors/notification_connector.dart';
 import 'package:airo_app/features/agent_chat/data/connectors/route_connector.dart';
 import 'package:airo_app/features/agent_chat/domain/models/agent_skill.dart';
 import 'package:airo_app/features/agent_chat/domain/services/agent_connector_registry.dart';
 import 'package:airo_app/features/agent_chat/domain/services/agent_skill_orchestrator.dart';
 import 'package:airo_app/features/agent_chat/domain/services/agent_skill_registry.dart';
+import 'package:core_domain/core_domain.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
@@ -81,6 +83,43 @@ void main() {
       expect(result.message, contains('Team standup'));
       expect(result.message, contains('10:00'));
     });
+
+    test(
+      'answers LifeTrack status questions through deterministic local tool',
+      () async {
+        final repository = _FakeLifeTrackRepository([
+          _track(
+            title: 'Flat purchase',
+            milestones: [
+              _milestone(
+                name: 'Documents',
+                items: [
+                  _item(summary: 'Upload sale agreement'),
+                  _item(summary: 'Pay booking amount', status: ItemStatus.done),
+                ],
+              ),
+            ],
+          ),
+        ]);
+        final orchestrator = _buildOrchestrator(
+          lifeTrackRepository: repository,
+        );
+
+        final result = await orchestrator.run(
+          'What is pending on my flat track?',
+        );
+
+        expect(result.handled, true);
+        expect(result.isError, false);
+        expect(result.message, contains('LifeTrack status for Flat purchase'));
+        expect(result.message, contains('Upload sale agreement'));
+        expect(result.message, isNot(contains('Pay booking amount')));
+        expect(
+          result.traces.map((trace) => trace.detail),
+          containsAll(['query-lifetrack-status', 'query_lifetrack_status']),
+        );
+      },
+    );
 
     test('schedules a daily notification reminder', () async {
       final notificationScheduler = InMemoryNotificationScheduler(
@@ -422,6 +461,7 @@ AgentSkillOrchestrator _buildOrchestrator({
   InMemoryNotificationScheduler? notificationScheduler,
   AgentSkillModelClient? modelClient,
   List<AgentSkill>? skills,
+  LifeTrackRepository? lifeTrackRepository,
   bool useFallbackModelClient = true,
   int maxSteps = 4,
 }) {
@@ -435,6 +475,8 @@ AgentSkillOrchestrator _buildOrchestrator({
         ScheduleNotificationConnector(
           scheduler: notificationScheduler ?? InMemoryNotificationScheduler(),
         ),
+        if (lifeTrackRepository != null)
+          LifeTrackStatusConnector(repository: lifeTrackRepository),
         RouteConnector(),
       ],
     ),
@@ -442,6 +484,106 @@ AgentSkillOrchestrator _buildOrchestrator({
     useFallbackModelClient: useFallbackModelClient,
     maxSteps: maxSteps,
   );
+}
+
+LifeTrack _track({
+  required String title,
+  LifeTrackCategory category = LifeTrackCategory.realEstate,
+  TrackStatus status = TrackStatus.active,
+  List<Milestone>? milestones,
+}) {
+  final id =
+      'track-${title.toLowerCase().replaceAll(RegExp(r'[^a-z0-9]+'), '-').replaceAll(RegExp(r'^-+|-+$'), '')}';
+  return LifeTrack(
+    id: id,
+    title: title,
+    category: category,
+    status: status,
+    milestones:
+        milestones ??
+        [
+          _milestone(
+            name: 'Next steps',
+            items: [_item(summary: 'Confirm documents')],
+          ),
+        ],
+    createdAt: DateTime.utc(2026, 7, 1),
+    updatedAt: DateTime.utc(2026, 7, 2),
+  );
+}
+
+Milestone _milestone({required String name, required List<ActionItem> items}) {
+  return Milestone(
+    id: 'milestone-${name.toLowerCase().replaceAll(' ', '-')}',
+    trackId: 'track-id',
+    name: name,
+    objective: '',
+    sortOrder: 0,
+    status: ItemStatus.todo,
+    actionItems: items,
+  );
+}
+
+ActionItem _item({
+  required String summary,
+  ItemStatus status = ItemStatus.todo,
+}) {
+  return ActionItem(
+    id: 'item-${summary.toLowerCase().replaceAll(' ', '-')}',
+    milestoneId: 'milestone-id',
+    summary: summary,
+    status: status,
+    requirements: const [],
+    createdAt: DateTime.utc(2026, 7, 1),
+    updatedAt: DateTime.utc(2026, 7, 2),
+  );
+}
+
+class _FakeLifeTrackRepository implements LifeTrackRepository {
+  _FakeLifeTrackRepository(this.tracks);
+
+  final List<LifeTrack> tracks;
+
+  @override
+  Future<Result<List<LifeTrack>>> listTracks({TrackStatus? status}) async => Ok(
+    tracks.where((track) => status == null || track.status == status).toList(),
+  );
+
+  @override
+  Future<Result<LifeTrack>> createTrack(LifeTrack track) async => Ok(track);
+
+  @override
+  Future<Result<void>> deleteTrack(String id) async => const Ok(null);
+
+  @override
+  Future<Result<LifeTrack>> getTrack(String id) async => Ok(tracks.first);
+
+  @override
+  Future<Result<void>> saveInputValue(
+    String requirementId,
+    String value,
+  ) async => const Ok(null);
+
+  @override
+  Future<Result<void>> updateActionItem(ActionItem item) async =>
+      const Ok(null);
+
+  @override
+  Future<Result<void>> updateItemStatus(
+    String itemId,
+    ItemStatus status,
+  ) async => const Ok(null);
+
+  @override
+  Future<Result<void>> updateMilestone(Milestone milestone) async =>
+      const Ok(null);
+
+  @override
+  Future<Result<void>> updateTrack(LifeTrack track) async => const Ok(null);
+
+  @override
+  Stream<List<LifeTrack>> watchTracks({TrackStatus? status}) =>
+      Stream.value(tracks);
 }
 
 class _UnsupportedToolModelClient implements AgentSkillModelClient {

--- a/docs/wiki/5.-AI-and-Model-Management.md
+++ b/docs/wiki/5.-AI-and-Model-Management.md
@@ -21,6 +21,18 @@ Assistant messages follow this order:
    Bill.
 3. Use AI generation for general prompts that do not map to a local tool.
 
+## LifeTrack Status Queries
+
+When the matching Agent Skill is enabled, Brain can answer LifeTrack goal
+status questions from local structured data instead of guessing.
+
+This deterministic path currently supports:
+
+- pending-item status queries for active LifeTrack goals
+- required-document lookups for matching tracks
+- suppression of postponed tracks from proactive summaries
+- explicit no-match responses when no local LifeTrack fits the query
+
 ## Chat Message Actions
 
 Brain chat now exposes a compact message-actions menu for non-empty user and


### PR DESCRIPTION
# PR Title
feat(agent-chat): add local LifeTrack status skill

---

# Summary

This PR introduces changes to the Brain / Agent Chat skill layer.
Goal: close #351 by letting Brain answer LifeTrack status and document questions from local structured data instead of hallucinating.

Core outcome:

* adds a deterministic local LifeTrack status connector and built-in skill registration
* wires the chat runtime to expose pending-item, required-document, and postponed-track suppression queries through the local tool path

Closes #351.

---

# Changes

### Code

* Added:

  * `LifeTrackStatusConnector` and focused formatter coverage
  * deterministic connector tests for pending status, document lookups, postponed suppression, and no-match handling
* Updated:

  * built-in skill catalog with the LifeTrack status skill
  * agent skill orchestrator rule-based model path for LifeTrack status queries
  * chat-screen connector registry to initialize and expose the local LifeTrack repository connector
  * wiki documentation for deterministic LifeTrack status queries

### Logic

* matches LifeTrack track/category aliases from the original user query
* formats pending work into markdown tables and document requirement summaries
* suppresses postponed tracks from proactive summaries
* returns explicit no-match responses rather than inventing missing local state

---

# API Changes (if any)

* None.

---

# Database Changes (if any)

* None.

---

# Observability / Logging

* None.

---

# Performance Impact

* Latency: one local LifeTrack repository read per status query
* Throughput: none
* Memory/CPU: negligible for the current local query scope

---

# Risks

* the initial skill-selection heuristic is keyword-based until richer model routing is added
* LifeTrack local-data initialization now happens at chat-screen startup and on first connector use
* Rollback plan:

  * revert this PR to remove the LifeTrack skill and connector wiring

---

# Testing

* Unit tests:

  * `flutter test --no-pub test/features/agent_chat/data/connectors/life_track_status_connector_test.dart`
  * `flutter test --no-pub test/features/agent_chat/domain/services/agent_skill_orchestrator_test.dart`
* Integration tests:

  * orchestrator coverage now includes the full local skill-call path for LifeTrack status questions
* Manual testing:

  * not run

---

# Deployment Notes

* Config changes:

  * none
* Order of deployment:

  * normal app release flow

---

# Related Commits

* `feat(agent-chat): add local LifeTrack status skill`
* `fix(agent-chat): initialize LifeTrack connectors lazily`
* `fix(agent-chat): keep clipboard import on restacked chat screen`

---

# Notes

* Reviewers should focus on the query-matching heuristics and whether the local markdown response shape is the right deterministic contract for Brain chat.
