### PR TITLE
feat(coins): persist Android import opt-in

### DIFF
--- a/app/lib/features/coins/application/providers/android_import_permission_provider.dart
+++ b/app/lib/features/coins/application/providers/android_import_permission_provider.dart
@@ -1,0 +1,66 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../services/android_finance_import_preferences.dart';
+import '../services/android_finance_import_service.dart';
+import '../services/finance_chat_ingestion_service.dart';
+import '../../domain/services/finance_message_parser.dart';
+import 'expense_providers.dart';
+
+final androidFinanceImportPreferencesProvider =
+    Provider<AndroidFinanceImportPreferences>(
+      (ref) => const AndroidFinanceImportPreferences(),
+    );
+
+final androidFinanceImportPermissionControllerProvider =
+    StateNotifierProvider<
+      AndroidFinanceImportPermissionController,
+      AsyncValue<AndroidFinanceImportPermission>
+    >((ref) {
+      final preferences = ref.watch(androidFinanceImportPreferencesProvider);
+      return AndroidFinanceImportPermissionController(preferences);
+    });
+
+final androidFinanceImportServiceProvider =
+    Provider<AndroidFinanceImportService>((ref) {
+      final preferences = ref.watch(androidFinanceImportPreferencesProvider);
+      final repository = ref.watch(transactionRepositoryProvider);
+      return AndroidFinanceImportService(
+        ingestionService: FinanceChatIngestionService(
+          parser: const FinanceMessageParser(),
+          repository: repository,
+        ),
+        permissionReader: preferences.readPermission,
+      );
+    });
+
+class AndroidFinanceImportPermissionController
+    extends StateNotifier<AsyncValue<AndroidFinanceImportPermission>> {
+  AndroidFinanceImportPermissionController(this._preferences)
+    : super(const AsyncValue.loading()) {
+    _load();
+  }
+
+  final AndroidFinanceImportPreferences _preferences;
+
+  Future<void> _load() async {
+    try {
+      state = AsyncValue.data(await _preferences.readPermission());
+    } catch (_) {
+      state = const AsyncValue.data(AndroidFinanceImportPermission.disabled);
+    }
+  }
+
+  Future<void> setEnabled(bool enabled) async {
+    state = const AsyncValue.loading();
+    try {
+      await _preferences.setEnabled(enabled);
+      state = AsyncValue.data(
+        enabled
+            ? AndroidFinanceImportPermission.enabled
+            : AndroidFinanceImportPermission.disabled,
+      );
+    } catch (_) {
+      state = const AsyncValue.data(AndroidFinanceImportPermission.disabled);
+    }
+  }
+}

--- a/app/lib/features/coins/application/services/android_finance_import_preferences.dart
+++ b/app/lib/features/coins/application/services/android_finance_import_preferences.dart
@@ -1,0 +1,22 @@
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'android_finance_import_service.dart';
+
+class AndroidFinanceImportPreferences {
+  const AndroidFinanceImportPreferences();
+
+  static const String preferenceKey = 'coins_android_finance_import_enabled';
+
+  Future<AndroidFinanceImportPermission> readPermission() async {
+    final prefs = await SharedPreferences.getInstance();
+    final enabled = prefs.getBool(preferenceKey) ?? false;
+    return enabled
+        ? AndroidFinanceImportPermission.enabled
+        : AndroidFinanceImportPermission.disabled;
+  }
+
+  Future<void> setEnabled(bool enabled) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool(preferenceKey, enabled);
+  }
+}

--- a/app/lib/features/coins/coins.dart
+++ b/app/lib/features/coins/coins.dart
@@ -61,6 +61,7 @@ export 'domain/errors/coins_errors.dart';
 
 // Application - Providers
 export 'application/providers/budget_providers.dart';
+export 'application/providers/android_import_permission_provider.dart';
 export 'application/providers/dashboard_providers.dart';
 export 'application/providers/expense_providers.dart';
 export 'application/providers/group_providers.dart';
@@ -82,6 +83,7 @@ export 'application/use_cases/update_expense_use_case.dart' hide Result;
 
 // Application - Services
 export 'application/services/android_finance_import_service.dart';
+export 'application/services/android_finance_import_preferences.dart';
 export 'application/services/coins_notification_service.dart';
 export 'application/services/coins_platform_support.dart';
 export 'application/services/coins_sync_service.dart';

--- a/app/lib/features/coins/presentation/screens/coins_dashboard_screen.dart
+++ b/app/lib/features/coins/presentation/screens/coins_dashboard_screen.dart
@@ -1,8 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../../../core/utils/locale_settings.dart';
+import '../../application/providers/android_import_permission_provider.dart';
 import '../../application/providers/dashboard_providers.dart';
 import '../../application/providers/expense_providers.dart';
+import '../../application/services/android_finance_import_service.dart';
 import '../../application/services/transaction_review_service.dart';
 import '../../domain/entities/transaction.dart';
 import '../../domain/models/budget_status.dart';
@@ -140,12 +142,17 @@ class CoinsDashboardScreen extends ConsumerWidget {
   }
 }
 
-class _AndroidImportPermissionCard extends StatelessWidget {
+class _AndroidImportPermissionCard extends ConsumerWidget {
   const _AndroidImportPermissionCard();
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final theme = Theme.of(context);
+    final permissionState = ref.watch(
+      androidFinanceImportPermissionControllerProvider,
+    );
+    final permission = permissionState.valueOrNull;
+    final enabled = permission == AndroidFinanceImportPermission.enabled;
     return Card(
       elevation: 0,
       child: Padding(
@@ -166,7 +173,9 @@ class _AndroidImportPermissionCard extends StatelessWidget {
                   ),
                 ),
                 Chip(
-                  label: const Text('Permission disabled'),
+                  label: Text(
+                    enabled ? 'Permission enabled' : 'Permission disabled',
+                  ),
                   visualDensity: VisualDensity.compact,
                   backgroundColor: theme.colorScheme.surfaceContainerHighest,
                 ),
@@ -174,16 +183,31 @@ class _AndroidImportPermissionCard extends StatelessWidget {
             ),
             const SizedBox(height: 8),
             Text(
-              'Import bank, UPI, and card alerts only after you enable access. Airo parses locally, ignores OTP/auth messages, and queues matches for review.',
+              enabled
+                  ? 'Airo can now parse supported bank, UPI, and card alerts locally and queue matches for review. OTP/auth messages stay ignored.'
+                  : 'Import bank, UPI, and card alerts only after you enable access. Airo parses locally, ignores OTP/auth messages, and queues matches for review.',
               style: theme.textTheme.bodyMedium?.copyWith(
                 color: theme.colorScheme.onSurfaceVariant,
               ),
             ),
             const SizedBox(height: 12),
-            OutlinedButton.icon(
-              onPressed: null,
-              icon: const Icon(Icons.lock_outline),
-              label: const Text('Enable explicitly later'),
+            SwitchListTile.adaptive(
+              value: enabled,
+              contentPadding: EdgeInsets.zero,
+              title: const Text('Allow local Android import'),
+              subtitle: const Text(
+                'This only flips Airo\'s local import gate. Android OS inbox/listener permissions are still a separate future step.',
+              ),
+              onChanged: permissionState.isLoading
+                  ? null
+                  : (value) {
+                      ref
+                          .read(
+                            androidFinanceImportPermissionControllerProvider
+                                .notifier,
+                          )
+                          .setEnabled(value);
+                    },
             ),
           ],
         ),

--- a/app/test/features/coins/application/services/android_finance_import_preferences_test.dart
+++ b/app/test/features/coins/application/services/android_finance_import_preferences_test.dart
@@ -1,0 +1,40 @@
+import 'package:airo_app/features/coins/application/services/android_finance_import_preferences.dart';
+import 'package:airo_app/features/coins/application/services/android_finance_import_service.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  group('AndroidFinanceImportPreferences', () {
+    late AndroidFinanceImportPreferences preferences;
+
+    setUp(() {
+      SharedPreferences.setMockInitialValues({});
+      preferences = const AndroidFinanceImportPreferences();
+    });
+
+    test('defaults to disabled on a fresh install', () async {
+      final permission = await preferences.readPermission();
+
+      expect(permission, AndroidFinanceImportPermission.disabled);
+    });
+
+    test('persists enabled state', () async {
+      await preferences.setEnabled(true);
+
+      expect(
+        await preferences.readPermission(),
+        AndroidFinanceImportPermission.enabled,
+      );
+    });
+
+    test('persists disabled state', () async {
+      await preferences.setEnabled(true);
+      await preferences.setEnabled(false);
+
+      expect(
+        await preferences.readPermission(),
+        AndroidFinanceImportPermission.disabled,
+      );
+    });
+  });
+}

--- a/app/test/features/coins/application/services/android_finance_import_service_test.dart
+++ b/app/test/features/coins/application/services/android_finance_import_service_test.dart
@@ -1,12 +1,18 @@
+import 'package:airo_app/features/coins/application/services/android_finance_import_preferences.dart';
 import 'package:airo_app/features/coins/application/services/android_finance_import_service.dart';
 import 'package:airo_app/features/coins/application/services/finance_chat_ingestion_service.dart';
 import 'package:airo_app/features/coins/domain/entities/transaction.dart';
 import 'package:airo_app/features/coins/domain/repositories/transaction_repository.dart';
 import 'package:airo_app/features/coins/domain/services/finance_message_parser.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 void main() {
   group('AndroidFinanceImportService', () {
+    setUp(() {
+      SharedPreferences.setMockInitialValues({});
+    });
+
     test('does not import SMS text when permission is disabled', () async {
       final repository = _InMemoryTransactionRepository();
       final service = AndroidFinanceImportService(
@@ -72,6 +78,27 @@ void main() {
 
       expect(result.status, AndroidFinanceImportStatus.ignored);
       expect(repository.transactions, isEmpty);
+    });
+
+    test('reads the persisted import preference for service gating', () async {
+      final repository = _InMemoryTransactionRepository();
+      final preferences = const AndroidFinanceImportPreferences();
+      await preferences.setEnabled(true);
+      final service = AndroidFinanceImportService(
+        ingestionService: FinanceChatIngestionService(
+          parser: FinanceMessageParser(now: () => DateTime(2026, 6, 20)),
+          repository: repository,
+        ),
+        permissionReader: preferences.readPermission,
+      );
+
+      final result = await service.importText(
+        'INR 450.00 spent on your HDFC Bank Credit Card at Swiggy on 20-06-26.',
+        accountId: 'cash_default',
+      );
+
+      expect(result.status, AndroidFinanceImportStatus.queuedForReview);
+      expect(repository.transactions, hasLength(1));
     });
   });
 }

--- a/app/test/features/coins/presentation/screens/coins_dashboard_screen_test.dart
+++ b/app/test/features/coins/presentation/screens/coins_dashboard_screen_test.dart
@@ -1,5 +1,7 @@
 import 'package:airo_app/core/utils/currency_formatter.dart';
 import 'package:airo_app/core/utils/locale_settings.dart';
+import 'package:airo_app/features/coins/application/providers/android_import_permission_provider.dart';
+import 'package:airo_app/features/coins/application/services/android_finance_import_service.dart';
 import 'package:airo_app/features/coins/application/providers/dashboard_providers.dart';
 import 'package:airo_app/features/coins/application/providers/expense_providers.dart';
 import 'package:airo_app/features/coins/domain/entities/transaction.dart';
@@ -10,8 +12,13 @@ import 'package:airo_app/features/coins/presentation/screens/coins_dashboard_scr
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 void main() {
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
   testWidgets('shows real safe-to-spend data in the user currency', (
     tester,
   ) async {
@@ -239,6 +246,40 @@ void main() {
       findsOneWidget,
     );
     expect(find.text('Permission disabled'), findsOneWidget);
+  });
+
+  testWidgets('persists the Android import toggle from the dashboard', (
+    tester,
+  ) async {
+    final container = ProviderContainer(
+      overrides: [
+        dashboardDataProvider.overrideWith(
+          (ref) async => const DashboardData(),
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: const MaterialApp(home: CoinsDashboardScreen()),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('Permission disabled'), findsOneWidget);
+
+    final switchFinder = find.byType(Switch);
+    await tester.ensureVisible(switchFinder);
+    await tester.tap(switchFinder);
+    await tester.pumpAndSettle();
+
+    expect(find.text('Permission enabled'), findsOneWidget);
+    expect(
+      container.read(androidFinanceImportPermissionControllerProvider).value,
+      AndroidFinanceImportPermission.enabled,
+    );
   });
 }
 


### PR DESCRIPTION
## Summary
- add a persisted Coins preference for Android SMS/notification import enablement
- expose a real dashboard toggle so users can explicitly enable or disable the local import gate
- cover the stored preference path in focused Coins unit/widget tests

## Verification
- `flutter analyze lib/features/coins test/features/coins/application/services/android_finance_import_preferences_test.dart test/features/coins/application/services/android_finance_import_service_test.dart test/features/coins/presentation/screens/coins_dashboard_screen_test.dart`
- `flutter test --no-pub test/features/coins/application/services/android_finance_import_preferences_test.dart test/features/coins/application/services/android_finance_import_service_test.dart test/features/coins/presentation/screens/coins_dashboard_screen_test.dart`

## Notes
- This closes the remaining app-level acceptance gap for issue #245: the import parser stays default-off until the user explicitly enables it.
- Real Android inbox/listener permission requests and background receivers remain separate follow-up platform work.
