### PR TITLE
feat(legal): Add Privacy Policy & Terms pages for Airo TV store readiness

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -29,6 +29,10 @@ nav:
     url: /architecture/
   - title: Features
     url: /features/
+  - title: Privacy Policy
+    url: /legal/privacy-policy/
+  - title: Terms & Conditions
+    url: /legal/terms-conditions/
   - title: GitHub
     url: https://github.com/DevelopersCoffee/airo
 
@@ -55,6 +59,9 @@ collections:
   guides:
     output: true
     permalink: /guides/:path/
+  legal:
+    output: true
+    permalink: /legal/:path/
 
 # Defaults
 defaults:

--- a/docs/index.md
+++ b/docs/index.md
@@ -150,6 +150,13 @@ See [Contributing Guide](./getting-started/START_HERE.md) for details.
 
 ---
 
+## 📄 Legal
+
+- [Privacy Policy](./legal/privacy-policy/) — How we handle your data
+- [Terms & Conditions](./legal/terms-conditions/) — Rules for using Airo TV
+
+---
+
 ## 📄 License
 
 This project is licensed under the MIT License.
@@ -164,6 +171,6 @@ This project is licensed under the MIT License.
 
 ---
 
-**Last Updated**: November 29, 2025
-**Version**: 1.1.0
+**Last Updated**: July 13, 2026
+**Version**: 2.0.0
 **Status**: ✅ Production Ready

--- a/docs/legal/privacy-policy.md
+++ b/docs/legal/privacy-policy.md
@@ -1,0 +1,181 @@
+---
+layout: default
+title: Privacy Policy — Airo TV
+description: Privacy Policy for the Airo TV application
+permalink: /legal/privacy-policy/
+---
+
+# Privacy Policy
+
+**Last Updated: July 13, 2026**
+
+---
+
+## Introduction
+
+Airo TV is built by **DevelopersCoffee** as a Free application. This app is
+provided at no cost and is intended for use "as is".
+
+This page is used to inform visitors regarding our policies with the
+collection, use, and disclosure of Personal Information if anyone decides
+to use our Service.
+
+If you choose to use our Service, then you agree to the collection and use
+of information in relation to this policy. The Personal Information that we
+collect is used for providing and improving the Service. We will not use or
+share your information with anyone except as described in this Privacy Policy.
+
+The terms used in this Privacy Policy have the same meanings as in our
+[Terms and Conditions](/airo/legal/terms-conditions/) unless otherwise
+defined in this Privacy Policy.
+
+---
+
+## Information Collection and Use
+
+For a better experience, while using our Service, we may require you to
+provide us with certain personally identifiable information. The information
+that we request will be retained on your device and is **not collected by
+us** in any way.
+
+### Data We Collect (On-Device Only)
+
+- **User preferences** — stored locally on your device
+- **IPTV playlist URLs** — user-provided, stored locally on your device
+- **Favorites and watch history** — stored locally on your device
+- **EPG (Electronic Program Guide) data** — cached locally for performance
+
+### Data We Do NOT Collect
+
+- Personal identification information (name, email, address)
+- Location data
+- Contact information
+- Financial or payment information
+- Viewing habits or analytics sent to external servers
+- Advertising identifiers
+
+---
+
+## On-Device Processing
+
+Airo TV processes all data locally on your device. Specifically:
+
+- **IPTV playlist parsing** is performed entirely on-device.
+- **EPG data** is fetched from URLs you provide and cached locally.
+- **No user data is transmitted** to DevelopersCoffee servers or any
+  third-party analytics services.
+
+Your streaming content, playlist URLs, favorites, and viewing history
+**never leave your device**.
+
+---
+
+## IPTV Content Disclaimer
+
+Airo TV is a **media player application only**. It does **NOT** provide,
+host, or distribute any content, channels, playlists, or streams.
+
+- All content displayed in Airo TV is **added by the user**.
+- Users are solely responsible for ensuring that the content they access
+  through Airo TV is legal in their jurisdiction.
+- DevelopersCoffee does **NOT** endorse, promote, or facilitate the
+  streaming of copyright-protected material without proper authorization
+  from the rights holder.
+
+---
+
+## Log Data
+
+In the event of an error in the app, we may collect data and information
+(through third-party products) on your device called Log Data. This Log
+Data may include information such as your device's Internet Protocol ("IP")
+address, device name, operating system version, the configuration of the
+app when utilizing our Service, the time and date of your use of the
+Service, and other statistics.
+
+This data is used solely for diagnosing crashes and improving app stability.
+
+---
+
+## Cookies
+
+This Service does not use "cookies" explicitly. However, the app may use
+third-party code and libraries that use "cookies" to collect information
+and improve their services. You have the option to either accept or refuse
+these cookies and know when a cookie is being sent to your device. If you
+choose to refuse our cookies, you may not be able to use some portions of
+this Service.
+
+---
+
+## Service Providers
+
+We may employ third-party companies and individuals due to the following
+reasons:
+
+- To facilitate our Service;
+- To provide the Service on our behalf;
+- To perform Service-related tasks; or
+- To assist us in analyzing how our Service is used.
+
+We want to inform users of this Service that these third parties may have
+access to certain information. The reason is to perform the tasks assigned
+to them on our behalf. However, they are obligated not to disclose or use
+the information for any other purpose.
+
+---
+
+## Security
+
+We value your trust in providing us your Personal Information, thus we
+are striving to use commercially acceptable means of protecting it. But
+remember that no method of transmission over the internet, or method of
+electronic storage is 100% secure and reliable, and we cannot guarantee
+its absolute security.
+
+---
+
+## Children's Privacy
+
+This Service does not address anyone under the age of 16. We do not
+knowingly collect personally identifiable information from children under
+16 years of age. In the case we discover that a child under 16 has
+provided us with personal information, we immediately delete this from
+our records. If you are a parent or guardian and you are aware that your
+child has provided us with personal information, please contact us so
+that we will be able to take the necessary actions.
+
+We encourage parents and guardians to observe, participate in, and/or
+monitor and guide their children's online activity.
+
+---
+
+## Links to Other Sites
+
+This Service may contain links to other sites. If you click on a
+third-party link, you will be directed to that site. Note that these
+external sites are not operated by us. Therefore, we strongly advise
+you to review the Privacy Policy of these websites. We have no control
+over and assume no responsibility for the content, privacy policies, or
+practices of any third-party sites or services.
+
+---
+
+## Changes to This Privacy Policy
+
+We may update our Privacy Policy from time to time. Thus, you are advised
+to review this page periodically for any changes. We will notify you of
+any changes by posting the new Privacy Policy on this page.
+
+This policy is effective as of **July 13, 2026**.
+
+---
+
+## Contact Us
+
+If you have any questions or suggestions about our Privacy Policy, do
+not hesitate to contact us:
+
+- **Developer**: DevelopersCoffee
+- **Email**: [team@airo.dev](mailto:team@airo.dev)
+- **GitHub**: [github.com/DevelopersCoffee/airo](https://github.com/DevelopersCoffee/airo)

--- a/docs/legal/terms-conditions.md
+++ b/docs/legal/terms-conditions.md
@@ -1,0 +1,197 @@
+---
+layout: default
+title: Terms & Conditions — Airo TV
+description: Terms and Conditions for the Airo TV application
+permalink: /legal/terms-conditions/
+---
+
+# Terms & Conditions
+
+**Last Updated: July 13, 2026**
+
+---
+
+## ⚠️ Important Notice — Content Disclaimer
+
+Airo TV **only displays content added by the user**. The application
+does **NOT** provide, host, supply, or distribute any content, channels,
+playlists, or streams of any kind.
+
+Airo TV is designed to be used with your own created content or playlists
+that contain content you are legally authorized to access. DevelopersCoffee
+does **NOT** endorse, promote, or facilitate the streaming of
+copyright-protected material without proper authorization from the rights
+holder.
+
+**You are solely responsible for ensuring that all content you access
+through Airo TV is legal in your jurisdiction.**
+
+---
+
+## Terms of Use
+
+By downloading or using the app, these terms will automatically apply
+to you — you should make sure therefore that you read them carefully
+before using the app.
+
+---
+
+## Intellectual Property
+
+You are not allowed to copy or modify the app, any part of the app, or
+our trademarks in any way. You are not allowed to attempt to extract the
+source code of the app, and you also should not try to translate the app
+into other languages or make derivative versions. The app itself, and all
+the trademarks, copyright, database rights, and other intellectual
+property rights related to it, still belong to **DevelopersCoffee**.
+
+---
+
+## App Changes and Updates
+
+DevelopersCoffee is committed to ensuring that the app is as useful and
+efficient as possible. For that reason, we reserve the right to make
+changes to the app or to charge for its services, at any time and for
+any reason. We will never charge you for the app or its services without
+making it very clear to you exactly what you are paying for.
+
+We may wish to update the app at some point. The app is currently
+available on Android (including Android TV and Fire TV) — the
+requirements for the system (and for any additional systems we decide
+to extend the availability of the app to) may change, and you will need
+to accept updates if you want to keep using the app.
+
+---
+
+## Supported Formats
+
+Airo TV supports the following media formats and protocols:
+
+### Playlist Formats
+- M3U / M3U8
+
+### Video Formats
+- MP4, MKV, AVI, MOV, FLV, WMV, WEBM
+
+### Streaming Protocols
+- HLS (HTTP Live Streaming)
+- MPEG-TS (Transport Stream)
+- RTMP (Real-Time Messaging Protocol)
+- RTSP (Real-Time Streaming Protocol)
+
+### Audio Formats
+- MP3, AAC, WAV, FLAC, OGG
+
+### Additional Features
+- EPG (Electronic Program Guide) via XMLTV
+- Chromecast casting support
+- Subtitle support (SRT, VTT)
+
+---
+
+## Third-Party Services
+
+The app may use third-party services that declare their own Terms and
+Conditions. These third-party services may collect information used to
+identify you. We encourage you to review the terms and privacy policies
+of any third-party services used by the app.
+
+---
+
+## Security and Your Data
+
+Airo TV stores and processes personal data that you have provided to us,
+in order to provide our Service. It is your responsibility to keep your
+device and access to the app secure. We recommend that you do not
+jailbreak or root your phone, which is the process of removing software
+restrictions and limitations imposed by the official operating system
+of your device. It could make your device vulnerable to
+malware/viruses/malicious programs, compromise your device's security
+features, and it could mean that the Airo TV app will not work properly
+or at all.
+
+---
+
+## Internet Connectivity
+
+Certain functions of the app will require the app to have an active
+internet connection. The connection can be Wi-Fi or provided by your
+mobile network provider, but DevelopersCoffee cannot take responsibility
+for the app not working at full functionality if you do not have access
+to Wi-Fi and you do not have any data allowance left.
+
+If you are using the app outside of an area with Wi-Fi, you should
+remember that the terms of the agreement with your mobile network
+provider will still apply. As a result, you may be charged by your
+mobile provider for the cost of data for the duration of the connection
+while accessing the app, or other third-party charges. In using the app,
+you are accepting responsibility for any such charges, including roaming
+data charges if you use the app outside of your home territory (i.e.,
+region or country) without turning off data roaming. If you are not the
+bill payer for the device on which you are using the app, please be
+aware that we assume that you have received permission from the bill
+payer for using the app.
+
+---
+
+## Limitation of Liability
+
+Along the same lines, DevelopersCoffee cannot always take responsibility
+for the way you use the app. For example:
+
+- You need to make sure that your device stays charged — if it runs out
+  of battery and you cannot turn it on to avail the Service,
+  DevelopersCoffee cannot accept responsibility.
+- DevelopersCoffee accepts no liability for any loss, direct or indirect,
+  you experience as a result of relying wholly on the functionality of
+  the app.
+- DevelopersCoffee is not responsible for the content, quality, legality,
+  or availability of any streams, channels, or media accessed through
+  the app, as all content is user-provided.
+- The app is provided on an **"as is"** and **"as available"** basis
+  without any warranties of any kind, either express or implied.
+
+---
+
+## Termination
+
+We may terminate or suspend your access to the app immediately, without
+prior notice or liability, for any reason whatsoever, including without
+limitation if you breach these Terms and Conditions.
+
+Upon termination, your right to use the app will cease immediately. If
+you wish to terminate your use, you may simply stop using the app and
+delete it from your device.
+
+All provisions of the Terms which by their nature should survive
+termination shall survive termination, including, without limitation,
+ownership provisions, warranty disclaimers, indemnity, and limitations
+of liability.
+
+---
+
+## Changes to These Terms and Conditions
+
+We may update our Terms and Conditions from time to time. Thus, you are
+advised to review this page periodically for any changes. We will notify
+you of any changes by posting the new Terms and Conditions on this page.
+
+These terms and conditions are effective as of **July 13, 2026**.
+
+---
+
+## Governing Law
+
+These Terms shall be governed and construed in accordance with applicable
+laws, without regard to conflict of law provisions.
+
+---
+
+## Contact Us
+
+If you have any questions or suggestions about our Terms and Conditions,
+do not hesitate to contact us:
+
+- **Developer**: DevelopersCoffee
+- **Email**: [team@airo.dev](mailto:team@airo.dev)
+- **GitHub**: [github.com/DevelopersCoffee/airo](https://github.com/DevelopersCoffee/airo)


### PR DESCRIPTION
## Summary

Adds Privacy Policy and Terms & Conditions pages to GitHub Pages, and updates site navigation — making Airo TV store-ready for Play Store and App Store submission.

## Changes

### New Files
- `docs/legal/privacy-policy.md` — Full privacy policy page
- `docs/legal/terms-conditions.md` — Full terms & conditions page

### Modified Files
- `docs/_config.yml` — Added legal nav links + Jekyll `legal` collection
- `docs/index.md` — Added Legal section, updated version to 2.0.0

## Privacy Policy Covers
- Data collection (on-device only, no PII sent to servers)
- IPTV content disclaimer (user-provided content only)
- On-device processing (no external AI servers)
- Children's privacy (16+ consent)
- Third-party services, cookies, security
- Contact information

## Terms & Conditions Covers
- **Content Disclaimer** (first section, prominent) — app does NOT provide content
- Intellectual property
- Supported formats (M3U, HLS, MP4, MKV, etc.)
- Limitation of liability ("as is" basis)
- Termination, governing law
- Contact information

## Reference
Modeled on: [IPTV Smart Player Privacy Policy](https://sites.google.com/view/iptv-smart-player/privacy-policy) and [Terms & Conditions](https://sites.google.com/view/iptv-smart-player/terms-conditions)

## Target URLs (after GitHub Pages is enabled on v2)
- `https://developerscoffee.github.io/airo/legal/privacy-policy/`
- `https://developerscoffee.github.io/airo/legal/terms-conditions/`

## Closes
- Closes #577
- Closes #578
- Closes #579

## Next Steps
After merge, enable GitHub Pages in repo Settings → Pages → Source: v2 branch, /docs folder.