### PR TITLE
feat(release): generate v2 artifact manifests

### DIFF
--- a/.github/workflows/airo-tv-release.yml
+++ b/.github/workflows/airo-tv-release.yml
@@ -287,6 +287,8 @@ jobs:
         run: |
           ruby -e 'require "yaml"; YAML.load_file(".github/workflows/airo-tv-release.yml"); puts "workflow-yaml-ok"'
           bash -n scripts/build-tv.sh scripts/check-android-tv-release.sh scripts/patch-android-plugin-gradle.sh
+          python3 -m py_compile scripts/generate-release-manifest.py
+          scripts/test-generate-release-manifest.sh
           scripts/check-android-tv-release.sh
           cd app
           flutter analyze lib/core/app/tv_router.dart lib/main_tv.dart test/core/app/tv_router_test.dart test/main_tv_debug_playlist_test.dart --no-fatal-infos --no-fatal-warnings
@@ -342,12 +344,21 @@ jobs:
           cp app/build/app/outputs/bundle/release/app-release.aab "release-artifacts/Airo-TV-${BUILD_NAME}-Play-Store.aab"
           cp docs/release/AIRO_TV_RELEASE_TEMPLATE.md "release-artifacts/Airo-TV-${BUILD_NAME}-Release-Template.md"
           cp docs/release/AIRO_TV_MEDIA_ASSETS.md "release-artifacts/Airo-TV-${BUILD_NAME}-Media-Checklist.md"
-          (
-            cd release-artifacts
-            shasum -a 256 "Airo-TV-${BUILD_NAME}.apk" "Airo-TV-${BUILD_NAME}-Play-Store.aab" > SHA256SUMS
-          )
+          scripts/generate-release-manifest.py \
+            --artifacts-dir release-artifacts \
+            --profile-id tv \
+            --version "$BUILD_NAME" \
+            --build-number "$BUILD_NUMBER" \
+            --source-ref "${{ needs.prepare-release-branch.outputs.release_ref || github.ref_name }}" \
+            --source-sha "$GITHUB_SHA" \
+            --workflow-name "$GITHUB_WORKFLOW" \
+            --workflow-run "$GITHUB_RUN_ID" \
+            --workflow-run-attempt "$GITHUB_RUN_ATTEMPT" \
+            --repository "$GITHUB_REPOSITORY"
+          mv release-artifacts/Release-Manifest.json "release-artifacts/Airo-TV-${BUILD_NAME}-Release-Manifest.json"
           ls -lh release-artifacts
           cat release-artifacts/SHA256SUMS
+          cat "release-artifacts/Airo-TV-${BUILD_NAME}-Release-Manifest.json"
 
       - name: Upload Airo TV release artifacts
         uses: actions/upload-artifact@v7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,8 +87,10 @@ jobs:
 
       - name: Validate platform build profiles
         run: |
-          chmod +x scripts/check-build-profiles.py
+          chmod +x scripts/check-build-profiles.py scripts/generate-release-manifest.py scripts/test-generate-release-manifest.sh
+          python3 -m py_compile scripts/check-build-profiles.py scripts/generate-release-manifest.py
           scripts/check-build-profiles.py
+          scripts/test-generate-release-manifest.sh
 
   # ============================================
   # Core Package Tests (runs on all events - fast)
@@ -159,9 +161,11 @@ jobs:
 
       - name: Validate dependency profile constraints
         run: |
-          chmod +x scripts/check-build-profiles.py scripts/check-variant-pubspecs.sh
+          chmod +x scripts/check-build-profiles.py scripts/check-variant-pubspecs.sh scripts/generate-release-manifest.py scripts/test-generate-release-manifest.sh
+          python3 -m py_compile scripts/check-build-profiles.py scripts/generate-release-manifest.py
           scripts/check-build-profiles.py
           scripts/check-variant-pubspecs.sh
+          scripts/test-generate-release-manifest.sh
 
   # ============================================
   # App Tests with Coverage (runs on push to main only)

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -65,8 +65,10 @@ jobs:
 
       - name: Validate platform build profiles
         run: |
-          chmod +x scripts/check-build-profiles.py
+          chmod +x scripts/check-build-profiles.py scripts/generate-release-manifest.py scripts/test-generate-release-manifest.sh
+          python3 -m py_compile scripts/check-build-profiles.py scripts/generate-release-manifest.py
           scripts/check-build-profiles.py
+          scripts/test-generate-release-manifest.sh
 
   # ============================================
   # Code Quality (analyze, format) - ~2 minutes

--- a/VERIFY_DOWNLOAD.md
+++ b/VERIFY_DOWNLOAD.md
@@ -67,6 +67,8 @@ Before installing, confirm:
 
 - the file is attached to a release in `DevelopersCoffee/airo`;
 - the release notes match the version in the APK filename;
+- the release manifest lists the same filename, package ID, profile, and
+  SHA256 checksum when a manifest is published;
 - the release is not marked as withdrawn or known-bad;
 - the artifact profile matches your device.
 

--- a/docs/release/V2_DISTRIBUTION_MATRIX.md
+++ b/docs/release/V2_DISTRIBUTION_MATRIX.md
@@ -38,6 +38,11 @@ Every public v2 Android release must publish:
 Internal-only QA releases may omit public GitHub Release publication, but must
 still produce APKs, checksums, and a workflow summary.
 
+The canonical checksum and manifest generator is
+`scripts/generate-release-manifest.py`. Release workflows should run it after
+final artifact renaming so `SHA256SUMS` and the JSON manifest cover the exact
+APK/AAB filenames attached to GitHub Releases or passed to store upload jobs.
+
 ## Artifact Naming
 
 Use stable, user-facing names:
@@ -57,6 +62,7 @@ Airo-IPTV-v2.0.0.apk
 Airo-Streaming-v2.0.0.apk
 Airo-TV-v2.0.0.apk
 Airo-TV-v2.0.0-Play-Store.aab
+Airo-TV-v2.0.0-Release-Manifest.json
 ```
 
 Do not publish debug-looking names such as `app-release.apk` or

--- a/scripts/generate-release-manifest.py
+++ b/scripts/generate-release-manifest.py
@@ -1,0 +1,215 @@
+#!/usr/bin/env python3
+"""Generate SHA256SUMS and a machine-readable v2 release manifest."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_PROFILE_FILE = ROOT / ".github" / "airo-build-profiles.json"
+RELEASE_EXTENSIONS = {".apk", ".aab"}
+MANIFEST_FILENAME = "Release-Manifest.json"
+SHA256_FILENAME = "SHA256SUMS"
+
+
+def error(message: str) -> None:
+    print(f"::error::{message}", file=sys.stderr)
+
+
+def load_profiles(path: Path) -> dict[str, dict]:
+    with path.open("r", encoding="utf-8") as handle:
+        data = json.load(handle)
+    profiles = {}
+    for profile in data.get("profiles", []):
+        profile_id = profile.get("id")
+        if profile_id:
+            profiles[profile_id] = profile
+    return profiles
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def resolve_under_root(path: Path, description: str) -> Path:
+    resolved = path.resolve()
+    try:
+        resolved.relative_to(ROOT)
+    except ValueError:
+        error(f"{description} must be inside repository root: {resolved}")
+        raise SystemExit(1)
+    return resolved
+
+
+def infer_profile_id(filename: str, profiles: dict[str, dict]) -> str | None:
+    normalized = filename.lower().replace("_", "-")
+    aliases = {
+        "tv": ["airo-tv"],
+        "iptv-standalone": ["airo-iptv", "iptv-standalone"],
+        "mobile-streaming": ["airo-streaming", "mobile-streaming"],
+        "mobile-full": ["airo-mobile-full", "mobile-full"],
+    }
+    for profile_id in profiles:
+        candidates = aliases.get(profile_id, [profile_id])
+        if any(candidate in normalized for candidate in candidates):
+            return profile_id
+    return None
+
+
+def infer_artifact_type(path: Path) -> str:
+    if path.suffix == ".apk":
+        return "apk"
+    if path.suffix == ".aab":
+        return "aab"
+    return path.suffix.lstrip(".")
+
+
+def infer_distribution_channel(path: Path) -> str:
+    if path.suffix == ".aab":
+        return "play-store"
+    return "direct-apk"
+
+
+def infer_abi(path: Path, profile: dict) -> str:
+    filename = path.name.lower()
+    if "arm64" in filename or "arm64-v8a" in filename:
+        return "android-arm64"
+    android = profile.get("android") or {}
+    if android.get("abiStrategy") == "single-arm64-apk":
+        return "android-arm64"
+    if path.suffix == ".aab":
+        return "play-managed"
+    return "unknown"
+
+
+def release_files(artifacts_dir: Path) -> list[Path]:
+    return sorted(
+        path
+        for path in artifacts_dir.iterdir()
+        if path.is_file() and path.suffix.lower() in RELEASE_EXTENSIONS
+    )
+
+
+def write_sha256s(paths: list[Path], checksums: dict[str, str], output: Path) -> None:
+    with output.open("w", encoding="utf-8") as handle:
+        for path in paths:
+            handle.write(f"{checksums[path.name]}  {path.name}\n")
+
+
+def env_default(name: str, fallback: str) -> str:
+    value = os.environ.get(name)
+    return value if value else fallback
+
+
+def build_manifest(args: argparse.Namespace) -> int:
+    artifacts_dir = resolve_under_root(args.artifacts_dir, "Artifacts directory")
+    if not artifacts_dir.is_dir():
+        error(f"Artifacts directory does not exist: {artifacts_dir}")
+        return 1
+
+    profiles = load_profiles(resolve_under_root(args.profiles_file, "Build profiles file"))
+    if args.profile_id and args.profile_id not in profiles:
+        error(f"Unknown profile id: {args.profile_id}")
+        return 1
+
+    paths = release_files(artifacts_dir)
+    if not paths and not args.allow_empty:
+        error(f"No APK or AAB artifacts found in {artifacts_dir}")
+        return 1
+
+    checksums = {path.name: sha256_file(path) for path in paths}
+    artifacts = []
+    failures = 0
+
+    for path in paths:
+        profile_id = args.profile_id or infer_profile_id(path.name, profiles)
+        if not profile_id:
+            error(
+                f"Cannot map artifact to a release profile: {path.name}. "
+                "Pass --profile-id or use a profile-specific release filename."
+            )
+            failures += 1
+            continue
+        profile = profiles[profile_id]
+        artifact = {
+            "filename": path.name,
+            "profileId": profile_id,
+            "packageId": profile.get("appId", "unknown"),
+            "version": args.version,
+            "buildNumber": args.build_number,
+            "artifactType": infer_artifact_type(path),
+            "abi": infer_abi(path, profile),
+            "distributionChannel": infer_distribution_channel(path),
+            "sizeBytes": path.stat().st_size,
+            "sha256": checksums[path.name],
+        }
+        artifacts.append(artifact)
+
+    if failures:
+        return 1
+
+    workflow_run_url = ""
+    if args.repository and args.workflow_run:
+        workflow_run_url = f"https://github.com/{args.repository}/actions/runs/{args.workflow_run}"
+
+    manifest = {
+        "schemaVersion": 1,
+        "generatedAt": datetime.now(timezone.utc).replace(microsecond=0).isoformat(),
+        "release": {
+            "version": args.version,
+            "buildNumber": args.build_number,
+            "sourceRef": args.source_ref,
+            "sourceSha": args.source_sha,
+            "workflowName": args.workflow_name,
+            "workflowRun": args.workflow_run,
+            "workflowRunAttempt": args.workflow_run_attempt,
+            "workflowRunUrl": workflow_run_url,
+        },
+        "artifacts": artifacts,
+    }
+
+    output_manifest = artifacts_dir / MANIFEST_FILENAME
+    output_sha256 = artifacts_dir / SHA256_FILENAME
+    write_sha256s(paths, checksums, output_sha256)
+    with output_manifest.open("w", encoding="utf-8") as handle:
+        json.dump(manifest, handle, indent=2, sort_keys=True)
+        handle.write("\n")
+
+    print(f"Wrote {output_sha256}")
+    print(f"Wrote {output_manifest}")
+    print(f"Release artifacts covered: {len(artifacts)}")
+    return 0
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Generate SHA256SUMS and a v2 release manifest for APK/AAB artifacts."
+    )
+    parser.add_argument("--artifacts-dir", type=Path, required=True)
+    parser.add_argument("--profiles-file", type=Path, default=DEFAULT_PROFILE_FILE)
+    parser.add_argument("--profile-id", help="Profile id for all artifacts in the directory.")
+    parser.add_argument("--version", default=env_default("BUILD_NAME", env_default("RELEASE_VERSION", "unknown")))
+    parser.add_argument("--build-number", default=env_default("BUILD_NUMBER", env_default("GITHUB_RUN_NUMBER", "unknown")))
+    parser.add_argument("--source-ref", default=env_default("GITHUB_REF_NAME", env_default("GITHUB_REF", "unknown")))
+    parser.add_argument("--source-sha", default=env_default("GITHUB_SHA", "unknown"))
+    parser.add_argument("--workflow-name", default=env_default("GITHUB_WORKFLOW", "unknown"))
+    parser.add_argument("--workflow-run", default=env_default("GITHUB_RUN_ID", "unknown"))
+    parser.add_argument("--workflow-run-attempt", default=env_default("GITHUB_RUN_ATTEMPT", "unknown"))
+    parser.add_argument("--repository", default=env_default("GITHUB_REPOSITORY", "DevelopersCoffee/airo"))
+    parser.add_argument("--allow-empty", action="store_true")
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    sys.exit(build_manifest(parse_args()))

--- a/scripts/test-generate-release-manifest.sh
+++ b/scripts/test-generate-release-manifest.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT="$ROOT_DIR/scripts/generate-release-manifest.py"
+TMP_DIR="$(mktemp -d "$ROOT_DIR/.tmp-release-manifest.XXXXXX")"
+
+cleanup() {
+  rm -rf "$TMP_DIR"
+}
+trap cleanup EXIT
+
+mkdir -p "$TMP_DIR/artifacts"
+printf 'apk-content' > "$TMP_DIR/artifacts/Airo-TV-v2.0.0.apk"
+printf 'aab-content' > "$TMP_DIR/artifacts/Airo-TV-v2.0.0-Play-Store.aab"
+
+python3 "$SCRIPT" \
+  --artifacts-dir "$TMP_DIR/artifacts" \
+  --profile-id tv \
+  --version v2.0.0 \
+  --build-number 200 \
+  --source-ref v2 \
+  --source-sha abc123 \
+  --workflow-name "Release Test" \
+  --workflow-run 42 \
+  --workflow-run-attempt 1 \
+  --repository DevelopersCoffee/airo \
+  > "$TMP_DIR/generate.out"
+
+grep -q "Airo-TV-v2.0.0.apk" "$TMP_DIR/artifacts/SHA256SUMS"
+grep -q "Airo-TV-v2.0.0-Play-Store.aab" "$TMP_DIR/artifacts/SHA256SUMS"
+
+python3 - "$TMP_DIR/artifacts/Release-Manifest.json" <<'PY'
+import json
+import sys
+
+manifest = json.load(open(sys.argv[1], encoding="utf-8"))
+assert manifest["schemaVersion"] == 1
+assert manifest["release"]["version"] == "v2.0.0"
+assert manifest["release"]["buildNumber"] == "200"
+assert manifest["release"]["sourceRef"] == "v2"
+assert manifest["release"]["sourceSha"] == "abc123"
+assert manifest["release"]["workflowRunUrl"].endswith("/actions/runs/42")
+
+artifacts = {artifact["filename"]: artifact for artifact in manifest["artifacts"]}
+apk = artifacts["Airo-TV-v2.0.0.apk"]
+aab = artifacts["Airo-TV-v2.0.0-Play-Store.aab"]
+assert apk["profileId"] == "tv"
+assert apk["packageId"] == "io.airo.app.tv"
+assert apk["artifactType"] == "apk"
+assert apk["distributionChannel"] == "direct-apk"
+assert apk["abi"] == "android-arm64"
+assert len(apk["sha256"]) == 64
+assert aab["artifactType"] == "aab"
+assert aab["distributionChannel"] == "play-store"
+assert len(aab["sha256"]) == 64
+PY
+
+mkdir -p "$TMP_DIR/empty"
+if python3 "$SCRIPT" \
+  --artifacts-dir "$TMP_DIR/empty" \
+  --profile-id tv \
+  > "$TMP_DIR/empty.out" 2>&1; then
+  echo "Expected empty artifact directory to fail"
+  exit 1
+fi
+grep -q "No APK or AAB artifacts found" "$TMP_DIR/empty.out"
+
+echo "generate-release-manifest tests passed"


### PR DESCRIPTION
# Summary

This PR adds the first credential-free implementation slice for v2 release verification.

Core outcome:

* Generates `SHA256SUMS` for final APK/AAB artifact filenames.
* Generates a machine-readable release manifest with profile, package ID, version, build number, artifact type, ABI, distribution channel, size, checksum, source ref, source SHA, and workflow run metadata.
* Wires the Airo TV release workflow to publish the generated manifest alongside existing release artifacts.
* Adds PR/CI validation for the generator so future release workflow edits cannot silently break manifest generation.

Partially addresses #680 and #679.

# Changes

### Code

* Added:
  * `scripts/generate-release-manifest.py`
  * `scripts/test-generate-release-manifest.sh`
* Updated:
  * `.github/workflows/airo-tv-release.yml`
  * `.github/workflows/ci.yml`
  * `.github/workflows/pr-checks.yml`
  * `docs/release/V2_DISTRIBUTION_MATRIX.md`
  * `VERIFY_DOWNLOAD.md`

### Logic

* Scans final release artifact directories for APK/AAB files.
* Produces `SHA256SUMS` after final artifact renaming.
* Emits a JSON manifest tied to `.github/airo-build-profiles.json` profile metadata.
* Fails when no release artifacts are present or when an artifact cannot be mapped to a profile.

# API Changes

None.

# Database Changes

None.

# Observability / Logging

* Release workflow logs the generated `SHA256SUMS` and manifest content.

# Performance Impact

Small CI-only checksum pass over release APK/AAB artifacts.

# Risks

* The first workflow integration covers the TV release leg. Mobile/tablet orchestrator jobs still need to call the same script once #676/#677 are implemented.
* SLSA/provenance signing is not added here; #680 still had a human decision on whether SHA256 is sufficient for the first wave.

Rollback plan:

* Revert this PR to restore the previous TV-only inline checksum generation.

# Testing

* `python3 -m py_compile scripts/generate-release-manifest.py scripts/check-build-profiles.py`
* `scripts/test-generate-release-manifest.sh`
* `scripts/check-build-profiles.py`
* `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "ok #{f}" }' .github/workflows/ci.yml .github/workflows/pr-checks.yml .github/workflows/airo-tv-release.yml`
* `bash scripts/check-docs-completeness.sh --base origin/v2 --head HEAD`
* `git diff --check HEAD~1 HEAD`

# Deployment Notes

* No credentials required.
* TV GitHub release assets will include `Airo-TV-<version>-Release-Manifest.json` after this merges.
* Mobile/tablet release jobs should reuse `scripts/generate-release-manifest.py` when #676/#677 fan-out workflows are added.
