### PR TITLE
docs(release): document v2 license review baseline

### DIFF
--- a/docs/release/README.md
+++ b/docs/release/README.md
@@ -47,6 +47,7 @@ Documentation for Airo releases and version history.
 | [Airo V1 and V2 Version Lines](./VERSION_LINES.md) | Base branch, tag, artifact, and support policy for monolith V1 and modular V2 |
 | [V2 Distribution Matrix](./V2_DISTRIBUTION_MATRIX.md) | Supported v2 profiles, artifact naming, channels, and support policy |
 | [V2 Publishing Human Setup](./V2_PUBLISHING_HUMAN_SETUP.md) | Account, credential, signing, store, and governance decisions maintainers must complete |
+| [V2 License Review](./V2_LICENSE_REVIEW.md) | License-readiness baseline and maintainer decisions before public distribution |
 | [Download Verification](../../VERIFY_DOWNLOAD.md) | SHA256 verification and safe direct APK install guidance |
 | [Trust and Transparency](../../TRUST.md) | Public trust boundaries for content, telemetry, accounts, and release artifacts |
 | [Changelog v1.1.0](./CHANGELOG_v1.1.0.md) | Current version changes |

--- a/docs/release/V2_LICENSE_REVIEW.md
+++ b/docs/release/V2_LICENSE_REVIEW.md
@@ -1,0 +1,127 @@
+# V2 License Review
+
+This document records the current license-readiness baseline for the v2 Android
+publishing wave. It does not choose the project license.
+
+Implementation work for this release line must start from latest `origin/v2`.
+
+## Current Status
+
+| Area | Status | Notes |
+| --- | --- | --- |
+| Root `LICENSE` | Blocked | No root license file is present. Maintainers must choose the project license before public reuse or broad distribution guidance is final. |
+| README license badge | Pending | README intentionally marks the repository license as pending. |
+| Internal package license files | Blocked | Package `LICENSE` files currently contain `TODO: Add your license here.` and must be replaced after the root license is chosen. |
+| Vendored Cast library | Identified | `packages/platform_player/third_party/flutter_chrome_cast` declares BSD-3-Clause. Preserve its copyright and license notice in source and binary notices. |
+| Private/commercial dependencies | Unknown | Maintainers must confirm whether any private or commercial dependency is bundled in release builds. |
+
+## V2 Release Profiles Reviewed
+
+The current v2 Android publishing candidates are documented in
+`docs/release/V2_DISTRIBUTION_MATRIX.md` and `.github/airo-build-profiles.json`:
+
+- `iptv-standalone`
+- `mobile-streaming`
+- `tv`
+
+The `ios-spm` and `web-validation` profiles are not part of the first v2
+Android publishing wave.
+
+## Direct Dependency Surface
+
+The following direct dependencies appear in at least one v2 Android release
+profile pubspec:
+
+```text
+audio_service
+audioplayers
+cached_network_image
+connectivity_plus
+core_ai
+core_auth
+core_data
+core_domain
+core_ui
+cupertino_icons
+dio
+drift
+equatable
+feature_iptv
+file_picker
+firebase_auth
+firebase_core
+flame
+flutter
+flutter_chrome_cast
+flutter_contacts
+flutter_image_compress
+flutter_local_notifications
+flutter_riverpod
+flutter_tts
+go_router
+google_mlkit_text_recognition
+google_sign_in
+hive
+hive_flutter
+image_picker
+intl
+just_audio
+package_info_plus
+path
+path_provider
+pdfx
+permission_handler
+riverpod
+rxdart
+share_plus
+shared_preferences
+sqlite3_flutter_libs
+stockfish
+timezone
+url_launcher
+uuid
+video_player
+wakelock_plus
+```
+
+Several heavy packages are stubbed in edge profiles through
+`dependency_overrides`; this reduces bundled release code for those profiles but
+does not remove the need to confirm license compatibility for any package that
+is actually included in a shipped artifact.
+
+## Native And Vendored Components
+
+Known native or vendored components that require explicit review before public
+distribution:
+
+- Flutter engine and Android Gradle build outputs.
+- Firebase and Google Sign-In Android libraries when included.
+- SQLite native libraries from `sqlite3_flutter_libs`.
+- Media playback and audio service native components.
+- ML/OCR/game/audio packages if a selected profile bundles them instead of a
+  local stub.
+- Vendored `flutter_chrome_cast` BSD-3-Clause source under
+  `packages/platform_player/third_party/flutter_chrome_cast`.
+
+## Required Before Public Distribution
+
+- Choose and add the root project `LICENSE`.
+- Replace package-level `TODO` license files with the approved license text or
+  remove them in favor of the root license policy if maintainers choose that
+  structure.
+- Generate third-party notices for the exact APK/AAB dependency graph produced
+  by each public profile.
+- Include the vendored Cast library BSD-3-Clause notice in third-party notices.
+- Confirm whether any private, commercial, gated, or restricted-license
+  dependency is bundled in each release artifact.
+- Confirm that Play Store, direct APK, and any other listing text matches the
+  selected project license and third-party notice obligations.
+
+## Human Decisions Still Needed
+
+- Root project license.
+- Whether package-level license files should duplicate the root license or be
+  replaced by a single root `LICENSE` plus notices.
+- Whether SHA256-only release provenance is sufficient for the first v2 wave or
+  whether signed/SLSA provenance is required.
+- Whether any private/commercial dependency is present in v2 release artifacts.

--- a/docs/release/V2_PUBLISHING_HUMAN_SETUP.md
+++ b/docs/release/V2_PUBLISHING_HUMAN_SETUP.md
@@ -71,6 +71,8 @@ Related issues: #687, #689.
 - [ ] Add the root `LICENSE` after the license is chosen.
 - [ ] Confirm whether any private or commercial dependencies are bundled in v2
       release profiles.
+- [ ] Resolve the open items in
+      [V2 License Review](./V2_LICENSE_REVIEW.md).
 - [ ] Decide whether GitHub Discussions should be enabled for public support.
 - [ ] Confirm CODEOWNERS entries for release, security, docs, v2 platform, and
       app/profile ownership.


### PR DESCRIPTION
# Summary

This PR adds a v2 license-readiness baseline so #687 has concrete current-state evidence before maintainers choose the root project license.

Core outcome:

* Documents that the root `LICENSE` is still absent and package license files still contain placeholders.
* Identifies the vendored `flutter_chrome_cast` BSD-3-Clause notice obligation.
* Lists the direct dependency surface across the current v2 Android release profiles.
* Links the review from release docs and the human setup checklist.

Partially addresses #687.

# Changes

### Docs

* Added:
  * `docs/release/V2_LICENSE_REVIEW.md`
* Updated:
  * `docs/release/README.md`
  * `docs/release/V2_PUBLISHING_HUMAN_SETUP.md`

# API Changes

None.

# Database Changes

None.

# Observability / Logging

None.

# Performance Impact

None. Documentation only.

# Risks

* This does not choose the project license.
* This does not generate final third-party notices; that requires the exact public artifact dependency graph and maintainer license decisions.

Rollback plan:

* Revert this PR if maintainers want a different license review format.

# Testing

* `bash scripts/check-docs-completeness.sh --base origin/v2 --head HEAD`
* `git diff --check origin/v2 HEAD`

# Deployment Notes

Human decisions still required before #687 can close:

* Choose the root project license.
* Decide whether package-level license files duplicate the root license or defer to root license plus notices.
* Confirm whether private/commercial dependencies are bundled in v2 release artifacts.
* Generate final third-party notices for each shipped APK/AAB.
