### PR TITLE
feat(release): add v2 release orchestrator

### DIFF
--- a/.github/workflows/airo-tv-release.yml
+++ b/.github/workflows/airo-tv-release.yml
@@ -1,6 +1,40 @@
 name: Airo TV Release
 
 on:
+  workflow_call:
+    inputs:
+      version:
+        description: 'Airo TV artifact and release version label'
+        required: true
+        type: string
+      build_name:
+        description: 'Android versionName, for example 0.0.2'
+        required: true
+        type: string
+      build_number:
+        description: 'Android versionCode, must increase for every Play upload'
+        required: true
+        type: string
+      release_ref:
+        description: 'Git ref to cut the release from; use v2 for Airo TV release line'
+        required: true
+        type: string
+      release_branch:
+        description: 'Release branch to create/update from release_ref before building'
+        required: true
+        type: string
+      publish_github_release:
+        description: 'Create/update the GitHub release and attach artifacts'
+        required: true
+        type: boolean
+      production_signing:
+        description: 'Require production Android signing and Firebase secrets'
+        required: true
+        type: boolean
+      play_track:
+        description: 'Optional Play upload track'
+        required: true
+        type: string
   pull_request:
     branches: [ v2 ]
     paths:
@@ -67,9 +101,9 @@ permissions:
 
 env:
   FLUTTER_VERSION: '3.44.4'
-  RELEASE_VERSION: ${{ github.event.inputs.version || github.ref_name }}
-  BUILD_NAME: ${{ github.event.inputs.build_name || '0.0.2' }}
-  BUILD_NUMBER: ${{ github.event.inputs.build_number || '2' }}
+  RELEASE_VERSION: ${{ inputs.version || github.event.inputs.version || github.ref_name }}
+  BUILD_NAME: ${{ inputs.build_name || github.event.inputs.build_name || '0.0.2' }}
+  BUILD_NUMBER: ${{ inputs.build_number || github.event.inputs.build_number || '2' }}
 
 jobs:
   prepare-release-branch:
@@ -81,22 +115,27 @@ jobs:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
-          ref: ${{ github.event.inputs.release_ref || github.ref }}
+          ref: ${{ inputs.release_ref || github.event.inputs.release_ref || github.ref }}
 
       - name: Use current ref for PR/push validation
         id: current_ref
-        if: github.event_name != 'workflow_dispatch'
+        if: github.event_name != 'workflow_dispatch' && github.event_name != 'workflow_call'
         run: echo "ref=${GITHUB_REF}" >> "$GITHUB_OUTPUT"
 
       - name: Create release branch from v2 base
         id: release_ref
-        if: github.event_name == 'workflow_dispatch'
+        if: github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_call'
         env:
-          RELEASE_BRANCH: ${{ github.event.inputs.release_branch || 'release/airo-tv-v0.0.2' }}
-          RELEASE_REF: ${{ github.event.inputs.release_ref || 'v2' }}
+          RELEASE_BRANCH: ${{ inputs.release_branch || github.event.inputs.release_branch || 'release/airo-tv-v0.0.2' }}
+          RELEASE_REF: ${{ inputs.release_ref || github.event.inputs.release_ref || 'v2' }}
         run: |
           git fetch origin main v2
-          git checkout -B "$RELEASE_BRANCH" "origin/$RELEASE_REF"
+          if git rev-parse --verify "origin/$RELEASE_REF^{commit}" >/dev/null 2>&1; then
+            base_ref="origin/$RELEASE_REF"
+          else
+            base_ref="$RELEASE_REF"
+          fi
+          git checkout -B "$RELEASE_BRANCH" "$base_ref"
           git push origin "$RELEASE_BRANCH" --force-with-lease
           echo "ref=$RELEASE_BRANCH" >> "$GITHUB_OUTPUT"
 
@@ -164,7 +203,7 @@ jobs:
       - name: Configure Firebase for TV build
         env:
           GOOGLE_SERVICES_JSON: ${{ secrets.GOOGLE_SERVICES_JSON }}
-          PRODUCTION_SIGNING: ${{ github.event.inputs.production_signing || 'false' }}
+          PRODUCTION_SIGNING: ${{ inputs.production_signing || github.event.inputs.production_signing || 'false' }}
         run: |
           cd app
           write_placeholder_config() {
@@ -226,7 +265,7 @@ jobs:
           KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
           KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
           KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
-          PRODUCTION_SIGNING: ${{ github.event.inputs.production_signing || 'false' }}
+          PRODUCTION_SIGNING: ${{ inputs.production_signing || github.event.inputs.production_signing || 'false' }}
         run: |
           cd app/android
           if [[ "$PRODUCTION_SIGNING" == "true" ]]; then
@@ -285,7 +324,9 @@ jobs:
 
       - name: Run release quality gates
         run: |
-          ruby -e 'require "yaml"; YAML.load_file(".github/workflows/airo-tv-release.yml"); puts "workflow-yaml-ok"'
+          ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "workflow-yaml-ok #{f}" }' \
+            .github/workflows/airo-tv-release.yml \
+            .github/workflows/v2-release-orchestrator.yml
           bash -n scripts/build-tv.sh scripts/check-android-tv-release.sh scripts/patch-android-plugin-gradle.sh
           python3 -m py_compile scripts/generate-release-manifest.py scripts/generate-release-qualification-report.py
           scripts/test-generate-release-manifest.sh
@@ -393,7 +434,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     needs: [prepare-release-branch, build-tv]
-    if: github.event_name == 'workflow_dispatch' && github.event.inputs.play_track != 'none'
+    if: (github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_call') && (inputs.play_track || github.event.inputs.play_track) != 'none'
     permissions:
       contents: read
     steps:
@@ -432,7 +473,7 @@ jobs:
           gem install fastlane --no-document
           fastlane supply \
             --aab "../../release-artifacts/Airo-TV-${BUILD_NAME}-Play-Store.aab" \
-            --track "${{ github.event.inputs.play_track }}" \
+            --track "${{ inputs.play_track || github.event.inputs.play_track }}" \
             --package_name "$SUPPLY_PACKAGE_NAME" \
             --json_key "$SUPPLY_JSON_KEY" \
             --skip_upload_metadata true \
@@ -444,14 +485,14 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     needs: [prepare-release-branch, build-tv]
-    if: github.event_name == 'workflow_dispatch' && github.event.inputs.publish_github_release == 'true'
+    if: (github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_call') && (inputs.publish_github_release == true || github.event.inputs.publish_github_release == 'true')
     permissions:
       contents: write
     steps:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
-          ref: ${{ needs.prepare-release-branch.outputs.release_ref || github.event.inputs.release_ref || 'v2' }}
+          ref: ${{ needs.prepare-release-branch.outputs.release_ref || inputs.release_ref || github.event.inputs.release_ref || 'v2' }}
 
       - name: Download release artifacts
         uses: actions/download-artifact@v8
@@ -463,7 +504,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           RELEASE_VERSION: ${{ env.RELEASE_VERSION }}
-          RELEASE_BRANCH: ${{ needs.prepare-release-branch.outputs.release_ref || github.event.inputs.release_branch || 'release/airo-tv-v0.0.2' }}
+          RELEASE_BRANCH: ${{ needs.prepare-release-branch.outputs.release_ref || inputs.release_branch || github.event.inputs.release_branch || 'release/airo-tv-v0.0.2' }}
         run: |
           notes=$(mktemp)
           cat > "$notes" <<NOTES

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,7 @@ jobs:
       - name: Validate platform build profiles
         run: |
           chmod +x scripts/check-build-profiles.py scripts/generate-release-manifest.py scripts/test-generate-release-manifest.sh scripts/generate-release-qualification-report.py scripts/test-generate-release-qualification-report.sh
+          ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "ok #{f}" }' .github/workflows/v2-release-orchestrator.yml .github/workflows/airo-tv-release.yml
           python3 -m py_compile scripts/check-build-profiles.py scripts/generate-release-manifest.py scripts/generate-release-qualification-report.py
           scripts/check-build-profiles.py
           scripts/test-generate-release-manifest.sh
@@ -163,6 +164,7 @@ jobs:
       - name: Validate dependency profile constraints
         run: |
           chmod +x scripts/check-build-profiles.py scripts/check-variant-pubspecs.sh scripts/generate-release-manifest.py scripts/test-generate-release-manifest.sh scripts/generate-release-qualification-report.py scripts/test-generate-release-qualification-report.sh
+          ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "ok #{f}" }' .github/workflows/v2-release-orchestrator.yml .github/workflows/airo-tv-release.yml
           python3 -m py_compile scripts/check-build-profiles.py scripts/generate-release-manifest.py scripts/generate-release-qualification-report.py
           scripts/check-build-profiles.py
           scripts/check-variant-pubspecs.sh

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -66,6 +66,7 @@ jobs:
       - name: Validate platform build profiles
         run: |
           chmod +x scripts/check-build-profiles.py scripts/generate-release-manifest.py scripts/test-generate-release-manifest.sh scripts/generate-release-qualification-report.py scripts/test-generate-release-qualification-report.sh
+          ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "ok #{f}" }' .github/workflows/v2-release-orchestrator.yml .github/workflows/airo-tv-release.yml
           python3 -m py_compile scripts/check-build-profiles.py scripts/generate-release-manifest.py scripts/generate-release-qualification-report.py
           scripts/check-build-profiles.py
           scripts/test-generate-release-manifest.sh

--- a/.github/workflows/v2-release-orchestrator.yml
+++ b/.github/workflows/v2-release-orchestrator.yml
@@ -1,0 +1,344 @@
+name: V2 Release Orchestrator
+
+on:
+  push:
+    tags:
+      - 'v2*'
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Release version label, for example v2.0.0'
+        required: true
+        default: 'v2.0.0'
+      build_name:
+        description: 'Android versionName, for example 2.0.0'
+        required: true
+        default: '2.0.0'
+      build_number:
+        description: 'Android versionCode shared by v2 Android artifacts'
+        required: true
+        default: '200'
+      release_ref:
+        description: 'Git ref to release; must be based on origin/v2'
+        required: true
+        default: 'v2'
+      release_branch:
+        description: 'Release branch to create/update from release_ref'
+        required: true
+        default: 'release/v2.0.0'
+      dry_run:
+        description: 'Build and upload workflow artifacts without public/store publishing'
+        required: true
+        default: true
+        type: boolean
+      publish_github_release:
+        description: 'Publish GitHub Release assets when dry_run is false'
+        required: true
+        default: false
+        type: boolean
+      production_signing:
+        description: 'Require production Android signing and Firebase secrets'
+        required: true
+        default: false
+        type: boolean
+      tv_play_track:
+        description: 'Optional TV Play upload track when dry_run is false'
+        required: true
+        default: none
+        type: choice
+        options:
+          - none
+          - internal
+          - alpha
+          - beta
+      mobile_profile:
+        description: 'Optional mobile/tablet profile; build automation is tracked in #677'
+        required: true
+        default: none
+        type: choice
+        options:
+          - none
+          - iptv-standalone
+          - mobile-streaming
+      qualification_mode:
+        description: 'Qualification report mode for top-level summary'
+        required: true
+        default: internal
+        type: choice
+        options:
+          - internal
+          - public
+
+concurrency:
+  group: v2-release-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  DEFAULT_VERSION: v2.0.0
+  DEFAULT_BUILD_NAME: 2.0.0
+  DEFAULT_BUILD_NUMBER: '200'
+
+jobs:
+  prepare:
+    name: Prepare v2 release context
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      version: ${{ steps.release.outputs.version }}
+      build_name: ${{ steps.release.outputs.build_name }}
+      build_number: ${{ steps.release.outputs.build_number }}
+      release_ref: ${{ steps.release.outputs.release_ref }}
+      release_branch: ${{ steps.release.outputs.release_branch }}
+      dry_run: ${{ steps.release.outputs.dry_run }}
+      publish_github_release: ${{ steps.release.outputs.publish_github_release }}
+      production_signing: ${{ steps.release.outputs.production_signing }}
+      tv_play_track: ${{ steps.release.outputs.tv_play_track }}
+      mobile_profile: ${{ steps.release.outputs.mobile_profile }}
+      qualification_mode: ${{ steps.release.outputs.qualification_mode }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          ref: ${{ inputs.release_ref || github.ref }}
+
+      - name: Resolve and validate release ref
+        id: release
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
+          INPUT_BUILD_NAME: ${{ inputs.build_name }}
+          INPUT_BUILD_NUMBER: ${{ inputs.build_number }}
+          INPUT_RELEASE_REF: ${{ inputs.release_ref }}
+          INPUT_RELEASE_BRANCH: ${{ inputs.release_branch }}
+          INPUT_DRY_RUN: ${{ inputs.dry_run }}
+          INPUT_PUBLISH_GITHUB_RELEASE: ${{ inputs.publish_github_release }}
+          INPUT_PRODUCTION_SIGNING: ${{ inputs.production_signing }}
+          INPUT_TV_PLAY_TRACK: ${{ inputs.tv_play_track }}
+          INPUT_MOBILE_PROFILE: ${{ inputs.mobile_profile }}
+          INPUT_QUALIFICATION_MODE: ${{ inputs.qualification_mode }}
+        run: |
+          git fetch origin main v2 --tags
+
+          version="${INPUT_VERSION:-${GITHUB_REF_NAME:-$DEFAULT_VERSION}}"
+          build_name="${INPUT_BUILD_NAME:-${version#v}}"
+          build_number="${INPUT_BUILD_NUMBER:-${GITHUB_RUN_NUMBER:-$DEFAULT_BUILD_NUMBER}}"
+          release_ref="${INPUT_RELEASE_REF:-$GITHUB_SHA}"
+          release_branch="${INPUT_RELEASE_BRANCH:-release/$version}"
+          dry_run="${INPUT_DRY_RUN:-true}"
+          publish_github_release="${INPUT_PUBLISH_GITHUB_RELEASE:-false}"
+          production_signing="${INPUT_PRODUCTION_SIGNING:-false}"
+          tv_play_track="${INPUT_TV_PLAY_TRACK:-none}"
+          mobile_profile="${INPUT_MOBILE_PROFILE:-none}"
+          qualification_mode="${INPUT_QUALIFICATION_MODE:-internal}"
+
+          if [ "$dry_run" = "true" ]; then
+            publish_github_release="false"
+            tv_play_track="none"
+          fi
+
+          if git rev-parse --verify "origin/$release_ref^{commit}" >/dev/null 2>&1; then
+            release_commit="$(git rev-parse "origin/$release_ref^{commit}")"
+          elif git rev-parse --verify "$release_ref^{commit}" >/dev/null 2>&1; then
+            release_commit="$(git rev-parse "$release_ref^{commit}")"
+          else
+            echo "::error::Cannot resolve release_ref: $release_ref"
+            exit 1
+          fi
+
+          if ! git merge-base --is-ancestor origin/v2 "$release_commit"; then
+            echo "::error::Release ref $release_ref does not contain latest origin/v2."
+            exit 1
+          fi
+
+          {
+            echo "version=$version"
+            echo "build_name=$build_name"
+            echo "build_number=$build_number"
+            echo "release_ref=$release_ref"
+            echo "release_branch=$release_branch"
+            echo "dry_run=$dry_run"
+            echo "publish_github_release=$publish_github_release"
+            echo "production_signing=$production_signing"
+            echo "tv_play_track=$tv_play_track"
+            echo "mobile_profile=$mobile_profile"
+            echo "qualification_mode=$qualification_mode"
+          } >> "$GITHUB_OUTPUT"
+
+          {
+            echo "# V2 release context"
+            echo ""
+            echo "| Field | Value |"
+            echo "| --- | --- |"
+            echo "| Version | $version |"
+            echo "| Build name | $build_name |"
+            echo "| Build number | $build_number |"
+            echo "| Release ref | $release_ref |"
+            echo "| Release branch | $release_branch |"
+            echo "| Dry run | $dry_run |"
+            echo "| TV Play track | $tv_play_track |"
+            echo "| Mobile/tablet profile | $mobile_profile |"
+            echo "| Qualification mode | $qualification_mode |"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  release-contracts:
+    name: Validate release contracts
+    runs-on: ubuntu-latest
+    needs: [prepare]
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ needs.prepare.outputs.release_ref }}
+
+      - name: Validate release scripts and workflow syntax
+        run: |
+          ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "ok #{f}" }' \
+            .github/workflows/v2-release-orchestrator.yml \
+            .github/workflows/airo-tv-release.yml
+          python3 -m py_compile \
+            scripts/check-build-profiles.py \
+            scripts/generate-release-manifest.py \
+            scripts/generate-release-qualification-report.py
+          scripts/check-build-profiles.py
+          scripts/test-generate-release-manifest.sh
+          scripts/test-generate-release-qualification-report.sh
+
+  mobile-tablet-status:
+    name: Mobile and tablet release leg
+    runs-on: ubuntu-latest
+    needs: [prepare]
+    steps:
+      - name: Report mobile/tablet release status
+        env:
+          MOBILE_PROFILE: ${{ needs.prepare.outputs.mobile_profile }}
+        run: |
+          if [ "$MOBILE_PROFILE" = "none" ]; then
+            echo "Mobile/tablet release build is not selected for this orchestrator run." >> "$GITHUB_STEP_SUMMARY"
+            echo "Mobile/tablet publish automation remains tracked by #677." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          echo "::error::Mobile/tablet profile '$MOBILE_PROFILE' was selected, but publishable APK/AAB automation is tracked by #677 and is not enabled yet."
+          exit 1
+
+  tv-release:
+    name: TV release leg
+    needs: [prepare, release-contracts]
+    permissions:
+      actions: read
+      contents: write
+    uses: ./.github/workflows/airo-tv-release.yml
+    with:
+      version: ${{ needs.prepare.outputs.version }}
+      build_name: ${{ needs.prepare.outputs.build_name }}
+      build_number: ${{ needs.prepare.outputs.build_number }}
+      release_ref: ${{ needs.prepare.outputs.release_ref }}
+      release_branch: ${{ needs.prepare.outputs.release_branch }}
+      publish_github_release: ${{ needs.prepare.outputs.publish_github_release == 'true' }}
+      production_signing: ${{ needs.prepare.outputs.production_signing == 'true' }}
+      play_track: ${{ needs.prepare.outputs.tv_play_track }}
+    secrets: inherit
+
+  release-summary:
+    name: V2 release summary
+    runs-on: ubuntu-latest
+    needs: [prepare, release-contracts, mobile-tablet-status, tv-release]
+    if: always()
+    permissions:
+      actions: read
+      contents: read
+    steps:
+      - uses: actions/checkout@v7
+        if: needs.tv-release.result == 'success'
+        with:
+          ref: ${{ needs.prepare.outputs.release_ref }}
+
+      - name: Download TV release artifacts
+        if: needs.tv-release.result == 'success'
+        uses: actions/download-artifact@v8
+        with:
+          name: airo-tv-release-${{ needs.prepare.outputs.version }}
+          path: release-artifacts/tv
+
+      - name: Generate TV qualification report
+        if: needs.tv-release.result == 'success'
+        env:
+          QUALIFICATION_MODE: ${{ needs.prepare.outputs.qualification_mode }}
+        run: |
+          manifest="$(find release-artifacts/tv -maxdepth 1 -name '*Release-Manifest.json' | head -n 1)"
+          if [ -z "$manifest" ]; then
+            echo "::error::TV release manifest was not found in downloaded artifacts."
+            exit 1
+          fi
+          scripts/generate-release-qualification-report.py \
+            --manifest "$manifest" \
+            --mode "$QUALIFICATION_MODE"
+
+      - name: Upload top-level release evidence
+        if: needs.tv-release.result == 'success'
+        uses: actions/upload-artifact@v7
+        with:
+          name: v2-release-evidence-${{ needs.prepare.outputs.version }}
+          path: release-artifacts/
+          retention-days: 30
+
+      - name: Write release summary
+        env:
+          VERSION: ${{ needs.prepare.outputs.version }}
+          BUILD_NAME: ${{ needs.prepare.outputs.build_name }}
+          BUILD_NUMBER: ${{ needs.prepare.outputs.build_number }}
+          RELEASE_REF: ${{ needs.prepare.outputs.release_ref }}
+          DRY_RUN: ${{ needs.prepare.outputs.dry_run }}
+          TV_RESULT: ${{ needs.tv-release.result }}
+          MOBILE_RESULT: ${{ needs.mobile-tablet-status.result }}
+          CONTRACT_RESULT: ${{ needs.release-contracts.result }}
+        run: |
+          {
+            echo "# V2 release summary"
+            echo ""
+            echo "| Field | Value |"
+            echo "| --- | --- |"
+            echo "| Version | $VERSION |"
+            echo "| Build name | $BUILD_NAME |"
+            echo "| Build number | $BUILD_NUMBER |"
+            echo "| Release ref | $RELEASE_REF |"
+            echo "| Dry run | $DRY_RUN |"
+            echo "| TV leg | $TV_RESULT |"
+            echo "| Mobile/tablet leg | $MOBILE_RESULT |"
+            echo "| Release contracts | $CONTRACT_RESULT |"
+            echo ""
+            echo "## Artifact evidence"
+            echo ""
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          if [ -d release-artifacts/tv ]; then
+            {
+              echo "### TV"
+              echo ""
+              find release-artifacts/tv -maxdepth 1 -type f -printf '- %f\n' | sort
+              echo ""
+              echo "TV artifacts include APK/AAB files, SHA256SUMS, release manifest, and an internal qualification report when generated by this orchestrator."
+            } >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "TV artifacts were not available because the TV leg result was $TV_RESULT." >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Enforce orchestrator result
+        env:
+          TV_RESULT: ${{ needs.tv-release.result }}
+          MOBILE_RESULT: ${{ needs.mobile-tablet-status.result }}
+          CONTRACT_RESULT: ${{ needs.release-contracts.result }}
+        run: |
+          if [ "$CONTRACT_RESULT" != "success" ]; then
+            echo "::error::Release contract validation did not pass: $CONTRACT_RESULT"
+            exit 1
+          fi
+          if [ "$TV_RESULT" != "success" ]; then
+            echo "::error::TV release leg did not pass: $TV_RESULT"
+            exit 1
+          fi
+          if [ "$MOBILE_RESULT" != "success" ]; then
+            echo "::error::Mobile/tablet release leg did not pass: $MOBILE_RESULT"
+            exit 1
+          fi

--- a/docs/release/README.md
+++ b/docs/release/README.md
@@ -49,6 +49,7 @@ Documentation for Airo releases and version history.
 | [V2 Publishing Human Setup](./V2_PUBLISHING_HUMAN_SETUP.md) | Account, credential, signing, store, and governance decisions maintainers must complete |
 | [V2 License Review](./V2_LICENSE_REVIEW.md) | License-readiness baseline and maintainer decisions before public distribution |
 | [V2 Release Qualification](./V2_RELEASE_QUALIFICATION.md) | Required release evidence, device matrix, waiver behavior, and qualification report format |
+| [V2 Release Orchestrator](./V2_RELEASE_ORCHESTRATOR.md) | Top-level v2 release workflow, dry-run behavior, TV workflow reuse, and remaining publishing blockers |
 | [Download Verification](../../VERIFY_DOWNLOAD.md) | SHA256 verification and safe direct APK install guidance |
 | [Trust and Transparency](../../TRUST.md) | Public trust boundaries for content, telemetry, accounts, and release artifacts |
 | [Changelog v1.1.0](./CHANGELOG_v1.1.0.md) | Current version changes |

--- a/docs/release/RELEASE_CHECKLIST.md
+++ b/docs/release/RELEASE_CHECKLIST.md
@@ -119,6 +119,7 @@ Pre-release verification checklist for Airo Super App releases.
 - [ ] Store-only AABs and private debug symbols are not published as public direct-download assets unless explicitly approved
 - [ ] Fire TV and legacy Android TV support labels match qualification evidence
 - [ ] [V2 Release Qualification](./V2_RELEASE_QUALIFICATION.md) report generated and attached or explicitly waived
+- [ ] [V2 Release Orchestrator](./V2_RELEASE_ORCHESTRATOR.md) dry-run completed from the release ref
 
 ### Legacy / General Required Artifacts
 

--- a/docs/release/V2_RELEASE_ORCHESTRATOR.md
+++ b/docs/release/V2_RELEASE_ORCHESTRATOR.md
@@ -1,0 +1,64 @@
+# V2 Release Orchestrator
+
+This document defines the top-level v2 release orchestration workflow in
+`.github/workflows/v2-release-orchestrator.yml`.
+
+Implementation work for this release line must start from latest `origin/v2`.
+
+## Entry Points
+
+The orchestrator runs from:
+
+- tags matching `v2*`;
+- manual `workflow_dispatch` runs.
+
+Manual runs default to dry-run mode. Dry-run builds and uploads workflow
+artifacts without creating public GitHub Releases or uploading to Google Play.
+
+## Current Scope
+
+The orchestrator currently validates the release contract, calls the existing
+Airo TV release workflow through `workflow_call`, downloads the TV artifacts,
+generates the top-level evidence bundle, and writes the release summary.
+
+The TV leg reuses `.github/workflows/airo-tv-release.yml` so package checks,
+Leanback validation, release artifact naming, checksums, manifest generation,
+debug-symbol retention, optional GitHub Release publication, and optional Play
+track upload remain owned by the TV workflow.
+
+Mobile/tablet publishing is intentionally not enabled yet. Selecting
+`iptv-standalone` or `mobile-streaming` in the orchestrator fails with a pointer
+to #677 until signed APK/AAB jobs and store/Firebase destinations are ready.
+
+## Release Evidence
+
+Successful TV orchestrator runs upload:
+
+- `airo-tv-release-<version>` from the TV workflow;
+- `v2-release-evidence-<version>` from the orchestrator.
+
+The top-level evidence bundle includes TV artifacts, `SHA256SUMS`, the release
+manifest, and a qualification report generated from the manifest. Public
+qualification mode fails when required device evidence or an approved waiver is
+missing.
+
+## Public Publishing Controls
+
+Public/store publishing requires:
+
+- `dry_run` set to `false`;
+- `publish_github_release` set to `true` for GitHub Release publication;
+- `production_signing` set to `true` for production-signed Android artifacts;
+- `tv_play_track` set to a Play testing track for TV Play uploads.
+
+When `dry_run` is `true`, the orchestrator forces GitHub Release publication
+off and sets the TV Play track to `none`.
+
+## Human Decisions Still Needed
+
+- Final v2 tag naming policy beyond the current `v2*` automation trigger.
+- Whether public releases should publish immediately or always start as draft
+  GitHub Releases.
+- Whether optional channels should block the whole release or report warnings.
+- Mobile/tablet package IDs, Firebase apps, Play tracks, and release signing
+  secrets for #677, #681, and #682.


### PR DESCRIPTION
## Summary

This PR adds the first top-level v2 release orchestration entrypoint.

Core outcome:

* adds `.github/workflows/v2-release-orchestrator.yml` for v2 tag/manual release coordination
* exposes `.github/workflows/airo-tv-release.yml` through `workflow_call` so the orchestrator reuses the existing TV release leg instead of duplicating it
* validates release refs against latest `origin/v2`
* keeps dry-run mode as the default and disables public/store publishing during dry runs
* downloads TV release artifacts and generates the top-level evidence bundle/summary
* documents current orchestrator behavior and remaining publishing blockers

Partially addresses #676 and #678.

## Changes

### Workflows

* Added `V2 Release Orchestrator` with tag and manual dispatch entrypoints.
* Added a reusable `workflow_call` contract to `Airo TV Release`.
* Preserved TV package, Leanback, permission, artifact naming, checksum, manifest, optional GitHub Release, and optional Play upload behavior in the existing TV workflow.
* Added a mobile/tablet status leg that stays inert by default and fails explicitly if a mobile profile is selected before #677 is implemented.

### Documentation

* Added `docs/release/V2_RELEASE_ORCHESTRATOR.md`.
* Linked the orchestrator from the release docs index and release checklist.

## Remaining Work

* #677 still needs publishable mobile/tablet APK and AAB jobs.
* #681/#682 still need Play/Firebase credentials, apps, tester groups, and tracks.
* Maintainers still need to confirm final v2 tag policy, draft-vs-publish behavior, optional-channel blocking behavior, and waiver authority.

## Testing

* `bash scripts/check-docs-completeness.sh --base origin/v2 --head HEAD`
* `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "ok #{f}" }' .github/workflows/v2-release-orchestrator.yml .github/workflows/airo-tv-release.yml .github/workflows/ci.yml .github/workflows/pr-checks.yml`
* `python3 -m py_compile scripts/check-build-profiles.py scripts/generate-release-manifest.py scripts/generate-release-qualification-report.py`
* `scripts/check-build-profiles.py`
* `scripts/test-generate-release-manifest.sh`
* `scripts/test-generate-release-qualification-report.sh`
* `git diff --check origin/v2 HEAD`

Note: `actionlint`/Go is not installed locally, so GitHub Actions is the authoritative reusable-workflow expression validation.
