### PR TITLE
fix(release): restore v2 profile Firebase compatibility

### DIFF
--- a/app/pubspec_ios_spm.yaml
+++ b/app/pubspec_ios_spm.yaml
@@ -38,8 +38,8 @@ dependencies:
   dio: ^5.10.0
 
   # Firebase & Authentication
-  firebase_core: 4.12.0
-  firebase_auth: 6.5.5
+  firebase_core: 4.4.0
+  firebase_auth: 6.1.4
   google_sign_in: 7.2.0
 
   # Audio & Media

--- a/app/pubspec_streaming.yaml
+++ b/app/pubspec_streaming.yaml
@@ -44,8 +44,8 @@ dependencies:
   dio: ^5.10.0
 
   # Firebase & Authentication
-  firebase_core: 4.12.0
-  firebase_auth: 6.5.5
+  firebase_core: 4.4.0
+  firebase_auth: 6.1.4
   google_sign_in: 7.2.0
 
   # Audio & Media - KEPT for streaming app!

--- a/app/pubspec_tv.yaml
+++ b/app/pubspec_tv.yaml
@@ -44,8 +44,8 @@ dependencies:
   dio: ^5.10.0
 
   # Firebase & Authentication
-  firebase_core: 4.12.0
-  firebase_auth: 6.5.5
+  firebase_core: 4.4.0
+  firebase_auth: 6.1.4
   google_sign_in: 7.2.0
 
   # Audio & Media


### PR DESCRIPTION
## Summary

This PR restores the v2 streaming, TV, and iOS SPM profile Firebase package pins to the last known compatible pair.

Goal: unblock current v2 profile CI after the dependency refresh on `origin/v2` introduced `firebase_auth 6.5.5` with a platform-interface API mismatch during the `mobile-streaming` Android build.

Core outcome:

* `mobile-streaming`, `tv`, and `ios-spm` profiles resolve `firebase_auth 6.1.4` and `firebase_core 4.4.0`.
* The full app dependency refresh remains untouched.
* PR #699 can be rebased after this lands instead of carrying dependency compatibility changes in the orchestrator PR.

## Changes

### Code

* Updated:
  * `app/pubspec_streaming.yaml` Firebase package pins
  * `app/pubspec_tv.yaml` Firebase package pins
  * `app/pubspec_ios_spm.yaml` Firebase package pins

### Logic

* No runtime logic changes.
* Narrows only the variant profile dependency set that failed CI.

## API Changes

None.

## Database Changes

None.

## Observability / Logging

None.

## Performance Impact

No expected runtime impact.

## Risks

* Risk: the reverted Firebase pair may miss fixes from the latest packages.
* Rollback plan: restore the refreshed pins once the Firebase platform-interface compatibility issue is resolved or a coherent Firebase package set is selected.

## Testing

* `scripts/check-build-profiles.py`
* `scripts/check-variant-pubspecs.sh`
* `git diff --check`

## Notes

This is intentionally separate from the v2 release orchestrator PR because the failure reproduced from the current `origin/v2` dependency refresh, not from orchestrator workflow changes.