### PR TITLE
feat(release): add v2 mobile tablet workflow

### DIFF
--- a/.github/workflows/airo-mobile-tablet-release.yml
+++ b/.github/workflows/airo-mobile-tablet-release.yml
@@ -1,0 +1,431 @@
+name: Airo Mobile and Tablet Release
+
+on:
+  workflow_call:
+    inputs:
+      profile:
+        description: 'Mobile/tablet v2 profile to build'
+        required: true
+        type: string
+      version:
+        description: 'Artifact and release version label'
+        required: true
+        type: string
+      build_name:
+        description: 'Android versionName, for example 2.0.0'
+        required: true
+        type: string
+      build_number:
+        description: 'Android versionCode, must increase for every Play upload'
+        required: true
+        type: string
+      release_ref:
+        description: 'Git ref to release; must contain latest origin/v2'
+        required: true
+        type: string
+      production_signing:
+        description: 'Require production Android signing and Firebase secrets'
+        required: true
+        type: boolean
+  workflow_dispatch:
+    inputs:
+      profile:
+        description: 'Mobile/tablet v2 profile to build'
+        required: true
+        default: iptv-standalone
+        type: choice
+        options:
+          - iptv-standalone
+          - mobile-streaming
+      version:
+        description: 'Artifact and release version label'
+        required: true
+        default: v2.0.0
+      build_name:
+        description: 'Android versionName, for example 2.0.0'
+        required: true
+        default: 2.0.0
+      build_number:
+        description: 'Android versionCode, must increase for every Play upload'
+        required: true
+        default: '200'
+      release_ref:
+        description: 'Git ref to release; must contain latest origin/v2'
+        required: true
+        default: v2
+      production_signing:
+        description: 'Require production Android signing and Firebase secrets'
+        required: true
+        default: false
+        type: boolean
+
+concurrency:
+  group: airo-mobile-tablet-release-${{ github.ref }}-${{ inputs.profile || github.event.inputs.profile || 'manual' }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  FLUTTER_VERSION: '3.44.4'
+  RELEASE_VERSION: ${{ inputs.version || github.event.inputs.version || github.ref_name }}
+  BUILD_NAME: ${{ inputs.build_name || github.event.inputs.build_name || '2.0.0' }}
+  BUILD_NUMBER: ${{ inputs.build_number || github.event.inputs.build_number || '200' }}
+  PROFILE: ${{ inputs.profile || github.event.inputs.profile || 'iptv-standalone' }}
+
+jobs:
+  prepare-release-ref:
+    name: Validate mobile/tablet release ref
+    runs-on: ubuntu-latest
+    outputs:
+      release_ref: ${{ steps.release_ref.outputs.ref }}
+      release_sha: ${{ steps.release_ref.outputs.sha }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          ref: ${{ inputs.release_ref || github.event.inputs.release_ref || github.ref }}
+
+      - name: Resolve and validate v2 ref
+        id: release_ref
+        env:
+          RELEASE_REF: ${{ inputs.release_ref || github.event.inputs.release_ref || github.ref }}
+        run: |
+          git fetch origin main v2 --tags
+
+          if git rev-parse --verify "origin/$RELEASE_REF^{commit}" >/dev/null 2>&1; then
+            release_commit="$(git rev-parse "origin/$RELEASE_REF^{commit}")"
+          elif git rev-parse --verify "$RELEASE_REF^{commit}" >/dev/null 2>&1; then
+            release_commit="$(git rev-parse "$RELEASE_REF^{commit}")"
+          else
+            echo "::error::Cannot resolve release_ref: $RELEASE_REF"
+            exit 1
+          fi
+
+          if ! git merge-base --is-ancestor origin/v2 "$release_commit"; then
+            echo "::error::Release ref $RELEASE_REF does not contain latest origin/v2."
+            exit 1
+          fi
+
+          echo "ref=$RELEASE_REF" >> "$GITHUB_OUTPUT"
+          echo "sha=$release_commit" >> "$GITHUB_OUTPUT"
+
+  build-mobile-tablet:
+    name: Build ${{ inputs.profile || github.event.inputs.profile || 'mobile/tablet' }} APK and AAB
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    needs: [prepare-release-ref]
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ needs.prepare-release-ref.outputs.release_sha }}
+
+      - name: Resolve mobile/tablet profile metadata
+        run: |
+          release_version="$(printf '%s' "$RELEASE_VERSION" | sed 's/[^A-Za-z0-9._-]/-/g')"
+          echo "RELEASE_VERSION=$release_version" >> "$GITHUB_ENV"
+
+          case "$PROFILE" in
+            iptv-standalone)
+              echo "TARGET_ENTRYPOINT=lib/main_airo_iptv.dart" >> "$GITHUB_ENV"
+              echo "PROFILE_PUBSPEC=pubspec_iptv.yaml" >> "$GITHUB_ENV"
+              echo "APP_VARIANT=iptv" >> "$GITHUB_ENV"
+              echo "APP_PLATFORM=mobileIptv" >> "$GITHUB_ENV"
+              echo "PACKAGE_ID=io.airo.app.iptv" >> "$GITHUB_ENV"
+              echo "ARTIFACT_PREFIX=Airo-IPTV" >> "$GITHUB_ENV"
+              ;;
+            mobile-streaming)
+              echo "TARGET_ENTRYPOINT=lib/main_mobile_streaming.dart" >> "$GITHUB_ENV"
+              echo "PROFILE_PUBSPEC=pubspec_streaming.yaml" >> "$GITHUB_ENV"
+              echo "APP_VARIANT=streaming" >> "$GITHUB_ENV"
+              echo "APP_PLATFORM=mobileStreaming" >> "$GITHUB_ENV"
+              echo "PACKAGE_ID=io.airo.app.streaming" >> "$GITHUB_ENV"
+              echo "ARTIFACT_PREFIX=Airo-Streaming" >> "$GITHUB_ENV"
+              ;;
+            *)
+              echo "::error::Unsupported mobile/tablet profile: $PROFILE"
+              exit 1
+              ;;
+          esac
+
+      - name: Setup Java
+        uses: actions/setup-java@v5
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Setup Flutter
+        uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2
+        with:
+          flutter-version: ${{ env.FLUTTER_VERSION }}
+          channel: 'stable'
+          cache: true
+
+      - name: Cache pub dependencies
+        uses: actions/cache@v6
+        with:
+          path: |
+            ~/.pub-cache
+            app/.dart_tool
+            packages/*/.dart_tool
+          key: mobile-tablet-pub-${{ runner.os }}-${{ env.PROFILE }}-${{ hashFiles('**/pubspec.lock', 'app/pubspec_iptv.yaml', 'app/pubspec_streaming.yaml') }}
+          restore-keys: mobile-tablet-pub-${{ runner.os }}-${{ env.PROFILE }}-
+
+      - name: Cache Gradle
+        uses: actions/cache@v6
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: mobile-tablet-gradle-${{ runner.os }}-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: mobile-tablet-gradle-${{ runner.os }}-
+
+      - name: Configure Firebase for mobile/tablet build
+        env:
+          GOOGLE_SERVICES_JSON: ${{ secrets.GOOGLE_SERVICES_JSON }}
+          PRODUCTION_SIGNING: ${{ inputs.production_signing || github.event.inputs.production_signing || 'false' }}
+        run: |
+          cd app
+          write_placeholder_config() {
+            cat > android/app/google-services.json <<JSON
+          {
+            "project_info": {
+              "project_number": "000000000000",
+              "project_id": "airo-mobile-ci-placeholder",
+              "storage_bucket": "airo-mobile-ci-placeholder.appspot.com"
+            },
+            "client": [
+              {
+                "client_info": {
+                  "mobilesdk_app_id": "1:000000000000:android:0000000000000000000000",
+                  "android_client_info": {
+                    "package_name": "$PACKAGE_ID"
+                  }
+                },
+                "oauth_client": [],
+                "api_key": [
+                  {
+                    "current_key": "ci-placeholder"
+                  }
+                ],
+                "services": {
+                  "appinvite_service": {
+                    "other_platform_oauth_client": []
+                  }
+                }
+              }
+            ],
+            "configuration_version": "1"
+          }
+          JSON
+          }
+
+          if [[ -n "$GOOGLE_SERVICES_JSON" ]]; then
+            echo "$GOOGLE_SERVICES_JSON" | base64 -d > android/app/google-services.json
+            if grep -q "\"package_name\"[[:space:]]*:[[:space:]]*\"$PACKAGE_ID\"" android/app/google-services.json; then
+              echo "Using GOOGLE_SERVICES_JSON for $PACKAGE_ID."
+            elif [[ "$PRODUCTION_SIGNING" == "true" ]]; then
+              echo "::error::GOOGLE_SERVICES_JSON must include a Firebase Android client for $PACKAGE_ID."
+              exit 1
+            else
+              echo "::warning::GOOGLE_SERVICES_JSON does not include $PACKAGE_ID; using placeholder Firebase config."
+              write_placeholder_config
+            fi
+          elif [[ "$PRODUCTION_SIGNING" == "true" ]]; then
+            echo "::error::GOOGLE_SERVICES_JSON is required for production-signed release builds."
+            exit 1
+          else
+            echo "::warning::GOOGLE_SERVICES_JSON is not set; using placeholder Firebase config."
+            write_placeholder_config
+          fi
+
+          if [[ "$PRODUCTION_SIGNING" == "true" && "$PROFILE" == "mobile-streaming" ]] && \
+             grep -q "TODO_REGISTER_IO_AIRO_APP_STREAMING" lib/firebase_options.dart; then
+            echo "::error::Production mobile-streaming releases require the real Firebase appId in app/lib/firebase_options.dart."
+            exit 1
+          fi
+
+      - name: Configure Android signing
+        env:
+          ANDROID_RELEASE_KEYSTORE_BASE64: ${{ secrets.ANDROID_RELEASE_KEYSTORE_BASE64 }}
+          KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
+          KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
+          KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
+          PRODUCTION_SIGNING: ${{ inputs.production_signing || github.event.inputs.production_signing || 'false' }}
+        run: |
+          cd app/android
+          if [[ "$PRODUCTION_SIGNING" == "true" ]]; then
+            missing=0
+            for name in ANDROID_RELEASE_KEYSTORE_BASE64 KEYSTORE_PASSWORD KEY_ALIAS KEY_PASSWORD; do
+              if [[ -z "${!name}" ]]; then
+                echo "::error::Missing required Android release signing secret: $name"
+                missing=1
+              fi
+            done
+            [[ "$missing" -eq 0 ]] || exit 1
+            echo "$ANDROID_RELEASE_KEYSTORE_BASE64" | base64 -d > release.keystore
+            {
+              echo "storeFile=release.keystore"
+              echo "storePassword=$KEYSTORE_PASSWORD"
+              echo "keyAlias=$KEY_ALIAS"
+              echo "keyPassword=$KEY_PASSWORD"
+            } > key.properties
+          else
+            keytool -genkeypair \
+              -v \
+              -keystore ci-validation.keystore \
+              -storepass ci-validation-password \
+              -keypass ci-validation-password \
+              -alias ci-validation \
+              -keyalg RSA \
+              -keysize 2048 \
+              -validity 10000 \
+              -dname "CN=Airo Mobile CI Validation,O=DevelopersCoffee,C=US"
+            {
+              echo "storeFile=ci-validation.keystore"
+              echo "storePassword=ci-validation-password"
+              echo "keyAlias=ci-validation"
+              echo "keyPassword=ci-validation-password"
+            } > key.properties
+          fi
+          chmod 600 *.keystore key.properties
+
+      - name: Apply mobile/tablet pubspec
+        run: |
+          cp app/pubspec.yaml app/pubspec.yaml.backup
+          cp "app/$PROFILE_PUBSPEC" app/pubspec.yaml
+
+      - name: Get dependencies
+        run: |
+          (cd packages/core_domain && flutter pub get) &
+          (cd packages/core_ui && flutter pub get) &
+          (cd packages/core_data && flutter pub get) &
+          (cd packages/core_ai && flutter pub get) &
+          (cd packages/core_auth && flutter pub get) &
+          wait
+          cd app && flutter pub get
+
+      - name: Patch Android plugin Gradle files
+        run: scripts/patch-android-plugin-gradle.sh
+
+      - name: Run mobile/tablet release quality gates
+        run: |
+          ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "workflow-yaml-ok #{f}" }' \
+            .github/workflows/v2-release-orchestrator.yml \
+            .github/workflows/airo-tv-release.yml \
+            .github/workflows/airo-mobile-tablet-release.yml
+          bash -n scripts/patch-android-plugin-gradle.sh scripts/check-apk-size.sh
+          python3 -m py_compile scripts/generate-release-manifest.py scripts/generate-release-qualification-report.py
+          scripts/check-build-profiles.py
+          scripts/test-generate-release-manifest.sh
+          scripts/test-generate-release-qualification-report.sh
+          cd app
+          flutter analyze "$TARGET_ENTRYPOINT" --no-fatal-infos --no-fatal-warnings
+          cd ..
+          git diff --check
+
+      - name: Build mobile/tablet APK
+        run: |
+          cd app
+          export GRADLE_OPTS="-Dorg.gradle.watch.fs=false -Xmx4g -Dorg.gradle.parallel=true"
+          flutter build apk --release \
+            --target="$TARGET_ENTRYPOINT" \
+            --dart-define=APP_VARIANT="$APP_VARIANT" \
+            --dart-define=APP_PLATFORM="$APP_PLATFORM" \
+            --build-name="$BUILD_NAME" \
+            --build-number="$BUILD_NUMBER" \
+            --target-platform=android-arm64 \
+            --tree-shake-icons \
+            --split-debug-info="build/debug-info-$PROFILE" \
+            --obfuscate
+          mv build/app/outputs/flutter-apk/app-release.apk \
+            build/app/outputs/flutter-apk/app-arm64-v8a-release.apk
+
+      - name: Build mobile/tablet AAB
+        run: |
+          cd app
+          export GRADLE_OPTS="-Dorg.gradle.watch.fs=false -Xmx4g -Dorg.gradle.parallel=true"
+          flutter build appbundle --release \
+            --target="$TARGET_ENTRYPOINT" \
+            --dart-define=APP_VARIANT="$APP_VARIANT" \
+            --dart-define=APP_PLATFORM="$APP_PLATFORM" \
+            --build-name="$BUILD_NAME" \
+            --build-number="$BUILD_NUMBER" \
+            --tree-shake-icons \
+            --split-debug-info="build/debug-info-$PROFILE" \
+            --obfuscate
+
+      - name: Check mobile/tablet APK size
+        env:
+          APK_SIZE_COMPONENT: ${{ env.PROFILE }}
+          APK_SIZE_APK_GLOB: app/build/app/outputs/flutter-apk/app-arm64-v8a-release.apk
+          APK_SIZE_REPORT_FILE: apk-size-${{ env.PROFILE }}.md
+        run: scripts/check-apk-size.sh
+
+      - name: Stage named release artifacts
+        run: |
+          mkdir -p release-artifacts
+          apk_name="${ARTIFACT_PREFIX}-${BUILD_NAME}-${BUILD_NUMBER}-arm64.apk"
+          aab_name="${ARTIFACT_PREFIX}-${BUILD_NAME}-${BUILD_NUMBER}-Play-Store.aab"
+          cp app/build/app/outputs/flutter-apk/app-arm64-v8a-release.apk "release-artifacts/$apk_name"
+          cp app/build/app/outputs/bundle/release/app-release.aab "release-artifacts/$aab_name"
+          scripts/generate-release-manifest.py \
+            --artifacts-dir release-artifacts \
+            --profile-id "$PROFILE" \
+            --version "$BUILD_NAME" \
+            --build-number "$BUILD_NUMBER" \
+            --source-ref "${{ needs.prepare-release-ref.outputs.release_ref }}" \
+            --source-sha "${{ needs.prepare-release-ref.outputs.release_sha }}" \
+            --workflow-name "$GITHUB_WORKFLOW" \
+            --workflow-run "$GITHUB_RUN_ID" \
+            --workflow-run-attempt "$GITHUB_RUN_ATTEMPT" \
+            --repository "$GITHUB_REPOSITORY"
+          mv release-artifacts/Release-Manifest.json "release-artifacts/${ARTIFACT_PREFIX}-${BUILD_NAME}-${BUILD_NUMBER}-Release-Manifest.json"
+
+          python3 - "$PROFILE" "$PACKAGE_ID" "$BUILD_NAME" "$BUILD_NUMBER" "$apk_name" "$aab_name" "release-artifacts/${ARTIFACT_PREFIX}-${BUILD_NAME}-${BUILD_NUMBER}-Release-Manifest.json" <<'PY'
+          import json
+          import sys
+
+          profile, package, version, build_number, apk_name, aab_name, manifest_path = sys.argv[1:]
+          manifest = json.load(open(manifest_path, encoding="utf-8"))
+          artifacts = {artifact["filename"]: artifact for artifact in manifest["artifacts"]}
+          for filename in (apk_name, aab_name):
+              artifact = artifacts[filename]
+              assert artifact["profileId"] == profile
+              assert artifact["packageId"] == package
+              assert artifact["version"] == version
+              assert artifact["buildNumber"] == build_number
+              assert len(artifact["sha256"]) == 64
+          assert artifacts[apk_name]["artifactType"] == "apk"
+          assert artifacts[aab_name]["artifactType"] == "aab"
+          PY
+
+          grep -q "$apk_name" release-artifacts/SHA256SUMS
+          grep -q "$aab_name" release-artifacts/SHA256SUMS
+          ls -lh release-artifacts
+          cat release-artifacts/SHA256SUMS
+          {
+            echo "# Airo mobile/tablet release artifacts"
+            echo ""
+            echo "| Asset | Visibility | Purpose |"
+            echo "| --- | --- | --- |"
+            echo "| $apk_name | Public/direct install | Mobile/tablet Android arm64 APK |"
+            echo "| $aab_name | Store upload / draft release evidence | Google Play upload input |"
+            echo "| SHA256SUMS | Public/internal verification | Checksum evidence after final renaming |"
+            echo "| ${ARTIFACT_PREFIX}-${BUILD_NAME}-${BUILD_NUMBER}-Release-Manifest.json | Public/internal verification | Profile, package, source ref, workflow run, and checksum mapping |"
+            echo "| airo-mobile-tablet-debug-info-${PROFILE}-${RELEASE_VERSION} | Restricted internal artifact | Obfuscation symbol lookup |"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload mobile/tablet release artifacts
+        uses: actions/upload-artifact@v7
+        with:
+          name: airo-mobile-tablet-${{ env.PROFILE }}-${{ env.RELEASE_VERSION }}
+          path: release-artifacts/
+          retention-days: 30
+
+      - name: Upload obfuscation symbols
+        uses: actions/upload-artifact@v7
+        with:
+          name: airo-mobile-tablet-debug-info-${{ env.PROFILE }}-${{ env.RELEASE_VERSION }}
+          path: app/build/debug-info-${{ env.PROFILE }}/
+          retention-days: 90

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,10 @@ jobs:
       - name: Validate platform build profiles
         run: |
           chmod +x scripts/check-build-profiles.py scripts/generate-release-manifest.py scripts/test-generate-release-manifest.sh scripts/generate-release-qualification-report.py scripts/test-generate-release-qualification-report.sh
-          ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "ok #{f}" }' .github/workflows/v2-release-orchestrator.yml .github/workflows/airo-tv-release.yml
+          ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "ok #{f}" }' \
+            .github/workflows/v2-release-orchestrator.yml \
+            .github/workflows/airo-tv-release.yml \
+            .github/workflows/airo-mobile-tablet-release.yml
           python3 -m py_compile scripts/check-build-profiles.py scripts/generate-release-manifest.py scripts/generate-release-qualification-report.py
           scripts/check-build-profiles.py
           scripts/test-generate-release-manifest.sh
@@ -164,7 +167,10 @@ jobs:
       - name: Validate dependency profile constraints
         run: |
           chmod +x scripts/check-build-profiles.py scripts/check-variant-pubspecs.sh scripts/generate-release-manifest.py scripts/test-generate-release-manifest.sh scripts/generate-release-qualification-report.py scripts/test-generate-release-qualification-report.sh
-          ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "ok #{f}" }' .github/workflows/v2-release-orchestrator.yml .github/workflows/airo-tv-release.yml
+          ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "ok #{f}" }' \
+            .github/workflows/v2-release-orchestrator.yml \
+            .github/workflows/airo-tv-release.yml \
+            .github/workflows/airo-mobile-tablet-release.yml
           python3 -m py_compile scripts/check-build-profiles.py scripts/generate-release-manifest.py scripts/generate-release-qualification-report.py
           scripts/check-build-profiles.py
           scripts/check-variant-pubspecs.sh

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -66,7 +66,10 @@ jobs:
       - name: Validate platform build profiles
         run: |
           chmod +x scripts/check-build-profiles.py scripts/generate-release-manifest.py scripts/test-generate-release-manifest.sh scripts/generate-release-qualification-report.py scripts/test-generate-release-qualification-report.sh
-          ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "ok #{f}" }' .github/workflows/v2-release-orchestrator.yml .github/workflows/airo-tv-release.yml
+          ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "ok #{f}" }' \
+            .github/workflows/v2-release-orchestrator.yml \
+            .github/workflows/airo-tv-release.yml \
+            .github/workflows/airo-mobile-tablet-release.yml
           python3 -m py_compile scripts/check-build-profiles.py scripts/generate-release-manifest.py scripts/generate-release-qualification-report.py
           scripts/check-build-profiles.py
           scripts/test-generate-release-manifest.sh

--- a/.github/workflows/v2-release-orchestrator.yml
+++ b/.github/workflows/v2-release-orchestrator.yml
@@ -52,7 +52,7 @@ on:
           - alpha
           - beta
       mobile_profile:
-        description: 'Optional mobile/tablet profile; build automation is tracked in #677'
+        description: 'Optional mobile/tablet profile to build'
         required: true
         default: none
         type: choice
@@ -195,7 +195,8 @@ jobs:
         run: |
           ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "ok #{f}" }' \
             .github/workflows/v2-release-orchestrator.yml \
-            .github/workflows/airo-tv-release.yml
+            .github/workflows/airo-tv-release.yml \
+            .github/workflows/airo-mobile-tablet-release.yml
           python3 -m py_compile \
             scripts/check-build-profiles.py \
             scripts/generate-release-manifest.py \
@@ -204,23 +205,21 @@ jobs:
           scripts/test-generate-release-manifest.sh
           scripts/test-generate-release-qualification-report.sh
 
-  mobile-tablet-status:
+  mobile-tablet-release:
     name: Mobile and tablet release leg
-    runs-on: ubuntu-latest
-    needs: [prepare]
-    steps:
-      - name: Report mobile/tablet release status
-        env:
-          MOBILE_PROFILE: ${{ needs.prepare.outputs.mobile_profile }}
-        run: |
-          if [ "$MOBILE_PROFILE" = "none" ]; then
-            echo "Mobile/tablet release build is not selected for this orchestrator run." >> "$GITHUB_STEP_SUMMARY"
-            echo "Mobile/tablet publish automation remains tracked by #677." >> "$GITHUB_STEP_SUMMARY"
-            exit 0
-          fi
-
-          echo "::error::Mobile/tablet profile '$MOBILE_PROFILE' was selected, but publishable APK/AAB automation is tracked by #677 and is not enabled yet."
-          exit 1
+    if: needs.prepare.outputs.mobile_profile != 'none'
+    needs: [prepare, release-contracts]
+    permissions:
+      contents: read
+    uses: ./.github/workflows/airo-mobile-tablet-release.yml
+    with:
+      profile: ${{ needs.prepare.outputs.mobile_profile }}
+      version: ${{ needs.prepare.outputs.version }}
+      build_name: ${{ needs.prepare.outputs.build_name }}
+      build_number: ${{ needs.prepare.outputs.build_number }}
+      release_ref: ${{ needs.prepare.outputs.release_ref }}
+      production_signing: ${{ needs.prepare.outputs.production_signing == 'true' }}
+    secrets: inherit
 
   tv-release:
     name: TV release leg
@@ -243,14 +242,13 @@ jobs:
   release-summary:
     name: V2 release summary
     runs-on: ubuntu-latest
-    needs: [prepare, release-contracts, mobile-tablet-status, tv-release]
+    needs: [prepare, release-contracts, mobile-tablet-release, tv-release]
     if: always()
     permissions:
       actions: read
       contents: read
     steps:
       - uses: actions/checkout@v7
-        if: needs.tv-release.result == 'success'
         with:
           ref: ${{ needs.prepare.outputs.release_ref }}
 
@@ -261,6 +259,13 @@ jobs:
           name: airo-tv-release-${{ needs.prepare.outputs.version }}
           path: release-artifacts/tv
 
+      - name: Download mobile/tablet release artifacts
+        if: needs.mobile-tablet-release.result == 'success'
+        uses: actions/download-artifact@v8
+        with:
+          name: airo-mobile-tablet-${{ needs.prepare.outputs.mobile_profile }}-${{ needs.prepare.outputs.version }}
+          path: release-artifacts/mobile-tablet
+
       - name: Generate TV qualification report
         if: needs.tv-release.result == 'success'
         env:
@@ -269,6 +274,20 @@ jobs:
           manifest="$(find release-artifacts/tv -maxdepth 1 -name '*Release-Manifest.json' | head -n 1)"
           if [ -z "$manifest" ]; then
             echo "::error::TV release manifest was not found in downloaded artifacts."
+            exit 1
+          fi
+          scripts/generate-release-qualification-report.py \
+            --manifest "$manifest" \
+            --mode "$QUALIFICATION_MODE"
+
+      - name: Generate mobile/tablet qualification report
+        if: needs.mobile-tablet-release.result == 'success'
+        env:
+          QUALIFICATION_MODE: ${{ needs.prepare.outputs.qualification_mode }}
+        run: |
+          manifest="$(find release-artifacts/mobile-tablet -maxdepth 1 -name '*Release-Manifest.json' | head -n 1)"
+          if [ -z "$manifest" ]; then
+            echo "::error::Mobile/tablet release manifest was not found in downloaded artifacts."
             exit 1
           fi
           scripts/generate-release-qualification-report.py \
@@ -291,7 +310,8 @@ jobs:
           RELEASE_REF: ${{ needs.prepare.outputs.release_ref }}
           DRY_RUN: ${{ needs.prepare.outputs.dry_run }}
           TV_RESULT: ${{ needs.tv-release.result }}
-          MOBILE_RESULT: ${{ needs.mobile-tablet-status.result }}
+          MOBILE_RESULT: ${{ needs.mobile-tablet-release.result }}
+          MOBILE_PROFILE: ${{ needs.prepare.outputs.mobile_profile }}
           CONTRACT_RESULT: ${{ needs.release-contracts.result }}
         run: |
           {
@@ -305,6 +325,7 @@ jobs:
             echo "| Release ref | $RELEASE_REF |"
             echo "| Dry run | $DRY_RUN |"
             echo "| TV leg | $TV_RESULT |"
+            echo "| Mobile/tablet profile | $MOBILE_PROFILE |"
             echo "| Mobile/tablet leg | $MOBILE_RESULT |"
             echo "| Release contracts | $CONTRACT_RESULT |"
             echo ""
@@ -324,10 +345,26 @@ jobs:
             echo "TV artifacts were not available because the TV leg result was $TV_RESULT." >> "$GITHUB_STEP_SUMMARY"
           fi
 
+          if [ -d release-artifacts/mobile-tablet ]; then
+            {
+              echo ""
+              echo "### Mobile/tablet"
+              echo ""
+              find release-artifacts/mobile-tablet -maxdepth 1 -type f -printf '- %f\n' | sort
+              echo ""
+              echo "Mobile/tablet artifacts include APK/AAB files, SHA256SUMS, release manifest, and an internal qualification report when generated by this orchestrator."
+            } >> "$GITHUB_STEP_SUMMARY"
+          elif [ "$MOBILE_PROFILE" = "none" ]; then
+            echo "Mobile/tablet artifacts were not requested for this orchestrator run." >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "Mobile/tablet artifacts were not available because the mobile/tablet leg result was $MOBILE_RESULT." >> "$GITHUB_STEP_SUMMARY"
+          fi
+
       - name: Enforce orchestrator result
         env:
           TV_RESULT: ${{ needs.tv-release.result }}
-          MOBILE_RESULT: ${{ needs.mobile-tablet-status.result }}
+          MOBILE_RESULT: ${{ needs.mobile-tablet-release.result }}
+          MOBILE_PROFILE: ${{ needs.prepare.outputs.mobile_profile }}
           CONTRACT_RESULT: ${{ needs.release-contracts.result }}
         run: |
           if [ "$CONTRACT_RESULT" != "success" ]; then
@@ -338,7 +375,7 @@ jobs:
             echo "::error::TV release leg did not pass: $TV_RESULT"
             exit 1
           fi
-          if [ "$MOBILE_RESULT" != "success" ]; then
+          if [ "$MOBILE_PROFILE" != "none" ] && [ "$MOBILE_RESULT" != "success" ]; then
             echo "::error::Mobile/tablet release leg did not pass: $MOBILE_RESULT"
             exit 1
           fi

--- a/docs/release/STORE_COMPLIANCE.md
+++ b/docs/release/STORE_COMPLIANCE.md
@@ -24,8 +24,8 @@ The current v2 profile matrix is maintained in
 | Profile | Package ID | Device class | Entrypoint | Store status |
 | --- | --- | --- | --- | --- |
 | `tv` | `io.airo.app.tv` | Android TV, Google TV, Fire TV-compatible APK testing | `app/lib/main_tv.dart` | TV release workflow builds APK and Play AAB; real Play upload needs #585/#681 setup |
-| `iptv-standalone` | `io.airo.app.iptv` | Android phone and tablet IPTV-only builds | `app/lib/main_airo_iptv.dart` | Build/publish automation tracked in #677 |
-| `mobile-streaming` | `io.airo.app.streaming` | Android phone and tablet streaming builds | `app/lib/main_mobile_streaming.dart` | Build/publish automation tracked in #677 |
+| `iptv-standalone` | `io.airo.app.iptv` | Android phone and tablet IPTV-only builds | `app/lib/main_airo_iptv.dart` | Mobile/tablet release workflow builds APK and Play AAB; real publish setup needs #585/#681/#682 |
+| `mobile-streaming` | `io.airo.app.streaming` | Android phone and tablet streaming builds | `app/lib/main_mobile_streaming.dart` | Mobile/tablet release workflow builds APK and Play AAB; real publish setup needs #585/#681/#682 |
 | `ios-spm` | `com.developerscoffee.airo` | iOS/iPadOS validation profile | `app/lib/main.dart` | Deferred from the first v2 Android publishing wave |
 
 The Android Gradle config currently uses:
@@ -83,7 +83,7 @@ and AI Core bind-service permissions inherited from broader dependencies.
 | Play service account JSON stored as GitHub secret | Pending | #585, #681 |
 | Production Android signing secrets stored in GitHub | Pending | #585, #677 |
 | AAB build for TV | Ready in CI | `.github/workflows/airo-tv-release.yml` |
-| AAB build for mobile/tablet | Pending | #677 |
+| AAB build for mobile/tablet | Ready in CI for selected v2 profile | `.github/workflows/airo-mobile-tablet-release.yml` |
 | IARC content rating completed | Pending store-console action | #584 |
 | Data Safety form completed | Pending store-console action | #584/#581 |
 | Store metadata finalized | Pending | #581 |
@@ -139,7 +139,7 @@ Before submitting a public v2 Android release:
 - #584: IARC/content rating and App Store age-rating questionnaires.
 - #585: Fastlane/store credentials and signing setup.
 - #675: supported v2 device/profile artifact matrix.
-- #677: mobile/tablet APK and AAB build/publish workflow.
+- #677: mobile/tablet APK and AAB build workflow.
 - #681: Google Play upload automation.
 - #682: Firebase App Distribution upload automation.
 - #683: release qualification matrix and evidence.

--- a/docs/release/V2_DISTRIBUTION_MATRIX.md
+++ b/docs/release/V2_DISTRIBUTION_MATRIX.md
@@ -10,8 +10,8 @@ Implementation work for these profiles must start from latest `origin/v2`.
 
 | Profile | Package ID | Entrypoint | Pubspec | Device class | Release artifacts | Distribution |
 | --- | --- | --- | --- | --- | --- | --- |
-| `iptv-standalone` | `io.airo.app.iptv` | `app/lib/main_airo_iptv.dart` | `app/pubspec_iptv.yaml` | Android phone and tablet IPTV-only builds | APK, AAB once store publishing is enabled | GitHub Release, Firebase App Distribution, Play track after credentials |
-| `mobile-streaming` | `io.airo.app.streaming` | `app/lib/main_mobile_streaming.dart` | `app/pubspec_streaming.yaml` | Android phone and tablet streaming builds | APK, AAB once store publishing is enabled | GitHub Release, Firebase App Distribution, Play track after credentials |
+| `iptv-standalone` | `io.airo.app.iptv` | `app/lib/main_airo_iptv.dart` | `app/pubspec_iptv.yaml` | Android phone and tablet IPTV-only builds | APK, Play Store AAB | GitHub Release evidence, Firebase App Distribution, Play track after credentials |
+| `mobile-streaming` | `io.airo.app.streaming` | `app/lib/main_mobile_streaming.dart` | `app/pubspec_streaming.yaml` | Android phone and tablet streaming builds | APK, Play Store AAB | GitHub Release evidence, Firebase App Distribution, Play track after credentials |
 | `tv` | `io.airo.app.tv` | `app/lib/main_tv.dart` | `app/pubspec_tv.yaml` | Android TV, Google TV, Fire TV-compatible APK testing | APK, Play Store AAB | GitHub Release, Firebase App Distribution where supported, Play TV track after credentials |
 | `ios-spm` | `com.developerscoffee.airo` | `app/lib/main.dart` | `app/pubspec_ios_spm.yaml` | iOS/iPadOS validation profile | Deferred | Not part of the first v2 Android publishing wave |
 | `web-validation` | `web` | `app/lib/main_airo_iptv.dart` | `app/pubspec.yaml` | Browser validation only | Deferred | Local validation only |

--- a/docs/release/V2_PUBLISHING_HUMAN_SETUP.md
+++ b/docs/release/V2_PUBLISHING_HUMAN_SETUP.md
@@ -13,7 +13,9 @@ production publishing cannot be verified without them.
 Related issues: #681, #585, #657.
 
 - [ ] Create or confirm the Play Console app for each public v2 package ID.
-- [ ] Confirm package IDs for mobile/tablet and TV.
+- [x] Confirm package IDs for mobile/tablet and TV:
+      `io.airo.app`, `io.airo.app.iptv`, `io.airo.app.streaming`, and
+      `io.airo.app.tv`.
 - [ ] Decide whether mobile and tablet share one adaptive listing or use
       separate listings.
 - [ ] Create a Play service account for release automation.
@@ -30,7 +32,8 @@ Related issues: #682, #574.
 
 - [ ] Create or confirm Firebase apps for each package ID that should receive
       internal APKs.
-- [ ] Add or confirm the Firebase Android client config for the TV package.
+- [ ] Add or confirm Firebase Android client configs for the registered
+      `io.airo.app.*` packages that should use Firebase services.
 - [ ] Create a Firebase service account or distribution token for CI.
 - [ ] Store the Firebase credential as a GitHub Actions secret.
 - [ ] Create tester groups for mobile/tablet QA and TV QA.
@@ -67,8 +70,8 @@ Related issues: #675, #685, #647, #657.
 
 Related issues: #687, #689.
 
-- [ ] Choose the root project license.
-- [ ] Add the root `LICENSE` after the license is chosen.
+- [x] Choose the root project license.
+- [x] Add the root `LICENSE` after the license is chosen.
 - [ ] Confirm whether any private or commercial dependencies are bundled in v2
       release profiles.
 - [ ] Resolve the open items in

--- a/docs/release/V2_RELEASE_ORCHESTRATOR.md
+++ b/docs/release/V2_RELEASE_ORCHESTRATOR.md
@@ -18,29 +18,36 @@ artifacts without creating public GitHub Releases or uploading to Google Play.
 ## Current Scope
 
 The orchestrator currently validates the release contract, calls the existing
-Airo TV release workflow through `workflow_call`, downloads the TV artifacts,
-generates the top-level evidence bundle, and writes the release summary.
+Airo TV release workflow through `workflow_call`, optionally calls the
+mobile/tablet release workflow when a mobile profile is selected, downloads the
+selected profile artifacts, generates the top-level evidence bundle, and writes
+the release summary.
 
 The TV leg reuses `.github/workflows/airo-tv-release.yml` so package checks,
 Leanback validation, release artifact naming, checksums, manifest generation,
 debug-symbol retention, optional GitHub Release publication, and optional Play
 track upload remain owned by the TV workflow.
 
-Mobile/tablet publishing is intentionally not enabled yet. Selecting
-`iptv-standalone` or `mobile-streaming` in the orchestrator fails with a pointer
-to #677 until signed APK/AAB jobs and store/Firebase destinations are ready.
+When `mobile_profile` is `iptv-standalone` or `mobile-streaming`, the
+orchestrator calls `.github/workflows/airo-mobile-tablet-release.yml` to build
+the selected profile's APK and Play Store AAB, generate `SHA256SUMS`, write a
+release manifest, retain obfuscation symbols, and contribute mobile/tablet
+qualification evidence. Real store or Firebase publication still depends on
+the credential and destination setup tracked in #681 and #682.
 
 ## Release Evidence
 
-Successful TV orchestrator runs upload:
+Successful orchestrator runs upload:
 
 - `airo-tv-release-<version>` from the TV workflow;
+- `airo-mobile-tablet-<profile>-<version>` from the mobile/tablet workflow when
+  `mobile_profile` is not `none`;
 - `v2-release-evidence-<version>` from the orchestrator.
 
-The top-level evidence bundle includes TV artifacts, `SHA256SUMS`, the release
-manifest, and a qualification report generated from the manifest. Public
-qualification mode fails when required device evidence or an approved waiver is
-missing.
+The top-level evidence bundle includes selected profile artifacts,
+`SHA256SUMS`, release manifests, and qualification reports generated from the
+manifests. Public qualification mode fails when required device evidence or an
+approved waiver is missing.
 
 ## Public Publishing Controls
 
@@ -60,5 +67,6 @@ off and sets the TV Play track to `none`.
 - Whether public releases should publish immediately or always start as draft
   GitHub Releases.
 - Whether optional channels should block the whole release or report warnings.
-- Mobile/tablet package IDs, Firebase apps, Play tracks, and release signing
-  secrets for #677, #681, and #682.
+- Mobile/tablet Firebase apps, Play tracks, release signing secrets, and upload
+  credentials for #681 and #682. Package IDs are registered under
+  `io.airo.app.*`.


### PR DESCRIPTION
# Summary

This PR adds the v2 mobile/tablet release artifact workflow for issue #677.

Goal: produce signed-mode-gated APK/AAB artifacts for the selected v2 mobile/tablet profile and wire that leg into the v2 release orchestrator.

Core outcome:

* Builds `iptv-standalone` or `mobile-streaming` APK plus Play Store AAB from a ref that contains latest `origin/v2`.
* Produces final artifact names, `SHA256SUMS`, release manifest JSON, qualification evidence, and obfuscation symbol artifacts.
* Fails production mode when Android signing or Firebase client config is missing.
* Keeps real Google Play and Firebase upload destination work in #681 and #682.

# Changes

### Code

* Added:
  * `.github/workflows/airo-mobile-tablet-release.yml`
* Updated:
  * `.github/workflows/v2-release-orchestrator.yml` to call the selected mobile/tablet profile leg and collect evidence.
  * `.github/workflows/ci.yml` and `.github/workflows/pr-checks.yml` to validate the new workflow YAML.
  * Release docs to reflect registered `io.airo.app.*` package IDs and remaining credential/account setup.

### Logic

* Validates release refs contain latest `origin/v2` before building.
* Resolves profile-specific entrypoints, pubspecs, Dart defines, package IDs, and artifact prefixes.
* Uses placeholder Firebase/signing only for non-production validation builds.
* Requires real Firebase JSON and release signing secrets for production-signed runs.

# Risks

* The reusable workflow has been locally YAML/script validated, but the full Android APK/AAB build should be proven by GitHub Actions on this PR or by a manual dry-run after merge.
* Real Play/Firebase publishing remains blocked on human-provided credentials and destinations tracked in #681/#682/#585.

# Testing

* Ruby YAML parse for orchestrator, TV, mobile/tablet, CI, and PR workflows.
* `python3 -m py_compile` for release manifest/profile/qualification scripts.
* `scripts/check-build-profiles.py`
* `scripts/test-generate-release-manifest.sh`
* `scripts/test-generate-release-qualification-report.sh`
* `scripts/check-variant-pubspecs.sh`
* `git diff --check` and `git diff --cached --check`

Closes #677
