### PR TITLE
docs(legal): finalize v2 license notices

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Download Airo TV](https://img.shields.io/badge/Download-Airo%20TV-success)](https://github.com/DevelopersCoffee/airo/releases/download/airo-tv-v0.0.2/Airo-TV-v0.0.2.apk)
 [![GitHub Release](https://img.shields.io/github/v/release/DevelopersCoffee/airo)](https://github.com/DevelopersCoffee/airo/releases)
 [![Flutter](https://img.shields.io/badge/Flutter-3.44.4+-blue.svg)](https://flutter.dev/)
-[![License: pending](https://img.shields.io/badge/license-pending-lightgrey)](#license)
+[![License: MIT](https://img.shields.io/badge/license-MIT-green)](LICENSE)
 [![Security Policy](https://img.shields.io/badge/security-policy-brightgreen)](SECURITY.md)
 [![Trust](https://img.shields.io/badge/trust-transparent-brightgreen)](TRUST.md)
 [![Versioning](https://img.shields.io/badge/versioning-semver-blue)](CHANGELOG.md)
@@ -253,10 +253,9 @@ cd ../airo-my-v2-task
 
 ## License
 
-The repository currently has public docs that reference MIT licensing, but the
-root `LICENSE` file is not present and package license files still need maintainer
-confirmation. Treat the license as **pending** until maintainers add the confirmed
-root license file.
+Airo is licensed under the [MIT License](LICENSE).
 
-If you plan to reuse code outside this repository, wait for the license cleanup or
-ask in a GitHub issue first.
+V2 release profiles also include third-party dependencies with their own
+licenses. See [V2 Third-Party Notices](docs/release/V2_THIRD_PARTY_NOTICES.md)
+and [V2 License Review](docs/release/V2_LICENSE_REVIEW.md) before public
+redistribution.

--- a/docs/release/README.md
+++ b/docs/release/README.md
@@ -48,6 +48,7 @@ Documentation for Airo releases and version history.
 | [V2 Distribution Matrix](./V2_DISTRIBUTION_MATRIX.md) | Supported v2 profiles, artifact naming, channels, and support policy |
 | [V2 Publishing Human Setup](./V2_PUBLISHING_HUMAN_SETUP.md) | Account, credential, signing, store, and governance decisions maintainers must complete |
 | [V2 License Review](./V2_LICENSE_REVIEW.md) | License-readiness baseline and maintainer decisions before public distribution |
+| [V2 Third-Party Notices](./V2_THIRD_PARTY_NOTICES.md) | Third-party notices for v2 Android release profiles |
 | [V2 Release Qualification](./V2_RELEASE_QUALIFICATION.md) | Required release evidence, device matrix, waiver behavior, and qualification report format |
 | [V2 Release Orchestrator](./V2_RELEASE_ORCHESTRATOR.md) | Top-level v2 release workflow, dry-run behavior, TV workflow reuse, and remaining publishing blockers |
 | [Download Verification](../../VERIFY_DOWNLOAD.md) | SHA256 verification and safe direct APK install guidance |

--- a/docs/release/V2_LICENSE_REVIEW.md
+++ b/docs/release/V2_LICENSE_REVIEW.md
@@ -1,7 +1,7 @@
 # V2 License Review
 
 This document records the current license-readiness baseline for the v2 Android
-publishing wave. It does not choose the project license.
+publishing wave.
 
 Implementation work for this release line must start from latest `origin/v2`.
 
@@ -9,10 +9,10 @@ Implementation work for this release line must start from latest `origin/v2`.
 
 | Area | Status | Notes |
 | --- | --- | --- |
-| Root `LICENSE` | Blocked | No root license file is present. Maintainers must choose the project license before public reuse or broad distribution guidance is final. |
-| README license badge | Pending | README intentionally marks the repository license as pending. |
-| Internal package license files | Blocked | Package `LICENSE` files currently contain `TODO: Add your license here.` and must be replaced after the root license is chosen. |
-| Vendored Cast library | Identified | `packages/platform_player/third_party/flutter_chrome_cast` declares BSD-3-Clause. Preserve its copyright and license notice in source and binary notices. |
+| Root `LICENSE` | Ready | Root project license is MIT. |
+| README license badge | Ready | README links to the root MIT license. |
+| Internal package license files | Ready | Airo-owned package `LICENSE` files use the root MIT license text. |
+| Vendored Cast library | Documented | `packages/platform_player/third_party/flutter_chrome_cast` declares BSD-3-Clause. Its notice is recorded in `docs/release/V2_THIRD_PARTY_NOTICES.md`. |
 | Private/commercial dependencies | Unknown | Maintainers must confirm whether any private or commercial dependency is bundled in release builds. |
 
 ## V2 Release Profiles Reviewed
@@ -105,13 +105,10 @@ distribution:
 
 ## Required Before Public Distribution
 
-- Choose and add the root project `LICENSE`.
-- Replace package-level `TODO` license files with the approved license text or
-  remove them in favor of the root license policy if maintainers choose that
-  structure.
-- Generate third-party notices for the exact APK/AAB dependency graph produced
-  by each public profile.
-- Include the vendored Cast library BSD-3-Clause notice in third-party notices.
+- Keep the root MIT `LICENSE` and package license files aligned.
+- Keep `docs/release/V2_THIRD_PARTY_NOTICES.md` with the release asset set.
+- Regenerate or re-check third-party notices when v2 release profile
+  dependencies change.
 - Confirm whether any private, commercial, gated, or restricted-license
   dependency is bundled in each release artifact.
 - Confirm that Play Store, direct APK, and any other listing text matches the
@@ -119,9 +116,6 @@ distribution:
 
 ## Human Decisions Still Needed
 
-- Root project license.
-- Whether package-level license files should duplicate the root license or be
-  replaced by a single root `LICENSE` plus notices.
 - Whether SHA256-only release provenance is sufficient for the first v2 wave or
   whether signed/SLSA provenance is required.
 - Whether any private/commercial dependency is present in v2 release artifacts.

--- a/docs/release/V2_PUBLISHING_HUMAN_SETUP.md
+++ b/docs/release/V2_PUBLISHING_HUMAN_SETUP.md
@@ -72,6 +72,8 @@ Related issues: #687, #689.
 
 - [x] Choose the root project license.
 - [x] Add the root `LICENSE` after the license is chosen.
+- [x] Replace Airo-owned package placeholder license files.
+- [x] Document v2 third-party notices for the current release profiles.
 - [ ] Confirm whether any private or commercial dependencies are bundled in v2
       release profiles.
 - [ ] Resolve the open items in

--- a/docs/release/V2_THIRD_PARTY_NOTICES.md
+++ b/docs/release/V2_THIRD_PARTY_NOTICES.md
@@ -1,0 +1,119 @@
+# V2 Third-Party Notices
+
+This document records third-party notice obligations for the current v2 Android
+release profiles:
+
+- `iptv-standalone`
+- `mobile-streaming`
+- `tv`
+
+The profile matrix is maintained in `docs/release/V2_DISTRIBUTION_MATRIX.md`
+and `.github/airo-build-profiles.json`.
+
+## Project License
+
+Airo-owned source code is licensed under the root MIT `LICENSE`.
+
+## Vendored Source
+
+### flutter_chrome_cast
+
+- Path: `packages/platform_player/third_party/flutter_chrome_cast`
+- Declared license: BSD-3-Clause
+- Repository: `https://github.com/felnanuke2/flutter_google_cast`
+- Used by: Cast discovery/session/control support in v2 Android profiles
+
+BSD-3-Clause notice:
+
+```text
+Copyright 2023 felnanuke2
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors
+   may be used to endorse or promote products derived from this software
+   without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+```
+
+## Direct Release Dependency Surface
+
+The current v2 release-profile pubspecs include these direct dependency names.
+Transitive dependency notices should be regenerated if the lockfile or profile
+pubspecs change before a public release.
+
+```text
+audio_service
+audioplayers
+cached_network_image
+connectivity_plus
+core_ai
+core_auth
+core_data
+core_domain
+core_ui
+cupertino_icons
+dio
+drift
+equatable
+feature_iptv
+file_picker
+firebase_auth
+firebase_core
+flame
+flutter
+flutter_chrome_cast
+flutter_contacts
+flutter_image_compress
+flutter_local_notifications
+flutter_riverpod
+flutter_tts
+go_router
+google_mlkit_text_recognition
+google_sign_in
+hive
+hive_flutter
+image_picker
+intl
+just_audio
+package_info_plus
+path
+path_provider
+pdfx
+permission_handler
+riverpod
+rxdart
+share_plus
+shared_preferences
+sqlite3_flutter_libs
+stockfish
+timezone
+url_launcher
+uuid
+video_player
+wakelock_plus
+```
+
+## Release Gate
+
+Before public distribution, maintainers must confirm whether any private,
+commercial, gated, or restricted-license dependency is bundled in the final
+APK/AAB artifacts.

--- a/docs/wiki/9.-Useful-Links.md
+++ b/docs/wiki/9.-Useful-Links.md
@@ -8,6 +8,8 @@
 - [Main documentation](../README.md)
 - [Download verification](../../VERIFY_DOWNLOAD.md)
 - [Trust and transparency](../../TRUST.md)
+- [MIT license](../../LICENSE)
+- [V2 third-party notices](../release/V2_THIRD_PARTY_NOTICES.md)
 - [Product strategy](../PRODUCT_STRATEGY.md)
 - [Technical architecture](../architecture/TECHNICAL_ARCHITECTURE.md)
 - [Games documentation](../games/README.md)

--- a/packages/airo/LICENSE
+++ b/packages/airo/LICENSE
@@ -1,1 +1,21 @@
-TODO: Add your license here.
+MIT License
+
+Copyright (c) 2025-present DevelopersCoffee
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/airomoney/LICENSE
+++ b/packages/airomoney/LICENSE
@@ -1,1 +1,21 @@
-TODO: Add your license here.
+MIT License
+
+Copyright (c) 2025-present DevelopersCoffee
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/core_ai/LICENSE
+++ b/packages/core_ai/LICENSE
@@ -1,1 +1,21 @@
-TODO: Add your license here.
+MIT License
+
+Copyright (c) 2025-present DevelopersCoffee
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/core_auth/LICENSE
+++ b/packages/core_auth/LICENSE
@@ -1,1 +1,21 @@
-TODO: Add your license here.
+MIT License
+
+Copyright (c) 2025-present DevelopersCoffee
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/core_data/LICENSE
+++ b/packages/core_data/LICENSE
@@ -1,1 +1,21 @@
-TODO: Add your license here.
+MIT License
+
+Copyright (c) 2025-present DevelopersCoffee
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/core_domain/LICENSE
+++ b/packages/core_domain/LICENSE
@@ -1,1 +1,21 @@
-TODO: Add your license here.
+MIT License
+
+Copyright (c) 2025-present DevelopersCoffee
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/core_ui/LICENSE
+++ b/packages/core_ui/LICENSE
@@ -1,1 +1,21 @@
-TODO: Add your license here.
+MIT License
+
+Copyright (c) 2025-present DevelopersCoffee
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/feature_iptv/LICENSE
+++ b/packages/feature_iptv/LICENSE
@@ -1,1 +1,21 @@
-TODO: Add your license here.
+MIT License
+
+Copyright (c) 2025-present DevelopersCoffee
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/platform_channels/LICENSE
+++ b/packages/platform_channels/LICENSE
@@ -1,1 +1,21 @@
-TODO: Add your license here.
+MIT License
+
+Copyright (c) 2025-present DevelopersCoffee
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/platform_epg/LICENSE
+++ b/packages/platform_epg/LICENSE
@@ -1,1 +1,21 @@
-TODO: Add your license here.
+MIT License
+
+Copyright (c) 2025-present DevelopersCoffee
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/platform_favorites/LICENSE
+++ b/packages/platform_favorites/LICENSE
@@ -1,1 +1,21 @@
-TODO: Add your license here.
+MIT License
+
+Copyright (c) 2025-present DevelopersCoffee
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/platform_history/LICENSE
+++ b/packages/platform_history/LICENSE
@@ -1,1 +1,21 @@
-TODO: Add your license here.
+MIT License
+
+Copyright (c) 2025-present DevelopersCoffee
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/platform_media/LICENSE
+++ b/packages/platform_media/LICENSE
@@ -1,1 +1,21 @@
-TODO: Add your license here.
+MIT License
+
+Copyright (c) 2025-present DevelopersCoffee
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/platform_player/LICENSE
+++ b/packages/platform_player/LICENSE
@@ -1,1 +1,21 @@
-TODO: Add your license here.
+MIT License
+
+Copyright (c) 2025-present DevelopersCoffee
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/platform_playlist/LICENSE
+++ b/packages/platform_playlist/LICENSE
@@ -1,1 +1,21 @@
-TODO: Add your license here.
+MIT License
+
+Copyright (c) 2025-present DevelopersCoffee
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/platform_playlist_export/LICENSE
+++ b/packages/platform_playlist_export/LICENSE
@@ -1,1 +1,21 @@
-TODO: Add your license here.
+MIT License
+
+Copyright (c) 2025-present DevelopersCoffee
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/platform_playlist_import/LICENSE
+++ b/packages/platform_playlist_import/LICENSE
@@ -1,1 +1,21 @@
-TODO: Add your license here.
+MIT License
+
+Copyright (c) 2025-present DevelopersCoffee
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/platform_streams/LICENSE
+++ b/packages/platform_streams/LICENSE
@@ -1,1 +1,21 @@
-TODO: Add your license here.
+MIT License
+
+Copyright (c) 2025-present DevelopersCoffee
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
# Summary

This PR cleans up the v2 legal/release-readiness documentation after the root MIT license landed.

Goal: remove stale license-pending guidance and document current v2 third-party notice obligations.

Core outcome:

* README now advertises MIT and links to the root `LICENSE`.
* Airo-owned package `LICENSE` placeholders now use the root MIT text.
* `docs/release/V2_LICENSE_REVIEW.md` reflects the current ready/remaining state.
* `docs/release/V2_THIRD_PARTY_NOTICES.md` records the vendored `flutter_chrome_cast` BSD-3-Clause notice.
* Human setup checklist now marks package license cleanup and current notices as complete.

# Remaining Human Gate

This advances #687 but does not close it by itself unless maintainers confirm whether any private/commercial/gated dependency is bundled in the v2 release artifacts.

# Testing

* Confirmed no stale license-pending/root-license-missing references remain in README/docs/packages outside the vendored third-party tree.
* Confirmed all Airo-owned package `LICENSE` files match the root MIT `LICENSE`.
* `git diff --check`
* `git diff --cached --check`

Refs #687
