### PR TITLE
feat(release): add v2 Play upload track automation

### DIFF
--- a/.github/workflows/airo-mobile-tablet-release.yml
+++ b/.github/workflows/airo-mobile-tablet-release.yml
@@ -27,6 +27,10 @@ on:
         description: 'Require production Android signing and Firebase secrets'
         required: true
         type: boolean
+      play_track:
+        description: 'Optional Play upload track'
+        required: true
+        type: string
   workflow_dispatch:
     inputs:
       profile:
@@ -58,6 +62,17 @@ on:
         required: true
         default: false
         type: boolean
+      play_track:
+        description: 'Optional Play upload track'
+        required: true
+        default: none
+        type: choice
+        options:
+          - none
+          - internal
+          - alpha
+          - beta
+          - production
 
 concurrency:
   group: airo-mobile-tablet-release-${{ github.ref }}-${{ inputs.profile || github.event.inputs.profile || 'manual' }}
@@ -429,3 +444,95 @@ jobs:
           name: airo-mobile-tablet-debug-info-${{ env.PROFILE }}-${{ env.RELEASE_VERSION }}
           path: app/build/debug-info-${{ env.PROFILE }}/
           retention-days: 90
+
+  play-upload:
+    name: Upload mobile/tablet to Play testing track
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    needs: [prepare-release-ref, build-mobile-tablet]
+    if: (github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_call') && (inputs.play_track || github.event.inputs.play_track) != 'none'
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ needs.prepare-release-ref.outputs.release_sha }}
+
+      - name: Resolve mobile/tablet profile metadata
+        run: |
+          release_version="$(printf '%s' "$RELEASE_VERSION" | sed 's/[^A-Za-z0-9._-]/-/g')"
+          echo "RELEASE_VERSION=$release_version" >> "$GITHUB_ENV"
+
+          case "$PROFILE" in
+            iptv-standalone)
+              echo "PACKAGE_ID=io.airo.app.iptv" >> "$GITHUB_ENV"
+              echo "ARTIFACT_PREFIX=Airo-IPTV" >> "$GITHUB_ENV"
+              ;;
+            mobile-streaming)
+              echo "PACKAGE_ID=io.airo.app.streaming" >> "$GITHUB_ENV"
+              echo "ARTIFACT_PREFIX=Airo-Streaming" >> "$GITHUB_ENV"
+              ;;
+            *)
+              echo "::error::Unsupported mobile/tablet profile for Play upload: $PROFILE"
+              exit 1
+              ;;
+          esac
+
+      - name: Download release artifacts
+        uses: actions/download-artifact@v8
+        with:
+          name: airo-mobile-tablet-${{ env.PROFILE }}-${{ env.RELEASE_VERSION }}
+          path: release-artifacts
+
+      - name: Configure Play service account
+        env:
+          GOOGLE_PLAY_SERVICE_ACCOUNT_JSON: ${{ secrets.GOOGLE_PLAY_SERVICE_ACCOUNT_JSON }}
+        run: |
+          if [[ -z "$GOOGLE_PLAY_SERVICE_ACCOUNT_JSON" ]]; then
+            echo "::error::GOOGLE_PLAY_SERVICE_ACCOUNT_JSON is required to upload to Google Play."
+            exit 1
+          fi
+          echo "$GOOGLE_PLAY_SERVICE_ACCOUNT_JSON" > app/android/play-store-credentials.json
+          chmod 600 app/android/play-store-credentials.json
+
+      - name: Upload to Google Play
+        working-directory: app/android
+        env:
+          PLAY_TRACK: ${{ inputs.play_track || github.event.inputs.play_track }}
+          SUPPLY_JSON_KEY: play-store-credentials.json
+        run: |
+          aab_path="../../release-artifacts/${ARTIFACT_PREFIX}-${BUILD_NAME}-${BUILD_NUMBER}-Play-Store.aab"
+          if [[ -z "$PACKAGE_ID" ]]; then
+            echo "::error::PACKAGE_ID was not resolved for $PROFILE."
+            exit 1
+          fi
+          if [[ -z "$PLAY_TRACK" || "$PLAY_TRACK" == "none" ]]; then
+            echo "::error::A real Play track is required for mobile/tablet upload."
+            exit 1
+          fi
+          if [[ ! -f "$aab_path" ]]; then
+            echo "::error::Expected mobile/tablet AAB not found: $aab_path"
+            exit 1
+          fi
+
+          gem install fastlane --no-document
+          fastlane supply \
+            --aab "$aab_path" \
+            --track "$PLAY_TRACK" \
+            --package_name "$PACKAGE_ID" \
+            --json_key "$SUPPLY_JSON_KEY" \
+            --skip_upload_metadata true \
+            --skip_upload_images true \
+            --skip_upload_screenshots true
+
+          {
+            echo "# Mobile/tablet Play upload"
+            echo ""
+            echo "| Field | Value |"
+            echo "| --- | --- |"
+            echo "| Profile | $PROFILE |"
+            echo "| Package | $PACKAGE_ID |"
+            echo "| Track | $PLAY_TRACK |"
+            echo "| AAB | ${ARTIFACT_PREFIX}-${BUILD_NAME}-${BUILD_NUMBER}-Play-Store.aab |"
+            echo "| Play Console | https://play.google.com/console/u/0/developers/app/$PACKAGE_ID/tracks/$PLAY_TRACK |"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/airo-tv-release.yml
+++ b/.github/workflows/airo-tv-release.yml
@@ -91,6 +91,7 @@ on:
           - internal
           - alpha
           - beta
+          - production
 
 concurrency:
   group: airo-tv-release-${{ github.ref }}
@@ -467,18 +468,38 @@ jobs:
       - name: Upload to Google Play
         working-directory: app/android
         env:
+          PLAY_TRACK: ${{ inputs.play_track || github.event.inputs.play_track }}
           SUPPLY_PACKAGE_NAME: io.airo.app.tv
           SUPPLY_JSON_KEY: play-store-credentials.json
         run: |
+          if [[ -z "$SUPPLY_PACKAGE_NAME" ]]; then
+            echo "::error::SUPPLY_PACKAGE_NAME is required for TV Play upload."
+            exit 1
+          fi
+          if [[ -z "$PLAY_TRACK" || "$PLAY_TRACK" == "none" ]]; then
+            echo "::error::A real Play track is required for TV upload."
+            exit 1
+          fi
           gem install fastlane --no-document
           fastlane supply \
             --aab "../../release-artifacts/Airo-TV-${BUILD_NAME}-Play-Store.aab" \
-            --track "${{ inputs.play_track || github.event.inputs.play_track }}" \
+            --track "$PLAY_TRACK" \
             --package_name "$SUPPLY_PACKAGE_NAME" \
             --json_key "$SUPPLY_JSON_KEY" \
             --skip_upload_metadata true \
             --skip_upload_images true \
             --skip_upload_screenshots true
+
+          {
+            echo "# TV Play upload"
+            echo ""
+            echo "| Field | Value |"
+            echo "| --- | --- |"
+            echo "| Package | $SUPPLY_PACKAGE_NAME |"
+            echo "| Track | $PLAY_TRACK |"
+            echo "| AAB | Airo-TV-${BUILD_NAME}-Play-Store.aab |"
+            echo "| Play Console | https://play.google.com/console/u/0/developers/app/$SUPPLY_PACKAGE_NAME/tracks/$PLAY_TRACK |"
+          } >> "$GITHUB_STEP_SUMMARY"
 
   github-release:
     name: Publish GitHub release

--- a/.github/workflows/v2-release-orchestrator.yml
+++ b/.github/workflows/v2-release-orchestrator.yml
@@ -59,6 +59,18 @@ on:
           - internal
           - alpha
           - beta
+          - production
+      mobile_play_track:
+        description: 'Optional mobile/tablet Play upload track when dry_run is false'
+        required: true
+        default: none
+        type: choice
+        options:
+          - none
+          - internal
+          - alpha
+          - beta
+          - production
       mobile_profile:
         description: 'Optional mobile/tablet profile to build'
         required: true
@@ -104,6 +116,7 @@ jobs:
       github_release_mode: ${{ steps.release.outputs.github_release_mode }}
       production_signing: ${{ steps.release.outputs.production_signing }}
       tv_play_track: ${{ steps.release.outputs.tv_play_track }}
+      mobile_play_track: ${{ steps.release.outputs.mobile_play_track }}
       mobile_profile: ${{ steps.release.outputs.mobile_profile }}
       qualification_mode: ${{ steps.release.outputs.qualification_mode }}
     steps:
@@ -125,6 +138,7 @@ jobs:
           INPUT_GITHUB_RELEASE_MODE: ${{ inputs.github_release_mode }}
           INPUT_PRODUCTION_SIGNING: ${{ inputs.production_signing }}
           INPUT_TV_PLAY_TRACK: ${{ inputs.tv_play_track }}
+          INPUT_MOBILE_PLAY_TRACK: ${{ inputs.mobile_play_track }}
           INPUT_MOBILE_PROFILE: ${{ inputs.mobile_profile }}
           INPUT_QUALIFICATION_MODE: ${{ inputs.qualification_mode }}
         run: |
@@ -140,12 +154,35 @@ jobs:
           github_release_mode="${INPUT_GITHUB_RELEASE_MODE:-draft}"
           production_signing="${INPUT_PRODUCTION_SIGNING:-false}"
           tv_play_track="${INPUT_TV_PLAY_TRACK:-none}"
+          mobile_play_track="${INPUT_MOBILE_PLAY_TRACK:-none}"
           mobile_profile="${INPUT_MOBILE_PROFILE:-none}"
           qualification_mode="${INPUT_QUALIFICATION_MODE:-internal}"
 
           if [ "$dry_run" = "true" ]; then
             publish_github_release="false"
             tv_play_track="none"
+            mobile_play_track="none"
+          fi
+
+          case "$tv_play_track" in
+            none|internal|alpha|beta|production) ;;
+            *)
+              echo "::error::Unsupported TV Play track: $tv_play_track"
+              exit 1
+              ;;
+          esac
+
+          case "$mobile_play_track" in
+            none|internal|alpha|beta|production) ;;
+            *)
+              echo "::error::Unsupported mobile/tablet Play track: $mobile_play_track"
+              exit 1
+              ;;
+          esac
+
+          if [ "$mobile_profile" = "none" ] && [ "$mobile_play_track" != "none" ]; then
+            echo "::error::mobile_play_track requires mobile_profile to be iptv-standalone or mobile-streaming."
+            exit 1
           fi
 
           case "$github_release_mode" in
@@ -182,6 +219,7 @@ jobs:
             echo "github_release_mode=$github_release_mode"
             echo "production_signing=$production_signing"
             echo "tv_play_track=$tv_play_track"
+            echo "mobile_play_track=$mobile_play_track"
             echo "mobile_profile=$mobile_profile"
             echo "qualification_mode=$qualification_mode"
           } >> "$GITHUB_OUTPUT"
@@ -201,6 +239,7 @@ jobs:
             echo "| GitHub Release publish | $publish_github_release |"
             echo "| GitHub Release mode | $github_release_mode |"
             echo "| TV Play track | $tv_play_track |"
+            echo "| Mobile/tablet Play track | $mobile_play_track |"
             echo "| Mobile/tablet profile | $mobile_profile |"
             echo "| Qualification mode | $qualification_mode |"
           } >> "$GITHUB_STEP_SUMMARY"
@@ -244,6 +283,7 @@ jobs:
       build_number: ${{ needs.prepare.outputs.build_number }}
       release_ref: ${{ needs.prepare.outputs.release_ref }}
       production_signing: ${{ needs.prepare.outputs.production_signing == 'true' }}
+      play_track: ${{ needs.prepare.outputs.mobile_play_track }}
     secrets: inherit
 
   tv-release:
@@ -464,6 +504,8 @@ jobs:
           TV_RESULT: ${{ needs.tv-release.result }}
           MOBILE_RESULT: ${{ needs.mobile-tablet-release.result }}
           MOBILE_PROFILE: ${{ needs.prepare.outputs.mobile_profile }}
+          TV_PLAY_TRACK: ${{ needs.prepare.outputs.tv_play_track }}
+          MOBILE_PLAY_TRACK: ${{ needs.prepare.outputs.mobile_play_track }}
           CONTRACT_RESULT: ${{ needs.release-contracts.result }}
         run: |
           {
@@ -480,8 +522,10 @@ jobs:
             echo "| GitHub Release publish | $PUBLISH_GITHUB_RELEASE |"
             echo "| GitHub Release mode | $GITHUB_RELEASE_MODE |"
             echo "| TV leg | $TV_RESULT |"
+            echo "| TV Play track | $TV_PLAY_TRACK |"
             echo "| Mobile/tablet profile | $MOBILE_PROFILE |"
             echo "| Mobile/tablet leg | $MOBILE_RESULT |"
+            echo "| Mobile/tablet Play track | $MOBILE_PLAY_TRACK |"
             echo "| Release contracts | $CONTRACT_RESULT |"
             echo ""
             echo "## Artifact evidence"

--- a/docs/release/STORE_COMPLIANCE.md
+++ b/docs/release/STORE_COMPLIANCE.md
@@ -84,6 +84,8 @@ and AI Core bind-service permissions inherited from broader dependencies.
 | Production Android signing secrets stored in GitHub | Pending | #585, #677 |
 | AAB build for TV | Ready in CI | `.github/workflows/airo-tv-release.yml` |
 | AAB build for mobile/tablet | Ready in CI for selected v2 profile | `.github/workflows/airo-mobile-tablet-release.yml` |
+| Play upload automation for TV | Ready after credentials and track selection | `tv_play_track` in `.github/workflows/v2-release-orchestrator.yml` |
+| Play upload automation for mobile/tablet | Ready after credentials, selected profile, and track selection | `mobile_play_track` in `.github/workflows/v2-release-orchestrator.yml` |
 | GitHub Release asset publication | Ready in orchestrator for selected v2 profiles | `.github/workflows/v2-release-orchestrator.yml` |
 | IARC content rating completed | Pending store-console action | #584 |
 | Data Safety form completed | Pending store-console action | #584/#581 |

--- a/docs/release/V2_PUBLISHING_HUMAN_SETUP.md
+++ b/docs/release/V2_PUBLISHING_HUMAN_SETUP.md
@@ -25,6 +25,10 @@ Related issues: #681, #585, #657.
       production, or no-upload.
 - [ ] Confirm whether TV uses the same Play app with device targeting or a
       separate Android TV listing.
+- [x] Keep release workflows in no-upload mode by default and require an
+      explicit Play track before uploading AABs.
+- [x] Wire mobile/tablet and TV workflows to fail fast when Play upload is
+      requested without `GOOGLE_PLAY_SERVICE_ACCOUNT_JSON`.
 
 ## Firebase App Distribution
 
@@ -92,3 +96,5 @@ Related issues: #687, #689.
   network addresses, or private user data.
 - Store uploads should support dry-run/no-upload mode until credentials and
   tracks are confirmed.
+- Play upload automation supports `internal`, `alpha`, `beta`, `production`,
+  and `none` tracks for selected v2 Android profiles.

--- a/docs/release/V2_RELEASE_ORCHESTRATOR.md
+++ b/docs/release/V2_RELEASE_ORCHESTRATOR.md
@@ -32,9 +32,10 @@ owns the aggregate multi-profile GitHub Release asset set.
 When `mobile_profile` is `iptv-standalone` or `mobile-streaming`, the
 orchestrator calls `.github/workflows/airo-mobile-tablet-release.yml` to build
 the selected profile's APK and Play Store AAB, generate `SHA256SUMS`, write a
-release manifest, retain obfuscation symbols, and contribute mobile/tablet
-qualification evidence. Real store or Firebase publication still depends on
-the credential and destination setup tracked in #681 and #682.
+release manifest, retain obfuscation symbols, optionally upload the AAB to a
+selected Play track, and contribute mobile/tablet qualification evidence. Real
+store or Firebase publication still depends on the credential and destination
+setup tracked in #681 and #682.
 
 ## Release Evidence
 
@@ -70,10 +71,13 @@ Public/store publishing requires:
 - `publish_github_release` set to `true` for GitHub Release publication;
 - `github_release_mode` set to `draft` or `published`;
 - `production_signing` set to `true` for production-signed Android artifacts;
-- `tv_play_track` set to a Play testing track for TV Play uploads.
+- `tv_play_track` set to a Play testing or production track for TV Play
+  uploads;
+- `mobile_play_track` set to a Play testing or production track for the
+  selected mobile/tablet profile.
 
 When `dry_run` is `true`, the orchestrator forces GitHub Release publication
-off and sets the TV Play track to `none`.
+off and sets the TV and mobile/tablet Play tracks to `none`.
 
 ## Human Decisions Still Needed
 
@@ -81,6 +85,7 @@ off and sets the TV Play track to `none`.
 - Whether public releases should publish immediately or always start as draft
   GitHub Releases. The workflow supports both and defaults to draft.
 - Whether optional channels should block the whole release or report warnings.
-- Mobile/tablet Firebase apps, Play tracks, release signing secrets, and upload
-  credentials for #681 and #682. Package IDs are registered under
-  `io.airo.app.*`.
+- Play Console apps/tracks, release signing secrets, and
+  `GOOGLE_PLAY_SERVICE_ACCOUNT_JSON` for #681.
+- Mobile/tablet Firebase apps and Firebase upload credentials for #682.
+  Package IDs are registered under `io.airo.app.*`.


### PR DESCRIPTION
# Summary

This PR advances #681 by adding Play upload automation for selected v2 Android profiles.

Core outcome:

* Adds mobile/tablet AAB upload support for `iptv-standalone` and `mobile-streaming` profiles.
* Passes `mobile_play_track` through the v2 release orchestrator, matching the existing TV `tv_play_track` control.
* Keeps no-upload/dry-run as the default and fails fast when a real Play upload is requested without `GOOGLE_PLAY_SERVICE_ACCOUNT_JSON`.

# Changes

### Code

* Updated:
  * `.github/workflows/airo-mobile-tablet-release.yml` with `play_track` input and Play upload job.
  * `.github/workflows/airo-tv-release.yml` to allow the documented `production` track and record upload summary details.
  * `.github/workflows/v2-release-orchestrator.yml` with `mobile_play_track`, track validation, and summary fields.

### Docs

* Updated:
  * `docs/release/V2_RELEASE_ORCHESTRATOR.md`
  * `docs/release/V2_PUBLISHING_HUMAN_SETUP.md`
  * `docs/release/STORE_COMPLIANCE.md`

# API Changes

None.

# Database Changes

None.

# Observability / Logging

* Adds GitHub Actions step summaries for Play upload package, track, and AAB name.

# Performance Impact

No runtime impact. Release workflows only run the Play upload job when a non-`none` track is selected.

# Risks

* Real Play uploads still require maintainer-owned Play Console app setup, release permissions, production signing, and `GOOGLE_PLAY_SERVICE_ACCOUNT_JSON`.
* The first real upload should run against `internal` before alpha/beta/production.

Rollback plan:

* Revert this PR to remove mobile Play upload wiring and the new orchestrator input.

# Testing

* `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "workflow-yaml-ok #{f}" }' .github/workflows/v2-release-orchestrator.yml .github/workflows/airo-tv-release.yml .github/workflows/airo-mobile-tablet-release.yml .github/workflows/pr-checks.yml .github/workflows/ci.yml`
* `bash -n scripts/patch-android-plugin-gradle.sh scripts/check-apk-size.sh scripts/test-generate-release-manifest.sh scripts/test-generate-release-qualification-report.sh`
* `python3 -m py_compile scripts/check-build-profiles.py scripts/generate-release-manifest.py scripts/generate-release-qualification-report.py`
* `scripts/check-build-profiles.py`
* `scripts/test-generate-release-manifest.sh`
* `scripts/test-generate-release-qualification-report.sh`
* `git diff --check`
* `bash scripts/check-docs-completeness.sh --base origin/v2 --head HEAD`

# Deployment Notes

Human setup still required before real uploads:

* Create/confirm Play Console apps for the selected package IDs.
* Add `GOOGLE_PLAY_SERVICE_ACCOUNT_JSON` as a GitHub Actions secret.
* Grant release permissions to the service account.
* Confirm first Play tracks for mobile/tablet and TV.
* Confirm production signing secrets and upload-key ownership.

# Related Commits

* `feat(release): add v2 Play upload track automation`
