### PR TITLE
feat(release): add v2 Firebase distribution automation

### DIFF
--- a/.github/workflows/airo-mobile-tablet-release.yml
+++ b/.github/workflows/airo-mobile-tablet-release.yml
@@ -2,6 +2,13 @@ name: Airo Mobile and Tablet Release
 
 on:
   workflow_call:
+    outputs:
+      firebase_distribution_status:
+        description: 'Firebase App Distribution result status'
+        value: ${{ jobs.firebase-distribution.outputs.status }}
+      firebase_distribution_url:
+        description: 'Firebase App Distribution console URL when available'
+        value: ${{ jobs.firebase-distribution.outputs.url }}
     inputs:
       profile:
         description: 'Mobile/tablet v2 profile to build'
@@ -30,6 +37,18 @@ on:
       play_track:
         description: 'Optional Play upload track'
         required: true
+        type: string
+      firebase_distribution:
+        description: 'Firebase App Distribution mode'
+        required: true
+        type: string
+      firebase_app_id:
+        description: 'Firebase App Distribution app ID for the selected profile'
+        required: false
+        type: string
+      firebase_tester_groups:
+        description: 'Comma-separated Firebase tester groups'
+        required: false
         type: string
   workflow_dispatch:
     inputs:
@@ -73,6 +92,22 @@ on:
           - alpha
           - beta
           - production
+      firebase_distribution:
+        description: 'Firebase App Distribution mode'
+        required: true
+        default: none
+        type: choice
+        options:
+          - none
+          - upload
+      firebase_app_id:
+        description: 'Firebase App Distribution app ID for this profile'
+        required: false
+        default: ''
+      firebase_tester_groups:
+        description: 'Comma-separated Firebase tester groups'
+        required: false
+        default: ''
 
 concurrency:
   group: airo-mobile-tablet-release-${{ github.ref }}-${{ inputs.profile || github.event.inputs.profile || 'manual' }}
@@ -124,6 +159,32 @@ jobs:
 
           echo "ref=$RELEASE_REF" >> "$GITHUB_OUTPUT"
           echo "sha=$release_commit" >> "$GITHUB_OUTPUT"
+
+      - name: Validate Firebase distribution inputs
+        env:
+          FIREBASE_DISTRIBUTION: ${{ inputs.firebase_distribution || github.event.inputs.firebase_distribution || 'none' }}
+          FIREBASE_APP_ID: ${{ inputs.firebase_app_id || github.event.inputs.firebase_app_id }}
+          FIREBASE_TESTER_GROUPS: ${{ inputs.firebase_tester_groups || github.event.inputs.firebase_tester_groups }}
+          FIREBASE_SERVICE_ACCOUNT_JSON: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_JSON }}
+        run: |
+          case "$FIREBASE_DISTRIBUTION" in
+            none|upload) ;;
+            *)
+              echo "::error::Unsupported Firebase distribution mode: $FIREBASE_DISTRIBUTION"
+              exit 1
+              ;;
+          esac
+
+          if [[ "$FIREBASE_DISTRIBUTION" == "upload" ]]; then
+            missing=0
+            for name in FIREBASE_APP_ID FIREBASE_TESTER_GROUPS FIREBASE_SERVICE_ACCOUNT_JSON; do
+              if [[ -z "${!name}" ]]; then
+                echo "::error::$name is required when Firebase distribution mode is upload."
+                missing=1
+              fi
+            done
+            [[ "$missing" -eq 0 ]] || exit 1
+          fi
 
   build-mobile-tablet:
     name: Build ${{ inputs.profile || github.event.inputs.profile || 'mobile/tablet' }} APK and AAB
@@ -535,4 +596,145 @@ jobs:
             echo "| Track | $PLAY_TRACK |"
             echo "| AAB | ${ARTIFACT_PREFIX}-${BUILD_NAME}-${BUILD_NUMBER}-Play-Store.aab |"
             echo "| Play Console | https://play.google.com/console/u/0/developers/app/$PACKAGE_ID/tracks/$PLAY_TRACK |"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  firebase-distribution:
+    name: Upload mobile/tablet to Firebase App Distribution
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    needs: [prepare-release-ref, build-mobile-tablet]
+    if: (github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_call') && (inputs.firebase_distribution || github.event.inputs.firebase_distribution) == 'upload'
+    permissions:
+      contents: read
+    outputs:
+      status: ${{ steps.firebase_result.outputs.status }}
+      url: ${{ steps.firebase_result.outputs.url }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ needs.prepare-release-ref.outputs.release_sha }}
+
+      - name: Resolve mobile/tablet profile metadata
+        run: |
+          release_version="$(printf '%s' "$RELEASE_VERSION" | sed 's/[^A-Za-z0-9._-]/-/g')"
+          echo "RELEASE_VERSION=$release_version" >> "$GITHUB_ENV"
+
+          case "$PROFILE" in
+            iptv-standalone)
+              echo "PACKAGE_ID=io.airo.app.iptv" >> "$GITHUB_ENV"
+              echo "ARTIFACT_PREFIX=Airo-IPTV" >> "$GITHUB_ENV"
+              ;;
+            mobile-streaming)
+              echo "PACKAGE_ID=io.airo.app.streaming" >> "$GITHUB_ENV"
+              echo "ARTIFACT_PREFIX=Airo-Streaming" >> "$GITHUB_ENV"
+              ;;
+            *)
+              echo "::error::Unsupported mobile/tablet profile for Firebase distribution: $PROFILE"
+              exit 1
+              ;;
+          esac
+
+      - name: Download release artifacts
+        uses: actions/download-artifact@v8
+        with:
+          name: airo-mobile-tablet-${{ env.PROFILE }}-${{ env.RELEASE_VERSION }}
+          path: release-artifacts
+
+      - name: Configure Firebase service account
+        env:
+          FIREBASE_SERVICE_ACCOUNT_JSON: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_JSON }}
+        run: |
+          if [[ -z "$FIREBASE_SERVICE_ACCOUNT_JSON" ]]; then
+            echo "::error::FIREBASE_SERVICE_ACCOUNT_JSON is required for Firebase App Distribution upload."
+            exit 1
+          fi
+          echo "$FIREBASE_SERVICE_ACCOUNT_JSON" > firebase-service-account.json
+          chmod 600 firebase-service-account.json
+
+      - name: Upload to Firebase App Distribution
+        id: firebase_result
+        env:
+          FIREBASE_APP_ID: ${{ inputs.firebase_app_id || github.event.inputs.firebase_app_id }}
+          FIREBASE_TESTER_GROUPS: ${{ inputs.firebase_tester_groups || github.event.inputs.firebase_tester_groups }}
+          GOOGLE_APPLICATION_CREDENTIALS: firebase-service-account.json
+        run: |
+          apk_name="${ARTIFACT_PREFIX}-${BUILD_NAME}-${BUILD_NUMBER}-arm64.apk"
+          apk_path="release-artifacts/$apk_name"
+          manifest_path="release-artifacts/${ARTIFACT_PREFIX}-${BUILD_NAME}-${BUILD_NUMBER}-Release-Manifest.json"
+
+          if [[ -z "$FIREBASE_APP_ID" ]]; then
+            echo "::error::firebase_app_id is required when Firebase distribution mode is upload."
+            exit 1
+          fi
+          if [[ -z "$FIREBASE_TESTER_GROUPS" ]]; then
+            echo "::error::firebase_tester_groups is required when Firebase distribution mode is upload."
+            exit 1
+          fi
+          if [[ ! -f "$apk_path" ]]; then
+            echo "::error::Expected mobile/tablet APK not found: $apk_path"
+            exit 1
+          fi
+          if [[ ! -f "$manifest_path" ]]; then
+            echo "::error::Expected release manifest not found: $manifest_path"
+            exit 1
+          fi
+
+          python3 - "$apk_name" "$manifest_path" > firebase-release-notes.md <<'PY'
+          import json
+          import sys
+
+          apk_name, manifest_path = sys.argv[1:]
+          manifest = json.load(open(manifest_path, encoding="utf-8"))
+          artifact = next(item for item in manifest["artifacts"] if item["filename"] == apk_name)
+          print(f"Airo {artifact['profileId']} {artifact['version']} ({artifact['buildNumber']})")
+          print("")
+          print(f"Package: {artifact['packageId']}")
+          print(f"Artifact: {artifact['filename']}")
+          print(f"SHA256: {artifact['sha256']}")
+          print(f"Source: {manifest['source']['ref']} @ {manifest['source']['sha']}")
+          PY
+
+          npm install -g firebase-tools
+          firebase appdistribution:distribute "$apk_path" \
+            --app "$FIREBASE_APP_ID" \
+            --groups "$FIREBASE_TESTER_GROUPS" \
+            --release-notes-file firebase-release-notes.md \
+            --json | tee firebase-result.json
+
+          url="$(python3 - firebase-result.json <<'PY'
+          import json
+          import sys
+
+          try:
+              data = json.load(open(sys.argv[1], encoding="utf-8"))
+          except Exception:
+              print("")
+              raise SystemExit
+          result = data.get("result") if isinstance(data, dict) else None
+          if not isinstance(result, dict):
+              result = data if isinstance(data, dict) else {}
+          print(result.get("firebase_console_uri") or result.get("testing_uri") or result.get("binary_download_uri") or "")
+          PY
+          )"
+
+          {
+            echo "status=uploaded"
+            echo "url=$url"
+          } >> "$GITHUB_OUTPUT"
+
+          {
+            echo "# Mobile/tablet Firebase App Distribution"
+            echo ""
+            echo "| Field | Value |"
+            echo "| --- | --- |"
+            echo "| Profile | $PROFILE |"
+            echo "| Package | $PACKAGE_ID |"
+            echo "| Firebase app | $FIREBASE_APP_ID |"
+            echo "| Tester groups | $FIREBASE_TESTER_GROUPS |"
+            echo "| APK | $apk_name |"
+            if [[ -n "$url" ]]; then
+              echo "| Result | $url |"
+            else
+              echo "| Result | Uploaded; Firebase CLI did not return a URL |"
+            fi
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/airo-tv-release.yml
+++ b/.github/workflows/airo-tv-release.yml
@@ -2,6 +2,13 @@ name: Airo TV Release
 
 on:
   workflow_call:
+    outputs:
+      firebase_distribution_status:
+        description: 'Firebase App Distribution result status'
+        value: ${{ jobs.firebase-distribution.outputs.status }}
+      firebase_distribution_url:
+        description: 'Firebase App Distribution console URL when available'
+        value: ${{ jobs.firebase-distribution.outputs.url }}
     inputs:
       version:
         description: 'Airo TV artifact and release version label'
@@ -34,6 +41,18 @@ on:
       play_track:
         description: 'Optional Play upload track'
         required: true
+        type: string
+      firebase_distribution:
+        description: 'Firebase App Distribution mode'
+        required: true
+        type: string
+      firebase_app_id:
+        description: 'Firebase App Distribution app ID for TV'
+        required: false
+        type: string
+      firebase_tester_groups:
+        description: 'Comma-separated Firebase tester groups'
+        required: false
         type: string
   pull_request:
     branches: [ v2 ]
@@ -92,6 +111,22 @@ on:
           - alpha
           - beta
           - production
+      firebase_distribution:
+        description: 'Firebase App Distribution mode'
+        required: true
+        default: none
+        type: choice
+        options:
+          - none
+          - upload
+      firebase_app_id:
+        description: 'Firebase App Distribution app ID for TV'
+        required: false
+        default: ''
+      firebase_tester_groups:
+        description: 'Comma-separated Firebase tester groups'
+        required: false
+        default: ''
 
 concurrency:
   group: airo-tv-release-${{ github.ref }}
@@ -139,6 +174,32 @@ jobs:
           git checkout -B "$RELEASE_BRANCH" "$base_ref"
           git push origin "$RELEASE_BRANCH" --force-with-lease
           echo "ref=$RELEASE_BRANCH" >> "$GITHUB_OUTPUT"
+
+      - name: Validate Firebase distribution inputs
+        env:
+          FIREBASE_DISTRIBUTION: ${{ inputs.firebase_distribution || github.event.inputs.firebase_distribution || 'none' }}
+          FIREBASE_APP_ID: ${{ inputs.firebase_app_id || github.event.inputs.firebase_app_id }}
+          FIREBASE_TESTER_GROUPS: ${{ inputs.firebase_tester_groups || github.event.inputs.firebase_tester_groups }}
+          FIREBASE_SERVICE_ACCOUNT_JSON: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_JSON }}
+        run: |
+          case "$FIREBASE_DISTRIBUTION" in
+            none|upload) ;;
+            *)
+              echo "::error::Unsupported Firebase distribution mode: $FIREBASE_DISTRIBUTION"
+              exit 1
+              ;;
+          esac
+
+          if [[ "$FIREBASE_DISTRIBUTION" == "upload" ]]; then
+            missing=0
+            for name in FIREBASE_APP_ID FIREBASE_TESTER_GROUPS FIREBASE_SERVICE_ACCOUNT_JSON; do
+              if [[ -z "${!name}" ]]; then
+                echo "::error::$name is required when Firebase distribution mode is upload."
+                missing=1
+              fi
+            done
+            [[ "$missing" -eq 0 ]] || exit 1
+          fi
 
   release-checks:
     name: TV release checks
@@ -499,6 +560,131 @@ jobs:
             echo "| Track | $PLAY_TRACK |"
             echo "| AAB | Airo-TV-${BUILD_NAME}-Play-Store.aab |"
             echo "| Play Console | https://play.google.com/console/u/0/developers/app/$SUPPLY_PACKAGE_NAME/tracks/$PLAY_TRACK |"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  firebase-distribution:
+    name: Upload Airo TV to Firebase App Distribution
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    needs: [prepare-release-branch, build-tv]
+    if: (github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_call') && (inputs.firebase_distribution || github.event.inputs.firebase_distribution) == 'upload'
+    permissions:
+      contents: read
+    outputs:
+      status: ${{ steps.firebase_result.outputs.status }}
+      url: ${{ steps.firebase_result.outputs.url }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ needs.prepare-release-branch.outputs.release_ref || github.ref }}
+
+      - name: Normalize release artifact label
+        run: |
+          release_version="$(printf '%s' "$RELEASE_VERSION" | sed 's/[^A-Za-z0-9._-]/-/g')"
+          echo "RELEASE_VERSION=$release_version" >> "$GITHUB_ENV"
+
+      - name: Download release artifacts
+        uses: actions/download-artifact@v8
+        with:
+          name: airo-tv-release-${{ env.RELEASE_VERSION }}
+          path: release-artifacts
+
+      - name: Configure Firebase service account
+        env:
+          FIREBASE_SERVICE_ACCOUNT_JSON: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_JSON }}
+        run: |
+          if [[ -z "$FIREBASE_SERVICE_ACCOUNT_JSON" ]]; then
+            echo "::error::FIREBASE_SERVICE_ACCOUNT_JSON is required for Firebase App Distribution upload."
+            exit 1
+          fi
+          echo "$FIREBASE_SERVICE_ACCOUNT_JSON" > firebase-service-account.json
+          chmod 600 firebase-service-account.json
+
+      - name: Upload to Firebase App Distribution
+        id: firebase_result
+        env:
+          FIREBASE_APP_ID: ${{ inputs.firebase_app_id || github.event.inputs.firebase_app_id }}
+          FIREBASE_TESTER_GROUPS: ${{ inputs.firebase_tester_groups || github.event.inputs.firebase_tester_groups }}
+          GOOGLE_APPLICATION_CREDENTIALS: firebase-service-account.json
+        run: |
+          apk_name="Airo-TV-${BUILD_NAME}.apk"
+          apk_path="release-artifacts/$apk_name"
+          manifest_path="release-artifacts/Airo-TV-${BUILD_NAME}-Release-Manifest.json"
+
+          if [[ -z "$FIREBASE_APP_ID" ]]; then
+            echo "::error::firebase_app_id is required when Firebase distribution mode is upload."
+            exit 1
+          fi
+          if [[ -z "$FIREBASE_TESTER_GROUPS" ]]; then
+            echo "::error::firebase_tester_groups is required when Firebase distribution mode is upload."
+            exit 1
+          fi
+          if [[ ! -f "$apk_path" ]]; then
+            echo "::error::Expected TV APK not found: $apk_path"
+            exit 1
+          fi
+          if [[ ! -f "$manifest_path" ]]; then
+            echo "::error::Expected TV release manifest not found: $manifest_path"
+            exit 1
+          fi
+
+          python3 - "$apk_name" "$manifest_path" > firebase-release-notes.md <<'PY'
+          import json
+          import sys
+
+          apk_name, manifest_path = sys.argv[1:]
+          manifest = json.load(open(manifest_path, encoding="utf-8"))
+          artifact = next(item for item in manifest["artifacts"] if item["filename"] == apk_name)
+          print(f"Airo TV {artifact['version']} ({artifact['buildNumber']})")
+          print("")
+          print(f"Package: {artifact['packageId']}")
+          print(f"Artifact: {artifact['filename']}")
+          print(f"SHA256: {artifact['sha256']}")
+          print(f"Source: {manifest['source']['ref']} @ {manifest['source']['sha']}")
+          PY
+
+          npm install -g firebase-tools
+          firebase appdistribution:distribute "$apk_path" \
+            --app "$FIREBASE_APP_ID" \
+            --groups "$FIREBASE_TESTER_GROUPS" \
+            --release-notes-file firebase-release-notes.md \
+            --json | tee firebase-result.json
+
+          url="$(python3 - firebase-result.json <<'PY'
+          import json
+          import sys
+
+          try:
+              data = json.load(open(sys.argv[1], encoding="utf-8"))
+          except Exception:
+              print("")
+              raise SystemExit
+          result = data.get("result") if isinstance(data, dict) else None
+          if not isinstance(result, dict):
+              result = data if isinstance(data, dict) else {}
+          print(result.get("firebase_console_uri") or result.get("testing_uri") or result.get("binary_download_uri") or "")
+          PY
+          )"
+
+          {
+            echo "status=uploaded"
+            echo "url=$url"
+          } >> "$GITHUB_OUTPUT"
+
+          {
+            echo "# TV Firebase App Distribution"
+            echo ""
+            echo "| Field | Value |"
+            echo "| --- | --- |"
+            echo "| Package | io.airo.app.tv |"
+            echo "| Firebase app | $FIREBASE_APP_ID |"
+            echo "| Tester groups | $FIREBASE_TESTER_GROUPS |"
+            echo "| APK | $apk_name |"
+            if [[ -n "$url" ]]; then
+              echo "| Result | $url |"
+            else
+              echo "| Result | Uploaded; Firebase CLI did not return a URL |"
+            fi
           } >> "$GITHUB_STEP_SUMMARY"
 
   github-release:

--- a/.github/workflows/v2-release-orchestrator.yml
+++ b/.github/workflows/v2-release-orchestrator.yml
@@ -71,6 +71,30 @@ on:
           - alpha
           - beta
           - production
+      firebase_distribution:
+        description: 'Optional Firebase App Distribution upload mode when dry_run is false'
+        required: true
+        default: none
+        type: choice
+        options:
+          - none
+          - upload
+      mobile_firebase_app_id:
+        description: 'Firebase App Distribution app ID for the selected mobile/tablet profile'
+        required: false
+        default: ''
+      mobile_firebase_tester_groups:
+        description: 'Comma-separated Firebase tester groups for mobile/tablet QA'
+        required: false
+        default: ''
+      tv_firebase_app_id:
+        description: 'Firebase App Distribution app ID for TV'
+        required: false
+        default: ''
+      tv_firebase_tester_groups:
+        description: 'Comma-separated Firebase tester groups for TV QA'
+        required: false
+        default: ''
       mobile_profile:
         description: 'Optional mobile/tablet profile to build'
         required: true
@@ -117,6 +141,11 @@ jobs:
       production_signing: ${{ steps.release.outputs.production_signing }}
       tv_play_track: ${{ steps.release.outputs.tv_play_track }}
       mobile_play_track: ${{ steps.release.outputs.mobile_play_track }}
+      firebase_distribution: ${{ steps.release.outputs.firebase_distribution }}
+      mobile_firebase_app_id: ${{ steps.release.outputs.mobile_firebase_app_id }}
+      mobile_firebase_tester_groups: ${{ steps.release.outputs.mobile_firebase_tester_groups }}
+      tv_firebase_app_id: ${{ steps.release.outputs.tv_firebase_app_id }}
+      tv_firebase_tester_groups: ${{ steps.release.outputs.tv_firebase_tester_groups }}
       mobile_profile: ${{ steps.release.outputs.mobile_profile }}
       qualification_mode: ${{ steps.release.outputs.qualification_mode }}
     steps:
@@ -139,6 +168,11 @@ jobs:
           INPUT_PRODUCTION_SIGNING: ${{ inputs.production_signing }}
           INPUT_TV_PLAY_TRACK: ${{ inputs.tv_play_track }}
           INPUT_MOBILE_PLAY_TRACK: ${{ inputs.mobile_play_track }}
+          INPUT_FIREBASE_DISTRIBUTION: ${{ inputs.firebase_distribution }}
+          INPUT_MOBILE_FIREBASE_APP_ID: ${{ inputs.mobile_firebase_app_id }}
+          INPUT_MOBILE_FIREBASE_TESTER_GROUPS: ${{ inputs.mobile_firebase_tester_groups }}
+          INPUT_TV_FIREBASE_APP_ID: ${{ inputs.tv_firebase_app_id }}
+          INPUT_TV_FIREBASE_TESTER_GROUPS: ${{ inputs.tv_firebase_tester_groups }}
           INPUT_MOBILE_PROFILE: ${{ inputs.mobile_profile }}
           INPUT_QUALIFICATION_MODE: ${{ inputs.qualification_mode }}
         run: |
@@ -155,6 +189,11 @@ jobs:
           production_signing="${INPUT_PRODUCTION_SIGNING:-false}"
           tv_play_track="${INPUT_TV_PLAY_TRACK:-none}"
           mobile_play_track="${INPUT_MOBILE_PLAY_TRACK:-none}"
+          firebase_distribution="${INPUT_FIREBASE_DISTRIBUTION:-none}"
+          mobile_firebase_app_id="${INPUT_MOBILE_FIREBASE_APP_ID:-}"
+          mobile_firebase_tester_groups="${INPUT_MOBILE_FIREBASE_TESTER_GROUPS:-}"
+          tv_firebase_app_id="${INPUT_TV_FIREBASE_APP_ID:-}"
+          tv_firebase_tester_groups="${INPUT_TV_FIREBASE_TESTER_GROUPS:-}"
           mobile_profile="${INPUT_MOBILE_PROFILE:-none}"
           qualification_mode="${INPUT_QUALIFICATION_MODE:-internal}"
 
@@ -162,6 +201,7 @@ jobs:
             publish_github_release="false"
             tv_play_track="none"
             mobile_play_track="none"
+            firebase_distribution="none"
           fi
 
           case "$tv_play_track" in
@@ -183,6 +223,25 @@ jobs:
           if [ "$mobile_profile" = "none" ] && [ "$mobile_play_track" != "none" ]; then
             echo "::error::mobile_play_track requires mobile_profile to be iptv-standalone or mobile-streaming."
             exit 1
+          fi
+
+          case "$firebase_distribution" in
+            none|upload) ;;
+            *)
+              echo "::error::Unsupported Firebase distribution mode: $firebase_distribution"
+              exit 1
+              ;;
+          esac
+
+          if [ "$firebase_distribution" = "upload" ]; then
+            if [ -z "$tv_firebase_app_id" ] || [ -z "$tv_firebase_tester_groups" ]; then
+              echo "::error::Firebase upload requires tv_firebase_app_id and tv_firebase_tester_groups."
+              exit 1
+            fi
+            if [ "$mobile_profile" != "none" ] && { [ -z "$mobile_firebase_app_id" ] || [ -z "$mobile_firebase_tester_groups" ]; }; then
+              echo "::error::Firebase upload with a mobile/tablet profile requires mobile_firebase_app_id and mobile_firebase_tester_groups."
+              exit 1
+            fi
           fi
 
           case "$github_release_mode" in
@@ -220,6 +279,11 @@ jobs:
             echo "production_signing=$production_signing"
             echo "tv_play_track=$tv_play_track"
             echo "mobile_play_track=$mobile_play_track"
+            echo "firebase_distribution=$firebase_distribution"
+            echo "mobile_firebase_app_id=$mobile_firebase_app_id"
+            echo "mobile_firebase_tester_groups=$mobile_firebase_tester_groups"
+            echo "tv_firebase_app_id=$tv_firebase_app_id"
+            echo "tv_firebase_tester_groups=$tv_firebase_tester_groups"
             echo "mobile_profile=$mobile_profile"
             echo "qualification_mode=$qualification_mode"
           } >> "$GITHUB_OUTPUT"
@@ -240,6 +304,7 @@ jobs:
             echo "| GitHub Release mode | $github_release_mode |"
             echo "| TV Play track | $tv_play_track |"
             echo "| Mobile/tablet Play track | $mobile_play_track |"
+            echo "| Firebase distribution | $firebase_distribution |"
             echo "| Mobile/tablet profile | $mobile_profile |"
             echo "| Qualification mode | $qualification_mode |"
           } >> "$GITHUB_STEP_SUMMARY"
@@ -284,6 +349,9 @@ jobs:
       release_ref: ${{ needs.prepare.outputs.release_ref }}
       production_signing: ${{ needs.prepare.outputs.production_signing == 'true' }}
       play_track: ${{ needs.prepare.outputs.mobile_play_track }}
+      firebase_distribution: ${{ needs.prepare.outputs.firebase_distribution }}
+      firebase_app_id: ${{ needs.prepare.outputs.mobile_firebase_app_id }}
+      firebase_tester_groups: ${{ needs.prepare.outputs.mobile_firebase_tester_groups }}
     secrets: inherit
 
   tv-release:
@@ -302,6 +370,9 @@ jobs:
       publish_github_release: false
       production_signing: ${{ needs.prepare.outputs.production_signing == 'true' }}
       play_track: ${{ needs.prepare.outputs.tv_play_track }}
+      firebase_distribution: ${{ needs.prepare.outputs.firebase_distribution }}
+      firebase_app_id: ${{ needs.prepare.outputs.tv_firebase_app_id }}
+      firebase_tester_groups: ${{ needs.prepare.outputs.tv_firebase_tester_groups }}
     secrets: inherit
 
   release-summary:
@@ -506,6 +577,11 @@ jobs:
           MOBILE_PROFILE: ${{ needs.prepare.outputs.mobile_profile }}
           TV_PLAY_TRACK: ${{ needs.prepare.outputs.tv_play_track }}
           MOBILE_PLAY_TRACK: ${{ needs.prepare.outputs.mobile_play_track }}
+          FIREBASE_DISTRIBUTION: ${{ needs.prepare.outputs.firebase_distribution }}
+          TV_FIREBASE_STATUS: ${{ needs.tv-release.outputs.firebase_distribution_status }}
+          TV_FIREBASE_URL: ${{ needs.tv-release.outputs.firebase_distribution_url }}
+          MOBILE_FIREBASE_STATUS: ${{ needs.mobile-tablet-release.outputs.firebase_distribution_status }}
+          MOBILE_FIREBASE_URL: ${{ needs.mobile-tablet-release.outputs.firebase_distribution_url }}
           CONTRACT_RESULT: ${{ needs.release-contracts.result }}
         run: |
           {
@@ -526,6 +602,9 @@ jobs:
             echo "| Mobile/tablet profile | $MOBILE_PROFILE |"
             echo "| Mobile/tablet leg | $MOBILE_RESULT |"
             echo "| Mobile/tablet Play track | $MOBILE_PLAY_TRACK |"
+            echo "| Firebase distribution | $FIREBASE_DISTRIBUTION |"
+            echo "| TV Firebase status | ${TV_FIREBASE_STATUS:-none} |"
+            echo "| Mobile/tablet Firebase status | ${MOBILE_FIREBASE_STATUS:-none} |"
             echo "| Release contracts | $CONTRACT_RESULT |"
             echo ""
             echo "## Artifact evidence"
@@ -539,6 +618,9 @@ jobs:
               find release-artifacts/tv -maxdepth 1 -type f -printf '- %f\n' | sort
               echo ""
               echo "TV artifacts include APK/AAB files, SHA256SUMS, release manifest, and an internal qualification report when generated by this orchestrator."
+              if [ -n "$TV_FIREBASE_URL" ]; then
+                echo "Firebase App Distribution result: $TV_FIREBASE_URL"
+              fi
             } >> "$GITHUB_STEP_SUMMARY"
           else
             echo "TV artifacts were not available because the TV leg result was $TV_RESULT." >> "$GITHUB_STEP_SUMMARY"
@@ -552,6 +634,9 @@ jobs:
               find release-artifacts/mobile-tablet -maxdepth 1 -type f -printf '- %f\n' | sort
               echo ""
               echo "Mobile/tablet artifacts include APK/AAB files, SHA256SUMS, release manifest, and an internal qualification report when generated by this orchestrator."
+              if [ -n "$MOBILE_FIREBASE_URL" ]; then
+                echo "Firebase App Distribution result: $MOBILE_FIREBASE_URL"
+              fi
             } >> "$GITHUB_STEP_SUMMARY"
           elif [ "$MOBILE_PROFILE" = "none" ]; then
             echo "Mobile/tablet artifacts were not requested for this orchestrator run." >> "$GITHUB_STEP_SUMMARY"

--- a/docs/release/STORE_COMPLIANCE.md
+++ b/docs/release/STORE_COMPLIANCE.md
@@ -86,6 +86,7 @@ and AI Core bind-service permissions inherited from broader dependencies.
 | AAB build for mobile/tablet | Ready in CI for selected v2 profile | `.github/workflows/airo-mobile-tablet-release.yml` |
 | Play upload automation for TV | Ready after credentials and track selection | `tv_play_track` in `.github/workflows/v2-release-orchestrator.yml` |
 | Play upload automation for mobile/tablet | Ready after credentials, selected profile, and track selection | `mobile_play_track` in `.github/workflows/v2-release-orchestrator.yml` |
+| Firebase App Distribution upload automation | Ready after Firebase app IDs, tester groups, and credential secret are configured | `firebase_distribution` in `.github/workflows/v2-release-orchestrator.yml` |
 | GitHub Release asset publication | Ready in orchestrator for selected v2 profiles | `.github/workflows/v2-release-orchestrator.yml` |
 | IARC content rating completed | Pending store-console action | #584 |
 | Data Safety form completed | Pending store-console action | #584/#581 |

--- a/docs/release/V2_PUBLISHING_HUMAN_SETUP.md
+++ b/docs/release/V2_PUBLISHING_HUMAN_SETUP.md
@@ -39,10 +39,16 @@ Related issues: #682, #574.
 - [ ] Add or confirm Firebase Android client configs for the registered
       `io.airo.app.*` packages that should use Firebase services.
 - [ ] Create a Firebase service account or distribution token for CI.
-- [ ] Store the Firebase credential as a GitHub Actions secret.
+- [ ] Store the Firebase service account JSON as the GitHub Actions secret
+      `FIREBASE_SERVICE_ACCOUNT_JSON`.
 - [ ] Create tester groups for mobile/tablet QA and TV QA.
 - [ ] Confirm whether TV APK distribution through Firebase is part of this
       release wave.
+- [x] Keep Firebase App Distribution in no-upload mode by default and require
+      explicit app IDs, tester groups, and credentials before uploading APKs.
+- [x] Wire mobile/tablet and TV workflows to fail fast when Firebase upload is
+      requested without app IDs, tester groups, or
+      `FIREBASE_SERVICE_ACCOUNT_JSON`.
 
 ## Android Signing
 
@@ -98,3 +104,5 @@ Related issues: #687, #689.
   tracks are confirmed.
 - Play upload automation supports `internal`, `alpha`, `beta`, `production`,
   and `none` tracks for selected v2 Android profiles.
+- Firebase App Distribution automation supports `upload` and `none` modes for
+  selected v2 Android profiles.

--- a/docs/release/V2_RELEASE_ORCHESTRATOR.md
+++ b/docs/release/V2_RELEASE_ORCHESTRATOR.md
@@ -37,6 +37,12 @@ selected Play track, and contribute mobile/tablet qualification evidence. Real
 store or Firebase publication still depends on the credential and destination
 setup tracked in #681 and #682.
 
+When `firebase_distribution` is `upload`, the reusable TV and mobile/tablet
+release workflows upload the final named APK artifacts to Firebase App
+Distribution after release artifacts are staged. Firebase release notes include
+the artifact name, package ID, version/build number, checksum, and source ref
+from the generated release manifest.
+
 ## Release Evidence
 
 Successful orchestrator runs upload:
@@ -74,10 +80,13 @@ Public/store publishing requires:
 - `tv_play_track` set to a Play testing or production track for TV Play
   uploads;
 - `mobile_play_track` set to a Play testing or production track for the
-  selected mobile/tablet profile.
+  selected mobile/tablet profile;
+- `firebase_distribution` set to `upload` for Firebase App Distribution,
+  alongside the required Firebase app IDs and tester groups.
 
 When `dry_run` is `true`, the orchestrator forces GitHub Release publication
-off and sets the TV and mobile/tablet Play tracks to `none`.
+off and sets the TV and mobile/tablet Play tracks plus Firebase distribution to
+`none`.
 
 ## Human Decisions Still Needed
 
@@ -87,5 +96,6 @@ off and sets the TV and mobile/tablet Play tracks to `none`.
 - Whether optional channels should block the whole release or report warnings.
 - Play Console apps/tracks, release signing secrets, and
   `GOOGLE_PLAY_SERVICE_ACCOUNT_JSON` for #681.
-- Mobile/tablet Firebase apps and Firebase upload credentials for #682.
-  Package IDs are registered under `io.airo.app.*`.
+- Mobile/tablet and TV Firebase apps, tester groups, and
+  `FIREBASE_SERVICE_ACCOUNT_JSON` for #682. Package IDs are registered under
+  `io.airo.app.*`.


### PR DESCRIPTION
# Summary

This PR advances #682 by adding Firebase App Distribution upload automation for v2 Android APK artifacts.

Core outcome:

* Adds Firebase App Distribution upload mode for mobile/tablet and TV release workflows.
* Passes Firebase app IDs and tester groups through the v2 release orchestrator.
* Keeps Firebase distribution disabled by default and fails fast when upload is requested without required inputs or `FIREBASE_SERVICE_ACCOUNT_JSON`.

# Changes

### Code

* Updated:
  * `.github/workflows/airo-mobile-tablet-release.yml` with Firebase distribution inputs, preflight validation, upload job, release notes, and workflow outputs.
  * `.github/workflows/airo-tv-release.yml` with matching TV Firebase distribution support.
  * `.github/workflows/v2-release-orchestrator.yml` with `firebase_distribution`, mobile/TV Firebase app IDs, tester groups, validation, pass-through inputs, and summary output.

### Docs

* Updated:
  * `docs/release/V2_RELEASE_ORCHESTRATOR.md`
  * `docs/release/V2_PUBLISHING_HUMAN_SETUP.md`
  * `docs/release/STORE_COMPLIANCE.md`

# API Changes

None.

# Database Changes

None.

# Observability / Logging

* Adds GitHub Actions step summaries for Firebase app ID, tester groups, APK filename, and returned Firebase result URL when available.
* Reusable workflows expose Firebase distribution status and URL outputs to the orchestrator summary.

# Performance Impact

No runtime impact. Firebase CLI install/upload only runs when `firebase_distribution` is set to `upload`.

# Risks

* Real Firebase uploads still require maintainer-owned Firebase apps, tester groups, and `FIREBASE_SERVICE_ACCOUNT_JSON`.
* TV production Firebase config still depends on #574 updating `GOOGLE_SERVICES_JSON` with `io.airo.app.tv` if Firebase runtime services are required in the build.

Rollback plan:

* Revert this PR to remove Firebase Distribution upload jobs and orchestrator inputs.

# Testing

* `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "workflow-yaml-ok #{f}" }' .github/workflows/v2-release-orchestrator.yml .github/workflows/airo-tv-release.yml .github/workflows/airo-mobile-tablet-release.yml .github/workflows/pr-checks.yml .github/workflows/ci.yml`
* `bash -n scripts/patch-android-plugin-gradle.sh scripts/check-apk-size.sh scripts/test-generate-release-manifest.sh scripts/test-generate-release-qualification-report.sh`
* `python3 -m py_compile scripts/check-build-profiles.py scripts/generate-release-manifest.py scripts/generate-release-qualification-report.py`
* `scripts/check-build-profiles.py`
* `scripts/test-generate-release-manifest.sh`
* `scripts/test-generate-release-qualification-report.sh`
* `git diff --check`
* `bash scripts/check-docs-completeness.sh --base origin/v2 --head HEAD`

# Deployment Notes

Human setup still required before real Firebase uploads:

* Create/confirm Firebase apps for `io.airo.app.iptv`, `io.airo.app.streaming`, and `io.airo.app.tv` as needed.
* Add `FIREBASE_SERVICE_ACCOUNT_JSON` as a GitHub Actions secret.
* Create Firebase tester groups for mobile/tablet QA and TV QA.
* Confirm whether TV APK distribution through Firebase is part of this release wave.
* Update `GOOGLE_SERVICES_JSON` with the registered `io.airo.app.tv` Android client if Firebase runtime config is required for production TV builds.

# Related Commits

* `feat(release): add v2 Firebase distribution automation`
