### PR TITLE
docs(release): finalize Airo TV store metadata

### DIFF
--- a/docs/release/AIRO_TV_STORE_LISTING.md
+++ b/docs/release/AIRO_TV_STORE_LISTING.md
@@ -1,0 +1,114 @@
+# Airo TV Store Listing Metadata
+
+Canonical listing metadata for the Airo TV v2 Android TV release profile.
+This copy is scoped to the shipped v0.0.2 feature set in
+[Airo TV Feature Matrix](./AIRO_TV_FEATURE_MATRIX.md). Do not claim planned
+features such as EPG, favorites, recording, cloud playlists, or bundled
+channels until the feature matrix marks them supported.
+
+## Release Scope
+
+| Field | Value |
+| --- | --- |
+| Product | Airo TV |
+| Android package ID | `io.airo.app.tv` |
+| Entrypoint | `app/lib/main_tv.dart` |
+| Device class | Android TV, Google TV, Fire TV-compatible APK testing |
+| First v2 wave | Android TV / Google Play TV track |
+| iOS / App Store | Deferred from the first v2 Android publishing wave |
+| Privacy Policy URL | `https://developerscoffee.github.io/airo/legal/privacy-policy/` |
+| Terms URL | `https://developerscoffee.github.io/airo/legal/terms-conditions/` |
+
+## Google Play Store
+
+| Field | Final metadata |
+| --- | --- |
+| App name | `Airo TV - IPTV Player` |
+| Short description | `Play your own IPTV playlists on Android TV with Cast support.` |
+| Category | Entertainment / Video Players & Editors |
+| Tags / keywords | IPTV, M3U, M3U8, streaming, live TV, playlist, Android TV, Google TV, Chromecast, Cast |
+| Privacy Policy URL | `https://developerscoffee.github.io/airo/legal/privacy-policy/` |
+| Content rating | Complete the IARC questionnaire in Play Console before submission. |
+
+Short description length: 61/80 characters.
+
+### Full Description
+
+```text
+Airo TV is an IPTV player for Android TV, Google TV, and compatible TV devices.
+Bring your own authorized M3U or M3U8 playlist and watch live streams in a
+clean, remote-friendly interface built for the living room.
+
+Key features:
+- Import your own M3U/M3U8 playlist URL
+- Browse and search channels by name
+- Play supported HLS and media streams on TV devices
+- Use Chromecast/Cast controls where supported by your device and network
+- Keep playlists local unless you choose to load a remote playlist URL
+- Use a TV-focused interface designed for remote navigation
+
+Important content notice:
+Airo TV is a media player only. It does not provide, host, sell, endorse,
+verify, or distribute channels, playlists, streams, subscriptions, or IPTV
+services. You must supply your own legal content sources and ensure that you
+have the rights to access every stream you load.
+
+Supported playlist formats:
+M3U and M3U8.
+
+Playback support depends on the stream format, codec, device capability, and
+network connection. Some planned features, including EPG, favorites, recording,
+and cloud playlists, are not included in this release.
+```
+
+Full description length: 1,122/4,000 characters.
+
+## Google Play Assets
+
+| Asset | Requirement | Status |
+| --- | --- | --- |
+| App icon | 512x512 PNG, 32-bit, alpha allowed | Launcher icon exists; export final Play asset before submission. |
+| Feature graphic | 1024x500 PNG/JPG | Required before Play submission. |
+| TV screenshots | 2-8 landscape screenshots, 1920x1080 recommended | Required before Play submission. |
+| Demo video | Optional YouTube URL | Recommended after screenshots. |
+
+Screenshot capture guidance is maintained in
+[Airo TV Release Media Assets](./AIRO_TV_MEDIA_ASSETS.md).
+
+## Apple App Store Draft
+
+iOS/iPadOS publication is not part of the first v2 Android release wave. Keep
+this draft for future App Store Connect preparation only; do not submit it
+until maintainers explicitly add iOS or tvOS to the release scope.
+
+| Field | Draft metadata |
+| --- | --- |
+| App name | `Airo TV - IPTV Player` |
+| Subtitle | `IPTV playlist player` |
+| Category | Entertainment |
+| Keywords | `iptv,m3u,m3u8,streaming,live tv,playlist,chromecast,android tv,player,channels` |
+| Privacy Policy URL | `https://developerscoffee.github.io/airo/legal/privacy-policy/` |
+| App Privacy | Complete App Store Connect nutrition labels before submission. |
+
+Keyword length: 78/100 characters.
+
+### App Store Description Draft
+
+```text
+Airo TV is an IPTV playlist player for users who bring their own authorized
+content sources. Import an M3U or M3U8 playlist URL, search channels by name,
+and watch supported live streams through a clean interface.
+
+Airo TV does not provide channels, playlists, subscriptions, or IPTV services.
+Users are responsible for loading only legal content sources that they have the
+right to access.
+```
+
+## Console Fields Requiring Human Action
+
+- Google Play IARC/content rating questionnaire.
+- Google Play Data Safety form.
+- Final Play listing upload and stakeholder approval.
+- Final Play icon, feature graphic, screenshots, and optional demo video.
+- Any future Apple App Store Connect app record, privacy nutrition labels,
+  screenshots, signing setup, and TestFlight/App Store upload credentials.

--- a/docs/release/README.md
+++ b/docs/release/README.md
@@ -44,6 +44,7 @@ Documentation for Airo releases and version history.
 | [Airo TV Release Template](./AIRO_TV_RELEASE_TEMPLATE.md) | Stable release format for future Airo TV versions |
 | [Airo TV Feature Matrix](./AIRO_TV_FEATURE_MATRIX.md) | Supported, planned, and unsupported features |
 | [Airo TV Media Assets](./AIRO_TV_MEDIA_ASSETS.md) | Screenshot and demo-video release checklist |
+| [Airo TV Store Listing Metadata](./AIRO_TV_STORE_LISTING.md) | Final Play listing copy and future App Store draft metadata |
 | [Airo V1 and V2 Version Lines](./VERSION_LINES.md) | Base branch, tag, artifact, and support policy for monolith V1 and modular V2 |
 | [V2 Distribution Matrix](./V2_DISTRIBUTION_MATRIX.md) | Supported v2 profiles, artifact naming, channels, and support policy |
 | [V2 Publishing Human Setup](./V2_PUBLISHING_HUMAN_SETUP.md) | Account, credential, signing, store, and governance decisions maintainers must complete |

--- a/docs/release/STORE_COMPLIANCE.md
+++ b/docs/release/STORE_COMPLIANCE.md
@@ -41,18 +41,18 @@ The Android Gradle config currently uses:
 
 | Field | Current value | Status |
 | --- | --- | --- |
-| App name | `Airo TV` | Ready |
-| Package ID | `io.airo.app.tv` | Ready pending Play Console confirmation |
-| Category | Entertainment / Video Players & Editors | Pending final store entry in #581 |
-| Short description | Draft in #581 | Pending stakeholder approval |
-| Full description | Draft in #581 | Pending stakeholder approval |
+| App name | `Airo TV - IPTV Player` | Ready in [Airo TV Store Listing Metadata](./AIRO_TV_STORE_LISTING.md) |
+| Package ID | `io.airo.app.tv` | Registered |
+| Category | Entertainment / Video Players & Editors | Ready in [Airo TV Store Listing Metadata](./AIRO_TV_STORE_LISTING.md) |
+| Short description | `Play your own IPTV playlists on Android TV with Cast support.` | Ready in [Airo TV Store Listing Metadata](./AIRO_TV_STORE_LISTING.md) |
+| Full description | Final copy in [Airo TV Store Listing Metadata](./AIRO_TV_STORE_LISTING.md) | Ready pending stakeholder approval |
 | Privacy Policy URL | `https://developerscoffee.github.io/airo/legal/privacy-policy/` | Ready |
 | Terms URL | `https://developerscoffee.github.io/airo/legal/terms-conditions/` | Ready |
 | Content disclaimer | User-provided IPTV content only; no bundled streams or playlists | Ready |
-| App icon | Android launcher icon present | Needs Play 512x512 asset confirmation in #581 |
+| App icon | Android launcher icon present | Needs Play 512x512 asset export in #582 |
 | TV banner | `app/android/app/src/tv/res/drawable-xhdpi/tv_banner.png` | Present |
-| Screenshots | TV screenshots required, 1920x1080 landscape | Pending #581 |
-| Feature graphic | 1024x500 PNG/JPG required for Play | Pending #581 |
+| Screenshots | TV screenshots required, 1920x1080 landscape | Pending media capture in #582 |
+| Feature graphic | 1024x500 PNG/JPG required for Play | Pending media asset in #582 |
 
 ### Airo TV Permissions
 
@@ -90,8 +90,8 @@ and AI Core bind-service permissions inherited from broader dependencies.
 | GitHub Release asset publication | Ready in orchestrator for selected v2 profiles | `.github/workflows/v2-release-orchestrator.yml` |
 | IARC content rating completed | Pending store-console action | #584 |
 | Data Safety form completed | Pending store-console action | #584/#581 |
-| Store metadata finalized | Pending | #581 |
-| TV screenshots and feature graphic uploaded | Pending | #581 |
+| Store metadata finalized | Ready pending stakeholder approval | #581, `docs/release/AIRO_TV_STORE_LISTING.md` |
+| TV screenshots and feature graphic uploaded | Pending media assets | #582 |
 | Release qualification evidence attached | Pending actual release evidence | #683 |
 
 ## App Store / iOS Checklist
@@ -128,7 +128,8 @@ Before submitting a public v2 Android release:
       `io.airo.app.*` package IDs in #675/#677.
 - [ ] Complete account, credential, signing, and repository-governance items in
       [V2 Publishing Human Setup](./V2_PUBLISHING_HUMAN_SETUP.md).
-- [ ] Finalize Airo TV store metadata in #581.
+- [ ] Confirm stakeholder approval for
+      [Airo TV Store Listing Metadata](./AIRO_TV_STORE_LISTING.md).
 - [ ] Complete content rating and data-safety store-console forms in #584.
 - [ ] Attach release qualification evidence or an explicit waiver per
       [V2 Release Qualification](./V2_RELEASE_QUALIFICATION.md).
@@ -139,7 +140,8 @@ Before submitting a public v2 Android release:
 ## Related Issues
 
 - #575, #577, #578, #579: legal/docs foundation.
-- #581: final Play/App Store listing metadata and screenshots.
+- #581: final Play/App Store listing metadata.
+- #582: final Play screenshot, feature graphic, and app icon assets.
 - #584: IARC/content rating and App Store age-rating questionnaires.
 - #585: Fastlane/store credentials and signing setup.
 - #675: supported v2 device/profile artifact matrix.

--- a/docs/wiki/9.-Useful-Links.md
+++ b/docs/wiki/9.-Useful-Links.md
@@ -9,6 +9,7 @@
 - [Download verification](../../VERIFY_DOWNLOAD.md)
 - [Trust and transparency](../../TRUST.md)
 - [MIT license](../../LICENSE)
+- [Airo TV store listing metadata](../release/AIRO_TV_STORE_LISTING.md)
 - [V2 third-party notices](../release/V2_THIRD_PARTY_NOTICES.md)
 - [Product strategy](../PRODUCT_STRATEGY.md)
 - [Technical architecture](../architecture/TECHNICAL_ARCHITECTURE.md)


### PR DESCRIPTION
# Summary

This PR finalizes the Airo TV v2 store listing metadata for #581.
Goal: give maintainers copy they can paste into Play Console without relying on the stale issue-body draft.

Core outcome:

* Adds canonical Google Play listing metadata for `io.airo.app.tv`
* Adds future App Store draft metadata while keeping iOS deferred from the first Android wave
* Keeps media assets separate under #582 instead of mixing screenshot work into metadata readiness

# Changes

### Code

* Added:
  * `docs/release/AIRO_TV_STORE_LISTING.md`
* Updated:
  * `docs/release/STORE_COMPLIANCE.md` to point at final listing copy and separate media asset blockers
  * `docs/release/README.md` and `docs/wiki/9.-Useful-Links.md` with links to the metadata doc

### Logic

* Uses the actual v2 TV package ID: `io.airo.app.tv`
* Avoids unsupported claims for EPG, favorites, recording, cloud playlists, or bundled channels
* Keeps the required IPTV content disclaimer in the full description

# API Changes

None.

# Database Changes

None.

# Observability / Logging

None.

# Performance Impact

None. Documentation-only change.

# Risks

* Stakeholders may still want wording adjustments before live store submission.
* Screenshot, app icon export, and feature graphic assets remain separate release blockers in #582.

Rollback plan:

* Revert this documentation commit if listing positioning changes materially.

# Testing

* `python3` character-count assertion for Play short description, Play full description, and App Store keywords
* `git diff --check origin/v2...HEAD`
* `bash scripts/check-docs-completeness.sh --base origin/v2 --head HEAD`

# Deployment Notes

Human follow-up remains required:

* Approve final listing copy for Play submission
* Complete IARC/content rating and Data Safety forms
* Upload final screenshots, feature graphic, and app icon assets through #582

# Related Commits

* `docs(release): finalize Airo TV store metadata`

Closes #581.
