### PR TITLE
fix(release): align Airo TV data safety declarations

### DIFF
--- a/app/lib/core/cast/flutter_chrome_cast_controller.dart
+++ b/app/lib/core/cast/flutter_chrome_cast_controller.dart
@@ -69,11 +69,7 @@ class FlutterChromeCastController implements AiroCastController {
 
     try {
       await GoogleCastContext.instance.setSharedInstanceWithOptions(
-        GoogleCastOptions(
-          disableDiscoveryAutostart: true,
-          startDiscoveryAfterFirstTapOnCastButton: false,
-          stopReceiverApplicationWhenEndingSession: false,
-        ),
+        buildCastOptions(),
       );
       _listenToPluginStreams();
       _initialized = true;
@@ -87,6 +83,16 @@ class FlutterChromeCastController implements AiroCastController {
         ),
       );
     }
+  }
+
+  @visibleForTesting
+  static GoogleCastOptions buildCastOptions() {
+    return GoogleCastOptions(
+      disableAnalyticsLogging: true,
+      disableDiscoveryAutostart: true,
+      startDiscoveryAfterFirstTapOnCastButton: false,
+      stopReceiverApplicationWhenEndingSession: false,
+    );
   }
 
   @override

--- a/app/test/core/cast/flutter_chrome_cast_request_mapping_test.dart
+++ b/app/test/core/cast/flutter_chrome_cast_request_mapping_test.dart
@@ -4,6 +4,13 @@ import 'package:flutter_chrome_cast/entities.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
+  test('disables Cast analytics logging during initialization', () {
+    final options = FlutterChromeCastController.buildCastOptions();
+
+    expect(options.toMap()['disableAnalyticsLogging'], isTrue);
+    expect(options.toMap()['disableDiscoveryAutostart'], isTrue);
+  });
+
   test('maps Airo live HLS request to GoogleCastMediaInformation', () {
     final request = AiroCastMediaRequest(
       url: Uri.parse('https://example.com/channel.m3u8'),

--- a/docs/legal/privacy-policy.md
+++ b/docs/legal/privacy-policy.md
@@ -42,8 +42,13 @@ us** in any way.
 
 - **User preferences** — stored locally on your device
 - **IPTV playlist URLs** — user-provided, stored locally on your device
-- **Favorites and watch history** — stored locally on your device
-- **EPG (Electronic Program Guide) data** — cached locally for performance
+- **Playback and playlist cache data** — stored locally when needed for app
+  functionality
+
+Planned features such as favorites, watch history, and Electronic Program
+Guide (EPG) data are not part of the current Airo TV v0.0.2 release. If those
+features are added later, the store declarations and this policy must be
+reviewed before public distribution.
 
 ### Data We Do NOT Collect
 
@@ -61,12 +66,12 @@ us** in any way.
 Airo TV processes all data locally on your device. Specifically:
 
 - **IPTV playlist parsing** is performed entirely on-device.
-- **EPG data** is fetched from URLs you provide and cached locally.
+- **Cast analytics logging is disabled** when initializing Google Cast support.
 - **No user data is transmitted** to DevelopersCoffee servers or any
   third-party analytics services.
 
-Your streaming content, playlist URLs, favorites, and viewing history
-**never leave your device**.
+Your streaming content and playlist URLs **never leave your device** except
+when your TV/device requests the stream or playlist URL that you chose to load.
 
 ---
 

--- a/docs/release/AIRO_TV_DATA_SAFETY.md
+++ b/docs/release/AIRO_TV_DATA_SAFETY.md
@@ -1,0 +1,94 @@
+# Airo TV Data Safety And App Privacy Declarations
+
+Console-ready privacy declaration worksheet for the Airo TV v2 release profile.
+Use this when completing Google Play Data Safety and any future Apple App
+Privacy labels. Final submission still requires a maintainer with store-console
+access.
+
+## Scope
+
+| Field | Value |
+| --- | --- |
+| Product | Airo TV |
+| Android package ID | `io.airo.app.tv` |
+| Entrypoint | `app/lib/main_tv.dart` |
+| Privacy Policy URL | `https://developerscoffee.github.io/airo/legal/privacy-policy/` |
+| Terms URL | `https://developerscoffee.github.io/airo/legal/terms-conditions/` |
+| Current release | v0.0.2 |
+
+This declaration is based on the current v2 TV release behavior:
+
+- User-provided playlist URLs and app preferences are stored locally.
+- Airo TV does not provide channels, playlists, streams, or subscriptions.
+- App-owned Firebase Analytics and Firebase Crashlytics SDKs are not included
+  in `app/pubspec_tv.yaml`.
+- Google Cast analytics logging is explicitly disabled during Cast
+  initialization.
+- Firebase Core/Auth packages may be present for runtime initialization and
+  future auth compatibility, but the TV flow does not require account sign-in
+  for IPTV playback.
+
+## Google Play Data Safety
+
+### Data Collection Summary
+
+| Data type | Collected by app? | Shared? | Purpose | Notes |
+| --- | --- | --- | --- | --- |
+| Name | No | No | Not applicable | TV playback does not require account creation. |
+| Email address | No | No | Not applicable | Firebase Auth is present but not required by the TV IPTV flow. |
+| User IDs | No | No | Not applicable | No app-owned account identifier is required for TV playback. |
+| Precise or approximate location | No | No | Not applicable | No location permission is declared in the TV manifest. |
+| Contacts | No | No | Not applicable | Contact permissions are removed from the TV release profile. |
+| Photos, videos, or audio files | No | No | Not applicable | No camera, microphone, or media-library permission is declared for TV. |
+| Financial info | No | No | Not applicable | No purchases or payment flow in the TV release. |
+| Health and fitness | No | No | Not applicable | Not used. |
+| Messages | No | No | Not applicable | Not used. |
+| App activity | No app-owned external collection | No | App functionality | Preferences and playlist state are stored on device. |
+| Web browsing | No | No | Not applicable | Airo TV does not provide a browser. |
+| App info and performance | No app-owned external collection | No | Diagnostics only if user shares logs manually | Crashlytics is not included in the TV pubspec. |
+| Device or other IDs | No app-owned external collection | No | Not applicable | No advertising ID permission or analytics SDK is enabled. |
+| IPTV playlist URLs | Local only | No | App functionality | User-provided playlist URLs are stored on device and used to fetch user-selected content. |
+| Stream URLs | Local/runtime only | No | App functionality | Stream URLs are requested by the app/player/Cast receiver only to play user-selected content. |
+
+Recommended Play Console answer:
+
+```text
+The app does not collect or share user data with the developer for the current
+TV release. User-provided IPTV playlist URLs, preferences, and playback state
+are stored locally on the device for app functionality. The app does not include
+advertising, analytics, Crashlytics, purchases, location, contacts, camera, or
+microphone data collection in the TV profile.
+```
+
+### Security Practices
+
+| Question | Recommended answer |
+| --- | --- |
+| Is all user data collected encrypted in transit? | Not applicable for developer collection. Network requests initiated by users use the URL scheme of the playlist or stream they provide. |
+| Can users request that data be deleted? | Local app data is removed by clearing app storage or uninstalling the app. No developer-hosted account data is collected for TV playback. |
+| Is data shared with third parties? | No app-owned user data sharing. Users may load playlist/stream URLs from third-party providers they choose. |
+| Does the app use advertising ID? | No. |
+| Does the app use tracking for ads or cross-app profiling? | No. |
+
+## Apple App Privacy Draft
+
+iOS/iPadOS publication is deferred from the first v2 Android release wave. If
+maintainers later add iOS/tvOS to scope, use this draft only after re-checking
+the active iOS dependency set and runtime behavior.
+
+| App Privacy category | Draft answer |
+| --- | --- |
+| Data Used to Track You | None |
+| Data Linked to You | None for the current TV IPTV playback flow |
+| Data Not Linked to You | None collected by the developer for the current TV profile |
+| Diagnostics | None unless a crash-reporting SDK is added before submission |
+| User Content | User-provided playlist URLs are local app functionality data, not collected by the developer |
+
+## Human Console Actions
+
+- Complete Google Play Data Safety using the final answers above.
+- Complete App Store Connect App Privacy labels only if iOS/tvOS enters scope.
+- Re-check this document if Firebase Analytics, Crashlytics, ads, account
+  sign-in, cloud playlists, EPG sync, favorites sync, or server-side telemetry
+  is added before release.
+- Attach screenshots or console export evidence back to #583 after submission.

--- a/docs/release/README.md
+++ b/docs/release/README.md
@@ -45,6 +45,7 @@ Documentation for Airo releases and version history.
 | [Airo TV Feature Matrix](./AIRO_TV_FEATURE_MATRIX.md) | Supported, planned, and unsupported features |
 | [Airo TV Media Assets](./AIRO_TV_MEDIA_ASSETS.md) | Screenshot and demo-video release checklist |
 | [Airo TV Store Listing Metadata](./AIRO_TV_STORE_LISTING.md) | Final Play listing copy and future App Store draft metadata |
+| [Airo TV Data Safety](./AIRO_TV_DATA_SAFETY.md) | Play Data Safety and future App Privacy declaration worksheet |
 | [Airo V1 and V2 Version Lines](./VERSION_LINES.md) | Base branch, tag, artifact, and support policy for monolith V1 and modular V2 |
 | [V2 Distribution Matrix](./V2_DISTRIBUTION_MATRIX.md) | Supported v2 profiles, artifact naming, channels, and support policy |
 | [V2 Publishing Human Setup](./V2_PUBLISHING_HUMAN_SETUP.md) | Account, credential, signing, store, and governance decisions maintainers must complete |

--- a/docs/release/STORE_COMPLIANCE.md
+++ b/docs/release/STORE_COMPLIANCE.md
@@ -89,9 +89,10 @@ and AI Core bind-service permissions inherited from broader dependencies.
 | Firebase App Distribution upload automation | Ready after Firebase app IDs, tester groups, and credential secret are configured | `firebase_distribution` in `.github/workflows/v2-release-orchestrator.yml` |
 | GitHub Release asset publication | Ready in orchestrator for selected v2 profiles | `.github/workflows/v2-release-orchestrator.yml` |
 | IARC content rating completed | Pending store-console action | #584 |
-| Data Safety form completed | Pending store-console action | #584/#581 |
+| Data Safety form completed | Pending store-console action | #583 |
 | Store metadata finalized | Ready pending stakeholder approval | #581, `docs/release/AIRO_TV_STORE_LISTING.md` |
 | TV screenshots and feature graphic uploaded | Pending media assets | #582 |
+| Data Safety and App Privacy declarations | Ready for console entry | #583, `docs/release/AIRO_TV_DATA_SAFETY.md` |
 | Release qualification evidence attached | Pending actual release evidence | #683 |
 
 ## App Store / iOS Checklist
@@ -130,7 +131,9 @@ Before submitting a public v2 Android release:
       [V2 Publishing Human Setup](./V2_PUBLISHING_HUMAN_SETUP.md).
 - [ ] Confirm stakeholder approval for
       [Airo TV Store Listing Metadata](./AIRO_TV_STORE_LISTING.md).
-- [ ] Complete content rating and data-safety store-console forms in #584.
+- [ ] Complete Data Safety/App Privacy console forms from
+      [Airo TV Data Safety](./AIRO_TV_DATA_SAFETY.md).
+- [ ] Complete content rating store-console forms in #584.
 - [ ] Attach release qualification evidence or an explicit waiver per
       [V2 Release Qualification](./V2_RELEASE_QUALIFICATION.md).
 - [x] Confirm every public APK/AAB has `SHA256SUMS` and a release manifest.
@@ -142,6 +145,7 @@ Before submitting a public v2 Android release:
 - #575, #577, #578, #579: legal/docs foundation.
 - #581: final Play/App Store listing metadata.
 - #582: final Play screenshot, feature graphic, and app icon assets.
+- #583: final Play Data Safety and App Store App Privacy console forms.
 - #584: IARC/content rating and App Store age-rating questionnaires.
 - #585: Fastlane/store credentials and signing setup.
 - #675: supported v2 device/profile artifact matrix.

--- a/docs/wiki/9.-Useful-Links.md
+++ b/docs/wiki/9.-Useful-Links.md
@@ -10,6 +10,7 @@
 - [Trust and transparency](../../TRUST.md)
 - [MIT license](../../LICENSE)
 - [Airo TV store listing metadata](../release/AIRO_TV_STORE_LISTING.md)
+- [Airo TV data safety](../release/AIRO_TV_DATA_SAFETY.md)
 - [V2 third-party notices](../release/V2_THIRD_PARTY_NOTICES.md)
 - [Product strategy](../PRODUCT_STRATEGY.md)
 - [Technical architecture](../architecture/TECHNICAL_ARCHITECTURE.md)

--- a/packages/platform_player/lib/src/services/flutter_chrome_cast_controller.dart
+++ b/packages/platform_player/lib/src/services/flutter_chrome_cast_controller.dart
@@ -77,27 +77,10 @@ class FlutterChromeCastController implements AiroCastController {
     if (_initialized) return;
 
     try {
-      final castOptions = Platform.isIOS
-          ? IOSGoogleCastOptions(
-              GoogleCastDiscoveryCriteriaInitialize.initWithApplicationID(
-                defaultReceiverApplicationId,
-              ),
-              disableDiscoveryAutostart: true,
-              startDiscoveryAfterFirstTapOnCastButton: false,
-              stopReceiverApplicationWhenEndingSession: false,
-            )
-          : Platform.isAndroid
-          ? GoogleCastOptionsAndroid(
-              appId: defaultReceiverApplicationId,
-              disableDiscoveryAutostart: true,
-              startDiscoveryAfterFirstTapOnCastButton: false,
-              stopReceiverApplicationWhenEndingSession: false,
-            )
-          : GoogleCastOptions(
-              disableDiscoveryAutostart: true,
-              startDiscoveryAfterFirstTapOnCastButton: false,
-              stopReceiverApplicationWhenEndingSession: false,
-            );
+      final castOptions = buildCastOptions(
+        isAndroid: Platform.isAndroid,
+        isIOS: Platform.isIOS,
+      );
 
       await GoogleCastContext.instance.setSharedInstanceWithOptions(
         castOptions,
@@ -116,6 +99,41 @@ class FlutterChromeCastController implements AiroCastController {
         ),
       );
     }
+  }
+
+  @visibleForTesting
+  static GoogleCastOptions buildCastOptions({
+    required bool isAndroid,
+    required bool isIOS,
+  }) {
+    if (isIOS) {
+      return IOSGoogleCastOptions(
+        GoogleCastDiscoveryCriteriaInitialize.initWithApplicationID(
+          defaultReceiverApplicationId,
+        ),
+        disableAnalyticsLogging: true,
+        disableDiscoveryAutostart: true,
+        startDiscoveryAfterFirstTapOnCastButton: false,
+        stopReceiverApplicationWhenEndingSession: false,
+      );
+    }
+
+    if (isAndroid) {
+      return GoogleCastOptionsAndroid(
+        appId: defaultReceiverApplicationId,
+        disableAnalyticsLogging: true,
+        disableDiscoveryAutostart: true,
+        startDiscoveryAfterFirstTapOnCastButton: false,
+        stopReceiverApplicationWhenEndingSession: false,
+      );
+    }
+
+    return GoogleCastOptions(
+      disableAnalyticsLogging: true,
+      disableDiscoveryAutostart: true,
+      startDiscoveryAfterFirstTapOnCastButton: false,
+      stopReceiverApplicationWhenEndingSession: false,
+    );
   }
 
   @override

--- a/packages/platform_player/test/flutter_chrome_cast_controller_test.dart
+++ b/packages/platform_player/test/flutter_chrome_cast_controller_test.dart
@@ -4,6 +4,28 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:platform_player/platform_player.dart';
 
 void main() {
+  group('Cast options', () {
+    test('disable analytics logging for Android Cast initialization', () {
+      final options = FlutterChromeCastController.buildCastOptions(
+        isAndroid: true,
+        isIOS: false,
+      );
+
+      expect(options.toMap()['disableAnalyticsLogging'], isTrue);
+      expect(options.toMap()['disableDiscoveryAutostart'], isTrue);
+    });
+
+    test('disable analytics logging for iOS Cast initialization', () {
+      final options = FlutterChromeCastController.buildCastOptions(
+        isAndroid: false,
+        isIOS: true,
+      );
+
+      expect(options.toMap()['disableAnalyticsLogging'], isTrue);
+      expect(options.toMap()['disableDiscoveryAutostart'], isTrue);
+    });
+  });
+
   test('maps live HLS request to Google Cast media information', () {
     final request = AiroCastMediaRequest(
       url: Uri.parse('https://example.com/channel.m3u8'),


### PR DESCRIPTION
# Summary

This PR prepares the Airo TV Data Safety/App Privacy submission evidence for #583.
Goal: make the store privacy declarations match actual v2 TV runtime behavior before a maintainer enters them in Play Console or App Store Connect.

Core outcome:

* Disables Google Cast analytics logging explicitly in both Cast controller surfaces
* Adds a console-ready Airo TV Data Safety/App Privacy declaration worksheet
* Updates the privacy policy so it does not claim planned EPG/favorites storage for the current release

# Changes

### Code

* Added:
  * `docs/release/AIRO_TV_DATA_SAFETY.md`
* Updated:
  * `packages/platform_player/lib/src/services/flutter_chrome_cast_controller.dart`
  * `app/lib/core/cast/flutter_chrome_cast_controller.dart`
  * Cast controller tests for analytics opt-out behavior
  * `docs/legal/privacy-policy.md`
  * release compliance and index docs

### Logic

* Cast initialization now sets `disableAnalyticsLogging: true`.
* The Data Safety worksheet documents that the TV profile does not include app-owned Firebase Analytics or Crashlytics SDKs.
* Store declarations distinguish local playlist/preference storage from developer-collected user data.

# API Changes

None. New Cast option builders are test-visible helpers only.

# Database Changes

None.

# Observability / Logging

* Reduces third-party Cast analytics exposure by explicitly disabling Cast analytics logging.

# Performance Impact

None expected.

# Risks

* A maintainer must re-check declarations if analytics, Crashlytics, ads, account sign-in, cloud playlists, EPG sync, favorites sync, or server-side telemetry are added before release.
* Final Play Console/App Store Connect answers still need human console access.

Rollback plan:

* Revert this commit if maintainers intentionally enable Cast analytics or choose a different data declaration policy.

# Testing

* `cd packages/platform_player && flutter test test/flutter_chrome_cast_controller_test.dart`
* `cd app && flutter test test/core/cast/flutter_chrome_cast_request_mapping_test.dart`
* `git diff --check origin/v2...HEAD`
* `bash scripts/check-docs-completeness.sh --base origin/v2 --head HEAD`

# Deployment Notes

Human follow-up required for #583:

* Enter the prepared Data Safety answers in Google Play Console.
* Complete App Store Connect App Privacy labels only if iOS/tvOS enters scope.
* Attach console evidence back to #583.

# Related Commits

* `fix(release): align Airo TV data safety declarations`

Refs #583.
