### PR TITLE
docs(release): add Airo TV content rating worksheet

### DIFF
--- a/docs/legal/terms-conditions.md
+++ b/docs/legal/terms-conditions.md
@@ -63,29 +63,28 @@ to accept updates if you want to keep using the app.
 
 ---
 
-## Supported Formats
+## Current Release Capabilities
 
-Airo TV supports the following media formats and protocols:
+Airo TV v0.0.2 supports the current release capabilities documented in the
+[Airo TV Feature Matrix](/airo/release/AIRO_TV_FEATURE_MATRIX/).
 
 ### Playlist Formats
 - M3U / M3U8
 
-### Video Formats
-- MP4, MKV, AVI, MOV, FLV, WMV, WEBM
+### Playback
 
-### Streaming Protocols
-- HLS (HTTP Live Streaming)
-- MPEG-TS (Transport Stream)
-- RTMP (Real-Time Messaging Protocol)
-- RTSP (Real-Time Streaming Protocol)
-
-### Audio Formats
-- MP3, AAC, WAV, FLAC, OGG
+Playback depends on the stream URL, protocol, codec support, and capabilities
+of your Android TV, Google TV, or compatible device. Airo TV does not guarantee
+that every third-party playlist or stream URL will play.
 
 ### Additional Features
-- EPG (Electronic Program Guide) via XMLTV
 - Chromecast casting support
-- Subtitle support (SRT, VTT)
+- Channel search by name
+- TV-focused remote navigation
+
+Planned features such as EPG, favorites, recording, cloud playlists, and AI
+Search are not included in the current release unless the feature matrix marks
+them supported.
 
 ---
 

--- a/docs/release/AIRO_TV_CONTENT_RATING.md
+++ b/docs/release/AIRO_TV_CONTENT_RATING.md
@@ -1,0 +1,69 @@
+# Airo TV Content Rating Worksheet
+
+Console-ready worksheet for Airo TV content rating submissions. Use this when
+completing the Google Play IARC questionnaire and any future App Store Connect
+age rating questionnaire. Final ratings are assigned by the store consoles and
+must be saved by a maintainer with console access.
+
+## Scope
+
+| Field | Value |
+| --- | --- |
+| Product | Airo TV |
+| Android package ID | `io.airo.app.tv` |
+| Entrypoint | `app/lib/main_tv.dart` |
+| Current release | v0.0.2 |
+| Privacy minimum age posture | Not directed to children under 16 |
+| Content model | Media player for user-provided playlist and stream URLs |
+
+## Recommended Store Position
+
+| Store | Expected result | Reason |
+| --- | --- | --- |
+| Google Play / IARC | Teen / 12+ or stricter if questionnaire output requires it | The app UI has no mature content, but users can load external media streams. |
+| App Store Connect | 12+ or stricter if questionnaire output requires it | Future iOS/tvOS scope would allow user-provided streaming URLs. |
+| Target audience | 16+ | Aligns with the current Privacy Policy children's privacy posture. |
+
+Do not market Airo TV as child-directed. Do not select a lower age target
+unless legal/privacy copy is changed first.
+
+## Questionnaire Answers
+
+| Topic | Recommended answer | Evidence / notes |
+| --- | --- | --- |
+| User-generated content | No social or in-app user-generated content platform | Users provide private playlist/stream URLs; Airo TV does not publish, host, or share user content. |
+| Unrestricted internet / web access | Yes if the questionnaire treats user-entered playlist or stream URLs as unrestricted network content | Users can load external media URLs they provide. |
+| Violence in app UI | No | Airo TV UI does not include violent content. User-loaded streams are outside app-provided content. |
+| Sexual content or nudity in app UI | No | Airo TV UI does not include sexual content or nudity. |
+| Profanity or crude humor in app UI | No | Airo TV UI does not include profanity or crude humor. |
+| Alcohol, tobacco, drugs, or regulated goods in app UI | No | No app-provided regulated-goods content. |
+| Gambling or contests | No | No gambling feature, betting flow, or contest mechanic. |
+| Horror/fear content in app UI | No | No app-provided horror/fear content. |
+| Ads | No | No advertising SDK or ad placement in the v2 TV release profile. |
+| In-app purchases | No | No purchase flow in the v2 TV release profile. |
+| User interaction / chat | No | No chat, social feed, or user-to-user communication in the TV IPTV flow. |
+| Location sharing | No | No location permission in the TV manifest. |
+| Account creation required | No | IPTV playback does not require account sign-in. |
+| Content disclaimer | Yes | Airo TV is a media player only and does not provide channels, playlists, streams, or subscriptions. |
+
+## Store Notes
+
+Recommended note for internal review:
+
+```text
+Airo TV is a media player for user-provided IPTV playlist and stream URLs. The
+app does not provide channels, subscriptions, playlists, streams, ads, gambling,
+chat, purchases, or app-hosted mature content. Because users can enter external
+media URLs, choose the questionnaire option that best represents unrestricted
+user-provided media/network content and accept the resulting Teen/12+ or
+stricter rating.
+```
+
+## Human Console Actions
+
+- Complete the Google Play IARC questionnaire for `io.airo.app.tv`.
+- Save the resulting Play rating certificate or console screenshot.
+- Complete App Store Connect age rating only if iOS/tvOS enters release scope.
+- Attach rating evidence back to #584 before closing the issue.
+- Re-run this review if ads, purchases, chat, cloud playlists, EPG sync,
+  account-gated services, curated content, or bundled streams are added.

--- a/docs/release/README.md
+++ b/docs/release/README.md
@@ -46,6 +46,7 @@ Documentation for Airo releases and version history.
 | [Airo TV Media Assets](./AIRO_TV_MEDIA_ASSETS.md) | Screenshot and demo-video release checklist |
 | [Airo TV Store Listing Metadata](./AIRO_TV_STORE_LISTING.md) | Final Play listing copy and future App Store draft metadata |
 | [Airo TV Data Safety](./AIRO_TV_DATA_SAFETY.md) | Play Data Safety and future App Privacy declaration worksheet |
+| [Airo TV Content Rating](./AIRO_TV_CONTENT_RATING.md) | IARC and future App Store age rating questionnaire worksheet |
 | [Airo V1 and V2 Version Lines](./VERSION_LINES.md) | Base branch, tag, artifact, and support policy for monolith V1 and modular V2 |
 | [V2 Distribution Matrix](./V2_DISTRIBUTION_MATRIX.md) | Supported v2 profiles, artifact naming, channels, and support policy |
 | [V2 Publishing Human Setup](./V2_PUBLISHING_HUMAN_SETUP.md) | Account, credential, signing, store, and governance decisions maintainers must complete |

--- a/docs/release/STORE_COMPLIANCE.md
+++ b/docs/release/STORE_COMPLIANCE.md
@@ -88,7 +88,7 @@ and AI Core bind-service permissions inherited from broader dependencies.
 | Play upload automation for mobile/tablet | Ready after credentials, selected profile, and track selection | `mobile_play_track` in `.github/workflows/v2-release-orchestrator.yml` |
 | Firebase App Distribution upload automation | Ready after Firebase app IDs, tester groups, and credential secret are configured | `firebase_distribution` in `.github/workflows/v2-release-orchestrator.yml` |
 | GitHub Release asset publication | Ready in orchestrator for selected v2 profiles | `.github/workflows/v2-release-orchestrator.yml` |
-| IARC content rating completed | Pending store-console action | #584 |
+| IARC content rating completed | Pending store-console action; worksheet ready | #584, `docs/release/AIRO_TV_CONTENT_RATING.md` |
 | Data Safety form completed | Pending store-console action | #583 |
 | Store metadata finalized | Ready pending stakeholder approval | #581, `docs/release/AIRO_TV_STORE_LISTING.md` |
 | TV screenshots and feature graphic uploaded | Pending media assets | #582 |
@@ -133,7 +133,8 @@ Before submitting a public v2 Android release:
       [Airo TV Store Listing Metadata](./AIRO_TV_STORE_LISTING.md).
 - [ ] Complete Data Safety/App Privacy console forms from
       [Airo TV Data Safety](./AIRO_TV_DATA_SAFETY.md).
-- [ ] Complete content rating store-console forms in #584.
+- [ ] Complete content rating store-console forms from
+      [Airo TV Content Rating](./AIRO_TV_CONTENT_RATING.md).
 - [ ] Attach release qualification evidence or an explicit waiver per
       [V2 Release Qualification](./V2_RELEASE_QUALIFICATION.md).
 - [x] Confirm every public APK/AAB has `SHA256SUMS` and a release manifest.

--- a/docs/wiki/9.-Useful-Links.md
+++ b/docs/wiki/9.-Useful-Links.md
@@ -11,6 +11,7 @@
 - [MIT license](../../LICENSE)
 - [Airo TV store listing metadata](../release/AIRO_TV_STORE_LISTING.md)
 - [Airo TV data safety](../release/AIRO_TV_DATA_SAFETY.md)
+- [Airo TV content rating](../release/AIRO_TV_CONTENT_RATING.md)
 - [V2 third-party notices](../release/V2_THIRD_PARTY_NOTICES.md)
 - [Product strategy](../PRODUCT_STRATEGY.md)
 - [Technical architecture](../architecture/TECHNICAL_ARCHITECTURE.md)


### PR DESCRIPTION
# Summary

This PR prepares the content-rating submission worksheet for #584.
Goal: give maintainers conservative, console-ready IARC/App Store age-rating guidance for `io.airo.app.tv`.

Core outcome:

* Adds `docs/release/AIRO_TV_CONTENT_RATING.md`
* Updates release compliance docs to point content-rating work at the worksheet
* Aligns Terms copy with the current feature matrix so planned features are not represented as shipped

# Changes

### Code

* Added:
  * `docs/release/AIRO_TV_CONTENT_RATING.md`
* Updated:
  * `docs/legal/terms-conditions.md`
  * `docs/release/STORE_COMPLIANCE.md`
  * release docs indexes

### Logic

* Documents conservative rating guidance: app UI has no mature content, ads, gambling, chat, or purchases, but users can load external media URLs.
* Keeps target audience aligned with the Privacy Policy posture: not directed to children under 16.
* Removes unsupported Terms claims for EPG/subtitle/protocol support and points to the current feature matrix.

# API Changes

None.

# Database Changes

None.

# Observability / Logging

None.

# Performance Impact

None. Documentation-only change.

# Risks

* Final rating may differ depending on store-console questionnaire wording and region-specific IARC output.
* Maintainers must re-run the review if ads, purchases, chat, cloud playlists, EPG sync, account-gated services, curated content, or bundled streams are added.

Rollback plan:

* Revert this docs commit if legal/store positioning changes.

# Testing

* `git diff --check origin/v2...HEAD`
* `bash scripts/check-docs-completeness.sh --base origin/v2 --head HEAD`

# Deployment Notes

Human follow-up required for #584:

* Complete the Google Play IARC questionnaire for `io.airo.app.tv`.
* Save the resulting rating certificate or console screenshot.
* Complete App Store Connect age rating only if iOS/tvOS enters release scope.
* Attach rating evidence back to #584.

# Related Commits

* `docs(release): add Airo TV content rating worksheet`

Refs #584.
