### PR TITLE
ci: limit Sonar PR comments to failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,8 @@ on:
   push:
     tags:
       - 'v*'
+  pull_request:
+    branches: [ main, v2 ]
   workflow_dispatch:
     inputs:
       build_full_android:
@@ -559,51 +561,85 @@ jobs:
 
   sonarqube:
     runs-on: ubuntu-latest
-    needs: test-app
-    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+    needs: [analyze, test-core]
+    if: >
+      github.event_name == 'pull_request' && (github.base_ref == 'main' || github.base_ref == 'v2')
+    permissions:
+      contents: read
+      checks: read
+      issues: write
+      pull-requests: read
     steps:
-      - uses: actions/checkout@v7
+      - name: Comment PR on SonarCloud Quality Gate failure
+        uses: actions/github-script@v8
         with:
-          fetch-depth: 0
+          script: |
+            const checkName = 'SonarCloud Code Analysis';
+            const marker = '<!-- airo-sonarqube-quality-gate-failure -->';
+            const headSha = context.payload.pull_request.head.sha;
 
-      - name: Setup Flutter
-        uses: subosito/flutter-action@v2
-        with:
-          flutter-version: ${{ env.FLUTTER_VERSION }}
-          channel: 'stable'
-          cache: true
+            let sonarCheck;
+            for (let attempt = 0; attempt < 40; attempt += 1) {
+              const { data } = await github.rest.checks.listForRef({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                ref: headSha,
+                per_page: 100,
+              });
+              sonarCheck = data.check_runs.find((check) => check.name === checkName);
 
-      - name: Get dependencies
-        run: |
-          cd app
-          flutter pub get
+              if (sonarCheck?.status === 'completed') {
+                break;
+              }
 
-      - name: Run tests with coverage
-        run: |
-          cd app
-          flutter test --coverage
+              await new Promise((resolve) => setTimeout(resolve, 15000));
+            }
 
-      - name: SonarQube Scan
-        uses: SonarSource/sonarqube-scan-action@master
-        env:
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-          SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
-        with:
-          args: >
-            -Dsonar.projectKey=airo-super-app
-            -Dsonar.projectName="Airo Super App"
-            -Dsonar.sources=app/lib
-            -Dsonar.tests=app/test
-            -Dsonar.dart.coverage.reportPath=app/coverage/lcov.info
-            -Dsonar.exclusions=**/*.g.dart,**/*.freezed.dart,**/generated/**
-        continue-on-error: true
+            if (!sonarCheck) {
+              core.setFailed(`${checkName} was not found for ${headSha}.`);
+              return;
+            }
 
-      - name: SonarQube Quality Gate
-        uses: SonarSource/sonarqube-quality-gate-action@master
-        timeout-minutes: 5
-        env:
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        continue-on-error: true
+            if (sonarCheck.conclusion === 'success') {
+              core.info(`${checkName} passed.`);
+              return;
+            }
+
+            const body = [
+              marker,
+              `## SonarCloud Quality Gate ${sonarCheck.conclusion ?? 'failed'}`,
+              '',
+              'The SonarCloud quality gate did not pass for this PR.',
+              '',
+              `[View SonarCloud details](${sonarCheck.details_url})`,
+            ].join('\n');
+            const comments = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              per_page: 100,
+            });
+            const existing = comments.data.find((comment) =>
+              comment.user.type === 'Bot' && comment.body.includes(marker)
+            );
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }
+
+            core.setFailed(`${checkName} concluded with ${sonarCheck.conclusion}.`);
 
   snyk:
     runs-on: ubuntu-latest

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -29,6 +29,12 @@ sonar.coverage.new.threshold=70
 # Quality gate
 sonar.qualitygate.wait=true
 
+# GitHub PR decoration
+# Keep the GitHub quality gate check, but suppress SonarQube Cloud's automatic
+# "Quality Gate passed" summary comment. Failure-only PR comments are handled
+# by GitHub Actions.
+sonar.pullrequest.github.summary_comment=false
+
 # Organization (for SonarCloud)
 sonar.organization=airo-super-app
 
@@ -45,4 +51,3 @@ sonar.cpd.exclusions=**/*.g.dart,**/*.freezed.dart,**/test/**
 
 # New code definition (changes in last 30 days or from previous version)
 sonar.leak.period=previous_version
-


### PR DESCRIPTION
## Summary
- suppress SonarQube Cloud's automatic GitHub PR summary comment
- keep the Sonar quality gate as a GitHub check
- add a repo-owned PR comment only when the quality gate fails
- add PR triggering for main/v2 so branch protection can require the check

## Verification
- ruby YAML parse for .github/workflows/ci.yml
- git diff --check