### PR TITLE
chore(release): wire Fastlane credential inputs

### DIFF
--- a/app/android/fastlane/Appfile
+++ b/app/android/fastlane/Appfile
@@ -1,7 +1,16 @@
 # Appfile for Airo Android
-# 
-# Uncomment and configure with your Play Store credentials
+#
+# CI writes the Google Play service account JSON to
+# app/android/play-store-credentials.json before invoking Fastlane. Local
+# maintainers can override both values without editing this tracked file:
+#
+#   SUPPLY_JSON_KEY=/path/to/play-store-credentials.json
+#   SUPPLY_PACKAGE_NAME=io.airo.app.tv
 
-# json_key_file("play-store-credentials.json") # Path to the json secret file
-# package_name("com.developerscoffee.airo") # Your package name
+play_json_key = ENV.fetch(
+  "SUPPLY_JSON_KEY_FILE",
+  ENV.fetch("SUPPLY_JSON_KEY", "play-store-credentials.json"),
+)
 
+json_key_file(play_json_key)
+package_name(ENV.fetch("SUPPLY_PACKAGE_NAME", "io.airo.app.tv"))

--- a/app/ios/fastlane/Appfile
+++ b/app/ios/fastlane/Appfile
@@ -1,9 +1,10 @@
 # Appfile for Airo iOS
 #
-# Uncomment and configure with your App Store credentials
+# iOS/iPadOS publication is deferred from the first v2 Android release wave.
+# When maintainers enable it, configure account-specific values through the
+# environment instead of committing Apple account identifiers.
 
-# app_identifier("com.developerscoffee.airo") # Your bundle identifier
-# apple_id("your@email.com") # Your Apple ID
-# team_id("XXXXXXXXXX") # Your Team ID
-# itc_team_id("XXXXXXXXXX") # App Store Connect Team ID (if different)
-
+app_identifier(ENV.fetch("APP_IDENTIFIER", "com.developerscoffee.airo"))
+apple_id(ENV["APPLE_ID"]) if ENV["APPLE_ID"]
+team_id(ENV["TEAM_ID"]) if ENV["TEAM_ID"]
+itc_team_id(ENV["ITC_TEAM_ID"]) if ENV["ITC_TEAM_ID"]

--- a/docs/release/FASTLANE_CREDENTIALS.md
+++ b/docs/release/FASTLANE_CREDENTIALS.md
@@ -1,0 +1,67 @@
+# Fastlane Credential Setup
+
+Fastlane configuration is present for Android and iOS, but real store uploads
+remain human-gated until account owners configure store accounts, signing, and
+repository secrets.
+
+## Android / Google Play
+
+The Android Appfile is `app/android/fastlane/Appfile`.
+
+It reads:
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `SUPPLY_JSON_KEY` or `SUPPLY_JSON_KEY_FILE` | `play-store-credentials.json` | Path to the Google Play service account JSON file used by Fastlane Supply. |
+| `SUPPLY_PACKAGE_NAME` | `io.airo.app.tv` | Package ID to upload. Override for mobile/tablet profiles. |
+
+Release workflows already write the Play service account JSON from
+`GOOGLE_PLAY_SERVICE_ACCOUNT_JSON` to
+`app/android/play-store-credentials.json` before invoking Play upload steps.
+
+Use these package values for v2 Android profiles:
+
+| Profile | `SUPPLY_PACKAGE_NAME` |
+| --- | --- |
+| `tv` | `io.airo.app.tv` |
+| `iptv-standalone` | `io.airo.app.iptv` |
+| `mobile-streaming` | `io.airo.app.streaming` |
+
+Human setup still required:
+
+- Create or confirm Play Console apps for the selected public packages.
+- Create a Play service account and grant release permissions for the selected
+  apps.
+- Store the service account JSON as `GOOGLE_PLAY_SERVICE_ACCOUNT_JSON`.
+- Confirm the first track for each profile: `internal`, `alpha`, `beta`,
+  `production`, or `none`.
+
+Local smoke check after credentials are available:
+
+```bash
+cd app/android
+SUPPLY_PACKAGE_NAME=io.airo.app.tv \
+SUPPLY_JSON_KEY=play-store-credentials.json \
+bundle exec fastlane supply init
+```
+
+## iOS / App Store Connect
+
+iOS/iPadOS publication is deferred from the first v2 Android release wave.
+The iOS Appfile is `app/ios/fastlane/Appfile` and reads account-specific values
+from the environment:
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `APP_IDENTIFIER` | `com.developerscoffee.airo` | App Store bundle identifier. |
+| `APPLE_ID` | unset | Apple ID email for legacy Fastlane flows. |
+| `TEAM_ID` | unset | Apple Developer Program team ID. |
+| `ITC_TEAM_ID` | unset | App Store Connect team ID, when different. |
+
+Human setup still required before TestFlight/App Store upload:
+
+- Confirm Apple Developer Program membership.
+- Create App Store Connect API credentials.
+- Configure signing certificates and provisioning profiles.
+- Store `MATCH_PASSWORD`, `ASC_KEY_ID`, `ASC_ISSUER_ID`, and
+  `ASC_KEY_CONTENT` as GitHub Actions secrets if iOS enters release scope.

--- a/docs/release/STORE_COMPLIANCE.md
+++ b/docs/release/STORE_COMPLIANCE.md
@@ -49,10 +49,10 @@ The Android Gradle config currently uses:
 | Privacy Policy URL | `https://developerscoffee.github.io/airo/legal/privacy-policy/` | Ready |
 | Terms URL | `https://developerscoffee.github.io/airo/legal/terms-conditions/` | Ready |
 | Content disclaimer | User-provided IPTV content only; no bundled streams or playlists | Ready |
-| App icon | Android launcher icon present | Needs Play 512x512 asset export in #582 |
+| App icon | Android launcher icon present | Needs Play 512x512 asset export before console submission |
 | TV banner | `app/android/app/src/tv/res/drawable-xhdpi/tv_banner.png` | Present |
-| Screenshots | TV screenshots required, 1920x1080 landscape | Pending media capture in #582 |
-| Feature graphic | 1024x500 PNG/JPG required for Play | Pending media asset in #582 |
+| Screenshots | TV screenshots required, 1920x1080 landscape | Ready in `docs/store-assets/airo-tv/` |
+| Feature graphic | 1024x500 PNG/JPG required for Play | Ready in `docs/store-assets/airo-tv/` |
 
 ### Airo TV Permissions
 
@@ -80,7 +80,7 @@ and AI Core bind-service permissions inherited from broader dependencies.
 | Play Console app/package created for TV | Pending | #681, #585 |
 | Play Console app/package created for mobile/tablet | Registered package IDs confirmed; Play listing strategy still pending | #675, #677, #681 |
 | First Play tracks selected | Pending | #681 |
-| Play service account JSON stored as GitHub secret | Pending | #585, #681 |
+| Play service account JSON stored as GitHub secret | Pending human setup; Fastlane config reads env-provided credential path | #585, #681, [Fastlane Credential Setup](./FASTLANE_CREDENTIALS.md) |
 | Production Android signing secrets stored in GitHub | Pending | #585, #677 |
 | AAB build for TV | Ready in CI | `.github/workflows/airo-tv-release.yml` |
 | AAB build for mobile/tablet | Ready in CI for selected v2 profile | `.github/workflows/airo-mobile-tablet-release.yml` |
@@ -91,7 +91,7 @@ and AI Core bind-service permissions inherited from broader dependencies.
 | IARC content rating completed | Pending store-console action; worksheet ready | #584, `docs/release/AIRO_TV_CONTENT_RATING.md` |
 | Data Safety form completed | Pending store-console action | #583 |
 | Store metadata finalized | Ready pending stakeholder approval | #581, `docs/release/AIRO_TV_STORE_LISTING.md` |
-| TV screenshots and feature graphic uploaded | Pending media assets | #582 |
+| TV screenshots and feature graphic uploaded | Assets ready in repo; pending Play Console upload | `docs/store-assets/airo-tv/` |
 | Data Safety and App Privacy declarations | Ready for console entry | #583, `docs/release/AIRO_TV_DATA_SAFETY.md` |
 | Release qualification evidence attached | Pending actual release evidence | #683 |
 
@@ -104,7 +104,7 @@ iOS to the release scope.
 | Item | Status | Owner / link |
 | --- | --- | --- |
 | Apple Developer Program membership | Human setup required | #585 |
-| App Store Connect API key and signing setup | Human setup required | #585 |
+| App Store Connect API key and signing setup | Human setup required; Appfile reads env-provided identifiers | #585, [Fastlane Credential Setup](./FASTLANE_CREDENTIALS.md) |
 | iOS deployment target | Pending final iOS release scope | #585/#675 |
 | App privacy nutrition labels | Pending App Store Connect action | #584/#585 |
 | TestFlight upload automation | Deferred | #585 |
@@ -145,7 +145,7 @@ Before submitting a public v2 Android release:
 
 - #575, #577, #578, #579: legal/docs foundation.
 - #581: final Play/App Store listing metadata.
-- #582: final Play screenshot, feature graphic, and app icon assets.
+- #582: final Play screenshot and feature graphic assets.
 - #583: final Play Data Safety and App Store App Privacy console forms.
 - #584: IARC/content rating and App Store age-rating questionnaires.
 - #585: Fastlane/store credentials and signing setup.

--- a/docs/release/V2_PUBLISHING_HUMAN_SETUP.md
+++ b/docs/release/V2_PUBLISHING_HUMAN_SETUP.md
@@ -21,6 +21,9 @@ Related issues: #681, #585, #657.
 - [ ] Create a Play service account for release automation.
 - [ ] Grant the service account release permissions for the target apps.
 - [ ] Store the service account JSON as a GitHub Actions secret.
+- [x] Configure Fastlane to read Play credential path and package ID from
+      environment variables. See
+      [Fastlane Credential Setup](./FASTLANE_CREDENTIALS.md).
 - [ ] Confirm the first upload track for each app: internal, alpha, beta,
       production, or no-upload.
 - [ ] Confirm whether TV uses the same Play app with device targeting or a
@@ -61,6 +64,21 @@ Related issues: #677, #678, #681.
 - [ ] Confirm whether internal QA uses production signing or a release-candidate
       signing key.
 - [ ] Confirm key backup and rotation ownership outside the repository.
+
+## App Store Connect / Fastlane
+
+Related issue: #585.
+
+- [x] Configure iOS Fastlane Appfile values from environment variables instead
+      of committed account identifiers.
+- [ ] Confirm Apple Developer Program membership before adding iOS/iPadOS to a
+      release wave.
+- [ ] Create App Store Connect API credentials if iOS/iPadOS enters scope.
+- [ ] Configure signing certificates and provisioning profiles if iOS/iPadOS
+      enters scope.
+- [ ] Store `MATCH_PASSWORD`, `ASC_KEY_ID`, `ASC_ISSUER_ID`, and
+      `ASC_KEY_CONTENT` as GitHub Actions secrets before TestFlight/App Store
+      upload.
 
 ## Distribution Channels
 


### PR DESCRIPTION
# Summary

This PR makes the existing Fastlane configuration usable without committing store credentials or account identifiers.

Core outcome:

* Android Fastlane reads the Play credential file path and package ID from environment variables.
* iOS Fastlane reads App Store identifiers from environment variables instead of placeholder comments.
* Release docs now explain the exact Fastlane variables and remaining human setup for Play and App Store Connect.
* Store compliance docs now point at the Fastlane setup doc and reflect that TV screenshots/feature graphic assets are ready in-repo.

# Changes

### Code / Config

* Updated `app/android/fastlane/Appfile`:
  * `SUPPLY_PACKAGE_NAME`, default `io.airo.app.tv`
  * `SUPPLY_JSON_KEY` or `SUPPLY_JSON_KEY_FILE`, default `play-store-credentials.json`
* Updated `app/ios/fastlane/Appfile`:
  * `APP_IDENTIFIER`, default `com.developerscoffee.airo`
  * optional `APPLE_ID`, `TEAM_ID`, `ITC_TEAM_ID`

### Docs

* Added `docs/release/FASTLANE_CREDENTIALS.md`.
* Updated `docs/release/V2_PUBLISHING_HUMAN_SETUP.md`.
* Updated `docs/release/STORE_COMPLIANCE.md`.

# Testing

* `ruby -c app/android/fastlane/Appfile`
* `ruby -c app/ios/fastlane/Appfile`
* `git diff --check HEAD~1 HEAD`
* `bash scripts/check-docs-completeness.sh --base origin/v2 --head HEAD`

# Human Setup Still Required

This does not add secrets to the repo. Maintainers still need to create/confirm Play Console and App Store Connect accounts, service accounts/API keys, signing ownership, and GitHub Actions secrets before real uploads can be verified.

Refs #585
