### PR TITLE
feat(platform): add dependency governance checklist

### DIFF
--- a/docs/features/airo-tv/DEPENDENCY_GOVERNANCE_CHECKLIST.md
+++ b/docs/features/airo-tv/DEPENDENCY_GOVERNANCE_CHECKLIST.md
@@ -1,0 +1,55 @@
+# Airo TV Dependency Governance Checklist
+
+This checklist defines the platform dependency-governance contract for Airo TV
+v2.0.0.1. Dependency decisions must preserve the API 26 Lite Receiver baseline
+unless a dependency is optional and has a fallback or stub path.
+
+Implementation contract:
+
+- Package: `packages/platform_dependency_governance`
+- Schema: `kAiroDependencyGovernanceSchemaVersion`
+- Default checklist: `AiroDependencyGovernanceChecklist()`
+- Android API baseline: `26`
+
+## Required Dependency Fields
+
+Every runtime dependency used by an Airo TV release profile must declare:
+
+- package name and version;
+- module/profile that uses it;
+- required, optional, or development-only importance;
+- minimum Android API floor;
+- native architecture support when native code is present;
+- estimated binary-size impact;
+- estimated runtime-memory impact;
+- background behavior, if any;
+- shrinker/proguard requirement status;
+- TV-specific issue review status;
+- fallback or stub path when the dependency is optional or raises the API floor;
+- maintenance owner.
+
+## Deterministic Blockers
+
+| Blocker | Release meaning |
+| --- | --- |
+| `missing_android_api_floor` | Dependency cannot enter a release profile until its effective Android floor is known |
+| `raises_android_api_floor` | Dependency threatens the API 26 Lite Receiver baseline |
+| `missing_fallback_for_raised_api` | A raised-API dependency is required or lacks a fallback/stub path |
+| `missing_native_architectures` | Native code does not declare supported Android architectures |
+| `binary_size_budget_exceeded` | Dependency exceeds the configured release-profile size budget |
+| `memory_budget_exceeded` | Dependency exceeds the configured runtime-memory budget |
+| `background_behavior_undeclared` | Background work exists but is not described for playback stress review |
+| `shrinker_rules_missing` | Required shrinker/proguard rules are not validated |
+| `tv_issues_not_reviewed` | Known Android TV/Fire TV/focus/playback issues were not reviewed |
+| `owner_missing` | No maintainer owns upgrades, alternatives, and rollback decisions |
+
+## Release Rule
+
+A dependency can be accepted for a Lite Receiver or legacy Airo TV profile only
+when `AiroDependencyGovernanceChecklist.evaluate(record).passed == true`.
+
+If a dependency raises the API floor above 26, release tooling may still record
+it, but it cannot be accepted for baseline profiles unless a profile-specific
+fallback or stub keeps API 26 builds functional. CI wiring, pubspec parsing,
+Gradle inspection, APK-size measurement, and dependency upgrades are follow-up
+implementation tasks.

--- a/packages/platform_dependency_governance/CHANGELOG.md
+++ b/packages/platform_dependency_governance/CHANGELOG.md
@@ -1,0 +1,3 @@
+## 0.0.1
+
+- Add initial dependency governance checklist contracts.

--- a/packages/platform_dependency_governance/README.md
+++ b/packages/platform_dependency_governance/README.md
@@ -1,0 +1,17 @@
+# Platform Dependency Governance
+
+Shared dependency governance contracts for Airo release profiles.
+
+This package is platform/framework code. Airo TV, release tooling, package
+maintainers, and future CI checks consume these contracts to keep Lite Receiver
+and legacy-device support from being broken by unnecessary dependency choices.
+
+## Scope
+
+- Dependency audit records with Android API, native architecture, size, memory,
+  background behavior, shrinker, TV-issue, and ownership fields.
+- A reusable checklist for API 26 baseline governance.
+- Deterministic blocker codes for release checks.
+
+This package does not edit pubspecs, inspect Gradle output, download packages,
+measure APK size, or run CI jobs.

--- a/packages/platform_dependency_governance/analysis_options.yaml
+++ b/packages/platform_dependency_governance/analysis_options.yaml
@@ -1,0 +1,4 @@
+include: package:flutter_lints/flutter.yaml
+
+# Additional information about this file can be found at
+# https://dart.dev/guides/language/analysis-options

--- a/packages/platform_dependency_governance/lib/platform_dependency_governance.dart
+++ b/packages/platform_dependency_governance/lib/platform_dependency_governance.dart
@@ -1,0 +1,3 @@
+library;
+
+export 'src/dependency_governance_models.dart';

--- a/packages/platform_dependency_governance/lib/src/dependency_governance_models.dart
+++ b/packages/platform_dependency_governance/lib/src/dependency_governance_models.dart
@@ -1,0 +1,255 @@
+import 'package:equatable/equatable.dart';
+
+const String kAiroDependencyGovernanceSchemaVersion = '1.0.0';
+
+enum AiroDependencyImportance {
+  required('required'),
+  optional('optional'),
+  developmentOnly('development_only');
+
+  const AiroDependencyImportance(this.stableId);
+
+  final String stableId;
+}
+
+enum AiroNativeArchitecture {
+  arm64('arm64'),
+  armeabiV7a('armeabi_v7a'),
+  x64('x64'),
+  x86('x86');
+
+  const AiroNativeArchitecture(this.stableId);
+
+  final String stableId;
+}
+
+enum AiroDependencyBlockerCode {
+  missingAndroidApiFloor('missing_android_api_floor'),
+  raisesAndroidApiFloor('raises_android_api_floor'),
+  missingFallbackForRaisedApi('missing_fallback_for_raised_api'),
+  missingNativeArchitectures('missing_native_architectures'),
+  binarySizeBudgetExceeded('binary_size_budget_exceeded'),
+  memoryBudgetExceeded('memory_budget_exceeded'),
+  backgroundBehaviorUndeclared('background_behavior_undeclared'),
+  shrinkerRulesMissing('shrinker_rules_missing'),
+  tvIssuesNotReviewed('tv_issues_not_reviewed'),
+  ownerMissing('owner_missing');
+
+  const AiroDependencyBlockerCode(this.stableId);
+
+  final String stableId;
+}
+
+class AiroDependencyAuditRecord extends Equatable {
+  AiroDependencyAuditRecord({
+    required this.packageName,
+    required this.version,
+    required this.usedByModule,
+    required this.importance,
+    required this.minimumAndroidApi,
+    Set<AiroNativeArchitecture> nativeArchitectures = const {},
+    this.hasNativeCode = false,
+    this.estimatedBinarySizeKb,
+    this.estimatedRuntimeMemoryMb,
+    this.hasBackgroundBehavior = false,
+    this.backgroundBehavior,
+    this.requiresShrinkerRules = false,
+    this.shrinkerRulesValidated = false,
+    this.tvIssuesReviewed = false,
+    this.hasFallbackOrStub = false,
+    this.maintenanceOwner,
+    this.schemaVersion = kAiroDependencyGovernanceSchemaVersion,
+  }) : nativeArchitectures = Set.unmodifiable(nativeArchitectures);
+
+  final String schemaVersion;
+  final String packageName;
+  final String version;
+  final String usedByModule;
+  final AiroDependencyImportance importance;
+  final int? minimumAndroidApi;
+  final bool hasNativeCode;
+  final Set<AiroNativeArchitecture> nativeArchitectures;
+  final int? estimatedBinarySizeKb;
+  final int? estimatedRuntimeMemoryMb;
+  final bool hasBackgroundBehavior;
+  final String? backgroundBehavior;
+  final bool requiresShrinkerRules;
+  final bool shrinkerRulesValidated;
+  final bool tvIssuesReviewed;
+  final bool hasFallbackOrStub;
+  final String? maintenanceOwner;
+
+  bool get isOptional =>
+      importance == AiroDependencyImportance.optional ||
+      importance == AiroDependencyImportance.developmentOnly;
+
+  @override
+  List<Object?> get props => [
+    schemaVersion,
+    packageName,
+    version,
+    usedByModule,
+    importance,
+    minimumAndroidApi,
+    hasNativeCode,
+    nativeArchitectures,
+    estimatedBinarySizeKb,
+    estimatedRuntimeMemoryMb,
+    hasBackgroundBehavior,
+    backgroundBehavior,
+    requiresShrinkerRules,
+    shrinkerRulesValidated,
+    tvIssuesReviewed,
+    hasFallbackOrStub,
+    maintenanceOwner,
+  ];
+}
+
+class AiroDependencyGovernanceChecklist extends Equatable {
+  const AiroDependencyGovernanceChecklist({
+    this.androidApiBaseline = 26,
+    this.maxBinarySizeKb = 4096,
+    this.maxRuntimeMemoryMb = 32,
+    this.schemaVersion = kAiroDependencyGovernanceSchemaVersion,
+  });
+
+  final String schemaVersion;
+  final int androidApiBaseline;
+  final int maxBinarySizeKb;
+  final int maxRuntimeMemoryMb;
+
+  AiroDependencyGovernanceResult evaluate(AiroDependencyAuditRecord record) {
+    final blockers = <AiroDependencyBlocker>[];
+
+    final apiFloor = record.minimumAndroidApi;
+    if (apiFloor == null) {
+      blockers.add(
+        AiroDependencyBlocker(
+          packageName: record.packageName,
+          code: AiroDependencyBlockerCode.missingAndroidApiFloor,
+        ),
+      );
+    } else if (apiFloor > androidApiBaseline) {
+      if (!record.isOptional || !record.hasFallbackOrStub) {
+        blockers.add(
+          AiroDependencyBlocker(
+            packageName: record.packageName,
+            code: AiroDependencyBlockerCode.raisesAndroidApiFloor,
+          ),
+        );
+        blockers.add(
+          AiroDependencyBlocker(
+            packageName: record.packageName,
+            code: AiroDependencyBlockerCode.missingFallbackForRaisedApi,
+          ),
+        );
+      }
+    }
+
+    if (record.hasNativeCode && record.nativeArchitectures.isEmpty) {
+      blockers.add(
+        AiroDependencyBlocker(
+          packageName: record.packageName,
+          code: AiroDependencyBlockerCode.missingNativeArchitectures,
+        ),
+      );
+    }
+
+    final binarySize = record.estimatedBinarySizeKb;
+    if (binarySize != null && binarySize > maxBinarySizeKb) {
+      blockers.add(
+        AiroDependencyBlocker(
+          packageName: record.packageName,
+          code: AiroDependencyBlockerCode.binarySizeBudgetExceeded,
+        ),
+      );
+    }
+
+    final runtimeMemory = record.estimatedRuntimeMemoryMb;
+    if (runtimeMemory != null && runtimeMemory > maxRuntimeMemoryMb) {
+      blockers.add(
+        AiroDependencyBlocker(
+          packageName: record.packageName,
+          code: AiroDependencyBlockerCode.memoryBudgetExceeded,
+        ),
+      );
+    }
+
+    if (record.hasBackgroundBehavior &&
+        (record.backgroundBehavior == null ||
+            record.backgroundBehavior!.trim().isEmpty)) {
+      blockers.add(
+        AiroDependencyBlocker(
+          packageName: record.packageName,
+          code: AiroDependencyBlockerCode.backgroundBehaviorUndeclared,
+        ),
+      );
+    }
+
+    if (record.requiresShrinkerRules && !record.shrinkerRulesValidated) {
+      blockers.add(
+        AiroDependencyBlocker(
+          packageName: record.packageName,
+          code: AiroDependencyBlockerCode.shrinkerRulesMissing,
+        ),
+      );
+    }
+
+    if (!record.tvIssuesReviewed) {
+      blockers.add(
+        AiroDependencyBlocker(
+          packageName: record.packageName,
+          code: AiroDependencyBlockerCode.tvIssuesNotReviewed,
+        ),
+      );
+    }
+
+    if (record.maintenanceOwner == null ||
+        record.maintenanceOwner!.trim().isEmpty) {
+      blockers.add(
+        AiroDependencyBlocker(
+          packageName: record.packageName,
+          code: AiroDependencyBlockerCode.ownerMissing,
+        ),
+      );
+    }
+
+    return AiroDependencyGovernanceResult(
+      packageName: record.packageName,
+      blockers: blockers,
+    );
+  }
+
+  @override
+  List<Object?> get props => [
+    schemaVersion,
+    androidApiBaseline,
+    maxBinarySizeKb,
+    maxRuntimeMemoryMb,
+  ];
+}
+
+class AiroDependencyBlocker extends Equatable {
+  const AiroDependencyBlocker({required this.packageName, required this.code});
+
+  final String packageName;
+  final AiroDependencyBlockerCode code;
+
+  @override
+  List<Object?> get props => [packageName, code];
+}
+
+class AiroDependencyGovernanceResult extends Equatable {
+  AiroDependencyGovernanceResult({
+    required this.packageName,
+    required List<AiroDependencyBlocker> blockers,
+  }) : blockers = List.unmodifiable(blockers);
+
+  final String packageName;
+  final List<AiroDependencyBlocker> blockers;
+
+  bool get passed => blockers.isEmpty;
+
+  @override
+  List<Object?> get props => [packageName, blockers];
+}

--- a/packages/platform_dependency_governance/pubspec.yaml
+++ b/packages/platform_dependency_governance/pubspec.yaml
@@ -1,0 +1,21 @@
+name: platform_dependency_governance
+description: Dependency governance checklist contracts for Airo release profiles.
+version: 0.0.1
+homepage:
+publish_to: none
+
+environment:
+  sdk: ^3.12.2
+  flutter: ">=1.17.0"
+
+dependencies:
+  equatable: ^2.0.8
+  flutter:
+    sdk: flutter
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+  flutter_lints: ^6.0.0
+
+flutter:

--- a/packages/platform_dependency_governance/test/dependency_governance_models_test.dart
+++ b/packages/platform_dependency_governance/test/dependency_governance_models_test.dart
@@ -1,0 +1,143 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:platform_dependency_governance/platform_dependency_governance.dart';
+
+void main() {
+  group('Airo dependency governance checklist', () {
+    const checklist = AiroDependencyGovernanceChecklist();
+
+    AiroDependencyAuditRecord record({
+      String packageName = 'video_player',
+      AiroDependencyImportance importance = AiroDependencyImportance.required,
+      int? minimumAndroidApi = 26,
+      bool hasNativeCode = false,
+      Set<AiroNativeArchitecture> nativeArchitectures = const {},
+      int? estimatedBinarySizeKb = 1024,
+      int? estimatedRuntimeMemoryMb = 8,
+      bool hasBackgroundBehavior = false,
+      String? backgroundBehavior,
+      bool requiresShrinkerRules = false,
+      bool shrinkerRulesValidated = false,
+      bool tvIssuesReviewed = true,
+      bool hasFallbackOrStub = false,
+      String? maintenanceOwner = 'release-devex',
+    }) {
+      return AiroDependencyAuditRecord(
+        packageName: packageName,
+        version: '1.0.0',
+        usedByModule: 'feature_iptv',
+        importance: importance,
+        minimumAndroidApi: minimumAndroidApi,
+        hasNativeCode: hasNativeCode,
+        nativeArchitectures: nativeArchitectures,
+        estimatedBinarySizeKb: estimatedBinarySizeKb,
+        estimatedRuntimeMemoryMb: estimatedRuntimeMemoryMb,
+        hasBackgroundBehavior: hasBackgroundBehavior,
+        backgroundBehavior: backgroundBehavior,
+        requiresShrinkerRules: requiresShrinkerRules,
+        shrinkerRulesValidated: shrinkerRulesValidated,
+        tvIssuesReviewed: tvIssuesReviewed,
+        hasFallbackOrStub: hasFallbackOrStub,
+        maintenanceOwner: maintenanceOwner,
+      );
+    }
+
+    test('accepts a baseline API 26 dependency with reviewed ownership', () {
+      final result = checklist.evaluate(record());
+
+      expect(result.passed, isTrue);
+      expect(result.blockers, isEmpty);
+    });
+
+    test('blocks dependencies without declared Android API floor', () {
+      final result = checklist.evaluate(record(minimumAndroidApi: null));
+
+      expect(result.passed, isFalse);
+      expect(
+        result.blockers.map((blocker) => blocker.code),
+        contains(AiroDependencyBlockerCode.missingAndroidApiFloor),
+      );
+    });
+
+    test('blocks required dependencies that raise the API floor', () {
+      final result = checklist.evaluate(record(minimumAndroidApi: 28));
+
+      expect(
+        result.blockers.map((blocker) => blocker.code),
+        containsAll(const {
+          AiroDependencyBlockerCode.raisesAndroidApiFloor,
+          AiroDependencyBlockerCode.missingFallbackForRaisedApi,
+        }),
+      );
+    });
+
+    test('allows optional raised-API dependencies only with fallback', () {
+      final blocked = checklist.evaluate(
+        record(
+          packageName: 'optional_cast_sdk',
+          importance: AiroDependencyImportance.optional,
+          minimumAndroidApi: 28,
+        ),
+      );
+      final accepted = checklist.evaluate(
+        record(
+          packageName: 'optional_cast_sdk',
+          importance: AiroDependencyImportance.optional,
+          minimumAndroidApi: 28,
+          hasFallbackOrStub: true,
+        ),
+      );
+
+      expect(
+        blocked.blockers.map((blocker) => blocker.code),
+        contains(AiroDependencyBlockerCode.missingFallbackForRaisedApi),
+      );
+      expect(
+        accepted.blockers.map((blocker) => blocker.code),
+        isNot(contains(AiroDependencyBlockerCode.missingFallbackForRaisedApi)),
+      );
+      expect(
+        accepted.blockers.map((blocker) => blocker.code),
+        isNot(contains(AiroDependencyBlockerCode.raisesAndroidApiFloor)),
+      );
+      expect(accepted.passed, isTrue);
+    });
+
+    test('blocks native dependencies without declared architectures', () {
+      final result = checklist.evaluate(record(hasNativeCode: true));
+
+      expect(
+        result.blockers.map((blocker) => blocker.code),
+        contains(AiroDependencyBlockerCode.missingNativeArchitectures),
+      );
+    });
+
+    test(
+      'blocks size, memory, background, shrinker, review, and owner gaps',
+      () {
+        final result = checklist.evaluate(
+          record(
+            estimatedBinarySizeKb: 8192,
+            estimatedRuntimeMemoryMb: 64,
+            hasBackgroundBehavior: true,
+            requiresShrinkerRules: true,
+            shrinkerRulesValidated: false,
+            tvIssuesReviewed: false,
+            maintenanceOwner: '',
+          ),
+        );
+
+        expect(
+          result.blockers.map((blocker) => blocker.code),
+          containsAll(const {
+            AiroDependencyBlockerCode.binarySizeBudgetExceeded,
+            AiroDependencyBlockerCode.memoryBudgetExceeded,
+            AiroDependencyBlockerCode.backgroundBehaviorUndeclared,
+            AiroDependencyBlockerCode.shrinkerRulesMissing,
+            AiroDependencyBlockerCode.tvIssuesNotReviewed,
+            AiroDependencyBlockerCode.ownerMissing,
+          }),
+        );
+      },
+    );
+  });
+}


### PR DESCRIPTION
# Summary

This PR brings the isolated dependency-governance checklist work from the stacked v2 planning branch onto the current `v2` release line.

Goal: close ATV-009 by adding a reusable platform contract for dependency review before release-profile dependencies can raise API floors, increase footprint, or affect Android TV behavior.

Core outcome:

* Added `packages/platform_dependency_governance` with deterministic dependency audit records and blocker codes.
* Documented the Airo TV dependency governance checklist and API 26 Lite Receiver baseline rule.
* Added tests for API floor, fallback, native architecture, size, memory, background, shrinker, TV review, and owner blockers.

Closes #599

# Changes

### Code

* Added:
  * `packages/platform_dependency_governance`
  * `AiroDependencyAuditRecord`
  * `AiroDependencyGovernanceChecklist`
  * stable blocker-code enums and result models

### Docs

* Added `docs/features/airo-tv/DEPENDENCY_GOVERNANCE_CHECKLIST.md` with the release rule and required dependency fields.

# API Changes

No app/runtime API changes. This adds a new internal platform package contract.

# Risks

Low. The new package is not wired into release builds yet; it establishes the shared governance model for follow-up audit automation.

Rollback plan: revert the package and doc if the governance schema needs to be redesigned.

# Testing

* `dart format --set-exit-if-changed packages/platform_dependency_governance`
* `cd packages/platform_dependency_governance && flutter pub get`
* `cd packages/platform_dependency_governance && flutter test`
* `cd packages/platform_dependency_governance && flutter analyze --fatal-infos`
* `bash scripts/check-docs-completeness.sh --base origin/v2 --head HEAD`
* `scripts/check-module-sizes.sh`
* `git diff --check HEAD~1 HEAD`
