### PR TITLE
feat(platform): add dependency audit report

### DIFF
--- a/docs/features/airo-tv/DEPENDENCY_GOVERNANCE_CHECKLIST.md
+++ b/docs/features/airo-tv/DEPENDENCY_GOVERNANCE_CHECKLIST.md
@@ -9,6 +9,7 @@ Implementation contract:
 - Package: `packages/platform_dependency_governance`
 - Schema: `kAiroDependencyGovernanceSchemaVersion`
 - Default checklist: `AiroDependencyGovernanceChecklist()`
+- Audit report: `AiroDependencyGovernanceAuditReport.evaluate(...)`
 - Android API baseline: `26`
 
 ## Required Dependency Fields
@@ -53,3 +54,32 @@ it, but it cannot be accepted for baseline profiles unless a profile-specific
 fallback or stub keeps API 26 builds functional. CI wiring, pubspec parsing,
 Gradle inspection, APK-size measurement, and dependency upgrades are follow-up
 implementation tasks.
+
+## Audit Report Contract
+
+Release tooling should group dependency records by release profile and create an
+audit report with `AiroDependencyGovernanceAuditReport.evaluate(...)`.
+
+The report captures:
+
+- schema version;
+- release profile name;
+- UTC generation timestamp;
+- checklist thresholds used for the audit;
+- stable dependency result ordering by module, package, and version;
+- stable aggregate blocker codes;
+- each dependency record and its evaluated result.
+
+The report passes only when every dependency result passes. Public release
+automation may fail a Lite Receiver or legacy profile when the report fails,
+unless a separate release waiver explicitly records why the blocker is accepted.
+
+Audit reports must not contain credentials, device identifiers, analytics
+payloads, personal data, or store-console account details. Those remain in
+credential stores and release evidence systems, not in dependency governance
+records.
+
+Follow-up automation can parse pubspec, Gradle, APK size, or dependency scanner
+output into `AiroDependencyAuditRecord` values. That extraction work must keep
+using the platform contract instead of adding profile-specific checks directly
+inside Airo TV app code.

--- a/packages/platform_dependency_governance/CHANGELOG.md
+++ b/packages/platform_dependency_governance/CHANGELOG.md
@@ -1,3 +1,4 @@
 ## 0.0.1
 
 - Add initial dependency governance checklist contracts.
+- Add audit report contract for release-profile dependency evidence.

--- a/packages/platform_dependency_governance/README.md
+++ b/packages/platform_dependency_governance/README.md
@@ -11,7 +11,9 @@ and legacy-device support from being broken by unnecessary dependency choices.
 - Dependency audit records with Android API, native architecture, size, memory,
   background behavior, shrinker, TV-issue, and ownership fields.
 - A reusable checklist for API 26 baseline governance.
+- Audit reports that capture profile, timestamp, checklist thresholds,
+  dependency results, and aggregate blocker codes.
 - Deterministic blocker codes for release checks.
 
 This package does not edit pubspecs, inspect Gradle output, download packages,
-measure APK size, or run CI jobs.
+measure APK size, run CI jobs, or store release credentials.

--- a/packages/platform_dependency_governance/lib/src/dependency_governance_models.dart
+++ b/packages/platform_dependency_governance/lib/src/dependency_governance_models.dart
@@ -40,6 +40,11 @@ enum AiroDependencyBlockerCode {
   final String stableId;
 }
 
+List<String> _stableArchitectureIds(Set<AiroNativeArchitecture> architectures) {
+  return architectures.map((architecture) => architecture.stableId).toList()
+    ..sort();
+}
+
 class AiroDependencyAuditRecord extends Equatable {
   AiroDependencyAuditRecord({
     required this.packageName,
@@ -83,6 +88,28 @@ class AiroDependencyAuditRecord extends Equatable {
       importance == AiroDependencyImportance.optional ||
       importance == AiroDependencyImportance.developmentOnly;
 
+  Map<String, Object?> toJson() {
+    return {
+      'schemaVersion': schemaVersion,
+      'packageName': packageName,
+      'version': version,
+      'usedByModule': usedByModule,
+      'importance': importance.stableId,
+      'minimumAndroidApi': minimumAndroidApi,
+      'hasNativeCode': hasNativeCode,
+      'nativeArchitectures': _stableArchitectureIds(nativeArchitectures),
+      'estimatedBinarySizeKb': estimatedBinarySizeKb,
+      'estimatedRuntimeMemoryMb': estimatedRuntimeMemoryMb,
+      'hasBackgroundBehavior': hasBackgroundBehavior,
+      'backgroundBehavior': backgroundBehavior,
+      'requiresShrinkerRules': requiresShrinkerRules,
+      'shrinkerRulesValidated': shrinkerRulesValidated,
+      'tvIssuesReviewed': tvIssuesReviewed,
+      'hasFallbackOrStub': hasFallbackOrStub,
+      'maintenanceOwner': maintenanceOwner,
+    };
+  }
+
   @override
   List<Object?> get props => [
     schemaVersion,
@@ -117,6 +144,15 @@ class AiroDependencyGovernanceChecklist extends Equatable {
   final int androidApiBaseline;
   final int maxBinarySizeKb;
   final int maxRuntimeMemoryMb;
+
+  Map<String, Object?> toJson() {
+    return {
+      'schemaVersion': schemaVersion,
+      'androidApiBaseline': androidApiBaseline,
+      'maxBinarySizeKb': maxBinarySizeKb,
+      'maxRuntimeMemoryMb': maxRuntimeMemoryMb,
+    };
+  }
 
   AiroDependencyGovernanceResult evaluate(AiroDependencyAuditRecord record) {
     final blockers = <AiroDependencyBlocker>[];
@@ -250,6 +286,136 @@ class AiroDependencyGovernanceResult extends Equatable {
 
   bool get passed => blockers.isEmpty;
 
+  List<AiroDependencyBlockerCode> get blockerCodes {
+    final codes = blockers.map((blocker) => blocker.code).toList()
+      ..sort((left, right) => left.stableId.compareTo(right.stableId));
+    return List.unmodifiable(codes);
+  }
+
+  Map<String, Object?> toJson() {
+    return {
+      'packageName': packageName,
+      'passed': passed,
+      'blockers': blockerCodes.map((code) => code.stableId).toList(),
+    };
+  }
+
   @override
   List<Object?> get props => [packageName, blockers];
+}
+
+class AiroDependencyGovernanceAuditEntry extends Equatable {
+  const AiroDependencyGovernanceAuditEntry({
+    required this.record,
+    required this.result,
+  });
+
+  final AiroDependencyAuditRecord record;
+  final AiroDependencyGovernanceResult result;
+
+  bool get passed => result.passed;
+
+  Map<String, Object?> toJson() {
+    return {'record': record.toJson(), 'result': result.toJson()};
+  }
+
+  @override
+  List<Object?> get props => [record, result];
+}
+
+class AiroDependencyGovernanceAuditReport extends Equatable {
+  AiroDependencyGovernanceAuditReport({
+    required this.profileName,
+    required this.generatedAtUtc,
+    required this.checklist,
+    required List<AiroDependencyGovernanceAuditEntry> entries,
+    this.schemaVersion = kAiroDependencyGovernanceSchemaVersion,
+  }) : entries = List.unmodifiable(
+         entries.toList()..sort((left, right) {
+           final moduleOrder = left.record.usedByModule.compareTo(
+             right.record.usedByModule,
+           );
+           if (moduleOrder != 0) {
+             return moduleOrder;
+           }
+
+           final packageOrder = left.record.packageName.compareTo(
+             right.record.packageName,
+           );
+           if (packageOrder != 0) {
+             return packageOrder;
+           }
+
+           return left.record.version.compareTo(right.record.version);
+         }),
+       );
+
+  factory AiroDependencyGovernanceAuditReport.evaluate({
+    required String profileName,
+    required DateTime generatedAtUtc,
+    required Iterable<AiroDependencyAuditRecord> records,
+    AiroDependencyGovernanceChecklist checklist =
+        const AiroDependencyGovernanceChecklist(),
+    String schemaVersion = kAiroDependencyGovernanceSchemaVersion,
+  }) {
+    return AiroDependencyGovernanceAuditReport(
+      profileName: profileName,
+      generatedAtUtc: generatedAtUtc.toUtc(),
+      checklist: checklist,
+      schemaVersion: schemaVersion,
+      entries: records
+          .map(
+            (record) => AiroDependencyGovernanceAuditEntry(
+              record: record,
+              result: checklist.evaluate(record),
+            ),
+          )
+          .toList(),
+    );
+  }
+
+  final String schemaVersion;
+  final String profileName;
+  final DateTime generatedAtUtc;
+  final AiroDependencyGovernanceChecklist checklist;
+  final List<AiroDependencyGovernanceAuditEntry> entries;
+
+  bool get passed => entries.every((entry) => entry.passed);
+
+  List<AiroDependencyGovernanceAuditEntry> get failingEntries {
+    return List.unmodifiable(entries.where((entry) => !entry.passed));
+  }
+
+  List<AiroDependencyBlockerCode> get blockerCodes {
+    final codes = <AiroDependencyBlockerCode>{};
+    for (final entry in entries) {
+      codes.addAll(entry.result.blockerCodes);
+    }
+
+    return List.unmodifiable(
+      codes.toList()
+        ..sort((left, right) => left.stableId.compareTo(right.stableId)),
+    );
+  }
+
+  Map<String, Object?> toJson() {
+    return {
+      'schemaVersion': schemaVersion,
+      'profileName': profileName,
+      'generatedAtUtc': generatedAtUtc.toUtc().toIso8601String(),
+      'passed': passed,
+      'checklist': checklist.toJson(),
+      'blockerCodes': blockerCodes.map((code) => code.stableId).toList(),
+      'dependencies': entries.map((entry) => entry.toJson()).toList(),
+    };
+  }
+
+  @override
+  List<Object?> get props => [
+    schemaVersion,
+    profileName,
+    generatedAtUtc,
+    checklist,
+    entries,
+  ];
 }

--- a/packages/platform_dependency_governance/test/dependency_governance_models_test.dart
+++ b/packages/platform_dependency_governance/test/dependency_governance_models_test.dart
@@ -7,6 +7,7 @@ void main() {
 
     AiroDependencyAuditRecord record({
       String packageName = 'video_player',
+      String usedByModule = 'feature_iptv',
       AiroDependencyImportance importance = AiroDependencyImportance.required,
       int? minimumAndroidApi = 26,
       bool hasNativeCode = false,
@@ -24,7 +25,7 @@ void main() {
       return AiroDependencyAuditRecord(
         packageName: packageName,
         version: '1.0.0',
-        usedByModule: 'feature_iptv',
+        usedByModule: usedByModule,
         importance: importance,
         minimumAndroidApi: minimumAndroidApi,
         hasNativeCode: hasNativeCode,
@@ -139,5 +140,102 @@ void main() {
         );
       },
     );
+
+    test('creates a passing empty audit report', () {
+      final report = AiroDependencyGovernanceAuditReport.evaluate(
+        profileName: 'tv',
+        generatedAtUtc: DateTime.utc(2026, 7, 14, 12),
+        records: const [],
+      );
+
+      expect(report.passed, isTrue);
+      expect(report.entries, isEmpty);
+      expect(report.failingEntries, isEmpty);
+      expect(report.blockerCodes, isEmpty);
+      expect(
+        report.toJson(),
+        containsPair('generatedAtUtc', '2026-07-14T12:00:00.000Z'),
+      );
+    });
+
+    test('creates a passing audit report for reviewed dependencies', () {
+      final report = AiroDependencyGovernanceAuditReport.evaluate(
+        profileName: 'tv',
+        generatedAtUtc: DateTime.utc(2026, 7, 14, 12),
+        records: [
+          record(packageName: 'platform_player'),
+          record(packageName: 'feature_iptv', usedByModule: 'feature_iptv'),
+        ],
+      );
+
+      expect(report.passed, isTrue);
+      expect(report.entries, hasLength(2));
+      expect(report.failingEntries, isEmpty);
+      expect(report.toJson(), containsPair('passed', true));
+    });
+
+    test('aggregates stable blocker codes for failing dependencies', () {
+      final report = AiroDependencyGovernanceAuditReport.evaluate(
+        profileName: 'tv',
+        generatedAtUtc: DateTime.utc(2026, 7, 14, 12),
+        records: [
+          record(packageName: 'large_native', hasNativeCode: true),
+          record(
+            packageName: 'api_raiser',
+            minimumAndroidApi: 28,
+            estimatedRuntimeMemoryMb: 64,
+          ),
+        ],
+      );
+
+      expect(report.passed, isFalse);
+      expect(report.failingEntries, hasLength(2));
+      expect(
+        report.blockerCodes.map((code) => code.stableId),
+        orderedEquals([
+          'memory_budget_exceeded',
+          'missing_fallback_for_raised_api',
+          'missing_native_architectures',
+          'raises_android_api_floor',
+        ]),
+      );
+    });
+
+    test('sorts audit entries for deterministic release output', () {
+      final report = AiroDependencyGovernanceAuditReport.evaluate(
+        profileName: 'tv',
+        generatedAtUtc: DateTime.utc(2026, 7, 14, 12),
+        records: [
+          record(packageName: 'zeta', usedByModule: 'platform_player'),
+          record(packageName: 'alpha', usedByModule: 'feature_iptv'),
+          record(packageName: 'beta', usedByModule: 'feature_iptv'),
+        ],
+      );
+
+      expect(
+        report.entries.map((entry) => entry.record.packageName),
+        orderedEquals(['alpha', 'beta', 'zeta']),
+      );
+    });
+
+    test('captures checklist thresholds in audit output', () {
+      const strictChecklist = AiroDependencyGovernanceChecklist(
+        androidApiBaseline: 24,
+        maxBinarySizeKb: 2048,
+        maxRuntimeMemoryMb: 16,
+      );
+      final report = AiroDependencyGovernanceAuditReport.evaluate(
+        profileName: 'legacy-tv',
+        generatedAtUtc: DateTime.utc(2026, 7, 14, 12),
+        checklist: strictChecklist,
+        records: [record()],
+      );
+      final json = report.toJson();
+
+      expect(json['profileName'], 'legacy-tv');
+      expect(json['checklist'], containsPair('androidApiBaseline', 24));
+      expect(json['checklist'], containsPair('maxBinarySizeKb', 2048));
+      expect(json['checklist'], containsPair('maxRuntimeMemoryMb', 16));
+    });
   });
 }


### PR DESCRIPTION
# Summary

This PR adds the release-profile dependency governance audit contract for Airo TV legacy/Lite Receiver release evidence.

Goal: make dependency governance delegable and deterministic so release tooling can evaluate dependency records without hard-coding profile-specific checks in Airo TV app code.

Core outcome:

* Adds `AiroDependencyGovernanceAuditReport` and audit entries on top of the existing governance checklist.
* Emits stable report data with profile, UTC timestamp, checklist thresholds, dependency results, and aggregate blocker codes.
* Documents the audit report contract and keeps pubspec/Gradle/APK extraction as follow-up tooling.

Closes #640

# Changes

### Code

* Added:
  * `AiroDependencyGovernanceAuditEntry`
  * `AiroDependencyGovernanceAuditReport`
  * stable `toJson()` output for records, checklists, results, entries, and reports
* Updated:
  * package tests for passing reports, failing reports, blocker aggregation, deterministic ordering, and threshold capture

### Docs

* Updated `docs/features/airo-tv/DEPENDENCY_GOVERNANCE_CHECKLIST.md` with the audit report contract and privacy boundary.
* Updated the package README and changelog.

# API Changes

No app/runtime API change. This extends the internal platform package contract used by release tooling.

# Risks

Low. The audit report is not wired into publishing yet; it provides deterministic evidence for follow-up CI/pubspec/Gradle extraction work.

Rollback plan: revert this package extension and keep the existing checklist-only contract.

# Testing

* `dart format --set-exit-if-changed packages/platform_dependency_governance`
* `cd packages/platform_dependency_governance && flutter test`
* `cd packages/platform_dependency_governance && flutter analyze --fatal-infos`
* `scripts/check-module-sizes.sh`
* `bash scripts/check-docs-completeness.sh --base origin/v2 --head HEAD`
* `git diff --check origin/v2...HEAD`
