### PR TITLE
docs(airo-tv): record v2 tag policy

### DIFF
--- a/docs/features/airo-tv/README.md
+++ b/docs/features/airo-tv/README.md
@@ -28,7 +28,10 @@ devices to improve discovery and playback without providing content.
 
 ## Release-Line Note
 
-The repository release policy uses semantic v2 versions such as `v2.0.0` and
-`v2.0.1`. These docs keep the requested label `v2.0.0.1` as a planning
-milestone name. Before tagging a build, Release and DevEx should decide whether
-this maps to `v2.0.1` or whether four-part product versioning is being adopted.
+The repository release policy uses immutable semantic v2 tags such as
+`v2.0.0`, `v2.0.1`, and `v2.1.0`. These docs keep the requested label
+`v2.0.0.1` only as the Airo TV platform-hardening planning milestone name.
+Do not publish four-part Git release tags such as `v2.0.0.1` for this
+workstream unless `docs/release/VERSION_LINES.md` is deliberately changed by
+Release and DevEx. Release candidates and public releases are tagged from `v2`
+with the next normal semantic v2 version.

--- a/docs/features/airo-tv/V2_0_0_1_FEATURE_PACKET.md
+++ b/docs/features/airo-tv/V2_0_0_1_FEATURE_PACKET.md
@@ -118,8 +118,9 @@ and delegated operation contract.
 **Versioning/migration:**
 - protocol fields must be forward compatible with unknown fields ignored;
 - profile capabilities must include schema version;
-- release tag naming must align with repository V2 semver policy before a build
-  is tagged.
+- `v2.0.0.1` is a planning milestone label, not a public Git release tag;
+- public builds must be tagged from `v2` with repository V2 semver tags such as
+  `v2.0.0`, `v2.0.1`, and `v2.1.0`.
 
 **Tests required:**
 - profile composition tests;
@@ -411,4 +412,3 @@ Experimental, or Unsupported.
 - Verification environment: host-only tests for contracts and privacy; physical
   Android TV/Fire TV devices for legacy certification. Android Emulator is not
   required and should not be used for certification unless explicitly approved.
-

--- a/docs/features/airo-tv/V2_0_0_1_GAP_ANALYSIS.md
+++ b/docs/features/airo-tv/V2_0_0_1_GAP_ANALYSIS.md
@@ -331,7 +331,8 @@ cleanup.
 
 - Decide whether v2.0.0.1 is docs-only, contract-only, or includes a Lite
   Receiver code MVP.
-- Resolve version naming: `v2.0.0.1` milestone vs semver `v2.0.1` tag.
+- Use the recorded version naming policy: `v2.0.0.1` is a planning milestone
+  label, and public Git release tags remain semantic v2 tags.
 - Move source secrets out of SharedPreferences before adding Xtream or provider
   credentials.
 - Define prohibited analytics/log/crash fields now.
@@ -396,4 +397,3 @@ multi-view, Stalker Portal, and broad provider integrations.
 The highest-leverage next move is not adding another visible feature. It is
 closing the P0 platform gaps so the product can safely expand without weakening
 privacy, compliance, or legacy-device reliability.
-

--- a/docs/features/airo-tv/V2_0_0_1_PLAN.md
+++ b/docs/features/airo-tv/V2_0_0_1_PLAN.md
@@ -243,7 +243,8 @@ Deliver:
 - Save raw PRD source.
 - Approve this v2.0.0.1 scope.
 - Open or update the GitHub issue with the feature packet.
-- Confirm release tag naming: `v2.0.0.1` milestone vs `v2.0.1` semver tag.
+- Use `v2.0.0.1` as the planning milestone label only; public Git release tags
+  remain semantic v2 tags such as `v2.0.0`, `v2.0.1`, and `v2.1.0`.
 
 Exit criteria:
 - Owning agents and review agents are listed.
@@ -651,7 +652,8 @@ Exit criteria:
 
 ## Open Questions
 
-- Is `v2.0.0.1` an internal milestone or an externally tagged release?
+- What exact semantic v2 tag will carry the first public artifact after this
+  planning milestone: `v2.0.0`, `v2.0.1`, or a later semver tag?
 - Which platforms are in the first implementation target: Android TV only, or Android TV plus mobile companion?
 - Does v2.0.0.1 include a code MVP, or only specs and issue packets?
 - What is the first physical Android 8/9 test device inventory?

--- a/docs/features/airo-tv/V2_0_0_1_REQUIREMENTS_REVIEW.md
+++ b/docs/features/airo-tv/V2_0_0_1_REQUIREMENTS_REVIEW.md
@@ -200,7 +200,9 @@ v2.0.0.1 should be considered ready when the team has:
 - opened implementation issues with deterministic use cases and automation
   flows;
 - confirmed the release-line base is latest `origin/v2`;
-- made a tag naming decision for `v2.0.0.1` vs semver `v2.0.1`.
+- recorded the tag policy decision: `v2.0.0.1` is a planning milestone label,
+  while public Git release tags remain semantic v2 tags such as `v2.0.0`,
+  `v2.0.1`, and `v2.1.0`.
 
 ## Requirement Conflicts and Corrections
 


### PR DESCRIPTION
# Summary

This PR records the Airo TV v2.0.0.1 tag-policy decision in the current `v2` planning docs.

Goal: remove the remaining ambiguity between the requested `v2.0.0.1` planning label and the repository's semantic v2 release tags.

Core outcome:

* `v2.0.0.1` is now documented as an Airo TV planning milestone label only.
* Public Git release tags remain semantic v2 tags from `docs/release/VERSION_LINES.md`, such as `v2.0.0`, `v2.0.1`, and `v2.1.0`.
* Airo TV planning docs no longer ask Release and DevEx to decide whether four-part Git tags should be used.

Closes #592

# Changes

### Docs

* Updated:
  * `docs/features/airo-tv/README.md`
  * `docs/features/airo-tv/V2_0_0_1_PLAN.md`
  * `docs/features/airo-tv/V2_0_0_1_REQUIREMENTS_REVIEW.md`
  * `docs/features/airo-tv/V2_0_0_1_FEATURE_PACKET.md`
  * `docs/features/airo-tv/V2_0_0_1_GAP_ANALYSIS.md`

# API Changes

None.

# Risks

Low. This is a docs-only release policy clarification aligned with the existing `docs/release/VERSION_LINES.md` policy.

# Testing

* `bash scripts/check-docs-completeness.sh --base origin/v2 --head HEAD`
* `git diff --check origin/v2...HEAD`
* Search confirmed the previous unresolved tag-policy wording is gone from active Airo TV planning docs.
