### PR TITLE
feat(airo-tv): add lite receiver shell

### DIFF
--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -1592,6 +1592,13 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.0.5"
+  product_capabilities:
+    dependency: transitive
+    description:
+      path: "../packages/product_capabilities"
+      relative: true
+    source: path
+    version: "0.0.1"
   pub_semver:
     dependency: transitive
     description:

--- a/packages/feature_iptv/lib/application/providers/airo_tv_profile_provider.dart
+++ b/packages/feature_iptv/lib/application/providers/airo_tv_profile_provider.dart
@@ -1,0 +1,6 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:product_capabilities/product_capabilities.dart';
+
+final airoTvProductProfileProvider = Provider<ProductProfileManifest>((ref) {
+  return AiroTvProductProfiles.liteReceiver();
+});

--- a/packages/feature_iptv/lib/application/providers/iptv_providers.dart
+++ b/packages/feature_iptv/lib/application/providers/iptv_providers.dart
@@ -9,6 +9,7 @@ import "package:platform_media/platform_media.dart";
 import "package:platform_playlist_import/platform_playlist_import.dart";
 
 export 'iptv_cast_providers.dart';
+export 'airo_tv_profile_provider.dart';
 export 'edge_intelligence_providers.dart';
 export 'iptv_navigation_provider.dart';
 export 'voice_search_provider.dart';

--- a/packages/feature_iptv/lib/presentation/tv/iptv_tv_screen.dart
+++ b/packages/feature_iptv/lib/presentation/tv/iptv_tv_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:platform_channels/platform_channels.dart';
 import 'package:platform_player/platform_player.dart';
+import 'package:product_capabilities/product_capabilities.dart';
 
 import '../../application/providers/iptv_providers.dart';
 import '../screens/iptv_screen.dart';
@@ -106,6 +107,7 @@ class _IptvTvScreenState extends ConsumerState<IptvTvScreen> {
     final streamingState = ref.watch(streamingStateProvider);
     final recentAsync = ref.watch(recentlyWatchedChannelsProvider);
     final hasActiveFilter = ref.watch(hasActiveFilterProvider);
+    final productProfile = ref.watch(airoTvProductProfileProvider);
 
     return Scaffold(
       backgroundColor: Theme.of(context).colorScheme.surface,
@@ -122,13 +124,17 @@ class _IptvTvScreenState extends ConsumerState<IptvTvScreen> {
                 : filteredChannels;
 
             if (allChannels.isEmpty) {
-              return _TvEmptyPlaylistState(
-                onPlaylistSourceTap: _showPlaylistSheet,
-                onPlaylistHelpTap: _showPlaylistGuideDialog,
+              return _TvEmptyPlaylistLayout(
+                productProfile: productProfile,
+                child: _TvEmptyPlaylistState(
+                  onPlaylistSourceTap: _showPlaylistSheet,
+                  onPlaylistHelpTap: _showPlaylistGuideDialog,
+                ),
               );
             }
 
             return _TvBrowseLayout(
+              productProfile: productProfile,
               allChannels: allChannels,
               visibleChannels: visibleChannels,
               streamingState: streamingState,
@@ -161,6 +167,7 @@ class _IptvTvScreenState extends ConsumerState<IptvTvScreen> {
 
 class _TvBrowseLayout extends ConsumerWidget {
   const _TvBrowseLayout({
+    required this.productProfile,
     required this.allChannels,
     required this.visibleChannels,
     required this.streamingState,
@@ -178,6 +185,7 @@ class _TvBrowseLayout extends ConsumerWidget {
     required this.onViewModeChanged,
   });
 
+  final ProductProfileManifest productProfile;
   final List<IPTVChannel> allChannels;
   final List<IPTVChannel> visibleChannels;
   final AsyncValue<StreamingState> streamingState;
@@ -205,6 +213,8 @@ class _TvBrowseLayout extends ConsumerWidget {
       padding: const EdgeInsets.fromLTRB(32, 24, 32, 24),
       child: Column(
         children: [
+          _TvLiteReceiverShellHeader(productProfile: productProfile),
+          const SizedBox(height: 18),
           _TvHeader(
             channelCount: allChannels.length,
             visibleCount: visibleChannels.length,
@@ -286,6 +296,127 @@ class _TvBrowseLayout extends ConsumerWidget {
           const SizedBox(height: 12),
           const IPTVMiniPlayer(forceVisible: true),
         ],
+      ),
+    );
+  }
+}
+
+class _TvLiteReceiverShellHeader extends StatelessWidget {
+  const _TvLiteReceiverShellHeader({required this.productProfile});
+
+  final ProductProfileManifest productProfile;
+
+  static const _heavyCapabilities = {
+    ProductCapability.localAi,
+    ProductCapability.recording,
+    ProductCapability.downloads,
+    ProductCapability.multiview,
+    ProductCapability.fullEpg,
+  };
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+    final unavailable = _heavyCapabilities
+        .where((capability) => !productProfile.supportsCapability(capability))
+        .map((capability) => capability.tvLabel)
+        .toList(growable: false);
+
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        color: colorScheme.surfaceContainerHighest.withValues(alpha: 0.28),
+        border: Border.all(color: colorScheme.outlineVariant),
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(18, 14, 18, 14),
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.center,
+          children: [
+            Icon(Icons.tv, color: colorScheme.primary, size: 32),
+            const SizedBox(width: 14),
+            SizedBox(
+              width: 260,
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    productProfile.displayName,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: theme.textTheme.titleLarge?.copyWith(
+                      fontWeight: FontWeight.w800,
+                    ),
+                  ),
+                  const SizedBox(height: 4),
+                  Text(
+                    '${productProfile.supportLevel.tvLabel} profile',
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: theme.textTheme.bodyMedium?.copyWith(
+                      color: colorScheme.onSurfaceVariant,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            const SizedBox(width: 18),
+            Expanded(
+              child: Wrap(
+                spacing: 8,
+                runSpacing: 8,
+                children: productProfile.navigation
+                    .map((entry) => _ProfileSectionChip(entry: entry))
+                    .toList(growable: false),
+              ),
+            ),
+            const SizedBox(width: 18),
+            SizedBox(
+              width: 300,
+              child: Text(
+                unavailable.isEmpty
+                    ? 'All profile capabilities available'
+                    : 'Profile-limited: ${unavailable.join(', ')}',
+                maxLines: 2,
+                overflow: TextOverflow.ellipsis,
+                textAlign: TextAlign.end,
+                style: theme.textTheme.bodySmall?.copyWith(
+                  color: colorScheme.onSurfaceVariant,
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _ProfileSectionChip extends StatelessWidget {
+  const _ProfileSectionChip({required this.entry});
+
+  final ProductNavigationEntry entry;
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+
+    return Semantics(
+      label: '${entry.tvLabel} section',
+      child: DecoratedBox(
+        decoration: BoxDecoration(
+          color: colorScheme.surface.withValues(alpha: 0.7),
+          border: Border.all(color: colorScheme.outlineVariant),
+          borderRadius: BorderRadius.circular(8),
+        ),
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+          child: Text(
+            entry.tvLabel,
+            style: Theme.of(context).textTheme.labelLarge,
+          ),
+        ),
       ),
     );
   }
@@ -1118,6 +1249,76 @@ class _TvNoChannelsState extends StatelessWidget {
         ],
       ),
     );
+  }
+}
+
+class _TvEmptyPlaylistLayout extends StatelessWidget {
+  const _TvEmptyPlaylistLayout({
+    required this.productProfile,
+    required this.child,
+  });
+
+  final ProductProfileManifest productProfile;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(32, 24, 32, 24),
+      child: Column(
+        children: [
+          _TvLiteReceiverShellHeader(productProfile: productProfile),
+          const SizedBox(height: 18),
+          Expanded(child: child),
+        ],
+      ),
+    );
+  }
+}
+
+extension on ProductSupportLevel {
+  String get tvLabel {
+    return switch (this) {
+      ProductSupportLevel.certified => 'Certified',
+      ProductSupportLevel.compatible => 'Compatible',
+      ProductSupportLevel.experimental => 'Experimental',
+      ProductSupportLevel.unsupported => 'Unsupported',
+    };
+  }
+}
+
+extension on ProductNavigationEntry {
+  String get tvLabel {
+    return switch (this) {
+      ProductNavigationEntry.home => 'Home',
+      ProductNavigationEntry.live => 'Live',
+      ProductNavigationEntry.guide => 'Guide',
+      ProductNavigationEntry.favorites => 'Favorites',
+      ProductNavigationEntry.recent => 'Recent',
+      ProductNavigationEntry.search => 'Search',
+      ProductNavigationEntry.settings => 'Settings',
+      ProductNavigationEntry.diagnostics => 'Diagnostics',
+      ProductNavigationEntry.profiles => 'Profiles',
+    };
+  }
+}
+
+extension on ProductCapability {
+  String get tvLabel {
+    return switch (this) {
+      ProductCapability.directPlayback => 'direct playback',
+      ProductCapability.dpadNavigation => 'D-pad navigation',
+      ProductCapability.companionRemote => 'companion remote',
+      ProductCapability.compactEpg => 'compact guide',
+      ProductCapability.fullEpg => 'full guide',
+      ProductCapability.basicSearch => 'basic search',
+      ProductCapability.diagnostics => 'diagnostics',
+      ProductCapability.analytics => 'analytics',
+      ProductCapability.localAi => 'local AI',
+      ProductCapability.recording => 'recording',
+      ProductCapability.downloads => 'downloads',
+      ProductCapability.multiview => 'multiview',
+    };
   }
 }
 

--- a/packages/feature_iptv/lib/src/iptv.dart
+++ b/packages/feature_iptv/lib/src/iptv.dart
@@ -18,6 +18,7 @@ export 'package:platform_media/platform_media.dart';
 export 'package:platform_player/platform_player.dart';
 export 'package:platform_playlist_import/platform_playlist_import.dart';
 export 'package:platform_streams/platform_streams.dart';
+export 'package:product_capabilities/product_capabilities.dart';
 
 // Providers
 export '../application/providers/iptv_providers.dart';

--- a/packages/feature_iptv/pubspec.yaml
+++ b/packages/feature_iptv/pubspec.yaml
@@ -26,6 +26,8 @@ dependencies:
     path: ../platform_playlist_import
   platform_streams:
     path: ../platform_streams
+  product_capabilities:
+    path: ../product_capabilities
   path_provider: ^2.1.6
   shared_preferences: ^2.5.5
   slm_edge_intelligence:

--- a/packages/feature_iptv/test/iptv/presentation/tv/iptv_tv_screen_test.dart
+++ b/packages/feature_iptv/test/iptv/presentation/tv/iptv_tv_screen_test.dart
@@ -67,13 +67,23 @@ void main() {
     await pumpScreen(tester);
 
     expect(find.text('Live channels'), findsOneWidget);
+    expect(find.text('Airo TV Lite Receiver'), findsOneWidget);
+    expect(find.text('Compatible profile'), findsOneWidget);
+    expect(find.text('Home'), findsOneWidget);
+    expect(find.text('Live'), findsOneWidget);
+    expect(find.text('Favorites'), findsOneWidget);
+    expect(find.text('Recent'), findsWidgets);
+    expect(find.text('Settings'), findsOneWidget);
+    expect(find.text('Diagnostics'), findsOneWidget);
+    expect(find.text('Guide'), findsNothing);
+    expect(find.textContaining('Profile-limited:'), findsOneWidget);
     expect(find.text('3 of 3 live channels'), findsOneWidget);
     expect(find.text('Browse'), findsOneWidget);
     expect(find.text('All'), findsWidgets);
     expect(find.text('News'), findsWidgets);
     expect(find.text('Sports'), findsWidgets);
     expect(find.text('Music'), findsWidgets);
-    expect(find.text('Search'), findsOneWidget);
+    expect(find.text('Search'), findsWidgets);
     expect(find.text('Playlist'), findsOneWidget);
     expect(find.text('Help'), findsOneWidget);
     expect(find.text('Refresh'), findsOneWidget);
@@ -84,6 +94,9 @@ void main() {
   testWidgets('shows TV empty playlist state', (tester) async {
     await pumpScreen(tester, visibleChannels: const []);
 
+    expect(find.text('Airo TV Lite Receiver'), findsOneWidget);
+    expect(find.text('Home'), findsOneWidget);
+    expect(find.text('Guide'), findsNothing);
     expect(find.text('Add your playlist'), findsOneWidget);
     expect(find.text('Import playlist URL'), findsOneWidget);
     expect(find.text('How to add'), findsOneWidget);


### PR DESCRIPTION
# Summary

This PR introduces the first Lite Receiver TV shell slice for #594.
Goal: keep reusable profile/capability rules in `product_capabilities` while the IPTV TV surface owns the product-specific layout and BYOC empty state.

Core outcome:

* Airo TV renders Lite Receiver identity and profile-driven shell sections from the platform manifest.
* Heavy features excluded by the Lite profile are summarized as profile-limited instead of exposed as navigation.

# Changes

### Code

* Added:
  * `airoTvProductProfileProvider` in `feature_iptv`.
* Updated:
  * `IptvTvScreen` consumes `AiroTvProductProfiles.liteReceiver()`.
  * TV shell renders Lite Receiver title, support status, profile sections, and unavailable heavy-capability messaging.
  * `feature_iptv` depends on `product_capabilities`; app lockfile records the transitive path package.
  * TV screen widget tests cover the shell state.

### Logic

* Profile rules remain in `packages/product_capabilities`.
* Airo TV app code owns only layout, copy, and BYOC shell behavior.
* No bundled content, pairing, compact EPG data source, or remote-control protocol is added in this slice.

# API Changes

* No public app API changes.
* `feature_iptv` now re-exports the platform product-capability contracts for TV consumers.

# Risks

* Future composition validation may tighten which shell sections are legal for each build profile.
* Rollback plan: revert this shell slice while leaving the platform package from #593 intact.

# Testing

* `cd packages/feature_iptv && flutter test test/iptv/presentation/tv/iptv_tv_screen_test.dart`
* `cd packages/feature_iptv && flutter analyze`
* `cd packages/feature_iptv && flutter test`
* `cd app && flutter pub get`
* `cd app && flutter test test/core/app/tv_router_test.dart`
* `cd app && flutter test test/main_tv_debug_playlist_test.dart`
* `git diff --check HEAD~1..HEAD`

Note: the first concurrent run of `test/main_tv_debug_playlist_test.dart` hit a local macOS native-assets signing race while another Flutter process held the startup lock; rerunning it by itself passed.

Closes #594