### PR TITLE
feat(platform): add connected node protocol

### DIFF
--- a/docs/features/airo-tv/CONNECTED_NODE_PROTOCOL.md
+++ b/docs/features/airo-tv/CONNECTED_NODE_PROTOCOL.md
@@ -1,0 +1,67 @@
+# Airo TV Connected-Node Protocol
+
+This contract defines the v2.0.0.1 platform boundary for connected Airo nodes.
+It must exist before local discovery, QR pairing, phone remote, command routing,
+AI delegation, handoff, or cloud coordination can advertise device support.
+
+Implementation contract:
+
+- Package: `packages/core_protocol`
+- Schema: `kAiroNodeProtocolSchemaVersion`
+- Protocol version: `kAiroNodeProtocolVersion`
+- Evaluator: `AiroNodeCompatibilityPolicy.evaluate`
+
+## Public Advertisement Fields
+
+Capability advertisements may expose only:
+
+- schema and protocol version;
+- stable node ID;
+- node role;
+- product profile;
+- platform category;
+- lifecycle state;
+- capability IDs;
+- issue and expiry timestamps.
+
+Advertisements must not include playlist names, source URLs, account details,
+credential material, viewing history, local network addresses, or user-entered
+search text.
+
+## Lifecycle States
+
+| State | Compatibility behavior |
+| --- | --- |
+| `available` | Eligible for negotiation |
+| `pairing` | Eligible for pairing-oriented negotiation |
+| `connected` | Eligible for authenticated/private negotiation |
+| `busy` | Eligible, but consumers may prefer another node |
+| `sleeping` | Not eligible until refreshed |
+| `offline` | Not eligible |
+| `incompatible` | Not eligible |
+| `update_required` | Not eligible |
+| `blocked` | Not eligible |
+
+## Compatibility Rules
+
+Consumers evaluate a node through `AiroNodeCompatibilityPolicy` using required
+capabilities, schema version, protocol version, trust requirement, and
+advertisement freshness.
+
+Stable blocker codes:
+
+- `schema_mismatch`
+- `protocol_too_old`
+- `protocol_too_new`
+- `stale_advertisement`
+- `missing_capability`
+- `lifecycle_unavailable`
+- `untrusted_node`
+- `blocked_node`
+
+## Release Rule
+
+Airo TV, companion, discovery, pairing, command, AI, and cloud layers should use
+`core_protocol` for node identity and capability compatibility. Product code may
+render the resulting state, but it should not invent a separate node model or
+advertise private media/account data.

--- a/packages/core_protocol/CHANGELOG.md
+++ b/packages/core_protocol/CHANGELOG.md
@@ -1,0 +1,4 @@
+## 0.0.1
+
+- Add initial connected-node identity, lifecycle, capability advertisement, and
+  compatibility contracts.

--- a/packages/core_protocol/README.md
+++ b/packages/core_protocol/README.md
@@ -1,0 +1,19 @@
+# Core Protocol
+
+Shared connected-node protocol contracts for Airo V2.
+
+This package is platform/framework code. Airo TV, mobile companion, desktop
+companion, home node, local discovery, pairing, command routing, AI delegation,
+and future cloud coordination consume these contracts to describe device nodes
+without leaking private media or account data.
+
+## Scope
+
+- Stable node identity records.
+- Node lifecycle states.
+- Privacy-safe capability advertisements.
+- Compatibility policies and deterministic blocker codes.
+
+This package does not discover devices, open sockets, store trust records,
+render pairing UI, send commands, maintain presence leases, or coordinate cloud
+state.

--- a/packages/core_protocol/analysis_options.yaml
+++ b/packages/core_protocol/analysis_options.yaml
@@ -1,0 +1,4 @@
+include: package:flutter_lints/flutter.yaml
+
+# Additional information about this file can be found at
+# https://dart.dev/guides/language/analysis-options

--- a/packages/core_protocol/lib/core_protocol.dart
+++ b/packages/core_protocol/lib/core_protocol.dart
@@ -1,0 +1,3 @@
+library;
+
+export 'src/connected_node_models.dart';

--- a/packages/core_protocol/lib/src/connected_node_models.dart
+++ b/packages/core_protocol/lib/src/connected_node_models.dart
@@ -1,0 +1,359 @@
+import 'package:equatable/equatable.dart';
+
+const String kAiroNodeProtocolSchemaVersion = '1.0.0';
+const int kAiroNodeProtocolVersion = 1;
+
+enum AiroNodeRole {
+  tvReceiver('tv_receiver'),
+  mobileCompanion('mobile_companion'),
+  desktopCompanion('desktop_companion'),
+  homeNode('home_node'),
+  cloudCoordinator('cloud_coordinator');
+
+  const AiroNodeRole(this.stableId);
+
+  final String stableId;
+}
+
+enum AiroNodeProductProfile {
+  fullTv('full_tv'),
+  standardTv('standard_tv'),
+  liteReceiver('lite_receiver'),
+  embeddedReceiver('embedded_receiver'),
+  experimentalLegacy('experimental_legacy'),
+  mobileCompanion('mobile_companion'),
+  desktopCompanion('desktop_companion'),
+  homeNode('home_node');
+
+  const AiroNodeProductProfile(this.stableId);
+
+  final String stableId;
+}
+
+enum AiroNodePlatformCategory {
+  androidTv('android_tv'),
+  fireTv('fire_tv'),
+  androidMobile('android_mobile'),
+  ios('ios'),
+  desktop('desktop'),
+  server('server'),
+  cloud('cloud'),
+  unknown('unknown');
+
+  const AiroNodePlatformCategory(this.stableId);
+
+  final String stableId;
+}
+
+enum AiroNodeLifecycleState {
+  available('available'),
+  pairing('pairing'),
+  connected('connected'),
+  busy('busy'),
+  sleeping('sleeping'),
+  offline('offline'),
+  incompatible('incompatible'),
+  updateRequired('update_required'),
+  blocked('blocked');
+
+  const AiroNodeLifecycleState(this.stableId);
+
+  final String stableId;
+
+  bool get canNegotiate =>
+      this == available || this == pairing || this == connected || this == busy;
+}
+
+enum AiroNodeTrustState {
+  unknown('unknown'),
+  untrusted('untrusted'),
+  paired('paired'),
+  trusted('trusted'),
+  revoked('revoked');
+
+  const AiroNodeTrustState(this.stableId);
+
+  final String stableId;
+
+  bool get allowsPrivateCompatibility => this == paired || this == trusted;
+}
+
+enum AiroNodeCapability {
+  playback('playback'),
+  display('display'),
+  voiceInput('voice_input'),
+  keyboardInput('keyboard_input'),
+  localAi('local_ai'),
+  mediaIndexing('media_indexing'),
+  storage('storage'),
+  remoteControl('remote_control'),
+  diagnostics('diagnostics'),
+  recording('recording'),
+  transcoding('transcoding'),
+  metadataProcessing('metadata_processing'),
+  compactEpg('compact_epg'),
+  basicSearch('basic_search'),
+  aiDelegation('ai_delegation'),
+  pairing('pairing'),
+  commandRouting('command_routing');
+
+  const AiroNodeCapability(this.stableId);
+
+  final String stableId;
+}
+
+enum AiroNodeCompatibilityBlockerCode {
+  schemaMismatch('schema_mismatch'),
+  protocolTooOld('protocol_too_old'),
+  protocolTooNew('protocol_too_new'),
+  staleAdvertisement('stale_advertisement'),
+  missingCapability('missing_capability'),
+  lifecycleUnavailable('lifecycle_unavailable'),
+  untrustedNode('untrusted_node'),
+  blockedNode('blocked_node');
+
+  const AiroNodeCompatibilityBlockerCode(this.stableId);
+
+  final String stableId;
+}
+
+class AiroNodeIdentity extends Equatable {
+  const AiroNodeIdentity({
+    required this.nodeId,
+    required this.role,
+    required this.productProfile,
+    required this.platformCategory,
+    this.schemaVersion = kAiroNodeProtocolSchemaVersion,
+    this.protocolVersion = kAiroNodeProtocolVersion,
+  });
+
+  final String schemaVersion;
+  final int protocolVersion;
+  final String nodeId;
+  final AiroNodeRole role;
+  final AiroNodeProductProfile productProfile;
+  final AiroNodePlatformCategory platformCategory;
+
+  @override
+  List<Object?> get props => [
+    schemaVersion,
+    protocolVersion,
+    nodeId,
+    role,
+    productProfile,
+    platformCategory,
+  ];
+}
+
+class AiroNodeCapabilityAdvertisement extends Equatable {
+  AiroNodeCapabilityAdvertisement({
+    required this.identity,
+    required this.lifecycle,
+    required Set<AiroNodeCapability> capabilities,
+    required this.issuedAt,
+    required this.expiresAt,
+    this.trustState = AiroNodeTrustState.unknown,
+    this.schemaVersion = kAiroNodeProtocolSchemaVersion,
+    this.protocolVersion = kAiroNodeProtocolVersion,
+  }) : capabilities = Set.unmodifiable(capabilities);
+
+  final String schemaVersion;
+  final int protocolVersion;
+  final AiroNodeIdentity identity;
+  final AiroNodeLifecycleState lifecycle;
+  final AiroNodeTrustState trustState;
+  final Set<AiroNodeCapability> capabilities;
+  final DateTime issuedAt;
+  final DateTime expiresAt;
+
+  bool isExpired(DateTime now) => !now.isBefore(expiresAt);
+
+  bool advertises(AiroNodeCapability capability) =>
+      capabilities.contains(capability);
+
+  bool advertisesAll(Set<AiroNodeCapability> requiredCapabilities) =>
+      capabilities.containsAll(requiredCapabilities);
+
+  Map<String, Object?> toPublicMap() {
+    return {
+      'schemaVersion': schemaVersion,
+      'protocolVersion': protocolVersion,
+      'nodeId': identity.nodeId,
+      'role': identity.role.stableId,
+      'productProfile': identity.productProfile.stableId,
+      'platformCategory': identity.platformCategory.stableId,
+      'lifecycle': lifecycle.stableId,
+      'capabilities': capabilities
+          .map((capability) => capability.stableId)
+          .toList(growable: false),
+      'issuedAt': issuedAt.toIso8601String(),
+      'expiresAt': expiresAt.toIso8601String(),
+    };
+  }
+
+  @override
+  String toString() {
+    return 'AiroNodeCapabilityAdvertisement('
+        'nodeId: ${identity.nodeId}, '
+        'role: ${identity.role.stableId}, '
+        'productProfile: ${identity.productProfile.stableId}, '
+        'platformCategory: ${identity.platformCategory.stableId}, '
+        'lifecycle: ${lifecycle.stableId}, '
+        'capabilities: ${capabilities.map((capability) => capability.stableId).join(',')}, '
+        'issuedAt: $issuedAt, '
+        'expiresAt: $expiresAt'
+        ')';
+  }
+
+  @override
+  List<Object?> get props => [
+    schemaVersion,
+    protocolVersion,
+    identity,
+    lifecycle,
+    trustState,
+    capabilities,
+    issuedAt,
+    expiresAt,
+  ];
+}
+
+class AiroNodeCompatibilityPolicy extends Equatable {
+  AiroNodeCompatibilityPolicy({
+    required Set<AiroNodeCapability> requiredCapabilities,
+    this.acceptedSchemaVersion = kAiroNodeProtocolSchemaVersion,
+    this.minProtocolVersion = kAiroNodeProtocolVersion,
+    this.maxProtocolVersion = kAiroNodeProtocolVersion,
+    this.requiresTrustedNode = false,
+  }) : requiredCapabilities = Set.unmodifiable(requiredCapabilities);
+
+  final String acceptedSchemaVersion;
+  final int minProtocolVersion;
+  final int maxProtocolVersion;
+  final bool requiresTrustedNode;
+  final Set<AiroNodeCapability> requiredCapabilities;
+
+  AiroNodeCompatibilityResult evaluate({
+    required AiroNodeCapabilityAdvertisement advertisement,
+    required DateTime now,
+  }) {
+    final blockers = <AiroNodeCompatibilityBlocker>[];
+
+    if (advertisement.schemaVersion != acceptedSchemaVersion ||
+        advertisement.identity.schemaVersion != acceptedSchemaVersion) {
+      blockers.add(
+        AiroNodeCompatibilityBlocker(
+          code: AiroNodeCompatibilityBlockerCode.schemaMismatch,
+          nodeId: advertisement.identity.nodeId,
+        ),
+      );
+    }
+
+    if (advertisement.protocolVersion < minProtocolVersion ||
+        advertisement.identity.protocolVersion < minProtocolVersion) {
+      blockers.add(
+        AiroNodeCompatibilityBlocker(
+          code: AiroNodeCompatibilityBlockerCode.protocolTooOld,
+          nodeId: advertisement.identity.nodeId,
+        ),
+      );
+    }
+
+    if (advertisement.protocolVersion > maxProtocolVersion ||
+        advertisement.identity.protocolVersion > maxProtocolVersion) {
+      blockers.add(
+        AiroNodeCompatibilityBlocker(
+          code: AiroNodeCompatibilityBlockerCode.protocolTooNew,
+          nodeId: advertisement.identity.nodeId,
+        ),
+      );
+    }
+
+    if (advertisement.isExpired(now)) {
+      blockers.add(
+        AiroNodeCompatibilityBlocker(
+          code: AiroNodeCompatibilityBlockerCode.staleAdvertisement,
+          nodeId: advertisement.identity.nodeId,
+        ),
+      );
+    }
+
+    if (advertisement.lifecycle == AiroNodeLifecycleState.blocked ||
+        advertisement.trustState == AiroNodeTrustState.revoked) {
+      blockers.add(
+        AiroNodeCompatibilityBlocker(
+          code: AiroNodeCompatibilityBlockerCode.blockedNode,
+          nodeId: advertisement.identity.nodeId,
+        ),
+      );
+    } else if (!advertisement.lifecycle.canNegotiate) {
+      blockers.add(
+        AiroNodeCompatibilityBlocker(
+          code: AiroNodeCompatibilityBlockerCode.lifecycleUnavailable,
+          nodeId: advertisement.identity.nodeId,
+        ),
+      );
+    }
+
+    if (requiresTrustedNode &&
+        !advertisement.trustState.allowsPrivateCompatibility) {
+      blockers.add(
+        AiroNodeCompatibilityBlocker(
+          code: AiroNodeCompatibilityBlockerCode.untrustedNode,
+          nodeId: advertisement.identity.nodeId,
+        ),
+      );
+    }
+
+    if (!advertisement.advertisesAll(requiredCapabilities)) {
+      blockers.add(
+        AiroNodeCompatibilityBlocker(
+          code: AiroNodeCompatibilityBlockerCode.missingCapability,
+          nodeId: advertisement.identity.nodeId,
+        ),
+      );
+    }
+
+    return AiroNodeCompatibilityResult(
+      nodeId: advertisement.identity.nodeId,
+      blockers: blockers,
+    );
+  }
+
+  @override
+  List<Object?> get props => [
+    acceptedSchemaVersion,
+    minProtocolVersion,
+    maxProtocolVersion,
+    requiresTrustedNode,
+    requiredCapabilities,
+  ];
+}
+
+class AiroNodeCompatibilityBlocker extends Equatable {
+  const AiroNodeCompatibilityBlocker({
+    required this.code,
+    required this.nodeId,
+  });
+
+  final AiroNodeCompatibilityBlockerCode code;
+  final String nodeId;
+
+  @override
+  List<Object?> get props => [code, nodeId];
+}
+
+class AiroNodeCompatibilityResult extends Equatable {
+  AiroNodeCompatibilityResult({
+    required this.nodeId,
+    required List<AiroNodeCompatibilityBlocker> blockers,
+  }) : blockers = List.unmodifiable(blockers);
+
+  final String nodeId;
+  final List<AiroNodeCompatibilityBlocker> blockers;
+
+  bool get compatible => blockers.isEmpty;
+
+  @override
+  List<Object?> get props => [nodeId, blockers];
+}

--- a/packages/core_protocol/pubspec.yaml
+++ b/packages/core_protocol/pubspec.yaml
@@ -1,0 +1,21 @@
+name: core_protocol
+description: Connected-node protocol contracts for Airo devices.
+version: 0.0.1
+homepage:
+publish_to: none
+
+environment:
+  sdk: ^3.12.2
+  flutter: ">=1.17.0"
+
+dependencies:
+  equatable: ^2.0.8
+  flutter:
+    sdk: flutter
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+  flutter_lints: ^6.0.0
+
+flutter:

--- a/packages/core_protocol/test/connected_node_models_test.dart
+++ b/packages/core_protocol/test/connected_node_models_test.dart
@@ -1,0 +1,201 @@
+import 'package:core_protocol/core_protocol.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('Airo connected-node protocol', () {
+    final now = DateTime.utc(2026, 7, 14, 12);
+
+    AiroNodeIdentity identity({
+      String nodeId = 'node-tv-1',
+      AiroNodeRole role = AiroNodeRole.tvReceiver,
+      AiroNodeProductProfile productProfile =
+          AiroNodeProductProfile.liteReceiver,
+      int protocolVersion = kAiroNodeProtocolVersion,
+      String schemaVersion = kAiroNodeProtocolSchemaVersion,
+    }) {
+      return AiroNodeIdentity(
+        nodeId: nodeId,
+        role: role,
+        productProfile: productProfile,
+        platformCategory: AiroNodePlatformCategory.androidTv,
+        protocolVersion: protocolVersion,
+        schemaVersion: schemaVersion,
+      );
+    }
+
+    AiroNodeCapabilityAdvertisement advertisement({
+      AiroNodeIdentity? nodeIdentity,
+      AiroNodeLifecycleState lifecycle = AiroNodeLifecycleState.available,
+      AiroNodeTrustState trustState = AiroNodeTrustState.trusted,
+      Set<AiroNodeCapability> capabilities = const {
+        AiroNodeCapability.playback,
+        AiroNodeCapability.remoteControl,
+        AiroNodeCapability.compactEpg,
+        AiroNodeCapability.basicSearch,
+      },
+      DateTime? issuedAt,
+      DateTime? expiresAt,
+      int protocolVersion = kAiroNodeProtocolVersion,
+      String schemaVersion = kAiroNodeProtocolSchemaVersion,
+    }) {
+      return AiroNodeCapabilityAdvertisement(
+        identity: nodeIdentity ?? identity(),
+        lifecycle: lifecycle,
+        trustState: trustState,
+        capabilities: capabilities,
+        issuedAt: issuedAt ?? now,
+        expiresAt: expiresAt ?? now.add(const Duration(seconds: 30)),
+        protocolVersion: protocolVersion,
+        schemaVersion: schemaVersion,
+      );
+    }
+
+    AiroNodeCompatibilityPolicy policy({
+      bool requiresTrustedNode = true,
+      Set<AiroNodeCapability> requiredCapabilities = const {
+        AiroNodeCapability.playback,
+        AiroNodeCapability.compactEpg,
+      },
+      int minProtocolVersion = kAiroNodeProtocolVersion,
+      int maxProtocolVersion = kAiroNodeProtocolVersion,
+      String acceptedSchemaVersion = kAiroNodeProtocolSchemaVersion,
+    }) {
+      return AiroNodeCompatibilityPolicy(
+        requiredCapabilities: requiredCapabilities,
+        requiresTrustedNode: requiresTrustedNode,
+        minProtocolVersion: minProtocolVersion,
+        maxProtocolVersion: maxProtocolVersion,
+        acceptedSchemaVersion: acceptedSchemaVersion,
+      );
+    }
+
+    test('identity exposes stable schema and role/profile identifiers', () {
+      final node = identity();
+
+      expect(node.schemaVersion, kAiroNodeProtocolSchemaVersion);
+      expect(node.protocolVersion, kAiroNodeProtocolVersion);
+      expect(node.role.stableId, 'tv_receiver');
+      expect(node.productProfile.stableId, 'lite_receiver');
+    });
+
+    test('public advertisement omits private media and account fields', () {
+      final publicMap = advertisement().toPublicMap();
+      final rendered = publicMap.toString();
+
+      expect(publicMap['nodeId'], 'node-tv-1');
+      expect(publicMap['capabilities'], contains('playback'));
+      expect(rendered, isNot(contains('playlist')));
+      expect(rendered, isNot(contains('credential')));
+      expect(rendered, isNot(contains('history')));
+      expect(rendered, isNot(contains('mediaUrl')));
+    });
+
+    test(
+      'compatible node passes schema, protocol, lifecycle, trust, and freshness',
+      () {
+        final result = policy().evaluate(
+          advertisement: advertisement(),
+          now: now,
+        );
+
+        expect(result.compatible, isTrue);
+        expect(result.blockers, isEmpty);
+      },
+    );
+
+    test('stale advertisement fails deterministically', () {
+      final result = policy().evaluate(
+        advertisement: advertisement(
+          issuedAt: now.subtract(const Duration(minutes: 2)),
+          expiresAt: now.subtract(const Duration(seconds: 1)),
+        ),
+        now: now,
+      );
+
+      expect(result.compatible, isFalse);
+      expect(
+        result.blockers.map((blocker) => blocker.code),
+        contains(AiroNodeCompatibilityBlockerCode.staleAdvertisement),
+      );
+    });
+
+    test('missing required capability fails deterministically', () {
+      final result = policy().evaluate(
+        advertisement: advertisement(
+          capabilities: const {AiroNodeCapability.playback},
+        ),
+        now: now,
+      );
+
+      expect(result.compatible, isFalse);
+      expect(
+        result.blockers.map((blocker) => blocker.code),
+        contains(AiroNodeCompatibilityBlockerCode.missingCapability),
+      );
+    });
+
+    test('untrusted nodes fail private compatibility checks', () {
+      final result = policy().evaluate(
+        advertisement: advertisement(trustState: AiroNodeTrustState.untrusted),
+        now: now,
+      );
+
+      expect(result.compatible, isFalse);
+      expect(
+        result.blockers.map((blocker) => blocker.code),
+        contains(AiroNodeCompatibilityBlockerCode.untrustedNode),
+      );
+    });
+
+    test('blocked and unavailable lifecycle states fail deterministically', () {
+      final blocked = policy().evaluate(
+        advertisement: advertisement(lifecycle: AiroNodeLifecycleState.blocked),
+        now: now,
+      );
+      final sleeping = policy().evaluate(
+        advertisement: advertisement(
+          lifecycle: AiroNodeLifecycleState.sleeping,
+        ),
+        now: now,
+      );
+
+      expect(
+        blocked.blockers.map((blocker) => blocker.code),
+        contains(AiroNodeCompatibilityBlockerCode.blockedNode),
+      );
+      expect(
+        sleeping.blockers.map((blocker) => blocker.code),
+        contains(AiroNodeCompatibilityBlockerCode.lifecycleUnavailable),
+      );
+    });
+
+    test('schema and protocol mismatches return stable blocker codes', () {
+      final wrongSchema = policy().evaluate(
+        advertisement: advertisement(
+          nodeIdentity: identity(schemaVersion: '2.0.0'),
+          schemaVersion: '2.0.0',
+        ),
+        now: now,
+      );
+      final oldProtocol = policy(
+        minProtocolVersion: 2,
+      ).evaluate(advertisement: advertisement(protocolVersion: 1), now: now);
+      final newProtocol = policy(
+        maxProtocolVersion: 1,
+      ).evaluate(advertisement: advertisement(protocolVersion: 2), now: now);
+
+      expect(
+        wrongSchema.blockers.map((blocker) => blocker.code),
+        contains(AiroNodeCompatibilityBlockerCode.schemaMismatch),
+      );
+      expect(
+        oldProtocol.blockers.map((blocker) => blocker.code),
+        contains(AiroNodeCompatibilityBlockerCode.protocolTooOld),
+      );
+      expect(
+        newProtocol.blockers.map((blocker) => blocker.code),
+        contains(AiroNodeCompatibilityBlockerCode.protocolTooNew),
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Adds the v2 connected-node protocol platform contract for Airo TV delegation.

## Changes

- Adds `packages/core_protocol` for reusable node identity, lifecycle states, trust states, capability advertisements, and compatibility negotiation.
- Keeps public advertisements privacy-safe by omitting private media, account, credential, and local-network details.
- Defines deterministic blocker codes for stale, missing capability, lifecycle, trust, schema, and protocol incompatibility cases.
- Documents the platform boundary in `docs/features/airo-tv/CONNECTED_NODE_PROTOCOL.md` so discovery, pairing, commands, AI delegation, and cloud coordination share one protocol.

## Testing

- `dart format --set-exit-if-changed packages/core_protocol`
- `cd packages/core_protocol && flutter test`
- `cd packages/core_protocol && flutter analyze --fatal-infos`
- `git diff --check HEAD~1..HEAD`

Closes #601