### PR TITLE
feat(platform): add local discovery abstraction

### DIFF
--- a/docs/features/airo-tv/LOCAL_DISCOVERY_ABSTRACTION.md
+++ b/docs/features/airo-tv/LOCAL_DISCOVERY_ABSTRACTION.md
@@ -1,0 +1,58 @@
+# Airo TV Local Discovery Abstraction
+
+This contract defines the v2.0.0.1 platform boundary for same-network Airo node
+discovery. It prepares the project for mDNS/DNS-SD service `_airotv._tcp`
+without committing to a native adapter in this issue.
+
+Implementation contract:
+
+- Package: `packages/platform_network_discovery`
+- Schema: `kAiroDiscoverySchemaVersion`
+- Service type: `kAiroDiscoveryServiceType == "_airotv._tcp"`
+- Protocol dependency: `packages/core_protocol`
+
+## Public Discovery Metadata
+
+Discovery metadata is derived from `AiroNodeCapabilityAdvertisement` and may
+include only:
+
+- discovery schema;
+- `_airotv._tcp` service type;
+- connected-node schema and protocol version;
+- stable node ID;
+- node role;
+- product profile;
+- platform category;
+- lifecycle;
+- public capability IDs;
+- expiry timestamp.
+
+Discovery metadata must not include playlist names, media URLs, provider
+credentials, local IP addresses, local file paths, viewing history, raw search
+text, or voice transcripts.
+
+## Adapter Boundary
+
+`AiroLocalDiscoveryAdapter` defines:
+
+- stream of discovery snapshots;
+- start with advertise, browse, or advertise-and-browse mode;
+- stop;
+- current snapshot.
+
+The package includes:
+
+- `AiroNoOpLocalDiscoveryAdapter` for unsupported platforms and disabled local
+  network permissions;
+- `AiroFakeLocalDiscoveryAdapter` for deterministic host-only tests.
+
+Real Android, iOS, desktop, and Fire TV discovery adapters should implement the
+same contract later. Product UI should render adapter states and permission
+states rather than branch on platform-specific discovery APIs.
+
+## Release Rule
+
+Airo TV, companion, pairing, command, and AI flows should consume
+`platform_network_discovery` snapshots. Standalone playback must continue when
+local discovery is unavailable, denied, blocked by multicast restrictions, or
+not yet implemented for a platform.

--- a/packages/platform_network_discovery/CHANGELOG.md
+++ b/packages/platform_network_discovery/CHANGELOG.md
@@ -1,0 +1,3 @@
+## 0.0.1
+
+- Add initial local network discovery abstraction and fake adapters.

--- a/packages/platform_network_discovery/README.md
+++ b/packages/platform_network_discovery/README.md
@@ -1,0 +1,17 @@
+# Platform Network Discovery
+
+Local network discovery abstractions for Airo connected nodes.
+
+This package is platform/framework code. Airo TV, mobile companion, desktop
+companion, home node, pairing, command routing, and QA automation consume this
+contract before native mDNS/DNS-SD adapters exist.
+
+## Scope
+
+- `_airotv._tcp` service metadata contract.
+- Privacy-safe discovery TXT record generation and validation.
+- Discovery snapshots with stale filtering and duplicate-node merge.
+- No-op and in-memory fake adapters for host-only tests.
+
+This package does not implement native mDNS/DNS-SD, ask local-network
+permissions, open sockets, pair devices, send commands, or render UI.

--- a/packages/platform_network_discovery/analysis_options.yaml
+++ b/packages/platform_network_discovery/analysis_options.yaml
@@ -1,0 +1,4 @@
+include: package:flutter_lints/flutter.yaml
+
+# Additional information about this file can be found at
+# https://dart.dev/guides/language/analysis-options

--- a/packages/platform_network_discovery/lib/platform_network_discovery.dart
+++ b/packages/platform_network_discovery/lib/platform_network_discovery.dart
@@ -1,0 +1,3 @@
+library;
+
+export 'src/local_discovery_models.dart';

--- a/packages/platform_network_discovery/lib/src/local_discovery_models.dart
+++ b/packages/platform_network_discovery/lib/src/local_discovery_models.dart
@@ -1,0 +1,433 @@
+import 'dart:async';
+
+import 'package:core_protocol/core_protocol.dart';
+import 'package:equatable/equatable.dart';
+
+const String kAiroDiscoverySchemaVersion = '1.0.0';
+const String kAiroDiscoveryServiceType = '_airotv._tcp';
+
+enum AiroDiscoveryTransport {
+  mdnsDnsSd('mdns_dns_sd'),
+  manualCode('manual_code'),
+  fake('fake');
+
+  const AiroDiscoveryTransport(this.stableId);
+
+  final String stableId;
+}
+
+enum AiroDiscoveryMode {
+  advertise('advertise'),
+  browse('browse'),
+  advertiseAndBrowse('advertise_and_browse');
+
+  const AiroDiscoveryMode(this.stableId);
+
+  final String stableId;
+}
+
+enum AiroDiscoveryPermissionState {
+  unknown('unknown'),
+  granted('granted'),
+  denied('denied'),
+  restricted('restricted'),
+  unavailable('unavailable');
+
+  const AiroDiscoveryPermissionState(this.stableId);
+
+  final String stableId;
+}
+
+enum AiroDiscoveryAdapterState {
+  idle('idle'),
+  advertising('advertising'),
+  browsing('browsing'),
+  advertisingAndBrowsing('advertising_and_browsing'),
+  stopped('stopped'),
+  permissionRequired('permission_required'),
+  failed('failed');
+
+  const AiroDiscoveryAdapterState(this.stableId);
+
+  final String stableId;
+}
+
+enum AiroDiscoveryPrivacyCode {
+  prohibitedFieldName('prohibited_field_name'),
+  urlValue('url_value'),
+  localPathValue('local_path_value'),
+  localIpValue('local_ip_value'),
+  credentialLikeValue('credential_like_value');
+
+  const AiroDiscoveryPrivacyCode(this.stableId);
+
+  final String stableId;
+}
+
+class AiroDiscoveryPrivacyViolation extends Equatable {
+  const AiroDiscoveryPrivacyViolation({
+    required this.code,
+    required this.field,
+  });
+
+  final AiroDiscoveryPrivacyCode code;
+  final String field;
+
+  @override
+  List<Object?> get props => [code, field];
+}
+
+class AiroDiscoveryPrivacyResult extends Equatable {
+  AiroDiscoveryPrivacyResult({
+    required List<AiroDiscoveryPrivacyViolation> violations,
+  }) : violations = List.unmodifiable(violations);
+
+  final List<AiroDiscoveryPrivacyViolation> violations;
+
+  bool get accepted => violations.isEmpty;
+
+  @override
+  List<Object?> get props => [violations];
+}
+
+class AiroDiscoveryPrivacyFilter {
+  AiroDiscoveryPrivacyFilter({
+    Set<String> prohibitedFields = _defaultProhibitedFields,
+  }) : prohibitedFields = Set.unmodifiable(
+         prohibitedFields.map(_normalizeFieldName),
+       );
+
+  static final AiroDiscoveryPrivacyFilter standard =
+      AiroDiscoveryPrivacyFilter();
+
+  static const Set<String> _defaultProhibitedFields = {
+    'playlist',
+    'playlistName',
+    'playlistUrl',
+    'mediaUrl',
+    'sourceUrl',
+    'streamUrl',
+    'signedUrl',
+    'url',
+    'credential',
+    'authorization',
+    'authHeader',
+    'cookie',
+    'history',
+    'viewingHistory',
+    'localIp',
+    'ipAddress',
+    'localPath',
+    'path',
+    'query',
+    'searchText',
+    'voiceTranscript',
+  };
+
+  final Set<String> prohibitedFields;
+
+  AiroDiscoveryPrivacyResult validate(Map<String, String> txtRecords) {
+    final violations = <AiroDiscoveryPrivacyViolation>[];
+
+    for (final entry in txtRecords.entries) {
+      final field = entry.key;
+      final normalized = _normalizeFieldName(field);
+      if (prohibitedFields.contains(normalized)) {
+        violations.add(
+          AiroDiscoveryPrivacyViolation(
+            code: AiroDiscoveryPrivacyCode.prohibitedFieldName,
+            field: field,
+          ),
+        );
+      }
+
+      final code = _classifyStringValue(entry.value);
+      if (code != null) {
+        violations.add(AiroDiscoveryPrivacyViolation(code: code, field: field));
+      }
+    }
+
+    return AiroDiscoveryPrivacyResult(violations: violations);
+  }
+
+  static String _normalizeFieldName(String field) {
+    return field.replaceAll(RegExp('[^A-Za-z0-9]'), '').toLowerCase();
+  }
+
+  static AiroDiscoveryPrivacyCode? _classifyStringValue(String value) {
+    final trimmed = value.trim();
+    if (trimmed.isEmpty) return null;
+
+    final uri = Uri.tryParse(trimmed);
+    if (uri != null && (uri.scheme == 'http' || uri.scheme == 'https')) {
+      return AiroDiscoveryPrivacyCode.urlValue;
+    }
+    if (trimmed.startsWith('file://') ||
+        trimmed.startsWith('/') ||
+        RegExp(r'^[A-Za-z]:\\').hasMatch(trimmed)) {
+      return AiroDiscoveryPrivacyCode.localPathValue;
+    }
+    if (RegExp(
+      r'\b(?:10|127|172\.(?:1[6-9]|2\d|3[0-1])|192\.168)\.',
+    ).hasMatch(trimmed)) {
+      return AiroDiscoveryPrivacyCode.localIpValue;
+    }
+    if (RegExp(
+      r'\b(?:bearer|basic)\s+[A-Za-z0-9._~+/=-]+',
+      caseSensitive: false,
+    ).hasMatch(trimmed)) {
+      return AiroDiscoveryPrivacyCode.credentialLikeValue;
+    }
+
+    return null;
+  }
+}
+
+class AiroDiscoveryServiceRecord extends Equatable {
+  AiroDiscoveryServiceRecord({
+    required this.recordId,
+    required this.instanceName,
+    required this.hostName,
+    required this.port,
+    required this.advertisement,
+    required this.discoveredAt,
+    required this.lastSeenAt,
+    this.transport = AiroDiscoveryTransport.mdnsDnsSd,
+    Map<String, String> extraTxtRecords = const {},
+    this.schemaVersion = kAiroDiscoverySchemaVersion,
+  }) : extraTxtRecords = Map.unmodifiable(extraTxtRecords) {
+    final result = AiroDiscoveryPrivacyFilter.standard.validate(toTxtRecords());
+    if (!result.accepted) {
+      throw ArgumentError.value(
+        extraTxtRecords,
+        'extraTxtRecords',
+        result.violations.map((violation) => violation.code.stableId).join(','),
+      );
+    }
+  }
+
+  final String schemaVersion;
+  final String recordId;
+  final String instanceName;
+  final String hostName;
+  final int port;
+  final AiroDiscoveryTransport transport;
+  final AiroNodeCapabilityAdvertisement advertisement;
+  final DateTime discoveredAt;
+  final DateTime lastSeenAt;
+  final Map<String, String> extraTxtRecords;
+
+  bool isExpired(DateTime now) => advertisement.isExpired(now);
+
+  Map<String, String> toTxtRecords() {
+    final publicMap = advertisement.toPublicMap();
+    return {
+      'discoverySchema': schemaVersion,
+      'service': kAiroDiscoveryServiceType,
+      'nodeSchema': publicMap['schemaVersion'] as String,
+      'protocol': '${publicMap['protocolVersion']}',
+      'nodeId': publicMap['nodeId'] as String,
+      'role': publicMap['role'] as String,
+      'profile': publicMap['productProfile'] as String,
+      'platform': publicMap['platformCategory'] as String,
+      'lifecycle': publicMap['lifecycle'] as String,
+      'capabilities': (publicMap['capabilities'] as List<String>).join(','),
+      'expiresAt': publicMap['expiresAt'] as String,
+      ...extraTxtRecords,
+    };
+  }
+
+  @override
+  String toString() {
+    return 'AiroDiscoveryServiceRecord('
+        'recordId: $recordId, '
+        'service: $kAiroDiscoveryServiceType, '
+        'nodeId: ${advertisement.identity.nodeId}, '
+        'transport: ${transport.stableId}, '
+        'lastSeenAt: $lastSeenAt'
+        ')';
+  }
+
+  @override
+  List<Object?> get props => [
+    schemaVersion,
+    recordId,
+    instanceName,
+    hostName,
+    port,
+    transport,
+    advertisement,
+    discoveredAt,
+    lastSeenAt,
+    extraTxtRecords,
+  ];
+}
+
+class AiroDiscoverySnapshot extends Equatable {
+  AiroDiscoverySnapshot({
+    required Iterable<AiroDiscoveryServiceRecord> records,
+    required this.capturedAt,
+    this.adapterState = AiroDiscoveryAdapterState.idle,
+    this.permissionState = AiroDiscoveryPermissionState.unknown,
+    this.schemaVersion = kAiroDiscoverySchemaVersion,
+  }) : records = List.unmodifiable(records);
+
+  factory AiroDiscoverySnapshot.active({
+    required Iterable<AiroDiscoveryServiceRecord> records,
+    required DateTime now,
+    AiroDiscoveryAdapterState adapterState = AiroDiscoveryAdapterState.browsing,
+    AiroDiscoveryPermissionState permissionState =
+        AiroDiscoveryPermissionState.granted,
+  }) {
+    final byNodeId = <String, AiroDiscoveryServiceRecord>{};
+
+    for (final record in records) {
+      if (record.isExpired(now)) continue;
+      final nodeId = record.advertisement.identity.nodeId;
+      final existing = byNodeId[nodeId];
+      if (existing == null || record.lastSeenAt.isAfter(existing.lastSeenAt)) {
+        byNodeId[nodeId] = record;
+      }
+    }
+
+    return AiroDiscoverySnapshot(
+      records: byNodeId.values,
+      capturedAt: now,
+      adapterState: adapterState,
+      permissionState: permissionState,
+    );
+  }
+
+  final String schemaVersion;
+  final List<AiroDiscoveryServiceRecord> records;
+  final DateTime capturedAt;
+  final AiroDiscoveryAdapterState adapterState;
+  final AiroDiscoveryPermissionState permissionState;
+
+  bool get hasRecords => records.isNotEmpty;
+
+  AiroDiscoveryServiceRecord? recordForNode(String nodeId) {
+    for (final record in records) {
+      if (record.advertisement.identity.nodeId == nodeId) return record;
+    }
+    return null;
+  }
+
+  @override
+  List<Object?> get props => [
+    schemaVersion,
+    records,
+    capturedAt,
+    adapterState,
+    permissionState,
+  ];
+}
+
+abstract class AiroLocalDiscoveryAdapter {
+  Stream<AiroDiscoverySnapshot> get snapshots;
+
+  Future<void> start(AiroDiscoveryMode mode);
+
+  Future<void> stop();
+
+  Future<AiroDiscoverySnapshot> currentSnapshot(DateTime now);
+}
+
+class AiroNoOpLocalDiscoveryAdapter implements AiroLocalDiscoveryAdapter {
+  AiroNoOpLocalDiscoveryAdapter({
+    this.permissionState = AiroDiscoveryPermissionState.unavailable,
+  });
+
+  final AiroDiscoveryPermissionState permissionState;
+  final StreamController<AiroDiscoverySnapshot> _controller =
+      StreamController<AiroDiscoverySnapshot>.broadcast();
+  AiroDiscoveryAdapterState _state = AiroDiscoveryAdapterState.idle;
+
+  @override
+  Stream<AiroDiscoverySnapshot> get snapshots => _controller.stream;
+
+  @override
+  Future<void> start(AiroDiscoveryMode mode) async {
+    _state = AiroDiscoveryAdapterState.permissionRequired;
+    _controller.add(await currentSnapshot(DateTime.now().toUtc()));
+  }
+
+  @override
+  Future<void> stop() async {
+    _state = AiroDiscoveryAdapterState.stopped;
+    _controller.add(await currentSnapshot(DateTime.now().toUtc()));
+  }
+
+  @override
+  Future<AiroDiscoverySnapshot> currentSnapshot(DateTime now) async {
+    return AiroDiscoverySnapshot(
+      records: const [],
+      capturedAt: now,
+      adapterState: _state,
+      permissionState: permissionState,
+    );
+  }
+}
+
+class AiroFakeLocalDiscoveryAdapter implements AiroLocalDiscoveryAdapter {
+  AiroFakeLocalDiscoveryAdapter({
+    this.permissionState = AiroDiscoveryPermissionState.granted,
+  });
+
+  final AiroDiscoveryPermissionState permissionState;
+  final StreamController<AiroDiscoverySnapshot> _controller =
+      StreamController<AiroDiscoverySnapshot>.broadcast();
+  final List<AiroDiscoveryServiceRecord> _records = [];
+  AiroDiscoveryAdapterState _state = AiroDiscoveryAdapterState.idle;
+
+  @override
+  Stream<AiroDiscoverySnapshot> get snapshots => _controller.stream;
+
+  void upsert(AiroDiscoveryServiceRecord record, DateTime now) {
+    _records.removeWhere(
+      (existing) =>
+          existing.advertisement.identity.nodeId ==
+          record.advertisement.identity.nodeId,
+    );
+    _records.add(record);
+    _controller.add(_snapshot(now));
+  }
+
+  void removeNode(String nodeId, DateTime now) {
+    _records.removeWhere(
+      (record) => record.advertisement.identity.nodeId == nodeId,
+    );
+    _controller.add(_snapshot(now));
+  }
+
+  @override
+  Future<void> start(AiroDiscoveryMode mode) async {
+    _state = switch (mode) {
+      AiroDiscoveryMode.advertise => AiroDiscoveryAdapterState.advertising,
+      AiroDiscoveryMode.browse => AiroDiscoveryAdapterState.browsing,
+      AiroDiscoveryMode.advertiseAndBrowse =>
+        AiroDiscoveryAdapterState.advertisingAndBrowsing,
+    };
+    _controller.add(_snapshot(DateTime.now().toUtc()));
+  }
+
+  @override
+  Future<void> stop() async {
+    _state = AiroDiscoveryAdapterState.stopped;
+    _controller.add(_snapshot(DateTime.now().toUtc()));
+  }
+
+  @override
+  Future<AiroDiscoverySnapshot> currentSnapshot(DateTime now) async {
+    return _snapshot(now);
+  }
+
+  AiroDiscoverySnapshot _snapshot(DateTime now) {
+    return AiroDiscoverySnapshot.active(
+      records: _records,
+      now: now,
+      adapterState: _state,
+      permissionState: permissionState,
+    );
+  }
+}

--- a/packages/platform_network_discovery/pubspec.yaml
+++ b/packages/platform_network_discovery/pubspec.yaml
@@ -1,0 +1,23 @@
+name: platform_network_discovery
+description: Local network discovery abstractions for Airo connected nodes.
+version: 0.0.1
+homepage:
+publish_to: none
+
+environment:
+  sdk: ^3.12.2
+  flutter: ">=1.17.0"
+
+dependencies:
+  core_protocol:
+    path: ../core_protocol
+  equatable: ^2.0.8
+  flutter:
+    sdk: flutter
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+  flutter_lints: ^6.0.0
+
+flutter:

--- a/packages/platform_network_discovery/test/local_discovery_models_test.dart
+++ b/packages/platform_network_discovery/test/local_discovery_models_test.dart
@@ -1,0 +1,152 @@
+import 'package:core_protocol/core_protocol.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:platform_network_discovery/platform_network_discovery.dart';
+
+void main() {
+  group('Airo local network discovery', () {
+    final now = DateTime.utc(2026, 7, 14, 12);
+
+    AiroNodeCapabilityAdvertisement advertisement({
+      String nodeId = 'node-tv-1',
+      DateTime? issuedAt,
+      DateTime? expiresAt,
+    }) {
+      return AiroNodeCapabilityAdvertisement(
+        identity: AiroNodeIdentity(
+          nodeId: nodeId,
+          role: AiroNodeRole.tvReceiver,
+          productProfile: AiroNodeProductProfile.liteReceiver,
+          platformCategory: AiroNodePlatformCategory.androidTv,
+        ),
+        lifecycle: AiroNodeLifecycleState.available,
+        trustState: AiroNodeTrustState.unknown,
+        capabilities: const {
+          AiroNodeCapability.playback,
+          AiroNodeCapability.compactEpg,
+          AiroNodeCapability.basicSearch,
+        },
+        issuedAt: issuedAt ?? now,
+        expiresAt: expiresAt ?? now.add(const Duration(seconds: 30)),
+      );
+    }
+
+    AiroDiscoveryServiceRecord record({
+      String nodeId = 'node-tv-1',
+      String recordId = 'record-1',
+      DateTime? lastSeenAt,
+      DateTime? expiresAt,
+      Map<String, String> extraTxtRecords = const {},
+    }) {
+      return AiroDiscoveryServiceRecord(
+        recordId: recordId,
+        instanceName: 'Airo TV',
+        hostName: 'airo-tv.local',
+        port: 41234,
+        advertisement: advertisement(nodeId: nodeId, expiresAt: expiresAt),
+        discoveredAt: now,
+        lastSeenAt: lastSeenAt ?? now,
+        extraTxtRecords: extraTxtRecords,
+      );
+    }
+
+    test('service record emits _airotv TXT metadata from core protocol', () {
+      final txt = record().toTxtRecords();
+
+      expect(txt['service'], kAiroDiscoveryServiceType);
+      expect(txt['nodeId'], 'node-tv-1');
+      expect(txt['role'], 'tv_receiver');
+      expect(txt['profile'], 'lite_receiver');
+      expect(txt['capabilities'], contains('playback'));
+      expect(txt.toString(), isNot(contains('playlist')));
+      expect(txt.toString(), isNot(contains('credential')));
+      expect(txt.toString(), isNot(contains('history')));
+    });
+
+    test('privacy filter rejects prohibited discovery metadata', () {
+      expect(
+        () => record(extraTxtRecords: const {'playlistUrl': 'hidden'}),
+        throwsArgumentError,
+      );
+      expect(
+        () => record(extraTxtRecords: const {'note': 'https://example.com'}),
+        throwsArgumentError,
+      );
+      expect(
+        () => record(extraTxtRecords: const {'note': '/Users/example/list'}),
+        throwsArgumentError,
+      );
+      expect(
+        () => record(extraTxtRecords: const {'note': 'seen 192.168.1.10'}),
+        throwsArgumentError,
+      );
+      expect(
+        () => record(extraTxtRecords: const {'note': 'Bearer abc.def'}),
+        throwsArgumentError,
+      );
+    });
+
+    test('active snapshot merges duplicates to newest non-expired record', () {
+      final older = record(
+        recordId: 'older',
+        lastSeenAt: now.subtract(const Duration(seconds: 5)),
+      );
+      final newer = record(recordId: 'newer', lastSeenAt: now);
+
+      final snapshot = AiroDiscoverySnapshot.active(
+        records: [older, newer],
+        now: now,
+      );
+
+      expect(snapshot.records, hasLength(1));
+      expect(snapshot.recordForNode('node-tv-1')?.recordId, 'newer');
+    });
+
+    test('active snapshot excludes stale discovery records', () {
+      final snapshot = AiroDiscoverySnapshot.active(
+        records: [
+          record(
+            recordId: 'stale',
+            expiresAt: now.subtract(const Duration(seconds: 1)),
+          ),
+          record(recordId: 'fresh'),
+        ],
+        now: now,
+      );
+
+      expect(snapshot.records.map((record) => record.recordId), ['fresh']);
+    });
+
+    test('no-op adapter starts and stops without discovered nodes', () async {
+      final adapter = AiroNoOpLocalDiscoveryAdapter();
+
+      await adapter.start(AiroDiscoveryMode.browse);
+      final started = await adapter.currentSnapshot(now);
+      await adapter.stop();
+      final stopped = await adapter.currentSnapshot(now);
+
+      expect(started.records, isEmpty);
+      expect(
+        started.adapterState,
+        AiroDiscoveryAdapterState.permissionRequired,
+      );
+      expect(started.permissionState, AiroDiscoveryPermissionState.unavailable);
+      expect(stopped.adapterState, AiroDiscoveryAdapterState.stopped);
+    });
+
+    test('fake adapter emits discovered and lost snapshots', () async {
+      final adapter = AiroFakeLocalDiscoveryAdapter();
+      final events = <AiroDiscoverySnapshot>[];
+      final subscription = adapter.snapshots.listen(events.add);
+
+      await adapter.start(AiroDiscoveryMode.browse);
+      adapter.upsert(record(), now);
+      adapter.removeNode('node-tv-1', now.add(const Duration(seconds: 1)));
+
+      await Future<void>.delayed(Duration.zero);
+      await subscription.cancel();
+
+      expect(events.map((event) => event.records.length), [0, 1, 0]);
+      expect(events.first.adapterState, AiroDiscoveryAdapterState.browsing);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Adds the v2 local discovery abstraction for Airo TV connected-device discovery.

## Changes

- Adds `packages/platform_network_discovery` with privacy-safe `_airotv._tcp` service records.
- Reuses `core_protocol` node advertisements for node identity, lifecycle, trust, and capability metadata.
- Adds stale-record filtering, duplicate merge behavior, no-op adapter, and fake adapter for deterministic tests.
- Documents the platform discovery boundary in `docs/features/airo-tv/LOCAL_DISCOVERY_ABSTRACTION.md`.

## Testing

- `dart format --set-exit-if-changed packages/platform_network_discovery`
- `cd packages/platform_network_discovery && flutter test`
- `cd packages/platform_network_discovery && flutter analyze --fatal-infos`
- `git diff --check HEAD~1..HEAD`

Closes #602