### PR TITLE
feat(platform): add trusted device security policy

### DIFF
--- a/docs/features/airo-tv/TRUSTED_DEVICE_MODEL.md
+++ b/docs/features/airo-tv/TRUSTED_DEVICE_MODEL.md
@@ -1,0 +1,80 @@
+# Airo TV Trusted Device Model
+
+This contract defines the v2.0.0.1 platform boundary for trusted-device
+relationships used by Airo TV, companion controllers, command routing, playback
+tickets, and future device-picker flows.
+
+Implementation contract:
+
+- Package: `packages/core_pairing`
+- Schema: `kAiroPairingSchemaVersion`
+- Primary record: `AiroTrustedDeviceRecord`
+- Policy evaluator: `AiroTrustedDeviceSecurityPolicy`
+
+## Trust Record
+
+A trusted-device record identifies one controller-to-receiver relationship. The
+record carries:
+
+- relationship ID;
+- controller and receiver device IDs;
+- controller and receiver roles;
+- granted pairing scopes;
+- validity window;
+- revocation metadata;
+- trust level;
+- public key descriptor metadata.
+
+The record must not carry raw key material, provider credentials, playlist
+contents, media URLs, local file paths, local IP addresses, viewing history,
+analytics payloads, or diagnostic contents.
+
+## Trust Levels
+
+The platform model defines these trust levels:
+
+- `restricted`: playback-ticket and basic receiver flows only;
+- `paired`: scoped pairing authority for routine controls;
+- `trusted`: full trusted-device authority for delegated private operations;
+- `owner`: owner-managed authority reserved for future account/device
+  administration.
+
+Product code should ask a platform policy whether a relationship satisfies a
+required trust level. Airo TV screens should not hard-code role-specific trust
+shortcuts.
+
+## Key Descriptor
+
+`AiroTrustedDeviceKeyDescriptor` stores public key metadata only:
+
+- key ID;
+- algorithm;
+- public key fingerprint;
+- creation time;
+- validity window;
+- revocation time.
+
+The descriptor is enough for platform policy and storage layers to reason about
+key freshness and rotation without committing this issue to native keystore,
+secure storage, signing, or transport implementation.
+
+## Security Policy
+
+`AiroTrustedDeviceSecurityPolicy` evaluates:
+
+- required pairing scope;
+- minimum trust level;
+- allowed key algorithms;
+- key presence;
+- not-yet-valid, expired, revoked, and rotation-due key states;
+- relationship expiry and revocation through the existing access evaluator.
+
+Results are deterministic and machine-readable through
+`AiroTrustedDeviceSecurityCode`.
+
+## Consumer Rule
+
+Airo TV, command, playback, pairing UI, device picker, and cloud coordination
+must consume the platform policy result. Product code may decide copy,
+navigation, and user recovery flows, but the authority decision belongs to
+`core_pairing`.

--- a/packages/core_pairing/README.md
+++ b/packages/core_pairing/README.md
@@ -10,10 +10,12 @@ defining product-specific trust or playback authorization models.
 
 - Pairing challenge lifecycle with explicit expiry.
 - Trusted-device relationships with scoped permissions and revocation.
+- Trusted-device trust levels, public key descriptors, and rotation policy
+  evaluation.
 - Receiver-bound and session-bound playback tickets.
 - Redacted playback source handles that reject raw URLs, local paths, and
   credential-like values.
 - Deterministic validation results with machine-readable codes.
 
 This package does not render QR codes, open sockets, persist records, sign
-payloads, or start playback.
+payloads, generate keys, store raw key material, or start playback.

--- a/packages/core_pairing/lib/src/pairing_models.dart
+++ b/packages/core_pairing/lib/src/pairing_models.dart
@@ -51,6 +51,57 @@ enum AiroTrustedDeviceAccessCode {
   final String stableId;
 }
 
+enum AiroTrustedDeviceTrustLevel {
+  restricted('restricted', 0),
+  paired('paired', 1),
+  trusted('trusted', 2),
+  owner('owner', 3);
+
+  const AiroTrustedDeviceTrustLevel(this.stableId, this.rank);
+
+  final String stableId;
+  final int rank;
+
+  bool satisfies(AiroTrustedDeviceTrustLevel minimum) => rank >= minimum.rank;
+}
+
+enum AiroTrustedDeviceKeyAlgorithm {
+  ed25519('ed25519'),
+  p256('p256');
+
+  const AiroTrustedDeviceKeyAlgorithm(this.stableId);
+
+  final String stableId;
+}
+
+enum AiroTrustedDeviceKeyState {
+  active('active'),
+  rotationDue('rotation_due'),
+  notYetValid('not_yet_valid'),
+  expired('expired'),
+  revoked('revoked');
+
+  const AiroTrustedDeviceKeyState(this.stableId);
+
+  final String stableId;
+}
+
+enum AiroTrustedDeviceSecurityCode {
+  accepted('accepted'),
+  accessDenied('access_denied'),
+  trustLevelInsufficient('trust_level_insufficient'),
+  keyMissing('key_missing'),
+  keyUnsupported('key_unsupported'),
+  keyNotYetValid('key_not_yet_valid'),
+  keyExpired('key_expired'),
+  keyRevoked('key_revoked'),
+  keyRotationRequired('key_rotation_required');
+
+  const AiroTrustedDeviceSecurityCode(this.stableId);
+
+  final String stableId;
+}
+
 enum AiroPlaybackTicketValidationCode {
   accepted('accepted'),
   receiverMismatch('receiver_mismatch'),
@@ -137,6 +188,10 @@ class AiroTrustedDeviceRecord extends Equatable {
     this.expiresAt,
     this.revokedAt,
     this.pairingChallengeId,
+    this.trustLevel = AiroTrustedDeviceTrustLevel.paired,
+    this.keyDescriptor,
+    this.revokedByDeviceId,
+    this.revocationReason,
     this.schemaVersion = kAiroPairingSchemaVersion,
   }) : scopes = Set.unmodifiable(scopes);
 
@@ -152,6 +207,10 @@ class AiroTrustedDeviceRecord extends Equatable {
   final DateTime? expiresAt;
   final DateTime? revokedAt;
   final String? pairingChallengeId;
+  final AiroTrustedDeviceTrustLevel trustLevel;
+  final AiroTrustedDeviceKeyDescriptor? keyDescriptor;
+  final String? revokedByDeviceId;
+  final String? revocationReason;
 
   AiroTrustedDeviceAccessResult evaluateAccess({
     required AiroPairingScope requiredScope,
@@ -204,6 +263,10 @@ class AiroTrustedDeviceRecord extends Equatable {
     expiresAt,
     revokedAt,
     pairingChallengeId,
+    trustLevel,
+    keyDescriptor,
+    revokedByDeviceId,
+    revocationReason,
   ];
 }
 
@@ -216,6 +279,217 @@ class AiroTrustedDeviceAccessResult extends Equatable {
 
   @override
   List<Object?> get props => [code];
+}
+
+class AiroTrustedDeviceKeyDescriptor extends Equatable {
+  const AiroTrustedDeviceKeyDescriptor({
+    required this.keyId,
+    required this.algorithm,
+    required this.publicKeyFingerprint,
+    required this.createdAt,
+    required this.notBefore,
+    required this.expiresAt,
+    this.revokedAt,
+    this.schemaVersion = kAiroPairingSchemaVersion,
+  });
+
+  final String schemaVersion;
+  final String keyId;
+  final AiroTrustedDeviceKeyAlgorithm algorithm;
+  final String publicKeyFingerprint;
+  final DateTime createdAt;
+  final DateTime notBefore;
+  final DateTime expiresAt;
+  final DateTime? revokedAt;
+
+  AiroTrustedDeviceKeyState stateAt({
+    required DateTime now,
+    Duration? rotationInterval,
+  }) {
+    if (revokedAt != null && !now.isBefore(revokedAt!)) {
+      return AiroTrustedDeviceKeyState.revoked;
+    }
+    if (now.isBefore(notBefore)) {
+      return AiroTrustedDeviceKeyState.notYetValid;
+    }
+    if (!now.isBefore(expiresAt)) {
+      return AiroTrustedDeviceKeyState.expired;
+    }
+    if (rotationInterval != null &&
+        !now.isBefore(createdAt.add(rotationInterval))) {
+      return AiroTrustedDeviceKeyState.rotationDue;
+    }
+    return AiroTrustedDeviceKeyState.active;
+  }
+
+  @override
+  String toString() {
+    return 'AiroTrustedDeviceKeyDescriptor('
+        'keyId: $keyId, '
+        'algorithm: ${algorithm.stableId}, '
+        'createdAt: $createdAt, '
+        'notBefore: $notBefore, '
+        'expiresAt: $expiresAt, '
+        'revokedAt: $revokedAt'
+        ')';
+  }
+
+  @override
+  List<Object?> get props => [
+    schemaVersion,
+    keyId,
+    algorithm,
+    publicKeyFingerprint,
+    createdAt,
+    notBefore,
+    expiresAt,
+    revokedAt,
+  ];
+}
+
+class AiroTrustedDeviceSecurityPolicy extends Equatable {
+  AiroTrustedDeviceSecurityPolicy({
+    required this.requiredScope,
+    this.minimumTrustLevel = AiroTrustedDeviceTrustLevel.paired,
+    Set<AiroTrustedDeviceKeyAlgorithm> allowedKeyAlgorithms = const {
+      AiroTrustedDeviceKeyAlgorithm.ed25519,
+      AiroTrustedDeviceKeyAlgorithm.p256,
+    },
+    this.keyRotationInterval,
+    this.requiresKeyDescriptor = true,
+  }) : allowedKeyAlgorithms = Set.unmodifiable(allowedKeyAlgorithms);
+
+  final AiroPairingScope requiredScope;
+  final AiroTrustedDeviceTrustLevel minimumTrustLevel;
+  final Set<AiroTrustedDeviceKeyAlgorithm> allowedKeyAlgorithms;
+  final Duration? keyRotationInterval;
+  final bool requiresKeyDescriptor;
+
+  AiroTrustedDeviceSecurityResult evaluate({
+    required AiroTrustedDeviceRecord record,
+    required DateTime now,
+  }) {
+    final blockers = <AiroTrustedDeviceSecurityBlocker>[];
+    final access = record.evaluateAccess(
+      requiredScope: requiredScope,
+      now: now,
+    );
+    if (!access.accepted) {
+      blockers.add(
+        AiroTrustedDeviceSecurityBlocker(
+          code: AiroTrustedDeviceSecurityCode.accessDenied,
+          accessCode: access.code,
+        ),
+      );
+    }
+    if (!record.trustLevel.satisfies(minimumTrustLevel)) {
+      blockers.add(
+        AiroTrustedDeviceSecurityBlocker(
+          code: AiroTrustedDeviceSecurityCode.trustLevelInsufficient,
+          field: 'trustLevel',
+        ),
+      );
+    }
+
+    final keyDescriptor = record.keyDescriptor;
+    if (keyDescriptor == null) {
+      if (requiresKeyDescriptor) {
+        blockers.add(
+          const AiroTrustedDeviceSecurityBlocker(
+            code: AiroTrustedDeviceSecurityCode.keyMissing,
+            field: 'keyDescriptor',
+          ),
+        );
+      }
+    } else {
+      if (!allowedKeyAlgorithms.contains(keyDescriptor.algorithm)) {
+        blockers.add(
+          AiroTrustedDeviceSecurityBlocker(
+            code: AiroTrustedDeviceSecurityCode.keyUnsupported,
+            field: keyDescriptor.algorithm.stableId,
+          ),
+        );
+      }
+      switch (keyDescriptor.stateAt(
+        now: now,
+        rotationInterval: keyRotationInterval,
+      )) {
+        case AiroTrustedDeviceKeyState.active:
+          break;
+        case AiroTrustedDeviceKeyState.rotationDue:
+          blockers.add(
+            const AiroTrustedDeviceSecurityBlocker(
+              code: AiroTrustedDeviceSecurityCode.keyRotationRequired,
+              field: 'keyDescriptor',
+            ),
+          );
+        case AiroTrustedDeviceKeyState.notYetValid:
+          blockers.add(
+            const AiroTrustedDeviceSecurityBlocker(
+              code: AiroTrustedDeviceSecurityCode.keyNotYetValid,
+              field: 'keyDescriptor',
+            ),
+          );
+        case AiroTrustedDeviceKeyState.expired:
+          blockers.add(
+            const AiroTrustedDeviceSecurityBlocker(
+              code: AiroTrustedDeviceSecurityCode.keyExpired,
+              field: 'keyDescriptor',
+            ),
+          );
+        case AiroTrustedDeviceKeyState.revoked:
+          blockers.add(
+            const AiroTrustedDeviceSecurityBlocker(
+              code: AiroTrustedDeviceSecurityCode.keyRevoked,
+              field: 'keyDescriptor',
+            ),
+          );
+      }
+    }
+
+    return AiroTrustedDeviceSecurityResult(blockers: blockers);
+  }
+
+  @override
+  List<Object?> get props => [
+    requiredScope,
+    minimumTrustLevel,
+    allowedKeyAlgorithms,
+    keyRotationInterval,
+    requiresKeyDescriptor,
+  ];
+}
+
+class AiroTrustedDeviceSecurityBlocker extends Equatable {
+  const AiroTrustedDeviceSecurityBlocker({
+    required this.code,
+    this.accessCode,
+    this.field,
+  });
+
+  final AiroTrustedDeviceSecurityCode code;
+  final AiroTrustedDeviceAccessCode? accessCode;
+  final String? field;
+
+  @override
+  List<Object?> get props => [code, accessCode, field];
+}
+
+class AiroTrustedDeviceSecurityResult extends Equatable {
+  AiroTrustedDeviceSecurityResult({
+    required List<AiroTrustedDeviceSecurityBlocker> blockers,
+  }) : blockers = List.unmodifiable(blockers);
+
+  final List<AiroTrustedDeviceSecurityBlocker> blockers;
+
+  bool get accepted => blockers.isEmpty;
+
+  bool has(AiroTrustedDeviceSecurityCode code) {
+    return blockers.any((blocker) => blocker.code == code);
+  }
+
+  @override
+  List<Object?> get props => [blockers];
 }
 
 class AiroPlaybackSourceHandle extends Equatable {

--- a/packages/core_pairing/test/pairing_models_test.dart
+++ b/packages/core_pairing/test/pairing_models_test.dart
@@ -5,6 +5,7 @@ void main() {
   group('Airo pairing contracts', () {
     final issuedAt = DateTime.utc(2026, 7, 14, 10);
     final expiresAt = issuedAt.add(const Duration(minutes: 5));
+    final trustedUntil = issuedAt.add(const Duration(days: 90));
 
     test('pairing challenge exposes stable schema and expiry', () {
       final challenge = AiroPairingChallenge(
@@ -84,6 +85,165 @@ void main() {
             )
             .code,
         AiroTrustedDeviceAccessCode.revoked,
+      );
+    });
+
+    test('trusted device security policy accepts active trusted key', () {
+      final relationship = trustedDeviceRecord(
+        issuedAt: issuedAt,
+        expiresAt: trustedUntil,
+      );
+      final policy = AiroTrustedDeviceSecurityPolicy(
+        requiredScope: AiroPairingScope.playbackControl,
+        minimumTrustLevel: AiroTrustedDeviceTrustLevel.trusted,
+        keyRotationInterval: const Duration(days: 30),
+      );
+
+      final result = policy.evaluate(
+        record: relationship,
+        now: issuedAt.add(const Duration(days: 1)),
+      );
+
+      expect(result.accepted, isTrue);
+    });
+
+    test('trusted device security rejects insufficient trust level', () {
+      final relationship = trustedDeviceRecord(
+        issuedAt: issuedAt,
+        expiresAt: trustedUntil,
+        trustLevel: AiroTrustedDeviceTrustLevel.restricted,
+      );
+      final policy = AiroTrustedDeviceSecurityPolicy(
+        requiredScope: AiroPairingScope.playbackControl,
+        minimumTrustLevel: AiroTrustedDeviceTrustLevel.trusted,
+      );
+
+      final result = policy.evaluate(
+        record: relationship,
+        now: issuedAt.add(const Duration(days: 1)),
+      );
+
+      expect(
+        result.has(AiroTrustedDeviceSecurityCode.trustLevelInsufficient),
+        isTrue,
+      );
+    });
+
+    test('trusted device security rejects missing key descriptor', () {
+      final relationship = trustedDeviceRecord(
+        issuedAt: issuedAt,
+        expiresAt: trustedUntil,
+        includeKeyDescriptor: false,
+      );
+      final policy = AiroTrustedDeviceSecurityPolicy(
+        requiredScope: AiroPairingScope.playbackControl,
+      );
+
+      final result = policy.evaluate(
+        record: relationship,
+        now: issuedAt.add(const Duration(days: 1)),
+      );
+
+      expect(result.has(AiroTrustedDeviceSecurityCode.keyMissing), isTrue);
+    });
+
+    test('trusted device security rejects key lifecycle failures', () {
+      final policy = AiroTrustedDeviceSecurityPolicy(
+        requiredScope: AiroPairingScope.playbackControl,
+        keyRotationInterval: const Duration(days: 30),
+      );
+
+      AiroTrustedDeviceSecurityResult evaluate(
+        AiroTrustedDeviceKeyDescriptor keyDescriptor,
+      ) {
+        return policy.evaluate(
+          record: trustedDeviceRecord(
+            issuedAt: issuedAt,
+            expiresAt: trustedUntil,
+            keyDescriptor: keyDescriptor,
+          ),
+          now: issuedAt.add(const Duration(days: 31)),
+        );
+      }
+
+      expect(
+        evaluate(
+          trustedKeyDescriptor(
+            issuedAt: issuedAt.add(const Duration(days: 32)),
+            expiresAt: trustedUntil,
+          ),
+        ).has(AiroTrustedDeviceSecurityCode.keyNotYetValid),
+        isTrue,
+      );
+      expect(
+        evaluate(
+          trustedKeyDescriptor(
+            issuedAt: issuedAt,
+            expiresAt: issuedAt.add(const Duration(days: 20)),
+          ),
+        ).has(AiroTrustedDeviceSecurityCode.keyExpired),
+        isTrue,
+      );
+      expect(
+        evaluate(
+          trustedKeyDescriptor(
+            issuedAt: issuedAt,
+            expiresAt: trustedUntil,
+            revokedAt: issuedAt.add(const Duration(days: 10)),
+          ),
+        ).has(AiroTrustedDeviceSecurityCode.keyRevoked),
+        isTrue,
+      );
+      expect(
+        evaluate(
+          trustedKeyDescriptor(issuedAt: issuedAt, expiresAt: trustedUntil),
+        ).has(AiroTrustedDeviceSecurityCode.keyRotationRequired),
+        isTrue,
+      );
+    });
+
+    test('trusted device security rejects unsupported key algorithm', () {
+      final relationship = trustedDeviceRecord(
+        issuedAt: issuedAt,
+        expiresAt: trustedUntil,
+      );
+      final policy = AiroTrustedDeviceSecurityPolicy(
+        requiredScope: AiroPairingScope.playbackControl,
+        allowedKeyAlgorithms: const {AiroTrustedDeviceKeyAlgorithm.p256},
+      );
+
+      final result = policy.evaluate(
+        record: relationship,
+        now: issuedAt.add(const Duration(days: 1)),
+      );
+
+      expect(result.has(AiroTrustedDeviceSecurityCode.keyUnsupported), isTrue);
+    });
+
+    test('trusted device security preserves revocation as access denial', () {
+      final relationship = trustedDeviceRecord(
+        issuedAt: issuedAt,
+        expiresAt: trustedUntil,
+        revokedAt: issuedAt.add(const Duration(minutes: 1)),
+      );
+      final policy = AiroTrustedDeviceSecurityPolicy(
+        requiredScope: AiroPairingScope.playbackControl,
+      );
+
+      final result = policy.evaluate(
+        record: relationship,
+        now: issuedAt.add(const Duration(minutes: 1)),
+      );
+
+      expect(result.has(AiroTrustedDeviceSecurityCode.accessDenied), isTrue);
+      expect(
+        result.blockers
+            .where(
+              (blocker) =>
+                  blocker.accessCode == AiroTrustedDeviceAccessCode.revoked,
+            )
+            .length,
+        1,
       );
     });
   });
@@ -246,4 +406,51 @@ void main() {
       );
     });
   });
+}
+
+AiroTrustedDeviceKeyDescriptor trustedKeyDescriptor({
+  required DateTime issuedAt,
+  required DateTime expiresAt,
+  AiroTrustedDeviceKeyAlgorithm algorithm =
+      AiroTrustedDeviceKeyAlgorithm.ed25519,
+  DateTime? revokedAt,
+}) {
+  return AiroTrustedDeviceKeyDescriptor(
+    keyId: 'key-1',
+    algorithm: algorithm,
+    publicKeyFingerprint: 'pub-fingerprint-1',
+    createdAt: issuedAt,
+    notBefore: issuedAt,
+    expiresAt: expiresAt,
+    revokedAt: revokedAt,
+  );
+}
+
+AiroTrustedDeviceRecord trustedDeviceRecord({
+  required DateTime issuedAt,
+  required DateTime expiresAt,
+  AiroTrustedDeviceTrustLevel trustLevel = AiroTrustedDeviceTrustLevel.trusted,
+  AiroTrustedDeviceKeyDescriptor? keyDescriptor,
+  bool includeKeyDescriptor = true,
+  DateTime? revokedAt,
+}) {
+  return AiroTrustedDeviceRecord(
+    relationshipId: 'trusted-device-1',
+    controllerDeviceId: 'phone-1',
+    receiverDeviceId: 'receiver-tv-1',
+    controllerRole: AiroDeviceRole.mobileController,
+    receiverRole: AiroDeviceRole.tvReceiver,
+    scopes: const {
+      AiroPairingScope.playbackControl,
+      AiroPairingScope.companionSearch,
+    },
+    createdAt: issuedAt,
+    expiresAt: expiresAt,
+    revokedAt: revokedAt,
+    trustLevel: trustLevel,
+    keyDescriptor: includeKeyDescriptor
+        ? keyDescriptor ??
+              trustedKeyDescriptor(issuedAt: issuedAt, expiresAt: expiresAt)
+        : null,
+  );
 }


### PR DESCRIPTION
## Summary

Adds the v2 trusted-device security model for Airo TV pairing and delegation.

## Changes

- Extends `packages/core_pairing` with trusted-device trust levels, public key descriptors, and deterministic security policy evaluation.
- Adds checks for scope, revocation, key algorithm, key validity, lifecycle state, and rotation timing.
- Preserves authority decisions in the reusable platform contract while Airo TV app code can route user-facing UX.
- Documents the trusted-device boundary in `docs/features/airo-tv/TRUSTED_DEVICE_MODEL.md`.

## Testing

- `dart format --set-exit-if-changed packages/core_pairing`
- `cd packages/core_pairing && flutter test`
- `cd packages/core_pairing && flutter analyze --fatal-infos`
- `git diff --check HEAD~1..HEAD`

Closes #603