### PR TITLE
feat(platform): add command envelope contracts

### DIFF
--- a/docs/features/airo-tv/COMMAND_ENVELOPE.md
+++ b/docs/features/airo-tv/COMMAND_ENVELOPE.md
@@ -1,0 +1,73 @@
+# Airo TV Command Envelope
+
+This contract defines the v2.0.0.1 platform boundary for connected-device
+commands used by Airo TV, companion controllers, playback sessions, AI
+delegation, local transports, and future cloud coordination.
+
+Implementation contract:
+
+- Package: `packages/core_commands`
+- Schema: `kAiroCommandSchemaVersion`
+- Protocol version: `kAiroCommandProtocolVersion`
+- Primary envelope: `AiroCommandEnvelope`
+- Validator: `AiroCommandValidationPolicy`
+
+## Envelope Fields
+
+A command envelope carries:
+
+- command ID;
+- session ID;
+- sender node ID;
+- target node ID;
+- command kind;
+- command action;
+- required pairing scope;
+- issue and expiry timestamps;
+- idempotency key;
+- privacy-checked payload keys.
+
+The envelope is transport-neutral. LAN, cloud, WebSocket, fake, and future
+generated-protocol transports must carry the same authority and expiry fields.
+
+## Command Kinds
+
+The platform model includes command kinds for:
+
+- playback;
+- navigation;
+- text input handles;
+- AI delegation handles;
+- device operations.
+
+Text and AI commands should carry handles or references approved by the
+platform contract, not raw user-entered text or voice transcripts.
+
+## Validation
+
+`AiroCommandValidationPolicy` rejects:
+
+- schema mismatch;
+- protocol too old or too new;
+- expired envelopes;
+- target mismatch;
+- missing authority scope;
+- duplicate idempotency key;
+- unsafe payload fields or values.
+
+Validation results are deterministic and machine-readable through
+`AiroCommandValidationCode`.
+
+## Result Contract
+
+`AiroCommandResult` reports accepted, rejected, unsupported, completed, or
+failed status. String output redacts payload values so logs and diagnostics can
+identify command shape without exposing media references, provider credentials,
+local paths, local IP addresses, user text, analytics payloads, or diagnostics.
+
+## Consumer Rule
+
+Airo TV, companion remote controls, playback sessions, AI delegation, and cloud
+coordination should consume `core_commands`. Product code may render progress,
+copy, and recovery flows, but command authority, expiry, idempotency, and
+payload privacy belong to the platform contract.

--- a/packages/core_commands/CHANGELOG.md
+++ b/packages/core_commands/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.0.1
+
+- Add initial versioned command envelope and dispatcher contracts.

--- a/packages/core_commands/README.md
+++ b/packages/core_commands/README.md
@@ -1,0 +1,20 @@
+# Core Commands
+
+Versioned command envelope contracts for Airo connected devices.
+
+This package is platform/framework code. Airo TV, companion apps, local
+transports, cloud coordination, playback sessions, and QA automation consume
+this contract instead of defining feature-specific remote-control payloads.
+
+## Scope
+
+- Versioned command envelopes for playback, navigation, text input,
+  AI delegation, and device commands.
+- Deterministic validation for schema, protocol, expiry, receiver, authority,
+  duplicate idempotency, and payload privacy.
+- Typed command results with redacted payload output.
+- No-op and fake dispatchers for host-only tests.
+
+This package does not open sockets, persist sessions, execute playback,
+render remote-control UI, generate Protobuf schemas, or coordinate cloud
+delivery.

--- a/packages/core_commands/analysis_options.yaml
+++ b/packages/core_commands/analysis_options.yaml
@@ -1,0 +1,5 @@
+include: package:flutter_lints/flutter.yaml
+
+linter:
+  rules:
+    prefer_const_constructors: true

--- a/packages/core_commands/lib/core_commands.dart
+++ b/packages/core_commands/lib/core_commands.dart
@@ -1,0 +1,3 @@
+library;
+
+export 'src/command_models.dart';

--- a/packages/core_commands/lib/src/command_models.dart
+++ b/packages/core_commands/lib/src/command_models.dart
@@ -1,0 +1,507 @@
+import 'package:core_pairing/core_pairing.dart';
+import 'package:equatable/equatable.dart';
+
+const String kAiroCommandSchemaVersion = '1.0.0';
+const int kAiroCommandProtocolVersion = 1;
+
+enum AiroCommandKind {
+  playback('playback'),
+  navigation('navigation'),
+  textInput('text_input'),
+  aiDelegation('ai_delegation'),
+  device('device');
+
+  const AiroCommandKind(this.stableId);
+
+  final String stableId;
+}
+
+enum AiroCommandAction {
+  play('play'),
+  pause('pause'),
+  stop('stop'),
+  seek('seek'),
+  select('select'),
+  back('back'),
+  home('home'),
+  focus('focus'),
+  submitTextHandle('submit_text_handle'),
+  searchHandle('search_handle'),
+  askAssistantHandle('ask_assistant_handle'),
+  refreshCapabilities('refresh_capabilities'),
+  diagnosticsPing('diagnostics_ping');
+
+  const AiroCommandAction(this.stableId);
+
+  final String stableId;
+}
+
+enum AiroCommandPrivacyCode {
+  prohibitedFieldName('prohibited_field_name'),
+  urlValue('url_value'),
+  localPathValue('local_path_value'),
+  localIpValue('local_ip_value'),
+  credentialLikeValue('credential_like_value');
+
+  const AiroCommandPrivacyCode(this.stableId);
+
+  final String stableId;
+}
+
+enum AiroCommandValidationCode {
+  accepted('accepted'),
+  schemaMismatch('schema_mismatch'),
+  protocolTooOld('protocol_too_old'),
+  protocolTooNew('protocol_too_new'),
+  expired('expired'),
+  targetMismatch('target_mismatch'),
+  scopeMissing('scope_missing'),
+  duplicateIdempotencyKey('duplicate_idempotency_key'),
+  unsafePayload('unsafe_payload');
+
+  const AiroCommandValidationCode(this.stableId);
+
+  final String stableId;
+}
+
+enum AiroCommandResultStatus {
+  accepted('accepted'),
+  rejected('rejected'),
+  unsupported('unsupported'),
+  completed('completed'),
+  failed('failed');
+
+  const AiroCommandResultStatus(this.stableId);
+
+  final String stableId;
+}
+
+class AiroCommandPrivacyViolation extends Equatable {
+  const AiroCommandPrivacyViolation({required this.code, required this.field});
+
+  final AiroCommandPrivacyCode code;
+  final String field;
+
+  @override
+  List<Object?> get props => [code, field];
+}
+
+class AiroCommandPrivacyResult extends Equatable {
+  AiroCommandPrivacyResult({
+    required List<AiroCommandPrivacyViolation> violations,
+  }) : violations = List.unmodifiable(violations);
+
+  final List<AiroCommandPrivacyViolation> violations;
+
+  bool get accepted => violations.isEmpty;
+
+  @override
+  List<Object?> get props => [violations];
+}
+
+class AiroCommandPrivacyFilter {
+  AiroCommandPrivacyFilter({
+    Set<String> prohibitedFields = _defaultProhibitedFields,
+  }) : prohibitedFields = Set.unmodifiable(
+         prohibitedFields.map(_normalizeFieldName),
+       );
+
+  static final AiroCommandPrivacyFilter standard = AiroCommandPrivacyFilter();
+
+  static const Set<String> _defaultProhibitedFields = {
+    'playlist',
+    'playlistName',
+    'playlistUrl',
+    'mediaUrl',
+    'sourceUrl',
+    'streamUrl',
+    'signedUrl',
+    'url',
+    'credential',
+    'authorization',
+    'authHeader',
+    'cookie',
+    'history',
+    'viewingHistory',
+    'localIp',
+    'ipAddress',
+    'localPath',
+    'path',
+    'query',
+    'searchText',
+    'voiceTranscript',
+    'diagnostics',
+    'analytics',
+    'rawText',
+  };
+
+  final Set<String> prohibitedFields;
+
+  AiroCommandPrivacyResult validate(Map<String, String> values) {
+    final violations = <AiroCommandPrivacyViolation>[];
+
+    for (final entry in values.entries) {
+      final field = entry.key;
+      if (prohibitedFields.contains(_normalizeFieldName(field))) {
+        violations.add(
+          AiroCommandPrivacyViolation(
+            code: AiroCommandPrivacyCode.prohibitedFieldName,
+            field: field,
+          ),
+        );
+      }
+
+      final code = _classifyStringValue(entry.value);
+      if (code != null) {
+        violations.add(AiroCommandPrivacyViolation(code: code, field: field));
+      }
+    }
+
+    return AiroCommandPrivacyResult(violations: violations);
+  }
+
+  static String _normalizeFieldName(String field) {
+    return field.replaceAll(RegExp('[^A-Za-z0-9]'), '').toLowerCase();
+  }
+
+  static AiroCommandPrivacyCode? _classifyStringValue(String value) {
+    final trimmed = value.trim();
+    if (trimmed.isEmpty) return null;
+
+    final uri = Uri.tryParse(trimmed);
+    if (uri != null && (uri.scheme == 'http' || uri.scheme == 'https')) {
+      return AiroCommandPrivacyCode.urlValue;
+    }
+    if (trimmed.startsWith('file://') ||
+        trimmed.startsWith('/') ||
+        RegExp(r'^[A-Za-z]:\\').hasMatch(trimmed)) {
+      return AiroCommandPrivacyCode.localPathValue;
+    }
+    if (RegExp(
+      r'\b(?:10|127|172\.(?:1[6-9]|2\d|3[0-1])|192\.168)\.',
+    ).hasMatch(trimmed)) {
+      return AiroCommandPrivacyCode.localIpValue;
+    }
+    if (RegExp(
+      r'\b(?:bearer|basic)\s+[A-Za-z0-9._~+/=-]+',
+      caseSensitive: false,
+    ).hasMatch(trimmed)) {
+      return AiroCommandPrivacyCode.credentialLikeValue;
+    }
+
+    return null;
+  }
+}
+
+class AiroCommandPayload extends Equatable {
+  AiroCommandPayload.safe(Map<String, String> values)
+    : values = Map.unmodifiable(values) {
+    final result = AiroCommandPrivacyFilter.standard.validate(values);
+    if (!result.accepted) {
+      throw ArgumentError.value(
+        values.keys.toList(growable: false),
+        'values',
+        result.violations.map((violation) => violation.code.stableId).join(','),
+      );
+    }
+  }
+
+  const AiroCommandPayload.empty() : values = const {};
+
+  final Map<String, String> values;
+
+  bool get isEmpty => values.isEmpty;
+
+  @override
+  String toString() => 'AiroCommandPayload(redactedKeys: ${values.keys})';
+
+  @override
+  List<Object?> get props => [values];
+}
+
+class AiroCommandEnvelope extends Equatable {
+  const AiroCommandEnvelope({
+    required this.commandId,
+    required this.sessionId,
+    required this.senderNodeId,
+    required this.targetNodeId,
+    required this.kind,
+    required this.action,
+    required this.requiredScope,
+    required this.issuedAt,
+    required this.expiresAt,
+    required this.idempotencyKey,
+    AiroCommandPayload? payload,
+    this.schemaVersion = kAiroCommandSchemaVersion,
+    this.protocolVersion = kAiroCommandProtocolVersion,
+  }) : payload = payload ?? const AiroCommandPayload.empty();
+
+  final String schemaVersion;
+  final int protocolVersion;
+  final String commandId;
+  final String sessionId;
+  final String senderNodeId;
+  final String targetNodeId;
+  final AiroCommandKind kind;
+  final AiroCommandAction action;
+  final AiroPairingScope requiredScope;
+  final DateTime issuedAt;
+  final DateTime expiresAt;
+  final String idempotencyKey;
+  final AiroCommandPayload payload;
+
+  bool isExpired(DateTime now) => !now.isBefore(expiresAt);
+
+  Map<String, Object?> toPublicMap() {
+    return {
+      'schemaVersion': schemaVersion,
+      'protocolVersion': protocolVersion,
+      'commandId': commandId,
+      'sessionId': sessionId,
+      'senderNodeId': senderNodeId,
+      'targetNodeId': targetNodeId,
+      'kind': kind.stableId,
+      'action': action.stableId,
+      'requiredScope': requiredScope.stableId,
+      'issuedAt': issuedAt.toIso8601String(),
+      'expiresAt': expiresAt.toIso8601String(),
+      'idempotencyKey': idempotencyKey,
+      'payloadKeys': payload.values.keys.toList(growable: false),
+    };
+  }
+
+  @override
+  String toString() {
+    return 'AiroCommandEnvelope('
+        'commandId: $commandId, '
+        'sessionId: $sessionId, '
+        'senderNodeId: $senderNodeId, '
+        'targetNodeId: $targetNodeId, '
+        'kind: ${kind.stableId}, '
+        'action: ${action.stableId}, '
+        'requiredScope: ${requiredScope.stableId}, '
+        'expiresAt: $expiresAt, '
+        'payload: $payload'
+        ')';
+  }
+
+  @override
+  List<Object?> get props => [
+    schemaVersion,
+    protocolVersion,
+    commandId,
+    sessionId,
+    senderNodeId,
+    targetNodeId,
+    kind,
+    action,
+    requiredScope,
+    issuedAt,
+    expiresAt,
+    idempotencyKey,
+    payload,
+  ];
+}
+
+class AiroCommandValidationPolicy extends Equatable {
+  AiroCommandValidationPolicy({
+    required Set<AiroPairingScope> grantedScopes,
+    this.targetNodeId,
+    Set<String> seenIdempotencyKeys = const {},
+    this.acceptedSchemaVersion = kAiroCommandSchemaVersion,
+    this.minProtocolVersion = kAiroCommandProtocolVersion,
+    this.maxProtocolVersion = kAiroCommandProtocolVersion,
+  }) : grantedScopes = Set.unmodifiable(grantedScopes),
+       seenIdempotencyKeys = Set.unmodifiable(seenIdempotencyKeys);
+
+  final String acceptedSchemaVersion;
+  final int minProtocolVersion;
+  final int maxProtocolVersion;
+  final String? targetNodeId;
+  final Set<AiroPairingScope> grantedScopes;
+  final Set<String> seenIdempotencyKeys;
+
+  AiroCommandValidationResult evaluate({
+    required AiroCommandEnvelope envelope,
+    required DateTime now,
+  }) {
+    final blockers = <AiroCommandValidationBlocker>[];
+
+    if (envelope.schemaVersion != acceptedSchemaVersion) {
+      blockers.add(
+        const AiroCommandValidationBlocker(
+          code: AiroCommandValidationCode.schemaMismatch,
+        ),
+      );
+    }
+    if (envelope.protocolVersion < minProtocolVersion) {
+      blockers.add(
+        const AiroCommandValidationBlocker(
+          code: AiroCommandValidationCode.protocolTooOld,
+        ),
+      );
+    }
+    if (envelope.protocolVersion > maxProtocolVersion) {
+      blockers.add(
+        const AiroCommandValidationBlocker(
+          code: AiroCommandValidationCode.protocolTooNew,
+        ),
+      );
+    }
+    if (envelope.isExpired(now)) {
+      blockers.add(
+        const AiroCommandValidationBlocker(
+          code: AiroCommandValidationCode.expired,
+        ),
+      );
+    }
+    if (targetNodeId != null && envelope.targetNodeId != targetNodeId) {
+      blockers.add(
+        const AiroCommandValidationBlocker(
+          code: AiroCommandValidationCode.targetMismatch,
+        ),
+      );
+    }
+    if (!grantedScopes.contains(envelope.requiredScope)) {
+      blockers.add(
+        const AiroCommandValidationBlocker(
+          code: AiroCommandValidationCode.scopeMissing,
+        ),
+      );
+    }
+    if (seenIdempotencyKeys.contains(envelope.idempotencyKey)) {
+      blockers.add(
+        const AiroCommandValidationBlocker(
+          code: AiroCommandValidationCode.duplicateIdempotencyKey,
+        ),
+      );
+    }
+    final privacy = AiroCommandPrivacyFilter.standard.validate(
+      envelope.payload.values,
+    );
+    if (!privacy.accepted) {
+      blockers.add(
+        const AiroCommandValidationBlocker(
+          code: AiroCommandValidationCode.unsafePayload,
+        ),
+      );
+    }
+
+    return AiroCommandValidationResult(blockers: blockers);
+  }
+
+  @override
+  List<Object?> get props => [
+    acceptedSchemaVersion,
+    minProtocolVersion,
+    maxProtocolVersion,
+    targetNodeId,
+    grantedScopes,
+    seenIdempotencyKeys,
+  ];
+}
+
+class AiroCommandValidationBlocker extends Equatable {
+  const AiroCommandValidationBlocker({required this.code});
+
+  final AiroCommandValidationCode code;
+
+  @override
+  List<Object?> get props => [code];
+}
+
+class AiroCommandValidationResult extends Equatable {
+  AiroCommandValidationResult({
+    required List<AiroCommandValidationBlocker> blockers,
+  }) : blockers = List.unmodifiable(blockers);
+
+  final List<AiroCommandValidationBlocker> blockers;
+
+  bool get accepted => blockers.isEmpty;
+
+  bool has(AiroCommandValidationCode code) {
+    return blockers.any((blocker) => blocker.code == code);
+  }
+
+  @override
+  List<Object?> get props => [blockers];
+}
+
+class AiroCommandResult extends Equatable {
+  const AiroCommandResult({
+    required this.commandId,
+    required this.status,
+    required this.completedAt,
+    AiroCommandPayload? payload,
+    this.code,
+    this.schemaVersion = kAiroCommandSchemaVersion,
+  }) : payload = payload ?? const AiroCommandPayload.empty();
+
+  final String schemaVersion;
+  final String commandId;
+  final AiroCommandResultStatus status;
+  final String? code;
+  final DateTime completedAt;
+  final AiroCommandPayload payload;
+
+  @override
+  String toString() {
+    return 'AiroCommandResult('
+        'commandId: $commandId, '
+        'status: ${status.stableId}, '
+        'code: $code, '
+        'completedAt: $completedAt, '
+        'payload: $payload'
+        ')';
+  }
+
+  @override
+  List<Object?> get props => [
+    schemaVersion,
+    commandId,
+    status,
+    code,
+    completedAt,
+    payload,
+  ];
+}
+
+abstract class AiroCommandDispatcher {
+  Future<AiroCommandResult> dispatch(AiroCommandEnvelope envelope);
+}
+
+class AiroNoOpCommandDispatcher implements AiroCommandDispatcher {
+  const AiroNoOpCommandDispatcher();
+
+  @override
+  Future<AiroCommandResult> dispatch(AiroCommandEnvelope envelope) async {
+    return AiroCommandResult(
+      commandId: envelope.commandId,
+      status: AiroCommandResultStatus.unsupported,
+      code: 'dispatcher_unavailable',
+      completedAt: DateTime.now().toUtc(),
+    );
+  }
+}
+
+class AiroFakeCommandDispatcher implements AiroCommandDispatcher {
+  AiroFakeCommandDispatcher({
+    Map<String, AiroCommandResult> cannedResults = const {},
+  }) : cannedResults = Map.unmodifiable(cannedResults);
+
+  final Map<String, AiroCommandResult> cannedResults;
+  final List<AiroCommandEnvelope> _dispatched = [];
+
+  List<AiroCommandEnvelope> get dispatched => List.unmodifiable(_dispatched);
+
+  @override
+  Future<AiroCommandResult> dispatch(AiroCommandEnvelope envelope) async {
+    _dispatched.add(envelope);
+    return cannedResults[envelope.commandId] ??
+        AiroCommandResult(
+          commandId: envelope.commandId,
+          status: AiroCommandResultStatus.accepted,
+          completedAt: DateTime.now().toUtc(),
+        );
+  }
+}

--- a/packages/core_commands/pubspec.yaml
+++ b/packages/core_commands/pubspec.yaml
@@ -1,0 +1,25 @@
+name: core_commands
+description: Versioned command envelope contracts for Airo connected devices.
+version: 0.0.1
+homepage:
+publish_to: none
+
+environment:
+  sdk: ^3.12.2
+  flutter: ">=1.17.0"
+
+dependencies:
+  core_pairing:
+    path: ../core_pairing
+  core_protocol:
+    path: ../core_protocol
+  equatable: ^2.0.8
+  flutter:
+    sdk: flutter
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+  flutter_lints: ^6.0.0
+
+flutter:

--- a/packages/core_commands/test/command_models_test.dart
+++ b/packages/core_commands/test/command_models_test.dart
@@ -1,0 +1,177 @@
+import 'package:core_commands/core_commands.dart';
+import 'package:core_pairing/core_pairing.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('Airo command envelope', () {
+    final issuedAt = DateTime.utc(2026, 7, 14, 12);
+    final expiresAt = issuedAt.add(const Duration(seconds: 30));
+
+    AiroCommandEnvelope envelope({
+      String commandId = 'command-1',
+      String targetNodeId = 'receiver-tv-1',
+      AiroPairingScope requiredScope = AiroPairingScope.playbackControl,
+      DateTime? expiresAtOverride,
+      int protocolVersion = kAiroCommandProtocolVersion,
+      String schemaVersion = kAiroCommandSchemaVersion,
+      String idempotencyKey = 'idempotency-1',
+      AiroCommandPayload? payload,
+    }) {
+      return AiroCommandEnvelope(
+        commandId: commandId,
+        sessionId: 'session-1',
+        senderNodeId: 'phone-1',
+        targetNodeId: targetNodeId,
+        kind: AiroCommandKind.playback,
+        action: AiroCommandAction.play,
+        requiredScope: requiredScope,
+        issuedAt: issuedAt,
+        expiresAt: expiresAtOverride ?? expiresAt,
+        idempotencyKey: idempotencyKey,
+        protocolVersion: protocolVersion,
+        schemaVersion: schemaVersion,
+        payload: payload,
+      );
+    }
+
+    AiroCommandValidationPolicy policy({
+      Set<AiroPairingScope> grantedScopes = const {
+        AiroPairingScope.playbackControl,
+        AiroPairingScope.textInput,
+      },
+      Set<String> seenIdempotencyKeys = const {},
+    }) {
+      return AiroCommandValidationPolicy(
+        targetNodeId: 'receiver-tv-1',
+        grantedScopes: grantedScopes,
+        seenIdempotencyKeys: seenIdempotencyKeys,
+      );
+    }
+
+    test('validates a scoped unexpired envelope', () {
+      final result = policy().evaluate(
+        envelope: envelope(),
+        now: issuedAt.add(const Duration(seconds: 1)),
+      );
+      final publicMap = envelope().toPublicMap();
+
+      expect(result.accepted, isTrue);
+      expect(publicMap['schemaVersion'], kAiroCommandSchemaVersion);
+      expect(publicMap['protocolVersion'], kAiroCommandProtocolVersion);
+      expect(publicMap['kind'], 'playback');
+      expect(publicMap['requiredScope'], 'playback_control');
+    });
+
+    test(
+      'rejects expired, unsupported version, target, scope, and duplicate',
+      () {
+        final result =
+            policy(
+              grantedScopes: const {AiroPairingScope.textInput},
+              seenIdempotencyKeys: const {'idempotency-1'},
+            ).evaluate(
+              envelope: envelope(
+                targetNodeId: 'other-tv',
+                requiredScope: AiroPairingScope.playbackControl,
+                expiresAtOverride: issuedAt,
+                protocolVersion: kAiroCommandProtocolVersion + 1,
+              ),
+              now: issuedAt.add(const Duration(seconds: 1)),
+            );
+
+        expect(result.has(AiroCommandValidationCode.expired), isTrue);
+        expect(result.has(AiroCommandValidationCode.protocolTooNew), isTrue);
+        expect(result.has(AiroCommandValidationCode.targetMismatch), isTrue);
+        expect(result.has(AiroCommandValidationCode.scopeMissing), isTrue);
+        expect(
+          result.has(AiroCommandValidationCode.duplicateIdempotencyKey),
+          isTrue,
+        );
+      },
+    );
+
+    test('rejects schema and old protocol mismatches', () {
+      final result = policy().evaluate(
+        envelope: envelope(
+          schemaVersion: '0.9.0',
+          protocolVersion: kAiroCommandProtocolVersion - 1,
+        ),
+        now: issuedAt.add(const Duration(seconds: 1)),
+      );
+
+      expect(result.has(AiroCommandValidationCode.schemaMismatch), isTrue);
+      expect(result.has(AiroCommandValidationCode.protocolTooOld), isTrue);
+    });
+
+    test('payload rejects unsafe fields and values deterministically', () {
+      expect(
+        () => AiroCommandPayload.safe(const {'playlistUrl': 'hidden'}),
+        throwsArgumentError,
+      );
+      expect(
+        () => AiroCommandPayload.safe(const {'note': 'https://example.com'}),
+        throwsArgumentError,
+      );
+      expect(
+        () => AiroCommandPayload.safe(const {'note': '/Users/example/list'}),
+        throwsArgumentError,
+      );
+      expect(
+        () => AiroCommandPayload.safe(const {'note': 'seen 192.168.1.10'}),
+        throwsArgumentError,
+      );
+      expect(
+        () => AiroCommandPayload.safe(const {'note': 'Bearer abc.def'}),
+        throwsArgumentError,
+      );
+    });
+
+    test('string output redacts command payload values', () {
+      final command = envelope(
+        payload: AiroCommandPayload.safe(const {'positionMs': '12000'}),
+      );
+      final result = AiroCommandResult(
+        commandId: command.commandId,
+        status: AiroCommandResultStatus.completed,
+        completedAt: issuedAt,
+        payload: AiroCommandPayload.safe(const {'positionMs': '12000'}),
+      );
+
+      expect(command.toString(), isNot(contains('12000')));
+      expect(result.toString(), isNot(contains('12000')));
+      expect(command.toString(), contains('redactedKeys'));
+      expect(result.toString(), contains('redactedKeys'));
+    });
+
+    test('no-op dispatcher returns deterministic unsupported result', () async {
+      const dispatcher = AiroNoOpCommandDispatcher();
+
+      final result = await dispatcher.dispatch(envelope());
+
+      expect(result.commandId, 'command-1');
+      expect(result.status, AiroCommandResultStatus.unsupported);
+      expect(result.code, 'dispatcher_unavailable');
+    });
+
+    test(
+      'fake dispatcher records envelopes and returns canned results',
+      () async {
+        final command = envelope(commandId: 'command-canned');
+        final dispatcher = AiroFakeCommandDispatcher(
+          cannedResults: {
+            'command-canned': AiroCommandResult(
+              commandId: 'command-canned',
+              status: AiroCommandResultStatus.completed,
+              completedAt: issuedAt,
+            ),
+          },
+        );
+
+        final result = await dispatcher.dispatch(command);
+
+        expect(dispatcher.dispatched, [command]);
+        expect(result.status, AiroCommandResultStatus.completed);
+      },
+    );
+  });
+}


### PR DESCRIPTION
## Summary

Adds the v2 versioned command envelope platform contract for Airo TV delegation.

## Changes

- Adds `packages/core_commands` with versioned transport-neutral command envelopes.
- Adds validation policies for version, schema, target node, trusted-device scope, expiry, replay, protocol compatibility, and payload privacy.
- Adds typed command results plus no-op and fake dispatchers for deterministic tests.
- Documents the command consumer boundary in `docs/features/airo-tv/COMMAND_ENVELOPE.md` so playback, navigation, text, AI, and device commands share platform authority rules.

## Testing

- `dart format --set-exit-if-changed packages/core_commands`
- `cd packages/core_commands && flutter test`
- `cd packages/core_commands && flutter analyze --fatal-infos`
- `git diff --check HEAD~1..HEAD`

Closes #604