### PR TITLE
feat(platform): add playback engine abstraction

### DIFF
--- a/docs/features/airo-tv/PLAYBACK_ENGINE_ABSTRACTION.md
+++ b/docs/features/airo-tv/PLAYBACK_ENGINE_ABSTRACTION.md
@@ -1,0 +1,77 @@
+# Airo TV Playback Engine Abstraction
+
+This contract defines the v2.0.0.1 platform boundary for backend-agnostic
+playback used by Airo TV, IPTV, Cast, future native media engines, command
+routing, diagnostics, and certification.
+
+Implementation contract:
+
+- Package: `packages/platform_player`
+- Schema: `kAiroPlaybackEngineSchemaVersion`
+- Primary interface: `AiroPlaybackEngine`
+- State model: `AiroPlaybackState`
+- Request model: `AiroMediaOpenRequest`
+
+## Engine Boundary
+
+`AiroPlaybackEngine` defines:
+
+- open;
+- play;
+- pause;
+- stop;
+- seek;
+- volume;
+- playback speed;
+- quality selection;
+- track selection;
+- diagnostics;
+- state stream;
+- dispose.
+
+The interface is backend-neutral. Existing IPTV/video_player and Cast code are
+adapter candidates. Native Media3, LibVLC, MPV, FFmpeg-assisted, AVFoundation,
+or other engines should implement the same contract later.
+
+## Media Requests
+
+`AiroMediaOpenRequest` carries an opaque `AiroPlaybackSourceHandle` instead of a
+raw URL, file path, local network address, provider credential, playlist entry,
+or viewing-history value.
+
+Adapters may resolve the handle internally after platform authorization and
+route selection. Product UI should never log or render the raw media source from
+this boundary.
+
+## State And Diagnostics
+
+`AiroPlaybackState` reports:
+
+- backend kind;
+- phase;
+- request ID;
+- position and duration;
+- volume;
+- playback speed;
+- quality options and selection;
+- track options and selection;
+- typed diagnostics;
+- typed errors.
+
+Diagnostics must use stable codes and backend identifiers. They must not expose
+media source URLs, local paths, local IP addresses, provider credentials,
+analytics payloads, raw crash details, or viewing history.
+
+## Adapter Rule
+
+Airo TV, IPTV features, command routing, route selection, and future
+certification checks should consume `platform_player` playback engine contracts.
+Product code may render controls, copy, and recovery flows, but backend
+selection, state semantics, typed errors, and diagnostics belong to the platform
+contract.
+
+## Out Of Scope
+
+This issue does not choose or implement a native backend, decoder probing,
+fallback policy, playback widgets, Protobuf schemas, command transport, or
+session persistence.

--- a/packages/platform_player/README.md
+++ b/packages/platform_player/README.md
@@ -1,39 +1,20 @@
-<!--
-This README describes the package. If you publish this package to pub.dev,
-this README's contents appear on the landing page for your package.
+# Platform Player
 
-For information about how to write a good package README, see the guide for
-[writing package pages](https://dart.dev/tools/pub/writing-package-pages).
+Reusable playback and receiver-control contracts for Airo.
 
-For general information about developing packages, see the Dart guide for
-[creating packages](https://dart.dev/guides/libraries/create-packages)
-and the Flutter guide for
-[developing packages and plugins](https://flutter.dev/to/develop-packages).
--->
+This package is platform/framework code. Airo TV, IPTV features, Cast adapters,
+future native media engines, command routing, diagnostics, and certification
+flows consume these contracts instead of defining app-specific playback models.
 
-TODO: Put a short description of the package here that helps potential users
-know whether this package might be useful for them.
+## Scope
 
-## Features
+- Backend-agnostic `AiroPlaybackEngine` contract.
+- Redacted media open requests with opaque source handles.
+- Typed playback states, quality options, tracks, diagnostics, and errors.
+- No-op/unavailable and fake playback engines for deterministic tests.
+- Cast discovery/session abstractions used by existing IPTV flows.
 
-TODO: List what your package can do. Maybe include images, gifs, or videos.
-
-## Getting started
-
-TODO: List prerequisites and provide or point to information on how to
-start using the package.
-
-## Usage
-
-TODO: Include short and useful examples for package users. Add longer examples
-to `/example` folder.
-
-```dart
-const like = 'sample';
-```
-
-## Additional information
-
-TODO: Tell users more about the package: where to find more information, how to
-contribute to the package, how to file issues, what response they can expect
-from the package authors, and more.
+This package does not choose a native media backend, probe decoders, persist
+sessions, render playback widgets, route commands, or expose raw media source
+URLs, local paths, local IP addresses, provider credentials, viewing history,
+analytics payloads, or diagnostic dumps.

--- a/packages/platform_player/lib/platform_player.dart
+++ b/packages/platform_player/lib/platform_player.dart
@@ -1,10 +1,14 @@
 library;
 
 export "src/models/cast_models.dart";
+export "src/models/playback_engine_models.dart";
 export "src/models/streaming_state.dart";
 export "src/services/airo_cast_controller.dart";
+export "src/services/airo_playback_engine.dart";
 export "src/services/fake_airo_cast_controller.dart";
+export "src/services/fake_playback_engine.dart";
 export "src/services/flutter_chrome_cast_controller.dart";
 export "src/services/iptv_streaming_service.dart";
 export "src/services/iptv_cast_media_adapter.dart";
+export "src/services/unavailable_playback_engine.dart";
 export "src/services/unavailable_cast_controller.dart";

--- a/packages/platform_player/lib/src/models/playback_engine_models.dart
+++ b/packages/platform_player/lib/src/models/playback_engine_models.dart
@@ -1,0 +1,379 @@
+import 'package:equatable/equatable.dart';
+
+const String kAiroPlaybackEngineSchemaVersion = '1.0.0';
+
+enum AiroPlaybackBackendKind {
+  videoPlayer('video_player'),
+  cast('cast'),
+  media3('media3'),
+  libVlc('lib_vlc'),
+  mpv('mpv'),
+  fake('fake'),
+  unavailable('unavailable');
+
+  const AiroPlaybackBackendKind(this.stableId);
+
+  final String stableId;
+}
+
+enum AiroPlaybackMediaKind {
+  hls('hls'),
+  dash('dash'),
+  progressive('progressive'),
+  rtsp('rtsp'),
+  file('file'),
+  live('live'),
+  protectedPlayback('protected_playback'),
+  localPreview('local_preview');
+
+  const AiroPlaybackMediaKind(this.stableId);
+
+  final String stableId;
+}
+
+enum AiroPlaybackEnginePhase {
+  idle('idle'),
+  opening('opening'),
+  open('open'),
+  playing('playing'),
+  paused('paused'),
+  buffering('buffering'),
+  seeking('seeking'),
+  stopped('stopped'),
+  ended('ended'),
+  failed('failed'),
+  unavailable('unavailable');
+
+  const AiroPlaybackEnginePhase(this.stableId);
+
+  final String stableId;
+}
+
+enum AiroPlaybackTrackKind {
+  audio('audio'),
+  subtitle('subtitle'),
+  video('video');
+
+  const AiroPlaybackTrackKind(this.stableId);
+
+  final String stableId;
+}
+
+enum AiroPlaybackSourceHandleRejectionCode {
+  empty('empty'),
+  urlValue('url_value'),
+  localPathValue('local_path_value'),
+  localIpValue('local_ip_value'),
+  credentialLikeValue('credential_like_value');
+
+  const AiroPlaybackSourceHandleRejectionCode(this.stableId);
+
+  final String stableId;
+}
+
+enum AiroPlaybackErrorCode {
+  backendUnavailable('backend_unavailable'),
+  unsupportedOperation('unsupported_operation'),
+  invalidSource('invalid_source'),
+  sourceUnavailable('source_unavailable'),
+  codecUnsupported('codec_unsupported'),
+  protectedPlaybackUnsupported('protected_playback_unsupported'),
+  networkUnavailable('network_unavailable'),
+  decoderFailed('decoder_failed'),
+  operationRejected('operation_rejected'),
+  qualityUnavailable('quality_unavailable'),
+  trackUnavailable('track_unavailable');
+
+  const AiroPlaybackErrorCode(this.stableId);
+
+  final String stableId;
+}
+
+class AiroPlaybackSourceHandle extends Equatable {
+  const AiroPlaybackSourceHandle._(this.value);
+
+  factory AiroPlaybackSourceHandle.redacted(String value) {
+    final rejection = validate(value);
+    if (rejection != null) {
+      throw ArgumentError.value(value, 'value', rejection.stableId);
+    }
+    return AiroPlaybackSourceHandle._(value.trim());
+  }
+
+  final String value;
+
+  static AiroPlaybackSourceHandleRejectionCode? validate(String value) {
+    final trimmed = value.trim();
+    if (trimmed.isEmpty) return AiroPlaybackSourceHandleRejectionCode.empty;
+
+    final uri = Uri.tryParse(trimmed);
+    if (uri != null && (uri.scheme == 'http' || uri.scheme == 'https')) {
+      return AiroPlaybackSourceHandleRejectionCode.urlValue;
+    }
+    if (trimmed.startsWith('file://') ||
+        trimmed.startsWith('/') ||
+        RegExp(r'^[A-Za-z]:\\').hasMatch(trimmed)) {
+      return AiroPlaybackSourceHandleRejectionCode.localPathValue;
+    }
+    if (RegExp(
+      r'\b(?:10|127|172\.(?:1[6-9]|2\d|3[0-1])|192\.168)\.',
+    ).hasMatch(trimmed)) {
+      return AiroPlaybackSourceHandleRejectionCode.localIpValue;
+    }
+    if (RegExp(
+      r'\b(?:bearer|basic)\s+[A-Za-z0-9._~+/=-]+',
+      caseSensitive: false,
+    ).hasMatch(trimmed)) {
+      return AiroPlaybackSourceHandleRejectionCode.credentialLikeValue;
+    }
+
+    return null;
+  }
+
+  @override
+  String toString() => 'AiroPlaybackSourceHandle(redacted)';
+
+  @override
+  List<Object?> get props => [value];
+}
+
+class AiroMediaOpenRequest extends Equatable {
+  const AiroMediaOpenRequest({
+    required this.requestId,
+    required this.sourceHandle,
+    required this.mediaKind,
+    this.startPosition = Duration.zero,
+    this.preferredQualityId,
+    this.schemaVersion = kAiroPlaybackEngineSchemaVersion,
+  });
+
+  final String schemaVersion;
+  final String requestId;
+  final AiroPlaybackSourceHandle sourceHandle;
+  final AiroPlaybackMediaKind mediaKind;
+  final Duration startPosition;
+  final String? preferredQualityId;
+
+  @override
+  String toString() {
+    return 'AiroMediaOpenRequest('
+        'requestId: $requestId, '
+        'mediaKind: ${mediaKind.stableId}, '
+        'startPosition: $startPosition, '
+        'preferredQualityId: $preferredQualityId, '
+        'sourceHandle: redacted'
+        ')';
+  }
+
+  @override
+  List<Object?> get props => [
+    schemaVersion,
+    requestId,
+    sourceHandle,
+    mediaKind,
+    startPosition,
+    preferredQualityId,
+  ];
+}
+
+class AiroPlaybackQualityOption extends Equatable {
+  const AiroPlaybackQualityOption({
+    required this.id,
+    required this.label,
+    this.width,
+    this.height,
+    this.bitrateKbps,
+  });
+
+  final String id;
+  final String label;
+  final int? width;
+  final int? height;
+  final int? bitrateKbps;
+
+  @override
+  List<Object?> get props => [id, label, width, height, bitrateKbps];
+}
+
+class AiroPlaybackTrackOption extends Equatable {
+  const AiroPlaybackTrackOption({
+    required this.id,
+    required this.kind,
+    required this.label,
+    this.languageCode,
+  });
+
+  final String id;
+  final AiroPlaybackTrackKind kind;
+  final String label;
+  final String? languageCode;
+
+  @override
+  List<Object?> get props => [id, kind, label, languageCode];
+}
+
+class AiroPlaybackDiagnostics extends Equatable {
+  AiroPlaybackDiagnostics({
+    required this.backendId,
+    List<String> detailCodes = const [],
+    this.decoderName,
+    this.codecName,
+    this.hardwareAccelerated,
+    this.droppedFrames,
+    this.bufferedPosition,
+  }) : detailCodes = List.unmodifiable(detailCodes);
+
+  final String backendId;
+  final String? decoderName;
+  final String? codecName;
+  final bool? hardwareAccelerated;
+  final int? droppedFrames;
+  final Duration? bufferedPosition;
+  final List<String> detailCodes;
+
+  @override
+  String toString() {
+    return 'AiroPlaybackDiagnostics('
+        'backendId: $backendId, '
+        'decoderName: $decoderName, '
+        'codecName: $codecName, '
+        'hardwareAccelerated: $hardwareAccelerated, '
+        'droppedFrames: $droppedFrames, '
+        'bufferedPosition: $bufferedPosition, '
+        'detailCodes: $detailCodes'
+        ')';
+  }
+
+  @override
+  List<Object?> get props => [
+    backendId,
+    decoderName,
+    codecName,
+    hardwareAccelerated,
+    droppedFrames,
+    bufferedPosition,
+    detailCodes,
+  ];
+}
+
+class AiroPlaybackError extends Equatable {
+  const AiroPlaybackError({required this.code, this.operation});
+
+  final AiroPlaybackErrorCode code;
+  final String? operation;
+
+  @override
+  List<Object?> get props => [code, operation];
+}
+
+class AiroPlaybackState extends Equatable {
+  AiroPlaybackState({
+    required this.backendKind,
+    required this.phase,
+    this.request,
+    this.position = Duration.zero,
+    this.duration,
+    this.volume = 1,
+    this.playbackSpeed = 1,
+    List<AiroPlaybackQualityOption> qualityOptions = const [],
+    this.selectedQualityId,
+    List<AiroPlaybackTrackOption> tracks = const [],
+    Map<AiroPlaybackTrackKind, String> selectedTrackIds = const {},
+    this.diagnostics,
+    this.error,
+    this.schemaVersion = kAiroPlaybackEngineSchemaVersion,
+  }) : qualityOptions = List.unmodifiable(qualityOptions),
+       tracks = List.unmodifiable(tracks),
+       selectedTrackIds = Map.unmodifiable(selectedTrackIds);
+
+  factory AiroPlaybackState.idle({
+    AiroPlaybackBackendKind backendKind = AiroPlaybackBackendKind.unavailable,
+  }) {
+    return AiroPlaybackState(
+      backendKind: backendKind,
+      phase: AiroPlaybackEnginePhase.idle,
+    );
+  }
+
+  final String schemaVersion;
+  final AiroPlaybackBackendKind backendKind;
+  final AiroPlaybackEnginePhase phase;
+  final AiroMediaOpenRequest? request;
+  final Duration position;
+  final Duration? duration;
+  final double volume;
+  final double playbackSpeed;
+  final List<AiroPlaybackQualityOption> qualityOptions;
+  final String? selectedQualityId;
+  final List<AiroPlaybackTrackOption> tracks;
+  final Map<AiroPlaybackTrackKind, String> selectedTrackIds;
+  final AiroPlaybackDiagnostics? diagnostics;
+  final AiroPlaybackError? error;
+
+  AiroPlaybackState copyWith({
+    AiroPlaybackEnginePhase? phase,
+    AiroMediaOpenRequest? request,
+    Duration? position,
+    Duration? duration,
+    double? volume,
+    double? playbackSpeed,
+    List<AiroPlaybackQualityOption>? qualityOptions,
+    String? selectedQualityId,
+    List<AiroPlaybackTrackOption>? tracks,
+    Map<AiroPlaybackTrackKind, String>? selectedTrackIds,
+    AiroPlaybackDiagnostics? diagnostics,
+    AiroPlaybackError? error,
+  }) {
+    return AiroPlaybackState(
+      schemaVersion: schemaVersion,
+      backendKind: backendKind,
+      phase: phase ?? this.phase,
+      request: request ?? this.request,
+      position: position ?? this.position,
+      duration: duration ?? this.duration,
+      volume: volume ?? this.volume,
+      playbackSpeed: playbackSpeed ?? this.playbackSpeed,
+      qualityOptions: qualityOptions ?? this.qualityOptions,
+      selectedQualityId: selectedQualityId ?? this.selectedQualityId,
+      tracks: tracks ?? this.tracks,
+      selectedTrackIds: selectedTrackIds ?? this.selectedTrackIds,
+      diagnostics: diagnostics ?? this.diagnostics,
+      error: error,
+    );
+  }
+
+  @override
+  String toString() {
+    return 'AiroPlaybackState('
+        'backendKind: ${backendKind.stableId}, '
+        'phase: ${phase.stableId}, '
+        'requestId: ${request?.requestId}, '
+        'position: $position, '
+        'duration: $duration, '
+        'volume: $volume, '
+        'playbackSpeed: $playbackSpeed, '
+        'selectedQualityId: $selectedQualityId, '
+        'selectedTrackIds: $selectedTrackIds, '
+        'diagnostics: $diagnostics, '
+        'error: $error'
+        ')';
+  }
+
+  @override
+  List<Object?> get props => [
+    schemaVersion,
+    backendKind,
+    phase,
+    request,
+    position,
+    duration,
+    volume,
+    playbackSpeed,
+    qualityOptions,
+    selectedQualityId,
+    tracks,
+    selectedTrackIds,
+    diagnostics,
+    error,
+  ];
+}

--- a/packages/platform_player/lib/src/services/airo_playback_engine.dart
+++ b/packages/platform_player/lib/src/services/airo_playback_engine.dart
@@ -1,0 +1,34 @@
+import '../models/playback_engine_models.dart';
+
+abstract class AiroPlaybackEngine {
+  AiroPlaybackBackendKind get backendKind;
+
+  Stream<AiroPlaybackState> get states;
+
+  AiroPlaybackState get currentState;
+
+  Future<AiroPlaybackState> open(AiroMediaOpenRequest request);
+
+  Future<AiroPlaybackState> play();
+
+  Future<AiroPlaybackState> pause();
+
+  Future<AiroPlaybackState> stop();
+
+  Future<AiroPlaybackState> seek(Duration position);
+
+  Future<AiroPlaybackState> setVolume(double volume);
+
+  Future<AiroPlaybackState> setPlaybackSpeed(double speed);
+
+  Future<AiroPlaybackState> selectQuality(String qualityId);
+
+  Future<AiroPlaybackState> selectTrack({
+    required AiroPlaybackTrackKind kind,
+    required String trackId,
+  });
+
+  Future<AiroPlaybackDiagnostics> diagnostics();
+
+  Future<void> dispose();
+}

--- a/packages/platform_player/lib/src/services/fake_playback_engine.dart
+++ b/packages/platform_player/lib/src/services/fake_playback_engine.dart
@@ -1,0 +1,191 @@
+import 'dart:async';
+
+import '../models/playback_engine_models.dart';
+import 'airo_playback_engine.dart';
+
+class FakeAiroPlaybackEngine implements AiroPlaybackEngine {
+  FakeAiroPlaybackEngine({
+    List<AiroPlaybackQualityOption> qualityOptions = const [
+      AiroPlaybackQualityOption(id: 'auto', label: 'Auto'),
+      AiroPlaybackQualityOption(
+        id: '720p',
+        label: '720p',
+        width: 1280,
+        height: 720,
+      ),
+    ],
+    List<AiroPlaybackTrackOption> tracks = const [
+      AiroPlaybackTrackOption(
+        id: 'audio-main',
+        kind: AiroPlaybackTrackKind.audio,
+        label: 'Main',
+      ),
+    ],
+    AiroPlaybackDiagnostics? diagnostics,
+  }) : _qualityOptions = List.unmodifiable(qualityOptions),
+       _tracks = List.unmodifiable(tracks),
+       _diagnostics =
+           diagnostics ??
+           AiroPlaybackDiagnostics(
+             backendId: AiroPlaybackBackendKind.fake.stableId,
+             detailCodes: const ['fake_engine'],
+           ),
+       _state = AiroPlaybackState.idle(
+         backendKind: AiroPlaybackBackendKind.fake,
+       );
+
+  final StreamController<AiroPlaybackState> _controller =
+      StreamController<AiroPlaybackState>.broadcast();
+  final List<AiroPlaybackQualityOption> _qualityOptions;
+  final List<AiroPlaybackTrackOption> _tracks;
+  final AiroPlaybackDiagnostics _diagnostics;
+  AiroPlaybackState _state;
+
+  @override
+  AiroPlaybackBackendKind get backendKind => AiroPlaybackBackendKind.fake;
+
+  @override
+  Stream<AiroPlaybackState> get states => _controller.stream;
+
+  @override
+  AiroPlaybackState get currentState => _state;
+
+  @override
+  Future<AiroPlaybackState> open(AiroMediaOpenRequest request) async {
+    _emit(
+      _state.copyWith(
+        phase: AiroPlaybackEnginePhase.opening,
+        request: request,
+        position: request.startPosition,
+      ),
+    );
+    _emit(
+      _state.copyWith(
+        phase: AiroPlaybackEnginePhase.open,
+        request: request,
+        position: request.startPosition,
+        qualityOptions: _qualityOptions,
+        selectedQualityId:
+            request.preferredQualityId ?? _qualityOptions.firstOrNull?.id,
+        tracks: _tracks,
+        selectedTrackIds: _initialTrackSelection(_tracks),
+        diagnostics: _diagnostics,
+      ),
+    );
+    return _state;
+  }
+
+  @override
+  Future<AiroPlaybackState> play() async {
+    return _transition(AiroPlaybackEnginePhase.playing);
+  }
+
+  @override
+  Future<AiroPlaybackState> pause() async {
+    return _transition(AiroPlaybackEnginePhase.paused);
+  }
+
+  @override
+  Future<AiroPlaybackState> stop() async {
+    _emit(
+      _state.copyWith(
+        phase: AiroPlaybackEnginePhase.stopped,
+        position: Duration.zero,
+      ),
+    );
+    return _state;
+  }
+
+  @override
+  Future<AiroPlaybackState> seek(Duration position) async {
+    _emit(_state.copyWith(phase: AiroPlaybackEnginePhase.seeking));
+    _emit(
+      _state.copyWith(
+        phase: AiroPlaybackEnginePhase.paused,
+        position: position,
+      ),
+    );
+    return _state;
+  }
+
+  @override
+  Future<AiroPlaybackState> setVolume(double volume) async {
+    final clamped = volume.clamp(0, 1).toDouble();
+    _emit(_state.copyWith(volume: clamped));
+    return _state;
+  }
+
+  @override
+  Future<AiroPlaybackState> setPlaybackSpeed(double speed) async {
+    _emit(_state.copyWith(playbackSpeed: speed));
+    return _state;
+  }
+
+  @override
+  Future<AiroPlaybackState> selectQuality(String qualityId) async {
+    if (!_qualityOptions.any((option) => option.id == qualityId)) {
+      return _fail(
+        AiroPlaybackError(
+          code: AiroPlaybackErrorCode.qualityUnavailable,
+          operation: 'selectQuality',
+        ),
+      );
+    }
+    _emit(_state.copyWith(selectedQualityId: qualityId));
+    return _state;
+  }
+
+  @override
+  Future<AiroPlaybackState> selectTrack({
+    required AiroPlaybackTrackKind kind,
+    required String trackId,
+  }) async {
+    if (!_tracks.any((track) => track.kind == kind && track.id == trackId)) {
+      return _fail(
+        AiroPlaybackError(
+          code: AiroPlaybackErrorCode.trackUnavailable,
+          operation: 'selectTrack',
+        ),
+      );
+    }
+    _emit(
+      _state.copyWith(
+        selectedTrackIds: {..._state.selectedTrackIds, kind: trackId},
+      ),
+    );
+    return _state;
+  }
+
+  @override
+  Future<AiroPlaybackDiagnostics> diagnostics() async => _diagnostics;
+
+  @override
+  Future<void> dispose() async {
+    await _controller.close();
+  }
+
+  Future<AiroPlaybackState> _transition(AiroPlaybackEnginePhase phase) async {
+    _emit(_state.copyWith(phase: phase));
+    return _state;
+  }
+
+  AiroPlaybackState _fail(AiroPlaybackError error) {
+    _emit(_state.copyWith(phase: AiroPlaybackEnginePhase.failed, error: error));
+    return _state;
+  }
+
+  void _emit(AiroPlaybackState state) {
+    _state = state;
+    _controller.add(state);
+  }
+
+  static Map<AiroPlaybackTrackKind, String> _initialTrackSelection(
+    List<AiroPlaybackTrackOption> tracks,
+  ) {
+    final selected = <AiroPlaybackTrackKind, String>{};
+    for (final track in tracks) {
+      selected.putIfAbsent(track.kind, () => track.id);
+    }
+    return selected;
+  }
+}

--- a/packages/platform_player/lib/src/services/unavailable_playback_engine.dart
+++ b/packages/platform_player/lib/src/services/unavailable_playback_engine.dart
@@ -1,0 +1,98 @@
+import 'dart:async';
+
+import '../models/playback_engine_models.dart';
+import 'airo_playback_engine.dart';
+
+class UnavailableAiroPlaybackEngine implements AiroPlaybackEngine {
+  UnavailableAiroPlaybackEngine({
+    AiroPlaybackErrorCode code = AiroPlaybackErrorCode.backendUnavailable,
+  }) : _errorCode = code,
+       _state = AiroPlaybackState(
+         backendKind: AiroPlaybackBackendKind.unavailable,
+         phase: AiroPlaybackEnginePhase.unavailable,
+         error: AiroPlaybackError(code: code),
+       );
+
+  final AiroPlaybackErrorCode _errorCode;
+  final StreamController<AiroPlaybackState> _controller =
+      StreamController<AiroPlaybackState>.broadcast();
+  AiroPlaybackState _state;
+
+  @override
+  AiroPlaybackBackendKind get backendKind =>
+      AiroPlaybackBackendKind.unavailable;
+
+  @override
+  Stream<AiroPlaybackState> get states => _controller.stream;
+
+  @override
+  AiroPlaybackState get currentState => _state;
+
+  @override
+  Future<AiroPlaybackState> open(AiroMediaOpenRequest request) async {
+    return _unsupported('open', request: request);
+  }
+
+  @override
+  Future<AiroPlaybackState> play() async => _unsupported('play');
+
+  @override
+  Future<AiroPlaybackState> pause() async => _unsupported('pause');
+
+  @override
+  Future<AiroPlaybackState> stop() async => _unsupported('stop');
+
+  @override
+  Future<AiroPlaybackState> seek(Duration position) async =>
+      _unsupported('seek');
+
+  @override
+  Future<AiroPlaybackState> setVolume(double volume) async {
+    return _unsupported('setVolume');
+  }
+
+  @override
+  Future<AiroPlaybackState> setPlaybackSpeed(double speed) async {
+    return _unsupported('setPlaybackSpeed');
+  }
+
+  @override
+  Future<AiroPlaybackState> selectQuality(String qualityId) async {
+    return _unsupported('selectQuality');
+  }
+
+  @override
+  Future<AiroPlaybackState> selectTrack({
+    required AiroPlaybackTrackKind kind,
+    required String trackId,
+  }) async {
+    return _unsupported('selectTrack');
+  }
+
+  @override
+  Future<AiroPlaybackDiagnostics> diagnostics() async {
+    return AiroPlaybackDiagnostics(
+      backendId: AiroPlaybackBackendKind.unavailable.stableId,
+      detailCodes: const ['backend_unavailable'],
+    );
+  }
+
+  @override
+  Future<void> dispose() async {
+    await _controller.close();
+  }
+
+  AiroPlaybackState _unsupported(
+    String operation, {
+    AiroMediaOpenRequest? request,
+  }) {
+    _state = AiroPlaybackState(
+      backendKind: AiroPlaybackBackendKind.unavailable,
+      phase: AiroPlaybackEnginePhase.unavailable,
+      request: request ?? _state.request,
+      error: AiroPlaybackError(code: _errorCode, operation: operation),
+    );
+    _controller.add(_state);
+    return _state;
+  }
+}

--- a/packages/platform_player/test/playback_engine_test.dart
+++ b/packages/platform_player/test/playback_engine_test.dart
@@ -1,0 +1,154 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:platform_player/platform_player.dart';
+
+void main() {
+  group('Airo playback engine contract', () {
+    AiroMediaOpenRequest request({
+      String handle = 'source-handle-1',
+      String? preferredQualityId,
+    }) {
+      return AiroMediaOpenRequest(
+        requestId: 'open-1',
+        sourceHandle: AiroPlaybackSourceHandle.redacted(handle),
+        mediaKind: AiroPlaybackMediaKind.hls,
+        preferredQualityId: preferredQualityId,
+      );
+    }
+
+    test('source handles reject unsafe raw media references', () {
+      expect(
+        AiroPlaybackSourceHandle.validate(''),
+        AiroPlaybackSourceHandleRejectionCode.empty,
+      );
+      expect(
+        AiroPlaybackSourceHandle.validate('https://example.com/live.m3u8'),
+        AiroPlaybackSourceHandleRejectionCode.urlValue,
+      );
+      expect(
+        AiroPlaybackSourceHandle.validate('/Users/example/live.m3u8'),
+        AiroPlaybackSourceHandleRejectionCode.localPathValue,
+      );
+      expect(
+        AiroPlaybackSourceHandle.validate('source at 192.168.1.10'),
+        AiroPlaybackSourceHandleRejectionCode.localIpValue,
+      );
+      expect(
+        AiroPlaybackSourceHandle.validate('Bearer abc.def'),
+        AiroPlaybackSourceHandleRejectionCode.credentialLikeValue,
+      );
+    });
+
+    test(
+      'fake engine emits open, play, pause, seek, and stop states',
+      () async {
+        final engine = FakeAiroPlaybackEngine();
+        final events = <AiroPlaybackEnginePhase>[];
+        final subscription = engine.states.listen(
+          (state) => events.add(state.phase),
+        );
+
+        await engine.open(request());
+        await engine.play();
+        await engine.pause();
+        await engine.seek(const Duration(seconds: 12));
+        await engine.stop();
+
+        await Future<void>.delayed(Duration.zero);
+        await subscription.cancel();
+        await engine.dispose();
+
+        expect(events, [
+          AiroPlaybackEnginePhase.opening,
+          AiroPlaybackEnginePhase.open,
+          AiroPlaybackEnginePhase.playing,
+          AiroPlaybackEnginePhase.paused,
+          AiroPlaybackEnginePhase.seeking,
+          AiroPlaybackEnginePhase.paused,
+          AiroPlaybackEnginePhase.stopped,
+        ]);
+        expect(engine.currentState.position, Duration.zero);
+      },
+    );
+
+    test('fake engine selects quality and tracks deterministically', () async {
+      final engine = FakeAiroPlaybackEngine(
+        tracks: const [
+          AiroPlaybackTrackOption(
+            id: 'audio-en',
+            kind: AiroPlaybackTrackKind.audio,
+            label: 'English',
+            languageCode: 'en',
+          ),
+          AiroPlaybackTrackOption(
+            id: 'subs-en',
+            kind: AiroPlaybackTrackKind.subtitle,
+            label: 'English CC',
+            languageCode: 'en',
+          ),
+        ],
+      );
+
+      await engine.open(request(preferredQualityId: '720p'));
+      await engine.setVolume(1.5);
+      await engine.setPlaybackSpeed(1.25);
+      await engine.selectQuality('auto');
+      await engine.selectTrack(
+        kind: AiroPlaybackTrackKind.subtitle,
+        trackId: 'subs-en',
+      );
+
+      expect(engine.currentState.volume, 1);
+      expect(engine.currentState.playbackSpeed, 1.25);
+      expect(engine.currentState.selectedQualityId, 'auto');
+      expect(
+        engine.currentState.selectedTrackIds[AiroPlaybackTrackKind.subtitle],
+        'subs-en',
+      );
+      await engine.dispose();
+    });
+
+    test('fake engine returns typed failure for unavailable options', () async {
+      final engine = FakeAiroPlaybackEngine();
+
+      await engine.open(request());
+      final qualityState = await engine.selectQuality('4k');
+      final trackState = await engine.selectTrack(
+        kind: AiroPlaybackTrackKind.subtitle,
+        trackId: 'missing',
+      );
+
+      expect(
+        qualityState.error?.code,
+        AiroPlaybackErrorCode.qualityUnavailable,
+      );
+      expect(trackState.error?.code, AiroPlaybackErrorCode.trackUnavailable);
+      await engine.dispose();
+    });
+
+    test('unavailable engine returns typed unsupported state', () async {
+      final engine = UnavailableAiroPlaybackEngine();
+
+      final state = await engine.open(request());
+      final diagnostics = await engine.diagnostics();
+
+      expect(state.phase, AiroPlaybackEnginePhase.unavailable);
+      expect(state.error?.code, AiroPlaybackErrorCode.backendUnavailable);
+      expect(state.error?.operation, 'open');
+      expect(diagnostics.backendId, 'unavailable');
+      await engine.dispose();
+    });
+
+    test('string output redacts source handles', () {
+      final mediaRequest = request(handle: 'opaque-source-ref');
+      final state = AiroPlaybackState(
+        backendKind: AiroPlaybackBackendKind.fake,
+        phase: AiroPlaybackEnginePhase.open,
+        request: mediaRequest,
+      );
+
+      expect(mediaRequest.toString(), isNot(contains('opaque-source-ref')));
+      expect(state.toString(), isNot(contains('opaque-source-ref')));
+      expect(mediaRequest.toString(), contains('sourceHandle: redacted'));
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Adds the v2 backend-neutral PlaybackEngine abstraction for Airo TV playback delegation.

## Changes

- Extends `packages/platform_player` with a reusable PlaybackEngine contract.
- Adds redacted media open requests, playback states, diagnostics, typed errors, and command/result modeling.
- Adds fake and unavailable playback engines for deterministic platform tests.
- Documents the playback boundary in `docs/features/airo-tv/PLAYBACK_ENGINE_ABSTRACTION.md` so IPTV/video_player and Cast can become adapters without app-specific shortcuts.

## Testing

- `dart format --set-exit-if-changed packages/platform_player`
- `cd packages/platform_player && flutter test`
- `cd packages/platform_player && flutter analyze --fatal-infos`
- `git diff --check HEAD~1..HEAD`

Closes #605