### PR TITLE
feat(platform): add session sync contracts

### DIFF
--- a/docs/features/airo-tv/LOCAL_SYNC_HANDOFF_CONTRACT.md
+++ b/docs/features/airo-tv/LOCAL_SYNC_HANDOFF_CONTRACT.md
@@ -1,0 +1,71 @@
+# Airo TV Local Sync And Handoff Contract
+
+This contract defines the v2.0.0.1 platform boundary for local playback-session
+sync, receiver-authoritative revisions, deterministic conflicts, and two-phase
+handoff preflight.
+
+Implementation contract:
+
+- Package: `packages/core_sessions`
+- Schema: `kAiroSessionSchemaVersion`
+- Session snapshot: `AiroPlaybackSessionSnapshot`
+- Sync delta: `AiroSessionSyncDelta`
+- Handoff preflight: `AiroHandoffPreflightPolicy`
+- Fake repository: `AiroFakePlaybackSessionRepository`
+
+## Session Authority
+
+`AiroPlaybackSessionSnapshot` separates:
+
+- desired playback state requested by a controller;
+- actual playback state reported by the receiver;
+- active controller node ID;
+- receiver node ID;
+- monotonic revision;
+- opaque media handle;
+- capture and expiry timestamps.
+
+The receiver is authoritative for actual playback state. Controllers may render
+optimistic desired state only until a newer receiver revision arrives.
+
+## Revisions And Conflicts
+
+`AiroSessionRevision` carries a monotonic value, update timestamp, and reporter
+node ID. Newer revisions win. Older revisions are ignored. Equal revisions from
+different reporters are conflicts and must be surfaced through stable result
+codes before UI or transport code attempts recovery.
+
+## Local Sync Deltas
+
+`AiroSessionSyncDelta` carries an entity kind, operation, revision, issue and
+expiry timestamps, and an opaque payload handle.
+
+Sync payload handles must not contain raw media URLs, provider credentials,
+local file paths, local IP addresses, diagnostics dumps, analytics payloads, or
+viewing history. Local and cloud transports may carry encrypted payloads later,
+but this issue defines only the privacy-safe contract boundary.
+
+## Handoff Preflight
+
+Handoff uses prepare, ready, commit, and abort semantics. Source playback should
+continue until the destination is ready and commit is accepted.
+
+`AiroHandoffPreflightPolicy` checks:
+
+- source snapshot exists, is fresh, and is active;
+- destination snapshot exists and is fresh;
+- destination node is available and advertises required capabilities;
+- trusted-device relationship satisfies the required scope and trust level.
+
+## Consumer Rule
+
+Airo TV, companion apps, command routing, playback engines, local LAN adapters,
+and future cloud orchestration must consume `core_sessions`. Product code may
+render progress, conflicts, and recovery copy, but session authority, revision
+merge behavior, sync validation, and handoff preflight belong to this platform
+contract.
+
+## Out Of Scope
+
+This issue does not implement WebSocket transport, cloud orchestration,
+encrypted persistence, playback execution, device picker UI, or Airo TV screens.

--- a/packages/core_sessions/CHANGELOG.md
+++ b/packages/core_sessions/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.0.1
+
+- Add initial playback session sync and handoff contracts.

--- a/packages/core_sessions/README.md
+++ b/packages/core_sessions/README.md
@@ -1,0 +1,20 @@
+# Core Sessions
+
+Playback session sync and handoff contracts for Airo connected devices.
+
+This package is platform/framework code. Airo TV, companion apps, local LAN
+adapters, command routing, playback engines, cloud coordination, and QA
+automation consume these contracts instead of defining app-specific session or
+handoff state.
+
+## Scope
+
+- Receiver-authoritative playback session snapshots.
+- Monotonic revisions and deterministic conflict policy.
+- Privacy-safe local sync deltas with redacted payload handles.
+- Two-phase handoff preflight and phase records.
+- No-op and fake session repositories for host-only tests.
+
+This package does not implement cloud orchestration, WebSocket transport,
+encrypted persistence, playback execution, device picker UI, or Airo TV
+screens.

--- a/packages/core_sessions/analysis_options.yaml
+++ b/packages/core_sessions/analysis_options.yaml
@@ -1,0 +1,5 @@
+include: package:flutter_lints/flutter.yaml
+
+linter:
+  rules:
+    prefer_const_constructors: true

--- a/packages/core_sessions/lib/core_sessions.dart
+++ b/packages/core_sessions/lib/core_sessions.dart
@@ -1,0 +1,3 @@
+library;
+
+export 'src/session_models.dart';

--- a/packages/core_sessions/lib/src/session_models.dart
+++ b/packages/core_sessions/lib/src/session_models.dart
@@ -1,0 +1,706 @@
+import 'dart:async';
+
+import 'package:core_commands/core_commands.dart';
+import 'package:core_pairing/core_pairing.dart';
+import 'package:core_protocol/core_protocol.dart';
+import 'package:equatable/equatable.dart';
+
+const String kAiroSessionSchemaVersion = '1.0.0';
+
+enum AiroPlaybackSessionPhase {
+  idle('idle'),
+  preparing('preparing'),
+  playing('playing'),
+  paused('paused'),
+  buffering('buffering'),
+  seeking('seeking'),
+  transferring('transferring'),
+  stopped('stopped'),
+  completed('completed'),
+  failed('failed');
+
+  const AiroPlaybackSessionPhase(this.stableId);
+
+  final String stableId;
+}
+
+enum AiroSessionSyncEntityKind {
+  playbackSession('playback_session'),
+  playbackProgress('playback_progress'),
+  controllerMembership('controller_membership'),
+  handoff('handoff');
+
+  const AiroSessionSyncEntityKind(this.stableId);
+
+  final String stableId;
+}
+
+enum AiroSessionSyncOperation {
+  upsert('upsert'),
+  delete('delete');
+
+  const AiroSessionSyncOperation(this.stableId);
+
+  final String stableId;
+}
+
+enum AiroSessionSyncValidationCode {
+  accepted('accepted'),
+  expired('expired'),
+  unsafePayload('unsafe_payload'),
+  staleRevision('stale_revision'),
+  conflict('conflict');
+
+  const AiroSessionSyncValidationCode(this.stableId);
+
+  final String stableId;
+}
+
+enum AiroSessionMergeCode {
+  acceptedLocal('accepted_local'),
+  acceptedRemote('accepted_remote'),
+  ignoredStale('ignored_stale'),
+  conflict('conflict');
+
+  const AiroSessionMergeCode(this.stableId);
+
+  final String stableId;
+}
+
+enum AiroHandoffPhase {
+  requested('requested'),
+  preparing('preparing'),
+  ready('ready'),
+  committed('committed'),
+  aborted('aborted'),
+  failed('failed');
+
+  const AiroHandoffPhase(this.stableId);
+
+  final String stableId;
+}
+
+enum AiroHandoffPreflightCode {
+  accepted('accepted'),
+  sourceMissing('source_missing'),
+  destinationMissing('destination_missing'),
+  sourceStale('source_stale'),
+  destinationStale('destination_stale'),
+  sourceNotActive('source_not_active'),
+  destinationUnavailable('destination_unavailable'),
+  trustInsufficient('trust_insufficient'),
+  capabilityMissing('capability_missing');
+
+  const AiroHandoffPreflightCode(this.stableId);
+
+  final String stableId;
+}
+
+enum AiroSessionPayloadRejectionCode {
+  empty('empty'),
+  urlValue('url_value'),
+  localPathValue('local_path_value'),
+  localIpValue('local_ip_value'),
+  credentialLikeValue('credential_like_value');
+
+  const AiroSessionPayloadRejectionCode(this.stableId);
+
+  final String stableId;
+}
+
+class AiroSessionRevision extends Equatable
+    implements Comparable<AiroSessionRevision> {
+  const AiroSessionRevision({
+    required this.value,
+    required this.updatedAt,
+    required this.reporterNodeId,
+  });
+
+  final int value;
+  final DateTime updatedAt;
+  final String reporterNodeId;
+
+  bool isNewerThan(AiroSessionRevision other) {
+    if (value != other.value) return value > other.value;
+    if (updatedAt != other.updatedAt) return updatedAt.isAfter(other.updatedAt);
+    return false;
+  }
+
+  bool conflictsWith(AiroSessionRevision other) {
+    return value == other.value &&
+        updatedAt == other.updatedAt &&
+        reporterNodeId != other.reporterNodeId;
+  }
+
+  @override
+  int compareTo(AiroSessionRevision other) {
+    if (isNewerThan(other)) return 1;
+    if (other.isNewerThan(this)) return -1;
+    if (conflictsWith(other)) return 0;
+    return reporterNodeId.compareTo(other.reporterNodeId);
+  }
+
+  @override
+  List<Object?> get props => [value, updatedAt, reporterNodeId];
+}
+
+class AiroSessionPayloadHandle extends Equatable {
+  const AiroSessionPayloadHandle._(this.value);
+
+  factory AiroSessionPayloadHandle.redacted(String value) {
+    final rejection = validate(value);
+    if (rejection != null) {
+      throw ArgumentError.value(value, 'value', rejection.stableId);
+    }
+    return AiroSessionPayloadHandle._(value.trim());
+  }
+
+  final String value;
+
+  static AiroSessionPayloadRejectionCode? validate(String value) {
+    final trimmed = value.trim();
+    if (trimmed.isEmpty) return AiroSessionPayloadRejectionCode.empty;
+
+    final uri = Uri.tryParse(trimmed);
+    if (uri != null && (uri.scheme == 'http' || uri.scheme == 'https')) {
+      return AiroSessionPayloadRejectionCode.urlValue;
+    }
+    if (trimmed.startsWith('file://') ||
+        trimmed.startsWith('/') ||
+        RegExp(r'^[A-Za-z]:\\').hasMatch(trimmed)) {
+      return AiroSessionPayloadRejectionCode.localPathValue;
+    }
+    if (RegExp(
+      r'\b(?:10|127|172\.(?:1[6-9]|2\d|3[0-1])|192\.168)\.',
+    ).hasMatch(trimmed)) {
+      return AiroSessionPayloadRejectionCode.localIpValue;
+    }
+    if (RegExp(
+      r'\b(?:bearer|basic)\s+[A-Za-z0-9._~+/=-]+',
+      caseSensitive: false,
+    ).hasMatch(trimmed)) {
+      return AiroSessionPayloadRejectionCode.credentialLikeValue;
+    }
+
+    return null;
+  }
+
+  @override
+  String toString() => 'AiroSessionPayloadHandle(redacted)';
+
+  @override
+  List<Object?> get props => [value];
+}
+
+class AiroSessionCommandReference extends Equatable {
+  const AiroSessionCommandReference({
+    required this.commandId,
+    required this.sessionId,
+    required this.senderNodeId,
+    required this.targetNodeId,
+    required this.issuedAt,
+  });
+
+  factory AiroSessionCommandReference.fromEnvelope(
+    AiroCommandEnvelope envelope,
+  ) {
+    return AiroSessionCommandReference(
+      commandId: envelope.commandId,
+      sessionId: envelope.sessionId,
+      senderNodeId: envelope.senderNodeId,
+      targetNodeId: envelope.targetNodeId,
+      issuedAt: envelope.issuedAt,
+    );
+  }
+
+  final String commandId;
+  final String sessionId;
+  final String senderNodeId;
+  final String targetNodeId;
+  final DateTime issuedAt;
+
+  @override
+  List<Object?> get props => [
+    commandId,
+    sessionId,
+    senderNodeId,
+    targetNodeId,
+    issuedAt,
+  ];
+}
+
+class AiroDesiredPlaybackState extends Equatable {
+  const AiroDesiredPlaybackState({
+    required this.phase,
+    required this.position,
+    required this.updatedByControllerNodeId,
+    required this.updatedAt,
+    this.commandReference,
+  });
+
+  final AiroPlaybackSessionPhase phase;
+  final Duration position;
+  final String updatedByControllerNodeId;
+  final DateTime updatedAt;
+  final AiroSessionCommandReference? commandReference;
+
+  @override
+  List<Object?> get props => [
+    phase,
+    position,
+    updatedByControllerNodeId,
+    updatedAt,
+    commandReference,
+  ];
+}
+
+class AiroActualPlaybackState extends Equatable {
+  const AiroActualPlaybackState({
+    required this.phase,
+    required this.position,
+    required this.reportedByReceiverNodeId,
+    required this.reportedAt,
+    this.bufferedPosition,
+    this.playbackSpeed = 1,
+  });
+
+  final AiroPlaybackSessionPhase phase;
+  final Duration position;
+  final String reportedByReceiverNodeId;
+  final DateTime reportedAt;
+  final Duration? bufferedPosition;
+  final double playbackSpeed;
+
+  @override
+  List<Object?> get props => [
+    phase,
+    position,
+    reportedByReceiverNodeId,
+    reportedAt,
+    bufferedPosition,
+    playbackSpeed,
+  ];
+}
+
+class AiroPlaybackSessionSnapshot extends Equatable {
+  const AiroPlaybackSessionSnapshot({
+    required this.sessionId,
+    required this.receiverNodeId,
+    required this.revision,
+    required this.actual,
+    required this.capturedAt,
+    this.activeControllerNodeId,
+    this.desired,
+    this.mediaHandle,
+    this.expiresAt,
+    this.schemaVersion = kAiroSessionSchemaVersion,
+  });
+
+  final String schemaVersion;
+  final String sessionId;
+  final String receiverNodeId;
+  final String? activeControllerNodeId;
+  final AiroSessionRevision revision;
+  final AiroActualPlaybackState actual;
+  final AiroDesiredPlaybackState? desired;
+  final AiroSessionPayloadHandle? mediaHandle;
+  final DateTime capturedAt;
+  final DateTime? expiresAt;
+
+  bool isExpired(DateTime now) =>
+      expiresAt != null && !now.isBefore(expiresAt!);
+
+  @override
+  String toString() {
+    return 'AiroPlaybackSessionSnapshot('
+        'sessionId: $sessionId, '
+        'receiverNodeId: $receiverNodeId, '
+        'activeControllerNodeId: $activeControllerNodeId, '
+        'revision: ${revision.value}, '
+        'actualPhase: ${actual.phase.stableId}, '
+        'desiredPhase: ${desired?.phase.stableId}, '
+        'mediaHandle: ${mediaHandle == null ? null : 'redacted'}, '
+        'capturedAt: $capturedAt, '
+        'expiresAt: $expiresAt'
+        ')';
+  }
+
+  @override
+  List<Object?> get props => [
+    schemaVersion,
+    sessionId,
+    receiverNodeId,
+    activeControllerNodeId,
+    revision,
+    actual,
+    desired,
+    mediaHandle,
+    capturedAt,
+    expiresAt,
+  ];
+}
+
+class AiroSessionMergeResult extends Equatable {
+  const AiroSessionMergeResult({required this.code, required this.snapshot});
+
+  final AiroSessionMergeCode code;
+  final AiroPlaybackSessionSnapshot snapshot;
+
+  @override
+  List<Object?> get props => [code, snapshot];
+}
+
+class AiroSessionConflictPolicy {
+  const AiroSessionConflictPolicy();
+
+  AiroSessionMergeResult merge({
+    required AiroPlaybackSessionSnapshot current,
+    required AiroPlaybackSessionSnapshot incoming,
+  }) {
+    if (incoming.revision.conflictsWith(current.revision)) {
+      return AiroSessionMergeResult(
+        code: AiroSessionMergeCode.conflict,
+        snapshot: current,
+      );
+    }
+    if (incoming.revision.isNewerThan(current.revision)) {
+      return AiroSessionMergeResult(
+        code: AiroSessionMergeCode.acceptedRemote,
+        snapshot: incoming,
+      );
+    }
+    if (current.revision.isNewerThan(incoming.revision)) {
+      return AiroSessionMergeResult(
+        code: AiroSessionMergeCode.ignoredStale,
+        snapshot: current,
+      );
+    }
+    return AiroSessionMergeResult(
+      code: AiroSessionMergeCode.acceptedLocal,
+      snapshot: current,
+    );
+  }
+}
+
+class AiroSessionSyncDelta extends Equatable {
+  const AiroSessionSyncDelta({
+    required this.deltaId,
+    required this.sessionId,
+    required this.entityKind,
+    required this.operation,
+    required this.revision,
+    required this.payloadHandle,
+    required this.issuedAt,
+    required this.expiresAt,
+    this.commandId,
+    this.schemaVersion = kAiroSessionSchemaVersion,
+  });
+
+  final String schemaVersion;
+  final String deltaId;
+  final String sessionId;
+  final AiroSessionSyncEntityKind entityKind;
+  final AiroSessionSyncOperation operation;
+  final AiroSessionRevision revision;
+  final AiroSessionPayloadHandle payloadHandle;
+  final DateTime issuedAt;
+  final DateTime expiresAt;
+  final String? commandId;
+
+  bool isExpired(DateTime now) => !now.isBefore(expiresAt);
+
+  @override
+  String toString() {
+    return 'AiroSessionSyncDelta('
+        'deltaId: $deltaId, '
+        'sessionId: $sessionId, '
+        'entityKind: ${entityKind.stableId}, '
+        'operation: ${operation.stableId}, '
+        'revision: ${revision.value}, '
+        'payloadHandle: redacted, '
+        'issuedAt: $issuedAt, '
+        'expiresAt: $expiresAt'
+        ')';
+  }
+
+  @override
+  List<Object?> get props => [
+    schemaVersion,
+    deltaId,
+    sessionId,
+    entityKind,
+    operation,
+    revision,
+    payloadHandle,
+    issuedAt,
+    expiresAt,
+    commandId,
+  ];
+}
+
+class AiroSessionSyncValidationResult extends Equatable {
+  AiroSessionSyncValidationResult({
+    required List<AiroSessionSyncValidationCode> codes,
+  }) : codes = List.unmodifiable(codes);
+
+  final List<AiroSessionSyncValidationCode> codes;
+
+  bool get accepted => codes.isEmpty;
+
+  bool has(AiroSessionSyncValidationCode code) => codes.contains(code);
+
+  @override
+  List<Object?> get props => [codes];
+}
+
+class AiroSessionSyncPolicy {
+  const AiroSessionSyncPolicy();
+
+  AiroSessionSyncValidationResult validate({
+    required AiroSessionSyncDelta delta,
+    required DateTime now,
+    AiroSessionRevision? currentRevision,
+  }) {
+    final codes = <AiroSessionSyncValidationCode>[];
+    if (delta.isExpired(now)) {
+      codes.add(AiroSessionSyncValidationCode.expired);
+    }
+    if (AiroSessionPayloadHandle.validate(delta.payloadHandle.value) != null) {
+      codes.add(AiroSessionSyncValidationCode.unsafePayload);
+    }
+    if (currentRevision != null) {
+      if (delta.revision.conflictsWith(currentRevision)) {
+        codes.add(AiroSessionSyncValidationCode.conflict);
+      } else if (currentRevision.isNewerThan(delta.revision)) {
+        codes.add(AiroSessionSyncValidationCode.staleRevision);
+      }
+    }
+    return AiroSessionSyncValidationResult(codes: codes);
+  }
+}
+
+class AiroHandoffRequest extends Equatable {
+  const AiroHandoffRequest({
+    required this.handoffId,
+    required this.sessionId,
+    required this.sourceReceiverNodeId,
+    required this.destinationReceiverNodeId,
+    required this.controllerNodeId,
+    required this.requiredScope,
+    required this.issuedAt,
+    required this.expiresAt,
+    this.expectedRevision,
+    this.commandId,
+    this.schemaVersion = kAiroSessionSchemaVersion,
+  });
+
+  final String schemaVersion;
+  final String handoffId;
+  final String sessionId;
+  final String sourceReceiverNodeId;
+  final String destinationReceiverNodeId;
+  final String controllerNodeId;
+  final AiroPairingScope requiredScope;
+  final AiroSessionRevision? expectedRevision;
+  final String? commandId;
+  final DateTime issuedAt;
+  final DateTime expiresAt;
+
+  bool isExpired(DateTime now) => !now.isBefore(expiresAt);
+
+  @override
+  List<Object?> get props => [
+    schemaVersion,
+    handoffId,
+    sessionId,
+    sourceReceiverNodeId,
+    destinationReceiverNodeId,
+    controllerNodeId,
+    requiredScope,
+    expectedRevision,
+    commandId,
+    issuedAt,
+    expiresAt,
+  ];
+}
+
+class AiroHandoffRecord extends Equatable {
+  const AiroHandoffRecord({
+    required this.request,
+    required this.phase,
+    required this.updatedAt,
+    this.reasonCode,
+  });
+
+  final AiroHandoffRequest request;
+  final AiroHandoffPhase phase;
+  final DateTime updatedAt;
+  final String? reasonCode;
+
+  @override
+  List<Object?> get props => [request, phase, updatedAt, reasonCode];
+}
+
+class AiroHandoffPreflightResult extends Equatable {
+  AiroHandoffPreflightResult({required List<AiroHandoffPreflightCode> codes})
+    : codes = List.unmodifiable(codes);
+
+  final List<AiroHandoffPreflightCode> codes;
+
+  bool get accepted => codes.isEmpty;
+
+  bool has(AiroHandoffPreflightCode code) => codes.contains(code);
+
+  @override
+  List<Object?> get props => [codes];
+}
+
+class AiroHandoffPreflightPolicy {
+  AiroHandoffPreflightPolicy({
+    required Set<AiroNodeCapability> requiredDestinationCapabilities,
+    this.maxSnapshotAge = const Duration(seconds: 10),
+    this.minimumTrustLevel = AiroTrustedDeviceTrustLevel.paired,
+  }) : requiredDestinationCapabilities = Set.unmodifiable(
+         requiredDestinationCapabilities,
+       );
+
+  final Set<AiroNodeCapability> requiredDestinationCapabilities;
+  final Duration maxSnapshotAge;
+  final AiroTrustedDeviceTrustLevel minimumTrustLevel;
+
+  AiroHandoffPreflightResult evaluate({
+    required AiroHandoffRequest request,
+    required DateTime now,
+    AiroPlaybackSessionSnapshot? sourceSnapshot,
+    AiroPlaybackSessionSnapshot? destinationSnapshot,
+    AiroTrustedDeviceRecord? trustRecord,
+    AiroNodeCapabilityAdvertisement? destinationAdvertisement,
+  }) {
+    final codes = <AiroHandoffPreflightCode>[];
+    if (sourceSnapshot == null) {
+      codes.add(AiroHandoffPreflightCode.sourceMissing);
+    } else {
+      if (sourceSnapshot.isExpired(now) ||
+          now.difference(sourceSnapshot.capturedAt) > maxSnapshotAge) {
+        codes.add(AiroHandoffPreflightCode.sourceStale);
+      }
+      if (!_activeSourcePhases.contains(sourceSnapshot.actual.phase)) {
+        codes.add(AiroHandoffPreflightCode.sourceNotActive);
+      }
+    }
+
+    if (destinationSnapshot == null) {
+      codes.add(AiroHandoffPreflightCode.destinationMissing);
+    } else if (destinationSnapshot.isExpired(now) ||
+        now.difference(destinationSnapshot.capturedAt) > maxSnapshotAge) {
+      codes.add(AiroHandoffPreflightCode.destinationStale);
+    }
+
+    if (destinationAdvertisement == null ||
+        destinationAdvertisement.isExpired(now) ||
+        !destinationAdvertisement.lifecycle.canNegotiate) {
+      codes.add(AiroHandoffPreflightCode.destinationUnavailable);
+    } else if (!destinationAdvertisement.advertisesAll(
+      requiredDestinationCapabilities,
+    )) {
+      codes.add(AiroHandoffPreflightCode.capabilityMissing);
+    }
+
+    if (trustRecord == null ||
+        !trustRecord.trustLevel.satisfies(minimumTrustLevel) ||
+        !trustRecord.allows(requiredScope: request.requiredScope, now: now)) {
+      codes.add(AiroHandoffPreflightCode.trustInsufficient);
+    }
+
+    return AiroHandoffPreflightResult(codes: codes);
+  }
+
+  static const Set<AiroPlaybackSessionPhase> _activeSourcePhases = {
+    AiroPlaybackSessionPhase.playing,
+    AiroPlaybackSessionPhase.paused,
+    AiroPlaybackSessionPhase.buffering,
+    AiroPlaybackSessionPhase.seeking,
+  };
+}
+
+abstract class AiroPlaybackSessionRepository {
+  Stream<AiroPlaybackSessionSnapshot> get snapshots;
+
+  Future<AiroPlaybackSessionSnapshot?> getById(String sessionId);
+
+  Future<AiroSessionMergeResult> upsert(AiroPlaybackSessionSnapshot snapshot);
+
+  Future<void> delete(String sessionId);
+}
+
+class AiroNoOpPlaybackSessionRepository
+    implements AiroPlaybackSessionRepository {
+  const AiroNoOpPlaybackSessionRepository();
+
+  @override
+  Stream<AiroPlaybackSessionSnapshot> get snapshots => const Stream.empty();
+
+  @override
+  Future<AiroPlaybackSessionSnapshot?> getById(String sessionId) async => null;
+
+  @override
+  Future<AiroSessionMergeResult> upsert(
+    AiroPlaybackSessionSnapshot snapshot,
+  ) async {
+    return AiroSessionMergeResult(
+      code: AiroSessionMergeCode.ignoredStale,
+      snapshot: snapshot,
+    );
+  }
+
+  @override
+  Future<void> delete(String sessionId) async {}
+}
+
+class AiroFakePlaybackSessionRepository
+    implements AiroPlaybackSessionRepository {
+  AiroFakePlaybackSessionRepository({
+    this.conflictPolicy = const AiroSessionConflictPolicy(),
+  });
+
+  final AiroSessionConflictPolicy conflictPolicy;
+  final StreamController<AiroPlaybackSessionSnapshot> _controller =
+      StreamController<AiroPlaybackSessionSnapshot>.broadcast();
+  final Map<String, AiroPlaybackSessionSnapshot> _snapshots = {};
+
+  @override
+  Stream<AiroPlaybackSessionSnapshot> get snapshots => _controller.stream;
+
+  @override
+  Future<AiroPlaybackSessionSnapshot?> getById(String sessionId) async {
+    return _snapshots[sessionId];
+  }
+
+  @override
+  Future<AiroSessionMergeResult> upsert(
+    AiroPlaybackSessionSnapshot snapshot,
+  ) async {
+    final current = _snapshots[snapshot.sessionId];
+    final result = current == null
+        ? AiroSessionMergeResult(
+            code: AiroSessionMergeCode.acceptedRemote,
+            snapshot: snapshot,
+          )
+        : conflictPolicy.merge(current: current, incoming: snapshot);
+    if (result.code == AiroSessionMergeCode.acceptedRemote ||
+        result.code == AiroSessionMergeCode.acceptedLocal) {
+      _snapshots[snapshot.sessionId] = result.snapshot;
+      _controller.add(result.snapshot);
+    }
+    return result;
+  }
+
+  @override
+  Future<void> delete(String sessionId) async {
+    _snapshots.remove(sessionId);
+  }
+
+  Future<void> dispose() async {
+    await _controller.close();
+  }
+}

--- a/packages/core_sessions/pubspec.yaml
+++ b/packages/core_sessions/pubspec.yaml
@@ -1,0 +1,27 @@
+name: core_sessions
+description: Playback session sync and handoff contracts for Airo devices.
+version: 0.0.1
+homepage:
+publish_to: none
+
+environment:
+  sdk: ^3.12.2
+  flutter: ">=1.17.0"
+
+dependencies:
+  core_commands:
+    path: ../core_commands
+  core_pairing:
+    path: ../core_pairing
+  core_protocol:
+    path: ../core_protocol
+  equatable: ^2.0.8
+  flutter:
+    sdk: flutter
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+  flutter_lints: ^6.0.0
+
+flutter:

--- a/packages/core_sessions/test/session_models_test.dart
+++ b/packages/core_sessions/test/session_models_test.dart
@@ -1,0 +1,298 @@
+import 'package:core_commands/core_commands.dart';
+import 'package:core_pairing/core_pairing.dart';
+import 'package:core_protocol/core_protocol.dart';
+import 'package:core_sessions/core_sessions.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('Airo session sync contracts', () {
+    final now = DateTime.utc(2026, 7, 14, 12);
+
+    AiroSessionRevision revision(
+      int value, {
+      String reporterNodeId = 'receiver-tv-1',
+      DateTime? updatedAt,
+    }) {
+      return AiroSessionRevision(
+        value: value,
+        updatedAt: updatedAt ?? now,
+        reporterNodeId: reporterNodeId,
+      );
+    }
+
+    AiroPlaybackSessionSnapshot snapshot({
+      int revisionValue = 1,
+      String reporterNodeId = 'receiver-tv-1',
+      DateTime? updatedAt,
+      DateTime? capturedAt,
+      DateTime? expiresAt,
+      AiroPlaybackSessionPhase phase = AiroPlaybackSessionPhase.playing,
+    }) {
+      return AiroPlaybackSessionSnapshot(
+        sessionId: 'session-1',
+        receiverNodeId: 'receiver-tv-1',
+        activeControllerNodeId: 'phone-1',
+        revision: revision(
+          revisionValue,
+          reporterNodeId: reporterNodeId,
+          updatedAt: updatedAt,
+        ),
+        actual: AiroActualPlaybackState(
+          phase: phase,
+          position: const Duration(seconds: 30),
+          reportedByReceiverNodeId: reporterNodeId,
+          reportedAt: updatedAt ?? now,
+        ),
+        desired: AiroDesiredPlaybackState(
+          phase: AiroPlaybackSessionPhase.playing,
+          position: const Duration(seconds: 31),
+          updatedByControllerNodeId: 'phone-1',
+          updatedAt: now,
+          commandReference: AiroSessionCommandReference.fromEnvelope(
+            commandEnvelope(now),
+          ),
+        ),
+        mediaHandle: AiroSessionPayloadHandle.redacted('media-ref-1'),
+        capturedAt: capturedAt ?? now,
+        expiresAt: expiresAt,
+      );
+    }
+
+    test('newer receiver revision wins over stale controller state', () {
+      const policy = AiroSessionConflictPolicy();
+      final current = snapshot(revisionValue: 2);
+      final stale = snapshot(
+        revisionValue: 1,
+        reporterNodeId: 'phone-1',
+        updatedAt: now.add(const Duration(seconds: 1)),
+      );
+
+      final result = policy.merge(current: current, incoming: stale);
+
+      expect(result.code, AiroSessionMergeCode.ignoredStale);
+      expect(result.snapshot, current);
+    });
+
+    test('equal revision from different reporters is conflict', () {
+      const policy = AiroSessionConflictPolicy();
+      final receiver = snapshot(reporterNodeId: 'receiver-tv-1');
+      final controller = snapshot(reporterNodeId: 'phone-1');
+
+      final result = policy.merge(current: receiver, incoming: controller);
+
+      expect(result.code, AiroSessionMergeCode.conflict);
+      expect(receiver.revision.conflictsWith(controller.revision), isTrue);
+    });
+
+    test('sync policy rejects expired and stale deltas', () {
+      const policy = AiroSessionSyncPolicy();
+      final delta = AiroSessionSyncDelta(
+        deltaId: 'delta-1',
+        sessionId: 'session-1',
+        entityKind: AiroSessionSyncEntityKind.playbackSession,
+        operation: AiroSessionSyncOperation.upsert,
+        revision: revision(1),
+        payloadHandle: AiroSessionPayloadHandle.redacted('snapshot-ref-1'),
+        issuedAt: now,
+        expiresAt: now,
+      );
+
+      final result = policy.validate(
+        delta: delta,
+        now: now.add(const Duration(seconds: 1)),
+        currentRevision: revision(2),
+      );
+
+      expect(result.has(AiroSessionSyncValidationCode.expired), isTrue);
+      expect(result.has(AiroSessionSyncValidationCode.staleRevision), isTrue);
+    });
+
+    test('payload handles reject unsafe sync data references', () {
+      expect(
+        AiroSessionPayloadHandle.validate(''),
+        AiroSessionPayloadRejectionCode.empty,
+      );
+      expect(
+        AiroSessionPayloadHandle.validate('https://example.com/snapshot'),
+        AiroSessionPayloadRejectionCode.urlValue,
+      );
+      expect(
+        AiroSessionPayloadHandle.validate('/Users/example/session.json'),
+        AiroSessionPayloadRejectionCode.localPathValue,
+      );
+      expect(
+        AiroSessionPayloadHandle.validate('seen at 192.168.1.10'),
+        AiroSessionPayloadRejectionCode.localIpValue,
+      );
+      expect(
+        AiroSessionPayloadHandle.validate('Bearer abc.def'),
+        AiroSessionPayloadRejectionCode.credentialLikeValue,
+      );
+    });
+
+    test('snapshot and delta string output redact handles', () {
+      final session = snapshot();
+      final delta = AiroSessionSyncDelta(
+        deltaId: 'delta-1',
+        sessionId: 'session-1',
+        entityKind: AiroSessionSyncEntityKind.playbackSession,
+        operation: AiroSessionSyncOperation.upsert,
+        revision: revision(2),
+        payloadHandle: AiroSessionPayloadHandle.redacted('private-ref-1'),
+        issuedAt: now,
+        expiresAt: now.add(const Duration(seconds: 30)),
+      );
+
+      expect(session.toString(), isNot(contains('media-ref-1')));
+      expect(delta.toString(), isNot(contains('private-ref-1')));
+      expect(session.toString(), contains('mediaHandle: redacted'));
+      expect(delta.toString(), contains('payloadHandle: redacted'));
+    });
+
+    test('handoff preflight accepts trusted compatible snapshots', () {
+      final policy = AiroHandoffPreflightPolicy(
+        requiredDestinationCapabilities: const {AiroNodeCapability.playback},
+      );
+
+      final result = policy.evaluate(
+        request: handoffRequest(now),
+        now: now,
+        sourceSnapshot: snapshot(),
+        destinationSnapshot: snapshot(phase: AiroPlaybackSessionPhase.paused),
+        trustRecord: trustRecord(now),
+        destinationAdvertisement: advertisement(now),
+      );
+
+      expect(result.accepted, isTrue);
+    });
+
+    test(
+      'handoff preflight rejects stale, inactive, and incompatible state',
+      () {
+        final policy = AiroHandoffPreflightPolicy(
+          requiredDestinationCapabilities: const {AiroNodeCapability.playback},
+        );
+
+        final result = policy.evaluate(
+          request: handoffRequest(now),
+          now: now,
+          sourceSnapshot: snapshot(
+            capturedAt: now.subtract(const Duration(seconds: 20)),
+            phase: AiroPlaybackSessionPhase.stopped,
+          ),
+          destinationSnapshot: snapshot(
+            capturedAt: now.subtract(const Duration(seconds: 20)),
+          ),
+          trustRecord: trustRecord(
+            now,
+            scopes: const {AiroPairingScope.textInput},
+          ),
+          destinationAdvertisement: advertisement(
+            now,
+            capabilities: const {AiroNodeCapability.display},
+          ),
+        );
+
+        expect(result.has(AiroHandoffPreflightCode.sourceStale), isTrue);
+        expect(result.has(AiroHandoffPreflightCode.destinationStale), isTrue);
+        expect(result.has(AiroHandoffPreflightCode.sourceNotActive), isTrue);
+        expect(result.has(AiroHandoffPreflightCode.capabilityMissing), isTrue);
+        expect(result.has(AiroHandoffPreflightCode.trustInsufficient), isTrue);
+      },
+    );
+
+    test(
+      'fake repository emits accepted snapshots and ignores stale updates',
+      () async {
+        final repository = AiroFakePlaybackSessionRepository();
+        final events = <AiroPlaybackSessionSnapshot>[];
+        final subscription = repository.snapshots.listen(events.add);
+
+        final first = await repository.upsert(snapshot(revisionValue: 1));
+        final second = await repository.upsert(snapshot(revisionValue: 2));
+        final stale = await repository.upsert(snapshot(revisionValue: 1));
+
+        await Future<void>.delayed(Duration.zero);
+        await subscription.cancel();
+        await repository.dispose();
+
+        expect(first.code, AiroSessionMergeCode.acceptedRemote);
+        expect(second.code, AiroSessionMergeCode.acceptedRemote);
+        expect(stale.code, AiroSessionMergeCode.ignoredStale);
+        expect(events.map((event) => event.revision.value), [1, 2]);
+      },
+    );
+
+    test('no-op repository never stores sessions', () async {
+      const repository = AiroNoOpPlaybackSessionRepository();
+
+      await repository.upsert(snapshot());
+
+      expect(await repository.getById('session-1'), isNull);
+    });
+  });
+}
+
+AiroCommandEnvelope commandEnvelope(DateTime now) {
+  return AiroCommandEnvelope(
+    commandId: 'command-1',
+    sessionId: 'session-1',
+    senderNodeId: 'phone-1',
+    targetNodeId: 'receiver-tv-1',
+    kind: AiroCommandKind.playback,
+    action: AiroCommandAction.play,
+    requiredScope: AiroPairingScope.playbackControl,
+    issuedAt: now,
+    expiresAt: now.add(const Duration(seconds: 30)),
+    idempotencyKey: 'idempotency-1',
+  );
+}
+
+AiroHandoffRequest handoffRequest(DateTime now) {
+  return AiroHandoffRequest(
+    handoffId: 'handoff-1',
+    sessionId: 'session-1',
+    sourceReceiverNodeId: 'receiver-tv-1',
+    destinationReceiverNodeId: 'receiver-tv-2',
+    controllerNodeId: 'phone-1',
+    requiredScope: AiroPairingScope.playbackControl,
+    issuedAt: now,
+    expiresAt: now.add(const Duration(seconds: 30)),
+  );
+}
+
+AiroTrustedDeviceRecord trustRecord(
+  DateTime now, {
+  Set<AiroPairingScope> scopes = const {AiroPairingScope.playbackControl},
+}) {
+  return AiroTrustedDeviceRecord(
+    relationshipId: 'trusted-device-1',
+    controllerDeviceId: 'phone-1',
+    receiverDeviceId: 'receiver-tv-2',
+    controllerRole: AiroDeviceRole.mobileController,
+    receiverRole: AiroDeviceRole.tvReceiver,
+    scopes: scopes,
+    createdAt: now,
+    expiresAt: now.add(const Duration(minutes: 5)),
+    trustLevel: AiroTrustedDeviceTrustLevel.trusted,
+  );
+}
+
+AiroNodeCapabilityAdvertisement advertisement(
+  DateTime now, {
+  Set<AiroNodeCapability> capabilities = const {AiroNodeCapability.playback},
+}) {
+  return AiroNodeCapabilityAdvertisement(
+    identity: const AiroNodeIdentity(
+      nodeId: 'receiver-tv-2',
+      role: AiroNodeRole.tvReceiver,
+      productProfile: AiroNodeProductProfile.liteReceiver,
+      platformCategory: AiroNodePlatformCategory.androidTv,
+    ),
+    lifecycle: AiroNodeLifecycleState.available,
+    trustState: AiroNodeTrustState.trusted,
+    capabilities: capabilities,
+    issuedAt: now,
+    expiresAt: now.add(const Duration(seconds: 30)),
+  );
+}


### PR DESCRIPTION
## Summary

Adds the v2 local sync and handoff state platform contract for Airo TV delegation.

## Changes

- Adds `packages/core_sessions` with receiver-authoritative playback session snapshots.
- Adds monotonic revisions, sync deltas, conflict policy, handoff preflight, and no-op/fake repositories.
- Reuses trusted-device, command, and protocol contracts for compatibility and authority checks.
- Documents the local sync and handoff boundary in `docs/features/airo-tv/LOCAL_SYNC_HANDOFF_CONTRACT.md`.

## Testing

- `dart format --set-exit-if-changed packages/core_sessions`
- `cd packages/core_sessions && flutter test`
- `cd packages/core_sessions && flutter analyze --fatal-infos`
- `git diff --check HEAD~1..HEAD`

Closes #606