### PR TITLE
feat(platform): add adaptive UI mode contract

### DIFF
--- a/docs/features/airo-tv/ADAPTIVE_UI_MODE_CONTRACT.md
+++ b/docs/features/airo-tv/ADAPTIVE_UI_MODE_CONTRACT.md
@@ -1,0 +1,58 @@
+# Airo TV Adaptive UI Mode Contract
+
+This contract defines the v2.0.0.1 platform boundary for adaptive UI mode
+resolution across TV, mobile companion, tablet, desktop, and constrained
+receiver surfaces.
+
+Implementation contract:
+
+- Package: `packages/core_ui`
+- Input model: `AiroAdaptiveUiInput`
+- Policy: `AiroAdaptiveUiPolicy`
+- Output model: `AiroAdaptiveUiMode`
+
+## Inputs
+
+Adaptive mode resolution uses:
+
+- form factor;
+- active input devices;
+- viewing distance;
+- window class;
+- orientation;
+- accessibility preferences;
+- product UI profile hint.
+
+The decision must not depend only on width. A TV with D-pad input, a tablet with
+touch and remote input, and a desktop pointer surface can share dimensions while
+requiring different focus, navigation, typography, and density behavior.
+
+## Outputs
+
+`AiroAdaptiveUiMode` resolves:
+
+- interaction mode;
+- density;
+- typography scale;
+- focus behavior;
+- artwork policy;
+- motion policy;
+- navigation style;
+- minimum target size;
+- focus persistence requirement.
+
+These outputs are stable contracts for Airo TV screens, IPTV widgets, companion
+remote surfaces, and future profile navigation manifests.
+
+## Consumer Rule
+
+Airo TV app code should consume `core_ui` adaptive mode results. Product code
+may choose screen-specific layout and copy, but it should not invent separate
+remote/touch/pointer behavior models or hard-code density and accessibility
+rules in individual screens.
+
+## Out Of Scope
+
+This issue does not rewrite Airo TV or IPTV screens, add golden tests, implement
+runtime platform detection, certify physical remotes, define navigation
+manifests, or enforce legacy performance budgets.

--- a/packages/core_ui/README.md
+++ b/packages/core_ui/README.md
@@ -1,39 +1,21 @@
-<!--
-This README describes the package. If you publish this package to pub.dev,
-this README's contents appear on the landing page for your package.
+# Core UI
 
-For information about how to write a good package README, see the guide for
-[writing package pages](https://dart.dev/tools/pub/writing-package-pages).
+Design-system contracts, theme primitives, adaptive mode policy, and shared widgets
+for Airo products.
 
-For general information about developing packages, see the Dart guide for
-[creating packages](https://dart.dev/guides/libraries/create-packages)
-and the Flutter guide for
-[developing packages and plugins](https://flutter.dev/to/develop-packages).
--->
+This package is platform/framework code. Airo TV, mobile companion, tablet,
+desktop, IPTV, and future profile-specific surfaces consume these contracts
+instead of defining separate input-mode, density, typography, focus, and
+accessibility behavior in product screens.
 
-TODO: Put a short description of the package here that helps potential users
-know whether this package might be useful for them.
+## Scope
 
-## Features
+- Theme definitions and design primitives.
+- Shared UI widgets.
+- Adaptive UI mode inputs and resolver policy.
+- Stable interaction, density, typography, focus, artwork, motion, navigation,
+  and target-size outputs.
 
-TODO: List what your package can do. Maybe include images, gifs, or videos.
-
-## Getting started
-
-TODO: List prerequisites and provide or point to information on how to
-start using the package.
-
-## Usage
-
-TODO: Include short and useful examples for package users. Add longer examples
-to `/example` folder.
-
-```dart
-const like = 'sample';
-```
-
-## Additional information
-
-TODO: Tell users more about the package: where to find more information, how to
-contribute to the package, how to file issues, what response they can expect
-from the package authors, and more.
+This package does not implement runtime platform detection, rewrite product
+screens, define product navigation manifests, run device certification, or ship
+golden-test assets.

--- a/packages/core_ui/lib/core_ui.dart
+++ b/packages/core_ui/lib/core_ui.dart
@@ -1,6 +1,6 @@
 /// Core UI package for Airo
 ///
-/// Contains theme, design tokens, and shared widgets.
+/// Contains theme, design primitives, and shared widgets.
 library;
 
 // Theme
@@ -18,3 +18,6 @@ export 'src/widgets/app_button.dart';
 export 'src/widgets/app_card.dart';
 export 'src/widgets/loading_indicator.dart';
 export 'src/widgets/error_view.dart';
+
+// Adaptive UI
+export 'src/adaptive/adaptive_ui_models.dart';

--- a/packages/core_ui/lib/src/adaptive/adaptive_ui_models.dart
+++ b/packages/core_ui/lib/src/adaptive/adaptive_ui_models.dart
@@ -1,0 +1,364 @@
+enum AiroFormFactor {
+  phone('phone'),
+  tablet('tablet'),
+  tv('tv'),
+  desktop('desktop'),
+  embedded('embedded');
+
+  const AiroFormFactor(this.stableId);
+
+  final String stableId;
+}
+
+enum AiroInputDevice {
+  touch('touch'),
+  pointer('pointer'),
+  remote('remote'),
+  keyboard('keyboard'),
+  gamepad('gamepad'),
+  voice('voice');
+
+  const AiroInputDevice(this.stableId);
+
+  final String stableId;
+}
+
+enum AiroViewingDistance {
+  handheld('handheld'),
+  desk('desk'),
+  couch('couch'),
+  wall('wall');
+
+  const AiroViewingDistance(this.stableId);
+
+  final String stableId;
+}
+
+enum AiroWindowClass {
+  compact('compact'),
+  medium('medium'),
+  expanded('expanded'),
+  fullBleed('full_bleed');
+
+  const AiroWindowClass(this.stableId);
+
+  final String stableId;
+}
+
+enum AiroOrientation {
+  portrait('portrait'),
+  landscape('landscape'),
+  square('square');
+
+  const AiroOrientation(this.stableId);
+
+  final String stableId;
+}
+
+enum AiroProductUiProfileHint {
+  full('full'),
+  standardTv('standard_tv'),
+  liteReceiver('lite_receiver'),
+  embeddedReceiver('embedded_receiver'),
+  experimentalLegacy('experimental_legacy'),
+  companion('companion');
+
+  const AiroProductUiProfileHint(this.stableId);
+
+  final String stableId;
+
+  bool get isConstrainedReceiver =>
+      this == liteReceiver ||
+      this == embeddedReceiver ||
+      this == experimentalLegacy;
+}
+
+enum AiroInteractionMode {
+  touch('touch'),
+  pointer('pointer'),
+  remote('remote'),
+  keyboard('keyboard'),
+  hybrid('hybrid');
+
+  const AiroInteractionMode(this.stableId);
+
+  final String stableId;
+}
+
+enum AiroUiDensity {
+  comfortable('comfortable'),
+  balanced('balanced'),
+  compact('compact'),
+  sparse('sparse');
+
+  const AiroUiDensity(this.stableId);
+
+  final String stableId;
+}
+
+enum AiroTypographyScale {
+  compact('compact'),
+  normal('normal'),
+  large('large'),
+  extraLarge('extra_large');
+
+  const AiroTypographyScale(this.stableId);
+
+  final String stableId;
+}
+
+enum AiroFocusBehavior {
+  none('none'),
+  pointerHover('pointer_hover'),
+  dpadRequired('dpad_required'),
+  hybridSafe('hybrid_safe');
+
+  const AiroFocusBehavior(this.stableId);
+
+  final String stableId;
+}
+
+enum AiroArtworkPolicy {
+  rich('rich'),
+  reduced('reduced'),
+  minimal('minimal');
+
+  const AiroArtworkPolicy(this.stableId);
+
+  final String stableId;
+}
+
+enum AiroMotionPolicy {
+  standard('standard'),
+  reduced('reduced'),
+  disabled('disabled');
+
+  const AiroMotionPolicy(this.stableId);
+
+  final String stableId;
+}
+
+enum AiroNavigationStyle {
+  bottomBar('bottom_bar'),
+  rail('rail'),
+  sidebar('sidebar'),
+  tvRows('tv_rows'),
+  compactTabs('compact_tabs');
+
+  const AiroNavigationStyle(this.stableId);
+
+  final String stableId;
+}
+
+class AiroAccessibilityPreferences {
+  const AiroAccessibilityPreferences({
+    this.requiresLargeTargets = false,
+    this.requiresLargeText = false,
+    this.reduceMotion = false,
+    this.highContrast = false,
+    this.screenReaderEnabled = false,
+  });
+
+  final bool requiresLargeTargets;
+  final bool requiresLargeText;
+  final bool reduceMotion;
+  final bool highContrast;
+  final bool screenReaderEnabled;
+
+  bool get needsExpandedUi => requiresLargeTargets || requiresLargeText;
+}
+
+class AiroAdaptiveUiInput {
+  AiroAdaptiveUiInput({
+    required this.formFactor,
+    required Set<AiroInputDevice> inputDevices,
+    required this.viewingDistance,
+    required this.windowClass,
+    required this.orientation,
+    this.accessibility = const AiroAccessibilityPreferences(),
+    this.profileHint = AiroProductUiProfileHint.full,
+  }) : inputDevices = Set.unmodifiable(inputDevices);
+
+  final AiroFormFactor formFactor;
+  final Set<AiroInputDevice> inputDevices;
+  final AiroViewingDistance viewingDistance;
+  final AiroWindowClass windowClass;
+  final AiroOrientation orientation;
+  final AiroAccessibilityPreferences accessibility;
+  final AiroProductUiProfileHint profileHint;
+
+  bool hasInput(AiroInputDevice input) => inputDevices.contains(input);
+}
+
+class AiroAdaptiveUiMode {
+  const AiroAdaptiveUiMode({
+    required this.interactionMode,
+    required this.density,
+    required this.typographyScale,
+    required this.focusBehavior,
+    required this.artworkPolicy,
+    required this.motionPolicy,
+    required this.navigationStyle,
+    required this.minTargetSize,
+    required this.requiresFocusPersistence,
+  });
+
+  final AiroInteractionMode interactionMode;
+  final AiroUiDensity density;
+  final AiroTypographyScale typographyScale;
+  final AiroFocusBehavior focusBehavior;
+  final AiroArtworkPolicy artworkPolicy;
+  final AiroMotionPolicy motionPolicy;
+  final AiroNavigationStyle navigationStyle;
+  final double minTargetSize;
+  final bool requiresFocusPersistence;
+}
+
+class AiroAdaptiveUiPolicy {
+  const AiroAdaptiveUiPolicy();
+
+  AiroAdaptiveUiMode resolve(AiroAdaptiveUiInput input) {
+    final interactionMode = _resolveInteractionMode(input);
+    final focusBehavior = _resolveFocusBehavior(input, interactionMode);
+    final accessibility = input.accessibility;
+    final constrained = input.profileHint.isConstrainedReceiver;
+
+    return AiroAdaptiveUiMode(
+      interactionMode: interactionMode,
+      density: _resolveDensity(input, interactionMode, constrained),
+      typographyScale: _resolveTypographyScale(input),
+      focusBehavior: focusBehavior,
+      artworkPolicy: _resolveArtworkPolicy(input, constrained),
+      motionPolicy: accessibility.reduceMotion
+          ? AiroMotionPolicy.reduced
+          : constrained
+          ? AiroMotionPolicy.reduced
+          : AiroMotionPolicy.standard,
+      navigationStyle: _resolveNavigationStyle(input, interactionMode),
+      minTargetSize: _resolveMinTargetSize(input, interactionMode),
+      requiresFocusPersistence:
+          focusBehavior == AiroFocusBehavior.dpadRequired ||
+          focusBehavior == AiroFocusBehavior.hybridSafe,
+    );
+  }
+
+  AiroInteractionMode _resolveInteractionMode(AiroAdaptiveUiInput input) {
+    final hasTouch = input.hasInput(AiroInputDevice.touch);
+    final hasPointer = input.hasInput(AiroInputDevice.pointer);
+    final hasRemote =
+        input.hasInput(AiroInputDevice.remote) ||
+        input.hasInput(AiroInputDevice.gamepad);
+    final hasKeyboard = input.hasInput(AiroInputDevice.keyboard);
+
+    final activeFamilies = [
+      hasTouch,
+      hasPointer,
+      hasRemote,
+      hasKeyboard,
+    ].where((active) => active).length;
+    if (activeFamilies > 1) return AiroInteractionMode.hybrid;
+    if (hasRemote || input.formFactor == AiroFormFactor.tv) {
+      return AiroInteractionMode.remote;
+    }
+    if (hasPointer) return AiroInteractionMode.pointer;
+    if (hasKeyboard) return AiroInteractionMode.keyboard;
+    return AiroInteractionMode.touch;
+  }
+
+  AiroFocusBehavior _resolveFocusBehavior(
+    AiroAdaptiveUiInput input,
+    AiroInteractionMode mode,
+  ) {
+    if (mode == AiroInteractionMode.hybrid &&
+        (input.hasInput(AiroInputDevice.remote) ||
+            input.hasInput(AiroInputDevice.gamepad))) {
+      return AiroFocusBehavior.hybridSafe;
+    }
+    if (mode == AiroInteractionMode.remote) {
+      return AiroFocusBehavior.dpadRequired;
+    }
+    if (mode == AiroInteractionMode.pointer) {
+      return AiroFocusBehavior.pointerHover;
+    }
+    return AiroFocusBehavior.none;
+  }
+
+  AiroUiDensity _resolveDensity(
+    AiroAdaptiveUiInput input,
+    AiroInteractionMode mode,
+    bool constrained,
+  ) {
+    if (input.accessibility.needsExpandedUi) return AiroUiDensity.sparse;
+    if (constrained) return AiroUiDensity.compact;
+    if (mode == AiroInteractionMode.remote ||
+        input.viewingDistance == AiroViewingDistance.couch ||
+        input.viewingDistance == AiroViewingDistance.wall) {
+      return AiroUiDensity.comfortable;
+    }
+    if (mode == AiroInteractionMode.pointer &&
+        input.windowClass == AiroWindowClass.expanded) {
+      return AiroUiDensity.compact;
+    }
+    return AiroUiDensity.balanced;
+  }
+
+  AiroTypographyScale _resolveTypographyScale(AiroAdaptiveUiInput input) {
+    if (input.accessibility.requiresLargeText ||
+        input.accessibility.screenReaderEnabled) {
+      return AiroTypographyScale.extraLarge;
+    }
+    if (input.formFactor == AiroFormFactor.tv ||
+        input.viewingDistance == AiroViewingDistance.couch ||
+        input.viewingDistance == AiroViewingDistance.wall) {
+      return AiroTypographyScale.large;
+    }
+    if (input.windowClass == AiroWindowClass.compact) {
+      return AiroTypographyScale.normal;
+    }
+    return AiroTypographyScale.normal;
+  }
+
+  AiroArtworkPolicy _resolveArtworkPolicy(
+    AiroAdaptiveUiInput input,
+    bool constrained,
+  ) {
+    if (constrained) return AiroArtworkPolicy.minimal;
+    if (input.accessibility.highContrast) return AiroArtworkPolicy.reduced;
+    if (input.formFactor == AiroFormFactor.tv) return AiroArtworkPolicy.reduced;
+    return AiroArtworkPolicy.rich;
+  }
+
+  AiroNavigationStyle _resolveNavigationStyle(
+    AiroAdaptiveUiInput input,
+    AiroInteractionMode mode,
+  ) {
+    if (mode == AiroInteractionMode.remote ||
+        input.formFactor == AiroFormFactor.tv) {
+      return AiroNavigationStyle.tvRows;
+    }
+    if (input.windowClass == AiroWindowClass.compact) {
+      return AiroNavigationStyle.bottomBar;
+    }
+    if (input.windowClass == AiroWindowClass.medium) {
+      return AiroNavigationStyle.rail;
+    }
+    if (mode == AiroInteractionMode.pointer) {
+      return AiroNavigationStyle.sidebar;
+    }
+    return AiroNavigationStyle.rail;
+  }
+
+  double _resolveMinTargetSize(
+    AiroAdaptiveUiInput input,
+    AiroInteractionMode mode,
+  ) {
+    if (input.accessibility.requiresLargeTargets ||
+        input.accessibility.screenReaderEnabled) {
+      return 64;
+    }
+    if (mode == AiroInteractionMode.remote) return 56;
+    if (mode == AiroInteractionMode.hybrid) return 56;
+    if (mode == AiroInteractionMode.pointer) return 40;
+    return 48;
+  }
+}

--- a/packages/core_ui/test/adaptive_ui_models_test.dart
+++ b/packages/core_ui/test/adaptive_ui_models_test.dart
@@ -1,0 +1,127 @@
+import 'package:core_ui/core_ui.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('AiroAdaptiveUiPolicy', () {
+    const policy = AiroAdaptiveUiPolicy();
+
+    test('resolves TV remote input to remote-first focus mode', () {
+      final mode = policy.resolve(
+        AiroAdaptiveUiInput(
+          formFactor: AiroFormFactor.tv,
+          inputDevices: const {AiroInputDevice.remote},
+          viewingDistance: AiroViewingDistance.couch,
+          windowClass: AiroWindowClass.fullBleed,
+          orientation: AiroOrientation.landscape,
+          profileHint: AiroProductUiProfileHint.standardTv,
+        ),
+      );
+
+      expect(mode.interactionMode, AiroInteractionMode.remote);
+      expect(mode.focusBehavior, AiroFocusBehavior.dpadRequired);
+      expect(mode.density, AiroUiDensity.comfortable);
+      expect(mode.typographyScale, AiroTypographyScale.large);
+      expect(mode.navigationStyle, AiroNavigationStyle.tvRows);
+      expect(mode.minTargetSize, 56);
+      expect(mode.requiresFocusPersistence, isTrue);
+    });
+
+    test('resolves phone touch input without D-pad focus requirements', () {
+      final mode = policy.resolve(
+        AiroAdaptiveUiInput(
+          formFactor: AiroFormFactor.phone,
+          inputDevices: const {AiroInputDevice.touch},
+          viewingDistance: AiroViewingDistance.handheld,
+          windowClass: AiroWindowClass.compact,
+          orientation: AiroOrientation.portrait,
+          profileHint: AiroProductUiProfileHint.companion,
+        ),
+      );
+
+      expect(mode.interactionMode, AiroInteractionMode.touch);
+      expect(mode.focusBehavior, AiroFocusBehavior.none);
+      expect(mode.navigationStyle, AiroNavigationStyle.bottomBar);
+      expect(mode.minTargetSize, 48);
+      expect(mode.requiresFocusPersistence, isFalse);
+    });
+
+    test('resolves desktop pointer input to dense sidebar navigation', () {
+      final mode = policy.resolve(
+        AiroAdaptiveUiInput(
+          formFactor: AiroFormFactor.desktop,
+          inputDevices: const {AiroInputDevice.pointer},
+          viewingDistance: AiroViewingDistance.desk,
+          windowClass: AiroWindowClass.expanded,
+          orientation: AiroOrientation.landscape,
+        ),
+      );
+
+      expect(mode.interactionMode, AiroInteractionMode.pointer);
+      expect(mode.focusBehavior, AiroFocusBehavior.pointerHover);
+      expect(mode.density, AiroUiDensity.compact);
+      expect(mode.navigationStyle, AiroNavigationStyle.sidebar);
+      expect(mode.minTargetSize, 40);
+    });
+
+    test('resolves touch plus remote input to hybrid-safe focus mode', () {
+      final mode = policy.resolve(
+        AiroAdaptiveUiInput(
+          formFactor: AiroFormFactor.tablet,
+          inputDevices: const {AiroInputDevice.touch, AiroInputDevice.remote},
+          viewingDistance: AiroViewingDistance.desk,
+          windowClass: AiroWindowClass.medium,
+          orientation: AiroOrientation.landscape,
+        ),
+      );
+
+      expect(mode.interactionMode, AiroInteractionMode.hybrid);
+      expect(mode.focusBehavior, AiroFocusBehavior.hybridSafe);
+      expect(mode.minTargetSize, 56);
+      expect(mode.requiresFocusPersistence, isTrue);
+    });
+
+    test(
+      'accessibility preferences force larger targets and reduced motion',
+      () {
+        final mode = policy.resolve(
+          AiroAdaptiveUiInput(
+            formFactor: AiroFormFactor.phone,
+            inputDevices: const {AiroInputDevice.touch},
+            viewingDistance: AiroViewingDistance.handheld,
+            windowClass: AiroWindowClass.compact,
+            orientation: AiroOrientation.portrait,
+            accessibility: const AiroAccessibilityPreferences(
+              requiresLargeTargets: true,
+              requiresLargeText: true,
+              reduceMotion: true,
+              screenReaderEnabled: true,
+            ),
+          ),
+        );
+
+        expect(mode.density, AiroUiDensity.sparse);
+        expect(mode.typographyScale, AiroTypographyScale.extraLarge);
+        expect(mode.motionPolicy, AiroMotionPolicy.reduced);
+        expect(mode.minTargetSize, 64);
+      },
+    );
+
+    test('constrained receiver profile reduces artwork and data density', () {
+      final mode = policy.resolve(
+        AiroAdaptiveUiInput(
+          formFactor: AiroFormFactor.tv,
+          inputDevices: const {AiroInputDevice.remote},
+          viewingDistance: AiroViewingDistance.couch,
+          windowClass: AiroWindowClass.fullBleed,
+          orientation: AiroOrientation.landscape,
+          profileHint: AiroProductUiProfileHint.experimentalLegacy,
+        ),
+      );
+
+      expect(mode.density, AiroUiDensity.compact);
+      expect(mode.artworkPolicy, AiroArtworkPolicy.minimal);
+      expect(mode.motionPolicy, AiroMotionPolicy.reduced);
+      expect(mode.focusBehavior, AiroFocusBehavior.dpadRequired);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Adds the v2 adaptive UI mode platform contract for Airo TV and companion surfaces.

## Changes

- Extends `packages/core_ui` with adaptive mode inputs and resolver outputs.
- Models form factor, input devices, viewing distance, density, focus behavior, motion, artwork, navigation, and accessibility preferences.
- Adds deterministic policy tests for TV remote, phone touch, desktop pointer, hybrid input, accessibility, and constrained receiver profiles.
- Documents the adaptive UI boundary in `docs/features/airo-tv/ADAPTIVE_UI_MODE_CONTRACT.md`.

## Testing

- `dart format --set-exit-if-changed packages/core_ui`
- `cd packages/core_ui && flutter test`
- `cd packages/core_ui && flutter analyze --fatal-infos`
- `git diff --check HEAD~1..HEAD`

Closes #607