### PR TITLE
feat(platform): add media routing engine contract

### DIFF
--- a/docs/features/airo-tv/MEDIA_ROUTING_ENGINE_CONTRACT.md
+++ b/docs/features/airo-tv/MEDIA_ROUTING_ENGINE_CONTRACT.md
@@ -1,0 +1,57 @@
+# Airo TV Media Routing Engine Contract
+
+This contract defines the v2.0.0.1 platform boundary for media route
+preflight and route selection. The goal is direct playback first and
+phone-proxy playback only as an explicit last resort.
+
+Implementation contract:
+
+- Package: `packages/core_media_routing`
+- Schema: `kAiroMediaRoutingSchemaVersion`
+- Engine interface: `AiroMediaRoutingEngine`
+- Default policy: `AiroDeterministicMediaRoutingEngine`
+- Current release branch: `codex/next-v2.0.0.0`
+
+## Route Priority
+
+The deterministic route order is:
+
+1. Receiver direct playback.
+2. LAN direct playback.
+3. Server direct playback.
+4. Desktop relay.
+5. Phone proxy.
+
+Cloud command/state orchestration is not a media path and must not be selected
+for video transport.
+
+## Preflight Rules
+
+A candidate is rejected before route selection when it is unavailable,
+untrusted, expired, codec-incompatible, direct playback is unsupported, cloud
+command-only, or a phone proxy without the required last-resort confirmation.
+
+Phone proxy is eligible only when no non-phone media route is eligible and the
+user has explicitly confirmed the fallback. This prevents phone-as-default
+server behavior.
+
+## Privacy Rule
+
+Route candidates use redacted source handles. Decisions and diagnostics expose
+candidate ids, route kind, source kind, and blocker codes only. They must not
+include raw URLs, local file paths, local IP addresses, provider auth material,
+playlist contents, or credential-bearing diagnostics.
+
+## Consumer Rule
+
+Airo TV screens, playback engines, local discovery adapters, and future route
+inspectors should consume `AiroMediaRoutingEngine` decisions. Product code may
+present user-facing fallback prompts, but it should not implement separate route
+priority or phone-proxy eligibility logic.
+
+## Out Of Scope
+
+This issue does not define the complete media-location schema, route-handle
+service, weighted route scoring, decision-log export, playback ownership model,
+route health events, phone media server implementation, NAS adapters, cloud
+orchestration service, playback engine changes, or route picker UI.

--- a/packages/core_media_routing/CHANGELOG.md
+++ b/packages/core_media_routing/CHANGELOG.md
@@ -1,0 +1,3 @@
+## 0.0.1
+
+- Added initial media routing engine contracts.

--- a/packages/core_media_routing/README.md
+++ b/packages/core_media_routing/README.md
@@ -1,0 +1,21 @@
+# Core Media Routing
+
+Reusable Media Routing Engine contracts for Airo products.
+
+This package is platform/framework code. Airo TV, companion controllers,
+playback engines, local discovery, session ownership, and QA automation consume
+these contracts to choose a media path without hard-coding route priority in
+product screens.
+
+## Scope
+
+- Versioned media routing request, candidate, policy, blocker, and decision
+  models.
+- Deterministic route preflight and selection.
+- Direct receiver playback preference before relay or phone-proxy fallback.
+- Privacy-safe diagnostics that expose ids and blocker codes, not raw source
+  values.
+
+This package does not start a media server, open playback, inspect codecs from a
+platform SDK, define full media-location schemas, collect route health events,
+or own playback-session state.

--- a/packages/core_media_routing/analysis_options.yaml
+++ b/packages/core_media_routing/analysis_options.yaml
@@ -1,0 +1,4 @@
+include: package:flutter_lints/flutter.yaml
+
+linter:
+  rules:

--- a/packages/core_media_routing/lib/core_media_routing.dart
+++ b/packages/core_media_routing/lib/core_media_routing.dart
@@ -1,0 +1,3 @@
+library;
+
+export 'src/media_routing_models.dart';

--- a/packages/core_media_routing/lib/src/media_routing_models.dart
+++ b/packages/core_media_routing/lib/src/media_routing_models.dart
@@ -1,0 +1,368 @@
+import 'dart:async';
+
+import 'package:equatable/equatable.dart';
+
+const String kAiroMediaRoutingSchemaVersion = '1.0.0';
+
+enum AiroMediaRouteIntent {
+  play('play'),
+  resume('resume'),
+  handoff('handoff'),
+  preview('preview');
+
+  const AiroMediaRouteIntent(this.stableId);
+
+  final String stableId;
+}
+
+enum AiroMediaRouteKind {
+  receiverDirect('receiver_direct'),
+  lanDirect('lan_direct'),
+  serverDirect('server_direct'),
+  desktopRelay('desktop_relay'),
+  phoneProxy('phone_proxy'),
+  cloudCommandOnly('cloud_command_only');
+
+  const AiroMediaRouteKind(this.stableId);
+
+  final String stableId;
+
+  bool get isPhoneProxy => this == phoneProxy;
+
+  bool get canCarryMedia => this != cloudCommandOnly;
+}
+
+enum AiroMediaSourceKind {
+  internet('internet'),
+  iptv('iptv'),
+  lanServer('lan_server'),
+  nas('nas'),
+  desktop('desktop'),
+  phoneLocal('phone_local'),
+  cloudStateOnly('cloud_state_only');
+
+  const AiroMediaSourceKind(this.stableId);
+
+  final String stableId;
+}
+
+enum AiroMediaRouteBlockerCode {
+  unavailable('unavailable'),
+  untrusted('untrusted'),
+  directPlaybackUnsupported('direct_playback_unsupported'),
+  codecUnsupported('codec_unsupported'),
+  unsafeSourceHandle('unsafe_source_handle'),
+  expired('expired'),
+  phoneProxyRequiresConfirmation('phone_proxy_requires_confirmation'),
+  cloudCannotCarryMedia('cloud_cannot_carry_media'),
+  noEligibleRoute('no_eligible_route');
+
+  const AiroMediaRouteBlockerCode(this.stableId);
+
+  final String stableId;
+}
+
+enum AiroMediaRouteSourceHandleRejectionCode {
+  empty('empty'),
+  urlValue('url_value'),
+  localPathValue('local_path_value'),
+  localIpValue('local_ip_value'),
+  credentialLikeValue('credential_like_value');
+
+  const AiroMediaRouteSourceHandleRejectionCode(this.stableId);
+
+  final String stableId;
+}
+
+class AiroMediaRouteSourceHandle extends Equatable {
+  const AiroMediaRouteSourceHandle._(this.value);
+
+  factory AiroMediaRouteSourceHandle.redacted(String value) {
+    final rejection = validate(value);
+    if (rejection != null) {
+      throw ArgumentError.value(value, 'value', rejection.stableId);
+    }
+    return AiroMediaRouteSourceHandle._(value.trim());
+  }
+
+  final String value;
+
+  static AiroMediaRouteSourceHandleRejectionCode? validate(String value) {
+    final trimmed = value.trim();
+    if (trimmed.isEmpty) {
+      return AiroMediaRouteSourceHandleRejectionCode.empty;
+    }
+
+    final uri = Uri.tryParse(trimmed);
+    if (uri != null && (uri.scheme == 'http' || uri.scheme == 'https')) {
+      return AiroMediaRouteSourceHandleRejectionCode.urlValue;
+    }
+    if (trimmed.startsWith('file://') ||
+        trimmed.startsWith('/') ||
+        RegExp(r'^[A-Za-z]:\\').hasMatch(trimmed)) {
+      return AiroMediaRouteSourceHandleRejectionCode.localPathValue;
+    }
+    if (RegExp(
+      r'\b(?:10|127|172\.(?:1[6-9]|2\d|3[0-1])|192\.168)\.',
+    ).hasMatch(trimmed)) {
+      return AiroMediaRouteSourceHandleRejectionCode.localIpValue;
+    }
+    if (RegExp(
+      r'\b(?:bearer|basic)\s+[A-Za-z0-9._~+/=-]+',
+      caseSensitive: false,
+    ).hasMatch(trimmed)) {
+      return AiroMediaRouteSourceHandleRejectionCode.credentialLikeValue;
+    }
+
+    return null;
+  }
+
+  @override
+  String toString() => 'AiroMediaRouteSourceHandle(redacted)';
+
+  @override
+  List<Object?> get props => [value];
+}
+
+class AiroMediaRouteCandidate extends Equatable {
+  AiroMediaRouteCandidate({
+    required this.candidateId,
+    required this.kind,
+    required this.sourceKind,
+    required this.sourceHandle,
+    required this.playbackNodeId,
+    required this.sourceNodeId,
+    Set<String> supportedCodecs = const {},
+    this.isAvailable = true,
+    this.isTrusted = true,
+    this.supportsDirectPlayback = true,
+    this.expiresAt,
+    this.schemaVersion = kAiroMediaRoutingSchemaVersion,
+  }) : supportedCodecs = Set.unmodifiable(supportedCodecs);
+
+  final String schemaVersion;
+  final String candidateId;
+  final AiroMediaRouteKind kind;
+  final AiroMediaSourceKind sourceKind;
+  final AiroMediaRouteSourceHandle sourceHandle;
+  final String playbackNodeId;
+  final String sourceNodeId;
+  final Set<String> supportedCodecs;
+  final bool isAvailable;
+  final bool isTrusted;
+  final bool supportsDirectPlayback;
+  final DateTime? expiresAt;
+
+  bool isExpired(DateTime now) =>
+      expiresAt != null && !now.isBefore(expiresAt!);
+
+  bool supportsAllCodecs(Set<String> requiredCodecs) =>
+      requiredCodecs.isEmpty || supportedCodecs.containsAll(requiredCodecs);
+
+  @override
+  String toString() {
+    return 'AiroMediaRouteCandidate('
+        'candidateId: $candidateId, '
+        'kind: ${kind.stableId}, '
+        'sourceKind: ${sourceKind.stableId}, '
+        'playbackNodeId: $playbackNodeId, '
+        'sourceNodeId: $sourceNodeId, '
+        'sourceHandle: redacted'
+        ')';
+  }
+
+  @override
+  List<Object?> get props => [
+    schemaVersion,
+    candidateId,
+    kind,
+    sourceKind,
+    sourceHandle,
+    playbackNodeId,
+    sourceNodeId,
+    supportedCodecs,
+    isAvailable,
+    isTrusted,
+    supportsDirectPlayback,
+    expiresAt,
+  ];
+}
+
+class AiroMediaRouteRequest extends Equatable {
+  AiroMediaRouteRequest({
+    required this.requestId,
+    required this.intent,
+    required this.requestedAt,
+    required Iterable<AiroMediaRouteCandidate> candidates,
+    Set<String> requiredCodecs = const {},
+    this.userConfirmedPhoneProxy = false,
+    this.schemaVersion = kAiroMediaRoutingSchemaVersion,
+  }) : candidates = List.unmodifiable(candidates),
+       requiredCodecs = Set.unmodifiable(requiredCodecs);
+
+  final String schemaVersion;
+  final String requestId;
+  final AiroMediaRouteIntent intent;
+  final DateTime requestedAt;
+  final List<AiroMediaRouteCandidate> candidates;
+  final Set<String> requiredCodecs;
+  final bool userConfirmedPhoneProxy;
+
+  @override
+  List<Object?> get props => [
+    schemaVersion,
+    requestId,
+    intent,
+    requestedAt,
+    candidates,
+    requiredCodecs,
+    userConfirmedPhoneProxy,
+  ];
+}
+
+class AiroMediaRouteEvaluation extends Equatable {
+  AiroMediaRouteEvaluation({
+    required this.candidate,
+    required List<AiroMediaRouteBlockerCode> blockers,
+  }) : blockers = List.unmodifiable(blockers);
+
+  final AiroMediaRouteCandidate candidate;
+  final List<AiroMediaRouteBlockerCode> blockers;
+
+  bool get eligible => blockers.isEmpty;
+
+  @override
+  List<Object?> get props => [candidate, blockers];
+}
+
+class AiroMediaRouteDecision extends Equatable {
+  AiroMediaRouteDecision({
+    required this.requestId,
+    required Iterable<AiroMediaRouteEvaluation> evaluations,
+    required this.selected,
+    this.schemaVersion = kAiroMediaRoutingSchemaVersion,
+  }) : evaluations = List.unmodifiable(evaluations);
+
+  final String schemaVersion;
+  final String requestId;
+  final List<AiroMediaRouteEvaluation> evaluations;
+  final AiroMediaRouteEvaluation? selected;
+
+  bool get hasRoute => selected != null;
+
+  AiroMediaRouteKind? get selectedKind => selected?.candidate.kind;
+
+  List<AiroMediaRouteEvaluation> get rejected =>
+      evaluations.where((evaluation) => !evaluation.eligible).toList();
+
+  @override
+  String toString() {
+    return 'AiroMediaRouteDecision('
+        'requestId: $requestId, '
+        'selectedCandidateId: ${selected?.candidate.candidateId}, '
+        'selectedKind: ${selected?.candidate.kind.stableId}, '
+        'rejections: ${rejected.map((evaluation) => {'candidateId': evaluation.candidate.candidateId, 'blockers': evaluation.blockers.map((code) => code.stableId)}).toList()}'
+        ')';
+  }
+
+  @override
+  List<Object?> get props => [schemaVersion, requestId, evaluations, selected];
+}
+
+abstract interface class AiroMediaRoutingEngine {
+  FutureOr<AiroMediaRouteDecision> selectRoute(AiroMediaRouteRequest request);
+}
+
+class AiroDeterministicMediaRoutingEngine implements AiroMediaRoutingEngine {
+  const AiroDeterministicMediaRoutingEngine();
+
+  @override
+  AiroMediaRouteDecision selectRoute(AiroMediaRouteRequest request) {
+    final baselineEvaluations = [
+      for (final candidate in request.candidates)
+        AiroMediaRouteEvaluation(
+          candidate: candidate,
+          blockers: _baselineBlockers(request, candidate),
+        ),
+    ];
+    final hasNonPhoneEligible = baselineEvaluations.any(
+      (evaluation) =>
+          evaluation.eligible && !evaluation.candidate.kind.isPhoneProxy,
+    );
+
+    final evaluations = [
+      for (final evaluation in baselineEvaluations)
+        if (evaluation.candidate.kind.isPhoneProxy)
+          AiroMediaRouteEvaluation(
+            candidate: evaluation.candidate,
+            blockers: [
+              ...evaluation.blockers,
+              if (hasNonPhoneEligible || !request.userConfirmedPhoneProxy)
+                AiroMediaRouteBlockerCode.phoneProxyRequiresConfirmation,
+            ],
+          )
+        else
+          evaluation,
+    ];
+
+    final eligible =
+        evaluations.where((evaluation) => evaluation.eligible).toList()
+          ..sort(_compareEvaluations);
+
+    return AiroMediaRouteDecision(
+      requestId: request.requestId,
+      evaluations: evaluations,
+      selected: eligible.isEmpty ? null : eligible.first,
+    );
+  }
+
+  List<AiroMediaRouteBlockerCode> _baselineBlockers(
+    AiroMediaRouteRequest request,
+    AiroMediaRouteCandidate candidate,
+  ) {
+    final blockers = <AiroMediaRouteBlockerCode>[];
+    if (!candidate.kind.canCarryMedia) {
+      blockers.add(AiroMediaRouteBlockerCode.cloudCannotCarryMedia);
+    }
+    if (!candidate.isAvailable) {
+      blockers.add(AiroMediaRouteBlockerCode.unavailable);
+    }
+    if (!candidate.isTrusted) {
+      blockers.add(AiroMediaRouteBlockerCode.untrusted);
+    }
+    if (!candidate.supportsDirectPlayback &&
+        !candidate.kind.isPhoneProxy &&
+        candidate.kind.canCarryMedia) {
+      blockers.add(AiroMediaRouteBlockerCode.directPlaybackUnsupported);
+    }
+    if (!candidate.supportsAllCodecs(request.requiredCodecs)) {
+      blockers.add(AiroMediaRouteBlockerCode.codecUnsupported);
+    }
+    if (candidate.isExpired(request.requestedAt)) {
+      blockers.add(AiroMediaRouteBlockerCode.expired);
+    }
+    return blockers;
+  }
+
+  int _compareEvaluations(
+    AiroMediaRouteEvaluation left,
+    AiroMediaRouteEvaluation right,
+  ) {
+    final priority = _routePriority(
+      right.candidate.kind,
+    ).compareTo(_routePriority(left.candidate.kind));
+    if (priority != 0) return priority;
+    return left.candidate.candidateId.compareTo(right.candidate.candidateId);
+  }
+
+  int _routePriority(AiroMediaRouteKind kind) {
+    return switch (kind) {
+      AiroMediaRouteKind.receiverDirect => 100,
+      AiroMediaRouteKind.lanDirect => 90,
+      AiroMediaRouteKind.serverDirect => 80,
+      AiroMediaRouteKind.desktopRelay => 70,
+      AiroMediaRouteKind.phoneProxy => 10,
+      AiroMediaRouteKind.cloudCommandOnly => -100,
+    };
+  }
+}

--- a/packages/core_media_routing/pubspec.yaml
+++ b/packages/core_media_routing/pubspec.yaml
@@ -1,0 +1,21 @@
+name: core_media_routing
+description: Media routing engine contracts for Airo products.
+version: 0.0.1
+homepage:
+publish_to: none
+
+environment:
+  sdk: ^3.12.2
+  flutter: ">=1.17.0"
+
+dependencies:
+  equatable: ^2.0.8
+  flutter:
+    sdk: flutter
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+  flutter_lints: ^6.0.0
+
+flutter:

--- a/packages/core_media_routing/test/media_routing_models_test.dart
+++ b/packages/core_media_routing/test/media_routing_models_test.dart
@@ -1,0 +1,200 @@
+import 'package:core_media_routing/core_media_routing.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('AiroDeterministicMediaRoutingEngine', () {
+    const engine = AiroDeterministicMediaRoutingEngine();
+    final now = DateTime.utc(2026, 7, 14, 12);
+
+    AiroMediaRouteCandidate candidate({
+      required String id,
+      required AiroMediaRouteKind kind,
+      AiroMediaSourceKind sourceKind = AiroMediaSourceKind.iptv,
+      Set<String> codecs = const {'h264', 'aac'},
+      bool available = true,
+      bool trusted = true,
+      bool direct = true,
+      DateTime? expiresAt,
+    }) {
+      return AiroMediaRouteCandidate(
+        candidateId: id,
+        kind: kind,
+        sourceKind: sourceKind,
+        sourceHandle: AiroMediaRouteSourceHandle.redacted('source-$id'),
+        playbackNodeId: 'receiver-1',
+        sourceNodeId: 'source-1',
+        supportedCodecs: codecs,
+        isAvailable: available,
+        isTrusted: trusted,
+        supportsDirectPlayback: direct,
+        expiresAt: expiresAt,
+      );
+    }
+
+    AiroMediaRouteRequest request({
+      required List<AiroMediaRouteCandidate> candidates,
+      bool userConfirmedPhoneProxy = false,
+      Set<String> requiredCodecs = const {'h264', 'aac'},
+    }) {
+      return AiroMediaRouteRequest(
+        requestId: 'request-1',
+        intent: AiroMediaRouteIntent.play,
+        requestedAt: now,
+        candidates: candidates,
+        requiredCodecs: requiredCodecs,
+        userConfirmedPhoneProxy: userConfirmedPhoneProxy,
+      );
+    }
+
+    test('selects direct receiver route before phone proxy', () {
+      final direct = candidate(
+        id: 'direct',
+        kind: AiroMediaRouteKind.receiverDirect,
+      );
+      final phone = candidate(
+        id: 'phone',
+        kind: AiroMediaRouteKind.phoneProxy,
+        sourceKind: AiroMediaSourceKind.phoneLocal,
+      );
+
+      final decision = engine.selectRoute(
+        request(candidates: [phone, direct], userConfirmedPhoneProxy: true),
+      );
+
+      expect(decision.selected?.candidate, direct);
+      expect(decision.selectedKind, AiroMediaRouteKind.receiverDirect);
+      expect(
+        decision.rejected
+            .singleWhere((evaluation) => evaluation.candidate == phone)
+            .blockers,
+        contains(AiroMediaRouteBlockerCode.phoneProxyRequiresConfirmation),
+      );
+    });
+
+    test(
+      'selects phone proxy only when confirmed and no direct route exists',
+      () {
+        final phone = candidate(
+          id: 'phone',
+          kind: AiroMediaRouteKind.phoneProxy,
+          sourceKind: AiroMediaSourceKind.phoneLocal,
+        );
+
+        final decision = engine.selectRoute(
+          request(candidates: [phone], userConfirmedPhoneProxy: true),
+        );
+
+        expect(decision.selected?.candidate, phone);
+        expect(decision.selectedKind, AiroMediaRouteKind.phoneProxy);
+        expect(decision.hasRoute, isTrue);
+      },
+    );
+
+    test('rejects phone proxy without user confirmation', () {
+      final phone = candidate(
+        id: 'phone',
+        kind: AiroMediaRouteKind.phoneProxy,
+        sourceKind: AiroMediaSourceKind.phoneLocal,
+      );
+
+      final decision = engine.selectRoute(request(candidates: [phone]));
+
+      expect(decision.hasRoute, isFalse);
+      expect(
+        decision.rejected.single.blockers,
+        contains(AiroMediaRouteBlockerCode.phoneProxyRequiresConfirmation),
+      );
+    });
+
+    test('rejects untrusted expired and codec-incompatible candidates', () {
+      final untrusted = candidate(
+        id: 'untrusted',
+        kind: AiroMediaRouteKind.receiverDirect,
+        trusted: false,
+      );
+      final expired = candidate(
+        id: 'expired',
+        kind: AiroMediaRouteKind.lanDirect,
+        expiresAt: now,
+      );
+      final codecMismatch = candidate(
+        id: 'codec',
+        kind: AiroMediaRouteKind.serverDirect,
+        codecs: const {'h264'},
+      );
+
+      final decision = engine.selectRoute(
+        request(candidates: [untrusted, expired, codecMismatch]),
+      );
+
+      expect(decision.hasRoute, isFalse);
+      expect(
+        decision.rejected
+            .singleWhere((evaluation) => evaluation.candidate == untrusted)
+            .blockers,
+        contains(AiroMediaRouteBlockerCode.untrusted),
+      );
+      expect(
+        decision.rejected
+            .singleWhere((evaluation) => evaluation.candidate == expired)
+            .blockers,
+        contains(AiroMediaRouteBlockerCode.expired),
+      );
+      expect(
+        decision.rejected
+            .singleWhere((evaluation) => evaluation.candidate == codecMismatch)
+            .blockers,
+        contains(AiroMediaRouteBlockerCode.codecUnsupported),
+      );
+    });
+
+    test('never selects cloud command route as a media path', () {
+      final cloud = candidate(
+        id: 'cloud',
+        kind: AiroMediaRouteKind.cloudCommandOnly,
+        sourceKind: AiroMediaSourceKind.cloudStateOnly,
+      );
+
+      final decision = engine.selectRoute(request(candidates: [cloud]));
+
+      expect(decision.hasRoute, isFalse);
+      expect(
+        decision.rejected.single.blockers,
+        contains(AiroMediaRouteBlockerCode.cloudCannotCarryMedia),
+      );
+    });
+
+    test('decision diagnostics do not expose source handle values', () {
+      final direct = candidate(
+        id: 'direct',
+        kind: AiroMediaRouteKind.receiverDirect,
+      );
+
+      final decision = engine.selectRoute(request(candidates: [direct]));
+
+      expect(decision.toString(), isNot(contains('source-direct')));
+      expect(direct.toString(), contains('sourceHandle: redacted'));
+    });
+  });
+
+  group('AiroMediaRouteSourceHandle', () {
+    test('rejects unsafe source values at the boundary', () {
+      expect(
+        AiroMediaRouteSourceHandle.validate('https://example.com/stream.m3u8'),
+        AiroMediaRouteSourceHandleRejectionCode.urlValue,
+      );
+      expect(
+        AiroMediaRouteSourceHandle.validate('http://192.168.1.4/live'),
+        AiroMediaRouteSourceHandleRejectionCode.urlValue,
+      );
+      expect(
+        AiroMediaRouteSourceHandle.validate('/tmp/live.m3u8'),
+        AiroMediaRouteSourceHandleRejectionCode.localPathValue,
+      );
+      expect(
+        AiroMediaRouteSourceHandle.validate('Bearer abc123'),
+        AiroMediaRouteSourceHandleRejectionCode.credentialLikeValue,
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Adds the v2 Media Routing Engine platform contract for Airo TV playback delegation.

## Changes

- Adds `packages/core_media_routing` as the reusable route preflight and selection boundary.
- Prefers direct receiver playback before phone proxy routes.
- Blocks cloud command routes from being selected as media paths.
- Allows phone proxy only as a confirmed last-resort fallback.
- Redacts raw media source values from diagnostics and string output.
- Documents the media routing boundary in `docs/features/airo-tv/MEDIA_ROUTING_ENGINE_CONTRACT.md`.

## Testing

- `dart format --set-exit-if-changed packages/core_media_routing`
- `cd packages/core_media_routing && flutter test`
- `cd packages/core_media_routing && flutter analyze --fatal-infos`
- `git diff --check HEAD~1..HEAD`

Closes #609