### PR TITLE
feat(platform): add media location access models

### DIFF
--- a/docs/features/airo-tv/MEDIA_LOCATION_ACCESS_MODEL.md
+++ b/docs/features/airo-tv/MEDIA_LOCATION_ACCESS_MODEL.md
@@ -1,0 +1,66 @@
+# Airo TV Media Location And Access Model
+
+This contract defines the v2.0.0.1 platform boundary for representing where
+media can be reached and how a receiver is granted scoped playback access
+without leaking source values.
+
+Implementation contract:
+
+- Package: `packages/core_media_routing`
+- Schema: `kAiroMediaLocationSchemaVersion`
+- Location model: `AiroMediaLocation`
+- Access model: `AiroRouteAccessGrant`
+- Release-line base: `origin/v2`
+
+## Location Kinds
+
+`AiroMediaLocation` supports:
+
+- public internet and IPTV streams;
+- authenticated internet streams;
+- LAN HTTP sources;
+- NAS share items;
+- media server items;
+- local files;
+- phone-local files;
+- TV removable-storage files;
+- desktop files;
+- temporary HTTP access paths.
+
+Locations are classified by locality: internet, local network, device-local,
+removable storage, or relay. A location can require local-network scope,
+trusted-device scope, expiry, range reads, and probe reads.
+
+## Access Grants
+
+`AiroRouteAccessGrant` is receiver-bound and expiring. It declares:
+
+- grant id;
+- location id;
+- audience node id;
+- issued and expiry times;
+- playback, range, metadata, and probe scopes;
+- trusted-device requirement;
+- redacted access handle.
+
+Grants validate against the requesting receiver, required scopes, trusted-device
+state, and both grant and location expiry.
+
+## Privacy Rule
+
+Locations and grants use redacted handles. They must not expose raw URLs, local
+paths, local IP addresses, provider auth material, playlist contents, or
+credential-like diagnostics in logs, analytics, UI, or route decisions.
+
+## Consumer Rule
+
+Media routing, playback engines, local discovery adapters, companion
+controllers, and Airo TV screens should consume location ids, locality, kind,
+scope, and validation results. Product code should not pass raw source values
+through navigation arguments, analytics events, diagnostics, or route decisions.
+
+## Out Of Scope
+
+This issue does not implement a temporary HTTP server, NAS adapter, cloud
+storage backend, DRM license flow, playback-ticket service, weighted route
+scoring, playback ownership, or playback execution.

--- a/packages/core_media_routing/README.md
+++ b/packages/core_media_routing/README.md
@@ -11,11 +11,14 @@ product screens.
 
 - Versioned media routing request, candidate, policy, blocker, and decision
   models.
+- Versioned media location and route access-grant models.
 - Deterministic route preflight and selection.
 - Direct receiver playback preference before relay or phone-proxy fallback.
+- Redacted source and access handles for cloud, LAN, server, local file,
+  phone-local, TV removable, desktop, and temporary access paths.
 - Privacy-safe diagnostics that expose ids and blocker codes, not raw source
   values.
 
 This package does not start a media server, open playback, inspect codecs from a
-platform SDK, define full media-location schemas, collect route health events,
-or own playback-session state.
+platform SDK, collect route health events, issue playback access grants, or own
+playback-session state.

--- a/packages/core_media_routing/lib/core_media_routing.dart
+++ b/packages/core_media_routing/lib/core_media_routing.dart
@@ -1,3 +1,4 @@
 library;
 
+export 'src/media_location_models.dart';
 export 'src/media_routing_models.dart';

--- a/packages/core_media_routing/lib/src/media_location_models.dart
+++ b/packages/core_media_routing/lib/src/media_location_models.dart
@@ -1,0 +1,366 @@
+import 'package:equatable/equatable.dart';
+
+const String kAiroMediaLocationSchemaVersion = '1.0.0';
+
+enum AiroMediaLocationKind {
+  publicInternet('public_internet'),
+  authenticatedInternet('authenticated_internet'),
+  iptvStream('iptv_stream'),
+  lanHttp('lan_http'),
+  nasShareItem('nas_share_item'),
+  mediaServerItem('media_server_item'),
+  localFile('local_file'),
+  phoneLocalFile('phone_local_file'),
+  tvRemovableFile('tv_removable_file'),
+  desktopFile('desktop_file'),
+  temporaryHttpAccess('temporary_http_access');
+
+  const AiroMediaLocationKind(this.stableId);
+
+  final String stableId;
+}
+
+enum AiroMediaLocationLocality {
+  internet('internet'),
+  localNetwork('local_network'),
+  deviceLocal('device_local'),
+  removableStorage('removable_storage'),
+  relay('relay');
+
+  const AiroMediaLocationLocality(this.stableId);
+
+  final String stableId;
+}
+
+enum AiroRouteAccessScope {
+  playbackRead('playback_read'),
+  rangeRead('range_read'),
+  metadataRead('metadata_read'),
+  probeRead('probe_read');
+
+  const AiroRouteAccessScope(this.stableId);
+
+  final String stableId;
+}
+
+enum AiroRouteAccessHandleRejectionCode {
+  empty('empty'),
+  urlValue('url_value'),
+  localPathValue('local_path_value'),
+  localIpValue('local_ip_value'),
+  credentialLikeValue('credential_like_value');
+
+  const AiroRouteAccessHandleRejectionCode(this.stableId);
+
+  final String stableId;
+}
+
+enum AiroMediaLocationValidationCode {
+  accepted('accepted'),
+  expired('expired'),
+  localNetworkScopeMissing('local_network_scope_missing'),
+  trustedDeviceScopeMissing('trusted_device_scope_missing'),
+  temporaryAccessExpiryMissing('temporary_access_expiry_missing');
+
+  const AiroMediaLocationValidationCode(this.stableId);
+
+  final String stableId;
+}
+
+enum AiroRouteAccessGrantValidationCode {
+  accepted('accepted'),
+  locationExpired('location_expired'),
+  grantExpired('grant_expired'),
+  wrongAudience('wrong_audience'),
+  scopeMissing('scope_missing'),
+  trustedDeviceScopeMissing('trusted_device_scope_missing');
+
+  const AiroRouteAccessGrantValidationCode(this.stableId);
+
+  final String stableId;
+}
+
+class AiroRouteAccessHandle extends Equatable {
+  const AiroRouteAccessHandle._(this.value);
+
+  factory AiroRouteAccessHandle.redacted(String value) {
+    final rejection = validate(value);
+    if (rejection != null) {
+      throw ArgumentError.value(value, 'value', rejection.stableId);
+    }
+    return AiroRouteAccessHandle._(value.trim());
+  }
+
+  final String value;
+
+  static AiroRouteAccessHandleRejectionCode? validate(String value) {
+    final trimmed = value.trim();
+    if (trimmed.isEmpty) return AiroRouteAccessHandleRejectionCode.empty;
+
+    final uri = Uri.tryParse(trimmed);
+    if (uri != null && (uri.scheme == 'http' || uri.scheme == 'https')) {
+      return AiroRouteAccessHandleRejectionCode.urlValue;
+    }
+    if (trimmed.startsWith('file://') ||
+        trimmed.startsWith('/') ||
+        RegExp(r'^[A-Za-z]:\\').hasMatch(trimmed)) {
+      return AiroRouteAccessHandleRejectionCode.localPathValue;
+    }
+    if (RegExp(
+      r'\b(?:10|127|172\.(?:1[6-9]|2\d|3[0-1])|192\.168)\.',
+    ).hasMatch(trimmed)) {
+      return AiroRouteAccessHandleRejectionCode.localIpValue;
+    }
+    if (RegExp(
+      r'\b(?:bearer|basic)\s+[A-Za-z0-9._~+/=-]+',
+      caseSensitive: false,
+    ).hasMatch(trimmed)) {
+      return AiroRouteAccessHandleRejectionCode.credentialLikeValue;
+    }
+
+    return null;
+  }
+
+  @override
+  String toString() => 'AiroRouteAccessHandle(redacted)';
+
+  @override
+  List<Object?> get props => [value];
+}
+
+class AiroMediaLocation extends Equatable {
+  const AiroMediaLocation({
+    required this.locationId,
+    required this.mediaId,
+    required this.kind,
+    required this.locality,
+    required this.accessHandle,
+    this.ownerNodeId,
+    this.expiresAt,
+    this.requiresLocalNetworkScope = false,
+    this.requiresTrustedDeviceScope = false,
+    this.supportsRangeRequests = false,
+    this.supportsProbeRequests = false,
+    this.schemaVersion = kAiroMediaLocationSchemaVersion,
+  });
+
+  final String schemaVersion;
+  final String locationId;
+  final String mediaId;
+  final AiroMediaLocationKind kind;
+  final AiroMediaLocationLocality locality;
+  final AiroRouteAccessHandle accessHandle;
+  final String? ownerNodeId;
+  final DateTime? expiresAt;
+  final bool requiresLocalNetworkScope;
+  final bool requiresTrustedDeviceScope;
+  final bool supportsRangeRequests;
+  final bool supportsProbeRequests;
+
+  bool get isTemporaryAccess =>
+      kind == AiroMediaLocationKind.temporaryHttpAccess;
+
+  bool isExpired(DateTime now) =>
+      expiresAt != null && !now.isBefore(expiresAt!);
+
+  @override
+  String toString() {
+    return 'AiroMediaLocation('
+        'locationId: $locationId, '
+        'mediaId: $mediaId, '
+        'kind: ${kind.stableId}, '
+        'locality: ${locality.stableId}, '
+        'ownerNodeId: $ownerNodeId, '
+        'accessHandle: redacted, '
+        'expiresAt: $expiresAt'
+        ')';
+  }
+
+  @override
+  List<Object?> get props => [
+    schemaVersion,
+    locationId,
+    mediaId,
+    kind,
+    locality,
+    accessHandle,
+    ownerNodeId,
+    expiresAt,
+    requiresLocalNetworkScope,
+    requiresTrustedDeviceScope,
+    supportsRangeRequests,
+    supportsProbeRequests,
+  ];
+}
+
+class AiroMediaLocationValidationContext extends Equatable {
+  const AiroMediaLocationValidationContext({
+    required this.now,
+    this.hasLocalNetworkScope = false,
+    this.hasTrustedDeviceScope = false,
+  });
+
+  final DateTime now;
+  final bool hasLocalNetworkScope;
+  final bool hasTrustedDeviceScope;
+
+  @override
+  List<Object?> get props => [now, hasLocalNetworkScope, hasTrustedDeviceScope];
+}
+
+class AiroMediaLocationValidationResult extends Equatable {
+  AiroMediaLocationValidationResult({
+    required this.locationId,
+    required List<AiroMediaLocationValidationCode> codes,
+  }) : codes = List.unmodifiable(codes);
+
+  final String locationId;
+  final List<AiroMediaLocationValidationCode> codes;
+
+  bool get accepted =>
+      codes.length == 1 &&
+      codes.single == AiroMediaLocationValidationCode.accepted;
+
+  @override
+  List<Object?> get props => [locationId, codes];
+}
+
+class AiroMediaLocationPolicy {
+  const AiroMediaLocationPolicy();
+
+  AiroMediaLocationValidationResult validate({
+    required AiroMediaLocation location,
+    required AiroMediaLocationValidationContext context,
+  }) {
+    final codes = <AiroMediaLocationValidationCode>[];
+    if (location.isExpired(context.now)) {
+      codes.add(AiroMediaLocationValidationCode.expired);
+    }
+    if (location.requiresLocalNetworkScope && !context.hasLocalNetworkScope) {
+      codes.add(AiroMediaLocationValidationCode.localNetworkScopeMissing);
+    }
+    if (location.requiresTrustedDeviceScope && !context.hasTrustedDeviceScope) {
+      codes.add(AiroMediaLocationValidationCode.trustedDeviceScopeMissing);
+    }
+    if (location.isTemporaryAccess && location.expiresAt == null) {
+      codes.add(AiroMediaLocationValidationCode.temporaryAccessExpiryMissing);
+    }
+
+    return AiroMediaLocationValidationResult(
+      locationId: location.locationId,
+      codes: codes.isEmpty
+          ? const [AiroMediaLocationValidationCode.accepted]
+          : codes,
+    );
+  }
+}
+
+class AiroRouteAccessGrant extends Equatable {
+  AiroRouteAccessGrant({
+    required this.grantId,
+    required this.locationId,
+    required this.audienceNodeId,
+    required this.handle,
+    required this.issuedAt,
+    required this.expiresAt,
+    required Set<AiroRouteAccessScope> scopes,
+    this.requiresTrustedDeviceScope = true,
+    this.schemaVersion = kAiroMediaLocationSchemaVersion,
+  }) : scopes = Set.unmodifiable(scopes);
+
+  final String schemaVersion;
+  final String grantId;
+  final String locationId;
+  final String audienceNodeId;
+  final AiroRouteAccessHandle handle;
+  final DateTime issuedAt;
+  final DateTime expiresAt;
+  final Set<AiroRouteAccessScope> scopes;
+  final bool requiresTrustedDeviceScope;
+
+  bool isExpired(DateTime now) => !now.isBefore(expiresAt);
+
+  bool isBoundTo(String nodeId) => audienceNodeId == nodeId;
+
+  bool allowsAll(Set<AiroRouteAccessScope> requiredScopes) =>
+      scopes.containsAll(requiredScopes);
+
+  @override
+  String toString() {
+    return 'AiroRouteAccessGrant('
+        'grantId: $grantId, '
+        'locationId: $locationId, '
+        'audienceNodeId: $audienceNodeId, '
+        'scopes: ${scopes.map((scope) => scope.stableId).toList()}, '
+        'handle: redacted, '
+        'expiresAt: $expiresAt'
+        ')';
+  }
+
+  @override
+  List<Object?> get props => [
+    schemaVersion,
+    grantId,
+    locationId,
+    audienceNodeId,
+    handle,
+    issuedAt,
+    expiresAt,
+    scopes,
+    requiresTrustedDeviceScope,
+  ];
+}
+
+class AiroRouteAccessGrantValidation extends Equatable {
+  AiroRouteAccessGrantValidation({
+    required this.grantId,
+    required List<AiroRouteAccessGrantValidationCode> codes,
+  }) : codes = List.unmodifiable(codes);
+
+  final String grantId;
+  final List<AiroRouteAccessGrantValidationCode> codes;
+
+  bool get accepted =>
+      codes.length == 1 &&
+      codes.single == AiroRouteAccessGrantValidationCode.accepted;
+
+  @override
+  List<Object?> get props => [grantId, codes];
+}
+
+class AiroRouteAccessGrantPolicy {
+  const AiroRouteAccessGrantPolicy();
+
+  AiroRouteAccessGrantValidation validate({
+    required AiroMediaLocation location,
+    required AiroRouteAccessGrant grant,
+    required String requestedByNodeId,
+    required Set<AiroRouteAccessScope> requiredScopes,
+    required DateTime now,
+    required bool hasTrustedDeviceScope,
+  }) {
+    final codes = <AiroRouteAccessGrantValidationCode>[];
+    if (location.isExpired(now)) {
+      codes.add(AiroRouteAccessGrantValidationCode.locationExpired);
+    }
+    if (grant.isExpired(now)) {
+      codes.add(AiroRouteAccessGrantValidationCode.grantExpired);
+    }
+    if (!grant.isBoundTo(requestedByNodeId)) {
+      codes.add(AiroRouteAccessGrantValidationCode.wrongAudience);
+    }
+    if (!grant.allowsAll(requiredScopes)) {
+      codes.add(AiroRouteAccessGrantValidationCode.scopeMissing);
+    }
+    if (grant.requiresTrustedDeviceScope && !hasTrustedDeviceScope) {
+      codes.add(AiroRouteAccessGrantValidationCode.trustedDeviceScopeMissing);
+    }
+
+    return AiroRouteAccessGrantValidation(
+      grantId: grant.grantId,
+      codes: codes.isEmpty
+          ? const [AiroRouteAccessGrantValidationCode.accepted]
+          : codes,
+    );
+  }
+}

--- a/packages/core_media_routing/test/media_location_models_test.dart
+++ b/packages/core_media_routing/test/media_location_models_test.dart
@@ -1,0 +1,274 @@
+import 'package:core_media_routing/core_media_routing.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('AiroMediaLocationPolicy', () {
+    const policy = AiroMediaLocationPolicy();
+    final now = DateTime.utc(2026, 7, 14, 12);
+
+    AiroMediaLocation location({
+      required String id,
+      required AiroMediaLocationKind kind,
+      required AiroMediaLocationLocality locality,
+      bool localNetwork = false,
+      bool trusted = false,
+      DateTime? expiresAt,
+    }) {
+      return AiroMediaLocation(
+        locationId: id,
+        mediaId: 'media-1',
+        kind: kind,
+        locality: locality,
+        accessHandle: AiroRouteAccessHandle.redacted('location-$id'),
+        ownerNodeId: 'owner-1',
+        expiresAt: expiresAt,
+        requiresLocalNetworkScope: localNetwork,
+        requiresTrustedDeviceScope: trusted,
+        supportsRangeRequests: true,
+        supportsProbeRequests: true,
+      );
+    }
+
+    test('accepts public IPTV location without exposing source value', () {
+      final publicLocation = location(
+        id: 'iptv',
+        kind: AiroMediaLocationKind.iptvStream,
+        locality: AiroMediaLocationLocality.internet,
+      );
+
+      final result = policy.validate(
+        location: publicLocation,
+        context: AiroMediaLocationValidationContext(now: now),
+      );
+
+      expect(result.accepted, isTrue);
+      expect(publicLocation.toString(), isNot(contains('location-iptv')));
+      expect(publicLocation.toString(), contains('accessHandle: redacted'));
+    });
+
+    test('LAN and NAS locations require local network scope', () {
+      final nasLocation = location(
+        id: 'nas',
+        kind: AiroMediaLocationKind.nasShareItem,
+        locality: AiroMediaLocationLocality.localNetwork,
+        localNetwork: true,
+      );
+
+      final rejected = policy.validate(
+        location: nasLocation,
+        context: AiroMediaLocationValidationContext(now: now),
+      );
+      final accepted = policy.validate(
+        location: nasLocation,
+        context: AiroMediaLocationValidationContext(
+          now: now,
+          hasLocalNetworkScope: true,
+        ),
+      );
+
+      expect(
+        rejected.codes,
+        contains(AiroMediaLocationValidationCode.localNetworkScopeMissing),
+      );
+      expect(accepted.accepted, isTrue);
+    });
+
+    test('temporary phone access requires trust scope and expiry', () {
+      final missingExpiry = location(
+        id: 'phone',
+        kind: AiroMediaLocationKind.temporaryHttpAccess,
+        locality: AiroMediaLocationLocality.relay,
+        trusted: true,
+      );
+      final validTemporary = location(
+        id: 'phone-expiring',
+        kind: AiroMediaLocationKind.temporaryHttpAccess,
+        locality: AiroMediaLocationLocality.relay,
+        trusted: true,
+        expiresAt: now.add(const Duration(minutes: 5)),
+      );
+
+      final rejected = policy.validate(
+        location: missingExpiry,
+        context: AiroMediaLocationValidationContext(now: now),
+      );
+      final accepted = policy.validate(
+        location: validTemporary,
+        context: AiroMediaLocationValidationContext(
+          now: now,
+          hasTrustedDeviceScope: true,
+        ),
+      );
+
+      expect(
+        rejected.codes,
+        contains(AiroMediaLocationValidationCode.temporaryAccessExpiryMissing),
+      );
+      expect(
+        rejected.codes,
+        contains(AiroMediaLocationValidationCode.trustedDeviceScopeMissing),
+      );
+      expect(accepted.accepted, isTrue);
+    });
+
+    test('expired locations are rejected', () {
+      final expired = location(
+        id: 'expired',
+        kind: AiroMediaLocationKind.authenticatedInternet,
+        locality: AiroMediaLocationLocality.internet,
+        expiresAt: now,
+      );
+
+      final result = policy.validate(
+        location: expired,
+        context: AiroMediaLocationValidationContext(now: now),
+      );
+
+      expect(result.accepted, isFalse);
+      expect(result.codes, contains(AiroMediaLocationValidationCode.expired));
+    });
+  });
+
+  group('AiroRouteAccessGrantPolicy', () {
+    const policy = AiroRouteAccessGrantPolicy();
+    final now = DateTime.utc(2026, 7, 14, 12);
+
+    final location = AiroMediaLocation(
+      locationId: 'location-1',
+      mediaId: 'media-1',
+      kind: AiroMediaLocationKind.temporaryHttpAccess,
+      locality: AiroMediaLocationLocality.relay,
+      accessHandle: AiroRouteAccessHandle.redacted('location-handle'),
+      ownerNodeId: 'phone-1',
+      expiresAt: now.add(const Duration(minutes: 5)),
+      requiresTrustedDeviceScope: true,
+      supportsRangeRequests: true,
+      supportsProbeRequests: true,
+    );
+
+    AiroRouteAccessGrant grant({
+      String audienceNodeId = 'receiver-1',
+      Set<AiroRouteAccessScope> scopes = const {
+        AiroRouteAccessScope.playbackRead,
+        AiroRouteAccessScope.rangeRead,
+      },
+      DateTime? expiresAt,
+    }) {
+      return AiroRouteAccessGrant(
+        grantId: 'grant-1',
+        locationId: location.locationId,
+        audienceNodeId: audienceNodeId,
+        handle: AiroRouteAccessHandle.redacted('grant-handle'),
+        issuedAt: now,
+        expiresAt: expiresAt ?? now.add(const Duration(minutes: 3)),
+        scopes: scopes,
+      );
+    }
+
+    test('accepts receiver-bound grant with required scopes', () {
+      final accessGrant = grant();
+
+      final result = policy.validate(
+        location: location,
+        grant: accessGrant,
+        requestedByNodeId: 'receiver-1',
+        requiredScopes: const {
+          AiroRouteAccessScope.playbackRead,
+          AiroRouteAccessScope.rangeRead,
+        },
+        now: now,
+        hasTrustedDeviceScope: true,
+      );
+
+      expect(result.accepted, isTrue);
+      expect(accessGrant.toString(), isNot(contains('grant-handle')));
+      expect(accessGrant.toString(), contains('handle: redacted'));
+    });
+
+    test('rejects expired wrong-audience or underscoped grants', () {
+      final expired = grant(expiresAt: now);
+      final wrongAudience = grant(audienceNodeId: 'receiver-2');
+      final underscoped = grant(
+        scopes: const {AiroRouteAccessScope.playbackRead},
+      );
+
+      final expiredResult = policy.validate(
+        location: location,
+        grant: expired,
+        requestedByNodeId: 'receiver-1',
+        requiredScopes: const {AiroRouteAccessScope.playbackRead},
+        now: now,
+        hasTrustedDeviceScope: true,
+      );
+      final audienceResult = policy.validate(
+        location: location,
+        grant: wrongAudience,
+        requestedByNodeId: 'receiver-1',
+        requiredScopes: const {AiroRouteAccessScope.playbackRead},
+        now: now,
+        hasTrustedDeviceScope: true,
+      );
+      final scopeResult = policy.validate(
+        location: location,
+        grant: underscoped,
+        requestedByNodeId: 'receiver-1',
+        requiredScopes: const {
+          AiroRouteAccessScope.playbackRead,
+          AiroRouteAccessScope.rangeRead,
+        },
+        now: now,
+        hasTrustedDeviceScope: true,
+      );
+
+      expect(
+        expiredResult.codes,
+        contains(AiroRouteAccessGrantValidationCode.grantExpired),
+      );
+      expect(
+        audienceResult.codes,
+        contains(AiroRouteAccessGrantValidationCode.wrongAudience),
+      );
+      expect(
+        scopeResult.codes,
+        contains(AiroRouteAccessGrantValidationCode.scopeMissing),
+      );
+    });
+
+    test('requires trusted-device scope for protected grants', () {
+      final result = policy.validate(
+        location: location,
+        grant: grant(),
+        requestedByNodeId: 'receiver-1',
+        requiredScopes: const {AiroRouteAccessScope.playbackRead},
+        now: now,
+        hasTrustedDeviceScope: false,
+      );
+
+      expect(
+        result.codes,
+        contains(AiroRouteAccessGrantValidationCode.trustedDeviceScopeMissing),
+      );
+    });
+  });
+
+  group('AiroRouteAccessHandle', () {
+    test('rejects raw source values at the boundary', () {
+      expect(
+        AiroRouteAccessHandle.validate('https://example.com/live.m3u8'),
+        AiroRouteAccessHandleRejectionCode.urlValue,
+      );
+      expect(
+        AiroRouteAccessHandle.validate('/Users/me/movie.ts'),
+        AiroRouteAccessHandleRejectionCode.localPathValue,
+      );
+      expect(
+        AiroRouteAccessHandle.validate('http://10.0.0.4/live'),
+        AiroRouteAccessHandleRejectionCode.urlValue,
+      );
+      expect(
+        AiroRouteAccessHandle.validate('Basic abc123'),
+        AiroRouteAccessHandleRejectionCode.credentialLikeValue,
+      );
+    });
+  });
+}


### PR DESCRIPTION
# Summary

This PR closes #610 by adding the v2 platform contract for media location representation and receiver-bound access grants.

Core outcome:

* adds redacted `AiroMediaLocation` and `AiroRouteAccessGrant` models in `core_media_routing`
* validates local-network scope, trusted-device scope, expiry, audience binding, and access scopes
* documents the platform boundary for cloud, LAN, server item, local file, phone-local, desktop, removable, and temporary access paths

# Changes

### Code

* Added:
  * `AiroMediaLocationKind`, locality, scope, validation, and access-grant contracts
  * deterministic policy validators for location and grant use
  * unit coverage for redaction and rejection paths
* Updated:
  * `packages/core_media_routing` exports and README
  * `docs/features/airo-tv/MEDIA_LOCATION_ACCESS_MODEL.md`

### Logic

* Raw URLs, local paths, local IPs, and credential-like values are rejected at the access-handle boundary.
* Temporary access requires expiry.
* Receiver access grants are audience-bound, expiring, scoped, and trust-gated.

# API Changes

* Adds new public Dart model/policy exports from `package:core_media_routing/core_media_routing.dart`.
* No app-layer API or product workflow change.

# Risks

* Low: this is additive platform contract work with no runtime integration yet.
* Rollback plan: revert this additive package/doc commit.

# Testing

* `dart format --set-exit-if-changed packages/core_media_routing`
* `cd packages/core_media_routing && flutter test`
* `cd packages/core_media_routing && flutter analyze --fatal-infos`
* `git diff --check HEAD~1..HEAD`
* diff-only secret scan for `password|secret|api_key|token`

Closes #610
