### PR TITLE
feat(platform): add route scoring decision logs

### DIFF
--- a/docs/features/airo-tv/ROUTE_SCORING_DECISION_LOGS.md
+++ b/docs/features/airo-tv/ROUTE_SCORING_DECISION_LOGS.md
@@ -1,0 +1,61 @@
+# Airo TV Route Scoring And Decision Logs
+
+This contract defines the v2.0.0.1 platform boundary for deterministic,
+explainable, privacy-safe media route scoring.
+
+Implementation contract:
+
+- Package: `packages/core_media_routing`
+- Schema: `kAiroMediaRouteScoringSchemaVersion`
+- Score policy: `AiroMediaRouteScoringPolicy`
+- Decision log: `AiroMediaRouteDecisionLog`
+- Release-line base: `origin/v2`
+
+## Score Inputs
+
+Route scoring uses normalized platform-provided signals:
+
+- route priority;
+- health;
+- bandwidth;
+- latency;
+- battery;
+- thermal state;
+- reliability;
+- user preference;
+- phone-proxy penalty;
+- blocker penalty.
+
+The score policy is deterministic. Eligible routes are ranked by total score
+and ties are resolved by stable candidate id ordering.
+
+## Decision Logs
+
+Decision logs include:
+
+- request id;
+- generation time;
+- selected candidate id;
+- route kind;
+- eligibility;
+- total score;
+- blocker codes;
+- reason codes.
+
+Logs are safe for local QA output and future diagnostics because they do not
+include raw source values, access handles, provider auth material, playlist
+contents, local paths, local IP addresses, device hostnames, or credential-like
+diagnostics.
+
+## Consumer Rule
+
+Airo TV screens, route inspectors, playback adapters, and QA automation should
+consume `AiroMediaRouteScoringPolicy` output. Product code should not implement
+separate route ranking, phone-proxy penalty, tie-breaking, or raw diagnostic
+formatting.
+
+## Out Of Scope
+
+This issue does not emit analytics events, collect benchmark traces, probe real
+networks, implement route health events, own playback session state, or execute
+media playback.

--- a/packages/core_media_routing/README.md
+++ b/packages/core_media_routing/README.md
@@ -12,12 +12,13 @@ product screens.
 - Versioned media routing request, candidate, policy, blocker, and decision
   models.
 - Versioned media location and route access-grant models.
+- Versioned route score breakdowns and privacy-safe decision logs.
 - Deterministic route preflight and selection.
 - Direct receiver playback preference before relay or phone-proxy fallback.
 - Redacted source and access handles for cloud, LAN, server, local file,
   phone-local, TV removable, desktop, and temporary access paths.
-- Privacy-safe diagnostics that expose ids and blocker codes, not raw source
-  values.
+- Privacy-safe diagnostics that expose ids, scores, reasons, and blocker codes,
+  not raw source values.
 
 This package does not start a media server, open playback, inspect codecs from a
 platform SDK, collect route health events, issue playback access grants, or own

--- a/packages/core_media_routing/lib/core_media_routing.dart
+++ b/packages/core_media_routing/lib/core_media_routing.dart
@@ -1,4 +1,5 @@
 library;
 
 export 'src/media_location_models.dart';
+export 'src/media_route_scoring_models.dart';
 export 'src/media_routing_models.dart';

--- a/packages/core_media_routing/lib/src/media_route_scoring_models.dart
+++ b/packages/core_media_routing/lib/src/media_route_scoring_models.dart
@@ -1,0 +1,456 @@
+import 'package:equatable/equatable.dart';
+
+import 'media_routing_models.dart';
+
+const String kAiroMediaRouteScoringSchemaVersion = '1.0.0';
+
+enum AiroMediaRouteScoreComponentId {
+  routePriority('route_priority'),
+  health('health'),
+  bandwidth('bandwidth'),
+  latency('latency'),
+  battery('battery'),
+  thermal('thermal'),
+  reliability('reliability'),
+  userPreference('user_preference'),
+  phoneProxyPenalty('phone_proxy_penalty'),
+  blockerPenalty('blocker_penalty');
+
+  const AiroMediaRouteScoreComponentId(this.stableId);
+
+  final String stableId;
+}
+
+enum AiroMediaRouteDecisionReasonCode {
+  selectedHighestScore('selected_highest_score'),
+  selectedByStableTieBreak('selected_by_stable_tie_break'),
+  rejectedByPreflight('rejected_by_preflight'),
+  directRoutePreferred('direct_route_preferred'),
+  phoneProxyPenalized('phone_proxy_penalized'),
+  lowBatteryPenalty('low_battery_penalty'),
+  thermalPenalty('thermal_penalty'),
+  noEligibleRoute('no_eligible_route');
+
+  const AiroMediaRouteDecisionReasonCode(this.stableId);
+
+  final String stableId;
+}
+
+class AiroMediaRouteScoreSignals extends Equatable {
+  const AiroMediaRouteScoreSignals({
+    this.health = 50,
+    this.bandwidth = 50,
+    this.latency = 50,
+    this.battery = 50,
+    this.thermal = 50,
+    this.reliability = 50,
+    this.userPreference = 50,
+  });
+
+  final int health;
+  final int bandwidth;
+  final int latency;
+  final int battery;
+  final int thermal;
+  final int reliability;
+  final int userPreference;
+
+  int normalizedHealth() => _clamp(health);
+  int normalizedBandwidth() => _clamp(bandwidth);
+  int normalizedLatency() => _clamp(latency);
+  int normalizedBattery() => _clamp(battery);
+  int normalizedThermal() => _clamp(thermal);
+  int normalizedReliability() => _clamp(reliability);
+  int normalizedUserPreference() => _clamp(userPreference);
+
+  static int _clamp(int value) {
+    if (value < 0) return 0;
+    if (value > 100) return 100;
+    return value;
+  }
+
+  @override
+  List<Object?> get props => [
+    health,
+    bandwidth,
+    latency,
+    battery,
+    thermal,
+    reliability,
+    userPreference,
+  ];
+}
+
+class AiroMediaRouteScoreComponent extends Equatable {
+  const AiroMediaRouteScoreComponent({
+    required this.componentId,
+    required this.value,
+    required this.weight,
+    required this.weightedValue,
+  });
+
+  final AiroMediaRouteScoreComponentId componentId;
+  final int value;
+  final int weight;
+  final int weightedValue;
+
+  @override
+  List<Object?> get props => [componentId, value, weight, weightedValue];
+}
+
+class AiroMediaRouteScoreBreakdown extends Equatable {
+  AiroMediaRouteScoreBreakdown({
+    required this.candidateId,
+    required this.routeKind,
+    required this.eligible,
+    required this.totalScore,
+    required Iterable<AiroMediaRouteBlockerCode> blockers,
+    required Iterable<AiroMediaRouteScoreComponent> components,
+    required Iterable<AiroMediaRouteDecisionReasonCode> reasonCodes,
+    this.schemaVersion = kAiroMediaRouteScoringSchemaVersion,
+  }) : blockers = List.unmodifiable(blockers),
+       components = List.unmodifiable(components),
+       reasonCodes = List.unmodifiable(reasonCodes);
+
+  final String schemaVersion;
+  final String candidateId;
+  final AiroMediaRouteKind routeKind;
+  final bool eligible;
+  final int totalScore;
+  final List<AiroMediaRouteBlockerCode> blockers;
+  final List<AiroMediaRouteScoreComponent> components;
+  final List<AiroMediaRouteDecisionReasonCode> reasonCodes;
+
+  @override
+  List<Object?> get props => [
+    schemaVersion,
+    candidateId,
+    routeKind,
+    eligible,
+    totalScore,
+    blockers,
+    components,
+    reasonCodes,
+  ];
+}
+
+class AiroMediaRouteDecisionLogEntry extends Equatable {
+  AiroMediaRouteDecisionLogEntry({
+    required this.candidateId,
+    required this.routeKind,
+    required this.eligible,
+    required this.selected,
+    required this.totalScore,
+    required Iterable<AiroMediaRouteBlockerCode> blockers,
+    required Iterable<AiroMediaRouteDecisionReasonCode> reasonCodes,
+  }) : blockers = List.unmodifiable(blockers),
+       reasonCodes = List.unmodifiable(reasonCodes);
+
+  final String candidateId;
+  final AiroMediaRouteKind routeKind;
+  final bool eligible;
+  final bool selected;
+  final int totalScore;
+  final List<AiroMediaRouteBlockerCode> blockers;
+  final List<AiroMediaRouteDecisionReasonCode> reasonCodes;
+
+  @override
+  String toString() {
+    return 'AiroMediaRouteDecisionLogEntry('
+        'candidateId: $candidateId, '
+        'routeKind: ${routeKind.stableId}, '
+        'eligible: $eligible, '
+        'selected: $selected, '
+        'totalScore: $totalScore, '
+        'blockers: ${blockers.map((code) => code.stableId).toList()}, '
+        'reasonCodes: ${reasonCodes.map((code) => code.stableId).toList()}'
+        ')';
+  }
+
+  @override
+  List<Object?> get props => [
+    candidateId,
+    routeKind,
+    eligible,
+    selected,
+    totalScore,
+    blockers,
+    reasonCodes,
+  ];
+}
+
+class AiroMediaRouteDecisionLog extends Equatable {
+  AiroMediaRouteDecisionLog({
+    required this.requestId,
+    required this.generatedAt,
+    required this.selectedCandidateId,
+    required Iterable<AiroMediaRouteDecisionLogEntry> entries,
+    this.schemaVersion = kAiroMediaRouteScoringSchemaVersion,
+  }) : entries = List.unmodifiable(entries);
+
+  final String schemaVersion;
+  final String requestId;
+  final DateTime generatedAt;
+  final String? selectedCandidateId;
+  final List<AiroMediaRouteDecisionLogEntry> entries;
+
+  @override
+  String toString() {
+    return 'AiroMediaRouteDecisionLog('
+        'requestId: $requestId, '
+        'generatedAt: $generatedAt, '
+        'selectedCandidateId: $selectedCandidateId, '
+        'entries: $entries'
+        ')';
+  }
+
+  @override
+  List<Object?> get props => [
+    schemaVersion,
+    requestId,
+    generatedAt,
+    selectedCandidateId,
+    entries,
+  ];
+}
+
+class AiroScoredMediaRouteDecision extends Equatable {
+  AiroScoredMediaRouteDecision({
+    required this.requestId,
+    required Iterable<AiroMediaRouteScoreBreakdown> scores,
+    required this.selected,
+    required this.decisionLog,
+    this.schemaVersion = kAiroMediaRouteScoringSchemaVersion,
+  }) : scores = List.unmodifiable(scores);
+
+  final String schemaVersion;
+  final String requestId;
+  final List<AiroMediaRouteScoreBreakdown> scores;
+  final AiroMediaRouteScoreBreakdown? selected;
+  final AiroMediaRouteDecisionLog decisionLog;
+
+  bool get hasRoute => selected != null;
+
+  @override
+  List<Object?> get props => [
+    schemaVersion,
+    requestId,
+    scores,
+    selected,
+    decisionLog,
+  ];
+}
+
+class AiroMediaRouteScoringPolicy {
+  const AiroMediaRouteScoringPolicy();
+
+  AiroScoredMediaRouteDecision scoreDecision({
+    required AiroMediaRouteDecision decision,
+    required Map<String, AiroMediaRouteScoreSignals> signalsByCandidateId,
+    required DateTime generatedAt,
+  }) {
+    final scores = [
+      for (final evaluation in decision.evaluations)
+        _scoreEvaluation(
+          evaluation: evaluation,
+          signals:
+              signalsByCandidateId[evaluation.candidate.candidateId] ??
+              const AiroMediaRouteScoreSignals(),
+        ),
+    ];
+
+    final eligibleScores = scores.where((score) => score.eligible).toList()
+      ..sort(_compareScores);
+    final selected = eligibleScores.isEmpty ? null : eligibleScores.first;
+    final selectedWithReason = selected == null
+        ? null
+        : _withSelectionReason(selected, eligibleScores);
+    final noEligibleRoute = eligibleScores.isEmpty;
+    final finalScores = [
+      for (final score in scores)
+        if (score.candidateId == selectedWithReason?.candidateId)
+          selectedWithReason!
+        else if (noEligibleRoute)
+          _withNoEligibleRouteReason(score)
+        else
+          score,
+    ];
+
+    final log = AiroMediaRouteDecisionLog(
+      requestId: decision.requestId,
+      generatedAt: generatedAt,
+      selectedCandidateId: selectedWithReason?.candidateId,
+      entries: [
+        for (final score in finalScores)
+          AiroMediaRouteDecisionLogEntry(
+            candidateId: score.candidateId,
+            routeKind: score.routeKind,
+            eligible: score.eligible,
+            selected: score.candidateId == selectedWithReason?.candidateId,
+            totalScore: score.totalScore,
+            blockers: score.blockers,
+            reasonCodes: score.reasonCodes,
+          ),
+      ],
+    );
+
+    return AiroScoredMediaRouteDecision(
+      requestId: decision.requestId,
+      scores: finalScores,
+      selected: selectedWithReason,
+      decisionLog: log,
+    );
+  }
+
+  AiroMediaRouteScoreBreakdown _scoreEvaluation({
+    required AiroMediaRouteEvaluation evaluation,
+    required AiroMediaRouteScoreSignals signals,
+  }) {
+    final candidate = evaluation.candidate;
+    final components = [
+      _component(
+        AiroMediaRouteScoreComponentId.routePriority,
+        _routePriority(candidate.kind),
+        6,
+      ),
+      _component(
+        AiroMediaRouteScoreComponentId.health,
+        signals.normalizedHealth(),
+        3,
+      ),
+      _component(
+        AiroMediaRouteScoreComponentId.bandwidth,
+        signals.normalizedBandwidth(),
+        3,
+      ),
+      _component(
+        AiroMediaRouteScoreComponentId.latency,
+        signals.normalizedLatency(),
+        2,
+      ),
+      _component(
+        AiroMediaRouteScoreComponentId.battery,
+        signals.normalizedBattery(),
+        2,
+      ),
+      _component(
+        AiroMediaRouteScoreComponentId.thermal,
+        signals.normalizedThermal(),
+        2,
+      ),
+      _component(
+        AiroMediaRouteScoreComponentId.reliability,
+        signals.normalizedReliability(),
+        3,
+      ),
+      _component(
+        AiroMediaRouteScoreComponentId.userPreference,
+        signals.normalizedUserPreference(),
+        1,
+      ),
+      if (candidate.kind.isPhoneProxy)
+        _component(AiroMediaRouteScoreComponentId.phoneProxyPenalty, -80, 1),
+      if (!evaluation.eligible)
+        _component(AiroMediaRouteScoreComponentId.blockerPenalty, -1000, 1),
+    ];
+    final reasons = <AiroMediaRouteDecisionReasonCode>[
+      if (!evaluation.eligible)
+        AiroMediaRouteDecisionReasonCode.rejectedByPreflight,
+      if (!candidate.kind.isPhoneProxy &&
+          candidate.kind != AiroMediaRouteKind.cloudCommandOnly)
+        AiroMediaRouteDecisionReasonCode.directRoutePreferred,
+      if (candidate.kind.isPhoneProxy)
+        AiroMediaRouteDecisionReasonCode.phoneProxyPenalized,
+      if (signals.normalizedBattery() < 20)
+        AiroMediaRouteDecisionReasonCode.lowBatteryPenalty,
+      if (signals.normalizedThermal() < 30)
+        AiroMediaRouteDecisionReasonCode.thermalPenalty,
+    ];
+
+    return AiroMediaRouteScoreBreakdown(
+      candidateId: candidate.candidateId,
+      routeKind: candidate.kind,
+      eligible: evaluation.eligible,
+      totalScore: components.fold(
+        0,
+        (total, component) => total + component.weightedValue,
+      ),
+      blockers: evaluation.blockers,
+      components: components,
+      reasonCodes: reasons,
+    );
+  }
+
+  AiroMediaRouteScoreComponent _component(
+    AiroMediaRouteScoreComponentId componentId,
+    int value,
+    int weight,
+  ) {
+    return AiroMediaRouteScoreComponent(
+      componentId: componentId,
+      value: value,
+      weight: weight,
+      weightedValue: value * weight,
+    );
+  }
+
+  AiroMediaRouteScoreBreakdown _withSelectionReason(
+    AiroMediaRouteScoreBreakdown selected,
+    List<AiroMediaRouteScoreBreakdown> ranked,
+  ) {
+    final tied =
+        ranked.length > 1 && ranked[1].totalScore == selected.totalScore;
+    return AiroMediaRouteScoreBreakdown(
+      candidateId: selected.candidateId,
+      routeKind: selected.routeKind,
+      eligible: selected.eligible,
+      totalScore: selected.totalScore,
+      blockers: selected.blockers,
+      components: selected.components,
+      reasonCodes: [
+        ...selected.reasonCodes,
+        if (tied)
+          AiroMediaRouteDecisionReasonCode.selectedByStableTieBreak
+        else
+          AiroMediaRouteDecisionReasonCode.selectedHighestScore,
+      ],
+    );
+  }
+
+  AiroMediaRouteScoreBreakdown _withNoEligibleRouteReason(
+    AiroMediaRouteScoreBreakdown score,
+  ) {
+    return AiroMediaRouteScoreBreakdown(
+      candidateId: score.candidateId,
+      routeKind: score.routeKind,
+      eligible: score.eligible,
+      totalScore: score.totalScore,
+      blockers: score.blockers,
+      components: score.components,
+      reasonCodes: [
+        ...score.reasonCodes,
+        AiroMediaRouteDecisionReasonCode.noEligibleRoute,
+      ],
+    );
+  }
+
+  int _compareScores(
+    AiroMediaRouteScoreBreakdown left,
+    AiroMediaRouteScoreBreakdown right,
+  ) {
+    final scoreOrder = right.totalScore.compareTo(left.totalScore);
+    if (scoreOrder != 0) return scoreOrder;
+    return left.candidateId.compareTo(right.candidateId);
+  }
+
+  int _routePriority(AiroMediaRouteKind kind) {
+    return switch (kind) {
+      AiroMediaRouteKind.receiverDirect => 100,
+      AiroMediaRouteKind.lanDirect => 90,
+      AiroMediaRouteKind.serverDirect => 80,
+      AiroMediaRouteKind.desktopRelay => 70,
+      AiroMediaRouteKind.phoneProxy => 10,
+      AiroMediaRouteKind.cloudCommandOnly => -100,
+    };
+  }
+}

--- a/packages/core_media_routing/test/media_route_scoring_models_test.dart
+++ b/packages/core_media_routing/test/media_route_scoring_models_test.dart
@@ -1,0 +1,208 @@
+import 'package:core_media_routing/core_media_routing.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('AiroMediaRouteScoringPolicy', () {
+    const routingEngine = AiroDeterministicMediaRoutingEngine();
+    const scoringPolicy = AiroMediaRouteScoringPolicy();
+    final now = DateTime.utc(2026, 7, 14, 12);
+
+    AiroMediaRouteCandidate candidate({
+      required String id,
+      required AiroMediaRouteKind kind,
+      bool available = true,
+      bool trusted = true,
+      Set<String> codecs = const {'h264', 'aac'},
+    }) {
+      return AiroMediaRouteCandidate(
+        candidateId: id,
+        kind: kind,
+        sourceKind: kind.isPhoneProxy
+            ? AiroMediaSourceKind.phoneLocal
+            : AiroMediaSourceKind.iptv,
+        sourceHandle: AiroMediaRouteSourceHandle.redacted('source-$id'),
+        playbackNodeId: 'receiver-1',
+        sourceNodeId: 'source-1',
+        supportedCodecs: codecs,
+        isAvailable: available,
+        isTrusted: trusted,
+      );
+    }
+
+    AiroMediaRouteDecision baseDecision({
+      required List<AiroMediaRouteCandidate> candidates,
+      bool userConfirmedPhoneProxy = false,
+    }) {
+      return routingEngine.selectRoute(
+        AiroMediaRouteRequest(
+          requestId: 'request-1',
+          intent: AiroMediaRouteIntent.play,
+          requestedAt: now,
+          candidates: candidates,
+          requiredCodecs: const {'h264', 'aac'},
+          userConfirmedPhoneProxy: userConfirmedPhoneProxy,
+        ),
+      );
+    }
+
+    test('higher health and bandwidth direct route wins', () {
+      final weak = candidate(
+        id: 'direct-b',
+        kind: AiroMediaRouteKind.lanDirect,
+      );
+      final strong = candidate(
+        id: 'direct-a',
+        kind: AiroMediaRouteKind.lanDirect,
+      );
+      final decision = scoringPolicy.scoreDecision(
+        decision: baseDecision(candidates: [weak, strong]),
+        signalsByCandidateId: const {
+          'direct-a': AiroMediaRouteScoreSignals(
+            health: 95,
+            bandwidth: 95,
+            reliability: 90,
+          ),
+          'direct-b': AiroMediaRouteScoreSignals(
+            health: 20,
+            bandwidth: 20,
+            reliability: 30,
+          ),
+        },
+        generatedAt: now,
+      );
+
+      expect(decision.selected?.candidateId, 'direct-a');
+      expect(
+        decision.selected!.reasonCodes,
+        contains(AiroMediaRouteDecisionReasonCode.selectedHighestScore),
+      );
+    });
+
+    test('phone proxy remains lower ranked despite strong signals', () {
+      final direct = candidate(
+        id: 'direct',
+        kind: AiroMediaRouteKind.receiverDirect,
+      );
+      final phone = candidate(id: 'phone', kind: AiroMediaRouteKind.phoneProxy);
+      final decision = scoringPolicy.scoreDecision(
+        decision: baseDecision(
+          candidates: [phone, direct],
+          userConfirmedPhoneProxy: true,
+        ),
+        signalsByCandidateId: const {
+          'direct': AiroMediaRouteScoreSignals(
+            health: 55,
+            bandwidth: 55,
+            reliability: 55,
+          ),
+          'phone': AiroMediaRouteScoreSignals(
+            health: 100,
+            bandwidth: 100,
+            reliability: 100,
+          ),
+        },
+        generatedAt: now,
+      );
+
+      expect(decision.selected?.candidateId, 'direct');
+      final phoneScore = decision.scores.singleWhere(
+        (score) => score.candidateId == 'phone',
+      );
+      expect(
+        phoneScore.reasonCodes,
+        contains(AiroMediaRouteDecisionReasonCode.phoneProxyPenalized),
+      );
+      expect(
+        phoneScore.components.map((component) => component.componentId),
+        contains(AiroMediaRouteScoreComponentId.phoneProxyPenalty),
+      );
+    });
+
+    test('battery and thermal penalties lower phone route score', () {
+      final phone = candidate(id: 'phone', kind: AiroMediaRouteKind.phoneProxy);
+      final decision = scoringPolicy.scoreDecision(
+        decision: baseDecision(
+          candidates: [phone],
+          userConfirmedPhoneProxy: true,
+        ),
+        signalsByCandidateId: const {
+          'phone': AiroMediaRouteScoreSignals(
+            health: 90,
+            bandwidth: 90,
+            battery: 5,
+            thermal: 10,
+          ),
+        },
+        generatedAt: now,
+      );
+
+      expect(decision.selected?.candidateId, 'phone');
+      expect(
+        decision.selected!.reasonCodes,
+        contains(AiroMediaRouteDecisionReasonCode.lowBatteryPenalty),
+      );
+      expect(
+        decision.selected!.reasonCodes,
+        contains(AiroMediaRouteDecisionReasonCode.thermalPenalty),
+      );
+    });
+
+    test('blocked candidates are logged with blocker codes only', () {
+      final blocked = candidate(
+        id: 'blocked',
+        kind: AiroMediaRouteKind.receiverDirect,
+        trusted: false,
+      );
+      final decision = scoringPolicy.scoreDecision(
+        decision: baseDecision(candidates: [blocked]),
+        signalsByCandidateId: const {},
+        generatedAt: now,
+      );
+
+      expect(decision.hasRoute, isFalse);
+      final entry = decision.decisionLog.entries.single;
+      expect(entry.eligible, isFalse);
+      expect(entry.blockers, contains(AiroMediaRouteBlockerCode.untrusted));
+      expect(
+        entry.reasonCodes,
+        contains(AiroMediaRouteDecisionReasonCode.rejectedByPreflight),
+      );
+      expect(
+        entry.reasonCodes,
+        contains(AiroMediaRouteDecisionReasonCode.noEligibleRoute),
+      );
+    });
+
+    test('tie breaking is stable by candidate id', () {
+      final b = candidate(id: 'b-route', kind: AiroMediaRouteKind.lanDirect);
+      final a = candidate(id: 'a-route', kind: AiroMediaRouteKind.lanDirect);
+      final decision = scoringPolicy.scoreDecision(
+        decision: baseDecision(candidates: [b, a]),
+        signalsByCandidateId: const {
+          'a-route': AiroMediaRouteScoreSignals(),
+          'b-route': AiroMediaRouteScoreSignals(),
+        },
+        generatedAt: now,
+      );
+
+      expect(decision.selected?.candidateId, 'a-route');
+      expect(
+        decision.selected!.reasonCodes,
+        contains(AiroMediaRouteDecisionReasonCode.selectedByStableTieBreak),
+      );
+    });
+
+    test('decision logs do not expose source handle values', () {
+      final route = candidate(id: 'direct', kind: AiroMediaRouteKind.lanDirect);
+      final decision = scoringPolicy.scoreDecision(
+        decision: baseDecision(candidates: [route]),
+        signalsByCandidateId: const {},
+        generatedAt: now,
+      );
+
+      expect(decision.decisionLog.toString(), isNot(contains('source-direct')));
+      expect(decision.decisionLog.toString(), contains('candidateId: direct'));
+      expect(decision.decisionLog.toString(), contains('totalScore'));
+    });
+  });
+}


### PR DESCRIPTION
# Summary

This PR closes #611 by adding the v2 platform contract for deterministic, explainable, privacy-safe route scoring and decision logs.

Core outcome:

* adds score signal, score breakdown, ranked decision, and decision log models in `core_media_routing`
* keeps route scoring in the platform layer with stable tie-breaking and explicit reason codes
* documents privacy-safe decision logs that avoid raw source values, access handles, provider auth material, local paths, local IPs, and credential-like diagnostics

# Changes

### Code

* Added:
  * `AiroMediaRouteScoringPolicy`
  * score signal/component/breakdown models
  * decision reason codes and privacy-safe decision log entries
  * unit coverage for scoring, penalties, blocker logs, tie-breaking, and redaction
* Updated:
  * `packages/core_media_routing` exports and README
  * `docs/features/airo-tv/ROUTE_SCORING_DECISION_LOGS.md`

### Logic

* Eligible routes are scored deterministically from normalized platform-provided signals.
* Phone proxy routes receive explicit penalty/reason handling.
* Ties resolve by stable candidate id ordering.
* Blocked routes are logged with blocker/reason codes only.

# API Changes

* Adds new public Dart scoring/log model and policy exports from `package:core_media_routing/core_media_routing.dart`.
* No app-layer API or product workflow change.

# Risks

* Low: this is additive platform contract work with no runtime integration yet.
* Rollback plan: revert this additive package/doc commit.

# Testing

* `dart format --set-exit-if-changed packages/core_media_routing`
* `cd packages/core_media_routing && flutter test`
* `cd packages/core_media_routing && flutter analyze --fatal-infos`
* `git diff --check HEAD~1..HEAD`
* diff-only secret scan for `password|secret|api_key|token`

Closes #611
