### PR TITLE
feat(platform): add playback ownership model

### DIFF
--- a/docs/features/airo-tv/PLAYBACK_OWNERSHIP_MODEL.md
+++ b/docs/features/airo-tv/PLAYBACK_OWNERSHIP_MODEL.md
@@ -1,0 +1,74 @@
+# Airo TV Playback Ownership Model
+
+This contract defines the v2.0.0.1 platform boundary for playback control
+authority after media routing selects a path.
+
+Implementation contract:
+
+- Package: `packages/core_sessions`
+- Schema: `kAiroSessionSchemaVersion`
+- Snapshot model: `AiroPlaybackOwnershipSnapshot`
+- Transfer policy: `AiroPlaybackOwnershipPolicy`
+- Release-line base: `origin/v2`
+
+## Ownership Snapshot
+
+`AiroPlaybackOwnershipSnapshot` records:
+
+- session id;
+- owner node id;
+- playback node id;
+- source node id;
+- route id and route kind;
+- analytics owner node id;
+- health reporter node id;
+- active controller node id;
+- controller operation grants;
+- monotonic session revision;
+- optional ownership lease expiry.
+
+The snapshot is platform state. Airo TV screens should not infer ownership from
+local widget state, current route, focused screen, or controller presence.
+
+## Operation Authority
+
+The playback owner can control pause, resume, seek, stop, volume, audio track,
+subtitle track, recovery, health reporting, and analytics reporting. A separate
+analytics owner and health reporter can submit their respective records. An
+active controller can perform only explicitly granted operations.
+
+Expired ownership leases reject all operation authority until refreshed or
+transferred.
+
+## Transfer Rules
+
+Ownership transfer is deterministic:
+
+- expired transfer requests are rejected;
+- expired ownership leases are rejected;
+- wrong current-owner claims are rejected;
+- stale base revisions are rejected;
+- unauthorized requesters are rejected;
+- accepted transfers move owner, analytics owner, health reporter, controller
+  grant, and increment the session revision.
+
+## Privacy Rule
+
+Ownership diagnostics expose node ids, route ids, route kind, scopes, revision,
+and lease metadata only. They must not include media URLs, local paths, local IP
+addresses, source handles, titles, analytics payloads, crash details, or
+diagnostic dumps.
+
+## Consumer Rule
+
+Airo TV, companion controllers, playback engines, route inspectors, and
+analytics adapters should consume `AiroPlaybackOwnershipSnapshot` and
+`AiroPlaybackOwnershipPolicy`. Product code may present ownership state, but it
+should not implement separate pause/seek/resume/health/analytics authority
+rules.
+
+## Out Of Scope
+
+This issue does not implement playback execution, analytics providers, route
+health events, cloud arbitration, persistent lease storage, UI ownership
+indicators, or route inspector screens.

--- a/packages/core_sessions/README.md
+++ b/packages/core_sessions/README.md
@@ -10,6 +10,7 @@ handoff state.
 ## Scope
 
 - Receiver-authoritative playback session snapshots.
+- Playback ownership, operation authority, and ownership transfer policy.
 - Monotonic revisions and deterministic conflict policy.
 - Privacy-safe local sync deltas with redacted payload handles.
 - Two-phase handoff preflight and phase records.

--- a/packages/core_sessions/lib/src/session_models.dart
+++ b/packages/core_sessions/lib/src/session_models.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:core_commands/core_commands.dart';
+import 'package:core_media_routing/core_media_routing.dart';
 import 'package:core_pairing/core_pairing.dart';
 import 'package:core_protocol/core_protocol.dart';
 import 'package:equatable/equatable.dart';
@@ -106,6 +107,288 @@ enum AiroSessionPayloadRejectionCode {
   const AiroSessionPayloadRejectionCode(this.stableId);
 
   final String stableId;
+}
+
+enum AiroPlaybackOwnershipOperation {
+  pause('pause'),
+  resume('resume'),
+  seek('seek'),
+  stop('stop'),
+  volume('volume'),
+  audioTrack('audio_track'),
+  subtitleTrack('subtitle_track'),
+  recovery('recovery'),
+  healthReport('health_report'),
+  analyticsReport('analytics_report');
+
+  const AiroPlaybackOwnershipOperation(this.stableId);
+
+  final String stableId;
+}
+
+enum AiroPlaybackOwnershipTransferCode {
+  accepted('accepted'),
+  requestExpired('request_expired'),
+  ownershipExpired('ownership_expired'),
+  currentOwnerMismatch('current_owner_mismatch'),
+  staleRevision('stale_revision'),
+  requesterUnauthorized('requester_unauthorized');
+
+  const AiroPlaybackOwnershipTransferCode(this.stableId);
+
+  final String stableId;
+}
+
+class AiroPlaybackOwnershipSnapshot extends Equatable {
+  AiroPlaybackOwnershipSnapshot({
+    required this.sessionId,
+    required this.ownerNodeId,
+    required this.playbackNodeId,
+    required this.sourceNodeId,
+    required this.routeId,
+    required this.routeKind,
+    required this.analyticsOwnerNodeId,
+    required this.healthReporterNodeId,
+    required this.revision,
+    required this.capturedAt,
+    this.activeControllerNodeId,
+    Set<AiroPlaybackOwnershipOperation> controllerGrant = const {},
+    this.leaseExpiresAt,
+    this.schemaVersion = kAiroSessionSchemaVersion,
+  }) : controllerGrant = Set.unmodifiable(controllerGrant);
+
+  final String schemaVersion;
+  final String sessionId;
+  final String ownerNodeId;
+  final String playbackNodeId;
+  final String sourceNodeId;
+  final String routeId;
+  final AiroMediaRouteKind routeKind;
+  final String analyticsOwnerNodeId;
+  final String healthReporterNodeId;
+  final String? activeControllerNodeId;
+  final Set<AiroPlaybackOwnershipOperation> controllerGrant;
+  final AiroSessionRevision revision;
+  final DateTime capturedAt;
+  final DateTime? leaseExpiresAt;
+
+  bool isExpired(DateTime now) =>
+      leaseExpiresAt != null && !now.isBefore(leaseExpiresAt!);
+
+  bool canPerform({
+    required String nodeId,
+    required AiroPlaybackOwnershipOperation operation,
+    required DateTime now,
+  }) {
+    if (isExpired(now)) return false;
+    if (nodeId == ownerNodeId) return true;
+    if (operation == AiroPlaybackOwnershipOperation.analyticsReport &&
+        nodeId == analyticsOwnerNodeId) {
+      return true;
+    }
+    if (operation == AiroPlaybackOwnershipOperation.healthReport &&
+        nodeId == healthReporterNodeId) {
+      return true;
+    }
+    return nodeId == activeControllerNodeId &&
+        controllerGrant.contains(operation);
+  }
+
+  AiroPlaybackOwnershipSnapshot copyWith({
+    String? ownerNodeId,
+    String? playbackNodeId,
+    String? sourceNodeId,
+    String? routeId,
+    AiroMediaRouteKind? routeKind,
+    String? analyticsOwnerNodeId,
+    String? healthReporterNodeId,
+    String? activeControllerNodeId,
+    Set<AiroPlaybackOwnershipOperation>? controllerGrant,
+    AiroSessionRevision? revision,
+    DateTime? capturedAt,
+    DateTime? leaseExpiresAt,
+  }) {
+    return AiroPlaybackOwnershipSnapshot(
+      sessionId: sessionId,
+      ownerNodeId: ownerNodeId ?? this.ownerNodeId,
+      playbackNodeId: playbackNodeId ?? this.playbackNodeId,
+      sourceNodeId: sourceNodeId ?? this.sourceNodeId,
+      routeId: routeId ?? this.routeId,
+      routeKind: routeKind ?? this.routeKind,
+      analyticsOwnerNodeId: analyticsOwnerNodeId ?? this.analyticsOwnerNodeId,
+      healthReporterNodeId: healthReporterNodeId ?? this.healthReporterNodeId,
+      activeControllerNodeId:
+          activeControllerNodeId ?? this.activeControllerNodeId,
+      controllerGrant: controllerGrant ?? this.controllerGrant,
+      revision: revision ?? this.revision,
+      capturedAt: capturedAt ?? this.capturedAt,
+      leaseExpiresAt: leaseExpiresAt ?? this.leaseExpiresAt,
+      schemaVersion: schemaVersion,
+    );
+  }
+
+  @override
+  String toString() {
+    return 'AiroPlaybackOwnershipSnapshot('
+        'sessionId: $sessionId, '
+        'ownerNodeId: $ownerNodeId, '
+        'playbackNodeId: $playbackNodeId, '
+        'sourceNodeId: $sourceNodeId, '
+        'routeId: $routeId, '
+        'routeKind: ${routeKind.stableId}, '
+        'analyticsOwnerNodeId: $analyticsOwnerNodeId, '
+        'healthReporterNodeId: $healthReporterNodeId, '
+        'activeControllerNodeId: $activeControllerNodeId, '
+        'controllerGrant: ${controllerGrant.map((operation) => operation.stableId).toList()}, '
+        'revision: ${revision.value}, '
+        'leaseExpiresAt: $leaseExpiresAt'
+        ')';
+  }
+
+  @override
+  List<Object?> get props => [
+    schemaVersion,
+    sessionId,
+    ownerNodeId,
+    playbackNodeId,
+    sourceNodeId,
+    routeId,
+    routeKind,
+    analyticsOwnerNodeId,
+    healthReporterNodeId,
+    activeControllerNodeId,
+    controllerGrant,
+    revision,
+    capturedAt,
+    leaseExpiresAt,
+  ];
+}
+
+class AiroPlaybackOwnershipTransferRequest extends Equatable {
+  AiroPlaybackOwnershipTransferRequest({
+    required this.transferId,
+    required this.sessionId,
+    required this.currentOwnerNodeId,
+    required this.newOwnerNodeId,
+    required this.requestedByNodeId,
+    required this.baseRevision,
+    required this.issuedAt,
+    required this.expiresAt,
+    this.analyticsOwnerNodeId,
+    this.healthReporterNodeId,
+    this.activeControllerNodeId,
+    Set<AiroPlaybackOwnershipOperation> controllerGrant = const {},
+    this.schemaVersion = kAiroSessionSchemaVersion,
+  }) : controllerGrant = Set.unmodifiable(controllerGrant);
+
+  final String schemaVersion;
+  final String transferId;
+  final String sessionId;
+  final String currentOwnerNodeId;
+  final String newOwnerNodeId;
+  final String requestedByNodeId;
+  final int baseRevision;
+  final DateTime issuedAt;
+  final DateTime expiresAt;
+  final String? analyticsOwnerNodeId;
+  final String? healthReporterNodeId;
+  final String? activeControllerNodeId;
+  final Set<AiroPlaybackOwnershipOperation> controllerGrant;
+
+  bool isExpired(DateTime now) => !now.isBefore(expiresAt);
+
+  @override
+  List<Object?> get props => [
+    schemaVersion,
+    transferId,
+    sessionId,
+    currentOwnerNodeId,
+    newOwnerNodeId,
+    requestedByNodeId,
+    baseRevision,
+    issuedAt,
+    expiresAt,
+    analyticsOwnerNodeId,
+    healthReporterNodeId,
+    activeControllerNodeId,
+    controllerGrant,
+  ];
+}
+
+class AiroPlaybackOwnershipTransferResult extends Equatable {
+  const AiroPlaybackOwnershipTransferResult({
+    required this.code,
+    required this.snapshot,
+  });
+
+  final AiroPlaybackOwnershipTransferCode code;
+  final AiroPlaybackOwnershipSnapshot snapshot;
+
+  bool get accepted => code == AiroPlaybackOwnershipTransferCode.accepted;
+
+  @override
+  List<Object?> get props => [code, snapshot];
+}
+
+class AiroPlaybackOwnershipPolicy {
+  const AiroPlaybackOwnershipPolicy();
+
+  AiroPlaybackOwnershipTransferResult transfer({
+    required AiroPlaybackOwnershipSnapshot current,
+    required AiroPlaybackOwnershipTransferRequest request,
+    required DateTime now,
+  }) {
+    if (request.isExpired(now)) {
+      return AiroPlaybackOwnershipTransferResult(
+        code: AiroPlaybackOwnershipTransferCode.requestExpired,
+        snapshot: current,
+      );
+    }
+    if (current.isExpired(now)) {
+      return AiroPlaybackOwnershipTransferResult(
+        code: AiroPlaybackOwnershipTransferCode.ownershipExpired,
+        snapshot: current,
+      );
+    }
+    if (request.currentOwnerNodeId != current.ownerNodeId) {
+      return AiroPlaybackOwnershipTransferResult(
+        code: AiroPlaybackOwnershipTransferCode.currentOwnerMismatch,
+        snapshot: current,
+      );
+    }
+    if (request.baseRevision != current.revision.value) {
+      return AiroPlaybackOwnershipTransferResult(
+        code: AiroPlaybackOwnershipTransferCode.staleRevision,
+        snapshot: current,
+      );
+    }
+    if (request.requestedByNodeId != current.ownerNodeId &&
+        request.requestedByNodeId != current.activeControllerNodeId) {
+      return AiroPlaybackOwnershipTransferResult(
+        code: AiroPlaybackOwnershipTransferCode.requesterUnauthorized,
+        snapshot: current,
+      );
+    }
+
+    return AiroPlaybackOwnershipTransferResult(
+      code: AiroPlaybackOwnershipTransferCode.accepted,
+      snapshot: current.copyWith(
+        ownerNodeId: request.newOwnerNodeId,
+        analyticsOwnerNodeId:
+            request.analyticsOwnerNodeId ?? request.newOwnerNodeId,
+        healthReporterNodeId:
+            request.healthReporterNodeId ?? request.newOwnerNodeId,
+        activeControllerNodeId: request.activeControllerNodeId,
+        controllerGrant: request.controllerGrant,
+        revision: AiroSessionRevision(
+          value: current.revision.value + 1,
+          updatedAt: now,
+          reporterNodeId: request.requestedByNodeId,
+        ),
+        capturedAt: now,
+      ),
+    );
+  }
 }
 
 class AiroSessionRevision extends Equatable

--- a/packages/core_sessions/pubspec.yaml
+++ b/packages/core_sessions/pubspec.yaml
@@ -11,6 +11,8 @@ environment:
 dependencies:
   core_commands:
     path: ../core_commands
+  core_media_routing:
+    path: ../core_media_routing
   core_pairing:
     path: ../core_pairing
   core_protocol:

--- a/packages/core_sessions/test/playback_ownership_models_test.dart
+++ b/packages/core_sessions/test/playback_ownership_models_test.dart
@@ -1,0 +1,262 @@
+import 'package:core_media_routing/core_media_routing.dart';
+import 'package:core_sessions/core_sessions.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('AiroPlaybackOwnershipSnapshot', () {
+    final now = DateTime.utc(2026, 7, 14, 12);
+
+    AiroPlaybackOwnershipSnapshot snapshot({
+      DateTime? leaseExpiresAt,
+      Set<AiroPlaybackOwnershipOperation> controllerGrant = const {
+        AiroPlaybackOwnershipOperation.pause,
+      },
+    }) {
+      return AiroPlaybackOwnershipSnapshot(
+        sessionId: 'session-1',
+        ownerNodeId: 'tv-1',
+        playbackNodeId: 'tv-1',
+        sourceNodeId: 'source-1',
+        routeId: 'route-1',
+        routeKind: AiroMediaRouteKind.receiverDirect,
+        analyticsOwnerNodeId: 'analytics-1',
+        healthReporterNodeId: 'tv-1',
+        activeControllerNodeId: 'phone-1',
+        controllerGrant: controllerGrant,
+        revision: AiroSessionRevision(
+          value: 4,
+          updatedAt: now,
+          reporterNodeId: 'tv-1',
+        ),
+        capturedAt: now,
+        leaseExpiresAt: leaseExpiresAt ?? now.add(const Duration(minutes: 5)),
+      );
+    }
+
+    test('playback owner controls playback operations', () {
+      final ownership = snapshot();
+
+      expect(
+        ownership.canPerform(
+          nodeId: 'tv-1',
+          operation: AiroPlaybackOwnershipOperation.pause,
+          now: now,
+        ),
+        isTrue,
+      );
+      expect(
+        ownership.canPerform(
+          nodeId: 'tv-1',
+          operation: AiroPlaybackOwnershipOperation.seek,
+          now: now,
+        ),
+        isTrue,
+      );
+    });
+
+    test('active controller only receives granted operations', () {
+      final ownership = snapshot();
+
+      expect(
+        ownership.canPerform(
+          nodeId: 'phone-1',
+          operation: AiroPlaybackOwnershipOperation.pause,
+          now: now,
+        ),
+        isTrue,
+      );
+      expect(
+        ownership.canPerform(
+          nodeId: 'phone-1',
+          operation: AiroPlaybackOwnershipOperation.seek,
+          now: now,
+        ),
+        isFalse,
+      );
+    });
+
+    test('analytics and health reporters are derived from ownership', () {
+      final ownership = snapshot();
+
+      expect(
+        ownership.canPerform(
+          nodeId: 'analytics-1',
+          operation: AiroPlaybackOwnershipOperation.analyticsReport,
+          now: now,
+        ),
+        isTrue,
+      );
+      expect(
+        ownership.canPerform(
+          nodeId: 'phone-1',
+          operation: AiroPlaybackOwnershipOperation.analyticsReport,
+          now: now,
+        ),
+        isFalse,
+      );
+      expect(
+        ownership.canPerform(
+          nodeId: 'tv-1',
+          operation: AiroPlaybackOwnershipOperation.healthReport,
+          now: now,
+        ),
+        isTrue,
+      );
+    });
+
+    test('expired ownership lease rejects operation authority', () {
+      final ownership = snapshot(leaseExpiresAt: now);
+
+      expect(
+        ownership.canPerform(
+          nodeId: 'tv-1',
+          operation: AiroPlaybackOwnershipOperation.pause,
+          now: now,
+        ),
+        isFalse,
+      );
+    });
+
+    test('diagnostics avoid media source values and payloads', () {
+      final ownership = snapshot();
+
+      expect(ownership.toString(), contains('routeId: route-1'));
+      expect(ownership.toString(), contains('routeKind: receiver_direct'));
+      expect(ownership.toString(), isNot(contains('http')));
+      expect(ownership.toString(), isNot(contains('payload')));
+    });
+  });
+
+  group('AiroPlaybackOwnershipPolicy', () {
+    const policy = AiroPlaybackOwnershipPolicy();
+    final now = DateTime.utc(2026, 7, 14, 12);
+
+    AiroPlaybackOwnershipSnapshot current({
+      DateTime? leaseExpiresAt,
+      int revision = 4,
+    }) {
+      return AiroPlaybackOwnershipSnapshot(
+        sessionId: 'session-1',
+        ownerNodeId: 'tv-1',
+        playbackNodeId: 'tv-1',
+        sourceNodeId: 'phone-1',
+        routeId: 'route-1',
+        routeKind: AiroMediaRouteKind.receiverDirect,
+        analyticsOwnerNodeId: 'tv-1',
+        healthReporterNodeId: 'tv-1',
+        activeControllerNodeId: 'phone-1',
+        controllerGrant: const {AiroPlaybackOwnershipOperation.pause},
+        revision: AiroSessionRevision(
+          value: revision,
+          updatedAt: now,
+          reporterNodeId: 'tv-1',
+        ),
+        capturedAt: now,
+        leaseExpiresAt: leaseExpiresAt ?? now.add(const Duration(minutes: 5)),
+      );
+    }
+
+    AiroPlaybackOwnershipTransferRequest request({
+      String currentOwnerNodeId = 'tv-1',
+      String requestedByNodeId = 'tv-1',
+      int baseRevision = 4,
+      DateTime? expiresAt,
+    }) {
+      return AiroPlaybackOwnershipTransferRequest(
+        transferId: 'transfer-1',
+        sessionId: 'session-1',
+        currentOwnerNodeId: currentOwnerNodeId,
+        newOwnerNodeId: 'desktop-1',
+        requestedByNodeId: requestedByNodeId,
+        baseRevision: baseRevision,
+        issuedAt: now,
+        expiresAt: expiresAt ?? now.add(const Duration(minutes: 1)),
+        activeControllerNodeId: 'phone-1',
+        controllerGrant: const {
+          AiroPlaybackOwnershipOperation.pause,
+          AiroPlaybackOwnershipOperation.seek,
+        },
+      );
+    }
+
+    test('valid transfer changes owner and increments revision', () {
+      final result = policy.transfer(
+        current: current(),
+        request: request(),
+        now: now,
+      );
+
+      expect(result.accepted, isTrue);
+      expect(result.snapshot.ownerNodeId, 'desktop-1');
+      expect(result.snapshot.analyticsOwnerNodeId, 'desktop-1');
+      expect(result.snapshot.healthReporterNodeId, 'desktop-1');
+      expect(result.snapshot.revision.value, 5);
+      expect(result.snapshot.revision.reporterNodeId, 'tv-1');
+      expect(
+        result.snapshot.controllerGrant,
+        contains(AiroPlaybackOwnershipOperation.seek),
+      );
+    });
+
+    test('stale transfer revision is rejected', () {
+      final result = policy.transfer(
+        current: current(),
+        request: request(baseRevision: 3),
+        now: now,
+      );
+
+      expect(result.accepted, isFalse);
+      expect(result.code, AiroPlaybackOwnershipTransferCode.staleRevision);
+      expect(result.snapshot.ownerNodeId, 'tv-1');
+    });
+
+    test('wrong current owner is rejected', () {
+      final result = policy.transfer(
+        current: current(),
+        request: request(currentOwnerNodeId: 'phone-1'),
+        now: now,
+      );
+
+      expect(result.accepted, isFalse);
+      expect(
+        result.code,
+        AiroPlaybackOwnershipTransferCode.currentOwnerMismatch,
+      );
+    });
+
+    test('expired transfer and expired lease are rejected', () {
+      final expiredRequest = policy.transfer(
+        current: current(),
+        request: request(expiresAt: now),
+        now: now,
+      );
+      final expiredLease = policy.transfer(
+        current: current(leaseExpiresAt: now),
+        request: request(),
+        now: now,
+      );
+
+      expect(
+        expiredRequest.code,
+        AiroPlaybackOwnershipTransferCode.requestExpired,
+      );
+      expect(
+        expiredLease.code,
+        AiroPlaybackOwnershipTransferCode.ownershipExpired,
+      );
+    });
+
+    test('unauthorized requester cannot transfer ownership', () {
+      final result = policy.transfer(
+        current: current(),
+        request: request(requestedByNodeId: 'unknown-1'),
+        now: now,
+      );
+
+      expect(
+        result.code,
+        AiroPlaybackOwnershipTransferCode.requesterUnauthorized,
+      );
+    });
+  });
+}


### PR DESCRIPTION
# Summary

This PR closes #612 by adding the v2 platform contract for playback ownership, operation authority, and deterministic ownership transfer.

Core outcome:

* adds ownership snapshots and transfer requests/results in `core_sessions`
* defines authority for playback control, health reporting, and analytics reporting
* keeps ownership rules in the platform layer so Airo TV and companion surfaces do not invent app-local control rules

# Changes

### Code

* Added:
  * `AiroPlaybackOwnershipSnapshot`
  * `AiroPlaybackOwnershipTransferRequest`
  * `AiroPlaybackOwnershipTransferResult`
  * `AiroPlaybackOwnershipPolicy`
  * ownership operation and transfer result codes
  * unit coverage for owner authority, controller grants, analytics/health authority, expiry, transfer acceptance, stale revision, wrong owner, and unauthorized requesters
* Updated:
  * `packages/core_sessions` dependencies, README, and session exports through `session_models.dart`
  * `docs/features/airo-tv/PLAYBACK_OWNERSHIP_MODEL.md`

### Logic

* Playback owner can perform playback operations while lease is valid.
* Active controller can perform only explicitly granted operations.
* Analytics owner and health reporter are independently authorized for their own reporting operations.
* Transfers reject expired requests, expired leases, owner mismatch, stale revisions, and unauthorized requesters.
* Accepted transfers move owner/reporting authority and increment the session revision.

# API Changes

* Adds new public Dart ownership model and policy exports from `package:core_sessions/core_sessions.dart`.
* Adds `core_media_routing` as a `core_sessions` package dependency for route identity.
* No app-layer API or product workflow change.

# Risks

* Low: this is additive platform contract work with no runtime integration yet.
* Rollback plan: revert this additive package/doc commit.

# Testing

* `dart format --set-exit-if-changed packages/core_sessions`
* `cd packages/core_sessions && flutter test`
* `cd packages/core_sessions && flutter analyze --fatal-infos`
* `git diff --check HEAD~1..HEAD`
* diff-only secret scan for `password|secret|api_key|token`

Closes #612
