### PR TITLE
feat(platform): add temporary mobile server contract

### DIFF
--- a/app/lib/main_qualification.dart
+++ b/app/lib/main_qualification.dart
@@ -52,17 +52,22 @@ class AiroIptvQualificationApp extends StatelessWidget {
         autoCycle: true,
         onFormFactorOverride: (formFactor, tvPlatform) {
           if (formFactor == 'tv') {
-            DeviceFormFactorDetector.debugFormFactorOverride = DeviceFormFactor.tv;
+            DeviceFormFactorDetector.debugFormFactorOverride =
+                DeviceFormFactor.tv;
           } else if (formFactor == 'tablet') {
-            DeviceFormFactorDetector.debugFormFactorOverride = DeviceFormFactor.tablet;
+            DeviceFormFactorDetector.debugFormFactorOverride =
+                DeviceFormFactor.tablet;
           } else {
-            DeviceFormFactorDetector.debugFormFactorOverride = DeviceFormFactor.mobile;
+            DeviceFormFactorDetector.debugFormFactorOverride =
+                DeviceFormFactor.mobile;
           }
 
           if (tvPlatform == 'fire_tv') {
-            DeviceFormFactorDetector.debugTvPlatformOverride = TvPlatform.fireTv;
+            DeviceFormFactorDetector.debugTvPlatformOverride =
+                TvPlatform.fireTv;
           } else if (tvPlatform == 'android_tv') {
-            DeviceFormFactorDetector.debugTvPlatformOverride = TvPlatform.androidTv;
+            DeviceFormFactorDetector.debugTvPlatformOverride =
+                TvPlatform.androidTv;
           } else {
             DeviceFormFactorDetector.debugTvPlatformOverride = null;
           }

--- a/docs/features/airo-tv/TEMPORARY_MOBILE_SERVER_CONTRACT.md
+++ b/docs/features/airo-tv/TEMPORARY_MOBILE_SERVER_CONTRACT.md
@@ -1,0 +1,78 @@
+# Temporary Mobile Server Contract
+
+Status: v2 platform contract for ATV-023.
+
+## Ownership
+
+The secure temporary mobile server boundary is platform/framework code. Airo TV
+uses it to decide whether a phone-local media item may be served to a trusted
+receiver, but the app does not own the lifecycle rules.
+
+The contract is defined in `packages/core_media_routing` so phones, TVs,
+desktop relays, QA automation, and future receivers can share the same
+deterministic validation model.
+
+## Required Server Guarantees
+
+A temporary mobile server route is eligible only when all of these guarantees
+are represented in the platform snapshot:
+
+- LAN-only exposure.
+- Trusted receiver scope.
+- Receiver allow-list binding.
+- Expiring route access grant.
+- Playback, range-read, and probe-read grant scopes.
+- HTTP range support.
+- HEAD/probe support.
+- Entity validation for resumed reads.
+- Auto shutdown on expiry.
+- Idle shutdown.
+- Battery and thermal host gates.
+
+The contract intentionally stores opaque route handles only. Diagnostics must
+show ids, capability names, stable blocker codes, and redacted access state, not
+raw local URLs, addresses, file paths, or access material.
+
+## Deterministic Validation
+
+`AiroTemporaryMobileServerPolicy` returns stable blocker codes for route
+preflight:
+
+- `accepted`
+- `server_unavailable`
+- `expired`
+- `idle_timeout_exceeded`
+- `local_network_required`
+- `trusted_receiver_required`
+- `receiver_not_allowed`
+- `grant_audience_mismatch`
+- `grant_expired`
+- `grant_scope_missing`
+- `range_requests_required`
+- `head_probe_requests_required`
+- `entity_validation_required`
+- `auto_shutdown_required`
+- `idle_shutdown_required`
+- `battery_too_low`
+- `thermal_too_high`
+- `concurrent_receiver_limit_exceeded`
+
+The default policy requires at least 20 percent battery unless the host is
+charging, thermal state no higher than warm, one active receiver, LAN scope,
+trusted receiver scope, playback/range/probe grant scopes, range requests,
+HEAD/probe handling, entity validation, and auto shutdown on expiry.
+Idle shutdown is also required so abandoned phone-local routes do not keep the
+host awake indefinitely.
+
+## Adapter Boundary
+
+`AiroTemporaryMobileServerController` is an interface for platform adapters.
+The package includes:
+
+- `AiroNoOpTemporaryMobileServerController` for products without a backend.
+- `AiroFakeTemporaryMobileServerController` for deterministic tests and route
+  preflight automation.
+
+Neither adapter starts a network listener or serves media. Production mobile
+server code must live behind this interface and satisfy the same policy before
+the route engine can choose phone-local serving.

--- a/packages/core_media_routing/README.md
+++ b/packages/core_media_routing/README.md
@@ -13,13 +13,18 @@ product screens.
   models.
 - Versioned media location and route access-grant models.
 - Versioned route score breakdowns and privacy-safe decision logs.
+- Versioned secure temporary mobile server lifecycle and validation contracts.
 - Deterministic route preflight and selection.
 - Direct receiver playback preference before relay or phone-proxy fallback.
 - Redacted source and access handles for cloud, LAN, server, local file,
   phone-local, TV removable, desktop, and temporary access paths.
+- Temporary phone-local hosting gates for trusted receivers, LAN-only exposure,
+  expiry, HEAD/probe handling, range reads, entity validation, auto-shutdown,
+  and battery/thermal state.
 - Privacy-safe diagnostics that expose ids, scores, reasons, and blocker codes,
   not raw source values.
 
 This package does not start a media server, open playback, inspect codecs from a
 platform SDK, collect route health events, issue playback access grants, or own
-playback-session state.
+playback-session state. Fake and no-op temporary mobile server controllers exist
+only for deterministic tests and product integration boundaries.

--- a/packages/core_media_routing/lib/core_media_routing.dart
+++ b/packages/core_media_routing/lib/core_media_routing.dart
@@ -3,3 +3,4 @@ library;
 export 'src/media_location_models.dart';
 export 'src/media_route_scoring_models.dart';
 export 'src/media_routing_models.dart';
+export 'src/temporary_mobile_server_models.dart';

--- a/packages/core_media_routing/lib/src/temporary_mobile_server_models.dart
+++ b/packages/core_media_routing/lib/src/temporary_mobile_server_models.dart
@@ -1,0 +1,380 @@
+import 'dart:async';
+
+import 'package:equatable/equatable.dart';
+
+import 'media_location_models.dart';
+
+const String kAiroTemporaryMobileServerSchemaVersion = '1.0.0';
+
+enum AiroTemporaryMobileServerCapability {
+  lanOnly('lan_only'),
+  rangeRequests('range_requests'),
+  probeRequests('head_probe_requests'),
+  entityValidation('entity_validation'),
+  autoShutdownOnExpiry('auto_shutdown_on_expiry'),
+  idleShutdown('idle_shutdown');
+
+  const AiroTemporaryMobileServerCapability(this.stableId);
+
+  final String stableId;
+}
+
+enum AiroTemporaryMobileThermalState {
+  normal('normal'),
+  warm('warm'),
+  hot('hot'),
+  critical('critical');
+
+  const AiroTemporaryMobileThermalState(this.stableId);
+
+  final String stableId;
+}
+
+enum AiroTemporaryMobileServerValidationCode {
+  accepted('accepted'),
+  serverUnavailable('server_unavailable'),
+  expired('expired'),
+  idleTimeoutExceeded('idle_timeout_exceeded'),
+  localNetworkRequired('local_network_required'),
+  trustedReceiverRequired('trusted_receiver_required'),
+  receiverNotAllowed('receiver_not_allowed'),
+  grantAudienceMismatch('grant_audience_mismatch'),
+  grantExpired('grant_expired'),
+  grantScopeMissing('grant_scope_missing'),
+  rangeRequestsRequired('range_requests_required'),
+  probeRequestsRequired('head_probe_requests_required'),
+  entityValidationRequired('entity_validation_required'),
+  autoShutdownRequired('auto_shutdown_required'),
+  idleShutdownRequired('idle_shutdown_required'),
+  batteryTooLow('battery_too_low'),
+  thermalTooHigh('thermal_too_high'),
+  concurrentReceiverLimitExceeded('concurrent_receiver_limit_exceeded');
+
+  const AiroTemporaryMobileServerValidationCode(this.stableId);
+
+  final String stableId;
+}
+
+class AiroTemporaryMobileServerSnapshot extends Equatable {
+  AiroTemporaryMobileServerSnapshot({
+    required this.serverId,
+    required this.hostNodeId,
+    required this.locationId,
+    required this.mediaId,
+    required this.accessGrant,
+    required this.startedAt,
+    required this.expiresAt,
+    required this.batteryPercent,
+    required this.thermalState,
+    required Set<String> allowedReceiverNodeIds,
+    required Set<AiroTemporaryMobileServerCapability> capabilities,
+    this.lastActivityAt,
+    this.idleTimeout = const Duration(minutes: 2),
+    this.requiresTrustedReceiverScope = true,
+    this.isCharging = false,
+    this.activeReceiverCount = 0,
+    this.schemaVersion = kAiroTemporaryMobileServerSchemaVersion,
+  }) : allowedReceiverNodeIds = Set.unmodifiable(allowedReceiverNodeIds),
+       capabilities = Set.unmodifiable(capabilities),
+       assert(batteryPercent >= 0 && batteryPercent <= 100),
+       assert(activeReceiverCount >= 0);
+
+  final String schemaVersion;
+  final String serverId;
+  final String hostNodeId;
+  final String locationId;
+  final String mediaId;
+  final AiroRouteAccessGrant accessGrant;
+  final DateTime startedAt;
+  final DateTime expiresAt;
+  final DateTime? lastActivityAt;
+  final Duration idleTimeout;
+  final Set<String> allowedReceiverNodeIds;
+  final Set<AiroTemporaryMobileServerCapability> capabilities;
+  final bool requiresTrustedReceiverScope;
+  final int batteryPercent;
+  final bool isCharging;
+  final AiroTemporaryMobileThermalState thermalState;
+  final int activeReceiverCount;
+
+  bool isExpired(DateTime now) => !now.isBefore(expiresAt);
+
+  bool isIdleTimedOut(DateTime now) {
+    final lastActivity = lastActivityAt ?? startedAt;
+    return !now.isBefore(lastActivity.add(idleTimeout));
+  }
+
+  bool allowsReceiver(String receiverNodeId) =>
+      allowedReceiverNodeIds.contains(receiverNodeId);
+
+  bool supports(AiroTemporaryMobileServerCapability capability) =>
+      capabilities.contains(capability);
+
+  @override
+  String toString() {
+    return 'AiroTemporaryMobileServerSnapshot('
+        'serverId: $serverId, '
+        'hostNodeId: $hostNodeId, '
+        'locationId: $locationId, '
+        'mediaId: $mediaId, '
+        'grantId: ${accessGrant.grantId}, '
+        'audienceNodeId: ${accessGrant.audienceNodeId}, '
+        'capabilities: ${capabilities.map((capability) => capability.stableId).toList()}, '
+        'expiresAt: $expiresAt, '
+        'access: redacted'
+        ')';
+  }
+
+  @override
+  List<Object?> get props => [
+    schemaVersion,
+    serverId,
+    hostNodeId,
+    locationId,
+    mediaId,
+    accessGrant,
+    startedAt,
+    expiresAt,
+    lastActivityAt,
+    idleTimeout,
+    allowedReceiverNodeIds,
+    capabilities,
+    requiresTrustedReceiverScope,
+    batteryPercent,
+    isCharging,
+    thermalState,
+    activeReceiverCount,
+  ];
+}
+
+class AiroTemporaryMobileServerValidationContext extends Equatable {
+  const AiroTemporaryMobileServerValidationContext({
+    required this.now,
+    required this.receiverNodeId,
+    this.hasLocalNetworkScope = false,
+    this.hasTrustedReceiverScope = false,
+  });
+
+  final DateTime now;
+  final String receiverNodeId;
+  final bool hasLocalNetworkScope;
+  final bool hasTrustedReceiverScope;
+
+  @override
+  List<Object?> get props => [
+    now,
+    receiverNodeId,
+    hasLocalNetworkScope,
+    hasTrustedReceiverScope,
+  ];
+}
+
+class AiroTemporaryMobileServerValidationResult extends Equatable {
+  AiroTemporaryMobileServerValidationResult({
+    required this.serverId,
+    required List<AiroTemporaryMobileServerValidationCode> codes,
+  }) : codes = List.unmodifiable(codes);
+
+  final String serverId;
+  final List<AiroTemporaryMobileServerValidationCode> codes;
+
+  bool get accepted =>
+      codes.length == 1 &&
+      codes.single == AiroTemporaryMobileServerValidationCode.accepted;
+
+  @override
+  List<Object?> get props => [serverId, codes];
+}
+
+class AiroTemporaryMobileServerPolicy {
+  const AiroTemporaryMobileServerPolicy({
+    this.minBatteryPercent = 20,
+    this.maxAllowedThermalState = AiroTemporaryMobileThermalState.warm,
+    this.maxConcurrentReceivers = 1,
+    this.requiredAccessScopes = const {
+      AiroRouteAccessScope.playbackRead,
+      AiroRouteAccessScope.rangeRead,
+      AiroRouteAccessScope.probeRead,
+    },
+    this.requiredCapabilities = const {
+      AiroTemporaryMobileServerCapability.lanOnly,
+      AiroTemporaryMobileServerCapability.rangeRequests,
+      AiroTemporaryMobileServerCapability.probeRequests,
+      AiroTemporaryMobileServerCapability.entityValidation,
+      AiroTemporaryMobileServerCapability.autoShutdownOnExpiry,
+      AiroTemporaryMobileServerCapability.idleShutdown,
+    },
+  });
+
+  final int minBatteryPercent;
+  final AiroTemporaryMobileThermalState maxAllowedThermalState;
+  final int maxConcurrentReceivers;
+  final Set<AiroRouteAccessScope> requiredAccessScopes;
+  final Set<AiroTemporaryMobileServerCapability> requiredCapabilities;
+
+  AiroTemporaryMobileServerValidationResult validate({
+    required AiroTemporaryMobileServerSnapshot snapshot,
+    required AiroTemporaryMobileServerValidationContext context,
+  }) {
+    final codes = <AiroTemporaryMobileServerValidationCode>[];
+    if (snapshot.isExpired(context.now)) {
+      codes.add(AiroTemporaryMobileServerValidationCode.expired);
+    }
+    if (snapshot.isIdleTimedOut(context.now)) {
+      codes.add(AiroTemporaryMobileServerValidationCode.idleTimeoutExceeded);
+    }
+    if (!context.hasLocalNetworkScope ||
+        !snapshot.supports(AiroTemporaryMobileServerCapability.lanOnly)) {
+      codes.add(AiroTemporaryMobileServerValidationCode.localNetworkRequired);
+    }
+    if (snapshot.requiresTrustedReceiverScope &&
+        !context.hasTrustedReceiverScope) {
+      codes.add(
+        AiroTemporaryMobileServerValidationCode.trustedReceiverRequired,
+      );
+    }
+    if (!snapshot.allowsReceiver(context.receiverNodeId)) {
+      codes.add(AiroTemporaryMobileServerValidationCode.receiverNotAllowed);
+    }
+    if (!snapshot.accessGrant.isBoundTo(context.receiverNodeId)) {
+      codes.add(AiroTemporaryMobileServerValidationCode.grantAudienceMismatch);
+    }
+    if (snapshot.accessGrant.isExpired(context.now)) {
+      codes.add(AiroTemporaryMobileServerValidationCode.grantExpired);
+    }
+    if (!snapshot.accessGrant.allowsAll(requiredAccessScopes)) {
+      codes.add(AiroTemporaryMobileServerValidationCode.grantScopeMissing);
+    }
+    _addCapabilityBlockers(snapshot, codes);
+    if (!snapshot.isCharging && snapshot.batteryPercent < minBatteryPercent) {
+      codes.add(AiroTemporaryMobileServerValidationCode.batteryTooLow);
+    }
+    if (snapshot.thermalState.index > maxAllowedThermalState.index) {
+      codes.add(AiroTemporaryMobileServerValidationCode.thermalTooHigh);
+    }
+    if (snapshot.activeReceiverCount > maxConcurrentReceivers) {
+      codes.add(
+        AiroTemporaryMobileServerValidationCode.concurrentReceiverLimitExceeded,
+      );
+    }
+
+    return AiroTemporaryMobileServerValidationResult(
+      serverId: snapshot.serverId,
+      codes: codes.isEmpty
+          ? const [AiroTemporaryMobileServerValidationCode.accepted]
+          : codes,
+    );
+  }
+
+  void _addCapabilityBlockers(
+    AiroTemporaryMobileServerSnapshot snapshot,
+    List<AiroTemporaryMobileServerValidationCode> codes,
+  ) {
+    if (requiredCapabilities.contains(
+          AiroTemporaryMobileServerCapability.rangeRequests,
+        ) &&
+        !snapshot.supports(AiroTemporaryMobileServerCapability.rangeRequests)) {
+      codes.add(AiroTemporaryMobileServerValidationCode.rangeRequestsRequired);
+    }
+    if (requiredCapabilities.contains(
+          AiroTemporaryMobileServerCapability.probeRequests,
+        ) &&
+        !snapshot.supports(AiroTemporaryMobileServerCapability.probeRequests)) {
+      codes.add(AiroTemporaryMobileServerValidationCode.probeRequestsRequired);
+    }
+    if (requiredCapabilities.contains(
+          AiroTemporaryMobileServerCapability.entityValidation,
+        ) &&
+        !snapshot.supports(
+          AiroTemporaryMobileServerCapability.entityValidation,
+        )) {
+      codes.add(
+        AiroTemporaryMobileServerValidationCode.entityValidationRequired,
+      );
+    }
+    if (requiredCapabilities.contains(
+          AiroTemporaryMobileServerCapability.autoShutdownOnExpiry,
+        ) &&
+        !snapshot.supports(
+          AiroTemporaryMobileServerCapability.autoShutdownOnExpiry,
+        )) {
+      codes.add(AiroTemporaryMobileServerValidationCode.autoShutdownRequired);
+    }
+    if (requiredCapabilities.contains(
+          AiroTemporaryMobileServerCapability.idleShutdown,
+        ) &&
+        !snapshot.supports(AiroTemporaryMobileServerCapability.idleShutdown)) {
+      codes.add(AiroTemporaryMobileServerValidationCode.idleShutdownRequired);
+    }
+  }
+}
+
+abstract interface class AiroTemporaryMobileServerController {
+  FutureOr<AiroTemporaryMobileServerSnapshot?> currentSnapshot();
+
+  FutureOr<AiroTemporaryMobileServerValidationResult> validate(
+    AiroTemporaryMobileServerValidationContext context,
+  );
+
+  FutureOr<void> shutdown(String serverId);
+}
+
+class AiroNoOpTemporaryMobileServerController
+    implements AiroTemporaryMobileServerController {
+  const AiroNoOpTemporaryMobileServerController();
+
+  @override
+  FutureOr<AiroTemporaryMobileServerSnapshot?> currentSnapshot() => null;
+
+  @override
+  FutureOr<AiroTemporaryMobileServerValidationResult> validate(
+    AiroTemporaryMobileServerValidationContext context,
+  ) {
+    return AiroTemporaryMobileServerValidationResult(
+      serverId: 'none',
+      codes: const [AiroTemporaryMobileServerValidationCode.serverUnavailable],
+    );
+  }
+
+  @override
+  FutureOr<void> shutdown(String serverId) {}
+}
+
+class AiroFakeTemporaryMobileServerController
+    implements AiroTemporaryMobileServerController {
+  AiroFakeTemporaryMobileServerController({
+    this.snapshot,
+    this.policy = const AiroTemporaryMobileServerPolicy(),
+  });
+
+  AiroTemporaryMobileServerSnapshot? snapshot;
+  final AiroTemporaryMobileServerPolicy policy;
+  int shutdownCallCount = 0;
+
+  @override
+  FutureOr<AiroTemporaryMobileServerSnapshot?> currentSnapshot() => snapshot;
+
+  @override
+  FutureOr<AiroTemporaryMobileServerValidationResult> validate(
+    AiroTemporaryMobileServerValidationContext context,
+  ) {
+    final current = snapshot;
+    if (current == null) {
+      return AiroTemporaryMobileServerValidationResult(
+        serverId: 'none',
+        codes: const [
+          AiroTemporaryMobileServerValidationCode.serverUnavailable,
+        ],
+      );
+    }
+    return policy.validate(snapshot: current, context: context);
+  }
+
+  @override
+  FutureOr<void> shutdown(String serverId) {
+    shutdownCallCount += 1;
+    if (snapshot?.serverId == serverId) {
+      snapshot = null;
+    }
+  }
+}

--- a/packages/core_media_routing/test/temporary_mobile_server_models_test.dart
+++ b/packages/core_media_routing/test/temporary_mobile_server_models_test.dart
@@ -1,0 +1,322 @@
+import 'package:core_media_routing/core_media_routing.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('AiroTemporaryMobileServerPolicy', () {
+    const policy = AiroTemporaryMobileServerPolicy();
+    final now = DateTime.utc(2026, 7, 14, 12);
+
+    AiroRouteAccessGrant grant({
+      String audienceNodeId = 'tv-1',
+      Set<AiroRouteAccessScope> scopes = const {
+        AiroRouteAccessScope.playbackRead,
+        AiroRouteAccessScope.rangeRead,
+        AiroRouteAccessScope.probeRead,
+      },
+      DateTime? expiresAt,
+    }) {
+      return AiroRouteAccessGrant(
+        grantId: 'grant-1',
+        locationId: 'location-1',
+        audienceNodeId: audienceNodeId,
+        handle: AiroRouteAccessHandle.redacted('grant-handle'),
+        issuedAt: now,
+        expiresAt: expiresAt ?? now.add(const Duration(minutes: 4)),
+        scopes: scopes,
+      );
+    }
+
+    AiroTemporaryMobileServerSnapshot snapshot({
+      DateTime? expiresAt,
+      DateTime? lastActivityAt,
+      Set<String> allowedReceiverNodeIds = const {'tv-1'},
+      Set<AiroTemporaryMobileServerCapability> capabilities = const {
+        AiroTemporaryMobileServerCapability.lanOnly,
+        AiroTemporaryMobileServerCapability.rangeRequests,
+        AiroTemporaryMobileServerCapability.probeRequests,
+        AiroTemporaryMobileServerCapability.entityValidation,
+        AiroTemporaryMobileServerCapability.autoShutdownOnExpiry,
+        AiroTemporaryMobileServerCapability.idleShutdown,
+      },
+      AiroRouteAccessGrant? accessGrant,
+      int batteryPercent = 60,
+      bool isCharging = false,
+      AiroTemporaryMobileThermalState thermalState =
+          AiroTemporaryMobileThermalState.normal,
+      int activeReceiverCount = 1,
+    }) {
+      return AiroTemporaryMobileServerSnapshot(
+        serverId: 'server-1',
+        hostNodeId: 'phone-1',
+        locationId: 'location-1',
+        mediaId: 'media-1',
+        accessGrant: accessGrant ?? grant(),
+        startedAt: now.subtract(const Duration(seconds: 20)),
+        expiresAt: expiresAt ?? now.add(const Duration(minutes: 5)),
+        lastActivityAt:
+            lastActivityAt ?? now.subtract(const Duration(seconds: 5)),
+        allowedReceiverNodeIds: allowedReceiverNodeIds,
+        capabilities: capabilities,
+        batteryPercent: batteryPercent,
+        isCharging: isCharging,
+        thermalState: thermalState,
+        activeReceiverCount: activeReceiverCount,
+      );
+    }
+
+    final context = AiroTemporaryMobileServerValidationContext(
+      now: DateTime.utc(2026, 7, 14, 12),
+      receiverNodeId: 'tv-1',
+      hasLocalNetworkScope: true,
+      hasTrustedReceiverScope: true,
+    );
+
+    test('accepts trusted LAN receiver with required media-serving gates', () {
+      final current = snapshot();
+
+      final result = policy.validate(snapshot: current, context: context);
+
+      expect(result.accepted, isTrue);
+      expect(current.toString(), isNot(contains('grant-handle')));
+      expect(current.toString(), contains('access: redacted'));
+    });
+
+    test('rejects expired and idle-timed-out sessions', () {
+      final expired = snapshot(expiresAt: now);
+      final idle = snapshot(
+        lastActivityAt: now.subtract(const Duration(minutes: 3)),
+      );
+
+      final expiredResult = policy.validate(
+        snapshot: expired,
+        context: context,
+      );
+      final idleResult = policy.validate(snapshot: idle, context: context);
+
+      expect(
+        expiredResult.codes,
+        contains(AiroTemporaryMobileServerValidationCode.expired),
+      );
+      expect(
+        idleResult.codes,
+        contains(AiroTemporaryMobileServerValidationCode.idleTimeoutExceeded),
+      );
+    });
+
+    test('rejects non-LAN, untrusted, or unlisted receivers', () {
+      final current = snapshot(allowedReceiverNodeIds: const {'tv-2'});
+      final untrusted = AiroTemporaryMobileServerValidationContext(
+        now: DateTime.utc(2026, 7, 14, 12),
+        receiverNodeId: 'tv-1',
+      );
+
+      final untrustedResult = policy.validate(
+        snapshot: current,
+        context: untrusted,
+      );
+      final unlistedResult = policy.validate(
+        snapshot: current,
+        context: context,
+      );
+
+      expect(
+        untrustedResult.codes,
+        contains(AiroTemporaryMobileServerValidationCode.localNetworkRequired),
+      );
+      expect(
+        untrustedResult.codes,
+        contains(
+          AiroTemporaryMobileServerValidationCode.trustedReceiverRequired,
+        ),
+      );
+      expect(
+        unlistedResult.codes,
+        contains(AiroTemporaryMobileServerValidationCode.receiverNotAllowed),
+      );
+    });
+
+    test('rejects mismatched or underscoped grants', () {
+      final wrongAudience = snapshot(
+        accessGrant: grant(audienceNodeId: 'tv-2'),
+      );
+      final underscoped = snapshot(
+        accessGrant: grant(scopes: const {AiroRouteAccessScope.playbackRead}),
+      );
+
+      final wrongAudienceResult = policy.validate(
+        snapshot: wrongAudience,
+        context: context,
+      );
+      final underscopedResult = policy.validate(
+        snapshot: underscoped,
+        context: context,
+      );
+
+      expect(
+        wrongAudienceResult.codes,
+        contains(AiroTemporaryMobileServerValidationCode.grantAudienceMismatch),
+      );
+      expect(
+        underscopedResult.codes,
+        contains(AiroTemporaryMobileServerValidationCode.grantScopeMissing),
+      );
+    });
+
+    test('rejects missing range, probe, entity, and shutdown capabilities', () {
+      final current = snapshot(
+        capabilities: const {AiroTemporaryMobileServerCapability.lanOnly},
+      );
+
+      final result = policy.validate(snapshot: current, context: context);
+
+      expect(
+        result.codes,
+        contains(AiroTemporaryMobileServerValidationCode.rangeRequestsRequired),
+      );
+      expect(
+        result.codes,
+        contains(AiroTemporaryMobileServerValidationCode.probeRequestsRequired),
+      );
+      expect(
+        result.codes,
+        contains(
+          AiroTemporaryMobileServerValidationCode.entityValidationRequired,
+        ),
+      );
+      expect(
+        result.codes,
+        contains(AiroTemporaryMobileServerValidationCode.autoShutdownRequired),
+      );
+      expect(
+        result.codes,
+        contains(AiroTemporaryMobileServerValidationCode.idleShutdownRequired),
+      );
+    });
+
+    test('rejects low battery, high thermal state, and receiver overload', () {
+      final current = snapshot(
+        batteryPercent: 10,
+        thermalState: AiroTemporaryMobileThermalState.hot,
+        activeReceiverCount: 2,
+      );
+
+      final result = policy.validate(snapshot: current, context: context);
+
+      expect(
+        result.codes,
+        contains(AiroTemporaryMobileServerValidationCode.batteryTooLow),
+      );
+      expect(
+        result.codes,
+        contains(AiroTemporaryMobileServerValidationCode.thermalTooHigh),
+      );
+      expect(
+        result.codes,
+        contains(
+          AiroTemporaryMobileServerValidationCode
+              .concurrentReceiverLimitExceeded,
+        ),
+      );
+    });
+
+    test('allows charging device below the battery threshold', () {
+      final current = snapshot(batteryPercent: 10, isCharging: true);
+
+      final result = policy.validate(snapshot: current, context: context);
+
+      expect(
+        result.codes,
+        isNot(contains(AiroTemporaryMobileServerValidationCode.batteryTooLow)),
+      );
+      expect(result.accepted, isTrue);
+    });
+  });
+
+  group('AiroTemporaryMobileServerController fakes', () {
+    final now = DateTime.utc(2026, 7, 14, 12);
+
+    AiroTemporaryMobileServerSnapshot snapshot() {
+      return AiroTemporaryMobileServerSnapshot(
+        serverId: 'server-1',
+        hostNodeId: 'phone-1',
+        locationId: 'location-1',
+        mediaId: 'media-1',
+        accessGrant: AiroRouteAccessGrant(
+          grantId: 'grant-1',
+          locationId: 'location-1',
+          audienceNodeId: 'tv-1',
+          handle: AiroRouteAccessHandle.redacted('grant-handle'),
+          issuedAt: now,
+          expiresAt: now.add(const Duration(minutes: 4)),
+          scopes: const {
+            AiroRouteAccessScope.playbackRead,
+            AiroRouteAccessScope.rangeRead,
+            AiroRouteAccessScope.probeRead,
+          },
+        ),
+        startedAt: now.subtract(const Duration(seconds: 20)),
+        expiresAt: now.add(const Duration(minutes: 5)),
+        lastActivityAt: now.subtract(const Duration(seconds: 5)),
+        allowedReceiverNodeIds: const {'tv-1'},
+        capabilities: const {
+          AiroTemporaryMobileServerCapability.lanOnly,
+          AiroTemporaryMobileServerCapability.rangeRequests,
+          AiroTemporaryMobileServerCapability.probeRequests,
+          AiroTemporaryMobileServerCapability.entityValidation,
+          AiroTemporaryMobileServerCapability.autoShutdownOnExpiry,
+          AiroTemporaryMobileServerCapability.idleShutdown,
+        },
+        batteryPercent: 80,
+        thermalState: AiroTemporaryMobileThermalState.normal,
+      );
+    }
+
+    test(
+      'no-op controller reports unavailable without a platform backend',
+      () async {
+        const controller = AiroNoOpTemporaryMobileServerController();
+
+        final result = await Future.value(
+          controller.validate(
+            AiroTemporaryMobileServerValidationContext(
+              now: DateTime.utc(2026, 7, 14, 12),
+              receiverNodeId: 'tv-1',
+              hasLocalNetworkScope: true,
+              hasTrustedReceiverScope: true,
+            ),
+          ),
+        );
+
+        expect(
+          result.codes,
+          contains(AiroTemporaryMobileServerValidationCode.serverUnavailable),
+        );
+      },
+    );
+
+    test(
+      'fake controller validates and shuts down deterministic state',
+      () async {
+        final controller = AiroFakeTemporaryMobileServerController(
+          snapshot: snapshot(),
+        );
+
+        final result = await Future.value(
+          controller.validate(
+            AiroTemporaryMobileServerValidationContext(
+              now: DateTime.utc(2026, 7, 14, 12),
+              receiverNodeId: 'tv-1',
+              hasLocalNetworkScope: true,
+              hasTrustedReceiverScope: true,
+            ),
+          ),
+        );
+        await Future.value(controller.shutdown('server-1'));
+
+        expect(result.accepted, isTrue);
+        expect(controller.shutdownCallCount, 1);
+        expect(await Future.value(controller.currentSnapshot()), isNull);
+      },
+    );
+  });
+}


### PR DESCRIPTION
# Summary

This PR closes #613 by adding the v2 platform contract for secure temporary mobile server eligibility and validation.

Core outcome:

* defines the reusable temporary mobile server snapshot, validation policy, and controller boundary in `core_media_routing`
* enforces LAN-only exposure, trusted receiver scope, allow-list binding, expiring grants, range/probe/entity support, auto/idle shutdown, and battery/thermal gates
* adds fake/no-op controllers for deterministic route preflight without starting a production phone server

# Changes

### Code

* Added:
  * `AiroTemporaryMobileServerSnapshot`
  * `AiroTemporaryMobileServerPolicy`
  * `AiroTemporaryMobileServerController`
  * no-op and fake temporary mobile server controllers
  * capability, thermal, and validation code enums
  * unit coverage for acceptance, expiry, idle timeout, LAN/trust/allow-list gates, grant checks, capability gates, battery/thermal gates, receiver limits, and fake/no-op controllers
* Updated:
  * `packages/core_media_routing` exports and README
  * `docs/features/airo-tv/TEMPORARY_MOBILE_SERVER_CONTRACT.md`

### Logic

* Phone-local temporary serving remains a platform preflight contract only.
* Raw local URLs, file paths, addresses, and access material stay outside diagnostics.
* Production server startup and media serving remain out of scope behind the controller boundary.

# API Changes

* Adds new public Dart temporary mobile server model/policy/controller exports from `package:core_media_routing/core_media_routing.dart`.
* No app-layer API or product workflow change.

# Risks

* Low: this is additive platform contract work with fake/no-op controllers only.
* Rollback plan: revert this additive package/doc commit.

# Testing

* `dart format --set-exit-if-changed packages/core_media_routing`
* `cd packages/core_media_routing && flutter test`
* `cd packages/core_media_routing && flutter analyze --fatal-infos`
* `git diff --check HEAD~1..HEAD`
* diff-only secret scan for `password|secret|api_key|token`

Closes #613
