### PR TITLE
feat(platform): add media capability contract

### DIFF
--- a/docs/features/airo-tv/MEDIA_CAPABILITY_DETECTION_CONTRACT.md
+++ b/docs/features/airo-tv/MEDIA_CAPABILITY_DETECTION_CONTRACT.md
@@ -1,0 +1,83 @@
+# Media Capability Detection Contract
+
+Status: v2 platform contract for ATV-024.
+
+## Ownership
+
+Media capability detection is platform/framework behavior. Airo TV consumes the
+result to select routes, choose fallback media, and present product-specific UX,
+but it must not hard-code codec or decoder assumptions in app screens.
+
+The initial contract lives in `packages/platform_media` because it sits beside
+playback-adjacent platform adapters and can later be consumed by media routing,
+playback engines, device certification, and product profiles.
+
+## Contract Shape
+
+`AiroMediaRequirement` describes normalized media needs:
+
+- container
+- video codec
+- audio codecs
+- subtitle formats
+- resolution
+- bitrate
+- frame rate
+- HDR format
+- adaptive streaming requirement
+- hardware-decoder requirement
+
+`AiroMediaDeviceCapabilityProfile` describes normalized receiver capability:
+
+- supported containers
+- video decoder capabilities
+- audio decoder capabilities
+- subtitle support
+- adaptive streaming support
+- profile availability
+
+`AiroMediaCapabilityPolicy` returns stable blocker codes:
+
+- `accepted`
+- `profile_unavailable`
+- `container_unsupported`
+- `adaptive_streaming_required`
+- `video_codec_unsupported`
+- `hardware_decoder_required`
+- `resolution_too_high`
+- `bitrate_too_high`
+- `frame_rate_too_high`
+- `hdr_unsupported`
+- `audio_codec_unsupported`
+- `audio_channel_count_too_high`
+- `subtitle_unsupported`
+
+## Adapter Boundary
+
+`AiroMediaCapabilityDetector` is the platform adapter interface. The package
+includes:
+
+- `AiroNoOpMediaCapabilityDetector` for products without native probing.
+- `AiroFakeMediaCapabilityDetector` for deterministic QA and route-preflight
+  tests.
+
+No adapter in this issue imports native SDKs, reads media files, opens network
+streams, or starts playback. Platform-specific probing must be implemented
+behind this interface.
+
+## Privacy And Diagnostics
+
+Diagnostics expose normalized ids, capability categories, decoder kind, and
+stable blocker codes. They must not expose raw stream URLs, local file paths,
+network addresses, access material, or unique hardware identifiers.
+
+## Deterministic Use Cases
+
+- HLS or MP4 with H.264/AAC/SDR/WebVTT is accepted when receiver capabilities
+  match the media requirement.
+- AV1, HEVC, HDR, high bitrate, high resolution, or advanced subtitles are
+  rejected unless the receiver profile explicitly supports them.
+- A hardware-decoder-required requirement rejects software-only support.
+- Missing adaptive streaming support rejects HLS/DASH paths that require it.
+- No-op detection reports an unavailable profile with stable blocker codes.
+- Fake detection returns deterministic profiles for QA automation.

--- a/packages/platform_media/README.md
+++ b/packages/platform_media/README.md
@@ -1,39 +1,65 @@
-<!--
-This README describes the package. If you publish this package to pub.dev,
-this README's contents appear on the landing page for your package.
+# Platform Media
 
-For information about how to write a good package README, see the guide for
-[writing package pages](https://dart.dev/tools/pub/writing-package-pages).
+Reusable media platform contracts and adapters for Airo products.
 
-For general information about developing packages, see the Dart guide for
-[creating packages](https://dart.dev/guides/libraries/create-packages)
-and the Flutter guide for
-[developing packages and plugins](https://flutter.dev/to/develop-packages).
--->
+This package owns playback-adjacent platform behavior that should not be
+hard-coded inside product screens. Airo TV, route selection, QA automation, and
+future native media adapters consume these contracts through stable interfaces.
 
-TODO: Put a short description of the package here that helps potential users
-know whether this package might be useful for them.
+## Scope
 
-## Features
+- Video-player based IPTV streaming service.
+- Privacy-filtered platform media analytics logging.
+- Versioned media capability requirement and device profile models.
+- Deterministic media capability preflight blocker codes for codec, container,
+  HDR, bitrate, resolution, subtitles, audio, adaptive streaming, and decoder
+  kind.
+- Fake and no-op media capability detectors for automation and integration
+  boundaries.
 
-TODO: List what your package can do. Maybe include images, gifs, or videos.
-
-## Getting started
-
-TODO: List prerequisites and provide or point to information on how to
-start using the package.
+This package does not perform native decoder probing yet, inspect raw media
+files, own route selection, or decide Airo TV product UX. Native adapters should
+plug in behind `AiroMediaCapabilityDetector`.
 
 ## Usage
 
-TODO: Include short and useful examples for package users. Add longer examples
-to `/example` folder.
-
 ```dart
-const like = 'sample';
+final profile = AiroMediaDeviceCapabilityProfile(
+  profileId: 'receiver-lite',
+  observedAt: DateTime.utc(2026, 7, 14),
+  supportedContainers: const {AiroMediaContainer.hls},
+  supportsAdaptiveStreaming: true,
+  videoDecoders: [
+    AiroVideoDecoderCapability(
+      codec: AiroVideoCodec.h264,
+      kind: AiroMediaDecoderKind.hardware,
+      maxWidth: 1920,
+      maxHeight: 1080,
+      maxBitrateKbps: 8000,
+      hdrFormats: const {AiroHdrFormat.sdr},
+    ),
+  ],
+  audioDecoders: const [
+    AiroAudioDecoderCapability(codec: AiroAudioCodec.aac, maxChannelCount: 2),
+  ],
+  subtitleFormats: const {AiroSubtitleFormat.webVtt},
+);
+
+final result = const AiroMediaCapabilityPolicy().validate(
+  profile: profile,
+  requirement: AiroMediaRequirement(
+    mediaId: 'episode-1',
+    container: AiroMediaContainer.hls,
+    videoCodec: AiroVideoCodec.h264,
+    audioCodecs: const {AiroAudioCodec.aac},
+    subtitleFormats: const {AiroSubtitleFormat.webVtt},
+    width: 1280,
+    height: 720,
+    bitrateKbps: 4500,
+    requiresAdaptiveStreaming: true,
+  ),
+);
 ```
 
-## Additional information
-
-TODO: Tell users more about the package: where to find more information, how to
-contribute to the package, how to file issues, what response they can expect
-from the package authors, and more.
+Diagnostics expose normalized ids and blocker codes, not source handles, local
+paths, addresses, or unique hardware identifiers.

--- a/packages/platform_media/lib/platform_media.dart
+++ b/packages/platform_media/lib/platform_media.dart
@@ -1,4 +1,5 @@
 library;
 
+export "src/media_capability_models.dart";
 export "src/platform_media_logger.dart";
 export "src/video_player_streaming_service.dart";

--- a/packages/platform_media/lib/src/media_capability_models.dart
+++ b/packages/platform_media/lib/src/media_capability_models.dart
@@ -1,0 +1,475 @@
+import 'dart:async';
+
+const String kAiroMediaCapabilitySchemaVersion = '1.0.0';
+
+enum AiroMediaContainer {
+  hls('hls'),
+  dash('dash'),
+  mp4('mp4'),
+  mpegTs('mpeg_ts'),
+  matroska('matroska'),
+  unknown('unknown');
+
+  const AiroMediaContainer(this.stableId);
+
+  final String stableId;
+}
+
+enum AiroVideoCodec {
+  h264('h264'),
+  h265('h265'),
+  av1('av1'),
+  vp9('vp9'),
+  mpeg2('mpeg2'),
+  unknown('unknown');
+
+  const AiroVideoCodec(this.stableId);
+
+  final String stableId;
+}
+
+enum AiroAudioCodec {
+  aac('aac'),
+  ac3('ac3'),
+  eac3('eac3'),
+  mp3('mp3'),
+  opus('opus'),
+  pcm('pcm'),
+  unknown('unknown');
+
+  const AiroAudioCodec(this.stableId);
+
+  final String stableId;
+}
+
+enum AiroHdrFormat {
+  sdr('sdr'),
+  hdr10('hdr10'),
+  hdr10Plus('hdr10_plus'),
+  dolbyVision('dolby_vision'),
+  hlg('hlg'),
+  unknown('unknown');
+
+  const AiroHdrFormat(this.stableId);
+
+  final String stableId;
+}
+
+enum AiroSubtitleFormat {
+  none('none'),
+  webVtt('web_vtt'),
+  srt('srt'),
+  cea608('cea_608'),
+  ttml('ttml'),
+  imageBased('image_based'),
+  unknown('unknown');
+
+  const AiroSubtitleFormat(this.stableId);
+
+  final String stableId;
+}
+
+enum AiroMediaDecoderKind {
+  hardware('hardware'),
+  software('software'),
+  hybrid('hybrid'),
+  unknown('unknown');
+
+  const AiroMediaDecoderKind(this.stableId);
+
+  final String stableId;
+}
+
+enum AiroMediaCapabilityBlockerCode {
+  accepted('accepted'),
+  profileUnavailable('profile_unavailable'),
+  containerUnsupported('container_unsupported'),
+  adaptiveStreamingRequired('adaptive_streaming_required'),
+  videoCodecUnsupported('video_codec_unsupported'),
+  hardwareDecoderRequired('hardware_decoder_required'),
+  resolutionTooHigh('resolution_too_high'),
+  bitrateTooHigh('bitrate_too_high'),
+  frameRateTooHigh('frame_rate_too_high'),
+  hdrUnsupported('hdr_unsupported'),
+  audioCodecUnsupported('audio_codec_unsupported'),
+  audioChannelCountTooHigh('audio_channel_count_too_high'),
+  subtitleUnsupported('subtitle_unsupported');
+
+  const AiroMediaCapabilityBlockerCode(this.stableId);
+
+  final String stableId;
+}
+
+class AiroMediaRequirement {
+  AiroMediaRequirement({
+    required this.mediaId,
+    required this.container,
+    required this.videoCodec,
+    required Set<AiroAudioCodec> audioCodecs,
+    required Set<AiroSubtitleFormat> subtitleFormats,
+    required this.width,
+    required this.height,
+    required this.bitrateKbps,
+    this.hdrFormat = AiroHdrFormat.sdr,
+    this.frameRate = 30,
+    this.audioChannelCount = 2,
+    this.requiresAdaptiveStreaming = false,
+    this.requiresHardwareDecoder = false,
+    this.schemaVersion = kAiroMediaCapabilitySchemaVersion,
+  }) : audioCodecs = Set.unmodifiable(audioCodecs),
+       subtitleFormats = Set.unmodifiable(subtitleFormats),
+       assert(width > 0),
+       assert(height > 0),
+       assert(bitrateKbps > 0),
+       assert(frameRate > 0),
+       assert(audioChannelCount > 0);
+
+  final String schemaVersion;
+  final String mediaId;
+  final AiroMediaContainer container;
+  final AiroVideoCodec videoCodec;
+  final Set<AiroAudioCodec> audioCodecs;
+  final Set<AiroSubtitleFormat> subtitleFormats;
+  final int width;
+  final int height;
+  final int bitrateKbps;
+  final AiroHdrFormat hdrFormat;
+  final int frameRate;
+  final int audioChannelCount;
+  final bool requiresAdaptiveStreaming;
+  final bool requiresHardwareDecoder;
+
+  @override
+  String toString() {
+    return 'AiroMediaRequirement('
+        'mediaId: $mediaId, '
+        'container: ${container.stableId}, '
+        'videoCodec: ${videoCodec.stableId}, '
+        'audioCodecs: ${audioCodecs.map((codec) => codec.stableId).toList()}, '
+        'subtitleFormats: ${subtitleFormats.map((format) => format.stableId).toList()}, '
+        'resolution: ${width}x$height, '
+        'bitrateKbps: $bitrateKbps, '
+        'hdrFormat: ${hdrFormat.stableId}'
+        ')';
+  }
+}
+
+class AiroVideoDecoderCapability {
+  AiroVideoDecoderCapability({
+    required this.codec,
+    required this.kind,
+    required this.maxWidth,
+    required this.maxHeight,
+    required this.maxBitrateKbps,
+    required Set<AiroHdrFormat> hdrFormats,
+    this.maxFrameRate = 60,
+  }) : hdrFormats = Set.unmodifiable(hdrFormats),
+       assert(maxWidth > 0),
+       assert(maxHeight > 0),
+       assert(maxBitrateKbps > 0),
+       assert(maxFrameRate > 0);
+
+  final AiroVideoCodec codec;
+  final AiroMediaDecoderKind kind;
+  final int maxWidth;
+  final int maxHeight;
+  final int maxBitrateKbps;
+  final int maxFrameRate;
+  final Set<AiroHdrFormat> hdrFormats;
+
+  bool get isHardwareAccelerated =>
+      kind == AiroMediaDecoderKind.hardware ||
+      kind == AiroMediaDecoderKind.hybrid;
+
+  bool canDecode(AiroMediaRequirement requirement) {
+    return codec == requirement.videoCodec &&
+        maxWidth >= requirement.width &&
+        maxHeight >= requirement.height &&
+        maxBitrateKbps >= requirement.bitrateKbps &&
+        maxFrameRate >= requirement.frameRate &&
+        hdrFormats.contains(requirement.hdrFormat);
+  }
+}
+
+class AiroAudioDecoderCapability {
+  const AiroAudioDecoderCapability({
+    required this.codec,
+    required this.maxChannelCount,
+    this.supportsPassthrough = false,
+  }) : assert(maxChannelCount > 0);
+
+  final AiroAudioCodec codec;
+  final int maxChannelCount;
+  final bool supportsPassthrough;
+
+  bool canDecode(AiroAudioCodec requiredCodec, int requiredChannelCount) {
+    return codec == requiredCodec && maxChannelCount >= requiredChannelCount;
+  }
+}
+
+class AiroMediaDeviceCapabilityProfile {
+  AiroMediaDeviceCapabilityProfile({
+    required this.profileId,
+    required this.observedAt,
+    required Set<AiroMediaContainer> supportedContainers,
+    required List<AiroVideoDecoderCapability> videoDecoders,
+    required List<AiroAudioDecoderCapability> audioDecoders,
+    required Set<AiroSubtitleFormat> subtitleFormats,
+    this.supportsAdaptiveStreaming = false,
+    this.isAvailable = true,
+    this.schemaVersion = kAiroMediaCapabilitySchemaVersion,
+  }) : supportedContainers = Set.unmodifiable(supportedContainers),
+       videoDecoders = List.unmodifiable(videoDecoders),
+       audioDecoders = List.unmodifiable(audioDecoders),
+       subtitleFormats = Set.unmodifiable(subtitleFormats);
+
+  AiroMediaDeviceCapabilityProfile.unavailable({
+    required this.observedAt,
+    this.profileId = 'unavailable',
+    this.schemaVersion = kAiroMediaCapabilitySchemaVersion,
+  }) : supportedContainers = const {},
+       videoDecoders = const [],
+       audioDecoders = const [],
+       subtitleFormats = const {},
+       supportsAdaptiveStreaming = false,
+       isAvailable = false;
+
+  final String schemaVersion;
+  final String profileId;
+  final DateTime observedAt;
+  final Set<AiroMediaContainer> supportedContainers;
+  final List<AiroVideoDecoderCapability> videoDecoders;
+  final List<AiroAudioDecoderCapability> audioDecoders;
+  final Set<AiroSubtitleFormat> subtitleFormats;
+  final bool supportsAdaptiveStreaming;
+  final bool isAvailable;
+
+  AiroVideoDecoderCapability? bestVideoDecoderFor(
+    AiroMediaRequirement requirement,
+  ) {
+    final matching =
+        videoDecoders
+            .where((decoder) => decoder.canDecode(requirement))
+            .toList()
+          ..sort((left, right) {
+            final hardwareRank = right.isHardwareAccelerated
+                .toString()
+                .compareTo(left.isHardwareAccelerated.toString());
+            if (hardwareRank != 0) return hardwareRank;
+            return left.kind.stableId.compareTo(right.kind.stableId);
+          });
+    return matching.isEmpty ? null : matching.first;
+  }
+
+  bool supportsAllSubtitles(Set<AiroSubtitleFormat> requiredFormats) =>
+      subtitleFormats.containsAll(requiredFormats);
+
+  @override
+  String toString() {
+    return 'AiroMediaDeviceCapabilityProfile('
+        'profileId: $profileId, '
+        'isAvailable: $isAvailable, '
+        'containers: ${supportedContainers.map((container) => container.stableId).toList()}, '
+        'videoCodecs: ${videoDecoders.map((decoder) => decoder.codec.stableId).toSet().toList()}, '
+        'audioCodecs: ${audioDecoders.map((decoder) => decoder.codec.stableId).toSet().toList()}, '
+        'subtitleFormats: ${subtitleFormats.map((format) => format.stableId).toList()}'
+        ')';
+  }
+}
+
+class AiroMediaCapabilityPreflightResult {
+  AiroMediaCapabilityPreflightResult({
+    required this.profileId,
+    required this.mediaId,
+    required List<AiroMediaCapabilityBlockerCode> blockers,
+    this.selectedDecoderKind,
+  }) : blockers = List.unmodifiable(blockers);
+
+  final String profileId;
+  final String mediaId;
+  final List<AiroMediaCapabilityBlockerCode> blockers;
+  final AiroMediaDecoderKind? selectedDecoderKind;
+
+  bool get accepted =>
+      blockers.length == 1 &&
+      blockers.single == AiroMediaCapabilityBlockerCode.accepted;
+
+  @override
+  String toString() {
+    return 'AiroMediaCapabilityPreflightResult('
+        'profileId: $profileId, '
+        'mediaId: $mediaId, '
+        'blockers: ${blockers.map((blocker) => blocker.stableId).toList()}, '
+        'selectedDecoderKind: ${selectedDecoderKind?.stableId}'
+        ')';
+  }
+}
+
+class AiroMediaCapabilityPolicy {
+  const AiroMediaCapabilityPolicy();
+
+  AiroMediaCapabilityPreflightResult validate({
+    required AiroMediaDeviceCapabilityProfile profile,
+    required AiroMediaRequirement requirement,
+  }) {
+    final blockers = <AiroMediaCapabilityBlockerCode>[];
+    if (!profile.isAvailable) {
+      blockers.add(AiroMediaCapabilityBlockerCode.profileUnavailable);
+    }
+    if (!profile.supportedContainers.contains(requirement.container)) {
+      blockers.add(AiroMediaCapabilityBlockerCode.containerUnsupported);
+    }
+    if (requirement.requiresAdaptiveStreaming &&
+        !profile.supportsAdaptiveStreaming) {
+      blockers.add(AiroMediaCapabilityBlockerCode.adaptiveStreamingRequired);
+    }
+
+    final videoDecoders = profile.videoDecoders
+        .where((decoder) => decoder.codec == requirement.videoCodec)
+        .toList();
+    final selectedVideoDecoder = profile.bestVideoDecoderFor(requirement);
+    if (videoDecoders.isEmpty) {
+      blockers.add(AiroMediaCapabilityBlockerCode.videoCodecUnsupported);
+    } else {
+      _addVideoLimitBlockers(
+        requirement,
+        videoDecoders,
+        selectedVideoDecoder,
+        blockers,
+      );
+    }
+
+    _addAudioBlockers(profile, requirement, blockers);
+    if (!profile.supportsAllSubtitles(requirement.subtitleFormats)) {
+      blockers.add(AiroMediaCapabilityBlockerCode.subtitleUnsupported);
+    }
+
+    return AiroMediaCapabilityPreflightResult(
+      profileId: profile.profileId,
+      mediaId: requirement.mediaId,
+      selectedDecoderKind: selectedVideoDecoder?.kind,
+      blockers: blockers.isEmpty
+          ? const [AiroMediaCapabilityBlockerCode.accepted]
+          : blockers,
+    );
+  }
+
+  void _addVideoLimitBlockers(
+    AiroMediaRequirement requirement,
+    List<AiroVideoDecoderCapability> videoDecoders,
+    AiroVideoDecoderCapability? selectedVideoDecoder,
+    List<AiroMediaCapabilityBlockerCode> blockers,
+  ) {
+    if (requirement.requiresHardwareDecoder &&
+        !videoDecoders.any(
+          (decoder) =>
+              decoder.isHardwareAccelerated && decoder.canDecode(requirement),
+        )) {
+      blockers.add(AiroMediaCapabilityBlockerCode.hardwareDecoderRequired);
+    }
+    if (!videoDecoders.any(
+      (decoder) =>
+          decoder.maxWidth >= requirement.width &&
+          decoder.maxHeight >= requirement.height,
+    )) {
+      blockers.add(AiroMediaCapabilityBlockerCode.resolutionTooHigh);
+    }
+    if (!videoDecoders.any(
+      (decoder) => decoder.maxBitrateKbps >= requirement.bitrateKbps,
+    )) {
+      blockers.add(AiroMediaCapabilityBlockerCode.bitrateTooHigh);
+    }
+    if (!videoDecoders.any(
+      (decoder) => decoder.maxFrameRate >= requirement.frameRate,
+    )) {
+      blockers.add(AiroMediaCapabilityBlockerCode.frameRateTooHigh);
+    }
+    if (!videoDecoders.any(
+      (decoder) => decoder.hdrFormats.contains(requirement.hdrFormat),
+    )) {
+      blockers.add(AiroMediaCapabilityBlockerCode.hdrUnsupported);
+    }
+    if (selectedVideoDecoder == null &&
+        !blockers.contains(
+          AiroMediaCapabilityBlockerCode.videoCodecUnsupported,
+        )) {
+      blockers.add(AiroMediaCapabilityBlockerCode.videoCodecUnsupported);
+    }
+  }
+
+  void _addAudioBlockers(
+    AiroMediaDeviceCapabilityProfile profile,
+    AiroMediaRequirement requirement,
+    List<AiroMediaCapabilityBlockerCode> blockers,
+  ) {
+    for (final audioCodec in requirement.audioCodecs) {
+      final matching = profile.audioDecoders
+          .where((decoder) => decoder.codec == audioCodec)
+          .toList();
+      if (matching.isEmpty) {
+        blockers.add(AiroMediaCapabilityBlockerCode.audioCodecUnsupported);
+        continue;
+      }
+      if (!matching.any(
+        (decoder) => decoder.maxChannelCount >= requirement.audioChannelCount,
+      )) {
+        blockers.add(AiroMediaCapabilityBlockerCode.audioChannelCountTooHigh);
+      }
+    }
+  }
+}
+
+abstract interface class AiroMediaCapabilityDetector {
+  FutureOr<AiroMediaDeviceCapabilityProfile> currentProfile();
+
+  FutureOr<AiroMediaCapabilityPreflightResult> preflight(
+    AiroMediaRequirement requirement,
+  );
+}
+
+class AiroNoOpMediaCapabilityDetector implements AiroMediaCapabilityDetector {
+  const AiroNoOpMediaCapabilityDetector({
+    this.policy = const AiroMediaCapabilityPolicy(),
+  });
+
+  final AiroMediaCapabilityPolicy policy;
+
+  @override
+  FutureOr<AiroMediaDeviceCapabilityProfile> currentProfile() {
+    return AiroMediaDeviceCapabilityProfile.unavailable(
+      observedAt: DateTime.fromMillisecondsSinceEpoch(0, isUtc: true),
+    );
+  }
+
+  @override
+  FutureOr<AiroMediaCapabilityPreflightResult> preflight(
+    AiroMediaRequirement requirement,
+  ) {
+    return policy.validate(
+      profile: AiroMediaDeviceCapabilityProfile.unavailable(
+        observedAt: DateTime.fromMillisecondsSinceEpoch(0, isUtc: true),
+      ),
+      requirement: requirement,
+    );
+  }
+}
+
+class AiroFakeMediaCapabilityDetector implements AiroMediaCapabilityDetector {
+  const AiroFakeMediaCapabilityDetector({
+    required this.profile,
+    this.policy = const AiroMediaCapabilityPolicy(),
+  });
+
+  final AiroMediaDeviceCapabilityProfile profile;
+  final AiroMediaCapabilityPolicy policy;
+
+  @override
+  FutureOr<AiroMediaDeviceCapabilityProfile> currentProfile() => profile;
+
+  @override
+  FutureOr<AiroMediaCapabilityPreflightResult> preflight(
+    AiroMediaRequirement requirement,
+  ) {
+    return policy.validate(profile: profile, requirement: requirement);
+  }
+}

--- a/packages/platform_media/test/media_capability_models_test.dart
+++ b/packages/platform_media/test/media_capability_models_test.dart
@@ -1,0 +1,335 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:platform_media/platform_media.dart';
+
+void main() {
+  group('AiroMediaCapabilityPolicy', () {
+    const policy = AiroMediaCapabilityPolicy();
+    final now = DateTime.utc(2026, 7, 14, 12);
+
+    AiroMediaDeviceCapabilityProfile profile({
+      Set<AiroMediaContainer> containers = const {
+        AiroMediaContainer.hls,
+        AiroMediaContainer.mp4,
+        AiroMediaContainer.mpegTs,
+      },
+      List<AiroVideoDecoderCapability>? videoDecoders,
+      List<AiroAudioDecoderCapability> audioDecoders = const [
+        AiroAudioDecoderCapability(
+          codec: AiroAudioCodec.aac,
+          maxChannelCount: 2,
+        ),
+        AiroAudioDecoderCapability(
+          codec: AiroAudioCodec.ac3,
+          maxChannelCount: 6,
+          supportsPassthrough: true,
+        ),
+      ],
+      Set<AiroSubtitleFormat> subtitleFormats = const {
+        AiroSubtitleFormat.webVtt,
+        AiroSubtitleFormat.cea608,
+      },
+      bool supportsAdaptiveStreaming = true,
+    }) {
+      return AiroMediaDeviceCapabilityProfile(
+        profileId: 'receiver-1',
+        observedAt: now,
+        supportedContainers: containers,
+        supportsAdaptiveStreaming: supportsAdaptiveStreaming,
+        videoDecoders:
+            videoDecoders ??
+            [
+              AiroVideoDecoderCapability(
+                codec: AiroVideoCodec.h264,
+                kind: AiroMediaDecoderKind.hardware,
+                maxWidth: 1920,
+                maxHeight: 1080,
+                maxBitrateKbps: 8000,
+                hdrFormats: const {AiroHdrFormat.sdr},
+              ),
+              AiroVideoDecoderCapability(
+                codec: AiroVideoCodec.h265,
+                kind: AiroMediaDecoderKind.software,
+                maxWidth: 1280,
+                maxHeight: 720,
+                maxBitrateKbps: 3000,
+                hdrFormats: const {AiroHdrFormat.sdr},
+              ),
+            ],
+        audioDecoders: audioDecoders,
+        subtitleFormats: subtitleFormats,
+      );
+    }
+
+    AiroMediaRequirement requirement({
+      AiroMediaContainer container = AiroMediaContainer.hls,
+      AiroVideoCodec videoCodec = AiroVideoCodec.h264,
+      Set<AiroAudioCodec> audioCodecs = const {AiroAudioCodec.aac},
+      Set<AiroSubtitleFormat> subtitleFormats = const {
+        AiroSubtitleFormat.webVtt,
+      },
+      AiroHdrFormat hdrFormat = AiroHdrFormat.sdr,
+      int width = 1280,
+      int height = 720,
+      int bitrateKbps = 4500,
+      int frameRate = 30,
+      int audioChannelCount = 2,
+      bool requiresAdaptiveStreaming = true,
+      bool requiresHardwareDecoder = false,
+    }) {
+      return AiroMediaRequirement(
+        mediaId: 'media-1',
+        container: container,
+        videoCodec: videoCodec,
+        audioCodecs: audioCodecs,
+        subtitleFormats: subtitleFormats,
+        hdrFormat: hdrFormat,
+        width: width,
+        height: height,
+        bitrateKbps: bitrateKbps,
+        frameRate: frameRate,
+        audioChannelCount: audioChannelCount,
+        requiresAdaptiveStreaming: requiresAdaptiveStreaming,
+        requiresHardwareDecoder: requiresHardwareDecoder,
+      );
+    }
+
+    test('accepts baseline HLS media when receiver capabilities match', () {
+      final result = policy.validate(
+        profile: profile(),
+        requirement: requirement(),
+      );
+
+      expect(result.accepted, isTrue);
+      expect(result.selectedDecoderKind, AiroMediaDecoderKind.hardware);
+    });
+
+    test('rejects unsupported container video audio and subtitles', () {
+      final result = policy.validate(
+        profile: profile(),
+        requirement: requirement(
+          container: AiroMediaContainer.matroska,
+          videoCodec: AiroVideoCodec.av1,
+          audioCodecs: const {AiroAudioCodec.opus},
+          subtitleFormats: const {AiroSubtitleFormat.srt},
+        ),
+      );
+
+      expect(
+        result.blockers,
+        contains(AiroMediaCapabilityBlockerCode.containerUnsupported),
+      );
+      expect(
+        result.blockers,
+        contains(AiroMediaCapabilityBlockerCode.videoCodecUnsupported),
+      );
+      expect(
+        result.blockers,
+        contains(AiroMediaCapabilityBlockerCode.audioCodecUnsupported),
+      );
+      expect(
+        result.blockers,
+        contains(AiroMediaCapabilityBlockerCode.subtitleUnsupported),
+      );
+    });
+
+    test(
+      'rejects bitrate resolution frame rate and HDR beyond decoder limits',
+      () {
+        final result = policy.validate(
+          profile: profile(),
+          requirement: requirement(
+            width: 3840,
+            height: 2160,
+            bitrateKbps: 18000,
+            frameRate: 120,
+            hdrFormat: AiroHdrFormat.hdr10,
+          ),
+        );
+
+        expect(
+          result.blockers,
+          contains(AiroMediaCapabilityBlockerCode.resolutionTooHigh),
+        );
+        expect(
+          result.blockers,
+          contains(AiroMediaCapabilityBlockerCode.bitrateTooHigh),
+        );
+        expect(
+          result.blockers,
+          contains(AiroMediaCapabilityBlockerCode.frameRateTooHigh),
+        );
+        expect(
+          result.blockers,
+          contains(AiroMediaCapabilityBlockerCode.hdrUnsupported),
+        );
+      },
+    );
+
+    test(
+      'rejects software-only decoder when hardware decoding is required',
+      () {
+        final result = policy.validate(
+          profile: profile(),
+          requirement: requirement(
+            videoCodec: AiroVideoCodec.h265,
+            bitrateKbps: 2500,
+            requiresHardwareDecoder: true,
+            requiresAdaptiveStreaming: false,
+          ),
+        );
+
+        expect(
+          result.blockers,
+          contains(AiroMediaCapabilityBlockerCode.hardwareDecoderRequired),
+        );
+      },
+    );
+
+    test(
+      'rejects hardware requirement when only software meets media limits',
+      () {
+        final result = policy.validate(
+          profile: profile(
+            videoDecoders: [
+              AiroVideoDecoderCapability(
+                codec: AiroVideoCodec.h265,
+                kind: AiroMediaDecoderKind.hardware,
+                maxWidth: 640,
+                maxHeight: 360,
+                maxBitrateKbps: 1000,
+                hdrFormats: const {AiroHdrFormat.sdr},
+              ),
+              AiroVideoDecoderCapability(
+                codec: AiroVideoCodec.h265,
+                kind: AiroMediaDecoderKind.software,
+                maxWidth: 1920,
+                maxHeight: 1080,
+                maxBitrateKbps: 8000,
+                hdrFormats: const {AiroHdrFormat.sdr},
+              ),
+            ],
+          ),
+          requirement: requirement(
+            videoCodec: AiroVideoCodec.h265,
+            requiresHardwareDecoder: true,
+            requiresAdaptiveStreaming: false,
+          ),
+        );
+
+        expect(
+          result.blockers,
+          contains(AiroMediaCapabilityBlockerCode.hardwareDecoderRequired),
+        );
+      },
+    );
+
+    test('rejects missing adaptive streaming and high audio channel count', () {
+      final result = policy.validate(
+        profile: profile(supportsAdaptiveStreaming: false),
+        requirement: requirement(audioChannelCount: 8),
+      );
+
+      expect(
+        result.blockers,
+        contains(AiroMediaCapabilityBlockerCode.adaptiveStreamingRequired),
+      );
+      expect(
+        result.blockers,
+        contains(AiroMediaCapabilityBlockerCode.audioChannelCountTooHigh),
+      );
+    });
+
+    test('unavailable profile returns stable unavailable blocker', () {
+      final result = policy.validate(
+        profile: AiroMediaDeviceCapabilityProfile.unavailable(observedAt: now),
+        requirement: requirement(),
+      );
+
+      expect(
+        result.blockers,
+        contains(AiroMediaCapabilityBlockerCode.profileUnavailable),
+      );
+      expect(result.accepted, isFalse);
+    });
+
+    test('diagnostics do not expose raw source values or device details', () {
+      final deviceProfile = profile();
+      final mediaRequirement = requirement();
+      final result = policy.validate(
+        profile: deviceProfile,
+        requirement: mediaRequirement,
+      );
+
+      expect(deviceProfile.toString(), isNot(contains('sdk')));
+      expect(mediaRequirement.toString(), isNot(contains('http')));
+      expect(result.toString(), contains('accepted'));
+    });
+  });
+
+  group('AiroMediaCapabilityDetector adapters', () {
+    final now = DateTime.utc(2026, 7, 14, 12);
+
+    final requirement = AiroMediaRequirement(
+      mediaId: 'media-1',
+      container: AiroMediaContainer.hls,
+      videoCodec: AiroVideoCodec.h264,
+      audioCodecs: const {AiroAudioCodec.aac},
+      subtitleFormats: const {AiroSubtitleFormat.webVtt},
+      width: 1280,
+      height: 720,
+      bitrateKbps: 4500,
+      requiresAdaptiveStreaming: true,
+    );
+
+    final profile = AiroMediaDeviceCapabilityProfile(
+      profileId: 'receiver-1',
+      observedAt: now,
+      supportedContainers: const {AiroMediaContainer.hls},
+      supportsAdaptiveStreaming: true,
+      videoDecoders: [
+        AiroVideoDecoderCapability(
+          codec: AiroVideoCodec.h264,
+          kind: AiroMediaDecoderKind.hardware,
+          maxWidth: 1920,
+          maxHeight: 1080,
+          maxBitrateKbps: 8000,
+          hdrFormats: const {AiroHdrFormat.sdr},
+        ),
+      ],
+      audioDecoders: const [
+        AiroAudioDecoderCapability(
+          codec: AiroAudioCodec.aac,
+          maxChannelCount: 2,
+        ),
+      ],
+      subtitleFormats: const {AiroSubtitleFormat.webVtt},
+    );
+
+    test('no-op detector reports unavailable without native probing', () async {
+      const detector = AiroNoOpMediaCapabilityDetector();
+
+      final currentProfile = await Future.value(detector.currentProfile());
+      final result = await Future.value(detector.preflight(requirement));
+
+      expect(currentProfile.isAvailable, isFalse);
+      expect(
+        result.blockers,
+        contains(AiroMediaCapabilityBlockerCode.profileUnavailable),
+      );
+    });
+
+    test(
+      'fake detector returns deterministic profile and preflight result',
+      () async {
+        final detector = AiroFakeMediaCapabilityDetector(profile: profile);
+
+        final currentProfile = await Future.value(detector.currentProfile());
+        final result = await Future.value(detector.preflight(requirement));
+
+        expect(currentProfile.profileId, 'receiver-1');
+        expect(result.accepted, isTrue);
+        expect(result.selectedDecoderKind, AiroMediaDecoderKind.hardware);
+      },
+    );
+  });
+}


### PR DESCRIPTION
## Summary
- define the ATV-024 media capability detection contract in `packages/platform_media`
- add normalized media requirements, receiver capability profiles, blocker codes, and detector boundaries
- document platform ownership and deterministic routing/preflight use cases
- add fake and no-op detector tests without introducing native probing or app-layer shortcuts

Closes #614

## Validation
- `dart format --set-exit-if-changed packages/platform_media`
- `cd packages/platform_media && flutter test`
- `cd packages/platform_media && flutter analyze --fatal-infos`
- `git diff --check HEAD~1..HEAD && git diff --check`
- diff-only secret scan for password/secret/api key/token patterns