### PR TITLE
feat(platform): add route health event schema

### DIFF
--- a/docs/features/airo-tv/ROUTE_HEALTH_EVENT_SCHEMA.md
+++ b/docs/features/airo-tv/ROUTE_HEALTH_EVENT_SCHEMA.md
@@ -1,0 +1,94 @@
+# Route Health Event Schema
+
+Status: v2 platform contract for ATV-025.
+
+## Ownership
+
+Route health events are platform/framework session state. Playback engines,
+receiver adapters, route recovery, companion controllers, and Airo TV screens
+consume the same typed event stream instead of polling playback state or
+inventing app-specific health payloads.
+
+The schema lives in `packages/core_sessions` because playback ownership already
+defines the session, route, owner, playback node, source node, and health
+reporter authority.
+
+## Event Shape
+
+`AiroRouteHealthEvent` records:
+
+- event id
+- session id
+- route id
+- media id
+- reporter node id
+- playback node id
+- source node id
+- monotonic sequence
+- event time
+- event kind
+- playback phase
+- position and duration
+- buffered-ahead duration
+- volume and mute state
+- audio and subtitle track ids
+- playback speed
+- route health level
+- typed failure detail
+- optional redacted diagnostic handle
+
+Events are designed for event-driven state updates. They are not a transport,
+analytics provider, playback engine, or persistence implementation.
+
+## Stable Event Kinds
+
+- `snapshot`
+- `playback_state`
+- `position`
+- `buffer`
+- `volume`
+- `audio_track`
+- `subtitle_track`
+- `playback_speed`
+- `route_health`
+- `failure`
+- `completed`
+
+## Validation Codes
+
+`AiroRouteHealthEventPolicy` returns stable validation codes:
+
+- `accepted`
+- `session_mismatch`
+- `route_mismatch`
+- `reporter_unauthorized`
+- `non_positive_sequence`
+- `stale_sequence`
+- `invalid_position`
+- `invalid_duration`
+- `invalid_buffered_ahead`
+- `invalid_volume`
+- `invalid_playback_speed`
+- `failure_missing`
+
+The policy validates events against `AiroPlaybackOwnershipSnapshot`, so only
+the current health reporter or playback owner can submit health events while
+the ownership lease is valid.
+
+## Privacy And Diagnostics
+
+Route health diagnostics must expose stable ids, normalized health levels, and
+typed failure categories. They must not expose raw stream URLs, local file
+paths, network addresses, provider payloads, or access material. Optional
+diagnostics use `AiroSessionPayloadHandle`, whose string representation is
+redacted and whose constructor rejects unsafe raw values.
+
+## Adapter Boundary
+
+`AiroRouteHealthEventSink` is the publishing boundary. The package includes:
+
+- `AiroNoOpRouteHealthEventSink` for products without a transport.
+- `AiroFakeRouteHealthEventSink` for deterministic host-only tests.
+
+No adapter in this issue collects player state, opens a socket, uploads
+analytics, or updates Airo TV UI.

--- a/packages/core_sessions/README.md
+++ b/packages/core_sessions/README.md
@@ -11,11 +11,14 @@ handoff state.
 
 - Receiver-authoritative playback session snapshots.
 - Playback ownership, operation authority, and ownership transfer policy.
+- Route health event schema for event-driven playback state, buffer, volume,
+  track, speed, health, and typed failure updates.
 - Monotonic revisions and deterministic conflict policy.
 - Privacy-safe local sync deltas with redacted payload handles.
 - Two-phase handoff preflight and phase records.
-- No-op and fake session repositories for host-only tests.
+- No-op and fake session repositories and route health sinks for host-only
+  tests.
 
 This package does not implement cloud orchestration, WebSocket transport,
-encrypted persistence, playback execution, device picker UI, or Airo TV
-screens.
+encrypted persistence, playback execution, route health collection, device
+picker UI, or Airo TV screens.

--- a/packages/core_sessions/lib/core_sessions.dart
+++ b/packages/core_sessions/lib/core_sessions.dart
@@ -1,3 +1,4 @@
 library;
 
+export 'src/route_health_event_models.dart';
 export 'src/session_models.dart';

--- a/packages/core_sessions/lib/src/route_health_event_models.dart
+++ b/packages/core_sessions/lib/src/route_health_event_models.dart
@@ -1,0 +1,351 @@
+import 'dart:async';
+
+import 'package:equatable/equatable.dart';
+
+import 'session_models.dart';
+
+const String kAiroRouteHealthEventSchemaVersion = '1.0.0';
+
+enum AiroRouteHealthEventKind {
+  snapshot('snapshot'),
+  playbackState('playback_state'),
+  position('position'),
+  buffer('buffer'),
+  volume('volume'),
+  audioTrack('audio_track'),
+  subtitleTrack('subtitle_track'),
+  playbackSpeed('playback_speed'),
+  routeHealth('route_health'),
+  failure('failure'),
+  completed('completed');
+
+  const AiroRouteHealthEventKind(this.stableId);
+
+  final String stableId;
+}
+
+enum AiroRouteHealthLevel {
+  healthy('healthy'),
+  degraded('degraded'),
+  critical('critical'),
+  recovering('recovering'),
+  failed('failed'),
+  unknown('unknown');
+
+  const AiroRouteHealthLevel(this.stableId);
+
+  final String stableId;
+}
+
+enum AiroRouteFailureCategory {
+  network('network'),
+  decoder('decoder'),
+  sourceExpired('source_expired'),
+  unsupportedMedia('unsupported_media'),
+  routeUnavailable('route_unavailable'),
+  permissionDenied('permission_denied'),
+  playbackBackend('playback_backend'),
+  timeout('timeout'),
+  unknown('unknown');
+
+  const AiroRouteFailureCategory(this.stableId);
+
+  final String stableId;
+}
+
+enum AiroRouteFailureRetryability {
+  retryable('retryable'),
+  alternateRoute('alternate_route'),
+  userActionRequired('user_action_required'),
+  terminal('terminal'),
+  unknown('unknown');
+
+  const AiroRouteFailureRetryability(this.stableId);
+
+  final String stableId;
+}
+
+enum AiroRouteHealthEventValidationCode {
+  accepted('accepted'),
+  sessionMismatch('session_mismatch'),
+  routeMismatch('route_mismatch'),
+  reporterUnauthorized('reporter_unauthorized'),
+  nonPositiveSequence('non_positive_sequence'),
+  staleSequence('stale_sequence'),
+  invalidPosition('invalid_position'),
+  invalidDuration('invalid_duration'),
+  invalidBufferedAhead('invalid_buffered_ahead'),
+  invalidVolume('invalid_volume'),
+  invalidPlaybackSpeed('invalid_playback_speed'),
+  failureMissing('failure_missing');
+
+  const AiroRouteHealthEventValidationCode(this.stableId);
+
+  final String stableId;
+}
+
+class AiroRouteFailureDetail extends Equatable {
+  const AiroRouteFailureDetail({
+    required this.category,
+    required this.retryability,
+    required this.stableCode,
+    this.messageBucket,
+  });
+
+  final AiroRouteFailureCategory category;
+  final AiroRouteFailureRetryability retryability;
+  final String stableCode;
+  final String? messageBucket;
+
+  @override
+  String toString() {
+    return 'AiroRouteFailureDetail('
+        'category: ${category.stableId}, '
+        'retryability: ${retryability.stableId}, '
+        'stableCode: $stableCode, '
+        'messageBucket: $messageBucket'
+        ')';
+  }
+
+  @override
+  List<Object?> get props => [
+    category,
+    retryability,
+    stableCode,
+    messageBucket,
+  ];
+}
+
+class AiroRouteHealthEvent extends Equatable {
+  const AiroRouteHealthEvent({
+    required this.eventId,
+    required this.sessionId,
+    required this.routeId,
+    required this.mediaId,
+    required this.reporterNodeId,
+    required this.playbackNodeId,
+    required this.sourceNodeId,
+    required this.sequence,
+    required this.occurredAt,
+    required this.kind,
+    this.playbackPhase,
+    this.position,
+    this.duration,
+    this.bufferedAhead,
+    this.volumePercent,
+    this.isMuted,
+    this.audioTrackId,
+    this.subtitleTrackId,
+    this.playbackSpeed,
+    this.healthLevel = AiroRouteHealthLevel.unknown,
+    this.failure,
+    this.diagnosticHandle,
+    this.schemaVersion = kAiroRouteHealthEventSchemaVersion,
+  });
+
+  final String schemaVersion;
+  final String eventId;
+  final String sessionId;
+  final String routeId;
+  final String mediaId;
+  final String reporterNodeId;
+  final String playbackNodeId;
+  final String sourceNodeId;
+  final int sequence;
+  final DateTime occurredAt;
+  final AiroRouteHealthEventKind kind;
+  final AiroPlaybackSessionPhase? playbackPhase;
+  final Duration? position;
+  final Duration? duration;
+  final Duration? bufferedAhead;
+  final int? volumePercent;
+  final bool? isMuted;
+  final String? audioTrackId;
+  final String? subtitleTrackId;
+  final double? playbackSpeed;
+  final AiroRouteHealthLevel healthLevel;
+  final AiroRouteFailureDetail? failure;
+  final AiroSessionPayloadHandle? diagnosticHandle;
+
+  @override
+  String toString() {
+    return 'AiroRouteHealthEvent('
+        'eventId: $eventId, '
+        'sessionId: $sessionId, '
+        'routeId: $routeId, '
+        'mediaId: $mediaId, '
+        'reporterNodeId: $reporterNodeId, '
+        'playbackNodeId: $playbackNodeId, '
+        'sourceNodeId: $sourceNodeId, '
+        'sequence: $sequence, '
+        'kind: ${kind.stableId}, '
+        'phase: ${playbackPhase?.stableId}, '
+        'healthLevel: ${healthLevel.stableId}, '
+        'failure: $failure, '
+        'diagnosticHandle: redacted'
+        ')';
+  }
+
+  @override
+  List<Object?> get props => [
+    schemaVersion,
+    eventId,
+    sessionId,
+    routeId,
+    mediaId,
+    reporterNodeId,
+    playbackNodeId,
+    sourceNodeId,
+    sequence,
+    occurredAt,
+    kind,
+    playbackPhase,
+    position,
+    duration,
+    bufferedAhead,
+    volumePercent,
+    isMuted,
+    audioTrackId,
+    subtitleTrackId,
+    playbackSpeed,
+    healthLevel,
+    failure,
+    diagnosticHandle,
+  ];
+}
+
+class AiroRouteHealthEventValidation extends Equatable {
+  AiroRouteHealthEventValidation({
+    required this.eventId,
+    required List<AiroRouteHealthEventValidationCode> codes,
+  }) : codes = List.unmodifiable(codes);
+
+  final String eventId;
+  final List<AiroRouteHealthEventValidationCode> codes;
+
+  bool get accepted =>
+      codes.length == 1 &&
+      codes.single == AiroRouteHealthEventValidationCode.accepted;
+
+  @override
+  List<Object?> get props => [eventId, codes];
+}
+
+class AiroRouteHealthEventPolicy {
+  const AiroRouteHealthEventPolicy();
+
+  AiroRouteHealthEventValidation validate({
+    required AiroRouteHealthEvent event,
+    required AiroPlaybackOwnershipSnapshot ownership,
+    required DateTime now,
+    int? lastAcceptedSequence,
+  }) {
+    final codes = <AiroRouteHealthEventValidationCode>[];
+    if (event.sessionId != ownership.sessionId) {
+      codes.add(AiroRouteHealthEventValidationCode.sessionMismatch);
+    }
+    if (event.routeId != ownership.routeId) {
+      codes.add(AiroRouteHealthEventValidationCode.routeMismatch);
+    }
+    if (!ownership.canPerform(
+      nodeId: event.reporterNodeId,
+      operation: AiroPlaybackOwnershipOperation.healthReport,
+      now: now,
+    )) {
+      codes.add(AiroRouteHealthEventValidationCode.reporterUnauthorized);
+    }
+    if (event.sequence <= 0) {
+      codes.add(AiroRouteHealthEventValidationCode.nonPositiveSequence);
+    }
+    if (lastAcceptedSequence != null &&
+        event.sequence <= lastAcceptedSequence) {
+      codes.add(AiroRouteHealthEventValidationCode.staleSequence);
+    }
+    _addDurationBlockers(event, codes);
+    if (event.volumePercent != null &&
+        (event.volumePercent! < 0 || event.volumePercent! > 100)) {
+      codes.add(AiroRouteHealthEventValidationCode.invalidVolume);
+    }
+    if (event.playbackSpeed != null &&
+        (event.playbackSpeed! <= 0 || event.playbackSpeed! > 4)) {
+      codes.add(AiroRouteHealthEventValidationCode.invalidPlaybackSpeed);
+    }
+    if (event.kind == AiroRouteHealthEventKind.failure &&
+        event.failure == null) {
+      codes.add(AiroRouteHealthEventValidationCode.failureMissing);
+    }
+
+    return AiroRouteHealthEventValidation(
+      eventId: event.eventId,
+      codes: codes.isEmpty
+          ? const [AiroRouteHealthEventValidationCode.accepted]
+          : codes,
+    );
+  }
+
+  void _addDurationBlockers(
+    AiroRouteHealthEvent event,
+    List<AiroRouteHealthEventValidationCode> codes,
+  ) {
+    final position = event.position;
+    final duration = event.duration;
+    final bufferedAhead = event.bufferedAhead;
+    if (position != null && position < Duration.zero) {
+      codes.add(AiroRouteHealthEventValidationCode.invalidPosition);
+    }
+    if (duration != null && duration < Duration.zero) {
+      codes.add(AiroRouteHealthEventValidationCode.invalidDuration);
+    }
+    if (bufferedAhead != null && bufferedAhead < Duration.zero) {
+      codes.add(AiroRouteHealthEventValidationCode.invalidBufferedAhead);
+    }
+    if (position != null && duration != null && position > duration) {
+      codes.add(AiroRouteHealthEventValidationCode.invalidPosition);
+    }
+  }
+}
+
+abstract interface class AiroRouteHealthEventSink {
+  FutureOr<AiroRouteHealthEventValidation> publish(AiroRouteHealthEvent event);
+}
+
+class AiroNoOpRouteHealthEventSink implements AiroRouteHealthEventSink {
+  const AiroNoOpRouteHealthEventSink();
+
+  @override
+  FutureOr<AiroRouteHealthEventValidation> publish(AiroRouteHealthEvent event) {
+    return AiroRouteHealthEventValidation(
+      eventId: event.eventId,
+      codes: const [AiroRouteHealthEventValidationCode.accepted],
+    );
+  }
+}
+
+class AiroFakeRouteHealthEventSink implements AiroRouteHealthEventSink {
+  AiroFakeRouteHealthEventSink({
+    required this.ownership,
+    this.policy = const AiroRouteHealthEventPolicy(),
+    this.now,
+  });
+
+  final AiroPlaybackOwnershipSnapshot ownership;
+  final AiroRouteHealthEventPolicy policy;
+  final DateTime? now;
+  final List<AiroRouteHealthEvent> events = [];
+  int? _lastAcceptedSequence;
+
+  @override
+  FutureOr<AiroRouteHealthEventValidation> publish(AiroRouteHealthEvent event) {
+    final validation = policy.validate(
+      event: event,
+      ownership: ownership,
+      now: now ?? event.occurredAt,
+      lastAcceptedSequence: _lastAcceptedSequence,
+    );
+    if (validation.accepted) {
+      events.add(event);
+      _lastAcceptedSequence = event.sequence;
+    }
+    return validation;
+  }
+}

--- a/packages/core_sessions/test/route_health_event_models_test.dart
+++ b/packages/core_sessions/test/route_health_event_models_test.dart
@@ -1,0 +1,286 @@
+import 'package:core_media_routing/core_media_routing.dart';
+import 'package:core_sessions/core_sessions.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('AiroRouteHealthEventPolicy', () {
+    const policy = AiroRouteHealthEventPolicy();
+    final now = DateTime.utc(2026, 7, 14, 12);
+
+    AiroPlaybackOwnershipSnapshot ownership({
+      String healthReporterNodeId = 'tv-1',
+      DateTime? leaseExpiresAt,
+    }) {
+      return AiroPlaybackOwnershipSnapshot(
+        sessionId: 'session-1',
+        ownerNodeId: 'tv-1',
+        playbackNodeId: 'tv-1',
+        sourceNodeId: 'phone-1',
+        routeId: 'route-1',
+        routeKind: AiroMediaRouteKind.receiverDirect,
+        analyticsOwnerNodeId: 'tv-1',
+        healthReporterNodeId: healthReporterNodeId,
+        revision: AiroSessionRevision(
+          value: 4,
+          updatedAt: now,
+          reporterNodeId: 'tv-1',
+        ),
+        capturedAt: now,
+        leaseExpiresAt: leaseExpiresAt,
+      );
+    }
+
+    AiroRouteHealthEvent event({
+      String sessionId = 'session-1',
+      String routeId = 'route-1',
+      String reporterNodeId = 'tv-1',
+      int sequence = 1,
+      AiroRouteHealthEventKind kind = AiroRouteHealthEventKind.snapshot,
+      Duration? position = const Duration(seconds: 30),
+      Duration? duration = const Duration(minutes: 10),
+      Duration? bufferedAhead = const Duration(seconds: 15),
+      int? volumePercent = 80,
+      double? playbackSpeed = 1,
+      AiroRouteHealthLevel healthLevel = AiroRouteHealthLevel.healthy,
+      AiroRouteFailureDetail? failure,
+      AiroSessionPayloadHandle? diagnosticHandle,
+    }) {
+      return AiroRouteHealthEvent(
+        eventId: 'event-$sequence',
+        sessionId: sessionId,
+        routeId: routeId,
+        mediaId: 'media-1',
+        reporterNodeId: reporterNodeId,
+        playbackNodeId: 'tv-1',
+        sourceNodeId: 'phone-1',
+        sequence: sequence,
+        occurredAt: now,
+        kind: kind,
+        playbackPhase: AiroPlaybackSessionPhase.playing,
+        position: position,
+        duration: duration,
+        bufferedAhead: bufferedAhead,
+        volumePercent: volumePercent,
+        isMuted: false,
+        audioTrackId: 'audio-main',
+        subtitleTrackId: 'sub-en',
+        playbackSpeed: playbackSpeed,
+        healthLevel: healthLevel,
+        failure: failure,
+        diagnosticHandle: diagnosticHandle,
+      );
+    }
+
+    test('accepts monotonic event from current health reporter', () {
+      final result = policy.validate(
+        event: event(),
+        ownership: ownership(),
+        now: now,
+      );
+
+      expect(result.accepted, isTrue);
+    });
+
+    test('rejects wrong session route and unauthorized reporter', () {
+      final result = policy.validate(
+        event: event(
+          sessionId: 'session-2',
+          routeId: 'route-2',
+          reporterNodeId: 'phone-1',
+        ),
+        ownership: ownership(),
+        now: now,
+      );
+
+      expect(
+        result.codes,
+        contains(AiroRouteHealthEventValidationCode.sessionMismatch),
+      );
+      expect(
+        result.codes,
+        contains(AiroRouteHealthEventValidationCode.routeMismatch),
+      );
+      expect(
+        result.codes,
+        contains(AiroRouteHealthEventValidationCode.reporterUnauthorized),
+      );
+    });
+
+    test('rejects stale or non-positive sequences', () {
+      final stale = policy.validate(
+        event: event(sequence: 2),
+        ownership: ownership(),
+        now: now,
+        lastAcceptedSequence: 2,
+      );
+      final nonPositive = policy.validate(
+        event: event(sequence: 0),
+        ownership: ownership(),
+        now: now,
+      );
+
+      expect(
+        stale.codes,
+        contains(AiroRouteHealthEventValidationCode.staleSequence),
+      );
+      expect(
+        nonPositive.codes,
+        contains(AiroRouteHealthEventValidationCode.nonPositiveSequence),
+      );
+    });
+
+    test('rejects invalid playback measurements', () {
+      final result = policy.validate(
+        event: event(
+          position: const Duration(minutes: 11),
+          duration: const Duration(minutes: 10),
+          bufferedAhead: const Duration(seconds: -1),
+          volumePercent: 120,
+          playbackSpeed: 0,
+        ),
+        ownership: ownership(),
+        now: now,
+      );
+
+      expect(
+        result.codes,
+        contains(AiroRouteHealthEventValidationCode.invalidPosition),
+      );
+      expect(
+        result.codes,
+        contains(AiroRouteHealthEventValidationCode.invalidBufferedAhead),
+      );
+      expect(
+        result.codes,
+        contains(AiroRouteHealthEventValidationCode.invalidVolume),
+      );
+      expect(
+        result.codes,
+        contains(AiroRouteHealthEventValidationCode.invalidPlaybackSpeed),
+      );
+    });
+
+    test('failure event requires typed failure detail', () {
+      final missing = policy.validate(
+        event: event(kind: AiroRouteHealthEventKind.failure, failure: null),
+        ownership: ownership(),
+        now: now,
+      );
+      final accepted = policy.validate(
+        event: event(
+          kind: AiroRouteHealthEventKind.failure,
+          healthLevel: AiroRouteHealthLevel.failed,
+          failure: const AiroRouteFailureDetail(
+            category: AiroRouteFailureCategory.decoder,
+            retryability: AiroRouteFailureRetryability.alternateRoute,
+            stableCode: 'decoder_init_failed',
+            messageBucket: 'decoder',
+          ),
+        ),
+        ownership: ownership(),
+        now: now,
+      );
+
+      expect(
+        missing.codes,
+        contains(AiroRouteHealthEventValidationCode.failureMissing),
+      );
+      expect(accepted.accepted, isTrue);
+    });
+
+    test('expired ownership rejects health reporting', () {
+      final result = policy.validate(
+        event: event(),
+        ownership: ownership(leaseExpiresAt: now),
+        now: now,
+      );
+
+      expect(
+        result.codes,
+        contains(AiroRouteHealthEventValidationCode.reporterUnauthorized),
+      );
+    });
+
+    test('diagnostics are redacted and reject unsafe payload handles', () {
+      final healthEvent = event(
+        diagnosticHandle: AiroSessionPayloadHandle.redacted('health-diag-1'),
+      );
+
+      expect(healthEvent.toString(), contains('diagnosticHandle: redacted'));
+      expect(healthEvent.toString(), isNot(contains('health-diag-1')));
+      expect(
+        () => AiroSessionPayloadHandle.redacted('https://example.com/diag'),
+        throwsArgumentError,
+      );
+    });
+  });
+
+  group('AiroRouteHealthEventSink adapters', () {
+    final now = DateTime.utc(2026, 7, 14, 12);
+
+    final ownership = AiroPlaybackOwnershipSnapshot(
+      sessionId: 'session-1',
+      ownerNodeId: 'tv-1',
+      playbackNodeId: 'tv-1',
+      sourceNodeId: 'phone-1',
+      routeId: 'route-1',
+      routeKind: AiroMediaRouteKind.receiverDirect,
+      analyticsOwnerNodeId: 'tv-1',
+      healthReporterNodeId: 'tv-1',
+      revision: AiroSessionRevision(
+        value: 4,
+        updatedAt: now,
+        reporterNodeId: 'tv-1',
+      ),
+      capturedAt: now,
+    );
+
+    AiroRouteHealthEvent event(int sequence) {
+      return AiroRouteHealthEvent(
+        eventId: 'event-$sequence',
+        sessionId: 'session-1',
+        routeId: 'route-1',
+        mediaId: 'media-1',
+        reporterNodeId: 'tv-1',
+        playbackNodeId: 'tv-1',
+        sourceNodeId: 'phone-1',
+        sequence: sequence,
+        occurredAt: now,
+        kind: AiroRouteHealthEventKind.buffer,
+        playbackPhase: AiroPlaybackSessionPhase.buffering,
+        bufferedAhead: const Duration(seconds: 3),
+        healthLevel: AiroRouteHealthLevel.degraded,
+      );
+    }
+
+    test('no-op sink accepts event without side effects', () async {
+      const sink = AiroNoOpRouteHealthEventSink();
+
+      final result = await Future.value(sink.publish(event(1)));
+
+      expect(result.accepted, isTrue);
+    });
+
+    test(
+      'fake sink records accepted events and rejects stale events',
+      () async {
+        final sink = AiroFakeRouteHealthEventSink(
+          ownership: ownership,
+          now: now,
+        );
+
+        final first = await Future.value(sink.publish(event(1)));
+        final stale = await Future.value(sink.publish(event(1)));
+        final second = await Future.value(sink.publish(event(2)));
+
+        expect(first.accepted, isTrue);
+        expect(
+          stale.codes,
+          contains(AiroRouteHealthEventValidationCode.staleSequence),
+        );
+        expect(second.accepted, isTrue);
+        expect(sink.events.map((event) => event.sequence), [1, 2]);
+      },
+    );
+  });
+}


### PR DESCRIPTION
## Summary
- define the ATV-025 route health event schema in `packages/core_sessions`
- add typed route health events, health levels, failure categories, retryability, and validation codes
- validate session, route, reporter authority, monotonic sequences, playback measurements, and failure details
- add fake and no-op event sinks for deterministic host-only tests

Closes #615

## Validation
- `dart format --set-exit-if-changed packages/core_sessions`
- `cd packages/core_sessions && flutter test`
- `cd packages/core_sessions && flutter analyze --fatal-infos`
- `git diff --check HEAD~1..HEAD && git diff --check`
- diff-only secret scan for password/secret/api key/token patterns