### PR TITLE
feat(platform): add edge media node placeholder

### DIFF
--- a/docs/features/airo-tv/EDGE_MEDIA_NODE_PLACEHOLDER_CONTRACT.md
+++ b/docs/features/airo-tv/EDGE_MEDIA_NODE_PLACEHOLDER_CONTRACT.md
@@ -1,0 +1,101 @@
+# Edge Media Node Placeholder Contract
+
+Status: v2 platform contract for ATV-026.
+
+## Ownership
+
+Edge Media Node is future platform infrastructure. It may eventually index
+media, enrich metadata, monitor stream health, relay trusted access, schedule
+recordings, transcode, and run always-on AI tasks from a desktop or home node.
+
+The placeholder contract lives in `packages/core_protocol` because it extends
+the connected-node protocol: identity, role, lifecycle, trust state,
+capability advertisements, and privacy-safe compatibility checks.
+
+## Non-Goals
+
+This issue does not implement:
+
+- media indexing
+- file scanning
+- relay tunnels
+- recording
+- transcoding
+- desktop services
+- AI workers
+- local discovery
+- Airo TV UI
+
+The contract only makes future work compatible with v2 protocol decisions.
+
+## Contract Shape
+
+`AiroEdgeMediaNodeProfile` combines a connected-node advertisement with
+normalized service descriptors. Supported service ids are:
+
+- `media_indexing`
+- `metadata_enrichment`
+- `stream_health`
+- `relay`
+- `recording`
+- `transcoding`
+- `ai_processing`
+- `artwork_processing`
+
+Each service descriptor has a state:
+
+- `placeholder`
+- `planned`
+- `available`
+- `disabled`
+- `unavailable`
+
+Only `available` services are executable. Placeholder and planned services keep
+the protocol shape visible without claiming runtime support.
+
+## Policy
+
+`AiroEdgeMediaNodePolicy` evaluates a requested service against:
+
+- connected-node role
+- lifecycle state
+- trust state
+- advertisement freshness
+- required connected-node capability
+- service descriptor presence
+- service executability
+- local-network scope
+- explicit risk opt-ins for relay, recording, and transcoding
+
+Stable blocker codes:
+
+- `accepted`
+- `schema_mismatch`
+- `stale_advertisement`
+- `incompatible_role`
+- `lifecycle_unavailable`
+- `untrusted_node`
+- `blocked_node`
+- `missing_connected_node_capability`
+- `service_missing`
+- `service_not_executable`
+- `local_network_required`
+- `relay_not_allowed`
+- `recording_not_allowed`
+- `transcoding_not_allowed`
+
+## Adapter Boundary
+
+`AiroEdgeMediaNodeRegistry` lists candidate profiles. The package includes:
+
+- `AiroNoOpEdgeMediaNodeRegistry` for products with no Edge Media Node support.
+- `AiroFakeEdgeMediaNodeRegistry` for deterministic tests.
+
+No registry in this issue discovers, connects to, or executes work on a node.
+
+## Privacy
+
+Profiles and diagnostics expose stable node ids, roles, service ids, service
+states, and blocker codes only. They must not expose provider credentials, raw
+media URLs, local file paths, recording payloads, relay addresses, or transcoder
+internals.

--- a/packages/core_protocol/README.md
+++ b/packages/core_protocol/README.md
@@ -13,7 +13,9 @@ without leaking private media or account data.
 - Node lifecycle states.
 - Privacy-safe capability advertisements.
 - Compatibility policies and deterministic blocker codes.
+- Edge Media Node placeholder profiles, service descriptors, policy blockers,
+  and fake/no-op registries for future home-node work.
 
 This package does not discover devices, open sockets, store trust records,
-render pairing UI, send commands, maintain presence leases, or coordinate cloud
-state.
+render pairing UI, send commands, maintain presence leases, index media, relay
+traffic, record media, transcode, run AI workers, or coordinate cloud state.

--- a/packages/core_protocol/lib/core_protocol.dart
+++ b/packages/core_protocol/lib/core_protocol.dart
@@ -1,3 +1,4 @@
 library;
 
 export 'src/connected_node_models.dart';
+export 'src/edge_media_node_models.dart';

--- a/packages/core_protocol/lib/src/edge_media_node_models.dart
+++ b/packages/core_protocol/lib/src/edge_media_node_models.dart
@@ -1,0 +1,338 @@
+import 'dart:async';
+
+import 'package:equatable/equatable.dart';
+
+import 'connected_node_models.dart';
+
+const String kAiroEdgeMediaNodeSchemaVersion = '1.0.0';
+
+enum AiroEdgeMediaNodeService {
+  mediaIndexing('media_indexing'),
+  metadataEnrichment('metadata_enrichment'),
+  streamHealth('stream_health'),
+  relay('relay'),
+  recording('recording'),
+  transcoding('transcoding'),
+  aiProcessing('ai_processing'),
+  artworkProcessing('artwork_processing');
+
+  const AiroEdgeMediaNodeService(this.stableId);
+
+  final String stableId;
+}
+
+enum AiroEdgeMediaNodeServiceState {
+  placeholder('placeholder'),
+  planned('planned'),
+  available('available'),
+  disabled('disabled'),
+  unavailable('unavailable');
+
+  const AiroEdgeMediaNodeServiceState(this.stableId);
+
+  final String stableId;
+
+  bool get executable => this == available;
+}
+
+enum AiroEdgeMediaNodeBlockerCode {
+  accepted('accepted'),
+  schemaMismatch('schema_mismatch'),
+  staleAdvertisement('stale_advertisement'),
+  incompatibleRole('incompatible_role'),
+  lifecycleUnavailable('lifecycle_unavailable'),
+  untrustedNode('untrusted_node'),
+  blockedNode('blocked_node'),
+  missingConnectedNodeCapability('missing_connected_node_capability'),
+  serviceMissing('service_missing'),
+  serviceNotExecutable('service_not_executable'),
+  localNetworkRequired('local_network_required'),
+  relayNotAllowed('relay_not_allowed'),
+  recordingNotAllowed('recording_not_allowed'),
+  transcodingNotAllowed('transcoding_not_allowed');
+
+  const AiroEdgeMediaNodeBlockerCode(this.stableId);
+
+  final String stableId;
+}
+
+class AiroEdgeMediaNodeServiceDescriptor extends Equatable {
+  const AiroEdgeMediaNodeServiceDescriptor({
+    required this.service,
+    required this.state,
+    this.requiresTrustedNode = true,
+    this.requiresLocalNetworkScope = true,
+    this.schemaVersion = kAiroEdgeMediaNodeSchemaVersion,
+  });
+
+  final String schemaVersion;
+  final AiroEdgeMediaNodeService service;
+  final AiroEdgeMediaNodeServiceState state;
+  final bool requiresTrustedNode;
+  final bool requiresLocalNetworkScope;
+
+  bool get executable => state.executable;
+
+  @override
+  String toString() {
+    return 'AiroEdgeMediaNodeServiceDescriptor('
+        'service: ${service.stableId}, '
+        'state: ${state.stableId}, '
+        'requiresTrustedNode: $requiresTrustedNode, '
+        'requiresLocalNetworkScope: $requiresLocalNetworkScope'
+        ')';
+  }
+
+  @override
+  List<Object?> get props => [
+    schemaVersion,
+    service,
+    state,
+    requiresTrustedNode,
+    requiresLocalNetworkScope,
+  ];
+}
+
+class AiroEdgeMediaNodeProfile extends Equatable {
+  AiroEdgeMediaNodeProfile({
+    required this.profileId,
+    required this.advertisement,
+    required List<AiroEdgeMediaNodeServiceDescriptor> services,
+    required this.observedAt,
+    this.schemaVersion = kAiroEdgeMediaNodeSchemaVersion,
+  }) : services = List.unmodifiable(services);
+
+  final String schemaVersion;
+  final String profileId;
+  final AiroNodeCapabilityAdvertisement advertisement;
+  final List<AiroEdgeMediaNodeServiceDescriptor> services;
+  final DateTime observedAt;
+
+  String get nodeId => advertisement.identity.nodeId;
+
+  AiroEdgeMediaNodeServiceDescriptor? descriptorFor(
+    AiroEdgeMediaNodeService service,
+  ) {
+    for (final descriptor in services) {
+      if (descriptor.service == service) return descriptor;
+    }
+    return null;
+  }
+
+  @override
+  String toString() {
+    return 'AiroEdgeMediaNodeProfile('
+        'profileId: $profileId, '
+        'nodeId: $nodeId, '
+        'role: ${advertisement.identity.role.stableId}, '
+        'platformCategory: ${advertisement.identity.platformCategory.stableId}, '
+        'services: ${services.map((service) => '${service.service.stableId}:${service.state.stableId}').toList()}'
+        ')';
+  }
+
+  @override
+  List<Object?> get props => [
+    schemaVersion,
+    profileId,
+    advertisement,
+    services,
+    observedAt,
+  ];
+}
+
+class AiroEdgeMediaNodeRequest extends Equatable {
+  const AiroEdgeMediaNodeRequest({
+    required this.requestId,
+    required this.requestedByNodeId,
+    required this.service,
+    this.hasLocalNetworkScope = false,
+    this.allowRelay = false,
+    this.allowRecording = false,
+    this.allowTranscoding = false,
+    this.schemaVersion = kAiroEdgeMediaNodeSchemaVersion,
+  });
+
+  final String schemaVersion;
+  final String requestId;
+  final String requestedByNodeId;
+  final AiroEdgeMediaNodeService service;
+  final bool hasLocalNetworkScope;
+  final bool allowRelay;
+  final bool allowRecording;
+  final bool allowTranscoding;
+
+  @override
+  List<Object?> get props => [
+    schemaVersion,
+    requestId,
+    requestedByNodeId,
+    service,
+    hasLocalNetworkScope,
+    allowRelay,
+    allowRecording,
+    allowTranscoding,
+  ];
+}
+
+class AiroEdgeMediaNodeEvaluation extends Equatable {
+  AiroEdgeMediaNodeEvaluation({
+    required this.nodeId,
+    required this.requestId,
+    required List<AiroEdgeMediaNodeBlockerCode> blockers,
+  }) : blockers = List.unmodifiable(blockers);
+
+  final String nodeId;
+  final String requestId;
+  final List<AiroEdgeMediaNodeBlockerCode> blockers;
+
+  bool get accepted =>
+      blockers.length == 1 &&
+      blockers.single == AiroEdgeMediaNodeBlockerCode.accepted;
+
+  @override
+  List<Object?> get props => [nodeId, requestId, blockers];
+}
+
+class AiroEdgeMediaNodePolicy {
+  const AiroEdgeMediaNodePolicy();
+
+  AiroEdgeMediaNodeEvaluation evaluate({
+    required AiroEdgeMediaNodeProfile profile,
+    required AiroEdgeMediaNodeRequest request,
+    required DateTime now,
+  }) {
+    final blockers = <AiroEdgeMediaNodeBlockerCode>[];
+    final advertisement = profile.advertisement;
+    final descriptor = profile.descriptorFor(request.service);
+
+    if (profile.schemaVersion != kAiroEdgeMediaNodeSchemaVersion) {
+      blockers.add(AiroEdgeMediaNodeBlockerCode.schemaMismatch);
+    }
+    if (advertisement.isExpired(now)) {
+      blockers.add(AiroEdgeMediaNodeBlockerCode.staleAdvertisement);
+    }
+    if (!_isEdgeNodeRole(advertisement.identity.role)) {
+      blockers.add(AiroEdgeMediaNodeBlockerCode.incompatibleRole);
+    }
+    if (advertisement.lifecycle == AiroNodeLifecycleState.blocked ||
+        advertisement.trustState == AiroNodeTrustState.revoked) {
+      blockers.add(AiroEdgeMediaNodeBlockerCode.blockedNode);
+    } else if (!advertisement.lifecycle.canNegotiate) {
+      blockers.add(AiroEdgeMediaNodeBlockerCode.lifecycleUnavailable);
+    }
+    if (!advertisement.trustState.allowsPrivateCompatibility) {
+      blockers.add(AiroEdgeMediaNodeBlockerCode.untrustedNode);
+    }
+    _addCapabilityBlockers(advertisement, request, blockers);
+    _addServiceBlockers(descriptor, request, blockers);
+
+    return AiroEdgeMediaNodeEvaluation(
+      nodeId: profile.nodeId,
+      requestId: request.requestId,
+      blockers: blockers.isEmpty
+          ? const [AiroEdgeMediaNodeBlockerCode.accepted]
+          : blockers,
+    );
+  }
+
+  bool _isEdgeNodeRole(AiroNodeRole role) {
+    return role == AiroNodeRole.homeNode ||
+        role == AiroNodeRole.desktopCompanion;
+  }
+
+  void _addCapabilityBlockers(
+    AiroNodeCapabilityAdvertisement advertisement,
+    AiroEdgeMediaNodeRequest request,
+    List<AiroEdgeMediaNodeBlockerCode> blockers,
+  ) {
+    final requiredCapability = _requiredConnectedNodeCapability(
+      request.service,
+    );
+    if (requiredCapability != null &&
+        !advertisement.advertises(requiredCapability)) {
+      blockers.add(AiroEdgeMediaNodeBlockerCode.missingConnectedNodeCapability);
+    }
+  }
+
+  AiroNodeCapability? _requiredConnectedNodeCapability(
+    AiroEdgeMediaNodeService service,
+  ) {
+    switch (service) {
+      case AiroEdgeMediaNodeService.mediaIndexing:
+        return AiroNodeCapability.mediaIndexing;
+      case AiroEdgeMediaNodeService.metadataEnrichment:
+        return AiroNodeCapability.metadataProcessing;
+      case AiroEdgeMediaNodeService.streamHealth:
+        return AiroNodeCapability.diagnostics;
+      case AiroEdgeMediaNodeService.relay:
+        return AiroNodeCapability.commandRouting;
+      case AiroEdgeMediaNodeService.recording:
+        return AiroNodeCapability.recording;
+      case AiroEdgeMediaNodeService.transcoding:
+        return AiroNodeCapability.transcoding;
+      case AiroEdgeMediaNodeService.aiProcessing:
+        return AiroNodeCapability.aiDelegation;
+      case AiroEdgeMediaNodeService.artworkProcessing:
+        return AiroNodeCapability.metadataProcessing;
+    }
+  }
+
+  void _addServiceBlockers(
+    AiroEdgeMediaNodeServiceDescriptor? descriptor,
+    AiroEdgeMediaNodeRequest request,
+    List<AiroEdgeMediaNodeBlockerCode> blockers,
+  ) {
+    if (descriptor == null) {
+      blockers.add(AiroEdgeMediaNodeBlockerCode.serviceMissing);
+      return;
+    }
+    if (!descriptor.executable) {
+      blockers.add(AiroEdgeMediaNodeBlockerCode.serviceNotExecutable);
+    }
+    if (descriptor.requiresLocalNetworkScope && !request.hasLocalNetworkScope) {
+      blockers.add(AiroEdgeMediaNodeBlockerCode.localNetworkRequired);
+    }
+    switch (request.service) {
+      case AiroEdgeMediaNodeService.relay:
+        if (!request.allowRelay) {
+          blockers.add(AiroEdgeMediaNodeBlockerCode.relayNotAllowed);
+        }
+      case AiroEdgeMediaNodeService.recording:
+        if (!request.allowRecording) {
+          blockers.add(AiroEdgeMediaNodeBlockerCode.recordingNotAllowed);
+        }
+      case AiroEdgeMediaNodeService.transcoding:
+        if (!request.allowTranscoding) {
+          blockers.add(AiroEdgeMediaNodeBlockerCode.transcodingNotAllowed);
+        }
+      case AiroEdgeMediaNodeService.mediaIndexing:
+      case AiroEdgeMediaNodeService.metadataEnrichment:
+      case AiroEdgeMediaNodeService.streamHealth:
+      case AiroEdgeMediaNodeService.aiProcessing:
+      case AiroEdgeMediaNodeService.artworkProcessing:
+        break;
+    }
+  }
+}
+
+abstract interface class AiroEdgeMediaNodeRegistry {
+  FutureOr<List<AiroEdgeMediaNodeProfile>> candidates();
+}
+
+class AiroNoOpEdgeMediaNodeRegistry implements AiroEdgeMediaNodeRegistry {
+  const AiroNoOpEdgeMediaNodeRegistry();
+
+  @override
+  FutureOr<List<AiroEdgeMediaNodeProfile>> candidates() => const [];
+}
+
+class AiroFakeEdgeMediaNodeRegistry implements AiroEdgeMediaNodeRegistry {
+  AiroFakeEdgeMediaNodeRegistry({
+    required List<AiroEdgeMediaNodeProfile> profiles,
+  }) : profiles = List.unmodifiable(profiles);
+
+  final List<AiroEdgeMediaNodeProfile> profiles;
+
+  @override
+  FutureOr<List<AiroEdgeMediaNodeProfile>> candidates() => profiles;
+}

--- a/packages/core_protocol/test/edge_media_node_models_test.dart
+++ b/packages/core_protocol/test/edge_media_node_models_test.dart
@@ -1,0 +1,313 @@
+import 'package:core_protocol/core_protocol.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('AiroEdgeMediaNodePolicy', () {
+    const policy = AiroEdgeMediaNodePolicy();
+    final now = DateTime.utc(2026, 7, 14, 12);
+
+    AiroNodeCapabilityAdvertisement advertisement({
+      AiroNodeRole role = AiroNodeRole.homeNode,
+      AiroNodeLifecycleState lifecycle = AiroNodeLifecycleState.available,
+      AiroNodeTrustState trustState = AiroNodeTrustState.trusted,
+      Set<AiroNodeCapability> capabilities = const {
+        AiroNodeCapability.mediaIndexing,
+        AiroNodeCapability.diagnostics,
+        AiroNodeCapability.commandRouting,
+        AiroNodeCapability.recording,
+        AiroNodeCapability.transcoding,
+        AiroNodeCapability.aiDelegation,
+        AiroNodeCapability.metadataProcessing,
+      },
+      DateTime? expiresAt,
+    }) {
+      return AiroNodeCapabilityAdvertisement(
+        identity: AiroNodeIdentity(
+          nodeId: 'edge-1',
+          role: role,
+          productProfile: AiroNodeProductProfile.homeNode,
+          platformCategory: AiroNodePlatformCategory.server,
+        ),
+        lifecycle: lifecycle,
+        trustState: trustState,
+        capabilities: capabilities,
+        issuedAt: now,
+        expiresAt: expiresAt ?? now.add(const Duration(minutes: 1)),
+      );
+    }
+
+    AiroEdgeMediaNodeProfile profile({
+      AiroNodeCapabilityAdvertisement? nodeAdvertisement,
+      List<AiroEdgeMediaNodeServiceDescriptor> services = const [
+        AiroEdgeMediaNodeServiceDescriptor(
+          service: AiroEdgeMediaNodeService.mediaIndexing,
+          state: AiroEdgeMediaNodeServiceState.available,
+        ),
+        AiroEdgeMediaNodeServiceDescriptor(
+          service: AiroEdgeMediaNodeService.streamHealth,
+          state: AiroEdgeMediaNodeServiceState.available,
+        ),
+        AiroEdgeMediaNodeServiceDescriptor(
+          service: AiroEdgeMediaNodeService.relay,
+          state: AiroEdgeMediaNodeServiceState.available,
+        ),
+        AiroEdgeMediaNodeServiceDescriptor(
+          service: AiroEdgeMediaNodeService.recording,
+          state: AiroEdgeMediaNodeServiceState.available,
+        ),
+        AiroEdgeMediaNodeServiceDescriptor(
+          service: AiroEdgeMediaNodeService.transcoding,
+          state: AiroEdgeMediaNodeServiceState.available,
+        ),
+      ],
+    }) {
+      return AiroEdgeMediaNodeProfile(
+        profileId: 'edge-profile-1',
+        advertisement: nodeAdvertisement ?? advertisement(),
+        services: services,
+        observedAt: now,
+      );
+    }
+
+    AiroEdgeMediaNodeRequest request({
+      AiroEdgeMediaNodeService service = AiroEdgeMediaNodeService.mediaIndexing,
+      bool hasLocalNetworkScope = true,
+      bool allowRelay = false,
+      bool allowRecording = false,
+      bool allowTranscoding = false,
+    }) {
+      return AiroEdgeMediaNodeRequest(
+        requestId: 'request-1',
+        requestedByNodeId: 'tv-1',
+        service: service,
+        hasLocalNetworkScope: hasLocalNetworkScope,
+        allowRelay: allowRelay,
+        allowRecording: allowRecording,
+        allowTranscoding: allowTranscoding,
+      );
+    }
+
+    test('accepts trusted fresh home node with available indexing service', () {
+      final result = policy.evaluate(
+        profile: profile(),
+        request: request(),
+        now: now,
+      );
+
+      expect(result.accepted, isTrue);
+    });
+
+    test('accepts trusted desktop companion as future edge node candidate', () {
+      final result = policy.evaluate(
+        profile: profile(
+          nodeAdvertisement: advertisement(role: AiroNodeRole.desktopCompanion),
+        ),
+        request: request(service: AiroEdgeMediaNodeService.streamHealth),
+        now: now,
+      );
+
+      expect(result.accepted, isTrue);
+    });
+
+    test('rejects stale untrusted blocked and incompatible nodes', () {
+      final stale = policy.evaluate(
+        profile: profile(nodeAdvertisement: advertisement(expiresAt: now)),
+        request: request(),
+        now: now,
+      );
+      final untrusted = policy.evaluate(
+        profile: profile(
+          nodeAdvertisement: advertisement(
+            trustState: AiroNodeTrustState.untrusted,
+          ),
+        ),
+        request: request(),
+        now: now,
+      );
+      final blocked = policy.evaluate(
+        profile: profile(
+          nodeAdvertisement: advertisement(
+            lifecycle: AiroNodeLifecycleState.blocked,
+          ),
+        ),
+        request: request(),
+        now: now,
+      );
+      final incompatible = policy.evaluate(
+        profile: profile(
+          nodeAdvertisement: advertisement(role: AiroNodeRole.tvReceiver),
+        ),
+        request: request(),
+        now: now,
+      );
+
+      expect(
+        stale.blockers,
+        contains(AiroEdgeMediaNodeBlockerCode.staleAdvertisement),
+      );
+      expect(
+        untrusted.blockers,
+        contains(AiroEdgeMediaNodeBlockerCode.untrustedNode),
+      );
+      expect(
+        blocked.blockers,
+        contains(AiroEdgeMediaNodeBlockerCode.blockedNode),
+      );
+      expect(
+        incompatible.blockers,
+        contains(AiroEdgeMediaNodeBlockerCode.incompatibleRole),
+      );
+    });
+
+    test('rejects missing capability service descriptor and local scope', () {
+      final result = policy.evaluate(
+        profile: profile(
+          nodeAdvertisement: advertisement(capabilities: const {}),
+          services: const [],
+        ),
+        request: request(hasLocalNetworkScope: false),
+        now: now,
+      );
+
+      expect(
+        result.blockers,
+        contains(AiroEdgeMediaNodeBlockerCode.missingConnectedNodeCapability),
+      );
+      expect(
+        result.blockers,
+        contains(AiroEdgeMediaNodeBlockerCode.serviceMissing),
+      );
+    });
+
+    test('rejects placeholder-only and disabled services', () {
+      final placeholder = policy.evaluate(
+        profile: profile(
+          services: const [
+            AiroEdgeMediaNodeServiceDescriptor(
+              service: AiroEdgeMediaNodeService.mediaIndexing,
+              state: AiroEdgeMediaNodeServiceState.placeholder,
+            ),
+          ],
+        ),
+        request: request(),
+        now: now,
+      );
+      final disabled = policy.evaluate(
+        profile: profile(
+          services: const [
+            AiroEdgeMediaNodeServiceDescriptor(
+              service: AiroEdgeMediaNodeService.mediaIndexing,
+              state: AiroEdgeMediaNodeServiceState.disabled,
+            ),
+          ],
+        ),
+        request: request(),
+        now: now,
+      );
+
+      expect(
+        placeholder.blockers,
+        contains(AiroEdgeMediaNodeBlockerCode.serviceNotExecutable),
+      );
+      expect(
+        disabled.blockers,
+        contains(AiroEdgeMediaNodeBlockerCode.serviceNotExecutable),
+      );
+    });
+
+    test('riskier relay recording and transcoding services require opt-in', () {
+      final relay = policy.evaluate(
+        profile: profile(),
+        request: request(service: AiroEdgeMediaNodeService.relay),
+        now: now,
+      );
+      final recording = policy.evaluate(
+        profile: profile(),
+        request: request(service: AiroEdgeMediaNodeService.recording),
+        now: now,
+      );
+      final transcoding = policy.evaluate(
+        profile: profile(),
+        request: request(service: AiroEdgeMediaNodeService.transcoding),
+        now: now,
+      );
+      final allowedTranscoding = policy.evaluate(
+        profile: profile(),
+        request: request(
+          service: AiroEdgeMediaNodeService.transcoding,
+          allowTranscoding: true,
+        ),
+        now: now,
+      );
+
+      expect(
+        relay.blockers,
+        contains(AiroEdgeMediaNodeBlockerCode.relayNotAllowed),
+      );
+      expect(
+        recording.blockers,
+        contains(AiroEdgeMediaNodeBlockerCode.recordingNotAllowed),
+      );
+      expect(
+        transcoding.blockers,
+        contains(AiroEdgeMediaNodeBlockerCode.transcodingNotAllowed),
+      );
+      expect(allowedTranscoding.accepted, isTrue);
+    });
+
+    test('diagnostics expose stable ids without private media fields', () {
+      final edgeProfile = profile();
+      final rendered = edgeProfile.toString();
+
+      expect(rendered, contains('edge-profile-1'));
+      expect(rendered, contains('media_indexing:available'));
+      expect(rendered, isNot(contains('credential')));
+      expect(rendered, isNot(contains('mediaUrl')));
+      expect(rendered, isNot(contains('/Users/')));
+    });
+  });
+
+  group('AiroEdgeMediaNodeRegistry adapters', () {
+    final now = DateTime.utc(2026, 7, 14, 12);
+
+    final profile = AiroEdgeMediaNodeProfile(
+      profileId: 'edge-profile-1',
+      advertisement: AiroNodeCapabilityAdvertisement(
+        identity: const AiroNodeIdentity(
+          nodeId: 'edge-1',
+          role: AiroNodeRole.homeNode,
+          productProfile: AiroNodeProductProfile.homeNode,
+          platformCategory: AiroNodePlatformCategory.server,
+        ),
+        lifecycle: AiroNodeLifecycleState.available,
+        trustState: AiroNodeTrustState.trusted,
+        capabilities: const {AiroNodeCapability.mediaIndexing},
+        issuedAt: now,
+        expiresAt: now.add(const Duration(minutes: 1)),
+      ),
+      services: const [
+        AiroEdgeMediaNodeServiceDescriptor(
+          service: AiroEdgeMediaNodeService.mediaIndexing,
+          state: AiroEdgeMediaNodeServiceState.available,
+        ),
+      ],
+      observedAt: now,
+    );
+
+    test('no-op registry returns no candidates', () async {
+      const registry = AiroNoOpEdgeMediaNodeRegistry();
+
+      final candidates = await Future.value(registry.candidates());
+
+      expect(candidates, isEmpty);
+    });
+
+    test('fake registry returns deterministic candidates', () async {
+      final registry = AiroFakeEdgeMediaNodeRegistry(profiles: [profile]);
+
+      final candidates = await Future.value(registry.candidates());
+
+      expect(candidates.single.profileId, 'edge-profile-1');
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- define the ATV-026 Edge Media Node placeholder contract in `packages/core_protocol`
- add service descriptors, service states, future request policy, stable blocker codes, and fake/no-op registries
- gate future relay, recording, and transcoding behind explicit opt-ins
- document that this does not implement discovery, indexing, relay, recording, transcoding, AI workers, desktop services, or UI

Closes #616

## Validation
- `dart format --set-exit-if-changed packages/core_protocol`
- `cd packages/core_protocol && flutter test`
- `cd packages/core_protocol && flutter analyze --fatal-infos`
- `git diff --check HEAD~1..HEAD && git diff --check`
- diff-only secret scan for password/secret/api key/token patterns