### PR TITLE
feat(platform): add native media engine spike contract

### DIFF
--- a/docs/features/airo-tv/NATIVE_MEDIA_ENGINE_SPIKE_CONTRACT.md
+++ b/docs/features/airo-tv/NATIVE_MEDIA_ENGINE_SPIKE_CONTRACT.md
@@ -1,0 +1,90 @@
+# Native Media Engine Spike Contract
+
+Status: v2 platform contract for ATV-027.
+
+## Ownership
+
+Native media engine evaluation is platform/framework behavior. Airo TV can
+consume the eventual engine decision, but backend selection, surface
+requirements, diagnostics, and decoder fallback rules belong in platform
+contracts.
+
+The spike contract lives in `packages/platform_player` because that package
+already owns `AiroPlaybackEngine`, backend kinds, playback state, diagnostics,
+fake engines, and unavailable engines.
+
+## Non-Goals
+
+This issue does not implement:
+
+- Media3
+- mpv
+- libVLC
+- native texture rendering
+- platform-view rendering
+- decoder probing
+- playback widgets
+- app screen wiring
+- route selection
+
+The goal is a deterministic evaluation surface for a future implementation
+spike.
+
+## Contract Shape
+
+`AiroNativeMediaEngineCandidate` describes a backend option:
+
+- candidate id
+- backend kind
+- maturity
+- supported media kinds
+- supported surface modes
+- supported features
+
+`AiroNativeMediaEngineSpikeRequest` describes spike requirements:
+
+- required media kinds
+- required surface modes
+- required features
+- whether experimental backends are allowed
+- whether hardware decode is required
+- whether decoder fallback is required
+- whether diagnostics are required
+
+`AiroNativeMediaEngineSpikePolicy` returns stable blocker codes:
+
+- `accepted`
+- `backend_blocked`
+- `experimental_backend_not_allowed`
+- `unsupported_media_kind`
+- `missing_surface_mode`
+- `missing_required_feature`
+- `missing_diagnostics`
+- `missing_hardware_decode`
+- `missing_decoder_fallback`
+
+## Adapter Boundary
+
+`AiroNativeMediaEngineCandidateRegistry` lists candidate backend descriptions.
+The package includes:
+
+- `AiroNoOpNativeMediaEngineCandidateRegistry`
+- `AiroFakeNativeMediaEngineCandidateRegistry`
+
+Neither registry imports player SDKs or probes a device.
+
+## Spike Acceptance
+
+A candidate is eligible for the v2 native media engine spike only when it can
+support baseline HLS/live/progressive playback, the requested surface mode,
+audio and subtitle tracks, adaptive streaming, hardware decode, decoder
+fallback, and privacy-safe decoder/buffer diagnostics.
+
+Experimental backends require explicit opt-in. Blocked backends are never
+accepted.
+
+## Privacy
+
+Diagnostics expose stable backend ids, feature ids, surface ids, and blocker
+codes only. The spike contract must not expose raw media URLs, local file paths,
+local addresses, provider payloads, viewing history, or diagnostic dumps.

--- a/packages/platform_player/README.md
+++ b/packages/platform_player/README.md
@@ -9,12 +9,14 @@ flows consume these contracts instead of defining app-specific playback models.
 ## Scope
 
 - Backend-agnostic `AiroPlaybackEngine` contract.
+- Native media engine spike candidate, surface, diagnostics, and fallback
+  evaluation contracts.
 - Redacted media open requests with opaque source handles.
 - Typed playback states, quality options, tracks, diagnostics, and errors.
 - No-op/unavailable and fake playback engines for deterministic tests.
 - Cast discovery/session abstractions used by existing IPTV flows.
 
-This package does not choose a native media backend, probe decoders, persist
-sessions, render playback widgets, route commands, or expose raw media source
-URLs, local paths, local IP addresses, provider credentials, viewing history,
-analytics payloads, or diagnostic dumps.
+This package does not choose or implement a native media backend, import native
+player SDKs, probe decoders, persist sessions, render playback widgets, route
+commands, or expose raw media source URLs, local paths, local IP addresses,
+provider credentials, viewing history, analytics payloads, or diagnostic dumps.

--- a/packages/platform_player/lib/platform_player.dart
+++ b/packages/platform_player/lib/platform_player.dart
@@ -1,6 +1,7 @@
 library;
 
 export "src/models/cast_models.dart";
+export "src/models/native_media_engine_spike_models.dart";
 export "src/models/playback_engine_models.dart";
 export "src/models/streaming_state.dart";
 export "src/services/airo_cast_controller.dart";

--- a/packages/platform_player/lib/src/models/native_media_engine_spike_models.dart
+++ b/packages/platform_player/lib/src/models/native_media_engine_spike_models.dart
@@ -1,0 +1,254 @@
+import 'package:equatable/equatable.dart';
+
+import 'playback_engine_models.dart';
+
+const String kAiroNativeMediaEngineSpikeSchemaVersion = '1.0.0';
+
+enum AiroPlaybackSurfaceMode {
+  texture('texture'),
+  platformView('platform_view'),
+  externalReceiver('external_receiver'),
+  headless('headless');
+
+  const AiroPlaybackSurfaceMode(this.stableId);
+
+  final String stableId;
+}
+
+enum AiroNativeMediaEngineFeature {
+  hardwareDecode('hardware_decode'),
+  softwareDecodeFallback('software_decode_fallback'),
+  decoderDiagnostics('decoder_diagnostics'),
+  bufferDiagnostics('buffer_diagnostics'),
+  subtitleTracks('subtitle_tracks'),
+  audioTracks('audio_tracks'),
+  adaptiveStreaming('adaptive_streaming'),
+  lowLatencyLive('low_latency_live'),
+  protectedPlayback('protected_playback');
+
+  const AiroNativeMediaEngineFeature(this.stableId);
+
+  final String stableId;
+}
+
+enum AiroNativeMediaEngineMaturity {
+  stable('stable'),
+  candidate('candidate'),
+  experimental('experimental'),
+  blocked('blocked');
+
+  const AiroNativeMediaEngineMaturity(this.stableId);
+
+  final String stableId;
+}
+
+enum AiroNativeMediaEngineBlockerCode {
+  accepted('accepted'),
+  backendBlocked('backend_blocked'),
+  experimentalBackendNotAllowed('experimental_backend_not_allowed'),
+  unsupportedMediaKind('unsupported_media_kind'),
+  missingSurfaceMode('missing_surface_mode'),
+  missingRequiredFeature('missing_required_feature'),
+  missingDiagnostics('missing_diagnostics'),
+  missingHardwareDecode('missing_hardware_decode'),
+  missingDecoderFallback('missing_decoder_fallback');
+
+  const AiroNativeMediaEngineBlockerCode(this.stableId);
+
+  final String stableId;
+}
+
+class AiroNativeMediaEngineCandidate extends Equatable {
+  AiroNativeMediaEngineCandidate({
+    required this.candidateId,
+    required this.backendKind,
+    required this.maturity,
+    required Set<AiroPlaybackMediaKind> supportedMediaKinds,
+    required Set<AiroPlaybackSurfaceMode> surfaceModes,
+    required Set<AiroNativeMediaEngineFeature> features,
+    this.schemaVersion = kAiroNativeMediaEngineSpikeSchemaVersion,
+  }) : supportedMediaKinds = Set.unmodifiable(supportedMediaKinds),
+       surfaceModes = Set.unmodifiable(surfaceModes),
+       features = Set.unmodifiable(features);
+
+  final String schemaVersion;
+  final String candidateId;
+  final AiroPlaybackBackendKind backendKind;
+  final AiroNativeMediaEngineMaturity maturity;
+  final Set<AiroPlaybackMediaKind> supportedMediaKinds;
+  final Set<AiroPlaybackSurfaceMode> surfaceModes;
+  final Set<AiroNativeMediaEngineFeature> features;
+
+  bool supportsAllMediaKinds(Set<AiroPlaybackMediaKind> mediaKinds) =>
+      supportedMediaKinds.containsAll(mediaKinds);
+
+  bool supportsAllSurfaceModes(Set<AiroPlaybackSurfaceMode> modes) =>
+      surfaceModes.containsAll(modes);
+
+  bool supportsAllFeatures(
+    Set<AiroNativeMediaEngineFeature> requiredFeatures,
+  ) => features.containsAll(requiredFeatures);
+
+  @override
+  String toString() {
+    return 'AiroNativeMediaEngineCandidate('
+        'candidateId: $candidateId, '
+        'backendKind: ${backendKind.stableId}, '
+        'maturity: ${maturity.stableId}, '
+        'supportedMediaKinds: ${supportedMediaKinds.map((kind) => kind.stableId).toList()}, '
+        'surfaceModes: ${surfaceModes.map((mode) => mode.stableId).toList()}, '
+        'features: ${features.map((feature) => feature.stableId).toList()}'
+        ')';
+  }
+
+  @override
+  List<Object?> get props => [
+    schemaVersion,
+    candidateId,
+    backendKind,
+    maturity,
+    supportedMediaKinds,
+    surfaceModes,
+    features,
+  ];
+}
+
+class AiroNativeMediaEngineSpikeRequest extends Equatable {
+  AiroNativeMediaEngineSpikeRequest({
+    required this.requestId,
+    required Set<AiroPlaybackMediaKind> requiredMediaKinds,
+    required Set<AiroPlaybackSurfaceMode> requiredSurfaceModes,
+    required Set<AiroNativeMediaEngineFeature> requiredFeatures,
+    this.allowExperimentalBackends = false,
+    this.requiresHardwareDecode = true,
+    this.requiresDecoderFallback = true,
+    this.requiresDiagnostics = true,
+    this.schemaVersion = kAiroNativeMediaEngineSpikeSchemaVersion,
+  }) : requiredMediaKinds = Set.unmodifiable(requiredMediaKinds),
+       requiredSurfaceModes = Set.unmodifiable(requiredSurfaceModes),
+       requiredFeatures = Set.unmodifiable(requiredFeatures);
+
+  final String schemaVersion;
+  final String requestId;
+  final Set<AiroPlaybackMediaKind> requiredMediaKinds;
+  final Set<AiroPlaybackSurfaceMode> requiredSurfaceModes;
+  final Set<AiroNativeMediaEngineFeature> requiredFeatures;
+  final bool allowExperimentalBackends;
+  final bool requiresHardwareDecode;
+  final bool requiresDecoderFallback;
+  final bool requiresDiagnostics;
+
+  @override
+  List<Object?> get props => [
+    schemaVersion,
+    requestId,
+    requiredMediaKinds,
+    requiredSurfaceModes,
+    requiredFeatures,
+    allowExperimentalBackends,
+    requiresHardwareDecode,
+    requiresDecoderFallback,
+    requiresDiagnostics,
+  ];
+}
+
+class AiroNativeMediaEngineEvaluation extends Equatable {
+  AiroNativeMediaEngineEvaluation({
+    required this.requestId,
+    required this.candidateId,
+    required List<AiroNativeMediaEngineBlockerCode> blockers,
+  }) : blockers = List.unmodifiable(blockers);
+
+  final String requestId;
+  final String candidateId;
+  final List<AiroNativeMediaEngineBlockerCode> blockers;
+
+  bool get accepted =>
+      blockers.length == 1 &&
+      blockers.single == AiroNativeMediaEngineBlockerCode.accepted;
+
+  @override
+  List<Object?> get props => [requestId, candidateId, blockers];
+}
+
+class AiroNativeMediaEngineSpikePolicy {
+  const AiroNativeMediaEngineSpikePolicy();
+
+  AiroNativeMediaEngineEvaluation evaluate({
+    required AiroNativeMediaEngineCandidate candidate,
+    required AiroNativeMediaEngineSpikeRequest request,
+  }) {
+    final blockers = <AiroNativeMediaEngineBlockerCode>[];
+    if (candidate.maturity == AiroNativeMediaEngineMaturity.blocked) {
+      blockers.add(AiroNativeMediaEngineBlockerCode.backendBlocked);
+    }
+    if (candidate.maturity == AiroNativeMediaEngineMaturity.experimental &&
+        !request.allowExperimentalBackends) {
+      blockers.add(
+        AiroNativeMediaEngineBlockerCode.experimentalBackendNotAllowed,
+      );
+    }
+    if (!candidate.supportsAllMediaKinds(request.requiredMediaKinds)) {
+      blockers.add(AiroNativeMediaEngineBlockerCode.unsupportedMediaKind);
+    }
+    if (!candidate.supportsAllSurfaceModes(request.requiredSurfaceModes)) {
+      blockers.add(AiroNativeMediaEngineBlockerCode.missingSurfaceMode);
+    }
+    if (!candidate.supportsAllFeatures(request.requiredFeatures)) {
+      blockers.add(AiroNativeMediaEngineBlockerCode.missingRequiredFeature);
+    }
+    if (request.requiresDiagnostics &&
+        (!candidate.features.contains(
+              AiroNativeMediaEngineFeature.decoderDiagnostics,
+            ) ||
+            !candidate.features.contains(
+              AiroNativeMediaEngineFeature.bufferDiagnostics,
+            ))) {
+      blockers.add(AiroNativeMediaEngineBlockerCode.missingDiagnostics);
+    }
+    if (request.requiresHardwareDecode &&
+        !candidate.features.contains(
+          AiroNativeMediaEngineFeature.hardwareDecode,
+        )) {
+      blockers.add(AiroNativeMediaEngineBlockerCode.missingHardwareDecode);
+    }
+    if (request.requiresDecoderFallback &&
+        !candidate.features.contains(
+          AiroNativeMediaEngineFeature.softwareDecodeFallback,
+        )) {
+      blockers.add(AiroNativeMediaEngineBlockerCode.missingDecoderFallback);
+    }
+
+    return AiroNativeMediaEngineEvaluation(
+      requestId: request.requestId,
+      candidateId: candidate.candidateId,
+      blockers: blockers.isEmpty
+          ? const [AiroNativeMediaEngineBlockerCode.accepted]
+          : blockers,
+    );
+  }
+}
+
+abstract interface class AiroNativeMediaEngineCandidateRegistry {
+  List<AiroNativeMediaEngineCandidate> candidates();
+}
+
+class AiroNoOpNativeMediaEngineCandidateRegistry
+    implements AiroNativeMediaEngineCandidateRegistry {
+  const AiroNoOpNativeMediaEngineCandidateRegistry();
+
+  @override
+  List<AiroNativeMediaEngineCandidate> candidates() => const [];
+}
+
+class AiroFakeNativeMediaEngineCandidateRegistry
+    implements AiroNativeMediaEngineCandidateRegistry {
+  AiroFakeNativeMediaEngineCandidateRegistry({
+    required List<AiroNativeMediaEngineCandidate> candidates,
+  }) : _candidates = List.unmodifiable(candidates);
+
+  final List<AiroNativeMediaEngineCandidate> _candidates;
+
+  @override
+  List<AiroNativeMediaEngineCandidate> candidates() => _candidates;
+}

--- a/packages/platform_player/test/native_media_engine_spike_models_test.dart
+++ b/packages/platform_player/test/native_media_engine_spike_models_test.dart
@@ -1,0 +1,191 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:platform_player/platform_player.dart';
+
+void main() {
+  group('AiroNativeMediaEngineSpikePolicy', () {
+    const policy = AiroNativeMediaEngineSpikePolicy();
+
+    AiroNativeMediaEngineSpikeRequest request({
+      bool allowExperimentalBackends = false,
+      bool requiresHardwareDecode = true,
+      bool requiresDecoderFallback = true,
+      bool requiresDiagnostics = true,
+    }) {
+      return AiroNativeMediaEngineSpikeRequest(
+        requestId: 'spike-1',
+        requiredMediaKinds: const {
+          AiroPlaybackMediaKind.hls,
+          AiroPlaybackMediaKind.progressive,
+          AiroPlaybackMediaKind.live,
+        },
+        requiredSurfaceModes: const {AiroPlaybackSurfaceMode.texture},
+        requiredFeatures: const {
+          AiroNativeMediaEngineFeature.subtitleTracks,
+          AiroNativeMediaEngineFeature.audioTracks,
+          AiroNativeMediaEngineFeature.adaptiveStreaming,
+        },
+        allowExperimentalBackends: allowExperimentalBackends,
+        requiresHardwareDecode: requiresHardwareDecode,
+        requiresDecoderFallback: requiresDecoderFallback,
+        requiresDiagnostics: requiresDiagnostics,
+      );
+    }
+
+    AiroNativeMediaEngineCandidate candidate({
+      String candidateId = 'media3-spike',
+      AiroPlaybackBackendKind backendKind = AiroPlaybackBackendKind.media3,
+      AiroNativeMediaEngineMaturity maturity =
+          AiroNativeMediaEngineMaturity.candidate,
+      Set<AiroPlaybackMediaKind> supportedMediaKinds = const {
+        AiroPlaybackMediaKind.hls,
+        AiroPlaybackMediaKind.progressive,
+        AiroPlaybackMediaKind.live,
+      },
+      Set<AiroPlaybackSurfaceMode> surfaceModes = const {
+        AiroPlaybackSurfaceMode.texture,
+        AiroPlaybackSurfaceMode.platformView,
+      },
+      Set<AiroNativeMediaEngineFeature> features = const {
+        AiroNativeMediaEngineFeature.hardwareDecode,
+        AiroNativeMediaEngineFeature.softwareDecodeFallback,
+        AiroNativeMediaEngineFeature.decoderDiagnostics,
+        AiroNativeMediaEngineFeature.bufferDiagnostics,
+        AiroNativeMediaEngineFeature.subtitleTracks,
+        AiroNativeMediaEngineFeature.audioTracks,
+        AiroNativeMediaEngineFeature.adaptiveStreaming,
+      },
+    }) {
+      return AiroNativeMediaEngineCandidate(
+        candidateId: candidateId,
+        backendKind: backendKind,
+        maturity: maturity,
+        supportedMediaKinds: supportedMediaKinds,
+        surfaceModes: surfaceModes,
+        features: features,
+      );
+    }
+
+    test(
+      'accepts candidate that meets baseline native engine requirements',
+      () {
+        final result = policy.evaluate(
+          candidate: candidate(),
+          request: request(),
+        );
+
+        expect(result.accepted, isTrue);
+      },
+    );
+
+    test('rejects unsupported media kind and missing surface mode', () {
+      final result = policy.evaluate(
+        candidate: candidate(
+          supportedMediaKinds: const {AiroPlaybackMediaKind.hls},
+          surfaceModes: const {AiroPlaybackSurfaceMode.externalReceiver},
+        ),
+        request: request(),
+      );
+
+      expect(
+        result.blockers,
+        contains(AiroNativeMediaEngineBlockerCode.unsupportedMediaKind),
+      );
+      expect(
+        result.blockers,
+        contains(AiroNativeMediaEngineBlockerCode.missingSurfaceMode),
+      );
+    });
+
+    test('rejects missing diagnostics hardware decode and fallback', () {
+      final result = policy.evaluate(
+        candidate: candidate(
+          features: const {
+            AiroNativeMediaEngineFeature.subtitleTracks,
+            AiroNativeMediaEngineFeature.audioTracks,
+            AiroNativeMediaEngineFeature.adaptiveStreaming,
+          },
+        ),
+        request: request(),
+      );
+
+      expect(
+        result.blockers,
+        contains(AiroNativeMediaEngineBlockerCode.missingDiagnostics),
+      );
+      expect(
+        result.blockers,
+        contains(AiroNativeMediaEngineBlockerCode.missingHardwareDecode),
+      );
+      expect(
+        result.blockers,
+        contains(AiroNativeMediaEngineBlockerCode.missingDecoderFallback),
+      );
+    });
+
+    test('rejects experimental or blocked backends by policy', () {
+      final experimental = policy.evaluate(
+        candidate: candidate(
+          maturity: AiroNativeMediaEngineMaturity.experimental,
+        ),
+        request: request(),
+      );
+      final allowedExperimental = policy.evaluate(
+        candidate: candidate(
+          maturity: AiroNativeMediaEngineMaturity.experimental,
+        ),
+        request: request(allowExperimentalBackends: true),
+      );
+      final blocked = policy.evaluate(
+        candidate: candidate(maturity: AiroNativeMediaEngineMaturity.blocked),
+        request: request(allowExperimentalBackends: true),
+      );
+
+      expect(
+        experimental.blockers,
+        contains(
+          AiroNativeMediaEngineBlockerCode.experimentalBackendNotAllowed,
+        ),
+      );
+      expect(allowedExperimental.accepted, isTrue);
+      expect(
+        blocked.blockers,
+        contains(AiroNativeMediaEngineBlockerCode.backendBlocked),
+      );
+    });
+
+    test('diagnostics expose stable ids without raw media references', () {
+      final rendered = candidate().toString();
+
+      expect(rendered, contains('media3-spike'));
+      expect(rendered, contains('media3'));
+      expect(rendered, isNot(contains('http')));
+      expect(rendered, isNot(contains('/Users/')));
+      expect(rendered, isNot(contains('credential')));
+    });
+  });
+
+  group('AiroNativeMediaEngineCandidateRegistry adapters', () {
+    final candidate = AiroNativeMediaEngineCandidate(
+      candidateId: 'media3-spike',
+      backendKind: AiroPlaybackBackendKind.media3,
+      maturity: AiroNativeMediaEngineMaturity.candidate,
+      supportedMediaKinds: const {AiroPlaybackMediaKind.hls},
+      surfaceModes: const {AiroPlaybackSurfaceMode.texture},
+      features: const {AiroNativeMediaEngineFeature.hardwareDecode},
+    );
+
+    test('no-op registry returns no candidates', () {
+      const registry = AiroNoOpNativeMediaEngineCandidateRegistry();
+
+      expect(registry.candidates(), isEmpty);
+    });
+
+    test('fake registry returns deterministic candidates', () {
+      final registry = AiroFakeNativeMediaEngineCandidateRegistry(
+        candidates: [candidate],
+      );
+
+      expect(registry.candidates().single.candidateId, 'media3-spike');
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Adds the ATV-027 native media engine spike contract in platform_player.
- Defines backend candidate, surface mode, feature, maturity, evaluation, blocker, and registry models.
- Documents the platform ownership boundary and non-goals for native engine evaluation.

## Agent Policy
- Owning agents: Media Agent / Platform Agent.
- Reviewing agents: Framework, Security and Privacy, QA Automation, Release and DevEx.
- Layer: platform/shared-contract.
- Base verified from latest origin/v2 after git fetch origin main v2.
- No application-layer player implementation, native SDK import, decoder probing, rendering, routing, or content/provider shortcut added.

## Validation
- dart format --set-exit-if-changed packages/platform_player
- cd packages/platform_player && flutter test
- cd packages/platform_player && flutter analyze --fatal-infos
- git diff --check HEAD~1..HEAD && git diff --check
- Diff secret scan reviewed: only literal privacy/negative-test terms for credential redaction, no secret material.

Closes #617