### PR TITLE
feat(platform): add large playlist worker contract

### DIFF
--- a/docs/features/airo-tv/LARGE_PLAYLIST_WORKER_PIPELINE.md
+++ b/docs/features/airo-tv/LARGE_PLAYLIST_WORKER_PIPELINE.md
@@ -1,0 +1,67 @@
+# Large Playlist Worker Pipeline
+
+Status: v2 platform contract for ATV-029.
+
+## Ownership
+
+Large playlist import orchestration is platform behavior. Airo TV can display
+progress or consume partial results later, but streamed parsing, normalization,
+dedupe, batch writes, cancellation, and import diagnostics belong in
+`packages/platform_playlist_import`.
+
+The storage boundary is `AiroPlaylistBatchWriter`, so database engines can be
+swapped without changing Airo TV product code.
+
+## Non-Goals
+
+This issue does not implement:
+
+- isolate scheduling
+- concrete database batch writes
+- network download or resume logic
+- generated large playlist fixtures
+- Airo TV progress UI
+- provider-specific shortcuts
+- analytics upload
+
+## Contract Shape
+
+`AiroLargePlaylistImportPlan` describes:
+
+- job id
+- redacted source reference
+- expected item count
+- batch size
+- max concurrency
+- required worker stages
+- partial availability behavior
+
+`AiroLargePlaylistProgress` reports:
+
+- current stage and status
+- parsed, normalized, deduped, written, and failed counts
+- batch index
+- safe diagnostic codes
+- completion ratio
+- partial availability and terminal state helpers
+
+`AiroPlaylistBatchWriter` is the persistence adapter boundary. It receives
+batch counts and returns accepted/rejected counts without exposing channel
+payloads in the contract.
+
+## Required Stages
+
+- `source_open`
+- `parse`
+- `normalize`
+- `dedupe`
+- `batch_write`
+- `index`
+- `finalize`
+
+## Privacy
+
+Worker diagnostics use stable ids, counts, stages, statuses, and blocker codes
+only. They must not expose raw playlist URLs, local paths, local addresses,
+request headers, provider payloads, viewing history, analytics payloads, or
+device identifiers.

--- a/packages/platform_playlist_import/README.md
+++ b/packages/platform_playlist_import/README.md
@@ -1,39 +1,19 @@
-<!--
-This README describes the package. If you publish this package to pub.dev,
-this README's contents appear on the landing page for your package.
+# Platform Playlist Import
 
-For information about how to write a good package README, see the guide for
-[writing package pages](https://dart.dev/tools/pub/writing-package-pages).
+Reusable playlist import contracts and services for Airo products.
 
-For general information about developing packages, see the Dart guide for
-[creating packages](https://dart.dev/guides/libraries/create-packages)
-and the Flutter guide for
-[developing packages and plugins](https://flutter.dev/to/develop-packages).
--->
+This package owns playlist parsing and import pipeline boundaries that should
+not be hard-coded inside Airo TV screens or tied to a concrete storage engine.
 
-TODO: Put a short description of the package here that helps potential users
-know whether this package might be useful for them.
+## Scope
 
-## Features
+- User-supplied M3U parsing and cache helpers.
+- Generic import pipeline stage abstraction.
+- Large playlist worker plan, progress, cancellation, partial availability,
+  batch-write, and diagnostic contracts.
+- Fake and no-op worker/batch-writer adapters for deterministic automation.
 
-TODO: List what your package can do. Maybe include images, gifs, or videos.
-
-## Getting started
-
-TODO: List prerequisites and provide or point to information on how to
-start using the package.
-
-## Usage
-
-TODO: Include short and useful examples for package users. Add longer examples
-to `/example` folder.
-
-```dart
-const like = 'sample';
-```
-
-## Additional information
-
-TODO: Tell users more about the package: where to find more information, how to
-contribute to the package, how to file issues, what response they can expect
-from the package authors, and more.
+This package does not choose a database engine, own Airo TV progress UI,
+download provider-specific bundled content, expose raw playlist URLs in worker
+diagnostics, or import storage SDKs directly. Concrete storage adapters should
+plug in behind `AiroPlaylistBatchWriter`.

--- a/packages/platform_playlist_import/lib/platform_playlist_import.dart
+++ b/packages/platform_playlist_import/lib/platform_playlist_import.dart
@@ -1,5 +1,6 @@
-library platform_playlist_import;
+library;
 
 export "src/pipeline/pipeline_stage.dart";
 export "src/pipeline/import_pipeline.dart";
+export "src/pipeline/large_playlist_worker_models.dart";
 export "src/m3u_parser_service.dart";

--- a/packages/platform_playlist_import/lib/src/m3u_parser_service.dart
+++ b/packages/platform_playlist_import/lib/src/m3u_parser_service.dart
@@ -1,3 +1,5 @@
+import 'dart:developer' as developer;
+
 import 'package:dio/dio.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:platform_channels/platform_channels.dart';
@@ -35,8 +37,11 @@ class M3UParserService {
         await _saveToCache(channels);
         return channels;
       }
-    } catch (e) {
-      print('[M3U] Failed to fetch user playlist: $e');
+    } catch (_) {
+      developer.log(
+        'Failed to fetch user playlist.',
+        name: 'platform_playlist_import',
+      );
     }
 
     // Network failed; use only a cache derived from the user's own playlist.

--- a/packages/platform_playlist_import/lib/src/pipeline/large_playlist_worker_models.dart
+++ b/packages/platform_playlist_import/lib/src/pipeline/large_playlist_worker_models.dart
@@ -1,0 +1,476 @@
+import 'package:equatable/equatable.dart';
+
+const String kAiroLargePlaylistWorkerSchemaVersion = '1.0.0';
+
+enum AiroLargePlaylistWorkerStage {
+  sourceOpen('source_open'),
+  parse('parse'),
+  normalize('normalize'),
+  dedupe('dedupe'),
+  batchWrite('batch_write'),
+  buildIndex('index'),
+  finalize('finalize');
+
+  const AiroLargePlaylistWorkerStage(this.stableId);
+
+  final String stableId;
+}
+
+enum AiroLargePlaylistWorkerStatus {
+  queued('queued'),
+  running('running'),
+  partialAvailable('partial_available'),
+  cancelRequested('cancel_requested'),
+  cancelled('cancelled'),
+  completed('completed'),
+  failed('failed');
+
+  const AiroLargePlaylistWorkerStatus(this.stableId);
+
+  final String stableId;
+}
+
+enum AiroLargePlaylistWorkerDiagnosticCode {
+  sourceUnavailable('source_unavailable'),
+  parseFailed('parse_failed'),
+  batchWriteFailed('batch_write_failed'),
+  cancellationRequested('cancellation_requested'),
+  partialAvailabilityPublished('partial_availability_published'),
+  privacyUnsafeSourceRef('privacy_unsafe_source_ref');
+
+  const AiroLargePlaylistWorkerDiagnosticCode(this.stableId);
+
+  final String stableId;
+}
+
+enum AiroLargePlaylistWorkerPlanBlockerCode {
+  accepted('accepted'),
+  emptyJobId('empty_job_id'),
+  invalidExpectedItemCount('invalid_expected_item_count'),
+  invalidBatchSize('invalid_batch_size'),
+  invalidConcurrency('invalid_concurrency'),
+  missingRequiredStage('missing_required_stage'),
+  privacyUnsafeSourceRef('privacy_unsafe_source_ref');
+
+  const AiroLargePlaylistWorkerPlanBlockerCode(this.stableId);
+
+  final String stableId;
+}
+
+enum AiroLargePlaylistSourceRefRejectionCode {
+  empty('empty'),
+  urlValue('url_value'),
+  localPathValue('local_path_value'),
+  localIpValue('local_ip_value'),
+  credentialLikeValue('credential_like_value');
+
+  const AiroLargePlaylistSourceRefRejectionCode(this.stableId);
+
+  final String stableId;
+}
+
+class AiroLargePlaylistSourceRef extends Equatable {
+  const AiroLargePlaylistSourceRef._(this.value);
+
+  factory AiroLargePlaylistSourceRef.redacted(String value) {
+    final rejection = validate(value);
+    if (rejection != null) {
+      throw ArgumentError.value(value, 'value', rejection.stableId);
+    }
+    return AiroLargePlaylistSourceRef._(value.trim());
+  }
+
+  final String value;
+
+  static AiroLargePlaylistSourceRefRejectionCode? validate(String value) {
+    final trimmed = value.trim();
+    if (trimmed.isEmpty) {
+      return AiroLargePlaylistSourceRefRejectionCode.empty;
+    }
+    final uri = Uri.tryParse(trimmed);
+    if (uri != null && (uri.scheme == 'http' || uri.scheme == 'https')) {
+      return AiroLargePlaylistSourceRefRejectionCode.urlValue;
+    }
+    if (trimmed.startsWith('file://') ||
+        trimmed.startsWith('/') ||
+        RegExp(r'^[A-Za-z]:\\').hasMatch(trimmed)) {
+      return AiroLargePlaylistSourceRefRejectionCode.localPathValue;
+    }
+    if (RegExp(
+      r'\b(?:10|127|172\.(?:1[6-9]|2\d|3[0-1])|192\.168)\.',
+    ).hasMatch(trimmed)) {
+      return AiroLargePlaylistSourceRefRejectionCode.localIpValue;
+    }
+    if (RegExp(
+      r'\b(?:bearer|basic)\s+[A-Za-z0-9._~+/=-]+',
+      caseSensitive: false,
+    ).hasMatch(trimmed)) {
+      return AiroLargePlaylistSourceRefRejectionCode.credentialLikeValue;
+    }
+    return null;
+  }
+
+  @override
+  String toString() => 'AiroLargePlaylistSourceRef(redacted)';
+
+  @override
+  List<Object?> get props => [value];
+}
+
+class AiroLargePlaylistImportPlan extends Equatable {
+  AiroLargePlaylistImportPlan({
+    required this.jobId,
+    required this.sourceRef,
+    required this.expectedItemCount,
+    required this.batchSize,
+    required this.maxConcurrency,
+    required Iterable<AiroLargePlaylistWorkerStage> stages,
+    this.allowPartialAvailability = true,
+    this.schemaVersion = kAiroLargePlaylistWorkerSchemaVersion,
+  }) : stages = List.unmodifiable(stages);
+
+  final String schemaVersion;
+  final String jobId;
+  final AiroLargePlaylistSourceRef sourceRef;
+  final int expectedItemCount;
+  final int batchSize;
+  final int maxConcurrency;
+  final List<AiroLargePlaylistWorkerStage> stages;
+  final bool allowPartialAvailability;
+
+  int get expectedBatchCount => (expectedItemCount / batchSize).ceil();
+
+  @override
+  List<Object?> get props => [
+    schemaVersion,
+    jobId,
+    sourceRef,
+    expectedItemCount,
+    batchSize,
+    maxConcurrency,
+    stages,
+    allowPartialAvailability,
+  ];
+}
+
+class AiroLargePlaylistImportDiagnostic extends Equatable {
+  const AiroLargePlaylistImportDiagnostic({
+    required this.code,
+    required this.stage,
+    this.safeDetail,
+    this.schemaVersion = kAiroLargePlaylistWorkerSchemaVersion,
+  });
+
+  final String schemaVersion;
+  final AiroLargePlaylistWorkerDiagnosticCode code;
+  final AiroLargePlaylistWorkerStage stage;
+  final String? safeDetail;
+
+  @override
+  List<Object?> get props => [schemaVersion, code, stage, safeDetail];
+}
+
+class AiroLargePlaylistProgress extends Equatable {
+  AiroLargePlaylistProgress({
+    required this.jobId,
+    required this.stage,
+    required this.status,
+    required this.expectedItemCount,
+    required this.parsedCount,
+    required this.normalizedCount,
+    required this.dedupedCount,
+    required this.writtenCount,
+    required this.failedCount,
+    required this.batchIndex,
+    Iterable<AiroLargePlaylistImportDiagnostic> diagnostics = const [],
+    this.schemaVersion = kAiroLargePlaylistWorkerSchemaVersion,
+  }) : diagnostics = List.unmodifiable(diagnostics);
+
+  final String schemaVersion;
+  final String jobId;
+  final AiroLargePlaylistWorkerStage stage;
+  final AiroLargePlaylistWorkerStatus status;
+  final int expectedItemCount;
+  final int parsedCount;
+  final int normalizedCount;
+  final int dedupedCount;
+  final int writtenCount;
+  final int failedCount;
+  final int batchIndex;
+  final List<AiroLargePlaylistImportDiagnostic> diagnostics;
+
+  double get completionRatio {
+    if (expectedItemCount <= 0) {
+      return 0;
+    }
+    final completed = writtenCount > 0 ? writtenCount : parsedCount;
+    return (completed / expectedItemCount).clamp(0, 1).toDouble();
+  }
+
+  bool get hasPartialAvailability =>
+      status == AiroLargePlaylistWorkerStatus.partialAvailable ||
+      writtenCount > 0;
+
+  bool get isTerminal =>
+      status == AiroLargePlaylistWorkerStatus.completed ||
+      status == AiroLargePlaylistWorkerStatus.cancelled ||
+      status == AiroLargePlaylistWorkerStatus.failed;
+
+  @override
+  String toString() {
+    return 'AiroLargePlaylistProgress('
+        'jobId: $jobId, '
+        'stage: ${stage.stableId}, '
+        'status: ${status.stableId}, '
+        'expectedItemCount: $expectedItemCount, '
+        'writtenCount: $writtenCount, '
+        'failedCount: $failedCount'
+        ')';
+  }
+
+  @override
+  List<Object?> get props => [
+    schemaVersion,
+    jobId,
+    stage,
+    status,
+    expectedItemCount,
+    parsedCount,
+    normalizedCount,
+    dedupedCount,
+    writtenCount,
+    failedCount,
+    batchIndex,
+    diagnostics,
+  ];
+}
+
+class AiroPlaylistBatchWriteRequest extends Equatable {
+  const AiroPlaylistBatchWriteRequest({
+    required this.jobId,
+    required this.batchIndex,
+    required this.recordCount,
+    this.schemaVersion = kAiroLargePlaylistWorkerSchemaVersion,
+  });
+
+  final String schemaVersion;
+  final String jobId;
+  final int batchIndex;
+  final int recordCount;
+
+  @override
+  List<Object?> get props => [schemaVersion, jobId, batchIndex, recordCount];
+}
+
+class AiroPlaylistBatchWriteResult extends Equatable {
+  const AiroPlaylistBatchWriteResult({
+    required this.jobId,
+    required this.batchIndex,
+    required this.acceptedCount,
+    required this.rejectedCount,
+    this.schemaVersion = kAiroLargePlaylistWorkerSchemaVersion,
+  });
+
+  final String schemaVersion;
+  final String jobId;
+  final int batchIndex;
+  final int acceptedCount;
+  final int rejectedCount;
+
+  bool get isSuccessful => rejectedCount == 0;
+
+  @override
+  List<Object?> get props => [
+    schemaVersion,
+    jobId,
+    batchIndex,
+    acceptedCount,
+    rejectedCount,
+  ];
+}
+
+class AiroLargePlaylistWorkerPlanEvaluation extends Equatable {
+  AiroLargePlaylistWorkerPlanEvaluation({
+    required this.jobId,
+    required Iterable<AiroLargePlaylistWorkerPlanBlockerCode> blockers,
+  }) : blockers = List.unmodifiable(blockers);
+
+  final String jobId;
+  final List<AiroLargePlaylistWorkerPlanBlockerCode> blockers;
+
+  bool get accepted =>
+      blockers.length == 1 &&
+      blockers.single == AiroLargePlaylistWorkerPlanBlockerCode.accepted;
+
+  @override
+  List<Object?> get props => [jobId, blockers];
+}
+
+class AiroLargePlaylistWorkerPolicy {
+  const AiroLargePlaylistWorkerPolicy();
+
+  static const Set<AiroLargePlaylistWorkerStage> requiredStages = {
+    AiroLargePlaylistWorkerStage.sourceOpen,
+    AiroLargePlaylistWorkerStage.parse,
+    AiroLargePlaylistWorkerStage.normalize,
+    AiroLargePlaylistWorkerStage.dedupe,
+    AiroLargePlaylistWorkerStage.batchWrite,
+    AiroLargePlaylistWorkerStage.buildIndex,
+    AiroLargePlaylistWorkerStage.finalize,
+  };
+
+  AiroLargePlaylistWorkerPlanEvaluation validate(
+    AiroLargePlaylistImportPlan plan,
+  ) {
+    final blockers = <AiroLargePlaylistWorkerPlanBlockerCode>[];
+    if (plan.jobId.trim().isEmpty) {
+      blockers.add(AiroLargePlaylistWorkerPlanBlockerCode.emptyJobId);
+    }
+    if (plan.expectedItemCount <= 0) {
+      blockers.add(
+        AiroLargePlaylistWorkerPlanBlockerCode.invalidExpectedItemCount,
+      );
+    }
+    if (plan.batchSize <= 0 || plan.batchSize > plan.expectedItemCount) {
+      blockers.add(AiroLargePlaylistWorkerPlanBlockerCode.invalidBatchSize);
+    }
+    if (plan.maxConcurrency <= 0) {
+      blockers.add(AiroLargePlaylistWorkerPlanBlockerCode.invalidConcurrency);
+    }
+    if (!plan.stages.toSet().containsAll(requiredStages)) {
+      blockers.add(AiroLargePlaylistWorkerPlanBlockerCode.missingRequiredStage);
+    }
+    if (AiroLargePlaylistSourceRef.validate(plan.sourceRef.value) != null) {
+      blockers.add(
+        AiroLargePlaylistWorkerPlanBlockerCode.privacyUnsafeSourceRef,
+      );
+    }
+
+    return AiroLargePlaylistWorkerPlanEvaluation(
+      jobId: plan.jobId,
+      blockers: blockers.isEmpty
+          ? const [AiroLargePlaylistWorkerPlanBlockerCode.accepted]
+          : blockers,
+    );
+  }
+}
+
+abstract interface class AiroPlaylistBatchWriter {
+  Future<AiroPlaylistBatchWriteResult> writeBatch(
+    AiroPlaylistBatchWriteRequest request,
+  );
+}
+
+class AiroNoOpPlaylistBatchWriter implements AiroPlaylistBatchWriter {
+  const AiroNoOpPlaylistBatchWriter();
+
+  @override
+  Future<AiroPlaylistBatchWriteResult> writeBatch(
+    AiroPlaylistBatchWriteRequest request,
+  ) async {
+    return AiroPlaylistBatchWriteResult(
+      jobId: request.jobId,
+      batchIndex: request.batchIndex,
+      acceptedCount: 0,
+      rejectedCount: request.recordCount,
+    );
+  }
+}
+
+class AiroFakePlaylistBatchWriter implements AiroPlaylistBatchWriter {
+  const AiroFakePlaylistBatchWriter({this.rejectAll = false});
+
+  final bool rejectAll;
+
+  @override
+  Future<AiroPlaylistBatchWriteResult> writeBatch(
+    AiroPlaylistBatchWriteRequest request,
+  ) async {
+    return AiroPlaylistBatchWriteResult(
+      jobId: request.jobId,
+      batchIndex: request.batchIndex,
+      acceptedCount: rejectAll ? 0 : request.recordCount,
+      rejectedCount: rejectAll ? request.recordCount : 0,
+    );
+  }
+}
+
+abstract interface class AiroLargePlaylistWorker {
+  Stream<AiroLargePlaylistProgress> run(AiroLargePlaylistImportPlan plan);
+  Future<void> cancel(String jobId);
+}
+
+class AiroNoOpLargePlaylistWorker implements AiroLargePlaylistWorker {
+  const AiroNoOpLargePlaylistWorker();
+
+  @override
+  Stream<AiroLargePlaylistProgress> run(
+    AiroLargePlaylistImportPlan plan,
+  ) async* {
+    yield AiroLargePlaylistProgress(
+      jobId: plan.jobId,
+      stage: AiroLargePlaylistWorkerStage.sourceOpen,
+      status: AiroLargePlaylistWorkerStatus.failed,
+      expectedItemCount: plan.expectedItemCount,
+      parsedCount: 0,
+      normalizedCount: 0,
+      dedupedCount: 0,
+      writtenCount: 0,
+      failedCount: 0,
+      batchIndex: 0,
+      diagnostics: const [
+        AiroLargePlaylistImportDiagnostic(
+          code: AiroLargePlaylistWorkerDiagnosticCode.sourceUnavailable,
+          stage: AiroLargePlaylistWorkerStage.sourceOpen,
+        ),
+      ],
+    );
+  }
+
+  @override
+  Future<void> cancel(String jobId) async {}
+}
+
+class AiroFakeLargePlaylistWorker implements AiroLargePlaylistWorker {
+  AiroFakeLargePlaylistWorker({
+    required Iterable<AiroLargePlaylistProgress> progress,
+  }) : _progress = List.unmodifiable(progress);
+
+  final List<AiroLargePlaylistProgress> _progress;
+  final Set<String> _cancelledJobIds = {};
+
+  @override
+  Stream<AiroLargePlaylistProgress> run(
+    AiroLargePlaylistImportPlan plan,
+  ) async* {
+    for (final event in _progress.where((event) => event.jobId == plan.jobId)) {
+      if (_cancelledJobIds.contains(plan.jobId)) {
+        yield AiroLargePlaylistProgress(
+          jobId: plan.jobId,
+          stage: event.stage,
+          status: AiroLargePlaylistWorkerStatus.cancelled,
+          expectedItemCount: plan.expectedItemCount,
+          parsedCount: event.parsedCount,
+          normalizedCount: event.normalizedCount,
+          dedupedCount: event.dedupedCount,
+          writtenCount: event.writtenCount,
+          failedCount: event.failedCount,
+          batchIndex: event.batchIndex,
+          diagnostics: const [
+            AiroLargePlaylistImportDiagnostic(
+              code: AiroLargePlaylistWorkerDiagnosticCode.cancellationRequested,
+              stage: AiroLargePlaylistWorkerStage.batchWrite,
+            ),
+          ],
+        );
+        return;
+      }
+      yield event;
+    }
+  }
+
+  @override
+  Future<void> cancel(String jobId) async {
+    _cancelledJobIds.add(jobId);
+  }
+}

--- a/packages/platform_playlist_import/pubspec.yaml
+++ b/packages/platform_playlist_import/pubspec.yaml
@@ -2,6 +2,7 @@ name: platform_playlist_import
 description: "A new Flutter package project."
 version: 0.0.1
 homepage:
+publish_to: none
 
 environment:
   sdk: ^3.12.2

--- a/packages/platform_playlist_import/test/large_playlist_worker_models_test.dart
+++ b/packages/platform_playlist_import/test/large_playlist_worker_models_test.dart
@@ -1,0 +1,246 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:platform_playlist_import/platform_playlist_import.dart';
+
+void main() {
+  group('AiroLargePlaylistWorkerPolicy', () {
+    const policy = AiroLargePlaylistWorkerPolicy();
+
+    AiroLargePlaylistImportPlan plan({
+      String jobId = 'large-import-250k',
+      int expectedItemCount = 250000,
+      int batchSize = 5000,
+      int maxConcurrency = 2,
+      List<AiroLargePlaylistWorkerStage>? stages,
+    }) {
+      return AiroLargePlaylistImportPlan(
+        jobId: jobId,
+        sourceRef: AiroLargePlaylistSourceRef.redacted('user-playlist-primary'),
+        expectedItemCount: expectedItemCount,
+        batchSize: batchSize,
+        maxConcurrency: maxConcurrency,
+        stages: stages ?? AiroLargePlaylistWorkerPolicy.requiredStages,
+      );
+    }
+
+    test('accepts large import plan with required worker stages', () {
+      final evaluation = policy.validate(plan());
+
+      expect(evaluation.accepted, isTrue);
+      expect(plan().expectedBatchCount, 50);
+    });
+
+    test('rejects invalid counts concurrency and missing stages', () {
+      final evaluation = policy.validate(
+        plan(
+          jobId: '',
+          expectedItemCount: 0,
+          batchSize: 0,
+          maxConcurrency: 0,
+          stages: const [AiroLargePlaylistWorkerStage.parse],
+        ),
+      );
+
+      expect(
+        evaluation.blockers,
+        contains(AiroLargePlaylistWorkerPlanBlockerCode.emptyJobId),
+      );
+      expect(
+        evaluation.blockers,
+        contains(
+          AiroLargePlaylistWorkerPlanBlockerCode.invalidExpectedItemCount,
+        ),
+      );
+      expect(
+        evaluation.blockers,
+        contains(AiroLargePlaylistWorkerPlanBlockerCode.invalidBatchSize),
+      );
+      expect(
+        evaluation.blockers,
+        contains(AiroLargePlaylistWorkerPlanBlockerCode.invalidConcurrency),
+      );
+      expect(
+        evaluation.blockers,
+        contains(AiroLargePlaylistWorkerPlanBlockerCode.missingRequiredStage),
+      );
+    });
+
+    test('redacted source refs reject raw playlist locations', () {
+      expect(
+        () => AiroLargePlaylistSourceRef.redacted(
+          'https://example.com/private.m3u',
+        ),
+        throwsArgumentError,
+      );
+      expect(
+        () => AiroLargePlaylistSourceRef.redacted('/Users/me/private.m3u'),
+        throwsArgumentError,
+      );
+      expect(
+        () => AiroLargePlaylistSourceRef.redacted('192.168.1.20/private.m3u'),
+        throwsArgumentError,
+      );
+      expect(
+        () => AiroLargePlaylistSourceRef.redacted('Basic abc123'),
+        throwsArgumentError,
+      );
+    });
+  });
+
+  group('AiroLargePlaylistProgress', () {
+    test(
+      'reports partial availability and terminal states deterministically',
+      () {
+        final progress = AiroLargePlaylistProgress(
+          jobId: 'large-import-50k',
+          stage: AiroLargePlaylistWorkerStage.batchWrite,
+          status: AiroLargePlaylistWorkerStatus.partialAvailable,
+          expectedItemCount: 50000,
+          parsedCount: 50000,
+          normalizedCount: 49000,
+          dedupedCount: 48000,
+          writtenCount: 12000,
+          failedCount: 0,
+          batchIndex: 3,
+          diagnostics: const [
+            AiroLargePlaylistImportDiagnostic(
+              code: AiroLargePlaylistWorkerDiagnosticCode
+                  .partialAvailabilityPublished,
+              stage: AiroLargePlaylistWorkerStage.batchWrite,
+            ),
+          ],
+        );
+
+        expect(progress.completionRatio, 0.24);
+        expect(progress.hasPartialAvailability, isTrue);
+        expect(progress.isTerminal, isFalse);
+        expect(progress.toString(), isNot(contains('http')));
+        expect(progress.toString(), isNot(contains('/Users/')));
+      },
+    );
+  });
+
+  group('AiroPlaylistBatchWriter adapters', () {
+    test('fake writer accepts all records by default', () async {
+      const writer = AiroFakePlaylistBatchWriter();
+
+      final result = await writer.writeBatch(
+        const AiroPlaylistBatchWriteRequest(
+          jobId: 'large-import-10k',
+          batchIndex: 1,
+          recordCount: 1000,
+        ),
+      );
+
+      expect(result.acceptedCount, 1000);
+      expect(result.rejectedCount, 0);
+      expect(result.isSuccessful, isTrue);
+    });
+
+    test(
+      'no-op writer rejects records without persistence side effects',
+      () async {
+        const writer = AiroNoOpPlaylistBatchWriter();
+
+        final result = await writer.writeBatch(
+          const AiroPlaylistBatchWriteRequest(
+            jobId: 'large-import-10k',
+            batchIndex: 1,
+            recordCount: 1000,
+          ),
+        );
+
+        expect(result.acceptedCount, 0);
+        expect(result.rejectedCount, 1000);
+        expect(result.isSuccessful, isFalse);
+      },
+    );
+  });
+
+  group('AiroLargePlaylistWorker adapters', () {
+    test('fake worker emits deterministic progress events', () async {
+      final plan = AiroLargePlaylistImportPlan(
+        jobId: 'large-import-10k',
+        sourceRef: AiroLargePlaylistSourceRef.redacted('user-playlist-primary'),
+        expectedItemCount: 10000,
+        batchSize: 1000,
+        maxConcurrency: 1,
+        stages: AiroLargePlaylistWorkerPolicy.requiredStages,
+      );
+      final worker = AiroFakeLargePlaylistWorker(
+        progress: [
+          AiroLargePlaylistProgress(
+            jobId: 'large-import-10k',
+            stage: AiroLargePlaylistWorkerStage.parse,
+            status: AiroLargePlaylistWorkerStatus.running,
+            expectedItemCount: 10000,
+            parsedCount: 1000,
+            normalizedCount: 0,
+            dedupedCount: 0,
+            writtenCount: 0,
+            failedCount: 0,
+            batchIndex: 0,
+          ),
+          AiroLargePlaylistProgress(
+            jobId: 'large-import-10k',
+            stage: AiroLargePlaylistWorkerStage.finalize,
+            status: AiroLargePlaylistWorkerStatus.completed,
+            expectedItemCount: 10000,
+            parsedCount: 10000,
+            normalizedCount: 9800,
+            dedupedCount: 9700,
+            writtenCount: 9700,
+            failedCount: 0,
+            batchIndex: 10,
+          ),
+        ],
+      );
+
+      final events = await worker.run(plan).toList();
+
+      expect(events, hasLength(2));
+      expect(events.last.isTerminal, isTrue);
+      expect(events.last.writtenCount, 9700);
+    });
+
+    test(
+      'fake worker emits cancelled event when cancellation is requested',
+      () async {
+        final plan = AiroLargePlaylistImportPlan(
+          jobId: 'large-import-10k',
+          sourceRef: AiroLargePlaylistSourceRef.redacted(
+            'user-playlist-primary',
+          ),
+          expectedItemCount: 10000,
+          batchSize: 1000,
+          maxConcurrency: 1,
+          stages: AiroLargePlaylistWorkerPolicy.requiredStages,
+        );
+        final worker = AiroFakeLargePlaylistWorker(
+          progress: [
+            AiroLargePlaylistProgress(
+              jobId: 'large-import-10k',
+              stage: AiroLargePlaylistWorkerStage.batchWrite,
+              status: AiroLargePlaylistWorkerStatus.running,
+              expectedItemCount: 10000,
+              parsedCount: 5000,
+              normalizedCount: 5000,
+              dedupedCount: 4900,
+              writtenCount: 4000,
+              failedCount: 0,
+              batchIndex: 4,
+            ),
+          ],
+        );
+
+        await worker.cancel('large-import-10k');
+        final events = await worker.run(plan).toList();
+
+        expect(events.single.status, AiroLargePlaylistWorkerStatus.cancelled);
+        expect(
+          events.single.diagnostics.single.code,
+          AiroLargePlaylistWorkerDiagnosticCode.cancellationRequested,
+        );
+      },
+    );
+  });
+}


### PR DESCRIPTION
## Summary
- Adds the ATV-029 large playlist worker pipeline contract in platform_playlist_import.
- Defines import plans, redacted source refs, worker stages/statuses, progress events, cancellation, diagnostics, and batch writer boundaries.
- Adds fake/no-op worker and batch-writer adapters for deterministic automation.

## Agent Policy
- Owning agents: Data Agent / Media Agent.
- Reviewing agents: Framework, Security and Privacy, QA Automation, Release and DevEx.
- Layer: platform/shared-contract.
- Base verified from latest origin/v2 after git fetch origin main v2.
- No isolate scheduler, concrete database writer, download/resume logic, app UI, provider shortcuts, generated fixtures, analytics upload, or storage SDK import added.

## Validation
- dart format --set-exit-if-changed packages/platform_playlist_import
- cd packages/platform_playlist_import && flutter pub get
- cd packages/platform_playlist_import && flutter test
- cd packages/platform_playlist_import && flutter analyze --fatal-infos
- git diff --check HEAD~1..HEAD && git diff --check
- Diff secret scan reviewed: only privacy rejection enum/code literal for credential-like values, no secret material.

Closes #619