### PR TITLE
feat(platform): add shared media error taxonomy

### DIFF
--- a/docs/features/airo-tv/MEDIA_ERROR_TAXONOMY.md
+++ b/docs/features/airo-tv/MEDIA_ERROR_TAXONOMY.md
@@ -1,0 +1,56 @@
+# Shared Airo Media Error Taxonomy
+
+Status: v2 platform contract for ATV-030.
+
+## Ownership
+
+Shared media error classification is platform behavior. Airo TV can map stable
+message keys to localized copy later, but category, severity, retryability,
+safe context references, diagnostic handles, and redaction rules belong in
+`packages/platform_media`.
+
+Backend-specific packages can keep local error codes, but they should map those
+codes into the shared taxonomy before analytics, diagnostics, retries, support
+bundles, or app UI consume them.
+
+## Non-Goals
+
+This issue does not implement:
+
+- localized user-facing strings
+- analytics event upload
+- crash reporting adapters
+- support bundle export
+- backend/native exception mapping
+- app error screens
+
+## Contract Shape
+
+`AiroMediaErrorDescriptor` describes:
+
+- error code
+- category
+- severity
+- retryability
+- stable user message key
+- safe context refs
+- diagnostic codes
+- optional redacted diagnostic handle
+
+`AiroDefaultMediaErrorClassifier` maps shared codes for source, auth, network,
+decoder, capability, route, playback, import, EPG, storage, protocol, analytics,
+and unknown failures.
+
+`AiroMediaErrorClassifier` is the adapter boundary for future platform modules.
+The package includes:
+
+- `AiroNoOpMediaErrorClassifier`
+- `AiroFakeMediaErrorClassifier`
+
+## Privacy
+
+Error descriptors must expose stable ids, message keys, category, severity,
+retryability, context kinds, diagnostic codes, and redacted handles only. They
+must not expose raw media URLs, playlist URLs, EPG URLs, request headers,
+provider domains, local paths, local addresses, credentials, titles, search
+text, viewing history, analytics payloads, or diagnostic dumps.

--- a/packages/platform_media/README.md
+++ b/packages/platform_media/README.md
@@ -16,10 +16,14 @@ future native media adapters consume these contracts through stable interfaces.
   kind.
 - Fake and no-op media capability detectors for automation and integration
   boundaries.
+- Shared media error taxonomy for category, severity, retryability, stable user
+  message keys, safe context refs, and redacted diagnostic handles.
 
 This package does not perform native decoder probing yet, inspect raw media
-files, own route selection, or decide Airo TV product UX. Native adapters should
-plug in behind `AiroMediaCapabilityDetector`.
+files, own route selection, localize user-facing copy, upload analytics, export
+support bundles, or decide Airo TV product UX. Native adapters should plug in
+behind `AiroMediaCapabilityDetector`, and backend-specific failures should map
+into `AiroMediaErrorClassifier`.
 
 ## Usage
 

--- a/packages/platform_media/lib/platform_media.dart
+++ b/packages/platform_media/lib/platform_media.dart
@@ -1,5 +1,6 @@
 library;
 
 export "src/media_capability_models.dart";
+export "src/media_error_taxonomy_models.dart";
 export "src/platform_media_logger.dart";
 export "src/video_player_streaming_service.dart";

--- a/packages/platform_media/lib/src/media_error_taxonomy_models.dart
+++ b/packages/platform_media/lib/src/media_error_taxonomy_models.dart
@@ -1,0 +1,527 @@
+import 'package:equatable/equatable.dart';
+
+const String kAiroMediaErrorTaxonomySchemaVersion = '1.0.0';
+
+enum AiroMediaErrorCategory {
+  source('source'),
+  authentication('authentication'),
+  authorization('authorization'),
+  network('network'),
+  decoder('decoder'),
+  capability('capability'),
+  route('route'),
+  playback('playback'),
+  import('import'),
+  epg('epg'),
+  storage('storage'),
+  protocol('protocol'),
+  analytics('analytics'),
+  unknown('unknown');
+
+  const AiroMediaErrorCategory(this.stableId);
+
+  final String stableId;
+}
+
+enum AiroMediaErrorSeverity {
+  info('info'),
+  warning('warning'),
+  recoverable('recoverable'),
+  critical('critical'),
+  fatal('fatal');
+
+  const AiroMediaErrorSeverity(this.stableId);
+
+  final String stableId;
+}
+
+enum AiroMediaErrorRetryability {
+  never('never'),
+  immediate('immediate'),
+  afterBackoff('after_backoff'),
+  afterUserAction('after_user_action'),
+  afterSourceRefresh('after_source_refresh');
+
+  const AiroMediaErrorRetryability(this.stableId);
+
+  final String stableId;
+
+  bool get canRetryAutomatically =>
+      this == AiroMediaErrorRetryability.immediate ||
+      this == AiroMediaErrorRetryability.afterBackoff;
+
+  bool get requiresUserAction =>
+      this == AiroMediaErrorRetryability.afterUserAction ||
+      this == AiroMediaErrorRetryability.afterSourceRefresh;
+}
+
+enum AiroMediaErrorCode {
+  sourceInvalid('source_invalid'),
+  sourceUnavailable('source_unavailable'),
+  sourceExpired('source_expired'),
+  authenticationRequired('authentication_required'),
+  authorizationDenied('authorization_denied'),
+  networkUnavailable('network_unavailable'),
+  networkTimeout('network_timeout'),
+  decoderUnsupported('decoder_unsupported'),
+  decoderFailed('decoder_failed'),
+  capabilityUnsupported('capability_unsupported'),
+  routeUnavailable('route_unavailable'),
+  playbackStartupFailed('playback_startup_failed'),
+  playbackInterrupted('playback_interrupted'),
+  importFailed('import_failed'),
+  epgUnavailable('epg_unavailable'),
+  storageFull('storage_full'),
+  protocolMismatch('protocol_mismatch'),
+  analyticsRejected('analytics_rejected'),
+  unknown('unknown');
+
+  const AiroMediaErrorCode(this.stableId);
+
+  final String stableId;
+}
+
+enum AiroMediaErrorContextKind {
+  session('session'),
+  source('source'),
+  route('route'),
+  backend('backend'),
+  device('device'),
+  profile('profile'),
+  worker('worker'),
+  operation('operation');
+
+  const AiroMediaErrorContextKind(this.stableId);
+
+  final String stableId;
+}
+
+enum AiroMediaErrorSafeValueRejectionCode {
+  empty('empty'),
+  urlValue('url_value'),
+  localPathValue('local_path_value'),
+  localIpValue('local_ip_value'),
+  credentialLikeValue('credential_like_value'),
+  messageKeyFormat('message_key_format'),
+  diagnosticCodeFormat('diagnostic_code_format');
+
+  const AiroMediaErrorSafeValueRejectionCode(this.stableId);
+
+  final String stableId;
+}
+
+class AiroMediaErrorSafeValue extends Equatable {
+  const AiroMediaErrorSafeValue._(this.value);
+
+  factory AiroMediaErrorSafeValue.redacted(String value) {
+    final rejection = validate(value);
+    if (rejection != null) {
+      throw ArgumentError.value(value, 'value', rejection.stableId);
+    }
+    return AiroMediaErrorSafeValue._(value.trim());
+  }
+
+  final String value;
+
+  static AiroMediaErrorSafeValueRejectionCode? validate(String value) {
+    final trimmed = value.trim();
+    if (trimmed.isEmpty) {
+      return AiroMediaErrorSafeValueRejectionCode.empty;
+    }
+    final uri = Uri.tryParse(trimmed);
+    if (uri != null && (uri.scheme == 'http' || uri.scheme == 'https')) {
+      return AiroMediaErrorSafeValueRejectionCode.urlValue;
+    }
+    if (trimmed.startsWith('file://') ||
+        trimmed.startsWith('/') ||
+        RegExp(r'^[A-Za-z]:\\').hasMatch(trimmed)) {
+      return AiroMediaErrorSafeValueRejectionCode.localPathValue;
+    }
+    if (RegExp(
+      r'\b(?:10|127|172\.(?:1[6-9]|2\d|3[0-1])|192\.168)\.',
+    ).hasMatch(trimmed)) {
+      return AiroMediaErrorSafeValueRejectionCode.localIpValue;
+    }
+    if (RegExp(
+      r'\b(?:bearer|basic)\s+[A-Za-z0-9._~+/=-]+',
+      caseSensitive: false,
+    ).hasMatch(trimmed)) {
+      return AiroMediaErrorSafeValueRejectionCode.credentialLikeValue;
+    }
+    return null;
+  }
+
+  @override
+  String toString() => 'AiroMediaErrorSafeValue(redacted)';
+
+  @override
+  List<Object?> get props => [value];
+}
+
+class AiroMediaUserMessageKey extends Equatable {
+  const AiroMediaUserMessageKey._(this.value);
+
+  factory AiroMediaUserMessageKey.stable(String value) {
+    final trimmed = value.trim();
+    final safeValueRejection = AiroMediaErrorSafeValue.validate(trimmed);
+    if (safeValueRejection != null) {
+      throw ArgumentError.value(value, 'value', safeValueRejection.stableId);
+    }
+    if (!RegExp(r'^media\.[a-z0-9_]+(\.[a-z0-9_]+)+$').hasMatch(trimmed)) {
+      throw ArgumentError.value(
+        value,
+        'value',
+        AiroMediaErrorSafeValueRejectionCode.messageKeyFormat.stableId,
+      );
+    }
+    return AiroMediaUserMessageKey._(trimmed);
+  }
+
+  final String value;
+
+  @override
+  String toString() => value;
+
+  @override
+  List<Object?> get props => [value];
+}
+
+class AiroMediaErrorContext extends Equatable {
+  const AiroMediaErrorContext({
+    required this.kind,
+    required this.ref,
+    this.schemaVersion = kAiroMediaErrorTaxonomySchemaVersion,
+  });
+
+  final String schemaVersion;
+  final AiroMediaErrorContextKind kind;
+  final AiroMediaErrorSafeValue ref;
+
+  @override
+  String toString() {
+    return 'AiroMediaErrorContext('
+        'kind: ${kind.stableId}, '
+        'ref: redacted'
+        ')';
+  }
+
+  @override
+  List<Object?> get props => [schemaVersion, kind, ref];
+}
+
+class AiroMediaDiagnosticHandle extends Equatable {
+  const AiroMediaDiagnosticHandle._(this.value);
+
+  factory AiroMediaDiagnosticHandle.redacted(String value) {
+    final rejection = AiroMediaErrorSafeValue.validate(value);
+    if (rejection != null) {
+      throw ArgumentError.value(value, 'value', rejection.stableId);
+    }
+    return AiroMediaDiagnosticHandle._(value.trim());
+  }
+
+  final String value;
+
+  @override
+  String toString() => 'AiroMediaDiagnosticHandle(redacted)';
+
+  @override
+  List<Object?> get props => [value];
+}
+
+class AiroMediaDiagnosticCode extends Equatable {
+  const AiroMediaDiagnosticCode._(this.value);
+
+  factory AiroMediaDiagnosticCode.stable(String value) {
+    final trimmed = value.trim();
+    final safeValueRejection = AiroMediaErrorSafeValue.validate(trimmed);
+    if (safeValueRejection != null) {
+      throw ArgumentError.value(value, 'value', safeValueRejection.stableId);
+    }
+    if (!RegExp(r'^[a-z0-9_]+(\.[a-z0-9_]+)*$').hasMatch(trimmed)) {
+      throw ArgumentError.value(
+        value,
+        'value',
+        AiroMediaErrorSafeValueRejectionCode.diagnosticCodeFormat.stableId,
+      );
+    }
+    return AiroMediaDiagnosticCode._(trimmed);
+  }
+
+  final String value;
+
+  @override
+  String toString() => value;
+
+  @override
+  List<Object?> get props => [value];
+}
+
+class AiroMediaErrorDescriptor extends Equatable {
+  AiroMediaErrorDescriptor({
+    required this.code,
+    required this.category,
+    required this.severity,
+    required this.retryability,
+    required this.userMessageKey,
+    Iterable<AiroMediaErrorContext> contexts = const [],
+    Iterable<AiroMediaDiagnosticCode> diagnosticCodes = const [],
+    this.diagnosticHandle,
+    this.schemaVersion = kAiroMediaErrorTaxonomySchemaVersion,
+  }) : contexts = List.unmodifiable(contexts),
+       diagnosticCodes = List.unmodifiable(diagnosticCodes);
+
+  final String schemaVersion;
+  final AiroMediaErrorCode code;
+  final AiroMediaErrorCategory category;
+  final AiroMediaErrorSeverity severity;
+  final AiroMediaErrorRetryability retryability;
+  final AiroMediaUserMessageKey userMessageKey;
+  final List<AiroMediaErrorContext> contexts;
+  final List<AiroMediaDiagnosticCode> diagnosticCodes;
+  final AiroMediaDiagnosticHandle? diagnosticHandle;
+
+  bool get retryable => retryability != AiroMediaErrorRetryability.never;
+
+  bool get canRetryAutomatically => retryability.canRetryAutomatically;
+
+  bool get requiresUserAction => retryability.requiresUserAction;
+
+  @override
+  String toString() {
+    return 'AiroMediaErrorDescriptor('
+        'code: ${code.stableId}, '
+        'category: ${category.stableId}, '
+        'severity: ${severity.stableId}, '
+        'retryability: ${retryability.stableId}, '
+        'userMessageKey: ${userMessageKey.value}, '
+        'contextCount: ${contexts.length}, '
+        'diagnosticCodes: ${diagnosticCodes.map((code) => code.value).toList()}, '
+        'diagnosticHandle: ${diagnosticHandle == null ? 'none' : 'redacted'}'
+        ')';
+  }
+
+  @override
+  List<Object?> get props => [
+    schemaVersion,
+    code,
+    category,
+    severity,
+    retryability,
+    userMessageKey,
+    contexts,
+    diagnosticCodes,
+    diagnosticHandle,
+  ];
+}
+
+class AiroMediaErrorInput extends Equatable {
+  AiroMediaErrorInput({
+    required this.code,
+    Iterable<AiroMediaErrorContext> contexts = const [],
+    Iterable<AiroMediaDiagnosticCode> diagnosticCodes = const [],
+    this.diagnosticHandle,
+  }) : contexts = List.unmodifiable(contexts),
+       diagnosticCodes = List.unmodifiable(diagnosticCodes);
+
+  final AiroMediaErrorCode code;
+  final List<AiroMediaErrorContext> contexts;
+  final List<AiroMediaDiagnosticCode> diagnosticCodes;
+  final AiroMediaDiagnosticHandle? diagnosticHandle;
+
+  @override
+  List<Object?> get props => [
+    code,
+    contexts,
+    diagnosticCodes,
+    diagnosticHandle,
+  ];
+}
+
+abstract interface class AiroMediaErrorClassifier {
+  AiroMediaErrorDescriptor classify(AiroMediaErrorInput input);
+}
+
+class AiroDefaultMediaErrorClassifier implements AiroMediaErrorClassifier {
+  const AiroDefaultMediaErrorClassifier();
+
+  @override
+  AiroMediaErrorDescriptor classify(AiroMediaErrorInput input) {
+    final preset = _presets[input.code] ?? _unknownPreset;
+    return AiroMediaErrorDescriptor(
+      code: input.code,
+      category: preset.category,
+      severity: preset.severity,
+      retryability: preset.retryability,
+      userMessageKey: AiroMediaUserMessageKey.stable(preset.userMessageKey),
+      contexts: input.contexts,
+      diagnosticCodes: input.diagnosticCodes,
+      diagnosticHandle: input.diagnosticHandle,
+    );
+  }
+}
+
+class AiroNoOpMediaErrorClassifier implements AiroMediaErrorClassifier {
+  const AiroNoOpMediaErrorClassifier();
+
+  @override
+  AiroMediaErrorDescriptor classify(AiroMediaErrorInput input) {
+    return AiroMediaErrorDescriptor(
+      code: AiroMediaErrorCode.unknown,
+      category: AiroMediaErrorCategory.unknown,
+      severity: AiroMediaErrorSeverity.warning,
+      retryability: AiroMediaErrorRetryability.never,
+      userMessageKey: AiroMediaUserMessageKey.stable('media.error.unknown'),
+      contexts: input.contexts,
+      diagnosticCodes: [AiroMediaDiagnosticCode.stable('noop_classifier')],
+    );
+  }
+}
+
+class AiroFakeMediaErrorClassifier implements AiroMediaErrorClassifier {
+  AiroFakeMediaErrorClassifier({
+    required Map<AiroMediaErrorCode, AiroMediaErrorDescriptor> descriptors,
+    this.fallback = const AiroNoOpMediaErrorClassifier(),
+  }) : _descriptors = Map.unmodifiable(descriptors);
+
+  final Map<AiroMediaErrorCode, AiroMediaErrorDescriptor> _descriptors;
+  final AiroMediaErrorClassifier fallback;
+
+  @override
+  AiroMediaErrorDescriptor classify(AiroMediaErrorInput input) {
+    return _descriptors[input.code] ?? fallback.classify(input);
+  }
+}
+
+class _MediaErrorPreset {
+  const _MediaErrorPreset({
+    required this.category,
+    required this.severity,
+    required this.retryability,
+    required this.userMessageKey,
+  });
+
+  final AiroMediaErrorCategory category;
+  final AiroMediaErrorSeverity severity;
+  final AiroMediaErrorRetryability retryability;
+  final String userMessageKey;
+}
+
+const _unknownPreset = _MediaErrorPreset(
+  category: AiroMediaErrorCategory.unknown,
+  severity: AiroMediaErrorSeverity.warning,
+  retryability: AiroMediaErrorRetryability.never,
+  userMessageKey: 'media.error.unknown',
+);
+
+const Map<AiroMediaErrorCode, _MediaErrorPreset> _presets = {
+  AiroMediaErrorCode.sourceInvalid: _MediaErrorPreset(
+    category: AiroMediaErrorCategory.source,
+    severity: AiroMediaErrorSeverity.recoverable,
+    retryability: AiroMediaErrorRetryability.afterUserAction,
+    userMessageKey: 'media.source.invalid',
+  ),
+  AiroMediaErrorCode.sourceUnavailable: _MediaErrorPreset(
+    category: AiroMediaErrorCategory.source,
+    severity: AiroMediaErrorSeverity.warning,
+    retryability: AiroMediaErrorRetryability.afterBackoff,
+    userMessageKey: 'media.source.unavailable',
+  ),
+  AiroMediaErrorCode.sourceExpired: _MediaErrorPreset(
+    category: AiroMediaErrorCategory.source,
+    severity: AiroMediaErrorSeverity.recoverable,
+    retryability: AiroMediaErrorRetryability.afterSourceRefresh,
+    userMessageKey: 'media.source.expired',
+  ),
+  AiroMediaErrorCode.authenticationRequired: _MediaErrorPreset(
+    category: AiroMediaErrorCategory.authentication,
+    severity: AiroMediaErrorSeverity.recoverable,
+    retryability: AiroMediaErrorRetryability.afterUserAction,
+    userMessageKey: 'media.auth.required',
+  ),
+  AiroMediaErrorCode.authorizationDenied: _MediaErrorPreset(
+    category: AiroMediaErrorCategory.authorization,
+    severity: AiroMediaErrorSeverity.critical,
+    retryability: AiroMediaErrorRetryability.afterUserAction,
+    userMessageKey: 'media.auth.denied',
+  ),
+  AiroMediaErrorCode.networkUnavailable: _MediaErrorPreset(
+    category: AiroMediaErrorCategory.network,
+    severity: AiroMediaErrorSeverity.warning,
+    retryability: AiroMediaErrorRetryability.afterBackoff,
+    userMessageKey: 'media.network.unavailable',
+  ),
+  AiroMediaErrorCode.networkTimeout: _MediaErrorPreset(
+    category: AiroMediaErrorCategory.network,
+    severity: AiroMediaErrorSeverity.warning,
+    retryability: AiroMediaErrorRetryability.afterBackoff,
+    userMessageKey: 'media.network.timeout',
+  ),
+  AiroMediaErrorCode.decoderUnsupported: _MediaErrorPreset(
+    category: AiroMediaErrorCategory.decoder,
+    severity: AiroMediaErrorSeverity.recoverable,
+    retryability: AiroMediaErrorRetryability.afterUserAction,
+    userMessageKey: 'media.decoder.unsupported',
+  ),
+  AiroMediaErrorCode.decoderFailed: _MediaErrorPreset(
+    category: AiroMediaErrorCategory.decoder,
+    severity: AiroMediaErrorSeverity.critical,
+    retryability: AiroMediaErrorRetryability.immediate,
+    userMessageKey: 'media.decoder.failed',
+  ),
+  AiroMediaErrorCode.capabilityUnsupported: _MediaErrorPreset(
+    category: AiroMediaErrorCategory.capability,
+    severity: AiroMediaErrorSeverity.recoverable,
+    retryability: AiroMediaErrorRetryability.afterUserAction,
+    userMessageKey: 'media.capability.unsupported',
+  ),
+  AiroMediaErrorCode.routeUnavailable: _MediaErrorPreset(
+    category: AiroMediaErrorCategory.route,
+    severity: AiroMediaErrorSeverity.warning,
+    retryability: AiroMediaErrorRetryability.afterBackoff,
+    userMessageKey: 'media.route.unavailable',
+  ),
+  AiroMediaErrorCode.playbackStartupFailed: _MediaErrorPreset(
+    category: AiroMediaErrorCategory.playback,
+    severity: AiroMediaErrorSeverity.critical,
+    retryability: AiroMediaErrorRetryability.immediate,
+    userMessageKey: 'media.playback.startup_failed',
+  ),
+  AiroMediaErrorCode.playbackInterrupted: _MediaErrorPreset(
+    category: AiroMediaErrorCategory.playback,
+    severity: AiroMediaErrorSeverity.warning,
+    retryability: AiroMediaErrorRetryability.afterBackoff,
+    userMessageKey: 'media.playback.interrupted',
+  ),
+  AiroMediaErrorCode.importFailed: _MediaErrorPreset(
+    category: AiroMediaErrorCategory.import,
+    severity: AiroMediaErrorSeverity.recoverable,
+    retryability: AiroMediaErrorRetryability.afterUserAction,
+    userMessageKey: 'media.import.failed',
+  ),
+  AiroMediaErrorCode.epgUnavailable: _MediaErrorPreset(
+    category: AiroMediaErrorCategory.epg,
+    severity: AiroMediaErrorSeverity.info,
+    retryability: AiroMediaErrorRetryability.afterBackoff,
+    userMessageKey: 'media.epg.unavailable',
+  ),
+  AiroMediaErrorCode.storageFull: _MediaErrorPreset(
+    category: AiroMediaErrorCategory.storage,
+    severity: AiroMediaErrorSeverity.critical,
+    retryability: AiroMediaErrorRetryability.afterUserAction,
+    userMessageKey: 'media.storage.full',
+  ),
+  AiroMediaErrorCode.protocolMismatch: _MediaErrorPreset(
+    category: AiroMediaErrorCategory.protocol,
+    severity: AiroMediaErrorSeverity.critical,
+    retryability: AiroMediaErrorRetryability.afterUserAction,
+    userMessageKey: 'media.protocol.mismatch',
+  ),
+  AiroMediaErrorCode.analyticsRejected: _MediaErrorPreset(
+    category: AiroMediaErrorCategory.analytics,
+    severity: AiroMediaErrorSeverity.info,
+    retryability: AiroMediaErrorRetryability.never,
+    userMessageKey: 'media.analytics.rejected',
+  ),
+  AiroMediaErrorCode.unknown: _unknownPreset,
+};

--- a/packages/platform_media/pubspec.yaml
+++ b/packages/platform_media/pubspec.yaml
@@ -11,6 +11,7 @@ environment:
 dependencies:
   core_analytics:
     path: ../core_analytics
+  equatable: ^2.0.8
   flutter:
     sdk: flutter
   platform_channels:

--- a/packages/platform_media/test/media_error_taxonomy_models_test.dart
+++ b/packages/platform_media/test/media_error_taxonomy_models_test.dart
@@ -1,0 +1,187 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:platform_media/platform_media.dart';
+
+void main() {
+  group('AiroDefaultMediaErrorClassifier', () {
+    const classifier = AiroDefaultMediaErrorClassifier();
+
+    test('classifies network failures as retryable warning errors', () {
+      final descriptor = classifier.classify(
+        AiroMediaErrorInput(
+          code: AiroMediaErrorCode.networkTimeout,
+          contexts: [
+            AiroMediaErrorContext(
+              kind: AiroMediaErrorContextKind.session,
+              ref: AiroMediaErrorSafeValue.redacted('session-1'),
+            ),
+          ],
+          diagnosticCodes: [AiroMediaDiagnosticCode.stable('dns_timeout')],
+          diagnosticHandle: AiroMediaDiagnosticHandle.redacted(
+            'local-diagnostic-1',
+          ),
+        ),
+      );
+
+      expect(descriptor.category, AiroMediaErrorCategory.network);
+      expect(descriptor.severity, AiroMediaErrorSeverity.warning);
+      expect(descriptor.retryability, AiroMediaErrorRetryability.afterBackoff);
+      expect(descriptor.retryable, isTrue);
+      expect(descriptor.canRetryAutomatically, isTrue);
+      expect(descriptor.requiresUserAction, isFalse);
+      expect(descriptor.userMessageKey.value, 'media.network.timeout');
+    });
+
+    test(
+      'classifies auth and source refresh errors as user-action retries',
+      () {
+        final auth = classifier.classify(
+          AiroMediaErrorInput(code: AiroMediaErrorCode.authenticationRequired),
+        );
+        final expired = classifier.classify(
+          AiroMediaErrorInput(code: AiroMediaErrorCode.sourceExpired),
+        );
+
+        expect(auth.category, AiroMediaErrorCategory.authentication);
+        expect(auth.requiresUserAction, isTrue);
+        expect(auth.userMessageKey.value, 'media.auth.required');
+        expect(
+          expired.retryability,
+          AiroMediaErrorRetryability.afterSourceRefresh,
+        );
+        expect(expired.requiresUserAction, isTrue);
+        expect(expired.userMessageKey.value, 'media.source.expired');
+      },
+    );
+
+    test('classifies decoder and playback failures for fallback decisions', () {
+      final decoder = classifier.classify(
+        AiroMediaErrorInput(code: AiroMediaErrorCode.decoderFailed),
+      );
+      final startup = classifier.classify(
+        AiroMediaErrorInput(code: AiroMediaErrorCode.playbackStartupFailed),
+      );
+
+      expect(decoder.category, AiroMediaErrorCategory.decoder);
+      expect(decoder.severity, AiroMediaErrorSeverity.critical);
+      expect(decoder.retryability, AiroMediaErrorRetryability.immediate);
+      expect(startup.category, AiroMediaErrorCategory.playback);
+      expect(startup.canRetryAutomatically, isTrue);
+    });
+
+    test('keeps analytics rejection local and non-retryable', () {
+      final descriptor = classifier.classify(
+        AiroMediaErrorInput(code: AiroMediaErrorCode.analyticsRejected),
+      );
+
+      expect(descriptor.category, AiroMediaErrorCategory.analytics);
+      expect(descriptor.severity, AiroMediaErrorSeverity.info);
+      expect(descriptor.retryability, AiroMediaErrorRetryability.never);
+      expect(descriptor.retryable, isFalse);
+      expect(descriptor.userMessageKey.value, 'media.analytics.rejected');
+    });
+  });
+
+  group('Airo media error redaction', () {
+    test('safe context and diagnostic handles reject raw sensitive values', () {
+      expect(
+        () => AiroMediaErrorSafeValue.redacted(
+          'https://provider.example/live.m3u8',
+        ),
+        throwsArgumentError,
+      );
+      expect(
+        () => AiroMediaErrorSafeValue.redacted('/Users/me/movie.mp4'),
+        throwsArgumentError,
+      );
+      expect(
+        () => AiroMediaErrorSafeValue.redacted('192.168.1.20/media.m3u8'),
+        throwsArgumentError,
+      );
+      expect(
+        () => AiroMediaDiagnosticHandle.redacted('Bearer abc123'),
+        throwsArgumentError,
+      );
+      expect(
+        () => AiroMediaDiagnosticCode.stable('https://example.com/detail'),
+        throwsArgumentError,
+      );
+      expect(
+        () => AiroMediaDiagnosticCode.stable('Decoder failed'),
+        throwsArgumentError,
+      );
+    });
+
+    test('user message keys are stable and not raw user copy', () {
+      expect(
+        AiroMediaUserMessageKey.stable('media.network.timeout').value,
+        'media.network.timeout',
+      );
+      expect(
+        () => AiroMediaUserMessageKey.stable('Network timed out'),
+        throwsArgumentError,
+      );
+      expect(
+        () => AiroMediaUserMessageKey.stable('https://example.com/error'),
+        throwsArgumentError,
+      );
+    });
+
+    test('string output redacts context and diagnostic handle values', () {
+      final descriptor = const AiroDefaultMediaErrorClassifier().classify(
+        AiroMediaErrorInput(
+          code: AiroMediaErrorCode.routeUnavailable,
+          contexts: [
+            AiroMediaErrorContext(
+              kind: AiroMediaErrorContextKind.route,
+              ref: AiroMediaErrorSafeValue.redacted('route-primary'),
+            ),
+          ],
+          diagnosticHandle: AiroMediaDiagnosticHandle.redacted('diag-1'),
+        ),
+      );
+
+      final rendered = descriptor.toString();
+
+      expect(rendered, contains('route_unavailable'));
+      expect(rendered, contains('diagnosticHandle: redacted'));
+      expect(rendered, isNot(contains('route-primary')));
+      expect(rendered, isNot(contains('diag-1')));
+      expect(rendered, isNot(contains('http')));
+      expect(rendered, isNot(contains('/Users/')));
+    });
+  });
+
+  group('AiroMediaErrorClassifier adapters', () {
+    test('no-op classifier returns safe unknown descriptor', () {
+      const classifier = AiroNoOpMediaErrorClassifier();
+
+      final descriptor = classifier.classify(
+        AiroMediaErrorInput(code: AiroMediaErrorCode.decoderFailed),
+      );
+
+      expect(descriptor.code, AiroMediaErrorCode.unknown);
+      expect(descriptor.category, AiroMediaErrorCategory.unknown);
+      expect(descriptor.userMessageKey.value, 'media.error.unknown');
+      expect(descriptor.diagnosticCodes.single.value, 'noop_classifier');
+    });
+
+    test('fake classifier returns deterministic descriptors', () {
+      final expected = AiroMediaErrorDescriptor(
+        code: AiroMediaErrorCode.storageFull,
+        category: AiroMediaErrorCategory.storage,
+        severity: AiroMediaErrorSeverity.critical,
+        retryability: AiroMediaErrorRetryability.afterUserAction,
+        userMessageKey: AiroMediaUserMessageKey.stable('media.storage.full'),
+      );
+      final classifier = AiroFakeMediaErrorClassifier(
+        descriptors: {AiroMediaErrorCode.storageFull: expected},
+      );
+
+      final descriptor = classifier.classify(
+        AiroMediaErrorInput(code: AiroMediaErrorCode.storageFull),
+      );
+
+      expect(descriptor, expected);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Adds the ATV-030 shared media error taxonomy in platform_media.
- Defines media error codes, categories, severity, retryability, stable user message keys, safe context refs, diagnostic codes, and redacted diagnostic handles.
- Adds default, fake, and no-op classifiers for deterministic adapter mapping.

## Agent Policy
- Owning agents: Framework Agent / Security Agent / Media Agent.
- Reviewing agents: Framework, Security and Privacy, QA Automation, Release and DevEx.
- Layer: platform/shared-contract.
- Base verified from latest origin/v2 after git fetch origin main v2.
- No localized strings, analytics upload, crash adapter, support bundle export, backend exception mapping, or app error screen added.

## Validation
- dart format --set-exit-if-changed packages/platform_media
- cd packages/platform_media && flutter pub get
- cd packages/platform_media && flutter test
- cd packages/platform_media && flutter analyze --fatal-infos
- git diff --check HEAD~1..HEAD && git diff --check
- Diff secret scan reviewed: only privacy copy and credential-like rejection code literals, no secret material.

Closes #620