### PR TITLE
feat(platform): add performance instrumentation schema

### DIFF
--- a/docs/features/airo-tv/PERFORMANCE_INSTRUMENTATION_SCHEMA.md
+++ b/docs/features/airo-tv/PERFORMANCE_INSTRUMENTATION_SCHEMA.md
@@ -1,0 +1,65 @@
+# Performance Instrumentation Schema
+
+Status: v2 platform contract for ATV-031.
+
+## Ownership
+
+Performance instrumentation is a shared platform contract. Airo TV, media
+playback, playlist import, search, protocol, and UI code can emit samples
+later, but metric names, units, buckets, safe dimensions, budget evaluation, and
+sink boundaries belong in `packages/core_analytics`.
+
+## Non-Goals
+
+This issue does not implement:
+
+- vendor analytics upload
+- dashboards
+- device profilers
+- UI frame observers
+- playback backend hooks
+- app performance screens
+- certified-device release thresholds
+
+## Contract Shape
+
+`AiroPerformanceSample` describes:
+
+- sample id
+- area
+- metric
+- unit
+- numeric value
+- bucket
+- observation timestamp
+- safe dimensions
+
+`AiroPerformanceBudget` and `AiroPerformanceBudgetPolicy` provide deterministic
+pass/fail checks for maximum and minimum thresholds.
+
+`AiroPerformanceInstrumentationSink` is the adapter boundary. The package
+includes:
+
+- `AiroNoOpPerformanceInstrumentationSink`
+- `AiroFakePerformanceInstrumentationSink`
+
+## Covered Areas
+
+- UI
+- playback
+- import
+- search
+- protocol
+- command acknowledgement
+- memory
+- storage
+- network
+- pairing
+
+## Privacy
+
+Performance samples may expose stable ids, areas, metrics, units, buckets,
+numeric values, and safe dimension ids only. They must not expose raw media
+URLs, playlist URLs, EPG URLs, request headers, provider names or domains, local
+paths, local addresses, credentials, titles, search text, viewing history,
+device identifiers, analytics payloads, or diagnostic dumps.

--- a/packages/core_analytics/README.md
+++ b/packages/core_analytics/README.md
@@ -14,5 +14,10 @@ analytics SDKs directly.
 - Prohibited field and value validation.
 - No-op provider for builds without external analytics.
 - Bounded local diagnostics provider for host tests and development builds.
+- Performance instrumentation schema for UI, playback, import, search,
+  protocol, command, memory, storage, network, and pairing samples.
+- No-op and fake performance instrumentation sinks for deterministic tests.
 
 This package does not include Firebase, Crashlytics, or another provider SDK.
+It also does not define dashboards, upload schedules, device profilers, frame
+observers, or app-specific performance UI.

--- a/packages/core_analytics/lib/core_analytics.dart
+++ b/packages/core_analytics/lib/core_analytics.dart
@@ -1,3 +1,4 @@
 library;
 
 export 'src/analytics_models.dart';
+export 'src/performance_instrumentation_models.dart';

--- a/packages/core_analytics/lib/src/performance_instrumentation_models.dart
+++ b/packages/core_analytics/lib/src/performance_instrumentation_models.dart
@@ -1,0 +1,443 @@
+import 'package:equatable/equatable.dart';
+
+const String kAiroPerformanceInstrumentationSchemaVersion = '1.0.0';
+
+enum AiroPerformanceArea {
+  ui('ui'),
+  playback('playback'),
+  import('import'),
+  search('search'),
+  protocol('protocol'),
+  command('command'),
+  memory('memory'),
+  storage('storage'),
+  network('network'),
+  pairing('pairing');
+
+  const AiroPerformanceArea(this.stableId);
+
+  final String stableId;
+}
+
+enum AiroPerformanceMetric {
+  appStartup('app_startup'),
+  frameBuild('frame_build'),
+  frameRaster('frame_raster'),
+  focusLatency('focus_latency'),
+  playbackStartup('playback_startup'),
+  timeToFirstFrame('time_to_first_frame'),
+  rebufferDuration('rebuffer_duration'),
+  rebufferCount('rebuffer_count'),
+  failoverRecovery('failover_recovery'),
+  decoderFallback('decoder_fallback'),
+  importDuration('import_duration'),
+  importThroughput('import_throughput'),
+  searchLatency('search_latency'),
+  protocolRoundTrip('protocol_round_trip'),
+  commandAcknowledgement('command_acknowledgement'),
+  memoryUsage('memory_usage'),
+  storageUsage('storage_usage'),
+  analyticsEnqueueLatency('analytics_enqueue_latency');
+
+  const AiroPerformanceMetric(this.stableId);
+
+  final String stableId;
+}
+
+enum AiroPerformanceUnit {
+  milliseconds('milliseconds'),
+  count('count'),
+  megabytes('megabytes'),
+  rowsPerSecond('rows_per_second'),
+  ratio('ratio');
+
+  const AiroPerformanceUnit(this.stableId);
+
+  final String stableId;
+}
+
+enum AiroPerformanceBucket {
+  under5ms('under_5ms'),
+  under16ms('under_16ms'),
+  under33ms('under_33ms'),
+  under100ms('under_100ms'),
+  under500ms('under_500ms'),
+  under1s('under_1s'),
+  oneTo3s('1_to_3s'),
+  threeTo10s('3_to_10s'),
+  over10s('over_10s'),
+  notBucketed('not_bucketed');
+
+  const AiroPerformanceBucket(this.stableId);
+
+  final String stableId;
+}
+
+enum AiroPerformanceBudgetBlockerCode {
+  accepted('accepted'),
+  missingSample('missing_sample'),
+  areaMismatch('area_mismatch'),
+  metricMismatch('metric_mismatch'),
+  unitMismatch('unit_mismatch'),
+  aboveMaximum('above_maximum'),
+  belowMinimum('below_minimum'),
+  privacyUnsafeDimension('privacy_unsafe_dimension');
+
+  const AiroPerformanceBudgetBlockerCode(this.stableId);
+
+  final String stableId;
+}
+
+enum AiroPerformanceSafeValueRejectionCode {
+  empty('empty'),
+  prohibitedDimension('prohibited_dimension'),
+  urlValue('url_value'),
+  localPathValue('local_path_value'),
+  localIpValue('local_ip_value'),
+  credentialLikeValue('credential_like_value'),
+  invalidStableId('invalid_stable_id');
+
+  const AiroPerformanceSafeValueRejectionCode(this.stableId);
+
+  final String stableId;
+}
+
+class AiroPerformanceSafeValue extends Equatable {
+  const AiroPerformanceSafeValue._(this.value);
+
+  factory AiroPerformanceSafeValue.stable(String value) {
+    final rejection = validate(value);
+    if (rejection != null) {
+      throw ArgumentError.value(value, 'value', rejection.stableId);
+    }
+    return AiroPerformanceSafeValue._(value.trim());
+  }
+
+  static const Set<String> prohibitedDimensions = {
+    'channel',
+    'channelname',
+    'mediatitle',
+    'movietitle',
+    'programtitle',
+    'playlistname',
+    'playlisturl',
+    'streamurl',
+    'signedurl',
+    'url',
+    'authorization',
+    'authheader',
+    'cookie',
+    'credential',
+    'providercredential',
+    'providerdomain',
+    'localpath',
+    'path',
+    'localip',
+    'ipaddress',
+    'query',
+    'searchquery',
+    'voicetranscript',
+    'deviceid',
+    'androidid',
+    'serial',
+    'macaddress',
+  };
+
+  final String value;
+
+  static AiroPerformanceSafeValueRejectionCode? validate(String value) {
+    final trimmed = value.trim();
+    if (trimmed.isEmpty) {
+      return AiroPerformanceSafeValueRejectionCode.empty;
+    }
+    final normalized = trimmed
+        .replaceAll(RegExp('[^A-Za-z0-9]'), '')
+        .toLowerCase();
+    if (prohibitedDimensions.contains(normalized)) {
+      return AiroPerformanceSafeValueRejectionCode.prohibitedDimension;
+    }
+    final uri = Uri.tryParse(trimmed);
+    if (uri != null && (uri.scheme == 'http' || uri.scheme == 'https')) {
+      return AiroPerformanceSafeValueRejectionCode.urlValue;
+    }
+    if (trimmed.startsWith('file://') ||
+        trimmed.startsWith('/') ||
+        RegExp(r'^[A-Za-z]:\\').hasMatch(trimmed)) {
+      return AiroPerformanceSafeValueRejectionCode.localPathValue;
+    }
+    if (RegExp(
+      r'\b(?:10|127|172\.(?:1[6-9]|2\d|3[0-1])|192\.168)\.',
+    ).hasMatch(trimmed)) {
+      return AiroPerformanceSafeValueRejectionCode.localIpValue;
+    }
+    if (RegExp(
+      r'\b(?:bearer|basic)\s+[A-Za-z0-9._~+/=-]+',
+      caseSensitive: false,
+    ).hasMatch(trimmed)) {
+      return AiroPerformanceSafeValueRejectionCode.credentialLikeValue;
+    }
+    if (!RegExp(r'^[A-Za-z0-9_.:-]+$').hasMatch(trimmed)) {
+      return AiroPerformanceSafeValueRejectionCode.invalidStableId;
+    }
+    return null;
+  }
+
+  @override
+  String toString() => 'AiroPerformanceSafeValue(redacted)';
+
+  @override
+  List<Object?> get props => [value];
+}
+
+class AiroPerformanceDimension extends Equatable {
+  const AiroPerformanceDimension({
+    required this.key,
+    required this.value,
+    this.schemaVersion = kAiroPerformanceInstrumentationSchemaVersion,
+  });
+
+  final String schemaVersion;
+  final AiroPerformanceSafeValue key;
+  final AiroPerformanceSafeValue value;
+
+  @override
+  String toString() {
+    return 'AiroPerformanceDimension(key: ${key.value}, value: redacted)';
+  }
+
+  @override
+  List<Object?> get props => [schemaVersion, key, value];
+}
+
+class AiroPerformanceSample extends Equatable {
+  AiroPerformanceSample({
+    required this.sampleId,
+    required this.area,
+    required this.metric,
+    required this.unit,
+    required this.value,
+    required this.observedAt,
+    this.bucket = AiroPerformanceBucket.notBucketed,
+    Iterable<AiroPerformanceDimension> dimensions = const [],
+    this.schemaVersion = kAiroPerformanceInstrumentationSchemaVersion,
+  }) : dimensions = List.unmodifiable(dimensions) {
+    _throwIfUnsafeStableId(sampleId, 'sampleId');
+  }
+
+  final String schemaVersion;
+  final String sampleId;
+  final AiroPerformanceArea area;
+  final AiroPerformanceMetric metric;
+  final AiroPerformanceUnit unit;
+  final double value;
+  final AiroPerformanceBucket bucket;
+  final DateTime observedAt;
+  final List<AiroPerformanceDimension> dimensions;
+
+  bool get isLatencyMetric =>
+      unit == AiroPerformanceUnit.milliseconds &&
+      {
+        AiroPerformanceMetric.appStartup,
+        AiroPerformanceMetric.frameBuild,
+        AiroPerformanceMetric.frameRaster,
+        AiroPerformanceMetric.focusLatency,
+        AiroPerformanceMetric.playbackStartup,
+        AiroPerformanceMetric.timeToFirstFrame,
+        AiroPerformanceMetric.failoverRecovery,
+        AiroPerformanceMetric.searchLatency,
+        AiroPerformanceMetric.protocolRoundTrip,
+        AiroPerformanceMetric.commandAcknowledgement,
+        AiroPerformanceMetric.analyticsEnqueueLatency,
+      }.contains(metric);
+
+  @override
+  String toString() {
+    return 'AiroPerformanceSample('
+        'sampleId: $sampleId, '
+        'area: ${area.stableId}, '
+        'metric: ${metric.stableId}, '
+        'unit: ${unit.stableId}, '
+        'value: $value, '
+        'bucket: ${bucket.stableId}, '
+        'dimensionCount: ${dimensions.length}'
+        ')';
+  }
+
+  @override
+  List<Object?> get props => [
+    schemaVersion,
+    sampleId,
+    area,
+    metric,
+    unit,
+    value,
+    bucket,
+    observedAt,
+    dimensions,
+  ];
+}
+
+class AiroPerformanceBudget extends Equatable {
+  AiroPerformanceBudget({
+    required this.budgetId,
+    required this.area,
+    required this.metric,
+    required this.unit,
+    this.maximum,
+    this.minimum,
+    this.schemaVersion = kAiroPerformanceInstrumentationSchemaVersion,
+  }) {
+    _throwIfUnsafeStableId(budgetId, 'budgetId');
+  }
+
+  final String schemaVersion;
+  final String budgetId;
+  final AiroPerformanceArea area;
+  final AiroPerformanceMetric metric;
+  final AiroPerformanceUnit unit;
+  final double? maximum;
+  final double? minimum;
+
+  @override
+  List<Object?> get props => [
+    schemaVersion,
+    budgetId,
+    area,
+    metric,
+    unit,
+    maximum,
+    minimum,
+  ];
+}
+
+class AiroPerformanceBudgetEvaluation extends Equatable {
+  AiroPerformanceBudgetEvaluation({
+    required this.budgetId,
+    required this.sampleId,
+    required Iterable<AiroPerformanceBudgetBlockerCode> blockers,
+  }) : blockers = List.unmodifiable(blockers);
+
+  final String budgetId;
+  final String sampleId;
+  final List<AiroPerformanceBudgetBlockerCode> blockers;
+
+  bool get accepted =>
+      blockers.length == 1 &&
+      blockers.single == AiroPerformanceBudgetBlockerCode.accepted;
+
+  @override
+  List<Object?> get props => [budgetId, sampleId, blockers];
+}
+
+class AiroPerformanceBudgetPolicy {
+  const AiroPerformanceBudgetPolicy();
+
+  AiroPerformanceBudgetEvaluation evaluate({
+    required AiroPerformanceBudget budget,
+    AiroPerformanceSample? sample,
+  }) {
+    final blockers = <AiroPerformanceBudgetBlockerCode>[];
+    if (sample == null) {
+      blockers.add(AiroPerformanceBudgetBlockerCode.missingSample);
+      return AiroPerformanceBudgetEvaluation(
+        budgetId: budget.budgetId,
+        sampleId: 'missing',
+        blockers: blockers,
+      );
+    }
+
+    if (sample.area != budget.area) {
+      blockers.add(AiroPerformanceBudgetBlockerCode.areaMismatch);
+    }
+    if (sample.metric != budget.metric) {
+      blockers.add(AiroPerformanceBudgetBlockerCode.metricMismatch);
+    }
+    if (sample.unit != budget.unit) {
+      blockers.add(AiroPerformanceBudgetBlockerCode.unitMismatch);
+    }
+    if (budget.maximum != null && sample.value > budget.maximum!) {
+      blockers.add(AiroPerformanceBudgetBlockerCode.aboveMaximum);
+    }
+    if (budget.minimum != null && sample.value < budget.minimum!) {
+      blockers.add(AiroPerformanceBudgetBlockerCode.belowMinimum);
+    }
+
+    return AiroPerformanceBudgetEvaluation(
+      budgetId: budget.budgetId,
+      sampleId: sample.sampleId,
+      blockers: blockers.isEmpty
+          ? const [AiroPerformanceBudgetBlockerCode.accepted]
+          : blockers,
+    );
+  }
+}
+
+abstract interface class AiroPerformanceInstrumentationSink {
+  Future<AiroPerformanceRecordResult> record(AiroPerformanceSample sample);
+}
+
+class AiroPerformanceRecordResult extends Equatable {
+  const AiroPerformanceRecordResult({required this.accepted, this.reason});
+
+  final bool accepted;
+  final AiroPerformanceBudgetBlockerCode? reason;
+
+  @override
+  List<Object?> get props => [accepted, reason];
+}
+
+class AiroNoOpPerformanceInstrumentationSink
+    implements AiroPerformanceInstrumentationSink {
+  const AiroNoOpPerformanceInstrumentationSink();
+
+  @override
+  Future<AiroPerformanceRecordResult> record(
+    AiroPerformanceSample sample,
+  ) async {
+    return const AiroPerformanceRecordResult(accepted: true);
+  }
+}
+
+class AiroFakePerformanceInstrumentationSink
+    implements AiroPerformanceInstrumentationSink {
+  AiroFakePerformanceInstrumentationSink({this.maxSamples = 100});
+
+  final int maxSamples;
+  final List<AiroPerformanceSample> _samples = [];
+
+  List<AiroPerformanceSample> get samples => List.unmodifiable(_samples);
+
+  @override
+  Future<AiroPerformanceRecordResult> record(
+    AiroPerformanceSample sample,
+  ) async {
+    if (_samples.length >= maxSamples) {
+      return const AiroPerformanceRecordResult(
+        accepted: false,
+        reason: AiroPerformanceBudgetBlockerCode.aboveMaximum,
+      );
+    }
+    _samples.add(sample);
+    return const AiroPerformanceRecordResult(accepted: true);
+  }
+}
+
+AiroPerformanceBucket bucketLatency(Duration duration) {
+  final millis = duration.inMilliseconds;
+  if (millis < 5) return AiroPerformanceBucket.under5ms;
+  if (millis < 16) return AiroPerformanceBucket.under16ms;
+  if (millis < 33) return AiroPerformanceBucket.under33ms;
+  if (millis < 100) return AiroPerformanceBucket.under100ms;
+  if (millis < 500) return AiroPerformanceBucket.under500ms;
+  if (millis < 1000) return AiroPerformanceBucket.under1s;
+  if (millis < 3000) return AiroPerformanceBucket.oneTo3s;
+  if (millis < 10000) return AiroPerformanceBucket.threeTo10s;
+  return AiroPerformanceBucket.over10s;
+}
+
+void _throwIfUnsafeStableId(String value, String name) {
+  final rejection = AiroPerformanceSafeValue.validate(value);
+  if (rejection != null) {
+    throw ArgumentError.value(value, name, rejection.stableId);
+  }
+}

--- a/packages/core_analytics/test/performance_instrumentation_models_test.dart
+++ b/packages/core_analytics/test/performance_instrumentation_models_test.dart
@@ -1,0 +1,212 @@
+import 'package:core_analytics/core_analytics.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('AiroPerformanceBudgetPolicy', () {
+    const policy = AiroPerformanceBudgetPolicy();
+    final observedAt = DateTime.utc(2026, 7, 14, 15);
+
+    AiroPerformanceSample sample({
+      String sampleId = 'playback-startup-1',
+      AiroPerformanceArea area = AiroPerformanceArea.playback,
+      AiroPerformanceMetric metric = AiroPerformanceMetric.timeToFirstFrame,
+      AiroPerformanceUnit unit = AiroPerformanceUnit.milliseconds,
+      double value = 1200,
+    }) {
+      return AiroPerformanceSample(
+        sampleId: sampleId,
+        area: area,
+        metric: metric,
+        unit: unit,
+        value: value,
+        bucket: bucketLatency(Duration(milliseconds: value.toInt())),
+        observedAt: observedAt,
+        dimensions: [
+          AiroPerformanceDimension(
+            key: AiroPerformanceSafeValue.stable('profile'),
+            value: AiroPerformanceSafeValue.stable('lite_receiver'),
+          ),
+        ],
+      );
+    }
+
+    test('accepts playback startup sample within budget', () {
+      final evaluation = policy.evaluate(
+        budget: AiroPerformanceBudget(
+          budgetId: 'ttff-under-3s',
+          area: AiroPerformanceArea.playback,
+          metric: AiroPerformanceMetric.timeToFirstFrame,
+          unit: AiroPerformanceUnit.milliseconds,
+          maximum: 3000,
+        ),
+        sample: sample(),
+      );
+
+      expect(evaluation.accepted, isTrue);
+      expect(sample().bucket, AiroPerformanceBucket.oneTo3s);
+      expect(sample().isLatencyMetric, isTrue);
+    });
+
+    test('rejects over-budget and mismatched samples', () {
+      final evaluation = policy.evaluate(
+        budget: AiroPerformanceBudget(
+          budgetId: 'search-under-100ms',
+          area: AiroPerformanceArea.search,
+          metric: AiroPerformanceMetric.searchLatency,
+          unit: AiroPerformanceUnit.milliseconds,
+          maximum: 100,
+        ),
+        sample: sample(
+          area: AiroPerformanceArea.playback,
+          metric: AiroPerformanceMetric.timeToFirstFrame,
+          value: 1200,
+        ),
+      );
+
+      expect(
+        evaluation.blockers,
+        contains(AiroPerformanceBudgetBlockerCode.areaMismatch),
+      );
+      expect(
+        evaluation.blockers,
+        contains(AiroPerformanceBudgetBlockerCode.metricMismatch),
+      );
+      expect(
+        evaluation.blockers,
+        contains(AiroPerformanceBudgetBlockerCode.aboveMaximum),
+      );
+    });
+
+    test('rejects missing sample for required budget', () {
+      final evaluation = policy.evaluate(
+        budget: AiroPerformanceBudget(
+          budgetId: 'memory-under-256mb',
+          area: AiroPerformanceArea.memory,
+          metric: AiroPerformanceMetric.memoryUsage,
+          unit: AiroPerformanceUnit.megabytes,
+          maximum: 256,
+        ),
+      );
+
+      expect(
+        evaluation.blockers,
+        contains(AiroPerformanceBudgetBlockerCode.missingSample),
+      );
+    });
+  });
+
+  group('AiroPerformanceSafeValue', () {
+    test('rejects unsafe dimension keys and values', () {
+      expect(
+        () => AiroPerformanceSafeValue.stable('playlistUrl'),
+        throwsArgumentError,
+      );
+      expect(
+        () => AiroPerformanceSafeValue.stable('https://example.com/live.m3u8'),
+        throwsArgumentError,
+      );
+      expect(
+        () => AiroPerformanceSafeValue.stable('/Users/me/movie.mp4'),
+        throwsArgumentError,
+      );
+      expect(
+        () => AiroPerformanceSafeValue.stable('192.168.1.10'),
+        throwsArgumentError,
+      );
+      expect(
+        () => AiroPerformanceSafeValue.stable('Bearer abc123'),
+        throwsArgumentError,
+      );
+    });
+
+    test('rejects unsafe sample and budget ids', () {
+      expect(
+        () => AiroPerformanceSample(
+          sampleId: 'https://example.com/sample',
+          area: AiroPerformanceArea.playback,
+          metric: AiroPerformanceMetric.timeToFirstFrame,
+          unit: AiroPerformanceUnit.milliseconds,
+          value: 100,
+          observedAt: DateTime.utc(2026, 7, 14, 15),
+        ),
+        throwsArgumentError,
+      );
+      expect(
+        () => AiroPerformanceBudget(
+          budgetId: '/Users/me/budget',
+          area: AiroPerformanceArea.playback,
+          metric: AiroPerformanceMetric.timeToFirstFrame,
+          unit: AiroPerformanceUnit.milliseconds,
+          maximum: 3000,
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('sample string output hides dimension values', () {
+      final sample = AiroPerformanceSample(
+        sampleId: 'import-throughput-1',
+        area: AiroPerformanceArea.import,
+        metric: AiroPerformanceMetric.importThroughput,
+        unit: AiroPerformanceUnit.rowsPerSecond,
+        value: 5000,
+        observedAt: DateTime.utc(2026, 7, 14, 15),
+        dimensions: [
+          AiroPerformanceDimension(
+            key: AiroPerformanceSafeValue.stable('worker'),
+            value: AiroPerformanceSafeValue.stable('large_playlist_worker'),
+          ),
+        ],
+      );
+
+      final rendered = sample.toString();
+
+      expect(rendered, contains('import_throughput'));
+      expect(rendered, contains('dimensionCount: 1'));
+      expect(rendered, isNot(contains('large_playlist_worker')));
+      expect(rendered, isNot(contains('http')));
+      expect(rendered, isNot(contains('/Users/')));
+    });
+  });
+
+  group('AiroPerformanceInstrumentationSink adapters', () {
+    test('no-op sink accepts samples without retaining them', () async {
+      const sink = AiroNoOpPerformanceInstrumentationSink();
+
+      final result = await sink.record(
+        AiroPerformanceSample(
+          sampleId: 'enqueue-1',
+          area: AiroPerformanceArea.network,
+          metric: AiroPerformanceMetric.analyticsEnqueueLatency,
+          unit: AiroPerformanceUnit.milliseconds,
+          value: 2,
+          bucket: bucketLatency(const Duration(milliseconds: 2)),
+          observedAt: DateTime.utc(2026, 7, 14, 15),
+        ),
+      );
+
+      expect(result.accepted, isTrue);
+    });
+
+    test('fake sink keeps bounded deterministic samples', () async {
+      final sink = AiroFakePerformanceInstrumentationSink(maxSamples: 1);
+      final sample = AiroPerformanceSample(
+        sampleId: 'protocol-rtt-1',
+        area: AiroPerformanceArea.protocol,
+        metric: AiroPerformanceMetric.protocolRoundTrip,
+        unit: AiroPerformanceUnit.milliseconds,
+        value: 40,
+        bucket: bucketLatency(const Duration(milliseconds: 40)),
+        observedAt: DateTime.utc(2026, 7, 14, 15),
+      );
+
+      final first = await sink.record(sample);
+      final second = await sink.record(sample);
+
+      expect(first.accepted, isTrue);
+      expect(second.accepted, isFalse);
+      expect(second.reason, AiroPerformanceBudgetBlockerCode.aboveMaximum);
+      expect(sink.samples.single.sampleId, 'protocol-rtt-1');
+    });
+  });
+}


### PR DESCRIPTION
# Summary\n\nAdds the ATV-031 v2 platform performance instrumentation contract in core_analytics.\n\nGoal: provide stable metric IDs, units, buckets, safe dimensions, budget evaluation, and sink boundaries before app/media/import/search/protocol instrumentation is wired.\n\nCore outcome:\n\n* Defines reusable Airo performance sample, budget, bucket, and safe-dimension models.\n* Adds no-op and fake instrumentation sinks for application/test consumption.\n* Documents the platform ownership boundary and privacy limits.\n\n# Changes\n\n### Code\n\n* Added:\n  * packages/core_analytics/lib/src/performance_instrumentation_models.dart\n  * packages/core_analytics/test/performance_instrumentation_models_test.dart\n  * docs/features/airo-tv/PERFORMANCE_INSTRUMENTATION_SCHEMA.md\n* Updated:\n  * packages/core_analytics/lib/core_analytics.dart to export the schema.\n  * packages/core_analytics/README.md to mention performance instrumentation.\n\n### Logic\n\n* Adds stable performance areas for UI, playback, import, search, protocol, command, memory, storage, network, and pairing.\n* Adds deterministic budget evaluation for maximum/minimum thresholds and mismatch blockers.\n* Rejects unsafe dimension/sample/budget values including URLs, local paths, local IPs, credentials, device identifiers, search text, and media/provider fields.\n\n# API Changes\n\n* New public Dart exports from core_analytics for performance instrumentation models and sinks.\n\n# Database Changes\n\n* None.\n\n# Observability / Logging\n\n* Adds the schema and adapter boundary only; no vendor upload, dashboard, or runtime app hooks in this PR.\n\n# Performance Impact\n\n* Runtime impact: none until consumers start recording samples.\n* Contract supports bounded fake sink behavior for deterministic tests.\n\n# Risks\n\n* Follow-up instrumentation must map app/media events to the stable schema without leaking raw user/provider data.\n* Rollback plan: revert this PR before consumers depend on the new export.\n\n# Testing\n\n* Unit tests:\n  * cd packages/core_analytics && flutter test\n* Static checks:\n  * dart format --set-exit-if-changed packages/core_analytics\n  * cd packages/core_analytics && flutter analyze --fatal-infos\n  * git diff --check HEAD~1..HEAD && git diff --check\n* Privacy scan:\n  * diff scanned for secret/token/password/credential/auth/API key/Firebase/package-id terms; hits are redaction rules and tests only.\n\n# Deployment Notes\n\n* No secret or environment changes required.\n\n# Related Issues\n\nCloses #621