### PR TITLE
feat(platform): add protobuf protocol schema contract

### DIFF
--- a/docs/features/airo-tv/PROTOBUF_PROTOCOL_SCHEMAS.md
+++ b/docs/features/airo-tv/PROTOBUF_PROTOCOL_SCHEMAS.md
@@ -1,0 +1,66 @@
+# Protobuf Protocol Schemas
+
+Status: v2 platform contract for ATV-032.
+
+## Ownership
+
+Binary protocol schema governance is platform behavior. Airo TV, companion
+controllers, local discovery, secure WebSocket transport, command routing,
+session state, route health, and EPG sync can consume the protocol contracts,
+but message-family descriptors, field numbers, schema compatibility, sequence
+checks, payload-size limits, and replay blockers belong in
+`packages/core_protocol`.
+
+`core_commands` remains the source of command envelope semantics.
+`core_sessions` remains the source of playback/session and route-health state.
+Future EPG sync packages own compact EPG payload semantics.
+
+## Non-Goals
+
+This issue does not implement:
+
+- generated Dart, native, or desktop Protobuf code
+- protoc build scripts
+- secure WebSocket transport
+- encryption or signing
+- cloud relay behavior
+- EPG compression
+- app command handling
+
+## Contract Shape
+
+`AiroProtobufSchemaRegistry` describes supported message families:
+
+- envelope
+- command
+- playback state
+- route health
+- EPG sync
+- acknowledgement
+
+`AiroProtobufMessageDescriptor` defines stable message names, field numbers,
+field types, required fields, and reserved field numbers.
+
+`AiroProtobufCompatibilityPolicy` validates:
+
+- schema version
+- protocol version range
+- replay sequence
+- positive sequence numbers
+- payload size
+- required fields
+- duplicate field numbers
+- reserved field conflicts
+- safe message ids
+
+The canonical source schema lives at:
+
+- `packages/core_protocol/proto/airo_v2_protocol.proto`
+
+## Privacy
+
+Protocol schema descriptors and compatibility probes expose only stable ids,
+field numbers, field types, payload sizes, sequence ids, and blocker codes. They
+must not expose raw media URLs, playlist URLs, EPG URLs, request headers, local
+paths, local addresses, credentials, provider payloads, titles, search text,
+viewing history, analytics payloads, diagnostic dumps, or credential material.

--- a/packages/core_protocol/README.md
+++ b/packages/core_protocol/README.md
@@ -15,7 +15,12 @@ without leaking private media or account data.
 - Compatibility policies and deterministic blocker codes.
 - Edge Media Node placeholder profiles, service descriptors, policy blockers,
   and fake/no-op registries for future home-node work.
+- Protobuf protocol schema descriptors for envelopes, commands, playback state,
+  route health, compact EPG sync, and acknowledgements.
+- Compatibility policy for schema/protocol version, replay sequence, payload
+  size, required fields, reserved fields, and stable ids.
 
 This package does not discover devices, open sockets, store trust records,
 render pairing UI, send commands, maintain presence leases, index media, relay
-traffic, record media, transcode, run AI workers, or coordinate cloud state.
+traffic, record media, transcode, run AI workers, generate Protobuf code, or
+coordinate cloud state.

--- a/packages/core_protocol/lib/core_protocol.dart
+++ b/packages/core_protocol/lib/core_protocol.dart
@@ -2,3 +2,4 @@ library;
 
 export 'src/connected_node_models.dart';
 export 'src/edge_media_node_models.dart';
+export 'src/protobuf_protocol_schema_models.dart';

--- a/packages/core_protocol/lib/src/protobuf_protocol_schema_models.dart
+++ b/packages/core_protocol/lib/src/protobuf_protocol_schema_models.dart
@@ -1,0 +1,520 @@
+import 'package:equatable/equatable.dart';
+
+const String kAiroProtobufProtocolSchemaVersion = '1.0.0';
+const int kAiroProtobufProtocolVersion = 1;
+const int kAiroProtobufDefaultMaxPayloadBytes = 64 * 1024;
+
+enum AiroProtobufMessageFamily {
+  envelope('envelope'),
+  command('command'),
+  playbackState('playback_state'),
+  routeHealth('route_health'),
+  epgSync('epg_sync'),
+  acknowledgement('acknowledgement');
+
+  const AiroProtobufMessageFamily(this.stableId);
+
+  final String stableId;
+}
+
+enum AiroProtobufFieldType {
+  string('string'),
+  int32('int32'),
+  int64('int64'),
+  bool('bool'),
+  enumValue('enum'),
+  bytes('bytes'),
+  message('message'),
+  repeatedString('repeated_string');
+
+  const AiroProtobufFieldType(this.stableId);
+
+  final String stableId;
+}
+
+enum AiroProtobufCompatibilityCode {
+  accepted('accepted'),
+  schemaMismatch('schema_mismatch'),
+  protocolTooOld('protocol_too_old'),
+  protocolTooNew('protocol_too_new'),
+  duplicateFieldNumber('duplicate_field_number'),
+  reservedFieldConflict('reserved_field_conflict'),
+  missingRequiredField('missing_required_field'),
+  oversizedPayload('oversized_payload'),
+  duplicateSequence('duplicate_sequence'),
+  nonPositiveSequence('non_positive_sequence'),
+  unsafeStableId('unsafe_stable_id');
+
+  const AiroProtobufCompatibilityCode(this.stableId);
+
+  final String stableId;
+}
+
+enum AiroProtobufSafeValueRejectionCode {
+  empty('empty'),
+  urlValue('url_value'),
+  localPathValue('local_path_value'),
+  localIpValue('local_ip_value'),
+  credentialLikeValue('credential_like_value'),
+  invalidStableId('invalid_stable_id');
+
+  const AiroProtobufSafeValueRejectionCode(this.stableId);
+
+  final String stableId;
+}
+
+class AiroProtobufSafeValue extends Equatable {
+  const AiroProtobufSafeValue._(this.value);
+
+  factory AiroProtobufSafeValue.stable(String value) {
+    final rejection = validate(value);
+    if (rejection != null) {
+      throw ArgumentError.value(value, 'value', rejection.stableId);
+    }
+    return AiroProtobufSafeValue._(value.trim());
+  }
+
+  final String value;
+
+  static AiroProtobufSafeValueRejectionCode? validate(String value) {
+    final trimmed = value.trim();
+    if (trimmed.isEmpty) {
+      return AiroProtobufSafeValueRejectionCode.empty;
+    }
+    final uri = Uri.tryParse(trimmed);
+    if (uri != null && (uri.scheme == 'http' || uri.scheme == 'https')) {
+      return AiroProtobufSafeValueRejectionCode.urlValue;
+    }
+    if (trimmed.startsWith('file://') ||
+        trimmed.startsWith('/') ||
+        RegExp(r'^[A-Za-z]:\\').hasMatch(trimmed)) {
+      return AiroProtobufSafeValueRejectionCode.localPathValue;
+    }
+    if (RegExp(
+      r'\b(?:10|127|172\.(?:1[6-9]|2\d|3[0-1])|192\.168)\.',
+    ).hasMatch(trimmed)) {
+      return AiroProtobufSafeValueRejectionCode.localIpValue;
+    }
+    if (RegExp(
+      r'\b(?:bearer|basic)\s+[A-Za-z0-9._~+/=-]+',
+      caseSensitive: false,
+    ).hasMatch(trimmed)) {
+      return AiroProtobufSafeValueRejectionCode.credentialLikeValue;
+    }
+    if (!RegExp(r'^[A-Za-z][A-Za-z0-9_.-]*$').hasMatch(trimmed)) {
+      return AiroProtobufSafeValueRejectionCode.invalidStableId;
+    }
+    return null;
+  }
+
+  @override
+  String toString() => 'AiroProtobufSafeValue(redacted)';
+
+  @override
+  List<Object?> get props => [value];
+}
+
+class AiroProtobufFieldDescriptor extends Equatable {
+  const AiroProtobufFieldDescriptor({
+    required this.name,
+    required this.number,
+    required this.type,
+    this.required = false,
+    this.schemaVersion = kAiroProtobufProtocolSchemaVersion,
+  }) : assert(number > 0);
+
+  final String schemaVersion;
+  final AiroProtobufSafeValue name;
+  final int number;
+  final AiroProtobufFieldType type;
+  final bool required;
+
+  @override
+  String toString() {
+    return 'AiroProtobufFieldDescriptor('
+        'name: ${name.value}, '
+        'number: $number, '
+        'type: ${type.stableId}, '
+        'required: $required'
+        ')';
+  }
+
+  @override
+  List<Object?> get props => [schemaVersion, name, number, type, required];
+}
+
+class AiroProtobufMessageDescriptor extends Equatable {
+  AiroProtobufMessageDescriptor({
+    required this.messageName,
+    required this.family,
+    required Iterable<AiroProtobufFieldDescriptor> fields,
+    Set<int> reservedFieldNumbers = const {},
+    this.schemaVersion = kAiroProtobufProtocolSchemaVersion,
+  }) : fields = List.unmodifiable(fields),
+       reservedFieldNumbers = Set.unmodifiable(reservedFieldNumbers);
+
+  final String schemaVersion;
+  final AiroProtobufSafeValue messageName;
+  final AiroProtobufMessageFamily family;
+  final List<AiroProtobufFieldDescriptor> fields;
+  final Set<int> reservedFieldNumbers;
+
+  Set<int> get fieldNumbers =>
+      Set.unmodifiable(fields.map((field) => field.number));
+
+  Set<int> get requiredFieldNumbers => Set.unmodifiable(
+    fields.where((field) => field.required).map((field) => field.number),
+  );
+
+  @override
+  String toString() {
+    return 'AiroProtobufMessageDescriptor('
+        'messageName: ${messageName.value}, '
+        'family: ${family.stableId}, '
+        'fieldCount: ${fields.length}, '
+        'reservedFieldNumbers: $reservedFieldNumbers'
+        ')';
+  }
+
+  @override
+  List<Object?> get props => [
+    schemaVersion,
+    messageName,
+    family,
+    fields,
+    reservedFieldNumbers,
+  ];
+}
+
+class AiroProtobufSchemaRegistry extends Equatable {
+  AiroProtobufSchemaRegistry({
+    required Iterable<AiroProtobufMessageDescriptor> messages,
+    this.schemaVersion = kAiroProtobufProtocolSchemaVersion,
+    this.protocolVersion = kAiroProtobufProtocolVersion,
+    this.minProtocolVersion = kAiroProtobufProtocolVersion,
+    this.maxProtocolVersion = kAiroProtobufProtocolVersion,
+  }) : messages = List.unmodifiable(messages);
+
+  final String schemaVersion;
+  final int protocolVersion;
+  final int minProtocolVersion;
+  final int maxProtocolVersion;
+  final List<AiroProtobufMessageDescriptor> messages;
+
+  AiroProtobufMessageDescriptor? descriptorFor(
+    AiroProtobufMessageFamily family,
+  ) {
+    for (final descriptor in messages) {
+      if (descriptor.family == family) return descriptor;
+    }
+    return null;
+  }
+
+  @override
+  List<Object?> get props => [
+    schemaVersion,
+    protocolVersion,
+    minProtocolVersion,
+    maxProtocolVersion,
+    messages,
+  ];
+}
+
+class AiroProtobufEnvelopeProbe extends Equatable {
+  AiroProtobufEnvelopeProbe({
+    required this.schemaVersion,
+    required this.protocolVersion,
+    required this.family,
+    required this.sequence,
+    required this.payloadBytes,
+    required Iterable<int> presentFieldNumbers,
+    this.messageId,
+  }) : presentFieldNumbers = Set.unmodifiable(presentFieldNumbers);
+
+  final String schemaVersion;
+  final int protocolVersion;
+  final AiroProtobufMessageFamily family;
+  final int sequence;
+  final int payloadBytes;
+  final Set<int> presentFieldNumbers;
+  final String? messageId;
+
+  @override
+  String toString() {
+    return 'AiroProtobufEnvelopeProbe('
+        'schemaVersion: $schemaVersion, '
+        'protocolVersion: $protocolVersion, '
+        'family: ${family.stableId}, '
+        'sequence: $sequence, '
+        'payloadBytes: $payloadBytes, '
+        'fieldCount: ${presentFieldNumbers.length}, '
+        'hasMessageId: ${messageId != null}'
+        ')';
+  }
+
+  @override
+  List<Object?> get props => [
+    schemaVersion,
+    protocolVersion,
+    family,
+    sequence,
+    payloadBytes,
+    presentFieldNumbers,
+    messageId,
+  ];
+}
+
+class AiroProtobufCompatibilityResult extends Equatable {
+  AiroProtobufCompatibilityResult({
+    required this.family,
+    required this.sequence,
+    required Iterable<AiroProtobufCompatibilityCode> codes,
+  }) : codes = List.unmodifiable(codes);
+
+  final AiroProtobufMessageFamily family;
+  final int sequence;
+  final List<AiroProtobufCompatibilityCode> codes;
+
+  bool get accepted =>
+      codes.length == 1 &&
+      codes.single == AiroProtobufCompatibilityCode.accepted;
+
+  @override
+  List<Object?> get props => [family, sequence, codes];
+}
+
+class AiroProtobufCompatibilityPolicy {
+  const AiroProtobufCompatibilityPolicy({
+    this.maxPayloadBytes = kAiroProtobufDefaultMaxPayloadBytes,
+  });
+
+  final int maxPayloadBytes;
+
+  AiroProtobufCompatibilityResult validate({
+    required AiroProtobufSchemaRegistry registry,
+    required AiroProtobufEnvelopeProbe probe,
+    Set<int> acceptedSequences = const {},
+  }) {
+    final codes = <AiroProtobufCompatibilityCode>[];
+    final descriptor = registry.descriptorFor(probe.family);
+
+    if (probe.schemaVersion != registry.schemaVersion) {
+      codes.add(AiroProtobufCompatibilityCode.schemaMismatch);
+    }
+    if (probe.protocolVersion < registry.minProtocolVersion) {
+      codes.add(AiroProtobufCompatibilityCode.protocolTooOld);
+    }
+    if (probe.protocolVersion > registry.maxProtocolVersion) {
+      codes.add(AiroProtobufCompatibilityCode.protocolTooNew);
+    }
+    if (probe.sequence <= 0) {
+      codes.add(AiroProtobufCompatibilityCode.nonPositiveSequence);
+    }
+    if (acceptedSequences.contains(probe.sequence)) {
+      codes.add(AiroProtobufCompatibilityCode.duplicateSequence);
+    }
+    if (probe.payloadBytes > maxPayloadBytes) {
+      codes.add(AiroProtobufCompatibilityCode.oversizedPayload);
+    }
+    if (descriptor != null) {
+      _addDescriptorCodes(descriptor, probe, codes);
+    }
+    final messageId = probe.messageId;
+    if (messageId != null &&
+        AiroProtobufSafeValue.validate(messageId) != null) {
+      codes.add(AiroProtobufCompatibilityCode.unsafeStableId);
+    }
+
+    return AiroProtobufCompatibilityResult(
+      family: probe.family,
+      sequence: probe.sequence,
+      codes: codes.isEmpty
+          ? const [AiroProtobufCompatibilityCode.accepted]
+          : codes,
+    );
+  }
+
+  void _addDescriptorCodes(
+    AiroProtobufMessageDescriptor descriptor,
+    AiroProtobufEnvelopeProbe probe,
+    List<AiroProtobufCompatibilityCode> codes,
+  ) {
+    if (descriptor.fields.length != descriptor.fieldNumbers.length) {
+      codes.add(AiroProtobufCompatibilityCode.duplicateFieldNumber);
+    }
+    if (descriptor.reservedFieldNumbers.any(descriptor.fieldNumbers.contains)) {
+      codes.add(AiroProtobufCompatibilityCode.reservedFieldConflict);
+    }
+    if (!probe.presentFieldNumbers.containsAll(
+      descriptor.requiredFieldNumbers,
+    )) {
+      codes.add(AiroProtobufCompatibilityCode.missingRequiredField);
+    }
+  }
+}
+
+abstract interface class AiroProtobufSchemaRegistryProvider {
+  AiroProtobufSchemaRegistry registry();
+}
+
+class AiroNoOpProtobufSchemaRegistryProvider
+    implements AiroProtobufSchemaRegistryProvider {
+  const AiroNoOpProtobufSchemaRegistryProvider();
+
+  @override
+  AiroProtobufSchemaRegistry registry() {
+    return AiroProtobufSchemaRegistry(messages: const []);
+  }
+}
+
+class AiroFakeProtobufSchemaRegistryProvider
+    implements AiroProtobufSchemaRegistryProvider {
+  const AiroFakeProtobufSchemaRegistryProvider(this._registry);
+
+  final AiroProtobufSchemaRegistry _registry;
+
+  @override
+  AiroProtobufSchemaRegistry registry() => _registry;
+}
+
+AiroProtobufSchemaRegistry airoV2ProtobufSchemaRegistry() {
+  return AiroProtobufSchemaRegistry(
+    messages: [
+      _message(
+        name: 'AiroProtocolEnvelope',
+        family: AiroProtobufMessageFamily.envelope,
+        fields: const [
+          _FieldSpec('schema_version', 1, AiroProtobufFieldType.string, true),
+          _FieldSpec('protocol_version', 2, AiroProtobufFieldType.int32, true),
+          _FieldSpec(
+            'message_family',
+            3,
+            AiroProtobufFieldType.enumValue,
+            true,
+          ),
+          _FieldSpec('sequence', 4, AiroProtobufFieldType.int64, true),
+          _FieldSpec('message_id', 5, AiroProtobufFieldType.string, true),
+          _FieldSpec(
+            'issued_unix_millis',
+            6,
+            AiroProtobufFieldType.int64,
+            true,
+          ),
+          _FieldSpec('payload', 7, AiroProtobufFieldType.bytes, true),
+        ],
+        reserved: const {100, 101, 102},
+      ),
+      _message(
+        name: 'AiroPlaybackCommand',
+        family: AiroProtobufMessageFamily.command,
+        fields: const [
+          _FieldSpec('command_id', 1, AiroProtobufFieldType.string, true),
+          _FieldSpec('session_id', 2, AiroProtobufFieldType.string, true),
+          _FieldSpec('sender_node_id', 3, AiroProtobufFieldType.string, true),
+          _FieldSpec('target_node_id', 4, AiroProtobufFieldType.string, true),
+          _FieldSpec('command_kind', 5, AiroProtobufFieldType.enumValue, true),
+          _FieldSpec(
+            'command_action',
+            6,
+            AiroProtobufFieldType.enumValue,
+            true,
+          ),
+          _FieldSpec('idempotency_key', 7, AiroProtobufFieldType.string, true),
+          _FieldSpec('payload_ref', 8, AiroProtobufFieldType.string, false),
+        ],
+      ),
+      _message(
+        name: 'AiroPlaybackStateSnapshot',
+        family: AiroProtobufMessageFamily.playbackState,
+        fields: const [
+          _FieldSpec('session_id', 1, AiroProtobufFieldType.string, true),
+          _FieldSpec('revision', 2, AiroProtobufFieldType.int64, true),
+          _FieldSpec('phase', 3, AiroProtobufFieldType.enumValue, true),
+          _FieldSpec('position_millis', 4, AiroProtobufFieldType.int64, false),
+          _FieldSpec('duration_millis', 5, AiroProtobufFieldType.int64, false),
+          _FieldSpec('owner_node_id', 6, AiroProtobufFieldType.string, true),
+          _FieldSpec('playback_node_id', 7, AiroProtobufFieldType.string, true),
+          _FieldSpec('route_id', 8, AiroProtobufFieldType.string, true),
+        ],
+      ),
+      _message(
+        name: 'AiroRouteHealthUpdate',
+        family: AiroProtobufMessageFamily.routeHealth,
+        fields: const [
+          _FieldSpec('event_id', 1, AiroProtobufFieldType.string, true),
+          _FieldSpec('session_id', 2, AiroProtobufFieldType.string, true),
+          _FieldSpec('route_id', 3, AiroProtobufFieldType.string, true),
+          _FieldSpec('sequence', 4, AiroProtobufFieldType.int64, true),
+          _FieldSpec('health_level', 5, AiroProtobufFieldType.enumValue, true),
+          _FieldSpec('failure_code', 6, AiroProtobufFieldType.string, false),
+          _FieldSpec('diagnostic_ref', 7, AiroProtobufFieldType.string, false),
+        ],
+      ),
+      _message(
+        name: 'AiroCompactEpgSync',
+        family: AiroProtobufMessageFamily.epgSync,
+        fields: const [
+          _FieldSpec('sync_id', 1, AiroProtobufFieldType.string, true),
+          _FieldSpec('source_node_id', 2, AiroProtobufFieldType.string, true),
+          _FieldSpec('target_node_id', 3, AiroProtobufFieldType.string, true),
+          _FieldSpec(
+            'window_start_unix_millis',
+            4,
+            AiroProtobufFieldType.int64,
+            true,
+          ),
+          _FieldSpec(
+            'window_end_unix_millis',
+            5,
+            AiroProtobufFieldType.int64,
+            true,
+          ),
+          _FieldSpec('entry_count', 6, AiroProtobufFieldType.int32, true),
+          _FieldSpec('payload_ref', 7, AiroProtobufFieldType.string, false),
+        ],
+      ),
+      _message(
+        name: 'AiroProtocolAcknowledgement',
+        family: AiroProtobufMessageFamily.acknowledgement,
+        fields: const [
+          _FieldSpec('message_id', 1, AiroProtobufFieldType.string, true),
+          _FieldSpec('sequence', 2, AiroProtobufFieldType.int64, true),
+          _FieldSpec('status', 3, AiroProtobufFieldType.enumValue, true),
+          _FieldSpec('stable_code', 4, AiroProtobufFieldType.string, false),
+        ],
+      ),
+    ],
+  );
+}
+
+AiroProtobufMessageDescriptor _message({
+  required String name,
+  required AiroProtobufMessageFamily family,
+  required List<_FieldSpec> fields,
+  Set<int> reserved = const {},
+}) {
+  return AiroProtobufMessageDescriptor(
+    messageName: AiroProtobufSafeValue.stable(name),
+    family: family,
+    reservedFieldNumbers: reserved,
+    fields: fields
+        .map(
+          (field) => AiroProtobufFieldDescriptor(
+            name: AiroProtobufSafeValue.stable(field.name),
+            number: field.number,
+            type: field.type,
+            required: field.required,
+          ),
+        )
+        .toList(growable: false),
+  );
+}
+
+class _FieldSpec {
+  const _FieldSpec(this.name, this.number, this.type, this.required);
+
+  final String name;
+  final int number;
+  final AiroProtobufFieldType type;
+  final bool required;
+}

--- a/packages/core_protocol/proto/airo_v2_protocol.proto
+++ b/packages/core_protocol/proto/airo_v2_protocol.proto
@@ -1,0 +1,76 @@
+syntax = "proto3";
+
+package airo.v2.protocol;
+
+option java_package = "io.airo.app.protocol.v2";
+option java_multiple_files = true;
+
+enum AiroMessageFamily {
+  AIRO_MESSAGE_FAMILY_UNSPECIFIED = 0;
+  AIRO_MESSAGE_FAMILY_ENVELOPE = 1;
+  AIRO_MESSAGE_FAMILY_COMMAND = 2;
+  AIRO_MESSAGE_FAMILY_PLAYBACK_STATE = 3;
+  AIRO_MESSAGE_FAMILY_ROUTE_HEALTH = 4;
+  AIRO_MESSAGE_FAMILY_EPG_SYNC = 5;
+  AIRO_MESSAGE_FAMILY_ACKNOWLEDGEMENT = 6;
+}
+
+message AiroProtocolEnvelope {
+  string schema_version = 1;
+  int32 protocol_version = 2;
+  AiroMessageFamily message_family = 3;
+  int64 sequence = 4;
+  string message_id = 5;
+  int64 issued_unix_millis = 6;
+  bytes payload = 7;
+  reserved 100 to 102;
+}
+
+message AiroPlaybackCommand {
+  string command_id = 1;
+  string session_id = 2;
+  string sender_node_id = 3;
+  string target_node_id = 4;
+  string command_kind = 5;
+  string command_action = 6;
+  string idempotency_key = 7;
+  string payload_ref = 8;
+}
+
+message AiroPlaybackStateSnapshot {
+  string session_id = 1;
+  int64 revision = 2;
+  string phase = 3;
+  int64 position_millis = 4;
+  int64 duration_millis = 5;
+  string owner_node_id = 6;
+  string playback_node_id = 7;
+  string route_id = 8;
+}
+
+message AiroRouteHealthUpdate {
+  string event_id = 1;
+  string session_id = 2;
+  string route_id = 3;
+  int64 sequence = 4;
+  string health_level = 5;
+  string failure_code = 6;
+  string diagnostic_ref = 7;
+}
+
+message AiroCompactEpgSync {
+  string sync_id = 1;
+  string source_node_id = 2;
+  string target_node_id = 3;
+  int64 window_start_unix_millis = 4;
+  int64 window_end_unix_millis = 5;
+  int32 entry_count = 6;
+  string payload_ref = 7;
+}
+
+message AiroProtocolAcknowledgement {
+  string message_id = 1;
+  int64 sequence = 2;
+  string status = 3;
+  string stable_code = 4;
+}

--- a/packages/core_protocol/test/protobuf_protocol_schema_models_test.dart
+++ b/packages/core_protocol/test/protobuf_protocol_schema_models_test.dart
@@ -1,0 +1,186 @@
+import 'package:core_protocol/core_protocol.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('Airo protobuf protocol schema registry', () {
+    const policy = AiroProtobufCompatibilityPolicy();
+
+    test('defines required v2 message families and stable fields', () {
+      final registry = airoV2ProtobufSchemaRegistry();
+
+      expect(registry.schemaVersion, kAiroProtobufProtocolSchemaVersion);
+      expect(registry.protocolVersion, kAiroProtobufProtocolVersion);
+      for (final family in AiroProtobufMessageFamily.values) {
+        expect(registry.descriptorFor(family), isNotNull);
+      }
+
+      final envelope = registry.descriptorFor(
+        AiroProtobufMessageFamily.envelope,
+      )!;
+      expect(envelope.messageName.value, 'AiroProtocolEnvelope');
+      expect(envelope.requiredFieldNumbers, containsAll({1, 2, 3, 4, 5, 6, 7}));
+      expect(envelope.reservedFieldNumbers, containsAll({100, 101, 102}));
+    });
+
+    test('accepts compatible envelope probe with required fields', () {
+      final registry = airoV2ProtobufSchemaRegistry();
+      final result = policy.validate(
+        registry: registry,
+        probe: AiroProtobufEnvelopeProbe(
+          schemaVersion: kAiroProtobufProtocolSchemaVersion,
+          protocolVersion: kAiroProtobufProtocolVersion,
+          family: AiroProtobufMessageFamily.envelope,
+          sequence: 1,
+          payloadBytes: 256,
+          messageId: 'message-1',
+          presentFieldNumbers: {1, 2, 3, 4, 5, 6, 7},
+        ),
+      );
+
+      expect(result.accepted, isTrue);
+    });
+
+    test('rejects schema protocol replay sequence and size failures', () {
+      final registry = airoV2ProtobufSchemaRegistry();
+      final result = policy.validate(
+        registry: registry,
+        acceptedSequences: const {7},
+        probe: AiroProtobufEnvelopeProbe(
+          schemaVersion: '2.0.0',
+          protocolVersion: 99,
+          family: AiroProtobufMessageFamily.command,
+          sequence: 7,
+          payloadBytes: kAiroProtobufDefaultMaxPayloadBytes + 1,
+          messageId: 'message-7',
+          presentFieldNumbers: {1, 2, 3, 4, 5, 6, 7},
+        ),
+      );
+
+      expect(
+        result.codes,
+        contains(AiroProtobufCompatibilityCode.schemaMismatch),
+      );
+      expect(
+        result.codes,
+        contains(AiroProtobufCompatibilityCode.protocolTooNew),
+      );
+      expect(
+        result.codes,
+        contains(AiroProtobufCompatibilityCode.duplicateSequence),
+      );
+      expect(
+        result.codes,
+        contains(AiroProtobufCompatibilityCode.oversizedPayload),
+      );
+    });
+
+    test('rejects missing required fields and unsafe message ids', () {
+      final registry = airoV2ProtobufSchemaRegistry();
+      final result = policy.validate(
+        registry: registry,
+        probe: AiroProtobufEnvelopeProbe(
+          schemaVersion: kAiroProtobufProtocolSchemaVersion,
+          protocolVersion: kAiroProtobufProtocolVersion,
+          family: AiroProtobufMessageFamily.routeHealth,
+          sequence: 2,
+          payloadBytes: 128,
+          messageId: 'https://example.com/message',
+          presentFieldNumbers: {1, 2},
+        ),
+      );
+
+      expect(
+        result.codes,
+        contains(AiroProtobufCompatibilityCode.missingRequiredField),
+      );
+      expect(
+        result.codes,
+        contains(AiroProtobufCompatibilityCode.unsafeStableId),
+      );
+    });
+
+    test('detects duplicate and reserved field number conflicts', () {
+      final registry = AiroProtobufSchemaRegistry(
+        messages: [
+          AiroProtobufMessageDescriptor(
+            messageName: AiroProtobufSafeValue.stable('AiroBrokenMessage'),
+            family: AiroProtobufMessageFamily.acknowledgement,
+            reservedFieldNumbers: const {2},
+            fields: [
+              AiroProtobufFieldDescriptor(
+                name: AiroProtobufSafeValue.stable('message_id'),
+                number: 1,
+                type: AiroProtobufFieldType.string,
+                required: true,
+              ),
+              AiroProtobufFieldDescriptor(
+                name: AiroProtobufSafeValue.stable('sequence'),
+                number: 2,
+                type: AiroProtobufFieldType.int64,
+                required: true,
+              ),
+              AiroProtobufFieldDescriptor(
+                name: AiroProtobufSafeValue.stable('duplicate_sequence'),
+                number: 2,
+                type: AiroProtobufFieldType.int64,
+              ),
+            ],
+          ),
+        ],
+      );
+
+      final result = policy.validate(
+        registry: registry,
+        probe: AiroProtobufEnvelopeProbe(
+          schemaVersion: kAiroProtobufProtocolSchemaVersion,
+          protocolVersion: kAiroProtobufProtocolVersion,
+          family: AiroProtobufMessageFamily.acknowledgement,
+          sequence: 3,
+          payloadBytes: 128,
+          messageId: 'ack-3',
+          presentFieldNumbers: {1, 2},
+        ),
+      );
+
+      expect(
+        result.codes,
+        contains(AiroProtobufCompatibilityCode.duplicateFieldNumber),
+      );
+      expect(
+        result.codes,
+        contains(AiroProtobufCompatibilityCode.reservedFieldConflict),
+      );
+    });
+
+    test('safe value rejects raw transport and credential data', () {
+      expect(
+        () => AiroProtobufSafeValue.stable('https://example.com/stream.m3u8'),
+        throwsArgumentError,
+      );
+      expect(
+        () => AiroProtobufSafeValue.stable('/Users/me/media.mp4'),
+        throwsArgumentError,
+      );
+      expect(
+        () => AiroProtobufSafeValue.stable('192.168.1.30'),
+        throwsArgumentError,
+      );
+      expect(
+        () => AiroProtobufSafeValue.stable('Bearer abc123'),
+        throwsArgumentError,
+      );
+    });
+
+    test('registry adapters are deterministic', () {
+      const noop = AiroNoOpProtobufSchemaRegistryProvider();
+      final registry = airoV2ProtobufSchemaRegistry();
+      final fake = AiroFakeProtobufSchemaRegistryProvider(registry);
+
+      expect(noop.registry().messages, isEmpty);
+      expect(
+        fake.registry().descriptorFor(AiroProtobufMessageFamily.epgSync),
+        isNotNull,
+      );
+    });
+  });
+}


### PR DESCRIPTION
# Summary\n\nAdds the ATV-032 v2 platform protobuf protocol schema contract in core_protocol.\n\nGoal: define stable binary protocol message families, field descriptors, compatibility checks, and canonical proto schema before generated code or transport work is introduced.\n\nCore outcome:\n\n* Defines reusable protobuf schema registry and compatibility policy models.\n* Adds the canonical v2 protocol proto descriptor.\n* Documents the platform ownership boundary and privacy limits.\n\n# Changes\n\n### Code\n\n* Added:\n  * packages/core_protocol/lib/src/protobuf_protocol_schema_models.dart\n  * packages/core_protocol/proto/airo_v2_protocol.proto\n  * packages/core_protocol/test/protobuf_protocol_schema_models_test.dart\n  * docs/features/airo-tv/PROTOBUF_PROTOCOL_SCHEMAS.md\n* Updated:\n  * packages/core_protocol/lib/core_protocol.dart to export the schema contract.\n  * packages/core_protocol/README.md to mention protobuf protocol schemas.\n\n### Logic\n\n* Adds stable message families for envelope, command, playback state, route health, EPG sync, and acknowledgement.\n* Adds schema/protocol compatibility checks for version ranges, replay sequences, positive sequence ids, payload size, required fields, duplicate field numbers, reserved field conflicts, and safe message ids.\n* Keeps generated Java package under io.airo.app.protocol.v2 to align with the registered io.airo.app.* namespace family.\n\n# API Changes\n\n* New public Dart exports from core_protocol for protobuf schema models and registry providers.\n* Adds canonical proto source at packages/core_protocol/proto/airo_v2_protocol.proto.\n\n# Database Changes\n\n* None.\n\n# Observability / Logging\n\n* Schema and validation contract only; no generated code, transport, encryption, or app command handling.\n\n# Performance Impact\n\n* Runtime impact: none until consumers use the registry/policy.\n* Payload size checks are deterministic and bounded.\n\n# Risks\n\n* Future generated protobuf code must preserve field numbers and reserved ranges.\n* Follow-up transport work must avoid leaking raw provider/media data into message ids or diagnostics.\n* Rollback plan: revert this PR before generated-code consumers depend on the export.\n\n# Testing\n\n* Unit tests:\n  * cd packages/core_protocol && flutter test\n* Static checks:\n  * dart format --set-exit-if-changed packages/core_protocol\n  * cd packages/core_protocol && flutter analyze --fatal-infos\n  * git diff --check HEAD~1..HEAD && git diff --check\n* Privacy/namespace scan:\n  * diff scanned for secret/token/password/credential/auth/API key/Firebase/app.airo/io.airo.app.tv terms; hits are redaction rules and tests only, and proto java_package uses io.airo.app.protocol.v2.\n\n# Deployment Notes\n\n* No secret or environment changes required.\n\n# Related Issues\n\nCloses #622