### PR TITLE
feat(platform): add secure transport contract

### DIFF
--- a/docs/features/airo-tv/SECURE_WEBSOCKET_TRANSPORT_CONTRACT.md
+++ b/docs/features/airo-tv/SECURE_WEBSOCKET_TRANSPORT_CONTRACT.md
@@ -1,0 +1,87 @@
+# Secure WebSocket Transport Contract
+
+Status: v2 platform contract for ATV-033.
+
+## Ownership
+
+Secure command and state transport is platform/framework behavior. Airo TV,
+companion controllers, home nodes, local discovery, command routing, session
+sync, route health, compact EPG sync, and future cloud coordination consume the
+same contract instead of adding product-specific socket shortcuts.
+
+The contract lives in `packages/core_protocol` because it defines versioned
+transport metadata, handshake validation, frame validation, redaction, fake
+adapters, and no-op adapters. `core_pairing` owns pairing and trust semantics,
+`core_commands` owns command payload semantics, and `core_sessions` owns
+playback/session state semantics.
+
+## Non-Goals
+
+This issue does not implement:
+
+- real WebSocket clients or servers
+- TLS certificate storage, pinning, or platform key generation
+- cloud relay/provider selection
+- push wake behavior
+- command dispatch
+- playback execution
+- persistent device records
+- app UI
+
+## Contract Shape
+
+`AiroSecureTransportEndpointDescriptor` describes a transport endpoint by stable
+id, channel kind, secure scheme, supported auth modes, supported frame kinds,
+frame-size budget, heartbeat interval, reconnect base delay, and trust
+requirements.
+
+`AiroSecureTransportHandshakeOffer` describes a redacted connection attempt from
+a peer device. It carries stable peer id, trust state, auth mode, proof
+presence, issue/expiry timestamps, optional credential expiry, and requested
+frame families.
+
+`AiroSecureTransportFrameProbe` describes a frame before it is sent or accepted.
+It carries stable frame id, frame kind, monotonic sequence, issue timestamp,
+payload byte count, proof presence, and an optional redacted diagnostic
+reference.
+
+`AiroSecureTransportPolicy` validates:
+
+- schema version
+- protocol version range
+- secure scheme per channel kind
+- supported auth mode
+- proof presence
+- handshake expiry
+- credential expiry
+- trusted peer state
+- supported frame kinds
+- positive monotonic sequence
+- replayed sequence
+- frame size
+- stale/future frame timestamps
+- safe diagnostic references
+
+`AiroSecureTransportAdapter` is the provider boundary. `AiroNoOpSecureTransportAdapter`
+rejects all work for products without transport support. `AiroFakeSecureTransportAdapter`
+validates and records frame probes for deterministic host-side tests without
+opening sockets.
+
+## Privacy
+
+Transport descriptors, offers, frame probes, and validation results expose only
+stable ids, channel/scheme/auth/frame families, timing metadata, payload byte
+counts, sequence numbers, proof presence, trust state, and blocker codes. They
+must not expose raw URLs, local IP addresses, request headers, provider payloads,
+credentials, media titles, search text, viewing history, analytics payloads, or
+diagnostic dumps.
+
+## Automation
+
+- Unit tests use fixed clocks and fake descriptors.
+- Handshake tests cover accepted, insecure scheme, missing proof, expired
+  handshake/credential, untrusted peer, and unsupported frame kinds.
+- Frame tests cover accepted, replayed sequence, oversized payload, stale/future
+  timestamps, unsupported frame kind, missing proof, and unsafe diagnostic ref.
+- Adapter tests cover no-op rejection and fake adapter recording without opening
+  sockets.

--- a/packages/core_protocol/README.md
+++ b/packages/core_protocol/README.md
@@ -19,6 +19,9 @@ without leaking private media or account data.
   route health, compact EPG sync, and acknowledgements.
 - Compatibility policy for schema/protocol version, replay sequence, payload
   size, required fields, reserved fields, and stable ids.
+- Secure transport descriptors for WSS/HTTP3-compatible command and state sync.
+- Handshake/frame policies for proof presence, trusted peers, replay, frame
+  size, stale frames, and redacted diagnostics.
 
 This package does not discover devices, open sockets, store trust records,
 render pairing UI, send commands, maintain presence leases, index media, relay

--- a/packages/core_protocol/lib/core_protocol.dart
+++ b/packages/core_protocol/lib/core_protocol.dart
@@ -3,3 +3,4 @@ library;
 export 'src/connected_node_models.dart';
 export 'src/edge_media_node_models.dart';
 export 'src/protobuf_protocol_schema_models.dart';
+export 'src/secure_transport_models.dart';

--- a/packages/core_protocol/lib/src/secure_transport_models.dart
+++ b/packages/core_protocol/lib/src/secure_transport_models.dart
@@ -1,0 +1,671 @@
+import 'package:equatable/equatable.dart';
+
+import 'connected_node_models.dart';
+
+const String kAiroSecureTransportSchemaVersion = '1.0.0';
+const int kAiroSecureTransportProtocolVersion = 1;
+const int kAiroSecureTransportDefaultMaxFrameBytes = 64 * 1024;
+const Duration kAiroSecureTransportDefaultClockSkew = Duration(seconds: 30);
+const Duration kAiroSecureTransportDefaultHeartbeat = Duration(seconds: 15);
+const Duration kAiroSecureTransportDefaultReconnectBaseDelay = Duration(
+  milliseconds: 250,
+);
+
+enum AiroSecureTransportChannelKind {
+  localWebSocket('local_websocket'),
+  cloudWebSocket('cloud_websocket'),
+  futureHttp3('future_http3'),
+  inMemoryTest('in_memory_test');
+
+  const AiroSecureTransportChannelKind(this.stableId);
+
+  final String stableId;
+}
+
+enum AiroSecureTransportScheme {
+  wss('wss'),
+  httpsHttp3('https_http3'),
+  ws('ws'),
+  inMemory('in_memory');
+
+  const AiroSecureTransportScheme(this.stableId);
+
+  final String stableId;
+}
+
+enum AiroSecureTransportAuthMode {
+  pairingProof('pairing_proof'),
+  deviceSignature('device_signature'),
+  sessionTicket('session_ticket'),
+  cloudCredential('cloud_credential'),
+  testHarness('test_harness');
+
+  const AiroSecureTransportAuthMode(this.stableId);
+
+  final String stableId;
+}
+
+enum AiroSecureTransportFrameKind {
+  command('command'),
+  playbackState('playback_state'),
+  routeHealth('route_health'),
+  epgSync('epg_sync'),
+  acknowledgement('acknowledgement'),
+  heartbeat('heartbeat'),
+  snapshotRequest('snapshot_request'),
+  snapshotResponse('snapshot_response');
+
+  const AiroSecureTransportFrameKind(this.stableId);
+
+  final String stableId;
+}
+
+enum AiroSecureTransportLifecycleState {
+  idle('idle'),
+  connecting('connecting'),
+  open('open'),
+  degraded('degraded'),
+  reconnecting('reconnecting'),
+  refreshingCredential('refreshing_credential'),
+  suspended('suspended'),
+  closed('closed'),
+  failed('failed');
+
+  const AiroSecureTransportLifecycleState(this.stableId);
+
+  final String stableId;
+
+  bool get allowsFrameSend =>
+      this == open || this == degraded || this == reconnecting;
+}
+
+enum AiroSecureTransportBlockerCode {
+  accepted('accepted'),
+  schemaMismatch('schema_mismatch'),
+  protocolTooOld('protocol_too_old'),
+  protocolTooNew('protocol_too_new'),
+  insecureScheme('insecure_scheme'),
+  unsupportedAuthMode('unsupported_auth_mode'),
+  missingAuthProof('missing_auth_proof'),
+  expiredHandshake('expired_handshake'),
+  expiredCredential('expired_credential'),
+  untrustedPeer('untrusted_peer'),
+  unsupportedFrameKind('unsupported_frame_kind'),
+  oversizedFrame('oversized_frame'),
+  nonPositiveSequence('non_positive_sequence'),
+  replayedFrame('replayed_frame'),
+  staleFrame('stale_frame'),
+  futureFrame('future_frame'),
+  unsafeStableId('unsafe_stable_id'),
+  adapterUnavailable('adapter_unavailable'),
+  notConnected('not_connected');
+
+  const AiroSecureTransportBlockerCode(this.stableId);
+
+  final String stableId;
+}
+
+enum AiroSecureTransportStableValueRejectionCode {
+  empty('empty'),
+  urlValue('url_value'),
+  localPathValue('local_path_value'),
+  localIpValue('local_ip_value'),
+  credentialLikeValue('credential_like_value'),
+  invalidStableId('invalid_stable_id');
+
+  const AiroSecureTransportStableValueRejectionCode(this.stableId);
+
+  final String stableId;
+}
+
+class AiroSecureTransportStableValue extends Equatable {
+  const AiroSecureTransportStableValue._(this.value);
+
+  factory AiroSecureTransportStableValue.stable(String value) {
+    final rejection = validate(value);
+    if (rejection != null) {
+      throw ArgumentError.value(value, 'value', rejection.stableId);
+    }
+    return AiroSecureTransportStableValue._(value.trim());
+  }
+
+  final String value;
+
+  static AiroSecureTransportStableValueRejectionCode? validate(String value) {
+    final trimmed = value.trim();
+    if (trimmed.isEmpty) {
+      return AiroSecureTransportStableValueRejectionCode.empty;
+    }
+    final uri = Uri.tryParse(trimmed);
+    if (uri != null && (uri.scheme == 'http' || uri.scheme == 'https')) {
+      return AiroSecureTransportStableValueRejectionCode.urlValue;
+    }
+    if (trimmed.startsWith('file://') ||
+        trimmed.startsWith('/') ||
+        RegExp(r'^[A-Za-z]:\\').hasMatch(trimmed)) {
+      return AiroSecureTransportStableValueRejectionCode.localPathValue;
+    }
+    if (RegExp(
+      r'\b(?:10|127|172\.(?:1[6-9]|2\d|3[0-1])|192\.168)\.',
+    ).hasMatch(trimmed)) {
+      return AiroSecureTransportStableValueRejectionCode.localIpValue;
+    }
+    if (RegExp(
+      r'\b(?:bearer|basic)\s+[A-Za-z0-9._~+/=-]+',
+      caseSensitive: false,
+    ).hasMatch(trimmed)) {
+      return AiroSecureTransportStableValueRejectionCode.credentialLikeValue;
+    }
+    if (!RegExp(r'^[A-Za-z][A-Za-z0-9_.-]*$').hasMatch(trimmed)) {
+      return AiroSecureTransportStableValueRejectionCode.invalidStableId;
+    }
+    return null;
+  }
+
+  @override
+  String toString() => 'AiroSecureTransportStableValue(redacted)';
+
+  @override
+  List<Object?> get props => [value];
+}
+
+class AiroSecureTransportEndpointDescriptor extends Equatable {
+  AiroSecureTransportEndpointDescriptor({
+    required this.endpointId,
+    required this.channelKind,
+    required this.scheme,
+    required Set<AiroSecureTransportAuthMode> authModes,
+    required Set<AiroSecureTransportFrameKind> frameKinds,
+    this.requiresTrustedPeer = true,
+    this.maxFrameBytes = kAiroSecureTransportDefaultMaxFrameBytes,
+    this.heartbeatInterval = kAiroSecureTransportDefaultHeartbeat,
+    this.reconnectBaseDelay = kAiroSecureTransportDefaultReconnectBaseDelay,
+    this.schemaVersion = kAiroSecureTransportSchemaVersion,
+    this.protocolVersion = kAiroSecureTransportProtocolVersion,
+  }) : authModes = Set.unmodifiable(authModes),
+       frameKinds = Set.unmodifiable(frameKinds);
+
+  final String schemaVersion;
+  final int protocolVersion;
+  final AiroSecureTransportStableValue endpointId;
+  final AiroSecureTransportChannelKind channelKind;
+  final AiroSecureTransportScheme scheme;
+  final Set<AiroSecureTransportAuthMode> authModes;
+  final Set<AiroSecureTransportFrameKind> frameKinds;
+  final bool requiresTrustedPeer;
+  final int maxFrameBytes;
+  final Duration heartbeatInterval;
+  final Duration reconnectBaseDelay;
+
+  bool supports(AiroSecureTransportFrameKind frameKind) {
+    return frameKinds.contains(frameKind);
+  }
+
+  @override
+  String toString() {
+    return 'AiroSecureTransportEndpointDescriptor('
+        'endpointId: ${endpointId.value}, '
+        'channelKind: ${channelKind.stableId}, '
+        'scheme: ${scheme.stableId}, '
+        'authModes: ${authModes.map((mode) => mode.stableId).join(',')}, '
+        'frameKinds: ${frameKinds.map((kind) => kind.stableId).join(',')}, '
+        'requiresTrustedPeer: $requiresTrustedPeer'
+        ')';
+  }
+
+  @override
+  List<Object?> get props => [
+    schemaVersion,
+    protocolVersion,
+    endpointId,
+    channelKind,
+    scheme,
+    authModes,
+    frameKinds,
+    requiresTrustedPeer,
+    maxFrameBytes,
+    heartbeatInterval,
+    reconnectBaseDelay,
+  ];
+}
+
+class AiroSecureTransportHandshakeOffer extends Equatable {
+  AiroSecureTransportHandshakeOffer({
+    required this.endpoint,
+    required this.peerNodeId,
+    required this.peerTrustState,
+    required this.authMode,
+    required this.proofPresent,
+    required this.issuedAt,
+    required this.expiresAt,
+    required Set<AiroSecureTransportFrameKind> requestedFrameKinds,
+    this.credentialExpiresAt,
+    this.schemaVersion = kAiroSecureTransportSchemaVersion,
+    this.protocolVersion = kAiroSecureTransportProtocolVersion,
+  }) : requestedFrameKinds = Set.unmodifiable(requestedFrameKinds);
+
+  final String schemaVersion;
+  final int protocolVersion;
+  final AiroSecureTransportEndpointDescriptor endpoint;
+  final AiroSecureTransportStableValue peerNodeId;
+  final AiroNodeTrustState peerTrustState;
+  final AiroSecureTransportAuthMode authMode;
+  final bool proofPresent;
+  final DateTime issuedAt;
+  final DateTime expiresAt;
+  final DateTime? credentialExpiresAt;
+  final Set<AiroSecureTransportFrameKind> requestedFrameKinds;
+
+  @override
+  String toString() {
+    return 'AiroSecureTransportHandshakeOffer('
+        'endpointId: ${endpoint.endpointId.value}, '
+        'peerNodeId: ${peerNodeId.value}, '
+        'peerTrustState: ${peerTrustState.stableId}, '
+        'authMode: ${authMode.stableId}, '
+        'proofPresent: $proofPresent, '
+        'issuedAt: $issuedAt, '
+        'expiresAt: $expiresAt'
+        ')';
+  }
+
+  @override
+  List<Object?> get props => [
+    schemaVersion,
+    protocolVersion,
+    endpoint,
+    peerNodeId,
+    peerTrustState,
+    authMode,
+    proofPresent,
+    issuedAt,
+    expiresAt,
+    credentialExpiresAt,
+    requestedFrameKinds,
+  ];
+}
+
+class AiroSecureTransportFrameProbe extends Equatable {
+  const AiroSecureTransportFrameProbe({
+    required this.frameId,
+    required this.kind,
+    required this.sequence,
+    required this.issuedAt,
+    required this.payloadBytes,
+    this.proofPresent = true,
+    this.diagnosticRef,
+    this.schemaVersion = kAiroSecureTransportSchemaVersion,
+    this.protocolVersion = kAiroSecureTransportProtocolVersion,
+  });
+
+  final String schemaVersion;
+  final int protocolVersion;
+  final AiroSecureTransportStableValue frameId;
+  final AiroSecureTransportFrameKind kind;
+  final int sequence;
+  final DateTime issuedAt;
+  final int payloadBytes;
+  final bool proofPresent;
+  final String? diagnosticRef;
+
+  Map<String, Object?> toDiagnosticMap() {
+    return {
+      'schemaVersion': schemaVersion,
+      'protocolVersion': protocolVersion,
+      'frameId': frameId.value,
+      'kind': kind.stableId,
+      'sequence': sequence,
+      'payloadBytes': payloadBytes,
+      'proofPresent': proofPresent,
+      'hasDiagnosticRef': diagnosticRef != null,
+    };
+  }
+
+  @override
+  String toString() {
+    return 'AiroSecureTransportFrameProbe('
+        'frameId: ${frameId.value}, '
+        'kind: ${kind.stableId}, '
+        'sequence: $sequence, '
+        'payloadBytes: $payloadBytes, '
+        'hasDiagnosticRef: ${diagnosticRef != null}'
+        ')';
+  }
+
+  @override
+  List<Object?> get props => [
+    schemaVersion,
+    protocolVersion,
+    frameId,
+    kind,
+    sequence,
+    issuedAt,
+    payloadBytes,
+    proofPresent,
+    diagnosticRef,
+  ];
+}
+
+class AiroSecureTransportValidationResult extends Equatable {
+  AiroSecureTransportValidationResult({
+    required this.endpointId,
+    required Iterable<AiroSecureTransportBlockerCode> codes,
+    this.peerNodeId,
+    this.frameId,
+    this.sequence,
+  }) : codes = List.unmodifiable(codes);
+
+  final AiroSecureTransportStableValue endpointId;
+  final AiroSecureTransportStableValue? peerNodeId;
+  final AiroSecureTransportStableValue? frameId;
+  final int? sequence;
+  final List<AiroSecureTransportBlockerCode> codes;
+
+  bool get accepted =>
+      codes.length == 1 &&
+      codes.single == AiroSecureTransportBlockerCode.accepted;
+
+  Map<String, Object?> toDiagnosticMap() {
+    return {
+      'endpointId': endpointId.value,
+      'peerNodeId': peerNodeId?.value,
+      'frameId': frameId?.value,
+      'sequence': sequence,
+      'accepted': accepted,
+      'codes': codes.map((code) => code.stableId).toList(growable: false),
+    };
+  }
+
+  @override
+  List<Object?> get props => [endpointId, peerNodeId, frameId, sequence, codes];
+}
+
+class AiroSecureTransportPolicy extends Equatable {
+  AiroSecureTransportPolicy({
+    Set<AiroSecureTransportFrameKind> requiredFrameKinds = const {},
+    Set<AiroNodeTrustState> trustedPeerStates = const {
+      AiroNodeTrustState.paired,
+      AiroNodeTrustState.trusted,
+    },
+    this.acceptedSchemaVersion = kAiroSecureTransportSchemaVersion,
+    this.minProtocolVersion = kAiroSecureTransportProtocolVersion,
+    this.maxProtocolVersion = kAiroSecureTransportProtocolVersion,
+    this.maxFrameBytes = kAiroSecureTransportDefaultMaxFrameBytes,
+    this.maxClockSkew = kAiroSecureTransportDefaultClockSkew,
+  }) : requiredFrameKinds = Set.unmodifiable(requiredFrameKinds),
+       trustedPeerStates = Set.unmodifiable(trustedPeerStates);
+
+  final String acceptedSchemaVersion;
+  final int minProtocolVersion;
+  final int maxProtocolVersion;
+  final int maxFrameBytes;
+  final Duration maxClockSkew;
+  final Set<AiroSecureTransportFrameKind> requiredFrameKinds;
+  final Set<AiroNodeTrustState> trustedPeerStates;
+
+  AiroSecureTransportValidationResult validateHandshake({
+    required AiroSecureTransportHandshakeOffer offer,
+    required DateTime now,
+  }) {
+    final codes = <AiroSecureTransportBlockerCode>[];
+    final endpoint = offer.endpoint;
+    _addVersionCodes(
+      schemaVersion: offer.schemaVersion,
+      protocolVersion: offer.protocolVersion,
+      codes: codes,
+    );
+    _addVersionCodes(
+      schemaVersion: endpoint.schemaVersion,
+      protocolVersion: endpoint.protocolVersion,
+      codes: codes,
+    );
+
+    if (!_schemeMatchesChannel(endpoint.channelKind, endpoint.scheme)) {
+      codes.add(AiroSecureTransportBlockerCode.insecureScheme);
+    }
+    if (!endpoint.authModes.contains(offer.authMode)) {
+      codes.add(AiroSecureTransportBlockerCode.unsupportedAuthMode);
+    }
+    if (!offer.proofPresent) {
+      codes.add(AiroSecureTransportBlockerCode.missingAuthProof);
+    }
+    if (!now.isBefore(offer.expiresAt)) {
+      codes.add(AiroSecureTransportBlockerCode.expiredHandshake);
+    }
+    final credentialExpiresAt = offer.credentialExpiresAt;
+    if (credentialExpiresAt != null && !now.isBefore(credentialExpiresAt)) {
+      codes.add(AiroSecureTransportBlockerCode.expiredCredential);
+    }
+    if (endpoint.requiresTrustedPeer &&
+        !trustedPeerStates.contains(offer.peerTrustState)) {
+      codes.add(AiroSecureTransportBlockerCode.untrustedPeer);
+    }
+    if (!endpoint.frameKinds.containsAll(requiredFrameKinds) ||
+        !offer.requestedFrameKinds.containsAll(requiredFrameKinds) ||
+        !endpoint.frameKinds.containsAll(offer.requestedFrameKinds)) {
+      codes.add(AiroSecureTransportBlockerCode.unsupportedFrameKind);
+    }
+
+    return AiroSecureTransportValidationResult(
+      endpointId: endpoint.endpointId,
+      peerNodeId: offer.peerNodeId,
+      codes: codes.isEmpty
+          ? const [AiroSecureTransportBlockerCode.accepted]
+          : codes,
+    );
+  }
+
+  AiroSecureTransportValidationResult validateFrame({
+    required AiroSecureTransportEndpointDescriptor endpoint,
+    required AiroSecureTransportFrameProbe frame,
+    required DateTime now,
+    Set<int> acceptedSequences = const {},
+  }) {
+    final codes = <AiroSecureTransportBlockerCode>[];
+    _addVersionCodes(
+      schemaVersion: frame.schemaVersion,
+      protocolVersion: frame.protocolVersion,
+      codes: codes,
+    );
+    _addVersionCodes(
+      schemaVersion: endpoint.schemaVersion,
+      protocolVersion: endpoint.protocolVersion,
+      codes: codes,
+    );
+
+    if (!endpoint.supports(frame.kind)) {
+      codes.add(AiroSecureTransportBlockerCode.unsupportedFrameKind);
+    }
+    if (frame.sequence <= 0) {
+      codes.add(AiroSecureTransportBlockerCode.nonPositiveSequence);
+    }
+    if (acceptedSequences.contains(frame.sequence)) {
+      codes.add(AiroSecureTransportBlockerCode.replayedFrame);
+    }
+    if (frame.payloadBytes > maxFrameBytes ||
+        frame.payloadBytes > endpoint.maxFrameBytes) {
+      codes.add(AiroSecureTransportBlockerCode.oversizedFrame);
+    }
+    if (!frame.proofPresent &&
+        frame.kind != AiroSecureTransportFrameKind.heartbeat) {
+      codes.add(AiroSecureTransportBlockerCode.missingAuthProof);
+    }
+    if (frame.issuedAt.isBefore(now.subtract(maxClockSkew))) {
+      codes.add(AiroSecureTransportBlockerCode.staleFrame);
+    }
+    if (frame.issuedAt.isAfter(now.add(maxClockSkew))) {
+      codes.add(AiroSecureTransportBlockerCode.futureFrame);
+    }
+    final diagnosticRef = frame.diagnosticRef;
+    if (diagnosticRef != null &&
+        AiroSecureTransportStableValue.validate(diagnosticRef) != null) {
+      codes.add(AiroSecureTransportBlockerCode.unsafeStableId);
+    }
+
+    return AiroSecureTransportValidationResult(
+      endpointId: endpoint.endpointId,
+      frameId: frame.frameId,
+      sequence: frame.sequence,
+      codes: codes.isEmpty
+          ? const [AiroSecureTransportBlockerCode.accepted]
+          : codes,
+    );
+  }
+
+  void _addVersionCodes({
+    required String schemaVersion,
+    required int protocolVersion,
+    required List<AiroSecureTransportBlockerCode> codes,
+  }) {
+    if (schemaVersion != acceptedSchemaVersion) {
+      codes.add(AiroSecureTransportBlockerCode.schemaMismatch);
+    }
+    if (protocolVersion < minProtocolVersion) {
+      codes.add(AiroSecureTransportBlockerCode.protocolTooOld);
+    }
+    if (protocolVersion > maxProtocolVersion) {
+      codes.add(AiroSecureTransportBlockerCode.protocolTooNew);
+    }
+  }
+
+  bool _schemeMatchesChannel(
+    AiroSecureTransportChannelKind channelKind,
+    AiroSecureTransportScheme scheme,
+  ) {
+    switch (channelKind) {
+      case AiroSecureTransportChannelKind.localWebSocket:
+      case AiroSecureTransportChannelKind.cloudWebSocket:
+        return scheme == AiroSecureTransportScheme.wss;
+      case AiroSecureTransportChannelKind.futureHttp3:
+        return scheme == AiroSecureTransportScheme.httpsHttp3;
+      case AiroSecureTransportChannelKind.inMemoryTest:
+        return scheme == AiroSecureTransportScheme.inMemory;
+    }
+  }
+
+  @override
+  List<Object?> get props => [
+    acceptedSchemaVersion,
+    minProtocolVersion,
+    maxProtocolVersion,
+    maxFrameBytes,
+    maxClockSkew,
+    requiredFrameKinds,
+    trustedPeerStates,
+  ];
+}
+
+abstract interface class AiroSecureTransportAdapter {
+  AiroSecureTransportLifecycleState get state;
+
+  Future<AiroSecureTransportValidationResult> connect(
+    AiroSecureTransportHandshakeOffer offer, {
+    required DateTime now,
+  });
+
+  Future<AiroSecureTransportValidationResult> sendFrame(
+    AiroSecureTransportFrameProbe frame, {
+    required DateTime now,
+  });
+
+  Future<void> close();
+}
+
+class AiroNoOpSecureTransportAdapter implements AiroSecureTransportAdapter {
+  const AiroNoOpSecureTransportAdapter(this.endpoint);
+
+  final AiroSecureTransportEndpointDescriptor endpoint;
+
+  @override
+  AiroSecureTransportLifecycleState get state =>
+      AiroSecureTransportLifecycleState.closed;
+
+  @override
+  Future<AiroSecureTransportValidationResult> connect(
+    AiroSecureTransportHandshakeOffer offer, {
+    required DateTime now,
+  }) async {
+    return AiroSecureTransportValidationResult(
+      endpointId: endpoint.endpointId,
+      peerNodeId: offer.peerNodeId,
+      codes: const [AiroSecureTransportBlockerCode.adapterUnavailable],
+    );
+  }
+
+  @override
+  Future<AiroSecureTransportValidationResult> sendFrame(
+    AiroSecureTransportFrameProbe frame, {
+    required DateTime now,
+  }) async {
+    return AiroSecureTransportValidationResult(
+      endpointId: endpoint.endpointId,
+      frameId: frame.frameId,
+      sequence: frame.sequence,
+      codes: const [AiroSecureTransportBlockerCode.adapterUnavailable],
+    );
+  }
+
+  @override
+  Future<void> close() async {}
+}
+
+class AiroFakeSecureTransportAdapter implements AiroSecureTransportAdapter {
+  AiroFakeSecureTransportAdapter({
+    required this.endpoint,
+    required this.policy,
+  });
+
+  final AiroSecureTransportEndpointDescriptor endpoint;
+  final AiroSecureTransportPolicy policy;
+  final List<AiroSecureTransportFrameProbe> sentFrames = [];
+  final Set<int> _acceptedSequences = {};
+  AiroSecureTransportLifecycleState _state =
+      AiroSecureTransportLifecycleState.idle;
+
+  @override
+  AiroSecureTransportLifecycleState get state => _state;
+
+  @override
+  Future<AiroSecureTransportValidationResult> connect(
+    AiroSecureTransportHandshakeOffer offer, {
+    required DateTime now,
+  }) async {
+    _state = AiroSecureTransportLifecycleState.connecting;
+    final result = policy.validateHandshake(offer: offer, now: now);
+    _state = result.accepted
+        ? AiroSecureTransportLifecycleState.open
+        : AiroSecureTransportLifecycleState.failed;
+    return result;
+  }
+
+  @override
+  Future<AiroSecureTransportValidationResult> sendFrame(
+    AiroSecureTransportFrameProbe frame, {
+    required DateTime now,
+  }) async {
+    if (!state.allowsFrameSend) {
+      return AiroSecureTransportValidationResult(
+        endpointId: endpoint.endpointId,
+        frameId: frame.frameId,
+        sequence: frame.sequence,
+        codes: const [AiroSecureTransportBlockerCode.notConnected],
+      );
+    }
+    final result = policy.validateFrame(
+      endpoint: endpoint,
+      frame: frame,
+      now: now,
+      acceptedSequences: _acceptedSequences,
+    );
+    if (result.accepted) {
+      _acceptedSequences.add(frame.sequence);
+      sentFrames.add(frame);
+    }
+    return result;
+  }
+
+  @override
+  Future<void> close() async {
+    _state = AiroSecureTransportLifecycleState.closed;
+  }
+}

--- a/packages/core_protocol/test/secure_transport_models_test.dart
+++ b/packages/core_protocol/test/secure_transport_models_test.dart
@@ -1,0 +1,302 @@
+import 'package:core_protocol/core_protocol.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('Airo secure transport contract', () {
+    final now = DateTime.utc(2026, 7, 14, 10);
+    final endpoint = _endpoint();
+    final policy = AiroSecureTransportPolicy(
+      requiredFrameKinds: const {
+        AiroSecureTransportFrameKind.command,
+        AiroSecureTransportFrameKind.playbackState,
+        AiroSecureTransportFrameKind.routeHealth,
+      },
+    );
+
+    test('accepts paired WSS handshake and command frame', () {
+      final handshake = policy.validateHandshake(
+        offer: _offer(endpoint: endpoint, now: now),
+        now: now,
+      );
+      final frame = policy.validateFrame(
+        endpoint: endpoint,
+        frame: _frame(now: now),
+        now: now,
+      );
+
+      expect(handshake.accepted, isTrue);
+      expect(frame.accepted, isTrue);
+      expect(
+        frame.toDiagnosticMap(),
+        containsPair('codes', [
+          AiroSecureTransportBlockerCode.accepted.stableId,
+        ]),
+      );
+    });
+
+    test('rejects insecure missing proof untrusted and expired handshakes', () {
+      final insecureEndpoint = _endpoint(
+        scheme: AiroSecureTransportScheme.ws,
+        authModes: const {AiroSecureTransportAuthMode.deviceSignature},
+      );
+      final result = policy.validateHandshake(
+        offer: _offer(
+          endpoint: insecureEndpoint,
+          now: now,
+          authMode: AiroSecureTransportAuthMode.pairingProof,
+          proofPresent: false,
+          peerTrustState: AiroNodeTrustState.revoked,
+          expiresAt: now.subtract(const Duration(seconds: 1)),
+          credentialExpiresAt: now,
+        ),
+        now: now,
+      );
+
+      expect(
+        result.codes,
+        contains(AiroSecureTransportBlockerCode.insecureScheme),
+      );
+      expect(
+        result.codes,
+        contains(AiroSecureTransportBlockerCode.unsupportedAuthMode),
+      );
+      expect(
+        result.codes,
+        contains(AiroSecureTransportBlockerCode.missingAuthProof),
+      );
+      expect(
+        result.codes,
+        contains(AiroSecureTransportBlockerCode.expiredHandshake),
+      );
+      expect(
+        result.codes,
+        contains(AiroSecureTransportBlockerCode.expiredCredential),
+      );
+      expect(
+        result.codes,
+        contains(AiroSecureTransportBlockerCode.untrustedPeer),
+      );
+    });
+
+    test('rejects unsupported handshake frame families', () {
+      final result = policy.validateHandshake(
+        offer: _offer(
+          endpoint: endpoint,
+          now: now,
+          requestedFrameKinds: const {
+            AiroSecureTransportFrameKind.command,
+            AiroSecureTransportFrameKind.snapshotResponse,
+          },
+        ),
+        now: now,
+      );
+
+      expect(
+        result.codes,
+        contains(AiroSecureTransportBlockerCode.unsupportedFrameKind),
+      );
+    });
+
+    test('rejects frame replay size time proof and diagnostic failures', () {
+      final result = policy.validateFrame(
+        endpoint: endpoint,
+        now: now,
+        acceptedSequences: const {8},
+        frame: _frame(
+          now: now,
+          kind: AiroSecureTransportFrameKind.epgSync,
+          sequence: 8,
+          payloadBytes: kAiroSecureTransportDefaultMaxFrameBytes + 1,
+          proofPresent: false,
+          issuedAt: now.subtract(const Duration(minutes: 2)),
+          diagnosticRef: 'https://example.com/raw-diagnostic',
+        ),
+      );
+
+      expect(
+        result.codes,
+        contains(AiroSecureTransportBlockerCode.unsupportedFrameKind),
+      );
+      expect(
+        result.codes,
+        contains(AiroSecureTransportBlockerCode.replayedFrame),
+      );
+      expect(
+        result.codes,
+        contains(AiroSecureTransportBlockerCode.oversizedFrame),
+      );
+      expect(
+        result.codes,
+        contains(AiroSecureTransportBlockerCode.missingAuthProof),
+      );
+      expect(result.codes, contains(AiroSecureTransportBlockerCode.staleFrame));
+      expect(
+        result.codes,
+        contains(AiroSecureTransportBlockerCode.unsafeStableId),
+      );
+    });
+
+    test('rejects non-positive and future frames', () {
+      final result = policy.validateFrame(
+        endpoint: endpoint,
+        now: now,
+        frame: _frame(
+          now: now,
+          sequence: 0,
+          issuedAt: now.add(const Duration(minutes: 2)),
+        ),
+      );
+
+      expect(
+        result.codes,
+        contains(AiroSecureTransportBlockerCode.nonPositiveSequence),
+      );
+      expect(
+        result.codes,
+        contains(AiroSecureTransportBlockerCode.futureFrame),
+      );
+    });
+
+    test('stable value rejects raw network and credential material', () {
+      expect(
+        () =>
+            AiroSecureTransportStableValue.stable('https://example.com/socket'),
+        throwsArgumentError,
+      );
+      expect(
+        () => AiroSecureTransportStableValue.stable('/Users/me/socket'),
+        throwsArgumentError,
+      );
+      expect(
+        () => AiroSecureTransportStableValue.stable('192.168.1.42'),
+        throwsArgumentError,
+      );
+      expect(
+        () => AiroSecureTransportStableValue.stable('Basic abc123'),
+        throwsArgumentError,
+      );
+    });
+
+    test('no-op adapter rejects without opening transport', () async {
+      final adapter = AiroNoOpSecureTransportAdapter(endpoint);
+
+      final connectResult = await adapter.connect(
+        _offer(endpoint: endpoint, now: now),
+        now: now,
+      );
+      final sendResult = await adapter.sendFrame(_frame(now: now), now: now);
+
+      expect(adapter.state, AiroSecureTransportLifecycleState.closed);
+      expect(
+        connectResult.codes,
+        contains(AiroSecureTransportBlockerCode.adapterUnavailable),
+      );
+      expect(
+        sendResult.codes,
+        contains(AiroSecureTransportBlockerCode.adapterUnavailable),
+      );
+    });
+
+    test('fake adapter validates and records accepted frame probes', () async {
+      final adapter = AiroFakeSecureTransportAdapter(
+        endpoint: endpoint,
+        policy: policy,
+      );
+
+      final beforeConnect = await adapter.sendFrame(_frame(now: now), now: now);
+      final connectResult = await adapter.connect(
+        _offer(endpoint: endpoint, now: now),
+        now: now,
+      );
+      final firstSend = await adapter.sendFrame(_frame(now: now), now: now);
+      final replaySend = await adapter.sendFrame(_frame(now: now), now: now);
+
+      expect(
+        beforeConnect.codes,
+        contains(AiroSecureTransportBlockerCode.notConnected),
+      );
+      expect(connectResult.accepted, isTrue);
+      expect(firstSend.accepted, isTrue);
+      expect(
+        replaySend.codes,
+        contains(AiroSecureTransportBlockerCode.replayedFrame),
+      );
+      expect(adapter.sentFrames, hasLength(1));
+
+      await adapter.close();
+      expect(adapter.state, AiroSecureTransportLifecycleState.closed);
+    });
+  });
+}
+
+AiroSecureTransportEndpointDescriptor _endpoint({
+  AiroSecureTransportScheme scheme = AiroSecureTransportScheme.wss,
+  Set<AiroSecureTransportAuthMode> authModes = const {
+    AiroSecureTransportAuthMode.deviceSignature,
+    AiroSecureTransportAuthMode.pairingProof,
+  },
+}) {
+  return AiroSecureTransportEndpointDescriptor(
+    endpointId: AiroSecureTransportStableValue.stable('receiver-wss-primary'),
+    channelKind: AiroSecureTransportChannelKind.localWebSocket,
+    scheme: scheme,
+    authModes: authModes,
+    frameKinds: const {
+      AiroSecureTransportFrameKind.command,
+      AiroSecureTransportFrameKind.playbackState,
+      AiroSecureTransportFrameKind.routeHealth,
+      AiroSecureTransportFrameKind.acknowledgement,
+      AiroSecureTransportFrameKind.heartbeat,
+      AiroSecureTransportFrameKind.snapshotRequest,
+    },
+  );
+}
+
+AiroSecureTransportHandshakeOffer _offer({
+  required AiroSecureTransportEndpointDescriptor endpoint,
+  required DateTime now,
+  AiroSecureTransportAuthMode authMode =
+      AiroSecureTransportAuthMode.deviceSignature,
+  bool proofPresent = true,
+  AiroNodeTrustState peerTrustState = AiroNodeTrustState.paired,
+  DateTime? expiresAt,
+  DateTime? credentialExpiresAt,
+  Set<AiroSecureTransportFrameKind> requestedFrameKinds = const {
+    AiroSecureTransportFrameKind.command,
+    AiroSecureTransportFrameKind.playbackState,
+    AiroSecureTransportFrameKind.routeHealth,
+  },
+}) {
+  return AiroSecureTransportHandshakeOffer(
+    endpoint: endpoint,
+    peerNodeId: AiroSecureTransportStableValue.stable('phone-controller-1'),
+    peerTrustState: peerTrustState,
+    authMode: authMode,
+    proofPresent: proofPresent,
+    issuedAt: now,
+    expiresAt: expiresAt ?? now.add(const Duration(minutes: 1)),
+    credentialExpiresAt:
+        credentialExpiresAt ?? now.add(const Duration(minutes: 5)),
+    requestedFrameKinds: requestedFrameKinds,
+  );
+}
+
+AiroSecureTransportFrameProbe _frame({
+  required DateTime now,
+  AiroSecureTransportFrameKind kind = AiroSecureTransportFrameKind.command,
+  int sequence = 8,
+  int payloadBytes = 512,
+  bool proofPresent = true,
+  DateTime? issuedAt,
+  String? diagnosticRef,
+}) {
+  return AiroSecureTransportFrameProbe(
+    frameId: AiroSecureTransportStableValue.stable('frame-$sequence'),
+    kind: kind,
+    sequence: sequence,
+    issuedAt: issuedAt ?? now,
+    payloadBytes: payloadBytes,
+    proofPresent: proofPresent,
+    diagnosticRef: diagnosticRef,
+  );
+}


### PR DESCRIPTION
# Summary\n\nAdds the ATV-033 v2 platform secure WebSocket transport contract in core_protocol.\n\nGoal: define secure command/state transport metadata, handshake validation, frame validation, and adapter boundaries before real socket transport is implemented.\n\nCore outcome:\n\n* Defines reusable secure transport endpoint, handshake, frame, policy, and adapter models.\n* Adds no-op and fake adapters for deterministic host-side tests.\n* Documents platform ownership boundaries and privacy limits.\n\n# Changes\n\n### Code\n\n* Added:\n  * packages/core_protocol/lib/src/secure_transport_models.dart\n  * packages/core_protocol/test/secure_transport_models_test.dart\n  * docs/features/airo-tv/SECURE_WEBSOCKET_TRANSPORT_CONTRACT.md\n* Updated:\n  * packages/core_protocol/lib/core_protocol.dart to export the transport contract.\n  * packages/core_protocol/README.md to describe secure transport scope.\n\n### Logic\n\n* Adds transport descriptors for local WSS, future cloud WSS/HTTP3, and in-memory test channels.\n* Adds handshake checks for schema/protocol version, secure scheme, supported auth mode, proof presence, expiry, credential expiry, trusted peer state, and requested frame families.\n* Adds frame checks for supported frame kind, proof presence, positive sequence, replayed sequence, frame size, stale/future timestamps, and safe diagnostic references.\n* Adds no-op/fake adapters without opening sockets.\n\n# API Changes\n\n* New public Dart exports from core_protocol for secure transport models and adapters.\n\n# Database Changes\n\n* None.\n\n# Observability / Logging\n\n* Adds redacted diagnostic output only; no socket logs, provider telemetry, or runtime transport implementation.\n\n# Performance Impact\n\n* Runtime impact: none until consumers use the adapter contract.\n* Frame validation is bounded by stable metadata and payload byte counts.\n\n# Risks\n\n* Follow-up real transport must integrate platform TLS/key handling without leaking local-network or credential material.\n* Pairing/trust semantics must remain owned by core_pairing and not duplicated in app code.\n* Rollback plan: revert this PR before consumers depend on the export.\n\n# Testing\n\n* Unit tests:\n  * cd packages/core_protocol && flutter test\n* Static checks:\n  * dart format --set-exit-if-changed packages/core_protocol\n  * cd packages/core_protocol && flutter analyze --fatal-infos\n  * git diff --check HEAD~1..HEAD && git diff --check\n* Privacy scan:\n  * diff scanned for secret/token/password/credential/auth/API key/Firebase/network endpoint terms; hits are redaction rules and negative tests only.\n\n# Deployment Notes\n\n* No secret or environment changes required.\n\n# Related Issues\n\nCloses #623