### PR TITLE
feat(platform): add distributed EPG worker contract

### DIFF
--- a/docs/features/airo-tv/DISTRIBUTED_EPG_WORKER_CONTRACT.md
+++ b/docs/features/airo-tv/DISTRIBUTED_EPG_WORKER_CONTRACT.md
@@ -1,0 +1,85 @@
+# Distributed EPG Worker Contract
+
+Status: v2 platform contract for ATV-034.
+
+## Ownership
+
+Distributed EPG work is platform/framework behavior. Airo TV, Lite Receiver,
+companion nodes, desktop nodes, home nodes, future cloud orchestration, and QA
+automation consume this contract instead of parsing full XMLTV datasets inside
+receiver screens.
+
+The contract lives in `packages/platform_epg` because that package already owns
+compact EPG programs, slices, source refs, and repositories. `core_protocol`
+owns binary protocol families. Secure transport owns connection and frame
+validation. `core_media_data` owns benchmark dataset budgets. Product features
+own rendering and navigation.
+
+## Non-Goals
+
+This issue does not implement:
+
+- XMLTV download, decompression, or parsing
+- provider SDK imports
+- binary payload encoding
+- device transfer
+- persistent TV cache writes
+- full guide UI
+- app navigation
+- playback
+
+## Contract Shape
+
+`DistributedEpgWorkerCapability` describes what a node can do: roles, supported
+task kinds, payload formats, transfer modes, maximum request window, maximum
+channel count, maximum entry count, snapshot size budget, and cache budget.
+
+`DistributedEpgSyncRequest` asks a capable node for compact EPG work by stable
+request id, redacted source ref, requested channel ids, window start/end, task
+kind, payload format, and transfer mode.
+
+`DistributedEpgSnapshotManifest` describes a produced compact snapshot or
+incremental patch without exposing the payload: stable snapshot id, redacted
+source ref, generated/expiry timestamps, covered window, channel count, entry
+count, payload byte count, payload format, transfer mode, sequence, and
+incremental flag.
+
+`DistributedEpgWorkerPolicy` validates:
+
+- schema version
+- protocol version range
+- required worker roles
+- supported task kind
+- supported payload format
+- supported transfer mode
+- valid and bounded request window
+- channel count
+- entry count
+- snapshot byte size
+- cache budget
+- stale, expired, or future snapshots
+- snapshot window coverage
+- safe stable ids
+
+`DistributedEpgWorker` is the provider boundary. `NoOpDistributedEpgWorker`
+returns a deterministic unavailable event. `FakeDistributedEpgWorker` emits
+queued, running, snapshot-ready, failed, or cancelled events without parsing,
+network transfer, or persistence.
+
+## Privacy
+
+Worker capabilities, requests, manifests, events, and diagnostics expose only
+stable ids, redacted source refs, counts, sizes, windows, progress, sequence
+numbers, and blocker codes. They must not expose raw EPG URLs, playlist URLs,
+request headers, local paths, local addresses, provider payloads, program
+titles, viewing history, analytics payloads, or credential material.
+
+## Automation
+
+- Unit tests use fixed clocks and fake worker capabilities.
+- Request policy tests cover role, task, format, transfer mode, window, channel
+  count, and source-ref failures.
+- Snapshot policy tests cover size, cache budget, entry count, stale, expired,
+  future, and uncovered-window failures.
+- Worker adapter tests cover no-op unavailable events, fake queued/running/ready
+  events, and cancellation.

--- a/packages/platform_epg/README.md
+++ b/packages/platform_epg/README.md
@@ -15,6 +15,9 @@ or parse full XMLTV datasets.
 - Repository boundary with no-op and in-memory fake implementations.
 - Redacted EPG source references that reject raw URLs, local paths, local IP
   values, and credential-like values.
+- Distributed EPG worker capability, sync request, snapshot manifest, and
+  validation contracts for delegated compact guide processing.
+- Fake and no-op distributed worker adapters for deterministic automation.
 
 This package does not parse XMLTV, render guide UI, persist guide data, import
-vendor SDKs, or start playback.
+vendor SDKs, open sockets, transfer payloads, or start playback.

--- a/packages/platform_epg/lib/platform_epg.dart
+++ b/packages/platform_epg/lib/platform_epg.dart
@@ -1,3 +1,4 @@
 library;
 
 export 'src/compact_epg_models.dart';
+export 'src/distributed_epg_worker_models.dart';

--- a/packages/platform_epg/lib/src/distributed_epg_worker_models.dart
+++ b/packages/platform_epg/lib/src/distributed_epg_worker_models.dart
@@ -1,0 +1,688 @@
+import 'package:equatable/equatable.dart';
+
+import 'compact_epg_models.dart';
+
+const String kDistributedEpgWorkerSchemaVersion = '1.0.0';
+const int kDistributedEpgWorkerProtocolVersion = 1;
+const int kDistributedEpgDefaultMaxSnapshotBytes = 256 * 1024;
+const int kDistributedEpgDefaultMaxChannelCount = 250;
+const int kDistributedEpgDefaultMaxEntryCount = 500;
+const Duration kDistributedEpgDefaultMaxWindow = Duration(hours: 24);
+const Duration kDistributedEpgDefaultMaxSnapshotAge = Duration(minutes: 15);
+
+enum DistributedEpgWorkerRole {
+  downloader('downloader'),
+  parser('parser'),
+  normalizer('normalizer'),
+  compactor('compactor'),
+  cacheHost('cache_host'),
+  consumer('consumer');
+
+  const DistributedEpgWorkerRole(this.stableId);
+
+  final String stableId;
+}
+
+enum DistributedEpgTaskKind {
+  compactSnapshot('compact_snapshot'),
+  incrementalPatch('incremental_patch'),
+  cacheWarmup('cache_warmup'),
+  cachePrune('cache_prune');
+
+  const DistributedEpgTaskKind(this.stableId);
+
+  final String stableId;
+}
+
+enum DistributedEpgPayloadFormat {
+  compactJson('compact_json'),
+  protobufEnvelope('protobuf_envelope'),
+  binaryDelta('binary_delta');
+
+  const DistributedEpgPayloadFormat(this.stableId);
+
+  final String stableId;
+}
+
+enum DistributedEpgTransferMode {
+  fullSnapshot('full_snapshot'),
+  incrementalPatch('incremental_patch'),
+  currentNextOnly('current_next_only');
+
+  const DistributedEpgTransferMode(this.stableId);
+
+  final String stableId;
+}
+
+enum DistributedEpgWorkerEventState {
+  queued('queued'),
+  running('running'),
+  snapshotReady('snapshot_ready'),
+  cancelled('cancelled'),
+  failed('failed');
+
+  const DistributedEpgWorkerEventState(this.stableId);
+
+  final String stableId;
+}
+
+enum DistributedEpgWorkerBlockerCode {
+  accepted('accepted'),
+  schemaMismatch('schema_mismatch'),
+  protocolTooOld('protocol_too_old'),
+  protocolTooNew('protocol_too_new'),
+  missingRequiredRole('missing_required_role'),
+  unsupportedTask('unsupported_task'),
+  unsupportedFormat('unsupported_format'),
+  unsupportedTransferMode('unsupported_transfer_mode'),
+  invalidWindow('invalid_window'),
+  windowTooLarge('window_too_large'),
+  tooManyChannels('too_many_channels'),
+  tooManyEntries('too_many_entries'),
+  snapshotTooLarge('snapshot_too_large'),
+  staleSnapshot('stale_snapshot'),
+  expiredSnapshot('expired_snapshot'),
+  futureSnapshot('future_snapshot'),
+  windowNotCovered('window_not_covered'),
+  unsafeStableId('unsafe_stable_id'),
+  cacheBudgetExceeded('cache_budget_exceeded'),
+  workerUnavailable('worker_unavailable'),
+  cancelled('cancelled');
+
+  const DistributedEpgWorkerBlockerCode(this.stableId);
+
+  final String stableId;
+}
+
+enum DistributedEpgStableValueRejectionCode {
+  empty('empty'),
+  urlValue('url_value'),
+  localPathValue('local_path_value'),
+  localIpValue('local_ip_value'),
+  credentialLikeValue('credential_like_value'),
+  invalidStableId('invalid_stable_id');
+
+  const DistributedEpgStableValueRejectionCode(this.stableId);
+
+  final String stableId;
+}
+
+class DistributedEpgStableValue extends Equatable {
+  const DistributedEpgStableValue._(this.value);
+
+  factory DistributedEpgStableValue.stable(String value) {
+    final rejection = validate(value);
+    if (rejection != null) {
+      throw ArgumentError.value(value, 'value', rejection.stableId);
+    }
+    return DistributedEpgStableValue._(value.trim());
+  }
+
+  final String value;
+
+  static DistributedEpgStableValueRejectionCode? validate(String value) {
+    final trimmed = value.trim();
+    if (trimmed.isEmpty) {
+      return DistributedEpgStableValueRejectionCode.empty;
+    }
+    final uri = Uri.tryParse(trimmed);
+    if (uri != null && (uri.scheme == 'http' || uri.scheme == 'https')) {
+      return DistributedEpgStableValueRejectionCode.urlValue;
+    }
+    if (trimmed.startsWith('file://') ||
+        trimmed.startsWith('/') ||
+        RegExp(r'^[A-Za-z]:\\').hasMatch(trimmed)) {
+      return DistributedEpgStableValueRejectionCode.localPathValue;
+    }
+    if (RegExp(
+      r'\b(?:10|127|172\.(?:1[6-9]|2\d|3[0-1])|192\.168)\.',
+    ).hasMatch(trimmed)) {
+      return DistributedEpgStableValueRejectionCode.localIpValue;
+    }
+    if (RegExp(
+      r'\b(?:bearer|basic)\s+[A-Za-z0-9._~+/=-]+',
+      caseSensitive: false,
+    ).hasMatch(trimmed)) {
+      return DistributedEpgStableValueRejectionCode.credentialLikeValue;
+    }
+    if (!RegExp(r'^[A-Za-z][A-Za-z0-9_.-]*$').hasMatch(trimmed)) {
+      return DistributedEpgStableValueRejectionCode.invalidStableId;
+    }
+    return null;
+  }
+
+  @override
+  String toString() => 'DistributedEpgStableValue(redacted)';
+
+  @override
+  List<Object?> get props => [value];
+}
+
+class DistributedEpgWorkerCapability extends Equatable {
+  DistributedEpgWorkerCapability({
+    required this.workerId,
+    required Set<DistributedEpgWorkerRole> roles,
+    required Set<DistributedEpgTaskKind> supportedTasks,
+    required Set<DistributedEpgPayloadFormat> supportedFormats,
+    required Set<DistributedEpgTransferMode> supportedTransferModes,
+    this.maxWindow = kDistributedEpgDefaultMaxWindow,
+    this.maxChannelCount = kDistributedEpgDefaultMaxChannelCount,
+    this.maxEntryCount = kDistributedEpgDefaultMaxEntryCount,
+    this.maxSnapshotBytes = kDistributedEpgDefaultMaxSnapshotBytes,
+    this.cacheBudgetBytes = kDistributedEpgDefaultMaxSnapshotBytes,
+    this.schemaVersion = kDistributedEpgWorkerSchemaVersion,
+    this.protocolVersion = kDistributedEpgWorkerProtocolVersion,
+  }) : roles = Set.unmodifiable(roles),
+       supportedTasks = Set.unmodifiable(supportedTasks),
+       supportedFormats = Set.unmodifiable(supportedFormats),
+       supportedTransferModes = Set.unmodifiable(supportedTransferModes);
+
+  final String schemaVersion;
+  final int protocolVersion;
+  final DistributedEpgStableValue workerId;
+  final Set<DistributedEpgWorkerRole> roles;
+  final Set<DistributedEpgTaskKind> supportedTasks;
+  final Set<DistributedEpgPayloadFormat> supportedFormats;
+  final Set<DistributedEpgTransferMode> supportedTransferModes;
+  final Duration maxWindow;
+  final int maxChannelCount;
+  final int maxEntryCount;
+  final int maxSnapshotBytes;
+  final int cacheBudgetBytes;
+
+  bool supportsRequest(DistributedEpgSyncRequest request) {
+    return supportedTasks.contains(request.taskKind) &&
+        supportedFormats.contains(request.payloadFormat) &&
+        supportedTransferModes.contains(request.transferMode);
+  }
+
+  @override
+  String toString() {
+    return 'DistributedEpgWorkerCapability('
+        'workerId: ${workerId.value}, '
+        'roles: ${roles.map((role) => role.stableId).join(',')}, '
+        'tasks: ${supportedTasks.map((task) => task.stableId).join(',')}, '
+        'formats: ${supportedFormats.map((format) => format.stableId).join(',')}, '
+        'transferModes: ${supportedTransferModes.map((mode) => mode.stableId).join(',')}'
+        ')';
+  }
+
+  @override
+  List<Object?> get props => [
+    schemaVersion,
+    protocolVersion,
+    workerId,
+    roles,
+    supportedTasks,
+    supportedFormats,
+    supportedTransferModes,
+    maxWindow,
+    maxChannelCount,
+    maxEntryCount,
+    maxSnapshotBytes,
+    cacheBudgetBytes,
+  ];
+}
+
+class DistributedEpgSyncRequest extends Equatable {
+  DistributedEpgSyncRequest({
+    required this.requestId,
+    required this.sourceRef,
+    required this.requestedAt,
+    required this.windowStart,
+    required this.windowEnd,
+    required Iterable<String> channelIds,
+    required this.taskKind,
+    required this.payloadFormat,
+    required this.transferMode,
+    this.schemaVersion = kDistributedEpgWorkerSchemaVersion,
+    this.protocolVersion = kDistributedEpgWorkerProtocolVersion,
+  }) : channelIds = List.unmodifiable(channelIds);
+
+  final String schemaVersion;
+  final int protocolVersion;
+  final DistributedEpgStableValue requestId;
+  final CompactEpgSourceRef sourceRef;
+  final DateTime requestedAt;
+  final DateTime windowStart;
+  final DateTime windowEnd;
+  final List<String> channelIds;
+  final DistributedEpgTaskKind taskKind;
+  final DistributedEpgPayloadFormat payloadFormat;
+  final DistributedEpgTransferMode transferMode;
+
+  Duration get window => windowEnd.difference(windowStart);
+
+  @override
+  List<Object?> get props => [
+    schemaVersion,
+    protocolVersion,
+    requestId,
+    sourceRef,
+    requestedAt,
+    windowStart,
+    windowEnd,
+    channelIds,
+    taskKind,
+    payloadFormat,
+    transferMode,
+  ];
+}
+
+class DistributedEpgSnapshotManifest extends Equatable {
+  const DistributedEpgSnapshotManifest({
+    required this.snapshotId,
+    required this.sourceRef,
+    required this.generatedAt,
+    required this.expiresAt,
+    required this.windowStart,
+    required this.windowEnd,
+    required this.channelCount,
+    required this.entryCount,
+    required this.payloadBytes,
+    required this.payloadFormat,
+    required this.transferMode,
+    required this.sequence,
+    this.incremental = false,
+    this.schemaVersion = kDistributedEpgWorkerSchemaVersion,
+    this.protocolVersion = kDistributedEpgWorkerProtocolVersion,
+  });
+
+  final String schemaVersion;
+  final int protocolVersion;
+  final DistributedEpgStableValue snapshotId;
+  final CompactEpgSourceRef sourceRef;
+  final DateTime generatedAt;
+  final DateTime expiresAt;
+  final DateTime windowStart;
+  final DateTime windowEnd;
+  final int channelCount;
+  final int entryCount;
+  final int payloadBytes;
+  final DistributedEpgPayloadFormat payloadFormat;
+  final DistributedEpgTransferMode transferMode;
+  final int sequence;
+  final bool incremental;
+
+  bool isExpired(DateTime now) => !now.isBefore(expiresAt);
+
+  bool coversWindow(DateTime start, DateTime end) {
+    return !windowStart.isAfter(start) && !windowEnd.isBefore(end);
+  }
+
+  Map<String, Object?> toDiagnosticMap() {
+    return {
+      'snapshotId': snapshotId.value,
+      'generatedAt': generatedAt.toIso8601String(),
+      'expiresAt': expiresAt.toIso8601String(),
+      'windowStart': windowStart.toIso8601String(),
+      'windowEnd': windowEnd.toIso8601String(),
+      'channelCount': channelCount,
+      'entryCount': entryCount,
+      'payloadBytes': payloadBytes,
+      'payloadFormat': payloadFormat.stableId,
+      'transferMode': transferMode.stableId,
+      'sequence': sequence,
+      'incremental': incremental,
+    };
+  }
+
+  @override
+  List<Object?> get props => [
+    schemaVersion,
+    protocolVersion,
+    snapshotId,
+    sourceRef,
+    generatedAt,
+    expiresAt,
+    windowStart,
+    windowEnd,
+    channelCount,
+    entryCount,
+    payloadBytes,
+    payloadFormat,
+    transferMode,
+    sequence,
+    incremental,
+  ];
+}
+
+class DistributedEpgWorkerValidationResult extends Equatable {
+  DistributedEpgWorkerValidationResult({
+    required this.workerId,
+    required Iterable<DistributedEpgWorkerBlockerCode> codes,
+    this.requestId,
+    this.snapshotId,
+  }) : codes = List.unmodifiable(codes);
+
+  final DistributedEpgStableValue workerId;
+  final DistributedEpgStableValue? requestId;
+  final DistributedEpgStableValue? snapshotId;
+  final List<DistributedEpgWorkerBlockerCode> codes;
+
+  bool get accepted =>
+      codes.length == 1 &&
+      codes.single == DistributedEpgWorkerBlockerCode.accepted;
+
+  Map<String, Object?> toDiagnosticMap() {
+    return {
+      'workerId': workerId.value,
+      'requestId': requestId?.value,
+      'snapshotId': snapshotId?.value,
+      'accepted': accepted,
+      'codes': codes.map((code) => code.stableId).toList(growable: false),
+    };
+  }
+
+  @override
+  List<Object?> get props => [workerId, requestId, snapshotId, codes];
+}
+
+class DistributedEpgWorkerPolicy extends Equatable {
+  DistributedEpgWorkerPolicy({
+    Set<DistributedEpgWorkerRole> requiredRoles = const {
+      DistributedEpgWorkerRole.compactor,
+      DistributedEpgWorkerRole.cacheHost,
+    },
+    this.acceptedSchemaVersion = kDistributedEpgWorkerSchemaVersion,
+    this.minProtocolVersion = kDistributedEpgWorkerProtocolVersion,
+    this.maxProtocolVersion = kDistributedEpgWorkerProtocolVersion,
+    this.maxSnapshotAge = kDistributedEpgDefaultMaxSnapshotAge,
+  }) : requiredRoles = Set.unmodifiable(requiredRoles);
+
+  final String acceptedSchemaVersion;
+  final int minProtocolVersion;
+  final int maxProtocolVersion;
+  final Duration maxSnapshotAge;
+  final Set<DistributedEpgWorkerRole> requiredRoles;
+
+  DistributedEpgWorkerValidationResult validateRequest({
+    required DistributedEpgWorkerCapability capability,
+    required DistributedEpgSyncRequest request,
+  }) {
+    final codes = <DistributedEpgWorkerBlockerCode>[];
+    _addVersionCodes(
+      schemaVersion: capability.schemaVersion,
+      protocolVersion: capability.protocolVersion,
+      codes: codes,
+    );
+    _addVersionCodes(
+      schemaVersion: request.schemaVersion,
+      protocolVersion: request.protocolVersion,
+      codes: codes,
+    );
+
+    if (!capability.roles.containsAll(requiredRoles)) {
+      codes.add(DistributedEpgWorkerBlockerCode.missingRequiredRole);
+    }
+    if (!capability.supportedTasks.contains(request.taskKind)) {
+      codes.add(DistributedEpgWorkerBlockerCode.unsupportedTask);
+    }
+    if (!capability.supportedFormats.contains(request.payloadFormat)) {
+      codes.add(DistributedEpgWorkerBlockerCode.unsupportedFormat);
+    }
+    if (!capability.supportedTransferModes.contains(request.transferMode)) {
+      codes.add(DistributedEpgWorkerBlockerCode.unsupportedTransferMode);
+    }
+    if (!request.windowEnd.isAfter(request.windowStart)) {
+      codes.add(DistributedEpgWorkerBlockerCode.invalidWindow);
+    }
+    if (request.window > capability.maxWindow) {
+      codes.add(DistributedEpgWorkerBlockerCode.windowTooLarge);
+    }
+    if (request.channelIds.length > capability.maxChannelCount) {
+      codes.add(DistributedEpgWorkerBlockerCode.tooManyChannels);
+    }
+    if (DistributedEpgStableValue.validate(request.sourceRef.value) != null) {
+      codes.add(DistributedEpgWorkerBlockerCode.unsafeStableId);
+    }
+
+    return DistributedEpgWorkerValidationResult(
+      workerId: capability.workerId,
+      requestId: request.requestId,
+      codes: codes.isEmpty
+          ? const [DistributedEpgWorkerBlockerCode.accepted]
+          : codes,
+    );
+  }
+
+  DistributedEpgWorkerValidationResult validateSnapshot({
+    required DistributedEpgWorkerCapability capability,
+    required DistributedEpgSyncRequest request,
+    required DistributedEpgSnapshotManifest manifest,
+    required DateTime now,
+  }) {
+    final codes = <DistributedEpgWorkerBlockerCode>[];
+    _addVersionCodes(
+      schemaVersion: manifest.schemaVersion,
+      protocolVersion: manifest.protocolVersion,
+      codes: codes,
+    );
+
+    if (manifest.payloadFormat != request.payloadFormat) {
+      codes.add(DistributedEpgWorkerBlockerCode.unsupportedFormat);
+    }
+    if (manifest.transferMode != request.transferMode) {
+      codes.add(DistributedEpgWorkerBlockerCode.unsupportedTransferMode);
+    }
+    if (manifest.channelCount > capability.maxChannelCount) {
+      codes.add(DistributedEpgWorkerBlockerCode.tooManyChannels);
+    }
+    if (manifest.entryCount > capability.maxEntryCount) {
+      codes.add(DistributedEpgWorkerBlockerCode.tooManyEntries);
+    }
+    if (manifest.payloadBytes > capability.maxSnapshotBytes) {
+      codes.add(DistributedEpgWorkerBlockerCode.snapshotTooLarge);
+    }
+    if (manifest.payloadBytes > capability.cacheBudgetBytes) {
+      codes.add(DistributedEpgWorkerBlockerCode.cacheBudgetExceeded);
+    }
+    if (manifest.generatedAt.isAfter(now)) {
+      codes.add(DistributedEpgWorkerBlockerCode.futureSnapshot);
+    }
+    if (manifest.generatedAt.isBefore(now.subtract(maxSnapshotAge))) {
+      codes.add(DistributedEpgWorkerBlockerCode.staleSnapshot);
+    }
+    if (manifest.isExpired(now)) {
+      codes.add(DistributedEpgWorkerBlockerCode.expiredSnapshot);
+    }
+    if (!manifest.coversWindow(request.windowStart, request.windowEnd)) {
+      codes.add(DistributedEpgWorkerBlockerCode.windowNotCovered);
+    }
+    if (manifest.sequence <= 0 ||
+        !manifest.windowEnd.isAfter(manifest.windowStart)) {
+      codes.add(DistributedEpgWorkerBlockerCode.invalidWindow);
+    }
+
+    return DistributedEpgWorkerValidationResult(
+      workerId: capability.workerId,
+      requestId: request.requestId,
+      snapshotId: manifest.snapshotId,
+      codes: codes.isEmpty
+          ? const [DistributedEpgWorkerBlockerCode.accepted]
+          : codes,
+    );
+  }
+
+  void _addVersionCodes({
+    required String schemaVersion,
+    required int protocolVersion,
+    required List<DistributedEpgWorkerBlockerCode> codes,
+  }) {
+    if (schemaVersion != acceptedSchemaVersion) {
+      codes.add(DistributedEpgWorkerBlockerCode.schemaMismatch);
+    }
+    if (protocolVersion < minProtocolVersion) {
+      codes.add(DistributedEpgWorkerBlockerCode.protocolTooOld);
+    }
+    if (protocolVersion > maxProtocolVersion) {
+      codes.add(DistributedEpgWorkerBlockerCode.protocolTooNew);
+    }
+  }
+
+  @override
+  List<Object?> get props => [
+    acceptedSchemaVersion,
+    minProtocolVersion,
+    maxProtocolVersion,
+    maxSnapshotAge,
+    requiredRoles,
+  ];
+}
+
+class DistributedEpgWorkerEvent extends Equatable {
+  const DistributedEpgWorkerEvent({
+    required this.requestId,
+    required this.state,
+    this.progressPercent = 0,
+    this.manifest,
+    this.validation,
+  });
+
+  final DistributedEpgStableValue requestId;
+  final DistributedEpgWorkerEventState state;
+  final int progressPercent;
+  final DistributedEpgSnapshotManifest? manifest;
+  final DistributedEpgWorkerValidationResult? validation;
+
+  @override
+  List<Object?> get props => [
+    requestId,
+    state,
+    progressPercent,
+    manifest,
+    validation,
+  ];
+}
+
+abstract interface class DistributedEpgWorker {
+  Stream<DistributedEpgWorkerEvent> run(DistributedEpgSyncRequest request);
+
+  Future<void> cancel(DistributedEpgStableValue requestId);
+}
+
+class NoOpDistributedEpgWorker implements DistributedEpgWorker {
+  const NoOpDistributedEpgWorker(this.capability);
+
+  final DistributedEpgWorkerCapability capability;
+
+  @override
+  Stream<DistributedEpgWorkerEvent> run(
+    DistributedEpgSyncRequest request,
+  ) async* {
+    yield DistributedEpgWorkerEvent(
+      requestId: request.requestId,
+      state: DistributedEpgWorkerEventState.failed,
+      validation: DistributedEpgWorkerValidationResult(
+        workerId: capability.workerId,
+        requestId: request.requestId,
+        codes: const [DistributedEpgWorkerBlockerCode.workerUnavailable],
+      ),
+    );
+  }
+
+  @override
+  Future<void> cancel(DistributedEpgStableValue requestId) async {}
+}
+
+class FakeDistributedEpgWorker implements DistributedEpgWorker {
+  FakeDistributedEpgWorker({
+    required this.capability,
+    required this.policy,
+    Map<DistributedEpgStableValue, DistributedEpgSnapshotManifest> snapshots =
+        const {},
+  }) : _snapshots = Map.unmodifiable(snapshots);
+
+  final DistributedEpgWorkerCapability capability;
+  final DistributedEpgWorkerPolicy policy;
+  final Map<DistributedEpgStableValue, DistributedEpgSnapshotManifest>
+  _snapshots;
+  final Set<DistributedEpgStableValue> _cancelled = {};
+
+  @override
+  Stream<DistributedEpgWorkerEvent> run(
+    DistributedEpgSyncRequest request,
+  ) async* {
+    final requestValidation = policy.validateRequest(
+      capability: capability,
+      request: request,
+    );
+    yield DistributedEpgWorkerEvent(
+      requestId: request.requestId,
+      state: DistributedEpgWorkerEventState.queued,
+      validation: requestValidation,
+    );
+    if (!requestValidation.accepted) {
+      yield DistributedEpgWorkerEvent(
+        requestId: request.requestId,
+        state: DistributedEpgWorkerEventState.failed,
+        validation: requestValidation,
+      );
+      return;
+    }
+    if (_cancelled.contains(request.requestId)) {
+      yield DistributedEpgWorkerEvent(
+        requestId: request.requestId,
+        state: DistributedEpgWorkerEventState.cancelled,
+        validation: DistributedEpgWorkerValidationResult(
+          workerId: capability.workerId,
+          requestId: request.requestId,
+          codes: const [DistributedEpgWorkerBlockerCode.cancelled],
+        ),
+      );
+      return;
+    }
+
+    yield DistributedEpgWorkerEvent(
+      requestId: request.requestId,
+      state: DistributedEpgWorkerEventState.running,
+      progressPercent: 50,
+    );
+
+    final manifest =
+        _snapshots[request.requestId] ?? _defaultManifestFor(request);
+    final snapshotValidation = policy.validateSnapshot(
+      capability: capability,
+      request: request,
+      manifest: manifest,
+      now: manifest.generatedAt,
+    );
+    yield DistributedEpgWorkerEvent(
+      requestId: request.requestId,
+      state: snapshotValidation.accepted
+          ? DistributedEpgWorkerEventState.snapshotReady
+          : DistributedEpgWorkerEventState.failed,
+      progressPercent: snapshotValidation.accepted ? 100 : 50,
+      manifest: snapshotValidation.accepted ? manifest : null,
+      validation: snapshotValidation,
+    );
+  }
+
+  @override
+  Future<void> cancel(DistributedEpgStableValue requestId) async {
+    _cancelled.add(requestId);
+  }
+
+  DistributedEpgSnapshotManifest _defaultManifestFor(
+    DistributedEpgSyncRequest request,
+  ) {
+    return DistributedEpgSnapshotManifest(
+      snapshotId: DistributedEpgStableValue.stable(
+        '${request.requestId.value}-snapshot',
+      ),
+      sourceRef: request.sourceRef,
+      generatedAt: request.requestedAt,
+      expiresAt: request.requestedAt.add(const Duration(minutes: 10)),
+      windowStart: request.windowStart,
+      windowEnd: request.windowEnd,
+      channelCount: request.channelIds.length,
+      entryCount: request.channelIds.length * 2,
+      payloadBytes: request.channelIds.length * 128,
+      payloadFormat: request.payloadFormat,
+      transferMode: request.transferMode,
+      sequence: 1,
+      incremental:
+          request.transferMode == DistributedEpgTransferMode.incrementalPatch,
+    );
+  }
+}

--- a/packages/platform_epg/test/distributed_epg_worker_models_test.dart
+++ b/packages/platform_epg/test/distributed_epg_worker_models_test.dart
@@ -1,0 +1,315 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:platform_epg/platform_epg.dart';
+
+void main() {
+  group('Distributed EPG worker contracts', () {
+    final now = DateTime.utc(2026, 7, 14, 12);
+    final capability = _capability();
+    final policy = DistributedEpgWorkerPolicy();
+
+    test('accepts bounded compact snapshot request and manifest', () {
+      final request = _request(now: now);
+      final manifest = _manifest(request: request, now: now);
+
+      final requestResult = policy.validateRequest(
+        capability: capability,
+        request: request,
+      );
+      final snapshotResult = policy.validateSnapshot(
+        capability: capability,
+        request: request,
+        manifest: manifest,
+        now: now,
+      );
+
+      expect(requestResult.accepted, isTrue);
+      expect(snapshotResult.accepted, isTrue);
+      expect(
+        manifest.toDiagnosticMap(),
+        containsPair('payloadBytes', manifest.payloadBytes),
+      );
+    });
+
+    test('rejects unsupported capability and invalid request shape', () {
+      final weakCapability = _capability(
+        roles: const {DistributedEpgWorkerRole.parser},
+        tasks: const {DistributedEpgTaskKind.cachePrune},
+        formats: const {DistributedEpgPayloadFormat.binaryDelta},
+        transferModes: const {DistributedEpgTransferMode.incrementalPatch},
+        maxChannelCount: 1,
+        maxWindow: const Duration(hours: 1),
+      );
+      final result = policy.validateRequest(
+        capability: weakCapability,
+        request: _request(
+          now: now,
+          windowStart: now,
+          windowEnd: now.add(const Duration(hours: 2)),
+          channelIds: const ['one', 'two'],
+        ),
+      );
+      final invalidWindowResult = policy.validateRequest(
+        capability: capability,
+        request: _request(
+          now: now,
+          windowStart: now.add(const Duration(hours: 2)),
+          windowEnd: now,
+        ),
+      );
+
+      expect(
+        result.codes,
+        contains(DistributedEpgWorkerBlockerCode.missingRequiredRole),
+      );
+      expect(
+        result.codes,
+        contains(DistributedEpgWorkerBlockerCode.unsupportedTask),
+      );
+      expect(
+        result.codes,
+        contains(DistributedEpgWorkerBlockerCode.unsupportedFormat),
+      );
+      expect(
+        result.codes,
+        contains(DistributedEpgWorkerBlockerCode.unsupportedTransferMode),
+      );
+      expect(
+        invalidWindowResult.codes,
+        contains(DistributedEpgWorkerBlockerCode.invalidWindow),
+      );
+      expect(
+        result.codes,
+        contains(DistributedEpgWorkerBlockerCode.windowTooLarge),
+      );
+      expect(
+        result.codes,
+        contains(DistributedEpgWorkerBlockerCode.tooManyChannels),
+      );
+    });
+
+    test('rejects stale oversized uncovered snapshot manifests', () {
+      final request = _request(now: now);
+      final result = policy.validateSnapshot(
+        capability: _capability(maxSnapshotBytes: 100, cacheBudgetBytes: 90),
+        request: request,
+        now: now,
+        manifest: _manifest(
+          request: request,
+          now: now.subtract(const Duration(minutes: 30)),
+          expiresAt: now.subtract(const Duration(minutes: 1)),
+          windowStart: now.subtract(const Duration(minutes: 15)),
+          windowEnd: now.add(const Duration(minutes: 15)),
+          entryCount: kDistributedEpgDefaultMaxEntryCount + 1,
+          payloadBytes: 120,
+        ),
+      );
+
+      expect(
+        result.codes,
+        contains(DistributedEpgWorkerBlockerCode.tooManyEntries),
+      );
+      expect(
+        result.codes,
+        contains(DistributedEpgWorkerBlockerCode.snapshotTooLarge),
+      );
+      expect(
+        result.codes,
+        contains(DistributedEpgWorkerBlockerCode.cacheBudgetExceeded),
+      );
+      expect(
+        result.codes,
+        contains(DistributedEpgWorkerBlockerCode.staleSnapshot),
+      );
+      expect(
+        result.codes,
+        contains(DistributedEpgWorkerBlockerCode.expiredSnapshot),
+      );
+      expect(
+        result.codes,
+        contains(DistributedEpgWorkerBlockerCode.windowNotCovered),
+      );
+    });
+
+    test('rejects future and invalid snapshot manifests', () {
+      final request = _request(now: now);
+      final result = policy.validateSnapshot(
+        capability: capability,
+        request: request,
+        now: now,
+        manifest: _manifest(
+          request: request,
+          now: now.add(const Duration(minutes: 5)),
+          sequence: 0,
+          windowStart: now.add(const Duration(hours: 1)),
+          windowEnd: now,
+        ),
+      );
+
+      expect(
+        result.codes,
+        contains(DistributedEpgWorkerBlockerCode.futureSnapshot),
+      );
+      expect(
+        result.codes,
+        contains(DistributedEpgWorkerBlockerCode.invalidWindow),
+      );
+    });
+
+    test('stable values reject raw network and credential material', () {
+      expect(
+        () => DistributedEpgStableValue.stable('https://example.com/guide.xml'),
+        throwsArgumentError,
+      );
+      expect(
+        () => DistributedEpgStableValue.stable('/Users/me/guide.xml'),
+        throwsArgumentError,
+      );
+      expect(
+        () => DistributedEpgStableValue.stable('10.0.0.12'),
+        throwsArgumentError,
+      );
+      expect(
+        () => DistributedEpgStableValue.stable('Bearer abc123'),
+        throwsArgumentError,
+      );
+    });
+
+    test('no-op worker emits unavailable event', () async {
+      final worker = NoOpDistributedEpgWorker(capability);
+      final events = await worker.run(_request(now: now)).toList();
+
+      expect(events, hasLength(1));
+      expect(events.single.state, DistributedEpgWorkerEventState.failed);
+      expect(
+        events.single.validation?.codes,
+        contains(DistributedEpgWorkerBlockerCode.workerUnavailable),
+      );
+    });
+
+    test(
+      'fake worker emits queued running and snapshot-ready events',
+      () async {
+        final worker = FakeDistributedEpgWorker(
+          capability: capability,
+          policy: policy,
+        );
+
+        final events = await worker.run(_request(now: now)).toList();
+
+        expect(events.map((event) => event.state), [
+          DistributedEpgWorkerEventState.queued,
+          DistributedEpgWorkerEventState.running,
+          DistributedEpgWorkerEventState.snapshotReady,
+        ]);
+        expect(events.last.validation?.accepted, isTrue);
+        expect(events.last.manifest?.channelCount, 2);
+      },
+    );
+
+    test(
+      'fake worker emits cancelled event for cancelled request id',
+      () async {
+        final worker = FakeDistributedEpgWorker(
+          capability: capability,
+          policy: policy,
+        );
+        final request = _request(now: now);
+
+        await worker.cancel(request.requestId);
+        final events = await worker.run(request).toList();
+
+        expect(events.map((event) => event.state), [
+          DistributedEpgWorkerEventState.queued,
+          DistributedEpgWorkerEventState.cancelled,
+        ]);
+        expect(
+          events.last.validation?.codes,
+          contains(DistributedEpgWorkerBlockerCode.cancelled),
+        );
+      },
+    );
+  });
+}
+
+DistributedEpgWorkerCapability _capability({
+  Set<DistributedEpgWorkerRole> roles = const {
+    DistributedEpgWorkerRole.downloader,
+    DistributedEpgWorkerRole.parser,
+    DistributedEpgWorkerRole.normalizer,
+    DistributedEpgWorkerRole.compactor,
+    DistributedEpgWorkerRole.cacheHost,
+  },
+  Set<DistributedEpgTaskKind> tasks = const {
+    DistributedEpgTaskKind.compactSnapshot,
+    DistributedEpgTaskKind.incrementalPatch,
+  },
+  Set<DistributedEpgPayloadFormat> formats = const {
+    DistributedEpgPayloadFormat.compactJson,
+    DistributedEpgPayloadFormat.protobufEnvelope,
+  },
+  Set<DistributedEpgTransferMode> transferModes = const {
+    DistributedEpgTransferMode.currentNextOnly,
+    DistributedEpgTransferMode.incrementalPatch,
+  },
+  Duration maxWindow = kDistributedEpgDefaultMaxWindow,
+  int maxChannelCount = kDistributedEpgDefaultMaxChannelCount,
+  int maxSnapshotBytes = kDistributedEpgDefaultMaxSnapshotBytes,
+  int cacheBudgetBytes = kDistributedEpgDefaultMaxSnapshotBytes,
+}) {
+  return DistributedEpgWorkerCapability(
+    workerId: DistributedEpgStableValue.stable('home-node-epg-worker'),
+    roles: roles,
+    supportedTasks: tasks,
+    supportedFormats: formats,
+    supportedTransferModes: transferModes,
+    maxWindow: maxWindow,
+    maxChannelCount: maxChannelCount,
+    maxSnapshotBytes: maxSnapshotBytes,
+    cacheBudgetBytes: cacheBudgetBytes,
+  );
+}
+
+DistributedEpgSyncRequest _request({
+  required DateTime now,
+  DateTime? windowStart,
+  DateTime? windowEnd,
+  Iterable<String> channelIds = const ['channel-1', 'channel-2'],
+}) {
+  return DistributedEpgSyncRequest(
+    requestId: DistributedEpgStableValue.stable('epg-request-1'),
+    sourceRef: CompactEpgSourceRef.redacted('epg-source-ref-1'),
+    requestedAt: now,
+    windowStart: windowStart ?? now,
+    windowEnd: windowEnd ?? now.add(const Duration(hours: 2)),
+    channelIds: channelIds,
+    taskKind: DistributedEpgTaskKind.compactSnapshot,
+    payloadFormat: DistributedEpgPayloadFormat.compactJson,
+    transferMode: DistributedEpgTransferMode.currentNextOnly,
+  );
+}
+
+DistributedEpgSnapshotManifest _manifest({
+  required DistributedEpgSyncRequest request,
+  required DateTime now,
+  DateTime? expiresAt,
+  DateTime? windowStart,
+  DateTime? windowEnd,
+  int entryCount = 4,
+  int payloadBytes = 1024,
+  int sequence = 1,
+}) {
+  return DistributedEpgSnapshotManifest(
+    snapshotId: DistributedEpgStableValue.stable('epg-snapshot-1'),
+    sourceRef: request.sourceRef,
+    generatedAt: now,
+    expiresAt: expiresAt ?? now.add(const Duration(minutes: 5)),
+    windowStart: windowStart ?? request.windowStart,
+    windowEnd: windowEnd ?? request.windowEnd,
+    channelCount: request.channelIds.length,
+    entryCount: entryCount,
+    payloadBytes: payloadBytes,
+    payloadFormat: request.payloadFormat,
+    transferMode: request.transferMode,
+    sequence: sequence,
+  );
+}


### PR DESCRIPTION
# Summary\n\nAdds the ATV-034 v2 platform distributed EPG worker contract in platform_epg.\n\nGoal: define delegated compact EPG snapshot and incremental sync contracts before any receiver UI, XMLTV parsing, transfer, or cache implementation is added.\n\nCore outcome:\n\n* Defines worker capabilities, sync requests, snapshot manifests, validation policy, and worker events.\n* Adds no-op and fake workers for deterministic automation.\n* Documents the platform ownership boundary and privacy limits.\n\n# Changes\n\n### Code\n\n* Added:\n  * packages/platform_epg/lib/src/distributed_epg_worker_models.dart\n  * packages/platform_epg/test/distributed_epg_worker_models_test.dart\n  * docs/features/airo-tv/DISTRIBUTED_EPG_WORKER_CONTRACT.md\n* Updated:\n  * packages/platform_epg/lib/platform_epg.dart to export the worker contract.\n  * packages/platform_epg/README.md to describe distributed EPG worker scope.\n\n### Logic\n\n* Adds worker role/task/format/transfer-mode capability descriptors.\n* Adds request validation for schema/protocol versions, required roles, supported task/format/mode, valid bounded windows, channel limits, and safe source refs.\n* Adds snapshot validation for size/cache budgets, entry counts, expiry/staleness/future timestamps, window coverage, and valid sequence/window shape.\n* Adds deterministic no-op and fake worker adapters without parsing, transfer, persistence, or sockets.\n\n# API Changes\n\n* New public Dart exports from platform_epg for distributed EPG worker models and adapters.\n\n# Database Changes\n\n* None.\n\n# Observability / Logging\n\n* Adds diagnostic maps with stable ids, counts, sizes, windows, sequence numbers, and blocker codes only.\n\n# Performance Impact\n\n* Runtime impact: none until consumers invoke the worker boundary.\n* Contract supports bounded snapshot and cache budgets for constrained receivers.\n\n# Risks\n\n* Future XMLTV/parser implementations must stay behind this platform boundary and avoid leaking provider payloads.\n* Future transfer/cache work must preserve redacted source refs and budget validation.\n* Rollback plan: revert this PR before consumers depend on the new export.\n\n# Testing\n\n* Unit tests:\n  * cd packages/platform_epg && flutter test\n* Static checks:\n  * dart format --set-exit-if-changed packages/platform_epg\n  * cd packages/platform_epg && flutter analyze --fatal-infos\n  * git diff --check HEAD~1..HEAD && git diff --check\n* Privacy scan:\n  * diff scanned for secret/token/password/credential/auth/API key/Firebase/network endpoint terms; hits are redaction rules and negative tests only.\n\n# Deployment Notes\n\n* No secret or environment changes required.\n\n# Related Issues\n\nCloses #624