### PR TITLE
feat(platform): add benchmark device-class gates

### DIFF
--- a/docs/features/airo-tv/BENCHMARK_DEVICE_CLASS_GATES.md
+++ b/docs/features/airo-tv/BENCHMARK_DEVICE_CLASS_GATES.md
@@ -1,0 +1,82 @@
+# Benchmark Device-Class Gates
+
+Status: v2 platform contract for ATV-036.
+
+## Ownership
+
+Benchmark device-class gates are platform certification behavior. Airo TV,
+Lite Receiver, companion apps, desktop companions, QA automation, release gates,
+and future device-lab tooling consume this contract to decide whether a device
+class can support advertised performance and compatibility claims.
+
+The contract lives in `packages/platform_certification` because that package
+already owns certification targets, validation matrices, evidence kinds, and
+support-claim decisions. Benchmark runners, media database plans, telemetry, and
+app UI remain separate consumers.
+
+## Non-Goals
+
+This issue does not implement:
+
+- physical benchmark execution
+- device-lab inventory
+- CI uploads
+- telemetry export
+- playback execution
+- import/search/EPG runners
+- app UI
+- store release submission
+
+## Contract Shape
+
+`AiroBenchmarkDeviceClassProfile` defines a device class by stable id, platform,
+product profile, hardware floor, and required benchmark gates.
+
+Default classes are:
+
+- constrained TV
+- standard TV
+- mobile companion
+- desktop companion
+
+`AiroBenchmarkGate` defines a workload, accepted evidence kinds, physical-device
+requirement, evidence freshness window, and metric thresholds.
+
+Default workloads cover:
+
+- startup latency
+- scroll while import runs
+- EPG refresh during playback
+- remote control during playback
+- protocol compatibility
+- large playlist import
+- search responsiveness
+- cache cleanup
+
+`AiroBenchmarkSample` records a redacted metric sample by stable sample id,
+device class id, gate id, metric id, numeric value, evidence kind, and capture
+time.
+
+`AiroBenchmarkDeviceClassMatrix` evaluates samples and returns deterministic
+blockers for missing classes, unsupported classes, missing gates, missing or
+wrong samples, host-only evidence for physical gates, stale samples, unsafe ids,
+and threshold failures.
+
+`AiroBenchmarkEvidenceProvider` is the provider boundary. No-op providers return
+no evidence. Fake providers return deterministic samples for host-side tests.
+
+## Privacy
+
+Benchmark profiles, gates, samples, and diagnostics expose only stable ids,
+platform/profile classes, workload ids, metric ids, numeric thresholds, evidence
+kinds, capture times, and blocker codes. They must not expose media URLs,
+playlist URLs, EPG URLs, request headers, local paths, local addresses, provider
+payloads, credentials, media titles, viewing history, analytics payloads, or
+diagnostic dumps.
+
+## Automation
+
+- Unit tests evaluate default matrix classes with fixed clocks.
+- Policy tests cover passing samples, missing evidence, stale evidence, wrong
+  evidence kind, host-only evidence for physical gates, and threshold failures.
+- Provider tests cover no-op and fake sample retrieval.

--- a/packages/platform_certification/README.md
+++ b/packages/platform_certification/README.md
@@ -20,6 +20,10 @@ unsupported.
   device classes.
 - Default Airo cross-platform validation matrix for Airo TV v2 platform
   hardening.
+- Benchmark device-class gates for constrained TV, standard TV, mobile
+  companion, and desktop companion performance/support claims.
+- Fake and no-op benchmark evidence providers for deterministic release
+  automation.
 
 This package does not collect device evidence, run benchmarks, upload logs,
 render UI, or submit store releases.

--- a/packages/platform_certification/lib/platform_certification.dart
+++ b/packages/platform_certification/lib/platform_certification.dart
@@ -1,3 +1,4 @@
 library;
 
+export 'src/benchmark_device_class_models.dart';
 export 'src/certification_models.dart';

--- a/packages/platform_certification/lib/src/benchmark_device_class_models.dart
+++ b/packages/platform_certification/lib/src/benchmark_device_class_models.dart
@@ -1,0 +1,822 @@
+import 'package:equatable/equatable.dart';
+
+import 'certification_models.dart';
+
+const String kAiroBenchmarkDeviceClassSchemaVersion = '1.0.0';
+
+enum AiroBenchmarkDeviceClass {
+  constrainedTv('constrained_tv'),
+  standardTv('standard_tv'),
+  mobileCompanion('mobile_companion'),
+  desktopCompanion('desktop_companion');
+
+  const AiroBenchmarkDeviceClass(this.stableId);
+
+  final String stableId;
+}
+
+enum AiroBenchmarkWorkload {
+  startup('startup'),
+  scrollWhileImportRuns('scroll_while_import_runs'),
+  epgRefreshDuringPlayback('epg_refresh_during_playback'),
+  remoteDuringPlayback('remote_during_playback'),
+  protocolCompatibility('protocol_compatibility'),
+  largePlaylistImport('large_playlist_import'),
+  searchResponsiveness('search_responsiveness'),
+  cacheCleanup('cache_cleanup');
+
+  const AiroBenchmarkWorkload(this.stableId);
+
+  final String stableId;
+}
+
+enum AiroBenchmarkMetric {
+  elapsedMillis('elapsed_millis'),
+  inputLatencyMillis('input_latency_millis'),
+  peakMemoryMb('peak_memory_mb'),
+  storageMb('storage_mb'),
+  droppedFramePercent('dropped_frame_percent'),
+  crashCount('crash_count'),
+  rowsPerSecond('rows_per_second'),
+  rejectedPayloadCount('rejected_payload_count');
+
+  const AiroBenchmarkMetric(this.stableId);
+
+  final String stableId;
+}
+
+enum AiroBenchmarkEvidenceKind {
+  hostAutomation('host_automation'),
+  physicalDeviceRun('physical_device_run'),
+  benchmarkTrace('benchmark_trace'),
+  releaseConfigReview('release_config_review');
+
+  const AiroBenchmarkEvidenceKind(this.stableId);
+
+  final String stableId;
+}
+
+enum AiroBenchmarkBlockerCode {
+  accepted('accepted'),
+  deviceClassMissing('device_class_missing'),
+  unsupportedDeviceClass('unsupported_device_class'),
+  gateMissing('gate_missing'),
+  sampleMissing('sample_missing'),
+  sampleWrongDeviceClass('sample_wrong_device_class'),
+  sampleWrongGate('sample_wrong_gate'),
+  sampleWrongMetric('sample_wrong_metric'),
+  sampleWrongEvidenceKind('sample_wrong_evidence_kind'),
+  hostOnlyEvidenceForPhysicalGate('host_only_evidence_for_physical_gate'),
+  sampleStale('sample_stale'),
+  metricAboveMaximum('metric_above_maximum'),
+  metricBelowMinimum('metric_below_minimum'),
+  unsafeStableId('unsafe_stable_id');
+
+  const AiroBenchmarkBlockerCode(this.stableId);
+
+  final String stableId;
+}
+
+enum AiroBenchmarkStableValueRejectionCode {
+  empty('empty'),
+  urlValue('url_value'),
+  localPathValue('local_path_value'),
+  localIpValue('local_ip_value'),
+  credentialLikeValue('credential_like_value'),
+  invalidStableId('invalid_stable_id');
+
+  const AiroBenchmarkStableValueRejectionCode(this.stableId);
+
+  final String stableId;
+}
+
+class AiroBenchmarkStableValue extends Equatable {
+  const AiroBenchmarkStableValue._(this.value);
+
+  factory AiroBenchmarkStableValue.stable(String value) {
+    final rejection = validate(value);
+    if (rejection != null) {
+      throw ArgumentError.value(value, 'value', rejection.stableId);
+    }
+    return AiroBenchmarkStableValue._(value.trim());
+  }
+
+  final String value;
+
+  static AiroBenchmarkStableValueRejectionCode? validate(String value) {
+    final trimmed = value.trim();
+    if (trimmed.isEmpty) {
+      return AiroBenchmarkStableValueRejectionCode.empty;
+    }
+    final uri = Uri.tryParse(trimmed);
+    if (uri != null && (uri.scheme == 'http' || uri.scheme == 'https')) {
+      return AiroBenchmarkStableValueRejectionCode.urlValue;
+    }
+    if (trimmed.startsWith('file://') ||
+        trimmed.startsWith('/') ||
+        RegExp(r'^[A-Za-z]:\\').hasMatch(trimmed)) {
+      return AiroBenchmarkStableValueRejectionCode.localPathValue;
+    }
+    if (RegExp(
+      r'\b(?:10|127|172\.(?:1[6-9]|2\d|3[0-1])|192\.168)\.',
+    ).hasMatch(trimmed)) {
+      return AiroBenchmarkStableValueRejectionCode.localIpValue;
+    }
+    if (RegExp(
+      r'\b(?:bearer|basic)\s+[A-Za-z0-9._~+/=-]+',
+      caseSensitive: false,
+    ).hasMatch(trimmed)) {
+      return AiroBenchmarkStableValueRejectionCode.credentialLikeValue;
+    }
+    if (!RegExp(r'^[A-Za-z][A-Za-z0-9_.-]*$').hasMatch(trimmed)) {
+      return AiroBenchmarkStableValueRejectionCode.invalidStableId;
+    }
+    return null;
+  }
+
+  @override
+  String toString() => 'AiroBenchmarkStableValue(redacted)';
+
+  @override
+  List<Object?> get props => [value];
+}
+
+class AiroBenchmarkMetricThreshold extends Equatable {
+  const AiroBenchmarkMetricThreshold({
+    required this.metric,
+    this.maximum,
+    this.minimum,
+  });
+
+  final AiroBenchmarkMetric metric;
+  final double? maximum;
+  final double? minimum;
+
+  bool accepts(double value) {
+    final max = maximum;
+    if (max != null && value > max) return false;
+    final min = minimum;
+    if (min != null && value < min) return false;
+    return true;
+  }
+
+  @override
+  List<Object?> get props => [metric, maximum, minimum];
+}
+
+class AiroBenchmarkGate extends Equatable {
+  AiroBenchmarkGate({
+    required this.gateId,
+    required this.workload,
+    required Set<AiroBenchmarkEvidenceKind> acceptedEvidenceKinds,
+    required Iterable<AiroBenchmarkMetricThreshold> thresholds,
+    this.requiresPhysicalDevice = false,
+    this.maxEvidenceAge = const Duration(days: 14),
+    this.schemaVersion = kAiroBenchmarkDeviceClassSchemaVersion,
+  }) : acceptedEvidenceKinds = Set.unmodifiable(acceptedEvidenceKinds),
+       thresholds = List.unmodifiable(thresholds);
+
+  final String schemaVersion;
+  final AiroBenchmarkStableValue gateId;
+  final AiroBenchmarkWorkload workload;
+  final Set<AiroBenchmarkEvidenceKind> acceptedEvidenceKinds;
+  final List<AiroBenchmarkMetricThreshold> thresholds;
+  final bool requiresPhysicalDevice;
+  final Duration maxEvidenceAge;
+
+  AiroBenchmarkMetricThreshold? thresholdFor(AiroBenchmarkMetric metric) {
+    for (final threshold in thresholds) {
+      if (threshold.metric == metric) return threshold;
+    }
+    return null;
+  }
+
+  bool accepts(AiroBenchmarkEvidenceKind evidenceKind) {
+    return acceptedEvidenceKinds.contains(evidenceKind);
+  }
+
+  @override
+  List<Object?> get props => [
+    schemaVersion,
+    gateId,
+    workload,
+    acceptedEvidenceKinds,
+    thresholds,
+    requiresPhysicalDevice,
+    maxEvidenceAge,
+  ];
+}
+
+class AiroBenchmarkDeviceClassProfile extends Equatable {
+  AiroBenchmarkDeviceClassProfile({
+    required this.deviceClassId,
+    required this.deviceClass,
+    required this.platform,
+    required this.productProfile,
+    required Set<AiroBenchmarkStableValue> requiredGateIds,
+    this.minMemoryMb,
+    this.minStorageMb,
+    this.minAndroidApi,
+    this.canAdvertiseSupport = true,
+    this.schemaVersion = kAiroBenchmarkDeviceClassSchemaVersion,
+  }) : requiredGateIds = Set.unmodifiable(requiredGateIds);
+
+  final String schemaVersion;
+  final AiroBenchmarkStableValue deviceClassId;
+  final AiroBenchmarkDeviceClass deviceClass;
+  final AiroValidationPlatform platform;
+  final AiroValidationProductProfile productProfile;
+  final Set<AiroBenchmarkStableValue> requiredGateIds;
+  final int? minMemoryMb;
+  final int? minStorageMb;
+  final int? minAndroidApi;
+  final bool canAdvertiseSupport;
+
+  @override
+  List<Object?> get props => [
+    schemaVersion,
+    deviceClassId,
+    deviceClass,
+    platform,
+    productProfile,
+    requiredGateIds,
+    minMemoryMb,
+    minStorageMb,
+    minAndroidApi,
+    canAdvertiseSupport,
+  ];
+}
+
+class AiroBenchmarkSample extends Equatable {
+  const AiroBenchmarkSample({
+    required this.sampleId,
+    required this.deviceClassId,
+    required this.gateId,
+    required this.metric,
+    required this.value,
+    required this.evidenceKind,
+    required this.capturedAt,
+    this.schemaVersion = kAiroBenchmarkDeviceClassSchemaVersion,
+  });
+
+  final String schemaVersion;
+  final AiroBenchmarkStableValue sampleId;
+  final AiroBenchmarkStableValue deviceClassId;
+  final AiroBenchmarkStableValue gateId;
+  final AiroBenchmarkMetric metric;
+  final double value;
+  final AiroBenchmarkEvidenceKind evidenceKind;
+  final DateTime capturedAt;
+
+  @override
+  List<Object?> get props => [
+    schemaVersion,
+    sampleId,
+    deviceClassId,
+    gateId,
+    metric,
+    value,
+    evidenceKind,
+    capturedAt,
+  ];
+}
+
+class AiroBenchmarkBlocker extends Equatable {
+  const AiroBenchmarkBlocker({
+    required this.code,
+    required this.deviceClassId,
+    this.gateId,
+    this.metric,
+  });
+
+  final AiroBenchmarkBlockerCode code;
+  final AiroBenchmarkStableValue deviceClassId;
+  final AiroBenchmarkStableValue? gateId;
+  final AiroBenchmarkMetric? metric;
+
+  @override
+  List<Object?> get props => [code, deviceClassId, gateId, metric];
+}
+
+class AiroBenchmarkEvaluationResult extends Equatable {
+  AiroBenchmarkEvaluationResult({
+    required this.deviceClassId,
+    required Iterable<AiroBenchmarkBlocker> blockers,
+  }) : blockers = List.unmodifiable(blockers);
+
+  final AiroBenchmarkStableValue deviceClassId;
+  final List<AiroBenchmarkBlocker> blockers;
+
+  bool get passed => blockers.isEmpty;
+
+  Map<String, Object?> toDiagnosticMap() {
+    return {
+      'deviceClassId': deviceClassId.value,
+      'passed': passed,
+      'codes': blockers
+          .map((blocker) => blocker.code.stableId)
+          .toList(growable: false),
+    };
+  }
+
+  @override
+  List<Object?> get props => [deviceClassId, blockers];
+}
+
+class AiroBenchmarkDeviceClassMatrix extends Equatable {
+  AiroBenchmarkDeviceClassMatrix({
+    required Iterable<AiroBenchmarkDeviceClassProfile> profiles,
+    required Iterable<AiroBenchmarkGate> gates,
+    this.schemaVersion = kAiroBenchmarkDeviceClassSchemaVersion,
+  }) : profiles = List.unmodifiable(profiles),
+       gates = List.unmodifiable(gates);
+
+  final String schemaVersion;
+  final List<AiroBenchmarkDeviceClassProfile> profiles;
+  final List<AiroBenchmarkGate> gates;
+
+  AiroBenchmarkDeviceClassProfile? profileById(String deviceClassId) {
+    for (final profile in profiles) {
+      if (profile.deviceClassId.value == deviceClassId) return profile;
+    }
+    return null;
+  }
+
+  AiroBenchmarkGate? gateById(AiroBenchmarkStableValue gateId) {
+    for (final gate in gates) {
+      if (gate.gateId == gateId) return gate;
+    }
+    return null;
+  }
+
+  AiroBenchmarkEvaluationResult evaluate({
+    required String deviceClassId,
+    required Iterable<AiroBenchmarkSample> samples,
+    required DateTime now,
+  }) {
+    final stableDeviceClassId = _stableOrFallback(deviceClassId);
+    final profile = profileById(deviceClassId);
+    if (profile == null) {
+      return AiroBenchmarkEvaluationResult(
+        deviceClassId: stableDeviceClassId,
+        blockers: [
+          AiroBenchmarkBlocker(
+            code: AiroBenchmarkBlockerCode.deviceClassMissing,
+            deviceClassId: stableDeviceClassId,
+          ),
+        ],
+      );
+    }
+    if (!profile.canAdvertiseSupport) {
+      return AiroBenchmarkEvaluationResult(
+        deviceClassId: profile.deviceClassId,
+        blockers: [
+          AiroBenchmarkBlocker(
+            code: AiroBenchmarkBlockerCode.unsupportedDeviceClass,
+            deviceClassId: profile.deviceClassId,
+          ),
+        ],
+      );
+    }
+
+    final blockers = <AiroBenchmarkBlocker>[];
+    for (final gateId in profile.requiredGateIds) {
+      final gate = gateById(gateId);
+      if (gate == null) {
+        blockers.add(
+          AiroBenchmarkBlocker(
+            code: AiroBenchmarkBlockerCode.gateMissing,
+            deviceClassId: profile.deviceClassId,
+            gateId: gateId,
+          ),
+        );
+        continue;
+      }
+      blockers.addAll(
+        _blockersForGate(
+          profile: profile,
+          gate: gate,
+          samples: samples,
+          now: now,
+        ),
+      );
+    }
+
+    return AiroBenchmarkEvaluationResult(
+      deviceClassId: profile.deviceClassId,
+      blockers: blockers,
+    );
+  }
+
+  Iterable<AiroBenchmarkBlocker> _blockersForGate({
+    required AiroBenchmarkDeviceClassProfile profile,
+    required AiroBenchmarkGate gate,
+    required Iterable<AiroBenchmarkSample> samples,
+    required DateTime now,
+  }) {
+    final blockers = <AiroBenchmarkBlocker>[];
+    final gateSamples = samples.where((sample) => sample.gateId == gate.gateId);
+    if (gateSamples.isEmpty) {
+      return [
+        AiroBenchmarkBlocker(
+          code: AiroBenchmarkBlockerCode.sampleMissing,
+          deviceClassId: profile.deviceClassId,
+          gateId: gate.gateId,
+        ),
+      ];
+    }
+
+    for (final threshold in gate.thresholds) {
+      final metricSamples = gateSamples.where(
+        (sample) => sample.metric == threshold.metric,
+      );
+      if (metricSamples.isEmpty) {
+        blockers.add(
+          AiroBenchmarkBlocker(
+            code: AiroBenchmarkBlockerCode.sampleWrongMetric,
+            deviceClassId: profile.deviceClassId,
+            gateId: gate.gateId,
+            metric: threshold.metric,
+          ),
+        );
+        continue;
+      }
+      blockers.addAll(
+        _blockersForMetricSamples(
+          profile: profile,
+          gate: gate,
+          threshold: threshold,
+          samples: metricSamples,
+          now: now,
+        ),
+      );
+    }
+    return blockers;
+  }
+
+  Iterable<AiroBenchmarkBlocker> _blockersForMetricSamples({
+    required AiroBenchmarkDeviceClassProfile profile,
+    required AiroBenchmarkGate gate,
+    required AiroBenchmarkMetricThreshold threshold,
+    required Iterable<AiroBenchmarkSample> samples,
+    required DateTime now,
+  }) sync* {
+    final usableSamples = <AiroBenchmarkSample>[];
+    for (final sample in samples) {
+      final sampleBlocker = _sampleBlocker(
+        profile: profile,
+        gate: gate,
+        sample: sample,
+        now: now,
+      );
+      if (sampleBlocker == null) {
+        usableSamples.add(sample);
+      } else {
+        yield sampleBlocker;
+      }
+    }
+    if (usableSamples.isEmpty) return;
+
+    final latest = usableSamples.reduce(
+      (a, b) => a.capturedAt.isAfter(b.capturedAt) ? a : b,
+    );
+    final max = threshold.maximum;
+    if (max != null && latest.value > max) {
+      yield AiroBenchmarkBlocker(
+        code: AiroBenchmarkBlockerCode.metricAboveMaximum,
+        deviceClassId: profile.deviceClassId,
+        gateId: gate.gateId,
+        metric: threshold.metric,
+      );
+    }
+    final min = threshold.minimum;
+    if (min != null && latest.value < min) {
+      yield AiroBenchmarkBlocker(
+        code: AiroBenchmarkBlockerCode.metricBelowMinimum,
+        deviceClassId: profile.deviceClassId,
+        gateId: gate.gateId,
+        metric: threshold.metric,
+      );
+    }
+  }
+
+  AiroBenchmarkBlocker? _sampleBlocker({
+    required AiroBenchmarkDeviceClassProfile profile,
+    required AiroBenchmarkGate gate,
+    required AiroBenchmarkSample sample,
+    required DateTime now,
+  }) {
+    if (sample.deviceClassId != profile.deviceClassId) {
+      return AiroBenchmarkBlocker(
+        code: AiroBenchmarkBlockerCode.sampleWrongDeviceClass,
+        deviceClassId: profile.deviceClassId,
+        gateId: gate.gateId,
+        metric: sample.metric,
+      );
+    }
+    if (sample.gateId != gate.gateId) {
+      return AiroBenchmarkBlocker(
+        code: AiroBenchmarkBlockerCode.sampleWrongGate,
+        deviceClassId: profile.deviceClassId,
+        gateId: gate.gateId,
+        metric: sample.metric,
+      );
+    }
+    if (gate.requiresPhysicalDevice &&
+        sample.evidenceKind != AiroBenchmarkEvidenceKind.physicalDeviceRun) {
+      return AiroBenchmarkBlocker(
+        code: AiroBenchmarkBlockerCode.hostOnlyEvidenceForPhysicalGate,
+        deviceClassId: profile.deviceClassId,
+        gateId: gate.gateId,
+        metric: sample.metric,
+      );
+    }
+    if (!gate.accepts(sample.evidenceKind)) {
+      return AiroBenchmarkBlocker(
+        code: AiroBenchmarkBlockerCode.sampleWrongEvidenceKind,
+        deviceClassId: profile.deviceClassId,
+        gateId: gate.gateId,
+        metric: sample.metric,
+      );
+    }
+    if (sample.capturedAt.add(gate.maxEvidenceAge).isBefore(now)) {
+      return AiroBenchmarkBlocker(
+        code: AiroBenchmarkBlockerCode.sampleStale,
+        deviceClassId: profile.deviceClassId,
+        gateId: gate.gateId,
+        metric: sample.metric,
+      );
+    }
+    if (AiroBenchmarkStableValue.validate(sample.sampleId.value) != null) {
+      return AiroBenchmarkBlocker(
+        code: AiroBenchmarkBlockerCode.unsafeStableId,
+        deviceClassId: profile.deviceClassId,
+        gateId: gate.gateId,
+        metric: sample.metric,
+      );
+    }
+    return null;
+  }
+
+  AiroBenchmarkStableValue _stableOrFallback(String value) {
+    try {
+      return AiroBenchmarkStableValue.stable(value);
+    } on ArgumentError {
+      return AiroBenchmarkStableValue.stable('invalid-device-class');
+    }
+  }
+
+  @override
+  List<Object?> get props => [schemaVersion, profiles, gates];
+}
+
+abstract interface class AiroBenchmarkEvidenceProvider {
+  Future<List<AiroBenchmarkSample>> samplesForDeviceClass(
+    AiroBenchmarkStableValue deviceClassId,
+  );
+}
+
+class AiroNoOpBenchmarkEvidenceProvider
+    implements AiroBenchmarkEvidenceProvider {
+  const AiroNoOpBenchmarkEvidenceProvider();
+
+  @override
+  Future<List<AiroBenchmarkSample>> samplesForDeviceClass(
+    AiroBenchmarkStableValue deviceClassId,
+  ) async {
+    return const [];
+  }
+}
+
+class AiroFakeBenchmarkEvidenceProvider
+    implements AiroBenchmarkEvidenceProvider {
+  AiroFakeBenchmarkEvidenceProvider({
+    required Iterable<AiroBenchmarkSample> samples,
+  }) : _samples = List.unmodifiable(samples);
+
+  final List<AiroBenchmarkSample> _samples;
+
+  @override
+  Future<List<AiroBenchmarkSample>> samplesForDeviceClass(
+    AiroBenchmarkStableValue deviceClassId,
+  ) async {
+    return [
+      for (final sample in _samples)
+        if (sample.deviceClassId == deviceClassId) sample,
+    ];
+  }
+}
+
+class AiroBenchmarkDeviceClasses {
+  const AiroBenchmarkDeviceClasses._();
+
+  static AiroBenchmarkDeviceClassMatrix matrix() {
+    return AiroBenchmarkDeviceClassMatrix(
+      profiles: _profiles(),
+      gates: _gates(),
+    );
+  }
+
+  static List<AiroBenchmarkDeviceClassProfile> _profiles() {
+    return [
+      AiroBenchmarkDeviceClassProfile(
+        deviceClassId: AiroBenchmarkStableValue.stable(
+          'constrained-tv-class-a',
+        ),
+        deviceClass: AiroBenchmarkDeviceClass.constrainedTv,
+        platform: AiroValidationPlatform.androidTv,
+        productProfile: AiroValidationProductProfile.liteReceiver,
+        minMemoryMb: 1024,
+        minStorageMb: 256,
+        minAndroidApi: 26,
+        requiredGateIds: _gateIds(const [
+          'startup-latency',
+          'scroll-while-import',
+          'epg-refresh-during-playback',
+          'protocol-compatibility',
+        ]),
+      ),
+      AiroBenchmarkDeviceClassProfile(
+        deviceClassId: AiroBenchmarkStableValue.stable('standard-tv-class-b'),
+        deviceClass: AiroBenchmarkDeviceClass.standardTv,
+        platform: AiroValidationPlatform.androidTv,
+        productProfile: AiroValidationProductProfile.fullTv,
+        minMemoryMb: 2048,
+        minStorageMb: 512,
+        minAndroidApi: 28,
+        requiredGateIds: _gateIds(const [
+          'startup-latency',
+          'remote-during-playback',
+          'large-playlist-import',
+          'protocol-compatibility',
+        ]),
+      ),
+      AiroBenchmarkDeviceClassProfile(
+        deviceClassId: AiroBenchmarkStableValue.stable(
+          'mobile-companion-class',
+        ),
+        deviceClass: AiroBenchmarkDeviceClass.mobileCompanion,
+        platform: AiroValidationPlatform.androidMobile,
+        productProfile: AiroValidationProductProfile.companion,
+        requiredGateIds: _gateIds(const [
+          'search-responsiveness',
+          'large-playlist-import',
+          'protocol-compatibility',
+        ]),
+      ),
+      AiroBenchmarkDeviceClassProfile(
+        deviceClassId: AiroBenchmarkStableValue.stable(
+          'desktop-companion-class',
+        ),
+        deviceClass: AiroBenchmarkDeviceClass.desktopCompanion,
+        platform: AiroValidationPlatform.desktop,
+        productProfile: AiroValidationProductProfile.desktopCompanion,
+        requiredGateIds: _gateIds(const [
+          'search-responsiveness',
+          'large-playlist-import',
+          'cache-cleanup',
+        ]),
+      ),
+    ];
+  }
+
+  static List<AiroBenchmarkGate> _gates() {
+    return [
+      _gate(
+        id: 'startup-latency',
+        workload: AiroBenchmarkWorkload.startup,
+        requiresPhysicalDevice: true,
+        thresholds: const [
+          AiroBenchmarkMetricThreshold(
+            metric: AiroBenchmarkMetric.elapsedMillis,
+            maximum: 3000,
+          ),
+          AiroBenchmarkMetricThreshold(
+            metric: AiroBenchmarkMetric.peakMemoryMb,
+            maximum: 256,
+          ),
+        ],
+      ),
+      _gate(
+        id: 'scroll-while-import',
+        workload: AiroBenchmarkWorkload.scrollWhileImportRuns,
+        requiresPhysicalDevice: true,
+        thresholds: const [
+          AiroBenchmarkMetricThreshold(
+            metric: AiroBenchmarkMetric.inputLatencyMillis,
+            maximum: 120,
+          ),
+          AiroBenchmarkMetricThreshold(
+            metric: AiroBenchmarkMetric.droppedFramePercent,
+            maximum: 2,
+          ),
+        ],
+      ),
+      _gate(
+        id: 'epg-refresh-during-playback',
+        workload: AiroBenchmarkWorkload.epgRefreshDuringPlayback,
+        requiresPhysicalDevice: true,
+        thresholds: const [
+          AiroBenchmarkMetricThreshold(
+            metric: AiroBenchmarkMetric.peakMemoryMb,
+            maximum: 256,
+          ),
+          AiroBenchmarkMetricThreshold(
+            metric: AiroBenchmarkMetric.droppedFramePercent,
+            maximum: 2,
+          ),
+        ],
+      ),
+      _gate(
+        id: 'remote-during-playback',
+        workload: AiroBenchmarkWorkload.remoteDuringPlayback,
+        requiresPhysicalDevice: true,
+        thresholds: const [
+          AiroBenchmarkMetricThreshold(
+            metric: AiroBenchmarkMetric.inputLatencyMillis,
+            maximum: 80,
+          ),
+          AiroBenchmarkMetricThreshold(
+            metric: AiroBenchmarkMetric.droppedFramePercent,
+            maximum: 1,
+          ),
+        ],
+      ),
+      _gate(
+        id: 'protocol-compatibility',
+        workload: AiroBenchmarkWorkload.protocolCompatibility,
+        thresholds: const [
+          AiroBenchmarkMetricThreshold(
+            metric: AiroBenchmarkMetric.rejectedPayloadCount,
+            minimum: 3,
+          ),
+          AiroBenchmarkMetricThreshold(
+            metric: AiroBenchmarkMetric.crashCount,
+            maximum: 0,
+          ),
+        ],
+      ),
+      _gate(
+        id: 'large-playlist-import',
+        workload: AiroBenchmarkWorkload.largePlaylistImport,
+        thresholds: const [
+          AiroBenchmarkMetricThreshold(
+            metric: AiroBenchmarkMetric.rowsPerSecond,
+            minimum: 1000,
+          ),
+          AiroBenchmarkMetricThreshold(
+            metric: AiroBenchmarkMetric.peakMemoryMb,
+            maximum: 512,
+          ),
+        ],
+      ),
+      _gate(
+        id: 'search-responsiveness',
+        workload: AiroBenchmarkWorkload.searchResponsiveness,
+        thresholds: const [
+          AiroBenchmarkMetricThreshold(
+            metric: AiroBenchmarkMetric.elapsedMillis,
+            maximum: 150,
+          ),
+        ],
+      ),
+      _gate(
+        id: 'cache-cleanup',
+        workload: AiroBenchmarkWorkload.cacheCleanup,
+        thresholds: const [
+          AiroBenchmarkMetricThreshold(
+            metric: AiroBenchmarkMetric.storageMb,
+            maximum: 256,
+          ),
+        ],
+      ),
+    ];
+  }
+
+  static AiroBenchmarkGate _gate({
+    required String id,
+    required AiroBenchmarkWorkload workload,
+    required List<AiroBenchmarkMetricThreshold> thresholds,
+    bool requiresPhysicalDevice = false,
+  }) {
+    return AiroBenchmarkGate(
+      gateId: AiroBenchmarkStableValue.stable(id),
+      workload: workload,
+      requiresPhysicalDevice: requiresPhysicalDevice,
+      acceptedEvidenceKinds: requiresPhysicalDevice
+          ? const {
+              AiroBenchmarkEvidenceKind.physicalDeviceRun,
+              AiroBenchmarkEvidenceKind.benchmarkTrace,
+            }
+          : const {
+              AiroBenchmarkEvidenceKind.hostAutomation,
+              AiroBenchmarkEvidenceKind.benchmarkTrace,
+            },
+      thresholds: thresholds,
+    );
+  }
+
+  static Set<AiroBenchmarkStableValue> _gateIds(List<String> ids) {
+    return {for (final id in ids) AiroBenchmarkStableValue.stable(id)};
+  }
+}

--- a/packages/platform_certification/test/benchmark_device_class_models_test.dart
+++ b/packages/platform_certification/test/benchmark_device_class_models_test.dart
@@ -1,0 +1,295 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:platform_certification/platform_certification.dart';
+
+void main() {
+  group('Airo benchmark device-class gates', () {
+    final now = DateTime.utc(2026, 7, 14, 12);
+
+    test('default matrix exposes stable benchmark device classes', () {
+      final matrix = AiroBenchmarkDeviceClasses.matrix();
+
+      expect(matrix.schemaVersion, kAiroBenchmarkDeviceClassSchemaVersion);
+      expect(matrix.profileById('constrained-tv-class-a'), isNotNull);
+      expect(matrix.profileById('standard-tv-class-b'), isNotNull);
+      expect(matrix.profileById('mobile-companion-class'), isNotNull);
+      expect(matrix.profileById('desktop-companion-class'), isNotNull);
+      expect(
+        matrix.profileById('constrained-tv-class-a')!.requiredGateIds,
+        contains(AiroBenchmarkStableValue.stable('scroll-while-import')),
+      );
+    });
+
+    test('passing constrained TV evidence satisfies required gates', () {
+      final matrix = AiroBenchmarkDeviceClasses.matrix();
+      final samples = _passingSamplesFor(
+        matrix: matrix,
+        deviceClassId: 'constrained-tv-class-a',
+        now: now,
+      );
+
+      final result = matrix.evaluate(
+        deviceClassId: 'constrained-tv-class-a',
+        samples: samples,
+        now: now,
+      );
+
+      expect(result.passed, isTrue);
+      expect(result.toDiagnosticMap(), {
+        'deviceClassId': 'constrained-tv-class-a',
+        'passed': true,
+        'codes': <String>[],
+      });
+    });
+
+    test('missing and wrong-class samples return deterministic blockers', () {
+      final matrix = AiroBenchmarkDeviceClasses.matrix();
+      final result = matrix.evaluate(
+        deviceClassId: 'constrained-tv-class-a',
+        now: now,
+        samples: [
+          _sample(
+            deviceClassId: 'standard-tv-class-b',
+            gateId: 'startup-latency',
+            metric: AiroBenchmarkMetric.elapsedMillis,
+            value: 1000,
+            evidenceKind: AiroBenchmarkEvidenceKind.physicalDeviceRun,
+            now: now,
+          ),
+        ],
+      );
+
+      expect(result.passed, isFalse);
+      expect(
+        result.blockers.map((blocker) => blocker.code),
+        contains(AiroBenchmarkBlockerCode.sampleWrongDeviceClass),
+      );
+      expect(
+        result.blockers.map((blocker) => blocker.code),
+        contains(AiroBenchmarkBlockerCode.sampleMissing),
+      );
+    });
+
+    test('host-only and stale samples cannot satisfy physical gates', () {
+      final matrix = AiroBenchmarkDeviceClasses.matrix();
+      final result = matrix.evaluate(
+        deviceClassId: 'constrained-tv-class-a',
+        now: now,
+        samples: [
+          _sample(
+            gateId: 'startup-latency',
+            metric: AiroBenchmarkMetric.elapsedMillis,
+            value: 1000,
+            evidenceKind: AiroBenchmarkEvidenceKind.hostAutomation,
+            capturedAt: now,
+            now: now,
+          ),
+          _sample(
+            gateId: 'startup-latency',
+            metric: AiroBenchmarkMetric.peakMemoryMb,
+            value: 100,
+            evidenceKind: AiroBenchmarkEvidenceKind.physicalDeviceRun,
+            capturedAt: now.subtract(const Duration(days: 30)),
+            now: now,
+          ),
+        ],
+      );
+
+      expect(
+        result.blockers.map((blocker) => blocker.code),
+        contains(AiroBenchmarkBlockerCode.hostOnlyEvidenceForPhysicalGate),
+      );
+      expect(
+        result.blockers.map((blocker) => blocker.code),
+        contains(AiroBenchmarkBlockerCode.sampleStale),
+      );
+    });
+
+    test('metric threshold failures are typed by direction', () {
+      final matrix = AiroBenchmarkDeviceClasses.matrix();
+      final result = matrix.evaluate(
+        deviceClassId: 'standard-tv-class-b',
+        now: now,
+        samples: [
+          ..._passingSamplesFor(
+            matrix: matrix,
+            deviceClassId: 'standard-tv-class-b',
+            now: now,
+          ),
+          _sample(
+            deviceClassId: 'standard-tv-class-b',
+            gateId: 'large-playlist-import',
+            metric: AiroBenchmarkMetric.rowsPerSecond,
+            value: 10,
+            evidenceKind: AiroBenchmarkEvidenceKind.hostAutomation,
+            now: now,
+          ),
+          _sample(
+            deviceClassId: 'standard-tv-class-b',
+            gateId: 'remote-during-playback',
+            metric: AiroBenchmarkMetric.droppedFramePercent,
+            value: 50,
+            evidenceKind: AiroBenchmarkEvidenceKind.physicalDeviceRun,
+            now: now,
+          ),
+        ],
+      );
+
+      expect(
+        result.blockers.map((blocker) => blocker.code),
+        contains(AiroBenchmarkBlockerCode.metricBelowMinimum),
+      );
+      expect(
+        result.blockers.map((blocker) => blocker.code),
+        contains(AiroBenchmarkBlockerCode.metricAboveMaximum),
+      );
+    });
+
+    test('unknown and unsupported classes fail before support claims', () {
+      final matrix = AiroBenchmarkDeviceClassMatrix(
+        profiles: [
+          AiroBenchmarkDeviceClassProfile(
+            deviceClassId: AiroBenchmarkStableValue.stable('unsupported-box'),
+            deviceClass: AiroBenchmarkDeviceClass.constrainedTv,
+            platform: AiroValidationPlatform.androidTv,
+            productProfile: AiroValidationProductProfile.liteReceiver,
+            canAdvertiseSupport: false,
+            requiredGateIds: const {},
+          ),
+        ],
+        gates: const [],
+      );
+
+      final missing = matrix.evaluate(
+        deviceClassId: 'missing-class',
+        samples: const [],
+        now: now,
+      );
+      final unsupported = matrix.evaluate(
+        deviceClassId: 'unsupported-box',
+        samples: const [],
+        now: now,
+      );
+
+      expect(
+        missing.blockers.single.code,
+        AiroBenchmarkBlockerCode.deviceClassMissing,
+      );
+      expect(
+        unsupported.blockers.single.code,
+        AiroBenchmarkBlockerCode.unsupportedDeviceClass,
+      );
+    });
+
+    test('stable value rejects raw private benchmark identifiers', () {
+      expect(
+        () => AiroBenchmarkStableValue.stable('https://example.com/sample'),
+        throwsArgumentError,
+      );
+      expect(
+        () => AiroBenchmarkStableValue.stable('/Users/me/sample'),
+        throwsArgumentError,
+      );
+      expect(
+        () => AiroBenchmarkStableValue.stable('10.0.0.20'),
+        throwsArgumentError,
+      );
+      expect(
+        () => AiroBenchmarkStableValue.stable('Basic abc123'),
+        throwsArgumentError,
+      );
+    });
+
+    test('no-op and fake evidence providers are deterministic', () async {
+      const noop = AiroNoOpBenchmarkEvidenceProvider();
+      final fake = AiroFakeBenchmarkEvidenceProvider(
+        samples: [
+          _sample(
+            deviceClassId: 'desktop-companion-class',
+            gateId: 'cache-cleanup',
+            metric: AiroBenchmarkMetric.storageMb,
+            value: 128,
+            now: now,
+          ),
+          _sample(
+            deviceClassId: 'mobile-companion-class',
+            gateId: 'search-responsiveness',
+            metric: AiroBenchmarkMetric.elapsedMillis,
+            value: 80,
+            now: now,
+          ),
+        ],
+      );
+
+      expect(
+        await noop.samplesForDeviceClass(
+          AiroBenchmarkStableValue.stable('desktop-companion-class'),
+        ),
+        isEmpty,
+      );
+      expect(
+        await fake.samplesForDeviceClass(
+          AiroBenchmarkStableValue.stable('desktop-companion-class'),
+        ),
+        hasLength(1),
+      );
+    });
+  });
+}
+
+List<AiroBenchmarkSample> _passingSamplesFor({
+  required AiroBenchmarkDeviceClassMatrix matrix,
+  required String deviceClassId,
+  required DateTime now,
+}) {
+  final profile = matrix.profileById(deviceClassId)!;
+  final samples = <AiroBenchmarkSample>[];
+  for (final gateId in profile.requiredGateIds) {
+    final gate = matrix.gateById(gateId)!;
+    for (final threshold in gate.thresholds) {
+      samples.add(
+        _sample(
+          deviceClassId: deviceClassId,
+          gateId: gateId.value,
+          metric: threshold.metric,
+          value: _passingValue(threshold),
+          evidenceKind: gate.requiresPhysicalDevice
+              ? AiroBenchmarkEvidenceKind.physicalDeviceRun
+              : AiroBenchmarkEvidenceKind.hostAutomation,
+          now: now,
+        ),
+      );
+    }
+  }
+  return samples;
+}
+
+double _passingValue(AiroBenchmarkMetricThreshold threshold) {
+  final max = threshold.maximum;
+  if (max != null) return max / 2;
+  final min = threshold.minimum;
+  if (min != null) return min * 2;
+  return 1;
+}
+
+AiroBenchmarkSample _sample({
+  required String gateId,
+  required AiroBenchmarkMetric metric,
+  required double value,
+  required DateTime now,
+  String deviceClassId = 'constrained-tv-class-a',
+  AiroBenchmarkEvidenceKind evidenceKind =
+      AiroBenchmarkEvidenceKind.hostAutomation,
+  DateTime? capturedAt,
+}) {
+  return AiroBenchmarkSample(
+    sampleId: AiroBenchmarkStableValue.stable(
+      '$deviceClassId-$gateId-${metric.stableId}',
+    ),
+    deviceClassId: AiroBenchmarkStableValue.stable(deviceClassId),
+    gateId: AiroBenchmarkStableValue.stable(gateId),
+    metric: metric,
+    value: value,
+    evidenceKind: evidenceKind,
+    capturedAt: capturedAt ?? now,
+  );
+}


### PR DESCRIPTION
## Summary
- Adds benchmark device-class gates to platform_certification.
- Defines device-class profiles, benchmark gates, samples, deterministic blockers, and no-op/fake evidence providers.
- Documents the Airo TV benchmark device-class boundary under docs/features/airo-tv.

Closes #626

## Validation
- dart format --set-exit-if-changed packages/platform_certification
- cd packages/platform_certification && flutter test
- cd packages/platform_certification && flutter analyze --fatal-infos
- git diff --check origin/v2..HEAD && git diff --check

## Human/device-loop note
- Physical benchmark evidence still requires real devices/lab runs before a device class is advertised as certified or compatible.
- Firebase release config still needs the registered io.airo.app.tv Android client added to the google-services config/secret separately.