### PR TITLE
fix(android): remove explicit Kotlin plugin usage

### DIFF
--- a/app/android/app/build.gradle.kts
+++ b/app/android/app/build.gradle.kts
@@ -34,9 +34,14 @@ val variantAppLabel = when (appVariant) {
 
 plugins {
     id("com.android.application")
-    id("kotlin-android")
-    // The Flutter Gradle Plugin must be applied after the Android and Kotlin Gradle plugins.
+    // The Flutter Gradle Plugin must be applied after the Android Gradle plugin.
     id("dev.flutter.flutter-gradle-plugin")
+}
+
+kotlin {
+    compilerOptions {
+        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17)
+    }
 }
 
 val hasGoogleServicesConfig = listOf(
@@ -62,12 +67,6 @@ android {
         targetCompatibility = JavaVersion.VERSION_17
         // Enable core library desugaring for flutter_local_notifications
         isCoreLibraryDesugaringEnabled = true
-    }
-
-    kotlin {
-        compilerOptions {
-            jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17)
-        }
     }
 
     defaultConfig {

--- a/packages/platform_player/third_party/flutter_chrome_cast/android/build.gradle
+++ b/packages/platform_player/third_party/flutter_chrome_cast/android/build.gradle
@@ -2,7 +2,6 @@ group 'com.felnanuke.google_cast'
 version '1.0-SNAPSHOT'
 
 buildscript {
-    ext.kotlin_version = '2.1.0'
     repositories {
         google()
         mavenCentral()
@@ -10,7 +9,6 @@ buildscript {
 
     dependencies {
         classpath 'com.android.tools.build:gradle:8.6.0'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
 
@@ -22,7 +20,6 @@ rootProject.allprojects {
 }
 
 apply plugin: 'com.android.library'
-apply plugin: 'kotlin-android'
 
 
 android {
@@ -34,10 +31,6 @@ android {
         targetCompatibility JavaVersion.VERSION_11
     }
 
-    kotlinOptions {
-        jvmTarget = '11'
-    }
-
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
     }
@@ -47,8 +40,13 @@ android {
     }
 }
 
+kotlin {
+    compilerOptions {
+        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_11
+    }
+}
+
 dependencies {
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation 'androidx.appcompat:appcompat:1.6.1'
     implementation 'androidx.mediarouter:mediarouter:1.4.0'
     implementation 'com.google.android.gms:play-services-cast-framework:21.5.0'


### PR DESCRIPTION
# Summary

This PR reduces Flutter 3.44 Kotlin Gradle Plugin migration warnings for v2 Android builds by removing explicit KGP application from repo-owned Android Gradle files.

Goal: move the app and vendored Cast plugin toward Flutter/AGP built-in Kotlin compatibility without changing runtime behavior or release workflows.

Core outcome:

* Android app no longer declares `kotlin-android` in `app/android/app/build.gradle.kts`.
* Vendored `flutter_chrome_cast` Android Gradle file no longer declares a Kotlin Gradle Plugin classpath, applies `kotlin-android`, or depends on `kotlin-stdlib-jdk7` directly.
* Kotlin JVM targets are expressed with the `kotlin { compilerOptions { ... } }` DSL.

# Changes

### Code

* Updated:
  * `app/android/app/build.gradle.kts` to remove explicit app KGP usage and keep JVM 17 compiler options at top level.
  * `packages/platform_player/third_party/flutter_chrome_cast/android/build.gradle` to remove explicit KGP usage and keep JVM 11 compiler options at top level.

### Logic

* No runtime logic change.
* No package ID change.
* No release/publish workflow change.

# API Changes

None.

# Database Changes

None.

# Observability / Logging

None.

# Performance Impact

No expected runtime impact.

# Risks

* This does not fully close #568 because the current app dependency graph still includes third-party plugins that explicitly apply KGP.
* The debug TV build still reports KGP warnings for `flutter_image_compress_common`, `flutter_tts`, `patrol`, `pdfx`, and `wakelock_plus`.
* Full closure needs compatible upstream plugin releases, dependency resolution updates, or local patches for those plugins.

Rollback plan:

* Revert this commit to restore the previous explicit KGP app/Cast plugin configuration.

# Testing

* `flutter build apk --debug --no-pub -DAPP_VARIANT=tv --target-platform android-arm64 --android-skip-build-dependency-validation`
  * Passed.
  * Built `build/app/outputs/flutter-apk/app-debug.apk` locally.
  * Warning list no longer includes the Android app, `flutter_chrome_cast`, `audio_session`, or `package_info_plus`.

# Deployment Notes

* Draft PR only.
* No CI release jobs, app distribution, signing, publishing, or monitoring workflows were triggered.

# Related Issues

* Partially addresses #568.
