### PR TITLE
fix(iptv): harden Airo TV browse layout

### DIFF
--- a/packages/feature_iptv/lib/presentation/tv/iptv_tv_screen.dart
+++ b/packages/feature_iptv/lib/presentation/tv/iptv_tv_screen.dart
@@ -208,13 +208,21 @@ class _TvBrowseLayout extends ConsumerWidget {
     final searchQuery = ref.watch(channelSearchQueryProvider);
     final selectedCategory = ref.watch(selectedCategoryProvider);
     final currentChannel = ref.watch(currentChannelProvider);
+    final viewport = MediaQuery.sizeOf(context);
+    final compactTv = viewport.height < 760 || viewport.width < 1200;
+    final denseTv = viewport.height < 650;
 
     return Padding(
-      padding: const EdgeInsets.fromLTRB(32, 24, 32, 24),
+      padding: EdgeInsets.fromLTRB(
+        compactTv ? 20 : 32,
+        compactTv ? 16 : 24,
+        compactTv ? 20 : 32,
+        compactTv ? 16 : 24,
+      ),
       child: Column(
         children: [
           _TvLiteReceiverShellHeader(productProfile: productProfile),
-          const SizedBox(height: 18),
+          SizedBox(height: compactTv ? 12 : 18),
           _TvHeader(
             channelCount: allChannels.length,
             visibleCount: visibleChannels.length,
@@ -224,13 +232,13 @@ class _TvBrowseLayout extends ConsumerWidget {
             onSearchTap: onSearchTap,
             onRefresh: onRefresh,
           ),
-          const SizedBox(height: 24),
+          SizedBox(height: compactTv ? 16 : 24),
           Expanded(
             child: Row(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
                 SizedBox(
-                  width: 320,
+                  width: compactTv ? 280 : 320,
                   child: _TvCategoryRail(
                     selectedCategory: selectedCategory,
                     onCategorySelected: (category) {
@@ -244,11 +252,14 @@ class _TvBrowseLayout extends ConsumerWidget {
                 Expanded(
                   child: Column(
                     children: [
-                      _TvPlayerPanel(
-                        streamingState: streamingState,
-                        currentChannel: currentChannel,
-                      ),
-                      const SizedBox(height: 20),
+                      if (!denseTv) ...[
+                        _TvPlayerPanel(
+                          streamingState: streamingState,
+                          currentChannel: currentChannel,
+                          compact: compactTv,
+                        ),
+                        SizedBox(height: compactTv ? 12 : 20),
+                      ],
                       _TvChannelToolbar(
                         viewMode: viewMode,
                         recentOnly: recentOnly,
@@ -258,7 +269,7 @@ class _TvBrowseLayout extends ConsumerWidget {
                         onClearFilters: onClearFilters,
                         onViewModeChanged: onViewModeChanged,
                       ),
-                      const SizedBox(height: 16),
+                      SizedBox(height: compactTv ? 10 : 16),
                       Expanded(
                         child: DecoratedBox(
                           decoration: BoxDecoration(
@@ -278,6 +289,7 @@ class _TvBrowseLayout extends ConsumerWidget {
                               ? _TvChannelGridView(
                                   channels: visibleChannels,
                                   currentChannel: currentChannel,
+                                  compact: denseTv,
                                   onChannelSelect: onChannelSelect,
                                 )
                               : _TvChannelListView(
@@ -293,7 +305,7 @@ class _TvBrowseLayout extends ConsumerWidget {
               ],
             ),
           ),
-          const SizedBox(height: 12),
+          SizedBox(height: compactTv ? 8 : 12),
           const IPTVMiniPlayer(forceVisible: true),
         ],
       ),
@@ -521,6 +533,14 @@ class _TvCategoryRail extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final counts = ref.watch(categoryCounts);
     final theme = Theme.of(context);
+    final visibleCategories = _visibleCategories
+        .where(
+          (category) =>
+              category == ChannelCategory.all ||
+              category == selectedCategory ||
+              (counts[category] ?? 0) > 0,
+        )
+        .toList(growable: false);
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
@@ -536,9 +556,9 @@ class _TvCategoryRail extends ConsumerWidget {
               mainAxisSpacing: 12,
               crossAxisSpacing: 12,
             ),
-            itemCount: _visibleCategories.length,
+            itemCount: visibleCategories.length,
             itemBuilder: (context, index) {
-              final category = _visibleCategories[index];
+              final category = visibleCategories[index];
               return _TvCategoryTile(
                 category: category,
                 count: counts[category] ?? 0,
@@ -625,10 +645,12 @@ class _TvPlayerPanel extends StatelessWidget {
   const _TvPlayerPanel({
     required this.streamingState,
     required this.currentChannel,
+    required this.compact,
   });
 
   final AsyncValue<StreamingState> streamingState;
   final IPTVChannel? currentChannel;
+  final bool compact;
 
   @override
   Widget build(BuildContext context) {
@@ -642,11 +664,11 @@ class _TvPlayerPanel extends StatelessWidget {
         borderRadius: BorderRadius.circular(8),
       ),
       child: Padding(
-        padding: const EdgeInsets.all(16),
+        padding: EdgeInsets.all(compact ? 12 : 16),
         child: Row(
           children: [
             SizedBox(
-              width: 420,
+              width: compact ? 300 : 420,
               child: AspectRatio(
                 aspectRatio: 16 / 9,
                 child: streamingState.when(
@@ -658,7 +680,7 @@ class _TvPlayerPanel extends StatelessWidget {
                 ),
               ),
             ),
-            const SizedBox(width: 20),
+            SizedBox(width: compact ? 16 : 20),
             Expanded(
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
@@ -668,7 +690,9 @@ class _TvPlayerPanel extends StatelessWidget {
                     currentChannel?.name ?? 'Choose a channel',
                     maxLines: 2,
                     overflow: TextOverflow.ellipsis,
-                    style: theme.textTheme.headlineSmall,
+                    style: compact
+                        ? theme.textTheme.titleLarge
+                        : theme.textTheme.headlineSmall,
                   ),
                   const SizedBox(height: 8),
                   Text(
@@ -770,42 +794,68 @@ class _TvChannelToolbar extends StatelessWidget {
   }
 }
 
-class _TvChannelGridView extends StatelessWidget {
+class _TvChannelGridView extends StatefulWidget {
   const _TvChannelGridView({
     required this.channels,
     required this.currentChannel,
+    required this.compact,
     required this.onChannelSelect,
   });
 
   final List<IPTVChannel> channels;
   final IPTVChannel? currentChannel;
+  final bool compact;
   final ValueChanged<IPTVChannel> onChannelSelect;
 
   @override
+  State<_TvChannelGridView> createState() => _TvChannelGridViewState();
+}
+
+class _TvChannelGridViewState extends State<_TvChannelGridView> {
+  late final ScrollController _scrollController;
+
+  @override
+  void initState() {
+    super.initState();
+    _scrollController = ScrollController();
+  }
+
+  @override
+  void dispose() {
+    _scrollController.dispose();
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
-    return GridView.builder(
-      padding: const EdgeInsets.all(16),
-      gridDelegate: const SliverGridDelegateWithMaxCrossAxisExtent(
-        maxCrossAxisExtent: 220,
-        childAspectRatio: 1.03,
-        mainAxisSpacing: 16,
-        crossAxisSpacing: 16,
+    return Scrollbar(
+      controller: _scrollController,
+      thumbVisibility: true,
+      child: GridView.builder(
+        controller: _scrollController,
+        padding: const EdgeInsets.all(16),
+        gridDelegate: SliverGridDelegateWithMaxCrossAxisExtent(
+          maxCrossAxisExtent: widget.compact ? 180 : 220,
+          childAspectRatio: widget.compact ? 1.2 : 1.03,
+          mainAxisSpacing: 16,
+          crossAxisSpacing: 16,
+        ),
+        itemCount: widget.channels.length,
+        itemBuilder: (context, index) {
+          final channel = widget.channels[index];
+          return _TvChannelCard(
+            channel: channel,
+            isPlaying: widget.currentChannel?.id == channel.id,
+            autofocus: index == 0,
+            onSelect: () => widget.onChannelSelect(channel),
+          );
+        },
       ),
-      itemCount: channels.length,
-      itemBuilder: (context, index) {
-        final channel = channels[index];
-        return _TvChannelCard(
-          channel: channel,
-          isPlaying: currentChannel?.id == channel.id,
-          autofocus: index == 0,
-          onSelect: () => onChannelSelect(channel),
-        );
-      },
     );
   }
 }
 
-class _TvChannelListView extends StatelessWidget {
+class _TvChannelListView extends StatefulWidget {
   const _TvChannelListView({
     required this.channels,
     required this.currentChannel,
@@ -817,20 +867,44 @@ class _TvChannelListView extends StatelessWidget {
   final ValueChanged<IPTVChannel> onChannelSelect;
 
   @override
+  State<_TvChannelListView> createState() => _TvChannelListViewState();
+}
+
+class _TvChannelListViewState extends State<_TvChannelListView> {
+  late final ScrollController _scrollController;
+
+  @override
+  void initState() {
+    super.initState();
+    _scrollController = ScrollController();
+  }
+
+  @override
+  void dispose() {
+    _scrollController.dispose();
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
-    return ListView.separated(
-      padding: const EdgeInsets.all(16),
-      itemCount: channels.length,
-      separatorBuilder: (_, _) => const SizedBox(height: 10),
-      itemBuilder: (context, index) {
-        final channel = channels[index];
-        return _TvChannelRow(
-          channel: channel,
-          isPlaying: currentChannel?.id == channel.id,
-          autofocus: index == 0,
-          onSelect: () => onChannelSelect(channel),
-        );
-      },
+    return Scrollbar(
+      controller: _scrollController,
+      thumbVisibility: true,
+      child: ListView.separated(
+        controller: _scrollController,
+        padding: const EdgeInsets.all(16),
+        itemCount: widget.channels.length,
+        separatorBuilder: (_, _) => const SizedBox(height: 10),
+        itemBuilder: (context, index) {
+          final channel = widget.channels[index];
+          return _TvChannelRow(
+            channel: channel,
+            isPlaying: widget.currentChannel?.id == channel.id,
+            autofocus: index == 0,
+            onSelect: () => widget.onChannelSelect(channel),
+          );
+        },
+      ),
     );
   }
 }
@@ -1472,7 +1546,7 @@ class _TvPlaylistGuideDialog extends StatelessWidget {
         ),
       ),
       actions: [
-        TextButton(
+        FilledButton(
           onPressed: () => Navigator.of(context).pop(),
           child: const Text('Done'),
         ),

--- a/packages/feature_iptv/test/iptv/presentation/tv/iptv_tv_screen_test.dart
+++ b/packages/feature_iptv/test/iptv/presentation/tv/iptv_tv_screen_test.dart
@@ -1,6 +1,7 @@
 import 'package:feature_iptv/feature_iptv.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
@@ -27,13 +28,28 @@ void main() {
       group: 'Music',
       category: ChannelCategory.music,
     ),
+    const IPTVChannel(
+      id: 'news-2',
+      name: 'Global News',
+      streamUrl: 'https://example.com/global-news.m3u8',
+      group: 'News',
+      category: ChannelCategory.news,
+    ),
+    const IPTVChannel(
+      id: 'sports-2',
+      name: 'Match Center',
+      streamUrl: 'https://example.com/match-center.m3u8',
+      group: 'Sports',
+      category: ChannelCategory.sports,
+    ),
   ];
 
   Future<void> pumpScreen(
     WidgetTester tester, {
     List<IPTVChannel>? visibleChannels,
+    Size surfaceSize = const Size(1280, 720),
   }) async {
-    await tester.binding.setSurfaceSize(const Size(1280, 720));
+    await tester.binding.setSurfaceSize(surfaceSize);
     addTearDown(() => tester.binding.setSurfaceSize(null));
     SharedPreferences.setMockInitialValues({});
     final prefs = await SharedPreferences.getInstance();
@@ -77,18 +93,55 @@ void main() {
     expect(find.text('Diagnostics'), findsOneWidget);
     expect(find.text('Guide'), findsNothing);
     expect(find.textContaining('Profile-limited:'), findsOneWidget);
-    expect(find.text('3 of 3 live channels'), findsOneWidget);
+    expect(find.text('5 of 5 live channels'), findsOneWidget);
     expect(find.text('Browse'), findsOneWidget);
     expect(find.text('All'), findsWidgets);
     expect(find.text('News'), findsWidgets);
     expect(find.text('Sports'), findsWidgets);
     expect(find.text('Music'), findsWidgets);
+    expect(find.text('Business'), findsNothing);
+    expect(find.text('General'), findsNothing);
     expect(find.text('Search'), findsWidgets);
     expect(find.text('Playlist'), findsOneWidget);
     expect(find.text('Help'), findsOneWidget);
     expect(find.text('Refresh'), findsOneWidget);
     expect(find.text('City News Live'), findsOneWidget);
     expect(find.text('Music India'), findsOneWidget);
+    expect(find.byType(Scrollbar), findsOneWidget);
+    expect(find.bySemanticsLabel('Search'), findsWidgets);
+    expect(find.bySemanticsLabel('City News Live'), findsOneWidget);
+  });
+
+  testWidgets('keeps compact TV viewport browse controls reachable', (
+    tester,
+  ) async {
+    await pumpScreen(tester, surfaceSize: const Size(1024, 576));
+
+    expect(find.text('Live channels'), findsOneWidget);
+    expect(find.text('Search'), findsWidgets);
+    expect(find.text('Playlist'), findsOneWidget);
+    expect(find.text('Help'), findsOneWidget);
+    expect(find.text('Refresh'), findsOneWidget);
+    expect(find.text('Browse'), findsOneWidget);
+    expect(find.text('City News Live'), findsOneWidget);
+    expect(find.byType(Scrollbar), findsOneWidget);
+  });
+
+  testWidgets('shows readable playlist guide with primary dismissal', (
+    tester,
+  ) async {
+    await pumpScreen(tester);
+
+    await tester.sendKeyEvent(LogicalKeyboardKey.arrowRight);
+    await tester.pump();
+    await tester.sendKeyEvent(LogicalKeyboardKey.arrowRight);
+    await tester.pump();
+    await tester.sendKeyEvent(LogicalKeyboardKey.enter);
+    await tester.pumpAndSettle();
+
+    expect(find.text('How to add a playlist'), findsOneWidget);
+    expect(find.text('Find your playlist URL'), findsOneWidget);
+    expect(find.widgetWithText(FilledButton, 'Done'), findsOneWidget);
   });
 
   testWidgets('shows TV empty playlist state', (tester) async {


### PR DESCRIPTION
# Summary

This PR hardens the Airo TV IPTV browse surface for #589 by addressing a focused slice of the release audit findings.

Goal: improve compact TV layout behavior, reduce wasted category rail space, and add clearer TV browse affordances without changing IPTV playback contracts.

Core outcome:

* Compact TV viewports keep browse controls and channel cards reachable.
* Zero-count categories are removed from the visible rail unless currently selected.
* Channel grid/list views now show persistent scrollbars for TV browsing affordance.
* Playlist guide dismissal is a primary `Done` action.

# Changes

### Code

* Updated:
  * `packages/feature_iptv/lib/presentation/tv/iptv_tv_screen.dart`
    * adds compact/dense viewport layout rules
    * hides the preview panel on very short TV viewports
    * uses denser grid cards where needed
    * filters zero-count category tiles
    * adds persistent scrollbars to grid/list channel browsing
    * upgrades playlist guide dismissal to `FilledButton`

### Tests

* Updated:
  * `packages/feature_iptv/test/iptv/presentation/tv/iptv_tv_screen_test.dart`
    * verifies zero-count categories are hidden
    * verifies scroll affordance and semantics labels exist
    * covers compact `1024x576` viewport reachability
    * covers playlist guide primary dismissal

# API Changes

None.

# Database Changes

None.

# Observability / Logging

None.

# Performance Impact

No expected runtime performance impact. The change adds local scroll controllers for TV channel grid/list widgets.

# Risks

* This is a focused #589 slice, not full browser/real-device release certification.
* Physical Android TV / Fire TV D-pad QA is still required for full #589 closure.
* Browser screenshot validation across the full viewport matrix is still recommended before closing #589.

Rollback plan:

* Revert this commit to restore the previous TV browse layout.

# Testing

* `cd packages/feature_iptv && flutter test test/iptv/presentation/tv/iptv_tv_screen_test.dart`
* `cd app && flutter test test/core/app/tv_router_test.dart`

# Deployment Notes

* Draft PR only.
* No release publishing, signing, app distribution, CI release jobs, or monitoring workflows were triggered manually.

# Related Issues

* Partially addresses #589.
