### PR TITLE
fix(iptv): add Cast VPN discovery guidance

### DIFF
--- a/packages/feature_iptv/lib/presentation/widgets/cast_device_picker_sheet.dart
+++ b/packages/feature_iptv/lib/presentation/widgets/cast_device_picker_sheet.dart
@@ -5,6 +5,13 @@ import 'package:platform_player/platform_player.dart';
 import '../../application/providers/iptv_cast_providers.dart';
 import 'adaptive_iptv_sheet.dart';
 
+const _castDiscoveryTroubleshootingGuidance =
+    'Make sure the TV is awake and Cast is enabled, both devices are on the '
+    'same Wi-Fi, and router client isolation is off.\n\n'
+    'VPN may be blocking discovery. If the TV or Android/Fire TV uses a VPN, '
+    'enable split tunneling/bypass for the TV player/Cast app or temporarily '
+    'turn off the TV VPN.';
+
 Future<void> showIptvCastDevicePicker({
   required BuildContext context,
   required ValueChanged<AiroCastDevice> onDeviceSelected,
@@ -106,9 +113,7 @@ class _DiscoveryBody extends StatelessWidget {
       AiroCastDiscoveryPhase.noDevices => ListTile(
         leading: const Icon(Icons.cast),
         title: const Text('No Cast devices found'),
-        subtitle: const Text(
-          'Make sure the TV is awake, Cast is enabled, both devices are on the same Wi-Fi, and router client isolation is off.',
-        ),
+        subtitle: const Text(_castDiscoveryTroubleshootingGuidance),
         trailing: TextButton(
           onPressed: onRetry,
           child: const Text('Scan again'),
@@ -117,7 +122,7 @@ class _DiscoveryBody extends StatelessWidget {
       AiroCastDiscoveryPhase.failed => ListTile(
         leading: const Icon(Icons.error_outline),
         title: const Text('Cast discovery failed'),
-        subtitle: Text(discovery.error ?? 'Try again.'),
+        subtitle: Text(_failedDiscoveryMessage(discovery.error)),
         trailing: TextButton(onPressed: onRetry, child: const Text('Retry')),
       ),
       AiroCastDiscoveryPhase.found => Column(
@@ -140,4 +145,22 @@ class _DiscoveryBody extends StatelessWidget {
       ),
     };
   }
+}
+
+String _failedDiscoveryMessage(String? error) {
+  final failure = error ?? 'Try again.';
+  if (_errorExplainsPermissionOrPlatformUnavailability(failure)) {
+    return failure;
+  }
+
+  return '$failure\n\n$_castDiscoveryTroubleshootingGuidance';
+}
+
+bool _errorExplainsPermissionOrPlatformUnavailability(String error) {
+  final normalized = error.toLowerCase();
+  return normalized.contains('permission') ||
+      normalized.contains('local network access') ||
+      normalized.contains('platform unavailable') ||
+      normalized.contains('not available on this platform') ||
+      normalized.contains('not supported on this platform');
 }

--- a/packages/feature_iptv/test/iptv/iptv_cast_ui_test.dart
+++ b/packages/feature_iptv/test/iptv/iptv_cast_ui_test.dart
@@ -23,6 +23,109 @@ void main() {
     expect(find.text('Sony Bravia'), findsOneWidget);
   });
 
+  testWidgets('empty Cast discovery shows no devices state', (tester) async {
+    final fake = FakeAiroCastController();
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [airoCastControllerProvider.overrideWithValue(fake)],
+        child: const MaterialApp(home: CastDevicePickerTestHost()),
+      ),
+    );
+
+    await tester.tap(find.text('Open'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('No Cast devices found'), findsOneWidget);
+    expect(find.text('Scan again'), findsOneWidget);
+  });
+
+  testWidgets('empty Cast discovery includes VPN guidance', (tester) async {
+    final fake = FakeAiroCastController();
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [airoCastControllerProvider.overrideWithValue(fake)],
+        child: const MaterialApp(home: CastDevicePickerTestHost()),
+      ),
+    );
+
+    await tester.tap(find.text('Open'));
+    await tester.pumpAndSettle();
+
+    expect(
+      find.textContaining('TV is awake and Cast is enabled'),
+      findsOneWidget,
+    );
+    expect(find.textContaining('same Wi-Fi'), findsOneWidget);
+    expect(
+      find.textContaining('router client isolation is off'),
+      findsOneWidget,
+    );
+    expect(
+      find.textContaining('VPN may be blocking discovery'),
+      findsOneWidget,
+    );
+    expect(find.textContaining('split tunneling/bypass'), findsOneWidget);
+    expect(
+      find.textContaining('temporarily turn off the TV VPN'),
+      findsOneWidget,
+    );
+    expect(find.textContaining('VPN detected'), findsNothing);
+  });
+
+  testWidgets(
+    'failed discovery keeps controller error and offers retry guidance',
+    (tester) async {
+      final fake = FakeAiroCastController(failDiscovery: true);
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [airoCastControllerProvider.overrideWithValue(fake)],
+          child: const MaterialApp(home: CastDevicePickerTestHost()),
+        ),
+      );
+
+      await tester.tap(find.text('Open'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Cast discovery failed'), findsOneWidget);
+      expect(find.textContaining('Cast discovery failed'), findsNWidgets(2));
+      expect(
+        find.textContaining('VPN may be blocking discovery'),
+        findsOneWidget,
+      );
+      expect(find.text('Retry'), findsOneWidget);
+    },
+  );
+
+  testWidgets('retry action starts Cast discovery again', (tester) async {
+    final fake = FakeAiroCastController();
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [airoCastControllerProvider.overrideWithValue(fake)],
+        child: const MaterialApp(home: CastDevicePickerTestHost()),
+      ),
+    );
+
+    await tester.tap(find.text('Open'));
+    await tester.pumpAndSettle();
+
+    expect(
+      fake.recordedActions.where((action) => action == 'startDiscovery'),
+      hasLength(1),
+    );
+
+    await tester.tap(find.text('Scan again'));
+    await tester.pumpAndSettle();
+
+    expect(
+      fake.recordedActions.where((action) => action == 'startDiscovery'),
+      hasLength(2),
+    );
+  });
+
   testWidgets('mini controller shows active cast session', (tester) async {
     final media = AiroCastMediaRequest(
       url: Uri.parse('https://example.com/live.m3u8'),


### PR DESCRIPTION
# Summary

This PR adds recoverable Cast discovery guidance for the IPTV Cast picker when no Chromecast/TV is found or discovery fails without an existing permission/platform explanation.

Core outcome:

* keeps the existing Cast discovery states and retry actions
* expands the no-devices state with TV wake/Cast, same Wi-Fi, router isolation, and VPN split-tunneling guidance
* keeps controller failure text visible while adding the same retry-oriented local-network/VPN guidance when appropriate

# Changes

### Code

* Updated `packages/feature_iptv/lib/presentation/widgets/cast_device_picker_sheet.dart`
  * added shared troubleshooting copy for no-devices and retryable failed discovery
  * keeps `Scan again` for no devices and `Retry` for failed discovery
  * avoids labeling the state as VPN detected

### Tests

* Updated `packages/feature_iptv/test/iptv/iptv_cast_ui_test.dart`
  * empty discovery shows `No Cast devices found`
  * empty discovery includes VPN/split-tunneling guidance
  * failed discovery keeps controller error text and retry guidance
  * retry action calls `startDiscovery()` again

# API Changes

None.

# Risks

Low. This is UI copy and focused widget coverage only; no Cast protocol, platform model, or public API changes.

# Testing

* `cd packages/feature_iptv && flutter test test/iptv/iptv_cast_ui_test.dart`
* `cd packages/feature_iptv && flutter test test/iptv/iptv_cast_notifier_test.dart`

Note: the first parallel notifier test attempt hit Flutter's local startup/native-asset lock before tests ran; rerunning serially passed.
