### PR TITLE
test(release): add Airo TV viewport qualification profiles

### DIFF
--- a/docs/release/UI_RESPONSIVENESS_VALIDATION.md
+++ b/docs/release/UI_RESPONSIVENESS_VALIDATION.md
@@ -40,6 +40,23 @@ device-only behavior, full-screen system UI, or feature-specific states:
 | Error state | Recoverable failures show actionable retry/error UI | Feature-specific manual flows |
 | Loading state | Long-running operations show progress without layout jumps | Feature-specific manual flows |
 
+## Airo TV Browser Viewport Qualification
+
+For Airo TV IPTV release candidates, capture browser or qualification-app
+screenshots for the viewports below before closing the UI release audit:
+
+| Viewport | Qualification profile | Required result |
+| --- | --- | --- |
+| `1920x1080` | `Android TV 1080p` | TV shell renders without overflow, clipped actions, or hidden channel browsing |
+| `1280x720` | `Android TV 720p` | At least one full channel row remains visible with a clear scroll affordance |
+| `1024x576` | `Android TV Compact Browser` | Compact TV layout keeps primary actions and browsing reachable |
+| `390x844` | `Mobile Browser Fallback` | The responsive mobile IPTV surface is used instead of the 10-foot TV shell |
+
+Use `app/lib/main_qualification.dart` with
+`packages/platform_device_qualification` when device screenshots are required.
+The reusable `SimulatedDevice` profiles include this matrix so QA can capture
+consistent evidence without adding Airo-TV-only viewport logic.
+
 ## Suggested Android Checks
 
 Use a connected Android device when possible:

--- a/docs/release/V2_RELEASE_QUALIFICATION.md
+++ b/docs/release/V2_RELEASE_QUALIFICATION.md
@@ -41,6 +41,21 @@ Store-only AAB artifacts require build integrity, checksum, and upload-result
 evidence before production store submission. Play upload automation is tracked
 separately in #681.
 
+### Airo TV Viewport Evidence
+
+The Airo TV IPTV browser release audit additionally requires responsive
+viewport evidence for:
+
+- `1920x1080` Android TV 1080p;
+- `1280x720` Android TV 720p;
+- `1024x576` Android TV compact browser;
+- `390x844` mobile browser fallback.
+
+Capture this evidence through `app/lib/main_qualification.dart` and the
+reusable `platform_device_qualification` simulated-device profiles. Attach the
+screenshots or browser validation notes to the release qualification evidence
+before closing the Airo TV UI audit.
+
 ## Evidence JSON Format
 
 Evidence files are intentionally simple JSON so local QA, BrowserStack,

--- a/packages/platform_device_qualification/lib/src/resolution_simulator.dart
+++ b/packages/platform_device_qualification/lib/src/resolution_simulator.dart
@@ -1,42 +1,29 @@
 import 'package:flutter/material.dart';
 
 enum SimulatedDevice {
-  native(
-    name: 'Native (Full Screen)',
-    width: 0,
-    height: 0,
+  native(name: 'Native (Full Screen)', width: 0, height: 0, isTv: false),
+  mobileBrowserPortrait(
+    name: 'Mobile Browser Fallback',
+    width: 390,
+    height: 844,
     isTv: false,
   ),
-  androidTv720p(
-    name: 'Android TV 720p',
-    width: 1280,
-    height: 720,
+  androidTvCompactBrowser(
+    name: 'Android TV Compact Browser',
+    width: 1024,
+    height: 576,
     isTv: true,
   ),
+  androidTv720p(name: 'Android TV 720p', width: 1280, height: 720, isTv: true),
   androidTv1080p(
     name: 'Android TV 1080p',
     width: 1920,
     height: 1080,
     isTv: true,
   ),
-  fireTvStick(
-    name: 'Fire TV Stick',
-    width: 1920,
-    height: 1080,
-    isTv: true,
-  ),
-  googleTv4k(
-    name: 'Google TV 4K',
-    width: 3840,
-    height: 2160,
-    isTv: true,
-  ),
-  shieldTv4k(
-    name: 'Shield TV 4K',
-    width: 3840,
-    height: 2160,
-    isTv: true,
-  ),
+  fireTvStick(name: 'Fire TV Stick', width: 1920, height: 1080, isTv: true),
+  googleTv4k(name: 'Google TV 4K', width: 3840, height: 2160, isTv: true),
+  shieldTv4k(name: 'Shield TV 4K', width: 3840, height: 2160, isTv: true),
   tabletLandscape(
     name: 'Tablet Landscape (iPad)',
     width: 1024,
@@ -56,11 +43,6 @@ enum SimulatedDevice {
     isTv: false,
   );
 
-  final String name;
-  final double width;
-  final double height;
-  final bool isTv;
-
   const SimulatedDevice({
     required this.name,
     required this.width,
@@ -68,20 +50,25 @@ enum SimulatedDevice {
     required this.isTv,
   });
 
+  final String name;
+  final double width;
+  final double height;
+  final bool isTv;
+
   bool get isNative => this == SimulatedDevice.native;
 }
 
 class ResolutionSimulator extends StatelessWidget {
-  final Widget child;
-  final SimulatedDevice device;
-  final bool showBezel;
-
   const ResolutionSimulator({
-    super.key,
     required this.child,
     required this.device,
     this.showBezel = true,
+    super.key,
   });
+
+  final Widget child;
+  final SimulatedDevice device;
+  final bool showBezel;
 
   @override
   Widget build(BuildContext context) {
@@ -96,10 +83,10 @@ class ResolutionSimulator extends StatelessWidget {
         final parentSize = constraints.biggest;
 
         // Calculate aspect ratios
-        final double parentAspect = parentSize.width / parentSize.height;
-        final double targetAspect = simulatedSize.width / simulatedSize.height;
+        final parentAspect = parentSize.width / parentSize.height;
+        final targetAspect = simulatedSize.width / simulatedSize.height;
 
-        double scale = 1.0;
+        var scale = 1.toDouble();
         if (targetAspect > parentAspect) {
           // Limited by width
           scale = parentSize.width / simulatedSize.width;
@@ -109,11 +96,11 @@ class ResolutionSimulator extends StatelessWidget {
         }
 
         // Apply a small margin so the simulated screen doesn't touch the edges
-        final double marginFactor = showBezel ? 0.90 : 1.0;
+        final marginFactor = showBezel ? 0.9 : 1.toDouble();
         scale *= marginFactor;
 
-        final double finalWidth = simulatedSize.width * scale;
-        final double finalHeight = simulatedSize.height * scale;
+        final finalWidth = simulatedSize.width * scale;
+        final finalHeight = simulatedSize.height * scale;
 
         return Container(
           color: Colors.grey[950],
@@ -123,7 +110,7 @@ class ResolutionSimulator extends StatelessWidget {
               children: [
                 if (showBezel) ...[
                   Padding(
-                    padding: const EdgeInsets.only(bottom: 8.0),
+                    padding: const EdgeInsets.only(bottom: 8),
                     child: Text(
                       '${device.name} (${device.width.toInt()} × ${device.height.toInt()})',
                       style: const TextStyle(
@@ -143,7 +130,7 @@ class ResolutionSimulator extends StatelessWidget {
                     boxShadow: showBezel
                         ? [
                             BoxShadow(
-                              color: Colors.black.withOpacity(0.6),
+                              color: Colors.black.withValues(alpha: 0.6),
                               blurRadius: 16,
                               spreadRadius: 2,
                             ),
@@ -155,7 +142,6 @@ class ResolutionSimulator extends StatelessWidget {
                   ),
                   child: ClipRect(
                     child: FittedBox(
-                      fit: BoxFit.contain,
                       child: SizedBox(
                         width: simulatedSize.width,
                         height: simulatedSize.height,

--- a/packages/platform_device_qualification/test/resolution_simulator_test.dart
+++ b/packages/platform_device_qualification/test/resolution_simulator_test.dart
@@ -3,51 +3,109 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:platform_device_qualification/src/resolution_simulator.dart';
 
 void main() {
-  testWidgets('ResolutionSimulator overrides MediaQuery size and navigationMode', (WidgetTester tester) async {
-    late MediaQueryData capturedMediaQuery;
+  testWidgets(
+    'ResolutionSimulator overrides MediaQuery size and navigationMode',
+    (WidgetTester tester) async {
+      late MediaQueryData capturedMediaQuery;
 
-    await tester.pumpWidget(
-      MaterialApp(
-        home: ResolutionSimulator(
-          device: SimulatedDevice.androidTv1080p,
-          showBezel: false,
-          child: Builder(
-            builder: (context) {
-              capturedMediaQuery = MediaQuery.of(context);
-              return const SizedBox.shrink();
-            },
+      await tester.pumpWidget(
+        MaterialApp(
+          home: ResolutionSimulator(
+            device: SimulatedDevice.androidTv1080p,
+            showBezel: false,
+            child: Builder(
+              builder: (context) {
+                capturedMediaQuery = MediaQuery.of(context);
+                return const SizedBox.shrink();
+              },
+            ),
           ),
         ),
-      ),
-    );
+      );
 
-    // Verify overridden size matches 1920x1080 (Android TV 1080p profile)
-    expect(capturedMediaQuery.size.width, 1920);
-    expect(capturedMediaQuery.size.height, 1080);
-    expect(capturedMediaQuery.navigationMode, NavigationMode.directional);
-  });
+      // Verify overridden size matches 1920x1080 (Android TV 1080p profile)
+      expect(capturedMediaQuery.size.width, 1920);
+      expect(capturedMediaQuery.size.height, 1080);
+      expect(capturedMediaQuery.navigationMode, NavigationMode.directional);
+    },
+  );
 
-  testWidgets('ResolutionSimulator passes through native size when set to native', (WidgetTester tester) async {
-    late MediaQueryData capturedMediaQuery;
+  testWidgets(
+    'ResolutionSimulator passes through native size when set to native',
+    (WidgetTester tester) async {
+      late MediaQueryData capturedMediaQuery;
 
-    await tester.pumpWidget(
-      MaterialApp(
-        home: ResolutionSimulator(
-          device: SimulatedDevice.native,
-          showBezel: false,
-          child: Builder(
-            builder: (context) {
-              capturedMediaQuery = MediaQuery.of(context);
-              return const SizedBox.shrink();
-            },
+      await tester.pumpWidget(
+        MaterialApp(
+          home: ResolutionSimulator(
+            device: SimulatedDevice.native,
+            showBezel: false,
+            child: Builder(
+              builder: (context) {
+                capturedMediaQuery = MediaQuery.of(context);
+                return const SizedBox.shrink();
+              },
+            ),
           ),
         ),
-      ),
-    );
+      );
 
-    // Native mode does not override sizes, so it matches the test window size (800x600 by default in widget tests)
-    expect(capturedMediaQuery.size.width, 800);
-    expect(capturedMediaQuery.size.height, 600);
-    expect(capturedMediaQuery.navigationMode, NavigationMode.traditional);
-  });
+      // Native mode does not override sizes, so it matches the test window size (800x600 by default in widget tests)
+      expect(capturedMediaQuery.size.width, 800);
+      expect(capturedMediaQuery.size.height, 600);
+      expect(capturedMediaQuery.navigationMode, NavigationMode.traditional);
+    },
+  );
+
+  testWidgets(
+    'ResolutionSimulator supports compact TV browser qualification viewport',
+    (WidgetTester tester) async {
+      late MediaQueryData capturedMediaQuery;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: ResolutionSimulator(
+            device: SimulatedDevice.androidTvCompactBrowser,
+            showBezel: false,
+            child: Builder(
+              builder: (context) {
+                capturedMediaQuery = MediaQuery.of(context);
+                return const SizedBox.shrink();
+              },
+            ),
+          ),
+        ),
+      );
+
+      expect(capturedMediaQuery.size.width, 1024);
+      expect(capturedMediaQuery.size.height, 576);
+      expect(capturedMediaQuery.navigationMode, NavigationMode.directional);
+    },
+  );
+
+  testWidgets(
+    'ResolutionSimulator supports narrow mobile browser fallback viewport',
+    (WidgetTester tester) async {
+      late MediaQueryData capturedMediaQuery;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: ResolutionSimulator(
+            device: SimulatedDevice.mobileBrowserPortrait,
+            showBezel: false,
+            child: Builder(
+              builder: (context) {
+                capturedMediaQuery = MediaQuery.of(context);
+                return const SizedBox.shrink();
+              },
+            ),
+          ),
+        ),
+      );
+
+      expect(capturedMediaQuery.size.width, 390);
+      expect(capturedMediaQuery.size.height, 844);
+      expect(capturedMediaQuery.navigationMode, NavigationMode.traditional);
+    },
+  );
 }

--- a/scripts/run_visual_qualification.sh
+++ b/scripts/run_visual_qualification.sh
@@ -49,26 +49,32 @@ fi
 echo "📡 Seeding and loading IPTV channels (https://iptv-org.github.io/iptv/index.m3u)..."
 sleep 10
 
-# Simulated devices order in SimulatedDevice enum:
+# The overlay auto-cycles every 8 seconds and this script waits 10 seconds for
+# playlist warmup before the first screenshot. Labels start at the first
+# post-warmup profile, then follow the SimulatedDevice enum cycle.
 # 1. Native
-# 2. Android TV 720p
-# 3. Android TV 1080p
-# 4. Fire TV Stick
-# 5. Google TV 4K
-# 6. Shield TV 4K
-# 7. Tablet Landscape
-# 8. Foldable Portrait
-# 9. Foldable Landscape
+# 2. Mobile Browser Fallback
+# 3. Android TV Compact Browser
+# 4. Android TV 720p
+# 5. Android TV 1080p
+# 6. Fire TV Stick
+# 7. Google TV 4K
+# 8. Shield TV 4K
+# 9. Tablet Landscape
+# 10. Foldable Portrait
+# 11. Foldable Landscape
 DEVICES=(
-  "01_native_ipad_air"
-  "02_android_tv_720p"
-  "03_android_tv_1080p"
-  "04_fire_tv_stick"
-  "05_google_tv_4k"
-  "06_shield_tv_4k"
-  "07_tablet_landscape"
-  "08_foldable_portrait"
-  "09_foldable_landscape"
+  "01_mobile_browser_fallback_390x844"
+  "02_android_tv_compact_browser_1024x576"
+  "03_android_tv_720p"
+  "04_android_tv_1080p"
+  "05_fire_tv_stick"
+  "06_google_tv_4k"
+  "07_shield_tv_4k"
+  "08_tablet_landscape"
+  "09_foldable_portrait"
+  "10_foldable_landscape"
+  "11_native_ipad_air"
 )
 
 # Step 5: Loop to take screenshots at each layout cycle


### PR DESCRIPTION
# Summary

This PR adds reusable Airo TV browser viewport qualification profiles to the platform device qualification tooling.
Goal: make the remaining #589 browser evidence gate repeatable instead of relying on ad hoc screenshot naming.

Core outcome:

* Added compact TV and narrow mobile fallback simulator profiles.
* Documented the required Airo TV browser viewport matrix for v2 release qualification.
* Aligned the visual qualification screenshot labels with the overlay auto-cycle after playlist warmup.

# Changes

### Code

* Added:
  * `SimulatedDevice.mobileBrowserPortrait` for `390x844` browser fallback checks.
  * `SimulatedDevice.androidTvCompactBrowser` for `1024x576` compact TV checks.
* Updated:
  * `scripts/run_visual_qualification.sh` screenshot labels to include the #589 viewport matrix and match post-warmup auto-cycle order.
  * `docs/release/UI_RESPONSIVENESS_VALIDATION.md` with Airo TV browser viewport qualification requirements.
  * `docs/release/V2_RELEASE_QUALIFICATION.md` with Airo TV viewport evidence requirements.

### Logic

* TV simulator profiles continue to use directional navigation mode.
* Narrow browser fallback uses traditional navigation mode.
* The reusable platform qualification package owns the viewport profiles so Airo TV can consume them without app-specific test-only viewport code.

# API Changes

None.

# Database Changes

None.

# Observability / Logging

None.

# Performance Impact

No runtime production impact. The change only affects qualification tooling and documentation.

# Risks

* Existing screenshot automation depends on the overlay auto-cycle interval. This PR documents and aligns the current label order, but a future interval change must update the script labels.
* This does not complete physical Android TV / Fire TV D-pad validation for #589.

Rollback plan:

* Revert this PR to remove the added simulator profiles and documentation updates.

# Testing

* `cd packages/platform_device_qualification && flutter test`
* `cd packages/platform_device_qualification && flutter analyze lib/src/resolution_simulator.dart test/resolution_simulator_test.dart --fatal-infos`
* `bash -n scripts/run_visual_qualification.sh`
* `cd packages/feature_iptv && flutter test test/iptv/presentation/tv/iptv_tv_screen_test.dart`

# Deployment Notes

No config or deployment changes.

# Related Commits

* `test(release): add Airo TV viewport qualification profiles`

# Notes

Advances #589 by adding repeatable browser viewport evidence tooling. #589 still needs actual screenshot/browser evidence capture and physical TV/Fire TV D-pad validation before full closure.
