### PR TITLE
test(release): add Airo TV browser viewport evidence

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,7 @@ vendor/
 *.log
 logs/
 artifacts/agent-skills-journey/
+artifacts/airo-tv-browser-viewports/
 $CODEX_HOME/
 app/pubspec.yaml.backup
 .superpowers/

--- a/app/lib/main_tv.dart
+++ b/app/lib/main_tv.dart
@@ -15,7 +15,9 @@ library;
 
 import 'package:dio/dio.dart';
 import 'package:firebase_core/firebase_core.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/semantics.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -42,6 +44,13 @@ void main() async {
 
   // Initialize global error handler for unhandled exceptions
   GlobalErrorHandler.initialize();
+
+  // Enable semantics for browser release-audit automation and accessibility
+  // inspection. This mirrors the main web entrypoint behavior.
+  if (kIsWeb) {
+    SemanticsBinding.instance.ensureSemantics();
+    debugPrint('Semantics enabled for Airo TV web testing');
+  }
 
   await configureTvSystemChrome();
 
@@ -136,4 +145,5 @@ Future<void> seedTvDebugDefaultPlaylist(
   if (parserService.getPlaylistUrl() != null) return;
 
   await parserService.setPlaylistUrl(playlistUrl);
+  await parserService.fetchPlaylist(forceRefresh: true);
 }

--- a/app/test/main_tv_debug_playlist_test.dart
+++ b/app/test/main_tv_debug_playlist_test.dart
@@ -1,3 +1,6 @@
+import 'dart:async';
+import 'dart:io';
+
 import 'package:airo_app/core/platform/device_form_factor.dart';
 import 'package:airo_app/main_tv.dart';
 import 'package:dio/dio.dart';
@@ -32,6 +35,45 @@ void main() {
     );
 
     expect(parser.getPlaylistUrl(), 'https://example.com/user.m3u');
+  });
+
+  test('warms cache for DEBUG_IPTV_PLAYLIST_URL fixture', () async {
+    SharedPreferences.setMockInitialValues({});
+    final prefs = await SharedPreferences.getInstance();
+    final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+
+    unawaited(
+      server.forEach((request) {
+        request.response
+          ..headers.contentType = ContentType.text
+          ..write('''
+#EXTM3U
+#EXTINF:-1 tvg-id="news.local" group-title="News",Airo News
+https://example.test/live/news.m3u8
+''')
+          ..close();
+      }),
+    );
+
+    final playlistUrl = Uri(
+      scheme: 'http',
+      host: InternetAddress.loopbackIPv4.address,
+      port: server.port,
+      path: '/fixture.m3u',
+    ).toString();
+
+    try {
+      await seedTvDebugDefaultPlaylist(prefs, playlistUrl: playlistUrl);
+    } finally {
+      await server.close(force: true);
+    }
+
+    final parser = M3UParserService(dio: Dio(), prefs: prefs);
+    expect(parser.getPlaylistUrl(), playlistUrl);
+
+    final cachedChannels = await parser.fetchPlaylist();
+    expect(cachedChannels, hasLength(1));
+    expect(cachedChannels.single.name, 'Airo News');
   });
 
   test('does not lock orientation on mobile devices', () async {

--- a/docs/release/UI_RESPONSIVENESS_VALIDATION.md
+++ b/docs/release/UI_RESPONSIVENESS_VALIDATION.md
@@ -57,6 +57,21 @@ Use `app/lib/main_qualification.dart` with
 The reusable `SimulatedDevice` profiles include this matrix so QA can capture
 consistent evidence without adding Airo-TV-only viewport logic.
 
+For repeatable browser evidence, run:
+
+```bash
+scripts/validate_airo_tv_browser_viewports.sh
+```
+
+The script builds the Airo TV web profile bundle from `app/lib/main_tv.dart`,
+serves the deterministic IPTV fixture, checks the viewport matrix with
+Playwright, and writes screenshots under
+`artifacts/airo-tv-browser-viewports/`.
+
+If the local Playwright browser cache is unavailable but Google Chrome is
+installed, set `AIRO_TV_USE_SYSTEM_CHROME=1` for local evidence capture. CI
+should continue to install and use the standard Playwright browser package.
+
 ## Suggested Android Checks
 
 Use a connected Android device when possible:

--- a/docs/release/V2_RELEASE_QUALIFICATION.md
+++ b/docs/release/V2_RELEASE_QUALIFICATION.md
@@ -56,6 +56,15 @@ reusable `platform_device_qualification` simulated-device profiles. Attach the
 screenshots or browser validation notes to the release qualification evidence
 before closing the Airo TV UI audit.
 
+When browser-only evidence is enough for a pre-device release audit slice, run:
+
+```bash
+scripts/validate_airo_tv_browser_viewports.sh
+```
+
+Attach the generated `artifacts/airo-tv-browser-viewports/` screenshots or the
+Playwright result summary to the release qualification evidence.
+
 ## Evidence JSON Format
 
 Evidence files are intentionally simple JSON so local QA, BrowserStack,

--- a/e2e/fixtures/airo-tv-viewport.m3u
+++ b/e2e/fixtures/airo-tv-viewport.m3u
@@ -1,0 +1,9 @@
+#EXTM3U
+#EXTINF:-1 tvg-id="news.local" tvg-name="Airo News" group-title="News",Airo News
+https://example.test/live/news.m3u8
+#EXTINF:-1 tvg-id="sports.local" tvg-name="Airo Sports" group-title="Sports",Airo Sports
+https://example.test/live/sports.m3u8
+#EXTINF:-1 tvg-id="movies.local" tvg-name="Airo Movies" group-title="Movies",Airo Movies
+https://example.test/live/movies.m3u8
+#EXTINF:-1 tvg-id="kids.local" tvg-name="Airo Kids" group-title="Kids",Airo Kids
+https://example.test/live/kids.m3u8

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -8,6 +8,7 @@
     "test:firefox": "playwright test --project=firefox",
     "test:webkit": "playwright test --project=webkit",
     "test:mobile": "playwright test --project='Mobile Chrome' --project='Mobile Safari'",
+    "test:airo-tv-viewports": "playwright test --config=playwright.airo-tv.config.ts",
     "test:bill-split": "playwright test bill-split",
     "test:auth": "playwright test auth",
     "test:smoke": "playwright test --grep @smoke",
@@ -25,4 +26,3 @@
     "typescript": "^5.3.0"
   }
 }
-

--- a/e2e/playwright.airo-tv.config.ts
+++ b/e2e/playwright.airo-tv.config.ts
@@ -1,0 +1,49 @@
+import { defineConfig, devices } from '@playwright/test';
+import * as path from 'path';
+
+const webPort = Number(process.env.AIRO_TV_WEB_PORT ?? '8790');
+const baseURL = process.env.FLUTTER_WEB_URL ?? `http://127.0.0.1:${webPort}`;
+const artifactDir =
+  process.env.AIRO_TV_VIEWPORT_ARTIFACT_DIR ??
+  path.join(__dirname, '..', 'artifacts', 'airo-tv-browser-viewports');
+const useSystemChrome = process.env.AIRO_TV_USE_SYSTEM_CHROME === '1';
+
+export default defineConfig({
+  testDir: './tests/airo-tv',
+  fullyParallel: false,
+  retries: 0,
+  workers: 1,
+  reporter: [['list']],
+  outputDir: path.join(artifactDir, 'playwright-results'),
+  timeout: 90000,
+  expect: {
+    timeout: 15000,
+  },
+  use: {
+    baseURL,
+    trace: 'retain-on-failure',
+    screenshot: 'only-on-failure',
+    video: 'off',
+  },
+  projects: [
+    {
+      name: 'airo-tv-browser-viewports',
+      use: {
+        ...devices['Desktop Chrome'],
+        ...(useSystemChrome ? { channel: 'chrome' as const } : {}),
+      },
+    },
+  ],
+  webServer: {
+    command: `python3 -m http.server ${webPort} --bind 127.0.0.1 --directory ${path.join(
+      __dirname,
+      '..',
+      'app',
+      'build',
+      'web',
+    )}`,
+    url: baseURL,
+    reuseExistingServer: !process.env.CI,
+    timeout: 120000,
+  },
+});

--- a/e2e/tests/airo-tv/viewport-matrix.spec.ts
+++ b/e2e/tests/airo-tv/viewport-matrix.spec.ts
@@ -1,0 +1,113 @@
+import { expect, test } from '@playwright/test';
+import * as fs from 'fs';
+import * as path from 'path';
+import { waitForFlutterReady } from '../helpers/flutter-selectors';
+
+const artifactDir =
+  process.env.AIRO_TV_VIEWPORT_ARTIFACT_DIR ??
+  path.join(__dirname, '..', '..', '..', 'artifacts', 'airo-tv-browser-viewports');
+
+const viewports = [
+  {
+    id: 'android-tv-1080p',
+    label: 'Android TV 1080p',
+    width: 1920,
+    height: 1080,
+    expectedText: /Airo TV|Search|Playlist|Help|Refresh|Airo News/i,
+  },
+  {
+    id: 'android-tv-720p',
+    label: 'Android TV 720p',
+    width: 1280,
+    height: 720,
+    expectedText: /Airo TV|Search|Playlist|Help|Refresh|Airo News/i,
+  },
+  {
+    id: 'android-tv-compact-browser',
+    label: 'Android TV Compact Browser',
+    width: 1024,
+    height: 576,
+    expectedText: /Search|Playlist|Help|Refresh|Airo News/i,
+  },
+  {
+    id: 'mobile-browser-fallback',
+    label: 'Mobile Browser Fallback',
+    width: 390,
+    height: 844,
+    expectedText: /Airo News|IPTV|Channels|Playlist/i,
+  },
+] as const;
+
+test.describe('Airo TV browser viewport release evidence', () => {
+  for (const viewport of viewports) {
+    test(`${viewport.label} renders without Flutter overflow`, async ({
+      page,
+    }) => {
+      const consoleErrors: string[] = [];
+      const pageErrors: string[] = [];
+
+      page.on('console', (message) => {
+        if (message.type() === 'error') {
+          consoleErrors.push(message.text());
+        }
+      });
+      page.on('pageerror', (error) => {
+        pageErrors.push(error.message);
+      });
+
+      await page.setViewportSize({
+        width: viewport.width,
+        height: viewport.height,
+      });
+
+      await page.goto('/');
+      await waitForFlutterReady(page, 60000);
+      await page.waitForSelector('flt-glass-pane, canvas', {
+        state: 'attached',
+      });
+      await expect(page.locator('body')).toBeVisible();
+      await expect
+        .poll(
+          async () =>
+            page
+              .locator('flt-semantics, [role="button"], [role="heading"]')
+              .count(),
+          { timeout: 30000 },
+        )
+        .toBeGreaterThan(0);
+      await expect(page.getByText(viewport.expectedText).first()).toBeVisible({
+        timeout: 60000,
+      });
+
+      await expect
+        .poll(
+          async () =>
+            page.evaluate(() =>
+              Object.entries(window.localStorage)
+                .filter(([key]) => key.includes('iptv'))
+                .map(([key, value]) => `${key}=${value}`)
+                .join('\n'),
+            ),
+          { timeout: 30000 },
+        )
+        .toContain('airo-tv-viewport.m3u');
+
+      fs.mkdirSync(artifactDir, { recursive: true });
+      const screenshotPath = path.join(
+        artifactDir,
+        `${viewport.id}-${viewport.width}x${viewport.height}.png`,
+      );
+      await page.screenshot({ path: screenshotPath, fullPage: true });
+      expect(fs.statSync(screenshotPath).size).toBeGreaterThan(10000);
+
+      const combinedErrors = [...consoleErrors, ...pageErrors];
+      const overflowErrors = combinedErrors.filter((entry) =>
+        /RenderFlex overflowed|A RenderFlex overflowed|EXCEPTION CAUGHT BY RENDERING LIBRARY/i.test(
+          entry,
+        ),
+      );
+
+      expect(overflowErrors).toEqual([]);
+    });
+  }
+});

--- a/scripts/validate_airo_tv_browser_viewports.sh
+++ b/scripts/validate_airo_tv_browser_viewports.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+APP_DIR="$ROOT_DIR/app"
+E2E_DIR="$ROOT_DIR/e2e"
+WEB_PORT="${AIRO_TV_WEB_PORT:-8790}"
+ARTIFACT_DIR="${AIRO_TV_VIEWPORT_ARTIFACT_DIR:-$ROOT_DIR/artifacts/airo-tv-browser-viewports}"
+PLAYLIST_URL="http://127.0.0.1:${WEB_PORT}/fixtures/airo-tv-viewport.m3u"
+
+echo "Building Airo TV web profile bundle for viewport validation..."
+cd "$APP_DIR"
+flutter build web --profile --no-wasm-dry-run \
+  --target=lib/main_tv.dart \
+  --dart-define=APP_VARIANT=tv \
+  --dart-define=APP_PLATFORM=androidTv \
+  --dart-define=DEBUG_IPTV_PLAYLIST_URL="$PLAYLIST_URL"
+
+mkdir -p "$APP_DIR/build/web/fixtures" "$ARTIFACT_DIR"
+cp "$E2E_DIR/fixtures/airo-tv-viewport.m3u" \
+  "$APP_DIR/build/web/fixtures/airo-tv-viewport.m3u"
+
+echo "Running Airo TV browser viewport validation..."
+cd "$E2E_DIR"
+AIRO_TV_WEB_PORT="$WEB_PORT" \
+AIRO_TV_VIEWPORT_ARTIFACT_DIR="$ARTIFACT_DIR" \
+AIRO_TV_USE_SYSTEM_CHROME="${AIRO_TV_USE_SYSTEM_CHROME:-0}" \
+npx playwright test --config=playwright.airo-tv.config.ts "$@"
+
+echo "Airo TV browser viewport evidence written to $ARTIFACT_DIR"


### PR DESCRIPTION
# Summary

This PR adds repeatable browser viewport evidence for the Airo TV v2 UI audit.
Goal: make the #589 viewport validation reproducible from a clean v2 branch before physical TV / Fire TV D-pad testing is available.

Core outcome:

* Adds an Airo TV Playwright viewport matrix for 1920x1080, 1280x720, 1024x576, and 390x844.
* Builds `app/lib/main_tv.dart` with a deterministic IPTV fixture and captures screenshots under `artifacts/airo-tv-browser-viewports/`.
* Enables Flutter web semantics from the TV entrypoint so browser evidence can assert accessible labels.

# Changes

### Code

* Added:
  * `scripts/validate_airo_tv_browser_viewports.sh`
  * `e2e/playwright.airo-tv.config.ts`
  * `e2e/tests/airo-tv/viewport-matrix.spec.ts`
  * `e2e/fixtures/airo-tv-viewport.m3u`
* Updated:
  * `app/lib/main_tv.dart` enables web semantics and warms debug playlist cache.
  * `app/test/main_tv_debug_playlist_test.dart` covers DEBUG_IPTV_PLAYLIST_URL cache warming.
  * release qualification docs include the browser evidence workflow.
  * `.gitignore` excludes generated viewport evidence artifacts.

### Logic

* The validation script builds the TV web profile bundle with `DEBUG_IPTV_PLAYLIST_URL` pointing at the served fixture.
* Playwright asserts semantic content, fixture-backed playlist state, screenshot output, and absence of Flutter overflow/rendering-library errors across the viewport matrix.

# Testing

* `dart format app/lib/main_tv.dart app/test/main_tv_debug_playlist_test.dart`
* `bash -n scripts/validate_airo_tv_browser_viewports.sh`
* `cd e2e && npx tsc --noEmit --project tsconfig.json`
* `cd app && flutter analyze lib/main_tv.dart --fatal-infos`
* `cd app && flutter test test/core/app/tv_router_test.dart test/main_tv_debug_playlist_test.dart`
* `AIRO_TV_USE_SYSTEM_CHROME=1 scripts/validate_airo_tv_browser_viewports.sh`

# Risks

* This is browser evidence only. It does not replace physical Android TV / Fire TV D-pad traversal for final #589 closure.
* Local machines without Playwright browser cache may need `AIRO_TV_USE_SYSTEM_CHROME=1`; CI should use the standard Playwright browser install.

# Related

* Advances #589
