### PR TITLE
fix(firebase): configure Android TV app options

### DIFF
--- a/app/lib/firebase_options.dart
+++ b/app/lib/firebase_options.dart
@@ -47,7 +47,7 @@ class DefaultFirebaseOptions {
   /// Returns false for generated placeholder options that would crash native
   /// Firebase initialization before Dart can recover.
   static bool isConfigured(FirebaseOptions options) {
-    return options.appId.isNotEmpty && !options.appId.contains('YOUR_');
+    return _isConfigured(options);
   }
 
   /// Get Firebase options for the current platform and variant
@@ -147,13 +147,9 @@ class DefaultFirebaseOptions {
   );
 
   /// Android TV - io.airo.app.tv
-  ///
-  /// The current TV release is auth-free, so Firebase remains disabled until a
-  /// Firebase Android client is registered for this package and this app id is
-  /// regenerated.
   static const FirebaseOptions androidTv = FirebaseOptions(
     apiKey: 'AIzaSyCBhj62CjX9G7-QNbF3e-53BiM3FYcWNxw',
-    appId: 'TODO_REGISTER_IO_AIRO_APP_TV',
+    appId: '1:906799550225:android:dfa957aac3a2fdc62206b0',
     messagingSenderId: '906799550225',
     projectId: 'devscoffee-airo',
     storageBucket: 'devscoffee-airo.firebasestorage.app',

--- a/app/test/firebase_options_test.dart
+++ b/app/test/firebase_options_test.dart
@@ -23,6 +23,26 @@ void main() {
         DefaultFirebaseOptions.isConfigured(DefaultFirebaseOptions.android),
         isTrue,
       );
+      expect(
+        DefaultFirebaseOptions.isConfigured(DefaultFirebaseOptions.androidTv),
+        isTrue,
+      );
+    });
+
+    test('uses the registered Android TV Firebase app id', () {
+      expect(
+        DefaultFirebaseOptions.androidTv.appId,
+        '1:906799550225:android:dfa957aac3a2fdc62206b0',
+      );
+    });
+
+    test('keeps streaming disabled until its Firebase app is registered', () {
+      expect(
+        DefaultFirebaseOptions.isConfigured(
+          DefaultFirebaseOptions.androidStreaming,
+        ),
+        isFalse,
+      );
     });
   });
 }


### PR DESCRIPTION
# Summary

This PR updates the v2 Firebase options so the Android TV variant uses the registered Firebase Android app id for `io.airo.app.tv`.

Core outcome:

* `DefaultFirebaseOptions.androidTv` now has the registered Firebase app id.
* `DefaultFirebaseOptions.isConfigured` now reuses the placeholder-aware check that rejects both `YOUR_` and `TODO` app ids.
* Tests cover Android TV configured state and keep the streaming placeholder explicitly disabled.

# Changes

### Code

* Updated `app/lib/firebase_options.dart`
  * replaced `TODO_REGISTER_IO_AIRO_APP_TV` with the registered Android TV app id
  * routed `isConfigured` through the existing `_isConfigured` helper
* Updated `app/test/firebase_options_test.dart`
  * asserts Android TV options are configured
  * asserts the expected TV app id
  * asserts streaming remains unconfigured until its Firebase app is registered

# API Changes

None.

# Database Changes

None.

# Observability / Logging

None.

# Performance Impact

None expected.

# Risks

* This does not update the production `GOOGLE_SERVICES_JSON` GitHub Actions secret. Production Firebase-enabled release workflows still need that secret to contain the `io.airo.app.tv` Android client.
* Firebase API keys/app ids are public client configuration, not service credentials; no private service account material is added.

Rollback plan:

* Revert this commit to restore the auth-free placeholder TV Firebase app id.

# Testing

* `dart format app/lib/firebase_options.dart app/test/firebase_options_test.dart`
* `cd app && flutter test test/firebase_options_test.dart --reporter=compact`
* `cd app && flutter analyze lib/firebase_options.dart test/firebase_options_test.dart --no-fatal-infos --no-fatal-warnings`
* `git diff --staged --check`
* staged additions scanned for common secret keywords

# Related Issues

Closes code-side portion of #574. Human/setup work remains to regenerate and store `GOOGLE_SERVICES_JSON` with the `io.airo.app.tv` client.
