### PR TITLE
docs(release): mark TV Firebase setup resolved

### DIFF
--- a/docs/release/V2_HUMAN_IN_LOOP_BLOCKERS.md
+++ b/docs/release/V2_HUMAN_IN_LOOP_BLOCKERS.md
@@ -14,11 +14,16 @@ exports, playlist URLs, local IP addresses, or private device logs.
 
 | Issue | Blocker | Human action needed |
 | --- | --- | --- |
-| #574 | Firebase Android client for TV | `io.airo.app.tv` is registered; regenerate the production `google-services.json` or `GOOGLE_SERVICES_JSON` secret so it includes that package. |
-| #756 | Firebase Android clients for mobile/tablet profiles | The checked-in Firebase config currently only contains `io.airo.app`; add or confirm Firebase Android clients for the v2 `io.airo.app.*` mobile/tablet profiles, then regenerate the production Firebase config/secret. |
+| #756 | Firebase Android clients for mobile/tablet profiles | TV is verified separately under #574. Add or confirm Firebase Android clients for the remaining v2 `io.airo.app.*` mobile/tablet profiles, then regenerate the production Firebase config/secret. |
 | #576 | Android release signing | Confirm keystore owner, upload key strategy, key backup/rotation owner, and GitHub Actions signing secrets. |
 | #585 | Store automation credentials | Create/confirm Play Console service account, app access, upload permissions, first tracks, and App Store Connect credentials only if iOS/iPadOS enters scope. |
 | #682 | Firebase App Distribution | Create/confirm Firebase apps, app IDs, tester groups, and service account/token for internal QA uploads. |
+
+## Recently Resolved Release Setup
+
+| Issue | Setup | Verification |
+| --- | --- | --- |
+| #574 | Firebase Android client for TV | Closed. Verified `io.airo.app.tv` in the local ignored Android Firebase config and in public Flutter Firebase options with app ID `1:906799550225:android:dfa957aac3a2fdc62206b0`. The `GOOGLE_SERVICES_JSON` GitHub secret exists and was updated; GitHub does not allow reading secret contents back for direct comparison. |
 
 ### Exact Secret And Input Names
 
@@ -28,7 +33,7 @@ release or distribution run is intentionally started.
 
 | Purpose | GitHub secret or workflow input | Issues |
 | --- | --- | --- |
-| Firebase Android config for `io.airo.app`, `io.airo.app.iptv`, `io.airo.app.streaming`, and `io.airo.app.tv` | Secret: `GOOGLE_SERVICES_JSON` containing the base64-encoded regenerated `google-services.json` | #574, #756 |
+| Firebase Android config for remaining mobile/tablet `io.airo.app.*` clients | Secret: `GOOGLE_SERVICES_JSON` containing the base64-encoded regenerated `google-services.json` | #756 |
 | Android release keystore | Secret: `ANDROID_RELEASE_KEYSTORE_BASE64` | #576 |
 | Android keystore password | Secret: `KEYSTORE_PASSWORD` | #576 |
 | Android key alias | Secret: `KEY_ALIAS` | #576 |
@@ -125,10 +130,9 @@ maintainer-decision blockers above.
 
 ## Fastest Parallel Setup Order
 
-1. Firebase: complete #574 and #756 first because the repo currently proves
-   only `io.airo.app` in `app/android/app/google-services.json`; regenerated
-   package-specific Firebase configs unblock app initialization and Firebase
-   App Distribution setup.
+1. Firebase: complete #756 next because #574 TV Firebase setup is verified and
+   closed, while the remaining mobile/tablet `io.airo.app.*` Firebase clients
+   still need confirmation before Firebase App Distribution setup.
 2. Signing and Play access: complete #576 and #585 before any real store upload.
 3. Firebase App Distribution: complete #682 after Firebase app IDs and tester
    groups exist.

--- a/docs/release/V2_PUBLISHING_HUMAN_SETUP.md
+++ b/docs/release/V2_PUBLISHING_HUMAN_SETUP.md
@@ -38,17 +38,18 @@ Related issues: #681, #585, #657.
 
 ## Firebase App Distribution
 
-Related issues: #682, #574.
+Related issues: #682, #574, #756.
 
 - [ ] Create or confirm Firebase apps for each package ID that should receive
       internal APKs.
-- [x] Confirm the checked-in Firebase config currently only contains
-      `io.airo.app`; v2 Firebase setup must regenerate the secret instead of
-      changing package IDs.
-- [ ] Add or confirm Firebase Android client configs for the registered
-      `io.airo.app.*` packages that should use Firebase services. The TV
-      package `io.airo.app.tv` is already registered and must be included in
-      the regenerated config.
+- [x] Confirm the TV Firebase Android client for `io.airo.app.tv` is
+      registered and represented in public Flutter Firebase options.
+- [x] Confirm `GOOGLE_SERVICES_JSON` exists as a GitHub secret. Secret contents
+      cannot be read back from GitHub; compare against the local ignored config
+      before publishing.
+- [ ] Add or confirm Firebase Android client configs for the remaining
+      registered `io.airo.app.*` mobile/tablet packages that should use
+      Firebase services.
 - [ ] Create a Firebase service account or distribution token for CI.
 - [ ] Store the Firebase service account JSON as the GitHub Actions secret
       `FIREBASE_SERVICE_ACCOUNT_JSON`.


### PR DESCRIPTION
# Summary

This PR updates the v2 human-in-loop release docs after verifying the Android TV Firebase setup.

Core outcome:

* Moves #574 out of the active Firebase blocker list because it is closed and verified.
* Keeps #756 open for the remaining mobile/tablet io.airo.app.* Firebase client setup.
* Clarifies that GOOGLE_SERVICES_JSON secret metadata can be verified, but secret contents cannot be read back from GitHub.

# Testing

* git diff --check

# Notes

Docs-only follow-up. No secrets or generated Firebase config files are committed.