### PR TITLE
fix(accessibility): label agent skill controls

### DIFF
--- a/app/lib/features/agent_chat/presentation/widgets/manage_skills_sheet.dart
+++ b/app/lib/features/agent_chat/presentation/widgets/manage_skills_sheet.dart
@@ -69,6 +69,7 @@ class _ManageSkillsSheetState extends State<ManageSkillsSheet> {
             const SizedBox(height: 16),
             TextField(
               decoration: const InputDecoration(
+                labelText: 'Search skills',
                 hintText: 'Search for a skill',
                 prefixIcon: Icon(Icons.search),
                 border: OutlineInputBorder(),
@@ -142,6 +143,7 @@ class _SkillTile extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
+    final toggleLabel = '${skill.name} skill';
     return Container(
       padding: const EdgeInsets.all(14),
       decoration: BoxDecoration(
@@ -163,7 +165,16 @@ class _SkillTile extends StatelessWidget {
                   ),
                 ),
               ),
-              Switch(value: skill.enabled, onChanged: onChanged),
+              Semantics(
+                container: true,
+                label: toggleLabel,
+                value: skill.enabled ? 'Enabled' : 'Disabled',
+                toggled: skill.enabled,
+                onTap: () => onChanged(!skill.enabled),
+                child: ExcludeSemantics(
+                  child: Switch(value: skill.enabled, onChanged: onChanged),
+                ),
+              ),
             ],
           ),
           const SizedBox(height: 4),

--- a/app/test/features/agent_chat/presentation/widgets/manage_skills_sheet_test.dart
+++ b/app/test/features/agent_chat/presentation/widgets/manage_skills_sheet_test.dart
@@ -5,25 +5,61 @@ import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   testWidgets('manage skills sheet searches visible skills', (tester) async {
+    final semantics = tester.ensureSemantics();
     final registry = AgentSkillRegistry();
 
-    await tester.pumpWidget(
-      MaterialApp(
-        home: Scaffold(
-          body: ManageSkillsSheet(registry: registry, onChanged: () {}),
+    try {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: ManageSkillsSheet(registry: registry, onChanged: () {}),
+          ),
         ),
-      ),
-    );
+      );
 
-    expect(find.text('Manage Skills'), findsOneWidget);
-    expect(find.text('4 skills'), findsOneWidget);
-    expect(find.text('read-calendar-events'), findsOneWidget);
+      expect(find.text('Manage Skills'), findsOneWidget);
+      expect(find.bySemanticsLabel('Search skills'), findsOneWidget);
+      expect(find.text('4 skills'), findsOneWidget);
+      expect(find.text('read-calendar-events'), findsOneWidget);
 
-    await tester.enterText(find.byType(TextField), 'Open Airo');
-    await tester.pump();
+      await tester.enterText(find.byType(TextField), 'Open Airo');
+      await tester.pump();
 
-    expect(find.text('open-airo-feature'), findsOneWidget);
-    expect(find.text('read-calendar-events'), findsNothing);
+      expect(find.text('open-airo-feature'), findsOneWidget);
+      expect(find.text('read-calendar-events'), findsNothing);
+    } finally {
+      semantics.dispose();
+    }
+  });
+
+  testWidgets('manage skills toggles expose skill name and state', (
+    tester,
+  ) async {
+    final semantics = tester.ensureSemantics();
+    final registry = AgentSkillRegistry();
+
+    try {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: ManageSkillsSheet(registry: registry, onChanged: () {}),
+          ),
+        ),
+      );
+
+      final createEventToggle = find.bySemanticsLabel(
+        'Create Calendar Event skill',
+      );
+      expect(createEventToggle, findsOneWidget);
+      expect(tester.getSemantics(createEventToggle).value, 'Disabled');
+
+      await tester.tap(createEventToggle);
+      await tester.pump();
+
+      expect(tester.getSemantics(createEventToggle).value, 'Enabled');
+    } finally {
+      semantics.dispose();
+    }
   });
 
   testWidgets(

--- a/docs/wiki/5.-AI-and-Model-Management.md
+++ b/docs/wiki/5.-AI-and-Model-Management.md
@@ -82,6 +82,11 @@ The Agent Skills plan extends the current card and routing system with:
 - Action traces.
 - Calendar read/create as the first end-to-end connector.
 
+The Agent Skills manager is also part of the Brain accessibility surface. The
+skills search field exposes an accessible `Search skills` label, and each skill
+toggle announces the skill name plus whether it is enabled or disabled so
+screen-reader users can manage capabilities without relying on visual context.
+
 ## Reminder Notifications
 
 Agent-created reminder notifications now preserve stable deep-link context in


### PR DESCRIPTION
# Summary

This PR adds a focused accessibility slice for #283.

Core outcome:

* Agent Skills search now has an explicit accessible label.
* Each Agent Skills toggle exposes the skill name and enabled/disabled state to assistive technologies.
* Widget coverage verifies the search label and skill-toggle semantics.
* The AI/model-management wiki documents the Agent Skills accessibility behavior.

# Changes

### Code

* Updated `ManageSkillsSheet` to label the search field as `Search skills`.
* Wrapped skill switches in explicit `Semantics` nodes with skill-specific labels and state values.

### Tests

* Added semantics assertions to `manage_skills_sheet_test.dart`.

### Docs

* Updated `docs/wiki/5.-AI-and-Model-Management.md` with the Agent Skills manager accessibility behavior.

# Testing

* `dart format app/lib/features/agent_chat/presentation/widgets/manage_skills_sheet.dart app/test/features/agent_chat/presentation/widgets/manage_skills_sheet_test.dart`
* `cd app && flutter test test/features/agent_chat/presentation/widgets/manage_skills_sheet_test.dart --reporter=compact`
* `cd app && flutter analyze lib/features/agent_chat/presentation/widgets/manage_skills_sheet.dart test/features/agent_chat/presentation/widgets/manage_skills_sheet_test.dart --no-fatal-infos --no-fatal-warnings`
* `bash scripts/check-docs-completeness.sh --base origin/v2 --head HEAD`
* `git diff --check HEAD~1..HEAD`

# Notes

This does not claim to close #283. Manual screen-reader/focus-order coverage across the broader Brain surfaces is still required.

Closes no issue; advances #283.
