### PR TITLE
perf(playlist): reduce M3U dedup hot-path cost

### DIFF
--- a/docs/features/airo-tv/LARGE_PLAYLIST_WORKER_PIPELINE.md
+++ b/docs/features/airo-tv/LARGE_PLAYLIST_WORKER_PIPELINE.md
@@ -59,6 +59,19 @@ payloads in the contract.
 - `index`
 - `finalize`
 
+## Parser Hot-Path Contract
+
+M3U channel normalization and deduplication remain owned by
+`packages/platform_playlist_import`, not by Airo TV screens. The parser builds a
+single normalized key per channel during parse using ASCII letter folding,
+digit preservation, and punctuation/whitespace removal. This keeps duplicate
+channel collapse reusable for Android TV, Fire TV, and future import workers.
+
+Duplicate handling keeps the first normalized channel unless a later duplicate
+has a logo and the existing channel does not. Deterministic tests cover this
+logo-preference rule in both input orders so large playlists do not regress
+while the Rust parser target is developed.
+
 ## Privacy
 
 Worker diagnostics use stable ids, counts, stages, statuses, and blocker codes

--- a/packages/platform_playlist_import/README.md
+++ b/packages/platform_playlist_import/README.md
@@ -13,6 +13,18 @@ not be hard-coded inside Airo TV screens or tied to a concrete storage engine.
   batch-write, and diagnostic contracts.
 - Fake and no-op worker/batch-writer adapters for deterministic automation.
 
+## M3U Deduplication Contract
+
+The M3U parser normalizes channel names inside the platform package before
+deduplication, so Airo TV screens consume already-collapsed channel lists.
+Normalization is ASCII-only for stable M3U behavior: letters are folded to
+lowercase, digits are preserved, and punctuation or whitespace is ignored.
+
+When duplicate normalized names are found, the first channel is kept unless a
+later duplicate has a logo and the existing channel does not. This preserves the
+existing first-entry policy while making logo preference deterministic for large
+user playlists.
+
 This package does not choose a database engine, own Airo TV progress UI,
 download provider-specific bundled content, expose raw playlist URLs in worker
 diagnostics, or import storage SDKs directly. Concrete storage adapters should

--- a/packages/platform_playlist_import/lib/src/m3u_parser_service.dart
+++ b/packages/platform_playlist_import/lib/src/m3u_parser_service.dart
@@ -10,6 +10,9 @@ class M3UParserService {
   static const String _cacheKey = 'iptv_playlist_cache';
   static const String _cacheTimestampKey = 'iptv_playlist_timestamp';
   static const Duration _cacheValidity = Duration(hours: 24);
+  static final RegExp _extInfAttributePattern = RegExp(
+    r'(\w+[-\w]*)="([^"]*)"',
+  );
 
   final Dio _dio;
   final SharedPreferences _prefs;
@@ -172,29 +175,61 @@ class M3UParserService {
 
   /// Normalize channel name for deduplication (lowercase, remove special chars)
   String _normalizeChannelName(String name) {
-    return name
-        .toLowerCase()
-        .replaceAll(RegExp(r'[^a-z0-9]'), '') // Remove non-alphanumeric
-        .replaceAll(RegExp(r'\s+'), ''); // Remove whitespace
+    final buffer = StringBuffer();
+    for (var i = 0; i < name.length; i++) {
+      final codeUnit = name.codeUnitAt(i);
+
+      if (codeUnit >= 0x30 && codeUnit <= 0x39) {
+        buffer.writeCharCode(codeUnit);
+      } else if (codeUnit >= 0x41 && codeUnit <= 0x5A) {
+        buffer.writeCharCode(codeUnit + 0x20);
+      } else if (codeUnit >= 0x61 && codeUnit <= 0x7A) {
+        buffer.writeCharCode(codeUnit);
+      }
+    }
+    return buffer.toString();
   }
 
   /// Format channel name for display (proper capitalization)
   String _formatChannelName(String name) {
-    // Remove extra whitespace
-    name = name.trim().replaceAll(RegExp(r'\s+'), ' ');
+    final buffer = StringBuffer();
+    var index = 0;
 
-    // Title case without correcting to specific channel brands.
-    return name
-        .split(' ')
-        .map((word) {
-          if (word.isEmpty) return word;
-          // Keep acronyms uppercase (2-4 letter all-caps words)
-          if (word.length <= 4 && word == word.toUpperCase()) {
-            return word;
-          }
-          return word[0].toUpperCase() + word.substring(1).toLowerCase();
-        })
-        .join(' ');
+    while (index < name.length) {
+      while (index < name.length && _isWhitespace(name.codeUnitAt(index))) {
+        index++;
+      }
+      if (index >= name.length) break;
+
+      final wordStart = index;
+      while (index < name.length && !_isWhitespace(name.codeUnitAt(index))) {
+        index++;
+      }
+
+      if (buffer.isNotEmpty) {
+        buffer.write(' ');
+      }
+
+      final word = name.substring(wordStart, index);
+      if (word.length <= 4 && word == word.toUpperCase()) {
+        buffer.write(word);
+      } else {
+        buffer
+          ..write(word[0].toUpperCase())
+          ..write(word.substring(1).toLowerCase());
+      }
+    }
+
+    return buffer.toString();
+  }
+
+  bool _isWhitespace(int codeUnit) {
+    return codeUnit == 0x20 ||
+        codeUnit == 0x09 ||
+        codeUnit == 0x0A ||
+        codeUnit == 0x0B ||
+        codeUnit == 0x0C ||
+        codeUnit == 0x0D;
   }
 
   /// Parse #EXTINF line attributes
@@ -208,8 +243,7 @@ class M3UParserService {
     }
 
     // Extract attributes
-    final attrPattern = RegExp(r'(\w+[-\w]*)="([^"]*)"');
-    for (final match in attrPattern.allMatches(line)) {
+    for (final match in _extInfAttributePattern.allMatches(line)) {
       result[match.group(1)!] = match.group(2);
     }
 

--- a/packages/platform_playlist_import/test/platform_playlist_import_test.dart
+++ b/packages/platform_playlist_import/test/platform_playlist_import_test.dart
@@ -20,6 +20,65 @@ https://example.com/news.m3u8
     expect(channels.single.streamUrl, 'https://example.com/news.m3u8');
   });
 
+  group('M3UParserService deduplication', () {
+    late M3UParserService parser;
+
+    setUp(() async {
+      SharedPreferences.setMockInitialValues({});
+      final prefs = await SharedPreferences.getInstance();
+      parser = M3UParserService(dio: Dio(), prefs: prefs);
+    });
+
+    test('deduplicates normalized channel names and prefers logo entries', () {
+      final channels = parser.parseM3U('''
+#EXTM3U
+#EXTINF:-1 group-title="News",News One
+https://example.com/news-no-logo.m3u8
+#EXTINF:-1 tvg-logo="https://example.com/news.png" group-title="News", news-one
+https://example.com/news-logo.m3u8
+''');
+
+      expect(channels, hasLength(1));
+      expect(channels.single.name, 'News-one');
+      expect(channels.single.logoUrl, 'https://example.com/news.png');
+      expect(channels.single.streamUrl, 'https://example.com/news-logo.m3u8');
+    });
+
+    test('keeps logo-preferred dedup output stable when order changes', () {
+      final logoFirst = parser.parseM3U('''
+#EXTM3U
+#EXTINF:-1 tvg-logo="https://example.com/sports.png",SPORTS 24
+https://example.com/sports-logo.m3u8
+#EXTINF:-1,sports-24
+https://example.com/sports-no-logo.m3u8
+''');
+
+      final logoSecond = parser.parseM3U('''
+#EXTM3U
+#EXTINF:-1,sports-24
+https://example.com/sports-no-logo.m3u8
+#EXTINF:-1 tvg-logo="https://example.com/sports.png",SPORTS 24
+https://example.com/sports-logo.m3u8
+''');
+
+      expect(logoFirst, hasLength(1));
+      expect(logoSecond, hasLength(1));
+      expect(logoFirst.single.name, logoSecond.single.name);
+      expect(logoFirst.single.logoUrl, logoSecond.single.logoUrl);
+      expect(logoFirst.single.streamUrl, logoSecond.single.streamUrl);
+    });
+
+    test('collapses display whitespace without lowercasing short acronyms', () {
+      final channels = parser.parseM3U('''
+#EXTM3U
+#EXTINF:-1,  BBC    WORLD   news
+https://example.com/bbc-world-news.m3u8
+''');
+
+      expect(channels.single.name, 'BBC World News');
+    });
+  });
+
   group('M3UParserService BYOC source', () {
     late SharedPreferences prefs;
     late M3UParserService parser;


### PR DESCRIPTION
# Summary

This PR reduces the M3U parser hot-path cost for v2 large playlist imports.
Goal: address #767 by moving channel dedup normalization away from per-channel regex construction while keeping Airo TV consumption unchanged.

Core outcome:

* Normalized dedup keys are built with a single ASCII fold loop per channel.
* `#EXTINF` attribute parsing reuses one matcher instead of recreating it per entry.
* Airo TV continues to consume the reusable `platform_playlist_import` parser contract.

# Changes

### Code

* Updated:

  * `packages/platform_playlist_import/lib/src/m3u_parser_service.dart` - optimized normalization, formatting, and EXTINF attribute matcher reuse.
  * `packages/platform_playlist_import/test/platform_playlist_import_test.dart` - added deterministic dedup/logo-order tests.
  * `packages/platform_playlist_import/README.md` - documented the platform dedup contract.
  * `docs/features/airo-tv/LARGE_PLAYLIST_WORKER_PIPELINE.md` - documented the TV-facing parser hot-path boundary.

### Logic

* Channel dedup remains normalized-name based.
* Duplicate entries keep first occurrence unless a later duplicate has a logo and the existing entry does not.
* Public `M3UParserService` and `IPTVChannel` APIs are unchanged.

# API Changes

None.

# Database Changes

None.

# Observability / Logging

None.

# Performance Impact

* Reduces per-channel regex allocation in the parser dedup path.
* Keeps the improvement in the reusable platform playlist package, so Android TV and future import workers share it.

# Risks

* Formatter whitespace handling is intentionally covered by package tests, but full corpus profiling is still needed for the broader Rust parser target.
* Rollback plan: revert this single commit; no schema or API migration is involved.

# Testing

* `cd packages/platform_playlist_import && flutter test test/platform_playlist_import_test.dart --reporter=compact`
* `cd packages/platform_playlist_import && flutter analyze lib/src/m3u_parser_service.dart test/platform_playlist_import_test.dart --no-fatal-infos --no-fatal-warnings`
* `bash scripts/check-docs-completeness.sh --base origin/v2 --head HEAD`
* `git diff --check HEAD~1..HEAD`

# Related Commits

* `perf(playlist): reduce M3U dedup hot-path cost`

# Notes

Issue policy/use-case note: https://github.com/DevelopersCoffee/airo/issues/767#issuecomment-4977585078
