### PR TITLE
fix(security): validate playlist-derived media URLs

### DIFF
--- a/docs/features/airo-tv/LARGE_PLAYLIST_WORKER_PIPELINE.md
+++ b/docs/features/airo-tv/LARGE_PLAYLIST_WORKER_PIPELINE.md
@@ -72,6 +72,19 @@ has a logo and the existing channel does not. Deterministic tests cover this
 logo-preference rule in both input orders so large playlists do not regress
 while the Rust parser target is developed.
 
+## Playlist URL Security
+
+Playlist-derived stream and logo URLs are sanitized in platform code before
+Airo TV UI consumes channel models. `platform_playlist_import` uses the shared
+`AiroPlaylistUrlPolicy` to accept public HTTP(S) URLs and reject local files,
+script/content schemes, URL credentials, localhost, link-local, and private
+network hosts by default.
+
+Unsafe stream entries are dropped from parsed channel output, and unsafe logo
+values are stripped. Cast proxy relay targets use the same policy and require a
+generated token on proxy requests, so malicious playlist content cannot cause
+unauthenticated local relay fetches.
+
 ## Privacy
 
 Worker diagnostics use stable ids, counts, stages, statuses, and blocker codes

--- a/packages/feature_iptv/test/iptv/iptv_cast_media_adapter_test.dart
+++ b/packages/feature_iptv/test/iptv/iptv_cast_media_adapter_test.dart
@@ -90,6 +90,22 @@ void main() {
     expect(result.error!.code, AiroCastErrorCode.unsupportedStream);
   });
 
+  test('rejects private network stream URLs', () {
+    final result = adapter.toCastRequest(
+      channel(streamUrl: 'http://192.168.1.20/live.m3u8'),
+    );
+
+    expect(result.isCastable, false);
+    expect(result.error!.code, AiroCastErrorCode.unsupportedStream);
+  });
+
+  test('drops unsafe artwork URLs from cast metadata', () {
+    final result = adapter.toCastRequest(channel(logoUrl: 'javascript:bad()'));
+
+    expect(result.isCastable, true);
+    expect(result.request!.imageUrl, isNull);
+  });
+
   test('rejects unknown stream formats', () {
     final result = adapter.toCastRequest(
       channel(streamUrl: 'https://example.com/playlist.ts'),

--- a/packages/platform_channels/README.md
+++ b/packages/platform_channels/README.md
@@ -1,39 +1,22 @@
-<!--
-This README describes the package. If you publish this package to pub.dev,
-this README's contents appear on the landing page for your package.
+# Platform Channels
 
-For information about how to write a good package README, see the guide for
-[writing package pages](https://dart.dev/tools/pub/writing-package-pages).
+Reusable IPTV channel models, source helpers, and playlist-derived URL policy
+for Airo products.
 
-For general information about developing packages, see the Dart guide for
-[creating packages](https://dart.dev/guides/libraries/create-packages)
-and the Flutter guide for
-[developing packages and plugins](https://flutter.dev/to/develop-packages).
--->
+## Scope
 
-TODO: Put a short description of the package here that helps potential users
-know whether this package might be useful for them.
+- `IPTVChannel` and related channel metadata models.
+- `ChannelDataService` for first-party channel data boundaries.
+- `AiroPlaylistUrlPolicy` for validating stream and artwork URLs parsed from
+  user-supplied playlist content.
 
-## Features
+## Playlist URL Policy
 
-TODO: List what your package can do. Maybe include images, gifs, or videos.
+Playlist content is hostile input. `AiroPlaylistUrlPolicy` accepts only HTTP(S)
+network URLs, rejects URL credentials, and blocks localhost, link-local,
+private, carrier-grade NAT, multicast, and other non-public host ranges by
+default.
 
-## Getting started
-
-TODO: List prerequisites and provide or point to information on how to
-start using the package.
-
-## Usage
-
-TODO: Include short and useful examples for package users. Add longer examples
-to `/example` folder.
-
-```dart
-const like = 'sample';
-```
-
-## Additional information
-
-TODO: Tell users more about the package: where to find more information, how to
-contribute to the package, how to file issues, what response they can expect
-from the package authors, and more.
+Callers may opt into private hosts only after a product-level user consent flow
+exists for LAN streams. Airo TV screens should consume the sanitized platform
+models instead of revalidating stream and logo URLs in UI code.

--- a/packages/platform_channels/lib/platform_channels.dart
+++ b/packages/platform_channels/lib/platform_channels.dart
@@ -1,4 +1,5 @@
 library platform_channels;
 
 export "src/models/iptv_channel.dart";
+export "src/security/playlist_url_policy.dart";
 export "src/services/channel_data_service.dart";

--- a/packages/platform_channels/lib/src/security/playlist_url_policy.dart
+++ b/packages/platform_channels/lib/src/security/playlist_url_policy.dart
@@ -1,0 +1,141 @@
+/// Shared URL policy for user-supplied IPTV playlist data.
+class AiroPlaylistUrlPolicy {
+  const AiroPlaylistUrlPolicy._();
+
+  /// Normalize a playlist-derived media stream URL.
+  ///
+  /// HTTP and HTTPS streams are valid IPTV sources, but local/private hosts are
+  /// blocked by default so hostile playlist content cannot reach internal
+  /// network services through players or cast proxies.
+  static Uri? normalizeStreamUrl(
+    String? value, {
+    bool allowHttp = true,
+    bool allowPrivateHosts = false,
+  }) {
+    return _normalizeNetworkUrl(
+      value,
+      allowHttp: allowHttp,
+      allowPrivateHosts: allowPrivateHosts,
+    );
+  }
+
+  /// Normalize a playlist-derived artwork/logo URL.
+  static Uri? normalizeLogoUrl(
+    String? value, {
+    bool allowHttp = true,
+    bool allowPrivateHosts = false,
+  }) {
+    return _normalizeNetworkUrl(
+      value,
+      allowHttp: allowHttp,
+      allowPrivateHosts: allowPrivateHosts,
+    );
+  }
+
+  /// Validate a target URL before a local relay fetches it.
+  static bool isAllowedCastProxyTarget(
+    Uri uri, {
+    bool allowHttp = true,
+    bool allowPrivateHosts = false,
+  }) {
+    return _isAllowedNetworkUri(
+      uri,
+      allowHttp: allowHttp,
+      allowPrivateHosts: allowPrivateHosts,
+    );
+  }
+
+  /// Returns true for localhost, link-local, RFC1918, and other non-public
+  /// address ranges that must not be fetched from playlist-derived data unless
+  /// the caller has an explicit user opt-in.
+  static bool isPrivateOrLocalHost(String host) {
+    final normalized = host.trim().toLowerCase();
+    if (normalized.isEmpty) return true;
+    if (normalized == 'localhost' || normalized.endsWith('.localhost')) {
+      return true;
+    }
+    if (normalized.endsWith('.local')) return true;
+
+    final ipv4 = _parseIpv4(normalized);
+    if (ipv4 != null) {
+      final first = ipv4[0];
+      final second = ipv4[1];
+      return first == 0 ||
+          first == 10 ||
+          first == 127 ||
+          (first == 100 && second >= 64 && second <= 127) ||
+          (first == 169 && second == 254) ||
+          (first == 172 && second >= 16 && second <= 31) ||
+          (first == 192 && second == 168) ||
+          first >= 224;
+    }
+
+    if (normalized.contains(':')) {
+      return normalized == '::' ||
+          normalized == '::1' ||
+          normalized == '0:0:0:0:0:0:0:1' ||
+          normalized.startsWith('fe80:') ||
+          normalized.startsWith('fc') ||
+          normalized.startsWith('fd');
+    }
+
+    return false;
+  }
+
+  static Uri? _normalizeNetworkUrl(
+    String? value, {
+    required bool allowHttp,
+    required bool allowPrivateHosts,
+  }) {
+    final raw = value?.trim();
+    if (raw == null || raw.isEmpty) return null;
+
+    final uri = Uri.tryParse(raw);
+    if (uri == null ||
+        !_isAllowedNetworkUri(
+          uri,
+          allowHttp: allowHttp,
+          allowPrivateHosts: allowPrivateHosts,
+        )) {
+      return null;
+    }
+    return uri;
+  }
+
+  static bool _isAllowedNetworkUri(
+    Uri uri, {
+    required bool allowHttp,
+    required bool allowPrivateHosts,
+  }) {
+    if (!uri.hasScheme || uri.host.isEmpty || uri.userInfo.isNotEmpty) {
+      return false;
+    }
+
+    final scheme = uri.scheme.toLowerCase();
+    if (scheme != 'https' && !(allowHttp && scheme == 'http')) {
+      return false;
+    }
+
+    if (!allowPrivateHosts && isPrivateOrLocalHost(uri.host)) {
+      return false;
+    }
+
+    return true;
+  }
+
+  static List<int>? _parseIpv4(String host) {
+    final parts = host.split('.');
+    if (parts.length != 4) return null;
+
+    final octets = <int>[];
+    for (final part in parts) {
+      if (part.isEmpty) return null;
+      final octet = int.tryParse(part);
+      if (octet == null || octet < 0 || octet > 255) {
+        return null;
+      }
+      octets.add(octet);
+    }
+    return octets;
+  }
+}

--- a/packages/platform_channels/test/platform_channels_test.dart
+++ b/packages/platform_channels/test/platform_channels_test.dart
@@ -5,6 +5,63 @@ import 'package:platform_channels/platform_channels.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 void main() {
+  group('AiroPlaylistUrlPolicy', () {
+    test('accepts public http and https media URLs', () {
+      expect(
+        AiroPlaylistUrlPolicy.normalizeStreamUrl(
+          ' https://cdn.example.com/live.m3u8 ',
+        ),
+        Uri.parse('https://cdn.example.com/live.m3u8'),
+      );
+      expect(
+        AiroPlaylistUrlPolicy.normalizeLogoUrl(
+          'http://images.example.com/logo.png',
+        ),
+        Uri.parse('http://images.example.com/logo.png'),
+      );
+    });
+
+    test('rejects unsafe schemes, credentials, and private hosts', () {
+      expect(
+        AiroPlaylistUrlPolicy.normalizeStreamUrl('file:///etc/passwd'),
+        isNull,
+      );
+      expect(
+        AiroPlaylistUrlPolicy.normalizeStreamUrl('javascript:alert(1)'),
+        isNull,
+      );
+      expect(
+        AiroPlaylistUrlPolicy.normalizeStreamUrl(
+          'https://user:pass@example.com/live.m3u8',
+        ),
+        isNull,
+      );
+      expect(
+        AiroPlaylistUrlPolicy.normalizeStreamUrl(
+          'http://192.168.1.10/live.m3u8',
+        ),
+        isNull,
+      );
+      expect(
+        AiroPlaylistUrlPolicy.normalizeStreamUrl(
+          'http://192.168.1.10/live.m3u8',
+          allowPrivateHosts: true,
+        ),
+        Uri.parse('http://192.168.1.10/live.m3u8'),
+      );
+      expect(
+        AiroPlaylistUrlPolicy.normalizeStreamUrl(
+          'https://fdn.example/live.m3u8',
+        ),
+        Uri.parse('https://fdn.example/live.m3u8'),
+      );
+      expect(
+        AiroPlaylistUrlPolicy.normalizeStreamUrl('http://[fd00::1]/live.m3u8'),
+        isNull,
+      );
+    });
+  });
+
   group('ChannelDataService', () {
     test('returns no first-party channels for Play Store V2', () async {
       SharedPreferences.setMockInitialValues({

--- a/packages/platform_player/README.md
+++ b/packages/platform_player/README.md
@@ -16,6 +16,17 @@ flows consume these contracts instead of defining app-specific playback models.
 - No-op/unavailable and fake playback engines for deterministic tests.
 - Cast discovery/session abstractions used by existing IPTV flows.
 
+## Cast Proxy Security
+
+`CastHttpProxy` is a compatibility relay for Cast playback, not a general local
+file server. Generated proxy URLs carry a random access token, and relay targets
+are validated with `AiroPlaylistUrlPolicy` before the proxy fetches them.
+
+Private, link-local, localhost, credential-bearing, and non-HTTP(S) targets are
+blocked by default. Tests may opt into private targets for loopback fixtures,
+but product flows should only do that behind an explicit user consent path for
+LAN streams.
+
 This package does not choose or implement a native media backend, import native
 player SDKs, probe decoders, persist sessions, render playback widgets, route
 commands, or expose raw media source URLs, local paths, local IP addresses,

--- a/packages/platform_player/lib/src/services/cast_http_proxy.dart
+++ b/packages/platform_player/lib/src/services/cast_http_proxy.dart
@@ -1,8 +1,10 @@
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
+import 'dart:math';
 
 import 'package:flutter/foundation.dart';
+import 'package:platform_channels/platform_channels.dart';
 
 /// Local HTTP server that re-serves media to a Cast receiver with permissive
 /// CORS headers.
@@ -12,9 +14,25 @@ import 'package:flutter/foundation.dart';
 /// receiver needs a local rewritten playlist, such as synthesized HEVC master
 /// playlists or live IPTV manifests with relative child playlists.
 class CastHttpProxy {
+  CastHttpProxy({bool allowPrivateTargets = false, String? accessToken})
+    : this._(allowPrivateTargets, accessToken);
+
+  CastHttpProxy._(this._allowPrivateTargets, String? accessToken)
+    : _accessToken = accessToken ?? _generateAccessToken() {
+    if (_accessToken.isEmpty) {
+      throw ArgumentError.value(
+        accessToken,
+        'accessToken',
+        'Must not be empty',
+      );
+    }
+  }
+
   HttpServer? _server;
   Uri? _baseUri;
   final HttpClient _httpClient = HttpClient();
+  final bool _allowPrivateTargets;
+  final String _accessToken;
 
   Future<Uri> start() async {
     final existing = _baseUri;
@@ -41,9 +59,10 @@ class CastHttpProxy {
     if (base == null) {
       throw StateError('Cast proxy is not running.');
     }
+    _validateTarget(original);
     return base.replace(
       path: '/proxy',
-      queryParameters: {'url': original.toString()},
+      queryParameters: {'url': original.toString(), 'token': _accessToken},
     );
   }
 
@@ -56,7 +75,12 @@ class CastHttpProxy {
     if (base == null) {
       throw StateError('Cast proxy is not running.');
     }
-    final queryParameters = {'url': mediaPlaylist.toString(), 'codecs': codecs};
+    _validateTarget(mediaPlaylist);
+    final queryParameters = {
+      'url': mediaPlaylist.toString(),
+      'codecs': codecs,
+      'token': _accessToken,
+    };
     if (resolution != null) {
       queryParameters['res'] = resolution;
     }
@@ -121,9 +145,15 @@ class CastHttpProxy {
       return;
     }
 
+    if (request.uri.queryParameters['token'] != _accessToken) {
+      response.statusCode = HttpStatus.forbidden;
+      await response.close();
+      return;
+    }
+
     final targetUrl = Uri.tryParse(targetParam);
-    if (targetUrl == null) {
-      response.statusCode = HttpStatus.badRequest;
+    if (targetUrl == null || !_isAllowedTarget(targetUrl)) {
+      response.statusCode = HttpStatus.forbidden;
       await response.close();
       return;
     }
@@ -232,9 +262,15 @@ class CastHttpProxy {
       if (trimmed.isEmpty) continue;
       if (_shouldDropTag(trimmed)) continue;
       if (trimmed.startsWith('#')) {
-        buffer.writeln(_rewriteTagUris(trimmed, playlistUrl));
+        final rewritten = _rewriteTagUris(trimmed, playlistUrl);
+        if (rewritten.isNotEmpty) {
+          buffer.writeln(rewritten);
+        }
       } else {
-        buffer.writeln(proxiedUrl(playlistUrl.resolve(trimmed)).toString());
+        final resolved = playlistUrl.resolve(trimmed);
+        if (_isAllowedTarget(resolved)) {
+          buffer.writeln(proxiedUrl(resolved).toString());
+        }
       }
     }
     return buffer.toString();
@@ -242,6 +278,11 @@ class CastHttpProxy {
 
   String _rewriteTagUris(String tagLine, Uri playlistUrl) {
     final uriPattern = RegExp(r'URI="([^"]+)"');
+    for (final match in uriPattern.allMatches(tagLine)) {
+      if (!_isAllowedTarget(playlistUrl.resolve(match.group(1)!))) {
+        return '';
+      }
+    }
     return tagLine.replaceAllMapped(uriPattern, (match) {
       final resolved = playlistUrl.resolve(match.group(1)!);
       return 'URI="${proxiedUrl(resolved)}"';
@@ -258,5 +299,28 @@ class CastHttpProxy {
     if (uri == null) return 'none';
     final port = uri.hasPort ? ':${uri.port}' : '';
     return '${uri.scheme}://${uri.host}$port${uri.path}';
+  }
+
+  bool _isAllowedTarget(Uri uri) {
+    return AiroPlaylistUrlPolicy.isAllowedCastProxyTarget(
+      uri,
+      allowPrivateHosts: _allowPrivateTargets,
+    );
+  }
+
+  void _validateTarget(Uri uri) {
+    if (!_isAllowedTarget(uri)) {
+      throw ArgumentError.value(
+        uri,
+        'uri',
+        'Cast proxy target must be a public HTTP(S) URL.',
+      );
+    }
+  }
+
+  static String _generateAccessToken() {
+    final random = Random.secure();
+    final bytes = List<int>.generate(16, (_) => random.nextInt(256));
+    return base64Url.encode(bytes).replaceAll('=', '');
   }
 }

--- a/packages/platform_player/lib/src/services/iptv_cast_media_adapter.dart
+++ b/packages/platform_player/lib/src/services/iptv_cast_media_adapter.dart
@@ -15,16 +15,12 @@ class IptvCastMediaAdapter {
       );
     }
 
-    final rawUrl = channel.getStreamUrl(selectedQuality).trim();
-    final uri = Uri.tryParse(rawUrl);
-    if (uri == null || !uri.hasScheme || uri.host.isEmpty) {
+    final uri = AiroPlaylistUrlPolicy.normalizeStreamUrl(
+      channel.getStreamUrl(selectedQuality),
+    );
+    if (uri == null) {
       return IptvCastMediaResult.unsupported(
         'This channel does not have a valid network stream URL.',
-      );
-    }
-    if (uri.scheme != 'http' && uri.scheme != 'https') {
-      return IptvCastMediaResult.unsupported(
-        'Only http and https IPTV streams can be cast in V1.',
       );
     }
 
@@ -35,9 +31,9 @@ class IptvCastMediaAdapter {
       );
     }
 
-    final imageUrl = channel.effectiveLogoUrl == null
-        ? null
-        : Uri.tryParse(channel.effectiveLogoUrl!);
+    final imageUrl = AiroPlaylistUrlPolicy.normalizeLogoUrl(
+      channel.effectiveLogoUrl,
+    );
 
     return IptvCastMediaResult.castable(
       AiroCastMediaRequest(

--- a/packages/platform_player/test/cast_http_proxy_test.dart
+++ b/packages/platform_player/test/cast_http_proxy_test.dart
@@ -36,7 +36,7 @@ void main() {
       await request.response.close();
     });
 
-    proxy = CastHttpProxy();
+    proxy = CastHttpProxy(allowPrivateTargets: true, accessToken: 'test-token');
     await proxy.start();
   });
 
@@ -89,5 +89,34 @@ void main() {
 
     expect(response.headers.value('access-control-allow-origin'), '*');
     expect(bytes, [1, 2, 3, 4]);
+  });
+
+  test('rejects requests without the generated access token', () async {
+    final originUrl = Uri.parse(
+      'http://${origin.address.address}:${origin.port}/segment1.ts',
+    );
+    final base = await proxy.start();
+    final missingTokenUrl = base.replace(
+      path: '/proxy',
+      queryParameters: {'url': originUrl.toString()},
+    );
+
+    final client = HttpClient();
+    final response = await (await client.getUrl(missingTokenUrl)).close();
+    await response.drain<void>();
+    client.close(force: true);
+
+    expect(response.statusCode, HttpStatus.forbidden);
+  });
+
+  test('rejects private relay targets by default', () async {
+    final hardened = CastHttpProxy(accessToken: 'test-token');
+    await hardened.start();
+    addTearDown(hardened.stop);
+
+    expect(
+      () => hardened.proxiedUrl(Uri.parse('http://192.168.1.20/live.m3u8')),
+      throwsArgumentError,
+    );
   });
 }

--- a/packages/platform_playlist_import/README.md
+++ b/packages/platform_playlist_import/README.md
@@ -25,6 +25,15 @@ later duplicate has a logo and the existing channel does not. This preserves the
 existing first-entry policy while making logo preference deterministic for large
 user playlists.
 
+## Playlist-Derived URL Policy
+
+M3U stream URLs and `tvg-logo` values are validated while parsing. Unsafe stream
+URLs are dropped before an `IPTVChannel` is created, and unsafe logo URLs are
+stripped from otherwise valid channels. The parser uses the shared
+`AiroPlaylistUrlPolicy` from `platform_channels`, which allows HTTP(S) public
+network URLs and blocks credentials, local files, script/content schemes,
+localhost, link-local, and private network hosts by default.
+
 This package does not choose a database engine, own Airo TV progress UI,
 download provider-specific bundled content, expose raw playlist URLs in worker
 diagnostics, or import storage SDKs directly. Concrete storage adapters should

--- a/packages/platform_playlist_import/lib/src/m3u_parser_service.dart
+++ b/packages/platform_playlist_import/lib/src/m3u_parser_service.dart
@@ -133,14 +133,26 @@ class M3UParserService {
       } else if (line.isNotEmpty &&
           !line.startsWith('#') &&
           currentName != null) {
+        final streamUri = AiroPlaylistUrlPolicy.normalizeStreamUrl(line);
+        if (streamUri == null) {
+          currentName = null;
+          currentLogo = null;
+          currentGroup = null;
+          currentTvgId = null;
+          currentTvgName = null;
+          currentLanguage = null;
+          continue;
+        }
+
         // Normalize the channel name for deduplication
         final normalizedName = _normalizeChannelName(currentName);
+        final logoUri = AiroPlaylistUrlPolicy.normalizeLogoUrl(currentLogo);
 
         // Create the channel
         final channel = IPTVChannel.fromM3U(
           name: _formatChannelName(currentName), // Use formatted name
-          url: line,
-          logo: currentLogo,
+          url: streamUri.toString(),
+          logo: logoUri?.toString(),
           group: currentGroup,
           tvgId: currentTvgId,
           tvgName: currentTvgName,

--- a/packages/platform_playlist_import/test/platform_playlist_import_test.dart
+++ b/packages/platform_playlist_import/test/platform_playlist_import_test.dart
@@ -79,6 +79,35 @@ https://example.com/bbc-world-news.m3u8
     });
   });
 
+  group('M3UParserService URL policy', () {
+    late M3UParserService parser;
+
+    setUp(() async {
+      SharedPreferences.setMockInitialValues({});
+      final prefs = await SharedPreferences.getInstance();
+      parser = M3UParserService(dio: Dio(), prefs: prefs);
+    });
+
+    test('drops forbidden stream URLs and strips forbidden logo URLs', () {
+      final channels = parser.parseM3U('''
+#EXTM3U
+#EXTINF:-1,Local File
+file:///etc/passwd
+#EXTINF:-1,Private Host
+http://192.168.1.1/live.m3u8
+#EXTINF:-1,Script
+javascript:alert(1)
+#EXTINF:-1 tvg-logo="file:///private/logo.png",Public Stream
+https://cdn.example.com/live.m3u8
+''');
+
+      expect(channels, hasLength(1));
+      expect(channels.single.name, 'Public Stream');
+      expect(channels.single.streamUrl, 'https://cdn.example.com/live.m3u8');
+      expect(channels.single.logoUrl, isNull);
+    });
+  });
+
   group('M3UParserService BYOC source', () {
     late SharedPreferences prefs;
     late M3UParserService parser;


### PR DESCRIPTION
# Summary

This PR hardens playlist-derived media URL handling for v2 Airo TV.
Goal: address the code-side security slice of #777 by preventing hostile M3U stream/logo URLs from reaching players, image loaders, or Cast relay fetches by default.

Core outcome:

* Shared `AiroPlaylistUrlPolicy` lives in `platform_channels` and is reused by parser/player code.
* `platform_playlist_import` drops forbidden stream entries and strips forbidden logo URLs during parse.
* `platform_player` rejects unsafe Cast metadata and requires access tokens for local proxy requests.

# Changes

### Code

* Added:

  * `packages/platform_channels/lib/src/security/playlist_url_policy.dart`
* Updated:

  * `packages/platform_playlist_import/lib/src/m3u_parser_service.dart` - validates stream/logo URLs during M3U parse.
  * `packages/platform_player/lib/src/services/iptv_cast_media_adapter.dart` - uses shared URL policy for stream/artwork metadata.
  * `packages/platform_player/lib/src/services/cast_http_proxy.dart` - adds generated token query parameters and default public-target-only relay policy.
  * Package tests and docs for the platform/Airo TV security boundary.

### Logic

* Accepts public HTTP(S) URLs by default.
* Rejects non-network schemes, URL credentials, localhost, link-local, private, CGNAT, and multicast ranges by default.
* Allows tests/callers to opt into private hosts explicitly where a user consent path exists.
* Keeps Airo TV UI free of duplicated URL validation logic.

# API Changes

* Added reusable platform API: `AiroPlaylistUrlPolicy`.
* `CastHttpProxy` constructor now accepts optional `allowPrivateTargets` and `accessToken` parameters.

# Database Changes

None.

# Observability / Logging

* Proxy logging continues to use URI summaries only.
* URL credentials are rejected before playlist-derived URLs can enter channel models or proxy fetches.

# Performance Impact

* Minimal per-channel URL parsing overhead during M3U parse.
* No additional network calls.

# Risks

* Private/LAN playlist-derived streams are blocked by default until a product-level explicit opt-in is added.
* The proxy still binds for Cast compatibility; this PR hardens access with tokens and target validation rather than switching to loopback-only, which would break Chromecast-style receiver access.
* Rollback plan: revert this single commit; no schema migration is involved.

# Testing

* `cd packages/platform_channels && flutter test test/platform_channels_test.dart --reporter=compact`
* `cd packages/platform_channels && flutter analyze lib/src/security/playlist_url_policy.dart test/platform_channels_test.dart --no-fatal-infos --no-fatal-warnings`
* `cd packages/platform_playlist_import && flutter test test/platform_playlist_import_test.dart --reporter=compact`
* `cd packages/platform_playlist_import && flutter analyze lib/src/m3u_parser_service.dart test/platform_playlist_import_test.dart --no-fatal-infos --no-fatal-warnings`
* `cd packages/platform_player && flutter test test/cast_http_proxy_test.dart --reporter=compact`
* `cd packages/platform_player && flutter analyze lib/src/services/cast_http_proxy.dart lib/src/services/iptv_cast_media_adapter.dart test/cast_http_proxy_test.dart --no-fatal-infos --no-fatal-warnings`
* `cd packages/feature_iptv && flutter test test/iptv/iptv_cast_media_adapter_test.dart --reporter=compact`
* `bash scripts/check-docs-completeness.sh --base origin/v2 --head HEAD`
* `git diff --check HEAD~1..HEAD`

# Related Commits

* `fix(security): validate playlist-derived media URLs`

# Notes

Issue policy/use-case note: https://github.com/DevelopersCoffee/airo/issues/777#issuecomment-4977741766
