### PR TITLE
perf(playlist): use conditional M3U refresh

### DIFF
--- a/docs/features/airo-tv/LARGE_PLAYLIST_WORKER_PIPELINE.md
+++ b/docs/features/airo-tv/LARGE_PLAYLIST_WORKER_PIPELINE.md
@@ -85,6 +85,20 @@ values are stripped. Cast proxy relay targets use the same policy and require a
 generated token on proxy requests, so malicious playlist content cannot cause
 unauthenticated local relay fetches.
 
+## Playlist Refresh Networking
+
+The platform playlist importer owns HTTP validators for user-supplied M3U
+sources. After a successful fetch, it stores `ETag` and `Last-Modified`
+metadata with the user-derived cache. Forced refreshes send
+`If-None-Match`/`If-Modified-Since` when validators exist, and a `304 Not
+Modified` response returns the cached channel list instead of downloading a
+full playlist body again.
+
+Compression negotiation is explicit with `Accept-Encoding: gzip, deflate`.
+HTTP/2 logo burst optimization remains a separate network slice; Airo TV UI
+must continue to consume the platform importer rather than issuing playlist
+refresh logic directly.
+
 ## Privacy
 
 Worker diagnostics use stable ids, counts, stages, statuses, and blocker codes

--- a/packages/platform_playlist_import/README.md
+++ b/packages/platform_playlist_import/README.md
@@ -34,6 +34,17 @@ stripped from otherwise valid channels. The parser uses the shared
 network URLs and blocks credentials, local files, script/content schemes,
 localhost, link-local, and private network hosts by default.
 
+## Conditional Playlist Refresh
+
+Playlist fetches send `Accept-Encoding: gzip, deflate` and reuse cached HTTP
+validators when available. `ETag` is stored as `iptv_playlist_etag`, and
+`Last-Modified` is stored as `iptv_playlist_last_modified` beside the
+user-derived playlist cache.
+
+On `304 Not Modified`, the parser returns the existing user-derived cache
+without downloading or parsing a new response body. Changing or clearing the
+playlist URL removes the cached body, timestamp, and validators together.
+
 This package does not choose a database engine, own Airo TV progress UI,
 download provider-specific bundled content, expose raw playlist URLs in worker
 diagnostics, or import storage SDKs directly. Concrete storage adapters should

--- a/packages/platform_playlist_import/lib/src/m3u_parser_service.dart
+++ b/packages/platform_playlist_import/lib/src/m3u_parser_service.dart
@@ -1,4 +1,5 @@
 import 'dart:developer' as developer;
+import 'dart:io';
 
 import 'package:dio/dio.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -9,6 +10,8 @@ class M3UParserService {
   static const String _playlistUrlKey = 'iptv_user_playlist_url';
   static const String _cacheKey = 'iptv_playlist_cache';
   static const String _cacheTimestampKey = 'iptv_playlist_timestamp';
+  static const String _cacheEtagKey = 'iptv_playlist_etag';
+  static const String _cacheLastModifiedKey = 'iptv_playlist_last_modified';
   static const Duration _cacheValidity = Duration(hours: 24);
   static final RegExp _extInfAttributePattern = RegExp(
     r'(\w+[-\w]*)="([^"]*)"',
@@ -79,6 +82,8 @@ class M3UParserService {
     await _prefs.setString(_playlistUrlKey, normalized);
     await _prefs.remove(_cacheKey);
     await _prefs.remove(_cacheTimestampKey);
+    await _prefs.remove(_cacheEtagKey);
+    await _prefs.remove(_cacheLastModifiedKey);
   }
 
   /// Remove the configured playlist and its user-derived cache.
@@ -89,19 +94,44 @@ class M3UParserService {
 
   /// Fetch and parse M3U from URL
   Future<List<IPTVChannel>> _fetchAndParse(String url) async {
+    final headers = <String, String>{'Accept-Encoding': 'gzip, deflate'};
+    final etag = _prefs.getString(_cacheEtagKey);
+    final lastModified = _prefs.getString(_cacheLastModifiedKey);
+    if (etag != null && etag.isNotEmpty) {
+      headers[HttpHeaders.ifNoneMatchHeader] = etag;
+    }
+    if (lastModified != null && lastModified.isNotEmpty) {
+      headers[HttpHeaders.ifModifiedSinceHeader] = lastModified;
+    }
+
     final response = await _dio.get<String>(
       url,
       options: Options(
+        headers: headers,
         responseType: ResponseType.plain,
         receiveTimeout: const Duration(seconds: 30),
+        validateStatus: (status) =>
+            status != null &&
+            ((status >= HttpStatus.ok && status < HttpStatus.multipleChoices) ||
+                status == HttpStatus.notModified),
       ),
     );
+
+    if (response.statusCode == HttpStatus.notModified) {
+      final cached = await _loadFromCache(ignoreExpiry: true);
+      if (cached != null && cached.isNotEmpty) {
+        return cached;
+      }
+      throw Exception('Playlist not modified but no cache is available');
+    }
 
     if (response.data == null || response.data!.isEmpty) {
       throw Exception('Empty playlist response');
     }
 
-    return parseM3U(response.data!);
+    final channels = parseM3U(response.data!);
+    await _saveHttpValidators(response.headers);
+    return channels;
   }
 
   /// Parse M3U content into channels with deduplication
@@ -263,12 +293,13 @@ class M3UParserService {
   }
 
   /// Load channels from cache
-  Future<List<IPTVChannel>?> _loadFromCache() async {
+  Future<List<IPTVChannel>?> _loadFromCache({bool ignoreExpiry = false}) async {
     final timestamp = _prefs.getInt(_cacheTimestampKey);
     if (timestamp == null) return null;
 
     final cacheTime = DateTime.fromMillisecondsSinceEpoch(timestamp);
-    if (DateTime.now().difference(cacheTime) > _cacheValidity) {
+    if (!ignoreExpiry &&
+        DateTime.now().difference(cacheTime) > _cacheValidity) {
       return null; // Cache expired
     }
 
@@ -299,5 +330,24 @@ class M3UParserService {
   Future<void> clearCache() async {
     await _prefs.remove(_cacheKey);
     await _prefs.remove(_cacheTimestampKey);
+    await _prefs.remove(_cacheEtagKey);
+    await _prefs.remove(_cacheLastModifiedKey);
+  }
+
+  Future<void> _saveHttpValidators(Headers headers) async {
+    await _setOrRemove(_cacheEtagKey, headers.value(HttpHeaders.etagHeader));
+    await _setOrRemove(
+      _cacheLastModifiedKey,
+      headers.value(HttpHeaders.lastModifiedHeader),
+    );
+  }
+
+  Future<void> _setOrRemove(String key, String? value) async {
+    final normalized = value?.trim();
+    if (normalized == null || normalized.isEmpty) {
+      await _prefs.remove(key);
+      return;
+    }
+    await _prefs.setString(key, normalized);
   }
 }

--- a/packages/platform_playlist_import/test/platform_playlist_import_test.dart
+++ b/packages/platform_playlist_import/test/platform_playlist_import_test.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:dio/dio.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:platform_playlist_import/platform_playlist_import.dart';
@@ -152,6 +154,61 @@ https://cdn.example.com/live.m3u8
 
       expect(parser.getPlaylistUrl(), isNull);
       await expectLater(parser.fetchPlaylist(), completion(isEmpty));
+    });
+
+    test('uses HTTP validators and cached playlist on 304 refresh', () async {
+      final requests = <HttpHeaders>[];
+      final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+      addTearDown(() => server.close(force: true));
+
+      server.listen((request) async {
+        requests.add(request.headers);
+        request.response.headers
+          ..set(HttpHeaders.etagHeader, '"playlist-v1"')
+          ..set(
+            HttpHeaders.lastModifiedHeader,
+            'Wed, 21 Oct 2015 07:28:00 GMT',
+          );
+
+        if (requests.length == 1) {
+          request.response.write('''
+#EXTM3U
+#EXTINF:-1 group-title="News",Conditional News
+https://cdn.example.com/conditional-news.m3u8
+''');
+        } else {
+          request.response.statusCode = HttpStatus.notModified;
+        }
+        await request.response.close();
+      });
+
+      await parser.setPlaylistUrl(
+        'http://${server.address.address}:${server.port}/playlist.m3u',
+      );
+
+      final initial = await parser.fetchPlaylist(forceRefresh: true);
+      final refreshed = await parser.fetchPlaylist(forceRefresh: true);
+
+      expect(initial, hasLength(1));
+      expect(refreshed, hasLength(1));
+      expect(refreshed.single.name, 'Conditional News');
+      expect(
+        refreshed.single.streamUrl,
+        'https://cdn.example.com/conditional-news.m3u8',
+      );
+      expect(requests, hasLength(2));
+      expect(
+        requests.last.value(HttpHeaders.ifNoneMatchHeader),
+        '"playlist-v1"',
+      );
+      expect(
+        requests.last.value(HttpHeaders.ifModifiedSinceHeader),
+        'Wed, 21 Oct 2015 07:28:00 GMT',
+      );
+      expect(
+        requests.last.value(HttpHeaders.acceptEncodingHeader),
+        contains('gzip'),
+      );
     });
   });
 }


### PR DESCRIPTION
# Summary

This PR adds conditional refresh support for user-supplied M3U playlists.
Goal: address the playlist fetch slice of #775 by avoiding full playlist downloads when the origin reports `304 Not Modified`.

Core outcome:

* Playlist fetches send `Accept-Encoding: gzip, deflate`.
* Successful responses persist `ETag` and `Last-Modified` beside the user-derived cache.
* Forced refreshes send `If-None-Match` / `If-Modified-Since` and return cached channels on `304`.

# Changes

### Code

* Updated:

  * `packages/platform_playlist_import/lib/src/m3u_parser_service.dart` - adds validator headers, 304 handling, and validator cleanup.
  * `packages/platform_playlist_import/test/platform_playlist_import_test.dart` - adds a local HTTP server test for 200 -> 304 refresh behavior.
  * `packages/platform_playlist_import/README.md` - documents conditional playlist refresh.
  * `docs/features/airo-tv/LARGE_PLAYLIST_WORKER_PIPELINE.md` - documents the Airo TV platform boundary.

### Logic

* Existing cache path remains user-derived and platform-owned.
* Changing or clearing the playlist URL removes the cached body, timestamp, and HTTP validators together.
* A 304 response uses the existing cache even if the timestamp-only freshness window has expired.

# API Changes

None.

# Database Changes

None.

# Observability / Logging

None.

# Performance Impact

* Unchanged playlist refreshes can avoid re-downloading the full M3U body.
* Compression negotiation is explicit for text playlist responses.
* HTTP/2 logo burst optimization remains a separate slice.

# Risks

* Some playlist origins may ignore validators; behavior falls back to normal 200 parsing.
* If an origin returns 304 before a local cache exists, the fetch fails and existing fallback behavior attempts cache load.
* Rollback plan: revert this single commit; no schema or API migration is involved.

# Testing

* `cd packages/platform_playlist_import && flutter test test/platform_playlist_import_test.dart --reporter=compact`
* `cd packages/platform_playlist_import && flutter analyze lib/src/m3u_parser_service.dart test/platform_playlist_import_test.dart --no-fatal-infos --no-fatal-warnings`
* `bash scripts/check-docs-completeness.sh --base origin/v2 --head HEAD`
* `git diff --check HEAD~1..HEAD`

# Related Commits

* `perf(playlist): use conditional M3U refresh`

# Notes

Issue policy/use-case note: https://github.com/DevelopersCoffee/airo/issues/775#issuecomment-4977891723
