### PR TITLE
perf(iptv): bound channel logo image decoding

### DIFF
--- a/app/lib/main_tv.dart
+++ b/app/lib/main_tv.dart
@@ -13,6 +13,7 @@
 /// ```
 library;
 
+import 'package:core_ui/core_ui.dart';
 import 'package:dio/dio.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter/foundation.dart';
@@ -41,6 +42,7 @@ const _debugDefaultPlaylistUrl = String.fromEnvironment(
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
+  AiroImageCacheBudget.configureAndroidTv();
 
   // Initialize global error handler for unhandled exceptions
   GlobalErrorHandler.initialize();

--- a/docs/features/airo-tv/LARGE_PLAYLIST_WORKER_PIPELINE.md
+++ b/docs/features/airo-tv/LARGE_PLAYLIST_WORKER_PIPELINE.md
@@ -99,6 +99,18 @@ HTTP/2 logo burst optimization remains a separate network slice; Airo TV UI
 must continue to consume the platform importer rather than issuing playlist
 refresh logic directly.
 
+## Logo Image Rendering
+
+Channel logo rendering is shared UI behavior, not screen-local image plumbing.
+Airo TV logo widgets consume `AiroNetworkImage` from `packages/core_ui`, which
+sets Flutter decode cache dimensions from the rendered size and device pixel
+ratio. The TV entrypoint also applies `AiroImageCacheBudget.configureAndroidTv()`
+so large playlists cannot leave the default process-wide `ImageCache`
+unbounded.
+
+This does not add disk LRU caching or HTTP/2 logo request coalescing. Those
+remain separate platform/network slices.
+
 ## Privacy
 
 Worker diagnostics use stable ids, counts, stages, statuses, and blocker codes

--- a/packages/core_ui/README.md
+++ b/packages/core_ui/README.md
@@ -19,3 +19,16 @@ accessibility behavior in product screens.
 This package does not implement runtime platform detection, rewrite product
 screens, define product navigation manifests, run device certification, or ship
 golden-test assets.
+
+## Image Rendering
+
+Use `AiroNetworkImage` for user-supplied remote artwork that appears in product
+UI at a known visual size, such as channel logos. The widget forwards to
+Flutter's network image renderer with `cacheWidth` and `cacheHeight` derived
+from layout constraints and device pixel ratio, so large source images decode
+near display size instead of native size.
+
+Android TV and Fire TV entrypoints should call
+`AiroImageCacheBudget.configureAndroidTv()` after
+`WidgetsFlutterBinding.ensureInitialized()` to keep Flutter's in-memory
+`ImageCache` bounded on constrained devices.

--- a/packages/core_ui/lib/core_ui.dart
+++ b/packages/core_ui/lib/core_ui.dart
@@ -16,6 +16,7 @@ export 'src/theme/bedtime_theme.dart';
 // Widgets
 export 'src/widgets/app_button.dart';
 export 'src/widgets/app_card.dart';
+export 'src/widgets/airo_network_image.dart';
 export 'src/widgets/loading_indicator.dart';
 export 'src/widgets/error_view.dart';
 

--- a/packages/core_ui/lib/src/widgets/airo_network_image.dart
+++ b/packages/core_ui/lib/src/widgets/airo_network_image.dart
@@ -1,0 +1,111 @@
+import 'dart:math' as math;
+
+import 'package:flutter/widgets.dart';
+
+typedef AiroImageFallbackBuilder =
+    Widget Function(BuildContext context, Object error, StackTrace? stackTrace);
+
+/// Network image that decodes near its rendered size.
+class AiroNetworkImage extends StatelessWidget {
+  const AiroNetworkImage({
+    super.key,
+    required this.url,
+    this.width,
+    this.height,
+    this.fit,
+    this.alignment = Alignment.center,
+    this.semanticLabel,
+    this.excludeFromSemantics = false,
+    this.filterQuality = FilterQuality.low,
+    this.placeholderBuilder,
+    this.errorBuilder,
+    this.maxDecodeDimension = 1024,
+  });
+
+  final String url;
+  final double? width;
+  final double? height;
+  final BoxFit? fit;
+  final AlignmentGeometry alignment;
+  final String? semanticLabel;
+  final bool excludeFromSemantics;
+  final FilterQuality filterQuality;
+  final WidgetBuilder? placeholderBuilder;
+  final AiroImageFallbackBuilder? errorBuilder;
+  final int maxDecodeDimension;
+
+  @override
+  Widget build(BuildContext context) {
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final devicePixelRatio = MediaQuery.devicePixelRatioOf(context);
+        final cacheWidth = _cacheDimension(
+          explicitSize: width,
+          constrainedSize: constraints.maxWidth,
+          devicePixelRatio: devicePixelRatio,
+        );
+        final cacheHeight = _cacheDimension(
+          explicitSize: height,
+          constrainedSize: constraints.maxHeight,
+          devicePixelRatio: devicePixelRatio,
+        );
+
+        return Image.network(
+          url,
+          width: width,
+          height: height,
+          fit: fit,
+          alignment: alignment,
+          semanticLabel: semanticLabel,
+          excludeFromSemantics: excludeFromSemantics,
+          filterQuality: filterQuality,
+          cacheWidth: _clampCacheDimension(cacheWidth),
+          cacheHeight: _clampCacheDimension(cacheHeight),
+          loadingBuilder: placeholderBuilder == null
+              ? null
+              : (context, child, progress) {
+                  if (progress == null) return child;
+                  return placeholderBuilder!(context);
+                },
+          errorBuilder: errorBuilder == null
+              ? null
+              : (context, error, stackTrace) {
+                  return errorBuilder!(context, error, stackTrace);
+                },
+        );
+      },
+    );
+  }
+
+  int? _cacheDimension({
+    required double? explicitSize,
+    required double constrainedSize,
+    required double devicePixelRatio,
+  }) {
+    final logicalSize = explicitSize ?? constrainedSize;
+    if (!logicalSize.isFinite || logicalSize <= 0) return null;
+    return (logicalSize * devicePixelRatio).ceil();
+  }
+
+  int? _clampCacheDimension(int? value) {
+    if (value == null) return null;
+    return math.max(1, math.min(value, maxDecodeDimension));
+  }
+}
+
+/// Shared image cache budget helpers for constrained device profiles.
+class AiroImageCacheBudget {
+  const AiroImageCacheBudget._();
+
+  static const int androidTvMaxEntries = 300;
+  static const int androidTvMaxBytes = 64 * 1024 * 1024;
+
+  static void configureAndroidTv({
+    int maximumSize = androidTvMaxEntries,
+    int maximumSizeBytes = androidTvMaxBytes,
+  }) {
+    final imageCache = PaintingBinding.instance.imageCache;
+    imageCache.maximumSize = maximumSize;
+    imageCache.maximumSizeBytes = maximumSizeBytes;
+  }
+}

--- a/packages/core_ui/test/airo_network_image_test.dart
+++ b/packages/core_ui/test/airo_network_image_test.dart
@@ -1,0 +1,76 @@
+import 'package:core_ui/core_ui.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('sets cache size from rendered bounds and pixel ratio', (
+    tester,
+  ) async {
+    tester.view.devicePixelRatio = 2;
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    await tester.pumpWidget(
+      const Directionality(
+        textDirection: TextDirection.ltr,
+        child: Center(
+          child: SizedBox(
+            width: 40,
+            height: 30,
+            child: AiroNetworkImage(url: 'https://example.com/logo.png'),
+          ),
+        ),
+      ),
+    );
+
+    final image = tester.widget<Image>(find.byType(Image));
+    final imageProvider = image.image as ResizeImage;
+    expect(imageProvider.width, 80);
+    expect(imageProvider.height, 60);
+  });
+
+  testWidgets('clamps very large decode dimensions', (tester) async {
+    tester.view.devicePixelRatio = 3;
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    await tester.pumpWidget(
+      const Directionality(
+        textDirection: TextDirection.ltr,
+        child: Center(
+          child: SizedBox(
+            width: 600,
+            height: 500,
+            child: AiroNetworkImage(
+              url: 'https://example.com/logo.png',
+              maxDecodeDimension: 256,
+            ),
+          ),
+        ),
+      ),
+    );
+
+    final image = tester.widget<Image>(find.byType(Image));
+    final imageProvider = image.image as ResizeImage;
+    expect(imageProvider.width, 256);
+    expect(imageProvider.height, 256);
+  });
+
+  test('configures Android TV image cache budget', () {
+    final imageCache = PaintingBinding.instance.imageCache;
+    final originalMaximumSize = imageCache.maximumSize;
+    final originalMaximumSizeBytes = imageCache.maximumSizeBytes;
+    addTearDown(() {
+      imageCache.maximumSize = originalMaximumSize;
+      imageCache.maximumSizeBytes = originalMaximumSizeBytes;
+    });
+
+    AiroImageCacheBudget.configureAndroidTv(
+      maximumSize: 12,
+      maximumSizeBytes: 34,
+    );
+
+    expect(imageCache.maximumSize, 12);
+    expect(imageCache.maximumSizeBytes, 34);
+  });
+}

--- a/packages/feature_iptv/lib/presentation/tv/iptv_tv_screen.dart
+++ b/packages/feature_iptv/lib/presentation/tv/iptv_tv_screen.dart
@@ -1,3 +1,4 @@
+import 'package:core_ui/core_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:platform_channels/platform_channels.dart';
@@ -1086,12 +1087,13 @@ class _ChannelLogo extends StatelessWidget {
       child: Padding(
         padding: const EdgeInsets.all(10),
         child: channel.hasLogo
-            ? Image.network(
-                channel.logoUrl!,
+            ? AiroNetworkImage(
+                url: channel.logoUrl!,
                 fit: BoxFit.contain,
-                errorBuilder: (_, _, _) => IptvIconPlaceholder.channel(
-                  isAudioOnly: channel.isAudioOnly,
-                ),
+                errorBuilder: (context, error, stackTrace) =>
+                    IptvIconPlaceholder.channel(
+                      isAudioOnly: channel.isAudioOnly,
+                    ),
               )
             : IptvIconPlaceholder.channel(isAudioOnly: channel.isAudioOnly),
       ),

--- a/packages/feature_iptv/lib/presentation/widgets/channel_list_widget.dart
+++ b/packages/feature_iptv/lib/presentation/widgets/channel_list_widget.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:core_ui/core_ui.dart';
 import '../../application/providers/iptv_providers.dart';
 import "package:platform_channels/platform_channels.dart";
 import 'iptv_icon_placeholder.dart';
@@ -320,10 +321,11 @@ class _RecentChannelCard extends StatelessWidget {
                 height: 56,
                 color: Colors.grey[200],
                 child: channel.hasLogo
-                    ? Image.network(
-                        channel.logoUrl!,
+                    ? AiroNetworkImage(
+                        url: channel.logoUrl!,
                         fit: BoxFit.cover,
-                        errorBuilder: (_, _, _) => _buildDefaultIcon(),
+                        errorBuilder: (context, error, stackTrace) =>
+                            _buildDefaultIcon(),
                       )
                     : _buildDefaultIcon(),
               ),
@@ -406,26 +408,19 @@ class _ChannelListTile extends ConsumerWidget {
                       height: 48,
                       color: colorScheme.surface.withValues(alpha: 0.42),
                       child: channel.hasLogo
-                          ? Image.network(
-                              channel.logoUrl!,
+                          ? AiroNetworkImage(
+                              url: channel.logoUrl!,
                               fit: BoxFit.cover,
-                              loadingBuilder: (_, child, loadingProgress) {
-                                if (loadingProgress == null) return child;
+                              placeholderBuilder: (_) {
                                 return Center(
                                   child: CircularProgressIndicator(
                                     strokeWidth: 2,
-                                    value:
-                                        loadingProgress.expectedTotalBytes !=
-                                            null
-                                        ? loadingProgress
-                                                  .cumulativeBytesLoaded /
-                                              loadingProgress
-                                                  .expectedTotalBytes!
-                                        : null,
+                                    color: colorScheme.primary,
                                   ),
                                 );
                               },
-                              errorBuilder: (_, _, _) => _buildDefaultIcon(),
+                              errorBuilder: (context, error, stackTrace) =>
+                                  _buildDefaultIcon(),
                             )
                           : _buildDefaultIcon(),
                     ),

--- a/packages/feature_iptv/lib/presentation/widgets/iptv_mini_player.dart
+++ b/packages/feature_iptv/lib/presentation/widgets/iptv_mini_player.dart
@@ -1,3 +1,4 @@
+import 'package:core_ui/core_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../application/providers/iptv_providers.dart';
@@ -57,10 +58,11 @@ class IPTVMiniPlayer extends ConsumerWidget {
                   height: 64,
                   color: Colors.black,
                   child: state.currentChannel!.logoUrl != null
-                      ? Image.network(
-                          state.currentChannel!.logoUrl!,
+                      ? AiroNetworkImage(
+                          url: state.currentChannel!.logoUrl!,
                           fit: BoxFit.cover,
-                          errorBuilder: (_, _, _) => _buildDefaultIcon(),
+                          errorBuilder: (context, error, stackTrace) =>
+                              _buildDefaultIcon(),
                         )
                       : _buildDefaultIcon(),
                 ),

--- a/packages/feature_iptv/lib/presentation/widgets/tv_channel_grid.dart
+++ b/packages/feature_iptv/lib/presentation/widgets/tv_channel_grid.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:core_ui/core_ui.dart';
 import '../../application/providers/iptv_providers.dart';
 import "package:platform_channels/platform_channels.dart";
 import '../tv/iptv_tv.dart';
@@ -142,8 +143,19 @@ class _TvChannelGridState extends ConsumerState<TvChannelGrid> {
     for (var i = startIndex; i < endIndex; i++) {
       final channel = channels[i];
       if (channel.hasLogo) {
-        // Precache the image in Flutter's image cache
-        precacheImage(NetworkImage(channel.logoUrl!), context);
+        final devicePixelRatio = MediaQuery.devicePixelRatioOf(context);
+        final cacheWidth = (dimensions.channelCardWidth * devicePixelRatio)
+            .ceil();
+        final cacheHeight = (dimensions.channelCardHeight * devicePixelRatio)
+            .ceil();
+        precacheImage(
+          ResizeImage.resizeIfNeeded(
+            cacheWidth,
+            cacheHeight,
+            NetworkImage(channel.logoUrl!),
+          ),
+          context,
+        );
       }
     }
   }
@@ -329,10 +341,10 @@ class _TvChannelCard extends StatelessWidget {
     if (channel.hasLogo) {
       return ClipRRect(
         borderRadius: BorderRadius.circular(8),
-        child: Image.network(
-          channel.logoUrl!,
+        child: AiroNetworkImage(
+          url: channel.logoUrl!,
           fit: BoxFit.contain,
-          errorBuilder: (_, _, _) => _buildDefaultIcon(),
+          errorBuilder: (context, error, stackTrace) => _buildDefaultIcon(),
         ),
       );
     }

--- a/packages/feature_iptv/lib/presentation/widgets/tv_player_controls.dart
+++ b/packages/feature_iptv/lib/presentation/widgets/tv_player_controls.dart
@@ -1,3 +1,4 @@
+import 'package:core_ui/core_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import "package:platform_player/platform_player.dart";
@@ -107,11 +108,12 @@ class _TvPlayerControlsState extends ConsumerState<TvPlayerControls> {
           if (channel.logoUrl != null)
             ClipRRect(
               borderRadius: BorderRadius.circular(8),
-              child: Image.network(
-                channel.logoUrl!,
+              child: AiroNetworkImage(
+                url: channel.logoUrl!,
                 width: 48,
                 height: 48,
-                errorBuilder: (_, _, _) => const SizedBox.shrink(),
+                errorBuilder: (context, error, stackTrace) =>
+                    const SizedBox.shrink(),
               ),
             ),
           const SizedBox(width: 16),

--- a/packages/feature_iptv/lib/presentation/widgets/video_player_widget.dart
+++ b/packages/feature_iptv/lib/presentation/widgets/video_player_widget.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'package:core_ui/core_ui.dart';
 import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -453,12 +454,13 @@ class _VideoPlayerWidgetState extends ConsumerState<VideoPlayerWidget> {
       ),
       child: Center(
         child: channel != null && channel.hasLogo
-            ? Image.network(
-                channel.logoUrl!,
+            ? AiroNetworkImage(
+                url: channel.logoUrl!,
                 width: 120,
                 height: 120,
                 fit: BoxFit.contain,
-                errorBuilder: (_, _, _) => _buildDefaultPlaceholder(),
+                errorBuilder: (context, error, stackTrace) =>
+                    _buildDefaultPlaceholder(),
               )
             : _buildDefaultPlaceholder(),
       ),
@@ -512,11 +514,12 @@ class _VideoPlayerWidgetState extends ConsumerState<VideoPlayerWidget> {
                     if (state.currentChannel!.logoUrl != null)
                       ClipRRect(
                         borderRadius: BorderRadius.circular(4),
-                        child: Image.network(
-                          state.currentChannel!.logoUrl!,
+                        child: AiroNetworkImage(
+                          url: state.currentChannel!.logoUrl!,
                           width: 32,
                           height: 32,
-                          errorBuilder: (_, _, _) => const SizedBox.shrink(),
+                          errorBuilder: (context, error, stackTrace) =>
+                              const SizedBox.shrink(),
                         ),
                       ),
                     const SizedBox(width: 8),

--- a/packages/feature_iptv/pubspec.yaml
+++ b/packages/feature_iptv/pubspec.yaml
@@ -9,6 +9,8 @@ environment:
   flutter: ">=1.17.0"
 
 dependencies:
+  core_ui:
+    path: ../core_ui
   dio: ^5.10.0
   equatable: ^2.0.8
   flutter:


### PR DESCRIPTION
# Summary

This PR introduces bounded channel-logo image decoding for Airo TV large playlists.
Goal: reduce memory and jank risk when browsing 10k+ playlist logos on constrained Android TV / Fire TV devices.

Core outcome:

* Added a reusable `core_ui` network image wrapper that decodes near rendered size.
* Routed Airo TV / IPTV channel logo widgets through the reusable wrapper.
* Configured the TV entrypoint with a bounded process-wide Flutter `ImageCache`.

# Changes

### Code

* Added:

  * `AiroNetworkImage` in `packages/core_ui`.
  * `AiroImageCacheBudget.configureAndroidTv()` for TV cache limits.
  * Core UI widget tests for decode sizing, clamp behavior, and cache budget configuration.

* Updated:

  * IPTV grid/list/player/mini-player/TV-screen logo render paths to consume `AiroNetworkImage`.
  * TV grid thumbnail prefetch to use `ResizeImage.resizeIfNeeded(...)` with card-derived cache dimensions.
  * `app/lib/main_tv.dart` to apply the Android TV image cache budget after binding initialization.
  * Core UI and Airo TV docs for the reusable image-rendering contract.

# API Changes

None.

# Database Changes

None.

# Observability / Logging

None.

# Performance Impact

* Memory: reduces logo decode pressure by using display-size cache dimensions instead of native-size decodes.
* CPU/GPU: reduces oversized decode work for logo-heavy channel grids and lists.
* Startup: negligible; the TV entrypoint only applies `ImageCache` limits after Flutter binding initialization.

# Risks

* Some logos may decode at lower resolution if rendered beyond their normal bounds; `maxDecodeDimension` defaults to 1024 to preserve quality for TV logo surfaces.
* Physical 1GB Android TV RSS plateau and decode-jank evidence still needs device/emulator benchmarking.

Rollback plan:

* Revert this commit to restore raw `Image.network` logo rendering and default Flutter image cache sizing.

# Testing

* Unit/widget tests:

  * `cd packages/core_ui && flutter test test/airo_network_image_test.dart --reporter=compact`
  * `cd packages/feature_iptv && flutter test test/feature_iptv_test.dart test/iptv/iptv_cast_media_adapter_test.dart --reporter=compact`

* Static analysis:

  * `cd packages/core_ui && flutter analyze lib/src/widgets/airo_network_image.dart test/airo_network_image_test.dart --no-fatal-infos --no-fatal-warnings`
  * `cd packages/feature_iptv && flutter analyze lib/presentation/widgets/tv_channel_grid.dart lib/presentation/widgets/channel_list_widget.dart lib/presentation/widgets/video_player_widget.dart lib/presentation/widgets/tv_player_controls.dart lib/presentation/widgets/iptv_mini_player.dart lib/presentation/tv/iptv_tv_screen.dart --no-fatal-infos --no-fatal-warnings`
  * `cd app && flutter analyze lib/main_tv.dart --no-fatal-infos --no-fatal-warnings`

* Repo checks:

  * `git diff --check`
  * `bash scripts/check-docs-completeness.sh --base origin/v2 --head HEAD`

Note: `feature_iptv` tests print an existing `uses-material-design` warning from the new `core_ui` package dependency, but the test process exits successfully.

# Deployment Notes

No config changes.

# Related Issues

Closes #773

# Notes

This is the reusable component + Airo TV consumption slice. Disk LRU caching, HTTP/2 logo burst optimization, and physical 1GB Android TV benchmark evidence remain separate follow-up work.
