### PR TITLE
perf(iptv): add platform channel search index

### DIFF
--- a/packages/feature_iptv/lib/application/providers/iptv_providers.dart
+++ b/packages/feature_iptv/lib/application/providers/iptv_providers.dart
@@ -172,61 +172,38 @@ final preferenceKeywordsProvider = StateProvider<List<String>>((ref) {
   ];
 });
 
+/// Reusable platform search index for the loaded channel list.
+final channelSearchIndexProvider = Provider<AiroChannelSearchIndex?>((ref) {
+  final channelsAsync = ref.watch(iptvChannelsProvider);
+  return channelsAsync.when(
+    data: AiroChannelSearchIndex.new,
+    loading: () => null,
+    error: (_, _) => null,
+  );
+});
+
 /// Filtered and sorted channels
 final filteredChannelsProvider = Provider<List<IPTVChannel>>((ref) {
-  final channelsAsync = ref.watch(iptvChannelsProvider);
+  final searchIndex = ref.watch(channelSearchIndexProvider);
   final category = ref.watch(selectedCategoryProvider);
   final flavor = ref.watch(selectedFlavorProvider);
-  final searchQuery = ref.watch(channelSearchQueryProvider).toLowerCase();
+  final searchQuery = ref.watch(channelSearchQueryProvider);
   final preferences = ref.watch(preferenceKeywordsProvider);
 
-  return channelsAsync.when(
-    data: (channels) {
-      // Filter by category
-      var filtered = category == ChannelCategory.all
-          ? channels.toList()
-          : channels.where((c) => c.category == category).toList();
-
-      // Filter by flavor (taste-based filtering)
-      if (flavor != null) {
-        filtered = filtered.where((c) => c.flavor == flavor).toList();
-      }
-
-      // Filter by search query
-      if (searchQuery.isNotEmpty) {
-        filtered = filtered
-            .where(
-              (c) =>
-                  c.name.toLowerCase().contains(searchQuery) ||
-                  c.group.toLowerCase().contains(searchQuery),
-            )
-            .toList();
-      }
-
-      // Sort by preference score
-      filtered.sort((a, b) {
-        final scoreA = _getPreferenceScore(a, preferences);
-        final scoreB = _getPreferenceScore(b, preferences);
-        if (scoreA != scoreB) return scoreB.compareTo(scoreA);
-        return a.name.compareTo(b.name);
-      });
-
-      return filtered;
-    },
-    loading: () => [],
-    error: (_, _) => [],
-  );
+  return searchIndex?.filterAndSort(
+        category: category,
+        flavor: flavor,
+        query: searchQuery,
+        preferenceKeywords: preferences,
+      ) ??
+      const [];
 });
 
 /// Channels filtered by specific flavor
 final channelsByFlavorProvider =
     Provider.family<List<IPTVChannel>, ChannelFlavor>((ref, flavor) {
-      final channelsAsync = ref.watch(iptvChannelsProvider);
-      return channelsAsync.when(
-        data: (channels) => channels.where((c) => c.flavor == flavor).toList(),
-        loading: () => [],
-        error: (_, _) => [],
-      );
+      final searchIndex = ref.watch(channelSearchIndexProvider);
+      return searchIndex?.channelsByFlavor(flavor) ?? const [];
     });
 
 /// Hindi music channels provider (convenience)
@@ -249,38 +226,10 @@ final englishNewsChannelsProvider = Provider<List<IPTVChannel>>((ref) {
   return ref.watch(channelsByFlavorProvider(ChannelFlavor.englishNews));
 });
 
-int _getPreferenceScore(IPTVChannel channel, List<String> preferences) {
-  final str = '${channel.name} ${channel.group}'.toLowerCase();
-  for (var i = 0; i < preferences.length; i++) {
-    if (str.contains(preferences[i])) {
-      return preferences.length - i; // Higher score for earlier preferences
-    }
-  }
-  return 0;
-}
-
 /// Category counts provider - shows how many channels in each category
 final categoryCounts = Provider<Map<ChannelCategory, int>>((ref) {
-  final channelsAsync = ref.watch(iptvChannelsProvider);
-
-  return channelsAsync.when(
-    data: (channels) {
-      final counts = <ChannelCategory, int>{};
-      // Count 'All' as total channels
-      counts[ChannelCategory.all] = channels.length;
-      // Count each category
-      for (final category in ChannelCategory.values) {
-        if (category != ChannelCategory.all) {
-          counts[category] = channels
-              .where((c) => c.category == category)
-              .length;
-        }
-      }
-      return counts;
-    },
-    loading: () => {},
-    error: (_, _) => {},
-  );
+  final searchIndex = ref.watch(channelSearchIndexProvider);
+  return searchIndex?.categoryCounts ?? const {};
 });
 
 /// Check if any filter is active (category, flavor, or search)
@@ -295,19 +244,8 @@ final hasActiveFilterProvider = Provider<bool>((ref) {
 
 /// Flavor counts provider - shows how many channels in each flavor
 final flavorCounts = Provider<Map<ChannelFlavor, int>>((ref) {
-  final channelsAsync = ref.watch(iptvChannelsProvider);
-
-  return channelsAsync.when(
-    data: (channels) {
-      final counts = <ChannelFlavor, int>{};
-      for (final flavor in ChannelFlavor.values) {
-        counts[flavor] = channels.where((c) => c.flavor == flavor).length;
-      }
-      return counts;
-    },
-    loading: () => {},
-    error: (_, _) => {},
-  );
+  final searchIndex = ref.watch(channelSearchIndexProvider);
+  return searchIndex?.flavorCounts ?? const {};
 });
 
 /// Streaming state provider

--- a/packages/feature_iptv/test/iptv/application/providers/iptv_providers_test.dart
+++ b/packages/feature_iptv/test/iptv/application/providers/iptv_providers_test.dart
@@ -80,6 +80,51 @@ void main() {
         final category = container.read(selectedCategoryProvider);
         expect(category, equals(ChannelCategory.all));
       });
+
+      test('uses platform search index for combined filters', () async {
+        final container = ProviderContainer(
+          overrides: [
+            sharedPreferencesProvider.overrideWithValue(
+              await SharedPreferences.getInstance(),
+            ),
+            iptvChannelsProvider.overrideWith((ref) async => _channels),
+          ],
+        );
+        addTearDown(container.dispose);
+
+        await container.read(iptvChannelsProvider.future);
+        container.read(selectedCategoryProvider.notifier).state =
+            ChannelCategory.news;
+        container.read(selectedFlavorProvider.notifier).state =
+            ChannelFlavor.englishNews;
+        container.read(channelSearchQueryProvider.notifier).state = 'global';
+
+        final filtered = container.read(filteredChannelsProvider);
+
+        expect(filtered.map((channel) => channel.id), ['3']);
+      });
+
+      test('uses platform search index counts', () async {
+        final container = ProviderContainer(
+          overrides: [
+            sharedPreferencesProvider.overrideWithValue(
+              await SharedPreferences.getInstance(),
+            ),
+            iptvChannelsProvider.overrideWith((ref) async => _channels),
+          ],
+        );
+        addTearDown(container.dispose);
+
+        await container.read(iptvChannelsProvider.future);
+
+        final categories = container.read(categoryCounts);
+        final flavors = container.read(flavorCounts);
+
+        expect(categories[ChannelCategory.all], 4);
+        expect(categories[ChannelCategory.news], 2);
+        expect(flavors[ChannelFlavor.hindiMusic], 1);
+        expect(flavors[ChannelFlavor.sports], 1);
+      });
     });
 
     group('Preference sorting', () {
@@ -165,3 +210,38 @@ void main() {
     });
   });
 }
+
+const _channels = [
+  IPTVChannel(
+    id: '1',
+    name: 'Bharat Samachar',
+    streamUrl: 'https://example.com/1.m3u8',
+    group: 'Hindi News',
+    category: ChannelCategory.news,
+    flavor: ChannelFlavor.hindiNews,
+  ),
+  IPTVChannel(
+    id: '2',
+    name: 'Aaj Music',
+    streamUrl: 'https://example.com/2.m3u8',
+    group: 'Hindi Hits',
+    category: ChannelCategory.music,
+    flavor: ChannelFlavor.hindiMusic,
+  ),
+  IPTVChannel(
+    id: '3',
+    name: 'Global News',
+    streamUrl: 'https://example.com/3.m3u8',
+    group: 'World',
+    category: ChannelCategory.news,
+    flavor: ChannelFlavor.englishNews,
+  ),
+  IPTVChannel(
+    id: '4',
+    name: 'Cricket Live',
+    streamUrl: 'https://example.com/4.m3u8',
+    group: 'Sports',
+    category: ChannelCategory.sports,
+    flavor: ChannelFlavor.sports,
+  ),
+];

--- a/packages/platform_channels/README.md
+++ b/packages/platform_channels/README.md
@@ -7,6 +7,8 @@ for Airo products.
 
 - `IPTVChannel` and related channel metadata models.
 - `ChannelDataService` for first-party channel data boundaries.
+- `AiroChannelSearchIndex` for reusable channel search, filtering, sorting, and
+  aggregate counts over loaded playlist data.
 - `AiroPlaylistUrlPolicy` for validating stream and artwork URLs parsed from
   user-supplied playlist content.
 
@@ -20,3 +22,15 @@ default.
 Callers may opt into private hosts only after a product-level user consent flow
 exists for LAN streams. Airo TV screens should consume the sanitized platform
 models instead of revalidating stream and logo URLs in UI code.
+
+## Channel Search Index
+
+`AiroChannelSearchIndex` precomputes normalized channel search text and category
+/ flavor counts once per loaded playlist. Airo TV providers should consume this
+index instead of lowercasing channel names, rebuilding count maps, or running
+separate category/flavor/search list passes on every keystroke.
+
+The current implementation preserves the existing exact substring behavior for
+channel name and group searches. Future Rust, trie, or tantivy-backed search can
+replace the internals behind this platform-owned contract without moving search
+logic back into product screens.

--- a/packages/platform_channels/lib/platform_channels.dart
+++ b/packages/platform_channels/lib/platform_channels.dart
@@ -1,5 +1,6 @@
 library platform_channels;
 
 export "src/models/iptv_channel.dart";
+export "src/search/channel_search_index.dart";
 export "src/security/playlist_url_policy.dart";
 export "src/services/channel_data_service.dart";

--- a/packages/platform_channels/lib/src/search/channel_search_index.dart
+++ b/packages/platform_channels/lib/src/search/channel_search_index.dart
@@ -1,0 +1,125 @@
+import '../models/iptv_channel.dart';
+
+/// Reusable search and filter index for channel lists.
+///
+/// This keeps normalized channel text and aggregate counts with the loaded
+/// playlist so product UI does not rebuild them on every search keystroke.
+class AiroChannelSearchIndex {
+  AiroChannelSearchIndex(List<IPTVChannel> channels)
+    : channels = List<IPTVChannel>.unmodifiable(channels) {
+    final categoryCounts = <ChannelCategory, int>{
+      for (final category in ChannelCategory.values) category: 0,
+    };
+    final flavorCounts = <ChannelFlavor, int>{
+      for (final flavor in ChannelFlavor.values) flavor: 0,
+    };
+    final channelsByFlavor = <ChannelFlavor, List<IPTVChannel>>{
+      for (final flavor in ChannelFlavor.values) flavor: <IPTVChannel>[],
+    };
+    final entries = <_AiroChannelSearchEntry>[];
+
+    categoryCounts[ChannelCategory.all] = channels.length;
+
+    for (final channel in channels) {
+      entries.add(_AiroChannelSearchEntry(channel));
+      if (channel.category != ChannelCategory.all) {
+        categoryCounts[channel.category] =
+            categoryCounts[channel.category]! + 1;
+      }
+      flavorCounts[channel.flavor] = flavorCounts[channel.flavor]! + 1;
+      channelsByFlavor[channel.flavor]!.add(channel);
+    }
+
+    _entries = List<_AiroChannelSearchEntry>.unmodifiable(entries);
+    _channelsByFlavor = Map<ChannelFlavor, List<IPTVChannel>>.unmodifiable(
+      channelsByFlavor.map(
+        (flavor, channels) =>
+            MapEntry(flavor, List<IPTVChannel>.unmodifiable(channels)),
+      ),
+    );
+    this.categoryCounts = Map<ChannelCategory, int>.unmodifiable(
+      categoryCounts,
+    );
+    this.flavorCounts = Map<ChannelFlavor, int>.unmodifiable(flavorCounts);
+  }
+
+  final List<IPTVChannel> channels;
+  late final List<_AiroChannelSearchEntry> _entries;
+  late final Map<ChannelFlavor, List<IPTVChannel>> _channelsByFlavor;
+  late final Map<ChannelCategory, int> categoryCounts;
+  late final Map<ChannelFlavor, int> flavorCounts;
+
+  List<IPTVChannel> filterAndSort({
+    ChannelCategory category = ChannelCategory.all,
+    ChannelFlavor? flavor,
+    String query = '',
+    List<String> preferenceKeywords = const [],
+  }) {
+    final normalizedQuery = query.trim().toLowerCase();
+    final normalizedPreferences = preferenceKeywords
+        .map((preference) => preference.trim().toLowerCase())
+        .where((preference) => preference.isNotEmpty)
+        .toList(growable: false);
+    final matched = <_AiroScoredChannel>[];
+
+    for (final entry in _entries) {
+      if (category != ChannelCategory.all &&
+          entry.channel.category != category) {
+        continue;
+      }
+      if (flavor != null && entry.channel.flavor != flavor) {
+        continue;
+      }
+      if (normalizedQuery.isNotEmpty &&
+          !entry.searchText.contains(normalizedQuery)) {
+        continue;
+      }
+
+      matched.add(
+        _AiroScoredChannel(
+          entry.channel,
+          _preferenceScore(entry.searchText, normalizedPreferences),
+        ),
+      );
+    }
+
+    matched.sort((a, b) {
+      if (a.preferenceScore != b.preferenceScore) {
+        return b.preferenceScore.compareTo(a.preferenceScore);
+      }
+      return a.channel.name.compareTo(b.channel.name);
+    });
+
+    return List<IPTVChannel>.unmodifiable(
+      matched.map((match) => match.channel),
+    );
+  }
+
+  List<IPTVChannel> channelsByFlavor(ChannelFlavor flavor) {
+    return _channelsByFlavor[flavor] ?? const [];
+  }
+
+  int _preferenceScore(String searchText, List<String> preferences) {
+    for (var i = 0; i < preferences.length; i++) {
+      if (searchText.contains(preferences[i])) {
+        return preferences.length - i;
+      }
+    }
+    return 0;
+  }
+}
+
+class _AiroChannelSearchEntry {
+  _AiroChannelSearchEntry(this.channel)
+    : searchText = '${channel.name} ${channel.group}'.toLowerCase();
+
+  final IPTVChannel channel;
+  final String searchText;
+}
+
+class _AiroScoredChannel {
+  const _AiroScoredChannel(this.channel, this.preferenceScore);
+
+  final IPTVChannel channel;
+  final int preferenceScore;
+}

--- a/packages/platform_channels/test/channel_search_index_test.dart
+++ b/packages/platform_channels/test/channel_search_index_test.dart
@@ -1,0 +1,91 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:platform_channels/platform_channels.dart';
+
+void main() {
+  group('AiroChannelSearchIndex', () {
+    test('searches name and group case-insensitively', () {
+      final index = AiroChannelSearchIndex(_channels);
+
+      final matches = index.filterAndSort(query: 'NEWS');
+
+      expect(matches.map((channel) => channel.id), ['1', '3']);
+    });
+
+    test('combines category, flavor, and query filters in one result set', () {
+      final index = AiroChannelSearchIndex(_channels);
+
+      final matches = index.filterAndSort(
+        category: ChannelCategory.news,
+        flavor: ChannelFlavor.englishNews,
+        query: 'global',
+      );
+
+      expect(matches.map((channel) => channel.id), ['3']);
+    });
+
+    test('sorts preference matches before alphabetical fallback', () {
+      final index = AiroChannelSearchIndex(_channels);
+
+      final matches = index.filterAndSort(
+        preferenceKeywords: const ['music', 'sports'],
+      );
+
+      expect(matches.map((channel) => channel.id), ['2', '4', '1', '3']);
+    });
+
+    test('memoizes category and flavor counts', () {
+      final index = AiroChannelSearchIndex(_channels);
+
+      expect(index.categoryCounts[ChannelCategory.all], 4);
+      expect(index.categoryCounts[ChannelCategory.news], 2);
+      expect(index.categoryCounts[ChannelCategory.music], 1);
+      expect(index.flavorCounts[ChannelFlavor.englishNews], 1);
+      expect(index.flavorCounts[ChannelFlavor.hindiNews], 1);
+      expect(index.flavorCounts[ChannelFlavor.hindiMusic], 1);
+      expect(index.flavorCounts[ChannelFlavor.sports], 1);
+    });
+
+    test('returns channels by flavor from the index', () {
+      final index = AiroChannelSearchIndex(_channels);
+
+      final matches = index.channelsByFlavor(ChannelFlavor.hindiNews);
+
+      expect(matches.map((channel) => channel.id), ['1']);
+    });
+  });
+}
+
+const _channels = [
+  IPTVChannel(
+    id: '1',
+    name: 'Bharat Samachar',
+    streamUrl: 'https://example.com/1.m3u8',
+    group: 'Hindi News',
+    category: ChannelCategory.news,
+    flavor: ChannelFlavor.hindiNews,
+  ),
+  IPTVChannel(
+    id: '2',
+    name: 'Aaj Music',
+    streamUrl: 'https://example.com/2.m3u8',
+    group: 'Hindi Hits',
+    category: ChannelCategory.music,
+    flavor: ChannelFlavor.hindiMusic,
+  ),
+  IPTVChannel(
+    id: '3',
+    name: 'Global News',
+    streamUrl: 'https://example.com/3.m3u8',
+    group: 'World',
+    category: ChannelCategory.news,
+    flavor: ChannelFlavor.englishNews,
+  ),
+  IPTVChannel(
+    id: '4',
+    name: 'Cricket Live',
+    streamUrl: 'https://example.com/4.m3u8',
+    group: 'Sports',
+    category: ChannelCategory.sports,
+    flavor: ChannelFlavor.sports,
+  ),
+];


### PR DESCRIPTION
# Summary

This PR adds a reusable platform channel search/filter index and routes Airo TV IPTV providers through it.
Goal: reduce per-keystroke channel search work for large playlists while preserving existing search semantics.

Core outcome:

* Precomputes normalized channel search text once per loaded playlist.
* Replaces repeated provider-local category/flavor/search/count passes with a platform-owned index.
* Establishes the contract that future Rust/trie/tantivy search can replace behind the same boundary.

# Changes

### Code

* Added:

  * `AiroChannelSearchIndex` in `packages/platform_channels`.
  * Platform tests for case-insensitive search, combined filters, preference sorting, counts, and flavor lookup.
  * Feature provider tests proving Airo TV consumes the platform index.

* Updated:

  * `filteredChannelsProvider` to call `AiroChannelSearchIndex.filterAndSort(...)`.
  * Flavor convenience providers to use indexed flavor lists.
  * Category and flavor count providers to use memoized aggregate maps.
  * `packages/platform_channels/README.md` with the platform search boundary.

# API Changes

* New exported platform API: `AiroChannelSearchIndex`.

# Database Changes

None.

# Observability / Logging

None.

# Performance Impact

* Reduces repeated `toLowerCase()` calls over every channel on every search rebuild.
* Reduces category/flavor count computation from repeated full-list scans to one index build per channel list.
* Keeps result filtering and preference sorting on the Dart side for now; Rust/tantivy indexed search remains a follow-up.

# Risks

* This intentionally preserves exact substring search behavior for channel name/group. It does not yet deliver fuzzy/ranked Rust search.
* The index rebuilds when the loaded channel list changes, which is expected for this slice.

Rollback plan:

* Revert this commit to restore direct provider-local filtering/count loops.

# Testing

* `cd packages/platform_channels && flutter test test/channel_search_index_test.dart test/platform_channels_test.dart --reporter=compact`
* `cd packages/platform_channels && flutter analyze lib/src/search/channel_search_index.dart test/channel_search_index_test.dart --no-fatal-infos --no-fatal-warnings`
* `cd packages/feature_iptv && flutter test test/feature_iptv_test.dart test/iptv/application/providers/iptv_providers_test.dart --reporter=compact`
* `cd packages/feature_iptv && flutter analyze lib/application/providers/iptv_providers.dart test/iptv/application/providers/iptv_providers_test.dart --no-fatal-infos --no-fatal-warnings`
* `git diff --check`
* `bash scripts/check-docs-completeness.sh --base origin/v2 --head HEAD`

Note: `feature_iptv` tests print the existing `core_ui uses-material-design` warning, but the test process exits successfully.

# Deployment Notes

No config changes.

# Related Issues

Part of #766.

# Notes

This is the short-term Dart/platform-index slice from the issue. Remaining #766 acceptance work includes profile-mode p95 search benchmark evidence, zero dropped frames while typing, and the target Rust/trie/tantivy fuzzy/ranked search backend.
