### PR TITLE
arch(storage): ADR, size guard, Hive retirement notice (#776)

### DIFF
--- a/app/lib/core/database/app_database.dart
+++ b/app/lib/core/database/app_database.dart
@@ -2,7 +2,7 @@
 ///
 /// This file uses conditional imports to provide:
 /// - Native platforms (Android, iOS, Windows, Linux, macOS): SQLite/Drift
-/// - Web platform: Hive/IndexedDB
+/// - Web platform: Hive/IndexedDB (DEPRECATED -- see ADR-0008)
 ///
 /// Usage:
 /// ```dart

--- a/app/lib/core/database/app_database_web.dart
+++ b/app/lib/core/database/app_database_web.dart
@@ -1,8 +1,11 @@
 // ignore_for_file: avoid_unused_constructor_parameters
 
 /// Web-compatible database implementation using Hive for IndexedDB storage.
-/// This provides the same interface as the native AppDatabase but uses
-/// Hive boxes instead of SQLite for web platform compatibility.
+///
+/// **DEPRECATED** -- Hive is RETIRED (ADR-0008). This file is the sole
+/// remaining Hive consumer. It will be replaced with Drift's sql.js / sqlite3
+/// WASM backend when web becomes a primary target. Do NOT add new Hive usage
+/// elsewhere in the codebase.
 library;
 
 import 'package:hive_flutter/hive_flutter.dart';

--- a/app/lib/core/di.dart
+++ b/app/lib/core/di.dart
@@ -21,10 +21,8 @@ final dioProvider = Provider<Dio>((ref) {
 //   return AppDb();
 // });
 
-// TODO: Add Hive boxes provider
-// final hiveBoxesProvider = Provider<HiveBoxes>((ref) {
-//   return HiveBoxes();
-// });
+// Hive: RETIRED (ADR-0008). Do not add Hive providers.
+// Use PreferencesStore (prefs tier) or Drift/SQLite (structured tier).
 
 // TODO: Add repository providers
 // final accountsRepositoryProvider = Provider<AccountsRepository>((ref) {

--- a/docs/adr/0008-storage-policy.md
+++ b/docs/adr/0008-storage-policy.md
@@ -1,0 +1,73 @@
+# ADR-0008: Storage Policy -- Tier Definitions and Hive Retirement
+
+## Status
+
+Accepted
+
+## Date
+
+2026-07-15
+
+## Context
+
+Three persistence mechanisms coexist in the Airo codebase:
+
+1. **SharedPreferences** (`PreferencesStore`) -- used for user settings, feature flags, small config values.
+2. **Hive 2.2.3** (`hive_flutter`) -- used only in `app_database_web.dart` as the web-platform fallback for structured data (IndexedDB backend). Hive 2.2.3 is unmaintained.
+3. **Drift/SQLite** (`app_database_native.dart`) -- used on native platforms for structured data (transactions, budgets, accounts, groups, sync metadata).
+
+There is no documented policy on what data belongs in which tier. Hive is an unmaintained dependency that should not receive new usage. Large values occasionally land in SharedPreferences, which is designed for small key-value pairs and has platform-specific size limits.
+
+## Decision
+
+### Storage tiers
+
+| Tier | Backend | Use for | Size limit |
+|------|---------|---------|------------|
+| **Prefs** | `SharedPreferences` via `KeyValueStore` / `PreferencesStore` | Boolean flags, small strings, ints, locale, theme, onboarding state | Max 64 KB per value (debug-asserted) |
+| **Structured** | Drift/SQLite (`AppDatabase`) | Playlists, channel data, EPG, user collections, transactions, budgets, accounts, sync metadata | No per-value limit; schema-governed |
+| **Secure** | `FlutterSecureStorage` via `SecureKeyValueStoreAdapter` | Auth tokens, encryption keys, credentials | Small values only |
+| **File** | `path_provider` directories | Cached images, M3U cache files, large blobs, downloaded media | Governed by cache eviction policy |
+
+### Hive: RETIRED
+
+- **Do not add new Hive usage anywhere in the codebase.**
+- Existing usage in `app_database_web.dart` is the web-platform structured-data backend. It will be replaced with `drift`'s web support (sql.js / sqlite3 WASM) in a future migration (see #776).
+- `hive` and `hive_flutter` dependencies remain until the web database migration is complete.
+
+### Size guard
+
+A debug assertion in `KeyValueStore.setString` rejects values exceeding 64 KB (65,536 chars). This catches accidental misuse of the prefs tier for large data during development without affecting release builds.
+
+## Consequences
+
+### Positive
+
+- Clear guidance for contributors on where to store data.
+- Debug-time protection against prefs tier misuse.
+- Path toward removing an unmaintained dependency.
+
+### Negative
+
+- Web database migration is deferred (tracked separately).
+- Hive dependency remains in pubspec until web migration completes.
+
+### Risks
+
+- Web platform users currently rely on the Hive-backed database; removing it without a replacement would break web builds.
+
+## Alternatives Considered
+
+### Alternative 1: Immediate Hive removal
+
+Remove Hive entirely and switch web to sql.js/WASM now. Not chosen because the Drift WASM backend requires additional setup and testing, and web is not a primary target today.
+
+### Alternative 2: Keep Hive, add wrapper
+
+Wrap Hive behind the same `KeyValueStore` interface. Not chosen because Hive is unmaintained, and the existing usage is for structured data, not key-value pairs.
+
+## References
+
+- Issue #776: Storage consolidation
+- Hive package: https://pub.dev/packages/hive (unmaintained since 2.2.3)
+- Drift web support: https://drift.simonbinder.eu/web/

--- a/packages/core_data/lib/src/storage/key_value_store.dart
+++ b/packages/core_data/lib/src/storage/key_value_store.dart
@@ -1,12 +1,39 @@
 /// Abstract interface for key-value storage operations.
 ///
-/// This abstraction allows for different storage backends
-/// (SharedPreferences, Hive, secure storage, etc.)
+/// This is the **prefs tier** (see ADR-0008). It is intended for small values
+/// only: boolean flags, short strings, ints. Do NOT store large blobs, JSON
+/// payloads, or serialised collections here -- use Drift/SQLite (structured
+/// tier) or file storage instead.
+///
+/// A debug assertion rejects string values larger than [maxValueChars]
+/// (64 KB). This fires only in debug mode and has no effect on release builds.
 abstract class KeyValueStore {
+  /// Maximum character length for a single string value in the prefs tier.
+  /// Values exceeding this limit indicate misuse -- the data belongs in the
+  /// structured tier (Drift/SQLite) or file tier (path_provider).
+  static const int maxValueChars = 65536;
+
+  /// Debug-only size guard. Call from [setString] / [setStringList]
+  /// implementations to catch prefs-tier misuse during development.
+  static void assertValueSize(String value, String key) {
+    assert(() {
+      if (value.length > maxValueChars) {
+        throw StateError(
+          'Value too large for prefs tier: key="$key", '
+          '${value.length} chars (limit $maxValueChars). '
+          'Use Drift/SQLite or file storage instead. See ADR-0008.',
+        );
+      }
+      return true;
+    }());
+  }
+
   /// Gets a string value
   Future<String?> getString(String key);
 
-  /// Sets a string value
+  /// Sets a string value.
+  ///
+  /// In debug mode, throws [StateError] if [value] exceeds [maxValueChars].
   Future<bool> setString(String key, String value);
 
   /// Gets an int value
@@ -30,7 +57,10 @@ abstract class KeyValueStore {
   /// Gets a list of strings
   Future<List<String>?> getStringList(String key);
 
-  /// Sets a list of strings
+  /// Sets a list of strings.
+  ///
+  /// In debug mode, throws [StateError] if any element exceeds
+  /// [maxValueChars].
   Future<bool> setStringList(String key, List<String> value);
 
   /// Checks if a key exists

--- a/packages/core_data/lib/src/storage/preferences_store.dart
+++ b/packages/core_data/lib/src/storage/preferences_store.dart
@@ -18,8 +18,10 @@ class PreferencesStore implements KeyValueStore {
   Future<String?> getString(String key) async => _prefs.getString(key);
 
   @override
-  Future<bool> setString(String key, String value) async =>
-      _prefs.setString(key, value);
+  Future<bool> setString(String key, String value) async {
+    KeyValueStore.assertValueSize(value, key);
+    return _prefs.setString(key, value);
+  }
 
   @override
   Future<int?> getInt(String key) async => _prefs.getInt(key);
@@ -46,8 +48,12 @@ class PreferencesStore implements KeyValueStore {
       _prefs.getStringList(key);
 
   @override
-  Future<bool> setStringList(String key, List<String> value) async =>
-      _prefs.setStringList(key, value);
+  Future<bool> setStringList(String key, List<String> value) async {
+    for (final item in value) {
+      KeyValueStore.assertValueSize(item, key);
+    }
+    return _prefs.setStringList(key, value);
+  }
 
   @override
   Future<bool> containsKey(String key) async => _prefs.containsKey(key);

--- a/packages/core_data/test/storage/key_value_store_size_guard_test.dart
+++ b/packages/core_data/test/storage/key_value_store_size_guard_test.dart
@@ -1,0 +1,57 @@
+import 'package:core_data/core_data.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('KeyValueStore.assertValueSize', () {
+    test('allows values within the 64KB limit', () {
+      // Should not throw for a value under the limit.
+      expect(
+        () => KeyValueStore.assertValueSize('short value', 'test_key'),
+        returnsNormally,
+      );
+    });
+
+    test('allows values at exactly the limit', () {
+      final value = 'x' * KeyValueStore.maxValueChars;
+      expect(
+        () => KeyValueStore.assertValueSize(value, 'test_key'),
+        returnsNormally,
+      );
+    });
+
+    test('rejects values exceeding the 64KB limit in debug mode', () {
+      final oversized = 'x' * (KeyValueStore.maxValueChars + 1);
+      expect(
+        () => KeyValueStore.assertValueSize(oversized, 'big_key'),
+        throwsA(
+          isA<StateError>().having(
+            (e) => e.message,
+            'message',
+            contains('Value too large for prefs tier'),
+          ),
+        ),
+      );
+    });
+
+    test('error message includes key name and actual size', () {
+      final oversized = 'x' * (KeyValueStore.maxValueChars + 100);
+      expect(
+        () => KeyValueStore.assertValueSize(oversized, 'my_key'),
+        throwsA(
+          isA<StateError>().having(
+            (e) => e.message,
+            'message',
+            allOf(
+              contains('my_key'),
+              contains('${oversized.length}'),
+            ),
+          ),
+        ),
+      );
+    });
+
+    test('maxValueChars is 65536', () {
+      expect(KeyValueStore.maxValueChars, 65536);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- **ADR-0008**: defines 4 storage tiers (prefs ≤64KB, structured→Drift/SQLite, secure→FlutterSecureStorage, file→path_provider). Hive retired.
- **Size guard**: `KeyValueStore.assertValueSize()` debug assertion rejects prefs values >64KB. Wired into `PreferencesStore.setString/setStringList`.
- **Hive audit**: usage isolated to `app_database_web.dart` (11 boxes for web IndexedDB). Marked DEPRECATED — full migration to Drift sql.js/WASM deferred to dedicated issue.
- 5 new tests for size guard

Closes #776

## Test plan
- [x] 37 storage tests pass (including 5 new size guard tests)
- [x] Debug assertion fires for values >64KB
- [x] Existing web database unaffected (deprecation notice only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)