### PR TITLE
perf(harness): benchmark suite + memory budgets per device class (#778, #779)

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -1,0 +1,39 @@
+name: Performance Benchmarks
+
+on:
+  schedule:
+    # Weekly: Sunday at 04:00 UTC
+    - cron: '0 4 * * 0'
+  workflow_dispatch:
+
+concurrency:
+  group: benchmarks-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  benchmarks:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    defaults:
+      run:
+        working-directory: packages/benchmarks
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: dart-lang/setup-dart@v1
+        with:
+          sdk: stable
+
+      - name: Install dependencies
+        run: dart pub get
+
+      - name: Run benchmarks
+        run: dart run bin/run_benchmarks.dart > benchmark_results.json
+
+      - name: Upload benchmark results
+        uses: actions/upload-artifact@v4
+        with:
+          name: benchmark-results
+          path: packages/benchmarks/benchmark_results.json
+          retention-days: 90

--- a/docs/adr/002-memory-budgets.md
+++ b/docs/adr/002-memory-budgets.md
@@ -1,0 +1,113 @@
+# ADR-002: Memory budgets per device class
+
+## Status
+
+Accepted
+
+## Date
+
+2026-07-15
+
+## Context
+
+Airo runs on a wide spectrum of hardware: Android TV boxes with as little as
+1 GB RAM, budget phones with 2 GB, mid-range phones with 4 GB, high-end
+phones with 8+ GB, and desktop machines with effectively unlimited memory.
+
+A single set of cache/list limits either wastes memory on high-end devices or
+causes OOM kills on low-end ones. The image cache, in-memory channel list,
+and overall RSS footprint are the three main memory consumers that need
+per-device tuning.
+
+Additionally, storage patterns vary in overhead. SharedPreferences serializes
+the entire file on every write and is unsuitable for anything larger than
+small config values. Hive has known corruption issues under concurrent access
+and is being phased out.
+
+## Decision
+
+### Device classes
+
+Introduce a `DeviceClass` enum with six tiers:
+
+| Class        | RAM heuristic   | Example hardware            |
+| ------------ | --------------- | --------------------------- |
+| `tvLow`      | TV, <= 1 GB     | Fire TV Stick Lite          |
+| `tvMid`      | TV, > 1 GB      | Chromecast w/ Google TV     |
+| `mobileLow`  | Mobile, <= 2 GB | Galaxy A03, Redmi A1        |
+| `mobileMid`  | Mobile, <= 4 GB | Pixel 6a, Galaxy A14        |
+| `mobileHigh` | Mobile, > 4 GB  | Pixel 8 Pro, iPhone 15      |
+| `desktop`    | Any desktop OS  | macOS, Linux, Windows       |
+
+### Memory budgets
+
+Each device class gets a `MemoryBudget` with five constraints:
+
+| Parameter          | tvLow  | tvMid  | mobLow | mobMid | mobHigh | desktop |
+| ------------------ | ------ | ------ | ------ | ------ | ------- | ------- |
+| imageCacheBytes    | 30 MB  | 50 MB  | 30 MB  | 80 MB  | 100 MB  | 200 MB  |
+| imageCacheCount    | 100    | 200    | 150    | 300    | 500     | 1000    |
+| maxChannelListSize | 5 000  | 20 000 | 5 000  | 20 000 | 50 000  | 100 000 |
+| rssTargetBytes     | 200 MB | 300 MB | 150 MB | 250 MB | 400 MB  | 800 MB  |
+| rssPeakBytes       | 300 MB | 450 MB | 250 MB | 400 MB | 600 MB  | 1200 MB |
+
+### Storage policy tiers
+
+| Data size / type    | Storage layer       | Rationale                                    |
+| ------------------- | ------------------- | -------------------------------------------- |
+| Prefs < 64 KB       | SharedPreferences   | Fast, atomic, platform-native                |
+| Structured records  | SQLite (sqflite)    | ACID, indexed queries, no corruption issues  |
+| Files / blobs       | path_provider dirs  | File-system backed, OS-managed lifecycle     |
+
+### Hive deprecation
+
+Hive is deprecated and must not be used in new code. Existing Hive usage
+should be migrated to SQLite or SharedPreferences as files are touched.
+
+## Consequences
+
+### Positive
+
+- Low-end devices stay within OS memory limits and avoid LMK (low memory
+  killer) termination.
+- High-end devices and desktop fully utilize available memory for smoother UX.
+- A single `MemoryBudget.forDevice()` call replaces scattered magic numbers.
+- Storage policy prevents SharedPreferences bloat (the root cause of several
+  past ANRs).
+
+### Negative
+
+- Device class detection requires a platform channel on Android to distinguish
+  TV from mobile; on other platforms the `dart:io` check is sufficient.
+- The RAM heuristic is approximate; borderline devices may land in a
+  sub-optimal tier.
+
+### Risks
+
+- If RAM reporting is unavailable at startup (e.g., permissions), the fallback
+  to `mobileMid` / `tvMid` may be too generous for the lowest-end hardware.
+
+## Alternatives Considered
+
+### Alternative 1: Single adaptive cache with dynamic resizing
+
+Dynamically resize caches based on runtime memory pressure signals.
+
+Rejected because Android's `onTrimMemory` callbacks are unreliable on TV
+devices, and reactive resizing causes visible jank when large caches are
+evicted mid-scroll.
+
+### Alternative 2: Two-tier (low / high) split
+
+Simpler but loses the TV-specific constraints which are the primary
+motivation. TV devices have unique display and input characteristics that
+warrant their own tier.
+
+## Related Decisions
+
+- [ADR-0001](0001-package-structure.md) - Package structure
+
+## References
+
+- Issue #778: Performance benchmark harness + CI budgets
+- Issue #779: Memory budgets per device class

--- a/packages/benchmarks/bin/run_benchmarks.dart
+++ b/packages/benchmarks/bin/run_benchmarks.dart
@@ -1,0 +1,36 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:benchmarks/benchmarks.dart';
+
+/// Entry point for the benchmark harness.
+///
+/// Runs all registered benchmarks, prints results to stdout as JSON, and
+/// writes them to `benchmark_results.json` in the current directory.
+Future<void> main() async {
+  final allResults = <BenchmarkResult>[];
+
+  // ---- M3U Parse benchmark ------------------------------------------------
+  stderr.writeln('Running M3U parse benchmark...');
+  final m3uBench = M3UParseBenchmark();
+  m3uBench.setup();
+  allResults.addAll(m3uBench.measureResults());
+
+  // ---- Channel dedup benchmark ---------------------------------------------
+  stderr.writeln('Running channel dedup benchmark...');
+  final dedupBench = DedupBenchmark();
+  dedupBench.setup();
+  allResults.addAll(dedupBench.measureResults());
+
+  // ---- Output --------------------------------------------------------------
+  final jsonOutput = const JsonEncoder.withIndent('  ')
+      .convert(allResults.map((r) => r.toJson()).toList());
+
+  // Structured JSON to stdout for CI consumption.
+  stdout.writeln(jsonOutput);
+
+  // Also persist to a file for artifact upload.
+  const outputPath = 'benchmark_results.json';
+  await File(outputPath).writeAsString(jsonOutput);
+  stderr.writeln('Results written to $outputPath');
+}

--- a/packages/benchmarks/lib/benchmarks.dart
+++ b/packages/benchmarks/lib/benchmarks.dart
@@ -1,0 +1,9 @@
+/// Performance benchmark harness for Airo.
+///
+/// Provides benchmarks for M3U parsing, channel deduplication, and a
+/// structured [BenchmarkResult] model for CI consumption.
+library benchmarks;
+
+export 'src/m3u_parse_bench.dart';
+export 'src/dedup_bench.dart';
+export 'src/results.dart';

--- a/packages/benchmarks/lib/src/dedup_bench.dart
+++ b/packages/benchmarks/lib/src/dedup_bench.dart
@@ -1,0 +1,94 @@
+import 'package:benchmark_harness/benchmark_harness.dart';
+
+import 'results.dart';
+
+/// Benchmark that measures channel deduplication / normalization throughput.
+///
+/// Mirrors the dedup logic in the production `M3UParserService.parseM3U` which
+/// normalizes channel names and keeps the first occurrence (preferring entries
+/// with a logo).
+class DedupBenchmark extends BenchmarkBase {
+  static const int _channelCount = 200;
+  late final List<_RawEntry> _entries;
+
+  DedupBenchmark() : super('ChannelDedup');
+
+  @override
+  void setup() {
+    _entries = _buildFixture(_channelCount);
+  }
+
+  @override
+  void run() {
+    final deduped = _dedup(_entries);
+    // Prevent dead-code elimination.
+    if (deduped.isEmpty) {
+      throw StateError('Dedup returned empty');
+    }
+  }
+
+  /// Run the benchmark and return structured results.
+  List<BenchmarkResult> measureResults() {
+    final usPerIteration = BenchmarkBase.measureFor(run, 2000);
+
+    final opsPerSec =
+        _channelCount / (usPerIteration / Duration.microsecondsPerSecond);
+
+    final now = DateTime.now().toUtc();
+    return [
+      BenchmarkResult(
+        name: 'channel_dedup_${_channelCount}',
+        metric: 'channels_per_sec',
+        value: opsPerSec,
+        unit: 'channels/s',
+        deviceClass: 'desktop',
+        timestamp: now,
+      ),
+    ];
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers mirroring the production dedup algorithm.
+// ---------------------------------------------------------------------------
+
+class _RawEntry {
+  final String name;
+  final String url;
+  final String? logo;
+  const _RawEntry({required this.name, required this.url, this.logo});
+}
+
+/// Generate a fixture with ~30 % duplicate names.
+List<_RawEntry> _buildFixture(int count) {
+  final entries = <_RawEntry>[];
+  for (var i = 0; i < count; i++) {
+    // Every third entry is a duplicate of an earlier channel (with variation).
+    final isDup = i >= 3 && i % 3 == 0;
+    final baseName = isDup ? 'Channel ${i - 3}' : 'Channel $i';
+    entries.add(_RawEntry(
+      name: baseName,
+      url: 'https://stream.example.com/live/$i.m3u8',
+      logo: isDup ? 'https://example.com/logo_$i.png' : null,
+    ));
+  }
+  return entries;
+}
+
+/// Normalize + dedup, keeping the entry with the best logo.
+List<_RawEntry> _dedup(List<_RawEntry> entries) {
+  final seen = <String, _RawEntry>{};
+  for (final e in entries) {
+    final key = _normalize(e.name);
+    if (!seen.containsKey(key)) {
+      seen[key] = e;
+    } else if (seen[key]!.logo == null && e.logo != null) {
+      seen[key] = e;
+    }
+  }
+  return seen.values.toList();
+}
+
+String _normalize(String name) {
+  return name.toLowerCase().replaceAll(RegExp(r'[^a-z0-9]'), '');
+}

--- a/packages/benchmarks/lib/src/m3u_parse_bench.dart
+++ b/packages/benchmarks/lib/src/m3u_parse_bench.dart
@@ -1,0 +1,151 @@
+import 'package:benchmark_harness/benchmark_harness.dart';
+
+import 'results.dart';
+
+/// Generates a synthetic M3U playlist with [channelCount] entries.
+String generateM3UFixture(int channelCount) {
+  final buf = StringBuffer('#EXTM3U\n');
+  for (var i = 0; i < channelCount; i++) {
+    buf.writeln(
+      '#EXTINF:-1 tvg-id="ch$i" tvg-name="Channel $i" '
+      'tvg-logo="https://example.com/logo$i.png" '
+      'group-title="Group ${i % 5}",Channel $i',
+    );
+    buf.writeln('https://stream.example.com/live/channel$i.m3u8');
+  }
+  return buf.toString();
+}
+
+/// Minimal parsed channel representation used by the benchmark.
+///
+/// Mirrors the fields extracted by the production [M3UParserService] in
+/// `platform_playlist_import` without pulling in the Flutter SDK.
+class _ParsedChannel {
+  final String name;
+  final String url;
+  final String? logo;
+  final String? group;
+  final String? tvgId;
+  final String? tvgName;
+
+  const _ParsedChannel({
+    required this.name,
+    required this.url,
+    this.logo,
+    this.group,
+    this.tvgId,
+    this.tvgName,
+  });
+}
+
+/// Parse an M3U string into a list of channels.
+///
+/// This mirrors the production parser in
+/// `packages/platform_playlist_import/lib/src/m3u_parser_service.dart`.
+List<_ParsedChannel> parseM3U(String content) {
+  final lines = content.split('\n');
+  final channels = <_ParsedChannel>[];
+
+  String? currentName;
+  String? currentLogo;
+  String? currentGroup;
+  String? currentTvgId;
+  String? currentTvgName;
+
+  final attrPattern = RegExp(r'(\w+[-\w]*)="([^"]*)"');
+
+  for (var i = 0; i < lines.length; i++) {
+    final line = lines[i].trim();
+
+    if (line.startsWith('#EXTINF:')) {
+      final commaIndex = line.lastIndexOf(',');
+      if (commaIndex != -1) {
+        currentName = line.substring(commaIndex + 1).trim();
+      }
+      for (final match in attrPattern.allMatches(line)) {
+        final key = match.group(1)!;
+        final value = match.group(2)!;
+        switch (key) {
+          case 'tvg-logo':
+            currentLogo = value;
+          case 'group-title':
+            currentGroup = value;
+          case 'tvg-id':
+            currentTvgId = value;
+          case 'tvg-name':
+            currentTvgName = value;
+        }
+      }
+    } else if (line.isNotEmpty && !line.startsWith('#') && currentName != null) {
+      channels.add(_ParsedChannel(
+        name: currentName,
+        url: line,
+        logo: currentLogo,
+        group: currentGroup,
+        tvgId: currentTvgId,
+        tvgName: currentTvgName,
+      ));
+      currentName = null;
+      currentLogo = null;
+      currentGroup = null;
+      currentTvgId = null;
+      currentTvgName = null;
+    }
+  }
+  return channels;
+}
+
+/// Benchmark that measures M3U parsing throughput.
+class M3UParseBenchmark extends BenchmarkBase {
+  static const int _channelCount = 50;
+  late final String _fixture;
+
+  M3UParseBenchmark() : super('M3UParse');
+
+  @override
+  void setup() {
+    _fixture = generateM3UFixture(_channelCount);
+  }
+
+  @override
+  void run() {
+    final channels = parseM3U(_fixture);
+    // Prevent the compiler from optimizing the call away.
+    if (channels.length != _channelCount) {
+      throw StateError('Expected $_channelCount channels');
+    }
+  }
+
+  /// Run the benchmark and return structured results.
+  List<BenchmarkResult> measureResults() {
+    // Warm up + measure via the harness (reports us/iteration).
+    final usPerIteration = BenchmarkBase.measureFor(run, 2000);
+
+    // Each iteration parses _channelCount channels.
+    final channelsPerSec =
+        _channelCount / (usPerIteration / Duration.microsecondsPerSecond);
+
+    final bytesPerSec =
+        _fixture.length / (usPerIteration / Duration.microsecondsPerSecond);
+
+    final now = DateTime.now().toUtc();
+    return [
+      BenchmarkResult(
+        name: 'm3u_parse_${_channelCount}ch',
+        metric: 'channels_per_sec',
+        value: channelsPerSec,
+        unit: 'channels/s',
+        deviceClass: 'desktop',
+        timestamp: now,
+      ),
+      BenchmarkResult(
+        name: 'm3u_parse_${_channelCount}ch',
+        metric: 'bytes_per_sec',
+        value: bytesPerSec,
+        unit: 'bytes/s',
+        deviceClass: 'desktop',
+        timestamp: now,
+      ),
+    ];
+  }
+}

--- a/packages/benchmarks/lib/src/results.dart
+++ b/packages/benchmarks/lib/src/results.dart
@@ -1,0 +1,66 @@
+import 'dart:convert';
+import 'dart:io';
+
+/// A single benchmark measurement.
+class BenchmarkResult {
+  /// Human-readable name of the benchmark (e.g. "m3u_parse_50ch").
+  final String name;
+
+  /// What is being measured (e.g. "channels_per_sec", "ops_per_sec").
+  final String metric;
+
+  /// The numeric measurement value.
+  final double value;
+
+  /// Unit label (e.g. "channels/s", "bytes/s", "us").
+  final String unit;
+
+  /// Device class that produced this result (e.g. "desktop", "tvLow").
+  final String deviceClass;
+
+  /// When the benchmark was run (UTC).
+  final DateTime timestamp;
+
+  const BenchmarkResult({
+    required this.name,
+    required this.metric,
+    required this.value,
+    required this.unit,
+    required this.deviceClass,
+    required this.timestamp,
+  });
+
+  /// Serialize to a JSON-compatible map.
+  Map<String, dynamic> toJson() => {
+    'name': name,
+    'metric': metric,
+    'value': value,
+    'unit': unit,
+    'device_class': deviceClass,
+    'timestamp': timestamp.toUtc().toIso8601String(),
+  };
+
+  /// Deserialize from a JSON map.
+  factory BenchmarkResult.fromJson(Map<String, dynamic> json) {
+    return BenchmarkResult(
+      name: json['name'] as String,
+      metric: json['metric'] as String,
+      value: (json['value'] as num).toDouble(),
+      unit: json['unit'] as String,
+      deviceClass: json['device_class'] as String,
+      timestamp: DateTime.parse(json['timestamp'] as String),
+    );
+  }
+
+  @override
+  String toString() => '$name: $value $unit ($metric)';
+}
+
+/// Write a list of [BenchmarkResult]s to [path] as a JSON array.
+Future<void> writeBenchmarkResults(
+  List<BenchmarkResult> results,
+  String path,
+) async {
+  final json = jsonEncode(results.map((r) => r.toJson()).toList());
+  await File(path).writeAsString(json);
+}

--- a/packages/benchmarks/pubspec.yaml
+++ b/packages/benchmarks/pubspec.yaml
@@ -1,0 +1,13 @@
+name: benchmarks
+description: "Performance benchmark harness for Airo"
+version: 0.0.1
+publish_to: 'none'
+
+environment:
+  sdk: ">=3.12.2 <4.0.0"
+
+dependencies:
+  benchmark_harness: ^2.3.0
+
+dev_dependencies:
+  test: ^1.25.0

--- a/packages/benchmarks/test/results_test.dart
+++ b/packages/benchmarks/test/results_test.dart
@@ -1,0 +1,72 @@
+import 'dart:convert';
+
+import 'package:benchmarks/benchmarks.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('BenchmarkResult', () {
+    final sampleTimestamp = DateTime.utc(2026, 7, 15, 12, 0, 0);
+
+    final sample = BenchmarkResult(
+      name: 'm3u_parse_50ch',
+      metric: 'channels_per_sec',
+      value: 125000.5,
+      unit: 'channels/s',
+      deviceClass: 'desktop',
+      timestamp: sampleTimestamp,
+    );
+
+    test('toJson produces expected keys and values', () {
+      final json = sample.toJson();
+
+      expect(json['name'], 'm3u_parse_50ch');
+      expect(json['metric'], 'channels_per_sec');
+      expect(json['value'], 125000.5);
+      expect(json['unit'], 'channels/s');
+      expect(json['device_class'], 'desktop');
+      expect(json['timestamp'], '2026-07-15T12:00:00.000Z');
+    });
+
+    test('fromJson round-trips correctly', () {
+      final json = sample.toJson();
+      final restored = BenchmarkResult.fromJson(json);
+
+      expect(restored.name, sample.name);
+      expect(restored.metric, sample.metric);
+      expect(restored.value, sample.value);
+      expect(restored.unit, sample.unit);
+      expect(restored.deviceClass, sample.deviceClass);
+      expect(restored.timestamp, sample.timestamp);
+    });
+
+    test('JSON encode/decode round-trip for a list of results', () {
+      final results = [
+        sample,
+        BenchmarkResult(
+          name: 'channel_dedup_200',
+          metric: 'channels_per_sec',
+          value: 500000.0,
+          unit: 'channels/s',
+          deviceClass: 'tvMid',
+          timestamp: sampleTimestamp,
+        ),
+      ];
+
+      final encoded = jsonEncode(results.map((r) => r.toJson()).toList());
+      final decoded = (jsonDecode(encoded) as List<dynamic>)
+          .map((e) => BenchmarkResult.fromJson(e as Map<String, dynamic>))
+          .toList();
+
+      expect(decoded.length, 2);
+      expect(decoded[0].name, 'm3u_parse_50ch');
+      expect(decoded[1].name, 'channel_dedup_200');
+      expect(decoded[1].deviceClass, 'tvMid');
+    });
+
+    test('toString contains name and value', () {
+      expect(sample.toString(), contains('m3u_parse_50ch'));
+      expect(sample.toString(), contains('125000.5'));
+      expect(sample.toString(), contains('channels/s'));
+    });
+  });
+}

--- a/packages/core_data/lib/core_data.dart
+++ b/packages/core_data/lib/core_data.dart
@@ -38,3 +38,7 @@ export 'src/plugins/plugin_kill_switch_service.dart';
 // Bug Reporting
 export 'src/bug_report/bug_report_model.dart';
 export 'src/bug_report/github_issue_service.dart';
+
+// Memory Budgets
+export 'src/memory/device_class.dart';
+export 'src/memory/memory_budget.dart';

--- a/packages/core_data/lib/src/memory/device_class.dart
+++ b/packages/core_data/lib/src/memory/device_class.dart
@@ -1,0 +1,62 @@
+import 'dart:io';
+
+/// Device class categories used to select appropriate memory budgets.
+///
+/// Each class represents a hardware tier with different memory constraints.
+/// Use [DeviceClass.detect] to determine the class at runtime.
+enum DeviceClass {
+  /// Android TV with <= 1 GB RAM.
+  tvLow,
+
+  /// Android TV with > 1 GB RAM.
+  tvMid,
+
+  /// Mobile device with <= 2 GB RAM.
+  mobileLow,
+
+  /// Mobile device with <= 4 GB RAM.
+  mobileMid,
+
+  /// Mobile device with > 4 GB RAM.
+  mobileHigh,
+
+  /// Desktop (macOS, Linux, Windows).
+  desktop;
+
+  /// Detect the device class using platform checks and a RAM heuristic.
+  ///
+  /// [totalRamBytes] can be injected for testing; when `null` the method
+  /// falls back to a conservative mid-tier default for each platform.
+  factory DeviceClass.detect({int? totalRamBytes}) {
+    if (Platform.isLinux || Platform.isMacOS || Platform.isWindows) {
+      // Android TV runs on Linux but is identified via the Android embedding.
+      // Pure desktop platforms always get the desktop tier.
+      return DeviceClass.desktop;
+    }
+
+    // Android or iOS (Flutter mobile).
+    //
+    // When RAM information is unavailable we default to mobileMid which gives
+    // a safe middle-ground budget.
+    if (totalRamBytes == null) {
+      return DeviceClass.mobileMid;
+    }
+
+    final totalRamMB = totalRamBytes ~/ (1024 * 1024);
+
+    if (totalRamMB <= 2048) return DeviceClass.mobileLow;
+    if (totalRamMB <= 4096) return DeviceClass.mobileMid;
+    return DeviceClass.mobileHigh;
+  }
+
+  /// Detect the device class for an Android TV device.
+  ///
+  /// Separated from [detect] because the TV/mobile distinction cannot be
+  /// determined from `dart:io` alone and must come from the platform channel.
+  factory DeviceClass.detectTV({int? totalRamBytes}) {
+    if (totalRamBytes == null) return DeviceClass.tvMid;
+
+    final totalRamMB = totalRamBytes ~/ (1024 * 1024);
+    return totalRamMB <= 1024 ? DeviceClass.tvLow : DeviceClass.tvMid;
+  }
+}

--- a/packages/core_data/lib/src/memory/memory_budget.dart
+++ b/packages/core_data/lib/src/memory/memory_budget.dart
@@ -1,0 +1,88 @@
+import 'device_class.dart';
+
+/// Byte-size constants used in budget definitions.
+const int _MB = 1024 * 1024;
+
+/// Per-device-class memory budget that constrains image caching, channel list
+/// sizes, and overall RSS targets.
+///
+/// Obtain a budget via [MemoryBudget.forDevice]. The values are deliberately
+/// conservative for low-end tiers and generous for desktop to maximize UX
+/// without OOM-killing the process on constrained hardware.
+class MemoryBudget {
+  /// Maximum bytes the image cache may occupy.
+  final int imageCacheBytes;
+
+  /// Maximum number of images held in the cache.
+  final int imageCacheCount;
+
+  /// Upper bound on the number of channels kept in memory at once.
+  final int maxChannelListSize;
+
+  /// Target RSS (resident set size) the app should stay below during normal
+  /// operation.
+  final int rssTargetBytes;
+
+  /// Absolute peak RSS the app must never exceed.
+  final int rssPeakBytes;
+
+  const MemoryBudget({
+    required this.imageCacheBytes,
+    required this.imageCacheCount,
+    required this.maxChannelListSize,
+    required this.rssTargetBytes,
+    required this.rssPeakBytes,
+  });
+
+  /// Return the memory budget for the given [DeviceClass].
+  static MemoryBudget forDevice(DeviceClass dc) => switch (dc) {
+    DeviceClass.tvLow => const MemoryBudget(
+      imageCacheBytes: 30 * _MB,
+      imageCacheCount: 100,
+      maxChannelListSize: 5000,
+      rssTargetBytes: 200 * _MB,
+      rssPeakBytes: 300 * _MB,
+    ),
+    DeviceClass.tvMid => const MemoryBudget(
+      imageCacheBytes: 50 * _MB,
+      imageCacheCount: 200,
+      maxChannelListSize: 20000,
+      rssTargetBytes: 300 * _MB,
+      rssPeakBytes: 450 * _MB,
+    ),
+    DeviceClass.mobileLow => const MemoryBudget(
+      imageCacheBytes: 30 * _MB,
+      imageCacheCount: 150,
+      maxChannelListSize: 5000,
+      rssTargetBytes: 150 * _MB,
+      rssPeakBytes: 250 * _MB,
+    ),
+    DeviceClass.mobileMid => const MemoryBudget(
+      imageCacheBytes: 80 * _MB,
+      imageCacheCount: 300,
+      maxChannelListSize: 20000,
+      rssTargetBytes: 250 * _MB,
+      rssPeakBytes: 400 * _MB,
+    ),
+    DeviceClass.mobileHigh => const MemoryBudget(
+      imageCacheBytes: 100 * _MB,
+      imageCacheCount: 500,
+      maxChannelListSize: 50000,
+      rssTargetBytes: 400 * _MB,
+      rssPeakBytes: 600 * _MB,
+    ),
+    DeviceClass.desktop => const MemoryBudget(
+      imageCacheBytes: 200 * _MB,
+      imageCacheCount: 1000,
+      maxChannelListSize: 100000,
+      rssTargetBytes: 800 * _MB,
+      rssPeakBytes: 1200 * _MB,
+    ),
+  };
+
+  @override
+  String toString() =>
+      'MemoryBudget(imageCache: ${imageCacheBytes ~/ _MB} MB / $imageCacheCount items, '
+      'channels: $maxChannelListSize, '
+      'rss: ${rssTargetBytes ~/ _MB}/${rssPeakBytes ~/ _MB} MB)';
+}

--- a/packages/core_data/test/memory_budget_test.dart
+++ b/packages/core_data/test/memory_budget_test.dart
@@ -1,0 +1,78 @@
+import 'package:core_data/core_data.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('DeviceClass', () {
+    test('detectTV returns tvLow for <= 1 GB', () {
+      final dc = DeviceClass.detectTV(totalRamBytes: 1024 * 1024 * 1024);
+      expect(dc, DeviceClass.tvLow);
+    });
+
+    test('detectTV returns tvMid for > 1 GB', () {
+      final dc = DeviceClass.detectTV(totalRamBytes: 2 * 1024 * 1024 * 1024);
+      expect(dc, DeviceClass.tvMid);
+    });
+
+    test('detectTV defaults to tvMid when RAM is null', () {
+      final dc = DeviceClass.detectTV();
+      expect(dc, DeviceClass.tvMid);
+    });
+  });
+
+  group('MemoryBudget', () {
+    test('forDevice returns a budget for every DeviceClass value', () {
+      for (final dc in DeviceClass.values) {
+        final budget = MemoryBudget.forDevice(dc);
+        expect(budget.imageCacheBytes, greaterThan(0));
+        expect(budget.imageCacheCount, greaterThan(0));
+        expect(budget.maxChannelListSize, greaterThan(0));
+        expect(budget.rssTargetBytes, greaterThan(0));
+        expect(budget.rssPeakBytes, greaterThan(budget.rssTargetBytes));
+      }
+    });
+
+    test('tvLow has the smallest image cache', () {
+      final tvLow = MemoryBudget.forDevice(DeviceClass.tvLow);
+      final desktop = MemoryBudget.forDevice(DeviceClass.desktop);
+      expect(tvLow.imageCacheBytes, lessThan(desktop.imageCacheBytes));
+    });
+
+    test('desktop has the largest channel list limit', () {
+      final desktop = MemoryBudget.forDevice(DeviceClass.desktop);
+      for (final dc in DeviceClass.values) {
+        if (dc == DeviceClass.desktop) continue;
+        final other = MemoryBudget.forDevice(dc);
+        expect(desktop.maxChannelListSize,
+            greaterThanOrEqualTo(other.maxChannelListSize));
+      }
+    });
+
+    test('tvLow budget values match specification', () {
+      const mb = 1024 * 1024;
+      final budget = MemoryBudget.forDevice(DeviceClass.tvLow);
+      expect(budget.imageCacheBytes, 30 * mb);
+      expect(budget.imageCacheCount, 100);
+      expect(budget.maxChannelListSize, 5000);
+      expect(budget.rssTargetBytes, 200 * mb);
+      expect(budget.rssPeakBytes, 300 * mb);
+    });
+
+    test('mobileHigh budget values match specification', () {
+      const mb = 1024 * 1024;
+      final budget = MemoryBudget.forDevice(DeviceClass.mobileHigh);
+      expect(budget.imageCacheBytes, 100 * mb);
+      expect(budget.imageCacheCount, 500);
+      expect(budget.maxChannelListSize, 50000);
+      expect(budget.rssTargetBytes, 400 * mb);
+      expect(budget.rssPeakBytes, 600 * mb);
+    });
+
+    test('toString includes readable size info', () {
+      final budget = MemoryBudget.forDevice(DeviceClass.desktop);
+      final str = budget.toString();
+      expect(str, contains('200 MB'));
+      expect(str, contains('1000'));
+      expect(str, contains('100000'));
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- **Benchmark package** (`packages/benchmarks/`): M3U parse bench (channels/sec), dedup bench (normalize/sec), JSON results output
- **Memory budgets** (`core_data/lib/src/memory/`): 6 device classes (tvLow→desktop), per-tier limits for ImageCache, channel list, RSS target/peak
- **ADR-002**: documents memory budget tiers + storage policy
- **CI workflow**: weekly benchmark run with artifact upload
- Entry point: `dart run bin/run_benchmarks.dart`

Closes #778, #779

## Test plan
- [x] 4 benchmark result serialization tests pass
- [x] 9 memory budget tests pass (all tiers + detection)
- [x] Entry point produces valid JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)