### PR TITLE
feat(rust): M3U playlist parser in Rust core + Dart FFI wrapper (#764)

### DIFF
--- a/packages/core_native/lib/core_native.dart
+++ b/packages/core_native/lib/core_native.dart
@@ -1,3 +1,4 @@
 // core_native — Flutter FFI bindings for airo_core Rust crate.
 // Feature packages use this package's public API; never import frb types directly.
+export 'src/m3u.dart';
 export 'src/text.dart';

--- a/packages/core_native/lib/src/m3u.dart
+++ b/packages/core_native/lib/src/m3u.dart
@@ -1,0 +1,119 @@
+import 'package:flutter/foundation.dart' show kIsWeb;
+
+// ignore: implementation_imports
+import 'frb_generated.dart' as frb;
+
+/// Parsed M3U channel entry returned by the native parser.
+///
+/// Mirrors the Rust `M3UEntry` struct.  The Dart consumer maps these into
+/// `IPTVChannel` objects.
+class NativeM3UEntry {
+  final String name;
+  final String url;
+  final String groupTitle;
+  final String tvgLogo;
+  final String tvgId;
+  final String tvgName;
+  final String tvgLanguage;
+  final String tvgCountry;
+
+  const NativeM3UEntry({
+    required this.name,
+    required this.url,
+    this.groupTitle = '',
+    this.tvgLogo = '',
+    this.tvgId = '',
+    this.tvgName = '',
+    this.tvgLanguage = '',
+    this.tvgCountry = '',
+  });
+}
+
+/// Parse M3U playlist content into a list of channel entries.
+///
+/// Delegates to the Rust implementation when the native library is loaded.
+/// Falls back to a minimal pure-Dart parser on web, in tests, or before
+/// `RustLib.init()` runs.
+List<NativeM3UEntry> parseM3UNative(String content) {
+  if (kIsWeb) return _dartParseM3U(content);
+  try {
+    final rustEntries = frb.parseM3U(content: content);
+    return rustEntries
+        .map((e) => NativeM3UEntry(
+              name: e.name,
+              url: e.url,
+              groupTitle: e.groupTitle,
+              tvgLogo: e.tvgLogo,
+              tvgId: e.tvgId,
+              tvgName: e.tvgName,
+              tvgLanguage: e.tvgLanguage,
+              tvgCountry: e.tvgCountry,
+            ))
+        .toList();
+  } on UnsupportedError {
+    return _dartParseM3U(content);
+  }
+}
+
+// ── Pure-Dart fallback ────────────────────────────────────────────────
+
+/// Minimal M3U parser — semantically identical to the Rust implementation.
+List<NativeM3UEntry> _dartParseM3U(String content) {
+  final entries = <NativeM3UEntry>[];
+  final lines = content.split('\n');
+
+  Map<String, String?>? pending;
+
+  for (final rawLine in lines) {
+    final line = rawLine.trim();
+
+    if (line.startsWith('#EXTINF:')) {
+      pending = _parseExtInf(line);
+    } else if (line.isNotEmpty && !line.startsWith('#') && pending != null) {
+      if (line.startsWith('http://') || line.startsWith('https://')) {
+        entries.add(NativeM3UEntry(
+          name: pending['name'] ?? '',
+          url: line,
+          groupTitle: pending['group-title'] ?? '',
+          tvgLogo: pending['tvg-logo'] ?? '',
+          tvgId: pending['tvg-id'] ?? '',
+          tvgName: pending['tvg-name'] ?? '',
+          tvgLanguage: pending['tvg-language'] ?? '',
+          tvgCountry: pending['tvg-country'] ?? '',
+        ));
+      }
+      pending = null;
+    }
+  }
+
+  return entries;
+}
+
+/// Parse `#EXTINF:` line attributes.  Channel name is after the last
+/// unquoted comma.
+Map<String, String?> _parseExtInf(String line) {
+  final result = <String, String?>{};
+
+  // Find the last comma outside quotes for the channel name.
+  var inQuotes = false;
+  var lastComma = -1;
+  for (var i = 0; i < line.length; i++) {
+    if (line[i] == '"') {
+      inQuotes = !inQuotes;
+    } else if (line[i] == ',' && !inQuotes) {
+      lastComma = i;
+    }
+  }
+
+  if (lastComma != -1) {
+    result['name'] = line.substring(lastComma + 1).trim();
+  }
+
+  // Extract key="value" pairs.
+  final attrPattern = RegExp(r'([\w-]+)="([^"]*)"');
+  for (final match in attrPattern.allMatches(line)) {
+    result[match.group(1)!.toLowerCase()] = match.group(2);
+  }
+
+  return result;
+}

--- a/rust/airo_core/src/api/m3u.rs
+++ b/rust/airo_core/src/api/m3u.rs
@@ -1,0 +1,343 @@
+/// M3U playlist parser — extracts channel entries from M3U/M3U8 content.
+///
+/// Parses `#EXTINF` attribute lines and the URL line that follows each one.
+/// Returns a flat Vec of [`M3UEntry`] structs ready for the Dart side to map
+/// into `IPTVChannel` objects.
+///
+/// Design constraints (see `mod.rs` header):
+///   - No panics.  Malformed lines are silently skipped.
+///   - Payload kept small: only the fields the Dart model needs.
+///   - Pure-Dart fallback exists in `m3u_parser_service.dart`.
+
+/// A single parsed M3U channel entry.
+#[derive(Debug, Clone, PartialEq)]
+pub struct M3UEntry {
+    pub name: String,
+    pub url: String,
+    pub group_title: String,
+    pub tvg_logo: String,
+    pub tvg_id: String,
+    pub tvg_name: String,
+    pub tvg_language: String,
+    pub tvg_country: String,
+}
+
+/// Parse M3U content into a list of channel entries.
+///
+/// Handles the standard `#EXTINF:-1 key="value",...,Channel Name` format
+/// followed by a URL line. Lines that don't match are skipped.
+///
+/// # Examples
+/// ```
+/// use airo_core::api::m3u::parse_m3u;
+///
+/// let content = concat!(
+///     "#EXTM3U\n",
+///     "#EXTINF:-1 tvg-id=\"bbc1\" tvg-name=\"BBC One\" ",
+///     "tvg-logo=\"http://logo.png\" group-title=\"News\",BBC News\n",
+///     "http://stream.example.com/bbc1\n",
+/// );
+/// let entries = parse_m3u(content.to_string());
+/// assert_eq!(entries.len(), 1);
+/// assert_eq!(entries[0].name, "BBC News");
+/// ```
+pub fn parse_m3u(content: String) -> Vec<M3UEntry> {
+    let mut entries = Vec::new();
+    let mut pending: Option<PendingEntry> = None;
+
+    for raw_line in content.lines() {
+        let line = raw_line.trim();
+
+        if line.starts_with("#EXTINF:") {
+            pending = Some(parse_extinf(line));
+        } else if !line.is_empty() && !line.starts_with('#') {
+            // URL line — only accept http(s) URLs.
+            if let Some(entry) = pending.take() {
+                if line.starts_with("http://") || line.starts_with("https://") {
+                    entries.push(M3UEntry {
+                        name: entry.name,
+                        url: line.to_string(),
+                        group_title: entry.group_title,
+                        tvg_logo: entry.tvg_logo,
+                        tvg_id: entry.tvg_id,
+                        tvg_name: entry.tvg_name,
+                        tvg_language: entry.tvg_language,
+                        tvg_country: entry.tvg_country,
+                    });
+                }
+            }
+            // If no pending EXTINF, skip the line (bare URL without metadata).
+        }
+    }
+
+    entries
+}
+
+// ── Internal helpers ──────────────────────────────────────────────────
+
+/// Intermediate struct holding parsed EXTINF attributes before the URL arrives.
+struct PendingEntry {
+    name: String,
+    group_title: String,
+    tvg_logo: String,
+    tvg_id: String,
+    tvg_name: String,
+    tvg_language: String,
+    tvg_country: String,
+}
+
+/// Parse a single `#EXTINF:` line into a `PendingEntry`.
+///
+/// Format: `#EXTINF:-1 key="value" key="value"...,Channel Name`
+///
+/// The channel name is everything after the last comma that is *outside*
+/// any quoted attribute value.  Attribute values are extracted with a simple
+/// state machine that handles quoted strings.
+fn parse_extinf(line: &str) -> PendingEntry {
+    // Find the last comma that is outside quotes to split name from attrs.
+    let split_idx = find_last_unquoted_comma(line);
+    let (attr_part, name) = match split_idx {
+        Some(idx) => (&line[..idx], line[idx + 1..].trim().to_string()),
+        None => (line, String::new()),
+    };
+
+    let attrs = extract_attributes(attr_part);
+
+    PendingEntry {
+        name,
+        group_title: find_attr(&attrs, "group-title"),
+        tvg_logo: find_attr(&attrs, "tvg-logo"),
+        tvg_id: find_attr(&attrs, "tvg-id"),
+        tvg_name: find_attr(&attrs, "tvg-name"),
+        tvg_language: find_attr(&attrs, "tvg-language"),
+        tvg_country: find_attr(&attrs, "tvg-country"),
+    }
+}
+
+/// Find an attribute value by key, returning empty string if not found.
+fn find_attr(attrs: &[(String, String)], key: &str) -> String {
+    attrs
+        .iter()
+        .find(|(k, _)| k == key)
+        .map(|(_, v)| v.clone())
+        .unwrap_or_default()
+}
+
+/// Find the last comma in `s` that is not inside a quoted attribute value.
+fn find_last_unquoted_comma(s: &str) -> Option<usize> {
+    let mut in_quotes = false;
+    let mut last_comma = None;
+
+    for (i, c) in s.char_indices() {
+        match c {
+            '"' => in_quotes = !in_quotes,
+            ',' if !in_quotes => last_comma = Some(i),
+            _ => {}
+        }
+    }
+
+    last_comma
+}
+
+/// Extract `key="value"` pairs from the attribute portion of an EXTINF line.
+///
+/// Returns a Vec of (key, value) tuples.  Keys are lowercased for
+/// case-insensitive matching; values are returned as-is.
+fn extract_attributes(s: &str) -> Vec<(String, String)> {
+    let mut attrs = Vec::new();
+    let bytes = s.as_bytes();
+    let len = bytes.len();
+    let mut i = 0;
+
+    while i < len {
+        // Skip to the start of a potential key (letter or hyphen).
+        if !bytes[i].is_ascii_alphanumeric() && bytes[i] != b'-' {
+            i += 1;
+            continue;
+        }
+
+        // Read the key.
+        let key_start = i;
+        while i < len && (bytes[i].is_ascii_alphanumeric() || bytes[i] == b'-') {
+            i += 1;
+        }
+        let key = &s[key_start..i];
+
+        // Expect '=' followed by '"'.
+        if i >= len || bytes[i] != b'=' {
+            continue;
+        }
+        i += 1; // skip '='
+        if i >= len || bytes[i] != b'"' {
+            continue;
+        }
+        i += 1; // skip opening '"'
+
+        // Read the value until the closing '"'.
+        let val_start = i;
+        while i < len && bytes[i] != b'"' {
+            i += 1;
+        }
+        let val = &s[val_start..i];
+
+        if i < len {
+            i += 1; // skip closing '"'
+        }
+
+        attrs.push((key.to_ascii_lowercase(), val.to_string()));
+    }
+
+    attrs
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_basic_m3u() {
+        let content = concat!(
+            "#EXTM3U\n",
+            "#EXTINF:-1 tvg-id=\"bbc1\" tvg-name=\"BBC One\" ",
+            "tvg-logo=\"http://logo.png\" group-title=\"News\" ",
+            "tvg-language=\"English\" tvg-country=\"UK\",BBC News\n",
+            "http://stream.example.com/bbc1\n",
+        );
+        let entries = parse_m3u(content.to_string());
+        assert_eq!(entries.len(), 1);
+
+        let e = &entries[0];
+        assert_eq!(e.name, "BBC News");
+        assert_eq!(e.url, "http://stream.example.com/bbc1");
+        assert_eq!(e.group_title, "News");
+        assert_eq!(e.tvg_logo, "http://logo.png");
+        assert_eq!(e.tvg_id, "bbc1");
+        assert_eq!(e.tvg_name, "BBC One");
+        assert_eq!(e.tvg_language, "English");
+        assert_eq!(e.tvg_country, "UK");
+    }
+
+    #[test]
+    fn parse_multiple_entries() {
+        let content = concat!(
+            "#EXTM3U\n",
+            "#EXTINF:-1 group-title=\"News\",Channel A\n",
+            "http://example.com/a\n",
+            "#EXTINF:-1 group-title=\"Sports\",Channel B\n",
+            "https://example.com/b\n",
+        );
+        let entries = parse_m3u(content.to_string());
+        assert_eq!(entries.len(), 2);
+        assert_eq!(entries[0].name, "Channel A");
+        assert_eq!(entries[0].group_title, "News");
+        assert_eq!(entries[1].name, "Channel B");
+        assert_eq!(entries[1].group_title, "Sports");
+    }
+
+    #[test]
+    fn missing_attributes_default_to_empty() {
+        let content = concat!("#EXTINF:-1,Bare Channel\n", "http://example.com/bare\n",);
+        let entries = parse_m3u(content.to_string());
+        assert_eq!(entries.len(), 1);
+
+        let e = &entries[0];
+        assert_eq!(e.name, "Bare Channel");
+        assert_eq!(e.group_title, "");
+        assert_eq!(e.tvg_logo, "");
+        assert_eq!(e.tvg_id, "");
+        assert_eq!(e.tvg_name, "");
+        assert_eq!(e.tvg_language, "");
+        assert_eq!(e.tvg_country, "");
+    }
+
+    #[test]
+    fn empty_input() {
+        let entries = parse_m3u(String::new());
+        assert!(entries.is_empty());
+    }
+
+    #[test]
+    fn whitespace_only_input() {
+        let entries = parse_m3u("   \n\n  \n".to_string());
+        assert!(entries.is_empty());
+    }
+
+    #[test]
+    fn malformed_extinf_without_url() {
+        let content = concat!(
+            "#EXTINF:-1 group-title=\"News\",Orphan Channel\n",
+            "# This is a comment\n",
+            "#EXTINF:-1 group-title=\"Music\",Valid Channel\n",
+            "http://example.com/valid\n",
+        );
+        let entries = parse_m3u(content.to_string());
+        // The orphan EXTINF is replaced by the next EXTINF before a URL appears.
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].name, "Valid Channel");
+    }
+
+    #[test]
+    fn non_http_url_skipped() {
+        let content = concat!(
+            "#EXTINF:-1,FTP Channel\n",
+            "ftp://example.com/stream\n",
+        );
+        let entries = parse_m3u(content.to_string());
+        assert!(entries.is_empty());
+    }
+
+    #[test]
+    fn url_without_extinf_skipped() {
+        let content = "http://example.com/orphan-url\n";
+        let entries = parse_m3u(content.to_string());
+        assert!(entries.is_empty());
+    }
+
+    #[test]
+    fn handles_windows_line_endings() {
+        let content =
+            "#EXTM3U\r\n#EXTINF:-1,Win Channel\r\nhttp://example.com/win\r\n";
+        let entries = parse_m3u(content.to_string());
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].name, "Win Channel");
+        assert_eq!(entries[0].url, "http://example.com/win");
+    }
+
+    #[test]
+    fn attributes_are_case_insensitive() {
+        let content = concat!(
+            "#EXTINF:-1 TVG-ID=\"id1\" Tvg-Name=\"Name1\" GROUP-TITLE=\"G\",Ch\n",
+            "http://example.com/ch\n",
+        );
+        let entries = parse_m3u(content.to_string());
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].tvg_id, "id1");
+        assert_eq!(entries[0].tvg_name, "Name1");
+        assert_eq!(entries[0].group_title, "G");
+    }
+
+    #[test]
+    fn empty_attribute_values() {
+        let content = concat!(
+            "#EXTINF:-1 tvg-id=\"\" group-title=\"\",No Attrs\n",
+            "http://example.com/noattrs\n",
+        );
+        let entries = parse_m3u(content.to_string());
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].tvg_id, "");
+        assert_eq!(entries[0].group_title, "");
+    }
+
+    #[test]
+    fn commas_in_attribute_values() {
+        // The channel name is everything after the last *unquoted* comma.
+        let content = concat!(
+            "#EXTINF:-1 group-title=\"News, Weather\",BBC News\n",
+            "http://example.com/bbc\n",
+        );
+        let entries = parse_m3u(content.to_string());
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].group_title, "News, Weather");
+        assert_eq!(entries[0].name, "BBC News");
+    }
+}

--- a/rust/airo_core/src/api/m3u.rs
+++ b/rust/airo_core/src/api/m3u.rs
@@ -9,7 +9,7 @@
 ///   - Payload kept small: only the fields the Dart model needs.
 ///   - Pure-Dart fallback exists in `m3u_parser_service.dart`.
 
-/// A single parsed M3U channel entry.
+// A single parsed M3U channel entry.
 #[derive(Debug, Clone, PartialEq)]
 pub struct M3UEntry {
     pub name: String,

--- a/rust/airo_core/src/api/mod.rs
+++ b/rust/airo_core/src/api/mod.rs
@@ -4,4 +4,5 @@
 //   - Keep payloads small (< 64 KB per call); batch large data.
 //   - Every function must have a pure-Dart fallback path on the Dart side.
 
+pub mod m3u;
 pub mod text;


### PR DESCRIPTION
## Summary
- Rust M3U parser (airo_core::api::m3u) — byte-level attribute extraction, 12 tests
- Dart NativeM3UEntry wrapper with UnsupportedError fallback
- Clean rebase on main (replaces #792)

Closes #764

🤖 Generated with [Claude Code](https://claude.com/claude-code)