### PR TITLE
fix(tv): resolve undefined identifiers breaking CI

### DIFF
--- a/app/lib/core/tv/tv_focusable.dart
+++ b/app/lib/core/tv/tv_focusable.dart
@@ -171,8 +171,9 @@ class _TvFocusableState extends State<TvFocusable>
                 child: Container(
                   decoration: isFocused && widget.showBorderEffect
                       ? BoxDecoration(
-                          borderRadius:
-                              BorderRadius.circular(widget.borderRadius),
+                          borderRadius: BorderRadius.circular(
+                            widget.borderRadius,
+                          ),
                           border: Border.all(
                             color: focusColor,
                             width: TvFocusConstants.focusBorderWidth,

--- a/app/lib/main.dart
+++ b/app/lib/main.dart
@@ -22,7 +22,7 @@ void main() async {
   GlobalErrorHandler.initialize();
 
   if (kIsWeb) {
-    SemanticsBinding.instance.ensureSemantics();
+    WidgetsBinding.instance.ensureSemantics();
     debugPrint('🔧 Semantics enabled for web testing');
   }
 

--- a/app/lib/main_tv.dart
+++ b/app/lib/main_tv.dart
@@ -51,7 +51,7 @@ void main() async {
   GlobalErrorHandler.initialize();
 
   if (kIsWeb) {
-    SemanticsBinding.instance.ensureSemantics();
+    WidgetsBinding.instance.ensureSemantics();
     debugPrint('Semantics enabled for Airo TV web testing');
   }
 
@@ -77,7 +77,6 @@ void main() async {
     ProviderScope(
       overrides: [
         sharedPreferencesProvider.overrideWithValue(prefs),
-        realIptvCastControllerOverride(),
         ...FeatureRegistry.allProviderOverrides,
       ],
       child: const AiroTvApp(),
@@ -86,7 +85,6 @@ void main() async {
 
   WidgetsBinding.instance.addPostFrameCallback((_) {
     unawaited(FeatureRegistry.initializeAll());
-    unawaited(seedTvDebugDefaultPlaylist(prefs));
   });
 }
 


### PR DESCRIPTION
## Summary
- Replace `SemanticsBinding.instance` with `WidgetsBinding.instance` in main.dart and main_tv.dart
- Remove references to unimplemented `realIptvCastControllerOverride()` and `seedTvDebugDefaultPlaylist()`
- Fixes CI analyze step failing on main

## Test plan
- [ ] CI analyze step passes
- [ ] TV app still launches without cast override (uses default `UnavailableAiroCastController`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)