### PR TITLE
docs(agents): add CI cost control policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,6 +38,38 @@ Minimum requirement:
 If this sync step is skipped, implementation must stop until the worktree is
 rebased, recreated, or reset onto the correct current remote base.
 
+## CI Cost Control Rule
+
+GitHub Actions minutes are a costed resource. During iterative issue work,
+agents must avoid unnecessary remote CI builds and use local validation first.
+For current v2.0.0.0 development, the default is to skip remote CI for
+issue-iteration and integration-branch merge commits unless a maintainer
+explicitly asks for a CI run.
+
+Minimum requirement:
+
+1. Run focused local validation for the touched package or module before
+   pushing: formatting, analyzer/lint, targeted tests, and `git diff --check`
+   as applicable.
+2. Add `[skip ci]` to iterative issue commits and merge commits unless the user
+   explicitly requests a CI run or the change is a release verification step.
+3. Prefer pushing issue branches and the `codex/next-v2.0.0.0` integration
+   branch for v2 development. Do not push directly to `v2` just to validate a
+   work-in-progress change, because release-line pushes can trigger additional
+   workflows such as Pages builds.
+4. Avoid empty commits, no-op pushes, repeated metadata-only pushes, or branch
+   churn that would trigger workflows without changing reviewable behavior.
+5. Do not wait for remote CI to close an issue when the agreed acceptance
+   criteria are satisfied by focused local validation and the issue records the
+   evidence.
+6. Close GitHub issues as soon as the acceptance criteria are satisfied and
+   local validation evidence has been recorded in the issue. Do not close issues
+   before required policy artifacts, deterministic use cases, and validation
+   notes are present.
+
+If remote CI is intentionally required, state why in the issue or PR before
+pushing without `[skip ci]`.
+
 Framework agents own reusable contracts, runtime boundaries, storage schemas,
 security rules, and platform abstractions. Application agents own product
 journeys, screens, copy, routine packs, templates, and end-user workflows.

--- a/docs/agents/AGENT_POLICY.md
+++ b/docs/agents/AGENT_POLICY.md
@@ -193,9 +193,37 @@ Required bootstrap sequence:
 - create the task branch or worktree from that chosen remote base
 - verify the task branch/worktree base matches the fetched remote base
 
-If new commits land on `main` before implementation starts, the agent must
-or `v2` before implementation starts, the agent must repeat this sync step and
-restack or recreate the worktree as needed.
+If new commits land on `main` or `v2` before implementation starts, the agent
+must repeat this sync step and restack or recreate the worktree as needed.
+
+### CI Cost Control
+
+GitHub Actions minutes are a costed resource. During iterative issue work,
+agents must avoid unnecessary remote builds and use focused local validation
+first.
+For current v2.0.0.0 development, agents should treat remote CI as opt-in
+during issue iteration and integration-branch merges. Local validation plus
+recorded evidence in the issue is enough to close issues unless the maintainer
+explicitly requests CI or the change is a release verification step.
+
+Required cost controls:
+- Run the smallest useful local checks for the touched module before pushing:
+  formatting, analyzer/lint, targeted tests, and `git diff --check` as
+  applicable.
+- Add `[skip ci]` to iterative issue commits and merge commits unless the user
+  explicitly requests remote CI or the change is a release verification step.
+- For v2 work, push issue branches and the `codex/next-v2.0.0.0` integration
+  branch. Do not push directly to `v2` just to validate work in progress.
+- Avoid empty commits, no-op pushes, repeated metadata-only pushes, and branch
+  churn that can trigger workflows without changing reviewable behavior.
+- Do not hold an otherwise complete issue open only to wait for remote CI when
+  the acceptance criteria are met by focused local validation.
+- Close GitHub issues as soon as the acceptance criteria are met and the issue
+  records the required policy artifacts, deterministic use cases, and
+  validation evidence.
+
+If remote CI is intentionally required, explain why in the issue or PR before
+pushing without `[skip ci]`.
 
 ### 2. Critical Agent Clarity Gate
 
@@ -330,7 +358,8 @@ Before completion:
 Release Agent confirms:
 - docs or ADR updated when contract changes
 - migrations are safe
-- CI checks cover the change
+- CI checks cover release validation, or focused local validation is documented
+  for iterative work where `[skip ci]` was used
 - rollback or disable path exists for risky features
 
 ## Feature Packet Template

--- a/docs/agents/RULES.md
+++ b/docs/agents/RULES.md
@@ -1,7 +1,7 @@
 # 🤖 Airo Agent Operating Rules
 
-> **Last Updated:** 2026-06-27  
-> **Version:** 1.1.0  
+> **Last Updated:** 2026-07-15
+> **Version:** 1.2.1
 > **Project Board:** https://github.com/orgs/DevelopersCoffee/projects/2
 
 ## 📋 Rule Updates
@@ -110,9 +110,31 @@ DORMANT → ACTIVATED → IN_PROGRESS → REVIEW → COMPLETE → DORMANT
 ### During Work
 1. Update issue with progress comments (daily minimum)
 2. Check off completed subtasks in issue body
-3. Run `act` before each push
-4. Keep commits small and focused
-5. Document blockers immediately
+3. Run focused local validation for the touched module before each push
+4. Add `[skip ci]` to iterative issue commits and merge commits unless remote
+   CI is explicitly required
+5. Keep commits small and focused
+6. Document blockers immediately
+
+### CI Cost Guardrail
+GitHub Actions minutes are a costed resource. Agents should avoid unnecessary
+remote builds during iterative issue work.
+
+- Prefer local validation first: formatting, analyzer/lint, targeted tests, and
+  `git diff --check` as applicable.
+- Use `[skip ci]` on iterative issue commits and integration merge commits.
+- For current v2.0.0.0 development, remote CI is opt-in during issue iteration
+  unless a maintainer explicitly asks for it or the change is a release
+  verification step.
+- Do not push directly to release-line branches such as `main` or `v2` just to
+  validate work in progress.
+- Avoid empty commits, no-op pushes, repeated metadata-only pushes, or branch
+  churn that can trigger workflows without changing reviewable behavior.
+- Close issues as soon as acceptance criteria and focused local validation
+  evidence are recorded. Do not keep an accepted issue open just to wait for
+  remote CI unless CI was explicitly required.
+- If remote CI is intentionally required, explain why in the issue or PR before
+  pushing without `[skip ci]`.
 
 ### Host Stability Guardrail
 LLM agents must not use the Android Emulator as the default verification path.
@@ -160,7 +182,7 @@ Agent rules:
 | ❌ Don't | ✅ Do Instead |
 |----------|---------------|
 | Work without issue | Create issue first |
-| Push without CI | Run `act` locally |
+| Trigger unnecessary Actions builds | Run focused local validation and use `[skip ci]` for iterative pushes |
 | Skip issue updates | Comment daily progress |
 | Ignore blockers | Document and escalate |
 | Large PRs (>500 lines) | Split into smaller PRs |
@@ -190,7 +212,7 @@ An agent task is DONE when:
 - [ ] All acceptance criteria checked
 - [ ] Tests pass (`flutter test`)
 - [ ] Linting clean (`flutter analyze`)
-- [ ] Local CI passes (`act`)
+- [ ] Focused local validation passes, with remote CI reserved for explicit release or PR gates
 - [ ] PR approved and merged
 - [ ] Issue closed
 - [ ] No regressions in related features


### PR DESCRIPTION
## Summary

- Add CI cost control guardrails to agent operating rules across all three policy documents (`AGENTS.md`, `docs/agents/AGENT_POLICY.md`, `docs/agents/RULES.md`)
- Agents must prefer focused local validation (formatting, analyzer/lint, targeted tests) over remote CI during iterative issue work
- `[skip ci]` required on iterative commits and integration merge commits unless remote CI is explicitly requested
- Fix a pre-existing syntax error in `AGENT_POLICY.md` (broken sentence at line 196)
- Bump RULES.md version to 1.2.1

## Why

GitHub Actions minutes are a costed resource. During the v2 milestone sprint, unnecessary CI runs were triggered on iterative pushes. This policy makes remote CI opt-in for issue iteration while keeping it mandatory for release verification and PR gates.

## Test plan

- [x] Docs-only change — no code affected
- [x] Policy is consistent across all three documents

🤖 Generated with [Claude Code](https://claude.com/claude-code)