### PR TITLE
feat(media): add pro guide and failover contracts

### DIFF
--- a/packages/platform_epg/lib/platform_epg.dart
+++ b/packages/platform_epg/lib/platform_epg.dart
@@ -1,7 +1,10 @@
 library;
 
 export 'src/compact_epg_models.dart';
+export 'src/compact_epg_event_resolver.dart';
+export 'src/compact_epg_reminders.dart';
 export 'src/compact_epg_snapshot_codec.dart';
 export 'src/compact_epg_snapshot_repository.dart';
 export 'src/distributed_epg_worker_models.dart';
+export 'src/sports_desk_models.dart';
 export 'src/xmltv_compact_epg_repository.dart';

--- a/packages/platform_epg/lib/src/compact_epg_event_resolver.dart
+++ b/packages/platform_epg/lib/src/compact_epg_event_resolver.dart
@@ -1,0 +1,83 @@
+import 'package:equatable/equatable.dart';
+
+import 'compact_epg_models.dart';
+
+enum CompactEpgEventResolutionCode {
+  resolved('resolved'),
+  missingEventId('missing_event_id'),
+  unresolved('unresolved');
+
+  const CompactEpgEventResolutionCode(this.stableId);
+
+  final String stableId;
+}
+
+class CompactEpgResolvedEvent extends Equatable {
+  const CompactEpgResolvedEvent({
+    required this.eventId,
+    required this.entry,
+    required this.program,
+  });
+
+  final String eventId;
+  final CompactEpgEntry entry;
+  final CompactEpgProgram program;
+
+  @override
+  List<Object?> get props => [eventId, entry, program];
+}
+
+class CompactEpgEventResolution extends Equatable {
+  const CompactEpgEventResolution._({required this.code, this.resolved});
+
+  factory CompactEpgEventResolution.resolved(CompactEpgResolvedEvent event) {
+    return CompactEpgEventResolution._(
+      code: CompactEpgEventResolutionCode.resolved,
+      resolved: event,
+    );
+  }
+
+  const CompactEpgEventResolution.missingEventId()
+    : this._(code: CompactEpgEventResolutionCode.missingEventId);
+
+  const CompactEpgEventResolution.unresolved()
+    : this._(code: CompactEpgEventResolutionCode.unresolved);
+
+  final CompactEpgEventResolutionCode code;
+  final CompactEpgResolvedEvent? resolved;
+
+  bool get isResolved => resolved != null;
+
+  @override
+  List<Object?> get props => [code, resolved];
+}
+
+class CompactEpgEventResolver {
+  const CompactEpgEventResolver();
+
+  CompactEpgEventResolution resolve({
+    required CompactEpgSlice slice,
+    required String eventId,
+  }) {
+    final trimmedEventId = eventId.trim();
+    if (trimmedEventId.isEmpty) {
+      return const CompactEpgEventResolution.missingEventId();
+    }
+
+    for (final entry in slice.entries) {
+      for (final program in [entry.current, entry.next]) {
+        if (program?.eventId == trimmedEventId) {
+          return CompactEpgEventResolution.resolved(
+            CompactEpgResolvedEvent(
+              eventId: trimmedEventId,
+              entry: entry,
+              program: program!,
+            ),
+          );
+        }
+      }
+    }
+
+    return const CompactEpgEventResolution.unresolved();
+  }
+}

--- a/packages/platform_epg/lib/src/compact_epg_models.dart
+++ b/packages/platform_epg/lib/src/compact_epg_models.dart
@@ -23,6 +23,18 @@ enum CompactEpgAvailability {
   final String stableId;
 }
 
+enum CompactEpgProgramKind {
+  standard('standard'),
+  movie('movie'),
+  episode('episode'),
+  sports('sports'),
+  news('news');
+
+  const CompactEpgProgramKind(this.stableId);
+
+  final String stableId;
+}
+
 enum CompactEpgSourceRefRejectionCode {
   empty('empty'),
   urlValue('url_value'),
@@ -91,18 +103,22 @@ class CompactEpgProgram extends Equatable {
     required this.title,
     required this.startsAt,
     required this.endsAt,
+    this.eventId,
     this.subtitle,
     this.category,
     this.rating,
+    this.kind = CompactEpgProgramKind.standard,
     this.schemaVersion = kCompactEpgSchemaVersion,
   });
 
   final String schemaVersion;
   final String programId;
   final String title;
+  final String? eventId;
   final String? subtitle;
   final String? category;
   final String? rating;
+  final CompactEpgProgramKind kind;
   final DateTime startsAt;
   final DateTime endsAt;
 
@@ -118,9 +134,11 @@ class CompactEpgProgram extends Equatable {
     schemaVersion,
     programId,
     title,
+    eventId,
     subtitle,
     category,
     rating,
+    kind,
     startsAt,
     endsAt,
   ];

--- a/packages/platform_epg/lib/src/compact_epg_reminders.dart
+++ b/packages/platform_epg/lib/src/compact_epg_reminders.dart
@@ -1,0 +1,242 @@
+import 'package:equatable/equatable.dart';
+
+import 'compact_epg_event_resolver.dart';
+import 'compact_epg_models.dart';
+
+enum CompactEpgReminderAction {
+  schedule('schedule'),
+  none('none');
+
+  const CompactEpgReminderAction(this.stableId);
+
+  final String stableId;
+}
+
+enum CompactEpgReminderStatus {
+  scheduled('scheduled'),
+  unchanged('unchanged'),
+  unresolved('unresolved'),
+  skippedPastNotification('skipped_past_notification');
+
+  const CompactEpgReminderStatus(this.stableId);
+
+  final String stableId;
+}
+
+class CompactEpgReminderRequest extends Equatable {
+  const CompactEpgReminderRequest({
+    required this.reminderId,
+    required this.title,
+    this.eventId,
+    this.channelId,
+    this.programId,
+    this.remindBefore = const Duration(minutes: 5),
+  });
+
+  final String reminderId;
+  final String title;
+  final String? eventId;
+  final String? channelId;
+  final String? programId;
+  final Duration remindBefore;
+
+  @override
+  List<Object?> get props => [
+    reminderId,
+    title,
+    eventId,
+    channelId,
+    programId,
+    remindBefore,
+  ];
+}
+
+class CompactEpgPendingReminder extends Equatable {
+  const CompactEpgPendingReminder({
+    required this.request,
+    required this.scheduledChannelId,
+    required this.scheduledProgramId,
+    required this.programStartsAt,
+    required this.notifyAt,
+  });
+
+  final CompactEpgReminderRequest request;
+  final String scheduledChannelId;
+  final String scheduledProgramId;
+  final DateTime programStartsAt;
+  final DateTime notifyAt;
+
+  @override
+  List<Object?> get props => [
+    request,
+    scheduledChannelId,
+    scheduledProgramId,
+    programStartsAt,
+    notifyAt,
+  ];
+}
+
+class CompactEpgReminderCommand extends Equatable {
+  const CompactEpgReminderCommand({
+    required this.action,
+    required this.reminderId,
+    required this.title,
+    required this.channelId,
+    required this.programId,
+    required this.programStartsAt,
+    required this.notifyAt,
+    this.eventId,
+  });
+
+  final CompactEpgReminderAction action;
+  final String reminderId;
+  final String title;
+  final String channelId;
+  final String programId;
+  final String? eventId;
+  final DateTime programStartsAt;
+  final DateTime notifyAt;
+
+  @override
+  List<Object?> get props => [
+    action,
+    reminderId,
+    title,
+    channelId,
+    programId,
+    eventId,
+    programStartsAt,
+    notifyAt,
+  ];
+}
+
+class CompactEpgReminderReconcileResult extends Equatable {
+  const CompactEpgReminderReconcileResult({
+    required this.request,
+    required this.status,
+    this.command,
+    this.pending,
+  });
+
+  final CompactEpgReminderRequest request;
+  final CompactEpgReminderStatus status;
+  final CompactEpgReminderCommand? command;
+  final CompactEpgPendingReminder? pending;
+
+  @override
+  List<Object?> get props => [request, status, command, pending];
+}
+
+class CompactEpgReminderReconciler {
+  const CompactEpgReminderReconciler({
+    this.eventResolver = const CompactEpgEventResolver(),
+  });
+
+  final CompactEpgEventResolver eventResolver;
+
+  List<CompactEpgReminderReconcileResult> reconcileAll({
+    required Iterable<CompactEpgReminderRequest> requests,
+    required CompactEpgSlice slice,
+    required DateTime now,
+    Iterable<CompactEpgPendingReminder> existing = const [],
+  }) {
+    final existingById = {
+      for (final pending in existing) pending.request.reminderId: pending,
+    };
+    return [
+      for (final request in requests)
+        reconcileOne(
+          request: request,
+          slice: slice,
+          now: now,
+          existing: existingById[request.reminderId],
+        ),
+    ];
+  }
+
+  CompactEpgReminderReconcileResult reconcileOne({
+    required CompactEpgReminderRequest request,
+    required CompactEpgSlice slice,
+    required DateTime now,
+    CompactEpgPendingReminder? existing,
+  }) {
+    final resolved = _resolve(request: request, slice: slice);
+    if (resolved == null) {
+      return CompactEpgReminderReconcileResult(
+        request: request,
+        status: CompactEpgReminderStatus.unresolved,
+      );
+    }
+
+    final notifyAt = resolved.program.startsAt.toUtc().subtract(
+      request.remindBefore,
+    );
+    if (!notifyAt.isAfter(now.toUtc())) {
+      return CompactEpgReminderReconcileResult(
+        request: request,
+        status: CompactEpgReminderStatus.skippedPastNotification,
+      );
+    }
+
+    final pending = CompactEpgPendingReminder(
+      request: request,
+      scheduledChannelId: resolved.entry.channelId,
+      scheduledProgramId: resolved.program.programId,
+      programStartsAt: resolved.program.startsAt.toUtc(),
+      notifyAt: notifyAt,
+    );
+
+    if (pending == existing) {
+      return CompactEpgReminderReconcileResult(
+        request: request,
+        status: CompactEpgReminderStatus.unchanged,
+        pending: pending,
+      );
+    }
+
+    return CompactEpgReminderReconcileResult(
+      request: request,
+      status: CompactEpgReminderStatus.scheduled,
+      pending: pending,
+      command: CompactEpgReminderCommand(
+        action: CompactEpgReminderAction.schedule,
+        reminderId: request.reminderId,
+        title: request.title,
+        channelId: resolved.entry.channelId,
+        programId: resolved.program.programId,
+        eventId: resolved.program.eventId ?? request.eventId,
+        programStartsAt: resolved.program.startsAt.toUtc(),
+        notifyAt: notifyAt,
+      ),
+    );
+  }
+
+  CompactEpgResolvedEvent? _resolve({
+    required CompactEpgReminderRequest request,
+    required CompactEpgSlice slice,
+  }) {
+    final eventId = request.eventId;
+    if (eventId != null && eventId.trim().isNotEmpty) {
+      return eventResolver.resolve(slice: slice, eventId: eventId).resolved;
+    }
+
+    final channelId = request.channelId;
+    final programId = request.programId;
+    if (channelId == null || programId == null) return null;
+
+    final entry = slice.entryForChannel(channelId);
+    if (entry == null) return null;
+
+    for (final program in [entry.current, entry.next]) {
+      if (program?.programId == programId) {
+        return CompactEpgResolvedEvent(
+          eventId: program!.eventId ?? program.programId,
+          entry: entry,
+          program: program,
+        );
+      }
+    }
+
+    return null;
+  }
+}

--- a/packages/platform_epg/lib/src/compact_epg_snapshot_codec.dart
+++ b/packages/platform_epg/lib/src/compact_epg_snapshot_codec.dart
@@ -75,9 +75,11 @@ Map<String, Object?> compactEpgProgramToJson(CompactEpgProgram program) {
     'schemaVersion': program.schemaVersion,
     'programId': program.programId,
     'title': program.title,
+    if (program.eventId != null) 'eventId': program.eventId,
     if (program.subtitle != null) 'subtitle': program.subtitle,
     if (program.category != null) 'category': program.category,
     if (program.rating != null) 'rating': program.rating,
+    'kind': program.kind.stableId,
     'startsAt': program.startsAt.toUtc().toIso8601String(),
     'endsAt': program.endsAt.toUtc().toIso8601String(),
   };
@@ -87,9 +89,11 @@ CompactEpgProgram compactEpgProgramFromJson(Map<String, dynamic> json) {
   return CompactEpgProgram(
     programId: _requiredString(json, 'programId'),
     title: _requiredString(json, 'title'),
+    eventId: _optionalString(json, 'eventId'),
     subtitle: _optionalString(json, 'subtitle'),
     category: _optionalString(json, 'category'),
     rating: _optionalString(json, 'rating'),
+    kind: _optionalProgramKind(json, 'kind') ?? CompactEpgProgramKind.standard,
     startsAt: _requiredDateTime(json, 'startsAt'),
     endsAt: _requiredDateTime(json, 'endsAt'),
     schemaVersion:
@@ -108,6 +112,18 @@ CompactEpgSliceSource _sliceSourceFromStableId(String value) {
     if (source.stableId == value) return source;
   }
   throw FormatException('Unknown CompactEpgSliceSource "$value".');
+}
+
+CompactEpgProgramKind? _optionalProgramKind(
+  Map<String, dynamic> json,
+  String key,
+) {
+  final value = _optionalString(json, key);
+  if (value == null) return null;
+  for (final kind in CompactEpgProgramKind.values) {
+    if (kind.stableId == value) return kind;
+  }
+  throw FormatException('Unknown CompactEpgProgramKind "$value".');
 }
 
 CompactEpgSourceRef _redactedSourceRef(String value, String key) {

--- a/packages/platform_epg/lib/src/sports_desk_models.dart
+++ b/packages/platform_epg/lib/src/sports_desk_models.dart
@@ -1,0 +1,106 @@
+import 'package:equatable/equatable.dart';
+
+import 'compact_epg_event_resolver.dart';
+import 'compact_epg_models.dart';
+
+enum SportsFixtureStatus {
+  scheduled('scheduled'),
+  live('live'),
+  finalScore('final'),
+  postponed('postponed');
+
+  const SportsFixtureStatus(this.stableId);
+
+  final String stableId;
+}
+
+class SportsFixture extends Equatable {
+  const SportsFixture({
+    required this.eventId,
+    required this.title,
+    required this.sport,
+    required this.startsAt,
+    this.league,
+    this.homeName,
+    this.awayName,
+    this.regionCode,
+    this.status = SportsFixtureStatus.scheduled,
+  });
+
+  final String eventId;
+  final String title;
+  final String sport;
+  final DateTime startsAt;
+  final String? league;
+  final String? homeName;
+  final String? awayName;
+  final String? regionCode;
+  final SportsFixtureStatus status;
+
+  @override
+  List<Object?> get props => [
+    eventId,
+    title,
+    sport,
+    startsAt,
+    league,
+    homeName,
+    awayName,
+    regionCode,
+    status,
+  ];
+}
+
+class SportsDeskRow extends Equatable {
+  SportsDeskRow({
+    required this.rowId,
+    required this.title,
+    required Iterable<SportsFixture> fixtures,
+  }) : fixtures = List.unmodifiable(fixtures);
+
+  final String rowId;
+  final String title;
+  final List<SportsFixture> fixtures;
+
+  @override
+  List<Object?> get props => [rowId, title, fixtures];
+}
+
+class SportsDeskFixtureResolution extends Equatable {
+  const SportsDeskFixtureResolution({
+    required this.fixture,
+    required this.epgResolution,
+  });
+
+  final SportsFixture fixture;
+  final CompactEpgEventResolution epgResolution;
+
+  bool get hasCarriage => epgResolution.isResolved;
+
+  @override
+  List<Object?> get props => [fixture, epgResolution];
+}
+
+class SportsDeskEventResolver {
+  const SportsDeskEventResolver({
+    this.eventResolver = const CompactEpgEventResolver(),
+  });
+
+  final CompactEpgEventResolver eventResolver;
+
+  List<SportsDeskFixtureResolution> resolveRow({
+    required SportsDeskRow row,
+    required CompactEpgSlice slice,
+  }) {
+    return [
+      for (final fixture in row.fixtures)
+        SportsDeskFixtureResolution(
+          fixture: fixture,
+          epgResolution: eventResolver.resolve(
+            slice: slice,
+            eventId: fixture.eventId,
+          ),
+        ),
+    ];
+  }
+}

--- a/packages/platform_epg/test/compact_epg_reminders_test.dart
+++ b/packages/platform_epg/test/compact_epg_reminders_test.dart
@@ -1,0 +1,107 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:platform_epg/platform_epg.dart';
+
+void main() {
+  group('CompactEpgReminderReconciler', () {
+    final now = DateTime.utc(2026, 7, 15, 9);
+    const request = CompactEpgReminderRequest(
+      reminderId: 'reminder-1',
+      title: 'IND vs AUS, 1st ODI',
+      eventId: 'fixture-ind-aus-odi-1',
+    );
+
+    test('reschedules event reminder when channel carriage changes', () {
+      final reconciler = CompactEpgReminderReconciler();
+      final oldSlice = _slice(
+        now: now,
+        channelId: 'sports-1',
+        programId: 'old-program',
+        startsAt: DateTime.utc(2026, 7, 15, 10),
+      );
+      final freshSlice = _slice(
+        now: now,
+        channelId: 'sports-2',
+        programId: 'fresh-program',
+        startsAt: DateTime.utc(2026, 7, 15, 10, 30),
+      );
+
+      final initial = reconciler.reconcileOne(
+        request: request,
+        slice: oldSlice,
+        now: now,
+      );
+      final refreshed = reconciler.reconcileOne(
+        request: request,
+        slice: freshSlice,
+        now: now,
+        existing: initial.pending,
+      );
+
+      expect(initial.status, CompactEpgReminderStatus.scheduled);
+      expect(refreshed.status, CompactEpgReminderStatus.scheduled);
+      expect(refreshed.command?.channelId, 'sports-2');
+      expect(refreshed.command?.programId, 'fresh-program');
+      expect(refreshed.command?.notifyAt, DateTime.utc(2026, 7, 15, 10, 25));
+    });
+
+    test('leaves unresolved event reminders pending without a command', () {
+      final result = const CompactEpgReminderReconciler().reconcileOne(
+        request: request,
+        slice: CompactEpgSlice(
+          entries: const [],
+          generatedAt: now,
+          expiresAt: now.add(const Duration(minutes: 15)),
+          source: CompactEpgSliceSource.unavailable,
+        ),
+        now: now,
+      );
+
+      expect(result.status, CompactEpgReminderStatus.unresolved);
+      expect(result.command, isNull);
+      expect(result.pending, isNull);
+    });
+
+    test('does not schedule notifications in the past', () {
+      final result = const CompactEpgReminderReconciler().reconcileOne(
+        request: request,
+        slice: _slice(
+          now: now,
+          channelId: 'sports-1',
+          programId: 'program-now',
+          startsAt: DateTime.utc(2026, 7, 15, 9, 3),
+        ),
+        now: now,
+      );
+
+      expect(result.status, CompactEpgReminderStatus.skippedPastNotification);
+      expect(result.command, isNull);
+    });
+  });
+}
+
+CompactEpgSlice _slice({
+  required DateTime now,
+  required String channelId,
+  required String programId,
+  required DateTime startsAt,
+}) {
+  return CompactEpgSlice(
+    generatedAt: now,
+    expiresAt: now.add(const Duration(minutes: 15)),
+    source: CompactEpgSliceSource.localCache,
+    entries: [
+      CompactEpgEntry(
+        channelId: channelId,
+        channelName: channelId,
+        current: CompactEpgProgram(
+          programId: programId,
+          eventId: 'fixture-ind-aus-odi-1',
+          title: 'IND vs AUS, 1st ODI',
+          kind: CompactEpgProgramKind.sports,
+          startsAt: startsAt,
+          endsAt: startsAt.add(const Duration(hours: 3)),
+        ),
+      ),
+    ],
+  );
+}

--- a/packages/platform_epg/test/compact_epg_snapshot_repository_test.dart
+++ b/packages/platform_epg/test/compact_epg_snapshot_repository_test.dart
@@ -17,10 +17,12 @@ void main() {
             sourceRef: CompactEpgSourceRef.redacted('user-guide-primary'),
             current: CompactEpgProgram(
               programId: 'current',
+              eventId: 'event-news-current',
               title: 'Morning News',
               subtitle: 'Top stories',
               category: 'news',
               rating: 'G',
+              kind: CompactEpgProgramKind.news,
               startsAt: now.subtract(const Duration(minutes: 15)),
               endsAt: now.add(const Duration(minutes: 15)),
             ),
@@ -40,6 +42,14 @@ void main() {
       expect(
         decoded.entryForChannel('news-1')?.sourceRef?.value,
         'user-guide-primary',
+      );
+      expect(
+        decoded.entryForChannel('news-1')?.current?.eventId,
+        'event-news-current',
+      );
+      expect(
+        decoded.entryForChannel('news-1')?.current?.kind,
+        CompactEpgProgramKind.news,
       );
     });
 

--- a/packages/platform_epg/test/sports_desk_models_test.dart
+++ b/packages/platform_epg/test/sports_desk_models_test.dart
@@ -1,0 +1,87 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:platform_epg/platform_epg.dart';
+
+void main() {
+  group('SportsDeskEventResolver', () {
+    final now = DateTime.utc(2026, 7, 15, 9);
+
+    test('resolves fixture rows through EPG event ids', () {
+      final row = SportsDeskRow(
+        rowId: 'live-sports',
+        title: 'Live Sports Desk',
+        fixtures: [
+          SportsFixture(
+            eventId: 'fixture-ind-aus-odi-1',
+            title: 'IND vs AUS, 1st ODI',
+            sport: 'cricket',
+            startsAt: DateTime.utc(2026, 7, 15, 10),
+            regionCode: 'IN',
+          ),
+        ],
+      );
+      final slice = CompactEpgSlice(
+        generatedAt: now,
+        expiresAt: now.add(const Duration(minutes: 15)),
+        source: CompactEpgSliceSource.localCache,
+        entries: [
+          CompactEpgEntry(
+            channelId: 'sports-hd',
+            channelName: 'Sports HD',
+            next: CompactEpgProgram(
+              programId: 'program-1',
+              eventId: 'fixture-ind-aus-odi-1',
+              title: 'IND vs AUS, 1st ODI',
+              kind: CompactEpgProgramKind.sports,
+              startsAt: DateTime.utc(2026, 7, 15, 10),
+              endsAt: DateTime.utc(2026, 7, 15, 13),
+            ),
+          ),
+        ],
+      );
+
+      final resolutions = const SportsDeskEventResolver().resolveRow(
+        row: row,
+        slice: slice,
+      );
+
+      expect(resolutions.single.hasCarriage, isTrue);
+      expect(
+        resolutions.single.epgResolution.resolved?.entry.channelId,
+        'sports-hd',
+      );
+    });
+
+    test('keeps fixture row renderable when EPG carriage is unresolved', () {
+      final row = SportsDeskRow(
+        rowId: 'live-sports',
+        title: 'Live Sports Desk',
+        fixtures: [
+          SportsFixture(
+            eventId: 'fixture-later',
+            title: 'Later Fixture',
+            sport: 'football',
+            startsAt: DateTime.utc(2026, 7, 15, 18),
+          ),
+        ],
+      );
+      final slice = CompactEpgSlice(
+        entries: const [],
+        generatedAt: now,
+        expiresAt: now.add(const Duration(minutes: 15)),
+        source: CompactEpgSliceSource.localCache,
+      );
+
+      final resolutions = const SportsDeskEventResolver().resolveRow(
+        row: row,
+        slice: slice,
+      );
+
+      expect(resolutions.single.fixture.title, 'Later Fixture');
+      expect(resolutions.single.hasCarriage, isFalse);
+      expect(
+        resolutions.single.epgResolution.code,
+        CompactEpgEventResolutionCode.unresolved,
+      );
+    });
+  });
+}

--- a/packages/platform_player/lib/platform_player.dart
+++ b/packages/platform_player/lib/platform_player.dart
@@ -2,6 +2,7 @@ library;
 
 export "src/models/cast_models.dart";
 export "src/models/cast_proxy_benchmark_models.dart";
+export "src/models/multi_source_failover_models.dart";
 export "src/models/native_media_engine_spike_models.dart";
 export "src/models/playback_engine_models.dart";
 export "src/models/streaming_state.dart";

--- a/packages/platform_player/lib/src/models/multi_source_failover_models.dart
+++ b/packages/platform_player/lib/src/models/multi_source_failover_models.dart
@@ -1,0 +1,324 @@
+import 'package:equatable/equatable.dart';
+
+import 'playback_engine_models.dart';
+
+enum AiroFailoverSourceHealth {
+  healthy('healthy'),
+  unknown('unknown'),
+  degraded('degraded'),
+  failed('failed');
+
+  const AiroFailoverSourceHealth(this.stableId);
+
+  final String stableId;
+}
+
+enum AiroFailoverTrigger {
+  playbackError('playback_error'),
+  stall('stall');
+
+  const AiroFailoverTrigger(this.stableId);
+
+  final String stableId;
+}
+
+enum AiroFailoverDecisionCode {
+  switched('switched'),
+  exhausted('exhausted'),
+  ignored('ignored');
+
+  const AiroFailoverDecisionCode(this.stableId);
+
+  final String stableId;
+}
+
+class AiroFailoverSource extends Equatable {
+  const AiroFailoverSource({
+    required this.sourceId,
+    required this.sourceHandle,
+    required this.canonicalChannelId,
+    this.rank = 0,
+    this.health = AiroFailoverSourceHealth.unknown,
+    this.resolutionHeight,
+    this.lastWorkedHere = false,
+  });
+
+  final String sourceId;
+  final AiroPlaybackSourceHandle sourceHandle;
+  final String canonicalChannelId;
+  final int rank;
+  final AiroFailoverSourceHealth health;
+  final int? resolutionHeight;
+  final bool lastWorkedHere;
+
+  AiroFailoverSource copyWith({
+    AiroFailoverSourceHealth? health,
+    bool? lastWorkedHere,
+  }) {
+    return AiroFailoverSource(
+      sourceId: sourceId,
+      sourceHandle: sourceHandle,
+      canonicalChannelId: canonicalChannelId,
+      rank: rank,
+      health: health ?? this.health,
+      resolutionHeight: resolutionHeight,
+      lastWorkedHere: lastWorkedHere ?? this.lastWorkedHere,
+    );
+  }
+
+  @override
+  String toString() {
+    return 'AiroFailoverSource('
+        'sourceId: $sourceId, '
+        'canonicalChannelId: $canonicalChannelId, '
+        'rank: $rank, '
+        'health: ${health.stableId}, '
+        'resolutionHeight: $resolutionHeight, '
+        'lastWorkedHere: $lastWorkedHere, '
+        'sourceHandle: redacted'
+        ')';
+  }
+
+  @override
+  List<Object?> get props => [
+    sourceId,
+    sourceHandle,
+    canonicalChannelId,
+    rank,
+    health,
+    resolutionHeight,
+    lastWorkedHere,
+  ];
+}
+
+class AiroFailoverPolicy extends Equatable {
+  const AiroFailoverPolicy({this.stallThreshold = const Duration(seconds: 4)});
+
+  final Duration stallThreshold;
+
+  List<AiroFailoverSource> rankSources(Iterable<AiroFailoverSource> sources) {
+    final ranked = sources.toList()
+      ..sort((a, b) {
+        final lastWorkedCompare = _boolScore(
+          b.lastWorkedHere,
+        ).compareTo(_boolScore(a.lastWorkedHere));
+        if (lastWorkedCompare != 0) return lastWorkedCompare;
+
+        final healthCompare = _healthScore(
+          b.health,
+        ).compareTo(_healthScore(a.health));
+        if (healthCompare != 0) return healthCompare;
+
+        final resolutionCompare = (b.resolutionHeight ?? 0).compareTo(
+          a.resolutionHeight ?? 0,
+        );
+        if (resolutionCompare != 0) return resolutionCompare;
+
+        return a.rank.compareTo(b.rank);
+      });
+    return ranked;
+  }
+
+  bool shouldFailoverForStall(Duration bufferingDuration) {
+    return bufferingDuration >= stallThreshold;
+  }
+
+  int _boolScore(bool value) => value ? 1 : 0;
+
+  int _healthScore(AiroFailoverSourceHealth health) {
+    return switch (health) {
+      AiroFailoverSourceHealth.healthy => 3,
+      AiroFailoverSourceHealth.unknown => 2,
+      AiroFailoverSourceHealth.degraded => 1,
+      AiroFailoverSourceHealth.failed => 0,
+    };
+  }
+
+  @override
+  List<Object?> get props => [stallThreshold];
+}
+
+class AiroFailoverSessionState extends Equatable {
+  AiroFailoverSessionState({
+    required Iterable<AiroFailoverSource> sources,
+    this.currentSourceId,
+    Iterable<String> failedSourceIds = const [],
+  }) : sources = List.unmodifiable(sources),
+       failedSourceIds = Set.unmodifiable(failedSourceIds);
+
+  final List<AiroFailoverSource> sources;
+  final String? currentSourceId;
+  final Set<String> failedSourceIds;
+
+  int get sourceCount => sources.length;
+
+  AiroFailoverSource? get currentSource {
+    final id = currentSourceId;
+    if (id == null) return null;
+    for (final source in sources) {
+      if (source.sourceId == id) return source;
+    }
+    return null;
+  }
+
+  int? get currentSourceNumber {
+    final current = currentSource;
+    if (current == null) return null;
+    return sources.indexOf(current) + 1;
+  }
+
+  AiroFailoverSessionState copyWith({
+    Iterable<AiroFailoverSource>? sources,
+    String? currentSourceId,
+    Iterable<String>? failedSourceIds,
+  }) {
+    return AiroFailoverSessionState(
+      sources: sources ?? this.sources,
+      currentSourceId: currentSourceId ?? this.currentSourceId,
+      failedSourceIds: failedSourceIds ?? this.failedSourceIds,
+    );
+  }
+
+  @override
+  List<Object?> get props => [sources, currentSourceId, failedSourceIds];
+}
+
+class AiroFailoverDecision extends Equatable {
+  const AiroFailoverDecision({
+    required this.code,
+    required this.trigger,
+    required this.state,
+    this.nextSource,
+    this.failedSourceId,
+  });
+
+  final AiroFailoverDecisionCode code;
+  final AiroFailoverTrigger trigger;
+  final AiroFailoverSessionState state;
+  final AiroFailoverSource? nextSource;
+  final String? failedSourceId;
+
+  bool get shouldSwitch => code == AiroFailoverDecisionCode.switched;
+
+  String get uiStatus {
+    final number = state.currentSourceNumber;
+    if (code == AiroFailoverDecisionCode.switched && number != null) {
+      return 'switching_source_$number/${state.sourceCount}';
+    }
+    return code.stableId;
+  }
+
+  @override
+  String toString() {
+    return 'AiroFailoverDecision('
+        'code: ${code.stableId}, '
+        'trigger: ${trigger.stableId}, '
+        'failedSourceId: $failedSourceId, '
+        'nextSourceId: ${nextSource?.sourceId}, '
+        'uiStatus: $uiStatus'
+        ')';
+  }
+
+  @override
+  List<Object?> get props => [code, trigger, state, nextSource, failedSourceId];
+}
+
+class AiroMultiSourceFailoverController {
+  AiroMultiSourceFailoverController({
+    required Iterable<AiroFailoverSource> sources,
+    this.policy = const AiroFailoverPolicy(),
+  }) : _state = AiroFailoverSessionState(sources: policy.rankSources(sources));
+
+  final AiroFailoverPolicy policy;
+  AiroFailoverSessionState _state;
+
+  AiroFailoverSessionState get state => _state;
+
+  AiroFailoverSource? start({String? preferredSourceId}) {
+    final source = _sourceById(preferredSourceId) ?? _firstAvailableSource();
+    if (source == null) return null;
+    _state = _state.copyWith(currentSourceId: source.sourceId);
+    return source;
+  }
+
+  AiroFailoverDecision recordPlaybackError(String sourceId) {
+    return _failCurrentSource(
+      sourceId: sourceId,
+      trigger: AiroFailoverTrigger.playbackError,
+    );
+  }
+
+  AiroFailoverDecision recordBuffering({
+    required String sourceId,
+    required Duration duration,
+  }) {
+    if (!policy.shouldFailoverForStall(duration)) {
+      return AiroFailoverDecision(
+        code: AiroFailoverDecisionCode.ignored,
+        trigger: AiroFailoverTrigger.stall,
+        state: _state,
+        failedSourceId: sourceId,
+      );
+    }
+    return _failCurrentSource(
+      sourceId: sourceId,
+      trigger: AiroFailoverTrigger.stall,
+    );
+  }
+
+  AiroFailoverDecision _failCurrentSource({
+    required String sourceId,
+    required AiroFailoverTrigger trigger,
+  }) {
+    final failed = {..._state.failedSourceIds, sourceId};
+    final downgradedSources = [
+      for (final source in _state.sources)
+        if (source.sourceId == sourceId)
+          source.copyWith(health: AiroFailoverSourceHealth.failed)
+        else
+          source,
+    ];
+    _state = AiroFailoverSessionState(
+      sources: downgradedSources,
+      currentSourceId: _state.currentSourceId,
+      failedSourceIds: failed,
+    );
+
+    final next = _firstAvailableSource(excluding: sourceId);
+    if (next == null) {
+      return AiroFailoverDecision(
+        code: AiroFailoverDecisionCode.exhausted,
+        trigger: trigger,
+        state: _state,
+        failedSourceId: sourceId,
+      );
+    }
+
+    _state = _state.copyWith(currentSourceId: next.sourceId);
+    return AiroFailoverDecision(
+      code: AiroFailoverDecisionCode.switched,
+      trigger: trigger,
+      state: _state,
+      nextSource: next,
+      failedSourceId: sourceId,
+    );
+  }
+
+  AiroFailoverSource? _firstAvailableSource({String? excluding}) {
+    for (final source in policy.rankSources(_state.sources)) {
+      if (source.sourceId == excluding) continue;
+      if (_state.failedSourceIds.contains(source.sourceId)) continue;
+      if (source.health == AiroFailoverSourceHealth.failed) continue;
+      return source;
+    }
+    return null;
+  }
+
+  AiroFailoverSource? _sourceById(String? sourceId) {
+    if (sourceId == null) return null;
+    for (final source in _state.sources) {
+      if (source.sourceId == sourceId) return source;
+    }
+    return null;
+  }
+}

--- a/packages/platform_player/test/multi_source_failover_test.dart
+++ b/packages/platform_player/test/multi_source_failover_test.dart
@@ -1,0 +1,116 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:platform_player/platform_player.dart';
+
+void main() {
+  group('AiroMultiSourceFailoverController', () {
+    test('ranks local last-worked source ahead of global health', () {
+      final controller = AiroMultiSourceFailoverController(
+        sources: [
+          _source(
+            'primary',
+            health: AiroFailoverSourceHealth.healthy,
+            resolutionHeight: 1080,
+            rank: 0,
+          ),
+          _source(
+            'local',
+            health: AiroFailoverSourceHealth.degraded,
+            resolutionHeight: 720,
+            rank: 1,
+            lastWorkedHere: true,
+          ),
+        ],
+      );
+
+      final selected = controller.start();
+
+      expect(selected?.sourceId, 'local');
+      expect(controller.state.currentSourceId, 'local');
+    });
+
+    test('switches to next ranked source on playback error', () {
+      final controller = AiroMultiSourceFailoverController(
+        sources: [
+          _source('primary', health: AiroFailoverSourceHealth.healthy),
+          _source('backup', rank: 1),
+        ],
+      );
+
+      expect(controller.start()?.sourceId, 'primary');
+      final decision = controller.recordPlaybackError('primary');
+
+      expect(decision.code, AiroFailoverDecisionCode.switched);
+      expect(decision.nextSource?.sourceId, 'backup');
+      expect(decision.uiStatus, 'switching_source_2/2');
+      expect(controller.state.failedSourceIds, contains('primary'));
+    });
+
+    test('uses configurable stall threshold before failover', () {
+      final controller = AiroMultiSourceFailoverController(
+        policy: const AiroFailoverPolicy(stallThreshold: Duration(seconds: 3)),
+        sources: [_source('primary'), _source('backup', rank: 1)],
+      )..start();
+
+      final ignored = controller.recordBuffering(
+        sourceId: 'primary',
+        duration: const Duration(seconds: 2),
+      );
+      final switched = controller.recordBuffering(
+        sourceId: 'primary',
+        duration: const Duration(seconds: 3),
+      );
+
+      expect(ignored.code, AiroFailoverDecisionCode.ignored);
+      expect(switched.code, AiroFailoverDecisionCode.switched);
+      expect(switched.nextSource?.sourceId, 'backup');
+    });
+
+    test('returns exhausted when every source has failed', () {
+      final controller = AiroMultiSourceFailoverController(
+        sources: [_source('primary'), _source('backup', rank: 1)],
+      )..start();
+
+      expect(
+        controller.recordPlaybackError('primary').code,
+        AiroFailoverDecisionCode.switched,
+      );
+      final exhausted = controller.recordPlaybackError('backup');
+
+      expect(exhausted.code, AiroFailoverDecisionCode.exhausted);
+      expect(exhausted.shouldSwitch, isFalse);
+      expect(exhausted.uiStatus, 'exhausted');
+    });
+
+    test('diagnostics do not expose source handles', () {
+      final source = _source('primary', handle: 'private-source-handle');
+      final decision = AiroMultiSourceFailoverController(
+        sources: [source, _source('backup', rank: 1)],
+      )..start();
+
+      final switched = decision.recordPlaybackError('primary');
+
+      expect(source.toString(), isNot(contains('private-source-handle')));
+      expect(switched.toString(), isNot(contains('private-source-handle')));
+      expect(source.toString(), contains('sourceHandle: redacted'));
+    });
+  });
+}
+
+AiroFailoverSource _source(
+  String id, {
+  int rank = 0,
+  String handle = 'source-handle',
+  AiroFailoverSourceHealth health = AiroFailoverSourceHealth.unknown,
+  int? resolutionHeight,
+  bool lastWorkedHere = false,
+}) {
+  return AiroFailoverSource(
+    sourceId: id,
+    sourceHandle: AiroPlaybackSourceHandle.redacted('$handle-$id'),
+    canonicalChannelId: 'channel-news',
+    rank: rank,
+    health: health,
+    resolutionHeight: resolutionHeight,
+    lastWorkedHere: lastWorkedHere,
+  );
+}


### PR DESCRIPTION
# Summary

This PR introduces framework contracts for the Airo Pro v2 intelligence milestone.
Goal: provide the public/platform layer needed by the private pro overlay for EPG reminders, Sports Desk event joins, and multi-source playback failover.

Core outcome:

* Compact EPG programmes can carry optional event IDs and kind flags while preserving existing snapshot compatibility.
* EPG reminders can be reconciled against refreshed guide snapshots so event reminders reschedule when carriage changes.
* Sports Desk rows can resolve fixture event IDs to current EPG channel/program windows with deterministic unresolved fallback.
* Playback failover can rank duplicate canonical-channel sources, switch on errors/stalls, and report exhaustion without exposing raw stream URLs.

# Changes

### Code

* Added:
  * `platform_epg` event resolver, reminder reconciler, and Sports Desk row contracts.
  * `platform_player` multi-source failover policy/controller contracts.
* Updated:
  * compact EPG snapshot codec to round-trip optional `eventId` and `kind`.
  * package exports for the new contracts.

### Logic

* Event reminders resolve by `eventId` first, then reconcile schedule commands from the latest compact EPG snapshot.
* Missing guide/event matches produce deterministic unresolved states rather than blocking guide or playback UI.
* Failover prefers locally last-worked sources, then health, resolution, and rank.
* Stall threshold is configurable and source exhaustion produces a reportable non-switch decision.

# API Changes

* Added optional fields to `CompactEpgProgram`:
  * `eventId`
  * `kind`
* Added additive exports from `platform_epg` and `platform_player`.

# Risks

* This is a framework-contract slice only. It does not add private `packages_pro` UI modules, server nightly jobs, Android reboot receivers, real local notification adapters, or playback engine wiring.
* Cross-repo milestone issues should stay open until private overlay/server/device acceptance evidence exists.

Rollback plan:

* Revert this commit; changes are additive and do not alter existing public method signatures.

# Testing

* `flutter test` in `packages/platform_epg`
* `flutter test` in `packages/platform_player`
* `flutter analyze` in `packages/platform_epg`
* `flutter analyze` in `packages/platform_player`
* `git diff --check`

# Related Issues

Refs DevelopersCoffee/airo-pro#6
Refs DevelopersCoffee/airo-pro#7
Refs DevelopersCoffee/airo-pro#9
Notes DevelopersCoffee/airo-pro#8 remains blocked by TMDB commercial-use approval and attribution evidence.
