### PR TITLE
style(app): dart format to clear CI formatting gate

### DIFF
--- a/app/lib/features/agent_chat/presentation/screens/profile_screen.dart
+++ b/app/lib/features/agent_chat/presentation/screens/profile_screen.dart
@@ -424,7 +424,8 @@ class _AIPreferencesSection extends ConsumerWidget {
                 onTap: () {
                   Navigator.of(context).push(
                     MaterialPageRoute(
-                      builder: (context) => const IntelligentModelManagerScreen(),
+                      builder: (context) =>
+                          const IntelligentModelManagerScreen(),
                     ),
                   );
                 },

--- a/app/lib/features/media_hub/application/providers/discovery_provider.dart
+++ b/app/lib/features/media_hub/application/providers/discovery_provider.dart
@@ -38,9 +38,15 @@ class DiscoveryNotifier extends AsyncNotifier<DiscoveryState> {
 
   @override
   FutureOr<DiscoveryState> build() async {
-    final items = await ref.watch(mediaHubDiscoverySourceProvider(_mode).future);
+    final items = await ref.watch(
+      mediaHubDiscoverySourceProvider(_mode).future,
+    );
     final pageSize = ref.watch(mediaHubDiscoveryPageSizeProvider);
-    return DiscoveryState.initial(mode: _mode, items: items, pageSize: pageSize);
+    return DiscoveryState.initial(
+      mode: _mode,
+      items: items,
+      pageSize: pageSize,
+    );
   }
 
   void setSearchQuery(String query) {

--- a/app/lib/features/settings/presentation/intelligent_model_manager_provider.dart
+++ b/app/lib/features/settings/presentation/intelligent_model_manager_provider.dart
@@ -8,20 +8,20 @@ final modelStorageManagerProvider = Provider<ModelStorageManager>((ref) {
 });
 
 /// Provider for [IntelligentModelManager].
-final intelligentModelManagerProvider = Provider<IntelligentModelManager>((ref) {
+final intelligentModelManagerProvider = Provider<IntelligentModelManager>((
+  ref,
+) {
   final storageManager = ref.watch(modelStorageManagerProvider);
   final registry = ref.watch(modelRegistryProvider);
   final downloadService = ref.watch(modelDownloadServiceProvider);
 
-  return IntelligentModelManager(
-    storageManager,
-    registry,
-    downloadService,
-  );
+  return IntelligentModelManager(storageManager, registry, downloadService);
 });
 
 /// Rebuilding provider of the [ModelEntry] list, reacting to registry and download changes.
-final intelligentModelsListProvider = FutureProvider<List<ModelEntry>>((ref) async {
+final intelligentModelsListProvider = FutureProvider<List<ModelEntry>>((
+  ref,
+) async {
   final manager = ref.watch(intelligentModelManagerProvider);
   // Rebuild the list if the model registry changes.
   ref.watch(modelRegistryEventsProvider);

--- a/app/lib/features/settings/presentation/screens/intelligent_model_manager_screen.dart
+++ b/app/lib/features/settings/presentation/screens/intelligent_model_manager_screen.dart
@@ -124,7 +124,7 @@ class IntelligentModelManagerScreen extends ConsumerWidget {
                       color: theme.colorScheme.primary.withOpacity(0.15),
                       blurRadius: 16,
                       spreadRadius: 2,
-                    )
+                    ),
                   ]
                 : [],
           ),
@@ -158,7 +158,9 @@ class IntelligentModelManagerScreen extends ConsumerWidget {
                                 ? 'By ${modelInfo.author}'
                                 : 'Local Model',
                             style: theme.textTheme.bodySmall?.copyWith(
-                              color: theme.colorScheme.onSurface.withOpacity(0.6),
+                              color: theme.colorScheme.onSurface.withOpacity(
+                                0.6,
+                              ),
                             ),
                           ),
                         ],
@@ -171,7 +173,12 @@ class IntelligentModelManagerScreen extends ConsumerWidget {
                         icon: const Icon(Icons.delete_outline),
                         color: theme.colorScheme.error,
                         tooltip: 'Delete Model',
-                        onPressed: () => _showDeleteConfirmation(context, ref, model, modelInfo),
+                        onPressed: () => _showDeleteConfirmation(
+                          context,
+                          ref,
+                          model,
+                          modelInfo,
+                        ),
                       ),
                   ],
                 ),
@@ -186,7 +193,12 @@ class IntelligentModelManagerScreen extends ConsumerWidget {
                 _buildModelMetrics(context, modelInfo),
                 const SizedBox(height: 16),
                 if (isDownloading && downloadProgress != null)
-                  _buildDownloadProgress(context, ref, modelInfo, downloadProgress)
+                  _buildDownloadProgress(
+                    context,
+                    ref,
+                    modelInfo,
+                    downloadProgress,
+                  )
                 else
                   _buildActionRow(context, ref, model, modelInfo, isActive),
               ],
@@ -369,7 +381,9 @@ class IntelligentModelManagerScreen extends ConsumerWidget {
             ),
             TextButton.icon(
               onPressed: () {
-                ref.read(activeDownloadsProvider.notifier).cancelDownload(model.id);
+                ref
+                    .read(activeDownloadsProvider.notifier)
+                    .cancelDownload(model.id);
               },
               icon: const Icon(Icons.cancel_outlined, size: 16),
               label: const Text('Cancel'),
@@ -444,7 +458,9 @@ class IntelligentModelManagerScreen extends ConsumerWidget {
             onPressed: () async {
               Navigator.of(context).pop();
               // Delete model
-              await ref.read(intelligentModelManagerProvider).deleteModel(model.id);
+              await ref
+                  .read(intelligentModelManagerProvider)
+                  .deleteModel(model.id);
               // Clear selections if deleted model was active
               await clearOfflineModelSelections(ref, modelInfo);
               // Refresh model list

--- a/app/lib/features/settings/presentation/tv/tv_playback_section.dart
+++ b/app/lib/features/settings/presentation/tv/tv_playback_section.dart
@@ -40,11 +40,13 @@ class TvPlaybackSection extends ConsumerWidget {
                 children: [
                   Text(
                     label,
-                    style: TextStyle(color: colorScheme.onSurface, fontSize: 16),
+                    style: TextStyle(
+                      color: colorScheme.onSurface,
+                      fontSize: 16,
+                    ),
                   ),
                   const Spacer(),
-                  if (isSelected)
-                    Icon(Icons.check, color: colorScheme.primary),
+                  if (isSelected) Icon(Icons.check, color: colorScheme.primary),
                 ],
               ),
             ),

--- a/app/lib/features/settings/presentation/tv/tv_settings_screen.dart
+++ b/app/lib/features/settings/presentation/tv/tv_settings_screen.dart
@@ -71,7 +71,9 @@ class _TvSettingsScreenState extends ConsumerState<TvSettingsScreen> {
                                   child: Text(
                                     label,
                                     overflow: TextOverflow.ellipsis,
-                                    style: TextStyle(color: colorScheme.onSurface),
+                                    style: TextStyle(
+                                      color: colorScheme.onSurface,
+                                    ),
                                   ),
                                 ),
                               ],

--- a/app/lib/features/settings/presentation/tv/tv_source_management_section.dart
+++ b/app/lib/features/settings/presentation/tv/tv_source_management_section.dart
@@ -97,7 +97,8 @@ class _TvSourceManagementSectionState
       return;
     }
 
-    if (_kind == ContentSourceKind.xtream || _kind == ContentSourceKind.jellyfin) {
+    if (_kind == ContentSourceKind.xtream ||
+        _kind == ContentSourceKind.jellyfin) {
       final username = _usernameController.text.trim();
       final password = _passwordController.text;
       if (username.isEmpty || password.isEmpty) {

--- a/app/lib/features/settings/presentation/tv/tv_theme_section.dart
+++ b/app/lib/features/settings/presentation/tv/tv_theme_section.dart
@@ -40,11 +40,13 @@ class TvThemeSection extends ConsumerWidget {
                 children: [
                   Text(
                     definition.name,
-                    style: TextStyle(color: colorScheme.onSurface, fontSize: 16),
+                    style: TextStyle(
+                      color: colorScheme.onSurface,
+                      fontSize: 16,
+                    ),
                   ),
                   const Spacer(),
-                  if (isSelected)
-                    Icon(Icons.check, color: colorScheme.primary),
+                  if (isSelected) Icon(Icons.check, color: colorScheme.primary),
                 ],
               ),
             ),

--- a/app/lib/main_tv.dart
+++ b/app/lib/main_tv.dart
@@ -98,7 +98,9 @@ void main() async {
         mutableXmltvCompactEpgRepositoryProvider.overrideWithValue(
           mutableXmltvRepository,
         ),
-        secureStoreProvider.overrideWithValue(SecureStoreFactory.createSecure()),
+        secureStoreProvider.overrideWithValue(
+          SecureStoreFactory.createSecure(),
+        ),
         realIptvCastControllerOverride(),
         ...FeatureRegistry.allProviderOverrides,
       ],

--- a/app/test/core/app/tv_shell_test.dart
+++ b/app/test/core/app/tv_shell_test.dart
@@ -18,9 +18,7 @@ void main() {
 
       SharedPreferences.setMockInitialValues({});
       final prefs = await SharedPreferences.getInstance();
-      final router = TvRouter.createRouter(
-        initialLocation: TvRouteNames.live,
-      );
+      final router = TvRouter.createRouter(initialLocation: TvRouteNames.live);
 
       await tester.pumpWidget(
         ProviderScope(

--- a/app/test/core/cast/cast_http_proxy_test.dart
+++ b/app/test/core/cast/cast_http_proxy_test.dart
@@ -106,45 +106,42 @@ void main() {
   // this typically reports >200 MB/s; on real Cast sessions the upstream
   // fetch is the bottleneck, not the local relay.
   // -----------------------------------------------------------------------
-  test(
-    'throughput benchmark: proxy 10 MB and verify byte counter',
-    () async {
-      final segmentUrl = Uri.parse(
-        'http://${origin.address.address}:${origin.port}/big_segment.ts',
-      );
-      final proxied = proxy.proxiedUrl(segmentUrl);
-      final client = HttpClient();
+  test('throughput benchmark: proxy 10 MB and verify byte counter', () async {
+    final segmentUrl = Uri.parse(
+      'http://${origin.address.address}:${origin.port}/big_segment.ts',
+    );
+    final proxied = proxy.proxiedUrl(segmentUrl);
+    final client = HttpClient();
 
-      const iterations = 10;
-      final stopwatch = Stopwatch()..start();
+    const iterations = 10;
+    final stopwatch = Stopwatch()..start();
 
-      for (var i = 0; i < iterations; i++) {
-        final response = await (await client.getUrl(proxied)).close();
-        // Drain the body to ensure the proxy actually forwards all bytes.
-        await response.drain<void>();
-      }
+    for (var i = 0; i < iterations; i++) {
+      final response = await (await client.getUrl(proxied)).close();
+      // Drain the body to ensure the proxy actually forwards all bytes.
+      await response.drain<void>();
+    }
 
-      stopwatch.stop();
-      final totalBytes = bigPayload.length * iterations;
-      final seconds = stopwatch.elapsedMicroseconds / 1e6;
-      final mbPerSec = totalBytes / (1024 * 1024) / seconds;
+    stopwatch.stop();
+    final totalBytes = bigPayload.length * iterations;
+    final seconds = stopwatch.elapsedMicroseconds / 1e6;
+    final mbPerSec = totalBytes / (1024 * 1024) / seconds;
 
-      // The proxy must have counted every forwarded byte.
-      expect(proxy.totalBytesForwarded, totalBytes);
+    // The proxy must have counted every forwarded byte.
+    expect(proxy.totalBytesForwarded, totalBytes);
 
-      // Sanity: even on slow CI, loopback throughput should exceed 1 MB/s.
-      // On real hardware this is typically >200 MB/s.
-      expect(mbPerSec, greaterThan(1.0));
+    // Sanity: even on slow CI, loopback throughput should exceed 1 MB/s.
+    // On real hardware this is typically >200 MB/s.
+    expect(mbPerSec, greaterThan(1.0));
 
-      // Print for manual inspection in test output.
-      // ignore: avoid_print
-      print(
-        '[CastProxy benchmark] ${(totalBytes / (1024 * 1024)).toStringAsFixed(1)} MB '
-        'in ${seconds.toStringAsFixed(3)}s = '
-        '${mbPerSec.toStringAsFixed(1)} MB/s',
-      );
+    // Print for manual inspection in test output.
+    // ignore: avoid_print
+    print(
+      '[CastProxy benchmark] ${(totalBytes / (1024 * 1024)).toStringAsFixed(1)} MB '
+      'in ${seconds.toStringAsFixed(3)}s = '
+      '${mbPerSec.toStringAsFixed(1)} MB/s',
+    );
 
-      client.close(force: true);
-    },
-  );
+    client.close(force: true);
+  });
 }

--- a/app/test/features/settings/presentation/tv/tv_playback_section_test.dart
+++ b/app/test/features/settings/presentation/tv/tv_playback_section_test.dart
@@ -49,7 +49,10 @@ void main() {
     );
     await tester.pump();
 
-    expect(container.read(videoAspectRatioProvider), AiroPlaybackViewFit.contain);
+    expect(
+      container.read(videoAspectRatioProvider),
+      AiroPlaybackViewFit.contain,
+    );
 
     await tester.tap(find.text('Fill screen (cropped)'));
     await tester.pump();

--- a/app/test/main_tv_debug_playlist_test.dart
+++ b/app/test/main_tv_debug_playlist_test.dart
@@ -170,87 +170,79 @@ https://cdn.example.com/live/news.m3u8
     },
   );
 
-  test(
-    'createTvCompactEpgRepository delegates to the provided fallback when '
-    'no snapshot is cached',
-    () async {
-      final supportDir = await Directory.systemTemp.createTemp(
-        'airo_tv_epg_fallback_',
-      );
-      addTearDown(() async {
-        if (await supportDir.exists()) {
-          await supportDir.delete(recursive: true);
-        }
-      });
-      final repository = createTvCompactEpgRepository(
-        supportDirectoryProvider: () async => supportDir,
-        fallback: _FakeFallbackCompactEpgRepository(),
-      );
-      final now = DateTime.utc(2026, 7, 15, 9, 30);
+  test('createTvCompactEpgRepository delegates to the provided fallback when '
+      'no snapshot is cached', () async {
+    final supportDir = await Directory.systemTemp.createTemp(
+      'airo_tv_epg_fallback_',
+    );
+    addTearDown(() async {
+      if (await supportDir.exists()) {
+        await supportDir.delete(recursive: true);
+      }
+    });
+    final repository = createTvCompactEpgRepository(
+      supportDirectoryProvider: () async => supportDir,
+      fallback: _FakeFallbackCompactEpgRepository(),
+    );
+    final now = DateTime.utc(2026, 7, 15, 9, 30);
 
-      final result = await repository.loadCurrentNext(
-        channelIds: const ['news-1'],
-        now: now,
-      );
+    final result = await repository.loadCurrentNext(
+      channelIds: const ['news-1'],
+      now: now,
+    );
 
-      expect(
-        result.entryForChannel('news-1')?.current?.title,
-        'Fallback Bulletin',
-      );
-    },
-  );
+    expect(
+      result.entryForChannel('news-1')?.current?.title,
+      'Fallback Bulletin',
+    );
+  });
 
-  test(
-    'mutableXmltvCompactEpgRepositoryProvider resolves to the same instance '
-    "main() passes as createTvCompactEpgRepository's fallback",
-    () async {
-      // Mirrors the ProviderScope overrides main() wires up: a single
-      // MutableXmltvCompactEpgRepository must back both the guide's EPG
-      // fallback (compactEpgRepositoryProvider) and the manual-refresh path
-      // (mutableXmltvCompactEpgRepositoryProvider), or "Save & Refresh"
-      // silently writes into an orphan instance the guide never reads.
-      final supportDir = await Directory.systemTemp.createTemp(
-        'airo_tv_epg_shared_instance_',
-      );
-      addTearDown(() async {
-        if (await supportDir.exists()) {
-          await supportDir.delete(recursive: true);
-        }
-      });
-      final mutableXmltvRepository = MutableXmltvCompactEpgRepository();
-      final compactEpgRepository = createTvCompactEpgRepository(
-        supportDirectoryProvider: () async => supportDir,
-        fallback: mutableXmltvRepository,
-      );
+  test('mutableXmltvCompactEpgRepositoryProvider resolves to the same instance '
+      "main() passes as createTvCompactEpgRepository's fallback", () async {
+    // Mirrors the ProviderScope overrides main() wires up: a single
+    // MutableXmltvCompactEpgRepository must back both the guide's EPG
+    // fallback (compactEpgRepositoryProvider) and the manual-refresh path
+    // (mutableXmltvCompactEpgRepositoryProvider), or "Save & Refresh"
+    // silently writes into an orphan instance the guide never reads.
+    final supportDir = await Directory.systemTemp.createTemp(
+      'airo_tv_epg_shared_instance_',
+    );
+    addTearDown(() async {
+      if (await supportDir.exists()) {
+        await supportDir.delete(recursive: true);
+      }
+    });
+    final mutableXmltvRepository = MutableXmltvCompactEpgRepository();
+    final compactEpgRepository = createTvCompactEpgRepository(
+      supportDirectoryProvider: () async => supportDir,
+      fallback: mutableXmltvRepository,
+    );
 
-      final container = ProviderContainer(
-        overrides: [
-          compactEpgRepositoryProvider.overrideWithValue(
-            compactEpgRepository,
-          ),
-          mutableXmltvCompactEpgRepositoryProvider.overrideWithValue(
-            mutableXmltvRepository,
-          ),
-        ],
-      );
-      addTearDown(container.dispose);
-
-      expect(
-        identical(
-          container.read(mutableXmltvCompactEpgRepositoryProvider),
+    final container = ProviderContainer(
+      overrides: [
+        compactEpgRepositoryProvider.overrideWithValue(compactEpgRepository),
+        mutableXmltvCompactEpgRepositoryProvider.overrideWithValue(
           mutableXmltvRepository,
         ),
-        isTrue,
-      );
-      expect(
-        identical(
-          container.read(compactEpgRepositoryProvider),
-          compactEpgRepository,
-        ),
-        isTrue,
-      );
-    },
-  );
+      ],
+    );
+    addTearDown(container.dispose);
+
+    expect(
+      identical(
+        container.read(mutableXmltvCompactEpgRepositoryProvider),
+        mutableXmltvRepository,
+      ),
+      isTrue,
+    );
+    expect(
+      identical(
+        container.read(compactEpgRepositoryProvider),
+        compactEpgRepository,
+      ),
+      isTrue,
+    );
+  });
 
   test('warms compact EPG snapshot from XMLTV using channel aliases', () async {
     SharedPreferences.setMockInitialValues({});
@@ -418,15 +410,13 @@ https://cdn.example.com/live/news.m3u8
     },
   );
 
-  test(
-    'refreshTvConfiguredXmltvSource refreshes an already-configured XMLTV '
-    'source',
-    () async {
-      SharedPreferences.setMockInitialValues({});
-      final prefs = await SharedPreferences.getInstance();
-      final repository = MutableXmltvCompactEpgRepository();
-      final sourceStore = XmltvSourceStore(PreferencesStore(prefs));
-      final server = await _xmltvServer('''
+  test('refreshTvConfiguredXmltvSource refreshes an already-configured XMLTV '
+      'source', () async {
+    SharedPreferences.setMockInitialValues({});
+    final prefs = await SharedPreferences.getInstance();
+    final repository = MutableXmltvCompactEpgRepository();
+    final sourceStore = XmltvSourceStore(PreferencesStore(prefs));
+    final server = await _xmltvServer('''
 <tv>
   <channel id="chan-1"><display-name>Channel 1</display-name></channel>
   <programme channel="chan-1" start="20260715090000 +0000" stop="20260715100000 +0000">
@@ -434,39 +424,41 @@ https://cdn.example.com/live/news.m3u8
   </programme>
 </tv>
 ''');
-      final downloadDir = await Directory.systemTemp.createTemp(
-        'airo-tv-xmltv-source-refresh-',
-      );
-      addTearDown(() async {
-        if (await downloadDir.exists()) {
-          await downloadDir.delete(recursive: true);
-        }
-      });
-      await sourceStore.save(
-        XmltvSourceConfig(url: _serverUrl(server, '/guide.xml')),
-      );
-
-      try {
-        await refreshTvConfiguredXmltvSource(
-          prefs,
-          repository: repository,
-          downloadDirectoryProvider: () async => downloadDir,
-        );
-
-        final now = DateTime.utc(2026, 7, 15, 9, 30);
-        final slice = await repository.loadCurrentNext(
-          channelIds: const ['chan-1'],
-          now: now,
-        );
-        expect(slice.entryForChannel('chan-1')?.current?.title, 'Morning Bulletin');
-
-        final config = await sourceStore.load();
-        expect(config?.lastRefreshedAt, isNotNull);
-      } finally {
-        await server.close(force: true);
+    final downloadDir = await Directory.systemTemp.createTemp(
+      'airo-tv-xmltv-source-refresh-',
+    );
+    addTearDown(() async {
+      if (await downloadDir.exists()) {
+        await downloadDir.delete(recursive: true);
       }
-    },
-  );
+    });
+    await sourceStore.save(
+      XmltvSourceConfig(url: _serverUrl(server, '/guide.xml')),
+    );
+
+    try {
+      await refreshTvConfiguredXmltvSource(
+        prefs,
+        repository: repository,
+        downloadDirectoryProvider: () async => downloadDir,
+      );
+
+      final now = DateTime.utc(2026, 7, 15, 9, 30);
+      final slice = await repository.loadCurrentNext(
+        channelIds: const ['chan-1'],
+        now: now,
+      );
+      expect(
+        slice.entryForChannel('chan-1')?.current?.title,
+        'Morning Bulletin',
+      );
+
+      final config = await sourceStore.load();
+      expect(config?.lastRefreshedAt, isNotNull);
+    } finally {
+      await server.close(force: true);
+    }
+  });
 
   test('schedules configured XMLTV source refresh after frame', () async {
     SharedPreferences.setMockInitialValues({});


### PR DESCRIPTION
## What

Runs `dart format` (Flutter 3.44.4) across `app/lib` and `app/test` so the `analyze` / `code-quality` CI checks' `dart format --set-exit-if-changed` gate passes.

## Why

That gate is currently **red on `main`** — a handful of files accumulated unformatted (some pre-existing, some carried through recent merges), e.g. `main_tv.dart`, the TV settings sections, `intelligent_model_manager_*`, `discovery_provider`, `profile_screen`, and a couple of tests. Every open/future PR shows a red `analyze` + `code-quality` until this is cleared.

## Scope

- **13 files**, `app/lib` + `app/test` only.
- **Formatting only** — whitespace, trailing commas, line reflow. No logic changes.
- Verified clean locally: `dart format --set-exit-if-changed` now reports `0 changed` on Flutter 3.44.4 (matches CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)