### PR TITLE
test(platform_playlist): Stalker + Jellyfin health integration tests (CV-012 slice-2b)

### DIFF
--- a/packages/platform_playlist/test/jellyfin/jellyfin_client_test.dart
+++ b/packages/platform_playlist/test/jellyfin/jellyfin_client_test.dart
@@ -52,11 +52,8 @@ void main() {
     () async {
       final dio = Dio(BaseOptions(baseUrl: 'https://jellyfin.example.com'));
       dio.httpClientAdapter = FakeHttpClientAdapter({
-        authUrl: (options) => Response(
-          requestOptions: options,
-          statusCode: 401,
-          data: {},
-        ),
+        authUrl: (options) =>
+            Response(requestOptions: options, statusCode: 401, data: {}),
       });
       final client = JellyfinClient(
         dio: dio,
@@ -144,6 +141,85 @@ void main() {
       expect(programs.single.endDate, DateTime.utc(2026, 7, 16, 18, 30, 0));
     },
   );
+
+  group('health tracking (CV-012 slice-2b)', () {
+    test('successful authenticate() records fetchSuccess sample', () async {
+      final dio = Dio();
+      dio.httpClientAdapter = FakeHttpClientAdapter({
+        authUrl: (options) => Response(
+          requestOptions: options,
+          statusCode: 200,
+          data: {
+            'AccessToken': 'jf-token',
+            'User': {'Id': 'user-1'},
+          },
+        ),
+      });
+      final tracker = ProviderHealthTracker();
+      final client = JellyfinClient(
+        dio: dio,
+        serverUrl: 'https://jellyfin.example.com',
+        username: 'alice',
+        password: 'hunter2',
+        healthTracker: tracker,
+        sourceId: 'jellyfin-1',
+      );
+
+      await client.authenticate();
+
+      final snap = tracker.snapshotFor('jellyfin-1');
+      expect(snap.totalSamples, 1);
+      expect(snap.healthClass, ProviderHealthClass.green);
+    });
+
+    test(
+      '401 on authenticate() records fetchFailure(auth) and rethrows',
+      () async {
+        final dio = Dio();
+        dio.httpClientAdapter = FakeHttpClientAdapter({
+          authUrl: (options) =>
+              Response(requestOptions: options, statusCode: 401),
+        });
+        final tracker = ProviderHealthTracker();
+        final client = JellyfinClient(
+          dio: dio,
+          serverUrl: 'https://jellyfin.example.com',
+          username: 'alice',
+          password: 'hunter2',
+          healthTracker: tracker,
+          sourceId: 'jellyfin-1',
+        );
+
+        await expectLater(client.authenticate(), throwsA(isA<DioException>()));
+
+        final snap = tracker.snapshotFor('jellyfin-1');
+        expect(snap.recentFailureCategory, ProviderHealthFailureCategory.auth);
+        expect(snap.failureRate, 1.0);
+      },
+    );
+
+    test('no tracker → no recording, existing behavior preserved', () async {
+      final dio = Dio();
+      dio.httpClientAdapter = FakeHttpClientAdapter({
+        authUrl: (options) => Response(
+          requestOptions: options,
+          statusCode: 200,
+          data: {
+            'AccessToken': 'jf-token',
+            'User': {'Id': 'user-1'},
+          },
+        ),
+      });
+      final client = JellyfinClient(
+        dio: dio,
+        serverUrl: 'https://jellyfin.example.com',
+        username: 'alice',
+        password: 'hunter2',
+      );
+      final result = await client.authenticate();
+      expect(result.accessToken, 'jf-token');
+    });
+  });
 
   test('streamUrl builds /Videos/{itemId}/stream with api_key', () {
     final client = JellyfinClient(

--- a/packages/platform_playlist/test/stalker/stalker_client_test.dart
+++ b/packages/platform_playlist/test/stalker/stalker_client_test.dart
@@ -19,7 +19,9 @@ void main() {
         return Response(
           requestOptions: options,
           statusCode: 200,
-          data: {'js': {'token': 'tok-123'}},
+          data: {
+            'js': {'token': 'tok-123'},
+          },
         );
       },
     });
@@ -94,7 +96,9 @@ void main() {
       portalUrl: (options) => Response(
         requestOptions: options,
         statusCode: 200,
-        data: {'js': {'cmd': 'https://stalker.example.com/stream/1.m3u8'}},
+        data: {
+          'js': {'cmd': 'https://stalker.example.com/stream/1.m3u8'},
+        },
       ),
     });
     final client = StalkerClient(
@@ -109,5 +113,78 @@ void main() {
     );
 
     expect(url, 'https://stalker.example.com/stream/1.m3u8');
+  });
+
+  group('health tracking (CV-012 slice-2b)', () {
+    test('successful handshake() records fetchSuccess sample', () async {
+      final dio = Dio();
+      dio.httpClientAdapter = FakeHttpClientAdapter({
+        portalUrl: (options) => Response(
+          requestOptions: options,
+          statusCode: 200,
+          data: {
+            'js': {'token': 'tok-1'},
+          },
+        ),
+      });
+      final tracker = ProviderHealthTracker();
+      final client = StalkerClient(
+        dio: dio,
+        serverUrl: 'https://stalker.example.com',
+        macAddress: 'AA:BB:CC:DD:EE:FF',
+        healthTracker: tracker,
+        sourceId: 'stalker-1',
+      );
+
+      await client.handshake();
+
+      final snap = tracker.snapshotFor('stalker-1');
+      expect(snap.totalSamples, 1);
+      expect(snap.healthClass, ProviderHealthClass.green);
+    });
+
+    test(
+      '401 on handshake() records fetchFailure(auth) and rethrows',
+      () async {
+        final dio = Dio();
+        dio.httpClientAdapter = FakeHttpClientAdapter({
+          portalUrl: (options) =>
+              Response(requestOptions: options, statusCode: 401),
+        });
+        final tracker = ProviderHealthTracker();
+        final client = StalkerClient(
+          dio: dio,
+          serverUrl: 'https://stalker.example.com',
+          macAddress: 'AA:BB:CC:DD:EE:FF',
+          healthTracker: tracker,
+          sourceId: 'stalker-1',
+        );
+
+        await expectLater(client.handshake(), throwsA(isA<DioException>()));
+
+        final snap = tracker.snapshotFor('stalker-1');
+        expect(snap.recentFailureCategory, ProviderHealthFailureCategory.auth);
+        expect(snap.failureRate, 1.0);
+      },
+    );
+
+    test('no tracker → no recording, existing behavior preserved', () async {
+      final dio = Dio();
+      dio.httpClientAdapter = FakeHttpClientAdapter({
+        portalUrl: (options) => Response(
+          requestOptions: options,
+          statusCode: 200,
+          data: {
+            'js': {'token': 'tok-1'},
+          },
+        ),
+      });
+      final client = StalkerClient(
+        dio: dio,
+        serverUrl: 'https://stalker.example.com',
+        macAddress: 'AA:BB:CC:DD:EE:FF',
+      );
+      expect(await client.handshake(), 'tok-1');
+    });
   });
 }


### PR DESCRIPTION
## Summary

Follow-up to [CV-012 slice-2 #857](https://github.com/DevelopersCoffee/airo/pull/857) which wired all three adapter clients but only shipped integration tests for Xtream. This lands the mirrored tests for Stalker and Jellyfin — same \`FakeHttpClientAdapter\` setup, three cases per client:

| Case | What it proves |
|---|---|
| **Success** | Real 200 response → \`fetchSuccess\` sample recorded, \`healthClass\` green |
| **401** | Auth failure → \`fetchFailure(auth)\` recorded, \`failureRate\` 1.0, \`DioException\` rethrown |
| **No tracker** | Optional \`healthTracker\` param omitted → recorder short-circuits, existing behavior preserved |

## Test plan

- [x] Full \`packages/platform_playlist\` suite → **81/81 pass** (was 75/75 on slice-2 — 6 new tests here).
- [x] \`dart format\` clean on touched files.

## Remaining CV-012 slice-2 tail

M3uPlaylistFetcher / M3UParserService health recording — lives outside \`platform_playlist\`, needs its own recon on where to inject \`tracker\` + \`sourceId\` (they're not owned by \`ContentSource\`-shaped callers today). Deferred to slice-2c.

Refs [#816](https://github.com/DevelopersCoffee/airo/issues/816).

🤖 Generated with [Claude Code](https://claude.com/claude-code)