### PR TITLE
feat(iptv): CV-001 slice 3 — structured diagnostic surface in the player UI

### DIFF
--- a/packages/feature_iptv/lib/presentation/widgets/playback_diagnostic_overlay.dart
+++ b/packages/feature_iptv/lib/presentation/widgets/playback_diagnostic_overlay.dart
@@ -1,0 +1,94 @@
+import 'package:flutter/material.dart';
+import 'package:platform_player/platform_player.dart';
+
+/// TV-safe playback failure/recovery overlay (CV-001 AUTO-003).
+///
+/// Renders the diagnostic's user-safe copy, reconnect progress for retryable
+/// failures, and — only when [showDetail] is set — the redacted technical
+/// detail line for the debug overlay.
+class PlaybackDiagnosticOverlay extends StatelessWidget {
+  const PlaybackDiagnosticOverlay({
+    super.key,
+    required this.diagnostic,
+    this.retryAttempt,
+    this.maxRetryAttempts,
+    this.showDetail = false,
+  });
+
+  final AiroPlaybackDiagnostic diagnostic;
+
+  /// 1-based attempt currently in flight, when a retry is scheduled.
+  final int? retryAttempt;
+
+  final int? maxRetryAttempts;
+
+  final bool showDetail;
+
+  bool get _isReconnecting => diagnostic.retryEligible && retryAttempt != null;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final detail = diagnostic.technicalDetail;
+
+    return Center(
+      child: ConstrainedBox(
+        constraints: const BoxConstraints(maxWidth: 560),
+        child: Padding(
+          padding: const EdgeInsets.all(24),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              if (_isReconnecting)
+                const SizedBox(
+                  width: 36,
+                  height: 36,
+                  child: CircularProgressIndicator(strokeWidth: 3),
+                )
+              else
+                Icon(
+                  diagnostic.severity == AiroPlaybackDiagnosticSeverity.fatal
+                      ? Icons.error_outline_rounded
+                      : Icons.wifi_tethering_error_rounded,
+                  size: 44,
+                  color: theme.colorScheme.error,
+                ),
+              const SizedBox(height: 16),
+              Text(
+                diagnostic.userMessage,
+                textAlign: TextAlign.center,
+                maxLines: 3,
+                overflow: TextOverflow.ellipsis,
+                style: theme.textTheme.titleMedium?.copyWith(
+                  color: Colors.white,
+                ),
+              ),
+              if (_isReconnecting && maxRetryAttempts != null) ...[
+                const SizedBox(height: 8),
+                Text(
+                  'Attempt $retryAttempt of $maxRetryAttempts',
+                  style: theme.textTheme.bodySmall?.copyWith(
+                    color: Colors.white70,
+                  ),
+                ),
+              ],
+              if (showDetail && detail != null) ...[
+                const SizedBox(height: 12),
+                Text(
+                  detail,
+                  textAlign: TextAlign.center,
+                  maxLines: 2,
+                  overflow: TextOverflow.ellipsis,
+                  style: theme.textTheme.bodySmall?.copyWith(
+                    color: Colors.white54,
+                    fontFamily: 'monospace',
+                  ),
+                ),
+              ],
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/packages/feature_iptv/lib/presentation/widgets/video_player_widget.dart
+++ b/packages/feature_iptv/lib/presentation/widgets/video_player_widget.dart
@@ -9,6 +9,7 @@ import 'package:wakelock_plus/wakelock_plus.dart';
 import '../../application/providers/iptv_providers.dart';
 import '../../application/providers/video_aspect_ratio_provider.dart';
 import '../../domain/wakelock_debouncer.dart';
+import 'playback_diagnostic_overlay.dart';
 import "package:platform_channels/platform_channels.dart";
 import "package:platform_player/platform_player.dart";
 import "package:platform_media/platform_media.dart";
@@ -244,6 +245,8 @@ class _VideoPlayerWidgetState extends ConsumerState<VideoPlayerWidget> {
                 )
               else if (state.playbackState == PlaybackState.loading)
                 _buildLoading()
+              else if (state.hasError && state.diagnostic != null)
+                _buildDiagnosticError(state)
               else
                 _buildPlaceholder(state),
 
@@ -382,6 +385,48 @@ class _VideoPlayerWidgetState extends ConsumerState<VideoPlayerWidget> {
             Text('Loading...', style: TextStyle(color: Colors.white)),
           ],
         ),
+      ),
+    );
+  }
+
+  /// CV-001 structured failure state: user-safe copy plus bounded-retry
+  /// progress from [StreamingState.diagnostic], with the legacy retry button.
+  Widget _buildDiagnosticError(StreamingState state) {
+    final diagnostic = state.diagnostic!;
+    return Container(
+      decoration: BoxDecoration(
+        gradient: LinearGradient(
+          begin: Alignment.topCenter,
+          end: Alignment.bottomCenter,
+          colors: [Colors.blueGrey.shade900, Colors.black87],
+        ),
+      ),
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          PlaybackDiagnosticOverlay(
+            diagnostic: diagnostic,
+            retryAttempt: state.retryCount > 0 ? state.retryCount : null,
+            maxRetryAttempts: 3,
+          ),
+          if (!diagnostic.retryEligible || state.retryCount == 0)
+            ElevatedButton.icon(
+              onPressed: () => ref.read(iptvStreamingServiceProvider).retry(),
+              icon: const Icon(Icons.refresh_rounded),
+              label: const Text('Try Again'),
+              style: ElevatedButton.styleFrom(
+                backgroundColor: Colors.blueGrey.shade700,
+                foregroundColor: Colors.white,
+                padding: const EdgeInsets.symmetric(
+                  horizontal: 24,
+                  vertical: 12,
+                ),
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(8),
+                ),
+              ),
+            ),
+        ],
       ),
     );
   }

--- a/packages/feature_iptv/test/iptv/presentation/widgets/playback_diagnostic_overlay_test.dart
+++ b/packages/feature_iptv/test/iptv/presentation/widgets/playback_diagnostic_overlay_test.dart
@@ -1,0 +1,87 @@
+import 'package:feature_iptv/presentation/widgets/playback_diagnostic_overlay.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:platform_player/platform_player.dart';
+
+void main() {
+  const stalled = AiroPlaybackDiagnostic(
+    code: AiroPlaybackDiagnosticCode.streamStalled,
+    severity: AiroPlaybackDiagnosticSeverity.recoverable,
+    retryEligible: true,
+    userMessage: 'Stream stalled. Reconnecting…',
+    technicalDetail: 'code=stream_stalled stalledMs=6000 source=http://host',
+  );
+
+  const authDenied = AiroPlaybackDiagnostic(
+    code: AiroPlaybackDiagnosticCode.providerAuthDenied,
+    severity: AiroPlaybackDiagnosticSeverity.fatal,
+    retryEligible: false,
+    userMessage:
+        'Your provider rejected this stream. Check your playlist credentials.',
+    technicalDetail: 'code=provider_auth_denied http=401 source=http://host',
+  );
+
+  Future<void> pump(
+    WidgetTester tester,
+    Widget child, {
+    Size size = const Size(1280, 720),
+  }) async {
+    tester.view.physicalSize = size;
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.reset);
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(backgroundColor: Colors.black, body: child),
+      ),
+    );
+  }
+
+  testWidgets('shows user-safe copy for a fatal diagnostic', (tester) async {
+    await pump(tester, const PlaybackDiagnosticOverlay(diagnostic: authDenied));
+
+    expect(
+      find.textContaining('provider rejected this stream'),
+      findsOneWidget,
+    );
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('shows reconnect progress for a retryable diagnostic', (
+    tester,
+  ) async {
+    await pump(
+      tester,
+      const PlaybackDiagnosticOverlay(
+        diagnostic: stalled,
+        retryAttempt: 2,
+        maxRetryAttempts: 3,
+      ),
+    );
+
+    expect(find.textContaining('Stream stalled'), findsOneWidget);
+    expect(find.textContaining('2 of 3'), findsOneWidget);
+  });
+
+  testWidgets('technical detail hidden by default, visible when enabled', (
+    tester,
+  ) async {
+    await pump(tester, const PlaybackDiagnosticOverlay(diagnostic: stalled));
+    expect(find.textContaining('stalledMs'), findsNothing);
+
+    await pump(
+      tester,
+      const PlaybackDiagnosticOverlay(diagnostic: stalled, showDetail: true),
+    );
+    expect(find.textContaining('stalledMs'), findsOneWidget);
+  });
+
+  testWidgets('does not overflow at TV size with long copy', (tester) async {
+    await pump(
+      tester,
+      const PlaybackDiagnosticOverlay(diagnostic: authDenied),
+      size: const Size(960, 540),
+    );
+
+    expect(tester.takeException(), isNull);
+  });
+}

--- a/packages/platform_player/lib/src/models/streaming_state.dart
+++ b/packages/platform_player/lib/src/models/streaming_state.dart
@@ -1,6 +1,8 @@
 import 'package:equatable/equatable.dart';
 import 'package:platform_channels/platform_channels.dart';
 
+import 'playback_recovery_models.dart';
+
 /// Network quality indicator
 enum NetworkQuality {
   excellent(4, 'Excellent'),
@@ -140,6 +142,10 @@ class StreamingState extends Equatable {
   final int retryCount;
   final DateTime? lastError;
 
+  /// Structured CV-001 diagnostic for the current failure, when one exists.
+  /// Preferred over [errorMessage] for user-facing copy.
+  final AiroPlaybackDiagnostic? diagnostic;
+
   // === Live DVR Properties (P0-1 to P0-4) ===
 
   /// Whether the current stream is a live stream (vs VOD)
@@ -180,6 +186,7 @@ class StreamingState extends Equatable {
     this.errorMessage,
     this.retryCount = 0,
     this.lastError,
+    this.diagnostic,
     // Live DVR defaults
     this.isLiveStream = false,
     this.liveEdge,
@@ -256,6 +263,8 @@ class StreamingState extends Equatable {
     String? errorMessage,
     int? retryCount,
     DateTime? lastError,
+    AiroPlaybackDiagnostic? diagnostic,
+    bool clearDiagnostic = false,
     // Live DVR properties
     bool? isLiveStream,
     Duration? liveEdge,
@@ -280,6 +289,7 @@ class StreamingState extends Equatable {
       errorMessage: errorMessage,
       retryCount: retryCount ?? this.retryCount,
       lastError: lastError ?? this.lastError,
+      diagnostic: clearDiagnostic ? null : (diagnostic ?? this.diagnostic),
       // Live DVR properties
       isLiveStream: isLiveStream ?? this.isLiveStream,
       liveEdge: liveEdge ?? this.liveEdge,
@@ -302,6 +312,7 @@ class StreamingState extends Equatable {
     volume,
     isMuted,
     errorMessage,
+    diagnostic,
     // Live DVR properties
     isLiveStream,
     liveEdge,

--- a/packages/platform_player/test/streaming_state_diagnostic_test.dart
+++ b/packages/platform_player/test/streaming_state_diagnostic_test.dart
@@ -1,0 +1,43 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:platform_player/platform_player.dart';
+
+void main() {
+  group('StreamingState.diagnostic', () {
+    const diagnostic = AiroPlaybackDiagnostic(
+      code: AiroPlaybackDiagnosticCode.streamStalled,
+      severity: AiroPlaybackDiagnosticSeverity.recoverable,
+      retryEligible: true,
+      userMessage: 'Stream stalled. Reconnecting…',
+    );
+
+    test('defaults to null and carries through copyWith', () {
+      const initial = StreamingState();
+      expect(initial.diagnostic, isNull);
+
+      final withDiagnostic = initial.copyWith(diagnostic: diagnostic);
+      expect(withDiagnostic.diagnostic, diagnostic);
+
+      final carried = withDiagnostic.copyWith(volume: 0.5);
+      expect(carried.diagnostic, diagnostic);
+    });
+
+    test('clearDiagnostic removes a stale diagnostic', () {
+      final withDiagnostic = const StreamingState().copyWith(
+        diagnostic: diagnostic,
+      );
+
+      final cleared = withDiagnostic.copyWith(clearDiagnostic: true);
+
+      expect(cleared.diagnostic, isNull);
+    });
+
+    test('participates in equality', () {
+      final a = const StreamingState().copyWith(diagnostic: diagnostic);
+      final b = const StreamingState().copyWith(diagnostic: diagnostic);
+      const c = StreamingState();
+
+      expect(a, b);
+      expect(a, isNot(c));
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Slice 3 of CV-001 (#805), building on the merged taxonomy/retry/session foundation (#855):

- **`StreamingState.diagnostic`** — optional `AiroPlaybackDiagnostic`, carried through `copyWith` with an explicit `clearDiagnostic` escape; preferred over raw `errorMessage` for user-facing copy.
- **`PlaybackDiagnosticOverlay`** (new, `feature_iptv`) — TV-safe failure/reconnect UI: user-safe message, "Attempt N of M" bounded-retry progress, redacted technical detail rendered only behind `showDetail` (AUTO-003).
- **`video_player_widget`** — renders the overlay whenever the state carries a diagnostic; legacy error card stays as fallback for diagnostic-less errors.

## Performance impact

One extra nullable field on `StreamingState`; overlay builds only in error states.

## Tests

- 3 new `StreamingState` tests (carry/clear/equality), 4 new overlay widget tests (fatal copy, reconnect progress, detail gating, no overflow at 960×540).
- platform_player 145/145, feature_iptv 226/226, format clean.

## Remaining for #805 (slice 4)

Streaming-service wiring: feed engine/HTTP failures through the mapper into `StreamingState.diagnostic`, drive `AiroPlaybackRetryStateMachine` + `AiroPlaybackSessionTracker` from the playback service.

Part of #805.

🤖 Generated with [Claude Code](https://claude.com/claude-code)