### PR TITLE
fix(platform_player): keep phone-media LAN server alive while receiver is paused

### DIFF
--- a/packages/platform_player/lib/src/models/playback_engine_models.dart
+++ b/packages/platform_player/lib/src/models/playback_engine_models.dart
@@ -278,9 +278,7 @@ List<AiroPlaybackTrackOption> externalSubtitleTracksFor(
       return AiroPlaybackTrackOption(
         id: '$kAiroExternalSubtitleTrackIdPrefix$i',
         kind: AiroPlaybackTrackKind.subtitle,
-        label: sub.label ??
-            sub.languageCode ??
-            'External subtitle ${i + 1}',
+        label: sub.label ?? sub.languageCode ?? 'External subtitle ${i + 1}',
         languageCode: sub.languageCode,
         isExternal: true,
       );

--- a/packages/platform_player/lib/src/services/phone_media_cast_handoff.dart
+++ b/packages/platform_player/lib/src/services/phone_media_cast_handoff.dart
@@ -109,6 +109,7 @@ class PhoneMediaCastHandoff {
     this.onSessionEvent,
     this._sessionTtl = const Duration(hours: 6),
     this._idleTimeout = const Duration(minutes: 2),
+    this._pauseKeepAliveInterval = const Duration(seconds: 30),
   });
 
   final AiroCastController _castController;
@@ -116,10 +117,16 @@ class PhoneMediaCastHandoff {
   final InternetAddress? _bindAddress;
   final Duration _sessionTtl;
   final Duration _idleTimeout;
+
+  /// How often to ping the file server's idle clock while the receiver is
+  /// paused. Must stay comfortably under [_idleTimeout], since a paused
+  /// receiver generates no HTTP traffic of its own.
+  final Duration _pauseKeepAliveInterval;
   final void Function(String event, Map<String, Object?> data)? onSessionEvent;
 
   PhoneMediaFileServer? _server;
   StreamSubscription<AiroCastSessionSnapshot>? _sessionSubscription;
+  Timer? _pauseKeepAliveTimer;
 
   bool get isServing => _server?.isRunning ?? false;
 
@@ -132,6 +139,7 @@ class PhoneMediaCastHandoff {
       return PhoneMediaHandoffUnsupported(reason: unsupportedReason);
     }
 
+    _cancelPauseKeepAlive();
     await _teardownServer();
 
     // Synchronous check: widget tests run in a fake-async zone where real
@@ -181,6 +189,7 @@ class PhoneMediaCastHandoff {
   Future<void> dispose() async {
     final subscription = _sessionSubscription;
     _sessionSubscription = null;
+    _cancelPauseKeepAlive();
     // Tear the server down first: stopServer cancels its lifecycle timer
     // synchronously, so no timer outlives a disposed widget tree.
     final teardown = _teardownServer();
@@ -194,14 +203,31 @@ class PhoneMediaCastHandoff {
       case AiroCastSessionPhase.disconnected:
       case AiroCastSessionPhase.failed:
       case AiroCastSessionPhase.idle:
+        _cancelPauseKeepAlive();
         unawaited(_teardownServer());
+      case AiroCastSessionPhase.paused:
+        _startPauseKeepAlive();
       case AiroCastSessionPhase.connecting:
       case AiroCastSessionPhase.connected:
       case AiroCastSessionPhase.loadingMedia:
       case AiroCastSessionPhase.playing:
-      case AiroCastSessionPhase.paused:
-        break;
+        _cancelPauseKeepAlive();
     }
+  }
+
+  // A paused receiver holds the session but sends no HTTP requests, so the
+  // file server's own idle-shutdown timer (driven by request traffic) would
+  // otherwise mistake "paused" for "abandoned" and kill the socket mid-pause.
+  void _startPauseKeepAlive() {
+    _pauseKeepAliveTimer ??= Timer.periodic(
+      _pauseKeepAliveInterval,
+      (_) => _server?.keepAlive(),
+    );
+  }
+
+  void _cancelPauseKeepAlive() {
+    _pauseKeepAliveTimer?.cancel();
+    _pauseKeepAliveTimer = null;
   }
 
   Future<void> _teardownServer() async {

--- a/packages/platform_player/lib/src/services/phone_media_file_server.dart
+++ b/packages/platform_player/lib/src/services/phone_media_file_server.dart
@@ -70,6 +70,15 @@ class PhoneMediaFileServer implements AiroTemporaryMobileServerController {
 
   bool get isRunning => _server != null;
 
+  /// Resets the idle clock without an HTTP request. A paused-but-connected
+  /// receiver generates no traffic, so [PhoneMediaCastHandoff] calls this on
+  /// a timer while paused; otherwise the idle-shutdown timer (CV-033) would
+  /// mistake "paused" for "abandoned" and tear the socket down mid-session.
+  void keepAlive() {
+    if (!isRunning) return;
+    _lastActivityAt = _now();
+  }
+
   /// True only for RFC1918 private ranges and loopback. Carrier-grade NAT
   /// (100.64/10), link-local, and public addresses are all rejected so the
   /// server can never bind or accept traffic outside the local network.

--- a/packages/platform_player/test/phone_media_cast_handoff_test.dart
+++ b/packages/platform_player/test/phone_media_cast_handoff_test.dart
@@ -145,6 +145,51 @@ void main() {
     expect(handoff.isServing, isFalse);
   });
 
+  test(
+    'pausing on the receiver keeps the server alive past the idle timeout',
+    () async {
+      final handoff = PhoneMediaCastHandoff(
+        castController: castController,
+        bindAddress: InternetAddress.loopbackIPv4,
+        idleTimeout: const Duration(milliseconds: 150),
+        pauseKeepAliveInterval: const Duration(milliseconds: 40),
+      );
+      await handoff.start(itemFor());
+      expect(handoff.isServing, isTrue);
+
+      await castController.pause();
+      // A paused receiver sends no HTTP traffic; without a keep-alive the
+      // file server's own idle timer would treat this as abandonment.
+      await Future<void>.delayed(const Duration(milliseconds: 400));
+      expect(handoff.isServing, isTrue);
+
+      await handoff.stopHandoff();
+    },
+  );
+
+  test(
+    'keep-alive stops once the receiver resumes playing or the session ends',
+    () async {
+      final handoff = PhoneMediaCastHandoff(
+        castController: castController,
+        bindAddress: InternetAddress.loopbackIPv4,
+        idleTimeout: const Duration(milliseconds: 150),
+        pauseKeepAliveInterval: const Duration(milliseconds: 40),
+      );
+      await handoff.start(itemFor());
+
+      await castController.pause();
+      await Future<void>.delayed(const Duration(milliseconds: 100));
+      await castController.play();
+      // Resuming stops the keep-alive timer; without further HTTP traffic
+      // the file server's idle timer resumes counting from here.
+      await Future<void>.delayed(const Duration(milliseconds: 400));
+      expect(handoff.isServing, isFalse);
+
+      await handoff.dispose();
+    },
+  );
+
   test('server stops when the receiver disconnects', () async {
     final handoff = handoffFor();
     await handoff.start(itemFor());

--- a/packages/platform_player/test/phone_media_file_server_test.dart
+++ b/packages/platform_player/test/phone_media_file_server_test.dart
@@ -243,6 +243,32 @@ void main() {
     expect(server.isRunning, isFalse);
   });
 
+  test('keepAlive prevents idle shutdown when the receiver is paused (no HTTP '
+      'traffic) rather than disconnected', () async {
+    final server = serverFor(idleTimeout: const Duration(milliseconds: 150));
+    await server.start();
+    addTearDown(server.stopServer);
+
+    // Simulate a paused receiver: no requests land, but the handoff pings
+    // keepAlive faster than the idle window elapses.
+    for (var i = 0; i < 4; i++) {
+      await Future<void>.delayed(const Duration(milliseconds: 80));
+      server.keepAlive();
+    }
+    expect(
+      server.isRunning,
+      isTrue,
+      reason: 'keepAlive must reset the idle clock, not just extend it once',
+    );
+
+    await Future<void>.delayed(const Duration(milliseconds: 400));
+    expect(
+      server.isRunning,
+      isFalse,
+      reason: 'once keepAlive stops arriving, idle shutdown still applies',
+    );
+  });
+
   test(
     'controller shutdown stops the server for the matching serverId',
     () async {

--- a/packages/platform_player/test/phone_media_large_file_soak_test.dart
+++ b/packages/platform_player/test/phone_media_large_file_soak_test.dart
@@ -10,106 +10,110 @@ import 'package:platform_player/platform_player.dart';
 /// One-off CV-033 soak: serves a sparse 5 GB file and seeks across it.
 /// Run explicitly with: flutter test --tags soak
 void main() {
-  test('5 GB file streams with correct far-offset range responses', () async {
-    final tempDir = await Directory.systemTemp.createTemp('cv033_soak');
-    addTearDown(() => tempDir.delete(recursive: true));
+  test(
+    '5 GB file streams with correct far-offset range responses',
+    () async {
+      final tempDir = await Directory.systemTemp.createTemp('cv033_soak');
+      addTearDown(() => tempDir.delete(recursive: true));
 
-    const fiveGb = 5 * 1024 * 1024 * 1024;
-    final mediaFile = File('${tempDir.path}/movie.mp4');
-    // Sparse file: write one marker byte at the end so length is 5 GB
-    // without materializing 5 GB on disk (APFS keeps holes sparse).
-    final raf = await mediaFile.open(mode: FileMode.write);
-    await raf.setPosition(fiveGb - 1);
-    await raf.writeByte(0x42);
-    await raf.close();
-    expect(await mediaFile.length(), fiveGb);
+      const fiveGb = 5 * 1024 * 1024 * 1024;
+      final mediaFile = File('${tempDir.path}/movie.mp4');
+      // Sparse file: write one marker byte at the end so length is 5 GB
+      // without materializing 5 GB on disk (APFS keeps holes sparse).
+      final raf = await mediaFile.open(mode: FileMode.write);
+      await raf.setPosition(fiveGb - 1);
+      await raf.writeByte(0x42);
+      await raf.close();
+      expect(await mediaFile.length(), fiveGb);
 
-    final now = DateTime.now();
-    final server = PhoneMediaFileServer(
-      snapshot: AiroTemporaryMobileServerSnapshot(
-        serverId: 'soak-server',
-        hostNodeId: 'phone-node',
-        locationId: 'loc-soak',
-        mediaId: 'media-soak',
-        accessGrant: AiroRouteAccessGrant(
-          grantId: 'grant-soak',
+      final now = DateTime.now();
+      final server = PhoneMediaFileServer(
+        snapshot: AiroTemporaryMobileServerSnapshot(
+          serverId: 'soak-server',
+          hostNodeId: 'phone-node',
           locationId: 'loc-soak',
-          audienceNodeId: 'tv-node',
-          handle: AiroRouteAccessHandle.redacted('soak-grant-handle'),
-          issuedAt: now,
+          mediaId: 'media-soak',
+          accessGrant: AiroRouteAccessGrant(
+            grantId: 'grant-soak',
+            locationId: 'loc-soak',
+            audienceNodeId: 'tv-node',
+            handle: AiroRouteAccessHandle.redacted('soak-grant-handle'),
+            issuedAt: now,
+            expiresAt: now.add(const Duration(hours: 1)),
+            scopes: const {
+              AiroRouteAccessScope.playbackRead,
+              AiroRouteAccessScope.rangeRead,
+              AiroRouteAccessScope.probeRead,
+            },
+          ),
+          startedAt: now,
           expiresAt: now.add(const Duration(hours: 1)),
-          scopes: const {
-            AiroRouteAccessScope.playbackRead,
-            AiroRouteAccessScope.rangeRead,
-            AiroRouteAccessScope.probeRead,
+          batteryPercent: 100,
+          thermalState: AiroTemporaryMobileThermalState.normal,
+          allowedReceiverNodeIds: const {'tv-node'},
+          capabilities: const {
+            AiroTemporaryMobileServerCapability.lanOnly,
+            AiroTemporaryMobileServerCapability.rangeRequests,
+            AiroTemporaryMobileServerCapability.probeRequests,
+            AiroTemporaryMobileServerCapability.entityValidation,
+            AiroTemporaryMobileServerCapability.autoShutdownOnExpiry,
+            AiroTemporaryMobileServerCapability.idleShutdown,
           },
         ),
-        startedAt: now,
-        expiresAt: now.add(const Duration(hours: 1)),
-        batteryPercent: 100,
-        thermalState: AiroTemporaryMobileThermalState.normal,
-        allowedReceiverNodeIds: const {'tv-node'},
-        capabilities: const {
-          AiroTemporaryMobileServerCapability.lanOnly,
-          AiroTemporaryMobileServerCapability.rangeRequests,
-          AiroTemporaryMobileServerCapability.probeRequests,
-          AiroTemporaryMobileServerCapability.entityValidation,
-          AiroTemporaryMobileServerCapability.autoShutdownOnExpiry,
-          AiroTemporaryMobileServerCapability.idleShutdown,
-        },
-      ),
-      filePath: mediaFile.path,
-      contentType: 'video/mp4',
-      bindAddress: InternetAddress.loopbackIPv4,
-      sessionToken: 'soak-token',
-    );
+        filePath: mediaFile.path,
+        contentType: 'video/mp4',
+        bindAddress: InternetAddress.loopbackIPv4,
+        sessionToken: 'soak-token',
+      );
 
-    final url = await server.start();
-    addTearDown(server.stopServer);
+      final url = await server.start();
+      addTearDown(server.stopServer);
 
-    final client = HttpClient();
-    addTearDown(client.close);
+      final client = HttpClient();
+      addTearDown(client.close);
 
-    Future<HttpClientResponse> range(String header) async {
-      final req = await client.getUrl(url);
-      req.headers.set(HttpHeaders.rangeHeader, header);
-      return req.close();
-    }
+      Future<HttpClientResponse> range(String header) async {
+        final req = await client.getUrl(url);
+        req.headers.set(HttpHeaders.rangeHeader, header);
+        return req.close();
+      }
 
-    // HEAD probe advertises the full 5 GB entity.
-    final headReq = await client.openUrl('HEAD', url);
-    final headResp = await headReq.close();
-    expect(headResp.statusCode, HttpStatus.ok);
-    expect(headResp.contentLength, fiveGb);
-    await headResp.drain<void>();
+      // HEAD probe advertises the full 5 GB entity.
+      final headReq = await client.openUrl('HEAD', url);
+      final headResp = await headReq.close();
+      expect(headResp.statusCode, HttpStatus.ok);
+      expect(headResp.contentLength, fiveGb);
+      await headResp.drain<void>();
 
-    // Seek to ~4.5 GB (beyond 32-bit offsets) — mid-file window.
-    const midStart = 4838400000;
-    final mid = await range('bytes=$midStart-${midStart + 1023}');
-    expect(mid.statusCode, HttpStatus.partialContent);
-    expect(
-      mid.headers.value(HttpHeaders.contentRangeHeader),
-      'bytes $midStart-${midStart + 1023}/$fiveGb',
-    );
-    final midBody = await mid.fold<List<int>>([], (a, b) => a..addAll(b));
-    expect(midBody.length, 1024);
-    expect(midBody.every((b) => b == 0), isTrue);
+      // Seek to ~4.5 GB (beyond 32-bit offsets) — mid-file window.
+      const midStart = 4838400000;
+      final mid = await range('bytes=$midStart-${midStart + 1023}');
+      expect(mid.statusCode, HttpStatus.partialContent);
+      expect(
+        mid.headers.value(HttpHeaders.contentRangeHeader),
+        'bytes $midStart-${midStart + 1023}/$fiveGb',
+      );
+      final midBody = await mid.fold<List<int>>([], (a, b) => a..addAll(b));
+      expect(midBody.length, 1024);
+      expect(midBody.every((b) => b == 0), isTrue);
 
-    // Suffix seek: last 512 bytes must include the marker byte at the end.
-    final tail = await range('bytes=-512');
-    expect(tail.statusCode, HttpStatus.partialContent);
-    expect(
-      tail.headers.value(HttpHeaders.contentRangeHeader),
-      'bytes ${fiveGb - 512}-${fiveGb - 1}/$fiveGb',
-    );
-    final tailBody = await tail.fold<List<int>>([], (a, b) => a..addAll(b));
-    expect(tailBody.length, 512);
-    expect(tailBody.last, 0x42);
+      // Suffix seek: last 512 bytes must include the marker byte at the end.
+      final tail = await range('bytes=-512');
+      expect(tail.statusCode, HttpStatus.partialContent);
+      expect(
+        tail.headers.value(HttpHeaders.contentRangeHeader),
+        'bytes ${fiveGb - 512}-${fiveGb - 1}/$fiveGb',
+      );
+      final tailBody = await tail.fold<List<int>>([], (a, b) => a..addAll(b));
+      expect(tailBody.length, 512);
+      expect(tailBody.last, 0x42);
 
-    // Sequential window near the start (receiver buffering pattern).
-    final head = await range('bytes=0-1048575');
-    expect(head.statusCode, HttpStatus.partialContent);
-    final headBody = await head.fold<int>(0, (n, b) => n + b.length);
-    expect(headBody, 1048576);
-  }, timeout: const Timeout(Duration(minutes: 3)));
+      // Sequential window near the start (receiver buffering pattern).
+      final head = await range('bytes=0-1048575');
+      expect(head.statusCode, HttpStatus.partialContent);
+      final headBody = await head.fold<int>(0, (n, b) => n + b.length);
+      expect(headBody, 1048576);
+    },
+    timeout: const Timeout(Duration(minutes: 3)),
+  );
 }

--- a/packages/platform_player/test/playback_engine_test.dart
+++ b/packages/platform_player/test/playback_engine_test.dart
@@ -275,18 +275,21 @@ void main() {
       expect(tracks[1].label, 'fr');
     });
 
-    test('falls back to positional label when both label and language null', () {
-      final tracks = externalSubtitleTracksFor(
-        requestWith([
-          AiroPlaybackExternalSubtitle(
-            handle: AiroPlaybackSourceHandle.redacted('sub-0'),
-          ),
-        ]),
-      );
+    test(
+      'falls back to positional label when both label and language null',
+      () {
+        final tracks = externalSubtitleTracksFor(
+          requestWith([
+            AiroPlaybackExternalSubtitle(
+              handle: AiroPlaybackSourceHandle.redacted('sub-0'),
+            ),
+          ]),
+        );
 
-      expect(tracks.single.label, 'External subtitle 1');
-      expect(tracks.single.languageCode, isNull);
-    });
+        expect(tracks.single.label, 'External subtitle 1');
+        expect(tracks.single.languageCode, isNull);
+      },
+    );
 
     test('projected list is unmodifiable', () {
       final tracks = externalSubtitleTracksFor(


### PR DESCRIPTION
CV-033 fast-follow (issue #844).

`PhoneMediaFileServer`'s idle-shutdown timer only resets on HTTP request traffic, but a paused-but-connected receiver sends none. A user pausing playback for longer than the 2-minute idle timeout got their session killed out from under them — flagged as a bug candidate in the CV-033 security review notes.

## Changes

- `PhoneMediaFileServer.keepAlive()` resets the idle clock without a request.
- `PhoneMediaCastHandoff` starts a periodic keep-alive ping while the cast session phase is `paused`, cancelling it on resume, stop, disconnect, or teardown — so idle-shutdown still applies once the receiver is genuinely abandoned, not merely paused.

## Tests

TDD, red→green: server survives repeated `keepAlive()` calls past the idle window then still times out once they stop; handoff-level test confirms pausing on the receiver keeps the server alive past what would otherwise be an idle timeout, and that resuming playback lets idle-shutdown resume counting. Full `platform_player` suite: 148/148 green, `dart analyze` clean, `dart format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)