### PR TITLE
feat(platform_media): CV-001 slice 4 -- map streaming exceptions to structured diagnostics

### DIFF
--- a/packages/platform_media/lib/platform_media.dart
+++ b/packages/platform_media/lib/platform_media.dart
@@ -3,6 +3,7 @@ library;
 export "src/media_capability_models.dart";
 export "src/media_error_taxonomy_models.dart";
 export "src/platform_media_logger.dart";
+export "src/streaming_error_diagnostic_mapping.dart";
 export "src/mpv/media_kit_mpv_player_facade.dart";
 export "src/mpv/mpv_player_facade.dart";
 export "src/mpv_airo_playback_engine.dart";

--- a/packages/platform_media/lib/src/streaming_error_diagnostic_mapping.dart
+++ b/packages/platform_media/lib/src/streaming_error_diagnostic_mapping.dart
@@ -1,0 +1,59 @@
+import 'dart:async';
+
+import 'package:platform_player/platform_player.dart';
+
+/// Maps a raw playback exception/message from [VideoPlayerController] or the
+/// streaming service (CV-001) to a stable, user-safe [AiroPlaybackDiagnostic].
+///
+/// `video_player` and its platform channels surface failures as opaque
+/// exceptions/strings rather than typed HTTP status codes, so this applies
+/// best-effort pattern matching before falling back to
+/// [AiroPlaybackDiagnosticCode.unknown]. The raw message is never included
+/// in [AiroPlaybackDiagnostic.technicalDetail] since it may embed the stream
+/// URL (and therefore credentials).
+AiroPlaybackDiagnostic mapStreamingErrorToDiagnostic(Object error) {
+  const mapper = AiroPlaybackDiagnosticMapper();
+
+  if (error is TimeoutException) {
+    return mapper.map(
+      const AiroPlaybackFailureEvent(
+        overrideCode: AiroPlaybackDiagnosticCode.networkUnavailable,
+      ),
+    );
+  }
+
+  final message = error.toString().toLowerCase();
+
+  if (_containsCodecSignal(message)) {
+    return mapper.map(
+      const AiroPlaybackFailureEvent(
+        overrideCode: AiroPlaybackDiagnosticCode.codecUnsupported,
+      ),
+    );
+  }
+
+  final status = _firstHttpStatus(message);
+  if (status != null) {
+    return mapper.map(AiroPlaybackFailureEvent(httpStatusCode: status));
+  }
+
+  return mapper.map(
+    const AiroPlaybackFailureEvent(
+      overrideCode: AiroPlaybackDiagnosticCode.unknown,
+    ),
+  );
+}
+
+bool _containsCodecSignal(String message) {
+  return message.contains('codec') || message.contains('unsupported format');
+}
+
+final _httpStatusPattern = RegExp(r'\b([1-5][0-9]{2})\b');
+
+int? _firstHttpStatus(String message) {
+  for (final match in _httpStatusPattern.allMatches(message)) {
+    final value = int.tryParse(match.group(1)!);
+    if (value != null && value >= 400 && value < 600) return value;
+  }
+  return null;
+}

--- a/packages/platform_media/lib/src/video_player_streaming_service.dart
+++ b/packages/platform_media/lib/src/video_player_streaming_service.dart
@@ -6,6 +6,7 @@ import 'package:video_player/video_player.dart';
 
 import 'audio_context.dart';
 import 'platform_media_logger.dart';
+import 'streaming_error_diagnostic_mapping.dart';
 
 /// Video Player implementation of IPTV Streaming Service
 ///
@@ -112,6 +113,7 @@ class VideoPlayerStreamingService implements IPTVStreamingService {
         currentChannel: channel,
         playbackState: PlaybackState.loading,
         errorMessage: null,
+        clearDiagnostic: true,
         retryCount: 0,
       ),
     );
@@ -298,10 +300,16 @@ class VideoPlayerStreamingService implements IPTVStreamingService {
       userMessage = 'Playback failed: $message';
     }
 
+    // CV-001: structured, user-safe diagnostic alongside the legacy
+    // errorMessage. UI prefers this when present; retry stays manual here
+    // (see comment below) — this call is additive, not a behavior change.
+    final diagnostic = mapStreamingErrorToDiagnostic(message);
+
     _updateState(
       _state.copyWith(
         playbackState: PlaybackState.error,
         errorMessage: userMessage,
+        diagnostic: diagnostic,
         retryCount: newRetryCount,
         lastError: DateTime.now(),
       ),

--- a/packages/platform_media/test/streaming_error_diagnostic_mapping_test.dart
+++ b/packages/platform_media/test/streaming_error_diagnostic_mapping_test.dart
@@ -1,0 +1,70 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:platform_media/platform_media.dart';
+import 'package:platform_player/platform_player.dart';
+
+void main() {
+  group('mapStreamingErrorToDiagnostic', () {
+    test('maps TimeoutException to a retryable network diagnostic', () {
+      final diagnostic = mapStreamingErrorToDiagnostic(
+        TimeoutException('Load timeout'),
+      );
+
+      expect(diagnostic.code, AiroPlaybackDiagnosticCode.networkUnavailable);
+      expect(diagnostic.retryEligible, isTrue);
+    });
+
+    test('maps a 401/403-bearing message to non-retryable provider auth', () {
+      for (final message in [
+        'HttpException: 401',
+        'PlatformException(VideoError, Exceeds error code, 403 Forbidden)',
+      ]) {
+        final diagnostic = mapStreamingErrorToDiagnostic(message);
+        expect(diagnostic.code, AiroPlaybackDiagnosticCode.providerAuthDenied);
+        expect(diagnostic.retryEligible, isFalse);
+      }
+    });
+
+    test('maps a 404-bearing message to non-retryable provider not-found', () {
+      final diagnostic = mapStreamingErrorToDiagnostic(
+        'source error: 404 not found',
+      );
+
+      expect(diagnostic.code, AiroPlaybackDiagnosticCode.providerNotFound);
+      expect(diagnostic.retryEligible, isFalse);
+    });
+
+    test('maps a 5xx-bearing message to a retryable provider server error', () {
+      final diagnostic = mapStreamingErrorToDiagnostic('upstream 502 error');
+
+      expect(diagnostic.code, AiroPlaybackDiagnosticCode.providerServerError);
+      expect(diagnostic.retryEligible, isTrue);
+    });
+
+    test('maps a codec/format message to non-retryable codec diagnostic', () {
+      final diagnostic = mapStreamingErrorToDiagnostic(
+        'MediaCodecVideoRenderer error, unsupported codec',
+      );
+
+      expect(diagnostic.code, AiroPlaybackDiagnosticCode.codecUnsupported);
+      expect(diagnostic.retryEligible, isFalse);
+    });
+
+    test('falls back to an unknown retryable diagnostic for opaque errors', () {
+      final diagnostic = mapStreamingErrorToDiagnostic('boom');
+
+      expect(diagnostic.code, AiroPlaybackDiagnosticCode.unknown);
+      expect(diagnostic.retryEligible, isTrue);
+    });
+
+    test('never includes the raw error text verbatim in technical detail', () {
+      final diagnostic = mapStreamingErrorToDiagnostic(
+        'http://user:secret@host/live/pw/1.ts?token=abc failed: 403',
+      );
+
+      expect(diagnostic.technicalDetail, isNot(contains('secret')));
+      expect(diagnostic.technicalDetail, isNot(contains('token=abc')));
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Wires the CV-001 (#805) diagnostic taxonomy into `VideoPlayerStreamingService`, the real playback path, additively:

- **`mapStreamingErrorToDiagnostic`** (new) -- best-effort mapping from raw `video_player` exceptions/messages to `AiroPlaybackDiagnostic`. `video_player` surfaces failures as opaque strings rather than typed HTTP status, so this pattern-matches `TimeoutException`, embedded 4xx/5xx codes, and codec/format signals before falling back to `unknown`. Raw error text (which can embed the stream URL/credentials) never reaches `technicalDetail`.
- `_handleError` now sets `StreamingState.diagnostic` alongside the existing `errorMessage`; `playChannel` clears it via `clearDiagnostic` on a fresh load.

## Scope note

This does **not** add auto-retry. `_handleError` has an explicit prior comment: *"NO auto-retry -- user must manually retry via the Retry button. This prevents flickering from continuous retry loops."* That's a deliberate design decision baked into the live player, which has zero existing tests and no DI seam for `VideoPlayerController`. Reversing it is a real product/UX call that needs its own scoped change with device verification, not something to fold silently into a diagnostics pass. Confirmed this scoping with the repo owner before implementing.

## Performance impact

One extra pure-function call per error path; no hot-path impact.

## Tests

- 7 new tests for the mapping function (timeout, 401/403, 404, 5xx, codec, fallback, credential redaction).
- `platform_media` suite 79/79 green, `flutter analyze` clean, `dart format` clean.

Part of #805.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
