### PR TITLE
feat(platform_favorites): CV-021 slice -- hidden-groups storage

### DIFF
--- a/packages/platform_favorites/lib/platform_favorites.dart
+++ b/packages/platform_favorites/lib/platform_favorites.dart
@@ -2,3 +2,4 @@
 library;
 
 export 'src/favorite_channels_storage.dart';
+export 'src/hidden_groups_storage.dart';

--- a/packages/platform_favorites/lib/src/hidden_groups_storage.dart
+++ b/packages/platform_favorites/lib/src/hidden_groups_storage.dart
@@ -1,0 +1,67 @@
+import 'package:core_data/core_data.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// Storage service for persisting groups/categories the user has hidden.
+///
+/// Local-only, matching the roadmap policy of no cloud sync for favorites
+/// (CV-021, issue #826). Hidden groups are keyed by the playlist's raw
+/// group/category string, not a synthetic id -- there is no shared group
+/// identity across BYOC sources.
+class HiddenGroupsStorage {
+  static const String _hiddenGroupsKey = 'iptv_hidden_group_ids';
+
+  final KeyValueStore _store;
+
+  HiddenGroupsStorage(
+    SharedPreferences prefs, {
+    KeyValueStore? store,
+    int maxPreferenceValueBytes = kKeyValueStorePreferenceMaxValueBytes,
+  }) : _store =
+           store ??
+           PreferencesStore(prefs, maxValueBytes: maxPreferenceValueBytes);
+
+  /// All hidden group ids, in no particular order.
+  Future<Set<String>> getHiddenGroupIds() async {
+    final ids = await _store.getStringList(_hiddenGroupsKey);
+    return ids?.toSet() ?? <String>{};
+  }
+
+  /// Whether [groupId] is currently hidden.
+  Future<bool> isHidden(String groupId) async {
+    final ids = await getHiddenGroupIds();
+    return ids.contains(groupId);
+  }
+
+  /// Hide [groupId]. No-op if already hidden.
+  Future<void> hideGroup(String groupId) async {
+    final ids = await getHiddenGroupIds();
+    if (ids.add(groupId)) {
+      await _save(ids);
+    }
+  }
+
+  /// Unhide [groupId]. No-op if not hidden.
+  Future<void> unhideGroup(String groupId) async {
+    final ids = await getHiddenGroupIds();
+    if (ids.remove(groupId)) {
+      await _save(ids);
+    }
+  }
+
+  /// Toggle [groupId]'s hidden state. Returns the new state.
+  Future<bool> toggleHidden(String groupId) async {
+    final ids = await getHiddenGroupIds();
+    final nowHidden = !ids.contains(groupId);
+    if (nowHidden) {
+      ids.add(groupId);
+    } else {
+      ids.remove(groupId);
+    }
+    await _save(ids);
+    return nowHidden;
+  }
+
+  Future<void> _save(Set<String> ids) {
+    return _store.setStringList(_hiddenGroupsKey, ids.toList(growable: false));
+  }
+}

--- a/packages/platform_favorites/test/hidden_groups_storage_test.dart
+++ b/packages/platform_favorites/test/hidden_groups_storage_test.dart
@@ -1,0 +1,75 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:platform_favorites/platform_favorites.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  test('starts with no hidden groups', () async {
+    SharedPreferences.setMockInitialValues({});
+    final prefs = await SharedPreferences.getInstance();
+    final storage = HiddenGroupsStorage(prefs);
+
+    expect(await storage.getHiddenGroupIds(), isEmpty);
+    expect(await storage.isHidden('Adult'), isFalse);
+  });
+
+  test('hides a group', () async {
+    SharedPreferences.setMockInitialValues({});
+    final prefs = await SharedPreferences.getInstance();
+    final storage = HiddenGroupsStorage(prefs);
+
+    await storage.hideGroup('Adult');
+
+    expect(await storage.getHiddenGroupIds(), {'Adult'});
+    expect(await storage.isHidden('Adult'), isTrue);
+  });
+
+  test('hiding the same group twice does not duplicate it', () async {
+    SharedPreferences.setMockInitialValues({});
+    final prefs = await SharedPreferences.getInstance();
+    final storage = HiddenGroupsStorage(prefs);
+
+    await storage.hideGroup('Adult');
+    await storage.hideGroup('Adult');
+
+    expect(await storage.getHiddenGroupIds(), {'Adult'});
+  });
+
+  test('unhides a group', () async {
+    SharedPreferences.setMockInitialValues({});
+    final prefs = await SharedPreferences.getInstance();
+    final storage = HiddenGroupsStorage(prefs);
+
+    await storage.hideGroup('Adult');
+    await storage.unhideGroup('Adult');
+
+    expect(await storage.getHiddenGroupIds(), isEmpty);
+    expect(await storage.isHidden('Adult'), isFalse);
+  });
+
+  test('toggling a group returns the new hidden state', () async {
+    SharedPreferences.setMockInitialValues({});
+    final prefs = await SharedPreferences.getInstance();
+    final storage = HiddenGroupsStorage(prefs);
+
+    final nowHidden = await storage.toggleHidden('Radio');
+    expect(nowHidden, isTrue);
+    expect(await storage.isHidden('Radio'), isTrue);
+
+    final nowShown = await storage.toggleHidden('Radio');
+    expect(nowShown, isFalse);
+    expect(await storage.isHidden('Radio'), isFalse);
+  });
+
+  test(
+    'persists hidden groups across storage instances (same prefs)',
+    () async {
+      SharedPreferences.setMockInitialValues({});
+      final prefs = await SharedPreferences.getInstance();
+      await HiddenGroupsStorage(prefs).hideGroup('Sports 24/7');
+
+      final reloaded = HiddenGroupsStorage(prefs);
+
+      expect(await reloaded.getHiddenGroupIds(), {'Sports 24/7'});
+    },
+  );
+}


### PR DESCRIPTION
## Summary

Storage-layer slice of CV-021 (#826). `platform_favorites` already has a real `FavoriteChannelsStorage` (channel favorites shipped -- the TV Favorites route is not the placeholder the issue text describes; that part landed already). The remaining gap per the issue's ACs is "hide a group/category, persisted, respected by browse/search/guide."

This PR adds the storage primitive:

- **`HiddenGroupsStorage`** -- same pattern as `FavoriteChannelsStorage` (shared_preferences, `KeyValueStore`): `hideGroup`, `unhideGroup`, `toggleHidden`, `isHidden`, `getHiddenGroupIds`. Keyed by the playlist's raw group/category string since there's no synthetic group id shared across BYOC sources.

## Scope note

Not included here: wiring hidden-group exclusion into browse, search, and guide (AC 3/4). Sequencing deliberately:
- Search-side wiring depends on #866 (`LocalIptvSearchIndex`) merging first.
- The "hide this group" action on the browse grid touches live channel-grid UI and deserves its own focused review rather than bundling with a storage-layer PR.

Follow-up slice will wire both once #866 lands.

## Tests

6 new tests (empty state, hide, dedupe, unhide, toggle, cross-instance persistence via shared prefs). `platform_favorites` suite green, analyze + format clean.

Part of #826.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
