### PR TITLE
feat(feature_iptv): Netflix-style brightness/volume gestures, lock button, mobile player fixes

### DIFF
--- a/app/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/app/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -24,6 +24,7 @@ import media_kit_libs_macos_video
 import package_info_plus
 import patrol
 import pdfx
+import screen_brightness_macos
 import share_plus
 import shared_preferences_foundation
 import sqflite_darwin
@@ -51,6 +52,7 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   FPPPackageInfoPlusPlugin.register(with: registry.registrar(forPlugin: "FPPPackageInfoPlusPlugin"))
   PatrolPlugin.register(with: registry.registrar(forPlugin: "PatrolPlugin"))
   PdfxPlugin.register(with: registry.registrar(forPlugin: "PdfxPlugin"))
+  ScreenBrightnessMacosPlugin.register(with: registry.registrar(forPlugin: "ScreenBrightnessMacosPlugin"))
   SharePlusMacosPlugin.register(with: registry.registrar(forPlugin: "SharePlusMacosPlugin"))
   SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
   SqflitePlugin.register(with: registry.registrar(forPlugin: "SqflitePlugin"))

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -1869,6 +1869,62 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.2"
+  screen_brightness:
+    dependency: transitive
+    description:
+      name: screen_brightness
+      sha256: e0edf92c08889e8f493cde291e7c687db2b4a1471f2371c074070b75d7c7d79b
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.11"
+  screen_brightness_android:
+    dependency: transitive
+    description:
+      name: screen_brightness_android
+      sha256: "2008ad8e9527cc968f7a4de1ec58b476d495b3c612a149dbd6550c4f046da147"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.6"
+  screen_brightness_ios:
+    dependency: transitive
+    description:
+      name: screen_brightness_ios
+      sha256: "352d355e8523a186ba1e494b74218e5ca96e51975a0630b8ed89fbb7ff609762"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.4"
+  screen_brightness_macos:
+    dependency: transitive
+    description:
+      name: screen_brightness_macos
+      sha256: b0957237b842d846a84363b69f229b339a8f91faced55041e245b2ebff7b0142
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.4"
+  screen_brightness_ohos:
+    dependency: transitive
+    description:
+      name: screen_brightness_ohos
+      sha256: "569a2c97909a50894b81487619eb7654f5358443a5af05f840c19261f49c0940"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.4"
+  screen_brightness_platform_interface:
+    dependency: transitive
+    description:
+      name: screen_brightness_platform_interface
+      sha256: "2de60c0ba569b898950029cc1f7e9dd72bda44a22beb5054aac331cb6fce2ff2"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.2"
+  screen_brightness_windows:
+    dependency: transitive
+    description:
+      name: screen_brightness_windows
+      sha256: "368b9c822e1671de81616e48150006e39eff2a434957e47ee638b09a32b2297c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.2"
   screenshot:
     dependency: "direct main"
     description:

--- a/app/windows/flutter/generated_plugin_registrant.cc
+++ b/app/windows/flutter/generated_plugin_registrant.cc
@@ -16,6 +16,7 @@
 #include <media_kit_libs_windows_video/media_kit_libs_windows_video_plugin_c_api.h>
 #include <pdfx/pdfx_plugin.h>
 #include <permission_handler_windows/permission_handler_windows_plugin.h>
+#include <screen_brightness_windows/screen_brightness_windows_plugin_c_api.h>
 #include <share_plus/share_plus_windows_plugin_c_api.h>
 #include <url_launcher_windows/url_launcher_windows.h>
 
@@ -40,6 +41,8 @@ void RegisterPlugins(flutter::PluginRegistry* registry) {
       registry->GetRegistrarForPlugin("PdfxPlugin"));
   PermissionHandlerWindowsPluginRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("PermissionHandlerWindowsPlugin"));
+  ScreenBrightnessWindowsPluginCApiRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("ScreenBrightnessWindowsPluginCApi"));
   SharePlusWindowsPluginCApiRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("SharePlusWindowsPluginCApi"));
   UrlLauncherWindowsRegisterWithRegistrar(

--- a/app/windows/flutter/generated_plugins.cmake
+++ b/app/windows/flutter/generated_plugins.cmake
@@ -13,6 +13,7 @@ list(APPEND FLUTTER_PLUGIN_LIST
   media_kit_libs_windows_video
   pdfx
   permission_handler_windows
+  screen_brightness_windows
   share_plus
   url_launcher_windows
 )

--- a/docs/agents/skills/run-airo-tv/SKILL.md
+++ b/docs/agents/skills/run-airo-tv/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: run-airo-tv
+description: Launch and drive the Airo TV Flutter app (main_tv.dart entrypoint) on a target device — macOS desktop, Chrome, Android/Fire TV, or phone. Use whenever asked to run, start, or preview Airo TV.
+---
+
+# Run Airo TV
+
+Airo TV is the TV-flavored Flutter entrypoint at `app/lib/main_tv.dart` (distinct from
+`main.dart`, `main_airo_iptv.dart`, `main_mobile_streaming.dart`, `main_qualification.dart`).
+
+## 1. Pick a device
+
+```bash
+cd app && flutter devices
+```
+
+Typical targets seen in this repo: `macos` (desktop), `chrome` (web), an Android device/emulator
+(`android-arm64`), Fire TV/Android TV over adb.
+
+## 2. Launch
+
+Run from the `app/` directory, targeting `main_tv.dart` explicitly — the bare `flutter run`
+defaults to `main.dart`, which is the wrong entrypoint for the TV experience.
+
+```bash
+cd /Users/udaychauhan/workspace/airo/app
+flutter run -d macos -t lib/main_tv.dart
+```
+
+Swap `-d macos` for `-d chrome`, `-d <android-device-id>`, etc. as needed.
+
+### Notes for macOS target
+
+- First launch runs `pod install` for the macOS Runner — can take 30-90s before
+  "Building macOS application..." appears.
+- You'll see warnings that `flutter_image_compress_macos`, `flutter_tts`, and `pdfx` don't
+  support Swift Package Manager on macOS yet — this is a non-fatal deprecation warning, not
+  a build failure. Ignore it.
+- Full cold build (pod install + Xcode build) commonly takes 2-5 minutes.
+
+## 3. Run it in the background and watch for the real terminal state
+
+`flutter run` is long-lived (hot-reload session) and never "completes," so launch it
+detached and tail the log rather than blocking on it:
+
+```bash
+nohup flutter run -d macos -t lib/main_tv.dart > /tmp/airo_tv_macos_run.log 2>&1 &
+```
+
+Poll/monitor for one of the terminal signals:
+- Success: log contains `Flutter run key commands` (the hot-reload prompt) or a line like
+  `🔥  To hot reload changes` / `An Observatory debugger and profiler on macOS is available at`.
+- Failure: log contains `Error`, `error:`, `Exception`, or `Failed`.
+
+```bash
+until grep -qE "Flutter run key commands|Error|error:|Exception|Failed" /tmp/airo_tv_macos_run.log; do sleep 3; done
+tail -60 /tmp/airo_tv_macos_run.log
+```
+
+## 4. Drive it
+
+Once the macOS window appears, it's a normal desktop app window — screenshot it to confirm
+it rendered rather than just checking the process launched. The TV UI expects an authorized
+M3U playlist to be added before channels appear (see
+[`docs/features/airo-tv/AIRO_TV_DEVICE_GUIDE.md`](../../../docs/features/airo-tv/AIRO_TV_DEVICE_GUIDE.md)
+for expected user flow / feature status if you need to sanity-check behavior against spec).
+
+## Stopping
+
+```bash
+pkill -f "flutter run -d macos -t lib/main_tv.dart"
+```
+or kill the specific dart_tools PID from `ps aux | grep main_tv`.

--- a/packages/feature_iptv/lib/presentation/widgets/player_brightness_controller.dart
+++ b/packages/feature_iptv/lib/presentation/widgets/player_brightness_controller.dart
@@ -1,0 +1,51 @@
+import 'package:screen_brightness/screen_brightness.dart';
+
+/// Reads and writes screen brightness for the Netflix-style gesture control.
+///
+/// Scoped to *application* brightness (not system brightness): dimming the
+/// player should only affect this app's window, and `screen_brightness`
+/// auto-resets application brightness when the app backgrounds/exits.
+abstract class PlayerBrightnessController {
+  Future<double> currentBrightness();
+  Future<void> setBrightness(double value);
+  Future<void> resetBrightness();
+}
+
+class SystemPlayerBrightnessController implements PlayerBrightnessController {
+  final _plugin = ScreenBrightness.instance;
+
+  @override
+  Future<double> currentBrightness() => _plugin.application;
+
+  @override
+  Future<void> setBrightness(double value) =>
+      _plugin.setApplicationScreenBrightness(value);
+
+  @override
+  Future<void> resetBrightness() => _plugin.resetApplicationScreenBrightness();
+}
+
+class FakePlayerBrightnessController implements PlayerBrightnessController {
+  FakePlayerBrightnessController({this.initial = 0.5}) : _current = initial;
+
+  final double initial;
+  double _current;
+
+  final List<double> setBrightnessCalls = [];
+  int resetCalls = 0;
+
+  @override
+  Future<double> currentBrightness() async => _current;
+
+  @override
+  Future<void> setBrightness(double value) async {
+    _current = value;
+    setBrightnessCalls.add(value);
+  }
+
+  @override
+  Future<void> resetBrightness() async {
+    _current = initial;
+    resetCalls++;
+  }
+}

--- a/packages/feature_iptv/lib/presentation/widgets/player_gesture_overlay.dart
+++ b/packages/feature_iptv/lib/presentation/widgets/player_gesture_overlay.dart
@@ -1,0 +1,226 @@
+import 'dart:async';
+import 'package:flutter/material.dart';
+
+/// Converts a vertical drag delta into a fractional value change for
+/// Netflix/YouTube-style brightness and volume gestures.
+///
+/// Dragging up (negative `dy`) increases the value; a drag spanning the full
+/// viewport height maps to a 100% change.
+double playerGestureValueDelta({
+  required double dy,
+  required double viewportHeight,
+}) {
+  if (viewportHeight <= 0) return 0;
+  return -dy / viewportHeight;
+}
+
+/// Clamps a gesture-driven value into the valid `0.0`-`1.0` range.
+double clampPlayerGestureValue(double value) => value.clamp(0.0, 1.0);
+
+/// Which control a vertical drag adjusts, based on which half of the
+/// viewport it starts in.
+enum PlayerGestureZone {
+  brightness,
+  volume;
+
+  /// The left half of the viewport controls brightness, the right half
+  /// controls volume — the standard Netflix/YouTube split. The exact
+  /// midpoint falls into the (right) volume zone.
+  static PlayerGestureZone forDx({
+    required double dx,
+    required double viewportWidth,
+  }) {
+    return dx < viewportWidth / 2
+        ? PlayerGestureZone.brightness
+        : PlayerGestureZone.volume;
+  }
+}
+
+/// Wraps the video surface with Netflix-style vertical drag gestures:
+/// dragging on the left half adjusts screen brightness, the right half
+/// adjusts playback volume. Shows an ephemeral icon + fill indicator while a
+/// value is changing, matching the mute-button/slider it replaces.
+///
+/// Disabled entirely while [locked] is true, so the lock button is the only
+/// way to affect playback state.
+class PlayerGestureOverlay extends StatefulWidget {
+  const PlayerGestureOverlay({
+    super.key,
+    required this.child,
+    required this.locked,
+    required this.brightness,
+    required this.volume,
+    required this.onBrightnessChanged,
+    required this.onVolumeChanged,
+  });
+
+  final Widget child;
+  final bool locked;
+
+  /// Current values in the `0.0`-`1.0` range; the overlay reads these as the
+  /// starting point of each new drag rather than owning the value itself.
+  final double brightness;
+  final double volume;
+
+  final ValueChanged<double> onBrightnessChanged;
+  final ValueChanged<double> onVolumeChanged;
+
+  @override
+  State<PlayerGestureOverlay> createState() => _PlayerGestureOverlayState();
+}
+
+class _PlayerGestureOverlayState extends State<PlayerGestureOverlay> {
+  static const _indicatorLingerDuration = Duration(milliseconds: 700);
+
+  PlayerGestureZone? _activeZone;
+  double? _dragStartValue;
+  double _liveValue = 0;
+  Timer? _indicatorHideTimer;
+
+  @override
+  void dispose() {
+    _indicatorHideTimer?.cancel();
+    super.dispose();
+  }
+
+  void _onDragStart(DragStartDetails details, double viewportWidth) {
+    if (widget.locked) return;
+    _indicatorHideTimer?.cancel();
+    final zone = PlayerGestureZone.forDx(
+      dx: details.localPosition.dx,
+      viewportWidth: viewportWidth,
+    );
+    setState(() {
+      _activeZone = zone;
+      _dragStartValue = zone == PlayerGestureZone.brightness
+          ? widget.brightness
+          : widget.volume;
+      _liveValue = _dragStartValue!;
+    });
+  }
+
+  void _onDragUpdate(DragUpdateDetails details, double viewportHeight) {
+    final zone = _activeZone;
+    final startValue = _dragStartValue;
+    if (widget.locked || zone == null || startValue == null) return;
+
+    final delta = playerGestureValueDelta(
+      dy: details.primaryDelta ?? 0,
+      viewportHeight: viewportHeight,
+    );
+    // Accumulate against the live value (not just the drag start) so each
+    // incremental frame's delta compounds correctly across the gesture.
+    final next = clampPlayerGestureValue(_liveValue + delta);
+    setState(() => _liveValue = next);
+    switch (zone) {
+      case PlayerGestureZone.brightness:
+        widget.onBrightnessChanged(next);
+      case PlayerGestureZone.volume:
+        widget.onVolumeChanged(next);
+    }
+  }
+
+  void _onDragEnd(DragEndDetails details) {
+    if (widget.locked) return;
+    _indicatorHideTimer?.cancel();
+    _indicatorHideTimer = Timer(_indicatorLingerDuration, () {
+      if (!mounted) return;
+      setState(() {
+        _activeZone = null;
+        _dragStartValue = null;
+      });
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final width = constraints.maxWidth;
+        final height = constraints.maxHeight;
+        return Stack(
+          fit: StackFit.expand,
+          children: [
+            widget.child,
+            if (!widget.locked)
+              Positioned.fill(
+                child: GestureDetector(
+                  behavior: HitTestBehavior.translucent,
+                  onVerticalDragStart: (d) => _onDragStart(d, width),
+                  onVerticalDragUpdate: (d) => _onDragUpdate(d, height),
+                  onVerticalDragEnd: _onDragEnd,
+                ),
+              ),
+            if (_activeZone != null)
+              _GestureValueIndicator(
+                key: ValueKey('player-gesture-indicator-${_activeZone!.name}'),
+                zone: _activeZone!,
+                value: _liveValue,
+              ),
+          ],
+        );
+      },
+    );
+  }
+}
+
+class _GestureValueIndicator extends StatelessWidget {
+  const _GestureValueIndicator({
+    super.key,
+    required this.zone,
+    required this.value,
+  });
+
+  final PlayerGestureZone zone;
+  final double value;
+
+  @override
+  Widget build(BuildContext context) {
+    final icon = switch (zone) {
+      PlayerGestureZone.brightness =>
+        value < 0.5 ? Icons.brightness_low : Icons.brightness_high,
+      PlayerGestureZone.volume =>
+        value == 0
+            ? Icons.volume_off
+            : value < 0.5
+            ? Icons.volume_down
+            : Icons.volume_up,
+    };
+    return Center(
+      child: Container(
+        width: 88,
+        padding: const EdgeInsets.symmetric(vertical: 16, horizontal: 12),
+        decoration: BoxDecoration(
+          color: Colors.black87,
+          borderRadius: BorderRadius.circular(12),
+        ),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(icon, color: Colors.white, size: 28),
+            const SizedBox(height: 8),
+            SizedBox(
+              height: 80,
+              width: 4,
+              child: Stack(
+                alignment: Alignment.bottomCenter,
+                children: [
+                  Container(color: Colors.white24),
+                  FractionallySizedBox(
+                    heightFactor: value,
+                    child: Container(color: Colors.white),
+                  ),
+                ],
+              ),
+            ),
+            const SizedBox(height: 8),
+            Text(
+              '${(value * 100).round()}%',
+              style: const TextStyle(color: Colors.white, fontSize: 12),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/packages/feature_iptv/lib/presentation/widgets/player_lock_button.dart
+++ b/packages/feature_iptv/lib/presentation/widgets/player_lock_button.dart
@@ -1,0 +1,32 @@
+import 'package:flutter/material.dart';
+
+/// Freezes/unfreezes the player's touch controls (tap-to-seek, gestures,
+/// overlay buttons) so the screen can go in a pocket without triggering
+/// accidental input. Standard lock/unlock icon toggle, always visible so a
+/// locked player can still be unlocked.
+class PlayerLockButton extends StatelessWidget {
+  const PlayerLockButton({
+    super.key,
+    required this.locked,
+    required this.onToggle,
+  });
+
+  final bool locked;
+  final VoidCallback onToggle;
+
+  @override
+  Widget build(BuildContext context) {
+    return IconButton(
+      icon: Icon(
+        locked ? Icons.lock_open : Icons.lock_outline,
+        color: Colors.white,
+        size: 20,
+      ),
+      tooltip: locked ? 'Unlock controls' : 'Lock controls',
+      onPressed: onToggle,
+      visualDensity: VisualDensity.compact,
+      padding: const EdgeInsets.all(6),
+      constraints: const BoxConstraints(),
+    );
+  }
+}

--- a/packages/feature_iptv/lib/presentation/widgets/video_player_widget.dart
+++ b/packages/feature_iptv/lib/presentation/widgets/video_player_widget.dart
@@ -16,6 +16,9 @@ import "package:platform_media/platform_media.dart";
 import '../utils/web_fullscreen.dart' as web_fullscreen;
 import 'iptv_icon_placeholder.dart';
 import 'live_indicators.dart';
+import 'player_brightness_controller.dart';
+import 'player_gesture_overlay.dart';
+import 'player_lock_button.dart';
 
 /// Video player widget with YouTube-like controls
 class VideoPlayerWidget extends ConsumerStatefulWidget {
@@ -23,6 +26,7 @@ class VideoPlayerWidget extends ConsumerStatefulWidget {
   final VoidCallback? onFullscreenToggle;
   final bool enableSwipeChannelChange;
   final bool initiallyFullscreen;
+  final PlayerBrightnessController? brightnessController;
 
   const VideoPlayerWidget({
     super.key,
@@ -30,6 +34,7 @@ class VideoPlayerWidget extends ConsumerStatefulWidget {
     this.onFullscreenToggle,
     this.enableSwipeChannelChange = false,
     this.initiallyFullscreen = false,
+    this.brightnessController,
   });
 
   @override
@@ -49,13 +54,31 @@ class _VideoPlayerWidgetState extends ConsumerState<VideoPlayerWidget> {
   String? _channelChangeOverlayText;
   Timer? _channelChangeOverlayTimer;
 
+  // Netflix-style gesture controls (CV-PLAYER-GESTURES) + lock button.
+  bool _isLocked = false;
+  double _brightness = 0.5;
+  late final PlayerBrightnessController _brightnessController;
+
   @override
   void initState() {
     super.initState();
     _isFullscreen = widget.initiallyFullscreen;
+    _brightnessController =
+        widget.brightnessController ?? SystemPlayerBrightnessController();
+    _loadInitialBrightness();
     _startHideControlsTimer();
     // Note: Wakelock is now managed by _updateWakelockForPlayback
     // based on actual playback state, not just widget mount
+  }
+
+  Future<void> _loadInitialBrightness() async {
+    try {
+      final value = await _brightnessController.currentBrightness();
+      if (!mounted) return;
+      setState(() => _brightness = value);
+    } catch (e) {
+      debugPrint('Failed to read initial brightness: $e');
+    }
   }
 
   @override
@@ -64,7 +87,27 @@ class _VideoPlayerWidgetState extends ConsumerState<VideoPlayerWidget> {
     _channelChangeOverlayTimer?.cancel();
     _wakelockDebouncer.cancel();
     _disableWakelock();
+    unawaited(_resetBrightnessSafely());
     super.dispose();
+  }
+
+  // screen_brightness has no Linux implementation and limited web support;
+  // platforms without it throw on every call, so failures here are expected
+  // on some desktop/web targets and must never crash the widget.
+  Future<void> _resetBrightnessSafely() async {
+    try {
+      await _brightnessController.resetBrightness();
+    } catch (e) {
+      debugPrint('Failed to reset brightness: $e');
+    }
+  }
+
+  Future<void> _setBrightnessSafely(double value) async {
+    try {
+      await _brightnessController.setBrightness(value);
+    } catch (e) {
+      debugPrint('Failed to set brightness: $e');
+    }
   }
 
   /// Update wakelock based on playback state
@@ -135,9 +178,29 @@ class _VideoPlayerWidgetState extends ConsumerState<VideoPlayerWidget> {
     _hideControlsTimer = null;
   }
 
+  // No-op while locked: the controls layer is unrendered in that state (see
+  // `_buildPlayer`), so revealing it would be dead code with no visible
+  // effect today — but tap/hover should never behave as an interactive
+  // surface while locked, regardless of how the render-gating evolves.
   void _showControls() {
+    if (_isLocked) return;
     setState(() => _showControlsOverlay = true);
     _startHideControlsTimer();
+  }
+
+  void _toggleLocked() {
+    setState(() {
+      _isLocked = !_isLocked;
+      _showControlsOverlay = true;
+    });
+    // Keep controls visible right after toggling so the lock/unlock state
+    // change itself is visible, then resume the normal auto-hide behavior.
+    _startHideControlsTimer();
+  }
+
+  void _onBrightnessGestureChanged(double value) {
+    setState(() => _brightness = value);
+    unawaited(_setBrightnessSafely(value));
   }
 
   void _toggleFullscreen() {
@@ -231,66 +294,87 @@ class _VideoPlayerWidgetState extends ConsumerState<VideoPlayerWidget> {
           child: Stack(
             alignment: Alignment.center,
             children: [
-              // Video display
-              if (controller != null && controller.value.isInitialized)
-                SizedBox.expand(
-                  child: FittedBox(
-                    fit: _boxFitFor(aspectRatioFit),
-                    child: SizedBox(
-                      width: controller.value.size.width,
-                      height: controller.value.size.height,
-                      child: VideoPlayer(controller),
-                    ),
-                  ),
-                )
-              else if (state.playbackState == PlaybackState.loading)
-                _buildLoading()
-              else if (state.hasError && state.diagnostic != null)
-                _buildDiagnosticError(state)
-              else
-                _buildPlaceholder(state),
+              // Video display + Netflix-style brightness/volume drag
+              // gestures. Left half of the video area adjusts brightness,
+              // right half adjusts volume; disabled while locked.
+              PlayerGestureOverlay(
+                locked: _isLocked,
+                brightness: _brightness,
+                volume: state.isMuted ? 0.0 : state.volume,
+                onBrightnessChanged: _onBrightnessGestureChanged,
+                onVolumeChanged: (value) {
+                  if (state.isMuted) service.toggleMute();
+                  service.setVolume(value);
+                },
+                child: Stack(
+                  alignment: Alignment.center,
+                  children: [
+                    if (controller != null && controller.value.isInitialized)
+                      SizedBox.expand(
+                        child: FittedBox(
+                          fit: _boxFitFor(aspectRatioFit),
+                          child: SizedBox(
+                            width: controller.value.size.width,
+                            height: controller.value.size.height,
+                            child: VideoPlayer(controller),
+                          ),
+                        ),
+                      )
+                    else if (state.playbackState == PlaybackState.loading)
+                      _buildLoading()
+                    else if (state.hasError && state.diagnostic != null)
+                      _buildDiagnosticError(state)
+                    else
+                      _buildPlaceholder(state),
 
-              // Cinema mode vignette overlay
-              if (_isCinemaMode)
-                Positioned.fill(
-                  child: IgnorePointer(
-                    child: Container(
-                      decoration: BoxDecoration(
-                        gradient: RadialGradient(
-                          center: Alignment.center,
-                          radius: 1.15,
-                          colors: [
-                            Colors.transparent,
-                            Colors.black.withValues(alpha: 0.6),
-                          ],
-                          stops: const [0.6, 1.0],
+                    // Cinema mode vignette overlay
+                    if (_isCinemaMode)
+                      Positioned.fill(
+                        child: IgnorePointer(
+                          child: Container(
+                            decoration: BoxDecoration(
+                              gradient: RadialGradient(
+                                center: Alignment.center,
+                                radius: 1.15,
+                                colors: [
+                                  Colors.transparent,
+                                  Colors.black.withValues(alpha: 0.6),
+                                ],
+                                stops: const [0.6, 1.0],
+                              ),
+                            ),
+                          ),
                         ),
                       ),
-                    ),
-                  ),
-                ),
 
-              // Buffering indicator
-              if (state.isBuffering)
-                Container(
-                  color: Colors.black45,
-                  child: const CircularProgressIndicator(color: Colors.white),
-                ),
-
-              // Controls overlay with fade animation
-              AnimatedOpacity(
-                opacity: (widget.showControls && _showControlsOverlay)
-                    ? 1.0
-                    : 0.0,
-                duration: const Duration(milliseconds: 300),
-                child: IgnorePointer(
-                  ignoring: !_showControlsOverlay,
-                  child: _buildControlsOverlay(context, service, state),
+                    // Buffering indicator
+                    if (state.isBuffering)
+                      Container(
+                        color: Colors.black45,
+                        child: const CircularProgressIndicator(
+                          color: Colors.white,
+                        ),
+                      ),
+                  ],
                 ),
               ),
 
+              // Controls overlay with fade animation — hidden entirely while
+              // locked so only the lock button remains interactive.
+              if (!_isLocked)
+                AnimatedOpacity(
+                  opacity: (widget.showControls && _showControlsOverlay)
+                      ? 1.0
+                      : 0.0,
+                  duration: const Duration(milliseconds: 300),
+                  child: IgnorePointer(
+                    ignoring: !_showControlsOverlay,
+                    child: _buildControlsOverlay(context, service, state),
+                  ),
+                ),
+
               // Network quality badge
-              if (state.metrics != null)
+              if (!_isLocked && state.metrics != null)
                 Positioned(
                   top: 8,
                   right: 8,
@@ -298,22 +382,25 @@ class _VideoPlayerWidgetState extends ConsumerState<VideoPlayerWidget> {
                 ),
 
               // Quality indicator and Live badge
-              Positioned(
-                top: 8,
-                left: 8,
-                child: Row(
-                  children: [
-                    _buildQualityBadge(state.currentQuality),
-                    const SizedBox(width: 8),
-                    // Live badge - shows "LIVE" when at live edge
-                    LiveBadge(state: state, showWhenNotLive: true),
-                    // Note: DelayIndicator removed for cleaner UI per design spec
-                  ],
+              if (!_isLocked)
+                Positioned(
+                  top: 8,
+                  left: 8,
+                  child: Row(
+                    children: [
+                      _buildQualityBadge(state.currentQuality),
+                      const SizedBox(width: 8),
+                      // Live badge - shows "LIVE" when at live edge
+                      LiveBadge(state: state, showWhenNotLive: true),
+                      // Note: DelayIndicator removed for cleaner UI per design spec
+                    ],
+                  ),
                 ),
-              ),
 
               // Previous/Next channel buttons (for fullscreen mode)
-              if (widget.enableSwipeChannelChange && _showControlsOverlay)
+              if (!_isLocked &&
+                  widget.enableSwipeChannelChange &&
+                  _showControlsOverlay)
                 Positioned(
                   left: 16,
                   top: 0,
@@ -326,7 +413,9 @@ class _VideoPlayerWidgetState extends ConsumerState<VideoPlayerWidget> {
                     ),
                   ),
                 ),
-              if (widget.enableSwipeChannelChange && _showControlsOverlay)
+              if (!_isLocked &&
+                  widget.enableSwipeChannelChange &&
+                  _showControlsOverlay)
                 Positioned(
                   right: 16,
                   top: 0,
@@ -339,6 +428,29 @@ class _VideoPlayerWidgetState extends ConsumerState<VideoPlayerWidget> {
                     ),
                   ),
                 ),
+
+              // Lock button: visible whenever the normal controls would be
+              // (fades with them), but stays visible when locked regardless
+              // of the hide timer — it's the only way back to unlocked.
+              Positioned(
+                top: 8,
+                right: 56,
+                child: AnimatedOpacity(
+                  opacity: (_isLocked || _showControlsOverlay) ? 1.0 : 0.0,
+                  duration: const Duration(milliseconds: 300),
+                  child: Container(
+                    decoration: BoxDecoration(
+                      color: Colors.black45,
+                      borderRadius: BorderRadius.circular(4),
+                    ),
+                    child: PlayerLockButton(
+                      key: const ValueKey('iptv-player-lock-button'),
+                      locked: _isLocked,
+                      onToggle: _toggleLocked,
+                    ),
+                  ),
+                ),
+              ),
 
               // Channel change overlay
               if (_channelChangeOverlayText != null)
@@ -631,16 +743,18 @@ class _VideoPlayerWidgetState extends ConsumerState<VideoPlayerWidget> {
                   Row(
                     mainAxisAlignment: MainAxisAlignment.spaceBetween,
                     children: [
-                      // Mute button + YouTube-style volume slider
-                      _VolumeControl(
-                        key: const ValueKey('iptv-player-volume-control'),
-                        volume: state.volume,
-                        isMuted: state.isMuted,
-                        onToggleMute: () => service.toggleMute(),
-                        onVolumeChanged: (value) {
-                          if (state.isMuted) service.toggleMute();
-                          service.setVolume(value);
-                        },
+                      // Mute toggle. Fine volume control is the right-half
+                      // drag gesture (PlayerGestureOverlay) — the old
+                      // hover-to-reveal slider never worked on touch devices.
+                      _PlayerControlButton(
+                        key: const ValueKey('iptv-player-mute-button'),
+                        icon: state.isMuted || state.volume == 0
+                            ? Icons.volume_off
+                            : state.volume < 0.5
+                            ? Icons.volume_down
+                            : Icons.volume_up,
+                        tooltip: state.isMuted ? 'Unmute' : 'Mute',
+                        onPressed: () => service.toggleMute(),
                       ),
                       const Spacer(),
                       // Aspect ratio toggle
@@ -846,87 +960,6 @@ class _VideoPlayerWidgetState extends ConsumerState<VideoPlayerWidget> {
       case AiroPlaybackViewFit.stretch:
         return BoxFit.fill;
     }
-  }
-}
-
-/// YouTube-style volume control: a mute icon that reveals a horizontal
-/// slider on hover/focus instead of taking up permanent control-bar width.
-class _VolumeControl extends StatefulWidget {
-  const _VolumeControl({
-    super.key,
-    required this.volume,
-    required this.isMuted,
-    required this.onToggleMute,
-    required this.onVolumeChanged,
-  });
-
-  final double volume;
-  final bool isMuted;
-  final VoidCallback onToggleMute;
-  final ValueChanged<double> onVolumeChanged;
-
-  @override
-  State<_VolumeControl> createState() => _VolumeControlState();
-}
-
-class _VolumeControlState extends State<_VolumeControl> {
-  static const _sliderWidth = 72.0;
-
-  bool _expanded = false;
-
-  void _setExpanded(bool expanded) {
-    if (_expanded == expanded) return;
-    setState(() => _expanded = expanded);
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    final effectiveVolume = widget.isMuted ? 0.0 : widget.volume;
-    return MouseRegion(
-      onEnter: (_) => _setExpanded(true),
-      onExit: (_) => _setExpanded(false),
-      child: Row(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          _PlayerControlButton(
-            icon: effectiveVolume == 0
-                ? Icons.volume_off
-                : effectiveVolume < 0.5
-                ? Icons.volume_down
-                : Icons.volume_up,
-            tooltip: widget.isMuted ? 'Unmute' : 'Mute',
-            onPressed: widget.onToggleMute,
-          ),
-          ClipRect(
-            child: AnimatedContainer(
-              duration: const Duration(milliseconds: 200),
-              curve: Curves.easeOut,
-              width: _expanded ? _sliderWidth : 0,
-              child: SliderTheme(
-                data: SliderTheme.of(context).copyWith(
-                  trackHeight: 3,
-                  activeTrackColor: Colors.white,
-                  inactiveTrackColor: Colors.white24,
-                  thumbColor: Colors.white,
-                  overlayColor: Colors.white24,
-                  thumbShape: const RoundSliderThumbShape(
-                    enabledThumbRadius: 6,
-                  ),
-                  overlayShape: const RoundSliderOverlayShape(
-                    overlayRadius: 12,
-                  ),
-                ),
-                child: Slider(
-                  key: const ValueKey('iptv-player-volume-slider'),
-                  value: effectiveVolume,
-                  onChanged: widget.onVolumeChanged,
-                ),
-              ),
-            ),
-          ),
-        ],
-      ),
-    );
   }
 }
 

--- a/packages/feature_iptv/pubspec.yaml
+++ b/packages/feature_iptv/pubspec.yaml
@@ -40,6 +40,7 @@ dependencies:
   product_capabilities:
     path: ../product_capabilities
   path_provider: ^2.1.6
+  screen_brightness: ^2.1.11
   shared_preferences: ^2.5.5
   slm_edge_intelligence:
     git:

--- a/packages/feature_iptv/test/iptv/presentation/tv/iptv_tv_screen_test.dart
+++ b/packages/feature_iptv/test/iptv/presentation/tv/iptv_tv_screen_test.dart
@@ -1,6 +1,5 @@
 import 'package:feature_iptv/feature_iptv.dart';
 import 'package:flutter/foundation.dart';
-import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter/services.dart';
@@ -274,7 +273,7 @@ void main() {
     await tester.pump();
   });
 
-  testWidgets('volume slider is present and adjustable', (tester) async {
+  testWidgets('mute button is present and toggles mute', (tester) async {
     await pumpScreen(
       tester,
       streamingState: StreamingState(
@@ -286,24 +285,14 @@ void main() {
       settle: false,
     );
 
-    final volumeControl = find.byKey(
-      const ValueKey('iptv-player-volume-control'),
-    );
-    expect(volumeControl, findsOneWidget);
+    // Fine volume control moved to the Netflix-style right-half drag gesture
+    // (see player_gesture_overlay_test.dart); the old hover-to-reveal slider
+    // never worked on touch devices and was removed. This mute toggle is the
+    // remaining quick-access volume control in the button row.
+    final muteButton = find.byKey(const ValueKey('iptv-player-mute-button'));
+    expect(muteButton, findsOneWidget);
 
-    // Hover to expand the collapsed slider before interacting with it.
-    final gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
-    addTearDown(gesture.removePointer);
-    await gesture.addPointer(location: tester.getCenter(volumeControl));
-    await tester.pump(const Duration(milliseconds: 250));
-
-    final slider = find.byKey(const ValueKey('iptv-player-volume-slider'));
-    expect(slider, findsOneWidget);
-
-    // Invoke the callback directly rather than a pixel-offset drag: the
-    // slider sits inside a hovered, animated, nested overlay stack where
-    // real hit-testing is flaky, but the wiring itself is what matters here.
-    tester.widget<Slider>(slider).onChanged!(0.5);
+    await tester.tap(muteButton);
     await tester.pump();
 
     await tester.pumpWidget(const SizedBox.shrink());

--- a/packages/feature_iptv/test/iptv/presentation/widgets/player_gesture_math_test.dart
+++ b/packages/feature_iptv/test/iptv/presentation/widgets/player_gesture_math_test.dart
@@ -1,0 +1,64 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:feature_iptv/presentation/widgets/player_gesture_overlay.dart';
+
+void main() {
+  group('playerGestureValueDelta', () {
+    test('dragging up (negative dy) increases the value', () {
+      expect(playerGestureValueDelta(dy: -100, viewportHeight: 400), 0.25);
+    });
+
+    test('dragging down (positive dy) decreases the value', () {
+      expect(playerGestureValueDelta(dy: 100, viewportHeight: 400), -0.25);
+    });
+
+    test('a full-height drag maps to a 100% change', () {
+      expect(playerGestureValueDelta(dy: -400, viewportHeight: 400), 1.0);
+    });
+
+    test('zero movement produces zero change', () {
+      expect(playerGestureValueDelta(dy: 0, viewportHeight: 400), 0.0);
+    });
+
+    test('a non-positive viewport height never divides by zero', () {
+      expect(playerGestureValueDelta(dy: -50, viewportHeight: 0), 0.0);
+      expect(playerGestureValueDelta(dy: -50, viewportHeight: -10), 0.0);
+    });
+  });
+
+  group('clampPlayerGestureValue', () {
+    test('clamps below zero up to zero', () {
+      expect(clampPlayerGestureValue(-0.3), 0.0);
+    });
+
+    test('clamps above one down to one', () {
+      expect(clampPlayerGestureValue(1.4), 1.0);
+    });
+
+    test('leaves in-range values untouched', () {
+      expect(clampPlayerGestureValue(0.42), 0.42);
+    });
+  });
+
+  group('PlayerGestureZone.forDx', () {
+    test('the left half of the viewport is the brightness zone', () {
+      expect(
+        PlayerGestureZone.forDx(dx: 50, viewportWidth: 300),
+        PlayerGestureZone.brightness,
+      );
+    });
+
+    test('the right half of the viewport is the volume zone', () {
+      expect(
+        PlayerGestureZone.forDx(dx: 250, viewportWidth: 300),
+        PlayerGestureZone.volume,
+      );
+    });
+
+    test('the exact midpoint counts as the volume (right) zone', () {
+      expect(
+        PlayerGestureZone.forDx(dx: 150, viewportWidth: 300),
+        PlayerGestureZone.volume,
+      );
+    });
+  });
+}

--- a/packages/feature_iptv/test/iptv/presentation/widgets/player_gesture_overlay_test.dart
+++ b/packages/feature_iptv/test/iptv/presentation/widgets/player_gesture_overlay_test.dart
@@ -1,0 +1,112 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:feature_iptv/presentation/widgets/player_gesture_overlay.dart';
+
+void main() {
+  // MaterialApp/Navigator gives `home` TIGHT constraints from the test
+  // surface (800x600 by default) — wrapping it in a SizedBox doesn't shrink
+  // it, since tight constraints always win. Shrinking the actual test
+  // surface via `tester.view` is the only way to control the viewport the
+  // gesture zones split against.
+  Future<void> pumpOverlay(
+    WidgetTester tester, {
+    bool locked = false,
+    double brightness = 0.5,
+    double volume = 0.5,
+    ValueChanged<double>? onBrightnessChanged,
+    ValueChanged<double>? onVolumeChanged,
+  }) {
+    tester.view.physicalSize = const Size(300, 400);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+    return tester.pumpWidget(
+      MaterialApp(
+        home: PlayerGestureOverlay(
+          locked: locked,
+          brightness: brightness,
+          volume: volume,
+          onBrightnessChanged: onBrightnessChanged ?? (_) {},
+          onVolumeChanged: onVolumeChanged ?? (_) {},
+          child: const ColoredBox(color: Colors.black),
+        ),
+      ),
+    );
+  }
+
+  testWidgets(
+    'dragging up on the left half increases brightness and never touches volume',
+    (tester) async {
+      final brightnessValues = <double>[];
+      final volumeValues = <double>[];
+      await pumpOverlay(
+        tester,
+        brightness: 0.5,
+        onBrightnessChanged: brightnessValues.add,
+        onVolumeChanged: volumeValues.add,
+      );
+
+      // Left quarter of the 300-wide surface is the brightness zone.
+      await tester.dragFrom(const Offset(50, 300), const Offset(0, -120));
+      await tester.pump();
+
+      expect(volumeValues, isEmpty);
+      expect(brightnessValues, isNotEmpty);
+      expect(brightnessValues.last, greaterThan(0.5));
+    },
+  );
+
+  testWidgets(
+    'dragging down on the right half decreases volume and never touches brightness',
+    (tester) async {
+      final brightnessValues = <double>[];
+      final volumeValues = <double>[];
+      await pumpOverlay(
+        tester,
+        volume: 0.5,
+        onBrightnessChanged: brightnessValues.add,
+        onVolumeChanged: volumeValues.add,
+      );
+
+      // Right quarter of the 300-wide surface is the volume zone.
+      await tester.dragFrom(const Offset(250, 100), const Offset(0, 120));
+      await tester.pump();
+
+      expect(brightnessValues, isEmpty);
+      expect(volumeValues, isNotEmpty);
+      expect(volumeValues.last, lessThan(0.5));
+    },
+  );
+
+  testWidgets('shows a value indicator while dragging', (tester) async {
+    await pumpOverlay(tester);
+
+    final gesture = await tester.startGesture(const Offset(250, 300));
+    await gesture.moveBy(const Offset(0, -50));
+    await tester.pump();
+
+    expect(find.textContaining('%'), findsOneWidget);
+
+    await gesture.up();
+  });
+
+  testWidgets('locked overlay ignores drags entirely', (tester) async {
+    final brightnessValues = <double>[];
+    final volumeValues = <double>[];
+    await pumpOverlay(
+      tester,
+      locked: true,
+      onBrightnessChanged: brightnessValues.add,
+      onVolumeChanged: volumeValues.add,
+    );
+
+    await tester.dragFrom(const Offset(50, 300), const Offset(0, -120));
+    await tester.pump();
+    await tester.dragFrom(const Offset(250, 300), const Offset(0, -120));
+    await tester.pump();
+
+    expect(brightnessValues, isEmpty);
+    expect(volumeValues, isEmpty);
+    expect(find.textContaining('%'), findsNothing);
+  });
+}

--- a/packages/feature_iptv/test/iptv/presentation/widgets/player_lock_button_test.dart
+++ b/packages/feature_iptv/test/iptv/presentation/widgets/player_lock_button_test.dart
@@ -1,0 +1,32 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:feature_iptv/presentation/widgets/player_lock_button.dart';
+
+void main() {
+  testWidgets('shows a closed lock icon when unlocked', (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(home: PlayerLockButton(locked: false, onToggle: () {})),
+    );
+    expect(find.byIcon(Icons.lock_outline), findsOneWidget);
+    expect(find.byIcon(Icons.lock_open), findsNothing);
+  });
+
+  testWidgets('shows an open lock icon when locked', (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(home: PlayerLockButton(locked: true, onToggle: () {})),
+    );
+    expect(find.byIcon(Icons.lock_open), findsOneWidget);
+    expect(find.byIcon(Icons.lock_outline), findsNothing);
+  });
+
+  testWidgets('tapping calls onToggle', (tester) async {
+    var toggled = false;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: PlayerLockButton(locked: false, onToggle: () => toggled = true),
+      ),
+    );
+    await tester.tap(find.byType(PlayerLockButton));
+    expect(toggled, isTrue);
+  });
+}

--- a/packages/feature_iptv/test/iptv/presentation/widgets/system_brightness_controller_test.dart
+++ b/packages/feature_iptv/test/iptv/presentation/widgets/system_brightness_controller_test.dart
@@ -1,0 +1,26 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:feature_iptv/presentation/widgets/player_brightness_controller.dart';
+
+void main() {
+  group('FakePlayerBrightnessController', () {
+    test('starts at the configured initial brightness', () async {
+      final controller = FakePlayerBrightnessController(initial: 0.7);
+      expect(await controller.currentBrightness(), 0.7);
+    });
+
+    test('setBrightness updates the current value', () async {
+      final controller = FakePlayerBrightnessController(initial: 0.5);
+      await controller.setBrightness(0.9);
+      expect(await controller.currentBrightness(), 0.9);
+      expect(controller.setBrightnessCalls, [0.9]);
+    });
+
+    test('resetBrightness restores the initial value', () async {
+      final controller = FakePlayerBrightnessController(initial: 0.4);
+      await controller.setBrightness(0.1);
+      await controller.resetBrightness();
+      expect(await controller.currentBrightness(), 0.4);
+      expect(controller.resetCalls, 1);
+    });
+  });
+}

--- a/packages/feature_iptv/test/iptv/presentation/widgets/video_player_widget_test.dart
+++ b/packages/feature_iptv/test/iptv/presentation/widgets/video_player_widget_test.dart
@@ -1,0 +1,95 @@
+import 'package:feature_iptv/feature_iptv.dart';
+import 'package:feature_iptv/presentation/widgets/player_brightness_controller.dart';
+import 'package:feature_iptv/presentation/widgets/player_lock_button.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  Future<void> pumpPlayer(
+    WidgetTester tester, {
+    bool enableSwipeChannelChange = false,
+    PlayerBrightnessController? brightnessController,
+  }) async {
+    SharedPreferences.setMockInitialValues({});
+    final prefs = await SharedPreferences.getInstance();
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          sharedPreferencesProvider.overrideWithValue(prefs),
+          streamingStateProvider.overrideWith(
+            (ref) => Stream.value(
+              const StreamingState(
+                playbackState: PlaybackState.idle,
+                isLiveStream: true,
+                currentChannel: IPTVChannel(
+                  id: 'news-1',
+                  name: 'City News Live',
+                  streamUrl: 'https://example.com/news.m3u8',
+                  group: 'News',
+                  category: ChannelCategory.news,
+                ),
+              ),
+            ),
+          ),
+        ],
+        child: MaterialApp(
+          home: VideoPlayerWidget(
+            enableSwipeChannelChange: enableSwipeChannelChange,
+            brightnessController: brightnessController,
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 100));
+  }
+
+  testWidgets(
+    'locking hides playback controls but keeps the lock button interactive',
+    (tester) async {
+      await pumpPlayer(tester, enableSwipeChannelChange: true);
+
+      expect(find.byIcon(Icons.play_arrow), findsOneWidget);
+      expect(find.byIcon(Icons.skip_previous), findsOneWidget);
+      expect(find.byIcon(Icons.skip_next), findsOneWidget);
+
+      await tester.tap(find.byType(PlayerLockButton));
+      await tester.pump();
+
+      expect(find.byIcon(Icons.play_arrow), findsNothing);
+      expect(find.byIcon(Icons.skip_previous), findsNothing);
+      expect(find.byIcon(Icons.skip_next), findsNothing);
+      expect(find.byType(PlayerLockButton), findsOneWidget);
+    },
+  );
+
+  testWidgets('tapping the lock button again unlocks and restores controls', (
+    tester,
+  ) async {
+    await pumpPlayer(tester);
+
+    await tester.tap(find.byType(PlayerLockButton));
+    await tester.pump();
+    expect(find.byIcon(Icons.play_arrow), findsNothing);
+
+    await tester.tap(find.byType(PlayerLockButton));
+    await tester.pump();
+    expect(find.byIcon(Icons.play_arrow), findsOneWidget);
+  });
+
+  testWidgets('resets brightness via the injected controller on dispose', (
+    tester,
+  ) async {
+    final controller = FakePlayerBrightnessController(initial: 0.6);
+    await pumpPlayer(tester, brightnessController: controller);
+    expect(controller.resetCalls, 0);
+
+    await tester.pumpWidget(const SizedBox.shrink());
+    await tester.pump();
+
+    expect(controller.resetCalls, 1);
+  });
+}


### PR DESCRIPTION
Fixes the reported bug: on Pixel 9 (and any touch device), the volume slider was unreachable. Root cause — `_VolumeControl`'s slider only expanded via `MouseRegion.onEnter/onExit` (hover), which never fires on touch, so the slider stayed permanently `width: 0`.

Also asked for: Netflix-style brightness + volume gestures and a lock-screen button, since neither existed anywhere in the app before this.

## What shipped

- **`PlayerGestureOverlay`** — vertical drag on the left half of the video surface adjusts screen brightness, right half adjusts volume (standard Netflix/YouTube split), with an ephemeral icon+fill indicator while dragging.
- **`PlayerLockButton`** — standard lock/unlock icon toggle. While locked: play/pause, mute, aspect ratio, cinema mode, fullscreen, channel skip, and the gesture zones are all disabled or unrendered — only the lock button stays tappable.
- **`PlayerBrightnessController`** — abstraction over the `screen_brightness` plugin (app-scoped brightness, auto-resets on background/exit), with a `Fake` for tests. Reads/writes wrapped in try/catch since the plugin has no Linux implementation and limited web support.
- Old `_VolumeControl` (hover-reveal slider) deleted.

## New dependency

`screen_brightness: ^2.1.11` — MIT license, pub score 160/160, actively maintained. Reviewed by Chief Open Source Officer (approve) and Flutter Architect (approve, one blocking finding fixed below).

## Review notes (self-requested council review during dev)

Ran Chief Open Source Officer + Flutter Architect review before opening this PR:
- **Fixed**: unhandled async errors on every brightness-drag frame and on dispose (`setBrightness`/`resetBrightness` weren't wrapped in try/catch, unlike the existing read path) — real crash risk on platforms without brightness support. Now guarded consistently.
- **Fixed**: outer tap-to-show-controls wasn't explicitly gated by `_isLocked` (harmless today since the controls layer is unrendered when locked, but incidental, not by design).
- **Fixed**: zero widget coverage for `VideoPlayerWidget` itself (pre-existing gap, not introduced by this PR) — added `video_player_widget_test.dart` covering lock-state gating and dispose-time brightness reset, using the same `FakePlayerBrightnessController` seam already built for the isolated unit tests.
- **Open, not fixed**: possible mute/volume race during a fast drag — `onVolumeChanged` reads `state.isMuted` from the last Riverpod build, and `onVerticalDragUpdate` can fire faster than the provider re-emits after `toggleMute()`, so a very fast drag could double-toggle mute. This pattern already existed in the old slider's `onChanged`, just amplified by gesture frequency. Flagging for **Media Intelligence Architect** (package owner) rather than guessing a fix into provider-timing territory I don't own.

Per this repo's Decision Matrix, this still wants sign-off from **Media Intelligence Architect** (package owner), **Chief Performance Officer** (per-frame `setState` cost during drag), and **Chief Security Officer** (new dependency) before merge — flagging here since I can't request GitHub reviewers by role directly.

## Tests

- Pure gesture-math unit tests (drag-delta → value, clamping, zone split)
- Isolated widget tests: `PlayerGestureOverlay` (drag zones don't cross-contaminate, locked ignores drags, shows indicator), `PlayerLockButton`, `FakePlayerBrightnessController`
- New `video_player_widget_test.dart`: lock hides controls but keeps lock button interactive, unlock restores controls, brightness resets on dispose
- Updated the one pre-existing test that exercised the now-removed hover slider (`iptv_tv_screen_test.dart`)

Full `feature_iptv` suite: 250/250 green, `dart analyze` clean (no new issues), `dart format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)