### PR TITLE
chore(release): bump Airo TV pubspec to 0.0.3-rc.4+4

### DIFF
--- a/app/pubspec_tv.yaml
+++ b/app/pubspec_tv.yaml
@@ -11,7 +11,7 @@
 name: airo_app
 description: "Airo TV - IPTV streaming for Android TV"
 publish_to: 'none'
-version: 0.0.3-rc.1+3
+version: 0.0.3-rc.4+4
 
 environment:
   sdk: ">=3.12.2 <4.0.0"


### PR DESCRIPTION
## Summary

Version-only prep for the next Airo TV RC. `app/pubspec_tv.yaml` was still pinned at `0.0.3-rc.1+3` despite git tags already reaching `v0.0.3-rc.3` (checkpoint tags, never published as GitHub Releases) and stable `airo-tv-v0.0.3` shipping since. No build, tag, or publish here.

## Why the actual RC build/publish isn't in this PR

Investigated cutting the real `airo-tv-v0.0.3-rc.4` artifact and hit a real blocker (see #846 for full writeup):

- Signed Android release builds need CI-only keystore secrets (`ANDROID_RELEASE_KEYSTORE_BASE64` etc.) -- can't produce those locally, won't fabricate/bypass.
- A bare `v0.0.3-rc.4` git tag matches `build-and-release.yml`'s `v*` trigger, which is the **generic Airo Super App** pipeline, not TV -- confirmed by checking today's `Airo Super App v0.0.3-rc.1/2/3` releases, which are that pipeline, not TV builds. Pushing a naive tag would have published the wrong thing.
- The only `workflow_dispatch` path with real signing secrets (`v2-release-orchestrator.yml`) builds TV + mobile/tablet + macOS together, not TV-only.

Left the decision on which path to run (full orchestrator in dry-run/draft mode, or someone with local signing secrets) to a human call rather than guessing further.

## Tests

`scripts/check-android-tv-release.sh` passes; `flutter pub get` resolves cleanly against the bumped version.

Part of #846.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
