### PR TITLE
feat(feature_iptv): CV-006 slice 3 -- TV search results panel (AUTO-003)

### DIFF
--- a/packages/feature_iptv/lib/application/providers/local_iptv_search_providers.dart
+++ b/packages/feature_iptv/lib/application/providers/local_iptv_search_providers.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_riverpod/legacy.dart';
 import 'package:platform_epg/platform_epg.dart';
 
 import '../../domain/local_iptv_search.dart';
@@ -38,3 +39,18 @@ final localIptvSearchIndexProvider = FutureProvider<LocalIptvSearchIndex>((
     recentChannelIds: [for (final channel in recentChannels) channel.id],
   );
 });
+
+/// The search screen's query text. Independent of [channelSearchQueryProvider]
+/// (the Live TV grid's quick-filter) -- opening search must not perturb the
+/// grid, matching [guideSearchQueryProvider]'s existing independence pattern.
+final localIptvSearchQueryProvider = StateProvider<String>((ref) => '');
+
+/// Ranked results for the current [localIptvSearchQueryProvider] value.
+final localIptvSearchResultsProvider =
+    FutureProvider<List<LocalIptvSearchResult>>((ref) async {
+      final query = ref.watch(localIptvSearchQueryProvider);
+      if (query.trim().isEmpty) return const [];
+
+      final index = await ref.watch(localIptvSearchIndexProvider.future);
+      return index.search(query);
+    });

--- a/packages/feature_iptv/lib/feature_iptv.dart
+++ b/packages/feature_iptv/lib/feature_iptv.dart
@@ -27,3 +27,4 @@ export "presentation/widgets/iptv_navigation_drawer.dart";
 export "presentation/widgets/phone_media_play_on_tv_sheet.dart";
 export "presentation/widgets/xmltv_source_sheet.dart";
 export "presentation/widgets/epg_match_override_sheet.dart";
+export "presentation/widgets/local_search_results_panel.dart";

--- a/packages/feature_iptv/lib/presentation/widgets/local_search_results_panel.dart
+++ b/packages/feature_iptv/lib/presentation/widgets/local_search_results_panel.dart
@@ -1,0 +1,179 @@
+import 'package:core_ui/core_ui.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../application/providers/iptv_providers.dart';
+import '../../application/providers/local_iptv_search_providers.dart';
+import '../../domain/local_iptv_search.dart';
+
+/// TV-safe local search results panel (CV-006 AUTO-003): grouped channel and
+/// program results for [localIptvSearchQueryProvider], focus-safe and
+/// overflow-safe at TV viewport sizes.
+class LocalSearchResultsPanel extends ConsumerWidget {
+  const LocalSearchResultsPanel({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final query = ref.watch(localIptvSearchQueryProvider);
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+
+    if (query.trim().isEmpty) {
+      return Center(
+        child: Text(
+          'Search your channels and guide',
+          style: theme.textTheme.bodyLarge?.copyWith(
+            color: colorScheme.onSurfaceVariant,
+          ),
+        ),
+      );
+    }
+
+    final resultsAsync = ref.watch(localIptvSearchResultsProvider);
+
+    return resultsAsync.when(
+      loading: () => const Center(child: CircularProgressIndicator()),
+      error: (error, _) => Center(child: Text('Search failed. Try again.')),
+      data: (results) {
+        if (results.isEmpty) {
+          return Center(
+            child: Text(
+              'No results for "$query"',
+              style: theme.textTheme.bodyLarge?.copyWith(
+                color: colorScheme.onSurfaceVariant,
+              ),
+            ),
+          );
+        }
+
+        final channelResults = results
+            .where((r) => r.type == LocalIptvSearchResultType.channel)
+            .toList(growable: false);
+        final programResults = results
+            .where((r) => r.type == LocalIptvSearchResultType.program)
+            .toList(growable: false);
+
+        return ListView(
+          padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 16),
+          children: [
+            if (channelResults.isNotEmpty) ...[
+              _SectionHeader('Channels'),
+              const SizedBox(height: 8),
+              for (var i = 0; i < channelResults.length; i++)
+                _ResultRow(result: channelResults[i], autofocus: i == 0),
+              const SizedBox(height: 20),
+            ],
+            if (programResults.isNotEmpty) ...[
+              _SectionHeader('Guide'),
+              const SizedBox(height: 8),
+              for (var i = 0; i < programResults.length; i++)
+                _ResultRow(
+                  result: programResults[i],
+                  autofocus: channelResults.isEmpty && i == 0,
+                ),
+            ],
+          ],
+        );
+      },
+    );
+  }
+}
+
+class _SectionHeader extends StatelessWidget {
+  const _SectionHeader(this.label);
+
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    return Text(
+      label,
+      style: Theme.of(context).textTheme.titleSmall?.copyWith(
+        color: Theme.of(context).colorScheme.onSurfaceVariant,
+        fontWeight: FontWeight.w700,
+        letterSpacing: 0.5,
+      ),
+    );
+  }
+}
+
+class _ResultRow extends ConsumerWidget {
+  const _ResultRow({required this.result, this.autofocus = false});
+
+  final LocalIptvSearchResult result;
+  final bool autofocus;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final isProgram = result.type == LocalIptvSearchResultType.program;
+
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 8),
+      child: TvFocusable(
+        autofocus: autofocus,
+        onSelect: () {
+          if (isProgram) return;
+          final channels = ref.read(iptvChannelsProvider).value ?? const [];
+          for (final channel in channels) {
+            if (channel.id == result.channelId) {
+              ref.read(iptvStreamingServiceProvider).playChannel(channel);
+              ref.read(addToRecentlyWatchedProvider(channel));
+              break;
+            }
+          }
+        },
+        semanticLabel: result.title,
+        semanticHint: isProgram
+            ? 'Guide result for ${result.subtitle ?? result.title}'
+            : 'Press OK to play this channel',
+        semanticButton: true,
+        borderRadius: 10,
+        child: DecoratedBox(
+          decoration: BoxDecoration(
+            color: colorScheme.surface,
+            border: Border.all(color: colorScheme.outlineVariant),
+            borderRadius: BorderRadius.circular(10),
+          ),
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+            child: Row(
+              children: [
+                Icon(
+                  isProgram ? Icons.live_tv_rounded : Icons.tv_rounded,
+                  size: 20,
+                  color: colorScheme.onSurfaceVariant,
+                ),
+                const SizedBox(width: 12),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Text(
+                        result.title,
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                        style: Theme.of(context).textTheme.bodyLarge,
+                      ),
+                      if (result.subtitle != null)
+                        Text(
+                          result.subtitle!,
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                          style: Theme.of(context).textTheme.bodySmall
+                              ?.copyWith(color: colorScheme.onSurfaceVariant),
+                        ),
+                    ],
+                  ),
+                ),
+                if (result.isFavorite)
+                  Icon(Icons.favorite, size: 16, color: colorScheme.error),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/packages/feature_iptv/test/iptv/presentation/widgets/local_search_results_panel_test.dart
+++ b/packages/feature_iptv/test/iptv/presentation/widgets/local_search_results_panel_test.dart
@@ -1,0 +1,92 @@
+import 'package:core_ui/core_ui.dart';
+import 'package:feature_iptv/feature_iptv.dart';
+import 'package:feature_iptv/presentation/widgets/local_search_results_panel.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  late SharedPreferences prefs;
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    prefs = await SharedPreferences.getInstance();
+  });
+
+  const bbcNews = IPTVChannel(
+    id: 'c1',
+    name: 'BBC News',
+    streamUrl: 'https://example.com/c1.m3u8',
+    group: 'News',
+  );
+  const cnn = IPTVChannel(
+    id: 'c2',
+    name: 'CNN International',
+    streamUrl: 'https://example.com/c2.m3u8',
+    group: 'News',
+  );
+
+  Future<void> pumpPanel(
+    WidgetTester tester, {
+    List<IPTVChannel> channels = const [bbcNews, cnn],
+    String query = '',
+  }) async {
+    tester.view.physicalSize = const Size(1280, 720);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.reset);
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          sharedPreferencesProvider.overrideWithValue(prefs),
+          iptvChannelsProvider.overrideWith((ref) async => channels),
+          compactEpgRepositoryProvider.overrideWithValue(
+            const EmptyCompactEpgRepository(),
+          ),
+          localIptvSearchQueryProvider.overrideWith((ref) => query),
+        ],
+        child: const MaterialApp(
+          home: Scaffold(body: LocalSearchResultsPanel()),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  testWidgets('empty query shows a prompt, not results', (tester) async {
+    await pumpPanel(tester, query: '');
+
+    expect(find.textContaining('Search'), findsWidgets);
+    expect(find.text('BBC News'), findsNothing);
+  });
+
+  testWidgets('shows matching channel results grouped under a header', (
+    tester,
+  ) async {
+    await pumpPanel(tester, query: 'BBC');
+
+    expect(find.text('Channels'), findsOneWidget);
+    expect(find.text('BBC News'), findsOneWidget);
+    expect(find.text('CNN International'), findsNothing);
+  });
+
+  testWidgets('shows an empty state when nothing matches', (tester) async {
+    await pumpPanel(tester, query: 'zzz-no-match');
+
+    expect(find.textContaining('No results'), findsOneWidget);
+  });
+
+  testWidgets('result rows are TV-focusable', (tester) async {
+    await pumpPanel(tester, query: 'BBC');
+
+    expect(find.byType(TvFocusable), findsWidgets);
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('does not overflow at TV viewport size', (tester) async {
+    await pumpPanel(tester, query: 'News');
+
+    expect(tester.takeException(), isNull);
+  });
+}


### PR DESCRIPTION
## Summary

Third and final planned slice of CV-006 (#810), building on #866 (index) and #871 (provider wiring).

- **`localIptvSearchQueryProvider`** -- search screen query state, independent of the Live TV grid's `channelSearchQueryProvider` (same independence pattern `guideSearchQueryProvider` already uses).
- **`localIptvSearchResultsProvider`** -- ranked results for the current query.
- **`LocalSearchResultsPanel`** -- grouped "Channels"/"Guide" sections, TV-safe empty-query and no-results copy, `TvFocusable` rows with autofocus on the first result, favorite indicator, verified no overflow at 1280x720.

## Scope note

Not wired into `tv_router`/`tv_shell` navigation here -- adding a sidebar destination touches live app-level navigation beyond what this milestone slice asked for. Standalone widget lands and reviews independently; nav wiring is a follow-up once this is validated.

## Tests

5 new widget tests (empty-query prompt, grouped channel results, no-results state, focusable rows, no overflow). `feature_iptv` suite 272/272 green, analyze + format clean on touched files.

Closes out CV-006's AUTO-001/002/003 acceptance criteria. Part of #810.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
