### PR TITLE
feat(feature_iptv): CV-016 slice 1 -- VOD seek bar with drag-to-seek

### DIFF
--- a/packages/feature_iptv/lib/presentation/widgets/video_player_widget.dart
+++ b/packages/feature_iptv/lib/presentation/widgets/video_player_widget.dart
@@ -59,6 +59,10 @@ class _VideoPlayerWidgetState extends ConsumerState<VideoPlayerWidget> {
   double _brightness = 0.5;
   late final PlayerBrightnessController _brightnessController;
 
+  // VOD seek bar drag state — null when the user isn't actively dragging,
+  // so the slider tracks live playback position between drags.
+  Duration? _vodSeekDragPosition;
+
   @override
   void initState() {
     super.initState();
@@ -738,6 +742,8 @@ class _VideoPlayerWidgetState extends ConsumerState<VideoPlayerWidget> {
               child: Column(
                 mainAxisSize: MainAxisSize.min,
                 children: [
+                  if (!state.isLiveStream && state.duration > Duration.zero)
+                    _buildVodSeekBar(service, state),
                   _buildBufferIndicator(state),
                   const SizedBox(height: 8),
                   Row(
@@ -878,6 +884,73 @@ class _VideoPlayerWidgetState extends ConsumerState<VideoPlayerWidget> {
         ),
       ),
     );
+  }
+
+  /// VOD-only seek bar (CV-016). Live streams use the live-edge/DVR
+  /// controls instead — this never renders when [StreamingState.isLiveStream]
+  /// is true or the stream has no known duration.
+  Widget _buildVodSeekBar(
+    VideoPlayerStreamingService service,
+    StreamingState state,
+  ) {
+    final durationSeconds = state.duration.inSeconds.toDouble();
+    final displayPosition = (_vodSeekDragPosition ?? state.position).inSeconds
+        .toDouble()
+        .clamp(0.0, durationSeconds);
+
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 4),
+      child: Row(
+        children: [
+          Text(
+            _formatDuration(_vodSeekDragPosition ?? state.position),
+            style: const TextStyle(color: Colors.white70, fontSize: 12),
+          ),
+          Expanded(
+            child: Material(
+              type: MaterialType.transparency,
+              child: SliderTheme(
+                data: SliderTheme.of(context).copyWith(
+                  trackHeight: 3,
+                  thumbShape: const RoundSliderThumbShape(
+                    enabledThumbRadius: 6,
+                  ),
+                ),
+                child: Slider(
+                  key: const ValueKey('iptv-player-vod-seek-bar'),
+                  value: displayPosition,
+                  min: 0,
+                  max: durationSeconds,
+                  activeColor: Colors.white,
+                  inactiveColor: Colors.white24,
+                  onChanged: (value) {
+                    setState(() {
+                      _vodSeekDragPosition = Duration(seconds: value.round());
+                    });
+                  },
+                  onChangeEnd: (value) {
+                    final target = Duration(seconds: value.round());
+                    service.seek(target);
+                    setState(() => _vodSeekDragPosition = null);
+                  },
+                ),
+              ),
+            ),
+          ),
+          Text(
+            _formatDuration(state.duration),
+            style: const TextStyle(color: Colors.white70, fontSize: 12),
+          ),
+        ],
+      ),
+    );
+  }
+
+  String _formatDuration(Duration d) {
+    final minutes = d.inMinutes.remainder(60).toString().padLeft(2, '0');
+    final hours = d.inHours;
+    final seconds = d.inSeconds.remainder(60).toString().padLeft(2, '0');
+    return hours > 0 ? '$hours:$minutes:$seconds' : '$minutes:$seconds';
   }
 
   Widget _buildBufferIndicator(StreamingState state) {

--- a/packages/feature_iptv/test/iptv/presentation/widgets/video_player_widget_test.dart
+++ b/packages/feature_iptv/test/iptv/presentation/widgets/video_player_widget_test.dart
@@ -11,6 +11,7 @@ void main() {
     WidgetTester tester, {
     bool enableSwipeChannelChange = false,
     PlayerBrightnessController? brightnessController,
+    StreamingState? state,
   }) async {
     SharedPreferences.setMockInitialValues({});
     final prefs = await SharedPreferences.getInstance();
@@ -21,17 +22,18 @@ void main() {
           sharedPreferencesProvider.overrideWithValue(prefs),
           streamingStateProvider.overrideWith(
             (ref) => Stream.value(
-              const StreamingState(
-                playbackState: PlaybackState.idle,
-                isLiveStream: true,
-                currentChannel: IPTVChannel(
-                  id: 'news-1',
-                  name: 'City News Live',
-                  streamUrl: 'https://example.com/news.m3u8',
-                  group: 'News',
-                  category: ChannelCategory.news,
-                ),
-              ),
+              state ??
+                  const StreamingState(
+                    playbackState: PlaybackState.idle,
+                    isLiveStream: true,
+                    currentChannel: IPTVChannel(
+                      id: 'news-1',
+                      name: 'City News Live',
+                      streamUrl: 'https://example.com/news.m3u8',
+                      group: 'News',
+                      category: ChannelCategory.news,
+                    ),
+                  ),
             ),
           ),
         ],
@@ -91,5 +93,42 @@ void main() {
     await tester.pump();
 
     expect(controller.resetCalls, 1);
+  });
+
+  testWidgets('shows a VOD seek bar with resume position when not live', (
+    tester,
+  ) async {
+    await pumpPlayer(
+      tester,
+      state: const StreamingState(
+        playbackState: PlaybackState.playing,
+        isLiveStream: false,
+        position: Duration(seconds: 30),
+        duration: Duration(seconds: 120),
+        currentChannel: IPTVChannel(
+          id: 'movie-1',
+          name: 'Sample Movie',
+          streamUrl: 'https://example.com/movie.m3u8',
+          group: 'Movies',
+          category: ChannelCategory.movies,
+        ),
+      ),
+    );
+
+    final seekBar = find.byKey(const ValueKey('iptv-player-vod-seek-bar'));
+    expect(seekBar, findsOneWidget);
+
+    final slider = tester.widget<Slider>(seekBar);
+    expect(slider.max, 120.0);
+    expect(slider.value, 30.0);
+  });
+
+  testWidgets('hides the VOD seek bar for live streams', (tester) async {
+    await pumpPlayer(tester);
+
+    expect(
+      find.byKey(const ValueKey('iptv-player-vod-seek-bar')),
+      findsNothing,
+    );
   });
 }


### PR DESCRIPTION
## Summary
Part of #820 (CV-016). First bounded slice: adds a VOD seek bar to
`VideoPlayerWidget`'s control overlay.

- Shown only when `!StreamingState.isLiveStream && duration > 0` -- live
  streams keep the existing live-edge/DVR controls untouched.
- Wired to the existing `VideoPlayerStreamingService.seek()` -- no
  playback engine changes (per CV-016 non-goals).
- Local drag state (`_vodSeekDragPosition`) so the slider doesn't jump
  mid-drag while position streams in from playback.

## Not in this slice
- Audio/subtitle track selection -- `video_player` package doesn't expose
  track metadata on any platform today; the `AiroPlaybackState.tracks`
  contract exists in `platform_player` but isn't wired into
  `VideoPlayerStreamingService` yet. Needs its own scoped slice.
- Resume-position persistence -- `AiroWatchProgressRepository` already
  exists in `core_watch_progress` (record/policy/fake+no-op impls) but
  isn't wired into this widget yet. Next slice.
- Capability contract flags (`canSelectAudioTrack` etc. from the issue's
  suggested contract) -- not added yet, deferred until track selection
  lands so the flags reflect something real.

## Test plan
- [x] New widget tests: seek bar visible with correct `min`/`max`/`value`
      for VOD state; absent for live state.
- [x] Full `feature_iptv` suite green (274 tests).
- [x] `flutter analyze` on changed files -- one pre-existing unused-import
      warning, unrelated to this diff.
- [x] `dart format --set-exit-if-changed` clean.