### PR TITLE
feat(feature_iptv): CV-008 slice 1 -- persisted caption preference

### DIFF
--- a/packages/feature_iptv/lib/application/providers/caption_preference_provider.dart
+++ b/packages/feature_iptv/lib/application/providers/caption_preference_provider.dart
@@ -1,0 +1,80 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_riverpod/legacy.dart';
+import 'iptv_providers.dart' show sharedPreferencesProvider;
+
+const captionPreferenceEnabledStorageKey = 'caption_preference_enabled';
+const captionPreferenceLanguageStorageKey = 'caption_preference_language';
+
+/// Persisted user preference (CV-008) for whether captions should be
+/// re-enabled automatically when a stream exposes a matching subtitle
+/// track, and which language to prefer.
+///
+/// The last-selected [languageCode] is remembered even after captions are
+/// turned off, so re-enabling them doesn't lose the user's language choice.
+class CaptionPreference {
+  const CaptionPreference({this.enabled = false, this.languageCode});
+
+  final bool enabled;
+  final String? languageCode;
+
+  CaptionPreference copyWith({bool? enabled, String? languageCode}) {
+    return CaptionPreference(
+      enabled: enabled ?? this.enabled,
+      languageCode: languageCode ?? this.languageCode,
+    );
+  }
+}
+
+/// Lives in this package (not the app layer) since VideoPlayerWidget is the
+/// primary consumer and mutator — mirrors [VideoAspectRatioNotifier]'s
+/// storage pattern (CV-031).
+class CaptionPreferenceNotifier extends StateNotifier<CaptionPreference> {
+  final Ref _ref;
+
+  CaptionPreferenceNotifier(this._ref) : super(const CaptionPreference()) {
+    _loadFromStorage();
+  }
+
+  void setCaptionPreference({required bool enabled, String? languageCode}) {
+    state = state.copyWith(enabled: enabled, languageCode: languageCode);
+    _saveToStorage();
+  }
+
+  /// Toggles captions on/off without touching the remembered language.
+  void setCaptionsEnabled(bool enabled) {
+    state = state.copyWith(enabled: enabled);
+    _saveToStorage();
+  }
+
+  Future<void> _loadFromStorage() async {
+    try {
+      final prefs = _ref.read(sharedPreferencesProvider);
+      state = CaptionPreference(
+        enabled: prefs.getBool(captionPreferenceEnabledStorageKey) ?? false,
+        languageCode: prefs.getString(captionPreferenceLanguageStorageKey),
+      );
+    } catch (e) {
+      // Failed to load, keep default
+    }
+  }
+
+  Future<void> _saveToStorage() async {
+    try {
+      final prefs = _ref.read(sharedPreferencesProvider);
+      await prefs.setBool(captionPreferenceEnabledStorageKey, state.enabled);
+      if (state.languageCode != null) {
+        await prefs.setString(
+          captionPreferenceLanguageStorageKey,
+          state.languageCode!,
+        );
+      }
+    } catch (e) {
+      // Failed to save
+    }
+  }
+}
+
+final captionPreferenceProvider =
+    StateNotifierProvider<CaptionPreferenceNotifier, CaptionPreference>(
+      (ref) => CaptionPreferenceNotifier(ref),
+    );

--- a/packages/feature_iptv/lib/feature_iptv.dart
+++ b/packages/feature_iptv/lib/feature_iptv.dart
@@ -9,6 +9,7 @@ export "application/providers/guide_providers.dart";
 export "application/providers/local_iptv_search_providers.dart";
 export "application/providers/playback_settings_extension_point.dart";
 export "application/providers/video_aspect_ratio_provider.dart";
+export "application/providers/caption_preference_provider.dart";
 export "application/content_source_store.dart";
 export "application/epg_channel_match_override_store.dart";
 export "application/mutable_xmltv_compact_epg_repository.dart";

--- a/packages/feature_iptv/test/caption_preference_provider_test.dart
+++ b/packages/feature_iptv/test/caption_preference_provider_test.dart
@@ -1,0 +1,106 @@
+import 'package:feature_iptv/feature_iptv.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  test(
+    'defaults to captions off with no language when nothing is persisted',
+    () async {
+      SharedPreferences.setMockInitialValues({});
+      final prefs = await SharedPreferences.getInstance();
+      final container = ProviderContainer(
+        overrides: [sharedPreferencesProvider.overrideWithValue(prefs)],
+      );
+      addTearDown(container.dispose);
+
+      final pref = container.read(captionPreferenceProvider);
+      expect(pref.enabled, isFalse);
+      expect(pref.languageCode, isNull);
+    },
+  );
+
+  test(
+    'loads a persisted caption preference through the shared store',
+    () async {
+      SharedPreferences.setMockInitialValues({
+        captionPreferenceEnabledStorageKey: true,
+        captionPreferenceLanguageStorageKey: 'es',
+      });
+      final prefs = await SharedPreferences.getInstance();
+      final container = ProviderContainer(
+        overrides: [sharedPreferencesProvider.overrideWithValue(prefs)],
+      );
+      addTearDown(container.dispose);
+
+      final pref = container.read(captionPreferenceProvider);
+      expect(pref.enabled, isTrue);
+      expect(pref.languageCode, 'es');
+    },
+  );
+
+  test('setCaptionPreference persists enabled flag and language', () async {
+    SharedPreferences.setMockInitialValues({});
+    final prefs = await SharedPreferences.getInstance();
+    final container = ProviderContainer(
+      overrides: [sharedPreferencesProvider.overrideWithValue(prefs)],
+    );
+    addTearDown(container.dispose);
+
+    container
+        .read(captionPreferenceProvider.notifier)
+        .setCaptionPreference(enabled: true, languageCode: 'fr');
+    await Future<void>.delayed(Duration.zero);
+
+    expect(prefs.getBool(captionPreferenceEnabledStorageKey), isTrue);
+    expect(prefs.getString(captionPreferenceLanguageStorageKey), 'fr');
+    final pref = container.read(captionPreferenceProvider);
+    expect(pref.enabled, isTrue);
+    expect(pref.languageCode, 'fr');
+  });
+
+  test(
+    'disabling captions keeps the last-selected language remembered',
+    () async {
+      SharedPreferences.setMockInitialValues({});
+      final prefs = await SharedPreferences.getInstance();
+      final container = ProviderContainer(
+        overrides: [sharedPreferencesProvider.overrideWithValue(prefs)],
+      );
+      addTearDown(container.dispose);
+
+      final notifier = container.read(captionPreferenceProvider.notifier);
+      notifier.setCaptionPreference(enabled: true, languageCode: 'de');
+      await Future<void>.delayed(Duration.zero);
+      notifier.setCaptionsEnabled(false);
+      await Future<void>.delayed(Duration.zero);
+
+      final pref = container.read(captionPreferenceProvider);
+      expect(pref.enabled, isFalse);
+      expect(pref.languageCode, 'de');
+    },
+  );
+
+  test('survives a fresh container read after persisting (restart)', () async {
+    SharedPreferences.setMockInitialValues({});
+    final prefs = await SharedPreferences.getInstance();
+    final container = ProviderContainer(
+      overrides: [sharedPreferencesProvider.overrideWithValue(prefs)],
+    );
+    addTearDown(container.dispose);
+
+    container
+        .read(captionPreferenceProvider.notifier)
+        .setCaptionPreference(enabled: true, languageCode: 'ja');
+    await Future<void>.delayed(Duration.zero);
+
+    final restarted = ProviderContainer(
+      overrides: [sharedPreferencesProvider.overrideWithValue(prefs)],
+    );
+    addTearDown(restarted.dispose);
+
+    final pref = restarted.read(captionPreferenceProvider);
+    expect(pref.enabled, isTrue);
+    expect(pref.languageCode, 'ja');
+  });
+}


### PR DESCRIPTION
## Summary
Part of #812 (CV-008). First bounded slice: local persistence for the
caption enabled/language preference (UC-003 in the issue).

- `CaptionPreferenceNotifier` / `captionPreferenceProvider`, storing
  `enabled` + `languageCode` via `SharedPreferences`.
- Mirrors the existing `VideoAspectRatioNotifier` storage pattern
  (CV-031) already in this package.
- Disabling captions keeps the last-selected language remembered, so
  re-enabling later doesn't lose the choice.

## Not in this slice
- TV font/accessibility mode (UC-001) and D-pad surf mode (UC-002) --
  separate, larger scopes; will follow as their own slices.
- Actually applying the preferred caption track to a playing stream --
  depends on real track selection landing in `VideoPlayerStreamingService`
  first (CV-016, still in progress, see #886). This slice only adds the
  persisted preference contract those later slices will consume.

## Test plan
- [x] New provider tests: default state, load-from-storage, persist on
      set, language remembered across enable/disable, survives a fresh
      `ProviderContainer` (restart).
- [x] Full `feature_iptv` suite green (279 tests).
- [x] `flutter analyze` clean on changed files.
- [x] `dart format --set-exit-if-changed` clean.