### PR TITLE
feat(platform_playlist): CV-017 slice 1 -- smart playlist rule model + evaluator

### DIFF
--- a/packages/platform_playlist/lib/platform_playlist.dart
+++ b/packages/platform_playlist/lib/platform_playlist.dart
@@ -11,6 +11,7 @@ export 'src/provider_health.dart';
 export 'src/provider_health_recorder.dart';
 export 'src/m3u_content_source.dart';
 export 'src/m3u_vod_adapter.dart';
+export 'src/smart_playlist_evaluator.dart';
 export 'src/xtream/xtream_client.dart';
 export 'src/xtream/xtream_content_source.dart';
 export 'src/xtream/xtream_epg_repository.dart';

--- a/packages/platform_playlist/lib/src/smart_playlist_evaluator.dart
+++ b/packages/platform_playlist/lib/src/smart_playlist_evaluator.dart
@@ -1,0 +1,82 @@
+import 'package:platform_channels/platform_channels.dart';
+
+/// A user-defined filter (CV-017) that reduces a large provider playlist
+/// down to a personal, cable-TV-like view without modifying the source
+/// import. Rules are additive exclusions plus an explicit include/exclude
+/// override — see [SmartPlaylistEvaluator.apply] for precedence.
+class SmartPlaylistRule {
+  const SmartPlaylistRule({
+    this.allowedLanguages,
+    this.excludeAdult = false,
+    this.excludeVod = false,
+    this.excludeRadio = false,
+    this.explicitIncludeChannelIds = const {},
+    this.explicitExcludeChannelIds = const {},
+  });
+
+  /// Null means no language filter is applied. Matches if any of a
+  /// channel's [IPTVChannel.languages] is in this set.
+  final Set<String>? allowedLanguages;
+  final bool excludeAdult;
+  final bool excludeVod;
+  final bool excludeRadio;
+
+  /// Always kept, even if the channel would otherwise be excluded.
+  /// Takes precedence over [explicitExcludeChannelIds].
+  final Set<String> explicitIncludeChannelIds;
+
+  /// Always dropped, even if the channel would otherwise pass every other
+  /// filter. Overridden by [explicitIncludeChannelIds].
+  final Set<String> explicitExcludeChannelIds;
+}
+
+/// Evaluates a [SmartPlaylistRule] against a raw provider channel list.
+///
+/// M3U/Xtream/Stalker sources have no formal adult/radio/VOD flag (see
+/// [M3uVodAdapter]'s note on the same limitation) so this classifies those
+/// shapes the same way: by [IPTVChannel.category] where already inferred,
+/// falling back to a group-title keyword match. Best-effort, not exact —
+/// callers that need certainty should route through explicit include/
+/// exclude channel ids instead.
+class SmartPlaylistEvaluator {
+  static const _adultGroupKeywords = ['adult', 'xxx', 'porn'];
+  static const _radioGroupKeywords = ['radio', 'fm ', 'fm-'];
+  static const _vodGroupKeywords = ['vod', 'series'];
+
+  List<IPTVChannel> apply(SmartPlaylistRule rule, List<IPTVChannel> channels) {
+    return [
+      for (final channel in channels)
+        if (rule.explicitIncludeChannelIds.contains(channel.id) ||
+            _passesAllFilters(rule, channel))
+          channel,
+    ];
+  }
+
+  bool _passesAllFilters(SmartPlaylistRule rule, IPTVChannel channel) {
+    if (rule.explicitExcludeChannelIds.contains(channel.id)) return false;
+    if (rule.excludeAdult && _isAdultShaped(channel)) return false;
+    if (rule.excludeVod && _isVodShaped(channel)) return false;
+    if (rule.excludeRadio && _isRadioShaped(channel)) return false;
+    if (rule.allowedLanguages != null &&
+        !channel.languages.any(rule.allowedLanguages!.contains)) {
+      return false;
+    }
+    return true;
+  }
+
+  bool _isAdultShaped(IPTVChannel channel) {
+    final group = channel.group.toLowerCase();
+    return _adultGroupKeywords.any(group.contains);
+  }
+
+  bool _isVodShaped(IPTVChannel channel) {
+    if (channel.category == ChannelCategory.movies) return true;
+    final group = channel.group.toLowerCase();
+    return _vodGroupKeywords.any(group.contains);
+  }
+
+  bool _isRadioShaped(IPTVChannel channel) {
+    final group = channel.group.toLowerCase();
+    return _radioGroupKeywords.any(group.contains);
+  }
+}

--- a/packages/platform_playlist/test/smart_playlist_evaluator_test.dart
+++ b/packages/platform_playlist/test/smart_playlist_evaluator_test.dart
@@ -1,0 +1,166 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:platform_channels/platform_channels.dart';
+import 'package:platform_playlist/platform_playlist.dart';
+
+void main() {
+  final evaluator = SmartPlaylistEvaluator();
+
+  IPTVChannel channel({
+    required String id,
+    required String name,
+    required String group,
+    List<String> languages = const ['en'],
+    ChannelCategory category = ChannelCategory.general,
+  }) {
+    return IPTVChannel(
+      id: id,
+      name: name,
+      streamUrl: 'https://example.com/$id.m3u8',
+      group: group,
+      category: category,
+      languages: languages,
+    );
+  }
+
+  test('no-op rule returns every channel unchanged', () {
+    final channels = [
+      channel(id: '1', name: 'News', group: 'News'),
+      channel(id: '2', name: 'Movie', group: 'Movies'),
+    ];
+
+    final result = evaluator.apply(const SmartPlaylistRule(), channels);
+
+    expect(result, channels);
+  });
+
+  test('excludeAdult removes channels whose group looks adult-shaped', () {
+    final channels = [
+      channel(id: '1', name: 'News', group: 'News'),
+      channel(id: '2', name: 'XXX Prime', group: 'Adult XXX'),
+    ];
+
+    final result = evaluator.apply(
+      const SmartPlaylistRule(excludeAdult: true),
+      channels,
+    );
+
+    expect(result.map((c) => c.id), ['1']);
+  });
+
+  test('excludeVod removes VOD-shaped channels (category or group)', () {
+    final channels = [
+      channel(id: '1', name: 'News', group: 'News'),
+      channel(
+        id: '2',
+        name: 'Movie',
+        group: 'Movies',
+        category: ChannelCategory.movies,
+      ),
+      channel(id: '3', name: 'Some Title', group: 'US VOD'),
+    ];
+
+    final result = evaluator.apply(
+      const SmartPlaylistRule(excludeVod: true),
+      channels,
+    );
+
+    expect(result.map((c) => c.id), ['1']);
+  });
+
+  test('excludeRadio removes radio-shaped channels by group', () {
+    final channels = [
+      channel(id: '1', name: 'News', group: 'News'),
+      channel(id: '2', name: 'FM 101', group: 'Radio Stations'),
+    ];
+
+    final result = evaluator.apply(
+      const SmartPlaylistRule(excludeRadio: true),
+      channels,
+    );
+
+    expect(result.map((c) => c.id), ['1']);
+  });
+
+  test(
+    'allowedLanguages keeps only channels matching one of the languages',
+    () {
+      final channels = [
+        channel(id: '1', name: 'BBC', group: 'News', languages: ['en']),
+        channel(id: '2', name: 'TF1', group: 'News', languages: ['fr']),
+      ];
+
+      final result = evaluator.apply(
+        const SmartPlaylistRule(allowedLanguages: {'en'}),
+        channels,
+      );
+
+      expect(result.map((c) => c.id), ['1']);
+    },
+  );
+
+  test('explicit exclude wins even when the channel would otherwise pass', () {
+    final channels = [
+      channel(id: '1', name: 'News', group: 'News'),
+      channel(id: '2', name: 'Other News', group: 'News'),
+    ];
+
+    final result = evaluator.apply(
+      const SmartPlaylistRule(explicitExcludeChannelIds: {'2'}),
+      channels,
+    );
+
+    expect(result.map((c) => c.id), ['1']);
+  });
+
+  test(
+    'explicit include always keeps a channel even if it fails other filters',
+    () {
+      final channels = [
+        channel(id: '1', name: 'News', group: 'News'),
+        channel(id: '2', name: 'FM 101', group: 'Radio Stations'),
+      ];
+
+      final result = evaluator.apply(
+        const SmartPlaylistRule(
+          excludeRadio: true,
+          explicitIncludeChannelIds: {'2'},
+        ),
+        channels,
+      );
+
+      expect(result.map((c) => c.id).toSet(), {'1', '2'});
+    },
+  );
+
+  test('combines multiple exclusion rules', () {
+    final channels = [
+      channel(id: '1', name: 'News', group: 'News'),
+      channel(id: '2', name: 'XXX Prime', group: 'Adult XXX'),
+      channel(id: '3', name: 'FM 101', group: 'Radio Stations'),
+      channel(
+        id: '4',
+        name: 'Movie',
+        group: 'Movies',
+        category: ChannelCategory.movies,
+      ),
+    ];
+
+    final result = evaluator.apply(
+      const SmartPlaylistRule(
+        excludeAdult: true,
+        excludeRadio: true,
+        excludeVod: true,
+      ),
+      channels,
+    );
+
+    expect(result.map((c) => c.id), ['1']);
+  });
+
+  test('empty source list yields empty result', () {
+    expect(
+      evaluator.apply(const SmartPlaylistRule(excludeAdult: true), const []),
+      isEmpty,
+    );
+  });
+}


### PR DESCRIPTION
## Summary
Part of #821 (CV-017, P0). First bounded slice: the framework-owned
smart-playlist rule model and evaluator, with no canonical-channel
identity work yet (that's the larger, riskier part of the issue).

- `SmartPlaylistRule`: language allowlist, exclude-adult/vod/radio,
  explicit include/exclude channel ids.
- `SmartPlaylistEvaluator.apply()`: reduces a raw provider channel list
  to a user-facing view without mutating the source import (AC: "A large
  provider playlist can be reduced ... without modifying the source
  import").
- Adult/VOD/radio classification is a best-effort group-title/category
  heuristic, following the same pattern `M3uVodAdapter` already uses and
  documents for VOD detection -- M3U/Xtream/Stalker have no formal flag
  for any of these.
- Precedence: explicit include > explicit exclude > the rest.

## Not in this slice
- Canonical channel identity / cross-provider alias matching (the
  "BBC One HD / BBC1 / BBC One UK" normalization) -- this is the larger,
  higher-risk half of #821 and needs its own design pass.
- Minimum-resolution, country/region, and category filters from the
  issue's suggested rule contract.
- Playlist management UI, quick-start filters, confidence-based conflict
  review.
- Favorites/history continuity across provider re-imports (depends on
  canonical identity landing first).

## Test plan
- [x] New evaluator tests: no-op passthrough, each exclusion rule alone,
      language allowlist, explicit include/exclude precedence, combined
      rules, empty input.
- [x] Full `platform_playlist` suite green (90 tests).
- [x] `flutter analyze` clean on changed files (one pre-existing,
      unrelated lint on the barrel file).
- [x] `dart format --set-exit-if-changed` clean.