### PR TITLE
chore(release): add device-qualification workflow + release artifact smoke tests

### DIFF
--- a/.github/workflows/release-device-qualification.yml
+++ b/.github/workflows/release-device-qualification.yml
@@ -1,0 +1,294 @@
+name: Release Device Qualification
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+    inputs:
+      release_version:
+        description: 'Release version label, for example v1.2.0'
+        required: true
+      artifact_run_id:
+        description: 'Workflow run id that produced release artifacts'
+        required: true
+      provider:
+        description: 'Real-device execution provider'
+        required: true
+        default: browserstack
+        type: choice
+        options:
+          - browserstack
+          - firebase
+          - local
+          - host-only
+      tier:
+        description: 'Device matrix tier'
+        required: true
+        default: tier1
+        type: choice
+        options:
+          - tier1
+          - full
+
+permissions:
+  contents: read
+  actions: read
+
+concurrency:
+  group: release-device-qualification-${{ github.ref }}-${{ github.event.inputs.artifact_run_id || github.run_id }}
+  cancel-in-progress: false
+
+env:
+  FLUTTER_VERSION: '3.44.4'
+  RELEASE_VERSION: ${{ github.event.inputs.release_version || github.ref_name }}
+  ARTIFACT_RUN_ID: ${{ github.event.inputs.artifact_run_id || '' }}
+  DEVICE_PROVIDER: ${{ github.event.inputs.provider || 'host-only' }}
+  QUALIFICATION_TIER: ${{ github.event.inputs.tier || 'tier1' }}
+
+jobs:
+  host-gates:
+    name: Host release gates
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Verify release-line base context
+        run: |
+          git fetch origin main v2
+          git merge-base --is-ancestor origin/main HEAD || {
+            echo "::warning::This qualification run is not based on origin/main. Use origin/v2 only for explicit v2 releases."
+          }
+
+      - name: Setup Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version: ${{ env.FLUTTER_VERSION }}
+          channel: stable
+          cache: true
+
+      - name: Cache pub dependencies
+        uses: actions/cache@v6
+        with:
+          path: |
+            ~/.pub-cache
+            app/.dart_tool
+            packages/*/.dart_tool
+          key: release-qualification-pub-${{ runner.os }}-${{ hashFiles('**/pubspec.lock') }}
+          restore-keys: release-qualification-pub-${{ runner.os }}-
+
+      - name: Get dependencies
+        run: |
+          (cd packages/core_domain && flutter pub get) &
+          (cd packages/core_ui && flutter pub get) &
+          (cd packages/core_data && flutter pub get) &
+          (cd packages/core_ai && flutter pub get) &
+          (cd packages/core_auth && flutter pub get) &
+          wait
+          cd app && flutter pub get
+
+      - name: Analyze app
+        run: |
+          cd app
+          flutter analyze --no-fatal-infos --no-fatal-warnings
+
+      - name: Run release responsiveness gate
+        run: make test-ui-responsive
+
+      - name: Validate Patrol test sources
+        run: |
+          cd app
+          dart analyze integration_test patrol_test
+
+  artifact-smoke:
+    name: Exact artifact smoke
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    needs: host-gates
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Download release artifacts
+        if: env.ARTIFACT_RUN_ID != ''
+        uses: actions/download-artifact@v8
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ env.ARTIFACT_RUN_ID }}
+          path: release-artifacts
+          merge-multiple: true
+
+      - name: Prepare empty artifact directory
+        if: env.ARTIFACT_RUN_ID == ''
+        run: |
+          mkdir -p release-artifacts
+          echo "::warning::No artifact_run_id supplied; artifact smoke will fail because release artifacts are required."
+
+      - name: Run exact artifact smoke checks
+        env:
+          AIRO_RELEASE_ARTIFACT_DIR: release-artifacts
+          AIRO_RELEASE_QUALIFICATION_DIR: artifacts/release-qualification/${{ env.RELEASE_VERSION }}
+          AIRO_REQUIRE_RELEASE_ARTIFACTS: 'true'
+          AIRO_DEVICE_PROVIDER: ${{ env.DEVICE_PROVIDER }}
+          AIRO_QUALIFICATION_TIER: ${{ env.QUALIFICATION_TIER }}
+        run: scripts/release-artifact-smoke.sh --require-artifacts
+
+      - name: Upload artifact smoke report
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: release-artifact-smoke-${{ env.RELEASE_VERSION }}
+          path: artifacts/release-qualification/
+          retention-days: 90
+
+  patrol-android-artifacts:
+    name: Build Patrol Android provider artifacts
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    needs: host-gates
+    if: ${{ (github.event.inputs.provider || 'host-only') == 'browserstack' || (github.event.inputs.provider || 'host-only') == 'firebase' }}
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Setup Java
+        uses: actions/setup-java@v5
+        with:
+          java-version: '17'
+          distribution: temurin
+
+      - name: Setup Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version: ${{ env.FLUTTER_VERSION }}
+          channel: stable
+          cache: true
+
+      - name: Get dependencies
+        run: |
+          cd app
+          flutter pub get
+
+      - name: Install Patrol CLI
+        run: dart pub global activate patrol_cli
+
+      - name: Build tagged Patrol Android app and test APKs
+        run: |
+          cd app
+          export PATH="$PATH:$HOME/.pub-cache/bin"
+          patrol build android \
+            -t integration_test/patrol_test.dart
+
+      - name: Collect Patrol APKs
+        run: |
+          mkdir -p patrol-provider-artifacts
+          app_apk="$(find app/build -type f -name "*.apk" ! -name "*androidTest*" | sort | tail -1)"
+          test_apk="$(find app/build -type f \( -name "*androidTest*.apk" -o -name "*test*.apk" \) | sort | tail -1)"
+          if [ -z "$app_apk" ] || [ -z "$test_apk" ]; then
+            echo "::error::Unable to locate Patrol app/test APK outputs."
+            find app/build -type f -name "*.apk" -print
+            exit 1
+          fi
+          cp "$app_apk" patrol-provider-artifacts/airo-patrol-app.apk
+          cp "$test_apk" patrol-provider-artifacts/airo-patrol-test.apk
+          ls -lh patrol-provider-artifacts
+
+      - name: Upload Patrol provider artifacts
+        uses: actions/upload-artifact@v7
+        with:
+          name: patrol-android-provider-artifacts-${{ env.RELEASE_VERSION }}
+          path: patrol-provider-artifacts/
+          retention-days: 14
+
+  browserstack-patrol:
+    name: BrowserStack Patrol Android tier
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    needs:
+      - artifact-smoke
+      - patrol-android-artifacts
+    if: ${{ (github.event.inputs.provider || 'host-only') == 'browserstack' }}
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Download Patrol provider artifacts
+        uses: actions/download-artifact@v8
+        with:
+          name: patrol-android-provider-artifacts-${{ env.RELEASE_VERSION }}
+          path: patrol-provider-artifacts
+
+      - name: Schedule BrowserStack Patrol run
+        env:
+          BROWSERSTACK_USERNAME: ${{ secrets.BROWSERSTACK_USERNAME }}
+          BROWSERSTACK_ACCESS_KEY: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
+          AIRO_QUALIFICATION_TIER: ${{ env.QUALIFICATION_TIER }}
+          AIRO_RELEASE_QUALIFICATION_DIR: artifacts/release-qualification/${{ env.RELEASE_VERSION }}/browserstack
+        run: |
+          scripts/run-browserstack-patrol.sh \
+            --app patrol-provider-artifacts/airo-patrol-app.apk \
+            --test-suite patrol-provider-artifacts/airo-patrol-test.apk \
+            --tier "$AIRO_QUALIFICATION_TIER"
+
+      - name: Upload BrowserStack scheduling report
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: browserstack-patrol-${{ env.RELEASE_VERSION }}
+          path: artifacts/release-qualification/
+          retention-days: 90
+
+  firebase-patrol:
+    name: Firebase Test Lab Patrol Android tier
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    needs:
+      - artifact-smoke
+      - patrol-android-artifacts
+    if: ${{ (github.event.inputs.provider || 'host-only') == 'firebase' }}
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Download Patrol provider artifacts
+        uses: actions/download-artifact@v8
+        with:
+          name: patrol-android-provider-artifacts-${{ env.RELEASE_VERSION }}
+          path: patrol-provider-artifacts
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v3
+        with:
+          credentials_json: ${{ secrets.GCP_FIREBASE_TEST_LAB_SERVICE_ACCOUNT }}
+
+      - name: Setup gcloud
+        uses: google-github-actions/setup-gcloud@v3
+
+      - name: Run Firebase Test Lab Patrol smoke
+        env:
+          AIRO_RELEASE_QUALIFICATION_DIR: artifacts/release-qualification/${{ env.RELEASE_VERSION }}/firebase
+          AIRO_FIREBASE_RESULTS_BUCKET: ${{ secrets.AIRO_FIREBASE_RESULTS_BUCKET }}
+        run: |
+          scripts/run-firebase-patrol.sh \
+            --app patrol-provider-artifacts/airo-patrol-app.apk \
+            --test-suite patrol-provider-artifacts/airo-patrol-test.apk
+
+      - name: Upload Firebase report
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: firebase-patrol-${{ env.RELEASE_VERSION }}
+          path: artifacts/release-qualification/
+          retention-days: 90
+
+  local-provider-note:
+    name: Local physical device note
+    runs-on: ubuntu-latest
+    needs: artifact-smoke
+    if: ${{ (github.event.inputs.provider || 'host-only') == 'local' }}
+    steps:
+      - name: Explain local provider execution
+        run: |
+          echo "Local provider selected."
+          echo "Download the artifact-smoke report and run scripts/release-artifact-smoke.sh with:"
+          echo "  AIRO_RUN_DEVICE_SMOKE=true AIRO_RELEASE_ARTIFACT_DIR=<artifact-dir> scripts/release-artifact-smoke.sh --require-artifacts"
+          echo "Attach the generated artifacts/release-qualification report to the release issue."

--- a/Makefile
+++ b/Makefile
@@ -756,6 +756,27 @@ test-device-android: ## Run Patrol tests on Android
 test-device-ios: ## Run Patrol tests on iOS
 	@cd $(APP_DIR) && patrol test -t integration_test/patrol_test.dart --target ios
 
+.PHONY: test-release-artifacts
+test-release-artifacts: ## Run static smoke checks against release artifacts; set AIRO_RELEASE_ARTIFACT_DIR=...
+	@scripts/release-artifact-smoke.sh
+
+.PHONY: test-release-artifacts-required
+test-release-artifacts-required: ## Run release-blocking artifact smoke checks
+	@AIRO_REQUIRE_RELEASE_ARTIFACTS=true scripts/release-artifact-smoke.sh --require-artifacts
+
+.PHONY: test-release-artifacts-device
+test-release-artifacts-device: ## Install/launch APK artifacts on a connected physical Android device
+	@AIRO_REQUIRE_RELEASE_ARTIFACTS=true AIRO_RUN_DEVICE_SMOKE=true scripts/release-artifact-smoke.sh --require-artifacts
+
+.PHONY: test-release-artifacts-web
+test-release-artifacts-web: ## Serve web artifact and run Playwright smoke checks
+	@AIRO_REQUIRE_RELEASE_ARTIFACTS=true AIRO_RUN_WEB_SMOKE=true scripts/release-artifact-smoke.sh --require-artifacts
+
+.PHONY: test-release-patrol-android-build
+test-release-patrol-android-build: ## Build Android Patrol provider APKs for device-farm execution
+	@cd $(APP_DIR) && patrol build android \
+		-t integration_test/patrol_test.dart
+
 .PHONY: test-agent-skills-journey
 test-agent-skills-journey: ## Run the Agent Skills calendar journey on the default iOS simulator
 	@./scripts/run_agent_skills_journey.sh

--- a/app/integration_test/patrol_test.dart
+++ b/app/integration_test/patrol_test.dart
@@ -19,108 +19,124 @@ import 'package:airo_app/features/bill_split/presentation/screens/itemized_split
 /// 1. Playwright tests (browser) → 2. Patrol tests (device) → 3. Deploy
 
 void main() {
-  patrolTest('Bill Split - Complete flow on device', ($) async {
-    // Launch the app
-    app.main();
-    await $.pumpAndSettle();
+  patrolTest(
+    'Bill Split - Complete flow on device',
+    ($) async {
+      // Launch the app
+      app.main();
+      await $.pumpAndSettle();
 
-    // Navigate to Coins tab
-    await $(#coins_tab).tap();
-    await $.pumpAndSettle();
+      // Navigate to Coins tab
+      await $(#coins_tab).tap();
+      await $.pumpAndSettle();
 
-    // Tap on Split Bill
-    await $('Split Bill').tap();
-    await $.pumpAndSettle();
+      // Tap on Split Bill
+      await $('Split Bill').tap();
+      await $.pumpAndSettle();
 
-    // Verify Bill Split screen is shown
-    expect($(BillSplitTestIds.screen), findsOneWidget);
-    expect($('Add expense'), findsOneWidget);
-  });
+      // Verify Bill Split screen is shown
+      expect($(BillSplitTestIds.screen), findsOneWidget);
+      expect($('Add expense'), findsOneWidget);
+    },
+    tags: ['release_smoke', 'finance_agent', 'responsive'],
+  );
 
-  patrolTest('Bill Split - Add participant and enter amount', ($) async {
-    app.main();
-    await $.pumpAndSettle();
+  patrolTest(
+    'Bill Split - Add participant and enter amount',
+    ($) async {
+      app.main();
+      await $.pumpAndSettle();
 
-    await $(#coins_tab).tap();
-    await $.pumpAndSettle();
+      await $(#coins_tab).tap();
+      await $.pumpAndSettle();
 
-    await $('Split Bill').tap();
-    await $.pumpAndSettle();
+      await $('Split Bill').tap();
+      await $.pumpAndSettle();
 
-    // Enter description
-    await $(BillSplitTestIds.descriptionInput).enterText('Lunch');
-    await $.pumpAndSettle();
+      // Enter description
+      await $(BillSplitTestIds.descriptionInput).enterText('Lunch');
+      await $.pumpAndSettle();
 
-    // Enter amount
-    await $(BillSplitTestIds.amountInput).enterText('250');
-    await $.pumpAndSettle();
+      // Enter amount
+      await $(BillSplitTestIds.amountInput).enterText('250');
+      await $.pumpAndSettle();
 
-    // Open participant picker
-    await $(BillSplitTestIds.participantsSection).tap();
-    await $.pumpAndSettle();
+      // Open participant picker
+      await $(BillSplitTestIds.participantsSection).tap();
+      await $.pumpAndSettle();
 
-    // Close picker
-    await $('Done').tap();
-    await $.pumpAndSettle();
-  });
+      // Close picker
+      await $('Done').tap();
+      await $.pumpAndSettle();
+    },
+    tags: ['release_smoke', 'finance_agent', 'responsive'],
+  );
 
-  patrolTest('Itemized Split - Open and verify UI', ($) async {
-    app.main();
-    await $.pumpAndSettle();
+  patrolTest(
+    'Itemized Split - Open and verify UI',
+    ($) async {
+      app.main();
+      await $.pumpAndSettle();
 
-    await $(#coins_tab).tap();
-    await $.pumpAndSettle();
+      await $(#coins_tab).tap();
+      await $.pumpAndSettle();
 
-    await $('Split Bill').tap();
-    await $.pumpAndSettle();
+      await $('Split Bill').tap();
+      await $.pumpAndSettle();
 
-    // Add participant first
-    await $(BillSplitTestIds.participantsSection).tap();
-    await $.pumpAndSettle();
-    await $('Done').tap();
-    await $.pumpAndSettle();
+      // Add participant first
+      await $(BillSplitTestIds.participantsSection).tap();
+      await $.pumpAndSettle();
+      await $('Done').tap();
+      await $.pumpAndSettle();
 
-    // Navigate to itemized split
-    await $(BillSplitTestIds.splitByItemsButton).tap();
-    await $.pumpAndSettle();
+      // Navigate to itemized split
+      await $(BillSplitTestIds.splitByItemsButton).tap();
+      await $.pumpAndSettle();
 
-    // Verify itemized split screen
-    expect($(ItemizedSplitTestIds.screen), findsOneWidget);
-    expect($('Upload Receipt'), findsOneWidget);
-  });
+      // Verify itemized split screen
+      expect($(ItemizedSplitTestIds.screen), findsOneWidget);
+      expect($('Upload Receipt'), findsOneWidget);
+    },
+    tags: ['release_smoke', 'finance_agent', 'responsive'],
+  );
 
-  patrolTest('Itemized Split - Camera permission and photo capture', ($) async {
-    app.main();
-    await $.pumpAndSettle();
+  patrolTest(
+    'Itemized Split - Camera permission and photo capture',
+    ($) async {
+      app.main();
+      await $.pumpAndSettle();
 
-    await $(#coins_tab).tap();
-    await $.pumpAndSettle();
+      await $(#coins_tab).tap();
+      await $.pumpAndSettle();
 
-    await $('Split Bill').tap();
-    await $.pumpAndSettle();
+      await $('Split Bill').tap();
+      await $.pumpAndSettle();
 
-    // Add participant
-    await $(BillSplitTestIds.participantsSection).tap();
-    await $.pumpAndSettle();
-    await $('Done').tap();
-    await $.pumpAndSettle();
+      // Add participant
+      await $(BillSplitTestIds.participantsSection).tap();
+      await $.pumpAndSettle();
+      await $('Done').tap();
+      await $.pumpAndSettle();
 
-    // Navigate to itemized split
-    await $(BillSplitTestIds.splitByItemsButton).tap();
-    await $.pumpAndSettle();
+      // Navigate to itemized split
+      await $(BillSplitTestIds.splitByItemsButton).tap();
+      await $.pumpAndSettle();
 
-    // Tap camera button (will request permission on device)
-    await $(ItemizedSplitTestIds.cameraButton).tap();
+      // Tap camera button (will request permission on device)
+      await $(ItemizedSplitTestIds.cameraButton).tap();
 
-    // Handle native camera permission dialog
-    // Using platformAutomator.mobile (Patrol 4.x API, replaces deprecated .native)
-    if (await $.platformAutomator.mobile.isPermissionDialogVisible()) {
-      await $.platformAutomator.mobile.grantPermissionWhenInUse();
-    }
+      // Handle native camera permission dialog
+      // Using platformAutomator.mobile (Patrol 4.x API, replaces deprecated .native)
+      if (await $.platformAutomator.mobile.isPermissionDialogVisible()) {
+        await $.platformAutomator.mobile.grantPermissionWhenInUse();
+      }
 
-    // Note: Actual photo capture would happen here on real device
-    // For CI, we might mock the image picker
-  });
+      // Note: Actual photo capture would happen here on real device
+      // For CI, we might mock the image picker
+    },
+    tags: ['permissions', 'finance_agent'],
+  );
 
   patrolTest('Itemized Split - Gallery selection', ($) async {
     app.main();
@@ -150,5 +166,5 @@ void main() {
     if (await $.platformAutomator.mobile.isPermissionDialogVisible()) {
       await $.platformAutomator.mobile.grantPermissionWhenInUse();
     }
-  });
+  }, tags: ['permissions', 'finance_agent']);
 }

--- a/app/patrol_test/agent_skills_journey_test.dart
+++ b/app/patrol_test/agent_skills_journey_test.dart
@@ -49,80 +49,87 @@ Future<bool> _grantPermissionIfShown(
 }
 
 void main() {
-  patrolTest('Agent Skills - calendar schedule journey', ($) async {
-    final prefs = await SharedPreferences.getInstance();
-    await prefs.setString(_selectedAssistantModelKey, 'gemini-nano');
-    await prefs.setBool(_isLoggedInKey, true);
-    await prefs.setString(_currentUserKey, _journeyUserJson);
+  patrolTest(
+    'Agent Skills - calendar schedule journey',
+    ($) async {
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.setString(_selectedAssistantModelKey, 'gemini-nano');
+      await prefs.setBool(_isLoggedInKey, true);
+      await prefs.setString(_currentUserKey, _journeyUserJson);
 
-    final stopwatch = Stopwatch()..start();
-    final events = <Map<String, Object?>>[];
+      final stopwatch = Stopwatch()..start();
+      final events = <Map<String, Object?>>[];
 
-    void record(String name, [Map<String, Object?> data = const {}]) {
-      events.add({
-        'name': name,
-        'elapsed_ms': stopwatch.elapsedMilliseconds,
-        ...data,
-      });
-    }
+      void record(String name, [Map<String, Object?> data = const {}]) {
+        events.add({
+          'name': name,
+          'elapsed_ms': stopwatch.elapsedMilliseconds,
+          ...data,
+        });
+      }
 
-    record('launch_start');
-    app.main();
-    await $.pumpAndSettle();
-    record('launch_ready');
-
-    if (find.byKey(const Key('agent_chat_skills_button')).evaluate().isEmpty) {
-      AppRouter.router.go('/agent');
+      record('launch_start');
+      app.main();
       await $.pumpAndSettle();
-    }
-    record('assistant_opened');
+      record('launch_ready');
 
-    expect($(#agent_chat_skills_button), findsOneWidget);
+      if (find
+          .byKey(const Key('agent_chat_skills_button'))
+          .evaluate()
+          .isEmpty) {
+        AppRouter.router.go('/agent');
+        await $.pumpAndSettle();
+      }
+      record('assistant_opened');
 
-    await $(#agent_chat_skills_button).tap();
-    await $.pumpAndSettle();
-    expect($('Manage Skills'), findsOneWidget);
-    expect($('read-calendar-events'), findsOneWidget);
-    record('skills_sheet_verified');
+      expect($(#agent_chat_skills_button), findsOneWidget);
 
-    await $(#manage_skills_close_button).tap();
-    await $.pumpAndSettle();
+      await $(#agent_chat_skills_button).tap();
+      await $.pumpAndSettle();
+      expect($('Manage Skills'), findsOneWidget);
+      expect($('read-calendar-events'), findsOneWidget);
+      record('skills_sheet_verified');
 
-    await $(#agent_chat_input).enterText(_journeyPrompt);
-    await $(#agent_chat_send_button).tap();
-    await $.pumpAndSettle();
-    record('prompt_sent', {'prompt': _journeyPrompt});
+      await $(#manage_skills_close_button).tap();
+      await $.pumpAndSettle();
 
-    await _pumpUntilFound($, find.text(_journeyPrompt));
+      await $(#agent_chat_input).enterText(_journeyPrompt);
+      await $(#agent_chat_send_button).tap();
+      await $.pumpAndSettle();
+      record('prompt_sent', {'prompt': _journeyPrompt});
 
-    if (defaultTargetPlatform != TargetPlatform.android &&
-        await _grantPermissionIfShown($)) {
-      record('calendar_permission_granted');
-    }
+      await _pumpUntilFound($, find.text(_journeyPrompt));
 
-    final actionTraceFinder = find.textContaining('Performed action');
-    await _pumpUntilFound($, actionTraceFinder);
+      if (defaultTargetPlatform != TargetPlatform.android &&
+          await _grantPermissionIfShown($)) {
+        record('calendar_permission_granted');
+      }
 
-    expect($(_journeyPrompt), findsOneWidget);
-    expect(actionTraceFinder, findsOneWidget);
-    expect($('read-calendar-events'), findsWidgets);
-    expect($('get_current_date_time'), findsOneWidget);
-    expect($('read_calendar_events'), findsOneWidget);
-    final scheduleResponseFinder = find.byWidgetPredicate(
-      (widget) =>
-          widget is Text &&
-          (widget.data?.contains('I checked your schedule') == true ||
-              widget.data?.contains('Here is your schedule') == true),
-    );
-    await _pumpUntilFound($, scheduleResponseFinder);
-    expect(scheduleResponseFinder, findsOneWidget);
+      final actionTraceFinder = find.textContaining('Performed action');
+      await _pumpUntilFound($, actionTraceFinder);
 
-    stopwatch.stop();
-    record('journey_complete', {'total_ms': stopwatch.elapsedMilliseconds});
+      expect($(_journeyPrompt), findsOneWidget);
+      expect(actionTraceFinder, findsOneWidget);
+      expect($('read-calendar-events'), findsWidgets);
+      expect($('get_current_date_time'), findsOneWidget);
+      expect($('read_calendar_events'), findsOneWidget);
+      final scheduleResponseFinder = find.byWidgetPredicate(
+        (widget) =>
+            widget is Text &&
+            (widget.data?.contains('I checked your schedule') == true ||
+                widget.data?.contains('Here is your schedule') == true),
+      );
+      await _pumpUntilFound($, scheduleResponseFinder);
+      expect(scheduleResponseFinder, findsOneWidget);
 
-    debugPrint(
-      'AIRO_AGENT_SKILLS_JOURNEY_RESULT '
-      '${jsonEncode({'journey': 'agent_skills_calendar_schedule', 'status': 'passed', 'platform': defaultTargetPlatform.name, 'total_ms': stopwatch.elapsedMilliseconds, 'events': events})}',
-    );
-  });
+      stopwatch.stop();
+      record('journey_complete', {'total_ms': stopwatch.elapsedMilliseconds});
+
+      debugPrint(
+        'AIRO_AGENT_SKILLS_JOURNEY_RESULT '
+        '${jsonEncode({'journey': 'agent_skills_calendar_schedule', 'status': 'passed', 'platform': defaultTargetPlatform.name, 'total_ms': stopwatch.elapsedMilliseconds, 'events': events})}',
+      );
+    },
+    tags: ['release_smoke', 'permissions', 'offline_lifecycle'],
+  );
 }

--- a/config/release_device_matrix.yaml
+++ b/config/release_device_matrix.yaml
@@ -1,0 +1,194 @@
+# Release artifact qualification matrix.
+#
+# This file is intentionally provider-neutral. Scripts and CI jobs map each
+# entry to BrowserStack, Firebase Test Lab, or local physical devices.
+#
+# tier:
+#   tier1 - release-blocking smoke coverage
+#   tier2 - expanded regression coverage
+#   tier3 - long-tail/manual coverage
+version: 1
+default_provider: browserstack
+release_blocking_tier: tier1
+
+patrol_suites:
+  - name: release_smoke
+    tags: [release_smoke]
+    blocking: true
+  - name: permissions
+    tags: [permissions]
+    blocking: true
+  - name: responsive
+    tags: [responsive]
+    blocking: true
+  - name: offline_lifecycle
+    tags: [offline_lifecycle]
+    blocking: true
+  - name: media_tv
+    tags: [media_tv]
+    blocking: true
+  - name: finance_agent
+    tags: [finance_agent]
+    blocking: true
+
+devices:
+  android_phone:
+    - id: android-api26-low-arm
+      tier: tier1
+      provider: browserstack
+      browserstack: "Google Pixel-8.0"
+      os: android
+      os_version: "8.0"
+      form_factor: phone
+      abi: armeabi-v7a
+      resolution: small
+      checks: [launch, navigation, permissions, offline_lifecycle]
+    - id: android-modern-samsung-arm64
+      tier: tier1
+      provider: browserstack
+      browserstack: "Samsung Galaxy S23-13.0"
+      os: android
+      os_version: "13.0"
+      form_factor: phone
+      abi: arm64-v8a
+      resolution: standard
+      checks: [launch, navigation, permissions, finance_agent]
+    - id: android-latest-pixel-arm64
+      tier: tier1
+      provider: browserstack
+      browserstack: "Google Pixel 9-15.0"
+      os: android
+      os_version: "15.0"
+      form_factor: phone
+      abi: arm64-v8a
+      resolution: large
+      checks: [launch, navigation, permissions, offline_lifecycle]
+
+  android_tablet_foldable:
+    - id: android-small-tablet
+      tier: tier1
+      provider: browserstack
+      browserstack: "Samsung Galaxy Tab S8-12.0"
+      os: android
+      os_version: "12.0"
+      form_factor: tablet
+      resolution: "8in"
+      checks: [launch, responsive, navigation]
+    - id: android-large-tablet
+      tier: tier2
+      provider: browserstack
+      browserstack: "Samsung Galaxy Tab S9-13.0"
+      os: android
+      os_version: "13.0"
+      form_factor: tablet
+      resolution: "11in"
+      checks: [launch, responsive, navigation, split_screen]
+    - id: android-foldable
+      tier: tier2
+      provider: browserstack
+      browserstack: "Samsung Galaxy Z Fold5-13.0"
+      os: android
+      os_version: "13.0"
+      form_factor: foldable
+      resolution: posture_change
+      checks: [launch, responsive, navigation]
+
+  android_tv:
+    - id: android-tv-1080p
+      tier: tier1
+      provider: local_physical_or_lab
+      os: android_tv
+      os_version: "12+"
+      form_factor: tv
+      resolution: "1920x1080"
+      checks: [leanback_launch, dpad_focus, back_menu, media_tv]
+    - id: fire-tv-4k
+      tier: tier2
+      provider: local_physical_or_lab
+      os: fire_tv
+      os_version: "8+"
+      form_factor: tv
+      resolution: "3840x2160"
+      checks: [leanback_launch, dpad_focus, back_menu, media_tv]
+
+  ios_ipados:
+    - id: ios-small-iphone
+      tier: tier1
+      provider: browserstack
+      browserstack: "iPhone SE 2022-16"
+      os: ios
+      os_version: "16"
+      form_factor: phone
+      resolution: small
+      checks: [launch, navigation, permissions, responsive]
+    - id: ios-standard-iphone
+      tier: tier1
+      provider: browserstack
+      browserstack: "iPhone 15-17"
+      os: ios
+      os_version: "17"
+      form_factor: phone
+      resolution: standard
+      checks: [launch, navigation, permissions, offline_lifecycle]
+    - id: ios-pro-max
+      tier: tier1
+      provider: browserstack
+      browserstack: "iPhone 16 Pro Max-18"
+      os: ios
+      os_version: "18"
+      form_factor: phone
+      resolution: large
+      checks: [launch, navigation, permissions, responsive]
+    - id: ipad-11
+      tier: tier1
+      provider: browserstack
+      browserstack: "iPad Pro 11 2022-17"
+      os: ipados
+      os_version: "17"
+      form_factor: tablet
+      resolution: "11in"
+      checks: [launch, navigation, responsive]
+    - id: ipad-13
+      tier: tier2
+      provider: browserstack
+      browserstack: "iPad Pro 12.9 2022-17"
+      os: ipados
+      os_version: "17"
+      form_factor: tablet
+      resolution: "13in"
+      checks: [launch, navigation, responsive, large_text]
+
+  web_desktop:
+    - id: web-mobile
+      tier: tier1
+      provider: playwright
+      os: web
+      form_factor: phone
+      viewport: "390x844"
+      checks: [launch, navigation, responsive]
+    - id: web-tablet
+      tier: tier1
+      provider: playwright
+      os: web
+      form_factor: tablet
+      viewport: "834x1194"
+      checks: [launch, navigation, responsive]
+    - id: web-desktop
+      tier: tier1
+      provider: playwright
+      os: web
+      form_factor: desktop
+      viewport: "1440x900"
+      checks: [launch, navigation, responsive]
+    - id: windows-x64
+      tier: tier2
+      provider: host_launch
+      os: windows
+      form_factor: desktop
+      checks: [archive_integrity, launch]
+    - id: linux-x64
+      tier: tier2
+      provider: host_launch
+      os: linux
+      form_factor: desktop
+      checks: [archive_integrity, launch]

--- a/docs/release/RELEASE_CHECKLIST.md
+++ b/docs/release/RELEASE_CHECKLIST.md
@@ -22,6 +22,8 @@ Pre-release verification checklist for Airo Super App releases.
 - [ ] Unit tests passing (>80% coverage target)
 - [ ] Integration tests passing
 - [ ] E2E smoke tests passing
+- [ ] Release device qualification report created (`artifacts/release-qualification/...`)
+- [ ] Exact release artifact smoke checks passing (`make test-release-artifacts-required`)
 - [ ] Shared UI responsiveness suite passing (`make test-ui-responsive`)
 - [ ] Database reliability validation suite passing (`make test-database-reliability`)
 - [ ] Background processing validation suite passing (`make test-background-processing`)
@@ -78,6 +80,8 @@ Pre-release verification checklist for Airo Super App releases.
 ### Platform-Specific
 - [ ] Android: Back button works correctly
 - [ ] iOS: Gestures work (swipe back)
+- [ ] iPad/tablet: Wide layouts remain readable and primary actions are reachable
+- [ ] Android TV / Fire TV: Leanback launch and D-pad focus work without touch
 - [ ] Web: Browser navigation works
 
 ### Google Cast V1
@@ -132,6 +136,8 @@ asset names and visibility rules in
 - [ ] `app-release.ipa` - iOS (if applicable)
 - [ ] `airo-web-release.zip` - Web deployment
 - [ ] `RELEASE_NOTES.md` - Release description
+- [ ] `artifact-smoke-report.md` - Exact artifact smoke result
+- [ ] Release device qualification report with device metadata, checksums, logs, and waivers
 
 ### Documentation
 - [ ] Changelog entry added
@@ -144,6 +150,7 @@ asset names and visibility rules in
 - [ ] [Notification validation runbook](./NOTIFICATION_VALIDATION.md) followed
 - [ ] [UI responsiveness validation runbook](./UI_RESPONSIVENESS_VALIDATION.md) followed
 - [ ] [Performance benchmark runbook](./PERFORMANCE_BENCHMARKS.md) followed
+- [ ] [Release device qualification runbook](./RELEASE_DEVICE_QUALIFICATION.md) followed
 
 ---
 
@@ -172,6 +179,7 @@ Date: ____-__-__
 - [Smoke Tests Workflow](/.github/workflows/smoke-tests.yml)
 - [Build & Release Workflow](/.github/workflows/build-and-release.yml)
 - [V2 Distribution Matrix](./V2_DISTRIBUTION_MATRIX.md)
+- [Release Device Qualification Workflow](/.github/workflows/release-device-qualification.yml)
 - [Rollback Procedure](./ROLLBACK_PROCEDURE.md)
 - [Store Compliance](./STORE_COMPLIANCE.md)
 - [Database Reliability Validation](./DATABASE_RELIABILITY_VALIDATION.md)
@@ -180,3 +188,4 @@ Date: ____-__-__
 - [Notification Validation](./NOTIFICATION_VALIDATION.md)
 - [UI Responsiveness Validation](./UI_RESPONSIVENESS_VALIDATION.md)
 - [Performance Benchmarks](./PERFORMANCE_BENCHMARKS.md)
+- [Release Device Qualification](./RELEASE_DEVICE_QUALIFICATION.md)

--- a/docs/release/RELEASE_DEVICE_QUALIFICATION.md
+++ b/docs/release/RELEASE_DEVICE_QUALIFICATION.md
@@ -1,0 +1,191 @@
+# Release Device Qualification
+
+This runbook defines the release-artifact validation gate for Airo release
+candidates. It complements the normal build workflow by testing the actual
+customer-facing artifacts and the Patrol native E2E suites across real devices.
+
+## Feature Packet
+
+**Problem:** Release artifacts can pass build checks while still failing on
+customer devices because of OS permissions, screen size, native lifecycle, ABI,
+or package-specific behavior.
+
+**User / actor:** Release manager, QA automation agent, and customer devices.
+
+**Framework or application layer:** Mixed. The owned implementation is release
+automation, test organization, and documentation. App behavior changes are out
+of scope except stable test IDs or deterministic test fixtures.
+
+**Owning agent:** Release and DevEx Agent.
+
+**Reviewing agents:** QA Automation Agent, Mobile UI Agent, Security and
+Privacy Agent, and Framework Agent if platform hooks or reusable contracts
+change.
+
+**Impacted modules/files:** GitHub Actions release qualification workflow,
+Patrol E2E tests, artifact smoke scripts, release device matrix, and release
+checklist.
+
+**Base branch/worktree:** Confirmed from latest `origin/main` for v1/full app
+release work. Use `origin/v2` only for explicit v2 modular/TV issues.
+
+**Decision:** Ready.
+
+## Cross-Agent Contract
+
+**Provider agent:** Release and DevEx Agent.
+
+**Consumer agent:** QA Automation Agent and Release Manager.
+
+**Interface/API:** `config/release_device_matrix.yaml`,
+`.github/workflows/release-device-qualification.yml`, and scripts under
+`scripts/`.
+
+**Input shape:** Release version, artifact workflow run id, provider
+(`browserstack`, `firebase`, `local`, or `host-only`), and tier (`tier1` or
+`full`).
+
+**Output shape:** Markdown report, JSONL artifact inventory, screenshots/logs
+when device execution is enabled, and uploaded CI artifacts.
+
+**State changes:** None in app data. Device runs may install/uninstall release
+artifacts on test devices.
+
+**Errors:** Missing artifacts, failed static checks, missing provider secrets,
+device launch failure, crash logs, Patrol test failures, and waived long-tail
+device gaps.
+
+**Permissions:** Device-farm credentials are read from CI secrets only. Local
+device runs require explicit environment opt-in.
+
+**Privacy/redaction:** Reports must include artifact names, checksums, device
+metadata, and status only. Do not include secrets, user credentials, or full
+customer URLs.
+
+**Persistence:** CI uploads reports with release artifacts. Local runs write to
+`artifacts/release-qualification/`.
+
+**Versioning/migration:** Matrix version is currently `1`. Add new matrix
+fields as optional until scripts are updated to require them.
+
+**Tests required:** Host gates, artifact smoke checks, Patrol tagged suites,
+and provider-specific real-device runs for release-blocking tier 1 devices.
+
+## Deterministic Use Cases
+
+### UC-001: Android release APK launches on real phone
+
+**Actor:** Release manager.
+
+**Preconditions:** Release APK exists and target device is connected or
+available in the selected device farm.
+
+**Trigger:** Release qualification workflow runs for `tier1`.
+
+**Happy path:** APK installs, launches, renders the first frame, and critical
+Patrol smoke tests pass.
+
+**Failure paths:** Install failure, first-frame timeout, startup crash,
+permission dialog dead-end, or Patrol failure blocks release.
+
+**Data created/updated/deleted:** Test app data only; device data is cleared
+between runs where supported.
+
+**Privacy expectations:** No real customer accounts or secrets.
+
+### UC-002: iOS/iPad release candidate passes native device smoke
+
+**Actor:** QA automation agent.
+
+**Preconditions:** IPA or provider-compatible iOS test artifacts exist.
+
+**Trigger:** Release qualification workflow runs with BrowserStack or local iOS
+provider.
+
+**Happy path:** App installs, launches on iPhone and iPad, permissions can be
+handled, and responsive navigation remains usable.
+
+**Failure paths:** IPA missing, signing/install failure, permission dead-end,
+layout blocks primary actions, or crash.
+
+**Data created/updated/deleted:** Test app data only.
+
+**Privacy expectations:** Demo/test fixture account only.
+
+### UC-003: Web and desktop archives are not broken
+
+**Actor:** Release manager.
+
+**Preconditions:** Web zip and desktop archives exist.
+
+**Trigger:** Artifact smoke script scans release artifacts.
+
+**Happy path:** Archives pass integrity checks; web artifact can be served and
+Playwright smoke tests pass when web smoke is enabled.
+
+**Failure paths:** Missing/empty archive, corrupt archive, missing web
+`index.html`, or launch smoke failure.
+
+**Data created/updated/deleted:** Temporary extraction directories.
+
+**Privacy expectations:** No secrets in reports.
+
+## Automation Flows
+
+### AUTO-001: Host artifact smoke
+
+**Given:** Release artifacts downloaded into `release-artifacts/`.
+
+**When:** `scripts/release-artifact-smoke.sh` runs.
+
+**Then:** The script inventories artifacts, records SHA-256 checksums, performs
+static package/archive checks, optionally runs local device smoke checks, and
+writes a Markdown report.
+
+**Fixtures:** Release artifact files from GitHub Actions.
+
+**Mocks/stubs:** None.
+
+**Assertions:** Required artifacts exist for release runs; static integrity
+checks pass; optional device launches do not crash.
+
+**Cleanup:** Temporary extraction directories are removed.
+
+### AUTO-002: Patrol real-device suites
+
+**Given:** Tagged Patrol suites and a provider selected in workflow input.
+
+**When:** The release qualification workflow runs provider jobs.
+
+**Then:** The provider lane runs release-blocking tagged suites on tier 1
+devices and uploads provider logs/videos/reports.
+
+**Fixtures:** Deterministic SharedPreferences login and model selection.
+
+**Mocks/stubs:** No real customer account. Device permission dialogs are
+handled through Patrol native automation where supported.
+
+**Assertions:** Launch, navigation, permission, responsive, lifecycle, and
+finance/agent journeys pass on tier 1 devices.
+
+**Cleanup:** Provider clears app data where supported.
+
+## Release Blocking Rules
+
+- Block release if any tier 1 device fails launch, navigation, permission
+  handling, or crash-free smoke.
+- Block release if Android TV artifact fails Leanback/package checks or D-pad
+  navigation in a TV-capable environment.
+- Block release if iOS/iPad artifacts cannot be produced unless the release
+  explicitly waives iOS with a known issue.
+- Waive non-critical long-tail devices only with device metadata, logs, and a
+  release-note known issue.
+
+## References
+
+- Patrol device farms: https://patrol.leancode.co/documentation/ci/platforms
+- Patrol BrowserStack: https://patrol.leancode.co/integrations/browserstack
+- Flutter integration tests: https://docs.flutter.dev/testing/integration-tests
+- Firebase Test Lab Flutter:
+  https://firebase.google.com/docs/test-lab/flutter/integration-testing-with-flutter
+- BrowserStack Flutter: https://www.browserstack.com/docs/app-automate/flutter

--- a/scripts/release-artifact-smoke.sh
+++ b/scripts/release-artifact-smoke.sh
@@ -1,0 +1,298 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ARTIFACT_DIR="${AIRO_RELEASE_ARTIFACT_DIR:-$ROOT_DIR/release-artifacts}"
+OUTPUT_DIR="${AIRO_RELEASE_QUALIFICATION_DIR:-$ROOT_DIR/artifacts/release-qualification/$(date -u +%Y%m%dT%H%M%SZ)}"
+PACKAGE_NAME="${AIRO_ANDROID_PACKAGE:-io.airo.app}"
+TV_PACKAGE_NAME="${AIRO_ANDROID_TV_PACKAGE:-io.airo.app.tv}"
+REQUIRE_ARTIFACTS="${AIRO_REQUIRE_RELEASE_ARTIFACTS:-false}"
+RUN_DEVICE_SMOKE="${AIRO_RUN_DEVICE_SMOKE:-false}"
+RUN_WEB_SMOKE="${AIRO_RUN_WEB_SMOKE:-false}"
+
+usage() {
+  cat <<EOF
+Usage: $0 [--artifact-dir DIR] [--output-dir DIR] [--require-artifacts]
+
+Validates release artifacts with static integrity checks and optional local
+device/web smoke checks.
+
+Environment:
+  AIRO_ANDROID_PACKAGE              Android package to launch, default io.airo.app
+  AIRO_ANDROID_TV_PACKAGE           Android TV package, default io.airo.app.tv
+  AIRO_REQUIRE_RELEASE_ARTIFACTS    true to fail when no artifacts are found
+  AIRO_RUN_DEVICE_SMOKE             true to install/launch APKs through adb
+  AIRO_RUN_WEB_SMOKE                true to serve web zip and run Playwright
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --artifact-dir)
+      ARTIFACT_DIR="$2"
+      shift 2
+      ;;
+    --output-dir)
+      OUTPUT_DIR="$2"
+      shift 2
+      ;;
+    --require-artifacts)
+      REQUIRE_ARTIFACTS=true
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+mkdir -p "$OUTPUT_DIR"
+REPORT="$OUTPUT_DIR/artifact-smoke-report.md"
+JSONL="$OUTPUT_DIR/artifact-inventory.jsonl"
+: > "$JSONL"
+
+failures=0
+warnings=0
+
+record() {
+  local status="$1"
+  local kind="$2"
+  local file="$3"
+  local message="$4"
+  local sha="${5:-}"
+  python3 - "$status" "$kind" "$file" "$message" "$sha" >> "$JSONL" <<'PY'
+import json
+import sys
+
+status, kind, file_path, message, sha = sys.argv[1:6]
+print(json.dumps({
+    "status": status,
+    "kind": kind,
+    "file": file_path,
+    "message": message,
+    "sha256": sha,
+}, sort_keys=True))
+PY
+}
+
+mark_fail() {
+  failures=$((failures + 1))
+  record "failed" "$1" "$2" "$3" "${4:-}"
+  echo "::error::$3"
+}
+
+mark_warn() {
+  warnings=$((warnings + 1))
+  record "warning" "$1" "$2" "$3" "${4:-}"
+  echo "::warning::$3"
+}
+
+mark_pass() {
+  record "passed" "$1" "$2" "$3" "${4:-}"
+}
+
+sha256() {
+  if command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 "$1" | awk '{print $1}'
+  else
+    sha256sum "$1" | awk '{print $1}'
+  fi
+}
+
+archive_test_zip() {
+  unzip -t "$1" >/dev/null
+}
+
+archive_test_tar() {
+  tar -tzf "$1" >/dev/null
+}
+
+android_device_available() {
+  command -v adb >/dev/null 2>&1 &&
+    adb devices | awk 'NR>1 && $2=="device" { found=1 } END { exit found?0:1 }'
+}
+
+smoke_android_apk() {
+  local apk="$1"
+  local package_name="$2"
+  local label="$3"
+
+  if [[ "$RUN_DEVICE_SMOKE" != "true" ]]; then
+    mark_warn "$label" "$apk" "Skipped adb launch smoke; set AIRO_RUN_DEVICE_SMOKE=true to enable." "$(sha256 "$apk")"
+    return
+  fi
+
+  if ! android_device_available; then
+    mark_fail "$label" "$apk" "AIRO_RUN_DEVICE_SMOKE=true but no connected adb device is available." "$(sha256 "$apk")"
+    return
+  fi
+
+  local base
+  base="$(basename "$apk" .apk)"
+  adb install -r "$apk" > "$OUTPUT_DIR/${base}-adb-install.log" 2>&1 ||
+    { mark_fail "$label" "$apk" "adb install failed for $apk" "$(sha256 "$apk")"; return; }
+
+  adb logcat -c || true
+  adb shell am force-stop "$package_name" >/dev/null 2>&1 || true
+  adb shell am start -W "$package_name/.MainActivity" > "$OUTPUT_DIR/${base}-launch.log" 2>&1 ||
+    { adb logcat -d > "$OUTPUT_DIR/${base}-logcat.txt" || true; mark_fail "$label" "$apk" "adb launch failed for $package_name" "$(sha256 "$apk")"; return; }
+
+  sleep 5
+  adb shell screencap -p "/sdcard/${base}.png" >/dev/null 2>&1 || true
+  adb pull "/sdcard/${base}.png" "$OUTPUT_DIR/${base}.png" >/dev/null 2>&1 || true
+  adb logcat -d > "$OUTPUT_DIR/${base}-logcat.txt" || true
+
+  if grep -E "FATAL EXCEPTION|AndroidRuntime|Process: ${package_name}" "$OUTPUT_DIR/${base}-logcat.txt" >/dev/null; then
+    mark_fail "$label" "$apk" "Crash signature found in logcat after launching $package_name" "$(sha256 "$apk")"
+    return
+  fi
+
+  mark_pass "$label" "$apk" "Installed and launched $package_name without startup crash." "$(sha256 "$apk")"
+}
+
+validate_apk() {
+  local apk="$1"
+  local sha
+  sha="$(sha256 "$apk")"
+  archive_test_zip "$apk" || { mark_fail "android_apk" "$apk" "APK zip integrity failed." "$sha"; return; }
+
+  if unzip -l "$apk" | grep -q "AndroidManifest.xml"; then
+    mark_pass "android_apk" "$apk" "APK integrity and manifest presence verified." "$sha"
+  else
+    mark_fail "android_apk" "$apk" "APK missing AndroidManifest.xml." "$sha"
+    return
+  fi
+
+  if [[ "$(basename "$apk")" == *tv* ]]; then
+    smoke_android_apk "$apk" "$TV_PACKAGE_NAME" "android_tv_apk"
+  else
+    smoke_android_apk "$apk" "$PACKAGE_NAME" "android_apk"
+  fi
+}
+
+validate_aab() {
+  local aab="$1"
+  local sha
+  sha="$(sha256 "$aab")"
+  archive_test_zip "$aab" || { mark_fail "android_aab" "$aab" "AAB zip integrity failed." "$sha"; return; }
+  if unzip -l "$aab" | grep -Eq "base/manifest/AndroidManifest.xml|base/manifest/.*AndroidManifest.xml"; then
+    mark_pass "android_aab" "$aab" "AAB integrity and base manifest verified." "$sha"
+  else
+    mark_fail "android_aab" "$aab" "AAB missing base manifest." "$sha"
+  fi
+}
+
+validate_ipa() {
+  local ipa="$1"
+  local sha
+  sha="$(sha256 "$ipa")"
+  archive_test_zip "$ipa" || { mark_fail "ios_ipa" "$ipa" "IPA zip integrity failed." "$sha"; return; }
+  if unzip -l "$ipa" | grep -Eq "Payload/.+\\.app/Info.plist"; then
+    mark_pass "ios_ipa" "$ipa" "IPA integrity and app Info.plist verified." "$sha"
+  else
+    mark_fail "ios_ipa" "$ipa" "IPA missing Payload/*.app/Info.plist." "$sha"
+  fi
+}
+
+validate_web_zip() {
+  local zip="$1"
+  local sha
+  sha="$(sha256 "$zip")"
+  archive_test_zip "$zip" || { mark_fail "web_zip" "$zip" "Web zip integrity failed." "$sha"; return; }
+  if unzip -l "$zip" | grep -q "index.html"; then
+    mark_pass "web_zip" "$zip" "Web archive integrity and index.html verified." "$sha"
+  else
+    mark_fail "web_zip" "$zip" "Web archive missing index.html." "$sha"
+    return
+  fi
+
+  if [[ "$RUN_WEB_SMOKE" != "true" ]]; then
+    mark_warn "web_zip" "$zip" "Skipped Playwright web artifact smoke; set AIRO_RUN_WEB_SMOKE=true to enable." "$sha"
+    return
+  fi
+
+  local web_dir="$OUTPUT_DIR/web-smoke"
+  rm -rf "$web_dir"
+  mkdir -p "$web_dir"
+  unzip -q "$zip" -d "$web_dir"
+  (cd "$web_dir" && python3 -m http.server 8080 > "$OUTPUT_DIR/web-server.log" 2>&1 & echo $! > "$OUTPUT_DIR/web-server.pid")
+  sleep 3
+  if (cd "$ROOT_DIR/e2e" && FLUTTER_WEB_URL=http://127.0.0.1:8080 npx playwright test --grep "@smoke" --project=chromium --reporter=list); then
+    mark_pass "web_zip" "$zip" "Playwright smoke passed against extracted web artifact." "$sha"
+  else
+    mark_fail "web_zip" "$zip" "Playwright smoke failed against extracted web artifact." "$sha"
+  fi
+  kill "$(cat "$OUTPUT_DIR/web-server.pid")" >/dev/null 2>&1 || true
+}
+
+validate_windows_zip() {
+  local zip="$1"
+  local sha
+  sha="$(sha256 "$zip")"
+  archive_test_zip "$zip" || { mark_fail "windows_zip" "$zip" "Windows zip integrity failed." "$sha"; return; }
+  mark_pass "windows_zip" "$zip" "Windows archive integrity verified." "$sha"
+}
+
+validate_linux_tar() {
+  local tarball="$1"
+  local sha
+  sha="$(sha256 "$tarball")"
+  archive_test_tar "$tarball" || { mark_fail "linux_tar" "$tarball" "Linux tarball integrity failed." "$sha"; return; }
+  mark_pass "linux_tar" "$tarball" "Linux archive integrity verified." "$sha"
+}
+
+declare -a artifacts
+artifacts=()
+while IFS= read -r artifact; do
+  artifacts+=("$artifact")
+done < <(find "$ARTIFACT_DIR" -type f \( \
+  -name "*.apk" -o \
+  -name "*.aab" -o \
+  -name "*.ipa" -o \
+  -name "*web*.zip" -o \
+  -name "*windows*.zip" -o \
+  -name "*linux*.tar.gz" \
+\) 2>/dev/null | sort)
+
+if [[ "${#artifacts[@]}" -eq 0 ]]; then
+  if [[ "$REQUIRE_ARTIFACTS" == "true" ]]; then
+    mark_fail "artifact_discovery" "$ARTIFACT_DIR" "No release artifacts found in $ARTIFACT_DIR."
+  else
+    mark_warn "artifact_discovery" "$ARTIFACT_DIR" "No release artifacts found in $ARTIFACT_DIR."
+  fi
+fi
+
+if [[ "${#artifacts[@]}" -gt 0 ]]; then
+  for artifact in "${artifacts[@]}"; do
+    case "$artifact" in
+      *.apk) validate_apk "$artifact" ;;
+      *.aab) validate_aab "$artifact" ;;
+      *.ipa) validate_ipa "$artifact" ;;
+      *web*.zip) validate_web_zip "$artifact" ;;
+      *windows*.zip) validate_windows_zip "$artifact" ;;
+      *linux*.tar.gz) validate_linux_tar "$artifact" ;;
+      *) mark_warn "unknown" "$artifact" "Unrecognized artifact type." "$(sha256 "$artifact")" ;;
+    esac
+  done
+fi
+
+python3 "$ROOT_DIR/scripts/generate-release-qualification-report.py" \
+  --inventory "$JSONL" \
+  --output "$REPORT" \
+  --artifact-dir "$ARTIFACT_DIR" \
+  --matrix "$ROOT_DIR/config/release_device_matrix.yaml"
+
+echo "Release artifact smoke report: $REPORT"
+
+if [[ "$failures" -gt 0 ]]; then
+  echo "Release artifact smoke failed: $failures failure(s), $warnings warning(s)." >&2
+  exit 1
+fi
+
+echo "Release artifact smoke passed: $warnings warning(s)."

--- a/scripts/run-browserstack-patrol.sh
+++ b/scripts/run-browserstack-patrol.sh
@@ -1,0 +1,232 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+MATRIX="${AIRO_RELEASE_DEVICE_MATRIX:-$ROOT_DIR/config/release_device_matrix.yaml}"
+OUTPUT_DIR="${AIRO_RELEASE_QUALIFICATION_DIR:-$ROOT_DIR/artifacts/release-qualification/browserstack-$(date -u +%Y%m%dT%H%M%SZ)}"
+TIER="${AIRO_QUALIFICATION_TIER:-tier1}"
+APP_APK="${AIRO_BROWSERSTACK_APP_APK:-}"
+TEST_APK="${AIRO_BROWSERSTACK_TEST_APK:-}"
+WAIT_FOR_COMPLETION="${AIRO_BROWSERSTACK_WAIT_FOR_COMPLETION:-true}"
+POLL_SECONDS="${AIRO_BROWSERSTACK_POLL_SECONDS:-60}"
+TIMEOUT_SECONDS="${AIRO_BROWSERSTACK_TIMEOUT_SECONDS:-1800}"
+
+usage() {
+  cat <<EOF
+Usage: $0 --app APK --test-suite APK [--output-dir DIR] [--tier tier1|full]
+
+Schedules Android Patrol instrumentation artifacts on BrowserStack App Automate
+using the tier 1 Android entries from config/release_device_matrix.yaml.
+
+Required secrets:
+  BROWSERSTACK_USERNAME
+  BROWSERSTACK_ACCESS_KEY
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --app)
+      APP_APK="$2"
+      shift 2
+      ;;
+    --test-suite)
+      TEST_APK="$2"
+      shift 2
+      ;;
+    --output-dir)
+      OUTPUT_DIR="$2"
+      shift 2
+      ;;
+    --tier)
+      TIER="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+mkdir -p "$OUTPUT_DIR"
+
+if [[ -z "${BROWSERSTACK_USERNAME:-}" || -z "${BROWSERSTACK_ACCESS_KEY:-}" ]]; then
+  echo "::error::BROWSERSTACK_USERNAME and BROWSERSTACK_ACCESS_KEY are required."
+  exit 1
+fi
+
+[[ -s "$APP_APK" ]] || { echo "::error::App APK not found: $APP_APK"; exit 1; }
+[[ -s "$TEST_APK" ]] || { echo "::error::Test APK not found: $TEST_APK"; exit 1; }
+
+auth="${BROWSERSTACK_USERNAME}:${BROWSERSTACK_ACCESS_KEY}"
+app_response="$OUTPUT_DIR/browserstack-app-upload.json"
+test_response="$OUTPUT_DIR/browserstack-test-upload.json"
+build_response="$OUTPUT_DIR/browserstack-build.json"
+
+curl --fail-with-body -u "$auth" \
+  -X POST "https://api-cloud.browserstack.com/app-automate/espresso/v2/app" \
+  -F "file=@${APP_APK}" \
+  -o "$app_response"
+
+curl --fail-with-body -u "$auth" \
+  -X POST "https://api-cloud.browserstack.com/app-automate/espresso/v2/test-suite" \
+  -F "file=@${TEST_APK}" \
+  -o "$test_response"
+
+python3 - "$MATRIX" "$TIER" "$app_response" "$test_response" "$build_response" <<'PY'
+import json
+import re
+import sys
+from pathlib import Path
+
+matrix_path, tier, app_response, test_response, build_response = sys.argv[1:6]
+text = Path(matrix_path).read_text(encoding="utf-8")
+
+devices = []
+current = {}
+for line in text.splitlines():
+    if re.match(r"\s+- id:", line):
+        current = {"id": line.split(":", 1)[1].strip()}
+    elif "tier:" in line and current is not None:
+        current["tier"] = line.split(":", 1)[1].strip()
+    elif "browserstack:" in line and current is not None:
+        value = line.split(":", 1)[1].strip().strip('"')
+        current["browserstack"] = value
+        if tier == "full" or current.get("tier") == tier:
+            devices.append(value)
+
+android_devices = [
+    d for d in devices
+    if any(marker in d.lower() for marker in ["pixel", "samsung", "galaxy"])
+]
+if not android_devices:
+    raise SystemExit("No BrowserStack Android devices found in matrix")
+
+app_url = json.loads(Path(app_response).read_text(encoding="utf-8")).get("app_url")
+test_url = json.loads(Path(test_response).read_text(encoding="utf-8")).get("test_suite_url")
+if not app_url or not test_url:
+    raise SystemExit("BrowserStack upload response missing app_url or test_suite_url")
+
+payload = {
+    "app": app_url,
+    "testSuite": test_url,
+    "devices": android_devices,
+    "project": "Airo",
+    "build": "release-device-qualification",
+    "networkLogs": True,
+    "deviceLogs": True,
+    "video": True,
+}
+Path(build_response + ".payload.json").write_text(json.dumps(payload, indent=2), encoding="utf-8")
+print(json.dumps(payload))
+PY
+
+curl --fail-with-body -u "$auth" \
+  -X POST "https://api-cloud.browserstack.com/app-automate/espresso/v2/build" \
+  -H "Content-Type: application/json" \
+  -d @"$build_response.payload.json" \
+  -o "$build_response"
+
+cat > "$OUTPUT_DIR/browserstack-summary.md" <<EOF
+# BrowserStack Patrol Qualification
+
+Provider: BrowserStack App Automate Espresso
+Tier: $TIER
+Matrix: $MATRIX
+
+Responses:
+- App upload: $(basename "$app_response")
+- Test upload: $(basename "$test_response")
+- Build schedule: $(basename "$build_response")
+
+Check the BrowserStack dashboard for live status, videos, and device logs.
+EOF
+
+if [[ "$WAIT_FOR_COMPLETION" == "true" ]]; then
+  build_id="$(python3 - "$build_response" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+data = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+for key in ("build_id", "id", "buildId"):
+    value = data.get(key)
+    if value:
+        print(value)
+        break
+else:
+    print("")
+PY
+)"
+
+  if [[ -z "$build_id" ]]; then
+    echo "::error::BrowserStack build response did not include a build id."
+    cat "$build_response"
+    exit 1
+  fi
+
+  status_file="$OUTPUT_DIR/browserstack-build-status.json"
+  elapsed=0
+  while [[ "$elapsed" -le "$TIMEOUT_SECONDS" ]]; do
+    curl --fail-with-body -u "$auth" \
+      "https://api-cloud.browserstack.com/app-automate/espresso/v2/builds/${build_id}" \
+      -o "$status_file"
+
+    status="$(python3 - "$status_file" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+data = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+text = json.dumps(data).lower()
+for key in ("status", "state", "build_status"):
+    value = data.get(key)
+    if isinstance(value, str):
+        print(value.lower())
+        break
+else:
+    if any(word in text for word in ("failed", "error", "timed out")):
+        print("failed")
+    elif any(word in text for word in ("passed", "success", "completed", "done")):
+        print("completed")
+    else:
+        print("running")
+PY
+)"
+
+    case "$status" in
+      passed|success|completed|done)
+        if grep -Eiq '"(failed|error|timed out)"' "$status_file"; then
+          echo "::error::BrowserStack build completed with failing session details."
+          cat "$status_file"
+          exit 1
+        fi
+        echo "BrowserStack build completed with status: $status"
+        break
+        ;;
+      failed|error|timedout|timed_out|timeout)
+        echo "::error::BrowserStack build failed with status: $status"
+        cat "$status_file"
+        exit 1
+        ;;
+      *)
+        echo "BrowserStack build status: $status (${elapsed}s elapsed)"
+        sleep "$POLL_SECONDS"
+        elapsed=$((elapsed + POLL_SECONDS))
+        ;;
+    esac
+  done
+
+  if [[ "$elapsed" -gt "$TIMEOUT_SECONDS" ]]; then
+    echo "::error::Timed out waiting for BrowserStack build $build_id."
+    exit 1
+  fi
+fi
+
+echo "BrowserStack build scheduled. Summary: $OUTPUT_DIR/browserstack-summary.md"

--- a/scripts/run-firebase-patrol.sh
+++ b/scripts/run-firebase-patrol.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+OUTPUT_DIR="${AIRO_RELEASE_QUALIFICATION_DIR:-$ROOT_DIR/artifacts/release-qualification/firebase-$(date -u +%Y%m%dT%H%M%SZ)}"
+APP_APK="${AIRO_FIREBASE_APP_APK:-}"
+TEST_APK="${AIRO_FIREBASE_TEST_APK:-}"
+RESULTS_BUCKET="${AIRO_FIREBASE_RESULTS_BUCKET:-}"
+DEVICE_MODEL="${AIRO_FIREBASE_DEVICE_MODEL:-oriole}"
+DEVICE_VERSION="${AIRO_FIREBASE_DEVICE_VERSION:-35}"
+DEVICE_LOCALE="${AIRO_FIREBASE_DEVICE_LOCALE:-en}"
+DEVICE_ORIENTATION="${AIRO_FIREBASE_DEVICE_ORIENTATION:-portrait}"
+
+usage() {
+  cat <<EOF
+Usage: $0 --app APK --test-suite APK [--output-dir DIR]
+
+Runs Android Patrol instrumentation artifacts on Firebase Test Lab.
+
+Required tools:
+  gcloud
+
+Optional environment:
+  AIRO_FIREBASE_RESULTS_BUCKET
+  AIRO_FIREBASE_DEVICE_MODEL
+  AIRO_FIREBASE_DEVICE_VERSION
+  AIRO_FIREBASE_DEVICE_LOCALE
+  AIRO_FIREBASE_DEVICE_ORIENTATION
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --app)
+      APP_APK="$2"
+      shift 2
+      ;;
+    --test-suite)
+      TEST_APK="$2"
+      shift 2
+      ;;
+    --output-dir)
+      OUTPUT_DIR="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+mkdir -p "$OUTPUT_DIR"
+[[ -s "$APP_APK" ]] || { echo "::error::App APK not found: $APP_APK"; exit 1; }
+[[ -s "$TEST_APK" ]] || { echo "::error::Test APK not found: $TEST_APK"; exit 1; }
+command -v gcloud >/dev/null 2>&1 || { echo "::error::gcloud is required for Firebase Test Lab."; exit 1; }
+
+args=(
+  firebase test android run
+  --type instrumentation
+  --app "$APP_APK"
+  --test "$TEST_APK"
+  --device "model=${DEVICE_MODEL},version=${DEVICE_VERSION},locale=${DEVICE_LOCALE},orientation=${DEVICE_ORIENTATION}"
+  --timeout 30m
+)
+
+if [[ -n "$RESULTS_BUCKET" ]]; then
+  args+=(--results-bucket "$RESULTS_BUCKET")
+fi
+
+gcloud "${args[@]}" | tee "$OUTPUT_DIR/firebase-test-lab.log"
+
+cat > "$OUTPUT_DIR/firebase-summary.md" <<EOF
+# Firebase Test Lab Patrol Qualification
+
+Device: ${DEVICE_MODEL} / Android ${DEVICE_VERSION} / ${DEVICE_ORIENTATION}
+App APK: $(basename "$APP_APK")
+Test APK: $(basename "$TEST_APK")
+
+See firebase-test-lab.log and the Firebase Test Lab console for device details.
+EOF


### PR DESCRIPTION
## Summary
- Lands stash `codex/release-device-qualification-v2` (from RC stabilization triage, issue #872), rebased onto current main and adapted where main had already diverged.
- Adds `release-device-qualification.yml`: new tag/manual-dispatch workflow running host gates + optional BrowserStack/Firebase real-device patrol runs against release artifacts (tier1/full device matrix).
- Adds `config/release_device_matrix.yaml`, `scripts/release-artifact-smoke.sh`, `scripts/run-browserstack-patrol.sh`, `scripts/run-firebase-patrol.sh`, `docs/release/RELEASE_DEVICE_QUALIFICATION.md`.
- Adds `release_smoke`/`permissions`/`finance_agent` etc. tags to existing Patrol tests (metadata only, no behavior change).
- New `make test-release-artifacts*` targets.

## Arch-fit adjustments made during landing
- Dropped stash's `ci.yml` changes entirely — main's CI has since been hardened (green-on-main); stash predated that work.
- Dropped stash's `app/ios/Podfile.lock` changes — stale lockfile snapshot.
- Kept main's `main_tv.dart` playlist-cache-warm condition — stash's inverted the equality check, which would have broken `main_tv_debug_playlist_test.dart`'s "warms cache after seed" case.
- Kept main's `cast_device_picker_sheet.dart` troubleshooting-text implementation over stash's parallel widget-based rework — same feature, main's is already shipped/tested.
- Dropped a stray local Xcode `.swiftpm` user-data cache file that came along in the stash.

## Test plan
- [x] `flutter analyze` clean on both modified patrol test files
- [x] YAML/shell/py syntax validated for all new workflow/script files
- [ ] Reviewer: confirm `release-device-qualification.yml` secrets/provider assumptions (BrowserStack/Firebase creds) before first real dispatch

🤖 Generated with [Claude Code](https://claude.com/claude-code)