### PR TITLE
feat(feature_iptv): CV-021 -- wire hidden groups into local search

### DIFF
--- a/packages/feature_iptv/lib/application/providers/iptv_providers.dart
+++ b/packages/feature_iptv/lib/application/providers/iptv_providers.dart
@@ -480,3 +480,32 @@ final toggleChannelFavoriteProvider = FutureProvider.family<bool, String>((
   ref.invalidate(favoriteChannelIdsProvider);
   return isNowFavorite;
 });
+
+// =============================================================================
+// Hidden Groups Providers (CV-021, #826)
+// =============================================================================
+
+/// Hidden groups storage provider.
+final hiddenGroupsStorageProvider = Provider<HiddenGroupsStorage>((ref) {
+  final prefs = ref.watch(sharedPreferencesProvider);
+  return HiddenGroupsStorage(prefs);
+});
+
+/// The set of hidden group/category ids. Consumed by search (CV-006) and,
+/// once it exists, the smart-playlist rule engine (CV-017) so hidden
+/// channels are excluded by default rather than just visually skipped.
+final hiddenGroupIdsProvider = FutureProvider<Set<String>>((ref) async {
+  final storage = ref.watch(hiddenGroupsStorageProvider);
+  return storage.getHiddenGroupIds();
+});
+
+/// Toggle a group's hidden state. Returns the new state.
+final toggleGroupHiddenProvider = FutureProvider.family<bool, String>((
+  ref,
+  groupId,
+) async {
+  final storage = ref.watch(hiddenGroupsStorageProvider);
+  final nowHidden = await storage.toggleHidden(groupId);
+  ref.invalidate(hiddenGroupIdsProvider);
+  return nowHidden;
+});

--- a/packages/feature_iptv/lib/application/providers/local_iptv_search_providers.dart
+++ b/packages/feature_iptv/lib/application/providers/local_iptv_search_providers.dart
@@ -22,6 +22,7 @@ final localIptvSearchIndexProvider = FutureProvider<LocalIptvSearchIndex>((
   final recentChannels = await ref.watch(
     recentlyWatchedChannelsProvider.future,
   );
+  final hiddenGroupIds = await ref.watch(hiddenGroupIdsProvider.future);
 
   // No EPG source configured falls back to EmptyCompactEpgRepository
   // (compactEpgRepositoryProvider's default), which resolves an empty
@@ -37,6 +38,7 @@ final localIptvSearchIndexProvider = FutureProvider<LocalIptvSearchIndex>((
     programsByChannelId: programsByChannelId,
     favoriteChannelIds: favoriteIds,
     recentChannelIds: [for (final channel in recentChannels) channel.id],
+    hiddenGroupIds: hiddenGroupIds,
   );
 });
 

--- a/packages/feature_iptv/lib/domain/local_iptv_search.dart
+++ b/packages/feature_iptv/lib/domain/local_iptv_search.dart
@@ -62,12 +62,20 @@ class LocalIptvSearchIndex {
     required Map<String, List<CompactEpgProgram>> programsByChannelId,
     required Set<String> favoriteChannelIds,
     required List<String> recentChannelIds,
+    Set<String> hiddenGroupIds = const {},
   }) {
     final recentRank = <String, int>{
       for (var i = 0; i < recentChannelIds.length; i++) recentChannelIds[i]: i,
     };
+    // CV-021: hidden groups are excluded from the index entirely, not just
+    // visually skipped, so they never surface as search results.
+    final visibleChannels = hiddenGroupIds.isEmpty
+        ? channels
+        : channels
+              .where((channel) => !hiddenGroupIds.contains(channel.group))
+              .toList(growable: false);
     return LocalIptvSearchIndex._(
-      List.unmodifiable(channels),
+      List.unmodifiable(visibleChannels),
       Map.unmodifiable(programsByChannelId),
       Set.unmodifiable(favoriteChannelIds),
       Map.unmodifiable(recentRank),

--- a/packages/feature_iptv/test/iptv/application/providers/local_iptv_search_providers_test.dart
+++ b/packages/feature_iptv/test/iptv/application/providers/local_iptv_search_providers_test.dart
@@ -81,6 +81,28 @@ void main() {
     expect(result.isFavorite, isTrue);
   });
 
+  test('excludes channels in a hidden group from search (CV-021)', () async {
+    final container = buildContainer(
+      epgRepository: InMemoryCompactEpgRepository(
+        seed: CompactEpgSlice(
+          entries: const [],
+          generatedAt: DateTime.now().toUtc(),
+          expiresAt: DateTime.now().toUtc().add(const Duration(hours: 1)),
+          source: CompactEpgSliceSource.unavailable,
+        ),
+      ),
+    );
+    addTearDown(container.dispose);
+
+    await container.read(hiddenGroupsStorageProvider).hideGroup('News');
+    container.invalidate(hiddenGroupIdsProvider);
+
+    final index = await container.read(localIptvSearchIndexProvider.future);
+
+    expect(index.search('BBC'), isEmpty);
+    expect(index.search('CNN'), isEmpty);
+  });
+
   test('rebuilds when the underlying channel list changes', () async {
     final container = buildContainer(channels: const [bbcNews]);
     addTearDown(container.dispose);

--- a/packages/feature_iptv/test/iptv/domain/local_iptv_search_test.dart
+++ b/packages/feature_iptv/test/iptv/domain/local_iptv_search_test.dart
@@ -39,14 +39,32 @@ void main() {
     LocalIptvSearchIndex buildIndex({
       Set<String> favoriteChannelIds = const {},
       List<String> recentChannelIds = const [],
+      Set<String> hiddenGroupIds = const {},
     }) {
       return LocalIptvSearchIndex.build(
         channels: channels,
         programsByChannelId: programsByChannel,
         favoriteChannelIds: favoriteChannelIds,
         recentChannelIds: recentChannelIds,
+        hiddenGroupIds: hiddenGroupIds,
       );
     }
+
+    test('excludes channels whose group is hidden (CV-021)', () {
+      final index = buildIndex(hiddenGroupIds: {'Sports'});
+
+      final results = index.search('ESPN');
+
+      expect(results, isEmpty);
+    });
+
+    test('hidden groups do not affect channels in other groups', () {
+      final index = buildIndex(hiddenGroupIds: {'Sports'});
+
+      final results = index.search('BBC News');
+
+      expect(results, isNotEmpty);
+    });
 
     test('returns empty results for a blank query', () {
       final index = buildIndex();


### PR DESCRIPTION
## Summary
Part of #826 (CV-021). `HiddenGroupsStorage` merged earlier this session
(#867) but was never wired into any consuming surface. This slice wires
it into search.

- New providers in `iptv_providers.dart`: `hiddenGroupsStorageProvider`,
  `hiddenGroupIdsProvider`, `toggleGroupHiddenProvider` (mirrors the
  existing favorites provider pattern in the same file).
- `LocalIptvSearchIndex.build()` takes an optional `hiddenGroupIds` set
  and excludes matching channels from the index entirely -- hidden
  groups are excluded by default, not just visually skipped, per the
  issue's acceptance criteria.
- `localIptvSearchIndexProvider` wires `hiddenGroupIdsProvider` through
  automatically.

## Not in this slice
- Browse (TV channel grid) and guide wiring -- still open, per the
  issue's "respected by browse, search, and guide" AC. Search was the
  smallest, most self-contained first cut.
- The "hide this group" UI action reachable from the channel browse/grid
  screen -- the provider (`toggleGroupHiddenProvider`) exists for a
  future UI slice to call.
- TV Favorites route still needs to render real content (separate part
  of #826, `platform_favorites`'s favorite-channels side is already real
  per earlier session work -- this issue's remaining gap is the hidden-
  groups wiring and the route itself).

## Test plan
- [x] `LocalIptvSearchIndex` tests: hidden group excluded, other groups
      unaffected.
- [x] Provider test: hiding a group via `hiddenGroupsStorageProvider`
      then invalidating removes its channels from
      `localIptvSearchIndexProvider` results.
- [x] `flutter analyze` clean on changed files (one pre-existing,
      unrelated `unnecessary_import` lint).
- [x] `dart format --set-exit-if-changed` clean.