### PR TITLE
fix(feature_iptv,app): CV-022-nit — TV source management polish

### DIFF
--- a/app/lib/features/settings/presentation/tv/tv_source_management_section.dart
+++ b/app/lib/features/settings/presentation/tv/tv_source_management_section.dart
@@ -53,6 +53,7 @@ class _TvSourceManagementSectionState
     _labelError = null;
     _urlError = null;
     _submitError = null;
+    _removeError = null;
   }
 
   void _openAddForm() {
@@ -61,6 +62,7 @@ class _TvSourceManagementSectionState
       _labelError = null;
       _urlError = null;
       _submitError = null;
+      _removeError = null;
     });
   }
 
@@ -159,8 +161,12 @@ class _TvSourceManagementSectionState
           );
       }
     } catch (error) {
+      debugPrint('TvSourceManagementSection: add source failed: $error');
       if (!mounted) return;
-      setState(() => _submitError = 'Could not add source: $error');
+      setState(
+        () =>
+            _submitError = 'Could not add source. Check the URL and try again.',
+      );
       return;
     }
 
@@ -204,8 +210,9 @@ class _TvSourceManagementSectionState
       if (!mounted) return;
       setState(() => _removeError = null);
     } catch (error) {
+      debugPrint('TvSourceManagementSection: remove source failed: $error');
       if (!mounted) return;
-      setState(() => _removeError = 'Could not remove source: $error');
+      setState(() => _removeError = 'Could not remove source. Try again.');
     }
   }
 

--- a/app/lib/features/settings/presentation/tv/tv_theme_section.dart
+++ b/app/lib/features/settings/presentation/tv/tv_theme_section.dart
@@ -23,7 +23,7 @@ class TvThemeSection extends ConsumerWidget {
         final definition = AppTheme.byId(id);
         final isSelected = id == current;
         return TvFocusable(
-          autofocus: index == 0,
+          autofocus: isSelected,
           onSelect: () => ref.read(appThemeProvider.notifier).setTheme(id),
           semanticLabel: definition.name,
           semanticButton: true,

--- a/app/test/features/settings/presentation/tv/tv_source_management_section_test.dart
+++ b/app/test/features/settings/presentation/tv/tv_source_management_section_test.dart
@@ -181,6 +181,7 @@ void main() {
         password: 'p',
       )).future,
     );
+    await tester.pump(const Duration(milliseconds: 1));
 
     await tester.pumpWidget(
       UncontrolledProviderScope(
@@ -247,6 +248,7 @@ void main() {
         url: 'https://example.com/playlist.m3u',
       )).future,
     );
+    await tester.pump(const Duration(milliseconds: 1));
 
     await tester.pumpWidget(
       UncontrolledProviderScope(

--- a/packages/feature_iptv/lib/application/providers/content_source_management_providers.dart
+++ b/packages/feature_iptv/lib/application/providers/content_source_management_providers.dart
@@ -29,11 +29,13 @@ final configuredContentSourcesProvider =
 
 /// Adds a new M3U [ContentSourceConfig] and invalidates
 /// [configuredContentSourcesProvider].
-final addM3uContentSourceProvider =
-    FutureProvider.family<void, ({String label, String url})>((
-      ref,
-      args,
-    ) async {
+final addM3uContentSourceProvider = FutureProvider.autoDispose
+    .family<void, ({String label, String url})>((ref, args) async {
+      // autoDispose has no external listener across this one-shot mutation
+      // (callers only `ref.read(...).future` it once) — keepAlive prevents
+      // the provider from being torn down mid-`await`, which would silently
+      // truncate the write.
+      final keepAlive = ref.keepAlive();
       final id = 'm3u-${DateTime.now().microsecondsSinceEpoch}';
       await ref
           .watch(contentSourceStoreProvider)
@@ -46,17 +48,19 @@ final addM3uContentSourceProvider =
             ),
           );
       ref.invalidate(configuredContentSourcesProvider);
+      keepAlive.close();
     });
 
 /// Adds a new Xtream Codes [ContentSourceConfig] and stores its
 /// credentials via [contentSourceCredentialStoreProvider], keyed on the
 /// generated config id so [removeContentSourceProvider] deletes the same
 /// credential slot.
-final addXtreamContentSourceProvider =
-    FutureProvider.family<
+final addXtreamContentSourceProvider = FutureProvider.autoDispose
+    .family<
       void,
       ({String label, String url, String username, String password})
     >((ref, args) async {
+      final keepAlive = ref.keepAlive();
       final id = 'xtream-${DateTime.now().microsecondsSinceEpoch}';
       await ref
           .watch(contentSourceCredentialStoreProvider)
@@ -78,16 +82,18 @@ final addXtreamContentSourceProvider =
             ),
           );
       ref.invalidate(configuredContentSourcesProvider);
+      keepAlive.close();
     });
 
 /// Adds a new Stalker Portal [ContentSourceConfig]. Stalker auth uses the
 /// device MAC address (persisted in the config itself, not a secret), so
 /// no credential store write is needed.
-final addStalkerContentSourceProvider =
-    FutureProvider.family<
-      void,
-      ({String label, String url, String macAddress})
-    >((ref, args) async {
+final addStalkerContentSourceProvider = FutureProvider.autoDispose
+    .family<void, ({String label, String url, String macAddress})>((
+      ref,
+      args,
+    ) async {
+      final keepAlive = ref.keepAlive();
       final id = 'stalker-${DateTime.now().microsecondsSinceEpoch}';
       await ref
           .watch(contentSourceStoreProvider)
@@ -101,15 +107,17 @@ final addStalkerContentSourceProvider =
             ),
           );
       ref.invalidate(configuredContentSourcesProvider);
+      keepAlive.close();
     });
 
 /// Adds a new Jellyfin [ContentSourceConfig] and stores its credentials
 /// (username + password/api-key) via [contentSourceCredentialStoreProvider].
-final addJellyfinContentSourceProvider =
-    FutureProvider.family<
+final addJellyfinContentSourceProvider = FutureProvider.autoDispose
+    .family<
       void,
       ({String label, String url, String username, String password})
     >((ref, args) async {
+      final keepAlive = ref.keepAlive();
       final id = 'jellyfin-${DateTime.now().microsecondsSinceEpoch}';
       await ref
           .watch(contentSourceCredentialStoreProvider)
@@ -131,19 +139,20 @@ final addJellyfinContentSourceProvider =
             ),
           );
       ref.invalidate(configuredContentSourcesProvider);
+      keepAlive.close();
     });
 
 /// Removes a content source by id and deletes any credential stored for it
 /// via [contentSourceCredentialStoreProvider] — otherwise a removed source
 /// leaves an orphaned secret behind with no owner. Invalidates
 /// [configuredContentSourcesProvider] afterwards.
-final removeContentSourceProvider = FutureProvider.family<void, String>((
-  ref,
-  id,
-) async {
-  await ref.watch(contentSourceStoreProvider).remove(id);
-  await ref
-      .watch(contentSourceCredentialStoreProvider)
-      .delete(ContentSourceCredentialRef(id));
-  ref.invalidate(configuredContentSourcesProvider);
-});
+final removeContentSourceProvider = FutureProvider.autoDispose
+    .family<void, String>((ref, id) async {
+      final keepAlive = ref.keepAlive();
+      await ref.watch(contentSourceStoreProvider).remove(id);
+      await ref
+          .watch(contentSourceCredentialStoreProvider)
+          .delete(ContentSourceCredentialRef(id));
+      ref.invalidate(configuredContentSourcesProvider);
+      keepAlive.close();
+    });


### PR DESCRIPTION
Closes #878.

Small cleanup pass on 5 minor items surfaced during CV-022 final review (all non-blocking):

1. `_removeError` now resets on add-form open/close and on a successful add — no more lingering stale error text.
2. **Already fixed** in the merged CV-022 code — the list-row subtitle already uses `_kindLabel(config.kind)`, not the raw `stableId`. No change needed.
3. `_submitError`/`_removeError` no longer interpolate raw exception text; fixed generic messages instead, raw error goes to `debugPrint`.
4. `addM3uContentSourceProvider`, `addXtreamContentSourceProvider`, `addStalkerContentSourceProvider`, `addJellyfinContentSourceProvider`, and `removeContentSourceProvider` are now `.autoDispose.family` so cached completed futures don't leak per unique args tuple. This surfaced a real bug: without `ref.keepAlive()`, autoDispose could tear the provider down mid-`await` (no external listener across the one-shot `ref.read(...).future` call), silently truncating the write. Guarded each provider body with `ref.keepAlive()`, closed after the mutation + invalidate complete.
5. TV theme picker's D-pad focus now lands on the currently-selected theme instead of always the first one.

## Test plan
- [x] `flutter test test/features/settings/presentation/tv/` — 15/15 pass
- [x] `flutter test` (app) — 980/980 pass
- [x] `flutter test` (packages/feature_iptv) — 279/279 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)