### PR TITLE
feat(feature_iptv): CV-008 -- TV font mode + D-pad surf mode

### DIFF
--- a/packages/feature_iptv/lib/application/providers/tv_font_mode_provider.dart
+++ b/packages/feature_iptv/lib/application/providers/tv_font_mode_provider.dart
@@ -1,0 +1,66 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_riverpod/legacy.dart';
+import 'iptv_providers.dart' show sharedPreferencesProvider;
+
+const tvFontModeStorageKey = 'tv_font_mode';
+
+/// Persisted user preference (CV-008, UC-001) for TV UI text size.
+enum TvFontMode {
+  standard('standard', 1),
+  large('large', 1.25),
+  extraLarge('extra_large', 1.5);
+
+  const TvFontMode(this.stableId, this.scale);
+
+  final String stableId;
+
+  /// Multiplier applied to a surface's base font size. TV channel/control
+  /// text is expected to keep its existing `maxLines`/`overflow: ellipsis`
+  /// handling at every scale rather than growing new overflow logic here.
+  final double scale;
+}
+
+/// Lives in this package (not the app layer) since the TV channel grid and
+/// controls are the primary consumers — mirrors [VideoAspectRatioNotifier]'s
+/// storage pattern (CV-031).
+class TvFontModeNotifier extends StateNotifier<TvFontMode> {
+  final Ref _ref;
+
+  TvFontModeNotifier(this._ref) : super(TvFontMode.standard) {
+    _loadFromStorage();
+  }
+
+  void setTvFontMode(TvFontMode mode) {
+    state = mode;
+    _saveToStorage();
+  }
+
+  Future<void> _loadFromStorage() async {
+    try {
+      final prefs = _ref.read(sharedPreferencesProvider);
+      final stored = prefs.getString(tvFontModeStorageKey);
+      if (stored != null) {
+        state = TvFontMode.values.firstWhere(
+          (value) => value.stableId == stored,
+          orElse: () => TvFontMode.standard,
+        );
+      }
+    } catch (e) {
+      // Failed to load, keep default
+    }
+  }
+
+  Future<void> _saveToStorage() async {
+    try {
+      final prefs = _ref.read(sharedPreferencesProvider);
+      await prefs.setString(tvFontModeStorageKey, state.stableId);
+    } catch (e) {
+      // Failed to save
+    }
+  }
+}
+
+final tvFontModeProvider =
+    StateNotifierProvider<TvFontModeNotifier, TvFontMode>(
+      (ref) => TvFontModeNotifier(ref),
+    );

--- a/packages/feature_iptv/lib/feature_iptv.dart
+++ b/packages/feature_iptv/lib/feature_iptv.dart
@@ -10,6 +10,7 @@ export "application/providers/local_iptv_search_providers.dart";
 export "application/providers/playback_settings_extension_point.dart";
 export "application/providers/video_aspect_ratio_provider.dart";
 export "application/providers/caption_preference_provider.dart";
+export "application/providers/tv_font_mode_provider.dart";
 export "application/content_source_store.dart";
 export "application/epg_channel_match_override_store.dart";
 export "application/mutable_xmltv_compact_epg_repository.dart";

--- a/packages/feature_iptv/lib/presentation/widgets/tv_channel_grid.dart
+++ b/packages/feature_iptv/lib/presentation/widgets/tv_channel_grid.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:core_ui/core_ui.dart';
 import '../../application/providers/iptv_providers.dart';
+import '../../application/providers/tv_font_mode_provider.dart';
 import "package:platform_channels/platform_channels.dart";
 import '../tv/iptv_tv.dart';
 import 'iptv_icon_placeholder.dart';
@@ -86,6 +87,9 @@ class _TvChannelGridState extends ConsumerState<TvChannelGrid> {
     final channels = ref.watch(filteredChannelsProvider);
     final dimensions = ref.watch(tvDimensionsProvider(context));
     final currentChannel = ref.watch(currentChannelProvider);
+    // CV-008 UC-001: user-selected TV font mode, applied on top of the
+    // device-based textScaleFactor already computed in `dimensions`.
+    final fontScale = ref.watch(tvFontModeProvider).scale;
 
     // Apply safe zone padding for Fire TV
     final padding =
@@ -117,6 +121,7 @@ class _TvChannelGridState extends ConsumerState<TvChannelGrid> {
             key: ValueKey('channel_card_${channel.id}'),
             channel: channel,
             dimensions: dimensions,
+            fontScale: fontScale,
             isPlaying: isPlaying,
             autofocus: isInitialFocus,
             onSelect: () => widget.onChannelSelect(channel),
@@ -240,6 +245,7 @@ class _TvChannelGridState extends ConsumerState<TvChannelGrid> {
 class _TvChannelCard extends StatelessWidget {
   final IPTVChannel channel;
   final TvUiDimensions dimensions;
+  final double fontScale;
   final bool isPlaying;
   final bool autofocus;
   final VoidCallback onSelect;
@@ -250,6 +256,7 @@ class _TvChannelCard extends StatelessWidget {
     super.key,
     required this.channel,
     required this.dimensions,
+    required this.fontScale,
     required this.isPlaying,
     required this.autofocus,
     required this.onSelect,
@@ -285,6 +292,7 @@ class _TvChannelCard extends StatelessWidget {
           child: _TvChannelCardContent(
             channel: channel,
             dimensions: dimensions,
+            fontScale: fontScale,
             isPlaying: isPlaying,
           ),
         ),
@@ -296,11 +304,13 @@ class _TvChannelCard extends StatelessWidget {
 class _TvChannelCardContent extends StatelessWidget {
   final IPTVChannel channel;
   final TvUiDimensions dimensions;
+  final double fontScale;
   final bool isPlaying;
 
   const _TvChannelCardContent({
     required this.channel,
     required this.dimensions,
+    required this.fontScale,
     required this.isPlaying,
   });
 
@@ -330,47 +340,54 @@ class _TvChannelCardContent extends StatelessWidget {
             flex: 2,
             child: Padding(
               padding: EdgeInsets.symmetric(horizontal: dimensions.cardPadding),
-              child: Column(
-                mainAxisAlignment: MainAxisAlignment.center,
-                children: [
-                  Text(
-                    channel.name,
-                    maxLines: isPlaying ? 1 : 2,
-                    textAlign: TextAlign.center,
-                    overflow: TextOverflow.ellipsis,
-                    style: TextStyle(
-                      color: Colors.white,
-                      fontSize: 14 * dimensions.textScaleFactor,
-                      fontWeight: isPlaying
-                          ? FontWeight.bold
-                          : FontWeight.normal,
-                    ),
-                  ),
-                  if (isPlaying) ...[
-                    const SizedBox(height: 4),
-                    FittedBox(
-                      fit: BoxFit.scaleDown,
-                      child: Row(
-                        mainAxisSize: MainAxisSize.min,
-                        children: [
-                          Icon(
-                            Icons.play_circle_filled,
-                            size: 14 * dimensions.textScaleFactor,
-                            color: Colors.green,
-                          ),
-                          const SizedBox(width: 4),
-                          Text(
-                            'Now Playing',
-                            style: TextStyle(
-                              color: Colors.green,
-                              fontSize: 11 * dimensions.textScaleFactor,
-                            ),
-                          ),
-                        ],
+              // CV-008 UC-001: the user's TV font mode can scale text up to
+              // 1.5x. FittedBox keeps the fixed-height card free of overflow
+              // at every scale instead of clipping or crashing layout.
+              child: FittedBox(
+                fit: BoxFit.scaleDown,
+                child: Column(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                    Text(
+                      channel.name,
+                      maxLines: isPlaying ? 1 : 2,
+                      textAlign: TextAlign.center,
+                      overflow: TextOverflow.ellipsis,
+                      style: TextStyle(
+                        color: Colors.white,
+                        fontSize: 14 * dimensions.textScaleFactor * fontScale,
+                        fontWeight: isPlaying
+                            ? FontWeight.bold
+                            : FontWeight.normal,
                       ),
                     ),
+                    if (isPlaying) ...[
+                      const SizedBox(height: 4),
+                      FittedBox(
+                        fit: BoxFit.scaleDown,
+                        child: Row(
+                          mainAxisSize: MainAxisSize.min,
+                          children: [
+                            Icon(
+                              Icons.play_circle_filled,
+                              size: 14 * dimensions.textScaleFactor * fontScale,
+                              color: Colors.green,
+                            ),
+                            const SizedBox(width: 4),
+                            Text(
+                              'Now Playing',
+                              style: TextStyle(
+                                color: Colors.green,
+                                fontSize:
+                                    11 * dimensions.textScaleFactor * fontScale,
+                              ),
+                            ),
+                          ],
+                        ),
+                      ),
+                    ],
                   ],
-                ],
+                ),
               ),
             ),
           ),

--- a/packages/feature_iptv/lib/presentation/widgets/video_player_widget.dart
+++ b/packages/feature_iptv/lib/presentation/widgets/video_player_widget.dart
@@ -245,6 +245,24 @@ class _VideoPlayerWidgetState extends ConsumerState<VideoPlayerWidget> {
     }
   }
 
+  // CV-008 UC-002: D-pad surf mode. Up/Down changes channel while playback
+  // stays primary; boundary channels are a no-op via
+  // nextChannelProvider/previousChannelProvider already returning null there.
+  // Gated on !_isLocked, matching every other in-player interaction.
+  TvInputResult _handleSurfInput(TvInputKey key) {
+    if (_isLocked) return TvInputResult.notHandled;
+    switch (key) {
+      case TvInputKey.up:
+        _goToPreviousChannel();
+        return TvInputResult.handled;
+      case TvInputKey.down:
+        _goToNextChannel();
+        return TvInputResult.handled;
+      default:
+        return TvInputResult.notHandled;
+    }
+  }
+
   void _showChannelChangeOverlay(String text) {
     _channelChangeOverlayTimer?.cancel();
     setState(() {
@@ -287,201 +305,213 @@ class _VideoPlayerWidgetState extends ConsumerState<VideoPlayerWidget> {
 
     final videoView = service.buildVideoView();
 
-    return MouseRegion(
-      onHover: (_) => _showControls(),
-      onEnter: (_) => _showControls(),
-      child: GestureDetector(
-        onTap: _showControls,
-        child: Container(
-          color: Colors.black,
-          child: Stack(
-            alignment: Alignment.center,
-            children: [
-              // Video display + Netflix-style brightness/volume drag
-              // gestures. Left half of the video area adjusts brightness,
-              // right half adjusts volume; disabled while locked. The video
-              // surface itself is the engine-driven view (CV-016 migration);
-              // when it's null we fall through to loading/diagnostic/
-              // placeholder inside the same gesture-enabled stack.
-              PlayerGestureOverlay(
-                locked: _isLocked,
-                brightness: _brightness,
-                volume: state.isMuted ? 0.0 : state.volume,
-                onBrightnessChanged: _onBrightnessGestureChanged,
-                onVolumeChanged: (value) {
-                  if (state.isMuted) service.toggleMute();
-                  service.setVolume(value);
-                },
-                child: Stack(
-                  alignment: Alignment.center,
-                  children: [
-                    // Video display (engine-driven view surface).
-                    if (videoView != null)
-                      SizedBox.expand(
-                        child: FittedBox(
-                          fit: _boxFitFor(aspectRatioFit),
-                          child: videoView,
-                        ),
-                      )
-                    else if (state.playbackState == PlaybackState.loading)
-                      _buildLoading()
-                    else if (state.hasError && state.diagnostic != null)
-                      _buildDiagnosticError(state)
-                    else
-                      _buildPlaceholder(state),
+    return TvInputHandler(
+      onInput: _handleSurfInput,
+      // Focus.onKeyEvent always ignores so the event bubbles up to
+      // TvInputHandler's own listener above -- this node exists purely to
+      // hold primary focus by default, since nothing else in the player
+      // (controls auto-hide) reliably claims it otherwise.
+      child: Focus(
+        autofocus: true,
+        skipTraversal: true,
+        onKeyEvent: (node, event) => KeyEventResult.ignored,
+        child: MouseRegion(
+          onHover: (_) => _showControls(),
+          onEnter: (_) => _showControls(),
+          child: GestureDetector(
+            onTap: _showControls,
+            child: Container(
+              color: Colors.black,
+              child: Stack(
+                alignment: Alignment.center,
+                children: [
+                  // Video display + Netflix-style brightness/volume drag
+                  // gestures. Left half of the video area adjusts brightness,
+                  // right half adjusts volume; disabled while locked. The video
+                  // surface itself is the engine-driven view (CV-016 migration);
+                  // when it's null we fall through to loading/diagnostic/
+                  // placeholder inside the same gesture-enabled stack.
+                  PlayerGestureOverlay(
+                    locked: _isLocked,
+                    brightness: _brightness,
+                    volume: state.isMuted ? 0.0 : state.volume,
+                    onBrightnessChanged: _onBrightnessGestureChanged,
+                    onVolumeChanged: (value) {
+                      if (state.isMuted) service.toggleMute();
+                      service.setVolume(value);
+                    },
+                    child: Stack(
+                      alignment: Alignment.center,
+                      children: [
+                        // Video display (engine-driven view surface).
+                        if (videoView != null)
+                          SizedBox.expand(
+                            child: FittedBox(
+                              fit: _boxFitFor(aspectRatioFit),
+                              child: videoView,
+                            ),
+                          )
+                        else if (state.playbackState == PlaybackState.loading)
+                          _buildLoading()
+                        else if (state.hasError && state.diagnostic != null)
+                          _buildDiagnosticError(state)
+                        else
+                          _buildPlaceholder(state),
 
-                    // Cinema mode vignette overlay
-                    if (_isCinemaMode)
-                      Positioned.fill(
-                        child: IgnorePointer(
-                          child: Container(
-                            decoration: BoxDecoration(
-                              gradient: RadialGradient(
-                                center: Alignment.center,
-                                radius: 1.15,
-                                colors: [
-                                  Colors.transparent,
-                                  Colors.black.withValues(alpha: 0.6),
-                                ],
-                                stops: const [0.6, 1.0],
+                        // Cinema mode vignette overlay
+                        if (_isCinemaMode)
+                          Positioned.fill(
+                            child: IgnorePointer(
+                              child: Container(
+                                decoration: BoxDecoration(
+                                  gradient: RadialGradient(
+                                    center: Alignment.center,
+                                    radius: 1.15,
+                                    colors: [
+                                      Colors.transparent,
+                                      Colors.black.withValues(alpha: 0.6),
+                                    ],
+                                    stops: const [0.6, 1.0],
+                                  ),
+                                ),
                               ),
+                            ),
+                          ),
+
+                        // Buffering indicator
+                        if (state.isBuffering)
+                          Container(
+                            color: Colors.black45,
+                            child: const CircularProgressIndicator(
+                              color: Colors.white,
+                            ),
+                          ),
+                      ],
+                    ),
+                  ),
+
+                  // Controls overlay with fade animation — hidden entirely while
+                  // locked so only the lock button remains interactive.
+                  if (!_isLocked)
+                    AnimatedOpacity(
+                      opacity: (widget.showControls && _showControlsOverlay)
+                          ? 1.0
+                          : 0.0,
+                      duration: const Duration(milliseconds: 300),
+                      child: IgnorePointer(
+                        ignoring: !_showControlsOverlay,
+                        child: _buildControlsOverlay(context, service, state),
+                      ),
+                    ),
+
+                  // Network quality badge
+                  if (!_isLocked && state.metrics != null)
+                    Positioned(
+                      top: 8,
+                      right: 8,
+                      child: _buildNetworkBadge(state.metrics!.networkQuality),
+                    ),
+
+                  // Quality indicator and Live badge
+                  if (!_isLocked)
+                    Positioned(
+                      top: 8,
+                      left: 8,
+                      child: Row(
+                        children: [
+                          _buildQualityBadge(state.currentQuality),
+                          const SizedBox(width: 8),
+                          // Live badge - shows "LIVE" when at live edge
+                          LiveBadge(state: state, showWhenNotLive: true),
+                          // Note: DelayIndicator removed for cleaner UI per design spec
+                        ],
+                      ),
+                    ),
+
+                  // Previous/Next channel buttons (for fullscreen mode)
+                  if (!_isLocked &&
+                      widget.enableSwipeChannelChange &&
+                      _showControlsOverlay)
+                    Positioned(
+                      left: 16,
+                      top: 0,
+                      bottom: 0,
+                      child: Center(
+                        child: IconButton(
+                          icon: const Icon(Icons.skip_previous, size: 40),
+                          color: Colors.white,
+                          onPressed: _goToPreviousChannel,
+                        ),
+                      ),
+                    ),
+                  if (!_isLocked &&
+                      widget.enableSwipeChannelChange &&
+                      _showControlsOverlay)
+                    Positioned(
+                      right: 16,
+                      top: 0,
+                      bottom: 0,
+                      child: Center(
+                        child: IconButton(
+                          icon: const Icon(Icons.skip_next, size: 40),
+                          color: Colors.white,
+                          onPressed: _goToNextChannel,
+                        ),
+                      ),
+                    ),
+
+                  // Lock button: visible whenever the normal controls would be
+                  // (fades with them), but stays visible when locked regardless
+                  // of the hide timer — it's the only way back to unlocked.
+                  Positioned(
+                    top: 8,
+                    right: 56,
+                    child: AnimatedOpacity(
+                      opacity: (_isLocked || _showControlsOverlay) ? 1.0 : 0.0,
+                      duration: const Duration(milliseconds: 300),
+                      child: Container(
+                        decoration: BoxDecoration(
+                          color: Colors.black45,
+                          borderRadius: BorderRadius.circular(4),
+                        ),
+                        child: PlayerLockButton(
+                          key: const ValueKey('iptv-player-lock-button'),
+                          locked: _isLocked,
+                          onToggle: _toggleLocked,
+                        ),
+                      ),
+                    ),
+                  ),
+
+                  // Channel change overlay
+                  if (_channelChangeOverlayText != null)
+                    Positioned(
+                      child: AnimatedOpacity(
+                        opacity: _channelChangeOverlayText != null ? 1.0 : 0.0,
+                        duration: const Duration(milliseconds: 200),
+                        child: Container(
+                          padding: const EdgeInsets.symmetric(
+                            horizontal: 24,
+                            vertical: 12,
+                          ),
+                          decoration: BoxDecoration(
+                            color: Colors.black.withValues(alpha: 0.8),
+                            borderRadius: BorderRadius.circular(8),
+                          ),
+                          child: Text(
+                            _channelChangeOverlayText!,
+                            style: const TextStyle(
+                              color: Colors.white,
+                              fontSize: 16,
+                              fontWeight: FontWeight.w600,
                             ),
                           ),
                         ),
                       ),
-
-                    // Buffering indicator
-                    if (state.isBuffering)
-                      Container(
-                        color: Colors.black45,
-                        child: const CircularProgressIndicator(
-                          color: Colors.white,
-                        ),
-                      ),
-                  ],
-                ),
+                    ),
+                ],
               ),
-
-              // Controls overlay with fade animation — hidden entirely while
-              // locked so only the lock button remains interactive.
-              if (!_isLocked)
-                AnimatedOpacity(
-                  opacity: (widget.showControls && _showControlsOverlay)
-                      ? 1.0
-                      : 0.0,
-                  duration: const Duration(milliseconds: 300),
-                  child: IgnorePointer(
-                    ignoring: !_showControlsOverlay,
-                    child: _buildControlsOverlay(context, service, state),
-                  ),
-                ),
-
-              // Network quality badge
-              if (!_isLocked && state.metrics != null)
-                Positioned(
-                  top: 8,
-                  right: 8,
-                  child: _buildNetworkBadge(state.metrics!.networkQuality),
-                ),
-
-              // Quality indicator and Live badge
-              if (!_isLocked)
-                Positioned(
-                  top: 8,
-                  left: 8,
-                  child: Row(
-                    children: [
-                      _buildQualityBadge(state.currentQuality),
-                      const SizedBox(width: 8),
-                      // Live badge - shows "LIVE" when at live edge
-                      LiveBadge(state: state, showWhenNotLive: true),
-                      // Note: DelayIndicator removed for cleaner UI per design spec
-                    ],
-                  ),
-                ),
-
-              // Previous/Next channel buttons (for fullscreen mode)
-              if (!_isLocked &&
-                  widget.enableSwipeChannelChange &&
-                  _showControlsOverlay)
-                Positioned(
-                  left: 16,
-                  top: 0,
-                  bottom: 0,
-                  child: Center(
-                    child: IconButton(
-                      icon: const Icon(Icons.skip_previous, size: 40),
-                      color: Colors.white,
-                      onPressed: _goToPreviousChannel,
-                    ),
-                  ),
-                ),
-              if (!_isLocked &&
-                  widget.enableSwipeChannelChange &&
-                  _showControlsOverlay)
-                Positioned(
-                  right: 16,
-                  top: 0,
-                  bottom: 0,
-                  child: Center(
-                    child: IconButton(
-                      icon: const Icon(Icons.skip_next, size: 40),
-                      color: Colors.white,
-                      onPressed: _goToNextChannel,
-                    ),
-                  ),
-                ),
-
-              // Lock button: visible whenever the normal controls would be
-              // (fades with them), but stays visible when locked regardless
-              // of the hide timer — it's the only way back to unlocked.
-              Positioned(
-                top: 8,
-                right: 56,
-                child: AnimatedOpacity(
-                  opacity: (_isLocked || _showControlsOverlay) ? 1.0 : 0.0,
-                  duration: const Duration(milliseconds: 300),
-                  child: Container(
-                    decoration: BoxDecoration(
-                      color: Colors.black45,
-                      borderRadius: BorderRadius.circular(4),
-                    ),
-                    child: PlayerLockButton(
-                      key: const ValueKey('iptv-player-lock-button'),
-                      locked: _isLocked,
-                      onToggle: _toggleLocked,
-                    ),
-                  ),
-                ),
-              ),
-
-              // Channel change overlay
-              if (_channelChangeOverlayText != null)
-                Positioned(
-                  child: AnimatedOpacity(
-                    opacity: _channelChangeOverlayText != null ? 1.0 : 0.0,
-                    duration: const Duration(milliseconds: 200),
-                    child: Container(
-                      padding: const EdgeInsets.symmetric(
-                        horizontal: 24,
-                        vertical: 12,
-                      ),
-                      decoration: BoxDecoration(
-                        color: Colors.black.withValues(alpha: 0.8),
-                        borderRadius: BorderRadius.circular(8),
-                      ),
-                      child: Text(
-                        _channelChangeOverlayText!,
-                        style: const TextStyle(
-                          color: Colors.white,
-                          fontSize: 16,
-                          fontWeight: FontWeight.w600,
-                        ),
-                      ),
-                    ),
-                  ),
-                ),
-            ],
+            ),
           ),
         ),
       ),
@@ -790,11 +820,8 @@ class _VideoPlayerWidgetState extends ConsumerState<VideoPlayerWidget> {
                           key: const ValueKey('iptv-player-subtitle-button'),
                           icon: Icons.subtitles,
                           tooltip: 'Subtitles & Tracks',
-                          onPressed: () => _showTrackSelector(
-                            context,
-                            service,
-                            state,
-                          ),
+                          onPressed: () =>
+                              _showTrackSelector(context, service, state),
                         ),
                       // Fullscreen button
                       _PlayerControlButton(
@@ -831,10 +858,9 @@ class _VideoPlayerWidgetState extends ConsumerState<VideoPlayerWidget> {
                 ListTile(
                   title: Text(track.label),
                   subtitle: track.isExternal ? const Text('External') : null,
-                  trailing:
-                      state.selectedTrackIds[track.kind] == track.id
-                          ? const Icon(Icons.check)
-                          : null,
+                  trailing: state.selectedTrackIds[track.kind] == track.id
+                      ? const Icon(Icons.check)
+                      : null,
                   onTap: () {
                     service.selectTrack(kind: track.kind, trackId: track.id);
                     Navigator.of(context).pop();

--- a/packages/feature_iptv/test/iptv/presentation/widgets/tv_channel_grid_test.dart
+++ b/packages/feature_iptv/test/iptv/presentation/widgets/tv_channel_grid_test.dart
@@ -1,4 +1,5 @@
 import 'package:feature_iptv/application/providers/iptv_providers.dart';
+import 'package:feature_iptv/application/providers/tv_font_mode_provider.dart';
 import 'package:feature_iptv/presentation/widgets/tv_channel_grid.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -93,6 +94,51 @@ void main() {
     expect(find.text('City News Live'), findsOneWidget);
     expect(find.text('Music Box'), findsOneWidget);
   });
+
+  testWidgets(
+    'applies the persisted TV font mode scale to channel name text (CV-008)',
+    (tester) async {
+      tester.view.physicalSize = const Size(1280, 720);
+      tester.view.devicePixelRatio = 1;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      SharedPreferences.setMockInitialValues({
+        tvFontModeStorageKey: TvFontMode.standard.stableId,
+      });
+      final prefs = await SharedPreferences.getInstance();
+      await tester.pumpWidget(buildGrid(prefs: prefs));
+      await tester.pumpAndSettle();
+      final standardFontSize = tester
+          .widget<Text>(find.text('City News Live').first)
+          .style
+          ?.fontSize;
+
+      // Same prefs instance, updated in place -- avoids relying on
+      // SharedPreferences.getInstance() re-reading mock values a second
+      // time within one test (it caches the instance on first call).
+      await prefs.setString(
+        tvFontModeStorageKey,
+        TvFontMode.extraLarge.stableId,
+      );
+      await tester.pumpWidget(const SizedBox.shrink());
+      await tester.pumpWidget(buildGrid(prefs: prefs));
+      await tester.pumpAndSettle();
+      final extraLargeFontSize = tester
+          .widget<Text>(find.text('City News Live').first)
+          .style
+          ?.fontSize;
+
+      expect(standardFontSize, isNotNull);
+      expect(
+        extraLargeFontSize! / standardFontSize!,
+        closeTo(TvFontMode.extraLarge.scale, 0.01),
+      );
+      // No overflow/layout exception for long titles at the largest scale
+      // (long channel names still exist in `channels` via maxLines/ellipsis).
+      expect(tester.takeException(), isNull);
+    },
+  );
 
   testWidgets(
     'wraps each visible channel tile in repaint boundaries',

--- a/packages/feature_iptv/test/iptv/presentation/widgets/video_player_widget_test.dart
+++ b/packages/feature_iptv/test/iptv/presentation/widgets/video_player_widget_test.dart
@@ -2,6 +2,7 @@ import 'package:feature_iptv/feature_iptv.dart';
 import 'package:feature_iptv/presentation/widgets/player_brightness_controller.dart';
 import 'package:feature_iptv/presentation/widgets/player_lock_button.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -17,6 +18,7 @@ void main() {
     bool enableSwipeChannelChange = false,
     PlayerBrightnessController? brightnessController,
     StreamingState? state,
+    List<IPTVChannel>? channels,
   }) async {
     SharedPreferences.setMockInitialValues({});
     final prefs = await SharedPreferences.getInstance();
@@ -25,6 +27,8 @@ void main() {
       ProviderScope(
         overrides: [
           sharedPreferencesProvider.overrideWithValue(prefs),
+          if (channels != null)
+            iptvChannelsProvider.overrideWith((ref) async => channels),
           streamingStateProvider.overrideWith(
             (ref) => Stream.value(
               state ??
@@ -53,6 +57,70 @@ void main() {
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 100));
   }
+
+  testWidgets(
+    'D-pad down surfs to the next channel while playback stays primary (CV-008 UC-002)',
+    (tester) async {
+      const current = IPTVChannel(
+        id: 'news-1',
+        name: 'City News Live',
+        streamUrl: 'https://example.com/news.m3u8',
+        group: 'News',
+        category: ChannelCategory.news,
+      );
+      const next = IPTVChannel(
+        id: 'sports-1',
+        name: 'Stadium Sports',
+        streamUrl: 'https://example.com/sports.m3u8',
+        group: 'Sports',
+        category: ChannelCategory.sports,
+      );
+
+      // Real service backed by a fake engine (not a real VideoPlayerController)
+      // -- same pattern the subtitle-selector tests below use, since a real
+      // controller here would leak (VideoPlayerStreamingService.dispose()
+      // does not resolve promptly once real playback has started).
+      final service = VideoPlayerStreamingService(
+        engine: FakeAiroPlaybackEngine(),
+      );
+      addTearDown(service.dispose);
+
+      final container = ProviderContainer(
+        overrides: [
+          iptvStreamingServiceProvider.overrideWithValue(service),
+          iptvChannelsProvider.overrideWith(
+            (ref) async => const [current, next],
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+      // Pre-warm so nextChannelProvider sees both channels the moment the
+      // key event fires, instead of starting from AsyncLoading (nothing
+      // else reads iptvChannelsProvider until then).
+      await container.read(iptvChannelsProvider.future);
+
+      await tester.pumpWidget(
+        UncontrolledProviderScope(
+          container: container,
+          child: const MaterialApp(home: Scaffold(body: VideoPlayerWidget())),
+        ),
+      );
+      await tester.pump();
+
+      await service.playChannel(current);
+      await tester.pump();
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+      await tester.pump();
+
+      expect(find.text('Stadium Sports'), findsWidgets);
+
+      // Pending timers (buffer monitor, live-edge detector) must be stopped
+      // inside the test body -- the pending-timer check runs before
+      // addTearDown(service.dispose) fires.
+      await service.stop();
+    },
+  );
 
   testWidgets(
     'locking hides playback controls but keeps the lock button interactive',
@@ -153,9 +221,7 @@ void main() {
 
       await tester.pumpWidget(
         ProviderScope(
-          overrides: [
-            iptvStreamingServiceProvider.overrideWithValue(service),
-          ],
+          overrides: [iptvStreamingServiceProvider.overrideWithValue(service)],
           child: const MaterialApp(home: VideoPlayerWidget()),
         ),
       );
@@ -168,51 +234,48 @@ void main() {
     },
   );
 
-  testWidgets(
-    'subtitle button is hidden when there are no tracks',
-    (tester) async {
-      final engine = FakeAiroPlaybackEngine(tracks: const []);
-      final service = VideoPlayerStreamingService(engine: engine);
-      addTearDown(service.dispose);
+  testWidgets('subtitle button is hidden when there are no tracks', (
+    tester,
+  ) async {
+    final engine = FakeAiroPlaybackEngine(tracks: const []);
+    final service = VideoPlayerStreamingService(engine: engine);
+    addTearDown(service.dispose);
 
-      // Pump the widget (and subscribe to service.stateStream via
-      // streamingStateProvider) BEFORE calling playChannel(). The service's
-      // state stream is a plain broadcast stream with no replay, so a
-      // listener that subscribes after playChannel() has already emitted
-      // would miss those events entirely and stay stuck in the loading
-      // branch — which would make this assertion trivially true regardless
-      // of tracks. Wrapping in a Scaffold matches how VideoPlayerWidget is
-      // actually embedded in production (see AiroResponsiveScaffold usage
-      // in iptv_screen.dart) — the control bar's volume Slider needs a
-      // Material ancestor once the widget reaches its "player" state.
-      await tester.pumpWidget(
-        ProviderScope(
-          overrides: [iptvStreamingServiceProvider.overrideWithValue(service)],
-          child: const MaterialApp(
-            home: Scaffold(body: VideoPlayerWidget()),
-          ),
-        ),
-      );
-      await tester.pump();
+    // Pump the widget (and subscribe to service.stateStream via
+    // streamingStateProvider) BEFORE calling playChannel(). The service's
+    // state stream is a plain broadcast stream with no replay, so a
+    // listener that subscribes after playChannel() has already emitted
+    // would miss those events entirely and stay stuck in the loading
+    // branch — which would make this assertion trivially true regardless
+    // of tracks. Wrapping in a Scaffold matches how VideoPlayerWidget is
+    // actually embedded in production (see AiroResponsiveScaffold usage
+    // in iptv_screen.dart) — the control bar's volume Slider needs a
+    // Material ancestor once the widget reaches its "player" state.
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [iptvStreamingServiceProvider.overrideWithValue(service)],
+        child: const MaterialApp(home: Scaffold(body: VideoPlayerWidget())),
+      ),
+    );
+    await tester.pump();
 
-      await service.playChannel(
-        IPTVChannel(id: 'c1', name: 'Chan', streamUrl: 'https://x/y.m3u8'),
-      );
-      await tester.pump();
+    await service.playChannel(
+      IPTVChannel(id: 'c1', name: 'Chan', streamUrl: 'https://x/y.m3u8'),
+    );
+    await tester.pump();
 
-      expect(
-        find.byKey(const ValueKey('iptv-player-subtitle-button')),
-        findsNothing,
-      );
+    expect(
+      find.byKey(const ValueKey('iptv-player-subtitle-button')),
+      findsNothing,
+    );
 
-      // playChannel() starts periodic timers (buffer monitor, live-edge
-      // detector). testWidgets' pending-timer invariant check runs before
-      // addTearDown callbacks fire, so those timers must be stopped inside
-      // the test body itself — addTearDown(service.dispose) alone isn't
-      // enough here (see VideoPlayerStreamingService.stop()).
-      await service.stop();
-    },
-  );
+    // playChannel() starts periodic timers (buffer monitor, live-edge
+    // detector). testWidgets' pending-timer invariant check runs before
+    // addTearDown callbacks fire, so those timers must be stopped inside
+    // the test body itself — addTearDown(service.dispose) alone isn't
+    // enough here (see VideoPlayerStreamingService.stop()).
+    await service.stop();
+  });
 
   testWidgets(
     'subtitle button is visible and calls selectTrack when tracks exist',
@@ -250,9 +313,7 @@ void main() {
       await tester.pumpWidget(
         ProviderScope(
           overrides: [iptvStreamingServiceProvider.overrideWithValue(service)],
-          child: const MaterialApp(
-            home: Scaffold(body: VideoPlayerWidget()),
-          ),
+          child: const MaterialApp(home: Scaffold(body: VideoPlayerWidget())),
         ),
       );
       await tester.pump();
@@ -280,7 +341,9 @@ void main() {
       // otherwise keep scheduling frames forever and make pumpAndSettle()
       // time out. This is enough to let the bottom-sheet's route transition
       // animation finish.
-      await tester.tap(find.byKey(const ValueKey('iptv-player-subtitle-button')));
+      await tester.tap(
+        find.byKey(const ValueKey('iptv-player-subtitle-button')),
+      );
       await tester.pump();
       await tester.pump(const Duration(milliseconds: 300));
 

--- a/packages/feature_iptv/test/tv_font_mode_provider_test.dart
+++ b/packages/feature_iptv/test/tv_font_mode_provider_test.dart
@@ -1,0 +1,71 @@
+import 'package:feature_iptv/feature_iptv.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  test('defaults to standard when nothing is persisted', () async {
+    SharedPreferences.setMockInitialValues({});
+    final prefs = await SharedPreferences.getInstance();
+    final container = ProviderContainer(
+      overrides: [sharedPreferencesProvider.overrideWithValue(prefs)],
+    );
+    addTearDown(container.dispose);
+
+    expect(container.read(tvFontModeProvider), TvFontMode.standard);
+  });
+
+  test('loads a persisted font mode through the shared store', () async {
+    SharedPreferences.setMockInitialValues({
+      tvFontModeStorageKey: TvFontMode.extraLarge.stableId,
+    });
+    final prefs = await SharedPreferences.getInstance();
+    final container = ProviderContainer(
+      overrides: [sharedPreferencesProvider.overrideWithValue(prefs)],
+    );
+    addTearDown(container.dispose);
+
+    expect(container.read(tvFontModeProvider), TvFontMode.extraLarge);
+  });
+
+  test('setTvFontMode persists the new value', () async {
+    SharedPreferences.setMockInitialValues({});
+    final prefs = await SharedPreferences.getInstance();
+    final container = ProviderContainer(
+      overrides: [sharedPreferencesProvider.overrideWithValue(prefs)],
+    );
+    addTearDown(container.dispose);
+
+    container.read(tvFontModeProvider.notifier).setTvFontMode(TvFontMode.large);
+    await Future<void>.delayed(Duration.zero);
+
+    expect(prefs.getString(tvFontModeStorageKey), TvFontMode.large.stableId);
+    expect(container.read(tvFontModeProvider), TvFontMode.large);
+  });
+
+  test('scale factors increase monotonically with mode', () {
+    expect(TvFontMode.standard.scale, lessThan(TvFontMode.large.scale));
+    expect(TvFontMode.large.scale, lessThan(TvFontMode.extraLarge.scale));
+  });
+
+  test('survives a fresh container read after persisting (restart)', () async {
+    SharedPreferences.setMockInitialValues({});
+    final prefs = await SharedPreferences.getInstance();
+    final container = ProviderContainer(
+      overrides: [sharedPreferencesProvider.overrideWithValue(prefs)],
+    );
+    addTearDown(container.dispose);
+
+    container
+        .read(tvFontModeProvider.notifier)
+        .setTvFontMode(TvFontMode.extraLarge);
+    await Future<void>.delayed(Duration.zero);
+
+    final restarted = ProviderContainer(
+      overrides: [sharedPreferencesProvider.overrideWithValue(prefs)],
+    );
+    addTearDown(restarted.dispose);
+
+    expect(restarted.read(tvFontModeProvider), TvFontMode.extraLarge);
+  });
+}


### PR DESCRIPTION
## Summary
Part of #812 (CV-008). Caption preference persistence already merged
(#888). This lands the other two of three UC slices.

### UC-001 TV font mode
- `TvFontMode` enum (standard/large/extraLarge) + persisted
  `tvFontModeProvider`, mirroring `VideoAspectRatioNotifier`'s storage
  pattern (CV-031).
- Consumed by `TvChannelGrid`: channel name/now-playing text scales with
  the user's mode on top of the existing device-based `textScaleFactor`.
- Fixed a real overflow bug the new test surfaced: the channel name
  Column overflowed its fixed-height card at 1.5x scale (`RenderFlex
  overflowed by 7.8 pixels`). Wrapped in `FittedBox(fit: scaleDown)` so
  every mode stays overflow-free instead of clipping/crashing.

### UC-002 D-pad surf mode
- `VideoPlayerWidget` wrapped in `TvInputHandler`; D-pad Up/Down while
  watching surfs to the previous/next channel via the same
  `nextChannelProvider`/`previousChannelProvider` the on-screen skip
  buttons already use -- identical behavior between D-pad and touch.
  Gated on `!_isLocked` like every other in-player interaction.
- Added a `Focus(autofocus: true, onKeyEvent: ignored)` node so the key
  event has somewhere to bubble from by default (nothing else in the
  player claims focus once the controls auto-hide timer fires).

## Not in this slice
- Caption preference isn't wired to actual subtitle-track application --
  still blocked on real track selection landing in
  `VideoPlayerStreamingService` (CV-016, in progress, #886).

## Test plan
- [x] New tests: font-mode persistence round-trip, font scale applied to
      channel-grid text with no overflow exception, D-pad down surfs to
      the next channel (via a fake-engine-backed service, avoiding the
      real `VideoPlayerController` dispose-hang this surfaced when first
      tried against the real engine).
- [x] Full `feature_iptv` suite green (305 tests), verified again after
      cherry-picking onto a clean branch off main.
- [x] `flutter analyze` clean on changed files (one pre-existing,
      unrelated unused-import warning).
- [x] `dart format --set-exit-if-changed` clean.