### PR TITLE
feat(app): mobile Settings hub — wire /settings route, extract settings from ProfileScreen

### DIFF
--- a/app/lib/core/routing/app_router.dart
+++ b/app/lib/core/routing/app_router.dart
@@ -8,6 +8,7 @@ import '../../features/agent_chat/presentation/screens/chat_screen.dart';
 import '../../features/agent_chat/presentation/screens/model_library_screen.dart';
 import '../../features/agent_chat/presentation/screens/notifications_screen.dart';
 import '../../features/agent_chat/presentation/screens/profile_screen.dart';
+import '../../features/settings/presentation/screens/settings_hub_screen.dart';
 import 'package:feature_iptv/feature_iptv.dart';
 import '../../features/iptv/phone_media_local_picker.dart';
 import '../../features/games/presentation/screens/games_hub_screen.dart';
@@ -94,6 +95,11 @@ class AppRouter {
         path: '/airo-explore',
         name: 'airo_explore',
         builder: (context, state) => const AiroExploreScreen(),
+      ),
+      GoRoute(
+        path: RouteNames.settings,
+        name: RouteNames.settings,
+        builder: (context, state) => const SettingsHubScreen(),
       ),
       GoRoute(
         path: RouteNames.login,

--- a/app/lib/features/agent_chat/presentation/screens/profile_screen.dart
+++ b/app/lib/features/agent_chat/presentation/screens/profile_screen.dart
@@ -2,24 +2,17 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:core_ai/core_ai.dart';
-import 'package:core_ui/core_ui.dart';
 import '../../../../core/auth/auth_service.dart';
 import '../../../../core/auth/google_auth_service.dart';
-import '../../../../core/auth/repositories/user_profile_repository.dart';
 import '../../../../core/http/http_dog.dart';
 import '../../../../core/dictionary/dictionary.dart';
-import '../../../../core/providers/app_theme_provider.dart';
 import '../../../../core/routing/route_names.dart';
-import '../../../../core/utils/currency_formatter.dart';
-import '../../../../core/utils/locale_settings.dart';
 import '../../../../shared/widgets/bug_report_dialog.dart';
 import '../../../quotes/presentation/widgets/daily_quote_card.dart';
 import '../../../settings/application/ai_storage_dashboard.dart';
 import '../../../settings/application/ai_preferences_settings.dart';
 import '../../../settings/application/ai_model_management.dart';
 import '../../../settings/presentation/screens/ai_models_screen.dart';
-import '../../../settings/presentation/screens/audio_settings_screen.dart';
-import '../../../settings/presentation/screens/playback_settings_screen.dart';
 import '../../../settings/presentation/screens/intelligent_model_manager_screen.dart';
 
 /// User profile screen
@@ -71,100 +64,15 @@ class ProfileScreen extends ConsumerWidget {
             ),
             const SizedBox(height: 32),
 
-            // Settings section
-            Text('Settings', style: Theme.of(context).textTheme.titleMedium),
-            const SizedBox(height: 16),
-
-            // Appearance
-            Text('Appearance', style: Theme.of(context).textTheme.titleMedium),
-            const SizedBox(height: 8),
-            RadioGroup<AppThemeId>(
-              groupValue: ref.watch(appThemeProvider),
-              onChanged: (themeId) {
-                if (themeId != null) {
-                  ref.read(appThemeProvider.notifier).setTheme(themeId);
-                }
-              },
-              child: Column(
-                children: [
-                  for (final theme in AppTheme.themes)
-                    RadioListTile<AppThemeId>(
-                      value: theme.id,
-                      title: Text(theme.name),
-                      subtitle: Text(theme.description),
-                    ),
-                ],
-              ),
-            ),
-
-            const SizedBox(height: 24),
-
-            // Bedtime mode toggle
+            // Settings
             ListTile(
-              title: const Text('Bedtime Mode'),
-              subtitle: const Text('Auto-enable at 22:30'),
-              trailing: Switch(
-                value: false,
-                onChanged: (value) {
-                  // TODO: Implement bedtime mode toggle
-                },
+              leading: const Icon(Icons.settings_outlined),
+              title: const Text('Settings'),
+              subtitle: const Text(
+                'Appearance, audio, playback, and playlist source',
               ),
-            ),
-
-            // Audio settings
-            ListTile(
-              title: const Text('Background Audio'),
-              subtitle: const Text('Allow music while using other apps'),
-              trailing: Switch(
-                value: true,
-                onChanged: (value) {
-                  // TODO: Implement background audio toggle
-                },
-              ),
-            ),
-
-            // Audio ducking
-            ListTile(
-              title: const Text('Audio Ducking'),
-              subtitle: const Text('Lower music volume during game SFX'),
-              trailing: Switch(
-                value: true,
-                onChanged: (value) {
-                  // TODO: Implement audio ducking toggle
-                },
-              ),
-            ),
-
-            const _CurrencySelector(),
-
-            // Audio Settings (Context-Aware Audio)
-            ListTile(
-              leading: const Icon(Icons.settings_voice),
-              title: const Text('Audio Settings'),
-              subtitle: const Text('Configure context-aware audio behavior'),
               trailing: const Icon(Icons.arrow_forward_ios, size: 16),
-              onTap: () {
-                Navigator.of(context).push(
-                  MaterialPageRoute(
-                    builder: (context) => const AudioSettingsScreen(),
-                  ),
-                );
-              },
-            ),
-
-            // Playback Settings (Aspect Ratio)
-            ListTile(
-              leading: const Icon(Icons.aspect_ratio),
-              title: const Text('Playback Settings'),
-              subtitle: const Text('Configure video aspect ratio'),
-              trailing: const Icon(Icons.arrow_forward_ios, size: 16),
-              onTap: () {
-                Navigator.of(context).push(
-                  MaterialPageRoute(
-                    builder: (context) => const PlaybackSettingsScreen(),
-                  ),
-                );
-              },
+              onTap: () => context.push(RouteNames.settings),
             ),
 
             const SizedBox(height: 24),
@@ -634,49 +542,6 @@ class _AIPreferencesSection extends ConsumerWidget {
           ),
         ),
       ],
-    );
-  }
-}
-
-class _CurrencySelector extends ConsumerWidget {
-  const _CurrencySelector();
-
-  @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final settings = ref.watch(localeSettingsProvider);
-    final selectedCurrency = SupportedCurrency.fromCode(settings.currency);
-
-    return ListTile(
-      leading: const Icon(Icons.payments_outlined),
-      title: const Text('Currency'),
-      subtitle: Text('${selectedCurrency.code} (${selectedCurrency.symbol})'),
-      trailing: DropdownButtonHideUnderline(
-        child: DropdownButton<String>(
-          value: selectedCurrency.code,
-          items: SupportedCurrency.values.map((currency) {
-            return DropdownMenuItem<String>(
-              value: currency.code,
-              child: Text('${currency.symbol} ${currency.code}'),
-            );
-          }).toList(),
-          onChanged: (value) async {
-            if (value == null || value == settings.currency) return;
-
-            final updatedSettings = settings.copyWith(currency: value);
-            await ref
-                .read(localeSettingsProvider.notifier)
-                .updateSettings(updatedSettings);
-
-            final repository = ref.read(userProfileRepositoryProvider);
-            final currentProfile = (await repository.getCurrentProfile())
-                .getOrNull();
-            if (currentProfile != null) {
-              await repository.updateProfile(localeSettings: updatedSettings);
-              ref.invalidate(currentUserProfileProvider);
-            }
-          },
-        ),
-      ),
     );
   }
 }

--- a/app/lib/features/settings/presentation/screens/settings_hub_screen.dart
+++ b/app/lib/features/settings/presentation/screens/settings_hub_screen.dart
@@ -1,0 +1,168 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:core_ui/core_ui.dart';
+import 'package:feature_iptv/feature_iptv.dart';
+import '../../../../core/auth/repositories/user_profile_repository.dart';
+import '../../../../core/providers/app_theme_provider.dart';
+import '../../../../core/utils/currency_formatter.dart';
+import '../../../../core/utils/locale_settings.dart';
+import 'audio_settings_screen.dart';
+import 'playback_settings_screen.dart';
+
+/// Mobile settings hub (CV item 3): the mobile counterpart to
+/// [TvSettingsScreen] — a single scrollable list rather than a rail/detail
+/// split, since phone screens don't have room for a persistent side rail.
+/// Aggregates appearance, quick audio toggles, currency, and links to the
+/// dedicated Audio/Playback/Source screens that previously lived inline in
+/// `ProfileScreen`.
+class SettingsHubScreen extends ConsumerWidget {
+  const SettingsHubScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Settings')),
+      body: ListView(
+        padding: const EdgeInsets.all(16),
+        children: [
+          Text('Appearance', style: Theme.of(context).textTheme.titleMedium),
+          const SizedBox(height: 8),
+          RadioGroup<AppThemeId>(
+            groupValue: ref.watch(appThemeProvider),
+            onChanged: (themeId) {
+              if (themeId != null) {
+                ref.read(appThemeProvider.notifier).setTheme(themeId);
+              }
+            },
+            child: Column(
+              children: [
+                for (final theme in AppTheme.themes)
+                  RadioListTile<AppThemeId>(
+                    value: theme.id,
+                    title: Text(theme.name),
+                    subtitle: Text(theme.description),
+                  ),
+              ],
+            ),
+          ),
+
+          const SizedBox(height: 24),
+
+          ListTile(
+            title: const Text('Bedtime Mode'),
+            subtitle: const Text('Auto-enable at 22:30'),
+            trailing: Switch(
+              value: false,
+              onChanged: (value) {
+                // TODO: Implement bedtime mode toggle
+              },
+            ),
+          ),
+
+          ListTile(
+            title: const Text('Background Audio'),
+            subtitle: const Text('Allow music while using other apps'),
+            trailing: Switch(
+              value: true,
+              onChanged: (value) {
+                // TODO: Implement background audio toggle
+              },
+            ),
+          ),
+
+          ListTile(
+            title: const Text('Audio Ducking'),
+            subtitle: const Text('Lower music volume during game SFX'),
+            trailing: Switch(
+              value: true,
+              onChanged: (value) {
+                // TODO: Implement audio ducking toggle
+              },
+            ),
+          ),
+
+          const _CurrencySelector(),
+
+          ListTile(
+            leading: const Icon(Icons.settings_voice),
+            title: const Text('Audio Settings'),
+            subtitle: const Text('Configure context-aware audio behavior'),
+            trailing: const Icon(Icons.arrow_forward_ios, size: 16),
+            onTap: () {
+              Navigator.of(context).push(
+                MaterialPageRoute(
+                  builder: (context) => const AudioSettingsScreen(),
+                ),
+              );
+            },
+          ),
+
+          ListTile(
+            leading: const Icon(Icons.aspect_ratio),
+            title: const Text('Playback Settings'),
+            subtitle: const Text('Configure video aspect ratio'),
+            trailing: const Icon(Icons.arrow_forward_ios, size: 16),
+            onTap: () {
+              Navigator.of(context).push(
+                MaterialPageRoute(
+                  builder: (context) => const PlaybackSettingsScreen(),
+                ),
+              );
+            },
+          ),
+
+          ListTile(
+            leading: const Icon(Icons.dns_outlined),
+            title: const Text('Playlist Source'),
+            subtitle: const Text('Add or remove your M3U playlist URL'),
+            trailing: const Icon(Icons.arrow_forward_ios, size: 16),
+            onTap: () => showPlaylistSourceSheet(context, ref),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _CurrencySelector extends ConsumerWidget {
+  const _CurrencySelector();
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final settings = ref.watch(localeSettingsProvider);
+    final selectedCurrency = SupportedCurrency.fromCode(settings.currency);
+
+    return ListTile(
+      leading: const Icon(Icons.payments_outlined),
+      title: const Text('Currency'),
+      subtitle: Text('${selectedCurrency.code} (${selectedCurrency.symbol})'),
+      trailing: DropdownButtonHideUnderline(
+        child: DropdownButton<String>(
+          value: selectedCurrency.code,
+          items: SupportedCurrency.values.map((currency) {
+            return DropdownMenuItem<String>(
+              value: currency.code,
+              child: Text('${currency.symbol} ${currency.code}'),
+            );
+          }).toList(),
+          onChanged: (value) async {
+            if (value == null || value == settings.currency) return;
+
+            final updatedSettings = settings.copyWith(currency: value);
+            await ref
+                .read(localeSettingsProvider.notifier)
+                .updateSettings(updatedSettings);
+
+            final repository = ref.read(userProfileRepositoryProvider);
+            final currentProfile = (await repository.getCurrentProfile())
+                .getOrNull();
+            if (currentProfile != null) {
+              await repository.updateProfile(localeSettings: updatedSettings);
+              ref.invalidate(currentUserProfileProvider);
+            }
+          },
+        ),
+      ),
+    );
+  }
+}

--- a/app/test/features/agent_chat/presentation/screens/profile_ai_preferences_test.dart
+++ b/app/test/features/agent_chat/presentation/screens/profile_ai_preferences_test.dart
@@ -3,36 +3,12 @@ import 'package:airo_app/features/agent_chat/presentation/screens/profile_screen
 import 'package:airo_app/features/settings/application/ai_storage_dashboard.dart';
 import 'package:feature_iptv/feature_iptv.dart';
 import 'package:airo_app/features/settings/application/ai_preferences_settings.dart';
-import 'package:core_ui/core_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 void main() {
-  testWidgets('profile appearance picker saves selected theme', (tester) async {
-    SharedPreferences.setMockInitialValues({});
-    final prefs = await SharedPreferences.getInstance();
-    final notifier = AppThemeNotifier.withPreferences(prefs);
-
-    await tester.pumpWidget(
-      ProviderScope(
-        overrides: [appThemeProvider.overrideWith((ref) => notifier)],
-        child: const MaterialApp(home: ProfileScreen()),
-      ),
-    );
-
-    expect(find.text('Appearance'), findsOneWidget);
-    expect(find.text('Airo Cyber'), findsOneWidget);
-    expect(find.text('Airo Classic'), findsOneWidget);
-
-    await tester.tap(find.text('Airo Classic'));
-    await tester.pump();
-
-    expect(notifier.state, AppThemeId.classic);
-    expect(prefs.getString(AppThemeNotifier.storageKey), 'classic');
-  });
-
   testWidgets('profile shows AI preferences and persists fallback changes', (
     tester,
   ) async {

--- a/app/test/features/settings/presentation/screens/settings_hub_screen_test.dart
+++ b/app/test/features/settings/presentation/screens/settings_hub_screen_test.dart
@@ -1,0 +1,108 @@
+import 'package:airo_app/core/providers/app_theme_provider.dart';
+import 'package:airo_app/features/settings/presentation/screens/settings_hub_screen.dart';
+import 'package:core_data/core_data.dart';
+import 'package:core_ui/core_ui.dart';
+import 'package:feature_iptv/feature_iptv.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  Future<void> pumpScreen(WidgetTester tester) async {
+    await tester.binding.setSurfaceSize(const Size(400, 1600));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+
+    final prefs = await SharedPreferences.getInstance();
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          sharedPreferencesProvider.overrideWithValue(prefs),
+          secureStoreProvider.overrideWithValue(InMemorySecureStore()),
+        ],
+        child: const MaterialApp(home: SettingsHubScreen()),
+      ),
+    );
+    await tester.pump();
+  }
+
+  testWidgets('renders appearance, quick toggles, currency, and navigation '
+      'tiles', (tester) async {
+    await pumpScreen(tester);
+
+    expect(find.text('Settings'), findsOneWidget);
+    expect(find.text('Appearance'), findsOneWidget);
+    expect(find.text('Bedtime Mode'), findsOneWidget);
+    expect(find.text('Background Audio'), findsOneWidget);
+    expect(find.text('Audio Ducking'), findsOneWidget);
+    expect(find.text('Currency'), findsOneWidget);
+    expect(find.text('Audio Settings'), findsOneWidget);
+    expect(find.text('Playback Settings'), findsOneWidget);
+    expect(find.text('Playlist Source'), findsOneWidget);
+  });
+
+  testWidgets('tapping Audio Settings pushes the audio settings screen', (
+    tester,
+  ) async {
+    await pumpScreen(tester);
+
+    await tester.tap(find.text('Audio Settings'));
+    await tester.pumpAndSettle();
+
+    expect(find.widgetWithText(AppBar, 'Audio Settings'), findsOneWidget);
+  });
+
+  testWidgets('tapping Playback Settings pushes the playback settings '
+      'screen', (tester) async {
+    await pumpScreen(tester);
+
+    await tester.tap(find.text('Playback Settings'));
+    await tester.pumpAndSettle();
+
+    expect(find.widgetWithText(AppBar, 'Playback Settings'), findsOneWidget);
+  });
+
+  testWidgets('tapping Playlist Source opens the playlist source sheet', (
+    tester,
+  ) async {
+    await pumpScreen(tester);
+
+    await tester.tap(find.text('Playlist Source'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Playlist source'), findsOneWidget);
+  });
+
+  testWidgets('appearance picker saves selected theme', (tester) async {
+    await tester.binding.setSurfaceSize(const Size(400, 1600));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+
+    final prefs = await SharedPreferences.getInstance();
+    final notifier = AppThemeNotifier.withPreferences(prefs);
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          appThemeProvider.overrideWith((ref) => notifier),
+          sharedPreferencesProvider.overrideWithValue(prefs),
+          secureStoreProvider.overrideWithValue(InMemorySecureStore()),
+        ],
+        child: const MaterialApp(home: SettingsHubScreen()),
+      ),
+    );
+    await tester.pump();
+
+    expect(find.text('Airo Cyber'), findsOneWidget);
+    expect(find.text('Airo Classic'), findsOneWidget);
+
+    await tester.tap(find.text('Airo Classic'));
+    await tester.pump();
+
+    expect(notifier.state, AppThemeId.classic);
+    expect(prefs.getString(AppThemeNotifier.storageKey), 'classic');
+  });
+}

--- a/packages/feature_iptv/lib/presentation/screens/iptv_screen.dart
+++ b/packages/feature_iptv/lib/presentation/screens/iptv_screen.dart
@@ -819,19 +819,26 @@ class _PlaylistSourceSheetState extends ConsumerState<_PlaylistSourceSheet> {
               _PlaylistSourceInfoCallout(),
             ],
             const SizedBox(height: 12),
-            Row(
+            OverflowBar(
+              alignment: MainAxisAlignment.spaceBetween,
+              overflowAlignment: OverflowBarAlignment.end,
+              spacing: 8,
+              overflowSpacing: 8,
               children: [
                 TextButton(onPressed: _remove, child: const Text('Remove')),
-                const Spacer(),
-                TextButton(
-                  onPressed: () => Navigator.of(context).pop(),
-                  child: const Text('Cancel'),
-                ),
-                const SizedBox(width: 8),
-                FilledButton.icon(
-                  onPressed: _save,
-                  icon: const Icon(Icons.check),
-                  label: const Text('Save'),
+                OverflowBar(
+                  spacing: 8,
+                  children: [
+                    TextButton(
+                      onPressed: () => Navigator.of(context).pop(),
+                      child: const Text('Cancel'),
+                    ),
+                    FilledButton.icon(
+                      onPressed: _save,
+                      icon: const Icon(Icons.check),
+                      label: const Text('Save'),
+                    ),
+                  ],
                 ),
               ],
             ),

--- a/packages/feature_iptv/test/iptv/presentation/screens/iptv_screen_test.dart
+++ b/packages/feature_iptv/test/iptv/presentation/screens/iptv_screen_test.dart
@@ -169,6 +169,24 @@ void main() {
     expect(find.text('Done'), findsOneWidget);
   });
 
+  testWidgets(
+    'playlist source sheet action row renders without overflow at phone '
+    'width',
+    (tester) async {
+      await tester.binding.setSurfaceSize(const Size(390, 844));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+
+      await tester.pumpWidget(createWidget());
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byTooltip('Playlist source'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Playlist source'), findsOneWidget);
+      expect(tester.takeException(), isNull);
+    },
+  );
+
   testWidgets('fresh install shows bring-your-own playlist state', (
     tester,
   ) async {


### PR DESCRIPTION
## Summary
- Wires `RouteNames.settings` ('/settings'), previously a dead stub, to a new `SettingsHubScreen` — mobile's counterpart to `TvSettingsScreen` (a scrollable list rather than a rail/detail split, since phones don't have room for a persistent side rail).
- Extracts appearance/theme, quick audio toggles, currency, and links to `AudioSettingsScreen`/`PlaybackSettingsScreen`/playlist-source out of the monolithic `ProfileScreen` into the new hub. `ProfileScreen` now keeps identity + AI Preferences + Features + Dev Tools, with a single "Settings" tile pushing to the new route.
- Reuses the existing `showPlaylistSourceSheet(context, ref)` from feature_iptv rather than duplicating source-management UI.
- Fixes a pre-existing overflow bug in `_PlaylistSourceSheet`'s action-button row (Remove/Cancel/Save), surfaced by this work being the first mobile entry point exercising that sheet at real phone width in a test. Replaced with nested `OverflowBar`s so it wraps instead of overflowing at ~390-430dp.

Reviewed by flutter-architect and media-intelligence-architect subagents; both approved.

## Test plan
- [x] `flutter test` green in `app/` (984 tests) and `packages/feature_iptv/` (298 tests)
- [x] New `settings_hub_screen_test.dart`: renders all tiles, Audio/Playback Settings navigation, Playlist Source sheet, theme picker persistence
- [x] Migrated theme-picker test out of `profile_theme_picker_test.dart` (renamed `profile_ai_preferences_test.dart`, kept AI-prefs/storage-dashboard tests)
- [x] New narrow-width regression test in `iptv_screen_test.dart` for the overflow fix
- [x] `dart format` + `dart analyze` clean on all touched files