### PR TITLE
feat(feature_iptv): CV-017 -- wire FavoriteChannelRemapper into a re-import coordinator

### DIFF
--- a/packages/feature_iptv/lib/domain/favorite_reimport_coordinator.dart
+++ b/packages/feature_iptv/lib/domain/favorite_reimport_coordinator.dart
@@ -1,0 +1,87 @@
+import 'package:platform_channels/platform_channels.dart';
+import 'package:platform_playlist/platform_playlist.dart';
+
+/// A favorite whose old channel no longer exists by id in a re-imported
+/// provider list, and whose best match is only a name-based (medium-
+/// confidence) one -- must be confirmed by the user rather than silently
+/// remapped (CV-017).
+class FavoriteReviewCandidate {
+  const FavoriteReviewCandidate({
+    required this.oldChannel,
+    required this.candidate,
+  });
+
+  final IPTVChannel oldChannel;
+  final IPTVChannel candidate;
+}
+
+class FavoriteReimportResult {
+  const FavoriteReimportResult({
+    required this.remappedFavoriteIds,
+    required this.needsReview,
+  });
+
+  /// The new set of favorited channel ids: unchanged ids that still exist,
+  /// plus high-confidence (tvg-id) remaps. Favorites with no match at all
+  /// are dropped rather than carried forward under a stale id.
+  final Set<String> remappedFavoriteIds;
+
+  /// Favorites whose only candidate match is name-based and needs explicit
+  /// user confirmation before being applied.
+  final List<FavoriteReviewCandidate> needsReview;
+}
+
+/// Carries favorites over a provider re-import (CV-017's "Favorites can
+/// point to canonical channel IDs and survive a provider re-import when a
+/// confident match exists" acceptance criterion).
+///
+/// Delegates matching to [FavoriteChannelRemapper] (platform_playlist);
+/// this class only decides what to do with each confidence tier for the
+/// specific case of favorites.
+class FavoriteReimportCoordinator {
+  FavoriteReimportCoordinator({FavoriteChannelRemapper? remapper})
+    : _remapper = remapper ?? FavoriteChannelRemapper();
+
+  final FavoriteChannelRemapper _remapper;
+
+  FavoriteReimportResult remapFavorites({
+    required Set<String> favoriteChannelIds,
+    required List<IPTVChannel> oldChannels,
+    required List<IPTVChannel> newChannels,
+  }) {
+    final newChannelsById = {for (final c in newChannels) c.id: c};
+    final oldChannelsById = {for (final c in oldChannels) c.id: c};
+
+    final remapped = <String>{};
+    final needsReview = <FavoriteReviewCandidate>[];
+
+    for (final favoriteId in favoriteChannelIds) {
+      if (newChannelsById.containsKey(favoriteId)) {
+        remapped.add(favoriteId);
+        continue;
+      }
+
+      final oldChannel = oldChannelsById[favoriteId];
+      if (oldChannel == null) continue;
+
+      final result = _remapper.findMatch(oldChannel, newChannels);
+      if (result.channel == null) continue;
+
+      if (result.needsReview) {
+        needsReview.add(
+          FavoriteReviewCandidate(
+            oldChannel: oldChannel,
+            candidate: result.channel!,
+          ),
+        );
+      } else {
+        remapped.add(result.channel!.id);
+      }
+    }
+
+    return FavoriteReimportResult(
+      remappedFavoriteIds: remapped,
+      needsReview: needsReview,
+    );
+  }
+}

--- a/packages/feature_iptv/lib/feature_iptv.dart
+++ b/packages/feature_iptv/lib/feature_iptv.dart
@@ -3,6 +3,7 @@ library;
 export "src/iptv.dart";
 export "domain/local_iptv_search.dart";
 export "domain/vod_resume_coordinator.dart";
+export "domain/favorite_reimport_coordinator.dart";
 export "application/providers/iptv_providers.dart";
 export "application/providers/iptv_cast_providers.dart";
 export "application/providers/content_source_management_providers.dart";

--- a/packages/feature_iptv/test/favorite_reimport_coordinator_test.dart
+++ b/packages/feature_iptv/test/favorite_reimport_coordinator_test.dart
@@ -1,0 +1,128 @@
+import 'package:feature_iptv/feature_iptv.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  final coordinator = FavoriteReimportCoordinator();
+
+  IPTVChannel channel({required String id, required String name, int? tvgId}) {
+    return IPTVChannel(
+      id: id,
+      name: name,
+      streamUrl: 'https://example.com/$id.m3u8',
+      tvgId: tvgId,
+    );
+  }
+
+  test('a favorite whose id still exists in the new list is kept as-is', () {
+    final oldChannels = [channel(id: 'a1', name: 'BBC One', tvgId: 101)];
+    final newChannels = [channel(id: 'a1', name: 'BBC One', tvgId: 101)];
+
+    final result = coordinator.remapFavorites(
+      favoriteChannelIds: {'a1'},
+      oldChannels: oldChannels,
+      newChannels: newChannels,
+    );
+
+    expect(result.remappedFavoriteIds, {'a1'});
+    expect(result.needsReview, isEmpty);
+  });
+
+  test(
+    'a favorite whose id changed is remapped via tvg-id with high confidence',
+    () {
+      final oldChannels = [channel(id: 'a1', name: 'BBC One', tvgId: 101)];
+      final newChannels = [
+        channel(id: 'b9', name: 'Totally Different Label', tvgId: 101),
+      ];
+
+      final result = coordinator.remapFavorites(
+        favoriteChannelIds: {'a1'},
+        oldChannels: oldChannels,
+        newChannels: newChannels,
+      );
+
+      expect(result.remappedFavoriteIds, {'b9'});
+      expect(result.needsReview, isEmpty);
+    },
+  );
+
+  test(
+    'a name-only match is not auto-remapped -- surfaced for review instead',
+    () {
+      final oldChannels = [channel(id: 'a1', name: 'BBC One HD')];
+      final newChannels = [channel(id: 'b9', name: 'bbc-one')];
+
+      final result = coordinator.remapFavorites(
+        favoriteChannelIds: {'a1'},
+        oldChannels: oldChannels,
+        newChannels: newChannels,
+      );
+
+      expect(
+        result.remappedFavoriteIds,
+        isEmpty,
+        reason: 'must not silently merge a low-confidence match',
+      );
+      expect(result.needsReview, hasLength(1));
+      expect(result.needsReview.single.oldChannel.id, 'a1');
+      expect(result.needsReview.single.candidate.id, 'b9');
+    },
+  );
+
+  test('a favorite with no match anywhere is dropped, not carried forward', () {
+    final oldChannels = [channel(id: 'a1', name: 'BBC One', tvgId: 101)];
+    final newChannels = [
+      channel(id: 'b9', name: 'CNN International', tvgId: 55),
+    ];
+
+    final result = coordinator.remapFavorites(
+      favoriteChannelIds: {'a1'},
+      oldChannels: oldChannels,
+      newChannels: newChannels,
+    );
+
+    expect(result.remappedFavoriteIds, isEmpty);
+    expect(result.needsReview, isEmpty);
+  });
+
+  test('non-favorited channels are ignored entirely', () {
+    final oldChannels = [
+      channel(id: 'a1', name: 'BBC One', tvgId: 101),
+      channel(id: 'a2', name: 'CNN International', tvgId: 55),
+    ];
+    final newChannels = [
+      channel(id: 'b1', name: 'Totally Different Label', tvgId: 101),
+      channel(id: 'b2', name: 'CNN Renamed', tvgId: 999),
+    ];
+
+    final result = coordinator.remapFavorites(
+      favoriteChannelIds: {'a1'},
+      oldChannels: oldChannels,
+      newChannels: newChannels,
+    );
+
+    expect(result.remappedFavoriteIds, {'b1'});
+    expect(result.needsReview, isEmpty);
+  });
+
+  test('handles multiple favorites independently', () {
+    final oldChannels = [
+      channel(id: 'a1', name: 'BBC One', tvgId: 101),
+      channel(id: 'a2', name: 'BBC Two HD'),
+    ];
+    final newChannels = [
+      channel(id: 'b1', name: 'Totally Different Label', tvgId: 101),
+      channel(id: 'b2', name: 'bbc-two'),
+    ];
+
+    final result = coordinator.remapFavorites(
+      favoriteChannelIds: {'a1', 'a2'},
+      oldChannels: oldChannels,
+      newChannels: newChannels,
+    );
+
+    expect(result.remappedFavoriteIds, {'b1'});
+    expect(result.needsReview, hasLength(1));
+    expect(result.needsReview.single.oldChannel.id, 'a2');
+  });
+}


### PR DESCRIPTION
## Summary
Part of #821 (CV-017, P0). Closes the "playlist import wiring" gap PR
#914 explicitly left open by adding the app-layer glue between
`platform_favorites`' plain id-based `FavoriteChannelsStorage` and
`platform_playlist`'s `FavoriteChannelRemapper`.

`FavoriteReimportCoordinator.remapFavorites()` takes the old channel
list, the freshly re-imported one, and the current favorite ids, and
returns:
- `remappedFavoriteIds`: ids unchanged (still present) plus
  high-confidence (tvg-id) remaps -- safe to write straight back to
  `FavoriteChannelsStorage`.
- `needsReview`: name-only matches, which must never be silently
  applied per CV-017's "uncertain matches are not silently merged" AC --
  left for a future review-confirmation UI slice to surface.

A favorite with no match at all (in either list) is dropped rather than
carried forward under a now-nonexistent id.

Deliberately kept pure -- no storage/provider wiring in this class -- so
it's testable without a widget tree or real storage.

## Not in this slice
- Actually invoking this coordinator during a real playlist re-import
  (needs a provider hook point in the import flow).
- The review-confirmation UI for the `needsReview` list.
- Persistent canonical channel identity / provider alias storage (a
  bigger, separate storage-engineering decision given the issue's scale
  concerns -- "tens of thousands of channels" likely wants something
  more queryable than flat SharedPreferences JSON, e.g. Drift).

## Test plan
- [x] New tests: unchanged-id favorite kept, tvg-id remap applied,
      name-only match surfaced for review (not auto-applied), no-match
      favorite dropped, non-favorited channels ignored, multiple
      favorites handled independently.
- [x] Full `feature_iptv` suite green (324 tests).
- [x] `flutter analyze` clean on changed files.
- [x] `dart format --set-exit-if-changed` clean.