### PR TITLE
feat(feature_iptv): CV-017 -- hook favorite remapping into refreshChannelsProvider

### DIFF
--- a/packages/feature_iptv/lib/application/providers/iptv_providers.dart
+++ b/packages/feature_iptv/lib/application/providers/iptv_providers.dart
@@ -10,6 +10,7 @@ import "package:platform_epg/platform_epg.dart";
 import "package:platform_player/platform_player.dart";
 import "package:platform_media/platform_media.dart";
 import "package:platform_playlist_import/platform_playlist_import.dart";
+import '../../domain/favorite_reimport_coordinator.dart';
 import '../../domain/vod_resume_coordinator.dart';
 
 export 'iptv_cast_providers.dart';
@@ -131,23 +132,45 @@ final refreshChannelsProvider = FutureProvider.family<List<IPTVChannel>, bool>((
   ref,
   forceRefresh,
 ) async {
+  // Snapshot before the refresh so CV-017's favorite remap has an "old"
+  // list to diff the freshly re-imported one against. Reads whatever is
+  // already cached without forcing a fetch -- null/absent on the very
+  // first import, which applyFavoriteRemapOnReimport treats as a no-op.
+  final oldChannels = ref.read(iptvChannelsProvider).value ?? const [];
+
+  List<IPTVChannel> newChannels;
   final channelDataService = ref.watch(channelDataServiceProvider);
   try {
     final channels = await channelDataService.fetchChannels(
       forceRefresh: forceRefresh,
     );
-    if (channels.isNotEmpty) {
-      return channels;
-    }
+    newChannels = channels.isNotEmpty
+        ? channels
+        : await ref
+              .watch(m3uParserProvider)
+              .fetchPlaylist(forceRefresh: forceRefresh);
   } catch (e) {
     debugPrint(
       '[Provider] ChannelDataService refresh failed, falling back to M3U: $e',
     );
+    newChannels = await ref
+        .watch(m3uParserProvider)
+        .fetchPlaylist(forceRefresh: forceRefresh);
   }
 
-  // Fallback to legacy M3U parser
-  final parser = ref.watch(m3uParserProvider);
-  return parser.fetchPlaylist(forceRefresh: forceRefresh);
+  final needsReview = await applyFavoriteRemapOnReimport(
+    favoriteStorage: ref.read(favoriteChannelsStorageProvider),
+    coordinator: ref.read(favoriteReimportCoordinatorProvider),
+    oldChannels: oldChannels,
+    newChannels: newChannels,
+  );
+  if (needsReview.isNotEmpty) {
+    ref.read(favoriteReimportReviewCandidatesProvider.notifier).state =
+        needsReview;
+  }
+  ref.invalidate(favoriteChannelIdsProvider);
+
+  return newChannels;
 });
 
 /// Current category filter
@@ -493,6 +516,60 @@ final toggleChannelFavoriteProvider = FutureProvider.family<bool, String>((
   ref.invalidate(favoriteChannelIdsProvider);
   return isNowFavorite;
 });
+
+/// Coordinator for CV-017's favorites-survive-reimport behavior.
+final favoriteReimportCoordinatorProvider =
+    Provider<FavoriteReimportCoordinator>(
+      (ref) => FavoriteReimportCoordinator(),
+    );
+
+/// Applies [FavoriteReimportCoordinator]'s decisions to real storage: writes
+/// high-confidence remaps directly, drops favorites with no match at all,
+/// and leaves name-only matches untouched in storage -- returning them so
+/// the caller can surface a review prompt (CV-017, #821).
+///
+/// A no-op when there's nothing to compare against (first import, before
+/// any channel list has ever been loaded) or no favorites exist yet.
+Future<List<FavoriteReviewCandidate>> applyFavoriteRemapOnReimport({
+  required FavoriteChannelsStorage favoriteStorage,
+  required FavoriteReimportCoordinator coordinator,
+  required List<IPTVChannel> oldChannels,
+  required List<IPTVChannel> newChannels,
+}) async {
+  if (oldChannels.isEmpty) return const [];
+
+  final favoriteIds = await favoriteStorage.getFavoriteChannelIds();
+  if (favoriteIds.isEmpty) return const [];
+
+  final result = coordinator.remapFavorites(
+    favoriteChannelIds: favoriteIds,
+    oldChannels: oldChannels,
+    newChannels: newChannels,
+  );
+
+  // Ids pending review must stay in storage untouched -- only a true
+  // no-match (neither remapped nor flagged for review) gets dropped.
+  final reviewIds = result.needsReview
+      .map((candidate) => candidate.oldChannel.id)
+      .toSet();
+  final toDrop = favoriteIds
+      .difference(result.remappedFavoriteIds)
+      .difference(reviewIds);
+  for (final droppedId in toDrop) {
+    await favoriteStorage.removeFavorite(droppedId);
+  }
+  for (final newId in result.remappedFavoriteIds.difference(favoriteIds)) {
+    await favoriteStorage.addFavorite(newId);
+  }
+
+  return result.needsReview;
+}
+
+/// Favorite matches from the most recent re-import that need explicit user
+/// confirmation before being applied (CV-017). Cleared by whatever UI
+/// eventually consumes and resolves them; empty until then.
+final favoriteReimportReviewCandidatesProvider =
+    StateProvider<List<FavoriteReviewCandidate>>((ref) => const []);
 
 // =============================================================================
 // Hidden Groups Providers (CV-021, #826)

--- a/packages/feature_iptv/test/favorite_reimport_provider_test.dart
+++ b/packages/feature_iptv/test/favorite_reimport_provider_test.dart
@@ -1,0 +1,113 @@
+import 'package:feature_iptv/feature_iptv.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  late SharedPreferences prefs;
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    prefs = await SharedPreferences.getInstance();
+  });
+
+  ProviderContainer buildContainer() {
+    return ProviderContainer(
+      overrides: [sharedPreferencesProvider.overrideWithValue(prefs)],
+    );
+  }
+
+  IPTVChannel channel({required String id, required String name, int? tvgId}) {
+    return IPTVChannel(
+      id: id,
+      name: name,
+      streamUrl: 'https://example.com/$id.m3u8',
+      tvgId: tvgId,
+    );
+  }
+
+  test(
+    'remaps a favorite via tvg-id and writes the new id to storage',
+    () async {
+      final container = buildContainer();
+      addTearDown(container.dispose);
+
+      final storage = container.read(favoriteChannelsStorageProvider);
+      await storage.addFavorite('a1');
+
+      final needsReview = await applyFavoriteRemapOnReimport(
+        favoriteStorage: storage,
+        coordinator: FavoriteReimportCoordinator(),
+        oldChannels: [channel(id: 'a1', name: 'BBC One', tvgId: 101)],
+        newChannels: [
+          channel(id: 'b9', name: 'Totally Different Label', tvgId: 101),
+        ],
+      );
+
+      expect(needsReview, isEmpty);
+      final favoriteIds = await storage.getFavoriteChannelIds();
+      expect(favoriteIds, {'b9'});
+    },
+  );
+
+  test(
+    'leaves storage untouched and reports a name-only match for review',
+    () async {
+      final container = buildContainer();
+      addTearDown(container.dispose);
+
+      final storage = container.read(favoriteChannelsStorageProvider);
+      await storage.addFavorite('a1');
+
+      final needsReview = await applyFavoriteRemapOnReimport(
+        favoriteStorage: storage,
+        coordinator: FavoriteReimportCoordinator(),
+        oldChannels: [channel(id: 'a1', name: 'BBC One HD')],
+        newChannels: [channel(id: 'b9', name: 'bbc-one')],
+      );
+
+      expect(needsReview, hasLength(1));
+      expect(needsReview.single.oldChannel.id, 'a1');
+      expect(needsReview.single.candidate.id, 'b9');
+      final favoriteIds = await storage.getFavoriteChannelIds();
+      expect(favoriteIds, {
+        'a1',
+      }, reason: 'must not silently repoint a name-only match');
+    },
+  );
+
+  test('does nothing when there are no favorites', () async {
+    final container = buildContainer();
+    addTearDown(container.dispose);
+
+    final storage = container.read(favoriteChannelsStorageProvider);
+
+    final needsReview = await applyFavoriteRemapOnReimport(
+      favoriteStorage: storage,
+      coordinator: FavoriteReimportCoordinator(),
+      oldChannels: [channel(id: 'a1', name: 'BBC One', tvgId: 101)],
+      newChannels: [channel(id: 'b9', name: 'Renamed', tvgId: 101)],
+    );
+
+    expect(needsReview, isEmpty);
+  });
+
+  test('does nothing on the first import (no old channels yet)', () async {
+    final container = buildContainer();
+    addTearDown(container.dispose);
+
+    final storage = container.read(favoriteChannelsStorageProvider);
+    await storage.addFavorite('a1');
+
+    final needsReview = await applyFavoriteRemapOnReimport(
+      favoriteStorage: storage,
+      coordinator: FavoriteReimportCoordinator(),
+      oldChannels: const [],
+      newChannels: [channel(id: 'b9', name: 'Renamed', tvgId: 101)],
+    );
+
+    expect(needsReview, isEmpty);
+    final favoriteIds = await storage.getFavoriteChannelIds();
+    expect(favoriteIds, {'a1'});
+  });
+}


### PR DESCRIPTION
## Summary
Part of #821 (CV-017, P0). Wires `FavoriteReimportCoordinator` (#915)
into the real playlist re-import path -- it was previously only a
standalone, unit-tested class with nothing calling it.

- `applyFavoriteRemapOnReimport()` (pure, storage-in/storage-out)
  applies the coordinator's decisions: high-confidence remaps get
  written to `FavoriteChannelsStorage` directly, favorites with no match
  anywhere are dropped, and name-only matches are left **untouched** in
  storage -- surfaced instead via the new
  `favoriteReimportReviewCandidatesProvider` for a future review-prompt
  UI to consume.
- `refreshChannelsProvider` now snapshots the currently-cached channel
  list before fetching, diffs it against the freshly re-imported one
  through `applyFavoriteRemapOnReimport`, and invalidates
  `favoriteChannelIdsProvider` so any UI watching favorites picks up the
  change. A no-op on the very first import (nothing cached yet to diff
  against).

Caught a real bug via the new provider-level test before it shipped:
the initial wiring treated every non-remapped id as a drop, which would
have deleted favorites that were actually pending review instead of
leaving them alone untouched.

## Not in this slice
- The review-confirmation UI that reads
  `favoriteReimportReviewCandidatesProvider` and lets the user
  accept/reject a name-only match.
- Persistent canonical channel identity / provider alias storage.

## Test plan
- [x] New tests: tvg-id remap writes the new id to storage, name-only
      match leaves storage untouched and reports for review, no-op with
      no favorites, no-op on first import (no old channels to diff).
- [x] Full `feature_iptv` suite green (328 tests).
- [x] `flutter analyze` clean on changed files.
- [x] `dart format --set-exit-if-changed` clean.