### PR TITLE
feat(feature_iptv): CV-017 -- favorite reimport review banner (TV)

### DIFF
--- a/packages/feature_iptv/lib/presentation/tv/tv_favorites_screen.dart
+++ b/packages/feature_iptv/lib/presentation/tv/tv_favorites_screen.dart
@@ -6,6 +6,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../application/providers/iptv_providers.dart';
+import '../widgets/favorite_reimport_review_banner.dart';
 import '../widgets/iptv_icon_placeholder.dart';
 
 /// Lists channels the user has favorited on TV, with a way to unfavorite
@@ -26,6 +27,7 @@ class TvFavoritesScreen extends ConsumerWidget {
         children: [
           Text('Favorites', style: Theme.of(context).textTheme.headlineSmall),
           const SizedBox(height: 8),
+          const FavoriteReimportReviewBanner(),
           Text(
             'Press the menu/context key on a channel to add or remove it '
             'from favorites.',

--- a/packages/feature_iptv/lib/presentation/widgets/favorite_reimport_review_banner.dart
+++ b/packages/feature_iptv/lib/presentation/widgets/favorite_reimport_review_banner.dart
@@ -1,0 +1,91 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../application/providers/iptv_providers.dart';
+import '../../domain/favorite_reimport_coordinator.dart';
+
+/// Surfaces CV-017's name-only favorite matches from the most recent
+/// playlist re-import for explicit user confirmation -- per the issue's
+/// "uncertain matches are not silently merged" acceptance criterion, these
+/// are never applied automatically (see [applyFavoriteRemapOnReimport]).
+///
+/// Renders nothing when [favoriteReimportReviewCandidatesProvider] is empty.
+class FavoriteReimportReviewBanner extends ConsumerWidget {
+  const FavoriteReimportReviewBanner({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final candidates = ref.watch(favoriteReimportReviewCandidatesProvider);
+    if (candidates.isEmpty) return const SizedBox.shrink();
+
+    final colorScheme = Theme.of(context).colorScheme;
+    return Container(
+      margin: const EdgeInsets.only(bottom: 16),
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: colorScheme.surfaceContainerHighest,
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(color: colorScheme.outlineVariant),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          for (final candidate in candidates)
+            Padding(
+              key: ValueKey(
+                'favorite-reimport-review-${candidate.oldChannel.id}',
+              ),
+              padding: const EdgeInsets.symmetric(vertical: 4),
+              child: Row(
+                children: [
+                  Expanded(
+                    child: Text(
+                      '"${candidate.oldChannel.name}" looks like '
+                      '"${candidate.candidate.name}" now. Keep as favorite?',
+                    ),
+                  ),
+                  TextButton(
+                    key: ValueKey(
+                      'favorite-reimport-accept-${candidate.oldChannel.id}',
+                    ),
+                    onPressed: () => _accept(ref, candidate),
+                    child: const Text('Keep'),
+                  ),
+                  TextButton(
+                    key: ValueKey(
+                      'favorite-reimport-dismiss-${candidate.oldChannel.id}',
+                    ),
+                    onPressed: () => _dismiss(ref, candidate),
+                    child: const Text('Dismiss'),
+                  ),
+                ],
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+
+  Future<void> _accept(WidgetRef ref, FavoriteReviewCandidate candidate) async {
+    final storage = ref.read(favoriteChannelsStorageProvider);
+    // Sequenced, not fired concurrently: both are independent read-modify-
+    // write calls against the same underlying id set, so running them
+    // concurrently risks the second overwriting the first's write with a
+    // stale read.
+    await storage.addFavorite(candidate.candidate.id);
+    await storage.removeFavorite(candidate.oldChannel.id);
+    ref.invalidate(favoriteChannelIdsProvider);
+    _dismiss(ref, candidate);
+  }
+
+  void _dismiss(WidgetRef ref, FavoriteReviewCandidate candidate) {
+    ref
+        .read(favoriteReimportReviewCandidatesProvider.notifier)
+        .update(
+          (state) => state
+              .where((c) => c.oldChannel.id != candidate.oldChannel.id)
+              .toList(),
+        );
+  }
+}

--- a/packages/feature_iptv/test/iptv/presentation/tv/tv_favorites_screen_test.dart
+++ b/packages/feature_iptv/test/iptv/presentation/tv/tv_favorites_screen_test.dart
@@ -1,0 +1,81 @@
+import 'package:feature_iptv/feature_iptv.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  const oldChannel = IPTVChannel(
+    id: 'a1',
+    name: 'BBC One HD',
+    streamUrl: 'https://example.com/a1.m3u8',
+  );
+  const candidateChannel = IPTVChannel(
+    id: 'b9',
+    name: 'bbc-one',
+    streamUrl: 'https://example.com/b9.m3u8',
+  );
+
+  testWidgets(
+    'shows the favorite-reimport review banner when a candidate is pending (CV-017)',
+    (tester) async {
+      SharedPreferences.setMockInitialValues({});
+      final prefs = await SharedPreferences.getInstance();
+      final container = ProviderContainer(
+        overrides: [
+          sharedPreferencesProvider.overrideWithValue(prefs),
+          iptvChannelsProvider.overrideWith((ref) async => const []),
+          streamingStateProvider.overrideWith(
+            (ref) => Stream.value(StreamingState()),
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+      container
+          .read(favoriteReimportReviewCandidatesProvider.notifier)
+          .state = [
+        const FavoriteReviewCandidate(
+          oldChannel: oldChannel,
+          candidate: candidateChannel,
+        ),
+      ];
+
+      await tester.pumpWidget(
+        UncontrolledProviderScope(
+          container: container,
+          child: const MaterialApp(home: TvFavoritesScreen()),
+        ),
+      );
+      await tester.pump();
+
+      expect(find.textContaining('looks like'), findsOneWidget);
+    },
+  );
+
+  testWidgets('hides the review banner when there is nothing pending', (
+    tester,
+  ) async {
+    SharedPreferences.setMockInitialValues({});
+    final prefs = await SharedPreferences.getInstance();
+    final container = ProviderContainer(
+      overrides: [
+        sharedPreferencesProvider.overrideWithValue(prefs),
+        iptvChannelsProvider.overrideWith((ref) async => const []),
+        streamingStateProvider.overrideWith(
+          (ref) => Stream.value(StreamingState()),
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: const MaterialApp(home: TvFavoritesScreen()),
+      ),
+    );
+    await tester.pump();
+
+    expect(find.textContaining('looks like'), findsNothing);
+  });
+}

--- a/packages/feature_iptv/test/iptv/presentation/widgets/favorite_reimport_review_banner_test.dart
+++ b/packages/feature_iptv/test/iptv/presentation/widgets/favorite_reimport_review_banner_test.dart
@@ -1,0 +1,117 @@
+import 'package:feature_iptv/feature_iptv.dart';
+import 'package:feature_iptv/presentation/widgets/favorite_reimport_review_banner.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  const oldChannel = IPTVChannel(
+    id: 'a1',
+    name: 'BBC One HD',
+    streamUrl: 'https://example.com/a1.m3u8',
+  );
+  const candidateChannel = IPTVChannel(
+    id: 'b9',
+    name: 'bbc-one',
+    streamUrl: 'https://example.com/b9.m3u8',
+  );
+  const candidate = FavoriteReviewCandidate(
+    oldChannel: oldChannel,
+    candidate: candidateChannel,
+  );
+
+  Future<ProviderContainer> buildContainer() async {
+    SharedPreferences.setMockInitialValues({});
+    final prefs = await SharedPreferences.getInstance();
+    return ProviderContainer(
+      overrides: [sharedPreferencesProvider.overrideWithValue(prefs)],
+    );
+  }
+
+  Future<void> pumpBanner(
+    WidgetTester tester,
+    ProviderContainer container,
+  ) async {
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: const MaterialApp(
+          home: Scaffold(body: FavoriteReimportReviewBanner()),
+        ),
+      ),
+    );
+  }
+
+  testWidgets('renders nothing when there are no review candidates', (
+    tester,
+  ) async {
+    final container = await buildContainer();
+    addTearDown(container.dispose);
+
+    await pumpBanner(tester, container);
+
+    expect(find.byType(FavoriteReimportReviewBanner), findsOneWidget);
+    expect(find.textContaining('looks like'), findsNothing);
+  });
+
+  testWidgets('shows a prompt for each pending review candidate', (
+    tester,
+  ) async {
+    final container = await buildContainer();
+    addTearDown(container.dispose);
+    container.read(favoriteReimportReviewCandidatesProvider.notifier).state = [
+      candidate,
+    ];
+
+    await pumpBanner(tester, container);
+
+    expect(find.textContaining('BBC One HD'), findsOneWidget);
+    expect(find.textContaining('bbc-one'), findsOneWidget);
+  });
+
+  testWidgets(
+    'tapping Keep favorites the new channel, unfavorites the old one, and clears the prompt',
+    (tester) async {
+      final container = await buildContainer();
+      addTearDown(container.dispose);
+      final storage = container.read(favoriteChannelsStorageProvider);
+      await storage.addFavorite(oldChannel.id);
+      container.read(favoriteReimportReviewCandidatesProvider.notifier).state =
+          [candidate];
+
+      await pumpBanner(tester, container);
+      await tester.tap(
+        find.byKey(const ValueKey('favorite-reimport-accept-a1')),
+      );
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 50));
+
+      expect(container.read(favoriteReimportReviewCandidatesProvider), isEmpty);
+      final favoriteIds = await storage.getFavoriteChannelIds();
+      expect(favoriteIds, {'b9'});
+    },
+  );
+
+  testWidgets('tapping Dismiss clears the prompt without changing favorites', (
+    tester,
+  ) async {
+    final container = await buildContainer();
+    addTearDown(container.dispose);
+    final storage = container.read(favoriteChannelsStorageProvider);
+    await storage.addFavorite(oldChannel.id);
+    container.read(favoriteReimportReviewCandidatesProvider.notifier).state = [
+      candidate,
+    ];
+
+    await pumpBanner(tester, container);
+    await tester.tap(
+      find.byKey(const ValueKey('favorite-reimport-dismiss-a1')),
+    );
+    await tester.pump();
+
+    expect(container.read(favoriteReimportReviewCandidatesProvider), isEmpty);
+    final favoriteIds = await storage.getFavoriteChannelIds();
+    expect(favoriteIds, {'a1'});
+  });
+}


### PR DESCRIPTION
## Summary
Part of #821 (CV-017, P0). Adds `FavoriteReimportReviewBanner`: the
confirmation UI for `favoriteReimportReviewCandidatesProvider` (#917)
that PR explicitly deferred.

Renders nothing when the candidate list is empty; otherwise shows one
row per pending name-only match with Keep/Dismiss actions:
- **Keep**: favorites the new channel, unfavorites the old one, clears
  the prompt. The two storage writes are sequenced (awaited in order),
  not fired concurrently -- the new widget test caught a real bug where
  firing them concurrently let the second read-modify-write silently
  clobber the first with a stale read (both operate on the same
  underlying id set).
- **Dismiss**: clears the prompt without touching favorites at all.

Wired into `TvFavoritesScreen`, above the existing favorites grid.

## Not in this slice
- The mobile Favorites screen (#916) doesn't show this banner yet --
  follow-up.
- Persistent canonical channel identity / provider alias storage.

## Test plan
- [x] New tests: banner hidden when empty, shows a prompt per candidate,
      Keep applies both storage writes and clears the prompt, Dismiss
      clears the prompt without changing favorites.
- [x] `TvFavoritesScreen` tests: banner shown when a candidate is
      pending, hidden when nothing is pending.
- [x] Full `feature_iptv` suite green (340 tests).
- [x] `flutter analyze` clean on changed files.
- [x] `dart format --set-exit-if-changed` clean.