### PR TITLE
feat(feature_iptv): CV-017 -- favorite reimport review banner (mobile)

### DIFF
--- a/packages/feature_iptv/lib/presentation/screens/mobile_favorites_screen.dart
+++ b/packages/feature_iptv/lib/presentation/screens/mobile_favorites_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../application/providers/iptv_providers.dart';
+import '../widgets/favorite_reimport_review_banner.dart';
 import '../widgets/iptv_icon_placeholder.dart';
 
 /// Mobile screen listing the user's favorited channels — the mobile
@@ -22,70 +23,87 @@ class MobileFavoritesScreen extends ConsumerWidget {
 
     return Scaffold(
       appBar: AppBar(title: const Text('Favorites')),
-      body: favoritesAsync.when(
-        loading: () => const Center(child: CircularProgressIndicator()),
-        error: (error, _) =>
-            Center(child: Text('Could not load favorites: $error')),
-        data: (channels) {
-          if (channels.isEmpty) {
-            return Center(
-              child: Column(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  Icon(Icons.star_border, size: 64, color: colorScheme.primary),
-                  const SizedBox(height: 16),
-                  Text(
-                    'No favorite channels yet',
-                    style: Theme.of(context).textTheme.titleLarge,
-                  ),
-                ],
-              ),
-            );
-          }
-
-          return ListView.separated(
-            padding: const EdgeInsets.symmetric(vertical: 8),
-            itemCount: channels.length,
-            separatorBuilder: (context, index) => const Divider(height: 1),
-            itemBuilder: (context, index) {
-              final channel = channels[index];
-
-              return ListTile(
-                leading: SizedBox(
-                  width: 48,
-                  height: 48,
-                  child: ClipRRect(
-                    borderRadius: BorderRadius.circular(6),
-                    child: IptvIconPlaceholder.channel(
-                      isAudioOnly: channel.isAudioOnly,
+      body: Column(
+        children: [
+          const Padding(
+            padding: EdgeInsets.fromLTRB(16, 12, 16, 0),
+            child: FavoriteReimportReviewBanner(),
+          ),
+          Expanded(
+            child: favoritesAsync.when(
+              loading: () => const Center(child: CircularProgressIndicator()),
+              error: (error, _) =>
+                  Center(child: Text('Could not load favorites: $error')),
+              data: (channels) {
+                if (channels.isEmpty) {
+                  return Center(
+                    child: Column(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        Icon(
+                          Icons.star_border,
+                          size: 64,
+                          color: colorScheme.primary,
+                        ),
+                        const SizedBox(height: 16),
+                        Text(
+                          'No favorite channels yet',
+                          style: Theme.of(context).textTheme.titleLarge,
+                        ),
+                      ],
                     ),
-                  ),
-                ),
-                title: Text(
-                  channel.name,
-                  maxLines: 1,
-                  overflow: TextOverflow.ellipsis,
-                ),
-                subtitle: Text(
-                  channel.group,
-                  maxLines: 1,
-                  overflow: TextOverflow.ellipsis,
-                ),
-                trailing: IconButton(
-                  icon: Icon(Icons.favorite, color: colorScheme.error),
-                  tooltip: 'Remove from favorites',
-                  onPressed: () =>
-                      ref.read(toggleChannelFavoriteProvider(channel.id)),
-                ),
-                onTap: () {
-                  ref.read(iptvStreamingServiceProvider).playChannel(channel);
-                  ref.read(addToRecentlyWatchedProvider(channel));
-                  onChannelSelected();
-                },
-              );
-            },
-          );
-        },
+                  );
+                }
+
+                return ListView.separated(
+                  padding: const EdgeInsets.symmetric(vertical: 8),
+                  itemCount: channels.length,
+                  separatorBuilder: (context, index) =>
+                      const Divider(height: 1),
+                  itemBuilder: (context, index) {
+                    final channel = channels[index];
+
+                    return ListTile(
+                      leading: SizedBox(
+                        width: 48,
+                        height: 48,
+                        child: ClipRRect(
+                          borderRadius: BorderRadius.circular(6),
+                          child: IptvIconPlaceholder.channel(
+                            isAudioOnly: channel.isAudioOnly,
+                          ),
+                        ),
+                      ),
+                      title: Text(
+                        channel.name,
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                      subtitle: Text(
+                        channel.group,
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                      trailing: IconButton(
+                        icon: Icon(Icons.favorite, color: colorScheme.error),
+                        tooltip: 'Remove from favorites',
+                        onPressed: () =>
+                            ref.read(toggleChannelFavoriteProvider(channel.id)),
+                      ),
+                      onTap: () {
+                        ref
+                            .read(iptvStreamingServiceProvider)
+                            .playChannel(channel);
+                        ref.read(addToRecentlyWatchedProvider(channel));
+                        onChannelSelected();
+                      },
+                    );
+                  },
+                );
+              },
+            ),
+          ),
+        ],
       ),
     );
   }

--- a/packages/feature_iptv/test/iptv/presentation/screens/mobile_favorites_screen_test.dart
+++ b/packages/feature_iptv/test/iptv/presentation/screens/mobile_favorites_screen_test.dart
@@ -59,6 +59,58 @@ void main() {
     expect(find.text('No favorite channels yet'), findsOneWidget);
   });
 
+  testWidgets(
+    'shows the favorite-reimport review banner when a candidate is pending (CV-017)',
+    (tester) async {
+      SharedPreferences.setMockInitialValues({});
+      final prefs = await SharedPreferences.getInstance();
+      final engine = FakeAiroPlaybackEngine(tracks: const []);
+      final service = VideoPlayerStreamingService(engine: engine);
+      addTearDown(service.dispose);
+
+      const oldChannel = IPTVChannel(
+        id: 'a1',
+        name: 'BBC One HD',
+        streamUrl: 'https://example.com/a1.m3u8',
+      );
+      const candidateChannel = IPTVChannel(
+        id: 'b9',
+        name: 'bbc-one',
+        streamUrl: 'https://example.com/b9.m3u8',
+      );
+
+      final container = ProviderContainer(
+        overrides: [
+          sharedPreferencesProvider.overrideWithValue(prefs),
+          iptvChannelsProvider.overrideWith((ref) async => const []),
+          iptvStreamingServiceProvider.overrideWithValue(service),
+        ],
+      );
+      addTearDown(container.dispose);
+      container
+          .read(favoriteReimportReviewCandidatesProvider.notifier)
+          .state = [
+        const FavoriteReviewCandidate(
+          oldChannel: oldChannel,
+          candidate: candidateChannel,
+        ),
+      ];
+
+      await tester.pumpWidget(
+        UncontrolledProviderScope(
+          container: container,
+          child: MaterialApp(
+            home: MobileFavoritesScreen(onChannelSelected: () {}),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.textContaining('looks like'), findsOneWidget);
+      await service.stop();
+    },
+  );
+
   testWidgets('renders favorited channels with name and group', (tester) async {
     await pumpScreen(tester, favoriteIds: {'news-1', 'sports-1'});
 


### PR DESCRIPTION
## Summary
Part of #821 (CV-017, P0). Wires `FavoriteReimportReviewBanner` (#918,
landed TV-only) into `MobileFavoritesScreen` too, above the favorites
list -- the follow-up that PR explicitly left open. Same widget, same
Keep/Dismiss behavior, no new logic.

## Test plan
- [x] New test: banner shows a pending review candidate on the mobile
      screen.
- [x] Existing `mobile_favorites_screen_test.dart` tests (empty state,
      render, tap-to-play, tap-to-unfavorite) still pass unchanged.
- [x] Full `feature_iptv` suite green (341 tests).
- [x] `flutter analyze` clean on changed files.
- [x] `dart format --set-exit-if-changed` clean.