### PR TITLE
fix(ci): wire firebase_options.dart injection into every workflow building app/

### DIFF
--- a/.github/workflows/airo-macos-release.yml
+++ b/.github/workflows/airo-macos-release.yml
@@ -218,6 +218,19 @@ jobs:
           wait
           cd app && flutter pub get
 
+      - name: Configure firebase_options.dart
+        env:
+          FIREBASE_OPTIONS_DART_B64: ${{ secrets.FIREBASE_OPTIONS_DART_B64 }}
+        run: |
+          cd app
+          if [[ -n "$FIREBASE_OPTIONS_DART_B64" ]]; then
+            echo "$FIREBASE_OPTIONS_DART_B64" | base64 -d > lib/firebase_options.dart
+            echo "Using FIREBASE_OPTIONS_DART_B64."
+          else
+            cp lib/firebase_options.dart.template lib/firebase_options.dart
+            echo "::warning::FIREBASE_OPTIONS_DART_B64 is not set; using placeholder firebase_options.dart."
+          fi
+
       - name: Run profile-specific quality gates
         run: |
           cd app

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,19 @@ jobs:
           dart run build_runner clean
           dart run build_runner build --delete-conflicting-outputs
 
+      - name: Configure firebase_options.dart
+        env:
+          FIREBASE_OPTIONS_DART_B64: ${{ secrets.FIREBASE_OPTIONS_DART_B64 }}
+        run: |
+          cd app
+          if [[ -n "$FIREBASE_OPTIONS_DART_B64" ]]; then
+            echo "$FIREBASE_OPTIONS_DART_B64" | base64 -d > lib/firebase_options.dart
+            echo "Using FIREBASE_OPTIONS_DART_B64."
+          else
+            cp lib/firebase_options.dart.template lib/firebase_options.dart
+            echo "::warning::FIREBASE_OPTIONS_DART_B64 is not set; using placeholder firebase_options.dart."
+          fi
+
       - name: Run Flutter Analyze
         run: |
           cd app
@@ -221,6 +234,19 @@ jobs:
           cd app
           dart run build_runner clean
           dart run build_runner build --delete-conflicting-outputs
+
+      - name: Configure firebase_options.dart
+        env:
+          FIREBASE_OPTIONS_DART_B64: ${{ secrets.FIREBASE_OPTIONS_DART_B64 }}
+        run: |
+          cd app
+          if [[ -n "$FIREBASE_OPTIONS_DART_B64" ]]; then
+            echo "$FIREBASE_OPTIONS_DART_B64" | base64 -d > lib/firebase_options.dart
+            echo "Using FIREBASE_OPTIONS_DART_B64."
+          else
+            cp lib/firebase_options.dart.template lib/firebase_options.dart
+            echo "::warning::FIREBASE_OPTIONS_DART_B64 is not set; using placeholder firebase_options.dart."
+          fi
 
       - name: Run app tests with coverage
         run: |
@@ -408,6 +434,20 @@ jobs:
             exit 1
           fi
           echo "✅ Firebase configuration created successfully for $package_name"
+
+      - name: Configure firebase_options.dart
+        if: steps.android_scope.outputs.should_build == 'true'
+        env:
+          FIREBASE_OPTIONS_DART_B64: ${{ secrets.FIREBASE_OPTIONS_DART_B64 }}
+        run: |
+          cd app
+          if [[ -n "$FIREBASE_OPTIONS_DART_B64" ]]; then
+            echo "$FIREBASE_OPTIONS_DART_B64" | base64 -d > lib/firebase_options.dart
+            echo "Using FIREBASE_OPTIONS_DART_B64."
+          else
+            cp lib/firebase_options.dart.template lib/firebase_options.dart
+            echo "::warning::FIREBASE_OPTIONS_DART_B64 is not set; using placeholder firebase_options.dart (Firebase init will be skipped at runtime)."
+          fi
 
       - name: Create CI validation signing config
         if: steps.android_scope.outputs.should_build == 'true'
@@ -786,6 +826,19 @@ jobs:
           cd ../core_ai && flutter pub get
           cd ../core_auth && flutter pub get
           cd ../../app && flutter pub get
+
+      - name: Configure firebase_options.dart
+        env:
+          FIREBASE_OPTIONS_DART_B64: ${{ secrets.FIREBASE_OPTIONS_DART_B64 }}
+        run: |
+          cd app
+          if [[ -n "$FIREBASE_OPTIONS_DART_B64" ]]; then
+            echo "$FIREBASE_OPTIONS_DART_B64" | base64 -d > lib/firebase_options.dart
+            echo "Using FIREBASE_OPTIONS_DART_B64."
+          else
+            cp lib/firebase_options.dart.template lib/firebase_options.dart
+            echo "::warning::FIREBASE_OPTIONS_DART_B64 is not set; using placeholder firebase_options.dart."
+          fi
 
       - name: Build Web
         run: |

--- a/.github/workflows/local-checks.yml
+++ b/.github/workflows/local-checks.yml
@@ -39,6 +39,19 @@ jobs:
           cd app
           flutter pub get
 
+      - name: Configure firebase_options.dart
+        env:
+          FIREBASE_OPTIONS_DART_B64: ${{ secrets.FIREBASE_OPTIONS_DART_B64 }}
+        run: |
+          cd app
+          if [[ -n "$FIREBASE_OPTIONS_DART_B64" ]]; then
+            echo "$FIREBASE_OPTIONS_DART_B64" | base64 -d > lib/firebase_options.dart
+            echo "Using FIREBASE_OPTIONS_DART_B64."
+          else
+            cp lib/firebase_options.dart.template lib/firebase_options.dart
+            echo "::warning::FIREBASE_OPTIONS_DART_B64 is not set; using placeholder firebase_options.dart."
+          fi
+
       - name: Check formatting
         run: |
           cd app
@@ -71,6 +84,19 @@ jobs:
           cd app
           flutter pub get
 
+      - name: Configure firebase_options.dart
+        env:
+          FIREBASE_OPTIONS_DART_B64: ${{ secrets.FIREBASE_OPTIONS_DART_B64 }}
+        run: |
+          cd app
+          if [[ -n "$FIREBASE_OPTIONS_DART_B64" ]]; then
+            echo "$FIREBASE_OPTIONS_DART_B64" | base64 -d > lib/firebase_options.dart
+            echo "Using FIREBASE_OPTIONS_DART_B64."
+          else
+            cp lib/firebase_options.dart.template lib/firebase_options.dart
+            echo "::warning::FIREBASE_OPTIONS_DART_B64 is not set; using placeholder firebase_options.dart."
+          fi
+
       - name: Run analyzer
         run: |
           cd app
@@ -92,6 +118,19 @@ jobs:
         run: |
           cd app
           flutter pub get
+
+      - name: Configure firebase_options.dart
+        env:
+          FIREBASE_OPTIONS_DART_B64: ${{ secrets.FIREBASE_OPTIONS_DART_B64 }}
+        run: |
+          cd app
+          if [[ -n "$FIREBASE_OPTIONS_DART_B64" ]]; then
+            echo "$FIREBASE_OPTIONS_DART_B64" | base64 -d > lib/firebase_options.dart
+            echo "Using FIREBASE_OPTIONS_DART_B64."
+          else
+            cp lib/firebase_options.dart.template lib/firebase_options.dart
+            echo "::warning::FIREBASE_OPTIONS_DART_B64 is not set; using placeholder firebase_options.dart."
+          fi
 
       - name: Run tests
         run: |
@@ -121,6 +160,19 @@ jobs:
         run: |
           cd app
           flutter pub get
+
+      - name: Configure firebase_options.dart
+        env:
+          FIREBASE_OPTIONS_DART_B64: ${{ secrets.FIREBASE_OPTIONS_DART_B64 }}
+        run: |
+          cd app
+          if [[ -n "$FIREBASE_OPTIONS_DART_B64" ]]; then
+            echo "$FIREBASE_OPTIONS_DART_B64" | base64 -d > lib/firebase_options.dart
+            echo "Using FIREBASE_OPTIONS_DART_B64."
+          else
+            cp lib/firebase_options.dart.template lib/firebase_options.dart
+            echo "::warning::FIREBASE_OPTIONS_DART_B64 is not set; using placeholder firebase_options.dart."
+          fi
 
       - name: Check formatting
         run: |

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -124,6 +124,19 @@ jobs:
           dart run build_runner clean
           dart run build_runner build --delete-conflicting-outputs
 
+      - name: Configure firebase_options.dart
+        env:
+          FIREBASE_OPTIONS_DART_B64: ${{ secrets.FIREBASE_OPTIONS_DART_B64 }}
+        run: |
+          cd app
+          if [[ -n "$FIREBASE_OPTIONS_DART_B64" ]]; then
+            echo "$FIREBASE_OPTIONS_DART_B64" | base64 -d > lib/firebase_options.dart
+            echo "Using FIREBASE_OPTIONS_DART_B64."
+          else
+            cp lib/firebase_options.dart.template lib/firebase_options.dart
+            echo "::warning::FIREBASE_OPTIONS_DART_B64 is not set; using placeholder firebase_options.dart."
+          fi
+
       - name: Run Flutter Analyze
         run: |
           cd app

--- a/.github/workflows/release-device-qualification.yml
+++ b/.github/workflows/release-device-qualification.yml
@@ -90,6 +90,19 @@ jobs:
           wait
           cd app && flutter pub get
 
+      - name: Configure firebase_options.dart
+        env:
+          FIREBASE_OPTIONS_DART_B64: ${{ secrets.FIREBASE_OPTIONS_DART_B64 }}
+        run: |
+          cd app
+          if [[ -n "$FIREBASE_OPTIONS_DART_B64" ]]; then
+            echo "$FIREBASE_OPTIONS_DART_B64" | base64 -d > lib/firebase_options.dart
+            echo "Using FIREBASE_OPTIONS_DART_B64."
+          else
+            cp lib/firebase_options.dart.template lib/firebase_options.dart
+            echo "::warning::FIREBASE_OPTIONS_DART_B64 is not set; using placeholder firebase_options.dart."
+          fi
+
       - name: Analyze app
         run: |
           cd app

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -74,7 +74,20 @@ jobs:
         run: |
           cd app
           flutter pub get
-      
+
+      - name: Configure firebase_options.dart
+        env:
+          FIREBASE_OPTIONS_DART_B64: ${{ secrets.FIREBASE_OPTIONS_DART_B64 }}
+        run: |
+          cd app
+          if [[ -n "$FIREBASE_OPTIONS_DART_B64" ]]; then
+            echo "$FIREBASE_OPTIONS_DART_B64" | base64 -d > lib/firebase_options.dart
+            echo "Using FIREBASE_OPTIONS_DART_B64."
+          else
+            cp lib/firebase_options.dart.template lib/firebase_options.dart
+            echo "::warning::FIREBASE_OPTIONS_DART_B64 is not set; using placeholder firebase_options.dart."
+          fi
+
       - name: Build Debug APK
         id: build_debug_apk
         run: |


### PR DESCRIPTION
## Summary
Fixes a regression from #910 that's currently breaking `ci.yml` on main (build-android mobile-full, analyze, and others all failing with `Error: Error when reading 'lib/firebase_options.dart': No such file or directory`).

#910 untracked `app/lib/firebase_options.dart` and added the copy-from-secret-or-template injection step to the three release workflows (`airo-tv-release.yml`, `airo-mobile-tablet-release.yml`, `build-and-release.yml`), but missed every other workflow that compiles/analyzes/tests `app/` against its default `lib/main.dart` entrypoint (which imports `firebase_options.dart`):

- `ci.yml` — `build-android` job (mobile-full/mobile-streaming/tv all import it), `analyze`, `test-app`, `build-web`
- `airo-macos-release.yml` — targets `lib/main_tv.dart`, also imports it
- `pr-checks.yml`, `release-device-qualification.yml`, `smoke-tests.yml`, `local-checks.yml`

Same pattern as #910: write the real file from `FIREBASE_OPTIONS_DART_B64` when the secret is set, else fall back to the checked-in placeholder template.

## Test plan
- [x] YAML validated for all 6 modified workflow files
- [x] Verified locally by reproducing the exact CI condition (fresh worktree, no `firebase_options.dart` on disk): `flutter analyze lib/main.dart` fails with the reported error without the fix, passes clean after `cp lib/firebase_options.dart.template lib/firebase_options.dart`
- [ ] Will confirm `ci.yml` goes green on this branch's PR checks