### PR TITLE
fix(app): restore real cast controller in TV entrypoint (Pixel 9 casting regression)

### DIFF
--- a/app/lib/main_tv.dart
+++ b/app/lib/main_tv.dart
@@ -25,6 +25,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/semantics.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_riverpod/misc.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
@@ -36,6 +37,7 @@ import 'core/platform/device_form_factor.dart';
 import 'core/providers/app_theme_provider.dart';
 import 'core/startup/deferred_startup_task.dart';
 import 'package:feature_iptv/feature_iptv.dart';
+import 'features/iptv/iptv_cast_provider_override.dart';
 import 'features/iptv/iptv_feature_module.dart';
 import 'firebase_options.dart';
 
@@ -86,22 +88,11 @@ void main() async {
 
   runApp(
     ProviderScope(
-      overrides: [
-        sharedPreferencesProvider.overrideWithValue(prefs),
-        // Airo TV defaults to the design handoff's dedicated theme unless
-        // the user has explicitly picked a different one in Settings.
-        appThemeProvider.overrideWith(
-          (ref) => AppThemeNotifier(defaultThemeId: AppThemeId.airoTv),
-        ),
-        compactEpgRepositoryProvider.overrideWithValue(compactEpgRepository),
-        mutableXmltvCompactEpgRepositoryProvider.overrideWithValue(
-          mutableXmltvRepository,
-        ),
-        secureStoreProvider.overrideWithValue(
-          SecureStoreFactory.createSecure(),
-        ),
-        ...FeatureRegistry.allProviderOverrides,
-      ],
+      overrides: buildTvProviderOverrides(
+        prefs: prefs,
+        compactEpgRepository: compactEpgRepository,
+        mutableXmltvRepository: mutableXmltvRepository,
+      ),
       child: const AiroTvApp(),
     ),
   );
@@ -113,6 +104,32 @@ void main() async {
   }
   scheduleTvDebugDefaultEpgWarmup(prefs, repository: compactEpgRepository);
   scheduleTvXmltvSourceRefresh(prefs, repository: mutableXmltvRepository);
+}
+
+@visibleForTesting
+List<Override> buildTvProviderOverrides({
+  required SharedPreferences prefs,
+  required CompactEpgRepository compactEpgRepository,
+  required MutableXmltvCompactEpgRepository mutableXmltvRepository,
+}) {
+  return [
+    sharedPreferencesProvider.overrideWithValue(prefs),
+    // Airo TV defaults to the design handoff's dedicated theme unless
+    // the user has explicitly picked a different one in Settings.
+    appThemeProvider.overrideWith(
+      (ref) => AppThemeNotifier(defaultThemeId: AppThemeId.airoTv),
+    ),
+    compactEpgRepositoryProvider.overrideWithValue(compactEpgRepository),
+    mutableXmltvCompactEpgRepositoryProvider.overrideWithValue(
+      mutableXmltvRepository,
+    ),
+    secureStoreProvider.overrideWithValue(SecureStoreFactory.createSecure()),
+    // Phones running the TV build fall back to the mobile IPTV screen
+    // (tv_router.dart compact layout), whose cast UI needs the real
+    // controller — without this override casting silently no-ops.
+    realIptvCastControllerOverride(),
+    ...FeatureRegistry.allProviderOverrides,
+  ];
 }
 
 @visibleForTesting

--- a/app/test/main_tv_cast_override_test.dart
+++ b/app/test/main_tv_cast_override_test.dart
@@ -1,0 +1,35 @@
+import 'package:airo_app/main_tv.dart';
+import 'package:feature_iptv/feature_iptv.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test(
+    'TV entrypoint wires a real cast controller — phones running the TV build '
+    'render the mobile IPTV screen whose cast UI needs it',
+    () async {
+      SharedPreferences.setMockInitialValues({});
+      final prefs = await SharedPreferences.getInstance();
+      final mutableRepo = MutableXmltvCompactEpgRepository();
+
+      final container = ProviderContainer(
+        overrides: buildTvProviderOverrides(
+          prefs: prefs,
+          compactEpgRepository: createTvCompactEpgRepository(
+            fallback: mutableRepo,
+          ),
+          mutableXmltvRepository: mutableRepo,
+        ),
+      );
+      addTearDown(container.dispose);
+
+      expect(
+        container.read(airoCastControllerProvider),
+        isA<FlutterChromeCastController>(),
+      );
+    },
+  );
+}


### PR DESCRIPTION
## Summary
- Casting broke on Pixel 9 in airo-tv-v0.0.4-rc.2. Root cause: 1f9059c2 removed `realIptvCastControllerOverride()` from `main_tv.dart` assuming TV screens have no cast UI consumers.
- That assumption misses the adaptive path: phones running the TV build (`width < 900 || height < 600`) render the mobile `IPTVScreen` via `tv_router.dart`, whose cast button then resolves the default `UnavailableAiroCastController` — casting silently no-ops.
- Fix restores the override and extracts `buildTvProviderOverrides()` (`@visibleForTesting`) so the wiring is regression-tested.

## Test plan
- [x] New `app/test/main_tv_cast_override_test.dart` asserts TV overrides yield `FlutterChromeCastController` (verified red without fix, green with)
- [x] `flutter analyze` clean on touched files; `dart format` clean
- [ ] Device dogfood: cast from Pixel 9 on next RC build

🤖 Generated with [Claude Code](https://claude.com/claude-code)