### PR TITLE
fix(feature_iptv): search shows matching channel list instead of auto-playing

### DIFF
--- a/packages/feature_iptv/lib/presentation/screens/iptv_screen.dart
+++ b/packages/feature_iptv/lib/presentation/screens/iptv_screen.dart
@@ -231,14 +231,57 @@ class _IPTVScreenState extends ConsumerState<IPTVScreen> {
                     onChanged: (value) =>
                         ref.read(channelSearchQueryProvider.notifier).state =
                             value,
-                    onSubmitted: (value) async {
-                      final played = await _playSearchAction(value);
-                      if (!context.mounted) return;
-                      if (played) {
-                        Navigator.of(context).pop();
-                      }
+                    onSubmitted: (value) {
+                      // Submitting applies the filter and keeps the results
+                      // list visible — playback stays behind an explicit
+                      // result tap or the Play button so users can browse
+                      // matches first.
+                      ref.read(channelSearchQueryProvider.notifier).state =
+                          value.trim();
                     },
                   ),
+                ),
+                Consumer(
+                  builder: (context, ref, _) {
+                    final query = ref.watch(channelSearchQueryProvider);
+                    if (query.trim().isEmpty) {
+                      return const SizedBox.shrink();
+                    }
+                    final matches = ref.watch(filteredChannelsProvider);
+                    if (matches.isEmpty) {
+                      return Padding(
+                        padding: const EdgeInsets.only(top: 12),
+                        child: Text('No channels match "$query"'),
+                      );
+                    }
+                    return ConstrainedBox(
+                      constraints: const BoxConstraints(maxHeight: 280),
+                      child: ListView.builder(
+                        shrinkWrap: true,
+                        itemCount: matches.length,
+                        itemBuilder: (context, index) {
+                          final channel = matches[index];
+                          return ListTile(
+                            leading: const Icon(Icons.live_tv),
+                            title: Text(
+                              channel.name,
+                              maxLines: 1,
+                              overflow: TextOverflow.ellipsis,
+                            ),
+                            subtitle: Text(
+                              channel.group,
+                              maxLines: 1,
+                              overflow: TextOverflow.ellipsis,
+                            ),
+                            onTap: () {
+                              _playChannel(channel);
+                              Navigator.of(context).pop();
+                            },
+                          );
+                        },
+                      ),
+                    );
+                  },
                 ),
                 const SizedBox(height: 12),
                 Row(

--- a/packages/feature_iptv/test/iptv/presentation/screens/iptv_screen_test.dart
+++ b/packages/feature_iptv/test/iptv/presentation/screens/iptv_screen_test.dart
@@ -536,4 +536,92 @@ void main() {
       expect(find.text('Play on TV'), findsNothing);
     },
   );
+
+  testWidgets(
+    'searching lists matching channels in the sheet instead of auto-playing '
+    'the single match; tapping a result plays it',
+    (tester) async {
+      final playedChannels = <IPTVChannel>[];
+      final fakeService = _RecordingStreamingService(played: playedChannels);
+
+      await tester.pumpWidget(
+        createWidget(
+          extraOverrides: [
+            // overrideWith (not overrideWithValue) so ref.onDispose cancels
+            // the periodic metrics timer started by initialize() before the
+            // pending-timer invariant check runs.
+            iptvStreamingServiceProvider.overrideWith((ref) {
+              ref.onDispose(() => fakeService.dispose());
+              return fakeService;
+            }),
+          ],
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byTooltip('Search channels'));
+      await tester.pumpAndSettle();
+
+      await tester.enterText(find.byType(TextField).last, 'City News');
+      await tester.testTextInput.receiveAction(TextInputAction.done);
+      await tester.pumpAndSettle();
+
+      // Single name match must NOT auto-play; the sheet stays open and
+      // lists the matching channel instead.
+      expect(playedChannels, isEmpty);
+      expect(find.text('Search channels'), findsOneWidget);
+      expect(find.widgetWithText(ListTile, 'City News Live'), findsOneWidget);
+
+      await tester.tap(find.widgetWithText(ListTile, 'City News Live'));
+      await tester.pumpAndSettle();
+
+      expect(playedChannels, hasLength(1));
+      expect(playedChannels.single.id, 'news-1');
+      expect(find.text('Search channels'), findsNothing);
+    },
+  );
+
+  testWidgets('search sheet Play button still plays the single match', (
+    tester,
+  ) async {
+    final playedChannels = <IPTVChannel>[];
+    final fakeService = _RecordingStreamingService(played: playedChannels);
+
+    await tester.pumpWidget(
+      createWidget(
+        extraOverrides: [
+          iptvStreamingServiceProvider.overrideWith((ref) {
+            ref.onDispose(() => fakeService.dispose());
+            return fakeService;
+          }),
+        ],
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byTooltip('Search channels'));
+    await tester.pumpAndSettle();
+
+    await tester.enterText(find.byType(TextField).last, 'City News');
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Play'));
+    await tester.pumpAndSettle();
+
+    expect(playedChannels, hasLength(1));
+    expect(playedChannels.single.id, 'news-1');
+  });
+}
+
+/// Streaming service double that records [playChannel] calls without touching
+/// the real playback engine.
+class _RecordingStreamingService extends VideoPlayerStreamingService {
+  _RecordingStreamingService({required this.played})
+    : super(engine: FakeAiroPlaybackEngine());
+
+  final List<IPTVChannel> played;
+
+  @override
+  Future<void> playChannel(IPTVChannel channel) async {
+    played.add(channel);
+  }
 }


### PR DESCRIPTION
## Summary
- Bug: after search, users couldn't see matching channels — a single name match auto-played immediately, otherwise a natural-language resolver played a "best guess". The rail-based browse UI (#922) never consumed `channelSearchQueryProvider`, so the applied filter had no visible surface.
- Fix: the search sheet now renders a live results list (`filteredChannelsProvider`) under the field. Tapping a result plays it and closes the sheet. Keyboard submit applies the filter and keeps the list visible. The explicit **Play** button retains the previous play-single-match shortcut.

## Test plan
- [x] New widget test: single name match does not auto-play; matching channel listed; tapping it plays and closes sheet
- [x] New widget test: Play button still plays the single match
- [x] Full `feature_iptv` suite: 366 tests pass
- [x] `dart format` clean; analyze has one pre-existing unused-import warning untouched by this diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)