### PR TITLE
fix(feature_iptv): EPG guide time ruler shows local time instead of UTC

### DIFF
--- a/packages/feature_iptv/lib/presentation/widgets/epg_timeline_grid.dart
+++ b/packages/feature_iptv/lib/presentation/widgets/epg_timeline_grid.dart
@@ -172,7 +172,8 @@ class _TimeAxis extends StatelessWidget {
             left: i * 60 * pxPerMinute,
             child: Text(
               TimeOfDay.fromDateTime(
-                windowStart.add(Duration(hours: i)),
+                // windowStart is UTC; labels must show the viewer's clock.
+                windowStart.add(Duration(hours: i)).toLocal(),
               ).format(context),
               style: baseStyle?.copyWith(
                 fontSize: (baseStyle.fontSize ?? 11) * textScaleFactor,

--- a/packages/feature_iptv/test/iptv/presentation/widgets/epg_timeline_grid_test.dart
+++ b/packages/feature_iptv/test/iptv/presentation/widgets/epg_timeline_grid_test.dart
@@ -347,4 +347,63 @@ void main() {
       expect(tester.takeException(), isNull);
     },
   );
+
+  testWidgets('time ruler shows the window start in local time, not UTC', (
+    tester,
+  ) async {
+    final windowStart = DateTime.utc(2026, 7, 17, 11);
+    final window = CompactEpgWindow(
+      entries: const [],
+      windowStart: windowStart,
+      windowEnd: windowStart.add(const Duration(hours: 3)),
+      generatedAt: windowStart,
+      expiresAt: windowStart.add(const Duration(hours: 1)),
+      source: CompactEpgSliceSource.localCache,
+    );
+    final prefs = await SharedPreferences.getInstance();
+    final container = ProviderContainer(
+      overrides: [
+        sharedPreferencesProvider.overrideWithValue(prefs),
+        iptvChannelsProvider.overrideWith((ref) async => [channel]),
+        guideEpgWindowProvider.overrideWith((ref) async => window),
+        guideWindowStartProvider.overrideWithValue(windowStart),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: const MaterialApp(
+          home: MediaQuery(
+            data: MediaQueryData(
+              size: Size(1280, 720),
+              navigationMode: NavigationMode.directional,
+            ),
+            child: Scaffold(
+              body: SizedBox(
+                width: 1280,
+                height: 720,
+                child: EpgTimelineGrid(),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+
+    final context = tester.element(find.byType(EpgTimelineGrid));
+    final localLabel = TimeOfDay.fromDateTime(
+      windowStart.toLocal(),
+    ).format(context);
+    expect(find.text(localLabel), findsOneWidget);
+
+    // Guard against regressing to raw-UTC labels on machines where local
+    // time differs from UTC (no-op on UTC CI runners).
+    final utcLabel = TimeOfDay.fromDateTime(windowStart).format(context);
+    if (utcLabel != localLabel) {
+      expect(find.text(utcLabel), findsNothing);
+    }
+  });
 }


### PR DESCRIPTION
## Summary
- Bug: guide timeline "always starts at 11 AM". Root cause: `_TimeRulerRow` formatted the UTC `guideWindowStartProvider` value directly via `TimeOfDay.fromDateTime` — afternoon IST is ~11:00 UTC, so the ruler always showed UTC hours.
- Fix: convert each ruler tick to `.toLocal()` before formatting. Program block positions are computed from durations against `windowStart` and were already timezone-correct.

## Test plan
- [x] New widget test overrides `guideWindowStartProvider` with a fixed UTC instant and asserts the rendered label is the local formatting (and that the raw-UTC label is absent when the machine's zone differs — verified red before fix on IST)
- [x] Full `feature_iptv` suite passes (365 tests); analyze/format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)