### PR TITLE
fix(feature_iptv): display no longer sleeps during playback (wakelock decoupled from player widget)

### DIFF
--- a/packages/feature_iptv/lib/application/wakelock_playback_coordinator.dart
+++ b/packages/feature_iptv/lib/application/wakelock_playback_coordinator.dart
@@ -1,0 +1,85 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:platform_player/platform_player.dart';
+import 'package:wakelock_plus/wakelock_plus.dart';
+
+import '../domain/wakelock_debouncer.dart';
+import 'providers/iptv_providers.dart';
+
+/// Holds the OS wakelock while video is actually playing, independent of any
+/// player widget's lifetime.
+///
+/// The previous widget-level approach released the wakelock whenever
+/// [VideoPlayerWidget] was disposed — which happens when the featured player
+/// scrolls out of a lazy viewport or playback continues under the mini
+/// player — so the display slept mid-stream.
+class WakelockPlaybackCoordinator {
+  WakelockPlaybackCoordinator({
+    WakelockDebouncer? debouncer,
+    Future<void> Function()? enable,
+    Future<void> Function()? disable,
+  }) : _debouncer = debouncer ?? WakelockDebouncer(),
+       _enable = enable ?? WakelockPlus.enable,
+       _disable = disable ?? WakelockPlus.disable;
+
+  final WakelockDebouncer _debouncer;
+  final Future<void> Function() _enable;
+  final Future<void> Function() _disable;
+
+  bool _held = false;
+
+  @visibleForTesting
+  bool get isHeld => _held;
+
+  /// Video actively playing on a non-audio-only channel holds the wakelock.
+  static bool shouldHoldWakelock(StreamingState state) {
+    final channel = state.currentChannel;
+    return state.isPlaying && channel != null && !channel.isAudioOnly;
+  }
+
+  void update(StreamingState state) {
+    _debouncer.update(
+      current: _held,
+      target: shouldHoldWakelock(state),
+      onSettled: (target) => unawaited(target ? _acquire() : _release()),
+    );
+  }
+
+  Future<void> _acquire() async {
+    if (_held) return;
+    try {
+      await _enable();
+      _held = true;
+    } catch (e) {
+      debugPrint('Failed to enable wakelock: $e');
+    }
+  }
+
+  Future<void> _release() async {
+    if (!_held) return;
+    try {
+      await _disable();
+      _held = false;
+    } catch (e) {
+      debugPrint('Failed to disable wakelock: $e');
+    }
+  }
+
+  void dispose() {
+    _debouncer.cancel();
+    unawaited(_release());
+  }
+}
+
+final wakelockPlaybackCoordinatorProvider =
+    Provider<WakelockPlaybackCoordinator>((ref) {
+      final coordinator = WakelockPlaybackCoordinator();
+      ref.onDispose(coordinator.dispose);
+      ref.listen(streamingStateProvider, (previous, next) {
+        final state = next.value;
+        if (state != null) coordinator.update(state);
+      });
+      return coordinator;
+    });

--- a/packages/feature_iptv/lib/presentation/screens/iptv_screen.dart
+++ b/packages/feature_iptv/lib/presentation/screens/iptv_screen.dart
@@ -7,6 +7,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_riverpod/legacy.dart';
 import 'package:core_ui/core_ui.dart';
 import '../../application/providers/iptv_providers.dart';
+import '../../application/wakelock_playback_coordinator.dart';
 import '../../application/providers/rails_provider.dart';
 import "package:platform_channels/platform_channels.dart";
 import "package:platform_player/platform_player.dart";
@@ -51,6 +52,9 @@ class _IPTVScreenState extends ConsumerState<IPTVScreen> {
     super.initState();
     // Initialize streaming service
     ref.read(iptvStreamingServiceProvider).initialize();
+    // Screen-level wakelock: survives the featured player widget being
+    // scrolled out of the viewport or playback moving to the mini player.
+    ref.read(wakelockPlaybackCoordinatorProvider);
   }
 
   @override
@@ -430,6 +434,9 @@ class _IPTVScreenBodyState extends ConsumerState<IPTVScreenBody> {
     super.initState();
     // Initialize streaming service
     ref.read(iptvStreamingServiceProvider).initialize();
+    // Screen-level wakelock: survives the featured player widget being
+    // scrolled out of the viewport or playback moving to the mini player.
+    ref.read(wakelockPlaybackCoordinatorProvider);
   }
 
   @override

--- a/packages/feature_iptv/lib/presentation/tv/iptv_tv_screen.dart
+++ b/packages/feature_iptv/lib/presentation/tv/iptv_tv_screen.dart
@@ -11,6 +11,7 @@ import 'package:platform_player/platform_player.dart';
 import 'package:product_capabilities/product_capabilities.dart';
 
 import '../../application/providers/iptv_providers.dart';
+import '../../application/wakelock_playback_coordinator.dart';
 import '../../application/providers/rails_provider.dart';
 import '../../application/services/airo_macos_update_service.dart';
 import '../screens/iptv_screen.dart';
@@ -37,6 +38,8 @@ class _IptvTvScreenState extends ConsumerState<IptvTvScreen> {
   void initState() {
     super.initState();
     ref.read(iptvStreamingServiceProvider).initialize();
+    // Screen-level wakelock: independent of any player widget's lifetime.
+    ref.read(wakelockPlaybackCoordinatorProvider);
   }
 
   void _playChannel(IPTVChannel channel) {

--- a/packages/feature_iptv/lib/presentation/widgets/video_player_widget.dart
+++ b/packages/feature_iptv/lib/presentation/widgets/video_player_widget.dart
@@ -3,12 +3,10 @@ import 'package:core_ui/core_ui.dart';
 import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:wakelock_plus/wakelock_plus.dart';
 import '../../application/providers/caption_preference_provider.dart';
 import '../../application/providers/iptv_providers.dart';
 import '../../application/providers/video_aspect_ratio_provider.dart';
 import '../../domain/vod_resume_coordinator.dart';
-import '../../domain/wakelock_debouncer.dart';
 import 'playback_diagnostic_overlay.dart';
 import "package:platform_player/platform_player.dart";
 import "package:platform_media/platform_media.dart";
@@ -55,8 +53,6 @@ class _VideoPlayerWidgetState extends ConsumerState<VideoPlayerWidget> {
   bool _isCinemaMode = false;
   Timer? _hideControlsTimer;
   static const _controlsHideDelay = Duration(seconds: 4);
-  bool _wakelockEnabled = false;
-  final _wakelockDebouncer = WakelockDebouncer();
 
   // Channel change overlay state
   String? _channelChangeOverlayText;
@@ -79,8 +75,8 @@ class _VideoPlayerWidgetState extends ConsumerState<VideoPlayerWidget> {
         widget.brightnessController ?? SystemPlayerBrightnessController();
     _loadInitialBrightness();
     _startHideControlsTimer();
-    // Note: Wakelock is now managed by _updateWakelockForPlayback
-    // based on actual playback state, not just widget mount
+    // Wakelock is managed by WakelockPlaybackCoordinator at screen scope,
+    // not by this widget's lifetime.
   }
 
   Future<void> _loadInitialBrightness() async {
@@ -97,8 +93,6 @@ class _VideoPlayerWidgetState extends ConsumerState<VideoPlayerWidget> {
   void dispose() {
     _cancelHideControlsTimer();
     _channelChangeOverlayTimer?.cancel();
-    _wakelockDebouncer.cancel();
-    _disableWakelock();
     unawaited(_resetBrightnessSafely());
     super.dispose();
   }
@@ -119,60 +113,6 @@ class _VideoPlayerWidgetState extends ConsumerState<VideoPlayerWidget> {
       await _brightnessController.setBrightness(value);
     } catch (e) {
       debugPrint('Failed to set brightness: $e');
-    }
-  }
-
-  /// Update wakelock based on playback state
-  /// Enable only when video is actively playing (not audio-only)
-  ///
-  /// Debounced via [WakelockDebouncer]: a single buffering tick shouldn't
-  /// flip the OS wakelock, only a target that holds steady does.
-  void _updateWakelockForPlayback(StreamingState state) {
-    if (!mounted) return;
-    final isVideoPlaying =
-        state.isPlaying &&
-        state.currentChannel != null &&
-        !state.currentChannel!.isAudioOnly;
-
-    _wakelockDebouncer.update(
-      current: _wakelockEnabled,
-      target: isVideoPlaying,
-      onSettled: (target) {
-        if (!mounted) return;
-        if (target) {
-          _enableWakelock();
-        } else {
-          _disableWakelock();
-        }
-      },
-    );
-  }
-
-  /// Enable screen wake lock to prevent screen from going off during video playback
-  Future<void> _enableWakelock() async {
-    if (!_wakelockEnabled) {
-      try {
-        await WakelockPlus.enable();
-        _wakelockEnabled = true;
-        debugPrint(
-          'Wakelock enabled - screen will stay on during video playback',
-        );
-      } catch (e) {
-        debugPrint('Failed to enable wakelock: $e');
-      }
-    }
-  }
-
-  /// Disable screen wake lock when video is stopped or widget is disposed
-  Future<void> _disableWakelock() async {
-    if (_wakelockEnabled) {
-      try {
-        await WakelockPlus.disable();
-        _wakelockEnabled = false;
-        debugPrint('Wakelock disabled - screen can now sleep');
-      } catch (e) {
-        debugPrint('Failed to disable wakelock: $e');
-      }
     }
   }
 
@@ -309,7 +249,6 @@ class _VideoPlayerWidgetState extends ConsumerState<VideoPlayerWidget> {
     // Update wakelock based on current playback state
     // This is called on every build when state changes
     WidgetsBinding.instance.addPostFrameCallback((_) {
-      _updateWakelockForPlayback(state);
       _handleVodResume(service, state);
       _applyCaptionPreferenceIfNeeded(service, state);
     });
@@ -324,10 +263,7 @@ class _VideoPlayerWidgetState extends ConsumerState<VideoPlayerWidget> {
         // Video display (engine-driven view surface).
         if (videoView != null)
           SizedBox.expand(
-            child: FittedBox(
-              fit: _boxFitFor(aspectRatioFit),
-              child: videoView,
-            ),
+            child: FittedBox(fit: _boxFitFor(aspectRatioFit), child: videoView),
           )
         else if (state.playbackState == PlaybackState.loading)
           _buildLoading()
@@ -360,9 +296,7 @@ class _VideoPlayerWidgetState extends ConsumerState<VideoPlayerWidget> {
         if (state.isBuffering)
           Container(
             color: Colors.black45,
-            child: const CircularProgressIndicator(
-              color: Colors.white,
-            ),
+            child: const CircularProgressIndicator(color: Colors.white),
           ),
       ],
     );
@@ -509,7 +443,9 @@ class _VideoPlayerWidgetState extends ConsumerState<VideoPlayerWidget> {
                       top: 8,
                       right: 56,
                       child: AnimatedOpacity(
-                        opacity: (_isLocked || _showControlsOverlay) ? 1.0 : 0.0,
+                        opacity: (_isLocked || _showControlsOverlay)
+                            ? 1.0
+                            : 0.0,
                         duration: const Duration(milliseconds: 300),
                         child: Container(
                           decoration: BoxDecoration(

--- a/packages/feature_iptv/test/iptv/application/wakelock_playback_coordinator_test.dart
+++ b/packages/feature_iptv/test/iptv/application/wakelock_playback_coordinator_test.dart
@@ -1,0 +1,111 @@
+import 'package:fake_async/fake_async.dart';
+import 'package:feature_iptv/application/wakelock_playback_coordinator.dart';
+import 'package:feature_iptv/domain/wakelock_debouncer.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:platform_channels/platform_channels.dart';
+import 'package:platform_player/platform_player.dart';
+
+void main() {
+  const videoChannel = IPTVChannel(
+    id: 'news-1',
+    name: 'City News Live',
+    streamUrl: 'https://example.com/news.m3u8',
+    group: 'News',
+  );
+  const audioChannel = IPTVChannel(
+    id: 'radio-1',
+    name: 'Radio One',
+    streamUrl: 'https://example.com/radio.m3u8',
+    group: 'Radio',
+    isAudioOnly: true,
+  );
+
+  StreamingState playing(IPTVChannel channel) => StreamingState(
+    playbackState: PlaybackState.playing,
+    currentChannel: channel,
+  );
+
+  ({WakelockPlaybackCoordinator coordinator, List<String> calls}) build() {
+    final calls = <String>[];
+    final coordinator = WakelockPlaybackCoordinator(
+      debouncer: WakelockDebouncer(settleDelay: const Duration(seconds: 2)),
+      enable: () async => calls.add('enable'),
+      disable: () async => calls.add('disable'),
+    );
+    return (coordinator: coordinator, calls: calls);
+  }
+
+  test('acquires wakelock once video playback holds steady', () {
+    fakeAsync((async) {
+      final (:coordinator, :calls) = build();
+
+      coordinator.update(playing(videoChannel));
+      expect(calls, isEmpty, reason: 'debounced — nothing before settle');
+
+      async.elapse(const Duration(seconds: 2));
+      expect(calls, ['enable']);
+      expect(coordinator.isHeld, isTrue);
+    });
+  });
+
+  test('releases wakelock when playback stops', () {
+    fakeAsync((async) {
+      final (:coordinator, :calls) = build();
+
+      coordinator.update(playing(videoChannel));
+      async.elapse(const Duration(seconds: 2));
+
+      coordinator.update(StreamingState());
+      async.elapse(const Duration(seconds: 2));
+
+      expect(calls, ['enable', 'disable']);
+      expect(coordinator.isHeld, isFalse);
+    });
+  });
+
+  test('a transient stutter within the settle delay never flips the lock', () {
+    fakeAsync((async) {
+      final (:coordinator, :calls) = build();
+
+      coordinator.update(playing(videoChannel));
+      async.elapse(const Duration(seconds: 2));
+
+      coordinator.update(
+        StreamingState(
+          playbackState: PlaybackState.buffering,
+          currentChannel: videoChannel,
+        ),
+      );
+      async.elapse(const Duration(seconds: 1));
+      coordinator.update(playing(videoChannel));
+      async.elapse(const Duration(seconds: 5));
+
+      expect(calls, ['enable']);
+    });
+  });
+
+  test('audio-only playback does not hold the wakelock', () {
+    fakeAsync((async) {
+      final (:coordinator, :calls) = build();
+
+      coordinator.update(playing(audioChannel));
+      async.elapse(const Duration(seconds: 5));
+
+      expect(calls, isEmpty);
+    });
+  });
+
+  test('dispose releases a held wakelock', () {
+    fakeAsync((async) {
+      final (:coordinator, :calls) = build();
+
+      coordinator.update(playing(videoChannel));
+      async.elapse(const Duration(seconds: 2));
+
+      coordinator.dispose();
+      async.flushMicrotasks();
+
+      expect(calls, ['enable', 'disable']);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Bug: display turns off even while a stream is playing. Root cause: the wakelock was owned by `VideoPlayerWidget` and released in its `dispose()`. The featured player lives in a lazy scroll viewport — scrolling it off-screen or playing under the mini player disposes the widget, dropping the wakelock mid-stream.
- Fix: new `WakelockPlaybackCoordinator` (screen scope, provider-backed) listens to `streamingStateProvider` and holds the OS wakelock while video is genuinely playing — debounced via the existing `WakelockDebouncer` so buffer stutters don't flip it. `VideoPlayerWidget` no longer manages the wakelock at all. Wired into both the mobile `IPTVScreen` and `IptvTvScreen`.

## Test plan
- [x] 5 new unit tests (fake_async): debounced acquire, release on stop, stutter immunity, audio-only excluded, dispose releases
- [x] Full `feature_iptv` suite: 369 tests pass; format clean; only pre-existing unused-import warnings remain
- [ ] Device dogfood: play stream, lock timeout elapsed, screen stays on; scroll player away — still on

🤖 Generated with [Claude Code](https://claude.com/claude-code)