### PR TITLE
fix(feature_iptv): app bar shows Airo TV branding instead of 'Stream'

### DIFF
--- a/packages/feature_iptv/lib/presentation/screens/iptv_screen.dart
+++ b/packages/feature_iptv/lib/presentation/screens/iptv_screen.dart
@@ -374,7 +374,7 @@ class _IPTVScreenState extends ConsumerState<IPTVScreen> {
             : _playLocalFileOnTv,
       ),
       appBar: AppBar(
-        title: const Text('Stream'),
+        title: const Text('Airo TV'),
         actions: [
           IconButton(
             icon: const Icon(Icons.search),

--- a/packages/feature_iptv/test/iptv/presentation/screens/iptv_screen_test.dart
+++ b/packages/feature_iptv/test/iptv/presentation/screens/iptv_screen_test.dart
@@ -143,13 +143,13 @@ void main() {
     );
   }
 
-  testWidgets('renders Stream app bar, category filters, and live list', (
+  testWidgets('renders Airo TV app bar, category filters, and live list', (
     tester,
   ) async {
     await tester.pumpWidget(createWidget());
     await tester.pumpAndSettle();
 
-    expect(find.text('Stream'), findsOneWidget);
+    expect(find.text('Airo TV'), findsOneWidget);
     expect(find.byTooltip('Search channels'), findsOneWidget);
     expect(find.byTooltip('Cast'), findsOneWidget);
     expect(find.text('All (3)'), findsOneWidget);
@@ -412,7 +412,7 @@ void main() {
     await tester.pumpWidget(createEmptyWidget());
     await tester.pumpAndSettle();
 
-    expect(find.text('Stream'), findsOneWidget);
+    expect(find.text('Airo TV'), findsOneWidget);
     expect(find.byTooltip('Playlist source'), findsOneWidget);
     expect(find.text('Add your playlist'), findsOneWidget);
     expect(


### PR DESCRIPTION
## Summary
- The mobile IPTV screen's app bar title said "Stream"; per product feedback it should carry Airo TV branding. Title changed to "Airo TV" (single call site; go_router route `name` is internal and untouched).

## Test plan
- [x] Updated existing widget test assertions; `iptv_screen_test.dart` all 15 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)