### PR TITLE
fix(app): update stale Playlist Source sheet title assertion

### DIFF
--- a/app/test/features/settings/presentation/screens/settings_hub_screen_test.dart
+++ b/app/test/features/settings/presentation/screens/settings_hub_screen_test.dart
@@ -74,7 +74,7 @@ void main() {
     await tester.tap(find.text('Playlist Source'));
     await tester.pumpAndSettle();
 
-    expect(find.text('Playlist source'), findsOneWidget);
+    expect(find.text('Add Playlist Source'), findsOneWidget);
   });
 
   testWidgets('appearance picker saves selected theme', (tester) async {


### PR DESCRIPTION
## Summary
- PR #922 renamed the playlist-source sheet title from "Playlist source" to "Add Playlist Source" but left `settings_hub_screen_test.dart` asserting the old string, causing a deterministic failure exposed once the sqlite3 fix (#925) unblocked full test-app compilation.
- Updates the assertion to match current UI text. No product code change.

## Test plan
- [x] `flutter test test/features/settings/presentation/screens/settings_hub_screen_test.dart` — all 5 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)