### PR TITLE
fix(app): restore theme options on phone-sized TV builds via adaptive settings route

### DIFF
--- a/app/lib/core/app/tv_router.dart
+++ b/app/lib/core/app/tv_router.dart
@@ -9,6 +9,7 @@ import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 
 import 'package:feature_iptv/feature_iptv.dart';
+import '../../features/settings/presentation/screens/settings_hub_screen.dart';
 import '../../features/settings/presentation/tv/tv_settings_screen.dart';
 import 'tv_shell.dart';
 
@@ -97,12 +98,28 @@ class TvRouter {
             GoRoute(
               path: TvRouteNames.settings,
               name: 'tv_settings',
-              builder: (context, state) => const TvSettingsScreen(),
+              builder: (context, state) => const AdaptiveTvSettingsScreen(),
             ),
           ],
         ),
       ],
     );
+  }
+}
+
+/// Phones running the TV build get the mobile settings hub (theme picker,
+/// audio/playback links); the two-pane [TvSettingsScreen] needs 10-foot
+/// width and clips on compact portrait layouts.
+class AdaptiveTvSettingsScreen extends StatelessWidget {
+  const AdaptiveTvSettingsScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    if (_usesCompactPhoneLayout(context)) {
+      return const SettingsHubScreen();
+    }
+
+    return const TvSettingsScreen();
   }
 }
 

--- a/app/test/adaptive_tv_settings_screen_test.dart
+++ b/app/test/adaptive_tv_settings_screen_test.dart
@@ -1,0 +1,68 @@
+import 'package:airo_app/core/app/tv_router.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:feature_iptv/feature_iptv.dart';
+
+void main() {
+  Widget wrap(Size size) {
+    SharedPreferences.setMockInitialValues({});
+    return FutureBuilder<SharedPreferences>(
+      future: SharedPreferences.getInstance(),
+      builder: (context, snapshot) {
+        if (!snapshot.hasData) {
+          return const MaterialApp(home: SizedBox());
+        }
+        return ProviderScope(
+          overrides: [
+            sharedPreferencesProvider.overrideWithValue(snapshot.data!),
+          ],
+          child: MaterialApp(
+            home: MediaQuery(
+              data: MediaQueryData(size: size),
+              child: const AdaptiveTvSettingsScreen(),
+            ),
+          ),
+        );
+      },
+    );
+  }
+
+  testWidgets('phone-sized layout shows the settings hub with theme picker', (
+    tester,
+  ) async {
+    tester.view.physicalSize = const Size(400, 850);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.reset);
+
+    await tester.pumpWidget(wrap(const Size(400, 850)));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Appearance'), findsOneWidget);
+    expect(find.text('Airo Classic'), findsOneWidget);
+    expect(
+      find.byWidgetPredicate((w) => w is RadioListTile),
+      findsWidgets,
+      reason: 'theme options must be selectable on phones',
+    );
+  });
+
+  testWidgets('TV-sized layout keeps the two-pane TV settings screen', (
+    tester,
+  ) async {
+    tester.view.physicalSize = const Size(1280, 720);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.reset);
+
+    await tester.pumpWidget(wrap(const Size(1280, 720)));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Appearance'), findsNothing);
+    expect(
+      find.byKey(const ValueKey('tv_settings_section_theme')),
+      findsOneWidget,
+    );
+  });
+}


### PR DESCRIPTION
## Summary
- Bug: settings page lost its multiple-theme options. Root cause: the TV `/settings` route always rendered the two-pane `TvSettingsScreen` (10-foot layout); on phones running the TV APK it clips and the theme section is unreachable.
- Fix: `AdaptiveTvSettingsScreen` — compact phone layouts (<900×600, same predicate as `_AdaptiveLiveTvScreen`) get the mobile `SettingsHubScreen` with its 4-theme radio picker; TV-sized layouts keep the two-pane screen.

## Test plan
- [x] New widget tests: phone size → Appearance section + theme radios present; TV size → `tv_settings_section_theme` pane present
- [x] analyze/format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)