### PR TITLE
feat(rails): restore recently-watched cards via a Recently Watched browse rail

### DIFF
--- a/packages/feature_iptv/lib/application/providers/rails_provider.dart
+++ b/packages/feature_iptv/lib/application/providers/rails_provider.dart
@@ -17,9 +17,18 @@ final railsProvider = FutureProvider<List<RailResult>>((ref) async {
     favorites = const <IPTVChannel>[];
   }
 
+  List<IPTVChannel> recents;
+  try {
+    recents = await ref.watch(recentlyWatchedChannelsProvider.future);
+  } catch (_) {
+    // Recents are an enhancement signal; rails must render without them.
+    recents = const <IPTVChannel>[];
+  }
+
   final provider = DefaultRailProvider(
     channels: channels,
     favoriteIds: favorites.map((ch) => ch.id).toSet(),
+    recentIds: [for (final ch in recents) ch.id],
     // Watch counts arrive when core_watch_progress wiring lands
     // (spec §9 — Continue Watching reserved).
   );

--- a/packages/platform_channels/lib/src/models/rail_definition.dart
+++ b/packages/platform_channels/lib/src/models/rail_definition.dart
@@ -18,12 +18,16 @@ class RailQuery extends Equatable {
     this.language,
     this.liveOnly = false,
     this.favoritesOnly = false,
+    this.recentOnly = false,
   });
 
   final ChannelCategory? category;
   final String? language;
   final bool liveOnly;
   final bool favoritesOnly;
+
+  /// Restrict to recently watched channels, ordered by recency.
+  final bool recentOnly;
 
   bool matches(IPTVChannel channel) {
     if (category != null && channel.category != category) return false;
@@ -34,7 +38,13 @@ class RailQuery extends Equatable {
   }
 
   @override
-  List<Object?> get props => [category, language, liveOnly, favoritesOnly];
+  List<Object?> get props => [
+    category,
+    language,
+    liveOnly,
+    favoritesOnly,
+    recentOnly,
+  ];
 }
 
 /// A generated rail: what it's called, what it contains, where it sits.
@@ -65,8 +75,16 @@ class RailDefinition extends Equatable {
   final int maxItems;
 
   @override
-  List<Object?> get props =>
-      [id, title, subtitle, query, priority, visibility, layout, maxItems];
+  List<Object?> get props => [
+    id,
+    title,
+    subtitle,
+    query,
+    priority,
+    visibility,
+    layout,
+    maxItems,
+  ];
 }
 
 /// A built rail ready for rendering.

--- a/packages/platform_channels/lib/src/services/default_rail_provider.dart
+++ b/packages/platform_channels/lib/src/services/default_rail_provider.dart
@@ -7,42 +7,49 @@ class DefaultRailCatalog {
   const DefaultRailCatalog._();
 
   static List<RailDefinition> definitions() => const [
-        RailDefinition(
-          id: 'top-india',
-          title: 'Top India',
-          subtitle: 'Ranked by popularity',
-          query: RailQuery(),
-          priority: 0,
-        ),
-        RailDefinition(
-          id: 'favorites',
-          title: 'Favorites',
-          subtitle: 'Your saved channels',
-          query: RailQuery(favoritesOnly: true),
-          priority: 10,
-        ),
-        RailDefinition(
-          id: 'live-sports',
-          title: 'Live Sports',
-          subtitle: 'Cricket, football and more',
-          query: RailQuery(category: ChannelCategory.sports, liveOnly: true),
-          priority: 20,
-        ),
-        RailDefinition(
-          id: 'hindi-news',
-          title: 'Hindi News',
-          subtitle: 'Breaking news and analysis',
-          query: RailQuery(category: ChannelCategory.news, language: 'hi'),
-          priority: 30,
-        ),
-        RailDefinition(
-          id: 'movies-on-now',
-          title: 'Movies On Now',
-          subtitle: 'Playing right now',
-          query: RailQuery(category: ChannelCategory.movies),
-          priority: 40,
-        ),
-      ];
+    RailDefinition(
+      id: 'top-india',
+      title: 'Top India',
+      subtitle: 'Ranked by popularity',
+      query: RailQuery(),
+      priority: 0,
+    ),
+    RailDefinition(
+      id: 'recently-watched',
+      title: 'Recently Watched',
+      subtitle: 'Jump back in',
+      query: RailQuery(recentOnly: true),
+      priority: 5,
+    ),
+    RailDefinition(
+      id: 'favorites',
+      title: 'Favorites',
+      subtitle: 'Your saved channels',
+      query: RailQuery(favoritesOnly: true),
+      priority: 10,
+    ),
+    RailDefinition(
+      id: 'live-sports',
+      title: 'Live Sports',
+      subtitle: 'Cricket, football and more',
+      query: RailQuery(category: ChannelCategory.sports, liveOnly: true),
+      priority: 20,
+    ),
+    RailDefinition(
+      id: 'hindi-news',
+      title: 'Hindi News',
+      subtitle: 'Breaking news and analysis',
+      query: RailQuery(category: ChannelCategory.news, language: 'hi'),
+      priority: 30,
+    ),
+    RailDefinition(
+      id: 'movies-on-now',
+      title: 'Movies On Now',
+      subtitle: 'Playing right now',
+      query: RailQuery(category: ChannelCategory.movies),
+      priority: 40,
+    ),
+  ];
 }
 
 /// Popularity-scored rail builder using tiered comparison: favorites strictly
@@ -55,11 +62,15 @@ class DefaultRailProvider implements RailProvider {
     required List<IPTVChannel> channels,
     this.favoriteIds = const {},
     this.watchCounts = const {},
+    this.recentIds = const [],
   }) : _channels = channels;
 
   final List<IPTVChannel> _channels;
   final Set<String> favoriteIds;
   final Map<String, int> watchCounts;
+
+  /// Most-recently-watched first; recentOnly rails preserve this order.
+  final List<String> recentIds;
 
   int _compare(IPTVChannel a, IPTVChannel b, Map<String, int> providerIndex) {
     final favA = favoriteIds.contains(a.id) ? 1 : 0;
@@ -73,6 +84,14 @@ class DefaultRailProvider implements RailProvider {
 
   @override
   Future<List<IPTVChannel>> buildRail(RailDefinition rail) async {
+    if (rail.query.recentOnly) {
+      final byId = {for (final ch in _channels) ch.id: ch};
+      return [
+        for (final id in recentIds)
+          if (byId[id] != null && rail.query.matches(byId[id]!)) byId[id]!,
+      ].take(rail.maxItems).toList();
+    }
+
     Iterable<IPTVChannel> pool = _channels.where(rail.query.matches);
     if (rail.query.favoritesOnly) {
       pool = pool.where((ch) => favoriteIds.contains(ch.id));

--- a/packages/platform_channels/test/services/default_rail_provider_test.dart
+++ b/packages/platform_channels/test/services/default_rail_provider_test.dart
@@ -7,24 +7,36 @@ void main() {
   const c = IPTVChannel(id: 'c', name: 'C', streamUrl: 'u');
 
   group('popularity ordering', () {
-    test('favorites outrank watch history, which outranks provider order',
-        () async {
-      final provider = DefaultRailProvider(
-        channels: const [a, b, c],
-        favoriteIds: const {'c'},
-        watchCounts: const {'b': 3},
-      );
-      final rail = await provider.buildRail(const RailDefinition(
-        id: 'top', title: 'Top', query: RailQuery(), priority: 0,
-      ));
-      expect(rail.map((ch) => ch.id).toList(), ['c', 'b', 'a']);
-    });
+    test(
+      'favorites outrank watch history, which outranks provider order',
+      () async {
+        final provider = DefaultRailProvider(
+          channels: const [a, b, c],
+          favoriteIds: const {'c'},
+          watchCounts: const {'b': 3},
+        );
+        final rail = await provider.buildRail(
+          const RailDefinition(
+            id: 'top',
+            title: 'Top',
+            query: RailQuery(),
+            priority: 0,
+          ),
+        );
+        expect(rail.map((ch) => ch.id).toList(), ['c', 'b', 'a']);
+      },
+    );
 
     test('falls back to provider order when no signals', () async {
       final provider = DefaultRailProvider(channels: const [a, b, c]);
-      final rail = await provider.buildRail(const RailDefinition(
-        id: 'top', title: 'Top', query: RailQuery(), priority: 0,
-      ));
+      final rail = await provider.buildRail(
+        const RailDefinition(
+          id: 'top',
+          title: 'Top',
+          query: RailQuery(),
+          priority: 0,
+        ),
+      );
       expect(rail.map((ch) => ch.id).toList(), ['a', 'b', 'c']);
     });
 
@@ -34,9 +46,14 @@ void main() {
         favoriteIds: const {'a'},
         watchCounts: const {'b': 5000},
       );
-      final rail = await provider.buildRail(const RailDefinition(
-        id: 'top', title: 'Top', query: RailQuery(), priority: 0,
-      ));
+      final rail = await provider.buildRail(
+        const RailDefinition(
+          id: 'top',
+          title: 'Top',
+          query: RailQuery(),
+          priority: 0,
+        ),
+      );
       expect(rail.map((ch) => ch.id).toList(), ['a', 'b']);
     });
   });
@@ -46,10 +63,16 @@ void main() {
       final provider = DefaultRailProvider(channels: const [a]);
       final results = await provider.buildAll(const [
         RailDefinition(
-          id: 'second', title: 'Second', query: RailQuery(), priority: 20,
+          id: 'second',
+          title: 'Second',
+          query: RailQuery(),
+          priority: 20,
         ),
         RailDefinition(
-          id: 'first', title: 'First', query: RailQuery(), priority: 10,
+          id: 'first',
+          title: 'First',
+          query: RailQuery(),
+          priority: 10,
         ),
         RailDefinition(
           id: 'empty',
@@ -59,8 +82,7 @@ void main() {
           priority: 0,
         ),
       ]);
-      expect(results.map((r) => r.definition.id).toList(),
-          ['first', 'second']);
+      expect(results.map((r) => r.definition.id).toList(), ['first', 'second']);
     });
 
     test('favoritesOnly excludes non-favorites', () async {
@@ -68,11 +90,54 @@ void main() {
         channels: const [a, b],
         favoriteIds: const {'b'},
       );
-      final rail = await provider.buildRail(const RailDefinition(
-        id: 'fav', title: 'Fav',
-        query: RailQuery(favoritesOnly: true), priority: 0,
-      ));
+      final rail = await provider.buildRail(
+        const RailDefinition(
+          id: 'fav',
+          title: 'Fav',
+          query: RailQuery(favoritesOnly: true),
+          priority: 0,
+        ),
+      );
       expect(rail.map((ch) => ch.id).toList(), ['b']);
+    });
+  });
+
+  group('recentOnly rails', () {
+    test('lists recently watched channels in recency order', () async {
+      final provider = DefaultRailProvider(
+        channels: const [a, b, c],
+        recentIds: const ['b', 'c'],
+      );
+      final rail = await provider.buildRail(
+        const RailDefinition(
+          id: 'recent',
+          title: 'Recently Watched',
+          query: RailQuery(recentOnly: true),
+          priority: 5,
+        ),
+      );
+      expect(rail.map((ch) => ch.id).toList(), ['b', 'c']);
+    });
+
+    test('recent rail is empty with no watch history', () async {
+      final provider = DefaultRailProvider(channels: const [a, b, c]);
+      final rail = await provider.buildRail(
+        const RailDefinition(
+          id: 'recent',
+          title: 'Recently Watched',
+          query: RailQuery(recentOnly: true),
+          priority: 5,
+        ),
+      );
+      expect(rail, isEmpty);
+    });
+
+    test('catalog includes a recently-watched rail dropped when empty', () {
+      final recent = DefaultRailCatalog.definitions()
+          .where((d) => d.query.recentOnly)
+          .toList();
+      expect(recent, hasLength(1));
+      expect(recent.single.visibility, RailVisibility.whenNonEmpty);
     });
   });
 
@@ -81,8 +146,11 @@ void main() {
     expect(
       ids,
       containsAll(<String>[
-        'top-india', 'live-sports', 'movies-on-now',
-        'hindi-news', 'favorites',
+        'top-india',
+        'live-sports',
+        'movies-on-now',
+        'hindi-news',
+        'favorites',
       ]),
     );
     // No 'recently-added' rail: IPTVChannel carries no "added at" signal, so


### PR DESCRIPTION
## Summary
- Bug: recently-watched cards missing since the rail-based browse (#922) — the provider tracked recents but no rail rendered them.
- Fix: `RailQuery.recentOnly` + recency-ordered building in `DefaultRailProvider` (`recentIds`, most-recent first), new catalog rail "Recently Watched" (priority 5, dropped when empty), wired to `recentlyWatchedChannelsProvider` in `railsProvider` with the same fail-soft handling as favorites.

## Test plan
- [x] 3 new unit tests: recency ordering, empty history → empty rail, catalog contains one whenNonEmpty recent rail
- [x] platform_channels 32/32, feature_iptv 364/364 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)