### PR TITLE
feat(feature_iptv): long-press browse cards to mark favorites (+ fix cached toggle no-op)

### DIFF
--- a/packages/feature_iptv/lib/application/providers/iptv_providers.dart
+++ b/packages/feature_iptv/lib/application/providers/iptv_providers.dart
@@ -506,15 +506,20 @@ final favoriteChannelsProvider = FutureProvider<List<IPTVChannel>>((ref) async {
       .toList(growable: false);
 });
 
-/// Toggle a channel's favorite state. Returns the new state.
-final toggleChannelFavoriteProvider = FutureProvider.family<bool, String>((
+/// Toggles a channel's favorite state and returns the new state.
+///
+/// A plain callable rather than a FutureProvider.family: a family instance
+/// caches its first result, so a second toggle of the same channel would
+/// silently no-op.
+final channelFavoriteTogglerProvider = Provider<Future<bool> Function(String)>((
   ref,
-  channelId,
-) async {
-  final storage = ref.watch(favoriteChannelsStorageProvider);
-  final isNowFavorite = await storage.toggleFavorite(channelId);
-  ref.invalidate(favoriteChannelIdsProvider);
-  return isNowFavorite;
+) {
+  return (channelId) async {
+    final storage = ref.read(favoriteChannelsStorageProvider);
+    final isNowFavorite = await storage.toggleFavorite(channelId);
+    ref.invalidate(favoriteChannelIdsProvider);
+    return isNowFavorite;
+  };
 });
 
 /// Coordinator for CV-017's favorites-survive-reimport behavior.

--- a/packages/feature_iptv/lib/presentation/screens/browse_screen.dart
+++ b/packages/feature_iptv/lib/presentation/screens/browse_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:platform_channels/platform_channels.dart';
 
+import '../../application/providers/iptv_providers.dart';
 import '../../application/providers/rails_provider.dart';
 import '../widgets/channel_initials.dart';
 
@@ -21,9 +22,7 @@ class BrowseScreen extends ConsumerWidget {
     final rails = ref.watch(railsProvider);
     return rails.when(
       loading: () => const Center(child: CircularProgressIndicator()),
-      error: (error, _) => Center(
-        child: Text('Could not build rails: $error'),
-      ),
+      error: (error, _) => Center(child: Text('Could not build rails: $error')),
       data: (results) => ListView(
         padding: const EdgeInsets.only(top: 12, bottom: 20),
         children: [
@@ -44,6 +43,7 @@ class BrowseScreen extends ConsumerWidget {
                     initials: channelInitials(channel.name),
                     variant: _variantFor(result.definition.layout),
                     onTap: () => onChannelSelected?.call(channel),
+                    onLongPress: () => _toggleFavorite(context, ref, channel),
                   ),
               ],
             ),
@@ -52,10 +52,33 @@ class BrowseScreen extends ConsumerWidget {
     );
   }
 
+  Future<void> _toggleFavorite(
+    BuildContext context,
+    WidgetRef ref,
+    IPTVChannel channel,
+  ) async {
+    final isNowFavorite = await ref.read(channelFavoriteTogglerProvider)(
+      channel.id,
+    );
+    if (!context.mounted) return;
+    ScaffoldMessenger.of(context)
+      ..hideCurrentSnackBar()
+      ..showSnackBar(
+        SnackBar(
+          content: Text(
+            isNowFavorite
+                ? '${channel.name} added to favorites'
+                : '${channel.name} removed from favorites',
+          ),
+          duration: const Duration(seconds: 2),
+        ),
+      );
+  }
+
   /// [MediaCardVariant] for each [RailLayout].
   static MediaCardVariant _variantFor(RailLayout layout) => switch (layout) {
-        RailLayout.compact => MediaCardVariant.compact,
-        RailLayout.standard => MediaCardVariant.standard,
-        RailLayout.hero => MediaCardVariant.hero,
-      };
+    RailLayout.compact => MediaCardVariant.compact,
+    RailLayout.standard => MediaCardVariant.standard,
+    RailLayout.hero => MediaCardVariant.hero,
+  };
 }

--- a/packages/feature_iptv/lib/presentation/screens/mobile_favorites_screen.dart
+++ b/packages/feature_iptv/lib/presentation/screens/mobile_favorites_screen.dart
@@ -87,8 +87,9 @@ class MobileFavoritesScreen extends ConsumerWidget {
                       trailing: IconButton(
                         icon: Icon(Icons.favorite, color: colorScheme.error),
                         tooltip: 'Remove from favorites',
-                        onPressed: () =>
-                            ref.read(toggleChannelFavoriteProvider(channel.id)),
+                        onPressed: () => ref.read(
+                          channelFavoriteTogglerProvider,
+                        )(channel.id),
                       ),
                       onTap: () {
                         ref

--- a/packages/feature_iptv/lib/presentation/tv/iptv_tv_screen.dart
+++ b/packages/feature_iptv/lib/presentation/tv/iptv_tv_screen.dart
@@ -231,7 +231,7 @@ class _TvBrowseLayout extends ConsumerWidget {
     final favoriteChannelIds =
         ref.watch(favoriteChannelIdsProvider).value ?? const <String>{};
     void toggleFavorite(IPTVChannel channel) {
-      ref.read(toggleChannelFavoriteProvider(channel.id));
+      ref.read(channelFavoriteTogglerProvider)(channel.id);
     }
 
     final viewport = MediaQuery.sizeOf(context);

--- a/packages/feature_iptv/lib/presentation/tv/tv_favorites_screen.dart
+++ b/packages/feature_iptv/lib/presentation/tv/tv_favorites_screen.dart
@@ -86,7 +86,7 @@ class TvFavoritesScreen extends ConsumerWidget {
                         ref.read(addToRecentlyWatchedProvider(channel));
                       },
                       onSecondaryAction: () {
-                        ref.read(toggleChannelFavoriteProvider(channel.id));
+                        ref.read(channelFavoriteTogglerProvider)(channel.id);
                       },
                       semanticLabel: channel.name,
                       semanticHint:

--- a/packages/feature_iptv/test/iptv/application/providers/iptv_providers_test.dart
+++ b/packages/feature_iptv/test/iptv/application/providers/iptv_providers_test.dart
@@ -357,6 +357,30 @@ void main() {
       );
     });
   });
+
+  group('channelFavoriteTogglerProvider', () {
+    test(
+      'toggling the same channel twice flips the state both times',
+      () async {
+        SharedPreferences.setMockInitialValues({});
+        final prefs = await SharedPreferences.getInstance();
+        final container = ProviderContainer(
+          overrides: [sharedPreferencesProvider.overrideWithValue(prefs)],
+        );
+        addTearDown(container.dispose);
+
+        final toggle = container.read(channelFavoriteTogglerProvider);
+
+        expect(await toggle('news-1'), isTrue);
+        // A FutureProvider.family here would return the stale first result
+        // instead of re-running the toggle.
+        expect(await toggle('news-1'), isFalse);
+
+        final ids = await container.read(favoriteChannelIdsProvider.future);
+        expect(ids, isNot(contains('news-1')));
+      },
+    );
+  });
 }
 
 const _channels = [

--- a/packages/feature_iptv/test/iptv/presentation/screens/browse_screen_test.dart
+++ b/packages/feature_iptv/test/iptv/presentation/screens/browse_screen_test.dart
@@ -1,0 +1,48 @@
+import 'package:core_ui/core_ui.dart';
+import 'package:feature_iptv/feature_iptv.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  const channels = [
+    IPTVChannel(
+      id: 'news-1',
+      name: 'City News Live',
+      streamUrl: 'https://example.com/news.m3u8',
+      group: 'News',
+      category: ChannelCategory.news,
+    ),
+  ];
+
+  testWidgets('long-pressing a card toggles the channel favorite', (
+    tester,
+  ) async {
+    SharedPreferences.setMockInitialValues({});
+    final prefs = await SharedPreferences.getInstance();
+    final container = ProviderContainer(
+      overrides: [
+        sharedPreferencesProvider.overrideWithValue(prefs),
+        iptvChannelsProvider.overrideWith((ref) async => channels),
+        recentlyWatchedChannelsProvider.overrideWith((ref) async => const []),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: const MaterialApp(home: Scaffold(body: BrowseScreen())),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.longPress(find.byType(MediaCard).first);
+    await tester.pumpAndSettle();
+
+    expect(find.text('City News Live added to favorites'), findsOneWidget);
+    final ids = await container.read(favoriteChannelIdsProvider.future);
+    expect(ids, contains('news-1'));
+  });
+}


### PR DESCRIPTION
## Summary
- Gap: Favorites tab existed but no UI marked a favorite. Long-press on any browse-rail `MediaCard` now toggles favorite with a snackbar; rails/tab refresh through the existing `favoriteChannelIdsProvider` invalidation.
- Latent bug fixed en route: `toggleChannelFavoriteProvider` was a `FutureProvider.family` whose instance cached its first result — the second toggle of the same channel silently no-oped on every existing call site (TV screen, TV favorites, mobile favorites). Replaced with `channelFavoriteTogglerProvider`, a plain callable; all call sites migrated.

## Test plan
- [x] Unit test: toggling same channel twice flips state both times (fails with the old family provider)
- [x] Widget test: long-press card → snackbar + id persisted
- [x] Full feature_iptv suite 366/366

🤖 Generated with [Claude Code](https://claude.com/claude-code)