### PR TITLE
refactor(feature_iptv): move category browsing into rails, drop top chip row

### DIFF
--- a/packages/feature_iptv/lib/presentation/screens/iptv_screen.dart
+++ b/packages/feature_iptv/lib/presentation/screens/iptv_screen.dart
@@ -627,8 +627,6 @@ class _StreamTabContent extends ConsumerWidget {
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         const SizedBox(height: 12),
-        const _PrimaryCategoryBar(),
-        const SizedBox(height: 12),
         Expanded(
           child: isWideScreen
               ? Row(
@@ -1179,43 +1177,6 @@ class _BringYourOwnPlaylistView extends StatelessWidget {
           ),
         );
       },
-    );
-  }
-}
-
-class _PrimaryCategoryBar extends ConsumerWidget {
-  const _PrimaryCategoryBar();
-
-  static const _categories = [
-    ChannelCategory.all,
-    ChannelCategory.news,
-    ChannelCategory.sports,
-    ChannelCategory.entertainment,
-    ChannelCategory.music,
-  ];
-
-  @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final selectedCategory = ref.watch(selectedCategoryProvider);
-    final counts = ref.watch(categoryCounts);
-
-    return SizedBox(
-      height: 42,
-      child: ListView.separated(
-        scrollDirection: Axis.horizontal,
-        padding: const EdgeInsets.symmetric(horizontal: 16),
-        itemCount: _categories.length,
-        separatorBuilder: (_, _) => const SizedBox(width: 8),
-        itemBuilder: (context, index) {
-          final category = _categories[index];
-          return ChoiceChip(
-            label: Text('${category.label} (${counts[category] ?? 0})'),
-            selected: selectedCategory == category,
-            onSelected: (_) =>
-                ref.read(selectedCategoryProvider.notifier).state = category,
-          );
-        },
-      ),
     );
   }
 }

--- a/packages/feature_iptv/test/iptv/presentation/screens/iptv_screen_test.dart
+++ b/packages/feature_iptv/test/iptv/presentation/screens/iptv_screen_test.dart
@@ -143,7 +143,7 @@ void main() {
     );
   }
 
-  testWidgets('renders Airo TV app bar, category filters, and live list', (
+  testWidgets('renders Airo TV app bar and live list without category chips', (
     tester,
   ) async {
     await tester.pumpWidget(createWidget());
@@ -152,11 +152,9 @@ void main() {
     expect(find.text('Airo TV'), findsOneWidget);
     expect(find.byTooltip('Search channels'), findsOneWidget);
     expect(find.byTooltip('Cast'), findsOneWidget);
-    expect(find.text('All (3)'), findsOneWidget);
-    expect(find.text('News (1)'), findsOneWidget);
-    expect(find.text('Sports (1)'), findsOneWidget);
-    expect(find.text('Entertainment (0)'), findsOneWidget);
-    expect(find.text('Music (1)'), findsOneWidget);
+    // Category browsing moved into the rails (Entertainment, Music, ...);
+    // the chip row is gone.
+    expect(find.byType(ChoiceChip), findsNothing);
     expect(find.text('Featured Player'), findsOneWidget);
     expect(find.text('Select a channel to start watching'), findsOneWidget);
 

--- a/packages/platform_channels/lib/src/services/default_rail_provider.dart
+++ b/packages/platform_channels/lib/src/services/default_rail_provider.dart
@@ -49,6 +49,20 @@ class DefaultRailCatalog {
       query: RailQuery(category: ChannelCategory.movies),
       priority: 40,
     ),
+    RailDefinition(
+      id: 'entertainment',
+      title: 'Entertainment',
+      subtitle: 'Shows and variety',
+      query: RailQuery(category: ChannelCategory.entertainment),
+      priority: 50,
+    ),
+    RailDefinition(
+      id: 'music',
+      title: 'Music',
+      subtitle: 'Hits and live performances',
+      query: RailQuery(category: ChannelCategory.music),
+      priority: 60,
+    ),
   ];
 }
 


### PR DESCRIPTION
## Summary
- Per product feedback: with horizontal card rails, the top `All|News|Sports|Entertainment|Music` chip row is redundant — category logic moves to the cards.
- Removed `_PrimaryCategoryBar` from the mobile IPTV screen; added `Entertainment` (priority 50) and `Music` (priority 60) rails to `DefaultRailCatalog` so every former chip category is represented as a rail (News was already covered by Hindi News, Sports by Live Sports).
- `selectedCategoryProvider` retained — still used by search filtering.
- Also addresses the "only 3 rows of cards" report: alongside #934 (Recently Watched) and #935 (favorites marking), the catalog now yields up to 8 rails; empty ones still collapse by design.

## Test plan
- [x] Updated widget test asserts no `ChoiceChip` remains and rails render
- [x] feature_iptv 364/364, platform_channels 29/29 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)