### PR TITLE
fix(player): wire TvAudioHandler to streaming service for MediaSession background audio (#980)

### DIFF
--- a/app/lib/core/audio/tv_audio_service.dart
+++ b/app/lib/core/audio/tv_audio_service.dart
@@ -267,12 +267,15 @@ Future<TvAudioHandler> initTvAudioService() async {
     config: AudioServiceConfig(
       androidNotificationChannelId: 'com.airo.app.tv.audio',
       androidNotificationChannelName: 'Airo TV',
-      androidNotificationOngoing: true,
-      androidStopForegroundOnPause: false, // Keep notification on pause for TV
+      // Keep the foreground service (and its notification) alive on pause —
+      // live-TV users pause for long stretches and must keep lock-screen
+      // controls. androidNotificationOngoing stays false: audio_service
+      // asserts it can't be true while stopForegroundOnPause is false.
+      androidStopForegroundOnPause: false,
       androidNotificationIcon: 'mipmap/ic_launcher',
-      // No fast forward/rewind for live TV
-      fastForwardInterval: Duration.zero,
-      rewindInterval: Duration.zero,
+      // fastForwardInterval/rewindInterval keep audio_service's defaults
+      // (must be > Duration.zero per its asserts); the intervals are
+      // inert because live TV exposes no fast-forward/rewind controls.
     ),
   );
 

--- a/app/lib/core/audio/tv_audio_service.dart
+++ b/app/lib/core/audio/tv_audio_service.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:audio_service/audio_service.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:platform_media/platform_media.dart';
 
 /// TV Audio Handler for background playback on Android TV/Fire TV
 ///
@@ -11,6 +12,18 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 /// - Notification controls (play/pause, stop)
 /// - Audio focus management for phone calls/alarms
 /// - Media session integration with Android TV
+///
+/// It connects to playback in two directions (#980):
+/// - **Reporting:** it implements [StreamingMediaSessionDelegate], so
+///   `VideoPlayerStreamingService` tells it what the player did
+///   (`onChannelStarted`/`onPlaybackPaused`/`onPlaybackResumed`/
+///   `onPlaybackStopped`). These paths only update media-session state —
+///   they never fire user-intent callbacks.
+/// - **Control:** the `audio_service` overrides ([play]/[pause]/[stop])
+///   fire [onUserPlayRequested]/[onUserPauseRequested]/
+///   [onUserStopRequested] so notification buttons round-trip back into the
+///   streaming service. Transition guards (e.g. [pause] while already
+///   paused is a no-op) keep the two directions from recursing.
 ///
 /// Usage:
 /// ```dart
@@ -25,7 +38,9 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 /// await handler.play();
 /// await handler.stop();
 /// ```
-class TvAudioHandler extends BaseAudioHandler with SeekHandler {
+class TvAudioHandler extends BaseAudioHandler
+    with SeekHandler
+    implements StreamingMediaSessionDelegate {
   /// Current channel name
   String? _currentChannelName;
 
@@ -43,6 +58,15 @@ class TvAudioHandler extends BaseAudioHandler with SeekHandler {
 
   /// Audio focus regained callback
   VoidCallback? onAudioFocusGained;
+
+  /// User-intent callbacks, wired by the app shell to the streaming service
+  /// so notification / lock-screen buttons actually control playback.
+  /// Fired only from the `audio_service` control overrides on genuine
+  /// state transitions — never from the [StreamingMediaSessionDelegate]
+  /// reporting path, which is what keeps the two directions loop-free.
+  VoidCallback? onUserPlayRequested;
+  VoidCallback? onUserPauseRequested;
+  VoidCallback? onUserStopRequested;
 
   TvAudioHandler() {
     _init();
@@ -84,18 +108,66 @@ class TvAudioHandler extends BaseAudioHandler with SeekHandler {
 
   @override
   Future<void> play() async {
-    _isPlaying = true;
-    _updatePlaybackState(playing: true);
+    // Guard: resuming an already-playing session is a no-op. Without this,
+    // the reporting path (delegate.onPlaybackResumed -> play()) and the
+    // control path (notification play -> onUserPlayRequested ->
+    // service.resume() -> delegate) would keep re-triggering each other.
+    if (_isPlaying) return;
+    _applyPlayState();
+    onUserPlayRequested?.call();
   }
 
   @override
   Future<void> pause() async {
-    _isPlaying = false;
-    _updatePlaybackState(playing: false);
+    // Guard: see play().
+    if (!_isPlaying) return;
+    _applyPauseState();
+    onUserPauseRequested?.call();
   }
 
   @override
   Future<void> stop() async {
+    // Guard: stopping an already-idle session is a no-op (see play()).
+    if (!_isPlaying && _currentStreamUrl == null) return;
+    await _applyStopState();
+    onUserStopRequested?.call();
+  }
+
+  // -----------------------------------------------------------------------
+  // StreamingMediaSessionDelegate — reporting path.
+  //
+  // These are called by VideoPlayerStreamingService when *it* transitions.
+  // They update media-session state only and deliberately do NOT fire the
+  // onUser* callbacks: the player is the source of truth here, calling back
+  // into it would be redundant (and, without the guards above, recursive).
+  // -----------------------------------------------------------------------
+
+  @override
+  Future<void> onChannelStarted({
+    required String channelName,
+    required String streamUrl,
+  }) => playChannel(channelName, streamUrl);
+
+  @override
+  Future<void> onPlaybackPaused() async => _applyPauseState();
+
+  @override
+  Future<void> onPlaybackResumed() async => _applyPlayState();
+
+  @override
+  Future<void> onPlaybackStopped() => _applyStopState();
+
+  void _applyPlayState() {
+    _isPlaying = true;
+    _updatePlaybackState(playing: true);
+  }
+
+  void _applyPauseState() {
+    _isPlaying = false;
+    _updatePlaybackState(playing: false);
+  }
+
+  Future<void> _applyStopState() async {
     _isPlaying = false;
     _currentChannelName = null;
     _currentStreamUrl = null;

--- a/app/lib/main_tv.dart
+++ b/app/lib/main_tv.dart
@@ -92,9 +92,19 @@ void main() async {
   // keeps live audio alive — and controllable — after a Home press (#980).
   // Skipped elsewhere: web has no audio_service host, and desktop dev
   // builds don't run the Android foreground service.
+  //
+  // Bounded: a misbehaving OS media service must never block app startup —
+  // on a timeout/failure the app boots normally without media-session
+  // controls (the pre-#980 behavior).
   TvAudioHandler? tvAudioHandler;
   if (!kIsWeb && Platform.isAndroid) {
-    tvAudioHandler = await initTvAudioService();
+    try {
+      tvAudioHandler = await initTvAudioService().timeout(
+        const Duration(seconds: 5),
+      );
+    } catch (e) {
+      debugPrint('📺 TV audio service init skipped: $e');
+    }
   }
 
   runApp(

--- a/app/lib/main_tv.dart
+++ b/app/lib/main_tv.dart
@@ -30,6 +30,7 @@ import 'package:path_provider/path_provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import 'core/app/airo_tv_app.dart';
+import 'core/audio/tv_audio_service.dart';
 import 'core/config/platform_features.dart';
 import 'core/error/global_error_handler.dart';
 import 'core/features/feature_registry.dart';
@@ -86,12 +87,23 @@ void main() async {
     '📦 Registered features: ${FeatureRegistry.featureNames.join(', ')}',
   );
 
+  // Initialize the OS media session (media notification + lock-screen
+  // controls) on Android, where audio_service's foreground service is what
+  // keeps live audio alive — and controllable — after a Home press (#980).
+  // Skipped elsewhere: web has no audio_service host, and desktop dev
+  // builds don't run the Android foreground service.
+  TvAudioHandler? tvAudioHandler;
+  if (!kIsWeb && Platform.isAndroid) {
+    tvAudioHandler = await initTvAudioService();
+  }
+
   runApp(
     ProviderScope(
       overrides: buildTvProviderOverrides(
         prefs: prefs,
         compactEpgRepository: compactEpgRepository,
         mutableXmltvRepository: mutableXmltvRepository,
+        tvAudioHandler: tvAudioHandler,
       ),
       child: const AiroTvApp(),
     ),
@@ -111,7 +123,9 @@ List<Override> buildTvProviderOverrides({
   required SharedPreferences prefs,
   required CompactEpgRepository compactEpgRepository,
   required MutableXmltvCompactEpgRepository mutableXmltvRepository,
+  TvAudioHandler? tvAudioHandler,
 }) {
+  final handler = tvAudioHandler;
   return [
     sharedPreferencesProvider.overrideWithValue(prefs),
     // Airo TV defaults to the design handoff's dedicated theme unless
@@ -128,6 +142,20 @@ List<Override> buildTvProviderOverrides({
     // (tv_router.dart compact layout), whose cast UI needs the real
     // controller — without this override casting silently no-ops.
     realIptvCastControllerOverride(),
+    // #980: publish playback state to the OS media session and route
+    // notification buttons back into the streaming service. The delegate
+    // reporting direction flows through tvIptvIntegrationProvider; the
+    // user-intent callbacks below are the control direction.
+    if (handler != null)
+      tvMediaSessionDelegateProvider.overrideWith((ref) {
+        handler.onUserPauseRequested = () =>
+            ref.read(iptvStreamingServiceProvider).pause();
+        handler.onUserPlayRequested = () =>
+            ref.read(iptvStreamingServiceProvider).resume();
+        handler.onUserStopRequested = () =>
+            ref.read(iptvStreamingServiceProvider).stop();
+        return handler;
+      }),
     ...FeatureRegistry.allProviderOverrides,
   ];
 }

--- a/app/test/core/audio/tv_audio_handler_media_session_test.dart
+++ b/app/test/core/audio/tv_audio_handler_media_session_test.dart
@@ -1,0 +1,144 @@
+import 'package:airo_app/core/audio/tv_audio_service.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// #980: TvAudioHandler's two-direction contract with
+/// VideoPlayerStreamingService — the delegate reporting path updates
+/// media-session state only, the audio_service control path fires
+/// user-intent callbacks, and transition guards keep the two from
+/// recursing into each other.
+void main() {
+  group('TvAudioHandler media session contract (#980)', () {
+    test(
+      'onChannelStarted reports playing state and channel metadata',
+      () async {
+        final handler = TvAudioHandler();
+        var userCallbacks = 0;
+        handler.onUserPlayRequested = () => userCallbacks++;
+        handler.onUserPauseRequested = () => userCallbacks++;
+        handler.onUserStopRequested = () => userCallbacks++;
+
+        await handler.onChannelStarted(
+          channelName: 'Test Channel',
+          streamUrl: 'https://example.com/live.m3u8',
+        );
+
+        expect(handler.isPlaying, isTrue);
+        expect(handler.currentChannelName, 'Test Channel');
+        expect(handler.currentStreamUrl, 'https://example.com/live.m3u8');
+        // Reporting path must not look like a user action.
+        expect(userCallbacks, 0);
+      },
+    );
+
+    test(
+      'delegate reporting path (paused/resumed/stopped) fires no user callbacks',
+      () async {
+        final handler = TvAudioHandler();
+        var userCallbacks = 0;
+        handler.onUserPlayRequested = () => userCallbacks++;
+        handler.onUserPauseRequested = () => userCallbacks++;
+        handler.onUserStopRequested = () => userCallbacks++;
+
+        await handler.onChannelStarted(
+          channelName: 'Test Channel',
+          streamUrl: 'https://example.com/live.m3u8',
+        );
+        await handler.onPlaybackPaused();
+        expect(handler.isPlaying, isFalse);
+
+        await handler.onPlaybackResumed();
+        expect(handler.isPlaying, isTrue);
+
+        await handler.onPlaybackStopped();
+        expect(handler.isPlaying, isFalse);
+        expect(handler.currentChannelName, isNull);
+        expect(handler.currentStreamUrl, isNull);
+
+        expect(userCallbacks, 0);
+      },
+    );
+
+    test(
+      'control path fires user-intent callbacks on real transitions',
+      () async {
+        final handler = TvAudioHandler();
+        var pauseRequests = 0;
+        var playRequests = 0;
+        var stopRequests = 0;
+        handler.onUserPauseRequested = () => pauseRequests++;
+        handler.onUserPlayRequested = () => playRequests++;
+        handler.onUserStopRequested = () => stopRequests++;
+
+        await handler.playChannel(
+          'Test Channel',
+          'https://example.com/live.m3u8',
+        );
+
+        await handler.pause();
+        expect(pauseRequests, 1);
+
+        await handler.play();
+        expect(playRequests, 1);
+
+        await handler.stop();
+        expect(stopRequests, 1);
+      },
+    );
+
+    test('pause while already paused is a no-op (recursion guard)', () async {
+      final handler = TvAudioHandler();
+      var pauseRequests = 0;
+      handler.onUserPauseRequested = () => pauseRequests++;
+
+      await handler.playChannel(
+        'Test Channel',
+        'https://example.com/live.m3u8',
+      );
+      await handler.pause();
+      expect(pauseRequests, 1);
+
+      // The loop this guards against: delegate.onPlaybackPaused ->
+      // handler state, then notification pause -> service.pause() ->
+      // delegate again. A second pause must not fire another callback.
+      await handler.pause();
+      expect(pauseRequests, 1);
+      expect(handler.isPlaying, isFalse);
+    });
+
+    test('play while already playing is a no-op (recursion guard)', () async {
+      final handler = TvAudioHandler();
+      var playRequests = 0;
+      handler.onUserPlayRequested = () => playRequests++;
+
+      await handler.playChannel(
+        'Test Channel',
+        'https://example.com/live.m3u8',
+      );
+
+      await handler.play();
+      expect(playRequests, 0);
+      expect(handler.isPlaying, isTrue);
+    });
+
+    test('stop while idle is a no-op (recursion guard)', () async {
+      final handler = TvAudioHandler();
+      var stopRequests = 0;
+      handler.onUserStopRequested = () => stopRequests++;
+
+      await handler.stop();
+      expect(stopRequests, 0);
+
+      await handler.playChannel(
+        'Test Channel',
+        'https://example.com/live.m3u8',
+      );
+      await handler.stop();
+      expect(stopRequests, 1);
+
+      // Already stopped: a repeat stop (e.g. service.stop() racing a
+      // notification stop) must not fire again.
+      await handler.stop();
+      expect(stopRequests, 1);
+    });
+  });
+}

--- a/app/test/main_tv_media_session_override_test.dart
+++ b/app/test/main_tv_media_session_override_test.dart
@@ -1,0 +1,89 @@
+import 'package:airo_app/core/audio/tv_audio_service.dart';
+import 'package:airo_app/main_tv.dart';
+import 'package:feature_iptv/feature_iptv.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// #980: the TV entrypoint wires TvAudioHandler into the IPTV streaming
+/// stack in both directions — the handler is exposed as the media-session
+/// delegate (reporting), and its user-intent callbacks route notification
+/// button presses back into the streaming service (control).
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('TV entrypoint exposes TvAudioHandler as the media session delegate and '
+      'routes notification controls back into the streaming service', () async {
+    SharedPreferences.setMockInitialValues({});
+    final prefs = await SharedPreferences.getInstance();
+    final mutableRepo = MutableXmltvCompactEpgRepository();
+    final handler = TvAudioHandler();
+    final streamingService = VideoPlayerStreamingService(
+      engine: FakeAiroPlaybackEngine(),
+    );
+    addTearDown(streamingService.dispose);
+
+    final container = ProviderContainer(
+      overrides: [
+        ...buildTvProviderOverrides(
+          prefs: prefs,
+          compactEpgRepository: createTvCompactEpgRepository(
+            fallback: mutableRepo,
+          ),
+          mutableXmltvRepository: mutableRepo,
+          tvAudioHandler: handler,
+        ),
+        iptvStreamingServiceProvider.overrideWithValue(streamingService),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    // Reporting direction: the delegate provider resolves to the handler
+    // and the integration provider attaches it to the service.
+    expect(container.read(tvMediaSessionDelegateProvider), same(handler));
+    container.read(tvIptvIntegrationProvider);
+    expect(streamingService.mediaSessionDelegate, same(handler));
+
+    // Control direction: notification buttons reach the streaming
+    // service. FakeAiroPlaybackEngine starts idle; simulate playback,
+    // then a notification pause must propagate. pumpEventQueue() between
+    // steps models real notification-tap timing — taps never arrive in
+    // the same microtask burst.
+    await handler.playChannel('Test Channel', 'https://example.com/live.m3u8');
+    await pumpEventQueue();
+
+    await handler.pause();
+    await pumpEventQueue();
+    expect(streamingService.currentState.playbackState, PlaybackState.paused);
+
+    await handler.play();
+    await pumpEventQueue();
+    expect(streamingService.currentState.playbackState, PlaybackState.playing);
+
+    await handler.stop();
+    await pumpEventQueue();
+    expect(streamingService.currentState.playbackState, PlaybackState.idle);
+  });
+
+  test(
+    'TV entrypoint without a TvAudioHandler leaves the delegate unset',
+    () async {
+      SharedPreferences.setMockInitialValues({});
+      final prefs = await SharedPreferences.getInstance();
+      final mutableRepo = MutableXmltvCompactEpgRepository();
+
+      final container = ProviderContainer(
+        overrides: buildTvProviderOverrides(
+          prefs: prefs,
+          compactEpgRepository: createTvCompactEpgRepository(
+            fallback: mutableRepo,
+          ),
+          mutableXmltvRepository: mutableRepo,
+        ),
+      );
+      addTearDown(container.dispose);
+
+      expect(container.read(tvMediaSessionDelegateProvider), isNull);
+    },
+  );
+}

--- a/packages/feature_iptv/lib/application/providers/iptv_providers.dart
+++ b/packages/feature_iptv/lib/application/providers/iptv_providers.dart
@@ -70,14 +70,28 @@ final iptvStreamingServiceProvider = Provider<VideoPlayerStreamingService>((
   return service;
 });
 
+/// OS media-session delegate supplied by the host application (e.g. the
+/// Airo TV shell overrides this with its `audio_service`-backed
+/// `TvAudioHandler`). Null on hosts without a media session (web, mobile,
+/// tests) — the streaming service treats that as "nothing to report to".
+final tvMediaSessionDelegateProvider = Provider<StreamingMediaSessionDelegate?>(
+  (ref) => null,
+);
+
 /// TV IPTV Streaming service integration provider
 ///
-/// This provider integrates the IPTV streaming service with TvAudioHandler
-/// for background playback on Android TV/Fire TV platforms.
+/// This provider integrates the IPTV streaming service with the host app's
+/// media-session delegate (see [tvMediaSessionDelegateProvider]) for
+/// background playback on Android TV/Fire TV platforms.
 ///
 /// Aligns with acceptance test [AND-PB-004]: Background Audio Foreground Service
 /// - When user switches to another app (home button), audio continues
 /// - Notification controls available for play/pause/stop
+///
+/// The delegate is attached via the service's setter (not a constructor
+/// rebuild) so overriding [tvMediaSessionDelegateProvider] never tears down
+/// in-flight playback. Something in the widget tree must watch this provider
+/// for the wiring to stay live (`IPTVScreen` does).
 ///
 /// Usage:
 /// ```dart
@@ -89,25 +103,8 @@ final iptvStreamingServiceProvider = Provider<VideoPlayerStreamingService>((
 /// await streamingService.playChannel(channel);
 /// ```
 final tvIptvIntegrationProvider = Provider<void>((ref) {
-  // Import TvAudioHandler from core/audio/tv_audio_service.dart
-  // and connect it with VideoPlayerStreamingService
-  //
-  // The TvAudioHandler should be notified when:
-  // - playChannel() is called -> handler.playChannel(name, url)
-  // - pause() is called -> handler.pause()
-  // - resume() is called -> handler.play()
-  // - stop() is called -> handler.stop()
-  //
-  // This enables:
-  // - Media session integration on Android TV
-  // - Background audio when home button is pressed
-  // - Notification controls (play/pause/stop)
-  // - Audio focus handling (auto-pause on phone calls)
-  //
-  // Implementation note:
-  // The actual integration requires modifying VideoPlayerStreamingService
-  // to accept an optional TvAudioHandler and call its methods when
-  // playback state changes. For now, the provider documents the pattern.
+  final delegate = ref.watch(tvMediaSessionDelegateProvider);
+  ref.watch(iptvStreamingServiceProvider).mediaSessionDelegate = delegate;
 });
 
 /// All channels provider - fetches preprocessed channels from IPTV Sanity Agent

--- a/packages/feature_iptv/lib/presentation/screens/iptv_screen.dart
+++ b/packages/feature_iptv/lib/presentation/screens/iptv_screen.dart
@@ -86,6 +86,9 @@ class _IPTVScreenState extends ConsumerState<IPTVScreen>
     ref.read(wakelockPlaybackCoordinatorProvider);
     // Decides PiP vs. audio-only when the app backgrounds during playback.
     ref.read(playerBackgroundingCoordinatorProvider);
+    // Publishes playback state to the OS media session (media notification
+    // + lock-screen controls) when the host supplies a delegate (#980).
+    ref.read(tvIptvIntegrationProvider);
     // Feeds real app lifecycle transitions into appLifecycleStateProvider,
     // which playerBackgroundingCoordinatorProvider listens to above.
     WidgetsBinding.instance.addObserver(this);

--- a/packages/feature_iptv/test/application/providers/tv_iptv_integration_provider_test.dart
+++ b/packages/feature_iptv/test/application/providers/tv_iptv_integration_provider_test.dart
@@ -1,0 +1,89 @@
+import 'package:feature_iptv/feature_iptv.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+class _FakeMediaSessionDelegate implements StreamingMediaSessionDelegate {
+  @override
+  Future<void> onChannelStarted({
+    required String channelName,
+    required String streamUrl,
+  }) async {}
+
+  @override
+  Future<void> onPlaybackPaused() async {}
+
+  @override
+  Future<void> onPlaybackResumed() async {}
+
+  @override
+  Future<void> onPlaybackStopped() async {}
+}
+
+void main() {
+  late VideoPlayerStreamingService service;
+
+  ProviderContainer buildContainer({StreamingMediaSessionDelegate? delegate}) {
+    return ProviderContainer(
+      overrides: [
+        iptvStreamingServiceProvider.overrideWithValue(service),
+        if (delegate != null)
+          tvMediaSessionDelegateProvider.overrideWithValue(delegate),
+      ],
+    );
+  }
+
+  setUp(() {
+    service = VideoPlayerStreamingService(engine: FakeAiroPlaybackEngine());
+  });
+
+  tearDown(() async {
+    await service.dispose();
+  });
+
+  group('tvIptvIntegrationProvider', () {
+    test('leaves the service delegate null when the host supplies none', () {
+      final container = buildContainer();
+      addTearDown(container.dispose);
+
+      container.read(tvIptvIntegrationProvider);
+
+      expect(service.mediaSessionDelegate, isNull);
+    });
+
+    test('attaches the host-provided delegate to the shared service', () {
+      final delegate = _FakeMediaSessionDelegate();
+      final container = buildContainer(delegate: delegate);
+      addTearDown(container.dispose);
+
+      container.read(tvIptvIntegrationProvider);
+
+      expect(service.mediaSessionDelegate, same(delegate));
+    });
+
+    test('a delegate change re-attaches without rebuilding the service', () {
+      final first = _FakeMediaSessionDelegate();
+      final second = _FakeMediaSessionDelegate();
+      final container = buildContainer(delegate: first);
+      addTearDown(container.dispose);
+
+      container.read(tvIptvIntegrationProvider);
+      expect(service.mediaSessionDelegate, same(first));
+
+      // Rebuild the container with a different delegate: the streaming
+      // service instance must survive (overrideWithValue) and simply get
+      // re-pointed at the new delegate — no playback teardown.
+      final updated = ProviderContainer(
+        overrides: [
+          iptvStreamingServiceProvider.overrideWithValue(service),
+          tvMediaSessionDelegateProvider.overrideWithValue(second),
+        ],
+      );
+      addTearDown(updated.dispose);
+
+      updated.read(tvIptvIntegrationProvider);
+
+      expect(service.mediaSessionDelegate, same(second));
+      expect(updated.read(iptvStreamingServiceProvider), same(service));
+    });
+  });
+}

--- a/packages/platform_media/lib/platform_media.dart
+++ b/packages/platform_media/lib/platform_media.dart
@@ -4,6 +4,7 @@ export "src/media_capability_models.dart";
 export "src/media_error_taxonomy_models.dart";
 export "src/platform_media_logger.dart";
 export "src/streaming_error_diagnostic_mapping.dart";
+export "src/streaming_media_session_delegate.dart";
 export "src/mpv/media_kit_mpv_player_facade.dart";
 export "src/mpv/mpv_player_facade.dart";
 export "src/mpv_airo_playback_engine.dart";

--- a/packages/platform_media/lib/src/streaming_media_session_delegate.dart
+++ b/packages/platform_media/lib/src/streaming_media_session_delegate.dart
@@ -1,0 +1,27 @@
+/// Receives playback lifecycle notifications from
+/// [VideoPlayerStreamingService] so a host application can publish them to
+/// the OS media session (e.g. an `audio_service`-backed handler on
+/// Android TV / Fire TV driving the lock-screen and notification controls).
+///
+/// This is a reporting-only contract: the delegate is told what the player
+/// did — it never controls playback. Control flows the other way: the user
+/// taps a notification button, and the host-side handler calls back into
+/// the streaming service's own `pause()`/`resume()`/`stop()`. Keeping the
+/// directions separate prevents delegate→handler→service recursion.
+abstract class StreamingMediaSessionDelegate {
+  /// A channel finished opening and transitioned to playing. [streamUrl] is
+  /// the resolved URL actually handed to the playback engine.
+  Future<void> onChannelStarted({
+    required String channelName,
+    required String streamUrl,
+  });
+
+  /// Playback was paused.
+  Future<void> onPlaybackPaused();
+
+  /// Playback resumed from a paused state.
+  Future<void> onPlaybackResumed();
+
+  /// Playback stopped and the session returned to idle.
+  Future<void> onPlaybackStopped();
+}

--- a/packages/platform_media/lib/src/video_player_streaming_service.dart
+++ b/packages/platform_media/lib/src/video_player_streaming_service.dart
@@ -7,6 +7,7 @@ import 'package:platform_streams/platform_streams.dart';
 import 'audio_context.dart';
 import 'platform_media_logger.dart';
 import 'streaming_error_diagnostic_mapping.dart';
+import 'streaming_media_session_delegate.dart';
 import 'video_player_airo_playback_engine.dart';
 
 /// Video Player implementation of IPTV Streaming Service
@@ -47,11 +48,34 @@ class VideoPlayerStreamingService implements IPTVStreamingService {
     this._config = StreamingConfig.youtube,
     AudioContextManager? audioContext,
     LiveEdgeConfig? liveEdgeConfig,
+    this.mediaSessionDelegate,
   }) : _engine = engine ?? VideoPlayerAiroPlaybackEngine(),
        _audioContext = audioContext ?? AudioContextManager(),
        _liveEdgeDetector = LiveEdgeDetector(config: liveEdgeConfig) {
     _setupLiveEdgeCallbacks();
     _engineSubscription = _engine.states.listen(_onEngineStateUpdate);
+  }
+
+  /// Optional OS media-session reporter (e.g. Android TV's `audio_service`
+  /// handler). Settable after construction because the host-side handler is
+  /// initialized asynchronously at app startup, while this service may
+  /// already exist. Null (the default) means "no media session host" —
+  /// playback behavior is unchanged.
+  StreamingMediaSessionDelegate? mediaSessionDelegate;
+
+  /// Notifies the media-session delegate without ever letting a host-side
+  /// failure affect playback. Reporting is best-effort by design: a broken
+  /// notification must not break the stream.
+  Future<void> _notifyMediaSession(
+    Future<void> Function(StreamingMediaSessionDelegate delegate) call,
+  ) async {
+    final delegate = mediaSessionDelegate;
+    if (delegate == null) return;
+    try {
+      await call(delegate);
+    } catch (e) {
+      AppLogger.info('Media session delegate error: $e', tag: 'MEDIA_SESSION');
+    }
   }
 
   void _setupLiveEdgeCallbacks() {
@@ -189,6 +213,16 @@ class VideoPlayerStreamingService implements IPTVStreamingService {
 
       _startBufferMonitoring();
 
+      // Report the now-playing channel to the OS media session only after
+      // the engine genuinely reached playing — never on the loading state
+      // or the error path below.
+      _notifyMediaSession(
+        (delegate) => delegate.onChannelStarted(
+          channelName: channel.name,
+          streamUrl: url,
+        ),
+      );
+
       // Attach live edge detector for live stream monitoring
       _liveEdgeDetector.attachToEngine(_engine);
     } catch (e) {
@@ -221,7 +255,8 @@ class VideoPlayerStreamingService implements IPTVStreamingService {
         duration: engineState.duration ?? _state.duration,
         tracks: engineState.tracks,
         selectedTrackIds: engineState.selectedTrackIds,
-        playbackState: _mapEnginePhase(engineState.phase) ?? _state.playbackState,
+        playbackState:
+            _mapEnginePhase(engineState.phase) ?? _state.playbackState,
       ),
     );
   }
@@ -387,6 +422,7 @@ class VideoPlayerStreamingService implements IPTVStreamingService {
     await _engine.pause();
     _audioContext.releaseFocus(AudioFocusType.video);
     _updateState(_state.copyWith(playbackState: PlaybackState.paused));
+    _notifyMediaSession((delegate) => delegate.onPlaybackPaused());
   }
 
   @override
@@ -394,6 +430,7 @@ class VideoPlayerStreamingService implements IPTVStreamingService {
     _audioContext.requestFocus(AudioFocusType.video);
     await _engine.play();
     _updateState(_state.copyWith(playbackState: PlaybackState.playing));
+    _notifyMediaSession((delegate) => delegate.onPlaybackResumed());
   }
 
   @override
@@ -403,6 +440,7 @@ class VideoPlayerStreamingService implements IPTVStreamingService {
     _liveEdgeDetector.detach();
     await _engine.stop();
     _updateState(StreamingState());
+    _notifyMediaSession((delegate) => delegate.onPlaybackStopped());
   }
 
   @override
@@ -412,7 +450,8 @@ class VideoPlayerStreamingService implements IPTVStreamingService {
     var clampedPosition = position;
     if (_state.isLiveStream && _state.hasDvrSupport) {
       final dvrStart = _state.dvrWindowStart ?? Duration.zero;
-      final liveEdge = _state.liveEdge ?? _engine.currentState.duration ?? Duration.zero;
+      final liveEdge =
+          _state.liveEdge ?? _engine.currentState.duration ?? Duration.zero;
 
       if (position < dvrStart) {
         clampedPosition = dvrStart;

--- a/packages/platform_media/test/streaming_media_session_delegate_test.dart
+++ b/packages/platform_media/test/streaming_media_session_delegate_test.dart
@@ -1,0 +1,187 @@
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:platform_channels/platform_channels.dart';
+import 'package:platform_media/platform_media.dart';
+import 'package:platform_player/platform_player.dart';
+import 'package:video_player_platform_interface/video_player_platform_interface.dart';
+
+import 'support/fake_video_player_platform.dart';
+
+/// Records every delegate callback so tests can assert exactly what the
+/// streaming service reported to the (fake) OS media session.
+class _RecordingMediaSessionDelegate implements StreamingMediaSessionDelegate {
+  final List<String> calls = <String>[];
+  String? lastChannelName;
+  String? lastStreamUrl;
+
+  @override
+  Future<void> onChannelStarted({
+    required String channelName,
+    required String streamUrl,
+  }) async {
+    calls.add('channelStarted');
+    lastChannelName = channelName;
+    lastStreamUrl = streamUrl;
+  }
+
+  @override
+  Future<void> onPlaybackPaused() async {
+    calls.add('paused');
+  }
+
+  @override
+  Future<void> onPlaybackResumed() async {
+    calls.add('resumed');
+  }
+
+  @override
+  Future<void> onPlaybackStopped() async {
+    calls.add('stopped');
+  }
+}
+
+class _ThrowingMediaSessionDelegate implements StreamingMediaSessionDelegate {
+  @override
+  Future<void> onChannelStarted({
+    required String channelName,
+    required String streamUrl,
+  }) async {
+    throw StateError('host media session exploded');
+  }
+
+  @override
+  Future<void> onPlaybackPaused() async {
+    throw StateError('host media session exploded');
+  }
+
+  @override
+  Future<void> onPlaybackResumed() async {
+    throw StateError('host media session exploded');
+  }
+
+  @override
+  Future<void> onPlaybackStopped() async {
+    throw StateError('host media session exploded');
+  }
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late FakeVideoPlayerPlatform fakePlatform;
+  late VideoPlayerAiroPlaybackEngine engine;
+  late _RecordingMediaSessionDelegate delegate;
+  late VideoPlayerStreamingService service;
+
+  const channel = IPTVChannel(
+    id: 'chan-1',
+    name: 'Test Channel',
+    streamUrl: 'https://example.com/live.m3u8',
+  );
+
+  setUp(() {
+    fakePlatform = FakeVideoPlayerPlatform();
+    VideoPlayerPlatform.instance = fakePlatform;
+    engine = VideoPlayerAiroPlaybackEngine();
+    delegate = _RecordingMediaSessionDelegate();
+    service = VideoPlayerStreamingService(
+      engine: engine,
+      mediaSessionDelegate: delegate,
+    );
+  });
+
+  tearDown(() async {
+    await service.dispose();
+  });
+
+  group('VideoPlayerStreamingService media session delegate', () {
+    test(
+      'playChannel success reports onChannelStarted with name and resolved URL',
+      () async {
+        await service.playChannel(channel);
+        await pumpEventQueue();
+
+        expect(delegate.calls, contains('channelStarted'));
+        expect(delegate.lastChannelName, 'Test Channel');
+        expect(delegate.lastStreamUrl, 'https://example.com/live.m3u8');
+      },
+    );
+
+    test('playChannel failure reports nothing to the delegate', () async {
+      fakePlatform.scriptedInitError = PlatformException(
+        code: 'VideoError',
+        message: 'decoder rejected format',
+      );
+
+      await service.playChannel(channel);
+      await pumpEventQueue();
+
+      expect(service.currentState.playbackState, PlaybackState.error);
+      expect(delegate.calls, isEmpty);
+    });
+
+    test('pause, resume, and stop each report their transition', () async {
+      await service.playChannel(channel);
+
+      await service.pause();
+      await service.resume();
+      await service.stop();
+      await pumpEventQueue();
+
+      expect(
+        delegate.calls,
+        containsAllInOrder(<String>[
+          'channelStarted',
+          'paused',
+          'resumed',
+          'stopped',
+        ]),
+      );
+    });
+
+    test('a throwing delegate never breaks playback', () async {
+      final throwingService = VideoPlayerStreamingService(
+        engine: engine,
+        mediaSessionDelegate: _ThrowingMediaSessionDelegate(),
+      );
+      addTearDown(throwingService.dispose);
+
+      await throwingService.playChannel(channel);
+      await throwingService.pause();
+      await throwingService.resume();
+      await throwingService.stop();
+      await pumpEventQueue();
+
+      // Every transition completed despite the host delegate throwing on
+      // each one — reporting is best-effort by design.
+      expect(throwingService.currentState.playbackState, PlaybackState.idle);
+    });
+
+    test('a null delegate leaves playback behavior unchanged', () async {
+      final plainService = VideoPlayerStreamingService(engine: engine);
+      addTearDown(plainService.dispose);
+
+      await plainService.playChannel(channel);
+      await plainService.pause();
+      await plainService.resume();
+      await plainService.stop();
+
+      expect(plainService.currentState.playbackState, PlaybackState.idle);
+    });
+
+    test('the delegate is settable after construction', () async {
+      final lateService = VideoPlayerStreamingService(engine: engine);
+      addTearDown(lateService.dispose);
+
+      // Host-side media handlers initialize asynchronously at app startup,
+      // after the service may already exist — hence the setter.
+      lateService.mediaSessionDelegate = delegate;
+
+      await lateService.playChannel(channel);
+      await pumpEventQueue();
+
+      expect(delegate.calls, contains('channelStarted'));
+      expect(delegate.lastChannelName, 'Test Channel');
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Adds `StreamingMediaSessionDelegate` reporting contract to `platform_media`; `VideoPlayerStreamingService` notifies it on play/pause/resume/stop (fail-safe, null = no-op).
- `feature_iptv`: `tvMediaSessionDelegateProvider` (app-overridable) + `tvIptvIntegrationProvider` attaches it via setter; `IPTVScreen` activates the wiring.
- App shell: `TvAudioHandler` implements the delegate, notification buttons round-trip into the streaming service via guarded user-intent callbacks; `main_tv.dart` initializes `audio_service` on Android with a bounded (5s) startup wait.
- Fixes two latent `AudioServiceConfig` assert violations that hung debug startup on the native splash.

## Validation
- Local: platform_media 110/110, feature_iptv 394/394, app 62/62 targeted tests; analyzer/format/`git diff --check` clean.
- On-device (Android 36 emulator): session `active=true / PLAYING(3)` with channel metadata, MediaStyle foreground-service notification on Home press, notification pause/play round-trip `PAUSED(2) → PLAYING(3)`. Evidence on #980.

Closes #980