### PR TITLE
fix(docs): add SRI integrity + crossorigin to lucide CDN script (SonarCloud gate)

### DIFF
--- a/docs/airo-tv/guides/index.html
+++ b/docs/airo-tv/guides/index.html
@@ -11,7 +11,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=DM+Sans:opsz,wght@9..40,400;9..40,500;9..40,600;9..40,700;9..40,800&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="../../assets/airo-tv/site.css">
-  <script defer src="https://unpkg.com/lucide@0.468.0/dist/umd/lucide.min.js"></script>
+  <script defer src="https://unpkg.com/lucide@0.468.0/dist/umd/lucide.min.js" integrity="sha384-uTYyvsSSUZeaPhb5RbKlQa0zY/WpX/QHfvg2mczXyBQOpkWPEDy9lczyp+w7SKXu" crossorigin="anonymous"></script>
   <script defer src="../../assets/airo-tv/site.js"></script>
 </head>
 <body>

--- a/docs/index.html
+++ b/docs/index.html
@@ -20,7 +20,7 @@ layout: null
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=DM+Sans:opsz,wght@9..40,400;9..40,500;9..40,600;9..40,700;9..40,800&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="./assets/airo-tv/site.css">
-  <script defer src="https://unpkg.com/lucide@0.468.0/dist/umd/lucide.min.js"></script>
+  <script defer src="https://unpkg.com/lucide@0.468.0/dist/umd/lucide.min.js" integrity="sha384-uTYyvsSSUZeaPhb5RbKlQa0zY/WpX/QHfvg2mczXyBQOpkWPEDy9lczyp+w7SKXu" crossorigin="anonymous"></script>
   <script defer src="./assets/airo-tv/third-party/hls.js-1.6.16/hls.min.js"></script>
   <script defer src="./assets/airo-tv/site.js"></script>
 </head>

--- a/docs/iptv-research.html
+++ b/docs/iptv-research.html
@@ -22,7 +22,7 @@ permalink: /iptv-research/
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=DM+Sans:opsz,wght@9..40,400;9..40,500;9..40,600;9..40,700;9..40,800&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/airo/assets/airo-tv/site.css">
-  <script defer src="https://unpkg.com/lucide@0.468.0/dist/umd/lucide.min.js"></script>
+  <script defer src="https://unpkg.com/lucide@0.468.0/dist/umd/lucide.min.js" integrity="sha384-uTYyvsSSUZeaPhb5RbKlQa0zY/WpX/QHfvg2mczXyBQOpkWPEDy9lczyp+w7SKXu" crossorigin="anonymous"></script>
   <script defer src="/airo/assets/airo-tv/site.js"></script>
   <style>
     .research-hero {

--- a/docs/release/IPAD_AIR_4_SOAK_TEST.html
+++ b/docs/release/IPAD_AIR_4_SOAK_TEST.html
@@ -15,7 +15,7 @@ permalink: /release/IPAD_AIR_4_SOAK_TEST.html
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=DM+Sans:opsz,wght@9..40,400;9..40,500;9..40,600;9..40,700;9..40,800&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="../assets/airo-tv/site.css">
-  <script defer src="https://unpkg.com/lucide@0.468.0/dist/umd/lucide.min.js"></script>
+  <script defer src="https://unpkg.com/lucide@0.468.0/dist/umd/lucide.min.js" integrity="sha384-uTYyvsSSUZeaPhb5RbKlQa0zY/WpX/QHfvg2mczXyBQOpkWPEDy9lczyp+w7SKXu" crossorigin="anonymous"></script>
   <script defer src="../assets/airo-tv/site.js"></script>
   <style>
     .report-main {


### PR DESCRIPTION
## Why

SonarCloud quality gate on `main` is failing: **B Security Rating on New Code** (required ≥ A).

Root cause: 4 open `Web:S5725` vulnerabilities — the lucide 0.468.0 script is loaded from unpkg.com without subresource integrity in:

- `docs/index.html`
- `docs/iptv-research.html`
- `docs/airo-tv/guides/index.html`
- `docs/release/IPAD_AIR_4_SOAK_TEST.html`

## What

Add `integrity="sha384-uTYyvsSSUZeaPhb5RbKlQa0zY/WpX/QHfvg2mczXyBQOpkWPEDy9lczyp+w7SKXu"` and `crossorigin="anonymous"` to all four occurrences. Hash computed from the pinned 0.468.0 artifact and verified byte-identical across unpkg and jsDelivr.

## Notes

- The remaining CDN reference (`mermaid@10` ESM import in iptv-research.html) is not flagged by S5725 and is unpinned, so SRI is not applicable there.
- Separately: SonarCloud shows **no coverage data** because the project uses automatic analysis, which cannot ingest lcov reports and ignores `sonar-project.properties`. Coverage currently goes to Codecov only. Surfacing coverage in SonarCloud requires migrating to CI-based analysis (scanner step + `SONAR_TOKEN`) — tracked as follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)