### PR TITLE
fix(docs): resolve 80 SonarCloud maintainability findings on airo-tv site

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![Flutter](https://img.shields.io/badge/Flutter-3.44.4+-blue.svg)](https://flutter.dev/)
 [![License: MIT](https://img.shields.io/badge/license-MIT-green)](LICENSE)
 [![Security Policy](https://img.shields.io/badge/security-policy-brightgreen)](SECURITY.md)
+[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=DevelopersCoffee_airo&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=DevelopersCoffee_airo)
 [![Trust](https://img.shields.io/badge/trust-transparent-brightgreen)](TRUST.md)
 [![Versioning](https://img.shields.io/badge/versioning-semver-blue)](CHANGELOG.md)
 [![Android TV](https://img.shields.io/badge/Android%20TV-compatible-green)](docs/release/AIRO_TV_v0.0.2.md)

--- a/docs/assets/airo-tv/site.css
+++ b/docs/assets/airo-tv/site.css
@@ -859,6 +859,7 @@ button,
 }
 
 .live-demo-status {
+  display: block;
   margin: 8px 0 0;
   padding: 9px 11px;
   border: 1px solid var(--border);

--- a/docs/assets/airo-tv/site.js
+++ b/docs/assets/airo-tv/site.js
@@ -1,8 +1,8 @@
 (function () {
   "use strict";
 
-  var menuButton = document.querySelector("[data-menu-button]");
-  var navigation = document.querySelector("[data-navigation]");
+  const menuButton = document.querySelector("[data-menu-button]");
+  const navigation = document.querySelector("[data-navigation]");
 
   function closeMenu() {
     if (!menuButton || !navigation) return;
@@ -13,7 +13,7 @@
 
   if (menuButton && navigation) {
     menuButton.addEventListener("click", function () {
-      var isOpen = menuButton.getAttribute("aria-expanded") === "true";
+      const isOpen = menuButton.getAttribute("aria-expanded") === "true";
       menuButton.setAttribute("aria-expanded", String(!isOpen));
       navigation.classList.toggle("open", !isOpen);
       document.body.classList.toggle("menu-open", !isOpen);
@@ -28,18 +28,18 @@
     });
   }
 
-  var sectionLinks = document.querySelectorAll('.site-nav > a[href^="#"]:not(.button)');
-  var sectionLinkMap = new Map();
+  const sectionLinks = document.querySelectorAll('.site-nav > a[href^="#"]:not(.button)');
+  const sectionLinkMap = new Map();
 
   sectionLinks.forEach(function (link) {
-    var section = document.querySelector(link.getAttribute("href"));
+    const section = document.querySelector(link.getAttribute("href"));
     if (section) sectionLinkMap.set(section, link);
   });
 
   if (typeof window.IntersectionObserver === "function" && sectionLinkMap.size) {
-    var sectionObserver = new IntersectionObserver(
+    const sectionObserver = new IntersectionObserver(
       function (entries) {
-        var current = entries
+        const current = entries
           .filter(function (entry) {
             return entry.isIntersecting;
           })
@@ -61,38 +61,38 @@
     });
   }
 
-  var filters = document.querySelectorAll("[data-guide-filter]");
-  var guides = document.querySelectorAll("[data-guide-device]");
+  const filters = document.querySelectorAll("[data-guide-filter]");
+  const guides = document.querySelectorAll("[data-guide-device]");
 
   filters.forEach(function (button) {
     button.addEventListener("click", function () {
-      var selected = button.getAttribute("data-guide-filter") || "all";
+      const selected = button.dataset.guideFilter || "all";
       filters.forEach(function (candidate) {
         candidate.setAttribute("aria-selected", String(candidate === button));
       });
       guides.forEach(function (guide) {
-        var devices = (guide.getAttribute("data-guide-device") || "").split(" ");
+        const devices = (guide.dataset.guideDevice || "").split(" ");
         guide.hidden = selected !== "all" && !devices.includes(selected);
       });
     });
   });
 
-  var year = document.querySelector("[data-current-year]");
+  const year = document.querySelector("[data-current-year]");
   if (year) year.textContent = String(new Date().getFullYear());
 
-  var reducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+  const reducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
 
   if (!reducedMotion) {
-    var scrollProgress = document.createElement("div");
+    const scrollProgress = document.createElement("div");
     scrollProgress.className = "scroll-progress";
     scrollProgress.setAttribute("aria-hidden", "true");
     document.body.appendChild(scrollProgress);
 
-    var progressFrameRequested = false;
+    let progressFrameRequested = false;
 
     function updateScrollProgress() {
-      var scrollRange = document.documentElement.scrollHeight - window.innerHeight;
-      var progress = scrollRange > 0 ? window.scrollY / scrollRange : 0;
+      const scrollRange = document.documentElement.scrollHeight - window.innerHeight;
+      const progress = scrollRange > 0 ? window.scrollY / scrollRange : 0;
       scrollProgress.style.transform = "scaleX(" + Math.min(1, Math.max(0, progress)) + ")";
       progressFrameRequested = false;
     }
@@ -107,7 +107,7 @@
     window.addEventListener("resize", requestProgressUpdate);
     requestProgressUpdate();
 
-    var revealSelectors = [
+    const revealSelectors = [
       ".section-intro",
       ".screen-step",
       ".channel-showcase-content",
@@ -119,7 +119,7 @@
       ".vision-step",
       ".trust-grid > *",
     ];
-    var revealTargets = [];
+    const revealTargets = [];
 
     revealSelectors.forEach(function (selector) {
       document.querySelectorAll(selector).forEach(function (element, index) {
@@ -130,7 +130,7 @@
     });
 
     if (typeof window.IntersectionObserver === "function") {
-      var revealObserver = new IntersectionObserver(
+      const revealObserver = new IntersectionObserver(
         function (entries) {
           entries.forEach(function (entry) {
             if (!entry.isIntersecting) return;
@@ -150,45 +150,45 @@
     }
   }
 
-  var liveDemoInstances = [];
+  const liveDemoInstances = [];
 
   function initializeLiveDemo(root) {
-    var demoVideo = root.querySelector("[data-live-demo-video]");
-    var demoStart = root.querySelector("[data-live-demo-start]");
-    var demoButton = root.querySelector("[data-live-demo-button]");
-    var demoAudio = root.querySelector("[data-live-demo-audio]");
-    var demoStatus = root.querySelector("[data-live-demo-status]");
+    const demoVideo = root.querySelector("[data-live-demo-video]");
+    const demoStart = root.querySelector("[data-live-demo-start]");
+    const demoButton = root.querySelector("[data-live-demo-button]");
+    const demoAudio = root.querySelector("[data-live-demo-audio]");
+    const demoStatus = root.querySelector("[data-live-demo-status]");
     if (!demoVideo || !demoStart || !demoButton || !demoStatus) return null;
 
-    var channelName = root.getAttribute("data-live-channel") || "live sample";
-    var retryLabel = root.getAttribute("data-live-retry-label") || "Try live sample again";
-    var autoplayMuted = root.hasAttribute("data-live-autoplay-muted");
-    var initialButtonMarkup = demoButton.innerHTML;
-    var idleStatus = demoStatus.textContent;
-    var demoHls = null;
-    var demoStarted = false;
-    var demoRecovering = false;
-    var demoRecoveryAttempts = 0;
-    var demoRecoveryTimer = null;
-    var demoSource = "";
-    var demoUsesNativeHls = false;
-    var demoAutomaticStart = false;
-    var demoAutoplayAttempted = false;
-    var autoplayBlockedByInitialHash =
+    const channelName = root.dataset.liveChannel || "live sample";
+    const retryLabel = root.dataset.liveRetryLabel || "Try live sample again";
+    const autoplayMuted = "liveAutoplayMuted" in root.dataset;
+    const initialButtonMarkup = demoButton.innerHTML;
+    const idleStatus = demoStatus.textContent;
+    let demoHls = null;
+    let demoStarted = false;
+    let demoRecovering = false;
+    let demoRecoveryAttempts = 0;
+    let demoRecoveryTimer = null;
+    let demoSource = "";
+    let demoUsesNativeHls = false;
+    let demoAutomaticStart = false;
+    let demoAutoplayAttempted = false;
+    let autoplayBlockedByInitialHash =
       autoplayMuted && Boolean(window.location.hash) && window.location.hash !== "#vevo-showcase";
-    var demoPausedByViewport = false;
-    var demoViewportObserver = null;
-    var demoViewportTimer = null;
+    let demoPausedByViewport = false;
+    let demoViewportObserver = null;
+    let demoViewportTimer = null;
 
     function setDemoStatus(message, state) {
       demoStatus.textContent = message;
-      demoStatus.setAttribute("data-state", state || "ready");
-      root.setAttribute("data-live-state", state || "ready");
+      demoStatus.dataset.state = state || "ready";
+      root.dataset.liveState = state || "ready";
     }
 
     function updateDemoAudioControl() {
       if (!demoAudio) return;
-      var soundEnabled = !demoVideo.muted;
+      const soundEnabled = !demoVideo.muted;
       demoAudio.setAttribute("aria-pressed", String(soundEnabled));
       demoAudio.innerHTML = soundEnabled
         ? '<i data-lucide="volume-2" aria-hidden="true"></i><span>Mute</span>'
@@ -215,7 +215,7 @@
 
     function requestDemoPlayback() {
       if (!demoStarted) return;
-      var playRequest = demoVideo.play();
+      const playRequest = demoVideo.play();
       if (!playRequest) return;
       playRequest
         .then(function () {
@@ -223,7 +223,7 @@
         })
         .catch(function (error) {
           if (!demoStarted) return;
-          if (demoAutomaticStart && error && error.name === "NotAllowedError") {
+          if (demoAutomaticStart && error?.name === "NotAllowedError") {
             clearDemoRecoveryTimer();
             demoAutomaticStart = false;
             demoButton.disabled = false;
@@ -284,7 +284,7 @@
 
     function retryNativeDemo() {
       if (!demoSource) return;
-      var separator = demoSource.includes("?") ? "&" : "?";
+      const separator = demoSource.includes("?") ? "&" : "?";
       demoVideo.pause();
       demoVideo.removeAttribute("src");
       demoVideo.load();
@@ -316,7 +316,8 @@
             demoHls.recoverMediaError();
           }
           requestDemoPlayback();
-        } catch (_error) {
+        } catch (error) {
+          console.warn("Airo TV live demo: automatic recovery failed.", error);
           failDemo("The live sample could not recover automatically.");
         }
         return true;
@@ -331,7 +332,7 @@
     }
 
     function startDemoPlayback(isAutomatic) {
-      var source = demoButton.getAttribute("data-live-source");
+      const source = demoButton.dataset.liveSource;
       if (!source) return;
       if (demoStarted) {
         if (!demoVideo.paused) return;
@@ -374,7 +375,7 @@
         return;
       }
 
-      if (window.Hls && window.Hls.isSupported()) {
+      if (window.Hls?.isSupported()) {
         demoHls = new window.Hls({
           capLevelToPlayerSize: true,
           backBufferLength: 20,
@@ -383,7 +384,7 @@
         });
         demoHls.on(window.Hls.Events.ERROR, function (_event, data) {
           if (!data.fatal || demoRecovering) return;
-          var kind = data.type === window.Hls.ErrorTypes.NETWORK_ERROR ? "network" : "media";
+          const kind = data.type === window.Hls.ErrorTypes.NETWORK_ERROR ? "network" : "media";
           if (!recoverDemo(kind)) {
             failDemo("The live sample is unavailable or blocked in this region.");
           }
@@ -404,7 +405,7 @@
     if (demoAudio) {
       demoAudio.addEventListener("click", function () {
         if (!demoStarted) return;
-        var enableSound = demoVideo.muted;
+        const enableSound = demoVideo.muted;
         demoVideo.defaultMuted = !enableSound;
         demoVideo.muted = !enableSound;
         demoVideo.volume = 1;
@@ -442,43 +443,49 @@
       }
     });
 
+    function resumeMutedPreview() {
+      if (!demoAutoplayAttempted && !demoStarted) {
+        demoAutoplayAttempted = true;
+        if (autoplayBlockedByInitialHash) return;
+        const anotherDemoActive = liveDemoInstances.some(function (instance) {
+          return instance.root !== root && instance.isActive();
+        });
+        if (anotherDemoActive) return;
+        startDemoPlayback(true);
+        return;
+      }
+      if (demoPausedByViewport && demoStarted) {
+        demoPausedByViewport = false;
+        demoVideo.defaultMuted = true;
+        demoVideo.muted = true;
+        updateDemoAudioControl();
+        if (demoHls) demoHls.startLoad(-1);
+        setDemoStatus("Resuming the muted live preview...", "loading");
+        requestDemoPlayback();
+      }
+    }
+
+    function pauseMutedPreview() {
+      if (!demoStarted || demoPausedByViewport) return;
+      demoPausedByViewport = true;
+      demoVideo.defaultMuted = true;
+      demoVideo.muted = true;
+      updateDemoAudioControl();
+      demoVideo.pause();
+      if (demoHls) demoHls.stopLoad();
+      setDemoStatus("Muted preview paused off screen.", "paused");
+    }
+
     if (autoplayMuted && "IntersectionObserver" in window) {
       demoViewportObserver = new IntersectionObserver(
         function (entries) {
-          var entry = entries[0];
-          var visibleEnough = entry.isIntersecting && entry.intersectionRatio >= 0.35;
-
+          const entry = entries[0];
+          const visibleEnough = entry.isIntersecting && entry.intersectionRatio >= 0.35;
           if (visibleEnough) {
-            if (!demoAutoplayAttempted && !demoStarted) {
-              demoAutoplayAttempted = true;
-              if (autoplayBlockedByInitialHash) return;
-              var anotherDemoActive = liveDemoInstances.some(function (instance) {
-                return instance.root !== root && instance.isActive();
-              });
-              if (anotherDemoActive) return;
-              startDemoPlayback(true);
-              return;
-            }
-            if (demoPausedByViewport && demoStarted) {
-              demoPausedByViewport = false;
-              demoVideo.defaultMuted = true;
-              demoVideo.muted = true;
-              updateDemoAudioControl();
-              if (demoHls) demoHls.startLoad(-1);
-              setDemoStatus("Resuming the muted live preview...", "loading");
-              requestDemoPlayback();
-            }
-            return;
+            resumeMutedPreview();
+          } else {
+            pauseMutedPreview();
           }
-
-          if (!demoStarted || demoPausedByViewport) return;
-          demoPausedByViewport = true;
-          demoVideo.defaultMuted = true;
-          demoVideo.muted = true;
-          updateDemoAudioControl();
-          demoVideo.pause();
-          if (demoHls) demoHls.stopLoad();
-          setDemoStatus("Muted preview paused off screen.", "paused");
         },
         { threshold: [0, 0.35] }
       );
@@ -536,7 +543,7 @@
   }
 
   document.querySelectorAll("[data-live-demo]").forEach(function (root) {
-    var instance = initializeLiveDemo(root);
+    const instance = initializeLiveDemo(root);
     if (instance) liveDemoInstances.push(instance);
   });
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -125,7 +125,7 @@ layout: null
             <button class="button button-secondary channel-showcase-audio" type="button" aria-pressed="false" data-live-demo-audio hidden>
               <i data-lucide="volume-x" aria-hidden="true"></i><span>Unmute</span>
             </button>
-            <p class="live-demo-status channel-showcase-status" role="status" aria-live="polite" data-live-demo-status>Muted preview starts on screen.</p>
+            <output class="live-demo-status channel-showcase-status" aria-live="polite" data-live-demo-status>Muted preview starts on screen.</output>
           </div>
         </div>
         <div class="channel-showcase-pitch">
@@ -243,7 +243,7 @@ layout: null
                   <i data-lucide="play" aria-hidden="true"></i> Play YRF Music sample
                 </button>
               </div>
-              <p class="live-demo-status live-demo-player-status" role="status" aria-live="polite" data-live-demo-status>Ready. No stream connection has been made.</p>
+              <output class="live-demo-status live-demo-player-status" aria-live="polite" data-live-demo-status>Ready. No stream connection has been made.</output>
             </div>
             <details class="channel-showcase-details live-demo-disclosure">
               <summary><i data-lucide="info" aria-hidden="true"></i> Third-party stream details</summary>
@@ -429,10 +429,10 @@ layout: null
             border-radius: 4px;
           }
           .status-badge.supported { color: var(--green); background: rgba(0, 230, 118, 0.1); }
-          .status-badge.partial { color: #2196f3; background: rgba(33, 150, 243, 0.1); }
-          .status-badge.planned { color: #9c27b0; background: rgba(156, 39, 176, 0.1); }
-          .status-badge.not-supported { color: #f44336; background: rgba(244, 67, 54, 0.1); }
-          .status-badge.keyboard { color: #ffeb3b; background: rgba(255, 235, 59, 0.1); }
+          .status-badge.partial { color: #ffffff; background: #1565c0; }
+          .status-badge.planned { color: #ffffff; background: #9c27b0; }
+          .status-badge.not-supported { color: #ffffff; background: #c62828; }
+          .status-badge.keyboard { color: #1a1a1a; background: #ffeb3b; }
           .pipeline-section {
             margin-top: 64px;
             padding-top: 48px;
@@ -666,7 +666,7 @@ layout: null
           
           const sector = document.createElementNS(svgNS, 'path');
           sector.setAttribute('class', 'feature-sector');
-          sector.setAttribute('data-feature', f.id);
+          sector.dataset.feature = f.id;
           sector.setAttribute('d', `M ${x1} ${y1} A 260 260 0 0 1 ${x2} ${y2} L ${x3} ${y3} A 70 70 0 0 0 ${x4} ${y4} Z`);
           sector.addEventListener('mouseenter', () => selectFeature(f.id));
           svg.appendChild(sector);
@@ -711,8 +711,8 @@ layout: null
             const status = f.support[dev];
             const cellG = document.createElementNS(svgNS, 'g');
             cellG.setAttribute('class', 'matrix-cell');
-            cellG.setAttribute('data-feature', f.id);
-            cellG.setAttribute('data-device', dev);
+            cellG.dataset.feature = f.id;
+            cellG.dataset.device = dev;
             
             let iconSvg = statusIcons[status]
               .replace('{x}', x.toFixed(1))
@@ -734,7 +734,7 @@ layout: null
           const btn = document.createElement('button');
           btn.setAttribute('type', 'button');
           btn.setAttribute('class', 'feature-btn');
-          btn.setAttribute('data-feature', f.id);
+          btn.dataset.feature = f.id;
           btn.innerHTML = `<span>${f.icon}</span> <span>${f.name}</span>`;
           btn.addEventListener('mouseenter', () => selectFeature(f.id));
           listContainer.appendChild(btn);
@@ -745,7 +745,7 @@ layout: null
 
       function selectFeature(featureId) {
         document.querySelectorAll('.feature-btn').forEach(btn => {
-          if(btn.getAttribute('data-feature') === featureId) {
+          if(btn.dataset.feature === featureId) {
             btn.classList.add('active');
           } else {
             btn.classList.remove('active');
@@ -753,7 +753,7 @@ layout: null
         });
 
         document.querySelectorAll('.feature-sector').forEach(sector => {
-          if(sector.getAttribute('data-feature') === featureId) {
+          if(sector.dataset.feature === featureId) {
             sector.classList.add('active');
           } else {
             sector.classList.remove('active');
@@ -761,7 +761,7 @@ layout: null
         });
 
         document.querySelectorAll('.matrix-cell').forEach(cell => {
-          if(cell.getAttribute('data-feature') === featureId) {
+          if(cell.dataset.feature === featureId) {
             cell.style.opacity = '1';
             cell.style.transform = 'scale(1.2)';
           } else {


### PR DESCRIPTION
## Why

SonarCloud main dashboard shows 80 open code-smell (maintainability) issues, all confined to the docs/assets/airo-tv marketing site -- not gate-blocking today, but real cleanup debt now that CI-based analysis (#1006) will make these visible and trackable going forward.

## What

| Rule | Count | Fix |
|---|---|---|
| javascript:S3504 | 55 | `var` -> `let`/`const` throughout site.js |
| javascript:S7761 | 15 | `getAttribute`/`setAttribute`/`hasAttribute` on `data-*` -> `.dataset` |
| css:S7924 | 4 | `.status-badge` variants had same-hue text-on-translucent-background, which fails contrast checks against anything but the exact dark backdrop. Switched to solid backgrounds + white/black text, each verified >= 4.5:1 |
| Web:S6819 | 2 | `<p role="status">` -> `<output>` for the two live-demo status announcements (added `display:block` in site.css since `<output>` defaults to inline) |
| javascript:S6582 | 2 | `x && x.y` -> `x?.y` guards, only where behavior is provably identical |
| javascript:S3776 | 1 | Extracted the viewport IntersectionObserver callback into `resumeMutedPreview()`/`pauseMutedPreview()`, cognitive complexity 19 -> well under 15 |
| javascript:S2486 | 1 | HLS recovery catch block now logs the caught error via `console.warn` instead of discarding it |

## Verification

No test suite covers this static docs site, so verified manually in-browser (Chrome preview pane):
- Guide filter buttons (`dataset.guideFilter`/`dataset.guideDevice`) filter correctly
- Capability-matrix wheel (`dataset.feature`) selects and updates the details card correctly
- Both live-demo `<output>` status elements render `display: block` as before
- `site.js` passes `node --check`
- No console errors on load

🤖 Generated with [Claude Code](https://claude.com/claude-code)