### PR TITLE
ci: run SonarCloud scan even when test-app has failing tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -255,6 +255,7 @@ jobs:
           flutter test --coverage --reporter=compact
 
       - name: Upload coverage
+        if: always()
         uses: codecov/codecov-action@v7
         with:
           files: ./app/coverage/lcov.info
@@ -262,11 +263,13 @@ jobs:
           name: flutter-coverage
 
       - name: Upload coverage artifact for SonarCloud
+        if: always()
         uses: actions/upload-artifact@v7
         with:
           name: lcov-coverage
           path: app/coverage/lcov.info
           retention-days: 1
+          if-no-files-found: warn
 
   # ============================================
   # Build Android - Multi-Platform Matrix
@@ -907,12 +910,18 @@ jobs:
   # and quality-gate coverage conditions become meaningful.
   # Requires: repo secret SONAR_TOKEN, and Automatic Analysis turned
   # off in SonarCloud project Administration > Analysis Method.
+  #
+  # Runs whenever test-app actually ran, whether or not its Flutter
+  # tests all passed -- a test regression should fail test-app and
+  # block on that signal separately, not silently stop static
+  # analysis and coverage reporting from running at all.
   # ============================================
   sonarcloud-scan:
     runs-on: ubuntu-latest
     needs: [test-app]
     if: >
-      always() && needs.test-app.result == 'success' &&
+      always() &&
+      (needs.test-app.result == 'success' || needs.test-app.result == 'failure') &&
       (github.event_name == 'push' ||
        (github.event_name == 'pull_request' && (github.base_ref == 'main' || github.base_ref == 'v2')))
     steps:
@@ -921,6 +930,7 @@ jobs:
           fetch-depth: 0
 
       - name: Download coverage artifact
+        continue-on-error: true
         uses: actions/download-artifact@v6
         with:
           name: lcov-coverage


### PR DESCRIPTION
## Why

After #1006 merged and the SONAR_TOKEN secret + Automatic Analysis toggle were both set up, SonarCloud's CI-based scan still has not run once. Confirmed on the latest main push (commit 2761758): `sonarcloud-scan` shows `skipped`.

Root cause: `sonarcloud-scan` requires `needs.test-app.result == 'success'`. `test-app` fails because `firebase_options_test.dart` expects a real Firebase App ID and gets the CI placeholder -- this is pre-existing and unrelated to the Sonar migration (confirmed failing on yesterday's push too, before any of this work started). Because the "Run app tests with coverage" step fails, the two steps after it (`Upload coverage`, `Upload coverage artifact for SonarCloud`) never ran -- no `if: always()` -- so the lcov artifact was never even produced, and `sonarcloud-scan` had nothing to consume and no green signal to proceed on.

Net effect: one unrelated, already-broken test permanently blocks all SonarCloud analysis, silently.

## What

- `Upload coverage` and `Upload coverage artifact for SonarCloud` steps in `test-app` now run with `if: always()`.
- `sonarcloud-scan` now proceeds when `test-app` result is `success` **or** `failure` (only `skipped`/`cancelled` block it).
- `Download coverage artifact` in `sonarcloud-scan` is `continue-on-error: true`, so a genuinely missing artifact degrades to running the scan without coverage instead of not running at all.

A failing Flutter test still fails `test-app` and should keep doing so as its own signal -- this only stops that failure from also silently killing static analysis and coverage reporting.

## Not in scope

The `firebase_options_test.dart` failure itself, and a separate, unrelated Android Lint/Kotlin toolchain crash (`NoSuchMethodError` in `JavaDocParser`) currently failing `build-android` on all 4 variants -- identical across variants including ones that never run codegen, so it's an environment/dependency-drift issue, not caused by anything in recent PRs. Flagging both as separate follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)