### PR TITLE
fix(android): revert AGP 9.3.0 -> 9.2.1 to fix build-android Lint crash

### DIFF
--- a/app/android/settings.gradle.kts
+++ b/app/android/settings.gradle.kts
@@ -19,7 +19,7 @@ pluginManagement {
 
 plugins {
     id("dev.flutter.flutter-plugin-loader") version "1.0.0"
-    id("com.android.application") version "9.3.0" apply false
+    id("com.android.application") version "9.2.1" apply false
     id("org.jetbrains.kotlin.android") version "2.4.10" apply false
 }
 


### PR DESCRIPTION
## Why

`build-android` has failed on all 4 matrix variants (mobile-full, mobile-streaming, iptv-standalone, tv) since #1007 (Dependabot bump of `com.android.application` 9.2.1 -> 9.3.0, merged 2026-07-21):

```
FAILURE: Build failed with an exception.
NoSuchMethodError: JavaDocParser.parseDataItem(JavaDocParser.kt:117) <- ... AndroidLintWorkAction ...
```

`assembleRelease` depends on `lintVitalRelease` by default. This AGP version's bundled Lint hits a binary incompatibility with the pinned Kotlin Gradle plugin (`2.4.10`, untouched by #1007).

Confirmed via before/after CI run comparison:
- 2026-07-20 push (AGP 9.2.1 + Kotlin 2.4.10): `build-android` green on all 4 variants
- 2026-07-21 push (AGP 9.3.0 + Kotlin 2.4.10, right after #1007 merged): identical Lint crash on all 4 variants

Identical failure across variants including 3 that never run Dart codegen rules out anything Flutter/Dart-side -- this is a native Android/Kotlin toolchain issue from the AGP bump alone.

## What

Revert `app/android/settings.gradle.kts` AGP version to `9.2.1`, the last known-good pairing with Kotlin Gradle plugin `2.4.10`.

## Note

Dependabot will likely re-propose the 9.3.0 bump later. If picked up again, it should be paired with a compatible Kotlin Gradle plugin bump in the same change rather than merged alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)