### PR TITLE
fix(feature_iptv): record history after playback starts [skip ci]

### DIFF
--- a/packages/feature_iptv/lib/application/providers/iptv_providers.dart
+++ b/packages/feature_iptv/lib/application/providers/iptv_providers.dart
@@ -339,10 +339,15 @@ final compactEpgWindowProvider =
       return repository.loadWindow(query);
     });
 
-/// Streaming state provider
-final streamingStateProvider = StreamProvider<StreamingState>((ref) {
+/// Raw streaming state events from the player service.
+final streamingStateStreamProvider = Provider<Stream<StreamingState>>((ref) {
   final service = ref.watch(iptvStreamingServiceProvider);
   return service.stateStream;
+});
+
+/// Streaming state provider
+final streamingStateProvider = StreamProvider<StreamingState>((ref) {
+  return ref.watch(streamingStateStreamProvider);
 });
 
 /// Current app lifecycle state, updated by a `WidgetsBindingObserver` in

--- a/packages/feature_iptv/lib/application/providers/recently_watched_recorder.dart
+++ b/packages/feature_iptv/lib/application/providers/recently_watched_recorder.dart
@@ -1,0 +1,67 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_riverpod/legacy.dart';
+import 'package:platform_channels/platform_channels.dart';
+import 'package:platform_player/platform_player.dart';
+
+import 'iptv_providers.dart';
+import 'vod_providers.dart';
+
+/// VOD item selected for playback but not yet confirmed by the player.
+///
+/// The live player reports VOD playback through a synthetic [IPTVChannel]
+/// with the same id, so the success recorder uses this marker to route the
+/// first playing transition into VOD history instead of live recents.
+final pendingVodHistoryItemProvider = StateProvider<VodItem?>((ref) => null);
+
+/// Records recently watched entries only after playback reaches `playing`.
+///
+/// Selection-time writes pollute history when a stream fails before it starts.
+/// Keeping this as a separate provider avoids an import cycle between the live
+/// IPTV providers and VOD providers.
+final recentlyWatchedRecorderProvider = Provider<void>((ref) {
+  String? lastRecordedChannelId;
+  var writeQueue = Future<void>.value();
+
+  void enqueueWrite(Future<void> Function() write) {
+    writeQueue = writeQueue.then((_) => write()).catchError((Object error) {
+      debugPrint('[RecentlyWatchedRecorder] Failed to record playback: $error');
+    });
+    unawaited(writeQueue);
+  }
+
+  void recordIfPlaying(StreamingState state) {
+    final channel = state.currentChannel;
+    if (channel == null || state.playbackState != PlaybackState.playing) {
+      return;
+    }
+
+    if (channel.id == lastRecordedChannelId) {
+      return;
+    }
+    lastRecordedChannelId = channel.id;
+
+    final pendingVod = ref.read(pendingVodHistoryItemProvider);
+    if (pendingVod != null && pendingVod.id == channel.id) {
+      ref.read(pendingVodHistoryItemProvider.notifier).state = null;
+      enqueueWrite(() async {
+        await ref.read(vodWatchHistoryStorageProvider).addToRecent(pendingVod);
+        ref.invalidate(vodContinueWatchingProvider);
+      });
+      return;
+    }
+
+    enqueueWrite(() async {
+      await ref.read(recentlyWatchedStorageProvider).addToRecent(channel);
+      ref.invalidate(recentlyWatchedChannelsProvider);
+    });
+  }
+
+  final subscription = ref
+      .watch(streamingStateStreamProvider)
+      .listen(recordIfPlaying);
+  ref.onDispose(subscription.cancel);
+  recordIfPlaying(ref.read(iptvStreamingServiceProvider).currentState);
+});

--- a/packages/feature_iptv/lib/feature_iptv.dart
+++ b/packages/feature_iptv/lib/feature_iptv.dart
@@ -11,6 +11,7 @@ export "application/providers/content_source_management_providers.dart";
 export "application/providers/guide_providers.dart";
 export "application/providers/local_iptv_search_providers.dart";
 export "application/providers/playback_settings_extension_point.dart";
+export "application/providers/recently_watched_recorder.dart";
 export "application/providers/video_aspect_ratio_provider.dart";
 export "application/providers/caption_preference_provider.dart";
 export "application/providers/tv_font_mode_provider.dart";

--- a/packages/feature_iptv/lib/presentation/screens/iptv_screen.dart
+++ b/packages/feature_iptv/lib/presentation/screens/iptv_screen.dart
@@ -5,7 +5,6 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:flutter_riverpod/legacy.dart';
 import 'package:core_ui/core_ui.dart';
 import '../../application/player_backgrounding_coordinator.dart';
 import '../../application/providers/iptv_providers.dart';
@@ -202,8 +201,6 @@ class _IPTVScreenState extends ConsumerState<IPTVScreen>
     }
 
     ref.read(iptvStreamingServiceProvider).playChannel(channel);
-    // Track recently watched for easy access
-    ref.read(addToRecentlyWatchedProvider(channel));
   }
 
   Future<bool> _playNaturalLanguageQuery(String query) async {

--- a/packages/feature_iptv/lib/presentation/screens/mobile_favorites_screen.dart
+++ b/packages/feature_iptv/lib/presentation/screens/mobile_favorites_screen.dart
@@ -95,7 +95,6 @@ class MobileFavoritesScreen extends ConsumerWidget {
                         ref
                             .read(iptvStreamingServiceProvider)
                             .playChannel(channel);
-                        ref.read(addToRecentlyWatchedProvider(channel));
                         onChannelSelected();
                       },
                     );

--- a/packages/feature_iptv/lib/presentation/screens/vod_screen.dart
+++ b/packages/feature_iptv/lib/presentation/screens/vod_screen.dart
@@ -5,6 +5,7 @@ import 'package:platform_channels/platform_channels.dart';
 import 'package:platform_player/platform_player.dart';
 
 import '../../application/providers/iptv_providers.dart';
+import '../../application/providers/recently_watched_recorder.dart';
 import '../../application/providers/vod_providers.dart';
 import '../widgets/vod_list_widget.dart';
 
@@ -79,8 +80,8 @@ class VodScreen extends ConsumerWidget {
       logoUrl: item.posterUrl,
       group: item.group,
     );
+    ref.read(pendingVodHistoryItemProvider.notifier).state = item;
     ref.read(iptvStreamingServiceProvider).playChannel(syntheticChannel);
-    ref.read(addToVodWatchHistoryProvider(item).future);
   }
 
   Future<void> _attachSubtitle(
@@ -140,13 +141,15 @@ class VodScreen extends ConsumerWidget {
     // it. If the item is already playing, the user needs to tap it again
     // for the subtitle to take effect; the dialog copy makes this explicit
     // rather than implying an instant attach.
-    ref.read(iptvStreamingServiceProvider).attachExternalSubtitle(
-      item.id,
-      AiroPlaybackExternalSubtitle(
-        handle: AiroPlaybackSourceHandle.direct(url),
-        label: 'Custom subtitle',
-      ),
-    );
+    ref
+        .read(iptvStreamingServiceProvider)
+        .attachExternalSubtitle(
+          item.id,
+          AiroPlaybackExternalSubtitle(
+            handle: AiroPlaybackSourceHandle.direct(url),
+            label: 'Custom subtitle',
+          ),
+        );
   }
 }
 

--- a/packages/feature_iptv/lib/presentation/tv/iptv_guide_screen.dart
+++ b/packages/feature_iptv/lib/presentation/tv/iptv_guide_screen.dart
@@ -68,7 +68,6 @@ class IptvGuideScreen extends ConsumerWidget {
                       ref
                           .read(iptvStreamingServiceProvider)
                           .playChannel(channel);
-                      ref.read(addToRecentlyWatchedProvider(channel));
                       onChannelSelected();
                     },
                   ),

--- a/packages/feature_iptv/lib/presentation/tv/iptv_tv_screen.dart
+++ b/packages/feature_iptv/lib/presentation/tv/iptv_tv_screen.dart
@@ -3,7 +3,6 @@ import 'dart:async';
 import 'package:core_ui/core_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:flutter_riverpod/legacy.dart';
 import 'package:flutter/services.dart';
 import 'package:platform_channels/platform_channels.dart';
 import 'package:platform_epg/platform_epg.dart';
@@ -44,7 +43,6 @@ class _IptvTvScreenState extends ConsumerState<IptvTvScreen> {
 
   void _playChannel(IPTVChannel channel) {
     ref.read(iptvStreamingServiceProvider).playChannel(channel);
-    ref.read(addToRecentlyWatchedProvider(channel));
   }
 
   Future<void> _showSearchDialog() async {

--- a/packages/feature_iptv/lib/presentation/tv/tv_favorites_screen.dart
+++ b/packages/feature_iptv/lib/presentation/tv/tv_favorites_screen.dart
@@ -83,7 +83,6 @@ class TvFavoritesScreen extends ConsumerWidget {
                         ref
                             .read(iptvStreamingServiceProvider)
                             .playChannel(channel);
-                        ref.read(addToRecentlyWatchedProvider(channel));
                       },
                       onSecondaryAction: () {
                         ref.read(channelFavoriteTogglerProvider)(channel.id);

--- a/packages/feature_iptv/lib/presentation/tv/vod_tv_screen.dart
+++ b/packages/feature_iptv/lib/presentation/tv/vod_tv_screen.dart
@@ -4,6 +4,7 @@ import 'package:core_ui/core_ui.dart';
 import 'package:platform_channels/platform_channels.dart';
 
 import '../../application/providers/iptv_providers.dart';
+import '../../application/providers/recently_watched_recorder.dart';
 import '../../application/providers/vod_providers.dart';
 import '../widgets/vod_grid.dart';
 
@@ -80,8 +81,8 @@ class VodTvScreen extends ConsumerWidget {
       logoUrl: item.posterUrl,
       group: item.group,
     );
+    ref.read(pendingVodHistoryItemProvider.notifier).state = item;
     ref.read(iptvStreamingServiceProvider).playChannel(syntheticChannel);
-    ref.read(addToVodWatchHistoryProvider(item).future);
   }
 }
 

--- a/packages/feature_iptv/lib/presentation/widgets/local_search_results_panel.dart
+++ b/packages/feature_iptv/lib/presentation/widgets/local_search_results_panel.dart
@@ -118,7 +118,6 @@ class _ResultRow extends ConsumerWidget {
           for (final channel in channels) {
             if (channel.id == result.channelId) {
               ref.read(iptvStreamingServiceProvider).playChannel(channel);
-              ref.read(addToRecentlyWatchedProvider(channel));
               break;
             }
           }

--- a/packages/feature_iptv/lib/presentation/widgets/video_player_widget.dart
+++ b/packages/feature_iptv/lib/presentation/widgets/video_player_widget.dart
@@ -6,6 +6,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../application/player_backgrounding_coordinator.dart';
 import '../../application/providers/caption_preference_provider.dart';
 import '../../application/providers/iptv_providers.dart';
+import '../../application/providers/recently_watched_recorder.dart';
 import '../../application/providers/video_aspect_ratio_provider.dart';
 import '../../domain/vod_resume_coordinator.dart';
 import 'playback_diagnostic_overlay.dart';
@@ -272,6 +273,7 @@ class _VideoPlayerWidgetState extends ConsumerState<VideoPlayerWidget> {
 
   @override
   Widget build(BuildContext context) {
+    ref.watch(recentlyWatchedRecorderProvider);
     final streamingService = ref.watch(iptvStreamingServiceProvider);
     final streamingState = ref.watch(streamingStateProvider);
     final aspectRatioFit = ref.watch(videoAspectRatioProvider);

--- a/packages/feature_iptv/test/application/recently_watched_recorder_test.dart
+++ b/packages/feature_iptv/test/application/recently_watched_recorder_test.dart
@@ -1,0 +1,144 @@
+import 'dart:async';
+
+import 'package:feature_iptv/application/providers/iptv_providers.dart';
+import 'package:feature_iptv/application/providers/recently_watched_recorder.dart';
+import 'package:feature_iptv/application/providers/vod_providers.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:platform_channels/platform_channels.dart';
+import 'package:platform_history/platform_history.dart';
+import 'package:platform_player/platform_player.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  const channelA = IPTVChannel(
+    id: 'chan-a',
+    name: 'Channel A',
+    streamUrl: 'https://example.com/a.m3u8',
+  );
+  const channelB = IPTVChannel(
+    id: 'chan-b',
+    name: 'Channel B',
+    streamUrl: 'https://example.com/b.m3u8',
+  );
+  const vodItem = VodItem(
+    id: 'vod-1',
+    title: 'Test Movie',
+    streamUrl: 'https://example.com/movie.mp4',
+    group: 'Movies',
+    kind: VodContentKind.movie,
+  );
+  // VOD plays through a synthetic IPTVChannel with the same id (see
+  // vod_screen.dart's _selectItem).
+  const vodSyntheticChannel = IPTVChannel(
+    id: 'vod-1',
+    name: 'Test Movie',
+    streamUrl: 'https://example.com/movie.mp4',
+  );
+
+  late StreamController<StreamingState> states;
+  late RecentlyWatchedStorage liveStorage;
+  late VodWatchHistoryStorage vodStorage;
+  late ProviderContainer container;
+
+  StreamingState stateFor(IPTVChannel channel, PlaybackState playback) {
+    return StreamingState(currentChannel: channel, playbackState: playback);
+  }
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    final prefs = await SharedPreferences.getInstance();
+    liveStorage = RecentlyWatchedStorage(prefs);
+    vodStorage = VodWatchHistoryStorage(prefs);
+    states = StreamController<StreamingState>.broadcast();
+    container = ProviderContainer(
+      overrides: [
+        sharedPreferencesProvider.overrideWithValue(prefs),
+        recentlyWatchedStorageProvider.overrideWithValue(liveStorage),
+        vodWatchHistoryStorageProvider.overrideWithValue(vodStorage),
+        streamingStateStreamProvider.overrideWithValue(states.stream),
+      ],
+    );
+    addTearDown(() async {
+      container.dispose();
+      await states.close();
+    });
+    // Activate the recorder (in the app, VideoPlayerWidget watches it).
+    container.read(recentlyWatchedRecorderProvider);
+  });
+
+  test(
+    'a channel that fails to start is NOT added to recently watched',
+    () async {
+      states.add(stateFor(channelA, PlaybackState.loading));
+      states.add(stateFor(channelA, PlaybackState.error));
+      await Future<void>.delayed(Duration.zero);
+
+      expect(await liveStorage.getRecentlyWatched(), isEmpty);
+    },
+  );
+
+  test('a channel is recorded once playback actually starts', () async {
+    states.add(stateFor(channelA, PlaybackState.loading));
+    states.add(stateFor(channelA, PlaybackState.playing));
+    await Future<void>.delayed(Duration.zero);
+
+    final recent = await liveStorage.getRecentlyWatched();
+    expect(recent.map((c) => c.id), ['chan-a']);
+  });
+
+  test('failed-then-successful play records only after the success', () async {
+    states.add(stateFor(channelA, PlaybackState.loading));
+    states.add(stateFor(channelA, PlaybackState.error));
+    await Future<void>.delayed(Duration.zero);
+    expect(await liveStorage.getRecentlyWatched(), isEmpty);
+
+    states.add(stateFor(channelA, PlaybackState.loading));
+    states.add(stateFor(channelA, PlaybackState.playing));
+    await Future<void>.delayed(Duration.zero);
+
+    expect((await liveStorage.getRecentlyWatched()).map((c) => c.id), [
+      'chan-a',
+    ]);
+  });
+
+  test('switching channels records each newly playing channel', () async {
+    states.add(stateFor(channelA, PlaybackState.playing));
+    states.add(stateFor(channelB, PlaybackState.loading));
+    states.add(stateFor(channelB, PlaybackState.playing));
+    await Future<void>.delayed(Duration.zero);
+
+    expect((await liveStorage.getRecentlyWatched()).map((c) => c.id), [
+      'chan-b',
+      'chan-a',
+    ]);
+  });
+
+  test(
+    'a pending VOD item lands in VOD history, not live recently watched',
+    () async {
+      container.read(pendingVodHistoryItemProvider.notifier).state = vodItem;
+
+      states.add(stateFor(vodSyntheticChannel, PlaybackState.loading));
+      states.add(stateFor(vodSyntheticChannel, PlaybackState.playing));
+      await Future<void>.delayed(Duration.zero);
+
+      expect(await vodStorage.getRecentlyWatched(), hasLength(1));
+      expect((await vodStorage.getRecentlyWatched()).single.id, 'vod-1');
+      expect(await liveStorage.getRecentlyWatched(), isEmpty);
+      // Pending marker consumed.
+      expect(container.read(pendingVodHistoryItemProvider), isNull);
+    },
+  );
+
+  test('a failed VOD play leaves the pending item unrecorded', () async {
+    container.read(pendingVodHistoryItemProvider.notifier).state = vodItem;
+
+    states.add(stateFor(vodSyntheticChannel, PlaybackState.loading));
+    states.add(stateFor(vodSyntheticChannel, PlaybackState.error));
+    await Future<void>.delayed(Duration.zero);
+
+    expect(await vodStorage.getRecentlyWatched(), isEmpty);
+    expect(await liveStorage.getRecentlyWatched(), isEmpty);
+  });
+}

--- a/packages/feature_iptv/test/iptv/presentation/widgets/video_player_widget_test.dart
+++ b/packages/feature_iptv/test/iptv/presentation/widgets/video_player_widget_test.dart
@@ -87,9 +87,12 @@ void main() {
         engine: FakeAiroPlaybackEngine(),
       );
       addTearDown(service.dispose);
+      SharedPreferences.setMockInitialValues({});
+      final prefs = await SharedPreferences.getInstance();
 
       final container = ProviderContainer(
         overrides: [
+          sharedPreferencesProvider.overrideWithValue(prefs),
           iptvStreamingServiceProvider.overrideWithValue(service),
           iptvChannelsProvider.overrideWith(
             (ref) async => const [current, next],
@@ -221,53 +224,52 @@ void main() {
   // button is reachable by tapping it via finder (never raw coordinates)
   // and asserting the real onBack callback fired.
   // ===========================================================================
-  testWidgets(
-    "PlayerOverlay's back button is reachable and invokes onBack",
-    (tester) async {
-      var backTapped = false;
+  testWidgets("PlayerOverlay's back button is reachable and invokes onBack", (
+    tester,
+  ) async {
+    var backTapped = false;
 
-      SharedPreferences.setMockInitialValues({});
-      final prefs = await SharedPreferences.getInstance();
+    SharedPreferences.setMockInitialValues({});
+    final prefs = await SharedPreferences.getInstance();
 
-      await tester.pumpWidget(
-        ProviderScope(
-          overrides: [
-            sharedPreferencesProvider.overrideWithValue(prefs),
-            streamingStateProvider.overrideWith(
-              (ref) => Stream.value(
-                StreamingState(
-                  playbackState: PlaybackState.playing,
-                  isLiveStream: true,
-                  currentChannel: const IPTVChannel(
-                    id: 'news-1',
-                    name: 'City News Live',
-                    streamUrl: 'https://example.com/news.m3u8',
-                    group: 'News',
-                    category: ChannelCategory.news,
-                  ),
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          sharedPreferencesProvider.overrideWithValue(prefs),
+          streamingStateProvider.overrideWith(
+            (ref) => Stream.value(
+              StreamingState(
+                playbackState: PlaybackState.playing,
+                isLiveStream: true,
+                currentChannel: const IPTVChannel(
+                  id: 'news-1',
+                  name: 'City News Live',
+                  streamUrl: 'https://example.com/news.m3u8',
+                  group: 'News',
+                  category: ChannelCategory.news,
                 ),
               ),
             ),
-          ],
-          child: MaterialApp(
-            home: Scaffold(
-              body: VideoPlayerWidget(onBack: () => backTapped = true),
-            ),
+          ),
+        ],
+        child: MaterialApp(
+          home: Scaffold(
+            body: VideoPlayerWidget(onBack: () => backTapped = true),
           ),
         ),
-      );
-      await tester.pump();
-      await tester.pump(const Duration(milliseconds: 100));
+      ),
+    );
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 100));
 
-      final backButton = find.byKey(const ValueKey('player-overlay-back'));
-      expect(backButton, findsOneWidget);
+    final backButton = find.byKey(const ValueKey('player-overlay-back'));
+    expect(backButton, findsOneWidget);
 
-      await tester.tap(backButton);
-      await tester.pump();
+    await tester.tap(backButton);
+    await tester.pump();
 
-      expect(backTapped, isTrue);
-    },
-  );
+    expect(backTapped, isTrue);
+  });
 
   // ===========================================================================
   // Engine-driven playback + subtitle/track selector (CV-016 migration). These
@@ -282,10 +284,15 @@ void main() {
         engine: FakeAiroPlaybackEngine(),
       );
       addTearDown(service.dispose);
+      SharedPreferences.setMockInitialValues({});
+      final prefs = await SharedPreferences.getInstance();
 
       await tester.pumpWidget(
         ProviderScope(
-          overrides: [iptvStreamingServiceProvider.overrideWithValue(service)],
+          overrides: [
+            sharedPreferencesProvider.overrideWithValue(prefs),
+            iptvStreamingServiceProvider.overrideWithValue(service),
+          ],
           child: const MaterialApp(home: VideoPlayerWidget()),
         ),
       );
@@ -304,6 +311,8 @@ void main() {
     final engine = FakeAiroPlaybackEngine(tracks: const []);
     final service = VideoPlayerStreamingService(engine: engine);
     addTearDown(service.dispose);
+    SharedPreferences.setMockInitialValues({});
+    final prefs = await SharedPreferences.getInstance();
 
     // Pump the widget (and subscribe to service.stateStream via
     // streamingStateProvider) BEFORE calling playChannel(). The service's
@@ -317,7 +326,10 @@ void main() {
     // Material ancestor once the widget reaches its "player" state.
     await tester.pumpWidget(
       ProviderScope(
-        overrides: [iptvStreamingServiceProvider.overrideWithValue(service)],
+        overrides: [
+          sharedPreferencesProvider.overrideWithValue(prefs),
+          iptvStreamingServiceProvider.overrideWithValue(service),
+        ],
         child: const MaterialApp(home: Scaffold(body: VideoPlayerWidget())),
       ),
     );
@@ -369,6 +381,8 @@ void main() {
       );
       final service = VideoPlayerStreamingService(engine: engine);
       addTearDown(service.dispose);
+      SharedPreferences.setMockInitialValues({});
+      final prefs = await SharedPreferences.getInstance();
 
       // See comment in the test above — pump before playChannel() so the
       // widget's stream subscription is live in time to observe the
@@ -376,7 +390,10 @@ void main() {
       // ancestor the control bar's volume Slider requires.
       await tester.pumpWidget(
         ProviderScope(
-          overrides: [iptvStreamingServiceProvider.overrideWithValue(service)],
+          overrides: [
+            sharedPreferencesProvider.overrideWithValue(prefs),
+            iptvStreamingServiceProvider.overrideWithValue(service),
+          ],
           child: const MaterialApp(home: Scaffold(body: VideoPlayerWidget())),
         ),
       );
@@ -553,7 +570,10 @@ void main() {
     (tester) async {
       await pumpPlayer(tester, enableTouchGestures: false);
 
-      expect(find.byKey(const ValueKey('iptv-player-lock-button')), findsNothing);
+      expect(
+        find.byKey(const ValueKey('iptv-player-lock-button')),
+        findsNothing,
+      );
       expect(find.byType(PlayerGestureOverlay), findsNothing);
     },
   );
@@ -563,7 +583,10 @@ void main() {
     (tester) async {
       await pumpPlayer(tester);
 
-      expect(find.byKey(const ValueKey('iptv-player-lock-button')), findsOneWidget);
+      expect(
+        find.byKey(const ValueKey('iptv-player-lock-button')),
+        findsOneWidget,
+      );
       expect(find.byType(PlayerGestureOverlay), findsOneWidget);
     },
   );


### PR DESCRIPTION
Move local live and VOD history writes behind confirmed playback state so failed stream attempts no longer pollute recently watched or continue watching rails.

Adds recorder coverage for failed starts, successful starts, channel switching, and VOD routing while keeping Cast history behavior unchanged for this slice.

## Summary

<!-- What changed and why? -->

## Test Plan

- [ ] `flutter analyze` or relevant package analyzer passed
- [ ] `flutter test` or relevant package tests passed
- [ ] CI-only change validated with local script/YAML checks
- [ ] Manual device/simulator verification documented, or not applicable

**Verification environment:** Host-only / Physical Android / iOS simulator / Android Emulator with explicit opt-in

## Agent Policy

- [ ] Linked issue includes a Critical Agent Gate.
- [ ] Linked issue includes a Feature Packet or documents why one is not needed.
- [ ] Cross-agent contract is documented for framework/application boundary work.
- [ ] Deterministic use cases and automation flows are linked or included.
- [ ] AI/tool/memory/routine changes include eval, trace, and redaction coverage.
- [ ] Android Emulator was not used unless the linked issue explicitly accepted
      `AIRO_ALLOW_ANDROID_EMULATOR=true`.

## Council Review

Per the Decision Matrix in [docs/agents/COUNCIL.md](../docs/agents/COUNCIL.md),
list every role required for this change's category and confirm each has
reviewed (name a human/agent session, or link their review comment):

<!-- Example:
- Rust Architect: reviewed by @handle
- Chief Performance Officer: reviewed by claude session <link>
- Chief Security Officer: reviewed by claude session <link>
-->

- [ ] I checked the Decision Matrix and listed every required role above.
- [ ] Every package touched has a `module.yaml`; if not, this PR adds one
      (`scripts/check-module-manifests.py` enforces this in CI).
- [ ] `owner`/`reviewers` in any touched `module.yaml` still match who
      actually reviewed this PR — updated if the roster has drifted.

## User-Facing Documentation

Every PR must keep the Airo public capability wiki accurate.

- [ ] I updated `docs/wiki` for any user-visible feature, route, platform,
      install, AI/model, privacy, file-type, media, game, finance, or
      troubleshooting change.
- [ ] No `docs/wiki` update is needed because this PR has no user-visible
      behavior or documentation impact.

Docs bypass for intentional exceptions:
use the `docs-not-needed` PR label or include `docs-not-needed` in the commit
message.

## Plugin and Size Impact

- [ ] This PR adds new dependencies
- [ ] This PR adds or grows app/packages/plugins code
- [ ] Size impact is documented below
- [ ] Any module over 3 MB is a plugin or has an explicit plugin marker
- [ ] Any plugin over 5 MB has cache-management documentation

Size impact / plugin justification:

<!-- Example: packages/feature_x adds 1.4 MB source footprint and remains bundled because ... -->

## Checklist

- [ ] Code is formatted.
- [ ] Tests or manual verification are included above.
- [ ] Sensitive data, credentials, and signing artifacts are not committed.

## Release Notes

- [ ] User-facing change documented, or not applicable
