### PR TITLE
docs: rewrite README with superapp positioning aligned to marketing site

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,208 +1,116 @@
+<div align="center">
+
 # Airo
 
-[![Download Airo TV](https://img.shields.io/badge/Download-Airo%20TV-success)](https://github.com/DevelopersCoffee/airo/releases/download/airo-tv-v0.0.2/Airo-TV-v0.0.2.apk)
+**The open-source super app — AI chat, personal finance, TV & music, games, and reading in one local-first Flutter codebase.**
+
+🌐 **[developerscoffee.github.io/airo](https://developerscoffee.github.io/airo/)** — live showcase, guides, and roadmap
+
 [![GitHub Release](https://img.shields.io/github/v/release/DevelopersCoffee/airo)](https://github.com/DevelopersCoffee/airo/releases)
-[![Flutter](https://img.shields.io/badge/Flutter-3.44.4+-blue.svg)](https://flutter.dev/)
-[![License: MIT](https://img.shields.io/badge/license-MIT-green)](LICENSE)
-[![Security Policy](https://img.shields.io/badge/security-policy-brightgreen)](SECURITY.md)
+[![Downloads](https://img.shields.io/github/downloads/DevelopersCoffee/airo/total)](https://github.com/DevelopersCoffee/airo/releases)
+[![CI](https://github.com/DevelopersCoffee/airo/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/DevelopersCoffee/airo/actions/workflows/ci.yml)
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=DevelopersCoffee_airo&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=DevelopersCoffee_airo)
-[![Trust](https://img.shields.io/badge/trust-transparent-brightgreen)](TRUST.md)
-[![Versioning](https://img.shields.io/badge/versioning-semver-blue)](CHANGELOG.md)
-[![Android TV](https://img.shields.io/badge/Android%20TV-compatible-green)](docs/release/AIRO_TV_v0.0.2.md)
+[![License: MIT](https://img.shields.io/badge/license-MIT-green)](LICENSE)
+[![Last Commit](https://img.shields.io/github/last-commit/DevelopersCoffee/airo)](https://github.com/DevelopersCoffee/airo/commits/main)
+[![GitHub Stars](https://img.shields.io/github/stars/DevelopersCoffee/airo?style=social)](https://github.com/DevelopersCoffee/airo/stargazers)
 
-Airo is a Flutter super app for local-first AI workflows: chat, model management,
-routine packs, media surfaces, and personal finance modules in one modular mobile
-codebase.
+![Airo super app](docs/assets/images/airo_superapp_mockup.jpg)
 
-The project is being shaped as an open-source playground for developers who care
-about on-device AI, agent skills, privacy-aware product design, and cross-platform
-Flutter architecture.
+[Download](#download) · [Modules](#modules) · [Quick Start](#quick-start) · [Contributing](#contributing) · [Docs](#documentation)
 
-## Why Star Or Fork This Repo
+</div>
 
-- **Build local-first AI UX**: help make model routing, offline fallback, and
-  privacy-forward AI interactions usable in a real app.
-- **Work across the stack**: Flutter UI, Android/iOS platform bridges, package
-  boundaries, CI, docs, release automation, and QA flows all live here.
-- **Contribute in small slices**: docs fixes, onboarding polish, tests, issue
-  reproduction, UI states, model metadata, and DevEx improvements are all useful.
-- **Learn agent-driven engineering**: every non-trivial change follows the
-  ownership, contract, and deterministic automation flow in
-  [`docs/agents/AGENT_POLICY.md`](docs/agents/AGENT_POLICY.md).
+---
 
-If this direction is useful to you, star the repo to follow the work. Fork it
-when you want to run experiments or send a PR.
+**Airo is the home.** A modular super app built with Flutter — Airo TV is its
+first focused product, available now. Every module is local-first: your data,
+playlists, and conversations stay on your device by default. On-device AI
+drives the experience — model routing, offline fallback, and privacy-forward
+interactions in a real shipping app, not a demo.
 
-## What You Can Work On
+## Modules
 
-Good open-source entry points:
+| Module | What it does | Status |
+|---|---|---|
+| 📺 **Airo TV** | Bring-your-own-playlist IPTV player for Android TV | **Available — [v0.0.3](https://github.com/DevelopersCoffee/airo/releases/tag/airo-tv-v0.0.3)** |
+| ⭐ **Airo TV Pro** | Import intelligence, resilient playback, guide intelligence | In testing |
+| 🤖 **Airo AI** | On-device AI chat (Gemini Nano), model management, agent skills | In development |
+| 💰 **AiroMoney** | Personal finance tracking and money workflows | In development |
+| 🎵 **Airo Music** | Music playback surfaces | In development |
+| ♟️ **Airo Games** | Chess and casual games (Stockfish engine) | In development |
+| 📖 **Airo Reader** | Reading surfaces with OCR | In development |
 
-- Improve first-run setup and troubleshooting docs.
-- Add or harden host-only tests for existing features.
-- Reproduce and minimize open bugs.
-- Improve accessibility, empty states, and responsive layout behavior.
-- Document model support, privacy behavior, and release checks.
-- Turn repeated setup or review steps into scripts.
+All modules live in one monorepo with strict package boundaries — see the
+[Repository Map](#repository-map).
 
-Start with:
+## 📺 Airo TV — Available Now
 
-- [Issues labeled `good first issue`](https://github.com/DevelopersCoffee/airo/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22)
-- [Issues labeled `help wanted`](https://github.com/DevelopersCoffee/airo/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22)
-- [Contributor guide](CONTRIBUTING.md)
-- [Open-source growth playbook](docs/community/GITHUB_GROWTH_PLAYBOOK.md)
+[![Download Airo TV](https://img.shields.io/badge/Download-Airo%20TV%20APK-success?style=for-the-badge)](https://github.com/DevelopersCoffee/airo/releases/download/airo-tv-v0.0.3/Airo-TV-v0.0.3.apk)
+[![Live Showcase](https://img.shields.io/badge/▶-Live%20Showcase-blue?style=for-the-badge)](https://developerscoffee.github.io/airo/)
 
+![Airo TV channel grid](docs/store-assets/airo-tv/01-tv-home-channel-grid.png)
 
-## Airo TV v0.0.2
+Airo TV is the focused Android TV build of Airo's media module
+(`io.airo.app.tv`). TV-first channel grid, search, and playback for your own
+M3U/M3U8 playlists.
 
-Airo TV is the Android TV variant of Airo, built from the current `main` release line (formerly `v2`) with package name `io.airo.app.tv`. The v0.0.2 release focuses on release trust, documentation, checksums, clean artifact names, and Play Store readiness.
-
-- Bring your own authorized M3U playlist URL; Airo TV does not provide IPTV content.
-- Release assets include APK, Play Store AAB, and SHA256 checksums.
-- Documentation covers privacy, security, threat model, roadmap, architecture, feature matrix, and reproducible builds.
-- Google Cast requires receiver discovery over `_googlecast._tcp` and port `8009` reachability on the local network.
-- Release artifacts are published at https://github.com/DevelopersCoffee/airo/releases/tag/airo-tv-v0.0.2.
-
-## V2 Release Health
-
-The current mainline Airo TV release line is coordinated through
-[`.github/workflows/v2-release-orchestrator.yml`](.github/workflows/v2-release-orchestrator.yml)
-and documented in
-[`docs/release/V2_RELEASE_ORCHESTRATOR.md`](docs/release/V2_RELEASE_ORCHESTRATOR.md).
-Public-release setup, maintainer decisions, and local evidence gates are tracked
-in
-[`docs/release/V2_PUBLISHING_HUMAN_SETUP.md`](docs/release/V2_PUBLISHING_HUMAN_SETUP.md),
-[`docs/release/V2_HUMAN_IN_LOOP_BLOCKERS.md`](docs/release/V2_HUMAN_IN_LOOP_BLOCKERS.md),
-[`docs/release/REPOSITORY_HEALTH_STATUS.md`](docs/release/REPOSITORY_HEALTH_STATUS.md),
-and [`docs/release/RELEASE_CHECKLIST.md`](docs/release/RELEASE_CHECKLIST.md).
-Security and community process files live in [`SECURITY.md`](SECURITY.md),
-[`CONTRIBUTING.md`](CONTRIBUTING.md), and
-[`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md).
-
-## Why Trust Airo?
-
-- Open source codebase with public issue tracking.
-- No bundled IPTV channels or copyrighted content.
-- User playlists remain on the device unless users load a remote playlist URL directly.
-- Release APK and AAB assets publish SHA256 checksums.
-- Transparent roadmap, changelog, security policy, privacy policy, and threat model.
-- No hidden subscriptions or mandatory accounts for the Airo TV player flow.
+- **Bring your own playlist** — Airo TV ships no IPTV content and no bundled channels.
+- **Google Cast support** — requires `_googlecast._tcp` discovery and port `8009` on the local network.
+- **Verifiable releases** — APK, Play Store AAB, macOS preview, and SHA256 checksums on every release.
+- **Honest device support** — Android TV available, Fire TV experimental, mobile partial, macOS preview, iPad verified; see [device paths](https://developerscoffee.github.io/airo/).
+- **Documented** — [architecture](docs/architecture/AIRO_TV_ARCHITECTURE.md), [threat model](docs/security/AIRO_TV_THREAT_MODEL.md), [release docs](docs/release/README.md).
 
 ## Download
 
-### Android
+| Platform | Link |
+|---|---|
+| 📺 Android TV | [Airo TV v0.0.3 APK](https://github.com/DevelopersCoffee/airo/releases/download/airo-tv-v0.0.3/Airo-TV-v0.0.3.apk) |
+| 🖥️ macOS (preview) | [Airo TV DMG](https://github.com/DevelopersCoffee/airo/releases/download/airo-tv-v0.0.3/Airo-TV-0.0.3-macOS.dmg) |
+| 🤖 Android | [Android releases](https://github.com/DevelopersCoffee/airo/releases) |
+| 🍎 iOS | [Latest IPA](https://github.com/DevelopersCoffee/airo/releases/latest/download/app-release.ipa) |
+| 🌐 Web | [Web build](https://github.com/DevelopersCoffee/airo/releases/latest/download/airo-web-release.zip) |
+| 📦 All | [All releases](https://github.com/DevelopersCoffee/airo/releases) |
 
-[View Android releases](https://github.com/DevelopersCoffee/airo/releases)
-
-### Airo TV
-
-[Download Airo TV APK](https://github.com/DevelopersCoffee/airo/releases/download/airo-tv-v0.0.2/Airo-TV-v0.0.2.apk)
-
-### iOS
-
-[Download latest IPA](https://github.com/DevelopersCoffee/airo/releases/latest/download/app-release.ipa)
-
-### Web
-
-[Download web build](https://github.com/DevelopersCoffee/airo/releases/latest/download/airo-web-release.zip)
-
-### All Platforms
-
-[View all releases](https://github.com/DevelopersCoffee/airo/releases)
-
-Before installing a direct-download APK, verify it with
+Before installing a direct-download APK, verify it against
 [`SHA256SUMS`](VERIFY_DOWNLOAD.md).
 
-## Quick Start
+## Why Trust Airo?
 
-### First-Time Setup
+- Open-source codebase with public issue tracking and a transparent [roadmap](ROADMAP.md).
+- Local-first: playlists and data stay on the device unless you load a remote URL directly.
+- No bundled IPTV channels or copyrighted content.
+- SHA256 checksums published for every release APK and AAB.
+- Public [security policy](SECURITY.md), [privacy policy](PRIVACY.md), [threat model](docs/security/AIRO_TV_THREAT_MODEL.md), and [trust report](TRUST.md).
+- No hidden subscriptions and no mandatory accounts for the Airo TV player flow.
+
+## Quick Start
 
 ```bash
 git clone git@github.com:DevelopersCoffee/airo.git
 cd airo
-make setup
+make setup        # or: make setup-android / setup-ios / setup-web
 ```
 
-Platform-specific setup:
+Run the app:
 
 ```bash
-make setup-android
-make setup-ios
-make setup-web
+make run-android  # or: run-ios / run-web / run-chrome
 ```
 
-### Run The App
+Verify changes:
 
 ```bash
-make run-android
-make run-ios
-make run-web
-make run-chrome
+make format && make analyze && make test
 ```
 
-Device-targeted helpers:
+Run `make help` for the full command list, including device-targeted helpers
+(`run-pixel9`, `run-iphone13`). For the Airo TV Edge Intelligence runtime
+(Rust FFI, media packs), see
+[docs/features](docs/features/README.md).
 
-```bash
-make run-pixel9
-make run-iphone13
-```
+### Platform Support
 
-### Airo TV Edge Intelligence
-
-The IPTV feature consumes `slm_edge_intelligence` from the public
-`DevelopersCoffee/barista-tuning` Git package. By default it uses the public
-rule backend:
-
-```bash
-flutter run -t lib/main_airo_iptv.dart
-```
-
-To use the Rust FFI pack-backed runtime, bundle the native `edge-ffi` artifact
-with the app and pass the media pack path by configuration:
-
-```bash
-flutter run -t lib/main_airo_iptv.dart \
-  --dart-define=AIRO_EDGE_INTELLIGENCE_BACKEND=native \
-  --dart-define=AIRO_MEDIA_PACK=/absolute/path/to/media.pack
-```
-
-For device builds where the pack is bundled as a Flutter asset, place it under
-`app/assets/packs/` and pass the asset key instead:
-
-```bash
-flutter run -t lib/main_airo_iptv.dart \
-  --dart-define=AIRO_EDGE_INTELLIGENCE_BACKEND=native \
-  --dart-define=AIRO_MEDIA_PACK_ASSET=assets/packs/media.pack
-```
-
-The Flutter screen still only submits natural-language media requests and plays
-the returned stream URI; pack installation and backend selection stay behind the
-feature package provider layer.
-
-Android TV builds must include `libedge_ffi.so` under
-`app/android/app/src/main/jniLibs/<abi>/`. From the Edge Intelligence repo:
-
-```bash
-slm package-edge-ffi-android \
-  --airo-app /absolute/path/to/airo/app \
-  --build \
-  --abi arm64-v8a
-```
-
-### Verify Changes
-
-```bash
-make format
-make analyze
-make test
-```
-
-Run `make help` to see the full command list.
-
-## Platform Support
-
-- **Android**: API 24+ with Pixel 9 helper targets.
-- **iOS**: iOS 12.0+ with iPhone 13 Pro Max helper targets.
-- **Web**: modern browsers, with Chrome as the preferred development target.
+- **Android**: API 24+ · **iOS**: 12.0+ · **Web**: modern browsers (Chrome preferred for development).
 
 Android release builds require private signing material. Never commit
 `app/android/key.properties`, keystores, tokens, API keys, or local credentials.
@@ -226,53 +134,39 @@ Android release builds require private signing material. Never commit
 └── .github/              # CI, issue templates, PR template
 ```
 
-## Contributor Workflow
+## Contributing
+
+Airo is an open-source playground for developers who care about on-device AI,
+agent-driven engineering, and cross-platform Flutter architecture. Star the
+repo to follow the work; fork it to experiment or send a PR.
+
+Good entry points:
+
+- Docs fixes, onboarding polish, and troubleshooting guides.
+- Host-only tests, bug reproduction, and accessibility improvements.
+- [`good first issue`](https://github.com/DevelopersCoffee/airo/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) · [`help wanted`](https://github.com/DevelopersCoffee/airo/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22)
+
+Workflow:
 
 1. Read [`CONTRIBUTING.md`](CONTRIBUTING.md).
 2. Pick or create a GitHub issue.
-3. Add the Critical Agent gate and Feature Packet required by
-   [`docs/agents/AGENT_POLICY.md`](docs/agents/AGENT_POLICY.md).
-4. Create a short-lived branch or worktree from the correct release-line base.
-   Use `origin/main` for current work. Only use `origin/v1_bkp` when the
-   linked issue explicitly targets the legacy pre-swap branch state.
-5. Keep the PR scoped, run the relevant checks, and document any test gaps.
-
-For parallel work, prefer a worktree:
-
-```bash
-git fetch origin main v1_bkp
-git worktree add -b codex/my-task ../airo-my-task origin/main
-cd ../airo-my-task
-```
+3. Follow the agent gate and Feature Packet flow in [`docs/agents/AGENT_POLICY.md`](docs/agents/AGENT_POLICY.md).
+4. Branch from `origin/main`, keep the PR scoped, run the relevant checks.
 
 ## Documentation
 
-- [GitHub wiki source](docs/wiki/README.md)
-- [Architecture docs](docs/architecture/README.md)
-- [Feature docs](docs/features/README.md)
-- [Security and code quality docs](docs/security/README.md)
-- [Release docs](docs/release/README.md)
-- [Troubleshooting docs](docs/troubleshooting/README.md)
+- [Architecture](docs/architecture/README.md) · [Features](docs/features/README.md) · [Security](docs/security/README.md) · [Release](docs/release/README.md) · [Troubleshooting](docs/troubleshooting/README.md) · [Wiki source](docs/wiki/README.md)
+- Release engineering: [V2 orchestrator](docs/release/V2_RELEASE_ORCHESTRATOR.md) · [release checklist](docs/release/RELEASE_CHECKLIST.md) · [repository health](docs/release/REPOSITORY_HEALTH_STATUS.md)
 
 ## Community Standards
 
-- [Contributing guide](CONTRIBUTING.md)
-- [Code of conduct](CODE_OF_CONDUCT.md)
-- [Security policy](SECURITY.md)
-- [Trust and transparency](TRUST.md)
-- [Download verification](VERIFY_DOWNLOAD.md)
-- [Privacy policy](PRIVACY.md)
-- [Roadmap](ROADMAP.md)
-- [Changelog](CHANGELOG.md)
-- [Airo TV threat model](docs/security/AIRO_TV_THREAT_MODEL.md)
-- [Airo TV architecture](docs/architecture/AIRO_TV_ARCHITECTURE.md)
-- [Agent policy](docs/agents/AGENT_POLICY.md)
+[Contributing](CONTRIBUTING.md) · [Code of Conduct](CODE_OF_CONDUCT.md) · [Security Policy](SECURITY.md) · [Trust](TRUST.md) · [Privacy](PRIVACY.md) · [Roadmap](ROADMAP.md) · [Changelog](CHANGELOG.md) · [Download Verification](VERIFY_DOWNLOAD.md)
 
 ## License
 
 Airo is licensed under the [MIT License](LICENSE).
 
-V2 release profiles also include third-party dependencies with their own
-licenses. See [V2 Third-Party Notices](docs/release/V2_THIRD_PARTY_NOTICES.md)
-and [V2 License Review](docs/release/V2_LICENSE_REVIEW.md) before public
+Release profiles include third-party dependencies with their own licenses. See
+[Third-Party Notices](docs/release/V2_THIRD_PARTY_NOTICES.md) and the
+[License Review](docs/release/V2_LICENSE_REVIEW.md) before public
 redistribution.

--- a/docs/superpowers/specs/2026-07-20-live-grid-epg-nav-design.md
+++ b/docs/superpowers/specs/2026-07-20-live-grid-epg-nav-design.md
@@ -1,0 +1,251 @@
+# Live Grid Navigation (EPG) — Design
+
+Status: Draft (spec self-reviewed, pending user review)
+Owner: Airo TV mobile + TV guide surfaces (feature_iptv)
+Related: `docs/superpowers/plans/2026-07-17-cv015-slice2-epg-grid.md` (predecessor EPG grid work — shipped `EpgTimelineGrid` + `guide_providers.dart`), `docs/superpowers/specs/2026-07-19-immediate-action-player-design.md` (predecessor Player spec — this spec reuses its `/iptv?channel=<id>` deep-link route for reminder notification taps)
+
+## Background
+
+Market scan (same sources as the Player spec, re-confirmed 2026-07-20 — see
+Sources) establishes the 2026 norms this spec designs against:
+
+- Mobile streaming apps use a bottom tab bar of 4–5 primary destinations;
+  Airo's phone shell already ships exactly this (Home, Live, Guide, Favorites,
+  Settings via `AppShell`'s `NavigationBar`), so Requirement 5 reduces to
+  verifying/fixing back-button behavior, not rebuilding navigation chrome.
+- Live guides on phone are free-drag-scrollable timelines (Pluto TV, YouTube
+  TV); on TV they are focus-traversal grids. The interaction models are
+  surface-native and must not be forced into one widget ("each surface needs
+  platform-native conventions, not the same UI scaled").
+- Time-to-content is the guiding metric: a sticky "jump to now" affordance
+  and at-a-glance progress state are the difference between a grid that
+  feels live and one that feels like a static table.
+
+The repo already has the shared data foundation: CV-015 slice 2 shipped
+`guide_providers.dart` (`guideEpgWindowProvider` with match-override
+remapping) and `EpgTimelineGrid`, a D-pad/focus-driven timeline grid used by
+`IptvGuideScreen` on both TV and (adapted) phone. That grid is deliberately
+focus-only — every row uses `NeverScrollableScrollPhysics`, scroll follows
+focus — so it cannot satisfy phone touch interaction. This spec adds a
+separate touch interaction implementation over the same data layer, plus the
+now-anchor, progress tickers, and phone-only reminders. TV keeps its
+receiver-only role: it gains the shared grid improvements (progress ticker,
+jump-to-present) but no scheduling/notification surface.
+
+Sources:
+- https://blog.mercury.io/designing-great-streaming-tv-apps-pt-1-introduction/
+- https://www.forasoft.com/blog/article/streaming-app-ux-best-practices
+
+## Goals
+
+1. **Time-axis scrolling (both surfaces).** Horizontal timeline of scheduled
+   programming paired with a vertical channel list. Phone: free two-axis
+   drag scroll over a window spanning `now-30min … now+24h`, loaded in
+   3-hour pages as the user scrolls. TV: existing focus-follow-scroll,
+   unchanged in feel.
+2. **"Now Playing" anchor (both surfaces).** A "Jump to Present" control
+   snaps the grid back to the current time slot — a sticky extended FAB on
+   phone (visible only when `now` is scrolled out of the viewport), a
+   focusable header button on TV.
+3. **Visual progress tickers (both surfaces).** Current program blocks show
+   a live progress fill and a "N min left" label, driven by a shared 30s
+   `nowTickerProvider`; the existing now-line indicator is retained.
+4. **Notification reminders (phone only).** One tap on a future program
+   block schedules an OS local notification (via
+   `flutter_local_notifications`, already an `app` dependency) at program
+   start; tapping the notification opens the channel directly via the
+   existing `/iptv?channel=<id>` deep link. Tapping a currently-airing
+   block plays the channel immediately (consistent with the Immediate
+   Action Player: no interstitial). Reminders persist across restarts and
+   are pruned once elapsed.
+5. **Navigation norms (phone only).** The existing Material 3
+   `NavigationBar` with the Guide tab is retained (matches the 4–5 tab
+   norm). Android hardware back and iOS swipe-back from the guide follow
+   the standard route stack — verified and fixed where broken; no
+   Cupertino rework.
+
+## Non-Goals
+
+- TV-side reminders, scheduling, or any notification surface — TV is
+  receiver-only per the Core TV Device-Role Principle. Requirements 4–5 do
+  not touch `iptv_tv_screen.dart` or the TV nav shell.
+- A single unified grid widget with an interaction-mode parameter —
+  rejected in favor of two widgets over one data layer, so each interaction
+  model evolves independently and TV focus traversal cannot regress from
+  phone work.
+- Xtream/Stalker EPG ingestion, catch-up/timeshift from guide cells —
+  carried over as non-goals from CV-015 slice 2.
+- Past browsing beyond `now-30min` — past blocks are dimmed and
+  non-interactive; the timeline floor is fixed.
+- `platform_epg` changes — `loadWindow(GuideWindowQuery)` already supports
+  arbitrary windows; pagination is an application-layer concern.
+
+## Architecture
+
+Three layers, same shape as the Player feature (application coordinators
+over platform primitives):
+
+- **`platform_epg`** — untouched (pure data/model layer per its
+  `module.yaml`).
+- **`feature_iptv/application`** — new orchestration: paged guide-window
+  provider, shared now-ticker, reminder store + scheduler.
+- **`feature_iptv/presentation`** — two interaction implementations over
+  one data path: existing `EpgTimelineGrid` (TV, D-pad) and new
+  `EpgTouchTimelineGrid` (phone, drag/tap). `IptvGuideScreen` selects the
+  grid by form factor, as it already adapts chrome via `overrideFormFactor`.
+
+### New components
+
+**`GuidePagedWindowNotifier`** (`feature_iptv/lib/application/providers/guide_providers.dart`, additive)
+- Holds loaded 3-hour pages keyed by page start, merged into one
+  `CompactEpgWindow` view for consumers.
+- Initial load covers `[now-30min, now+6h)`; `extendForward()` loads the
+  next 3h page, hard-capped at `now+24h`; the lower bound is fixed at
+  `now-30min`.
+- Reuses the match-override query+remap logic currently inside
+  `guideEpgWindowProvider` — extracted into a shared helper so both query
+  paths stay byte-identical in behavior (override application and
+  channel-id remapping must not diverge between the two grids).
+- A failed page load keeps already-loaded pages and records a per-edge
+  error state the UI renders as an inline retry cell (see Error Handling).
+- Both grids consume this paged provider's merged window: the phone grid
+  drives pagination via its scroll-edge listener, while the TV grid simply
+  renders its fixed 3h viewport from the initially loaded pages (a subset)
+  and never triggers `extendForward()`. The legacy `guideEpgWindowProvider`
+  is superseded by the paged provider and removed once both grids are
+  migrated, keeping exactly one data path (Approach A).
+
+**`nowTickerProvider`** (`guide_providers.dart`, additive)
+- 30s periodic `StreamProvider<DateTime>` (UTC). Lifts the cadence of the
+  existing `_CurrentTimeIndicator`'s private `Timer.periodic` into a shared
+  provider so the now-line, progress fills, and "N min left" labels on both
+  grids run off one clock.
+
+**`EpgReminderStore`** (`feature_iptv/lib/application/epg_reminder_store.dart`)
+- Persisted list of `{channelId, programId, title, startsAt,
+  notificationId}` via `core_data`'s `KeyValueStore` as a single JSON blob —
+  mirrors `XmltvSourceStore` (reminder counts are small).
+- `save/remove/list/pruneElapsed(now)` primitives only; no scheduling
+  logic.
+
+**`EpgReminderScheduler`** (`feature_iptv/lib/application/epg_reminder_scheduler.dart`)
+- Wraps `flutter_local_notifications` (already in `app/pubspec.yaml`;
+  pattern precedent: `app/lib/features/quest/domain/services/reminder_service.dart`).
+- `scheduleReminder(program)` — requests OS permission on first use;
+  schedules a local notification at `program.startsAt`; persists via
+  `EpgReminderStore`. Returns an enum outcome: `scheduled`,
+  `scheduledInAppOnly` (permission denied — see Error Handling),
+  `unavailable` (`MissingPluginException`, e.g. macOS/web/debug hosts).
+- `cancelReminder(programId)` — cancels the OS notification and removes the
+  store record.
+- `isAvailable` — false on `MissingPluginException`; the UI hides the
+  reminder affordance entirely in that case.
+
+**`EpgTouchTimelineGrid`** (`feature_iptv/lib/presentation/widgets/epg_touch_timeline_grid.dart`)
+- New phone widget. Two-axis drag scroll: vertical channel list +
+  horizontal timeline rows sharing one `ScrollController` with the
+  time-axis header (same multi-attachment pattern as the TV grid — read
+  extents via `.positions.first`, never `.position` — but with drag physics
+  instead of `NeverScrollableScrollPhysics`).
+- Sticky channel-label column; program blocks sized by duration using the
+  same `pxPerMinute` model as the TV grid (tuned const for phone density).
+- Per-current-block progress fill + "N min left" label driven by
+  `nowTickerProvider`; past blocks dimmed and non-interactive.
+- Tap a currently-airing block → `iptvStreamingServiceProvider.playChannel`
+  immediately (no interstitial, per the Player spec). Tap a future block →
+  toggle reminder via `EpgReminderScheduler`, with snackbar confirm + Undo.
+- Scroll-edge listener triggers `GuidePagedWindowNotifier.extendForward()`.
+- Sticky "Jump to Present" extended FAB, visible only when `now` is outside
+  the visible time viewport; animates the shared controller back to the now
+  offset.
+
+**`EpgTimelineGrid` additions (TV, additive only)**
+- Same progress fill + "N min left" rendering inside current blocks
+  (visual only), driven by `nowTickerProvider`.
+- A focusable "Jump to Present" button in the guide header that re-scrolls
+  the shared controller to the now offset. Focus traversal and
+  `NeverScrollableScrollPhysics` are unchanged.
+
+### App-shell wiring
+
+- Reminder notification taps resolve through the existing
+  `/iptv?channel=<id>` deep-link route (shipped in the Player feature) — no
+  new route, no per-source special casing.
+- `IptvGuideScreen` renders `EpgTouchTimelineGrid` when the effective form
+  factor is phone/tablet, `EpgTimelineGrid` when TV — the same
+  `overrideFormFactor` mechanism it already uses.
+- Requirement 5 verification: Android hardware back from the guide follows
+  the `go_router` stack to the previous tab/exit; iOS back-swipe leaves no
+  orphaned grid state (controllers disposed, ticker canceled). Fixes are
+  made only where verification finds breakage.
+
+## Data Flow
+
+1. Guide opens → paged provider loads initial pages `[now-30min, now+6h)`
+   via the shared override-remap query path; grid renders rows with empty
+   timelines while pages stream in.
+2. User drags toward the forward edge → scroll listener calls
+   `extendForward()` → next 3h page merges → hard stop at `now+24h`;
+   backward drag stops at `now-30min`.
+3. `nowTickerProvider` ticks every 30s → now-line, progress fills, and
+   "N min left" labels recompute; when `now` crosses a block boundary,
+   current/past/future block status flips without re-querying EPG data.
+4. Tap current block → `playChannel` immediately (Player spec path).
+5. Tap future block → `EpgReminderScheduler.scheduleReminder` → (first
+   time) OS permission prompt → OS notification at `startsAt` + persisted
+   record → snackbar "Reminder set for \<title\>" with Undo →
+   `cancelReminder`. Tapping an already-reminded block cancels (toggle).
+6. Notification fires → user taps → app opens `/iptv?channel=<id>` → plays
+   immediately.
+7. On guide open and on app resume, `pruneElapsed` removes reminders whose
+   program has ended.
+
+## Error Handling
+
+- **Notification permission denied** → outcome `scheduledInAppOnly`: the
+  reminder is persisted and shown in-app (scheduled indicator on the
+  block), but no OS notification is scheduled; snackbar explains
+  "Notifications are off — reminder will only show in-app." No silent drop,
+  no crash.
+- **Reminded program disappears after an EPG refresh** → the notification
+  still fires with the stored title; the `/iptv?channel=<id>` deep link
+  falls back to the browse grid per the Player spec's missing-channel
+  handling.
+- **`MissingPluginException`** (macOS/web/debug hosts) → `isAvailable`
+  false; reminder affordance hidden on future blocks; grid and playback
+  unaffected. Matches the existing `native_fullscreen.dart` /
+  `AiroNativePictureInPicture` degradation pattern.
+- **Page load failure during pagination** → already-loaded pages stay
+  rendered; an inline "Couldn't load more guide data — Retry" cell renders
+  at the forward edge; retry re-issues the failed page load.
+- **EPG unavailable/stale** → existing `_GuideAvailabilityBanner` behavior
+  carries over unchanged; rows render with empty timelines.
+- **Zero-duration / malformed programs** → progress calculator clamps to
+  `[0, 1]`; zero-duration blocks render without a fill (no division by
+  zero).
+
+## Testing
+
+- **Unit:** `GuidePagedWindowNotifier` (page merge/dedup, 24h cap, -30min
+  floor, failed-page-keeps-loaded-pages, retry); shared override-remap
+  helper parity with the existing `guideEpgWindowProvider` behavior;
+  `EpgReminderStore` round-trip (mirrors `XmltvSourceStore` tests);
+  `EpgReminderScheduler` with a mocked notification plugin (schedule,
+  cancel, toggle, permission-denied → `scheduledInAppOnly`,
+  `MissingPluginException` → `unavailable`, prune); progress-fraction
+  calculator (block straddling window edges, zero-duration guard).
+- **Widget (phone):** drag scroll keeps rows + time axis in sync;
+  now-anchor FAB appears only when `now` is off-viewport and snaps back on
+  tap; tap current block calls `playChannel` with no route push; tap future
+  block toggles reminder with snackbar + Undo; progress fill renders on the
+  current block only; inline retry cell on page failure.
+- **Widget (TV):** "Jump to Present" is focusable via D-pad and re-scrolls
+  to now; progress fill renders on current blocks; all existing
+  `EpgTimelineGrid` focus/navigation tests still pass unchanged
+  (regression gate).
+- **Widget (nav):** Android hardware back from the guide follows the
+  expected route stack; iOS back-swipe leaves no orphaned state.
+- **Manual QA gate (same as the Player feature):** OS notification
+  delivery + deep-link tap verified on physical iOS and Android hardware
+  before merge — notification behavior is not reliably testable in
+  simulator/emulator; flag as a manual gate, not automatable in CI.


### PR DESCRIPTION
## Summary
- Repositions README around the superapp identity ("Airo is the home") aligned with https://developerscoffee.github.io/airo/
- Dynamic badge row: release, download count, CI, SonarCloud quality gate, last commit, stars — replaces static decoration badges
- Hero image (superapp mockup) + Airo TV store screenshot
- Module table matching the site capability matrix: Airo TV (available v0.0.3), Airo TV Pro (in testing), Airo AI, AiroMoney, Music, Games (Stockfish), Reader (OCR)
- Airo TV flagship section with v0.0.3 download CTA + live showcase link; adds macOS preview DMG row
- Compresses Quick Start (Edge Intelligence FFI deep-dive → docs pointer) and demotes V2 release-ops content to doc links

## Test plan
- [ ] Badge URLs render on GitHub
- [ ] Relative image paths resolve (docs/assets, docs/store-assets)
- [ ] All download links return assets

🤖 Generated with [Claude Code](https://claude.com/claude-code)