### PR TITLE
fix(ci): correct sonar.projectKey/organization to match the real SonarCloud project

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,7 +1,12 @@
 # SonarQube Configuration for Airo Super App
 
 # Project identification
-sonar.projectKey=airo-super-app
+# Must match the project as registered in SonarCloud, not an aspirational
+# name -- this project was previously analyzed via Automatic Analysis
+# under the GitHub App's default key/org, DevelopersCoffee_airo /
+# developerscoffee. A mismatched key here makes the scanner try to
+# create/target a nonexistent project instead of the real one.
+sonar.projectKey=DevelopersCoffee_airo
 sonar.projectName=Airo Super App
 sonar.projectVersion=1.0.0
 
@@ -41,7 +46,7 @@ sonar.qualitygate.wait=true
 sonar.pullrequest.github.summary_comment=false
 
 # Organization (for SonarCloud)
-sonar.organization=airo-super-app
+sonar.organization=developerscoffee
 
 # Host URL (for self-hosted SonarQube)
 # sonar.host.url=https://your-sonarqube-instance.com


### PR DESCRIPTION
## Why

sonarcloud-scan's first real run (right after #1011/#1013 finally got test-app green) failed in 8 seconds:

```
ERROR Organization key 'airo-super-app' does not exist.
```

`sonar-project.properties` had `sonar.projectKey=airo-super-app` and `sonar.organization=airo-super-app` -- neither is the real registered project. Every prior analysis (automatic analysis, the dashboard, the badge, every API query used throughout this thread's work) targets `DevelopersCoffee_airo` under the `developerscoffee` organization, per the GitHub App's default naming when automatic analysis was first set up.

CI-based analysis only reads this properties file (unlike automatic analysis, which ignored it entirely -- the original root cause investigated earlier in this thread), so this mismatch was invisible until the scanner actually tried to push.

## What

- `sonar.projectKey`: `airo-super-app` -> `DevelopersCoffee_airo`
- `sonar.organization`: `airo-super-app` -> `developerscoffee`

This is the last piece needed for the CI-based SonarCloud scan (#1006, #1010) to actually complete a run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)