### PR TITLE
fix(feature_iptv): TV search dialog crash + live results while typing

### DIFF
--- a/packages/feature_iptv/lib/presentation/tv/iptv_tv_screen.dart
+++ b/packages/feature_iptv/lib/presentation/tv/iptv_tv_screen.dart
@@ -46,49 +46,10 @@ class _IptvTvScreenState extends ConsumerState<IptvTvScreen> {
   }
 
   Future<void> _showSearchDialog() async {
-    final controller = TextEditingController(
-      text: ref.read(channelSearchQueryProvider),
-    );
-
     await showDialog<void>(
       context: context,
-      builder: (context) {
-        return AlertDialog(
-          title: const Text('Search channels'),
-          content: SizedBox(
-            width: 520,
-            child: TextField(
-              controller: controller,
-              autofocus: true,
-              decoration: const InputDecoration(
-                prefixIcon: Icon(Icons.search),
-                labelText: 'Channel name or group',
-                hintText: 'Music India, Hindi news, sports...',
-              ),
-              textInputAction: TextInputAction.search,
-              onChanged: (value) =>
-                  ref.read(channelSearchQueryProvider.notifier).state = value,
-              onSubmitted: (_) => Navigator.of(context).pop(),
-            ),
-          ),
-          actions: [
-            TextButton(
-              onPressed: () {
-                controller.clear();
-                ref.read(channelSearchQueryProvider.notifier).state = '';
-              },
-              child: const Text('Clear'),
-            ),
-            FilledButton(
-              onPressed: () => Navigator.of(context).pop(),
-              child: const Text('Done'),
-            ),
-          ],
-        );
-      },
+      builder: (_) => _TvSearchDialog(onChannelSelect: _playChannel),
     );
-
-    controller.dispose();
   }
 
   Future<void> _showMacosUpdateDialog() async {
@@ -180,6 +141,134 @@ class _IptvTvScreenState extends ConsumerState<IptvTvScreen> {
           },
         ),
       ),
+    );
+  }
+}
+
+/// Search dialog with live results. The [TextEditingController] is owned by
+/// this widget's State so it is disposed only after the dialog route has
+/// fully unmounted — disposing it right after `await showDialog(...)` (the
+/// previous shape) races the pop animation, which still rebuilds the
+/// TextField and crashes with "used after being disposed".
+class _TvSearchDialog extends ConsumerStatefulWidget {
+  const _TvSearchDialog({required this.onChannelSelect});
+
+  final ValueChanged<IPTVChannel> onChannelSelect;
+
+  @override
+  ConsumerState<_TvSearchDialog> createState() => _TvSearchDialogState();
+}
+
+class _TvSearchDialogState extends ConsumerState<_TvSearchDialog> {
+  late final TextEditingController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = TextEditingController(
+      text: ref.read(channelSearchQueryProvider),
+    );
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  void _selectChannel(IPTVChannel channel) {
+    Navigator.of(context).pop();
+    widget.onChannelSelect(channel);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final query = ref.watch(channelSearchQueryProvider);
+    // Same list the browse grid renders, so the dialog and the grid behind
+    // it always agree on what matches.
+    final results = ref.watch(filteredChannelsProvider);
+
+    return AlertDialog(
+      title: const Text('Search channels'),
+      content: SizedBox(
+        width: 520,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            TextField(
+              controller: _controller,
+              autofocus: true,
+              decoration: const InputDecoration(
+                prefixIcon: Icon(Icons.search),
+                labelText: 'Channel name or group',
+                hintText: 'Music India, Hindi news, sports...',
+              ),
+              textInputAction: TextInputAction.search,
+              onChanged: (value) =>
+                  ref.read(channelSearchQueryProvider.notifier).state = value,
+              onSubmitted: (_) => Navigator.of(context).pop(),
+            ),
+            if (query.trim().isNotEmpty) ...[
+              const SizedBox(height: 12),
+              ConstrainedBox(
+                constraints: const BoxConstraints(maxHeight: 320),
+                child: results.isEmpty
+                    ? Padding(
+                        padding: const EdgeInsets.symmetric(vertical: 16),
+                        child: Text(
+                          'No channels match "$query".',
+                          style: Theme.of(context).textTheme.bodyMedium
+                              ?.copyWith(
+                                color: Theme.of(
+                                  context,
+                                ).colorScheme.onSurfaceVariant,
+                              ),
+                        ),
+                      )
+                    : ListView.builder(
+                        shrinkWrap: true,
+                        itemCount: results.length,
+                        itemBuilder: (context, index) {
+                          final channel = results[index];
+                          return ListTile(
+                            key: ValueKey('tv-search-result-${channel.id}'),
+                            leading: SizedBox(
+                              width: 44,
+                              height: 44,
+                              child: _ChannelLogo(channel: channel),
+                            ),
+                            title: Text(
+                              channel.name,
+                              maxLines: 1,
+                              overflow: TextOverflow.ellipsis,
+                            ),
+                            subtitle: Text(
+                              channel.group,
+                              maxLines: 1,
+                              overflow: TextOverflow.ellipsis,
+                            ),
+                            onTap: () => _selectChannel(channel),
+                          );
+                        },
+                      ),
+              ),
+            ],
+          ],
+        ),
+      ),
+      actions: [
+        TextButton(
+          onPressed: () {
+            _controller.clear();
+            ref.read(channelSearchQueryProvider.notifier).state = '';
+          },
+          child: const Text('Clear'),
+        ),
+        FilledButton(
+          onPressed: () => Navigator.of(context).pop(),
+          child: const Text('Done'),
+        ),
+      ],
     );
   }
 }

--- a/packages/feature_iptv/test/iptv/presentation/tv/iptv_tv_screen_test.dart
+++ b/packages/feature_iptv/test/iptv/presentation/tv/iptv_tv_screen_test.dart
@@ -499,4 +499,92 @@ void main() {
     expect(find.text('Add Playlist URL'), findsOneWidget);
     expect(find.text('How to add'), findsOneWidget);
   });
+
+  testWidgets('search dialog shows live channel results while typing', (
+    tester,
+  ) async {
+    final semantics = tester.ensureSemantics();
+    try {
+      await pumpScreen(tester, settle: false);
+
+      await tester.tap(find.byIcon(Icons.search).first);
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 200));
+
+      expect(find.text('Search channels'), findsOneWidget);
+
+      await tester.enterText(find.byType(TextField), 'music');
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 100));
+
+      // The matching channel surfaces inside the dialog itself — the user
+      // does not have to press Done and hunt through the grid behind it.
+      expect(
+        find.byKey(const ValueKey('tv-search-result-music-1')),
+        findsOneWidget,
+      );
+      expect(find.text('No channels match "music".'), findsNothing);
+    } finally {
+      semantics.dispose();
+    }
+  });
+
+  testWidgets('search dialog shows empty state for a query with no matches', (
+    tester,
+  ) async {
+    final semantics = tester.ensureSemantics();
+    try {
+      await pumpScreen(tester, settle: false);
+
+      await tester.tap(find.byIcon(Icons.search).first);
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 200));
+
+      await tester.enterText(find.byType(TextField), 'zzz-no-such-channel');
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 100));
+
+      expect(
+        find.text('No channels match "zzz-no-such-channel".'),
+        findsOneWidget,
+      );
+    } finally {
+      semantics.dispose();
+    }
+  });
+
+  testWidgets(
+    'closing the search dialog after typing does not crash during the pop '
+    'animation (regression: TextEditingController used after dispose)',
+    (tester) async {
+      final semantics = tester.ensureSemantics();
+      try {
+        await pumpScreen(tester, settle: false);
+
+        await tester.tap(find.byIcon(Icons.search).first);
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 200));
+
+        await tester.enterText(find.byType(TextField), 'news');
+        await tester.pump();
+
+        await tester.tap(find.text('Done'));
+        // Pump through the dialog's pop animation frame by frame — the old
+        // code disposed the controller as soon as showDialog's future
+        // resolved, so these exact frames rebuilt a TextField bound to a
+        // disposed controller and threw.
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 50));
+        await tester.pump(const Duration(milliseconds: 100));
+        await tester.pump(const Duration(milliseconds: 200));
+
+        expect(tester.takeException(), isNull);
+        expect(find.text('Search channels'), findsNothing);
+        // The query survives the dialog: the grid stays filtered.
+        expect(find.text('2 results for "news"'), findsOneWidget);
+      } finally {
+        semantics.dispose();
+      }
+    },
+  );
 }


### PR DESCRIPTION
## Summary
- **Crash fix**: the TV search dialog disposed its `TextEditingController` right after `await showDialog(...)` returned, but the route is still animating out then — the next rebuild used the disposed controller and cascaded into the `_dependents.isEmpty` framework assertion (red screen). Repro: Search → type → Done → tap a channel card. The controller is now owned by the dialog widget's State and disposed after the route fully unmounts.
- **UX fix**: typing in the search dialog only filtered the grid behind it; you had to press Done and hunt for the card. The dialog now shows live matching channels inline (same `filteredChannelsProvider` list as the grid) — tap a result to play it directly.

## Test plan
- [x] 3 new widget tests: live results while typing, no-match empty state, and a pop-animation regression test that fails on the old implementation and passes on this one
- [x] Full `iptv_tv_screen_test.dart` suite: 14/14 pass
- [x] `flutter analyze` clean on changed files (2 pre-existing infos in the test file untouched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)