### PR TITLE
fix(ci): exclude app/test/** from sonar.sources to fix double-indexing

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -25,7 +25,10 @@ sonar.dart.coverage.reportPath=app/coverage/lcov.info
 sonar.dart.analysis.reportPath=app/analysis_result.txt
 
 # Exclusions
-sonar.exclusions=**/*.g.dart,**/*.freezed.dart,**/generated/**,**/build/**,.dart_tool/**,.github/workflows/**,app/third_party/**,app/android/**,app/ios/**,app/macos/**,app/windows/**,app/linux/**,app/web/**,e2e/**,iptv-data/**,packages/**,scripts/**
+# app/test/** must stay out of sonar.sources -- it's declared separately
+# via sonar.tests below, and a file indexed by both sets fails analysis
+# ("can't be indexed twice").
+sonar.exclusions=**/*.g.dart,**/*.freezed.dart,**/generated/**,**/build/**,.dart_tool/**,.github/workflows/**,app/test/**,app/third_party/**,app/android/**,app/ios/**,app/macos/**,app/windows/**,app/linux/**,app/web/**,e2e/**,iptv-data/**,packages/**,scripts/**
 sonar.test.exclusions=**/*.g.dart,**/*.freezed.dart
 
 # Code coverage


### PR DESCRIPTION
## Why

sonarcloud-scan's second real run (right after #1016 fixed the project key/org) failed:

```
ERROR File app/test/core/tv/tv_focusable_test.dart can't be indexed twice. Please check that inclusion/exclusion patterns produce disjoint sets for main and test files
```

`sonar.sources` was broadened from `app/lib` to `.` (repo root) in #1006 so CI-based analysis would keep covering non-Dart paths like `docs/**` (previously covered by automatic analysis via `.sonarcloud.properties`). That change didn't account for `app/test/**` already being claimed separately by `sonar.tests=app/test` -- with `sources=.`, every file under `app/test/**` matched both the main-sources set and the tests set, which SonarQube requires to be disjoint. This was invisible under `app/lib`-only sources (no overlap possible) and under automatic analysis (ignores this file entirely).

## What

Add `app/test/**` to `sonar.exclusions`, so it's only ever indexed via `sonar.tests`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)