### PR TITLE
test: freeze ProFeature stable ids

### DIFF
--- a/docs/OPEN_CORE.md
+++ b/docs/OPEN_CORE.md
@@ -68,6 +68,7 @@ is overlay.
 ## Adding a new pro feature
 
 1. Add a `ProFeature` value (stable id is permanent) in `core_entitlements`.
+   Freeze the stable-id list in `packages/core_entitlements/test/goldens/pro_feature_stable_ids.dart`; any rename or renumber requires an explicit compatibility decision.
 2. If the public UI needs a hook (an empty row slot, a settings entry), land
    it here behind `entitlements.isEnabled(...)`.
 3. Implement the feature as a `ProModule` package in `airo-pro`'s

--- a/packages/core_entitlements/test/entitlements_test.dart
+++ b/packages/core_entitlements/test/entitlements_test.dart
@@ -1,6 +1,8 @@
 import 'package:core_entitlements/core_entitlements.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+import 'goldens/pro_feature_stable_ids.dart';
+
 class _FakeModule implements ProModule {
   _FakeModule(this.id, this.feature, {this.failOnInit = false});
 
@@ -51,6 +53,11 @@ void main() {
     test('stable ids are unique', () {
       final ids = ProFeature.values.map((f) => f.stableId).toSet();
       expect(ids.length, ProFeature.values.length);
+    });
+
+    test('stable ids match the frozen golden fixture', () {
+      final ids = ProFeature.values.map((f) => f.stableId).toList();
+      expect(ids, expectedProFeatureStableIds);
     });
   });
 

--- a/packages/core_entitlements/test/goldens/pro_feature_stable_ids.dart
+++ b/packages/core_entitlements/test/goldens/pro_feature_stable_ids.dart
@@ -1,0 +1,8 @@
+const expectedProFeatureStableIds = [
+  'import_intelligence',
+  'regional_ranking',
+  'epg_reminders',
+  'metadata_enrichment',
+  'sports_desk',
+  'multi_source_failover',
+];


### PR DESCRIPTION
## Summary\n\nAdds a fixture-backed regression test for ProFeature stable IDs and documents the stable-id freeze in the open-core guide.\n\nCloses #998\n\n## Testing\n\n- flutter test test/entitlements_test.dart from packages/core_entitlements\n