### PR TITLE
feat(feature_coin): add secure vault UI phase 0

### DIFF
--- a/app/lib/core/routing/app_router.dart
+++ b/app/lib/core/routing/app_router.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/foundation.dart';
+import 'package:feature_coin/feature_coin.dart';
 import 'package:go_router/go_router.dart';
 import '../../features/auth/screens/login_screen.dart';
 import '../../features/auth/screens/register_screen.dart';
@@ -145,6 +146,11 @@ class AppRouter {
                     path: 'budgets',
                     name: RouteNames.coinsBudgets,
                     builder: (context, state) => const BudgetManagementScreen(),
+                  ),
+                  GoRoute(
+                    path: 'vault',
+                    name: RouteNames.coinVault,
+                    builder: (context, state) => const VaultGateScreen(),
                   ),
                   GoRoute(
                     path: 'groups',

--- a/app/lib/core/routing/route_names.dart
+++ b/app/lib/core/routing/route_names.dart
@@ -5,7 +5,6 @@ class RouteNames {
   // Route paths
   static const String home = '/';
   static const String airo = '/airo';
-  static const String airomoney = '/airomoney';
   static const String login = '/login';
   static const String register = '/register';
   static const String profile = '/profile';
@@ -21,10 +20,12 @@ class RouteNames {
   static const String coinsGroups = 'coins_groups';
   static const String coinsGroupDetail = 'coins_group_detail';
   static const String coinsAddSplit = 'coins_add_split';
+  static const String coinVault = 'coin_vault';
 
   // Coins Full Paths (for direct navigation)
   static const String coinsDashboardPath = '/money/dashboard';
   static const String coinsAddExpensePath = '/money/add-expense';
   static const String coinsBudgetsPath = '/money/budgets';
   static const String coinsGroupsPath = '/money/groups';
+  static const String coinVaultPath = '/money/vault';
 }

--- a/app/lib/features/coins/presentation/screens/coins_dashboard_screen.dart
+++ b/app/lib/features/coins/presentation/screens/coins_dashboard_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:feature_coin/feature_coin.dart';
 import '../../../../core/utils/locale_settings.dart';
 import '../../application/providers/android_import_permission_provider.dart';
 import '../../application/providers/dashboard_providers.dart';
@@ -745,7 +746,13 @@ class _QuickActionsRow extends StatelessWidget {
             MaterialPageRoute(builder: (_) => const BudgetManagementScreen()),
           ),
         ),
-        const _QuickActionButton(icon: Icons.camera_alt, label: 'Scan Receipt'),
+        _QuickActionButton(
+          icon: Icons.lock_outline,
+          label: 'Secure Vault',
+          onTap: () => Navigator.of(
+            context,
+          ).push(MaterialPageRoute(builder: (_) => const VaultGateScreen())),
+        ),
       ],
     );
   }

--- a/app/lib/features/home/screens/home_screen.dart
+++ b/app/lib/features/home/screens/home_screen.dart
@@ -117,11 +117,11 @@ class HomeScreen extends StatelessWidget {
                     onTap: () => context.go(RouteNames.airo),
                   ),
                   AppCard(
-                    title: 'AiroMoney',
+                    title: 'Coins',
                     description: 'Financial management',
                     icon: Icons.account_balance_wallet,
                     color: Colors.green,
-                    onTap: () => context.go(RouteNames.airomoney),
+                    onTap: () => context.go('/money'),
                   ),
                 ],
               ),

--- a/app/lib/features/money/domain/repositories/wallet_repository.dart
+++ b/app/lib/features/money/domain/repositories/wallet_repository.dart
@@ -1,7 +1,7 @@
 import '../../../../core/domain/repository.dart';
 import '../../../../core/utils/result.dart';
 
-/// Wallet type enum matching airomoney package
+/// Wallet type enum for the Money feature.
 enum WalletType { cash, bank, credit, investment, crypto }
 
 /// Wallet model for the money feature

--- a/app/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/app/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -20,6 +20,7 @@ import flutter_secure_storage_darwin
 import flutter_tts
 import google_sign_in_ios
 import just_audio
+import local_auth_darwin
 import media_kit_libs_macos_video
 import package_info_plus
 import patrol
@@ -49,6 +50,7 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   FlutterTtsPlugin.register(with: registry.registrar(forPlugin: "FlutterTtsPlugin"))
   FLTGoogleSignInPlugin.register(with: registry.registrar(forPlugin: "FLTGoogleSignInPlugin"))
   JustAudioPlugin.register(with: registry.registrar(forPlugin: "JustAudioPlugin"))
+  LocalAuthPlugin.register(with: registry.registrar(forPlugin: "LocalAuthPlugin"))
   MediaKitLibsMacosVideoPlugin.register(with: registry.registrar(forPlugin: "MediaKitLibsMacosVideoPlugin"))
   FPPPackageInfoPlusPlugin.register(with: registry.registrar(forPlugin: "FPPPackageInfoPlusPlugin"))
   PatrolPlugin.register(with: registry.registrar(forPlugin: "PatrolPlugin"))

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -24,13 +24,6 @@ packages:
       relative: true
     source: path
     version: "0.0.1"
-  airomoney:
-    dependency: "direct main"
-    description:
-      path: "../packages/airomoney"
-      relative: true
-    source: path
-    version: "0.0.1"
   alchemist:
     dependency: "direct dev"
     description:
@@ -470,6 +463,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.7"
+  cryptography:
+    dependency: transitive
+    description:
+      name: cryptography
+      sha256: "3eda3029d34ec9095a27a198ac9785630fe525c0eb6a49f3d575272f8e792ef0"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.9.0"
   csslib:
     dependency: transitive
     description:
@@ -598,6 +599,13 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.3"
+  feature_coin:
+    dependency: "direct main"
+    description:
+      path: "../packages/feature_coin"
+      relative: true
+    source: path
+    version: "0.0.1"
   feature_iptv:
     dependency: "direct main"
     description:
@@ -1298,6 +1306,46 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.1.0"
+  local_auth:
+    dependency: transitive
+    description:
+      name: local_auth
+      sha256: "434d854cf478f17f12ab29a76a02b3067f86a63a6d6c4eb8fbfdcfe4879c1b7b"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.0"
+  local_auth_android:
+    dependency: transitive
+    description:
+      name: local_auth_android
+      sha256: a0bdfcc0607050a26ef5b31d6b4b254581c3d3ce3c1816ab4d4f4a9173e84467
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.56"
+  local_auth_darwin:
+    dependency: transitive
+    description:
+      name: local_auth_darwin
+      sha256: "699873970067a40ef2f2c09b4c72eb1cfef64224ef041b3df9fdc5c4c1f91f49"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.6.1"
+  local_auth_platform_interface:
+    dependency: transitive
+    description:
+      name: local_auth_platform_interface
+      sha256: f98b8e388588583d3f781f6806e4f4c9f9e189d898d27f0c249b93a1973dd122
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.0"
+  local_auth_windows:
+    dependency: transitive
+    description:
+      name: local_auth_windows
+      sha256: bc4e66a29b0fdf751aafbec923b5bed7ad6ed3614875d8151afe2578520b2ab5
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.11"
   logging:
     dependency: transitive
     description:
@@ -1665,6 +1713,13 @@ packages:
       relative: true
     source: path
     version: "0.0.1"
+  platform_coin_vault:
+    dependency: transitive
+    description:
+      path: "../packages/platform_coin_vault"
+      relative: true
+    source: path
+    version: "0.0.1"
   platform_device_profile:
     dependency: transitive
     description:
@@ -1925,6 +1980,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.2"
+  screen_protector:
+    dependency: transitive
+    description:
+      name: screen_protector
+      sha256: "66f2ffbfbe7acc26db49de893e0c49078c67b546c27a57958d9bd9901f77c38e"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.5.3"
   screenshot:
     dependency: "direct main"
     description:

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -80,8 +80,8 @@ dependencies:
   # Local packages - Features
   airo:
     path: ../packages/airo
-  airomoney:
-    path: ../packages/airomoney
+  feature_coin:
+    path: ../packages/feature_coin
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.

--- a/app/pubspec_ios_spm.yaml
+++ b/app/pubspec_ios_spm.yaml
@@ -63,8 +63,8 @@ dependencies:
   # Local packages - Features
   airo:
     path: ../packages/airo
-  airomoney:
-    path: ../packages/airomoney
+  feature_coin:
+    path: ../packages/feature_coin
 
   cupertino_icons: ^1.0.9
   equatable: ^2.1.0

--- a/app/pubspec_tv.yaml
+++ b/app/pubspec_tv.yaml
@@ -121,7 +121,7 @@ dependencies:
   # - screenshot: (screenshots - not needed)
   # - flutter_image_compress: (image compression - not needed)
   # - flutter_local_notifications: (notifications - TV uses different approach)
-  # - airomoney: (finance features - not on TV)
+  # - feature_coin: (finance vault features - not on TV)
 
 dev_dependencies:
   flutter_test:

--- a/app/windows/flutter/generated_plugin_registrant.cc
+++ b/app/windows/flutter/generated_plugin_registrant.cc
@@ -13,6 +13,7 @@
 #include <firebase_core/firebase_core_plugin_c_api.h>
 #include <flutter_secure_storage_windows/flutter_secure_storage_windows_plugin.h>
 #include <flutter_tts/flutter_tts_plugin.h>
+#include <local_auth_windows/local_auth_plugin.h>
 #include <media_kit_libs_windows_video/media_kit_libs_windows_video_plugin_c_api.h>
 #include <pdfx/pdfx_plugin.h>
 #include <permission_handler_windows/permission_handler_windows_plugin.h>
@@ -36,6 +37,8 @@ void RegisterPlugins(flutter::PluginRegistry* registry) {
       registry->GetRegistrarForPlugin("FlutterSecureStorageWindowsPlugin"));
   FlutterTtsPluginRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("FlutterTtsPlugin"));
+  LocalAuthPluginRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("LocalAuthPlugin"));
   MediaKitLibsWindowsVideoPluginCApiRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("MediaKitLibsWindowsVideoPluginCApi"));
   PdfxPluginRegisterWithRegistrar(

--- a/app/windows/flutter/generated_plugins.cmake
+++ b/app/windows/flutter/generated_plugins.cmake
@@ -10,6 +10,7 @@ list(APPEND FLUTTER_PLUGIN_LIST
   firebase_core
   flutter_secure_storage_windows
   flutter_tts
+  local_auth_windows
   media_kit_libs_windows_video
   pdfx
   permission_handler_windows

--- a/docs/superpowers/plans/2026-07-22-feature-coin-ui-phase0.md
+++ b/docs/superpowers/plans/2026-07-22-feature-coin-ui-phase0.md
@@ -1,0 +1,51 @@
+# Implementation Plan: feature_coin UI Phase 0
+
+## Overview
+
+Implement the deferred `feature_coin` presentation slice on the already-merged vault platform/session foundation. The work stays package-first, then wires the tested vault gate into the app Money branch and corrects the stale platform doc comment.
+
+## Architecture Decisions
+
+- Use summary aggregation for the vault home screen so no list render requires a DEK.
+- Model selected records with a typed `VaultRecordRef` because bank/card/document records use nickname and PAN uses id.
+- Keep screen security behind an injectable service so native calls are testable without platform channels.
+- Keep forms explicit per record type rather than introducing a generic form builder for four small schemas.
+- Wire app shell routing only after the package UI is tested; use `/money/vault` under the existing Money branch.
+
+## Task List
+
+### Phase 1: Foundation
+
+- [ ] Task 1: Add typed UI refs, summary aggregation, and screen-security service.
+- [ ] Task 2: Add lock gate and grouped home list widgets.
+
+### Checkpoint: Foundation
+
+- [ ] `cd packages/feature_coin && flutter test` covers lock/home behavior.
+
+### Phase 2: Record Interaction
+
+- [ ] Task 3: Add masked detail sheet with reveal/copy for sensitive fields.
+- [ ] Task 4: Add add/edit forms for bank account, PAN card, credit card, and secure document.
+
+### Checkpoint: Core Flow
+
+- [ ] Widget tests prove masked default, reveal-on-demand, copy delegation, and validation errors.
+
+### Phase 3: Cleanup
+
+- [ ] Task 5: Export UI surface and fix the stale platform key-manager doc comment.
+- [ ] Task 6: Wire `/money/vault`, replace stale `airomoney` app dependency, and run focused validation.
+
+## Risks and Mitigations
+
+| Risk | Impact | Mitigation |
+| --- | --- | --- |
+| Platform-channel calls break widget tests | Medium | Use injectable screen-security and auth seams. |
+| Sensitive data leaks into list/provider state | High | Home screen uses summaries only; full records are local detail state. |
+| PAN routing assumes nickname | Medium | Use `VaultRecordRef.panCard(id)` everywhere. |
+| Form scope expands into attachments/reset | Medium | Keep attachments/reset out of Phase 0 UI. |
+
+## Open Questions
+
+- Physical-device verification is still needed for native screenshot-blocking and real biometric prompt UX.

--- a/docs/superpowers/specs/2026-07-22-feature-coin-ui-phase0.md
+++ b/docs/superpowers/specs/2026-07-22-feature-coin-ui-phase0.md
@@ -1,0 +1,80 @@
+# Spec: feature_coin UI Phase 0
+
+## Assumptions
+
+1. This slice builds the standalone `feature_coin` UI package first, then wires the tested gate into the app Money branch at `/money/vault`.
+2. The merged `platform_coin_vault` API is the source of truth for records, summaries, validation, encryption, and CRUD.
+3. PAN cards use row `id` as their UI handle because the platform table has no nickname column.
+4. Attachments, vault reset, key rotation UI, cloud sync, transactions, balances, and TV surfaces remain out of scope.
+
+## Objective
+
+Build the first usable Airo Coin secure-vault UI: biometric lock gate, grouped vault list, add/edit forms for bank accounts, PAN cards, credit cards, and secure documents, masked detail/reveal/copy interactions, screen security, and auto-lock integration through the existing `VaultSessionNotifier`.
+
+Success means a phone user can unlock the vault, see summaries without decrypting records, add a record, inspect sensitive fields only after reveal, copy values with auto-clear, and return to a locked state on timeout/background/manual lock.
+
+## Tech Stack
+
+- Flutter package: `packages/feature_coin`
+- State: Riverpod 3.3.2 `Notifier` and `FutureProvider`
+- Storage/crypto API: `platform_coin_vault`
+- Shared UI: `core_ui`
+- Native privacy: `screen_protector`
+- Biometric prompt: `local_auth` via `VaultKeyManager`; destructive delete re-prompt deferred unless `local_auth` can be tested cleanly in this slice
+
+## Commands
+
+- Package dependencies: `cd packages/feature_coin && flutter pub get`
+- Package tests: `cd packages/feature_coin && flutter test`
+- Package analyze: `cd packages/feature_coin && dart analyze`
+- Platform cleanup test: `cd packages/platform_coin_vault && flutter test test/crypto/vault_key_manager_test.dart`
+- Diff hygiene: `git diff --check`
+
+## Project Structure
+
+- `packages/feature_coin/lib/src/application/` -> providers, aggregation, screen-security wrapper, save/load operations
+- `packages/feature_coin/lib/src/presentation/screens/` -> lock gate, home list, form screens
+- `packages/feature_coin/lib/src/presentation/widgets/` -> masked field/detail/list/form widgets
+- `packages/feature_coin/test/` -> widget and application tests with provider overrides
+- `app/lib/core/routing/` and `app/lib/features/coins/` -> `/money/vault` shell wiring
+- `packages/platform_coin_vault/lib/src/crypto/vault_key_manager.dart` -> stale doc-comment cleanup only
+
+## Code Style
+
+Use small, typed UI models and keep the DEK out of widget state.
+
+```dart
+final record = await ref.read(vaultSessionProvider.notifier).withKey(
+  (keyBytes) => repositories.bankAccounts.getByNickname(nickname, keyBytes),
+);
+```
+
+Forms should catch platform `ArgumentError` validation and show inline field errors. List screens must consume summary projections only and must not call `withKey`.
+
+## Testing Strategy
+
+- Widget tests cover lock states, grouped empty/list rendering, masked-by-default fields, reveal/copy behavior, and form validation.
+- Application tests cover summary aggregation and screen-security controller behavior with test doubles.
+- Existing session and clipboard tests remain authoritative for auto-lock and clipboard timer internals.
+- Physical Android verification is required later for real `FLAG_SECURE`, screenshots, and biometric prompt behavior; this slice provides a testable wrapper.
+
+## Boundaries
+
+- Always: mask sensitive values by default, use `withKey` for decrypting records, refresh summaries after mutations, keep PAN keyed by id.
+- Ask first: new dependencies, database/schema changes, attachment handling, app-wide navigation redesign, custom PIN fallback, vault reset/delete-all flow.
+- Never: expose full card numbers/CVV/PIN, call destructive `rotateKey()`, decrypt full records for the home list, log vault field values, write sensitive values to provider state.
+
+## Success Criteria
+
+- `VaultGateScreen` switches locked/unlocking/unavailable/error/unlocked states deterministically.
+- `VaultHomeScreen` renders grouped summaries from all four repositories without requiring key bytes.
+- Add/edit forms persist valid records and show inline errors for invalid PAN/IFSC or duplicate nicknames.
+- Detail UI masks sensitive fields by default, reveals through `VaultSessionNotifier.withKey`, and copies via `ClipboardService`.
+- Screen security is enabled while the gate is mounted and disabled on dispose through an injectable controller.
+- Stale `generateCandidateKey()` documentation references `persistRotatedKeyUnauthenticated`.
+- Focused package tests and analyzer pass, or gaps are documented.
+
+## Open Questions
+
+- Deeper app navigation for direct add/edit URLs remains a follow-up after the package UI is exercised.
+- Real device verification is still needed for native screenshot blocking and biometric prompt UX.

--- a/packages/feature_coin/lib/feature_coin.dart
+++ b/packages/feature_coin/lib/feature_coin.dart
@@ -6,6 +6,15 @@ library;
 
 export 'src/application/vault_config.dart';
 export 'src/application/clipboard_service.dart';
+export 'src/application/screen_security.dart';
 export 'src/application/vault_providers.dart';
+export 'src/application/vault_record_reader.dart';
+export 'src/application/vault_record_ref.dart';
 export 'src/application/vault_session.dart';
+export 'src/application/vault_summaries_provider.dart';
+export 'src/presentation/screens/vault_gate_screen.dart';
+export 'src/presentation/screens/vault_home_screen.dart';
+export 'src/presentation/screens/vault_record_form_screen.dart';
+export 'src/presentation/widgets/masked_vault_field.dart';
+export 'src/presentation/widgets/record_detail_sheet.dart';
 export 'src/presentation/widgets/vault_lifecycle_observer.dart';

--- a/packages/feature_coin/lib/src/application/screen_security.dart
+++ b/packages/feature_coin/lib/src/application/screen_security.dart
@@ -1,0 +1,32 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:screen_protector/screen_protector.dart';
+
+class VaultScreenSecurity {
+  const VaultScreenSecurity({
+    this.enableProtection = ScreenProtector.protectDataLeakageOn,
+    this.disableProtection = ScreenProtector.protectDataLeakageOff,
+  });
+
+  final Future<void> Function() enableProtection;
+  final Future<void> Function() disableProtection;
+
+  Future<void> protect() async {
+    try {
+      await enableProtection();
+    } catch (_) {
+      // Native screen-protection failures must not block access to the vault.
+    }
+  }
+
+  Future<void> unprotect() async {
+    try {
+      await disableProtection();
+    } catch (_) {
+      // See protect().
+    }
+  }
+}
+
+final screenSecurityProvider = Provider<VaultScreenSecurity>(
+  (ref) => const VaultScreenSecurity(),
+);

--- a/packages/feature_coin/lib/src/application/vault_record_reader.dart
+++ b/packages/feature_coin/lib/src/application/vault_record_reader.dart
@@ -1,0 +1,81 @@
+import 'package:core_domain/core_domain.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:platform_coin_vault/platform_coin_vault.dart';
+
+import 'vault_providers.dart';
+import 'vault_session.dart';
+
+abstract interface class VaultRecordReader {
+  Future<String?> revealBankAccountNumber(String nickname);
+  Future<String?> revealBankNotes(String nickname);
+  Future<String?> revealPanNumber(int id);
+  Future<String?> revealDocumentNotes(String nickname);
+}
+
+final class RepositoryVaultRecordReader implements VaultRecordReader {
+  const RepositoryVaultRecordReader({
+    required this.readRepositories,
+    required this.session,
+  });
+
+  final Future<VaultRepositories> Function() readRepositories;
+  final VaultSessionNotifier session;
+
+  @override
+  Future<String?> revealBankAccountNumber(String nickname) {
+    return _loadBank(nickname, (record) => record.accountNumber);
+  }
+
+  @override
+  Future<String?> revealBankNotes(String nickname) {
+    return _loadBank(nickname, (record) => record.notes);
+  }
+
+  @override
+  Future<String?> revealPanNumber(int id) async {
+    final repositories = await readRepositories();
+    final result = await session.withKey(
+      (keyBytes) => repositories.panCards.getById(id, keyBytes),
+    );
+    return _selectedValue(result, (record) => record.panNumber);
+  }
+
+  @override
+  Future<String?> revealDocumentNotes(String nickname) async {
+    final repositories = await readRepositories();
+    final result = await session.withKey(
+      (keyBytes) =>
+          repositories.secureDocuments.getByNickname(nickname, keyBytes),
+    );
+    return _selectedValue(result, (record) => record.notes);
+  }
+
+  Future<String?> _loadBank(
+    String nickname,
+    String? Function(BankAccountRecord record) select,
+  ) async {
+    final repositories = await readRepositories();
+    final result = await session.withKey(
+      (keyBytes) => repositories.bankAccounts.getByNickname(nickname, keyBytes),
+    );
+    return _selectedValue(result, select);
+  }
+
+  String? _selectedValue<T>(
+    Result<T?>? result,
+    String? Function(T record) select,
+  ) {
+    if (result == null || result.isFailure) return null;
+    final record = result.valueOrNull;
+    if (record == null) return null;
+    final value = select(record);
+    return value == null || value.isEmpty ? 'Not set' : value;
+  }
+}
+
+final vaultRecordReaderProvider = Provider<VaultRecordReader>((ref) {
+  return RepositoryVaultRecordReader(
+    readRepositories: () => ref.read(vaultRepositoriesProvider.future),
+    session: ref.read(vaultSessionProvider.notifier),
+  );
+});

--- a/packages/feature_coin/lib/src/application/vault_record_ref.dart
+++ b/packages/feature_coin/lib/src/application/vault_record_ref.dart
@@ -1,0 +1,28 @@
+import 'package:equatable/equatable.dart';
+
+enum VaultRecordType { bankAccount, panCard, creditCard, secureDocument }
+
+final class VaultRecordRef extends Equatable {
+  const VaultRecordRef._({required this.type, this.nickname, this.id});
+
+  const VaultRecordRef.bankAccount(String nickname)
+    : this._(type: VaultRecordType.bankAccount, nickname: nickname);
+
+  const VaultRecordRef.panCard(int id)
+    : this._(type: VaultRecordType.panCard, id: id);
+
+  const VaultRecordRef.creditCard(String nickname)
+    : this._(type: VaultRecordType.creditCard, nickname: nickname);
+
+  const VaultRecordRef.secureDocument(String nickname)
+    : this._(type: VaultRecordType.secureDocument, nickname: nickname);
+
+  final VaultRecordType type;
+  final String? nickname;
+  final int? id;
+
+  String get displayHandle => nickname ?? '#$id';
+
+  @override
+  List<Object?> get props => [type, nickname, id];
+}

--- a/packages/feature_coin/lib/src/application/vault_summaries_provider.dart
+++ b/packages/feature_coin/lib/src/application/vault_summaries_provider.dart
@@ -1,0 +1,63 @@
+import 'package:core_domain/core_domain.dart';
+import 'package:equatable/equatable.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:platform_coin_vault/platform_coin_vault.dart';
+
+import 'vault_providers.dart';
+
+final class VaultSummaries extends Equatable {
+  const VaultSummaries({
+    this.bankAccounts = const [],
+    this.panCards = const [],
+    this.creditCards = const [],
+    this.secureDocuments = const [],
+  });
+
+  final List<BankAccountSummary> bankAccounts;
+  final List<PanCardSummary> panCards;
+  final List<CreditCardSummary> creditCards;
+  final List<SecureDocumentSummary> secureDocuments;
+
+  bool get isEmpty =>
+      bankAccounts.isEmpty &&
+      panCards.isEmpty &&
+      creditCards.isEmpty &&
+      secureDocuments.isEmpty;
+
+  int get count =>
+      bankAccounts.length +
+      panCards.length +
+      creditCards.length +
+      secureDocuments.length;
+
+  @override
+  List<Object?> get props => [
+    bankAccounts,
+    panCards,
+    creditCards,
+    secureDocuments,
+  ];
+}
+
+final vaultSummariesProvider = FutureProvider<VaultSummaries>((ref) async {
+  final repositories = await ref.watch(vaultRepositoriesProvider.future);
+  return VaultSummaries(
+    bankAccounts: _valueOrThrow(
+      await repositories.bankAccounts.listAllSummaries(),
+    ),
+    panCards: _valueOrThrow(await repositories.panCards.listAllSummaries()),
+    creditCards: _valueOrThrow(
+      await repositories.creditCards.listAllSummaries(),
+    ),
+    secureDocuments: _valueOrThrow(
+      await repositories.secureDocuments.listAllSummaries(),
+    ),
+  );
+});
+
+T _valueOrThrow<T>(Result<T> result) {
+  if (result case Success<T>(:final value)) {
+    return value;
+  }
+  throw result.failure;
+}

--- a/packages/feature_coin/lib/src/presentation/screens/vault_gate_screen.dart
+++ b/packages/feature_coin/lib/src/presentation/screens/vault_gate_screen.dart
@@ -1,0 +1,147 @@
+import 'package:core_ui/core_ui.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../application/screen_security.dart';
+import '../../application/vault_session.dart';
+import '../widgets/vault_lifecycle_observer.dart';
+import 'vault_home_screen.dart';
+
+class VaultGateScreen extends ConsumerStatefulWidget {
+  const VaultGateScreen({
+    super.key,
+    this.unlockedChild,
+    this.autoUnlock = true,
+  });
+
+  final Widget? unlockedChild;
+  final bool autoUnlock;
+
+  @override
+  ConsumerState<VaultGateScreen> createState() => _VaultGateScreenState();
+}
+
+class _VaultGateScreenState extends ConsumerState<VaultGateScreen> {
+  late final VaultScreenSecurity _screenSecurity;
+  var _autoUnlockAttempted = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _screenSecurity = ref.read(screenSecurityProvider);
+    Future<void>.microtask(_screenSecurity.protect);
+    WidgetsBinding.instance.addPostFrameCallback((_) => _maybeAutoUnlock());
+  }
+
+  @override
+  void dispose() {
+    Future<void>.microtask(_screenSecurity.unprotect);
+    super.dispose();
+  }
+
+  void _maybeAutoUnlock() {
+    if (!mounted || !widget.autoUnlock || _autoUnlockAttempted) return;
+    if (ref.read(vaultSessionProvider) is! VaultLocked) return;
+    _autoUnlockAttempted = true;
+    ref.read(vaultSessionProvider.notifier).unlock();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final state = ref.watch(vaultSessionProvider);
+    final child = switch (state) {
+      VaultUnlocked() => widget.unlockedChild ?? const VaultHomeScreen(),
+      VaultUnlocking() => const _VaultUnlockingView(),
+      VaultUnavailable() => const _VaultUnavailableView(),
+      VaultAuthError(:final failure) => _VaultAuthErrorView(
+        message: failure.message,
+      ),
+      VaultLocked() => const _VaultLockedView(),
+    };
+
+    return VaultLifecycleObserver(child: child);
+  }
+}
+
+class _VaultLockedView extends ConsumerWidget {
+  const _VaultLockedView();
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Secure Vault')),
+      body: EmptyStateWidget(
+        icon: Icons.lock_outline,
+        title: 'Vault locked',
+        message:
+            'Unlock with your device biometrics to view local vault records.',
+        action: FilledButton.icon(
+          key: const ValueKey('vault_unlock_button'),
+          onPressed: () => ref.read(vaultSessionProvider.notifier).unlock(),
+          icon: const Icon(Icons.fingerprint),
+          label: const Text('Unlock vault'),
+        ),
+      ),
+    );
+  }
+}
+
+class _VaultUnlockingView extends StatelessWidget {
+  const _VaultUnlockingView();
+
+  @override
+  Widget build(BuildContext context) {
+    return const Scaffold(
+      appBar: _VaultTitleBar(),
+      body: Center(child: LoadingIndicator(message: 'Unlocking vault')),
+    );
+  }
+}
+
+class _VaultUnavailableView extends StatelessWidget {
+  const _VaultUnavailableView();
+
+  @override
+  Widget build(BuildContext context) {
+    return const Scaffold(
+      appBar: _VaultTitleBar(),
+      body: EmptyStateWidget(
+        icon: Icons.no_encryption_outlined,
+        title: 'Biometrics unavailable',
+        message:
+            'Enroll biometrics or a supported device credential in system settings before creating an Airo Coin vault.',
+      ),
+    );
+  }
+}
+
+class _VaultAuthErrorView extends ConsumerWidget {
+  const _VaultAuthErrorView({required this.message});
+
+  final String message;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return Scaffold(
+      appBar: const _VaultTitleBar(),
+      body: ErrorView(
+        icon: Icons.lock_reset_outlined,
+        title: 'Could not unlock vault',
+        message: message,
+        retryLabel: 'Try again',
+        onRetry: () => ref.read(vaultSessionProvider.notifier).unlock(),
+      ),
+    );
+  }
+}
+
+class _VaultTitleBar extends StatelessWidget implements PreferredSizeWidget {
+  const _VaultTitleBar();
+
+  @override
+  Widget build(BuildContext context) =>
+      AppBar(title: const Text('Secure Vault'));
+
+  @override
+  Size get preferredSize => const Size.fromHeight(kToolbarHeight);
+}

--- a/packages/feature_coin/lib/src/presentation/screens/vault_home_screen.dart
+++ b/packages/feature_coin/lib/src/presentation/screens/vault_home_screen.dart
@@ -1,0 +1,437 @@
+import 'package:core_ui/core_ui.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:platform_coin_vault/platform_coin_vault.dart';
+
+import '../../application/vault_record_ref.dart';
+import '../../application/vault_session.dart';
+import '../../application/vault_summaries_provider.dart';
+import '../widgets/record_detail_sheet.dart';
+import 'vault_record_form_screen.dart';
+
+class VaultHomeScreen extends ConsumerWidget {
+  const VaultHomeScreen({super.key, this.onAddRecord, this.onOpenRecord});
+
+  final ValueChanged<VaultRecordType>? onAddRecord;
+  final ValueChanged<VaultRecordRef>? onOpenRecord;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final summaries = ref.watch(vaultSummariesProvider);
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Secure Vault'),
+        actions: [
+          IconButton(
+            key: const ValueKey('vault_manual_lock_button'),
+            tooltip: 'Lock vault',
+            icon: const Icon(Icons.lock_outline),
+            onPressed: () => ref.read(vaultSessionProvider.notifier).lock(),
+          ),
+        ],
+      ),
+      body: summaries.when(
+        loading: () =>
+            const Center(child: LoadingIndicator(message: 'Loading vault')),
+        error: (error, stackTrace) => ErrorView(
+          title: 'Could not load vault',
+          message: error.toString(),
+          onRetry: () => ref.invalidate(vaultSummariesProvider),
+        ),
+        data: (data) => data.isEmpty
+            ? EmptyStateWidget(
+                key: const ValueKey('vault_empty_state'),
+                icon: Icons.account_balance_wallet_outlined,
+                title: 'Your phone is the vault',
+                message:
+                    'Add bank accounts, PAN cards, masked cards, and secure documents stored locally with biometric protection.',
+                action: FilledButton.icon(
+                  onPressed: () =>
+                      _openAddTypePicker(context, ref, onAddRecord),
+                  icon: const Icon(Icons.add),
+                  label: const Text('Add record'),
+                ),
+              )
+            : RefreshIndicator(
+                onRefresh: () async =>
+                    ref.refresh(vaultSummariesProvider.future),
+                child: ListView(
+                  padding: AppSpacing.paddingMd,
+                  children: [
+                    _SummaryHeader(count: data.count),
+                    const SizedBox(height: AppSpacing.md),
+                    _BankAccountsSection(
+                      summaries: data.bankAccounts,
+                      onOpen: (summary) => _openDetail(
+                        context,
+                        ref,
+                        summary,
+                        VaultRecordRef.bankAccount(summary.nickname),
+                      ),
+                      onCallback: onOpenRecord,
+                    ),
+                    _PanCardsSection(
+                      summaries: data.panCards,
+                      onOpen: (summary) => _openDetail(
+                        context,
+                        ref,
+                        summary,
+                        VaultRecordRef.panCard(summary.id),
+                      ),
+                      onCallback: onOpenRecord,
+                    ),
+                    _CreditCardsSection(
+                      summaries: data.creditCards,
+                      onOpen: (summary) => _openDetail(
+                        context,
+                        ref,
+                        summary,
+                        VaultRecordRef.creditCard(summary.nickname),
+                      ),
+                      onCallback: onOpenRecord,
+                    ),
+                    _DocumentsSection(
+                      summaries: data.secureDocuments,
+                      onOpen: (summary) => _openDetail(
+                        context,
+                        ref,
+                        summary,
+                        VaultRecordRef.secureDocument(summary.nickname),
+                      ),
+                      onCallback: onOpenRecord,
+                    ),
+                    const SizedBox(height: 96),
+                  ],
+                ),
+              ),
+      ),
+      floatingActionButton: FloatingActionButton.extended(
+        key: const ValueKey('vault_add_record_button'),
+        onPressed: () => _openAddTypePicker(context, ref, onAddRecord),
+        icon: const Icon(Icons.add),
+        label: const Text('Add'),
+      ),
+    );
+  }
+
+  void _openDetail(
+    BuildContext context,
+    WidgetRef ref,
+    VaultEntrySummary summary,
+    VaultRecordRef recordRef,
+  ) {
+    onOpenRecord?.call(recordRef);
+    showModalBottomSheet<void>(
+      context: context,
+      isScrollControlled: true,
+      showDragHandle: true,
+      builder: (_) => RecordDetailSheet(summary: summary, recordRef: recordRef),
+    );
+  }
+
+  Future<void> _openAddTypePicker(
+    BuildContext context,
+    WidgetRef ref,
+    ValueChanged<VaultRecordType>? callback,
+  ) async {
+    final type = await showModalBottomSheet<VaultRecordType>(
+      context: context,
+      showDragHandle: true,
+      builder: (_) => const _AddTypePicker(),
+    );
+    if (type == null) return;
+    callback?.call(type);
+    if (!context.mounted) return;
+    await Navigator.of(context).push<void>(
+      MaterialPageRoute(builder: (_) => VaultRecordFormScreen(type: type)),
+    );
+  }
+}
+
+class _SummaryHeader extends StatelessWidget {
+  const _SummaryHeader({required this.count});
+
+  final int count;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return AppCard(
+      elevation: 0,
+      child: Row(
+        children: [
+          Icon(Icons.security_outlined, color: theme.colorScheme.primary),
+          const SizedBox(width: AppSpacing.md),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  '$count vault records',
+                  style: theme.textTheme.titleMedium?.copyWith(
+                    fontWeight: FontWeight.w700,
+                  ),
+                ),
+                Text(
+                  'Summaries only. Sensitive fields stay encrypted until reveal.',
+                  style: theme.textTheme.bodySmall?.copyWith(
+                    color: theme.colorScheme.onSurfaceVariant,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _BankAccountsSection extends StatelessWidget {
+  const _BankAccountsSection({
+    required this.summaries,
+    required this.onOpen,
+    required this.onCallback,
+  });
+
+  final List<BankAccountSummary> summaries;
+  final ValueChanged<BankAccountSummary> onOpen;
+  final ValueChanged<VaultRecordRef>? onCallback;
+
+  @override
+  Widget build(BuildContext context) {
+    return _VaultSection(
+      title: 'Bank accounts',
+      emptyText: 'No bank accounts yet',
+      children: [
+        for (final summary in summaries)
+          ListTile(
+            leading: const Icon(Icons.account_balance_outlined),
+            title: Text(summary.nickname),
+            subtitle: Text('${summary.bankName} · ${summary.ifscCode}'),
+            trailing: const Icon(Icons.chevron_right),
+            onTap: () {
+              onCallback?.call(VaultRecordRef.bankAccount(summary.nickname));
+              onOpen(summary);
+            },
+          ),
+      ],
+    );
+  }
+}
+
+class _PanCardsSection extends StatelessWidget {
+  const _PanCardsSection({
+    required this.summaries,
+    required this.onOpen,
+    required this.onCallback,
+  });
+
+  final List<PanCardSummary> summaries;
+  final ValueChanged<PanCardSummary> onOpen;
+  final ValueChanged<VaultRecordRef>? onCallback;
+
+  @override
+  Widget build(BuildContext context) {
+    return _VaultSection(
+      title: 'PAN cards',
+      emptyText: 'No PAN cards yet',
+      children: [
+        for (final summary in summaries)
+          ListTile(
+            leading: const Icon(Icons.badge_outlined),
+            title: Text(summary.nameOnCard),
+            subtitle: Text('PAN record #${summary.id}'),
+            trailing: const Icon(Icons.chevron_right),
+            onTap: () {
+              onCallback?.call(VaultRecordRef.panCard(summary.id));
+              onOpen(summary);
+            },
+          ),
+      ],
+    );
+  }
+}
+
+class _CreditCardsSection extends StatelessWidget {
+  const _CreditCardsSection({
+    required this.summaries,
+    required this.onOpen,
+    required this.onCallback,
+  });
+
+  final List<CreditCardSummary> summaries;
+  final ValueChanged<CreditCardSummary> onOpen;
+  final ValueChanged<VaultRecordRef>? onCallback;
+
+  @override
+  Widget build(BuildContext context) {
+    return _VaultSection(
+      title: 'Cards',
+      emptyText: 'No masked cards yet',
+      children: [
+        for (final summary in summaries)
+          ListTile(
+            leading: const Icon(Icons.credit_card_outlined),
+            title: Text(summary.nickname),
+            subtitle: Text(
+              '${summary.issuingBank} · ${summary.cardNetwork.name.toUpperCase()} ending ${summary.last4}',
+            ),
+            trailing: const Icon(Icons.chevron_right),
+            onTap: () {
+              onCallback?.call(VaultRecordRef.creditCard(summary.nickname));
+              onOpen(summary);
+            },
+          ),
+      ],
+    );
+  }
+}
+
+class _DocumentsSection extends StatelessWidget {
+  const _DocumentsSection({
+    required this.summaries,
+    required this.onOpen,
+    required this.onCallback,
+  });
+
+  final List<SecureDocumentSummary> summaries;
+  final ValueChanged<SecureDocumentSummary> onOpen;
+  final ValueChanged<VaultRecordRef>? onCallback;
+
+  @override
+  Widget build(BuildContext context) {
+    return _VaultSection(
+      title: 'Documents',
+      emptyText: 'No secure documents yet',
+      children: [
+        for (final summary in summaries)
+          ListTile(
+            leading: const Icon(Icons.description_outlined),
+            title: Text(summary.nickname),
+            subtitle: Text(_documentCategoryLabel(summary.category)),
+            trailing: const Icon(Icons.chevron_right),
+            onTap: () {
+              onCallback?.call(VaultRecordRef.secureDocument(summary.nickname));
+              onOpen(summary);
+            },
+          ),
+      ],
+    );
+  }
+}
+
+class _VaultSection extends StatelessWidget {
+  const _VaultSection({
+    required this.title,
+    required this.emptyText,
+    required this.children,
+  });
+
+  final String title;
+  final String emptyText;
+  final List<Widget> children;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Padding(
+      padding: const EdgeInsets.only(bottom: AppSpacing.md),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Padding(
+            padding: AppSpacing.paddingHorizontalSm,
+            child: Text(
+              title,
+              style: theme.textTheme.titleSmall?.copyWith(
+                fontWeight: FontWeight.w700,
+              ),
+            ),
+          ),
+          const SizedBox(height: AppSpacing.sm),
+          AppCard(
+            padding: EdgeInsets.zero,
+            elevation: 0,
+            child: children.isEmpty
+                ? ListTile(
+                    title: Text(emptyText),
+                    leading: const Icon(Icons.inbox_outlined),
+                  )
+                : Column(children: children),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _AddTypePicker extends StatelessWidget {
+  const _AddTypePicker();
+
+  @override
+  Widget build(BuildContext context) {
+    return SafeArea(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          const ListTile(title: Text('Add vault record')),
+          _TypeTile(
+            icon: Icons.account_balance_outlined,
+            label: 'Bank account',
+            type: VaultRecordType.bankAccount,
+          ),
+          _TypeTile(
+            icon: Icons.badge_outlined,
+            label: 'PAN card',
+            type: VaultRecordType.panCard,
+          ),
+          _TypeTile(
+            icon: Icons.credit_card_outlined,
+            label: 'Masked card',
+            type: VaultRecordType.creditCard,
+          ),
+          _TypeTile(
+            icon: Icons.description_outlined,
+            label: 'Secure document',
+            type: VaultRecordType.secureDocument,
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _TypeTile extends StatelessWidget {
+  const _TypeTile({
+    required this.icon,
+    required this.label,
+    required this.type,
+  });
+
+  final IconData icon;
+  final String label;
+  final VaultRecordType type;
+
+  @override
+  Widget build(BuildContext context) {
+    return ListTile(
+      leading: Icon(icon),
+      title: Text(label),
+      onTap: () => Navigator.of(context).pop(type),
+    );
+  }
+}
+
+String _documentCategoryLabel(DocumentCategory category) {
+  return switch (category) {
+    DocumentCategory.personalId => 'Personal ID',
+    DocumentCategory.incomeProof => 'Income proof',
+    DocumentCategory.taxCredit => 'Tax credit',
+    DocumentCategory.investmentProof => 'Investment proof',
+    DocumentCategory.hra => 'HRA',
+    DocumentCategory.capitalGains => 'Capital gains',
+    DocumentCategory.homeLoan => 'Home loan',
+    DocumentCategory.other => 'Other',
+  };
+}

--- a/packages/feature_coin/lib/src/presentation/screens/vault_record_form_screen.dart
+++ b/packages/feature_coin/lib/src/presentation/screens/vault_record_form_screen.dart
@@ -1,0 +1,453 @@
+import 'package:core_domain/core_domain.dart';
+import 'package:core_ui/core_ui.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:platform_coin_vault/platform_coin_vault.dart';
+
+import '../../application/vault_providers.dart';
+import '../../application/vault_record_ref.dart';
+import '../../application/vault_session.dart';
+import '../../application/vault_summaries_provider.dart';
+
+class VaultRecordFormScreen extends ConsumerStatefulWidget {
+  const VaultRecordFormScreen({
+    super.key,
+    required this.type,
+    this.editRef,
+    this.onSaved,
+  });
+
+  final VaultRecordType type;
+  final VaultRecordRef? editRef;
+  final VoidCallback? onSaved;
+
+  @override
+  ConsumerState<VaultRecordFormScreen> createState() =>
+      _VaultRecordFormScreenState();
+}
+
+class _VaultRecordFormScreenState extends ConsumerState<VaultRecordFormScreen> {
+  final _formKey = GlobalKey<FormState>();
+  final _controllers = <String, TextEditingController>{};
+  var _saving = false;
+  String? _formError;
+  String? _nicknameError;
+  DocumentCategory _documentCategory = DocumentCategory.other;
+  CardNetwork _cardNetwork = CardNetwork.visa;
+
+  bool get _isEditing => widget.editRef != null;
+
+  @override
+  void initState() {
+    super.initState();
+    for (final key in _fieldKeys) {
+      _controllers[key] = TextEditingController();
+    }
+    if (_isEditing) {
+      WidgetsBinding.instance.addPostFrameCallback((_) => _loadForEdit());
+    }
+  }
+
+  @override
+  void dispose() {
+    for (final controller in _controllers.values) {
+      controller.dispose();
+    }
+    super.dispose();
+  }
+
+  List<String> get _fieldKeys => const [
+    'nickname',
+    'bankName',
+    'accountHolderName',
+    'accountNumber',
+    'ifscCode',
+    'accountType',
+    'branchName',
+    'notes',
+    'panNumber',
+    'nameOnCard',
+    'fathersName',
+    'dateOfBirth',
+    'last4',
+    'expiryMonth',
+    'expiryYear',
+    'issuingBank',
+    'linkedAccountNickname',
+    'customFields',
+  ];
+
+  TextEditingController _c(String key) => _controllers[key]!;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: Text(_title)),
+      body: Form(
+        key: _formKey,
+        child: ListView(
+          padding: AppSpacing.paddingMd,
+          children: [
+            if (_formError != null) ...[
+              InlineError(message: _formError!),
+              const SizedBox(height: AppSpacing.md),
+            ],
+            ..._fieldsForType(),
+            const SizedBox(height: AppSpacing.lg),
+            FilledButton.icon(
+              key: const ValueKey('vault_save_record_button'),
+              onPressed: _saving ? null : _save,
+              icon: _saving
+                  ? const SizedBox.square(
+                      dimension: 18,
+                      child: CircularProgressIndicator(strokeWidth: 2),
+                    )
+                  : const Icon(Icons.save_outlined),
+              label: Text(_saving ? 'Saving' : 'Save record'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  String get _title {
+    final action = _isEditing ? 'Edit' : 'Add';
+    return switch (widget.type) {
+      VaultRecordType.bankAccount => '$action bank account',
+      VaultRecordType.panCard => '$action PAN card',
+      VaultRecordType.creditCard => '$action masked card',
+      VaultRecordType.secureDocument => '$action secure document',
+    };
+  }
+
+  List<Widget> _fieldsForType() {
+    return switch (widget.type) {
+      VaultRecordType.bankAccount => [
+        _text('nickname', 'Nickname', required: true, enabled: !_isEditing),
+        _text('bankName', 'Bank name', required: true),
+        _text('accountHolderName', 'Account holder name', required: true),
+        _text('accountNumber', 'Account number', required: true),
+        _text('ifscCode', 'IFSC code', required: true),
+        _text('accountType', 'Account type', required: true),
+        _text('branchName', 'Branch name'),
+        _text('notes', 'Notes', maxLines: 3),
+      ],
+      VaultRecordType.panCard => [
+        _text('panNumber', 'PAN number', required: true),
+        _text('nameOnCard', 'Name on card', required: true),
+        _text('fathersName', 'Father name'),
+        _text('dateOfBirth', 'Date of birth (YYYY-MM-DD)'),
+      ],
+      VaultRecordType.creditCard => [
+        _text('nickname', 'Nickname', required: true, enabled: !_isEditing),
+        DropdownButtonFormField<CardNetwork>(
+          initialValue: _cardNetwork,
+          decoration: const InputDecoration(labelText: 'Network'),
+          items: [
+            for (final network in CardNetwork.values)
+              DropdownMenuItem(
+                value: network,
+                child: Text(network.name.toUpperCase()),
+              ),
+          ],
+          onChanged: (value) {
+            if (value != null) setState(() => _cardNetwork = value);
+          },
+        ),
+        _text('last4', 'Last 4 digits', required: true),
+        _text('expiryMonth', 'Expiry month', required: true),
+        _text('expiryYear', 'Expiry year', required: true),
+        _text('issuingBank', 'Issuing bank', required: true),
+      ],
+      VaultRecordType.secureDocument => [
+        _text('nickname', 'Nickname', required: true, enabled: !_isEditing),
+        DropdownButtonFormField<DocumentCategory>(
+          initialValue: _documentCategory,
+          decoration: const InputDecoration(labelText: 'Category'),
+          items: [
+            for (final category in DocumentCategory.values)
+              DropdownMenuItem(value: category, child: Text(category.name)),
+          ],
+          onChanged: (value) {
+            if (value != null) setState(() => _documentCategory = value);
+          },
+        ),
+        _text('linkedAccountNickname', 'Linked account nickname'),
+        _text(
+          'customFields',
+          'Custom fields (one key=value per line)',
+          maxLines: 4,
+        ),
+        _text('notes', 'Notes', maxLines: 3),
+      ],
+    };
+  }
+
+  Widget _text(
+    String key,
+    String label, {
+    bool required = false,
+    bool enabled = true,
+    int maxLines = 1,
+  }) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: AppSpacing.md),
+      child: TextFormField(
+        key: ValueKey('vault_${key}_field'),
+        controller: _c(key),
+        enabled: enabled,
+        maxLines: maxLines,
+        decoration: InputDecoration(
+          labelText: label,
+          errorText: key == 'nickname' ? _nicknameError : null,
+        ),
+        validator: required
+            ? (value) => _trim(value).isEmpty ? '$label is required' : null
+            : null,
+      ),
+    );
+  }
+
+  Future<void> _loadForEdit() async {
+    final editRef = widget.editRef;
+    if (editRef == null) return;
+    final repositories = await ref.read(vaultRepositoriesProvider.future);
+    final result = await ref.read(vaultSessionProvider.notifier).withKey((
+      keyBytes,
+    ) async {
+      return switch (editRef.type) {
+        VaultRecordType.bankAccount => repositories.bankAccounts.getByNickname(
+          editRef.nickname!,
+          keyBytes,
+        ),
+        VaultRecordType.panCard => repositories.panCards.getById(
+          editRef.id!,
+          keyBytes,
+        ),
+        VaultRecordType.secureDocument =>
+          repositories.secureDocuments.getByNickname(
+            editRef.nickname!,
+            keyBytes,
+          ),
+        VaultRecordType.creditCard => repositories.creditCards.getByNickname(
+          editRef.nickname!,
+        ),
+      };
+    });
+    if (!mounted || result == null || result.isFailure) return;
+    final record = result.valueOrNull;
+    if (record == null) return;
+    setState(() => _fillFromRecord(record));
+  }
+
+  void _fillFromRecord(Object record) {
+    switch (record) {
+      case BankAccountRecord():
+        _c('nickname').text = record.nickname;
+        _c('bankName').text = record.bankName;
+        _c('accountHolderName').text = record.accountHolderName;
+        _c('accountNumber').text = record.accountNumber;
+        _c('ifscCode').text = record.ifscCode;
+        _c('accountType').text = record.accountType;
+        _c('branchName').text = record.branchName ?? '';
+        _c('notes').text = record.notes ?? '';
+      case PanCardRecord():
+        _c('panNumber').text = record.panNumber;
+        _c('nameOnCard').text = record.nameOnCard;
+        _c('fathersName').text = record.fathersName ?? '';
+        _c('dateOfBirth').text = _formatDate(record.dateOfBirth);
+      case CreditCardRecord():
+        _c('nickname').text = record.nickname;
+        _cardNetwork = record.cardNetwork;
+        _c('last4').text = record.last4;
+        _c('expiryMonth').text = '${record.expiryMonth}';
+        _c('expiryYear').text = '${record.expiryYear}';
+        _c('issuingBank').text = record.issuingBank;
+      case SecureDocumentRecord():
+        _c('nickname').text = record.nickname;
+        _documentCategory = record.category;
+        _c('linkedAccountNickname').text = record.linkedAccountNickname ?? '';
+        _c('customFields').text = record.customFields.entries
+            .map((entry) => '${entry.key}=${entry.value}')
+            .join('\n');
+        _c('notes').text = record.notes ?? '';
+    }
+  }
+
+  Future<void> _save() async {
+    setState(() {
+      _formError = null;
+      _nicknameError = null;
+    });
+    if (!(_formKey.currentState?.validate() ?? false)) return;
+    final preflightError = _platformValidationError();
+    if (preflightError != null) {
+      setState(() => _formError = preflightError);
+      return;
+    }
+
+    setState(() => _saving = true);
+    try {
+      final repositories = await ref.read(vaultRepositoriesProvider.future);
+      final result = await _saveForType(repositories);
+      if (!mounted) return;
+      if (result.isFailure) {
+        final failure = result.failure;
+        setState(() {
+          if (failure is ValidationFailure && failure.field == 'nickname') {
+            _nicknameError = failure.message;
+          } else {
+            _formError = failure.message;
+          }
+        });
+        return;
+      }
+      ref.invalidate(vaultSummariesProvider);
+      widget.onSaved?.call();
+      if (Navigator.of(context).canPop()) Navigator.of(context).pop();
+    } on ArgumentError catch (error) {
+      setState(
+        () => _formError = error.message?.toString() ?? error.toString(),
+      );
+    } on FormatException catch (error) {
+      setState(() => _formError = error.message);
+    } finally {
+      if (mounted) setState(() => _saving = false);
+    }
+  }
+
+  Future<Result<void>> _saveForType(VaultRepositories repositories) async {
+    return switch (widget.type) {
+      VaultRecordType.bankAccount => _withKey((keyBytes) async {
+        final record = BankAccountRecord(
+          id: null,
+          nickname: _trimText('nickname'),
+          bankName: _trimText('bankName'),
+          accountHolderName: _trimText('accountHolderName'),
+          accountNumber: _trimText('accountNumber'),
+          ifscCode: _trimText('ifscCode').toUpperCase(),
+          accountType: _trimText('accountType'),
+          branchName: _optionalText('branchName'),
+          notes: _optionalText('notes'),
+        );
+        return _isEditing
+            ? repositories.bankAccounts.update(record, keyBytes)
+            : _voidFromId(repositories.bankAccounts.create(record, keyBytes));
+      }),
+      VaultRecordType.panCard => _withKey((keyBytes) async {
+        final record = PanCardRecord(
+          id: widget.editRef?.id,
+          panNumber: _trimText('panNumber').toUpperCase(),
+          nameOnCard: _trimText('nameOnCard'),
+          fathersName: _optionalText('fathersName'),
+          dateOfBirth: _optionalDate('dateOfBirth'),
+        );
+        return _isEditing
+            ? repositories.panCards.update(record, keyBytes)
+            : _voidFromId(repositories.panCards.create(record, keyBytes));
+      }),
+      VaultRecordType.creditCard => _saveCreditCard(repositories),
+      VaultRecordType.secureDocument => _withKey((keyBytes) async {
+        final record = SecureDocumentRecord(
+          id: null,
+          nickname: _trimText('nickname'),
+          category: _documentCategory,
+          linkedAccountNickname: _optionalText('linkedAccountNickname'),
+          customFields: _parseCustomFields(_c('customFields').text),
+          notes: _optionalText('notes'),
+          createdAt: DateTime.now(),
+        );
+        return _isEditing
+            ? repositories.secureDocuments.update(record, keyBytes)
+            : _voidFromId(
+                repositories.secureDocuments.create(record, keyBytes),
+              );
+      }),
+    };
+  }
+
+  String? _platformValidationError() {
+    return switch (widget.type) {
+      VaultRecordType.bankAccount =>
+        isValidIfsc(_trimText('ifscCode').toUpperCase())
+            ? null
+            : 'Not a valid IFSC code',
+      VaultRecordType.panCard =>
+        isValidPan(_trimText('panNumber').toUpperCase())
+            ? null
+            : 'Not a valid PAN number',
+      VaultRecordType.creditCard || VaultRecordType.secureDocument => null,
+    };
+  }
+
+  Future<Result<void>> _saveCreditCard(VaultRepositories repositories) {
+    final record = CreditCardRecord(
+      id: null,
+      nickname: _trimText('nickname'),
+      cardNetwork: _cardNetwork,
+      last4: _trimText('last4'),
+      expiryMonth: int.parse(_trimText('expiryMonth')),
+      expiryYear: int.parse(_trimText('expiryYear')),
+      issuingBank: _trimText('issuingBank'),
+      createdAt: DateTime.now(),
+    );
+    return _isEditing
+        ? repositories.creditCards.update(record)
+        : _voidFromId(repositories.creditCards.create(record));
+  }
+
+  Future<Result<void>> _withKey(
+    Future<Result<void>> Function(List<int> keyBytes) operation,
+  ) async {
+    final result = await ref
+        .read(vaultSessionProvider.notifier)
+        .withKey(operation);
+    return result ??
+        const Failure(AuthFailure(message: 'Unlock the vault before saving.'));
+  }
+
+  Future<Result<void>> _voidFromId(Future<Result<int>> resultFuture) async {
+    final result = await resultFuture;
+    if (result.isFailure) return Failure(result.failure);
+    return const Success(null);
+  }
+
+  String _trimText(String key) => _trim(_c(key).text);
+
+  String? _optionalText(String key) {
+    final value = _trimText(key);
+    return value.isEmpty ? null : value;
+  }
+
+  DateTime? _optionalDate(String key) {
+    final value = _trimText(key);
+    if (value.isEmpty) return null;
+    return DateTime.parse(value);
+  }
+
+  Map<String, String> _parseCustomFields(String raw) {
+    final fields = <String, String>{};
+    for (final line in raw.split('\n')) {
+      final trimmed = line.trim();
+      if (trimmed.isEmpty) continue;
+      final separator = trimmed.indexOf('=');
+      if (separator <= 0) {
+        throw const FormatException('Custom fields must use key=value lines');
+      }
+      fields[trimmed.substring(0, separator).trim()] = trimmed
+          .substring(separator + 1)
+          .trim();
+    }
+    return fields;
+  }
+
+  String _formatDate(DateTime? date) {
+    if (date == null) return '';
+    return '${date.year.toString().padLeft(4, '0')}-'
+        '${date.month.toString().padLeft(2, '0')}-'
+        '${date.day.toString().padLeft(2, '0')}';
+  }
+}
+
+String _trim(String? value) => value?.trim() ?? '';

--- a/packages/feature_coin/lib/src/presentation/widgets/masked_vault_field.dart
+++ b/packages/feature_coin/lib/src/presentation/widgets/masked_vault_field.dart
@@ -1,0 +1,74 @@
+import 'package:flutter/material.dart';
+
+class MaskedVaultField extends StatefulWidget {
+  const MaskedVaultField({
+    super.key,
+    required this.label,
+    required this.maskedValue,
+    required this.revealValue,
+    this.onCopy,
+  });
+
+  final String label;
+  final String maskedValue;
+  final Future<String?> Function() revealValue;
+  final Future<void> Function(String value)? onCopy;
+
+  @override
+  State<MaskedVaultField> createState() => _MaskedVaultFieldState();
+}
+
+class _MaskedVaultFieldState extends State<MaskedVaultField> {
+  String? _revealedValue;
+  var _loading = false;
+
+  bool get _isRevealed => _revealedValue != null;
+
+  @override
+  Widget build(BuildContext context) {
+    return ListTile(
+      contentPadding: EdgeInsets.zero,
+      title: Text(widget.label),
+      subtitle: Text(_revealedValue ?? widget.maskedValue),
+      trailing: Wrap(
+        spacing: 4,
+        children: [
+          IconButton(
+            tooltip: _isRevealed
+                ? 'Hide ${widget.label}'
+                : 'Reveal ${widget.label}',
+            icon: _loading
+                ? const SizedBox.square(
+                    dimension: 20,
+                    child: CircularProgressIndicator(strokeWidth: 2),
+                  )
+                : Icon(_isRevealed ? Icons.visibility_off : Icons.visibility),
+            onPressed: _loading ? null : _toggleReveal,
+          ),
+          if (widget.onCopy != null)
+            IconButton(
+              tooltip: 'Copy ${widget.label}',
+              icon: const Icon(Icons.copy_outlined),
+              onPressed: _isRevealed
+                  ? () => widget.onCopy?.call(_revealedValue!)
+                  : null,
+            ),
+        ],
+      ),
+    );
+  }
+
+  Future<void> _toggleReveal() async {
+    if (_isRevealed) {
+      setState(() => _revealedValue = null);
+      return;
+    }
+    setState(() => _loading = true);
+    final value = await widget.revealValue();
+    if (!mounted) return;
+    setState(() {
+      _revealedValue = value;
+      _loading = false;
+    });
+  }
+}

--- a/packages/feature_coin/lib/src/presentation/widgets/record_detail_sheet.dart
+++ b/packages/feature_coin/lib/src/presentation/widgets/record_detail_sheet.dart
@@ -1,0 +1,170 @@
+import 'package:core_ui/core_ui.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:platform_coin_vault/platform_coin_vault.dart';
+
+import '../../application/clipboard_service.dart';
+import '../../application/vault_record_reader.dart';
+import '../../application/vault_record_ref.dart';
+import 'masked_vault_field.dart';
+
+class RecordDetailSheet extends ConsumerWidget {
+  const RecordDetailSheet({
+    super.key,
+    required this.summary,
+    required this.recordRef,
+  });
+
+  final VaultEntrySummary summary;
+  final VaultRecordRef recordRef;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return SafeArea(
+      child: Padding(
+        padding: EdgeInsets.only(
+          left: AppSpacing.md,
+          right: AppSpacing.md,
+          bottom: MediaQuery.viewInsetsOf(context).bottom + AppSpacing.md,
+        ),
+        child: SingleChildScrollView(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Text(
+                _title,
+                style: Theme.of(
+                  context,
+                ).textTheme.titleLarge?.copyWith(fontWeight: FontWeight.w700),
+              ),
+              const SizedBox(height: AppSpacing.sm),
+              ..._summaryRows(),
+              ..._sensitiveRows(ref),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  String get _title {
+    return switch (summary) {
+      BankAccountSummary(:final nickname) => nickname,
+      PanCardSummary(:final nameOnCard) => nameOnCard,
+      CreditCardSummary(:final nickname) => nickname,
+      SecureDocumentSummary(:final nickname) => nickname,
+    };
+  }
+
+  List<Widget> _summaryRows() {
+    return switch (summary) {
+      BankAccountSummary(
+        :final bankName,
+        :final accountHolderName,
+        :final ifscCode,
+        :final accountType,
+      ) =>
+        [
+          _PlainRow(label: 'Bank', value: bankName),
+          _PlainRow(label: 'Holder', value: accountHolderName),
+          _PlainRow(label: 'IFSC', value: ifscCode),
+          _PlainRow(label: 'Type', value: accountType),
+        ],
+      PanCardSummary(:final id, :final fathersName) => [
+        _PlainRow(label: 'Record id', value: '$id'),
+        if (fathersName != null)
+          _PlainRow(label: 'Father name', value: fathersName),
+      ],
+      CreditCardSummary(
+        :final cardNetwork,
+        :final last4,
+        :final expiryMonth,
+        :final expiryYear,
+        :final issuingBank,
+      ) =>
+        [
+          _PlainRow(label: 'Issuer', value: issuingBank),
+          _PlainRow(label: 'Network', value: cardNetwork.name.toUpperCase()),
+          _PlainRow(label: 'Card', value: '•••• $last4'),
+          _PlainRow(
+            label: 'Expiry',
+            value: '${expiryMonth.toString().padLeft(2, '0')}/$expiryYear',
+          ),
+        ],
+      SecureDocumentSummary(
+        :final category,
+        :final linkedAccountNickname,
+        :final hasAttachment,
+      ) =>
+        [
+          _PlainRow(label: 'Category', value: category.name),
+          if (linkedAccountNickname != null)
+            _PlainRow(label: 'Linked account', value: linkedAccountNickname),
+          _PlainRow(
+            label: 'Attachment',
+            value: hasAttachment ? 'Stored' : 'None',
+          ),
+        ],
+    };
+  }
+
+  List<Widget> _sensitiveRows(WidgetRef ref) {
+    final clipboard = ref.read(clipboardServiceProvider);
+    final reader = ref.read(vaultRecordReaderProvider);
+    Future<void> copy(String value) => clipboard.copyWithAutoClear(value);
+    return switch (summary) {
+      BankAccountSummary() => [
+        MaskedVaultField(
+          key: const ValueKey('vault_bank_account_number_field'),
+          label: 'Account number',
+          maskedValue: '••••••••',
+          revealValue: () =>
+              reader.revealBankAccountNumber(recordRef.nickname ?? ''),
+          onCopy: copy,
+        ),
+        MaskedVaultField(
+          label: 'Notes',
+          maskedValue: '••••',
+          revealValue: () => reader.revealBankNotes(recordRef.nickname ?? ''),
+          onCopy: copy,
+        ),
+      ],
+      PanCardSummary() => [
+        MaskedVaultField(
+          key: const ValueKey('vault_pan_number_field'),
+          label: 'PAN number',
+          maskedValue: '••••••••••',
+          revealValue: () => reader.revealPanNumber(recordRef.id ?? -1),
+          onCopy: copy,
+        ),
+      ],
+      CreditCardSummary() => const [],
+      SecureDocumentSummary() => [
+        MaskedVaultField(
+          label: 'Notes',
+          maskedValue: '••••',
+          revealValue: () =>
+              reader.revealDocumentNotes(recordRef.nickname ?? ''),
+          onCopy: copy,
+        ),
+      ],
+    };
+  }
+}
+
+class _PlainRow extends StatelessWidget {
+  const _PlainRow({required this.label, required this.value});
+
+  final String label;
+  final String value;
+
+  @override
+  Widget build(BuildContext context) {
+    return ListTile(
+      contentPadding: EdgeInsets.zero,
+      title: Text(label),
+      subtitle: Text(value),
+    );
+  }
+}

--- a/packages/feature_coin/test/presentation/screens/vault_gate_screen_test.dart
+++ b/packages/feature_coin/test/presentation/screens/vault_gate_screen_test.dart
@@ -1,0 +1,75 @@
+// ignore_for_file: depend_on_referenced_packages
+
+import 'package:core_data/core_data.dart';
+import 'package:feature_coin/feature_coin.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:platform_coin_vault/platform_coin_vault.dart';
+
+class FakeScreenSecurity extends VaultScreenSecurity {
+  FakeScreenSecurity()
+    : super(enableProtection: () async {}, disableProtection: () async {});
+
+  var protects = 0;
+  var unprotects = 0;
+
+  @override
+  Future<void> protect() async => protects++;
+
+  @override
+  Future<void> unprotect() async => unprotects++;
+}
+
+void main() {
+  testWidgets('renders locked state without exposing vault content', (
+    tester,
+  ) async {
+    final security = FakeScreenSecurity();
+    final container = ProviderContainer(
+      overrides: [screenSecurityProvider.overrideWithValue(security)],
+    );
+    addTearDown(container.dispose);
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: const MaterialApp(home: VaultGateScreen(autoUnlock: false)),
+      ),
+    );
+    await tester.pump();
+
+    expect(find.text('Vault locked'), findsOneWidget);
+    expect(find.byKey(const ValueKey('vault_unlock_button')), findsOneWidget);
+    expect(security.protects, 1);
+
+    await tester.pumpWidget(const SizedBox.shrink());
+    await tester.pump();
+    expect(security.unprotects, 1);
+  });
+
+  testWidgets('renders unavailable state when biometrics are not enrolled', (
+    tester,
+  ) async {
+    final keyManager = VaultKeyManager.forTesting(
+      secureStorage: InMemorySecureStorage(),
+      authenticate: () async => true,
+      isAvailable: () async => false,
+    );
+    final container = ProviderContainer(
+      overrides: [vaultKeyManagerProvider.overrideWithValue(keyManager)],
+    );
+    addTearDown(container.dispose);
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: const MaterialApp(home: VaultGateScreen()),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('Biometrics unavailable'), findsOneWidget);
+    expect(find.textContaining('Enroll biometrics'), findsOneWidget);
+  });
+}

--- a/packages/feature_coin/test/presentation/screens/vault_home_screen_test.dart
+++ b/packages/feature_coin/test/presentation/screens/vault_home_screen_test.dart
@@ -1,0 +1,63 @@
+// ignore_for_file: depend_on_referenced_packages
+
+import 'package:feature_coin/feature_coin.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:platform_coin_vault/platform_coin_vault.dart';
+
+void main() {
+  testWidgets('renders grouped summaries without an unlocked session', (
+    tester,
+  ) async {
+    const summaries = VaultSummaries(
+      bankAccounts: [
+        BankAccountSummary(
+          nickname: 'HDFC Salary',
+          bankName: 'HDFC Bank',
+          accountHolderName: 'Jane Doe',
+          ifscCode: 'HDFC0001234',
+          accountType: 'savings',
+        ),
+      ],
+      panCards: [PanCardSummary(id: 7, nameOnCard: 'JANE DOE')],
+      creditCards: [
+        CreditCardSummary(
+          nickname: 'ICICI Amazon Pay',
+          cardNetwork: CardNetwork.visa,
+          last4: '4321',
+          expiryMonth: 8,
+          expiryYear: 2029,
+          issuingBank: 'ICICI Bank',
+        ),
+      ],
+      secureDocuments: [
+        SecureDocumentSummary(
+          nickname: 'Form 16 FY25',
+          category: DocumentCategory.incomeProof,
+          hasAttachment: false,
+        ),
+      ],
+    );
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          vaultSummariesProvider.overrideWith((ref) async => summaries),
+        ],
+        child: const MaterialApp(home: VaultHomeScreen()),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('Bank accounts'), findsOneWidget);
+    expect(find.text('PAN cards'), findsOneWidget);
+    expect(find.text('Cards'), findsOneWidget);
+    expect(find.text('Documents'), findsOneWidget);
+    expect(find.text('HDFC Salary'), findsOneWidget);
+    expect(find.text('JANE DOE'), findsOneWidget);
+    expect(find.text('ICICI Amazon Pay'), findsOneWidget);
+    expect(find.text('Form 16 FY25'), findsOneWidget);
+    expect(find.textContaining('Summaries only'), findsOneWidget);
+  });
+}

--- a/packages/feature_coin/test/presentation/screens/vault_record_form_screen_test.dart
+++ b/packages/feature_coin/test/presentation/screens/vault_record_form_screen_test.dart
@@ -1,0 +1,56 @@
+// ignore_for_file: depend_on_referenced_packages
+
+import 'package:feature_coin/feature_coin.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('shows inline error for invalid IFSC and does not save', (
+    tester,
+  ) async {
+    var saved = false;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: VaultRecordFormScreen(
+          type: VaultRecordType.bankAccount,
+          onSaved: () => saved = true,
+        ),
+      ),
+    );
+
+    await tester.enterText(
+      find.byKey(const ValueKey('vault_nickname_field')),
+      'HDFC Salary',
+    );
+    await tester.enterText(
+      find.byKey(const ValueKey('vault_bankName_field')),
+      'HDFC Bank',
+    );
+    await tester.enterText(
+      find.byKey(const ValueKey('vault_accountHolderName_field')),
+      'Jane Doe',
+    );
+    await tester.enterText(
+      find.byKey(const ValueKey('vault_accountNumber_field')),
+      '123456789012',
+    );
+    await tester.enterText(
+      find.byKey(const ValueKey('vault_ifscCode_field')),
+      'BADIFSC',
+    );
+    await tester.enterText(
+      find.byKey(const ValueKey('vault_accountType_field')),
+      'savings',
+    );
+
+    await tester.drag(find.byType(ListView), const Offset(0, -600));
+    await tester.pump();
+    await tester.tap(find.byKey(const ValueKey('vault_save_record_button')));
+    await tester.pump();
+    await tester.drag(find.byType(ListView), const Offset(0, 600));
+    await tester.pump();
+
+    expect(find.text('Not a valid IFSC code'), findsOneWidget);
+    expect(saved, isFalse);
+  });
+}

--- a/packages/feature_coin/test/presentation/widgets/record_detail_sheet_test.dart
+++ b/packages/feature_coin/test/presentation/widgets/record_detail_sheet_test.dart
@@ -1,0 +1,80 @@
+// ignore_for_file: depend_on_referenced_packages
+
+import 'package:feature_coin/feature_coin.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:platform_coin_vault/platform_coin_vault.dart';
+
+class FakeVaultRecordReader implements VaultRecordReader {
+  var bankAccountNumberRevealCount = 0;
+
+  @override
+  Future<String?> revealBankAccountNumber(String nickname) async {
+    bankAccountNumberRevealCount++;
+    return '123456789012';
+  }
+
+  @override
+  Future<String?> revealBankNotes(String nickname) async => 'Payroll account';
+
+  @override
+  Future<String?> revealDocumentNotes(String nickname) async => null;
+
+  @override
+  Future<String?> revealPanNumber(int id) async => null;
+}
+
+void main() {
+  testWidgets('masks account number until reveal and delegates copy', (
+    tester,
+  ) async {
+    final reader = FakeVaultRecordReader();
+    String? copied;
+    final clipboard = ClipboardService(
+      setData: (data) async => copied = data.text,
+      getData: () async => ClipboardData(text: copied ?? ''),
+    );
+    addTearDown(clipboard.dispose);
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          vaultRecordReaderProvider.overrideWithValue(reader),
+          clipboardServiceProvider.overrideWithValue(clipboard),
+        ],
+        child: const MaterialApp(
+          home: Scaffold(
+            body: RecordDetailSheet(
+              recordRef: VaultRecordRef.bankAccount('HDFC Salary'),
+              summary: BankAccountSummary(
+                nickname: 'HDFC Salary',
+                bankName: 'HDFC Bank',
+                accountHolderName: 'Jane Doe',
+                ifscCode: 'HDFC0001234',
+                accountType: 'savings',
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    expect(find.text('••••••••'), findsOneWidget);
+    expect(find.text('123456789012'), findsNothing);
+
+    await tester.tap(find.byIcon(Icons.visibility).first);
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 100));
+
+    expect(find.text('123456789012'), findsOneWidget);
+    expect(reader.bankAccountNumberRevealCount, 1);
+
+    await tester.tap(find.byIcon(Icons.copy_outlined).first);
+    await tester.pump();
+
+    expect(copied, '123456789012');
+    clipboard.dispose();
+  });
+}

--- a/packages/platform_coin_vault/lib/src/crypto/vault_key_manager.dart
+++ b/packages/platform_coin_vault/lib/src/crypto/vault_key_manager.dart
@@ -101,9 +101,9 @@ class VaultKeyManager implements EncryptionKeyManager {
   }
 
   /// Generates a new candidate DEK without persisting it. Pair with
-  /// [commitRotatedKey] via `VaultKeyRotationService.rotateKeyWithReencryption()`
-  /// — never call [commitRotatedKey] with a candidate key before all vault
-  /// data has been re-encrypted under it.
+  /// [persistRotatedKeyUnauthenticated] via
+  /// `VaultKeyRotationService.rotateKeyWithReencryption()` — never persist a
+  /// candidate key before all vault data has been re-encrypted under it.
   List<int> generateCandidateKey() => _generateKeyBytes();
 
   /// Persists [newKeyBytes] as the active DEK. Only call this after all

--- a/tasks/plan.md
+++ b/tasks/plan.md
@@ -1,0 +1,7 @@
+# Implementation Plan: feature_coin UI Phase 0
+
+Canonical spec: `docs/superpowers/specs/2026-07-22-feature-coin-ui-phase0.md`
+
+Canonical plan: `docs/superpowers/plans/2026-07-22-feature-coin-ui-phase0.md`
+
+This task starts from `origin/main` on `codex/feature-coin-ui-phase0`, implements the standalone package UI, and wires the tested vault gate into `/money/vault`.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,0 +1,30 @@
+# feature_coin UI Phase 0 Tasks
+
+- [x] Task 1: Add typed UI refs, summary aggregation, and screen-security service.
+  - Acceptance: Home data can be loaded from all four summary repositories without a DEK.
+  - Verify: `cd packages/feature_coin && flutter test test/application`
+  - Files: `packages/feature_coin/lib/src/application/*`
+
+- [x] Task 2: Add lock gate and grouped home list widgets.
+  - Acceptance: Locked, unavailable, auth-error, and unlocked states render deterministically.
+  - Verify: `cd packages/feature_coin && flutter test test/presentation`
+  - Files: `packages/feature_coin/lib/src/presentation/screens/*`
+
+- [x] Task 3: Add masked detail sheet with reveal/copy.
+  - Acceptance: Sensitive fields are masked by default and reveal only through `withKey`.
+  - Verify: widget test for detail reveal and copy delegation.
+  - Files: `packages/feature_coin/lib/src/presentation/widgets/*`
+
+- [x] Task 4: Add add/edit forms.
+  - Acceptance: Valid records persist; invalid PAN/IFSC and duplicate nickname failures show inline errors.
+  - Verify: widget tests for form validation and save paths.
+  - Files: `packages/feature_coin/lib/src/presentation/screens/*`, `packages/feature_coin/lib/src/presentation/widgets/forms/*`
+
+- [x] Task 5: Export UI and clean stale key-manager docs.
+  - Acceptance: Public `feature_coin.dart` exports the Phase 0 UI surface and `generateCandidateKey()` docs name `persistRotatedKeyUnauthenticated`.
+  - Verify: `cd packages/platform_coin_vault && flutter test test/crypto/vault_key_manager_test.dart`
+  - Files: `packages/feature_coin/lib/feature_coin.dart`, `packages/platform_coin_vault/lib/src/crypto/vault_key_manager.dart`
+
+- [x] Task 6: Shell wiring and focused validation.
+  - Acceptance: `/money/vault` opens the vault gate, the app depends on `feature_coin` instead of stale `airomoney`, and focused checks complete.
+  - Verify: `cd packages/feature_coin && flutter test`; `cd packages/feature_coin && dart analyze`; focused app analyze/test; `git diff --check`


### PR DESCRIPTION
# Summary

This PR implements the Airo Coin secure vault UI Phase 0.
Goal: provide the first usable biometric-gated vault experience on top of the merged platform vault/session foundation.

Core outcome:

* Adds the feature_coin lock gate, grouped summary list, masked detail reveal/copy UI, and add/edit forms.
* Wires /money/vault into the app and replaces the stale airomoney app dependency with feature_coin.

# Changes

### Code

* Added:
  * VaultGateScreen, VaultHomeScreen, VaultRecordFormScreen
  * MaskedVaultField and RecordDetailSheet
  * VaultRecordRef, VaultSummaries provider, VaultRecordReader, VaultScreenSecurity
  * Phase 0 widget tests for gate, summaries, reveal/copy, and invalid IFSC validation
* Updated:
  * app routing and Coins dashboard to expose Secure Vault
  * app pubspecs/lockfile and generated desktop plugin registrants for feature_coin dependencies
  * VaultKeyManager.generateCandidateKey docs to reference persistRotatedKeyUnauthenticated

### Logic

* Summary lists use platform summary repositories and do not require key bytes.
* Sensitive detail fields stay masked until a reveal action goes through the vault record reader/session boundary.
* Copy delegates to the existing ClipboardService auto-clear behavior.
* Invalid PAN/IFSC preflight validation shows inline form errors.

# API Changes

* Adds route: /money/vault

# Database Changes

* None.

# Observability / Logging

* No vault field logging added.

# Performance Impact

* List screen uses summary projections only; no bulk decrypt on home render.

# Risks

* Native screen protection and real biometric prompt behavior still require physical-device verification.
* The current form UI is functional Phase 0, not final visual polish.

Rollback plan:

* Revert this single commit; platform vault package remains intact.

# Testing

* Unit/widget tests:
  * cd packages/feature_coin && dart analyze
  * cd packages/feature_coin && flutter test
  * cd packages/platform_coin_vault && flutter test test/crypto/vault_key_manager_test.dart
* App focused validation:
  * cd app && dart analyze lib/core/routing/app_router.dart lib/core/routing/route_names.dart lib/features/coins/presentation/screens/coins_dashboard_screen.dart lib/features/home/screens/home_screen.dart lib/features/money/domain/repositories/wallet_repository.dart
  * cd app && flutter test test/features/coins/presentation/screens/coins_dashboard_screen_test.dart
* Hygiene:
  * git diff --check

# Deployment Notes

* Commit uses [skip ci] per issue-iteration CI cost policy.
* Draft until physical Android verification confirms biometric prompt, background lock, and screenshot/recents protection.

# Related Commits

* feat(feature_coin): add secure vault UI phase 0 [skip ci]

# Notes

* Feature packet and deterministic flows were recorded on #927.
* Physical-device verification remains pending from this thread.