### PR TITLE
Release Airo TV v0.0.4

### DIFF
--- a/.github/airo-build-profiles.json
+++ b/.github/airo-build-profiles.json
@@ -20,8 +20,8 @@
       "appPlatform": "mobileFull",
       "ciBuild": true,
       "edgeProfile": false,
-      "requiredPackages": ["airo", "airomoney"],
-      "featureModules": ["airo", "airomoney"],
+      "requiredPackages": ["airo"],
+      "featureModules": ["airo", "feature_coin"],
       "allowedNativePlugins": ["*"],
       "heavyPackages": [],
       "requiredDependencyOverrides": {
@@ -61,8 +61,7 @@
         "chess",
         "flame",
         "flame_audio",
-        "google_mlkit_text_recognition",
-        "airomoney"
+        "google_mlkit_text_recognition"
       ],
       "requiredDependencyOverrides": {
         "flutter_chrome_cast": "../packages/platform_player/third_party/flutter_chrome_cast"
@@ -237,8 +236,8 @@
       "appPlatform": "ios",
       "ciBuild": false,
       "edgeProfile": false,
-      "requiredPackages": ["airo", "airomoney"],
-      "featureModules": ["airo", "airomoney"],
+      "requiredPackages": ["airo"],
+      "featureModules": ["airo", "feature_coin"],
       "allowedNativePlugins": ["*"],
       "heavyPackages": [],
       "requiredDependencyOverrides": {

--- a/.github/workflows/airo-tv-release.yml
+++ b/.github/workflows/airo-tv-release.yml
@@ -470,6 +470,7 @@ jobs:
             --tree-shake-icons \
             --split-debug-info=build/debug-info-tv \
             --obfuscate
+          cp build/app/outputs/flutter-apk/app-release.apk build/airo-tv-canonical-arm64.apk
 
       - name: Build Android TV AAB
         run: |
@@ -485,16 +486,34 @@ jobs:
             --split-debug-info=build/debug-info-tv \
             --obfuscate
 
+      - name: Build Android TV ABI split APKs
+        run: |
+          cd app
+          export GRADLE_OPTS="-Dorg.gradle.watch.fs=false -Xmx4g -Dorg.gradle.parallel=true"
+          flutter build apk --release \
+            --target=lib/main_tv.dart \
+            --dart-define=APP_VARIANT=tv \
+            --dart-define=APP_PLATFORM=androidTv \
+            --build-name="$BUILD_NAME" \
+            --build-number="$BUILD_NUMBER" \
+            --split-per-abi \
+            --tree-shake-icons \
+            --split-debug-info=build/debug-info-tv \
+            --obfuscate
+
       - name: Verify release artifacts
         env:
-          AIRO_TV_RELEASE_APK: app/build/app/outputs/flutter-apk/app-release.apk
+          AIRO_TV_RELEASE_APK: app/build/airo-tv-canonical-arm64.apk
           AIRO_TV_RELEASE_AAB: app/build/app/outputs/bundle/release/app-release.aab
         run: scripts/check-android-tv-release.sh
 
       - name: Stage named release artifacts
         run: |
           mkdir -p release-artifacts
-          cp app/build/app/outputs/flutter-apk/app-release.apk "release-artifacts/Airo-TV-${BUILD_NAME}.apk"
+          cp app/build/airo-tv-canonical-arm64.apk "release-artifacts/Airo-TV-${BUILD_NAME}.apk"
+          cp app/build/app/outputs/flutter-apk/app-arm64-v8a-release.apk "release-artifacts/Airo-TV-${BUILD_NAME}-arm64-v8a.apk"
+          cp app/build/app/outputs/flutter-apk/app-armeabi-v7a-release.apk "release-artifacts/Airo-TV-${BUILD_NAME}-armeabi-v7a.apk"
+          cp app/build/app/outputs/flutter-apk/app-x86_64-release.apk "release-artifacts/Airo-TV-${BUILD_NAME}-x86_64.apk"
           cp app/build/app/outputs/bundle/release/app-release.aab "release-artifacts/Airo-TV-${BUILD_NAME}-Play-Store.aab"
           cp docs/release/AIRO_TV_RELEASE_TEMPLATE.md "release-artifacts/Airo-TV-${BUILD_NAME}-Release-Template.md"
           cp docs/release/AIRO_TV_MEDIA_ASSETS.md "release-artifacts/Airo-TV-${BUILD_NAME}-Media-Checklist.md"
@@ -519,6 +538,9 @@ jobs:
             echo "| Asset | Visibility | Purpose |"
             echo "| --- | --- | --- |"
             echo "| Airo-TV-${BUILD_NAME}.apk | Public/direct install | Android TV and compatible Fire TV testing |"
+            echo "| Airo-TV-${BUILD_NAME}-arm64-v8a.apk | Public/direct install | 64-bit ARM Android TV devices |"
+            echo "| Airo-TV-${BUILD_NAME}-armeabi-v7a.apk | Public/direct install | 32-bit ARM Android TV devices |"
+            echo "| Airo-TV-${BUILD_NAME}-x86_64.apk | Public/direct install | x86_64 emulator/Chromebook validation |"
             echo "| Airo-TV-${BUILD_NAME}-Play-Store.aab | Store upload / draft release evidence | Google Play TV upload input |"
             echo "| SHA256SUMS | Public/internal verification | Checksum evidence after final renaming |"
             echo "| Airo-TV-${BUILD_NAME}-Release-Manifest.json | Public/internal verification | Profile, package, source ref, workflow run, and checksum mapping |"

--- a/.github/workflows/release-orchestrator.yml
+++ b/.github/workflows/release-orchestrator.yml
@@ -519,6 +519,9 @@ jobs:
           }
 
           require_asset "release-artifacts/tv/Airo-TV-${BUILD_NAME}.apk"
+          require_asset "release-artifacts/tv/Airo-TV-${BUILD_NAME}-arm64-v8a.apk"
+          require_asset "release-artifacts/tv/Airo-TV-${BUILD_NAME}-armeabi-v7a.apk"
+          require_asset "release-artifacts/tv/Airo-TV-${BUILD_NAME}-x86_64.apk"
           require_asset "release-artifacts/tv/Airo-TV-${BUILD_NAME}-Play-Store.aab"
 
           case "$MOBILE_PROFILE" in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - Android TV/Google TV artifact verification is recorded with the release; Fire TV remains compatible/experimental pending dedicated device evidence.
 - Phone-hosted media streaming and its real-device receiver matrix remain under qualification.
 - macOS artifacts are unsigned and not notarized; they are release evidence, not a notarized macOS distribution.
+- Production Android signing and Firebase runtime secrets are not configured;
+  the release manifest discloses the non-production signing profile for each
+  direct-install artifact.
 
 ## [Airo TV v0.0.4-rc.3] - 2026-07-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,33 @@ All notable changes to this project are documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html) for public release tags.
 
+## [Airo TV v0.0.4] - 2026-07-22
+
+### Added
+
+- Local, deterministic search across imported channels and available guide data, including live TV search results.
+- Smart-playlist rules and persistent canonical channel identities to keep personal lists resilient across re-imports.
+- A bring-your-own XMLTV source flow, guide timeline improvements, favorites, captions, VOD resume/seek, and provider add-flows for Xtream, Stalker, and Jellyfin.
+- Aggregate M3U import counters for parsed, skipped, malformed, and elapsed values, processed through the existing Rust/worker parser boundary.
+
+### Changed
+
+- Airo TV uses a virtualized, paged playlist path for large user-provided playlists and a unified browse experience across TV and compact layouts.
+- Playback diagnostics and bounded retries now explain unavailable streams more clearly while keeping playlist credentials out of diagnostics.
+
+### Fixed
+
+- A channel is added to Recently Watched only after playback starts.
+- Favorites are discoverable from browse cards and the player, and the Guide's source action leads to a working XMLTV setup flow.
+- System picture-in-picture renders a video-only surface and restores the full interface when it closes.
+
+### Known limitations
+
+- Airo TV remains BYOC: it does not bundle playlists, channels, subscriptions, or media content.
+- Android TV/Google TV artifact verification is recorded with the release; Fire TV remains compatible/experimental pending dedicated device evidence.
+- Phone-hosted media streaming and its real-device receiver matrix remain under qualification.
+- macOS artifacts are unsigned and not notarized; they are release evidence, not a notarized macOS distribution.
+
 ## [Airo TV v0.0.4-rc.3] - 2026-07-19
 
 ### Added
@@ -109,5 +136,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - IPTV playlist import, search, playback, Cast controls, and Play Store readiness notes.
 
 [Airo TV v0.0.4-rc.1]: https://github.com/DevelopersCoffee/airo/compare/airo-tv-v0.0.3...airo-tv-v0.0.4-rc.1
+[Airo TV v0.0.4]: https://github.com/DevelopersCoffee/airo/compare/airo-tv-v0.0.3...airo-tv-v0.0.4
 [Airo TV v0.0.2]: https://github.com/DevelopersCoffee/airo/compare/airo-tv-v0.0.1...airo-tv-v0.0.2
 [Airo TV v0.0.1]: https://github.com/DevelopersCoffee/airo/releases/tag/airo-tv-v0.0.1

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ interactions in a real shipping app, not a demo.
 
 | Module | What it does | Status |
 |---|---|---|
-| 📺 **Airo TV** | Bring-your-own-playlist IPTV player for Android TV | **Available — [v0.0.3](https://github.com/DevelopersCoffee/airo/releases/tag/airo-tv-v0.0.3)** |
+| 📺 **Airo TV** | Bring-your-own-playlist IPTV player for Android TV | **Available — [v0.0.4](https://github.com/DevelopersCoffee/airo/releases/tag/airo-tv-v0.0.4)** |
 | ⭐ **Airo TV Pro** | Import intelligence, resilient playback, guide intelligence | In testing |
 | 🤖 **Airo AI** | On-device AI chat (Gemini Nano), model management, agent skills | In development |
 | 💰 **AiroMoney** | Personal finance tracking and money workflows | In development |
@@ -45,7 +45,7 @@ All modules live in one monorepo with strict package boundaries — see the
 
 ## 📺 Airo TV — Available Now
 
-[![Download Airo TV](https://img.shields.io/badge/Download-Airo%20TV%20APK-success?style=for-the-badge)](https://github.com/DevelopersCoffee/airo/releases/download/airo-tv-v0.0.3/Airo-TV-v0.0.3.apk)
+[![Download Airo TV](https://img.shields.io/badge/Download-Airo%20TV%20APK-success?style=for-the-badge)](https://github.com/DevelopersCoffee/airo/releases/download/airo-tv-v0.0.4/Airo-TV-0.0.4.apk)
 [![Live Showcase](https://img.shields.io/badge/▶-Live%20Showcase-blue?style=for-the-badge)](https://developerscoffee.github.io/airo/)
 
 ### See it in action
@@ -68,8 +68,8 @@ M3U/M3U8 playlists.
 
 | Platform | Link |
 |---|---|
-| 📺 Android TV | [Airo TV v0.0.3 APK](https://github.com/DevelopersCoffee/airo/releases/download/airo-tv-v0.0.3/Airo-TV-v0.0.3.apk) |
-| 🖥️ macOS (preview) | [Airo TV DMG](https://github.com/DevelopersCoffee/airo/releases/download/airo-tv-v0.0.3/Airo-TV-0.0.3-macOS.dmg) |
+| 📺 Android TV | [Airo TV v0.0.4 APK](https://github.com/DevelopersCoffee/airo/releases/download/airo-tv-v0.0.4/Airo-TV-0.0.4.apk) |
+| 🖥️ macOS (preview) | [Airo TV DMG](https://github.com/DevelopersCoffee/airo/releases/download/airo-tv-v0.0.4/Airo-TV-0.0.4-macOS.dmg) |
 | 🤖 Android | [Android releases](https://github.com/DevelopersCoffee/airo/releases) |
 | 🍎 iOS | [Latest IPA](https://github.com/DevelopersCoffee/airo/releases/latest/download/app-release.ipa) |
 | 🌐 Web | [Web build](https://github.com/DevelopersCoffee/airo/releases/latest/download/airo-web-release.zip) |

--- a/app/pubspec_tv.yaml
+++ b/app/pubspec_tv.yaml
@@ -11,7 +11,7 @@
 name: airo_app
 description: "Airo TV - IPTV streaming for Android TV"
 publish_to: 'none'
-version: 0.0.3-rc.4+4
+version: 0.0.4+4
 
 environment:
   sdk: ">=3.12.2 <4.0.0"

--- a/docs/airo-tv/guides/index.html
+++ b/docs/airo-tv/guides/index.html
@@ -1,222 +1,452 @@
 <!doctype html>
 <html lang="en">
-<head>
-  <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Airo TV device guides</title>
-  <meta name="description" content="Set up Airo TV on Android TV, Google TV, compatible Fire TV devices, Android mobile, Google Cast, and macOS preview builds.">
-  <meta name="theme-color" content="#071010">
-  <link rel="icon" type="image/svg+xml" href="../../assets/airo-tv/airo-icon.svg">
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=DM+Sans:opsz,wght@9..40,400;9..40,500;9..40,600;9..40,700;9..40,800&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="../../assets/airo-tv/site.css">
-  <script defer src="https://unpkg.com/lucide@0.468.0/dist/umd/lucide.min.js" integrity="sha384-uTYyvsSSUZeaPhb5RbKlQa0zY/WpX/QHfvg2mczXyBQOpkWPEDy9lczyp+w7SKXu" crossorigin="anonymous"></script>
-  <script defer src="../../assets/airo-tv/site.js"></script>
-</head>
-<body>
-  <a class="skip-link" href="#guide-content">Skip to guides</a>
-  <header class="site-header">
-    <div class="container nav-shell">
-      <a class="brand" href="../../tv/" aria-label="Airo TV home">
-        <img src="../../assets/airo-tv/airo-icon.svg" alt="">
-        <span>Airo TV <small>An Airo product</small></span>
-      </a>
-      <button class="menu-button" type="button" aria-label="Open navigation" aria-controls="guide-navigation" aria-expanded="false" data-menu-button><i data-lucide="menu" aria-hidden="true"></i></button>
-      <nav class="site-nav" id="guide-navigation" aria-label="Guide navigation" data-navigation>
-        <a href="#android-tv">Android TV</a>
-        <a href="#fire-tv">Fire TV</a>
-        <a href="#mobile">Mobile</a>
-        <a href="#cast">Cast</a>
-        <a href="#macos">macOS</a>
-        <a class="button button-primary" href="https://github.com/DevelopersCoffee/airo/releases"><i data-lucide="download" aria-hidden="true"></i> Download</a>
-      </nav>
-    </div>
-  </header>
-
-  <main id="guide-content">
-    <section class="guide-hero">
-      <div class="container">
-        <p class="eyebrow">Airo TV, an Airo product</p>
-        <h1>Choose the screen in front of you.</h1>
-        <p>Airo TV is a bring-your-own-content player. It does not include channels, playlists, subscriptions, or media. Use only sources you are authorized to access, and check the status label before following a device path.</p>
-        <nav class="guide-index" aria-label="Guide sections">
-          <a href="#playlist">Playlist basics</a>
-          <a href="#android-tv">Android TV / Google TV</a>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Airo TV device guides</title>
+    <meta
+      name="description"
+      content="Set up Airo TV on Android TV, Google TV, compatible Fire TV devices, Android mobile, Google Cast, and macOS preview builds."
+    />
+    <meta name="theme-color" content="#071010" />
+    <link
+      rel="icon"
+      type="image/svg+xml"
+      href="../../assets/airo-tv/airo-icon.svg"
+    />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=DM+Sans:opsz,wght@9..40,400;9..40,500;9..40,600;9..40,700;9..40,800&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="../../assets/airo-tv/site.css" />
+    <script
+      defer
+      src="https://unpkg.com/lucide@0.468.0/dist/umd/lucide.min.js"
+      integrity="sha384-uTYyvsSSUZeaPhb5RbKlQa0zY/WpX/QHfvg2mczXyBQOpkWPEDy9lczyp+w7SKXu"
+      crossorigin="anonymous"
+    ></script>
+    <script defer src="../../assets/airo-tv/site.js"></script>
+  </head>
+  <body>
+    <a class="skip-link" href="#guide-content">Skip to guides</a>
+    <header class="site-header">
+      <div class="container nav-shell">
+        <a class="brand" href="../../tv/" aria-label="Airo TV home">
+          <img src="../../assets/airo-tv/airo-icon.svg" alt="" />
+          <span>Airo TV <small>An Airo product</small></span>
+        </a>
+        <button
+          class="menu-button"
+          type="button"
+          aria-label="Open navigation"
+          aria-controls="guide-navigation"
+          aria-expanded="false"
+          data-menu-button
+        >
+          <i data-lucide="menu" aria-hidden="true"></i>
+        </button>
+        <nav
+          class="site-nav"
+          id="guide-navigation"
+          aria-label="Guide navigation"
+          data-navigation
+        >
+          <a href="#android-tv">Android TV</a>
           <a href="#fire-tv">Fire TV</a>
-          <a href="#mobile">Android mobile</a>
-          <a href="#cast">Google Cast</a>
-          <a href="#macos">macOS preview</a>
-          <a href="#troubleshooting">Troubleshooting</a>
+          <a href="#mobile">Mobile</a>
+          <a href="#cast">Cast</a>
+          <a href="#macos">macOS</a>
+          <a
+            class="button button-primary"
+            href="https://github.com/DevelopersCoffee/airo/releases"
+            ><i data-lucide="download" aria-hidden="true"></i> Download</a
+          >
         </nav>
       </div>
-    </section>
+    </header>
 
-    <div class="container">
-      <article class="tutorial" id="playlist">
-        <header>
-          <span class="status status-available">Available</span>
-          <h2>Playlist basics</h2>
-          <p class="tutorial-summary">The same starting point for every supported device.</p>
-        </header>
-        <div class="tutorial-content">
-          <h3>Before you start</h3>
-          <ul>
-            <li>Use an M3U or M3U8 URL supplied by a source you are authorized to access.</li>
-            <li>Keep private tokens and provider credentials out of screenshots and support posts.</li>
-            <li>Test with a small known-good playlist when diagnosing a large or unreliable source.</li>
-          </ul>
-          <h3>Add the source</h3>
-          <ol>
-            <li>Open Airo TV and choose the playlist or source action.</li>
-            <li>Enter the authorized playlist URL carefully.</li>
-            <li>Save the source and wait for channel loading to finish.</li>
-            <li>Open Live TV, then use Search if the playlist contains many channels.</li>
-            <li>Select a channel to test playback.</li>
-          </ol>
-          <div class="note">Airo TV cannot repair a provider outage, unsupported codec, expired token, or inaccessible stream. Try a second channel from the same source to separate a channel problem from a playlist problem.</div>
+    <main id="guide-content">
+      <section class="guide-hero">
+        <div class="container">
+          <p class="eyebrow">Airo TV, an Airo product</p>
+          <h1>Choose the screen in front of you.</h1>
+          <p>
+            Airo TV is a bring-your-own-content player. It does not include
+            channels, playlists, subscriptions, or media. Use only sources you
+            are authorized to access, and check the status label before
+            following a device path.
+          </p>
+          <nav class="guide-index" aria-label="Guide sections">
+            <a href="#playlist">Playlist basics</a>
+            <a href="#android-tv">Android TV / Google TV</a>
+            <a href="#fire-tv">Fire TV</a>
+            <a href="#mobile">Android mobile</a>
+            <a href="#cast">Google Cast</a>
+            <a href="#macos">macOS preview</a>
+            <a href="#troubleshooting">Troubleshooting</a>
+          </nav>
         </div>
-      </article>
+      </section>
 
-      <article class="tutorial" id="android-tv">
-        <header>
-          <span class="status status-available">Available</span>
-          <h2>Android TV and Google TV</h2>
-          <p class="tutorial-summary">The primary Airo TV living-room experience.</p>
-        </header>
-        <div class="tutorial-content">
-          <h3>Install and start</h3>
-          <ol>
-            <li>Open the <a href="https://github.com/DevelopersCoffee/airo/releases">latest release</a> on a trusted computer or device.</li>
-            <li>Choose the canonical APK unless your device requires a specific ABI build.</li>
-            <li>Install the APK through your approved device installation path.</li>
-            <li>Open Airo TV from the TV launcher.</li>
-            <li>Add your authorized playlist, browse channels, and test playback.</li>
-          </ol>
-          <h3>Remote controls</h3>
-          <ul>
-            <li>Use the D-pad to move focus and Select to activate the focused control.</li>
-            <li>Use Back to leave playback or return to the previous screen.</li>
-            <li>Use Search instead of scrolling an entire large playlist.</li>
-          </ul>
-          <div class="note">The release process checks 1920x1080, 1280x720, and compact 1024x576 layouts. A specific TV model still needs device qualification for decoder, focus, and performance behavior.</div>
-        </div>
-      </article>
+      <div class="container">
+        <article class="tutorial" id="playlist">
+          <header>
+            <span class="status status-available">Available</span>
+            <h2>Playlist basics</h2>
+            <p class="tutorial-summary">
+              The same starting point for every supported device.
+            </p>
+          </header>
+          <div class="tutorial-content">
+            <h3>Before you start</h3>
+            <ul>
+              <li>
+                Use an M3U or M3U8 URL supplied by a source you are authorized
+                to access.
+              </li>
+              <li>
+                Keep private tokens and provider credentials out of screenshots
+                and support posts.
+              </li>
+              <li>
+                Test with a small known-good playlist when diagnosing a large or
+                unreliable source.
+              </li>
+            </ul>
+            <h3>Add the source</h3>
+            <ol>
+              <li>Open Airo TV and choose the playlist or source action.</li>
+              <li>Enter the authorized playlist URL carefully.</li>
+              <li>Save the source and wait for channel loading to finish.</li>
+              <li>
+                Open Live TV, then use Search if the playlist contains many
+                channels.
+              </li>
+              <li>Select a channel to test playback.</li>
+            </ol>
+            <div class="note">
+              Airo TV cannot repair a provider outage, unsupported codec,
+              expired token, or inaccessible stream. Try a second channel from
+              the same source to separate a channel problem from a playlist
+              problem.
+            </div>
+          </div>
+        </article>
 
-      <article class="tutorial" id="fire-tv">
-        <header>
-          <span class="status status-qualifying">Experimental</span>
-          <h2>Fire TV and Fire TV Stick</h2>
-          <p class="tutorial-summary">Compatible APK path while dedicated qualification continues.</p>
-        </header>
-        <div class="tutorial-content">
-          <h3>Install safely</h3>
-          <ol>
-            <li>Download the Airo TV APK only from the official GitHub release.</li>
-            <li>If sideloading is required, enable installation only for the installer you are using.</li>
-            <li>Install the APK, then disable that sideload permission again.</li>
-            <li>Open Airo TV and test D-pad focus before adding a private playlist.</li>
-            <li>Add a small authorized playlist and verify browsing and playback.</li>
-          </ol>
-          <h3>Report a Fire TV problem</h3>
-          <p>Include the Fire TV model, Fire OS version, Airo TV release, screen name, and exact remote action. Never include playlist credentials.</p>
-          <div class="note">Fire TV remains compatible/experimental until dedicated install, remote-navigation, playback, and performance evidence is attached to a release.</div>
-        </div>
-      </article>
+        <article class="tutorial" id="android-tv">
+          <header>
+            <span class="status status-available">Available</span>
+            <h2>Android TV and Google TV</h2>
+            <p class="tutorial-summary">
+              The primary Airo TV living-room experience.
+            </p>
+          </header>
+          <div class="tutorial-content">
+            <h3>Install and start</h3>
+            <ol>
+              <li>
+                Open the
+                <a href="https://github.com/DevelopersCoffee/airo/releases"
+                  >latest release</a
+                >
+                on a trusted computer or device.
+              </li>
+              <li>
+                Choose the canonical APK unless your device requires a specific
+                ABI build.
+              </li>
+              <li>
+                Install the APK through your approved device installation path.
+              </li>
+              <li>Open Airo TV from the TV launcher.</li>
+              <li>
+                Add your authorized playlist, browse channels, and test
+                playback.
+              </li>
+            </ol>
+            <h3>Remote controls</h3>
+            <ul>
+              <li>
+                Use the D-pad to move focus and Select to activate the focused
+                control.
+              </li>
+              <li>
+                Use Back to leave playback or return to the previous screen.
+              </li>
+              <li>Use Search instead of scrolling an entire large playlist.</li>
+            </ul>
+            <div class="note">
+              The release process checks 1920x1080, 1280x720, and compact
+              1024x576 layouts. A specific TV model still needs device
+              qualification for decoder, focus, and performance behavior.
+            </div>
+          </div>
+        </article>
 
-      <article class="tutorial" id="mobile">
-        <header>
-          <span class="status status-qualifying">Partial</span>
-          <h2>Android phone and tablet</h2>
-          <p class="tutorial-summary">Separate modular profiles for mobile playback and Cast validation.</p>
-        </header>
-        <div class="tutorial-content">
-          <h3>Current guidance</h3>
-          <ol>
-            <li>Use only a release that explicitly includes an Android mobile or tablet profile.</li>
-            <li>Add the same authorized test playlist used on TV.</li>
-            <li>Validate search and playback in portrait and landscape where supported.</li>
-            <li>Use the Cast sender when both devices share a usable local network.</li>
-          </ol>
-          <p>Phone-to-TV pairing, synchronized favorites, and companion organization are planned in <a href="https://github.com/DevelopersCoffee/airo/issues/833">issue #833</a>. They are not guaranteed current behavior.</p>
-        </div>
-      </article>
+        <article class="tutorial" id="fire-tv">
+          <header>
+            <span class="status status-qualifying">Experimental</span>
+            <h2>Fire TV and Fire TV Stick</h2>
+            <p class="tutorial-summary">
+              Compatible APK path while dedicated qualification continues.
+            </p>
+          </header>
+          <div class="tutorial-content">
+            <h3>Install safely</h3>
+            <ol>
+              <li>
+                Download the Airo TV APK only from the official GitHub release.
+              </li>
+              <li>
+                If sideloading is required, enable installation only for the
+                installer you are using.
+              </li>
+              <li>
+                Install the APK, then disable that sideload permission again.
+              </li>
+              <li>
+                Open Airo TV and test D-pad focus before adding a private
+                playlist.
+              </li>
+              <li>
+                Add a small authorized playlist and verify browsing and
+                playback.
+              </li>
+            </ol>
+            <h3>Report a Fire TV problem</h3>
+            <p>
+              Include the Fire TV model, Fire OS version, Airo TV release,
+              screen name, and exact remote action. Never include playlist
+              credentials.
+            </p>
+            <div class="note">
+              Fire TV remains compatible/experimental until dedicated install,
+              remote-navigation, playback, and performance evidence is attached
+              to a release.
+            </div>
+          </div>
+        </article>
 
-      <article class="tutorial" id="cast">
-        <header>
-          <span class="status status-available">Supported path</span>
-          <h2>Chromecast and Google Cast</h2>
-          <p class="tutorial-summary">Local-network discovery and sender controls.</p>
-        </header>
-        <div class="tutorial-content">
-          <h3>Connect</h3>
-          <ol>
-            <li>Connect the sender and receiver to the same usable local network.</li>
-            <li>Open an Airo build that exposes Cast controls.</li>
-            <li>Open the Cast picker and choose the receiver.</li>
-            <li>Start a supported stream from your authorized playlist.</li>
-            <li>Use play, pause, stop, reload, new-session, and volume controls as available.</li>
-          </ol>
-          <h3>If the receiver is missing</h3>
-          <ul>
-            <li>Check guest Wi-Fi or client isolation.</li>
-            <li>Check whether a VPN blocks local discovery.</li>
-            <li>Confirm the receiver is awake and visible to another Cast sender.</li>
-            <li>Confirm local discovery traffic and receiver port reachability are allowed.</li>
-          </ul>
-        </div>
-      </article>
+        <article class="tutorial" id="mobile">
+          <header>
+            <span class="status status-qualifying">Partial</span>
+            <h2>Android phone and tablet</h2>
+            <p class="tutorial-summary">
+              Separate modular profiles for mobile playback and Cast validation.
+            </p>
+          </header>
+          <div class="tutorial-content">
+            <h3>Current guidance</h3>
+            <ol>
+              <li>
+                Use only a release that explicitly includes an Android mobile or
+                tablet profile.
+              </li>
+              <li>Add the same authorized test playlist used on TV.</li>
+              <li>
+                Validate search and playback in portrait and landscape where
+                supported.
+              </li>
+              <li>
+                Use the Cast sender when both devices share a usable local
+                network.
+              </li>
+            </ol>
+            <p>
+              Phone-to-TV pairing, synchronized favorites, and companion
+              organization are planned in
+              <a href="https://github.com/DevelopersCoffee/airo/issues/833"
+                >issue #833</a
+              >. They are not guaranteed current behavior.
+            </p>
+          </div>
+        </article>
 
-      <article class="tutorial" id="macos">
-        <header>
-          <span class="status status-qualifying">Preview</span>
-          <h2>macOS validation build</h2>
-          <p class="tutorial-summary">Unsigned and unnotarized artifacts in v0.0.3.</p>
-        </header>
-        <div class="tutorial-content">
-          <h3>Understand the limitation first</h3>
-          <p>The v0.0.3 release includes ZIP and DMG artifacts for direct validation. They are not a notarized public macOS distribution and may trigger normal macOS security warnings for unsigned software.</p>
-          <ol>
-            <li>Read the release notes and verify the downloaded file against SHA256SUMS.</li>
-            <li>Use the artifact only if you understand and accept its unsigned preview status.</li>
-            <li>Open Airo TV, add a non-sensitive authorized test playlist, and validate search and playback.</li>
-            <li>Report macOS version, device architecture, and the exact failure without sharing credentials.</li>
-          </ol>
-        </div>
-      </article>
+        <article class="tutorial" id="cast">
+          <header>
+            <span class="status status-available">Supported path</span>
+            <h2>Chromecast and Google Cast</h2>
+            <p class="tutorial-summary">
+              Local-network discovery and sender controls.
+            </p>
+          </header>
+          <div class="tutorial-content">
+            <h3>Connect</h3>
+            <ol>
+              <li>
+                Connect the sender and receiver to the same usable local
+                network.
+              </li>
+              <li>Open an Airo build that exposes Cast controls.</li>
+              <li>Open the Cast picker and choose the receiver.</li>
+              <li>Start a supported stream from your authorized playlist.</li>
+              <li>
+                Use play, pause, stop, reload, new-session, and volume controls
+                as available.
+              </li>
+            </ol>
+            <h3>If the receiver is missing</h3>
+            <ul>
+              <li>Check guest Wi-Fi or client isolation.</li>
+              <li>Check whether a VPN blocks local discovery.</li>
+              <li>
+                Confirm the receiver is awake and visible to another Cast
+                sender.
+              </li>
+              <li>
+                Confirm local discovery traffic and receiver port reachability
+                are allowed.
+              </li>
+            </ul>
+          </div>
+        </article>
 
-      <article class="tutorial" id="troubleshooting">
-        <header>
-          <span class="status status-available">All devices</span>
-          <h2>Troubleshooting</h2>
-          <p class="tutorial-summary">Identify whether the source, network, stream, decoder, or device is failing.</p>
-        </header>
-        <div class="tutorial-content">
-          <h3>No channels appear</h3>
-          <ul><li>Check the playlist URL and network.</li><li>Test the source with a small authorized fixture.</li><li>Confirm the build supports the source format.</li></ul>
-          <h3>A channel does not play</h3>
-          <ul><li>Try another channel from the same source.</li><li>Check whether the device supports the stream codec and container.</li><li>Record the local error or diagnostic state instead of only reporting a black screen.</li></ul>
-          <h3>The guide is empty</h3>
-          <ul><li>Confirm the build includes guide support.</li><li>Confirm XMLTV data exists and channel identifiers match.</li><li>Track the full guide and source-management work in <a href="https://github.com/DevelopersCoffee/airo/issues/825">issue #825</a>.</li></ul>
-          <h3>A large playlist feels slow</h3>
-          <ul><li>Use Search and recent-channel paths.</li><li>Compare with a smaller playlist.</li><li>Follow large-list hardening in <a href="https://github.com/DevelopersCoffee/airo/issues/814">issue #814</a>.</li></ul>
-          <h3>Get support</h3>
-          <p>Open a <a href="https://github.com/DevelopersCoffee/airo/issues/new">GitHub issue</a> with the device model, OS version, Airo TV release, screen, expected result, actual result, and reproduction steps. Remove all private playlist and account data.</p>
-        </div>
-      </article>
-    </div>
-  </main>
+        <article class="tutorial" id="macos">
+          <header>
+            <span class="status status-qualifying">Preview</span>
+            <h2>macOS validation build</h2>
+            <p class="tutorial-summary">
+              Unsigned and unnotarized artifacts in v0.0.4.
+            </p>
+          </header>
+          <div class="tutorial-content">
+            <h3>Understand the limitation first</h3>
+            <p>
+              The v0.0.4 release includes ZIP and DMG artifacts for direct
+              validation. They are not a notarized public macOS distribution and
+              may trigger normal macOS security warnings for unsigned software.
+            </p>
+            <ol>
+              <li>
+                Read the release notes and verify the downloaded file against
+                SHA256SUMS.
+              </li>
+              <li>
+                Use the artifact only if you understand and accept its unsigned
+                preview status.
+              </li>
+              <li>
+                Open Airo TV, add a non-sensitive authorized test playlist, and
+                validate search and playback.
+              </li>
+              <li>
+                Report macOS version, device architecture, and the exact failure
+                without sharing credentials.
+              </li>
+            </ol>
+          </div>
+        </article>
 
-  <footer class="site-footer">
-    <div class="container">
-      <div class="footer-grid">
-        <div><a class="brand" href="../../tv/"><img src="../../assets/airo-tv/airo-icon.svg" alt=""><span>Airo TV</span></a><h2>Your device, clearly explained.</h2><p>An Airo product. Guidance follows current release evidence and preserves experimental or deferred status.</p></div>
-        <div class="footer-col"><h3>Product</h3><a href="../../tv/#difference">Why Airo TV</a><a href="../../tv/#devices">Devices</a><a href="../../tv/#roadmap">Roadmap</a></div>
-        <div class="footer-col"><h3>Progress</h3><a href="https://github.com/DevelopersCoffee/airo/issues?q=state%3Aopen%20label%3Acommunity-voice">Community Voice</a><a href="https://github.com/DevelopersCoffee/airo/releases">Releases</a></div>
-        <div class="footer-col"><h3>Trust</h3><a href="../../legal/privacy-policy/">Privacy</a><a href="../../legal/terms-conditions/">Terms</a><a href="mailto:coffee.devloper@gmail.com">Support</a></div>
+        <article class="tutorial" id="troubleshooting">
+          <header>
+            <span class="status status-available">All devices</span>
+            <h2>Troubleshooting</h2>
+            <p class="tutorial-summary">
+              Identify whether the source, network, stream, decoder, or device
+              is failing.
+            </p>
+          </header>
+          <div class="tutorial-content">
+            <h3>No channels appear</h3>
+            <ul>
+              <li>Check the playlist URL and network.</li>
+              <li>Test the source with a small authorized fixture.</li>
+              <li>Confirm the build supports the source format.</li>
+            </ul>
+            <h3>A channel does not play</h3>
+            <ul>
+              <li>Try another channel from the same source.</li>
+              <li>
+                Check whether the device supports the stream codec and
+                container.
+              </li>
+              <li>
+                Record the local error or diagnostic state instead of only
+                reporting a black screen.
+              </li>
+            </ul>
+            <h3>The guide is empty</h3>
+            <ul>
+              <li>Confirm the build includes guide support.</li>
+              <li>Confirm XMLTV data exists and channel identifiers match.</li>
+              <li>
+                Track the full guide and source-management work in
+                <a href="https://github.com/DevelopersCoffee/airo/issues/825"
+                  >issue #825</a
+                >.
+              </li>
+            </ul>
+            <h3>A large playlist feels slow</h3>
+            <ul>
+              <li>Use Search and recent-channel paths.</li>
+              <li>Compare with a smaller playlist.</li>
+              <li>
+                Follow large-list hardening in
+                <a href="https://github.com/DevelopersCoffee/airo/issues/814"
+                  >issue #814</a
+                >.
+              </li>
+            </ul>
+            <h3>Get support</h3>
+            <p>
+              Open a
+              <a href="https://github.com/DevelopersCoffee/airo/issues/new"
+                >GitHub issue</a
+              >
+              with the device model, OS version, Airo TV release, screen,
+              expected result, actual result, and reproduction steps. Remove all
+              private playlist and account data.
+            </p>
+          </div>
+        </article>
       </div>
-      <div class="footer-bottom"><span>&copy; <span data-current-year>2026</span> DevelopersCoffee</span><span>No channels included. Use authorized sources only.</span></div>
-    </div>
-  </footer>
-</body>
+    </main>
+
+    <footer class="site-footer">
+      <div class="container">
+        <div class="footer-grid">
+          <div>
+            <a class="brand" href="../../tv/"
+              ><img src="../../assets/airo-tv/airo-icon.svg" alt="" /><span
+                >Airo TV</span
+              ></a
+            >
+            <h2>Your device, clearly explained.</h2>
+            <p>
+              An Airo product. Guidance follows current release evidence and
+              preserves experimental or deferred status.
+            </p>
+          </div>
+          <div class="footer-col">
+            <h3>Product</h3>
+            <a href="../../tv/#difference">Why Airo TV</a
+            ><a href="../../tv/#devices">Devices</a
+            ><a href="../../tv/#roadmap">Roadmap</a>
+          </div>
+          <div class="footer-col">
+            <h3>Progress</h3>
+            <a
+              href="https://github.com/DevelopersCoffee/airo/issues?q=state%3Aopen%20label%3Acommunity-voice"
+              >Community Voice</a
+            ><a href="https://github.com/DevelopersCoffee/airo/releases"
+              >Releases</a
+            >
+          </div>
+          <div class="footer-col">
+            <h3>Trust</h3>
+            <a href="../../legal/privacy-policy/">Privacy</a
+            ><a href="../../legal/terms-conditions/">Terms</a
+            ><a href="mailto:coffee.devloper@gmail.com">Support</a>
+          </div>
+        </div>
+        <div class="footer-bottom">
+          <span
+            >&copy; <span data-current-year>2026</span> DevelopersCoffee</span
+          ><span>No channels included. Use authorized sources only.</span>
+        </div>
+      </div>
+    </footer>
+  </body>
 </html>

--- a/docs/release/AIRO_TV_FEATURE_MATRIX.md
+++ b/docs/release/AIRO_TV_FEATURE_MATRIX.md
@@ -1,18 +1,22 @@
 # Airo TV Feature Matrix
 
-Current public release: [`airo-tv-v0.0.3`](https://github.com/DevelopersCoffee/airo/releases/tag/airo-tv-v0.0.3).
+Current public release: [`airo-tv-v0.0.4`](https://github.com/DevelopersCoffee/airo/releases/tag/airo-tv-v0.0.4).
 
 | Feature | Status | Notes |
 | --- | --- | --- |
 | M3U playlists | Supported | User supplies authorized playlist URLs. |
 | M3U8 streams | Supported | Playback depends on the stream URL and codec support on the device. |
-| Channel search | Supported | Search by channel name. |
+| Local channel and guide search | Supported | Deterministic search across user-imported channels and available XMLTV guide data; no cloud or LLM query is required. |
 | Android TV | Supported | Package `io.airo.app.tv`; Leanback launcher enabled. |
 | Pixel/mobile fallback | Supported | Used for smoke testing and responsive layout coverage. |
 | Chromecast controls | Supported | Discovery, play, pause, stop, reload, new session, volume. |
-| Favorites | Planned | Not included in v0.0.3. |
-| EPG | Planned | Not included in v0.0.3. |
+| Favorites | Supported | Mark/unmark channels from browse and player flows; stored locally. |
+| XMLTV guide | Supported | User-configured XMLTV sources only; no bundled guide feed. |
+| Smart playlists and canonical channels | Supported | Local filtering and canonical identity matching help preserve personal organization across imports. |
+| Provider add-flows | Supported | User-authorized Xtream, Stalker, Jellyfin, and M3U sources. |
+| Picture-in-picture | Under qualification | Video-only PiP layout is test-covered; device evidence is still being gathered. |
+| Phone-hosted TV streaming | Under qualification | Debug entry point and protocol tests exist; real phone-to-receiver dogfood is not yet complete. |
 | Recording | Not supported | No recording or DVR storage. |
-| AI Search | Planned | Not included in v0.0.3. |
+| AI Search | Planned | Local search is intentionally deterministic in this release. |
 | Cloud playlists | Not supported | Playlists stay local unless users load a remote URL directly. |
 | Bundled channels | Not supported | Airo TV does not provide IPTV content. |

--- a/docs/release/AIRO_TV_v0.0.4.md
+++ b/docs/release/AIRO_TV_v0.0.4.md
@@ -37,6 +37,10 @@ bundled media.
 - Airo TV does not provide playlists, channels, subscriptions, or media.
   Users must provide content they are authorized to access.
 - No accounts, cloud sync, recording/DVR, or bundled catalog are included.
+- The production Android signing and Firebase runtime secrets are not
+  configured in this repository. The release manifest records the resulting
+  non-production signing profile; an `ephemeral-ci-validation` artifact cannot
+  upgrade a previously installed build with a different certificate.
 - Phone-hosted media streaming and the real phone-to-receiver dogfood matrix
   remain under qualification.
 - Web is validation-only and iOS/iPadOS are not part of this TV release.

--- a/docs/release/AIRO_TV_v0.0.4.md
+++ b/docs/release/AIRO_TV_v0.0.4.md
@@ -1,0 +1,47 @@
+# Airo TV v0.0.4
+
+Airo TV v0.0.4 closes the user-visible IPTV loop while preserving the
+bring-your-own-content boundary. It adds local search, favorites, guide setup,
+provider add-flows, smarter personal lists, clearer playback diagnostics, and
+large-playlist import telemetry without adding accounts, cloud sync, DVR, or
+bundled media.
+
+## Highlights
+
+- Search imported channels and available XMLTV guide data locally, with
+  deterministic ranking and no remote query service.
+- Create locally filtered smart playlists and preserve favorites/history more
+  reliably through canonical channel identity matching.
+- Add authorized M3U, Xtream, Stalker, Jellyfin, and XMLTV sources from the
+  product flow.
+- Mark favorites from browse or player surfaces; open a real guide-source flow
+  when no guide data is available.
+- Diagnose unavailable playback without blaming the device, record watch
+  history only after playback starts, and show video-only Android PiP.
+- Import large playlists through the Rust/worker boundary with safe aggregate
+  parsed, skipped, malformed, and elapsed counters.
+
+## Distribution and verification
+
+- Android TV direct-install APK and Play Store AAB assets are published with
+  checksums and a release manifest for `io.airo.app.tv`.
+- macOS ZIP, DMG, and Homebrew Cask metadata are included as unsigned,
+  non-notarized release evidence.
+- This release records automated artifact verification. Android TV/Google TV
+  and Fire TV device qualification remain explicitly limited until the
+  corresponding real-device evidence is attached; Fire TV is
+  compatible/experimental rather than a general-support claim.
+
+## Known limitations
+
+- Airo TV does not provide playlists, channels, subscriptions, or media.
+  Users must provide content they are authorized to access.
+- No accounts, cloud sync, recording/DVR, or bundled catalog are included.
+- Phone-hosted media streaming and the real phone-to-receiver dogfood matrix
+  remain under qualification.
+- Web is validation-only and iOS/iPadOS are not part of this TV release.
+
+## Full changelog
+
+See the [repository changelog](../../CHANGELOG.md) and compare
+[`airo-tv-v0.0.3...airo-tv-v0.0.4`](https://github.com/DevelopersCoffee/airo/compare/airo-tv-v0.0.3...airo-tv-v0.0.4).

--- a/docs/tv/index.html
+++ b/docs/tv/index.html
@@ -1,58 +1,939 @@
 ---
 layout: null
 ---
+
 <!doctype html>
 <html lang="en">
-<head>
-  <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Airo TV | Your sources. Your screen.</title>
-  <meta name="description" content="Airo TV is a remote-first player for M3U and M3U8 media sources you are authorized to use.">
-  <meta name="theme-color" content="#071010">
-  <meta property="og:type" content="website">
-  <meta property="og:url" content="https://developerscoffee.github.io/airo/tv/">
-  <meta property="og:title" content="Airo TV | Your sources. Your screen.">
-  <meta property="og:description" content="Airo TV is a remote-first player for authorized media sources, built on Airo.">
-  <meta property="og:image" content="https://developerscoffee.github.io/airo/store-assets/airo-tv/feature-graphic-1024x500.png">
-  <link rel="icon" type="image/svg+xml" href="../assets/airo-tv/airo-icon.svg">
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=DM+Sans:opsz,wght@9..40,400;9..40,500;9..40,600;9..40,700;9..40,800&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="../assets/airo-tv/site.css">
-  <script defer src="https://unpkg.com/lucide@0.468.0/dist/umd/lucide.min.js" integrity="sha384-uTYyvsSSUZeaPhb5RbKlQa0zY/WpX/QHfvg2mczXyBQOpkWPEDy9lczyp+w7SKXu" crossorigin="anonymous"></script>
-  <script defer src="../assets/airo-tv/third-party/hls.js-1.6.16/hls.min.js"></script>
-  <script defer src="../assets/airo-tv/site.js"></script>
-</head>
-<body>
-  <a class="skip-link" href="#main-content">Skip to content</a>
-  <header class="site-header"><div class="container nav-shell"><a class="brand" href="../" aria-label="Airo platform home"><img src="../assets/airo-tv/airo-icon.svg" alt=""><span>Airo <small>TV</small></span></a><button class="menu-button" type="button" aria-label="Open navigation" aria-controls="site-navigation" aria-expanded="false" data-menu-button><i data-lucide="menu" aria-hidden="true"></i></button><nav class="site-nav" id="site-navigation" aria-label="Primary navigation" data-navigation><a href="#product">Product</a><a href="#browse">Browse</a><a href="#devices">Devices</a><a href="#guides">Guides</a><a href="#community">Community</a><a href="#roadmap">Roadmap</a><a class="button button-primary" href="https://github.com/DevelopersCoffee/airo/releases/tag/airo-tv-v0.0.3"><i data-lucide="download" aria-hidden="true"></i> Download</a></nav></div></header>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Airo TV | Your sources. Your screen.</title>
+    <meta
+      name="description"
+      content="Airo TV is a remote-first player for M3U and M3U8 media sources you are authorized to use."
+    />
+    <meta name="theme-color" content="#071010" />
+    <meta property="og:type" content="website" />
+    <meta
+      property="og:url"
+      content="https://developerscoffee.github.io/airo/tv/"
+    />
+    <meta property="og:title" content="Airo TV | Your sources. Your screen." />
+    <meta
+      property="og:description"
+      content="Airo TV is a remote-first player for authorized media sources, built on Airo."
+    />
+    <meta
+      property="og:image"
+      content="https://developerscoffee.github.io/airo/store-assets/airo-tv/feature-graphic-1024x500.png"
+    />
+    <link
+      rel="icon"
+      type="image/svg+xml"
+      href="../assets/airo-tv/airo-icon.svg"
+    />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=DM+Sans:opsz,wght@9..40,400;9..40,500;9..40,600;9..40,700;9..40,800&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="../assets/airo-tv/site.css" />
+    <script
+      defer
+      src="https://unpkg.com/lucide@0.468.0/dist/umd/lucide.min.js"
+      integrity="sha384-uTYyvsSSUZeaPhb5RbKlQa0zY/WpX/QHfvg2mczXyBQOpkWPEDy9lczyp+w7SKXu"
+      crossorigin="anonymous"
+    ></script>
+    <script
+      defer
+      src="../assets/airo-tv/third-party/hls.js-1.6.16/hls.min.js"
+    ></script>
+    <script defer src="../assets/airo-tv/site.js"></script>
+  </head>
+  <body>
+    <a class="skip-link" href="#main-content">Skip to content</a>
+    <header class="site-header">
+      <div class="container nav-shell">
+        <a class="brand" href="../" aria-label="Airo platform home"
+          ><img src="../assets/airo-tv/airo-icon.svg" alt="" /><span
+            >Airo <small>TV</small></span
+          ></a
+        ><button
+          class="menu-button"
+          type="button"
+          aria-label="Open navigation"
+          aria-controls="site-navigation"
+          aria-expanded="false"
+          data-menu-button
+        >
+          <i data-lucide="menu" aria-hidden="true"></i>
+        </button>
+        <nav
+          class="site-nav"
+          id="site-navigation"
+          aria-label="Primary navigation"
+          data-navigation
+        >
+          <a href="#product">Product</a><a href="#browse">Browse</a
+          ><a href="#devices">Devices</a><a href="#guides">Guides</a
+          ><a href="#community">Community</a><a href="#roadmap">Roadmap</a
+          ><a
+            class="button button-primary"
+            href="https://github.com/DevelopersCoffee/airo/releases/tag/airo-tv-v0.0.4"
+            ><i data-lucide="download" aria-hidden="true"></i> Download</a
+          >
+        </nav>
+      </div>
+    </header>
 
-  <main id="main-content">
-    <section class="hero hero-tv-board" id="top" aria-labelledby="hero-title" data-live-demo data-live-channel="Vevo Pop" data-live-retry-label="Try the muted preview again" data-live-autoplay-muted><div class="container"><div class="hero-content"><p class="eyebrow">Born from Airo <span class="status status-available">v0.0.3 available</span></p><h1 id="hero-title">Airo TV</h1><p class="hero-lede">Your sources. Your screen.</p><p class="hero-copy">A remote-first player for M3U and M3U8 media sources you are authorized to use. Airo TV includes no channels, playlists, subscriptions, or media catalog.</p><div class="hero-actions"><a class="button button-primary" href="https://github.com/DevelopersCoffee/airo/releases/tag/airo-tv-v0.0.3"><i data-lucide="download" aria-hidden="true"></i> Download Airo TV</a><a class="button button-secondary" href="#browse">Explore browsing <i data-lucide="arrow-down" aria-hidden="true"></i></a></div></div><div class="hero-preview-stage"><div class="hero-preview-board"><div class="hero-preview-board-head"><span>Airo TV</span><span>CH 01 · muted preview</span></div><div class="hero-preview-screen"><img class="hero-media" src="../store-assets/airo-tv/01-tv-home-channel-grid.png" alt="Airo TV browse screen using authorized demo data"><video class="hero-preview-video" controls muted playsinline preload="none" poster="../store-assets/airo-tv/01-tv-home-channel-grid.png" data-live-demo-video aria-label="Vevo Pop public live preview"></video><span class="hero-preview-scanlines" aria-hidden="true"></span></div><div class="hero-preview-board-foot"><span>Your sources. Your screen.</span><span>TV board edition</span></div></div></div><div class="hero-preview-controls"><details class="channel-showcase-details"><summary><i data-lucide="info" aria-hidden="true"></i> Third-party stream details</summary><p>Vevo Pop is a public HLS listing. When the muted preview starts, your browser connects directly to the operator, which may serve advertising, apply regional limits, or change availability. Airo does not host, proxy, cache, transcode, copy, or rebroadcast the channel.</p></details><div class="hero-preview-feedback"><button class="button button-secondary hero-preview-audio" type="button" aria-pressed="false" data-live-demo-audio hidden><i data-lucide="volume-x" aria-hidden="true"></i><span>Unmute</span></button><p class="live-demo-status hero-preview-status" role="status" aria-live="polite" data-live-demo-status data-state="ready">Muted preview starts when this hero is on screen.</p></div><div class="hero-preview-start" data-live-demo-start><button class="button button-secondary" type="button" data-live-demo-button data-live-source="https://d128y56w6v2kax.cloudfront.net/playlist/amg00056-vevotv-vevopopau-samsungau/playlist.m3u8"><i data-lucide="play" aria-hidden="true"></i> Start muted preview</button><span>Use this if autoplay is unavailable.</span></div></div><ul class="hero-status" aria-label="Airo TV release status"><li>Android TV release available</li><li>Fire TV compatible / experimental</li><li>macOS validation preview</li></ul></div></section>
+    <main id="main-content">
+      <section
+        class="hero hero-tv-board"
+        id="top"
+        aria-labelledby="hero-title"
+        data-live-demo
+        data-live-channel="Vevo Pop"
+        data-live-retry-label="Try the muted preview again"
+        data-live-autoplay-muted
+      >
+        <div class="container">
+          <div class="hero-content">
+            <p class="eyebrow">
+              Born from Airo
+              <span class="status status-available">v0.0.4 available</span>
+            </p>
+            <h1 id="hero-title">Airo TV</h1>
+            <p class="hero-lede">Your sources. Your screen.</p>
+            <p class="hero-copy">
+              A remote-first player for M3U and M3U8 media sources you are
+              authorized to use. Airo TV includes no channels, playlists,
+              subscriptions, or media catalog.
+            </p>
+            <div class="hero-actions">
+              <a
+                class="button button-primary"
+                href="https://github.com/DevelopersCoffee/airo/releases/tag/airo-tv-v0.0.4"
+                ><i data-lucide="download" aria-hidden="true"></i> Download Airo
+                TV</a
+              ><a class="button button-secondary" href="#browse"
+                >Explore browsing
+                <i data-lucide="arrow-down" aria-hidden="true"></i
+              ></a>
+            </div>
+          </div>
+          <div class="hero-preview-stage">
+            <div class="hero-preview-board">
+              <div class="hero-preview-board-head">
+                <span>Airo TV</span><span>CH 01 · muted preview</span>
+              </div>
+              <div class="hero-preview-screen">
+                <img
+                  class="hero-media"
+                  src="../store-assets/airo-tv/01-tv-home-channel-grid.png"
+                  alt="Airo TV browse screen using authorized demo data"
+                /><video
+                  class="hero-preview-video"
+                  controls
+                  muted
+                  playsinline
+                  preload="none"
+                  poster="../store-assets/airo-tv/01-tv-home-channel-grid.png"
+                  data-live-demo-video
+                  aria-label="Vevo Pop public live preview"
+                ></video
+                ><span class="hero-preview-scanlines" aria-hidden="true"></span>
+              </div>
+              <div class="hero-preview-board-foot">
+                <span>Your sources. Your screen.</span
+                ><span>TV board edition</span>
+              </div>
+            </div>
+          </div>
+          <div class="hero-preview-controls">
+            <details
+              class="channel-showcase-details"
+              aria-label="Third-party stream details"
+            >
+              <summary>
+                <i data-lucide="info" aria-hidden="true"></i> Third-party stream
+                details
+              </summary>
+              <p>
+                Vevo Pop is a public HLS listing. When the muted preview starts,
+                your browser connects directly to the operator, which may serve
+                advertising, apply regional limits, or change availability. Airo
+                does not host, proxy, cache, transcode, copy, or rebroadcast the
+                channel.
+              </p>
+            </details>
+            <div class="hero-preview-feedback">
+              <button
+                class="button button-secondary hero-preview-audio"
+                type="button"
+                aria-pressed="false"
+                data-live-demo-audio
+                hidden
+              >
+                <i data-lucide="volume-x" aria-hidden="true"></i
+                ><span>Unmute</span>
+              </button>
+              <p
+                class="live-demo-status hero-preview-status"
+                role="status"
+                aria-live="polite"
+                data-live-demo-status
+                data-state="ready"
+              >
+                Muted preview starts when this hero is on screen.
+              </p>
+            </div>
+            <div class="hero-preview-start" data-live-demo-start>
+              <button
+                class="button button-secondary"
+                type="button"
+                data-live-demo-button
+                aria-label="Start muted preview"
+                data-live-source="https://d128y56w6v2kax.cloudfront.net/playlist/amg00056-vevotv-vevopopau-samsungau/playlist.m3u8"
+              >
+                <i data-lucide="play" aria-hidden="true"></i> Start muted
+                preview</button
+              ><span>Use this if autoplay is unavailable.</span>
+            </div>
+          </div>
+          <ul class="hero-status" aria-label="Airo TV release status">
+            <li>Android TV release available</li>
+            <li>Fire TV compatible / experimental</li>
+            <li>macOS validation preview</li>
+          </ul>
+        </div>
+      </section>
 
-    <section class="proof-strip" id="product" aria-label="Available in Airo TV v0.0.3"><div class="container proof-grid"><div class="proof-item"><strong>M3U / M3U8</strong><span>Bring an authorized playlist or stream source.</span></div><div class="proof-item"><strong>Channel search</strong><span>Find a channel by name instead of endless scrolling.</span></div><div class="proof-item"><strong>TV-first</strong><span>Built for a remote-led living-room experience.</span></div><div class="proof-item"><strong>Cast controls</strong><span>Discovery and sender controls on a usable local network.</span></div></div></section>
+      <section
+        class="proof-strip"
+        id="product"
+        aria-label="Available in Airo TV v0.0.4"
+      >
+        <div class="container proof-grid">
+          <div class="proof-item">
+            <strong>M3U / M3U8</strong
+            ><span>Bring an authorized playlist or stream source.</span>
+          </div>
+          <div class="proof-item">
+            <strong>Channel search</strong
+            ><span>Find a channel by name instead of endless scrolling.</span>
+          </div>
+          <div class="proof-item">
+            <strong>TV-first</strong
+            ><span>Built for a remote-led living-room experience.</span>
+          </div>
+          <div class="proof-item">
+            <strong>Cast controls</strong
+            ><span
+              >Discovery and sender controls on a usable local network.</span
+            >
+          </div>
+        </div>
+      </section>
 
-    <section class="band" id="browse" aria-labelledby="browse-title"><div class="container"><div class="section-intro"><div><p class="eyebrow">Browse your way</p><h2 id="browse-title">Make your own playlist feel smaller.</h2></div><p>Start with the source you trust. Airo TV makes the direct path useful today, then develops local organisation and clearer playback answers in public—without turning your playlist into a catalogue.</p></div><div class="browse-ledger"><article class="browse-row"><span class="browse-icon"><i data-lucide="search" aria-hidden="true"></i></span><div><span class="status status-available">Available</span><h3>Search loaded channels</h3></div><p>Type a channel name and search the playlist already on your device instead of scrolling every row.</p><a class="text-link" href="../airo-tv/guides/#android-tv">Use search <i data-lucide="arrow-right" aria-hidden="true"></i></a></article><article class="browse-row"><span class="browse-icon"><i data-lucide="star" aria-hidden="true"></i></span><div><span class="status status-planned">Planned</span><h3>Keep favorites close</h3></div><p>Local favorites are the next shortcut for channels you return to. They are not included in v0.0.3.</p><a class="text-link" href="https://github.com/DevelopersCoffee/airo/issues/826">Follow progress <i data-lucide="arrow-up-right" aria-hidden="true"></i></a></article><article class="browse-row"><span class="browse-icon"><i data-lucide="bookmark" aria-hidden="true"></i></span><div><span class="status status-planned">Planned</span><h3>Return to a useful view</h3></div><p>Saved browse views and source-based filters need public release evidence before they become a product promise.</p><a class="text-link" href="#roadmap">See roadmap <i data-lucide="arrow-right" aria-hidden="true"></i></a></article><article class="browse-row"><span class="browse-icon"><i data-lucide="circle-alert" aria-hidden="true"></i></span><div><span class="status status-planned">Planned</span><h3>Understand a playback problem</h3></div><p>Diagnostics should distinguish a source, network, device, or decoder issue without pretending Airo TV can repair an unavailable stream.</p><a class="text-link" href="https://github.com/DevelopersCoffee/airo/issues/805">Follow progress <i data-lucide="arrow-up-right" aria-hidden="true"></i></a></article></div></div></section>
+      <section class="band" id="browse" aria-labelledby="browse-title">
+        <div class="container">
+          <div class="section-intro">
+            <div>
+              <p class="eyebrow">Browse your way</p>
+              <h2 id="browse-title">Make your own playlist feel smaller.</h2>
+            </div>
+            <p>
+              Start with the source you trust. Airo TV makes the direct path
+              useful today, then develops local organisation and clearer
+              playback answers in public—without turning your playlist into a
+              catalogue.
+            </p>
+          </div>
+          <div class="browse-ledger">
+            <article class="browse-row">
+              <span class="browse-icon"
+                ><i data-lucide="search" aria-hidden="true"></i
+              ></span>
+              <div>
+                <span class="status status-available">Available</span>
+                <h3>Search loaded channels</h3>
+              </div>
+              <p>
+                Type a channel name and search the playlist already on your
+                device instead of scrolling every row.
+              </p>
+              <a class="text-link" href="../airo-tv/guides/#android-tv"
+                >Use search <i data-lucide="arrow-right" aria-hidden="true"></i
+              ></a>
+            </article>
+            <article class="browse-row">
+              <span class="browse-icon"
+                ><i data-lucide="star" aria-hidden="true"></i
+              ></span>
+              <div>
+                <span class="status status-available">Available</span>
+                <h3>Keep favorites close</h3>
+              </div>
+              <p>
+                Mark or unmark a channel from browse and player surfaces; your
+                favorites remain local to the device.
+              </p>
+              <a class="text-link" href="../airo-tv/guides/#android-tv"
+                >Use favorites
+                <i data-lucide="arrow-right" aria-hidden="true"></i
+              ></a>
+            </article>
+            <article class="browse-row">
+              <span class="browse-icon"
+                ><i data-lucide="bookmark" aria-hidden="true"></i
+              ></span>
+              <div>
+                <span class="status status-available">Available</span>
+                <h3>Keep your view personal</h3>
+              </div>
+              <p>
+                Use smart-playlist rules and canonical channel matching to keep
+                your locally organized view useful after a re-import.
+              </p>
+              <a class="text-link" href="#roadmap"
+                >See roadmap <i data-lucide="arrow-right" aria-hidden="true"></i
+              ></a>
+            </article>
+            <article class="browse-row">
+              <span class="browse-icon"
+                ><i data-lucide="circle-alert" aria-hidden="true"></i
+              ></span>
+              <div>
+                <span class="status status-available">Available</span>
+                <h3>Understand a playback problem</h3>
+              </div>
+              <p>
+                Bounded retries and playback diagnostics explain an unavailable
+                source without pretending Airo TV can repair it.
+              </p>
+              <a class="text-link" href="../airo-tv/guides/#troubleshooting"
+                >Troubleshoot playback
+                <i data-lucide="arrow-right" aria-hidden="true"></i
+              ></a>
+            </article>
+          </div>
+        </div>
+      </section>
 
-    <section class="band" id="difference" aria-labelledby="difference-title"><div class="container"><div class="section-intro"><div><p class="eyebrow">Why Airo TV</p><h2 id="difference-title">A direct path from source to screen.</h2></div><p>Set up a source you are allowed to use, find what you want to watch, and play it on the screen in front of you. The product keeps its content boundary explicit instead of pretending to be a provider.</p></div><div class="difference-list"><article class="difference-row"><span class="difference-icon"><i data-lucide="shield-check" aria-hidden="true"></i></span><h3>Your source stays yours</h3><p>Airo TV does not sell, recommend, unlock, host, or bundle content.</p><span class="status status-available">Available</span></article><article class="difference-row"><span class="difference-icon"><i data-lucide="search" aria-hidden="true"></i></span><h3>Find channels faster</h3><p>Search a loaded playlist by channel name.</p><span class="status status-available">Available</span></article><article class="difference-row"><span class="difference-icon"><i data-lucide="tv" aria-hidden="true"></i></span><h3>Designed for the couch</h3><p>Android TV is the current release profile; device status remains visible rather than assumed.</p><span class="status status-available">Available</span></article><article class="difference-row"><span class="difference-icon"><i data-lucide="cast" aria-hidden="true"></i></span><h3>Clear Cast controls</h3><p>Discovery and control depend on receiver reachability and a usable local network.</p><span class="status status-available">Available</span></article></div></div></section>
+      <section class="band" id="difference" aria-labelledby="difference-title">
+        <div class="container">
+          <div class="section-intro">
+            <div>
+              <p class="eyebrow">Why Airo TV</p>
+              <h2 id="difference-title">
+                A direct path from source to screen.
+              </h2>
+            </div>
+            <p>
+              Set up a source you are allowed to use, find what you want to
+              watch, and play it on the screen in front of you. The product
+              keeps its content boundary explicit instead of pretending to be a
+              provider.
+            </p>
+          </div>
+          <div class="difference-list">
+            <article class="difference-row">
+              <span class="difference-icon"
+                ><i data-lucide="shield-check" aria-hidden="true"></i
+              ></span>
+              <h3>Your source stays yours</h3>
+              <p>
+                Airo TV does not sell, recommend, unlock, host, or bundle
+                content.
+              </p>
+              <span class="status status-available">Available</span>
+            </article>
+            <article class="difference-row">
+              <span class="difference-icon"
+                ><i data-lucide="search" aria-hidden="true"></i
+              ></span>
+              <h3>Find channels faster</h3>
+              <p>Search a loaded playlist by channel name.</p>
+              <span class="status status-available">Available</span>
+            </article>
+            <article class="difference-row">
+              <span class="difference-icon"
+                ><i data-lucide="tv" aria-hidden="true"></i
+              ></span>
+              <h3>Designed for the couch</h3>
+              <p>
+                Android TV is the current release profile; device status remains
+                visible rather than assumed.
+              </p>
+              <span class="status status-available">Available</span>
+            </article>
+            <article class="difference-row">
+              <span class="difference-icon"
+                ><i data-lucide="cast" aria-hidden="true"></i
+              ></span>
+              <h3>Clear Cast controls</h3>
+              <p>
+                Discovery and control depend on receiver reachability and a
+                usable local network.
+              </p>
+              <span class="status status-available">Available</span>
+            </article>
+          </div>
+        </div>
+      </section>
 
-    <section class="band band-alt" aria-labelledby="journey-title"><div class="container"><div class="section-intro"><div><p class="eyebrow">The product journey</p><h2 id="journey-title">Bring a source. Find a channel. Start watching.</h2></div><p>Every screen below uses sanitized Airo TV release artwork with neutral demo data. It illustrates the product journey, not a content catalog.</p></div><div class="screen-story"><article class="screen-step"><figure class="screen-shot"><img src="../store-assets/airo-tv/04-tv-playlist-source.png" alt="Airo TV playlist source setup using a neutral authorized demo URL"></figure><div class="screen-copy"><span class="step-number">01</span><h3>Bring your source</h3><p>Add an authorized M3U or M3U8 URL. The app does not provide a playlist for you.</p></div></article><article class="screen-step"><figure class="screen-shot"><img src="../store-assets/airo-tv/01-tv-home-channel-grid.png" alt="Airo TV browse screen with channel categories and visible remote focus"></figure><div class="screen-copy"><span class="step-number">02</span><h3>Browse from the couch</h3><p>TV-sized hierarchy and visible focus keep browsing readable at living-room distance.</p></div></article><article class="screen-step"><figure class="screen-shot"><img src="../store-assets/airo-tv/03-tv-search-dialog.png" alt="Airo TV channel search using neutral demo data"></figure><div class="screen-copy"><span class="step-number">03</span><h3>Search the playlist</h3><p>Find a channel by name instead of scrolling through every group.</p></div></article><article class="screen-step"><figure class="screen-shot"><img src="../store-assets/airo-tv/02-tv-now-playing.png" alt="Airo TV now-playing screen using authorized demo content"></figure><div class="screen-copy"><span class="step-number">04</span><h3>Play with clear controls</h3><p>Play supported streams and use Cast controls where the sender, receiver, and network support the connection.</p></div></article></div></div></section>
+      <section class="band band-alt" aria-labelledby="journey-title">
+        <div class="container">
+          <div class="section-intro">
+            <div>
+              <p class="eyebrow">The product journey</p>
+              <h2 id="journey-title">
+                Bring a source. Find a channel. Start watching.
+              </h2>
+            </div>
+            <p>
+              Every screen below uses sanitized Airo TV release artwork with
+              neutral demo data. It illustrates the product journey, not a
+              content catalog.
+            </p>
+          </div>
+          <div class="screen-story">
+            <article class="screen-step">
+              <figure class="screen-shot">
+                <img
+                  src="../store-assets/airo-tv/04-tv-playlist-source.png"
+                  alt="Airo TV playlist source setup using a neutral authorized demo URL"
+                />
+              </figure>
+              <div class="screen-copy">
+                <span class="step-number">01</span>
+                <h3>Bring your source</h3>
+                <p>
+                  Add an authorized M3U or M3U8 URL. The app does not provide a
+                  playlist for you.
+                </p>
+              </div>
+            </article>
+            <article class="screen-step">
+              <figure class="screen-shot">
+                <img
+                  src="../store-assets/airo-tv/01-tv-home-channel-grid.png"
+                  alt="Airo TV browse screen with channel categories and visible remote focus"
+                />
+              </figure>
+              <div class="screen-copy">
+                <span class="step-number">02</span>
+                <h3>Browse from the couch</h3>
+                <p>
+                  TV-sized hierarchy and visible focus keep browsing readable at
+                  living-room distance.
+                </p>
+              </div>
+            </article>
+            <article class="screen-step">
+              <figure class="screen-shot">
+                <img
+                  src="../store-assets/airo-tv/03-tv-search-dialog.png"
+                  alt="Airo TV channel search using neutral demo data"
+                />
+              </figure>
+              <div class="screen-copy">
+                <span class="step-number">03</span>
+                <h3>Search the playlist</h3>
+                <p>
+                  Find a channel by name instead of scrolling through every
+                  group.
+                </p>
+              </div>
+            </article>
+            <article class="screen-step">
+              <figure class="screen-shot">
+                <img
+                  src="../store-assets/airo-tv/02-tv-now-playing.png"
+                  alt="Airo TV now-playing screen using authorized demo content"
+                />
+              </figure>
+              <div class="screen-copy">
+                <span class="step-number">04</span>
+                <h3>Play with clear controls</h3>
+                <p>
+                  Play supported streams and use Cast controls where the sender,
+                  receiver, and network support the connection.
+                </p>
+              </div>
+            </article>
+          </div>
+        </div>
+      </section>
 
-    <section class="band" id="devices" aria-labelledby="devices-title"><div class="container"><div class="section-intro"><div><p class="eyebrow">Device support</p><h2 id="devices-title">One product. Honest support levels.</h2></div><p>Availability is tied to the published v0.0.3 release and its known limitations. The status is part of the product—not fine print.</p></div><div class="device-list"><article class="device-row"><h3>Android TV / Google TV</h3><p>Direct-install release APKs and a Play Store AAB are published for the TV profile.</p><span class="status status-available">Available</span><a class="text-link" href="../airo-tv/guides/#android-tv">Setup guide</a></article><article class="device-row"><h3>Fire TV</h3><p>Compatible APK path; dedicated qualification remains required.</p><span class="status status-qualifying">Experimental</span><a class="text-link" href="../airo-tv/guides/#fire-tv">Setup guide</a></article><article class="device-row"><h3>Chromecast / Google Cast</h3><p>Controls depend on local network discovery and receiver reachability.</p><span class="status status-available">Supported path</span><a class="text-link" href="../airo-tv/guides/#cast">Cast guide</a></article><article class="device-row"><h3>macOS</h3><p>ZIP and DMG artifacts are unsigned and not notarized; use them as validation/direct-download evidence.</p><span class="status status-qualifying">Preview</span><a class="text-link" href="../airo-tv/guides/#macos">Install guide</a></article><article class="device-row"><h3>iPhone / iPad</h3><p>Deferred for the current v2 release wave.</p><span class="status status-planned">Deferred</span><a class="text-link" href="../airo-tv/guides/#mobile">Status guide</a></article><article class="device-row"><h3>Web</h3><p>Browser use is validation-only, not a public Airo TV release artifact.</p><span class="status status-planned">Validation only</span><a class="text-link" href="../airo-tv/guides/#troubleshooting">Learn more</a></article></div></div></section>
+      <section class="band" id="devices" aria-labelledby="devices-title">
+        <div class="container">
+          <div class="section-intro">
+            <div>
+              <p class="eyebrow">Device support</p>
+              <h2 id="devices-title">One product. Honest support levels.</h2>
+            </div>
+            <p>
+              Availability is tied to the published v0.0.4 release and its known
+              limitations. The status is part of the product—not fine print.
+            </p>
+          </div>
+          <div class="device-list">
+            <article class="device-row">
+              <h3>Android TV / Google TV</h3>
+              <p>
+                Direct-install release APKs and a Play Store AAB are published
+                for the TV profile.
+              </p>
+              <span class="status status-available">Available</span
+              ><a class="text-link" href="../airo-tv/guides/#android-tv"
+                >Setup guide</a
+              >
+            </article>
+            <article class="device-row">
+              <h3>Fire TV</h3>
+              <p>
+                Compatible APK path; dedicated qualification remains required.
+              </p>
+              <span class="status status-qualifying">Experimental</span
+              ><a class="text-link" href="../airo-tv/guides/#fire-tv"
+                >Setup guide</a
+              >
+            </article>
+            <article class="device-row">
+              <h3>Chromecast / Google Cast</h3>
+              <p>
+                Controls depend on local network discovery and receiver
+                reachability.
+              </p>
+              <span class="status status-available">Supported path</span
+              ><a class="text-link" href="../airo-tv/guides/#cast"
+                >Cast guide</a
+              >
+            </article>
+            <article class="device-row">
+              <h3>macOS</h3>
+              <p>
+                ZIP and DMG artifacts are unsigned and not notarized; use them
+                as validation/direct-download evidence.
+              </p>
+              <span class="status status-qualifying">Preview</span
+              ><a class="text-link" href="../airo-tv/guides/#macos"
+                >Install guide</a
+              >
+            </article>
+            <article class="device-row">
+              <h3>iPhone / iPad</h3>
+              <p>Deferred for the current v2 release wave.</p>
+              <span class="status status-planned">Deferred</span
+              ><a class="text-link" href="../airo-tv/guides/#mobile"
+                >Status guide</a
+              >
+            </article>
+            <article class="device-row">
+              <h3>Web</h3>
+              <p>
+                Browser use is validation-only, not a public Airo TV release
+                artifact.
+              </p>
+              <span class="status status-planned">Validation only</span
+              ><a class="text-link" href="../airo-tv/guides/#troubleshooting"
+                >Learn more</a
+              >
+            </article>
+          </div>
+        </div>
+      </section>
 
-    <section class="band band-alt" id="capability-matrix" aria-labelledby="capability-title"><div class="container"><div class="section-intro"><div><p class="eyebrow">Capability matrix</p><h2 id="capability-title">What is available today—and what is not.</h2></div><p>Airo TV v0.0.3 is intentionally focused. Planned work is visible, but it is not presented as a download-time promise.</p></div><div class="capability-grid"><article class="capability-item"><span class="status status-available">Available</span><h3>Playlist playback</h3><p>User-supplied M3U playlists and M3U8 streams, subject to source and device codec support.</p></article><article class="capability-item"><span class="status status-available">Available</span><h3>Channel search</h3><p>Search loaded channels by name.</p></article><article class="capability-item"><span class="status status-planned">Planned</span><h3>Favorites</h3><p>Local favorites are not included in v0.0.3.</p></article><article class="capability-item"><span class="status status-planned">Planned</span><h3>Saved browse views</h3><p>Persistent shortcuts and source-based filters are not included in v0.0.3.</p></article><article class="capability-item"><span class="status status-planned">Planned</span><h3>EPG and playback diagnostics</h3><p>Guide intelligence and clearer playback explanations need release evidence.</p></article><article class="capability-item"><span class="status status-planned">Not supported</span><h3>Recording and cloud playlists</h3><p>Airo TV does not record and does not run cloud playlist storage.</p></article></div></div></section>
+      <section
+        class="band band-alt"
+        id="capability-matrix"
+        aria-labelledby="capability-title"
+      >
+        <div class="container">
+          <div class="section-intro">
+            <div>
+              <p class="eyebrow">Capability matrix</p>
+              <h2 id="capability-title">
+                What is available today—and what is not.
+              </h2>
+            </div>
+            <p>
+              Airo TV v0.0.4 adds local organization, guide setup, and clearer
+              playback answers without turning the player into a content
+              service.
+            </p>
+          </div>
+          <div class="capability-grid">
+            <article class="capability-item">
+              <span class="status status-available">Available</span>
+              <h3>Playlist playback</h3>
+              <p>
+                User-supplied M3U playlists and M3U8 streams, subject to source
+                and device codec support.
+              </p>
+            </article>
+            <article class="capability-item">
+              <span class="status status-available">Available</span>
+              <h3>Channel search</h3>
+              <p>Search loaded channels by name.</p>
+            </article>
+            <article class="capability-item">
+              <span class="status status-available">Available</span>
+              <h3>Favorites</h3>
+              <p>
+                Mark channels as favorites locally from browse and player flows.
+              </p>
+            </article>
+            <article class="capability-item">
+              <span class="status status-available">Available</span>
+              <h3>Smart playlists</h3>
+              <p>
+                Local rules and canonical channel matching help preserve a
+                personal view across source refreshes.
+              </p>
+            </article>
+            <article class="capability-item">
+              <span class="status status-available">Available</span>
+              <h3>XMLTV guide and playback diagnostics</h3>
+              <p>
+                Add an authorized XMLTV source and receive bounded, clearer
+                playback-recovery states.
+              </p>
+            </article>
+            <article class="capability-item">
+              <span class="status status-planned">Not supported</span>
+              <h3>Recording and cloud playlists</h3>
+              <p>
+                Airo TV does not record and does not run cloud playlist storage.
+              </p>
+            </article>
+          </div>
+        </div>
+      </section>
 
-    <section class="band" id="guides" aria-labelledby="guides-title"><div class="container"><div class="section-intro"><div><p class="eyebrow">Guides</p><h2 id="guides-title">Set it up once. Know what your device supports.</h2></div><p>Start with the short guide hub, then use the device-specific steps and troubleshooting path when you need them.</p></div><div class="guide-list"><a class="guide-item" href="./guides/#android-tv"><i data-lucide="tv" aria-hidden="true"></i><h3>Set up Android TV or Google TV</h3><p>Install, add an authorized source, browse, search, and play.</p><i data-lucide="arrow-right" aria-hidden="true"></i></a><a class="guide-item" href="./guides/#fire-tv"><i data-lucide="flame" aria-hidden="true"></i><h3>Install on Fire TV</h3><p>Use the compatible APK safely and understand experimental status.</p><i data-lucide="arrow-right" aria-hidden="true"></i></a><a class="guide-item" href="./guides/#cast"><i data-lucide="cast" aria-hidden="true"></i><h3>Connect with Google Cast</h3><p>Check the network, receiver, VPN, and discovery path.</p><i data-lucide="arrow-right" aria-hidden="true"></i></a><a class="guide-item" href="./guides/#troubleshooting"><i data-lucide="wrench" aria-hidden="true"></i><h3>Troubleshoot sources and playback</h3><p>Separate source, network, decoder, guide, and device problems.</p><i data-lucide="arrow-right" aria-hidden="true"></i></a></div></div></section>
+      <section class="band" id="guides" aria-labelledby="guides-title">
+        <div class="container">
+          <div class="section-intro">
+            <div>
+              <p class="eyebrow">Guides</p>
+              <h2 id="guides-title">
+                Set it up once. Know what your device supports.
+              </h2>
+            </div>
+            <p>
+              Start with the short guide hub, then use the device-specific steps
+              and troubleshooting path when you need them.
+            </p>
+          </div>
+          <div class="guide-list">
+            <a class="guide-item" href="./guides/#android-tv"
+              ><i data-lucide="tv" aria-hidden="true"></i>
+              <h3>Set up Android TV or Google TV</h3>
+              <p>
+                Install, add an authorized source, browse, search, and play.
+              </p>
+              <i data-lucide="arrow-right" aria-hidden="true"></i></a
+            ><a class="guide-item" href="./guides/#fire-tv"
+              ><i data-lucide="flame" aria-hidden="true"></i>
+              <h3>Install on Fire TV</h3>
+              <p>
+                Use the compatible APK safely and understand experimental
+                status.
+              </p>
+              <i data-lucide="arrow-right" aria-hidden="true"></i></a
+            ><a class="guide-item" href="./guides/#cast"
+              ><i data-lucide="cast" aria-hidden="true"></i>
+              <h3>Connect with Google Cast</h3>
+              <p>Check the network, receiver, VPN, and discovery path.</p>
+              <i data-lucide="arrow-right" aria-hidden="true"></i></a
+            ><a class="guide-item" href="./guides/#troubleshooting"
+              ><i data-lucide="wrench" aria-hidden="true"></i>
+              <h3>Troubleshoot sources and playback</h3>
+              <p>
+                Separate source, network, decoder, guide, and device problems.
+              </p>
+              <i data-lucide="arrow-right" aria-hidden="true"></i
+            ></a>
+          </div>
+        </div>
+      </section>
 
-    <section class="band band-alt" id="community" aria-labelledby="community-title"><div class="container"><div class="community-header"><div><p class="eyebrow">Community Voice</p><h2 id="community-title">Built from viewer problems, not a copied feature checklist.</h2></div><a class="button button-secondary" href="https://github.com/DevelopersCoffee/airo/issues?q=state%3Aopen%20label%3Acommunity-voice"><i data-lucide="messages-square" aria-hidden="true"></i> View Community Voice</a></div><div class="community-grid"><article class="community-item"><span class="status status-planned">Planned</span><h3>Large lists without frozen screens</h3><p>Worker processing and virtualized browsing for real-world playlist sizes.</p><a class="text-link" href="https://github.com/DevelopersCoffee/airo/issues/814">Issue #814</a></article><article class="community-item"><span class="status status-planned">Planned</span><h3>A guide that remains useful</h3><p>Useful programme-guide states, timelines, and clear missing-data behaviour.</p><a class="text-link" href="https://github.com/DevelopersCoffee/airo/issues/825">Issue #825</a></article><article class="community-item"><span class="status status-planned">Planned</span><h3>More source choices, same boundary</h3><p>Additional adapters without turning Airo TV into a content provider.</p><a class="text-link" href="https://github.com/DevelopersCoffee/airo/issues/823">Issue #823</a></article><article class="community-item"><span class="status status-planned">Planned</span><h3>Playback that explains failure</h3><p>Clear diagnostics and bounded recovery rather than a blank screen.</p><a class="text-link" href="https://github.com/DevelopersCoffee/airo/issues/805">Issue #805</a></article></div></div></section>
+      <section
+        class="band band-alt"
+        id="community"
+        aria-labelledby="community-title"
+      >
+        <div class="container">
+          <div class="community-header">
+            <div>
+              <p class="eyebrow">Community Voice</p>
+              <h2 id="community-title">
+                Built from viewer problems, not a copied feature checklist.
+              </h2>
+            </div>
+            <a
+              class="button button-secondary"
+              href="https://github.com/DevelopersCoffee/airo/issues?q=state%3Aopen%20label%3Acommunity-voice"
+              ><i data-lucide="messages-square" aria-hidden="true"></i> View
+              Community Voice</a
+            >
+          </div>
+          <div class="community-grid">
+            <article class="community-item">
+              <span class="status status-available">Available</span>
+              <h3>Large lists without frozen screens</h3>
+              <p>
+                Worker processing and virtualized browsing for real-world
+                playlist sizes.
+              </p>
+              <a
+                class="text-link"
+                href="https://github.com/DevelopersCoffee/airo/issues/814"
+                >Implementation evidence</a
+              >
+            </article>
+            <article class="community-item">
+              <span class="status status-available">Available</span>
+              <h3>A guide that remains useful</h3>
+              <p>
+                Useful programme-guide states, timelines, and clear missing-data
+                behaviour.
+              </p>
+              <a
+                class="text-link"
+                href="https://github.com/DevelopersCoffee/airo/issues/825"
+                >Issue #825</a
+              >
+            </article>
+            <article class="community-item">
+              <span class="status status-available">Available</span>
+              <h3>More source choices, same boundary</h3>
+              <p>
+                Additional adapters without turning Airo TV into a content
+                provider.
+              </p>
+              <a
+                class="text-link"
+                href="https://github.com/DevelopersCoffee/airo/issues/823"
+                >Issue #823</a
+              >
+            </article>
+            <article class="community-item">
+              <span class="status status-available">Available</span>
+              <h3>Playback that explains failure</h3>
+              <p>
+                Clear diagnostics and bounded recovery rather than a blank
+                screen.
+              </p>
+              <a
+                class="text-link"
+                href="https://github.com/DevelopersCoffee/airo/issues/805"
+                >Issue #805</a
+              >
+            </article>
+          </div>
+        </div>
+      </section>
 
-    <section class="band" id="pro-vision" aria-labelledby="pro-title"><div class="container pro-shell"><div><span class="status status-private">In testing</span><h2 id="pro-title">Airo TV Pro adds an intelligence layer.</h2><p>Advanced TV capabilities are being tested under the Airo TV Pro name. They are not included in the public Airo TV release and carry no delivery promise until public evidence is published.</p></div><div class="pro-list"><article class="pro-item"><h3>Cleaner imports</h3><p>Explore more useful source cleanup and organization.</p></article><article class="pro-item"><h3>More resilient playback</h3><p>Explore health-informed source handling and bounded recovery outcomes.</p></article><article class="pro-item"><h3>Richer guide context</h3><p>Explore guide and reminder outcomes behind explicit release boundaries.</p></article></div></div></section>
+      <section class="band" id="pro-vision" aria-labelledby="pro-title">
+        <div class="container pro-shell">
+          <div>
+            <span class="status status-private">In testing</span>
+            <h2 id="pro-title">Airo TV Pro adds an intelligence layer.</h2>
+            <p>
+              Advanced TV capabilities are being tested under the Airo TV Pro
+              name. They are not included in the public Airo TV release and
+              carry no delivery promise until public evidence is published.
+            </p>
+          </div>
+          <div class="pro-list">
+            <article class="pro-item">
+              <h3>Cleaner imports</h3>
+              <p>Explore more useful source cleanup and organization.</p>
+            </article>
+            <article class="pro-item">
+              <h3>More resilient playback</h3>
+              <p>
+                Explore health-informed source handling and bounded recovery
+                outcomes.
+              </p>
+            </article>
+            <article class="pro-item">
+              <h3>Richer guide context</h3>
+              <p>
+                Explore guide and reminder outcomes behind explicit release
+                boundaries.
+              </p>
+            </article>
+          </div>
+        </div>
+      </section>
 
-    <section class="band band-alt" id="roadmap" aria-labelledby="roadmap-title"><div class="container"><div class="section-intro"><div><p class="eyebrow">The path forward</p><h2 id="roadmap-title">Useful today. Building with evidence.</h2></div><p>The public roadmap makes current release work, qualification, and future direction visible without hiding their different states.</p></div><div class="roadmap"><article class="roadmap-stage"><span class="status status-available">Available</span><h3>Airo TV v0.0.3</h3><p>The current focused player release with M3U/M3U8 sources, search, Android TV artifacts, and Cast controls.</p><a class="text-link" href="https://github.com/DevelopersCoffee/airo/releases/tag/airo-tv-v0.0.3">Release notes <i data-lucide="arrow-up-right" aria-hidden="true"></i></a></article><article class="roadmap-stage"><span class="status status-planned">Building in public</span><h3>Browse and organize</h3><p>Favorites, saved browse views, guide intelligence, and local organization—without cloud playlist storage or a bundled catalogue.</p><a class="text-link" href="https://github.com/DevelopersCoffee/airo/milestone/5">View milestone <i data-lucide="arrow-up-right" aria-hidden="true"></i></a></article><article class="roadmap-stage"><span class="status status-qualifying">Foundation</span><h3>Performance platform</h3><p>Native parsing, indexing, storage, networking, and measured device budgets.</p><a class="text-link" href="https://github.com/DevelopersCoffee/airo/milestone/6">View milestone <i data-lucide="arrow-up-right" aria-hidden="true"></i></a></article><article class="roadmap-stage"><span class="status status-private">In testing</span><h3>Airo TV Pro</h3><p>Advanced outcomes remain under explicit disclosure and release gates.</p></article></div></div></section>
+      <section
+        class="band band-alt"
+        id="roadmap"
+        aria-labelledby="roadmap-title"
+      >
+        <div class="container">
+          <div class="section-intro">
+            <div>
+              <p class="eyebrow">The path forward</p>
+              <h2 id="roadmap-title">Useful today. Building with evidence.</h2>
+            </div>
+            <p>
+              The public roadmap makes current release work, qualification, and
+              future direction visible without hiding their different states.
+            </p>
+          </div>
+          <div class="roadmap">
+            <article class="roadmap-stage">
+              <span class="status status-available">Available</span>
+              <h3>Airo TV v0.0.4</h3>
+              <p>
+                The current focused player release with local search, favorites,
+                XMLTV setup, smarter playlist organization, and Android TV
+                artifacts.
+              </p>
+              <a
+                class="text-link"
+                href="https://github.com/DevelopersCoffee/airo/releases/tag/airo-tv-v0.0.4"
+                >Release notes
+                <i data-lucide="arrow-up-right" aria-hidden="true"></i
+              ></a>
+            </article>
+            <article class="roadmap-stage">
+              <span class="status status-qualifying">Planned</span>
+              <h3>Saved browse views</h3>
+              <p>
+                Saving a reusable browse view remains planned product work; it
+                is not an available Airo TV v0.0.4 feature.
+              </p>
+              <a
+                class="text-link"
+                href="https://github.com/DevelopersCoffee/airo/milestone/5"
+                >View product milestone
+                <i data-lucide="arrow-up-right" aria-hidden="true"></i
+              ></a>
+            </article>
+            <article class="roadmap-stage">
+              <span class="status status-qualifying">Under qualification</span>
+              <h3>Connected-device streaming</h3>
+              <p>
+                Phone-hosted media streaming remains under real-device receiver
+                qualification; it is not a general availability promise yet.
+              </p>
+              <a
+                class="text-link"
+                href="https://github.com/DevelopersCoffee/airo/issues/889"
+                >Track qualification
+                <i data-lucide="arrow-up-right" aria-hidden="true"></i
+              ></a>
+            </article>
+            <article class="roadmap-stage">
+              <span class="status status-qualifying">Foundation</span>
+              <h3>Performance platform</h3>
+              <p>
+                Native parsing, indexing, storage, networking, and measured
+                device budgets.
+              </p>
+              <a
+                class="text-link"
+                href="https://github.com/DevelopersCoffee/airo/milestone/6"
+                >View milestone
+                <i data-lucide="arrow-up-right" aria-hidden="true"></i
+              ></a>
+            </article>
+            <article class="roadmap-stage">
+              <span class="status status-private">In testing</span>
+              <h3>Airo TV Pro</h3>
+              <p>
+                Advanced outcomes remain under explicit disclosure and release
+                gates.
+              </p>
+            </article>
+          </div>
+        </div>
+      </section>
 
-    <section class="band" id="trust" aria-labelledby="trust-title"><div class="container trust-grid"><div><p class="eyebrow">Trust before features</p><h2 id="trust-title">Your sources. Clear boundaries. Public evidence.</h2><p>Airo TV is a player for playlists and streams you are authorized to access. It does not provide, host, sell, endorse, verify, or distribute television channels, playlists, subscriptions, or media catalogs.</p><p>Local-first means local where the product can be local. Remote sources and Cast still use a network, and the guide explains that boundary clearly.</p></div><div class="trust-links"><a href="./guides/">Airo TV guides <i data-lucide="arrow-right" aria-hidden="true"></i></a><a href="../legal/privacy-policy/">Privacy policy <i data-lucide="arrow-right" aria-hidden="true"></i></a><a href="https://github.com/DevelopersCoffee/airo/releases/tag/airo-tv-v0.0.3">Release checksums <i data-lucide="arrow-up-right" aria-hidden="true"></i></a><a href="https://github.com/DevelopersCoffee/airo">Source repository <i data-lucide="arrow-up-right" aria-hidden="true"></i></a></div></div></section>
-  </main>
+      <section class="band" id="trust" aria-labelledby="trust-title">
+        <div class="container trust-grid">
+          <div>
+            <p class="eyebrow">Trust before features</p>
+            <h2 id="trust-title">
+              Your sources. Clear boundaries. Public evidence.
+            </h2>
+            <p>
+              Airo TV is a player for playlists and streams you are authorized
+              to access. It does not provide, host, sell, endorse, verify, or
+              distribute television channels, playlists, subscriptions, or media
+              catalogs.
+            </p>
+            <p>
+              Local-first means local where the product can be local. Remote
+              sources and Cast still use a network, and the guide explains that
+              boundary clearly.
+            </p>
+          </div>
+          <div class="trust-links">
+            <a href="./guides/"
+              >Airo TV guides
+              <i data-lucide="arrow-right" aria-hidden="true"></i></a
+            ><a href="../legal/privacy-policy/"
+              >Privacy policy
+              <i data-lucide="arrow-right" aria-hidden="true"></i></a
+            ><a
+              href="https://github.com/DevelopersCoffee/airo/releases/tag/airo-tv-v0.0.4"
+              >Release checksums
+              <i data-lucide="arrow-up-right" aria-hidden="true"></i></a
+            ><a href="https://github.com/DevelopersCoffee/airo"
+              >Source repository
+              <i data-lucide="arrow-up-right" aria-hidden="true"></i
+            ></a>
+          </div>
+        </div>
+      </section>
+    </main>
 
-  <footer class="site-footer"><div class="container"><div class="footer-grid"><div><a class="brand" href="../"><img src="../assets/airo-tv/airo-icon.svg" alt=""><span>Airo TV</span></a><h2>Your sources. Your screen.</h2><p>Airo TV is the first focused product born from Airo.</p></div><div class="footer-col"><h3>Product</h3><a href="#product">How it works</a><a href="#devices">Devices</a><a href="#pro-vision">Airo TV Pro</a></div><div class="footer-col"><h3>Support</h3><a href="./guides/">Guides</a><a href="#community">Community Voice</a><a href="#roadmap">Roadmap</a></div><div class="footer-col"><h3>Airo</h3><a href="../">Platform</a><a href="../legal/privacy-policy/">Privacy</a><a href="mailto:coffee.devloper@gmail.com">Support</a></div></div><div class="footer-bottom"><span>&copy; <span data-current-year>2026</span> DevelopersCoffee</span><span>Airo TV includes no channels. Use authorized sources only.</span></div></div></footer>
-</body>
+    <footer class="site-footer">
+      <div class="container">
+        <div class="footer-grid">
+          <div>
+            <a class="brand" href="../"
+              ><img src="../assets/airo-tv/airo-icon.svg" alt="" /><span
+                >Airo TV</span
+              ></a
+            >
+            <h2>Your sources. Your screen.</h2>
+            <p>Airo TV is the first focused product born from Airo.</p>
+          </div>
+          <div class="footer-col">
+            <h3>Product</h3>
+            <a href="#product">How it works</a><a href="#devices">Devices</a
+            ><a href="#pro-vision">Airo TV Pro</a>
+          </div>
+          <div class="footer-col">
+            <h3>Support</h3>
+            <a href="./guides/">Guides</a
+            ><a href="#community">Community Voice</a
+            ><a href="#roadmap">Roadmap</a>
+          </div>
+          <div class="footer-col">
+            <h3>Airo</h3>
+            <a href="../">Platform</a
+            ><a href="../legal/privacy-policy/">Privacy</a
+            ><a href="mailto:coffee.devloper@gmail.com">Support</a>
+          </div>
+        </div>
+        <div class="footer-bottom">
+          <span
+            >&copy; <span data-current-year>2026</span> DevelopersCoffee</span
+          ><span
+            >Airo TV includes no channels. Use authorized sources only.</span
+          >
+        </div>
+      </div>
+    </footer>
+  </body>
 </html>

--- a/packages/core_native/lib/src/api/m3u.dart
+++ b/packages/core_native/lib/src/api/m3u.dart
@@ -7,9 +7,9 @@ import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart';
 
 import '../frb_generated.dart';
 
-// These functions are ignored because they are not marked as `pub`: `is_attr_key_byte`, `new`, `parse_extinf`, `parse_line`, `parse_m3u_playlist_str`
+// These functions are ignored because they are not marked as `pub`: `is_attr_key_byte`, `new`, `parse_extinf`, `parse_line`, `parse_m3u_playlist_str_with_stats`, `parse_m3u_playlist_str`
 // These types are ignored because they are neither used by any `pub` functions nor (for structs and enums) marked `#[frb(unignore)]`: `AttributeIter`, `PendingExtInf`
-// These function are ignored because they are on traits that is not defined in current crate (put an empty `#[frb]` on it to unignore): `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `clone`, `clone`, `clone`, `eq`, `eq`, `eq`, `fmt`, `fmt`, `fmt`, `next`
+// These function are ignored because they are on traits that is not defined in current crate (put an empty `#[frb]` on it to unignore): `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `clone`, `clone`, `clone`, `clone`, `clone`, `eq`, `eq`, `eq`, `eq`, `eq`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `next`
 // These functions are ignored (category: IgnoreBecauseOwnerTyShouldIgnore): `default`
 
 Future<List<M3uEntry>> parseM3UEntries({required String content}) =>
@@ -17,6 +17,11 @@ Future<List<M3uEntry>> parseM3UEntries({required String content}) =>
 
 Future<M3uPlaylist> parseM3UPlaylist({required String content}) =>
     RustLib.instance.api.crateApiM3UParseM3UPlaylist(content: content);
+
+/// Parse through the same Rust parser while retaining only safe aggregate
+/// counters for large-playlist import progress reporting.
+Future<M3uParseResult> parseM3UWithStats({required String content}) =>
+    RustLib.instance.api.crateApiM3UParseM3UWithStats(content: content);
 
 class M3uEntry {
   const M3uEntry({
@@ -72,6 +77,62 @@ class M3uEntry {
           language == other.language &&
           duration == other.duration &&
           extras == other.extras;
+}
+
+class M3uParseResult {
+  const M3uParseResult({required this.playlist, required this.stats});
+  final M3uPlaylist playlist;
+  final M3uParseStats stats;
+
+  static Future<M3uParseResult> default_() =>
+      RustLib.instance.api.crateApiM3UM3UParseResultDefault();
+
+  @override
+  int get hashCode => playlist.hashCode ^ stats.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is M3uParseResult &&
+          runtimeType == other.runtimeType &&
+          playlist == other.playlist &&
+          stats == other.stats;
+}
+
+/// Aggregate-only results for a playlist parse. These counters deliberately
+/// contain no source URL, channel name, or other user playlist content so they
+/// can safely be used in import progress and release diagnostics.
+class M3uParseStats {
+  const M3uParseStats({
+    required this.parsedCount,
+    required this.skippedCount,
+    required this.malformedCount,
+    required this.elapsedMillis,
+  });
+  final int parsedCount;
+  final int skippedCount;
+  final int malformedCount;
+  final PlatformInt64 elapsedMillis;
+
+  static Future<M3uParseStats> default_() =>
+      RustLib.instance.api.crateApiM3UM3UParseStatsDefault();
+
+  @override
+  int get hashCode =>
+      parsedCount.hashCode ^
+      skippedCount.hashCode ^
+      malformedCount.hashCode ^
+      elapsedMillis.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is M3uParseStats &&
+          runtimeType == other.runtimeType &&
+          parsedCount == other.parsedCount &&
+          skippedCount == other.skippedCount &&
+          malformedCount == other.malformedCount &&
+          elapsedMillis == other.elapsedMillis;
 }
 
 /// Full parse result: channel entries plus attributes from the `#EXTM3U`

--- a/packages/core_native/lib/src/frb_generated.dart
+++ b/packages/core_native/lib/src/frb_generated.dart
@@ -66,7 +66,7 @@ class RustLib extends BaseEntrypoint<RustLibApi, RustLibApiImpl, RustLibWire> {
   String get codegenVersion => '2.11.1';
 
   @override
-  int get rustContentHash => -50892443;
+  int get rustContentHash => -939726224;
 
   static const kDefaultExternalLibraryLoaderConfig =
       ExternalLibraryLoaderConfig(
@@ -77,6 +77,10 @@ class RustLib extends BaseEntrypoint<RustLibApi, RustLibApiImpl, RustLibWire> {
 }
 
 abstract class RustLibApi extends BaseApi {
+  Future<M3uParseResult> crateApiM3UM3UParseResultDefault();
+
+  Future<M3uParseStats> crateApiM3UM3UParseStatsDefault();
+
   Future<M3uPlaylist> crateApiM3UM3UPlaylistDefault();
 
   Future<String> crateApiTextNormalizeChannelName({required String name});
@@ -84,6 +88,10 @@ abstract class RustLibApi extends BaseApi {
   Future<List<M3uEntry>> crateApiM3UParseM3UEntries({required String content});
 
   Future<M3uPlaylist> crateApiM3UParseM3UPlaylist({required String content});
+
+  Future<M3uParseResult> crateApiM3UParseM3UWithStats({
+    required String content,
+  });
 
   Future<XmltvCurrentNextResult> crateApiXmltvParseXmltvCurrentNextFile({
     required String path,
@@ -120,7 +128,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   });
 
   @override
-  Future<M3uPlaylist> crateApiM3UM3UPlaylistDefault() {
+  Future<M3uParseResult> crateApiM3UM3UParseResultDefault() {
     return handler.executeNormal(
       NormalTask(
         callFfi: (port_) {
@@ -129,6 +137,63 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             generalizedFrbRustBinding,
             serializer,
             funcId: 1,
+            port: port_,
+          );
+        },
+        codec: SseCodec(
+          decodeSuccessData: sse_decode_m_3_u_parse_result,
+          decodeErrorData: null,
+        ),
+        constMeta: kCrateApiM3Um3UParseResultDefaultConstMeta,
+        argValues: [],
+        apiImpl: this,
+      ),
+    );
+  }
+
+  TaskConstMeta get kCrateApiM3Um3UParseResultDefaultConstMeta =>
+      const TaskConstMeta(
+        debugName: "m_3_u_parse_result_default",
+        argNames: [],
+      );
+
+  @override
+  Future<M3uParseStats> crateApiM3UM3UParseStatsDefault() {
+    return handler.executeNormal(
+      NormalTask(
+        callFfi: (port_) {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          pdeCallFfi(
+            generalizedFrbRustBinding,
+            serializer,
+            funcId: 2,
+            port: port_,
+          );
+        },
+        codec: SseCodec(
+          decodeSuccessData: sse_decode_m_3_u_parse_stats,
+          decodeErrorData: null,
+        ),
+        constMeta: kCrateApiM3Um3UParseStatsDefaultConstMeta,
+        argValues: [],
+        apiImpl: this,
+      ),
+    );
+  }
+
+  TaskConstMeta get kCrateApiM3Um3UParseStatsDefaultConstMeta =>
+      const TaskConstMeta(debugName: "m_3_u_parse_stats_default", argNames: []);
+
+  @override
+  Future<M3uPlaylist> crateApiM3UM3UPlaylistDefault() {
+    return handler.executeNormal(
+      NormalTask(
+        callFfi: (port_) {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          pdeCallFfi(
+            generalizedFrbRustBinding,
+            serializer,
+            funcId: 3,
             port: port_,
           );
         },
@@ -156,7 +221,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 2,
+            funcId: 4,
             port: port_,
           );
         },
@@ -187,7 +252,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 3,
+            funcId: 5,
             port: port_,
           );
         },
@@ -217,7 +282,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 4,
+            funcId: 6,
             port: port_,
           );
         },
@@ -239,6 +304,39 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       );
 
   @override
+  Future<M3uParseResult> crateApiM3UParseM3UWithStats({
+    required String content,
+  }) {
+    return handler.executeNormal(
+      NormalTask(
+        callFfi: (port_) {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          sse_encode_String(content, serializer);
+          pdeCallFfi(
+            generalizedFrbRustBinding,
+            serializer,
+            funcId: 7,
+            port: port_,
+          );
+        },
+        codec: SseCodec(
+          decodeSuccessData: sse_decode_m_3_u_parse_result,
+          decodeErrorData: null,
+        ),
+        constMeta: kCrateApiM3UParseM3UWithStatsConstMeta,
+        argValues: [content],
+        apiImpl: this,
+      ),
+    );
+  }
+
+  TaskConstMeta get kCrateApiM3UParseM3UWithStatsConstMeta =>
+      const TaskConstMeta(
+        debugName: "parse_m3u_with_stats",
+        argNames: ["content"],
+      );
+
+  @override
   Future<XmltvCurrentNextResult> crateApiXmltvParseXmltvCurrentNextFile({
     required String path,
     required List<String> channelIds,
@@ -256,7 +354,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 5,
+            funcId: 8,
             port: port_,
           );
         },
@@ -296,7 +394,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 6,
+            funcId: 9,
             port: port_,
           );
         },
@@ -331,7 +429,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 7,
+            funcId: 10,
             port: port_,
           );
         },
@@ -361,7 +459,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 8,
+            funcId: 11,
             port: port_,
           );
         },
@@ -391,7 +489,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 9,
+            funcId: 12,
             port: port_,
           );
         },
@@ -421,7 +519,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 10,
+            funcId: 13,
             port: port_,
           );
         },
@@ -451,7 +549,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 11,
+            funcId: 14,
             port: port_,
           );
         },
@@ -565,6 +663,32 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       language: dco_decode_opt_String(arr[6]),
       duration: dco_decode_opt_box_autoadd_i_64(arr[7]),
       extras: dco_decode_Map_String_String_None(arr[8]),
+    );
+  }
+
+  @protected
+  M3uParseResult dco_decode_m_3_u_parse_result(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    final arr = raw as List<dynamic>;
+    if (arr.length != 2)
+      throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
+    return M3uParseResult(
+      playlist: dco_decode_m_3_u_playlist(arr[0]),
+      stats: dco_decode_m_3_u_parse_stats(arr[1]),
+    );
+  }
+
+  @protected
+  M3uParseStats dco_decode_m_3_u_parse_stats(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    final arr = raw as List<dynamic>;
+    if (arr.length != 4)
+      throw Exception('unexpected arr length: expect 4 but see ${arr.length}');
+    return M3uParseStats(
+      parsedCount: dco_decode_u_32(arr[0]),
+      skippedCount: dco_decode_u_32(arr[1]),
+      malformedCount: dco_decode_u_32(arr[2]),
+      elapsedMillis: dco_decode_i_64(arr[3]),
     );
   }
 
@@ -842,6 +966,29 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       language: var_language,
       duration: var_duration,
       extras: var_extras,
+    );
+  }
+
+  @protected
+  M3uParseResult sse_decode_m_3_u_parse_result(SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    var var_playlist = sse_decode_m_3_u_playlist(deserializer);
+    var var_stats = sse_decode_m_3_u_parse_stats(deserializer);
+    return M3uParseResult(playlist: var_playlist, stats: var_stats);
+  }
+
+  @protected
+  M3uParseStats sse_decode_m_3_u_parse_stats(SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    var var_parsedCount = sse_decode_u_32(deserializer);
+    var var_skippedCount = sse_decode_u_32(deserializer);
+    var var_malformedCount = sse_decode_u_32(deserializer);
+    var var_elapsedMillis = sse_decode_i_64(deserializer);
+    return M3uParseStats(
+      parsedCount: var_parsedCount,
+      skippedCount: var_skippedCount,
+      malformedCount: var_malformedCount,
+      elapsedMillis: var_elapsedMillis,
     );
   }
 
@@ -1128,6 +1275,28 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     sse_encode_opt_String(self.language, serializer);
     sse_encode_opt_box_autoadd_i_64(self.duration, serializer);
     sse_encode_Map_String_String_None(self.extras, serializer);
+  }
+
+  @protected
+  void sse_encode_m_3_u_parse_result(
+    M3uParseResult self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_m_3_u_playlist(self.playlist, serializer);
+    sse_encode_m_3_u_parse_stats(self.stats, serializer);
+  }
+
+  @protected
+  void sse_encode_m_3_u_parse_stats(
+    M3uParseStats self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_u_32(self.parsedCount, serializer);
+    sse_encode_u_32(self.skippedCount, serializer);
+    sse_encode_u_32(self.malformedCount, serializer);
+    sse_encode_i_64(self.elapsedMillis, serializer);
   }
 
   @protected

--- a/packages/core_native/lib/src/frb_generated.io.dart
+++ b/packages/core_native/lib/src/frb_generated.io.dart
@@ -62,6 +62,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   M3uEntry dco_decode_m_3_u_entry(dynamic raw);
 
   @protected
+  M3uParseResult dco_decode_m_3_u_parse_result(dynamic raw);
+
+  @protected
+  M3uParseStats dco_decode_m_3_u_parse_stats(dynamic raw);
+
+  @protected
   M3uPlaylist dco_decode_m_3_u_playlist(dynamic raw);
 
   @protected
@@ -151,6 +157,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   M3uEntry sse_decode_m_3_u_entry(SseDeserializer deserializer);
+
+  @protected
+  M3uParseResult sse_decode_m_3_u_parse_result(SseDeserializer deserializer);
+
+  @protected
+  M3uParseStats sse_decode_m_3_u_parse_stats(SseDeserializer deserializer);
 
   @protected
   M3uPlaylist sse_decode_m_3_u_playlist(SseDeserializer deserializer);
@@ -269,6 +281,18 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   void sse_encode_m_3_u_entry(M3uEntry self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_m_3_u_parse_result(
+    M3uParseResult self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_m_3_u_parse_stats(
+    M3uParseStats self,
+    SseSerializer serializer,
+  );
 
   @protected
   void sse_encode_m_3_u_playlist(M3uPlaylist self, SseSerializer serializer);

--- a/packages/core_native/lib/src/frb_generated.web.dart
+++ b/packages/core_native/lib/src/frb_generated.web.dart
@@ -64,6 +64,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   M3uEntry dco_decode_m_3_u_entry(dynamic raw);
 
   @protected
+  M3uParseResult dco_decode_m_3_u_parse_result(dynamic raw);
+
+  @protected
+  M3uParseStats dco_decode_m_3_u_parse_stats(dynamic raw);
+
+  @protected
   M3uPlaylist dco_decode_m_3_u_playlist(dynamic raw);
 
   @protected
@@ -153,6 +159,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   M3uEntry sse_decode_m_3_u_entry(SseDeserializer deserializer);
+
+  @protected
+  M3uParseResult sse_decode_m_3_u_parse_result(SseDeserializer deserializer);
+
+  @protected
+  M3uParseStats sse_decode_m_3_u_parse_stats(SseDeserializer deserializer);
 
   @protected
   M3uPlaylist sse_decode_m_3_u_playlist(SseDeserializer deserializer);
@@ -271,6 +283,18 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   void sse_encode_m_3_u_entry(M3uEntry self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_m_3_u_parse_result(
+    M3uParseResult self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_m_3_u_parse_stats(
+    M3uParseStats self,
+    SseSerializer serializer,
+  );
 
   @protected
   void sse_encode_m_3_u_playlist(M3uPlaylist self, SseSerializer serializer);

--- a/packages/core_native/lib/src/m3u.dart
+++ b/packages/core_native/lib/src/m3u.dart
@@ -42,6 +42,29 @@ class NativeM3uPlaylist {
   final Map<String, String> headers;
 }
 
+/// Redacted aggregate parser telemetry for playlist import progress. It never
+/// contains a user-supplied source URL or individual channel data.
+class NativeM3uParseStats {
+  const NativeM3uParseStats({
+    required this.parsedCount,
+    required this.skippedCount,
+    required this.malformedCount,
+    required this.elapsedMillis,
+  });
+
+  final int parsedCount;
+  final int skippedCount;
+  final int malformedCount;
+  final int elapsedMillis;
+}
+
+class NativeM3uParseResult {
+  const NativeM3uParseResult({required this.playlist, required this.stats});
+
+  final NativeM3uPlaylist playlist;
+  final NativeM3uParseStats stats;
+}
+
 /// Parse M3U channel entries with the synchronous Dart fallback parser.
 ///
 /// This is the web fallback and the deterministic-test path; native
@@ -58,23 +81,47 @@ Future<List<NativeM3uEntry>> parseM3uEntriesNative(String content) async =>
 /// synchronous Dart fallback parser. Web fallback / deterministic-test path;
 /// prefer [parseM3uPlaylistNative] on native platforms.
 NativeM3uPlaylist parseM3uPlaylist(String content) =>
-    _dartParseM3uPlaylist(content);
+    parseM3uPlaylistWithStats(content).playlist;
+
+/// Synchronous Dart fallback with redacted aggregate counters. Production
+/// native callers should use [parseM3uPlaylistWithStatsNative].
+NativeM3uParseResult parseM3uPlaylistWithStats(String content) =>
+    _dartParseM3uPlaylistWithStats(content);
 
 /// Parse M3U content (entries + `#EXTM3U` header attributes) through the
 /// Rust core parser, falling back to the Dart parser on web or when the
 /// native bridge is unavailable.
 Future<NativeM3uPlaylist> parseM3uPlaylistNative(String content) async {
+  return (await parseM3uPlaylistWithStatsNative(content)).playlist;
+}
+
+/// Parse M3U content and safe aggregate parser telemetry through Rust,
+/// falling back to the deterministic Dart parser when unavailable.
+Future<NativeM3uParseResult> parseM3uPlaylistWithStatsNative(
+  String content,
+) async {
   if (kIsWeb) {
-    return _dartParseM3uPlaylist(content);
+    return _dartParseM3uPlaylistWithStats(content);
   }
   if (!await initializeCoreNativeBridge()) {
-    return _dartParseM3uPlaylist(content);
+    return _dartParseM3uPlaylistWithStats(content);
   }
   try {
-    final result = await native_m3u.parseM3UPlaylist(content: content);
-    return _fromNativeM3uPlaylist(result);
+    final result = await native_m3u.parseM3UWithStats(content: content);
+    return NativeM3uParseResult(
+      playlist: _fromNativeM3uPlaylist(result.playlist),
+      stats: NativeM3uParseStats(
+        parsedCount: result.stats.parsedCount,
+        skippedCount: result.stats.skippedCount,
+        malformedCount: result.stats.malformedCount,
+        // PlatformInt64 is int on IO and BigInt on web. Native execution is
+        // the only path here, but the conversion keeps web builds compiling.
+        // ignore: noop_primitive_operations
+        elapsedMillis: result.stats.elapsedMillis.toInt(),
+      ),
+    );
   } on Object {
-    return _dartParseM3uPlaylist(content);
+    return _dartParseM3uPlaylistWithStats(content);
   }
 }
 
@@ -102,15 +149,25 @@ NativeM3uEntry _fromNativeM3uEntry(native_m3u.M3uEntry entry) {
   );
 }
 
-NativeM3uPlaylist _dartParseM3uPlaylist(String content) {
+NativeM3uParseResult _dartParseM3uPlaylistWithStats(String content) {
+  final stopwatch = Stopwatch()..start();
   final entries = <NativeM3uEntry>[];
   final headers = <String, String>{};
   _PendingM3uEntry? pending;
+  var skippedCount = 0;
+  var malformedCount = 0;
 
   for (final rawLine in content.split('\n')) {
     final line = rawLine.trim();
     if (line.startsWith('#EXTINF:')) {
-      pending = _parseExtInf(line);
+      if (pending != null) {
+        skippedCount++;
+      }
+      final parsed = _parseExtInf(line);
+      if (parsed == null) {
+        malformedCount++;
+      }
+      pending = parsed;
       continue;
     }
 
@@ -142,7 +199,19 @@ NativeM3uPlaylist _dartParseM3uPlaylist(String content) {
     pending = null;
   }
 
-  return NativeM3uPlaylist(entries: entries, headers: headers);
+  if (pending != null) {
+    skippedCount++;
+  }
+  stopwatch.stop();
+  return NativeM3uParseResult(
+    playlist: NativeM3uPlaylist(entries: entries, headers: headers),
+    stats: NativeM3uParseStats(
+      parsedCount: entries.length,
+      skippedCount: skippedCount,
+      malformedCount: malformedCount,
+      elapsedMillis: stopwatch.elapsedMilliseconds,
+    ),
+  );
 }
 
 _PendingM3uEntry? _parseExtInf(String line) {

--- a/packages/core_native/test/m3u_test.dart
+++ b/packages/core_native/test/m3u_test.dart
@@ -117,6 +117,23 @@ https://example.com/news.m3u8
       expect(playlist.headers, isEmpty);
     });
 
+    test('reports redacted aggregate parse stats', () async {
+      final result = await parseM3uPlaylistWithStatsNative('''
+#EXTM3U
+#EXTINF:-1 Broken entry without a comma
+#EXTINF:-1,Skipped without URL
+#EXTINF:-1,Parsed channel
+https://example.com/parsed.m3u8
+#EXTINF:-1,Trailing without URL
+''');
+
+      expect(result.playlist.entries, hasLength(1));
+      expect(result.stats.parsedCount, 1);
+      expect(result.stats.skippedCount, 2);
+      expect(result.stats.malformedCount, 1);
+      expect(result.stats.elapsedMillis, greaterThanOrEqualTo(0));
+    });
+
     test(
       'native-preferred playlist API matches Dart fallback output',
       () async {

--- a/packages/platform_playlist_import/lib/src/m3u_parser_service.dart
+++ b/packages/platform_playlist_import/lib/src/m3u_parser_service.dart
@@ -154,9 +154,9 @@ class M3UParserService {
       throw Exception('Empty playlist response');
     }
 
-    final channels = await parseM3UOffMain(response.data!);
+    final parseResult = await parseM3UWithStatsOffMain(response.data!);
     await _saveHttpValidators(response.headers);
-    return _PlaylistFetchResult(channels: channels);
+    return _PlaylistFetchResult(channels: parseResult.channels);
   }
 
   /// Stream-based staged import of the user-supplied playlist, wrapping this
@@ -220,7 +220,8 @@ class M3UParserService {
         stage: ImportStage.parse,
         message: 'Parsing playlist',
       );
-      final channels = await parseM3UOffMain(response.data!);
+      final parseResult = await parseM3UWithStatsOffMain(response.data!);
+      final channels = parseResult.channels;
       await _saveHttpValidators(response.headers);
 
       // parseM3UOffMain (via parseM3UChannels) already normalizes and
@@ -230,7 +231,10 @@ class M3UParserService {
       yield ImportProgress(
         stage: ImportStage.normalize,
         fraction: 1,
-        message: '${channels.length} channels parsed',
+        message:
+            '${parseResult.stats.parsedCount} parsed; '
+            '${parseResult.stats.skippedCount} skipped; '
+            '${parseResult.stats.malformedCount} malformed',
       );
       yield const ImportProgress(stage: ImportStage.deduplicate, fraction: 1);
       yield const ImportProgress(stage: ImportStage.indexing, fraction: 1);
@@ -286,13 +290,40 @@ class M3UParserService {
   /// per the repo isolate policy; `parseM3uEntriesNative` also falls back to
   /// it automatically when the native bridge is unavailable.
   Future<List<IPTVChannel>> parseM3UOffMain(String content) {
+    return parseM3UWithStatsOffMain(content).then((result) => result.channels);
+  }
+
+  /// Parse through the production worker boundary and retain aggregate-only
+  /// telemetry for progress/diagnostics. No source URL or playlist entry is
+  /// retained in the stats result.
+  Future<M3UParseResult> parseM3UWithStatsOffMain(String content) async {
     if (!kIsWeb) {
-      return parseM3UChannelsNative(content);
+      final result = await parseM3uPlaylistWithStatsNative(content);
+      return M3UParseResult(
+        channels: _channelsFromM3uEntries(result.playlist.entries),
+        stats: M3UParseStats(
+          parsedCount: result.stats.parsedCount,
+          skippedCount: result.stats.skippedCount,
+          malformedCount: result.stats.malformedCount,
+          elapsedMillis: result.stats.elapsedMillis,
+        ),
+      );
     }
-    return workerExecutor.run<List<IPTVChannel>>(
+    return workerExecutor.run<M3UParseResult>(
       debugName: 'm3u_playlist_parse',
       kind: AiroWorkerJobKind.playlistImport,
-      computation: () => parseM3UChannels(content),
+      computation: () {
+        final result = parseM3uPlaylistWithStats(content);
+        return M3UParseResult(
+          channels: _channelsFromM3uEntries(result.playlist.entries),
+          stats: M3UParseStats(
+            parsedCount: result.stats.parsedCount,
+            skippedCount: result.stats.skippedCount,
+            malformedCount: result.stats.malformedCount,
+            elapsedMillis: result.stats.elapsedMillis,
+          ),
+        );
+      },
     );
   }
 
@@ -408,6 +439,29 @@ class _PlaylistFetchResult {
 
   final List<IPTVChannel> channels;
   final bool fromCache;
+}
+
+/// Aggregate-only output of a playlist parse. Channel records remain local to
+/// the import pipeline while progress and diagnostics use only [stats].
+class M3UParseResult {
+  const M3UParseResult({required this.channels, required this.stats});
+
+  final List<IPTVChannel> channels;
+  final M3UParseStats stats;
+}
+
+class M3UParseStats {
+  const M3UParseStats({
+    required this.parsedCount,
+    required this.skippedCount,
+    required this.malformedCount,
+    required this.elapsedMillis,
+  });
+
+  final int parsedCount;
+  final int skippedCount;
+  final int malformedCount;
+  final int elapsedMillis;
 }
 
 String _encodeChannelCache(List<IPTVChannel> channels) {

--- a/packages/platform_playlist_import/test/platform_playlist_import_test.dart
+++ b/packages/platform_playlist_import/test/platform_playlist_import_test.dart
@@ -40,6 +40,27 @@ https://example.com/worker.m3u8
     expect(channels.single.streamUrl, 'https://example.com/worker.m3u8');
   });
 
+  test('returns aggregate stats without retaining playlist content', () async {
+    SharedPreferences.setMockInitialValues({});
+    final prefs = await SharedPreferences.getInstance();
+    final parser = M3UParserService(dio: Dio(), prefs: prefs);
+
+    final result = await parser.parseM3UWithStatsOffMain('''
+#EXTM3U
+#EXTINF:-1 Broken entry without a comma
+#EXTINF:-1,Skipped without URL
+#EXTINF:-1,Parsed channel
+https://example.com/parsed.m3u8
+#EXTINF:-1,Trailing without URL
+''');
+
+    expect(result.channels, hasLength(1));
+    expect(result.stats.parsedCount, 1);
+    expect(result.stats.skippedCount, 2);
+    expect(result.stats.malformedCount, 1);
+    expect(result.stats.elapsedMillis, greaterThanOrEqualTo(0));
+  });
+
   group('M3UParserService deduplication', () {
     late M3UParserService parser;
 

--- a/rust/airo_core/src/api/m3u.rs
+++ b/rust/airo_core/src/api/m3u.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::time::Instant;
 
 use memchr::memchr;
 
@@ -27,6 +28,23 @@ pub struct M3uPlaylist {
     pub headers: HashMap<String, String>,
 }
 
+/// Aggregate-only results for a playlist parse. These counters deliberately
+/// contain no source URL, channel name, or other user playlist content so they
+/// can safely be used in import progress and release diagnostics.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct M3uParseStats {
+    pub parsed_count: u32,
+    pub skipped_count: u32,
+    pub malformed_count: u32,
+    pub elapsed_millis: i64,
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct M3uParseResult {
+    pub playlist: M3uPlaylist,
+    pub stats: M3uParseStats,
+}
+
 #[flutter_rust_bridge::frb(ignore)]
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 struct PendingExtInf {
@@ -48,16 +66,28 @@ pub fn parse_m3u_playlist(content: String) -> M3uPlaylist {
     parse_m3u_playlist_str(&content)
 }
 
+/// Parse through the same Rust parser while retaining only safe aggregate
+/// counters for large-playlist import progress reporting.
+pub fn parse_m3u_with_stats(content: String) -> M3uParseResult {
+    parse_m3u_playlist_str_with_stats(&content)
+}
+
 fn parse_m3u_playlist_str(content: &str) -> M3uPlaylist {
+    parse_m3u_playlist_str_with_stats(content).playlist
+}
+
+fn parse_m3u_playlist_str_with_stats(content: &str) -> M3uParseResult {
+    let started_at = Instant::now();
     let bytes = content.as_bytes();
     let mut playlist = M3uPlaylist::default();
     let mut pending: Option<PendingExtInf> = None;
+    let mut stats = M3uParseStats::default();
     let mut offset = 0;
 
     while offset <= bytes.len() {
         let remaining = &bytes[offset..];
         let Some(newline_index) = memchr(b'\n', remaining) else {
-            parse_line(&content[offset..], &mut pending, &mut playlist);
+            parse_line(&content[offset..], &mut pending, &mut playlist, &mut stats);
             break;
         };
 
@@ -65,17 +95,42 @@ fn parse_m3u_playlist_str(content: &str) -> M3uPlaylist {
             &content[offset..offset + newline_index],
             &mut pending,
             &mut playlist,
+            &mut stats,
         );
         offset += newline_index + 1;
     }
 
-    playlist
+    if pending.is_some() {
+        stats.skipped_count += 1;
+    }
+    stats.parsed_count = playlist.entries.len().try_into().unwrap_or(u32::MAX);
+    stats.elapsed_millis = started_at
+        .elapsed()
+        .as_millis()
+        .try_into()
+        .unwrap_or(i64::MAX);
+
+    M3uParseResult { playlist, stats }
 }
 
-fn parse_line(line: &str, pending: &mut Option<PendingExtInf>, playlist: &mut M3uPlaylist) {
+fn parse_line(
+    line: &str,
+    pending: &mut Option<PendingExtInf>,
+    playlist: &mut M3uPlaylist,
+    stats: &mut M3uParseStats,
+) {
     let line = line.trim();
     if line.starts_with("#EXTINF:") {
-        *pending = parse_extinf(line);
+        if pending.is_some() {
+            stats.skipped_count += 1;
+        }
+        match parse_extinf(line) {
+            Some(entry) => *pending = Some(entry),
+            None => {
+                stats.malformed_count += 1;
+                *pending = None;
+            }
+        }
         return;
     }
 
@@ -333,5 +388,25 @@ https://example.com/news.m3u8
 
         assert_eq!(playlist.entries.len(), 1);
         assert!(playlist.headers.is_empty());
+    }
+
+    #[test]
+    fn reports_safe_parse_stats_for_malformed_and_skipped_rows() {
+        let result = parse_m3u_playlist_str_with_stats(
+            r#"#EXTM3U
+#EXTINF:-1 This row has no comma
+#EXTINF:-1,Skipped without URL
+# a comment does not consume the pending row
+#EXTINF:-1,Parsed channel
+https://example.com/parsed.m3u8
+#EXTINF:-1,Trailing without URL
+"#,
+        );
+
+        assert_eq!(result.playlist.entries.len(), 1);
+        assert_eq!(result.stats.parsed_count, 1);
+        assert_eq!(result.stats.skipped_count, 2);
+        assert_eq!(result.stats.malformed_count, 1);
+        assert!(result.stats.elapsed_millis >= 0);
     }
 }

--- a/rust/airo_core/src/frb_generated.rs
+++ b/rust/airo_core/src/frb_generated.rs
@@ -37,7 +37,7 @@ flutter_rust_bridge::frb_generated_boilerplate!(
     default_rust_auto_opaque = RustAutoOpaqueMoi,
 );
 pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_VERSION: &str = "2.11.1";
-pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = -50892443;
+pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = -939726224;
 
 // Section: executor
 
@@ -45,6 +45,71 @@ flutter_rust_bridge::frb_generated_default_handler!();
 
 // Section: wire_funcs
 
+fn wire__crate__api__m3u__m_3_u_parse_result_default_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "m_3_u_parse_result_default",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            deserializer.end();
+            move |context| {
+                transform_result_sse::<_, ()>((move || {
+                    let output_ok =
+                        Result::<_, ()>::Ok(crate::api::m3u::M3uParseResult::default())?;
+                    Ok(output_ok)
+                })())
+            }
+        },
+    )
+}
+fn wire__crate__api__m3u__m_3_u_parse_stats_default_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "m_3_u_parse_stats_default",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            deserializer.end();
+            move |context| {
+                transform_result_sse::<_, ()>((move || {
+                    let output_ok = Result::<_, ()>::Ok(crate::api::m3u::M3uParseStats::default())?;
+                    Ok(output_ok)
+                })())
+            }
+        },
+    )
+}
 fn wire__crate__api__m3u__m_3_u_playlist_default_impl(
     port_: flutter_rust_bridge::for_generated::MessagePort,
     ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
@@ -173,6 +238,40 @@ fn wire__crate__api__m3u__parse_m3u_playlist_impl(
                 transform_result_sse::<_, ()>((move || {
                     let output_ok =
                         Result::<_, ()>::Ok(crate::api::m3u::parse_m3u_playlist(api_content))?;
+                    Ok(output_ok)
+                })())
+            }
+        },
+    )
+}
+fn wire__crate__api__m3u__parse_m3u_with_stats_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "parse_m3u_with_stats",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_content = <String>::sse_decode(&mut deserializer);
+            deserializer.end();
+            move |context| {
+                transform_result_sse::<_, ()>((move || {
+                    let output_ok =
+                        Result::<_, ()>::Ok(crate::api::m3u::parse_m3u_with_stats(api_content))?;
                     Ok(output_ok)
                 })())
             }
@@ -559,6 +658,34 @@ impl SseDecode for crate::api::m3u::M3uEntry {
     }
 }
 
+impl SseDecode for crate::api::m3u::M3uParseResult {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut var_playlist = <crate::api::m3u::M3uPlaylist>::sse_decode(deserializer);
+        let mut var_stats = <crate::api::m3u::M3uParseStats>::sse_decode(deserializer);
+        return crate::api::m3u::M3uParseResult {
+            playlist: var_playlist,
+            stats: var_stats,
+        };
+    }
+}
+
+impl SseDecode for crate::api::m3u::M3uParseStats {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut var_parsedCount = <u32>::sse_decode(deserializer);
+        let mut var_skippedCount = <u32>::sse_decode(deserializer);
+        let mut var_malformedCount = <u32>::sse_decode(deserializer);
+        let mut var_elapsedMillis = <i64>::sse_decode(deserializer);
+        return crate::api::m3u::M3uParseStats {
+            parsed_count: var_parsedCount,
+            skipped_count: var_skippedCount,
+            malformed_count: var_malformedCount,
+            elapsed_millis: var_elapsedMillis,
+        };
+    }
+}
+
 impl SseDecode for crate::api::m3u::M3uPlaylist {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
@@ -737,44 +864,54 @@ fn pde_ffi_dispatcher_primary_impl(
 ) {
     // Codec=Pde (Serialization + dispatch), see doc to use other codecs
     match func_id {
-        1 => wire__crate__api__m3u__m_3_u_playlist_default_impl(port, ptr, rust_vec_len, data_len),
-        2 => wire__crate__api__text__normalize_channel_name_impl(port, ptr, rust_vec_len, data_len),
-        3 => wire__crate__api__m3u__parse_m3u_entries_impl(port, ptr, rust_vec_len, data_len),
-        4 => wire__crate__api__m3u__parse_m3u_playlist_impl(port, ptr, rust_vec_len, data_len),
-        5 => wire__crate__api__xmltv__parse_xmltv_current_next_file_impl(
+        1 => wire__crate__api__m3u__m_3_u_parse_result_default_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        6 => {
+        2 => {
+            wire__crate__api__m3u__m_3_u_parse_stats_default_impl(port, ptr, rust_vec_len, data_len)
+        }
+        3 => wire__crate__api__m3u__m_3_u_playlist_default_impl(port, ptr, rust_vec_len, data_len),
+        4 => wire__crate__api__text__normalize_channel_name_impl(port, ptr, rust_vec_len, data_len),
+        5 => wire__crate__api__m3u__parse_m3u_entries_impl(port, ptr, rust_vec_len, data_len),
+        6 => wire__crate__api__m3u__parse_m3u_playlist_impl(port, ptr, rust_vec_len, data_len),
+        7 => wire__crate__api__m3u__parse_m3u_with_stats_impl(port, ptr, rust_vec_len, data_len),
+        8 => wire__crate__api__xmltv__parse_xmltv_current_next_file_impl(
+            port,
+            ptr,
+            rust_vec_len,
+            data_len,
+        ),
+        9 => {
             wire__crate__api__xmltv__parse_xmltv_programmes_impl(port, ptr, rust_vec_len, data_len)
         }
-        7 => wire__crate__api__xmltv__parse_xmltv_programmes_file_impl(
+        10 => wire__crate__api__xmltv__parse_xmltv_programmes_file_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        8 => wire__crate__api__xmltv__xmltv_current_next_result_default_impl(
+        11 => wire__crate__api__xmltv__xmltv_current_next_result_default_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        9 => wire__crate__api__xmltv__xmltv_current_next_stats_default_impl(
+        12 => wire__crate__api__xmltv__xmltv_current_next_stats_default_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        10 => wire__crate__api__xmltv__xmltv_parse_result_default_impl(
+        13 => wire__crate__api__xmltv__xmltv_parse_result_default_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        11 => wire__crate__api__xmltv__xmltv_parse_stats_default_impl(
+        14 => wire__crate__api__xmltv__xmltv_parse_stats_default_impl(
             port,
             ptr,
             rust_vec_len,
@@ -818,6 +955,50 @@ impl flutter_rust_bridge::IntoDart for crate::api::m3u::M3uEntry {
 impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive for crate::api::m3u::M3uEntry {}
 impl flutter_rust_bridge::IntoIntoDart<crate::api::m3u::M3uEntry> for crate::api::m3u::M3uEntry {
     fn into_into_dart(self) -> crate::api::m3u::M3uEntry {
+        self
+    }
+}
+// Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for crate::api::m3u::M3uParseResult {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        [
+            self.playlist.into_into_dart().into_dart(),
+            self.stats.into_into_dart().into_dart(),
+        ]
+        .into_dart()
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
+    for crate::api::m3u::M3uParseResult
+{
+}
+impl flutter_rust_bridge::IntoIntoDart<crate::api::m3u::M3uParseResult>
+    for crate::api::m3u::M3uParseResult
+{
+    fn into_into_dart(self) -> crate::api::m3u::M3uParseResult {
+        self
+    }
+}
+// Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for crate::api::m3u::M3uParseStats {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        [
+            self.parsed_count.into_into_dart().into_dart(),
+            self.skipped_count.into_into_dart().into_dart(),
+            self.malformed_count.into_into_dart().into_dart(),
+            self.elapsed_millis.into_into_dart().into_dart(),
+        ]
+        .into_dart()
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
+    for crate::api::m3u::M3uParseStats
+{
+}
+impl flutter_rust_bridge::IntoIntoDart<crate::api::m3u::M3uParseStats>
+    for crate::api::m3u::M3uParseStats
+{
+    fn into_into_dart(self) -> crate::api::m3u::M3uParseStats {
         self
     }
 }
@@ -1073,6 +1254,24 @@ impl SseEncode for crate::api::m3u::M3uEntry {
         <Option<String>>::sse_encode(self.language, serializer);
         <Option<i64>>::sse_encode(self.duration, serializer);
         <std::collections::HashMap<String, String>>::sse_encode(self.extras, serializer);
+    }
+}
+
+impl SseEncode for crate::api::m3u::M3uParseResult {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <crate::api::m3u::M3uPlaylist>::sse_encode(self.playlist, serializer);
+        <crate::api::m3u::M3uParseStats>::sse_encode(self.stats, serializer);
+    }
+}
+
+impl SseEncode for crate::api::m3u::M3uParseStats {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <u32>::sse_encode(self.parsed_count, serializer);
+        <u32>::sse_encode(self.skipped_count, serializer);
+        <u32>::sse_encode(self.malformed_count, serializer);
+        <i64>::sse_encode(self.elapsed_millis, serializer);
     }
 }
 


### PR DESCRIPTION
## Summary

Publishes Airo TV v0.0.4 with safe playlist-import telemetry, finalized product copy, release pages, and full Android ABI release artifacts.

## Validation

- Rust and focused Flutter parser/import tests
- Release-branding, workflow, and browser runtime checks
- Successful release pipeline: https://github.com/DevelopersCoffee/airo/actions/runs/29870481907

## Release

https://github.com/DevelopersCoffee/airo/releases/tag/airo-tv-v0.0.4