### PR TITLE
fix(cast): guard macOS sender capability

### DIFF
--- a/app/lib/features/iptv/iptv_cast_provider_override.dart
+++ b/app/lib/features/iptv/iptv_cast_provider_override.dart
@@ -1,14 +1,13 @@
 import 'dart:async';
 
 import 'package:feature_iptv/feature_iptv.dart';
-import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/misc.dart';
 
 Override realIptvCastControllerOverride() {
   return airoCastControllerProvider.overrideWith((ref) {
-    final controller = kIsWeb
-        ? UnavailableAiroCastController()
-        : FlutterChromeCastController(useProxy: true);
+    final controller = isGoogleCastSenderPlatform
+        ? FlutterChromeCastController(useProxy: true)
+        : UnavailableAiroCastController();
     ref.onDispose(() => unawaited(controller.dispose()));
     return controller;
   });

--- a/app/test/main_tv_cast_override_test.dart
+++ b/app/test/main_tv_cast_override_test.dart
@@ -1,5 +1,6 @@
 import 'package:airo_app/main_tv.dart';
 import 'package:feature_iptv/feature_iptv.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -11,6 +12,8 @@ void main() {
     'TV entrypoint wires a real cast controller — phones running the TV build '
     'render the mobile IPTV screen whose cast UI needs it',
     () async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.android;
+      addTearDown(() => debugDefaultTargetPlatformOverride = null);
       SharedPreferences.setMockInitialValues({});
       final prefs = await SharedPreferences.getInstance();
       final mutableRepo = MutableXmltvCompactEpgRepository();
@@ -29,6 +32,33 @@ void main() {
       expect(
         container.read(airoCastControllerProvider),
         isA<FlutterChromeCastController>(),
+      );
+    },
+  );
+
+  test(
+    'TV entrypoint keeps Cast no-op on macOS per release contract',
+    () async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.macOS;
+      addTearDown(() => debugDefaultTargetPlatformOverride = null);
+      SharedPreferences.setMockInitialValues({});
+      final prefs = await SharedPreferences.getInstance();
+      final mutableRepo = MutableXmltvCompactEpgRepository();
+
+      final container = ProviderContainer(
+        overrides: buildTvProviderOverrides(
+          prefs: prefs,
+          compactEpgRepository: createTvCompactEpgRepository(
+            fallback: mutableRepo,
+          ),
+          mutableXmltvRepository: mutableRepo,
+        ),
+      );
+      addTearDown(container.dispose);
+
+      expect(
+        container.read(airoCastControllerProvider),
+        isA<UnavailableAiroCastController>(),
       );
     },
   );

--- a/docs/superpowers/audits/2026-07-22-macos-cast-architecture-gap.md
+++ b/docs/superpowers/audits/2026-07-22-macos-cast-architecture-gap.md
@@ -1,0 +1,53 @@
+# macOS Cast architecture gap audit
+
+Date: 2026-07-22
+
+## Trigger
+
+The macOS Airo TV app exposed the same Cast picker used by Pixel/iPad, but the
+picker stayed at `Ready to search` / no receiver discovery on macOS.
+
+## Finding
+
+The Cast V1 implementation is a Google Cast sender path for Android and iOS.
+The vendored `flutter_chrome_cast` plugin declares Android and iOS platforms
+only, and the real controller rejects every other platform at runtime.
+
+The macOS release contract already said Cast-only mobile behavior must be
+hidden or no-op on macOS, but the app-level provider override always supplied
+`FlutterChromeCastController` for every non-web platform. The feature screen
+also rendered the Cast action for every non-web platform. That let macOS show a
+mobile Cast affordance even though there was no macOS sender implementation.
+
+## Architecture gap
+
+Platform capability was inferred locally in UI and app wiring instead of being
+declared as an executable product capability. Android/iOS fixes were validated
+against Android/iOS sender flows, but the macOS build path had no regression
+test enforcing the release contract.
+
+## Process correction
+
+- Treat Cast sender support as Android/iOS-only until a deliberate macOS Cast,
+  AirPlay, or custom receiver implementation is designed.
+- Keep macOS Cast behavior hidden or no-op.
+- Add regression tests for both sides of the contract:
+  - Android TV/mobile sender profiles wire a real Cast controller.
+  - macOS wires an unavailable controller and hides the Cast toolbar action.
+- Future Cast PRs must include a device/platform matrix note, not only a
+  generic "works on mobile" statement.
+
+## Source references
+
+- Google Cast iOS permissions and discovery:
+  https://developers.google.com/cast/docs/ios_sender/permissions_and_discovery
+- Google Cast iOS sender integration:
+  https://developers.google.com/cast/docs/ios_sender/integrate
+- Apple Bonjour overview:
+  https://developer.apple.com/bonjour/
+- Apple local-network privacy guidance:
+  https://developer.apple.com/videos/play/wwdc2020/10110/
+- Local implementation:
+  `packages/platform_player/lib/src/services/flutter_chrome_cast_controller.dart`
+- Local plugin declaration:
+  `packages/platform_player/third_party/flutter_chrome_cast/pubspec.yaml`

--- a/docs/wiki/7.-Troubleshooting-and-FAQ.md
+++ b/docs/wiki/7.-Troubleshooting-and-FAQ.md
@@ -34,6 +34,17 @@ supported local command, Airo treats it as a general AI chat prompt.
 - Try a different channel or track.
 - Restart the app if the player state appears stuck.
 
+## Cast Button Is Missing on macOS
+
+Airo currently shows Google Cast controls only on Android and iOS, where the
+Google Cast sender bridge is available. The macOS app does not reuse the mobile
+Cast sheet because that path cannot discover or connect to Chromecast devices
+from desktop builds.
+
+On macOS, use local playback for now. Desktop casting support needs a dedicated
+native sender, AirPlay route, or system-player design before the Cast action can
+be enabled there.
+
 ## FAQ
 
 **Q: Is Airo only an AI app?**

--- a/packages/feature_iptv/lib/presentation/screens/iptv_screen.dart
+++ b/packages/feature_iptv/lib/presentation/screens/iptv_screen.dart
@@ -1,7 +1,6 @@
 import 'dart:async';
 
 import 'package:collection/collection.dart';
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -434,7 +433,7 @@ class _IPTVScreenState extends ConsumerState<IPTVScreen>
   }
 
   Future<void> _showCastSheet() async {
-    if (kIsWeb) {
+    if (!isGoogleCastSenderPlatform) {
       ScaffoldMessenger.of(context).showSnackBar(
         const SnackBar(content: Text('Cast is available in the mobile app.')),
       );
@@ -609,7 +608,7 @@ class _IPTVScreenState extends ConsumerState<IPTVScreen>
             tooltip: 'Playlist source',
             onPressed: _showPlaylistSheet,
           ),
-          if (!kIsWeb)
+          if (isGoogleCastSenderPlatform)
             IconButton(
               icon: const Icon(Icons.cast_connected),
               tooltip: 'Cast',

--- a/packages/feature_iptv/test/iptv/presentation/screens/iptv_screen_test.dart
+++ b/packages/feature_iptv/test/iptv/presentation/screens/iptv_screen_test.dart
@@ -3,6 +3,7 @@ import "dart:io";
 
 import "package:dio/dio.dart";
 import "package:feature_iptv/feature_iptv.dart";
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_riverpod/misc.dart';
@@ -146,33 +147,51 @@ void main() {
   testWidgets('renders Airo TV app bar and live list without category chips', (
     tester,
   ) async {
-    await tester.pumpWidget(createWidget());
-    await tester.pumpAndSettle();
+    debugDefaultTargetPlatformOverride = TargetPlatform.android;
+    try {
+      await tester.pumpWidget(createWidget());
+      await tester.pumpAndSettle();
 
-    expect(find.text('Airo TV'), findsOneWidget);
-    expect(find.byTooltip('Search channels'), findsOneWidget);
-    expect(find.byTooltip('Cast'), findsOneWidget);
-    // Category browsing moved into the rails (Entertainment, Music, ...);
-    // the chip row is gone.
-    expect(find.byType(ChoiceChip), findsNothing);
-    expect(find.text('Featured Player'), findsNothing);
-    expect(find.text('Play media from your saved playlist.'), findsNothing);
-    expect(find.text('Select a channel to start watching'), findsNothing);
-    expect(
-      find.text('Choose a channel from your playlist to begin streaming.'),
-      findsNothing,
-    );
+      expect(find.text('Airo TV'), findsOneWidget);
+      expect(find.byTooltip('Search channels'), findsOneWidget);
+      expect(find.byTooltip('Cast'), findsOneWidget);
+      // Category browsing moved into the rails (Entertainment, Music, ...);
+      // the chip row is gone.
+      expect(find.byType(ChoiceChip), findsNothing);
+      expect(find.text('Featured Player'), findsNothing);
+      expect(find.text('Play media from your saved playlist.'), findsNothing);
+      expect(find.text('Select a channel to start watching'), findsNothing);
+      expect(
+        find.text('Choose a channel from your playlist to begin streaming.'),
+        findsNothing,
+      );
 
-    await tester.drag(find.byType(CustomScrollView), const Offset(0, -320));
-    await tester.pumpAndSettle();
+      await tester.drag(find.byType(CustomScrollView), const Offset(0, -320));
+      await tester.pumpAndSettle();
 
-    // The old flat "Playlist Channels" list panel is replaced by the
-    // unified, rail-based BrowseScreen (Task 6): rails from the default
-    // catalog render the matching channels as MediaCards. Only the first
-    // rail is guaranteed to be mounted without further scrolling the
-    // BrowseScreen's own (nested) list.
-    expect(find.text('Top India'), findsOneWidget);
-    expect(find.text('City News Live'), findsWidgets);
+      // The old flat "Playlist Channels" list panel is replaced by the
+      // unified, rail-based BrowseScreen (Task 6): rails from the default
+      // catalog render the matching channels as MediaCards. Only the first
+      // rail is guaranteed to be mounted without further scrolling the
+      // BrowseScreen's own (nested) list.
+      expect(find.text('Top India'), findsOneWidget);
+      expect(find.text('City News Live'), findsWidgets);
+    } finally {
+      debugDefaultTargetPlatformOverride = null;
+    }
+  });
+
+  testWidgets('hides Cast action on macOS', (tester) async {
+    debugDefaultTargetPlatformOverride = TargetPlatform.macOS;
+    try {
+      await tester.pumpWidget(createWidget());
+      await tester.pumpAndSettle();
+
+      expect(find.text('Airo TV'), findsOneWidget);
+      expect(find.byTooltip('Cast'), findsNothing);
+    } finally {
+      debugDefaultTargetPlatformOverride = null;
+    }
   });
 
   testWidgets('shows only the video surface while Android PiP is active', (

--- a/packages/platform_player/lib/platform_player.dart
+++ b/packages/platform_player/lib/platform_player.dart
@@ -19,6 +19,7 @@ export "src/services/fake_playback_engine.dart";
 export "src/services/flutter_chrome_cast_controller.dart";
 export "src/services/iptv_streaming_service.dart";
 export "src/services/iptv_cast_media_adapter.dart";
+export "src/services/google_cast_platform_support.dart";
 export "src/services/native_fullscreen.dart";
 export "src/services/native_picture_in_picture.dart";
 export "src/services/phone_media_cast_handoff.dart";

--- a/packages/platform_player/lib/src/services/google_cast_platform_support.dart
+++ b/packages/platform_player/lib/src/services/google_cast_platform_support.dart
@@ -1,0 +1,10 @@
+import 'package:flutter/foundation.dart';
+
+/// Google Cast sender support currently ships through the Android/iOS sender
+/// SDK bridge. Desktop support needs a deliberate native sender, AirPlay, or
+/// custom receiver design instead of reusing the mobile controller.
+bool get isGoogleCastSenderPlatform {
+  if (kIsWeb) return false;
+  return defaultTargetPlatform == TargetPlatform.android ||
+      defaultTargetPlatform == TargetPlatform.iOS;
+}


### PR DESCRIPTION
# Summary

This PR fixes the macOS Cast architecture gap shown by the desktop app exposing the mobile Cast picker even though the current Google Cast sender implementation is Android/iOS-only.

Core outcome:

* macOS no longer wires the real Google Cast sender controller.
* macOS no longer shows the Cast toolbar action in `IPTVScreen`.
* Android/iOS sender behavior remains enabled.
* The architecture/process gap is recorded in a due-diligence audit.

# Changes

### Code

* Added `isGoogleCastSenderPlatform` in `platform_player` as the single platform support predicate for Google Cast sender behavior.
* Updated app-level IPTV Cast provider override to use the real `FlutterChromeCastController` only on Android/iOS.
* Updated `IPTVScreen` to hide the Cast action on unsupported platforms.

### Tests

* Added regression coverage that Android wires a real Cast controller.
* Added regression coverage that macOS wires `UnavailableAiroCastController`.
* Added feature UI coverage that macOS hides the Cast action.

### Documentation

* Added `docs/superpowers/audits/2026-07-22-macos-cast-architecture-gap.md` with the architecture finding and process correction.

# Architecture finding

The previous process validated Pixel/iPad fixes against Android/iOS sender flows, but the macOS build path had no executable guard for the release contract that Cast-only mobile behavior must be hidden or no-op on macOS. The vendored `flutter_chrome_cast` plugin declares Android/iOS platforms only, and the runtime controller already rejects non-Android/iOS platforms. The gap was app/feature wiring exposing that capability anyway.

# Testing

* `flutter test test/main_tv_cast_override_test.dart` in `app`
* `flutter test test/iptv/presentation/screens/iptv_screen_test.dart` in `packages/feature_iptv`
* `flutter analyze lib/features/iptv/iptv_cast_provider_override.dart test/main_tv_cast_override_test.dart` in `app`
* `flutter analyze lib/presentation/screens/iptv_screen.dart test/iptv/presentation/screens/iptv_screen_test.dart` in `packages/feature_iptv`
* `flutter analyze lib/src/services/google_cast_platform_support.dart lib/platform_player.dart` in `packages/platform_player`
* `git diff --check`

# Notes

This does not add macOS Google Cast sender support. It makes the current product truth explicit: Google Cast sender is Android/iOS-only until a deliberate macOS sender, AirPlay, or custom receiver design is approved.
