### PR TITLE
fix(tv): render playback settings extensions

### DIFF
--- a/app/lib/features/settings/presentation/tv/tv_playback_section.dart
+++ b/app/lib/features/settings/presentation/tv/tv_playback_section.dart
@@ -12,47 +12,30 @@ class TvPlaybackSection extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final current = ref.watch(videoAspectRatioProvider);
+    final extraSections = ref.watch(playbackSettingsExtraSectionsProvider);
     final colorScheme = Theme.of(context).colorScheme;
 
-    return ListView.separated(
-      itemCount: AiroPlaybackViewFit.values.length,
-      separatorBuilder: (_, _) => const SizedBox(height: 8),
-      itemBuilder: (context, index) {
-        final fit = AiroPlaybackViewFit.values[index];
-        final label = _labelFor(fit);
-        final isSelected = fit == current;
-        return TvFocusable(
-          autofocus: index == 0,
-          onSelect: () =>
-              ref.read(videoAspectRatioProvider.notifier).setAspectRatio(fit),
-          semanticLabel: label,
-          semanticButton: true,
-          child: DecoratedBox(
-            decoration: BoxDecoration(
-              color: isSelected
-                  ? colorScheme.primaryContainer
-                  : colorScheme.surfaceContainerHighest.withValues(alpha: 0.4),
-              borderRadius: BorderRadius.circular(8),
+    return ListView(
+      children: [
+        for (var index = 0; index < AiroPlaybackViewFit.values.length; index++)
+          Padding(
+            padding: EdgeInsets.only(
+              bottom: index == AiroPlaybackViewFit.values.length - 1 ? 0 : 8,
             ),
-            child: Padding(
-              padding: const EdgeInsets.all(16),
-              child: Row(
-                children: [
-                  Text(
-                    label,
-                    style: TextStyle(
-                      color: colorScheme.onSurface,
-                      fontSize: 16,
-                    ),
-                  ),
-                  const Spacer(),
-                  if (isSelected) Icon(Icons.check, color: colorScheme.primary),
-                ],
-              ),
+            child: _AspectRatioOption(
+              fit: AiroPlaybackViewFit.values[index],
+              isSelected: AiroPlaybackViewFit.values[index] == current,
+              autofocus: index == 0,
+              onSelect: () => ref
+                  .read(videoAspectRatioProvider.notifier)
+                  .setAspectRatio(AiroPlaybackViewFit.values[index]),
+              labelFor: _labelFor,
+              colorScheme: colorScheme,
             ),
           ),
-        );
-      },
+        if (extraSections.isNotEmpty) const SizedBox(height: 24),
+        ...extraSections,
+      ],
     );
   }
 
@@ -65,5 +48,56 @@ class TvPlaybackSection extends ConsumerWidget {
       AiroPlaybackViewFit.fill => 'Fill width',
       AiroPlaybackViewFit.stretch => 'Stretch to fill',
     };
+  }
+}
+
+class _AspectRatioOption extends StatelessWidget {
+  const _AspectRatioOption({
+    required this.fit,
+    required this.isSelected,
+    required this.autofocus,
+    required this.onSelect,
+    required this.labelFor,
+    required this.colorScheme,
+  });
+
+  final AiroPlaybackViewFit fit;
+  final bool isSelected;
+  final bool autofocus;
+  final VoidCallback onSelect;
+  final String Function(AiroPlaybackViewFit fit) labelFor;
+  final ColorScheme colorScheme;
+
+  @override
+  Widget build(BuildContext context) {
+    final label = labelFor(fit);
+
+    return TvFocusable(
+      autofocus: autofocus,
+      onSelect: onSelect,
+      semanticLabel: label,
+      semanticButton: true,
+      child: DecoratedBox(
+        decoration: BoxDecoration(
+          color: isSelected
+              ? colorScheme.primaryContainer
+              : colorScheme.surfaceContainerHighest.withValues(alpha: 0.4),
+          borderRadius: BorderRadius.circular(8),
+        ),
+        child: Padding(
+          padding: const EdgeInsets.all(16),
+          child: Row(
+            children: [
+              Text(
+                label,
+                style: TextStyle(color: colorScheme.onSurface, fontSize: 16),
+              ),
+              const Spacer(),
+              if (isSelected) Icon(Icons.check, color: colorScheme.primary),
+            ],
+          ),
+        ),
+      ),
+    );
   }
 }

--- a/app/test/features/settings/presentation/tv/tv_playback_section_test.dart
+++ b/app/test/features/settings/presentation/tv/tv_playback_section_test.dart
@@ -2,6 +2,7 @@ import 'package:airo_app/features/settings/presentation/tv/tv_playback_section.d
 import 'package:feature_iptv/feature_iptv.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_riverpod/misc.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
@@ -10,10 +11,15 @@ void main() {
     SharedPreferences.setMockInitialValues({});
   });
 
-  Future<ProviderContainer> buildContainer() async {
+  Future<ProviderContainer> buildContainer({
+    List<Override> extraOverrides = const [],
+  }) async {
     final prefs = await SharedPreferences.getInstance();
     return ProviderContainer(
-      overrides: [sharedPreferencesProvider.overrideWithValue(prefs)],
+      overrides: [
+        sharedPreferencesProvider.overrideWithValue(prefs),
+        ...extraOverrides,
+      ],
     );
   }
 
@@ -58,5 +64,27 @@ void main() {
     await tester.pump();
 
     expect(container.read(videoAspectRatioProvider), AiroPlaybackViewFit.cover);
+  });
+
+  testWidgets('renders playback settings extension sections', (tester) async {
+    final container = await buildContainer(
+      extraOverrides: [
+        playbackSettingsExtraSectionsProvider.overrideWithValue(const [
+          ListTile(title: Text('Injected playback setting')),
+        ]),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: const MaterialApp(home: Scaffold(body: TvPlaybackSection())),
+      ),
+    );
+    await tester.pump();
+
+    expect(find.text('Injected playback setting'), findsOneWidget);
+    expect(find.text('Fit (letterboxed)'), findsOneWidget);
   });
 }


### PR DESCRIPTION
## Summary

This PR wires the current modular TV playback settings pane to the existing playback settings extension provider. Goal: let reusable/plugin overlays inject playback controls, such as Airo Pro Picture-in-Picture, without editing app-owned settings code in overlay repositories.

Core outcome:

* TV playback settings render `playbackSettingsExtraSectionsProvider` after the public aspect-ratio controls.
* The mobile playback settings screen already had this seam; this brings the TV pane into parity.
* Focused widget coverage verifies injected sections render in the TV pane.

## Changes

### Code

* Updated:
  * `app/lib/features/settings/presentation/tv/tv_playback_section.dart` renders extension sections below the TV aspect-ratio choices.
  * `app/test/features/settings/presentation/tv/tv_playback_section_test.dart` adds extension rendering coverage.

### Logic

* Public playback controls remain app-owned.
* Plugin/pro playback controls remain injected through the existing feature package provider seam.

## Database Changes

None.

## Performance Impact

No meaningful impact. The provider defaults to an empty list in the public app.

## Risks

* Low: only the TV playback settings pane changes, and the default public provider renders no extra controls.
* Rollback plan: revert this PR; overlay playback controls will again be invisible in the TV pane.

## Testing

* `app`: `flutter analyze lib/features/settings/presentation/tv/tv_playback_section.dart test/features/settings/presentation/tv/tv_playback_section_test.dart`
* `app`: `flutter test test/features/settings/presentation/tv/tv_playback_section_test.dart`
* `git diff --check`

## Deployment Notes

No config or migration steps. Commit includes `[skip ci]` per local-validation/cost-control policy.

## Notes

This is the upstream/public half required before syncing the Pro PiP settings visibility fix back into `airo-pro`.
