### PR TITLE
perf(tv): adapt channel warmup for release

### DIFF
--- a/packages/feature_iptv/lib/application/channel_warmup_policy.dart
+++ b/packages/feature_iptv/lib/application/channel_warmup_policy.dart
@@ -1,0 +1,142 @@
+import 'dart:math' as math;
+
+import 'package:platform_channels/platform_channels.dart';
+import 'package:platform_player/platform_player.dart';
+
+class ChannelWarmupPlan {
+  const ChannelWarmupPlan({
+    required this.limit,
+    required this.maxConcurrentRequests,
+    required this.debounce,
+  });
+
+  final int limit;
+  final int maxConcurrentRequests;
+  final Duration debounce;
+
+  bool get isEmpty => limit <= 0;
+}
+
+/// Chooses a bounded stream-health warmup size for the current interaction.
+///
+/// The plan is conservative while playback is loading or buffering because
+/// probes share network capacity with the player open. As cache coverage
+/// improves, the app can safely test a wider lookahead window because most
+/// rows are served from memory and fewer network probes are needed.
+ChannelWarmupPlan planChannelWarmup({
+  required int totalChannelCount,
+  required int candidateCount,
+  required int cachedChannelCount,
+  required PlaybackState playbackState,
+  bool interactionCritical = false,
+}) {
+  if (totalChannelCount <= 0 || candidateCount <= 0) {
+    return const ChannelWarmupPlan(
+      limit: 0,
+      maxConcurrentRequests: 1,
+      debounce: Duration(milliseconds: 350),
+    );
+  }
+
+  final coverage = (cachedChannelCount / totalChannelCount).clamp(0.0, 1.0);
+  final isPlaybackBusy =
+      playbackState == PlaybackState.loading ||
+      playbackState == PlaybackState.buffering;
+  final isPlaying = playbackState == PlaybackState.playing;
+
+  if (interactionCritical) {
+    final cap = isPlaybackBusy
+        ? 10
+        : coverage < 0.25
+        ? 14
+        : coverage < 0.75
+        ? 20
+        : 28;
+    return ChannelWarmupPlan(
+      limit: _boundedLimit(candidateCount, totalChannelCount, cap),
+      maxConcurrentRequests: 1,
+      debounce: Duration(milliseconds: isPlaybackBusy ? 450 : 180),
+    );
+  }
+
+  if (totalChannelCount <= 60) {
+    return ChannelWarmupPlan(
+      limit: _boundedLimit(
+        candidateCount,
+        totalChannelCount,
+        totalChannelCount,
+      ),
+      maxConcurrentRequests: isPlaying || isPlaybackBusy ? 1 : 3,
+      debounce: const Duration(milliseconds: 220),
+    );
+  }
+
+  if (isPlaybackBusy) {
+    return ChannelWarmupPlan(
+      limit: _boundedLimit(candidateCount, totalChannelCount, 18),
+      maxConcurrentRequests: 1,
+      debounce: const Duration(milliseconds: 450),
+    );
+  }
+
+  if (isPlaying) {
+    final cap = coverage < 0.25
+        ? 30
+        : coverage < 0.75
+        ? 42
+        : 60;
+    return ChannelWarmupPlan(
+      limit: _boundedLimit(candidateCount, totalChannelCount, cap),
+      maxConcurrentRequests: coverage >= 0.75 ? 2 : 1,
+      debounce: const Duration(milliseconds: 300),
+    );
+  }
+
+  final cap = coverage < 0.25
+      ? 48
+      : coverage < 0.75
+      ? 72
+      : 96;
+  return ChannelWarmupPlan(
+    limit: _boundedLimit(candidateCount, totalChannelCount, cap),
+    maxConcurrentRequests: 3,
+    debounce: const Duration(milliseconds: 220),
+  );
+}
+
+List<IPTVChannel> channelWarmupWindowAround({
+  required IPTVChannel? currentChannel,
+  required List<IPTVChannel> channels,
+  int lookBehind = 4,
+  int lookAhead = 12,
+}) {
+  if (currentChannel == null || channels.isEmpty) return const [];
+  final currentIndex = channels.indexWhere(
+    (channel) => channel.streamUrl == currentChannel.streamUrl,
+  );
+  if (currentIndex < 0) return const [];
+
+  final result = <IPTVChannel>[];
+  final seen = <String>{};
+
+  void addIndex(int index) {
+    final channel = channels[(index + channels.length) % channels.length];
+    if (seen.add(channel.id)) result.add(channel);
+  }
+
+  addIndex(currentIndex);
+  final distance = math.max(lookAhead, lookBehind);
+  for (var offset = 1; offset <= distance; offset++) {
+    if (offset <= lookAhead) addIndex(currentIndex + offset);
+    if (offset <= lookBehind) addIndex(currentIndex - offset);
+    if (seen.length >= channels.length) break;
+  }
+  return result;
+}
+
+int _boundedLimit(int candidateCount, int totalChannelCount, int cap) {
+  return math.max(
+    0,
+    math.min(math.min(candidateCount, totalChannelCount), cap),
+  );
+}

--- a/packages/feature_iptv/lib/presentation/tv_ux/airo_tv_shell.dart
+++ b/packages/feature_iptv/lib/presentation/tv_ux/airo_tv_shell.dart
@@ -11,6 +11,7 @@ import '../../application/providers/channel_auto_scan_providers.dart';
 import '../../application/providers/hotbar_channels_provider.dart';
 import '../../application/providers/iptv_providers.dart';
 import '../../application/channel_metadata_enrichment.dart';
+import '../../application/channel_warmup_policy.dart';
 import 'sections/channel_info_bar.dart';
 import 'sections/channel_table.dart';
 import 'sections/filter_dialogs.dart';
@@ -223,21 +224,27 @@ class _AiroTvShellState extends ConsumerState<AiroTvShell> {
   }
 
   void _scheduleVisibleChannelScan(List<IPTVChannel> channels) {
-    final visible = channels.take(42).toList(growable: false);
+    final autoScanState = ref.read(channelAutoScanProvider);
+    final plan = planChannelWarmup(
+      totalChannelCount: ref.read(filteredChannelsProvider).length,
+      candidateCount: channels.length,
+      cachedChannelCount: autoScanState.availabilityByChannelId.length,
+      playbackState: ref.read(playbackStateProvider),
+    );
+    if (plan.isEmpty) return;
+    final visible = channels.take(plan.limit).toList(growable: false);
     final signature = visible.map((channel) => channel.id).join(',');
     if (signature.isEmpty || signature == _visibleScanSignature) return;
     _visibleScanSignature = signature;
     _visibleScanDebounce?.cancel();
-    _visibleScanDebounce = Timer(const Duration(milliseconds: 350), () {
+    _visibleScanDebounce = Timer(plan.debounce, () {
       if (!mounted) return;
       ref
           .read(channelAutoScanProvider.notifier)
           .start(
             scopeId: 'airo-tv-visible|$signature',
             channels: visible,
-            maxConcurrentRequests: ref.read(
-              channelAutoScanMaxConcurrentRequestsProvider,
-            ),
+            maxConcurrentRequests: plan.maxConcurrentRequests,
             currentPlayingChannelId: ref
                 .read(iptvStreamingServiceProvider)
                 .currentState

--- a/packages/feature_iptv/lib/presentation/widgets/video_player_widget.dart
+++ b/packages/feature_iptv/lib/presentation/widgets/video_player_widget.dart
@@ -6,6 +6,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:platform_channels/platform_channels.dart';
 import '../../application/player_backgrounding_coordinator.dart';
+import '../../application/channel_warmup_policy.dart';
 import '../../application/providers/caption_preference_provider.dart';
 import '../../application/providers/channel_auto_scan_providers.dart';
 import '../../application/providers/iptv_providers.dart';
@@ -75,6 +76,8 @@ class _VideoPlayerWidgetState extends ConsumerState<VideoPlayerWidget> {
   // Channel change overlay state
   String? _channelChangeOverlayText;
   Timer? _channelChangeOverlayTimer;
+  Timer? _adjacentChannelWarmupDebounce;
+  String _adjacentChannelWarmupSignature = '';
 
   // Netflix-style gesture controls (CV-PLAYER-GESTURES) + lock button.
   bool _isLocked = false;
@@ -121,6 +124,7 @@ class _VideoPlayerWidgetState extends ConsumerState<VideoPlayerWidget> {
   void dispose() {
     _cancelHideControlsTimer();
     _channelChangeOverlayTimer?.cancel();
+    _adjacentChannelWarmupDebounce?.cancel();
     unawaited(_resetBrightnessSafely());
     super.dispose();
   }
@@ -245,6 +249,7 @@ class _VideoPlayerWidgetState extends ConsumerState<VideoPlayerWidget> {
     if (nextChannel != null) {
       streamingService.playChannel(nextChannel);
       _showChannelChangeOverlay(nextChannel.name);
+      _scheduleAdjacentChannelWarmupFor(nextChannel);
     }
   }
 
@@ -254,7 +259,57 @@ class _VideoPlayerWidgetState extends ConsumerState<VideoPlayerWidget> {
     if (prevChannel != null) {
       streamingService.playChannel(prevChannel);
       _showChannelChangeOverlay(prevChannel.name);
+      _scheduleAdjacentChannelWarmupFor(prevChannel);
     }
+  }
+
+  void _scheduleAdjacentChannelWarmup(StreamingState state) {
+    final currentChannel = state.currentChannel;
+    if (currentChannel == null) return;
+    _scheduleAdjacentChannelWarmupFor(currentChannel);
+  }
+
+  void _scheduleAdjacentChannelWarmupFor(IPTVChannel currentChannel) {
+    final channels = ref.read(filteredChannelsProvider);
+    if (channels.isEmpty) return;
+    final candidates = channelWarmupWindowAround(
+      currentChannel: currentChannel,
+      channels: channels,
+    );
+    if (candidates.isEmpty) return;
+
+    final autoScanState = ref.read(channelAutoScanProvider);
+    final plan = planChannelWarmup(
+      totalChannelCount: channels.length,
+      candidateCount: candidates.length,
+      cachedChannelCount: autoScanState.availabilityByChannelId.length,
+      playbackState: ref.read(playbackStateProvider),
+      interactionCritical: true,
+    );
+    if (plan.isEmpty) return;
+
+    final warmupChannels = candidates.take(plan.limit).toList(growable: false);
+    final signature = warmupChannels.map((channel) => channel.id).join(',');
+    if (signature.isEmpty || signature == _adjacentChannelWarmupSignature) {
+      return;
+    }
+    _adjacentChannelWarmupSignature = signature;
+    _adjacentChannelWarmupDebounce?.cancel();
+    _adjacentChannelWarmupDebounce = Timer(plan.debounce, () {
+      if (!mounted) return;
+      ref
+          .read(channelAutoScanProvider.notifier)
+          .start(
+            scopeId: 'airo-tv-player-nearby|$signature',
+            channels: warmupChannels,
+            maxConcurrentRequests: plan.maxConcurrentRequests,
+            currentPlayingChannelId: ref
+                .read(iptvStreamingServiceProvider)
+                .currentState
+                .currentChannel
+                ?.id,
+          );
+    });
   }
 
   void _seekBackward10(
@@ -348,6 +403,7 @@ class _VideoPlayerWidgetState extends ConsumerState<VideoPlayerWidget> {
     WidgetsBinding.instance.addPostFrameCallback((_) {
       _handleVodResume(service, state);
       _applyCaptionPreferenceIfNeeded(service, state);
+      _scheduleAdjacentChannelWarmup(state);
     });
 
     final videoView = service.buildVideoView();
@@ -773,18 +829,18 @@ class _VideoPlayerWidgetState extends ConsumerState<VideoPlayerWidget> {
             child: Row(
               mainAxisSize: MainAxisSize.min,
               children: [
-                if (!_isFullscreen) ...[
-                  _PlayerRoundControlButton(
-                    key: const ValueKey('iptv-player-fullscreen-button'),
-                    icon: Icons.fullscreen,
-                    tooltip: 'Fullscreen',
-                    onPressed: _toggleFullscreen,
-                    diameter: 44,
-                    iconSize: 24,
-                    backgroundAlpha: 0.48,
-                  ),
-                  const SizedBox(width: 10),
-                ],
+                _PlayerRoundControlButton(
+                  key: const ValueKey('iptv-player-fullscreen-button'),
+                  icon: _isFullscreen
+                      ? Icons.fullscreen_exit
+                      : Icons.fullscreen,
+                  tooltip: _isFullscreen ? 'Exit fullscreen' : 'Fullscreen',
+                  onPressed: _toggleFullscreen,
+                  diameter: 44,
+                  iconSize: 24,
+                  backgroundAlpha: 0.48,
+                ),
+                const SizedBox(width: 10),
                 _PlayerRoundControlButton(
                   key: const ValueKey('iptv-player-pip-button'),
                   icon: Icons.picture_in_picture_alt_outlined,

--- a/packages/feature_iptv/test/iptv/application/channel_warmup_policy_test.dart
+++ b/packages/feature_iptv/test/iptv/application/channel_warmup_policy_test.dart
@@ -1,0 +1,67 @@
+import 'package:feature_iptv/application/channel_warmup_policy.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:platform_channels/platform_channels.dart';
+import 'package:platform_player/platform_player.dart';
+
+void main() {
+  test('keeps interaction-critical warmup small while playback is busy', () {
+    final plan = planChannelWarmup(
+      totalChannelCount: 5000,
+      candidateCount: 80,
+      cachedChannelCount: 0,
+      playbackState: PlaybackState.loading,
+      interactionCritical: true,
+    );
+
+    expect(plan.limit, 10);
+    expect(plan.maxConcurrentRequests, 1);
+    expect(plan.debounce, const Duration(milliseconds: 450));
+  });
+
+  test('widens browse warmup as stream-health cache coverage improves', () {
+    final cold = planChannelWarmup(
+      totalChannelCount: 5000,
+      candidateCount: 100,
+      cachedChannelCount: 0,
+      playbackState: PlaybackState.playing,
+    );
+    final warm = planChannelWarmup(
+      totalChannelCount: 5000,
+      candidateCount: 100,
+      cachedChannelCount: 4000,
+      playbackState: PlaybackState.playing,
+    );
+
+    expect(cold.limit, 30);
+    expect(cold.maxConcurrentRequests, 1);
+    expect(warm.limit, 60);
+    expect(warm.maxConcurrentRequests, 2);
+  });
+
+  test('builds a deduped nearby channel window around the current channel', () {
+    final channels = List<IPTVChannel>.generate(
+      6,
+      (index) => IPTVChannel(
+        id: 'channel-$index',
+        name: 'Channel $index',
+        streamUrl: 'https://example.com/$index.m3u8',
+      ),
+    );
+
+    final window = channelWarmupWindowAround(
+      currentChannel: channels[2],
+      channels: channels,
+      lookBehind: 2,
+      lookAhead: 3,
+    );
+
+    expect(window.map((channel) => channel.id), [
+      'channel-2',
+      'channel-3',
+      'channel-1',
+      'channel-4',
+      'channel-0',
+      'channel-5',
+    ]);
+  });
+}

--- a/packages/feature_iptv/test/iptv/presentation/widgets/video_player_widget_test.dart
+++ b/packages/feature_iptv/test/iptv/presentation/widgets/video_player_widget_test.dart
@@ -7,6 +7,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:platform_channels/platform_channels.dart';
+import 'package:platform_streams/platform_streams.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 void main() {
@@ -31,6 +32,9 @@ void main() {
       ProviderScope(
         overrides: [
           sharedPreferencesProvider.overrideWithValue(prefs),
+          streamProbeTransportProvider.overrideWithValue(
+            _AlwaysAvailableProbeTransport(),
+          ),
           if (channels != null)
             iptvChannelsProvider.overrideWith((ref) async => channels),
           streamingStateProvider.overrideWith(
@@ -97,6 +101,9 @@ void main() {
         overrides: [
           sharedPreferencesProvider.overrideWithValue(prefs),
           iptvStreamingServiceProvider.overrideWithValue(service),
+          streamProbeTransportProvider.overrideWithValue(
+            _AlwaysAvailableProbeTransport(),
+          ),
           iptvChannelsProvider.overrideWith(
             (ref) async => const [current, next],
           ),
@@ -243,8 +250,9 @@ void main() {
     );
     expect(
       find.byKey(const ValueKey('iptv-player-fullscreen-button')),
-      findsNothing,
+      findsOneWidget,
     );
+    expect(find.byIcon(Icons.fullscreen_exit), findsOneWidget);
     expect(
       find.byKey(const ValueKey('iptv-player-more-button')),
       findsOneWidget,
@@ -654,6 +662,9 @@ void main() {
         overrides: [
           sharedPreferencesProvider.overrideWithValue(prefs),
           iptvStreamingServiceProvider.overrideWithValue(service),
+          streamProbeTransportProvider.overrideWithValue(
+            _AlwaysAvailableProbeTransport(),
+          ),
           iptvChannelsProvider.overrideWith(
             (ref) async => const [current, next],
           ),
@@ -1019,5 +1030,15 @@ class _RecordingSeekStreamingService extends VideoPlayerStreamingService {
   @override
   Future<void> seek(Duration position) async {
     seekedPositions.add(position);
+  }
+}
+
+class _AlwaysAvailableProbeTransport implements StreamProbeTransport {
+  @override
+  Future<StreamProbeHttpResponse> get(
+    StreamProbeRequest request, {
+    required StreamProbeCancellation cancellation,
+  }) async {
+    return const StreamProbeHttpResponse(statusCode: 206);
   }
 }


### PR DESCRIPTION
# Summary

This PR carries the remaining post-#1059 Airo TV warmup change onto the current main base.

Goal: keep Android TV/mobile channel switching responsive without reverting newer main-branch Rust playlist work.

Core outcome:

* Adds adaptive channel warmup sizing based on playback/browse state and cache coverage.
* Keeps fullscreen/channel switching controls stable while nearby channels are warmed.

# Changes

### Code

* Added:
  * Channel warmup policy and focused tests.
* Updated:
  * Airo TV shell warmup scheduling.
  * Video player switch path to warm nearby channels without blocking playback.

# Performance Impact

* Latency: expected decrease for nearby channel switching after warmup coverage improves.
* Throughput: bounded warmup windows avoid scanning too many channels while playback is active.
* Memory/CPU: adaptive limits keep active playback warmup smaller than browse warmup.

# Testing

* flutter test test/iptv/application/channel_warmup_policy_test.dart from packages/feature_iptv — passed.
* flutter test test/iptv/presentation/widgets/video_player_widget_test.dart from packages/feature_iptv — passed.
* git diff --check origin/main..HEAD — passed.
* flutter build apk --debug -t lib/main_tv.dart --dart-define=APP_VARIANT=tv --dart-define=APP_PLATFORM=androidTv from app — passed.

# Notes

* This branch was recreated from current origin/main to avoid carrying stale pre-merge branch ancestry or reverting newer Rust playlist changes.