### PR TITLE
chore(release): prepare Airo TV v0.0.5

### DIFF
--- a/.github/workflows/airo-macos-release.yml
+++ b/.github/workflows/airo-macos-release.yml
@@ -50,15 +50,15 @@ on:
       version:
         description: 'Artifact and release version label'
         required: true
-        default: airo-tv-v0.0.2
+        default: airo-tv-v0.0.5
       build_name:
-        description: 'Flutter build name, for example 0.0.2'
+        description: 'Flutter build name, for example 0.0.5'
         required: true
-        default: 0.0.2
+        default: 0.0.5
       build_number:
         description: 'Flutter build number'
         required: true
-        default: '2'
+        default: '5'
       release_ref:
         description: 'Git ref to release; must contain latest origin/main'
         required: true
@@ -66,7 +66,7 @@ on:
       release_branch:
         description: 'Release branch to create/update from release_ref before building'
         required: true
-        default: release/airo-tv-v0.0.2
+        default: release/airo-tv-v0.0.5
       require_notarization:
         description: 'Fail unless Developer ID signing and notarization succeed'
         required: true
@@ -82,9 +82,9 @@ permissions:
 
 env:
   FLUTTER_VERSION: '3.44.4'
-  RELEASE_VERSION: ${{ inputs.version || github.event.inputs.version || github.ref_name || 'airo-tv-v0.0.2' }}
-  BUILD_NAME: ${{ inputs.build_name || github.event.inputs.build_name || '0.0.2' }}
-  BUILD_NUMBER: ${{ inputs.build_number || github.event.inputs.build_number || '2' }}
+  RELEASE_VERSION: ${{ inputs.version || github.event.inputs.version || github.ref_name || 'airo-tv-v0.0.5' }}
+  BUILD_NAME: ${{ inputs.build_name || github.event.inputs.build_name || '0.0.5' }}
+  BUILD_NUMBER: ${{ inputs.build_number || github.event.inputs.build_number || '5' }}
   PROFILE: ${{ inputs.profile || github.event.inputs.profile || 'tv' }}
 
 jobs:

--- a/.github/workflows/airo-mobile-tablet-release.yml
+++ b/.github/workflows/airo-mobile-tablet-release.yml
@@ -65,15 +65,15 @@ on:
       version:
         description: 'Artifact and release version label'
         required: true
-        default: v2.0.0
+        default: v0.0.5
       build_name:
-        description: 'Android versionName, for example 2.0.0'
+        description: 'Android versionName, for example 0.0.5'
         required: true
-        default: 2.0.0
+        default: 0.0.5
       build_number:
         description: 'Android versionCode, must increase for every Play upload'
         required: true
-        default: '200'
+        default: '7'
       release_ref:
         description: 'Git ref to release; must contain latest origin/main'
         required: true
@@ -121,8 +121,8 @@ permissions:
 env:
   FLUTTER_VERSION: '3.44.4'
   RELEASE_VERSION: ${{ inputs.version || github.event.inputs.version || github.ref_name }}
-  BUILD_NAME: ${{ inputs.build_name || github.event.inputs.build_name || '2.0.0' }}
-  BUILD_NUMBER: ${{ inputs.build_number || github.event.inputs.build_number || '200' }}
+  BUILD_NAME: ${{ inputs.build_name || github.event.inputs.build_name || '0.0.5' }}
+  BUILD_NUMBER: ${{ inputs.build_number || github.event.inputs.build_number || '7' }}
   PROFILE: ${{ inputs.profile || github.event.inputs.profile || 'full' }}
 
 jobs:

--- a/.github/workflows/airo-tv-release.yml
+++ b/.github/workflows/airo-tv-release.yml
@@ -18,7 +18,7 @@ on:
         required: true
         type: string
       build_name:
-        description: 'Android versionName, for example 0.0.2'
+        description: 'Android versionName, for example 0.0.5'
         required: true
         type: string
       build_number:
@@ -26,7 +26,7 @@ on:
         required: true
         type: string
       release_ref:
-        description: 'Git ref to cut the release from; use v2 for Airo TV release line'
+        description: 'Git ref to cut the release from; use main for the active Airo TV release line'
         required: true
         type: string
       release_branch:
@@ -58,14 +58,14 @@ on:
         required: false
         type: string
   pull_request:
-    branches: [ v2 ]
+    branches: [ main ]
     paths:
       - 'app/**'
       - 'packages/**'
       - 'scripts/**'
       - '.github/workflows/airo-tv-release.yml'
   push:
-    branches: [ v2 ]
+    branches: [ main ]
     paths:
       - 'app/**'
       - 'packages/**'
@@ -76,23 +76,23 @@ on:
       version:
         description: 'Airo TV artifact and release version label'
         required: true
-        default: 'airo-tv-v0.0.2'
+        default: 'airo-tv-v0.0.5'
       build_name:
-        description: 'Android versionName, for example 0.0.2'
+        description: 'Android versionName, for example 0.0.5'
         required: true
-        default: '0.0.2'
+        default: '0.0.5'
       build_number:
         description: 'Android versionCode, must increase for every Play upload'
         required: true
-        default: '2'
+        default: '5'
       release_ref:
-        description: 'Git ref to cut the release from; use v2 for Airo TV release line'
+        description: 'Git ref to cut the release from; use main for the active Airo TV release line'
         required: true
-        default: 'v2'
+        default: 'main'
       release_branch:
         description: 'Release branch to create/update from release_ref before building'
         required: true
-        default: 'release/airo-tv-v0.0.2'
+        default: 'release/airo-tv-v0.0.5'
       publish_github_release:
         description: 'Create/update the GitHub release and attach artifacts'
         required: true
@@ -141,12 +141,12 @@ permissions:
 env:
   FLUTTER_VERSION: '3.44.4'
   RELEASE_VERSION: ${{ inputs.version || github.event.inputs.version || github.ref_name }}
-  BUILD_NAME: ${{ inputs.build_name || github.event.inputs.build_name || '0.0.2' }}
-  BUILD_NUMBER: ${{ inputs.build_number || github.event.inputs.build_number || '2' }}
+  BUILD_NAME: ${{ inputs.build_name || github.event.inputs.build_name || '0.0.5' }}
+  BUILD_NUMBER: ${{ inputs.build_number || github.event.inputs.build_number || '5' }}
 
 jobs:
   prepare-release-branch:
-    name: Cut release branch from v2
+    name: Cut release branch from main
     runs-on: ubuntu-latest
     outputs:
       release_ref: ${{ steps.release_ref.outputs.ref || steps.current_ref.outputs.ref }}
@@ -165,8 +165,8 @@ jobs:
         id: release_ref
         if: github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_call'
         env:
-          RELEASE_BRANCH: ${{ inputs.release_branch || github.event.inputs.release_branch || 'release/airo-tv-v0.0.2' }}
-          RELEASE_REF: ${{ inputs.release_ref || github.event.inputs.release_ref || 'v2' }}
+          RELEASE_BRANCH: ${{ inputs.release_branch || github.event.inputs.release_branch || 'release/airo-tv-v0.0.5' }}
+          RELEASE_REF: ${{ inputs.release_ref || github.event.inputs.release_ref || 'main' }}
         run: |
           git fetch origin main
           if [ "$RELEASE_REF" != "main" ]; then
@@ -783,7 +783,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           RELEASE_VERSION: ${{ env.RELEASE_VERSION }}
-          RELEASE_BRANCH: ${{ needs.prepare-release-branch.outputs.release_ref || inputs.release_branch || github.event.inputs.release_branch || 'release/airo-tv-v0.0.2' }}
+          RELEASE_BRANCH: ${{ needs.prepare-release-branch.outputs.release_ref || inputs.release_branch || github.event.inputs.release_branch || 'release/airo-tv-v0.0.5' }}
           SIGNING_CERT: ${{ needs.build-tv.outputs.signing_cert }}
         run: |
           case "$SIGNING_CERT" in
@@ -798,27 +798,26 @@ jobs:
           cat > "$notes" <<NOTES
           # Airo TV ${BUILD_NAME}
 
-          Airo TV ${BUILD_NAME} is a release-management and trust-readiness update for the Android TV variant of Airo.
+          Airo TV ${BUILD_NAME} is a product-surface consolidation and playback usability release for the Android TV variant of Airo.
 
           ## Highlights
 
-          - Published clean release asset names for APK and Play Store AAB downloads.
-          - Added SHA256 checksum publishing for release artifacts.
-          - Added structured release notes for Airo TV releases.
-          - Documented privacy, security, threat model, roadmap, architecture, and feature matrix.
-          - Updated public download links and release documentation.
+          - Kept Airo TV as the focused IPTV product surface.
+          - Removed obsolete Airo Streaming and Airo IPTV product-target wiring from release configuration.
+          - Added TV Explorer-inspired filters, settings, player controls, and bounded channel warmup.
+          - Updated public release documentation, store posture, and feature matrix for ${BUILD_NAME}.
 
           ## New Features
 
           ### IPTV
 
-          - Supports user-supplied M3U playlist URLs.
+          - Supports user-supplied M3U playlist URLs and XMLTV guide URLs.
           - Keeps IPTV content responsibility with the user; Airo TV does not bundle channels or playlists.
 
           ### Search
 
-          - Supports channel search by channel name.
-          - Includes validation coverage for Music India search/play.
+          - Supports channel search by channel name and available guide data.
+          - Supports category, country, and language filtering with deduplicated category values.
 
           ### Android TV
 
@@ -834,6 +833,7 @@ jobs:
           ### Playback
 
           - Supports IPTV channel playback from authorized playlist URLs.
+          - Warms nearby visible channels with bounded async stream-health checks.
 
           ### User Interface
 
@@ -845,11 +845,12 @@ jobs:
           - Release artifacts use clean user-facing names.
           - Release assets include SHA256SUMS for download verification.
           - Release notes follow a stable template for future Airo TV versions.
+          - Player controls use a single Airo TV overlay layer in compact and fullscreen modes.
 
           ## Bug Fixes
 
-          - Fixed broken and misleading Airo TV download references that pointed to generic or missing release assets.
-          - Removed debug-looking public APK names from the Airo TV release flow.
+          - Fixed stale release defaults that pointed at earlier Airo TV releases.
+          - Fixed no-op player controls by wiring supported actions or removing unsupported affordances.
 
           ## Performance
 
@@ -868,9 +869,8 @@ jobs:
 
           ## Known Limitations
 
-          - No EPG support.
           - No recording.
-          - No favorites sync.
+          - No cloud favorites sync.
           - No cloud playlists.
           - No multiple playlist merge.
           - No bundled IPTV channels or media content.
@@ -913,7 +913,7 @@ jobs:
 
           ## Full Changelog
 
-          https://github.com/DevelopersCoffee/airo/compare/airo-tv-v0.0.1...${RELEASE_VERSION}
+          https://github.com/DevelopersCoffee/airo/compare/airo-tv-v0.0.4...${RELEASE_VERSION}
           NOTES
           gh release create "$RELEASE_VERSION" release-artifacts/* \
             --title "Airo TV ${BUILD_NAME}" \

--- a/.github/workflows/release-orchestrator.yml
+++ b/.github/workflows/release-orchestrator.yml
@@ -3,21 +3,22 @@ name: Release Orchestrator
 on:
   push:
     tags:
-      - 'v2*'
+      - 'v*'
+      - 'airo-tv-v*'
   workflow_dispatch:
     inputs:
       version:
-        description: 'Release version label, for example v2.0.0'
+        description: 'Release version label, for example v0.0.5'
         required: true
-        default: 'v2.0.0'
+        default: 'airo-tv-v0.0.5'
       build_name:
-        description: 'Android versionName, for example 2.0.0'
+        description: 'Android versionName, for example 0.0.5'
         required: true
-        default: '2.0.0'
+        default: '0.0.5'
       build_number:
-        description: 'Android versionCode shared by v2 Android artifacts'
+        description: 'Android versionCode shared by Android artifacts'
         required: true
-        default: '200'
+        default: '7'
       release_ref:
         description: 'Git ref to release; must be based on origin/main'
         required: true
@@ -25,7 +26,7 @@ on:
       release_branch:
         description: 'Release branch to create/update from release_ref'
         required: true
-        default: 'release/v2.0.0'
+        default: 'release/airo-tv-v0.0.5'
       dry_run:
         description: 'Build and upload workflow artifacts without public/store publishing'
         required: true
@@ -130,9 +131,9 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  DEFAULT_VERSION: v2.0.0
-  DEFAULT_BUILD_NAME: 2.0.0
-  DEFAULT_BUILD_NUMBER: '200'
+  DEFAULT_VERSION: airo-tv-v0.0.5
+  DEFAULT_BUILD_NAME: 0.0.5
+  DEFAULT_BUILD_NUMBER: '7'
 
 jobs:
   prepare:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,46 @@ All notable changes to this project are documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html) for public release tags.
 
+## [Airo TV v0.0.5] - 2026-07-22
+
+### Added
+
+- First-run country selection and a Settings path for changing the country
+  filter after onboarding.
+- TV Explorer-inspired browse controls for search, category, country, and
+  language filtering, including clearer country labels and deduplicated
+  category values.
+- Bounded visible-channel health warmup and adaptive nearby-channel warming so
+  channel switching can avoid known-unavailable streams without scanning the
+  full playlist on the UI path.
+
+### Changed
+
+- Airo TV is the focused IPTV product surface. Obsolete Airo Streaming and Airo
+  IPTV product-target wiring was removed from build profiles, package IDs,
+  Firebase/preflight expectations, scripts, and release documentation.
+- Compact phone/tablet and fullscreen player controls now keep a single Airo TV
+  overlay layer instead of falling back to mixed legacy/native overlay buttons.
+- Channel rows prioritize channel and category space, move country to a compact
+  flag/metadata position, and keep list scrolling virtualized for large
+  playlists.
+
+### Fixed
+
+- Restored Settings entry points for theme and playback/PiP preferences.
+- Corrected player lock/unlock behavior and fullscreen escape affordances.
+- Fixed no-op player actions by either wiring supported controls or removing
+  unsupported affordances from the active Airo TV product surface.
+
+### Known limitations
+
+- Airo TV remains BYOC: it does not bundle playlists, channels, subscriptions,
+  or media content.
+- Production signing, Play upload, Firebase distribution, and macOS
+  notarization require maintainer-owned credentials.
+- Fire TV and legacy Android TV support remain compatible/experimental until
+  dedicated physical-device evidence is attached.
+
 ## [Airo TV v0.0.4] - 2026-07-22
 
 ### Added
@@ -138,7 +178,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - Android TV package `io.airo.app.tv`.
 - IPTV playlist import, search, playback, Cast controls, and Play Store readiness notes.
 
-[Airo TV v0.0.4-rc.1]: https://github.com/DevelopersCoffee/airo/compare/airo-tv-v0.0.3...airo-tv-v0.0.4-rc.1
+[Airo TV v0.0.5]: https://github.com/DevelopersCoffee/airo/compare/airo-tv-v0.0.4...airo-tv-v0.0.5
 [Airo TV v0.0.4]: https://github.com/DevelopersCoffee/airo/compare/airo-tv-v0.0.3...airo-tv-v0.0.4
+[Airo TV v0.0.4-rc.1]: https://github.com/DevelopersCoffee/airo/compare/airo-tv-v0.0.3...airo-tv-v0.0.4-rc.1
 [Airo TV v0.0.2]: https://github.com/DevelopersCoffee/airo/compare/airo-tv-v0.0.1...airo-tv-v0.0.2
 [Airo TV v0.0.1]: https://github.com/DevelopersCoffee/airo/releases/tag/airo-tv-v0.0.1

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 0.0.4-rc.3+6
+version: 0.0.5+7
 
 environment:
   sdk: ">=3.12.2 <4.0.0"

--- a/app/pubspec_tv.yaml
+++ b/app/pubspec_tv.yaml
@@ -11,7 +11,7 @@
 name: airo_app
 description: "Airo TV - IPTV streaming for Android TV"
 publish_to: 'none'
-version: 0.0.4+4
+version: 0.0.5+5
 
 environment:
   sdk: ">=3.12.2 <4.0.0"

--- a/app/test/main_tv_debug_playlist_test.dart
+++ b/app/test/main_tv_debug_playlist_test.dart
@@ -73,6 +73,7 @@ void main() {
       dio: Dio(),
       prefs: prefs,
       cacheDirectoryProvider: () async => cacheDir,
+      downloadDirectoryProvider: () async => cacheDir,
     );
 
     unawaited(

--- a/docs/airo-tv/guides/index.html
+++ b/docs/airo-tv/guides/index.html
@@ -308,13 +308,13 @@
             <span class="status status-qualifying">Preview</span>
             <h2>macOS validation build</h2>
             <p class="tutorial-summary">
-              Unsigned and unnotarized artifacts in v0.0.4.
+              Unsigned and unnotarized artifacts in v0.0.5.
             </p>
           </header>
           <div class="tutorial-content">
             <h3>Understand the limitation first</h3>
             <p>
-              The v0.0.4 release includes ZIP and DMG artifacts for direct
+              The v0.0.5 release includes ZIP and DMG artifacts for direct
               validation. They are not a notarized public macOS distribution and
               may trigger normal macOS security warnings for unsigned software.
             </p>

--- a/docs/release/AIRO_TV_CONTENT_RATING.md
+++ b/docs/release/AIRO_TV_CONTENT_RATING.md
@@ -12,7 +12,7 @@ must be saved by a maintainer with console access.
 | Product | Airo TV |
 | Android package ID | `io.airo.app.tv` |
 | Entrypoint | `app/lib/main_tv.dart` |
-| Current release | v0.0.2 |
+| Current release | v0.0.5 |
 | Privacy minimum age posture | Not directed to children under 16 |
 | Content model | Media player for user-provided playlist and stream URLs |
 

--- a/docs/release/AIRO_TV_DATA_SAFETY.md
+++ b/docs/release/AIRO_TV_DATA_SAFETY.md
@@ -14,7 +14,7 @@ access.
 | Entrypoint | `app/lib/main_tv.dart` |
 | Privacy Policy URL | `https://developerscoffee.github.io/airo/legal/privacy-policy/` |
 | Terms URL | `https://developerscoffee.github.io/airo/legal/terms-conditions/` |
-| Current release | v0.0.2 |
+| Current release | v0.0.5 |
 
 This declaration is based on the current v2 TV release behavior:
 

--- a/docs/release/AIRO_TV_FEATURE_MATRIX.md
+++ b/docs/release/AIRO_TV_FEATURE_MATRIX.md
@@ -1,6 +1,6 @@
 # Airo TV Feature Matrix
 
-Current public release: [`airo-tv-v0.0.4`](https://github.com/DevelopersCoffee/airo/releases/tag/airo-tv-v0.0.4).
+Current public release: [`airo-tv-v0.0.5`](https://github.com/DevelopersCoffee/airo/releases/tag/airo-tv-v0.0.5).
 
 | Feature | Status | Notes |
 | --- | --- | --- |
@@ -14,7 +14,8 @@ Current public release: [`airo-tv-v0.0.4`](https://github.com/DevelopersCoffee/a
 | XMLTV guide | Supported | User-configured XMLTV sources only; no bundled guide feed. |
 | Smart playlists and canonical channels | Supported | Local filtering and canonical identity matching help preserve personal organization across imports. |
 | Provider add-flows | Supported | User-authorized Xtream, Stalker, Jellyfin, and M3U sources. |
-| Picture-in-picture | Under qualification | Video-only PiP layout is test-covered; device evidence is still being gathered. |
+| Channel health warmup | Supported | Visible channels are warmed with bounded async stream checks so unavailable streams can be signaled before playback. |
+| Picture-in-picture | Under qualification | Video-only PiP layout is test-covered; full device evidence is still being gathered. |
 | Phone-hosted TV streaming | Under qualification | Debug entry point and protocol tests exist; real phone-to-receiver dogfood is not yet complete. |
 | Recording | Not supported | No recording or DVR storage. |
 | AI Search | Planned | Local search is intentionally deterministic in this release. |

--- a/docs/release/AIRO_TV_MEDIA_ASSETS.md
+++ b/docs/release/AIRO_TV_MEDIA_ASSETS.md
@@ -29,9 +29,10 @@ Python environment does not already provide it.
 - Search
 - Playlist Import
 
-The current v0.0.2 release does not include EPG, favorites, recording, cloud
-playlists, or AI Search. Do not add store screenshots for planned features until
-[Airo TV Feature Matrix](./AIRO_TV_FEATURE_MATRIX.md) marks them supported.
+The current v0.0.5 release includes guide-source setup and local favorites, but
+does not include recording, cloud playlists, or AI Search. Do not add store
+screenshots for planned features until [Airo TV Feature Matrix](./AIRO_TV_FEATURE_MATRIX.md)
+marks them supported.
 
 ## Demo Video
 

--- a/docs/release/AIRO_TV_RELEASE_TEMPLATE.md
+++ b/docs/release/AIRO_TV_RELEASE_TEMPLATE.md
@@ -56,9 +56,8 @@ No breaking changes.
 
 ## Known Limitations
 
-- No EPG support.
 - No recording.
-- No favorites sync.
+- No cloud favorites sync.
 - No cloud playlists.
 - No multiple playlist merge.
 

--- a/docs/release/AIRO_TV_STORE_LISTING.md
+++ b/docs/release/AIRO_TV_STORE_LISTING.md
@@ -1,10 +1,10 @@
 # Airo TV Store Listing Metadata
 
 Canonical listing metadata for the Airo TV v2 Android TV release profile.
-This copy is scoped to the shipped v0.0.2 feature set in
+This copy is scoped to the shipped v0.0.5 feature set in
 [Airo TV Feature Matrix](./AIRO_TV_FEATURE_MATRIX.md). Do not claim planned
-features such as EPG, favorites, recording, cloud playlists, or bundled
-channels until the feature matrix marks them supported.
+features such as recording, cloud playlists, or bundled channels until the
+feature matrix marks them supported.
 
 ## Release Scope
 
@@ -42,6 +42,8 @@ clean, remote-friendly interface built for the living room.
 Key features:
 - Import your own M3U/M3U8 playlist URL
 - Browse and search channels by name
+- Add XMLTV guide sources, favorites, and user-authorized provider sources
+- See local channel status signals while browsing supported playlists
 - Play supported HLS and media streams on TV devices
 - Use Chromecast/Cast controls where supported by your device and network
 - Keep playlists local unless you choose to load a remote playlist URL
@@ -57,8 +59,8 @@ Supported playlist formats:
 M3U and M3U8.
 
 Playback support depends on the stream format, codec, device capability, and
-network connection. Some planned features, including EPG, favorites, recording,
-and cloud playlists, are not included in this release.
+network connection. Some planned features, including recording and cloud
+playlists, are not included in this release.
 ```
 
 Full description length: 1,122/4,000 characters.

--- a/docs/release/AIRO_TV_v0.0.5.md
+++ b/docs/release/AIRO_TV_v0.0.5.md
@@ -1,0 +1,52 @@
+# Airo TV v0.0.5
+
+Airo TV v0.0.5 is a product-surface consolidation and playback usability
+release for the Airo TV profile. It keeps Airo TV as the focused IPTV product,
+removes obsolete standalone Streaming/IPTV product targets from the release
+surface, and improves phone, tablet, Android TV, and macOS browse/playback
+flows without bundling media content.
+
+## Highlights
+
+- Keeps the public product matrix focused on `Airo` and `Airo TV`; obsolete
+  Airo Streaming and Airo IPTV release targets are removed from build and
+  release configuration.
+- Adds TV Explorer-inspired Airo TV browse controls: search, category, country,
+  and language filters with clearer country names and deduplicated categories.
+- Adds first-run country selection and a Settings path to change country later.
+- Restores important Settings affordances for theme selection and playback/PiP
+  preferences.
+- Improves player overlays so Airo TV keeps one consistent control layer across
+  compact portrait, compact landscape, and fullscreen playback.
+- Adds bounded channel-health warmup around the visible/current channel window
+  so channel switching can avoid obviously unavailable streams and feel closer
+  to normal TV surfing.
+
+## Distribution and verification
+
+- Android TV direct-install APK and Play Store AAB assets are built from
+  `app/lib/main_tv.dart` with package `io.airo.app.tv`.
+- Full Airo Android artifacts remain built from `app/lib/main.dart` with package
+  `io.airo.app`.
+- macOS Airo TV artifacts remain direct-download validation artifacts unless
+  signing and notarization secrets are supplied.
+- The release workflows default to `airo-tv-v0.0.5`, build name `0.0.5`, build
+  number `5`, and release branch `release/airo-tv-v0.0.5`.
+
+## Known limitations
+
+- Airo TV does not provide playlists, channels, subscriptions, or media. Users
+  must provide content they are authorized to access.
+- Recording/DVR storage and cloud playlist sync are not included.
+- Picture-in-picture and cast behavior have automated coverage and local
+  dogfood evidence, but final public device qualification must be attached to
+  the release evidence before broad publication claims.
+- Production Android signing, Firebase distribution, Play upload, and macOS
+  notarization still require maintainer-owned secrets and console access.
+- Fire TV and legacy Android TV boxes remain compatible/experimental until
+  dedicated physical-device evidence is attached.
+
+## Full changelog
+
+See the [repository changelog](../../CHANGELOG.md) and compare
+[`airo-tv-v0.0.4...airo-tv-v0.0.5`](https://github.com/DevelopersCoffee/airo/compare/airo-tv-v0.0.4...airo-tv-v0.0.5).

--- a/docs/release/MACOS_AIRO_TV_RELEASE.md
+++ b/docs/release/MACOS_AIRO_TV_RELEASE.md
@@ -27,11 +27,11 @@ Recommended workflow inputs:
 
 ```text
 profile=tv
-version=airo-tv-v0.0.2
-build_name=0.0.2
-build_number=2
+version=airo-tv-v0.0.5
+build_name=0.0.5
+build_number=5
 release_ref=main
-release_branch=release/airo-tv-v0.0.2
+release_branch=release/airo-tv-v0.0.5
 require_notarization=false
 ```
 

--- a/docs/release/README.md
+++ b/docs/release/README.md
@@ -8,6 +8,8 @@ Documentation for Airo releases and version history.
 
 | Version | Date | Highlights |
 |---------|------|------------|
+| [Airo TV v0.0.5](./AIRO_TV_v0.0.5.md) | 2026-07-22 | Product target consolidation, TV controls, filters, channel warmup |
+| [Airo TV v0.0.4](./AIRO_TV_v0.0.4.md) | 2026-07-22 | Search, favorites, guide setup, provider add-flows, diagnostics |
 | [Airo TV v0.0.2](./AIRO_TV_v0.0.2.md) | 2026-07-14 | Release trust update, checksums, clean assets, documentation |
 | [Airo TV v0.0.1](./AIRO_TV_v0.0.1.md) | 2026-07-14 | Android TV IPTV release, Play Store readiness, Cast diagnostics |
 | [v1.1.0](./CHANGELOG_v1.1.0.md) | 2025-11-29 | Bill Split, E2E Testing, OCR Integration |
@@ -15,21 +17,21 @@ Documentation for Airo releases and version history.
 
 ---
 
-## Latest Release: Airo TV v0.0.2
+## Latest Release: Airo TV v0.0.5
 
 ### New Features
-- **Release assets** - Clean APK/AAB filenames and SHA256 checksums
-- **Release notes** - Mature open-source release format for Airo TV releases
-- **Trust documentation** - Privacy, security, threat model, roadmap, feature matrix, and architecture docs
-- **Play Store readiness** - Release process documents screenshots, demo video, legal notice, and known limitations
+- **Focused product surface** - Airo TV is the active IPTV product target; obsolete Streaming/IPTV release targets are removed.
+- **Filters and setup** - First-run country selection, country/language/category filters, and deduplicated category values.
+- **Player controls** - Consistent Airo TV overlay controls across compact portrait, landscape, and fullscreen playback.
+- **Channel warmup** - Bounded health checks and nearby-channel warmup improve channel switching responsiveness.
 
 ### Quick Links
-- [Airo TV v0.0.2 Notes](./AIRO_TV_v0.0.2.md)
+- [Airo TV v0.0.5 Notes](./AIRO_TV_v0.0.5.md)
 - [Airo TV Release Template](./AIRO_TV_RELEASE_TEMPLATE.md)
 - [Airo TV Feature Matrix](./AIRO_TV_FEATURE_MATRIX.md)
 - [Airo TV Media Assets](./AIRO_TV_MEDIA_ASSETS.md)
 - [GitHub Releases](https://github.com/DevelopersCoffee/airo/releases)
-- [Download Airo TV APK](https://github.com/DevelopersCoffee/airo/releases/download/airo-tv-v0.0.2/Airo-TV-v0.0.2.apk)
+- [Download Airo TV APK](https://github.com/DevelopersCoffee/airo/releases/download/airo-tv-v0.0.5/Airo-TV-0.0.5.apk)
 - [Verify direct APK downloads](../../VERIFY_DOWNLOAD.md)
 - [Trust and transparency](../../TRUST.md)
 
@@ -39,6 +41,8 @@ Documentation for Airo releases and version history.
 
 | Document | Description |
 |----------|-------------|
+| [Airo TV v0.0.5](./AIRO_TV_v0.0.5.md) | Product target consolidation, TV controls, filters, channel warmup |
+| [Airo TV v0.0.4](./AIRO_TV_v0.0.4.md) | Search, favorites, guide setup, provider add-flows, diagnostics |
 | [Airo TV v0.0.2](./AIRO_TV_v0.0.2.md) | Professional release notes, checksums, limitations, installation |
 | [Airo TV v0.0.1](./AIRO_TV_v0.0.1.md) | Release notes, Play Store readiness, artifact checklist |
 | [Airo TV Release Template](./AIRO_TV_RELEASE_TEMPLATE.md) | Stable release format for future Airo TV versions |
@@ -78,7 +82,7 @@ Documentation for Airo releases and version history.
 
 - **GitHub Releases**: https://github.com/DevelopersCoffee/airo/releases
 - **GitHub Actions**: https://github.com/DevelopersCoffee/airo/actions
-- **Airo TV APK**: https://github.com/DevelopersCoffee/airo/releases/download/airo-tv-v0.0.2/Airo-TV-v0.0.2.apk
+- **Airo TV APK**: https://github.com/DevelopersCoffee/airo/releases/download/airo-tv-v0.0.5/Airo-TV-0.0.5.apk
 
 ---
 

--- a/docs/release/V2_DISTRIBUTION_MATRIX.md
+++ b/docs/release/V2_DISTRIBUTION_MATRIX.md
@@ -84,13 +84,13 @@ SHA256SUMS
 Examples:
 
 ```text
-Airo-IPTV-v2.0.0.apk
-Airo-Streaming-v2.0.0.apk
-Airo-TV-v2.0.0.apk
-Airo-TV-v2.0.0-Play-Store.aab
-Airo-TV-v2.0.0-macOS.zip
-Airo-TV-v2.0.0-macOS.dmg
-Airo-TV-v2.0.0-Release-Manifest.json
+Airo-0.0.5-7-arm64.apk
+Airo-0.0.5-7-Play-Store.aab
+Airo-TV-0.0.5.apk
+Airo-TV-0.0.5-Play-Store.aab
+Airo-TV-0.0.5-macOS.zip
+Airo-TV-0.0.5-macOS.dmg
+Airo-TV-0.0.5-Release-Manifest.json
 ```
 
 Do not publish debug-looking names such as `app-release.apk` or

--- a/docs/release/V2_RELEASE_QUALIFICATION.md
+++ b/docs/release/V2_RELEASE_QUALIFICATION.md
@@ -21,7 +21,7 @@ device evidence into a release report:
 
 ```bash
 scripts/generate-release-qualification-report.py \
-  --manifest release-artifacts/Airo-TV-v2.0.0-Release-Manifest.json \
+  --manifest release-artifacts/Airo-TV-0.0.5-Release-Manifest.json \
   --evidence release-artifacts/qualification-evidence.json \
   --mode public
 ```
@@ -36,7 +36,7 @@ Use the reusable `core_release` preflight before public publication to verify
 the same evidence policy from package code instead of ad hoc script logic:
 
 ```bash
-AIRO_RELEASE_MANIFEST=release-artifacts/Airo-TV-v2.0.0-Release-Manifest.json \
+AIRO_RELEASE_MANIFEST=release-artifacts/Airo-TV-0.0.5-Release-Manifest.json \
 AIRO_QUALIFICATION_EVIDENCE=release-artifacts/qualification-evidence.json \
 QUALIFICATION_MODE=public \
 dart pub global run melos run release:qualification-preflight
@@ -95,7 +95,7 @@ Firebase Test Lab, and manual physical-device runs can all emit the same shape.
   "checks": [
     {
       "profileId": "tv",
-      "filename": "Airo-TV-v2.0.0.apk",
+      "filename": "Airo-TV-0.0.5.apk",
       "deviceClass": "android-tv",
       "checkType": "physical-device",
       "deviceModel": "Chromecast with Google TV",
@@ -107,11 +107,11 @@ Firebase Test Lab, and manual physical-device runs can all emit the same shape.
   "waivers": [
     {
       "profileId": "tv",
-      "filename": "Airo-TV-v2.0.0.apk",
+      "filename": "Airo-TV-0.0.5.apk",
       "deviceClass": "fire-tv",
       "reason": "Fire TV remains compatible/experimental for this release.",
       "approvedBy": "release-manager",
-      "expiresAfter": "v2.0.0"
+      "expiresAfter": "airo-tv-v0.0.5"
     }
   ]
 }

--- a/docs/release/VERSION_LINES.md
+++ b/docs/release/VERSION_LINES.md
@@ -85,31 +85,33 @@ V2 is the new modular Airo architecture. It separates reusable foundation code
 from business modules so releases can target smaller APKs by user journey,
 device class, or store listing.
 
-**Market position:** Next major platform line.
+**Market position:** Active modular platform line.
 
 **Versioning:**
-- Use semantic versions under `v2.x.y`.
-- Start public modular releases at `v2.0.0`.
+- Use semantic product release tags for the current product line. Airo TV tags
+  use `airo-tv-v0.0.x`; full Airo tags use `v0.0.x` unless a release issue
+  explicitly defines a product-specific prefix.
+- The current Airo TV release train advances from `airo-tv-v0.0.4` to
+  `airo-tv-v0.0.5`.
 - Treat package contracts, feature registry APIs, and build target manifests as
   V2 compatibility surfaces.
 
 **Branching:**
-- `v2` is the long-lived base branch for the V2 modular architecture.
-- `feat/v2-modular-foundation` or issue-scoped `codex/v2-*` branches must start
-  from `v2` and carry isolated V2 implementation work before merge.
-- V2 release candidates are cut from `v2`; do not create a separate release
-  branch unless the team later adopts point-in-time release branches.
-- Tags use immutable semantic version tags such as `v2.0.0`, `v2.0.1`, and
-  `v2.1.0`.
+- Active modular release work starts from latest `origin/main`.
+- Issue-scoped `codex/*` branches must start from `origin/main` and carry
+  isolated implementation work before merge.
+- Release candidates are cut from `origin/main` into point-in-time release
+  branches such as `release/airo-tv-v0.0.5`.
+- Tags use immutable semantic product tags such as `airo-tv-v0.0.5` and
+  `v0.0.5`.
 
 **Artifact naming:**
-- `airo-v2-foundation.apk`
-- `airo-v2-full.apk`
-- `airo-v2-tv.apk`
-- `airo-v2-streaming.apk`
-- `airo-v2-coins.apk`
-- `airo-v2-<business-module>.apk`
-- `airo-v2-full.aab`
+- `Airo-0.0.5-7-arm64.apk`
+- `Airo-0.0.5-7-Play-Store.aab`
+- `Airo-TV-0.0.5.apk`
+- `Airo-TV-0.0.5-Play-Store.aab`
+- `Airo-TV-0.0.5-macOS.zip`
+- `Airo-TV-0.0.5-macOS.dmg`
 
 **Allowed changes:**
 - Feature registry and module manifest work.

--- a/docs/tv/index.html
+++ b/docs/tv/index.html
@@ -80,7 +80,7 @@ layout: null
           ><a href="#community">Community</a><a href="#roadmap">Roadmap</a
           ><a
             class="button button-primary"
-            href="https://github.com/DevelopersCoffee/airo/releases/tag/airo-tv-v0.0.4"
+            href="https://github.com/DevelopersCoffee/airo/releases/tag/airo-tv-v0.0.5"
             ><i data-lucide="download" aria-hidden="true"></i> Download</a
           >
         </nav>
@@ -101,7 +101,7 @@ layout: null
           <div class="hero-content">
             <p class="eyebrow">
               Born from Airo
-              <span class="status status-available">v0.0.4 available</span>
+              <span class="status status-available">v0.0.5 available</span>
             </p>
             <h1 id="hero-title">Airo TV</h1>
             <p class="hero-lede">Your sources. Your screen.</p>
@@ -113,7 +113,7 @@ layout: null
             <div class="hero-actions">
               <a
                 class="button button-primary"
-                href="https://github.com/DevelopersCoffee/airo/releases/tag/airo-tv-v0.0.4"
+                href="https://github.com/DevelopersCoffee/airo/releases/tag/airo-tv-v0.0.5"
                 ><i data-lucide="download" aria-hidden="true"></i> Download Airo
                 TV</a
               ><a class="button button-secondary" href="#browse"
@@ -212,7 +212,7 @@ layout: null
       <section
         class="proof-strip"
         id="product"
-        aria-label="Available in Airo TV v0.0.4"
+        aria-label="Available in Airo TV v0.0.5"
       >
         <div class="container proof-grid">
           <div class="proof-item">
@@ -475,7 +475,7 @@ layout: null
               <h2 id="devices-title">One product. Honest support levels.</h2>
             </div>
             <p>
-              Availability is tied to the published v0.0.4 release and its known
+              Availability is tied to the published v0.0.5 release and its known
               limitations. The status is part of the product—not fine print.
             </p>
           </div>
@@ -560,9 +560,9 @@ layout: null
               </h2>
             </div>
             <p>
-              Airo TV v0.0.4 adds local organization, guide setup, and clearer
-              playback answers without turning the player into a content
-              service.
+              Airo TV v0.0.5 adds focused product targets, local organization,
+              guide setup, channel warmup, and clearer playback answers without
+              turning the player into a content service.
             </p>
           </div>
           <div class="capability-grid">
@@ -790,15 +790,15 @@ layout: null
           <div class="roadmap">
             <article class="roadmap-stage">
               <span class="status status-available">Available</span>
-              <h3>Airo TV v0.0.4</h3>
+              <h3>Airo TV v0.0.5</h3>
               <p>
                 The current focused player release with local search, favorites,
-                XMLTV setup, smarter playlist organization, and Android TV
-                artifacts.
+                XMLTV setup, smarter playlist organization, channel warmup, and
+                Android TV artifacts.
               </p>
               <a
                 class="text-link"
-                href="https://github.com/DevelopersCoffee/airo/releases/tag/airo-tv-v0.0.4"
+                href="https://github.com/DevelopersCoffee/airo/releases/tag/airo-tv-v0.0.5"
                 >Release notes
                 <i data-lucide="arrow-up-right" aria-hidden="true"></i
               ></a>
@@ -808,7 +808,7 @@ layout: null
               <h3>Saved browse views</h3>
               <p>
                 Saving a reusable browse view remains planned product work; it
-                is not an available Airo TV v0.0.4 feature.
+                is not an available Airo TV v0.0.5 feature.
               </p>
               <a
                 class="text-link"
@@ -884,7 +884,7 @@ layout: null
               >Privacy policy
               <i data-lucide="arrow-right" aria-hidden="true"></i></a
             ><a
-              href="https://github.com/DevelopersCoffee/airo/releases/tag/airo-tv-v0.0.4"
+              href="https://github.com/DevelopersCoffee/airo/releases/tag/airo-tv-v0.0.5"
               >Release checksums
               <i data-lucide="arrow-up-right" aria-hidden="true"></i></a
             ><a href="https://github.com/DevelopersCoffee/airo"


### PR DESCRIPTION
# Summary

This PR prepares Airo TV v0.0.5 from the current main release base.

Goal: update release versions, workflow defaults, public release docs, and release-facing copy before cutting the v0.0.5 release.

Core outcome:

* Bumps full Airo to 0.0.5+7.
* Bumps Airo TV to 0.0.5+5.
* Updates Airo TV release defaults to airo-tv-v0.0.5, build name 0.0.5, and release branch release/airo-tv-v0.0.5.
* Updates public Airo TV docs and release notes for the v0.0.5 product surface.

# Changes

### Code and config

* Updated app pubspec versions for full Airo and Airo TV.
* Updated TV, macOS, mobile/tablet, and orchestrator release workflow defaults.
* Aligned Airo TV release workflow release-ref language with origin/main policy.

### Documentation

* Added Airo TV v0.0.5 release notes.
* Updated CHANGELOG, release index, feature matrix, store listing, data safety, content rating, media checklist, macOS runbook, distribution matrix, qualification examples, version-line policy, and public Airo TV page references.

# Performance Impact

* No runtime code changes in this PR.
* Release notes include the already-merged adaptive channel warmup work from PR 1060.

# Risks

* Release workflow defaults now target v0.0.5 and main. If maintainers want a different tag prefix, adjust before merge.
* Public artifact links point at the intended release tag and will resolve after the GitHub release is created.

Rollback plan:

* Revert this PR before tagging if the release is deferred.

# Testing

* scripts/test-check-build-profiles.sh and scripts/check-build-profiles.py passed.
* scripts/test-generate-release-manifest.sh and scripts/test-generate-release-qualification-report.sh passed.
* YAML parse check for modified workflow files passed.
* flutter test in packages/core_release passed.
* Airo full Android debug build passed.
* Airo TV Android debug build passed.
* python3 .agents/skills/airo-release-branding/scripts/audit_public_page.py with release tag airo-tv-v0.0.5 passed.
* git diff --check passed.

# Deployment Notes

After merge, dispatch the Release Orchestrator or Airo TV Release workflow with:

* version: airo-tv-v0.0.5
* build_name: 0.0.5
* build_number: 5 for TV-only, or 7 for combined full plus TV release
* release_ref: main
* release_branch: release/airo-tv-v0.0.5
* dry_run: true first unless maintainers are ready to publish.