### PR TITLE
feat(iptv): add filtered random and hardware channel actions

### DIFF
--- a/docs/superpowers/plans/2026-07-22-airo-tv-ux-phase-3.md
+++ b/docs/superpowers/plans/2026-07-22-airo-tv-ux-phase-3.md
@@ -4,12 +4,13 @@
 
 1. Write failing pure-unit tests for random selection from the filtered list,
    including empty and single-item inputs; implement the deterministic helper.
-2. Write failing widget tests for visible touch controls, inactivity dismissal,
-   pointer reappearance, and one callback per touch control; implement the
-   overlay without changing playback or failover behavior.
-3. Write failing remote-input tests using existing TV focus/key patterns;
-   wire channel navigation and mute/volume to established providers, with no
-   drawn touch controls on D-pad surfaces.
-4. Compose the overlay into `AiroTvShell`, giving random a D-pad focus target.
+2. Reuse the player's existing auto-hiding compact and expanded control layers
+   for volume, mute, and channel navigation. Do not mount a second full-screen
+   overlay over those controls.
+3. Write remote-input tests using existing TV focus/key patterns and map
+   hardware channel up/down to established filtered-list navigation.
+4. Add one focusable random action to both existing player control layouts.
+   Hardware volume and mute remain platform/OS-owned because `TvInputKey`
+   does not expose those keys.
 5. Run focused tests per slice, full feature-package tests/analyzer, review,
    and device dogfood before opening the PR.

--- a/docs/superpowers/plans/2026-07-22-airo-tv-ux-phase-3.md
+++ b/docs/superpowers/plans/2026-07-22-airo-tv-ux-phase-3.md
@@ -1,0 +1,15 @@
+# Airo TV UX Phase 3 — Remote Overlay Plan
+
+> Issue #1039. Base: `origin/main` at `d46dbade`.
+
+1. Write failing pure-unit tests for random selection from the filtered list,
+   including empty and single-item inputs; implement the deterministic helper.
+2. Write failing widget tests for visible touch controls, inactivity dismissal,
+   pointer reappearance, and one callback per touch control; implement the
+   overlay without changing playback or failover behavior.
+3. Write failing remote-input tests using existing TV focus/key patterns;
+   wire channel navigation and mute/volume to established providers, with no
+   drawn touch controls on D-pad surfaces.
+4. Compose the overlay into `AiroTvShell`, giving random a D-pad focus target.
+5. Run focused tests per slice, full feature-package tests/analyzer, review,
+   and device dogfood before opening the PR.

--- a/packages/feature_iptv/lib/presentation/tv_ux/sections/remote_overlay.dart
+++ b/packages/feature_iptv/lib/presentation/tv_ux/sections/remote_overlay.dart
@@ -1,5 +1,8 @@
+import 'dart:async';
 import 'dart:math';
 
+import 'package:core_ui/core_ui.dart';
+import 'package:flutter/material.dart';
 import 'package:platform_channels/platform_channels.dart';
 
 /// Selects exclusively from the caller's already-filtered channel list.
@@ -10,4 +13,127 @@ IPTVChannel? randomFilteredChannel(
   if (channels.isEmpty) return null;
   final index = (nextInt ?? Random().nextInt)(channels.length);
   return channels[index];
+}
+
+/// Touch controls over the video stage. TV surfaces retain hardware input and
+/// expose only the random action as a focus stop in the surrounding shell.
+class RemoteOverlay extends StatefulWidget {
+  const RemoteOverlay({
+    super.key,
+    this.isTv = false,
+    this.autoHideDuration = const Duration(seconds: 3),
+    this.onVolumeDown,
+    this.onVolumeUp,
+    this.onChannelPrevious,
+    this.onChannelNext,
+    this.onMute,
+    this.onRandom,
+  });
+
+  final bool isTv;
+  final Duration autoHideDuration;
+  final VoidCallback? onVolumeDown;
+  final VoidCallback? onVolumeUp;
+  final VoidCallback? onChannelPrevious;
+  final VoidCallback? onChannelNext;
+  final VoidCallback? onMute;
+  final VoidCallback? onRandom;
+
+  @override
+  State<RemoteOverlay> createState() => _RemoteOverlayState();
+}
+
+class _RemoteOverlayState extends State<RemoteOverlay> {
+  Timer? _hideTimer;
+  bool _visible = true;
+
+  @override
+  void initState() {
+    super.initState();
+    _restartTimer();
+  }
+
+  @override
+  void dispose() {
+    _hideTimer?.cancel();
+    super.dispose();
+  }
+
+  void _restartTimer() {
+    if (widget.isTv) return;
+    _hideTimer?.cancel();
+    _hideTimer = Timer(widget.autoHideDuration, () {
+      if (mounted) setState(() => _visible = false);
+    });
+  }
+
+  void _show() {
+    if (widget.isTv) return;
+    if (!_visible) setState(() => _visible = true);
+    _restartTimer();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (widget.isTv) {
+      return Align(
+        alignment: Alignment.bottomRight,
+        child: TvFocusable(
+          semanticLabel: 'Random channel',
+          onSelect: widget.onRandom,
+          child: IconButton(
+            key: const ValueKey('remote-random'),
+            tooltip: 'Random channel',
+            onPressed: widget.onRandom,
+            icon: const Icon(Icons.casino_outlined),
+          ),
+        ),
+      );
+    }
+
+    if (!_visible) {
+      return Listener(
+        behavior: HitTestBehavior.opaque,
+        onPointerDown: (_) => _show(),
+        child: const SizedBox.expand(),
+      );
+    }
+
+    return Listener(
+      onPointerDown: (_) => _show(),
+      child: Center(
+        child: Wrap(
+          spacing: 8,
+          children: [
+            _button(
+              'remote-volume-down',
+              Icons.volume_down,
+              widget.onVolumeDown,
+            ),
+            _button('remote-volume-up', Icons.volume_up, widget.onVolumeUp),
+            _button(
+              'remote-channel-previous',
+              Icons.keyboard_arrow_up,
+              widget.onChannelPrevious,
+            ),
+            _button(
+              'remote-channel-next',
+              Icons.keyboard_arrow_down,
+              widget.onChannelNext,
+            ),
+            _button('remote-mute', Icons.volume_off, widget.onMute),
+            _button('remote-random', Icons.casino_outlined, widget.onRandom),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _button(String id, IconData icon, VoidCallback? onPressed) {
+    return IconButton.filledTonal(
+      key: ValueKey(id),
+      onPressed: onPressed,
+      icon: Icon(icon),
+    );
+  }
 }

--- a/packages/feature_iptv/lib/presentation/tv_ux/sections/remote_overlay.dart
+++ b/packages/feature_iptv/lib/presentation/tv_ux/sections/remote_overlay.dart
@@ -1,0 +1,13 @@
+import 'dart:math';
+
+import 'package:platform_channels/platform_channels.dart';
+
+/// Selects exclusively from the caller's already-filtered channel list.
+IPTVChannel? randomFilteredChannel(
+  List<IPTVChannel> channels, {
+  int Function(int max)? nextInt,
+}) {
+  if (channels.isEmpty) return null;
+  final index = (nextInt ?? Random().nextInt)(channels.length);
+  return channels[index];
+}

--- a/packages/feature_iptv/lib/presentation/tv_ux/sections/remote_overlay.dart
+++ b/packages/feature_iptv/lib/presentation/tv_ux/sections/remote_overlay.dart
@@ -15,6 +15,23 @@ IPTVChannel? randomFilteredChannel(
   return channels[index];
 }
 
+TvInputResult handleRemoteOverlayInput(
+  TvInputKey key, {
+  VoidCallback? onChannelPrevious,
+  VoidCallback? onChannelNext,
+}) {
+  switch (key) {
+    case TvInputKey.channelUp:
+      onChannelNext?.call();
+      return TvInputResult.handled;
+    case TvInputKey.channelDown:
+      onChannelPrevious?.call();
+      return TvInputResult.handled;
+    default:
+      return TvInputResult.notHandled;
+  }
+}
+
 /// Touch controls over the video stage. TV surfaces retain hardware input and
 /// expose only the random action as a focus stop in the surrounding shell.
 class RemoteOverlay extends StatefulWidget {

--- a/packages/feature_iptv/lib/presentation/tv_ux/sections/remote_overlay.dart
+++ b/packages/feature_iptv/lib/presentation/tv_ux/sections/remote_overlay.dart
@@ -1,8 +1,7 @@
-import 'dart:async';
 import 'dart:math';
 
 import 'package:core_ui/core_ui.dart';
-import 'package:flutter/material.dart';
+import 'package:flutter/foundation.dart';
 import 'package:platform_channels/platform_channels.dart';
 
 /// Selects exclusively from the caller's already-filtered channel list.
@@ -29,128 +28,5 @@ TvInputResult handleRemoteOverlayInput(
       return TvInputResult.handled;
     default:
       return TvInputResult.notHandled;
-  }
-}
-
-/// Touch controls over the video stage. TV surfaces retain hardware input and
-/// expose only the random action as a focus stop in the surrounding shell.
-class RemoteOverlay extends StatefulWidget {
-  const RemoteOverlay({
-    super.key,
-    this.isTv = false,
-    this.autoHideDuration = const Duration(seconds: 3),
-    this.onVolumeDown,
-    this.onVolumeUp,
-    this.onChannelPrevious,
-    this.onChannelNext,
-    this.onMute,
-    this.onRandom,
-  });
-
-  final bool isTv;
-  final Duration autoHideDuration;
-  final VoidCallback? onVolumeDown;
-  final VoidCallback? onVolumeUp;
-  final VoidCallback? onChannelPrevious;
-  final VoidCallback? onChannelNext;
-  final VoidCallback? onMute;
-  final VoidCallback? onRandom;
-
-  @override
-  State<RemoteOverlay> createState() => _RemoteOverlayState();
-}
-
-class _RemoteOverlayState extends State<RemoteOverlay> {
-  Timer? _hideTimer;
-  bool _visible = true;
-
-  @override
-  void initState() {
-    super.initState();
-    _restartTimer();
-  }
-
-  @override
-  void dispose() {
-    _hideTimer?.cancel();
-    super.dispose();
-  }
-
-  void _restartTimer() {
-    if (widget.isTv) return;
-    _hideTimer?.cancel();
-    _hideTimer = Timer(widget.autoHideDuration, () {
-      if (mounted) setState(() => _visible = false);
-    });
-  }
-
-  void _show() {
-    if (widget.isTv) return;
-    if (!_visible) setState(() => _visible = true);
-    _restartTimer();
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    if (widget.isTv) {
-      return Align(
-        alignment: Alignment.bottomRight,
-        child: TvFocusable(
-          semanticLabel: 'Random channel',
-          onSelect: widget.onRandom,
-          child: IconButton(
-            key: const ValueKey('remote-random'),
-            tooltip: 'Random channel',
-            onPressed: widget.onRandom,
-            icon: const Icon(Icons.casino_outlined),
-          ),
-        ),
-      );
-    }
-
-    if (!_visible) {
-      return Listener(
-        behavior: HitTestBehavior.opaque,
-        onPointerDown: (_) => _show(),
-        child: const SizedBox.expand(),
-      );
-    }
-
-    return Listener(
-      onPointerDown: (_) => _show(),
-      child: Center(
-        child: Wrap(
-          spacing: 8,
-          children: [
-            _button(
-              'remote-volume-down',
-              Icons.volume_down,
-              widget.onVolumeDown,
-            ),
-            _button('remote-volume-up', Icons.volume_up, widget.onVolumeUp),
-            _button(
-              'remote-channel-previous',
-              Icons.keyboard_arrow_up,
-              widget.onChannelPrevious,
-            ),
-            _button(
-              'remote-channel-next',
-              Icons.keyboard_arrow_down,
-              widget.onChannelNext,
-            ),
-            _button('remote-mute', Icons.volume_off, widget.onMute),
-            _button('remote-random', Icons.casino_outlined, widget.onRandom),
-          ],
-        ),
-      ),
-    );
-  }
-
-  Widget _button(String id, IconData icon, VoidCallback? onPressed) {
-    return IconButton.filledTonal(
-      key: ValueKey(id),
-      onPressed: onPressed,
-      icon: Icon(icon),
-    );
   }
 }

--- a/packages/feature_iptv/lib/presentation/widgets/video_player_widget.dart
+++ b/packages/feature_iptv/lib/presentation/widgets/video_player_widget.dart
@@ -264,6 +264,14 @@ class _VideoPlayerWidgetState extends ConsumerState<VideoPlayerWidget> {
     }
   }
 
+  void _playRandomFilteredChannel(VideoPlayerStreamingService service) {
+    final channel = randomFilteredChannel(ref.read(filteredChannelsProvider));
+    if (channel == null) return;
+    service.playChannel(channel);
+    _showChannelChangeOverlay(channel.name);
+    _scheduleAdjacentChannelWarmupFor(channel);
+  }
+
   void _scheduleAdjacentChannelWarmup(StreamingState state) {
     final currentChannel = state.currentChannel;
     if (currentChannel == null) return;
@@ -562,28 +570,6 @@ class _VideoPlayerWidgetState extends ConsumerState<VideoPlayerWidget> {
                       ),
                     ),
 
-                  if (!_isLocked && !isPipActive)
-                    Positioned.fill(
-                      child: RemoteOverlay(
-                        isTv: !widget.enableTouchGestures,
-                        onChannelPrevious: _goToPreviousChannel,
-                        onChannelNext: _goToNextChannel,
-                        onMute: () => service.toggleMute(),
-                        onVolumeDown: () => service.setVolume(
-                          (state.volume - 0.1).clamp(0.0, 1.0).toDouble(),
-                        ),
-                        onVolumeUp: () => service.setVolume(
-                          (state.volume + 0.1).clamp(0.0, 1.0).toDouble(),
-                        ),
-                        onRandom: () {
-                          final channel = randomFilteredChannel(
-                            ref.read(filteredChannelsProvider),
-                          );
-                          if (channel != null) service.playChannel(channel);
-                        },
-                      ),
-                    ),
-
                   // Channel change overlay
                   if (_channelChangeOverlayText != null)
                     Positioned(
@@ -879,6 +865,16 @@ class _VideoPlayerWidgetState extends ConsumerState<VideoPlayerWidget> {
                   iconSize: 22,
                   backgroundAlpha: 0.48,
                 ),
+                const SizedBox(width: 10),
+                _PlayerRoundControlButton(
+                  key: const ValueKey('iptv-player-random-channel-button'),
+                  icon: Icons.casino_outlined,
+                  tooltip: 'Random channel',
+                  onPressed: () => _playRandomFilteredChannel(service),
+                  diameter: 44,
+                  iconSize: 22,
+                  backgroundAlpha: 0.48,
+                ),
               ],
             ),
           ),
@@ -1059,6 +1055,12 @@ class _VideoPlayerWidgetState extends ConsumerState<VideoPlayerWidget> {
                     onPressed: _goToNextChannel,
                   ),
                 ],
+                _PlayerFloatingControlButton(
+                  key: const ValueKey('iptv-player-random-channel-button'),
+                  icon: Icons.casino_outlined,
+                  tooltip: 'Random channel',
+                  onPressed: () => _playRandomFilteredChannel(service),
+                ),
                 _PlayerFloatingControlButton(
                   key: const ValueKey('iptv-player-more-button'),
                   icon: Icons.settings_outlined,

--- a/packages/feature_iptv/lib/presentation/widgets/video_player_widget.dart
+++ b/packages/feature_iptv/lib/presentation/widgets/video_player_widget.dart
@@ -342,6 +342,12 @@ class _VideoPlayerWidgetState extends ConsumerState<VideoPlayerWidget> {
   // Gated on !_isLocked, matching every other in-player interaction.
   TvInputResult _handleSurfInput(TvInputKey key) {
     if (_isLocked) return TvInputResult.notHandled;
+    final remoteResult = handleRemoteOverlayInput(
+      key,
+      onChannelPrevious: _goToPreviousChannel,
+      onChannelNext: _goToNextChannel,
+    );
+    if (remoteResult == TvInputResult.handled) return remoteResult;
     switch (key) {
       case TvInputKey.up:
         _goToPreviousChannel();

--- a/packages/feature_iptv/lib/presentation/widgets/video_player_widget.dart
+++ b/packages/feature_iptv/lib/presentation/widgets/video_player_widget.dart
@@ -22,6 +22,7 @@ import 'player_brightness_controller.dart';
 import 'player_gesture_overlay.dart';
 import 'player_lock_button.dart';
 import 'player_overlay.dart';
+import '../tv_ux/sections/remote_overlay.dart';
 
 /// Video player widget with YouTube-like controls
 class VideoPlayerWidget extends ConsumerStatefulWidget {
@@ -552,6 +553,28 @@ class _VideoPlayerWidgetState extends ConsumerState<VideoPlayerWidget> {
                             onToggle: _toggleLocked,
                           ),
                         ),
+                      ),
+                    ),
+
+                  if (!_isLocked && !isPipActive)
+                    Positioned.fill(
+                      child: RemoteOverlay(
+                        isTv: !widget.enableTouchGestures,
+                        onChannelPrevious: _goToPreviousChannel,
+                        onChannelNext: _goToNextChannel,
+                        onMute: () => service.toggleMute(),
+                        onVolumeDown: () => service.setVolume(
+                          (state.volume - 0.1).clamp(0.0, 1.0).toDouble(),
+                        ),
+                        onVolumeUp: () => service.setVolume(
+                          (state.volume + 0.1).clamp(0.0, 1.0).toDouble(),
+                        ),
+                        onRandom: () {
+                          final channel = randomFilteredChannel(
+                            ref.read(filteredChannelsProvider),
+                          );
+                          if (channel != null) service.playChannel(channel);
+                        },
                       ),
                     ),
 

--- a/packages/feature_iptv/test/iptv/presentation/tv_ux/remote_overlay_test.dart
+++ b/packages/feature_iptv/test/iptv/presentation/tv_ux/remote_overlay_test.dart
@@ -1,5 +1,6 @@
 import 'package:feature_iptv/presentation/tv_ux/sections/remote_overlay.dart';
 import 'package:flutter/material.dart';
+import 'package:core_ui/core_ui.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:platform_channels/platform_channels.dart';
 
@@ -51,5 +52,29 @@ void main() {
 
     expect(find.byKey(const ValueKey('remote-channel-next')), findsNothing);
     expect(find.byKey(const ValueKey('remote-random')), findsOneWidget);
+  });
+
+  test('hardware channel keys map without drawing touch controls', () {
+    var next = 0;
+    var previous = 0;
+
+    expect(
+      handleRemoteOverlayInput(
+        TvInputKey.channelUp,
+        onChannelNext: () => next++,
+        onChannelPrevious: () => previous++,
+      ),
+      TvInputResult.handled,
+    );
+    expect(
+      handleRemoteOverlayInput(
+        TvInputKey.channelDown,
+        onChannelNext: () => next++,
+        onChannelPrevious: () => previous++,
+      ),
+      TvInputResult.handled,
+    );
+    expect(next, 1);
+    expect(previous, 1);
   });
 }

--- a/packages/feature_iptv/test/iptv/presentation/tv_ux/remote_overlay_test.dart
+++ b/packages/feature_iptv/test/iptv/presentation/tv_ux/remote_overlay_test.dart
@@ -1,4 +1,5 @@
 import 'package:feature_iptv/presentation/tv_ux/sections/remote_overlay.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:platform_channels/platform_channels.dart';
 
@@ -20,5 +21,35 @@ void main() {
       randomFilteredChannel([channels.first], nextInt: (_) => 0),
       channels.first,
     );
+  });
+
+  testWidgets('touch controls dispatch and hide after inactivity', (
+    tester,
+  ) async {
+    var next = 0;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: RemoteOverlay(
+            autoHideDuration: const Duration(seconds: 1),
+            onChannelNext: () => next++,
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.byKey(const ValueKey('remote-channel-next')));
+    expect(next, 1);
+    await tester.pump(const Duration(seconds: 1));
+    expect(find.byKey(const ValueKey('remote-channel-next')), findsNothing);
+  });
+
+  testWidgets('TV mode does not draw touch buttons', (tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(home: Scaffold(body: RemoteOverlay(isTv: true))),
+    );
+
+    expect(find.byKey(const ValueKey('remote-channel-next')), findsNothing);
+    expect(find.byKey(const ValueKey('remote-random')), findsOneWidget);
   });
 }

--- a/packages/feature_iptv/test/iptv/presentation/tv_ux/remote_overlay_test.dart
+++ b/packages/feature_iptv/test/iptv/presentation/tv_ux/remote_overlay_test.dart
@@ -24,25 +24,51 @@ void main() {
     );
   });
 
-  testWidgets('touch controls dispatch and hide after inactivity', (
+  testWidgets('touch controls dispatch, hide, and reappear on pointer input', (
     tester,
   ) async {
+    var volumeDown = 0;
+    var volumeUp = 0;
+    var previous = 0;
     var next = 0;
+    var mute = 0;
+    var random = 0;
     await tester.pumpWidget(
       MaterialApp(
         home: Scaffold(
           body: RemoteOverlay(
             autoHideDuration: const Duration(seconds: 1),
+            onVolumeDown: () => volumeDown++,
+            onVolumeUp: () => volumeUp++,
+            onChannelPrevious: () => previous++,
             onChannelNext: () => next++,
+            onMute: () => mute++,
+            onRandom: () => random++,
           ),
         ),
       ),
     );
 
+    await tester.tap(find.byKey(const ValueKey('remote-volume-down')));
+    await tester.tap(find.byKey(const ValueKey('remote-volume-up')));
+    await tester.tap(find.byKey(const ValueKey('remote-channel-previous')));
     await tester.tap(find.byKey(const ValueKey('remote-channel-next')));
+    await tester.tap(find.byKey(const ValueKey('remote-mute')));
+    await tester.tap(find.byKey(const ValueKey('remote-random')));
+
+    expect(volumeDown, 1);
+    expect(volumeUp, 1);
+    expect(previous, 1);
     expect(next, 1);
+    expect(mute, 1);
+    expect(random, 1);
+
     await tester.pump(const Duration(seconds: 1));
     expect(find.byKey(const ValueKey('remote-channel-next')), findsNothing);
+
+    await tester.tapAt(const Offset(1, 1));
+    await tester.pump();
+    expect(find.byKey(const ValueKey('remote-channel-next')), findsOneWidget);
   });
 
   testWidgets('TV mode does not draw touch buttons', (tester) async {

--- a/packages/feature_iptv/test/iptv/presentation/tv_ux/remote_overlay_test.dart
+++ b/packages/feature_iptv/test/iptv/presentation/tv_ux/remote_overlay_test.dart
@@ -1,0 +1,24 @@
+import 'package:feature_iptv/presentation/tv_ux/sections/remote_overlay.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:platform_channels/platform_channels.dart';
+
+void main() {
+  const channels = [
+    IPTVChannel(id: 'one', name: 'One', streamUrl: 'https://one'),
+    IPTVChannel(id: 'two', name: 'Two', streamUrl: 'https://two'),
+  ];
+
+  test('random channel selects only from the supplied filtered channels', () {
+    final selected = randomFilteredChannel(channels, nextInt: (_) => 1);
+
+    expect(selected, channels.last);
+  });
+
+  test('random channel handles empty and one-item filtered lists', () {
+    expect(randomFilteredChannel(const [], nextInt: (_) => 0), isNull);
+    expect(
+      randomFilteredChannel([channels.first], nextInt: (_) => 0),
+      channels.first,
+    );
+  });
+}

--- a/packages/feature_iptv/test/iptv/presentation/tv_ux/remote_overlay_test.dart
+++ b/packages/feature_iptv/test/iptv/presentation/tv_ux/remote_overlay_test.dart
@@ -1,5 +1,4 @@
 import 'package:feature_iptv/presentation/tv_ux/sections/remote_overlay.dart';
-import 'package:flutter/material.dart';
 import 'package:core_ui/core_ui.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:platform_channels/platform_channels.dart';
@@ -24,63 +23,7 @@ void main() {
     );
   });
 
-  testWidgets('touch controls dispatch, hide, and reappear on pointer input', (
-    tester,
-  ) async {
-    var volumeDown = 0;
-    var volumeUp = 0;
-    var previous = 0;
-    var next = 0;
-    var mute = 0;
-    var random = 0;
-    await tester.pumpWidget(
-      MaterialApp(
-        home: Scaffold(
-          body: RemoteOverlay(
-            autoHideDuration: const Duration(seconds: 1),
-            onVolumeDown: () => volumeDown++,
-            onVolumeUp: () => volumeUp++,
-            onChannelPrevious: () => previous++,
-            onChannelNext: () => next++,
-            onMute: () => mute++,
-            onRandom: () => random++,
-          ),
-        ),
-      ),
-    );
-
-    await tester.tap(find.byKey(const ValueKey('remote-volume-down')));
-    await tester.tap(find.byKey(const ValueKey('remote-volume-up')));
-    await tester.tap(find.byKey(const ValueKey('remote-channel-previous')));
-    await tester.tap(find.byKey(const ValueKey('remote-channel-next')));
-    await tester.tap(find.byKey(const ValueKey('remote-mute')));
-    await tester.tap(find.byKey(const ValueKey('remote-random')));
-
-    expect(volumeDown, 1);
-    expect(volumeUp, 1);
-    expect(previous, 1);
-    expect(next, 1);
-    expect(mute, 1);
-    expect(random, 1);
-
-    await tester.pump(const Duration(seconds: 1));
-    expect(find.byKey(const ValueKey('remote-channel-next')), findsNothing);
-
-    await tester.tapAt(const Offset(1, 1));
-    await tester.pump();
-    expect(find.byKey(const ValueKey('remote-channel-next')), findsOneWidget);
-  });
-
-  testWidgets('TV mode does not draw touch buttons', (tester) async {
-    await tester.pumpWidget(
-      const MaterialApp(home: Scaffold(body: RemoteOverlay(isTv: true))),
-    );
-
-    expect(find.byKey(const ValueKey('remote-channel-next')), findsNothing);
-    expect(find.byKey(const ValueKey('remote-random')), findsOneWidget);
-  });
-
-  test('hardware channel keys map without drawing touch controls', () {
+  test('hardware channel keys map to filtered-list navigation', () {
     var next = 0;
     var previous = 0;
 
@@ -102,5 +45,9 @@ void main() {
     );
     expect(next, 1);
     expect(previous, 1);
+    expect(
+      handleRemoteOverlayInput(TvInputKey.playPause),
+      TvInputResult.notHandled,
+    );
   });
 }

--- a/packages/feature_iptv/test/iptv/presentation/widgets/video_player_widget_test.dart
+++ b/packages/feature_iptv/test/iptv/presentation/widgets/video_player_widget_test.dart
@@ -24,6 +24,7 @@ void main() {
     PlayerBrightnessController? brightnessController,
     StreamingState? state,
     List<IPTVChannel>? channels,
+    VideoPlayerStreamingService? service,
   }) async {
     SharedPreferences.setMockInitialValues({});
     final prefs = await SharedPreferences.getInstance();
@@ -37,6 +38,8 @@ void main() {
           ),
           if (channels != null)
             iptvChannelsProvider.overrideWith((ref) async => channels),
+          if (service != null)
+            iptvStreamingServiceProvider.overrideWithValue(service),
           streamingStateProvider.overrideWith(
             (ref) => Stream.value(
               state ??
@@ -217,6 +220,10 @@ void main() {
       find.byKey(const ValueKey('iptv-player-more-button')),
       findsOneWidget,
     );
+    expect(
+      find.byKey(const ValueKey('iptv-player-random-channel-button')),
+      findsOneWidget,
+    );
     expect(find.byKey(const ValueKey('audio-only-toggle')), findsNothing);
     expect(
       find.byKey(const ValueKey('iptv-player-quality-button')),
@@ -261,6 +268,30 @@ void main() {
       find.byKey(const ValueKey('iptv-player-channel-next-button')),
       findsOneWidget,
     );
+  });
+
+  testWidgets('random control plays from the filtered channel list', (
+    tester,
+  ) async {
+    const randomChannel = IPTVChannel(
+      id: 'random-1',
+      name: 'Random Channel',
+      streamUrl: 'https://example.com/random.m3u8',
+    );
+    final service = VideoPlayerStreamingService(
+      engine: FakeAiroPlaybackEngine(),
+    );
+    addTearDown(service.dispose);
+
+    await pumpPlayer(tester, channels: const [randomChannel], service: service);
+
+    await tester.tap(
+      find.byKey(const ValueKey('iptv-player-random-channel-button')),
+    );
+    await tester.pump();
+
+    expect(service.currentState.currentChannel, randomChannel);
+    await service.stop();
   });
 
   testWidgets('tapping the lock button again unlocks and restores controls', (
@@ -708,6 +739,10 @@ void main() {
       );
       expect(
         find.byKey(const ValueKey('iptv-player-more-button')),
+        findsOneWidget,
+      );
+      expect(
+        find.byKey(const ValueKey('iptv-player-random-channel-button')),
         findsOneWidget,
       );
       expect(


### PR DESCRIPTION
Closes #1039

# Summary

Adds the remaining remote-style actions to the current Airo TV player without introducing a second overlay layer.

Core outcome:

* random channel selects only from the active filtered channel list
* compact and expanded player controls expose one random action
* hardware channel up/down maps to existing filtered-list navigation
* current auto-hide, compact-player, fullscreen, lock, and PiP behavior remains owned by the existing player controls

# Changes

### Code

* Added deterministic filtered random selection and hardware channel-key mapping.
* Added a random action to the existing compact and expanded player control layouts.
* Preserved channel-change feedback and adjacent-channel warmup.
* Avoided the stale branch design that mounted duplicate full-screen controls over the current player.

### Tests

* Passed remote-action unit tests (3).
* Passed focused compact/expanded/random player tests (3).
* Passed affected TV fullscreen regression tests (3).
* Focused analyzer completed with six pre-existing warnings from current `main` player/test files; no new analyzer finding was introduced.
* Full `feature_iptv` suite was exercised. The branch-specific TV layout failures found during review were fixed. Remaining failures are existing unrelated lock-icon/deep-link baseline failures and are not in this diff.
* `git diff --check` passed.

# Architecture

This remains application-layer `feature_iptv` work. It consumes existing `TvInputKey`, filtered-channel provider, and player service contracts without adding dependencies or changing framework APIs. Hardware volume/mute remain platform/OS-owned because the shared input model does not expose those keys.

# CI

Focused local evidence is sufficient for this bounded slice. Iterative commits use `[skip ci]` per repository cost-control policy.

# Rollback

Revert the squash commit to remove the random action and hardware channel-key mapping.