### PR TITLE
docs(release): use repository-local health preflight

### DIFF
--- a/docs/release/REPOSITORY_HEALTH_STATUS.md
+++ b/docs/release/REPOSITORY_HEALTH_STATUS.md
@@ -8,7 +8,7 @@ Implementation work for this release line must start from latest `origin/main`.
 ## Local Evidence Command
 
 ```bash
-dart pub global run melos run release:repo-health-preflight
+dart run melos run release:repo-health-preflight
 ```
 
 The default command is expected to fail until maintainers record the remaining
@@ -19,7 +19,7 @@ made, set:
 AIRO_REPO_DISCUSSIONS=enabled \
 AIRO_REPO_CODEOWNERS=present \
 AIRO_REPO_FUNDING=intentionally_absent \
-dart pub global run melos run release:repo-health-preflight
+dart run melos run release:repo-health-preflight
 ```
 
 Use `AIRO_REPO_CODEOWNERS=present` when a root or `.github/CODEOWNERS` file is


### PR DESCRIPTION
## Summary

Updates the repository-health guide to invoke the checked-in Melos dependency with `dart run melos` instead of requiring a global Melos installation.

## Validation

* `dart run melos --version` returned 8.2.2.
* The documented `release:repo-health-preflight` command completed successfully with a ready report and no findings when supplied the current governance decisions.
* `git diff --check` passed.

The stale local README/funding wording was discarded during rebase because current `main` already contains the release links and `.github/FUNDING.yml`.