### PR TITLE
fix(release): add Applications shortcut to macOS DMG

### DIFF
--- a/.github/workflows/airo-macos-release.yml
+++ b/.github/workflows/airo-macos-release.yml
@@ -325,12 +325,18 @@ jobs:
             exit 1
           fi
 
+          dmg_stage_dir="$(mktemp -d)"
+          cp -R "$app_path" "$dmg_stage_dir/"
+          ln -s /Applications "$dmg_stage_dir/Applications"
+
           hdiutil create \
             -volname "$APP_NAME" \
-            -srcfolder "$app_path" \
+            -srcfolder "$dmg_stage_dir" \
             -ov \
             -format UDZO \
             "release-artifacts/$dmg_name"
+
+          rm -rf "$dmg_stage_dir"
 
           if [[ "$signing_status" == "signed" ]]; then
             codesign --force --timestamp --sign "$MACOS_CODESIGN_IDENTITY" "release-artifacts/$dmg_name"

--- a/docs/airo-tv/guides/index.html
+++ b/docs/airo-tv/guides/index.html
@@ -328,6 +328,12 @@
                 preview status.
               </li>
               <li>
+                If you use the DMG, drag <strong>Airo TV.app</strong> to the
+                <strong>Applications</strong> shortcut shown in the mounted disk.
+                If Finder does not show that layout, use the ZIP instead and move
+                the app into Applications manually.
+              </li>
+              <li>
                 Open Airo TV, add a non-sensitive authorized test playlist, and
                 validate search and playback.
               </li>

--- a/docs/release/MACOS_AIRO_TV_RELEASE.md
+++ b/docs/release/MACOS_AIRO_TV_RELEASE.md
@@ -95,6 +95,10 @@ SHA256SUMS
 homebrew/airo-tv.rb
 ```
 
+The DMG is built from a staging folder that contains both `Airo TV.app` and an
+`Applications` symlink, so testers get the standard Finder install gesture
+instead of a bare app bundle view when the disk image opens.
+
 The generated Homebrew Cask points to:
 
 ```text


### PR DESCRIPTION
Closes #1068

# Summary

Builds the Airo TV DMG from a staging directory containing both `Airo TV.app` and an `/Applications` symlink, giving macOS testers the standard drag-to-install Finder layout.

# Changes

* Preserve existing app build, signing, artifact naming, ZIP, checksum, and Homebrew Cask behavior.
* Stage only the DMG source folder with the app and Applications shortcut.
* Document the Finder gesture and ZIP fallback in the release guide and public Airo TV guide.

# Validation

* Workflow YAML parsed successfully.
* Release shell block passed syntax validation.
* A local dummy DMG was created, mounted, and verified to contain `Airo TV.app` plus an `Applications -> /Applications` symlink.
* Airo release-branding public-page audit passed for `airo-tv-v0.0.5`; all 22 assets resolved and all 7 legacy guides plus the guide hub were present.
* `git diff --check` passed.

# Risks and rollback

Risk is limited to DMG folder layout. ZIP and Cask outputs are unchanged. Revert the squash commit to restore direct app-bundle DMG creation.