### PR TITLE
refactor(iptv): move TV EPG bootstrap into feature package

### DIFF
--- a/app/lib/main_tv.dart
+++ b/app/lib/main_tv.dart
@@ -14,7 +14,6 @@
 library;
 
 import 'dart:io';
-import 'dart:isolate';
 
 import 'package:core_data/core_data.dart';
 import 'package:core_ui/core_ui.dart';
@@ -26,7 +25,6 @@ import 'package:flutter/semantics.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_riverpod/misc.dart';
-import 'package:path_provider/path_provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import 'core/app/airo_tv_app.dart';
@@ -285,13 +283,11 @@ Future<bool> seedTvDebugDefaultPlaylist(
   String playlistUrl = _debugDefaultPlaylistUrl,
   M3UParserService? parser,
 }) async {
-  if (playlistUrl.isEmpty) return false;
-
-  final parserService = parser ?? M3UParserService(dio: Dio(), prefs: prefs);
-  if (parserService.getPlaylistUrl() != null) return false;
-
-  await parserService.setPlaylistUrl(playlistUrl);
-  return true;
+  return seedAiroTvDebugDefaultPlaylist(
+    prefs,
+    playlistUrl: playlistUrl,
+    parser: parser,
+  );
 }
 
 @visibleForTesting
@@ -325,12 +321,11 @@ Future<void> warmTvDebugDefaultPlaylistCache(
   String playlistUrl = _debugDefaultPlaylistUrl,
   M3UParserService? parser,
 }) async {
-  if (playlistUrl.isEmpty) return;
-
-  final parserService = parser ?? M3UParserService(dio: Dio(), prefs: prefs);
-  if (parserService.getPlaylistUrl() != playlistUrl) return;
-
-  await parserService.fetchPlaylist(forceRefresh: true);
+  return warmAiroTvDebugDefaultPlaylistCache(
+    prefs,
+    playlistUrl: playlistUrl,
+    parser: parser,
+  );
 }
 
 @visibleForTesting
@@ -338,16 +333,9 @@ SnapshotBackedCompactEpgRepository createTvCompactEpgRepository({
   Future<Directory> Function()? supportDirectoryProvider,
   CompactEpgRepository? fallback,
 }) {
-  final directoryProvider =
-      supportDirectoryProvider ?? getApplicationSupportDirectory;
-  return SnapshotBackedCompactEpgRepository(
-    store: FileCompactEpgSnapshotStore(
-      fileProvider: () async {
-        final supportDir = await directoryProvider();
-        return File('${supportDir.path}/epg/compact_epg_snapshot.json');
-      },
-    ),
-    fallback: fallback ?? const EmptyCompactEpgRepository(),
+  return createAiroTvCompactEpgRepository(
+    supportDirectoryProvider: supportDirectoryProvider,
+    fallback: fallback,
   );
 }
 
@@ -397,68 +385,16 @@ Future<Duration?> warmTvDebugDefaultEpgCache(
   Future<Directory> Function()? epgDownloadDirectoryProvider,
   DateTime Function()? clock,
 }) async {
-  final normalizedEpgUrl = epgUrl.trim();
-  if (normalizedEpgUrl.isEmpty) return null;
-
-  final uri = Uri.tryParse(normalizedEpgUrl);
-  if (uri == null ||
-      uri.host.isEmpty ||
-      (uri.scheme != 'https' && uri.scheme != 'http')) {
-    throw ArgumentError.value(
-      epgUrl,
-      'epgUrl',
-      'Enter a valid HTTP(S) XMLTV EPG URL.',
-    );
-  }
-
-  final http = dio ?? Dio();
-  final parserService = parser ?? M3UParserService(dio: http, prefs: prefs);
-  final channels = await parserService.fetchPlaylist();
-  if (channels.isEmpty) return null;
-
-  final downloadDirectory =
-      await (epgDownloadDirectoryProvider ?? getTemporaryDirectory)();
-  await downloadDirectory.create(recursive: true);
-  final guideFile = File(
-    '${downloadDirectory.path}/airo_tv_debug_epg_${DateTime.now().microsecondsSinceEpoch}.xml',
+  return warmAiroTvDebugDefaultEpgCache(
+    prefs,
+    repository: repository,
+    windowRepository: windowRepository,
+    epgUrl: epgUrl,
+    parser: parser,
+    dio: dio,
+    epgDownloadDirectoryProvider: epgDownloadDirectoryProvider,
+    clock: clock,
   );
-
-  try {
-    await http.download(
-      normalizedEpgUrl,
-      guideFile.path,
-      options: Options(
-        responseType: ResponseType.stream,
-        receiveTimeout: const Duration(seconds: 30),
-        validateStatus: (status) =>
-            status != null && status >= 200 && status < 300,
-      ),
-    );
-    if (!await guideFile.exists() || await guideFile.length() == 0) {
-      return null;
-    }
-
-    final stopwatch = Stopwatch()..start();
-    final now = (clock ?? DateTime.now)().toUtc();
-    final snapshot = await Isolate.run<CompactEpgSlice>(
-      () async => _buildTvCompactEpgSnapshot(
-        xmltvPath: guideFile.path,
-        now: now,
-        channels: channels,
-      ),
-      debugName: 'tv_debug_epg_warmup',
-    );
-    await repository.saveSnapshot(snapshot);
-    windowRepository?.updateSource(
-      InMemoryCompactEpgRepository(seed: snapshot),
-    );
-    stopwatch.stop();
-    return stopwatch.elapsed;
-  } finally {
-    if (await guideFile.exists()) {
-      await guideFile.delete();
-    }
-  }
 }
 
 /// Refreshes whatever XMLTV source the user has previously configured (a
@@ -473,14 +409,13 @@ Future<void> refreshTvConfiguredXmltvSource(
   XmltvSourceStore? sourceStore,
   Future<Directory> Function()? downloadDirectoryProvider,
 }) async {
-  final refreshService = XmltvSourceRefreshService(
-    dio: dio ?? Dio(),
-    sourceStore: sourceStore ?? XmltvSourceStore(PreferencesStore(prefs)),
+  return refreshAiroTvConfiguredXmltvSource(
+    prefs,
     repository: repository,
-    downloadDirectoryProvider:
-        downloadDirectoryProvider ?? getTemporaryDirectory,
+    dio: dio,
+    sourceStore: sourceStore,
+    downloadDirectoryProvider: downloadDirectoryProvider,
   );
-  await refreshService.refreshConfiguredSource();
 }
 
 @visibleForTesting
@@ -508,79 +443,4 @@ void scheduleTvXmltvSourceRefresh(
       downloadDirectoryProvider: downloadDirectoryProvider,
     ),
   );
-}
-
-Future<CompactEpgSlice> _buildTvCompactEpgSnapshot({
-  required String xmltvPath,
-  required DateTime now,
-  required List<IPTVChannel> channels,
-}) async {
-  final aliasesByChannel = {
-    for (final channel in channels) channel.id: _xmltvGuideAliasesFor(channel),
-  };
-  final guideChannelIds = aliasesByChannel.values
-      .expand((aliases) => aliases)
-      .toSet()
-      .toList(growable: false);
-  final channelNamesByGuideId = {
-    for (final channel in channels)
-      for (final alias in aliasesByChannel[channel.id]!) alias: channel.name,
-  };
-  final guideRepository =
-      await XmltvCompactEpgRepository.fromXmltvCurrentNextFileNative(
-        path: xmltvPath,
-        ingestedAt: now,
-        channelIds: guideChannelIds,
-        now: now,
-        sourceRef: CompactEpgSourceRef.redacted('debug-tv-epg'),
-        channelNamesById: channelNamesByGuideId,
-      );
-  final guideSlice = await guideRepository.loadCurrentNext(
-    channelIds: guideChannelIds,
-    now: now,
-  );
-  final entries = <CompactEpgEntry>[];
-
-  for (final channel in channels) {
-    for (final alias in aliasesByChannel[channel.id]!) {
-      final guideEntry = guideSlice.entryForChannel(alias);
-      if (guideEntry == null || !guideEntry.hasPrograms) {
-        continue;
-      }
-      entries.add(
-        CompactEpgEntry(
-          channelId: channel.id,
-          channelName: channel.name,
-          channelNumber: channel.tvgId?.toString(),
-          current: guideEntry.current,
-          next: guideEntry.next,
-          sourceRef: guideEntry.sourceRef,
-        ),
-      );
-      break;
-    }
-  }
-
-  return CompactEpgSlice(
-    entries: entries,
-    generatedAt: guideSlice.generatedAt,
-    expiresAt: guideSlice.expiresAt,
-    source: entries.isEmpty
-        ? CompactEpgSliceSource.unavailable
-        : CompactEpgSliceSource.localCache,
-  );
-}
-
-List<String> _xmltvGuideAliasesFor(IPTVChannel channel) {
-  final aliases = <String>{
-    channel.id,
-    if (channel.tvgId != null) channel.tvgId.toString(),
-    if (channel.tvgName != null) channel.tvgName!,
-    channel.name,
-    ...channel.altNames,
-  };
-  return aliases
-      .map((alias) => alias.trim())
-      .where((alias) => alias.isNotEmpty)
-      .toList(growable: false);
 }

--- a/packages/feature_iptv/lib/application/airo_tv_bootstrap.dart
+++ b/packages/feature_iptv/lib/application/airo_tv_bootstrap.dart
@@ -1,0 +1,2 @@
+export 'airo_tv_bootstrap_stub.dart'
+    if (dart.library.io) 'airo_tv_bootstrap_io.dart';

--- a/packages/feature_iptv/lib/application/airo_tv_bootstrap_io.dart
+++ b/packages/feature_iptv/lib/application/airo_tv_bootstrap_io.dart
@@ -1,0 +1,226 @@
+import 'dart:io';
+
+import 'package:core_data/core_data.dart';
+import 'package:dio/dio.dart';
+import 'package:path_provider/path_provider.dart';
+import 'package:platform_channels/platform_channels.dart';
+import 'package:platform_epg/platform_epg.dart';
+import 'package:platform_playlist_import/platform_playlist_import.dart';
+import 'package:platform_worker_jobs/platform_worker_jobs.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'mutable_xmltv_compact_epg_repository.dart';
+import 'xmltv_source_refresh_service.dart';
+import 'xmltv_source_store.dart';
+
+Future<bool> seedAiroTvDebugDefaultPlaylist(
+  SharedPreferences prefs, {
+  required String playlistUrl,
+  M3UParserService? parser,
+}) async {
+  if (playlistUrl.isEmpty) return false;
+
+  final parserService = parser ?? M3UParserService(dio: Dio(), prefs: prefs);
+  if (parserService.getPlaylistUrl() != null) return false;
+
+  await parserService.setPlaylistUrl(playlistUrl);
+  return true;
+}
+
+Future<void> warmAiroTvDebugDefaultPlaylistCache(
+  SharedPreferences prefs, {
+  required String playlistUrl,
+  M3UParserService? parser,
+}) async {
+  if (playlistUrl.isEmpty) return;
+
+  final parserService = parser ?? M3UParserService(dio: Dio(), prefs: prefs);
+  if (parserService.getPlaylistUrl() != playlistUrl) return;
+
+  await parserService.fetchPlaylist(forceRefresh: true);
+}
+
+SnapshotBackedCompactEpgRepository createAiroTvCompactEpgRepository({
+  Future<Directory> Function()? supportDirectoryProvider,
+  CompactEpgRepository? fallback,
+}) {
+  final directoryProvider =
+      supportDirectoryProvider ?? getApplicationSupportDirectory;
+  return SnapshotBackedCompactEpgRepository(
+    store: FileCompactEpgSnapshotStore(
+      fileProvider: () async {
+        final supportDir = await directoryProvider();
+        return File('${supportDir.path}/epg/compact_epg_snapshot.json');
+      },
+    ),
+    fallback: fallback ?? const EmptyCompactEpgRepository(),
+  );
+}
+
+Future<Duration?> warmAiroTvDebugDefaultEpgCache(
+  SharedPreferences prefs, {
+  required SnapshotBackedCompactEpgRepository repository,
+  MutableXmltvCompactEpgRepository? windowRepository,
+  required String epgUrl,
+  M3UParserService? parser,
+  Dio? dio,
+  Future<Directory> Function()? epgDownloadDirectoryProvider,
+  DateTime Function()? clock,
+  AiroWorkerExecutor workerExecutor = const AiroWorkerExecutor(),
+}) async {
+  final normalizedEpgUrl = epgUrl.trim();
+  if (normalizedEpgUrl.isEmpty) return null;
+
+  final uri = Uri.tryParse(normalizedEpgUrl);
+  if (uri == null ||
+      uri.host.isEmpty ||
+      (uri.scheme != 'https' && uri.scheme != 'http')) {
+    throw ArgumentError.value(
+      epgUrl,
+      'epgUrl',
+      'Enter a valid HTTP(S) XMLTV EPG URL.',
+    );
+  }
+
+  final http = dio ?? Dio();
+  final parserService = parser ?? M3UParserService(dio: http, prefs: prefs);
+  final channels = await parserService.fetchPlaylist();
+  if (channels.isEmpty) return null;
+
+  final downloadDirectory =
+      await (epgDownloadDirectoryProvider ?? getTemporaryDirectory)();
+  await downloadDirectory.create(recursive: true);
+  final guideFile = File(
+    '${downloadDirectory.path}/airo_tv_debug_epg_${DateTime.now().microsecondsSinceEpoch}.xml',
+  );
+
+  try {
+    await http.download(
+      normalizedEpgUrl,
+      guideFile.path,
+      options: Options(
+        responseType: ResponseType.stream,
+        receiveTimeout: const Duration(seconds: 30),
+        validateStatus: (status) =>
+            status != null && status >= 200 && status < 300,
+      ),
+    );
+    if (!await guideFile.exists() || await guideFile.length() == 0) {
+      return null;
+    }
+
+    final stopwatch = Stopwatch()..start();
+    final now = (clock ?? DateTime.now)().toUtc();
+    final snapshot = await workerExecutor.run<CompactEpgSlice>(
+      debugName: 'airo_tv_debug_epg_warmup',
+      kind: AiroWorkerJobKind.epgRefresh,
+      computation: () async => _buildAiroTvCompactEpgSnapshot(
+        xmltvPath: guideFile.path,
+        now: now,
+        channels: channels,
+      ),
+    );
+    await repository.saveSnapshot(snapshot);
+    windowRepository?.updateSource(
+      InMemoryCompactEpgRepository(seed: snapshot),
+    );
+    stopwatch.stop();
+    return stopwatch.elapsed;
+  } finally {
+    if (await guideFile.exists()) {
+      await guideFile.delete();
+    }
+  }
+}
+
+Future<void> refreshAiroTvConfiguredXmltvSource(
+  SharedPreferences prefs, {
+  required MutableXmltvCompactEpgRepository repository,
+  Dio? dio,
+  XmltvSourceStore? sourceStore,
+  Future<Directory> Function()? downloadDirectoryProvider,
+}) async {
+  final refreshService = XmltvSourceRefreshService(
+    dio: dio ?? Dio(),
+    sourceStore: sourceStore ?? XmltvSourceStore(PreferencesStore(prefs)),
+    repository: repository,
+    downloadDirectoryProvider:
+        downloadDirectoryProvider ?? getTemporaryDirectory,
+  );
+  await refreshService.refreshConfiguredSource();
+}
+
+Future<CompactEpgSlice> _buildAiroTvCompactEpgSnapshot({
+  required String xmltvPath,
+  required DateTime now,
+  required List<IPTVChannel> channels,
+}) async {
+  final aliasesByChannel = {
+    for (final channel in channels) channel.id: _xmltvGuideAliasesFor(channel),
+  };
+  final guideChannelIds = aliasesByChannel.values
+      .expand((aliases) => aliases)
+      .toSet()
+      .toList(growable: false);
+  final channelNamesByGuideId = {
+    for (final channel in channels)
+      for (final alias in aliasesByChannel[channel.id]!) alias: channel.name,
+  };
+  final guideRepository =
+      await XmltvCompactEpgRepository.fromXmltvCurrentNextFileNative(
+        path: xmltvPath,
+        ingestedAt: now,
+        channelIds: guideChannelIds,
+        now: now,
+        sourceRef: CompactEpgSourceRef.redacted('debug-tv-epg'),
+        channelNamesById: channelNamesByGuideId,
+      );
+  final guideSlice = await guideRepository.loadCurrentNext(
+    channelIds: guideChannelIds,
+    now: now,
+  );
+  final entries = <CompactEpgEntry>[];
+
+  for (final channel in channels) {
+    for (final alias in aliasesByChannel[channel.id]!) {
+      final guideEntry = guideSlice.entryForChannel(alias);
+      if (guideEntry == null || !guideEntry.hasPrograms) {
+        continue;
+      }
+      entries.add(
+        CompactEpgEntry(
+          channelId: channel.id,
+          channelName: channel.name,
+          channelNumber: channel.tvgId?.toString(),
+          current: guideEntry.current,
+          next: guideEntry.next,
+          sourceRef: guideEntry.sourceRef,
+        ),
+      );
+      break;
+    }
+  }
+
+  return CompactEpgSlice(
+    entries: entries,
+    generatedAt: guideSlice.generatedAt,
+    expiresAt: guideSlice.expiresAt,
+    source: entries.isEmpty
+        ? CompactEpgSliceSource.unavailable
+        : CompactEpgSliceSource.localCache,
+  );
+}
+
+List<String> _xmltvGuideAliasesFor(IPTVChannel channel) {
+  final aliases = <String>{
+    channel.id,
+    if (channel.tvgId != null) channel.tvgId.toString(),
+    if (channel.tvgName != null) channel.tvgName!,
+    channel.name,
+    ...channel.altNames,
+  };
+  return aliases
+      .map((alias) => alias.trim())
+      .where((alias) => alias.isNotEmpty)
+      .toList(growable: false);
+}

--- a/packages/feature_iptv/lib/application/airo_tv_bootstrap_stub.dart
+++ b/packages/feature_iptv/lib/application/airo_tv_bootstrap_stub.dart
@@ -1,0 +1,50 @@
+import 'package:platform_epg/platform_epg.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'mutable_xmltv_compact_epg_repository.dart';
+
+Future<bool> seedAiroTvDebugDefaultPlaylist(
+  SharedPreferences prefs, {
+  required String playlistUrl,
+  Object? parser,
+}) async {
+  return false;
+}
+
+Future<void> warmAiroTvDebugDefaultPlaylistCache(
+  SharedPreferences prefs, {
+  required String playlistUrl,
+  Object? parser,
+}) async {}
+
+SnapshotBackedCompactEpgRepository createAiroTvCompactEpgRepository({
+  Object? supportDirectoryProvider,
+  CompactEpgRepository? fallback,
+}) {
+  return SnapshotBackedCompactEpgRepository(
+    store: InMemoryCompactEpgSnapshotStore(),
+    fallback: fallback ?? const EmptyCompactEpgRepository(),
+  );
+}
+
+Future<Duration?> warmAiroTvDebugDefaultEpgCache(
+  SharedPreferences prefs, {
+  required SnapshotBackedCompactEpgRepository repository,
+  MutableXmltvCompactEpgRepository? windowRepository,
+  required String epgUrl,
+  Object? parser,
+  Object? dio,
+  Object? epgDownloadDirectoryProvider,
+  Object? clock,
+  Object? workerExecutor,
+}) async {
+  return null;
+}
+
+Future<void> refreshAiroTvConfiguredXmltvSource(
+  SharedPreferences prefs, {
+  required MutableXmltvCompactEpgRepository repository,
+  Object? dio,
+  Object? sourceStore,
+  Object? downloadDirectoryProvider,
+}) async {}

--- a/packages/feature_iptv/lib/feature_iptv.dart
+++ b/packages/feature_iptv/lib/feature_iptv.dart
@@ -30,6 +30,7 @@ export "application/epg_reminder_scheduler.dart";
 export "application/providers/epg_reminder_providers.dart";
 export "application/epg_channel_match_override_store.dart";
 export "application/mutable_xmltv_compact_epg_repository.dart";
+export "application/airo_tv_bootstrap.dart";
 export "application/resume_last_channel_controller.dart";
 export "application/xmltv_source_refresh_service.dart";
 export "application/xmltv_source_store.dart";

--- a/packages/feature_iptv/module.yaml
+++ b/packages/feature_iptv/module.yaml
@@ -16,6 +16,7 @@ allowed_dependencies:
   - platform_playlist
   - platform_playlist_import
   - platform_streams
+  - platform_worker_jobs
   - product_capabilities
 forbidden_dependencies:
   - app

--- a/packages/feature_iptv/pubspec.yaml
+++ b/packages/feature_iptv/pubspec.yaml
@@ -38,6 +38,8 @@ dependencies:
     path: ../platform_playlist_import
   platform_streams:
     path: ../platform_streams
+  platform_worker_jobs:
+    path: ../platform_worker_jobs
   product_capabilities:
     path: ../product_capabilities
   path_provider: ^2.1.6

--- a/packages/feature_iptv/test/application/airo_tv_bootstrap_test.dart
+++ b/packages/feature_iptv/test/application/airo_tv_bootstrap_test.dart
@@ -1,0 +1,124 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:dio/dio.dart';
+import 'package:feature_iptv/application/airo_tv_bootstrap.dart';
+import 'package:feature_iptv/application/mutable_xmltv_compact_epg_repository.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:platform_channels/platform_channels.dart';
+import 'package:platform_epg/platform_epg.dart';
+import 'package:platform_playlist_import/platform_playlist_import.dart';
+import 'package:platform_worker_jobs/platform_worker_jobs.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  test(
+    'debug EPG warmup uses the shared worker-backed bootstrap helper',
+    () async {
+      SharedPreferences.setMockInitialValues({});
+      final prefs = await SharedPreferences.getInstance();
+      final now = DateTime.utc(2026, 7, 15, 9, 30);
+      final server = await _xmltvServer('''
+<tv>
+  <programme channel="news.local" start="20260715090000 +0000" stop="20260715100000 +0000">
+    <title>Morning Bulletin</title>
+  </programme>
+</tv>
+''');
+      final repository = SnapshotBackedCompactEpgRepository(
+        store: InMemoryCompactEpgSnapshotStore(),
+      );
+      final windowRepository = MutableXmltvCompactEpgRepository();
+      final downloadDir = await Directory.systemTemp.createTemp(
+        'airo-tv-bootstrap-epg-',
+      );
+      addTearDown(() async {
+        if (await downloadDir.exists()) {
+          await downloadDir.delete(recursive: true);
+        }
+      });
+      final parser = _RecordingM3UParserService(prefs, const [
+        IPTVChannel(
+          id: 'stream-news',
+          name: 'Airo News',
+          streamUrl: 'https://example.com/news.m3u8',
+          tvgName: 'news.local',
+        ),
+      ]);
+
+      try {
+        final elapsed = await warmAiroTvDebugDefaultEpgCache(
+          prefs,
+          repository: repository,
+          windowRepository: windowRepository,
+          epgUrl: _serverUrl(server, '/guide.xml'),
+          parser: parser,
+          epgDownloadDirectoryProvider: () async => downloadDir,
+          clock: () => now,
+          workerExecutor: const AiroWorkerExecutor(forceInline: true),
+        );
+
+        expect(elapsed, isNotNull);
+        expect(parser.fetchCalls, 1);
+        final snapshot = await repository.loadCurrentNext(
+          channelIds: const ['stream-news'],
+          now: now,
+        );
+        expect(
+          snapshot.entryForChannel('stream-news')?.current?.title,
+          'Morning Bulletin',
+        );
+        final window = await windowRepository.loadWindow(
+          GuideWindowQuery(
+            channelIds: const ['stream-news'],
+            windowStart: DateTime.utc(2026, 7, 15, 9),
+            windowEnd: DateTime.utc(2026, 7, 15, 10),
+            now: now,
+          ),
+        );
+        expect(window.availabilityAt(now), CompactEpgAvailability.available);
+        expect(await downloadDir.list().isEmpty, isTrue);
+      } finally {
+        await server.close(force: true);
+      }
+    },
+  );
+}
+
+class _RecordingM3UParserService extends M3UParserService {
+  _RecordingM3UParserService(
+    SharedPreferences prefs, [
+    this.channels = const [],
+  ]) : super(dio: Dio(), prefs: prefs);
+
+  final List<IPTVChannel> channels;
+  var fetchCalls = 0;
+
+  @override
+  Future<List<IPTVChannel>> fetchPlaylist({bool forceRefresh = false}) async {
+    fetchCalls++;
+    return channels;
+  }
+}
+
+Future<HttpServer> _xmltvServer(String body) async {
+  final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+  unawaited(
+    server.forEach((request) {
+      request.response
+        ..headers.contentType = ContentType.text
+        ..write(body)
+        ..close();
+    }),
+  );
+  return server;
+}
+
+String _serverUrl(HttpServer server, String path) {
+  return Uri(
+    scheme: 'http',
+    host: InternetAddress.loopbackIPv4.address,
+    port: server.port,
+    path: path,
+  ).toString();
+}


### PR DESCRIPTION
## Summary
- Port the relevant non-stale Phase 1 behavior from `origin/codex/fix-tv-debug-epg-window` by moving Airo TV debug playlist/EPG/XMLTV bootstrap helpers from the app entrypoint into `feature_iptv/application`.
- Preserve the current `origin/main` TV UX, playback, release, native M3U, and build-profile work instead of rebasing or merging the stale branch.
- Keep the EPG parse/snapshot build behind `platform_worker_jobs` / `AiroWorkerExecutor`, with web-safe conditional bootstrap stubs.

## Repository policy / Critical Agent gate
- Base: exact `origin/main` at `90af0d36c4c87579f0d94ee0a0f776aa566f5d63` in isolated worktree `/Users/udaychauhan/workspace/airo-hermes-preserved-work-triage`.
- Owner: Media Intelligence Architect (`feature_iptv`).
- Required reviewers by contract: Chief Architect, Platform Architect, Chief QA Officer, Chief Performance Officer.
- Cross-agent contract: app/Airo TV entrypoint delegates bootstrap/runtime work to `feature_iptv`; `feature_iptv` consumes `platform_worker_jobs` and does not depend on app/Airo Pro/AiroCoin layers.
- Issue audit: Phase 1 start and stale-branch decision recorded in #1065.

## Validation
- `git diff --check`
- `flutter analyze lib/main_tv.dart` from `app` — no issues
- `flutter analyze lib/application/airo_tv_bootstrap.dart lib/application/airo_tv_bootstrap_io.dart lib/application/airo_tv_bootstrap_stub.dart test/application/airo_tv_bootstrap_test.dart` from `packages/feature_iptv` — no issues
- `flutter test test/application/airo_tv_bootstrap_test.dart` from `packages/feature_iptv` — passed
- `flutter test test/main_tv_debug_playlist_test.dart` from `app` — passed
- `python3 scripts/check-module-manifests.py` — 54 manifests valid
- Secret scan on staged diff via `grep -nEi 'password|secret|api[_-]?key|token|credential|gho_'` — no matches

## Known validation note
- `make format` is currently blocked by an existing repository target for missing `packages/airomoney`; it formatted one unrelated file before failing, and that unrelated formatting change was reverted. Focused Dart format on touched files and `git diff --check` passed.
- Full `packages/feature_iptv` analyze still reports pre-existing warnings in `channel_table.dart`, `video_player_widget.dart`, and existing widget tests; the touched bootstrap files analyze cleanly.
