### PR TITLE
feat(platform_player): add typed CV-033 diagnostics

### DIFF
--- a/packages/platform_player/lib/platform_player.dart
+++ b/packages/platform_player/lib/platform_player.dart
@@ -9,6 +9,7 @@ export "src/models/playback_engine_models.dart";
 export "src/models/playback_engine_resolver_models.dart";
 export "src/models/playback_recovery_models.dart";
 export "src/models/player_view_state.dart";
+export "src/models/phone_media_diagnostic_models.dart";
 export "src/models/streaming_state.dart";
 export "src/services/airo_cast_controller.dart";
 export "src/services/airo_playback_engine.dart";

--- a/packages/platform_player/lib/src/models/phone_media_diagnostic_models.dart
+++ b/packages/platform_player/lib/src/models/phone_media_diagnostic_models.dart
@@ -1,0 +1,76 @@
+import 'package:equatable/equatable.dart';
+
+/// Stable, redacted event taxonomy for CV-033 phone-hosted playback.
+///
+/// These events are safe to surface to diagnostics pipelines because they
+/// contain only stable ids and codes. They never carry media URLs, session
+/// tokens, file paths, or receiver credentials.
+enum PhoneMediaDiagnosticEventKind {
+  sessionOpen('session_open'),
+  sessionClose('session_close'),
+  sessionExpired('session_expired'),
+  requestRejected('request_rejected'),
+  requestRejectedSuppressed('request_rejected_suppressed'),
+  requestError('request_error'),
+  wifiDisconnectedTeardown('wifi_disconnected_teardown');
+
+  const PhoneMediaDiagnosticEventKind(this.stableId);
+
+  final String stableId;
+}
+
+class PhoneMediaDiagnosticEvent extends Equatable {
+  PhoneMediaDiagnosticEvent({
+    required this.kind,
+    this.serverId,
+    this.reason,
+    this.errorType,
+    this.suppressedCount,
+    List<String> validationCodes = const [],
+    List<String> servingCodes = const [],
+  }) : validationCodes = List.unmodifiable(validationCodes),
+       servingCodes = List.unmodifiable(servingCodes);
+
+  final PhoneMediaDiagnosticEventKind kind;
+  final String? serverId;
+  final String? reason;
+  final String? errorType;
+  final int? suppressedCount;
+  final List<String> validationCodes;
+  final List<String> servingCodes;
+
+  Map<String, Object?> toPublicMap() {
+    return {
+      if (serverId != null) 'serverId': serverId,
+      if (reason != null) 'reason': reason,
+      if (errorType != null) 'errorType': errorType,
+      if (suppressedCount != null) 'suppressedCount': suppressedCount,
+      if (validationCodes.isNotEmpty) 'validationCodes': validationCodes,
+      if (servingCodes.isNotEmpty) 'servingCodes': servingCodes,
+    };
+  }
+
+  @override
+  String toString() {
+    return 'PhoneMediaDiagnosticEvent('
+        'kind: ${kind.stableId}, '
+        'serverId: $serverId, '
+        'reason: $reason, '
+        'errorType: $errorType, '
+        'suppressedCount: $suppressedCount, '
+        'validationCodes: $validationCodes, '
+        'servingCodes: $servingCodes'
+        ')';
+  }
+
+  @override
+  List<Object?> get props => [
+    kind,
+    serverId,
+    reason,
+    errorType,
+    suppressedCount,
+    validationCodes,
+    servingCodes,
+  ];
+}

--- a/packages/platform_player/lib/src/services/phone_media_cast_handoff.dart
+++ b/packages/platform_player/lib/src/services/phone_media_cast_handoff.dart
@@ -7,6 +7,7 @@ import 'package:core_media_routing/core_media_routing.dart';
 import 'package:equatable/equatable.dart';
 
 import '../models/cast_models.dart';
+import '../models/phone_media_diagnostic_models.dart';
 import 'airo_cast_controller.dart';
 import 'phone_media_file_server.dart';
 
@@ -107,6 +108,7 @@ class PhoneMediaCastHandoff {
     required this._castController,
     this.capabilities = PhoneMediaReceiverCapabilities.chromecastDefault,
     this._bindAddress,
+    this.onDiagnosticEvent,
     this.onSessionEvent,
     this._sessionTtl = const Duration(hours: 6),
     this._idleTimeout = const Duration(minutes: 2),
@@ -126,6 +128,7 @@ class PhoneMediaCastHandoff {
   /// paused. Must stay comfortably under [_idleTimeout], since a paused
   /// receiver generates no HTTP traffic of its own.
   final Duration _pauseKeepAliveInterval;
+  final void Function(PhoneMediaDiagnosticEvent event)? onDiagnosticEvent;
   final void Function(String event, Map<String, Object?> data)? onSessionEvent;
 
   PhoneMediaFileServer? _server;
@@ -160,6 +163,7 @@ class PhoneMediaCastHandoff {
       filePath: item.filePath,
       contentType: _contentTypeFor(item.container),
       bindAddress: _bindAddress,
+      onDiagnosticEvent: onDiagnosticEvent,
       onSessionEvent: onSessionEvent,
     );
     _server = server;
@@ -216,7 +220,11 @@ class PhoneMediaCastHandoff {
   // out the idle timeout.
   void _onConnectivityChanged(List<ConnectivityResult> results) {
     if (results.every((result) => result == ConnectivityResult.none)) {
-      onSessionEvent?.call('wifi_disconnected_teardown', const {});
+      final event = PhoneMediaDiagnosticEvent(
+        kind: PhoneMediaDiagnosticEventKind.wifiDisconnectedTeardown,
+      );
+      onDiagnosticEvent?.call(event);
+      onSessionEvent?.call(event.kind.stableId, event.toPublicMap());
       _cancelPauseKeepAlive();
       unawaited(_teardownServer());
     }

--- a/packages/platform_player/lib/src/services/phone_media_file_server.dart
+++ b/packages/platform_player/lib/src/services/phone_media_file_server.dart
@@ -5,6 +5,8 @@ import 'dart:math';
 import 'package:core_media_routing/core_media_routing.dart';
 import 'package:flutter/foundation.dart';
 
+import '../models/phone_media_diagnostic_models.dart';
+
 /// A network interface candidate for LAN binding: OS name plus its addresses.
 typedef PhoneMediaLanInterface = ({
   String name,
@@ -29,6 +31,7 @@ class PhoneMediaFileServer implements AiroTemporaryMobileServerController {
     Future<List<PhoneMediaLanInterface>> Function()? interfaceLister,
     String? sessionToken,
     DateTime Function()? now,
+    this.onDiagnosticEvent,
     this.onSessionEvent,
   }) : _initialSnapshot = snapshot,
        _interfaceLister = interfaceLister ?? _systemInterfaces,
@@ -46,6 +49,10 @@ class PhoneMediaFileServer implements AiroTemporaryMobileServerController {
 
   /// Diagnostics hook (CV-001). Events carry stable ids only — never URLs,
   /// tokens, or file paths.
+  final void Function(PhoneMediaDiagnosticEvent event)? onDiagnosticEvent;
+
+  /// Backward-compatible diagnostics hook. Prefer [onDiagnosticEvent] for new
+  /// callers that want typed, redacted events.
   final void Function(String event, Map<String, Object?> data)? onSessionEvent;
 
   /// Cap on `request_rejected` diagnostics per [rejectedEventWindow]. A LAN
@@ -133,7 +140,12 @@ class PhoneMediaFileServer implements AiroTemporaryMobileServerController {
       const Duration(milliseconds: 100),
       (_) => _enforceLifecycle(),
     );
-    _emit('session_open', {'serverId': _initialSnapshot.serverId});
+    _emit(
+      PhoneMediaDiagnosticEvent(
+        kind: PhoneMediaDiagnosticEventKind.sessionOpen,
+        serverId: _initialSnapshot.serverId,
+      ),
+    );
     return url;
   }
 
@@ -146,7 +158,12 @@ class PhoneMediaFileServer implements AiroTemporaryMobileServerController {
     _lifecycleTimer = null;
     await server.close(force: true);
     _flushSuppressedRejections();
-    _emit('session_close', {'serverId': _initialSnapshot.serverId});
+    _emit(
+      PhoneMediaDiagnosticEvent(
+        kind: PhoneMediaDiagnosticEventKind.sessionClose,
+        serverId: _initialSnapshot.serverId,
+      ),
+    );
   }
 
   @override
@@ -228,7 +245,12 @@ class PhoneMediaFileServer implements AiroTemporaryMobileServerController {
     final snapshot = _effectiveSnapshot();
     final now = _now();
     if (snapshot.isExpired(now) || snapshot.isIdleTimedOut(now)) {
-      _emit('session_expired', {'serverId': _initialSnapshot.serverId});
+      _emit(
+        PhoneMediaDiagnosticEvent(
+          kind: PhoneMediaDiagnosticEventKind.sessionExpired,
+          serverId: _initialSnapshot.serverId,
+        ),
+      );
       unawaited(stopServer());
     }
   }
@@ -259,13 +281,23 @@ class PhoneMediaFileServer implements AiroTemporaryMobileServerController {
     final response = request.response;
     try {
       if (!_isAuthorizedPath(request.uri.path)) {
-        _emitRejected({'reason': 'unknown_path'});
+        _emitRejected(
+          PhoneMediaDiagnosticEvent(
+            kind: PhoneMediaDiagnosticEventKind.requestRejected,
+            reason: 'unknown_path',
+          ),
+        );
         response.statusCode = HttpStatus.notFound;
         await response.close();
         return;
       }
       if (request.method != 'GET' && request.method != 'HEAD') {
-        _emitRejected({'reason': 'unsupported_method'});
+        _emitRejected(
+          PhoneMediaDiagnosticEvent(
+            kind: PhoneMediaDiagnosticEventKind.requestRejected,
+            reason: 'unsupported_method',
+          ),
+        );
         response.statusCode = HttpStatus.methodNotAllowed;
         await response.close();
         return;
@@ -311,14 +343,17 @@ class PhoneMediaFileServer implements AiroTemporaryMobileServerController {
         final rangeNotSatisfiable = decision.servingCodes.contains(
           AiroTemporaryMobileServerServingCode.rangeNotSatisfiable,
         );
-        _emitRejected({
-          'validationCodes': decision.validationCodes
-              .map((code) => code.stableId)
-              .toList(),
-          'servingCodes': decision.servingCodes
-              .map((code) => code.stableId)
-              .toList(),
-        });
+        _emitRejected(
+          PhoneMediaDiagnosticEvent(
+            kind: PhoneMediaDiagnosticEventKind.requestRejected,
+            validationCodes: decision.validationCodes
+                .map((code) => code.stableId)
+                .toList(),
+            servingCodes: decision.servingCodes
+                .map((code) => code.stableId)
+                .toList(),
+          ),
+        );
         if (rangeNotSatisfiable) {
           response.statusCode = HttpStatus.requestedRangeNotSatisfiable;
           response.headers.set(
@@ -363,7 +398,12 @@ class PhoneMediaFileServer implements AiroTemporaryMobileServerController {
       _lastActivityAt = _now();
       await response.close();
     } catch (error) {
-      _emit('request_error', {'error': error.runtimeType.toString()});
+      _emit(
+        PhoneMediaDiagnosticEvent(
+          kind: PhoneMediaDiagnosticEventKind.requestError,
+          errorType: error.runtimeType.toString(),
+        ),
+      );
       try {
         response.statusCode = HttpStatus.internalServerError;
         await response.close();
@@ -377,7 +417,7 @@ class PhoneMediaFileServer implements AiroTemporaryMobileServerController {
   /// [maxRejectedEventsPerWindow] events fire within [rejectedEventWindow],
   /// further rejections only increment a counter that is flushed as one
   /// `request_rejected_suppressed` event on window rollover or shutdown.
-  void _emitRejected(Map<String, Object?> data) {
+  void _emitRejected(PhoneMediaDiagnosticEvent event) {
     final now = _now();
     final windowStart = _rejectedWindowStartedAt;
     if (windowStart == null ||
@@ -391,23 +431,31 @@ class PhoneMediaFileServer implements AiroTemporaryMobileServerController {
       return;
     }
     _rejectedEventsInWindow++;
-    _emit('request_rejected', data);
+    _emit(event);
   }
 
   void _flushSuppressedRejections() {
     if (_suppressedRejectedEvents == 0) return;
-    _emit('request_rejected_suppressed', {
-      'suppressedCount': _suppressedRejectedEvents,
-    });
+    _emit(
+      PhoneMediaDiagnosticEvent(
+        kind: PhoneMediaDiagnosticEventKind.requestRejectedSuppressed,
+        suppressedCount: _suppressedRejectedEvents,
+      ),
+    );
     _suppressedRejectedEvents = 0;
   }
 
-  void _emit(String event, Map<String, Object?> data) {
-    final handler = onSessionEvent;
-    if (handler != null) {
-      handler(event, data);
+  void _emit(PhoneMediaDiagnosticEvent event) {
+    final diagnosticHandler = onDiagnosticEvent;
+    if (diagnosticHandler != null) {
+      diagnosticHandler(event);
+    }
+
+    final legacyHandler = onSessionEvent;
+    if (legacyHandler != null) {
+      legacyHandler(event.kind.stableId, event.toPublicMap());
     } else {
-      debugPrint('[PhoneMediaServer] $event $data');
+      debugPrint('[PhoneMediaServer] ${event.kind.stableId} ${event.toPublicMap()}');
     }
   }
 

--- a/packages/platform_player/test/phone_media_cast_handoff_test.dart
+++ b/packages/platform_player/test/phone_media_cast_handoff_test.dart
@@ -211,11 +211,13 @@ void main() {
   test('stops the server when connectivity reports disconnected', () async {
     final connectivityController =
         StreamController<List<ConnectivityResult>>();
+    final events = <PhoneMediaDiagnosticEvent>[];
     addTearDown(connectivityController.close);
     final handoff = PhoneMediaCastHandoff(
       castController: castController,
       bindAddress: InternetAddress.loopbackIPv4,
       debugConnectivityStream: connectivityController.stream,
+      onDiagnosticEvent: events.add,
     );
     await handoff.start(itemFor());
     expect(handoff.isServing, isTrue);
@@ -224,6 +226,10 @@ void main() {
     await Future<void>.delayed(Duration.zero);
 
     expect(handoff.isServing, isFalse);
+    expect(
+      events.map((event) => event.kind),
+      contains(PhoneMediaDiagnosticEventKind.wifiDisconnectedTeardown),
+    );
 
     await handoff.dispose();
   });

--- a/packages/platform_player/test/phone_media_file_server_test.dart
+++ b/packages/platform_player/test/phone_media_file_server_test.dart
@@ -186,6 +186,39 @@ void main() {
     expect(response2.statusCode, HttpStatus.notFound);
   });
 
+  test('typed diagnostics emit stable redacted lifecycle events', () async {
+    final events = <PhoneMediaDiagnosticEvent>[];
+    final server = PhoneMediaFileServer(
+      snapshot: snapshotFor(),
+      filePath: mediaFile.path,
+      contentType: 'video/mp4',
+      bindAddress: InternetAddress.loopbackIPv4,
+      sessionToken: 'typed-events-token',
+      onDiagnosticEvent: events.add,
+    );
+    final url = await server.start();
+
+    final rejected = await request(url.replace(path: '/m/wrong/media'));
+    expect(rejected.statusCode, HttpStatus.notFound);
+
+    await server.stopServer();
+
+    expect(
+      events.map((event) => event.kind),
+      containsAll([
+        PhoneMediaDiagnosticEventKind.sessionOpen,
+        PhoneMediaDiagnosticEventKind.requestRejected,
+        PhoneMediaDiagnosticEventKind.sessionClose,
+      ]),
+    );
+    final rejection = events.firstWhere(
+      (event) => event.kind == PhoneMediaDiagnosticEventKind.requestRejected,
+    );
+    expect(rejection.reason, 'unknown_path');
+    expect(rejection.toPublicMap().toString(), isNot(contains(mediaFile.path)));
+    expect(rejection.toString(), isNot(contains('typed-events-token')));
+  });
+
   test('rejects non-GET/HEAD methods with 405', () async {
     final server = serverFor();
     final url = await server.start();
@@ -491,5 +524,15 @@ void main() {
     expect(server.toString(), isNot(contains('test-session-token')));
     expect(server.toString(), isNot(contains(url.toString())));
     expect(server.toString(), isNot(contains(mediaFile.path)));
+  });
+
+  test('diagnostic event toString stays redacted', () {
+    final event = PhoneMediaDiagnosticEvent(
+      kind: PhoneMediaDiagnosticEventKind.requestError,
+      errorType: 'FileSystemException',
+    );
+    expect(event.toString(), contains('request_error'));
+    expect(event.toString(), isNot(contains('/Users/')));
+    expect(event.toPublicMap().toString(), isNot(contains('http://')));
   });
 }


### PR DESCRIPTION
## Summary
- add a typed redacted diagnostic event model for CV-033 phone-hosted playback
- emit typed lifecycle and rejection events from `PhoneMediaFileServer` while preserving the legacy string/map callback
- forward Wi-Fi teardown events through the typed handoff path and add focused coverage for redaction and event emission

## Validation
- `flutter test test/phone_media_file_server_test.dart test/phone_media_cast_handoff_test.dart`
- `git diff --check`

## Notes
- branch created in dedicated worktree from `origin/main`
- focused local validation only; commit uses `[skip ci]` per repo policy for this bounded slice