### PR TITLE
fix(iptv): reveal controls from gesture overlay taps

### DIFF
--- a/packages/feature_iptv/lib/presentation/widgets/player_gesture_overlay.dart
+++ b/packages/feature_iptv/lib/presentation/widgets/player_gesture_overlay.dart
@@ -52,6 +52,7 @@ class PlayerGestureOverlay extends StatefulWidget {
     required this.volume,
     required this.onBrightnessChanged,
     required this.onVolumeChanged,
+    this.onTap,
   });
 
   final Widget child;
@@ -64,6 +65,7 @@ class PlayerGestureOverlay extends StatefulWidget {
 
   final ValueChanged<double> onBrightnessChanged;
   final ValueChanged<double> onVolumeChanged;
+  final VoidCallback? onTap;
 
   @override
   State<PlayerGestureOverlay> createState() => _PlayerGestureOverlayState();
@@ -146,6 +148,7 @@ class _PlayerGestureOverlayState extends State<PlayerGestureOverlay> {
               Positioned.fill(
                 child: GestureDetector(
                   behavior: HitTestBehavior.translucent,
+                  onTap: widget.onTap,
                   onVerticalDragStart: (d) => _onDragStart(d, width),
                   onVerticalDragUpdate: (d) => _onDragUpdate(d, height),
                   onVerticalDragEnd: _onDragEnd,

--- a/packages/feature_iptv/lib/presentation/widgets/player_overlay.dart
+++ b/packages/feature_iptv/lib/presentation/widgets/player_overlay.dart
@@ -19,6 +19,7 @@ class PlayerOverlay extends StatefulWidget {
     this.onNext,
     this.onGuide,
     this.onFullscreen,
+    this.onReveal,
     this.autoHideDelay = const Duration(seconds: 3),
     this.showTopChrome = true,
     this.showCenterControls = true,
@@ -32,6 +33,7 @@ class PlayerOverlay extends StatefulWidget {
   final VoidCallback? onNext;
   final VoidCallback? onGuide;
   final VoidCallback? onFullscreen;
+  final VoidCallback? onReveal;
   final Duration autoHideDelay;
 
   /// Whether to render the top back/title/quality chrome. Feature-specific
@@ -88,6 +90,7 @@ class _PlayerOverlayState extends State<PlayerOverlay> {
   }
 
   void _reveal() {
+    widget.onReveal?.call();
     setState(() => _controlsVisible = true);
     _startHideTimer();
   }

--- a/packages/feature_iptv/lib/presentation/widgets/video_player_widget.dart
+++ b/packages/feature_iptv/lib/presentation/widgets/video_player_widget.dart
@@ -501,6 +501,7 @@ class _VideoPlayerWidgetState extends ConsumerState<VideoPlayerWidget> {
                           locked: _isLocked,
                           brightness: _brightness,
                           volume: state.isMuted ? 0.0 : state.volume,
+                          onTap: _showControls,
                           onBrightnessChanged: _onBrightnessGestureChanged,
                           onVolumeChanged: (value) {
                             if (state.isMuted) service.toggleMute();
@@ -526,6 +527,7 @@ class _VideoPlayerWidgetState extends ConsumerState<VideoPlayerWidget> {
                           service.resume();
                         }
                       },
+                      onReveal: _showControls,
                       showTopChrome: false,
                       showCenterControls: false,
                       showBottomBar: false,

--- a/packages/feature_iptv/test/iptv/presentation/widgets/player_gesture_overlay_test.dart
+++ b/packages/feature_iptv/test/iptv/presentation/widgets/player_gesture_overlay_test.dart
@@ -15,6 +15,7 @@ void main() {
     double volume = 0.5,
     ValueChanged<double>? onBrightnessChanged,
     ValueChanged<double>? onVolumeChanged,
+    VoidCallback? onTap,
   }) {
     tester.view.physicalSize = const Size(300, 400);
     tester.view.devicePixelRatio = 1.0;
@@ -28,6 +29,7 @@ void main() {
           volume: volume,
           onBrightnessChanged: onBrightnessChanged ?? (_) {},
           onVolumeChanged: onVolumeChanged ?? (_) {},
+          onTap: onTap,
           child: const ColoredBox(color: Colors.black),
         ),
       ),
@@ -88,6 +90,16 @@ void main() {
     expect(find.textContaining('%'), findsOneWidget);
 
     await gesture.up();
+  });
+
+  testWidgets('tapping the gesture surface invokes onTap', (tester) async {
+    var taps = 0;
+    await pumpOverlay(tester, onTap: () => taps++);
+
+    await tester.tap(find.byType(PlayerGestureOverlay));
+    await tester.pump();
+
+    expect(taps, 1);
   });
 
   testWidgets('locked overlay ignores drags entirely', (tester) async {


### PR DESCRIPTION
## Summary
- Port the non-stale player-control reveal behavior from `origin/codex/fix-tv-debug-epg-window` without merging the stale branch.
- Let the gesture overlay forward taps to `VideoPlayerWidget._showControls`, so taps on the video surface can reveal hidden controls while preserving brightness/volume drags.
- Add an `onReveal` seam to the generic `PlayerOverlay` so internal overlay reveal can keep host-owned controls in sync.

## Repository policy / ownership
- Base: exact `origin/main` at `b1023a44eb886ac1bd27e0423bed6a83a18afc00` in isolated worktree `/Users/udaychauhan/workspace/airo-hermes-preserved-work-triage`.
- Owner: TV Experience Architect / Flutter Architect for player touch interaction.
- Reviewers: Chief UX Officer and Chief QA Officer; no platform/pro/AiroCoin dependency changes.
- Cross-agent contract: UI-only callback seams within `feature_iptv` widgets; no lower layer depends on higher layers.

## Validation
- `git diff --check`
- `flutter analyze lib/presentation/widgets/player_gesture_overlay.dart lib/presentation/widgets/player_overlay.dart test/iptv/presentation/widgets/player_gesture_overlay_test.dart` from `packages/feature_iptv` — no issues
- `flutter test test/iptv/presentation/widgets/player_gesture_overlay_test.dart test/presentation/widgets/video_player_widget_background_modes_test.dart` from `packages/feature_iptv` — passed
- Secret scan on diff via `grep -nEi 'password|secret|api[_-]?key|token|credential|gho_'` — no matches
