### PR TITLE
feat(receiver): add gated phone-media product entry

### DIFF
--- a/app/lib/core/config/feature_flags.dart
+++ b/app/lib/core/config/feature_flags.dart
@@ -11,3 +11,12 @@ const bool kEnablePerformanceOverlay = bool.fromEnvironment(
   'ENABLE_PERF_OVERLAY',
   defaultValue: false,
 );
+
+/// Enable the experimental phone-local media handoff entry point.
+///
+/// This stays off in normal builds until the Airo Receiver qualification
+/// matrix and launch gate are complete.
+const bool kEnablePhoneMediaReceiverExperimental = bool.fromEnvironment(
+  'ENABLE_PHONE_MEDIA_RECEIVER',
+  defaultValue: false,
+);

--- a/app/lib/core/routing/app_router.dart
+++ b/app/lib/core/routing/app_router.dart
@@ -27,6 +27,7 @@ import '../../features/life_track/presentation/screens/track_detail_screen.dart'
 import '../../features/life_track/presentation/screens/track_list_screen.dart';
 import '../../core/auth/auth_service.dart';
 import '../../core/app/app_shell.dart';
+import '../config/feature_flags.dart';
 import '../http/http_dog.dart';
 import 'route_names.dart';
 
@@ -267,7 +268,9 @@ class AppRouter {
                   name: 'Stream',
                   builder: (context, state) => IPTVScreen(
                     onOpenVod: () => context.go('/vod'),
-                    onPickLocalMediaForTv: pickPhoneLocalMediaForTv,
+                    onPickLocalMediaForTv: kEnablePhoneMediaReceiverExperimental
+                        ? pickPhoneLocalMediaForTv
+                        : null,
                     deepLinkChannelId: state.uri.queryParameters['channel'],
                   ),
                 ),
@@ -326,7 +329,9 @@ class AppRouter {
                   name: 'Home',
                   builder: (context, state) => IPTVScreen(
                     onOpenVod: () => context.go('/vod'),
-                    onPickLocalMediaForTv: pickPhoneLocalMediaForTv,
+                    onPickLocalMediaForTv: kEnablePhoneMediaReceiverExperimental
+                        ? pickPhoneLocalMediaForTv
+                        : null,
                   ),
                 ),
               ],

--- a/app/lib/core/routing/app_router.dart
+++ b/app/lib/core/routing/app_router.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/foundation.dart';
 import 'package:feature_coin/feature_coin.dart';
 import 'package:go_router/go_router.dart';
 import '../../features/auth/screens/login_screen.dart';
@@ -268,9 +267,7 @@ class AppRouter {
                   name: 'Stream',
                   builder: (context, state) => IPTVScreen(
                     onOpenVod: () => context.go('/vod'),
-                    onPickLocalMediaForTv: kDebugMode
-                        ? pickPhoneLocalMediaForTv
-                        : null,
+                    onPickLocalMediaForTv: pickPhoneLocalMediaForTv,
                     deepLinkChannelId: state.uri.queryParameters['channel'],
                   ),
                 ),
@@ -329,9 +326,7 @@ class AppRouter {
                   name: 'Home',
                   builder: (context, state) => IPTVScreen(
                     onOpenVod: () => context.go('/vod'),
-                    onPickLocalMediaForTv: kDebugMode
-                        ? pickPhoneLocalMediaForTv
-                        : null,
+                    onPickLocalMediaForTv: pickPhoneLocalMediaForTv,
                   ),
                 ),
               ],

--- a/app/lib/features/iptv/phone_media_local_picker.dart
+++ b/app/lib/features/iptv/phone_media_local_picker.dart
@@ -1,11 +1,10 @@
 import 'package:file_picker/file_picker.dart';
 import 'package:platform_player/platform_player.dart';
 
-/// CV-033 debug entry point: lets the user pick a phone-local video file to
-/// stream to a cast receiver. Only wired into the app for debug builds
-/// (see `app_router.dart`) — the end-user surface for this flow is
-/// undecided, so this stays behind a debug gate rather than blocking
-/// hardware testing on final UX.
+/// Lets the user pick a phone-local video file to stream to a cast receiver.
+///
+/// The feature package keeps the picker app-owned so `feature_iptv` does not
+/// depend on `file_picker`, but the flow itself is a real product surface.
 Future<PhoneLocalMediaItem?> pickPhoneLocalMediaForTv() async {
   final result = await FilePicker.pickFiles(type: FileType.video);
   final files = result?.files;

--- a/app/lib/features/iptv/phone_media_local_picker.dart
+++ b/app/lib/features/iptv/phone_media_local_picker.dart
@@ -1,7 +1,8 @@
 import 'package:file_picker/file_picker.dart';
 import 'package:platform_player/platform_player.dart';
 
-/// Lets the user pick a phone-local video file to stream to a cast receiver.
+/// Lets an experimental build pick a phone-local video file to stream to a
+/// receiver.
 ///
 /// The feature package keeps the picker app-owned so `feature_iptv` does not
 /// depend on `file_picker`, but the flow itself is a real product surface.

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -1783,6 +1783,13 @@ packages:
       relative: true
     source: path
     version: "0.0.1"
+  platform_receiver_modes:
+    dependency: transitive
+    description:
+      path: "../packages/platform_receiver_modes"
+      relative: true
+    source: path
+    version: "0.0.1"
   platform_streams:
     dependency: "direct main"
     description:

--- a/docs/wiki/4.-Using-Core-Capabilities.md
+++ b/docs/wiki/4.-Using-Core-Capabilities.md
@@ -120,3 +120,18 @@ Available games documented today:
 
 Planned or documented upcoming games include Texas Hold'em, Poker, Rummy, and
 Solitaire.
+
+## Experimental Phone-to-TV Playback
+
+Qualified development builds can expose **Stream > Play file on TV** by
+launching with:
+
+```bash
+flutter run --dart-define=ENABLE_PHONE_MEDIA_RECEIVER=true
+```
+
+The phone serves the selected personal video over the local Wi-Fi network for
+the active session. The receiver streams byte ranges and does not retain a
+movie-file copy. This capability is experimental and remains hidden in normal
+builds until receiver pairing, device qualification, recovery, and launch-gate
+evidence are complete.

--- a/docs/wiki/7.-Troubleshooting-and-FAQ.md
+++ b/docs/wiki/7.-Troubleshooting-and-FAQ.md
@@ -45,6 +45,14 @@ On macOS, use local playback for now. Desktop casting support needs a dedicated
 native sender, AirPlay route, or system-player design before the Cast action can
 be enabled there.
 
+## Play File on TV Is Missing
+
+Phone-local playback is an experimental receiver capability and is hidden in
+normal builds. Qualified development builds must opt in with
+`--dart-define=ENABLE_PHONE_MEDIA_RECEIVER=true`. Both devices must be on the
+same local Wi-Fi network. The feature is not a desktop, cloud-relay, AirPlay,
+or general transcoding path.
+
 ## FAQ
 
 **Q: Is Airo only an AI app?**

--- a/packages/feature_iptv/lib/presentation/screens/iptv_screen.dart
+++ b/packages/feature_iptv/lib/presentation/screens/iptv_screen.dart
@@ -45,11 +45,9 @@ class IPTVScreen extends ConsumerStatefulWidget {
   /// because the feature package does not depend on go_router or app routes.
   final VoidCallback? onSettings;
 
-  /// CV-033 debug entry point: resolves a phone-local file into a
-  /// [PhoneLocalMediaItem], or null if the user cancelled. Left as an
-  /// optional callback so this package doesn't depend on `file_picker`; the
-  /// app wires this in only for debug builds while the end-user surface for
-  /// "Play on TV" is undecided. Null hides the drawer entry entirely.
+  /// Resolves a phone-local file into a [PhoneLocalMediaItem], or null if the
+  /// user cancelled. Left as an optional callback so this package does not
+  /// depend on `file_picker`; the host app owns the native file-picker wiring.
   final Future<PhoneLocalMediaItem?> Function()? onPickLocalMediaForTv;
 
   /// Channel id resolved from a deep link (universal link, home-screen

--- a/packages/feature_iptv/lib/presentation/widgets/iptv_navigation_drawer.dart
+++ b/packages/feature_iptv/lib/presentation/widgets/iptv_navigation_drawer.dart
@@ -23,9 +23,8 @@ class IptvNavigationDrawer extends StatelessWidget {
   final VoidCallback? onSettings;
   final bool showMovies;
 
-  /// CV-033 debug entry point: streams a phone-local file to a receiver.
-  /// Left unwired (null) unless the app build supplies a picker, since the
-  /// end-user surface for this flow is still undecided.
+  /// Streams a phone-local file to a receiver.
+  /// Left unwired (null) unless the host app supplies a picker callback.
   final VoidCallback? onPlayLocalFileOnTv;
 
   @override
@@ -77,7 +76,7 @@ class IptvNavigationDrawer extends StatelessWidget {
               ListTile(
                 key: const ValueKey('iptv-drawer-play-on-tv'),
                 leading: const Icon(Icons.cast_outlined),
-                title: const Text('Play file on TV (debug)'),
+                title: const Text('Play file on TV'),
                 onTap: () => _select(context, onPlayLocalFileOnTv),
               ),
           ],

--- a/packages/feature_iptv/test/iptv/presentation/screens/iptv_screen_test.dart
+++ b/packages/feature_iptv/test/iptv/presentation/screens/iptv_screen_test.dart
@@ -718,7 +718,7 @@ void main() {
 
       await openIptvDrawer(tester);
 
-      expect(find.text('Play file on TV (debug)'), findsNothing);
+      expect(find.text('Play file on TV'), findsNothing);
     },
   );
 
@@ -738,7 +738,7 @@ void main() {
 
       await openIptvDrawer(tester);
 
-      expect(find.text('Play file on TV (debug)'), findsOneWidget);
+      expect(find.text('Play file on TV'), findsOneWidget);
 
       await selectDrawerTile(tester, const ValueKey('iptv-drawer-play-on-tv'));
 

--- a/packages/feature_iptv/test/iptv/presentation/widgets/iptv_navigation_drawer_test.dart
+++ b/packages/feature_iptv/test/iptv/presentation/widgets/iptv_navigation_drawer_test.dart
@@ -133,7 +133,7 @@ void main() {
     await tester.tap(find.byIcon(Icons.menu));
     await tester.pumpAndSettle();
 
-    expect(find.text('Play file on TV (debug)'), findsNothing);
+    expect(find.text('Play file on TV'), findsNothing);
   });
 
   testWidgets(
@@ -145,13 +145,13 @@ void main() {
       await tester.tap(find.byIcon(Icons.menu));
       await tester.pumpAndSettle();
 
-      expect(find.text('Play file on TV (debug)'), findsOneWidget);
+      expect(find.text('Play file on TV'), findsOneWidget);
 
-      await tester.tap(find.text('Play file on TV (debug)'));
+      await tester.tap(find.text('Play file on TV'));
       await tester.pumpAndSettle();
 
       expect(tapped, isTrue);
-      expect(find.text('Play file on TV (debug)'), findsNothing);
+      expect(find.text('Play file on TV'), findsNothing);
     },
   );
 }

--- a/packages/platform_player/lib/src/services/phone_media_cast_handoff.dart
+++ b/packages/platform_player/lib/src/services/phone_media_cast_handoff.dart
@@ -5,6 +5,7 @@ import 'dart:math';
 import 'package:connectivity_plus/connectivity_plus.dart';
 import 'package:core_media_routing/core_media_routing.dart';
 import 'package:equatable/equatable.dart';
+import 'package:platform_receiver_modes/platform_receiver_modes.dart';
 
 import '../models/cast_models.dart';
 import '../models/phone_media_diagnostic_models.dart';
@@ -52,10 +53,39 @@ class PhoneMediaReceiverCapabilities extends Equatable {
     required this.supportedVideoCodecs,
   });
 
+  static const none = PhoneMediaReceiverCapabilities(
+    supportedContainers: {},
+    supportedVideoCodecs: {},
+  );
+
   static const chromecastDefault = PhoneMediaReceiverCapabilities(
     supportedContainers: {'mp4', 'm4v', 'webm'},
     supportedVideoCodecs: {'h264', 'vp8', 'vp9'},
   );
+
+  /// Conservative envelope derived from Airo's legacy-receiver mode contract.
+  ///
+  /// The contract does not currently expose codec tables directly, so this
+  /// maps mode classes to the safest local-file assumptions:
+  /// - `blocked`: reject all direct local-file handoffs
+  /// - `lite`/`restrictedLite`: MP4/M4V with H.264 only
+  /// - `off`: fall back to the generic Cast baseline
+  factory PhoneMediaReceiverCapabilities.forLegacyReceiverMode(
+    LegacyReceiverModeContract contract,
+  ) {
+    switch (contract.modeId) {
+      case LegacyReceiverModeId.blocked:
+        return none;
+      case LegacyReceiverModeId.liteReceiver:
+      case LegacyReceiverModeId.restrictedLiteReceiver:
+        return const PhoneMediaReceiverCapabilities(
+          supportedContainers: {'mp4', 'm4v'},
+          supportedVideoCodecs: {'h264'},
+        );
+      case LegacyReceiverModeId.off:
+        return chromecastDefault;
+    }
+  }
 
   final Set<String> supportedContainers;
   final Set<String> supportedVideoCodecs;
@@ -107,6 +137,7 @@ class PhoneMediaCastHandoff {
   PhoneMediaCastHandoff({
     required this._castController,
     this.capabilities = PhoneMediaReceiverCapabilities.chromecastDefault,
+    this.receiverModeContract,
     this._bindAddress,
     this.onDiagnosticEvent,
     this.onSessionEvent,
@@ -119,6 +150,7 @@ class PhoneMediaCastHandoff {
 
   final AiroCastController _castController;
   final PhoneMediaReceiverCapabilities capabilities;
+  final LegacyReceiverModeContract? receiverModeContract;
   final InternetAddress? _bindAddress;
   final Duration _sessionTtl;
   final Duration _idleTimeout;
@@ -141,8 +173,14 @@ class PhoneMediaCastHandoff {
   String? get connectedDeviceName =>
       _castController.currentSessionState.device?.name;
 
+  PhoneMediaReceiverCapabilities get resolvedCapabilities {
+    final contract = receiverModeContract;
+    if (contract == null) return capabilities;
+    return PhoneMediaReceiverCapabilities.forLegacyReceiverMode(contract);
+  }
+
   Future<PhoneMediaHandoffResult> start(PhoneLocalMediaItem item) async {
-    final unsupportedReason = capabilities.evaluate(item);
+    final unsupportedReason = resolvedCapabilities.evaluate(item);
     if (unsupportedReason != null) {
       return PhoneMediaHandoffUnsupported(reason: unsupportedReason);
     }

--- a/packages/platform_player/module.yaml
+++ b/packages/platform_player/module.yaml
@@ -9,6 +9,7 @@ allowed_dependencies:
   - flutter_chrome_cast
   - core_media_routing
   - platform_receiver_modes
+  - product_capabilities
 forbidden_dependencies:
   - app
 quality_gates: {}

--- a/packages/platform_player/module.yaml
+++ b/packages/platform_player/module.yaml
@@ -8,6 +8,7 @@ allowed_dependencies:
   - platform_channels
   - flutter_chrome_cast
   - core_media_routing
+  - platform_receiver_modes
 forbidden_dependencies:
   - app
 quality_gates: {}

--- a/packages/platform_player/pubspec.yaml
+++ b/packages/platform_player/pubspec.yaml
@@ -26,6 +26,8 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   flutter_lints: ^6.0.0
+  product_capabilities:
+    path: ../product_capabilities
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec

--- a/packages/platform_player/pubspec.yaml
+++ b/packages/platform_player/pubspec.yaml
@@ -19,6 +19,8 @@ dependencies:
     path: third_party/flutter_chrome_cast
   platform_channels:
     path: ../platform_channels
+  platform_receiver_modes:
+    path: ../platform_receiver_modes
 
 dev_dependencies:
   flutter_test:

--- a/packages/platform_player/test/phone_media_cast_handoff_test.dart
+++ b/packages/platform_player/test/phone_media_cast_handoff_test.dart
@@ -101,9 +101,13 @@ void main() {
   test('legacy lite receiver mode resolves a conservative local-file '
       'capability envelope', () async {
     final handoff = handoffFor(
-      receiverModeContract: legacyModeContract(LegacyReceiverModeId.liteReceiver),
+      receiverModeContract: legacyModeContract(
+        LegacyReceiverModeId.liteReceiver,
+      ),
     );
-    final result = await handoff.start(itemFor(container: 'webm', videoCodec: 'vp9'));
+    final result = await handoff.start(
+      itemFor(container: 'webm', videoCodec: 'vp9'),
+    );
 
     expect(result, isA<PhoneMediaHandoffUnsupported>());
     final unsupported = result as PhoneMediaHandoffUnsupported;
@@ -111,16 +115,18 @@ void main() {
     expect(handoff.isServing, isFalse);
   });
 
-  test('legacy blocked receiver mode rejects even supported local files',
-      () async {
-    final handoff = handoffFor(
-      receiverModeContract: legacyModeContract(LegacyReceiverModeId.blocked),
-    );
-    final result = await handoff.start(itemFor());
+  test(
+    'legacy blocked receiver mode rejects even supported local files',
+    () async {
+      final handoff = handoffFor(
+        receiverModeContract: legacyModeContract(LegacyReceiverModeId.blocked),
+      );
+      final result = await handoff.start(itemFor());
 
-    expect(result, isA<PhoneMediaHandoffUnsupported>());
-    expect(handoff.isServing, isFalse);
-  });
+      expect(result, isA<PhoneMediaHandoffUnsupported>());
+      expect(handoff.isServing, isFalse);
+    },
+  );
 
   test('starts the LAN server and loads a buffered cast request', () async {
     final handoff = handoffFor();
@@ -237,8 +243,7 @@ void main() {
   });
 
   test('stops the server when connectivity reports disconnected', () async {
-    final connectivityController =
-        StreamController<List<ConnectivityResult>>();
+    final connectivityController = StreamController<List<ConnectivityResult>>();
     final events = <PhoneMediaDiagnosticEvent>[];
     addTearDown(connectivityController.close);
     final handoff = PhoneMediaCastHandoff(

--- a/packages/platform_player/test/phone_media_cast_handoff_test.dart
+++ b/packages/platform_player/test/phone_media_cast_handoff_test.dart
@@ -4,6 +4,8 @@ import 'dart:io';
 import 'package:connectivity_plus/connectivity_plus.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:platform_player/platform_player.dart';
+import 'package:platform_receiver_modes/platform_receiver_modes.dart';
+import 'package:product_capabilities/product_capabilities.dart';
 
 void main() {
   late Directory tempDir;
@@ -44,10 +46,12 @@ void main() {
   PhoneMediaCastHandoff handoffFor({
     PhoneMediaReceiverCapabilities capabilities =
         PhoneMediaReceiverCapabilities.chromecastDefault,
+    LegacyReceiverModeContract? receiverModeContract,
   }) {
     return PhoneMediaCastHandoff(
       castController: castController,
       capabilities: capabilities,
+      receiverModeContract: receiverModeContract,
       bindAddress: InternetAddress.loopbackIPv4,
       // Tests that aren't exercising connectivity teardown shouldn't reach
       // the real platform channel, which has no plugin registered here.
@@ -93,6 +97,30 @@ void main() {
       await handoff.stopHandoff();
     },
   );
+
+  test('legacy lite receiver mode resolves a conservative local-file '
+      'capability envelope', () async {
+    final handoff = handoffFor(
+      receiverModeContract: legacyModeContract(LegacyReceiverModeId.liteReceiver),
+    );
+    final result = await handoff.start(itemFor(container: 'webm', videoCodec: 'vp9'));
+
+    expect(result, isA<PhoneMediaHandoffUnsupported>());
+    final unsupported = result as PhoneMediaHandoffUnsupported;
+    expect(unsupported.reason, PhoneMediaUnsupportedReason.container);
+    expect(handoff.isServing, isFalse);
+  });
+
+  test('legacy blocked receiver mode rejects even supported local files',
+      () async {
+    final handoff = handoffFor(
+      receiverModeContract: legacyModeContract(LegacyReceiverModeId.blocked),
+    );
+    final result = await handoff.start(itemFor());
+
+    expect(result, isA<PhoneMediaHandoffUnsupported>());
+    expect(handoff.isServing, isFalse);
+  });
 
   test('starts the LAN server and loads a buffered cast request', () async {
     final handoff = handoffFor();
@@ -233,6 +261,59 @@ void main() {
 
     await handoff.dispose();
   });
+}
+
+LegacyReceiverModeContract legacyModeContract(LegacyReceiverModeId modeId) {
+  return LegacyReceiverModeContract(
+    contractId: 'contract-${modeId.stableId}',
+    modeId: modeId,
+    sourceProfileId: 'profile-1',
+    enabled: modeId != LegacyReceiverModeId.off,
+    activationBlocked: modeId == LegacyReceiverModeId.blocked,
+    recommendedProductProfile: switch (modeId) {
+      LegacyReceiverModeId.blocked => ProductProfileId.embeddedReceiver,
+      LegacyReceiverModeId.off ||
+      LegacyReceiverModeId.liteReceiver ||
+      LegacyReceiverModeId.restrictedLiteReceiver =>
+        ProductProfileId.liteReceiver,
+    },
+    triggers: const [],
+    navigation: const [],
+    homeSections: const [],
+    includedModules: const {},
+    disabledModules: const {},
+    dataBudget: const LegacyReceiverDataBudget(
+      epgPastHours: 0,
+      epgFutureHours: 0,
+      catalogPageSize: 0,
+      maxRecentItems: 0,
+      maxFavoriteItems: 0,
+      allowFullLocalIndex: false,
+      allowBackgroundEnrichment: false,
+    ),
+    visualBudget: const LegacyReceiverVisualBudget(
+      artworkPolicy: LegacyReceiverArtworkPolicy.textOnly,
+      motionPolicy: LegacyReceiverMotionPolicy.none,
+      maxArtworkCacheMb: 0,
+      allowAnimatedPreviews: false,
+      allowBlurEffects: false,
+      allowAutoplayPreviews: false,
+    ),
+    delegationPolicy: LegacyReceiverDelegationPolicy(
+      preferred: const {},
+      required: const {},
+      allowStandalonePlayback: true,
+      allowCompanionDiscovery: true,
+    ),
+    resourceBudget: const ProductResourceBudget(
+      maxMemoryMb: 256,
+      maxStorageMb: 512,
+      maxArtworkCacheMb: 64,
+      maxBackgroundJobs: 1,
+    ),
+    runtimeConstraints: const [],
+    capturedAt: DateTime(2026),
+  );
 }
 
 /// Delegates to the fake for state but fails every media load.


### PR DESCRIPTION
## Summary

- resolve phone-local media compatibility from the selected receiver-mode contract
- promote **Play file on TV** from a debug-only label to a real product surface
- keep that surface disabled by default behind `ENABLE_PHONE_MEDIA_RECEIVER` until milestone #10 qualification and launch gates pass
- document the experimental opt-in and declare the new package/test dependency boundaries

Closes part of #844. Follow-up to #1082. Does not close #889 or the milestone.

## Test Plan

- [x] `flutter analyze` passed for the touched app, `platform_player`, and `feature_iptv` files
- [x] focused `platform_player` server/handoff tests passed (41 tests)
- [x] focused `feature_iptv` handoff/screen/drawer tests passed (35 passed, 2 existing skips)
- [x] `python3 scripts/check-module-manifests.py`
- [x] `bash scripts/check-docs-completeness.sh`
- [x] `git diff --check origin/main...HEAD`
- [ ] Manual device verification is not complete: no Android/TV device is attached; tracked by #889

**Verification environment:** Host-only

## Agent Policy

- [x] #844 includes a Critical Agent Gate and Feature Packet.
- [x] #844 documents the framework/application cross-agent contract.
- [x] Deterministic use cases are in #844; AUTO-006/AUTO-007 were added in issue comment 5068605849.
- [x] Redaction and lifecycle behavior remain covered by the focused server/handoff tests.
- [x] Android Emulator was not used.

## Council Review

Required by `docs/agents/COUNCIL.md` for the touched widget/package, dependency, boundary, and user-visible feature:

- Playback Architect: pending
- Flutter Architect: pending
- Chief Architect: pending
- Platform Architect: pending
- Chief Performance Officer: pending
- Chief Open Source Officer: pending
- Chief Security Officer: pending
- Chief QA Officer: pending
- Product Manager: pending

- [x] Decision Matrix reviewed and all required roles are listed above.
- [x] Touched packages have valid `module.yaml` manifests.
- [ ] Every required role has reviewed.

## User-Facing Documentation

- [x] Updated `docs/wiki/4.-Using-Core-Capabilities.md`.
- [x] Updated `docs/wiki/7.-Troubleshooting-and-FAQ.md`.

## Plugin and Size Impact

- [x] Adds a path dependency from `platform_player` to existing `platform_receiver_modes`; no third-party package is introduced.
- [x] Adds existing `product_capabilities` as a test-only direct dependency.
- [x] Size impact is limited to receiver capability mapping, gating, and tests; no plugin or binary asset is added.

## Checklist

- [x] Code is formatted.
- [x] Focused host-only tests are included above.
- [x] No sensitive data, credentials, URLs, local paths, or session tokens are added to diagnostics.

## Release Notes

- [x] Experimental phone-to-TV local-file entry is documented and remains disabled in normal builds.
