### PR TITLE
docs(setup): add Codex MCP setup guides

### DIFF
--- a/docs/setup/GITHUB_MCP_SERVER.md
+++ b/docs/setup/GITHUB_MCP_SERVER.md
@@ -1,0 +1,69 @@
+# GitHub MCP Server For Codex
+
+This guide documents optional local Codex MCP setup for Airo contributors who want GitHub tools available in trusted workspaces. Do not commit personal Codex config, tokens, or local credential files to this repository.
+
+## Hosted GitHub MCP Server
+
+GitHub's hosted MCP endpoint can be configured in your local Codex config:
+
+```toml
+[mcp_servers.github]
+url = "https://api.githubcopilot.com/mcp/"
+bearer_token_env_var = "GITHUB_PAT_TOKEN"
+```
+
+Why this shape:
+
+- Codex supports project and user MCP server configuration for trusted workspaces.
+- GitHub documents a hosted MCP endpoint for Codex.
+- The token is read from an environment variable instead of stored in config.
+
+## Setup
+
+1. Create a least-privilege GitHub Personal Access Token appropriate for the repository operations you intend to perform.
+2. Export it before starting Codex:
+
+   ```bash
+   export GITHUB_PAT_TOKEN=<YOUR_GITHUB_PAT>
+   ```
+
+3. Add the `mcp_servers.github` snippet to your local Codex config.
+4. Restart Codex or reopen the Airo task.
+5. Run `/mcp` and confirm the `github` server is listed.
+
+Notes:
+
+- Do not commit `.env` files with real tokens.
+- Do not commit local `.codex/config.toml` files unless repository maintainers explicitly decide to track a project-scoped config.
+- If you prefer local shell persistence, add the export to your shell profile or use a secret manager.
+
+## Local Docker Server With OAuth
+
+Use this if you do not want to manage a PAT for Codex. GitHub's Codex guide documents a local Docker flow that opens a browser for OAuth and keeps the token out of repository config. Example local config:
+
+```toml
+mcp_oauth_callback_port = 8085
+
+[mcp_servers.github]
+command = "docker"
+args = ["run", "-i", "--rm", "-p", "127.0.0.1:8085:8085", "-e", "GITHUB_OAUTH_CALLBACK_PORT", "ghcr.io/github/github-mcp-server"]
+env = { GITHUB_OAUTH_CALLBACK_PORT = "8085" }
+```
+
+This version is not enabled by default in Airo because it would require Docker for every trusted workspace.
+
+## Verification
+
+After setup:
+
+1. Open Codex in this repository.
+2. Run `/mcp`.
+3. Confirm `github` is enabled.
+4. Try a simple GitHub task such as listing repository context or reading an issue.
+
+## Sources
+
+- OpenAI Codex MCP docs: https://developers.openai.com/codex/mcp
+- OpenAI Codex config reference: https://developers.openai.com/codex/config-reference
+- GitHub MCP Server: https://github.com/github/github-mcp-server
+- GitHub Codex installation guide: https://github.com/github/github-mcp-server/blob/main/docs/installation-guides/install-codex.md

--- a/docs/setup/HACKER_NEWS_MCP_SERVER.md
+++ b/docs/setup/HACKER_NEWS_MCP_SERVER.md
@@ -1,0 +1,53 @@
+# Hacker News MCP Server For Codex
+
+This guide documents optional local Codex MCP setup for Hacker News research workflows in trusted Airo workspaces.
+
+## Local STDIO Server
+
+The `mcp-hn` server can run through Codex's STDIO MCP support:
+
+```toml
+[mcp_servers.hackernews]
+command = "uvx"
+args = ["mcp-hn"]
+```
+
+Why this shape:
+
+- Codex supports STDIO MCP servers in trusted workspaces.
+- The upstream `mcp-hn` README documents `uvx mcp-hn` as its runtime shape for MCP clients.
+- The upstream package defines the `mcp-hn` script entrypoint and requires Python 3.12 or newer.
+
+## Prerequisites
+
+1. Install `uv` if it is not already available.
+2. Ensure your Python environment supports Python 3.12 or newer.
+3. Add the `mcp_servers.hackernews` snippet to your local Codex config.
+4. Restart Codex after trusting the project.
+
+No API key is documented for this server.
+
+## Verification
+
+After setup:
+
+1. Open Codex in this repository.
+2. Run `/mcp`.
+3. Confirm `hackernews` is enabled.
+4. Try a prompt such as "Show today's top Hacker News stories."
+
+## Upstream Tools
+
+The upstream README documents these tools:
+
+- `get_stories`
+- `get_story_info`
+- `search_stories`
+- `get_user_info`
+
+## Sources
+
+- OpenAI Codex MCP docs: https://developers.openai.com/codex/mcp
+- OpenAI Codex config reference: https://developers.openai.com/codex/config-reference
+- Hacker News MCP Server README: https://github.com/erithwik/mcp-hn/blob/main/README.md
+- Hacker News MCP Server package metadata: https://github.com/erithwik/mcp-hn/blob/main/pyproject.toml

--- a/docs/setup/README.md
+++ b/docs/setup/README.md
@@ -20,6 +20,20 @@ Detailed setup and configuration guides.
 - GitHub secret setup
 - Dashboard access
 
+### [GITHUB_MCP_SERVER.md](./GITHUB_MCP_SERVER.md)
+**GitHub MCP server for Codex**:
+- Local Codex setup
+- PAT and Docker/OAuth options
+- Safe credential handling
+- Verification steps
+
+### [HACKER_NEWS_MCP_SERVER.md](./HACKER_NEWS_MCP_SERVER.md)
+**Hacker News MCP server for Codex**:
+- Local Codex setup
+- `uvx` runtime shape
+- Python/`uv` prerequisites
+- Verification steps
+
 ---
 
 ## 🎯 Setup Guides
@@ -36,6 +50,18 @@ Detailed setup and configuration guides.
 3. Generate tokens
 4. Add GitHub secrets
 
+### GitHub MCP Server
+1. Read [GITHUB_MCP_SERVER.md](./GITHUB_MCP_SERVER.md)
+2. Choose hosted PAT or local Docker/OAuth
+3. Add the server to your local Codex config
+4. Verify the `github` server appears in `/mcp`
+
+### Hacker News MCP Server
+1. Read [HACKER_NEWS_MCP_SERVER.md](./HACKER_NEWS_MCP_SERVER.md)
+2. Install `uv` if needed
+3. Add the server to your local Codex config
+4. Verify the `hackernews` server appears in `/mcp`
+
 ---
 
 ## 📋 Checklist
@@ -47,6 +73,8 @@ Detailed setup and configuration guides.
 - [ ] Snyk account created
 - [ ] Tokens generated
 - [ ] GitHub secrets added
+- [ ] GitHub MCP server configured in local Codex
+- [ ] Hacker News MCP server configured in local Codex
 - [ ] First build successful
 
 ---
@@ -54,6 +82,8 @@ Detailed setup and configuration guides.
 ## 🔗 Links
 
 - **GitHub Actions**: https://docs.github.com/en/actions
+- **GitHub MCP Server**: https://github.com/github/github-mcp-server
+- **Hacker News MCP Server**: https://github.com/erithwik/mcp-hn
 - **SonarCloud**: https://sonarcloud.io
 - **Snyk**: https://app.snyk.io
 


### PR DESCRIPTION
## Summary
- Add safe setup docs for optional GitHub and Hacker News MCP servers in local Codex workspaces.
- Link the new guides from `docs/setup/README.md`.
- Intentionally do not commit archive `.codex/config.toml`, credentials, local paths, or stale `implementation_plan.md`.

## Phase 2 archive decision
Ported from `origin/archive/primary-wip-20260724` as a documentation-only slice after review. Current `origin/main` remains source of truth; archive config and planning content were not merged directly.

## Validation
- `git diff --cached --check`
- staged diff secret/path scan for PAT-like prefixes, private-key markers, inline assignments, and `/Users/` paths
- `search_files` scan of `docs/setup` for PAT-like prefixes/local paths/private-key markers: no matches

## Not included
- `.codex/config.toml` remains unmerged because project-scoped Codex config should be a maintainer decision and local config must not carry credentials.
- `implementation_plan.md` remains unmerged; it should be tracked as an issue/backlog item instead of root authoritative docs.
- TV integration-test infrastructure is tracked separately because it needs focused adaptation and deterministic validation.
- lockfile/build-profile changes are rejected as stale and should only be regenerated from current main after accepted manifest/build changes.
