### PR TITLE
fix(app): install Cast controller in mobile entrypoint

### DIFF
--- a/app/android/app/src/main/kotlin/io/airo/app/MainActivity.kt
+++ b/app/android/app/src/main/kotlin/io/airo/app/MainActivity.kt
@@ -37,6 +37,7 @@ class MainActivity : AudioServiceActivity() {
 
     private lateinit var pictureInPicturePlugin: AiroPictureInPicturePlugin
     private lateinit var backgroundAudioPlugin: AiroBackgroundAudioPlugin
+    private lateinit var phoneMediaPickerPlugin: PhoneMediaPickerPlugin
 
     override fun shouldDestroyEngineWithHost(): Boolean {
         return false
@@ -110,6 +111,9 @@ class MainActivity : AudioServiceActivity() {
 
         backgroundAudioPlugin = AiroBackgroundAudioPlugin(this)
         backgroundAudioPlugin.register(flutterEngine.dartExecutor.binaryMessenger)
+
+        phoneMediaPickerPlugin = PhoneMediaPickerPlugin(this)
+        phoneMediaPickerPlugin.register(flutterEngine.dartExecutor.binaryMessenger)
     }
 
     override fun onUserLeaveHint() {
@@ -190,6 +194,16 @@ class MainActivity : AudioServiceActivity() {
                 }
             }
         }
+    }
+
+    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
+        if (
+            ::phoneMediaPickerPlugin.isInitialized &&
+            phoneMediaPickerPlugin.onActivityResult(requestCode, resultCode, data)
+        ) {
+            return
+        }
+        super.onActivityResult(requestCode, resultCode, data)
     }
 
     private fun readCalendarEvents(date: String, endDate: String?, result: MethodChannel.Result) {

--- a/app/android/app/src/main/kotlin/io/airo/app/PhoneMediaPickerPlugin.kt
+++ b/app/android/app/src/main/kotlin/io/airo/app/PhoneMediaPickerPlugin.kt
@@ -1,0 +1,107 @@
+package io.airo.app
+
+import android.app.Activity
+import android.content.Intent
+import android.net.Uri
+import android.os.ParcelFileDescriptor
+import android.provider.OpenableColumns
+import io.flutter.plugin.common.BinaryMessenger
+import io.flutter.plugin.common.MethodChannel
+import java.util.UUID
+
+class PhoneMediaPickerPlugin(private val activity: Activity) {
+    companion object {
+        private const val CHANNEL = "com.airo/phone_media_picker"
+        private const val REQUEST_PICK_VIDEO = 9410
+    }
+
+    private val leases = mutableMapOf<String, ParcelFileDescriptor>()
+    private var pendingResult: MethodChannel.Result? = null
+
+    fun register(messenger: BinaryMessenger) {
+        MethodChannel(messenger, CHANNEL).setMethodCallHandler { call, result ->
+            when (call.method) {
+                "pickVideo" -> pickVideo(result)
+                "release" -> {
+                    release(call.argument<String>("token"))
+                    result.success(null)
+                }
+                else -> result.notImplemented()
+            }
+        }
+    }
+
+    private fun pickVideo(result: MethodChannel.Result) {
+        if (pendingResult != null) {
+            result.error("picker_active", "A video picker is already open.", null)
+            return
+        }
+
+        val intent = Intent(Intent.ACTION_OPEN_DOCUMENT).apply {
+            type = "video/*"
+            addCategory(Intent.CATEGORY_OPENABLE)
+            addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+        }
+        if (intent.resolveActivity(activity.packageManager) == null) {
+            result.error("picker_unavailable", "No video picker is available.", null)
+            return
+        }
+
+        pendingResult = result
+        activity.startActivityForResult(intent, REQUEST_PICK_VIDEO)
+    }
+
+    fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?): Boolean {
+        if (requestCode != REQUEST_PICK_VIDEO) return false
+
+        val result = pendingResult
+        pendingResult = null
+        if (result == null) return true
+        val uri = data?.data
+        if (resultCode != Activity.RESULT_OK || uri == null) {
+            result.success(null)
+            return true
+        }
+
+        try {
+            val descriptor = activity.contentResolver.openFileDescriptor(uri, "r")
+                ?: error("The selected video could not be opened.")
+            val title = queryDisplayName(uri) ?: "Selected video"
+            val token = UUID.randomUUID().toString()
+            leases[token] = descriptor
+            result.success(
+                mapOf(
+                    "token" to token,
+                    "filePath" to "/proc/self/fd/${descriptor.fd}",
+                    "title" to title,
+                    "size" to descriptor.statSize
+                )
+            )
+        } catch (error: Exception) {
+            result.error(
+                "open_failed",
+                error.message ?: "The selected video could not be opened.",
+                null
+            )
+        }
+        return true
+    }
+
+    private fun queryDisplayName(uri: Uri): String? {
+        return activity.contentResolver.query(
+            uri,
+            arrayOf(OpenableColumns.DISPLAY_NAME),
+            null,
+            null,
+            null
+        )?.use { cursor ->
+            if (!cursor.moveToFirst()) return@use null
+            val index = cursor.getColumnIndex(OpenableColumns.DISPLAY_NAME)
+            if (index < 0) null else cursor.getString(index)
+        }
+    }
+
+    private fun release(token: String?) {
+        token?.let(leases::remove)?.close()
+    }
+}

--- a/app/lib/core/app/app_shell.dart
+++ b/app/lib/core/app/app_shell.dart
@@ -12,12 +12,11 @@ import 'app_shell_chrome.dart';
 import '../../features/music/presentation/widgets/mini_player.dart';
 import 'package:feature_iptv/feature_iptv.dart';
 
-/// App shell with bottom navigation whose destinations vary by layout
-/// width: phone shows exactly 5 destinations (Home, Live, Guide, Favorites,
-/// Settings) matching the TV sidebar, while tablet/desktop shows a curated
-/// 8-destination set (the original six super-app domains plus Guide and
-/// Favorites) — see `AppNavigationPolicy` in `navigation_provider.dart` for
-/// the exact lists per width.
+/// Airo super-app shell with destinations that vary by layout width.
+///
+/// Compact layouts keep four primary domains visible and put all other Airo
+/// branches behind More. Tablet/desktop shows a curated 8-destination set.
+/// Airo TV uses its own shell and navigation policy.
 class AppShell extends ConsumerWidget {
   const AppShell({
     super.key,

--- a/app/lib/core/app/main_provider_overrides.dart
+++ b/app/lib/core/app/main_provider_overrides.dart
@@ -1,0 +1,18 @@
+import 'package:feature_iptv/feature_iptv.dart';
+import 'package:flutter_riverpod/misc.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../../features/iptv/iptv_cast_provider_override.dart';
+
+List<Override> buildMainProviderOverrides({
+  required SharedPreferences prefs,
+  required EpgReminderNotificationGateway epgReminderGateway,
+}) {
+  return [
+    sharedPreferencesProvider.overrideWithValue(prefs),
+    epgReminderNotificationGatewayProvider.overrideWithValue(
+      epgReminderGateway,
+    ),
+    realIptvCastControllerOverride(),
+  ];
+}

--- a/app/lib/core/providers/navigation_provider.dart
+++ b/app/lib/core/providers/navigation_provider.dart
@@ -163,9 +163,9 @@ class AppNavigationPolicy {
   }
 }
 
-/// Phone bottom nav: exactly 5 destinations, matching the TV sidebar
-/// (`tv_shell.dart`) one-for-one — Home, Live, Guide, Favorites, Settings.
-/// All 5 fit persistently, so no overflow is needed on phone.
+/// Phone bottom nav keeps Airo's four primary super-app domains visible and
+/// exposes every remaining branch through a shared overflow destination.
+/// Airo TV owns its separate navigation policy in `tv_shell.dart`.
 ///
 /// Wide (tablet/desktop) layouts get a *different* curated set, not the
 /// full ten-tab list: the original six super-app domains (Coins, Mind,
@@ -180,11 +180,10 @@ class AppNavigationPolicy {
 /// `ProfileScreen`'s "Settings" entry) regardless of screen width.
 const appNavigationPolicy = AppNavigationPolicy(
   compactPrimaryTabs: [
-    AppNavigationTab.home,
+    AppNavigationTab.coins,
+    AppNavigationTab.mind,
+    AppNavigationTab.beats,
     AppNavigationTab.live,
-    AppNavigationTab.guide,
-    AppNavigationTab.favorites,
-    AppNavigationTab.settings,
   ],
   widePrimaryTabs: [
     AppNavigationTab.coins,
@@ -196,7 +195,14 @@ const appNavigationPolicy = AppNavigationPolicy(
     AppNavigationTab.guide,
     AppNavigationTab.favorites,
   ],
-  overflowTabs: [],
+  overflowTabs: [
+    AppNavigationTab.arena,
+    AppNavigationTab.quest,
+    AppNavigationTab.home,
+    AppNavigationTab.guide,
+    AppNavigationTab.favorites,
+    AppNavigationTab.settings,
+  ],
 );
 
 final appNavigationPolicyProvider = Provider<AppNavigationPolicy>(

--- a/app/lib/features/iptv/phone_media_local_picker.dart
+++ b/app/lib/features/iptv/phone_media_local_picker.dart
@@ -1,5 +1,12 @@
+import 'dart:io';
+
 import 'package:file_picker/file_picker.dart';
+import 'package:flutter/services.dart';
 import 'package:platform_player/platform_player.dart';
+
+const _androidPhoneMediaPickerChannel = MethodChannel(
+  'com.airo/phone_media_picker',
+);
 
 /// Lets an experimental build pick a phone-local video file to stream to a
 /// receiver.
@@ -7,11 +14,14 @@ import 'package:platform_player/platform_player.dart';
 /// The feature package keeps the picker app-owned so `feature_iptv` does not
 /// depend on `file_picker`, but the flow itself is a real product surface.
 Future<PhoneLocalMediaItem?> pickPhoneLocalMediaForTv() async {
-  final result = await FilePicker.pickFiles(type: FileType.video);
-  final files = result?.files;
-  if (files == null || files.isEmpty) return null;
+  if (Platform.isAndroid) {
+    return pickAndroidPhoneLocalMediaForTv(
+      channel: _androidPhoneMediaPickerChannel,
+    );
+  }
 
-  final file = files.first;
+  final file = await FilePicker.pickFile(type: FileType.video);
+  if (file == null) return null;
   final path = file.path;
   if (path == null) return null;
 
@@ -20,4 +30,63 @@ Future<PhoneLocalMediaItem?> pickPhoneLocalMediaForTv() async {
     title: file.name,
     container: (file.extension ?? '').toLowerCase(),
   );
+}
+
+Future<PhoneLocalMediaItem?> pickAndroidPhoneLocalMediaForTv({
+  required MethodChannel channel,
+}) async {
+  try {
+    final selection = await channel.invokeMapMethod<String, Object?>(
+      'pickVideo',
+    );
+    if (selection == null) return null;
+
+    final token = selection['token'] as String?;
+    final filePath = selection['filePath'] as String?;
+    final title = selection['title'] as String?;
+    if (token == null ||
+        token.isEmpty ||
+        filePath == null ||
+        filePath.isEmpty ||
+        title == null ||
+        title.isEmpty) {
+      if (token != null && token.isNotEmpty) {
+        await channel.invokeMethod<void>('release', {'token': token});
+      }
+      return null;
+    }
+
+    return PhoneLocalMediaItem(
+      filePath: filePath,
+      title: title,
+      container: _extensionOf(title),
+      sourceLease: _AndroidPhoneMediaSourceLease(
+        channel: channel,
+        token: token,
+      ),
+    );
+  } on PlatformException {
+    return null;
+  }
+}
+
+String _extensionOf(String fileName) {
+  final separator = fileName.lastIndexOf('.');
+  if (separator < 0 || separator == fileName.length - 1) return '';
+  return fileName.substring(separator + 1).toLowerCase();
+}
+
+class _AndroidPhoneMediaSourceLease implements PhoneMediaSourceLease {
+  _AndroidPhoneMediaSourceLease({required this.channel, required this.token});
+
+  final MethodChannel channel;
+  final String token;
+  bool _released = false;
+
+  @override
+  Future<void> release() async {
+    if (_released) return;
+    _released = true;
+    await channel.invokeMethod<void>('release', {'token': token});
+  }
 }

--- a/app/lib/main.dart
+++ b/app/lib/main.dart
@@ -6,6 +6,7 @@ import 'package:flutter/semantics.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'core/app/airo_app.dart';
+import 'core/app/main_provider_overrides.dart';
 import 'core/config/firebase_status.dart';
 import 'core/error/global_error_handler.dart';
 import 'core/routing/app_router.dart';
@@ -84,12 +85,10 @@ void main() async {
 
   runApp(
     ProviderScope(
-      overrides: [
-        sharedPreferencesProvider.overrideWithValue(prefs),
-        epgReminderNotificationGatewayProvider.overrideWithValue(
-          epgReminderGateway,
-        ),
-      ],
+      overrides: buildMainProviderOverrides(
+        prefs: prefs,
+        epgReminderGateway: epgReminderGateway,
+      ),
       child: const AiroApp(),
     ),
   );

--- a/app/test/core/app/app_shell_navigation_policy_test.dart
+++ b/app/test/core/app/app_shell_navigation_policy_test.dart
@@ -134,34 +134,40 @@ void main() {
     await tester.pumpAndSettle();
   }
 
-  testWidgets('phone width shows exactly the 5 TV-matching destinations', (
+  testWidgets('phone width preserves Airo super-app primary destinations', (
     tester,
   ) async {
-    await pumpShell(tester, initialLocation: '/home', width: 420);
+    await pumpShell(tester, initialLocation: '/money', width: 420);
 
-    expect(find.byKey(const ValueKey('app_nav_home')), findsOneWidget);
+    expect(find.byKey(const ValueKey('app_nav_coins')), findsOneWidget);
+    expect(find.byKey(const ValueKey('app_nav_mind')), findsOneWidget);
+    expect(find.byKey(const ValueKey('app_nav_beats')), findsOneWidget);
     expect(find.byKey(const ValueKey('app_nav_live')), findsOneWidget);
-    expect(find.byKey(const ValueKey('app_nav_guide')), findsOneWidget);
-    expect(find.byKey(const ValueKey('app_nav_favorites')), findsOneWidget);
-    expect(find.byKey(const ValueKey('app_nav_settings')), findsOneWidget);
-    expect(find.byKey(const ValueKey('app_nav_overflow')), findsNothing);
+    expect(find.byKey(const ValueKey('app_nav_overflow')), findsOneWidget);
 
-    // The other six domains are not part of the phone bottom nav.
-    expect(find.byKey(const ValueKey('app_nav_coins')), findsNothing);
-    expect(find.byKey(const ValueKey('app_nav_mind')), findsNothing);
-    expect(find.byKey(const ValueKey('app_nav_beats')), findsNothing);
+    // Secondary domains stay reachable through More instead of adopting the
+    // separate Airo TV shell's primary navigation.
     expect(find.byKey(const ValueKey('app_nav_arena')), findsNothing);
     expect(find.byKey(const ValueKey('app_nav_quest')), findsNothing);
+    expect(find.byKey(const ValueKey('app_nav_home')), findsNothing);
+    expect(find.byKey(const ValueKey('app_nav_guide')), findsNothing);
+    expect(find.byKey(const ValueKey('app_nav_favorites')), findsNothing);
+    expect(find.byKey(const ValueKey('app_nav_settings')), findsNothing);
 
-    expect(find.text('Home body'), findsOneWidget);
+    expect(find.text('Coins body'), findsOneWidget);
+    expect(tester.takeException(), isNull);
   });
 
-  testWidgets('tapping a phone destination navigates to its branch', (
+  testWidgets('phone overflow navigates to a secondary Airo branch', (
     tester,
   ) async {
-    await pumpShell(tester, initialLocation: '/home', width: 420);
+    await pumpShell(tester, initialLocation: '/money', width: 420);
 
-    await tester.tap(find.byKey(const ValueKey('app_nav_guide')));
+    await tester.tap(find.byKey(const ValueKey('app_nav_overflow')));
+    await tester.pumpAndSettle();
+    await tester.tap(
+      find.byKey(const ValueKey('app_nav_overflow_entry_guide')),
+    );
     await tester.pumpAndSettle();
 
     expect(find.text('Guide body'), findsOneWidget);

--- a/app/test/core/providers/navigation_provider_test.dart
+++ b/app/test/core/providers/navigation_provider_test.dart
@@ -109,8 +109,7 @@ void main() {
       expect(chromeConfig.compactWidthBreakpoint, 600);
     });
 
-    test('phone bottom nav exposes exactly 5 destinations matching the TV '
-        'sidebar: Home, Live, Guide, Favorites, Settings', () {
+    test('phone navigation preserves Airo domains and overflows the rest', () {
       final container = ProviderContainer();
       addTearDown(container.dispose);
 
@@ -119,14 +118,24 @@ void main() {
       final phoneTabs = phoneLayout.persistentTabs;
 
       expect(phoneTabs.map((t) => t.label).toList(), [
-        'Home',
+        'Coins',
+        'Mind',
+        'Beats',
         'Live',
+      ]);
+      expect(phoneLayout.overflowTabs.map((t) => t.label).toList(), [
+        'Arena',
+        'Quest',
+        'Home',
         'Guide',
         'Favorites',
         'Settings',
       ]);
-      expect(phoneLayout.overflowTabs, isEmpty);
-      expect(phoneLayout.usesOverflow, isFalse);
+      expect(phoneLayout.usesOverflow, isTrue);
+      expect({
+        ...phoneTabs,
+        ...phoneLayout.overflowTabs,
+      }, containsAll(AppNavigationTab.values));
     });
 
     test('wide layouts show a curated 8-tab set: the original six domains '

--- a/app/test/features/iptv/phone_media_local_picker_test.dart
+++ b/app/test/features/iptv/phone_media_local_picker_test.dart
@@ -1,0 +1,84 @@
+import 'package:airo_app/features/iptv/phone_media_local_picker.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const channel = MethodChannel('test/phone_media_picker');
+  final messenger =
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger;
+
+  tearDown(() {
+    messenger.setMockMethodCallHandler(channel, null);
+  });
+
+  test(
+    'maps Android descriptor selection without reading file bytes',
+    () async {
+      final calls = <MethodCall>[];
+      messenger.setMockMethodCallHandler(channel, (call) async {
+        calls.add(call);
+        if (call.method == 'pickVideo') {
+          return <String, Object?>{
+            'token': 'lease-1',
+            'filePath': '/proc/self/fd/42',
+            'title': 'Feature.FILM.MKV',
+            'size': 6101307309,
+          };
+        }
+        return null;
+      });
+
+      final item = await pickAndroidPhoneLocalMediaForTv(channel: channel);
+
+      expect(item, isNotNull);
+      expect(item!.filePath, '/proc/self/fd/42');
+      expect(item.title, 'Feature.FILM.MKV');
+      expect(item.container, 'mkv');
+      expect(calls.map((call) => call.method), ['pickVideo']);
+    },
+  );
+
+  test('cancel returns null', () async {
+    messenger.setMockMethodCallHandler(channel, (_) async => null);
+
+    expect(await pickAndroidPhoneLocalMediaForTv(channel: channel), isNull);
+  });
+
+  test('source lease releases native descriptor once', () async {
+    final calls = <MethodCall>[];
+    messenger.setMockMethodCallHandler(channel, (call) async {
+      calls.add(call);
+      if (call.method == 'pickVideo') {
+        return <String, Object?>{
+          'token': 'lease-2',
+          'filePath': '/proc/self/fd/43',
+          'title': 'movie.mp4',
+        };
+      }
+      return null;
+    });
+    final item = await pickAndroidPhoneLocalMediaForTv(channel: channel);
+
+    await item!.sourceLease!.release();
+    await item.sourceLease!.release();
+
+    expect(calls.map((call) => call.method), ['pickVideo', 'release']);
+    expect(calls.last.arguments, {'token': 'lease-2'});
+  });
+
+  test('malformed selection releases a supplied native token', () async {
+    final calls = <MethodCall>[];
+    messenger.setMockMethodCallHandler(channel, (call) async {
+      calls.add(call);
+      if (call.method == 'pickVideo') {
+        return <String, Object?>{'token': 'lease-3'};
+      }
+      return null;
+    });
+
+    expect(await pickAndroidPhoneLocalMediaForTv(channel: channel), isNull);
+    expect(calls.map((call) => call.method), ['pickVideo', 'release']);
+  });
+}

--- a/app/test/main_cast_override_test.dart
+++ b/app/test/main_cast_override_test.dart
@@ -1,0 +1,50 @@
+import 'package:airo_app/core/app/main_provider_overrides.dart';
+import 'package:feature_iptv/feature_iptv.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('mobile entrypoint installs the real Android Cast controller', () async {
+    debugDefaultTargetPlatformOverride = TargetPlatform.android;
+    addTearDown(() => debugDefaultTargetPlatformOverride = null);
+    SharedPreferences.setMockInitialValues({});
+    final prefs = await SharedPreferences.getInstance();
+
+    final container = ProviderContainer(
+      overrides: buildMainProviderOverrides(
+        prefs: prefs,
+        epgReminderGateway: const UnavailableEpgReminderNotificationGateway(),
+      ),
+    );
+    addTearDown(container.dispose);
+
+    expect(
+      container.read(airoCastControllerProvider),
+      isA<FlutterChromeCastController>(),
+    );
+  });
+
+  test('mobile entrypoint keeps Cast unavailable on macOS', () async {
+    debugDefaultTargetPlatformOverride = TargetPlatform.macOS;
+    addTearDown(() => debugDefaultTargetPlatformOverride = null);
+    SharedPreferences.setMockInitialValues({});
+    final prefs = await SharedPreferences.getInstance();
+
+    final container = ProviderContainer(
+      overrides: buildMainProviderOverrides(
+        prefs: prefs,
+        epgReminderGateway: const UnavailableEpgReminderNotificationGateway(),
+      ),
+    );
+    addTearDown(container.dispose);
+
+    expect(
+      container.read(airoCastControllerProvider),
+      isA<UnavailableAiroCastController>(),
+    );
+  });
+}

--- a/packages/feature_iptv/lib/presentation/screens/iptv_screen.dart
+++ b/packages/feature_iptv/lib/presentation/screens/iptv_screen.dart
@@ -300,14 +300,16 @@ class _IPTVScreenState extends ConsumerState<IPTVScreen>
     final item = await picker();
     if (item == null || !mounted) return;
 
-    final handoff = PhoneMediaCastHandoff(
-      castController: ref.read(airoCastControllerProvider),
-    );
+    final castController = ref.read(airoCastControllerProvider);
+    final handoff = PhoneMediaCastHandoff(castController: castController);
     await showModalBottomSheet<void>(
       context: context,
       isScrollControlled: true,
-      builder: (context) =>
-          PhoneMediaPlayOnTvSheet(item: item, handoff: handoff),
+      builder: (context) => PhoneMediaPlayOnTvSheet(
+        item: item,
+        handoff: handoff,
+        castController: castController,
+      ),
     );
   }
 

--- a/packages/feature_iptv/lib/presentation/screens/iptv_screen.dart
+++ b/packages/feature_iptv/lib/presentation/screens/iptv_screen.dart
@@ -298,13 +298,17 @@ class _IPTVScreenState extends ConsumerState<IPTVScreen>
     if (picker == null) return;
 
     final item = await picker();
-    if (item == null || !mounted) return;
+    if (item == null) return;
+    if (!mounted) {
+      await item.sourceLease?.release();
+      return;
+    }
 
     final castController = ref.read(airoCastControllerProvider);
     final handoff = PhoneMediaCastHandoff(castController: castController);
-    await showModalBottomSheet<void>(
+    await showAdaptiveIptvSheet<void>(
       context: context,
-      isScrollControlled: true,
+      maxWidth: 600,
       builder: (context) => PhoneMediaPlayOnTvSheet(
         item: item,
         handoff: handoff,

--- a/packages/feature_iptv/lib/presentation/tv_ux/airo_tv_shell.dart
+++ b/packages/feature_iptv/lib/presentation/tv_ux/airo_tv_shell.dart
@@ -138,19 +138,20 @@ class _AiroTvShellState extends ConsumerState<AiroTvShell> {
               Flexible(
                 flex: 3,
                 child: Center(
-                  child: ConstrainedBox(
-                    key: const ValueKey('airo-tv-explorer-video-stage'),
-                    constraints: BoxConstraints.tightFor(
+                  child: FittedBox(
+                    fit: BoxFit.contain,
+                    child: SizedBox(
+                      key: const ValueKey('airo-tv-explorer-video-stage'),
                       width: previewWidth,
                       height: previewHeight,
-                    ),
-                    child: ClipRect(
-                      child: FittedBox(
-                        fit: BoxFit.contain,
-                        child: SizedBox(
-                          width: 640,
-                          height: 360,
-                          child: widget.videoStage,
+                      child: ClipRect(
+                        child: FittedBox(
+                          fit: BoxFit.contain,
+                          child: SizedBox(
+                            width: 640,
+                            height: 360,
+                            child: widget.videoStage,
+                          ),
                         ),
                       ),
                     ),

--- a/packages/feature_iptv/lib/presentation/widgets/cast_device_picker_sheet.dart
+++ b/packages/feature_iptv/lib/presentation/widgets/cast_device_picker_sheet.dart
@@ -65,7 +65,7 @@ class _CastDevicePickerSheetState extends ConsumerState<CastDevicePickerSheet> {
               maxLines: 2,
             ),
             const SizedBox(height: 16),
-            _DiscoveryBody(
+            CastDiscoveryBody(
               discovery: discovery,
               onRetry: () =>
                   ref.read(iptvCastProvider.notifier).startDiscovery(),
@@ -81,8 +81,9 @@ class _CastDevicePickerSheetState extends ConsumerState<CastDevicePickerSheet> {
   }
 }
 
-class _DiscoveryBody extends StatelessWidget {
-  const _DiscoveryBody({
+class CastDiscoveryBody extends StatelessWidget {
+  const CastDiscoveryBody({
+    super.key,
     required this.discovery,
     required this.onRetry,
     required this.onDeviceSelected,

--- a/packages/feature_iptv/lib/presentation/widgets/iptv_cast_mini_controller.dart
+++ b/packages/feature_iptv/lib/presentation/widgets/iptv_cast_mini_controller.dart
@@ -21,15 +21,21 @@ class IptvCastMiniController extends ConsumerStatefulWidget {
 class _IptvCastMiniControllerState
     extends ConsumerState<IptvCastMiniController> {
   String? _confirmedDeviceId;
-  bool _expanded = false;
   bool _initialized = false;
 
-  void _confirm({required bool expand}) {
+  void _confirm() {
     final device = ref.read(iptvCastProvider).session.device;
-    setState(() {
-      _confirmedDeviceId = device?.id;
-      _expanded = expand;
-    });
+    setState(() => _confirmedDeviceId = device?.id);
+  }
+
+  void _openRemote() {
+    _confirm();
+    showModalBottomSheet<void>(
+      context: context,
+      isScrollControlled: true,
+      useSafeArea: true,
+      builder: (_) => const _CastRemoteControlSheet(),
+    );
   }
 
   @override
@@ -49,11 +55,8 @@ class _IptvCastMiniControllerState
       iptvCastProvider.select((state) => state.session),
       (previous, next) {
         if (!next.isConnected) {
-          if (_confirmedDeviceId != null || _expanded) {
-            setState(() {
-              _confirmedDeviceId = null;
-              _expanded = false;
-            });
+          if (_confirmedDeviceId != null) {
+            setState(() => _confirmedDeviceId = null);
           }
           return;
         }
@@ -83,8 +86,8 @@ class _IptvCastMiniControllerState
       return _ConnectionConfirmationBanner(
         device: device,
         media: media,
-        onBrowseChannels: () => _confirm(expand: false),
-        onOpenControls: () => _confirm(expand: true),
+        onBrowseChannels: _confirm,
+        onOpenControls: _openRemote,
       );
     }
 
@@ -92,8 +95,7 @@ class _IptvCastMiniControllerState
       session: session,
       device: device,
       media: media,
-      expanded: _expanded,
-      onToggleExpanded: () => setState(() => _expanded = !_expanded),
+      onOpenRemote: _openRemote,
     );
   }
 }
@@ -169,15 +171,13 @@ class _CompactCastController extends ConsumerWidget {
     required this.session,
     required this.device,
     required this.media,
-    required this.expanded,
-    required this.onToggleExpanded,
+    required this.onOpenRemote,
   });
 
   final AiroCastSessionSnapshot session;
   final AiroCastDevice device;
   final AiroCastMediaRequest? media;
-  final bool expanded;
-  final VoidCallback onToggleExpanded;
+  final VoidCallback onOpenRemote;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -248,11 +248,9 @@ class _CompactCastController extends ConsumerWidget {
                     ),
                   ),
                   IconButton(
-                    tooltip: expanded ? 'Fewer controls' : 'More controls',
-                    icon: Icon(
-                      expanded ? Icons.expand_less : Icons.expand_more,
-                    ),
-                    onPressed: onToggleExpanded,
+                    tooltip: 'Open Cast remote',
+                    icon: const Icon(Icons.settings_remote),
+                    onPressed: onOpenRemote,
                   ),
                 ],
               ),
@@ -292,35 +290,6 @@ class _CompactCastController extends ConsumerWidget {
                         ? null
                         : () => ref.read(iptvCastProvider.notifier).stop(),
                   ),
-                  if (expanded) ...[
-                    if (hasMedia) ...[
-                      _CastControlButton(
-                        tooltip: 'Reload current stream',
-                        icon: Icons.refresh,
-                        label: 'Reload',
-                        onPressed: isLoading
-                            ? null
-                            : () => ref
-                                  .read(iptvCastProvider.notifier)
-                                  .reloadActiveMedia(),
-                      ),
-                      _CastControlButton(
-                        tooltip: 'Start a new Cast session',
-                        icon: Icons.restart_alt,
-                        label: 'New session',
-                        onPressed: () => ref
-                            .read(iptvCastProvider.notifier)
-                            .restartActiveSession(),
-                      ),
-                    ],
-                    _CastControlButton(
-                      tooltip: 'Disconnect from ${device.name}',
-                      icon: Icons.cast_connected,
-                      label: 'Disconnect',
-                      onPressed: () =>
-                          ref.read(iptvCastProvider.notifier).disconnect(),
-                    ),
-                  ],
                 ],
               ),
               const SizedBox(height: 6),
@@ -433,43 +402,12 @@ class _CompactCastController extends ConsumerWidget {
                     ),
                   ),
                   IconButton(
-                    tooltip: expanded ? 'Fewer controls' : 'More controls',
-                    icon: Icon(
-                      expanded ? Icons.expand_less : Icons.expand_more,
-                    ),
-                    onPressed: onToggleExpanded,
+                    tooltip: 'Open Cast remote',
+                    icon: const Icon(Icons.settings_remote),
+                    onPressed: onOpenRemote,
                   ),
                 ],
               ),
-              if (expanded)
-                Wrap(
-                  spacing: 6,
-                  runSpacing: 6,
-                  children: [
-                    if (hasMedia) ...[
-                      _CastControlButton(
-                        tooltip: 'Reload current stream',
-                        icon: Icons.refresh,
-                        label: 'Reload',
-                        onPressed: isLoading
-                            ? null
-                            : notifier.reloadActiveMedia,
-                      ),
-                      _CastControlButton(
-                        tooltip: 'Start a new Cast session',
-                        icon: Icons.restart_alt,
-                        label: 'New session',
-                        onPressed: notifier.restartActiveSession,
-                      ),
-                    ],
-                    _CastControlButton(
-                      tooltip: 'Disconnect from ${device.name}',
-                      icon: Icons.cast_connected,
-                      label: 'Disconnect',
-                      onPressed: notifier.disconnect,
-                    ),
-                  ],
-                ),
             ],
           ),
         ),
@@ -496,6 +434,214 @@ class _CompactCastController extends ConsumerWidget {
       return session.error?.message ?? media?.title ?? 'Receiver needs action.';
     }
     return media?.title ?? 'Choose a channel to cast, or disconnect the TV.';
+  }
+}
+
+class _CastRemoteControlSheet extends ConsumerWidget {
+  const _CastRemoteControlSheet();
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final session = ref.watch(iptvCastProvider).session;
+    final device = session.device;
+    if (device == null || !session.isConnected) {
+      return const SizedBox.shrink();
+    }
+
+    final size = MediaQuery.sizeOf(context);
+    final landscape = size.width > size.height;
+    final notifier = ref.read(iptvCastProvider.notifier);
+    final mediaTitle = session.media?.title ?? 'No media loaded';
+    final isPaused = session.phase == AiroCastSessionPhase.paused;
+    final isStopped = session.phase == AiroCastSessionPhase.stopped;
+    final isLoading = session.phase == AiroCastSessionPhase.loadingMedia;
+
+    final details = Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: landscape
+          ? CrossAxisAlignment.start
+          : CrossAxisAlignment.center,
+      children: [
+        Icon(
+          Icons.cast_connected,
+          size: 28,
+          color: Theme.of(context).colorScheme.primary,
+        ),
+        const SizedBox(height: 8),
+        Text(
+          'Remote for ${device.name}',
+          textAlign: landscape ? TextAlign.start : TextAlign.center,
+          style: Theme.of(context).textTheme.titleLarge,
+        ),
+        const SizedBox(height: 4),
+        Text(
+          mediaTitle,
+          maxLines: 2,
+          overflow: TextOverflow.ellipsis,
+          textAlign: landscape ? TextAlign.start : TextAlign.center,
+          style: Theme.of(context).textTheme.bodyMedium,
+        ),
+        const SizedBox(height: 16),
+        Row(
+          children: [
+            const Icon(Icons.volume_down),
+            Expanded(
+              child: Slider(
+                value: session.volume.clamp(0.0, 1.0).toDouble(),
+                onChanged: notifier.setVolume,
+              ),
+            ),
+            const Icon(Icons.volume_up),
+          ],
+        ),
+        const SizedBox(height: 8),
+        OutlinedButton.icon(
+          onPressed: () {
+            notifier.disconnect();
+            Navigator.of(context).pop();
+          },
+          icon: const Icon(Icons.cast_connected),
+          label: const Text('Disconnect TV'),
+        ),
+      ],
+    );
+
+    final pad = _CastRemotePad(
+      diameter: landscape ? 210 : 280,
+      isPaused: isPaused,
+      isStopped: isStopped,
+      isLoading: isLoading,
+      onPrimary: () {
+        if (isStopped) {
+          notifier.reloadActiveMedia();
+        } else {
+          isPaused ? notifier.play() : notifier.pause();
+        }
+      },
+      onVolumeUp: () =>
+          notifier.setVolume((session.volume + 0.1).clamp(0.0, 1.0).toDouble()),
+      onVolumeDown: () =>
+          notifier.setVolume((session.volume - 0.1).clamp(0.0, 1.0).toDouble()),
+      onMute: () => notifier.setVolume(0),
+      onStop: notifier.stop,
+    );
+
+    return SingleChildScrollView(
+      padding: const EdgeInsets.fromLTRB(24, 12, 24, 24),
+      child: Center(
+        child: ConstrainedBox(
+          constraints: const BoxConstraints(maxWidth: 720),
+          child: landscape
+              ? Row(
+                  children: [
+                    Expanded(child: details),
+                    const SizedBox(width: 32),
+                    pad,
+                  ],
+                )
+              : Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [details, const SizedBox(height: 20), pad],
+                ),
+        ),
+      ),
+    );
+  }
+}
+
+class _CastRemotePad extends StatelessWidget {
+  const _CastRemotePad({
+    required this.diameter,
+    required this.isPaused,
+    required this.isStopped,
+    required this.isLoading,
+    required this.onPrimary,
+    required this.onVolumeUp,
+    required this.onVolumeDown,
+    required this.onMute,
+    required this.onStop,
+  });
+
+  final double diameter;
+  final bool isPaused;
+  final bool isStopped;
+  final bool isLoading;
+  final VoidCallback onPrimary;
+  final VoidCallback onVolumeUp;
+  final VoidCallback onVolumeDown;
+  final VoidCallback onMute;
+  final VoidCallback onStop;
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final edgeOffset = diameter * 0.08;
+    final centerSize = diameter * 0.42;
+
+    return SizedBox.square(
+      dimension: diameter,
+      child: DecoratedBox(
+        decoration: BoxDecoration(
+          shape: BoxShape.circle,
+          color: colorScheme.surfaceContainerHighest,
+          border: Border.all(color: colorScheme.outlineVariant),
+        ),
+        child: Stack(
+          alignment: Alignment.center,
+          children: [
+            Positioned(
+              top: edgeOffset,
+              child: IconButton(
+                tooltip: 'Volume up',
+                onPressed: onVolumeUp,
+                icon: const Icon(Icons.volume_up),
+              ),
+            ),
+            Positioned(
+              bottom: edgeOffset,
+              child: IconButton(
+                tooltip: 'Volume down',
+                onPressed: onVolumeDown,
+                icon: const Icon(Icons.volume_down),
+              ),
+            ),
+            Positioned(
+              left: edgeOffset,
+              child: IconButton(
+                tooltip: 'Mute',
+                onPressed: onMute,
+                icon: const Icon(Icons.volume_off),
+              ),
+            ),
+            Positioned(
+              right: edgeOffset,
+              child: IconButton(
+                tooltip: 'Stop receiver media',
+                onPressed: isLoading ? null : onStop,
+                icon: const Icon(Icons.stop),
+              ),
+            ),
+            SizedBox.square(
+              dimension: centerSize,
+              child: FilledButton(
+                style: FilledButton.styleFrom(
+                  shape: const CircleBorder(),
+                  padding: EdgeInsets.zero,
+                ),
+                onPressed: isLoading ? null : onPrimary,
+                child: Icon(
+                  isPaused || isStopped ? Icons.play_arrow : Icons.pause,
+                  size: centerSize * 0.42,
+                  semanticLabel: isPaused || isStopped
+                      ? 'Start playback'
+                      : 'Pause',
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
   }
 }
 

--- a/packages/feature_iptv/lib/presentation/widgets/iptv_cast_mini_controller.dart
+++ b/packages/feature_iptv/lib/presentation/widgets/iptv_cast_mini_controller.dart
@@ -4,6 +4,15 @@ import 'package:platform_player/platform_player.dart';
 
 import '../../application/providers/iptv_cast_providers.dart';
 
+Future<void> showIptvCastRemoteControlSheet(BuildContext context) {
+  return showModalBottomSheet<void>(
+    context: context,
+    isScrollControlled: true,
+    useSafeArea: true,
+    builder: (_) => const _CastRemoteControlSheet(),
+  );
+}
+
 /// CV-028 "After connection" surface: a one-time "Playing on {deviceName}"
 /// confirmation the first time this widget observes a live transition into
 /// an active Cast session, settling into the persistent compact controller
@@ -30,12 +39,7 @@ class _IptvCastMiniControllerState
 
   void _openRemote() {
     _confirm();
-    showModalBottomSheet<void>(
-      context: context,
-      isScrollControlled: true,
-      useSafeArea: true,
-      builder: (_) => const _CastRemoteControlSheet(),
-    );
+    showIptvCastRemoteControlSheet(context);
   }
 
   @override

--- a/packages/feature_iptv/lib/presentation/widgets/iptv_cast_mini_controller.dart
+++ b/packages/feature_iptv/lib/presentation/widgets/iptv_cast_mini_controller.dart
@@ -122,6 +122,58 @@ class _ConnectionConfirmationBanner extends ConsumerWidget {
     final colorScheme = Theme.of(context).colorScheme;
     final textTheme = Theme.of(context).textTheme;
     final channelName = media?.title ?? 'This channel';
+    final size = MediaQuery.sizeOf(context);
+
+    if (size.width > size.height && size.height < 600) {
+      return Material(
+        color: colorScheme.primaryContainer,
+        child: SafeArea(
+          top: false,
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+            child: Row(
+              children: [
+                const Icon(Icons.cast_connected),
+                const SizedBox(width: 10),
+                Expanded(
+                  child: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        'Playing on ${device.name}',
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                        style: textTheme.titleSmall?.copyWith(
+                          color: colorScheme.onPrimaryContainer,
+                        ),
+                      ),
+                      Text(
+                        channelName,
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                        style: textTheme.bodySmall?.copyWith(
+                          color: colorScheme.onPrimaryContainer,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+                TextButton(
+                  onPressed: onBrowseChannels,
+                  child: const Text('Browse'),
+                ),
+                FilledButton.tonalIcon(
+                  onPressed: onOpenControls,
+                  icon: const Icon(Icons.settings_remote),
+                  label: const Text('Remote'),
+                ),
+              ],
+            ),
+          ),
+        ),
+      );
+    }
 
     return Material(
       color: colorScheme.primaryContainer,

--- a/packages/feature_iptv/lib/presentation/widgets/iptv_cast_mini_controller.dart
+++ b/packages/feature_iptv/lib/presentation/widgets/iptv_cast_mini_controller.dart
@@ -61,7 +61,8 @@ class _IptvCastMiniControllerState
             previous != null &&
             previous.isConnected &&
             previous.device?.id == next.device?.id;
-        if (!wasConnectedToSameDevice && next.device?.id != _confirmedDeviceId) {
+        if (!wasConnectedToSameDevice &&
+            next.device?.id != _confirmedDeviceId) {
           setState(() {}); // rebuild to evaluate the banner below
         }
       },
@@ -187,6 +188,19 @@ class _CompactCastController extends ConsumerWidget {
     final hasMedia = media != null;
     final colorScheme = Theme.of(context).colorScheme;
     final textTheme = Theme.of(context).textTheme;
+    final size = MediaQuery.sizeOf(context);
+
+    if (size.width > size.height && size.height < 600) {
+      return _buildLandscape(
+        context,
+        ref,
+        isPaused: isPaused,
+        isLoading: isLoading,
+        isStopped: isStopped,
+        isFailed: isFailed,
+        hasMedia: hasMedia,
+      );
+    }
 
     return Material(
       color: colorScheme.surfaceContainerHighest,
@@ -235,7 +249,9 @@ class _CompactCastController extends ConsumerWidget {
                   ),
                   IconButton(
                     tooltip: expanded ? 'Fewer controls' : 'More controls',
-                    icon: Icon(expanded ? Icons.expand_less : Icons.expand_more),
+                    icon: Icon(
+                      expanded ? Icons.expand_less : Icons.expand_more,
+                    ),
                     onPressed: onToggleExpanded,
                   ),
                 ],
@@ -321,6 +337,139 @@ class _CompactCastController extends ConsumerWidget {
                   const Icon(Icons.volume_up, size: 20),
                 ],
               ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildLandscape(
+    BuildContext context,
+    WidgetRef ref, {
+    required bool isPaused,
+    required bool isLoading,
+    required bool isStopped,
+    required bool isFailed,
+    required bool hasMedia,
+  }) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final textTheme = Theme.of(context).textTheme;
+    final notifier = ref.read(iptvCastProvider.notifier);
+
+    return Material(
+      color: colorScheme.surfaceContainerHighest,
+      child: SafeArea(
+        top: false,
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Row(
+                children: [
+                  Icon(
+                    isLoading
+                        ? Icons.hourglass_top
+                        : isFailed
+                        ? Icons.error_outline
+                        : Icons.cast_connected,
+                    color: isFailed ? colorScheme.error : null,
+                  ),
+                  const SizedBox(width: 10),
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        Text(
+                          _statusLabel(session.phase, device.name),
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                          style: textTheme.titleSmall,
+                        ),
+                        Text(
+                          _subtitle(session, media),
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                          style: textTheme.bodySmall?.copyWith(
+                            color: isFailed
+                                ? colorScheme.error
+                                : colorScheme.onSurfaceVariant,
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                  if (hasMedia)
+                    IconButton(
+                      tooltip: isPaused || isStopped
+                          ? 'Start playback'
+                          : 'Pause',
+                      onPressed: isLoading
+                          ? null
+                          : () {
+                              if (isStopped) {
+                                notifier.reloadActiveMedia();
+                              } else {
+                                isPaused ? notifier.play() : notifier.pause();
+                              }
+                            },
+                      icon: Icon(
+                        isPaused || isStopped ? Icons.play_arrow : Icons.pause,
+                      ),
+                    ),
+                  IconButton(
+                    tooltip: 'Stop receiver media',
+                    onPressed: isLoading ? null : notifier.stop,
+                    icon: const Icon(Icons.stop),
+                  ),
+                  const Icon(Icons.volume_down, size: 20),
+                  SizedBox(
+                    width: 180,
+                    child: Slider(
+                      value: session.volume.clamp(0.0, 1.0).toDouble(),
+                      onChanged: notifier.setVolume,
+                    ),
+                  ),
+                  IconButton(
+                    tooltip: expanded ? 'Fewer controls' : 'More controls',
+                    icon: Icon(
+                      expanded ? Icons.expand_less : Icons.expand_more,
+                    ),
+                    onPressed: onToggleExpanded,
+                  ),
+                ],
+              ),
+              if (expanded)
+                Wrap(
+                  spacing: 6,
+                  runSpacing: 6,
+                  children: [
+                    if (hasMedia) ...[
+                      _CastControlButton(
+                        tooltip: 'Reload current stream',
+                        icon: Icons.refresh,
+                        label: 'Reload',
+                        onPressed: isLoading
+                            ? null
+                            : notifier.reloadActiveMedia,
+                      ),
+                      _CastControlButton(
+                        tooltip: 'Start a new Cast session',
+                        icon: Icons.restart_alt,
+                        label: 'New session',
+                        onPressed: notifier.restartActiveSession,
+                      ),
+                    ],
+                    _CastControlButton(
+                      tooltip: 'Disconnect from ${device.name}',
+                      icon: Icons.cast_connected,
+                      label: 'Disconnect',
+                      onPressed: notifier.disconnect,
+                    ),
+                  ],
+                ),
             ],
           ),
         ),

--- a/packages/feature_iptv/lib/presentation/widgets/phone_media_play_on_tv_sheet.dart
+++ b/packages/feature_iptv/lib/presentation/widgets/phone_media_play_on_tv_sheet.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:platform_player/platform_player.dart';
 
 import 'cast_device_picker_sheet.dart';
+import 'iptv_cast_mini_controller.dart';
 
 /// "Play on TV" surface for a phone-local media file (CV-033).
 ///
@@ -179,10 +180,21 @@ class _PhoneMediaPlayOnTvSheetState extends State<PhoneMediaPlayOnTvSheet> {
               style: theme.textTheme.bodyMedium,
             ),
             const SizedBox(height: 12),
-            OutlinedButton.icon(
-              onPressed: _stopHandoff,
-              icon: const Icon(Icons.stop),
-              label: const Text('Stop casting'),
+            Wrap(
+              spacing: 8,
+              runSpacing: 8,
+              children: [
+                FilledButton.icon(
+                  onPressed: () => showIptvCastRemoteControlSheet(context),
+                  icon: const Icon(Icons.settings_remote),
+                  label: const Text('Open remote'),
+                ),
+                OutlinedButton.icon(
+                  onPressed: _stopHandoff,
+                  icon: const Icon(Icons.stop),
+                  label: const Text('Stop casting'),
+                ),
+              ],
             ),
           ],
           _HandoffPhase.failed => [

--- a/packages/feature_iptv/lib/presentation/widgets/phone_media_play_on_tv_sheet.dart
+++ b/packages/feature_iptv/lib/presentation/widgets/phone_media_play_on_tv_sheet.dart
@@ -62,8 +62,14 @@ class _PhoneMediaPlayOnTvSheetState extends State<PhoneMediaPlayOnTvSheet> {
   void dispose() {
     unawaited(_discoverySubscription?.cancel());
     unawaited(_sessionSubscription?.cancel());
-    unawaited(widget.handoff.dispose());
+    unawaited(_disposeResources());
     super.dispose();
+  }
+
+  Future<void> _disposeResources() async {
+    await widget.handoff.prepareSourceRelease();
+    await widget.item.sourceLease?.release();
+    await widget.handoff.dispose();
   }
 
   Future<void> _startDiscovery() async {

--- a/packages/feature_iptv/lib/presentation/widgets/phone_media_play_on_tv_sheet.dart
+++ b/packages/feature_iptv/lib/presentation/widgets/phone_media_play_on_tv_sheet.dart
@@ -1,5 +1,9 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:platform_player/platform_player.dart';
+
+import 'cast_device_picker_sheet.dart';
 
 /// "Play on TV" surface for a phone-local media file (CV-033).
 ///
@@ -11,28 +15,93 @@ class PhoneMediaPlayOnTvSheet extends StatefulWidget {
     super.key,
     required this.item,
     required this.handoff,
+    required this.castController,
   });
 
   final PhoneLocalMediaItem item;
   final PhoneMediaCastHandoff handoff;
+  final AiroCastController castController;
 
   @override
   State<PhoneMediaPlayOnTvSheet> createState() =>
       _PhoneMediaPlayOnTvSheetState();
 }
 
-enum _HandoffPhase { idle, starting, playing, unsupported, failed }
+enum _HandoffPhase { idle, connecting, starting, playing, unsupported, failed }
 
 class _PhoneMediaPlayOnTvSheetState extends State<PhoneMediaPlayOnTvSheet> {
   _HandoffPhase _phase = _HandoffPhase.idle;
+  late AiroCastDiscoveryState _discovery;
+  late AiroCastSessionSnapshot _session;
+  AiroCastDevice? _targetDevice;
+  StreamSubscription<AiroCastDiscoveryState>? _discoverySubscription;
+  StreamSubscription<AiroCastSessionSnapshot>? _sessionSubscription;
+
+  @override
+  void initState() {
+    super.initState();
+    _discovery = widget.castController.currentDiscoveryState;
+    _session = widget.castController.currentSessionState;
+    _discoverySubscription = widget.castController.discoveryStateStream.listen((
+      state,
+    ) {
+      if (mounted) setState(() => _discovery = state);
+    });
+    _sessionSubscription = widget.castController.sessionStateStream.listen((
+      state,
+    ) {
+      if (mounted) setState(() => _session = state);
+    });
+    if (!_session.isConnected) {
+      unawaited(_startDiscovery());
+    }
+  }
 
   @override
   void dispose() {
-    widget.handoff.dispose();
+    unawaited(_discoverySubscription?.cancel());
+    unawaited(_sessionSubscription?.cancel());
+    unawaited(widget.handoff.dispose());
     super.dispose();
   }
 
+  Future<void> _startDiscovery() async {
+    if (mounted) {
+      setState(() {
+        _phase = _HandoffPhase.idle;
+        _discovery = AiroCastDiscoveryState.discovering(
+          devices: _discovery.devices,
+        );
+      });
+    }
+    await widget.castController.initialize();
+    await widget.castController.startDiscovery();
+    if (!mounted) return;
+    setState(() => _discovery = widget.castController.currentDiscoveryState);
+  }
+
+  Future<void> _connectAndStart(AiroCastDevice device) async {
+    setState(() {
+      _targetDevice = device;
+      _phase = _HandoffPhase.connecting;
+    });
+    await widget.castController.connect(device);
+    if (!mounted) return;
+    final session = widget.castController.currentSessionState;
+    setState(() => _session = session);
+    if (!session.isConnected) {
+      setState(() => _phase = _HandoffPhase.failed);
+      return;
+    }
+    await widget.castController.stopDiscovery();
+    await _startHandoff();
+  }
+
   Future<void> _startHandoff() async {
+    if (!widget.castController.currentSessionState.isConnected) {
+      await _startDiscovery();
+      return;
+    }
     setState(() => _phase = _HandoffPhase.starting);
     final result = await widget.handoff.start(widget.item);
     if (!mounted) return;
@@ -54,8 +123,7 @@ class _PhoneMediaPlayOnTvSheetState extends State<PhoneMediaPlayOnTvSheet> {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    final deviceName =
-        widget.handoff.connectedDeviceName ?? 'a Chromecast-enabled TV';
+    final deviceName = _session.device?.name ?? _targetDevice?.name;
 
     return Padding(
       padding: const EdgeInsets.all(16),
@@ -63,11 +131,25 @@ class _PhoneMediaPlayOnTvSheetState extends State<PhoneMediaPlayOnTvSheet> {
         mainAxisSize: MainAxisSize.min,
         crossAxisAlignment: CrossAxisAlignment.start,
         children: switch (_phase) {
+          _HandoffPhase.idle when !_session.isConnected => [
+            Text(widget.item.title, style: theme.textTheme.titleMedium),
+            const SizedBox(height: 4),
+            const Text(
+              'Choose a Chromecast-enabled TV on this Wi-Fi network. The '
+              'video streams from your phone and is not stored on the TV.',
+            ),
+            const SizedBox(height: 12),
+            CastDiscoveryBody(
+              discovery: _discovery,
+              onRetry: _startDiscovery,
+              onDeviceSelected: _connectAndStart,
+            ),
+          ],
           _HandoffPhase.idle || _HandoffPhase.starting => [
             Text(widget.item.title, style: theme.textTheme.titleMedium),
             const SizedBox(height: 4),
             Text(
-              'Send this video to $deviceName. It streams from your phone — '
+              'Send this video to $deviceName. It streams from your phone - '
               'nothing is stored on the TV.',
               style: theme.textTheme.bodyMedium,
             ),
@@ -77,8 +159,16 @@ class _PhoneMediaPlayOnTvSheetState extends State<PhoneMediaPlayOnTvSheet> {
                   ? null
                   : _startHandoff,
               icon: const Icon(Icons.cast),
-              label: const Text('Play on TV'),
+              label: Text('Play on $deviceName'),
             ),
+          ],
+          _HandoffPhase.connecting => [
+            Text(
+              'Connecting to $deviceName',
+              style: theme.textTheme.titleMedium,
+            ),
+            const SizedBox(height: 12),
+            const LinearProgressIndicator(),
           ],
           _HandoffPhase.playing => [
             Text('Playing on $deviceName', style: theme.textTheme.titleMedium),
@@ -102,14 +192,17 @@ class _PhoneMediaPlayOnTvSheetState extends State<PhoneMediaPlayOnTvSheet> {
             ),
             const SizedBox(height: 4),
             Text(
-              'The stream could not start. Check that both devices are on '
-              'the same Wi-Fi network.',
+              _session.error?.message ??
+                  'The stream could not start. Check that both devices are on '
+                      'the same Wi-Fi network.',
               style: theme.textTheme.bodyMedium,
             ),
             const SizedBox(height: 12),
             TextButton(
-              onPressed: () => setState(() => _phase = _HandoffPhase.idle),
-              child: const Text('Try again'),
+              onPressed: _session.isConnected
+                  ? () => setState(() => _phase = _HandoffPhase.idle)
+                  : _startDiscovery,
+              child: Text(_session.isConnected ? 'Try again' : 'Find a TV'),
             ),
           ],
           _HandoffPhase.unsupported => [

--- a/packages/feature_iptv/test/iptv/phone_media_play_on_tv_test.dart
+++ b/packages/feature_iptv/test/iptv/phone_media_play_on_tv_test.dart
@@ -75,6 +75,7 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.text('Playing on Fire Stick'), findsOneWidget);
+    expect(find.text('Open remote'), findsOneWidget);
     expect(find.text('Stop casting'), findsOneWidget);
   });
 

--- a/packages/feature_iptv/test/iptv/phone_media_play_on_tv_test.dart
+++ b/packages/feature_iptv/test/iptv/phone_media_play_on_tv_test.dart
@@ -36,15 +36,21 @@ void main() {
     );
   }
 
-  Widget hostFor(PhoneLocalMediaItem item) {
+  Widget hostFor(
+    PhoneLocalMediaItem item, {
+    FakeAiroCastController? controller,
+  }) {
+    final selectedController = controller ?? castController;
     return MaterialApp(
       home: Scaffold(
         body: PhoneMediaPlayOnTvSheet(
           item: item,
           handoff: PhoneMediaCastHandoff(
-            castController: castController,
+            castController: selectedController,
             bindAddress: InternetAddress.loopbackIPv4,
+            debugConnectivityStream: const Stream.empty(),
           ),
+          castController: selectedController,
         ),
       ),
     );
@@ -55,8 +61,8 @@ void main() {
   ) async {
     await tester.pumpWidget(hostFor(itemFor()));
 
-    expect(find.text('Play on TV'), findsOneWidget);
-    expect(find.textContaining('Fire Stick'), findsOneWidget);
+    expect(find.text('Play on Fire Stick'), findsOneWidget);
+    expect(find.textContaining('Fire Stick'), findsNWidgets(2));
     expect(find.textContaining('Movie Night'), findsOneWidget);
   });
 
@@ -65,7 +71,7 @@ void main() {
   ) async {
     await tester.pumpWidget(hostFor(itemFor()));
 
-    await tester.tap(find.text('Play on TV'));
+    await tester.tap(find.text('Play on Fire Stick'));
     await tester.pumpAndSettle();
 
     expect(find.text('Playing on Fire Stick'), findsOneWidget);
@@ -77,7 +83,7 @@ void main() {
   ) async {
     await tester.pumpWidget(hostFor(itemFor(container: 'avi')));
 
-    await tester.tap(find.text('Play on TV'));
+    await tester.tap(find.text('Play on Fire Stick'));
     await tester.pumpAndSettle();
 
     expect(find.text("This format isn't supported by your TV"), findsOneWidget);
@@ -95,7 +101,7 @@ void main() {
     );
     await tester.pumpWidget(hostFor(missingFile));
 
-    await tester.tap(find.text('Play on TV'));
+    await tester.tap(find.text('Play on Fire Stick'));
     await tester.pumpAndSettle();
 
     expect(find.text("Couldn't play on your TV"), findsOneWidget);
@@ -105,12 +111,74 @@ void main() {
   testWidgets('stop casting returns to the idle offer state', (tester) async {
     await tester.pumpWidget(hostFor(itemFor()));
 
-    await tester.tap(find.text('Play on TV'));
+    await tester.tap(find.text('Play on Fire Stick'));
     await tester.pumpAndSettle();
     await tester.tap(find.text('Stop casting'));
     await tester.pumpAndSettle();
 
-    expect(find.text('Play on TV'), findsOneWidget);
+    expect(find.text('Play on Fire Stick'), findsOneWidget);
     expect(find.text('Playing on Fire Stick'), findsNothing);
+  });
+
+  testWidgets('discovers a receiver and connects before starting playback', (
+    tester,
+  ) async {
+    await castController.disconnect();
+    await tester.pumpWidget(hostFor(itemFor()));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Fire Stick'), findsOneWidget);
+    expect(
+      find.textContaining('Choose a Chromecast-enabled TV'),
+      findsOneWidget,
+    );
+
+    await tester.tap(find.text('Fire Stick'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Playing on Fire Stick'), findsOneWidget);
+    final connectIndex = castController.recordedActions.indexOf('connect:tv-1');
+    final loadIndex = castController.recordedActions.indexWhere(
+      (action) => action.startsWith('load:'),
+    );
+    expect(connectIndex, greaterThanOrEqualTo(0));
+    expect(loadIndex, greaterThan(connectIndex));
+  });
+
+  testWidgets('shows a retryable empty state when no receivers are found', (
+    tester,
+  ) async {
+    final emptyController = FakeAiroCastController();
+    addTearDown(emptyController.dispose);
+
+    await tester.pumpWidget(hostFor(itemFor(), controller: emptyController));
+    await tester.pumpAndSettle();
+
+    expect(find.text('No Cast devices found'), findsOneWidget);
+    expect(find.text('Scan again'), findsOneWidget);
+    expect(
+      emptyController.recordedActions,
+      isNot(contains(startsWith('load:'))),
+    );
+  });
+
+  testWidgets('connection failure does not claim playback started', (
+    tester,
+  ) async {
+    await castController.disconnect();
+    castController.failConnection = true;
+    await tester.pumpWidget(hostFor(itemFor()));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Fire Stick'));
+    await tester.pumpAndSettle();
+
+    expect(find.text("Couldn't play on your TV"), findsOneWidget);
+    expect(find.text('Find a TV'), findsOneWidget);
+    expect(find.textContaining('Playing on'), findsNothing);
+    expect(
+      castController.recordedActions,
+      isNot(contains(startsWith('load:'))),
+    );
   });
 }

--- a/packages/feature_iptv/test/iptv/phone_media_play_on_tv_test.dart
+++ b/packages/feature_iptv/test/iptv/phone_media_play_on_tv_test.dart
@@ -91,6 +91,38 @@ void main() {
     expect(find.text('Playing on Fire Stick'), findsNothing);
   });
 
+  testWidgets('disposal releases the selected source lease', (tester) async {
+    late PhoneMediaCastHandoff handoff;
+    final lease = _RecordingSourceLease(() {
+      expect(handoff.isServing, isFalse);
+    });
+    final item = PhoneLocalMediaItem(
+      filePath: mediaFile.path,
+      title: 'Movie Night',
+      container: 'mkv',
+      sourceLease: lease,
+    );
+    handoff = PhoneMediaCastHandoff(
+      castController: castController,
+      bindAddress: InternetAddress.loopbackIPv4,
+      debugConnectivityStream: const Stream.empty(),
+    );
+    await tester.pumpWidget(
+      MaterialApp(
+        home: PhoneMediaPlayOnTvSheet(
+          item: item,
+          handoff: handoff,
+          castController: castController,
+        ),
+      ),
+    );
+
+    await tester.pumpWidget(const SizedBox.shrink());
+    await tester.pump();
+
+    expect(lease.releaseCount, 1);
+  });
+
   testWidgets('failed handoff shows an error state and offers retry', (
     tester,
   ) async {
@@ -182,4 +214,17 @@ void main() {
       isNot(contains(startsWith('load:'))),
     );
   });
+}
+
+class _RecordingSourceLease implements PhoneMediaSourceLease {
+  _RecordingSourceLease(this.onRelease);
+
+  final void Function() onRelease;
+  int releaseCount = 0;
+
+  @override
+  Future<void> release() async {
+    releaseCount++;
+    onRelease();
+  }
 }

--- a/packages/feature_iptv/test/iptv/presentation/screens/iptv_screen_test.dart
+++ b/packages/feature_iptv/test/iptv/presentation/screens/iptv_screen_test.dart
@@ -743,7 +743,11 @@ void main() {
       await selectDrawerTile(tester, const ValueKey('iptv-drawer-play-on-tv'));
 
       expect(find.text('Movie Night'), findsOneWidget);
-      expect(find.text('Play on TV'), findsOneWidget);
+      expect(
+        find.textContaining('Choose a Chromecast-enabled TV'),
+        findsOneWidget,
+      );
+      expect(find.text('Play on TV'), findsNothing);
     },
   );
 

--- a/packages/feature_iptv/test/iptv/presentation/tv_ux/airo_tv_shell_test.dart
+++ b/packages/feature_iptv/test/iptv/presentation/tv_ux/airo_tv_shell_test.dart
@@ -35,7 +35,11 @@ void main() {
     });
   });
 
-  Future<ProviderContainer> pumpAt(WidgetTester tester, double width) async {
+  Future<ProviderContainer> pumpAt(
+    WidgetTester tester,
+    double width, {
+    double height = 720,
+  }) async {
     final prefs = await SharedPreferences.getInstance();
     final container = ProviderContainer(
       overrides: [
@@ -51,7 +55,7 @@ void main() {
           home: Scaffold(
             body: SizedBox(
               width: width,
-              height: 720,
+              height: height,
               child: AiroTvShell(
                 channels: channels,
                 videoStage: const SizedBox(key: ValueKey('video-stage')),
@@ -138,6 +142,18 @@ void main() {
         .getSize(find.byKey(const ValueKey('airo-tv-explorer-panel')))
         .width;
     expect(stageWidth, lessThan(panelWidth));
+  });
+
+  testWidgets('wide preview scales down when cast controls reduce height', (
+    tester,
+  ) async {
+    await pumpAt(tester, 1280, height: 400);
+
+    expect(tester.takeException(), isNull);
+    expect(
+      find.byKey(const ValueKey('airo-tv-explorer-video-stage')),
+      findsOneWidget,
+    );
   });
 
   testWidgets('TV-sized layout keeps channel rows focusable', (tester) async {

--- a/packages/feature_iptv/test/iptv/presentation/widgets/iptv_cast_connection_banner_test.dart
+++ b/packages/feature_iptv/test/iptv/presentation/widgets/iptv_cast_connection_banner_test.dart
@@ -107,36 +107,68 @@ void main() {
     expect(find.byTooltip('Stop receiver media'), findsOneWidget);
   });
 
-  testWidgets(
-    '"Open controls" dismisses the banner into the expanded controller',
-    (tester) async {
-      final notifier = _MutableCastNotifier(const IptvCastState());
+  testWidgets('Cast remote fits a short landscape surface', (tester) async {
+    final notifier = _MutableCastNotifier(
+      IptvCastState(
+        session: AiroCastSessionSnapshot.playing(device: tv, media: media),
+      ),
+    );
 
-      await tester.pumpWidget(
-        ProviderScope(
-          overrides: [iptvCastProvider.overrideWith((ref) => notifier)],
-          child: const MaterialApp(
-            home: Scaffold(body: IptvCastMiniController()),
-          ),
+    tester.view.physicalSize = const Size(1280, 400);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [iptvCastProvider.overrideWith((ref) => notifier)],
+        child: const MaterialApp(
+          home: Scaffold(body: IptvCastMiniController()),
         ),
-      );
+      ),
+    );
+    await tester.tap(find.byTooltip('Open Cast remote'));
+    await tester.pumpAndSettle();
 
-      notifier.setState(
-        IptvCastState(
-          session: AiroCastSessionSnapshot.playing(device: tv, media: media),
+    expect(tester.takeException(), isNull);
+    expect(find.text('Remote for Sony Bravia'), findsOneWidget);
+    expect(find.text('Disconnect TV'), findsOneWidget);
+  });
+
+  testWidgets('"Open controls" presents the Cast remote sheet', (tester) async {
+    final notifier = _MutableCastNotifier(const IptvCastState());
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [iptvCastProvider.overrideWith((ref) => notifier)],
+        child: const MaterialApp(
+          home: Scaffold(body: IptvCastMiniController()),
         ),
-      );
-      await tester.pump();
+      ),
+    );
 
-      await tester.tap(find.text('Open controls'));
-      await tester.pump();
+    notifier.setState(
+      IptvCastState(
+        session: AiroCastSessionSnapshot.playing(device: tv, media: media),
+      ),
+    );
+    await tester.pump();
 
-      expect(find.textContaining('Playing on'), findsNothing);
-      expect(find.text('Reload'), findsOneWidget);
-      expect(find.text('New session'), findsOneWidget);
-      expect(find.text('Disconnect'), findsOneWidget);
-    },
-  );
+    await tester.tap(find.text('Open controls'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Remote for Sony Bravia'), findsOneWidget);
+    expect(find.text('P4U Music'), findsWidgets);
+    expect(find.byTooltip('Volume up'), findsOneWidget);
+    expect(find.byTooltip('Volume down'), findsOneWidget);
+    expect(find.byTooltip('Mute'), findsOneWidget);
+    expect(find.byTooltip('Stop receiver media'), findsWidgets);
+    expect(find.text('Disconnect TV'), findsOneWidget);
+
+    await tester.tap(find.byTooltip('Mute'));
+    await tester.pump();
+    expect(notifier.fakeController.recordedActions, contains('setVolume:0.0'));
+  });
 
   testWidgets(
     'no banner for a session that is already connected when the widget mounts '
@@ -206,12 +238,14 @@ void main() {
 
 class _MutableCastNotifier extends IptvCastNotifier {
   _MutableCastNotifier(IptvCastState initial)
-    : super(
-        controller: FakeAiroCastController(),
-        adapter: const IptvCastMediaAdapter(),
-      ) {
+    : this._(initial, FakeAiroCastController());
+
+  _MutableCastNotifier._(IptvCastState initial, this.fakeController)
+    : super(controller: fakeController, adapter: const IptvCastMediaAdapter()) {
     state = initial;
   }
+
+  final FakeAiroCastController fakeController;
 
   void setState(IptvCastState next) => state = next;
 }

--- a/packages/feature_iptv/test/iptv/presentation/widgets/iptv_cast_connection_banner_test.dart
+++ b/packages/feature_iptv/test/iptv/presentation/widgets/iptv_cast_connection_banner_test.dart
@@ -107,6 +107,37 @@ void main() {
     expect(find.byTooltip('Stop receiver media'), findsOneWidget);
   });
 
+  testWidgets('connection banner fits a short landscape surface', (
+    tester,
+  ) async {
+    final notifier = _MutableCastNotifier(const IptvCastState());
+
+    tester.view.physicalSize = const Size(1280, 400);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [iptvCastProvider.overrideWith((ref) => notifier)],
+        child: const MaterialApp(
+          home: Scaffold(body: IptvCastMiniController()),
+        ),
+      ),
+    );
+    notifier.setState(
+      IptvCastState(
+        session: AiroCastSessionSnapshot.playing(device: tv, media: media),
+      ),
+    );
+    await tester.pump();
+
+    expect(tester.takeException(), isNull);
+    expect(find.text('Playing on Sony Bravia'), findsOneWidget);
+    expect(find.text('Browse'), findsOneWidget);
+    expect(find.text('Remote'), findsOneWidget);
+  });
+
   testWidgets('Cast remote fits a short landscape surface', (tester) async {
     final notifier = _MutableCastNotifier(
       IptvCastState(

--- a/packages/feature_iptv/test/iptv/presentation/widgets/iptv_cast_connection_banner_test.dart
+++ b/packages/feature_iptv/test/iptv/presentation/widgets/iptv_cast_connection_banner_test.dart
@@ -18,9 +18,7 @@ void main() {
 
       await tester.pumpWidget(
         ProviderScope(
-          overrides: [
-            iptvCastProvider.overrideWith((ref) => notifier),
-          ],
+          overrides: [iptvCastProvider.overrideWith((ref) => notifier)],
           child: const MaterialApp(
             home: Scaffold(body: IptvCastMiniController()),
           ),
@@ -50,10 +48,49 @@ void main() {
     },
   );
 
-  testWidgets('"Browse channels" dismisses the banner into the compact controller', (
+  testWidgets(
+    '"Browse channels" dismisses the banner into the compact controller',
+    (tester) async {
+      final notifier = _MutableCastNotifier(const IptvCastState());
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [iptvCastProvider.overrideWith((ref) => notifier)],
+          child: const MaterialApp(
+            home: Scaffold(body: IptvCastMiniController()),
+          ),
+        ),
+      );
+
+      notifier.setState(
+        IptvCastState(
+          session: AiroCastSessionSnapshot.playing(device: tv, media: media),
+        ),
+      );
+      await tester.pump();
+
+      await tester.tap(find.text('Browse channels'));
+      await tester.pump();
+
+      expect(find.textContaining('Playing on'), findsNothing);
+      expect(find.text('Casting to Sony Bravia'), findsOneWidget);
+      expect(find.text('Reload'), findsNothing, reason: 'compact by default');
+    },
+  );
+
+  testWidgets('compact controller fits a short landscape surface', (
     tester,
   ) async {
-    final notifier = _MutableCastNotifier(const IptvCastState());
+    final notifier = _MutableCastNotifier(
+      IptvCastState(
+        session: AiroCastSessionSnapshot.playing(device: tv, media: media),
+      ),
+    );
+
+    tester.view.physicalSize = const Size(1280, 400);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
 
     await tester.pumpWidget(
       ProviderScope(
@@ -64,50 +101,42 @@ void main() {
       ),
     );
 
-    notifier.setState(
-      IptvCastState(
-        session: AiroCastSessionSnapshot.playing(device: tv, media: media),
-      ),
-    );
-    await tester.pump();
-
-    await tester.tap(find.text('Browse channels'));
-    await tester.pump();
-
-    expect(find.textContaining('Playing on'), findsNothing);
+    expect(tester.takeException(), isNull);
     expect(find.text('Casting to Sony Bravia'), findsOneWidget);
-    expect(find.text('Reload'), findsNothing, reason: 'compact by default');
+    expect(find.byTooltip('Pause'), findsOneWidget);
+    expect(find.byTooltip('Stop receiver media'), findsOneWidget);
   });
 
-  testWidgets('"Open controls" dismisses the banner into the expanded controller', (
-    tester,
-  ) async {
-    final notifier = _MutableCastNotifier(const IptvCastState());
+  testWidgets(
+    '"Open controls" dismisses the banner into the expanded controller',
+    (tester) async {
+      final notifier = _MutableCastNotifier(const IptvCastState());
 
-    await tester.pumpWidget(
-      ProviderScope(
-        overrides: [iptvCastProvider.overrideWith((ref) => notifier)],
-        child: const MaterialApp(
-          home: Scaffold(body: IptvCastMiniController()),
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [iptvCastProvider.overrideWith((ref) => notifier)],
+          child: const MaterialApp(
+            home: Scaffold(body: IptvCastMiniController()),
+          ),
         ),
-      ),
-    );
+      );
 
-    notifier.setState(
-      IptvCastState(
-        session: AiroCastSessionSnapshot.playing(device: tv, media: media),
-      ),
-    );
-    await tester.pump();
+      notifier.setState(
+        IptvCastState(
+          session: AiroCastSessionSnapshot.playing(device: tv, media: media),
+        ),
+      );
+      await tester.pump();
 
-    await tester.tap(find.text('Open controls'));
-    await tester.pump();
+      await tester.tap(find.text('Open controls'));
+      await tester.pump();
 
-    expect(find.textContaining('Playing on'), findsNothing);
-    expect(find.text('Reload'), findsOneWidget);
-    expect(find.text('New session'), findsOneWidget);
-    expect(find.text('Disconnect'), findsOneWidget);
-  });
+      expect(find.textContaining('Playing on'), findsNothing);
+      expect(find.text('Reload'), findsOneWidget);
+      expect(find.text('New session'), findsOneWidget);
+      expect(find.text('Disconnect'), findsOneWidget);
+    },
+  );
 
   testWidgets(
     'no banner for a session that is already connected when the widget mounts '

--- a/packages/platform_player/lib/src/services/flutter_chrome_cast_controller.dart
+++ b/packages/platform_player/lib/src/services/flutter_chrome_cast_controller.dart
@@ -12,6 +12,7 @@ import 'package:flutter_chrome_cast/media.dart';
 import 'package:flutter_chrome_cast/models/android/android_cast_options.dart';
 import 'package:flutter_chrome_cast/models/ios/ios_cast_options.dart';
 import 'package:flutter_chrome_cast/session.dart';
+import 'package:platform_channels/platform_channels.dart';
 
 import '../models/cast_models.dart';
 import 'airo_cast_controller.dart';
@@ -439,12 +440,17 @@ class FlutterChromeCastController implements AiroCastController {
         codecs: 'hvc1.1.6.L93.B0,mp4a.40.2',
       );
     }
-    if (useProxy) {
+    if (shouldProxyUrl(original, proxyEnabled: useProxy)) {
       await _httpProxy.start();
       _log('load using proxy original=${_uriSummary(original)}');
       return _httpProxy.proxiedUrl(original);
     }
     return original;
+  }
+
+  @visibleForTesting
+  static bool shouldProxyUrl(Uri url, {required bool proxyEnabled}) {
+    return proxyEnabled && AiroPlaylistUrlPolicy.isAllowedCastProxyTarget(url);
   }
 
   Future<HlsProbe> probeHls(Uri url) async {

--- a/packages/platform_player/lib/src/services/phone_media_cast_handoff.dart
+++ b/packages/platform_player/lib/src/services/phone_media_cast_handoff.dart
@@ -184,6 +184,9 @@ class PhoneMediaCastHandoff {
     if (unsupportedReason != null) {
       return PhoneMediaHandoffUnsupported(reason: unsupportedReason);
     }
+    if (!_castController.currentSessionState.isConnected) {
+      return const PhoneMediaHandoffFailed();
+    }
 
     _cancelPauseKeepAlive();
     await _teardownServer();
@@ -223,6 +226,15 @@ class PhoneMediaCastHandoff {
         _onConnectivityChanged,
       );
       await _castController.load(request);
+      final loadPhase = _castController.currentSessionState.phase;
+      final loadAccepted =
+          loadPhase == AiroCastSessionPhase.loadingMedia ||
+          loadPhase == AiroCastSessionPhase.playing ||
+          loadPhase == AiroCastSessionPhase.paused;
+      if (!loadAccepted) {
+        await _teardownServer();
+        return const PhoneMediaHandoffFailed();
+      }
       return PhoneMediaHandoffStarted(request: request);
     } catch (_) {
       // Never leave a live tokenized URL behind a handoff that failed.

--- a/packages/platform_player/lib/src/services/phone_media_cast_handoff.dart
+++ b/packages/platform_player/lib/src/services/phone_media_cast_handoff.dart
@@ -12,12 +12,21 @@ import '../models/phone_media_diagnostic_models.dart';
 import 'airo_cast_controller.dart';
 import 'phone_media_file_server.dart';
 
+/// A process-local handle that keeps a selected media source readable.
+///
+/// Android document URIs use this to retain a seekable file descriptor without
+/// copying multi-gigabyte videos into the app cache.
+abstract interface class PhoneMediaSourceLease {
+  Future<void> release();
+}
+
 /// A phone-local media file selected for playback on a receiver (CV-033).
 class PhoneLocalMediaItem extends Equatable {
   const PhoneLocalMediaItem({
     required this.filePath,
     required this.title,
     required this.container,
+    this.sourceLease,
     this.videoCodec,
     this.audioCodec,
     this.duration,
@@ -28,6 +37,7 @@ class PhoneLocalMediaItem extends Equatable {
 
   /// Container/extension in lowercase without a dot, e.g. `mp4`, `mkv`.
   final String container;
+  final PhoneMediaSourceLease? sourceLease;
   final String? videoCodec;
   final String? audioCodec;
   final Duration? duration;
@@ -247,6 +257,12 @@ class PhoneMediaCastHandoff {
     await _castController.stop();
     await _teardownServer();
   }
+
+  /// Stops every read of the selected source before its platform lease closes.
+  ///
+  /// Full [dispose] also cancels session/connectivity subscriptions, which is
+  /// intentionally separate from this file-lifetime barrier.
+  Future<void> prepareSourceRelease() => _teardownServer();
 
   Future<void> dispose() async {
     final subscription = _sessionSubscription;

--- a/packages/platform_player/test/flutter_chrome_cast_controller_test.dart
+++ b/packages/platform_player/test/flutter_chrome_cast_controller_test.dart
@@ -62,6 +62,23 @@ void main() {
     expect(mediaInfo.streamType, CastMediaStreamType.buffered);
   });
 
+  test('proxy mode bypasses tokenized private-LAN handoff URLs', () {
+    expect(
+      FlutterChromeCastController.shouldProxyUrl(
+        Uri.parse('http://192.168.1.15:33573/media?token=redacted'),
+        proxyEnabled: true,
+      ),
+      isFalse,
+    );
+    expect(
+      FlutterChromeCastController.shouldProxyUrl(
+        Uri.parse('https://example.com/channel.m3u8'),
+        proxyEnabled: true,
+      ),
+      isTrue,
+    );
+  });
+
   test('ignores stale receiver status for previous media content id', () {
     const tv = AiroCastDevice(id: 'tv-1', name: 'Sony Bravia');
     final current = AiroCastMediaRequest(

--- a/packages/platform_player/test/phone_media_cast_handoff_test.dart
+++ b/packages/platform_player/test/phone_media_cast_handoff_test.dart
@@ -149,6 +149,36 @@ void main() {
     await handoff.stopHandoff();
   });
 
+  test('does not open a server or report success without a receiver', () async {
+    await castController.disconnect();
+    final handoff = handoffFor();
+
+    final result = await handoff.start(itemFor());
+
+    expect(result, isA<PhoneMediaHandoffFailed>());
+    expect(handoff.isServing, isFalse);
+    expect(
+      castController.recordedActions.where(
+        (action) => action.startsWith('load:'),
+      ),
+      isEmpty,
+    );
+  });
+
+  test('tears down when the controller records a failed media load', () async {
+    castController.failMediaLoad = true;
+    final handoff = handoffFor();
+
+    final result = await handoff.start(itemFor());
+
+    expect(result, isA<PhoneMediaHandoffFailed>());
+    expect(handoff.isServing, isFalse);
+    expect(
+      castController.currentSessionState.phase,
+      AiroCastSessionPhase.failed,
+    );
+  });
+
   test('stopHandoff stops the server and the cast session', () async {
     final handoff = handoffFor();
     await handoff.start(itemFor());

--- a/packages/stubs/file_picker_stub/lib/file_picker.dart
+++ b/packages/stubs/file_picker_stub/lib/file_picker.dart
@@ -40,6 +40,15 @@ enum FilePickerStatus { picking, done }
 
 /// Stub FilePicker - returns null on TV
 abstract final class FilePicker {
+  /// Pick one file - returns null on TV
+  static Future<PlatformFile?> pickFile({
+    String? dialogTitle,
+    String? initialDirectory,
+    FileType type = FileType.any,
+    List<String>? allowedExtensions,
+    bool lockParentWindow = false,
+  }) async => null;
+
   /// Pick files - returns null on TV
   static Future<FilePickerResult?> pickFiles({
     String? dialogTitle,


### PR DESCRIPTION
## Summary

- install the platform-aware Cast controller override in the normal Airo mobile composition root
- extract provider composition so it is testable without generated Firebase configuration
- prove Android gets `FlutterChromeCastController` while macOS preserves the unavailable desktop contract
- fix #1088 by preserving Airo's compact super-app navigation and keeping every secondary branch overflow-reachable

Follow-up to #1085 and #844. Without the composition fix, the experimental mobile entry always receives `UnavailableAiroCastController`. Pixel qualification also exposed the pre-existing compact-shell assertion after login; this PR now fixes that bounded blocker without changing `TvShell`.

## Test Plan

- [x] `flutter test test/core/app/app_shell_navigation_policy_test.dart test/core/providers/navigation_provider_test.dart test/main_cast_override_test.dart test/main_tv_cast_override_test.dart` (18 passed)
- [x] `flutter test test/widget_test.dart`
- [x] targeted analyzer for composition, Cast override, app shell/navigation, and regression tests
- [x] `python3 scripts/check-module-manifests.py` (54 valid)
- [x] `bash scripts/check-docs-completeness.sh`
- [x] `git diff --check`
- [x] Physical Pixel 9, Android 17 / API 37

**Physical flow:** Built with `ENABLE_PHONE_MEDIA_RECEIVER=true`, installed exact head `c3b2ce9c`, opened authenticated Airo, navigated Live -> Play file on TV, and selected a 15-second local video. Runtime logged `[AiroCast] initialized receiverApp=CC1AD845`; no Flutter assertion, `MissingPluginException`, `PlatformException`, or Android crash occurred.

## Agent Policy

- [x] #844 covers the receiver composition contract.
- [x] #1088 records the compact-navigation Critical Agent gate, application-only contract, deterministic use cases, and Pixel automation flow.
- [x] Changes stay in application composition/navigation and consume existing framework contracts.
- [x] Airo remains the super app; Airo TV retains its separate shell until intentional stable integration.
- [x] Android Emulator was not used.

## Council Review

- Flutter Architect: PASS - Riverpod composition and app-shell navigation contracts remain deterministic.
- Chief Performance Officer: PASS - no new worker, startup loop, dependency, or heavy main-isolate work.
- Chief Open Source Officer: PASS - no dependency or plugin added.
- Chief Architect: PASS - Airo super-app and Airo TV shell boundaries are explicit and unchanged.
- Chief QA Officer: PASS - deterministic host tests plus physical Pixel flow cover both regressions.
- Product Manager: PASS - experimental receiver entry is functional while TV-specific navigation remains isolated.

- [x] Decision Matrix reviewed and required roles recorded by the external Codex review session.

## User-Facing Documentation

- [x] No wiki update is needed; #1085 already documents the experimental entry. This PR repairs composition and a shell regression without changing the documented product flow.

## Plugin and Size Impact

- [x] No new dependency, plugin, binary asset, or protocol is added.

## Checklist

- [x] Code is formatted.
- [x] Tests and physical evidence are included above.
- [x] No sensitive data or credentials are added.
- [x] Remote CI intentionally skipped under repository cost-control policy; focused local evidence is recorded.

## Release Notes

- [x] Fixes the experimental phone-to-TV entry so supported Android builds use the real Cast controller.
- [x] Fixes compact Airo login navigation while preserving the separate Airo TV shell.