### PR TITLE
fix(app): restore CI on main — go_router constraint + docs gate

### DIFF
--- a/app/lib/core/features/feature_registry.dart
+++ b/app/lib/core/features/feature_registry.dart
@@ -89,8 +89,7 @@ abstract class AppFeatureModule implements shell.AppModule {
   List<RouteBase> routesFor(shell.ShellId shell) => routes;
 
   @override
-  List<Override> providerOverridesFor(shell.ShellId shell) =>
-      providerOverrides;
+  List<Override> providerOverridesFor(shell.ShellId shell) => providerOverrides;
 
   /// Initialize the feature (called once on app startup)
   ///

--- a/app/lib/features/settings/presentation/screens/settings_hub_screen.dart
+++ b/app/lib/features/settings/presentation/screens/settings_hub_screen.dart
@@ -91,9 +91,7 @@ class SettingsHubScreen extends ConsumerWidget {
                 _section(IptvSettingsSectionId.audio).iconFor(ShellId.mobile),
               ),
               title: Text(
-                _section(
-                  IptvSettingsSectionId.audio,
-                ).labelFor(ShellId.mobile),
+                _section(IptvSettingsSectionId.audio).labelFor(ShellId.mobile),
               ),
               subtitle: const Text('Configure context-aware audio behavior'),
               trailing: const Icon(Icons.arrow_forward_ios, size: 16),

--- a/app/lib/features/settings/presentation/tv/tv_settings_screen.dart
+++ b/app/lib/features/settings/presentation/tv/tv_settings_screen.dart
@@ -48,8 +48,7 @@ class _TvSettingsScreenState extends ConsumerState<TvSettingsScreen> {
                       padding: const EdgeInsets.only(bottom: 8),
                       child: TvFocusable(
                         autofocus: section.id == IptvSettingsSectionId.theme,
-                        onSelect: () =>
-                            setState(() => _selected = section.id),
+                        onSelect: () => setState(() => _selected = section.id),
                         semanticLabel: section.labelFor(ShellId.tv),
                         semanticButton: true,
                         child: DecoratedBox(

--- a/docs/wiki/3.-Navigating-Airo.md
+++ b/docs/wiki/3.-Navigating-Airo.md
@@ -88,3 +88,12 @@ Header behavior:
 
 - `/quest` and nested quest flows use route-level app bars so quest actions stay
   contextual to the current task.
+
+## Settings
+
+Both mobile Settings and Airo TV Settings now read their section list from a
+single shared IPTV settings manifest instead of two hand-maintained lists.
+Sections still differ intentionally per platform — for example, Country and
+Audio settings are mobile-only, and Accessibility plus a combined Sources
+section are TV-only — but any shared section stays in sync automatically
+across both screens.

--- a/packages/core_product_shell/pubspec.yaml
+++ b/packages/core_product_shell/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
   flutter:
     sdk: flutter
   flutter_riverpod: 3.3.2
-  go_router: ^17.3.0
+  go_router: ">=17.1.0 <18.0.0"
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Why
PR #1098 (SSOT phase 1) got squash-merged to main using only its first commit, before two follow-up fixes landed on the branch. Main currently has:
- `packages/core_product_shell` pinned to `go_router: ^17.3.0`, which conflicts with the TV build variant's pinned `go_router: 17.1.0` in `app/pubspec_tv.yaml` — breaks the TV build job
- no `docs/wiki` update for the settings-manifest change, failing `check-docs-completeness.sh`

This PR cherry-picks the two fix commits that were pushed to the now-merged branch too late to be included.

## Changes
- Loosen `core_product_shell`'s go_router constraint to `>=17.1.0 <18.0.0`
- Add a Settings section to `docs/wiki/3.-Navigating-Airo.md` documenting the shared IPTV settings manifest

## Test plan
- [x] `scripts/check-docs-completeness.sh --base origin/main --head HEAD` passes
- [x] `go_router` constraint verified compatible with both `app/pubspec.yaml` (`^17.3.0`) and `app/pubspec_tv.yaml` (`17.1.0`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)