### PR TITLE
fix(feature_iptv): update cast mini-controller test for CV-028 redesign

### DIFF
--- a/packages/feature_iptv/test/iptv/iptv_cast_ui_test.dart
+++ b/packages/feature_iptv/test/iptv/iptv_cast_ui_test.dart
@@ -156,18 +156,15 @@ void main() {
     expect(find.text('Casting to Sony Bravia'), findsOneWidget);
     expect(find.text('P4U Music'), findsOneWidget);
     expect(find.text('Stop'), findsOneWidget);
-    // CV-028: Reload/New session/Disconnect are secondary actions, hidden
-    // behind the "More controls" expand toggle by default.
-    expect(find.text('Reload'), findsNothing);
-    expect(find.text('New session'), findsNothing);
+    // CV-028: secondary actions (disconnect) live in the full remote-control
+    // sheet reached via "Open Cast remote", not inline in the compact
+    // controller.
     expect(find.text('Disconnect'), findsNothing);
 
-    await tester.tap(find.byTooltip('More controls'));
-    await tester.pump();
+    await tester.tap(find.byTooltip('Open Cast remote'));
+    await tester.pumpAndSettle();
 
-    expect(find.text('Reload'), findsOneWidget);
-    expect(find.text('New session'), findsOneWidget);
-    expect(find.text('Disconnect'), findsOneWidget);
+    expect(find.text('Disconnect TV'), findsOneWidget);
   });
 
   testWidgets('mini controller keeps controls for recovered session', (


### PR DESCRIPTION
## Why
`iptv_cast_ui_test.dart`'s "mini controller shows active cast session" test asserts an inline "More controls" expand toggle (Reload/New session/Disconnect) that no longer exists — `IptvCastMiniController` was rewritten in #1087 (CV-028) to move secondary actions into the full remote-control sheet reached via "Open Cast remote". This has been broken on `main` since #1087 merged; it's unrelated to the SSOT phase 1 work (#1098) or the go_router/docs hotfix (#1099), it just wasn't caught until those PRs' merges exercised the TV APK build gate again.

## Fix
Update the test to match the current CV-028 design: check the compact controls, tap "Open Cast remote", assert "Disconnect TV" in the opened sheet.

## Test plan
- [x] `flutter test test/iptv/iptv_cast_ui_test.dart` — 7/7 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)