### PR TITLE
docs(wiki): document TV settings module-ownership split

### DIFF
--- a/docs/wiki/3.-Navigating-Airo.md
+++ b/docs/wiki/3.-Navigating-Airo.md
@@ -97,3 +97,10 @@ Sections still differ intentionally per platform — for example, Country and
 Audio settings are mobile-only, and Accessibility plus a combined Sources
 section are TV-only — but any shared section stays in sync automatically
 across both screens.
+
+Section ownership follows the modular-app model: Playback and Source
+Management are IPTV-module concerns and live in the `feature_iptv` package;
+Theme stays a super-app-level "Airo profile" setting, since it shares the
+same theme provider as the phone profile screen. A setting only lives at the
+app level when it's genuinely cross-app — otherwise it's local to the module
+that owns it.


### PR DESCRIPTION
## Why
#1101 merged before this docs update landed (docs-completeness gate failed at merge time; only sonarqube is a required check so it merged anyway). Content on main is correct — this just closes the docs gate retroactively and records the ownership rule for future settings work.

## Test plan
- [x] \`scripts/check-docs-completeness.sh\` passes for this range

🤖 Generated with [Claude Code](https://claude.com/claude-code)