### PR TITLE
fix(app): add core_app_shell dependency to TV pubspec variant

### DIFF
--- a/app/pubspec_tv.yaml
+++ b/app/pubspec_tv.yaml
@@ -71,6 +71,8 @@ dependencies:
     path: ../packages/core_ai
   core_auth:
     path: ../packages/core_auth
+  core_app_shell:
+    path: ../packages/core_app_shell
   core_product_shell:
     path: ../packages/core_product_shell
 


### PR DESCRIPTION
## Why
#1104 merged before the TV build finished (only sonarqube is a required check). It added `core_app_shell` to `app/pubspec.yaml` but missed `app/pubspec_tv.yaml`, the separate pubspec swapped in for Android TV builds — so `main_tv.dart`'s shim-based imports (`PlatformFeatures`, `DeviceFormFactor`, `appThemeProvider`, `scheduleDeferredStartupTask`) resolved against a pubspec that never declared the package. TV build is currently broken on main.

## Fix
Add the same `core_app_shell` path dependency to `app/pubspec_tv.yaml`.

## Test plan
- [x] Swapped `pubspec_tv.yaml` into place locally, ran `flutter analyze lib/main_tv.dart test/main_tv_debug_playlist_test.dart` — only the pre-existing, unrelated `firebase_options.dart` gap remains (gitignored, not present in this worktree; CI injects it from secrets)

🤖 Generated with [Claude Code](https://claude.com/claude-code)