### PR TITLE
refactor(settings): move mobile CountrySettingsTile into feature_iptv

### DIFF
--- a/app/lib/features/settings/presentation/screens/settings_hub_screen.dart
+++ b/app/lib/features/settings/presentation/screens/settings_hub_screen.dart
@@ -1,11 +1,8 @@
-import 'dart:async';
-
 import 'package:core_product_shell/core_product_shell.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:core_ui/core_ui.dart';
 import 'package:feature_iptv/feature_iptv.dart';
-import 'package:feature_iptv/presentation/tv_ux/sections/filter_dialogs.dart';
 import '../../../../core/providers/app_theme_provider.dart';
 import 'audio_settings_screen.dart';
 
@@ -125,7 +122,7 @@ class SettingsHubScreen extends ConsumerWidget {
               },
             ),
 
-            const _CountrySettingsTile(),
+            const CountrySettingsTile(),
 
             ListTile(
               leading: Icon(
@@ -165,64 +162,3 @@ class SettingsHubScreen extends ConsumerWidget {
   }
 }
 
-class _CountrySettingsTile extends ConsumerWidget {
-  const _CountrySettingsTile();
-
-  @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final filters = ref.watch(channelFiltersProvider);
-    final channelsAsync = ref.watch(iptvChannelsProvider);
-    final channels = channelsAsync.value ?? const <IPTVChannel>[];
-    final dimensions = channelFilterDimensions(
-      channels: channels,
-      metadataByChannelId: const {},
-    );
-    final canPickCountry =
-        dimensions.countries.isNotEmpty || filters.country != null;
-
-    final country = _section(IptvSettingsSectionId.country);
-    return ListTile(
-      leading: Icon(country.iconFor(ShellId.mobile)),
-      title: Text(country.labelFor(ShellId.mobile)),
-      subtitle: Text(
-        filters.country != null
-            ? countryDisplayLabel(filters.country)
-            : channelsAsync.isLoading
-            ? 'Loading countries…'
-            : dimensions.countries.isEmpty
-            ? 'Load channels first to choose a country'
-            : 'Choose your default channel country',
-      ),
-      trailing: const Icon(Icons.arrow_forward_ios, size: 16),
-      enabled: canPickCountry,
-      onTap: !canPickCountry
-          ? null
-          : () => _showCountryPicker(context, ref, dimensions, filters.country),
-    );
-  }
-
-  Future<void> _showCountryPicker(
-    BuildContext context,
-    WidgetRef ref,
-    ChannelFilterDimensions dimensions,
-    String? selectedCountry,
-  ) {
-    final filters = ref.read(channelFiltersProvider.notifier);
-    final countryPrompt = ref.read(channelCountryPromptProvider.notifier);
-    return showFilterOptionDialog(
-      context: context,
-      title: 'Country',
-      options: dimensions.countries.toList(growable: false),
-      selectedValue: selectedCountry,
-      onSelected: (country) {
-        filters.setCountry(country);
-        unawaited(countryPrompt.markCompleted());
-      },
-      onClear: () {
-        filters.setCountry(null);
-        unawaited(countryPrompt.markCompleted());
-      },
-      optionLabel: countryDisplayLabel,
-    );
-  }
-}

--- a/app/lib/features/settings/presentation/screens/settings_hub_screen.dart
+++ b/app/lib/features/settings/presentation/screens/settings_hub_screen.dart
@@ -161,4 +161,3 @@ class SettingsHubScreen extends ConsumerWidget {
     );
   }
 }
-

--- a/app/test/firebase_options_test.dart
+++ b/app/test/firebase_options_test.dart
@@ -63,11 +63,7 @@ void main() {
     test('selects the supported full, streaming, and TV variants', () {
       expect(
         AppVariant.values,
-        containsAll([
-          AppVariant.full,
-          AppVariant.streaming,
-          AppVariant.tv,
-        ]),
+        containsAll([AppVariant.full, AppVariant.streaming, AppVariant.tv]),
       );
       expect(AppVariant.values, hasLength(3));
     });

--- a/docs/wiki/3.-Navigating-Airo.md
+++ b/docs/wiki/3.-Navigating-Airo.md
@@ -98,9 +98,10 @@ Audio settings are mobile-only, and Accessibility plus a combined Sources
 section are TV-only — but any shared section stays in sync automatically
 across both screens.
 
-Section ownership follows the modular-app model: Playback and Source
-Management are IPTV-module concerns and live in the `feature_iptv` package
-(mobile's `PlaybackSettingsScreen` and TV's `TvPlaybackSection` /
+Section ownership follows the modular-app model: Playback, Source
+Management, and Country are IPTV-module concerns and live in the
+`feature_iptv` package (mobile's `PlaybackSettingsScreen` /
+`CountrySettingsTile` and TV's `TvPlaybackSection` /
 `TvSourceManagementSection`); Theme and Audio stay app-level "Airo profile"
 settings, since both are genuinely cross-app (Theme is shared with the whole
 app's chrome, Audio shares `audio_context_provider` with the Music player). A

--- a/packages/feature_iptv/lib/application/providers/last_channel_provider.dart
+++ b/packages/feature_iptv/lib/application/providers/last_channel_provider.dart
@@ -27,9 +27,7 @@ class LastChannelRecorder extends StateNotifier<String?> {
         .watch(streamingStateStreamProvider)
         .listen(_recordCurrentChannel);
     _ref.onDispose(subscription.cancel);
-    _recordCurrentChannel(
-      _ref.read(iptvStreamingServiceProvider).currentState,
-    );
+    _recordCurrentChannel(_ref.read(iptvStreamingServiceProvider).currentState);
   }
 
   final Ref _ref;

--- a/packages/feature_iptv/lib/feature_iptv.dart
+++ b/packages/feature_iptv/lib/feature_iptv.dart
@@ -39,6 +39,7 @@ export "application/xmltv_source_store.dart";
 export "presentation/screens/browse_screen.dart";
 export "presentation/screens/iptv_screen.dart";
 export "presentation/screens/mobile_favorites_screen.dart";
+export "presentation/screens/settings/country_settings_tile.dart";
 export "presentation/screens/settings/playback_settings_screen.dart";
 export "presentation/screens/vod_screen.dart";
 export "presentation/tv/iptv_guide_screen.dart";

--- a/packages/feature_iptv/lib/presentation/screens/settings/country_settings_tile.dart
+++ b/packages/feature_iptv/lib/presentation/screens/settings/country_settings_tile.dart
@@ -1,0 +1,76 @@
+import 'dart:async';
+
+import 'package:core_product_shell/core_product_shell.dart';
+import 'package:feature_iptv/feature_iptv.dart';
+import 'package:feature_iptv/presentation/tv_ux/sections/filter_dialogs.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+/// Mobile Settings' country-filter tile (CV item 3): shows the user's
+/// default channel country and opens a picker built from whatever countries
+/// their loaded channels actually have. IPTV-module concern — moved out of
+/// `app/lib/features/settings` alongside `PlaybackSettingsScreen`, following
+/// the same module-ownership rule (see docs/wiki/3.-Navigating-Airo.md).
+class CountrySettingsTile extends ConsumerWidget {
+  const CountrySettingsTile({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final filters = ref.watch(channelFiltersProvider);
+    final channelsAsync = ref.watch(iptvChannelsProvider);
+    final channels = channelsAsync.value ?? const <IPTVChannel>[];
+    final dimensions = channelFilterDimensions(
+      channels: channels,
+      metadataByChannelId: const {},
+    );
+    final canPickCountry =
+        dimensions.countries.isNotEmpty || filters.country != null;
+
+    final country = iptvSettingsSections.firstWhere(
+      (section) => section.id == IptvSettingsSectionId.country,
+    );
+    return ListTile(
+      leading: Icon(country.iconFor(ShellId.mobile)),
+      title: Text(country.labelFor(ShellId.mobile)),
+      subtitle: Text(
+        filters.country != null
+            ? countryDisplayLabel(filters.country)
+            : channelsAsync.isLoading
+            ? 'Loading countries…'
+            : dimensions.countries.isEmpty
+            ? 'Load channels first to choose a country'
+            : 'Choose your default channel country',
+      ),
+      trailing: const Icon(Icons.arrow_forward_ios, size: 16),
+      enabled: canPickCountry,
+      onTap: !canPickCountry
+          ? null
+          : () => _showCountryPicker(context, ref, dimensions, filters.country),
+    );
+  }
+
+  Future<void> _showCountryPicker(
+    BuildContext context,
+    WidgetRef ref,
+    ChannelFilterDimensions dimensions,
+    String? selectedCountry,
+  ) {
+    final filters = ref.read(channelFiltersProvider.notifier);
+    final countryPrompt = ref.read(channelCountryPromptProvider.notifier);
+    return showFilterOptionDialog(
+      context: context,
+      title: 'Country',
+      options: dimensions.countries.toList(growable: false),
+      selectedValue: selectedCountry,
+      onSelected: (country) {
+        filters.setCountry(country);
+        unawaited(countryPrompt.markCompleted());
+      },
+      onClear: () {
+        filters.setCountry(null);
+        unawaited(countryPrompt.markCompleted());
+      },
+      optionLabel: countryDisplayLabel,
+    );
+  }
+}

--- a/packages/feature_iptv/lib/presentation/widgets/iptv_navigation_drawer.dart
+++ b/packages/feature_iptv/lib/presentation/widgets/iptv_navigation_drawer.dart
@@ -52,8 +52,7 @@ class IptvNavigationDrawer extends StatelessWidget {
                   key: ValueKey('iptv-drawer-${_keySuffix(destination.id)}'),
                   leading: Icon(destination.icon),
                   title: Text(destination.labelFor(ShellId.mobile)),
-                  onTap: () =>
-                      _select(context, _actionFor(destination.id)!),
+                  onTap: () => _select(context, _actionFor(destination.id)!),
                 ),
             if (onPlayLocalFileOnTv case final onPlayLocalFileOnTv?)
               ListTile(

--- a/packages/feature_iptv/test/iptv/application/providers/last_channel_provider_test.dart
+++ b/packages/feature_iptv/test/iptv/application/providers/last_channel_provider_test.dart
@@ -8,11 +8,8 @@ import 'package:platform_channels/platform_channels.dart';
 import 'package:platform_player/platform_player.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
-IPTVChannel channel(String id, {String name = 'Test'}) => IPTVChannel(
-  id: id,
-  name: name,
-  streamUrl: 'https://example.com/$id.m3u8',
-);
+IPTVChannel channel(String id, {String name = 'Test'}) =>
+    IPTVChannel(id: id, name: name, streamUrl: 'https://example.com/$id.m3u8');
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -30,7 +27,10 @@ void main() {
     });
 
     test('returns null when id is null', () {
-      expect(findResumeChannel(lastChannelId: null, channels: channels), isNull);
+      expect(
+        findResumeChannel(lastChannelId: null, channels: channels),
+        isNull,
+      );
     });
 
     test('returns null when the channel is gone from the list', () {

--- a/packages/feature_iptv/test/iptv/domain/iptv_navigation_manifest_test.dart
+++ b/packages/feature_iptv/test/iptv/domain/iptv_navigation_manifest_test.dart
@@ -6,16 +6,13 @@ void main() {
   group('iptvNavigationDestinations', () {
     test('declares exactly Home, Guide, Movies/VOD, Favorites, Settings in '
         'order', () {
-      expect(
-        iptvNavigationDestinations.map((d) => d.id).toList(),
-        const [
-          IptvDestinationId.home,
-          IptvDestinationId.guide,
-          IptvDestinationId.vod,
-          IptvDestinationId.favorites,
-          IptvDestinationId.settings,
-        ],
-      );
+      expect(iptvNavigationDestinations.map((d) => d.id).toList(), const [
+        IptvDestinationId.home,
+        IptvDestinationId.guide,
+        IptvDestinationId.vod,
+        IptvDestinationId.favorites,
+        IptvDestinationId.settings,
+      ]);
     });
 
     test('mobile and TV share the same destination list (one manifest, two '

--- a/packages/feature_iptv/test/iptv/domain/iptv_settings_manifest_test.dart
+++ b/packages/feature_iptv/test/iptv/domain/iptv_settings_manifest_test.dart
@@ -9,30 +9,24 @@ void main() {
 
     test('mobile sees theme, playback, playlistSource, epgGuideSource, '
         'country, audio — matching settings_hub_screen.dart today', () {
-      expect(
-        visibleOn(ShellId.mobile).map((s) => s.id).toSet(),
-        {
-          IptvSettingsSectionId.theme,
-          IptvSettingsSectionId.playback,
-          IptvSettingsSectionId.playlistSource,
-          IptvSettingsSectionId.epgGuideSource,
-          IptvSettingsSectionId.country,
-          IptvSettingsSectionId.audio,
-        },
-      );
+      expect(visibleOn(ShellId.mobile).map((s) => s.id).toSet(), {
+        IptvSettingsSectionId.theme,
+        IptvSettingsSectionId.playback,
+        IptvSettingsSectionId.playlistSource,
+        IptvSettingsSectionId.epgGuideSource,
+        IptvSettingsSectionId.country,
+        IptvSettingsSectionId.audio,
+      });
     });
 
     test('TV sees theme, playback, sources, accessibility — matching '
         'tv_settings_screen.dart today', () {
-      expect(
-        visibleOn(ShellId.tv).map((s) => s.id).toList(),
-        const [
-          IptvSettingsSectionId.theme,
-          IptvSettingsSectionId.playback,
-          IptvSettingsSectionId.sources,
-          IptvSettingsSectionId.accessibility,
-        ],
-      );
+      expect(visibleOn(ShellId.tv).map((s) => s.id).toList(), const [
+        IptvSettingsSectionId.theme,
+        IptvSettingsSectionId.playback,
+        IptvSettingsSectionId.sources,
+        IptvSettingsSectionId.accessibility,
+      ]);
     });
 
     test('theme section renders as "Appearance" on mobile and "Theme" on '
@@ -50,7 +44,10 @@ void main() {
         (s) => s.id == IptvSettingsSectionId.playback,
       );
 
-      expect(playback.iconFor(ShellId.mobile).codePoint, isNot(playback.icon.codePoint));
+      expect(
+        playback.iconFor(ShellId.mobile).codePoint,
+        isNot(playback.icon.codePoint),
+      );
       expect(playback.iconFor(ShellId.tv).codePoint, playback.icon.codePoint);
     });
 

--- a/packages/feature_iptv/test/iptv/presentation/widgets/iptv_cast_prompt_card_test.dart
+++ b/packages/feature_iptv/test/iptv/presentation/widgets/iptv_cast_prompt_card_test.dart
@@ -19,9 +19,7 @@ void main() {
 
   Future<SharedPreferences> prefs() => SharedPreferences.getInstance();
 
-  testWidgets('renders nothing when the prompt is not visible', (
-    tester,
-  ) async {
+  testWidgets('renders nothing when the prompt is not visible', (tester) async {
     await tester.pumpWidget(
       ProviderScope(
         overrides: [
@@ -139,10 +137,7 @@ void main() {
         ],
         child: MaterialApp(
           home: Scaffold(
-            body: IptvCastPromptCard(
-              channel: uncastable,
-              onChooseTv: () {},
-            ),
+            body: IptvCastPromptCard(channel: uncastable, onChooseTv: () {}),
           ),
         ),
       ),

--- a/packages/feature_iptv/test/presentation/screens/iptv_screen_lifecycle_test.dart
+++ b/packages/feature_iptv/test/presentation/screens/iptv_screen_lifecycle_test.dart
@@ -97,9 +97,7 @@ void main() {
       );
 
       // Resume too, to confirm the wiring works both directions.
-      tester.binding.handleAppLifecycleStateChanged(
-        AppLifecycleState.resumed,
-      );
+      tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.resumed);
       await tester.pumpAndSettle();
 
       expect(

--- a/packages/feature_iptv/test/presentation/widgets/video_player_widget_pip_layout_test.dart
+++ b/packages/feature_iptv/test/presentation/widgets/video_player_widget_pip_layout_test.dart
@@ -8,7 +8,10 @@ import 'package:shared_preferences/shared_preferences.dart';
 // only — no controls overlay, lock button, or other chrome that would
 // clutter the floating window.
 void main() {
-  Future<void> pumpPlayer(WidgetTester tester, {required bool pipActive}) async {
+  Future<void> pumpPlayer(
+    WidgetTester tester, {
+    required bool pipActive,
+  }) async {
     SharedPreferences.setMockInitialValues({});
     final prefs = await SharedPreferences.getInstance();
 


### PR DESCRIPTION
## Summary
Completes the settings module-ownership pass (#1101/#1103): the mobile country-filter tile (`_CountrySettingsTile`, private in `settings_hub_screen.dart`) is a pure IPTV concern — drives `channelFiltersProvider`, `iptvChannelsProvider`, `channelFilterDimensions`, all `feature_iptv` state. Made public as `CountrySettingsTile` and moved into `packages/feature_iptv/lib/presentation/screens/settings/`.

## Test plan
- [x] `feature_iptv` analyze clean (pre-existing info/warnings only)
- [x] `app` settings analyze clean, full settings + adaptive TV settings suites pass, including "country settings picker updates the global country filter"
- [x] `scripts/check-module-manifests.py`: 57/57 valid
- [x] `scripts/check-docs-completeness.sh`: passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)