### PR TITLE
feat(feature_coin): make vault route prefix shell-configurable

### DIFF
--- a/app/lib/core/coins/coin_vault_module.dart
+++ b/app/lib/core/coins/coin_vault_module.dart
@@ -1,5 +1,6 @@
 import 'package:core_product_shell/core_product_shell.dart';
 import 'package:feature_coin/feature_coin.dart';
+import 'package:flutter_riverpod/misc.dart';
 import 'package:go_router/go_router.dart';
 
 /// The Airo Coin vault as a shell-registrable [AppModule].
@@ -11,12 +12,18 @@ import 'package:go_router/go_router.dart';
 /// super-app still mounts the same screens through its existing
 /// `app_router.dart` wiring, which stays untouched per the no-break rule.
 ///
-/// Routes are mounted under `/money/vault` on every shell because
-/// `feature_coin`'s screens navigate with those literal paths today
-/// (`vault_home_screen.dart`, `record_detail_sheet.dart`). Making that
-/// base path shell-configurable is a `feature_coin` API change tracked for
-/// a later slice — not silently forked here.
+/// [basePath] controls where the vault mounts. The module both mounts its
+/// routes there and overrides `feature_coin`'s `vaultRoutePrefixProvider`
+/// to match, so the vault's internal add/edit navigation follows the mount
+/// point instead of a hardcoded host-app URL. The default stays the
+/// super-app's historical `/money/vault`.
 class CoinVaultModule extends AppModule {
+  CoinVaultModule({this.basePath = '/money/vault'})
+    : assert(basePath.startsWith('/'), 'basePath must be absolute');
+
+  /// Absolute route prefix the vault mounts under for the owning shell.
+  final String basePath;
+
   @override
   String get id => 'coin_vault';
 
@@ -26,9 +33,14 @@ class CoinVaultModule extends AppModule {
   Set<ShellId> get supportedShells => {ShellId.mobile, ShellId.coins};
 
   @override
+  List<Override> providerOverridesFor(ShellId shell) => [
+    vaultRoutePrefixProvider.overrideWithValue(basePath),
+  ];
+
+  @override
   List<RouteBase> routesFor(ShellId shell) => [
     GoRoute(
-      path: '/money/vault',
+      path: basePath,
       builder: (context, state) => const VaultGateScreen(),
       routes: [
         GoRoute(

--- a/app/lib/main_coins.dart
+++ b/app/lib/main_coins.dart
@@ -38,7 +38,10 @@ void main() {
 @visibleForTesting
 ModuleRegistry buildCoinsModuleRegistry() {
   final registry = ModuleRegistry(shell: ShellId.coins)
-    ..register(CoinVaultModule());
+    // Standalone shell owns its URL space: mount the vault at /vault
+    // instead of inheriting the super-app's /money/vault prefix. The
+    // module overrides feature_coin's vaultRoutePrefixProvider to match.
+    ..register(CoinVaultModule(basePath: '/vault'));
   return registry;
 }
 
@@ -55,7 +58,7 @@ class AiroCoinsApp extends StatefulWidget {
 
 class _AiroCoinsAppState extends State<AiroCoinsApp> {
   late final GoRouter _router = GoRouter(
-    initialLocation: '/money/vault',
+    initialLocation: '/vault',
     routes: widget.registry.allRoutes,
   );
 

--- a/app/test/main_coins_shell_test.dart
+++ b/app/test/main_coins_shell_test.dart
@@ -24,7 +24,33 @@ void main() {
     expect(registry.shell, ShellId.coins);
     expect(registry.moduleIds, ['coin_vault']);
     final paths = registry.allRoutes.whereType<GoRoute>().map((r) => r.path);
-    expect(paths, contains('/money/vault'));
+    expect(paths, contains('/vault'));
+  });
+
+  test('vault module mounts routes and route-prefix override at basePath', () {
+    final module = CoinVaultModule(basePath: '/vault');
+
+    final paths = module
+        .routesFor(ShellId.coins)
+        .whereType<GoRoute>()
+        .map((r) => r.path);
+    expect(paths, contains('/vault'));
+
+    // The module keeps feature_coin's internal add/edit navigation in sync
+    // with the mount point by overriding vaultRoutePrefixProvider.
+    final container = ProviderContainer(
+      overrides: module.providerOverridesFor(ShellId.coins),
+    );
+    addTearDown(container.dispose);
+    expect(container.read(vaultRoutePrefixProvider), '/vault');
+  });
+
+  test('vault route prefix defaults to the super-app mount point', () {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    // The super-app registers no override, so feature_coin's default must
+    // stay its historical /money/vault mount (no-break rule).
+    expect(container.read(vaultRoutePrefixProvider), '/money/vault');
   });
 
   test('vault module ships to mobile and coins shells but never TV', () {

--- a/packages/feature_coin/lib/src/application/vault_providers.dart
+++ b/packages/feature_coin/lib/src/application/vault_providers.dart
@@ -63,3 +63,9 @@ final vaultKeyManagerProvider = Provider<VaultKeyManager>((ref) {
 final localAuthenticationProvider = Provider<LocalAuthentication>(
   (ref) => LocalAuthentication(),
 );
+
+/// Route prefix the vault's internal navigation pushes against (add/edit
+/// flows). Defaults to the super-app's historical mount point; a shell
+/// that mounts the vault elsewhere overrides this alongside its route
+/// table so `feature_coin` never hardcodes a host app's URL structure.
+final vaultRoutePrefixProvider = Provider<String>((ref) => '/money/vault');

--- a/packages/feature_coin/lib/src/presentation/screens/vault_home_screen.dart
+++ b/packages/feature_coin/lib/src/presentation/screens/vault_home_screen.dart
@@ -4,6 +4,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:platform_coin_vault/platform_coin_vault.dart';
 
+import '../../application/vault_providers.dart';
 import '../../application/vault_record_ref.dart';
 import '../../application/vault_session.dart';
 import '../../application/vault_summaries_provider.dart';
@@ -147,7 +148,8 @@ class VaultHomeScreen extends ConsumerWidget {
     if (type == null) return;
     callback?.call(type);
     if (!context.mounted) return;
-    await context.push<void>('/money/vault/add/${type.name}');
+    final prefix = ref.read(vaultRoutePrefixProvider);
+    await context.push<void>('$prefix/add/${type.name}');
   }
 }
 

--- a/packages/feature_coin/lib/src/presentation/widgets/record_detail_sheet.dart
+++ b/packages/feature_coin/lib/src/presentation/widgets/record_detail_sheet.dart
@@ -253,7 +253,8 @@ class _RecordDetailSheetState extends ConsumerState<RecordDetailSheet> {
 
   void _edit() {
     final encodedKey = Uri.encodeComponent(widget.recordKey);
-    context.push('/money/vault/edit/${widget.recordType.name}/$encodedKey');
+    final prefix = ref.read(vaultRoutePrefixProvider);
+    context.push('$prefix/edit/${widget.recordType.name}/$encodedKey');
   }
 
   void _showSnack(String message) {


### PR DESCRIPTION
## Summary
Closes the deferred slice from #1108: `feature_coin`'s add/edit flows hardcoded `/money/vault/...` navigation paths, coupling the package to the super-app's URL structure. Now:
- New `vaultRoutePrefixProvider` in `feature_coin` (default `/money/vault` — super-app behavior unchanged, no-break rule)
- Both push call sites (`vault_home_screen.dart`, `record_detail_sheet.dart`) read the provider
- `CoinVaultModule` takes a `basePath`, mounts routes there, and overrides the provider to match
- Airo Coins shell switches to a clean `/vault` mount as first consumer

## Test plan
- [x] `feature_coin`: analyze clean, full suite 60/60 pass
- [x] `app` coins shell tests 5/5: registry paths, basePath route+override sync, default-prefix no-break check, ship-policy matrix, widget boot into `VaultGateScreen`
- [x] dart format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)