### PR TITLE
fix(feature_iptv): repair the three long-failing tests on main

### DIFF
--- a/packages/feature_iptv/test/iptv/presentation/widgets/player_lock_button_test.dart
+++ b/packages/feature_iptv/test/iptv/presentation/widgets/player_lock_button_test.dart
@@ -3,20 +3,25 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:feature_iptv/presentation/widgets/player_lock_button.dart';
 
 void main() {
-  testWidgets('shows a closed lock icon when unlocked', (tester) async {
+  // Icon orientation is state-display (an open lock while controls are
+  // usable, a closed lock while locked), flipped intentionally in #1059's
+  // TV-surface consolidation — video_player_widget_test codifies the same
+  // orientation for the full player. This unit test was left asserting the
+  // pre-#1059 orientation and has failed deterministically since.
+  testWidgets('shows an open lock icon when unlocked', (tester) async {
     await tester.pumpWidget(
       MaterialApp(home: PlayerLockButton(locked: false, onToggle: () {})),
     );
-    expect(find.byIcon(Icons.lock_outline), findsOneWidget);
-    expect(find.byIcon(Icons.lock_open), findsNothing);
+    expect(find.byIcon(Icons.lock_open), findsOneWidget);
+    expect(find.byIcon(Icons.lock_outline), findsNothing);
   });
 
-  testWidgets('shows an open lock icon when locked', (tester) async {
+  testWidgets('shows a closed lock icon when locked', (tester) async {
     await tester.pumpWidget(
       MaterialApp(home: PlayerLockButton(locked: true, onToggle: () {})),
     );
-    expect(find.byIcon(Icons.lock_open), findsOneWidget);
-    expect(find.byIcon(Icons.lock_outline), findsNothing);
+    expect(find.byIcon(Icons.lock_outline), findsOneWidget);
+    expect(find.byIcon(Icons.lock_open), findsNothing);
   });
 
   testWidgets('tapping calls onToggle', (tester) async {

--- a/packages/feature_iptv/test/presentation/screens/iptv_screen_default_to_live_test.dart
+++ b/packages/feature_iptv/test/presentation/screens/iptv_screen_default_to_live_test.dart
@@ -134,7 +134,13 @@ void main() {
         child: const MaterialApp(home: IPTVScreen(deepLinkChannelId: 'c1')),
       ),
     );
-    await tester.pumpAndSettle();
+    // Bounded pumps, not pumpAndSettle: the deep link lands on the player
+    // surface, whose progress indicator animates indefinitely — settle can
+    // never complete there (same reason the sibling deep-link tests above
+    // use plain pump()). Two pumps flush the deep-link resolution
+    // microtasks and the post-frame resume gate.
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 100));
 
     expect(deepLinkPlayed.map((channel) => channel.id), ['c1']);
     expect(resumePlayed, isEmpty);


### PR DESCRIPTION
## Summary
The "3 known pre-existing flaky failures" tracked since phase 1 turned out to be deterministic bugs, not flakiness:

1. **`player_lock_button_test` (2 tests)** — #1059's TV-surface consolidation intentionally flipped `PlayerLockButton` to state-display icon orientation and updated the integration test (`video_player_widget_test`) to match, but missed this unit test. It has failed on every run since. Expectations now aligned with the shipped, integration-tested orientation (widget untouched).
2. **`iptv_screen_default_to_live_test` deep-link/resume test** — used `pumpAndSettle`, but the deep link lands on the player surface whose progress indicator animates forever, so settle can never complete. Sibling deep-link tests in the same file already use plain `pump()` for this exact reason. Replaced with bounded pumps.

## Test plan
- [x] `player_lock_button_test`: 3/3 pass
- [x] `iptv_screen_default_to_live_test`: 5/5 pass
- [x] Full `feature_iptv` suite: **618 tests, 0 failures** — first fully green run since #1059
- [x] dart format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)