### PR TITLE
feat(app): wire the airo-pro bootstrap seam into all three shells

### DIFF
--- a/app/lib/core/pro/pro_bootstrap_runner.dart
+++ b/app/lib/core/pro/pro_bootstrap_runner.dart
@@ -1,4 +1,4 @@
-import 'package:airo_pro_bootstrap/airo_pro_bootstrap.dart';
+import 'package:airo_pro_bootstrap/airo_pro_bootstrap.dart' as pro_bootstrap;
 import 'package:core_entitlements/core_entitlements.dart';
 import 'package:flutter/foundation.dart';
 
@@ -12,13 +12,20 @@ import 'package:flutter/foundation.dart';
 ///
 /// Failures never propagate: the overlay contract is that a broken pro
 /// module degrades to the open-source baseline, not a broken app.
+///
+/// [entitlements] and [register] exist for tests to stand in for the
+/// build-flavor-linked seam; production callers pass neither.
 Future<List<String>> runProBootstrap({
   void Function(String message)? log,
+  Entitlements Function()? entitlements,
+  void Function(ProModuleRegistry registry)? register,
 }) async {
   final logger = log ?? debugPrint;
   try {
-    final registry = ProModuleRegistry(createEntitlements());
-    registerProModules(registry);
+    final registry = ProModuleRegistry(
+      (entitlements ?? pro_bootstrap.createEntitlements)(),
+    );
+    (register ?? pro_bootstrap.registerProModules)(registry);
     final initialized = await registry.initializeEntitled();
     if (initialized.isNotEmpty) {
       logger('✨ Pro modules initialized: ${initialized.join(', ')}');

--- a/app/lib/core/pro/pro_bootstrap_runner.dart
+++ b/app/lib/core/pro/pro_bootstrap_runner.dart
@@ -1,0 +1,31 @@
+import 'package:airo_pro_bootstrap/airo_pro_bootstrap.dart';
+import 'package:core_entitlements/core_entitlements.dart';
+import 'package:flutter/foundation.dart';
+
+/// Runs the open-core pro bootstrap seam for one shell.
+///
+/// Every entrypoint (super-app, TV, Coins) calls this once after first
+/// frame. In open-source builds `registerProModules` is a no-op, so this
+/// resolves to an empty list at near-zero cost; in `airo-pro` overlay
+/// builds the same-named package registers real modules and
+/// [ProModuleRegistry.initializeEntitled] starts the entitled subset.
+///
+/// Failures never propagate: the overlay contract is that a broken pro
+/// module degrades to the open-source baseline, not a broken app.
+Future<List<String>> runProBootstrap({
+  void Function(String message)? log,
+}) async {
+  final logger = log ?? debugPrint;
+  try {
+    final registry = ProModuleRegistry(createEntitlements());
+    registerProModules(registry);
+    final initialized = await registry.initializeEntitled();
+    if (initialized.isNotEmpty) {
+      logger('✨ Pro modules initialized: ${initialized.join(', ')}');
+    }
+    return initialized;
+  } catch (e) {
+    logger('⚠️ Pro bootstrap failed; continuing with baseline: $e');
+    return const [];
+  }
+}

--- a/app/lib/core/startup/app_startup_tasks.dart
+++ b/app/lib/core/startup/app_startup_tasks.dart
@@ -2,6 +2,7 @@ import 'package:flutter/foundation.dart';
 
 import '../auth/auth_service.dart';
 import '../features/feature_registry.dart';
+import '../pro/pro_bootstrap_runner.dart';
 import 'deferred_startup_task.dart';
 
 typedef AppStartupInitializer = Future<void> Function();
@@ -52,5 +53,21 @@ void scheduleDeferredAudioInitialization({
     addPostFrameCallback: addPostFrameCallback,
     log: log,
     task: initializeAudio,
+  );
+}
+
+/// Runs the open-core pro bootstrap seam after the first frame.
+///
+/// No-op cost in open-source builds; in `airo-pro` overlay builds this is
+/// where entitled pro modules initialize. Never blocks or breaks startup.
+void scheduleDeferredProBootstrap({
+  void Function(DeferredStartupFrameCallback callback)? addPostFrameCallback,
+  void Function(String message)? log,
+}) {
+  scheduleDeferredStartupTask(
+    debugName: 'pro_bootstrap',
+    addPostFrameCallback: addPostFrameCallback,
+    log: log,
+    task: () => runProBootstrap(log: log),
   );
 }

--- a/app/lib/main.dart
+++ b/app/lib/main.dart
@@ -107,6 +107,7 @@ void main() async {
   );
 
   scheduleDeferredAuthInitialization();
+  scheduleDeferredProBootstrap();
   scheduleDeferredAudioInitialization(
     initializeAudio: initAudioService,
     skipOnWeb: true,

--- a/app/lib/main_coins.dart
+++ b/app/lib/main_coins.dart
@@ -26,10 +26,12 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
 import 'core/coins/coin_vault_module.dart';
+import 'core/startup/app_startup_tasks.dart';
 
 void main() {
   WidgetsFlutterBinding.ensureInitialized();
   runApp(AiroCoinsApp(registry: buildCoinsModuleRegistry()));
+  scheduleDeferredProBootstrap();
 }
 
 /// Builds the Airo Coins shell's module registry. Split out (and returning

--- a/app/lib/main_tv.dart
+++ b/app/lib/main_tv.dart
@@ -34,6 +34,7 @@ import 'core/error/global_error_handler.dart';
 import 'core/features/feature_registry.dart';
 import 'core/platform/device_form_factor.dart';
 import 'core/providers/app_theme_provider.dart';
+import 'core/startup/app_startup_tasks.dart';
 import 'core/startup/deferred_startup_task.dart';
 import 'package:feature_iptv/feature_iptv.dart';
 import 'features/iptv/iptv_cast_provider_override.dart';
@@ -119,6 +120,7 @@ void main() async {
 
   scheduleTvFirebaseInitialization();
   scheduleTvFeatureInitialization();
+  scheduleDeferredProBootstrap();
   if (shouldWarmDebugPlaylist) {
     scheduleTvDebugDefaultPlaylistWarmup(prefs);
   }

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -24,6 +24,13 @@ packages:
       relative: true
     source: path
     version: "0.0.1"
+  airo_pro_bootstrap:
+    dependency: "direct main"
+    description:
+      path: "../packages/airo_pro_bootstrap"
+      relative: true
+    source: path
+    version: "0.0.1"
   alchemist:
     dependency: "direct dev"
     description:
@@ -418,6 +425,13 @@ packages:
       relative: true
     source: path
     version: "0.0.1"
+  core_entitlements:
+    dependency: "direct main"
+    description:
+      path: "../packages/core_entitlements"
+      relative: true
+    source: path
+    version: "0.0.1"
   core_media_routing:
     dependency: transitive
     description:
@@ -758,18 +772,18 @@ packages:
     dependency: "direct main"
     description:
       name: flame
-      sha256: b9e65f6d7d06a301d6ea3cde03731cad3cdc255d56e0fb53c56c1e7806aaaf6a
+      sha256: c918f8d0e340cbc5e3b20603bd5dc0bac6d939133fed4044366180081a63561d
       url: "https://pub.dev"
     source: hosted
-    version: "1.37.0"
+    version: "1.38.0"
   flame_audio:
     dependency: "direct main"
     description:
       name: flame_audio
-      sha256: "16303eef8e21281432d91f88526f91ef949d13a6f706a7d9252bfc027ceea39d"
+      sha256: f88692222444231cdb380af8ca087b521da26773c1bb4d1da33a24c953d3b3ea
       url: "https://pub.dev"
     source: hosted
-    version: "2.12.1"
+    version: "2.12.2"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -794,10 +808,10 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_contacts
-      sha256: c2591314166678adab23ef02a0ab3b4d4da71071dc03519de3dc059982dcfef2
+      sha256: "8f76f36ae0efacdfbcc86ca1271cb14b160c40cdc10ebe6923910e33a80e066c"
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.2"
+    version: "2.3.0"
   flutter_driver:
     dependency: transitive
     description: flutter
@@ -815,42 +829,42 @@ packages:
     dependency: transitive
     description:
       name: flutter_image_compress_common
-      sha256: c5c5d50c15e97dd7dc72ff96bd7077b9f791932f2076c5c5b6c43f2c88607bfb
+      sha256: "10520a2d4bade23d31ba5a4b9f56fa7d11b6a62f11fe3576106c1867cc10dcf6"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.6"
+    version: "1.1.0"
   flutter_image_compress_macos:
     dependency: transitive
     description:
       name: flutter_image_compress_macos
-      sha256: "20019719b71b743aba0ef874ed29c50747461e5e8438980dfa5c2031898f7337"
+      sha256: "0d2a842d2e544828fb32bda16dcfccb3149107df568898a4936d78232e486847"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.3"
+    version: "1.1.0"
   flutter_image_compress_ohos:
     dependency: transitive
     description:
       name: flutter_image_compress_ohos
-      sha256: e76b92bbc830ee08f5b05962fc78a532011fcd2041f620b5400a593e96da3f51
+      sha256: "1491bb7bcfdf59e3b127c263c116cfbf8ed3afade6e7fa691d9622e838ed7e48"
       url: "https://pub.dev"
     source: hosted
-    version: "0.0.3"
+    version: "0.0.3+1"
   flutter_image_compress_platform_interface:
     dependency: transitive
     description:
       name: flutter_image_compress_platform_interface
-      sha256: "579cb3947fd4309103afe6442a01ca01e1e6f93dc53bb4cbd090e8ce34a41889"
+      sha256: bbefb7967bda565004fdabdb3300dcbfb40c7ef8402675d23206e5bddc358178
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.5"
+    version: "1.1.0"
   flutter_image_compress_web:
     dependency: transitive
     description:
       name: flutter_image_compress_web
-      sha256: b9b141ac7c686a2ce7bb9a98176321e1182c9074650e47bb140741a44b6f5a96
+      sha256: "91cc58e091a1e09c7683d216d579e2b964119a8527fc43b64dfdb00f1acc94ec"
       url: "https://pub.dev"
     source: hosted
-    version: "0.1.5"
+    version: "0.1.5+1"
   flutter_lints:
     dependency: "direct dev"
     description:
@@ -863,10 +877,10 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_local_notifications
-      sha256: a0d7141f14cabcee42967470a858dfc99dd6cfb70d3cab404bacfcafa9e84e70
+      sha256: "9375211fd7df9c070504ac4db7047c7fae857e238291433b770cfe696b5c357a"
       url: "https://pub.dev"
     source: hosted
-    version: "22.0.1"
+    version: "22.2.0"
   flutter_local_notifications_linux:
     dependency: transitive
     description:
@@ -879,10 +893,10 @@ packages:
     dependency: transitive
     description:
       name: flutter_local_notifications_platform_interface
-      sha256: ff0013eae795e8dc8fad4a8992a209e64d3ba2fbd8bf5e43c36bf448f95bd814
+      sha256: "945a438a4779f3aca3a948718d8a4048cbe9f9c8c797492c00abd5d39112bf37"
       url: "https://pub.dev"
     source: hosted
-    version: "12.0.0"
+    version: "12.1.0"
   flutter_local_notifications_web:
     dependency: transitive
     description:
@@ -1499,10 +1513,10 @@ packages:
     dependency: transitive
     description:
       name: native_toolchain_c
-      sha256: a1c26117c48cebe5677b0cf0e33a980a79a7c5577effc86f52e5a0d309cdcb60
+      sha256: f9c168717100ae6d9fee9ffb0be379bf1f8b26b0f6bcbd4fdddcd931993a6a72
       url: "https://pub.dev"
     source: hosted
-    version: "0.19.3"
+    version: "0.19.2"
   nm:
     dependency: transitive
     description:
@@ -1539,10 +1553,10 @@ packages:
     dependency: transitive
     description:
       name: ordered_set
-      sha256: d6c1d053a533e84931a388cbf03f1ad21a0543bf06c7a281859d3ffacd8e15f2
+      sha256: ca415a0e28b8e8f5e284af4b7d1b189d2d09af6d2082532ddaec54473f67d226
       url: "https://pub.dev"
     source: hosted
-    version: "8.0.0"
+    version: "8.0.1"
   package_config:
     dependency: transitive
     description:
@@ -1627,10 +1641,10 @@ packages:
     dependency: "direct dev"
     description:
       name: patrol
-      sha256: "1cb54197ba329a81cb0f7dca1ffae3b6425b4ea514a63b60dec9dbb9d662c866"
+      sha256: bdeec6400d0ec22aefb875b2fd17a7bd4f25d37a40fd3bd83a74441c65f69f1e
       url: "https://pub.dev"
     source: hosted
-    version: "4.7.1"
+    version: "4.8.0"
   patrol_finders:
     dependency: transitive
     description:
@@ -2027,18 +2041,18 @@ packages:
     dependency: "direct main"
     description:
       name: share_plus
-      sha256: "02180b01c1237b9706b663d9402b2cf2402b3407f48cce99cc19e3200f095b8a"
+      sha256: "34f00f9becd2743c1fb05363d624f9f70d37f7ccdcdda47450bc0b8c9d327b8c"
       url: "https://pub.dev"
     source: hosted
-    version: "13.2.1"
+    version: "13.3.0"
   share_plus_platform_interface:
     dependency: transitive
     description:
       name: share_plus_platform_interface
-      sha256: "7f7ae28cf400d13f811e297ff37742dba83b79e0a6f5dce14eec0248274e6ce9"
+      sha256: "365ef7379fc22507256adda3385152942ffce08935452bc972c2e52a0bebae41"
       url: "https://pub.dev"
     source: hosted
-    version: "7.1.0"
+    version: "7.2.0"
   shared_preferences:
     dependency: "direct main"
     description:
@@ -2145,10 +2159,10 @@ packages:
     dependency: "direct overridden"
     description:
       name: source_gen
-      sha256: ec37cc0e6694374cbef59ed79685572c870a54ede6fa30a3e420feb3adffea02
+      sha256: a603f1fb984a7391ae5978d1b92bfaaa08b350dca5c825256f925818f7943bf5
       url: "https://pub.dev"
     source: hosted
-    version: "4.2.3"
+    version: "4.2.4"
   source_map_stack_trace:
     dependency: transitive
     description:
@@ -2496,18 +2510,18 @@ packages:
     dependency: "direct main"
     description:
       name: wakelock_plus
-      sha256: "824c5bba0f800e86d32e57d3d1843c531f090005cc89d9a837933e6601093d53"
+      sha256: "7253bca0fcf40d8413ddfcf4d2a1fa0a82475e79be25a4f2c564b695c9351486"
       url: "https://pub.dev"
     source: hosted
-    version: "1.6.1"
+    version: "1.7.0"
   wakelock_plus_platform_interface:
     dependency: transitive
     description:
       name: wakelock_plus_platform_interface
-      sha256: b13f99e992e7ae6a152e16c5559d3c07ff445b13330192662494e614ca3e7d7b
+      sha256: "0618d1799f0b28bcf98255b4ee8313e6fc4d38589dc4ee5fe5840d57d1aff6da"
       url: "https://pub.dev"
     source: hosted
-    version: "1.5.1"
+    version: "1.6.0"
   watcher:
     dependency: transitive
     description:

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -76,8 +76,12 @@ dependencies:
     path: ../packages/core_ai
   core_auth:
     path: ../packages/core_auth
+  airo_pro_bootstrap:
+    path: ../packages/airo_pro_bootstrap
   core_app_shell:
     path: ../packages/core_app_shell
+  core_entitlements:
+    path: ../packages/core_entitlements
   core_product_shell:
     path: ../packages/core_product_shell
 

--- a/app/pubspec_tv.yaml
+++ b/app/pubspec_tv.yaml
@@ -71,8 +71,12 @@ dependencies:
     path: ../packages/core_ai
   core_auth:
     path: ../packages/core_auth
+  airo_pro_bootstrap:
+    path: ../packages/airo_pro_bootstrap
   core_app_shell:
     path: ../packages/core_app_shell
+  core_entitlements:
+    path: ../packages/core_entitlements
   core_product_shell:
     path: ../packages/core_product_shell
 

--- a/app/test/core/pro/pro_bootstrap_runner_test.dart
+++ b/app/test/core/pro/pro_bootstrap_runner_test.dart
@@ -1,0 +1,37 @@
+import 'package:airo_app/core/pro/pro_bootstrap_runner.dart';
+import 'package:airo_app/core/startup/app_startup_tasks.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('open-source seam initializes zero pro modules without error', () async {
+    final logs = <String>[];
+    final initialized = await runProBootstrap(log: logs.add);
+
+    // The upstream airo_pro_bootstrap registers nothing; the overlay build
+    // swaps in a same-named package that does. Either way this must not
+    // throw, and the GA build must come back empty.
+    expect(initialized, isEmpty);
+    expect(logs, isEmpty);
+  });
+
+  test(
+    'scheduleDeferredProBootstrap runs the seam after first frame',
+    () async {
+      final callbacks = <void Function(Duration)>[];
+      final logs = <String>[];
+
+      scheduleDeferredProBootstrap(
+        addPostFrameCallback: callbacks.add,
+        log: logs.add,
+      );
+
+      expect(callbacks, hasLength(1));
+      callbacks.single(Duration.zero);
+      // The deferred task completes (and logs) asynchronously.
+      await Future<void>.delayed(Duration.zero);
+      expect(logs.any((line) => line.contains('pro_bootstrap')), isTrue);
+    },
+  );
+}

--- a/app/test/core/pro/pro_bootstrap_runner_test.dart
+++ b/app/test/core/pro/pro_bootstrap_runner_test.dart
@@ -1,6 +1,31 @@
 import 'package:airo_app/core/pro/pro_bootstrap_runner.dart';
 import 'package:airo_app/core/startup/app_startup_tasks.dart';
+import 'package:core_entitlements/core_entitlements.dart';
 import 'package:flutter_test/flutter_test.dart';
+
+class _RecordingModule implements ProModule {
+  _RecordingModule(this.id, this.feature, {this.throwOnInit = false});
+
+  @override
+  final String id;
+  @override
+  final ProFeature feature;
+  final bool throwOnInit;
+
+  var initialized = 0;
+  var disposed = 0;
+
+  @override
+  Future<void> initialize() async {
+    if (throwOnInit) throw StateError('boom');
+    initialized++;
+  }
+
+  @override
+  Future<void> dispose() async {
+    disposed++;
+  }
+}
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -15,6 +40,57 @@ void main() {
     expect(initialized, isEmpty);
     expect(logs, isEmpty);
   });
+
+  test('entitled modules initialize; unentitled and broken ones are '
+      'contained', () async {
+    final entitled = _RecordingModule('a', ProFeature.epgReminders);
+    final broken = _RecordingModule(
+      'b',
+      ProFeature.regionalRanking,
+      throwOnInit: true,
+    );
+    final logs = <String>[];
+
+    final initialized = await runProBootstrap(
+      log: logs.add,
+      entitlements: LaunchPromoEntitlements.new,
+      register: (registry) {
+        registry.register(entitled);
+        registry.register(broken);
+      },
+    );
+
+    expect(initialized, ['a']);
+    expect(entitled.initialized, 1);
+    expect(logs.single, contains('Pro modules initialized: a'));
+  });
+
+  test('unentitled modules never initialize', () async {
+    final module = _RecordingModule('a', ProFeature.epgReminders);
+
+    final initialized = await runProBootstrap(
+      entitlements: NoEntitlements.new,
+      register: (registry) => registry.register(module),
+    );
+
+    expect(initialized, isEmpty);
+    expect(module.initialized, 0);
+  });
+
+  test(
+    'a throwing seam degrades to the baseline instead of crashing',
+    () async {
+      final logs = <String>[];
+
+      final initialized = await runProBootstrap(
+        log: logs.add,
+        register: (_) => throw StateError('bad overlay'),
+      );
+
+      expect(initialized, isEmpty);
+      expect(logs.single, contains('Pro bootstrap failed'));
+    },
+  );
 
   test(
     'scheduleDeferredProBootstrap runs the seam after first frame',


### PR DESCRIPTION
## Summary
The open-core pro seam (`packages/airo_pro_bootstrap` + `core_entitlements.ProModuleRegistry`) was designed but **never invoked** — no entrypoint depended on it in either repo, so `airo-pro` overlay builds could never actually load pro modules. This wires it end to end:

- `app/lib/core/pro/pro_bootstrap_runner.dart` — builds `ProModuleRegistry(createEntitlements())`, runs `registerProModules`, then `initializeEntitled()`; failures degrade to the open-source baseline
- `scheduleDeferredProBootstrap()` runs after first frame in **all three shells** (`main.dart`, `main_tv.dart`, `main_coins.dart`)
- `airo_pro_bootstrap` + `core_entitlements` added to both `app/pubspec.yaml` and `app/pubspec_tv.yaml`

Overlay contract respected: seam signature unchanged, so the current `airo-pro` same-named package stays drop-in compatible ("public file needs a hook → land it upstream first" per PRO.md). Shell-aware pro modules (`ShellId` in the seam) tracked as a follow-up.

## Test plan
- [x] New tests: GA seam returns zero modules without error; deferred scheduling runs the seam post-frame (async-log verified)
- [x] Coins shell tests still 5/5
- [x] `flutter analyze` clean on all 3 entrypoints + new files (mobile pubspec)
- [x] **TV variant verified both ways** (#1105 lesson): `pub get` solves and `main_tv.dart` analyzes clean under `pubspec_tv.yaml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)