### PR TITLE
fix(coins): correct biometric enrolment diagnosis, give Coins its own app id

### DIFF
--- a/app/android/app/build.gradle.kts
+++ b/app/android/app/build.gradle.kts
@@ -21,10 +21,12 @@ val isLeanVariant = appVariant != "full"
 val isTvVariant = appVariant == "tv"
 val variantApplicationId = when (appVariant) {
     "tv" -> "io.airo.app.tv"
+    "coins" -> "io.airo.app.coins"
     else -> "io.airo.app"
 }
 val variantAppLabel = when (appVariant) {
     "tv" -> "Airo TV"
+    "coins" -> "Airo Coins"
     else -> "Airo"
 }
 

--- a/packages/feature_coin/lib/src/application/vault_session.dart
+++ b/packages/feature_coin/lib/src/application/vault_session.dart
@@ -106,7 +106,20 @@ class VaultSessionNotifier extends Notifier<VaultSessionState> {
         state = const VaultUnlocked();
         _resetIdleTimer();
       case Err<List<int>>():
-        state = VaultAuthError(result.failure);
+        // A failure with nothing enrolled is not a bad scan — there is no
+        // factor to scan against (Android needs a screen lock before a
+        // print can be enrolled at all). Route those users to the
+        // actionable "enrol something in system settings" screen instead
+        // of an unhelpful "authentication failed" they can only retry.
+        if (!await keyManager.hasEnrolledBiometrics()) {
+          if (_isCurrentUnlock(unlockGeneration)) {
+            state = const VaultUnavailable();
+          }
+          return;
+        }
+        if (_isCurrentUnlock(unlockGeneration)) {
+          state = VaultAuthError(result.failure);
+        }
     }
   }
 

--- a/packages/feature_coin/test/presentation/screens/vault_gate_screen_test.dart
+++ b/packages/feature_coin/test/presentation/screens/vault_gate_screen_test.dart
@@ -153,4 +153,70 @@ void main() {
     expect(find.text('Biometrics unavailable'), findsOneWidget);
     expect(find.textContaining('Enroll biometrics'), findsOneWidget);
   });
+
+  testWidgets('no enrolled biometric guides to enrolment, not "try again"', (
+    tester,
+  ) async {
+    // Reproduces the Pixel 9 case: fingerprint hardware present, but no
+    // screen lock and so nothing enrolled. authenticate() fails instantly
+    // and the user used to see "Could not unlock vault / Try again",
+    // which they can retry forever without success.
+    final keyManager = VaultKeyManager.forTesting(
+      secureStorage: InMemorySecureStorage(),
+      authenticate: () async => false,
+      isAvailable: () async => true,
+      hasEnrolled: () async => false,
+    );
+    final container = ProviderContainer(
+      overrides: [
+        screenSecurityProvider.overrideWithValue(FakeScreenSecurity()),
+        vaultKeyManagerProvider.overrideWithValue(keyManager),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: const MaterialApp(home: VaultGateScreen(autoUnlock: true)),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('Biometrics unavailable'), findsOneWidget);
+    expect(find.textContaining('Enroll biometrics'), findsOneWidget);
+  });
+
+  testWidgets('a real failed scan still reports an auth error', (tester) async {
+    // Contrast with the case above: a biometric IS enrolled, so a failure
+    // genuinely means the scan did not match and retrying can work.
+    final keyManager = VaultKeyManager.forTesting(
+      secureStorage: InMemorySecureStorage(),
+      authenticate: () async => false,
+      isAvailable: () async => true,
+      hasEnrolled: () async => true,
+    );
+    final container = ProviderContainer(
+      overrides: [
+        screenSecurityProvider.overrideWithValue(FakeScreenSecurity()),
+        vaultKeyManagerProvider.overrideWithValue(keyManager),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: const MaterialApp(home: VaultGateScreen(autoUnlock: true)),
+      ),
+    );
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 50));
+
+    expect(find.text('Biometrics unavailable'), findsNothing);
+    expect(
+      find.textContaining('Biometric authentication failed'),
+      findsOneWidget,
+    );
+  });
 }

--- a/packages/platform_coin_vault/integration_test/vault_secure_storage_integration_test.dart
+++ b/packages/platform_coin_vault/integration_test/vault_secure_storage_integration_test.dart
@@ -22,28 +22,29 @@ import 'package:platform_coin_vault/src/crypto/vault_secure_storage.dart';
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
-  testWidgets('write, read, and delete roundtrip against the real secure storage channel', (
-    tester,
-  ) async {
-    final storage = VaultSecureStorage();
-    const key = 'integration_test_key';
-    const value = 'integration_test_value';
+  testWidgets(
+    'write, read, and delete roundtrip against the real secure storage channel',
+    (tester) async {
+      final storage = VaultSecureStorage();
+      const key = 'integration_test_key';
+      const value = 'integration_test_value';
 
-    await storage.delete(key);
+      await storage.delete(key);
 
-    final writeResult = await storage.write(key, value);
-    expect(writeResult.isSuccess, isTrue);
+      final writeResult = await storage.write(key, value);
+      expect(writeResult.isSuccess, isTrue);
 
-    final readResult = await storage.read(key);
-    expect(readResult.value, value);
+      final readResult = await storage.read(key);
+      expect(readResult.value, value);
 
-    final containsResult = await storage.containsKey(key);
-    expect(containsResult.value, isTrue);
+      final containsResult = await storage.containsKey(key);
+      expect(containsResult.value, isTrue);
 
-    final deleteResult = await storage.delete(key);
-    expect(deleteResult.isSuccess, isTrue);
+      final deleteResult = await storage.delete(key);
+      expect(deleteResult.isSuccess, isTrue);
 
-    final afterDelete = await storage.read(key);
-    expect(afterDelete.value, isNull);
-  });
+      final afterDelete = await storage.read(key);
+      expect(afterDelete.value, isNull);
+    },
+  );
 }

--- a/packages/platform_coin_vault/lib/src/crypto/vault_key_manager.dart
+++ b/packages/platform_coin_vault/lib/src/crypto/vault_key_manager.dart
@@ -24,7 +24,8 @@ class VaultKeyManager implements EncryptionKeyManager {
        )),
        _localAuth = localAuth,
        _secureStorage = secureStorage,
-       _isAvailable = null;
+       _isAvailable = null,
+       _hasEnrolled = null;
 
   /// Test-only constructor: bypasses the real `local_auth` plugin and
   /// `flutter_secure_storage` platform channel, both of which are
@@ -33,10 +34,12 @@ class VaultKeyManager implements EncryptionKeyManager {
     required SecureStorage secureStorage,
     required Future<bool> Function() authenticate,
     Future<bool> Function()? isAvailable,
+    Future<bool> Function()? hasEnrolled,
   }) : _secureStorage = secureStorage,
        _authenticate = authenticate,
        _localAuth = null,
-       _isAvailable = isAvailable;
+       _isAvailable = isAvailable,
+       _hasEnrolled = hasEnrolled;
 
   final SecureStorage _secureStorage;
   final Future<bool> Function() _authenticate;
@@ -48,6 +51,9 @@ class VaultKeyManager implements EncryptionKeyManager {
   /// existing tests passing unchanged, while the production constructor
   /// always exercises the real `local_auth` checks below.
   final Future<bool> Function()? _isAvailable;
+
+  /// Test-only seam for [hasEnrolledBiometrics]; see [_isAvailable].
+  final Future<bool> Function()? _hasEnrolled;
 
   @override
   Future<Result<List<int>>> getDatabaseKey() async {
@@ -161,6 +167,30 @@ class VaultKeyManager implements EncryptionKeyManager {
     final canCheck = await _localAuth.canCheckBiometrics;
     final deviceSupported = await _localAuth.isDeviceSupported();
     return canCheck && deviceSupported;
+  }
+
+  /// Whether the user has actually enrolled a biometric.
+  ///
+  /// [isEncryptionAvailable] only reports hardware capability: on a device
+  /// with a fingerprint sensor but no enrolled print (and no screen lock,
+  /// which Android requires before enrolment), it still returns true. The
+  /// authentication attempt then fails, and without this signal the vault
+  /// reports a generic "authentication failed" — implying a bad scan —
+  /// when the real problem is that there is nothing to scan against.
+  ///
+  /// Used to classify failures, never to gate the attempt: `authenticate`
+  /// runs with `biometricOnly: false`, so a device credential is a valid
+  /// factor even when this returns false.
+  Future<bool> hasEnrolledBiometrics() async {
+    final localAuth = _localAuth;
+    if (localAuth == null) return _hasEnrolled?.call() ?? true;
+    try {
+      final enrolled = await localAuth.getAvailableBiometrics();
+      return enrolled.isNotEmpty;
+    } catch (_) {
+      // Never let a diagnostic probe change the outcome of an unlock.
+      return true;
+    }
   }
 
   @override

--- a/packages/platform_coin_vault/lib/src/crypto/vault_secure_storage.dart
+++ b/packages/platform_coin_vault/lib/src/crypto/vault_secure_storage.dart
@@ -6,17 +6,19 @@ import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 /// Android Keystore / iOS Keychain, configured for biometric binding.
 class VaultSecureStorage implements SecureStorage {
   VaultSecureStorage({FlutterSecureStorage? storage})
-    : _storage = storage ?? const FlutterSecureStorage(
-        aOptions: AndroidOptions.biometric(
-          enforceBiometrics: true,
-          storageNamespace: 'airo_coin_vault',
-        ),
-        iOptions: IOSOptions(
-          accessibility: KeychainAccessibility.first_unlock_this_device,
-          accessControlFlags: [AccessControlFlag.biometryCurrentSet],
-          accountName: 'airo_coin_vault',
-        ),
-      );
+    : _storage =
+          storage ??
+          const FlutterSecureStorage(
+            aOptions: AndroidOptions.biometric(
+              enforceBiometrics: true,
+              storageNamespace: 'airo_coin_vault',
+            ),
+            iOptions: IOSOptions(
+              accessibility: KeychainAccessibility.first_unlock_this_device,
+              accessControlFlags: [AccessControlFlag.biometryCurrentSet],
+              accountName: 'airo_coin_vault',
+            ),
+          );
 
   final FlutterSecureStorage _storage;
 
@@ -55,7 +57,9 @@ class VaultSecureStorage implements SecureStorage {
       await _storage.deleteAll();
       return const Success(null);
     } catch (e) {
-      return Failure(CacheFailure(message: 'Failed to delete all keys', cause: e));
+      return Failure(
+        CacheFailure(message: 'Failed to delete all keys', cause: e),
+      );
     }
   }
 

--- a/packages/platform_coin_vault/lib/src/domain/entities/pan_card_record.dart
+++ b/packages/platform_coin_vault/lib/src/domain/entities/pan_card_record.dart
@@ -14,7 +14,11 @@ class PanCardRecord extends Equatable {
     DateTime? createdAt,
   }) : createdAt = createdAt ?? DateTime.now() {
     if (!isValidPan(panNumber)) {
-      throw ArgumentError.value(panNumber, 'panNumber', 'Not a valid PAN number');
+      throw ArgumentError.value(
+        panNumber,
+        'panNumber',
+        'Not a valid PAN number',
+      );
     }
   }
 

--- a/packages/platform_coin_vault/test/crypto/field_cipher_test.dart
+++ b/packages/platform_coin_vault/test/crypto/field_cipher_test.dart
@@ -13,22 +13,25 @@ void main() {
   });
 
   group('FieldCipher', () {
-    test('decrypting an encrypted value returns the original plaintext', () async {
-      const plaintext = '1234567890';
+    test(
+      'decrypting an encrypted value returns the original plaintext',
+      () async {
+        const plaintext = '1234567890';
 
-      final encrypted = await cipher.encryptField(
-        plaintext,
-        keyBytes,
-        context: 'bank_accounts:account_number_enc:1',
-      );
-      final decrypted = await cipher.decryptField(
-        encrypted,
-        keyBytes,
-        context: 'bank_accounts:account_number_enc:1',
-      );
+        final encrypted = await cipher.encryptField(
+          plaintext,
+          keyBytes,
+          context: 'bank_accounts:account_number_enc:1',
+        );
+        final decrypted = await cipher.decryptField(
+          encrypted,
+          keyBytes,
+          context: 'bank_accounts:account_number_enc:1',
+        );
 
-      expect(decrypted, plaintext);
-    });
+        expect(decrypted, plaintext);
+      },
+    );
 
     test('encrypted output differs from plaintext', () async {
       const plaintext = 'ABCDE1234F';
@@ -42,26 +45,32 @@ void main() {
       expect(encrypted, isNot(contains(plaintext)));
     });
 
-    test('same plaintext encrypted twice yields different ciphertext (random nonce)', () async {
-      const plaintext = 'repeat-me';
+    test(
+      'same plaintext encrypted twice yields different ciphertext (random nonce)',
+      () async {
+        const plaintext = 'repeat-me';
 
-      final first = await cipher.encryptField(
-        plaintext,
-        keyBytes,
-        context: 'bank_accounts:notes_enc:1',
-      );
-      final second = await cipher.encryptField(
-        plaintext,
-        keyBytes,
-        context: 'bank_accounts:notes_enc:1',
-      );
+        final first = await cipher.encryptField(
+          plaintext,
+          keyBytes,
+          context: 'bank_accounts:notes_enc:1',
+        );
+        final second = await cipher.encryptField(
+          plaintext,
+          keyBytes,
+          context: 'bank_accounts:notes_enc:1',
+        );
 
-      expect(first, isNot(equals(second)));
-    });
+        expect(first, isNot(equals(second)));
+      },
+    );
 
     test('decrypting with the wrong key throws', () async {
       const plaintext = 'secret-value';
-      final wrongKey = List<int>.generate(32, (_) => Random.secure().nextInt(256));
+      final wrongKey = List<int>.generate(
+        32,
+        (_) => Random.secure().nextInt(256),
+      );
 
       final encrypted = await cipher.encryptField(
         plaintext,
@@ -70,29 +79,48 @@ void main() {
       );
 
       expect(
-        () => cipher.decryptField(encrypted, wrongKey, context: 'bank_accounts:notes_enc:1'),
+        () => cipher.decryptField(
+          encrypted,
+          wrongKey,
+          context: 'bank_accounts:notes_enc:1',
+        ),
         throwsA(anything),
       );
     });
 
-    test('decrypting with a mismatched context throws, even with the right key', () async {
-      const plaintext = 'secret-value';
+    test(
+      'decrypting with a mismatched context throws, even with the right key',
+      () async {
+        const plaintext = 'secret-value';
 
-      final encrypted = await cipher.encryptField(
-        plaintext,
-        keyBytes,
-        context: 'bank_accounts:notes_enc:1',
-      );
+        final encrypted = await cipher.encryptField(
+          plaintext,
+          keyBytes,
+          context: 'bank_accounts:notes_enc:1',
+        );
 
-      expect(
-        () => cipher.decryptField(encrypted, keyBytes, context: 'bank_accounts:notes_enc:2'),
-        throwsA(anything),
-      );
-    });
+        expect(
+          () => cipher.decryptField(
+            encrypted,
+            keyBytes,
+            context: 'bank_accounts:notes_enc:2',
+          ),
+          throwsA(anything),
+        );
+      },
+    );
 
     test('roundtrips empty string', () async {
-      final encrypted = await cipher.encryptField('', keyBytes, context: 'bank_accounts:notes_enc:1');
-      final decrypted = await cipher.decryptField(encrypted, keyBytes, context: 'bank_accounts:notes_enc:1');
+      final encrypted = await cipher.encryptField(
+        '',
+        keyBytes,
+        context: 'bank_accounts:notes_enc:1',
+      );
+      final decrypted = await cipher.decryptField(
+        encrypted,
+        keyBytes,
+        context: 'bank_accounts:notes_enc:1',
+      );
 
       expect(decrypted, '');
     });

--- a/packages/platform_coin_vault/test/crypto/vault_key_manager_test.dart
+++ b/packages/platform_coin_vault/test/crypto/vault_key_manager_test.dart
@@ -11,17 +11,20 @@ void main() {
   });
 
   group('VaultKeyManager', () {
-    test('getDatabaseKey generates and persists a 32-byte key on first call', () async {
-      final manager = VaultKeyManager.forTesting(
-        secureStorage: secureStorage,
-        authenticate: () async => true,
-      );
+    test(
+      'getDatabaseKey generates and persists a 32-byte key on first call',
+      () async {
+        final manager = VaultKeyManager.forTesting(
+          secureStorage: secureStorage,
+          authenticate: () async => true,
+        );
 
-      final result = await manager.getDatabaseKey();
+        final result = await manager.getDatabaseKey();
 
-      expect(result.isSuccess, isTrue);
-      expect(result.value, hasLength(32));
-    });
+        expect(result.isSuccess, isTrue);
+        expect(result.value, hasLength(32));
+      },
+    );
 
     test('getDatabaseKey returns the same key on repeated calls', () async {
       final manager = VaultKeyManager.forTesting(
@@ -35,17 +38,20 @@ void main() {
       expect(second.value, equals(first.value));
     });
 
-    test('getDatabaseKey fails when biometric authentication is denied', () async {
-      final manager = VaultKeyManager.forTesting(
-        secureStorage: secureStorage,
-        authenticate: () async => false,
-      );
+    test(
+      'getDatabaseKey fails when biometric authentication is denied',
+      () async {
+        final manager = VaultKeyManager.forTesting(
+          secureStorage: secureStorage,
+          authenticate: () async => false,
+        );
 
-      final result = await manager.getDatabaseKey();
+        final result = await manager.getDatabaseKey();
 
-      expect(result.isFailure, isTrue);
-      expect(result.failure, isA<AuthFailure>());
-    });
+        expect(result.isFailure, isTrue);
+        expect(result.failure, isA<AuthFailure>());
+      },
+    );
 
     test('rotateKey generates a different key and persists it', () async {
       final manager = VaultKeyManager.forTesting(
@@ -69,73 +75,90 @@ void main() {
 
       await manager.getDatabaseKey();
       await manager.clearKeys();
-      final containsKey = await secureStorage.containsKey('airo_coin_wrapped_dek');
+      final containsKey = await secureStorage.containsKey(
+        'airo_coin_wrapped_dek',
+      );
 
       expect(containsKey.value, isFalse);
     });
 
-    test('isEncryptionAvailable reports false when biometrics are unavailable, blocking vault creation', () async {
-      final manager = VaultKeyManager.forTesting(
-        secureStorage: secureStorage,
-        authenticate: () async => false,
-      );
+    test(
+      'isEncryptionAvailable reports false when biometrics are unavailable, blocking vault creation',
+      () async {
+        final manager = VaultKeyManager.forTesting(
+          secureStorage: secureStorage,
+          authenticate: () async => false,
+        );
 
-      final result = await manager.getDatabaseKey();
+        final result = await manager.getDatabaseKey();
 
-      expect(result.isFailure, isTrue);
-      expect(result.failure, isA<AuthFailure>());
-    });
+        expect(result.isFailure, isTrue);
+        expect(result.failure, isA<AuthFailure>());
+      },
+    );
 
-    test('getDatabaseKey fails closed when local_auth throws (e.g. no biometrics enrolled)', () async {
-      final manager = VaultKeyManager.forTesting(
-        secureStorage: secureStorage,
-        authenticate: () async => throw Exception('platform unavailable'),
-      );
+    test(
+      'getDatabaseKey fails closed when local_auth throws (e.g. no biometrics enrolled)',
+      () async {
+        final manager = VaultKeyManager.forTesting(
+          secureStorage: secureStorage,
+          authenticate: () async => throw Exception('platform unavailable'),
+        );
 
-      final result = await manager.getDatabaseKey();
+        final result = await manager.getDatabaseKey();
 
-      expect(result.isFailure, isTrue);
-      expect(result.failure, isA<AuthFailure>());
-    });
+        expect(result.isFailure, isTrue);
+        expect(result.failure, isA<AuthFailure>());
+      },
+    );
 
-    test('rotateKey fails closed when local_auth throws (e.g. no biometrics enrolled)', () async {
-      final manager = VaultKeyManager.forTesting(
-        secureStorage: secureStorage,
-        authenticate: () async => throw Exception('platform unavailable'),
-      );
+    test(
+      'rotateKey fails closed when local_auth throws (e.g. no biometrics enrolled)',
+      () async {
+        final manager = VaultKeyManager.forTesting(
+          secureStorage: secureStorage,
+          authenticate: () async => throw Exception('platform unavailable'),
+        );
 
-      final result = await manager.rotateKey();
+        final result = await manager.rotateKey();
 
-      expect(result.isFailure, isTrue);
-      expect(result.failure, isA<AuthFailure>());
-    });
+        expect(result.isFailure, isTrue);
+        expect(result.failure, isA<AuthFailure>());
+      },
+    );
 
-    test('isEncryptionAvailable uses the injected isAvailable seam when provided', () async {
-      final manager = VaultKeyManager.forTesting(
-        secureStorage: secureStorage,
-        authenticate: () async => true,
-        isAvailable: () async => false,
-      );
+    test(
+      'isEncryptionAvailable uses the injected isAvailable seam when provided',
+      () async {
+        final manager = VaultKeyManager.forTesting(
+          secureStorage: secureStorage,
+          authenticate: () async => true,
+          isAvailable: () async => false,
+        );
 
-      final available = await manager.isEncryptionAvailable();
-      final keyResult = await manager.getDatabaseKey();
+        final available = await manager.isEncryptionAvailable();
+        final keyResult = await manager.getDatabaseKey();
 
-      expect(available, isFalse);
-      expect(keyResult.isSuccess, isTrue);
-    });
+        expect(available, isFalse);
+        expect(keyResult.isSuccess, isTrue);
+      },
+    );
 
-    test('generateCandidateKey returns a 32-byte key without persisting it', () async {
-      final manager = VaultKeyManager.forTesting(
-        secureStorage: secureStorage,
-        authenticate: () async => true,
-      );
+    test(
+      'generateCandidateKey returns a 32-byte key without persisting it',
+      () async {
+        final manager = VaultKeyManager.forTesting(
+          secureStorage: secureStorage,
+          authenticate: () async => true,
+        );
 
-      final candidate = manager.generateCandidateKey();
-      final stored = await secureStorage.containsKey('airo_coin_wrapped_dek');
+        final candidate = manager.generateCandidateKey();
+        final stored = await secureStorage.containsKey('airo_coin_wrapped_dek');
 
-      expect(candidate, hasLength(32));
-      expect(stored.value, isFalse);
-    });
+        expect(candidate, hasLength(32));
+        expect(stored.value, isFalse);
+      },
+    );
 
     test('commitRotatedKey persists the given key as the active DEK', () async {
       final manager = VaultKeyManager.forTesting(
@@ -151,16 +174,19 @@ void main() {
       expect(active.value, equals(candidate));
     });
 
-    test('commitRotatedKey fails closed when authentication is denied', () async {
-      final manager = VaultKeyManager.forTesting(
-        secureStorage: secureStorage,
-        authenticate: () async => false,
-      );
+    test(
+      'commitRotatedKey fails closed when authentication is denied',
+      () async {
+        final manager = VaultKeyManager.forTesting(
+          secureStorage: secureStorage,
+          authenticate: () async => false,
+        );
 
-      final result = await manager.commitRotatedKey(List<int>.filled(32, 1));
+        final result = await manager.commitRotatedKey(List<int>.filled(32, 1));
 
-      expect(result.isFailure, isTrue);
-      expect(result.failure, isA<AuthFailure>());
-    });
+        expect(result.isFailure, isTrue);
+        expect(result.failure, isA<AuthFailure>());
+      },
+    );
   });
 }

--- a/packages/platform_coin_vault/test/data/bank_account_repository_test.dart
+++ b/packages/platform_coin_vault/test/data/bank_account_repository_test.dart
@@ -32,25 +32,28 @@ void main() {
   });
 
   group('BankAccountRepository', () {
-    test('create then getByNickname roundtrips the decrypted account number', () async {
-      final record = BankAccountRecord(
-        id: null,
-        nickname: 'HDFC Salary',
-        bankName: 'HDFC Bank',
-        accountHolderName: 'Jane Doe',
-        accountNumber: '1234567890',
-        ifscCode: 'HDFC0001234',
-        accountType: 'savings',
-      );
+    test(
+      'create then getByNickname roundtrips the decrypted account number',
+      () async {
+        final record = BankAccountRecord(
+          id: null,
+          nickname: 'HDFC Salary',
+          bankName: 'HDFC Bank',
+          accountHolderName: 'Jane Doe',
+          accountNumber: '1234567890',
+          ifscCode: 'HDFC0001234',
+          accountType: 'savings',
+        );
 
-      final createResult = await repository.create(record, keyBytes);
-      expect(createResult.isSuccess, isTrue);
+        final createResult = await repository.create(record, keyBytes);
+        expect(createResult.isSuccess, isTrue);
 
-      final fetched = await repository.getByNickname('HDFC Salary', keyBytes);
+        final fetched = await repository.getByNickname('HDFC Salary', keyBytes);
 
-      expect(fetched.value?.accountNumber, '1234567890');
-      expect(fetched.value?.nickname, 'HDFC Salary');
-    });
+        expect(fetched.value?.accountNumber, '1234567890');
+        expect(fetched.value?.nickname, 'HDFC Salary');
+      },
+    );
 
     test('stored account_number_enc column is never plaintext', () async {
       final record = BankAccountRecord(
@@ -96,47 +99,50 @@ void main() {
       expect(secondResult.failure, isA<ValidationFailure>());
     });
 
-    test('ciphertext swapped between two rows of the same column fails to decrypt', () async {
-      final first = BankAccountRecord(
-        id: null,
-        nickname: 'Row One',
-        bankName: 'HDFC Bank',
-        accountHolderName: 'Jane Doe',
-        accountNumber: '1111111111',
-        ifscCode: 'HDFC0001234',
-        accountType: 'savings',
-      );
-      final second = BankAccountRecord(
-        id: null,
-        nickname: 'Row Two',
-        bankName: 'HDFC Bank',
-        accountHolderName: 'Jane Doe',
-        accountNumber: '2222222222',
-        ifscCode: 'HDFC0001234',
-        accountType: 'savings',
-      );
+    test(
+      'ciphertext swapped between two rows of the same column fails to decrypt',
+      () async {
+        final first = BankAccountRecord(
+          id: null,
+          nickname: 'Row One',
+          bankName: 'HDFC Bank',
+          accountHolderName: 'Jane Doe',
+          accountNumber: '1111111111',
+          ifscCode: 'HDFC0001234',
+          accountType: 'savings',
+        );
+        final second = BankAccountRecord(
+          id: null,
+          nickname: 'Row Two',
+          bankName: 'HDFC Bank',
+          accountHolderName: 'Jane Doe',
+          accountNumber: '2222222222',
+          ifscCode: 'HDFC0001234',
+          accountType: 'savings',
+        );
 
-      await repository.create(first, keyBytes);
-      await repository.create(second, keyBytes);
+        await repository.create(first, keyBytes);
+        await repository.create(second, keyBytes);
 
-      final firstRow = (await vaultDb.db.query(
-        VaultTables.bankAccounts,
-        where: 'nickname = ?',
-        whereArgs: ['Row One'],
-      )).single;
-      final stolenCiphertext = firstRow['account_number_enc'];
+        final firstRow = (await vaultDb.db.query(
+          VaultTables.bankAccounts,
+          where: 'nickname = ?',
+          whereArgs: ['Row One'],
+        )).single;
+        final stolenCiphertext = firstRow['account_number_enc'];
 
-      await vaultDb.db.update(
-        VaultTables.bankAccounts,
-        {'account_number_enc': stolenCiphertext},
-        where: 'nickname = ?',
-        whereArgs: ['Row Two'],
-      );
+        await vaultDb.db.update(
+          VaultTables.bankAccounts,
+          {'account_number_enc': stolenCiphertext},
+          where: 'nickname = ?',
+          whereArgs: ['Row Two'],
+        );
 
-      final tampered = await repository.getByNickname('Row Two', keyBytes);
+        final tampered = await repository.getByNickname('Row Two', keyBytes);
 
-      expect(tampered.isFailure, isTrue);
-    });
+        expect(tampered.isFailure, isTrue);
+      },
+    );
 
     test('getByNickname returns null for an unknown nickname', () async {
       final result = await repository.getByNickname('Nobody', keyBytes);

--- a/packages/platform_coin_vault/test/data/pan_card_repository_test.dart
+++ b/packages/platform_coin_vault/test/data/pan_card_repository_test.dart
@@ -19,7 +19,10 @@ void main() {
   setUp(() async {
     vaultDb = VaultDatabase(databaseFactory: databaseFactoryFfi);
     await vaultDb.open(path: inMemoryDatabasePath);
-    repository = PanCardRepository(database: vaultDb, fieldCipher: FieldCipher());
+    repository = PanCardRepository(
+      database: vaultDb,
+      fieldCipher: FieldCipher(),
+    );
     keyBytes = List<int>.generate(32, (_) => Random.secure().nextInt(256));
   });
 
@@ -43,7 +46,11 @@ void main() {
   });
 
   test('stored pan_number_enc column is never plaintext', () async {
-    final record = PanCardRecord(id: null, panNumber: 'ABCDE1234F', nameOnCard: 'Jane Doe');
+    final record = PanCardRecord(
+      id: null,
+      panNumber: 'ABCDE1234F',
+      nameOnCard: 'Jane Doe',
+    );
     final createResult = await repository.create(record, keyBytes);
 
     final rows = await vaultDb.db.query(VaultTables.panCards);
@@ -51,20 +58,23 @@ void main() {
     expect(createResult.isSuccess, isTrue);
   });
 
-  test('cardImageBlob roundtrips through encryption, including bytes >= 128', () async {
-    final blob = [0, 127, 128, 200, 255];
-    final record = PanCardRecord(
-      id: null,
-      panNumber: 'ABCDE1234F',
-      nameOnCard: 'Jane Doe',
-      cardImageBlob: blob,
-    );
+  test(
+    'cardImageBlob roundtrips through encryption, including bytes >= 128',
+    () async {
+      final blob = [0, 127, 128, 200, 255];
+      final record = PanCardRecord(
+        id: null,
+        panNumber: 'ABCDE1234F',
+        nameOnCard: 'Jane Doe',
+        cardImageBlob: blob,
+      );
 
-    final createResult = await repository.create(record, keyBytes);
-    final fetched = await repository.getById(createResult.value, keyBytes);
+      final createResult = await repository.create(record, keyBytes);
+      final fetched = await repository.getById(createResult.value, keyBytes);
 
-    expect(fetched.value?.cardImageBlob, blob);
-  });
+      expect(fetched.value?.cardImageBlob, blob);
+    },
+  );
 
   test(
     'create leaves no placeholder row behind when encryption throws mid-create',
@@ -73,7 +83,11 @@ void main() {
         database: vaultDb,
         fieldCipher: _ThrowingFieldCipher(),
       );
-      final record = PanCardRecord(id: null, panNumber: 'ABCDE1234F', nameOnCard: 'Jane Doe');
+      final record = PanCardRecord(
+        id: null,
+        panNumber: 'ABCDE1234F',
+        nameOnCard: 'Jane Doe',
+      );
 
       final result = await throwingRepository.create(record, keyBytes);
       expect(result.isFailure, isTrue);

--- a/packages/platform_coin_vault/test/data/secure_document_repository_test.dart
+++ b/packages/platform_coin_vault/test/data/secure_document_repository_test.dart
@@ -20,7 +20,10 @@ void main() {
   setUp(() async {
     vaultDb = VaultDatabase(databaseFactory: databaseFactoryFfi);
     await vaultDb.open(path: inMemoryDatabasePath);
-    repository = SecureDocumentRepository(database: vaultDb, fieldCipher: FieldCipher());
+    repository = SecureDocumentRepository(
+      database: vaultDb,
+      fieldCipher: FieldCipher(),
+    );
     keyBytes = List<int>.generate(32, (_) => Random.secure().nextInt(256));
   });
 
@@ -28,25 +31,31 @@ void main() {
     await vaultDb.close();
   });
 
-  test('create then getByNickname roundtrips category and linked account', () async {
-    final record = SecureDocumentRecord(
-      id: null,
-      nickname: 'Form 16 FY24-25',
-      category: DocumentCategory.incomeProof,
-      linkedAccountNickname: 'HDFC Salary',
-      notes: 'Employer TDS certificate',
-      createdAt: DateTime(2026, 7, 19),
-    );
+  test(
+    'create then getByNickname roundtrips category and linked account',
+    () async {
+      final record = SecureDocumentRecord(
+        id: null,
+        nickname: 'Form 16 FY24-25',
+        category: DocumentCategory.incomeProof,
+        linkedAccountNickname: 'HDFC Salary',
+        notes: 'Employer TDS certificate',
+        createdAt: DateTime(2026, 7, 19),
+      );
 
-    final createResult = await repository.create(record, keyBytes);
-    expect(createResult.isSuccess, isTrue);
+      final createResult = await repository.create(record, keyBytes);
+      expect(createResult.isSuccess, isTrue);
 
-    final fetched = await repository.getByNickname('Form 16 FY24-25', keyBytes);
+      final fetched = await repository.getByNickname(
+        'Form 16 FY24-25',
+        keyBytes,
+      );
 
-    expect(fetched.value?.category, DocumentCategory.incomeProof);
-    expect(fetched.value?.linkedAccountNickname, 'HDFC Salary');
-    expect(fetched.value?.notes, 'Employer TDS certificate');
-  });
+      expect(fetched.value?.category, DocumentCategory.incomeProof);
+      expect(fetched.value?.linkedAccountNickname, 'HDFC Salary');
+      expect(fetched.value?.notes, 'Employer TDS certificate');
+    },
+  );
 
   test('stored notes_enc column is never plaintext', () async {
     final record = SecureDocumentRecord(
@@ -78,21 +87,27 @@ void main() {
     expect(fetched.value?.customFields, {'insurer': 'LIC', 'premium': '25000'});
   });
 
-  test('attachmentBlob roundtrips through encryption, including bytes >= 128', () async {
-    final blob = [0, 127, 128, 200, 255];
-    final record = SecureDocumentRecord(
-      id: null,
-      nickname: 'Scanned Rent Receipt',
-      category: DocumentCategory.hra,
-      attachmentBlob: blob,
-      createdAt: DateTime(2026, 7, 19),
-    );
+  test(
+    'attachmentBlob roundtrips through encryption, including bytes >= 128',
+    () async {
+      final blob = [0, 127, 128, 200, 255];
+      final record = SecureDocumentRecord(
+        id: null,
+        nickname: 'Scanned Rent Receipt',
+        category: DocumentCategory.hra,
+        attachmentBlob: blob,
+        createdAt: DateTime(2026, 7, 19),
+      );
 
-    await repository.create(record, keyBytes);
-    final fetched = await repository.getByNickname('Scanned Rent Receipt', keyBytes);
+      await repository.create(record, keyBytes);
+      final fetched = await repository.getByNickname(
+        'Scanned Rent Receipt',
+        keyBytes,
+      );
 
-    expect(fetched.value?.attachmentBlob, blob);
-  });
+      expect(fetched.value?.attachmentBlob, blob);
+    },
+  );
 
   test('creating a second document with the same nickname fails', () async {
     final record = SecureDocumentRecord(

--- a/packages/platform_coin_vault/test/data/vault_integration_test.dart
+++ b/packages/platform_coin_vault/test/data/vault_integration_test.dart
@@ -31,65 +31,90 @@ void main() {
     await vaultDb.close();
   });
 
-  test('all four repositories operate against one VaultDatabase instance without schema drift', () async {
-    final fieldCipher = FieldCipher();
-    final bankAccounts = BankAccountRepository(database: vaultDb, fieldCipher: fieldCipher);
-    final panCards = PanCardRepository(database: vaultDb, fieldCipher: fieldCipher);
-    final creditCards = CreditCardRepository(database: vaultDb);
-    final secureDocuments = SecureDocumentRepository(database: vaultDb, fieldCipher: fieldCipher);
+  test(
+    'all four repositories operate against one VaultDatabase instance without schema drift',
+    () async {
+      final fieldCipher = FieldCipher();
+      final bankAccounts = BankAccountRepository(
+        database: vaultDb,
+        fieldCipher: fieldCipher,
+      );
+      final panCards = PanCardRepository(
+        database: vaultDb,
+        fieldCipher: fieldCipher,
+      );
+      final creditCards = CreditCardRepository(database: vaultDb);
+      final secureDocuments = SecureDocumentRepository(
+        database: vaultDb,
+        fieldCipher: fieldCipher,
+      );
 
-    final bankResult = await bankAccounts.create(
-      BankAccountRecord(
-        id: null,
-        nickname: 'HDFC Salary',
-        bankName: 'HDFC Bank',
-        accountHolderName: 'Jane Doe',
-        accountNumber: '1234567890',
-        ifscCode: 'HDFC0001234',
-        accountType: 'savings',
-      ),
-      keyBytes,
-    );
-    final panResult = await panCards.create(
-      PanCardRecord(id: null, panNumber: 'ABCDE1234F', nameOnCard: 'Jane Doe'),
-      keyBytes,
-    );
-    final creditResult = await creditCards.create(
-      CreditCardRecord(
-        id: null,
-        nickname: 'HDFC Regalia',
-        cardNetwork: CardNetwork.visa,
-        last4: '4242',
-        expiryMonth: 12,
-        expiryYear: 2028,
-        issuingBank: 'HDFC Bank',
-        createdAt: DateTime(2026, 7, 19),
-      ),
-    );
-    final documentResult = await secureDocuments.create(
-      SecureDocumentRecord(
-        id: null,
-        nickname: 'Form 16 FY24-25',
-        category: DocumentCategory.incomeProof,
-        linkedAccountNickname: 'HDFC Salary',
-        createdAt: DateTime(2026, 7, 19),
-      ),
-      keyBytes,
-    );
+      final bankResult = await bankAccounts.create(
+        BankAccountRecord(
+          id: null,
+          nickname: 'HDFC Salary',
+          bankName: 'HDFC Bank',
+          accountHolderName: 'Jane Doe',
+          accountNumber: '1234567890',
+          ifscCode: 'HDFC0001234',
+          accountType: 'savings',
+        ),
+        keyBytes,
+      );
+      final panResult = await panCards.create(
+        PanCardRecord(
+          id: null,
+          panNumber: 'ABCDE1234F',
+          nameOnCard: 'Jane Doe',
+        ),
+        keyBytes,
+      );
+      final creditResult = await creditCards.create(
+        CreditCardRecord(
+          id: null,
+          nickname: 'HDFC Regalia',
+          cardNetwork: CardNetwork.visa,
+          last4: '4242',
+          expiryMonth: 12,
+          expiryYear: 2028,
+          issuingBank: 'HDFC Bank',
+          createdAt: DateTime(2026, 7, 19),
+        ),
+      );
+      final documentResult = await secureDocuments.create(
+        SecureDocumentRecord(
+          id: null,
+          nickname: 'Form 16 FY24-25',
+          category: DocumentCategory.incomeProof,
+          linkedAccountNickname: 'HDFC Salary',
+          createdAt: DateTime(2026, 7, 19),
+        ),
+        keyBytes,
+      );
 
-    expect(bankResult.isSuccess, isTrue);
-    expect(panResult.isSuccess, isTrue);
-    expect(creditResult.isSuccess, isTrue);
-    expect(documentResult.isSuccess, isTrue);
+      expect(bankResult.isSuccess, isTrue);
+      expect(panResult.isSuccess, isTrue);
+      expect(creditResult.isSuccess, isTrue);
+      expect(documentResult.isSuccess, isTrue);
 
-    final fetchedBank = await bankAccounts.getByNickname('HDFC Salary', keyBytes);
-    final fetchedPan = await panCards.getById(panResult.value, keyBytes);
-    final fetchedCredit = await creditCards.getByNickname('HDFC Regalia');
-    final fetchedDocument = await secureDocuments.getByNickname('Form 16 FY24-25', keyBytes);
+      final fetchedBank = await bankAccounts.getByNickname(
+        'HDFC Salary',
+        keyBytes,
+      );
+      final fetchedPan = await panCards.getById(panResult.value, keyBytes);
+      final fetchedCredit = await creditCards.getByNickname('HDFC Regalia');
+      final fetchedDocument = await secureDocuments.getByNickname(
+        'Form 16 FY24-25',
+        keyBytes,
+      );
 
-    expect(fetchedBank.value?.accountNumber, '1234567890');
-    expect(fetchedPan.value?.panNumber, 'ABCDE1234F');
-    expect(fetchedCredit.value?.last4, '4242');
-    expect(fetchedDocument.value?.linkedAccountNickname, fetchedBank.value?.nickname);
-  });
+      expect(fetchedBank.value?.accountNumber, '1234567890');
+      expect(fetchedPan.value?.panNumber, 'ABCDE1234F');
+      expect(fetchedCredit.value?.last4, '4242');
+      expect(
+        fetchedDocument.value?.linkedAccountNickname,
+        fetchedBank.value?.nickname,
+      );
+    },
+  );
 }

--- a/packages/platform_coin_vault/test/data/vault_key_rotation_service_test.dart
+++ b/packages/platform_coin_vault/test/data/vault_key_rotation_service_test.dart
@@ -40,105 +40,85 @@ void main() {
       keyManager: keyManager,
       fieldCipher: fieldCipher,
     );
-    bankAccounts = BankAccountRepository(database: vaultDb, fieldCipher: fieldCipher);
+    bankAccounts = BankAccountRepository(
+      database: vaultDb,
+      fieldCipher: fieldCipher,
+    );
     panCards = PanCardRepository(database: vaultDb, fieldCipher: fieldCipher);
-    secureDocuments = SecureDocumentRepository(database: vaultDb, fieldCipher: fieldCipher);
+    secureDocuments = SecureDocumentRepository(
+      database: vaultDb,
+      fieldCipher: fieldCipher,
+    );
   });
 
   tearDown(() async {
     await vaultDb.close();
   });
 
-  test('rotateKeyWithReencryption re-encrypts existing data so it remains readable under the new key', () async {
-    final oldKey = (await keyManager.getDatabaseKey()).value;
+  test(
+    'rotateKeyWithReencryption re-encrypts existing data so it remains readable under the new key',
+    () async {
+      final oldKey = (await keyManager.getDatabaseKey()).value;
 
-    await bankAccounts.create(
-      BankAccountRecord(
-        id: null,
-        nickname: 'HDFC Salary',
-        bankName: 'HDFC Bank',
-        accountHolderName: 'Jane Doe',
-        accountNumber: '1234567890',
-        ifscCode: 'HDFC0001234',
-        accountType: 'savings',
-        notes: 'primary account',
-      ),
-      oldKey,
-    );
-    final panResult = await panCards.create(
-      PanCardRecord(id: null, panNumber: 'ABCDE1234F', nameOnCard: 'Jane Doe'),
-      oldKey,
-    );
-    await secureDocuments.create(
-      SecureDocumentRecord(
-        id: null,
-        nickname: 'Form 16 FY24-25',
-        category: DocumentCategory.incomeProof,
-        notes: 'Employer TDS certificate',
-        createdAt: DateTime(2026, 7, 19),
-      ),
-      oldKey,
-    );
+      await bankAccounts.create(
+        BankAccountRecord(
+          id: null,
+          nickname: 'HDFC Salary',
+          bankName: 'HDFC Bank',
+          accountHolderName: 'Jane Doe',
+          accountNumber: '1234567890',
+          ifscCode: 'HDFC0001234',
+          accountType: 'savings',
+          notes: 'primary account',
+        ),
+        oldKey,
+      );
+      final panResult = await panCards.create(
+        PanCardRecord(
+          id: null,
+          panNumber: 'ABCDE1234F',
+          nameOnCard: 'Jane Doe',
+        ),
+        oldKey,
+      );
+      await secureDocuments.create(
+        SecureDocumentRecord(
+          id: null,
+          nickname: 'Form 16 FY24-25',
+          category: DocumentCategory.incomeProof,
+          notes: 'Employer TDS certificate',
+          createdAt: DateTime(2026, 7, 19),
+        ),
+        oldKey,
+      );
 
-    final rotateResult = await rotationService.rotateKeyWithReencryption();
-    expect(rotateResult.isSuccess, isTrue);
+      final rotateResult = await rotationService.rotateKeyWithReencryption();
+      expect(rotateResult.isSuccess, isTrue);
 
-    final newKey = (await keyManager.getDatabaseKey()).value;
-    expect(newKey, isNot(equals(oldKey)));
+      final newKey = (await keyManager.getDatabaseKey()).value;
+      expect(newKey, isNot(equals(oldKey)));
 
-    final fetchedBank = await bankAccounts.getByNickname('HDFC Salary', newKey);
-    final fetchedPan = await panCards.getById(panResult.value, newKey);
-    final fetchedDocument = await secureDocuments.getByNickname('Form 16 FY24-25', newKey);
+      final fetchedBank = await bankAccounts.getByNickname(
+        'HDFC Salary',
+        newKey,
+      );
+      final fetchedPan = await panCards.getById(panResult.value, newKey);
+      final fetchedDocument = await secureDocuments.getByNickname(
+        'Form 16 FY24-25',
+        newKey,
+      );
 
-    expect(fetchedBank.value?.accountNumber, '1234567890');
-    expect(fetchedBank.value?.notes, 'primary account');
-    expect(fetchedPan.value?.panNumber, 'ABCDE1234F');
-    expect(fetchedDocument.value?.notes, 'Employer TDS certificate');
-  });
-
-  test('data is no longer decryptable under the old key after rotation', () async {
-    final oldKey = (await keyManager.getDatabaseKey()).value;
-
-    await bankAccounts.create(
-      BankAccountRecord(
-        id: null,
-        nickname: 'HDFC Salary',
-        bankName: 'HDFC Bank',
-        accountHolderName: 'Jane Doe',
-        accountNumber: '1234567890',
-        ifscCode: 'HDFC0001234',
-        accountType: 'savings',
-      ),
-      oldKey,
-    );
-
-    await rotationService.rotateKeyWithReencryption();
-
-    final fetchedWithOldKey = await bankAccounts.getByNickname('HDFC Salary', oldKey);
-
-    expect(fetchedWithOldKey.isFailure, isTrue);
-  });
+      expect(fetchedBank.value?.accountNumber, '1234567890');
+      expect(fetchedBank.value?.notes, 'primary account');
+      expect(fetchedPan.value?.panNumber, 'ABCDE1234F');
+      expect(fetchedDocument.value?.notes, 'Employer TDS certificate');
+    },
+  );
 
   test(
-    'rotateKeyWithReencryption requires exactly one successful authenticate() call, '
-    'not two, so a denied second prompt can never brick the vault',
+    'data is no longer decryptable under the old key after rotation',
     () async {
-      var authCallCount = 0;
-      final countingKeyManager = VaultKeyManager.forTesting(
-        secureStorage: secureStorage,
-        authenticate: () async {
-          authCallCount++;
-          return true;
-        },
-      );
-      final countingRotationService = VaultKeyRotationService(
-        database: vaultDb,
-        keyManager: countingKeyManager,
-        fieldCipher: fieldCipher,
-      );
-
-      final oldKey = (await countingKeyManager.getDatabaseKey()).value;
-      authCallCount = 0; // reset after the setup auth above
+      final oldKey = (await keyManager.getDatabaseKey()).value;
 
       await bankAccounts.create(
         BankAccountRecord(
@@ -153,19 +133,62 @@ void main() {
         oldKey,
       );
 
-      final rotateResult = await countingRotationService.rotateKeyWithReencryption();
+      await rotationService.rotateKeyWithReencryption();
 
-      expect(rotateResult.isSuccess, isTrue);
-      expect(
-        authCallCount,
-        1,
-        reason:
-            'rotation must authenticate exactly once for the whole operation — a '
-            'second re-auth before persisting the new key is what previously let a '
-            'denied prompt brick the vault after data was already re-encrypted',
+      final fetchedWithOldKey = await bankAccounts.getByNickname(
+        'HDFC Salary',
+        oldKey,
       );
+
+      expect(fetchedWithOldKey.isFailure, isTrue);
     },
   );
+
+  test('rotateKeyWithReencryption requires exactly one successful authenticate() call, '
+      'not two, so a denied second prompt can never brick the vault', () async {
+    var authCallCount = 0;
+    final countingKeyManager = VaultKeyManager.forTesting(
+      secureStorage: secureStorage,
+      authenticate: () async {
+        authCallCount++;
+        return true;
+      },
+    );
+    final countingRotationService = VaultKeyRotationService(
+      database: vaultDb,
+      keyManager: countingKeyManager,
+      fieldCipher: fieldCipher,
+    );
+
+    final oldKey = (await countingKeyManager.getDatabaseKey()).value;
+    authCallCount = 0; // reset after the setup auth above
+
+    await bankAccounts.create(
+      BankAccountRecord(
+        id: null,
+        nickname: 'HDFC Salary',
+        bankName: 'HDFC Bank',
+        accountHolderName: 'Jane Doe',
+        accountNumber: '1234567890',
+        ifscCode: 'HDFC0001234',
+        accountType: 'savings',
+      ),
+      oldKey,
+    );
+
+    final rotateResult = await countingRotationService
+        .rotateKeyWithReencryption();
+
+    expect(rotateResult.isSuccess, isTrue);
+    expect(
+      authCallCount,
+      1,
+      reason:
+          'rotation must authenticate exactly once for the whole operation — a '
+          'second re-auth before persisting the new key is what previously let a '
+          'denied prompt brick the vault after data was already re-encrypted',
+    );
+  });
 
   test(
     '_encryptedColumnsByTable stays in sync with every actual *_enc column in the schema',

--- a/packages/platform_coin_vault/test/domain/entities/secure_document_record_test.dart
+++ b/packages/platform_coin_vault/test/domain/entities/secure_document_record_test.dart
@@ -3,16 +3,19 @@ import 'package:platform_coin_vault/src/domain/entities/secure_document_record.d
 
 void main() {
   test('all ITR-driven categories are available', () {
-    expect(DocumentCategory.values, containsAll(<DocumentCategory>[
-      DocumentCategory.personalId,
-      DocumentCategory.incomeProof,
-      DocumentCategory.taxCredit,
-      DocumentCategory.investmentProof,
-      DocumentCategory.hra,
-      DocumentCategory.capitalGains,
-      DocumentCategory.homeLoan,
-      DocumentCategory.other,
-    ]));
+    expect(
+      DocumentCategory.values,
+      containsAll(<DocumentCategory>[
+        DocumentCategory.personalId,
+        DocumentCategory.incomeProof,
+        DocumentCategory.taxCredit,
+        DocumentCategory.investmentProof,
+        DocumentCategory.hra,
+        DocumentCategory.capitalGains,
+        DocumentCategory.homeLoan,
+        DocumentCategory.other,
+      ]),
+    );
   });
 
   test('linkedAccountNickname is optional', () {


### PR DESCRIPTION
Two defects found while testing the biometric journey on a Pixel 9.

## 1. Wrong diagnosis when nothing is enrolled
`isEncryptionAvailable()` only asks whether the *hardware* exists (`canCheckBiometrics && isDeviceSupported`). On a device with a fingerprint sensor but **no screen lock** — and therefore nothing enrolled — it returns true, so the vault attempts auth, gets an instant refusal, and shows **"Biometric authentication failed"**.

Device evidence:
```
BiometricService/PreAuthInfo: io.airo.app Sensor ID: 1        Modality: 8 (face)
BiometricService/PreAuthInfo: io.airo.app Sensor ID: 37748992 Modality: 2 (fingerprint)
dumpsys window → KeyguardSecure: false        ← no screen lock, so nothing can be enrolled
```
No system prompt ever appears. The message implies a bad scan and invites retries that can never succeed — while the accurate, actionable `VaultUnavailable` screen was unreachable.

**Fix:** `VaultKeyManager.hasEnrolledBiometrics()` classifies the failure. *Deliberately not used to gate the attempt* — `authenticate` runs with `biometricOnly: false`, so a device credential is still a valid factor; gating on enrolment would lock out PIN-only users.

## 2. Airo Coins had no application id
`APP_VARIANT=coins` fell through the gradle `when` to `io.airo.app`, so the Coins build **installed over the super app** under the "Airo" name. They could never coexist, which is why the vault looked like part of the super app. Now `io.airo.app.coins` / "Airo Coins", matching how `tv` is handled.

## Test plan
- [x] `platform_coin_vault`: 91 pass
- [x] `feature_coin`: 65 pass (was 63) — new coverage for the unenrolled case, plus a contrast test that a *genuine* failed scan still reports an auth error
- [x] analyze clean on both

## Not yet verified
The happy path (prompt appears → scan → vault unlocks) still can't be confirmed on this device — it has no screen lock, so nothing can be enrolled. Needs a device with a fingerprint enrolled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)