### PR TITLE
fix(android): host BiometricPrompt so vault unlock can actually work

### DIFF
--- a/app/android/app/src/main/kotlin/io/airo/app/MainActivity.kt
+++ b/app/android/app/src/main/kotlin/io/airo/app/MainActivity.kt
@@ -11,7 +11,7 @@ import android.content.pm.PackageManager
 import android.net.Uri
 import android.provider.CalendarContract
 import android.provider.Settings
-import com.ryanheise.audioservice.AudioServiceActivity
+import com.ryanheise.audioservice.AudioServiceFragmentActivity
 import io.flutter.embedding.engine.FlutterEngine
 import io.flutter.plugin.common.EventChannel
 import io.flutter.plugin.common.MethodChannel
@@ -20,7 +20,13 @@ import java.util.Calendar
 import java.util.Locale
 import java.util.TimeZone
 
-class MainActivity : AudioServiceActivity() {
+// AudioServiceFragmentActivity (FlutterFragmentActivity) rather than
+// AudioServiceActivity (FlutterActivity): local_auth hosts Android's
+// BiometricPrompt in a Fragment, so a plain FlutterActivity makes every
+// authenticate() call throw no_fragment_activity — the vault could never
+// show a biometric prompt. The audio_service behaviour is identical
+// between the two base classes.
+class MainActivity : AudioServiceFragmentActivity() {
     private val GEMINI_NANO_CHANNEL = "com.airo.gemini_nano"
     private val GEMINI_NANO_EVENT_CHANNEL = "com.airo.gemini_nano/stream"
     private val LITERT_LM_CHANNEL = "com.airo.litert_lm"


### PR DESCRIPTION
## The bug
`MainActivity` extended `AudioServiceActivity` → `FlutterActivity`. `local_auth` hosts Android's `BiometricPrompt` **inside a Fragment**, so on a plain `FlutterActivity` every `authenticate()` call throws `no_fragment_activity` and **no prompt is ever shown**.

The vault's catch-all then reported *"Biometric authentication failed"* — so a setup defect presented as a failed fingerprint scan, inviting retries that could never succeed. The OS was reporting the device as fully capable the whole time (`AUTHENTICATOR_OK`, fingerprint enrolled).

## The fix
Switch to `AudioServiceFragmentActivity` (`FlutterFragmentActivity`) — `audio_service` ships it for exactly this case, and media-session behaviour is identical between the two base classes. Both manifests reference `".MainActivity"` by name, so the full and TV variants pick it up automatically.

## Verified on device (Pixel 9, Android 17)
Tapping Unlock now focuses the real system prompt:
```
mCurrentFocus = Window{BiometricPrompt}
"Airo Coins" · "Verify identity" · "Authentication required"
"Unlock your Airo Coin vault"      ← our localizedReason
"Touch the fingerprint sensor" · "Use PIN" · "Cancel"
```
Previously the identical tap produced an instant in-app error and no system prompt.

## Note
This is the *actual* cause of the symptom investigated in #1125. That PR's enrolment-classification fix remains correct and useful (it handles genuinely unenrolled devices), but it was not this bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)