### PR TITLE
fix(playback): send playlist-declared HTTP headers to the player

### DIFF
--- a/docs/release/AIRO_TV_DATA_SAFETY.md
+++ b/docs/release/AIRO_TV_DATA_SAFETY.md
@@ -26,7 +26,12 @@ This declaration is based on the current v2 TV release behavior:
   initialization.
 - Firebase Core/Auth packages may be present for runtime initialization and
   future auth compatibility, but the TV flow does not require account sign-in
-  for IPTV playback.
+  for IPTV playback. Because `firebase_core` ships, a Firebase installation ID
+  may be generated and sent to Google; this is declared under "Device or other
+  IDs" below.
+- Playlist and program-guide requests go directly from the device to the
+  servers the user configured, and the public iptv-org catalogue is downloaded
+  and matched on-device. The user's playlist is never uploaded anywhere.
 
 ## Google Play Data Safety
 
@@ -46,7 +51,7 @@ This declaration is based on the current v2 TV release behavior:
 | App activity | No app-owned external collection | No | App functionality | Preferences and playlist state are stored on device. |
 | Web browsing | No | No | Not applicable | Airo TV does not provide a browser. |
 | App info and performance | No app-owned external collection | No | Diagnostics only if user shares logs manually | Crashlytics is not included in the TV pubspec. |
-| Device or other IDs | No app-owned external collection | No | Not applicable | No advertising ID permission or analytics SDK is enabled. |
+| Device or other IDs | **Yes — collected by Firebase SDK, not by the developer** | No | App functionality | `firebase_core` is in `app/pubspec_tv.yaml`. Where Firebase generates a Firebase installation ID (FID), it is sent to Google under Google's own privacy policy. It is not received by DevelopersCoffee, not linked to a user or account, not used for advertising or cross-app tracking, and reset on uninstall or clear-data. No advertising ID permission or analytics SDK is enabled. |
 | IPTV playlist URLs | Local only | No | App functionality | User-provided playlist URLs are stored on device and used to fetch user-selected content. |
 | Stream URLs | Local/runtime only | No | App functionality | Stream URLs are requested by the app/player/Cast receiver only to play user-selected content. |
 
@@ -58,7 +63,27 @@ TV release. User-provided IPTV playlist URLs, preferences, and playback state
 are stored locally on the device for app functionality. The app does not include
 advertising, analytics, Crashlytics, purchases, location, contacts, camera, or
 microphone data collection in the TV profile.
+
+The app includes the Firebase core library. Where Firebase generates a Firebase
+installation ID, that identifier is transmitted to Google under Google's privacy
+policy. It is declared under "Device or other IDs" for app functionality. It is
+not received by the developer, not linked to a user or account, not used for
+advertising or tracking, and is reset when the app is uninstalled or its data
+cleared.
 ```
+
+### Why "Device or other IDs" is declared Yes
+
+Play's Data Safety scope covers data collected by **third-party SDKs bundled in
+the app**, not only data the developer receives. `firebase_core` ships in the TV
+profile, so the honest answer is to declare the identifier and describe its
+narrow purpose, rather than answer No on the grounds that DevelopersCoffee never
+sees it. Under-declaring is a policy-enforcement risk; declaring it with an
+accurate purpose is not.
+
+This must stay consistent with the published privacy policy, which describes the
+same identifier in its "Network Connections" section. If `firebase_core` is ever
+removed from `app/pubspec_tv.yaml`, revisit both together.
 
 ### Security Practices
 
@@ -80,7 +105,7 @@ the active iOS dependency set and runtime behavior.
 | --- | --- |
 | Data Used to Track You | None |
 | Data Linked to You | None for the current TV IPTV playback flow |
-| Data Not Linked to You | None collected by the developer for the current TV profile |
+| Data Not Linked to You | Identifiers — the Firebase installation ID, if generated. Nothing collected by the developer. |
 | Diagnostics | None unless a crash-reporting SDK is added before submission |
 | User Content | User-provided playlist URLs are local app functionality data, not collected by the developer |
 

--- a/packages/platform_media/lib/src/mpv/media_kit_mpv_player_facade.dart
+++ b/packages/platform_media/lib/src/mpv/media_kit_mpv_player_facade.dart
@@ -25,8 +25,14 @@ class MediaKitMpvPlayerFacade implements MpvPlayerFacade {
   final Player _player;
 
   @override
-  Future<MpvOpenResult> open(String url) async {
-    await _player.open(Media(url), play: false);
+  Future<MpvOpenResult> open(
+    String url, {
+    Map<String, String> httpHeaders = const {},
+  }) async {
+    await _player.open(
+      Media(url, httpHeaders: httpHeaders.isEmpty ? null : httpHeaders),
+      play: false,
+    );
     Duration duration = Duration.zero;
     try {
       duration = _player.state.duration;

--- a/packages/platform_media/lib/src/mpv/mpv_player_facade.dart
+++ b/packages/platform_media/lib/src/mpv/mpv_player_facade.dart
@@ -8,11 +8,17 @@ import 'dart:async';
 /// machine, error taxonomy translation, source-handle handling) live in the
 /// engine adapter, not here.
 abstract class MpvPlayerFacade {
-  /// Load a source URL. Returns the observed post-open metadata (duration,
-  /// hardware-accel flag). Throw an [Object] to signal a decoder/codec
-  /// failure — the engine adapter maps that to a typed
-  /// [AiroPlaybackErrorCode.decoderFailed].
-  Future<MpvOpenResult> open(String url);
+  /// Load a source URL, sending [httpHeaders] with the request. Returns the
+  /// observed post-open metadata (duration, hardware-accel flag). Throw an
+  /// [Object] to signal a decoder/codec failure — the engine adapter maps
+  /// that to a typed [AiroPlaybackErrorCode.decoderFailed].
+  ///
+  /// [httpHeaders] carries the playlist's own `http-user-agent`/referrer
+  /// attributes. Providers that require them answer 403 without them.
+  Future<MpvOpenResult> open(
+    String url, {
+    Map<String, String> httpHeaders = const {},
+  });
 
   Future<void> play();
 

--- a/packages/platform_media/lib/src/mpv_airo_playback_engine.dart
+++ b/packages/platform_media/lib/src/mpv_airo_playback_engine.dart
@@ -54,7 +54,10 @@ class MpvAiroPlaybackEngine implements AiroPlaybackEngine {
 
     late MpvOpenResult result;
     try {
-      result = await player.open(request.sourceHandle.value);
+      result = await player.open(
+        request.sourceHandle.value,
+        httpHeaders: request.httpHeaders,
+      );
     } on Object {
       return _fail(AiroPlaybackErrorCode.decoderFailed, 'open', request);
     }

--- a/packages/platform_media/lib/src/video_player_airo_playback_engine.dart
+++ b/packages/platform_media/lib/src/video_player_airo_playback_engine.dart
@@ -62,6 +62,7 @@ class VideoPlayerAiroPlaybackEngine implements AiroPlaybackEngine {
 
     final controller = VideoPlayerController.networkUrl(
       Uri.parse(request.sourceHandle.value),
+      httpHeaders: request.httpHeaders,
       videoPlayerOptions: VideoPlayerOptions(
         mixWithOthers: request.mixWithOthers,
         allowBackgroundPlayback: request.allowBackgroundPlayback,

--- a/packages/platform_media/lib/src/video_player_streaming_service.dart
+++ b/packages/platform_media/lib/src/video_player_streaming_service.dart
@@ -210,6 +210,7 @@ class VideoPlayerStreamingService implements IPTVStreamingService {
             mixWithOthers: _isBackgroundAudioMode,
             allowBackgroundPlayback:
                 _isBackgroundAudioMode || channel.isAudioOnly,
+            httpHeaders: _httpHeadersFor(channel),
           ),
         );
 
@@ -755,6 +756,17 @@ class VideoPlayerStreamingService implements IPTVStreamingService {
   void _updateState(StreamingState newState) {
     _state = newState;
     _stateController.add(_state);
+  }
+
+  /// Mirrors the header names the availability probe sends
+  /// (`ChannelAutoScanController._toProbeRequest`). The probe and the player
+  /// must agree: if only the probe sends them, a provider that requires a
+  /// `User-Agent` reports the channel reachable and then refuses playback.
+  Map<String, String> _httpHeadersFor(IPTVChannel channel) {
+    return {
+      'User-Agent': ?channel.headers?.userAgent,
+      'Referer': ?channel.headers?.referrer,
+    };
   }
 
   @override

--- a/packages/platform_media/test/support/fake_mpv_player_facade.dart
+++ b/packages/platform_media/test/support/fake_mpv_player_facade.dart
@@ -20,6 +20,7 @@ class FakeMpvPlayerFacade implements MpvPlayerFacade {
 
   bool disposed = false;
   String? lastOpenedUrl;
+  Map<String, String>? lastOpenedHeaders;
   bool playing = false;
   Duration position = Duration.zero;
   double volume = 1;
@@ -28,13 +29,17 @@ class FakeMpvPlayerFacade implements MpvPlayerFacade {
   final List<String> calls = [];
 
   @override
-  Future<MpvOpenResult> open(String url) async {
+  Future<MpvOpenResult> open(
+    String url, {
+    Map<String, String> httpHeaders = const {},
+  }) async {
     calls.add('open($url)');
     final error = scriptedOpenError;
     if (error != null) {
       throw error;
     }
     lastOpenedUrl = url;
+    lastOpenedHeaders = httpHeaders;
     return MpvOpenResult(
       duration: fakeDuration,
       hardwareAccelerated: hardwareAccelerated,

--- a/packages/platform_media/test/support/fake_video_player_platform.dart
+++ b/packages/platform_media/test/support/fake_video_player_platform.dart
@@ -34,6 +34,12 @@ class FakeVideoPlayerPlatform extends VideoPlayerPlatform {
   int _nextPlayerId = 0;
   int? _lastPlayerId;
 
+  /// Data source the most recent create was given. Exposes `httpHeaders` so
+  /// tests can assert that playlist-supplied headers survive the trip from
+  /// [IPTVChannel] down to the platform — providers that require a
+  /// `User-Agent` reject the stream without them.
+  DataSource? lastDataSource;
+
   @override
   Future<void> init() async {}
 
@@ -42,6 +48,7 @@ class FakeVideoPlayerPlatform extends VideoPlayerPlatform {
     final id = _nextPlayerId++;
     _eventControllers[id] = StreamController<VideoEvent>.broadcast();
     _lastPlayerId = id;
+    lastDataSource = options.dataSource;
     return id;
   }
 

--- a/packages/platform_media/test/video_player_streaming_service_test.dart
+++ b/packages/platform_media/test/video_player_streaming_service_test.dart
@@ -20,12 +20,14 @@ void main() {
   IPTVChannel channel({
     String streamUrl = 'https://example.com/live.m3u8',
     bool isAudioOnly = false,
+    ChannelHeaders? headers,
   }) {
     return IPTVChannel(
       id: 'chan-1',
       name: 'Test Channel',
       streamUrl: streamUrl,
       isAudioOnly: isAudioOnly,
+      headers: headers,
     );
   }
 
@@ -41,6 +43,28 @@ void main() {
   });
 
   group('VideoPlayerStreamingService playChannel', () {
+    test('forwards playlist-supplied headers to the platform', () async {
+      await service.playChannel(
+        channel(
+          headers: const ChannelHeaders(
+            userAgent: 'Mozilla/5.0 (Airo test)',
+            referrer: 'https://example.com/portal',
+          ),
+        ),
+      );
+
+      expect(fakePlatform.lastDataSource?.httpHeaders, {
+        'User-Agent': 'Mozilla/5.0 (Airo test)',
+        'Referer': 'https://example.com/portal',
+      });
+    });
+
+    test('sends no headers when the playlist supplies none', () async {
+      await service.playChannel(channel());
+
+      expect(fakePlatform.lastDataSource?.httpHeaders, isEmpty);
+    });
+
     test('opens via the injected engine and reaches playing', () async {
       await service.playChannel(channel());
       expect(service.currentState.playbackState, PlaybackState.playing);

--- a/packages/platform_player/lib/src/models/playback_engine_models.dart
+++ b/packages/platform_player/lib/src/models/playback_engine_models.dart
@@ -193,8 +193,10 @@ class AiroMediaOpenRequest extends Equatable {
     List<AiroPlaybackExternalSubtitle> externalSubtitles = const [],
     this.mixWithOthers = false,
     this.allowBackgroundPlayback = false,
+    Map<String, String> httpHeaders = const {},
     this.schemaVersion = kAiroPlaybackEngineSchemaVersion,
-  }) : externalSubtitles = List.unmodifiable(externalSubtitles);
+  }) : externalSubtitles = List.unmodifiable(externalSubtitles),
+       httpHeaders = Map.unmodifiable(httpHeaders);
 
   final String schemaVersion;
   final String requestId;
@@ -214,6 +216,14 @@ class AiroMediaOpenRequest extends Equatable {
   /// `VideoPlayerOptions.allowBackgroundPlayback` on the videoPlayer engine.
   /// Typically true for audio-only/radio-style content.
   final bool allowBackgroundPlayback;
+
+  /// Request headers the playlist declared for this stream, e.g. the
+  /// `http-user-agent` and `http-referrer` attributes on an `#EXTINF` line.
+  ///
+  /// Many IPTV providers reject requests that omit them, so these must reach
+  /// the engine: dropping them makes a stream that the availability probe
+  /// verified as reachable fail at playback with a 403.
+  final Map<String, String> httpHeaders;
 
   @override
   String toString() {
@@ -240,6 +250,7 @@ class AiroMediaOpenRequest extends Equatable {
     externalSubtitles,
     mixWithOthers,
     allowBackgroundPlayback,
+    httpHeaders,
   ];
 }
 


### PR DESCRIPTION
Found while capturing store screenshots on a Fire TV Stick: a channel showing a green "Channel reachable" check failed to play with HTTP 403.

## Root cause — the probe and the player made different requests

`ChannelAutoScanController._toProbeRequest` sends `User-Agent` and `Referer` from `IPTVChannel.headers` when probing availability. So the probe got a 200 and the row rendered a green check.

`AiroMediaOpenRequest` carried **no headers at all**, so `VideoPlayerController.networkUrl` was called without `httpHeaders` and the provider refused the identical stream.

The status indicator was reporting its measurement honestly — the player was the one making a different request. Worth stating plainly because it changes the fix: **this is not a display bug**, so it is not fixed at the icon. Any channel whose playlist declares `http-user-agent` was unplayable, which is a large share of real IPTV providers. The iptv-org list used for testing declares it extensively.

## The fix

Adds `httpHeaders` to `AiroMediaOpenRequest` and plumbs `IPTVChannel.headers` through `VideoPlayerStreamingService`, deriving the header names from the same rule the probe uses so the two cannot silently drift apart again.

**Both engines**, not just the TV one:
- the `videoPlayer` engine passes `httpHeaders` to `networkUrl`
- `MpvPlayerFacade.open` takes an optional `httpHeaders` map, forwarded to media_kit via `Media()`

The TV profile strips mpv per CV-030, so Fire TV only exercises the `videoPlayer` path — but the mobile engine had the same defect and is fixed here rather than left half-done.

## Tests

Asserted at the platform boundary. `FakeVideoPlayerPlatform` now captures the `DataSource`, so the test proves headers survive the full trip from `IPTVChannel` down into `video_player`, rather than trusting an intermediate call:

```
forwards playlist-supplied headers to the platform   → before: Actual: {}
sends no headers when the playlist supplies none
```

Suites: `platform_media` 130, `platform_player` 205, `feature_iptv` 626, `core_release` 89 — all passing. `platform_media`, `platform_player`, and `feature_iptv` analyze clean. The one remaining `app` analyzer info (`IndianDateFormatter` deprecated) predates this branch, from #1112.

## Also: Data Safety alignment

Brings `docs/release/AIRO_TV_DATA_SAFETY.md` in line with the privacy policy merged in #1123. **"Device or other IDs" now declares Yes** for the Firebase installation ID.

Play's Data Safety scope covers data collected by bundled third-party SDKs, not only data the developer receives, and `firebase_core` ships in the TV profile. The previous "No app-owned external collection" was defensible on its own terms but would have put the console form out of step with the published policy. Under-declaring is an enforcement risk; declaring it with an accurate, narrow purpose is not. The rationale is written into the doc so the next person doesn't re-litigate it.

Data-safety preflight still passes with no blocking findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)