### PR TITLE
fix(tv): stop the sidebar from unmounting live playback on navigation

### DIFF
--- a/app/lib/core/app/tv_shell.dart
+++ b/app/lib/core/app/tv_shell.dart
@@ -12,57 +12,106 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_riverpod/legacy.dart';
 import 'package:go_router/go_router.dart';
 
-import 'tv_router.dart';
+import '../../features/settings/presentation/tv/tv_settings_screen.dart';
 
 /// Provider for current TV navigation index
 final tvNavigationIndexProvider = StateProvider<int>((ref) => 0);
 
+/// Non-live destinations the sidebar can show. Rendered as an overlay on
+/// top of [TvShell.child] instead of being routed to — routing away would
+/// unmount whatever live playback [child] holds (AiroTV D-pad design:
+/// "VIDEO LAYER always present, never destroyed" / "Playback never
+/// stops"). Only index 0 (Home) ever calls [GoRouter.go]: it's the one
+/// case where returning to the live route is actually correct even if it
+/// means building a fresh live screen (e.g. after a deep link landed the
+/// shell on a non-live route).
+enum _TvOverlayScreen { guide, vod, favorites, settings }
+
 /// TV Shell with sidebar navigation
-class TvShell extends ConsumerWidget {
+class TvShell extends ConsumerStatefulWidget {
   final Widget child;
 
   const TvShell({super.key, required this.child});
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  ConsumerState<TvShell> createState() => _TvShellState();
+}
+
+class _TvShellState extends ConsumerState<TvShell> {
+  _TvOverlayScreen? _overlay;
+
+  @override
+  Widget build(BuildContext context) {
     final currentIndex = ref.watch(tvNavigationIndexProvider);
 
     return Scaffold(
-      body: Row(
+      body: Stack(
         children: [
-          // Sidebar navigation rail
-          _TvNavigationRail(
-            currentIndex: currentIndex,
-            onDestinationSelected: (index) {
-              ref.read(tvNavigationIndexProvider.notifier).state = index;
-              _navigateToIndex(context, index);
-            },
+          // The routed content (the live TV screen on the common path).
+          // Never removed from the tree by a sidebar tap — only a direct
+          // deep link to a different route replaces it.
+          Positioned.fill(child: widget.child),
+          if (_overlay != null)
+            Positioned.fill(
+              // The rail stays visible (painted after this, so on top) and
+              // isn't docked in a layout row anymore, so it no longer
+              // reserves space of its own — give overlay screens the same
+              // left inset the old Row gave them, so their content doesn't
+              // render underneath the now-floating rail.
+              child: Padding(
+                padding: const EdgeInsets.only(left: 88),
+                child: _buildOverlay(_overlay!),
+              ),
+            ),
+          // The rail is painted on top instead of docked in a Row, so it
+          // never claims layout width from the content beneath it.
+          Positioned(
+            left: 0,
+            top: 0,
+            bottom: 0,
+            child: _TvNavigationRail(
+              currentIndex: currentIndex,
+              onDestinationSelected: (index) =>
+                  _selectDestination(context, index),
+            ),
           ),
-          // Main content
-          Expanded(child: child),
         ],
       ),
     );
   }
 
-  void _navigateToIndex(BuildContext context, int index) {
-    switch (index) {
-      case 0:
-        context.go(TvRouteNames.live);
-        break;
-      case 1:
-        context.go(TvRouteNames.guide);
-        break;
-      case 2:
-        context.go(TvRouteNames.vod);
-        break;
-      case 3:
-        context.go(TvRouteNames.favorites);
-        break;
-      case 4:
-        context.go(TvRouteNames.settings);
-        break;
+  void _selectDestination(BuildContext context, int index) {
+    ref.read(tvNavigationIndexProvider.notifier).state = index;
+    if (index == 0) {
+      setState(() => _overlay = null);
+      GoRouter.of(context).go('/live');
+      return;
     }
+    setState(() {
+      _overlay = switch (index) {
+        1 => _TvOverlayScreen.guide,
+        2 => _TvOverlayScreen.vod,
+        3 => _TvOverlayScreen.favorites,
+        _ => _TvOverlayScreen.settings,
+      };
+    });
+  }
+
+  void _closeOverlay() {
+    ref.read(tvNavigationIndexProvider.notifier).state = 0;
+    setState(() => _overlay = null);
+  }
+
+  Widget _buildOverlay(_TvOverlayScreen overlay) {
+    return switch (overlay) {
+      _TvOverlayScreen.guide => IptvGuideScreen(
+        overrideFormFactor: AiroFormFactor.tv,
+        onChannelSelected: _closeOverlay,
+      ),
+      _TvOverlayScreen.vod => const VodTvScreen(),
+      _TvOverlayScreen.favorites => const TvFavoritesScreen(),
+      _TvOverlayScreen.settings => const TvSettingsScreen(),
+    };
   }
 }
 

--- a/app/test/core/app/tv_router_test.dart
+++ b/app/test/core/app/tv_router_test.dart
@@ -185,6 +185,79 @@ void main() {
     },
   );
 
+  testWidgets(
+    'sidebar navigation overlays Guide without unmounting the live shell '
+    '(playback must never stop for a menu tap)',
+    (tester) async {
+      DeviceFormFactorDetector.debugFormFactorOverride = DeviceFormFactor.tv;
+      addTearDown(DeviceFormFactorDetector.clearCache);
+
+      SharedPreferences.setMockInitialValues({});
+      final prefs = await SharedPreferences.getInstance();
+      await tester.binding.setSurfaceSize(const Size(960, 540));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            sharedPreferencesProvider.overrideWithValue(prefs),
+            iptvChannelsProvider.overrideWith(
+              (ref) async => const [
+                IPTVChannel(
+                  id: 'ch1',
+                  name: 'Test Channel',
+                  streamUrl: 'https://example.com/ch1.m3u8',
+                ),
+              ],
+            ),
+            recentlyWatchedChannelsProvider.overrideWith(
+              (ref) async => const [],
+            ),
+            streamingStateProvider.overrideWith(
+              (ref) => Stream.value(
+                StreamingState(
+                  playbackState: PlaybackState.idle,
+                  isLiveStream: true,
+                ),
+              ),
+            ),
+          ],
+          child: MaterialApp.router(
+            routerConfig: TvRouter.createRouter(
+              initialLocation: TvRouteNames.live,
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(
+        find.byKey(const ValueKey('airo-tv-explorer-wide-shell')),
+        findsOneWidget,
+      );
+
+      await tester.tap(find.text('Guide'));
+      await tester.pumpAndSettle();
+
+      // The live shell (and the video widget it hosts) is still in the
+      // tree underneath the Guide overlay — a sidebar tap must not tear
+      // it down and rebuild it from scratch.
+      expect(
+        find.byKey(const ValueKey('airo-tv-explorer-wide-shell')),
+        findsOneWidget,
+      );
+      expect(find.text('Guide'), findsWidgets);
+
+      await tester.tap(find.text('Home'));
+      await tester.pumpAndSettle();
+
+      expect(
+        find.byKey(const ValueKey('airo-tv-explorer-wide-shell')),
+        findsOneWidget,
+      );
+    },
+  );
+
   testWidgets('redirects legacy login route to live TV', (tester) async {
     await pumpTvRouter(
       tester,


### PR DESCRIPTION
## Summary
- Root cause: `TvShell` docked its sidebar in a `Row` and routed each destination (Guide/Movies/Favorites/Settings) to its own go_router location, sibling to `/live` under the same `ShellRoute`. Navigating to any of them replaced `child` — the live TV screen, video and all — with the destination screen. **Every sidebar tap silently killed playback**; returning to Live rebuilt the player from scratch.
- Fix: sidebar taps (except Home) no longer call `GoRouter.go`. They set local overlay state, and `TvShell` renders the requested screen as a `Stack` layer on top of the live screen, which stays mounted underneath throughout the whole session.
- The sidebar itself moves from a `Row` (which reserved 88px of layout width from the content) to a `Positioned` overlay, so it no longer resizes whatever's beneath it — matches the design's "overlays, never resizes video" invariant for the live/video layer specifically. (Non-video overlay screens get an 88px left padding inset instead, since they weren't built expecting a floating rail.)
- Direct deep links to `/guide`, `/favorites`, etc. still work via the existing go_router routes (used e.g. by the compact-phone path, which never uses `TvShell`) — only the interactive sidebar's own navigation changed.

Matches the AiroTV D-pad Claude Design project's (`02b0b312`) core invariant: "VIDEO LAYER always present, never destroyed" / "Playback never stops".

## Test plan
- [x] New test: `sidebar navigation overlays Guide without unmounting the live shell` — asserts the live shell's key survives a Guide sidebar tap and a return to Home, which fails against the old `Row`+routed implementation.
- [x] `app` package: `flutter test test/core/app` — 20/20 pass, including all pre-existing `tv_router_test.dart` / `tv_shell_test.dart` coverage (deep links, compact-phone back button, TV detection at 960x540).
- [x] `app` package: full `flutter test` — 1029/1032 pass; the 3 failures are `test/asset_gen/brand_assets_golden_test.dart` golden/`setSurfaceSize` failures, confirmed pre-existing on `main` with no changes applied.
- [x] `flutter analyze` — clean (1 pre-existing, unrelated deprecation info in a currency formatter test).
- [ ] On-device: confirm switching Guide → Settings → Home on the Fire TV Stick resumes the exact same channel/position with no re-buffer.