### PR TITLE
feat(feature_coin): prompt for biometrics when a sensitive value is opened

### DIFF
--- a/packages/feature_coin/lib/src/presentation/widgets/record_detail_sheet.dart
+++ b/packages/feature_coin/lib/src/presentation/widgets/record_detail_sheet.dart
@@ -57,14 +57,16 @@ class _RecordDetailSheetState extends ConsumerState<RecordDetailSheet> {
 
   Future<bool> _ensureRecord() async {
     if (!_isVaultUnlocked) {
-      // Fails closed. The vault is browsable while locked, so this path is
-      // reachable by design; the user unlocks from the banner on
-      // VaultGateScreen. Prompting for biometrics inline from here is
-      // tracked separately — it interacts with the sensitive-value cache
-      // clearing below and needs its own tests.
+      // The vault is browsable while locked, so reaching for a sensitive
+      // value is exactly the moment to ask for biometrics rather than
+      // dead-ending the user on "unlock it somewhere else and come back".
       _clearSensitiveCache();
-      _showSnack('Vault is locked - unlock and try again');
-      return false;
+      await ref.read(vaultSessionProvider.notifier).unlock();
+      if (!mounted) return false;
+      if (!_isVaultUnlocked) {
+        _showSnack('Vault is locked - unlock and try again');
+        return false;
+      }
     }
     if (_record != null) return true;
     if (_loadingRecord) return false;
@@ -285,7 +287,7 @@ class _RecordDetailSheetState extends ConsumerState<RecordDetailSheet> {
   @override
   Widget build(BuildContext context) {
     ref.listen<VaultSessionState>(vaultSessionProvider, (_, next) {
-      if (next is! VaultUnlocked) {
+      if (next is! VaultUnlocked && next is! VaultUnlocking) {
         _clearSensitiveCache();
       }
     });

--- a/packages/feature_coin/test/presentation/widgets/record_detail_sheet_test.dart
+++ b/packages/feature_coin/test/presentation/widgets/record_detail_sheet_test.dart
@@ -193,11 +193,17 @@ void main() {
     expect(find.text('1234567890'), findsNothing);
     expect(find.text('•••• •••• ••••'), findsOneWidget);
 
+    // Progressive auth: reaching for the value again re-prompts for
+    // biometrics and, once granted, serves it. The cache clearing asserted
+    // above is the security property; this is the recovery path.
     await tester.tap(find.byTooltip('Copy Account number'));
-    await settleVaultAsync(tester);
+    await settleVaultAsync(tester, until: () => clipboard == '1234567890');
 
-    expect(clipboard, isEmpty);
-    expect(find.text('Vault is locked - unlock and try again'), findsOneWidget);
+    expect(clipboard, '1234567890');
+    // Same teardown as the other successful-copy test: the clipboard's
+    // auto-clear timer and the vault's idle timer must not outlive it.
+    clipboardService.dispose();
+    container.read(vaultSessionProvider.notifier).lock();
   });
 
   testWidgets('denied biometrics keep sensitive values locked away', (


### PR DESCRIPTION
Closes #1128.

## What
The vault has been browsable while locked since #1122, but reaching for a sensitive value dead-ended on *"Vault is locked - unlock and try again"* — the user had to find the Unlock button in the gate banner and come back. Reveal and copy now prompt for biometrics **at the moment the value is requested**, which is what the vault gates on anyway.

## Two things had to be true
1. **The `ref.listen` race (the real bug).** It cleared the cached record on every non-unlocked state — including the transient `VaultUnlocking` that `unlock()` passes through — so an inline unlock wiped the record it was about to display. It now ignores `VaultUnlocking` only. Not a hole: the DEK is still absent during it, `withKey` fails closed, and every other outcome lands on a state that still clears.
2. **Refusal stays fail-closed.** `unlock()` leaves the session in `VaultAuthError`, `_ensureRecord` returns false, nothing is revealed or copied. Covered by *"denied biometrics keep sensitive values locked away"*.

## Why the two earlier attempts were reverted
I believed the implementation was wrong. It wasn't — both failures were **test-harness artifacts**, found by instrumenting rather than guessing:
- the clipboard write is async-queued, so the assertion must wait via `settleVaultAsync(until:)`
- a successful copy plus an unlock leave a **30s auto-clear** and **60s idle** timer pending, which Flutter reports as a test failure

Both now use the same teardown (`clipboardService.dispose()` + `lock()`) the existing successful-copy test already used.

## Test plan
- [x] `feature_coin`: **65 pass**, analyze clean
- [x] Security cases intact: cache cleared on lock, denied biometrics reveal nothing, delete still re-authenticates

🤖 Generated with [Claude Code](https://claude.com/claude-code)