### PR TITLE
feat(playback): wire the MENU key to a context menu (favorite toggle)

### DIFF
--- a/packages/feature_iptv/lib/presentation/widgets/video_player_widget.dart
+++ b/packages/feature_iptv/lib/presentation/widgets/video_player_widget.dart
@@ -92,6 +92,9 @@ class _VideoPlayerWidgetState extends ConsumerState<VideoPlayerWidget> {
   Timer? _adjacentChannelWarmupDebounce;
   String _adjacentChannelWarmupSignature = '';
 
+  // MENU key context menu (AiroTV D-pad design "CONTEXT MENU (MENU key)").
+  bool _showContextMenu = false;
+
   // Netflix-style gesture controls (CV-PLAYER-GESTURES) + lock button.
   bool _isLocked = false;
   double _brightness = 0.5;
@@ -392,6 +395,17 @@ class _VideoPlayerWidgetState extends ConsumerState<VideoPlayerWidget> {
       case TvInputKey.down:
         _goToNextChannel();
         return TvInputResult.handled;
+      case TvInputKey.menu:
+        if (ref.read(streamingStateProvider).asData?.value.currentChannel ==
+            null) {
+          return TvInputResult.notHandled;
+        }
+        setState(() => _showContextMenu = !_showContextMenu);
+        return TvInputResult.handled;
+      case TvInputKey.back:
+        if (!_showContextMenu) return TvInputResult.notHandled;
+        setState(() => _showContextMenu = false);
+        return TvInputResult.handled;
       // Left/right walk the visible controls via normal focus traversal
       // (the buttons are TvFocusable); with the overlay hidden there are
       // no focus candidates (ExcludeFocus), so the keys are inert.
@@ -414,6 +428,26 @@ class _VideoPlayerWidgetState extends ConsumerState<VideoPlayerWidget> {
       default:
         return TvInputResult.notHandled;
     }
+  }
+
+  Future<void> _toggleFavoriteForCurrentChannel() async {
+    final channel = ref.read(streamingStateProvider).asData?.value.currentChannel;
+    if (channel == null) return;
+    final toggle = ref.read(channelFavoriteTogglerProvider);
+    final isNowFavorite = await toggle(channel.id);
+    if (!mounted) return;
+    setState(() => _showContextMenu = false);
+    ScaffoldMessenger.of(context)
+      ..hideCurrentSnackBar()
+      ..showSnackBar(
+        SnackBar(
+          content: Text(
+            isNowFavorite
+                ? '${channel.name} added to favorites'
+                : '${channel.name} removed from favorites',
+          ),
+        ),
+      );
   }
 
   void _showChannelChangeOverlay(String text) {
@@ -653,6 +687,17 @@ class _VideoPlayerWidgetState extends ConsumerState<VideoPlayerWidget> {
                           ),
                         ),
                       ),
+                    ),
+
+                  // Context menu (MENU key) — right-side overlay, matching
+                  // the AiroTV D-pad design's "CONTEXT MENU (MENU key)"
+                  // screen. Only rendered while open; doesn't touch layout
+                  // otherwise.
+                  if (_showContextMenu && state.currentChannel != null)
+                    _ContextMenuOverlay(
+                      channel: state.currentChannel!,
+                      onToggleFavorite: _toggleFavoriteForCurrentChannel,
+                      onClose: () => setState(() => _showContextMenu = false),
                     ),
                 ],
               ),
@@ -1843,6 +1888,144 @@ class _PlayerStepperPillar extends StatelessWidget {
               tooltip: bottomTooltip,
               onPressed: onBottomPressed,
               iconColor: Colors.white,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// MENU-key context menu: right-side overlay panel for actions on the
+/// currently-playing channel. AiroTV D-pad design's "CONTEXT MENU (MENU
+/// key)" screen.
+class _ContextMenuOverlay extends ConsumerWidget {
+  const _ContextMenuOverlay({
+    required this.channel,
+    required this.onToggleFavorite,
+    required this.onClose,
+  });
+
+  final IPTVChannel channel;
+  final VoidCallback onToggleFavorite;
+  final VoidCallback onClose;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final favoriteIds = ref.watch(favoriteChannelIdsProvider).asData?.value;
+    final isFavorite = favoriteIds?.contains(channel.id) ?? false;
+
+    return Positioned(
+      right: 0,
+      top: 0,
+      bottom: 0,
+      width: 280,
+      child: Container(
+        padding: const EdgeInsets.fromLTRB(20, 24, 20, 24),
+        decoration: BoxDecoration(
+          gradient: LinearGradient(
+            begin: Alignment.centerRight,
+            end: Alignment.centerLeft,
+            colors: [
+              Colors.black.withValues(alpha: 0.96),
+              Colors.black.withValues(alpha: 0.0),
+            ],
+          ),
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              'Actions for',
+              style: TextStyle(
+                color: Colors.white.withValues(alpha: 0.6),
+                fontSize: 12,
+                letterSpacing: 1.0,
+              ),
+            ),
+            const SizedBox(height: 4),
+            Text(
+              channel.name,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              style: const TextStyle(
+                color: Colors.white,
+                fontSize: 18,
+                fontWeight: FontWeight.w700,
+              ),
+            ),
+            const SizedBox(height: 20),
+            TvFocusable(
+              key: const ValueKey('context-menu-favorite'),
+              autofocus: true,
+              semanticLabel: isFavorite
+                  ? 'Remove from favorites'
+                  : 'Add to favorites',
+              onSelect: onToggleFavorite,
+              child: _ContextMenuItem(
+                icon: isFavorite ? Icons.favorite : Icons.favorite_border,
+                label: isFavorite
+                    ? 'Remove from favorites'
+                    : 'Add to favorites',
+                onTap: onToggleFavorite,
+              ),
+            ),
+            const SizedBox(height: 8),
+            TvFocusable(
+              key: const ValueKey('context-menu-close'),
+              semanticLabel: 'Close menu',
+              onSelect: onClose,
+              child: _ContextMenuItem(
+                icon: Icons.close,
+                label: 'Close',
+                onTap: onClose,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _ContextMenuItem extends StatelessWidget {
+  const _ContextMenuItem({
+    required this.icon,
+    required this.label,
+    required this.onTap,
+  });
+
+  final IconData icon;
+  final String label;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return InkWell(
+      onTap: onTap,
+      borderRadius: BorderRadius.circular(9),
+      child: Container(
+        height: 42,
+        padding: const EdgeInsets.symmetric(horizontal: 14),
+        decoration: BoxDecoration(
+          color: Colors.white.withValues(alpha: 0.06),
+          borderRadius: BorderRadius.circular(9),
+        ),
+        child: Row(
+          children: [
+            Icon(icon, size: 18, color: Colors.white),
+            const SizedBox(width: 11),
+            Expanded(
+              child: Text(
+                label,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                style: const TextStyle(
+                  color: Colors.white,
+                  fontSize: 15,
+                  fontWeight: FontWeight.w500,
+                ),
+              ),
             ),
           ],
         ),

--- a/packages/feature_iptv/test/presentation/widgets/video_player_widget_context_menu_test.dart
+++ b/packages/feature_iptv/test/presentation/widgets/video_player_widget_context_menu_test.dart
@@ -1,0 +1,101 @@
+import 'package:feature_iptv/feature_iptv.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+// AiroTV D-pad design's "CONTEXT MENU (MENU key)" screen — reachable from
+// the live player via the remote's MENU key, previously entirely unhandled
+// (TvInputKey.menu fell through to the switch's default case).
+void main() {
+  Future<ProviderContainer> pumpPlayer(WidgetTester tester) async {
+    SharedPreferences.setMockInitialValues({});
+    final prefs = await SharedPreferences.getInstance();
+    final container = ProviderContainer(
+      overrides: [
+        sharedPreferencesProvider.overrideWithValue(prefs),
+        streamingStateProvider.overrideWith(
+          (ref) => Stream.value(
+            StreamingState(
+              playbackState: PlaybackState.playing,
+              isLiveStream: true,
+              currentChannel: IPTVChannel(
+                id: 'news-1',
+                name: 'City News Live',
+                streamUrl: 'https://example.com/news.m3u8',
+                group: 'News',
+              ),
+            ),
+          ),
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: const MaterialApp(
+          home: Scaffold(
+            body: SizedBox(
+              width: 960,
+              height: 540,
+              child: VideoPlayerWidget(),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 100));
+    return container;
+  }
+
+  testWidgets('MENU key opens the context menu for the current channel', (
+    tester,
+  ) async {
+    await pumpPlayer(tester);
+
+    expect(find.text('Actions for'), findsNothing);
+
+    await tester.sendKeyEvent(LogicalKeyboardKey.contextMenu);
+    await tester.pump();
+
+    expect(find.text('Actions for'), findsOneWidget);
+    expect(find.text('City News Live'), findsWidgets);
+    expect(find.text('Add to favorites'), findsOneWidget);
+  });
+
+  testWidgets('selecting Add to favorites toggles the favorite and closes '
+      'the menu', (tester) async {
+    final container = await pumpPlayer(tester);
+
+    await tester.sendKeyEvent(LogicalKeyboardKey.contextMenu);
+    await tester.pump();
+
+    await tester.tap(find.text('Add to favorites'));
+    await tester.pump();
+    await tester.pump();
+
+    final ids = await container.read(favoriteChannelIdsProvider.future);
+    expect(ids, contains('news-1'));
+    expect(find.text('Actions for'), findsNothing);
+    expect(find.text('City News Live added to favorites'), findsOneWidget);
+  });
+
+  testWidgets('BACK closes the context menu without navigating away', (
+    tester,
+  ) async {
+    await pumpPlayer(tester);
+
+    await tester.sendKeyEvent(LogicalKeyboardKey.contextMenu);
+    await tester.pump();
+    expect(find.text('Actions for'), findsOneWidget);
+
+    await tester.sendKeyEvent(LogicalKeyboardKey.escape);
+    await tester.pump();
+
+    expect(find.text('Actions for'), findsNothing);
+  });
+}


### PR DESCRIPTION
## Summary
- `TvInputKey.menu` reached the player's key handler (`_handleSurfInput`) and fell through to the switch's `default` case — completely unhandled. The remote's MENU button did nothing while watching a channel.
- Adds a right-side context menu overlay (`_ContextMenuOverlay`), opened/closed by MENU, closed by BACK (previously also unhandled at this level).
- First action wired: toggle the current channel's favorite state. `channelFavoriteTogglerProvider` already existed but was only reachable from the Favorites screen — this gives it a second, more natural entry point from the live player itself.

Matches the AiroTV D-pad Claude Design project's (`02b0b312`) "CONTEXT MENU (MENU key)" screen.

## Test plan
- [x] New test `video_player_widget_context_menu_test.dart`: MENU opens the menu with channel name + Favorite action; selecting it toggles favorite state (verified via `favoriteChannelIdsProvider`), shows confirmation, and closes the menu; BACK closes the menu without navigating away.
- [x] `feature_iptv`: `flutter test` — 632/632 pass.
- [x] `feature_iptv`: `flutter analyze` — clean.