### PR TITLE
feat(playback): replace instant channel-surf on UP/DOWN with browse overlays

### DIFF
--- a/packages/feature_iptv/lib/presentation/widgets/video_player_widget.dart
+++ b/packages/feature_iptv/lib/presentation/widgets/video_player_widget.dart
@@ -95,6 +95,12 @@ class _VideoPlayerWidgetState extends ConsumerState<VideoPlayerWidget> {
   // MENU key context menu (AiroTV D-pad design "CONTEXT MENU (MENU key)").
   bool _showContextMenu = false;
 
+  // UP/DOWN quick-browse overlays (AiroTV D-pad design "MINI GUIDE (UP)" /
+  // "RECENT CHANNELS (DOWN)"). Replaces the previous instant channel-surf
+  // on up/down: browsing now stops on a channel instead of committing to
+  // it, and OK is what actually switches.
+  _TvQuickBrowse? _quickBrowse;
+
   // Netflix-style gesture controls (CV-PLAYER-GESTURES) + lock button.
   bool _isLocked = false;
   double _brightness = 0.5;
@@ -387,13 +393,18 @@ class _VideoPlayerWidgetState extends ConsumerState<VideoPlayerWidget> {
     }
 
     switch (key) {
-      // Channel surfing on up/down is the player's contract (CV-008
-      // UC-002) — it stays active whether or not the controls are shown.
+      // UP opens the Mini Guide, DOWN opens Recent Channels — browsing
+      // stops on a channel instead of committing to it; OK inside the
+      // overlay is what actually switches (AiroTV D-pad design).
       case TvInputKey.up:
-        _goToPreviousChannel();
+        if (ref.read(streamingStateProvider).asData?.value.currentChannel ==
+            null) {
+          return TvInputResult.notHandled;
+        }
+        setState(() => _quickBrowse = _TvQuickBrowse.miniGuide);
         return TvInputResult.handled;
       case TvInputKey.down:
-        _goToNextChannel();
+        setState(() => _quickBrowse = _TvQuickBrowse.recent);
         return TvInputResult.handled;
       case TvInputKey.menu:
         if (ref.read(streamingStateProvider).asData?.value.currentChannel ==
@@ -403,9 +414,15 @@ class _VideoPlayerWidgetState extends ConsumerState<VideoPlayerWidget> {
         setState(() => _showContextMenu = !_showContextMenu);
         return TvInputResult.handled;
       case TvInputKey.back:
-        if (!_showContextMenu) return TvInputResult.notHandled;
-        setState(() => _showContextMenu = false);
-        return TvInputResult.handled;
+        if (_showContextMenu) {
+          setState(() => _showContextMenu = false);
+          return TvInputResult.handled;
+        }
+        if (_quickBrowse != null) {
+          setState(() => _quickBrowse = null);
+          return TvInputResult.handled;
+        }
+        return TvInputResult.notHandled;
       // Left/right walk the visible controls via normal focus traversal
       // (the buttons are TvFocusable); with the overlay hidden there are
       // no focus candidates (ExcludeFocus), so the keys are inert.
@@ -428,6 +445,31 @@ class _VideoPlayerWidgetState extends ConsumerState<VideoPlayerWidget> {
       default:
         return TvInputResult.notHandled;
     }
+  }
+
+  static const _miniGuideWindowSize = 12;
+
+  List<IPTVChannel> _miniGuideChannels(IPTVChannel current) {
+    final all = ref.read(filteredChannelsProvider);
+    if (all.isEmpty) return const [];
+    final currentIndex = all.indexWhere((c) => c.id == current.id);
+    if (currentIndex < 0) {
+      return all.take(_miniGuideWindowSize).toList(growable: false);
+    }
+    final start = (currentIndex - _miniGuideWindowSize ~/ 2).clamp(
+      0,
+      all.length,
+    );
+    final end = (start + _miniGuideWindowSize).clamp(0, all.length);
+    return all.sublist(start, end);
+  }
+
+  void _playChannelFromQuickBrowse(IPTVChannel channel) {
+    final streamingService = ref.read(iptvStreamingServiceProvider);
+    streamingService.playChannel(channel);
+    _showChannelChangeOverlay(channel.name);
+    _scheduleAdjacentChannelWarmupFor(channel);
+    setState(() => _quickBrowse = null);
   }
 
   Future<void> _toggleFavoriteForCurrentChannel() async {
@@ -698,6 +740,36 @@ class _VideoPlayerWidgetState extends ConsumerState<VideoPlayerWidget> {
                       channel: state.currentChannel!,
                       onToggleFavorite: _toggleFavoriteForCurrentChannel,
                       onClose: () => setState(() => _showContextMenu = false),
+                    ),
+
+                  // UP/DOWN quick-browse overlays.
+                  if (_quickBrowse == _TvQuickBrowse.miniGuide &&
+                      state.currentChannel != null)
+                    _QuickBrowseOverlay(
+                      title: 'Mini guide',
+                      channels: _miniGuideChannels(state.currentChannel!),
+                      currentChannelId: state.currentChannel!.id,
+                      onSelected: _playChannelFromQuickBrowse,
+                    ),
+                  if (_quickBrowse == _TvQuickBrowse.recent)
+                    Consumer(
+                      builder: (context, ref, _) {
+                        final recent = ref.watch(
+                          recentlyWatchedChannelsProvider,
+                        );
+                        return recent.when(
+                          data: (channels) => channels.isEmpty
+                              ? const SizedBox.shrink()
+                              : _QuickBrowseOverlay(
+                                  title: 'Recently watched',
+                                  channels: channels,
+                                  currentChannelId: state.currentChannel?.id,
+                                  onSelected: _playChannelFromQuickBrowse,
+                                ),
+                          loading: () => const SizedBox.shrink(),
+                          error: (_, _) => const SizedBox.shrink(),
+                        );
+                      },
                     ),
                 ],
               ),
@@ -1911,6 +1983,127 @@ class _PlayerStepperPillar extends StatelessWidget {
 /// MENU-key context menu: right-side overlay panel for actions on the
 /// currently-playing channel. AiroTV D-pad design's "CONTEXT MENU (MENU
 /// key)" screen.
+enum _TvQuickBrowse { miniGuide, recent }
+
+/// Bottom-docked horizontal browse strip for UP (Mini Guide) and DOWN
+/// (Recent Channels). AiroTV D-pad design: "◀ ▶ browse · OK switch".
+class _QuickBrowseOverlay extends StatelessWidget {
+  const _QuickBrowseOverlay({
+    required this.title,
+    required this.channels,
+    required this.currentChannelId,
+    required this.onSelected,
+  });
+
+  final String title;
+  final List<IPTVChannel> channels;
+  final String? currentChannelId;
+  final ValueChanged<IPTVChannel> onSelected;
+
+  @override
+  Widget build(BuildContext context) {
+    return Positioned(
+      left: 0,
+      right: 0,
+      bottom: 0,
+      child: Container(
+        padding: const EdgeInsets.fromLTRB(24, 20, 24, 20),
+        decoration: BoxDecoration(
+          gradient: LinearGradient(
+            begin: Alignment.bottomCenter,
+            end: Alignment.topCenter,
+            colors: [
+              Colors.black.withValues(alpha: 0.97),
+              Colors.black.withValues(alpha: 0.0),
+            ],
+          ),
+        ),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                Text(
+                  title,
+                  style: const TextStyle(
+                    color: Colors.white,
+                    fontSize: 15,
+                    fontWeight: FontWeight.w700,
+                  ),
+                ),
+                const Text(
+                  '◀ ▶ browse   OK switch',
+                  style: TextStyle(color: Colors.white54, fontSize: 12),
+                ),
+              ],
+            ),
+            const SizedBox(height: 12),
+            SizedBox(
+              height: 96,
+              child: ListView.separated(
+                scrollDirection: Axis.horizontal,
+                itemCount: channels.length,
+                separatorBuilder: (context, index) => const SizedBox(width: 10),
+                itemBuilder: (context, index) {
+                  final channel = channels[index];
+                  final isCurrent = channel.id == currentChannelId;
+                  return TvFocusable(
+                    key: ValueKey('quick-browse-${channel.id}'),
+                    autofocus: isCurrent || index == 0,
+                    semanticLabel: channel.name,
+                    onSelect: () => onSelected(channel),
+                    child: Container(
+                      width: 130,
+                      padding: const EdgeInsets.all(10),
+                      decoration: BoxDecoration(
+                        color: isCurrent
+                            ? Colors.white.withValues(alpha: 0.16)
+                            : Colors.white.withValues(alpha: 0.06),
+                        borderRadius: BorderRadius.circular(10),
+                      ),
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        mainAxisAlignment: MainAxisAlignment.end,
+                        children: [
+                          if (isCurrent)
+                            const Padding(
+                              padding: EdgeInsets.only(bottom: 6),
+                              child: Text(
+                                'ON NOW',
+                                style: TextStyle(
+                                  color: Colors.greenAccent,
+                                  fontSize: 10,
+                                  fontWeight: FontWeight.w700,
+                                  letterSpacing: 0.6,
+                                ),
+                              ),
+                            ),
+                          Text(
+                            channel.name,
+                            maxLines: 1,
+                            overflow: TextOverflow.ellipsis,
+                            style: const TextStyle(
+                              color: Colors.white,
+                              fontSize: 13,
+                              fontWeight: FontWeight.w600,
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                  );
+                },
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
 class _ContextMenuOverlay extends ConsumerWidget {
   const _ContextMenuOverlay({
     required this.channel,

--- a/packages/feature_iptv/test/iptv/presentation/widgets/video_player_widget_test.dart
+++ b/packages/feature_iptv/test/iptv/presentation/widgets/video_player_widget_test.dart
@@ -70,7 +70,9 @@ void main() {
   }
 
   testWidgets(
-    'D-pad down surfs to the next channel while playback stays primary (CV-008 UC-002)',
+    'D-pad up opens the Mini Guide, and selecting a channel there switches '
+    'playback (CV-008 UC-002, superseded by the AiroTV D-pad design: '
+    'UP browses instead of instantly surfing)',
     (tester) async {
       const current = IPTVChannel(
         id: 'news-1',
@@ -127,10 +129,19 @@ void main() {
       await service.playChannel(current);
       await tester.pump();
 
-      await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowUp);
       await tester.pump();
 
+      // Mini Guide is open — browsing, not yet switched.
+      expect(find.text('Mini guide'), findsOneWidget);
       expect(find.text('Stadium Sports'), findsWidgets);
+      expect(service.currentState.currentChannel?.id, 'news-1');
+
+      await tester.tap(find.text('Stadium Sports').first);
+      await tester.pump();
+
+      expect(service.currentState.currentChannel?.id, 'sports-1');
+      expect(find.text('Mini guide'), findsNothing);
 
       // Pending timers (buffer monitor, live-edge detector) must be stopped
       // inside the test body -- the pending-timer check runs before

--- a/packages/feature_iptv/test/presentation/widgets/video_player_widget_recent_channels_test.dart
+++ b/packages/feature_iptv/test/presentation/widgets/video_player_widget_recent_channels_test.dart
@@ -1,0 +1,92 @@
+import 'package:feature_iptv/feature_iptv.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+// AiroTV D-pad design's "RECENT CHANNELS (DOWN)" screen.
+void main() {
+  Future<ProviderContainer> pumpPlayer(
+    WidgetTester tester, {
+    required List<IPTVChannel> recent,
+  }) async {
+    SharedPreferences.setMockInitialValues({});
+    final prefs = await SharedPreferences.getInstance();
+    final container = ProviderContainer(
+      overrides: [
+        sharedPreferencesProvider.overrideWithValue(prefs),
+        recentlyWatchedChannelsProvider.overrideWith((ref) async => recent),
+        streamingStateProvider.overrideWith(
+          (ref) => Stream.value(
+            StreamingState(
+              playbackState: PlaybackState.playing,
+              isLiveStream: true,
+              currentChannel: IPTVChannel(
+                id: 'news-1',
+                name: 'City News Live',
+                streamUrl: 'https://example.com/news.m3u8',
+                group: 'News',
+              ),
+            ),
+          ),
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: const MaterialApp(
+          home: Scaffold(
+            body: SizedBox(width: 960, height: 540, child: VideoPlayerWidget()),
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 100));
+    return container;
+  }
+
+  testWidgets('DOWN opens Recent Channels, and BACK closes it again', (
+    tester,
+  ) async {
+    await pumpPlayer(
+      tester,
+      recent: const [
+        IPTVChannel(
+          id: 'sports-1',
+          name: 'Stadium Sports',
+          streamUrl: 'https://example.com/sports.m3u8',
+          group: 'Sports',
+        ),
+      ],
+    );
+
+    expect(find.text('Recently watched'), findsNothing);
+
+    await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+    await tester.pump();
+    await tester.pump();
+
+    expect(find.text('Recently watched'), findsOneWidget);
+    expect(find.text('Stadium Sports'), findsOneWidget);
+
+    await tester.sendKeyEvent(LogicalKeyboardKey.escape);
+    await tester.pump();
+
+    expect(find.text('Recently watched'), findsNothing);
+  });
+
+  testWidgets('DOWN with no recent channels renders nothing', (tester) async {
+    await pumpPlayer(tester, recent: const []);
+
+    await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+    await tester.pump();
+    await tester.pump();
+
+    expect(find.text('Recently watched'), findsNothing);
+  });
+}


### PR DESCRIPTION
## Summary
- UP and DOWN previously jumped straight to the next/previous channel (`CV-008 UC-002`) — no way to look before committing.
- Per explicit product direction (this reverses a previously deliberate decision, confirmed before implementing): replace instant surf with the AiroTV D-pad design's browse overlays.
  - **UP** opens a **Mini Guide**: a window of up to 12 channels from the current filtered list, centered on the one playing.
  - **DOWN** opens **Recent Channels** (existing `recentlyWatchedChannelsProvider`, previously only reachable from a separate screen).
  - Left/right browses (native Flutter arrow-key focus traversal, same mechanism the rest of the D-pad UI already relies on), OK switches, BACK dismisses without switching.
- `CV-008`'s original test is rewritten, not deleted: it now asserts the new contract (UP opens Mini Guide, selecting a channel there is what actually switches playback) instead of the old instant-surf one.

Matches the AiroTV D-pad Claude Design project's (`02b0b312`) "MINI GUIDE (UP)" and "RECENT CHANNELS (DOWN)" screens.

## Test plan
- [x] Rewrote `D-pad down surfs to the next channel...` → `D-pad up opens the Mini Guide, and selecting a channel there switches playback`.
- [x] New test `video_player_widget_recent_channels_test.dart`: DOWN opens Recent Channels and shows its contents; BACK closes it; DOWN with an empty recent list renders nothing (no dead overlay).
- [x] `feature_iptv`: `flutter test` — 634/634 pass.
- [x] `feature_iptv`: `flutter analyze` — clean.