### PR TITLE
feat(tv): browse-first search overlay, replacing the bare AlertDialog

### DIFF
--- a/packages/feature_iptv/lib/presentation/tv_ux/sections/filter_row.dart
+++ b/packages/feature_iptv/lib/presentation/tv_ux/sections/filter_row.dart
@@ -4,6 +4,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../application/providers/channel_filters_provider.dart';
 import 'filter_dialogs.dart';
+import 'search_overlay.dart';
 
 class FilterRow extends ConsumerWidget {
   const FilterRow({super.key, required this.dimensions});
@@ -20,7 +21,8 @@ class FilterRow extends ConsumerWidget {
         label: filters.search.isEmpty ? 'Search' : filters.search,
         active: filters.search.isNotEmpty,
         icon: Icons.search,
-        onSelected: () => _showSearchDialog(context, notifier, filters.search),
+        onSelected: () =>
+            _showSearchOverlay(context, dimensions, notifier, filters.search),
       ),
       if (dimensions.categories.isNotEmpty)
         _FilterChip(
@@ -118,50 +120,20 @@ class FilterRow extends ConsumerWidget {
   }
 }
 
-Future<void> _showSearchDialog(
+Future<void> _showSearchOverlay(
   BuildContext context,
+  ChannelFilterDimensions dimensions,
   ChannelFiltersNotifier notifier,
   String initialValue,
-) async {
-  var searchText = initialValue;
-  await showDialog<void>(
+) {
+  return showDialog<void>(
     context: context,
-    builder: (dialogContext) {
-      return AlertDialog(
-        title: const Text('Search channels'),
-        content: TextFormField(
-          key: const ValueKey('filter-search-field'),
-          initialValue: initialValue,
-          autofocus: true,
-          decoration: const InputDecoration(
-            prefixIcon: Icon(Icons.search),
-            hintText: 'Search by channel name',
-          ),
-          textInputAction: TextInputAction.search,
-          onChanged: (value) => searchText = value,
-          onFieldSubmitted: (value) {
-            notifier.setSearch(value);
-            Navigator.of(dialogContext).pop();
-          },
-        ),
-        actions: [
-          TextButton(
-            onPressed: () {
-              notifier.setSearch('');
-              Navigator.of(dialogContext).pop();
-            },
-            child: const Text('Clear'),
-          ),
-          FilledButton(
-            onPressed: () {
-              notifier.setSearch(searchText);
-              Navigator.of(dialogContext).pop();
-            },
-            child: const Text('Apply'),
-          ),
-        ],
-      );
-    },
+    useSafeArea: false,
+    builder: (dialogContext) => SearchOverlay(
+      dimensions: dimensions,
+      notifier: notifier,
+      initialQuery: initialValue,
+    ),
   );
 }
 

--- a/packages/feature_iptv/lib/presentation/tv_ux/sections/search_overlay.dart
+++ b/packages/feature_iptv/lib/presentation/tv_ux/sections/search_overlay.dart
@@ -1,0 +1,276 @@
+import 'package:core_ui/core_ui.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../application/providers/channel_filters_provider.dart';
+import '../../../application/providers/local_iptv_search_providers.dart';
+import '../../widgets/local_search_results_panel.dart';
+import 'filter_dialogs.dart';
+
+/// AiroTV D-pad design's "SEARCH — browse first, typing last" screen:
+/// category/country/language tiles up top (a D-pad remote makes typing
+/// expensive; browsing is nearly free), the text field and live results
+/// below for when browsing isn't enough.
+///
+/// Opened from [FilterRow]'s search chip in place of the previous bare
+/// [AlertDialog] + [TextFormField].
+class SearchOverlay extends ConsumerStatefulWidget {
+  const SearchOverlay({
+    super.key,
+    required this.dimensions,
+    required this.notifier,
+    required this.initialQuery,
+  });
+
+  final ChannelFilterDimensions dimensions;
+  final ChannelFiltersNotifier notifier;
+  final String initialQuery;
+
+  @override
+  ConsumerState<SearchOverlay> createState() => _SearchOverlayState();
+}
+
+class _SearchOverlayState extends ConsumerState<SearchOverlay> {
+  late final TextEditingController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = TextEditingController(text: widget.initialQuery);
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      ref.read(localIptvSearchQueryProvider.notifier).state =
+          widget.initialQuery;
+    });
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  void _close() {
+    final query = ref.read(localIptvSearchQueryProvider);
+    widget.notifier.setSearch(query);
+    Navigator.of(context).pop();
+  }
+
+  Future<void> _browseBy({
+    required String title,
+    required List<String> options,
+    required String? selectedValue,
+    required ValueChanged<String> onSelected,
+    required VoidCallback onClear,
+    String Function(String)? optionLabel,
+  }) async {
+    Navigator.of(context).pop();
+    await showFilterOptionDialog(
+      // ignore: use_build_context_synchronously
+      context: context,
+      title: title,
+      options: options,
+      selectedValue: selectedValue,
+      onSelected: onSelected,
+      onClear: onClear,
+      optionLabel: optionLabel,
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final filters = ref.watch(channelFiltersProvider);
+    final dimensions = widget.dimensions;
+
+    return Dialog.fullscreen(
+      backgroundColor: theme.colorScheme.surface,
+      child: SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.fromLTRB(28, 20, 28, 20),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Row(
+                children: [
+                  Expanded(
+                    child: Text(
+                      'Find a channel',
+                      style: theme.textTheme.headlineSmall,
+                    ),
+                  ),
+                  TvFocusable(
+                    semanticLabel: 'Close search',
+                    onSelect: _close,
+                    borderRadius: 20,
+                    child: IconButton(
+                      icon: const Icon(Icons.close),
+                      onPressed: _close,
+                    ),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 4),
+              Text(
+                'Browsing is faster than typing on a remote. Type only if '
+                'you must.',
+                style: theme.textTheme.bodyMedium?.copyWith(
+                  color: theme.colorScheme.onSurfaceVariant,
+                ),
+              ),
+              const SizedBox(height: 18),
+              if (dimensions.categories.isNotEmpty ||
+                  dimensions.countries.isNotEmpty ||
+                  dimensions.languages.isNotEmpty) ...[
+                Text(
+                  'Browse by',
+                  style: theme.textTheme.labelMedium?.copyWith(
+                    color: theme.colorScheme.onSurfaceVariant,
+                    letterSpacing: 1.0,
+                  ),
+                ),
+                const SizedBox(height: 9),
+                SingleChildScrollView(
+                  scrollDirection: Axis.horizontal,
+                  child: Row(
+                    children: [
+                      if (dimensions.categories.isNotEmpty)
+                        _BrowseTile(
+                          key: const ValueKey('search-browse-category'),
+                          icon: Icons.category_outlined,
+                          label: 'Category',
+                          count: '${dimensions.categories.length}',
+                          onSelect: () => _browseBy(
+                            title: 'Category',
+                            options: dimensions.categories.toList(
+                              growable: false,
+                            ),
+                            selectedValue: filters.category,
+                            onSelected: widget.notifier.setCategory,
+                            onClear: () => widget.notifier.setCategory(null),
+                          ),
+                        ),
+                      if (dimensions.countries.isNotEmpty)
+                        _BrowseTile(
+                          key: const ValueKey('search-browse-country'),
+                          icon: Icons.flag_outlined,
+                          label: 'Country',
+                          count: '${dimensions.countries.length}',
+                          onSelect: () => _browseBy(
+                            title: 'Country',
+                            options: dimensions.countries.toList(
+                              growable: false,
+                            ),
+                            selectedValue: filters.country,
+                            onSelected: widget.notifier.setCountry,
+                            onClear: () => widget.notifier.setCountry(null),
+                            optionLabel: countryDisplayLabel,
+                          ),
+                        ),
+                      if (dimensions.languages.isNotEmpty)
+                        _BrowseTile(
+                          key: const ValueKey('search-browse-language'),
+                          icon: Icons.translate_outlined,
+                          label: 'Language',
+                          count: '${dimensions.languages.length}',
+                          onSelect: () => _browseBy(
+                            title: 'Language',
+                            options: dimensions.languages.toList(
+                              growable: false,
+                            ),
+                            selectedValue: filters.language,
+                            onSelected: widget.notifier.setLanguage,
+                            onClear: () => widget.notifier.setLanguage(null),
+                            optionLabel: languageDisplayLabel,
+                          ),
+                        ),
+                    ],
+                  ),
+                ),
+                const SizedBox(height: 20),
+              ],
+              TvFocusable(
+                semanticLabel: 'Search field',
+                borderRadius: 10,
+                onSelect: () {},
+                child: TextField(
+                  key: const ValueKey('search-overlay-field'),
+                  controller: _controller,
+                  autofocus:
+                      dimensions.categories.isEmpty &&
+                      dimensions.countries.isEmpty &&
+                      dimensions.languages.isEmpty,
+                  decoration: const InputDecoration(
+                    prefixIcon: Icon(Icons.search),
+                    hintText: 'Type a channel name',
+                    border: OutlineInputBorder(),
+                  ),
+                  textInputAction: TextInputAction.search,
+                  onChanged: (value) => ref
+                      .read(localIptvSearchQueryProvider.notifier)
+                      .state = value,
+                  onSubmitted: (_) => _close(),
+                ),
+              ),
+              const SizedBox(height: 12),
+              const Expanded(child: LocalSearchResultsPanel()),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _BrowseTile extends StatelessWidget {
+  const _BrowseTile({
+    super.key,
+    required this.icon,
+    required this.label,
+    required this.count,
+    required this.onSelect,
+  });
+
+  final IconData icon;
+  final String label;
+  final String count;
+  final VoidCallback onSelect;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Padding(
+      padding: const EdgeInsets.only(right: 11),
+      child: TvFocusable(
+        semanticLabel: 'Browse by $label',
+        onSelect: onSelect,
+        borderRadius: 11,
+        child: Container(
+          width: 148,
+          height: 96,
+          padding: const EdgeInsets.all(14),
+          decoration: BoxDecoration(
+            color: theme.colorScheme.surfaceContainerHighest,
+            borderRadius: BorderRadius.circular(11),
+          ),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              Icon(icon, size: 22, color: theme.colorScheme.onSurfaceVariant),
+              Text(
+                label,
+                style: theme.textTheme.titleSmall,
+              ),
+              Text(
+                count,
+                style: theme.textTheme.bodySmall?.copyWith(
+                  color: theme.colorScheme.onSurfaceVariant,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/packages/feature_iptv/test/iptv/presentation/tv_ux/filter_row_test.dart
+++ b/packages/feature_iptv/test/iptv/presentation/tv_ux/filter_row_test.dart
@@ -114,10 +114,10 @@ void main() {
     await tester.tap(find.byKey(const ValueKey('filter-chip-search')));
     await tester.pumpAndSettle();
     await tester.enterText(
-      find.byKey(const ValueKey('filter-search-field')),
+      find.byKey(const ValueKey('search-overlay-field')),
       'news',
     );
-    await tester.tap(find.text('Apply'));
+    await tester.tap(find.byIcon(Icons.close));
     await tester.pumpAndSettle();
 
     expect(container.read(channelFiltersProvider).search, 'news');
@@ -125,7 +125,11 @@ void main() {
 
     await tester.tap(find.byKey(const ValueKey('filter-chip-search')));
     await tester.pumpAndSettle();
-    await tester.tap(find.text('Clear'));
+    await tester.enterText(
+      find.byKey(const ValueKey('search-overlay-field')),
+      '',
+    );
+    await tester.tap(find.byIcon(Icons.close));
     await tester.pumpAndSettle();
 
     expect(container.read(channelFiltersProvider).search, '');


### PR DESCRIPTION
## Summary
- The search chip opened a plain `AlertDialog` + `TextFormField` — typing on a D-pad remote is the most expensive input available to a TV user, and the dialog offered no other way in.
- `feature_iptv` already had a fully-built `LocalSearchResultsPanel` (CV-006, channel + guide results, focus-safe) that nothing in the live app actually used — it and its supporting providers were orphaned.
- New `SearchOverlay`: "Browse by" tiles (Category/Country/Language — reusing the exact same `showFilterOptionDialog` the other `FilterRow` chips already open, no new filtering logic) up top, the text field and live `LocalSearchResultsPanel` below for when browsing isn't enough.
- Typing remains fully functional — this doesn't remove capability, it demotes text entry from the *only* path to a fallback, per the design.

Matches the AiroTV D-pad Claude Design project's (`02b0b312`) "SEARCH — browse first, typing last" screen. The design's QR-to-phone typing assist is a separate companion-app surface (needs a hosted page + pairing) and is explicitly out of scope here.

## Test plan
- [x] Rewrote `filter_row_test.dart`'s search test for the new overlay (`search-overlay-field` key, close button instead of Apply/Clear buttons) — same assertions on the underlying `channelFiltersProvider.search` state.
- [x] Confirmed `iptv_screen_test.dart`'s several `'Search channels'` references are an unrelated mobile app-bar search action, not `FilterRow`'s chip — unaffected, still passes.
- [x] `feature_iptv`: `flutter test` — 636/636 pass.
- [x] `feature_iptv`: `flutter analyze` — clean.