### PR TITLE
feat(media): normalize phone-local asset capabilities

### DIFF
--- a/app/android/app/src/main/kotlin/io/airo/app/AiroMediaAssetAnalyzerPlugin.kt
+++ b/app/android/app/src/main/kotlin/io/airo/app/AiroMediaAssetAnalyzerPlugin.kt
@@ -9,8 +9,41 @@ import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
 import java.io.File
 import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.Executor
 import java.util.concurrent.Executors
 import java.util.concurrent.FutureTask
+import java.util.concurrent.atomic.AtomicBoolean
+
+internal class MediaAnalysisJob<T>(
+    analysis: () -> T,
+    private val cancelledResult: () -> T,
+    private val failedResult: (Exception) -> T,
+    private val complete: (T) -> Unit,
+) {
+    private val didComplete = AtomicBoolean(false)
+    private val task = FutureTask {
+        try {
+            deliver(analysis())
+        } catch (error: Exception) {
+            deliver(failedResult(error))
+        }
+    }
+
+    fun enqueueOn(executor: Executor) {
+        executor.execute(task)
+    }
+
+    fun cancel() {
+        task.cancel(true)
+        deliver(cancelledResult())
+    }
+
+    private fun deliver(value: T) {
+        if (didComplete.compareAndSet(false, true)) {
+            complete(value)
+        }
+    }
+}
 
 class AiroMediaAssetAnalyzerPlugin(private val activity: MainActivity) {
     companion object {
@@ -18,7 +51,8 @@ class AiroMediaAssetAnalyzerPlugin(private val activity: MainActivity) {
     }
 
     private val executor = Executors.newSingleThreadExecutor()
-    private val analysisJobs = ConcurrentHashMap<String, FutureTask<Unit>>()
+    private val analysisJobs =
+        ConcurrentHashMap<String, MediaAnalysisJob<Map<String, Any?>>>()
 
     fun register(messenger: BinaryMessenger) {
         MethodChannel(messenger, CHANNEL_NAME).setMethodCallHandler { call, result ->
@@ -34,23 +68,25 @@ class AiroMediaAssetAnalyzerPlugin(private val activity: MainActivity) {
                         )
                         return@setMethodCallHandler
                     }
-                    lateinit var task: FutureTask<Unit>
-                    task = FutureTask {
-                        try {
-                            val payload = analyze(request)
+                    val queuedAt = System.currentTimeMillis()
+                    lateinit var job: MediaAnalysisJob<Map<String, Any?>>
+                    job = MediaAnalysisJob(
+                        analysis = { analyze(request) },
+                        cancelledResult = { queuedCancelledPayload(queuedAt) },
+                        failedResult = { unexpectedFailurePayload(queuedAt) },
+                        complete = { payload ->
+                            analysisJobs.remove(request.analysisId, job)
                             activity.runOnUiThread {
                                 result.success(payload)
                             }
-                        } finally {
-                            analysisJobs.remove(request.analysisId, task)
                         }
-                    }
-                    analysisJobs[request.analysisId] = task
-                    executor.execute(task)
+                    )
+                    analysisJobs[request.analysisId] = job
+                    job.enqueueOn(executor)
                 }
                 "cancel" -> {
                     val analysisId = call.argument<String>("analysisId")
-                    analysisId?.let { analysisJobs.remove(it)?.cancel(true) }
+                    analysisId?.let { analysisJobs.remove(it)?.cancel() }
                     result.success(null)
                 }
                 else -> result.notImplemented()
@@ -236,6 +272,33 @@ class AiroMediaAssetAnalyzerPlugin(private val activity: MainActivity) {
                 "fileSizeBytes" to null,
                 "estimatedBytesRead" to null,
                 "peakMemoryBytes" to maxOf(startingMemoryBytes, residentMemoryBytes()),
+            ),
+        )
+    }
+
+    private fun queuedCancelledPayload(startedAt: Long): Map<String, Any?> {
+        return mapOf(
+            "status" to "cancelled",
+            "diagnostics" to mapOf(
+                "elapsedMs" to (System.currentTimeMillis() - startedAt),
+                "didUseMetadataProbe" to false,
+                "fileSizeBytes" to null,
+                "estimatedBytesRead" to null,
+                "peakMemoryBytes" to null,
+            ),
+        )
+    }
+
+    private fun unexpectedFailurePayload(startedAt: Long): Map<String, Any?> {
+        return mapOf(
+            "status" to "inspection_failed",
+            "failureReason" to "unexpected_native_failure",
+            "diagnostics" to mapOf(
+                "elapsedMs" to (System.currentTimeMillis() - startedAt),
+                "didUseMetadataProbe" to false,
+                "fileSizeBytes" to null,
+                "estimatedBytesRead" to null,
+                "peakMemoryBytes" to null,
             ),
         )
     }

--- a/app/android/app/src/main/kotlin/io/airo/app/AiroMediaAssetAnalyzerPlugin.kt
+++ b/app/android/app/src/main/kotlin/io/airo/app/AiroMediaAssetAnalyzerPlugin.kt
@@ -3,11 +3,14 @@ package io.airo.app
 import android.media.MediaExtractor
 import android.media.MediaFormat
 import android.media.MediaMetadataRetriever
+import android.os.Debug
 import io.flutter.plugin.common.BinaryMessenger
 import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
 import java.io.File
+import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.Executors
+import java.util.concurrent.FutureTask
 
 class AiroMediaAssetAnalyzerPlugin(private val activity: MainActivity) {
     companion object {
@@ -15,6 +18,7 @@ class AiroMediaAssetAnalyzerPlugin(private val activity: MainActivity) {
     }
 
     private val executor = Executors.newSingleThreadExecutor()
+    private val analysisJobs = ConcurrentHashMap<String, FutureTask<Unit>>()
 
     fun register(messenger: BinaryMessenger) {
         MethodChannel(messenger, CHANNEL_NAME).setMethodCallHandler { call, result ->
@@ -30,12 +34,24 @@ class AiroMediaAssetAnalyzerPlugin(private val activity: MainActivity) {
                         )
                         return@setMethodCallHandler
                     }
-                    executor.execute {
-                        val payload = analyze(request)
-                        activity.runOnUiThread {
-                            result.success(payload)
+                    lateinit var task: FutureTask<Unit>
+                    task = FutureTask {
+                        try {
+                            val payload = analyze(request)
+                            activity.runOnUiThread {
+                                result.success(payload)
+                            }
+                        } finally {
+                            analysisJobs.remove(request.analysisId, task)
                         }
                     }
+                    analysisJobs[request.analysisId] = task
+                    executor.execute(task)
+                }
+                "cancel" -> {
+                    val analysisId = call.argument<String>("analysisId")
+                    analysisId?.let { analysisJobs.remove(it)?.cancel(true) }
+                    result.success(null)
                 }
                 else -> result.notImplemented()
             }
@@ -44,6 +60,10 @@ class AiroMediaAssetAnalyzerPlugin(private val activity: MainActivity) {
 
     private fun analyze(request: MediaAssetAnalysisRequest): Map<String, Any?> {
         val startedAt = System.currentTimeMillis()
+        val startingMemoryBytes = residentMemoryBytes()
+        if (Thread.currentThread().isInterrupted) {
+            return cancelledPayload(startedAt, startingMemoryBytes, didUseMetadataProbe = false)
+        }
         val warnings = linkedSetOf<String>()
         val fileSizeBytes = request.fileSizeBytesHint ?: runCatching {
             File(request.filePath).length()
@@ -73,6 +93,9 @@ class AiroMediaAssetAnalyzerPlugin(private val activity: MainActivity) {
             extractor = MediaExtractor()
             extractor.setDataSource(request.filePath)
             for (index in 0 until extractor.trackCount) {
+                if (Thread.currentThread().isInterrupted) {
+                    return cancelledPayload(startedAt, startingMemoryBytes, didUseMetadataProbe = true)
+                }
                 val format = extractor.getTrackFormat(index)
                 val mimeType = format.getString(MediaFormat.KEY_MIME).orEmpty()
                 when {
@@ -142,6 +165,7 @@ class AiroMediaAssetAnalyzerPlugin(private val activity: MainActivity) {
                     "didUseMetadataProbe" to true,
                     "fileSizeBytes" to fileSizeBytes,
                     "estimatedBytesRead" to null,
+                    "peakMemoryBytes" to maxOf(startingMemoryBytes, residentMemoryBytes()),
                 ),
             )
         } finally {
@@ -149,6 +173,9 @@ class AiroMediaAssetAnalyzerPlugin(private val activity: MainActivity) {
             runCatching { extractor?.release() }
         }
 
+        if (Thread.currentThread().isInterrupted) {
+            return cancelledPayload(startedAt, startingMemoryBytes, didUseMetadataProbe = true)
+        }
         if (durationMs == null || durationMs <= 0) {
             warnings.add("duration_unavailable")
             durationMs = null
@@ -191,9 +218,29 @@ class AiroMediaAssetAnalyzerPlugin(private val activity: MainActivity) {
                 "didUseMetadataProbe" to true,
                 "fileSizeBytes" to fileSizeBytes,
                 "estimatedBytesRead" to null,
+                "peakMemoryBytes" to maxOf(startingMemoryBytes, residentMemoryBytes()),
             ),
         )
     }
+
+    private fun cancelledPayload(
+        startedAt: Long,
+        startingMemoryBytes: Long,
+        didUseMetadataProbe: Boolean,
+    ): Map<String, Any?> {
+        return mapOf(
+            "status" to "cancelled",
+            "diagnostics" to mapOf(
+                "elapsedMs" to (System.currentTimeMillis() - startedAt),
+                "didUseMetadataProbe" to didUseMetadataProbe,
+                "fileSizeBytes" to null,
+                "estimatedBytesRead" to null,
+                "peakMemoryBytes" to maxOf(startingMemoryBytes, residentMemoryBytes()),
+            ),
+        )
+    }
+
+    private fun residentMemoryBytes(): Long = Debug.getPss().toLong() * 1024L
 
     private fun videoCodecForMimeType(mimeType: String): String {
         return when (mimeType.lowercase()) {
@@ -244,6 +291,7 @@ class AiroMediaAssetAnalyzerPlugin(private val activity: MainActivity) {
 }
 
 private data class MediaAssetAnalysisRequest(
+    val analysisId: String,
     val assetId: String,
     val filePath: String,
     val fileName: String?,
@@ -253,9 +301,11 @@ private data class MediaAssetAnalysisRequest(
     companion object {
         fun from(arguments: Map<*, *>?): MediaAssetAnalysisRequest? {
             if (arguments == null) return null
+            val analysisId = arguments["analysisId"] as? String ?: return null
             val assetId = arguments["assetId"] as? String ?: return null
             val filePath = arguments["filePath"] as? String ?: return null
             return MediaAssetAnalysisRequest(
+                analysisId = analysisId,
                 assetId = assetId,
                 filePath = filePath,
                 fileName = arguments["fileName"] as? String,

--- a/app/android/app/src/main/kotlin/io/airo/app/MainActivity.kt
+++ b/app/android/app/src/main/kotlin/io/airo/app/MainActivity.kt
@@ -44,6 +44,7 @@ class MainActivity : AudioServiceFragmentActivity() {
     private lateinit var pictureInPicturePlugin: AiroPictureInPicturePlugin
     private lateinit var backgroundAudioPlugin: AiroBackgroundAudioPlugin
     private lateinit var phoneMediaPickerPlugin: PhoneMediaPickerPlugin
+    private lateinit var mediaAssetAnalyzerPlugin: AiroMediaAssetAnalyzerPlugin
 
     override fun shouldDestroyEngineWithHost(): Boolean {
         return false
@@ -120,6 +121,9 @@ class MainActivity : AudioServiceFragmentActivity() {
 
         phoneMediaPickerPlugin = PhoneMediaPickerPlugin(this)
         phoneMediaPickerPlugin.register(flutterEngine.dartExecutor.binaryMessenger)
+
+        mediaAssetAnalyzerPlugin = AiroMediaAssetAnalyzerPlugin(this)
+        mediaAssetAnalyzerPlugin.register(flutterEngine.dartExecutor.binaryMessenger)
     }
 
     override fun onUserLeaveHint() {

--- a/app/android/app/src/test/kotlin/io/airo/app/MediaAnalysisJobTest.kt
+++ b/app/android/app/src/test/kotlin/io/airo/app/MediaAnalysisJobTest.kt
@@ -1,0 +1,93 @@
+package io.airo.app
+
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class MediaAnalysisJobTest {
+    @Test
+    fun cancellingQueuedJobCompletesExactlyOnceWithoutRunningAnalysis() {
+        val executor = Executors.newSingleThreadExecutor()
+        val blockerStarted = CountDownLatch(1)
+        val releaseBlocker = CountDownLatch(1)
+        executor.execute {
+            blockerStarted.countDown()
+            releaseBlocker.await()
+        }
+        assertTrue(blockerStarted.await(2, TimeUnit.SECONDS))
+
+        var analysisRuns = 0
+        val results = mutableListOf<String>()
+        val job = MediaAnalysisJob(
+            analysis = {
+                analysisRuns += 1
+                "complete"
+            },
+            cancelledResult = { "cancelled" },
+            failedResult = { "inspection-failed" },
+            complete = results::add,
+        )
+
+        job.enqueueOn(executor)
+        job.cancel()
+        releaseBlocker.countDown()
+        executor.shutdown()
+        assertTrue(executor.awaitTermination(2, TimeUnit.SECONDS))
+
+        assertEquals(0, analysisRuns)
+        assertEquals(listOf("cancelled"), results)
+    }
+
+    @Test
+    fun cancellingRunningJobReturnsCancelledOnlyOnce() {
+        val executor = Executors.newSingleThreadExecutor()
+        val analysisStarted = CountDownLatch(1)
+        val analysisInterrupted = CountDownLatch(1)
+        val results = mutableListOf<String>()
+        val job = MediaAnalysisJob(
+            analysis = {
+                analysisStarted.countDown()
+                try {
+                    CountDownLatch(1).await()
+                    "complete"
+                } catch (_: InterruptedException) {
+                    analysisInterrupted.countDown()
+                    "cancelled-from-analysis"
+                }
+            },
+            cancelledResult = { "cancelled" },
+            failedResult = { "inspection-failed" },
+            complete = results::add,
+        )
+
+        job.enqueueOn(executor)
+        assertTrue(analysisStarted.await(2, TimeUnit.SECONDS))
+        job.cancel()
+        assertTrue(analysisInterrupted.await(2, TimeUnit.SECONDS))
+        executor.shutdown()
+        assertTrue(executor.awaitTermination(2, TimeUnit.SECONDS))
+
+        assertEquals(listOf("cancelled"), results)
+    }
+
+    @Test
+    fun unexpectedAnalysisFailureCompletesAndDoesNotLeakTheJob() {
+        val executor = Executors.newSingleThreadExecutor()
+        val results = mutableListOf<String>()
+        val job = MediaAnalysisJob(
+            analysis = { error("unexpected native failure") },
+            cancelledResult = { "cancelled" },
+            failedResult = { "inspection-failed" },
+            complete = results::add,
+        )
+
+        job.enqueueOn(executor)
+        executor.shutdown()
+        assertTrue(executor.awaitTermination(2, TimeUnit.SECONDS))
+
+        assertEquals(listOf("inspection-failed"), results)
+    }
+}

--- a/app/integration_test/media_asset_analyzer_device_test.dart
+++ b/app/integration_test/media_asset_analyzer_device_test.dart
@@ -1,0 +1,69 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:platform_media/platform_media.dart';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  const fixturePath = String.fromEnvironment('AIRO_MEDIA_ANALYZER_FIXTURE');
+  const expectLargeFixture = bool.fromEnvironment(
+    'AIRO_MEDIA_ANALYZER_EXPECT_LARGE',
+  );
+
+  testWidgets(
+    'native adapter returns a normalized redacted profile',
+    (_) async {
+      final fixture = File(fixturePath);
+      expect(fixture.existsSync(), isTrue);
+
+      final result = await HostPlatformMediaAssetAnalyzer().analyze(
+        MediaAssetAnalysisRequest(
+          assetId: 'physical-device-fixture',
+          filePath: fixture.path,
+          fileName: fixture.uri.pathSegments.last,
+          fileSizeBytesHint: fixture.lengthSync(),
+        ),
+      );
+
+      expect(result.status, MediaAssetAnalysisStatus.complete);
+      expect(result.profile?.videoTracks, isNotEmpty);
+      expect(result.profile?.duration, isNotNull);
+      expect(result.diagnostics.didUseMetadataProbe, isTrue);
+      expect(result.toString(), isNot(contains(fixture.path)));
+      if (expectLargeFixture) {
+        expect(
+          result.profile?.fileSizeBytes,
+          greaterThan(5 * 1024 * 1024 * 1024),
+        );
+        expect(result.profile?.duration, greaterThan(const Duration(hours: 2)));
+        expect(result.profile?.audioTracks, isNotEmpty);
+        if (result.profile?.subtitleTracks.isEmpty ?? true) {
+          expect(
+            result.profile?.warnings,
+            contains(MediaAssetWarningCode.subtitleTracksUnavailable),
+          );
+        }
+      }
+
+      debugPrint(
+        'AIRO_MEDIA_ANALYZER_EVIDENCE ${jsonEncode({
+          'status': result.status.stableId,
+          'fileSizeBytes': result.profile?.fileSizeBytes,
+          'durationMs': result.profile?.duration?.inMilliseconds,
+          'container': result.profile?.container.stableId,
+          'videoCodecs': [for (final track in result.profile?.videoTracks ?? const []) track.codec.stableId],
+          'audioCodecs': [for (final track in result.profile?.audioTracks ?? const []) track.codec.stableId],
+          'subtitleFormats': [for (final track in result.profile?.subtitleTracks ?? const []) track.format.stableId],
+          'elapsedMs': result.diagnostics.elapsed.inMilliseconds,
+          'estimatedBytesRead': result.diagnostics.estimatedBytesRead,
+          'peakMemoryBytes': result.diagnostics.peakMemoryBytes,
+        })}',
+      );
+    },
+    skip: fixturePath.isEmpty,
+  );
+}

--- a/app/integration_test/media_asset_analyzer_device_test.dart
+++ b/app/integration_test/media_asset_analyzer_device_test.dart
@@ -10,6 +10,12 @@ void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
   const fixturePath = String.fromEnvironment('AIRO_MEDIA_ANALYZER_FIXTURE');
+  const fixtureDirectory = String.fromEnvironment(
+    'AIRO_MEDIA_ANALYZER_FIXTURE_DIRECTORY',
+  );
+  const imageSubtitleFixturePath = String.fromEnvironment(
+    'AIRO_MEDIA_ANALYZER_IMAGE_SUBTITLE_FIXTURE',
+  );
   const expectLargeFixture = bool.fromEnvironment(
     'AIRO_MEDIA_ANALYZER_EXPECT_LARGE',
   );
@@ -65,5 +71,152 @@ void main() {
       );
     },
     skip: fixturePath.isEmpty,
+  );
+
+  testWidgets(
+    'native adapter preserves deterministic fixture capabilities',
+    (_) async {
+      const fixtures = [
+        (
+          fileName: 'mp4-h264-aac.mp4',
+          container: MediaAssetContainer.mp4,
+          videoCodec: MediaVideoCodec.h264,
+          audioCodecs: [MediaAudioCodec.aac],
+          audioUnavailable: false,
+          dynamicRange: MediaDynamicRangeProfile.unknown,
+        ),
+        (
+          fileName: 'webm-vp9-opus.webm',
+          container: MediaAssetContainer.webm,
+          videoCodec: MediaVideoCodec.vp9,
+          audioCodecs: [MediaAudioCodec.opus],
+          audioUnavailable: false,
+          dynamicRange: MediaDynamicRangeProfile.unknown,
+        ),
+        (
+          fileName: 'mkv-hevc-main10-hdr10-dts.mkv',
+          container: MediaAssetContainer.mkv,
+          videoCodec: MediaVideoCodec.hevc,
+          audioCodecs: <MediaAudioCodec>[],
+          audioUnavailable: true,
+          dynamicRange: MediaDynamicRangeProfile.hdr10,
+        ),
+        (
+          fileName: 'mkv-multi-audio-text-subtitles.mkv',
+          container: MediaAssetContainer.mkv,
+          videoCodec: MediaVideoCodec.h264,
+          audioCodecs: [MediaAudioCodec.aac, MediaAudioCodec.aac],
+          audioUnavailable: false,
+          dynamicRange: MediaDynamicRangeProfile.unknown,
+        ),
+      ];
+
+      for (final expectation in fixtures) {
+        final fixture = File('$fixtureDirectory/${expectation.fileName}');
+        expect(fixture.existsSync(), isTrue, reason: expectation.fileName);
+
+        final result = await HostPlatformMediaAssetAnalyzer().analyze(
+          MediaAssetAnalysisRequest(
+            assetId: 'deterministic-fixture',
+            filePath: fixture.path,
+            fileName: expectation.fileName,
+            fileSizeBytesHint: fixture.lengthSync(),
+          ),
+        );
+        final profile = result.profile;
+
+        expect(
+          result.status,
+          MediaAssetAnalysisStatus.complete,
+          reason: expectation.fileName,
+        );
+        expect(
+          profile?.container,
+          expectation.container,
+          reason: expectation.fileName,
+        );
+        expect(
+          profile?.videoTracks.single.codec,
+          expectation.videoCodec,
+          reason: expectation.fileName,
+        );
+        expect(
+          [for (final track in profile?.audioTracks ?? const []) track.codec],
+          expectation.audioCodecs,
+          reason: expectation.fileName,
+        );
+        expect(
+          profile?.warnings.contains(
+            MediaAssetWarningCode.audioTracksUnavailable,
+          ),
+          expectation.audioUnavailable,
+          reason: expectation.fileName,
+        );
+        expect(
+          profile?.videoTracks.single.dynamicRange,
+          expectation.dynamicRange,
+          reason: expectation.fileName,
+        );
+        expect(
+          result.toString(),
+          isNot(contains(fixture.path)),
+          reason: expectation.fileName,
+        );
+
+        debugPrint(
+          'AIRO_MEDIA_ANALYZER_FIXTURE_EVIDENCE ${jsonEncode({
+            'fixture': expectation.fileName,
+            'status': result.status.stableId,
+            'container': profile?.container.stableId,
+            'videoCodecs': [for (final track in profile?.videoTracks ?? const []) track.codec.stableId],
+            'audioCodecs': [for (final track in profile?.audioTracks ?? const []) track.codec.stableId],
+            'subtitleFormats': [for (final track in profile?.subtitleTracks ?? const []) track.format.stableId],
+            'dynamicRanges': [for (final track in profile?.videoTracks ?? const []) track.dynamicRange.stableId],
+            'warnings': [for (final warning in profile?.warnings ?? const []) warning.stableId],
+          })}',
+        );
+      }
+    },
+    skip: fixtureDirectory.isEmpty,
+  );
+
+  testWidgets(
+    'native adapter exposes image subtitles or explicit uncertainty',
+    (_) async {
+      final fixture = File(imageSubtitleFixturePath);
+      expect(fixture.existsSync(), isTrue);
+
+      final result = await HostPlatformMediaAssetAnalyzer().analyze(
+        MediaAssetAnalysisRequest(
+          assetId: 'image-subtitle-fixture',
+          filePath: fixture.path,
+          fileName: 'image-subtitle.mkv',
+          fileSizeBytesHint: fixture.lengthSync(),
+        ),
+      );
+      final subtitleFormats = [
+        for (final track in result.profile?.subtitleTracks ?? const [])
+          track.format,
+      ];
+
+      expect(result.status, MediaAssetAnalysisStatus.complete);
+      if (subtitleFormats.isEmpty) {
+        expect(
+          result.profile?.warnings,
+          contains(MediaAssetWarningCode.subtitleTracksUnavailable),
+        );
+      } else {
+        expect(subtitleFormats, contains(MediaSubtitleFormat.vobSub));
+      }
+      expect(result.toString(), isNot(contains(fixture.path)));
+      debugPrint(
+        'AIRO_MEDIA_ANALYZER_IMAGE_SUBTITLE_EVIDENCE ${jsonEncode({
+          'status': result.status.stableId,
+          'subtitleFormats': [for (final format in subtitleFormats) format.stableId],
+          'warnings': [for (final warning in result.profile?.warnings ?? const []) warning.stableId],
+        })}',
+      );
+    },
+    skip: imageSubtitleFixturePath.isEmpty,
   );
 }

--- a/app/ios/Runner/AiroMediaAssetAnalyzerPlugin.swift
+++ b/app/ios/Runner/AiroMediaAssetAnalyzerPlugin.swift
@@ -1,11 +1,13 @@
 import AVFoundation
 import CoreMedia
 import CoreVideo
+import Darwin
 import Flutter
 import Foundation
 
 final class AiroMediaAssetAnalyzerPlugin: NSObject {
   static let channelName = "com.airo.media_asset_analyzer"
+  private var analysisTasks = [String: Task<Void, Never>]()
 
   func register(with messenger: FlutterBinaryMessenger) {
     let channel = FlutterMethodChannel(name: Self.channelName, binaryMessenger: messenger)
@@ -15,6 +17,15 @@ final class AiroMediaAssetAnalyzerPlugin: NSObject {
   }
 
   private func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
+    if call.method == "cancel" {
+      let arguments = call.arguments as? [String: Any]
+      let analysisId = arguments?["analysisId"] as? String
+      if let analysisId {
+        analysisTasks.removeValue(forKey: analysisId)?.cancel()
+      }
+      result(nil)
+      return
+    }
     guard call.method == "analyze" else {
       result(FlutterMethodNotImplemented)
       return
@@ -32,16 +43,27 @@ final class AiroMediaAssetAnalyzerPlugin: NSObject {
       return
     }
 
-    Task {
-      let payload = await analyze(request)
+    let task = Task { [weak self] in
+      guard let self else { return }
+      let payload = await self.analyze(request)
       await MainActor.run {
+        self.analysisTasks.removeValue(forKey: request.analysisId)
         result(payload)
       }
     }
+    analysisTasks[request.analysisId] = task
   }
 
   private func analyze(_ request: MediaAssetAnalysisRequest) async -> [String: Any] {
     let startedAt = Date()
+    let startingMemoryBytes = residentMemoryBytes()
+    if Task.isCancelled {
+      return cancelledPayload(
+        startedAt: startedAt,
+        startingMemoryBytes: startingMemoryBytes,
+        didUseMetadataProbe: false
+      )
+    }
     var warnings = OrderedStringSet()
     let container = request.containerStableId()
     let fileSizeBytes = request.fileSizeBytesHint ?? fileSize(request.filePath)
@@ -61,6 +83,13 @@ final class AiroMediaAssetAnalyzerPlugin: NSObject {
       var subtitleTracks = [[String: Any]]()
 
       for (index, track) in tracks.enumerated() {
+        if Task.isCancelled {
+          return cancelledPayload(
+            startedAt: startedAt,
+            startingMemoryBytes: startingMemoryBytes,
+            didUseMetadataProbe: true
+          )
+        }
         let mediaType = track.mediaType
         let estimatedDataRate = Int((try? await track.load(.estimatedDataRate)).map { $0.rounded() } ?? 0)
         if estimatedDataRate > 0 {
@@ -159,9 +188,17 @@ final class AiroMediaAssetAnalyzerPlugin: NSObject {
           "didUseMetadataProbe": true,
           "fileSizeBytes": fileSizeBytes as Any,
           "estimatedBytesRead": NSNull(),
+          "peakMemoryBytes": max(startingMemoryBytes, residentMemoryBytes()),
         ],
       ]
     } catch {
+      if Task.isCancelled {
+        return cancelledPayload(
+          startedAt: startedAt,
+          startingMemoryBytes: startingMemoryBytes,
+          didUseMetadataProbe: true
+        )
+      }
       warnings.append("metadata_probe_failed")
       return [
         "status": "inspection_failed",
@@ -183,9 +220,45 @@ final class AiroMediaAssetAnalyzerPlugin: NSObject {
           "didUseMetadataProbe": true,
           "fileSizeBytes": fileSizeBytes as Any,
           "estimatedBytesRead": NSNull(),
+          "peakMemoryBytes": max(startingMemoryBytes, residentMemoryBytes()),
         ],
       ]
     }
+  }
+
+  private func cancelledPayload(
+    startedAt: Date,
+    startingMemoryBytes: Int,
+    didUseMetadataProbe: Bool
+  ) -> [String: Any] {
+    [
+      "status": "cancelled",
+      "diagnostics": [
+        "elapsedMs": Int(Date().timeIntervalSince(startedAt) * 1000.0),
+        "didUseMetadataProbe": didUseMetadataProbe,
+        "fileSizeBytes": NSNull(),
+        "estimatedBytesRead": NSNull(),
+        "peakMemoryBytes": max(startingMemoryBytes, residentMemoryBytes()),
+      ],
+    ]
+  }
+
+  private func residentMemoryBytes() -> Int {
+    var info = mach_task_basic_info()
+    var count = mach_msg_type_number_t(
+      MemoryLayout<mach_task_basic_info>.size / MemoryLayout<integer_t>.size
+    )
+    let status = withUnsafeMutablePointer(to: &info) { infoPointer in
+      infoPointer.withMemoryRebound(to: integer_t.self, capacity: Int(count)) {
+        task_info(
+          mach_task_self_,
+          task_flavor_t(MACH_TASK_BASIC_INFO),
+          $0,
+          &count
+        )
+      }
+    }
+    return status == KERN_SUCCESS ? Int(info.resident_size) : 0
   }
 
   private func fileSize(_ filePath: String) -> Int? {
@@ -296,6 +369,7 @@ final class AiroMediaAssetAnalyzerPlugin: NSObject {
 }
 
 private struct MediaAssetAnalysisRequest {
+  let analysisId: String
   let assetId: String
   let filePath: String
   let fileName: String?
@@ -303,11 +377,13 @@ private struct MediaAssetAnalysisRequest {
   let mimeTypeHint: String?
 
   init?(arguments: [String: Any]) {
-    guard let assetId = arguments["assetId"] as? String,
+    guard let analysisId = arguments["analysisId"] as? String,
+          let assetId = arguments["assetId"] as? String,
           let filePath = arguments["filePath"] as? String
     else {
       return nil
     }
+    self.analysisId = analysisId
     self.assetId = assetId
     self.filePath = filePath
     self.fileName = arguments["fileName"] as? String

--- a/app/ios/Runner/AiroMediaAssetAnalyzerPlugin.swift
+++ b/app/ios/Runner/AiroMediaAssetAnalyzerPlugin.swift
@@ -276,44 +276,18 @@ final class AiroMediaAssetAnalyzerPlugin: NSObject {
     guard let description else {
       return "unknown"
     }
-    switch CMFormatDescriptionGetMediaSubType(description) {
-    case kCMVideoCodecType_H264:
-      return "h264"
-    case kCMVideoCodecType_HEVC:
-      return "hevc"
-    case kCMVideoCodecType_AV1:
-      return "av1"
-    case kCMVideoCodecType_VP9:
-      return "vp9"
-    case makeFourCC("dvh1"), makeFourCC("dvhe"):
-      return "hevc"
-    default:
-      return "unknown"
-    }
+    return MediaAssetFormatNormalizer.videoCodecStableId(
+      subtype: CMFormatDescriptionGetMediaSubType(description)
+    )
   }
 
   private func audioCodecStableId(_ description: CMFormatDescription?) -> String {
     guard let description else {
       return "unknown"
     }
-    switch CMFormatDescriptionGetMediaSubType(description) {
-    case kAudioFormatMPEG4AAC, kAudioFormatMPEG4AAC_HE:
-      return "aac"
-    case kAudioFormatAC3:
-      return "ac3"
-    case kAudioFormatEnhancedAC3:
-      return "eac3"
-    case makeFourCC("dtsc"), makeFourCC("dtsh"), makeFourCC("dtsl"):
-      return "dts"
-    case kAudioFormatOpus:
-      return "opus"
-    case kAudioFormatMPEGLayer3:
-      return "mp3"
-    case makeFourCC("mlpa"):
-      return "truehd"
-    default:
-      return "unknown"
-    }
+    return MediaAssetFormatNormalizer.audioCodecStableId(
+      subtype: CMFormatDescriptionGetMediaSubType(description)
+    )
   }
 
   private func audioChannelCount(_ description: CMFormatDescription?) -> Int? {
@@ -341,30 +315,18 @@ final class AiroMediaAssetAnalyzerPlugin: NSObject {
   }
 
   private func dynamicRangeStableId(_ description: CMFormatDescription?, codec: String) -> String {
-    if codec == "hevc",
-       let description,
-       let extensions = CMFormatDescriptionGetExtensions(description) as? [CFString: Any],
-       let transferFunction = extensions[kCVImageBufferTransferFunctionKey]
-    {
-      let transferFunctionValue = String(describing: transferFunction)
-      switch transferFunctionValue {
-      case String(describing: kCVImageBufferTransferFunction_SMPTE_ST_2084_PQ):
-        return "hdr10"
-      case String(describing: kCVImageBufferTransferFunction_ITU_R_2100_HLG):
-        return "hlg"
-      default:
-        break
-      }
+    let subtype = description.map(CMFormatDescriptionGetMediaSubType)
+    let extensions = description.flatMap {
+      CMFormatDescriptionGetExtensions($0) as? [CFString: Any]
     }
-    if codec == "hevc",
-       let description
-    {
-      let subtype = CMFormatDescriptionGetMediaSubType(description)
-      if subtype == makeFourCC("dvh1") || subtype == makeFourCC("dvhe") {
-        return "dolby_vision"
-      }
+    let transferFunction = extensions?[kCVImageBufferTransferFunctionKey].map {
+      String(describing: $0)
     }
-    return "unknown"
+    return MediaAssetFormatNormalizer.dynamicRangeStableId(
+      codec: codec,
+      subtype: subtype,
+      transferFunction: transferFunction
+    )
   }
 }
 
@@ -392,12 +354,83 @@ private struct MediaAssetAnalysisRequest {
   }
 
   func containerStableId() -> String {
-    let mimeType = mimeTypeHint?.lowercased() ?? ""
-    if mimeType.contains("matroska") || mimeType.contains("x-mkv") { return "mkv" }
-    if mimeType.contains("webm") { return "webm" }
-    if mimeType.contains("mp4") { return "mp4" }
-    if mimeType.contains("quicktime") { return "mov" }
-    if mimeType.contains("mpegts") || mimeType.contains("mp2t") { return "ts" }
+    MediaAssetFormatNormalizer.containerStableId(
+      mimeType: mimeTypeHint,
+      fileName: fileName
+    )
+  }
+}
+
+enum MediaAssetFormatNormalizer {
+  static func videoCodecStableId(subtype: FourCharCode) -> String {
+    switch subtype {
+    case kCMVideoCodecType_H264:
+      return "h264"
+    case kCMVideoCodecType_HEVC:
+      return "hevc"
+    case kCMVideoCodecType_AV1:
+      return "av1"
+    case kCMVideoCodecType_VP9:
+      return "vp9"
+    case makeFourCC("dvh1"), makeFourCC("dvhe"):
+      return "hevc"
+    default:
+      return "unknown"
+    }
+  }
+
+  static func audioCodecStableId(subtype: FourCharCode) -> String {
+    switch subtype {
+    case kAudioFormatMPEG4AAC, kAudioFormatMPEG4AAC_HE:
+      return "aac"
+    case kAudioFormatAC3:
+      return "ac3"
+    case kAudioFormatEnhancedAC3:
+      return "eac3"
+    case makeFourCC("dtsc"), makeFourCC("dtsh"), makeFourCC("dtsl"):
+      return "dts"
+    case kAudioFormatOpus:
+      return "opus"
+    case kAudioFormatMPEGLayer3:
+      return "mp3"
+    case makeFourCC("mlpa"):
+      return "truehd"
+    default:
+      return "unknown"
+    }
+  }
+
+  static func dynamicRangeStableId(
+    codec: String,
+    subtype: FourCharCode?,
+    transferFunction: String?
+  ) -> String {
+    guard codec == "hevc" else { return "unknown" }
+    switch transferFunction {
+    case String(describing: kCVImageBufferTransferFunction_SMPTE_ST_2084_PQ):
+      return "hdr10"
+    case String(describing: kCVImageBufferTransferFunction_ITU_R_2100_HLG):
+      return "hlg"
+    default:
+      break
+    }
+    if subtype == makeFourCC("dvh1") || subtype == makeFourCC("dvhe") {
+      return "dolby_vision"
+    }
+    return "unknown"
+  }
+
+  static func containerStableId(mimeType: String?, fileName: String?) -> String {
+    let normalizedMimeType = mimeType?.lowercased() ?? ""
+    if normalizedMimeType.contains("matroska") || normalizedMimeType.contains("x-mkv") {
+      return "mkv"
+    }
+    if normalizedMimeType.contains("webm") { return "webm" }
+    if normalizedMimeType.contains("mp4") { return "mp4" }
+    if normalizedMimeType.contains("quicktime") { return "mov" }
+    if normalizedMimeType.contains("mpegts") || normalizedMimeType.contains("mp2t") {
+      return "ts"
+    }
 
     let ext = (fileName as NSString?)?.pathExtension.lowercased() ?? ""
     switch ext {
@@ -426,6 +459,6 @@ private struct OrderedStringSet {
   }
 }
 
-private func makeFourCC(_ string: String) -> FourCharCode {
+func makeFourCC(_ string: String) -> FourCharCode {
   string.utf8.reduce(0) { ($0 << 8) + FourCharCode($1) }
 }

--- a/app/ios/RunnerTests/RunnerTests.swift
+++ b/app/ios/RunnerTests/RunnerTests.swift
@@ -1,12 +1,81 @@
+import AudioToolbox
+import CoreMedia
+import CoreVideo
 import Flutter
 import UIKit
 import XCTest
+@testable import Runner
 
 class RunnerTests: XCTestCase {
-
-  func testExample() {
-    // If you add code to the Runner application, consider adding tests here.
-    // See https://developer.apple.com/documentation/xctest for more information about using XCTest.
+  func testMediaAnalyzerNormalizesSupportedAndUnknownCodecs() {
+    XCTAssertEqual(
+      MediaAssetFormatNormalizer.videoCodecStableId(subtype: kCMVideoCodecType_H264),
+      "h264"
+    )
+    XCTAssertEqual(
+      MediaAssetFormatNormalizer.videoCodecStableId(subtype: kCMVideoCodecType_HEVC),
+      "hevc"
+    )
+    XCTAssertEqual(
+      MediaAssetFormatNormalizer.audioCodecStableId(subtype: kAudioFormatMPEG4AAC),
+      "aac"
+    )
+    XCTAssertEqual(
+      MediaAssetFormatNormalizer.audioCodecStableId(subtype: makeFourCC("dtsc")),
+      "dts"
+    )
+    XCTAssertEqual(
+      MediaAssetFormatNormalizer.videoCodecStableId(subtype: makeFourCC("zzzz")),
+      "unknown"
+    )
+    XCTAssertEqual(
+      MediaAssetFormatNormalizer.audioCodecStableId(subtype: makeFourCC("zzzz")),
+      "unknown"
+    )
   }
 
+  func testMediaAnalyzerNormalizesHdrAndExplicitUnknownTransferFunctions() {
+    XCTAssertEqual(
+      MediaAssetFormatNormalizer.dynamicRangeStableId(
+        codec: "hevc",
+        subtype: kCMVideoCodecType_HEVC,
+        transferFunction: String(
+          describing: kCVImageBufferTransferFunction_SMPTE_ST_2084_PQ
+        )
+      ),
+      "hdr10"
+    )
+    XCTAssertEqual(
+      MediaAssetFormatNormalizer.dynamicRangeStableId(
+        codec: "hevc",
+        subtype: kCMVideoCodecType_HEVC,
+        transferFunction: "not-exposed"
+      ),
+      "unknown"
+    )
+  }
+
+  func testMediaAnalyzerNormalizesContainerHintsWithoutOpeningTheAsset() {
+    XCTAssertEqual(
+      MediaAssetFormatNormalizer.containerStableId(
+        mimeType: "video/mp4",
+        fileName: "opaque.bin"
+      ),
+      "mp4"
+    )
+    XCTAssertEqual(
+      MediaAssetFormatNormalizer.containerStableId(
+        mimeType: nil,
+        fileName: "movie.mkv"
+      ),
+      "mkv"
+    )
+    XCTAssertEqual(
+      MediaAssetFormatNormalizer.containerStableId(
+        mimeType: nil,
+        fileName: "opaque"
+      ),
+      "unknown"
+    )
+  }
 }

--- a/app/lib/features/iptv/phone_media_local_picker.dart
+++ b/app/lib/features/iptv/phone_media_local_picker.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter/services.dart';
+import 'package:platform_media/platform_media.dart';
 import 'package:platform_player/platform_player.dart';
 
 const _androidPhoneMediaPickerChannel = MethodChannel(
@@ -17,6 +18,7 @@ Future<PhoneLocalMediaItem?> pickPhoneLocalMediaForTv() async {
   if (Platform.isAndroid) {
     return pickAndroidPhoneLocalMediaForTv(
       channel: _androidPhoneMediaPickerChannel,
+      analyzer: DefaultLocalMediaAssetAnalyzer(),
     );
   }
 
@@ -24,16 +26,26 @@ Future<PhoneLocalMediaItem?> pickPhoneLocalMediaForTv() async {
   if (file == null) return null;
   final path = file.path;
   if (path == null) return null;
+  final analysis = await DefaultLocalMediaAssetAnalyzer().analyze(
+    MediaAssetAnalysisRequest(
+      assetId: file.identifier ?? file.name,
+      filePath: path,
+      fileName: file.name,
+      fileSizeBytesHint: file.size > 0 ? file.size : null,
+    ),
+  );
 
-  return PhoneLocalMediaItem(
+  return _phoneLocalMediaItem(
     filePath: path,
     title: file.name,
-    container: (file.extension ?? '').toLowerCase(),
+    fallbackContainer: (file.extension ?? '').toLowerCase(),
+    analysis: analysis,
   );
 }
 
 Future<PhoneLocalMediaItem?> pickAndroidPhoneLocalMediaForTv({
   required MethodChannel channel,
+  LocalMediaAssetAnalyzer? analyzer,
 }) async {
   try {
     final selection = await channel.invokeMapMethod<String, Object?>(
@@ -55,11 +67,21 @@ Future<PhoneLocalMediaItem?> pickAndroidPhoneLocalMediaForTv({
       }
       return null;
     }
+    final analysis = await (analyzer ?? DefaultLocalMediaAssetAnalyzer())
+        .analyze(
+          MediaAssetAnalysisRequest(
+            assetId: token,
+            filePath: filePath,
+            fileName: title,
+            fileSizeBytesHint: (selection['size'] as num?)?.round(),
+          ),
+        );
 
-    return PhoneLocalMediaItem(
+    return _phoneLocalMediaItem(
       filePath: filePath,
       title: title,
-      container: _extensionOf(title),
+      fallbackContainer: _extensionOf(title),
+      analysis: analysis,
       sourceLease: _AndroidPhoneMediaSourceLease(
         channel: channel,
         token: token,
@@ -68,6 +90,38 @@ Future<PhoneLocalMediaItem?> pickAndroidPhoneLocalMediaForTv({
   } on PlatformException {
     return null;
   }
+}
+
+PhoneLocalMediaItem _phoneLocalMediaItem({
+  required String filePath,
+  required String title,
+  required String fallbackContainer,
+  required MediaAssetAnalysisResult analysis,
+  PhoneMediaSourceLease? sourceLease,
+}) {
+  final profile = analysis.profile;
+  final analyzedContainer = profile?.container;
+  final primaryVideo = profile?.videoTracks.firstOrNull;
+  final primaryAudio = profile?.audioTracks.firstOrNull;
+  return PhoneLocalMediaItem(
+    filePath: filePath,
+    title: title,
+    container:
+        analyzedContainer == null ||
+            analyzedContainer == MediaAssetContainer.unknown
+        ? fallbackContainer
+        : analyzedContainer.stableId,
+    sourceLease: sourceLease,
+    videoCodec:
+        primaryVideo == null || primaryVideo.codec == MediaVideoCodec.unknown
+        ? null
+        : primaryVideo.codec.stableId,
+    audioCodec:
+        primaryAudio == null || primaryAudio.codec == MediaAudioCodec.unknown
+        ? null
+        : primaryAudio.codec.stableId,
+    duration: profile?.duration,
+  );
 }
 
 String _extensionOf(String fileName) {

--- a/app/test/features/iptv/phone_media_local_picker_test.dart
+++ b/app/test/features/iptv/phone_media_local_picker_test.dart
@@ -1,6 +1,7 @@
 import 'package:airo_app/features/iptv/phone_media_local_picker.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:platform_media/platform_media.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -14,9 +15,42 @@ void main() {
   });
 
   test(
-    'maps Android descriptor selection without reading file bytes',
+    'analyzes Android descriptor selection without reading file bytes',
     () async {
       final calls = <MethodCall>[];
+      final analyzer = _RecordingAnalyzer(
+        const MediaAssetAnalysisResult(
+          status: MediaAssetAnalysisStatus.complete,
+          profile: MediaAssetProfile(
+            assetId: 'lease-1',
+            container: MediaAssetContainer.mkv,
+            duration: Duration(hours: 2, minutes: 10, seconds: 7),
+            videoTracks: [
+              MediaVideoTrackProfile(
+                id: 'video-0',
+                codec: MediaVideoCodec.hevc,
+                dimensions: MediaAssetDimensions(width: 3840, height: 2160),
+                dynamicRange: MediaDynamicRangeProfile.hdr10,
+                confidence: MediaTrackConfidence.exact,
+              ),
+            ],
+            audioTracks: [
+              MediaAudioTrackProfile(
+                id: 'audio-1',
+                codec: MediaAudioCodec.dts,
+                confidence: MediaTrackConfidence.exact,
+              ),
+            ],
+            subtitleTracks: [],
+            warnings: [],
+          ),
+          diagnostics: MediaAssetAnalysisDiagnostics(
+            elapsed: Duration(milliseconds: 120),
+            didUseMetadataProbe: true,
+            fileSizeBytes: 6101307309,
+          ),
+        ),
+      );
       messenger.setMockMethodCallHandler(channel, (call) async {
         calls.add(call);
         if (call.method == 'pickVideo') {
@@ -30,12 +64,26 @@ void main() {
         return null;
       });
 
-      final item = await pickAndroidPhoneLocalMediaForTv(channel: channel);
+      final item = await pickAndroidPhoneLocalMediaForTv(
+        channel: channel,
+        analyzer: analyzer,
+      );
 
       expect(item, isNotNull);
       expect(item!.filePath, '/proc/self/fd/42');
       expect(item.title, 'Feature.FILM.MKV');
       expect(item.container, 'mkv');
+      expect(item.videoCodec, 'hevc');
+      expect(item.audioCodec, 'dts');
+      expect(item.duration, const Duration(hours: 2, minutes: 10, seconds: 7));
+      expect(analyzer.requests, [
+        const MediaAssetAnalysisRequest(
+          assetId: 'lease-1',
+          filePath: '/proc/self/fd/42',
+          fileName: 'Feature.FILM.MKV',
+          fileSizeBytesHint: 6101307309,
+        ),
+      ]);
       expect(calls.map((call) => call.method), ['pickVideo']);
     },
   );
@@ -59,7 +107,10 @@ void main() {
       }
       return null;
     });
-    final item = await pickAndroidPhoneLocalMediaForTv(channel: channel);
+    final item = await pickAndroidPhoneLocalMediaForTv(
+      channel: channel,
+      analyzer: const _UnsupportedAnalyzer(),
+    );
 
     await item!.sourceLease!.release();
     await item.sourceLease!.release();
@@ -81,4 +132,36 @@ void main() {
     expect(await pickAndroidPhoneLocalMediaForTv(channel: channel), isNull);
     expect(calls.map((call) => call.method), ['pickVideo', 'release']);
   });
+}
+
+class _RecordingAnalyzer implements LocalMediaAssetAnalyzer {
+  _RecordingAnalyzer(this.result);
+
+  final MediaAssetAnalysisResult result;
+  final List<MediaAssetAnalysisRequest> requests = [];
+
+  @override
+  Future<MediaAssetAnalysisResult> analyze(
+    MediaAssetAnalysisRequest request,
+  ) async {
+    requests.add(request);
+    return result;
+  }
+}
+
+class _UnsupportedAnalyzer implements LocalMediaAssetAnalyzer {
+  const _UnsupportedAnalyzer();
+
+  @override
+  Future<MediaAssetAnalysisResult> analyze(
+    MediaAssetAnalysisRequest request,
+  ) async {
+    return const MediaAssetAnalysisResult(
+      status: MediaAssetAnalysisStatus.unsupportedInspection,
+      diagnostics: MediaAssetAnalysisDiagnostics(
+        elapsed: Duration.zero,
+        didUseMetadataProbe: false,
+      ),
+    );
+  }
 }

--- a/app/tool/generate_media_analyzer_fixtures.sh
+++ b/app/tool/generate_media_analyzer_fixtures.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+  echo "usage: $0 OUTPUT_DIRECTORY" >&2
+  exit 64
+fi
+
+command -v ffmpeg >/dev/null || {
+  echo "ffmpeg is required to generate media analyzer fixtures" >&2
+  exit 69
+}
+
+output_directory=$1
+mkdir -p "$output_directory"
+temporary_directory=$(mktemp -d)
+trap 'rm -rf "$temporary_directory"' EXIT
+
+cat >"$temporary_directory/english.srt" <<'EOF'
+1
+00:00:00,000 --> 00:00:01,500
+Deterministic English subtitle
+EOF
+
+cat >"$temporary_directory/spanish.ass" <<'EOF'
+[Script Info]
+ScriptType: v4.00+
+PlayResX: 320
+PlayResY: 180
+
+[V4+ Styles]
+Format: Name, Fontname, Fontsize, PrimaryColour, SecondaryColour, OutlineColour, BackColour, Bold, Italic, Underline, StrikeOut, ScaleX, ScaleY, Spacing, Angle, BorderStyle, Outline, Shadow, Alignment, MarginL, MarginR, MarginV, Encoding
+Style: Default,Arial,16,&H00FFFFFF,&H000000FF,&H00000000,&H00000000,0,0,0,0,100,100,0,0,1,1,0,2,10,10,10,1
+
+[Events]
+Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text
+Dialogue: 0,0:00:00.00,0:00:01.50,Default,,0,0,0,,Subtítulo determinista
+EOF
+
+common_video=(-f lavfi -i color=c=blue:s=320x180:r=24:d=2)
+
+ffmpeg -hide_banner -loglevel error -y \
+  "${common_video[@]}" \
+  -f lavfi -i sine=frequency=440:sample_rate=48000:duration=2 \
+  -map 0:v:0 -map 1:a:0 \
+  -c:v libx264 -preset ultrafast -pix_fmt yuv420p \
+  -c:a aac -b:a 96k -movflags +faststart \
+  "$output_directory/mp4-h264-aac.mp4"
+
+ffmpeg -hide_banner -loglevel error -y \
+  "${common_video[@]}" \
+  -f lavfi -i sine=frequency=550:sample_rate=48000:duration=2 \
+  -map 0:v:0 -map 1:a:0 \
+  -c:v libvpx-vp9 -deadline realtime -cpu-used 8 -pix_fmt yuv420p \
+  -c:a libopus -b:a 64k \
+  "$output_directory/webm-vp9-opus.webm"
+
+ffmpeg -hide_banner -loglevel error -y \
+  "${common_video[@]}" \
+  -f lavfi -i sine=frequency=660:sample_rate=48000:duration=2 \
+  -map 0:v:0 -map 1:a:0 \
+  -vf 'setparams=color_primaries=bt2020:color_trc=smpte2084:colorspace=bt2020nc' \
+  -c:v libx265 -preset ultrafast -pix_fmt yuv420p10le \
+  -color_primaries bt2020 -color_trc smpte2084 -colorspace bt2020nc \
+  -x265-params 'repeat-headers=1:colorprim=bt2020:transfer=smpte2084:colormatrix=bt2020nc' \
+  -c:a dca -strict -2 -b:a 768k \
+  "$output_directory/mkv-hevc-main10-hdr10-dts.mkv"
+
+ffmpeg -hide_banner -loglevel error -y \
+  "${common_video[@]}" \
+  -f lavfi -i sine=frequency=440:sample_rate=48000:duration=2 \
+  -f lavfi -i sine=frequency=880:sample_rate=48000:duration=2 \
+  -i "$temporary_directory/english.srt" \
+  -i "$temporary_directory/spanish.ass" \
+  -map 0:v:0 -map 1:a:0 -map 2:a:0 -map 3:s:0 -map 4:s:0 \
+  -c:v libx264 -preset ultrafast -pix_fmt yuv420p \
+  -c:a aac -b:a 96k -c:s copy \
+  -metadata:s:a:0 language=eng -metadata:s:a:1 language=spa \
+  -metadata:s:s:0 language=eng -metadata:s:s:1 language=spa \
+  -disposition:a:0 default -disposition:a:1 0 \
+  -disposition:s:0 default -disposition:s:1 forced \
+  "$output_directory/mkv-multi-audio-text-subtitles.mkv"
+
+(
+  cd "$output_directory"
+  shasum -a 256 \
+    mp4-h264-aac.mp4 \
+    webm-vp9-opus.webm \
+    mkv-hevc-main10-hdr10-dts.mkv \
+    mkv-multi-audio-text-subtitles.mkv \
+    > SHA256SUMS
+)

--- a/packages/platform_media/lib/platform_media.dart
+++ b/packages/platform_media/lib/platform_media.dart
@@ -2,6 +2,7 @@ library;
 
 export "src/media_capability_models.dart";
 export "src/media_asset_profile_models.dart";
+export "src/media_asset_profile_codec.dart";
 export "src/media_error_taxonomy_models.dart";
 export "src/local_media_asset_analyzer.dart";
 export "src/platform_media_logger.dart";

--- a/packages/platform_media/lib/src/local_media_asset_analyzer.dart
+++ b/packages/platform_media/lib/src/local_media_asset_analyzer.dart
@@ -4,6 +4,7 @@ import 'package:flutter/foundation.dart' show visibleForTesting;
 import 'package:flutter/services.dart';
 import 'package:video_player/video_player.dart';
 
+import 'media_asset_profile_codec.dart';
 import 'media_asset_profile_models.dart';
 
 abstract class LocalMediaAssetAnalyzer {
@@ -40,6 +41,7 @@ class HostPlatformMediaAssetAnalyzer implements LocalMediaAssetAnalyzer {
   static MethodChannel _defaultChannel = const MethodChannel(
     'com.airo.media_asset_analyzer',
   );
+  static int _nextAnalysisId = 1;
 
   final MethodChannel _channel;
 
@@ -47,18 +49,50 @@ class HostPlatformMediaAssetAnalyzer implements LocalMediaAssetAnalyzer {
   Future<MediaAssetAnalysisResult> analyze(
     MediaAssetAnalysisRequest request,
   ) async {
+    final cancellation = request.cancellationToken;
+    if (cancellation?.isCancelled ?? false) return _cancelledResult();
+    final analysisId = 'analysis-${_nextAnalysisId++}';
     try {
-      final raw = await _channel.invokeMapMethod<String, Object?>('analyze', {
+      final invocation = _channel.invokeMapMethod<String, Object?>('analyze', {
+        'analysisId': analysisId,
         'assetId': request.assetId,
         'filePath': request.filePath,
         'fileName': request.fileName,
         'fileSizeBytesHint': request.fileSizeBytesHint,
         'mimeTypeHint': request.mimeTypeHint,
       });
+      final raw = cancellation == null
+          ? await invocation
+          : await Future.any<Map<String, Object?>?>([
+              invocation,
+              cancellation.whenCancelled.then((_) async {
+                await _channel.invokeMethod<void>('cancel', {
+                  'analysisId': analysisId,
+                });
+                return <String, Object?>{
+                  'status': MediaAssetAnalysisStatus.cancelled.stableId,
+                  'diagnostics': <String, Object?>{
+                    'elapsedMs': 0,
+                    'didUseMetadataProbe': true,
+                  },
+                };
+              }),
+            ]);
       if (raw == null) {
         return _unsupportedResult();
       }
-      return _parseResult(raw);
+      try {
+        return _parseResult(raw);
+      } on UnsupportedMediaAssetProfileVersion {
+        return const MediaAssetAnalysisResult(
+          status: MediaAssetAnalysisStatus.unsupportedInspection,
+          failureReason: 'unsupported_profile_version',
+          diagnostics: MediaAssetAnalysisDiagnostics(
+            elapsed: Duration.zero,
+            didUseMetadataProbe: false,
+          ),
+        );
+      }
     } on MissingPluginException {
       return _unsupportedResult();
     } on PlatformException catch (error) {
@@ -83,6 +117,16 @@ class HostPlatformMediaAssetAnalyzer implements LocalMediaAssetAnalyzer {
     );
   }
 
+  MediaAssetAnalysisResult _cancelledResult() {
+    return const MediaAssetAnalysisResult(
+      status: MediaAssetAnalysisStatus.cancelled,
+      diagnostics: MediaAssetAnalysisDiagnostics(
+        elapsed: Duration.zero,
+        didUseMetadataProbe: false,
+      ),
+    );
+  }
+
   MediaAssetAnalysisResult _parseResult(Map<String, Object?> raw) {
     return MediaAssetAnalysisResult(
       status: _analysisStatusFromStableId(raw['status'] as String?),
@@ -100,98 +144,13 @@ class HostPlatformMediaAssetAnalyzer implements LocalMediaAssetAnalyzer {
       didUseMetadataProbe: raw['didUseMetadataProbe'] as bool? ?? false,
       fileSizeBytes: (raw['fileSizeBytes'] as num?)?.round(),
       estimatedBytesRead: (raw['estimatedBytesRead'] as num?)?.round(),
+      peakMemoryBytes: (raw['peakMemoryBytes'] as num?)?.round(),
     );
   }
 
   MediaAssetProfile? _parseProfile(Map<Object?, Object?>? raw) {
     if (raw == null) return null;
-    return MediaAssetProfile(
-      schemaVersion:
-          raw['schemaVersion'] as String? ?? kMediaAssetProfileSchemaVersion,
-      assetId: raw['assetId'] as String? ?? 'unknown',
-      container: _containerFromStableId(raw['container'] as String?),
-      duration: _durationFromMs(raw['durationMs']),
-      fileSizeBytes: (raw['fileSizeBytes'] as num?)?.round(),
-      overallBitrate: (raw['overallBitrate'] as num?)?.round(),
-      videoTracks: _parseVideoTracks(raw['videoTracks']),
-      audioTracks: _parseAudioTracks(raw['audioTracks']),
-      subtitleTracks: _parseSubtitleTracks(raw['subtitleTracks']),
-      warnings: _parseWarnings(raw['warnings']),
-    );
-  }
-
-  List<MediaVideoTrackProfile> _parseVideoTracks(Object? rawTracks) {
-    final tracks = rawTracks as List<Object?>? ?? const [];
-    return tracks
-        .whereType<Map<Object?, Object?>>()
-        .map(
-          (raw) => MediaVideoTrackProfile(
-            id: raw['id'] as String? ?? 'video-unknown',
-            codec: _videoCodecFromStableId(raw['codec'] as String?),
-            bitrate: (raw['bitrate'] as num?)?.round(),
-            dynamicRange: _dynamicRangeFromStableId(
-              raw['dynamicRange'] as String?,
-            ),
-            confidence: _confidenceFromStableId(raw['confidence'] as String?),
-            dimensions: MediaAssetDimensions(
-              width: (raw['width'] as num?)?.round() ?? 0,
-              height: (raw['height'] as num?)?.round() ?? 0,
-            ),
-          ),
-        )
-        .toList(growable: false);
-  }
-
-  List<MediaAudioTrackProfile> _parseAudioTracks(Object? rawTracks) {
-    final tracks = rawTracks as List<Object?>? ?? const [];
-    return tracks
-        .whereType<Map<Object?, Object?>>()
-        .map(
-          (raw) => MediaAudioTrackProfile(
-            id: raw['id'] as String? ?? 'audio-unknown',
-            codec: _audioCodecFromStableId(raw['codec'] as String?),
-            confidence: _confidenceFromStableId(raw['confidence'] as String?),
-            language: raw['language'] as String?,
-            label: raw['label'] as String?,
-            channelCount: (raw['channelCount'] as num?)?.round(),
-            isDefault: raw['isDefault'] as bool? ?? false,
-            isCommentary: raw['isCommentary'] as bool? ?? false,
-          ),
-        )
-        .toList(growable: false);
-  }
-
-  List<MediaSubtitleTrackProfile> _parseSubtitleTracks(Object? rawTracks) {
-    final tracks = rawTracks as List<Object?>? ?? const [];
-    return tracks
-        .whereType<Map<Object?, Object?>>()
-        .map(
-          (raw) => MediaSubtitleTrackProfile(
-            id: raw['id'] as String? ?? 'subtitle-unknown',
-            format: _subtitleFormatFromStableId(raw['format'] as String?),
-            confidence: _confidenceFromStableId(raw['confidence'] as String?),
-            language: raw['language'] as String?,
-            label: raw['label'] as String?,
-            isDefault: raw['isDefault'] as bool? ?? false,
-            isForced: raw['isForced'] as bool? ?? false,
-            isCommentary: raw['isCommentary'] as bool? ?? false,
-          ),
-        )
-        .toList(growable: false);
-  }
-
-  List<MediaAssetWarningCode> _parseWarnings(Object? rawWarnings) {
-    final warnings = rawWarnings as List<Object?>? ?? const [];
-    return warnings
-        .whereType<String>()
-        .map(_warningCodeFromStableId)
-        .toList(growable: false);
-  }
-
-  Duration? _durationFromMs(Object? raw) {
-    final milliseconds = (raw as num?)?.round();
-    if (milliseconds == null || milliseconds <= 0) return null;
-    return Duration(milliseconds: milliseconds);
+    return MediaAssetProfileCodec.decode(raw);
   }
 
   @visibleForTesting
@@ -208,6 +167,9 @@ class VideoPlayerLocalMediaAssetAnalyzer implements LocalMediaAssetAnalyzer {
     MediaAssetAnalysisRequest request,
   ) async {
     final startedAt = DateTime.now();
+    if (request.cancellationToken?.isCancelled ?? false) {
+      return _cancelledResult(startedAt, didUseMetadataProbe: false);
+    }
     final warnings = <MediaAssetWarningCode>[];
     final container = _resolveContainer(request, warnings);
 
@@ -232,6 +194,9 @@ class VideoPlayerLocalMediaAssetAnalyzer implements LocalMediaAssetAnalyzer {
     try {
       didUseMetadataProbe = true;
       await controller.initialize();
+      if (request.cancellationToken?.isCancelled ?? false) {
+        return _cancelledResult(startedAt, didUseMetadataProbe: true);
+      }
       duration = controller.value.duration;
       final size = controller.value.size;
       dimensions = MediaAssetDimensions(
@@ -305,6 +270,19 @@ class VideoPlayerLocalMediaAssetAnalyzer implements LocalMediaAssetAnalyzer {
     );
   }
 
+  MediaAssetAnalysisResult _cancelledResult(
+    DateTime startedAt, {
+    required bool didUseMetadataProbe,
+  }) {
+    return MediaAssetAnalysisResult(
+      status: MediaAssetAnalysisStatus.cancelled,
+      diagnostics: MediaAssetAnalysisDiagnostics(
+        elapsed: DateTime.now().difference(startedAt),
+        didUseMetadataProbe: didUseMetadataProbe,
+      ),
+    );
+  }
+
   MediaAssetContainer _resolveContainer(
     MediaAssetAnalysisRequest request,
     List<MediaAssetWarningCode> warnings,
@@ -334,54 +312,5 @@ MediaAssetAnalysisStatus _analysisStatusFromStableId(String? stableId) {
   return MediaAssetAnalysisStatus.values.firstWhere(
     (value) => value.stableId == stableId,
     orElse: () => MediaAssetAnalysisStatus.inspectionFailed,
-  );
-}
-
-MediaAssetContainer _containerFromStableId(String? stableId) {
-  return MediaAssetContainer.values.firstWhere(
-    (value) => value.stableId == stableId,
-    orElse: () => MediaAssetContainer.unknown,
-  );
-}
-
-MediaTrackConfidence _confidenceFromStableId(String? stableId) {
-  return MediaTrackConfidence.values.firstWhere(
-    (value) => value.stableId == stableId,
-    orElse: () => MediaTrackConfidence.unknown,
-  );
-}
-
-MediaVideoCodec _videoCodecFromStableId(String? stableId) {
-  return MediaVideoCodec.values.firstWhere(
-    (value) => value.stableId == stableId,
-    orElse: () => MediaVideoCodec.unknown,
-  );
-}
-
-MediaAudioCodec _audioCodecFromStableId(String? stableId) {
-  return MediaAudioCodec.values.firstWhere(
-    (value) => value.stableId == stableId,
-    orElse: () => MediaAudioCodec.unknown,
-  );
-}
-
-MediaSubtitleFormat _subtitleFormatFromStableId(String? stableId) {
-  return MediaSubtitleFormat.values.firstWhere(
-    (value) => value.stableId == stableId,
-    orElse: () => MediaSubtitleFormat.unknown,
-  );
-}
-
-MediaDynamicRangeProfile _dynamicRangeFromStableId(String? stableId) {
-  return MediaDynamicRangeProfile.values.firstWhere(
-    (value) => value.stableId == stableId,
-    orElse: () => MediaDynamicRangeProfile.unknown,
-  );
-}
-
-MediaAssetWarningCode _warningCodeFromStableId(String? stableId) {
-  return MediaAssetWarningCode.values.firstWhere(
-    (value) => value.stableId == stableId,
-    orElse: () => MediaAssetWarningCode.metadataProbeFailed,
   );
 }

--- a/packages/platform_media/lib/src/media_asset_profile_codec.dart
+++ b/packages/platform_media/lib/src/media_asset_profile_codec.dart
@@ -1,0 +1,216 @@
+import 'media_asset_profile_models.dart';
+
+/// Stable wire codec for the platform-neutral media inspection contract.
+abstract final class MediaAssetProfileCodec {
+  static Map<String, Object?> encode(MediaAssetProfile profile) {
+    return <String, Object?>{
+      'schemaVersion': profile.schemaVersion,
+      'assetId': profile.assetId,
+      'container': profile.container.stableId,
+      'durationMs': profile.duration?.inMilliseconds,
+      'fileSizeBytes': profile.fileSizeBytes,
+      'overallBitrate': profile.overallBitrate,
+      'videoTracks': [
+        for (final track in profile.videoTracks)
+          <String, Object?>{
+            'id': track.id,
+            'codec': track.codec.stableId,
+            'width': track.dimensions.width,
+            'height': track.dimensions.height,
+            'bitrate': track.bitrate,
+            'dynamicRange': track.dynamicRange.stableId,
+            'confidence': track.confidence.stableId,
+          },
+      ],
+      'audioTracks': [
+        for (final track in profile.audioTracks)
+          <String, Object?>{
+            'id': track.id,
+            'codec': track.codec.stableId,
+            'confidence': track.confidence.stableId,
+            'language': track.language,
+            'label': track.label,
+            'channelCount': track.channelCount,
+            'isDefault': track.isDefault,
+            'isCommentary': track.isCommentary,
+          },
+      ],
+      'subtitleTracks': [
+        for (final track in profile.subtitleTracks)
+          <String, Object?>{
+            'id': track.id,
+            'format': track.format.stableId,
+            'confidence': track.confidence.stableId,
+            'language': track.language,
+            'label': track.label,
+            'isDefault': track.isDefault,
+            'isForced': track.isForced,
+            'isCommentary': track.isCommentary,
+          },
+      ],
+      'warnings': [for (final warning in profile.warnings) warning.stableId],
+    };
+  }
+
+  static MediaAssetProfile decode(Map<Object?, Object?> raw) {
+    final schemaVersion =
+        raw['schemaVersion'] as String? ?? kMediaAssetProfileSchemaVersion;
+    if (schemaVersion != kMediaAssetProfileSchemaVersion) {
+      throw UnsupportedMediaAssetProfileVersion(
+        receivedVersion: schemaVersion,
+        supportedVersion: kMediaAssetProfileSchemaVersion,
+      );
+    }
+    return MediaAssetProfile(
+      schemaVersion: schemaVersion,
+      assetId: raw['assetId'] as String? ?? 'unknown',
+      container: _enumByStableId(
+        MediaAssetContainer.values,
+        raw['container'] as String?,
+        MediaAssetContainer.unknown,
+      ),
+      duration: _durationFromMs(raw['durationMs']),
+      fileSizeBytes: (raw['fileSizeBytes'] as num?)?.round(),
+      overallBitrate: (raw['overallBitrate'] as num?)?.round(),
+      videoTracks: _decodeVideoTracks(raw['videoTracks']),
+      audioTracks: _decodeAudioTracks(raw['audioTracks']),
+      subtitleTracks: _decodeSubtitleTracks(raw['subtitleTracks']),
+      warnings: _decodeWarnings(raw['warnings']),
+    );
+  }
+
+  static List<MediaVideoTrackProfile> _decodeVideoTracks(Object? rawTracks) {
+    return _maps(rawTracks)
+        .map(
+          (raw) => MediaVideoTrackProfile(
+            id: raw['id'] as String? ?? 'video-unknown',
+            codec: _enumByStableId(
+              MediaVideoCodec.values,
+              raw['codec'] as String?,
+              MediaVideoCodec.unknown,
+            ),
+            dimensions: MediaAssetDimensions(
+              width: (raw['width'] as num?)?.round() ?? 0,
+              height: (raw['height'] as num?)?.round() ?? 0,
+            ),
+            bitrate: (raw['bitrate'] as num?)?.round(),
+            dynamicRange: _enumByStableId(
+              MediaDynamicRangeProfile.values,
+              raw['dynamicRange'] as String?,
+              MediaDynamicRangeProfile.unknown,
+            ),
+            confidence: _enumByStableId(
+              MediaTrackConfidence.values,
+              raw['confidence'] as String?,
+              MediaTrackConfidence.unknown,
+            ),
+          ),
+        )
+        .toList(growable: false);
+  }
+
+  static List<MediaAudioTrackProfile> _decodeAudioTracks(Object? rawTracks) {
+    return _maps(rawTracks)
+        .map(
+          (raw) => MediaAudioTrackProfile(
+            id: raw['id'] as String? ?? 'audio-unknown',
+            codec: _enumByStableId(
+              MediaAudioCodec.values,
+              raw['codec'] as String?,
+              MediaAudioCodec.unknown,
+            ),
+            confidence: _enumByStableId(
+              MediaTrackConfidence.values,
+              raw['confidence'] as String?,
+              MediaTrackConfidence.unknown,
+            ),
+            language: raw['language'] as String?,
+            label: raw['label'] as String?,
+            channelCount: (raw['channelCount'] as num?)?.round(),
+            isDefault: raw['isDefault'] as bool? ?? false,
+            isCommentary: raw['isCommentary'] as bool? ?? false,
+          ),
+        )
+        .toList(growable: false);
+  }
+
+  static List<MediaSubtitleTrackProfile> _decodeSubtitleTracks(
+    Object? rawTracks,
+  ) {
+    return _maps(rawTracks)
+        .map(
+          (raw) => MediaSubtitleTrackProfile(
+            id: raw['id'] as String? ?? 'subtitle-unknown',
+            format: _enumByStableId(
+              MediaSubtitleFormat.values,
+              raw['format'] as String?,
+              MediaSubtitleFormat.unknown,
+            ),
+            confidence: _enumByStableId(
+              MediaTrackConfidence.values,
+              raw['confidence'] as String?,
+              MediaTrackConfidence.unknown,
+            ),
+            language: raw['language'] as String?,
+            label: raw['label'] as String?,
+            isDefault: raw['isDefault'] as bool? ?? false,
+            isForced: raw['isForced'] as bool? ?? false,
+            isCommentary: raw['isCommentary'] as bool? ?? false,
+          ),
+        )
+        .toList(growable: false);
+  }
+
+  static List<MediaAssetWarningCode> _decodeWarnings(Object? rawWarnings) {
+    return (rawWarnings as List<Object?>? ?? const [])
+        .whereType<String>()
+        .map(
+          (value) => _enumByStableId(
+            MediaAssetWarningCode.values,
+            value,
+            MediaAssetWarningCode.metadataProbeFailed,
+          ),
+        )
+        .toList(growable: false);
+  }
+
+  static Iterable<Map<Object?, Object?>> _maps(Object? raw) {
+    return (raw as List<Object?>? ?? const [])
+        .whereType<Map<Object?, Object?>>();
+  }
+
+  static Duration? _durationFromMs(Object? raw) {
+    final milliseconds = (raw as num?)?.round();
+    if (milliseconds == null || milliseconds <= 0) return null;
+    return Duration(milliseconds: milliseconds);
+  }
+
+  static T _enumByStableId<T>(
+    Iterable<T> values,
+    String? stableId,
+    T fallback,
+  ) {
+    for (final value in values) {
+      if ((value as dynamic).stableId == stableId) return value;
+    }
+    return fallback;
+  }
+}
+
+class UnsupportedMediaAssetProfileVersion implements Exception {
+  const UnsupportedMediaAssetProfileVersion({
+    required this.receivedVersion,
+    required this.supportedVersion,
+  });
+
+  final String receivedVersion;
+  final String supportedVersion;
+
+  @override
+  String toString() {
+    return 'UnsupportedMediaAssetProfileVersion('
+        'receivedVersion: $receivedVersion, '
+        'supportedVersion: $supportedVersion'
+        ')';
+  }
+}

--- a/packages/platform_media/lib/src/media_asset_profile_models.dart
+++ b/packages/platform_media/lib/src/media_asset_profile_models.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:equatable/equatable.dart';
 
 const String kMediaAssetProfileSchemaVersion = '1.0.0';
@@ -305,12 +307,14 @@ class MediaAssetAnalysisDiagnostics extends Equatable {
     required this.didUseMetadataProbe,
     this.fileSizeBytes,
     this.estimatedBytesRead,
+    this.peakMemoryBytes,
   });
 
   final Duration elapsed;
   final bool didUseMetadataProbe;
   final int? fileSizeBytes;
   final int? estimatedBytesRead;
+  final int? peakMemoryBytes;
 
   @override
   List<Object?> get props => [
@@ -318,6 +322,7 @@ class MediaAssetAnalysisDiagnostics extends Equatable {
     didUseMetadataProbe,
     fileSizeBytes,
     estimatedBytesRead,
+    peakMemoryBytes,
   ];
 }
 
@@ -328,6 +333,7 @@ class MediaAssetAnalysisRequest extends Equatable {
     this.fileName,
     this.fileSizeBytesHint,
     this.mimeTypeHint,
+    this.cancellationToken,
   });
 
   final String assetId;
@@ -335,6 +341,7 @@ class MediaAssetAnalysisRequest extends Equatable {
   final String? fileName;
   final int? fileSizeBytesHint;
   final String? mimeTypeHint;
+  final MediaAssetAnalysisCancellationToken? cancellationToken;
 
   String get fileExtension {
     final name = fileName;
@@ -362,6 +369,18 @@ class MediaAssetAnalysisRequest extends Equatable {
     fileSizeBytesHint,
     mimeTypeHint,
   ];
+}
+
+/// Cooperative cancellation shared by Dart and native media inspectors.
+class MediaAssetAnalysisCancellationToken {
+  final Completer<void> _cancelled = Completer<void>();
+
+  bool get isCancelled => _cancelled.isCompleted;
+  Future<void> get whenCancelled => _cancelled.future;
+
+  void cancel() {
+    if (!_cancelled.isCompleted) _cancelled.complete();
+  }
 }
 
 class MediaAssetAnalysisResult extends Equatable {

--- a/packages/platform_media/test/host_platform_media_asset_analyzer_test.dart
+++ b/packages/platform_media/test/host_platform_media_asset_analyzer_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:platform_media/platform_media.dart';
@@ -68,6 +70,7 @@ void main() {
           'elapsedMs': 120,
           'didUseMetadataProbe': true,
           'fileSizeBytes': 6100000000,
+          'peakMemoryBytes': 73400320,
         },
       };
     });
@@ -96,6 +99,7 @@ void main() {
       result.profile?.warnings,
       contains(MediaAssetWarningCode.overallBitrateEstimated),
     );
+    expect(result.diagnostics.peakMemoryBytes, 73400320);
   });
 
   test(
@@ -134,6 +138,81 @@ void main() {
 
       expect(result.status, MediaAssetAnalysisStatus.partial);
       expect(result.profile?.assetId, 'asset-fallback');
+    },
+  );
+
+  test(
+    'host analyzer fails closed for an unsupported profile version',
+    () async {
+      messenger.setMockMethodCallHandler(channel, (_) async {
+        return {
+          'status': 'complete',
+          'profile': {
+            'schemaVersion': '2.0.0',
+            'assetId': 'asset-future',
+            'container': 'mp4',
+            'videoTracks': <Object?>[],
+            'audioTracks': <Object?>[],
+            'subtitleTracks': <Object?>[],
+            'warnings': <Object?>[],
+          },
+          'diagnostics': {'elapsedMs': 1, 'didUseMetadataProbe': true},
+        };
+      });
+
+      final result = await HostPlatformMediaAssetAnalyzer().analyze(
+        const MediaAssetAnalysisRequest(
+          assetId: 'asset-future',
+          filePath: '/private/tmp/movie.mp4',
+        ),
+      );
+
+      expect(result.status, MediaAssetAnalysisStatus.unsupportedInspection);
+      expect(result.failureReason, 'unsupported_profile_version');
+      expect(result.profile, isNull);
+    },
+  );
+
+  test(
+    'cancellation stops the native probe and returns a typed result',
+    () async {
+      final analysisStarted = Completer<void>();
+      final nativeAnalysis = Completer<Map<String, Object?>>();
+      final calls = <MethodCall>[];
+      messenger.setMockMethodCallHandler(channel, (call) async {
+        calls.add(call);
+        if (call.method == 'analyze') {
+          analysisStarted.complete();
+          return nativeAnalysis.future;
+        }
+        if (call.method == 'cancel') {
+          nativeAnalysis.complete({
+            'status': 'cancelled',
+            'diagnostics': {'elapsedMs': 2, 'didUseMetadataProbe': true},
+          });
+          return null;
+        }
+        throw MissingPluginException();
+      });
+      final cancellation = MediaAssetAnalysisCancellationToken();
+      final resultFuture = HostPlatformMediaAssetAnalyzer().analyze(
+        MediaAssetAnalysisRequest(
+          assetId: 'asset-cancel',
+          filePath: '/private/tmp/movie.mkv',
+          cancellationToken: cancellation,
+        ),
+      );
+
+      await analysisStarted.future;
+      cancellation.cancel();
+      final result = await resultFuture;
+
+      expect(result.status, MediaAssetAnalysisStatus.cancelled);
+      expect(calls.map((call) => call.method), ['analyze', 'cancel']);
+      final analysisId =
+          (calls.first.arguments as Map<Object?, Object?>)['analysisId'];
+      expect(analysisId, isNotNull);
+      expect(calls.last.arguments, {'analysisId': analysisId});
     },
   );
 }

--- a/packages/platform_media/test/host_platform_media_asset_analyzer_test.dart
+++ b/packages/platform_media/test/host_platform_media_asset_analyzer_test.dart
@@ -215,6 +215,47 @@ void main() {
       expect(calls.last.arguments, {'analysisId': analysisId});
     },
   );
+
+  test('native analysis leaves the Dart event loop responsive', () async {
+    final nativeAnalysis = Completer<Map<String, Object?>>();
+    messenger.setMockMethodCallHandler(channel, (call) {
+      expect(call.method, 'analyze');
+      return nativeAnalysis.future;
+    });
+    var analysisCompleted = false;
+
+    final analysis = HostPlatformMediaAssetAnalyzer()
+        .analyze(
+          const MediaAssetAnalysisRequest(
+            assetId: 'asset-responsive',
+            filePath: '/private/tmp/movie.mkv',
+          ),
+        )
+        .then((result) {
+          analysisCompleted = true;
+          return result;
+        });
+    final eventLoopTurn = Completer<void>();
+    Timer.run(eventLoopTurn.complete);
+
+    await eventLoopTurn.future.timeout(const Duration(seconds: 1));
+    expect(analysisCompleted, isFalse);
+
+    nativeAnalysis.complete({
+      'status': 'complete',
+      'profile': {
+        'schemaVersion': '1.0.0',
+        'assetId': 'asset-responsive',
+        'container': 'mkv',
+        'videoTracks': <Object?>[],
+        'audioTracks': <Object?>[],
+        'subtitleTracks': <Object?>[],
+        'warnings': <Object?>[],
+      },
+      'diagnostics': {'elapsedMs': 1, 'didUseMetadataProbe': true},
+    });
+    expect((await analysis).status, MediaAssetAnalysisStatus.complete);
+  });
 }
 
 class _FakeAnalyzer implements LocalMediaAssetAnalyzer {

--- a/packages/platform_media/test/local_media_asset_analyzer_test.dart
+++ b/packages/platform_media/test/local_media_asset_analyzer_test.dart
@@ -108,4 +108,19 @@ void main() {
     expect(request.toString(), contains('movie.mkv'));
     expect(request.toString(), isNot(contains(mediaFile.path)));
   });
+
+  test('pre-cancelled fallback never opens the selected asset', () async {
+    final cancellation = MediaAssetAnalysisCancellationToken()..cancel();
+
+    final result = await const VideoPlayerLocalMediaAssetAnalyzer().analyze(
+      MediaAssetAnalysisRequest(
+        assetId: 'asset-cancelled',
+        filePath: mediaFile.path,
+        cancellationToken: cancellation,
+      ),
+    );
+
+    expect(result.status, MediaAssetAnalysisStatus.cancelled);
+    expect(fakePlatform.lastDataSource, isNull);
+  });
 }

--- a/packages/platform_media/test/media_asset_profile_codec_test.dart
+++ b/packages/platform_media/test/media_asset_profile_codec_test.dart
@@ -1,0 +1,82 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:platform_media/platform_media.dart';
+
+void main() {
+  test('version 1 profile round-trips every normalized media dimension', () {
+    const profile = MediaAssetProfile(
+      assetId: 'asset-1',
+      container: MediaAssetContainer.mkv,
+      duration: Duration(hours: 2, minutes: 10, seconds: 7),
+      fileSizeBytes: 6101307309,
+      overallBitrate: 6250000,
+      videoTracks: [
+        MediaVideoTrackProfile(
+          id: 'video-0',
+          codec: MediaVideoCodec.hevc,
+          dimensions: MediaAssetDimensions(width: 3840, height: 2160),
+          bitrate: 5800000,
+          dynamicRange: MediaDynamicRangeProfile.hdr10,
+          confidence: MediaTrackConfidence.exact,
+        ),
+      ],
+      audioTracks: [
+        MediaAudioTrackProfile(
+          id: 'audio-1',
+          codec: MediaAudioCodec.dts,
+          confidence: MediaTrackConfidence.exact,
+          language: 'eng',
+          label: 'Main',
+          channelCount: 6,
+          isDefault: true,
+        ),
+      ],
+      subtitleTracks: [
+        MediaSubtitleTrackProfile(
+          id: 'subtitle-2',
+          format: MediaSubtitleFormat.pgs,
+          confidence: MediaTrackConfidence.exact,
+          language: 'eng',
+          label: 'Signs',
+          isForced: true,
+        ),
+      ],
+      warnings: [MediaAssetWarningCode.overallBitrateEstimated],
+    );
+
+    final encoded = MediaAssetProfileCodec.encode(profile);
+    final decoded = MediaAssetProfileCodec.decode(encoded);
+
+    expect(decoded, profile);
+    expect(encoded['schemaVersion'], kMediaAssetProfileSchemaVersion);
+    expect(encoded.toString(), isNot(contains('/')));
+  });
+
+  test('unknown profile schema fails closed with a typed version error', () {
+    final encoded = <String, Object?>{
+      'schemaVersion': '2.0.0',
+      'assetId': 'asset-1',
+      'container': 'mp4',
+      'videoTracks': const [],
+      'audioTracks': const [],
+      'subtitleTracks': const [],
+      'warnings': const [],
+    };
+
+    expect(
+      () => MediaAssetProfileCodec.decode(encoded),
+      throwsA(
+        isA<UnsupportedMediaAssetProfileVersion>()
+            .having(
+              (error) => error.receivedVersion,
+              'receivedVersion',
+              '2.0.0',
+            )
+            .having(
+              (error) => error.supportedVersion,
+              'supportedVersion',
+              kMediaAssetProfileSchemaVersion,
+            ),
+      ),
+    );
+  });
+}


### PR DESCRIPTION
## Summary

- expose a versioned, platform-neutral `MediaAssetProfile` codec and fail closed on unknown schema versions
- register Android `MediaExtractor` and iOS async `AVAsset` adapters, including redacted timing/memory diagnostics and cooperative cancellation
- feed normalized analysis into phone-local selection instead of relying only on filename/MIME hints
- guarantee exactly-once Android completion for queued/running cancellation and unexpected native failures
- add deterministic media fixture generation, Pixel 9 matrix evidence, event-loop responsiveness proof, and iOS normalization XCTest coverage

Tracks #1091. This draft intentionally does not auto-close the issue because the iOS test target and physical image-subtitle run still have external validation blockers.

## Ownership and review contract

- Primary owner: Playback Architect (`platform_media`, media analyzer)
- Native/channel contract reviewer: Platform Architect
- Architecture reviewer: Chief Architect
- Required evidence reviewers: Chief Performance Officer, Chief Security Officer, Chief QA Officer, Chief Open Source Officer, Product Manager
- Layering: reusable framework/platform analyzer plus a thin application picker consumer
- No new runtime dependency, persistent schema, raw-path diagnostic, or full-file cache was added

## Deterministic behavior

1. MP4/H.264/AAC maps to normalized direct media facts.
2. WebM/VP9/Opus maps without platform-specific consumer branches.
3. MKV/HEVC Main10/PQ maps to HEVC/HDR10; Pixel reports DTS unavailable when `MediaExtractor` omits it.
4. Dual-AAC MKV preserves both audio tracks; omitted SRT/ASS tracks produce explicit subtitle uncertainty.
5. Unsupported schema versions fail closed.
6. Queued and running cancellation complete once and release the pending Flutter result.
7. A 6.1 GB movie is inspected via metadata APIs without copying/scanning the full asset.

## Validation

- `packages/platform_media`: focused analyzer/codec/cancellation/responsiveness tests pass; analyzer clean
- Android JVM: `MediaAnalysisJobTest` passes all queued, running, and failure lifecycle cases
- Android debug APK builds
- Pixel 9 deterministic matrix passes for MP4, WebM, HDR10 MKV, and dual-audio MKV
- Pixel 9 authoritative 6,101,307,309-byte MKV: 163 ms, 328,310,784-byte sampled process resident-memory high-water, duration 7,807,802 ms
- iOS analyzer source compiles for arm64 and x86_64 from fresh derived data
- focused app analyzer and `git diff --check` pass

## Known validation blockers

- RunnerTests cannot execute because the existing simulator link pulls an iOS-device MLImage object; the analyzer source itself compiles before that baseline link failure.
- Pixel wireless ADB repeatedly disconnects after APK installation for the optional 32 KB DVDSub evidence run. The test asserts either a normalized VobSub track or explicit subtitle uncertainty.
- `estimatedBytesRead` is null because `MediaExtractor`/`AVAsset` do not expose metadata-probe byte counts.

## CI cost

Both commits use `[skip ci]`. Validation is focused and local; no broad matrix is requested for this draft.
