### PR TITLE
fix(playback): actually consume BACK when an overlay is open

### DIFF
--- a/packages/feature_iptv/lib/presentation/widgets/video_player_widget.dart
+++ b/packages/feature_iptv/lib/presentation/widgets/video_player_widget.dart
@@ -510,7 +510,11 @@ class _VideoPlayerWidgetState extends ConsumerState<VideoPlayerWidget> {
   }
 
   Future<void> _toggleFavoriteForCurrentChannel() async {
-    final channel = ref.read(streamingStateProvider).asData?.value.currentChannel;
+    final channel = ref
+        .read(streamingStateProvider)
+        .asData
+        ?.value
+        .currentChannel;
     if (channel == null) return;
     final toggle = ref.read(channelFavoriteTogglerProvider);
     final isNowFavorite = await toggle(channel.id);
@@ -631,184 +635,209 @@ class _VideoPlayerWidgetState extends ConsumerState<VideoPlayerWidget> {
       ],
     );
 
-    return TvInputHandler(
-      onInput: _handleSurfInput,
-      // Focus.onKeyEvent always ignores so the event bubbles up to
-      // TvInputHandler's own listener above -- this node exists purely to
-      // hold primary focus by default, since nothing else in the player
-      // (controls auto-hide) reliably claims it otherwise. The state-owned
-      // node lets the hide timer reclaim focus from on-screen controls.
-      child: Focus(
-        focusNode: _playerFocusNode,
-        autofocus: true,
-        onKeyEvent: _detectSelectLongPress,
-        child: MouseRegion(
-          onHover: (_) => _showControls(),
-          onEnter: (_) => _showControls(),
-          child: GestureDetector(
-            onTap: _showControls,
-            child: Container(
-              color: Colors.black,
-              child: Stack(
-                alignment: Alignment.center,
-                children: [
-                  // Video display + Netflix-style brightness/volume drag
-                  // gestures. Left half of the video area adjusts brightness,
-                  // right half adjusts volume; disabled while locked. The video
-                  // surface itself is the engine-driven view (CV-016 migration);
-                  // when it's null we fall through to loading/diagnostic/
-                  // placeholder inside the same gesture-enabled stack.
-                  widget.enableTouchGestures
-                      ? PlayerGestureOverlay(
-                          locked: _isLocked,
-                          brightness: _brightness,
-                          volume: state.isMuted ? 0.0 : state.volume,
-                          onTap: _showControls,
-                          onBrightnessChanged: _onBrightnessGestureChanged,
-                          onVolumeChanged: (value) {
-                            if (state.isMuted) service.toggleMute();
-                            service.setVolume(value);
-                          },
-                          child: playerSurface,
-                        )
-                      : playerSurface,
+    // TvInputHandler observes raw key events via a KeyboardListener, which
+    // is passive -- it cannot consume/stop the platform BACK button. So
+    // even though _handleSurfInput's TvInputKey.back case closes the
+    // context menu / quick-browse overlay via setState, the real Android
+    // back press keeps propagating past it and exits the Activity (there's
+    // no route to pop). PopScope is what actually intercepts the platform
+    // back button; block it exactly when an overlay needs BACK to close it
+    // instead of leaving the app.
+    return PopScope(
+      canPop: !_showContextMenu && _quickBrowse == null,
+      onPopInvokedWithResult: (didPop, result) {
+        if (didPop) return;
+        setState(() {
+          _showContextMenu = false;
+          _quickBrowse = null;
+        });
+      },
+      child: TvInputHandler(
+        onInput: _handleSurfInput,
+        // Focus.onKeyEvent always ignores so the event bubbles up to
+        // TvInputHandler's own listener above -- this node exists purely to
+        // hold primary focus by default, since nothing else in the player
+        // (controls auto-hide) reliably claims it otherwise. The state-owned
+        // node lets the hide timer reclaim focus from on-screen controls.
+        child: Focus(
+          focusNode: _playerFocusNode,
+          autofocus: true,
+          onKeyEvent: _detectSelectLongPress,
+          child: MouseRegion(
+            onHover: (_) => _showControls(),
+            onEnter: (_) => _showControls(),
+            child: GestureDetector(
+              onTap: _showControls,
+              child: Container(
+                color: Colors.black,
+                child: Stack(
+                  alignment: Alignment.center,
+                  children: [
+                    // Video display + Netflix-style brightness/volume drag
+                    // gestures. Left half of the video area adjusts brightness,
+                    // right half adjusts volume; disabled while locked. The video
+                    // surface itself is the engine-driven view (CV-016 migration);
+                    // when it's null we fall through to loading/diagnostic/
+                    // placeholder inside the same gesture-enabled stack.
+                    widget.enableTouchGestures
+                        ? PlayerGestureOverlay(
+                            locked: _isLocked,
+                            brightness: _brightness,
+                            volume: state.isMuted ? 0.0 : state.volume,
+                            onTap: _showControls,
+                            onBrightnessChanged: _onBrightnessGestureChanged,
+                            onVolumeChanged: (value) {
+                              if (state.isMuted) service.toggleMute();
+                              service.setVolume(value);
+                            },
+                            child: playerSurface,
+                          )
+                        : playerSurface,
 
-                  // Failover toast only. Airo TV owns one visible control
-                  // system below; keeping PlayerOverlay's old back/title layer
-                  // mounted here caused a second set of controls to reappear
-                  // after the floating controls faded.
-                  if (!_isLocked && !isPipActive && !compactInlinePlayer)
-                    PlayerOverlay(
-                      state: _toPlayerViewState(state),
-                      onBack:
-                          widget.onBack ?? widget.onFullscreenToggle ?? () {},
-                      onPlayPause: () {
-                        if (state.isPlaying) {
-                          service.pause();
-                        } else {
-                          service.resume();
-                        }
-                      },
-                      onReveal: _showControls,
-                      showTopChrome: false,
-                      showCenterControls: false,
-                      showBottomBar: false,
-                    ),
-
-                  // Controls overlay with fade animation — hidden entirely while
-                  // locked so only the lock button remains interactive.
-                  if (!_isLocked && !isPipActive)
-                    AnimatedOpacity(
-                      opacity: (widget.showControls && _showControlsOverlay)
-                          ? 1.0
-                          : 0.0,
-                      duration: const Duration(milliseconds: 300),
-                      child: IgnorePointer(
-                        ignoring: !widget.showControls || !_showControlsOverlay,
-                        // Hidden controls must be invisible to D-pad focus
-                        // too, or arrow keys traverse buttons nobody can see
-                        // while the surface expects channel-surf input.
-                        child: ExcludeFocus(
-                          excluding:
-                              !widget.showControls || !_showControlsOverlay,
-                          child: _buildControlsOverlay(context, service, state),
-                        ),
+                    // Failover toast only. Airo TV owns one visible control
+                    // system below; keeping PlayerOverlay's old back/title layer
+                    // mounted here caused a second set of controls to reappear
+                    // after the floating controls faded.
+                    if (!_isLocked && !isPipActive && !compactInlinePlayer)
+                      PlayerOverlay(
+                        state: _toPlayerViewState(state),
+                        onBack:
+                            widget.onBack ?? widget.onFullscreenToggle ?? () {},
+                        onPlayPause: () {
+                          if (state.isPlaying) {
+                            service.pause();
+                          } else {
+                            service.resume();
+                          }
+                        },
+                        onReveal: _showControls,
+                        showTopChrome: false,
+                        showCenterControls: false,
+                        showBottomBar: false,
                       ),
-                    ),
 
-                  // Lock button: touch-only concept, hidden entirely when
-                  // enableTouchGestures is false (e.g. TV/remote input).
-                  if (widget.enableTouchGestures && !isPipActive)
-                    Positioned(
-                      top: 8,
-                      right: 56,
-                      child: AnimatedOpacity(
-                        opacity: (_isLocked || _showControlsOverlay)
+                    // Controls overlay with fade animation — hidden entirely while
+                    // locked so only the lock button remains interactive.
+                    if (!_isLocked && !isPipActive)
+                      AnimatedOpacity(
+                        opacity: (widget.showControls && _showControlsOverlay)
                             ? 1.0
                             : 0.0,
                         duration: const Duration(milliseconds: 300),
-                        child: Container(
-                          decoration: BoxDecoration(
-                            color: Colors.black45,
-                            borderRadius: BorderRadius.circular(4),
-                          ),
-                          child: PlayerLockButton(
-                            key: const ValueKey('iptv-player-lock-button'),
-                            locked: _isLocked,
-                            onToggle: _toggleLocked,
-                          ),
-                        ),
-                      ),
-                    ),
-
-                  // Channel change overlay
-                  if (_channelChangeOverlayText != null)
-                    Positioned(
-                      child: AnimatedOpacity(
-                        opacity: _channelChangeOverlayText != null ? 1.0 : 0.0,
-                        duration: const Duration(milliseconds: 200),
-                        child: Container(
-                          padding: const EdgeInsets.symmetric(
-                            horizontal: 24,
-                            vertical: 12,
-                          ),
-                          decoration: BoxDecoration(
-                            color: Colors.black.withValues(alpha: 0.8),
-                            borderRadius: BorderRadius.circular(8),
-                          ),
-                          child: Text(
-                            _channelChangeOverlayText!,
-                            style: const TextStyle(
-                              color: Colors.white,
-                              fontSize: 16,
-                              fontWeight: FontWeight.w600,
+                        child: IgnorePointer(
+                          ignoring:
+                              !widget.showControls || !_showControlsOverlay,
+                          // Hidden controls must be invisible to D-pad focus
+                          // too, or arrow keys traverse buttons nobody can see
+                          // while the surface expects channel-surf input.
+                          child: ExcludeFocus(
+                            excluding:
+                                !widget.showControls || !_showControlsOverlay,
+                            child: _buildControlsOverlay(
+                              context,
+                              service,
+                              state,
                             ),
                           ),
                         ),
                       ),
-                    ),
 
-                  // Context menu (MENU key) — right-side overlay, matching
-                  // the AiroTV D-pad design's "CONTEXT MENU (MENU key)"
-                  // screen. Only rendered while open; doesn't touch layout
-                  // otherwise.
-                  if (_showContextMenu && state.currentChannel != null)
-                    _ContextMenuOverlay(
-                      channel: state.currentChannel!,
-                      onToggleFavorite: _toggleFavoriteForCurrentChannel,
-                      onClose: () => setState(() => _showContextMenu = false),
-                    ),
+                    // Lock button: touch-only concept, hidden entirely when
+                    // enableTouchGestures is false (e.g. TV/remote input).
+                    if (widget.enableTouchGestures && !isPipActive)
+                      Positioned(
+                        top: 8,
+                        right: 56,
+                        child: AnimatedOpacity(
+                          opacity: (_isLocked || _showControlsOverlay)
+                              ? 1.0
+                              : 0.0,
+                          duration: const Duration(milliseconds: 300),
+                          child: Container(
+                            decoration: BoxDecoration(
+                              color: Colors.black45,
+                              borderRadius: BorderRadius.circular(4),
+                            ),
+                            child: PlayerLockButton(
+                              key: const ValueKey('iptv-player-lock-button'),
+                              locked: _isLocked,
+                              onToggle: _toggleLocked,
+                            ),
+                          ),
+                        ),
+                      ),
 
-                  // UP/DOWN quick-browse overlays.
-                  if (_quickBrowse == _TvQuickBrowse.miniGuide &&
-                      state.currentChannel != null)
-                    _QuickBrowseOverlay(
-                      title: 'Mini guide',
-                      channels: _miniGuideChannels(state.currentChannel!),
-                      currentChannelId: state.currentChannel!.id,
-                      onSelected: _playChannelFromQuickBrowse,
-                    ),
-                  if (_quickBrowse == _TvQuickBrowse.recent)
-                    Consumer(
-                      builder: (context, ref, _) {
-                        final recent = ref.watch(
-                          recentlyWatchedChannelsProvider,
-                        );
-                        return recent.when(
-                          data: (channels) => channels.isEmpty
-                              ? const SizedBox.shrink()
-                              : _QuickBrowseOverlay(
-                                  title: 'Recently watched',
-                                  channels: channels,
-                                  currentChannelId: state.currentChannel?.id,
-                                  onSelected: _playChannelFromQuickBrowse,
-                                ),
-                          loading: () => const SizedBox.shrink(),
-                          error: (_, _) => const SizedBox.shrink(),
-                        );
-                      },
-                    ),
-                ],
+                    // Channel change overlay
+                    if (_channelChangeOverlayText != null)
+                      Positioned(
+                        child: AnimatedOpacity(
+                          opacity: _channelChangeOverlayText != null
+                              ? 1.0
+                              : 0.0,
+                          duration: const Duration(milliseconds: 200),
+                          child: Container(
+                            padding: const EdgeInsets.symmetric(
+                              horizontal: 24,
+                              vertical: 12,
+                            ),
+                            decoration: BoxDecoration(
+                              color: Colors.black.withValues(alpha: 0.8),
+                              borderRadius: BorderRadius.circular(8),
+                            ),
+                            child: Text(
+                              _channelChangeOverlayText!,
+                              style: const TextStyle(
+                                color: Colors.white,
+                                fontSize: 16,
+                                fontWeight: FontWeight.w600,
+                              ),
+                            ),
+                          ),
+                        ),
+                      ),
+
+                    // Context menu (MENU key) — right-side overlay, matching
+                    // the AiroTV D-pad design's "CONTEXT MENU (MENU key)"
+                    // screen. Only rendered while open; doesn't touch layout
+                    // otherwise.
+                    if (_showContextMenu && state.currentChannel != null)
+                      _ContextMenuOverlay(
+                        channel: state.currentChannel!,
+                        onToggleFavorite: _toggleFavoriteForCurrentChannel,
+                        onClose: () => setState(() => _showContextMenu = false),
+                      ),
+
+                    // UP/DOWN quick-browse overlays.
+                    if (_quickBrowse == _TvQuickBrowse.miniGuide &&
+                        state.currentChannel != null)
+                      _QuickBrowseOverlay(
+                        title: 'Mini guide',
+                        channels: _miniGuideChannels(state.currentChannel!),
+                        currentChannelId: state.currentChannel!.id,
+                        onSelected: _playChannelFromQuickBrowse,
+                      ),
+                    if (_quickBrowse == _TvQuickBrowse.recent)
+                      Consumer(
+                        builder: (context, ref, _) {
+                          final recent = ref.watch(
+                            recentlyWatchedChannelsProvider,
+                          );
+                          return recent.when(
+                            data: (channels) => channels.isEmpty
+                                ? const SizedBox.shrink()
+                                : _QuickBrowseOverlay(
+                                    title: 'Recently watched',
+                                    channels: channels,
+                                    currentChannelId: state.currentChannel?.id,
+                                    onSelected: _playChannelFromQuickBrowse,
+                                  ),
+                            loading: () => const SizedBox.shrink(),
+                            error: (_, _) => const SizedBox.shrink(),
+                          );
+                        },
+                      ),
+                  ],
+                ),
               ),
             ),
           ),

--- a/packages/feature_iptv/test/presentation/widgets/video_player_widget_context_menu_test.dart
+++ b/packages/feature_iptv/test/presentation/widgets/video_player_widget_context_menu_test.dart
@@ -99,6 +99,38 @@ void main() {
     expect(find.text('Actions for'), findsNothing);
   });
 
+  // Confirmed on a real Fire TV Stick: TvInputHandler observes the BACK key
+  // via a passive KeyboardListener, which cannot consume the platform back
+  // button. tester.sendKeyEvent(escape) above only proves the in-app state
+  // closes -- it doesn't touch the Navigator's real pop path, so it missed
+  // this. The real Android back button was reaching the Activity handler
+  // *at the same time* as our state update and exiting the app. PopScope
+  // is what actually intercepts a platform pop request; simulate that
+  // directly via handlePopRoute (what a real Android back button drives).
+  testWidgets(
+    'a real platform back request is consumed while the context menu is '
+    'open, instead of also popping the app',
+    (tester) async {
+      await pumpPlayer(tester);
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.contextMenu);
+      await tester.pump();
+      expect(find.text('Actions for'), findsOneWidget);
+
+      final handled = await tester.binding.handlePopRoute();
+
+      expect(
+        handled,
+        isTrue,
+        reason: 'PopScope must report the back request as handled, or the '
+            'platform (Android) proceeds to pop/exit the Activity on top '
+            "of whatever the app's own state did.",
+      );
+      await tester.pump();
+      expect(find.text('Actions for'), findsNothing);
+    },
+  );
+
   // Confirmed via on-device logcat: Fire OS intercepts KEYCODE_MENU for its
   // own system overlay before Flutter's embedding ever sees it, so
   // TvInputKey.menu is unreachable on real Fire TV hardware. Long-press


### PR DESCRIPTION
## Summary
Found on real hardware. Confirmed on a Fire TV Stick: pressing BACK while the context menu (#1134) or a quick-browse overlay (#1136) was open closed the overlay **and** exited the app to the Fire TV launcher, at the same time.

Root cause: `TvInputHandler` observes raw key events through a `KeyboardListener`, which is passive — it can report a key press but cannot consume or stop it. `TvInputKey.back`'s handling in `_handleSurfInput` correctly closed the overlay via `setState`, but the real platform BACK press kept propagating past it with nothing to pop, so Android's default back behavior (exit the Activity) ran too, invisibly, in parallel.

`PopScope` is what actually intercepts a platform pop request. Wraps the player in one, blocking pop exactly while the context menu or a quick-browse overlay is open, closing it in `onPopInvokedWithResult` instead of letting the pop through. The Search overlay (#1139) was never affected — it's a real `showDialog` route, and `Navigator`/`ModalRoute` already consumes back correctly for routes.

## Test plan
- [x] New test drives this via `WidgetsBinding.handlePopRoute()` — what a real Android back button triggers — rather than a synthetic key event, since the existing key-event test was already green and didn't catch this.
- [x] Confirmed the new test fails against the pre-fix code (`handled: false`, i.e. the platform pop would have gone through) and passes with the fix.
- [x] `feature_iptv`: `flutter test` — 639/639 pass.
- [x] `feature_iptv`: `flutter analyze` — clean.
- [ ] On-device re-verify: open context menu / Mini Guide / Recent Channels on the Fire TV Stick, press BACK, confirm the app stays open and only the overlay closes.