### PR TITLE
fix(iptv): derive phone Cast UI from session truth

### DIFF
--- a/packages/feature_iptv/lib/presentation/widgets/phone_media_play_on_tv_sheet.dart
+++ b/packages/feature_iptv/lib/presentation/widgets/phone_media_play_on_tv_sheet.dart
@@ -51,7 +51,23 @@ class _PhoneMediaPlayOnTvSheetState extends State<PhoneMediaPlayOnTvSheet> {
     _sessionSubscription = widget.castController.sessionStateStream.listen((
       state,
     ) {
-      if (mounted) setState(() => _session = state);
+      if (!mounted) return;
+      setState(() {
+        _session = state;
+        _phase = switch (state.phase) {
+          AiroCastSessionPhase.playing ||
+          AiroCastSessionPhase.paused => _HandoffPhase.playing,
+          AiroCastSessionPhase.failed ||
+          AiroCastSessionPhase.disconnected => _HandoffPhase.failed,
+          AiroCastSessionPhase.idle
+              when _phase == _HandoffPhase.connecting ||
+                  _phase == _HandoffPhase.starting ||
+                  _phase == _HandoffPhase.playing =>
+            _HandoffPhase.failed,
+          AiroCastSessionPhase.stopped => _HandoffPhase.idle,
+          _ => _phase,
+        };
+      });
     });
     if (!_session.isConnected) {
       unawaited(_startDiscovery());
@@ -114,7 +130,15 @@ class _PhoneMediaPlayOnTvSheetState extends State<PhoneMediaPlayOnTvSheet> {
     if (!mounted) return;
     setState(() {
       _phase = switch (result) {
-        PhoneMediaHandoffStarted() => _HandoffPhase.playing,
+        PhoneMediaHandoffStarted() =>
+          switch (widget.castController.currentSessionState.phase) {
+            AiroCastSessionPhase.playing ||
+            AiroCastSessionPhase.paused => _HandoffPhase.playing,
+            AiroCastSessionPhase.failed ||
+            AiroCastSessionPhase.disconnected ||
+            AiroCastSessionPhase.idle => _HandoffPhase.failed,
+            _ => _HandoffPhase.starting,
+          },
         PhoneMediaHandoffUnsupported() => _HandoffPhase.unsupported,
         PhoneMediaHandoffFailed() => _HandoffPhase.failed,
       };

--- a/packages/feature_iptv/test/iptv/phone_media_play_on_tv_test.dart
+++ b/packages/feature_iptv/test/iptv/phone_media_play_on_tv_test.dart
@@ -79,6 +79,46 @@ void main() {
     expect(find.text('Stop casting'), findsOneWidget);
   });
 
+  testWidgets('receiver disconnect replaces stale Playing state', (
+    tester,
+  ) async {
+    await tester.pumpWidget(hostFor(itemFor()));
+
+    await tester.tap(find.text('Play on Fire Stick'));
+    await tester.pumpAndSettle();
+    expect(find.text('Playing on Fire Stick'), findsOneWidget);
+
+    castController.emitReceiverDisconnected();
+    await tester.pumpAndSettle();
+
+    expect(find.text('Playing on Fire Stick'), findsNothing);
+    expect(find.text('Open remote'), findsNothing);
+    expect(find.text("Couldn't play on your TV"), findsOneWidget);
+    expect(find.text('Find a TV'), findsOneWidget);
+  });
+
+  testWidgets('loading media does not claim playback has started', (
+    tester,
+  ) async {
+    castController.completeLoads = false;
+    await tester.pumpWidget(hostFor(itemFor()));
+
+    await tester.tap(find.text('Play on Fire Stick'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Playing on Fire Stick'), findsNothing);
+    expect(find.text('Open remote'), findsNothing);
+    expect(find.text('Play on Fire Stick'), findsOneWidget);
+    expect(
+      tester
+          .widget<FilledButton>(
+            find.widgetWithText(FilledButton, 'Play on Fire Stick'),
+          )
+          .onPressed,
+      isNull,
+    );
+  });
+
   testWidgets('unsupported container shows format-not-supported state', (
     tester,
   ) async {


### PR DESCRIPTION
## Summary

Fixes #1157 by making the phone-media sheet reconcile its local handoff phase with the authoritative Cast session stream.

- Playing/remote actions appear only after `playing` or `paused`.
- Receiver failure/disconnection replaces stale Playing UI with recovery.
- `loadingMedia` remains a disabled starting state and does not claim first frame.
- A terminal session event cannot be overwritten by a stale successful handoff future.

Classification: application-layer presentation in `feature_iptv`; no player/platform contract changed. No D-pad, focus, or TV remote behavior changed.

## Test Plan

- [x] `flutter test test/iptv/phone_media_play_on_tv_test.dart` — 11 passed
- [x] focused `flutter analyze` — clean
- [x] `scripts/check-module-manifests.py` — 59 valid
- [x] `scripts/check-docs-completeness.sh` — no docs-gated change
- [x] `git diff --check` — clean
- [x] Physical failure reproduction documented in #889/#1158

**Verification environment:** Host-only Flutter widget tests; originating reproduction on physical Pixel 9 + Sony BRAVIA.

## Agent Policy

- [x] #1157 includes Critical Agent gate, classification, deterministic cases, and automation flow
- [x] Application consumes the existing `platform_player` session contract
- [x] No Android Emulator used

## Council Review

- Media Intelligence Architect: package owner; change remains within `feature_iptv` presentation
- Chief Architect / Platform Architect: existing Cast contract is unchanged
- Chief QA Officer: RED/GREEN regression plus full focused widget file
- Flutter Architect: session-derived rendering follows existing widget/state pattern

- [x] Decision Matrix checked
- [x] `feature_iptv/module.yaml` remains valid and unchanged

## User-Facing Documentation

- [x] No wiki update needed; this corrects erroneous transient state without adding capability

## Plugin and Size Impact

- [x] No dependency or plugin change
- [x] Two focused files; negligible source impact

## Checklist

- [x] Code formatted
- [x] Regression tests included
- [x] No sensitive data or artifacts committed

## Release Notes

- [x] Not applicable; experimental qualification bug fix

Closes #1157.