### PR TITLE
fix(tv): close search after selecting a channel result

### DIFF
--- a/packages/feature_iptv/lib/presentation/tv_ux/sections/search_overlay.dart
+++ b/packages/feature_iptv/lib/presentation/tv_ux/sections/search_overlay.dart
@@ -205,14 +205,16 @@ class _SearchOverlayState extends ConsumerState<SearchOverlay> {
                     border: OutlineInputBorder(),
                   ),
                   textInputAction: TextInputAction.search,
-                  onChanged: (value) => ref
-                      .read(localIptvSearchQueryProvider.notifier)
-                      .state = value,
+                  onChanged: (value) =>
+                      ref.read(localIptvSearchQueryProvider.notifier).state =
+                          value,
                   onSubmitted: (_) => _close(),
                 ),
               ),
               const SizedBox(height: 12),
-              const Expanded(child: LocalSearchResultsPanel()),
+              Expanded(
+                child: LocalSearchResultsPanel(onChannelSelected: _close),
+              ),
             ],
           ),
         ),
@@ -257,10 +259,7 @@ class _BrowseTile extends StatelessWidget {
             mainAxisAlignment: MainAxisAlignment.spaceBetween,
             children: [
               Icon(icon, size: 22, color: theme.colorScheme.onSurfaceVariant),
-              Text(
-                label,
-                style: theme.textTheme.titleSmall,
-              ),
+              Text(label, style: theme.textTheme.titleSmall),
               Text(
                 count,
                 style: theme.textTheme.bodySmall?.copyWith(

--- a/packages/feature_iptv/lib/presentation/widgets/local_search_results_panel.dart
+++ b/packages/feature_iptv/lib/presentation/widgets/local_search_results_panel.dart
@@ -10,7 +10,13 @@ import '../../domain/local_iptv_search.dart';
 /// program results for [localIptvSearchQueryProvider], focus-safe and
 /// overflow-safe at TV viewport sizes.
 class LocalSearchResultsPanel extends ConsumerWidget {
-  const LocalSearchResultsPanel({super.key});
+  const LocalSearchResultsPanel({super.key, this.onChannelSelected});
+
+  /// Called after a channel result is selected and playback has started.
+  /// The search overlay is modal (a [Dialog.fullscreen]); without this,
+  /// selecting a channel left the dialog open with nothing re-claiming
+  /// D-pad focus, so the remote appeared dead until Back was pressed.
+  final VoidCallback? onChannelSelected;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -60,7 +66,11 @@ class LocalSearchResultsPanel extends ConsumerWidget {
               _SectionHeader('Channels'),
               const SizedBox(height: 8),
               for (var i = 0; i < channelResults.length; i++)
-                _ResultRow(result: channelResults[i], autofocus: i == 0),
+                _ResultRow(
+                  result: channelResults[i],
+                  autofocus: i == 0,
+                  onChannelSelected: onChannelSelected,
+                ),
               const SizedBox(height: 20),
             ],
             if (programResults.isNotEmpty) ...[
@@ -70,6 +80,7 @@ class LocalSearchResultsPanel extends ConsumerWidget {
                 _ResultRow(
                   result: programResults[i],
                   autofocus: channelResults.isEmpty && i == 0,
+                  onChannelSelected: onChannelSelected,
                 ),
             ],
           ],
@@ -98,10 +109,15 @@ class _SectionHeader extends StatelessWidget {
 }
 
 class _ResultRow extends ConsumerWidget {
-  const _ResultRow({required this.result, this.autofocus = false});
+  const _ResultRow({
+    required this.result,
+    this.autofocus = false,
+    this.onChannelSelected,
+  });
 
   final LocalIptvSearchResult result;
   final bool autofocus;
+  final VoidCallback? onChannelSelected;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -118,6 +134,7 @@ class _ResultRow extends ConsumerWidget {
           for (final channel in channels) {
             if (channel.id == result.channelId) {
               ref.read(iptvStreamingServiceProvider).playChannel(channel);
+              onChannelSelected?.call();
               break;
             }
           }

--- a/packages/feature_iptv/test/iptv/presentation/widgets/local_search_results_panel_test.dart
+++ b/packages/feature_iptv/test/iptv/presentation/widgets/local_search_results_panel_test.dart
@@ -26,14 +26,19 @@ void main() {
     group: 'News',
   );
 
-  Future<void> pumpPanel(
+  Future<VideoPlayerStreamingService> pumpPanel(
     WidgetTester tester, {
     List<IPTVChannel> channels = const [bbcNews, cnn],
     String query = '',
+    VoidCallback? onChannelSelected,
   }) async {
     tester.view.physicalSize = const Size(1280, 720);
     tester.view.devicePixelRatio = 1.0;
     addTearDown(tester.view.reset);
+
+    final engine = FakeAiroPlaybackEngine(tracks: const []);
+    final service = VideoPlayerStreamingService(engine: engine);
+    addTearDown(service.dispose);
 
     await tester.pumpWidget(
       ProviderScope(
@@ -44,13 +49,17 @@ void main() {
             const EmptyCompactEpgRepository(),
           ),
           localIptvSearchQueryProvider.overrideWith((ref) => query),
+          iptvStreamingServiceProvider.overrideWithValue(service),
         ],
-        child: const MaterialApp(
-          home: Scaffold(body: LocalSearchResultsPanel()),
+        child: MaterialApp(
+          home: Scaffold(
+            body: LocalSearchResultsPanel(onChannelSelected: onChannelSelected),
+          ),
         ),
       ),
     );
     await tester.pumpAndSettle();
+    return service;
   }
 
   testWidgets('empty query shows a prompt, not results', (tester) async {
@@ -88,4 +97,27 @@ void main() {
 
     expect(tester.takeException(), isNull);
   });
+
+  // Regression: selecting a channel used to leave the modal search overlay
+  // open with nothing re-claiming D-pad focus, so the remote appeared dead
+  // until Back was pressed. onChannelSelected lets the host overlay close
+  // itself once playback has started.
+  testWidgets(
+    'selecting a channel result plays it and calls onChannelSelected',
+    (tester) async {
+      var selected = false;
+      final service = await pumpPanel(
+        tester,
+        query: 'BBC',
+        onChannelSelected: () => selected = true,
+      );
+
+      await tester.tap(find.text('BBC News'));
+      await tester.pumpAndSettle();
+
+      expect(selected, isTrue);
+      expect(service.currentState.currentChannel?.id, 'c1');
+      await service.stop();
+    },
+  );
 }


### PR DESCRIPTION
## Summary
- Root-caused the "D-pad unresponsive" report from the search-results select path: `SearchOverlay` is a `Dialog.fullscreen`; selecting a channel called `playChannel()` but never dismissed the dialog, leaving the modal on top with no focusable path back to the underlying TvFocusable tree.
- Added `LocalSearchResultsPanel.onChannelSelected`, wired to `SearchOverlay._close()` (persists the search text into the channel filter and pops, same as the X button).

## Test plan
- [x] `flutter analyze` clean
- [x] New test: selecting a channel result plays it and calls `onChannelSelected`
- [x] Full `feature_iptv` suite: 652 passed, 2 skipped, 0 failed
- [ ] On-device re-verification on Fire TV Stick once it's back online (Vevo Pop / Aaj Tak / Music India / YRF Music only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)