### PR TITLE
fix(tv): long-pressing Select no longer also fires the short-press action

### DIFF
--- a/packages/feature_iptv/lib/presentation/widgets/video_player_widget.dart
+++ b/packages/feature_iptv/lib/presentation/widgets/video_player_widget.dart
@@ -121,6 +121,7 @@ class _VideoPlayerWidgetState extends ConsumerState<VideoPlayerWidget> {
   // Android TV remotes that do have a working menu key.
   bool _showContextMenu = false;
   Timer? _selectLongPressTimer;
+  bool _selectConsumedByLongPress = false;
 
   // UP/DOWN quick-browse overlays (AiroTV D-pad design "MINI GUIDE (UP)" /
   // "RECENT CHANNELS (DOWN)"). Replaces the previous instant channel-surf
@@ -454,24 +455,37 @@ class _VideoPlayerWidgetState extends ConsumerState<VideoPlayerWidget> {
       // Left/right walk the visible controls via normal focus traversal
       // (the buttons are TvFocusable); with the overlay hidden there are
       // no focus candidates (ExcludeFocus), so the keys are inert.
-      case TvInputKey.select:
-        if (controlsVisible) {
-          // A focused control's own TvFocusable consumes select before
-          // this listener; reaching here means nothing was focused yet.
-          if (_centerControlFocusNode.canRequestFocus) {
-            _centerControlFocusNode.requestFocus();
-          }
-          return TvInputResult.handled;
-        }
-        // Controls hidden: OK reveals them with focus on play/pause, the
-        // same pattern as every mainstream TV player.
-        _showControls();
-        if (_centerControlFocusNode.canRequestFocus) {
-          _centerControlFocusNode.requestFocus();
-        }
-        return TvInputResult.handled;
+      //
+      // Select is deliberately NOT handled here: TvInputHandler fires on
+      // every key-down, which would reveal controls the instant Select is
+      // pressed -- including the down-stroke of what turns out to be a
+      // long-press. That doubled the short-press action on top of the
+      // context menu opening (issues/01-remote-focus-contract.md
+      // acceptance criterion 5: "Holding Select does not also trigger the
+      // short-press action"). _detectSelectLongPress below owns Select
+      // entirely and only fires the short-press reveal on a clean key-up.
       default:
         return TvInputResult.notHandled;
+    }
+  }
+
+  /// The short-press Select action: reveal controls (or move focus onto
+  /// them if already visible). Only invoked from [_detectSelectLongPress]
+  /// on a key-up that wasn't consumed by the long-press timer.
+  void _revealControlsForSelect() {
+    if (_showControlsOverlay && widget.showControls) {
+      // A focused control's own TvFocusable consumes select before this
+      // listener; reaching here means nothing was focused yet.
+      if (_centerControlFocusNode.canRequestFocus) {
+        _centerControlFocusNode.requestFocus();
+      }
+      return;
+    }
+    // Controls hidden: OK reveals them with focus on play/pause, the same
+    // pattern as every mainstream TV player.
+    _showControls();
+    if (_centerControlFocusNode.canRequestFocus) {
+      _centerControlFocusNode.requestFocus();
     }
   }
 
@@ -494,25 +508,34 @@ class _VideoPlayerWidgetState extends ConsumerState<VideoPlayerWidget> {
 
   static const _selectLongPressDuration = Duration(milliseconds: 500);
 
-  /// Detects a long-press of Select/OK to open the context menu (see the
-  /// field doc on [_showContextMenu] for why). Always returns `ignored` —
-  /// this only observes timing, it never claims the key event, so normal
-  /// short-press handling in [_handleSurfInput] (via [TvInputHandler]) is
-  /// unaffected.
+  /// Owns Select/OK end to end: starts the long-press timer on key-down,
+  /// and on key-up either leaves it to the context menu it already opened
+  /// (long-press) or fires the short-press reveal-controls action (clean
+  /// tap) -- never both, per issues/01-remote-focus-contract.md acceptance
+  /// criterion 5. Always returns `ignored` since nothing else needs this
+  /// key event once decided.
   KeyEventResult _detectSelectLongPress(FocusNode node, KeyEvent event) {
     final key = TvInputHandler.mapLogicalKeyToTvInput(event.logicalKey);
     if (key != TvInputKey.select) return KeyEventResult.ignored;
 
     if (event is KeyDownEvent) {
       _selectLongPressTimer ??= Timer(_selectLongPressDuration, () {
+        _selectLongPressTimer = null;
         if (ref.read(streamingStateProvider).asData?.value.currentChannel !=
             null) {
+          _selectConsumedByLongPress = true;
           setState(() => _showContextMenu = true);
         }
       });
     } else if (event is KeyUpEvent) {
+      final wasStillPending = _selectLongPressTimer != null;
       _selectLongPressTimer?.cancel();
       _selectLongPressTimer = null;
+      if (_selectConsumedByLongPress) {
+        _selectConsumedByLongPress = false;
+      } else if (wasStillPending) {
+        _revealControlsForSelect();
+      }
     }
     return KeyEventResult.ignored;
   }

--- a/packages/feature_iptv/test/presentation/widgets/video_player_widget_context_menu_test.dart
+++ b/packages/feature_iptv/test/presentation/widgets/video_player_widget_context_menu_test.dart
@@ -38,11 +38,7 @@ void main() {
         container: container,
         child: const MaterialApp(
           home: Scaffold(
-            body: SizedBox(
-              width: 960,
-              height: 540,
-              child: VideoPlayerWidget(),
-            ),
+            body: SizedBox(width: 960, height: 540, child: VideoPlayerWidget()),
           ),
         ),
       ),
@@ -122,7 +118,8 @@ void main() {
       expect(
         handled,
         isTrue,
-        reason: 'PopScope must report the back request as handled, or the '
+        reason:
+            'PopScope must report the back request as handled, or the '
             'platform (Android) proceeds to pop/exit the Activity on top '
             "of whatever the app's own state did.",
       );
@@ -162,4 +159,50 @@ void main() {
 
     expect(find.text('Actions for'), findsNothing);
   });
+
+  // Regression for issues/01-remote-focus-contract.md acceptance criterion
+  // 5: "Holding Select does not also trigger the short-press action."
+  // TvInputHandler fires on every key-down, so before this fix the
+  // short-press reveal-controls action (which moves focus onto the center
+  // play/pause control) ran on Select's down-stroke regardless of how long
+  // it was then held -- doubling up with the context menu that opened 500ms
+  // later on the same press.
+  testWidgets('a short Select tap moves focus onto the center control', (
+    tester,
+  ) async {
+    await pumpPlayer(tester);
+
+    await tester.sendKeyDownEvent(LogicalKeyboardKey.select);
+    await tester.pump(const Duration(milliseconds: 100));
+    await tester.sendKeyUpEvent(LogicalKeyboardKey.select);
+    await tester.pump();
+
+    expect(find.text('Actions for'), findsNothing);
+    expect(
+      FocusManager.instance.primaryFocus?.debugLabel,
+      'player center control',
+    );
+  });
+
+  testWidgets(
+    'a long-press does not also move focus onto the center control -- only '
+    'the context menu opens',
+    (tester) async {
+      await pumpPlayer(tester);
+
+      await tester.sendKeyDownEvent(LogicalKeyboardKey.select);
+      await tester.pump(const Duration(milliseconds: 600));
+      await tester.sendKeyUpEvent(LogicalKeyboardKey.select);
+      await tester.pump();
+
+      expect(find.text('Actions for'), findsOneWidget);
+      expect(
+        FocusManager.instance.primaryFocus?.debugLabel,
+        isNot('player center control'),
+        reason:
+            'the long-press must not also fire the short-press reveal '
+            'action on top of opening the context menu',
+      );
+    },
+  );
 }


### PR DESCRIPTION
## Summary
- `TvInputHandler` fires on every key-down, so Select's short-press action (reveal controls, focus play/pause) ran immediately on key-down -- including the down-stroke of a hold that 500ms later also opens the context menu via the separate long-press timer. Every long-press doubled up both actions.
- Moved short-press handling out of `_handleSurfInput` and into `_detectSelectLongPress` (which already owns the long-press timer): now deferred to key-up, and only fires when the hold never reached the long-press threshold.
- Satisfies acceptance criterion 5 of `issues/01-remote-focus-contract.md`: "Holding Select does not also trigger the short-press action."

## Test plan
- [x] `flutter analyze` clean
- [x] New tests: short tap moves focus onto center control; long-press opens the context menu *without* also moving focus there
- [x] Existing long-press/short-tap context-menu tests still pass
- [x] Full `feature_iptv` suite: 654 passed, 2 skipped, 1 pre-existing unrelated failure (`Play file on TV drawer entry...`, confirmed failing on main without this change too)
- [ ] On-device re-verification on Fire TV Stick once it's back online (Vevo Pop / Aaj Tak / Music India / YRF Music only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)