### PR TITLE
refactor(player): add seekable phone-media source contract

### DIFF
--- a/packages/platform_player/lib/platform_player.dart
+++ b/packages/platform_player/lib/platform_player.dart
@@ -25,6 +25,7 @@ export "src/services/native_fullscreen.dart";
 export "src/services/native_picture_in_picture.dart";
 export "src/services/phone_media_cast_handoff.dart";
 export "src/services/phone_media_file_server.dart";
+export "src/services/phone_media_seekable_source.dart";
 export "src/services/playback_session_tracker.dart";
 export "src/services/unavailable_playback_engine.dart";
 export "src/services/unavailable_cast_controller.dart";

--- a/packages/platform_player/lib/src/services/phone_media_cast_handoff.dart
+++ b/packages/platform_player/lib/src/services/phone_media_cast_handoff.dart
@@ -11,6 +11,7 @@ import '../models/cast_models.dart';
 import '../models/phone_media_diagnostic_models.dart';
 import 'airo_cast_controller.dart';
 import 'phone_media_file_server.dart';
+import 'phone_media_seekable_source.dart';
 
 /// A process-local handle that keeps a selected media source readable.
 ///
@@ -27,6 +28,7 @@ class PhoneLocalMediaItem extends Equatable {
     required this.title,
     required this.container,
     this.sourceLease,
+    this.source,
     this.videoCodec,
     this.audioCodec,
     this.duration,
@@ -38,6 +40,7 @@ class PhoneLocalMediaItem extends Equatable {
   /// Container/extension in lowercase without a dot, e.g. `mp4`, `mkv`.
   final String container;
   final PhoneMediaSourceLease? sourceLease;
+  final PhoneMediaSeekableSource? source;
   final String? videoCodec;
   final String? audioCodec;
   final Duration? duration;
@@ -203,7 +206,8 @@ class PhoneMediaCastHandoff {
 
     // Synchronous check: widget tests run in a fake-async zone where real
     // file IO futures never complete before the pump settles.
-    if (!File(item.filePath).existsSync()) {
+    final source = item.source ?? FilePhoneMediaSeekableSource(item.filePath);
+    if (!source.isAvailable) {
       return const PhoneMediaHandoffFailed();
     }
 
@@ -211,7 +215,7 @@ class PhoneMediaCastHandoff {
         _castController.currentSessionState.device?.id ?? 'receiver-unknown';
     final server = PhoneMediaFileServer(
       snapshot: _snapshotFor(item, receiverNodeId),
-      filePath: item.filePath,
+      source: source,
       contentType: _contentTypeFor(item.container),
       bindAddress: _bindAddress,
       onDiagnosticEvent: onDiagnosticEvent,

--- a/packages/platform_player/lib/src/services/phone_media_file_server.dart
+++ b/packages/platform_player/lib/src/services/phone_media_file_server.dart
@@ -6,6 +6,7 @@ import 'package:core_media_routing/core_media_routing.dart';
 import 'package:flutter/foundation.dart';
 
 import '../models/phone_media_diagnostic_models.dart';
+import 'phone_media_seekable_source.dart';
 
 /// A network interface candidate for LAN binding: OS name plus its addresses.
 typedef PhoneMediaLanInterface = ({
@@ -24,7 +25,8 @@ typedef PhoneMediaLanInterface = ({
 class PhoneMediaFileServer implements AiroTemporaryMobileServerController {
   PhoneMediaFileServer({
     required AiroTemporaryMobileServerSnapshot snapshot,
-    required this.filePath,
+    String? filePath,
+    PhoneMediaSeekableSource? source,
     required this.contentType,
     this._servingPolicy = const AiroTemporaryMobileServerServingPolicy(),
     this._bindAddress,
@@ -33,13 +35,15 @@ class PhoneMediaFileServer implements AiroTemporaryMobileServerController {
     DateTime Function()? now,
     this.onDiagnosticEvent,
     this.onSessionEvent,
-  }) : _initialSnapshot = snapshot,
+  }) : assert(filePath != null || source != null),
+       _initialSnapshot = snapshot,
+       _source = source ?? FilePhoneMediaSeekableSource(filePath!),
        _interfaceLister = interfaceLister ?? _systemInterfaces,
        _sessionToken = sessionToken ?? _generateSessionToken(),
        _now = now ?? DateTime.now;
 
-  final String filePath;
   final String contentType;
+  final PhoneMediaSeekableSource _source;
   final AiroTemporaryMobileServerSnapshot _initialSnapshot;
   final AiroTemporaryMobileServerServingPolicy _servingPolicy;
   final InternetAddress? _bindAddress;
@@ -303,14 +307,12 @@ class PhoneMediaFileServer implements AiroTemporaryMobileServerController {
         return;
       }
 
-      final file = File(filePath);
-      if (!await file.exists()) {
+      if (!_source.isAvailable) {
         response.statusCode = HttpStatus.notFound;
         await response.close();
         return;
       }
-      final stat = await file.stat();
-      final length = stat.size;
+      final length = await _source.length();
       // Nonce-based validator: stable for the session, changes with length,
       // and never exposes the file mtime to LAN peers.
       final etag = '"$_entityTagNonce-${length.toRadixString(16)}"';
@@ -394,7 +396,7 @@ class PhoneMediaFileServer implements AiroTemporaryMobileServerController {
 
       final start = range?.start ?? 0;
       final end = range == null ? length : range.end + 1;
-      await response.addStream(file.openRead(start, end));
+      await response.addStream(_source.openRead(start, end));
       _lastActivityAt = _now();
       await response.close();
     } catch (error) {
@@ -455,7 +457,9 @@ class PhoneMediaFileServer implements AiroTemporaryMobileServerController {
     if (legacyHandler != null) {
       legacyHandler(event.kind.stableId, event.toPublicMap());
     } else {
-      debugPrint('[PhoneMediaServer] ${event.kind.stableId} ${event.toPublicMap()}');
+      debugPrint(
+        '[PhoneMediaServer] ${event.kind.stableId} ${event.toPublicMap()}',
+      );
     }
   }
 

--- a/packages/platform_player/lib/src/services/phone_media_seekable_source.dart
+++ b/packages/platform_player/lib/src/services/phone_media_seekable_source.dart
@@ -1,0 +1,33 @@
+import 'dart:io';
+
+/// A bounded, random-access media source consumed by the phone HTTP server.
+///
+/// Platform adapters may retain a permission-scoped descriptor instead of
+/// exposing a filesystem path. Reads use an exclusive end offset, matching
+/// [File.openRead].
+abstract interface class PhoneMediaSeekableSource {
+  bool get isAvailable;
+
+  Future<int> length();
+
+  Stream<List<int>> openRead(int start, int end);
+}
+
+/// Filesystem implementation used by desktop platforms and deterministic
+/// host tests.
+class FilePhoneMediaSeekableSource implements PhoneMediaSeekableSource {
+  FilePhoneMediaSeekableSource(this.filePath);
+
+  final String filePath;
+
+  File get _file => File(filePath);
+
+  @override
+  bool get isAvailable => _file.existsSync();
+
+  @override
+  Future<int> length() => _file.length();
+
+  @override
+  Stream<List<int>> openRead(int start, int end) => _file.openRead(start, end);
+}

--- a/packages/platform_player/test/phone_media_file_server_test.dart
+++ b/packages/platform_player/test/phone_media_file_server_test.dart
@@ -150,6 +150,35 @@ void main() {
     expect(body, mediaBytes.sublist(3996));
   });
 
+  test(
+    'serves a bounded high-offset range through a seekable source',
+    () async {
+      const mediaLength = 6 * 1024 * 1024 * 1024;
+      const start = 5 * 1024 * 1024 * 1024;
+      const endInclusive = start + 1023;
+      final source = _RecordingSeekableSource(mediaLength);
+      final server = PhoneMediaFileServer(
+        snapshot: snapshotFor(),
+        source: source,
+        contentType: 'video/mp4',
+        bindAddress: InternetAddress.loopbackIPv4,
+        sessionToken: 'seekable-source-token',
+      );
+      final url = await server.start();
+      addTearDown(server.stopServer);
+
+      final response = await request(url, range: 'bytes=$start-$endInclusive');
+      expect(response.statusCode, HttpStatus.partialContent);
+      expect(
+        response.headers.value(HttpHeaders.contentRangeHeader),
+        'bytes $start-$endInclusive/$mediaLength',
+      );
+      final body = await response.fold<List<int>>([], (a, b) => a..addAll(b));
+      expect(body, hasLength(1024));
+      expect(source.reads, [(start: start, end: endInclusive + 1)]);
+    },
+  );
+
   test('rejects unsatisfiable ranges with 416', () async {
     final server = serverFor();
     final url = await server.start();
@@ -535,4 +564,25 @@ void main() {
     expect(event.toString(), isNot(contains('/Users/')));
     expect(event.toPublicMap().toString(), isNot(contains('http://')));
   });
+}
+
+class _RecordingSeekableSource implements PhoneMediaSeekableSource {
+  _RecordingSeekableSource(this.mediaLength);
+
+  final int mediaLength;
+  final List<({int start, int end})> reads = [];
+
+  @override
+  bool get isAvailable => true;
+
+  @override
+  Future<int> length() async => mediaLength;
+
+  @override
+  Stream<List<int>> openRead(int start, int end) {
+    reads.add((start: start, end: end));
+    return Stream.value(
+      List<int>.generate(end - start, (index) => (start + index) % 251),
+    );
+  }
 }


### PR DESCRIPTION
## Summary

Delivers the first repository-only increment of #1155. `PhoneMediaFileServer` now consumes a reusable `PhoneMediaSeekableSource` instead of being hard-wired to reopen a filesystem path. Files remain the default implementation; platform adapters can supply a retained descriptor-backed source without copying a multi-gigabyte movie.

This PR intentionally does not claim the Android defect fixed and does not close #1155. The Android descriptor adapter and physical first-frame evidence remain follow-up acceptance work. No D-pad, focus, remote-navigation, UI, or product behavior changed.

## Test Plan

- [x] server + handoff + 5 GB soak suites: 45 passed
- [x] focused analyzer: clean
- [x] new fake-source test serves 1 KB at a simulated 5 GB offset
- [x] module manifests: 59 valid
- [x] docs completeness and `git diff --check`: clean

**Verification environment:** Host-only. Physical-device verification explicitly deferred.

## Agent Policy

- [x] #1155 includes Critical Agent gate, cross-agent contract, deterministic reproduction, and automation flow
- [x] Reusable source boundary is in `platform_player`; no app-local transport workaround
- [x] No full-file copy or main-isolate parser/serialization loop added
- [x] Android Emulator was not used

## Council Review

- Playback Architect: `platform_player` owner for the serving boundary
- Platform Architect: adapter seam established without implementing Android in application UI
- Chief Performance Officer: bounded high-offset source test; no full allocation/scan
- Chief Security Officer: source contract exposes bytes/length only and adds no diagnostic fields
- Chief QA Officer: existing and new focused suites pass

- [x] Decision Matrix checked
- [x] Existing `platform_player/module.yaml` remains valid

## User-Facing Documentation

- [x] No wiki update needed; this is an internal contract increment with no available capability claim

## Plugin and Size Impact

- [x] No dependency or plugin change
- [x] One 33-line framework contract plus focused wiring/tests

## Checklist

- [x] Code formatted
- [x] Tests included
- [x] No sensitive data or artifacts committed

## Release Notes

- [x] Not applicable; #1155 remains under qualification

Refs #1155.