### PR TITLE
feat(tv): align focus tokens to the D-pad design, honor reduced motion

### DIFF
--- a/app/test/core/tv/tv_focus_manager_test.dart
+++ b/app/test/core/tv/tv_focus_manager_test.dart
@@ -111,8 +111,11 @@ void main() {
   });
 
   group('TvFocusConstants', () {
+    // AiroTV D-pad design's reviewed token set
+    // (issues/02-focus-tokens-reduced-motion.md): 2.5lp border, 1.04 scale,
+    // 5lp ring at 20% opacity, 120ms motion.
     test('should have correct focus border width', () {
-      expect(TvFocusConstants.focusBorderWidth, equals(3.0));
+      expect(TvFocusConstants.focusBorderWidth, equals(2.5));
     });
 
     test('should have correct focus border radius', () {
@@ -122,16 +125,20 @@ void main() {
     test('should have correct animation duration', () {
       expect(
         TvFocusConstants.focusAnimationDuration,
-        equals(const Duration(milliseconds: 200)),
+        equals(const Duration(milliseconds: 120)),
       );
     });
 
     test('should have correct focus scale factor', () {
-      expect(TvFocusConstants.focusScaleFactor, equals(1.05));
+      expect(TvFocusConstants.focusScaleFactor, equals(1.04));
     });
 
     test('should have correct glow spread', () {
-      expect(TvFocusConstants.focusGlowSpread, equals(4.0));
+      expect(TvFocusConstants.focusGlowSpread, equals(5.0));
+    });
+
+    test('should have correct glow opacity', () {
+      expect(TvFocusConstants.focusGlowOpacity, equals(0.20));
     });
   });
 

--- a/app/test/core/tv/tv_integration_test.dart
+++ b/app/test/core/tv/tv_integration_test.dart
@@ -519,11 +519,12 @@ void main() {
     });
 
     test('TV should support D-pad focus states', () {
-      // From WEB-AC-005 adapted for TV
-      // TV focus indicators: border (3dp), scale (1.05x), glow
-      expect(TvFocusConstants.focusBorderWidth, equals(3.0));
-      expect(TvFocusConstants.focusScaleFactor, equals(1.05));
-      expect(TvFocusConstants.focusGlowSpread, equals(4.0));
+      // From WEB-AC-005 adapted for TV, tokens per the AiroTV D-pad design
+      // (issues/02-focus-tokens-reduced-motion.md): border (2.5dp),
+      // scale (1.04x), glow ring (5dp at 20% opacity)
+      expect(TvFocusConstants.focusBorderWidth, equals(2.5));
+      expect(TvFocusConstants.focusScaleFactor, equals(1.04));
+      expect(TvFocusConstants.focusGlowSpread, equals(5.0));
     });
 
     test('TV player controls should auto-hide after inactivity', () {
@@ -942,10 +943,10 @@ void main() {
     });
 
     test('Focus indicators provide sufficient contrast', () {
-      // Focus indicators use theme primary color with 3dp border
-      // and 4dp glow spread for visibility
-      expect(TvFocusConstants.focusBorderWidth, equals(3.0));
-      expect(TvFocusConstants.focusGlowSpread, equals(4.0));
+      // Focus indicators use theme primary color with a 2.5dp border
+      // and a 5dp glow spread ring for visibility
+      expect(TvFocusConstants.focusBorderWidth, equals(2.5));
+      expect(TvFocusConstants.focusGlowSpread, equals(5.0));
     });
   });
 

--- a/packages/core_ui/lib/src/widgets/tv_focusable.dart
+++ b/packages/core_ui/lib/src/widgets/tv_focusable.dart
@@ -148,15 +148,19 @@ class _TvInputHandlerState extends State<TvInputHandler> {
   }
 }
 
+/// The AiroTV D-pad design's single reviewed focus token set
+/// (issues/02-focus-tokens-reduced-motion.md): 2.5lp border, 1.04 scale,
+/// a 5lp ring at 20% opacity, 120ms motion. Every TvFocusable consumes
+/// these -- there is no per-screen override of the numeric values.
 class TvFocusConstants {
   TvFocusConstants._();
 
-  static const double focusBorderWidth = 3.0;
+  static const double focusBorderWidth = 2.5;
   static const double focusBorderRadius = 8.0;
-  static const Duration focusAnimationDuration = Duration(milliseconds: 200);
-  static const double focusScaleFactor = 1.05;
-  static const double focusGlowSpread = 4.0;
-  static const double focusGlowBlur = 24.0;
+  static const Duration focusAnimationDuration = Duration(milliseconds: 120);
+  static const double focusScaleFactor = 1.04;
+  static const double focusGlowSpread = 5.0;
+  static const double focusGlowOpacity = 0.20;
 }
 
 /// A focusable wrapper for TV/D-pad navigation: draws a focus ring + glow,
@@ -333,6 +337,15 @@ class _TvFocusableState extends State<TvFocusable>
     final focusColor =
         widget.focusColor ?? Theme.of(context).colorScheme.primary;
     final isButton = widget.semanticButton ?? widget.onSelect != null;
+    // OS-level reduced-motion (System Settings > Accessibility): scale and
+    // list auto-scroll become instantaneous, but the border/glow stays --
+    // focus must remain visible with motion disabled
+    // (issues/02-focus-tokens-reduced-motion.md).
+    final reduceMotion =
+        MediaQuery.maybeOf(context)?.disableAnimations ?? false;
+    _animationController.duration = reduceMotion
+        ? Duration.zero
+        : TvFocusConstants.focusAnimationDuration;
 
     Widget result = Focus(
       focusNode: _focusNode,
@@ -352,8 +365,10 @@ class _TvFocusableState extends State<TvFocusable>
                   boxShadow: widget.showGlowEffect
                       ? [
                           BoxShadow(
-                            color: focusColor.withValues(alpha: 0.35),
-                            blurRadius: TvFocusConstants.focusGlowBlur,
+                            color: focusColor.withValues(
+                              alpha: TvFocusConstants.focusGlowOpacity,
+                            ),
+                            spreadRadius: TvFocusConstants.focusGlowSpread,
                           ),
                         ]
                       : null,
@@ -365,7 +380,9 @@ class _TvFocusableState extends State<TvFocusable>
             child: child,
             builder: (context, child) {
               return Transform.scale(
-                scale: widget.showScaleEffect ? _scaleAnimation.value : 1,
+                scale: widget.showScaleEffect && !reduceMotion
+                    ? _scaleAnimation.value
+                    : 1,
                 child: DecoratedBox(
                   // Foreground, not background: an opaque child (e.g. a
                   // filled Material chip) fully covers a background-painted

--- a/packages/core_ui/test/widgets/tv_focusable_test.dart
+++ b/packages/core_ui/test/widgets/tv_focusable_test.dart
@@ -254,6 +254,82 @@ void main() {
 
     expect(secondaryCount, 1);
   });
+
+  // issues/02-focus-tokens-reduced-motion.md acceptance criterion 2:
+  // reduced motion makes focus scale instantaneous/absent without removing
+  // focus visibility (the border must still appear).
+  Widget wrap({required bool disableAnimations}) {
+    return MediaQuery(
+      data: MediaQueryData(disableAnimations: disableAnimations),
+      child: MaterialApp(
+        home: Scaffold(
+          body: Center(
+            child: SizedBox(
+              width: 160,
+              height: 80,
+              child: TvFocusable(
+                autofocus: true,
+                onSelect: () {},
+                child: const Center(child: Text('Focus me')),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  testWidgets('normal motion animates scale up to the design token (1.04) once '
+      'settled', (tester) async {
+    await tester.pumpWidget(wrap(disableAnimations: false));
+    await tester.pumpAndSettle();
+
+    final transform = tester.widget<Transform>(
+      find.descendant(
+        of: find.byType(TvFocusable),
+        matching: find.byType(Transform),
+      ),
+    );
+    expect(transform.transform.getMaxScaleOnAxis(), closeTo(1.04, 0.001));
+
+    final decoratedBox = tester.widget<DecoratedBox>(
+      find.descendant(
+        of: find.byType(TvFocusable),
+        matching: find.byType(DecoratedBox),
+      ),
+    );
+    final decoration = decoratedBox.decoration as BoxDecoration;
+    expect(decoration.border, isNotNull);
+  });
+
+  testWidgets(
+    'reduced motion keeps scale at 1.0 but still draws the focus border',
+    (tester) async {
+      await tester.pumpWidget(wrap(disableAnimations: true));
+      await tester.pumpAndSettle();
+
+      final transform = tester.widget<Transform>(
+        find.descendant(
+          of: find.byType(TvFocusable),
+          matching: find.byType(Transform),
+        ),
+      );
+      expect(transform.transform.getMaxScaleOnAxis(), closeTo(1.0, 0.001));
+
+      final decoratedBox = tester.widget<DecoratedBox>(
+        find.descendant(
+          of: find.byType(TvFocusable),
+          matching: find.byType(DecoratedBox),
+        ),
+      );
+      final decoration = decoratedBox.decoration as BoxDecoration;
+      expect(
+        decoration.border,
+        isNotNull,
+        reason: 'reduced motion must not remove focus visibility',
+      );
+    },
+  );
 }
 
 class _BuildCounter extends StatelessWidget {


### PR DESCRIPTION
## Summary
- `TvFocusConstants` (the single source of truth every `TvFocusable` consumes) carried placeholder values instead of the AiroTV D-pad design's reviewed token set. Updated: border 3.0→2.5, scale 1.05→1.04, glow 4.0/24.0(blur)→5.0 spread @ 20% opacity, duration 200ms→120ms.
- Fixed a latent bug in the process: `focusGlowSpread` was declared but never actually applied to the `BoxShadow` (only `blurRadius` was), so the glow ring geometry never matched any token set, old or new.
- Wired OS-level reduced motion (`MediaQuery.disableAnimations`) into `TvFocusable`: scale becomes instantaneous (stays at 1.0) and the animation controller's duration drops to zero, while the border/glow decoration -- already painted on the foreground so opaque children can't cover it -- keeps focus visible per acceptance criterion 2.
- No overlay slide/rise motion exists anywhere in the TV UX codebase yet (checked `tv_ux/` and `app/core/app/`), so that part of the criterion is vacuously satisfied -- nothing to suppress.
- Updated the two existing app-level tests that hard-asserted the old token values.

## Test plan
- [x] `flutter analyze` clean (`core_ui`, `app`)
- [x] New `core_ui` tests: normal motion animates scale to 1.04 with border visible; reduced motion holds scale at 1.0 with border still visible
- [x] Full `core_ui` suite: 68 passed
- [x] `app` TV focus/integration suites: 86 passed (updated to the new token values)
- [x] Full `feature_iptv` suite: 654 passed, 2 skipped, 1 pre-existing unrelated failure (`Play file on TV drawer entry...`)
- [ ] On-device re-verification on Fire TV Stick once it's back online (Vevo Pop / Aaj Tak / Music India / YRF Music only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)