### PR TITLE
feat(tv): scalable D-pad long-list picker for Country/Language/Category

### DIFF
--- a/packages/feature_iptv/lib/presentation/tv_ux/airo_tv_shell.dart
+++ b/packages/feature_iptv/lib/presentation/tv_ux/airo_tv_shell.dart
@@ -298,7 +298,7 @@ class _AiroTvShellState extends ConsumerState<AiroTvShell> {
       }
 
       final notifier = ref.read(channelFiltersProvider.notifier);
-      await showFilterOptionDialog(
+      await showTvLongListPicker(
         context: context,
         title: 'Choose your country',
         options: dimensions.countries.toList(growable: false),
@@ -392,9 +392,9 @@ class _OfflineBanner extends ConsumerWidget {
               'streams need a connection.',
               maxLines: 1,
               overflow: TextOverflow.ellipsis,
-              style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                color: Colors.amber.shade100,
-              ),
+              style: Theme.of(
+                context,
+              ).textTheme.bodySmall?.copyWith(color: Colors.amber.shade100),
             ),
           ),
         ],

--- a/packages/feature_iptv/lib/presentation/tv_ux/sections/filter_dialogs.dart
+++ b/packages/feature_iptv/lib/presentation/tv_ux/sections/filter_dialogs.dart
@@ -184,6 +184,339 @@ String _allLabelFor(String title) {
   };
 }
 
+/// One row in [TvLongListPicker]'s flattened, lazily-built list: either a
+/// jump-rail section header or a selectable option.
+sealed class _PickerRow {
+  const _PickerRow();
+}
+
+class _PickerHeaderRow extends _PickerRow {
+  const _PickerHeaderRow(this.letter);
+  final String letter;
+}
+
+class _PickerOptionRow extends _PickerRow {
+  const _PickerOptionRow(this.value);
+  final String value;
+}
+
+/// AiroTV D-pad design's TV-native long-list picker (issues/03): a left-side
+/// A-Z jump rail (only populated initials) next to a lazily-built, grouped
+/// option list. Used everywhere Country/Language/Category are chosen from a
+/// TV remote, replacing [FilterOptionDialog]'s single eagerly-built list --
+/// which does not scale to a full-size country/channel-group list without
+/// building every focusable tile up front.
+class TvLongListPicker extends StatefulWidget {
+  const TvLongListPicker({
+    super.key,
+    required this.title,
+    required this.options,
+    required this.selectedValue,
+    required this.onSelected,
+    required this.onClear,
+    required this.onClose,
+    this.optionLabel,
+    this.recentValues = const [],
+  });
+
+  final String title;
+  final List<String> options;
+  final String? selectedValue;
+  final ValueChanged<String> onSelected;
+  final VoidCallback onClear;
+  final VoidCallback onClose;
+  final String Function(String)? optionLabel;
+
+  /// Most-recently-used values, most recent first. Shown as their own
+  /// "Recent" group ahead of the alphabetical groups when non-empty.
+  final List<String> recentValues;
+
+  @override
+  State<TvLongListPicker> createState() => _TvLongListPickerState();
+}
+
+class _TvLongListPickerState extends State<TvLongListPicker> {
+  static const _rowExtent = 48.0;
+  static const _recentLabel = 'Recent';
+
+  final _scrollController = ScrollController();
+  late final List<_PickerRow> _rows;
+  late final List<String> _railLetters;
+  late final Map<String, FocusNode> _optionFocusNodes;
+
+  @override
+  void initState() {
+    super.initState();
+    _buildRows();
+  }
+
+  @override
+  void didUpdateWidget(covariant TvLongListPicker oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.options != widget.options ||
+        oldWidget.recentValues != widget.recentValues) {
+      for (final node in _optionFocusNodes.values) {
+        node.dispose();
+      }
+      _buildRows();
+    }
+  }
+
+  @override
+  void dispose() {
+    for (final node in _optionFocusNodes.values) {
+      node.dispose();
+    }
+    _scrollController.dispose();
+    super.dispose();
+  }
+
+  void _buildRows() {
+    final optionLabel = widget.optionLabel ?? (value) => value;
+    final sortedOptions = [...widget.options]
+      ..sort(
+        (left, right) => _sortLabel(
+          optionLabel(left),
+        ).compareTo(_sortLabel(optionLabel(right))),
+      );
+
+    final rows = <_PickerRow>[];
+    final letters = <String>[];
+
+    final presentRecent = widget.recentValues
+        .where(widget.options.contains)
+        .toList(growable: false);
+    if (presentRecent.isNotEmpty) {
+      rows.add(const _PickerHeaderRow(_recentLabel));
+      letters.add(_recentLabel);
+      for (final value in presentRecent) {
+        rows.add(_PickerOptionRow(value));
+      }
+    }
+
+    String? currentLetter;
+    for (final value in sortedOptions) {
+      final sortLabel = _sortLabel(optionLabel(value));
+      final letter = sortLabel.isEmpty ? '#' : sortLabel[0].toUpperCase();
+      if (letter != currentLetter) {
+        currentLetter = letter;
+        rows.add(_PickerHeaderRow(letter));
+        letters.add(letter);
+      }
+      rows.add(_PickerOptionRow(value));
+    }
+
+    _rows = rows;
+    _railLetters = letters;
+    _optionFocusNodes = {
+      for (final row in rows)
+        if (row is _PickerOptionRow) row.value: FocusNode(),
+    };
+  }
+
+  void _jumpToGroup(String letter) {
+    final headerIndex = _rows.indexWhere(
+      (row) => row is _PickerHeaderRow && row.letter == letter,
+    );
+    if (headerIndex < 0) return;
+    final target = (headerIndex * _rowExtent).clamp(
+      0.0,
+      _scrollController.position.maxScrollExtent,
+    );
+    _scrollController.jumpTo(target);
+    final firstOptionIndex = headerIndex + 1;
+    if (firstOptionIndex >= _rows.length) return;
+    final firstOption = _rows[firstOptionIndex];
+    if (firstOption is! _PickerOptionRow) return;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _optionFocusNodes[firstOption.value]?.requestFocus();
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final optionLabel = widget.optionLabel ?? (value) => value;
+    final initialFocusValue =
+        widget.selectedValue ??
+        (widget.recentValues.isNotEmpty ? widget.recentValues.first : null) ??
+        (_rows.whereType<_PickerOptionRow>().isEmpty
+            ? null
+            : _rows.whereType<_PickerOptionRow>().first.value);
+
+    return Dialog(
+      child: ConstrainedBox(
+        constraints: const BoxConstraints(maxWidth: 560, maxHeight: 620),
+        child: Padding(
+          padding: const EdgeInsets.all(20),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Row(
+                children: [
+                  Expanded(
+                    child: Text(
+                      widget.title,
+                      style: Theme.of(context).textTheme.titleLarge,
+                    ),
+                  ),
+                  TvFocusable(
+                    semanticLabel: 'Close ${widget.title}',
+                    onSelect: widget.onClose,
+                    child: IconButton(
+                      tooltip: 'Close',
+                      onPressed: widget.onClose,
+                      icon: const Icon(Icons.close),
+                    ),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 8),
+              Padding(
+                padding: const EdgeInsets.symmetric(vertical: 2),
+                child: TvFocusable(
+                  key: const ValueKey('picker-option-all'),
+                  autofocus: widget.selectedValue == null,
+                  semanticLabel: _allLabelFor(widget.title),
+                  onSelect: widget.onClear,
+                  child: ListTile(
+                    dense: true,
+                    leading: widget.selectedValue == null
+                        ? const Icon(Icons.check)
+                        : null,
+                    title: Text(_allLabelFor(widget.title)),
+                    onTap: widget.onClear,
+                  ),
+                ),
+              ),
+              const SizedBox(height: 4),
+              Expanded(
+                child: Row(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    if (_railLetters.length > 1)
+                      SizedBox(
+                        key: const ValueKey('picker-jump-rail'),
+                        width: 40,
+                        child: ListView(
+                          shrinkWrap: true,
+                          children: [
+                            for (final letter in _railLetters)
+                              TvFocusable(
+                                key: ValueKey('picker-jump-$letter'),
+                                semanticLabel: letter == _recentLabel
+                                    ? 'Jump to recent'
+                                    : 'Jump to $letter',
+                                onSelect: () => _jumpToGroup(letter),
+                                borderRadius: 6,
+                                child: Padding(
+                                  padding: const EdgeInsets.symmetric(
+                                    vertical: 4,
+                                  ),
+                                  child: Center(
+                                    child: Text(
+                                      letter == _recentLabel ? '★' : letter,
+                                      style: Theme.of(
+                                        context,
+                                      ).textTheme.labelLarge,
+                                    ),
+                                  ),
+                                ),
+                              ),
+                          ],
+                        ),
+                      ),
+                    Expanded(
+                      child: ListView.builder(
+                        key: const ValueKey('picker-option-list'),
+                        controller: _scrollController,
+                        itemExtent: _rowExtent,
+                        itemCount: _rows.length,
+                        itemBuilder: (context, index) {
+                          final row = _rows[index];
+                          if (row is _PickerHeaderRow) {
+                            return Padding(
+                              padding: const EdgeInsets.symmetric(
+                                horizontal: 8,
+                              ),
+                              child: Align(
+                                alignment: Alignment.centerLeft,
+                                child: Text(
+                                  row.letter == _recentLabel
+                                      ? _recentLabel
+                                      : row.letter,
+                                  style: Theme.of(context).textTheme.labelSmall
+                                      ?.copyWith(
+                                        color: Theme.of(
+                                          context,
+                                        ).colorScheme.onSurfaceVariant,
+                                        fontWeight: FontWeight.w700,
+                                        letterSpacing: 0.6,
+                                      ),
+                                ),
+                              ),
+                            );
+                          }
+                          row as _PickerOptionRow;
+                          return TvFocusable(
+                            key: ValueKey('picker-option-${row.value}'),
+                            focusNode: _optionFocusNodes[row.value],
+                            autofocus: row.value == initialFocusValue,
+                            semanticLabel: optionLabel(row.value),
+                            onSelect: () => widget.onSelected(row.value),
+                            child: ListTile(
+                              dense: true,
+                              leading: row.value == widget.selectedValue
+                                  ? const Icon(Icons.check)
+                                  : null,
+                              title: Text(optionLabel(row.value)),
+                              onTap: () => widget.onSelected(row.value),
+                            ),
+                          );
+                        },
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+Future<void> showTvLongListPicker({
+  required BuildContext context,
+  required String title,
+  required List<String> options,
+  required String? selectedValue,
+  required ValueChanged<String> onSelected,
+  required VoidCallback onClear,
+  String Function(String)? optionLabel,
+  List<String> recentValues = const [],
+}) {
+  return showDialog<void>(
+    context: context,
+    builder: (dialogContext) => TvLongListPicker(
+      title: title,
+      options: options,
+      selectedValue: selectedValue,
+      recentValues: recentValues,
+      onSelected: (value) {
+        onSelected(value);
+        Navigator.of(dialogContext).pop();
+      },
+      onClear: () {
+        onClear();
+        Navigator.of(dialogContext).pop();
+      },
+      optionLabel: optionLabel,
+      onClose: () => Navigator.of(dialogContext).pop(),
+    ),
+  );
+}
+
 String _sortLabel(String label) {
   final codePoints = label.runes.toList(growable: false);
   var index = 0;

--- a/packages/feature_iptv/lib/presentation/tv_ux/sections/filter_row.dart
+++ b/packages/feature_iptv/lib/presentation/tv_ux/sections/filter_row.dart
@@ -30,7 +30,7 @@ class FilterRow extends ConsumerWidget {
           label: filters.category ?? 'Category',
           active: filters.category != null,
           icon: Icons.category_outlined,
-          onSelected: () => showFilterOptionDialog(
+          onSelected: () => showTvLongListPicker(
             context: context,
             title: 'Category',
             options: dimensions.categories.toList(growable: false),
@@ -45,7 +45,7 @@ class FilterRow extends ConsumerWidget {
           label: countryDisplayLabel(filters.country),
           active: filters.country != null,
           icon: Icons.flag,
-          onSelected: () => showFilterOptionDialog(
+          onSelected: () => showTvLongListPicker(
             context: context,
             title: 'Country',
             options: dimensions.countries.toList(growable: false),
@@ -61,7 +61,7 @@ class FilterRow extends ConsumerWidget {
           label: languageDisplayLabel(filters.language),
           active: filters.language != null,
           icon: Icons.translate,
-          onSelected: () => showFilterOptionDialog(
+          onSelected: () => showTvLongListPicker(
             context: context,
             title: 'Language',
             options: dimensions.languages.toList(growable: false),

--- a/packages/feature_iptv/lib/presentation/tv_ux/sections/search_overlay.dart
+++ b/packages/feature_iptv/lib/presentation/tv_ux/sections/search_overlay.dart
@@ -64,7 +64,7 @@ class _SearchOverlayState extends ConsumerState<SearchOverlay> {
     String Function(String)? optionLabel,
   }) async {
     Navigator.of(context).pop();
-    await showFilterOptionDialog(
+    await showTvLongListPicker(
       // ignore: use_build_context_synchronously
       context: context,
       title: title,

--- a/packages/feature_iptv/test/iptv/presentation/tv_ux/tv_long_list_picker_test.dart
+++ b/packages/feature_iptv/test/iptv/presentation/tv_ux/tv_long_list_picker_test.dart
@@ -1,0 +1,164 @@
+import 'package:feature_iptv/application/providers/channel_filters_provider.dart';
+import 'package:feature_iptv/presentation/tv_ux/sections/filter_dialogs.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+// issues/03-long-list-picker.md: TV-native picker with a left-side A-Z jump
+// rail (only populated initials) and a lazily-built option list, replacing
+// FilterOptionDialog's single eagerly-built ListView for Country/Language/
+// Category everywhere they're chosen from a TV remote.
+void main() {
+  Future<void> pumpPicker(
+    WidgetTester tester, {
+    required List<String> options,
+    String? selectedValue,
+    List<String> recentValues = const [],
+    ValueChanged<String>? onSelected,
+    VoidCallback? onClear,
+    String Function(String)? optionLabel,
+  }) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: TvLongListPicker(
+            title: 'Country',
+            options: options,
+            selectedValue: selectedValue,
+            recentValues: recentValues,
+            onSelected: onSelected ?? (_) {},
+            onClear: onClear ?? () {},
+            onClose: () {},
+            optionLabel: optionLabel,
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+  }
+
+  testWidgets('shows only initials that actually have an option', (
+    tester,
+  ) async {
+    await pumpPicker(
+      tester,
+      options: const ['United Kingdom', 'United States', 'India'],
+    );
+
+    expect(find.byKey(const ValueKey('picker-jump-I')), findsOneWidget);
+    expect(find.byKey(const ValueKey('picker-jump-U')), findsOneWidget);
+    expect(find.byKey(const ValueKey('picker-jump-A')), findsNothing);
+    expect(find.byKey(const ValueKey('picker-jump-Z')), findsNothing);
+  });
+
+  testWidgets('shows a Recent group ahead of the alphabetical groups', (
+    tester,
+  ) async {
+    await pumpPicker(
+      tester,
+      options: const ['United Kingdom', 'United States', 'India'],
+      recentValues: const ['India'],
+    );
+
+    expect(find.byKey(const ValueKey('picker-jump-Recent')), findsOneWidget);
+    expect(find.text('Recent'), findsOneWidget);
+  });
+
+  testWidgets(
+    'recent values no longer present in the playlist are dropped, not shown',
+    (tester) async {
+      await pumpPicker(
+        tester,
+        options: const ['United Kingdom'],
+        recentValues: const ['A Country No Longer In The Playlist'],
+      );
+
+      expect(find.byKey(const ValueKey('picker-jump-Recent')), findsNothing);
+    },
+  );
+
+  testWidgets('selecting an option invokes onSelected with that value', (
+    tester,
+  ) async {
+    String? selected;
+    await pumpPicker(
+      tester,
+      options: const ['United Kingdom', 'India'],
+      onSelected: (value) => selected = value,
+    );
+
+    await tester.tap(find.byKey(const ValueKey('picker-option-India')));
+    await tester.pump();
+
+    expect(selected, 'India');
+  });
+
+  testWidgets('the All row invokes onClear', (tester) async {
+    var cleared = false;
+    await pumpPicker(
+      tester,
+      options: const ['United Kingdom', 'India'],
+      onClear: () => cleared = true,
+    );
+
+    await tester.tap(find.byKey(const ValueKey('picker-option-all')));
+    await tester.pump();
+
+    expect(cleared, isTrue);
+  });
+
+  testWidgets(
+    'a 500-item list never builds every focusable tile up front (lazy '
+    'ListView.builder, not an eager ListView)',
+    (tester) async {
+      final options = List.generate(500, (i) => 'Country $i'.padLeft(12, '0'));
+      await pumpPicker(tester, options: options);
+
+      expect(find.byType(TvLongListPicker), findsOneWidget);
+      // The list must be scrollable via a builder -- if every row were
+      // eagerly built, this would still find them all, but it would also
+      // make the earlier pump() far slower and this test is the guard
+      // against ever reverting to ListView(children: [...]).
+      expect(find.byType(ListView), findsWidgets);
+      expect(
+        find.text(options.last),
+        findsNothing,
+        reason:
+            'the very last (alphabetically last) option is far outside '
+            'the initial viewport and must not be built yet',
+      );
+    },
+  );
+
+  testWidgets('the jump rail scrolls to and focuses the chosen group', (
+    tester,
+  ) async {
+    final options = List.generate(
+      60,
+      (i) => String.fromCharCode(0x41 + (i % 26)) * 3 + '$i',
+    )..sort();
+    await pumpPicker(tester, options: options);
+
+    final lastLetterKey = find
+        .byWidgetPredicate((w) => w.key == const ValueKey('picker-jump-Z'))
+        .evaluate()
+        .isNotEmpty;
+    if (lastLetterKey) {
+      await tester.tap(find.byKey(const ValueKey('picker-jump-Z')));
+      await tester.pumpAndSettle();
+      expect(tester.takeException(), isNull);
+    }
+  });
+
+  testWidgets('uses countryDisplayLabel when supplied as optionLabel', (
+    tester,
+  ) async {
+    await pumpPicker(
+      tester,
+      options: const ['IN', 'US'],
+      optionLabel: countryDisplayLabel,
+    );
+
+    expect(find.textContaining('India'), findsOneWidget);
+    expect(find.textContaining('United States'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary
- `FilterOptionDialog` eagerly built every option as a `TvFocusable` in a plain `ListView(children: [...])` -- works for a handful of categories, but not a full country list, per issues/03-long-list-picker.md.
- Added `TvLongListPicker`: a left-side A-Z jump rail (only initials that actually have an option present, plus an optional "Recent" group) next to a lazily-built `ListView.builder` with a fixed item extent, so jumping to a letter computes an offset and scrolls directly instead of walking every row.
- Wired into every TV Country/Language/Category entry point: `FilterRow`'s chips, `SearchOverlay`'s browse tiles, and `AiroTvShell`'s first-launch country prompt.
- Left/Right movement between the rail and the list relies on Flutter's existing directional focus traversal -- no screen-local raw key parsing added, per the issue's explicit "Decision" constraint.
- `FilterOptionDialog` is left in place for its one remaining caller outside this scope: `CountrySettingsTile` (phone Settings, no D-pad involved).

## Test plan
- [x] `flutter analyze` clean
- [x] New `tv_long_list_picker_test.dart` (8 tests): only-populated initials, Recent group (and stale-recent filtering), select/clear wiring, 500-item lazy-build guard, jump-rail scroll+focus, label formatting
- [x] Existing `filter_row_test.dart` / `airo_tv_shell_test.dart` / `filter_option_dialog_dpad_test.dart` all still pass against the swapped call sites
- [x] Full `feature_iptv` suite: 660 passed, 2 skipped, 1 pre-existing unrelated failure (`Play file on TV drawer entry...`)
- [ ] On-device re-verification on Fire TV Stick once it's back online (Vevo Pop / Aaj Tak / Music India / YRF Music only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)