### PR TITLE
feat(tv): shared, tested overscan-safe-area primitive (32x24)

### DIFF
--- a/packages/core_ui/lib/core_ui.dart
+++ b/packages/core_ui/lib/core_ui.dart
@@ -30,6 +30,7 @@ export 'src/widgets/empty_state_widget.dart';
 export 'src/widgets/airo_responsive_scaffold.dart';
 export 'src/widgets/tv_focus_manager.dart';
 export 'src/widgets/tv_focusable.dart';
+export 'src/widgets/tv_overscan_safe_area.dart';
 
 // Adaptive UI
 export 'src/adaptive/adaptive_ui_models.dart';

--- a/packages/core_ui/lib/src/widgets/tv_overscan_safe_area.dart
+++ b/packages/core_ui/lib/src/widgets/tv_overscan_safe_area.dart
@@ -1,0 +1,40 @@
+import 'package:flutter/widgets.dart';
+
+/// The AiroTV D-pad design's overscan-safe budget
+/// (issues/05-device-scaling-overscan.md acceptance criterion 1): no
+/// actionable content may cross 32 logical pixels horizontally or 24
+/// vertically from the screen edge, since some TV panels/boxes (notably
+/// older Fire TV hardware) crop or hide content in that band.
+///
+/// This is a single source of truth for the inset values -- consolidating
+/// what one screen already inlined as a magic literal -- not a claim that
+/// every TV screen has been measured against it on real hardware. That
+/// qualification (physical Fire TV Stick Lite/4K, Google/Android TV
+/// devices; screenshots, MediaQuery values, focus traces) is tracked
+/// separately per the issue's own device-matrix requirement.
+class TvOverscanConstants {
+  TvOverscanConstants._();
+
+  static const double horizontalInset = 32.0;
+  static const double verticalInset = 24.0;
+
+  static const EdgeInsets padding = EdgeInsets.symmetric(
+    horizontal: horizontalInset,
+    vertical: verticalInset,
+  );
+}
+
+/// Applies [TvOverscanConstants.padding] around [child]. A thin,
+/// intention-revealing wrapper so screens opt into the shared budget by
+/// name instead of re-typing the literal `EdgeInsets.fromLTRB(32, 24, 32,
+/// 24)` (or drifting from it) at each call site.
+class TvOverscanSafeArea extends StatelessWidget {
+  const TvOverscanSafeArea({super.key, required this.child});
+
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(padding: TvOverscanConstants.padding, child: child);
+  }
+}

--- a/packages/core_ui/test/widgets/tv_overscan_safe_area_test.dart
+++ b/packages/core_ui/test/widgets/tv_overscan_safe_area_test.dart
@@ -1,0 +1,56 @@
+import 'package:core_ui/core_ui.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+// issues/05-device-scaling-overscan.md acceptance criterion 1: no
+// actionable content may cross the 32x24 logical-pixel overscan budget.
+// This proves the shared primitive itself is correct at the required
+// device-matrix logical sizes; it does not substitute for the physical
+// device qualification pass the issue calls for separately.
+void main() {
+  test('constants match the design\'s 32x24 budget', () {
+    expect(TvOverscanConstants.horizontalInset, 32.0);
+    expect(TvOverscanConstants.verticalInset, 24.0);
+    expect(
+      TvOverscanConstants.padding,
+      const EdgeInsets.symmetric(horizontal: 32, vertical: 24),
+    );
+  });
+
+  for (final size in [
+    const Size(960, 540),
+    const Size(1280, 720),
+    const Size(1920, 1080),
+  ]) {
+    testWidgets('insets content by exactly 32x24 at ${size.width.toInt()}x'
+        '${size.height.toInt()}', (tester) async {
+      tester.view.physicalSize = size;
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.reset);
+
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: TvOverscanSafeArea(
+            child: ColoredBox(
+              color: Colors.black,
+              child: SizedBox.expand(key: ValueKey('content')),
+            ),
+          ),
+        ),
+      );
+
+      final contentRect = tester.getRect(find.byKey(const ValueKey('content')));
+
+      expect(contentRect.left, TvOverscanConstants.horizontalInset);
+      expect(contentRect.top, TvOverscanConstants.verticalInset);
+      expect(
+        size.width - contentRect.right,
+        TvOverscanConstants.horizontalInset,
+      );
+      expect(
+        size.height - contentRect.bottom,
+        TvOverscanConstants.verticalInset,
+      );
+    });
+  }
+}

--- a/packages/feature_iptv/lib/presentation/tv/iptv_tv_screen.dart
+++ b/packages/feature_iptv/lib/presentation/tv/iptv_tv_screen.dart
@@ -2227,8 +2227,7 @@ class _TvEmptyPlaylistLayout extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Padding(
-      padding: const EdgeInsets.fromLTRB(32, 24, 32, 24),
+    return TvOverscanSafeArea(
       child: Column(
         children: [
           _TvLiteReceiverShellHeader(productProfile: productProfile),


### PR DESCRIPTION
## Summary
issues/05-device-scaling-overscan.md is explicitly a **QA qualification slice**, not a code-architecture task — its own "Decision" says: *"Do not 'fix' dimensions until screenshots, MediaQuery values, focus traces, and frame timings identify a real defect."* That evidence requires physical Fire TV Stick Lite/4K, Google/Android TV, and Android TV box hardware, none of which is available right now (Fire TV Stick is offline this session).

What's actually addressable without hardware: the design's 32×24 logical-pixel overscan budget already existed, correctly, in exactly one place (`_TvEmptyPlaylistLayout`) as an inlined `EdgeInsets.fromLTRB(32, 24, 32, 24)` literal. Following Issue 02's precedent (centralizing focus tokens), this consolidates it into a single named `core_ui` source of truth — `TvOverscanConstants` / `TvOverscanSafeArea` — and tests it holds at the design's own logical-size matrix (960×540, 1280×720, 1920×1080), rather than rewriting every TV screen's padding on a guess (which the issue explicitly prohibits).

**This is not a claim that overscan conformance is verified on real hardware.** The Markdown Pass/Fail device matrix and physical remote validation the issue calls for remain a separate, hardware-gated follow-up once the Fire TV Stick (or other test hardware) is available again.

## Test plan
- [x] `flutter analyze` clean (`core_ui`, `feature_iptv`)
- [x] New `tv_overscan_safe_area_test.dart` (4 tests): constants match spec, exact 32×24 inset proven at all three required logical sizes
- [x] Full `core_ui` suite: 70 passed
- [x] `iptv_tv_screen_test.dart`: 15 passed (empty-playlist state unchanged behaviorally)
- [x] Full `feature_iptv` suite: 662 passed, 2 skipped, 1 pre-existing unrelated failure
- [ ] Physical device qualification matrix (blocked on hardware access — Fire TV Stick Lite/4K, Google/Android TV, Android TV box)

🤖 Generated with [Claude Code](https://claude.com/claude-code)