### PR TITLE
fix(player): type phone-media source failures

### DIFF
--- a/packages/platform_player/lib/src/services/phone_media_file_server.dart
+++ b/packages/platform_player/lib/src/services/phone_media_file_server.dart
@@ -399,6 +399,25 @@ class PhoneMediaFileServer implements AiroTemporaryMobileServerController {
       await response.addStream(_source.openRead(start, end));
       _lastActivityAt = _now();
       await response.close();
+    } on PhoneMediaSourceException catch (error) {
+      _emit(
+        PhoneMediaDiagnosticEvent(
+          kind: PhoneMediaDiagnosticEventKind.requestError,
+          errorType: 'source_${error.code.stableId}',
+        ),
+      );
+      try {
+        response.statusCode = switch (error.code) {
+          PhoneMediaSourceFailureCode.unavailable => HttpStatus.notFound,
+          PhoneMediaSourceFailureCode.closed => HttpStatus.gone,
+          PhoneMediaSourceFailureCode.permissionLost => HttpStatus.forbidden,
+          PhoneMediaSourceFailureCode.readFailed =>
+            HttpStatus.internalServerError,
+        };
+        await response.close();
+      } catch (_) {
+        // Response headers or socket may already be committed.
+      }
     } catch (error) {
       _emit(
         PhoneMediaDiagnosticEvent(

--- a/packages/platform_player/lib/src/services/phone_media_seekable_source.dart
+++ b/packages/platform_player/lib/src/services/phone_media_seekable_source.dart
@@ -1,5 +1,29 @@
 import 'dart:io';
 
+enum PhoneMediaSourceFailureCode {
+  unavailable('unavailable'),
+  closed('closed'),
+  permissionLost('permission_lost'),
+  readFailed('read_failed');
+
+  const PhoneMediaSourceFailureCode(this.stableId);
+
+  final String stableId;
+}
+
+/// A redacted platform-source failure.
+///
+/// Platform exceptions, paths, document URIs, and descriptor values must not
+/// cross this boundary. Callers receive only a stable reason code.
+class PhoneMediaSourceException implements Exception {
+  const PhoneMediaSourceException(this.code);
+
+  final PhoneMediaSourceFailureCode code;
+
+  @override
+  String toString() => 'PhoneMediaSourceException(${code.stableId})';
+}
+
 /// A bounded, random-access media source consumed by the phone HTTP server.
 ///
 /// Platform adapters may retain a permission-scoped descriptor instead of

--- a/packages/platform_player/test/phone_media_file_server_test.dart
+++ b/packages/platform_player/test/phone_media_file_server_test.dart
@@ -179,6 +179,44 @@ void main() {
     },
   );
 
+  for (final fixture in [
+    (code: PhoneMediaSourceFailureCode.closed, status: HttpStatus.gone),
+    (
+      code: PhoneMediaSourceFailureCode.permissionLost,
+      status: HttpStatus.forbidden,
+    ),
+    (
+      code: PhoneMediaSourceFailureCode.readFailed,
+      status: HttpStatus.internalServerError,
+    ),
+  ]) {
+    test(
+      'maps ${fixture.code.stableId} source failures deterministically',
+      () async {
+        final events = <PhoneMediaDiagnosticEvent>[];
+        final server = PhoneMediaFileServer(
+          snapshot: snapshotFor(),
+          source: _FailingSeekableSource(fixture.code),
+          contentType: 'video/mp4',
+          bindAddress: InternetAddress.loopbackIPv4,
+          sessionToken: 'source-failure-token',
+          onDiagnosticEvent: events.add,
+        );
+        final url = await server.start();
+        addTearDown(server.stopServer);
+
+        final response = await request(url, method: 'HEAD');
+
+        expect(response.statusCode, fixture.status);
+        final error = events.singleWhere(
+          (event) => event.kind == PhoneMediaDiagnosticEventKind.requestError,
+        );
+        expect(error.errorType, 'source_${fixture.code.stableId}');
+        expect(error.toString(), isNot(contains('source-failure-token')));
+      },
+    );
+  }
+
   test('rejects unsatisfiable ranges with 416', () async {
     final server = serverFor();
     final url = await server.start();
@@ -585,4 +623,21 @@ class _RecordingSeekableSource implements PhoneMediaSeekableSource {
       List<int>.generate(end - start, (index) => (start + index) % 251),
     );
   }
+}
+
+class _FailingSeekableSource implements PhoneMediaSeekableSource {
+  _FailingSeekableSource(this.code);
+
+  final PhoneMediaSourceFailureCode code;
+
+  @override
+  bool get isAvailable => true;
+
+  @override
+  Future<int> length() async {
+    throw PhoneMediaSourceException(code);
+  }
+
+  @override
+  Stream<List<int>> openRead(int start, int end) => const Stream.empty();
 }


### PR DESCRIPTION
## Summary

Second repository-only increment for #1155. Adds redacted stable failure codes to the seekable phone-media source contract and deterministic HTTP mappings:

- unavailable → 404
- closed → 410
- permission lost → 403
- read failed → 500

Diagnostics emit only stable values such as `source_permission_lost`; platform exception messages, document URIs, paths, descriptor ids, and session tokens remain outside the contract. No Android adapter or physical-device qualification is claimed. No D-pad/UI work.

## Test Plan

- [x] RED/GREEN tests for closed, permission-lost, and read-failed sources
- [x] server + handoff + 5 GB soak suites: 48 passed
- [x] focused analyzer clean
- [x] 59 module manifests valid
- [x] docs completeness and `git diff --check` clean

**Verification environment:** Host-only.

## Agent Policy

- [x] #1155 has Critical Agent gate and cross-agent contract
- [x] Failure semantics remain in framework code
- [x] No full-file copy or bulk main-isolate serialization
- [x] Physical verification remains explicitly deferred

## Council Review

- Playback Architect: source/server contract
- Platform Architect: stable adapter-facing failure taxonomy
- Chief Security Officer: redacted codes only
- Chief QA Officer: deterministic failure table

## User-Facing Documentation

- [x] No wiki change; internal contract only

## Plugin and Size Impact

- [x] No dependency/plugin change

## Checklist

- [x] Formatted and tested
- [x] No sensitive data committed

Refs #1155; does not close it.