### PR TITLE
docs(wiki): align finance claims with Airo Coins status

### DIFF
--- a/docs/wiki/1.-Overview.md
+++ b/docs/wiki/1.-Overview.md
@@ -1,20 +1,22 @@
 # What Is Airo?
 
-Airo is a cross-platform super app that brings everyday AI, finance, media, and
-task workflows into one Flutter application.
+Airo is a modular, local-first platform. Airo TV is its first available focused
+product. Other areas remain part of the Airo umbrella until published release
+evidence establishes a different claim state.
 
 It is built to:
 
-- **Run useful workflows from one app:** Money, Assistant, Music, TV, Games, and
-  Tasks are available from the main navigation.
+- **Keep module status explicit:** Airo TV is available; Airo Coins is in
+  development; other areas remain exploratory unless a release proves
+  availability.
 - **Use AI where it helps:** The Assistant can chat, route commands, draft plans,
   calculate bill splits, and open Airo tools.
 - **Prefer local execution:** On supported devices, Airo initializes Gemini Nano
   for faster and more private on-device responses.
 - **Make documents actionable:** Quest workflows let users upload files and ask
   questions about them.
-- **Keep personal workflows practical:** Expense sharing, budgets, games, media,
-  and file-based tasks are designed as real app surfaces, not demos.
+- **Keep public claims evidence-backed:** Repository code, tests, or historical
+  routes do not by themselves prove that a capability ships.
 
 ## Key Capabilities
 
@@ -23,10 +25,9 @@ It is built to:
 - **Agent Skills:** Use Gallery-style prompt cards for Airo actions such as bill
   splitting, diet planning, routines, image/file analysis, model management, and
   games.
-- **Split Bill:** Split a total in chat or open the Split Bill flow for richer
-  expense sharing.
-- **Money Dashboard:** Track balances, expenses, budgets, groups, and shared
-  splits.
+- **Airo Coins — In development:** A focused, local-first vault direction for
+  organizing essential financial records behind locked access, masked
+  summaries, and deliberate reveal. It is not publicly released.
 - **Quest:** Upload PDFs, images, text files, or documents and continue in a
   quest chat.
 - **Model Management:** Open model settings from the Assistant profile area.
@@ -35,13 +36,23 @@ It is built to:
 - **Arena Games:** Play available games such as Chess and Blackjack, with more
   documented games planned.
 
-## Current Navigation
+## Repository Navigation Reference
 
-| Tab | Route | Purpose |
+The repository contains historical and in-development super-app routes. This
+table is a source-navigation reference, not a release or availability matrix.
+Always use the [public product page](https://developerscoffee.github.io/airo/)
+for current claim states.
+
+| Area | Historical/source route | Public status |
 | --- | --- | --- |
-| Dashboard | `/money` | Finance dashboard, budgets, groups, and bill split |
+| Airo Coins / legacy Money | `/money` | In development; no public Coins release |
 | Assistant | `/agent` | Chat, prompt cards, AI commands, model profile |
 | Music | `/beats` | Music playback |
 | TV | `/stream` | TV/IPTV playback |
 | Games | `/games` | Arena games |
 | Tasks | `/quest` | File upload and quest chat |
+
+The legacy `/money` tree must not be used as evidence that balances,
+transactions, budgets, groups, shared splits, or payment behavior are publicly
+available. See [Airo Coins](https://developerscoffee.github.io/airo/coins/) for
+the approved direction and product boundary.

--- a/docs/wiki/3.-Navigating-Airo.md
+++ b/docs/wiki/3.-Navigating-Airo.md
@@ -1,24 +1,23 @@
 # Navigating Airo
 
-Airo is organized around six primary tabs.
+Airo's repository contains a legacy super-app navigation model alongside newer
+focused modules. Routes documented here describe source organization; they do
+not establish public availability.
 
-## Dashboard
+## Airo Coins and legacy Money routes
 
-The Dashboard tab opens `/money`. Use it to view financial state, add expenses,
-manage budgets, open groups, and launch bill splitting.
+Airo Coins is **in development** and has no public release artifact. The
+repository still contains legacy Money routes under `/money`; they are
+historical source and migration context, not a currently supported public
+finance journey.
 
-Header behavior:
+Do not rely on the public wiki for instructions to enter balances, review
+transactions, manage budgets or groups, add expenses, or create shared splits.
+Those legacy workflows are outside the released Airo Coins claim.
 
-- `/money` uses the shared shell header.
-- nested money routes switch to their own contextual app bars.
-
-Common routes:
-
-- `/money`
-- `/money/split`
-- `/money/add-expense`
-- `/money/budgets`
-- `/money/groups`
+See [Airo Coins](https://developerscoffee.github.io/airo/coins/) for the
+approved vault direction, explicit financial boundaries, and public evidence
+links.
 
 ## Assistant
 

--- a/docs/wiki/4.-Using-Core-Capabilities.md
+++ b/docs/wiki/4.-Using-Core-Capabilities.md
@@ -15,25 +15,25 @@ Examples:
 - `Make me a 7 day vegetarian diet plan`
 - `Create a morning study routine for tomorrow`
 
-## Split Bill
+## Airo Coins — In development
 
-Use chat for quick equal splits or open the full bill split flow.
+Airo Coins is not yet a publicly released capability. Its approved first
+direction is a focused, local-first vault journey for organizing essential
+financial records:
 
-Examples:
+- Enter through a clear locked boundary.
+- Scan grouped summaries without exposing full sensitive values.
+- Reveal or copy a selected value through an intentional interaction.
+- Return to a locked state on background, timeout, or manual lock.
 
-- `Split this ₹2400 bill with Asha, Ben and Chen`
-- Open **Dashboard** then **Split Bill** for receipt or participant details.
+These outcomes remain **in development** until a published release proves
+availability. The concept does not provide banking, payments, money transfer,
+investments, token value, returns, or financial advice.
 
-## Money Dashboard
-
-Use Dashboard for finance workflows:
-
-- View total balance.
-- Review recent transactions.
-- Track budgets.
-- Add expenses.
-- Manage groups.
-- Add shared splits inside a group.
+Legacy Dashboard, balance, transaction, budget, expense, group, and split-bill
+code may still appear in repository history or source routes. It is not the
+public Airo Coins product contract. Follow the current status at
+[Airo Coins](https://developerscoffee.github.io/airo/coins/).
 
 ## LifeTrack
 

--- a/docs/wiki/5.-AI-and-Model-Management.md
+++ b/docs/wiki/5.-AI-and-Model-Management.md
@@ -17,8 +17,8 @@ on the device.
 Assistant messages follow this order:
 
 1. Parse the message for known Airo intents.
-2. Execute matching local tools, such as opening Money, Games, Quest, or Split
-   Bill.
+2. Execute a matching local tool only when that tool belongs to the current
+   build and release profile.
 3. Use AI generation for general prompts that do not map to a local tool.
 
 ## LifeTrack Status Queries
@@ -46,7 +46,8 @@ You can:
 
 ## Current Skill Cards
 
-The Assistant currently exposes these Gallery-style cards:
+The repository documents these Gallery-style cards. Their presence in source
+does not establish that the underlying product workflow is publicly available:
 
 - AI Chat
 - Agent Skills
@@ -58,6 +59,10 @@ The Assistant currently exposes these Gallery-style cards:
 - Mobile Actions
 - Model Management
 - Arena Games
+
+Finance-oriented cards and legacy Money/Split Bill intents do not upgrade Airo
+Coins beyond its **in development** state. See the
+[current Coins boundary](https://developerscoffee.github.io/airo/coins/).
 
 ## Model Profile
 

--- a/docs/wiki/6.-Privacy-and-Local-Data.md
+++ b/docs/wiki/6.-Privacy-and-Local-Data.md
@@ -24,15 +24,25 @@ files as private user data. Any new PR that changes file handling must document:
 - Whether processing is local, remote, or mixed.
 - Any deletion or retention behavior visible to users.
 
-## Money Data
+## Airo Coins data — in-development direction
 
-Money, expenses, groups, and shared splits represent sensitive personal data.
-New finance features must document:
+Airo Coins is not publicly released. Its approved direction treats financial
+records as sensitive personal data and starts from a local-first, locked vault
+boundary. Public documentation must not imply that legacy Money workflows,
+cloud sync, payments, transfers, exports, or sharing are shipped.
 
-- What data is stored.
-- Whether data syncs beyond the device.
-- Any export, sharing, or payment behavior.
-- Confirmation behavior for writes or sends.
+Before any future Coins capability can be described as available, its release
+evidence must document:
+
+- what record categories and fields are stored;
+- whether processing and retention stay on the device;
+- whether any data syncs, exports, or shares beyond the device;
+- deletion and recovery behavior;
+- confirmation behavior for reveals, copies, writes, exports, or sends.
+
+Airo Coins is not a bank, payment service, cryptocurrency, token sale,
+investment product, or financial adviser. See the
+[current Coins boundary](https://developerscoffee.github.io/airo/coins/).
 
 ## Model and Connector Data
 

--- a/docs/wiki/7.-Troubleshooting-and-FAQ.md
+++ b/docs/wiki/7.-Troubleshooting-and-FAQ.md
@@ -8,8 +8,9 @@
 
 ## Login Redirects Me Back to Sign In
 
-Airo protects most routes behind authentication. Sign in or create an account
-before opening Dashboard, Assistant, Music, TV, Games, or Tasks.
+Airo can protect app routes behind authentication. Follow the guidance shipped
+with the specific release profile you installed; repository routes are not by
+themselves proof that a module is publicly available.
 
 ## On-Device AI Is Not Available
 
@@ -56,7 +57,9 @@ or general transcoding path.
 ## FAQ
 
 **Q: Is Airo only an AI app?**
-A: No. Airo combines AI with finance, file tasks, media, games, and app actions.
+A: No. Airo is a modular platform for focused experiences. Airo TV is
+available, Airo Coins is in development, and other module areas retain their
+own evidence-backed claim states.
 
 **Q: Does Airo work offline?**
 A: Some workflows are designed for local or offline execution, especially

--- a/docs/wiki/9.-Useful-Links.md
+++ b/docs/wiki/9.-Useful-Links.md
@@ -5,6 +5,8 @@
 - [Airo repository](https://github.com/DevelopersCoffee/airo)
 - [Airo releases](https://github.com/DevelopersCoffee/airo/releases)
 - [Airo issues](https://github.com/DevelopersCoffee/airo/issues)
+- [Airo public product status](https://developerscoffee.github.io/airo/)
+- [Airo Coins — in development](https://developerscoffee.github.io/airo/coins/)
 - [Main documentation](../README.md)
 - [Download verification](../../VERIFY_DOWNLOAD.md)
 - [Trust and transparency](../../TRUST.md)

--- a/docs/wiki/Home.md
+++ b/docs/wiki/Home.md
@@ -1,12 +1,18 @@
 # Airo User Guide
 
-Welcome to the public user guide for Airo, a Flutter super app for on-device AI,
-money workflows, media, games, and task-oriented file analysis.
+Welcome to the public user guide for Airo, a modular, local-first platform for
+focused experiences.
 
-Airo combines an assistant surface with practical app modules: split bills,
-track expenses, upload files for AI-assisted quests, play games, listen to
-music, watch TV streams, and manage offline AI models where device support is
-available.
+Airo TV is the available focused product. Other module areas have their own
+public claim states: Airo Coins is **in development**, while additional AI,
+productivity, media, and entertainment directions remain subject to release
+evidence. The wiki must not be read as proof that code present in the
+repository is available in a published app.
+
+For the current product hierarchy and claim states, start with the
+[Airo public site](https://developerscoffee.github.io/airo/). For the finance
+direction and its explicit boundaries, see
+[Airo Coins](https://developerscoffee.github.io/airo/coins/).
 
 Start here:
 


### PR DESCRIPTION
## Summary

- reconcile legacy finance wiki claims with the evidence-backed Airo Coins
  `In development` state
- stop presenting balances, transactions, budgets, expenses, groups,
  split-bill flows, and `/money` routes as released user journeys
- describe `/money` as historical/source and migration context
- add direct links to the live Airo product-status and Coins boundary pages
- preserve unrelated AI, TV, games, music, task, and platform documentation

Closes #1172

## Test Plan

- [x] Relevant docs audit passed:
  `python3 .agents/skills/airo-release-branding/scripts/audit_public_page.py`
- [x] `scripts/check-docs-completeness.sh` passed
- [x] Changed-wiki relative links resolve
- [x] Focused searches find no legacy finance usage instructions
- [x] `git diff --check` passed
- [x] Manual device/simulator verification documented, or not applicable

**Verification environment:** Host-only documentation checks. No runtime,
device, simulator, emulator, or application package is changed.

## Agent Policy

- [x] Linked issue includes a Critical Agent Gate.
- [x] Linked issue includes a Feature Packet or documents why one is not needed.
- [x] Cross-agent contract is documented for framework/application boundary work.
- [x] Deterministic use cases and automation flows are linked or included.
- [x] AI/tool/memory/routine changes include eval, trace, and redaction coverage.
  Not applicable: no runtime behavior changes.
- [x] Android Emulator was not used unless the linked issue explicitly accepted
      `AIRO_ALLOW_ANDROID_EMULATOR=true`.

## Council Review

Required roles:

- Coins / Finance Agent: product truth owner
- Chief Documentation Officer: public wiki owner
- Product Manager: claim state and hierarchy review
- Chief Security Officer: finance/privacy boundary review
- Chief QA Officer: deterministic documentation validation

Reviews remain pending until recorded by maintainers on this PR.

- [x] I checked the Decision Matrix and listed every required role above.
- [x] Every package touched has a `module.yaml`; not applicable because no
      package is touched.
- [ ] `owner`/`reviewers` in touched `module.yaml` match actual reviews; no
      module manifest is touched and council review is pending.

## User-Facing Documentation

- [x] I updated `docs/wiki` for the finance/Coins documentation impact.
- [ ] No `docs/wiki` update is needed.

## Plugin and Size Impact

- [ ] This PR adds new dependencies
- [ ] This PR adds or grows app/packages/plugins code
- [x] Size impact is documented below
- [x] Any module over 3 MB is a plugin or has an explicit plugin marker
- [x] Any plugin over 5 MB has cache-management documentation

Size impact / plugin justification:

Markdown-only wording changes. No application binary, dependency, package,
plugin, runtime, or cache impact.

## Checklist

- [x] Code is formatted.
- [x] Tests or manual verification are included above.
- [x] Sensitive data, credentials, and signing artifacts are not committed.

## Release Notes

- [x] User-facing change documented

The wiki now follows the live public product hierarchy: Airo TV is available;
Airo Coins is in development and has no public release artifact.
