### PR TITLE
chore(app): fix dart format drift in tv_shell_test.dart

### DIFF
--- a/app/test/adaptive_tv_settings_screen_test.dart
+++ b/app/test/adaptive_tv_settings_screen_test.dart
@@ -30,24 +30,32 @@ void main() {
     );
   }
 
-  testWidgets('phone-sized layout shows the settings hub with theme picker', (
-    tester,
-  ) async {
-    tester.view.physicalSize = const Size(400, 850);
-    tester.view.devicePixelRatio = 1.0;
-    addTearDown(tester.view.reset);
+  testWidgets(
+    'phone-sized layout shows the settings hub with an Appearance entry '
+    'that opens the theme picker',
+    (tester) async {
+      tester.view.physicalSize = const Size(400, 850);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.reset);
 
-    await tester.pumpWidget(wrap(const Size(400, 850)));
-    await tester.pumpAndSettle();
+      await tester.pumpWidget(wrap(const Size(400, 850)));
+      await tester.pumpAndSettle();
 
-    expect(find.text('Appearance'), findsOneWidget);
-    expect(find.text('Airo Classic'), findsOneWidget);
-    expect(
-      find.byWidgetPredicate((w) => w is RadioListTile),
-      findsWidgets,
-      reason: 'theme options must be selectable on phones',
-    );
-  });
+      expect(find.text('Appearance'), findsOneWidget);
+      // The theme picker (RadioListTile per AppThemeId) lives on its own
+      // ThemeSettingsScreen, reached via the Appearance entry -- not
+      // inline on the hub.
+      await tester.tap(find.text('Appearance'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Airo Classic'), findsOneWidget);
+      expect(
+        find.byWidgetPredicate((w) => w is RadioListTile),
+        findsWidgets,
+        reason: 'theme options must be selectable on phones',
+      );
+    },
+  );
 
   testWidgets('TV-sized layout keeps the two-pane TV settings screen', (
     tester,

--- a/app/test/core/app/tv_shell_test.dart
+++ b/app/test/core/app/tv_shell_test.dart
@@ -60,34 +60,29 @@ void main() {
     },
   );
 
-  testWidgets(
-    'zen mode: sidebar is hidden while the player is fullscreen, and '
-    'returns when fullscreen exits',
-    (tester) async {
-      final container = ProviderContainer();
-      addTearDown(container.dispose);
+  testWidgets('zen mode: sidebar is hidden while the player is fullscreen, and '
+      'returns when fullscreen exits', (tester) async {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
 
-      await tester.pumpWidget(
-        UncontrolledProviderScope(
-          container: container,
-          child: const MaterialApp(
-            home: TvShell(child: SizedBox.expand()),
-          ),
-        ),
-      );
-      await tester.pump();
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: const MaterialApp(home: TvShell(child: SizedBox.expand())),
+      ),
+    );
+    await tester.pump();
 
-      expect(find.byKey(const Key('tv-sidebar-nav')), findsOneWidget);
+    expect(find.byKey(const Key('tv-sidebar-nav')), findsOneWidget);
 
-      container.read(isFullscreenModeProvider.notifier).state = true;
-      await tester.pump();
+    container.read(isFullscreenModeProvider.notifier).state = true;
+    await tester.pump();
 
-      expect(find.byKey(const Key('tv-sidebar-nav')), findsNothing);
+    expect(find.byKey(const Key('tv-sidebar-nav')), findsNothing);
 
-      container.read(isFullscreenModeProvider.notifier).state = false;
-      await tester.pump();
+    container.read(isFullscreenModeProvider.notifier).state = false;
+    await tester.pump();
 
-      expect(find.byKey(const Key('tv-sidebar-nav')), findsOneWidget);
-    },
-  );
+    expect(find.byKey(const Key('tv-sidebar-nav')), findsOneWidget);
+  });
 }


### PR DESCRIPTION
## Summary
Every PR this session (#1161, #1162, #1164, #1167-#1170) failed both CI gates below, unrelated to what each PR actually touched — both are pre-existing on `main`.

**`code-quality` (dart format):** `app/test/core/app/tv_shell_test.dart` had format drift predating this session (confirmed against a fresh clone of `main`). The format check runs across the whole `app/` tree regardless of which files a PR changes, so this one file broke the gate for everyone.

**`test-app`:** `app/test/adaptive_tv_settings_screen_test.dart` expected the theme picker (`RadioListTile` per `AppThemeId`) to render inline on `SettingsHubScreen`. It moved to its own `ThemeSettingsScreen` behind an "Appearance" entry back in #933, but this test was never updated to navigate there first.

## Test plan
- [x] `dart format --set-exit-if-changed` clean on `app/`
- [x] `tv_shell_test.dart`: 2 passed (formatting-only change)
- [x] `adaptive_tv_settings_screen_test.dart`: 2 passed (now navigates to Appearance before asserting theme options)

🤖 Generated with [Claude Code](https://claude.com/claude-code)