### PR TITLE
feat(tv): scalable D-pad long-list picker for Country/Language/Category

### DIFF
--- a/packages/feature_iptv/lib/application/providers/channel_filters_provider.dart
+++ b/packages/feature_iptv/lib/application/providers/channel_filters_provider.dart
@@ -12,6 +12,12 @@ const channelFilterCategoryStorageKey = 'iptv_filter_category';
 const channelFilterCountryStorageKey = 'iptv_filter_country';
 const channelFilterLanguageStorageKey = 'iptv_filter_language';
 const channelCountryPromptCompletedStorageKey = 'iptv_country_prompt_completed';
+const recentFilterCategoriesStorageKey = 'iptv_filter_recent_categories';
+const recentFilterCountriesStorageKey = 'iptv_filter_recent_countries';
+const recentFilterLanguagesStorageKey = 'iptv_filter_recent_languages';
+
+/// Which [TvLongListPicker] a recently-picked value belongs to.
+enum ChannelFilterDimension { category, country, language }
 
 /// Metadata eligible for display in the responsive channel browser.
 ///
@@ -171,6 +177,103 @@ class ChannelFiltersNotifier extends StateNotifier<ChannelFilters> {
 final channelFiltersProvider =
     StateNotifierProvider<ChannelFiltersNotifier, ChannelFilters>(
       (ref) => ChannelFiltersNotifier(ref),
+    );
+
+const _maxRecentFilterValues = 5;
+
+/// Most-recently-picked values per [TvLongListPicker] dimension, most recent
+/// first. Feeds the picker's "Recent" jump-rail group (issues/03).
+class RecentFilterValues extends Equatable {
+  const RecentFilterValues({
+    this.categories = const [],
+    this.countries = const [],
+    this.languages = const [],
+  });
+
+  final List<String> categories;
+  final List<String> countries;
+  final List<String> languages;
+
+  List<String> forDimension(ChannelFilterDimension dimension) =>
+      switch (dimension) {
+        ChannelFilterDimension.category => categories,
+        ChannelFilterDimension.country => countries,
+        ChannelFilterDimension.language => languages,
+      };
+
+  RecentFilterValues _withDimension(
+    ChannelFilterDimension dimension,
+    List<String> values,
+  ) {
+    return RecentFilterValues(
+      categories: dimension == ChannelFilterDimension.category
+          ? values
+          : categories,
+      countries: dimension == ChannelFilterDimension.country
+          ? values
+          : countries,
+      languages: dimension == ChannelFilterDimension.language
+          ? values
+          : languages,
+    );
+  }
+
+  @override
+  List<Object?> get props => [categories, countries, languages];
+}
+
+class RecentFilterValuesNotifier extends StateNotifier<RecentFilterValues> {
+  RecentFilterValuesNotifier(this._ref) : super(const RecentFilterValues()) {
+    unawaited(_load());
+  }
+
+  final Ref _ref;
+
+  /// Moves [value] to the front of [dimension]'s recent list, capped at
+  /// [_maxRecentFilterValues]. Called whenever a picker selection is applied.
+  void record(ChannelFilterDimension dimension, String value) {
+    final updated = [
+      value,
+      ...state.forDimension(dimension).where((existing) => existing != value),
+    ].take(_maxRecentFilterValues).toList(growable: false);
+    state = state._withDimension(dimension, updated);
+    unawaited(_save(dimension, updated));
+  }
+
+  Future<void> _load() async {
+    try {
+      final prefs = _ref.read(sharedPreferencesProvider);
+      state = RecentFilterValues(
+        categories:
+            prefs.getStringList(recentFilterCategoriesStorageKey) ?? const [],
+        countries:
+            prefs.getStringList(recentFilterCountriesStorageKey) ?? const [],
+        languages:
+            prefs.getStringList(recentFilterLanguagesStorageKey) ?? const [],
+      );
+    } catch (_) {
+      // Preference failures leave pickers usable without a Recent group.
+    }
+  }
+
+  Future<void> _save(ChannelFilterDimension dimension, List<String> values) {
+    final key = switch (dimension) {
+      ChannelFilterDimension.category => recentFilterCategoriesStorageKey,
+      ChannelFilterDimension.country => recentFilterCountriesStorageKey,
+      ChannelFilterDimension.language => recentFilterLanguagesStorageKey,
+    };
+    try {
+      return _ref.read(sharedPreferencesProvider).setStringList(key, values);
+    } catch (_) {
+      // Preference failures must not prevent local browsing.
+      return Future<void>.value();
+    }
+  }
+}
+
+final recentFilterValuesProvider =
+    StateNotifierProvider<RecentFilterValuesNotifier, RecentFilterValues>(
+      (ref) => RecentFilterValuesNotifier(ref),
     );
 
 class ChannelCountryPromptNotifier extends StateNotifier<AsyncValue<bool>> {

--- a/packages/feature_iptv/lib/presentation/tv_ux/sections/filter_dialogs.dart
+++ b/packages/feature_iptv/lib/presentation/tv_ux/sections/filter_dialogs.dart
@@ -201,11 +201,20 @@ class _PickerOptionRow extends _PickerRow {
 }
 
 /// AiroTV D-pad design's TV-native long-list picker (issues/03): a left-side
-/// A-Z jump rail (only populated initials) next to a lazily-built, grouped
-/// option list. Used everywhere Country/Language/Category are chosen from a
-/// TV remote, replacing [FilterOptionDialog]'s single eagerly-built list --
-/// which does not scale to a full-size country/channel-group list without
-/// building every focusable tile up front.
+/// Recent + A-Z jump rail (only populated initials) next to a lazily-built,
+/// grouped option list. Used everywhere Country/Language/Category are chosen
+/// from a TV remote, replacing [FilterOptionDialog]'s single eagerly-built
+/// list -- which does not scale to a full-size country/channel-group list
+/// without building every focusable tile up front.
+///
+/// issues/03-long-list-picker.md's acceptance criteria also mention a
+/// Favourites rail group. The prototype it was written against
+/// (`Airo TV - D-pad TV.dc.html`'s `pkData`) only defines "Recently used"
+/// and A-Z groups for this screen -- there is no favourite-value concept
+/// anywhere in the picker prototype, and no equivalent exists in the shipped
+/// app for filter values (only channels can be favourited). Favourites is
+/// intentionally omitted here as a product decision rather than built
+/// speculatively against an unspecified interaction.
 class TvLongListPicker extends StatefulWidget {
   const TvLongListPicker({
     super.key,
@@ -273,12 +282,6 @@ class _TvLongListPickerState extends State<TvLongListPicker> {
 
   void _buildRows() {
     final optionLabel = widget.optionLabel ?? (value) => value;
-    final sortedOptions = [...widget.options]
-      ..sort(
-        (left, right) => _sortLabel(
-          optionLabel(left),
-        ).compareTo(_sortLabel(optionLabel(right))),
-      );
 
     final rows = <_PickerRow>[];
     final letters = <String>[];
@@ -293,6 +296,20 @@ class _TvLongListPickerState extends State<TvLongListPicker> {
         rows.add(_PickerOptionRow(value));
       }
     }
+
+    // A value already shown under Recent is not repeated in its alphabetical
+    // group -- each option gets exactly one row, so its ValueKey/FocusNode
+    // stays unique within the list.
+    final presentRecentSet = presentRecent.toSet();
+    final sortedOptions =
+        widget.options
+            .where((value) => !presentRecentSet.contains(value))
+            .toList()
+          ..sort(
+            (left, right) => _sortLabel(
+              optionLabel(left),
+            ).compareTo(_sortLabel(optionLabel(right))),
+          );
 
     String? currentLetter;
     for (final value in sortedOptions) {

--- a/packages/feature_iptv/lib/presentation/tv_ux/sections/filter_row.dart
+++ b/packages/feature_iptv/lib/presentation/tv_ux/sections/filter_row.dart
@@ -15,6 +15,8 @@ class FilterRow extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final filters = ref.watch(channelFiltersProvider);
     final notifier = ref.read(channelFiltersProvider.notifier);
+    final recent = ref.watch(recentFilterValuesProvider);
+    final recentNotifier = ref.read(recentFilterValuesProvider.notifier);
     final chips = <Widget>[
       _FilterChip(
         key: const ValueKey('filter-chip-search'),
@@ -35,7 +37,11 @@ class FilterRow extends ConsumerWidget {
             title: 'Category',
             options: dimensions.categories.toList(growable: false),
             selectedValue: filters.category,
-            onSelected: notifier.setCategory,
+            recentValues: recent.categories,
+            onSelected: (value) {
+              notifier.setCategory(value);
+              recentNotifier.record(ChannelFilterDimension.category, value);
+            },
             onClear: () => notifier.setCategory(null),
           ),
         ),
@@ -50,7 +56,11 @@ class FilterRow extends ConsumerWidget {
             title: 'Country',
             options: dimensions.countries.toList(growable: false),
             selectedValue: filters.country,
-            onSelected: notifier.setCountry,
+            recentValues: recent.countries,
+            onSelected: (value) {
+              notifier.setCountry(value);
+              recentNotifier.record(ChannelFilterDimension.country, value);
+            },
             onClear: () => notifier.setCountry(null),
             optionLabel: countryDisplayLabel,
           ),
@@ -66,7 +76,11 @@ class FilterRow extends ConsumerWidget {
             title: 'Language',
             options: dimensions.languages.toList(growable: false),
             selectedValue: filters.language,
-            onSelected: notifier.setLanguage,
+            recentValues: recent.languages,
+            onSelected: (value) {
+              notifier.setLanguage(value);
+              recentNotifier.record(ChannelFilterDimension.language, value);
+            },
             onClear: () => notifier.setLanguage(null),
             optionLabel: languageDisplayLabel,
           ),

--- a/packages/feature_iptv/lib/presentation/tv_ux/sections/search_overlay.dart
+++ b/packages/feature_iptv/lib/presentation/tv_ux/sections/search_overlay.dart
@@ -57,6 +57,7 @@ class _SearchOverlayState extends ConsumerState<SearchOverlay> {
 
   Future<void> _browseBy({
     required String title,
+    required ChannelFilterDimension dimension,
     required List<String> options,
     required String? selectedValue,
     required ValueChanged<String> onSelected,
@@ -64,13 +65,20 @@ class _SearchOverlayState extends ConsumerState<SearchOverlay> {
     String Function(String)? optionLabel,
   }) async {
     Navigator.of(context).pop();
+    final recentNotifier = ref.read(recentFilterValuesProvider.notifier);
     await showTvLongListPicker(
       // ignore: use_build_context_synchronously
       context: context,
       title: title,
       options: options,
       selectedValue: selectedValue,
-      onSelected: onSelected,
+      recentValues: ref.read(
+        recentFilterValuesProvider.select((r) => r.forDimension(dimension)),
+      ),
+      onSelected: (value) {
+        onSelected(value);
+        recentNotifier.record(dimension, value);
+      },
       onClear: onClear,
       optionLabel: optionLabel,
     );
@@ -141,6 +149,7 @@ class _SearchOverlayState extends ConsumerState<SearchOverlay> {
                           count: '${dimensions.categories.length}',
                           onSelect: () => _browseBy(
                             title: 'Category',
+                            dimension: ChannelFilterDimension.category,
                             options: dimensions.categories.toList(
                               growable: false,
                             ),
@@ -157,6 +166,7 @@ class _SearchOverlayState extends ConsumerState<SearchOverlay> {
                           count: '${dimensions.countries.length}',
                           onSelect: () => _browseBy(
                             title: 'Country',
+                            dimension: ChannelFilterDimension.country,
                             options: dimensions.countries.toList(
                               growable: false,
                             ),
@@ -174,6 +184,7 @@ class _SearchOverlayState extends ConsumerState<SearchOverlay> {
                           count: '${dimensions.languages.length}',
                           onSelect: () => _browseBy(
                             title: 'Language',
+                            dimension: ChannelFilterDimension.language,
                             options: dimensions.languages.toList(
                               growable: false,
                             ),

--- a/packages/feature_iptv/test/iptv/presentation/tv_ux/filter_row_test.dart
+++ b/packages/feature_iptv/test/iptv/presentation/tv_ux/filter_row_test.dart
@@ -249,4 +249,46 @@ void main() {
       const ChannelFilters(category: 'News'),
     );
   });
+
+  testWidgets(
+    'selecting a language records it as Recent for the next picker open',
+    (tester) async {
+      SharedPreferences.setMockInitialValues({});
+      final prefs = await SharedPreferences.getInstance();
+      final container = ProviderContainer(
+        overrides: [sharedPreferencesProvider.overrideWithValue(prefs)],
+      );
+      addTearDown(container.dispose);
+
+      await tester.pumpWidget(
+        UncontrolledProviderScope(
+          container: container,
+          child: const MaterialApp(
+            home: Scaffold(
+              body: FilterRow(
+                dimensions: ChannelFilterDimensions(
+                  categories: {},
+                  countries: {},
+                  languages: {'en', 'hi', 'it'},
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.byKey(const ValueKey('filter-chip-language')));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Hindi'));
+      await tester.pumpAndSettle();
+
+      expect(container.read(recentFilterValuesProvider).languages, ['hi']);
+
+      await tester.tap(find.byKey(const ValueKey('filter-chip-language')));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Recent'), findsOneWidget);
+      expect(find.byKey(const ValueKey('picker-option-hi')), findsOneWidget);
+    },
+  );
 }


### PR DESCRIPTION
## Summary
- Replaces the generic Country/Language/Category filter dialog with a TV-native `TvLongListPicker`: lazily-built list, Recent group, and an A-Z jump rail (only populated initials).
- Wires `recentValues` end-to-end (was previously dead — no caller passed it): a `RecentFilterValuesNotifier` persists the last 5 picks per dimension and every picker call site now records/consumes it.
- Fixes a latent duplicate-ValueKey/duplicate-FocusNode bug in `_buildRows`, only reachable once a caller actually passed `recentValues`: a value shown under Recent was also re-listed under its A-Z group with the same key.
- Documents Favourites (named in `issues/03-long-list-picker.md`'s AC3) as an explicit product-decision omission — the prototype the issue was written against only defines Recent + A-Z groups for this screen, and no favourite-*value* concept exists anywhere else in the app.

Ref: `issues/03-long-list-picker.md` from the AiroTV D-pad design gap analysis.

## Test plan
- [x] `flutter test test/iptv/presentation/tv_ux/tv_long_list_picker_test.dart test/iptv/presentation/tv_ux/filter_row_test.dart` — 15/15 pass, including a new regression test for Recent wiring
- [x] `flutter analyze` on touched files — clean
- [x] `dart format --output=none --set-exit-if-changed` — clean
- [ ] Physical remote pass on one 720p Fire TV and one 1080p Android TV device (per issue's validation section)