### PR TITLE
fix(tv): distinct, D-pad-reachable recovery actions + fix dead error buttons

### DIFF
--- a/packages/feature_iptv/lib/application/providers/dead_link_report_provider.dart
+++ b/packages/feature_iptv/lib/application/providers/dead_link_report_provider.dart
@@ -1,0 +1,77 @@
+import 'dart:convert';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'iptv_providers.dart' show sharedPreferencesProvider;
+
+const deadLinkReportsStorageKey = 'dead_link_reports_v1';
+const deadLinkReportsMaxStored = 20;
+
+/// A user-triggered "this channel is broken" report (issues/04-recovery-
+/// states.md). [technicalDetail] is already redacted upstream by
+/// [AiroPlaybackDiagnostic.technicalDetail] -- source URIs never appear
+/// here beyond `scheme://host[:port]`.
+class DeadLinkReport {
+  const DeadLinkReport({
+    required this.channelName,
+    required this.diagnosticCode,
+    required this.userMessage,
+    required this.reportedAt,
+    this.technicalDetail,
+  });
+
+  final String channelName;
+  final String diagnosticCode;
+  final String userMessage;
+  final DateTime reportedAt;
+  final String? technicalDetail;
+
+  Map<String, Object?> toJson() => {
+    'channelName': channelName,
+    'diagnosticCode': diagnosticCode,
+    'userMessage': userMessage,
+    'reportedAt': reportedAt.toIso8601String(),
+    'technicalDetail': technicalDetail,
+  };
+
+  static DeadLinkReport fromJson(Map<String, Object?> json) => DeadLinkReport(
+    channelName: json['channelName'] as String,
+    diagnosticCode: json['diagnosticCode'] as String,
+    userMessage: json['userMessage'] as String,
+    reportedAt: DateTime.parse(json['reportedAt'] as String),
+    technicalDetail: json['technicalDetail'] as String?,
+  );
+}
+
+/// Persists dead-link reports to device storage only. Nothing here ever
+/// makes a network call or leaves the device -- sending reports elsewhere
+/// requires a separate, explicit user action that does not exist yet.
+class DeadLinkReportStorage {
+  DeadLinkReportStorage(this._prefs);
+
+  final SharedPreferences _prefs;
+
+  List<DeadLinkReport> readAll() {
+    final raw = _prefs.getStringList(deadLinkReportsStorageKey) ?? const [];
+    return raw
+        .map(
+          (entry) => DeadLinkReport.fromJson(
+            jsonDecode(entry) as Map<String, Object?>,
+          ),
+        )
+        .toList(growable: false);
+  }
+
+  Future<void> save(DeadLinkReport report) async {
+    final updated = [report, ...readAll()]
+        .take(deadLinkReportsMaxStored)
+        .map((r) => jsonEncode(r.toJson()))
+        .toList(growable: false);
+    await _prefs.setStringList(deadLinkReportsStorageKey, updated);
+  }
+}
+
+final deadLinkReportStorageProvider = Provider<DeadLinkReportStorage>((ref) {
+  return DeadLinkReportStorage(ref.watch(sharedPreferencesProvider));
+});

--- a/packages/feature_iptv/lib/feature_iptv.dart
+++ b/packages/feature_iptv/lib/feature_iptv.dart
@@ -19,6 +19,7 @@ export "application/providers/playback_settings_extension_point.dart";
 export "application/providers/recently_watched_recorder.dart";
 export "application/providers/video_aspect_ratio_provider.dart";
 export "application/providers/caption_preference_provider.dart";
+export "application/providers/dead_link_report_provider.dart";
 export "application/providers/channel_auto_scan_providers.dart";
 export "application/providers/tv_font_mode_provider.dart";
 export "application/providers/channel_filters_provider.dart";

--- a/packages/feature_iptv/lib/presentation/tv_ux/airo_tv_shell.dart
+++ b/packages/feature_iptv/lib/presentation/tv_ux/airo_tv_shell.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:collection/collection.dart';
+import 'package:core_ui/core_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:platform_channels/platform_channels.dart';
@@ -370,11 +371,41 @@ class _ExplorerSection extends StatelessWidget {
 /// channels stay browsable and (if already playing) video keeps playing —
 /// only new stream starts would actually need the connection. Renders
 /// nothing while online.
-class _OfflineBanner extends ConsumerWidget {
+class _OfflineBanner extends ConsumerStatefulWidget {
   const _OfflineBanner();
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  ConsumerState<_OfflineBanner> createState() => _OfflineBannerState();
+}
+
+class _OfflineBannerState extends ConsumerState<_OfflineBanner> {
+  bool _checking = false;
+
+  // issues/04-recovery-states.md acceptance criterion 4: Retry must report
+  // success or failure, not just spin -- and must not be a fake button
+  // (isOnlineProvider is watched from the same ConnectivityService this
+  // re-checks, so a real change is what actually dismisses the banner).
+  Future<void> _retry() async {
+    if (_checking) return;
+    setState(() => _checking = true);
+    final isConnected = await ref.read(connectivityServiceProvider).isConnected;
+    if (!mounted) return;
+    setState(() => _checking = false);
+    ScaffoldMessenger.of(context)
+      ..hideCurrentSnackBar()
+      ..showSnackBar(
+        SnackBar(
+          content: Text(
+            isConnected
+                ? 'Back online'
+                : 'Still no connection — check your network and try again',
+          ),
+        ),
+      );
+  }
+
+  @override
+  Widget build(BuildContext context) {
     final isOnline = ref.watch(isOnlineProvider).asData?.value ?? true;
     if (isOnline) return const SizedBox.shrink();
 
@@ -394,6 +425,36 @@ class _OfflineBanner extends ConsumerWidget {
               overflow: TextOverflow.ellipsis,
               style: Theme.of(context).textTheme.bodySmall?.copyWith(
                 color: Colors.amber.shade100,
+              ),
+            ),
+          ),
+          const SizedBox(width: 8),
+          TvFocusable(
+            key: const ValueKey('offline-banner-retry'),
+            semanticLabel: 'Retry connection',
+            onSelect: _checking ? null : _retry,
+            borderRadius: 6,
+            child: TextButton.icon(
+              onPressed: _checking ? null : _retry,
+              icon: _checking
+                  ? const SizedBox(
+                      width: 14,
+                      height: 14,
+                      child: CircularProgressIndicator(
+                        strokeWidth: 2,
+                        color: Colors.amber,
+                      ),
+                    )
+                  : const Icon(
+                      Icons.refresh_rounded,
+                      size: 16,
+                      color: Colors.amber,
+                    ),
+              label: Text(
+                'Retry',
+                style: Theme.of(
+                  context,
+                ).textTheme.bodySmall?.copyWith(color: Colors.amber),
               ),
             ),
           ),

--- a/packages/feature_iptv/lib/presentation/tv_ux/airo_tv_shell.dart
+++ b/packages/feature_iptv/lib/presentation/tv_ux/airo_tv_shell.dart
@@ -423,9 +423,9 @@ class _OfflineBannerState extends ConsumerState<_OfflineBanner> {
               'streams need a connection.',
               maxLines: 1,
               overflow: TextOverflow.ellipsis,
-              style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                color: Colors.amber.shade100,
-              ),
+              style: Theme.of(
+                context,
+              ).textTheme.bodySmall?.copyWith(color: Colors.amber.shade100),
             ),
           ),
           const SizedBox(width: 8),

--- a/packages/feature_iptv/lib/presentation/widgets/video_player_widget.dart
+++ b/packages/feature_iptv/lib/presentation/widgets/video_player_widget.dart
@@ -10,6 +10,7 @@ import '../../application/player_backgrounding_coordinator.dart';
 import '../../application/channel_warmup_policy.dart';
 import '../../application/providers/caption_preference_provider.dart';
 import '../../application/providers/channel_auto_scan_providers.dart';
+import '../../application/providers/dead_link_report_provider.dart';
 import '../../application/providers/iptv_providers.dart';
 import '../../application/providers/recently_watched_recorder.dart';
 import '../../application/providers/video_aspect_ratio_provider.dart';
@@ -831,9 +832,14 @@ class _VideoPlayerWidgetState extends ConsumerState<VideoPlayerWidget> {
                     // gestures. Left half of the video area adjusts brightness,
                     // right half adjusts volume; disabled while locked. The video
                     // surface itself is the engine-driven view (CV-016 migration);
-                    // when it's null we fall through to loading/diagnostic/
-                    // placeholder inside the same gesture-enabled stack.
-                    widget.enableTouchGestures
+                    // when it's null we fall through to loading/placeholder
+                    // inside the same gesture-enabled stack -- except a
+                    // diagnostic error, whose own recovery buttons need to
+                    // win every tap outright rather than compete with this
+                    // overlay's translucent drag detector for the same
+                    // gesture arena.
+                    widget.enableTouchGestures &&
+                            !(state.hasError && state.diagnostic != null)
                         ? PlayerGestureOverlay(
                             locked: _isLocked,
                             brightness: _brightness,
@@ -871,8 +877,14 @@ class _VideoPlayerWidgetState extends ConsumerState<VideoPlayerWidget> {
                       ),
 
                     // Controls overlay with fade animation — hidden entirely while
-                    // locked so only the lock button remains interactive.
-                    if (!_isLocked && !isPipActive)
+                    // locked so only the lock button remains interactive, and
+                    // while a diagnostic error owns the screen (there's no
+                    // video to control, and its own recovery buttons occupy
+                    // the same vertical band the center play/pause button
+                    // would otherwise sit in and silently swallow taps for).
+                    if (!_isLocked &&
+                        !isPipActive &&
+                        !(state.hasError && state.diagnostic != null))
                       AnimatedOpacity(
                         opacity: (widget.showControls && _showControlsOverlay)
                             ? 1.0
@@ -1059,29 +1071,70 @@ class _VideoPlayerWidgetState extends ConsumerState<VideoPlayerWidget> {
                 retryAttempt: state.retryCount > 0 ? state.retryCount : null,
                 maxRetryAttempts: 3,
               ),
-              if (!diagnostic.retryEligible || state.retryCount == 0)
-                ElevatedButton.icon(
-                  onPressed: () =>
-                      ref.read(iptvStreamingServiceProvider).retry(),
-                  icon: const Icon(Icons.refresh_rounded),
-                  label: const Text('Try Again'),
-                  style: ElevatedButton.styleFrom(
-                    backgroundColor: Colors.blueGrey.shade700,
-                    foregroundColor: Colors.white,
-                    padding: const EdgeInsets.symmetric(
-                      horizontal: 24,
-                      vertical: 12,
+              const SizedBox(height: 16),
+              // issues/04-recovery-states.md acceptance criterion 1: three
+              // distinct outcomes, not just retry -- and every one of them
+              // must be D-pad reachable (the old ElevatedButton had no
+              // TvFocusable, so a remote-only viewer could never reach it).
+              Wrap(
+                alignment: WrapAlignment.center,
+                spacing: 10,
+                runSpacing: 10,
+                children: [
+                  if (!diagnostic.retryEligible || state.retryCount == 0)
+                    _RecoveryActionButton(
+                      key: const ValueKey('diagnostic-error-retry'),
+                      icon: Icons.refresh_rounded,
+                      label: 'Try Again',
+                      autofocus: true,
+                      onSelect: () =>
+                          ref.read(iptvStreamingServiceProvider).retry(),
                     ),
-                    shape: RoundedRectangleBorder(
-                      borderRadius: BorderRadius.circular(8),
-                    ),
+                  _RecoveryActionButton(
+                    key: const ValueKey('diagnostic-error-skip'),
+                    icon: Icons.skip_next_rounded,
+                    label: 'Skip channel',
+                    autofocus: diagnostic.retryEligible && state.retryCount > 0,
+                    onSelect: _goToNextChannel,
                   ),
-                ),
+                  _RecoveryActionButton(
+                    key: const ValueKey('diagnostic-error-report'),
+                    icon: Icons.flag_outlined,
+                    label: 'Report dead link',
+                    onSelect: () => _saveDeadLinkReport(state, diagnostic),
+                  ),
+                ],
+              ),
             ],
           ),
         ),
       ),
     );
+  }
+
+  Future<void> _saveDeadLinkReport(
+    StreamingState state,
+    AiroPlaybackDiagnostic diagnostic,
+  ) async {
+    final channel = state.currentChannel;
+    if (channel == null) return;
+    await ref
+        .read(deadLinkReportStorageProvider)
+        .save(
+          DeadLinkReport(
+            channelName: channel.name,
+            diagnosticCode: diagnostic.code.name,
+            userMessage: diagnostic.userMessage,
+            technicalDetail: diagnostic.technicalDetail,
+            reportedAt: DateTime.now(),
+          ),
+        );
+    if (!mounted) return;
+    ScaffoldMessenger.of(context)
+      ..hideCurrentSnackBar()
+      ..showSnackBar(
+        const SnackBar(content: Text('Saved locally — nothing was sent')),
+      );
   }
 
   Widget _buildError(String message) {
@@ -2836,6 +2889,45 @@ class _ContextMenuItem extends StatelessWidget {
 /// the actual action live on the [TvFocusable] wrapping it; this just draws
 /// the pill matching the AiroTV D-pad design's transport button style
 /// (icon-only when unlabeled, icon+label otherwise).
+/// A D-pad-reachable recovery action for [_buildDiagnosticError] --
+/// TvFocusable-wrapped so remote-only viewers (no touch input) can actually
+/// reach it, unlike a bare ElevatedButton.
+class _RecoveryActionButton extends StatelessWidget {
+  const _RecoveryActionButton({
+    super.key,
+    required this.icon,
+    required this.label,
+    required this.onSelect,
+    this.autofocus = false,
+  });
+
+  final IconData icon;
+  final String label;
+  final VoidCallback onSelect;
+  final bool autofocus;
+
+  @override
+  Widget build(BuildContext context) {
+    return TvFocusable(
+      autofocus: autofocus,
+      onSelect: onSelect,
+      semanticLabel: label,
+      borderRadius: 8,
+      child: ElevatedButton.icon(
+        onPressed: onSelect,
+        icon: Icon(icon),
+        label: Text(label),
+        style: ElevatedButton.styleFrom(
+          backgroundColor: Colors.blueGrey.shade700,
+          foregroundColor: Colors.white,
+          padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 12),
+          shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
+        ),
+      ),
+    );
+  }
+}
+
 class _TvTransportButton extends StatelessWidget {
   const _TvTransportButton({required this.icon, this.label});
 

--- a/packages/feature_iptv/test/application/providers/dead_link_report_provider_test.dart
+++ b/packages/feature_iptv/test/application/providers/dead_link_report_provider_test.dart
@@ -1,0 +1,96 @@
+import 'package:feature_iptv/feature_iptv.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+// issues/04-recovery-states.md: dead-link reports must remain local until
+// the user explicitly opts to send them -- this storage class never makes
+// a network call, only SharedPreferences.
+void main() {
+  Future<ProviderContainer> makeContainer() async {
+    SharedPreferences.setMockInitialValues({});
+    final prefs = await SharedPreferences.getInstance();
+    final container = ProviderContainer(
+      overrides: [sharedPreferencesProvider.overrideWithValue(prefs)],
+    );
+    return container;
+  }
+
+  test('saves and reads back a report, most recent first', () async {
+    final container = await makeContainer();
+    addTearDown(container.dispose);
+    final storage = container.read(deadLinkReportStorageProvider);
+
+    await storage.save(
+      DeadLinkReport(
+        channelName: 'City News',
+        diagnosticCode: 'httpForbidden',
+        userMessage: 'Your provider rejected this stream.',
+        technicalDetail: 'source=https://example.com',
+        reportedAt: DateTime(2026, 1, 1),
+      ),
+    );
+    await storage.save(
+      DeadLinkReport(
+        channelName: 'Sports 24',
+        diagnosticCode: 'timeout',
+        userMessage: 'The stream timed out.',
+        reportedAt: DateTime(2026, 1, 2),
+      ),
+    );
+
+    final reports = storage.readAll();
+    expect(reports, hasLength(2));
+    expect(reports.first.channelName, 'Sports 24');
+    expect(reports.last.channelName, 'City News');
+    expect(reports.last.technicalDetail, 'source=https://example.com');
+  });
+
+  test('bounds stored reports to the most recent 20', () async {
+    final container = await makeContainer();
+    addTearDown(container.dispose);
+    final storage = container.read(deadLinkReportStorageProvider);
+
+    for (var i = 0; i < 25; i++) {
+      await storage.save(
+        DeadLinkReport(
+          channelName: 'Channel $i',
+          diagnosticCode: 'timeout',
+          userMessage: 'The stream timed out.',
+          reportedAt: DateTime(2026, 1, 1).add(Duration(minutes: i)),
+        ),
+      );
+    }
+
+    final reports = storage.readAll();
+    expect(reports, hasLength(deadLinkReportsMaxStored));
+    expect(reports.first.channelName, 'Channel 24');
+  });
+
+  test('persists across a fresh provider read (survives restart)', () async {
+    SharedPreferences.setMockInitialValues({});
+    final prefs = await SharedPreferences.getInstance();
+
+    final first = ProviderContainer(
+      overrides: [sharedPreferencesProvider.overrideWithValue(prefs)],
+    );
+    await first
+        .read(deadLinkReportStorageProvider)
+        .save(
+          DeadLinkReport(
+            channelName: 'City News',
+            diagnosticCode: 'httpForbidden',
+            userMessage: 'Your provider rejected this stream.',
+            reportedAt: DateTime(2026, 1, 1),
+          ),
+        );
+    first.dispose();
+
+    final second = ProviderContainer(
+      overrides: [sharedPreferencesProvider.overrideWithValue(prefs)],
+    );
+    addTearDown(second.dispose);
+
+    expect(second.read(deadLinkReportStorageProvider).readAll(), hasLength(1));
+  });
+}

--- a/packages/feature_iptv/test/iptv/presentation/tv_ux/airo_tv_shell_test.dart
+++ b/packages/feature_iptv/test/iptv/presentation/tv_ux/airo_tv_shell_test.dart
@@ -1,3 +1,4 @@
+import 'package:core_data/core_data.dart';
 import 'package:feature_iptv/application/providers/channel_filters_provider.dart';
 import 'package:feature_iptv/application/providers/channel_auto_scan_providers.dart';
 import 'package:feature_iptv/application/providers/connectivity_provider.dart';
@@ -136,10 +137,7 @@ void main() {
       await tester.pump();
 
       expect(find.byIcon(Icons.wifi_off_rounded), findsOneWidget);
-      expect(
-        find.textContaining('your playlist is cached'),
-        findsOneWidget,
-      );
+      expect(find.textContaining('your playlist is cached'), findsOneWidget);
     },
   );
 
@@ -249,6 +247,66 @@ void main() {
     expect(selected, ['two']);
     expect(find.text('One is unavailable. Skipping.'), findsOneWidget);
   });
+
+  // issues/04-recovery-states.md acceptance criterion 4: Retry must be a
+  // real, D-pad reachable action that reports success or failure.
+  testWidgets('offline banner Retry re-checks connectivity and reports the '
+      'outcome', (tester) async {
+    final prefs = await SharedPreferences.getInstance();
+    final container = ProviderContainer(
+      overrides: [
+        sharedPreferencesProvider.overrideWithValue(prefs),
+        streamProbeTransportProvider.overrideWithValue(_FakeProbeTransport()),
+        isOnlineProvider.overrideWith((ref) => Stream.value(false)),
+        connectivityServiceProvider.overrideWithValue(
+          _FakeConnectivityService(false),
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: MaterialApp(
+          home: Scaffold(
+            body: SizedBox(
+              width: 900,
+              height: 720,
+              child: AiroTvShell(
+                channels: channels,
+                videoStage: const SizedBox(key: ValueKey('video-stage')),
+                onChannelSelected: (_) {},
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+
+    expect(find.byKey(const ValueKey('offline-banner-retry')), findsOneWidget);
+
+    await tester.tap(find.byKey(const ValueKey('offline-banner-retry')));
+    await tester.pump();
+
+    expect(
+      find.text('Still no connection — check your network and try again'),
+      findsOneWidget,
+    );
+  });
+}
+
+class _FakeConnectivityService implements ConnectivityService {
+  _FakeConnectivityService(this._connected);
+
+  final bool _connected;
+
+  @override
+  Future<bool> get isConnected async => _connected;
+
+  @override
+  Stream<bool> get onConnectivityChanged => const Stream.empty();
 }
 
 class _FakeProbeTransport implements StreamProbeTransport {

--- a/packages/feature_iptv/test/presentation/widgets/video_player_widget_error_layout_test.dart
+++ b/packages/feature_iptv/test/presentation/widgets/video_player_widget_error_layout_test.dart
@@ -1,3 +1,4 @@
+import 'package:core_ui/core_ui.dart';
 import 'package:feature_iptv/feature_iptv.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -12,41 +13,64 @@ import 'package:shared_preferences/shared_preferences.dart';
 void main() {
   const viewportHeight = 540.0;
 
-  Future<void> pumpErrorPlayer(WidgetTester tester) async {
+  Future<ProviderContainer> pumpErrorPlayer(
+    WidgetTester tester, {
+    int retryCount = 0,
+    List<IPTVChannel>? channels,
+  }) async {
     SharedPreferences.setMockInitialValues({});
     final prefs = await SharedPreferences.getInstance();
     const mapper = AiroPlaybackDiagnosticMapper();
     final diagnostic = mapper.map(
       const AiroPlaybackFailureEvent(httpStatusCode: 403),
     );
+    const currentChannel = IPTVChannel(
+      id: 'news-1',
+      name: 'City News Live',
+      streamUrl: 'https://example.com/news.m3u8',
+      group: 'News',
+    );
+    // A fake engine, not the real service default: Skip channel drives a
+    // real playChannel() call, which would otherwise stand up a genuine
+    // VideoPlayerController that never gets disposed once the test ends.
+    final service = VideoPlayerStreamingService(
+      engine: FakeAiroPlaybackEngine(),
+    );
+    addTearDown(() async {
+      await service.stop();
+      service.dispose();
+    });
 
-    await tester.pumpWidget(
-      ProviderScope(
-        overrides: [
-          sharedPreferencesProvider.overrideWithValue(prefs),
-          streamingStateProvider.overrideWith(
-            (ref) => Stream.value(
-              StreamingState(
-                playbackState: PlaybackState.error,
-                isLiveStream: true,
-                diagnostic: diagnostic,
-                retryCount: 0,
-                currentChannel: IPTVChannel(
-                  id: 'news-1',
-                  name: 'City News Live',
-                  streamUrl: 'https://example.com/news.m3u8',
-                  group: 'News',
-                ),
-              ),
+    final container = ProviderContainer(
+      overrides: [
+        sharedPreferencesProvider.overrideWithValue(prefs),
+        iptvStreamingServiceProvider.overrideWithValue(service),
+        if (channels != null)
+          iptvChannelsProvider.overrideWith((ref) async => channels),
+        streamingStateProvider.overrideWith(
+          (ref) => Stream.value(
+            StreamingState(
+              playbackState: PlaybackState.error,
+              isLiveStream: true,
+              diagnostic: diagnostic,
+              retryCount: retryCount,
+              currentChannel: currentChannel,
             ),
           ),
-        ],
-        child: MaterialApp(
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: const MaterialApp(
           home: Scaffold(
             body: SizedBox(
               width: 960,
               height: viewportHeight,
-              child: const VideoPlayerWidget(),
+              child: VideoPlayerWidget(),
             ),
           ),
         ),
@@ -54,27 +78,101 @@ void main() {
     );
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 100));
+    return container;
   }
 
-  testWidgets(
-    'diagnostic error message stays in the upper band, clear of the '
-    'bottom transport controls',
-    (tester) async {
-      await pumpErrorPlayer(tester);
+  testWidgets('diagnostic error message stays in the upper band, clear of the '
+      'bottom transport controls', (tester) async {
+    await pumpErrorPlayer(tester);
 
-      expect(find.text('Your provider rejected this stream. Check your playlist credentials.'), findsOneWidget);
+    expect(
+      find.text(
+        'Your provider rejected this stream. Check your playlist credentials.',
+      ),
+      findsOneWidget,
+    );
 
-      final messageTop = tester
-          .getTopLeft(
-            find.text(
-              'Your provider rejected this stream. Check your playlist credentials.',
-            ),
-          )
-          .dy;
+    final messageTop = tester
+        .getTopLeft(
+          find.text(
+            'Your provider rejected this stream. Check your playlist credentials.',
+          ),
+        )
+        .dy;
 
-      // Upper-band placement: the message must start well above vertical
-      // center, leaving the whole bottom half clear for transport controls.
-      expect(messageTop, lessThan(viewportHeight * 0.3));
-    },
-  );
+    // Upper-band placement: the message must start well above vertical
+    // center, leaving the whole bottom half clear for transport controls.
+    expect(messageTop, lessThan(viewportHeight * 0.3));
+  });
+
+  // issues/04-recovery-states.md acceptance criterion 1: three distinct
+  // outcomes, all D-pad reachable (the old ElevatedButton had no
+  // TvFocusable at all).
+  testWidgets('offers Try Again, Skip channel, and Report dead link, each a '
+      'D-pad-reachable TvFocusable', (tester) async {
+    await pumpErrorPlayer(tester);
+
+    for (final key in [
+      'diagnostic-error-retry',
+      'diagnostic-error-skip',
+      'diagnostic-error-report',
+    ]) {
+      expect(
+        find.descendant(
+          of: find.byKey(ValueKey(key)),
+          matching: find.byType(TvFocusable),
+        ),
+        findsOneWidget,
+        reason: '$key must be a TvFocusable so a remote can reach it',
+      );
+    }
+  });
+
+  testWidgets('Report dead link saves a local report and confirms it', (
+    tester,
+  ) async {
+    final container = await pumpErrorPlayer(tester);
+
+    await tester.tap(find.text('Report dead link'));
+    await tester.pump();
+    await tester.pump();
+
+    final reports = container.read(deadLinkReportStorageProvider).readAll();
+    expect(reports, hasLength(1));
+    expect(reports.single.channelName, 'City News Live');
+    expect(find.text('Saved locally — nothing was sent'), findsOneWidget);
+  });
+
+  testWidgets('Skip channel moves to the next channel in the playlist', (
+    tester,
+  ) async {
+    const nextChannel = IPTVChannel(
+      id: 'sports-1',
+      name: 'Stadium Sports',
+      streamUrl: 'https://example.com/sports.m3u8',
+      group: 'Sports',
+    );
+    final container = await pumpErrorPlayer(
+      tester,
+      channels: const [
+        IPTVChannel(
+          id: 'news-1',
+          name: 'City News Live',
+          streamUrl: 'https://example.com/news.m3u8',
+          group: 'News',
+        ),
+        nextChannel,
+      ],
+    );
+
+    await tester.tap(find.text('Skip channel'));
+    await tester.pump();
+
+    expect(tester.takeException(), isNull);
+
+    // Pending timers (buffer monitor, live-edge detector) must be stopped
+    // inside the test body -- the pending-timer check runs before
+    // addTearDown(service.dispose) fires.
+    await container.read(iptvStreamingServiceProvider).stop();
+  });
 }


### PR DESCRIPTION
## Summary
- Provider-error state now shows three distinct, D-pad-reachable actions (`TvFocusable`): Try Again, Skip channel, Report dead link (local-only save, confirmed by test).
- Offline banner Retry now actually re-checks `connectivityServiceProvider.isConnected` and shows a distinct success/failure snackbar instead of a static message.
- Autofocus lands on the safest primary action (Try Again when retry-eligible, otherwise Skip channel).

Scoped intentionally to this slice of `issues/04-recovery-states.md`. Not addressed here — filed as a follow-up:
- Empty-state URL entry / phone QR / USB onboarding (AC3)
- "Open Wi-Fi Settings" button + real platform adapter (AC4's second half)

Both require a platform adapter (Wi-Fi settings intent, USB picker) per the issue's own cross-agent contract, which is a separate scope of work from this UI slice.

## Test plan
- [x] `flutter test test/application/providers/dead_link_report_provider_test.dart test/presentation/widgets/video_player_widget_error_layout_test.dart test/iptv/presentation/tv_ux/airo_tv_shell_test.dart` — 17/17 pass
- [x] `flutter analyze` on touched files — clean
- [x] `dart format --output=none --set-exit-if-changed` — clean
- [ ] Physical-device validation for the (separately-scoped) Wi-Fi settings/USB capabilities, per the issue's validation section