### PR TITLE
feat: add Airo TV Ways to Watch dialog

### DIFF
--- a/docs/wiki/3.-Navigating-Airo.md
+++ b/docs/wiki/3.-Navigating-Airo.md
@@ -65,6 +65,12 @@ sections filtered to the active mode.
 TV discovery in the shared Media Hub now uses visual cards in a two-column grid
 with live/status cues when available.
 
+While a live channel is selected, the monitor action in the channel information
+bar opens **Ways to Watch**. Fit Screen and Full Screen are always available.
+Floating Window appears only when the current platform supports
+picture-in-picture, and Cast to TV becomes selectable only after Airo discovers
+a Cast-enabled TV on the local network.
+
 Header behavior:
 
 - `/iptv` keeps its own route-level app bar for stream search and cast actions.

--- a/packages/feature_iptv/lib/presentation/screens/iptv_screen.dart
+++ b/packages/feature_iptv/lib/presentation/screens/iptv_screen.dart
@@ -21,6 +21,7 @@ import '../widgets/xmltv_source_sheet.dart';
 import '../tv/iptv_guide_screen.dart';
 import '../tv_ux/airo_tv_shell.dart';
 import '../tv_ux/iptv_resume_gate.dart';
+import '../tv_ux/sections/ways_to_watch_dialog.dart';
 import '../tv_ux/tv_loading_screen.dart';
 import 'mobile_favorites_screen.dart';
 
@@ -526,6 +527,26 @@ class _IPTVScreenState extends ConsumerState<IPTVScreen>
     );
   }
 
+  Future<void> _showWaysToWatch() async {
+    final pictureInPictureSupported =
+        !widget.tenFootMode && await AiroNativePictureInPicture.isSupported();
+    if (!mounted) return;
+
+    if (isGoogleCastSenderPlatform) {
+      unawaited(ref.read(iptvCastProvider.notifier).startDiscovery());
+    }
+
+    await _showWaysToWatchDialog(
+      context: context,
+      pictureInPictureSupported: pictureInPictureSupported,
+      onExitFullscreen: _exitFullscreen,
+      onEnterFullscreen: () {
+        if (!ref.read(isFullscreenModeProvider)) _toggleFullscreen();
+      },
+      onShowCast: _showCastSheet,
+    );
+  }
+
   Future<void> _showPlaylistSheet() async {
     await showPlaylistSourceSheet(context, ref);
   }
@@ -626,9 +647,9 @@ class _IPTVScreenState extends ConsumerState<IPTVScreen>
                   const SizedBox(height: 24),
                   Text(
                     'Starting channel...',
-                    style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                      color: Colors.white70,
-                    ),
+                    style: Theme.of(
+                      context,
+                    ).textTheme.bodyMedium?.copyWith(color: Colors.white70),
                   ),
                   const SizedBox(height: 32),
                   // Escape hatch: the user must never be stuck here indefinitely
@@ -705,6 +726,7 @@ class _IPTVScreenState extends ConsumerState<IPTVScreen>
               onChannelTap: _playChannelFullscreen,
               onFullscreenToggle: _toggleFullscreen,
               onPlaylistSourceTap: _showPlaylistSheet,
+              onWaysToWatchTap: _showWaysToWatch,
               playlistSourceInInfoBar: true,
             ),
           ),
@@ -768,6 +790,7 @@ class _IPTVScreenState extends ConsumerState<IPTVScreen>
                   onChannelTap: _playChannel,
                   onFullscreenToggle: _toggleFullscreen,
                   onPlaylistSourceTap: _showPlaylistSheet,
+                  onWaysToWatchTap: _showWaysToWatch,
                 ),
               ),
               const IptvCastMiniController(),
@@ -777,6 +800,52 @@ class _IPTVScreenState extends ConsumerState<IPTVScreen>
       ),
     );
   }
+}
+
+Future<void> _showWaysToWatchDialog({
+  required BuildContext context,
+  required bool pictureInPictureSupported,
+  required VoidCallback onExitFullscreen,
+  required VoidCallback onEnterFullscreen,
+  required VoidCallback onShowCast,
+}) {
+  return showDialog<void>(
+    context: context,
+    builder: (dialogContext) => Consumer(
+      builder: (context, dialogRef, _) {
+        final castState = dialogRef.watch(iptvCastProvider);
+        final castAvailable =
+            isGoogleCastSenderPlatform &&
+            castState.discovery.devices.isNotEmpty;
+        return WaysToWatchDialog(
+          pictureInPictureSupported: pictureInPictureSupported,
+          castAvailable: castAvailable,
+          onFitScreen: () {
+            Navigator.of(dialogContext).pop();
+            onExitFullscreen();
+          },
+          onFullScreen: () {
+            Navigator.of(dialogContext).pop();
+            onEnterFullscreen();
+          },
+          onPictureInPicture: () async {
+            Navigator.of(dialogContext).pop();
+            final entered = await AiroNativePictureInPicture.requestEnter();
+            if (!context.mounted || entered) return;
+            ScaffoldMessenger.of(context).showSnackBar(
+              const SnackBar(
+                content: Text('Floating Window could not be started.'),
+              ),
+            );
+          },
+          onCast: () {
+            Navigator.of(dialogContext).pop();
+            onShowCast();
+          },
+        );
+      },
+    ),
+  );
 }
 
 /// IPTV Screen body content (without AppBar) for embedding in MediaHubScreen
@@ -881,6 +950,45 @@ class _IPTVScreenBodyState extends ConsumerState<IPTVScreenBody>
     await showPlaylistSourceSheet(context, ref);
   }
 
+  Future<void> _showCastSheet() async {
+    final channel = ref
+        .read(iptvStreamingServiceProvider)
+        .currentState
+        .currentChannel;
+    if (channel == null) return;
+    await showIptvCastDevicePicker(
+      context: context,
+      onDeviceSelected: (device) {
+        ref
+            .read(iptvCastProvider.notifier)
+            .castChannelToDevice(
+              channel: channel,
+              device: device,
+              selectedQuality: ref
+                  .read(iptvStreamingServiceProvider)
+                  .currentState
+                  .selectedQuality,
+            );
+      },
+    );
+  }
+
+  Future<void> _showWaysToWatch() async {
+    final pictureInPictureSupported =
+        await AiroNativePictureInPicture.isSupported();
+    if (!mounted) return;
+    unawaited(ref.read(iptvCastProvider.notifier).startDiscovery());
+    await _showWaysToWatchDialog(
+      context: context,
+      pictureInPictureSupported: pictureInPictureSupported,
+      onExitFullscreen: _exitFullscreen,
+      onEnterFullscreen: () {
+        if (!ref.read(isFullscreenModeProvider)) _toggleFullscreen();
+      },
+      onShowCast: _showCastSheet,
+    );
+  }
+
   void _syncLocalPlaybackWithCast(bool? wasCasting, bool isCasting) {
     final streaming = ref.read(iptvStreamingServiceProvider);
     if (isCasting) {
@@ -944,6 +1052,7 @@ class _IPTVScreenBodyState extends ConsumerState<IPTVScreenBody>
                       onChannelTap: _playChannel,
                       onFullscreenToggle: _toggleFullscreen,
                       onPlaylistSourceTap: _showPlaylistSheet,
+                      onWaysToWatchTap: _showWaysToWatch,
                     ),
                   ),
                   const IptvCastMiniController(),
@@ -960,12 +1069,14 @@ class _StreamTabContent extends ConsumerWidget {
     required this.onChannelTap,
     required this.onFullscreenToggle,
     required this.onPlaylistSourceTap,
+    required this.onWaysToWatchTap,
     this.playlistSourceInInfoBar = false,
   });
 
   final ValueChanged<IPTVChannel> onChannelTap;
   final VoidCallback onFullscreenToggle;
   final VoidCallback onPlaylistSourceTap;
+  final VoidCallback onWaysToWatchTap;
 
   /// True on TV (no app bar): surfaces the playlist-source entry in the
   /// shell's LIVE bar instead. Phones keep it in the app bar only.
@@ -1004,6 +1115,7 @@ class _StreamTabContent extends ConsumerWidget {
       currentChannel: activeChannel,
       onChannelSelected: onChannelTap,
       onPlaylistSourceTap: playlistSourceInInfoBar ? onPlaylistSourceTap : null,
+      onWaysToWatchTap: onWaysToWatchTap,
       videoStage: AspectRatio(
         aspectRatio: 16 / 9,
         child: activeChannel == null

--- a/packages/feature_iptv/lib/presentation/tv_ux/airo_tv_shell.dart
+++ b/packages/feature_iptv/lib/presentation/tv_ux/airo_tv_shell.dart
@@ -31,6 +31,7 @@ class AiroTvShell extends ConsumerStatefulWidget {
     this.availabilityByChannelId = const {},
     this.enrichMetadata = false,
     this.onPlaylistSourceTap,
+    this.onWaysToWatchTap,
   });
 
   final List<IPTVChannel> channels;
@@ -44,6 +45,9 @@ class AiroTvShell extends ConsumerStatefulWidget {
   /// Opens the playlist-source sheet from the LIVE bar. Wired on TV where
   /// the phone app bar is suppressed; null hides the entry.
   final VoidCallback? onPlaylistSourceTap;
+
+  /// Opens the fit/full/floating/Cast chooser from the LIVE info bar.
+  final VoidCallback? onWaysToWatchTap;
 
   @override
   ConsumerState<AiroTvShell> createState() => _AiroTvShellState();
@@ -107,6 +111,7 @@ class _AiroTvShellState extends ConsumerState<AiroTvShell> {
     final infoBar = ChannelInfoBar(
       channel: widget.currentChannel,
       onPlaylistSourceTap: widget.onPlaylistSourceTap,
+      onWaysToWatchTap: widget.onWaysToWatchTap,
     );
     final hotbar = Hotbar(
       channels: widget.channels,

--- a/packages/feature_iptv/lib/presentation/tv_ux/sections/channel_info_bar.dart
+++ b/packages/feature_iptv/lib/presentation/tv_ux/sections/channel_info_bar.dart
@@ -8,13 +8,21 @@ import '../../../application/providers/iptv_providers.dart';
 import '../../widgets/channel_logo.dart';
 
 class ChannelInfoBar extends ConsumerWidget {
-  const ChannelInfoBar({super.key, this.channel, this.onPlaylistSourceTap});
+  const ChannelInfoBar({
+    super.key,
+    this.channel,
+    this.onPlaylistSourceTap,
+    this.onWaysToWatchTap,
+  });
 
   final IPTVChannel? channel;
 
   /// Opens the playlist-source sheet. Wired on TV where the phone app bar
   /// (the usual home of this action) is suppressed; null hides the button.
   final VoidCallback? onPlaylistSourceTap;
+
+  /// Opens the capability-aware fit/full/floating/Cast chooser.
+  final VoidCallback? onWaysToWatchTap;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -71,6 +79,17 @@ class ChannelInfoBar extends ConsumerWidget {
                   : () => _copyShareDetails(context, channel!),
               tooltip: 'Share',
               icon: const Icon(Icons.share_outlined),
+            ),
+          ),
+          TvFocusable(
+            key: const ValueKey('channel-info-ways-to-watch'),
+            semanticLabel: 'Ways to Watch',
+            enabled: channel != null && onWaysToWatchTap != null,
+            onSelect: channel == null ? null : onWaysToWatchTap,
+            child: IconButton(
+              onPressed: channel == null ? null : onWaysToWatchTap,
+              tooltip: 'Ways to Watch',
+              icon: const Icon(Icons.monitor_outlined),
             ),
           ),
         ],

--- a/packages/feature_iptv/lib/presentation/tv_ux/sections/ways_to_watch_dialog.dart
+++ b/packages/feature_iptv/lib/presentation/tv_ux/sections/ways_to_watch_dialog.dart
@@ -1,0 +1,135 @@
+import 'package:core_ui/core_ui.dart';
+import 'package:flutter/material.dart';
+
+class WaysToWatchDialog extends StatelessWidget {
+  const WaysToWatchDialog({
+    super.key,
+    required this.pictureInPictureSupported,
+    required this.castAvailable,
+    required this.onFitScreen,
+    required this.onFullScreen,
+    required this.onPictureInPicture,
+    required this.onCast,
+  });
+
+  final bool pictureInPictureSupported;
+  final bool castAvailable;
+  final VoidCallback onFitScreen;
+  final VoidCallback onFullScreen;
+  final VoidCallback onPictureInPicture;
+  final VoidCallback onCast;
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      key: const ValueKey('ways-to-watch-dialog'),
+      title: const Text('Ways to Watch'),
+      content: ConstrainedBox(
+        constraints: const BoxConstraints(maxWidth: 440),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            const _SectionLabel('ON THIS DEVICE'),
+            _WatchOption(
+              key: const ValueKey('ways-to-watch-fit'),
+              icon: Icons.fit_screen_outlined,
+              title: 'Fit Screen',
+              description: 'Keep video fitted inside the Airo TV window.',
+              autofocus: true,
+              onSelect: onFitScreen,
+            ),
+            _WatchOption(
+              key: const ValueKey('ways-to-watch-fullscreen'),
+              icon: Icons.fullscreen,
+              title: 'Full Screen',
+              description: 'Fill this display and hide the browsing shell.',
+              onSelect: onFullScreen,
+            ),
+            if (pictureInPictureSupported)
+              _WatchOption(
+                key: const ValueKey('ways-to-watch-pip'),
+                icon: Icons.picture_in_picture_alt_outlined,
+                title: 'Floating Window',
+                description: 'Keep video visible while using other apps.',
+                onSelect: onPictureInPicture,
+              ),
+            const Divider(height: 28),
+            const _SectionLabel('ON ANOTHER SCREEN'),
+            _WatchOption(
+              key: const ValueKey('ways-to-watch-cast'),
+              icon: Icons.cast,
+              title: 'Cast to TV',
+              description: castAvailable
+                  ? 'Choose a nearby Cast-enabled TV.'
+                  : 'No Cast devices available.',
+              onSelect: castAvailable ? onCast : null,
+            ),
+          ],
+        ),
+      ),
+      actions: [
+        TextButton(
+          key: const ValueKey('ways-to-watch-close'),
+          onPressed: () => Navigator.of(context).pop(),
+          child: const Text('Close'),
+        ),
+      ],
+    );
+  }
+}
+
+class _SectionLabel extends StatelessWidget {
+  const _SectionLabel(this.text);
+
+  final String text;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(left: 16, bottom: 4),
+      child: Text(
+        text,
+        style: Theme.of(context).textTheme.labelSmall?.copyWith(
+          color: Theme.of(context).colorScheme.primary,
+          letterSpacing: 1.1,
+        ),
+      ),
+    );
+  }
+}
+
+class _WatchOption extends StatelessWidget {
+  const _WatchOption({
+    super.key,
+    required this.icon,
+    required this.title,
+    required this.description,
+    required this.onSelect,
+    this.autofocus = false,
+  });
+
+  final IconData icon;
+  final String title;
+  final String description;
+  final VoidCallback? onSelect;
+  final bool autofocus;
+
+  @override
+  Widget build(BuildContext context) {
+    return TvFocusable(
+      semanticLabel: title,
+      autofocus: autofocus,
+      enabled: onSelect != null,
+      onSelect: onSelect,
+      borderRadius: 8,
+      child: ListTile(
+        enabled: onSelect != null,
+        leading: Icon(icon),
+        title: Text(title),
+        subtitle: Text(description, maxLines: 1),
+        onTap: onSelect,
+      ),
+    );
+  }
+}

--- a/packages/feature_iptv/test/iptv/presentation/tv_ux/ways_to_watch_dialog_test.dart
+++ b/packages/feature_iptv/test/iptv/presentation/tv_ux/ways_to_watch_dialog_test.dart
@@ -1,0 +1,113 @@
+import 'package:feature_iptv/presentation/tv_ux/sections/ways_to_watch_dialog.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  Future<void> pumpDialog(
+    WidgetTester tester, {
+    required bool pictureInPictureSupported,
+    required bool castAvailable,
+    VoidCallback? onFitScreen,
+    VoidCallback? onFullScreen,
+    VoidCallback? onPictureInPicture,
+    VoidCallback? onCast,
+  }) {
+    return tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: WaysToWatchDialog(
+            pictureInPictureSupported: pictureInPictureSupported,
+            castAvailable: castAvailable,
+            onFitScreen: onFitScreen ?? () {},
+            onFullScreen: onFullScreen ?? () {},
+            onPictureInPicture: onPictureInPicture ?? () {},
+            onCast: onCast ?? () {},
+          ),
+        ),
+      ),
+    );
+  }
+
+  testWidgets('renders fit and full but hides unsupported floating window', (
+    tester,
+  ) async {
+    await pumpDialog(
+      tester,
+      pictureInPictureSupported: false,
+      castAvailable: false,
+    );
+
+    expect(find.text('Fit Screen'), findsOneWidget);
+    expect(find.text('Full Screen'), findsOneWidget);
+    expect(find.text('Floating Window'), findsNothing);
+    expect(find.text('No Cast devices available.'), findsOneWidget);
+  });
+
+  testWidgets('renders supported floating window and invokes each action', (
+    tester,
+  ) async {
+    var fitCount = 0;
+    var fullCount = 0;
+    var pipCount = 0;
+    var castCount = 0;
+    await pumpDialog(
+      tester,
+      pictureInPictureSupported: true,
+      castAvailable: true,
+      onFitScreen: () => fitCount++,
+      onFullScreen: () => fullCount++,
+      onPictureInPicture: () => pipCount++,
+      onCast: () => castCount++,
+    );
+
+    await tester.tap(find.byKey(const ValueKey('ways-to-watch-fit')));
+    await tester.tap(find.byKey(const ValueKey('ways-to-watch-fullscreen')));
+    await tester.tap(find.byKey(const ValueKey('ways-to-watch-pip')));
+    await tester.tap(find.byKey(const ValueKey('ways-to-watch-cast')));
+
+    expect((fitCount, fullCount, pipCount, castCount), (1, 1, 1, 1));
+  });
+
+  testWidgets('Cast row is disabled when no device is available', (
+    tester,
+  ) async {
+    var castCount = 0;
+    await pumpDialog(
+      tester,
+      pictureInPictureSupported: true,
+      castAvailable: false,
+      onCast: () => castCount++,
+    );
+
+    final castTile = tester.widget<ListTile>(
+      find.descendant(
+        of: find.byKey(const ValueKey('ways-to-watch-cast')),
+        matching: find.byType(ListTile),
+      ),
+    );
+    expect(castTile.enabled, isFalse);
+    expect(castTile.onTap, isNull);
+    await tester.tap(find.byKey(const ValueKey('ways-to-watch-cast')));
+    expect(castCount, 0);
+  });
+
+  testWidgets('D-pad traversal reaches and activates enabled options', (
+    tester,
+  ) async {
+    var fullCount = 0;
+    await pumpDialog(
+      tester,
+      pictureInPictureSupported: true,
+      castAvailable: true,
+      onFullScreen: () => fullCount++,
+    );
+
+    await tester.pump();
+    await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+    await tester.sendKeyEvent(LogicalKeyboardKey.enter);
+    await tester.pump(const Duration(milliseconds: 200));
+
+    expect(fullCount, 1);
+  });
+}


### PR DESCRIPTION
## Summary

- add the Phase 4 Ways to Watch dialog with Fit Screen, Full Screen, capability-gated Floating Window, and Cast to TV
- wire the reserved monitor action in the explorer channel info bar to existing fullscreen, native PiP, and IPTV Cast contracts
- keep Cast disabled with explicit no-device copy until discovery finds a receiver
- document the watch-mode entry in the public capability wiki

Closes #1040
Parent: #1050

## Test Plan

- [x] `flutter analyze` or relevant package analyzer passed
- [x] `flutter test` or relevant package tests passed
- [ ] CI-only change validated with local script/YAML checks — not applicable
- [x] Manual device/simulator verification documented, or not applicable — host-only capability and D-pad widget coverage

**Verification environment:** Host-only

Commands:
- `flutter test test/iptv/presentation/tv_ux/ways_to_watch_dialog_test.dart test/iptv/presentation/tv_ux/airo_tv_shell_test.dart` — 14 passed
- `flutter analyze lib/presentation/tv_ux lib/presentation/screens/iptv_screen.dart test/iptv/presentation/tv_ux/ways_to_watch_dialog_test.dart` — no issues
- `git diff --check` — passed

A broader screen-suite attempt encountered host `ENOSPC` while Flutter copied a generated test cache; focused contract tests and analysis completed successfully.

## Agent Policy

- [x] Linked issue includes a Critical Agent Gate.
- [x] Linked issue includes a Feature Packet.
- [x] Cross-agent contract is documented; no new cross-package API/schema is introduced.
- [x] Deterministic use cases and automation flows are included in #1040.
- [x] AI/tool/memory/routine eval coverage is not applicable.
- [x] Android Emulator was not used.

## Council Review

Reviewed in this Codex implementation session against `docs/agents/COUNCIL.md`:
- Media Intelligence Architect: package ownership and IPTV flow scope
- Flutter Architect: widget structure and Riverpod callback wiring
- Platform Architect: existing PiP/Cast contracts consumed without boundary changes
- Chief Architect: no new package, schema, dependency, or cross-module contract
- Chief QA Officer: capability matrix, disabled state, callback, and D-pad tests
- Chief UX Officer: focusable option order, descriptions, and unavailable-state copy
- Chief Performance Officer: no player/decoder changes; discovery starts only on explicit dialog entry
- Chief Open Source Officer: no dependency changes

- [x] I checked the Decision Matrix and listed every required role above.
- [x] `packages/feature_iptv/module.yaml` exists and remains accurate.
- [x] Owner/reviewer roster remains aligned; no manifest edit required.

## User-Facing Documentation

- [x] Updated `docs/wiki/3.-Navigating-Airo.md` with the capability and platform gating.
- [ ] No docs update needed — not applicable.

## Plugin and Size Impact

- [ ] This PR adds new dependencies
- [x] This PR grows `feature_iptv` presentation/test source only
- [x] Size impact is documented below
- [x] Module remains far below plugin thresholds; no plugin marker change
- [x] Plugin cache documentation is not applicable

Size impact: approximately 394 added source/test/wiki lines, no assets, generated files, binaries, or dependencies.

## Checklist

- [x] Code is formatted.
- [x] Focused tests and validation are documented above and on #1040.
- [x] Sensitive data, credentials, and signing artifacts are not committed.

## Release Notes

- [x] User-facing Ways to Watch capability documented in the public wiki.