### PR TITLE
fix(player): stream Android documents from retained descriptors

### DIFF
--- a/app/android/app/src/main/kotlin/io/airo/app/PhoneMediaPickerPlugin.kt
+++ b/app/android/app/src/main/kotlin/io/airo/app/PhoneMediaPickerPlugin.kt
@@ -72,6 +72,7 @@ class PhoneMediaPickerPlugin(private val activity: Activity) {
             result.success(
                 mapOf(
                     "token" to token,
+                    "descriptor" to descriptor.fd,
                     "filePath" to "/proc/self/fd/${descriptor.fd}",
                     "title" to title,
                     "size" to descriptor.statSize

--- a/app/lib/features/iptv/phone_media_local_picker.dart
+++ b/app/lib/features/iptv/phone_media_local_picker.dart
@@ -54,10 +54,16 @@ Future<PhoneLocalMediaItem?> pickAndroidPhoneLocalMediaForTv({
     if (selection == null) return null;
 
     final token = selection['token'] as String?;
+    final descriptor = (selection['descriptor'] as num?)?.round();
+    final mediaLength = (selection['size'] as num?)?.round();
     final filePath = selection['filePath'] as String?;
     final title = selection['title'] as String?;
     if (token == null ||
         token.isEmpty ||
+        descriptor == null ||
+        descriptor < 0 ||
+        mediaLength == null ||
+        mediaLength < 0 ||
         filePath == null ||
         filePath.isEmpty ||
         title == null ||
@@ -73,19 +79,23 @@ Future<PhoneLocalMediaItem?> pickAndroidPhoneLocalMediaForTv({
             assetId: token,
             filePath: filePath,
             fileName: title,
-            fileSizeBytesHint: (selection['size'] as num?)?.round(),
+            fileSizeBytesHint: mediaLength,
           ),
         );
+    final source = _AndroidPhoneMediaSource(
+      channel: channel,
+      token: token,
+      descriptor: descriptor,
+      mediaLength: mediaLength,
+    );
 
     return _phoneLocalMediaItem(
       filePath: filePath,
       title: title,
       fallbackContainer: _extensionOf(title),
       analysis: analysis,
-      sourceLease: _AndroidPhoneMediaSourceLease(
-        channel: channel,
-        token: token,
-      ),
+      sourceLease: source,
+      source: source,
     );
   } on PlatformException {
     return null;
@@ -98,6 +108,7 @@ PhoneLocalMediaItem _phoneLocalMediaItem({
   required String fallbackContainer,
   required MediaAssetAnalysisResult analysis,
   PhoneMediaSourceLease? sourceLease,
+  PhoneMediaSeekableSource? source,
 }) {
   final profile = analysis.profile;
   final analyzedContainer = profile?.container;
@@ -112,6 +123,7 @@ PhoneLocalMediaItem _phoneLocalMediaItem({
         ? fallbackContainer
         : analyzedContainer.stableId,
     sourceLease: sourceLease,
+    source: source,
     videoCodec:
         primaryVideo == null || primaryVideo.codec == MediaVideoCodec.unknown
         ? null
@@ -130,17 +142,38 @@ String _extensionOf(String fileName) {
   return fileName.substring(separator + 1).toLowerCase();
 }
 
-class _AndroidPhoneMediaSourceLease implements PhoneMediaSourceLease {
-  _AndroidPhoneMediaSourceLease({required this.channel, required this.token});
+class _AndroidPhoneMediaSource
+    implements PhoneMediaSourceLease, PhoneMediaSeekableSource {
+  _AndroidPhoneMediaSource({
+    required this.channel,
+    required this.token,
+    required int descriptor,
+    required int mediaLength,
+  }) : _source = NativeDescriptorPhoneMediaSource(
+         descriptor: descriptor,
+         mediaLength: mediaLength,
+       );
 
   final MethodChannel channel;
   final String token;
+  final NativeDescriptorPhoneMediaSource _source;
   bool _released = false;
+
+  @override
+  bool get isAvailable => !_released && _source.isAvailable;
+
+  @override
+  Future<int> length() => _source.length();
+
+  @override
+  Stream<List<int>> openRead(int start, int end) =>
+      _source.openRead(start, end);
 
   @override
   Future<void> release() async {
     if (_released) return;
     _released = true;
+    _source.close();
     await channel.invokeMethod<void>('release', {'token': token});
   }
 }

--- a/app/test/features/iptv/phone_media_local_picker_test.dart
+++ b/app/test/features/iptv/phone_media_local_picker_test.dart
@@ -2,6 +2,7 @@ import 'package:airo_app/features/iptv/phone_media_local_picker.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:platform_media/platform_media.dart';
+import 'package:platform_player/platform_player.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -56,6 +57,7 @@ void main() {
         if (call.method == 'pickVideo') {
           return <String, Object?>{
             'token': 'lease-1',
+            'descriptor': 42,
             'filePath': '/proc/self/fd/42',
             'title': 'Feature.FILM.MKV',
             'size': 6101307309,
@@ -76,6 +78,8 @@ void main() {
       expect(item.videoCodec, 'hevc');
       expect(item.audioCodec, 'dts');
       expect(item.duration, const Duration(hours: 2, minutes: 10, seconds: 7));
+      expect(item.source, isA<PhoneMediaSeekableSource>());
+      expect(await item.source!.length(), 6101307309);
       expect(analyzer.requests, [
         const MediaAssetAnalysisRequest(
           assetId: 'lease-1',
@@ -101,8 +105,10 @@ void main() {
       if (call.method == 'pickVideo') {
         return <String, Object?>{
           'token': 'lease-2',
+          'descriptor': 43,
           'filePath': '/proc/self/fd/43',
           'title': 'movie.mp4',
+          'size': 4096,
         };
       }
       return null;
@@ -117,6 +123,17 @@ void main() {
 
     expect(calls.map((call) => call.method), ['pickVideo', 'release']);
     expect(calls.last.arguments, {'token': 'lease-2'});
+    expect(item.source!.isAvailable, isFalse);
+    expect(
+      item.source!.length(),
+      throwsA(
+        isA<PhoneMediaSourceException>().having(
+          (error) => error.code,
+          'code',
+          PhoneMediaSourceFailureCode.closed,
+        ),
+      ),
+    );
   });
 
   test('malformed selection releases a supplied native token', () async {

--- a/packages/platform_player/lib/platform_player.dart
+++ b/packages/platform_player/lib/platform_player.dart
@@ -22,6 +22,7 @@ export "src/services/iptv_streaming_service.dart";
 export "src/services/iptv_cast_media_adapter.dart";
 export "src/services/google_cast_platform_support.dart";
 export "src/services/native_fullscreen.dart";
+export "src/services/native_descriptor_phone_media_source.dart";
 export "src/services/native_picture_in_picture.dart";
 export "src/services/phone_media_cast_handoff.dart";
 export "src/services/phone_media_file_server.dart";

--- a/packages/platform_player/lib/src/services/native_descriptor_phone_media_source.dart
+++ b/packages/platform_player/lib/src/services/native_descriptor_phone_media_source.dart
@@ -1,0 +1,2 @@
+export 'native_descriptor_phone_media_source_stub.dart'
+    if (dart.library.io) 'native_descriptor_phone_media_source_io.dart';

--- a/packages/platform_player/lib/src/services/native_descriptor_phone_media_source_io.dart
+++ b/packages/platform_player/lib/src/services/native_descriptor_phone_media_source_io.dart
@@ -1,0 +1,164 @@
+// ignore_for_file: prefer_initializing_formals
+
+import 'dart:async';
+import 'dart:ffi';
+import 'dart:io';
+import 'dart:isolate';
+import 'dart:typed_data';
+
+import 'phone_media_seekable_source.dart';
+
+typedef _MallocNative = Pointer<Void> Function(IntPtr);
+typedef _MallocDart = Pointer<Void> Function(int);
+typedef _FreeNative = Void Function(Pointer<Void>);
+typedef _FreeDart = void Function(Pointer<Void>);
+typedef _PreadNative = IntPtr Function(Int32, Pointer<Void>, IntPtr, Int64);
+typedef _PreadDart = int Function(int, Pointer<Void>, int, int);
+
+const _chunkSize = 256 * 1024;
+
+/// Random-access source backed by a descriptor retained by the host platform.
+///
+/// Reads run on short-lived isolates and transfer bounded byte chunks without
+/// reopening `/proc/self/fd` or copying the complete media asset.
+class NativeDescriptorPhoneMediaSource implements PhoneMediaSeekableSource {
+  NativeDescriptorPhoneMediaSource({
+    required int descriptor,
+    required int mediaLength,
+  }) : _descriptor = descriptor,
+       _mediaLength = mediaLength;
+
+  final int _descriptor;
+  final int _mediaLength;
+  bool _closed = false;
+
+  @override
+  bool get isAvailable => !_closed && _descriptor >= 0 && _mediaLength >= 0;
+
+  @override
+  Future<int> length() async {
+    if (_closed) {
+      throw const PhoneMediaSourceException(PhoneMediaSourceFailureCode.closed);
+    }
+    if (!isAvailable) {
+      throw const PhoneMediaSourceException(
+        PhoneMediaSourceFailureCode.unavailable,
+      );
+    }
+    return _mediaLength;
+  }
+
+  @override
+  Stream<List<int>> openRead(int start, int end) {
+    if (_closed) {
+      return Stream.error(
+        const PhoneMediaSourceException(PhoneMediaSourceFailureCode.closed),
+      );
+    }
+    if (start < 0 || end < start || end > _mediaLength) {
+      return Stream.error(
+        const PhoneMediaSourceException(PhoneMediaSourceFailureCode.readFailed),
+      );
+    }
+    return _readInWorker(_descriptor, start, end);
+  }
+
+  void close() => _closed = true;
+}
+
+Stream<List<int>> _readInWorker(int descriptor, int start, int end) {
+  late StreamController<List<int>> controller;
+  final events = ReceivePort();
+  Isolate? worker;
+  StreamSubscription<Object?>? subscription;
+  var offset = start;
+
+  Future<void> finish() async {
+    await subscription?.cancel();
+    events.close();
+    worker?.kill(priority: Isolate.immediate);
+    if (!controller.isClosed) await controller.close();
+  }
+
+  controller = StreamController<List<int>>(
+    onListen: () async {
+      try {
+        worker = await Isolate.spawn(_descriptorReaderWorker, events.sendPort);
+        subscription = events.listen((message) {
+          if (message is SendPort) {
+            final remaining = end - offset;
+            if (remaining == 0) {
+              unawaited(finish());
+            } else {
+              message.send([
+                descriptor,
+                offset,
+                remaining < _chunkSize ? remaining : _chunkSize,
+              ]);
+            }
+            return;
+          }
+          if (message is TransferableTypedData) {
+            final bytes = message.materialize().asUint8List();
+            offset += bytes.length;
+            controller.add(bytes);
+            if (offset >= end) {
+              unawaited(finish());
+            }
+            return;
+          }
+          controller.addError(
+            const PhoneMediaSourceException(
+              PhoneMediaSourceFailureCode.readFailed,
+            ),
+          );
+          unawaited(finish());
+        });
+      } catch (_) {
+        controller.addError(
+          const PhoneMediaSourceException(
+            PhoneMediaSourceFailureCode.readFailed,
+          ),
+        );
+        await finish();
+      }
+    },
+    onCancel: finish,
+  );
+  return controller.stream;
+}
+
+void _descriptorReaderWorker(SendPort events) {
+  final commands = ReceivePort();
+  events.send(commands.sendPort);
+  final library = DynamicLibrary.process();
+  final malloc = library.lookupFunction<_MallocNative, _MallocDart>('malloc');
+  final free = library.lookupFunction<_FreeNative, _FreeDart>('free');
+  final pread = library.lookupFunction<_PreadNative, _PreadDart>(
+    Platform.isAndroid ? 'pread64' : 'pread',
+  );
+  commands.listen((message) {
+    if (message is! List || message.length != 3) {
+      events.send('read_failed');
+      return;
+    }
+    final descriptor = message[0] as int;
+    final offset = message[1] as int;
+    final count = message[2] as int;
+    final buffer = malloc(count);
+    try {
+      final bytesRead = pread(descriptor, buffer, count, offset);
+      if (bytesRead <= 0) {
+        events.send('read_failed');
+        return;
+      }
+      final bytes = Uint8List.fromList(
+        buffer.cast<Uint8>().asTypedList(bytesRead),
+      );
+      events.send(TransferableTypedData.fromList([bytes]));
+      events.send(commands.sendPort);
+    } finally {
+      free(buffer);
+    }
+  });
+}

--- a/packages/platform_player/lib/src/services/native_descriptor_phone_media_source_stub.dart
+++ b/packages/platform_player/lib/src/services/native_descriptor_phone_media_source_stub.dart
@@ -1,0 +1,27 @@
+import 'phone_media_seekable_source.dart';
+
+class NativeDescriptorPhoneMediaSource implements PhoneMediaSeekableSource {
+  factory NativeDescriptorPhoneMediaSource({
+    required int descriptor,
+    required int mediaLength,
+  }) {
+    throw UnsupportedError(
+      'Native descriptors are unavailable on this platform.',
+    );
+  }
+
+  @override
+  bool get isAvailable => false;
+
+  @override
+  Future<int> length() => throw const PhoneMediaSourceException(
+    PhoneMediaSourceFailureCode.unavailable,
+  );
+
+  @override
+  Stream<List<int>> openRead(int start, int end) => Stream.error(
+    const PhoneMediaSourceException(PhoneMediaSourceFailureCode.unavailable),
+  );
+
+  void close() {}
+}

--- a/packages/platform_player/test/native_descriptor_phone_media_source_test.dart
+++ b/packages/platform_player/test/native_descriptor_phone_media_source_test.dart
@@ -1,0 +1,80 @@
+import 'dart:convert';
+import 'dart:ffi';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:platform_player/platform_player.dart';
+
+typedef _OpenNative = Int32 Function(Pointer<Uint8>, Int32);
+typedef _OpenDart = int Function(Pointer<Uint8>, int);
+typedef _CloseNative = Int32 Function(Int32);
+typedef _CloseDart = int Function(int);
+typedef _MallocNative = Pointer<Void> Function(IntPtr);
+typedef _MallocDart = Pointer<Void> Function(int);
+typedef _FreeNative = Void Function(Pointer<Void>);
+typedef _FreeDart = void Function(Pointer<Void>);
+
+void main() {
+  test(
+    'reads a bounded high-offset range from a retained descriptor',
+    () async {
+      final directory = await Directory.systemTemp.createTemp(
+        'native_descriptor_source',
+      );
+      addTearDown(() => directory.delete(recursive: true));
+      final bytes = List<int>.generate(1024 * 1024, (index) => index % 251);
+      final file = File('${directory.path}/media.bin');
+      await file.writeAsBytes(bytes);
+      final descriptor = _openReadOnly(file.path);
+      addTearDown(() => _close(descriptor));
+      final source = NativeDescriptorPhoneMediaSource(
+        descriptor: descriptor,
+        mediaLength: bytes.length,
+      );
+
+      const start = 900000;
+      const end = start + 4096;
+      final actual = await source
+          .openRead(start, end)
+          .fold<List<int>>([], (all, chunk) => all..addAll(chunk));
+
+      expect(actual, bytes.sublist(start, end));
+      source.close();
+      expect(
+        source.openRead(0, 1),
+        emitsError(
+          isA<PhoneMediaSourceException>().having(
+            (error) => error.code,
+            'code',
+            PhoneMediaSourceFailureCode.closed,
+          ),
+        ),
+      );
+    },
+  );
+}
+
+int _openReadOnly(String path) {
+  final library = DynamicLibrary.process();
+  final open = library.lookupFunction<_OpenNative, _OpenDart>('open');
+  final malloc = library.lookupFunction<_MallocNative, _MallocDart>('malloc');
+  final free = library.lookupFunction<_FreeNative, _FreeDart>('free');
+  final encoded = utf8.encode(path);
+  final pointer = malloc(encoded.length + 1).cast<Uint8>();
+  try {
+    pointer.asTypedList(encoded.length + 1)
+      ..setRange(0, encoded.length, encoded)
+      ..[encoded.length] = 0;
+    final descriptor = open(pointer, 0);
+    if (descriptor < 0) throw StateError('Could not open test descriptor.');
+    return descriptor;
+  } finally {
+    free(pointer.cast<Void>());
+  }
+}
+
+void _close(int descriptor) {
+  final close = DynamicLibrary.process()
+      .lookupFunction<_CloseNative, _CloseDart>('close');
+  close(descriptor);
+}


### PR DESCRIPTION
## Summary

- retain and expose the Android document descriptor through the picker lease
- implement bounded positional reads off the main isolate behind `PhoneMediaSeekableSource`
- compose the descriptor source into the existing HTTP Range handoff without a full-file copy
- close the source before releasing the native descriptor and preserve typed closed failures

## Ownership and classification

This is a mixed platform/framework slice owned by the Platform Architect with Playback, Security, Performance, and QA review. Android owns descriptor lifetime; `platform_player` owns the reusable seekable-source adapter. No UI workaround or D-pad behavior is included.

## Validation

- 48 focused `platform_player` server/handoff/descriptor/5 GB soak tests passed
- 4 Android picker composition tests passed
- focused analyzers clean
- Android debug APK built successfully with the receiver feature enabled
- module manifests, docs completeness, and `git diff --check` passed

## Deferred evidence

Physical Pixel/Fire TV testing is deferred until tomorrow. Fire TV can validate Android selection and local Range serving; the CV-033 Google Cast receiver acceptance still requires a Google Cast receiver such as BRAVIA. This repository-only slice does not close #1155.

Refs #1155