### PR TITLE
feat: add bounded Airo TV multiview

### DIFF
--- a/docs/wiki/3.-Navigating-Airo.md
+++ b/docs/wiki/3.-Navigating-Airo.md
@@ -78,6 +78,15 @@ Hotbar, and Playlist sections per device. Playback Stats appears only during an
 active stream and displays codec, resolution, and bitrate only when the active
 player reports those values; Airo does not substitute estimated values.
 
+Each channel tile also has a multiview action. One selected channel fills the
+stage, two use a split layout, and three or four use a featured player above a
+thumbnail strip. Select a thumbnail with a remote, keyboard, or pointer to
+feature it; audio follows the featured channel and every other stream stays
+muted. Airo limits multiview to the device decoder budget: two concurrent
+streams on web, Android, and iOS; four on macOS, Windows, and Linux; and one on
+Fuchsia. The absolute limit is four, and the channel action reports when the
+current device limit has been reached.
+
 Header behavior:
 
 - `/iptv` keeps its own route-level app bar for stream search and cast actions.

--- a/packages/feature_iptv/CHANGELOG.md
+++ b/packages/feature_iptv/CHANGELOG.md
@@ -6,3 +6,8 @@
   Cast playback.
 - Added persistent Explorer row controls, real engine-reported playback stats,
   contextual help, and in-app release notes.
+- Added channel-tile multiview controls with single, split, and featured-strip
+  layouts. Multiview keeps audio on the featured channel and supports
+  remote/keyboard promotion.
+- Limited concurrent multiview decoders to two on web and mobile and four on
+  desktop, with a hard ceiling of four and clear capacity feedback.

--- a/packages/feature_iptv/lib/application/providers/multiview_provider.dart
+++ b/packages/feature_iptv/lib/application/providers/multiview_provider.dart
@@ -1,0 +1,215 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_riverpod/legacy.dart';
+import 'package:platform_channels/platform_channels.dart';
+import 'package:platform_media/platform_media.dart';
+import 'package:platform_player/platform_player.dart';
+
+import 'iptv_providers.dart';
+
+typedef IptvMultiviewSessionFactory =
+    Future<IptvMultiviewSession> Function(IPTVChannel channel);
+
+abstract interface class IptvMultiviewSession implements AiroMultiviewSession {
+  IPTVChannel get channel;
+
+  Stream<StreamingState> get states;
+
+  StreamingState get currentState;
+
+  Widget? buildView();
+}
+
+enum MultiviewToggleResult { added, removed, capacityReached, failed }
+
+class MultiviewState {
+  const MultiviewState({
+    this.sessions = const [],
+    this.featuredChannelId,
+    required this.capacity,
+  });
+
+  final List<IptvMultiviewSession> sessions;
+  final String? featuredChannelId;
+  final int capacity;
+
+  bool contains(String channelId) =>
+      sessions.any((session) => session.id == channelId);
+}
+
+class MultiviewController extends StateNotifier<MultiviewState> {
+  MultiviewController({
+    required int decoderBudget,
+    required IptvMultiviewSessionFactory sessionFactory,
+    required IPTVStreamingService primaryService,
+  }) : // Public constructor labels intentionally omit private field names.
+       // ignore: prefer_initializing_formals
+       _sessionFactory = sessionFactory,
+       // ignore: prefer_initializing_formals
+       _primaryService = primaryService,
+       super(
+         MultiviewState(
+           capacity: decoderBudget.clamp(1, kAiroMultiviewHardCap),
+         ),
+       ) {
+    _pool = AiroMultiviewPool(
+      decoderBudget: decoderBudget,
+      onChanged: _syncFromPool,
+    );
+  }
+
+  final IptvMultiviewSessionFactory _sessionFactory;
+  final IPTVStreamingService _primaryService;
+  late final AiroMultiviewPool _pool;
+  bool _primaryPausedByMultiview = false;
+  bool _disposed = false;
+
+  Future<MultiviewToggleResult> toggle(IPTVChannel channel) async {
+    if (_pool.state.contains(channel.id)) {
+      await _pool.remove(channel.id);
+      if (_pool.state.count == 0) await _resumePrimary();
+      return MultiviewToggleResult.removed;
+    }
+
+    final firstSession = _pool.state.count == 0;
+    if (firstSession) {
+      _primaryPausedByMultiview = _primaryService.currentState.isPlaying;
+      if (_primaryPausedByMultiview) await _primaryService.pause();
+    }
+    final result = await _pool.add(
+      id: channel.id,
+      openSession: () => _sessionFactory(channel),
+    );
+    if (result != AiroMultiviewAddResult.added && firstSession) {
+      await _resumePrimary();
+    }
+    return switch (result) {
+      AiroMultiviewAddResult.added => MultiviewToggleResult.added,
+      AiroMultiviewAddResult.capacityReached =>
+        MultiviewToggleResult.capacityReached,
+      AiroMultiviewAddResult.alreadyPresent ||
+      AiroMultiviewAddResult.openFailed => MultiviewToggleResult.failed,
+    };
+  }
+
+  Future<void> promote(String channelId) => _pool.promote(channelId);
+
+  Future<void> close() async {
+    if (_disposed) return;
+    _disposed = true;
+    await _pool.close();
+    await _resumePrimary();
+  }
+
+  void _syncFromPool(AiroMultiviewPoolState poolState) {
+    if (_disposed) return;
+    state = MultiviewState(
+      sessions: List.unmodifiable(
+        poolState.sessions.cast<IptvMultiviewSession>(),
+      ),
+      featuredChannelId: poolState.featuredSessionId,
+      capacity: _pool.capacity,
+    );
+  }
+
+  Future<void> _resumePrimary() async {
+    if (!_primaryPausedByMultiview) return;
+    _primaryPausedByMultiview = false;
+    await _primaryService.resume();
+  }
+
+  @override
+  void dispose() {
+    unawaited(close());
+    super.dispose();
+  }
+}
+
+final multiviewDecoderBudgetProvider = Provider<int>((ref) {
+  if (kIsWeb) return 2;
+  return switch (defaultTargetPlatform) {
+    TargetPlatform.android || TargetPlatform.iOS => 2,
+    TargetPlatform.macOS || TargetPlatform.windows || TargetPlatform.linux => 4,
+    TargetPlatform.fuchsia => 1,
+  };
+});
+
+final iptvMultiviewSessionFactoryProvider =
+    Provider<IptvMultiviewSessionFactory>((ref) {
+      return (channel) async {
+        final service = VideoPlayerStreamingService(
+          config: StreamingConfig.live,
+        );
+        try {
+          await service.initialize();
+          await service.setVolume(0);
+          await service.playChannel(channel);
+          if (service.currentState.hasError) {
+            throw StateError('Multiview channel failed to open');
+          }
+          return _VideoPlayerMultiviewSession(
+            channel: channel,
+            service: service,
+          );
+        } catch (_) {
+          await service.dispose();
+          rethrow;
+        }
+      };
+    });
+
+final multiviewProvider =
+    StateNotifierProvider<MultiviewController, MultiviewState>((ref) {
+      final controller = MultiviewController(
+        decoderBudget: ref.watch(multiviewDecoderBudgetProvider),
+        sessionFactory: ref.watch(iptvMultiviewSessionFactoryProvider),
+        primaryService: ref.watch(iptvStreamingServiceProvider),
+      );
+      return controller;
+    });
+
+class _VideoPlayerMultiviewSession implements IptvMultiviewSession {
+  _VideoPlayerMultiviewSession({
+    required this.channel,
+    required VideoPlayerStreamingService service,
+  }) : // Keep the factory-facing label independent of the private field.
+       // ignore: prefer_initializing_formals
+       _service = service;
+
+  @override
+  final IPTVChannel channel;
+  final VideoPlayerStreamingService _service;
+
+  @override
+  String get id => channel.id;
+
+  @override
+  Stream<StreamingState> get states => _service.stateStream;
+
+  @override
+  StreamingState get currentState => _service.currentState;
+
+  @override
+  Widget? buildView() => _service.buildVideoView();
+
+  @override
+  Future<void> setAudible(bool audible) async {
+    try {
+      await _service.setVolume(audible ? 1 : 0);
+    } catch (_) {
+      // Pool invariants and cleanup continue after a backend volume failure.
+    }
+  }
+
+  @override
+  Future<void> close() async {
+    try {
+      await _service.stop();
+    } finally {
+      await _service.dispose();
+    }
+  }
+}

--- a/packages/feature_iptv/lib/presentation/tv_ux/airo_tv_shell.dart
+++ b/packages/feature_iptv/lib/presentation/tv_ux/airo_tv_shell.dart
@@ -13,6 +13,7 @@ import '../../application/providers/connectivity_provider.dart';
 import '../../application/providers/control_row_visibility_provider.dart';
 import '../../application/providers/hotbar_channels_provider.dart';
 import '../../application/providers/iptv_providers.dart';
+import '../../application/providers/multiview_provider.dart';
 import '../../application/channel_metadata_enrichment.dart';
 import '../../application/channel_warmup_policy.dart';
 import 'sections/channel_info_bar.dart';
@@ -20,6 +21,7 @@ import 'sections/channel_library_grid.dart';
 import 'sections/filter_dialogs.dart';
 import 'sections/filter_row.dart';
 import 'sections/hotbar.dart';
+import 'sections/multiview_stage.dart';
 import 'sections/playback_stats_bar.dart';
 import 'sections/shell_help_dialog.dart';
 import 'sections/shell_settings_dialog.dart';
@@ -81,6 +83,7 @@ class _AiroTvShellState extends ConsumerState<AiroTvShell> {
     final countryPrompt = ref.watch(channelCountryPromptProvider);
     final hasHotbar = ref.watch(hotbarChannelsProvider).isNotEmpty;
     final rowVisibility = ref.watch(controlRowVisibilityProvider);
+    final multiview = ref.watch(multiviewProvider);
     final playbackStats = ref
         .watch(streamingStateProvider)
         .asData
@@ -117,6 +120,10 @@ class _AiroTvShellState extends ConsumerState<AiroTvShell> {
         availabilityByChannelId,
       ),
       onVisibleChannelsChanged: _scheduleVisibleChannelScan,
+      multiviewChannelIds: {
+        for (final session in multiview.sessions) session.id,
+      },
+      onMultiviewToggle: (channel) => _toggleMultiview(context, channel),
     );
     final infoBar = ChannelInfoBar(
       channel: widget.currentChannel,
@@ -129,7 +136,14 @@ class _AiroTvShellState extends ConsumerState<AiroTvShell> {
     );
     final filterRow = FilterRow(dimensions: snapshot.dimensions);
     final videoStage = _VideoStageWithActions(
-      child: widget.videoStage,
+      child: multiview.sessions.isEmpty
+          ? widget.videoStage
+          : MultiviewStage(
+              sessions: multiview.sessions,
+              featuredChannelId: multiview.featuredChannelId,
+              onPromote: (channelId) =>
+                  ref.read(multiviewProvider.notifier).promote(channelId),
+            ),
       onSettings: () => showAiroTvShellSettingsDialog(context),
       onHelp: () => showAiroTvShellHelpDialog(context),
     );
@@ -241,6 +255,26 @@ class _AiroTvShellState extends ConsumerState<AiroTvShell> {
         );
       },
     );
+  }
+
+  Future<void> _toggleMultiview(
+    BuildContext context,
+    IPTVChannel channel,
+  ) async {
+    final result = await ref.read(multiviewProvider.notifier).toggle(channel);
+    if (!context.mounted) return;
+    final message = switch (result) {
+      MultiviewToggleResult.added => '${channel.name} added to multiview',
+      MultiviewToggleResult.removed => '${channel.name} removed from multiview',
+      MultiviewToggleResult.capacityReached =>
+        'This device supports up to '
+            '${ref.read(multiviewProvider).capacity} multiview streams.',
+      MultiviewToggleResult.failed =>
+        '${channel.name} could not be opened in multiview.',
+    };
+    ScaffoldMessenger.of(context)
+      ..hideCurrentSnackBar()
+      ..showSnackBar(SnackBar(content: Text(message)));
   }
 
   void _selectChannel(

--- a/packages/feature_iptv/lib/presentation/tv_ux/sections/channel_library_grid.dart
+++ b/packages/feature_iptv/lib/presentation/tv_ux/sections/channel_library_grid.dart
@@ -25,6 +25,8 @@ class ChannelLibraryGrid extends StatefulWidget {
     this.onSort,
     this.onChannelSelected,
     this.onVisibleChannelsChanged,
+    this.multiviewChannelIds = const {},
+    this.onMultiviewToggle,
   });
 
   final List<IPTVChannel> channels;
@@ -34,6 +36,8 @@ class ChannelLibraryGrid extends StatefulWidget {
   final ValueChanged<ChannelSortColumn>? onSort;
   final ValueChanged<IPTVChannel>? onChannelSelected;
   final ValueChanged<List<IPTVChannel>>? onVisibleChannelsChanged;
+  final Set<String> multiviewChannelIds;
+  final ValueChanged<IPTVChannel>? onMultiviewToggle;
 
   @override
   State<ChannelLibraryGrid> createState() => _ChannelLibraryGridState();
@@ -122,12 +126,7 @@ class _ChannelLibraryGridState extends State<ChannelLibraryGrid> {
               child: _LibrarySortRow(sort: widget.sort, onSort: widget.onSort),
             ),
             SliverPadding(
-              padding: const EdgeInsets.fromLTRB(
-                12,
-                4,
-                12,
-                _gridSpacing,
-              ),
+              padding: const EdgeInsets.fromLTRB(12, 4, 12, _gridSpacing),
               sliver: SliverGrid(
                 gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
                   crossAxisCount: columns,
@@ -146,6 +145,10 @@ class _ChannelLibraryGridState extends State<ChannelLibraryGrid> {
                         availability:
                             widget.availabilityByChannelId[channel.id],
                         onSelected: widget.onChannelSelected,
+                        inMultiview: widget.multiviewChannelIds.contains(
+                          channel.id,
+                        ),
+                        onMultiviewToggle: widget.onMultiviewToggle,
                       ),
                     );
                   },
@@ -225,12 +228,16 @@ class _ChannelTile extends StatelessWidget {
     required this.metadata,
     required this.availability,
     this.onSelected,
+    required this.inMultiview,
+    this.onMultiviewToggle,
   });
 
   final IPTVChannel channel;
   final ChannelBrowseMetadata? metadata;
   final StreamAvailability? availability;
   final ValueChanged<IPTVChannel>? onSelected;
+  final bool inMultiview;
+  final ValueChanged<IPTVChannel>? onMultiviewToggle;
 
   @override
   Widget build(BuildContext context) {
@@ -252,6 +259,37 @@ class _ChannelTile extends StatelessWidget {
           left: 7,
           child: _AvailabilityDot(availability: availability),
         ),
+        if (onMultiviewToggle != null)
+          Positioned(
+            top: 4,
+            right: 4,
+            child: TvFocusable(
+              key: ValueKey('channel-multiview-${channel.id}'),
+              semanticLabel: inMultiview
+                  ? 'Remove ${channel.name} from multiview'
+                  : 'Add ${channel.name} to multiview',
+              onSelect: () => onMultiviewToggle!(channel),
+              borderRadius: 20,
+              child: Material(
+                color: Colors.black.withValues(alpha: 0.68),
+                shape: const CircleBorder(),
+                child: IconButton(
+                  visualDensity: VisualDensity.compact,
+                  tooltip: inMultiview
+                      ? 'Remove from multiview'
+                      : 'Add to multiview',
+                  onPressed: () => onMultiviewToggle!(channel),
+                  icon: Icon(
+                    inMultiview ? Icons.remove_from_queue : Icons.add_to_queue,
+                    size: 18,
+                    color: inMultiview
+                        ? Theme.of(context).colorScheme.primary
+                        : Colors.white,
+                  ),
+                ),
+              ),
+            ),
+          ),
       ],
     );
   }
@@ -306,7 +344,8 @@ class _AvailabilityDot extends StatelessWidget {
         'Channel may be restricted',
       ),
       StreamAvailability.cancelled => (Colors.amber, 'Channel check pending'),
-      StreamAvailability.unverified || null => (null, 'Channel not checked yet'),
+      StreamAvailability.unverified ||
+      null => (null, 'Channel not checked yet'),
     };
     if (color == null) return const SizedBox.shrink();
     return Tooltip(

--- a/packages/feature_iptv/lib/presentation/tv_ux/sections/multiview_stage.dart
+++ b/packages/feature_iptv/lib/presentation/tv_ux/sections/multiview_stage.dart
@@ -1,0 +1,181 @@
+import 'package:core_ui/core_ui.dart';
+import 'package:flutter/material.dart';
+
+import '../../../application/providers/multiview_provider.dart';
+
+class MultiviewStage extends StatelessWidget {
+  const MultiviewStage({
+    super.key,
+    required this.sessions,
+    required this.featuredChannelId,
+    required this.onPromote,
+  });
+
+  final List<IptvMultiviewSession> sessions;
+  final String? featuredChannelId;
+  final ValueChanged<String> onPromote;
+
+  @override
+  Widget build(BuildContext context) {
+    // Materialize the covariant input as the interface type. Callers may pass
+    // a List<SessionSubtype>, whose runtime `firstWhere` otherwise expects an
+    // `orElse` returning that subtype.
+    final activeSessions = List<IptvMultiviewSession>.of(sessions);
+    if (activeSessions.isEmpty) return const SizedBox.shrink();
+    if (activeSessions.length == 1) {
+      return _SessionSurface(
+        key: const ValueKey('multiview-layout-single'),
+        session: activeSessions.single,
+        featured: true,
+      );
+    }
+    if (activeSessions.length == 2) {
+      return Row(
+        key: const ValueKey('multiview-layout-split'),
+        children: [
+          for (final session in activeSessions)
+            Expanded(
+              child: _PromotableSurface(
+                session: session,
+                featured: session.id == featuredChannelId,
+                onPromote: onPromote,
+              ),
+            ),
+        ],
+      );
+    }
+
+    final featured = activeSessions.firstWhere(
+      (session) => session.id == featuredChannelId,
+      orElse: () => activeSessions.first,
+    );
+    final thumbnails = activeSessions
+        .where((session) => session.id != featured.id)
+        .toList(growable: false);
+    return Column(
+      key: ValueKey('multiview-layout-featured-${activeSessions.length}'),
+      children: [
+        Expanded(child: _SessionSurface(session: featured, featured: true)),
+        SizedBox(
+          height: 108,
+          child: ListView.separated(
+            key: const ValueKey('multiview-thumbnail-strip'),
+            scrollDirection: Axis.horizontal,
+            padding: const EdgeInsets.fromLTRB(8, 6, 8, 8),
+            itemCount: thumbnails.length,
+            separatorBuilder: (_, _) => const SizedBox(width: 8),
+            itemBuilder: (context, index) {
+              final session = thumbnails[index];
+              return SizedBox(
+                width: 172,
+                child: _PromotableSurface(
+                  session: session,
+                  featured: false,
+                  onPromote: onPromote,
+                ),
+              );
+            },
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _PromotableSurface extends StatelessWidget {
+  const _PromotableSurface({
+    required this.session,
+    required this.featured,
+    required this.onPromote,
+  });
+
+  final IptvMultiviewSession session;
+  final bool featured;
+  final ValueChanged<String> onPromote;
+
+  @override
+  Widget build(BuildContext context) {
+    return TvFocusable(
+      key: ValueKey('multiview-promote-${session.id}'),
+      semanticLabel: featured
+          ? '${session.channel.name}, featured'
+          : 'Feature ${session.channel.name}',
+      onSelect: featured ? null : () => onPromote(session.id),
+      child: GestureDetector(
+        behavior: HitTestBehavior.opaque,
+        onTap: featured ? null : () => onPromote(session.id),
+        child: _SessionSurface(session: session, featured: featured),
+      ),
+    );
+  }
+}
+
+class _SessionSurface extends StatelessWidget {
+  const _SessionSurface({
+    super.key,
+    required this.session,
+    required this.featured,
+  });
+
+  final IptvMultiviewSession session;
+  final bool featured;
+
+  @override
+  Widget build(BuildContext context) {
+    return StreamBuilder(
+      stream: session.states,
+      initialData: session.currentState,
+      builder: (context, _) {
+        final player = session.buildView();
+        return DecoratedBox(
+          decoration: BoxDecoration(
+            color: Colors.black,
+            border: Border.all(
+              color: featured
+                  ? Theme.of(context).colorScheme.primary
+                  : Colors.white24,
+              width: featured ? 2 : 1,
+            ),
+          ),
+          child: Stack(
+            fit: StackFit.expand,
+            children: [
+              player ??
+                  const Center(
+                    child: CircularProgressIndicator(strokeWidth: 2),
+                  ),
+              Positioned(
+                left: 8,
+                bottom: 6,
+                right: 8,
+                child: Row(
+                  children: [
+                    Icon(
+                      featured ? Icons.volume_up : Icons.volume_off,
+                      size: 14,
+                      color: Colors.white,
+                    ),
+                    const SizedBox(width: 5),
+                    Expanded(
+                      child: Text(
+                        session.channel.name,
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                        style: Theme.of(context).textTheme.labelSmall?.copyWith(
+                          color: Colors.white,
+                          shadows: const [
+                            Shadow(color: Colors.black, blurRadius: 4),
+                          ],
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+        );
+      },
+    );
+  }
+}

--- a/packages/feature_iptv/test/application/multiview_provider_test.dart
+++ b/packages/feature_iptv/test/application/multiview_provider_test.dart
@@ -1,0 +1,193 @@
+import 'dart:async';
+
+import 'package:feature_iptv/application/providers/multiview_provider.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:platform_channels/platform_channels.dart';
+import 'package:platform_player/platform_player.dart';
+
+void main() {
+  IPTVChannel channel(String id) => IPTVChannel(
+    id: id,
+    name: 'Channel $id',
+    streamUrl: 'https://example.com/$id.m3u8',
+    group: 'News',
+  );
+
+  test(
+    'controller pauses primary, enforces cap, and resumes when empty',
+    () async {
+      final primary = _FakePrimaryService();
+      final sessions = <String, _FakeMultiviewSession>{};
+      final controller = MultiviewController(
+        decoderBudget: 2,
+        primaryService: primary,
+        sessionFactory: (item) async =>
+            sessions.putIfAbsent(item.id, () => _FakeMultiviewSession(item)),
+      );
+      addTearDown(controller.close);
+
+      expect(
+        await controller.toggle(channel('one')),
+        MultiviewToggleResult.added,
+      );
+      expect(primary.pauseCalls, 1);
+      expect(
+        await controller.toggle(channel('two')),
+        MultiviewToggleResult.added,
+      );
+      expect(
+        await controller.toggle(channel('three')),
+        MultiviewToggleResult.capacityReached,
+      );
+      expect(sessions, hasLength(2));
+
+      expect(
+        await controller.toggle(channel('one')),
+        MultiviewToggleResult.removed,
+      );
+      expect(
+        await controller.toggle(channel('two')),
+        MultiviewToggleResult.removed,
+      );
+      expect(primary.resumeCalls, 1);
+      expect(controller.state.sessions, isEmpty);
+    },
+  );
+
+  test('failed first open resumes primary and leaves no session', () async {
+    final primary = _FakePrimaryService();
+    final controller = MultiviewController(
+      decoderBudget: 4,
+      primaryService: primary,
+      sessionFactory: (_) async => throw StateError('open failed'),
+    );
+    addTearDown(controller.close);
+
+    expect(
+      await controller.toggle(channel('bad')),
+      MultiviewToggleResult.failed,
+    );
+    expect(primary.pauseCalls, 1);
+    expect(primary.resumeCalls, 1);
+    expect(controller.state.sessions, isEmpty);
+  });
+
+  test('close mutes and disposes every owned session', () async {
+    final primary = _FakePrimaryService();
+    final sessions = <_FakeMultiviewSession>[];
+    final controller = MultiviewController(
+      decoderBudget: 4,
+      primaryService: primary,
+      sessionFactory: (item) async {
+        final session = _FakeMultiviewSession(item);
+        sessions.add(session);
+        return session;
+      },
+    );
+    await controller.toggle(channel('one'));
+    await controller.toggle(channel('two'));
+
+    await controller.close();
+
+    expect(sessions.every((session) => session.closed), isTrue);
+    expect(sessions.every((session) => !session.audible), isTrue);
+    expect(primary.resumeCalls, 1);
+  });
+}
+
+class _FakeMultiviewSession implements IptvMultiviewSession {
+  _FakeMultiviewSession(this.channel);
+
+  @override
+  final IPTVChannel channel;
+  bool audible = false;
+  bool closed = false;
+  final _states = StreamController<StreamingState>.broadcast();
+
+  @override
+  String get id => channel.id;
+
+  @override
+  StreamingState get currentState => StreamingState(
+    currentChannel: channel,
+    playbackState: PlaybackState.playing,
+  );
+
+  @override
+  Stream<StreamingState> get states => _states.stream;
+
+  @override
+  Widget buildView() => const SizedBox();
+
+  @override
+  Future<void> setAudible(bool value) async {
+    audible = value;
+  }
+
+  @override
+  Future<void> close() async {
+    closed = true;
+    await _states.close();
+  }
+}
+
+class _FakePrimaryService implements IPTVStreamingService {
+  int pauseCalls = 0;
+  int resumeCalls = 0;
+  StreamingState _state = StreamingState(playbackState: PlaybackState.playing);
+
+  @override
+  StreamingState get currentState => _state;
+
+  @override
+  Stream<StreamingState> get stateStream => const Stream.empty();
+
+  @override
+  Future<void> pause() async {
+    pauseCalls++;
+    _state = _state.copyWith(playbackState: PlaybackState.paused);
+  }
+
+  @override
+  Future<void> resume() async {
+    resumeCalls++;
+    _state = _state.copyWith(playbackState: PlaybackState.playing);
+  }
+
+  @override
+  Future<void> clearTrackSelection(AiroPlaybackTrackKind kind) async {}
+
+  @override
+  Future<void> dispose() async {}
+
+  @override
+  Future<void> goLive() async {}
+
+  @override
+  Future<void> initialize() async {}
+
+  @override
+  Future<void> playChannel(IPTVChannel channel) async {}
+
+  @override
+  Future<void> retry() async {}
+
+  @override
+  Future<void> seek(Duration position) async {}
+
+  @override
+  Future<void> setBackgroundAudioMode(bool enabled) async {}
+
+  @override
+  Future<void> setQuality(VideoQuality quality) async {}
+
+  @override
+  Future<void> setVolume(double volume) async {}
+
+  @override
+  Future<void> stop() async {}
+
+  @override
+  Future<void> toggleMute() async {}
+}

--- a/packages/feature_iptv/test/iptv/presentation/tv_ux/channel_library_grid_test.dart
+++ b/packages/feature_iptv/test/iptv/presentation/tv_ux/channel_library_grid_test.dart
@@ -107,6 +107,35 @@ void main() {
     expect(sorted, ChannelSortColumn.category);
   });
 
+  testWidgets('TV action adds and removes channels from multiview', (
+    tester,
+  ) async {
+    IPTVChannel? toggled;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: SizedBox(
+            width: 800,
+            height: 600,
+            child: ChannelLibraryGrid(
+              channels: channels,
+              metadataByChannelId: const {},
+              multiviewChannelIds: const {'two'},
+              onMultiviewToggle: (channel) => toggled = channel,
+            ),
+          ),
+        ),
+      ),
+    );
+
+    expect(find.byTooltip('Add to multiview'), findsOneWidget);
+    expect(find.byTooltip('Remove from multiview'), findsOneWidget);
+    await tester.tap(find.byKey(const ValueKey('channel-multiview-one')));
+    await tester.pump();
+
+    expect(toggled?.id, 'one');
+  });
+
   testWidgets('reports the currently visible channels for bounded scanning', (
     tester,
   ) async {
@@ -183,9 +212,7 @@ void main() {
     expect(find.text('Channel 119'), findsOneWidget);
   });
 
-  testWidgets('availability dot renders for checked channels', (
-    tester,
-  ) async {
+  testWidgets('availability dot renders for checked channels', (tester) async {
     await tester.pumpWidget(
       const MaterialApp(
         home: Scaffold(

--- a/packages/feature_iptv/test/iptv/presentation/tv_ux/multiview_stage_test.dart
+++ b/packages/feature_iptv/test/iptv/presentation/tv_ux/multiview_stage_test.dart
@@ -1,0 +1,132 @@
+import 'dart:async';
+
+import 'package:feature_iptv/application/providers/multiview_provider.dart';
+import 'package:feature_iptv/presentation/tv_ux/sections/multiview_stage.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:platform_channels/platform_channels.dart';
+import 'package:platform_player/platform_player.dart';
+
+void main() {
+  _FakeSession session(String id) => _FakeSession(
+    IPTVChannel(
+      id: id,
+      name: 'Channel $id',
+      streamUrl: 'https://example.com/$id',
+      group: 'News',
+    ),
+  );
+
+  Future<void> pump(
+    WidgetTester tester,
+    List<_FakeSession> sessions, {
+    ValueChanged<String>? onPromote,
+  }) {
+    return tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: SizedBox(
+            width: 640,
+            height: 360,
+            child: MultiviewStage(
+              sessions: sessions,
+              featuredChannelId: sessions.first.id,
+              onPromote: onPromote ?? (_) {},
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  testWidgets('one channel uses the single layout', (tester) async {
+    final sessions = [session('one')];
+    addTearDown(sessions.single.close);
+    await pump(tester, sessions);
+
+    expect(
+      find.byKey(const ValueKey('multiview-layout-single')),
+      findsOneWidget,
+    );
+    expect(find.byKey(const ValueKey('player-one')), findsOneWidget);
+  });
+
+  testWidgets('two channels use split layout', (tester) async {
+    final sessions = [session('one'), session('two')];
+    addTearDown(() => Future.wait(sessions.map((item) => item.close())));
+    await pump(tester, sessions);
+
+    expect(
+      find.byKey(const ValueKey('multiview-layout-split')),
+      findsOneWidget,
+    );
+    expect(find.byKey(const ValueKey('player-one')), findsOneWidget);
+    expect(find.byKey(const ValueKey('player-two')), findsOneWidget);
+  });
+
+  for (final count in [3, 4]) {
+    testWidgets('$count channels use featured plus thumbnail strip', (
+      tester,
+    ) async {
+      final sessions = [
+        for (var index = 1; index <= count; index++) session('$index'),
+      ];
+      addTearDown(() => Future.wait(sessions.map((item) => item.close())));
+      await pump(tester, sessions);
+
+      expect(
+        find.byKey(ValueKey('multiview-layout-featured-$count')),
+        findsOneWidget,
+      );
+      expect(
+        find.byKey(const ValueKey('multiview-thumbnail-strip')),
+        findsOneWidget,
+      );
+      expect(find.byIcon(Icons.volume_up), findsOneWidget);
+      expect(find.byIcon(Icons.volume_off), findsNWidgets(count - 1));
+    });
+  }
+
+  testWidgets('thumbnail supports D-pad promotion', (tester) async {
+    final sessions = [session('one'), session('two'), session('three')];
+    addTearDown(() => Future.wait(sessions.map((item) => item.close())));
+    String? promoted;
+    await pump(tester, sessions, onPromote: (id) => promoted = id);
+
+    await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+    await tester.sendKeyEvent(LogicalKeyboardKey.enter);
+    await tester.pump();
+
+    expect(promoted, 'two');
+  });
+}
+
+class _FakeSession implements IptvMultiviewSession {
+  _FakeSession(this.channel);
+
+  @override
+  final IPTVChannel channel;
+  final _states = StreamController<StreamingState>.broadcast();
+
+  @override
+  String get id => channel.id;
+
+  @override
+  StreamingState get currentState => StreamingState(
+    currentChannel: channel,
+    playbackState: PlaybackState.playing,
+  );
+
+  @override
+  Stream<StreamingState> get states => _states.stream;
+
+  @override
+  Widget buildView() => SizedBox(key: ValueKey('player-$id'));
+
+  @override
+  Future<void> setAudible(bool audible) async {}
+
+  @override
+  Future<void> close() => _states.close();
+}

--- a/packages/platform_player/lib/platform_player.dart
+++ b/packages/platform_player/lib/platform_player.dart
@@ -12,6 +12,7 @@ export "src/models/player_view_state.dart";
 export "src/models/phone_media_diagnostic_models.dart";
 export "src/models/streaming_state.dart";
 export "src/services/airo_cast_controller.dart";
+export "src/services/airo_multiview_pool.dart";
 export "src/services/airo_playback_engine.dart";
 export "src/services/background_audio_mode.dart";
 export "src/services/cast_log_redaction.dart";

--- a/packages/platform_player/lib/src/services/airo_multiview_pool.dart
+++ b/packages/platform_player/lib/src/services/airo_multiview_pool.dart
@@ -1,0 +1,173 @@
+import 'dart:async';
+
+const int kAiroMultiviewHardCap = 4;
+
+/// One independently owned playback session in a bounded multiview pool.
+///
+/// Implementations must absorb backend volume/cleanup failures so the pool can
+/// preserve its single-audible-session invariant without throwing into UI.
+abstract interface class AiroMultiviewSession {
+  String get id;
+
+  Future<void> setAudible(bool audible);
+
+  Future<void> close();
+}
+
+enum AiroMultiviewAddResult {
+  added,
+  alreadyPresent,
+  capacityReached,
+  openFailed,
+}
+
+class AiroMultiviewPoolState {
+  const AiroMultiviewPoolState({
+    this.sessions = const [],
+    this.featuredSessionId,
+  });
+
+  final List<AiroMultiviewSession> sessions;
+  final String? featuredSessionId;
+
+  int get count => sessions.length;
+
+  bool contains(String id) => sessions.any((session) => session.id == id);
+}
+
+/// Owns at most [capacity] playback sessions and routes audio exclusively to
+/// the featured session.
+class AiroMultiviewPool {
+  AiroMultiviewPool({required int decoderBudget, this.onChanged})
+    : capacity = decoderBudget.clamp(1, kAiroMultiviewHardCap);
+
+  final int capacity;
+  final void Function(AiroMultiviewPoolState state)? onChanged;
+  final Set<String> _pendingIds = {};
+  AiroMultiviewPoolState _state = const AiroMultiviewPoolState();
+  bool _closed = false;
+
+  AiroMultiviewPoolState get state => _state;
+
+  Future<AiroMultiviewAddResult> add({
+    required String id,
+    required Future<AiroMultiviewSession> Function() openSession,
+  }) async {
+    if (_closed) return AiroMultiviewAddResult.openFailed;
+    if (_state.contains(id) || _pendingIds.contains(id)) {
+      return AiroMultiviewAddResult.alreadyPresent;
+    }
+    if (_state.count + _pendingIds.length >= capacity) {
+      return AiroMultiviewAddResult.capacityReached;
+    }
+
+    _pendingIds.add(id);
+    AiroMultiviewSession? session;
+    try {
+      session = await openSession();
+      if (_closed) {
+        await _closeSafely(session);
+        return AiroMultiviewAddResult.openFailed;
+      }
+      if (session.id != id) {
+        await _closeSafely(session);
+        return AiroMultiviewAddResult.openFailed;
+      }
+      await session.setAudible(false);
+      final sessions = List<AiroMultiviewSession>.unmodifiable([
+        ..._state.sessions,
+        session,
+      ]);
+      final featured = _state.featuredSessionId ?? id;
+      _setState(
+        AiroMultiviewPoolState(sessions: sessions, featuredSessionId: featured),
+      );
+      await _routeAudio(featured);
+      return AiroMultiviewAddResult.added;
+    } catch (_) {
+      if (session != null) await _closeSafely(session);
+      return AiroMultiviewAddResult.openFailed;
+    } finally {
+      _pendingIds.remove(id);
+    }
+  }
+
+  Future<void> promote(String id) async {
+    if (_closed || !_state.contains(id) || _state.featuredSessionId == id) {
+      return;
+    }
+    await _routeAudio(id);
+    _setState(
+      AiroMultiviewPoolState(sessions: _state.sessions, featuredSessionId: id),
+    );
+  }
+
+  Future<void> remove(String id) async {
+    if (_closed) return;
+    AiroMultiviewSession? removed;
+    final remaining = <AiroMultiviewSession>[];
+    for (final session in _state.sessions) {
+      if (session.id == id) {
+        removed = session;
+      } else {
+        remaining.add(session);
+      }
+    }
+    if (removed == null) return;
+
+    final featured = _state.featuredSessionId == id
+        ? remaining.firstOrNull?.id
+        : _state.featuredSessionId;
+    _setState(
+      AiroMultiviewPoolState(
+        sessions: List.unmodifiable(remaining),
+        featuredSessionId: featured,
+      ),
+    );
+    await removed.setAudible(false);
+    await _closeSafely(removed);
+    if (featured != null) await _routeAudio(featured);
+  }
+
+  Future<void> close() async {
+    if (_closed) return;
+    _closed = true;
+    final sessions = _state.sessions;
+    _setState(const AiroMultiviewPoolState());
+    await Future.wait(
+      sessions.map((session) async {
+        try {
+          await session.setAudible(false);
+        } catch (_) {
+          // Continue closing every owned session.
+        }
+        await _closeSafely(session);
+      }),
+    );
+  }
+
+  Future<void> _routeAudio(String featuredId) async {
+    for (final session in _state.sessions) {
+      await session.setAudible(false);
+    }
+    for (final session in _state.sessions) {
+      if (session.id == featuredId) {
+        await session.setAudible(true);
+        break;
+      }
+    }
+  }
+
+  Future<void> _closeSafely(AiroMultiviewSession session) async {
+    try {
+      await session.close();
+    } catch (_) {
+      // One broken backend must not leak the remaining sessions.
+    }
+  }
+
+  void _setState(AiroMultiviewPoolState state) {
+    _state = state;
+    onChanged?.call(state);
+  }
+}

--- a/packages/platform_player/test/airo_multiview_pool_test.dart
+++ b/packages/platform_player/test/airo_multiview_pool_test.dart
@@ -1,0 +1,150 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:platform_player/platform_player.dart';
+
+void main() {
+  test('hard cap rejects a fifth session without opening it', () async {
+    final opened = <_FakeSession>[];
+    final pool = AiroMultiviewPool(decoderBudget: 99);
+
+    for (var index = 0; index < 4; index++) {
+      final id = 'channel-$index';
+      expect(
+        await pool.add(
+          id: id,
+          openSession: () async {
+            final session = _FakeSession(id);
+            opened.add(session);
+            return session;
+          },
+        ),
+        AiroMultiviewAddResult.added,
+      );
+    }
+    var fifthFactoryCalled = false;
+    expect(
+      await pool.add(
+        id: 'channel-4',
+        openSession: () async {
+          fifthFactoryCalled = true;
+          return _FakeSession('channel-4');
+        },
+      ),
+      AiroMultiviewAddResult.capacityReached,
+    );
+
+    expect(pool.capacity, kAiroMultiviewHardCap);
+    expect(pool.state.count, 4);
+    expect(fifthFactoryCalled, isFalse);
+    expect(opened.where((session) => session.audible), [opened.first]);
+    await pool.close();
+  });
+
+  test('lower decoder budget rejects excess sessions', () async {
+    final pool = AiroMultiviewPool(decoderBudget: 2);
+    var factoryCalls = 0;
+
+    for (final id in ['one', 'two']) {
+      expect(
+        await pool.add(
+          id: id,
+          openSession: () async {
+            factoryCalls++;
+            return _FakeSession(id);
+          },
+        ),
+        AiroMultiviewAddResult.added,
+      );
+    }
+    expect(
+      await pool.add(
+        id: 'three',
+        openSession: () async {
+          factoryCalls++;
+          return _FakeSession('three');
+        },
+      ),
+      AiroMultiviewAddResult.capacityReached,
+    );
+    expect(factoryCalls, 2);
+    await pool.close();
+  });
+
+  test('promotion keeps exactly one session audible', () async {
+    final sessions = <String, _FakeSession>{};
+    final pool = AiroMultiviewPool(decoderBudget: 4);
+    for (final id in ['one', 'two', 'three']) {
+      await pool.add(
+        id: id,
+        openSession: () async =>
+            sessions.putIfAbsent(id, () => _FakeSession(id)),
+      );
+    }
+
+    await pool.promote('three');
+
+    expect(pool.state.featuredSessionId, 'three');
+    expect(
+      sessions.values.where((session) => session.audible).single.id,
+      'three',
+    );
+    await pool.close();
+  });
+
+  test('removing featured promotes next and close disposes all', () async {
+    final sessions = <String, _FakeSession>{};
+    final pool = AiroMultiviewPool(decoderBudget: 4);
+    for (final id in ['one', 'two', 'three']) {
+      await pool.add(
+        id: id,
+        openSession: () async =>
+            sessions.putIfAbsent(id, () => _FakeSession(id)),
+      );
+    }
+
+    await pool.remove('one');
+
+    expect(pool.state.featuredSessionId, 'two');
+    expect(sessions['one']!.closed, isTrue);
+    expect(
+      sessions.values.where((session) => session.audible).single.id,
+      'two',
+    );
+
+    await pool.close();
+    expect(sessions.values.every((session) => session.closed), isTrue);
+    expect(sessions.values.every((session) => !session.audible), isTrue);
+  });
+
+  test('open failure leaves pool unchanged', () async {
+    final pool = AiroMultiviewPool(decoderBudget: 4);
+
+    expect(
+      await pool.add(
+        id: 'broken',
+        openSession: () async => throw StateError('decoder failed'),
+      ),
+      AiroMultiviewAddResult.openFailed,
+    );
+    expect(pool.state.count, 0);
+    await pool.close();
+  });
+}
+
+class _FakeSession implements AiroMultiviewSession {
+  _FakeSession(this.id);
+
+  @override
+  final String id;
+  bool audible = false;
+  bool closed = false;
+
+  @override
+  Future<void> setAudible(bool value) async {
+    audible = value;
+  }
+
+  @override
+  Future<void> close() async {
+    closed = true;
+  }
+}


### PR DESCRIPTION
## Summary

- add a reusable `platform_player` session pool with a hard four-decoder ceiling and lower per-device budgets
- add channel-tile multiview actions, 1/2/3/4-stream layouts, featured-channel promotion, and single-audio ownership
- document interaction behavior and platform limits

Closes #1042.

## Test Plan

- [x] `flutter analyze` or relevant package analyzer passed
- [x] `flutter test` or relevant package tests passed
- [x] CI-only change validated with local script/YAML checks (not applicable; manifest/docs scripts passed)
- [x] Manual device/simulator verification documented, or not applicable

**Verification environment:** Host-only (32 focused tests; no emulator)

## Agent Policy

- [x] Linked issue includes a Critical Agent Gate.
- [x] Linked issue includes a Feature Packet or documents why one is not needed.
- [x] Cross-agent contract is documented for framework/application boundary work.
- [x] Deterministic use cases and automation flows are linked or included.
- [x] AI/tool/memory/routine changes include eval, trace, and redaction coverage (not applicable).
- [x] Android Emulator was not used unless the linked issue explicitly accepted `AIRO_ALLOW_ANDROID_EMULATOR=true`.

## Council Review

Required lanes identified from the Decision Matrix and module manifests:
- Playback Architect: reusable session ownership and decoder ceiling
- Media Intelligence Architect: IPTV provider adapter and feature integration
- Flutter Architect + TV Experience Architect + Chief UX Officer: widget/focus interaction
- Chief Performance Officer: bounded decoder budgets and no added dependency
- Chief QA Officer: deterministic controller, pool, layout, grid, and shell coverage
- Product Manager + Chief Architect + Platform Architect: end-user feature and framework/application contract
- Chief Documentation Officer: changelog and wiki consistency
- Chief Open Source Officer + Chief Security Officer: no dependency or playback-pipeline dependency change

Review metadata remains available for maintainer confirmation; the implementation evidence is recorded on #1042.

- [x] I checked the Decision Matrix and listed every required role above.
- [x] Every package touched has a `module.yaml`; `scripts/check-module-manifests.py` reports 59 valid manifests.
- [x] `owner`/`reviewers` in touched manifests remain aligned; no roster change was needed.

## User-Facing Documentation

- [x] I updated `docs/wiki` for the user-visible multiview behavior and device limits.
- [ ] No `docs/wiki` update is needed because this PR has no user-visible behavior or documentation impact.

## Plugin and Size Impact

- [ ] This PR adds new dependencies
- [x] This PR adds or grows app/packages/plugins code
- [x] Size impact is documented below
- [x] Any module over 3 MB is a plugin or has an explicit plugin marker (no threshold status changed)
- [x] Any plugin over 5 MB has cache-management documentation (not applicable)

Size impact / plugin justification: Dart source/tests only in existing bundled `platform_player` and `feature_iptv` packages; no assets, binaries, plugins, or dependencies added.

## Checklist

- [x] Code is formatted.
- [x] Tests or manual verification are included above.
- [x] Sensitive data, credentials, and signing artifacts are not committed.

## Release Notes

- [x] User-facing change documented in `packages/feature_iptv/CHANGELOG.md` and the navigation wiki.