### PR TITLE
feat: add Airo TV deep links and frame sharing

### DIFF
--- a/app/android/app/src/main/AndroidManifest.xml
+++ b/app/android/app/src/main/AndroidManifest.xml
@@ -48,6 +48,21 @@
                 <action android:name="android.intent.action.MAIN"/>
                 <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW"/>
+                <category android:name="android.intent.category.DEFAULT"/>
+                <category android:name="android.intent.category.BROWSABLE"/>
+                <data android:scheme="airo" android:host="iptv"/>
+            </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW"/>
+                <category android:name="android.intent.category.DEFAULT"/>
+                <category android:name="android.intent.category.BROWSABLE"/>
+                <data
+                    android:scheme="https"
+                    android:host="developerscoffee.github.io"
+                    android:pathPrefix="/airo/iptv"/>
+            </intent-filter>
         </activity>
         <!-- Don't delete the meta-data below.
              This is used by the Flutter tool to generate GeneratedPluginRegistrant.java -->

--- a/app/ios/Runner/Info.plist
+++ b/app/ios/Runner/Info.plist
@@ -14,6 +14,19 @@
 	<string>6.0</string>
 	<key>CFBundleName</key>
 	<string>Airo</string>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Viewer</string>
+			<key>CFBundleURLName</key>
+			<string>com.developerscoffee.airo.iptv</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>airo</string>
+			</array>
+		</dict>
+	</array>
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
@@ -23,6 +36,8 @@
 	<key>CFBundleVersion</key>
 	<string>$(FLUTTER_BUILD_NUMBER)</string>
 	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>FlutterDeepLinkingEnabled</key>
 	<true/>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>

--- a/app/lib/core/routing/app_router.dart
+++ b/app/lib/core/routing/app_router.dart
@@ -1,5 +1,8 @@
+import 'dart:typed_data';
+
 import 'package:feature_coin/feature_coin.dart';
 import 'package:go_router/go_router.dart';
+import 'package:share_plus/share_plus.dart';
 import '../../features/auth/screens/login_screen.dart';
 import '../../features/auth/screens/register_screen.dart';
 import '../../features/bill_split/presentation/screens/bill_split_screen.dart';
@@ -79,6 +82,13 @@ class AppRouter {
         ),
         GoRoute(path: '/beats', redirect: (context, state) => '/music'),
         GoRoute(path: '/stream', redirect: (context, state) => '/iptv'),
+        GoRoute(
+          path: '/airo/iptv',
+          redirect: (context, state) => Uri(
+            path: '/iptv',
+            queryParameters: state.uri.queryParameters,
+          ).toString(),
+        ),
         GoRoute(path: '/live', redirect: (context, state) => '/music'),
         GoRoute(path: '/live/music', redirect: (context, state) => '/music'),
         GoRoute(path: '/live/tv', redirect: (context, state) => '/iptv'),
@@ -271,7 +281,8 @@ class AppRouter {
                     onPickLocalMediaForTv: kEnablePhoneMediaReceiverExperimental
                         ? pickPhoneLocalMediaForTv
                         : null,
-                    deepLinkChannelId: state.uri.queryParameters['channel'],
+                    deepLinkIntent: IptvDeepLinkIntent.tryParse(state.uri),
+                    onShareVideoFrame: _shareIptvVideoFrame,
                   ),
                 ),
                 GoRoute(
@@ -387,4 +398,19 @@ class AppRouter {
       ),
     );
   }
+}
+
+Future<void> _shareIptvVideoFrame(Uint8List pngBytes) async {
+  await SharePlus.instance.share(
+    ShareParams(
+      files: [
+        XFile.fromData(
+          pngBytes,
+          mimeType: 'image/png',
+          name: 'airo-tv-frame.png',
+        ),
+      ],
+      subject: 'Airo TV video frame',
+    ),
+  );
 }

--- a/app/macos/Runner/Info.plist
+++ b/app/macos/Runner/Info.plist
@@ -14,6 +14,19 @@
 	<string>6.0</string>
 	<key>CFBundleName</key>
 	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Viewer</string>
+			<key>CFBundleURLName</key>
+			<string>com.developerscoffee.airo.iptv</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>airo</string>
+			</array>
+		</dict>
+	</array>
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
@@ -22,6 +35,8 @@
 	<string>$(FLUTTER_BUILD_NUMBER)</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
+	<key>FlutterDeepLinkingEnabled</key>
+	<true/>
 	<key>NSHumanReadableCopyright</key>
 	<string>$(PRODUCT_COPYRIGHT)</string>
 	<key>NSMainNibFile</key>

--- a/docs/wiki/3.-Navigating-Airo.md
+++ b/docs/wiki/3.-Navigating-Airo.md
@@ -87,6 +87,22 @@ streams on web, Android, and iOS; four on macOS, Windows, and Linux; and one on
 Fuchsia. The absolute limit is four, and the channel action reports when the
 current device limit has been reached.
 
+**Under qualification (not in the current Airo TV 0.0.5 release):** the Share
+action is designed to copy a versioned Airo TV link instead of the playlist's
+raw stream URL. If Explorer filters are active, the link includes that filter
+combination; opening it restores the filters and tunes the channel through the
+normal launch gate. If the channel is no longer in the current playlist, Airo
+returns to browsing with a notice. Android source registers both the public
+HTTPS link and the `airo://iptv` fallback; iOS and macOS source register the
+custom scheme.
+
+Also under qualification, **Share video frame** captures only the current
+player or multiview stage as a PNG and opens the platform share surface when
+the host supports image sharing. Explorer rows, help/settings controls, and
+other overlay chrome are outside the capture boundary. Image sharing is
+capability-based and may be unavailable on some TV, web, Windows, or Linux
+builds.
+
 Header behavior:
 
 - `/iptv` keeps its own route-level app bar for stream search and cast actions.

--- a/packages/feature_iptv/CHANGELOG.md
+++ b/packages/feature_iptv/CHANGELOG.md
@@ -11,3 +11,9 @@
   remote/keyboard promotion.
 - Limited concurrent multiview decoders to two on web and mobile and four on
   desktop, with a hard ceiling of four and clear capacity feedback.
+- Changed channel sharing to copy versioned Airo TV deep links that can restore
+  the active Explorer filters and tune the channel without exposing stream
+  URLs.
+- Added video-frame sharing from a capture boundary that excludes Explorer
+  chrome. The host opens the platform share surface where image sharing is
+  available.

--- a/packages/feature_iptv/lib/application/iptv_deep_link.dart
+++ b/packages/feature_iptv/lib/application/iptv_deep_link.dart
@@ -1,0 +1,65 @@
+import 'providers/channel_filters_provider.dart';
+
+const _canonicalIptvOrigin = 'https://developerscoffee.github.io';
+const _canonicalIptvPath = '/airo/iptv';
+const _deepLinkVersion = '1';
+const _maxDeepLinkValueLength = 256;
+
+/// A secret-free, host-independent intent for opening Airo TV.
+class IptvDeepLinkIntent {
+  const IptvDeepLinkIntent({
+    required this.channelId,
+    this.filters = const ChannelFilters(),
+  });
+
+  final String channelId;
+  final ChannelFilters filters;
+
+  Uri toUri({bool includeFilters = true}) {
+    final query = <String, String>{'v': _deepLinkVersion, 'channel': channelId};
+    if (includeFilters && filters.isActive) {
+      if (filters.search.isNotEmpty) query['search'] = filters.search;
+      if (filters.category case final value?) query['category'] = value;
+      if (filters.country case final value?) query['country'] = value;
+      if (filters.language case final value?) query['language'] = value;
+    }
+    return Uri.parse(
+      '$_canonicalIptvOrigin$_canonicalIptvPath',
+    ).replace(queryParameters: query);
+  }
+
+  static IptvDeepLinkIntent? tryParse(Uri uri) {
+    final isCanonical =
+        uri.scheme == 'https' &&
+        uri.host == 'developerscoffee.github.io' &&
+        uri.path == _canonicalIptvPath;
+    final isCustomScheme =
+        uri.scheme == 'airo' && (uri.host == 'iptv' || uri.path == '/iptv');
+    final isInternalRoute = uri.scheme.isEmpty && uri.path == '/iptv';
+    if (!isCanonical && !isCustomScheme && !isInternalRoute) return null;
+
+    final version = uri.queryParameters['v'];
+    if (version != null && version != _deepLinkVersion) return null;
+    final channelId = _normalized(uri.queryParameters['channel']);
+    if (channelId == null) return null;
+    return IptvDeepLinkIntent(
+      channelId: channelId,
+      filters: ChannelFilters(
+        search: _normalized(uri.queryParameters['search']) ?? '',
+        category: _normalized(uri.queryParameters['category']),
+        country: _normalized(uri.queryParameters['country']),
+        language: _normalized(uri.queryParameters['language']),
+      ),
+    );
+  }
+}
+
+String? _normalized(String? value) {
+  final normalized = value?.trim();
+  if (normalized == null ||
+      normalized.isEmpty ||
+      normalized.length > _maxDeepLinkValueLength) {
+    return null;
+  }
+  return normalized;
+}

--- a/packages/feature_iptv/lib/feature_iptv.dart
+++ b/packages/feature_iptv/lib/feature_iptv.dart
@@ -11,6 +11,7 @@ export "application/providers/last_channel_provider.dart";
 export "application/providers/rails_provider.dart";
 export "application/providers/iptv_cast_providers.dart";
 export "application/providers/iptv_cast_prompt_providers.dart";
+export "application/iptv_deep_link.dart";
 export "application/providers/content_source_management_providers.dart";
 export "application/providers/guide_providers.dart";
 export "application/providers/local_iptv_search_providers.dart";

--- a/packages/feature_iptv/lib/presentation/screens/iptv_screen.dart
+++ b/packages/feature_iptv/lib/presentation/screens/iptv_screen.dart
@@ -5,7 +5,9 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:core_ui/core_ui.dart';
+import '../../application/iptv_deep_link.dart';
 import '../../application/player_backgrounding_coordinator.dart';
+import '../../application/providers/channel_filters_provider.dart';
 import '../../application/providers/iptv_providers.dart';
 import '../../application/wakelock_playback_coordinator.dart';
 import '../../application/providers/rails_provider.dart';
@@ -31,7 +33,9 @@ class IPTVScreen extends ConsumerStatefulWidget {
     this.onOpenVod,
     this.onSettings,
     this.onPickLocalMediaForTv,
+    this.deepLinkIntent,
     this.deepLinkChannelId,
+    this.onShareVideoFrame,
     this.tenFootMode = false,
     super.key,
   });
@@ -60,12 +64,22 @@ class IPTVScreen extends ConsumerStatefulWidget {
   /// depend on `file_picker`; the host app owns the native file-picker wiring.
   final Future<PhoneLocalMediaItem?> Function()? onPickLocalMediaForTv;
 
+  /// Parsed link intent supplied by the host router. Includes the channel and
+  /// optional Explorer filters without coupling this package to go_router.
+  final IptvDeepLinkIntent? deepLinkIntent;
+
+  /// Host-owned image delivery for frame-only screenshots.
+  final Future<void> Function(Uint8List pngBytes)? onShareVideoFrame;
+
   /// Channel id resolved from a deep link (universal link, home-screen
   /// widget, or "continue watching" notification tap) or the app's
   /// resume-last-channel affordance. When set, playback starts immediately
   /// in [initState] instead of waiting for a tap on the browse grid, and
   /// the browse grid is not the first frame rendered.
   final String? deepLinkChannelId;
+
+  String? get effectiveDeepLinkChannelId =>
+      deepLinkIntent?.channelId ?? deepLinkChannelId;
 
   @override
   ConsumerState<IPTVScreen> createState() => _IPTVScreenState();
@@ -81,7 +95,7 @@ class _IPTVScreenState extends ConsumerState<IPTVScreen>
   /// (in the post-frame callback below) hasn't yet either started playback
   /// or determined the channel doesn't exist. Gates the first frame so the
   /// browse grid never flashes before deep-linked playback begins.
-  late bool _deepLinkPending = widget.deepLinkChannelId != null;
+  late bool _deepLinkPending = widget.effectiveDeepLinkChannelId != null;
 
   /// True once the user has tapped Cancel on the deep-link loading screen.
   /// Sticky for the lifetime of this deep-link attempt: unlike
@@ -116,10 +130,14 @@ class _IPTVScreenState extends ConsumerState<IPTVScreen>
       if (mounted) setState(() => _isPictureInPicture = isActive);
     });
 
-    final deepLinkId = widget.deepLinkChannelId;
+    final deepLinkId = widget.effectiveDeepLinkChannelId;
     if (deepLinkId != null) {
       WidgetsBinding.instance.addPostFrameCallback((_) async {
         if (!mounted) return;
+        final deepLinkFilters = widget.deepLinkIntent?.filters;
+        if (deepLinkFilters != null) {
+          ref.read(channelFiltersProvider.notifier).restore(deepLinkFilters);
+        }
         // Await the channel list rather than reading its current `.value`:
         // the list is almost never loaded yet by the very next frame (it's
         // usually still an in-flight fetch), so a synchronous read would
@@ -157,11 +175,19 @@ class _IPTVScreenState extends ConsumerState<IPTVScreen>
           _playChannel(channel);
           setState(() => _deepLinkPending = false);
         } else {
-          // Missing (or unresolvable) channel: fall through to the normal
-          // browse-grid landing (spec Error Handling) — no snackbar wiring
-          // needed here since the grid is the existing default UI, not a
-          // special error state.
           setState(() => _deepLinkPending = false);
+          WidgetsBinding.instance.addPostFrameCallback((_) {
+            if (!mounted) return;
+            ScaffoldMessenger.of(context)
+              ..hideCurrentSnackBar()
+              ..showSnackBar(
+                const SnackBar(
+                  content: Text(
+                    'That shared channel is no longer available. Browse to choose another.',
+                  ),
+                ),
+              );
+          });
         }
       });
     }
@@ -720,13 +746,14 @@ class _IPTVScreenState extends ConsumerState<IPTVScreen>
         AiroResponsiveScaffold(
           padding: EdgeInsets.zero,
           body: IptvResumeGate(
-            enabled: widget.deepLinkChannelId == null,
+            enabled: widget.effectiveDeepLinkChannelId == null,
             child: _StreamTabContent(
               key: const ValueKey('iptv-browse-grid'),
               onChannelTap: _playChannelFullscreen,
               onFullscreenToggle: _toggleFullscreen,
               onPlaylistSourceTap: _showPlaylistSheet,
               onWaysToWatchTap: _showWaysToWatch,
+              onShareVideoFrame: widget.onShareVideoFrame,
               playlistSourceInInfoBar: true,
             ),
           ),
@@ -781,7 +808,7 @@ class _IPTVScreenState extends ConsumerState<IPTVScreen>
           ],
         ),
         body: IptvResumeGate(
-          enabled: widget.deepLinkChannelId == null,
+          enabled: widget.effectiveDeepLinkChannelId == null,
           child: Column(
             children: [
               Expanded(
@@ -791,6 +818,7 @@ class _IPTVScreenState extends ConsumerState<IPTVScreen>
                   onFullscreenToggle: _toggleFullscreen,
                   onPlaylistSourceTap: _showPlaylistSheet,
                   onWaysToWatchTap: _showWaysToWatch,
+                  onShareVideoFrame: widget.onShareVideoFrame,
                 ),
               ),
               const IptvCastMiniController(),
@@ -1070,6 +1098,7 @@ class _StreamTabContent extends ConsumerWidget {
     required this.onFullscreenToggle,
     required this.onPlaylistSourceTap,
     required this.onWaysToWatchTap,
+    this.onShareVideoFrame,
     this.playlistSourceInInfoBar = false,
   });
 
@@ -1077,6 +1106,7 @@ class _StreamTabContent extends ConsumerWidget {
   final VoidCallback onFullscreenToggle;
   final VoidCallback onPlaylistSourceTap;
   final VoidCallback onWaysToWatchTap;
+  final Future<void> Function(Uint8List pngBytes)? onShareVideoFrame;
 
   /// True on TV (no app bar): surfaces the playlist-source entry in the
   /// shell's LIVE bar instead. Phones keep it in the app bar only.
@@ -1116,6 +1146,7 @@ class _StreamTabContent extends ConsumerWidget {
       onChannelSelected: onChannelTap,
       onPlaylistSourceTap: playlistSourceInInfoBar ? onPlaylistSourceTap : null,
       onWaysToWatchTap: onWaysToWatchTap,
+      onShareVideoFrame: onShareVideoFrame,
       videoStage: AspectRatio(
         aspectRatio: 16 / 9,
         child: activeChannel == null

--- a/packages/feature_iptv/lib/presentation/tv_ux/airo_tv_shell.dart
+++ b/packages/feature_iptv/lib/presentation/tv_ux/airo_tv_shell.dart
@@ -1,8 +1,11 @@
 import 'dart:async';
+import 'dart:typed_data';
+import 'dart:ui' as ui;
 
 import 'package:collection/collection.dart';
 import 'package:core_ui/core_ui.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:platform_channels/platform_channels.dart';
 import 'package:platform_streams/platform_streams.dart';
@@ -26,6 +29,9 @@ import 'sections/playback_stats_bar.dart';
 import 'sections/shell_help_dialog.dart';
 import 'sections/shell_settings_dialog.dart';
 
+typedef VideoFrameEncoder =
+    Future<Uint8List> Function(RenderRepaintBoundary boundary);
+
 class AiroTvShell extends ConsumerStatefulWidget {
   const AiroTvShell({
     super.key,
@@ -38,6 +44,8 @@ class AiroTvShell extends ConsumerStatefulWidget {
     this.enrichMetadata = false,
     this.onPlaylistSourceTap,
     this.onWaysToWatchTap,
+    this.onShareVideoFrame,
+    this.videoFrameEncoder,
   });
 
   final List<IPTVChannel> channels;
@@ -55,6 +63,13 @@ class AiroTvShell extends ConsumerStatefulWidget {
   /// Opens the fit/full/floating/Cast chooser from the LIVE info bar.
   final VoidCallback? onWaysToWatchTap;
 
+  /// Host-owned delivery for a frame-only PNG capture.
+  final Future<void> Function(Uint8List pngBytes)? onShareVideoFrame;
+
+  /// Test seam for deterministic rendering validation. Production uses the
+  /// boundary's PNG encoder.
+  final VideoFrameEncoder? videoFrameEncoder;
+
   @override
   ConsumerState<AiroTvShell> createState() => _AiroTvShellState();
 }
@@ -64,6 +79,7 @@ class _AiroTvShellState extends ConsumerState<AiroTvShell> {
   bool _countryPromptShowing = false;
   Timer? _visibleScanDebounce;
   String _visibleScanSignature = '';
+  final _videoCaptureKey = GlobalKey();
 
   @override
   void dispose() {
@@ -129,6 +145,9 @@ class _AiroTvShellState extends ConsumerState<AiroTvShell> {
       channel: widget.currentChannel,
       onPlaylistSourceTap: widget.onPlaylistSourceTap,
       onWaysToWatchTap: widget.onWaysToWatchTap,
+      onScreenshotTap: widget.onShareVideoFrame == null
+          ? null
+          : () => _captureVideoFrame(context),
     );
     final hotbar = Hotbar(
       channels: widget.channels,
@@ -136,14 +155,20 @@ class _AiroTvShellState extends ConsumerState<AiroTvShell> {
     );
     final filterRow = FilterRow(dimensions: snapshot.dimensions);
     final videoStage = _VideoStageWithActions(
-      child: multiview.sessions.isEmpty
-          ? widget.videoStage
-          : MultiviewStage(
-              sessions: multiview.sessions,
-              featuredChannelId: multiview.featuredChannelId,
-              onPromote: (channelId) =>
-                  ref.read(multiviewProvider.notifier).promote(channelId),
-            ),
+      child: KeyedSubtree(
+        key: const ValueKey('airo-tv-video-capture-scope'),
+        child: RepaintBoundary(
+          key: _videoCaptureKey,
+          child: multiview.sessions.isEmpty
+              ? widget.videoStage
+              : MultiviewStage(
+                  sessions: multiview.sessions,
+                  featuredChannelId: multiview.featuredChannelId,
+                  onPromote: (channelId) =>
+                      ref.read(multiviewProvider.notifier).promote(channelId),
+                ),
+        ),
+      ),
       onSettings: () => showAiroTvShellSettingsDialog(context),
       onHelp: () => showAiroTvShellHelpDialog(context),
     );
@@ -272,6 +297,46 @@ class _AiroTvShellState extends ConsumerState<AiroTvShell> {
       MultiviewToggleResult.failed =>
         '${channel.name} could not be opened in multiview.',
     };
+    ScaffoldMessenger.of(context)
+      ..hideCurrentSnackBar()
+      ..showSnackBar(SnackBar(content: Text(message)));
+  }
+
+  Future<void> _captureVideoFrame(BuildContext context) async {
+    final share = widget.onShareVideoFrame;
+    final boundary =
+        _videoCaptureKey.currentContext?.findRenderObject()
+            as RenderRepaintBoundary?;
+    if (share == null || boundary == null) {
+      _showCaptureMessage(context, 'Video frame is not ready to share.');
+      return;
+    }
+    try {
+      final bytes =
+          await (widget.videoFrameEncoder?.call(boundary) ??
+              _encodeVideoBoundary(boundary));
+      await share(bytes);
+      if (!context.mounted) return;
+      _showCaptureMessage(context, 'Video frame ready to share.');
+    } catch (error) {
+      debugPrint('[AiroTvShell] video-frame capture failed: $error');
+      if (!context.mounted) return;
+      _showCaptureMessage(context, 'Could not capture this video frame.');
+    }
+  }
+
+  Future<Uint8List> _encodeVideoBoundary(RenderRepaintBoundary boundary) async {
+    final image = await boundary.toImage(pixelRatio: 1);
+    try {
+      final data = await image.toByteData(format: ui.ImageByteFormat.png);
+      if (data == null) throw StateError('PNG encoding failed');
+      return data.buffer.asUint8List();
+    } finally {
+      image.dispose();
+    }
+  }
+
+  void _showCaptureMessage(BuildContext context, String message) {
     ScaffoldMessenger.of(context)
       ..hideCurrentSnackBar()
       ..showSnackBar(SnackBar(content: Text(message)));

--- a/packages/feature_iptv/lib/presentation/tv_ux/sections/channel_info_bar.dart
+++ b/packages/feature_iptv/lib/presentation/tv_ux/sections/channel_info_bar.dart
@@ -4,6 +4,8 @@ import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:platform_channels/platform_channels.dart';
 
+import '../../../application/iptv_deep_link.dart';
+import '../../../application/providers/channel_filters_provider.dart';
 import '../../../application/providers/iptv_providers.dart';
 import '../../widgets/channel_logo.dart';
 
@@ -13,6 +15,7 @@ class ChannelInfoBar extends ConsumerWidget {
     this.channel,
     this.onPlaylistSourceTap,
     this.onWaysToWatchTap,
+    this.onScreenshotTap,
   });
 
   final IPTVChannel? channel;
@@ -23,6 +26,10 @@ class ChannelInfoBar extends ConsumerWidget {
 
   /// Opens the capability-aware fit/full/floating/Cast chooser.
   final VoidCallback? onWaysToWatchTap;
+
+  /// Captures and shares only the current video frame when the host supports
+  /// image delivery.
+  final VoidCallback? onScreenshotTap;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -72,15 +79,27 @@ class ChannelInfoBar extends ConsumerWidget {
             enabled: channel != null,
             onSelect: channel == null
                 ? null
-                : () => _copyShareDetails(context, channel!),
+                : () => _copyShareDetails(context, ref, channel!),
             child: IconButton(
               onPressed: channel == null
                   ? null
-                  : () => _copyShareDetails(context, channel!),
+                  : () => _copyShareDetails(context, ref, channel!),
               tooltip: 'Share',
               icon: const Icon(Icons.share_outlined),
             ),
           ),
+          if (onScreenshotTap != null)
+            TvFocusable(
+              key: const ValueKey('channel-info-screenshot'),
+              semanticLabel: 'Share video frame',
+              enabled: channel != null,
+              onSelect: channel == null ? null : onScreenshotTap,
+              child: IconButton(
+                onPressed: channel == null ? null : onScreenshotTap,
+                tooltip: 'Share video frame',
+                icon: const Icon(Icons.photo_camera_outlined),
+              ),
+            ),
           TvFocusable(
             key: const ValueKey('channel-info-ways-to-watch'),
             semanticLabel: 'Ways to Watch',
@@ -130,15 +149,17 @@ class ChannelInfoBar extends ConsumerWidget {
 
   Future<void> _copyShareDetails(
     BuildContext context,
+    WidgetRef ref,
     IPTVChannel selectedChannel,
   ) async {
     final messenger = ScaffoldMessenger.of(context);
     try {
-      await Clipboard.setData(
-        ClipboardData(
-          text: '${selectedChannel.name}\n${selectedChannel.streamUrl}',
-        ),
-      );
+      final filters = ref.read(channelFiltersProvider);
+      final link = IptvDeepLinkIntent(
+        channelId: selectedChannel.id,
+        filters: filters,
+      ).toUri();
+      await Clipboard.setData(ClipboardData(text: link.toString()));
       if (!context.mounted) return;
       messenger
         ..hideCurrentSnackBar()

--- a/packages/feature_iptv/test/application/iptv_deep_link_test.dart
+++ b/packages/feature_iptv/test/application/iptv_deep_link_test.dart
@@ -1,0 +1,79 @@
+import 'package:feature_iptv/application/iptv_deep_link.dart';
+import 'package:feature_iptv/application/providers/channel_filters_provider.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('channel-only link round-trips without filter parameters', () {
+    const intent = IptvDeepLinkIntent(channelId: 'news/local');
+
+    final uri = intent.toUri();
+    final parsed = IptvDeepLinkIntent.tryParse(uri);
+
+    expect(uri.toString(), contains('/airo/iptv?'));
+    expect(uri.queryParameters, {'v': '1', 'channel': 'news/local'});
+    expect(parsed?.channelId, 'news/local');
+    expect(parsed?.filters, const ChannelFilters());
+  });
+
+  test('channel and active filters round-trip exactly', () {
+    const filters = ChannelFilters(
+      search: 'evening news',
+      category: 'News',
+      country: 'in',
+      language: 'Hindi',
+    );
+    const intent = IptvDeepLinkIntent(
+      channelId: 'news.local',
+      filters: filters,
+    );
+
+    final parsed = IptvDeepLinkIntent.tryParse(intent.toUri());
+
+    expect(parsed?.channelId, intent.channelId);
+    expect(parsed?.filters, filters);
+  });
+
+  test('internal and custom-scheme routes parse through the same contract', () {
+    for (final uri in [
+      Uri.parse('/iptv?channel=one&country=in'),
+      Uri.parse('airo://iptv?channel=one&country=in'),
+    ]) {
+      final parsed = IptvDeepLinkIntent.tryParse(uri);
+      expect(parsed?.channelId, 'one');
+      expect(parsed?.filters.country, 'in');
+    }
+  });
+
+  test('malformed, unsupported, and oversized links are rejected safely', () {
+    expect(
+      IptvDeepLinkIntent.tryParse(
+        Uri.parse('https://example.com/airo/iptv?channel=one'),
+      ),
+      isNull,
+    );
+    expect(
+      IptvDeepLinkIntent.tryParse(Uri.parse('/iptv?v=2&channel=one')),
+      isNull,
+    );
+    expect(IptvDeepLinkIntent.tryParse(Uri.parse('/iptv?channel=')), isNull);
+    expect(
+      IptvDeepLinkIntent.tryParse(
+        Uri.parse('/iptv?channel=${List.filled(257, 'x').join()}'),
+      ),
+      isNull,
+    );
+  });
+
+  test('generated links never include stream or credential material', () {
+    const intent = IptvDeepLinkIntent(
+      channelId: 'safe-id',
+      filters: ChannelFilters(search: 'sports'),
+    );
+
+    final link = intent.toUri().toString();
+
+    expect(link, isNot(contains('stream')));
+    expect(link, isNot(contains('token')));
+    expect(link, isNot(contains('password')));
+  });
+}

--- a/packages/feature_iptv/test/iptv/presentation/tv_ux/airo_tv_shell_test.dart
+++ b/packages/feature_iptv/test/iptv/presentation/tv_ux/airo_tv_shell_test.dart
@@ -5,8 +5,11 @@ import 'package:feature_iptv/application/providers/connectivity_provider.dart';
 import 'package:feature_iptv/application/providers/iptv_providers.dart';
 import 'package:feature_iptv/presentation/tv_ux/airo_tv_shell.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'dart:async';
+import 'dart:typed_data';
 import 'package:platform_channels/platform_channels.dart';
 import 'package:platform_player/platform_player.dart';
 import 'package:platform_streams/platform_streams.dart';
@@ -45,6 +48,8 @@ void main() {
     bool isOnline = true,
     IPTVChannel? currentChannel,
     StreamingState? streamingState,
+    Future<void> Function(Uint8List)? onShareVideoFrame,
+    Future<Uint8List> Function(RenderRepaintBoundary)? videoFrameEncoder,
   }) async {
     final prefs = await SharedPreferences.getInstance();
     final container = ProviderContainer(
@@ -72,6 +77,8 @@ void main() {
                 currentChannel: currentChannel,
                 videoStage: const SizedBox(key: ValueKey('video-stage')),
                 onChannelSelected: (_) {},
+                onShareVideoFrame: onShareVideoFrame,
+                videoFrameEncoder: videoFrameEncoder,
               ),
             ),
           ),
@@ -122,6 +129,49 @@ void main() {
       find.byKey(const ValueKey('airo-tv-channel-library')),
       findsOneWidget,
     );
+  });
+
+  testWidgets('screenshot captures the video scope without shell chrome', (
+    tester,
+  ) async {
+    final capturedCompleter = Completer<Uint8List>();
+    await pumpAt(
+      tester,
+      900,
+      currentChannel: channels.first,
+      onShareVideoFrame: (bytes) async => capturedCompleter.complete(bytes),
+      videoFrameEncoder: (_) async =>
+          Uint8List.fromList([137, 80, 78, 71, 13, 10, 26, 10]),
+    );
+    await tester.pumpAndSettle();
+
+    final scope = find.byKey(const ValueKey('airo-tv-video-capture-scope'));
+    expect(
+      find.descendant(
+        of: scope,
+        matching: find.byKey(const ValueKey('video-stage')),
+      ),
+      findsOneWidget,
+    );
+    expect(
+      find.descendant(of: scope, matching: find.byTooltip('Share video frame')),
+      findsNothing,
+    );
+
+    tester
+        .widget<IconButton>(
+          find.widgetWithIcon(IconButton, Icons.photo_camera_outlined),
+        )
+        .onPressed!
+        .call();
+    await tester.pump();
+    final captured = await tester.runAsync(
+      () => capturedCompleter.future.timeout(const Duration(seconds: 2)),
+    );
+    await tester.pumpAndSettle();
+
+    expect(captured, isNotNull);
+    expect(captured!.take(8), [137, 80, 78, 71, 13, 10, 26, 10]);
   });
 
   testWidgets('wide layout retains the full channel library grid', (

--- a/packages/feature_iptv/test/iptv/presentation/tv_ux/channel_info_bar_test.dart
+++ b/packages/feature_iptv/test/iptv/presentation/tv_ux/channel_info_bar_test.dart
@@ -1,3 +1,5 @@
+import 'package:feature_iptv/application/iptv_deep_link.dart';
+import 'package:feature_iptv/application/providers/channel_filters_provider.dart';
 import 'package:feature_iptv/application/providers/iptv_providers.dart';
 import 'package:feature_iptv/presentation/tv_ux/sections/channel_info_bar.dart';
 import 'package:flutter/material.dart';
@@ -110,9 +112,52 @@ void main() {
 
       expect(
         clipboardText,
-        'Example Channel\nhttps://example.test/stream.m3u8',
+        'https://developerscoffee.github.io/airo/iptv?v=1&channel=channel-1',
       );
       expect(find.text('Example Channel copied to clipboard'), findsOneWidget);
     },
   );
+
+  testWidgets('share includes the active filter combination', (tester) async {
+    final binding = TestDefaultBinaryMessengerBinding.instance;
+    String? clipboardText;
+    binding.defaultBinaryMessenger.setMockMethodCallHandler(
+      SystemChannels.platform,
+      (call) async {
+        if (call.method == 'Clipboard.setData') {
+          final data = Map<String, Object?>.from(call.arguments as Map);
+          clipboardText = data['text'] as String?;
+        }
+        return null;
+      },
+    );
+    addTearDown(
+      () => binding.defaultBinaryMessenger.setMockMethodCallHandler(
+        SystemChannels.platform,
+        null,
+      ),
+    );
+    SharedPreferences.setMockInitialValues({
+      channelFilterSearchStorageKey: 'local news',
+      channelFilterCountryStorageKey: 'in',
+    });
+    final preferences = await SharedPreferences.getInstance();
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [sharedPreferencesProvider.overrideWithValue(preferences)],
+        child: const MaterialApp(
+          home: Scaffold(body: ChannelInfoBar(channel: channel)),
+        ),
+      ),
+    );
+    await tester.pump();
+    await tester.tap(find.byTooltip('Share'));
+    await tester.pump();
+
+    final parsed = IptvDeepLinkIntent.tryParse(Uri.parse(clipboardText!));
+    expect(parsed?.channelId, channel.id);
+    expect(parsed?.filters.search, 'local news');
+    expect(parsed?.filters.country, 'in');
+  });
 }

--- a/packages/feature_iptv/test/presentation/screens/iptv_screen_default_to_live_test.dart
+++ b/packages/feature_iptv/test/presentation/screens/iptv_screen_default_to_live_test.dart
@@ -146,6 +146,36 @@ void main() {
     expect(resumePlayed, isEmpty);
   });
 
+  testWidgets('deep-link intent restores filters before tuning', (
+    tester,
+  ) async {
+    const filters = ChannelFilters(
+      search: 'channel',
+      category: 'News',
+      country: 'in',
+      language: 'Hindi',
+    );
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: _providerOverrides(played: <IPTVChannel>[]),
+        child: const MaterialApp(
+          home: IPTVScreen(
+            deepLinkIntent: IptvDeepLinkIntent(
+              channelId: 'c1',
+              filters: filters,
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+
+    final container = ProviderScope.containerOf(
+      tester.element(find.byType(IPTVScreen)),
+    );
+    expect(container.read(channelFiltersProvider), filters);
+  });
+
   testWidgets(
     'deepLinkChannelId for a missing channel falls back to the browse grid',
     (tester) async {
@@ -163,6 +193,12 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.byKey(const ValueKey('iptv-browse-grid')), findsOneWidget);
+      expect(
+        find.text(
+          'That shared channel is no longer available. Browse to choose another.',
+        ),
+        findsOneWidget,
+      );
     },
   );
 


### PR DESCRIPTION
## Summary

- replace raw-stream sharing with a versioned, secret-free Airo TV link codec for channel-only and channel+filter intents
- restore link filters and tune through the existing launch gate, with safe missing-channel fallback
- capture only the player/multiview repaint boundary and delegate PNG delivery to the host’s existing share surface
- register Android/iOS/macOS deep-link schemes and document the capability as under qualification

Closes #1043.

## Test Plan

- [x] `flutter analyze` or relevant package analyzer passed
- [x] `flutter test` or relevant package tests passed
- [x] CI-only change validated with local script/YAML checks (not applicable; manifests/plists/XML/docs scripts passed)
- [x] Manual device/simulator verification documented, or not applicable

**Verification environment:** Host-only (28 focused tests; no emulator)

## Agent Policy

- [x] Linked issue includes a Critical Agent Gate.
- [x] Linked issue includes a Feature Packet or documents why one is not needed.
- [x] Cross-agent contract is documented for framework/application boundary work.
- [x] Deterministic use cases and automation flows are linked or included.
- [x] AI/tool/memory/routine changes include eval, trace, and redaction coverage (not applicable; link redaction is unit-tested).
- [x] Android Emulator was not used unless the linked issue explicitly accepted `AIRO_ALLOW_ANDROID_EMULATOR=true`.

## Council Review

Required lanes identified from the Decision Matrix and manifests:
- Media Intelligence Architect: IPTV link/intent and filter orchestration
- Flutter Architect + Platform Architect: host router, platform registration, and image-share adapter
- TV Experience Architect + Chief UX Officer: remote-focusable Share video frame action
- Playback Architect: player-only capture boundary; no decoder/pipeline change
- Product Manager + Chief Architect + Chief QA Officer: end-user feature, cross-layer contract, deterministic acceptance coverage
- Chief Performance Officer: bounded 1x PNG capture on explicit user action only
- Chief Documentation Officer: changelog/wiki and release-claim consistency
- Chief Open Source Officer + Chief Security Officer: no new dependency; no stream URL/credential/persistent screenshot data exported

Review metadata remains available for maintainer confirmation; validation is recorded on #1043.

- [x] I checked the Decision Matrix and listed every required role above.
- [x] Every package touched has a `module.yaml`; all 59 manifests validate.
- [x] `owner`/`reviewers` in touched manifests remain aligned; no roster update was needed.

## User-Facing Documentation

- [x] I updated `docs/wiki` and explicitly classify this capability as under qualification/not in 0.0.5.
- [ ] No `docs/wiki` update is needed because this PR has no user-visible behavior or documentation impact.

## Plugin and Size Impact

- [ ] This PR adds new dependencies
- [x] This PR adds or grows app/packages/plugins code
- [x] Size impact is documented below
- [x] Any module over 3 MB is a plugin or has an explicit plugin marker (no threshold status changed)
- [x] Any plugin over 5 MB has cache-management documentation (not applicable)

Size impact / plugin justification: Dart source/tests plus additive runner manifest entries only. Existing `share_plus` is reused; no assets, binaries, plugins, or dependencies were added.

## Checklist

- [x] Code is formatted.
- [x] Tests or manual verification are included above.
- [x] Sensitive data, credentials, and signing artifacts are not committed.

## Release Notes

- [x] User-facing change documented in the IPTV changelog and wiki; public-page branding audit passed.