### PR TITLE
feat(tv): Open Wi-Fi Settings action on the offline banner

### DIFF
--- a/app/android/app/src/main/kotlin/io/airo/app/MainActivity.kt
+++ b/app/android/app/src/main/kotlin/io/airo/app/MainActivity.kt
@@ -77,6 +77,7 @@ class MainActivity : AudioServiceFragmentActivity() {
                 when (call.method) {
                     "isTV" -> result.success(isTvDevice())
                     "getTvPlatform" -> result.success(getTvPlatform())
+                    "openWifiSettings" -> openWifiSettings(result)
                     else -> result.notImplemented()
                 }
             }
@@ -343,6 +344,15 @@ class MainActivity : AudioServiceFragmentActivity() {
             "can_request" to !granted,
             "permission" to Manifest.permission.READ_CALENDAR
         ))
+    }
+
+    private fun openWifiSettings(result: MethodChannel.Result) {
+        try {
+            startActivity(Intent(Settings.ACTION_WIFI_SETTINGS))
+            result.success(mapOf("opened" to true))
+        } catch (error: android.content.ActivityNotFoundException) {
+            result.success(mapOf("opened" to false))
+        }
     }
 
     private fun openCalendarPermissionSettings(result: MethodChannel.Result) {

--- a/packages/feature_iptv/lib/application/providers/connectivity_provider.dart
+++ b/packages/feature_iptv/lib/application/providers/connectivity_provider.dart
@@ -1,12 +1,20 @@
 import 'package:core_data/core_data.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../services/wifi_settings_launcher.dart';
+
 /// Shared connectivity monitor for the "OFFLINE" banner (AiroTV D-pad
 /// design): the playlist is cached, so channels stay listed, but streams
 /// need a real connection.
 final connectivityServiceProvider = Provider<ConnectivityService>((ref) {
   final service = ConnectivityService();
   return service;
+});
+
+/// issues/04-recovery-states.md AC4: the offline banner's "Open Wi-Fi
+/// Settings" action, backed by a real platform adapter.
+final wifiSettingsLauncherProvider = Provider<WifiSettingsLauncher>((ref) {
+  return const WifiSettingsLauncher();
 });
 
 /// Whether the device currently has network connectivity. Seeded with a

--- a/packages/feature_iptv/lib/application/services/wifi_settings_launcher.dart
+++ b/packages/feature_iptv/lib/application/services/wifi_settings_launcher.dart
@@ -1,0 +1,38 @@
+import 'dart:io';
+
+import 'package:flutter/services.dart';
+
+/// Opens the system Wi-Fi settings screen from the TV offline banner
+/// (issues/04-recovery-states.md AC4). Reuses the `com.airo/device_info`
+/// channel already registered in `MainActivity.kt` for `DeviceFormFactorDetector`
+/// -- one more case on an existing channel, not a new one.
+class WifiSettingsLauncher {
+  const WifiSettingsLauncher({bool Function()? isAndroid})
+    : _isAndroid = isAndroid ?? _platformIsAndroid;
+
+  static const _channel = MethodChannel('com.airo/device_info');
+  final bool Function() _isAndroid;
+
+  static bool _platformIsAndroid() => Platform.isAndroid;
+
+  /// The TV app ships Android only -- callers should hide the action
+  /// entirely rather than show it disabled where this is false.
+  bool get isSupported => _isAndroid();
+
+  /// Opens system Wi-Fi settings. Returns whether the native side actually
+  /// launched it; a `false` here (or an unexpected platform failure) must
+  /// surface a real error to the user, not a silent no-op.
+  Future<bool> open() async {
+    if (!isSupported) return false;
+    try {
+      final result = await _channel.invokeMapMethod<String, Object?>(
+        'openWifiSettings',
+      );
+      return result?['opened'] == true;
+    } on PlatformException {
+      return false;
+    } on MissingPluginException {
+      return false;
+    }
+  }
+}

--- a/packages/feature_iptv/lib/presentation/tv_ux/airo_tv_shell.dart
+++ b/packages/feature_iptv/lib/presentation/tv_ux/airo_tv_shell.dart
@@ -617,10 +617,27 @@ class _OfflineBannerState extends ConsumerState<_OfflineBanner> {
       );
   }
 
+  // issues/04-recovery-states.md acceptance criterion 4, second half: a
+  // real platform adapter, or omitted where unsupported -- never a
+  // disabled button (WifiSettingsLauncher.isSupported gates whether this
+  // renders at all, see build()).
+  Future<void> _openWifiSettings() async {
+    final opened = await ref.read(wifiSettingsLauncherProvider).open();
+    if (!mounted || opened) return;
+    ScaffoldMessenger.of(context)
+      ..hideCurrentSnackBar()
+      ..showSnackBar(
+        const SnackBar(content: Text("Couldn't open Wi-Fi settings")),
+      );
+  }
+
   @override
   Widget build(BuildContext context) {
     final isOnline = ref.watch(isOnlineProvider).asData?.value ?? true;
     if (isOnline) return const SizedBox.shrink();
+    final wifiSettingsSupported = ref
+        .watch(wifiSettingsLauncherProvider)
+        .isSupported;
 
     return Container(
       width: double.infinity,
@@ -671,6 +688,29 @@ class _OfflineBannerState extends ConsumerState<_OfflineBanner> {
               ),
             ),
           ),
+          if (wifiSettingsSupported) ...[
+            const SizedBox(width: 4),
+            TvFocusable(
+              key: const ValueKey('offline-banner-wifi-settings'),
+              semanticLabel: 'Open Wi-Fi settings',
+              onSelect: _openWifiSettings,
+              borderRadius: 6,
+              child: TextButton.icon(
+                onPressed: _openWifiSettings,
+                icon: const Icon(
+                  Icons.settings_outlined,
+                  size: 16,
+                  color: Colors.amber,
+                ),
+                label: Text(
+                  'Wi-Fi Settings',
+                  style: Theme.of(
+                    context,
+                  ).textTheme.bodySmall?.copyWith(color: Colors.amber),
+                ),
+              ),
+            ),
+          ],
         ],
       ),
     );

--- a/packages/feature_iptv/test/application/services/wifi_settings_launcher_test.dart
+++ b/packages/feature_iptv/test/application/services/wifi_settings_launcher_test.dart
@@ -1,0 +1,71 @@
+import 'package:feature_iptv/application/services/wifi_settings_launcher.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  const channel = MethodChannel('com.airo/device_info');
+
+  Future<void> mockChannel(
+    Future<Object?> Function(MethodCall call)? handler,
+  ) async {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, handler);
+  }
+
+  tearDown(() => mockChannel(null));
+
+  test('isSupported is false when not Android', () {
+    final launcher = WifiSettingsLauncher(isAndroid: () => false);
+    expect(launcher.isSupported, isFalse);
+  });
+
+  test(
+    'open() returns false without invoking the channel when unsupported',
+    () async {
+      var invoked = false;
+      await mockChannel((call) async {
+        invoked = true;
+        return {'opened': true};
+      });
+      final launcher = WifiSettingsLauncher(isAndroid: () => false);
+
+      expect(await launcher.open(), isFalse);
+      expect(invoked, isFalse);
+    },
+  );
+
+  test('open() returns true when the native side reports opened', () async {
+    await mockChannel((call) async {
+      expect(call.method, 'openWifiSettings');
+      return {'opened': true};
+    });
+    final launcher = WifiSettingsLauncher(isAndroid: () => true);
+
+    expect(await launcher.open(), isTrue);
+  });
+
+  test(
+    'open() returns false when the native side reports not opened',
+    () async {
+      await mockChannel((call) async => {'opened': false});
+      final launcher = WifiSettingsLauncher(isAndroid: () => true);
+
+      expect(await launcher.open(), isFalse);
+    },
+  );
+
+  test('open() returns false on a platform exception', () async {
+    await mockChannel((call) async => throw PlatformException(code: 'error'));
+    final launcher = WifiSettingsLauncher(isAndroid: () => true);
+
+    expect(await launcher.open(), isFalse);
+  });
+
+  test('open() returns false when the plugin is not registered', () async {
+    await mockChannel(null);
+    final launcher = WifiSettingsLauncher(isAndroid: () => true);
+
+    expect(await launcher.open(), isFalse);
+  });
+}

--- a/packages/feature_iptv/test/iptv/presentation/tv_ux/airo_tv_shell_test.dart
+++ b/packages/feature_iptv/test/iptv/presentation/tv_ux/airo_tv_shell_test.dart
@@ -3,6 +3,7 @@ import 'package:feature_iptv/application/providers/channel_filters_provider.dart
 import 'package:feature_iptv/application/providers/channel_auto_scan_providers.dart';
 import 'package:feature_iptv/application/providers/connectivity_provider.dart';
 import 'package:feature_iptv/application/providers/iptv_providers.dart';
+import 'package:feature_iptv/application/services/wifi_settings_launcher.dart';
 import 'package:feature_iptv/presentation/tv_ux/airo_tv_shell.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
@@ -407,6 +408,103 @@ void main() {
       findsOneWidget,
     );
   });
+
+  // issues/04-recovery-states.md acceptance criterion 4, second half: a
+  // real platform adapter, or omitted where unsupported.
+  testWidgets(
+    'offline banner Wi-Fi Settings action opens settings and reports failure',
+    (tester) async {
+      final prefs = await SharedPreferences.getInstance();
+      final launcher = _FakeWifiSettingsLauncher(opened: false);
+      final container = ProviderContainer(
+        overrides: [
+          sharedPreferencesProvider.overrideWithValue(prefs),
+          streamProbeTransportProvider.overrideWithValue(_FakeProbeTransport()),
+          isOnlineProvider.overrideWith((ref) => Stream.value(false)),
+          connectivityServiceProvider.overrideWithValue(
+            _FakeConnectivityService(false),
+          ),
+          wifiSettingsLauncherProvider.overrideWithValue(launcher),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      await tester.pumpWidget(
+        UncontrolledProviderScope(
+          container: container,
+          child: MaterialApp(
+            home: Scaffold(
+              body: SizedBox(
+                width: 900,
+                height: 720,
+                child: AiroTvShell(
+                  channels: channels,
+                  videoStage: const SizedBox(key: ValueKey('video-stage')),
+                  onChannelSelected: (_) {},
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      final button = find.byKey(const ValueKey('offline-banner-wifi-settings'));
+      expect(button, findsOneWidget);
+
+      await tester.tap(button);
+      await tester.pump();
+
+      expect(launcher.openCallCount, 1);
+      expect(find.text("Couldn't open Wi-Fi settings"), findsOneWidget);
+    },
+  );
+
+  testWidgets(
+    'offline banner hides the Wi-Fi Settings action where unsupported',
+    (tester) async {
+      final prefs = await SharedPreferences.getInstance();
+      final container = ProviderContainer(
+        overrides: [
+          sharedPreferencesProvider.overrideWithValue(prefs),
+          streamProbeTransportProvider.overrideWithValue(_FakeProbeTransport()),
+          isOnlineProvider.overrideWith((ref) => Stream.value(false)),
+          connectivityServiceProvider.overrideWithValue(
+            _FakeConnectivityService(false),
+          ),
+          wifiSettingsLauncherProvider.overrideWithValue(
+            _FakeWifiSettingsLauncher(opened: false, isSupported: false),
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      await tester.pumpWidget(
+        UncontrolledProviderScope(
+          container: container,
+          child: MaterialApp(
+            home: Scaffold(
+              body: SizedBox(
+                width: 900,
+                height: 720,
+                child: AiroTvShell(
+                  channels: channels,
+                  videoStage: const SizedBox(key: ValueKey('video-stage')),
+                  onChannelSelected: (_) {},
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      expect(
+        find.byKey(const ValueKey('offline-banner-wifi-settings')),
+        findsNothing,
+      );
+    },
+  );
 }
 
 class _FakeConnectivityService implements ConnectivityService {
@@ -419,6 +517,25 @@ class _FakeConnectivityService implements ConnectivityService {
 
   @override
   Stream<bool> get onConnectivityChanged => const Stream.empty();
+}
+
+class _FakeWifiSettingsLauncher extends WifiSettingsLauncher {
+  _FakeWifiSettingsLauncher({required bool opened, bool isSupported = true})
+    : _opened = opened,
+      _isSupported = isSupported;
+
+  final bool _opened;
+  final bool _isSupported;
+  int openCallCount = 0;
+
+  @override
+  bool get isSupported => _isSupported;
+
+  @override
+  Future<bool> open() async {
+    openCallCount++;
+    return _opened;
+  }
 }
 
 class _FakeProbeTransport implements StreamProbeTransport {


### PR DESCRIPTION
## Summary
- Part of issue #1179 (split from `issues/04-recovery-states.md`). Ships the well-scoped piece: a real "Open Wi-Fi Settings" action next to the offline banner's Retry, backed by `Settings.ACTION_WIFI_SETTINGS` on Android (same pattern as `MainActivity.openCalendarPermissionSettings`, on the already-registered `com.airo/device_info` channel — no new channel).
- `WifiSettingsLauncher.isSupported` gates on `Platform.isAndroid` (injectable for tests): the button is omitted entirely where unsupported, never shown disabled.
- On a native `opened: false` (or platform exception), a snackbar reports the real failure instead of silently no-oping.

Design doc: `docs/superpowers/specs/2026-07-27-tv-recovery-onboarding-design.md`, section A.

## Test plan
- [x] `flutter test test/application/services/wifi_settings_launcher_test.dart test/iptv/presentation/tv_ux/airo_tv_shell_test.dart` — 21/21 pass
- [x] `flutter analyze` on touched files — clean
- [x] `dart format --output=none --set-exit-if-changed` — clean
- [ ] Physical-device pass confirming `Settings.ACTION_WIFI_SETTINGS` actually opens on a real Fire TV / Android TV remote