### PR TITLE
fix(iptv): stop the phone-cast handoff sheet from showing false failures

### DIFF
--- a/packages/feature_iptv/lib/presentation/widgets/phone_media_play_on_tv_sheet.dart
+++ b/packages/feature_iptv/lib/presentation/widgets/phone_media_play_on_tv_sheet.dart
@@ -57,9 +57,15 @@ class _PhoneMediaPlayOnTvSheetState extends State<PhoneMediaPlayOnTvSheet> {
         _phase = switch (state.phase) {
           AiroCastSessionPhase.playing ||
           AiroCastSessionPhase.paused => _HandoffPhase.playing,
-          AiroCastSessionPhase.failed ||
-          AiroCastSessionPhase.disconnected => _HandoffPhase.failed,
-          AiroCastSessionPhase.idle
+          // An explicit failure signal always surfaces as failed. But
+          // `disconnected`/`idle` are also this controller's normal
+          // *starting* state before any device has been picked -- mapping
+          // them to failed unconditionally showed the "Couldn't play on
+          // your TV" error the instant the sheet opened, before the user
+          // had done anything. Only treat them as a failure when a
+          // connection was actually in flight and dropped.
+          AiroCastSessionPhase.failed => _HandoffPhase.failed,
+          (AiroCastSessionPhase.disconnected || AiroCastSessionPhase.idle)
               when _phase == _HandoffPhase.connecting ||
                   _phase == _HandoffPhase.starting ||
                   _phase == _HandoffPhase.playing =>

--- a/packages/feature_iptv/test/iptv/presentation/screens/iptv_screen_test.dart
+++ b/packages/feature_iptv/test/iptv/presentation/screens/iptv_screen_test.dart
@@ -731,8 +731,15 @@ void main() {
         title: 'Movie Night',
         container: 'mp4',
       );
+      final castController = FakeAiroCastController();
+      addTearDown(castController.dispose);
       await tester.pumpWidget(
-        createWidget(onPickLocalMediaForTv: () async => item),
+        createWidget(
+          onPickLocalMediaForTv: () async => item,
+          extraOverrides: [
+            airoCastControllerProvider.overrideWithValue(castController),
+          ],
+        ),
       );
       await tester.pumpAndSettle();
 


### PR DESCRIPTION
## Summary
Root-caused the CI failure that's been blocking the "Build Airo TV APK" gate on every PR this session.

**Real bug**: #1160 added logic deriving `PhoneMediaPlayOnTvSheet`'s UI phase from the cast controller's real session state, but mapped `AiroCastSessionPhase.disconnected` unconditionally to `_HandoffPhase.failed` -- the same bucket as an explicit failure. `disconnected` is also this controller's completely normal starting state before any device has been picked, so on a real device the sheet would show "Couldn't play on your TV" the instant it opened, before the user had done anything -- broken UX, not just a broken test. Narrowed it (matching the existing `idle` case right below) to only fail when a connection was actually in flight and dropped.

**Why the test broke**: `iptv_screen_test.dart`'s "Play file on TV drawer entry" test never overrides `airoCastControllerProvider`, so it falls back to `UnavailableAiroCastController` -- whose `initialize()` genuinely reports a `failed` session. That's now correctly surfaced as failed (was previously silently ignored pre-#1160), but the test was never updated to provide a working `FakeAiroCastController` -- the same one #1160's own `phone_media_play_on_tv_test.dart` already uses -- to exercise the "picking a file, before choosing a TV" path it's actually meant to cover.

## Test plan
- [x] `flutter analyze` clean
- [x] `iptv_screen_test.dart` + `phone_media_play_on_tv_test.dart`: all pass
- [x] Full `feature_iptv` suite: 702 passed, 2 skipped, **0 failed** (previously 1 failing on every run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)