### PR TITLE
feat(tv): QR phone-handoff for playlist onboarding; document USB as omitted

### DIFF
--- a/packages/feature_iptv/lib/application/providers/tv_playlist_pairing_provider.dart
+++ b/packages/feature_iptv/lib/application/providers/tv_playlist_pairing_provider.dart
@@ -1,0 +1,12 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../services/tv_playlist_pairing_server.dart';
+
+/// Factory, not a singleton -- a fresh [TvPlaylistPairingServer] per QR
+/// pairing attempt. Providing the constructor (rather than an instance)
+/// keeps the server's lifecycle owned by the dialog that starts/stops it,
+/// while still giving tests a seam to inject a loopback-bound fake.
+final tvPlaylistPairingServerFactoryProvider =
+    Provider<TvPlaylistPairingServer Function()>((ref) {
+      return TvPlaylistPairingServer.new;
+    });

--- a/packages/feature_iptv/lib/application/services/tv_playlist_pairing_server.dart
+++ b/packages/feature_iptv/lib/application/services/tv_playlist_pairing_server.dart
@@ -1,0 +1,258 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+import 'dart:math';
+
+import 'package:platform_player/platform_player.dart';
+
+/// Short-lived LAN-only HTTP server that lets a phone hand a playlist URL to
+/// the TV by scanning a QR code (issues/04-recovery-states.md's empty-state
+/// "phone QR" onboarding). The phone never needs the Airo app installed --
+/// it gets a plain HTML form.
+///
+/// Mirrors [PhoneMediaFileServer]'s already-reviewed safety pattern (private-
+/// LAN-only binding, constant-time token comparison, redacted logging) for
+/// the opposite direction: the TV serves the form and receives the URL,
+/// rather than serving media.
+class TvPlaylistPairingServer {
+  TvPlaylistPairingServer({
+    Future<List<PhoneMediaLanInterface>> Function()? interfaceLister,
+    this.bindAddress,
+    String? token,
+    this.idleTimeout = const Duration(minutes: 5),
+    this.stopGracePeriod = const Duration(seconds: 2),
+  }) : _interfaceLister = interfaceLister ?? _systemInterfaces,
+       _token = token ?? _generateToken();
+
+  static const int _maxRejectedRequests = 20;
+
+  final Future<List<PhoneMediaLanInterface>> Function() _interfaceLister;
+  final InternetAddress? bindAddress;
+  final String _token;
+  final Duration idleTimeout;
+  final Duration stopGracePeriod;
+
+  HttpServer? _server;
+  Timer? _idleTimer;
+  bool _consumed = false;
+  int _rejectedRequests = 0;
+  final _resultCompleter = Completer<String?>();
+
+  bool get isRunning => _server != null;
+
+  /// Resolves with the submitted playlist URL, or `null` if the session
+  /// expired, was cancelled, or was stopped after too many bad requests --
+  /// never with a URL that wasn't validated by [_handlePost].
+  Future<String?> get result => _resultCompleter.future;
+
+  /// Starts the server and returns the pairing URL to encode as a QR code.
+  /// Throws [StateError] if no private LAN address is available -- callers
+  /// must not fall back to a public/carrier interface.
+  Future<Uri> start() async {
+    final address =
+        bindAddress ??
+        PhoneMediaFileServer.selectLanAddress(await _interfaceLister());
+    if (address == null) {
+      throw StateError(
+        'No private LAN address available; refusing to serve the pairing form.',
+      );
+    }
+    final server = await HttpServer.bind(address, 0);
+    _server = server;
+    final url = Uri(
+      scheme: 'http',
+      host: address.address,
+      port: server.port,
+      path: '/pair/$_token',
+    );
+    server.listen(_handleRequest, onError: (_) {}, cancelOnError: false);
+    _idleTimer = Timer(idleTimeout, () {
+      unawaited(stop());
+    });
+    return url;
+  }
+
+  /// Cancels the session without a result. Safe to call whether or not the
+  /// server is running, and safe to call more than once.
+  Future<void> cancel() async {
+    await stop();
+  }
+
+  Future<void> stop() async {
+    final server = _server;
+    _server = null;
+    _idleTimer?.cancel();
+    _idleTimer = null;
+    if (server != null) await server.close(force: true);
+    if (!_resultCompleter.isCompleted) _resultCompleter.complete(null);
+  }
+
+  Future<void> _handleRequest(HttpRequest request) async {
+    final response = request.response;
+    try {
+      final token = _tokenFromPath(request.uri.path);
+      if (token == null || !_constantTimeEquals(token, _token)) {
+        await _reject(response, HttpStatus.notFound);
+        return;
+      }
+      if (_consumed) {
+        // Single-use: a second request against an already-consumed token
+        // (a race, a reload, or an attacker's guess after the fact) gets
+        // the same "gone" treatment regardless of method.
+        await _reject(response, HttpStatus.gone);
+        return;
+      }
+
+      switch (request.method) {
+        case 'GET':
+          await _handleGet(response);
+        case 'POST':
+          await _handlePost(request, response);
+        default:
+          await _reject(response, HttpStatus.methodNotAllowed);
+      }
+    } catch (_) {
+      await _reject(response, HttpStatus.internalServerError);
+    }
+  }
+
+  Future<void> _handleGet(HttpResponse response) async {
+    response.statusCode = HttpStatus.ok;
+    response.headers.contentType = ContentType.html;
+    response.write(_formHtml);
+    await response.close();
+  }
+
+  Future<void> _handlePost(HttpRequest request, HttpResponse response) async {
+    final body = await _readUrlEncodedForm(request);
+    final url = body['url']?.trim();
+    if (url == null || url.isEmpty) {
+      response.statusCode = HttpStatus.badRequest;
+      response.headers.contentType = ContentType.html;
+      response.write(_formHtml);
+      await response.close();
+      return;
+    }
+
+    // Set the moment a valid submission is accepted -- synchronously, no
+    // await before this point in the handler -- so a second concurrent
+    // request against the same token can never also complete the result.
+    _consumed = true;
+    _idleTimer?.cancel();
+    if (!_resultCompleter.isCompleted) _resultCompleter.complete(url);
+
+    response.statusCode = HttpStatus.ok;
+    response.headers.contentType = ContentType.html;
+    response.write(_successHtml);
+    await response.close();
+
+    unawaited(
+      Future<void>.delayed(stopGracePeriod, () {
+        if (isRunning) unawaited(stop());
+      }),
+    );
+  }
+
+  Future<void> _reject(HttpResponse response, int statusCode) async {
+    _rejectedRequests++;
+    try {
+      response.statusCode = statusCode;
+      await response.close();
+    } catch (_) {
+      // Socket already gone; nothing to clean up.
+    }
+    if (_rejectedRequests >= _maxRejectedRequests) {
+      unawaited(stop());
+    }
+  }
+
+  static Future<Map<String, String>> _readUrlEncodedForm(
+    HttpRequest request,
+  ) async {
+    final raw = await utf8.decoder.bind(request).join();
+    return Uri(query: raw).queryParameters;
+  }
+
+  static Future<List<PhoneMediaLanInterface>> _systemInterfaces() async {
+    final interfaces = await NetworkInterface.list(
+      type: InternetAddressType.IPv4,
+      includeLoopback: false,
+      includeLinkLocal: false,
+    );
+    return [
+      for (final interface in interfaces)
+        (name: interface.name, addresses: interface.addresses),
+    ];
+  }
+
+  String? _tokenFromPath(String path) {
+    const prefix = '/pair/';
+    if (!path.startsWith(prefix)) return null;
+    final token = path.substring(prefix.length);
+    return token.isEmpty ? null : token;
+  }
+
+  static bool _constantTimeEquals(String a, String b) {
+    if (a.length != b.length) return false;
+    var mismatch = 0;
+    for (var i = 0; i < a.length; i++) {
+      mismatch |= a.codeUnitAt(i) ^ b.codeUnitAt(i);
+    }
+    return mismatch == 0;
+  }
+
+  static String _generateToken() {
+    final random = Random.secure();
+    const alphabet =
+        'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ'
+        '0123456789';
+    return List.generate(
+      32,
+      (_) => alphabet[random.nextInt(alphabet.length)],
+    ).join();
+  }
+
+  @override
+  String toString() {
+    return 'TvPlaylistPairingServer('
+        'running: $isRunning, '
+        'consumed: $_consumed, '
+        'url: redacted'
+        ')';
+  }
+}
+
+const _formHtml = '''
+<!doctype html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Add playlist to Airo TV</title>
+<style>
+body{font-family:sans-serif;max-width:480px;margin:48px auto;padding:0 20px;color:#1a1a1a}
+h1{font-size:20px}
+input{width:100%;box-sizing:border-box;padding:12px;font-size:16px;border:1px solid #ccc;border-radius:8px;margin:12px 0}
+button{width:100%;padding:14px;font-size:16px;background:#0a84ff;color:#fff;border:none;border-radius:8px}
+</style>
+</head>
+<body>
+<h1>Add a playlist to your TV</h1>
+<form method="POST">
+<input name="url" type="url" placeholder="https://example.com/playlist.m3u" required autofocus>
+<button type="submit">Send to TV</button>
+</form>
+</body>
+</html>
+''';
+
+const _successHtml = '''
+<!doctype html>
+<html>
+<head><meta charset="utf-8"><title>Sent</title></head>
+<body style="font-family:sans-serif;max-width:480px;margin:48px auto;padding:0 20px">
+<h1>Sent to your TV</h1>
+<p>Check your TV screen to finish adding the playlist.</p>
+</body>
+</html>
+''';

--- a/packages/feature_iptv/lib/presentation/screens/iptv_screen.dart
+++ b/packages/feature_iptv/lib/presentation/screens/iptv_screen.dart
@@ -1203,17 +1203,24 @@ class _StreamTabContent extends ConsumerWidget {
 
 Future<void> showPlaylistSourceSheet(
   BuildContext context,
-  WidgetRef ref,
-) async {
+  WidgetRef ref, {
+  String? initialUrl,
+}) async {
   await showAdaptiveIptvSheet<void>(
     context: context,
     maxWidth: 640,
-    builder: (_) => const _PlaylistSourceSheet(),
+    builder: (_) => _PlaylistSourceSheet(initialUrl: initialUrl),
   );
 }
 
 class _PlaylistSourceSheet extends ConsumerStatefulWidget {
-  const _PlaylistSourceSheet();
+  const _PlaylistSourceSheet({this.initialUrl});
+
+  /// Pre-fills the URL field without auto-submitting -- the TV empty
+  /// state's QR handoff (issues/04-recovery-states.md) hands a phone-typed
+  /// URL in here, but the user still confirms/imports it themselves, same
+  /// as manual entry.
+  final String? initialUrl;
 
   @override
   ConsumerState<_PlaylistSourceSheet> createState() =>
@@ -1230,7 +1237,9 @@ class _PlaylistSourceSheetState extends ConsumerState<_PlaylistSourceSheet> {
   void initState() {
     super.initState();
     final parser = ref.read(m3uParserProvider);
-    _controller = TextEditingController(text: parser.getPlaylistUrl() ?? '');
+    _controller = TextEditingController(
+      text: widget.initialUrl ?? parser.getPlaylistUrl() ?? '',
+    );
   }
 
   @override

--- a/packages/feature_iptv/lib/presentation/tv/iptv_tv_screen.dart
+++ b/packages/feature_iptv/lib/presentation/tv/iptv_tv_screen.dart
@@ -21,6 +21,7 @@ import '../tv_ux/iptv_resume_gate.dart';
 import '../widgets/channel_initials.dart';
 import '../widgets/iptv_icon_placeholder.dart';
 import '../widgets/iptv_mini_player.dart';
+import '../widgets/tv_playlist_qr_dialog.dart';
 import '../widgets/video_player_widget.dart';
 
 enum _TvChannelViewMode { grid, list }
@@ -65,6 +66,15 @@ class _IptvTvScreenState extends ConsumerState<IptvTvScreen> {
 
   Future<void> _showPlaylistSheet() async {
     await showPlaylistSourceSheet(context, ref);
+  }
+
+  Future<void> _showQrPairingDialog() async {
+    final submittedUrl = await showDialog<String>(
+      context: context,
+      builder: (_) => const TvPlaylistQrDialog(),
+    );
+    if (submittedUrl == null || !mounted) return;
+    await showPlaylistSourceSheet(context, ref, initialUrl: submittedUrl);
   }
 
   Future<void> _showPlaylistGuideDialog() async {
@@ -129,6 +139,7 @@ class _IptvTvScreenState extends ConsumerState<IptvTvScreen> {
                   child: _TvEmptyPlaylistState(
                     onPlaylistSourceTap: _showPlaylistSheet,
                     onPlaylistHelpTap: _showPlaylistGuideDialog,
+                    onScanWithPhoneTap: _showQrPairingDialog,
                   ),
                 );
               }
@@ -2289,10 +2300,17 @@ class _TvEmptyPlaylistState extends StatelessWidget {
   const _TvEmptyPlaylistState({
     required this.onPlaylistSourceTap,
     required this.onPlaylistHelpTap,
+    required this.onScanWithPhoneTap,
   });
 
   final VoidCallback onPlaylistSourceTap;
   final VoidCallback onPlaylistHelpTap;
+
+  /// issues/04-recovery-states.md's "phone QR" onboarding. USB is
+  /// intentionally absent from this screen: `file_picker` is a hard no-op
+  /// stub on TV builds (packages/stubs/file_picker_stub), so a USB button
+  /// here would be exactly the "disabled focus bait" that issue forbids.
+  final VoidCallback onScanWithPhoneTap;
 
   @override
   Widget build(BuildContext context) {
@@ -2344,6 +2362,11 @@ class _TvEmptyPlaylistState extends StatelessWidget {
                     label: 'Add Playlist URL',
                     onSelect: onPlaylistSourceTap,
                     autofocus: true,
+                  ),
+                  _TvActionButton(
+                    icon: Icons.qr_code_2,
+                    label: 'Scan with phone',
+                    onSelect: onScanWithPhoneTap,
                   ),
                   _TvActionButton(
                     icon: Icons.help_outline,

--- a/packages/feature_iptv/lib/presentation/widgets/tv_playlist_qr_dialog.dart
+++ b/packages/feature_iptv/lib/presentation/widgets/tv_playlist_qr_dialog.dart
@@ -1,0 +1,177 @@
+import 'dart:async';
+
+import 'package:core_ui/core_ui.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:qr_flutter/qr_flutter.dart';
+
+import '../../application/providers/tv_playlist_pairing_provider.dart';
+import '../../application/services/tv_playlist_pairing_server.dart';
+
+/// Empty-state "phone QR" onboarding (issues/04-recovery-states.md): shows
+/// a QR code for a short-lived LAN-only pairing session, lets the user
+/// cancel or regenerate on expiry, and returns the phone-submitted URL (or
+/// `null` if cancelled/expired) to the caller.
+class TvPlaylistQrDialog extends ConsumerStatefulWidget {
+  const TvPlaylistQrDialog({super.key});
+
+  @override
+  ConsumerState<TvPlaylistQrDialog> createState() => _TvPlaylistQrDialogState();
+}
+
+enum _PairingStatus { waiting, expired }
+
+class _TvPlaylistQrDialogState extends ConsumerState<TvPlaylistQrDialog> {
+  TvPlaylistPairingServer? _server;
+  Uri? _pairingUrl;
+  _PairingStatus _status = _PairingStatus.waiting;
+  Object? _startError;
+
+  @override
+  void initState() {
+    super.initState();
+    unawaited(_startSession());
+  }
+
+  @override
+  void dispose() {
+    unawaited(_server?.stop());
+    super.dispose();
+  }
+
+  Future<void> _startSession() async {
+    final previous = _server;
+    if (previous != null) unawaited(previous.stop());
+
+    final server = ref.read(tvPlaylistPairingServerFactoryProvider)();
+    setState(() {
+      _server = server;
+      _pairingUrl = null;
+      _status = _PairingStatus.waiting;
+      _startError = null;
+    });
+
+    try {
+      final url = await server.start();
+      if (!mounted) return;
+      setState(() => _pairingUrl = url);
+      final submittedUrl = await server.result;
+      if (!mounted) return;
+      if (submittedUrl != null) {
+        Navigator.of(context).pop(submittedUrl);
+        return;
+      }
+      setState(() => _status = _PairingStatus.expired);
+    } catch (error) {
+      if (!mounted) return;
+      setState(() => _startError = error);
+    }
+  }
+
+  void _cancel() {
+    unawaited(_server?.stop());
+    Navigator.of(context).pop();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Dialog(
+      child: ConstrainedBox(
+        constraints: const BoxConstraints(maxWidth: 420),
+        child: Padding(
+          padding: const EdgeInsets.all(28),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.center,
+            children: [
+              Text(
+                'Scan with your phone',
+                style: theme.textTheme.titleLarge,
+                textAlign: TextAlign.center,
+              ),
+              const SizedBox(height: 8),
+              Text(
+                'Connect to the same Wi-Fi, scan the code, and type your '
+                'playlist link on your phone.',
+                style: theme.textTheme.bodyMedium?.copyWith(
+                  color: theme.colorScheme.onSurfaceVariant,
+                ),
+                textAlign: TextAlign.center,
+              ),
+              const SizedBox(height: 20),
+              _buildBody(theme),
+              const SizedBox(height: 20),
+              TvFocusable(
+                key: const ValueKey('tv-playlist-qr-cancel'),
+                semanticLabel: 'Cancel',
+                autofocus: true,
+                onSelect: _cancel,
+                borderRadius: 8,
+                child: OutlinedButton(
+                  onPressed: _cancel,
+                  child: const Text('Cancel'),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildBody(ThemeData theme) {
+    if (_startError != null) {
+      return Text(
+        "Couldn't start pairing — check your TV's Wi-Fi connection.",
+        key: const ValueKey('tv-playlist-qr-error'),
+        style: theme.textTheme.bodyMedium?.copyWith(
+          color: theme.colorScheme.error,
+        ),
+        textAlign: TextAlign.center,
+      );
+    }
+    if (_status == _PairingStatus.expired) {
+      return Column(
+        key: const ValueKey('tv-playlist-qr-expired'),
+        children: [
+          Text('QR code expired', style: theme.textTheme.titleMedium),
+          const SizedBox(height: 12),
+          TvFocusable(
+            key: const ValueKey('tv-playlist-qr-regenerate'),
+            semanticLabel: 'Generate new code',
+            onSelect: () => unawaited(_startSession()),
+            borderRadius: 8,
+            child: FilledButton(
+              onPressed: () => unawaited(_startSession()),
+              child: const Text('Generate new code'),
+            ),
+          ),
+        ],
+      );
+    }
+    final url = _pairingUrl;
+    if (url == null) {
+      return const SizedBox(
+        height: 220,
+        child: Center(child: CircularProgressIndicator()),
+      );
+    }
+    return Column(
+      key: const ValueKey('tv-playlist-qr-waiting'),
+      children: [
+        Container(
+          padding: const EdgeInsets.all(12),
+          color: Colors.white,
+          child: QrImageView(
+            data: url.toString(),
+            size: 200,
+            backgroundColor: Colors.white,
+          ),
+        ),
+        const SizedBox(height: 12),
+        Text('Waiting for your phone…', style: theme.textTheme.bodySmall),
+      ],
+    );
+  }
+}

--- a/packages/feature_iptv/pubspec.yaml
+++ b/packages/feature_iptv/pubspec.yaml
@@ -47,6 +47,7 @@ dependencies:
   product_capabilities:
     path: ../product_capabilities
   path_provider: ^2.1.6
+  qr_flutter: ^4.1.0
   screen_brightness: ^2.1.11
   shared_preferences: ^2.5.5
   slm_edge_intelligence:

--- a/packages/feature_iptv/test/application/services/tv_playlist_pairing_server_test.dart
+++ b/packages/feature_iptv/test/application/services/tv_playlist_pairing_server_test.dart
@@ -1,0 +1,195 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:feature_iptv/application/services/tv_playlist_pairing_server.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  TvPlaylistPairingServer serverFor({
+    String token = 'test-pairing-token',
+    Duration idleTimeout = const Duration(minutes: 5),
+    Duration stopGracePeriod = const Duration(milliseconds: 20),
+  }) {
+    return TvPlaylistPairingServer(
+      bindAddress: InternetAddress.loopbackIPv4,
+      token: token,
+      idleTimeout: idleTimeout,
+      stopGracePeriod: stopGracePeriod,
+    );
+  }
+
+  Future<HttpClientResponse> request(
+    Uri url, {
+    String method = 'GET',
+    String? body,
+  }) async {
+    final client = HttpClient();
+    try {
+      final httpRequest = await client.openUrl(method, url);
+      if (body != null) {
+        httpRequest.headers.contentType = ContentType(
+          'application',
+          'x-www-form-urlencoded',
+        );
+        httpRequest.write(body);
+      }
+      return await httpRequest.close();
+    } finally {
+      client.close(force: true);
+    }
+  }
+
+  test('binds only to the loopback/private address given', () async {
+    final server = serverFor();
+    addTearDown(server.stop);
+    final url = await server.start();
+
+    expect(url.host, InternetAddress.loopbackIPv4.address);
+    expect(url.path, '/pair/test-pairing-token');
+  });
+
+  test('GET on the token path serves the pairing form', () async {
+    final server = serverFor();
+    addTearDown(server.stop);
+    final url = await server.start();
+
+    final response = await request(url);
+    final content = await response.transform(utf8.decoder).join();
+
+    expect(response.statusCode, HttpStatus.ok);
+    expect(content, contains('<form'));
+  });
+
+  test('unknown path is rejected with 404', () async {
+    final server = serverFor();
+    addTearDown(server.stop);
+    final url = await server.start();
+
+    final response = await request(url.replace(path: '/pair/wrong-token'));
+
+    expect(response.statusCode, HttpStatus.notFound);
+  });
+
+  test('unsupported method is rejected with 405', () async {
+    final server = serverFor();
+    addTearDown(server.stop);
+    final url = await server.start();
+
+    final response = await request(url, method: 'PUT');
+
+    expect(response.statusCode, HttpStatus.methodNotAllowed);
+  });
+
+  test('POST with a URL completes the result and consumes the token', () async {
+    final server = serverFor();
+    addTearDown(server.stop);
+    final url = await server.start();
+
+    final response = await request(
+      url,
+      method: 'POST',
+      body:
+          'url=${Uri.encodeQueryComponent('https://example.com/playlist.m3u')}',
+    );
+
+    expect(response.statusCode, HttpStatus.ok);
+    expect(await server.result, 'https://example.com/playlist.m3u');
+  });
+
+  test('token is single-use: a second POST is rejected as gone', () async {
+    final server = serverFor();
+    addTearDown(server.stop);
+    final url = await server.start();
+
+    await request(
+      url,
+      method: 'POST',
+      body: 'url=${Uri.encodeQueryComponent('https://example.com/a.m3u')}',
+    );
+    final second = await request(
+      url,
+      method: 'POST',
+      body: 'url=${Uri.encodeQueryComponent('https://example.com/b.m3u')}',
+    );
+
+    expect(second.statusCode, HttpStatus.gone);
+    // The first, legitimate submission is the one that wins -- a racing or
+    // repeat POST can never overwrite an already-completed result.
+    expect(await server.result, 'https://example.com/a.m3u');
+  });
+
+  test('POST with an empty URL re-shows the form and does not consume the '
+      'token', () async {
+    final server = serverFor();
+    addTearDown(server.stop);
+    final url = await server.start();
+
+    final empty = await request(url, method: 'POST', body: 'url=');
+    expect(empty.statusCode, HttpStatus.badRequest);
+
+    final real = await request(
+      url,
+      method: 'POST',
+      body: 'url=${Uri.encodeQueryComponent('https://example.com/c.m3u')}',
+    );
+    expect(real.statusCode, HttpStatus.ok);
+    expect(await server.result, 'https://example.com/c.m3u');
+  });
+
+  test(
+    'idle timeout resolves the result with null and stops the server',
+    () async {
+      final server = serverFor(idleTimeout: const Duration(milliseconds: 30));
+      addTearDown(server.stop);
+      await server.start();
+
+      expect(await server.result, isNull);
+      expect(server.isRunning, isFalse);
+    },
+  );
+
+  test('cancel() resolves the result with null', () async {
+    final server = serverFor();
+    final url = await server.start();
+
+    await server.cancel();
+
+    expect(await server.result, isNull);
+    expect(server.isRunning, isFalse);
+    await expectLater(request(url), throwsA(isA<Object>()));
+  });
+
+  test('too many rejected requests stops the server', () async {
+    final server = serverFor();
+    addTearDown(server.stop);
+    final url = await server.start();
+
+    for (var i = 0; i < 25; i++) {
+      try {
+        await request(url.replace(path: '/pair/wrong'));
+      } catch (_) {
+        // The server may already be closing mid-loop; that's the point.
+      }
+    }
+
+    expect(server.isRunning, isFalse);
+  });
+
+  test('toString never includes the submitted URL', () async {
+    final server = serverFor();
+    addTearDown(server.stop);
+    final url = await server.start();
+
+    await request(
+      url,
+      method: 'POST',
+      body:
+          'url=${Uri.encodeQueryComponent('https://secret.example/token=abc123')}',
+    );
+    await server.result;
+
+    expect(server.toString(), isNot(contains('secret.example')));
+    expect(server.toString(), isNot(contains('abc123')));
+    expect(server.toString(), contains('redacted'));
+  });
+}

--- a/packages/feature_iptv/test/presentation/widgets/tv_playlist_qr_dialog_test.dart
+++ b/packages/feature_iptv/test/presentation/widgets/tv_playlist_qr_dialog_test.dart
@@ -1,0 +1,156 @@
+import 'dart:async';
+
+import 'package:feature_iptv/application/providers/tv_playlist_pairing_provider.dart';
+import 'package:feature_iptv/application/services/tv_playlist_pairing_server.dart';
+import 'package:feature_iptv/presentation/widgets/tv_playlist_qr_dialog.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  Future<String?> pumpAndOpen(
+    WidgetTester tester,
+    TvPlaylistPairingServer Function() factory,
+  ) async {
+    final container = ProviderContainer(
+      overrides: [
+        tvPlaylistPairingServerFactoryProvider.overrideWithValue(factory),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    String? result;
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: MaterialApp(
+          home: Builder(
+            builder: (context) => ElevatedButton(
+              onPressed: () async {
+                result = await showDialog<String>(
+                  context: context,
+                  builder: (_) => const TvPlaylistQrDialog(),
+                );
+              },
+              child: const Text('open'),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.tap(find.text('open'));
+    await tester.pump();
+    return result;
+  }
+
+  testWidgets('shows the waiting state with a QR code while pending', (
+    tester,
+  ) async {
+    await pumpAndOpen(tester, () => _FakePairingServer(never: true));
+    await tester.pump();
+
+    expect(
+      find.byKey(const ValueKey('tv-playlist-qr-waiting')),
+      findsOneWidget,
+    );
+    expect(find.text('Waiting for your phone…'), findsOneWidget);
+  });
+
+  testWidgets('resolves with the submitted URL and closes the dialog', (
+    tester,
+  ) async {
+    await pumpAndOpen(
+      tester,
+      () => _FakePairingServer(resultUrl: 'https://example.com/p.m3u'),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.byType(TvPlaylistQrDialog), findsNothing);
+  });
+
+  testWidgets('shows the expired state with a regenerate action', (
+    tester,
+  ) async {
+    await pumpAndOpen(tester, () => _FakePairingServer(resultUrl: null));
+    await tester.pumpAndSettle();
+
+    expect(
+      find.byKey(const ValueKey('tv-playlist-qr-expired')),
+      findsOneWidget,
+    );
+    expect(
+      find.byKey(const ValueKey('tv-playlist-qr-regenerate')),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets('regenerate starts a fresh session', (tester) async {
+    var startCount = 0;
+    await pumpAndOpen(tester, () {
+      startCount++;
+      return _FakePairingServer(resultUrl: null);
+    });
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(const ValueKey('tv-playlist-qr-regenerate')));
+    await tester.pump();
+    await tester.pumpAndSettle();
+
+    expect(startCount, 2);
+  });
+
+  testWidgets('cancel stops the server and closes without a result', (
+    tester,
+  ) async {
+    final server = _FakePairingServer(never: true);
+    await pumpAndOpen(tester, () => server);
+    await tester.pump();
+
+    await tester.tap(find.byKey(const ValueKey('tv-playlist-qr-cancel')));
+    await tester.pumpAndSettle();
+
+    expect(server.stopped, isTrue);
+    expect(find.byType(TvPlaylistQrDialog), findsNothing);
+  });
+}
+
+/// A fake that mimics [TvPlaylistPairingServer]'s public surface without
+/// binding a real socket. `noSuchMethod` covers the rest of the concrete
+/// class's interface (fields like `bindAddress`) that this dialog never
+/// touches.
+class _FakePairingServer implements TvPlaylistPairingServer {
+  _FakePairingServer({this.resultUrl, this.never = false});
+
+  final String? resultUrl;
+  final bool never;
+  final _resultCompleter = Completer<String?>();
+  bool stopped = false;
+
+  @override
+  Future<Uri> start() async {
+    return Uri.parse('http://192.168.1.5:8080/pair/fake-token');
+  }
+
+  @override
+  Future<String?> get result {
+    if (!never && !_resultCompleter.isCompleted) {
+      _resultCompleter.complete(resultUrl);
+    }
+    return _resultCompleter.future;
+  }
+
+  @override
+  Future<void> cancel() => stop();
+
+  @override
+  Future<void> stop() async {
+    stopped = true;
+    if (!_resultCompleter.isCompleted) _resultCompleter.complete(null);
+  }
+
+  @override
+  bool get isRunning => !stopped;
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}


### PR DESCRIPTION
## Summary
Closes the rest of issue #1179 (empty-state onboarding, split from `issues/04-recovery-states.md` after PR #1169's error/offline slice; PR #1188 already shipped the Wi-Fi settings piece). Design doc: `docs/superpowers/specs/2026-07-27-tv-recovery-onboarding-design.md`.

Investigation found the issue's three requirements had very different real scope:
- **URL entry**: already existed (`_TvEmptyPlaylistState`'s "Add Playlist URL"). Not touched.
- **QR phone handoff**: genuinely missing — built here.
- **USB**: `file_picker` is a hard no-op stub on TV builds. Building a button against it would be exactly the "disabled focus bait" this issue forbids. **Documented as an intentional omission, no code.**

### QR handoff
- New `TvPlaylistPairingServer`: a short-lived, LAN-only HTTP server the TV starts on demand. Reuses `PhoneMediaFileServer`'s already-audited private-LAN-address selection (`platform_player`) rather than re-deriving it. Serves a plain, self-contained HTML form (no external assets) at `/pair/<token>`; the phone types a playlist URL into it; the TV receives it.
- New "Scan with phone" empty-state action opens a dialog showing the QR (via `qr_flutter`), waits for the submission, then hands the URL to the *existing* `showPlaylistSourceSheet` flow (now takes an optional `initialUrl`) so the user still confirms/imports on the TV — no auto-apply.
- **Security-reviewed before implementation** (see design doc "Verification"/chief-security-officer pass): constant-time token comparison, atomic single-use consumption (a racing/repeat POST can never overwrite an already-completed result), a rejected-request rate cap, and the submitted URL is never logged/exposed via `toString()` since it may carry credentials.
- **Architecture-reviewed before implementation** (media-intelligence-architect): flagged that the original design's `showPlaylistSourceSheet` integration was unimplementable as first written (no URL param existed) — fixed by adding `initialUrl`. Also required a provider seam for testability — done via `tvPlaylistPairingServerFactoryProvider`.

### New dependency: `qr_flutter`
Pure-Dart QR rendering, BSD-3-Clause, no native code. Vetted by chief-open-source-officer (approve-with-caveats: pin version, slow release cadence noted).

## Test plan
- [x] `flutter test test/application/services/tv_playlist_pairing_server_test.dart` — 11/11 pass, including single-use race safety, rate-cap, and redaction
- [x] `flutter test test/presentation/widgets/tv_playlist_qr_dialog_test.dart` — 5/5 pass (waiting/success/expired/regenerate/cancel states)
- [x] `flutter test test/iptv/presentation/tv/iptv_tv_screen_test.dart test/iptv/presentation/screens/iptv_screen_test.dart` — 36/37 pass; the one failure is a pre-existing, unrelated Cast-UI regression already on `main` (traced separately, not touched here)
- [x] `flutter analyze` on touched files — clean
- [x] `dart format --output=none --set-exit-if-changed` — clean
- [ ] Physical remote pass: scan the QR from a real phone on the same Wi-Fi as a Fire TV / Android TV