### PR TITLE
fix(playback): wire sustained-stall detection into the multi-source failover controller

### DIFF
--- a/docs/superpowers/specs/2026-07-27-playback-stall-failover-wiring-design.md
+++ b/docs/superpowers/specs/2026-07-27-playback-stall-failover-wiring-design.md
@@ -1,0 +1,131 @@
+# Wire stall detection into the existing multi-source failover controller
+
+Date: 2026-07-27
+Status: Approved
+
+## Context
+
+Original ask: reduce pixelation/freezing on poor network connections
+(lower resolution, bigger buffer, hardware decode, network tuning). A
+`playback-architect` discovery pass found the real state of the codebase:
+
+1. No native ExoPlayer/ Media3 `LoadControl` tuning exists anywhere — the
+   TV app runs the stock `video_player` plugin's internal defaults, and
+   `StreamingConfig.targetBufferDuration`/`minBufferDuration`
+   (`platform_player/lib/src/services/iptv_streaming_service.dart:65-111`)
+   never reach the native player; `targetBufferDuration` is display-only.
+2. No real adaptive bitrate. `VideoPlayerAiroPlaybackEngine.selectQuality()`
+   unconditionally fails; the "quality selector" does a full reload to a
+   different manual URL from `channel.qualityUrls`, not in-stream ABR.
+3. Hardware decoding is hardcoded `true` in diagnostics, not a real
+   toggle/decision.
+4. `StreamingConfig.retryDelay` is defined but never read; retry is
+   manual-only (user taps "Try Again").
+5. No buffer/quality settings screen exists.
+6. **`AiroMultiSourceFailoverController`
+   (`platform_player/lib/src/models/multi_source_failover_models.dart:226`)
+   is fully implemented and tested, and is already wired for open-time
+   playback errors (`video_player_streaming_service.dart:264-278`,
+   `recordPlaybackError`). Its stall-triggered path
+   (`recordBuffering`/`shouldFailoverForStall`, 4s threshold via
+   `AiroFailoverPolicy.stallThreshold`) is never called anywhere.** The
+   live buffer-monitor timer (`_startBufferMonitoring`,
+   `video_player_streaming_service.dart:398-429`) only updates a
+   display-only `bufferHealth` percentage every second; it never reports
+   sustained buffering to the failover controller.
+
+Items 1-5 need native platform-channel work, an engine change, or new UI
+— out of scope for this pass (see "Out of scope"). Item 6 is a pure
+wiring job: closing a real gap using infrastructure that already exists,
+is already tested, and is already surfaced in the UI (the failover toast)
+for the sibling open-time-error path. That's this spec's entire scope.
+
+## The gap in concrete terms
+
+Today: a channel is playing, the network degrades, the buffer drains,
+`isBuffering` goes true. The buffer monitor keeps ticking `bufferHealth`
+toward 0 forever. Nothing else happens. If the stream never recovers, the
+user watches a frozen/buffering screen indefinitely with no automatic
+recovery, even though the channel may have other quality-URL sources that
+`AiroMultiSourceFailoverController` already knows about and could switch
+to — the exact mechanism that already fires correctly when the *initial*
+open fails.
+
+## Design
+
+All changes in `packages/platform_media/lib/src/video_player_streaming_service.dart`.
+
+1. New instance fields: `DateTime? _bufferingSince` and
+   `bool _isHandlingStall = false` (mirrors the existing `_isHandlingError`
+   reentrancy guard).
+2. `_startBufferMonitoring()` resets `_bufferingSince = null` when
+   (re)started (a fresh monitor means a fresh episode — e.g. after a
+   successful failover switch, per point 4 below).
+3. Inside the existing 1s timer callback, after computing `isBuffering`:
+   - If `isBuffering` and `_bufferingSince == null` → set
+     `_bufferingSince = DateTime.now()`.
+   - If `!isBuffering` → clear `_bufferingSince = null` (buffering
+     recovered on its own; no failover needed).
+   - If `isBuffering`, `_bufferingSince != null`, and not already
+     `_isHandlingStall` → call
+     `_failoverController?.recordBuffering(sourceId: currentSourceId,
+     duration: DateTime.now().difference(_bufferingSince!))`.
+     `shouldFailoverForStall`'s existing 4s-threshold check inside the
+     controller means most ticks return `ignored` (a no-op) until the
+     threshold is actually crossed — no new threshold logic needed here.
+4. On a `switched` decision: set `_isHandlingStall = true`, stop the
+   current engine, and call the existing
+   `_playChannel(channel, preserveFailover: true, resetRetryCount: false)`
+   — the exact call shape the open-time-error path already uses to open
+   the controller's `nextSource`. This naturally populates the same
+   `failover` state field the UI's `PlayerOverlay._buildFailoverToast`
+   already renders for the sibling path — no new UI. Reset
+   `_isHandlingStall = false` once `_playChannel` returns (success or
+   failure both restart/replace the buffer monitor, so stale state can't
+   leak into the next episode).
+5. On an `exhausted` decision: call the existing `_handleError(...)` —
+   the same terminal path open-time failures already use, including its
+   existing retry-count/max-retries and terminal-message behavior.
+6. On `ignored` (below threshold): no-op, as today.
+
+## What this does not do
+
+- Does not change the 4s `stallThreshold` — that's `AiroFailoverPolicy`'s
+  existing, already-reviewed default.
+- Does not add a new UI surface — reuses the failover toast the
+  open-time-error path already drives.
+- Does not touch buffer *sizing*, bitrate selection, or hardware decoding
+  — those require native platform-channel work or an engine change,
+  neither of which fits a same-day wiring fix.
+
+## Testing
+
+- Unit test on `VideoPlayerStreamingService` (or its existing test
+  harness) with a fake engine that reports `bufferedRanges` producing
+  `isBuffering: true` for a controlled duration: assert
+  `recordBuffering` fires only after crossing 4s, assert a `switched`
+  decision re-opens the next source (spy on `_engine.open` calls or
+  observe `_state.currentChannel`'s source), assert an `exhausted`
+  decision reaches `PlaybackState.error`.
+- Regression: a transient stall that recovers before 4s must not trigger
+  any failover call sequence beyond the `ignored`/ no-op ticks.
+- Existing failover and buffer-monitor tests must continue to pass
+  unmodified in behavior for the open-time-error path.
+
+## Review requirements (per this repo's Decision Matrix)
+
+Changes `platform_media`'s failover trigger conditions — flagged for
+Media Intelligence Architect, Platform Architect, and Chief QA Officer
+review before merge, in addition to Playback Architect (package owner).
+
+## Out of scope
+
+- Native buffer-size (`LoadControl`) tuning.
+- Real adaptive bitrate / in-stream track switching.
+- Hardware-decoding toggle.
+- `StreamingConfig.retryDelay` wiring (separate, unrelated dead field).
+- Any buffer/quality settings UI.
+
+These remain real, evidenced gaps for a future, larger pass — the
+playback-architect's original discovery report is preserved in this
+session's history for whoever picks that up next.

--- a/packages/platform_media/lib/src/video_player_streaming_service.dart
+++ b/packages/platform_media/lib/src/video_player_streaming_service.dart
@@ -397,6 +397,7 @@ class VideoPlayerStreamingService implements IPTVStreamingService {
 
   void _startBufferMonitoring() {
     _bufferMonitor?.cancel();
+    _bufferingSince = null;
     _bufferMonitor = Timer.periodic(const Duration(seconds: 1), (_) {
       final engineState = _engine.currentState;
       final position = engineState.position;
@@ -416,16 +417,83 @@ class VideoPlayerStreamingService implements IPTVStreamingService {
               .clamp(0, 100)
               .toInt();
 
+      final isBuffering =
+          engineState.phase == AiroPlaybackEnginePhase.buffering;
+
       _updateState(
         _state.copyWith(
           bufferStatus: BufferStatus(
             bufferedAhead: bufferedAhead,
             bufferHealth: bufferHealth,
-            isBuffering: engineState.phase == AiroPlaybackEnginePhase.buffering,
+            isBuffering: isBuffering,
           ),
         ),
       );
+
+      _trackStall(isBuffering);
     });
+  }
+
+  /// Reports sustained buffering to the already-built, already-wired-for-
+  /// open-time-errors `AiroMultiSourceFailoverController` -- the stall
+  /// half of its trigger surface (`recordBuffering`) was previously never
+  /// called. A transient buffering blip that clears on its own never
+  /// reaches the controller at all; only a continuous stall does.
+  void _trackStall(bool isBuffering) {
+    if (!isBuffering) {
+      _bufferingSince = null;
+      return;
+    }
+    final since = _bufferingSince;
+    if (since == null) {
+      _bufferingSince = DateTime.now();
+      return;
+    }
+    if (_isHandlingStall) return;
+
+    final controller = _failoverController;
+    final currentSourceId = controller?.state.currentSourceId;
+    final channel = _state.currentChannel;
+    if (controller == null || currentSourceId == null || channel == null) {
+      return;
+    }
+
+    final decision = controller.recordBuffering(
+      sourceId: currentSourceId,
+      duration: DateTime.now().difference(since),
+    );
+    unawaited(_handleStallDecision(decision, channel));
+  }
+
+  Future<void> _handleStallDecision(
+    AiroFailoverDecision decision,
+    IPTVChannel channel,
+  ) async {
+    switch (decision.code) {
+      case AiroFailoverDecisionCode.ignored:
+        return;
+      case AiroFailoverDecisionCode.switched:
+        _isHandlingStall = true;
+        _updateState(
+          _state.copyWith(failover: _failoverProgressFor(decision.state)),
+        );
+        try {
+          await _playChannel(
+            channel,
+            preserveFailover: true,
+            resetRetryCount: false,
+          );
+        } finally {
+          _isHandlingStall = false;
+        }
+      case AiroFailoverDecisionCode.exhausted:
+        _isHandlingStall = true;
+        try {
+          await _handleError('Playback stalled on every available source.');
+        } finally {
+          _isHandlingStall = false;
+        }
+    }
   }
 
   void _startMetricsCollection() {
@@ -472,6 +540,16 @@ class VideoPlayerStreamingService implements IPTVStreamingService {
 
   /// Flag to prevent duplicate error handling
   bool _isHandlingError = false;
+
+  /// When the current buffering episode started, or `null` when not
+  /// currently buffering. Reset whenever `_startBufferMonitoring` (re)starts
+  /// so a fresh source (post-failover, post-retry) begins a fresh episode.
+  DateTime? _bufferingSince;
+
+  /// Prevents the 1s buffer-monitor tick from calling `recordBuffering`
+  /// again while a stall-triggered source switch/error is already in
+  /// flight -- mirrors [_isHandlingError]'s reentrancy guard.
+  bool _isHandlingStall = false;
 
   /// Maps a failure to its structured diagnostic. Shared by the playChannel
   /// failover loop (which needs `retryEligible` to decide whether to

--- a/packages/platform_media/test/video_player_streaming_service_test.dart
+++ b/packages/platform_media/test/video_player_streaming_service_test.dart
@@ -219,9 +219,7 @@ void main() {
       );
     }
 
-    VideoPlayerStreamingService serviceWith(
-      _ScriptedMultiSourceEngine scripted,
-    ) {
+    VideoPlayerStreamingService serviceWith(AiroPlaybackEngine scripted) {
       final svc = VideoPlayerStreamingService(engine: scripted);
       addTearDown(svc.dispose);
       return svc;
@@ -357,6 +355,89 @@ void main() {
         expect(svc.currentState.playbackState, PlaybackState.error);
       },
     );
+
+    // AiroMultiSourceFailoverController.recordBuffering/
+    // shouldFailoverForStall (4s threshold) previously had no caller in
+    // this service; the 1s buffer-monitor timer only updated a display
+    // bufferHealth percentage. These tests exercise the wiring added to
+    // close that gap.
+    test('sustained buffering past the stall threshold fails over to the '
+        'next source', () async {
+      final scripted = _StallableMultiSourceEngine();
+      final svc = serviceWith(scripted);
+
+      await svc.playChannel(multiSourceChannel());
+      expect(scripted.openedUrls, [urlA]);
+
+      scripted.setBuffering(true);
+      // Policy threshold is 4s; wait well past it to absorb Timer.periodic
+      // scheduling jitter under load rather than racing a tight margin.
+      await Future<void>.delayed(const Duration(milliseconds: 8000));
+
+      expect(scripted.openedUrls, [urlA, urlB]);
+      expect(svc.currentState.playbackState, PlaybackState.playing);
+      expect(svc.currentState.failover, isNull);
+    }, timeout: const Timeout(Duration(seconds: 15)));
+
+    test(
+      'buffering that clears before the stall threshold does not fail over',
+      () async {
+        final scripted = _StallableMultiSourceEngine();
+        final svc = serviceWith(scripted);
+
+        await svc.playChannel(multiSourceChannel());
+        scripted.setBuffering(true);
+        await Future<void>.delayed(const Duration(milliseconds: 1500));
+        scripted.setBuffering(false);
+        await Future<void>.delayed(const Duration(milliseconds: 1500));
+
+        expect(scripted.openedUrls, [urlA]);
+        expect(svc.currentState.playbackState, PlaybackState.playing);
+      },
+      timeout: const Timeout(Duration(seconds: 10)),
+    );
+
+    test('sustained buffering with no remaining source reaches the terminal '
+        'error state', () async {
+      final scripted = _StallableMultiSourceEngine();
+      final svc = serviceWith(scripted);
+
+      await svc.playChannel(channel());
+      scripted.setBuffering(true);
+      await Future<void>.delayed(const Duration(milliseconds: 8000));
+
+      expect(svc.currentState.playbackState, PlaybackState.error);
+      expect(svc.currentState.failover, isNull);
+    }, timeout: const Timeout(Duration(seconds: 15)));
+
+    test('a stall on the switched-to source after an initial switch reaches '
+        'exhausted, not an instant or stuck re-trigger', () async {
+      // Exercises the one new piece of state central to this wiring:
+      // _startBufferMonitoring() resets _bufferingSince on every restart,
+      // including the one triggered by a stall-driven switch. A stale
+      // _bufferingSince would either fire the second stall instantly
+      // (reset never happened) or never re-arm (reset happened but the
+      // new episode's start was lost).
+      final scripted = _StallableMultiSourceEngine();
+      final svc = serviceWith(scripted);
+
+      await svc.playChannel(multiSourceChannel());
+      scripted.setBuffering(true);
+      await Future<void>.delayed(const Duration(milliseconds: 8000));
+
+      expect(scripted.openedUrls, [urlA, urlB]);
+      expect(svc.currentState.playbackState, PlaybackState.playing);
+
+      // The switch's own open() reset phase to `.open`, clearing
+      // isBuffering -- stall a second time on the new (and now only
+      // remaining) source.
+      scripted.setBuffering(true);
+      await Future<void>.delayed(const Duration(milliseconds: 8000));
+
+      expect(scripted.openedUrls, [urlA, urlB]);
+      expect(svc.currentState.playbackState, PlaybackState.error);
+      expect(svc.currentState.failover, isNull);
+    }, timeout: const Timeout(Duration(seconds: 25)));
 
     test('retry exhaustion explains a dead or region-blocked stream', () async {
       final scripted = _ScriptedOpenFailureEngine(
@@ -733,6 +814,96 @@ class _ScriptedMultiSourceEngine implements AiroPlaybackEngine {
         duration: const Duration(minutes: 30),
       );
     }
+    _controller.add(_state);
+    return _state;
+  }
+
+  @override
+  Future<AiroPlaybackState> play() async => _state;
+
+  @override
+  Future<AiroPlaybackState> pause() async => _state;
+
+  @override
+  Future<AiroPlaybackState> stop() async => _state;
+
+  @override
+  Future<AiroPlaybackState> seek(Duration position) async => _state;
+
+  @override
+  Future<AiroPlaybackState> setVolume(double volume) async => _state;
+
+  @override
+  Future<AiroPlaybackState> setPlaybackSpeed(double speed) async => _state;
+
+  @override
+  Future<AiroPlaybackState> selectQuality(String qualityId) async => _state;
+
+  @override
+  Future<AiroPlaybackState> selectTrack({
+    required AiroPlaybackTrackKind kind,
+    required String trackId,
+  }) async => _state;
+
+  @override
+  Future<AiroPlaybackState> clearTrackSelection(
+    AiroPlaybackTrackKind kind,
+  ) async => _state;
+
+  @override
+  Future<AiroPlaybackDiagnostics> diagnostics() async =>
+      AiroPlaybackDiagnostics(backendId: backendKind.stableId);
+
+  @override
+  Future<AiroPlaybackState> enterPictureInPicture() async => _state;
+
+  @override
+  Future<AiroPlaybackState> exitPictureInPicture() async => _state;
+
+  @override
+  Widget? buildView() => null;
+
+  @override
+  Future<void> dispose() async => _controller.close();
+}
+
+/// Like [_ScriptedMultiSourceEngine] (every `open()` succeeds), plus
+/// [setBuffering] to drive the stall-failover tests: the buffer monitor
+/// reads `_engine.currentState.phase` directly, and any subsequent
+/// `open()` call (a failover switch) naturally resets it away from
+/// `buffering`, matching a real engine's behavior on source switch.
+class _StallableMultiSourceEngine implements AiroPlaybackEngine {
+  final openedUrls = <String>[];
+  final _controller = StreamController<AiroPlaybackState>.broadcast();
+  AiroPlaybackState _state = AiroPlaybackState.idle(
+    backendKind: AiroPlaybackBackendKind.fake,
+  );
+
+  void setBuffering(bool buffering) {
+    _state = _state.copyWith(
+      phase: buffering
+          ? AiroPlaybackEnginePhase.buffering
+          : AiroPlaybackEnginePhase.open,
+    );
+  }
+
+  @override
+  AiroPlaybackBackendKind get backendKind => AiroPlaybackBackendKind.fake;
+
+  @override
+  Stream<AiroPlaybackState> get states => _controller.stream;
+
+  @override
+  AiroPlaybackState get currentState => _state;
+
+  @override
+  Future<AiroPlaybackState> open(AiroMediaOpenRequest request) async {
+    openedUrls.add(request.sourceHandle.value);
+    _state = _state.copyWith(
+      phase: AiroPlaybackEnginePhase.open,
+      request: request,
+      duration: const Duration(minutes: 30),
+    );
     _controller.add(_state);
     return _state;
   }


### PR DESCRIPTION
## Summary
Original ask: reduce pixelation/freezing on poor network connections. A `playback-architect` discovery pass found no native buffer/ABR tuning exists anywhere (out of scope for a single pass — see design doc), but found one real, contained, high-value gap: `AiroMultiSourceFailoverController.recordBuffering()`/`shouldFailoverForStall()` (4s threshold) is fully implemented and tested at the controller level, and already wired for open-time errors — but had **zero caller** for the stall path. A stalling stream on a bad connection just sat there indefinitely, even on channels with untried backup sources.

This PR closes that gap:
- New `_trackStall`/`_handleStallDecision` in `VideoPlayerStreamingService`, called from the existing 1s buffer-monitor timer.
- Tracks continuous buffering via a `_bufferingSince` timestamp, reset on every `_startBufferMonitoring()` restart (i.e. every reopen — initial play, quality switch, or failover switch), so a fresh source never inherits stale stall time.
- On a `switched` decision, reuses the exact `_playChannel(preserveFailover: true, resetRetryCount: false)` call shape the open-time-error path already uses — same reentrancy guard pattern (`_isHandlingStall` mirrors `_isHandlingError`), same failover-toast UI, no new UI surface.
- On `exhausted`, reuses the existing `_handleError` terminal path.

Design doc: `docs/superpowers/specs/2026-07-27-playback-stall-failover-wiring-design.md` (also records the other 5 gap areas found — native buffer tuning, real ABR, hardware-decode toggle, `retryDelay` wiring, quality/buffer settings UI — as explicitly out of scope for this pass).

## Review (per this repo's Decision Matrix for failover-trigger-condition changes)
- **Media Intelligence Architect**: approve. One non-blocking risk flagged for the record: a single-tick `buffering→open→buffering` flicker resets the stall clock (matches the design as specified, not a deviation).
- **Platform Architect**: approve. Verified no re-entrancy race (the `_isHandlingStall` guard is set synchronously before any `await`, so the 1s timer can't double-trigger) and no timer leak (`_bufferMonitor?.cancel()` always precedes the next `Timer.periodic`).
- **Chief QA Officer**: approve-with-changes — required a test proving `_bufferingSince` survives a real mid-episode switch (stall on source A → switch to B → stall on B again → exhausted), not just a fresh play. Added and passing.

## Test plan
- [x] `flutter test test/video_player_streaming_service_test.dart` — 31/31 pass, including 4 new stall-specific tests (switched, transient/ignored, exhausted, and double-stall-across-a-switch)
- [x] `flutter analyze` on touched files — clean
- [x] `dart format --output=none --set-exit-if-changed` — clean
- [ ] Physical-device pass: verify a real backup-source switch on an actual degraded/throttled network, not just the fake-engine unit tests