### PR TITLE
fix(tv): stop fullscreen from permanently killing the D-pad after entry

### DIFF
--- a/packages/feature_iptv/lib/presentation/screens/iptv_screen.dart
+++ b/packages/feature_iptv/lib/presentation/screens/iptv_screen.dart
@@ -91,6 +91,14 @@ class _IPTVScreenState extends ConsumerState<IPTVScreen>
     debugLabel: 'IPTV fullscreen back handler',
   );
 
+  /// Guards the postFrameCallback below to fire once per fullscreen entry,
+  /// not on every rebuild. Live playback rebuilds constantly (buffering,
+  /// position, cast state); requesting focus on every one of those was
+  /// yanking focus back to this Back-only node from the player's own
+  /// TvInputHandler after it had already (correctly) taken over, leaving
+  /// every D-pad key except Back permanently dead in fullscreen.
+  bool _fullscreenFocusClaimed = false;
+
   /// True while a [IPTVScreen.deepLinkChannelId] is set and its resolution
   /// (in the post-frame callback below) hasn't yet either started playback
   /// or determined the channel doesn't exist. Gates the first frame so the
@@ -242,6 +250,10 @@ class _IPTVScreenState extends ConsumerState<IPTVScreen>
   void _toggleFullscreen() {
     final isFullscreen = ref.read(isFullscreenModeProvider);
     ref.read(isFullscreenModeProvider.notifier).state = !isFullscreen;
+    if (isFullscreen) {
+      // Leaving fullscreen -- let the next entry claim focus fresh.
+      _fullscreenFocusClaimed = false;
+    }
 
     // TV chrome is fixed: always landscape, always immersive (set once at
     // startup by the app's configureTvSystemChrome). The phone-style
@@ -715,11 +727,14 @@ class _IPTVScreenState extends ConsumerState<IPTVScreen>
     }
 
     if (showFullscreenPlayer) {
-      WidgetsBinding.instance.addPostFrameCallback((_) {
-        if (mounted && ref.read(isFullscreenModeProvider)) {
-          _fullscreenFocusNode.requestFocus();
-        }
-      });
+      if (!_fullscreenFocusClaimed) {
+        _fullscreenFocusClaimed = true;
+        WidgetsBinding.instance.addPostFrameCallback((_) {
+          if (mounted && ref.read(isFullscreenModeProvider)) {
+            _fullscreenFocusNode.requestFocus();
+          }
+        });
+      }
       return guardRouteBack(
         Focus(
           focusNode: _fullscreenFocusNode,
@@ -890,6 +905,10 @@ class _IPTVScreenBodyState extends ConsumerState<IPTVScreenBody>
     debugLabel: 'IPTV body fullscreen back handler',
   );
 
+  /// See _IPTVScreenState's identical field: guards the postFrameCallback
+  /// below to fire once per fullscreen entry, not on every rebuild.
+  bool _fullscreenFocusClaimed = false;
+
   @override
   void initState() {
     super.initState();
@@ -936,6 +955,10 @@ class _IPTVScreenBodyState extends ConsumerState<IPTVScreenBody>
   void _toggleFullscreen() {
     final isFullscreen = ref.read(isFullscreenModeProvider);
     ref.read(isFullscreenModeProvider.notifier).state = !isFullscreen;
+    if (isFullscreen) {
+      // Leaving fullscreen -- let the next entry claim focus fresh.
+      _fullscreenFocusClaimed = false;
+    }
 
     if (!isFullscreen) {
       // Entering fullscreen
@@ -1033,7 +1056,8 @@ class _IPTVScreenBodyState extends ConsumerState<IPTVScreenBody>
       _syncLocalPlaybackWithCast,
     );
     final isFullscreen = ref.watch(isFullscreenModeProvider);
-    if (isFullscreen) {
+    if (isFullscreen && !_fullscreenFocusClaimed) {
+      _fullscreenFocusClaimed = true;
       WidgetsBinding.instance.addPostFrameCallback((_) {
         if (mounted && ref.read(isFullscreenModeProvider)) {
           _fullscreenFocusNode.requestFocus();

--- a/packages/feature_iptv/test/presentation/screens/iptv_screen_ten_foot_fullscreen_test.dart
+++ b/packages/feature_iptv/test/presentation/screens/iptv_screen_ten_foot_fullscreen_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -160,6 +162,100 @@ void main() {
             'a television must never be asked to rotate to portrait — '
             'seen on Fire TV Stick: display flipped to 1080x1920 after '
             'exiting the full player',
+      );
+    },
+  );
+
+  testWidgets(
+    'tenFootMode: the D-pad still reaches the player after rebuilds while '
+    'fullscreen (regression: an outer focus node re-requested focus on '
+    'every build, permanently stealing it back from the player once live '
+    'playback started rebuilding for buffering/position updates)',
+    (tester) async {
+      tester.view.physicalSize = const Size(960, 540);
+      tester.view.devicePixelRatio = 1;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      final played = <IPTVChannel>[];
+      final stateController = StreamController<StreamingState>.broadcast();
+      addTearDown(stateController.close);
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            iptvChannelsProvider.overrideWith((ref) async => _channels),
+            recentlyWatchedChannelsProvider.overrideWith(
+              (ref) async => const [],
+            ),
+            streamingStateProvider.overrideWith(
+              (ref) => stateController.stream,
+            ),
+            iptvStreamingServiceProvider.overrideWith((ref) {
+              final service = _RecordingStreamingService(played: played);
+              ref.onDispose(service.dispose);
+              return service;
+            }),
+          ],
+          child: const MaterialApp(home: IPTVScreen(tenFootMode: true)),
+        ),
+      );
+      await tester.pump();
+      stateController.add(
+        StreamingState(playbackState: PlaybackState.idle, isLiveStream: true),
+      );
+      await tester.pump();
+
+      await tester.tap(find.text('Channel One'));
+      await tester.pump(const Duration(milliseconds: 400));
+      stateController.add(
+        StreamingState(
+          playbackState: PlaybackState.playing,
+          isLiveStream: true,
+          currentChannel: _channels.single,
+        ),
+      );
+      await tester.pump(const Duration(milliseconds: 400));
+
+      // The player only organically claims focus from the outer Back-only
+      // node once its own controls-auto-hide timer fires and calls
+      // requestFocus() (VideoPlayerWidget._controlsHideDelay = 4s) -- so
+      // clear that first, same as real playback would.
+      await tester.pump(const Duration(seconds: 5));
+
+      // Now simulate the rebuilds live playback drives constantly once a
+      // channel is playing (buffering/position/quality updates) -- exactly
+      // what used to let the outer Back-only focus node re-request and
+      // steal focus back from the player on every single one of them.
+      for (var i = 0; i < 5; i++) {
+        stateController.add(
+          StreamingState(
+            playbackState: PlaybackState.playing,
+            isLiveStream: true,
+            currentChannel: _channels.single,
+            position: Duration(seconds: i),
+          ),
+        );
+        await tester.pump(const Duration(milliseconds: 50));
+      }
+
+      expect(
+        find.text('Channel One'),
+        findsWidgets,
+        reason:
+            'sanity check: the streamed state must have actually '
+            'propagated before testing the key event',
+      );
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowUp);
+      await tester.pump();
+
+      expect(
+        find.text('Mini guide'),
+        findsOneWidget,
+        reason:
+            'Up must still reach the player\'s TvInputHandler after '
+            'several rebuilds, not just on the first frame of fullscreen',
       );
     },
   );


### PR DESCRIPTION
## Summary
Root-caused and fixed the long-standing, previously-flagged-but-never-diagnosed bug: **D-pad unresponsive after entering fullscreen**. Confirmed live on a Fire TV Stick (rebuilt + reinstalled from this branch) — before the fix, every D-pad key except Back silently did nothing in fullscreen (Up/Mini Guide, Select, MENU all dead), while touch taps still worked. After the fix: Up opens Mini Guide, Back closes correctly, playback unaffected.

**Root cause**: `IPTVScreen` wraps the fullscreen `VideoPlayerWidget` in an outer `Focus` node whose only job is Back/Escape (`_handleFullscreenKey` ignores every other key). Its `postFrameCallback` called `_fullscreenFocusNode.requestFocus()` **unconditionally on every single build** while fullscreen — not just on entry. Live playback rebuilds constantly (buffering, position, cast state), so on real hardware this fired repeatedly, yanking focus back to the Back-only node the moment `VideoPlayerWidget`'s own controls-auto-hide timer (4s) handed it to the player's `TvInputHandler`. Since Flutter key events only walk from the focused node up through ancestors, once the outer node held focus, every other key routed to `_handleFullscreenKey`, got silently ignored, and never reached the player.

**Fix**: guard the `postFrameCallback` to fire once per fullscreen entry (reset on exit), in both `_IPTVScreenState` and `_IPTVScreenBodyState` (duplicated logic, same bug in both).

## Test plan
- [x] `flutter analyze` clean
- [x] New regression test modeling the real timing (auto-hide timer + repeated rebuilds): confirmed **fails against the pre-fix code** and passes with the fix
- [x] All existing `iptv_screen*` tests pass (34 total, including the existing "system Back exits fullscreen playback before popping the app" and "exiting fullscreen never rotates the TV to portrait" tests)
- [x] **Live device verification on Fire TV Stick**: rebuilt debug APK from this branch, reinstalled, played Vevo Pop fullscreen, confirmed Up opens Mini Guide and Back works — both dead before the fix on the same device/build

🤖 Generated with [Claude Code](https://claude.com/claude-code)