### PR TITLE
fix(iptv): make player sheets, error retry, and favorite banner D-pad reachable

### DIFF
--- a/packages/feature_iptv/lib/presentation/widgets/favorite_reimport_review_banner.dart
+++ b/packages/feature_iptv/lib/presentation/widgets/favorite_reimport_review_banner.dart
@@ -1,3 +1,4 @@
+import 'package:core_ui/core_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
@@ -45,19 +46,27 @@ class FavoriteReimportReviewBanner extends ConsumerWidget {
                       '"${candidate.candidate.name}" now. Keep as favorite?',
                     ),
                   ),
-                  TextButton(
-                    key: ValueKey(
-                      'favorite-reimport-accept-${candidate.oldChannel.id}',
+                  TvFocusable(
+                    semanticLabel: 'Keep as favorite',
+                    onSelect: () => _accept(ref, candidate),
+                    child: TextButton(
+                      key: ValueKey(
+                        'favorite-reimport-accept-${candidate.oldChannel.id}',
+                      ),
+                      onPressed: () => _accept(ref, candidate),
+                      child: const Text('Keep'),
                     ),
-                    onPressed: () => _accept(ref, candidate),
-                    child: const Text('Keep'),
                   ),
-                  TextButton(
-                    key: ValueKey(
-                      'favorite-reimport-dismiss-${candidate.oldChannel.id}',
+                  TvFocusable(
+                    semanticLabel: 'Dismiss',
+                    onSelect: () => _dismiss(ref, candidate),
+                    child: TextButton(
+                      key: ValueKey(
+                        'favorite-reimport-dismiss-${candidate.oldChannel.id}',
+                      ),
+                      onPressed: () => _dismiss(ref, candidate),
+                      child: const Text('Dismiss'),
                     ),
-                    onPressed: () => _dismiss(ref, candidate),
-                    child: const Text('Dismiss'),
                   ),
                 ],
               ),

--- a/packages/feature_iptv/lib/presentation/widgets/video_player_widget.dart
+++ b/packages/feature_iptv/lib/presentation/widgets/video_player_widget.dart
@@ -1189,22 +1189,15 @@ class _VideoPlayerWidgetState extends ConsumerState<VideoPlayerWidget> {
                 overflow: TextOverflow.ellipsis,
               ),
               const SizedBox(height: 24),
-              // Retry button with better styling
-              ElevatedButton.icon(
-                onPressed: () => ref.read(iptvStreamingServiceProvider).retry(),
-                icon: const Icon(Icons.refresh_rounded),
-                label: const Text('Try Again'),
-                style: ElevatedButton.styleFrom(
-                  backgroundColor: Colors.blueGrey.shade700,
-                  foregroundColor: Colors.white,
-                  padding: const EdgeInsets.symmetric(
-                    horizontal: 24,
-                    vertical: 12,
-                  ),
-                  shape: RoundedRectangleBorder(
-                    borderRadius: BorderRadius.circular(8),
-                  ),
-                ),
+              // TvFocusable-wrapped so a remote-only viewer can reach it --
+              // the bare ElevatedButton this replaced was the same class of
+              // bug already fixed for the diagnostic error screen below.
+              _RecoveryActionButton(
+                key: const ValueKey('iptv-player-error-retry'),
+                icon: Icons.refresh_rounded,
+                label: 'Try Again',
+                autofocus: true,
+                onSelect: () => ref.read(iptvStreamingServiceProvider).retry(),
               ),
               const SizedBox(height: 12),
               // Hint text
@@ -1940,27 +1933,28 @@ class _VideoPlayerWidgetState extends ConsumerState<VideoPlayerWidget> {
                 subtitle: Text('Secondary controls for this stream'),
               ),
               if (widget.showPictureInPicture)
-                ListTile(
-                  key: const ValueKey('iptv-player-pip-menu-action'),
+                _TvSheetListTile(
+                  itemKey: const ValueKey('iptv-player-pip-menu-action'),
                   leading: const Icon(Icons.picture_in_picture_alt_outlined),
                   title: const Text('Picture-in-picture'),
-                  onTap: () => unawaited(afterSheet(_requestPictureInPicture)),
+                  onSelect: () =>
+                      unawaited(afterSheet(_requestPictureInPicture)),
                 ),
               if (hasQualityChoices)
-                ListTile(
-                  key: const ValueKey('iptv-player-quality-menu-action'),
+                _TvSheetListTile(
+                  itemKey: const ValueKey('iptv-player-quality-menu-action'),
                   leading: const Icon(Icons.hd_outlined),
                   title: const Text('Quality'),
                   subtitle: Text(state.currentQuality.label),
-                  onTap: () => unawaited(
+                  onSelect: () => unawaited(
                     afterSheet(
                       () => _showQualitySelector(context, service, state),
                     ),
                   ),
                 ),
               if (hasSubtitles)
-                ListTile(
-                  key: const ValueKey('iptv-player-subtitle-menu-action'),
+                _TvSheetListTile(
+                  itemKey: const ValueKey('iptv-player-subtitle-menu-action'),
                   leading: Icon(
                     state.selectedTrackIds.containsKey(
                           AiroPlaybackTrackKind.subtitle,
@@ -1969,25 +1963,29 @@ class _VideoPlayerWidgetState extends ConsumerState<VideoPlayerWidget> {
                         : Icons.subtitles_off_outlined,
                   ),
                   title: const Text('Subtitles'),
-                  onTap: () => unawaited(
+                  onSelect: () => unawaited(
                     afterSheet(
                       () => _showTrackSelector(context, service, state),
                     ),
                   ),
                 ),
-              ListTile(
-                key: const ValueKey('iptv-player-audio-only-menu-action'),
+              _TvSheetListTile(
+                itemKey: const ValueKey('iptv-player-audio-only-menu-action'),
+                // Always rendered regardless of PiP/quality/subtitles
+                // availability, so it's the one deterministic focus target
+                // this sheet can always autofocus.
+                autofocus: true,
                 leading: Icon(
                   _isAudioOnly ? Icons.hearing : Icons.hearing_disabled,
                 ),
                 title: Text(_isAudioOnly ? 'Exit audio-only' : 'Listen only'),
-                onTap: () => unawaited(afterSheet(_toggleAudioOnly)),
+                onSelect: () => unawaited(afterSheet(_toggleAudioOnly)),
               ),
-              ListTile(
-                key: const ValueKey('iptv-player-aspect-ratio-menu-action'),
+              _TvSheetListTile(
+                itemKey: const ValueKey('iptv-player-aspect-ratio-menu-action'),
                 leading: const Icon(Icons.aspect_ratio),
                 title: const Text('Aspect ratio'),
-                onTap: () => unawaited(
+                onSelect: () => unawaited(
                   afterSheet(
                     () => ref
                         .read(videoAspectRatioProvider.notifier)
@@ -1995,23 +1993,23 @@ class _VideoPlayerWidgetState extends ConsumerState<VideoPlayerWidget> {
                   ),
                 ),
               ),
-              ListTile(
-                key: const ValueKey('iptv-player-cinema-menu-action'),
+              _TvSheetListTile(
+                itemKey: const ValueKey('iptv-player-cinema-menu-action'),
                 leading: Icon(_isCinemaMode ? Icons.wb_sunny : Icons.theaters),
                 title: Text(_isCinemaMode ? 'Standard mode' : 'Cinema mode'),
-                onTap: () => unawaited(
+                onSelect: () => unawaited(
                   afterSheet(
                     () => setState(() => _isCinemaMode = !_isCinemaMode),
                   ),
                 ),
               ),
-              ListTile(
-                key: const ValueKey('iptv-player-fullscreen-menu-action'),
+              _TvSheetListTile(
+                itemKey: const ValueKey('iptv-player-fullscreen-menu-action'),
                 leading: Icon(
                   _isFullscreen ? Icons.fullscreen_exit : Icons.fullscreen,
                 ),
                 title: Text(_isFullscreen ? 'Exit fullscreen' : 'Fullscreen'),
-                onTap: () => unawaited(afterSheet(_toggleFullscreen)),
+                onSelect: () => unawaited(afterSheet(_toggleFullscreen)),
               ),
             ],
           ),
@@ -2123,33 +2121,64 @@ class _VideoPlayerWidgetState extends ConsumerState<VideoPlayerWidget> {
     showModalBottomSheet<void>(
       context: context,
       builder: (context) {
+        final noneSelected = state.selectedTrackIds[kind] == null;
+        // Autofocus the selected row; if nothing is selected and there's
+        // no "Off" row to fall back to, autofocus the first track so the
+        // sheet is never opened with nothing D-pad-focused.
+        final autofocusOff = offLabel != null && noneSelected;
         return SafeArea(
           child: ListView(
             shrinkWrap: true,
             children: [
               if (offLabel != null)
-                ListTile(
-                  leading: offIcon == null ? null : Icon(offIcon),
-                  title: Text(offLabel),
-                  trailing: state.selectedTrackIds[kind] == null
-                      ? const Icon(Icons.check)
-                      : null,
-                  onTap: () {
+                TvFocusable(
+                  autofocus: autofocusOff,
+                  semanticLabel: offLabel,
+                  onSelect: () {
                     service.clearTrackSelection(kind);
                     Navigator.of(context).pop();
                   },
+                  child: ListTile(
+                    leading: offIcon == null ? null : Icon(offIcon),
+                    title: Text(offLabel),
+                    trailing: noneSelected ? const Icon(Icons.check) : null,
+                    onTap: () {
+                      service.clearTrackSelection(kind);
+                      Navigator.of(context).pop();
+                    },
+                  ),
                 ),
-              for (final track in tracks)
-                ListTile(
-                  title: Text(track.label),
-                  subtitle: track.isExternal ? const Text('External') : null,
-                  trailing: state.selectedTrackIds[track.kind] == track.id
-                      ? const Icon(Icons.check)
-                      : null,
-                  onTap: () {
-                    service.selectTrack(kind: track.kind, trackId: track.id);
+              for (var i = 0; i < tracks.length; i++)
+                TvFocusable(
+                  autofocus:
+                      !autofocusOff &&
+                      (state.selectedTrackIds[tracks[i].kind] == tracks[i].id ||
+                          (noneSelected && offLabel == null && i == 0)),
+                  semanticLabel: tracks[i].label,
+                  onSelect: () {
+                    service.selectTrack(
+                      kind: tracks[i].kind,
+                      trackId: tracks[i].id,
+                    );
                     Navigator.of(context).pop();
                   },
+                  child: ListTile(
+                    title: Text(tracks[i].label),
+                    subtitle: tracks[i].isExternal
+                        ? const Text('External')
+                        : null,
+                    trailing:
+                        state.selectedTrackIds[tracks[i].kind] == tracks[i].id
+                        ? const Icon(Icons.check)
+                        : null,
+                    onTap: () {
+                      service.selectTrack(
+                        kind: tracks[i].kind,
+                        trackId: tracks[i].id,
+                      );
+                      Navigator.of(context).pop();
+                    },
+                  ),
                 ),
             ],
           ),
@@ -2172,12 +2201,13 @@ class _VideoPlayerWidgetState extends ConsumerState<VideoPlayerWidget> {
             shrinkWrap: true,
             children: [
               for (final quality in options)
-                ListTile(
+                _TvSheetListTile(
                   title: Text(quality.label),
+                  autofocus: state.selectedQuality == quality,
                   trailing: state.selectedQuality == quality
                       ? const Icon(Icons.check)
                       : null,
-                  onTap: () {
+                  onSelect: () {
                     service.setQuality(quality);
                     Navigator.of(context).pop();
                   },
@@ -2892,6 +2922,46 @@ class _ContextMenuItem extends StatelessWidget {
 /// A D-pad-reachable recovery action for [_buildDiagnosticError] --
 /// TvFocusable-wrapped so remote-only viewers (no touch input) can actually
 /// reach it, unlike a bare ElevatedButton.
+/// A D-pad-reachable row for the player-actions / track-selector bottom
+/// sheets -- wraps a [ListTile] in [TvFocusable] so a remote-only viewer
+/// can actually reach it. Bare [ListTile]s in these sheets were previously
+/// unreachable by D-pad despite the buttons that open them being focusable.
+class _TvSheetListTile extends StatelessWidget {
+  const _TvSheetListTile({
+    this.itemKey,
+    this.leading,
+    required this.title,
+    this.subtitle,
+    this.trailing,
+    required this.onSelect,
+    this.autofocus = false,
+  });
+
+  final Key? itemKey;
+  final Widget? leading;
+  final Widget title;
+  final Widget? subtitle;
+  final Widget? trailing;
+  final VoidCallback onSelect;
+  final bool autofocus;
+
+  @override
+  Widget build(BuildContext context) {
+    return TvFocusable(
+      autofocus: autofocus,
+      onSelect: onSelect,
+      child: ListTile(
+        key: itemKey,
+        leading: leading,
+        title: title,
+        subtitle: subtitle,
+        trailing: trailing,
+        onTap: onSelect,
+      ),
+    );
+  }
+}
+
 class _RecoveryActionButton extends StatelessWidget {
   const _RecoveryActionButton({
     super.key,

--- a/packages/feature_iptv/test/iptv/presentation/widgets/video_player_widget_test.dart
+++ b/packages/feature_iptv/test/iptv/presentation/widgets/video_player_widget_test.dart
@@ -1,3 +1,4 @@
+import 'package:core_ui/core_ui.dart';
 import 'package:feature_iptv/feature_iptv.dart';
 import 'package:feature_iptv/presentation/widgets/player_brightness_controller.dart';
 import 'package:feature_iptv/presentation/widgets/player_gesture_overlay.dart';
@@ -1098,6 +1099,82 @@ void main() {
       expect(find.text('Switching to source 2 of 2'), findsOneWidget);
     },
   );
+
+  // Regression: the player-actions sheet and the audio/subtitle/quality
+  // selectors it opens were bare ListTiles with no TvFocusable -- reachable
+  // by touch but invisible to D-pad focus traversal, so a remote-only
+  // viewer who opened the sheet (via the TvFocusable "more" button) hit a
+  // dead end once inside it.
+  testWidgets('player-actions sheet rows and the selectors they open are all '
+      'D-pad-reachable (TvFocusable)', (tester) async {
+    final engine = FakeAiroPlaybackEngine(
+      tracks: const [
+        AiroPlaybackTrackOption(
+          id: 'external_sub_0',
+          kind: AiroPlaybackTrackKind.subtitle,
+          label: 'English',
+          isExternal: true,
+        ),
+      ],
+    );
+    final service = VideoPlayerStreamingService(engine: engine);
+    addTearDown(service.dispose);
+    SharedPreferences.setMockInitialValues({});
+    final prefs = await SharedPreferences.getInstance();
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          sharedPreferencesProvider.overrideWithValue(prefs),
+          iptvStreamingServiceProvider.overrideWithValue(service),
+        ],
+        child: const MaterialApp(home: Scaffold(body: VideoPlayerWidget())),
+      ),
+    );
+    await tester.pump();
+
+    await service.playChannel(
+      IPTVChannel(id: 'c1', name: 'Chan', streamUrl: 'https://x/y.m3u8'),
+    );
+    await tester.pump();
+
+    await tester.tap(find.byKey(const ValueKey('iptv-player-more-button')));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 300));
+
+    for (final key in [
+      'iptv-player-subtitle-menu-action',
+      'iptv-player-audio-only-menu-action',
+      'iptv-player-aspect-ratio-menu-action',
+      'iptv-player-cinema-menu-action',
+      'iptv-player-fullscreen-menu-action',
+    ]) {
+      await tester.ensureVisible(find.byKey(ValueKey(key)));
+      await tester.pump();
+      expect(
+        find.ancestor(
+          of: find.byKey(ValueKey(key)),
+          matching: find.byType(TvFocusable),
+        ),
+        findsOneWidget,
+        reason: '$key must be a TvFocusable so a remote can reach it',
+      );
+    }
+
+    await tester.tap(
+      find.byKey(const ValueKey('iptv-player-subtitle-menu-action')),
+    );
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 300));
+
+    expect(
+      find.ancestor(of: find.text('Off'), matching: find.byType(TvFocusable)),
+      findsOneWidget,
+      reason: 'the subtitle selector\'s "Off" row must be a TvFocusable too',
+    );
+
+    await service.stop();
+  });
 }
 
 class _RecordingSeekStreamingService extends VideoPlayerStreamingService {


### PR DESCRIPTION
## Summary
- Bare `ListTile`/`ElevatedButton`/`TextButton` rows in TV-reachable UI had no `TvFocusable` wrapper, so a remote-only viewer could open the surface but never select an item on it.
- `video_player_widget.dart`: player-actions sheet (PiP, quality, subtitles, audio-only, aspect ratio, cinema, fullscreen), track selector sheet (subtitle/audio "Off" + per-track rows, autofocus on current selection), quality selector rows, playback-error retry button (now reuses `_RecoveryActionButton`). Added `_TvSheetListTile` to cut the repeated `TvFocusable`+`ListTile` boilerplate.
- `favorite_reimport_review_banner.dart`: "Keep" / "Dismiss" buttons — shared by both mobile and TV favorites screens.
- Two other findings from the same audit (`IptvTvScreen` / `_TvSearchDialog` in `iptv_tv_screen.dart`) were confirmed dead code — never instantiated outside their own file — and left alone.

## Test plan
- [x] New regression test: player-actions sheet rows and the subtitle selector's "Off" row are each wrapped in `TvFocusable`.
- [x] `flutter analyze` clean (2 pre-existing unrelated infos only).
- [x] Full `feature_iptv` suite: 728 passed, 0 failed.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>