### PR TITLE
fix(playback): stop fabricating hardwareAccelerated:true in TV diagnostics

### DIFF
--- a/packages/platform_media/lib/src/video_player_airo_playback_engine.dart
+++ b/packages/platform_media/lib/src/video_player_airo_playback_engine.dart
@@ -117,7 +117,14 @@ class VideoPlayerAiroPlaybackEngine implements AiroPlaybackEngine {
         tracks: externalSubtitleTracksFor(request),
         diagnostics: AiroPlaybackDiagnostics(
           backendId: backendKind.stableId,
-          hardwareAccelerated: true,
+          // The video_player plugin doesn't expose which decode path
+          // ExoPlayer actually chose -- it auto-selects hardware vs.
+          // software per-codec with no signal surfaced to this layer.
+          // hardwareAccelerated stays null (unknown) rather than a
+          // fabricated true, since a diagnostic value someone might use
+          // to debug a decode problem must not lie about the one thing
+          // it's meant to report.
+          hardwareAccelerated: null,
         ),
       ),
     );

--- a/packages/platform_media/test/video_player_airo_playback_engine_test.dart
+++ b/packages/platform_media/test/video_player_airo_playback_engine_test.dart
@@ -187,17 +187,19 @@ void main() {
       },
     );
 
-    test(
-      'diagnostics reports hardware-accelerated after a successful open',
-      () async {
-        final engine = VideoPlayerAiroPlaybackEngine();
-        await engine.open(request());
+    test('diagnostics reports hardwareAccelerated as unknown (null), never a '
+        'fabricated value', () async {
+      // video_player exposes no signal for which decode path ExoPlayer
+      // actually chose -- reporting a hardcoded true would be a fake
+      // diagnostic value someone could use to wrongly rule out a
+      // software-decode-related bug.
+      final engine = VideoPlayerAiroPlaybackEngine();
+      await engine.open(request());
 
-        final diagnostics = await engine.diagnostics();
-        expect(diagnostics.hardwareAccelerated, isTrue);
-        await engine.dispose();
-      },
-    );
+      final diagnostics = await engine.diagnostics();
+      expect(diagnostics.hardwareAccelerated, isNull);
+      await engine.dispose();
+    });
 
     test('buildView is null before open, non-null after', () async {
       final engine = VideoPlayerAiroPlaybackEngine();


### PR DESCRIPTION
## Summary
Follow-up from the "hardware-decode toggle" pending item. Investigation found no real toggle is buildable: `video_player`/ExoPlayer expose no signal for which decode path was chosen, and building one requires the same native platform-channel work already parked alongside buffer tuning and ABR (see `docs/superpowers/specs/2026-07-27-native-buffer-tuning-parked-research.md`).

What was real and worth fixing: `AiroPlaybackDiagnostics.hardwareAccelerated` is already a nullable `bool?`, modeling exactly this "unknown" case — but `VideoPlayerAiroPlaybackEngine` hardcoded it to `true` unconditionally regardless of what actually happened. A diagnostic value meant to help debug decode problems must not fabricate the one thing it's supposed to report. Changed to `null`.

Out of scope: `MediaKitMpvPlayerFacade`'s similar hardcode — mpv isn't the TV's engine (excluded from TV builds per the CV-030 decision) and mpv can plausibly query its real hwdec state via a documented property, unlike `video_player`. Left alone; noted here for whoever picks up ABR/engine work next.

## Test plan
- [x] `flutter test test/video_player_airo_playback_engine_test.dart` — 25/25 pass; updated the one test that previously asserted the fabricated `true`
- [x] Swept `platform_media`/`feature_iptv` for any other consumer of this field — none found (no UI renders it)
- [x] `flutter analyze` on touched files — clean
- [x] `dart format --output=none --set-exit-if-changed` — clean