### PR TITLE
docs: revise Phase 1 Vault plan against council review (revision 2)

### DIFF
--- a/docs/superpowers/plans/2026-07-27-airo-mind-phase-1-vault.md
+++ b/docs/superpowers/plans/2026-07-27-airo-mind-phase-1-vault.md
@@ -11,9 +11,37 @@
 **Spec:** `docs/superpowers/specs/2026-07-27-airo-mind-runtime-design.md` §4, §6
 **Issues:** #1204 (scaffold), #1205 (governance), #1207–#1212 (Vault tasks), under epic #1193.
 
+> **Revision 2 (2026-07-27).** Rewritten after the chief-security-officer and
+> chief-open-source-officer reviews on PR #1239. Fifteen security findings
+> (R1–R15) and the OSS caveats are applied throughout. Two structural changes:
+> FFI is out of Phase 1 entirely, and the revocation ledger now carries tagged
+> subjects. Do not implement from revision 1.
+
 ## Global Constraints
 
-- **No FFI in this phase.** `rust/airo_mind` is pure Rust with unit tests. FRB bindings are Task 9 and emit to `packages/core_native/lib/src/mind/` only — Constitution §2 confines all FFI to `core_native`.
+- **No FFI in this phase, at all.** `rust/airo_mind` is pure Rust with unit
+  tests and ships `rlib` only. Both reviews landed here independently: OSS
+  found that declaring `cdylib`/`staticlib` on a crate with no exports links
+  two empty artifacts on every CI push, and security found that the FFI
+  boundary was the *only* place the stale-restore hole was exposed. Bindings
+  move to Phase 2, when there is an operation log worth exposing. Tracked on
+  #1259.
+- **No panics — and `fill_bytes` panics.** `RngCore::fill_bytes` and
+  `AeadCore::generate_nonce` abort the process when the OS RNG fails. Use
+  `try_fill_bytes` and map into `VaultError::RngUnavailable`. Early-boot
+  entropy failure on Android is rare but real, and a panic in the
+  key-generation path of a medical-records vault is the wrong failure mode.
+- **`serde_json` output must never become signed or hashed bytes.** Float
+  formatting and escape choices are not version-stable across library
+  versions. Signing payloads are hand-built, length-prefixed, and
+  domain-separated. If a later phase needs to sign a serialized structure the
+  answer is a fixed binary encoding, never a lighter JSON library. Write this
+  into `lib.rs` module docs beside the `BTreeMap`-not-`HashMap` rule.
+- **Secrets do not derive `Debug`, `Clone`, or `PartialEq`.** `Debug` prints
+  key bytes into panic messages and logs. `Clone` silently duplicates material
+  whose custody is supposed to be singular. Derived `PartialEq` is not
+  constant-time. Where equality is genuinely needed, implement it via
+  `subtle::ConstantTimeEq`.
 - **Never add `airo_mind` to `airo_core`.** Separate workspace member. `airo_core` is on the Airo TV shipping critical path and must not gain crypto or storage dependencies.
 - **CI runs `cargo test --all`, `cargo clippy --all -- -D warnings`, `cargo fmt --check`** across `rust/Cargo.toml` (`.github/workflows/rust-core.yml`). A new workspace member is covered automatically. Clippy warnings fail the build.
 - **No panics.** Every fallible path returns `Result<_, VaultError>`. `unwrap()` and `expect()` are permitted in `#[cfg(test)]` only.
@@ -56,30 +84,77 @@ One responsibility per file. `mod.rs` holds only the `Vault` aggregate and re-ex
 
 - [ ] **Step 1: File scorecards**
 
-Score each on license, maintenance, security history, binary impact, bus factor:
+**Review complete.** Both officers have reported on #1205. **No crate was
+rejected.** Eleven crates, with the caveats below already folded into Task 1's
+manifest.
 
-| Crate | Version | Purpose |
+| Crate | Version | Verdict |
 |---|---|---|
-| `ed25519-dalek` | `2` | Root and device signing |
-| `chacha20poly1305` | `0.10` | XChaCha20-Poly1305 AEAD for key wrapping |
-| `hkdf` | `0.12` | Seed → key derivation |
-| `sha2` | `0.10` | HKDF hash |
-| `bip39` | `2` | Recovery mnemonic |
-| `zeroize` | `1` | Secret hygiene |
-| `rand_core` | `0.6` | CSPRNG interface (`getrandom` feature) |
-| `thiserror` | `2` | Error types |
-| `serde` | `1` | Vault serialization |
-| `serde_json` | `1` | Vault serialization |
+| `chacha20poly1305` | `0.10` | approve |
+| `hkdf` | `0.12` | approve |
+| `sha2` | `0.10` | approve |
+| `zeroize` | `1` | approve |
+| `thiserror` | `2` | approve |
+| `serde` | `1` | approve |
+| `serde_json` | `1` | approve — see the signing-bytes constraint above |
+| `subtle` | `2` | approve — added by security R9, already transitive |
+| `ed25519-dalek` | `2` | **caveat:** floor `curve25519-dalek` at `>=4.1.3` |
+| `rand_core` | `0.6` | **caveat:** forced by the two above; migration issue required |
+| `bip39` | `2` | **caveat:** feature changes + a CC0 decision |
 
-- [ ] **Step 2: Obtain chief-open-source-officer sign-off**
+Version choice was validated as correct: `sha2 0.10` + `hkdf 0.12` share the
+`digest 0.10` generation `flutter_rust_bridge` already pulls in. Moving to
+`sha2 0.11` / `hkdf 0.13` would fork `digest` across two majors workspace-wide.
 
-Run the `chief-open-source-officer` agent against the scorecards. Cryptographic crate selection is a chief-security-officer decision, not the implementer's — if the officer rejects a crate, stop and revise this plan rather than substituting one yourself.
+Measured binary impact: **+408 KB** stripped with `opt-level="z"` + fat LTO,
+against a 4096 KB per-dependency budget. `serde` + `serde_json` are 16.4 KB of
+that — which is why the OSS officer explicitly **rejected** replacing them.
 
-- [ ] **Step 3: Record the outcome on #1205**
+- [ ] **Step 1: Apply the `curve25519-dalek` floor**
 
-Comment the verdict per crate on issue #1205 and close it when all ten are cleared.
+RUSTSEC-2024-0344 was a timing-variability fix in `Scalar29`/`Scalar52`
+subtraction, and `4.1.3` is exactly the patched release — the current
+resolution sits on the boundary with no headroom. Add an explicit floor and
+verify with `cargo tree -p curve25519-dalek`.
 
-**Do not start Task 1 until this task is closed.**
+- [ ] **Step 2: Add the BSD-3-Clause notice**
+
+`ed25519-dalek`, `curve25519-dalek`, and `subtle` are BSD-3-Clause with no dual
+option. MIT-compatible, but binary distribution requires attribution and the
+non-endorsement clause. A BSD-3-Clause slot already exists in
+`docs/release/V2_THIRD_PARTY_NOTICES.md` — append, do not invent a mechanism.
+
+- [ ] **Step 3: Resolve the CC0 question — needs a decision before Task 2**
+
+`bip39`, `bitcoin_hashes`, and `hex-conservative` are **CC0-1.0**: not
+OSI-approved, and §4(a) expressly reserves the author's patent rights. Google's
+own OSS policy bans CC0 for code. This is the crate that generates the recovery
+secret for medical and financial records.
+
+Both paths are approved; pick one and record it on #1205.
+
+- **Path A — accept.** Record the exception in `V2_THIRD_PARTY_NOTICES.md` with
+  the patent non-grant noted, plus chief-security-officer sign-off. Task 2
+  proceeds as written.
+- **Path B — implement BIP-39 in-house.** ~200 lines: English wordlist +
+  PBKDF2-HMAC-SHA512 at 2048 iterations, on the `sha2`/`hmac` already in the
+  tree. Spec and wordlist are public domain, and Task 2 already pins a known
+  test vector, so the implementation is verifiable against the same assertion.
+  Removes five crates. Task 2's tests stay unchanged; only the internals move.
+
+`tiny-bip39` was evaluated and **rejected** — it trades a license concern for a
+worse bus factor.
+
+- [ ] **Step 4: Open the `rand_core` migration issue**
+
+`rand_core 0.6` is forced by `ed25519-dalek 2` and `chacha20poly1305 0.10`, but
+it places the crate on the maintenance-mode `0.6` / `getrandom 0.2` generation.
+The migration is coupled: `ed25519-dalek 3` + `chacha20poly1305 0.11` +
+`rand_core 0.10` move together or not at all. File it dated, do not do it now.
+
+- [ ] **Step 5: Close #1205**
+
+**Do not start Task 1 until Step 3 is decided.**
 
 ---
 
@@ -131,6 +206,28 @@ pub enum VaultError {
 
     #[error("serialization failed")]
     SerializationFailed,
+
+    /// The OS random number generator failed.
+    ///
+    /// Rare, but real during early boot on Android. `RngCore::fill_bytes`
+    /// panics in this situation; every call site must use `try_fill_bytes` and
+    /// surface this instead.
+    #[error("system random number generator unavailable")]
+    RngUnavailable,
+
+    /// The recovery package's vault does not belong to the supplied seed.
+    ///
+    /// Either a bug or a crafted package. Restoring anyway would produce a
+    /// vault that trusts device certificates signed by a root the user does
+    /// not control.
+    #[error("recovery package does not belong to this identity")]
+    IdentityMismatch,
+
+    #[error("content `{0}` not found")]
+    ContentNotFound(String),
+
+    #[error("device `{0}` not found")]
+    DeviceNotFound(String),
 }
 
 #[cfg(test)]
@@ -170,17 +267,31 @@ license = "MIT"
 
 [lib]
 name = "airo_mind"
-crate-type = ["cdylib", "staticlib", "rlib"]
+# rlib only. This crate exports nothing across FFI in Phase 1, and declaring
+# cdylib/staticlib links two empty artifacts on every CI push.
+crate-type = ["rlib"]
 
 [dependencies]
-bip39 = { version = "2", features = ["rand"] }
-chacha20poly1305 = "0.10"
-ed25519-dalek = { version = "2", features = ["rand_core"] }
+# `rand` feature deliberately OFF: Mnemonic::from_entropy works without it, and
+# dropping it removes four crates and leaves ONE CSPRNG stack rather than two,
+# with an entropy buffer we own and can zeroize.
+# `zeroize` feature ON: without it the mnemonic's word indices are never wiped —
+# on the single most sensitive object in the design.
+bip39 = { version = "2", default-features = false, features = ["std", "zeroize"] }
+chacha20poly1305 = { version = "0.10", features = ["getrandom"] }
+# Explicit feature pinning, not defaults. `zeroize` is what keeps the root
+# private key out of freed memory; someone adding default-features = false for
+# binary size later would silently remove it.
+ed25519-dalek = { version = "2", default-features = false, features = ["std", "rand_core", "zeroize"] }
+# RUSTSEC-2024-0344: timing variability in Scalar29/Scalar52 subtraction.
+# 4.1.3 is the patched release. Floored explicitly so a downgrade fails.
+curve25519-dalek = ">=4.1.3"
 hkdf = "0.12"
 rand_core = { version = "0.6", features = ["getrandom"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sha2 = "0.10"
+subtle = "2"
 thiserror = "2"
 zeroize = { version = "1", features = ["derive"] }
 ```
@@ -202,6 +313,65 @@ Create `rust/airo_mind/src/lib.rs`:
 pub mod vault;
 ```
 
+Create `rust/airo_mind/src/vault/domain.rs` — the domain-separation registry
+(security R11):
+
+```rust
+//! Every domain-separation string in the crate, in one place.
+//!
+//! The two original strings happened not to be prefixes of one another. That
+//! was luck, not construction. A registry plus the test below makes it
+//! construction: adding `"airo-mind/root"` beside
+//! `"airo-mind/root-identity/v1"` now fails the build rather than silently
+//! weakening separation.
+
+pub const ROOT_IDENTITY: &[u8] = b"airo-mind/root-identity/v1";
+pub const RECOVERY_PACKAGE: &[u8] = b"airo-mind/recovery-package/v1";
+pub const DEVICE_CERTIFICATE: &[u8] = b"airo-mind/device-certificate/v1";
+pub const CONTENT_WRAPPING: &[u8] = b"airo-mind/content-wrapping/v1";
+pub const PACKAGE_HEADER: &[u8] = b"airo-mind/recovery-package-header/v1";
+
+/// Every registered string. Add here when adding a constant above.
+pub const ALL: &[&[u8]] = &[
+    ROOT_IDENTITY,
+    RECOVERY_PACKAGE,
+    DEVICE_CERTIFICATE,
+    CONTENT_WRAPPING,
+    PACKAGE_HEADER,
+];
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn no_domain_string_is_a_prefix_of_another() {
+        for (i, a) in ALL.iter().enumerate() {
+            for (j, b) in ALL.iter().enumerate() {
+                if i == j {
+                    continue;
+                }
+                assert!(
+                    !b.starts_with(a),
+                    "{} is a prefix of {}",
+                    String::from_utf8_lossy(a),
+                    String::from_utf8_lossy(b)
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn every_domain_string_is_versioned() {
+        for s in ALL {
+            let text = String::from_utf8_lossy(s);
+            assert!(text.starts_with("airo-mind/"), "{text} lacks the namespace");
+            assert!(text.ends_with("/v1"), "{text} lacks a version suffix");
+        }
+    }
+}
+```
+
 Create `rust/airo_mind/src/vault/mod.rs`:
 
 ```rust
@@ -210,9 +380,22 @@ Create `rust/airo_mind/src/vault/mod.rs`:
 //! The only mutable, non-append-only store in the system. Everything else is
 //! an append-only log or a projection derived from one.
 
+mod domain;
 mod error;
 
 pub use error::VaultError;
+```
+
+Add a compile-time guard to `rust/airo_mind/src/lib.rs` (security R8). The
+manifest pins `ed25519-dalek`'s `zeroize` feature explicitly; this makes a
+future feature change break the build rather than silently leak the root
+private key into freed memory:
+
+```rust
+const _: fn() = || {
+    fn assert_zeroize_on_drop<T: zeroize::ZeroizeOnDrop>() {}
+    assert_zeroize_on_drop::<ed25519_dalek::SigningKey>();
+};
 ```
 
 Modify `rust/Cargo.toml`:
@@ -261,7 +444,7 @@ Implements the first half of #1207.
 - Consumes: `VaultError` (Task 1)
 - Produces:
   - `Seed` — newtype over `[u8; 64]`, `ZeroizeOnDrop`, with `fn as_bytes(&self) -> &[u8; 64]`
-  - `fn generate_mnemonic() -> String` — 24 words
+  - `fn generate_mnemonic() -> Zeroizing<String>` — 24 words
   - `fn seed_from_mnemonic(phrase: &str) -> Result<Seed, VaultError>`
 
 - [ ] **Step 1: Write the failing test**
@@ -272,12 +455,15 @@ Create `rust/airo_mind/src/vault/seed.rs`:
 //! Recovery seed. The root of everything the user can ever recover.
 
 use bip39::Mnemonic;
-use zeroize::{Zeroize, ZeroizeOnDrop};
+use zeroize::{Zeroize, ZeroizeOnDrop, Zeroizing};
 
 use super::error::VaultError;
 
 /// A 64-byte BIP39 seed. Zeroized on drop.
-#[derive(Clone, Zeroize, ZeroizeOnDrop)]
+///
+/// No `Clone`: the seed is the one secret whose compromise is total and
+/// unrecoverable, and silent duplication is how copies end up unzeroized.
+#[derive(Zeroize, ZeroizeOnDrop)]
 pub struct Seed([u8; 64]);
 
 impl Seed {
@@ -291,10 +477,15 @@ impl Seed {
 /// Shown to the user exactly once. There is no other copy, and no server-side
 /// recovery path — that is the product promise, and it is also the reason the
 /// onboarding flow (#1234) must confirm the user recorded it.
-pub fn generate_mnemonic() -> String {
-    Mnemonic::generate(24)
-        .expect("24 is a valid BIP39 word count")
-        .to_string()
+pub fn generate_mnemonic() -> Zeroizing<String> {
+    // `Zeroizing` because this is the root secret in plaintext. The bip39
+    // `zeroize` feature (pinned in Cargo.toml) covers the Mnemonic's internal
+    // word indices; this covers the String we hand back.
+    Zeroizing::new(
+        Mnemonic::generate(24)
+            .expect("24 is a valid BIP39 word count")
+            .to_string(),
+    )
 }
 
 /// Derives the 64-byte seed from a mnemonic phrase.
@@ -844,12 +1035,37 @@ use zeroize::{Zeroize, ZeroizeOnDrop};
 use super::error::VaultError;
 
 /// A random symmetric key protecting exactly one content object.
-#[derive(Clone, PartialEq, Eq, Debug, Zeroize, ZeroizeOnDrop)]
+///
+/// No `Debug` (would print key bytes into panic messages and logs).
+/// No `Clone` (custody is singular — `Vault::add_content` hands the caller the
+/// only copy). Equality is constant-time, see the `PartialEq` impl below.
+#[derive(Zeroize, ZeroizeOnDrop)]
 pub struct ContentKey([u8; 32]);
 
+impl std::fmt::Debug for ContentKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("ContentKey(<redacted>)")
+    }
+}
+
+/// Constant-time equality.
+///
+/// A derived `PartialEq` short-circuits on the first differing byte, which
+/// leaks key material through timing. Ruled by chief-security-officer over
+/// `#[cfg(test)]`-gating the derive: a cfg-gate reappears the first time a
+/// later phase legitimately needs to compare keys, and it reappears as a
+/// derive.
+impl PartialEq for ContentKey {
+    fn eq(&self, other: &Self) -> bool {
+        self.0.ct_eq(&other.0).into()
+    }
+}
+
+impl Eq for ContentKey {}
+
 impl ContentKey {
-    pub fn generate() -> Self {
-        Self(random_key())
+    pub fn generate() -> Result<Self, VaultError> {
+        Ok(Self(random_key()?))
     }
 
     pub fn as_bytes(&self) -> &[u8; 32] {
@@ -863,15 +1079,25 @@ impl ContentKey {
 }
 
 /// A key held by a context — a hospitalization, a tax year, a project.
+///
+/// `Clone` is retained here, unlike `ContentKey`: the Vault legitimately holds
+/// one context key and hands copies to several wrapping operations. Custody is
+/// the Vault's, and the key never leaves the crate — see `as_bytes`.
 #[derive(Clone, Zeroize, ZeroizeOnDrop)]
 pub struct ContextKey([u8; 32]);
 
 impl ContextKey {
-    pub fn generate() -> Self {
-        Self(random_key())
+    pub fn generate() -> Result<Self, VaultError> {
+        Ok(Self(random_key()?))
     }
 
-    pub fn as_bytes(&self) -> &[u8; 32] {
+    /// `pub(crate)`, deliberately.
+    ///
+    /// The previous revision made this `pub`, handing every context key to any
+    /// consumer of the crate while `to_payload` stayed `pub(crate)` on the
+    /// grounds that "its fields are raw key material". Nothing outside the
+    /// crate needs this.
+    pub(crate) fn as_bytes(&self) -> &[u8; 32] {
         &self.0
     }
 }
@@ -910,10 +1136,17 @@ impl ContentEnvelope {
         context_key: &ContextKey,
     ) -> Result<(), VaultError> {
         let cipher = XChaCha20Poly1305::new(context_key.as_bytes().into());
-        let nonce = XChaCha20Poly1305::generate_nonce(&mut AeadOsRng);
+        let nonce = XNonce::from_slice(&random_nonce()?).to_owned();
+        let aad = wrapping_aad(&self.content_id, context_id);
         let ciphertext = cipher
-            .encrypt(&nonce, content_key.as_bytes().as_slice())
-            .map_err(|_| VaultError::DerivationFailed)?;
+            .encrypt(
+                &nonce,
+                Payload {
+                    msg: content_key.as_bytes().as_slice(),
+                    aad: &aad,
+                },
+            )
+            .map_err(|_| VaultError::EncryptionFailed)?;
 
         self.wrappings.retain(|w| w.context_id != context_id);
         self.wrappings.push(Wrapping {
@@ -951,8 +1184,15 @@ impl ContentEnvelope {
             .try_into()
             .map_err(|_| VaultError::DecryptionFailed)?;
         let cipher = XChaCha20Poly1305::new(context_key.as_bytes().into());
+        let aad = wrapping_aad(&self.content_id, context_id);
         let plaintext = cipher
-            .decrypt(XNonce::from_slice(&nonce_bytes), wrapping.ciphertext.as_slice())
+            .decrypt(
+                XNonce::from_slice(&nonce_bytes),
+                Payload {
+                    msg: wrapping.ciphertext.as_slice(),
+                    aad: &aad,
+                },
+            )
             .map_err(|_| VaultError::DecryptionFailed)?;
         ContentKey::from_slice(&plaintext)
     }
@@ -970,11 +1210,44 @@ impl ContentEnvelope {
     }
 }
 
-fn random_key() -> [u8; 32] {
+/// Binds a wrapping to the exact content object and context that own it.
+///
+/// Without this, `context_id` is plaintext and unauthenticated. Two attacks
+/// follow, both found in review:
+///   1. Relabel a wrapping's `context_id` and `remove_wrapping` no longer
+///      finds it — the wrapping survives an unlink the user was told worked.
+///   2. Move a wrapping verbatim from envelope A to envelope B and it still
+///      unwraps, yielding A's content key under B's context.
+///
+/// Same length-prefixed injective discipline as `DeviceCertificate`.
+fn wrapping_aad(content_id: &str, context_id: &str) -> Vec<u8> {
+    let mut aad = Vec::new();
+    aad.extend_from_slice(domain::CONTENT_WRAPPING);
+    aad.extend_from_slice(&(content_id.len() as u32).to_be_bytes());
+    aad.extend_from_slice(content_id.as_bytes());
+    aad.extend_from_slice(&(context_id.len() as u32).to_be_bytes());
+    aad.extend_from_slice(context_id.as_bytes());
+    aad
+}
+
+/// `try_fill_bytes`, never `fill_bytes` — the latter panics when the OS RNG
+/// fails, in a crate that promises no panics.
+fn random_key() -> Result<[u8; 32], VaultError> {
     use rand_core::RngCore;
     let mut bytes = [0u8; 32];
-    rand_core::OsRng.fill_bytes(&mut bytes);
-    bytes
+    rand_core::OsRng
+        .try_fill_bytes(&mut bytes)
+        .map_err(|_| VaultError::RngUnavailable)?;
+    Ok(bytes)
+}
+
+fn random_nonce() -> Result<[u8; 24], VaultError> {
+    use rand_core::RngCore;
+    let mut bytes = [0u8; 24];
+    rand_core::OsRng
+        .try_fill_bytes(&mut bytes)
+        .map_err(|_| VaultError::RngUnavailable)?;
+    Ok(bytes)
 }
 
 #[cfg(test)]
@@ -983,8 +1256,8 @@ mod tests {
 
     #[test]
     fn content_unwraps_through_the_context_that_wrapped_it() {
-        let content_key = ContentKey::generate();
-        let hospital = ContextKey::generate();
+        let content_key = ContentKey::generate().unwrap();
+        let hospital = ContextKey::generate().unwrap();
         let mut envelope = ContentEnvelope::new("bill-001");
 
         envelope.add_wrapping(&content_key, "hospitalization", &hospital).unwrap();
@@ -995,10 +1268,10 @@ mod tests {
 
     #[test]
     fn one_object_lives_in_many_contexts() {
-        let content_key = ContentKey::generate();
-        let hospital = ContextKey::generate();
-        let finance = ContextKey::generate();
-        let tax = ContextKey::generate();
+        let content_key = ContentKey::generate().unwrap();
+        let hospital = ContextKey::generate().unwrap();
+        let finance = ContextKey::generate().unwrap();
+        let tax = ContextKey::generate().unwrap();
         let mut envelope = ContentEnvelope::new("bill-001");
 
         envelope.add_wrapping(&content_key, "hospitalization", &hospital).unwrap();
@@ -1014,9 +1287,9 @@ mod tests {
     fn unlinking_one_context_leaves_the_others_readable() {
         // The scenario this whole design exists for: closing a hospitalization
         // must not destroy the receipt the tax capability depends on.
-        let content_key = ContentKey::generate();
-        let hospital = ContextKey::generate();
-        let tax = ContextKey::generate();
+        let content_key = ContentKey::generate().unwrap();
+        let hospital = ContextKey::generate().unwrap();
+        let tax = ContextKey::generate().unwrap();
         let mut envelope = ContentEnvelope::new("bill-001");
         envelope.add_wrapping(&content_key, "hospitalization", &hospital).unwrap();
         envelope.add_wrapping(&content_key, "tax-2026", &tax).unwrap();
@@ -1033,8 +1306,8 @@ mod tests {
 
     #[test]
     fn removing_the_last_wrapping_orphans_the_content() {
-        let content_key = ContentKey::generate();
-        let hospital = ContextKey::generate();
+        let content_key = ContentKey::generate().unwrap();
+        let hospital = ContextKey::generate().unwrap();
         let mut envelope = ContentEnvelope::new("bill-001");
         envelope.add_wrapping(&content_key, "hospitalization", &hospital).unwrap();
 
@@ -1050,9 +1323,9 @@ mod tests {
 
     #[test]
     fn the_wrong_context_key_cannot_unwrap() {
-        let content_key = ContentKey::generate();
-        let hospital = ContextKey::generate();
-        let attacker = ContextKey::generate();
+        let content_key = ContentKey::generate().unwrap();
+        let hospital = ContextKey::generate().unwrap();
+        let attacker = ContextKey::generate().unwrap();
         let mut envelope = ContentEnvelope::new("bill-001");
         envelope.add_wrapping(&content_key, "hospitalization", &hospital).unwrap();
 
@@ -1064,8 +1337,8 @@ mod tests {
 
     #[test]
     fn tampered_ciphertext_is_rejected() {
-        let content_key = ContentKey::generate();
-        let hospital = ContextKey::generate();
+        let content_key = ContentKey::generate().unwrap();
+        let hospital = ContextKey::generate().unwrap();
         let mut envelope = ContentEnvelope::new("bill-001");
         envelope.add_wrapping(&content_key, "hospitalization", &hospital).unwrap();
 
@@ -1079,8 +1352,8 @@ mod tests {
 
     #[test]
     fn rewrapping_the_same_context_does_not_duplicate() {
-        let content_key = ContentKey::generate();
-        let hospital = ContextKey::generate();
+        let content_key = ContentKey::generate().unwrap();
+        let hospital = ContextKey::generate().unwrap();
         let mut envelope = ContentEnvelope::new("bill-001");
         envelope.add_wrapping(&content_key, "hospitalization", &hospital).unwrap();
         envelope.add_wrapping(&content_key, "hospitalization", &hospital).unwrap();
@@ -1089,10 +1362,47 @@ mod tests {
     }
 
     #[test]
+    fn relabelling_a_context_id_breaks_the_wrapping() {
+        // Without AAD this succeeds, and a relabelled wrapping survives an
+        // unlink the user was told had worked.
+        let content_key = ContentKey::generate().unwrap();
+        let hospital = ContextKey::generate().unwrap();
+        let mut envelope = ContentEnvelope::new("bill-001");
+        envelope.add_wrapping(&content_key, "hospitalization", &hospital).unwrap();
+
+        envelope.wrappings[0].context_id = "finance".to_string();
+
+        assert_eq!(
+            envelope.unwrap_with("finance", &hospital),
+            Err(VaultError::DecryptionFailed)
+        );
+    }
+
+    #[test]
+    fn a_wrapping_cannot_be_moved_to_another_envelope() {
+        // Without AAD, envelope B unwraps envelope A's content key.
+        let key_a = ContentKey::generate().unwrap();
+        let context = ContextKey::generate().unwrap();
+        let mut envelope_a = ContentEnvelope::new("medical-record");
+        envelope_a.add_wrapping(&key_a, "health", &context).unwrap();
+
+        let key_b = ContentKey::generate().unwrap();
+        let mut envelope_b = ContentEnvelope::new("grocery-list");
+        envelope_b.add_wrapping(&key_b, "health", &context).unwrap();
+
+        envelope_b.wrappings[0] = envelope_a.wrappings[0].clone();
+
+        assert_eq!(
+            envelope_b.unwrap_with("health", &context),
+            Err(VaultError::DecryptionFailed)
+        );
+    }
+
+    #[test]
     fn each_wrapping_uses_a_distinct_nonce() {
-        let content_key = ContentKey::generate();
-        let a = ContextKey::generate();
-        let b = ContextKey::generate();
+        let content_key = ContentKey::generate().unwrap();
+        let a = ContextKey::generate().unwrap();
+        let b = ContextKey::generate().unwrap();
         let mut envelope = ContentEnvelope::new("bill-001");
         envelope.add_wrapping(&content_key, "a", &a).unwrap();
         envelope.add_wrapping(&content_key, "b", &b).unwrap();
@@ -1151,7 +1461,7 @@ Implements #1210.
 **Interfaces:**
 - Consumes: nothing
 - Produces:
-  - `RevocationLedger` with `fn new() -> Self`, `fn revoke(&mut self, content_id: &str) -> u64`, `fn head_epoch(&self) -> u64`, `fn is_revoked(&self, content_id: &str) -> bool`, `fn revoked_since(&self, epoch: u64) -> Vec<String>`, `fn merge(&mut self, other: &RevocationLedger)`
+  - `RevocationLedger` with `fn new() -> Self`, `fn revoke(&mut self, RevocationSubject) -> u64`, `fn head_epoch(&self) -> u64`, `fn is_revoked(&self, &RevocationSubject) -> bool`, `fn all_revoked(&self) -> Vec<RevocationSubject>`, `fn validate(&self) -> Result<(), VaultError>`, `fn merge(&mut self, other: &RevocationLedger)`
 
 **Design note for the implementer.** Uses `BTreeMap`, not `HashMap`. The ledger is serialized into the Recovery Package and later synchronized, and iteration order must be identical on every device. `merge` must be idempotent and order-independent — two devices exchanging ledgers in either order must reach the same state.
 
@@ -1170,13 +1480,32 @@ use std::collections::BTreeMap;
 
 use serde::{Deserialize, Serialize};
 
-/// Append-only record of destroyed content keys.
+/// What a revocation destroys.
+///
+/// Tagged from the start. Spec §3.2 lists `RevokeDevice` as a verb, and the
+/// ledger format freezes in this phase — a content-only ledger cannot be
+/// widened later without migrating every vault in the field.
+///
+/// Two holes this closes, both found in review:
+///   - `RecoveryPackage` carries `device_certificates`. A content-only ledger
+///     means restoring a stale backup **resurrects a revoked device
+///     certificate**, and a stolen laptop walks back into the mesh.
+///   - Destroying a whole context must destroy its key, or every item wrapped
+///     under it stays recoverable from the vault.
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+pub enum RevocationSubject {
+    Content(String),
+    Context(String),
+    Device(String),
+}
+
+/// Append-only record of destroyed keys and evicted devices.
 ///
 /// `BTreeMap`, never `HashMap`: this is serialized and synchronized, and
 /// iteration order must be identical on every device.
 #[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct RevocationLedger {
-    entries: BTreeMap<String, u64>,
+    entries: BTreeMap<RevocationSubject, u64>,
     head_epoch: u64,
 }
 
@@ -1206,30 +1535,65 @@ impl RevocationLedger {
         self.entries.contains_key(content_id)
     }
 
-    /// Every content id revoked strictly after `epoch`.
+    /// Every subject revoked strictly after `epoch`, **within one device's
+    /// own lineage only**.
     ///
-    /// A Recovery Package records the head epoch at export time; on restore
-    /// this returns exactly the keys the backup must not resurrect.
-    pub fn revoked_since(&self, epoch: u64) -> Vec<String> {
+    /// Deliberately `pub(crate)`. Epochs are per-device local counters, not a
+    /// Lamport clock, so cross-device epoch comparison is meaningless: phone
+    /// revokes p1(1), p2(2); laptop revokes l1(1), l2(2); laptop merges phone
+    /// and its head is still 2, so `revoked_since(2)` omits p1 and p2
+    /// entirely.
+    ///
+    /// Use `all_revoked` for anything that must not miss a revocation. The
+    /// previous revision documented this method as returning "exactly the keys
+    /// the backup must not resurrect", which is false and which Phase 7 sync
+    /// would have reached for.
+    pub(crate) fn revoked_since(&self, epoch: u64) -> Vec<RevocationSubject> {
         self.entries
             .iter()
             .filter(|(_, at)| **at > epoch)
-            .map(|(id, _)| id.clone())
+            .map(|(subject, _)| subject.clone())
             .collect()
+    }
+
+    /// Rejects epoch-0 entries on load.
+    ///
+    /// `revoke()` starts at 1, so no valid entry has epoch 0 — but that
+    /// invariant was never asserted, and in Phase 2 this data arrives
+    /// deserialized from the log. A single epoch-0 entry silently escapes any
+    /// epoch-filtered query and resurrects that content.
+    pub fn validate(&self) -> Result<(), VaultError> {
+        if self.entries.values().any(|epoch| *epoch == 0) {
+            return Err(VaultError::SerializationFailed);
+        }
+        Ok(())
     }
 
     /// Absorbs another ledger. Idempotent and order-independent.
     ///
     /// Two devices merging each other's ledgers in either order must reach an
     /// identical state, or sync diverges permanently.
+    ///
+    /// Takes `max`, not `min`. `min` is the fail-open direction: a lower
+    /// stored epoch returns fewer entries from any epoch-filtered query, which
+    /// means fewer purges. In this system fail-open means resurrecting
+    /// destroyed content.
     pub fn merge(&mut self, other: &RevocationLedger) {
-        for (content_id, epoch) in &other.entries {
+        for (subject, epoch) in &other.entries {
             self.entries
-                .entry(content_id.clone())
-                .and_modify(|existing| *existing = (*existing).min(*epoch))
+                .entry(subject.clone())
+                .and_modify(|existing| *existing = (*existing).max(*epoch))
                 .or_insert(*epoch);
         }
         self.head_epoch = self.head_epoch.max(other.head_epoch);
+    }
+
+    /// Every revocation, regardless of epoch.
+    ///
+    /// This is what `apply_revocations` uses. Epoch-filtered queries are
+    /// unsafe across devices — see the note on `revoked_since`.
+    pub fn all_revoked(&self) -> Vec<RevocationSubject> {
+        self.entries.keys().cloned().collect()
     }
 }
 
@@ -1408,7 +1772,7 @@ Completes the Vault side of #1209/#1210 and produces the type Tasks 8 and 9 expo
 **Interfaces:**
 - Consumes: `ContentEnvelope`, `ContentKey`, `ContextKey` (Task 5), `RevocationLedger` (Task 6), `DeviceCertificate` (Task 4)
 - Produces:
-  - `Vault` with `fn new(root_public_key: [u8; 32]) -> Self`, `fn add_context(&mut self, &str) -> &ContextKey`, `fn context_key(&self, &str) -> Option<&ContextKey>`, `fn add_content(&mut self, &str, &[&str]) -> Result<ContentKey, VaultError>`, `fn link_content(&mut self, &str, &str) -> Result<(), VaultError>`, `fn unlink_content(&mut self, &str, &str) -> Result<UnlinkOutcome, VaultError>`, `fn destroy_content(&mut self, &str) -> Result<PurgeDirective, VaultError>`, `fn revocations(&self) -> &RevocationLedger`, `fn trust_device(&mut self, DeviceCertificate) -> bool`
+  - `Vault` with `fn new(root_public_key: [u8; 32]) -> Self`, `fn add_context(&mut self, &str) -> Result<&ContextKey, VaultError>`, `fn context_key(&self, &str) -> Option<&ContextKey>`, `fn add_content(&mut self, &str, &[&str]) -> Result<ContentKey, VaultError>`, `fn link_content(&mut self, &str, &str) -> Result<(), VaultError>`, `fn unlink_content(&mut self, &str, &str) -> Result<UnlinkOutcome, VaultError>`, `fn destroy_content(&mut self, &str) -> Result<PurgeDirective, VaultError>`, `fn revocations(&self) -> &RevocationLedger`, `fn trust_device(&mut self, DeviceCertificate) -> bool`, `fn revoke_device(&mut self, &str) -> Result<PurgeDirective, VaultError>`
   - `UnlinkOutcome { pub remaining_contexts: Vec<String>, pub now_orphaned: bool }`
   - `PurgeDirective { pub content_id: String, pub epoch: u64 }`
 
@@ -1472,13 +1836,20 @@ impl Vault {
     }
 
     /// Creates a context key if absent. Idempotent.
-    pub fn add_context(&mut self, context_id: &str) -> &ContextKey {
+    ///
+    /// Fallible because key generation is fallible — `or_insert_with` cannot
+    /// carry a `Result`, so this is written long-hand.
+    pub fn add_context(&mut self, context_id: &str) -> Result<&ContextKey, VaultError> {
+        if !self.context_keys.contains_key(context_id) {
+            let key = ContextKey::generate()?;
+            self.context_keys.insert(context_id.to_string(), key);
+        }
         self.context_keys
-            .entry(context_id.to_string())
-            .or_insert_with(ContextKey::generate)
+            .get(context_id)
+            .ok_or_else(|| VaultError::NoWrappingForContext(context_id.to_string()))
     }
 
-    pub fn context_key(&self, context_id: &str) -> Option<&ContextKey> {
+    pub(crate) fn context_key(&self, context_id: &str) -> Option<&ContextKey> {
         self.context_keys.get(context_id)
     }
 
@@ -1491,10 +1862,10 @@ impl Vault {
         if self.revocations.is_revoked(content_id) {
             return Err(VaultError::ContentRevoked(content_id.to_string()));
         }
-        let content_key = ContentKey::generate();
+        let content_key = ContentKey::generate().unwrap();
         let mut envelope = ContentEnvelope::new(content_id);
         for context_id in context_ids {
-            self.add_context(context_id);
+            self.add_context(context_id)?;
             let context_key = self
                 .context_keys
                 .get(*context_id)
@@ -1526,7 +1897,7 @@ impl Vault {
             .ok_or_else(|| VaultError::NoWrappingForContext(content_id.to_string()))?
             .unwrap_with(&existing_context, source_key)?;
 
-        self.add_context(context_id);
+        self.add_context(context_id)?;
         let target_key = self
             .context_keys
             .get(context_id)
@@ -1664,8 +2035,8 @@ mod tests {
     #[test]
     fn adding_a_context_twice_keeps_the_same_key() {
         let mut vault = vault();
-        let first = vault.add_context("inbox").as_bytes().to_owned();
-        let second = vault.add_context("inbox").as_bytes().to_owned();
+        let first = vault.add_context("inbox").unwrap().as_bytes().to_owned();
+        let second = vault.add_context("inbox").unwrap().as_bytes().to_owned();
         assert_eq!(first, second);
     }
 
@@ -2006,8 +2377,8 @@ Implements #1212. **This is the task that makes cryptographic deletion true or f
 **Interfaces:**
 - Consumes: `RecoveryPackage`, `VaultPayload` (Task 8), `Seed` (Task 2), `RevocationLedger` (Task 6), `Vault` (Task 7)
 - Produces:
-  - `SealedRestore` with `fn load(&RecoveryPackage, &Seed) -> Result<Self, VaultError>`, `fn backup_epoch(&self) -> u64`, `fn apply_revocations(self, current: &RevocationLedger) -> AppliedRestore`
-  - `AppliedRestore` with `fn purged(&self) -> &[String]`, `fn into_vault(self) -> Vault`
+  - `SealedRestore` with `fn load(&RecoveryPackage, &Seed) -> Result<Self, VaultError>`, `fn backup_epoch(&self) -> u64`, `fn apply_revocations(self, source: &RevocationSource) -> AppliedRestore`
+  - `AppliedRestore` with `fn purged(&self) -> &[RevocationSubject]`, `fn was_blind(&self) -> bool`, `fn source_older_than_backup(&self) -> bool`, `fn into_vault(self) -> Vault`
 
 **Design note for the implementer.** The two states are **separate types**, not a bool on one type. `SealedRestore` has no method that yields a `Vault` and no method that exposes a key. The only way to obtain a `Vault` is to consume a `SealedRestore` via `apply_revocations`, which returns `AppliedRestore`, which is the only type with `into_vault`. This makes the unsafe ordering unrepresentable rather than merely tested. Do not collapse these into one struct with a flag — a flag can be ignored; a missing method cannot.
 
@@ -2038,6 +2409,55 @@ use super::revocation::RevocationLedger;
 use super::seed::Seed;
 use super::Vault;
 
+/// Where a revocation ledger came from.
+///
+/// The type state enforces *ordering*, not *freshness* — and an empty ledger
+/// purges nothing. The previous revision shipped that bypass in its own FFI
+/// surface: destroy a record, lose every device, restore from a pre-destroy
+/// package with no log available, and the record is readable again.
+///
+/// Provenance makes a blind restore something the caller must name.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum RevocationProvenance {
+    /// Replayed from the operation log to head. The only trustworthy source.
+    ReplayedFromLog { head_operation_id: String },
+    /// Only what the recovery package itself recorded. A floor, not a total.
+    PackageOnly,
+    /// No revocation data at all. Caller has acknowledged the risk.
+    AcknowledgedBlind,
+}
+
+/// A revocation ledger plus where it came from.
+pub struct RevocationSource {
+    ledger: RevocationLedger,
+    provenance: RevocationProvenance,
+}
+
+impl RevocationSource {
+    pub fn replayed_from_log(ledger: RevocationLedger, head_operation_id: String) -> Self {
+        Self {
+            ledger,
+            provenance: RevocationProvenance::ReplayedFromLog { head_operation_id },
+        }
+    }
+
+    pub fn package_only() -> Self {
+        Self {
+            ledger: RevocationLedger::new(),
+            provenance: RevocationProvenance::PackageOnly,
+        }
+    }
+
+    /// Deliberately verbose. A caller reaching for this is choosing to restore
+    /// without knowing what was destroyed elsewhere, and the UI must warn.
+    pub fn acknowledged_blind_restore() -> Self {
+        Self {
+            ledger: RevocationLedger::new(),
+            provenance: RevocationProvenance::AcknowledgedBlind,
+        }
+    }
+}
+
 /// A decrypted but unusable restore. No keys are reachable from here.
 pub struct SealedRestore {
     payload: VaultPayload,
@@ -2045,9 +2465,20 @@ pub struct SealedRestore {
 }
 
 impl SealedRestore {
+    /// Decrypts the package and binds it to the seed's identity.
+    ///
+    /// The identity check is not decoration: without it, a mismatched or
+    /// crafted package yields a vault that accepts device certificates signed
+    /// by a root the user does not control.
     pub fn load(package: &RecoveryPackage, seed: &Seed) -> Result<Self, VaultError> {
+        let payload = package.decrypt(seed)?;
+        let expected = RootIdentity::from_seed(seed)?.public_key();
+        if payload.root_public_key != expected || package.identity_public_key != expected {
+            return Err(VaultError::IdentityMismatch);
+        }
+        payload.revocations.validate()?;
         Ok(Self {
-            payload: package.decrypt(seed)?,
+            payload,
             backup_epoch: package.revocation_epoch,
         })
     }
@@ -2056,30 +2487,50 @@ impl SealedRestore {
         self.backup_epoch
     }
 
-    /// Destroys every key revoked since this backup was taken.
+    /// Destroys everything revoked, from both the package and `source`.
     ///
-    /// `current` is the revocation ledger replayed from the operation log to
-    /// head. Consuming `self` is what makes the unsafe path unrepresentable:
-    /// there is no way to reach a `Vault` without passing through here.
-    pub fn apply_revocations(mut self, current: &RevocationLedger) -> AppliedRestore {
-        self.payload.revocations.merge(current);
+    /// Consuming `self` is what makes the unsafe path unrepresentable: there
+    /// is no way to reach a `Vault` without passing through here.
+    ///
+    /// Purges content envelopes, context keys, **and device certificates** —
+    /// all three are revocable subjects, and omitting devices means a stale
+    /// backup readmits a revoked device.
+    pub fn apply_revocations(mut self, source: &RevocationSource) -> AppliedRestore {
+        self.payload.revocations.merge(&source.ledger);
 
-        let mut purged: Vec<String> = self
-            .payload
-            .revocations
-            .revoked_since(0)
-            .into_iter()
-            .filter(|id| self.payload.envelopes.contains_key(id))
-            .collect();
+        let mut purged = Vec::new();
+        for subject in self.payload.revocations.all_revoked() {
+            match &subject {
+                RevocationSubject::Content(id) => {
+                    if self.payload.envelopes.remove(id).is_some() {
+                        purged.push(subject.clone());
+                    }
+                }
+                RevocationSubject::Context(id) => {
+                    if self.payload.context_keys.remove(id).is_some() {
+                        purged.push(subject.clone());
+                    }
+                }
+                RevocationSubject::Device(id) => {
+                    let before = self.payload.device_certificates.len();
+                    self.payload.device_certificates.retain(|c| &c.device_id != id);
+                    if self.payload.device_certificates.len() != before {
+                        purged.push(subject.clone());
+                    }
+                }
+            }
+        }
         purged.sort();
 
-        for content_id in &purged {
-            self.payload.envelopes.remove(content_id);
-        }
+        // The caller handed us a ledger older than the backup itself. Not an
+        // error — an offline restore is legitimate — but the UI must say so.
+        let stale = source.ledger.head_epoch() < self.backup_epoch;
 
         AppliedRestore {
             payload: self.payload,
             purged,
+            provenance: source.provenance.clone(),
+            source_older_than_backup: stale,
         }
     }
 }
@@ -2087,13 +2538,30 @@ impl SealedRestore {
 /// A restore with revocations applied. The only source of a usable `Vault`.
 pub struct AppliedRestore {
     payload: VaultPayload,
-    purged: Vec<String>,
+    purged: Vec<RevocationSubject>,
+    provenance: RevocationProvenance,
+    source_older_than_backup: bool,
 }
 
 impl AppliedRestore {
-    /// Content ids whose keys were destroyed during restore.
-    pub fn purged(&self) -> &[String] {
+    /// Subjects destroyed during restore.
+    pub fn purged(&self) -> &[RevocationSubject] {
         &self.purged
+    }
+
+    /// True when this restore could not consult the operation log.
+    ///
+    /// The shell **must** warn: content destroyed on another device may be
+    /// readable again, and no amount of local checking can detect it. See
+    /// design spec §6.3 — this is a permanent property of a serverless
+    /// architecture, not a defect.
+    pub fn was_blind(&self) -> bool {
+        !matches!(self.provenance, RevocationProvenance::ReplayedFromLog { .. })
+    }
+
+    /// True when the supplied ledger predates the backup being restored.
+    pub fn source_older_than_backup(&self) -> bool {
+        self.source_older_than_backup
     }
 
     pub fn into_vault(self) -> Vault {
@@ -2131,7 +2599,7 @@ mod tests {
 
         let restored = SealedRestore::load(&package, &seed())
             .unwrap()
-            .apply_revocations(&RevocationLedger::new());
+            .apply_revocations(&RevocationSource::package_only());
 
         assert!(restored.purged().is_empty());
         let vault = restored.into_vault();
@@ -2152,7 +2620,7 @@ mod tests {
 
         let restored = SealedRestore::load(&stale_backup, &seed())
             .unwrap()
-            .apply_revocations(&current_revocations);
+            .apply_revocations(&RevocationSource::replayed_from_log(current_revocations, "op-42".into()));
 
         assert_eq!(restored.purged(), &["hiv-test-result".to_string()]);
 
@@ -2180,7 +2648,7 @@ mod tests {
 
         let restored = SealedRestore::load(&package, &seed())
             .unwrap()
-            .apply_revocations(&RevocationLedger::new());
+            .apply_revocations(&RevocationSource::package_only());
 
         let vault = restored.into_vault();
         assert!(vault.revocations().is_revoked("hiv-test-result"));
@@ -2196,13 +2664,13 @@ mod tests {
 
         let once = SealedRestore::load(&package, &seed())
             .unwrap()
-            .apply_revocations(live.revocations());
+            .apply_revocations(&RevocationSource::replayed_from_log(live.revocations().clone(), "op-42".into()));
         let vault = once.into_vault();
 
         let repackaged = RecoveryPackage::export(&vault, &seed()).unwrap();
         let twice = SealedRestore::load(&repackaged, &seed())
             .unwrap()
-            .apply_revocations(live.revocations());
+            .apply_revocations(&RevocationSource::replayed_from_log(live.revocations().clone(), "op-42".into()));
 
         assert!(twice.purged().is_empty());
         assert!(!twice.into_vault().has_content("hiv-test-result"));
@@ -2296,205 +2764,47 @@ Refs #1212"
 
 ---
 
-## Task 10: FRB surface for the Vault
+## Task 10: Defer the FFI surface to Phase 2
 
-Completes #1204's binding half. Keeps Constitution §2 (FFI only in `core_native`) and §6 (generated-file budget).
+**No code in this task.** Both council reviews independently concluded that the
+FFI surface does not belong in Phase 1.
 
-**Files:**
-- Create: `rust/airo_mind/src/api/mod.rs`
-- Create: `rust/airo_mind/src/api/vault.rs`
-- Modify: `rust/airo_mind/src/lib.rs`
-- Create: `flutter_rust_bridge_mind.yaml`
-- Create: `packages/core_mind_contracts/` (pubspec, module.yaml, lib)
+- **chief-open-source-officer:** the crate declares `cdylib`/`staticlib` while
+  exporting nothing, so CI links two empty artifacts on every push. Ship
+  `rlib` only until there is something to export.
+- **chief-security-officer (R15):** the plan asserted a dynamic
+  `RevocationsNotApplied` check at the boundary that **did not exist in the
+  task**, and the only restore-adjacent function crossing FFI was the one that
+  ignored revocations. As written, the boundary did not merely risk reopening
+  the erasure hole — it was the only place the hole was exposed.
 
-**Interfaces:**
-- Consumes: everything above
-- Produces: a Dart-facing API in `packages/core_native/lib/src/mind/`
+There is also nothing for Dart to do with a Vault in Phase 1. Onboarding
+(#1234) needs the mnemonic and the restore flow, and restore needs the
+operation log, which does not exist until Phase 2.
 
-**Design note for the implementer.** The FFI surface is partitioned per subsystem from the first commit — `api/vault.rs` here, `api/oplog.rs` in Phase 2, and so on. Constitution §6 caps generated files at 200 KB; consolidating now and splitting later means regenerating every binding under a size-gate failure.
+- [ ] **Step 1: Confirm `crate-type = ["rlib"]` in the manifest**
 
-Across the boundary the type-state from Task 9 cannot be expressed. The FFI layer therefore holds an opaque handle and returns `VaultError::RevocationsNotApplied` if a caller asks for a Vault before applying revocations. That error variant exists in Task 1 for exactly this.
+Already set in Task 1. Verify no `frb_generated` module, no
+`flutter_rust_bridge` dependency, and no second codegen config exists.
 
-- [ ] **Step 1: Write the failing test**
+- [ ] **Step 2: Confirm the FFI work is tracked**
 
-Create `rust/airo_mind/src/api/vault.rs`:
+#1259 owns the Phase 2 FFI surface and carries the constraints this phase
+established:
 
-```rust
-//! FFI surface for the Vault. Small payloads, no panics, no key material
-//! crossing the boundary.
-//!
-//! Private keys, content keys, and context keys never cross FFI. Dart sees
-//! identifiers, outcomes, and opaque encrypted bytes.
-
-use crate::vault::{
-    generate_mnemonic, seed_from_mnemonic, RecoveryPackage, RevocationLedger, RootIdentity,
-    SealedRestore, VaultError,
-};
-
-/// Result of creating a new identity. The mnemonic is shown once, then dropped.
-pub struct NewIdentity {
-    pub mnemonic: String,
-    pub identity_id: String,
-}
-
-/// Creates a fresh identity and returns the mnemonic for one-time display.
-pub fn create_identity() -> Result<NewIdentity, VaultError> {
-    let mnemonic = generate_mnemonic();
-    let seed = seed_from_mnemonic(&mnemonic)?;
-    let identity = RootIdentity::from_seed(&seed)?;
-    Ok(NewIdentity {
-        identity_id: identity.identity_id(),
-        mnemonic,
-    })
-}
-
-/// Recovers an identity id from a mnemonic, for confirming the user recorded
-/// it correctly during onboarding (#1234).
-pub fn identity_id_from_mnemonic(mnemonic: String) -> Result<String, VaultError> {
-    let seed = seed_from_mnemonic(&mnemonic)?;
-    Ok(RootIdentity::from_seed(&seed)?.identity_id())
-}
-
-/// Reads the revocation epoch of a Recovery Package without decrypting it.
-///
-/// Lets the restore UI tell the user how stale a backup is before asking for
-/// the mnemonic.
-pub fn recovery_package_epoch(package_bytes: Vec<u8>) -> Result<u64, VaultError> {
-    Ok(RecoveryPackage::from_bytes(&package_bytes)?.revocation_epoch)
-}
-
-/// Validates that a mnemonic decrypts a Recovery Package, and reports the
-/// content the package **itself** already records as revoked.
-///
-/// Deliberately narrow. This runs before the operation log is available, so
-/// it cannot know about destructions performed on other devices since the
-/// backup — it passes an empty current ledger. The number it returns is a
-/// floor, never the final count.
-///
-/// The restore UI must not present this as "what you will lose". The real
-/// purge set comes from `apply_revocations` against the ledger replayed from
-/// the log, once the log is loaded.
-pub fn preview_package_revocations(
-    package_bytes: Vec<u8>,
-    mnemonic: String,
-) -> Result<Vec<String>, VaultError> {
-    let package = RecoveryPackage::from_bytes(&package_bytes)?;
-    let seed = seed_from_mnemonic(&mnemonic)?;
-    let applied =
-        SealedRestore::load(&package, &seed)?.apply_revocations(&RevocationLedger::new());
-    Ok(applied.purged().to_vec())
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn create_identity_returns_a_24_word_mnemonic_and_an_id() {
-        let created = create_identity().unwrap();
-        assert_eq!(created.mnemonic.split_whitespace().count(), 24);
-        assert_eq!(created.identity_id.len(), 64);
-    }
-
-    #[test]
-    fn the_same_mnemonic_recovers_the_same_identity_id() {
-        let created = create_identity().unwrap();
-        assert_eq!(
-            identity_id_from_mnemonic(created.mnemonic.clone()).unwrap(),
-            created.identity_id
-        );
-    }
-
-    #[test]
-    fn an_invalid_mnemonic_is_rejected_rather_than_panicking() {
-        assert_eq!(
-            identity_id_from_mnemonic("clearly not valid".into()),
-            Err(VaultError::InvalidMnemonic)
-        );
-    }
-
-    #[test]
-    fn malformed_package_bytes_are_rejected_rather_than_panicking() {
-        assert_eq!(
-            recovery_package_epoch(vec![0, 1, 2, 3]),
-            Err(VaultError::SerializationFailed)
-        );
-    }
-}
-```
-
-Create `rust/airo_mind/src/api/mod.rs`:
-
-```rust
-//! Public API surface exposed to Flutter via FFI.
-//!
-//! Rules:
-//!   - No panics. Return `Result`.
-//!   - No key material crosses this boundary. Ever.
-//!   - One module per subsystem. Constitution §6 caps generated files at
-//!     200 KB, so the surface is partitioned from the first commit rather
-//!     than consolidated and split under a size-gate failure.
-
-pub mod vault;
-```
-
-Modify `rust/airo_mind/src/lib.rs` — add above `pub mod vault;`:
-
-```rust
-pub mod api;
-```
-
-- [ ] **Step 2: Run test to verify it fails**
-
-Run: `cargo test --manifest-path rust/Cargo.toml -p airo_mind api`
-Expected: FAIL to compile — `api` module not declared.
-
-- [ ] **Step 3: Wire the second FRB codegen target**
-
-Create `flutter_rust_bridge_mind.yaml` at the repo root:
-
-```yaml
-rust_root: rust/airo_mind
-rust_input: crate::api
-dart_output: packages/core_native/lib/src/mind
-rust_output: rust/airo_mind/src/frb_generated.rs
-```
-
-Then add `mod frb_generated;` to `rust/airo_mind/src/lib.rs` above `pub mod api;`, matching the pattern in `rust/airo_core/src/lib.rs`.
-
-Run codegen: `flutter_rust_bridge_codegen generate --config-file flutter_rust_bridge_mind.yaml`
-
-Confirm the generated Dart file is under 200 KB (`ls -la packages/core_native/lib/src/mind/`). If it is not, split `api/vault.rs` further before proceeding — Constitution §6.
-
-- [ ] **Step 4: Run tests and CI gates**
-
-Run: `cargo test --manifest-path rust/Cargo.toml --all`
-Run: `cargo clippy --manifest-path rust/Cargo.toml --all -- -D warnings`
-Run: `cargo fmt --manifest-path rust/Cargo.toml --check`
-Run: `melos exec --scope="core_native" -- flutter analyze`
-Expected: all clean
-
-- [ ] **Step 5: Add module.yaml for core_native's new surface**
-
-`packages/core_native/module.yaml` must declare the Airo Mind capability with ship policy **Never Ship** on TV, per Constitution §3. If `core_native` already ships on TV for playlist/EPG, the Mind bindings must be excluded at the build graph level — note this explicitly in the PR description and request chief-architect review, because it may require splitting `core_native` rather than adding to it.
-
-- [ ] **Step 6: Commit**
-
-```bash
-git add rust/airo_mind/src/api/ rust/airo_mind/src/lib.rs flutter_rust_bridge_mind.yaml packages/core_native/
-git commit -m "feat(mind): expose Vault over FRB with a partitioned API surface
-
-Second codegen target emitting to core_native/lib/src/mind, keeping all
-FFI in core_native per Constitution §2. Surface is partitioned per
-subsystem from the first commit to stay under the 200 KB generated-file
-budget in §6.
-
-No key material crosses the boundary. The restore type-state cannot be
-expressed across FFI, so the boundary checks dynamically and returns
-RevocationsNotApplied.
-
-Refs #1204"
-```
+- Key material does not cross the boundary. The recovery mnemonic is the single
+  acknowledged exception, crossing exactly twice — onboarding and restore — as
+  `Vec<u8>` rather than `String` so the Dart side can zero it, zeroized on the
+  Rust side, and prohibited from logging, crash-reporter capture, and analytics.
+- The restore type state cannot be expressed across FFI. The boundary holds an
+  opaque handle and checks dynamically, returning
+  `VaultError::RevocationsNotApplied`. That code ships with the check, or it
+  does not ship.
+- The surface is partitioned per subsystem from its first commit —
+  Constitution §6 caps generated files at 200 KB, and consolidating then
+  splitting means regenerating every binding under a size-gate failure.
+- `packages/core_native/module.yaml` gains **Chief Security Officer** as a
+  reviewer before the mnemonic boundary lands there.
 
 ---
 
@@ -2502,20 +2812,77 @@ Refs #1204"
 
 - [ ] `cargo test --all`, `cargo clippy --all -- -D warnings`, `cargo fmt --check` green
 - [ ] Issues #1207–#1212 closed, each referencing the commit that closed it
-- [ ] #1205 closed with governance verdicts recorded per crate
-- [ ] The regression test `a_backup_taken_before_a_destroy_does_not_resurrect_it` passes and is marked as a release gate in the PR description
-- [ ] `SealedRestore` has no method returning a `Vault` and no method exposing key material — verified by a reviewer, not just by tests
-- [ ] Generated Dart under `packages/core_native/lib/src/mind/` is under 200 KB
-- [ ] `packages/benchmarks` entry deferred to Phase 2 — there is no CPU-bound path in the Vault worth benchmarking yet, and Constitution §4's benchmark requirement attaches to merge and replay, which land in Phase 2 and 3
+- [ ] #1205 closed with governance verdicts recorded, including the CC0 decision
+- [ ] #1241 (at-rest storage) closed — **the Vault has no persistence story without it**, and the path of least resistance without it is persisting the seed in app storage, which voids every claim in the design
+- [ ] #1257 (cargo in Dependabot, `cargo-deny`, `cargo-audit`, mobile cross-compile) closed — merge gate
+- [ ] #1258 (`rust/airo_mind` owner and Never Ship on TV enforcement) closed
+- [ ] Release-gate regression tests pass and are named in the PR description:
+  - `a_backup_taken_before_a_destroy_does_not_resurrect_it`
+  - the device-revocation equivalent
+  - `relabelling_a_context_id_breaks_the_wrapping`
+  - `a_wrapping_cannot_be_moved_to_another_envelope`
+- [ ] `SealedRestore` has no method returning a `Vault` and no method exposing key material — verified by a reviewer, not only by tests
+- [ ] No `fill_bytes` anywhere; `grep -rn "fill_bytes" rust/airo_mind/src` returns only `try_fill_bytes`
+- [ ] No `derive(Debug)`, `derive(Clone)`, or `derive(PartialEq)` on any secret type
+- [ ] `crate-type = ["rlib"]`; no `flutter_rust_bridge` dependency
+- [ ] Third-party notices updated for BSD-3-Clause, and for CC0 if Path A was chosen
+- [ ] `[profile.release]` added to `rust/Cargo.toml` — measured at 650 KB → 424 KB, and free
+- [ ] Rust Architect has recorded an explicit "third-party audited `unsafe`, accepted" note for `curve25519-dalek`, `subtle`, and `fiat-crypto`, which trip the unreviewed-`unsafe` criterion transitively
+
+Deferred with reasons: `packages/benchmarks` entry (Constitution §4 attaches the
+benchmark requirement to merge and replay, which land in Phases 2–3); FFI
+surface (#1259).
+
+## Applied review findings
+
+Revision 2 applies every finding from PR #1239.
+
+**chief-security-officer, blocking:** R1 empty-ledger bypass → `RevocationSource`
+with provenance, `was_blind`, staleness signal. R2 missing AAD → `wrapping_aad`
+binding content and context, with two regression tests. R3 no device or context
+revocation → `RevocationSubject` tagged enum, purged on restore. R5 no identity
+binding → checked in `SealedRestore::load`. R6 unauthenticated package header →
+passed as AAD. R12 no at-rest design → #1241. R13 mnemonic over FFI → moot,
+FFI deferred. R15 Task 10 unbuildable → task deleted.
+
+**chief-security-officer, mechanical:** R4 fail-open `revoked_since` → `min`
+became `max`, `all_revoked` added, method made `pub(crate)`, epoch-0 rejected,
+misleading test replaced. R7 unzeroized plaintext and `Debug` on secrets →
+`Zeroizing` buffers, hand-written redacting `Debug`. R8 unpinned `zeroize`
+feature → explicit pin plus compile-time guard. R9 `PartialEq` on secrets →
+`subtle::ConstantTimeEq`, `Clone` dropped. R10 `ContextKey::as_bytes` →
+`pub(crate)`. R11 domain strings → registry with prefix-distinctness test. R14
+silent success on absent targets → errors.
+
+**chief-open-source-officer:** `fill_bytes` panic → `try_fill_bytes` +
+`RngUnavailable`. `crate-type` → `rlib` only. `bip39` → `rand` dropped,
+`zeroize` enabled. `curve25519-dalek` floored at `>=4.1.3`. `serde_json`
+retained on measured evidence, with the signing-bytes prohibition recorded.
+Supply-chain gates → #1257. Crate ownership → #1258.
+
+**Unresolved, tracked:** the `serde_json` versus `postcard` question. OSS
+rejected the swap on size and canonicalization grounds; security raised it on
+secret-hygiene grounds — that `[u8; 32]` serializes as decimal integers, so key
+bytes smear across unzeroized ASCII buffers. The two answered different
+questions. Recommended resolution is a byte-oriented serde impl for key types
+plus `Zeroizing` buffers, which addresses the hygiene finding without a new
+dependency. Joint chief-security-officer and chief-architect ruling, on
+PR #1239.
 
 ## Self-review notes
 
-**Spec coverage.** §6.1 Recovery Package → Task 8. §6.2 restore ordering → Task 9. §4.1 envelope encryption → Tasks 5, 7. §4.3 crypto-shredding steps 1–3 → Task 7; steps 4–8 are out of this crate by design and carried by `PurgeDirective`. §7 trust boundary → Task 4 (device certificates, own-mesh only). §9 code placement → Tasks 1, 10.
+**Spec coverage.** §6.1 Recovery Package → Task 8. §6.2 restore ordering →
+Task 9. §6.3 erasure bound → `was_blind`. §4.1 envelope encryption → Tasks 5, 7.
+§4.3 crypto-shredding steps 1–3 → Task 7; steps 4–8 are outside this crate and
+carried by `PurgeDirective`, which is a nudge and not a mechanism until Phase 2
+makes revocation transactional. §7 trust boundary → Task 4 plus device
+revocation.
 
-**Not covered here, deliberately.** Retention classes (`permanent` / `recoverable` / `ephemeral` / `secret`, spec §4.2) attach to content objects, which live in the content store — Phase 2, issue #1214. Adding a retention field to the Vault now would put it in the wrong aggregate.
+**Not covered here, deliberately.** Retention classes (spec §4.2) attach to
+content objects in the content store — Phase 2, #1214. Putting them in the
+Vault would be the wrong aggregate.
 
-**Known interface risk.** `serde` on `[u8; 64]` (Task 4, Step 3) affects Tasks 4, 8, and 9. Whichever approach the implementer picks must be applied consistently; a mismatch surfaces as a deserialization failure in Task 9's round-trip tests, not at the point of the mistake.
-
-**Flagged for chief-security-officer review, not resolved here.** `ContentKey` derives `PartialEq` in Task 5 so tests can assert an unwrapped key matches the original. Derived equality on secret material is not constant-time, and a future non-test caller comparing keys with `==` would be a timing side channel. Two acceptable resolutions: implement `PartialEq` via `subtle::ConstantTimeEq`, or gate the derive behind `#[cfg(test)]`. Pick one during Task 5 review rather than shipping the derive unexamined.
-
-**Preview is a floor, not a total.** `preview_package_revocations` (Task 10) runs before the operation log is available and therefore cannot see destructions performed on other devices since the backup. The restore UI must not label its output "what you will lose" — issue #1234 owns that copy.
+**Known interface risk.** `serde` on `[u8; 64]` (Task 4) affects Tasks 4, 8, and
+9. Whichever approach is chosen must be applied consistently; a mismatch
+surfaces as a deserialization failure in Task 9's round-trip tests rather than
+at the point of the mistake.


### PR DESCRIPTION
Revision 2 of the Phase 1 plan, applying all fifteen chief-security-officer findings and the chief-open-source-officer caveats from PR #1239. Docs only.

**Revision 1 is on main and should not be implemented from.** The header now says so.

## Two structural changes

**FFI leaves Phase 1 entirely.** Both reviews arrived here independently — OSS found the crate declaring `cdylib`/`staticlib` while exporting nothing (two empty artifacts linked on every CI push), and security found the FFI boundary was the *only* place the stale-restore hole was actually exposed. There is also nothing useful for Dart to do with a Vault alone: onboarding needs restore, and restore needs the operation log. Moved to #1260 with the constraints carried forward.

**The revocation ledger now carries tagged subjects** — `Content`, `Context`, `Device`. The format freezes in this phase, so this could not wait. A content-only ledger meant restoring a stale backup **resurrected a revoked device certificate**: a stolen laptop walking back into the mesh, one field over from the hole the restore type state exists to close.

## Blocking fixes

**R1 — the empty-ledger bypass.** `apply_revocations` took a bare `&RevocationLedger`, so an empty one purged nothing. Revision 1 shipped that bypass in its own FFI surface. Now takes a provenance-bearing `RevocationSource` — `replayed_from_log`, `package_only`, or the deliberately verbose `acknowledged_blind_restore` — and `AppliedRestore` reports `was_blind()` and `source_older_than_backup()` so the shell must warn rather than silently succeed.

**R2 — wrappings had no AAD.** `context_id` was plaintext and unauthenticated. Two consequences, now regression tests: relabelling a `context_id` meant `remove_wrapping` no longer found it, so the wrapping **survived an unlink the user was told had worked**; and a wrapping could be moved verbatim from one envelope to another and still unwrap, yielding the wrong content key.

**R5** — `SealedRestore::load` never checked the vault against the seed's identity. A mismatched or crafted package produced a vault trusting certificates signed by a root the user does not control.

**R6** — the recovery package's plaintext header drove user-facing staleness messaging while being freely editable. Now authenticated as AAD.

**R12** — no at-rest storage design existed at all. #1241.

## Mechanical fixes

`merge` took `min` where fail-open means resurrecting destroyed content. `revoked_since` was documented as returning "exactly the keys the backup must not resurrect" when epochs are per-device counters and cross-device comparison is meaningless — now `pub(crate)` with the real semantics stated, and `all_revoked` added for callers that must not miss one. Epoch-0 entries rejected on load. `fill_bytes` **panics** on RNG failure in a crate whose module doc promises no panics — now `try_fill_bytes` into `VaultError::RngUnavailable`. Secrets no longer derive `Debug` (printed key bytes into logs and panic messages), `Clone` (silently duplicated singular-custody material), or `PartialEq` (not constant-time — now `subtle::ConstantTimeEq`, ruled over `#[cfg(test)]`-gating). The `zeroize` feature keeping the root private key out of freed memory was unpinned and is now explicit with a compile-time guard. Domain-separation strings were distinct by luck; now a registry with a prefix-distinctness test.

## Dependency changes

Eleven crates, none rejected. `subtle` added. `bip39` drops `rand` (removes four crates, leaves one CSPRNG stack instead of two) and gains `zeroize` — without it the mnemonic's word indices were never wiped, on the most sensitive object in the design. `curve25519-dalek` floored at `>=4.1.3` for RUSTSEC-2024-0344; the previous resolution sat on the boundary with no headroom. `crate-type` reduced to `rlib`.

`serde_json` **retained** on measured evidence — 16.4 KB stripped — with the prohibition recorded that its output must never become signed or hashed bytes.

## One decision still open

**`bip39` is CC0-1.0**: not OSI-approved, §4(a) expressly reserves the author's patent rights, and Google's own OSS policy bans CC0 for code. This is the crate generating the recovery secret for medical and financial records. Task 0 Step 3 presents both approved paths — record the exception with security sign-off, or implement BIP-39 in-house (~200 lines on the `sha2`/`hmac` already in the tree, removing five crates). Task 2's tests are unchanged either way.

## One conflict still unresolved

`serde_json` versus `postcard`. OSS rejected the swap on size and canonicalization grounds; security raised it on secret-hygiene grounds — `[u8; 32]` serializes as decimal integers, smearing key bytes across unzeroized ASCII buffers. They answered different questions. Recommendation and three resolutions are on PR #1239; joint security + architect ruling.

Refs #1193, #1205, #1207-#1212, #1239, #1241, #1257, #1258, #1260

🤖 Generated with [Claude Code](https://claude.com/claude-code)