### PR TITLE
chore: superseded media analyzer branch (merged in #1145)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,6 @@ app/android/*.keystore
 google-services.json
 firebase-adminsdk*.json
 GoogleService-Info.plist
-app/lib/firebase_options.dart
 
 # E2E Test Authentication Sessions (sensitive - contains OAuth tokens)
 e2e/googleAuth.json

--- a/app/android/app/src/main/kotlin/io/airo/app/AiroMediaAssetAnalyzerPlugin.kt
+++ b/app/android/app/src/main/kotlin/io/airo/app/AiroMediaAssetAnalyzerPlugin.kt
@@ -1,0 +1,295 @@
+package io.airo.app
+
+import android.media.MediaExtractor
+import android.media.MediaFormat
+import android.media.MediaMetadataRetriever
+import io.flutter.plugin.common.BinaryMessenger
+import io.flutter.plugin.common.MethodCall
+import io.flutter.plugin.common.MethodChannel
+import java.io.File
+import java.util.concurrent.Executors
+
+class AiroMediaAssetAnalyzerPlugin(private val activity: MainActivity) {
+    companion object {
+        const val CHANNEL_NAME = "com.airo.media_asset_analyzer"
+    }
+
+    private val executor = Executors.newSingleThreadExecutor()
+
+    fun register(messenger: BinaryMessenger) {
+        MethodChannel(messenger, CHANNEL_NAME).setMethodCallHandler { call, result ->
+            when (call.method) {
+                "analyze" -> {
+                    val arguments = call.arguments as? Map<*, *>
+                    val request = MediaAssetAnalysisRequest.from(arguments)
+                    if (request == null) {
+                        result.error(
+                            "invalid_arguments",
+                            "Media asset analyzer requires assetId and filePath.",
+                            null,
+                        )
+                        return@setMethodCallHandler
+                    }
+                    executor.execute {
+                        val payload = analyze(request)
+                        activity.runOnUiThread {
+                            result.success(payload)
+                        }
+                    }
+                }
+                else -> result.notImplemented()
+            }
+        }
+    }
+
+    private fun analyze(request: MediaAssetAnalysisRequest): Map<String, Any?> {
+        val startedAt = System.currentTimeMillis()
+        val warnings = linkedSetOf<String>()
+        val fileSizeBytes = request.fileSizeBytesHint ?: runCatching {
+            File(request.filePath).length()
+        }.getOrNull()
+        if (fileSizeBytes == null) {
+            warnings.add("file_size_unavailable")
+        }
+
+        var durationMs: Long? = null
+        var overallBitrate: Int? = null
+        val videoTracks = mutableListOf<Map<String, Any?>>()
+        val audioTracks = mutableListOf<Map<String, Any?>>()
+        val subtitleTracks = mutableListOf<Map<String, Any?>>()
+
+        var retriever: MediaMetadataRetriever? = null
+        var extractor: MediaExtractor? = null
+        try {
+            retriever = MediaMetadataRetriever()
+            retriever.setDataSource(request.filePath)
+            durationMs = retriever.extractMetadata(
+                MediaMetadataRetriever.METADATA_KEY_DURATION,
+            )?.toLongOrNull()
+            overallBitrate = retriever.extractMetadata(
+                MediaMetadataRetriever.METADATA_KEY_BITRATE,
+            )?.toIntOrNull()
+
+            extractor = MediaExtractor()
+            extractor.setDataSource(request.filePath)
+            for (index in 0 until extractor.trackCount) {
+                val format = extractor.getTrackFormat(index)
+                val mimeType = format.getString(MediaFormat.KEY_MIME).orEmpty()
+                when {
+                    mimeType.startsWith("video/") -> {
+                        videoTracks.add(
+                            mapOf(
+                                "id" to "video-$index",
+                                "codec" to videoCodecForMimeType(mimeType),
+                                "width" to format.getIntegerOrNull(MediaFormat.KEY_WIDTH),
+                                "height" to format.getIntegerOrNull(MediaFormat.KEY_HEIGHT),
+                                "bitrate" to format.getIntegerOrNull(MediaFormat.KEY_BIT_RATE),
+                                "dynamicRange" to dynamicRangeFor(mimeType, format),
+                                "confidence" to "exact",
+                            ),
+                        )
+                    }
+                    mimeType.startsWith("audio/") -> {
+                        audioTracks.add(
+                            mapOf(
+                                "id" to "audio-$index",
+                                "codec" to audioCodecForMimeType(mimeType),
+                                "language" to format.getString(MediaFormat.KEY_LANGUAGE),
+                                "label" to null,
+                                "channelCount" to format.getIntegerOrNull(MediaFormat.KEY_CHANNEL_COUNT),
+                                "isDefault" to (format.getIntegerOrNull(MediaFormat.KEY_IS_DEFAULT) == 1),
+                                "isCommentary" to false,
+                                "confidence" to "exact",
+                            ),
+                        )
+                    }
+                    mimeType.startsWith("text/") ||
+                        mimeType.startsWith("application/") -> {
+                        subtitleTracks.add(
+                            mapOf(
+                                "id" to "subtitle-$index",
+                                "format" to subtitleFormatForMimeType(mimeType),
+                                "language" to format.getString(MediaFormat.KEY_LANGUAGE),
+                                "label" to null,
+                                "isDefault" to (format.getIntegerOrNull(MediaFormat.KEY_IS_DEFAULT) == 1),
+                                "isForced" to (format.getIntegerOrNull(MediaFormat.KEY_IS_FORCED_SUBTITLE) == 1),
+                                "isCommentary" to false,
+                                "confidence" to "exact",
+                            ),
+                        )
+                    }
+                }
+            }
+        } catch (_: Exception) {
+            warnings.add("metadata_probe_failed")
+            return mapOf(
+                "status" to "inspection_failed",
+                "failureReason" to "metadata_probe_failed",
+                "profile" to mapOf(
+                    "schemaVersion" to "1.0.0",
+                    "assetId" to request.assetId,
+                    "container" to request.containerStableId(),
+                    "durationMs" to durationMs,
+                    "fileSizeBytes" to fileSizeBytes,
+                    "overallBitrate" to overallBitrate,
+                    "videoTracks" to emptyList<Map<String, Any?>>(),
+                    "audioTracks" to emptyList<Map<String, Any?>>(),
+                    "subtitleTracks" to emptyList<Map<String, Any?>>(),
+                    "warnings" to warnings.toList(),
+                ),
+                "diagnostics" to mapOf(
+                    "elapsedMs" to (System.currentTimeMillis() - startedAt),
+                    "didUseMetadataProbe" to true,
+                    "fileSizeBytes" to fileSizeBytes,
+                    "estimatedBytesRead" to null,
+                ),
+            )
+        } finally {
+            runCatching { retriever?.release() }
+            runCatching { extractor?.release() }
+        }
+
+        if (durationMs == null || durationMs <= 0) {
+            warnings.add("duration_unavailable")
+            durationMs = null
+        }
+        if (overallBitrate == null && durationMs != null && fileSizeBytes != null && durationMs > 0) {
+            overallBitrate = (((fileSizeBytes * 8.0) / (durationMs / 1000.0))).toInt()
+            warnings.add("overall_bitrate_estimated")
+        } else if (overallBitrate == null) {
+            warnings.add("overall_bitrate_unavailable")
+        }
+        if (videoTracks.none { (it["codec"] as? String) != "unknown" }) {
+            warnings.add("video_codec_unavailable")
+        }
+        if (audioTracks.isEmpty()) {
+            warnings.add("audio_tracks_unavailable")
+        }
+        if (subtitleTracks.isEmpty()) {
+            warnings.add("subtitle_tracks_unavailable")
+        }
+        if (videoTracks.none { (it["dynamicRange"] as? String) != "unknown" }) {
+            warnings.add("hdr_unavailable")
+        }
+
+        return mapOf(
+            "status" to "complete",
+            "profile" to mapOf(
+                "schemaVersion" to "1.0.0",
+                "assetId" to request.assetId,
+                "container" to request.containerStableId(),
+                "durationMs" to durationMs,
+                "fileSizeBytes" to fileSizeBytes,
+                "overallBitrate" to overallBitrate,
+                "videoTracks" to videoTracks,
+                "audioTracks" to audioTracks,
+                "subtitleTracks" to subtitleTracks,
+                "warnings" to warnings.toList(),
+            ),
+            "diagnostics" to mapOf(
+                "elapsedMs" to (System.currentTimeMillis() - startedAt),
+                "didUseMetadataProbe" to true,
+                "fileSizeBytes" to fileSizeBytes,
+                "estimatedBytesRead" to null,
+            ),
+        )
+    }
+
+    private fun videoCodecForMimeType(mimeType: String): String {
+        return when (mimeType.lowercase()) {
+            "video/avc" -> "h264"
+            "video/hevc" -> "hevc"
+            "video/dolby-vision" -> "hevc"
+            "video/av01" -> "av1"
+            "video/x-vnd.on2.vp9" -> "vp9"
+            else -> "unknown"
+        }
+    }
+
+    private fun audioCodecForMimeType(mimeType: String): String {
+        return when (mimeType.lowercase()) {
+            "audio/mp4a-latm", "audio/aac" -> "aac"
+            "audio/ac3" -> "ac3"
+            "audio/eac3", "audio/eac3-joc" -> "eac3"
+            "audio/vnd.dts", "audio/vnd.dts.hd" -> "dts"
+            "audio/true-hd" -> "truehd"
+            "audio/opus" -> "opus"
+            "audio/mpeg" -> "mp3"
+            else -> "unknown"
+        }
+    }
+
+    private fun subtitleFormatForMimeType(mimeType: String): String {
+        return when (mimeType.lowercase()) {
+            "application/x-subrip", "text/srt" -> "srt"
+            "text/x-ssa", "text/x-ass", "application/x-ass" -> "ass"
+            "application/pgs" -> "pgs"
+            "application/vobsub" -> "vobsub"
+            "application/dvbsubs" -> "dvb"
+            else -> "unknown"
+        }
+    }
+
+    private fun dynamicRangeFor(mimeType: String, format: MediaFormat): String {
+        if (mimeType.equals("video/dolby-vision", ignoreCase = true)) {
+            return "dolby_vision"
+        }
+        val colorTransfer = format.getIntegerOrNull(MediaFormat.KEY_COLOR_TRANSFER)
+        return when (colorTransfer) {
+            MediaFormat.COLOR_TRANSFER_ST2084 -> "hdr10"
+            MediaFormat.COLOR_TRANSFER_HLG -> "hlg"
+            else -> "unknown"
+        }
+    }
+}
+
+private data class MediaAssetAnalysisRequest(
+    val assetId: String,
+    val filePath: String,
+    val fileName: String?,
+    val fileSizeBytesHint: Long?,
+    val mimeTypeHint: String?,
+) {
+    companion object {
+        fun from(arguments: Map<*, *>?): MediaAssetAnalysisRequest? {
+            if (arguments == null) return null
+            val assetId = arguments["assetId"] as? String ?: return null
+            val filePath = arguments["filePath"] as? String ?: return null
+            return MediaAssetAnalysisRequest(
+                assetId = assetId,
+                filePath = filePath,
+                fileName = arguments["fileName"] as? String,
+                fileSizeBytesHint = (arguments["fileSizeBytesHint"] as? Number)?.toLong(),
+                mimeTypeHint = arguments["mimeTypeHint"] as? String,
+            )
+        }
+    }
+
+    fun containerStableId(): String {
+        val mimeType = mimeTypeHint?.lowercase().orEmpty()
+        if ("matroska" in mimeType || "x-mkv" in mimeType) return "mkv"
+        if ("webm" in mimeType) return "webm"
+        if ("mp4" in mimeType) return "mp4"
+        if ("quicktime" in mimeType) return "mov"
+        if ("mpegts" in mimeType || "mp2t" in mimeType) return "ts"
+        val extension = fileName?.substringAfterLast('.', "")?.lowercase().orEmpty()
+        return when (extension) {
+            "mp4" -> "mp4"
+            "m4v" -> "m4v"
+            "mkv" -> "mkv"
+            "webm" -> "webm"
+            "avi" -> "avi"
+            "mov" -> "mov"
+            "ts" -> "ts"
+            "m2ts" -> "m2ts"
+            "flv" -> "flv"
+            "wmv" -> "wmv"
+            "vob" -> "vob"
+            else -> "unknown"
+        }
+    }
+}
+
+private fun MediaFormat.getIntegerOrNull(key: String): Int? {
+    return if (containsKey(key)) getInteger(key) else null
+}

--- a/app/android/app/src/main/kotlin/io/airo/app/MainActivity.kt
+++ b/app/android/app/src/main/kotlin/io/airo/app/MainActivity.kt
@@ -37,6 +37,7 @@ class MainActivity : AudioServiceActivity() {
 
     private lateinit var pictureInPicturePlugin: AiroPictureInPicturePlugin
     private lateinit var backgroundAudioPlugin: AiroBackgroundAudioPlugin
+    private lateinit var mediaAssetAnalyzerPlugin: AiroMediaAssetAnalyzerPlugin
 
     override fun shouldDestroyEngineWithHost(): Boolean {
         return false
@@ -110,6 +111,9 @@ class MainActivity : AudioServiceActivity() {
 
         backgroundAudioPlugin = AiroBackgroundAudioPlugin(this)
         backgroundAudioPlugin.register(flutterEngine.dartExecutor.binaryMessenger)
+
+        mediaAssetAnalyzerPlugin = AiroMediaAssetAnalyzerPlugin(this)
+        mediaAssetAnalyzerPlugin.register(flutterEngine.dartExecutor.binaryMessenger)
     }
 
     override fun onUserLeaveHint() {

--- a/app/ios/Runner.xcodeproj/project.pbxproj
+++ b/app/ios/Runner.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		74858FAF1ED2DC5600515810 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74858FAE1ED2DC5600515810 /* AppDelegate.swift */; };
 		1011ED82E2066711D2D92B78 /* AiroPictureInPicturePlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37DA06DDE5F7490D400C0FD4 /* AiroPictureInPicturePlugin.swift */; };
 		CC4450675FFA4697DF9EE1F3 /* AiroBackgroundAudioPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F270DAF94482DD77365C39D /* AiroBackgroundAudioPlugin.swift */; };
+		5C3C4D0E8F6A44BBA0D4C3B1 /* AiroMediaAssetAnalyzerPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C3C4D0D8F6A44BBA0D4C3B1 /* AiroMediaAssetAnalyzerPlugin.swift */; };
 		78A318202AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage in Frameworks */ = {isa = PBXBuildFile; productRef = 78A3181F2AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage */; };
 		97C146FC1CF9000F007C117D /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FA1CF9000F007C117D /* Main.storyboard */; };
 		97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FD1CF9000F007C117D /* Assets.xcassets */; };
@@ -60,6 +61,7 @@
 		74858FAE1ED2DC5600515810 /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		37DA06DDE5F7490D400C0FD4 /* AiroPictureInPicturePlugin.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AiroPictureInPicturePlugin.swift; sourceTree = "<group>"; };
 		4F270DAF94482DD77365C39D /* AiroBackgroundAudioPlugin.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AiroBackgroundAudioPlugin.swift; sourceTree = "<group>"; };
+		5C3C4D0D8F6A44BBA0D4C3B1 /* AiroMediaAssetAnalyzerPlugin.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AiroMediaAssetAnalyzerPlugin.swift; sourceTree = "<group>"; };
 		76A1DD44D701A798F4C80892 /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
 		78E0A7A72DC9AD7400C4905E /* FlutterGeneratedPluginSwiftPackage */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = FlutterGeneratedPluginSwiftPackage; path = Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage; sourceTree = "<group>"; };
 		7AFA3C8E1D35360C0083082E /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Release.xcconfig; path = Flutter/Release.xcconfig; sourceTree = "<group>"; };
@@ -169,6 +171,7 @@
 				74858FAE1ED2DC5600515810 /* AppDelegate.swift */,
 				37DA06DDE5F7490D400C0FD4 /* AiroPictureInPicturePlugin.swift */,
 				4F270DAF94482DD77365C39D /* AiroBackgroundAudioPlugin.swift */,
+				5C3C4D0D8F6A44BBA0D4C3B1 /* AiroMediaAssetAnalyzerPlugin.swift */,
 				74858FAD1ED2DC5600515810 /* Runner-Bridging-Header.h */,
 			);
 			path = Runner;
@@ -413,6 +416,7 @@
 				74858FAF1ED2DC5600515810 /* AppDelegate.swift in Sources */,
 				1011ED82E2066711D2D92B78 /* AiroPictureInPicturePlugin.swift in Sources */,
 				CC4450675FFA4697DF9EE1F3 /* AiroBackgroundAudioPlugin.swift in Sources */,
+				5C3C4D0E8F6A44BBA0D4C3B1 /* AiroMediaAssetAnalyzerPlugin.swift in Sources */,
 				1498D2341E8E89220040F4C2 /* GeneratedPluginRegistrant.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/app/ios/Runner/AiroMediaAssetAnalyzerPlugin.swift
+++ b/app/ios/Runner/AiroMediaAssetAnalyzerPlugin.swift
@@ -1,0 +1,348 @@
+import AVFoundation
+import CoreMedia
+import CoreVideo
+import Flutter
+import Foundation
+
+final class AiroMediaAssetAnalyzerPlugin: NSObject {
+  static let channelName = "com.airo.media_asset_analyzer"
+
+  func register(with messenger: FlutterBinaryMessenger) {
+    let channel = FlutterMethodChannel(name: Self.channelName, binaryMessenger: messenger)
+    channel.setMethodCallHandler { [weak self] call, result in
+      self?.handle(call, result: result)
+    }
+  }
+
+  private func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
+    guard call.method == "analyze" else {
+      result(FlutterMethodNotImplemented)
+      return
+    }
+    guard let arguments = call.arguments as? [String: Any],
+          let request = MediaAssetAnalysisRequest(arguments: arguments)
+    else {
+      result(
+        FlutterError(
+          code: "invalid_arguments",
+          message: "Media asset analyzer requires assetId and filePath.",
+          details: nil
+        )
+      )
+      return
+    }
+
+    Task {
+      let payload = await analyze(request)
+      await MainActor.run {
+        result(payload)
+      }
+    }
+  }
+
+  private func analyze(_ request: MediaAssetAnalysisRequest) async -> [String: Any] {
+    let startedAt = Date()
+    var warnings = OrderedStringSet()
+    let container = request.containerStableId()
+    let fileSizeBytes = request.fileSizeBytesHint ?? fileSize(request.filePath)
+    if fileSizeBytes == nil {
+      warnings.append("file_size_unavailable")
+    }
+
+    let asset = AVURLAsset(url: URL(fileURLWithPath: request.filePath))
+
+    do {
+      let duration = try await asset.load(.duration)
+      let tracks = try await asset.load(.tracks)
+      let durationMs = duration.isNumeric ? Int((CMTimeGetSeconds(duration) * 1000.0).rounded()) : nil
+      var overallBitrate = 0
+      var videoTracks = [[String: Any]]()
+      var audioTracks = [[String: Any]]()
+      var subtitleTracks = [[String: Any]]()
+
+      for (index, track) in tracks.enumerated() {
+        let mediaType = try await track.load(.mediaType)
+        let estimatedDataRate = Int((try? await track.load(.estimatedDataRate)).map { $0.rounded() } ?? 0)
+        if estimatedDataRate > 0 {
+          overallBitrate += estimatedDataRate
+        }
+
+        switch mediaType {
+        case .video:
+          let naturalSize = try? await track.load(.naturalSize)
+          let formatDescriptions = try? await track.load(.formatDescriptions)
+          let codec = videoCodecStableId(formatDescriptions?.first)
+          let dynamicRange = dynamicRangeStableId(formatDescriptions?.first, codec: codec)
+          videoTracks.append([
+            "id": "video-\(index)",
+            "codec": codec,
+            "width": Int(naturalSize?.width.rounded() ?? 0),
+            "height": Int(naturalSize?.height.rounded() ?? 0),
+            "bitrate": estimatedDataRate > 0 ? estimatedDataRate : NSNull(),
+            "dynamicRange": dynamicRange,
+            "confidence": "exact",
+          ])
+        case .audio:
+          let formatDescriptions = try? await track.load(.formatDescriptions)
+          let locale = try? await track.load(.extendedLanguageTag)
+          let commonMetadata = try? await track.load(.commonMetadata)
+          audioTracks.append([
+            "id": "audio-\(index)",
+            "codec": audioCodecStableId(formatDescriptions?.first),
+            "language": locale ?? NSNull(),
+            "label": trackLabel(commonMetadata) ?? NSNull(),
+            "channelCount": audioChannelCount(formatDescriptions?.first) ?? NSNull(),
+            "isDefault": false,
+            "isCommentary": false,
+            "confidence": "exact",
+          ])
+        case .subtitle, .text, .closedCaption:
+          let formatDescriptions = try? await track.load(.formatDescriptions)
+          let locale = try? await track.load(.extendedLanguageTag)
+          let commonMetadata = try? await track.load(.commonMetadata)
+          subtitleTracks.append([
+            "id": "subtitle-\(index)",
+            "format": subtitleFormatStableId(formatDescriptions?.first, mediaType: mediaType),
+            "language": locale ?? NSNull(),
+            "label": trackLabel(commonMetadata) ?? NSNull(),
+            "isDefault": false,
+            "isForced": false,
+            "isCommentary": false,
+            "confidence": "exact",
+          ])
+        default:
+          continue
+        }
+      }
+
+      if durationMs == nil || durationMs == 0 {
+        warnings.append("duration_unavailable")
+      }
+      if overallBitrate == 0, let fileSizeBytes, let durationMs, durationMs > 0 {
+        overallBitrate = Int(((Double(fileSizeBytes) * 8.0) / (Double(durationMs) / 1000.0)).rounded())
+        warnings.append("overall_bitrate_estimated")
+      } else if overallBitrate == 0 {
+        warnings.append("overall_bitrate_unavailable")
+      }
+      if videoTracks.allSatisfy({ ($0["codec"] as? String) == "unknown" }) {
+        warnings.append("video_codec_unavailable")
+      }
+      if audioTracks.isEmpty {
+        warnings.append("audio_tracks_unavailable")
+      }
+      if subtitleTracks.isEmpty {
+        warnings.append("subtitle_tracks_unavailable")
+      }
+      if videoTracks.allSatisfy({ ($0["dynamicRange"] as? String) == "unknown" }) {
+        warnings.append("hdr_unavailable")
+      }
+
+      return [
+        "status": "complete",
+        "profile": [
+          "schemaVersion": "1.0.0",
+          "assetId": request.assetId,
+          "container": container,
+          "durationMs": durationMs as Any,
+          "fileSizeBytes": fileSizeBytes as Any,
+          "overallBitrate": overallBitrate > 0 ? overallBitrate : NSNull(),
+          "videoTracks": videoTracks,
+          "audioTracks": audioTracks,
+          "subtitleTracks": subtitleTracks,
+          "warnings": warnings.values,
+        ],
+        "diagnostics": [
+          "elapsedMs": Int(Date().timeIntervalSince(startedAt) * 1000.0),
+          "didUseMetadataProbe": true,
+          "fileSizeBytes": fileSizeBytes as Any,
+          "estimatedBytesRead": NSNull(),
+        ],
+      ]
+    } catch {
+      warnings.append("metadata_probe_failed")
+      return [
+        "status": "inspection_failed",
+        "failureReason": "metadata_probe_failed",
+        "profile": [
+          "schemaVersion": "1.0.0",
+          "assetId": request.assetId,
+          "container": container,
+          "durationMs": NSNull(),
+          "fileSizeBytes": fileSizeBytes as Any,
+          "overallBitrate": NSNull(),
+          "videoTracks": [],
+          "audioTracks": [],
+          "subtitleTracks": [],
+          "warnings": warnings.values,
+        ],
+        "diagnostics": [
+          "elapsedMs": Int(Date().timeIntervalSince(startedAt) * 1000.0),
+          "didUseMetadataProbe": true,
+          "fileSizeBytes": fileSizeBytes as Any,
+          "estimatedBytesRead": NSNull(),
+        ],
+      ]
+    }
+  }
+
+  private func fileSize(_ filePath: String) -> Int? {
+    let attributes = try? FileManager.default.attributesOfItem(atPath: filePath)
+    return attributes?[.size] as? Int
+  }
+
+  private func trackLabel(_ metadata: [AVMetadataItem]?) -> String? {
+    metadata?
+      .first(where: { $0.commonKey == .commonKeyTitle })?
+      .stringValue
+  }
+
+  private func videoCodecStableId(_ description: Any?) -> String {
+    guard let description = description as? CMFormatDescription else {
+      return "unknown"
+    }
+    switch CMFormatDescriptionGetMediaSubType(description) {
+    case kCMVideoCodecType_H264:
+      return "h264"
+    case kCMVideoCodecType_HEVC:
+      return "hevc"
+    case kCMVideoCodecType_AV1:
+      return "av1"
+    case kCMVideoCodecType_VP9:
+      return "vp9"
+    case makeFourCC("dvh1"), makeFourCC("dvhe"):
+      return "hevc"
+    default:
+      return "unknown"
+    }
+  }
+
+  private func audioCodecStableId(_ description: Any?) -> String {
+    guard let description = description as? CMAudioFormatDescription else {
+      return "unknown"
+    }
+    switch CMAudioFormatDescriptionGetMediaSubType(description) {
+    case kAudioFormatMPEG4AAC, kAudioFormatMPEG4AAC_HE:
+      return "aac"
+    case kAudioFormatAC3:
+      return "ac3"
+    case kAudioFormatEnhancedAC3:
+      return "eac3"
+    case makeFourCC("dtsc"), makeFourCC("dtsh"), makeFourCC("dtsl"):
+      return "dts"
+    case kAudioFormatOpus:
+      return "opus"
+    case kAudioFormatMPEGLayer3:
+      return "mp3"
+    case makeFourCC("mlpa"):
+      return "truehd"
+    default:
+      return "unknown"
+    }
+  }
+
+  private func audioChannelCount(_ description: Any?) -> Int? {
+    guard let description = description as? CMAudioFormatDescription,
+          let streamDescription = CMAudioFormatDescriptionGetStreamBasicDescription(description)
+    else {
+      return nil
+    }
+    return Int(streamDescription.pointee.mChannelsPerFrame)
+  }
+
+  private func subtitleFormatStableId(_ description: Any?, mediaType: AVMediaType) -> String {
+    guard let description = description as? CMFormatDescription else {
+      return mediaType == .closedCaption ? "unknown" : "unknown"
+    }
+    switch CMFormatDescriptionGetMediaSubType(description) {
+    case makeFourCC("wvtt"), makeFourCC("tx3g"):
+      return "unknown"
+    default:
+      return "unknown"
+    }
+  }
+
+  private func dynamicRangeStableId(_ description: Any?, codec: String) -> String {
+    if codec == "hevc",
+       let description = description as? CMFormatDescription,
+       let extensions = CMFormatDescriptionGetExtensions(description) as? [CFString: Any],
+       let transferFunction = extensions[kCVImageBufferTransferFunctionKey] as? String
+    {
+      switch transferFunction {
+      case kCVImageBufferTransferFunction_SMPTE_ST_2084_PQ as String:
+        return "hdr10"
+      case kCVImageBufferTransferFunction_ITU_R_2100_HLG as String:
+        return "hlg"
+      default:
+        break
+      }
+    }
+    if codec == "hevc",
+       let description = description as? CMFormatDescription
+    {
+      let subtype = CMFormatDescriptionGetMediaSubType(description)
+      if subtype == makeFourCC("dvh1") || subtype == makeFourCC("dvhe") {
+        return "dolby_vision"
+      }
+    }
+    return "unknown"
+  }
+}
+
+private struct MediaAssetAnalysisRequest {
+  let assetId: String
+  let filePath: String
+  let fileName: String?
+  let fileSizeBytesHint: Int?
+  let mimeTypeHint: String?
+
+  init?(arguments: [String: Any]) {
+    guard let assetId = arguments["assetId"] as? String,
+          let filePath = arguments["filePath"] as? String
+    else {
+      return nil
+    }
+    self.assetId = assetId
+    self.filePath = filePath
+    self.fileName = arguments["fileName"] as? String
+    self.fileSizeBytesHint = arguments["fileSizeBytesHint"] as? Int
+    self.mimeTypeHint = arguments["mimeTypeHint"] as? String
+  }
+
+  func containerStableId() -> String {
+    let mimeType = mimeTypeHint?.lowercased() ?? ""
+    if mimeType.contains("matroska") || mimeType.contains("x-mkv") { return "mkv" }
+    if mimeType.contains("webm") { return "webm" }
+    if mimeType.contains("mp4") { return "mp4" }
+    if mimeType.contains("quicktime") { return "mov" }
+    if mimeType.contains("mpegts") || mimeType.contains("mp2t") { return "ts" }
+
+    let ext = (fileName as NSString?)?.pathExtension.lowercased() ?? ""
+    switch ext {
+    case "mp4": return "mp4"
+    case "m4v": return "m4v"
+    case "mkv": return "mkv"
+    case "webm": return "webm"
+    case "avi": return "avi"
+    case "mov": return "mov"
+    case "ts": return "ts"
+    case "m2ts": return "m2ts"
+    case "flv": return "flv"
+    case "wmv": return "wmv"
+    case "vob": return "vob"
+    default: return "unknown"
+    }
+  }
+}
+
+private struct OrderedStringSet {
+  private(set) var values: [String] = []
+
+  mutating func append(_ value: String) {
+    guard !values.contains(value) else { return }
+    values.append(value)
+  }
+}
+
+private func makeFourCC(_ string: String) -> FourCharCode {
+  string.utf8.reduce(0) { ($0 << 8) + FourCharCode($1) }
+}

--- a/app/ios/Runner/AiroMediaAssetAnalyzerPlugin.swift
+++ b/app/ios/Runner/AiroMediaAssetAnalyzerPlugin.swift
@@ -61,7 +61,7 @@ final class AiroMediaAssetAnalyzerPlugin: NSObject {
       var subtitleTracks = [[String: Any]]()
 
       for (index, track) in tracks.enumerated() {
-        let mediaType = try await track.load(.mediaType)
+        let mediaType = track.mediaType
         let estimatedDataRate = Int((try? await track.load(.estimatedDataRate)).map { $0.rounded() } ?? 0)
         if estimatedDataRate > 0 {
           overallBitrate += estimatedDataRate
@@ -71,8 +71,9 @@ final class AiroMediaAssetAnalyzerPlugin: NSObject {
         case .video:
           let naturalSize = try? await track.load(.naturalSize)
           let formatDescriptions = try? await track.load(.formatDescriptions)
-          let codec = videoCodecStableId(formatDescriptions?.first)
-          let dynamicRange = dynamicRangeStableId(formatDescriptions?.first, codec: codec)
+          let primaryFormatDescription = formatDescriptions?.first
+          let codec = videoCodecStableId(primaryFormatDescription)
+          let dynamicRange = dynamicRangeStableId(primaryFormatDescription, codec: codec)
           videoTracks.append([
             "id": "video-\(index)",
             "codec": codec,
@@ -84,25 +85,27 @@ final class AiroMediaAssetAnalyzerPlugin: NSObject {
           ])
         case .audio:
           let formatDescriptions = try? await track.load(.formatDescriptions)
+          let primaryFormatDescription = formatDescriptions?.first
           let locale = try? await track.load(.extendedLanguageTag)
           let commonMetadata = try? await track.load(.commonMetadata)
           audioTracks.append([
             "id": "audio-\(index)",
-            "codec": audioCodecStableId(formatDescriptions?.first),
+            "codec": audioCodecStableId(primaryFormatDescription),
             "language": locale ?? NSNull(),
             "label": trackLabel(commonMetadata) ?? NSNull(),
-            "channelCount": audioChannelCount(formatDescriptions?.first) ?? NSNull(),
+            "channelCount": audioChannelCount(primaryFormatDescription) ?? NSNull(),
             "isDefault": false,
             "isCommentary": false,
             "confidence": "exact",
           ])
         case .subtitle, .text, .closedCaption:
           let formatDescriptions = try? await track.load(.formatDescriptions)
+          let primaryFormatDescription = formatDescriptions?.first
           let locale = try? await track.load(.extendedLanguageTag)
           let commonMetadata = try? await track.load(.commonMetadata)
           subtitleTracks.append([
             "id": "subtitle-\(index)",
-            "format": subtitleFormatStableId(formatDescriptions?.first, mediaType: mediaType),
+            "format": subtitleFormatStableId(primaryFormatDescription, mediaType: mediaType),
             "language": locale ?? NSNull(),
             "label": trackLabel(commonMetadata) ?? NSNull(),
             "isDefault": false,
@@ -196,8 +199,8 @@ final class AiroMediaAssetAnalyzerPlugin: NSObject {
       .stringValue
   }
 
-  private func videoCodecStableId(_ description: Any?) -> String {
-    guard let description = description as? CMFormatDescription else {
+  private func videoCodecStableId(_ description: CMFormatDescription?) -> String {
+    guard let description else {
       return "unknown"
     }
     switch CMFormatDescriptionGetMediaSubType(description) {
@@ -216,11 +219,11 @@ final class AiroMediaAssetAnalyzerPlugin: NSObject {
     }
   }
 
-  private func audioCodecStableId(_ description: Any?) -> String {
-    guard let description = description as? CMAudioFormatDescription else {
+  private func audioCodecStableId(_ description: CMFormatDescription?) -> String {
+    guard let description else {
       return "unknown"
     }
-    switch CMAudioFormatDescriptionGetMediaSubType(description) {
+    switch CMFormatDescriptionGetMediaSubType(description) {
     case kAudioFormatMPEG4AAC, kAudioFormatMPEG4AAC_HE:
       return "aac"
     case kAudioFormatAC3:
@@ -240,8 +243,8 @@ final class AiroMediaAssetAnalyzerPlugin: NSObject {
     }
   }
 
-  private func audioChannelCount(_ description: Any?) -> Int? {
-    guard let description = description as? CMAudioFormatDescription,
+  private func audioChannelCount(_ description: CMFormatDescription?) -> Int? {
+    guard let description,
           let streamDescription = CMAudioFormatDescriptionGetStreamBasicDescription(description)
     else {
       return nil
@@ -249,8 +252,11 @@ final class AiroMediaAssetAnalyzerPlugin: NSObject {
     return Int(streamDescription.pointee.mChannelsPerFrame)
   }
 
-  private func subtitleFormatStableId(_ description: Any?, mediaType: AVMediaType) -> String {
-    guard let description = description as? CMFormatDescription else {
+  private func subtitleFormatStableId(
+    _ description: CMFormatDescription?,
+    mediaType: AVMediaType
+  ) -> String {
+    guard let description else {
       return mediaType == .closedCaption ? "unknown" : "unknown"
     }
     switch CMFormatDescriptionGetMediaSubType(description) {
@@ -261,23 +267,24 @@ final class AiroMediaAssetAnalyzerPlugin: NSObject {
     }
   }
 
-  private func dynamicRangeStableId(_ description: Any?, codec: String) -> String {
+  private func dynamicRangeStableId(_ description: CMFormatDescription?, codec: String) -> String {
     if codec == "hevc",
-       let description = description as? CMFormatDescription,
+       let description,
        let extensions = CMFormatDescriptionGetExtensions(description) as? [CFString: Any],
-       let transferFunction = extensions[kCVImageBufferTransferFunctionKey] as? String
+       let transferFunction = extensions[kCVImageBufferTransferFunctionKey]
     {
-      switch transferFunction {
-      case kCVImageBufferTransferFunction_SMPTE_ST_2084_PQ as String:
+      let transferFunctionValue = String(describing: transferFunction)
+      switch transferFunctionValue {
+      case String(describing: kCVImageBufferTransferFunction_SMPTE_ST_2084_PQ):
         return "hdr10"
-      case kCVImageBufferTransferFunction_ITU_R_2100_HLG as String:
+      case String(describing: kCVImageBufferTransferFunction_ITU_R_2100_HLG):
         return "hlg"
       default:
         break
       }
     }
     if codec == "hevc",
-       let description = description as? CMFormatDescription
+       let description
     {
       let subtype = CMFormatDescriptionGetMediaSubType(description)
       if subtype == makeFourCC("dvh1") || subtype == makeFourCC("dvhe") {

--- a/app/ios/Runner/AppDelegate.swift
+++ b/app/ios/Runner/AppDelegate.swift
@@ -1,4 +1,3 @@
-import EventKit
 import EventKitUI
 import Flutter
 import EventKit
@@ -11,6 +10,7 @@ import UIKit
   private var pendingCreateEventResult: FlutterResult?
   private let pictureInPicturePlugin = AiroPictureInPicturePlugin()
   private let backgroundAudioPlugin = AiroBackgroundAudioPlugin()
+  private let mediaAssetAnalyzerPlugin = AiroMediaAssetAnalyzerPlugin()
 
   override func application(
     _ application: UIApplication,
@@ -18,17 +18,19 @@ import UIKit
   ) -> Bool {
     GeneratedPluginRegistrant.register(with: self)
 
-    if let controller = window?.rootViewController as? FlutterViewController {
+    if let registrar = registrar(forPlugin: "AiroAppDelegate") {
+      let messenger = registrar.messenger()
       let channel = FlutterMethodChannel(
         name: agentConnectorsChannel,
-        binaryMessenger: controller.binaryMessenger
+        binaryMessenger: messenger
       )
       channel.setMethodCallHandler { [weak self] call, result in
         self?.handleAgentConnectorCall(call, result: result)
       }
 
-      pictureInPicturePlugin.register(with: controller.binaryMessenger)
-      backgroundAudioPlugin.register(with: controller.binaryMessenger)
+      pictureInPicturePlugin.register(with: messenger)
+      backgroundAudioPlugin.register(with: messenger)
+      mediaAssetAnalyzerPlugin.register(with: messenger)
     }
 
     return super.application(application, didFinishLaunchingWithOptions: launchOptions)

--- a/app/lib/features/iptv/phone_media_local_picker.dart
+++ b/app/lib/features/iptv/phone_media_local_picker.dart
@@ -1,4 +1,5 @@
 import 'package:file_picker/file_picker.dart';
+import 'package:platform_media/platform_media.dart';
 import 'package:platform_player/platform_player.dart';
 
 /// Lets an experimental build pick a phone-local video file to stream to a
@@ -14,10 +15,43 @@ Future<PhoneLocalMediaItem?> pickPhoneLocalMediaForTv() async {
   final file = files.first;
   final path = file.path;
   if (path == null) return null;
+  final analysis = await DefaultLocalMediaAssetAnalyzer().analyze(
+    MediaAssetAnalysisRequest(
+      assetId: file.identifier ?? file.name,
+      filePath: path,
+      fileName: file.name,
+      fileSizeBytesHint: file.size > 0 ? file.size : null,
+    ),
+  );
+  final profile = analysis.profile;
+  final primaryVideoTrack = profile != null && profile.videoTracks.isNotEmpty
+      ? profile.videoTracks.first
+      : null;
+  final primaryAudioTrack = profile != null && profile.audioTracks.isNotEmpty
+      ? profile.audioTracks.first
+      : null;
 
   return PhoneLocalMediaItem(
     filePath: path,
     title: file.name,
-    container: (file.extension ?? '').toLowerCase(),
+    container:
+        profile?.container.stableId ?? (file.extension ?? '').toLowerCase(),
+    videoCodec: _mapVideoCodec(primaryVideoTrack?.codec),
+    audioCodec: _mapAudioCodec(primaryAudioTrack?.codec),
+    duration: profile?.duration,
   );
+}
+
+String? _mapVideoCodec(MediaVideoCodec? codec) {
+  return switch (codec) {
+    null || MediaVideoCodec.unknown => null,
+    _ => codec.stableId,
+  };
+}
+
+String? _mapAudioCodec(MediaAudioCodec? codec) {
+  return switch (codec) {
+    null || MediaAudioCodec.unknown => null,
+    _ => codec.stableId,
+  };
 }

--- a/app/lib/firebase_options.dart
+++ b/app/lib/firebase_options.dart
@@ -1,26 +1,17 @@
-// Firebase configuration with multi-platform variant support
+// Placeholder Firebase configuration with multi-platform variant support.
+//
+// This checked-in file keeps local analysis/builds working when no secret
+// Firebase config has been provisioned. CI and release workflows may overwrite
+// it with real values from `FIREBASE_OPTIONS_DART_B64`.
+//
+// Do not commit real Firebase keys into this file.
+//
 // Supports: Mobile Full (io.airo.app), Mobile Streaming
 // (io.airo.app.streaming), Android TV (io.airo.app.tv)
-//
-// This is a TEMPLATE. To use:
-// 1. Copy or write to app/lib/firebase_options.dart.
-// 2. Fill in the real `web`, `android`, and `androidTv` values from the Firebase
-//    Console (Project settings > Your apps) or from the `GOOGLE_SERVICES_JSON` /
-//    `FIREBASE_OPTIONS_DART` secrets used by the release workflows.
-// 3. Leave the `androidStreaming`, `ios`, `macos`, and `windows` entries as
-//    placeholders until those apps are registered in the Firebase project --
-//    `DefaultFirebaseOptions.isCurrentPlatformConfigured` skips Firebase init
-//    for any entry whose appId still contains `YOUR_` or `TODO`, so shipping
-//    with placeholders there is safe and intentional, not a bug.
-//
-// Build with variant:
-//   flutter build apk --dart-define=APP_VARIANT=tv
-//   flutter build apk --dart-define=APP_VARIANT=streaming
-//   flutter build apk --dart-define=APP_VARIANT=full (default)
 
 import 'package:firebase_core/firebase_core.dart' show FirebaseOptions;
 import 'package:flutter/foundation.dart'
-    show defaultTargetPlatform, kIsWeb, TargetPlatform;
+    show TargetPlatform, defaultTargetPlatform, kIsWeb;
 
 /// App variant for Firebase configuration selection
 // Set via --dart-define=APP_VARIANT=<value>

--- a/app/test/firebase_options_test.dart
+++ b/app/test/firebase_options_test.dart
@@ -60,9 +60,16 @@ void main() {
       );
     });
 
-    test('selects the supported full and TV variants', () {
-      expect(AppVariant.values, containsAll([AppVariant.full, AppVariant.tv]));
-      expect(AppVariant.values, hasLength(2));
+    test('selects the supported full, streaming, and TV variants', () {
+      expect(
+        AppVariant.values,
+        containsAll([
+          AppVariant.full,
+          AppVariant.streaming,
+          AppVariant.tv,
+        ]),
+      );
+      expect(AppVariant.values, hasLength(3));
     });
   });
 }

--- a/packages/platform_media/lib/platform_media.dart
+++ b/packages/platform_media/lib/platform_media.dart
@@ -1,7 +1,9 @@
 library;
 
 export "src/media_capability_models.dart";
+export "src/media_asset_profile_models.dart";
 export "src/media_error_taxonomy_models.dart";
+export "src/local_media_asset_analyzer.dart";
 export "src/platform_media_logger.dart";
 export "src/streaming_error_diagnostic_mapping.dart";
 export "src/streaming_media_session_delegate.dart";

--- a/packages/platform_media/lib/src/local_media_asset_analyzer.dart
+++ b/packages/platform_media/lib/src/local_media_asset_analyzer.dart
@@ -1,0 +1,387 @@
+import 'dart:io';
+
+import 'package:flutter/foundation.dart' show visibleForTesting;
+import 'package:flutter/services.dart';
+import 'package:video_player/video_player.dart';
+
+import 'media_asset_profile_models.dart';
+
+abstract class LocalMediaAssetAnalyzer {
+  Future<MediaAssetAnalysisResult> analyze(MediaAssetAnalysisRequest request);
+}
+
+class DefaultLocalMediaAssetAnalyzer implements LocalMediaAssetAnalyzer {
+  DefaultLocalMediaAssetAnalyzer({
+    LocalMediaAssetAnalyzer? nativeAnalyzer,
+    LocalMediaAssetAnalyzer? fallbackAnalyzer,
+  }) : _nativeAnalyzer = nativeAnalyzer ?? HostPlatformMediaAssetAnalyzer(),
+       _fallbackAnalyzer =
+           fallbackAnalyzer ?? const VideoPlayerLocalMediaAssetAnalyzer();
+
+  final LocalMediaAssetAnalyzer _nativeAnalyzer;
+  final LocalMediaAssetAnalyzer _fallbackAnalyzer;
+
+  @override
+  Future<MediaAssetAnalysisResult> analyze(
+    MediaAssetAnalysisRequest request,
+  ) async {
+    final nativeResult = await _nativeAnalyzer.analyze(request);
+    if (nativeResult.status != MediaAssetAnalysisStatus.unsupportedInspection) {
+      return nativeResult;
+    }
+    return _fallbackAnalyzer.analyze(request);
+  }
+}
+
+class HostPlatformMediaAssetAnalyzer implements LocalMediaAssetAnalyzer {
+  HostPlatformMediaAssetAnalyzer({MethodChannel? channel})
+    : _channel = channel ?? _defaultChannel;
+
+  static MethodChannel _defaultChannel = const MethodChannel(
+    'com.airo.media_asset_analyzer',
+  );
+
+  final MethodChannel _channel;
+
+  @override
+  Future<MediaAssetAnalysisResult> analyze(
+    MediaAssetAnalysisRequest request,
+  ) async {
+    try {
+      final raw = await _channel.invokeMapMethod<String, Object?>('analyze', {
+        'assetId': request.assetId,
+        'filePath': request.filePath,
+        'fileName': request.fileName,
+        'fileSizeBytesHint': request.fileSizeBytesHint,
+        'mimeTypeHint': request.mimeTypeHint,
+      });
+      if (raw == null) {
+        return _unsupportedResult();
+      }
+      return _parseResult(raw);
+    } on MissingPluginException {
+      return _unsupportedResult();
+    } on PlatformException catch (error) {
+      return MediaAssetAnalysisResult(
+        status: MediaAssetAnalysisStatus.inspectionFailed,
+        failureReason: error.code,
+        diagnostics: const MediaAssetAnalysisDiagnostics(
+          elapsed: Duration.zero,
+          didUseMetadataProbe: false,
+        ),
+      );
+    }
+  }
+
+  MediaAssetAnalysisResult _unsupportedResult() {
+    return const MediaAssetAnalysisResult(
+      status: MediaAssetAnalysisStatus.unsupportedInspection,
+      diagnostics: MediaAssetAnalysisDiagnostics(
+        elapsed: Duration.zero,
+        didUseMetadataProbe: false,
+      ),
+    );
+  }
+
+  MediaAssetAnalysisResult _parseResult(Map<String, Object?> raw) {
+    return MediaAssetAnalysisResult(
+      status: _analysisStatusFromStableId(raw['status'] as String?),
+      failureReason: raw['failureReason'] as String?,
+      diagnostics: _parseDiagnostics(
+        raw['diagnostics'] as Map<Object?, Object?>? ?? const {},
+      ),
+      profile: _parseProfile(raw['profile'] as Map<Object?, Object?>?),
+    );
+  }
+
+  MediaAssetAnalysisDiagnostics _parseDiagnostics(Map<Object?, Object?> raw) {
+    return MediaAssetAnalysisDiagnostics(
+      elapsed: Duration(milliseconds: (raw['elapsedMs'] as num?)?.round() ?? 0),
+      didUseMetadataProbe: raw['didUseMetadataProbe'] as bool? ?? false,
+      fileSizeBytes: (raw['fileSizeBytes'] as num?)?.round(),
+      estimatedBytesRead: (raw['estimatedBytesRead'] as num?)?.round(),
+    );
+  }
+
+  MediaAssetProfile? _parseProfile(Map<Object?, Object?>? raw) {
+    if (raw == null) return null;
+    return MediaAssetProfile(
+      schemaVersion:
+          raw['schemaVersion'] as String? ?? kMediaAssetProfileSchemaVersion,
+      assetId: raw['assetId'] as String? ?? 'unknown',
+      container: _containerFromStableId(raw['container'] as String?),
+      duration: _durationFromMs(raw['durationMs']),
+      fileSizeBytes: (raw['fileSizeBytes'] as num?)?.round(),
+      overallBitrate: (raw['overallBitrate'] as num?)?.round(),
+      videoTracks: _parseVideoTracks(raw['videoTracks']),
+      audioTracks: _parseAudioTracks(raw['audioTracks']),
+      subtitleTracks: _parseSubtitleTracks(raw['subtitleTracks']),
+      warnings: _parseWarnings(raw['warnings']),
+    );
+  }
+
+  List<MediaVideoTrackProfile> _parseVideoTracks(Object? rawTracks) {
+    final tracks = rawTracks as List<Object?>? ?? const [];
+    return tracks
+        .whereType<Map<Object?, Object?>>()
+        .map(
+          (raw) => MediaVideoTrackProfile(
+            id: raw['id'] as String? ?? 'video-unknown',
+            codec: _videoCodecFromStableId(raw['codec'] as String?),
+            bitrate: (raw['bitrate'] as num?)?.round(),
+            dynamicRange: _dynamicRangeFromStableId(
+              raw['dynamicRange'] as String?,
+            ),
+            confidence: _confidenceFromStableId(raw['confidence'] as String?),
+            dimensions: MediaAssetDimensions(
+              width: (raw['width'] as num?)?.round() ?? 0,
+              height: (raw['height'] as num?)?.round() ?? 0,
+            ),
+          ),
+        )
+        .toList(growable: false);
+  }
+
+  List<MediaAudioTrackProfile> _parseAudioTracks(Object? rawTracks) {
+    final tracks = rawTracks as List<Object?>? ?? const [];
+    return tracks
+        .whereType<Map<Object?, Object?>>()
+        .map(
+          (raw) => MediaAudioTrackProfile(
+            id: raw['id'] as String? ?? 'audio-unknown',
+            codec: _audioCodecFromStableId(raw['codec'] as String?),
+            confidence: _confidenceFromStableId(raw['confidence'] as String?),
+            language: raw['language'] as String?,
+            label: raw['label'] as String?,
+            channelCount: (raw['channelCount'] as num?)?.round(),
+            isDefault: raw['isDefault'] as bool? ?? false,
+            isCommentary: raw['isCommentary'] as bool? ?? false,
+          ),
+        )
+        .toList(growable: false);
+  }
+
+  List<MediaSubtitleTrackProfile> _parseSubtitleTracks(Object? rawTracks) {
+    final tracks = rawTracks as List<Object?>? ?? const [];
+    return tracks
+        .whereType<Map<Object?, Object?>>()
+        .map(
+          (raw) => MediaSubtitleTrackProfile(
+            id: raw['id'] as String? ?? 'subtitle-unknown',
+            format: _subtitleFormatFromStableId(raw['format'] as String?),
+            confidence: _confidenceFromStableId(raw['confidence'] as String?),
+            language: raw['language'] as String?,
+            label: raw['label'] as String?,
+            isDefault: raw['isDefault'] as bool? ?? false,
+            isForced: raw['isForced'] as bool? ?? false,
+            isCommentary: raw['isCommentary'] as bool? ?? false,
+          ),
+        )
+        .toList(growable: false);
+  }
+
+  List<MediaAssetWarningCode> _parseWarnings(Object? rawWarnings) {
+    final warnings = rawWarnings as List<Object?>? ?? const [];
+    return warnings
+        .whereType<String>()
+        .map(_warningCodeFromStableId)
+        .toList(growable: false);
+  }
+
+  Duration? _durationFromMs(Object? raw) {
+    final milliseconds = (raw as num?)?.round();
+    if (milliseconds == null || milliseconds <= 0) return null;
+    return Duration(milliseconds: milliseconds);
+  }
+
+  @visibleForTesting
+  static void debugSetMethodChannel(MethodChannel channel) {
+    _defaultChannel = channel;
+  }
+}
+
+class VideoPlayerLocalMediaAssetAnalyzer implements LocalMediaAssetAnalyzer {
+  const VideoPlayerLocalMediaAssetAnalyzer();
+
+  @override
+  Future<MediaAssetAnalysisResult> analyze(
+    MediaAssetAnalysisRequest request,
+  ) async {
+    final startedAt = DateTime.now();
+    final warnings = <MediaAssetWarningCode>[];
+    final container = _resolveContainer(request, warnings);
+
+    int? fileSizeBytes = request.fileSizeBytesHint;
+    if (fileSizeBytes == null) {
+      try {
+        fileSizeBytes = await File(request.filePath).length();
+      } catch (_) {
+        warnings.add(MediaAssetWarningCode.fileSizeUnavailable);
+      }
+    }
+
+    Duration? duration;
+    MediaAssetDimensions dimensions = const MediaAssetDimensions(
+      width: 0,
+      height: 0,
+    );
+    var didUseMetadataProbe = false;
+    String? failureReason;
+
+    final controller = VideoPlayerController.file(File(request.filePath));
+    try {
+      didUseMetadataProbe = true;
+      await controller.initialize();
+      duration = controller.value.duration;
+      final size = controller.value.size;
+      dimensions = MediaAssetDimensions(
+        width: size.width.round(),
+        height: size.height.round(),
+      );
+    } catch (_) {
+      warnings.add(MediaAssetWarningCode.metadataProbeFailed);
+      failureReason = 'metadata_probe_failed';
+    } finally {
+      await controller.dispose();
+    }
+
+    if (duration == null || duration == Duration.zero) {
+      warnings.add(MediaAssetWarningCode.durationUnavailable);
+      duration = null;
+    }
+    final overallBitrate = duration != null && fileSizeBytes != null
+        ? _estimatedBitrateBitsPerSecond(
+            fileSizeBytes: fileSizeBytes,
+            duration: duration,
+          )
+        : null;
+    if (overallBitrate == null) {
+      warnings.add(MediaAssetWarningCode.overallBitrateUnavailable);
+    } else {
+      warnings.add(MediaAssetWarningCode.overallBitrateEstimated);
+    }
+    warnings.add(MediaAssetWarningCode.videoCodecUnavailable);
+    warnings.add(MediaAssetWarningCode.audioTracksUnavailable);
+    warnings.add(MediaAssetWarningCode.subtitleTracksUnavailable);
+    warnings.add(MediaAssetWarningCode.hdrUnavailable);
+
+    final profile = MediaAssetProfile(
+      assetId: request.assetId,
+      container: container,
+      duration: duration,
+      fileSizeBytes: fileSizeBytes,
+      overallBitrate: overallBitrate,
+      videoTracks: [
+        MediaVideoTrackProfile(
+          id: 'video-0',
+          codec: MediaVideoCodec.unknown,
+          dimensions: dimensions,
+          dynamicRange: MediaDynamicRangeProfile.unknown,
+          confidence: dimensions.isKnown
+              ? MediaTrackConfidence.inferred
+              : MediaTrackConfidence.unknown,
+        ),
+      ],
+      audioTracks: const [],
+      subtitleTracks: const [],
+      warnings: warnings.toSet().toList(growable: false),
+    );
+
+    final status = switch (failureReason) {
+      null => MediaAssetAnalysisStatus.partial,
+      _ => MediaAssetAnalysisStatus.inspectionFailed,
+    };
+
+    return MediaAssetAnalysisResult(
+      status: status,
+      profile: profile,
+      failureReason: failureReason,
+      diagnostics: MediaAssetAnalysisDiagnostics(
+        elapsed: DateTime.now().difference(startedAt),
+        didUseMetadataProbe: didUseMetadataProbe,
+        fileSizeBytes: fileSizeBytes,
+        estimatedBytesRead: null,
+      ),
+    );
+  }
+
+  MediaAssetContainer _resolveContainer(
+    MediaAssetAnalysisRequest request,
+    List<MediaAssetWarningCode> warnings,
+  ) {
+    final fromMime = MediaAssetContainer.fromMimeType(request.mimeTypeHint);
+    if (fromMime != MediaAssetContainer.unknown) return fromMime;
+    final fromExtension = MediaAssetContainer.fromExtension(
+      request.fileExtension,
+    );
+    if (fromExtension != MediaAssetContainer.unknown) {
+      warnings.add(MediaAssetWarningCode.containerInferredFromFileExtension);
+    }
+    return fromExtension;
+  }
+
+  int _estimatedBitrateBitsPerSecond({
+    required int fileSizeBytes,
+    required Duration duration,
+  }) {
+    final seconds = duration.inMilliseconds / 1000;
+    if (seconds <= 0) return 0;
+    return ((fileSizeBytes * 8) / seconds).round();
+  }
+}
+
+MediaAssetAnalysisStatus _analysisStatusFromStableId(String? stableId) {
+  return MediaAssetAnalysisStatus.values.firstWhere(
+    (value) => value.stableId == stableId,
+    orElse: () => MediaAssetAnalysisStatus.inspectionFailed,
+  );
+}
+
+MediaAssetContainer _containerFromStableId(String? stableId) {
+  return MediaAssetContainer.values.firstWhere(
+    (value) => value.stableId == stableId,
+    orElse: () => MediaAssetContainer.unknown,
+  );
+}
+
+MediaTrackConfidence _confidenceFromStableId(String? stableId) {
+  return MediaTrackConfidence.values.firstWhere(
+    (value) => value.stableId == stableId,
+    orElse: () => MediaTrackConfidence.unknown,
+  );
+}
+
+MediaVideoCodec _videoCodecFromStableId(String? stableId) {
+  return MediaVideoCodec.values.firstWhere(
+    (value) => value.stableId == stableId,
+    orElse: () => MediaVideoCodec.unknown,
+  );
+}
+
+MediaAudioCodec _audioCodecFromStableId(String? stableId) {
+  return MediaAudioCodec.values.firstWhere(
+    (value) => value.stableId == stableId,
+    orElse: () => MediaAudioCodec.unknown,
+  );
+}
+
+MediaSubtitleFormat _subtitleFormatFromStableId(String? stableId) {
+  return MediaSubtitleFormat.values.firstWhere(
+    (value) => value.stableId == stableId,
+    orElse: () => MediaSubtitleFormat.unknown,
+  );
+}
+
+MediaDynamicRangeProfile _dynamicRangeFromStableId(String? stableId) {
+  return MediaDynamicRangeProfile.values.firstWhere(
+    (value) => value.stableId == stableId,
+    orElse: () => MediaDynamicRangeProfile.unknown,
+  );
+}
+
+MediaAssetWarningCode _warningCodeFromStableId(String? stableId) {
+  return MediaAssetWarningCode.values.firstWhere(
+    (value) => value.stableId == stableId,
+    orElse: () => MediaAssetWarningCode.metadataProbeFailed,
+  );
+}

--- a/packages/platform_media/lib/src/media_asset_profile_models.dart
+++ b/packages/platform_media/lib/src/media_asset_profile_models.dart
@@ -1,0 +1,396 @@
+import 'package:equatable/equatable.dart';
+
+const String kMediaAssetProfileSchemaVersion = '1.0.0';
+
+enum MediaAssetContainer {
+  mp4('mp4'),
+  m4v('m4v'),
+  mkv('mkv'),
+  webm('webm'),
+  avi('avi'),
+  mov('mov'),
+  ts('ts'),
+  m2ts('m2ts'),
+  flv('flv'),
+  wmv('wmv'),
+  vob('vob'),
+  unknown('unknown');
+
+  const MediaAssetContainer(this.stableId);
+
+  final String stableId;
+
+  static MediaAssetContainer fromExtension(String? extension) {
+    return switch ((extension ?? '').toLowerCase()) {
+      'mp4' => MediaAssetContainer.mp4,
+      'm4v' => MediaAssetContainer.m4v,
+      'mkv' => MediaAssetContainer.mkv,
+      'webm' => MediaAssetContainer.webm,
+      'avi' => MediaAssetContainer.avi,
+      'mov' => MediaAssetContainer.mov,
+      'ts' => MediaAssetContainer.ts,
+      'm2ts' => MediaAssetContainer.m2ts,
+      'flv' => MediaAssetContainer.flv,
+      'wmv' => MediaAssetContainer.wmv,
+      'vob' => MediaAssetContainer.vob,
+      _ => MediaAssetContainer.unknown,
+    };
+  }
+
+  static MediaAssetContainer fromMimeType(String? mimeType) {
+    final normalized = (mimeType ?? '').toLowerCase();
+    if (normalized.contains('matroska') || normalized.contains('x-mkv')) {
+      return MediaAssetContainer.mkv;
+    }
+    if (normalized.contains('webm')) return MediaAssetContainer.webm;
+    if (normalized.contains('mp4')) return MediaAssetContainer.mp4;
+    if (normalized.contains('quicktime')) return MediaAssetContainer.mov;
+    if (normalized.contains('mpegts') || normalized.contains('mp2t')) {
+      return MediaAssetContainer.ts;
+    }
+    if (normalized.contains('x-msvideo')) return MediaAssetContainer.avi;
+    if (normalized.contains('x-ms-wmv')) return MediaAssetContainer.wmv;
+    if (normalized.contains('x-flv')) return MediaAssetContainer.flv;
+    return MediaAssetContainer.unknown;
+  }
+}
+
+enum MediaTrackConfidence {
+  exact('exact'),
+  inferred('inferred'),
+  unknown('unknown');
+
+  const MediaTrackConfidence(this.stableId);
+
+  final String stableId;
+}
+
+enum MediaVideoCodec {
+  h264('h264'),
+  hevc('hevc'),
+  av1('av1'),
+  vp9('vp9'),
+  unknown('unknown');
+
+  const MediaVideoCodec(this.stableId);
+
+  final String stableId;
+}
+
+enum MediaAudioCodec {
+  aac('aac'),
+  ac3('ac3'),
+  eac3('eac3'),
+  dts('dts'),
+  trueHd('truehd'),
+  opus('opus'),
+  mp3('mp3'),
+  unknown('unknown');
+
+  const MediaAudioCodec(this.stableId);
+
+  final String stableId;
+}
+
+enum MediaSubtitleFormat {
+  srt('srt'),
+  ass('ass'),
+  pgs('pgs'),
+  vobSub('vobsub'),
+  dvb('dvb'),
+  unknown('unknown');
+
+  const MediaSubtitleFormat(this.stableId);
+
+  final String stableId;
+}
+
+enum MediaDynamicRangeProfile {
+  sdr('sdr'),
+  hdr10('hdr10'),
+  hdr10Plus('hdr10_plus'),
+  dolbyVision('dolby_vision'),
+  hlg('hlg'),
+  unknown('unknown');
+
+  const MediaDynamicRangeProfile(this.stableId);
+
+  final String stableId;
+}
+
+enum MediaAssetWarningCode {
+  containerInferredFromFileExtension('container_inferred_from_file_extension'),
+  fileSizeUnavailable('file_size_unavailable'),
+  durationUnavailable('duration_unavailable'),
+  overallBitrateUnavailable('overall_bitrate_unavailable'),
+  overallBitrateEstimated('overall_bitrate_estimated'),
+  videoCodecUnavailable('video_codec_unavailable'),
+  audioTracksUnavailable('audio_tracks_unavailable'),
+  subtitleTracksUnavailable('subtitle_tracks_unavailable'),
+  hdrUnavailable('hdr_unavailable'),
+  metadataProbeFailed('metadata_probe_failed');
+
+  const MediaAssetWarningCode(this.stableId);
+
+  final String stableId;
+}
+
+enum MediaAssetAnalysisStatus {
+  complete('complete'),
+  partial('partial'),
+  cancelled('cancelled'),
+  permissionLost('permission_lost'),
+  malformed('malformed'),
+  unsupportedInspection('unsupported_inspection'),
+  inspectionFailed('inspection_failed');
+
+  const MediaAssetAnalysisStatus(this.stableId);
+
+  final String stableId;
+}
+
+class MediaAssetDimensions extends Equatable {
+  const MediaAssetDimensions({required this.width, required this.height})
+    : assert(width >= 0),
+      assert(height >= 0);
+
+  final int width;
+  final int height;
+
+  bool get isKnown => width > 0 && height > 0;
+
+  @override
+  List<Object?> get props => [width, height];
+}
+
+class MediaVideoTrackProfile extends Equatable {
+  const MediaVideoTrackProfile({
+    required this.id,
+    required this.codec,
+    required this.dimensions,
+    required this.confidence,
+    this.bitrate,
+    this.dynamicRange = MediaDynamicRangeProfile.unknown,
+  });
+
+  final String id;
+  final MediaVideoCodec codec;
+  final MediaAssetDimensions dimensions;
+  final int? bitrate;
+  final MediaDynamicRangeProfile dynamicRange;
+  final MediaTrackConfidence confidence;
+
+  @override
+  List<Object?> get props => [
+    id,
+    codec,
+    dimensions,
+    bitrate,
+    dynamicRange,
+    confidence,
+  ];
+}
+
+class MediaAudioTrackProfile extends Equatable {
+  const MediaAudioTrackProfile({
+    required this.id,
+    required this.codec,
+    required this.confidence,
+    this.language,
+    this.label,
+    this.channelCount,
+    this.isDefault = false,
+    this.isCommentary = false,
+  });
+
+  final String id;
+  final MediaAudioCodec codec;
+  final MediaTrackConfidence confidence;
+  final String? language;
+  final String? label;
+  final int? channelCount;
+  final bool isDefault;
+  final bool isCommentary;
+
+  @override
+  List<Object?> get props => [
+    id,
+    codec,
+    confidence,
+    language,
+    label,
+    channelCount,
+    isDefault,
+    isCommentary,
+  ];
+}
+
+class MediaSubtitleTrackProfile extends Equatable {
+  const MediaSubtitleTrackProfile({
+    required this.id,
+    required this.format,
+    required this.confidence,
+    this.language,
+    this.label,
+    this.isDefault = false,
+    this.isForced = false,
+    this.isCommentary = false,
+  });
+
+  final String id;
+  final MediaSubtitleFormat format;
+  final MediaTrackConfidence confidence;
+  final String? language;
+  final String? label;
+  final bool isDefault;
+  final bool isForced;
+  final bool isCommentary;
+
+  @override
+  List<Object?> get props => [
+    id,
+    format,
+    confidence,
+    language,
+    label,
+    isDefault,
+    isForced,
+    isCommentary,
+  ];
+}
+
+class MediaAssetProfile extends Equatable {
+  const MediaAssetProfile({
+    required this.assetId,
+    required this.container,
+    required this.videoTracks,
+    required this.audioTracks,
+    required this.subtitleTracks,
+    required this.warnings,
+    this.schemaVersion = kMediaAssetProfileSchemaVersion,
+    this.duration,
+    this.fileSizeBytes,
+    this.overallBitrate,
+  });
+
+  final String schemaVersion;
+  final String assetId;
+  final MediaAssetContainer container;
+  final Duration? duration;
+  final int? fileSizeBytes;
+  final int? overallBitrate;
+  final List<MediaVideoTrackProfile> videoTracks;
+  final List<MediaAudioTrackProfile> audioTracks;
+  final List<MediaSubtitleTrackProfile> subtitleTracks;
+  final List<MediaAssetWarningCode> warnings;
+
+  @override
+  List<Object?> get props => [
+    schemaVersion,
+    assetId,
+    container,
+    duration,
+    fileSizeBytes,
+    overallBitrate,
+    videoTracks,
+    audioTracks,
+    subtitleTracks,
+    warnings,
+  ];
+}
+
+class MediaAssetAnalysisDiagnostics extends Equatable {
+  const MediaAssetAnalysisDiagnostics({
+    required this.elapsed,
+    required this.didUseMetadataProbe,
+    this.fileSizeBytes,
+    this.estimatedBytesRead,
+  });
+
+  final Duration elapsed;
+  final bool didUseMetadataProbe;
+  final int? fileSizeBytes;
+  final int? estimatedBytesRead;
+
+  @override
+  List<Object?> get props => [
+    elapsed,
+    didUseMetadataProbe,
+    fileSizeBytes,
+    estimatedBytesRead,
+  ];
+}
+
+class MediaAssetAnalysisRequest extends Equatable {
+  const MediaAssetAnalysisRequest({
+    required this.assetId,
+    required this.filePath,
+    this.fileName,
+    this.fileSizeBytesHint,
+    this.mimeTypeHint,
+  });
+
+  final String assetId;
+  final String filePath;
+  final String? fileName;
+  final int? fileSizeBytesHint;
+  final String? mimeTypeHint;
+
+  String get fileExtension {
+    final name = fileName;
+    if (name == null) return '';
+    final dot = name.lastIndexOf('.');
+    if (dot < 0 || dot == name.length - 1) return '';
+    return name.substring(dot + 1).toLowerCase();
+  }
+
+  @override
+  String toString() {
+    return 'MediaAssetAnalysisRequest('
+        'assetId: $assetId, '
+        'fileName: $fileName, '
+        'fileSizeBytesHint: $fileSizeBytesHint, '
+        'mimeTypeHint: $mimeTypeHint'
+        ')';
+  }
+
+  @override
+  List<Object?> get props => [
+    assetId,
+    filePath,
+    fileName,
+    fileSizeBytesHint,
+    mimeTypeHint,
+  ];
+}
+
+class MediaAssetAnalysisResult extends Equatable {
+  const MediaAssetAnalysisResult({
+    required this.status,
+    required this.diagnostics,
+    this.profile,
+    this.failureReason,
+  });
+
+  final MediaAssetAnalysisStatus status;
+  final MediaAssetProfile? profile;
+  final MediaAssetAnalysisDiagnostics diagnostics;
+  final String? failureReason;
+
+  bool get isSuccess =>
+      status == MediaAssetAnalysisStatus.complete ||
+      status == MediaAssetAnalysisStatus.partial;
+
+  @override
+  String toString() {
+    return 'MediaAssetAnalysisResult('
+        'status: ${status.stableId}, '
+        'assetId: ${profile?.assetId}, '
+        'warnings: ${profile?.warnings.map((warning) => warning.stableId).toList()}, '
+        'failureReason: $failureReason'
+        ')';
+  }
+
+  @override
+  List<Object?> get props => [status, profile, diagnostics, failureReason];
+}

--- a/packages/platform_media/test/host_platform_media_asset_analyzer_test.dart
+++ b/packages/platform_media/test/host_platform_media_asset_analyzer_test.dart
@@ -1,0 +1,152 @@
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:platform_media/platform_media.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const channel = MethodChannel('com.airo.media_asset_analyzer');
+  final messenger =
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger;
+
+  setUp(() {
+    HostPlatformMediaAssetAnalyzer.debugSetMethodChannel(channel);
+  });
+
+  tearDown(() {
+    messenger.setMockMethodCallHandler(channel, null);
+  });
+
+  test('host analyzer parses a complete native payload', () async {
+    messenger.setMockMethodCallHandler(channel, (call) async {
+      expect(call.method, 'analyze');
+      return {
+        'status': 'complete',
+        'profile': {
+          'schemaVersion': '1.0.0',
+          'assetId': 'asset-1',
+          'container': 'mkv',
+          'durationMs': 7807000,
+          'fileSizeBytes': 6100000000,
+          'overallBitrate': 6250000,
+          'videoTracks': [
+            {
+              'id': 'video-0',
+              'codec': 'hevc',
+              'width': 3840,
+              'height': 2160,
+              'bitrate': 5800000,
+              'dynamicRange': 'hdr10',
+              'confidence': 'exact',
+            },
+          ],
+          'audioTracks': [
+            {
+              'id': 'audio-0',
+              'codec': 'dts',
+              'language': 'eng',
+              'channelCount': 6,
+              'isDefault': true,
+              'isCommentary': false,
+              'confidence': 'exact',
+            },
+          ],
+          'subtitleTracks': [
+            {
+              'id': 'subtitle-0',
+              'format': 'pgs',
+              'language': 'eng',
+              'isDefault': true,
+              'isForced': false,
+              'isCommentary': false,
+              'confidence': 'exact',
+            },
+          ],
+          'warnings': ['overall_bitrate_estimated'],
+        },
+        'diagnostics': {
+          'elapsedMs': 120,
+          'didUseMetadataProbe': true,
+          'fileSizeBytes': 6100000000,
+        },
+      };
+    });
+
+    final result = await HostPlatformMediaAssetAnalyzer().analyze(
+      const MediaAssetAnalysisRequest(
+        assetId: 'asset-1',
+        filePath: '/private/tmp/movie.mkv',
+        fileName: 'movie.mkv',
+      ),
+    );
+
+    expect(result.status, MediaAssetAnalysisStatus.complete);
+    expect(result.profile?.container, MediaAssetContainer.mkv);
+    expect(result.profile?.videoTracks.single.codec, MediaVideoCodec.hevc);
+    expect(
+      result.profile?.videoTracks.single.dynamicRange,
+      MediaDynamicRangeProfile.hdr10,
+    );
+    expect(result.profile?.audioTracks.single.codec, MediaAudioCodec.dts);
+    expect(
+      result.profile?.subtitleTracks.single.format,
+      MediaSubtitleFormat.pgs,
+    );
+    expect(
+      result.profile?.warnings,
+      contains(MediaAssetWarningCode.overallBitrateEstimated),
+    );
+  });
+
+  test(
+    'default analyzer falls back when native inspection is unavailable',
+    () async {
+      messenger.setMockMethodCallHandler(channel, (call) async {
+        throw MissingPluginException();
+      });
+
+      final result =
+          await DefaultLocalMediaAssetAnalyzer(
+            fallbackAnalyzer: _FakeAnalyzer(
+              const MediaAssetAnalysisResult(
+                status: MediaAssetAnalysisStatus.partial,
+                profile: MediaAssetProfile(
+                  assetId: 'asset-fallback',
+                  container: MediaAssetContainer.mp4,
+                  videoTracks: [],
+                  audioTracks: [],
+                  subtitleTracks: [],
+                  warnings: [MediaAssetWarningCode.videoCodecUnavailable],
+                ),
+                diagnostics: MediaAssetAnalysisDiagnostics(
+                  elapsed: Duration(milliseconds: 1),
+                  didUseMetadataProbe: true,
+                ),
+              ),
+            ),
+          ).analyze(
+            const MediaAssetAnalysisRequest(
+              assetId: 'asset-fallback',
+              filePath: '/private/tmp/movie.mp4',
+              fileName: 'movie.mp4',
+            ),
+          );
+
+      expect(result.status, MediaAssetAnalysisStatus.partial);
+      expect(result.profile?.assetId, 'asset-fallback');
+    },
+  );
+}
+
+class _FakeAnalyzer implements LocalMediaAssetAnalyzer {
+  const _FakeAnalyzer(this.result);
+
+  final MediaAssetAnalysisResult result;
+
+  @override
+  Future<MediaAssetAnalysisResult> analyze(
+    MediaAssetAnalysisRequest request,
+  ) async {
+    return result;
+  }
+}

--- a/packages/platform_media/test/local_media_asset_analyzer_test.dart
+++ b/packages/platform_media/test/local_media_asset_analyzer_test.dart
@@ -1,0 +1,111 @@
+import 'dart:io';
+
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:platform_media/platform_media.dart';
+import 'package:video_player_platform_interface/video_player_platform_interface.dart';
+
+import 'support/fake_video_player_platform.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late Directory tempDir;
+  late File mediaFile;
+  late FakeVideoPlayerPlatform fakePlatform;
+
+  setUp(() async {
+    tempDir = await Directory.systemTemp.createTemp(
+      'local_media_asset_analyzer_test',
+    );
+    mediaFile = File('${tempDir.path}/movie.mkv');
+    await mediaFile.writeAsBytes(List<int>.filled(2048, 7));
+    fakePlatform = FakeVideoPlayerPlatform(
+      fakeDuration: const Duration(minutes: 130, seconds: 7),
+      fakeSize: const Size(3840, 2160),
+    );
+    VideoPlayerPlatform.instance = fakePlatform;
+  });
+
+  tearDown(() async {
+    await tempDir.delete(recursive: true);
+  });
+
+  test('analyzes a local asset into a normalized partial profile', () async {
+    const analyzer = VideoPlayerLocalMediaAssetAnalyzer();
+
+    final result = await analyzer.analyze(
+      MediaAssetAnalysisRequest(
+        assetId: 'asset-1',
+        filePath: mediaFile.path,
+        fileName: 'movie.mkv',
+        mimeTypeHint: 'video/x-matroska',
+      ),
+    );
+
+    expect(result.status, MediaAssetAnalysisStatus.partial);
+    expect(result.failureReason, isNull);
+    expect(result.profile, isNotNull);
+    expect(result.profile!.schemaVersion, kMediaAssetProfileSchemaVersion);
+    expect(result.profile!.container, MediaAssetContainer.mkv);
+    expect(result.profile!.duration, const Duration(minutes: 130, seconds: 7));
+    expect(result.profile!.fileSizeBytes, 2048);
+    expect(result.profile!.overallBitrate, isNotNull);
+    expect(result.profile!.videoTracks, hasLength(1));
+    expect(
+      result.profile!.videoTracks.single.dimensions,
+      const MediaAssetDimensions(width: 3840, height: 2160),
+    );
+    expect(
+      result.profile!.warnings,
+      contains(MediaAssetWarningCode.overallBitrateEstimated),
+    );
+    expect(
+      result.profile!.warnings,
+      contains(MediaAssetWarningCode.videoCodecUnavailable),
+    );
+    expect(result.diagnostics.didUseMetadataProbe, isTrue);
+    expect(result.diagnostics.fileSizeBytes, 2048);
+  });
+
+  test(
+    'surfaces metadata probe failure without exposing the file path',
+    () async {
+      fakePlatform.scriptedInitError = PlatformException(
+        code: 'VideoError',
+        message: 'decoder rejected format',
+      );
+      const analyzer = VideoPlayerLocalMediaAssetAnalyzer();
+
+      final result = await analyzer.analyze(
+        MediaAssetAnalysisRequest(
+          assetId: 'asset-2',
+          filePath: mediaFile.path,
+          fileName: 'movie.mkv',
+        ),
+      );
+
+      expect(result.status, MediaAssetAnalysisStatus.inspectionFailed);
+      expect(result.failureReason, 'metadata_probe_failed');
+      expect(
+        result.profile!.warnings,
+        contains(MediaAssetWarningCode.metadataProbeFailed),
+      );
+      expect(result.toString(), isNot(contains(mediaFile.path)));
+    },
+  );
+
+  test('request redaction never prints the raw local path', () {
+    final request = MediaAssetAnalysisRequest(
+      assetId: 'asset-3',
+      filePath: mediaFile.path,
+      fileName: 'movie.mkv',
+      fileSizeBytesHint: 1234,
+      mimeTypeHint: 'video/x-matroska',
+    );
+
+    expect(request.toString(), contains('asset-3'));
+    expect(request.toString(), contains('movie.mkv'));
+    expect(request.toString(), isNot(contains(mediaFile.path)));
+  });
+}


### PR DESCRIPTION
## Summary

<!-- What changed and why? -->

## Test Plan

- [ ] `flutter analyze` or relevant package analyzer passed
- [ ] `flutter test` or relevant package tests passed
- [ ] CI-only change validated with local script/YAML checks
- [ ] Manual device/simulator verification documented, or not applicable

**Verification environment:** Host-only / Physical Android / iOS simulator / Android Emulator with explicit opt-in

## Agent Policy

- [ ] Linked issue includes a Critical Agent Gate.
- [ ] Linked issue includes a Feature Packet or documents why one is not needed.
- [ ] Cross-agent contract is documented for framework/application boundary work.
- [ ] Deterministic use cases and automation flows are linked or included.
- [ ] AI/tool/memory/routine changes include eval, trace, and redaction coverage.
- [ ] Android Emulator was not used unless the linked issue explicitly accepted
      `AIRO_ALLOW_ANDROID_EMULATOR=true`.

## Council Review

Per the Decision Matrix in [docs/agents/COUNCIL.md](../docs/agents/COUNCIL.md),
list every role required for this change's category and confirm each has
reviewed (name a human/agent session, or link their review comment):

<!-- Example:
- Rust Architect: reviewed by @handle
- Chief Performance Officer: reviewed by claude session <link>
- Chief Security Officer: reviewed by claude session <link>
-->

- [ ] I checked the Decision Matrix and listed every required role above.
- [ ] Every package touched has a `module.yaml`; if not, this PR adds one
      (`scripts/check-module-manifests.py` enforces this in CI).
- [ ] `owner`/`reviewers` in any touched `module.yaml` still match who
      actually reviewed this PR — updated if the roster has drifted.

## User-Facing Documentation

Every PR must keep the Airo public capability wiki accurate.

- [ ] I updated `docs/wiki` for any user-visible feature, route, platform,
      install, AI/model, privacy, file-type, media, game, finance, or
      troubleshooting change.
- [ ] No `docs/wiki` update is needed because this PR has no user-visible
      behavior or documentation impact.

Docs bypass for intentional exceptions:
use the `docs-not-needed` PR label or include `docs-not-needed` in the commit
message.

## Plugin and Size Impact

- [ ] This PR adds new dependencies
- [ ] This PR adds or grows app/packages/plugins code
- [ ] Size impact is documented below
- [ ] Any module over 3 MB is a plugin or has an explicit plugin marker
- [ ] Any plugin over 5 MB has cache-management documentation

Size impact / plugin justification:

<!-- Example: packages/feature_x adds 1.4 MB source footprint and remains bundled because ... -->

## Checklist

- [ ] Code is formatted.
- [ ] Tests or manual verification are included above.
- [ ] Sensitive data, credentials, and signing artifacts are not committed.

## Release Notes

- [ ] User-facing change documented, or not applicable
