### PR TITLE
fix(iptv): stop force-locking portrait on fullscreen exit for touch devices

### DIFF
--- a/packages/feature_iptv/lib/presentation/screens/iptv_screen.dart
+++ b/packages/feature_iptv/lib/presentation/screens/iptv_screen.dart
@@ -269,9 +269,11 @@ class _IPTVScreenState extends ConsumerState<IPTVScreen>
         DeviceOrientation.landscapeRight,
       ]);
     } else {
-      // Exiting fullscreen
+      // Exiting fullscreen -- restore system-default orientation instead of
+      // forcing portrait, so tablets/foldables already using landscape as
+      // their default layout aren't rotated out of it.
       SystemChrome.setEnabledSystemUIMode(SystemUiMode.edgeToEdge);
-      SystemChrome.setPreferredOrientations([DeviceOrientation.portraitUp]);
+      SystemChrome.setPreferredOrientations([]);
     }
   }
 
@@ -968,9 +970,11 @@ class _IPTVScreenBodyState extends ConsumerState<IPTVScreenBody>
         DeviceOrientation.landscapeRight,
       ]);
     } else {
-      // Exiting fullscreen
+      // Exiting fullscreen -- restore system-default orientation instead of
+      // forcing portrait, so tablets/foldables already using landscape as
+      // their default layout aren't rotated out of it.
       SystemChrome.setEnabledSystemUIMode(SystemUiMode.edgeToEdge);
-      SystemChrome.setPreferredOrientations([DeviceOrientation.portraitUp]);
+      SystemChrome.setPreferredOrientations([]);
     }
   }
 

--- a/packages/feature_iptv/test/presentation/screens/iptv_screen_touch_fullscreen_orientation_test.dart
+++ b/packages/feature_iptv/test/presentation/screens/iptv_screen_touch_fullscreen_orientation_test.dart
@@ -1,0 +1,133 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:feature_iptv/feature_iptv.dart';
+
+// Mirrors iptv_screen_ten_foot_fullscreen_test.dart's setup, but for the
+// default (touch, non-tenFootMode) screen used on phones/tablets/foldables.
+final _channels = [
+  const IPTVChannel(
+    id: 'c1',
+    name: 'Channel One',
+    streamUrl: 'https://example.com/c1.m3u8',
+    group: 'News',
+    category: ChannelCategory.news,
+  ),
+];
+
+class _RecordingStreamingService extends VideoPlayerStreamingService {
+  _RecordingStreamingService({required this.played})
+    : super(engine: FakeAiroPlaybackEngine());
+
+  final List<IPTVChannel> played;
+
+  @override
+  Future<void> playChannel(IPTVChannel channel) async {
+    played.add(channel);
+  }
+}
+
+void main() {
+  testWidgets(
+    'touch (non-tenFootMode): exiting fullscreen restores system-default '
+    'orientation instead of forcing portrait, so tablets/foldables already '
+    'in landscape are not rotated out of it',
+    (tester) async {
+      tester.view.physicalSize = const Size(1024, 768);
+      tester.view.devicePixelRatio = 1;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      final orientationCalls = <List<Object?>>[];
+      tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+        SystemChannels.platform,
+        (call) async {
+          if (call.method == 'SystemChrome.setPreferredOrientations') {
+            orientationCalls.add(call.arguments as List<Object?>);
+          }
+          return null;
+        },
+      );
+      addTearDown(
+        () => tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+          SystemChannels.platform,
+          null,
+        ),
+      );
+
+      final played = <IPTVChannel>[];
+      final stateController = StreamController<StreamingState>.broadcast();
+      addTearDown(stateController.close);
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            iptvChannelsProvider.overrideWith((ref) async => _channels),
+            recentlyWatchedChannelsProvider.overrideWith(
+              (ref) async => const [],
+            ),
+            streamingStateProvider.overrideWith(
+              (ref) => stateController.stream,
+            ),
+            iptvStreamingServiceProvider.overrideWith((ref) {
+              final service = _RecordingStreamingService(played: played);
+              ref.onDispose(service.dispose);
+              return service;
+            }),
+          ],
+          child: const MaterialApp(home: IPTVScreen()),
+        ),
+      );
+      await tester.pump();
+      stateController.add(
+        StreamingState(playbackState: PlaybackState.idle, isLiveStream: true),
+      );
+      await tester.pump();
+
+      await tester.tap(find.text('Channel One'));
+      await tester.pump(const Duration(milliseconds: 400));
+      stateController.add(
+        StreamingState(
+          playbackState: PlaybackState.playing,
+          isLiveStream: true,
+          currentChannel: _channels.single,
+        ),
+      );
+      await tester.pump(const Duration(milliseconds: 400));
+
+      // Enter fullscreen via the preview stage's fullscreen button, then
+      // exit with back/escape (bounded pumps: the fullscreen player shows
+      // a looping buffering spinner, so pumpAndSettle would never settle).
+      await tester.tap(
+        find.byKey(const ValueKey('iptv-preview-fullscreen-button')),
+      );
+      await tester.pump(const Duration(milliseconds: 400));
+      await tester.pump(const Duration(milliseconds: 400));
+      await tester.sendKeyEvent(LogicalKeyboardKey.escape);
+      await tester.pump(const Duration(milliseconds: 400));
+      await tester.pump(const Duration(milliseconds: 400));
+
+      expect(
+        orientationCalls.where(
+          (arguments) => arguments.contains('DeviceOrientation.portraitUp'),
+        ),
+        isEmpty,
+        reason:
+            'a phone/tablet/foldable already using landscape as its '
+            'default layout must not be force-rotated to portrait on '
+            'fullscreen exit',
+      );
+      expect(
+        orientationCalls.any((arguments) => arguments.isEmpty),
+        isTrue,
+        reason:
+            'exiting fullscreen should restore the system-default '
+            'orientation (empty preference list), not force any specific '
+            'orientation',
+      );
+    },
+  );
+}


### PR DESCRIPTION
## Summary
- Exiting fullscreen playback unconditionally called `SystemChrome.setPreferredOrientations([DeviceOrientation.portraitUp])`, forcibly rotating tablets/foldables out of a landscape layout they may already be using by default (split-screen, unfolded state).
- Restore the system-default orientation instead by passing an empty preference list — mirrors the TV code path's existing "never force a rotation" rule, just applied to the touch path this time.
- Two duplicate `_toggleFullscreen()` implementations in `iptv_screen.dart` both had the bug; fixed both.

Part of milestone [Phase 2 — Reliability](https://github.com/DevelopersCoffee/airo/milestone/2) — touch-only device reliability (phones/tablets/foldables, no d-pad).

## Test plan
- [x] New widget test: `iptv_screen_touch_fullscreen_orientation_test.dart` asserts fullscreen exit on the touch (`tenFootMode: false`) path never sends `portraitUp` and does send the empty/system-default preference list
- [x] Existing TV test (`iptv_screen_ten_foot_fullscreen_test.dart`) still passes — TV path untouched (early-returns before this code)
- [x] `flutter analyze` clean
- [x] Full `feature_iptv` test suite green aside from one pre-existing flaky test unrelated to this change (`tv_playlist_pairing_server_test.dart`, passes in isolation on both branches)