### PR TITLE
fix(iptv): restore sub-second precision on the VOD seek bar

### DIFF
--- a/packages/feature_iptv/lib/presentation/widgets/video_player_widget.dart
+++ b/packages/feature_iptv/lib/presentation/widgets/video_player_widget.dart
@@ -1856,23 +1856,23 @@ class _VideoPlayerWidgetState extends ConsumerState<VideoPlayerWidget> {
                     ),
                     child: Slider(
                       key: const ValueKey('iptv-player-vod-seek-bar'),
-                      value: displayPosition.inSeconds.toDouble().clamp(
+                      value: displayPosition.inMilliseconds.toDouble().clamp(
                         0.0,
-                        state.duration.inSeconds.toDouble(),
+                        state.duration.inMilliseconds.toDouble(),
                       ),
                       min: 0,
-                      max: state.duration.inSeconds.toDouble(),
+                      max: state.duration.inMilliseconds.toDouble(),
                       activeColor: Colors.white,
                       inactiveColor: Colors.white38,
                       onChanged: (value) {
                         setState(() {
                           _vodSeekDragPosition = Duration(
-                            seconds: value.round(),
+                            milliseconds: value.round(),
                           );
                         });
                       },
                       onChangeEnd: (value) {
-                        final target = Duration(seconds: value.round());
+                        final target = Duration(milliseconds: value.round());
                         service.seek(target);
                         setState(() => _vodSeekDragPosition = null);
                       },

--- a/packages/feature_iptv/test/iptv/presentation/widgets/video_player_widget_test.dart
+++ b/packages/feature_iptv/test/iptv/presentation/widgets/video_player_widget_test.dart
@@ -395,8 +395,8 @@ void main() {
     expect(seekBar, findsOneWidget);
 
     final slider = tester.widget<Slider>(seekBar);
-    expect(slider.max, 120.0);
-    expect(slider.value, 30.0);
+    expect(slider.max, 120000.0);
+    expect(slider.value, 30000.0);
   });
 
   testWidgets('hides the VOD seek bar for live streams', (tester) async {


### PR DESCRIPTION
## Summary
- VOD seek `Slider` tracked position/duration via `Duration.inSeconds`, so drag/seek precision collapsed to ~1 unit per second of track width — on a typical movie the whole scrub bar only had a couple hundred discrete steps, making accurate seeking on touch difficult.
- Switch the slider's value/min/max/onChanged/onChangeEnd domain to milliseconds.

Part of milestone [Phase 2 — Reliability](https://github.com/DevelopersCoffee/airo/milestone/2) (touch-only device reliability — issue #514 "Validation: Audio Playback" calls out seek bar accuracy directly).

## Test plan
- [x] Updated `video_player_widget_test.dart` slider assertions to milliseconds
- [x] `flutter analyze` clean
- [x] Full `feature_iptv` test suite green (729 tests)