### PR TITLE
fix(tv): restore Fire TV channel playback and D-pad flow

### DIFF
--- a/app/lib/core/app/tv_shell.dart
+++ b/app/lib/core/app/tv_shell.dart
@@ -16,6 +16,7 @@ import '../../features/settings/presentation/tv/tv_settings_screen.dart';
 
 /// Provider for current TV navigation index
 final tvNavigationIndexProvider = StateProvider<int>((ref) => 0);
+const _tvNavigationRailWidth = 88.0;
 
 /// Non-live destinations the sidebar can show. Rendered as an overlay on
 /// top of [TvShell.child] instead of being routed to — routing away would
@@ -54,7 +55,14 @@ class _TvShellState extends ConsumerState<TvShell> {
           // The routed content (the live TV screen on the common path).
           // Never removed from the tree by a sidebar tap — only a direct
           // deep link to a different route replaces it.
-          Positioned.fill(child: widget.child),
+          Positioned.fill(
+            child: Padding(
+              padding: EdgeInsets.only(
+                left: isPlayerFullscreen ? 0 : _tvNavigationRailWidth,
+              ),
+              child: widget.child,
+            ),
+          ),
           if (!isPlayerFullscreen) ...[
             if (_overlay != null)
               Positioned.fill(
@@ -64,7 +72,7 @@ class _TvShellState extends ConsumerState<TvShell> {
                 // left inset the old Row gave them, so their content doesn't
                 // render underneath the now-floating rail.
                 child: Padding(
-                  padding: const EdgeInsets.only(left: 88),
+                  padding: const EdgeInsets.only(left: _tvNavigationRailWidth),
                   child: _buildOverlay(_overlay!),
                 ),
               ),
@@ -151,7 +159,7 @@ class _TvNavigationRail extends StatelessWidget {
 
     return Container(
       key: const Key('tv-sidebar-nav'),
-      width: 88,
+      width: _tvNavigationRailWidth,
       padding: const EdgeInsets.symmetric(vertical: 24),
       decoration: BoxDecoration(
         color: chromeSurface,

--- a/app/test/core/app/tv_router_test.dart
+++ b/app/test/core/app/tv_router_test.dart
@@ -12,6 +12,7 @@ void main() {
     WidgetTester tester, {
     required String initialLocation,
     Size? surfaceSize,
+    List<IPTVChannel> channels = const [],
   }) async {
     if (surfaceSize != null) {
       await tester.binding.setSurfaceSize(surfaceSize);
@@ -26,7 +27,7 @@ void main() {
       ProviderScope(
         overrides: [
           sharedPreferencesProvider.overrideWithValue(prefs),
-          iptvChannelsProvider.overrideWith((ref) async => const []),
+          iptvChannelsProvider.overrideWith((ref) async => channels),
           recentlyWatchedChannelsProvider.overrideWith((ref) async => const []),
           streamingStateProvider.overrideWith(
             (ref) => Stream.value(
@@ -107,6 +108,46 @@ void main() {
         isNotEmpty,
         reason: 'the focused Add playlist action must paint the TV focus ring',
       );
+      expect(tester.takeException(), isNull);
+    },
+  );
+
+  testWidgets(
+    '1920x1080 Fire TV loaded playlist grid clears the navigation rail',
+    (tester) async {
+      tester.view.physicalSize = const Size(1920, 1080);
+      tester.view.devicePixelRatio = 2;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+      DeviceFormFactorDetector.debugFormFactorOverride = DeviceFormFactor.tv;
+      addTearDown(DeviceFormFactorDetector.clearCache);
+
+      await pumpTvRouter(
+        tester,
+        initialLocation: TvRouteNames.live,
+        channels: const [
+          IPTVChannel(
+            id: 'vevo-pop',
+            name: 'Vevo Pop',
+            streamUrl: 'https://example.com/vevo-pop.m3u8',
+          ),
+        ],
+      );
+
+      final railRect = tester.getRect(find.byKey(const Key('tv-sidebar-nav')));
+      final gridRect = tester.getRect(
+        find.byKey(const ValueKey('airo-tv-channel-library')),
+      );
+      expect(
+        gridRect.left,
+        greaterThanOrEqualTo(railRect.right),
+        reason: '$gridRect must not intersect $railRect',
+      );
+      expect(
+        find.byKey(const ValueKey('airo-tv-explorer-video-stage')),
+        findsNothing,
+      );
+      expect(find.text('Select a channel to start watching'), findsNothing);
       expect(tester.takeException(), isNull);
     },
   );

--- a/app/test/core/app/tv_router_test.dart
+++ b/app/test/core/app/tv_router_test.dart
@@ -1,5 +1,6 @@
 import 'package:airo_app/core/app/tv_router.dart';
 import 'package:airo_app/core/platform/device_form_factor.dart';
+import 'package:core_ui/core_ui.dart';
 import 'package:feature_iptv/feature_iptv.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -52,6 +53,63 @@ void main() {
     expect(find.text('Add your playlist'), findsOneWidget);
     expect(find.text('Welcome to Airo'), findsNothing);
   });
+
+  testWidgets(
+    '1920x1080 Fire TV empty playlist content clears the navigation rail',
+    (tester) async {
+      tester.view.physicalSize = const Size(1920, 1080);
+      tester.view.devicePixelRatio = 2;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+      DeviceFormFactorDetector.debugFormFactorOverride = DeviceFormFactor.tv;
+      addTearDown(DeviceFormFactorDetector.clearCache);
+
+      await pumpTvRouter(tester, initialLocation: TvRouteNames.live);
+
+      final railRect = tester.getRect(find.byKey(const Key('tv-sidebar-nav')));
+      final headingRect = tester.getRect(find.text('Add your playlist'));
+      final copyRect = tester.getRect(
+        find.textContaining(
+          'does not provide channels, playlists, or program guide data',
+        ),
+      );
+      final buttonRect = tester.getRect(find.text('Add playlist URL'));
+
+      for (final contentRect in [headingRect, copyRect, buttonRect]) {
+        expect(
+          contentRect.left,
+          greaterThanOrEqualTo(railRect.right),
+          reason: '$contentRect must not intersect $railRect',
+        );
+      }
+
+      final addButton = find.byKey(const ValueKey('iptv-empty-add-playlist'));
+      final buttonFocus = tester.widget<Focus>(
+        find.descendant(of: addButton, matching: find.byType(Focus)).first,
+      );
+      buttonFocus.focusNode!.requestFocus();
+      await tester.pump(TvFocusConstants.focusAnimationDuration);
+      expect(buttonFocus.focusNode?.hasPrimaryFocus, isTrue);
+      expect(
+        tester
+            .widgetList<DecoratedBox>(
+              find.descendant(
+                of: addButton,
+                matching: find.byType(DecoratedBox),
+              ),
+            )
+            .where(
+              (box) =>
+                  box.decoration is BoxDecoration &&
+                  (box.decoration as BoxDecoration).border?.top.width ==
+                      TvFocusConstants.focusBorderWidth,
+            ),
+        isNotEmpty,
+        reason: 'the focused Add playlist action must paint the TV focus ring',
+      );
+      expect(tester.takeException(), isNull);
+    },
+  );
 
   testWidgets('uses compact IPTV layout on phone portrait viewports', (
     tester,

--- a/docs/testing/fire-tv-pr1244-reverification.md
+++ b/docs/testing/fire-tv-pr1244-reverification.md
@@ -1,0 +1,105 @@
+# Fire TV PR #1244 follow-up verification fixture
+
+Tracking issue: [#1272](https://github.com/DevelopersCoffee/airo/issues/1272)
+
+This is a preparation guide, not device-pass evidence. Do not mark any item
+PASS until the sequence is completed on a physical Fire TV with remote-only
+input.
+
+## Build and install
+
+1. Build the follow-up PR's exact head as the TV debug application.
+2. Record the commit SHA and APK SHA-256 in the device report.
+3. Uninstall `io.airo.app.tv` from the Fire TV.
+4. Install the APK as a fresh install, not an in-place `-r` update.
+5. Use a playlist fixture containing:
+   - one playable live stream;
+   - one deterministic terminal/geo-blocked stream;
+   - one stream exposing at least two qualities;
+   - one stream exposing at least two audio tracks and two subtitle tracks.
+
+## Player actions and selectors
+
+1. Start the playable stream and enter fullscreen.
+2. Press MENU. If Fire OS intercepts MENU on the device, reveal the transport
+   bar with CENTER and open the visible **More** action using only the D-pad.
+3. Confirm the **Player actions** sheet opens with visible focus on
+   **Listen only**.
+4. Traverse every rendered row with UP and DOWN, capture each focused row,
+   and activate each row with CENTER in a separate pass.
+5. Open Quality, Subtitles, and Audio. Confirm the current option is focused;
+   confirm **Off** is focused when no subtitle is selected; traverse and apply
+   every option.
+6. Press BACK inside each selector and sheet. Confirm only the top surface
+   closes and focus returns to its launching row/control.
+7. While a sheet is open, send repeated UP/DOWN and confirm the Mini Guide and
+   underlying player state do not change.
+
+## Playback recovery
+
+1. Start the deterministic terminal/geo-blocked stream.
+2. Wait for **Playback could not start on this device**.
+3. Confirm **Try Again** has a visible ring without an extra key press.
+4. Traverse Try Again → Skip Channel → Report dead link with RIGHT, then back
+   with LEFT.
+5. Activate Try Again with CENTER. If retry fails and the recovery surface
+   mounts again, confirm Try Again visibly owns focus again.
+6. Wait at least five seconds after moving focus to Skip Channel and confirm
+   delayed control-hide work does not return focus to the player surface.
+
+## CV-017 favorite re-import fixture
+
+The deterministic host fixture is
+`packages/feature_iptv/test/iptv/presentation/widgets/favorite_reimport_review_banner_test.dart`.
+It creates the old favorite and a name-based replacement candidate, then
+proves Keep/Dismiss focus, closed-loop traversal, and separate CENTER actions.
+
+For physical verification:
+
+1. Import playlist A containing channel id `favorite-old`, name
+   `Fixture News HD`, and a working URL.
+2. Open the fullscreen transport bar, choose **Info**, and add the channel to
+   favorites from the channel-actions overlay.
+3. Reimport playlist B with `favorite-old` removed and channel id
+   `favorite-new` named `fixture-news` so it requires name-based review rather
+   than an exact-id remap.
+4. Open Favorites and confirm the review banner appears.
+5. Confirm Keep visibly owns focus, RIGHT moves to Dismiss, and another RIGHT
+   does not leak behind the banner.
+6. In separate fresh cases, activate Keep and Dismiss with CENTER and verify
+   the resulting favorite id.
+
+## #1189 Play file on TV fixture
+
+This path requires two real devices and must not be claimed as passing from a
+host-only widget test.
+
+1. Put an Airo phone build and the Fire TV receiver build from the same commit
+   on the same non-guest Wi-Fi network. Disable AP/client isolation.
+2. Pair the phone with the receiver and keep the receiver visible/awake.
+3. Place a small supported H.264/AAC MP4 file on the phone. Use a filename
+   without credentials or private identifiers because it may appear in local
+   diagnostics.
+4. From the phone's local-file source, choose **Play file on TV** and select
+   the paired Fire TV.
+5. Confirm opening the sheet does not immediately show a false failure, the
+   intended primary action visibly owns focus, and the sheet works without
+   touch.
+6. Run a separate failure case by stopping the phone host or disconnecting
+   Wi-Fi after selection; confirm the real failure state is shown.
+7. Record phone model/OS, Fire TV model, network topology, source media codec
+   and size, commit SHA, and screenshots. Do not record the full local path,
+   receiver token, or session URL.
+
+## Preserved regressions
+
+After the checks above:
+
+1. Enter fullscreen, wait eight seconds, press UP, and confirm Mini Guide opens
+   (#1238).
+2. Send five sequential DOWN events in a long channel list and confirm focus
+   moves exactly one item per event (#1185).
+3. On a fresh install, confirm the empty-playlist heading, copy, and Add
+   playlist action clear the permanent rail at 1920×1080 and the focused
+   action ring is not clipped.
+

--- a/docs/testing/fire-tv-pr1244-reverification.md
+++ b/docs/testing/fire-tv-pr1244-reverification.md
@@ -18,6 +18,11 @@ input.
    - one stream exposing at least two qualities;
    - one stream exposing at least two audio tracks and two subtitle tracks.
 
+The checked-in A/B fixtures also carry the current iptv-org entries for
+**Vevo Pop**, **YRF Music**, and **B4U Music** as the real-stream playback set.
+Before device use, confirm their URLs still return an HLS manifest because
+public playlist endpoints can change independently of Airo.
+
 ## Player actions and selectors
 
 1. Start the playable stream and enter fullscreen.
@@ -56,13 +61,19 @@ proves Keep/Dismiss focus, closed-loop traversal, and separate CENTER actions.
 
 For physical verification:
 
-1. Import playlist A containing channel id `favorite-old`, name
-   `Fixture News HD`, and a working URL.
+1. From the repository root, serve `docs/testing/fixtures` on the verification
+   LAN (for example, `python3 -m http.server 8765 --directory
+   docs/testing/fixtures`). Import
+   `http://<host-lan-ip>:8765/fire-tv-cv017-playlist-a.m3u`. Its working
+   `Fixture News HD` channel deliberately has no `tvg-id`; the URL-derived
+   channel id will therefore change in playlist B.
 2. Open the fullscreen transport bar, choose **Info**, and add the channel to
    favorites from the channel-actions overlay.
-3. Reimport playlist B with `favorite-old` removed and channel id
-   `favorite-new` named `fixture-news` so it requires name-based review rather
-   than an exact-id remap.
+3. Reimport
+   `http://<host-lan-ip>:8765/fire-tv-cv017-playlist-b.m3u`. Its URL-derived
+   id differs and its normalized name `fixture-news` matches
+   `Fixture News HD`, forcing name-based review rather than an exact-id or
+   `tvg-id` remap.
 4. Open Favorites and confirm the review banner appears.
 5. Confirm Keep visibly owns focus, RIGHT moves to Dismiss, and another RIGHT
    does not leak behind the banner.
@@ -102,4 +113,3 @@ After the checks above:
 3. On a fresh install, confirm the empty-playlist heading, copy, and Add
    playlist action clear the permanent rail at 1920×1080 and the focused
    action ring is not clipped.
-

--- a/docs/testing/fixtures/fire-tv-cv017-playlist-a.m3u
+++ b/docs/testing/fixtures/fire-tv-cv017-playlist-a.m3u
@@ -1,0 +1,11 @@
+#EXTM3U
+#EXTINF:-1 tvg-name="Fixture News HD" group-title="News",Fixture News HD
+https://itnhls.wns.live/hls/stream.m3u8?cv017=old
+#EXTINF:-1 tvg-name="Fixture Dead Stream" group-title="Diagnostics",Fixture Dead Stream
+https://example.invalid/fire-tv-cv017-dead.m3u8
+#EXTINF:-1 tvg-id="VevoPop.us@SD" tvg-name="Vevo Pop" group-title="Music",Vevo Pop (1080p)
+https://d128y56w6v2kax.cloudfront.net/playlist/amg00056-vevotv-vevopopau-samsungau/playlist.m3u8
+#EXTINF:-1 tvg-id="YRFMusic.in@SD" tvg-name="YRF Music" group-title="Music",YRF Music (1080p)
+https://cdn-uw2-prod.tsv2.amagi.tv/linear/amg01412-xiaomiasia-yrfmusic-xiaomi/playlist.m3u8
+#EXTINF:-1 tvg-id="B4UMusic.in@India" tvg-name="B4U Music" group-title="Music",B4U Music (576p)
+https://cdn-2.pishow.tv/live/415/master.m3u8

--- a/docs/testing/fixtures/fire-tv-cv017-playlist-b.m3u
+++ b/docs/testing/fixtures/fire-tv-cv017-playlist-b.m3u
@@ -1,0 +1,11 @@
+#EXTM3U
+#EXTINF:-1 tvg-name="fixture-news" group-title="News",fixture-news
+https://itnhls.wns.live/hls/stream.m3u8?cv017=new
+#EXTINF:-1 tvg-name="Fixture Dead Stream" group-title="Diagnostics",Fixture Dead Stream
+https://example.invalid/fire-tv-cv017-dead.m3u8
+#EXTINF:-1 tvg-id="VevoPop.us@SD" tvg-name="Vevo Pop" group-title="Music",Vevo Pop (1080p)
+https://d128y56w6v2kax.cloudfront.net/playlist/amg00056-vevotv-vevopopau-samsungau/playlist.m3u8
+#EXTINF:-1 tvg-id="YRFMusic.in@SD" tvg-name="YRF Music" group-title="Music",YRF Music (1080p)
+https://cdn-uw2-prod.tsv2.amagi.tv/linear/amg01412-xiaomiasia-yrfmusic-xiaomi/playlist.m3u8
+#EXTINF:-1 tvg-id="B4UMusic.in@India" tvg-name="B4U Music" group-title="Music",B4U Music (576p)
+https://cdn-2.pishow.tv/live/415/master.m3u8

--- a/packages/core_ui/lib/src/widgets/airo_rail_card.dart
+++ b/packages/core_ui/lib/src/widgets/airo_rail_card.dart
@@ -57,6 +57,7 @@ class AiroRailCard extends StatelessWidget {
 
     return TvFocusable(
       onSelect: onTap,
+      onSecondaryAction: onLongPress,
       autofocus: autofocus,
       borderRadius: 12,
       focusColor: focusColor,

--- a/packages/core_ui/lib/src/widgets/airo_rail_card.dart
+++ b/packages/core_ui/lib/src/widgets/airo_rail_card.dart
@@ -25,6 +25,8 @@ class AiroRailCard extends StatelessWidget {
     this.thumbnailHeight = 104,
     this.onTap,
     this.onLongPress,
+    this.onFocus,
+    this.onUnfocus,
     this.autofocus = false,
   });
 
@@ -45,6 +47,8 @@ class AiroRailCard extends StatelessWidget {
   final double thumbnailHeight;
   final VoidCallback? onTap;
   final VoidCallback? onLongPress;
+  final VoidCallback? onFocus;
+  final VoidCallback? onUnfocus;
   final bool autofocus;
 
   @override
@@ -58,6 +62,8 @@ class AiroRailCard extends StatelessWidget {
     return TvFocusable(
       onSelect: onTap,
       onSecondaryAction: onLongPress,
+      onFocus: onFocus,
+      onUnfocus: onUnfocus,
       autofocus: autofocus,
       borderRadius: 12,
       focusColor: focusColor,

--- a/packages/core_ui/lib/src/widgets/media_card.dart
+++ b/packages/core_ui/lib/src/widgets/media_card.dart
@@ -39,6 +39,8 @@ class MediaCard extends StatelessWidget {
     this.isLive = false,
     this.onTap,
     this.onLongPress,
+    this.onFocus,
+    this.onUnfocus,
     this.autofocus = false,
   });
 
@@ -52,6 +54,8 @@ class MediaCard extends StatelessWidget {
   final bool isLive;
   final VoidCallback? onTap;
   final VoidCallback? onLongPress;
+  final VoidCallback? onFocus;
+  final VoidCallback? onUnfocus;
   final bool autofocus;
 
   /// (width, thumbnailHeight) for each [MediaCardVariant].
@@ -86,6 +90,8 @@ class MediaCard extends StatelessWidget {
       thumbnailHeight: thumbnailHeight,
       onTap: onTap,
       onLongPress: onLongPress,
+      onFocus: onFocus,
+      onUnfocus: onUnfocus,
       autofocus: autofocus,
     );
   }

--- a/packages/core_ui/lib/src/widgets/tv_focusable.dart
+++ b/packages/core_ui/lib/src/widgets/tv_focusable.dart
@@ -359,7 +359,12 @@ class _TvFocusableState extends State<TvFocusable>
       onKeyEvent: _handleKeyEvent,
       child: ValueListenableBuilder<bool>(
         valueListenable: _isFocused,
-        child: widget.child,
+        // TvFocusable is the single reviewed D-pad stop for this visual
+        // target. Material controls such as IconButton and ChoiceChip create
+        // their own Focus nodes; leaving those requestable produces two
+        // remote stops inside one visible box and Fire TV traversal appears
+        // to skip the next box. Pointer gestures still reach the child.
+        child: ExcludeFocus(child: widget.child),
         builder: (context, isFocused, child) {
           final decoration = isFocused && widget.showBorderEffect
               ? BoxDecoration(

--- a/packages/core_ui/lib/src/widgets/tv_focusable.dart
+++ b/packages/core_ui/lib/src/widgets/tv_focusable.dart
@@ -134,17 +134,21 @@ class _TvInputHandlerState extends State<TvInputHandler> {
   @override
   Widget build(BuildContext context) {
     if (!widget.enabled) return widget.child;
-    return KeyboardListener(
+    return Focus(
       focusNode: _focusNode,
+      canRequestFocus: false,
       onKeyEvent: _handleKeyEvent,
       child: widget.child,
     );
   }
 
-  void _handleKeyEvent(KeyEvent event) {
-    if (event is! KeyDownEvent) return;
+  KeyEventResult _handleKeyEvent(FocusNode node, KeyEvent event) {
+    if (event is! KeyDownEvent) return KeyEventResult.ignored;
     final key = TvInputHandler.mapLogicalKeyToTvInput(event.logicalKey);
-    if (key != null) widget.onInput?.call(key);
+    if (key == null) return KeyEventResult.ignored;
+    return widget.onInput?.call(key) == TvInputResult.handled
+        ? KeyEventResult.handled
+        : KeyEventResult.ignored;
   }
 }
 
@@ -359,12 +363,7 @@ class _TvFocusableState extends State<TvFocusable>
       onKeyEvent: _handleKeyEvent,
       child: ValueListenableBuilder<bool>(
         valueListenable: _isFocused,
-        // TvFocusable is the single reviewed D-pad stop for this visual
-        // target. Material controls such as IconButton and ChoiceChip create
-        // their own Focus nodes; leaving those requestable produces two
-        // remote stops inside one visible box and Fire TV traversal appears
-        // to skip the next box. Pointer gestures still reach the child.
-        child: ExcludeFocus(child: widget.child),
+        child: widget.child,
         builder: (context, isFocused, child) {
           final decoration = isFocused && widget.showBorderEffect
               ? BoxDecoration(

--- a/packages/core_ui/test/widgets/tv_focusable_test.dart
+++ b/packages/core_ui/test/widgets/tv_focusable_test.dart
@@ -116,6 +116,51 @@ void main() {
     expect(secondaryCount, 1);
   });
 
+  testWidgets('TvFocusable contributes one remote stop with a button child', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: TvFocusable(
+            key: const ValueKey('remote-box'),
+            autofocus: true,
+            onSelect: () {},
+            child: IconButton(onPressed: () {}, icon: const Icon(Icons.share)),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    final boxElement = tester.element(find.byKey(const ValueKey('remote-box')));
+    bool belongsToBox(FocusNode node) {
+      final context = node.context;
+      if (context is! Element) return false;
+      if (context == boxElement) return true;
+      var belongs = false;
+      context.visitAncestorElements((ancestor) {
+        if (ancestor == boxElement) {
+          belongs = true;
+          return false;
+        }
+        return true;
+      });
+      return belongs;
+    }
+
+    final requestableStops = FocusManager.instance.rootScope.descendants.where(
+      (node) => node.canRequestFocus && belongsToBox(node),
+    );
+    expect(
+      requestableStops,
+      hasLength(1),
+      reason:
+          'a focusable child must not become a hidden second stop inside '
+          'one visual TV box',
+    );
+  });
+
   testWidgets(
     'TvFocusable scrolls itself into view when it gains focus off-screen '
     '(D-pad through a long list must not leave focus invisible)',

--- a/packages/core_ui/test/widgets/tv_focusable_test.dart
+++ b/packages/core_ui/test/widgets/tv_focusable_test.dart
@@ -116,48 +116,52 @@ void main() {
     expect(secondaryCount, 1);
   });
 
-  testWidgets('TvFocusable contributes one remote stop with a button child', (
+  testWidgets('handled global D-pad input does not traverse a second time', (
     tester,
   ) async {
+    final nodes = List.generate(3, (_) => FocusNode());
+    addTearDown(() {
+      for (final node in nodes) {
+        node.dispose();
+      }
+    });
+
     await tester.pumpWidget(
       MaterialApp(
-        home: Scaffold(
-          body: TvFocusable(
-            key: const ValueKey('remote-box'),
-            autofocus: true,
-            onSelect: () {},
-            child: IconButton(onPressed: () {}, icon: const Icon(Icons.share)),
+        home: TvInputHandler(
+          onInput: (key) {
+            if (key == TvInputKey.right) {
+              FocusManager.instance.primaryFocus!.focusInDirection(
+                TraversalDirection.right,
+              );
+              return TvInputResult.handled;
+            }
+            return TvInputResult.notHandled;
+          },
+          child: Row(
+            children: [
+              for (var index = 0; index < nodes.length; index++)
+                TvFocusable(
+                  focusNode: nodes[index],
+                  autofocus: index == 0,
+                  child: Text('Box $index'),
+                ),
+            ],
           ),
         ),
       ),
     );
     await tester.pumpAndSettle();
+    expect(nodes[0].hasFocus, isTrue);
 
-    final boxElement = tester.element(find.byKey(const ValueKey('remote-box')));
-    bool belongsToBox(FocusNode node) {
-      final context = node.context;
-      if (context is! Element) return false;
-      if (context == boxElement) return true;
-      var belongs = false;
-      context.visitAncestorElements((ancestor) {
-        if (ancestor == boxElement) {
-          belongs = true;
-          return false;
-        }
-        return true;
-      });
-      return belongs;
-    }
+    await tester.sendKeyEvent(LogicalKeyboardKey.arrowRight);
+    await tester.pumpAndSettle();
 
-    final requestableStops = FocusManager.instance.rootScope.descendants.where(
-      (node) => node.canRequestFocus && belongsToBox(node),
-    );
+    expect(nodes[1].hasFocus, isTrue);
     expect(
-      requestableStops,
-      hasLength(1),
-      reason:
-          'a focusable child must not become a hidden second stop inside '
-          'one visual TV box',
+      nodes[2].hasFocus,
+      isFalse,
+      reason: 'one Fire TV key press must advance exactly one visual box',
     );
   });
 

--- a/packages/feature_iptv/lib/presentation/screens/iptv_screen.dart
+++ b/packages/feature_iptv/lib/presentation/screens/iptv_screen.dart
@@ -750,7 +750,11 @@ class _IPTVScreenState extends ConsumerState<IPTVScreen>
               initiallyFullscreen: true,
               onFullscreenToggle: _toggleFullscreen,
               enableSwipeChannelChange: true,
-              showPictureInPicture: !widget.tenFootMode,
+              // The Fire TV acceptance contract keeps Picture-in-picture
+              // in Player actions even when the platform ultimately
+              // reports it unavailable; hiding the row made the required
+              // seven-row remote traversal impossible.
+              showPictureInPicture: true,
               useTvTransportBar: widget.tenFootMode,
             ),
           ),
@@ -1164,6 +1168,7 @@ class _StreamTabContent extends ConsumerWidget {
     if (channels.isEmpty) {
       return _BringYourOwnPlaylistView(
         onPlaylistSourceTap: onPlaylistSourceTap,
+        tenFootMode: playlistSourceInInfoBar,
       );
     }
 
@@ -1600,54 +1605,99 @@ class _PlaylistSourceInfoCallout extends StatelessWidget {
 }
 
 class _BringYourOwnPlaylistView extends StatelessWidget {
-  const _BringYourOwnPlaylistView({required this.onPlaylistSourceTap});
+  const _BringYourOwnPlaylistView({
+    required this.onPlaylistSourceTap,
+    required this.tenFootMode,
+  });
 
   final VoidCallback onPlaylistSourceTap;
+  final bool tenFootMode;
 
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
+
+    final scrollView = SingleChildScrollView(
+      padding: tenFootMode ? EdgeInsets.zero : const EdgeInsets.all(16),
+      child: Column(
+        children: [
+          Align(
+            alignment: Alignment.centerLeft,
+            child: Text(
+              'Add your playlist',
+              style: theme.textTheme.titleLarge?.copyWith(
+                fontWeight: FontWeight.w700,
+              ),
+            ),
+          ),
+          const SizedBox(height: 8),
+          Text(
+            'Airo is a media player. It does not provide channels, playlists, or program guide data. Add an M3U URL for media you own or are authorized to watch.',
+            style: theme.textTheme.bodyMedium,
+          ),
+          const SizedBox(height: 16),
+          Align(
+            alignment: Alignment.centerLeft,
+            child: Semantics(
+              button: true,
+              label: 'Add a playlist URL',
+              hint: 'Opens playlist source setup.',
+              child: tenFootMode
+                  ? TvFocusable(
+                      key: const ValueKey('iptv-empty-add-playlist'),
+                      autofocus: true,
+                      semanticLabel: 'Add a playlist URL',
+                      onSelect: onPlaylistSourceTap,
+                      borderRadius: 20,
+                      child: Material(
+                        color: theme.colorScheme.primary,
+                        borderRadius: BorderRadius.circular(20),
+                        child: InkWell(
+                          onTap: onPlaylistSourceTap,
+                          canRequestFocus: false,
+                          borderRadius: BorderRadius.circular(20),
+                          child: Padding(
+                            padding: const EdgeInsets.symmetric(
+                              horizontal: 20,
+                              vertical: 12,
+                            ),
+                            child: Row(
+                              mainAxisSize: MainAxisSize.min,
+                              children: [
+                                Icon(
+                                  Icons.link,
+                                  color: theme.colorScheme.onPrimary,
+                                ),
+                                const SizedBox(width: 8),
+                                Text(
+                                  'Add playlist URL',
+                                  style: TextStyle(
+                                    color: theme.colorScheme.onPrimary,
+                                  ),
+                                ),
+                              ],
+                            ),
+                          ),
+                        ),
+                      ),
+                    )
+                  : FilledButton.icon(
+                      onPressed: onPlaylistSourceTap,
+                      icon: const Icon(Icons.link),
+                      label: const Text('Add playlist URL'),
+                    ),
+            ),
+          ),
+        ],
+      ),
+    );
 
     return Semantics(
       container: true,
       explicitChildNodes: true,
       label: 'Playlist setup',
       hint: 'Add a playlist URL to browse your channels.',
-      child: SingleChildScrollView(
-        padding: const EdgeInsets.all(16),
-        child: Column(
-          children: [
-            Align(
-              alignment: Alignment.centerLeft,
-              child: Text(
-                'Add your playlist',
-                style: theme.textTheme.titleLarge?.copyWith(
-                  fontWeight: FontWeight.w700,
-                ),
-              ),
-            ),
-            const SizedBox(height: 8),
-            Text(
-              'Airo is a media player. It does not provide channels, playlists, or program guide data. Add an M3U URL for media you own or are authorized to watch.',
-              style: theme.textTheme.bodyMedium,
-            ),
-            const SizedBox(height: 16),
-            Align(
-              alignment: Alignment.centerLeft,
-              child: Semantics(
-                button: true,
-                label: 'Add a playlist URL',
-                hint: 'Opens playlist source setup.',
-                child: FilledButton.icon(
-                  onPressed: onPlaylistSourceTap,
-                  icon: const Icon(Icons.link),
-                  label: const Text('Add playlist URL'),
-                ),
-              ),
-            ),
-          ],
-        ),
-      ),
+      child: tenFootMode ? TvOverscanSafeArea(child: scrollView) : scrollView,
     );
   }
 }

--- a/packages/feature_iptv/lib/presentation/screens/iptv_screen.dart
+++ b/packages/feature_iptv/lib/presentation/screens/iptv_screen.dart
@@ -1176,6 +1176,10 @@ class _StreamTabContent extends ConsumerWidget {
       channels: channels,
       enrichMetadata: true,
       currentChannel: activeChannel,
+      showVideoStage: !playlistSourceInInfoBar,
+      focusPlayDelay: playlistSourceInInfoBar
+          ? const Duration(milliseconds: 1200)
+          : null,
       onChannelSelected: onChannelTap,
       onPlaylistSourceTap: playlistSourceInInfoBar ? onPlaylistSourceTap : null,
       onWaysToWatchTap: onWaysToWatchTap,

--- a/packages/feature_iptv/lib/presentation/screens/iptv_screen.dart
+++ b/packages/feature_iptv/lib/presentation/screens/iptv_screen.dart
@@ -1265,6 +1265,8 @@ class _PlaylistSourceSheetState extends ConsumerState<_PlaylistSourceSheet> {
   String? _errorText;
   StreamSubscription<ImportProgress>? _importSubscription;
   ImportProgress? _importProgress;
+  List<IPTVChannel> _channelsBeforeImport = const [];
+  bool _isCompletingImport = false;
 
   @override
   void initState() {
@@ -1290,6 +1292,11 @@ class _PlaylistSourceSheetState extends ConsumerState<_PlaylistSourceSheet> {
 
   Future<void> _save() async {
     final parser = ref.read(m3uParserProvider);
+    // Capture the provider-backed list before changing the source. The staged
+    // parser persists playlist B directly, so waiting until `ready` would lose
+    // playlist A and make CV-017 favorite remapping impossible.
+    _channelsBeforeImport =
+        ref.read(iptvChannelsProvider).value ?? const <IPTVChannel>[];
     try {
       await parser.setPlaylistUrl(_controller.text);
     } on ArgumentError catch (error) {
@@ -1321,13 +1328,40 @@ class _PlaylistSourceSheetState extends ConsumerState<_PlaylistSourceSheet> {
   void _onImportProgress(ImportProgress progress) {
     if (!mounted) return;
     setState(() => _importProgress = progress);
-    if (progress.stage == ImportStage.ready) {
-      // The staged import already persisted the new channels; refresh both
-      // the channel list and the derived rails so BrowseScreen picks them
-      // up immediately instead of waiting for the next cold read.
+    if (progress.stage == ImportStage.ready && !_isCompletingImport) {
+      unawaited(_completeImport());
+    }
+  }
+
+  Future<void> _completeImport() async {
+    _isCompletingImport = true;
+    try {
+      // The staged import already persisted the new channels. Rebuild the
+      // provider first, then reconcile favorites against the pre-import
+      // snapshot before closing the sheet or rebuilding derived rails.
       ref.invalidate(iptvChannelsProvider);
+      final newChannels = await ref.read(iptvChannelsProvider.future);
+      final needsReview = await applyFavoriteRemapOnReimport(
+        favoriteStorage: ref.read(favoriteChannelsStorageProvider),
+        coordinator: ref.read(favoriteReimportCoordinatorProvider),
+        oldChannels: _channelsBeforeImport,
+        newChannels: newChannels,
+      );
+      ref.read(favoriteReimportReviewCandidatesProvider.notifier).state =
+          needsReview;
+      ref.invalidate(favoriteChannelIdsProvider);
       ref.invalidate(railsProvider);
-      Navigator.of(context).pop();
+      if (mounted) Navigator.of(context).pop();
+    } catch (error) {
+      if (!mounted) return;
+      setState(() {
+        _importProgress = ImportProgress(
+          stage: ImportStage.failed,
+          error: error,
+        );
+      });
+    } finally {
+      _isCompletingImport = false;
     }
   }
 

--- a/packages/feature_iptv/lib/presentation/screens/iptv_screen.dart
+++ b/packages/feature_iptv/lib/presentation/screens/iptv_screen.dart
@@ -90,6 +90,7 @@ class _IPTVScreenState extends ConsumerState<IPTVScreen>
   final FocusNode _fullscreenFocusNode = FocusNode(
     debugLabel: 'IPTV fullscreen back handler',
   );
+  DateTime? _lastFullscreenBackAt;
 
   /// Guards the postFrameCallback below to fire once per fullscreen entry,
   /// not on every rebuild. Live playback rebuilds constantly (buffering,
@@ -228,9 +229,21 @@ class _IPTVScreenState extends ConsumerState<IPTVScreen>
 
   @override
   Future<bool> didPopRoute() async {
-    if (!ref.read(isFullscreenModeProvider)) return false;
-    _exitFullscreen();
-    return true;
+    if (ref.read(isFullscreenModeProvider)) {
+      _lastFullscreenBackAt = DateTime.now();
+      _exitFullscreen();
+      return true;
+    }
+    final lastFullscreenBackAt = _lastFullscreenBackAt;
+    if (lastFullscreenBackAt != null &&
+        DateTime.now().difference(lastFullscreenBackAt) <
+            const Duration(seconds: 1)) {
+      // Fire OS can dispatch one remote BACK as two pop-route callbacks.
+      // Consume the duplicate so returning to browse never closes the app.
+      _lastFullscreenBackAt = null;
+      return true;
+    }
+    return false;
   }
 
   KeyEventResult _handleFullscreenKey(FocusNode node, KeyEvent event) {
@@ -238,9 +251,11 @@ class _IPTVScreenState extends ConsumerState<IPTVScreen>
       return KeyEventResult.ignored;
     }
     final key = event.logicalKey;
-    if (key == LogicalKeyboardKey.goBack ||
-        key == LogicalKeyboardKey.escape ||
-        key == LogicalKeyboardKey.browserBack) {
+    // Android/Fire OS also sends BACK through didPopRoute. Consuming GoBack
+    // here exits fullscreen on key-down, then the platform pop-route closes
+    // the newly exposed browse route. Escape remains useful for desktop/web;
+    // Android BACK is handled exactly once by didPopRoute/PopScope.
+    if (key == LogicalKeyboardKey.escape) {
       _exitFullscreen();
       return KeyEventResult.handled;
     }
@@ -279,6 +294,7 @@ class _IPTVScreenState extends ConsumerState<IPTVScreen>
 
   void _exitFullscreen() {
     if (!ref.read(isFullscreenModeProvider)) return;
+    _lastFullscreenBackAt = DateTime.now();
     _toggleFullscreen();
   }
 
@@ -634,10 +650,20 @@ class _IPTVScreenState extends ConsumerState<IPTVScreen>
     final isPlaying =
         ref.watch(streamingStateProvider).value?.isPlaying == true;
     Widget guardRouteBack(Widget child) {
+      final lastFullscreenBackAt = _lastFullscreenBackAt;
+      final suppressDuplicateBack =
+          lastFullscreenBackAt != null &&
+          DateTime.now().difference(lastFullscreenBackAt) <
+              const Duration(seconds: 1);
       return PopScope<void>(
-        canPop: !isFullscreen,
+        canPop: !isFullscreen && !suppressDuplicateBack,
         onPopInvokedWithResult: (didPop, _) {
-          if (!didPop) _exitFullscreen();
+          if (didPop) return;
+          if (isFullscreen) {
+            _exitFullscreen();
+          } else if (suppressDuplicateBack) {
+            _lastFullscreenBackAt = null;
+          }
         },
         child: child,
       );
@@ -910,6 +936,7 @@ class _IPTVScreenBodyState extends ConsumerState<IPTVScreenBody>
   final FocusNode _fullscreenFocusNode = FocusNode(
     debugLabel: 'IPTV body fullscreen back handler',
   );
+  DateTime? _lastFullscreenBackAt;
 
   /// See _IPTVScreenState's identical field: guards the postFrameCallback
   /// below to fire once per fullscreen entry, not on every rebuild.
@@ -939,9 +966,19 @@ class _IPTVScreenBodyState extends ConsumerState<IPTVScreenBody>
 
   @override
   Future<bool> didPopRoute() async {
-    if (!ref.read(isFullscreenModeProvider)) return false;
-    _exitFullscreen();
-    return true;
+    if (ref.read(isFullscreenModeProvider)) {
+      _lastFullscreenBackAt = DateTime.now();
+      _exitFullscreen();
+      return true;
+    }
+    final lastFullscreenBackAt = _lastFullscreenBackAt;
+    if (lastFullscreenBackAt != null &&
+        DateTime.now().difference(lastFullscreenBackAt) <
+            const Duration(seconds: 1)) {
+      _lastFullscreenBackAt = null;
+      return true;
+    }
+    return false;
   }
 
   KeyEventResult _handleFullscreenKey(FocusNode node, KeyEvent event) {
@@ -949,9 +986,7 @@ class _IPTVScreenBodyState extends ConsumerState<IPTVScreenBody>
       return KeyEventResult.ignored;
     }
     final key = event.logicalKey;
-    if (key == LogicalKeyboardKey.goBack ||
-        key == LogicalKeyboardKey.escape ||
-        key == LogicalKeyboardKey.browserBack) {
+    if (key == LogicalKeyboardKey.escape) {
       _exitFullscreen();
       return KeyEventResult.handled;
     }
@@ -984,6 +1019,7 @@ class _IPTVScreenBodyState extends ConsumerState<IPTVScreenBody>
 
   void _exitFullscreen() {
     if (!ref.read(isFullscreenModeProvider)) return;
+    _lastFullscreenBackAt = DateTime.now();
     _toggleFullscreen();
   }
 

--- a/packages/feature_iptv/lib/presentation/tv_ux/airo_tv_shell.dart
+++ b/packages/feature_iptv/lib/presentation/tv_ux/airo_tv_shell.dart
@@ -38,6 +38,8 @@ class AiroTvShell extends ConsumerStatefulWidget {
     required this.channels,
     required this.videoStage,
     required this.onChannelSelected,
+    this.showVideoStage = true,
+    this.focusPlayDelay,
     this.currentChannel,
     this.metadataByChannelId = const {},
     this.availabilityByChannelId = const {},
@@ -51,6 +53,8 @@ class AiroTvShell extends ConsumerStatefulWidget {
   final List<IPTVChannel> channels;
   final Widget videoStage;
   final ValueChanged<IPTVChannel> onChannelSelected;
+  final bool showVideoStage;
+  final Duration? focusPlayDelay;
   final IPTVChannel? currentChannel;
   final Map<String, ChannelBrowseMetadata> metadataByChannelId;
   final Map<String, StreamAvailability> availabilityByChannelId;
@@ -135,6 +139,7 @@ class _AiroTvShellState extends ConsumerState<AiroTvShell> {
         snapshot.visibleChannels,
         availabilityByChannelId,
       ),
+      focusPlayDelay: widget.focusPlayDelay,
       onVisibleChannelsChanged: _scheduleVisibleChannelScan,
       multiviewChannelIds: {
         for (final session in multiview.sessions) session.id,
@@ -214,7 +219,7 @@ class _AiroTvShellState extends ConsumerState<AiroTvShell> {
         if (constraints.maxWidth < 600) {
           return Column(
             children: [
-              Flexible(flex: 3, child: videoStage),
+              if (widget.showVideoStage) Flexible(flex: 3, child: videoStage),
               ...compactChrome,
               if (showPlaylist) Expanded(flex: 4, child: table),
             ],
@@ -224,40 +229,41 @@ class _AiroTvShellState extends ConsumerState<AiroTvShell> {
             .clamp(320.0, 480.0)
             .toDouble();
         final previewHeight = previewWidth * 9 / 16;
-        final panelWidth = (constraints.maxWidth * 0.88)
-            .clamp(720.0, 1120.0)
-            .toDouble();
+        final panelWidth = widget.showVideoStage
+            ? (constraints.maxWidth * 0.88).clamp(720.0, 1120.0).toDouble()
+            : constraints.maxWidth;
 
         return Container(
           key: const ValueKey('airo-tv-explorer-wide-shell'),
           color: Colors.black,
           child: Column(
             children: [
-              Flexible(
-                flex: 3,
-                child: Center(
-                  child: FittedBox(
-                    fit: BoxFit.contain,
-                    child: SizedBox(
-                      key: const ValueKey('airo-tv-explorer-video-stage'),
-                      width: previewWidth,
-                      height: previewHeight,
-                      child: ClipRect(
-                        child: FittedBox(
-                          fit: BoxFit.contain,
-                          child: SizedBox(
-                            width: 640,
-                            height: 360,
-                            child: videoStage,
+              if (widget.showVideoStage)
+                Flexible(
+                  flex: 3,
+                  child: Center(
+                    child: FittedBox(
+                      fit: BoxFit.contain,
+                      child: SizedBox(
+                        key: const ValueKey('airo-tv-explorer-video-stage'),
+                        width: previewWidth,
+                        height: previewHeight,
+                        child: ClipRect(
+                          child: FittedBox(
+                            fit: BoxFit.contain,
+                            child: SizedBox(
+                              width: 640,
+                              height: 360,
+                              child: videoStage,
+                            ),
                           ),
                         ),
                       ),
                     ),
                   ),
                 ),
-              ),
               Expanded(
-                flex: 5,
+                flex: widget.showVideoStage ? 5 : 1,
                 child: Align(
                   alignment: Alignment.topCenter,
                   child: ConstrainedBox(

--- a/packages/feature_iptv/lib/presentation/tv_ux/sections/channel_library_grid.dart
+++ b/packages/feature_iptv/lib/presentation/tv_ux/sections/channel_library_grid.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:core_ui/core_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:platform_channels/platform_channels.dart';
@@ -24,6 +26,7 @@ class ChannelLibraryGrid extends StatefulWidget {
     this.sort = const ChannelSort(),
     this.onSort,
     this.onChannelSelected,
+    this.focusPlayDelay,
     this.onVisibleChannelsChanged,
     this.multiviewChannelIds = const {},
     this.onMultiviewToggle,
@@ -35,6 +38,7 @@ class ChannelLibraryGrid extends StatefulWidget {
   final ChannelSort sort;
   final ValueChanged<ChannelSortColumn>? onSort;
   final ValueChanged<IPTVChannel>? onChannelSelected;
+  final Duration? focusPlayDelay;
   final ValueChanged<List<IPTVChannel>>? onVisibleChannelsChanged;
   final Set<String> multiviewChannelIds;
   final ValueChanged<IPTVChannel>? onMultiviewToggle;
@@ -145,6 +149,7 @@ class _ChannelLibraryGridState extends State<ChannelLibraryGrid> {
                         availability:
                             widget.availabilityByChannelId[channel.id],
                         onSelected: widget.onChannelSelected,
+                        focusPlayDelay: widget.focusPlayDelay,
                         inMultiview: widget.multiviewChannelIds.contains(
                           channel.id,
                         ),
@@ -222,12 +227,13 @@ class _LibrarySortRow extends StatelessWidget {
   }
 }
 
-class _ChannelTile extends StatelessWidget {
+class _ChannelTile extends StatefulWidget {
   const _ChannelTile({
     required this.channel,
     required this.metadata,
     required this.availability,
     this.onSelected,
+    this.focusPlayDelay,
     required this.inMultiview,
     this.onMultiviewToggle,
   });
@@ -236,51 +242,104 @@ class _ChannelTile extends StatelessWidget {
   final ChannelBrowseMetadata? metadata;
   final StreamAvailability? availability;
   final ValueChanged<IPTVChannel>? onSelected;
+  final Duration? focusPlayDelay;
   final bool inMultiview;
   final ValueChanged<IPTVChannel>? onMultiviewToggle;
 
   @override
+  State<_ChannelTile> createState() => _ChannelTileState();
+}
+
+class _ChannelTileState extends State<_ChannelTile> {
+  Timer? _focusPlayTimer;
+
+  @override
+  void didUpdateWidget(covariant _ChannelTile oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.channel.id != widget.channel.id ||
+        oldWidget.focusPlayDelay != widget.focusPlayDelay ||
+        oldWidget.onSelected != widget.onSelected) {
+      _cancelFocusPlay();
+    }
+  }
+
+  @override
+  void dispose() {
+    _cancelFocusPlay();
+    super.dispose();
+  }
+
+  void _scheduleFocusPlay() {
+    _cancelFocusPlay();
+    final delay = widget.focusPlayDelay;
+    final onSelected = widget.onSelected;
+    if (delay == null || onSelected == null) return;
+    _focusPlayTimer = Timer(delay, () {
+      _focusPlayTimer = null;
+      if (!mounted) return;
+      onSelected(widget.channel);
+    });
+  }
+
+  void _cancelFocusPlay() {
+    _focusPlayTimer?.cancel();
+    _focusPlayTimer = null;
+  }
+
+  void _selectNow() {
+    _cancelFocusPlay();
+    widget.onSelected?.call(widget.channel);
+  }
+
+  @override
   Widget build(BuildContext context) {
-    final country = effectiveChannelCountry(channel, metadata);
-    final languages = effectiveChannelLanguages(channel, metadata);
+    final country = effectiveChannelCountry(widget.channel, widget.metadata);
+    final languages = effectiveChannelLanguages(
+      widget.channel,
+      widget.metadata,
+    );
     final subtitle = _subtitleFor(country, languages);
 
     return Stack(
       children: [
         MediaCard(
-          name: channel.name,
+          name: widget.channel.name,
           subtitle: subtitle,
-          logoUrl: channel.effectiveLogoUrl,
-          initials: _initialsFor(channel.name),
-          onTap: onSelected == null ? null : () => onSelected!(channel),
-          onLongPress: onMultiviewToggle == null
+          logoUrl: widget.channel.effectiveLogoUrl,
+          initials: _initialsFor(widget.channel.name),
+          onTap: widget.onSelected == null ? null : _selectNow,
+          onLongPress: widget.onMultiviewToggle == null
               ? null
-              : () => onMultiviewToggle!(channel),
+              : () => widget.onMultiviewToggle!(widget.channel),
+          onFocus: _scheduleFocusPlay,
+          onUnfocus: _cancelFocusPlay,
         ),
         Positioned(
           top: 7,
           left: 7,
-          child: _AvailabilityDot(availability: availability),
+          child: _AvailabilityDot(availability: widget.availability),
         ),
-        if (onMultiviewToggle != null)
+        if (widget.onMultiviewToggle != null)
           Positioned(
             top: 4,
             right: 4,
             child: ExcludeFocus(
               child: Material(
-                key: ValueKey('channel-multiview-${channel.id}'),
+                key: ValueKey('channel-multiview-${widget.channel.id}'),
                 color: Colors.black.withValues(alpha: 0.68),
                 shape: const CircleBorder(),
                 child: IconButton(
                   visualDensity: VisualDensity.compact,
-                  tooltip: inMultiview
+                  tooltip: widget.inMultiview
                       ? 'Remove from multiview'
                       : 'Add to multiview',
-                  onPressed: () => onMultiviewToggle!(channel),
+                  onPressed: () => widget.onMultiviewToggle!(widget.channel),
                   icon: Icon(
-                    inMultiview ? Icons.remove_from_queue : Icons.add_to_queue,
+                    widget.inMultiview
+                        ? Icons.remove_from_queue
+                        : Icons.add_to_queue,
                     size: 18,
-                    color: inMultiview
+                    color: widget.inMultiview
                         ? Theme.of(context).colorScheme.primary
                         : Colors.white,
                   ),
@@ -293,7 +352,8 @@ class _ChannelTile extends StatelessWidget {
   }
 
   String? _subtitleFor(String? country, List<String> languages) {
-    final category = categoryDisplayLabel(channel.group) ?? channel.group;
+    final category =
+        categoryDisplayLabel(widget.channel.group) ?? widget.channel.group;
     final flag = _countryFlagOnly(country);
     final languageSummary = _languageSummary(languages);
     final parts = [category, ?flag, ?languageSummary];

--- a/packages/feature_iptv/lib/presentation/tv_ux/sections/channel_library_grid.dart
+++ b/packages/feature_iptv/lib/presentation/tv_ux/sections/channel_library_grid.dart
@@ -253,6 +253,9 @@ class _ChannelTile extends StatelessWidget {
           logoUrl: channel.effectiveLogoUrl,
           initials: _initialsFor(channel.name),
           onTap: onSelected == null ? null : () => onSelected!(channel),
+          onLongPress: onMultiviewToggle == null
+              ? null
+              : () => onMultiviewToggle!(channel),
         ),
         Positioned(
           top: 7,
@@ -263,14 +266,9 @@ class _ChannelTile extends StatelessWidget {
           Positioned(
             top: 4,
             right: 4,
-            child: TvFocusable(
-              key: ValueKey('channel-multiview-${channel.id}'),
-              semanticLabel: inMultiview
-                  ? 'Remove ${channel.name} from multiview'
-                  : 'Add ${channel.name} to multiview',
-              onSelect: () => onMultiviewToggle!(channel),
-              borderRadius: 20,
+            child: ExcludeFocus(
               child: Material(
+                key: ValueKey('channel-multiview-${channel.id}'),
                 color: Colors.black.withValues(alpha: 0.68),
                 shape: const CircleBorder(),
                 child: IconButton(

--- a/packages/feature_iptv/lib/presentation/widgets/favorite_reimport_review_banner.dart
+++ b/packages/feature_iptv/lib/presentation/widgets/favorite_reimport_review_banner.dart
@@ -11,67 +11,132 @@ import '../../domain/favorite_reimport_coordinator.dart';
 /// are never applied automatically (see [applyFavoriteRemapOnReimport]).
 ///
 /// Renders nothing when [favoriteReimportReviewCandidatesProvider] is empty.
-class FavoriteReimportReviewBanner extends ConsumerWidget {
+class FavoriteReimportReviewBanner extends ConsumerStatefulWidget {
   const FavoriteReimportReviewBanner({super.key});
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  ConsumerState<FavoriteReimportReviewBanner> createState() =>
+      _FavoriteReimportReviewBannerState();
+}
+
+class _FavoriteReimportReviewBannerState
+    extends ConsumerState<FavoriteReimportReviewBanner> {
+  final FocusScopeNode _scopeNode = FocusScopeNode(
+    debugLabel: 'favorite reimport review',
+    directionalTraversalEdgeBehavior: TraversalEdgeBehavior.closedLoop,
+  );
+  final Map<String, FocusNode> _keepFocusNodes = {};
+  final Map<String, FocusNode> _dismissFocusNodes = {};
+  String? _focusedCandidateId;
+
+  FocusNode _keepFocusNode(String id) => _keepFocusNodes.putIfAbsent(
+    id,
+    () => FocusNode(debugLabel: 'favorite review Keep'),
+  );
+
+  FocusNode _dismissFocusNode(String id) => _dismissFocusNodes.putIfAbsent(
+    id,
+    () => FocusNode(debugLabel: 'favorite review Dismiss'),
+  );
+
+  @override
+  void dispose() {
+    _scopeNode.dispose();
+    for (final node in [
+      ..._keepFocusNodes.values,
+      ..._dismissFocusNodes.values,
+    ]) {
+      node.dispose();
+    }
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
     final candidates = ref.watch(favoriteReimportReviewCandidatesProvider);
-    if (candidates.isEmpty) return const SizedBox.shrink();
+    if (candidates.isEmpty) {
+      _focusedCandidateId = null;
+      return const SizedBox.shrink();
+    }
+
+    final firstCandidateId = candidates.first.oldChannel.id;
+    if (_focusedCandidateId != firstCandidateId) {
+      _focusedCandidateId = firstCandidateId;
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (!mounted ||
+            _focusedCandidateId != firstCandidateId ||
+            !_keepFocusNode(firstCandidateId).canRequestFocus) {
+          return;
+        }
+        _keepFocusNode(firstCandidateId).requestFocus();
+      });
+    }
 
     final colorScheme = Theme.of(context).colorScheme;
-    return Container(
-      margin: const EdgeInsets.only(bottom: 16),
-      padding: const EdgeInsets.all(12),
-      decoration: BoxDecoration(
-        color: colorScheme.surfaceContainerHighest,
-        borderRadius: BorderRadius.circular(8),
-        border: Border.all(color: colorScheme.outlineVariant),
-      ),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          for (final candidate in candidates)
-            Padding(
-              key: ValueKey(
-                'favorite-reimport-review-${candidate.oldChannel.id}',
-              ),
-              padding: const EdgeInsets.symmetric(vertical: 4),
-              child: Row(
-                children: [
-                  Expanded(
-                    child: Text(
-                      '"${candidate.oldChannel.name}" looks like '
-                      '"${candidate.candidate.name}" now. Keep as favorite?',
-                    ),
+    return FocusTraversalGroup(
+      policy: WidgetOrderTraversalPolicy(),
+      child: FocusScope(
+        node: _scopeNode,
+        child: Container(
+          margin: const EdgeInsets.only(bottom: 16),
+          padding: const EdgeInsets.all(12),
+          decoration: BoxDecoration(
+            color: colorScheme.surfaceContainerHighest,
+            borderRadius: BorderRadius.circular(8),
+            border: Border.all(color: colorScheme.outlineVariant),
+          ),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              for (final candidate in candidates)
+                Padding(
+                  key: ValueKey(
+                    'favorite-reimport-review-${candidate.oldChannel.id}',
                   ),
-                  TvFocusable(
-                    semanticLabel: 'Keep as favorite',
-                    onSelect: () => _accept(ref, candidate),
-                    child: TextButton(
-                      key: ValueKey(
-                        'favorite-reimport-accept-${candidate.oldChannel.id}',
+                  padding: const EdgeInsets.symmetric(vertical: 4),
+                  child: Row(
+                    children: [
+                      Expanded(
+                        child: Text(
+                          '"${candidate.oldChannel.name}" looks like '
+                          '"${candidate.candidate.name}" now. Keep as favorite?',
+                        ),
                       ),
-                      onPressed: () => _accept(ref, candidate),
-                      child: const Text('Keep'),
-                    ),
-                  ),
-                  TvFocusable(
-                    semanticLabel: 'Dismiss',
-                    onSelect: () => _dismiss(ref, candidate),
-                    child: TextButton(
-                      key: ValueKey(
-                        'favorite-reimport-dismiss-${candidate.oldChannel.id}',
+                      TvFocusable(
+                        focusNode: _keepFocusNode(candidate.oldChannel.id),
+                        semanticLabel: 'Keep as favorite',
+                        onSelect: () => _accept(ref, candidate),
+                        child: ExcludeFocus(
+                          child: TextButton(
+                            key: ValueKey(
+                              'favorite-reimport-accept-${candidate.oldChannel.id}',
+                            ),
+                            onPressed: () => _accept(ref, candidate),
+                            child: const Text('Keep'),
+                          ),
+                        ),
                       ),
-                      onPressed: () => _dismiss(ref, candidate),
-                      child: const Text('Dismiss'),
-                    ),
+                      TvFocusable(
+                        focusNode: _dismissFocusNode(candidate.oldChannel.id),
+                        semanticLabel: 'Dismiss',
+                        onSelect: () => _dismiss(ref, candidate),
+                        child: ExcludeFocus(
+                          child: TextButton(
+                            key: ValueKey(
+                              'favorite-reimport-dismiss-${candidate.oldChannel.id}',
+                            ),
+                            onPressed: () => _dismiss(ref, candidate),
+                            child: const Text('Dismiss'),
+                          ),
+                        ),
+                      ),
+                    ],
                   ),
-                ],
-              ),
-            ),
-        ],
+                ),
+            ],
+          ),
+        ),
       ),
     );
   }

--- a/packages/feature_iptv/lib/presentation/widgets/video_player_widget.dart
+++ b/packages/feature_iptv/lib/presentation/widgets/video_player_widget.dart
@@ -1175,6 +1175,14 @@ class _VideoPlayerWidgetState extends ConsumerState<VideoPlayerWidget> {
     return '${state.currentChannel?.id}|${diagnostic.code}|${state.retryCount}';
   }
 
+  FocusNode? _diagnosticRecoveryFocusNode(StreamingState state) {
+    final diagnostic = state.diagnostic;
+    if (!state.hasError || diagnostic == null) return null;
+    return !diagnostic.retryEligible || state.retryCount == 0
+        ? _diagnosticRetryFocusNode
+        : _diagnosticSkipFocusNode;
+  }
+
   void _scheduleRecoveryFocus(StreamingState state) {
     final token = _recoveryFocusToken(state);
     if (token == null) {
@@ -1188,10 +1196,7 @@ class _VideoPlayerWidgetState extends ConsumerState<VideoPlayerWidget> {
     _cancelHideControlsTimer();
     if (_lastRecoveryFocusToken == token) return;
     _lastRecoveryFocusToken = token;
-    final diagnostic = state.diagnostic!;
-    final target = !diagnostic.retryEligible || state.retryCount == 0
-        ? _diagnosticRetryFocusNode
-        : _diagnosticSkipFocusNode;
+    final target = _diagnosticRecoveryFocusNode(state)!;
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!mounted || _lastRecoveryFocusToken != token) return;
       if (target.canRequestFocus) target.requestFocus();
@@ -2303,8 +2308,13 @@ class _VideoPlayerWidgetState extends ConsumerState<VideoPlayerWidget> {
         setState(() => _playerModalOpen = false);
         _startHideControlsTimer();
         WidgetsBinding.instance.addPostFrameCallback((_) {
-          if (mounted && restoreFocusNode.canRequestFocus) {
-            restoreFocusNode.requestFocus();
+          if (!mounted) return;
+          final currentState = ref.read(streamingStateProvider).asData?.value;
+          final target = currentState == null
+              ? restoreFocusNode
+              : _diagnosticRecoveryFocusNode(currentState) ?? restoreFocusNode;
+          if (target.canRequestFocus) {
+            target.requestFocus();
           }
         });
       }

--- a/packages/feature_iptv/lib/presentation/widgets/video_player_widget.dart
+++ b/packages/feature_iptv/lib/presentation/widgets/video_player_widget.dart
@@ -2855,7 +2855,7 @@ enum _TvQuickBrowse { miniGuide, recent }
 
 /// Bottom-docked horizontal browse strip for UP (Mini Guide) and DOWN
 /// (Recent Channels). AiroTV D-pad design: "◀ ▶ browse · OK switch".
-class _QuickBrowseOverlay extends StatelessWidget {
+class _QuickBrowseOverlay extends StatefulWidget {
   const _QuickBrowseOverlay({
     required this.title,
     required this.channels,
@@ -2869,103 +2869,200 @@ class _QuickBrowseOverlay extends StatelessWidget {
   final ValueChanged<IPTVChannel> onSelected;
 
   @override
+  State<_QuickBrowseOverlay> createState() => _QuickBrowseOverlayState();
+}
+
+class _QuickBrowseOverlayState extends State<_QuickBrowseOverlay> {
+  late List<FocusNode> _focusNodes;
+  late int _focusedIndex;
+
+  String get _channelSignature =>
+      widget.channels.map((channel) => channel.id).join('|');
+
+  @override
+  void initState() {
+    super.initState();
+    _createFocusNodes();
+    _requestInitialFocus();
+  }
+
+  @override
+  void didUpdateWidget(covariant _QuickBrowseOverlay oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    final oldSignature = oldWidget.channels
+        .map((channel) => channel.id)
+        .join('|');
+    if (oldSignature == _channelSignature &&
+        oldWidget.currentChannelId == widget.currentChannelId) {
+      return;
+    }
+    for (final node in _focusNodes) {
+      node.dispose();
+    }
+    _createFocusNodes();
+    _requestInitialFocus();
+  }
+
+  @override
+  void dispose() {
+    for (final node in _focusNodes) {
+      node.dispose();
+    }
+    super.dispose();
+  }
+
+  void _createFocusNodes() {
+    _focusedIndex = widget.channels.indexWhere(
+      (channel) => channel.id == widget.currentChannelId,
+    );
+    if (_focusedIndex < 0) _focusedIndex = 0;
+    _focusNodes = [
+      for (final channel in widget.channels)
+        FocusNode(debugLabel: 'quick browse ${channel.name}'),
+    ];
+  }
+
+  void _requestInitialFocus() {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted || _focusNodes.isEmpty) return;
+      _focusNodes[_focusedIndex].requestFocus();
+    });
+  }
+
+  KeyEventResult _handleBrowseKey(FocusNode node, KeyEvent event) {
+    if (event is! KeyDownEvent || widget.channels.isEmpty) {
+      return KeyEventResult.ignored;
+    }
+    final key = TvInputHandler.mapLogicalKeyToTvInput(event.logicalKey);
+    final nextIndex = switch (key) {
+      TvInputKey.left => (_focusedIndex - 1).clamp(
+        0,
+        widget.channels.length - 1,
+      ),
+      TvInputKey.right => (_focusedIndex + 1).clamp(
+        0,
+        widget.channels.length - 1,
+      ),
+      _ => null,
+    };
+    if (nextIndex != null) {
+      _focusedIndex = nextIndex;
+      _focusNodes[_focusedIndex].requestFocus();
+      return KeyEventResult.handled;
+    }
+    if (key == TvInputKey.up || key == TvInputKey.down) {
+      return KeyEventResult.handled;
+    }
+    return KeyEventResult.ignored;
+  }
+
+  @override
   Widget build(BuildContext context) {
     return Positioned(
       left: 0,
       right: 0,
       bottom: 0,
-      child: Container(
-        padding: const EdgeInsets.fromLTRB(24, 20, 24, 20),
-        decoration: BoxDecoration(
-          gradient: LinearGradient(
-            begin: Alignment.bottomCenter,
-            end: Alignment.topCenter,
-            colors: [
-              Colors.black.withValues(alpha: 0.97),
-              Colors.black.withValues(alpha: 0.0),
-            ],
-          ),
-        ),
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Row(
-              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+      child: Focus(
+        canRequestFocus: false,
+        skipTraversal: true,
+        onKeyEvent: _handleBrowseKey,
+        child: FocusScope(
+          child: Container(
+            padding: const EdgeInsets.fromLTRB(24, 20, 24, 20),
+            decoration: BoxDecoration(
+              gradient: LinearGradient(
+                begin: Alignment.bottomCenter,
+                end: Alignment.topCenter,
+                colors: [
+                  Colors.black.withValues(alpha: 0.97),
+                  Colors.black.withValues(alpha: 0.0),
+                ],
+              ),
+            ),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.start,
               children: [
-                Text(
-                  title,
-                  style: const TextStyle(
-                    color: Colors.white,
-                    fontSize: 15,
-                    fontWeight: FontWeight.w700,
-                  ),
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  children: [
+                    Text(
+                      widget.title,
+                      style: const TextStyle(
+                        color: Colors.white,
+                        fontSize: 15,
+                        fontWeight: FontWeight.w700,
+                      ),
+                    ),
+                    const Text(
+                      '◀ ▶ browse   OK switch',
+                      style: TextStyle(color: Colors.white54, fontSize: 12),
+                    ),
+                  ],
                 ),
-                const Text(
-                  '◀ ▶ browse   OK switch',
-                  style: TextStyle(color: Colors.white54, fontSize: 12),
+                const SizedBox(height: 12),
+                SizedBox(
+                  height: 96,
+                  child: ListView.separated(
+                    scrollDirection: Axis.horizontal,
+                    itemCount: widget.channels.length,
+                    separatorBuilder: (context, index) =>
+                        const SizedBox(width: 10),
+                    itemBuilder: (context, index) {
+                      final channel = widget.channels[index];
+                      final isCurrent = channel.id == widget.currentChannelId;
+                      return TvFocusable(
+                        key: ValueKey('quick-browse-${channel.id}'),
+                        focusNode: _focusNodes[index],
+                        semanticLabel: channel.name,
+                        onFocus: () => _focusedIndex = index,
+                        onSelect: () => widget.onSelected(channel),
+                        child: Container(
+                          width: 130,
+                          padding: const EdgeInsets.all(10),
+                          decoration: BoxDecoration(
+                            color: isCurrent
+                                ? Colors.white.withValues(alpha: 0.16)
+                                : Colors.white.withValues(alpha: 0.06),
+                            borderRadius: BorderRadius.circular(10),
+                          ),
+                          child: Column(
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            mainAxisAlignment: MainAxisAlignment.end,
+                            children: [
+                              if (isCurrent)
+                                const Padding(
+                                  padding: EdgeInsets.only(bottom: 6),
+                                  child: Text(
+                                    'ON NOW',
+                                    style: TextStyle(
+                                      color: Colors.greenAccent,
+                                      fontSize: 10,
+                                      fontWeight: FontWeight.w700,
+                                      letterSpacing: 0.6,
+                                    ),
+                                  ),
+                                ),
+                              Text(
+                                channel.name,
+                                maxLines: 1,
+                                overflow: TextOverflow.ellipsis,
+                                style: const TextStyle(
+                                  color: Colors.white,
+                                  fontSize: 13,
+                                  fontWeight: FontWeight.w600,
+                                ),
+                              ),
+                            ],
+                          ),
+                        ),
+                      );
+                    },
+                  ),
                 ),
               ],
             ),
-            const SizedBox(height: 12),
-            SizedBox(
-              height: 96,
-              child: ListView.separated(
-                scrollDirection: Axis.horizontal,
-                itemCount: channels.length,
-                separatorBuilder: (context, index) => const SizedBox(width: 10),
-                itemBuilder: (context, index) {
-                  final channel = channels[index];
-                  final isCurrent = channel.id == currentChannelId;
-                  return TvFocusable(
-                    key: ValueKey('quick-browse-${channel.id}'),
-                    autofocus: isCurrent || index == 0,
-                    semanticLabel: channel.name,
-                    onSelect: () => onSelected(channel),
-                    child: Container(
-                      width: 130,
-                      padding: const EdgeInsets.all(10),
-                      decoration: BoxDecoration(
-                        color: isCurrent
-                            ? Colors.white.withValues(alpha: 0.16)
-                            : Colors.white.withValues(alpha: 0.06),
-                        borderRadius: BorderRadius.circular(10),
-                      ),
-                      child: Column(
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        mainAxisAlignment: MainAxisAlignment.end,
-                        children: [
-                          if (isCurrent)
-                            const Padding(
-                              padding: EdgeInsets.only(bottom: 6),
-                              child: Text(
-                                'ON NOW',
-                                style: TextStyle(
-                                  color: Colors.greenAccent,
-                                  fontSize: 10,
-                                  fontWeight: FontWeight.w700,
-                                  letterSpacing: 0.6,
-                                ),
-                              ),
-                            ),
-                          Text(
-                            channel.name,
-                            maxLines: 1,
-                            overflow: TextOverflow.ellipsis,
-                            style: const TextStyle(
-                              color: Colors.white,
-                              fontSize: 13,
-                              fontWeight: FontWeight.w600,
-                            ),
-                          ),
-                        ],
-                      ),
-                    ),
-                  );
-                },
-              ),
-            ),
-          ],
+          ),
         ),
       ),
     );

--- a/packages/feature_iptv/lib/presentation/widgets/video_player_widget.dart
+++ b/packages/feature_iptv/lib/presentation/widgets/video_player_widget.dart
@@ -3,7 +3,13 @@ import 'package:core_ui/core_ui.dart';
 import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart'
-    show Clipboard, ClipboardData, KeyDownEvent, KeyUpEvent;
+    show
+        Clipboard,
+        ClipboardData,
+        KeyDownEvent,
+        KeyEvent,
+        KeyUpEvent,
+        LogicalKeyboardKey;
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:platform_channels/platform_channels.dart';
 import '../../application/player_backgrounding_coordinator.dart';
@@ -1204,10 +1210,38 @@ class _VideoPlayerWidgetState extends ConsumerState<VideoPlayerWidget> {
     });
   }
 
+  KeyEventResult _handleDiagnosticRecoveryKey(
+    FocusNode node,
+    KeyEvent event, {
+    required bool showRetry,
+  }) {
+    final moveRight = event.logicalKey == LogicalKeyboardKey.arrowRight;
+    final moveLeft = event.logicalKey == LogicalKeyboardKey.arrowLeft;
+    if (!moveRight && !moveLeft) return KeyEventResult.ignored;
+
+    // Consume the complete physical key sequence. Fire OS can expose a
+    // directional press to both Flutter traversal and the raw TV listener;
+    // allowing either key-up or repeat to bubble can therefore skip an action.
+    if (event is! KeyDownEvent) return KeyEventResult.handled;
+
+    final actions = <FocusNode>[
+      if (showRetry) _diagnosticRetryFocusNode,
+      _diagnosticSkipFocusNode,
+      _diagnosticReportFocusNode,
+    ];
+    final currentIndex = actions.indexWhere((candidate) => candidate.hasFocus);
+    if (currentIndex < 0) return KeyEventResult.handled;
+    final offset = moveRight ? 1 : -1;
+    final targetIndex = (currentIndex + offset).clamp(0, actions.length - 1);
+    actions[targetIndex].requestFocus();
+    return KeyEventResult.handled;
+  }
+
   /// CV-001 structured failure state: user-safe copy plus bounded-retry
   /// progress from [StreamingState.diagnostic], with the legacy retry button.
   Widget _buildDiagnosticError(StreamingState state) {
     final diagnostic = state.diagnostic!;
+    final showRetry = !diagnostic.retryEligible || state.retryCount == 0;
     return Container(
       decoration: BoxDecoration(
         gradient: LinearGradient(
@@ -1238,37 +1272,47 @@ class _VideoPlayerWidgetState extends ConsumerState<VideoPlayerWidget> {
               // distinct outcomes, not just retry -- and every one of them
               // must be D-pad reachable (the old ElevatedButton had no
               // TvFocusable, so a remote-only viewer could never reach it).
-              Wrap(
-                alignment: WrapAlignment.center,
-                spacing: 10,
-                runSpacing: 10,
-                children: [
-                  if (!diagnostic.retryEligible || state.retryCount == 0)
+              Focus(
+                canRequestFocus: false,
+                skipTraversal: true,
+                onKeyEvent: (node, event) => _handleDiagnosticRecoveryKey(
+                  node,
+                  event,
+                  showRetry: showRetry,
+                ),
+                child: Wrap(
+                  alignment: WrapAlignment.center,
+                  spacing: 10,
+                  runSpacing: 10,
+                  children: [
+                    if (showRetry)
+                      _RecoveryActionButton(
+                        key: const ValueKey('diagnostic-error-retry'),
+                        focusNode: _diagnosticRetryFocusNode,
+                        icon: Icons.refresh_rounded,
+                        label: 'Try Again',
+                        autofocus: true,
+                        onSelect: () =>
+                            ref.read(iptvStreamingServiceProvider).retry(),
+                      ),
                     _RecoveryActionButton(
-                      key: const ValueKey('diagnostic-error-retry'),
-                      focusNode: _diagnosticRetryFocusNode,
-                      icon: Icons.refresh_rounded,
-                      label: 'Try Again',
-                      autofocus: true,
-                      onSelect: () =>
-                          ref.read(iptvStreamingServiceProvider).retry(),
+                      key: const ValueKey('diagnostic-error-skip'),
+                      focusNode: _diagnosticSkipFocusNode,
+                      icon: Icons.skip_next_rounded,
+                      label: 'Skip channel',
+                      autofocus:
+                          diagnostic.retryEligible && state.retryCount > 0,
+                      onSelect: _goToNextChannel,
                     ),
-                  _RecoveryActionButton(
-                    key: const ValueKey('diagnostic-error-skip'),
-                    focusNode: _diagnosticSkipFocusNode,
-                    icon: Icons.skip_next_rounded,
-                    label: 'Skip channel',
-                    autofocus: diagnostic.retryEligible && state.retryCount > 0,
-                    onSelect: _goToNextChannel,
-                  ),
-                  _RecoveryActionButton(
-                    key: const ValueKey('diagnostic-error-report'),
-                    focusNode: _diagnosticReportFocusNode,
-                    icon: Icons.flag_outlined,
-                    label: 'Report dead link',
-                    onSelect: () => _saveDeadLinkReport(state, diagnostic),
-                  ),
-                ],
+                    _RecoveryActionButton(
+                      key: const ValueKey('diagnostic-error-report'),
+                      focusNode: _diagnosticReportFocusNode,
+                      icon: Icons.flag_outlined,
+                      label: 'Report dead link',
+                      onSelect: () => _saveDeadLinkReport(state, diagnostic),
+                    ),
+                  ],
+                ),
               ),
             ],
           ),

--- a/packages/feature_iptv/lib/presentation/widgets/video_player_widget.dart
+++ b/packages/feature_iptv/lib/presentation/widgets/video_player_widget.dart
@@ -103,6 +103,43 @@ class _VideoPlayerWidgetState extends ConsumerState<VideoPlayerWidget> {
   final FocusNode _centerControlFocusNode = FocusNode(
     debugLabel: 'player center control',
   );
+  final FocusNode _moreActionsFocusNode = FocusNode(
+    debugLabel: 'player more actions',
+  );
+  final FocusNode _infoFocusNode = FocusNode(debugLabel: 'player channel info');
+  final FocusNode _audioTransportFocusNode = FocusNode(
+    debugLabel: 'player audio track',
+  );
+  final FocusNode _subtitleTransportFocusNode = FocusNode(
+    debugLabel: 'player subtitles',
+  );
+  final FocusNode _playerActionsAudioFocusNode = FocusNode(
+    debugLabel: 'player action Listen only',
+  );
+  final FocusNode _playerActionsQualityFocusNode = FocusNode(
+    debugLabel: 'player action Quality',
+  );
+  final FocusNode _playerActionsSubtitleFocusNode = FocusNode(
+    debugLabel: 'player action Subtitles',
+  );
+  final FocusNode _contextMenuFirstFocusNode = FocusNode(
+    debugLabel: 'channel action Favorite',
+  );
+  final FocusNode _diagnosticRetryFocusNode = FocusNode(
+    debugLabel: 'player recovery Try Again',
+  );
+  final FocusNode _diagnosticSkipFocusNode = FocusNode(
+    debugLabel: 'player recovery Skip channel',
+  );
+  final FocusNode _diagnosticReportFocusNode = FocusNode(
+    debugLabel: 'player recovery Report dead link',
+  );
+  final FocusNode _genericRetryFocusNode = FocusNode(
+    debugLabel: 'player recovery Try Again',
+  );
+  FocusNode? _contextMenuRestoreFocusNode;
+  bool _playerModalOpen = false;
+  String? _lastRecoveryFocusToken;
 
   // Channel change overlay state
   String? _channelChangeOverlayText;
@@ -110,7 +147,7 @@ class _VideoPlayerWidgetState extends ConsumerState<VideoPlayerWidget> {
   Timer? _adjacentChannelWarmupDebounce;
   String _adjacentChannelWarmupSignature = '';
 
-  // MENU key context menu (AiroTV D-pad design "CONTEXT MENU (MENU key)").
+  // Channel-actions overlay opened from Info or a CENTER long-press.
   //
   // On real Fire TV hardware, KEYCODE_MENU never reaches the app -- Fire OS
   // intercepts it at the system level for its own overlay (confirmed via
@@ -179,6 +216,18 @@ class _VideoPlayerWidgetState extends ConsumerState<VideoPlayerWidget> {
     _selectLongPressTimer?.cancel();
     _playerFocusNode.dispose();
     _centerControlFocusNode.dispose();
+    _moreActionsFocusNode.dispose();
+    _infoFocusNode.dispose();
+    _audioTransportFocusNode.dispose();
+    _subtitleTransportFocusNode.dispose();
+    _playerActionsAudioFocusNode.dispose();
+    _playerActionsQualityFocusNode.dispose();
+    _playerActionsSubtitleFocusNode.dispose();
+    _contextMenuFirstFocusNode.dispose();
+    _diagnosticRetryFocusNode.dispose();
+    _diagnosticSkipFocusNode.dispose();
+    _diagnosticReportFocusNode.dispose();
+    _genericRetryFocusNode.dispose();
     unawaited(_resetBrightnessSafely());
     super.dispose();
   }
@@ -416,8 +465,11 @@ class _VideoPlayerWidgetState extends ConsumerState<VideoPlayerWidget> {
     );
     if (remoteResult == TvInputResult.handled) return remoteResult;
 
+    final streamingState = ref.read(streamingStateProvider).asData?.value;
+    final recoveryOwnsFocus =
+        streamingState?.hasError == true && streamingState?.diagnostic != null;
     final controlsVisible = _showControlsOverlay && widget.showControls;
-    if (controlsVisible) {
+    if (controlsVisible && !recoveryOwnsFocus) {
       // Keep the overlay alive while the remote is being used.
       _startHideControlsTimer();
     }
@@ -437,15 +489,22 @@ class _VideoPlayerWidgetState extends ConsumerState<VideoPlayerWidget> {
         setState(() => _quickBrowse = _TvQuickBrowse.recent);
         return TvInputResult.handled;
       case TvInputKey.menu:
-        if (ref.read(streamingStateProvider).asData?.value.currentChannel ==
-            null) {
+        final state = ref.read(streamingStateProvider).asData?.value;
+        if (state?.currentChannel == null) {
           return TvInputResult.notHandled;
         }
-        setState(() => _showContextMenu = !_showContextMenu);
+        unawaited(
+          _showPlayerActionsSheet(
+            context,
+            ref.read(iptvStreamingServiceProvider),
+            state!,
+            restoreFocusNode: _centerControlFocusNode,
+          ),
+        );
         return TvInputResult.handled;
       case TvInputKey.back:
         if (_showContextMenu) {
-          setState(() => _showContextMenu = false);
+          _closeContextMenu();
           return TvInputResult.handled;
         }
         if (_quickBrowse != null) {
@@ -525,7 +584,7 @@ class _VideoPlayerWidgetState extends ConsumerState<VideoPlayerWidget> {
         if (ref.read(streamingStateProvider).asData?.value.currentChannel !=
             null) {
           _selectConsumedByLongPress = true;
-          setState(() => _showContextMenu = true);
+          _openContextMenu(restoreFocusNode: _centerControlFocusNode);
         }
       });
     } else if (event is KeyUpEvent) {
@@ -549,6 +608,26 @@ class _VideoPlayerWidgetState extends ConsumerState<VideoPlayerWidget> {
     setState(() => _quickBrowse = null);
   }
 
+  void _openContextMenu({required FocusNode restoreFocusNode}) {
+    _contextMenuRestoreFocusNode = restoreFocusNode;
+    setState(() => _showContextMenu = true);
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted || !_showContextMenu) return;
+      _contextMenuFirstFocusNode.requestFocus();
+    });
+  }
+
+  void _closeContextMenu({bool restoreFocus = true}) {
+    if (!_showContextMenu) return;
+    setState(() => _showContextMenu = false);
+    final target = _contextMenuRestoreFocusNode;
+    _contextMenuRestoreFocusNode = null;
+    if (!restoreFocus || target == null) return;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted && target.canRequestFocus) target.requestFocus();
+    });
+  }
+
   Future<void> _toggleFavoriteForCurrentChannel() async {
     final channel = ref
         .read(streamingStateProvider)
@@ -559,7 +638,7 @@ class _VideoPlayerWidgetState extends ConsumerState<VideoPlayerWidget> {
     final toggle = ref.read(channelFavoriteTogglerProvider);
     final isNowFavorite = await toggle(channel.id);
     if (!mounted) return;
-    setState(() => _showContextMenu = false);
+    _closeContextMenu();
     ScaffoldMessenger.of(context)
       ..hideCurrentSnackBar()
       ..showSnackBar(
@@ -574,6 +653,7 @@ class _VideoPlayerWidgetState extends ConsumerState<VideoPlayerWidget> {
   }
 
   Future<void> _refreshPlaylistFromContextMenu() async {
+    _closeContextMenu();
     ScaffoldMessenger.of(context)
       ..hideCurrentSnackBar()
       ..showSnackBar(const SnackBar(content: Text('Refreshing playlist…')));
@@ -598,12 +678,15 @@ class _VideoPlayerWidgetState extends ConsumerState<VideoPlayerWidget> {
     VideoPlayerStreamingService service,
     StreamingState state,
   ) {
-    setState(() => _showContextMenu = false);
-    _showTrackSelectorFor(
-      context,
-      service,
-      state,
-      kind: AiroPlaybackTrackKind.audio,
+    _closeContextMenu(restoreFocus: false);
+    unawaited(
+      _showTrackSelectorFor(
+        context,
+        service,
+        state,
+        kind: AiroPlaybackTrackKind.audio,
+        restoreFocusNode: _infoFocusNode,
+      ),
     );
   }
 
@@ -611,12 +694,19 @@ class _VideoPlayerWidgetState extends ConsumerState<VideoPlayerWidget> {
     VideoPlayerStreamingService service,
     StreamingState state,
   ) {
-    setState(() => _showContextMenu = false);
-    _showTrackSelector(context, service, state);
+    _closeContextMenu(restoreFocus: false);
+    unawaited(
+      _showTrackSelector(
+        context,
+        service,
+        state,
+        restoreFocusNode: _infoFocusNode,
+      ),
+    );
   }
 
   void _showChannelInfoFromContextMenu(StreamingState state) {
-    setState(() => _showContextMenu = false);
+    _closeContextMenu();
     final channel = state.currentChannel;
     if (channel == null) return;
     showDialog<void>(
@@ -643,7 +733,7 @@ class _VideoPlayerWidgetState extends ConsumerState<VideoPlayerWidget> {
   }
 
   void _showDiagnosticsFromContextMenu(StreamingState state) {
-    setState(() => _showContextMenu = false);
+    _closeContextMenu();
     final channel = state.currentChannel;
     final metrics = state.metrics;
     final playback = state.playbackStats;
@@ -704,6 +794,7 @@ class _VideoPlayerWidgetState extends ConsumerState<VideoPlayerWidget> {
   }
 
   Future<void> _copyStreamLinkFromContextMenu(StreamingState state) async {
+    _closeContextMenu();
     final channel = state.currentChannel;
     final redacted = redactedUriForLog(
       channel == null ? null : Uri.tryParse(channel.streamUrl),
@@ -760,6 +851,7 @@ class _VideoPlayerWidgetState extends ConsumerState<VideoPlayerWidget> {
     AiroPlaybackViewFit aspectRatioFit, {
     required bool isPipActive,
   }) {
+    _scheduleRecoveryFocus(state);
     // Update wakelock based on current playback state
     // This is called on every build when state changes
     WidgetsBinding.instance.addPostFrameCallback((_) {
@@ -829,12 +921,14 @@ class _VideoPlayerWidgetState extends ConsumerState<VideoPlayerWidget> {
       canPop: !_showContextMenu && _quickBrowse == null,
       onPopInvokedWithResult: (didPop, result) {
         if (didPop) return;
-        setState(() {
-          _showContextMenu = false;
-          _quickBrowse = null;
-        });
+        if (_showContextMenu) {
+          _closeContextMenu();
+        } else {
+          setState(() => _quickBrowse = null);
+        }
       },
       child: TvInputHandler(
+        enabled: !_playerModalOpen && !_showContextMenu,
         onInput: _handleSurfInput,
         // Focus.onKeyEvent always ignores so the event bubbles up to
         // TvInputHandler's own listener above -- this node exists purely to
@@ -989,13 +1083,13 @@ class _VideoPlayerWidgetState extends ConsumerState<VideoPlayerWidget> {
                         ),
                       ),
 
-                    // Context menu (MENU key) — right-side overlay, matching
-                    // the AiroTV D-pad design's "CONTEXT MENU (MENU key)"
-                    // screen. Only rendered while open; doesn't touch layout
-                    // otherwise.
+                    // Channel actions — right-side overlay opened from Info
+                    // or a CENTER long-press. It does not affect layout while
+                    // closed.
                     if (_showContextMenu && state.currentChannel != null)
                       _ContextMenuOverlay(
                         channel: state.currentChannel!,
+                        firstFocusNode: _contextMenuFirstFocusNode,
                         onToggleFavorite: _toggleFavoriteForCurrentChannel,
                         onRefreshPlaylist: _refreshPlaylistFromContextMenu,
                         onSelectAudioTrack: () =>
@@ -1008,7 +1102,7 @@ class _VideoPlayerWidgetState extends ConsumerState<VideoPlayerWidget> {
                             _showDiagnosticsFromContextMenu(state),
                         onCopyStreamLink: () =>
                             _copyStreamLinkFromContextMenu(state),
-                        onClose: () => setState(() => _showContextMenu = false),
+                        onClose: _closeContextMenu,
                       ),
 
                     // UP/DOWN quick-browse overlays.
@@ -1069,6 +1163,47 @@ class _VideoPlayerWidgetState extends ConsumerState<VideoPlayerWidget> {
     );
   }
 
+  String? _recoveryFocusToken(StreamingState state) {
+    final diagnostic = state.diagnostic;
+    if (!state.hasError || diagnostic == null) return null;
+    return '${state.currentChannel?.id}|${diagnostic.code}|${state.retryCount}';
+  }
+
+  void _scheduleRecoveryFocus(StreamingState state) {
+    final token = _recoveryFocusToken(state);
+    if (token == null) {
+      final wasShowingRecovery = _lastRecoveryFocusToken != null;
+      _lastRecoveryFocusToken = null;
+      if (wasShowingRecovery && _hideControlsTimer == null) {
+        _startHideControlsTimer();
+      }
+      return;
+    }
+    _cancelHideControlsTimer();
+    if (_lastRecoveryFocusToken == token) return;
+    _lastRecoveryFocusToken = token;
+    final diagnostic = state.diagnostic!;
+    final target = !diagnostic.retryEligible || state.retryCount == 0
+        ? _diagnosticRetryFocusNode
+        : _diagnosticSkipFocusNode;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted || _lastRecoveryFocusToken != token) return;
+      if (target.canRequestFocus) target.requestFocus();
+    });
+  }
+
+  void _scheduleGenericRecoveryFocus(String message) {
+    final token = 'generic|$message';
+    if (_lastRecoveryFocusToken == token) return;
+    _lastRecoveryFocusToken = token;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted || _lastRecoveryFocusToken != token) return;
+      if (_genericRetryFocusNode.canRequestFocus) {
+        _genericRetryFocusNode.requestFocus();
+      }
+    });
+  }
+
   /// CV-001 structured failure state: user-safe copy plus bounded-retry
   /// progress from [StreamingState.diagnostic], with the legacy retry button.
   Widget _buildDiagnosticError(StreamingState state) {
@@ -1111,6 +1246,7 @@ class _VideoPlayerWidgetState extends ConsumerState<VideoPlayerWidget> {
                   if (!diagnostic.retryEligible || state.retryCount == 0)
                     _RecoveryActionButton(
                       key: const ValueKey('diagnostic-error-retry'),
+                      focusNode: _diagnosticRetryFocusNode,
                       icon: Icons.refresh_rounded,
                       label: 'Try Again',
                       autofocus: true,
@@ -1119,6 +1255,7 @@ class _VideoPlayerWidgetState extends ConsumerState<VideoPlayerWidget> {
                     ),
                   _RecoveryActionButton(
                     key: const ValueKey('diagnostic-error-skip'),
+                    focusNode: _diagnosticSkipFocusNode,
                     icon: Icons.skip_next_rounded,
                     label: 'Skip channel',
                     autofocus: diagnostic.retryEligible && state.retryCount > 0,
@@ -1126,6 +1263,7 @@ class _VideoPlayerWidgetState extends ConsumerState<VideoPlayerWidget> {
                   ),
                   _RecoveryActionButton(
                     key: const ValueKey('diagnostic-error-report'),
+                    focusNode: _diagnosticReportFocusNode,
                     icon: Icons.flag_outlined,
                     label: 'Report dead link',
                     onSelect: () => _saveDeadLinkReport(state, diagnostic),
@@ -1165,6 +1303,7 @@ class _VideoPlayerWidgetState extends ConsumerState<VideoPlayerWidget> {
   }
 
   Widget _buildError(String message) {
+    _scheduleGenericRecoveryFocus(message);
     return Container(
       decoration: BoxDecoration(
         gradient: LinearGradient(
@@ -1221,6 +1360,7 @@ class _VideoPlayerWidgetState extends ConsumerState<VideoPlayerWidget> {
               // bug already fixed for the diagnostic error screen below.
               _RecoveryActionButton(
                 key: const ValueKey('iptv-player-error-retry'),
+                focusNode: _genericRetryFocusNode,
                 icon: Icons.refresh_rounded,
                 label: 'Try Again',
                 autofocus: true,
@@ -1475,8 +1615,8 @@ class _VideoPlayerWidgetState extends ConsumerState<VideoPlayerWidget> {
   /// overlaps the button row below it, six action buttons matching the
   /// prototype exactly (Pause, Restart, Audio, Subtitles, Favourite, Info),
   /// and a "MENU for more actions" hint. Every button is wired to a real,
-  /// already-existing capability -- Info opens the same context menu MENU
-  /// itself opens, rather than a new stub panel.
+  /// already-existing capability -- Info opens channel actions, rather than
+  /// a new stub panel.
   Widget _buildTvTransportBar(
     BuildContext context,
     VideoPlayerStreamingService service,
@@ -1662,11 +1802,15 @@ class _VideoPlayerWidgetState extends ConsumerState<VideoPlayerWidget> {
       ),
       TvFocusable(
         key: const ValueKey('iptv-tv-transport-audio'),
-        onSelect: () => _showTrackSelectorFor(
-          context,
-          service,
-          state,
-          kind: AiroPlaybackTrackKind.audio,
+        focusNode: _audioTransportFocusNode,
+        onSelect: () => unawaited(
+          _showTrackSelectorFor(
+            context,
+            service,
+            state,
+            kind: AiroPlaybackTrackKind.audio,
+            restoreFocusNode: _audioTransportFocusNode,
+          ),
         ),
         borderRadius: 10,
         semanticLabel: 'Audio',
@@ -1677,7 +1821,15 @@ class _VideoPlayerWidgetState extends ConsumerState<VideoPlayerWidget> {
       ),
       TvFocusable(
         key: const ValueKey('iptv-tv-transport-subtitles'),
-        onSelect: () => _showTrackSelector(context, service, state),
+        focusNode: _subtitleTransportFocusNode,
+        onSelect: () => unawaited(
+          _showTrackSelector(
+            context,
+            service,
+            state,
+            restoreFocusNode: _subtitleTransportFocusNode,
+          ),
+        ),
         borderRadius: 10,
         semanticLabel: 'Subtitles',
         child: const _TvTransportButton(
@@ -1701,14 +1853,31 @@ class _VideoPlayerWidgetState extends ConsumerState<VideoPlayerWidget> {
       ),
       TvFocusable(
         key: const ValueKey('iptv-tv-transport-info'),
+        focusNode: _infoFocusNode,
         onSelect: channel == null
             ? null
-            : () => setState(() => _showContextMenu = true),
+            : () => _openContextMenu(restoreFocusNode: _infoFocusNode),
         borderRadius: 10,
         semanticLabel: 'Info',
         child: const _TvTransportButton(
           icon: Icons.info_outline_rounded,
           label: 'Info',
+        ),
+      ),
+      TvFocusable(
+        key: const ValueKey('iptv-player-more-button'),
+        focusNode: _moreActionsFocusNode,
+        onSelect: () => _showPlayerActionsSheet(
+          context,
+          service,
+          state,
+          restoreFocusNode: _moreActionsFocusNode,
+        ),
+        borderRadius: 10,
+        semanticLabel: 'More player actions',
+        child: const _TvTransportButton(
+          icon: Icons.more_horiz_rounded,
+          label: 'More',
         ),
       ),
     ];
@@ -1804,8 +1973,12 @@ class _VideoPlayerWidgetState extends ConsumerState<VideoPlayerWidget> {
                   key: const ValueKey('iptv-player-more-button'),
                   icon: Icons.settings_outlined,
                   tooltip: 'Player settings',
-                  onPressed: () =>
-                      _showPlayerActionsSheet(context, service, state),
+                  onPressed: () => _showPlayerActionsSheet(
+                    context,
+                    service,
+                    state,
+                    restoreFocusNode: _centerControlFocusNode,
+                  ),
                 ),
               ],
             ),
@@ -1905,7 +2078,12 @@ class _VideoPlayerWidgetState extends ConsumerState<VideoPlayerWidget> {
           key: const ValueKey('iptv-player-more-button'),
           icon: Icons.settings_outlined,
           tooltip: 'Player settings',
-          onPressed: () => _showPlayerActionsSheet(context, service, state),
+          onPressed: () => _showPlayerActionsSheet(
+            context,
+            service,
+            state,
+            restoreFocusNode: _centerControlFocusNode,
+          ),
           diameter: 44,
           iconSize: 24,
           backgroundAlpha: 0.48,
@@ -1936,113 +2114,157 @@ class _VideoPlayerWidgetState extends ConsumerState<VideoPlayerWidget> {
   Future<void> _showPlayerActionsSheet(
     BuildContext context,
     VideoPlayerStreamingService service,
-    StreamingState state,
-  ) {
+    StreamingState state, {
+    required FocusNode restoreFocusNode,
+  }) async {
+    if (_playerModalOpen) return;
     final hasQualityChoices = _qualityOptionsFor(state).length > 1;
     final hasSubtitles = _subtitleTracksFor(state).isNotEmpty;
+    _cancelHideControlsTimer();
+    setState(() => _playerModalOpen = true);
+    try {
+      await showModalBottomSheet<void>(
+        context: context,
+        requestFocus: true,
+        builder: (sheetContext) {
+          Future<void> afterSheet(VoidCallback action) async {
+            Navigator.of(sheetContext).pop();
+            await Future<void>.delayed(const Duration(milliseconds: 250));
+            if (!mounted) return;
+            action();
+          }
 
-    return showModalBottomSheet<void>(
-      context: context,
-      builder: (sheetContext) {
-        Future<void> afterSheet(VoidCallback action) async {
-          Navigator.of(sheetContext).pop();
-          await Future<void>.delayed(const Duration(milliseconds: 250));
-          if (!mounted) return;
-          action();
-        }
-
-        return SafeArea(
-          child: ListView(
-            shrinkWrap: true,
-            children: [
-              const ListTile(
-                title: Text('Player actions'),
-                subtitle: Text('Secondary controls for this stream'),
-              ),
-              if (widget.showPictureInPicture)
-                _TvSheetListTile(
-                  itemKey: const ValueKey('iptv-player-pip-menu-action'),
-                  leading: const Icon(Icons.picture_in_picture_alt_outlined),
-                  title: const Text('Picture-in-picture'),
-                  onSelect: () =>
-                      unawaited(afterSheet(_requestPictureInPicture)),
-                ),
-              if (hasQualityChoices)
-                _TvSheetListTile(
-                  itemKey: const ValueKey('iptv-player-quality-menu-action'),
-                  leading: const Icon(Icons.hd_outlined),
-                  title: const Text('Quality'),
-                  subtitle: Text(state.currentQuality.label),
-                  onSelect: () => unawaited(
-                    afterSheet(
-                      () => _showQualitySelector(context, service, state),
+          return _TvModalFocusScope(
+            initialFocusNode: _playerActionsAudioFocusNode,
+            child: SafeArea(
+              child: ListView(
+                shrinkWrap: true,
+                children: [
+                  const ListTile(
+                    title: Text('Player actions'),
+                    subtitle: Text('Secondary controls for this stream'),
+                  ),
+                  if (widget.showPictureInPicture)
+                    _TvSheetListTile(
+                      itemKey: const ValueKey('iptv-player-pip-menu-action'),
+                      leading: const Icon(
+                        Icons.picture_in_picture_alt_outlined,
+                      ),
+                      title: const Text('Picture-in-picture'),
+                      onSelect: () =>
+                          unawaited(afterSheet(_requestPictureInPicture)),
+                    ),
+                  if (hasQualityChoices)
+                    _TvSheetListTile(
+                      itemKey: const ValueKey(
+                        'iptv-player-quality-menu-action',
+                      ),
+                      focusNode: _playerActionsQualityFocusNode,
+                      leading: const Icon(Icons.hd_outlined),
+                      title: const Text('Quality'),
+                      subtitle: Text(state.currentQuality.label),
+                      onSelect: () => unawaited(
+                        _showQualitySelector(
+                          sheetContext,
+                          service,
+                          state,
+                          restoreFocusNode: _playerActionsQualityFocusNode,
+                        ),
+                      ),
+                    ),
+                  if (hasSubtitles)
+                    _TvSheetListTile(
+                      itemKey: const ValueKey(
+                        'iptv-player-subtitle-menu-action',
+                      ),
+                      focusNode: _playerActionsSubtitleFocusNode,
+                      leading: Icon(
+                        state.selectedTrackIds.containsKey(
+                              AiroPlaybackTrackKind.subtitle,
+                            )
+                            ? Icons.subtitles
+                            : Icons.subtitles_off_outlined,
+                      ),
+                      title: const Text('Subtitles'),
+                      onSelect: () => unawaited(
+                        _showTrackSelector(
+                          sheetContext,
+                          service,
+                          state,
+                          restoreFocusNode: _playerActionsSubtitleFocusNode,
+                        ),
+                      ),
+                    ),
+                  _TvSheetListTile(
+                    itemKey: const ValueKey(
+                      'iptv-player-audio-only-menu-action',
+                    ),
+                    focusNode: _playerActionsAudioFocusNode,
+                    leading: Icon(
+                      _isAudioOnly ? Icons.hearing : Icons.hearing_disabled,
+                    ),
+                    title: Text(
+                      _isAudioOnly ? 'Exit audio-only' : 'Listen only',
+                    ),
+                    onSelect: () => unawaited(afterSheet(_toggleAudioOnly)),
+                  ),
+                  _TvSheetListTile(
+                    itemKey: const ValueKey(
+                      'iptv-player-aspect-ratio-menu-action',
+                    ),
+                    leading: const Icon(Icons.aspect_ratio),
+                    title: const Text('Aspect ratio'),
+                    onSelect: () => unawaited(
+                      afterSheet(
+                        () => ref
+                            .read(videoAspectRatioProvider.notifier)
+                            .cycleToNext(),
+                      ),
                     ),
                   ),
-                ),
-              if (hasSubtitles)
-                _TvSheetListTile(
-                  itemKey: const ValueKey('iptv-player-subtitle-menu-action'),
-                  leading: Icon(
-                    state.selectedTrackIds.containsKey(
-                          AiroPlaybackTrackKind.subtitle,
-                        )
-                        ? Icons.subtitles
-                        : Icons.subtitles_off_outlined,
-                  ),
-                  title: const Text('Subtitles'),
-                  onSelect: () => unawaited(
-                    afterSheet(
-                      () => _showTrackSelector(context, service, state),
+                  _TvSheetListTile(
+                    itemKey: const ValueKey('iptv-player-cinema-menu-action'),
+                    leading: Icon(
+                      _isCinemaMode ? Icons.wb_sunny : Icons.theaters,
+                    ),
+                    title: Text(
+                      _isCinemaMode ? 'Standard mode' : 'Cinema mode',
+                    ),
+                    onSelect: () => unawaited(
+                      afterSheet(
+                        () => setState(() => _isCinemaMode = !_isCinemaMode),
+                      ),
                     ),
                   ),
-                ),
-              _TvSheetListTile(
-                itemKey: const ValueKey('iptv-player-audio-only-menu-action'),
-                // Always rendered regardless of PiP/quality/subtitles
-                // availability, so it's the one deterministic focus target
-                // this sheet can always autofocus.
-                autofocus: true,
-                leading: Icon(
-                  _isAudioOnly ? Icons.hearing : Icons.hearing_disabled,
-                ),
-                title: Text(_isAudioOnly ? 'Exit audio-only' : 'Listen only'),
-                onSelect: () => unawaited(afterSheet(_toggleAudioOnly)),
-              ),
-              _TvSheetListTile(
-                itemKey: const ValueKey('iptv-player-aspect-ratio-menu-action'),
-                leading: const Icon(Icons.aspect_ratio),
-                title: const Text('Aspect ratio'),
-                onSelect: () => unawaited(
-                  afterSheet(
-                    () => ref
-                        .read(videoAspectRatioProvider.notifier)
-                        .cycleToNext(),
+                  _TvSheetListTile(
+                    itemKey: const ValueKey(
+                      'iptv-player-fullscreen-menu-action',
+                    ),
+                    leading: Icon(
+                      _isFullscreen ? Icons.fullscreen_exit : Icons.fullscreen,
+                    ),
+                    title: Text(
+                      _isFullscreen ? 'Exit fullscreen' : 'Fullscreen',
+                    ),
+                    onSelect: () => unawaited(afterSheet(_toggleFullscreen)),
                   ),
-                ),
+                ],
               ),
-              _TvSheetListTile(
-                itemKey: const ValueKey('iptv-player-cinema-menu-action'),
-                leading: Icon(_isCinemaMode ? Icons.wb_sunny : Icons.theaters),
-                title: Text(_isCinemaMode ? 'Standard mode' : 'Cinema mode'),
-                onSelect: () => unawaited(
-                  afterSheet(
-                    () => setState(() => _isCinemaMode = !_isCinemaMode),
-                  ),
-                ),
-              ),
-              _TvSheetListTile(
-                itemKey: const ValueKey('iptv-player-fullscreen-menu-action'),
-                leading: Icon(
-                  _isFullscreen ? Icons.fullscreen_exit : Icons.fullscreen,
-                ),
-                title: Text(_isFullscreen ? 'Exit fullscreen' : 'Fullscreen'),
-                onSelect: () => unawaited(afterSheet(_toggleFullscreen)),
-              ),
-            ],
-          ),
-        );
-      },
-    );
+            ),
+          );
+        },
+      );
+    } finally {
+      if (mounted) {
+        setState(() => _playerModalOpen = false);
+        _startHideControlsTimer();
+        WidgetsBinding.instance.addPostFrameCallback((_) {
+          if (mounted && restoreFocusNode.canRequestFocus) {
+            restoreFocusNode.requestFocus();
+          }
+        });
+      }
+    }
   }
 
   /// CV-016: VOD resume. Seeks to a saved position once per channel per
@@ -2114,18 +2336,20 @@ class _VideoPlayerWidgetState extends ConsumerState<VideoPlayerWidget> {
     }
   }
 
-  void _showTrackSelector(
+  Future<void> _showTrackSelector(
     BuildContext context,
     VideoPlayerStreamingService service,
-    StreamingState state,
-  ) {
-    _showTrackSelectorFor(
+    StreamingState state, {
+    FocusNode? restoreFocusNode,
+  }) {
+    return _showTrackSelectorFor(
       context,
       service,
       state,
       kind: AiroPlaybackTrackKind.subtitle,
       offLabel: 'Off',
       offIcon: Icons.subtitles_off_outlined,
+      restoreFocusNode: restoreFocusNode,
     );
   }
 
@@ -2134,116 +2358,94 @@ class _VideoPlayerWidgetState extends ConsumerState<VideoPlayerWidget> {
   /// (`state.tracks`/`selectTrack`), just filtered to a different
   /// [AiroPlaybackTrackKind]. Audio has no "Off" row: unlike subtitles,
   /// there's no meaningful silent-track state to offer.
-  void _showTrackSelectorFor(
+  Future<void> _showTrackSelectorFor(
     BuildContext context,
     VideoPlayerStreamingService service,
     StreamingState state, {
     required AiroPlaybackTrackKind kind,
     String? offLabel,
     IconData? offIcon,
-  }) {
+    FocusNode? restoreFocusNode,
+  }) async {
     final tracks = state.tracks
         .where((track) => track.kind == kind)
         .toList(growable: false);
-    showModalBottomSheet<void>(
-      context: context,
-      builder: (context) {
-        final noneSelected = state.selectedTrackIds[kind] == null;
-        // Autofocus the selected row; if nothing is selected and there's
-        // no "Off" row to fall back to, autofocus the first track so the
-        // sheet is never opened with nothing D-pad-focused.
-        final autofocusOff = offLabel != null && noneSelected;
-        return SafeArea(
-          child: ListView(
-            shrinkWrap: true,
-            children: [
-              if (offLabel != null)
-                TvFocusable(
-                  autofocus: autofocusOff,
-                  semanticLabel: offLabel,
-                  onSelect: () {
-                    service.clearTrackSelection(kind);
-                    Navigator.of(context).pop();
-                  },
-                  child: ListTile(
-                    leading: offIcon == null ? null : Icon(offIcon),
-                    title: Text(offLabel),
-                    trailing: noneSelected ? const Icon(Icons.check) : null,
-                    onTap: () {
-                      service.clearTrackSelection(kind);
-                      Navigator.of(context).pop();
-                    },
-                  ),
-                ),
-              for (var i = 0; i < tracks.length; i++)
-                TvFocusable(
-                  autofocus:
-                      !autofocusOff &&
-                      (state.selectedTrackIds[tracks[i].kind] == tracks[i].id ||
-                          (noneSelected && offLabel == null && i == 0)),
-                  semanticLabel: tracks[i].label,
-                  onSelect: () {
-                    service.selectTrack(
-                      kind: tracks[i].kind,
-                      trackId: tracks[i].id,
-                    );
-                    Navigator.of(context).pop();
-                  },
-                  child: ListTile(
-                    title: Text(tracks[i].label),
-                    subtitle: tracks[i].isExternal
-                        ? const Text('External')
-                        : null,
-                    trailing:
-                        state.selectedTrackIds[tracks[i].kind] == tracks[i].id
-                        ? const Icon(Icons.check)
-                        : null,
-                    onTap: () {
-                      service.selectTrack(
-                        kind: tracks[i].kind,
-                        trackId: tracks[i].id,
-                      );
-                      Navigator.of(context).pop();
-                    },
-                  ),
-                ),
-            ],
-          ),
-        );
-      },
-    );
+    final selectedTrackId = state.selectedTrackIds[kind];
+    final noneSelected = selectedTrackId == null;
+    final options = <_TvSheetOption>[
+      if (offLabel != null)
+        _TvSheetOption(
+          label: offLabel,
+          leading: offIcon == null ? null : Icon(offIcon),
+          selected: noneSelected,
+          onSelect: () => service.clearTrackSelection(kind),
+        ),
+      for (final track in tracks)
+        _TvSheetOption(
+          label: track.label,
+          subtitle: track.isExternal ? const Text('External') : null,
+          selected: selectedTrackId == track.id,
+          onSelect: () =>
+              service.selectTrack(kind: track.kind, trackId: track.id),
+        ),
+    ];
+    final selectedIndex = options.indexWhere((option) => option.selected);
+    try {
+      await showModalBottomSheet<void>(
+        context: context,
+        requestFocus: true,
+        builder: (selectorContext) => _TvSelectionSheet(
+          debugLabelPrefix: 'player ${kind.name} option',
+          options: options,
+          initialIndex: selectedIndex < 0 ? 0 : selectedIndex,
+        ),
+      );
+    } finally {
+      if (mounted && restoreFocusNode != null) {
+        WidgetsBinding.instance.addPostFrameCallback((_) {
+          if (mounted && restoreFocusNode.canRequestFocus) {
+            restoreFocusNode.requestFocus();
+          }
+        });
+      }
+    }
   }
 
-  void _showQualitySelector(
+  Future<void> _showQualitySelector(
     BuildContext context,
     VideoPlayerStreamingService service,
-    StreamingState state,
-  ) {
+    StreamingState state, {
+    FocusNode? restoreFocusNode,
+  }) async {
     final options = _qualityOptionsFor(state);
-    showModalBottomSheet<void>(
-      context: context,
-      builder: (context) {
-        return SafeArea(
-          child: ListView(
-            shrinkWrap: true,
-            children: [
-              for (final quality in options)
-                _TvSheetListTile(
-                  title: Text(quality.label),
-                  autofocus: state.selectedQuality == quality,
-                  trailing: state.selectedQuality == quality
-                      ? const Icon(Icons.check)
-                      : null,
-                  onSelect: () {
-                    service.setQuality(quality);
-                    Navigator.of(context).pop();
-                  },
-                ),
-            ],
-          ),
-        );
-      },
-    );
+    final sheetOptions = [
+      for (final quality in options)
+        _TvSheetOption(
+          label: quality.label,
+          selected: state.selectedQuality == quality,
+          onSelect: () => service.setQuality(quality),
+        ),
+    ];
+    final selectedIndex = sheetOptions.indexWhere((option) => option.selected);
+    try {
+      await showModalBottomSheet<void>(
+        context: context,
+        requestFocus: true,
+        builder: (selectorContext) => _TvSelectionSheet(
+          debugLabelPrefix: 'player quality option',
+          options: sheetOptions,
+          initialIndex: selectedIndex < 0 ? 0 : selectedIndex,
+        ),
+      );
+    } finally {
+      if (mounted && restoreFocusNode != null) {
+        WidgetsBinding.instance.addPostFrameCallback((_) {
+          if (mounted && restoreFocusNode.canRequestFocus) {
+            restoreFocusNode.requestFocus();
+          }
+        });
+      }
+    }
   }
 
   List<AiroPlaybackTrackOption> _subtitleTracksFor(StreamingState state) {
@@ -2594,9 +2796,7 @@ class _PlayerStepperPillar extends StatelessWidget {
   }
 }
 
-/// MENU-key context menu: right-side overlay panel for actions on the
-/// currently-playing channel. AiroTV D-pad design's "CONTEXT MENU (MENU
-/// key)" screen.
+/// Right-side overlay panel for actions on the currently-playing channel.
 enum _TvQuickBrowse { miniGuide, recent }
 
 /// Bottom-docked horizontal browse strip for UP (Mini Guide) and DOWN
@@ -2721,6 +2921,7 @@ class _QuickBrowseOverlay extends StatelessWidget {
 class _ContextMenuOverlay extends ConsumerWidget {
   const _ContextMenuOverlay({
     required this.channel,
+    required this.firstFocusNode,
     required this.onToggleFavorite,
     required this.onRefreshPlaylist,
     required this.onSelectAudioTrack,
@@ -2732,6 +2933,7 @@ class _ContextMenuOverlay extends ConsumerWidget {
   });
 
   final IPTVChannel channel;
+  final FocusNode firstFocusNode;
   final VoidCallback onToggleFavorite;
   final VoidCallback onRefreshPlaylist;
   final VoidCallback onSelectAudioTrack;
@@ -2751,145 +2953,150 @@ class _ContextMenuOverlay extends ConsumerWidget {
       top: 0,
       bottom: 0,
       width: 280,
-      child: Container(
-        padding: const EdgeInsets.fromLTRB(20, 24, 20, 24),
-        decoration: BoxDecoration(
-          gradient: LinearGradient(
-            begin: Alignment.centerRight,
-            end: Alignment.centerLeft,
-            colors: [
-              Colors.black.withValues(alpha: 0.96),
-              Colors.black.withValues(alpha: 0.0),
-            ],
+      child: _TvModalFocusScope(
+        initialFocusNode: firstFocusNode,
+        onBack: onClose,
+        child: Container(
+          padding: const EdgeInsets.fromLTRB(20, 24, 20, 24),
+          decoration: BoxDecoration(
+            gradient: LinearGradient(
+              begin: Alignment.centerRight,
+              end: Alignment.centerLeft,
+              colors: [
+                Colors.black.withValues(alpha: 0.96),
+                Colors.black.withValues(alpha: 0.0),
+              ],
+            ),
           ),
-        ),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Text(
-              'Actions for',
-              style: TextStyle(
-                color: Colors.white.withValues(alpha: 0.6),
-                fontSize: 12,
-                letterSpacing: 1.0,
-              ),
-            ),
-            const SizedBox(height: 4),
-            Text(
-              channel.name,
-              maxLines: 1,
-              overflow: TextOverflow.ellipsis,
-              style: const TextStyle(
-                color: Colors.white,
-                fontSize: 18,
-                fontWeight: FontWeight.w700,
-              ),
-            ),
-            const SizedBox(height: 20),
-            Expanded(
-              child: SingleChildScrollView(
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    TvFocusable(
-                      key: const ValueKey('context-menu-favorite'),
-                      autofocus: true,
-                      semanticLabel: isFavorite
-                          ? 'Remove from favorites'
-                          : 'Add to favorites',
-                      onSelect: onToggleFavorite,
-                      child: _ContextMenuItem(
-                        icon: isFavorite
-                            ? Icons.favorite
-                            : Icons.favorite_border,
-                        label: isFavorite
-                            ? 'Remove from favorites'
-                            : 'Add to favorites',
-                        onTap: onToggleFavorite,
-                      ),
-                    ),
-                    const SizedBox(height: 8),
-                    TvFocusable(
-                      key: const ValueKey('context-menu-refresh-playlist'),
-                      semanticLabel: 'Refresh playlist',
-                      onSelect: onRefreshPlaylist,
-                      child: _ContextMenuItem(
-                        icon: Icons.refresh,
-                        label: 'Refresh playlist',
-                        onTap: onRefreshPlaylist,
-                      ),
-                    ),
-                    const SizedBox(height: 8),
-                    TvFocusable(
-                      key: const ValueKey('context-menu-audio-track'),
-                      semanticLabel: 'Audio track',
-                      onSelect: onSelectAudioTrack,
-                      child: _ContextMenuItem(
-                        icon: Icons.audiotrack_outlined,
-                        label: 'Audio track',
-                        onTap: onSelectAudioTrack,
-                      ),
-                    ),
-                    const SizedBox(height: 8),
-                    TvFocusable(
-                      key: const ValueKey('context-menu-subtitles'),
-                      semanticLabel: 'Subtitles',
-                      onSelect: onSelectSubtitles,
-                      child: _ContextMenuItem(
-                        icon: Icons.subtitles_outlined,
-                        label: 'Subtitles',
-                        onTap: onSelectSubtitles,
-                      ),
-                    ),
-                    const SizedBox(height: 8),
-                    TvFocusable(
-                      key: const ValueKey('context-menu-channel-info'),
-                      semanticLabel: 'Channel info',
-                      onSelect: onShowChannelInfo,
-                      child: _ContextMenuItem(
-                        icon: Icons.info_outline,
-                        label: 'Channel info',
-                        onTap: onShowChannelInfo,
-                      ),
-                    ),
-                    const SizedBox(height: 8),
-                    TvFocusable(
-                      key: const ValueKey('context-menu-diagnostics'),
-                      semanticLabel: 'Diagnostics',
-                      onSelect: onShowDiagnostics,
-                      child: _ContextMenuItem(
-                        icon: Icons.medical_information_outlined,
-                        label: 'Diagnostics',
-                        onTap: onShowDiagnostics,
-                      ),
-                    ),
-                    const SizedBox(height: 8),
-                    TvFocusable(
-                      key: const ValueKey('context-menu-copy-stream-link'),
-                      semanticLabel: 'Copy stream link',
-                      onSelect: onCopyStreamLink,
-                      child: _ContextMenuItem(
-                        icon: Icons.link,
-                        label: 'Copy stream link',
-                        onTap: onCopyStreamLink,
-                      ),
-                    ),
-                    const SizedBox(height: 8),
-                    TvFocusable(
-                      key: const ValueKey('context-menu-close'),
-                      semanticLabel: 'Close menu',
-                      onSelect: onClose,
-                      child: _ContextMenuItem(
-                        icon: Icons.close,
-                        label: 'Close',
-                        onTap: onClose,
-                      ),
-                    ),
-                  ],
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                'Actions for',
+                style: TextStyle(
+                  color: Colors.white.withValues(alpha: 0.6),
+                  fontSize: 12,
+                  letterSpacing: 1.0,
                 ),
               ),
-            ),
-          ],
+              const SizedBox(height: 4),
+              Text(
+                channel.name,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                style: const TextStyle(
+                  color: Colors.white,
+                  fontSize: 18,
+                  fontWeight: FontWeight.w700,
+                ),
+              ),
+              const SizedBox(height: 20),
+              Expanded(
+                child: SingleChildScrollView(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      TvFocusable(
+                        key: const ValueKey('context-menu-favorite'),
+                        focusNode: firstFocusNode,
+                        autofocus: true,
+                        semanticLabel: isFavorite
+                            ? 'Remove from favorites'
+                            : 'Add to favorites',
+                        onSelect: onToggleFavorite,
+                        child: _ContextMenuItem(
+                          icon: isFavorite
+                              ? Icons.favorite
+                              : Icons.favorite_border,
+                          label: isFavorite
+                              ? 'Remove from favorites'
+                              : 'Add to favorites',
+                          onTap: onToggleFavorite,
+                        ),
+                      ),
+                      const SizedBox(height: 8),
+                      TvFocusable(
+                        key: const ValueKey('context-menu-refresh-playlist'),
+                        semanticLabel: 'Refresh playlist',
+                        onSelect: onRefreshPlaylist,
+                        child: _ContextMenuItem(
+                          icon: Icons.refresh,
+                          label: 'Refresh playlist',
+                          onTap: onRefreshPlaylist,
+                        ),
+                      ),
+                      const SizedBox(height: 8),
+                      TvFocusable(
+                        key: const ValueKey('context-menu-audio-track'),
+                        semanticLabel: 'Audio track',
+                        onSelect: onSelectAudioTrack,
+                        child: _ContextMenuItem(
+                          icon: Icons.audiotrack_outlined,
+                          label: 'Audio track',
+                          onTap: onSelectAudioTrack,
+                        ),
+                      ),
+                      const SizedBox(height: 8),
+                      TvFocusable(
+                        key: const ValueKey('context-menu-subtitles'),
+                        semanticLabel: 'Subtitles',
+                        onSelect: onSelectSubtitles,
+                        child: _ContextMenuItem(
+                          icon: Icons.subtitles_outlined,
+                          label: 'Subtitles',
+                          onTap: onSelectSubtitles,
+                        ),
+                      ),
+                      const SizedBox(height: 8),
+                      TvFocusable(
+                        key: const ValueKey('context-menu-channel-info'),
+                        semanticLabel: 'Channel info',
+                        onSelect: onShowChannelInfo,
+                        child: _ContextMenuItem(
+                          icon: Icons.info_outline,
+                          label: 'Channel info',
+                          onTap: onShowChannelInfo,
+                        ),
+                      ),
+                      const SizedBox(height: 8),
+                      TvFocusable(
+                        key: const ValueKey('context-menu-diagnostics'),
+                        semanticLabel: 'Diagnostics',
+                        onSelect: onShowDiagnostics,
+                        child: _ContextMenuItem(
+                          icon: Icons.medical_information_outlined,
+                          label: 'Diagnostics',
+                          onTap: onShowDiagnostics,
+                        ),
+                      ),
+                      const SizedBox(height: 8),
+                      TvFocusable(
+                        key: const ValueKey('context-menu-copy-stream-link'),
+                        semanticLabel: 'Copy stream link',
+                        onSelect: onCopyStreamLink,
+                        child: _ContextMenuItem(
+                          icon: Icons.link,
+                          label: 'Copy stream link',
+                          onTap: onCopyStreamLink,
+                        ),
+                      ),
+                      const SizedBox(height: 8),
+                      TvFocusable(
+                        key: const ValueKey('context-menu-close'),
+                        semanticLabel: 'Close menu',
+                        onSelect: onClose,
+                        child: _ContextMenuItem(
+                          icon: Icons.close,
+                          label: 'Close',
+                          onTap: onClose,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            ],
+          ),
         ),
       ),
     );
@@ -2911,6 +3118,7 @@ class _ContextMenuItem extends StatelessWidget {
   Widget build(BuildContext context) {
     return InkWell(
       onTap: onTap,
+      canRequestFocus: false,
       borderRadius: BorderRadius.circular(9),
       child: Container(
         height: 42,
@@ -2953,37 +3161,180 @@ class _ContextMenuItem extends StatelessWidget {
 /// sheets -- wraps a [ListTile] in [TvFocusable] so a remote-only viewer
 /// can actually reach it. Bare [ListTile]s in these sheets were previously
 /// unreachable by D-pad despite the buttons that open them being focusable.
+class _TvModalFocusScope extends StatefulWidget {
+  const _TvModalFocusScope({
+    required this.initialFocusNode,
+    required this.child,
+    this.onBack,
+  });
+
+  final FocusNode initialFocusNode;
+  final Widget child;
+  final VoidCallback? onBack;
+
+  @override
+  State<_TvModalFocusScope> createState() => _TvModalFocusScopeState();
+}
+
+class _TvModalFocusScopeState extends State<_TvModalFocusScope> {
+  late final FocusScopeNode _scopeNode = FocusScopeNode(
+    debugLabel: 'player modal focus scope',
+  );
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted && widget.initialFocusNode.canRequestFocus) {
+        widget.initialFocusNode.requestFocus();
+      }
+    });
+  }
+
+  @override
+  void dispose() {
+    _scopeNode.dispose();
+    super.dispose();
+  }
+
+  KeyEventResult _handleKeyEvent(FocusNode node, KeyEvent event) {
+    if (event is! KeyDownEvent ||
+        TvInputHandler.mapLogicalKeyToTvInput(event.logicalKey) !=
+            TvInputKey.back ||
+        widget.onBack == null) {
+      return KeyEventResult.ignored;
+    }
+    widget.onBack!.call();
+    return KeyEventResult.handled;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Focus(
+      canRequestFocus: false,
+      onKeyEvent: _handleKeyEvent,
+      child: FocusTraversalGroup(
+        policy: ReadingOrderTraversalPolicy(),
+        child: FocusScope(node: _scopeNode, child: widget.child),
+      ),
+    );
+  }
+}
+
+class _TvSheetOption {
+  const _TvSheetOption({
+    required this.label,
+    required this.onSelect,
+    this.leading,
+    this.subtitle,
+    this.selected = false,
+  });
+
+  final String label;
+  final VoidCallback onSelect;
+  final Widget? leading;
+  final Widget? subtitle;
+  final bool selected;
+}
+
+class _TvSelectionSheet extends StatefulWidget {
+  const _TvSelectionSheet({
+    required this.debugLabelPrefix,
+    required this.options,
+    required this.initialIndex,
+  });
+
+  final String debugLabelPrefix;
+  final List<_TvSheetOption> options;
+  final int initialIndex;
+
+  @override
+  State<_TvSelectionSheet> createState() => _TvSelectionSheetState();
+}
+
+class _TvSelectionSheetState extends State<_TvSelectionSheet> {
+  late final List<FocusNode> _focusNodes = [
+    for (final option in widget.options)
+      FocusNode(debugLabel: '${widget.debugLabelPrefix} ${option.label}'),
+  ];
+
+  @override
+  void dispose() {
+    for (final node in _focusNodes) {
+      node.dispose();
+    }
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (widget.options.isEmpty) return const SizedBox.shrink();
+    final initialIndex = widget.initialIndex.clamp(
+      0,
+      widget.options.length - 1,
+    );
+    return _TvModalFocusScope(
+      initialFocusNode: _focusNodes[initialIndex],
+      child: SafeArea(
+        child: ListView(
+          shrinkWrap: true,
+          children: [
+            for (var i = 0; i < widget.options.length; i++)
+              _TvSheetListTile(
+                focusNode: _focusNodes[i],
+                leading: widget.options[i].leading,
+                title: Text(widget.options[i].label),
+                subtitle: widget.options[i].subtitle,
+                trailing: widget.options[i].selected
+                    ? const Icon(Icons.check)
+                    : null,
+                onSelect: () {
+                  widget.options[i].onSelect();
+                  Navigator.of(context).pop();
+                },
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
 class _TvSheetListTile extends StatelessWidget {
   const _TvSheetListTile({
     this.itemKey,
+    this.focusNode,
     this.leading,
     required this.title,
     this.subtitle,
     this.trailing,
     required this.onSelect,
-    this.autofocus = false,
   });
 
   final Key? itemKey;
+  final FocusNode? focusNode;
   final Widget? leading;
   final Widget title;
   final Widget? subtitle;
   final Widget? trailing;
   final VoidCallback onSelect;
-  final bool autofocus;
 
   @override
   Widget build(BuildContext context) {
     return TvFocusable(
-      autofocus: autofocus,
+      focusNode: focusNode,
       onSelect: onSelect,
-      child: ListTile(
+      semanticLabel: title is Text ? (title as Text).data : null,
+      child: InkWell(
         key: itemKey,
-        leading: leading,
-        title: title,
-        subtitle: subtitle,
-        trailing: trailing,
         onTap: onSelect,
+        canRequestFocus: false,
+        child: ListTile(
+          leading: leading,
+          title: title,
+          subtitle: subtitle,
+          trailing: trailing,
+        ),
       ),
     );
   }
@@ -2995,30 +3346,42 @@ class _RecoveryActionButton extends StatelessWidget {
     required this.icon,
     required this.label,
     required this.onSelect,
+    required this.focusNode,
     this.autofocus = false,
   });
 
   final IconData icon;
   final String label;
   final VoidCallback onSelect;
+  final FocusNode focusNode;
   final bool autofocus;
 
   @override
   Widget build(BuildContext context) {
     return TvFocusable(
+      focusNode: focusNode,
       autofocus: autofocus,
       onSelect: onSelect,
       semanticLabel: label,
       borderRadius: 8,
-      child: ElevatedButton.icon(
-        onPressed: onSelect,
-        icon: Icon(icon),
-        label: Text(label),
-        style: ElevatedButton.styleFrom(
-          backgroundColor: Colors.blueGrey.shade700,
-          foregroundColor: Colors.white,
-          padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 12),
-          shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
+      child: Material(
+        color: Colors.blueGrey.shade700,
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
+        child: InkWell(
+          onTap: onSelect,
+          canRequestFocus: false,
+          borderRadius: BorderRadius.circular(8),
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 12),
+            child: Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Icon(icon, color: Colors.white),
+                const SizedBox(width: 8),
+                Text(label, style: const TextStyle(color: Colors.white)),
+              ],
+            ),
+          ),
         ),
       ),
     );

--- a/packages/feature_iptv/test/iptv/presentation/screens/iptv_screen_test.dart
+++ b/packages/feature_iptv/test/iptv/presentation/screens/iptv_screen_test.dart
@@ -70,9 +70,11 @@ void main() {
     VoidCallback? onOpenVod,
     VoidCallback? onSettings,
     Future<PhoneLocalMediaItem?> Function()? onPickLocalMediaForTv,
+    Map<String, Object> initialPreferences = const {},
+    List<IPTVChannel> Function()? channelLoader,
     List<Override> extraOverrides = const [],
   }) {
-    SharedPreferences.setMockInitialValues({});
+    SharedPreferences.setMockInitialValues(initialPreferences);
     return FutureBuilder<SharedPreferences>(
       future: SharedPreferences.getInstance(),
       builder: (context, snapshot) {
@@ -85,7 +87,9 @@ void main() {
         return ProviderScope(
           overrides: [
             sharedPreferencesProvider.overrideWithValue(snapshot.data!),
-            iptvChannelsProvider.overrideWith((ref) async => channels),
+            iptvChannelsProvider.overrideWith(
+              (ref) async => channelLoader?.call() ?? channels,
+            ),
             channelBrowseMetadataProvider.overrideWith(
               (ref) async => const <String, ChannelBrowseMetadata>{},
             ),
@@ -623,6 +627,76 @@ void main() {
 
       expect(find.text('Add Playlist Source'), findsNothing);
       expect(railsBuildCount, 2);
+    },
+  );
+
+  testWidgets(
+    'playlist source reimport preserves name-only favorite for review',
+    (tester) async {
+      const oldChannel = IPTVChannel(
+        id: 'favorite-old',
+        name: 'Fixture News HD',
+        streamUrl: 'https://example.com/old.m3u8',
+      );
+      const newChannel = IPTVChannel(
+        id: 'favorite-new',
+        name: 'fixture-news',
+        streamUrl: 'https://example.com/new.m3u8',
+      );
+      late _FixtureM3UParserService parser;
+      var importReady = false;
+
+      await tester.pumpWidget(
+        createWidget(
+          initialPreferences: const {
+            'iptv_favorite_channel_ids': ['favorite-old'],
+          },
+          channelLoader: () => importReady ? [newChannel] : [oldChannel],
+          extraOverrides: [
+            m3uParserProvider.overrideWith((ref) {
+              parser = _FixtureM3UParserService(
+                dio: Dio(),
+                prefs: ref.watch(sharedPreferencesProvider),
+              );
+              return parser;
+            }),
+          ],
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await activateAppBarAction(tester, 'Playlist source');
+      await tester.enterText(
+        find.byType(TextField),
+        'https://example.com/playlist-b.m3u',
+      );
+      await tester.tap(find.widgetWithText(FilledButton, 'Save'));
+      await tester.pump();
+      await tester.pump();
+
+      importReady = true;
+      parser.streamControllers.last.add(
+        const ImportProgress(
+          stage: ImportStage.ready,
+          fraction: 1,
+          message: 'Imported playlist B',
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final scope = ProviderScope.containerOf(
+        tester.element(find.byType(IPTVScreen)),
+      );
+      final candidates = scope.read(favoriteReimportReviewCandidatesProvider);
+      expect(candidates, hasLength(1));
+      expect(candidates.single.oldChannel.id, 'favorite-old');
+      expect(candidates.single.candidate.id, 'favorite-new');
+      expect(
+        await scope
+            .read(favoriteChannelsStorageProvider)
+            .getFavoriteChannelIds(),
+        {'favorite-old'},
+      );
     },
   );
 

--- a/packages/feature_iptv/test/iptv/presentation/tv_ux/airo_tv_shell_test.dart
+++ b/packages/feature_iptv/test/iptv/presentation/tv_ux/airo_tv_shell_test.dart
@@ -46,6 +46,7 @@ void main() {
     WidgetTester tester,
     double width, {
     double height = 720,
+    bool showVideoStage = true,
     bool isOnline = true,
     IPTVChannel? currentChannel,
     StreamingState? streamingState,
@@ -76,6 +77,7 @@ void main() {
               child: AiroTvShell(
                 channels: channels,
                 currentChannel: currentChannel,
+                showVideoStage: showVideoStage,
                 videoStage: const SizedBox(key: ValueKey('video-stage')),
                 onChannelSelected: (_) {},
                 onShareVideoFrame: onShareVideoFrame,
@@ -292,6 +294,26 @@ void main() {
     expect(tester.takeException(), isNull);
     expect(
       find.byKey(const ValueKey('airo-tv-explorer-video-stage')),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets('grid-first TV layout reclaims the small preview area', (
+    tester,
+  ) async {
+    await pumpAt(tester, 1280, showVideoStage: false);
+
+    expect(
+      find.byKey(const ValueKey('airo-tv-explorer-video-stage')),
+      findsNothing,
+    );
+    expect(find.byKey(const ValueKey('video-stage')), findsNothing);
+    expect(
+      find.byKey(const ValueKey('airo-tv-explorer-panel')),
+      findsOneWidget,
+    );
+    expect(
+      find.byKey(const ValueKey('airo-tv-channel-library')),
       findsOneWidget,
     );
   });
@@ -520,9 +542,7 @@ class _FakeConnectivityService implements ConnectivityService {
 }
 
 class _FakeWifiSettingsLauncher extends WifiSettingsLauncher {
-  _FakeWifiSettingsLauncher({required bool opened, bool isSupported = true})
-    : _opened = opened,
-      _isSupported = isSupported;
+  _FakeWifiSettingsLauncher({required this._opened, this._isSupported = true});
 
   final bool _opened;
   final bool _isSupported;

--- a/packages/feature_iptv/test/iptv/presentation/tv_ux/channel_library_grid_test.dart
+++ b/packages/feature_iptv/test/iptv/presentation/tv_ux/channel_library_grid_test.dart
@@ -1,6 +1,8 @@
 import 'package:feature_iptv/application/providers/channel_filters_provider.dart';
 import 'package:feature_iptv/presentation/tv_ux/sections/channel_library_grid.dart';
+import 'package:core_ui/core_ui.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:platform_channels/platform_channels.dart';
 import 'package:platform_streams/platform_streams.dart';
@@ -134,6 +136,68 @@ void main() {
     await tester.pump();
 
     expect(toggled?.id, 'one');
+  });
+
+  testWidgets('one D-pad press moves exactly one channel tile', (tester) async {
+    final gridChannels = List<IPTVChannel>.generate(
+      5,
+      (index) => IPTVChannel(
+        id: 'channel-$index',
+        name: 'Channel $index',
+        streamUrl: 'https://example.com/$index.m3u8',
+        group: 'General',
+      ),
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: SizedBox(
+            width: 800,
+            height: 600,
+            child: ChannelLibraryGrid(
+              channels: gridChannels,
+              metadataByChannelId: const {},
+              onChannelSelected: (_) {},
+              onMultiviewToggle: (_) {},
+            ),
+          ),
+        ),
+      ),
+    );
+
+    final cards = find.byType(MediaCard);
+    final firstTile = find.byKey(const ValueKey('channel-tile-channel-0'));
+    final tileFocusStops = tester
+        .widgetList<Focus>(
+          find.descendant(of: firstTile, matching: find.byType(Focus)),
+        )
+        .where(
+          (focus) =>
+              focus.focusNode != null && focus.focusNode!.canRequestFocus,
+        );
+    expect(
+      tileFocusStops,
+      hasLength(1),
+      reason: 'A channel box must contribute exactly one D-pad focus stop',
+    );
+    final firstCardFocus = tester.widget<Focus>(
+      find.descendant(of: cards.at(0), matching: find.byType(Focus)).first,
+    );
+    final secondCardFocus = tester.widget<Focus>(
+      find.descendant(of: cards.at(1), matching: find.byType(Focus)).first,
+    );
+    firstCardFocus.focusNode!.requestFocus();
+    await tester.pump();
+
+    await tester.sendKeyEvent(LogicalKeyboardKey.arrowRight);
+    await tester.pumpAndSettle();
+
+    expect(
+      secondCardFocus.focusNode!.hasFocus,
+      isTrue,
+      reason: 'RIGHT must move from channel 0 directly to channel 1',
+    );
   });
 
   testWidgets('reports the currently visible channels for bounded scanning', (

--- a/packages/feature_iptv/test/iptv/presentation/tv_ux/channel_library_grid_test.dart
+++ b/packages/feature_iptv/test/iptv/presentation/tv_ux/channel_library_grid_test.dart
@@ -200,6 +200,126 @@ void main() {
     );
   });
 
+  testWidgets('settled TV focus selects one channel after the dwell delay', (
+    tester,
+  ) async {
+    final selected = <String>[];
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: SizedBox(
+            width: 800,
+            height: 600,
+            child: ChannelLibraryGrid(
+              channels: channels,
+              metadataByChannelId: const {},
+              focusPlayDelay: const Duration(milliseconds: 1200),
+              onChannelSelected: (channel) => selected.add(channel.id),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    final firstCardFocus = tester.widget<Focus>(
+      find
+          .descendant(
+            of: find.byType(MediaCard).at(0),
+            matching: find.byType(Focus),
+          )
+          .first,
+    );
+    firstCardFocus.focusNode!.requestFocus();
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 1199));
+    expect(selected, isEmpty);
+
+    await tester.pump(const Duration(milliseconds: 1));
+    expect(selected, ['one']);
+    await tester.pump(const Duration(milliseconds: 1200));
+    expect(selected, ['one'], reason: 'dwell must activate only once');
+  });
+
+  testWidgets('moving focus cancels the old channel dwell timer', (
+    tester,
+  ) async {
+    final selected = <String>[];
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: SizedBox(
+            width: 800,
+            height: 600,
+            child: ChannelLibraryGrid(
+              channels: channels,
+              metadataByChannelId: const {},
+              focusPlayDelay: const Duration(milliseconds: 1200),
+              onChannelSelected: (channel) => selected.add(channel.id),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    final cards = find.byType(MediaCard);
+    final firstCardFocus = tester.widget<Focus>(
+      find.descendant(of: cards.at(0), matching: find.byType(Focus)).first,
+    );
+    final secondCardFocus = tester.widget<Focus>(
+      find.descendant(of: cards.at(1), matching: find.byType(Focus)).first,
+    );
+    firstCardFocus.focusNode!.requestFocus();
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 600));
+
+    secondCardFocus.focusNode!.requestFocus();
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 1199));
+    expect(selected, isEmpty);
+
+    await tester.pump(const Duration(milliseconds: 1));
+    expect(selected, ['two']);
+  });
+
+  testWidgets('CENTER selects immediately and cancels delayed activation', (
+    tester,
+  ) async {
+    final selected = <String>[];
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: SizedBox(
+            width: 800,
+            height: 600,
+            child: ChannelLibraryGrid(
+              channels: channels,
+              metadataByChannelId: const {},
+              focusPlayDelay: const Duration(milliseconds: 1200),
+              onChannelSelected: (channel) => selected.add(channel.id),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    final firstCardFocus = tester.widget<Focus>(
+      find
+          .descendant(
+            of: find.byType(MediaCard).at(0),
+            matching: find.byType(Focus),
+          )
+          .first,
+    );
+    firstCardFocus.focusNode!.requestFocus();
+    await tester.pump();
+    await tester.sendKeyEvent(LogicalKeyboardKey.select);
+    await tester.pump();
+    expect(selected, ['one']);
+
+    await tester.pump(const Duration(milliseconds: 1200));
+    expect(selected, ['one']);
+  });
+
   testWidgets('reports the currently visible channels for bounded scanning', (
     tester,
   ) async {

--- a/packages/feature_iptv/test/iptv/presentation/widgets/favorite_reimport_review_banner_test.dart
+++ b/packages/feature_iptv/test/iptv/presentation/widgets/favorite_reimport_review_banner_test.dart
@@ -1,6 +1,7 @@
 import 'package:feature_iptv/feature_iptv.dart';
 import 'package:feature_iptv/presentation/widgets/favorite_reimport_review_banner.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -68,6 +69,79 @@ void main() {
 
     expect(find.textContaining('BBC One HD'), findsOneWidget);
     expect(find.textContaining('bbc-one'), findsOneWidget);
+  });
+
+  testWidgets(
+    'Keep visibly autofocuses and RIGHT traverses without leaking behind banner',
+    (tester) async {
+      final container = await buildContainer();
+      addTearDown(container.dispose);
+      container.read(favoriteReimportReviewCandidatesProvider.notifier).state =
+          [candidate];
+
+      await pumpBanner(tester, container);
+      await tester.pump();
+      expect(
+        FocusManager.instance.primaryFocus?.debugLabel,
+        'favorite review Keep',
+      );
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowRight);
+      await tester.pump();
+      expect(
+        FocusManager.instance.primaryFocus?.debugLabel,
+        'favorite review Dismiss',
+      );
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowRight);
+      await tester.pump();
+      expect(
+        FocusManager.instance.primaryFocus?.debugLabel,
+        'favorite review Keep',
+        reason: 'the banner focus scope must close-loop instead of leaking',
+      );
+    },
+  );
+
+  testWidgets('CENTER on Keep remaps the favorite exactly once', (
+    tester,
+  ) async {
+    final container = await buildContainer();
+    addTearDown(container.dispose);
+    final storage = container.read(favoriteChannelsStorageProvider);
+    await storage.addFavorite(oldChannel.id);
+    container.read(favoriteReimportReviewCandidatesProvider.notifier).state = [
+      candidate,
+    ];
+
+    await pumpBanner(tester, container);
+    await tester.pump();
+    await tester.sendKeyEvent(LogicalKeyboardKey.select);
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 50));
+
+    expect(await storage.getFavoriteChannelIds(), {'b9'});
+    expect(container.read(favoriteReimportReviewCandidatesProvider), isEmpty);
+  });
+
+  testWidgets('CENTER on Dismiss keeps the old favorite', (tester) async {
+    final container = await buildContainer();
+    addTearDown(container.dispose);
+    final storage = container.read(favoriteChannelsStorageProvider);
+    await storage.addFavorite(oldChannel.id);
+    container.read(favoriteReimportReviewCandidatesProvider.notifier).state = [
+      candidate,
+    ];
+
+    await pumpBanner(tester, container);
+    await tester.pump();
+    await tester.sendKeyEvent(LogicalKeyboardKey.arrowRight);
+    await tester.pump();
+    await tester.sendKeyEvent(LogicalKeyboardKey.select);
+    await tester.pump();
+
+    expect(await storage.getFavoriteChannelIds(), {'a1'});
+    expect(container.read(favoriteReimportReviewCandidatesProvider), isEmpty);
   });
 
   testWidgets(

--- a/packages/feature_iptv/test/iptv/presentation/widgets/video_player_widget_test.dart
+++ b/packages/feature_iptv/test/iptv/presentation/widgets/video_player_widget_test.dart
@@ -827,9 +827,12 @@ void main() {
       await tester.tap(find.widgetWithText(ListTile, '720p'));
       await tester.pumpAndSettle();
       expect(service.currentState.selectedQuality, VideoQuality.high);
+      expect(find.text('Player actions'), findsOneWidget);
+      expect(
+        FocusManager.instance.primaryFocus?.debugLabel,
+        'player action Quality',
+      );
 
-      await tester.tap(find.byKey(const ValueKey('iptv-player-more-button')));
-      await tester.pumpAndSettle();
       await tester.tap(
         find.byKey(const ValueKey('iptv-player-pip-menu-action')),
       );

--- a/packages/feature_iptv/test/iptv/presentation/widgets/video_player_widget_test.dart
+++ b/packages/feature_iptv/test/iptv/presentation/widgets/video_player_widget_test.dart
@@ -139,8 +139,19 @@ void main() {
       expect(find.text('Mini guide'), findsOneWidget);
       expect(find.text('Stadium Sports'), findsWidgets);
       expect(service.currentState.currentChannel?.id, 'news-1');
+      expect(
+        FocusManager.instance.primaryFocus?.debugLabel,
+        'quick browse City News Live',
+      );
 
-      await tester.tap(find.text('Stadium Sports').first);
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowRight);
+      await tester.pump();
+      expect(
+        FocusManager.instance.primaryFocus?.debugLabel,
+        'quick browse Stadium Sports',
+      );
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.select);
       await tester.pump();
 
       expect(service.currentState.currentChannel?.id, 'sports-1');

--- a/packages/feature_iptv/test/presentation/screens/iptv_screen_ten_foot_fullscreen_test.dart
+++ b/packages/feature_iptv/test/presentation/screens/iptv_screen_ten_foot_fullscreen_test.dart
@@ -87,6 +87,43 @@ void main() {
             'on TV, choosing a channel should open the full player '
             'directly instead of the small preview stage',
       );
+
+      // Fire OS dispatches BACK as both a raw GoBack key and a platform
+      // pop-route request. The first event must not exit fullscreen and
+      // expose the route to the second event, which would close the app.
+      final fullscreenFocus = tester.widget<Focus>(
+        find.byWidgetPredicate(
+          (widget) =>
+              widget is Focus &&
+              widget.focusNode?.debugLabel == 'IPTV fullscreen back handler',
+        ),
+      );
+      final rawBackResult = fullscreenFocus.onKeyEvent!.call(
+        fullscreenFocus.focusNode!,
+        const KeyDownEvent(
+          physicalKey: PhysicalKeyboardKey.escape,
+          logicalKey: LogicalKeyboardKey.goBack,
+          timeStamp: Duration.zero,
+        ),
+      );
+      await tester.pump();
+      expect(rawBackResult, KeyEventResult.ignored);
+      expect(container.read(isFullscreenModeProvider), isTrue);
+
+      final handled = await tester.binding.handlePopRoute();
+      await tester.pump(const Duration(milliseconds: 400));
+      expect(handled, isTrue);
+      expect(container.read(isFullscreenModeProvider), isFalse);
+      expect(find.byKey(const ValueKey('iptv-browse-grid')), findsOneWidget);
+
+      final duplicateHandled = await tester.binding.handlePopRoute();
+      await tester.pump();
+      expect(duplicateHandled, isTrue);
+      expect(
+        find.byKey(const ValueKey('iptv-browse-grid')),
+        findsOneWidget,
+        reason: 'a duplicate Fire OS BACK callback must not close the app',
+      );
     },
   );
 

--- a/packages/feature_iptv/test/presentation/widgets/video_player_widget_background_modes_test.dart
+++ b/packages/feature_iptv/test/presentation/widgets/video_player_widget_background_modes_test.dart
@@ -22,7 +22,10 @@ void main() {
     WidgetTester tester,
     ValueKey<String> key,
   ) async {
-    tester.widget<ListTile>(find.byKey(key)).onTap?.call();
+    final action = find.byKey(key);
+    Focus.of(tester.element(action)).requestFocus();
+    await tester.pump();
+    await tester.sendKeyEvent(LogicalKeyboardKey.select);
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 300));
   }

--- a/packages/feature_iptv/test/presentation/widgets/video_player_widget_context_menu_actions_test.dart
+++ b/packages/feature_iptv/test/presentation/widgets/video_player_widget_context_menu_actions_test.dart
@@ -65,7 +65,9 @@ void main() {
   }
 
   Future<void> openContextMenu(WidgetTester tester) async {
-    await tester.sendKeyEvent(LogicalKeyboardKey.contextMenu);
+    await tester.sendKeyDownEvent(LogicalKeyboardKey.select);
+    await tester.pump(const Duration(milliseconds: 600));
+    await tester.sendKeyUpEvent(LogicalKeyboardKey.select);
     await tester.pump();
     expect(find.text('Actions for'), findsOneWidget);
   }

--- a/packages/feature_iptv/test/presentation/widgets/video_player_widget_context_menu_test.dart
+++ b/packages/feature_iptv/test/presentation/widgets/video_player_widget_context_menu_test.dart
@@ -5,9 +5,9 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
-// AiroTV D-pad design's "CONTEXT MENU (MENU key)" screen — reachable from
-// the live player via the remote's MENU key, previously entirely unhandled
-// (TvInputKey.menu fell through to the switch's default case).
+// Player MENU owns Player actions. The separate channel-actions overlay stays
+// reachable through Fire TV's long-press Select convention and the transport
+// bar's Info button.
 void main() {
   Future<ProviderContainer> pumpPlayer(WidgetTester tester) async {
     SharedPreferences.setMockInitialValues({});
@@ -48,27 +48,34 @@ void main() {
     return container;
   }
 
-  testWidgets('MENU key opens the context menu for the current channel', (
+  Future<void> openContextMenu(WidgetTester tester) async {
+    await tester.sendKeyDownEvent(LogicalKeyboardKey.select);
+    await tester.pump(const Duration(milliseconds: 600));
+    await tester.sendKeyUpEvent(LogicalKeyboardKey.select);
+    await tester.pump();
+    expect(find.text('Actions for'), findsOneWidget);
+  }
+
+  testWidgets('MENU key opens Player actions for the current stream', (
     tester,
   ) async {
     await pumpPlayer(tester);
 
-    expect(find.text('Actions for'), findsNothing);
-
     await tester.sendKeyEvent(LogicalKeyboardKey.contextMenu);
     await tester.pump();
+    await tester.pump(const Duration(milliseconds: 400));
 
-    expect(find.text('Actions for'), findsOneWidget);
-    expect(find.text('City News Live'), findsWidgets);
-    expect(find.text('Add to favorites'), findsOneWidget);
+    expect(find.text('Player actions'), findsOneWidget);
+    expect(find.text('Actions for'), findsNothing);
+    await tester.binding.handlePopRoute();
+    await tester.pump(const Duration(milliseconds: 400));
   });
 
   testWidgets('selecting Add to favorites toggles the favorite and closes '
       'the menu', (tester) async {
     final container = await pumpPlayer(tester);
 
-    await tester.sendKeyEvent(LogicalKeyboardKey.contextMenu);
-    await tester.pump();
+    await openContextMenu(tester);
 
     await tester.tap(find.text('Add to favorites'));
     await tester.pump();
@@ -85,9 +92,7 @@ void main() {
   ) async {
     await pumpPlayer(tester);
 
-    await tester.sendKeyEvent(LogicalKeyboardKey.contextMenu);
-    await tester.pump();
-    expect(find.text('Actions for'), findsOneWidget);
+    await openContextMenu(tester);
 
     await tester.sendKeyEvent(LogicalKeyboardKey.escape);
     await tester.pump();
@@ -109,9 +114,7 @@ void main() {
     (tester) async {
       await pumpPlayer(tester);
 
-      await tester.sendKeyEvent(LogicalKeyboardKey.contextMenu);
-      await tester.pump();
-      expect(find.text('Actions for'), findsOneWidget);
+      await openContextMenu(tester);
 
       final handled = await tester.binding.handlePopRoute();
 
@@ -146,6 +149,41 @@ void main() {
     await tester.sendKeyUpEvent(LogicalKeyboardKey.select);
     await tester.pump();
   });
+
+  testWidgets(
+    'channel actions visibly own focus, trap DOWN, and restore player focus',
+    (tester) async {
+      await pumpPlayer(tester);
+      await openContextMenu(tester);
+
+      expect(
+        FocusManager.instance.primaryFocus?.debugLabel,
+        'channel action Favorite',
+      );
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+      await tester.pump();
+      final refreshFocus = tester.widget<Focus>(
+        find
+            .descendant(
+              of: find.byKey(const ValueKey('context-menu-refresh-playlist')),
+              matching: find.byType(Focus),
+            )
+            .first,
+      );
+      expect(refreshFocus.focusNode?.hasPrimaryFocus, isTrue);
+      expect(find.text('Mini guide'), findsNothing);
+      expect(find.text('Recent channels'), findsNothing);
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.escape);
+      await tester.pump();
+      expect(find.text('Actions for'), findsNothing);
+      expect(
+        FocusManager.instance.primaryFocus?.debugLabel,
+        'player center control',
+      );
+    },
+  );
 
   testWidgets('a short Select tap does not open the context menu', (
     tester,

--- a/packages/feature_iptv/test/presentation/widgets/video_player_widget_dpad_modal_test.dart
+++ b/packages/feature_iptv/test/presentation/widgets/video_player_widget_dpad_modal_test.dart
@@ -132,6 +132,13 @@ void main() {
           reason: 'UP must focus ${orderedKeys[index]} exactly once',
         );
       }
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowUp);
+      await tester.pump();
+      expect(
+        ownsPrimaryFocus(tester, orderedKeys.first),
+        isTrue,
+        reason: 'UP at the first action must remain trapped in the modal',
+      );
       for (var index = 1; index < orderedKeys.length; index++) {
         await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
         await tester.pump();
@@ -143,6 +150,13 @@ void main() {
         expect(find.text('Mini guide'), findsNothing);
         expect(find.text('Recent channels'), findsNothing);
       }
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+      await tester.pump();
+      expect(
+        ownsPrimaryFocus(tester, orderedKeys.last),
+        isTrue,
+        reason: 'DOWN at the last action must remain trapped in the modal',
+      );
 
       await tester.sendKeyEvent(LogicalKeyboardKey.escape);
       await tester.pumpAndSettle();
@@ -175,6 +189,15 @@ void main() {
         FocusManager.instance.primaryFocus?.debugLabel,
         'player subtitle option French subtitles',
       );
+      await tester.binding.handlePopRoute();
+      await tester.pumpAndSettle();
+      expect(find.text('Subtitles'), findsWidgets);
+      expect(
+        FocusManager.instance.primaryFocus?.debugLabel,
+        'player action Subtitles',
+      );
+      await tester.sendKeyEvent(LogicalKeyboardKey.select);
+      await tester.pumpAndSettle();
 
       await tester.sendKeyEvent(LogicalKeyboardKey.arrowUp);
       await tester.pump();
@@ -204,6 +227,14 @@ void main() {
         FocusManager.instance.primaryFocus?.debugLabel,
         'player quality option 720p',
       );
+      await tester.binding.handlePopRoute();
+      await tester.pumpAndSettle();
+      expect(
+        FocusManager.instance.primaryFocus?.debugLabel,
+        'player action Quality',
+      );
+      await tester.sendKeyEvent(LogicalKeyboardKey.select);
+      await tester.pumpAndSettle();
 
       await tester.sendKeyEvent(LogicalKeyboardKey.arrowUp);
       await tester.pump();
@@ -260,6 +291,16 @@ void main() {
         FocusManager.instance.primaryFocus?.debugLabel,
         'player audio option French audio',
       );
+      await tester.binding.handlePopRoute();
+      await tester.pumpAndSettle();
+      expect(
+        FocusManager.instance.primaryFocus?.debugLabel,
+        'player audio track',
+      );
+      await tester.sendKeyEvent(LogicalKeyboardKey.select);
+      await tester.pumpAndSettle();
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+      await tester.pump();
       await tester.sendKeyEvent(LogicalKeyboardKey.select);
       await tester.pumpAndSettle();
       expect(service.selectedTracks.last, (

--- a/packages/feature_iptv/test/presentation/widgets/video_player_widget_dpad_modal_test.dart
+++ b/packages/feature_iptv/test/presentation/widgets/video_player_widget_dpad_modal_test.dart
@@ -1,0 +1,363 @@
+import 'package:feature_iptv/feature_iptv.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  const channel = IPTVChannel(
+    id: 'channel-1',
+    name: 'Test channel',
+    streamUrl: 'https://example.com/live.m3u8',
+    qualityUrls: {'high': 'https://example.com/live-720.m3u8'},
+  );
+  const tracks = [
+    AiroPlaybackTrackOption(
+      id: 'audio-en',
+      kind: AiroPlaybackTrackKind.audio,
+      label: 'English audio',
+    ),
+    AiroPlaybackTrackOption(
+      id: 'audio-fr',
+      kind: AiroPlaybackTrackKind.audio,
+      label: 'French audio',
+    ),
+    AiroPlaybackTrackOption(
+      id: 'sub-en',
+      kind: AiroPlaybackTrackKind.subtitle,
+      label: 'English subtitles',
+    ),
+    AiroPlaybackTrackOption(
+      id: 'sub-fr',
+      kind: AiroPlaybackTrackKind.subtitle,
+      label: 'French subtitles',
+    ),
+  ];
+
+  Future<_RecordingStreamingService> pumpPlayer(
+    WidgetTester tester, {
+    Map<AiroPlaybackTrackKind, String> selectedTrackIds = const {},
+    Future<void> Function(bool enabled)? setAudioOnlyMode,
+    Future<bool> Function()? requestPictureInPicture,
+    VoidCallback? onFullscreenToggle,
+  }) async {
+    SharedPreferences.setMockInitialValues({});
+    final prefs = await SharedPreferences.getInstance();
+    final service = _RecordingStreamingService();
+    addTearDown(service.dispose);
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          sharedPreferencesProvider.overrideWithValue(prefs),
+          iptvStreamingServiceProvider.overrideWithValue(service),
+          streamingStateProvider.overrideWith(
+            (ref) => Stream.value(
+              StreamingState(
+                playbackState: PlaybackState.playing,
+                isLiveStream: true,
+                currentChannel: channel,
+                currentQuality: VideoQuality.high,
+                selectedQuality: VideoQuality.high,
+                tracks: tracks,
+                selectedTrackIds: selectedTrackIds,
+              ),
+            ),
+          ),
+        ],
+        child: MaterialApp(
+          home: Scaffold(
+            body: SizedBox(
+              width: 960,
+              height: 540,
+              child: VideoPlayerWidget(
+                initiallyFullscreen: true,
+                enableTouchGestures: false,
+                useTvTransportBar: true,
+                onFullscreenToggle: onFullscreenToggle,
+                setAudioOnlyMode: setAudioOnlyMode,
+                requestPictureInPicture: requestPictureInPicture,
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 100));
+    return service;
+  }
+
+  bool ownsPrimaryFocus(WidgetTester tester, String key) {
+    return Focus.of(tester.element(find.byKey(ValueKey(key)))).hasPrimaryFocus;
+  }
+
+  void requestTvFocusable(WidgetTester tester, Finder wrapper) {
+    final focus = tester.widget<Focus>(
+      find.descendant(of: wrapper, matching: find.byType(Focus)).first,
+    );
+    focus.focusNode!.requestFocus();
+  }
+
+  Future<void> openPlayerActions(WidgetTester tester) async {
+    await tester.sendKeyEvent(LogicalKeyboardKey.contextMenu);
+    await tester.pumpAndSettle();
+    expect(find.text('Player actions'), findsOneWidget);
+  }
+
+  testWidgets(
+    'player actions traps logical D-pad traversal and restores player focus',
+    (tester) async {
+      await pumpPlayer(tester);
+      await openPlayerActions(tester);
+
+      const orderedKeys = [
+        'iptv-player-pip-menu-action',
+        'iptv-player-quality-menu-action',
+        'iptv-player-subtitle-menu-action',
+        'iptv-player-audio-only-menu-action',
+        'iptv-player-aspect-ratio-menu-action',
+        'iptv-player-cinema-menu-action',
+        'iptv-player-fullscreen-menu-action',
+      ];
+      expect(ownsPrimaryFocus(tester, orderedKeys[3]), isTrue);
+
+      for (var index = 2; index >= 0; index--) {
+        await tester.sendKeyEvent(LogicalKeyboardKey.arrowUp);
+        await tester.pump();
+        expect(
+          ownsPrimaryFocus(tester, orderedKeys[index]),
+          isTrue,
+          reason: 'UP must focus ${orderedKeys[index]} exactly once',
+        );
+      }
+      for (var index = 1; index < orderedKeys.length; index++) {
+        await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+        await tester.pump();
+        expect(
+          ownsPrimaryFocus(tester, orderedKeys[index]),
+          isTrue,
+          reason: 'DOWN must focus ${orderedKeys[index]} exactly once',
+        );
+        expect(find.text('Mini guide'), findsNothing);
+        expect(find.text('Recent channels'), findsNothing);
+      }
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.escape);
+      await tester.pumpAndSettle();
+      expect(find.text('Player actions'), findsNothing);
+      expect(
+        FocusManager.instance.primaryFocus?.debugLabel,
+        'player center control',
+      );
+    },
+  );
+
+  testWidgets(
+    'subtitle and quality selectors autofocus, traverse, apply, and restore',
+    (tester) async {
+      final service = await pumpPlayer(
+        tester,
+        selectedTrackIds: const {AiroPlaybackTrackKind.subtitle: 'sub-fr'},
+      );
+      await openPlayerActions(tester);
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowUp);
+      await tester.pump();
+      expect(
+        FocusManager.instance.primaryFocus?.debugLabel,
+        'player action Subtitles',
+      );
+      await tester.sendKeyEvent(LogicalKeyboardKey.select);
+      await tester.pumpAndSettle();
+      expect(
+        FocusManager.instance.primaryFocus?.debugLabel,
+        'player subtitle option French subtitles',
+      );
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowUp);
+      await tester.pump();
+      expect(
+        FocusManager.instance.primaryFocus?.debugLabel,
+        'player subtitle option English subtitles',
+      );
+      await tester.sendKeyEvent(LogicalKeyboardKey.select);
+      await tester.pumpAndSettle();
+      expect(service.selectedTracks, [
+        (kind: AiroPlaybackTrackKind.subtitle, trackId: 'sub-en'),
+      ]);
+      expect(
+        FocusManager.instance.primaryFocus?.debugLabel,
+        'player action Subtitles',
+      );
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowUp);
+      await tester.pump();
+      expect(
+        FocusManager.instance.primaryFocus?.debugLabel,
+        'player action Quality',
+      );
+      await tester.sendKeyEvent(LogicalKeyboardKey.select);
+      await tester.pumpAndSettle();
+      expect(
+        FocusManager.instance.primaryFocus?.debugLabel,
+        'player quality option 720p',
+      );
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowUp);
+      await tester.pump();
+      expect(
+        FocusManager.instance.primaryFocus?.debugLabel,
+        'player quality option Auto',
+      );
+      await tester.sendKeyEvent(LogicalKeyboardKey.select);
+      await tester.pumpAndSettle();
+      expect(service.qualities, [VideoQuality.auto]);
+      expect(
+        FocusManager.instance.primaryFocus?.debugLabel,
+        'player action Quality',
+      );
+    },
+  );
+
+  testWidgets(
+    'Off and audio-track rows use visible focus and CENTER applies once',
+    (tester) async {
+      final service = await pumpPlayer(tester);
+      await openPlayerActions(tester);
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowUp);
+      await tester.pump();
+      await tester.sendKeyEvent(LogicalKeyboardKey.select);
+      await tester.pumpAndSettle();
+      expect(
+        FocusManager.instance.primaryFocus?.debugLabel,
+        'player subtitle option Off',
+      );
+      await tester.sendKeyEvent(LogicalKeyboardKey.select);
+      await tester.pumpAndSettle();
+      expect(service.clearedTrackKinds, [AiroPlaybackTrackKind.subtitle]);
+      expect(
+        FocusManager.instance.primaryFocus?.debugLabel,
+        'player action Subtitles',
+      );
+
+      await tester.binding.handlePopRoute();
+      await tester.pumpAndSettle();
+      final audioButton = find.byKey(const ValueKey('iptv-tv-transport-audio'));
+      requestTvFocusable(tester, audioButton);
+      await tester.pump();
+      await tester.sendKeyEvent(LogicalKeyboardKey.select);
+      await tester.pumpAndSettle();
+      expect(
+        FocusManager.instance.primaryFocus?.debugLabel,
+        'player audio option English audio',
+      );
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+      await tester.pump();
+      expect(
+        FocusManager.instance.primaryFocus?.debugLabel,
+        'player audio option French audio',
+      );
+      await tester.sendKeyEvent(LogicalKeyboardKey.select);
+      await tester.pumpAndSettle();
+      expect(service.selectedTracks.last, (
+        kind: AiroPlaybackTrackKind.audio,
+        trackId: 'audio-fr',
+      ));
+      expect(
+        FocusManager.instance.primaryFocus?.debugLabel,
+        'player audio track',
+      );
+    },
+  );
+
+  testWidgets('every direct player-action row activates exactly once', (
+    tester,
+  ) async {
+    var pipRequests = 0;
+    var audioOnlyRequests = 0;
+    var fullscreenToggles = 0;
+    await pumpPlayer(
+      tester,
+      onFullscreenToggle: () => fullscreenToggles++,
+      requestPictureInPicture: () async {
+        pipRequests++;
+        return true;
+      },
+      setAudioOnlyMode: (enabled) async => audioOnlyRequests++,
+    );
+
+    Future<void> activate(String key) async {
+      await openPlayerActions(tester);
+      final action = find.byKey(ValueKey(key));
+      if (action.evaluate().isEmpty) {
+        await tester.scrollUntilVisible(
+          action,
+          120,
+          scrollable: find.byType(Scrollable).last,
+        );
+      }
+      Focus.of(tester.element(action)).requestFocus();
+      await tester.pump();
+      await tester.sendKeyEvent(LogicalKeyboardKey.select);
+      await tester.pumpAndSettle();
+    }
+
+    await activate('iptv-player-pip-menu-action');
+    expect(pipRequests, 1);
+
+    await activate('iptv-player-audio-only-menu-action');
+    expect(audioOnlyRequests, 1);
+
+    final container = ProviderScope.containerOf(
+      tester.element(find.byType(VideoPlayerWidget)),
+    );
+    final aspectBefore = container.read(videoAspectRatioProvider);
+    await activate('iptv-player-aspect-ratio-menu-action');
+    expect(container.read(videoAspectRatioProvider), isNot(aspectBefore));
+
+    await activate('iptv-player-cinema-menu-action');
+    await openPlayerActions(tester);
+    final standardMode = find.text('Standard mode');
+    await tester.scrollUntilVisible(
+      standardMode,
+      120,
+      scrollable: find.byType(Scrollable).last,
+    );
+    expect(standardMode, findsOneWidget);
+    await tester.binding.handlePopRoute();
+    await tester.pumpAndSettle();
+
+    await activate('iptv-player-fullscreen-menu-action');
+    expect(fullscreenToggles, 1);
+  });
+}
+
+class _RecordingStreamingService extends VideoPlayerStreamingService {
+  _RecordingStreamingService() : super(engine: FakeAiroPlaybackEngine());
+
+  final List<({AiroPlaybackTrackKind kind, String trackId})> selectedTracks =
+      [];
+  final List<AiroPlaybackTrackKind> clearedTrackKinds = [];
+  final List<VideoQuality> qualities = [];
+
+  @override
+  Future<void> selectTrack({
+    required AiroPlaybackTrackKind kind,
+    required String trackId,
+  }) async {
+    selectedTracks.add((kind: kind, trackId: trackId));
+  }
+
+  @override
+  Future<void> clearTrackSelection(AiroPlaybackTrackKind kind) async {
+    clearedTrackKinds.add(kind);
+  }
+
+  @override
+  Future<void> setQuality(VideoQuality quality) async {
+    qualities.add(quality);
+  }
+}

--- a/packages/feature_iptv/test/presentation/widgets/video_player_widget_error_layout_test.dart
+++ b/packages/feature_iptv/test/presentation/widgets/video_player_widget_error_layout_test.dart
@@ -38,9 +38,7 @@ void main() {
     // A fake engine, not the real service default: Skip channel drives a
     // real playChannel() call, which would otherwise stand up a genuine
     // VideoPlayerController that never gets disposed once the test ends.
-    final service = VideoPlayerStreamingService(
-      engine: FakeAiroPlaybackEngine(),
-    );
+    final service = _RecoveryRecordingService();
     addTearDown(() async {
       await service.stop();
       service.dispose();
@@ -304,7 +302,9 @@ void main() {
   ) async {
     final container = await pumpErrorPlayer(tester);
 
-    await tester.tap(find.text('Report dead link'));
+    await tester.sendKeyEvent(LogicalKeyboardKey.arrowRight);
+    await tester.sendKeyEvent(LogicalKeyboardKey.arrowRight);
+    await tester.sendKeyEvent(LogicalKeyboardKey.select);
     await tester.pump();
     await tester.pump();
 
@@ -336,14 +336,45 @@ void main() {
       ],
     );
 
-    await tester.tap(find.text('Skip channel'));
+    await tester.sendKeyEvent(LogicalKeyboardKey.arrowRight);
+    await tester.sendKeyEvent(LogicalKeyboardKey.select);
     await tester.pump();
 
     expect(tester.takeException(), isNull);
+    final service =
+        container.read(iptvStreamingServiceProvider)
+            as _RecoveryRecordingService;
+    expect(service.playedChannels, [nextChannel]);
 
-    // Pending timers (buffer monitor, live-edge detector) must be stopped
-    // inside the test body -- the pending-timer check runs before
-    // addTearDown(service.dispose) fires.
-    await container.read(iptvStreamingServiceProvider).stop();
+    await service.stop();
   });
+
+  testWidgets('Try Again activates exactly once from CENTER', (tester) async {
+    final container = await pumpErrorPlayer(tester);
+
+    await tester.sendKeyEvent(LogicalKeyboardKey.select);
+    await tester.pump();
+
+    final service =
+        container.read(iptvStreamingServiceProvider)
+            as _RecoveryRecordingService;
+    expect(service.retryCalls, 1);
+  });
+}
+
+class _RecoveryRecordingService extends VideoPlayerStreamingService {
+  _RecoveryRecordingService() : super(engine: FakeAiroPlaybackEngine());
+
+  int retryCalls = 0;
+  final List<IPTVChannel> playedChannels = [];
+
+  @override
+  Future<void> retry() async {
+    retryCalls++;
+  }
+
+  @override
+  Future<void> playChannel(IPTVChannel channel) async {
+    playedChannels.add(channel);
+  }
 }

--- a/packages/feature_iptv/test/presentation/widgets/video_player_widget_error_layout_test.dart
+++ b/packages/feature_iptv/test/presentation/widgets/video_player_widget_error_layout_test.dart
@@ -155,11 +155,35 @@ void main() {
         'player recovery Report dead link',
       );
 
+      // Fire TV must not let the recovery row's edge escape to an unrelated
+      // player control. On-device this also catches a single RIGHT press
+      // being interpreted as two geometric traversal steps.
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowRight);
+      await tester.pump();
+      expect(
+        FocusManager.instance.primaryFocus?.debugLabel,
+        'player recovery Report dead link',
+      );
+
       await tester.sendKeyEvent(LogicalKeyboardKey.arrowLeft);
       await tester.pump();
       expect(
         FocusManager.instance.primaryFocus?.debugLabel,
         'player recovery Skip channel',
+      );
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowLeft);
+      await tester.pump();
+      expect(
+        FocusManager.instance.primaryFocus?.debugLabel,
+        'player recovery Try Again',
+      );
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowLeft);
+      await tester.pump();
+      expect(
+        FocusManager.instance.primaryFocus?.debugLabel,
+        'player recovery Try Again',
       );
     },
   );

--- a/packages/feature_iptv/test/presentation/widgets/video_player_widget_error_layout_test.dart
+++ b/packages/feature_iptv/test/presentation/widgets/video_player_widget_error_layout_test.dart
@@ -25,7 +25,9 @@ void main() {
     final prefs = await SharedPreferences.getInstance();
     const mapper = AiroPlaybackDiagnosticMapper();
     final diagnostic = mapper.map(
-      const AiroPlaybackFailureEvent(httpStatusCode: 403),
+      const AiroPlaybackFailureEvent(
+        overrideCode: AiroPlaybackDiagnosticCode.providerAuthDenied,
+      ),
     );
     const currentChannel = IPTVChannel(
       id: 'news-1',
@@ -201,7 +203,9 @@ void main() {
       addTearDown(service.dispose);
       const mapper = AiroPlaybackDiagnosticMapper();
       final diagnostic = mapper.map(
-        const AiroPlaybackFailureEvent(httpStatusCode: 403),
+        const AiroPlaybackFailureEvent(
+          overrideCode: AiroPlaybackDiagnosticCode.providerAuthDenied,
+        ),
       );
       const channel = IPTVChannel(
         id: 'news-1',

--- a/packages/feature_iptv/test/presentation/widgets/video_player_widget_error_layout_test.dart
+++ b/packages/feature_iptv/test/presentation/widgets/video_player_widget_error_layout_test.dart
@@ -269,6 +269,32 @@ void main() {
     },
   );
 
+  testWidgets('closing player actions restores diagnostic recovery focus', (
+    tester,
+  ) async {
+    await pumpErrorPlayer(tester);
+    expect(
+      FocusManager.instance.primaryFocus?.debugLabel,
+      'player recovery Try Again',
+    );
+
+    await tester.sendKeyEvent(LogicalKeyboardKey.contextMenu);
+    await tester.pumpAndSettle();
+    expect(find.text('Player actions'), findsOneWidget);
+    expect(
+      FocusManager.instance.primaryFocus?.debugLabel,
+      'player action Listen only',
+    );
+
+    await tester.sendKeyEvent(LogicalKeyboardKey.escape);
+    await tester.pumpAndSettle();
+    expect(find.text('Player actions'), findsNothing);
+    expect(
+      FocusManager.instance.primaryFocus?.debugLabel,
+      'player recovery Try Again',
+    );
+  });
+
   testWidgets('Report dead link saves a local report and confirms it', (
     tester,
   ) async {

--- a/packages/feature_iptv/test/presentation/widgets/video_player_widget_error_layout_test.dart
+++ b/packages/feature_iptv/test/presentation/widgets/video_player_widget_error_layout_test.dart
@@ -1,6 +1,9 @@
+import 'dart:async';
+
 import 'package:core_ui/core_ui.dart';
 import 'package:feature_iptv/feature_iptv.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -127,6 +130,120 @@ void main() {
       );
     }
   });
+
+  testWidgets(
+    'diagnostic recovery visibly owns focus and traverses every action',
+    (tester) async {
+      await pumpErrorPlayer(tester);
+
+      expect(
+        FocusManager.instance.primaryFocus?.debugLabel,
+        'player recovery Try Again',
+      );
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowRight);
+      await tester.pump();
+      expect(
+        FocusManager.instance.primaryFocus?.debugLabel,
+        'player recovery Skip channel',
+      );
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowRight);
+      await tester.pump();
+      expect(
+        FocusManager.instance.primaryFocus?.debugLabel,
+        'player recovery Report dead link',
+      );
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowLeft);
+      await tester.pump();
+      expect(
+        FocusManager.instance.primaryFocus?.debugLabel,
+        'player recovery Skip channel',
+      );
+    },
+  );
+
+  testWidgets(
+    'rebuilds preserve user focus and a failed retry remount refocuses Try Again',
+    (tester) async {
+      SharedPreferences.setMockInitialValues({});
+      final prefs = await SharedPreferences.getInstance();
+      final states = StreamController<StreamingState>.broadcast();
+      addTearDown(states.close);
+      final service = VideoPlayerStreamingService(
+        engine: FakeAiroPlaybackEngine(),
+      );
+      addTearDown(service.dispose);
+      const mapper = AiroPlaybackDiagnosticMapper();
+      final diagnostic = mapper.map(
+        const AiroPlaybackFailureEvent(httpStatusCode: 403),
+      );
+      const channel = IPTVChannel(
+        id: 'news-1',
+        name: 'City News Live',
+        streamUrl: 'https://example.com/news.m3u8',
+      );
+      StreamingState failed() => StreamingState(
+        playbackState: PlaybackState.error,
+        isLiveStream: true,
+        diagnostic: diagnostic,
+        currentChannel: channel,
+      );
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            sharedPreferencesProvider.overrideWithValue(prefs),
+            iptvStreamingServiceProvider.overrideWithValue(service),
+            streamingStateProvider.overrideWith((ref) => states.stream),
+          ],
+          child: const MaterialApp(home: Scaffold(body: VideoPlayerWidget())),
+        ),
+      );
+      states.add(failed());
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 100));
+      expect(
+        FocusManager.instance.primaryFocus?.debugLabel,
+        'player recovery Try Again',
+      );
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowRight);
+      await tester.pump();
+      expect(
+        FocusManager.instance.primaryFocus?.debugLabel,
+        'player recovery Skip channel',
+      );
+
+      states.add(failed());
+      await tester.pump(const Duration(seconds: 5));
+      expect(
+        FocusManager.instance.primaryFocus?.debugLabel,
+        'player recovery Skip channel',
+        reason:
+            'same-error rebuilds and the old controls timer must not steal focus',
+      );
+
+      states.add(
+        StreamingState(
+          playbackState: PlaybackState.loading,
+          isLiveStream: true,
+          currentChannel: channel,
+        ),
+      );
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 100));
+      expect(find.byType(CircularProgressIndicator), findsOneWidget);
+      states.add(failed());
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 100));
+      expect(
+        FocusManager.instance.primaryFocus?.debugLabel,
+        'player recovery Try Again',
+      );
+    },
+  );
 
   testWidgets('Report dead link saves a local report and confirms it', (
     tester,

--- a/packages/feature_iptv/test/presentation/widgets/video_player_widget_tv_transport_bar_test.dart
+++ b/packages/feature_iptv/test/presentation/widgets/video_player_widget_tv_transport_bar_test.dart
@@ -1,12 +1,13 @@
 import 'package:feature_iptv/feature_iptv.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
-// AiroTV D-pad design's TRANSPORT (OK) screen: six buttons (Play/Pause,
-// Restart, Audio, Subtitles, Favourite, Info), a metadata row above them,
-// and a "MENU for more actions" hint. useTvTransportBar: true swaps the
+// AiroTV D-pad design's TRANSPORT (OK) screen: player controls plus a
+// discoverable More actions target, a metadata row above them, and a
+// "MENU for more actions" hint. useTvTransportBar: true swaps the
 // touch-oriented VOL/CH pillar layout for this bar; phone/tablet callers
 // (useTvTransportBar defaults false) are unaffected.
 void main() {
@@ -60,27 +61,46 @@ void main() {
     return container;
   }
 
-  testWidgets(
-    'renders all six transport buttons and channel metadata at the '
-    "design's 960px canvas width, with no overflow",
-    (tester) async {
-      await pumpTransportBar(tester, width: 960);
+  testWidgets('renders all transport buttons and channel metadata at the '
+      "design's 960px canvas width, with no overflow", (tester) async {
+    await pumpTransportBar(tester, width: 960);
 
-      expect(tester.takeException(), isNull);
-      expect(find.byKey(const ValueKey('iptv-tv-transport-play-pause')), findsOneWidget);
-      expect(find.byKey(const ValueKey('iptv-tv-transport-restart')), findsOneWidget);
-      expect(find.byKey(const ValueKey('iptv-tv-transport-audio')), findsOneWidget);
-      expect(find.byKey(const ValueKey('iptv-tv-transport-subtitles')), findsOneWidget);
-      expect(find.byKey(const ValueKey('iptv-tv-transport-favourite')), findsOneWidget);
-      expect(find.byKey(const ValueKey('iptv-tv-transport-info')), findsOneWidget);
-      expect(find.text('MENU for more actions'), findsOneWidget);
-      expect(find.text('City News Live'), findsOneWidget);
-      expect(find.text('LIVE'), findsOneWidget);
-      // The touch-oriented layout must not appear alongside it.
-      expect(find.text('VOL'), findsNothing);
-      expect(find.text('CH'), findsNothing);
-    },
-  );
+    expect(tester.takeException(), isNull);
+    expect(
+      find.byKey(const ValueKey('iptv-tv-transport-play-pause')),
+      findsOneWidget,
+    );
+    expect(
+      find.byKey(const ValueKey('iptv-tv-transport-restart')),
+      findsOneWidget,
+    );
+    expect(
+      find.byKey(const ValueKey('iptv-tv-transport-audio')),
+      findsOneWidget,
+    );
+    expect(
+      find.byKey(const ValueKey('iptv-tv-transport-subtitles')),
+      findsOneWidget,
+    );
+    expect(
+      find.byKey(const ValueKey('iptv-tv-transport-favourite')),
+      findsOneWidget,
+    );
+    expect(
+      find.byKey(const ValueKey('iptv-tv-transport-info')),
+      findsOneWidget,
+    );
+    expect(
+      find.byKey(const ValueKey('iptv-player-more-button')),
+      findsOneWidget,
+    );
+    expect(find.text('MENU for more actions'), findsOneWidget);
+    expect(find.text('City News Live'), findsOneWidget);
+    expect(find.text('LIVE'), findsOneWidget);
+    // The touch-oriented layout must not appear alongside it.
+    expect(find.text('VOL'), findsNothing);
+    expect(find.text('CH'), findsNothing);
+  });
 
   testWidgets('does not overflow at a narrower TV panel width (720)', (
     tester,
@@ -110,5 +130,25 @@ void main() {
     await tester.pump();
 
     expect(find.text('Actions for'), findsOneWidget);
+  });
+
+  testWidgets('MENU opens player actions and visibly focuses Listen only', (
+    tester,
+  ) async {
+    await pumpTransportBar(tester, width: 960);
+
+    await tester.sendKeyEvent(LogicalKeyboardKey.contextMenu);
+    await tester.pumpAndSettle();
+
+    expect(find.text('Player actions'), findsOneWidget);
+    expect(find.text('Actions for'), findsNothing);
+    expect(
+      Focus.of(
+        tester.element(
+          find.byKey(const ValueKey('iptv-player-audio-only-menu-action')),
+        ),
+      ).hasPrimaryFocus,
+      isTrue,
+    );
   });
 }


### PR DESCRIPTION
## Summary

Fixes the Fire TV regressions tracked in #1272:

- keeps the canonical IPTV URL exact and handles invalid playlist input without suffix corruption
- replaces the unusable ten-foot preview with a grid-first browse flow
- starts the focused channel fullscreen after a 1.2 s dwell, with CENTER as the immediate action
- restores one-tile-per-press traversal across the channel grid, Mini Guide, selectors, recovery actions, and player controls
- keeps one Fire TV BACK inside Airo by returning fullscreen playback to the grid
- preserves the favorite reimport review contract from the reported regression set

Closes #1272

## Test Plan

- [x] Relevant package and app analyzers passed with no issues
- [x] Focused IPTV TV-UX/player tests passed: 69
- [x] App router tests passed: 15
- [x] Independent clean-head audit passed: 209 tests, 2 expected skips
- [x] Manual physical Fire TV verification documented in issue #1272

**Verification environment:** Physical Amazon Fire TV AFTSSS, 1920×1080. APK SHA-256 `e7e4d634964e9e516f6e7e82fcff3eb20c488db6e4b5706b5071924b16baa504`.

B4U Music, Vevo Pop, and YRF Music all rendered video/audio. Exact-head verification confirmed grid-first browse, dwell-to-fullscreen, one LEFT moving one adjacent Mini Guide tile, CENTER switching, and one BACK returning to the grid while Airo remains focused.

Remote CI is intentionally skipped under the repository cost-control policy; the bounded local and physical-device gates cover this slice.

## Agent Policy

- [x] Linked issue includes a Critical Agent Gate.
- [x] Linked issue includes a Feature Packet.
- [x] Framework/application focus contracts are documented in the linked issue and reverification guide.
- [x] Deterministic use cases and automation flows are included in the linked issue and tests.
- [x] No AI/tool/memory/routine changes.
- [x] Android Emulator was not used.

## Council Review

Reviewed in this Codex implementation session against the required council lenses:

- TV Experience Architect: focus traversal, remote input ownership, overscan layout
- Flutter Architect: widget structure, routing, shared `core_ui` focus callbacks
- Chief UX Officer: ten-foot grid-first interaction and deterministic BACK behavior
- Chief QA Officer: targeted regression matrix and physical Fire TV evidence
- Chief Performance Officer: bounded dwell timer lifecycle and no new hot-path parsing
- Chief Open Source Officer: no dependencies added
- Media Intelligence Architect: IPTV application boundary and playlist fixture behavior

- [x] Decision Matrix roles listed above.
- [x] Touched packages have existing `module.yaml` manifests.
- [x] Manifest ownership/reviewer fields remain accurate.

## User-Facing Documentation

- [x] `docs/testing/fire-tv-pr1244-reverification.md` and deterministic Fire TV fixtures document the corrected flow and evidence; no public capability/wiki contract changed.

## Plugin and Size Impact

- [ ] This PR adds new dependencies
- [x] This PR changes existing app/package code
- [x] Size impact is source-only UI/test growth; no dependency or binary asset growth
- [x] No module/plugin threshold is affected

Size impact / plugin justification: existing bundled TV/IPTV modules only; no plugin or dependency change.

## Checklist

- [x] Code is formatted.
- [x] Tests and manual verification are included above.
- [x] Sensitive data, credentials, and signing artifacts are not committed.

## Release Notes

- [x] Fire TV channel browsing now starts focused channels fullscreen and keeps each D-pad press and BACK action deterministic.