### PR TITLE
feat(iptv): surface a distinct offline state during touch-device playback

### DIFF
--- a/packages/feature_iptv/lib/application/providers/connectivity_providers.dart
+++ b/packages/feature_iptv/lib/application/providers/connectivity_providers.dart
@@ -1,0 +1,25 @@
+import 'package:connectivity_plus/connectivity_plus.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+/// Raw connectivity change stream, overridable in tests so widgets don't
+/// need a real platform channel to exercise offline UI.
+final connectivityStreamProvider = StreamProvider<List<ConnectivityResult>>((
+  ref,
+) {
+  return Connectivity().onConnectivityChanged;
+});
+
+/// Whether the device currently has no network connectivity at all.
+///
+/// Defers to the raw connectivity stream rather than actual reachability --
+/// this distinguishes "device says it's offline" (checklist's "offline
+/// state") from playback-specific failures, which the player's own error
+/// states already handle.
+final isOfflineProvider = Provider<bool>((ref) {
+  final connectivity = ref.watch(connectivityStreamProvider);
+  return connectivity.maybeWhen(
+    data: (results) =>
+        results.every((result) => result == ConnectivityResult.none),
+    orElse: () => false,
+  );
+});

--- a/packages/feature_iptv/lib/application/providers/iptv_providers.dart
+++ b/packages/feature_iptv/lib/application/providers/iptv_providers.dart
@@ -25,6 +25,7 @@ import 'content_source_providers.dart';
 
 export 'iptv_cast_providers.dart';
 export 'airo_tv_profile_provider.dart';
+export 'connectivity_providers.dart';
 export 'edge_intelligence_providers.dart';
 export 'iptv_navigation_provider.dart';
 export 'voice_search_provider.dart';

--- a/packages/feature_iptv/lib/presentation/screens/iptv_screen.dart
+++ b/packages/feature_iptv/lib/presentation/screens/iptv_screen.dart
@@ -17,6 +17,7 @@ import '../widgets/adaptive_iptv_sheet.dart';
 import '../widgets/cast_device_picker_sheet.dart';
 import '../widgets/iptv_cast_mini_controller.dart';
 import '../widgets/iptv_navigation_drawer.dart';
+import '../widgets/offline_playback_banner.dart';
 import '../widgets/phone_media_play_on_tv_sheet.dart';
 import '../widgets/video_player_widget.dart';
 import '../widgets/xmltv_source_sheet.dart';
@@ -1202,6 +1203,12 @@ class _StreamTabContent extends ConsumerWidget {
                         onPressed: onFullscreenToggle,
                       ),
                     ),
+                  ),
+                  const Positioned(
+                    top: 60,
+                    left: 8,
+                    right: 8,
+                    child: OfflinePlaybackBanner(),
                   ),
                 ],
               ),

--- a/packages/feature_iptv/lib/presentation/widgets/offline_playback_banner.dart
+++ b/packages/feature_iptv/lib/presentation/widgets/offline_playback_banner.dart
@@ -1,0 +1,46 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../application/providers/connectivity_providers.dart';
+
+/// Surfaces a distinct "you're offline" state on touch devices, per the
+/// reliability checklist's "Offline state" item -- without this, a dropped
+/// connection during playback only ever showed a generic player error,
+/// indistinguishable from a bad stream URL or a dead source.
+///
+/// Renders nothing while online.
+class OfflinePlaybackBanner extends ConsumerWidget {
+  const OfflinePlaybackBanner({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final isOffline = ref.watch(isOfflineProvider);
+    if (!isOffline) return const SizedBox.shrink();
+
+    final colorScheme = Theme.of(context).colorScheme;
+    return Container(
+      key: const ValueKey('iptv-offline-banner'),
+      width: double.infinity,
+      margin: const EdgeInsets.only(bottom: 16),
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+      decoration: BoxDecoration(
+        color: colorScheme.errorContainer,
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(Icons.wifi_off, color: colorScheme.onErrorContainer, size: 18),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Text(
+              "You're offline. Playback and channel updates are paused "
+              'until your connection is back.',
+              style: TextStyle(color: colorScheme.onErrorContainer),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/packages/feature_iptv/pubspec.yaml
+++ b/packages/feature_iptv/pubspec.yaml
@@ -13,6 +13,7 @@ dependencies:
     path: ../core_entitlements
   cached_network_image: 3.4.1
   collection: ^1.19.0
+  connectivity_plus: ^7.2.0
   core_data:
     path: ../core_data
   core_edge_intelligence:

--- a/packages/feature_iptv/test/iptv/presentation/widgets/offline_playback_banner_test.dart
+++ b/packages/feature_iptv/test/iptv/presentation/widgets/offline_playback_banner_test.dart
@@ -1,0 +1,65 @@
+import 'dart:async';
+
+import 'package:connectivity_plus/connectivity_plus.dart';
+import 'package:feature_iptv/feature_iptv.dart';
+import 'package:feature_iptv/presentation/widgets/offline_playback_banner.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  Future<void> pumpBanner(
+    WidgetTester tester,
+    Stream<List<ConnectivityResult>> stream,
+  ) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [connectivityStreamProvider.overrideWith((ref) => stream)],
+        child: const MaterialApp(home: Scaffold(body: OfflinePlaybackBanner())),
+      ),
+    );
+  }
+
+  testWidgets('renders nothing while online', (tester) async {
+    await pumpBanner(tester, Stream.value([ConnectivityResult.wifi]));
+    await tester.pump();
+
+    expect(find.byKey(const ValueKey('iptv-offline-banner')), findsNothing);
+  });
+
+  testWidgets('shows the offline banner once connectivity drops to none', (
+    tester,
+  ) async {
+    final controller = StreamController<List<ConnectivityResult>>();
+    addTearDown(controller.close);
+
+    await pumpBanner(tester, controller.stream);
+    controller.add([ConnectivityResult.wifi]);
+    await tester.pump();
+
+    expect(find.byKey(const ValueKey('iptv-offline-banner')), findsNothing);
+
+    controller.add([ConnectivityResult.none]);
+    await tester.pump();
+
+    expect(find.byKey(const ValueKey('iptv-offline-banner')), findsOneWidget);
+    expect(find.textContaining("You're offline"), findsOneWidget);
+  });
+
+  testWidgets('hides the banner again once connectivity is restored', (
+    tester,
+  ) async {
+    final controller = StreamController<List<ConnectivityResult>>();
+    addTearDown(controller.close);
+
+    await pumpBanner(tester, controller.stream);
+    controller.add([ConnectivityResult.none]);
+    await tester.pump();
+    expect(find.byKey(const ValueKey('iptv-offline-banner')), findsOneWidget);
+
+    controller.add([ConnectivityResult.wifi]);
+    await tester.pump();
+
+    expect(find.byKey(const ValueKey('iptv-offline-banner')), findsNothing);
+  });
+}


### PR DESCRIPTION
## Summary
- Dropping connectivity mid-playback on phones/tablets only ever surfaced a generic player error, indistinguishable from a bad stream URL or a dead source — no dedicated "offline" state existed, per the reliability checklist in #519.
- Add `isOfflineProvider`/`connectivityStreamProvider` (`connectivity_providers.dart`) wrapping `connectivity_plus`, and an `OfflinePlaybackBanner` widget that renders only while the device reports zero connectivity, wired into the shared preview/playback stage in `iptv_screen.dart` (covers both `IPTVScreen` and `IPTVScreenBody`, phone and TV — TV simply won't hit the offline path in practice, that's fine).
- `connectivity_plus` was already a transitive dependency via `platform_player`; now declared directly since `feature_iptv` imports it.

Part of milestone [Phase 2 — Reliability](https://github.com/DevelopersCoffee/airo/milestone/2) — touch-only device reliability, issue #519 "Validation: UI Responsiveness" (offline state item).

## Test plan
- [x] `flutter analyze` clean
- [x] New widget test `offline_playback_banner_test.dart` (online → nothing rendered, drops to none → banner shows, restored → banner clears) — **not run live** in this environment: `flutter test`'s frontend_server compile repeatedly hung under heavy machine contention from unrelated concurrent worktree sessions on this box. Please confirm green in CI before merge.