### PR TITLE
docs: in-house BIP-39, runtime invariants I1-I3, machine-checkable DoD

### DIFF
--- a/docs/superpowers/plans/2026-07-27-airo-mind-phase-1-vault.md
+++ b/docs/superpowers/plans/2026-07-27-airo-mind-phase-1-vault.md
@@ -1027,8 +1027,8 @@ Create `rust/airo_mind/src/vault/envelope.rs`:
 //! exists. This is what lets one object be a medical record, an expense, and
 //! a tax deduction at the same time.
 
-use chacha20poly1305::aead::{Aead, KeyInit, OsRng as AeadOsRng};
-use chacha20poly1305::{AeadCore, XChaCha20Poly1305, XNonce};
+use chacha20poly1305::aead::{Aead, KeyInit, Payload};
+use chacha20poly1305::{XChaCha20Poly1305, XNonce};
 use serde::{Deserialize, Serialize};
 use zeroize::{Zeroize, ZeroizeOnDrop};
 
@@ -1241,7 +1241,7 @@ fn random_key() -> Result<[u8; 32], VaultError> {
     Ok(bytes)
 }
 
-fn random_nonce() -> Result<[u8; 24], VaultError> {
+pub(crate) fn random_nonce() -> Result<[u8; 24], VaultError> {
     use rand_core::RngCore;
     let mut bytes = [0u8; 24];
     rand_core::OsRng
@@ -1427,7 +1427,7 @@ Expected: FAIL to compile — module not declared.
 
 - [ ] **Step 3: Reconcile against the real `chacha20poly1305` v0.10 API**
 
-`AeadCore::generate_nonce` requires the `getrandom` feature. `KeyInit::new` takes `&Key`, which is `&GenericArray<u8, U32>` — the `.into()` on `&[u8; 32]` should work, but adjust if the compiler disagrees. The `aead` re-export path may be `chacha20poly1305::aead` or require the `aead` crate directly.
+Nonces come from `random_nonce()` (`try_fill_bytes`), never `AeadCore::generate_nonce`, which panics on RNG failure. `KeyInit::new` takes `&Key`, which is `&GenericArray<u8, U32>` — the `.into()` on `&[u8; 32]` should work, but adjust if the compiler disagrees. The `aead` re-export path may be `chacha20poly1305::aead` or require the `aead` crate directly.
 
 - [ ] **Step 4: Run test to verify it passes**
 
@@ -2121,13 +2121,16 @@ Create `rust/airo_mind/src/vault/package.rs`:
 
 use std::collections::BTreeMap;
 
-use chacha20poly1305::aead::{Aead, KeyInit, OsRng as AeadOsRng};
-use chacha20poly1305::{AeadCore, XChaCha20Poly1305, XNonce};
+use chacha20poly1305::aead::{Aead, KeyInit, Payload};
+use chacha20poly1305::{XChaCha20Poly1305, XNonce};
 use hkdf::Hkdf;
+use rand_core::RngCore;
 use serde::{Deserialize, Serialize};
 use sha2::Sha512;
+use zeroize::Zeroizing;
 
-use super::envelope::ContentEnvelope;
+use super::domain;
+use super::envelope::{random_nonce, ContentEnvelope};
 use super::error::VaultError;
 use super::revocation::RevocationLedger;
 use super::seed::Seed;
@@ -2157,52 +2160,154 @@ pub struct RecoveryPackage {
     /// restore must read it before it can decrypt anything, to know how far
     /// behind this backup is.
     pub revocation_epoch: u64,
+
+    // ── Reserved in v1, not yet used ────────────────────────────────────────
+    //
+    // A user-chosen passphrase over the 24 words is real defence: this package
+    // is designed to sit on a NAS, a USB stick, or the user's own cloud, where
+    // "someone photographed the seed card" is the realistic threat.
+    //
+    // The slot is reserved rather than the feature built, because adding these
+    // fields later changes the format and breaks every package already in the
+    // field. Reserving costs three fields and one AAD entry; not reserving
+    // forecloses the option permanently.
+    //
+    // v1 always writes `passphrase_used: false`, an empty `kdf_params`, and a
+    // random `kdf_salt`. `decrypt` MUST reject `passphrase_used: true` with
+    // `UnsupportedPackageVersion` until the feature ships — a package this
+    // build cannot open must fail loudly, never silently ignore the flag and
+    // derive the wrong key.
+    pub passphrase_used: bool,
+    pub kdf_params: BTreeMap<String, u64>,
+    pub kdf_salt: Vec<u8>,
+
     nonce: Vec<u8>,
     ciphertext: Vec<u8>,
 }
 
 impl RecoveryPackage {
+    /// The plaintext header, canonically encoded, bound as AAD.
+    ///
+    /// Without this the header is freely editable: `revocation_epoch` drives
+    /// the "your backup is N revocations behind" warning, and
+    /// `identity_public_key` drives "this package belongs to identity X".
+    /// Both are user-facing safety signals sitting outside the ciphertext.
+    ///
+    /// `kdf_*` and `passphrase_used` are bound too, so a downgrade attack
+    /// cannot strip a future passphrase by flipping the flag.
+    fn header_aad(&self) -> Vec<u8> {
+        let mut aad = Vec::new();
+        aad.extend_from_slice(domain::PACKAGE_HEADER);
+        aad.extend_from_slice(&self.format_version.to_be_bytes());
+        aad.extend_from_slice(&self.identity_public_key);
+        aad.extend_from_slice(&self.revocation_epoch.to_be_bytes());
+        aad.push(u8::from(self.passphrase_used));
+        aad.extend_from_slice(&(self.kdf_params.len() as u32).to_be_bytes());
+        for (key, value) in &self.kdf_params {
+            aad.extend_from_slice(&(key.len() as u32).to_be_bytes());
+            aad.extend_from_slice(key.as_bytes());
+            aad.extend_from_slice(&value.to_be_bytes());
+        }
+        aad.extend_from_slice(&(self.kdf_salt.len() as u32).to_be_bytes());
+        aad.extend_from_slice(&self.kdf_salt);
+        aad
+    }
+
     pub fn export(vault: &Vault, seed: &Seed) -> Result<Self, VaultError> {
         let payload = vault.to_payload();
-        let plaintext = serde_json::to_vec(&payload).map_err(|_| VaultError::SerializationFailed)?;
+        // `Zeroizing`: this buffer holds every context key in plaintext.
+        let plaintext = Zeroizing::new(
+            serde_json::to_vec(&payload).map_err(|_| VaultError::SerializationFailed)?,
+        );
 
-        let cipher = XChaCha20Poly1305::new(&package_key(seed)?.into());
-        let nonce = XChaCha20Poly1305::generate_nonce(&mut AeadOsRng);
-        let ciphertext = cipher
-            .encrypt(&nonce, plaintext.as_slice())
-            .map_err(|_| VaultError::SerializationFailed)?;
+        let mut salt = vec![0u8; 16];
+        rand_core::OsRng
+            .try_fill_bytes(&mut salt)
+            .map_err(|_| VaultError::RngUnavailable)?;
 
-        Ok(Self {
+        // Header is built first, because it is the AAD the ciphertext commits to.
+        let mut package = Self {
             format_version: RECOVERY_PACKAGE_FORMAT_VERSION,
             identity_public_key: payload.root_public_key,
             revocation_epoch: payload.revocations.head_epoch(),
-            nonce: nonce.to_vec(),
-            ciphertext,
-        })
+            passphrase_used: false,
+            kdf_params: BTreeMap::new(),
+            kdf_salt: salt,
+            nonce: random_nonce()?.to_vec(),
+            ciphertext: Vec::new(),
+        };
+
+        let nonce_bytes: [u8; 24] = package
+            .nonce
+            .as_slice()
+            .try_into()
+            .map_err(|_| VaultError::SerializationFailed)?;
+        let cipher = XChaCha20Poly1305::new(&package_key(seed)?.into());
+        package.ciphertext = cipher
+            .encrypt(
+                XNonce::from_slice(&nonce_bytes),
+                Payload {
+                    msg: plaintext.as_slice(),
+                    aad: &package.header_aad(),
+                },
+            )
+            .map_err(|_| VaultError::SerializationFailed)?;
+
+        Ok(package)
     }
 
     pub(crate) fn decrypt(&self, seed: &Seed) -> Result<VaultPayload, VaultError> {
-        if self.format_version != RECOVERY_PACKAGE_FORMAT_VERSION {
-            return Err(VaultError::UnsupportedPackageVersion(self.format_version));
-        }
+        self.check_supported()?;
         let nonce_bytes: [u8; 24] = self
             .nonce
             .as_slice()
             .try_into()
             .map_err(|_| VaultError::DecryptionFailed)?;
         let cipher = XChaCha20Poly1305::new(&package_key(seed)?.into());
-        let plaintext = cipher
-            .decrypt(XNonce::from_slice(&nonce_bytes), self.ciphertext.as_slice())
-            .map_err(|_| VaultError::DecryptionFailed)?;
+        let plaintext = Zeroizing::new(
+            cipher
+                .decrypt(
+                    XNonce::from_slice(&nonce_bytes),
+                    Payload {
+                        msg: self.ciphertext.as_slice(),
+                        aad: &self.header_aad(),
+                    },
+                )
+                .map_err(|_| VaultError::DecryptionFailed)?,
+        );
         serde_json::from_slice(&plaintext).map_err(|_| VaultError::SerializationFailed)
+    }
+
+    /// Rejects anything this build cannot open correctly.
+    ///
+    /// `passphrase_used: true` means a future build wrote a package whose key
+    /// derivation this build does not implement. Failing loudly is mandatory —
+    /// ignoring the flag would derive the wrong key and surface as
+    /// "wrong seed", sending the user hunting for a mnemonic that is correct.
+    fn check_supported(&self) -> Result<(), VaultError> {
+        if self.format_version != RECOVERY_PACKAGE_FORMAT_VERSION {
+            return Err(VaultError::UnsupportedPackageVersion(self.format_version));
+        }
+        if self.passphrase_used || !self.kdf_params.is_empty() {
+            return Err(VaultError::UnsupportedPackageVersion(self.format_version));
+        }
+        Ok(())
     }
 
     pub fn to_bytes(&self) -> Result<Vec<u8>, VaultError> {
         serde_json::to_vec(self).map_err(|_| VaultError::SerializationFailed)
     }
 
+    /// Version-checks on parse, not only on decrypt.
+    ///
+    /// The restore UI reads `revocation_epoch` from a parsed package before it
+    /// ever asks for the mnemonic, so an unsupported package must be rejected
+    /// at that point rather than after the user has typed 24 words.
     pub fn from_bytes(bytes: &[u8]) -> Result<Self, VaultError> {
-        serde_json::from_slice(bytes).map_err(|_| VaultError::SerializationFailed)
+        let package: Self =
+            serde_json::from_slice(bytes).map_err(|_| VaultError::SerializationFailed)?;
+        package.check_supported()?;
+        Ok(package)
     }
 }
 

--- a/docs/superpowers/plans/2026-07-27-airo-mind-phase-1-vault.md
+++ b/docs/superpowers/plans/2026-07-27-airo-mind-phase-1-vault.md
@@ -6,7 +6,7 @@
 
 **Architecture:** A new `rust/airo_mind` workspace crate holding pure-Rust cryptographic state. A BIP39 seed derives a root Ed25519 identity. Each device generates its *own* keypair locally and receives a root-signed certificate, so the seed never leaves the device that created it. Content keys are wrapped independently under each granting context key (envelope encryption over a hypergraph, not a key tree). A monotonic revocation ledger records destroyed keys, and restore is type-state enforced: a `RecoveryPackage` cannot become a usable `Vault` without first applying revocations.
 
-**Tech Stack:** Rust 2021, `ed25519-dalek` (signing), `chacha20poly1305` (XChaCha20-Poly1305 AEAD), `hkdf` + `sha2` (derivation), `bip39` (mnemonic), `zeroize`, `thiserror`, `serde` + `serde_json`.
+**Tech Stack:** Rust 2021, `ed25519-dalek` (signing), `chacha20poly1305` (XChaCha20-Poly1305 AEAD), `hkdf` + `sha2` + `hmac` (derivation, and BIP-39 implemented in-house), `zeroize`, `thiserror`, `serde` + `serde_json`.
 
 **Spec:** `docs/superpowers/specs/2026-07-27-airo-mind-runtime-design.md` §4, §6
 **Issues:** #1204 (scaffold), #1205 (governance), #1207–#1212 (Vault tasks), under epic #1193.
@@ -100,7 +100,7 @@ manifest.
 | `subtle` | `2` | approve — added by security R9, already transitive |
 | `ed25519-dalek` | `2` | **caveat:** floor `curve25519-dalek` at `>=4.1.3` |
 | `rand_core` | `0.6` | **caveat:** forced by the two above; migration issue required |
-| `bip39` | `2` | **caveat:** feature changes + a CC0 decision |
+| `hmac` | `0.12` | approve — replaces `bip39`, same `digest 0.10` generation |
 
 Version choice was validated as correct: `sha2 0.10` + `hkdf 0.12` share the
 `digest 0.10` generation `flutter_rust_bridge` already pulls in. Moving to
@@ -124,7 +124,29 @@ option. MIT-compatible, but binary distribution requires attribution and the
 non-endorsement clause. A BSD-3-Clause slot already exists in
 `docs/release/V2_THIRD_PARTY_NOTICES.md` — append, do not invent a mechanism.
 
-- [ ] **Step 3: Resolve the CC0 question — needs a decision before Task 2**
+- [ ] **Step 3: CC0 — DECIDED. Path B, implement BIP-39 in-house.**
+
+**`bip39`, `bitcoin_hashes`, and `hex-conservative` are dropped.** Task 2
+implements BIP-39 directly on the `sha2` and `hmac` already in the tree.
+
+Rationale, recorded so it is not relitigated:
+
+- ~200 LOC is small enough to audit completely
+- removes three supply-chain dependencies, one of which is CC0-1.0 — not
+  OSI-approved, and §4(a) expressly reserves the author's patent rights
+- verifiable against the complete official BIP-39 test vectors, not a sample
+- fits the long-term goal of minimising the trusted computing base
+
+Update the manifest: remove `bip39`, remove `default-features`/`features` for
+it, and add `hmac = "0.12"` (same `digest 0.10` generation as `sha2` and
+`hkdf`, so no new tree). File a governance scorecard for `hmac` on #1205.
+
+Dependency count drops from eleven to nine.
+
+The rest of Step 3 below is retained for the record only.
+
+<details>
+<summary>Original decision framing (resolved)</summary>
 
 `bip39`, `bitcoin_hashes`, and `hex-conservative` are **CC0-1.0**: not
 OSI-approved, and §4(a) expressly reserves the author's patent rights. Google's
@@ -144,6 +166,8 @@ Both paths are approved; pick one and record it on #1205.
 
 `tiny-bip39` was evaluated and **rejected** — it trades a license concern for a
 worse bus factor.
+
+</details>
 
 - [ ] **Step 4: Open the `rand_core` migration issue**
 
@@ -272,12 +296,11 @@ name = "airo_mind"
 crate-type = ["rlib"]
 
 [dependencies]
-# `rand` feature deliberately OFF: Mnemonic::from_entropy works without it, and
-# dropping it removes four crates and leaves ONE CSPRNG stack rather than two,
-# with an entropy buffer we own and can zeroize.
-# `zeroize` feature ON: without it the mnemonic's word indices are never wiped —
-# on the single most sensitive object in the design.
-bip39 = { version = "2", default-features = false, features = ["std", "zeroize"] }
+# BIP-39 is implemented in-house (Task 2), not taken as a dependency: ~200 LOC
+# auditable in full, no CC0 patent-non-grant on the recovery path, and three
+# fewer supply-chain crates. `hmac` is the same digest 0.10 generation as sha2
+# and hkdf, so it adds no new tree.
+hmac = "0.12"
 chacha20poly1305 = { version = "0.10", features = ["getrandom"] }
 # Explicit feature pinning, not defaults. `zeroize` is what keeps the root
 # private key out of freed memory; someone adding default-features = false for
@@ -444,22 +467,57 @@ Implements the first half of #1207.
 - Consumes: `VaultError` (Task 1)
 - Produces:
   - `Seed` — newtype over `[u8; 64]`, `ZeroizeOnDrop`, with `fn as_bytes(&self) -> &[u8; 64]`
-  - `fn generate_mnemonic() -> Zeroizing<String>` — 24 words
+  - `fn generate_mnemonic() -> Result<Zeroizing<String>, VaultError>` — 24 words
   - `fn seed_from_mnemonic(phrase: &str) -> Result<Seed, VaultError>`
 
 - [ ] **Step 1: Write the failing test**
 
 Create `rust/airo_mind/src/vault/seed.rs`:
 
+Create `rust/airo_mind/src/vault/wordlist.rs` — the official BIP-39 English
+wordlist, 2048 entries, public domain, verbatim from the specification:
+
+```rust
+//! BIP-39 English wordlist. Public domain, verbatim from the specification.
+//!
+//! Do not sort, reformat, or "clean up". Index order *is* the encoding — a
+//! single reordered entry silently changes every mnemonic ever generated.
+
+pub const WORDS: [&str; 2048] = [
+    "abandon", "ability", "able", "about", "above", "absent",
+    // ... 2042 more, in specification order ...
+    "zebra", "zero", "zone", "zoo",
+];
+```
+
+Source it from the BIP-39 repository's `english.txt` and verify with the
+checksum test in Step 1 rather than by eye.
+
+Create `rust/airo_mind/src/vault/seed.rs`:
+
 ```rust
 //! Recovery seed. The root of everything the user can ever recover.
+//!
+//! BIP-39 implemented in-house rather than taken as a dependency: ~200 lines
+//! auditable in full, verifiable against the complete official test vectors,
+//! and three fewer crates on the path that generates the recovery secret for
+//! medical and financial records.
 
-use bip39::Mnemonic;
+use hmac::Hmac;
+use rand_core::RngCore;
+use sha2::{Digest, Sha256, Sha512};
 use zeroize::{Zeroize, ZeroizeOnDrop, Zeroizing};
 
 use super::error::VaultError;
+use super::wordlist::WORDS;
 
-/// A 64-byte BIP39 seed. Zeroized on drop.
+/// 24 words = 256 bits of entropy + an 8-bit checksum.
+const ENTROPY_BYTES: usize = 32;
+const WORD_COUNT: usize = 24;
+/// Fixed by BIP-39. Not a tunable.
+const PBKDF2_ROUNDS: u32 = 2048;
+
+/// A 64-byte BIP-39 seed. Zeroized on drop.
 ///
 /// No `Clone`: the seed is the one secret whose compromise is total and
 /// unrecoverable, and silent duplication is how copies end up unzeroized.
@@ -477,24 +535,130 @@ impl Seed {
 /// Shown to the user exactly once. There is no other copy, and no server-side
 /// recovery path — that is the product promise, and it is also the reason the
 /// onboarding flow (#1234) must confirm the user recorded it.
-pub fn generate_mnemonic() -> Zeroizing<String> {
-    // `Zeroizing` because this is the root secret in plaintext. The bip39
-    // `zeroize` feature (pinned in Cargo.toml) covers the Mnemonic's internal
-    // word indices; this covers the String we hand back.
-    Zeroizing::new(
-        Mnemonic::generate(24)
-            .expect("24 is a valid BIP39 word count")
-            .to_string(),
-    )
+pub fn generate_mnemonic() -> Result<Zeroizing<String>, VaultError> {
+    let mut entropy = Zeroizing::new([0u8; ENTROPY_BYTES]);
+    rand_core::OsRng
+        .try_fill_bytes(entropy.as_mut())
+        .map_err(|_| VaultError::RngUnavailable)?;
+    Ok(mnemonic_from_entropy(&entropy))
+}
+
+/// Encodes entropy as a mnemonic. Separated from generation so the official
+/// test vectors can drive it directly.
+fn mnemonic_from_entropy(entropy: &[u8; ENTROPY_BYTES]) -> Zeroizing<String> {
+    // Checksum: the first `entropy_bits / 32` bits of SHA-256(entropy).
+    let checksum = Sha256::digest(entropy);
+    let checksum_bits = ENTROPY_BYTES * 8 / 32; // 8 for 256-bit entropy
+
+    // Concatenate entropy || checksum bits, then read 11 bits per word.
+    let mut bits = Vec::with_capacity(ENTROPY_BYTES * 8 + checksum_bits);
+    for byte in entropy.iter() {
+        for i in (0..8).rev() {
+            bits.push((byte >> i) & 1 == 1);
+        }
+    }
+    for i in 0..checksum_bits {
+        bits.push((checksum[i / 8] >> (7 - (i % 8))) & 1 == 1);
+    }
+
+    let words: Vec<&str> = bits
+        .chunks(11)
+        .map(|chunk| {
+            let index = chunk.iter().fold(0usize, |acc, bit| (acc << 1) | *bit as usize);
+            WORDS[index]
+        })
+        .collect();
+
+    Zeroizing::new(words.join(" "))
 }
 
 /// Derives the 64-byte seed from a mnemonic phrase.
 ///
-/// No passphrase. Adding one later is a breaking change to every existing
-/// recovery package, so it is deliberately excluded rather than defaulted.
+/// Validates word membership and the checksum before deriving — a typo must
+/// fail here, not silently produce a valid-looking seed for the wrong vault.
+///
+/// No passphrase in v1. The Recovery Package reserves `passphrase_used`,
+/// `kdf_params`, and `kdf_salt` so the option survives; see Task 8.
 pub fn seed_from_mnemonic(phrase: &str) -> Result<Seed, VaultError> {
-    let mnemonic = Mnemonic::parse(phrase).map_err(|_| VaultError::InvalidMnemonic)?;
-    Ok(Seed(mnemonic.to_seed("")))
+    let words: Vec<&str> = phrase.split_whitespace().collect();
+    if words.len() != WORD_COUNT {
+        return Err(VaultError::InvalidMnemonic);
+    }
+
+    // Word → index. Linear scan over 2048 entries is fine here; this runs once
+    // per restore, and a binary search would depend on the list being sorted,
+    // which is a property we deliberately do not assert.
+    let mut bits = Vec::with_capacity(WORD_COUNT * 11);
+    for word in &words {
+        let index = WORDS
+            .iter()
+            .position(|candidate| candidate == word)
+            .ok_or(VaultError::InvalidMnemonic)?;
+        for i in (0..11).rev() {
+            bits.push((index >> i) & 1 == 1);
+        }
+    }
+
+    let entropy_bits = ENTROPY_BYTES * 8;
+    let mut entropy = Zeroizing::new([0u8; ENTROPY_BYTES]);
+    for (i, bit) in bits[..entropy_bits].iter().enumerate() {
+        if *bit {
+            entropy[i / 8] |= 1 << (7 - (i % 8));
+        }
+    }
+
+    // Verify the checksum in constant time — a mismatch is a typo, and timing
+    // must not reveal how many words were right.
+    let expected = Sha256::digest(entropy.as_ref());
+    let checksum_bits = entropy_bits / 32;
+    let mut diff = 0u8;
+    for i in 0..checksum_bits {
+        let actual = u8::from(bits[entropy_bits + i]);
+        let want = (expected[i / 8] >> (7 - (i % 8))) & 1;
+        diff |= actual ^ want;
+    }
+    if diff != 0 {
+        return Err(VaultError::InvalidMnemonic);
+    }
+
+    // PBKDF2-HMAC-SHA512, 2048 rounds, salt = "mnemonic" || passphrase.
+    // Passphrase is empty in v1.
+    Ok(Seed(pbkdf2_hmac_sha512(
+        phrase.as_bytes(),
+        b"mnemonic",
+        PBKDF2_ROUNDS,
+    )))
+}
+
+/// PBKDF2-HMAC-SHA512 producing exactly 64 bytes — one block, since SHA-512's
+/// output is 64 bytes, so the block-index loop collapses to a single pass.
+///
+/// Hand-written rather than pulling the `pbkdf2` crate: this is the whole
+/// algorithm, it is driven entirely by the official BIP-39 vectors in Step 1,
+/// and it keeps the trusted computing base on the recovery path to `sha2` and
+/// `hmac` alone.
+fn pbkdf2_hmac_sha512(password: &[u8], salt: &[u8], rounds: u32) -> [u8; 64] {
+    use hmac::Mac;
+
+    let mut mac = <Hmac<Sha512> as Mac>::new_from_slice(password)
+        .expect("HMAC accepts a key of any length");
+    mac.update(salt);
+    mac.update(&1u32.to_be_bytes()); // block index, big-endian
+    let mut u = mac.finalize().into_bytes();
+
+    let mut out = [0u8; 64];
+    out.copy_from_slice(&u);
+
+    for _ in 1..rounds {
+        let mut mac = <Hmac<Sha512> as Mac>::new_from_slice(password)
+            .expect("HMAC accepts a key of any length");
+        mac.update(&u);
+        u = mac.finalize().into_bytes();
+        for (acc, byte) in out.iter_mut().zip(u.iter()) {
+            *acc ^= byte;
+        }
+    }
+    out
 }
 
 #[cfg(test)]
@@ -503,19 +667,19 @@ mod tests {
 
     #[test]
     fn generated_mnemonic_has_24_words() {
-        let phrase = generate_mnemonic();
+        let phrase = generate_mnemonic().unwrap();
         assert_eq!(phrase.split_whitespace().count(), 24);
     }
 
     #[test]
     fn generated_mnemonic_round_trips_to_a_seed() {
-        let phrase = generate_mnemonic();
+        let phrase = generate_mnemonic().unwrap();
         assert!(seed_from_mnemonic(&phrase).is_ok());
     }
 
     #[test]
     fn same_mnemonic_always_yields_the_same_seed() {
-        let phrase = generate_mnemonic();
+        let phrase = generate_mnemonic().unwrap();
         let a = seed_from_mnemonic(&phrase).unwrap();
         let b = seed_from_mnemonic(&phrase).unwrap();
         assert_eq!(a.as_bytes(), b.as_bytes());
@@ -523,24 +687,103 @@ mod tests {
 
     #[test]
     fn two_generated_mnemonics_differ() {
-        assert_ne!(generate_mnemonic(), generate_mnemonic());
+        assert_ne!(*generate_mnemonic().unwrap(), *generate_mnemonic().unwrap());
     }
 
     #[test]
-    fn known_vector_is_stable_across_platforms() {
-        // BIP39 test vector. If this assertion ever changes, every existing
-        // recovery package in the world stops working. Treat a failure here as
-        // a release blocker, never as a test to update.
-        let phrase = "abandon abandon abandon abandon abandon abandon abandon \
-                      abandon abandon abandon abandon abandon abandon abandon \
-                      abandon abandon abandon abandon abandon abandon abandon \
-                      abandon abandon art";
-        let seed = seed_from_mnemonic(phrase).unwrap();
+    fn wordlist_matches_the_specification() {
+        // Index order IS the encoding: one moved entry silently changes every
+        // mnemonic ever generated, and no other test would notice.
+        //
+        // The expected digest is not written here by hand. Compute it once from
+        // the official english.txt and paste the result — see Step 3.
+        assert_eq!(WORDS.len(), 2048);
+        assert_eq!(WORDS[0], "abandon");
+        assert_eq!(WORDS[2047], "zoo");
         assert_eq!(
-            hex_lower(seed.as_bytes()),
-            "5eb00bbddcf069084889a8ab9155568165f5c453ccb85e70811aaed6f6da5fc1\
-             9a5ac40b389cd370d086206dec8aa6c43daea6690f20ad3d8d48b2d2ce9e38e4"
+            hex_lower(&Sha256::digest((WORDS.join("\n") + "\n").as_bytes())),
+            include_str!("../../tests/fixtures/bip39/english.txt.sha256").trim()
         );
+    }
+
+    #[test]
+    fn official_vectors_encode_and_derive_correctly() {
+        // Drives the COMPLETE Trezor reference vector set from a checked-in
+        // fixture. Do not transcribe vectors by hand into this file: a
+        // mistyped expectation either fails mysteriously or, worse, gets
+        // "fixed" by bending the implementation to match it.
+        //
+        // Fixture format, one case per line, tab-separated:
+        //     <entropy_hex>\t<mnemonic>\t<seed_hex>
+        // Only the 256-bit (24-word) cases apply here; skip the rest.
+        let raw = include_str!("../../tests/fixtures/bip39/vectors.tsv");
+        let mut checked = 0;
+
+        for line in raw.lines().filter(|l| !l.trim().is_empty()) {
+            let mut parts = line.split('\t');
+            let entropy_hex = parts.next().expect("entropy column");
+            let expected_phrase = parts.next().expect("mnemonic column");
+            let expected_seed = parts.next().expect("seed column");
+
+            if entropy_hex.len() != ENTROPY_BYTES * 2 {
+                continue; // not a 24-word case
+            }
+
+            let entropy: [u8; ENTROPY_BYTES] =
+                hex_bytes(entropy_hex).try_into().expect("32 bytes");
+
+            let phrase = mnemonic_from_entropy(&entropy);
+            assert_eq!(&*phrase, expected_phrase, "encoding {entropy_hex}");
+
+            let seed = seed_from_mnemonic(&phrase).unwrap();
+            assert_eq!(hex_lower(seed.as_bytes()), expected_seed, "derivation {entropy_hex}");
+
+            checked += 1;
+        }
+
+        // Guards against an empty or truncated fixture silently passing.
+        assert!(checked >= 8, "expected the full 24-word vector set, got {checked}");
+    }
+
+    #[test]
+    fn a_single_wrong_word_fails_the_checksum() {
+        // A typo must fail here, not silently derive a valid-looking seed for
+        // a vault that does not exist.
+        let phrase = generate_mnemonic().unwrap();
+        let mut words: Vec<&str> = phrase.split_whitespace().collect();
+        words[5] = if words[5] == "zoo" { "abandon" } else { "zoo" };
+        assert_eq!(
+            seed_from_mnemonic(&words.join(" ")),
+            Err(VaultError::InvalidMnemonic)
+        );
+    }
+
+    #[test]
+    fn a_word_outside_the_list_is_rejected() {
+        let phrase = generate_mnemonic().unwrap();
+        let mut words: Vec<&str> = phrase.split_whitespace().collect();
+        words[0] = "notabip39word";
+        assert_eq!(
+            seed_from_mnemonic(&words.join(" ")),
+            Err(VaultError::InvalidMnemonic)
+        );
+    }
+
+    #[test]
+    fn wrong_word_count_is_rejected() {
+        let phrase = generate_mnemonic().unwrap();
+        let short: Vec<&str> = phrase.split_whitespace().take(23).collect();
+        assert_eq!(
+            seed_from_mnemonic(&short.join(" ")),
+            Err(VaultError::InvalidMnemonic)
+        );
+    }
+
+    fn hex_bytes(hex: &str) -> Vec<u8> {
+        (0..hex.len())
+            .step_by(2)
+            .map(|i| u8::from_str_radix(&hex[i..i + 2], 16).unwrap())
+            .collect()
     }
 
     #[test]
@@ -561,6 +804,7 @@ Modify `rust/airo_mind/src/vault/mod.rs` — add below the existing `mod error;`
 
 ```rust
 mod seed;
+mod wordlist;
 
 pub use seed::{generate_mnemonic, seed_from_mnemonic, Seed};
 ```
@@ -568,16 +812,39 @@ pub use seed::{generate_mnemonic, seed_from_mnemonic, Seed};
 - [ ] **Step 2: Run test to verify it fails**
 
 Run: `cargo test --manifest-path rust/Cargo.toml -p airo_mind seed`
-Expected: FAIL to compile — `bip39` not yet resolved, or `Mnemonic::generate` signature mismatch.
+Expected: FAIL to compile — `wordlist` module and the fixtures do not exist yet.
 
-- [ ] **Step 3: Reconcile against the real `bip39` API**
+- [ ] **Step 3: Vendor the official wordlist and vectors**
 
-The code above targets `bip39` v2. Run `cargo doc -p bip39 --open` or read `~/.cargo/registry/src/*/bip39-2*/src/lib.rs` and adjust the two call sites (`Mnemonic::generate`, `Mnemonic::parse`, `to_seed`) to the actual signatures. Do **not** change the known-vector assertion to make a test pass — if the vector fails, the derivation is wrong.
+Both are public domain and come from the BIP-39 specification repository
+(`bitcoin/bips`, BIP-0039). **Copy them; do not transcribe by hand and do not
+generate them from memory.** A mistyped vector either fails mysteriously or, worse,
+gets "fixed" by bending the implementation to match it.
+
+```bash
+mkdir -p rust/airo_mind/tests/fixtures/bip39
+# english.txt — 2048 words, newline separated, specification order
+curl -sSL https://raw.githubusercontent.com/bitcoin/bips/master/bip-0039/english.txt \
+  -o rust/airo_mind/tests/fixtures/bip39/english.txt
+# record its digest for the wordlist guard test
+shasum -a 256 rust/airo_mind/tests/fixtures/bip39/english.txt \
+  | cut -d' ' -f1 > rust/airo_mind/tests/fixtures/bip39/english.txt.sha256
+```
+
+Then generate `src/vault/wordlist.rs` from `english.txt` (a one-off script is
+fine; commit the generated file, not the script), and build
+`tests/fixtures/bip39/vectors.tsv` from the Trezor reference vectors
+(`trezor/python-mnemonic`, `vectors.json`), tab-separated as
+`entropy_hex \t mnemonic \t seed_hex`, keeping every case.
+
+Both fixtures are checked in. This crate must build and test offline — CI has
+no network, and a vendored vector set is also a record of exactly what was
+verified.
 
 - [ ] **Step 4: Run test to verify it passes**
 
 Run: `cargo test --manifest-path rust/Cargo.toml -p airo_mind seed`
-Expected: PASS, 6 tests
+Expected: PASS — wordlist guard, the full official vector set, and the four rejection cases
 
 - [ ] **Step 5: Commit**
 
@@ -724,7 +991,7 @@ mod tests {
     fn signature_fails_under_a_different_identity() {
         let mine = RootIdentity::from_seed(&test_seed()).unwrap();
         let theirs = RootIdentity::from_seed(
-            &seed_from_mnemonic(&crate::vault::generate_mnemonic()).unwrap(),
+            &seed_from_mnemonic(&crate::vault::generate_mnemonic().unwrap()).unwrap(),
         )
         .unwrap();
         let sig = theirs.sign(b"authorize device");
@@ -735,7 +1002,7 @@ mod tests {
     fn different_seeds_produce_different_identities() {
         let a = RootIdentity::from_seed(&test_seed()).unwrap();
         let b = RootIdentity::from_seed(
-            &seed_from_mnemonic(&crate::vault::generate_mnemonic()).unwrap(),
+            &seed_from_mnemonic(&crate::vault::generate_mnemonic().unwrap()).unwrap(),
         )
         .unwrap();
         assert_ne!(a.public_key(), b.public_key());
@@ -763,7 +1030,7 @@ Expected: FAIL to compile — module not yet declared, or `ed25519_dalek` trait 
 - [ ] **Step 4: Run test to verify it passes**
 
 Run: `cargo test --manifest-path rust/Cargo.toml -p airo_mind identity`
-Expected: PASS, 6 tests
+Expected: PASS — wordlist guard, the full official vector set, and the four rejection cases
 
 - [ ] **Step 5: Commit**
 
@@ -928,7 +1195,7 @@ mod tests {
     fn certificate_fails_against_a_different_root() {
         let root = RootIdentity::from_seed(&test_seed()).unwrap();
         let stranger = RootIdentity::from_seed(
-            &seed_from_mnemonic(&crate::vault::generate_mnemonic()).unwrap(),
+            &seed_from_mnemonic(&crate::vault::generate_mnemonic().unwrap()).unwrap(),
         )
         .unwrap();
         let certificate = DeviceCertificate::issue(&root, &DeviceKey::generate(), 1);
@@ -981,7 +1248,7 @@ Expected: FAIL to compile — module not declared.
 - [ ] **Step 4: Run test to verify it passes**
 
 Run: `cargo test --manifest-path rust/Cargo.toml -p airo_mind device`
-Expected: PASS, 6 tests
+Expected: PASS — wordlist guard, the full official vector set, and the four rejection cases
 
 - [ ] **Step 5: Commit**
 
@@ -2354,7 +2621,7 @@ mod tests {
     fn a_different_seed_cannot_decrypt() {
         let (vault, seed) = seeded_vault();
         let package = RecoveryPackage::export(&vault, &seed).unwrap();
-        let stranger = seed_from_mnemonic(&generate_mnemonic()).unwrap();
+        let stranger = seed_from_mnemonic(&generate_mnemonic().unwrap()).unwrap();
 
         assert_eq!(package.decrypt(&stranger), Err(VaultError::DecryptionFailed));
     }

--- a/docs/superpowers/plans/2026-07-27-airo-mind-phase-1-vault.md
+++ b/docs/superpowers/plans/2026-07-27-airo-mind-phase-1-vault.md
@@ -3194,7 +3194,14 @@ established:
   - `relabelling_a_context_id_breaks_the_wrapping`
   - `a_wrapping_cannot_be_moved_to_another_envelope`
 - [ ] `SealedRestore` has no method returning a `Vault` and no method exposing key material — verified by a reviewer, not only by tests
-- [ ] No `fill_bytes` anywhere; `grep -rn "fill_bytes" rust/airo_mind/src` returns only `try_fill_bytes`
+- [ ] **Repository-wide verification passes (#1287), not reviewer memory.** These are CI checks because the last two defects were both "fixed in one file, forgotten in another":
+  - no `panic!`, `unwrap()`, `expect()`, or `todo!()` outside `#[cfg(test)]`
+  - no `fill_bytes`; only `try_fill_bytes`
+  - no direct RNG use outside `random_key` / `random_nonce`
+  - no `AeadCore::generate_nonce`
+  - every `Serialize`/`Deserialize` type has a round-trip test
+  - every AAD-bound field has a tamper test (invariant I3)
+  - no `derive(Debug)`, `derive(Clone)`, or `derive(PartialEq)` on a secret type
 - [ ] No `derive(Debug)`, `derive(Clone)`, or `derive(PartialEq)` on any secret type
 - [ ] `crate-type = ["rlib"]`; no `flutter_rust_bridge` dependency
 - [ ] Third-party notices updated for BSD-3-Clause, and for CC0 if Path A was chosen

--- a/docs/superpowers/specs/2026-07-27-airo-mind-runtime-design.md
+++ b/docs/superpowers/specs/2026-07-27-airo-mind-runtime-design.md
@@ -588,6 +588,72 @@ encryption, search projection — and it carries zero regulatory surface.
 
 Each is a follow-on milestone. None is a prerequisite.
 
+## 11a. Runtime invariants
+
+Non-negotiable. These are not guidelines and not subject to a capability's
+judgement. A change that violates one of these is a defect regardless of what
+it enables.
+
+### I1 — Only the operation log and the encrypted content store are durable
+
+Everything else is a **projection** and must be disposable.
+
+```
+Durable          Operation Log · encrypted Content Store
+Disposable       knowledge graph · memory graph · search index · FTS
+                 embeddings · AI cache · timeline · calendar · analytics
+```
+
+Two consequences, both testable:
+
+- **Destroying a projection must never lose data.** Any projection can be
+  deleted at any time and rebuilt from the log. If a value exists only in a
+  projection, it is a defect, not a feature.
+- **Destroying content must invalidate every projection derived from it.**
+  Otherwise crypto-shredding is incomplete by construction — an embedding of a
+  destroyed note is a lossy copy of that note.
+
+### I2 — No capability may create durable storage outside the runtime
+
+A capability that wants persistence has exactly one path:
+
+```
+Capability → Operation → Content → Operation Log
+```
+
+Never a private SQLite database, a JSON file, a preferences entry, a cache
+directory, or any other store it owns.
+
+This is not tidiness. The moment a capability writes durable state the runtime
+cannot see, `DestroyContent`, backup, recovery, sync, projection rebuild, and
+crypto-shredding all become **incomplete by construction** — each one silently
+missing whatever that capability kept to itself. The user is then told their
+data was destroyed while a copy survives in a file nobody enumerated.
+
+Enforcement is a Phase 4 requirement on the capability runtime, not a review
+convention: a Tier 1 capability has no filesystem access to violate this with,
+and Tier 2's sandbox prohibits file access outright (§5.1).
+
+### I3 — Every claimed security property has an automated tamper test
+
+If this document, a store listing, or a UI string claims a security property,
+a test must demonstrate it by attempting the violation and observing failure.
+
+```
+Claim:  the header AAD authenticates revocation_epoch
+Test:   modify revocation_epoch → decrypt fails
+```
+
+Required at minimum for: `revocation_epoch`, `identity_public_key`, package
+format version, schema fingerprint, capability manifest hash, content wrapping
+`content_id` and `context_id` binding, and device certificate fields.
+
+The reason this is an invariant rather than good practice: revision 2 of the
+Phase 1 plan **stated** that the recovery package header was authenticated as
+AAD, in the section recording that the review finding had been applied. It was
+not. Prose asserting a security property is not evidence that the property
+holds, and reviewer memory is not a control.
+
 ## 12. Open decisions, assigned to subsystem specs
 
 These are deliberately unresolved here. Resolving them without implementation

--- a/docs/superpowers/specs/2026-07-27-meeting-intelligence-coverage.md
+++ b/docs/superpowers/specs/2026-07-27-meeting-intelligence-coverage.md
@@ -1,0 +1,174 @@
+# Meeting Intelligence — Coverage Against Airo, and Gaps to Adopt
+
+Status: **Research.** Input to milestones 13, 19, 20.
+Date: 2026-07-27
+Reference feature set: Meetily (local-first meeting transcription and summarisation).
+Owner: Product Manager (Airo Engineering Council)
+
+Answers the question "are we supporting this?" against what is actually in the
+repository, not against intent. Every row is checked.
+
+---
+
+## 1. Summary
+
+- **Most of the list is already scoped**, across milestone 13 (Audio Scribe,
+  #266–#269, #306), the meeting-intelligence issues (#241, #242, #248), and the
+  reliability phases (#504, #511, #512).
+- **`app/lib/features/meeting/` is real and substantial** — a full domain model
+  with `MeetingRecord`, `TranscriptChunk`, `MeetingSummary`, `MeetingSegment`,
+  `MeetingAudioMetadata`, `MeetingIntelligence`, a redaction service, and an
+  intelligence pipeline.
+- **Transcription itself is not built.** No Whisper, whisper.cpp, or Parakeet
+  code exists anywhere in `packages/`, `app/`, or `rust/`. The only hit for
+  "whisper" in the tree is a comment in `intent_parser.dart`.
+- **Three capabilities are not covered at all:** simultaneous microphone and
+  system-audio capture with ducking, desktop GPU acceleration
+  (Metal/CoreML, CUDA, Vulkan), and document export (PDF/DOCX/Markdown).
+- **One is refused, deliberately:** self-hosted team deployment. It contradicts
+  the v1 trust boundary.
+- **One item Airo is structurally better at:** GDPR audit trails. The operation
+  log *is* an append-only audit trail, so this is a property of the
+  architecture rather than a feature to build.
+- **One existing violation found.** `DriftMeetingRepository` persists meetings
+  to a feature-owned SQLite database, outside the operation log. Under runtime
+  invariant **I2** that is a defect, and it is the first concrete instance.
+
+---
+
+## 2. Coverage table
+
+| Capability | Status | Where |
+|---|---|---|
+| Works offline | **Yes** | Core positioning; runtime is local-first by construction |
+| Local-first, no data leaves the machine | **Yes** | Design spec §7; stronger than the reference — no cloud OAuth broker, no telemetry |
+| Real-time transcription | **Planned, not built** | #248 Live Notes, #241 Android recorder + whisper.cpp, #242 iOS |
+| AI-powered summaries | **Planned** | `meeting_summary.dart` entity exists; `core_ai` has LiteRT / Gemini Nano / GGUF routers |
+| macOS, Windows, Linux | **Partial** | Flutter desktop targets exist (`app/macos`, `app/windows`, `app/linux`); no evidence of a shipped desktop build |
+| Open source | **Yes** | MIT, public repo |
+| Flexible AI providers | **Partial** | #287 remote model servers with LAN discovery, #308 local OpenAI-compatible API, #139 on-prem, #132 Bedrock, #136 Vertex. Ollama-style local is #277/#284. |
+| Local transcription (Whisper) | **Planned** | #241, #242, #248, #511 robustness |
+| Local transcription (Parakeet) | **Not covered** | No mention anywhere in the tree |
+| Import audio files / re-transcribe | **Planned** | #269 import, #306 formats and multi-clip |
+| Mic + system audio simultaneously, with ducking | **NOT COVERED** | Gap — see §3 |
+| Hardware acceleration, mobile | **Planned** | #279 Pixel TPU, NPU, GPU, CPU |
+| Hardware acceleration, desktop (Metal/CoreML, CUDA, Vulkan) | **NOT COVERED** | Gap — see §3 |
+| Custom summary templates | **Conceptually covered** | Capability templates, milestone 20 (#1246). Not specified for meetings. |
+| Export PDF / DOCX / Markdown | **NOT COVERED** | Gap — see §3 |
+| Auto-detect and join meetings | **Not covered** | See §4 — needs a decision, not just an issue |
+| Speaker identification | **Planned** | #267 enrolment, #504 speaker learning, #512 diarisation validation |
+| Chat with meetings | **Planned** | #300 Memory Chat grounded in user history |
+| Calendar integration | **Partial** | `CalendarEvent` is a core ontology entity (#1223); no calendar connector exists |
+| Self-hosted deployment for teams | **REFUSED** | Contradicts the v1 trust boundary — see §4 |
+| GDPR compliance, audit trails | **Structurally superior** | The operation log is an append-only signed audit trail. Plus real erasure via crypto-shredding, which most "GDPR-compliant" products cannot offer. |
+
+---
+
+## 3. Gaps worth adopting
+
+### G1 — Simultaneous microphone and system-audio capture
+
+The single most valuable missing piece. Without system audio, only the local
+speaker is transcribed, which makes remote-meeting transcription close to
+useless — and remote meetings are the use case.
+
+Needs: dual-stream capture, intelligent ducking, clipping prevention, and a
+per-platform capture path (macOS requires a system-audio driver or
+ScreenCaptureKit; Windows uses WASAPI loopback; Linux uses PulseAudio/PipeWire
+monitor sources).
+
+**Consent obligation, binding:** capturing system audio records every remote
+participant. Eleven US states require all-party consent, and interstate calls
+default to the most restrictive jurisdiction (`2026-07-27-airo-mind-roadmap.md`
+§4). A visible indicator is **not** legally sufficient consent. No system-audio
+capture ships without a consent design reviewed by counsel.
+
+### G2 — Desktop GPU acceleration
+
+Mobile acceleration is scoped (#279). Desktop is not, and desktop is where
+long meeting transcription actually runs. Metal + CoreML on Apple Silicon,
+CUDA on NVIDIA, Vulkan on AMD/Intel.
+
+The reference implementation enables these at build time with no runtime
+configuration, which is the right default — a user should not choose a
+backend.
+
+### G3 — Document export
+
+PDF, DOCX, and Markdown with formatting. Currently nothing in the tree exports
+a meeting artifact to a document.
+
+This is a good early test of invariant **I1**: an exported document is derived
+from content and must not become a second source of truth. Export writes a
+file the user owns and the runtime stops tracking — the same one-way boundary
+as capsule export (§7).
+
+### G4 — Parakeet as an alternative STT model
+
+NVIDIA Parakeet, via the ONNX conversion, alongside Whisper. Worth having as
+a second option for accuracy and speed trade-offs, but strictly after Whisper
+works. Not urgent.
+
+### G5 — Calendar connector
+
+`CalendarEvent` exists as a core ontology entity, so meetings can already
+attach to calendar entries structurally. What is missing is a connector that
+populates them.
+
+---
+
+## 4. Two items that need a decision, not an issue
+
+### Auto-detect and join meetings
+
+Joining a meeting means driving a third-party client, or joining as a bot with
+credentials. Both put Airo inside the meeting as a participant, which changes
+the consent story from "I am recording my own audio" to "an automated
+participant is recording everyone".
+
+Recommendation: **detect and prompt, never auto-join.** Detection (a calendar
+event is starting, a meeting app is in the foreground) is a local signal and
+is fine. Joining is an action with legal weight and belongs behind an explicit
+per-meeting approval — the same class as `#1235`'s destructive confirmations.
+
+### Self-hosted deployment for teams
+
+**Refused for v1**, consistent with the roadmap's existing refusals. It
+requires a multi-user trust domain, shared storage, and administrative
+control — none of which exist in a design whose trust boundary is one person's
+device mesh, and all of which reopen the human-to-human sharing question
+already refused (`roadmap.md` §2).
+
+If team meeting intelligence is wanted, it is a different product with a
+different threat model, not a deployment mode of this one.
+
+---
+
+## 5. The violation this analysis found
+
+`app/lib/features/meeting/infrastructure/storage/drift_meeting_repository.dart`
+persists meeting records, transcripts, summaries, and audio metadata into a
+feature-owned Drift/SQLite database via `core/database/app_database_native.dart`.
+
+Under design spec **I2** — *no capability may create durable storage outside
+the runtime* — this is a defect. Concretely, meeting data stored this way is
+invisible to:
+
+- `DestroyContent` — a destroyed meeting survives in the SQLite file
+- Backup and Recovery Package — meetings are not in the Vault or the log
+- Sync — meetings never reach another device
+- Projection rebuild — nothing can regenerate them
+- Crypto-shredding — the audio and transcript are not behind a content key
+
+The same pattern appears in `features/coins/data/datasources/`,
+`features/money/application/services/`, and the settings AI-storage dashboard.
+Meetings are simply the clearest case because the content is high-sensitivity
+and the erasure claim is loudest.
+
+This is not a reason to stop meeting work. It is the reason meeting storage
+should migrate to the runtime rather than grow further on its own schema —
+and it is worth knowing before #241, #242, and #248 add transcription data to
+that same database.
+
+Migration is not free and is not Phase 1 work. It belongs after the operation
+log and content store exist (#1194), tracked as its own issue.


### PR DESCRIPTION
Applies seven decisions from review. Docs only. **Stacked on #1286** — merge that first.

## 1. CC0 resolved: BIP-39 in-house

`bip39`, `bitcoin_hashes`, `hex-conservative` **dropped**. `hmac = "0.12"` added — same `digest 0.10` generation as `sha2`/`hkdf`, so no new tree. **Nine dependencies, not eleven.** No CC0 code enters the tree.

PBKDF2-HMAC-SHA512 is hand-written too (~20 lines; one block, since SHA-512 output is exactly 64 bytes), so the recovery path depends on `sha2` and `hmac` alone rather than pulling `pbkdf2` as a fourth crate.

**I had first written the expected seed hex and the wordlist digest from memory.** That is the worst kind of placeholder — a wrong crypto vector either fails mysteriously or gets "fixed" by bending the implementation to match it. Both are now vendored from the specification and driven from checked-in fixtures, with a digest guard on the wordlist (index order *is* the encoding — one reordered entry silently changes every mnemonic ever generated) and a minimum case count so a truncated vector file cannot pass silently.

## 2. Three runtime invariants — design spec §11a

**I1 — only the operation log and encrypted content store are durable.** Everything else is a projection. Destroying a projection must never lose data; destroying content must invalidate every projection derived from it.

**I2 — no capability may create durable storage outside the runtime.** One path: `Capability → Operation → Content → Operation Log`. Never a private SQLite database, JSON file, or cache it owns. Not tidiness — a capability writing state the runtime cannot see makes `DestroyContent`, backup, recovery, sync, and crypto-shredding **incomplete by construction**, and the user is told their data was destroyed while a copy survives in a file nobody enumerated.

**I3 — every claimed security property has an automated tamper test.** This is an invariant rather than good practice because revision 2 stated the recovery package header was authenticated as AAD, *in the section recording that the finding had been applied*, and it was not.

## 3. Definition of Done is now machine-checkable

The last two defects had the same shape: fixed in one file, forgotten in another. Reviewer memory is not a control. Moved to CI checks in #1287 — no `panic!`/`unwrap!`/`expect()` outside tests, no `fill_bytes`, no direct RNG outside the approved helpers, round-trip tests on every serialized type, tamper tests on every AAD-bound field, no `HashMap` in anything serialized.

## Also

`#297` renamed **Memory Vault → Memory Store**. `Vault` is now reserved vocabulary meaning identity, keys, revocations, trust — nothing else.

Council gate **retained** with an explicit verification checklist on `#1193`. Phase 1 now has exactly one gate left: the three outstanding reviews.

Refs #1193, #1205, #1207, #1287
