### PR TITLE
docs: invariant I4, architecture compliance, runtime API, and review checklists

### DIFF
--- a/docs/superpowers/specs/2026-07-27-airo-mind-review-checklists.md
+++ b/docs/superpowers/specs/2026-07-27-airo-mind-review-checklists.md
@@ -1,0 +1,140 @@
+# Airo Mind — Reusable Review Checklists
+
+Status: **Binding for every Airo Mind change.**
+Date: 2026-07-27
+Owner: Airo Engineering Council
+
+Council reviews should not produce one-off findings that have to be
+rediscovered next time. Each review run adds to these lists; every future
+capability is reviewed against them.
+
+These exist because two consecutive revisions of the Phase 1 Vault plan shipped
+defects of the same shape — a fix applied in one file and forgotten in another,
+and a security property recorded as applied that was never written. Neither was
+hard to find. Both survived review because nothing carried forward.
+
+Where a line can be a CI check it is marked **[CI]** and belongs in #1287 or
+#1294 rather than in a reviewer's head.
+
+---
+
+## Security checklist
+
+Applied by chief-security-officer to any change touching keys, content,
+operations, or the trust boundary.
+
+### Authenticated metadata
+- [ ] Every plaintext field that influences a security decision is bound as AAD or covered by a signature
+- [ ] AAD construction is injective — length-prefixed, domain-separated, no two distinct inputs producing the same bytes
+- [ ] **[CI]** Every AAD-bound field has a tamper test: modify it, assert failure (invariant I3)
+- [ ] Signing payloads are hand-built, never a serializer's output
+
+### Replay protection
+- [ ] Replaying the same log produces byte-identical state on every platform
+- [ ] **[CI]** No wall-clock, `HashMap` iteration, float formatting, or locale in any replay path
+- [ ] Operations are idempotent under re-delivery
+- [ ] Migrations are pure, total, and forward-only
+
+### Revocation
+- [ ] Revocation covers every subject type — content, context, device — not only the obvious one
+- [ ] Revocation merge is fail-**closed**: when two ledgers disagree, the outcome revokes more, never less
+- [ ] No path reaches usable key material without applying revocations
+- [ ] A revocation source carries provenance; an empty ledger cannot silently pass as a checked one
+
+### Recovery
+- [ ] Restore is deterministic: same package + same seed + same ledger ⇒ identical state
+- [ ] A backup predating a destruction cannot resurrect it
+- [ ] The recovery artifact grants access without carrying data
+- [ ] Restore fails closed on an unsupported format or an unknown protected mode
+
+### Tamper detection
+- [ ] Ciphertext modification is detected, not silently mis-decrypted
+- [ ] Identity binding is verified before any decrypted state is trusted
+- [ ] Format version is checked at parse time, not only at use time
+
+### Key lifecycle
+- [ ] Every secret type is `Zeroize` + `ZeroizeOnDrop`
+- [ ] **[CI]** No `derive(Debug)`, `derive(Clone)`, or `derive(PartialEq)` on a secret; equality is constant-time
+- [ ] Intermediate plaintext buffers are `Zeroizing`
+- [ ] Feature flags that provide zeroization are pinned explicitly, with a compile-time guard
+- [ ] Key material does not cross an FFI boundary; documented exceptions are enumerated and prohibited from logging
+
+---
+
+## Runtime checklist
+
+Applied by chief-architect to every capability and every runtime change.
+
+### The question that governs everything
+- [ ] **Can this be implemented entirely by emitting operations and consuming projections?** If no: either the runtime is missing something generic that should be added once for everyone, or the feature is bypassing the runtime. There is no third branch and no "this feature is special".
+
+### No direct persistence
+- [ ] **[CI]** The module declares `persistence: runtime | projection | ephemeral` and the declaration matches reality (§11b)
+- [ ] **[CI]** No SQLite, Drift, JSON file, preferences entry, or object store owned by a capability (invariants I2, I4)
+- [ ] The capability uses only the runtime API — `create_operation`, `attach_content`, `query_projection`, `instantiate_context`, `emit_event` — and names no storage engine
+
+### Replay determinism
+- [ ] State is derived from the log, never accumulated in place
+- [ ] Concurrent operations have a defined total order
+- [ ] **[CI]** Serialized structures use `BTreeMap`, never `HashMap`
+
+### Projection rebuilds
+- [ ] **[CI]** Every `projection` module has a rebuild-from-scratch test
+- [ ] Dropping the projection loses no data (invariant I1)
+- [ ] `DestroyContent` invalidates every projection derived from that content — including embeddings, search snippets, and caches
+- [ ] No value exists only in a projection
+
+### Migration determinism
+- [ ] Migrations transform interpretation at replay; the log is never rewritten
+- [ ] Every device running the same migration chain reaches the same state
+- [ ] Merge strategy does not change within a compatible version
+- [ ] Schema fingerprint changes when and only when the schema changes
+
+### Ontology discipline
+- [ ] Capability entities extend the core ontology, never an archetype directly
+- [ ] Domain meaning rides on labels, not new types
+- [ ] Safety class ratchets — stricter is allowed, looser is rejected at validation
+
+---
+
+## Rust checklist
+
+Applied by rust-architect to any change under `rust/`.
+
+### No panic paths
+- [ ] **[CI]** No `panic!`, `unwrap()`, `expect()`, `todo!()`, or `unreachable!()` outside `#[cfg(test)]`
+- [ ] **[CI]** No `fill_bytes` — `try_fill_bytes` only
+- [ ] **[CI]** No `AeadCore::generate_nonce`; RNG access goes through the approved helpers
+- [ ] Slice indexing and arithmetic cannot panic on hostile input
+
+### Error propagation
+- [ ] Errors carry enough context to debug without carrying secrets
+- [ ] No error variant is used for two unrelated failures — a mis-mapped variant misleads whoever debugs it next
+- [ ] Fallible constructors return `Result` rather than defaulting
+
+### Zeroization
+- [ ] Covered by the security checklist's key-lifecycle section; the Rust reviewer confirms the derives and drop order actually do what they claim
+- [ ] A `ZeroizeOnDrop` struct whose only field is `#[zeroize(skip)]` is flagged — it zeroizes nothing
+
+### Fuzz coverage
+- [ ] Every parser reachable from untrusted input has a fuzz target — recovery packages, capability manifests, operation headers, imported capsules
+- [ ] Fuzz targets run in CI on a schedule, not only locally
+
+### Property tests
+- [ ] Round-trip: encode then decode is the identity, for every serialized type
+- [ ] Merge is commutative, associative, and idempotent
+- [ ] Replay of any operation permutation converges
+- [ ] Revocation is monotonic — applying it twice equals applying it once
+
+### `unsafe`
+- [ ] The crate itself contains no `unsafe`
+- [ ] Transitive `unsafe` in audited third-party crypto crates is explicitly accepted and named, not passed over in silence
+
+---
+
+## How these are used
+
+1. A capability or runtime change opens with the relevant checklists in the PR body, unticked.
+2. The reviewing officer ticks what they verified **against the code**, not against the PR description. A line ticked because the summary said so is the exact failure this document exists to prevent.
+3. Anything a review discovers that is not on a list gets **added to the list** in the same PR. That is what makes the next review cheaper than the last.
+4. **[CI]** lines migrate out of here and into #1287 and #1294 as they are automated. A line that CI enforces is deleted from the human checklist — reviewer attention is scarce and should be spent on what machines cannot check.

--- a/docs/superpowers/specs/2026-07-27-airo-mind-runtime-design.md
+++ b/docs/superpowers/specs/2026-07-27-airo-mind-runtime-design.md
@@ -654,6 +654,113 @@ AAD, in the section recording that the review finding had been applied. It was
 not. Prose asserting a security property is not evidence that the property
 holds, and reviewer memory is not a control.
 
+### I4 — Runtime exclusivity
+
+**All durable user state originates from the runtime.** There is no alternate
+persistence path.
+
+```
+Capability
+    │
+    ▼
+Operation
+    │
+    ▼
+Runtime
+    ├── Operation Log
+    ├── Content Store
+    └── Vault
+```
+
+I2 says a capability must not create durable storage. I4 is the stronger
+statement it implies: durable state does not merely *avoid* other paths, it has
+exactly one origin.
+
+The distinction matters for classification. Under I4, a feature-owned SQLite
+database, JSON file, or object store is not technical debt to be scheduled — it
+is an **architectural violation**, and it is named as one. Debt is a trade
+someone chose; a violation is a defect that makes `DestroyContent`, backup,
+recovery, sync, projection rebuild, and crypto-shredding incomplete for that
+feature's data.
+
+Known violations at the time of writing: `DriftMeetingRepository`,
+`features/coins/`, `features/money/`, and the settings AI-storage dashboard.
+Migration is tracked on #1293.
+
+## 11b. Architecture compliance
+
+Invariants that only a reviewer can check are invariants that erode. Every
+module declares how it persists, and CI validates the declaration against what
+the code actually does.
+
+```yaml
+module:
+  persistence: runtime | projection | ephemeral
+```
+
+| Value | Meaning | Allowed to write |
+|---|---|---|
+| `runtime` | Durable user state, via operations | Nothing directly — the runtime writes |
+| `projection` | Derived, rebuildable, disposable | Its own index or cache, droppable at any time without data loss |
+| `ephemeral` | Process- or session-scoped | Temp files, in-memory caches, nothing that outlives a reinstall |
+
+Worked examples:
+
+| Module | Declared | Actual | Result |
+|---|---|---|---|
+| Meeting | `runtime` | Drift database | **fail** |
+| Memory projection | `projection` | rebuildable index | pass |
+| Image cache | `ephemeral` | temp files | pass |
+| Vault | `runtime` | encrypted keystore | pass |
+
+A module declaring `runtime` that opens a database fails. A module declaring
+`projection` whose data cannot be regenerated from the log fails — that one is
+only catchable by a rebuild test, so `projection` modules must have one.
+
+## 11c. The runtime API
+
+**A capability never knows where data lives.** It receives a small, fixed
+surface:
+
+```rust
+create_operation()
+attach_content()
+query_projection()
+instantiate_context()
+emit_event()
+```
+
+Nothing else. No SQL. No filesystem. No encryption primitives. No sync. No key
+material.
+
+This is what makes I2 and I4 enforceable rather than aspirational: a Tier 1
+capability is declarative data and has no way to reach a filesystem, and a
+Tier 2 capability's sandbox prohibits file and network access outright (§5.1).
+The API is the only door, so the invariant holds by construction instead of by
+review.
+
+It is also the compatibility boundary. Storage can move from SQLite to
+something else in 2035 without touching a single capability, because no
+capability ever named a storage engine.
+
+### The test every capability is judged by
+
+> **Can it be implemented entirely by emitting operations and consuming
+> projections?**
+
+If no, exactly one of two things is true:
+
+1. **The runtime is missing a generic capability** that should be added once,
+   for everyone — in which case add it to the runtime, not to the feature.
+2. **The feature is attempting to bypass the runtime** — in which case the
+   answer is no.
+
+There is no third branch, and in particular there is no "this feature is
+special". Meeting intelligence is the current test of this: it is a capability
+that captures audio, transcribes, extracts entities, emits operations, and
+builds notes, tasks, and calendar events. It is **not** a runtime feature, and
+it gets no privileged storage path.
+
 ## 12. Open decisions, assigned to subsystem specs
 
 These are deliberately unresolved here. Resolving them without implementation


### PR DESCRIPTION
Stops adding features and starts protecting the architecture. Docs only.

The argument for this PR is empirical: **the invariants added in #1288 found four real violations in existing code within a day of being written.** That makes them useful rather than theoretical, and it makes enforcement the next thing worth building.

## I4 — Runtime exclusivity

> All durable user state originates from the runtime. There is no alternate persistence path.

I2 said a capability must not create durable storage. I4 is the stronger statement it implies.

The distinction is **classification**. Under I4, a feature-owned SQLite database is not technical debt to be scheduled — it is an **architectural violation**. Debt is a trade someone chose. A violation is a defect that makes `DestroyContent`, backup, recovery, sync, projection rebuild, and crypto-shredding incomplete for that feature's data.

For meetings specifically that means our claim — *destroyed content cannot be recovered* — **is currently false**, because a destroyed meeting survives in the Drift file.

## Architecture compliance — #1294

Every module declares `persistence: runtime | projection | ephemeral`; CI validates the declaration against what the code does. Invariants only a reviewer can check are invariants that erode.

This **fails on day one** on four modules. That is the point — they land on a dated exception list that shrinks with each migration and can only grow by officer sign-off. An exception list that can grow freely is just a checkbox.

## The runtime API — #1295

Capabilities receive `create_operation`, `attach_content`, `query_projection`, `instantiate_context`, `emit_event`. Nothing else. No SQL, no filesystem, no encryption, no sync, no key material.

This is the load-bearing piece: it makes I2 and I4 hold **by construction** rather than by review, since the API is the only door. It is also the compatibility boundary — storage can change in 2035 without touching a capability, because no capability ever named a storage engine.

## Migration strategy changed — #1293

**Adapters first, not per-feature rewrites.** One adapter implementing the existing repository interfaces on top of the runtime API; point features at it one at a time; delete the old implementations in a single change at the end.

Written and reviewed once instead of four times, each switch small and revertible, and both paths can run side by side during verification.

Meetings go first — not because it is easiest, but because #241/#242/#248 are about to add transcript data to that schema, and migrating one table is cheaper than four.

## Meeting stays a capability — recorded on #266

No privileged storage path, no runtime special case. It proves the runtime precisely by being ordinary. First implementation stops at: capture, transcribe, extract entities, emit operations, build notes, create tasks, create calendar events.

## Reusable review checklists

New: `2026-07-27-airo-mind-review-checklists.md` — security, runtime, and Rust lists so council reviews produce durable artifacts instead of findings that must be rediscovered.

Two rules that matter more than the contents:

- **A line is ticked against the code, never against the PR description.** Ticking because the summary said so is the exact failure that let the AAD finding be recorded as applied while never being written.
- **Lines CI can enforce are marked and migrate out** to #1287 and #1294, then get deleted from the human list. Reviewer attention is scarce and should be spent on what machines cannot check.

## The question recorded for the long run

> **Can it be implemented entirely by emitting operations and consuming projections?**

If no: either the runtime is missing something generic that should be added once for everyone, or the feature is bypassing the runtime. There is no third branch and no special cases.

Refs #1193, #1266, #1287, #1293, #1294, #1295
