### PR TITLE
docs: one sync model, invariants I5-I6, Runtime Architect, revised runtime API

### DIFF
--- a/docs/superpowers/specs/2026-07-27-airo-mind-review-checklists.md
+++ b/docs/superpowers/specs/2026-07-27-airo-mind-review-checklists.md
@@ -79,7 +79,20 @@ operations, or the trust boundary.
 
 ## Runtime checklist
 
-Applied by chief-architect to every capability and every runtime change.
+Applied by the **Runtime Architect** to every capability and every runtime
+change. This is a distinct council role from chief-architect and
+chief-security-officer, added because neither was asking its questions:
+`DriftMeetingRepository` passed both and would have been caught here on the
+first line.
+
+Its six questions, in order:
+
+1. Does this introduce a second source of truth?
+2. Does this bypass the operation log?
+3. Does this bypass the Vault?
+4. Does this bypass projections?
+5. Does this create feature-owned state?
+6. Does this violate I1–I6?
 
 ### The question that governs everything
 - [ ] **Can this be implemented entirely by emitting operations and consuming projections?** If no: either the runtime is missing something generic that should be added once for everyone, or the feature is bypassing the runtime. There is no third branch and no "this feature is special".
@@ -105,6 +118,16 @@ Applied by chief-architect to every capability and every runtime change.
 - [ ] Every device running the same migration chain reaches the same state
 - [ ] Merge strategy does not change within a compatible version
 - [ ] Schema fingerprint changes when and only when the schema changes
+
+### Invariants are testable (I5)
+- [ ] Every invariant this change claims has a **failing form**: a compile error or a test that fails when it is violated. Documentation alone is not evidence.
+- [ ] The test was written before the claim was recorded as applied — three review cycles found properties marked done that were absent from the code
+
+### Canonicalization (I6)
+- [ ] Externally-supplied values pass through a canonicalizer before anything else sees them; nothing below that layer receives raw input
+- [ ] Canonicalization happens **exactly once**, not defensively re-applied at each layer — re-canonicalizing hides the layer that forgot
+- [ ] No function accepts a raw and a canonical value at the same type; the type distinguishes them or the raw form is unreachable past the boundary
+- [ ] Applies to identifiers and derivation inputs, not just user text: entity, context, capability and package IDs, paths, URLs
 
 ### Ontology discipline
 - [ ] Capability entities extend the core ontology, never an archetype directly
@@ -141,6 +164,12 @@ Applied by rust-architect to any change under `rust/`.
 - [ ] Merge is commutative, associative, and idempotent
 - [ ] Replay of any operation permutation converges
 - [ ] Revocation is monotonic — applying it twice equals applying it once
+
+### Types over comments
+- [ ] Where a comment asserts a property, ask whether a type could hold it instead — `RevocationSubject` existed while the API still took `&str`, so the invariant never became enforceable
+- [ ] Impossible states are unrepresentable, not merely untested: no route to a guarded value via `Debug`, `Clone`, serde, a public field, or a pattern match
+- [ ] A convenience overload that accepts the looser type re-opens what the newtype closed
+- [ ] APIs cannot be called in the wrong order — prefer consuming methods and typestate over documented sequencing
 
 ### `unsafe`
 - [ ] The crate itself contains no `unsafe`

--- a/docs/superpowers/specs/2026-07-27-airo-mind-runtime-design.md
+++ b/docs/superpowers/specs/2026-07-27-airo-mind-runtime-design.md
@@ -687,6 +687,62 @@ Known violations at the time of writing: `DriftMeetingRepository`,
 `features/coins/`, `features/money/`, and the settings AI-storage dashboard.
 Migration is tracked on #1293.
 
+### I5 — An invariant is not complete until it can fail
+
+**An architectural invariant is not complete until there is a compile-time
+constraint or an automated test that fails when it is violated.**
+
+Documentation alone is not evidence. This is not a style preference — it is the
+conclusion of three consecutive review cycles on the Phase 1 Vault plan, each
+of which found a property *recorded as applied* that was absent from the code:
+the header AAD, the revocation subject rewrite, and the `ContentNotFound`
+variants that were declared and never constructed.
+
+| Invariant | What makes it complete |
+|---|---|
+| Header authenticated | Tamper test — modify the field, assert failure |
+| Canonical mnemonic | Normalization test — messy input derives the same seed |
+| Revocation | Replay test — a stale backup does not resurrect |
+| No feature persistence | Architecture CI (§11b) |
+| Runtime-only storage | Static analysis |
+
+The failing form comes **first**. An invariant added to a document without its
+test is an invariant that will be recorded as applied and will not be.
+
+### I6 — Canonicalize exactly once, at the boundary
+
+Every externally-supplied value passes through a canonicalizer before anything
+else sees it. Nothing below that layer ever receives raw input.
+
+```
+User / external input
+        ↓
+   Canonicalizer
+        ↓
+Canonical representation
+        ↓
+   Everything else
+```
+
+The mnemonic bug is the worked example: `seed_from_mnemonic` validated the
+words but handed the *raw string* to PBKDF2, so a pasted phrase with a trailing
+newline derived a different seed and surfaced as "wrong seed" while the user's
+mnemonic was correct.
+
+Applies to every identifier and every derivation input, not just mnemonics:
+
+| Value | Canonical form |
+|---|---|
+| Recovery mnemonic | NFKD, single-space-joined, trimmed |
+| Entity / context IDs | Slug-validated, case-fixed, no traversal sequences |
+| Capability / package IDs | Same, plus filesystem-safe on every OS |
+| Paths | Resolved, symlinks followed, confined to a granted root |
+| URLs | Scheme and host lowercased, normalized, percent-encoding settled |
+
+A function that accepts a raw value **and** a canonical one at the same type is
+a defect: the type must distinguish them, or the raw form must be unreachable
+past the boundary.
+
 ## 11b. Architecture compliance
 
 Invariants that only a reviewer can check are invariants that erode. Every
@@ -723,15 +779,24 @@ only catchable by a rebuild test, so `projection` modules must have one.
 surface:
 
 ```rust
-create_operation()
+emit_operation()
 attach_content()
 query_projection()
 instantiate_context()
-emit_event()
+replay()
+sync()
 ```
 
-Nothing else. No SQL. No filesystem. No encryption primitives. No sync. No key
-material.
+Nothing else. No SQL. No filesystem. No encryption primitives. No key material.
+
+`replay()` and `sync()` are on the list deliberately: they are the same
+operation stream at different scope, not two mechanisms. See §11d.
+
+When a capability needs something outside this surface, the **default
+assumption is that the runtime is missing a generic primitive** — not that the
+capability should reach around it. Adding it to the runtime serves every
+capability; adding it to the capability serves one and creates an exception
+that outlives whoever approved it.
 
 This is what makes I2 and I4 enforceable rather than aspirational: a Tier 1
 capability is declarative data and has no way to reach a filesystem, and a
@@ -760,6 +825,40 @@ special". Meeting intelligence is the current test of this: it is a capability
 that captures audio, transcribes, extracts entities, emits operations, and
 builds notes, tasks, and calendar events. It is **not** a runtime feature, and
 it gets no privileged storage path.
+
+## 11d. One sync model
+
+**Decided: one model. Everything is an operation.**
+
+```
+Capture
+   ↓
+Operation
+   ↓
+Operation Log
+   ↓
+Local Replay
+   ↓
+Remote Replay
+```
+
+Single-device mode replays only local operations. Multi-device mode replays
+local plus remote operations. That is the entire difference — there is no
+second storage model, no second merge engine, and no second code path.
+
+The alternative was live: `rust/airo_core` already ships a state-based CRDT
+store — `compare_vector_clocks()` in `api/native_engine.rs` and
+`api/relational_store.rs` (rusqlite, entity + field model, per-field
+last-write-wins, tombstones, SQL migrations). Keeping both was a real option
+and is rejected.
+
+**Every additional sync model doubles the testing matrix**, and the two would
+drift. `relational_store` is also durable user state that does not originate
+from the runtime, which makes it an I4 case on its own terms.
+
+Consequence for existing code: `relational_store` migrates onto the operation
+log via the shared adapter in #1293, alongside the feature-owned stores. It is
+not a parallel substrate to build on. Tracked on #1297.
 
 ## 12. Open decisions, assigned to subsystem specs
 


### PR DESCRIPTION
Resolves **#1297** and adds the structural rules the last three review cycles argued for. Docs only.

## One sync model — decided

Everything is an operation. Single-device mode replays local operations; multi-device replays local plus remote. **That is the entire difference** — no second storage model, no second merge engine, no second code path.

The alternative was live, not hypothetical: `airo_core` already ships a state-based CRDT store with vector clocks, per-field LWW, and tombstones. Rejected because **every additional sync model doubles the testing matrix** and the two would drift — and because `relational_store` is itself durable user state not originating from the runtime, which makes it an I4 case on its own terms.

It migrates via the shared adapter in #1293 rather than becoming a parallel substrate.

## I5 — an invariant is not complete until it can fail

> An architectural invariant is not complete until there is a compile-time constraint or an automated test that fails when it is violated. Documentation alone is not evidence.

This is the conclusion of three consecutive review cycles on one document, each of which found a property **recorded as applied that was absent from the code**: the header AAD, the revocation-subject rewrite, and error variants declared and never constructed.

The failing form comes **first**. An invariant added to a document without its test is an invariant that will be recorded as applied and will not be.

## I6 — canonicalize exactly once, at the boundary

The mnemonic bug is the worked example: validation ran on split words while PBKDF2 received the raw string, so a pasted phrase with a trailing newline derived a different seed and surfaced as "wrong seed" while the mnemonic was correct.

Applies to identifiers and derivation inputs generally — entity, context, capability and package IDs, paths, URLs — not just user text. **A function that accepts a raw and a canonical value at the same type is a defect**: the type distinguishes them, or the raw form is unreachable past the boundary.

## Runtime API revised

`emit_operation` · `attach_content` · `query_projection` · `instantiate_context` · `replay` · `sync`

`replay` and `sync` are on the list deliberately — the same operation stream at different scope, not two mechanisms.

When a capability needs something outside this surface, the default assumption is that **the runtime is missing a generic primitive**, not that the capability should reach around it. Adding it to the runtime serves every capability; adding it to the capability creates an exception that outlives whoever approved it.

## Runtime Architect — new council role

Distinct from chief-architect and chief-security-officer, added because neither was asking its questions. `DriftMeetingRepository` passed both reviews and would have been caught here on the first line.

Its six questions: second source of truth · bypasses the log · bypasses the Vault · bypasses projections · creates feature-owned state · violates I1–I6.

## Checklist additions

**Types over comments**, in the Rust list — `RevocationSubject` existed while the API still took `&str`, so the invariant never became enforceable. Includes the trap that caught us: *a convenience overload accepting the looser type re-opens what the newtype closed.*

Plus **Invariants are testable (I5)** and **Canonicalization (I6)** sections in the Runtime list.

## Running

Rust architecture review, dispatched with the architectural lens rather than the safety one: does it compile as designed, do types enforce invariants or merely describe them, are impossible states actually impossible, can APIs be misused. It is the review most likely to have caught the non-compiling `revocation.rs`.

Refs #1192, #1293, #1295, #1297
