### PR TITLE
Fix Gemma download size and stale retries

### DIFF
--- a/app/lib/features/settings/application/ai_model_management.dart
+++ b/app/lib/features/settings/application/ai_model_management.dart
@@ -143,7 +143,8 @@ class ActiveDownloadsNotifier
 
   Future<void> retryDownload(String modelId) {
     final service = _ref.read(modelDownloadServiceProvider);
-    return service.retryDownload(modelId);
+    final model = _ref.read(modelRegistryProvider).getModel(modelId);
+    return service.retryDownload(modelId, model: model);
   }
 
   Future<void> cancelDownload(String modelId) {

--- a/app/test/features/settings/presentation/screens/intelligent_model_manager_screen_test.dart
+++ b/app/test/features/settings/presentation/screens/intelligent_model_manager_screen_test.dart
@@ -86,7 +86,9 @@ void main() {
     when(
       () => downloads.restoreQueue(catalogModels: any(named: 'catalogModels')),
     ).thenAnswer((_) async => []);
-    when(() => downloads.retryDownload('queued')).thenAnswer((_) async {});
+    when(
+      () => downloads.retryDownload('queued', model: queuedInfo),
+    ).thenAnswer((_) async {});
     when(() => downloads.resumeDownload('queued')).thenAnswer((_) async {});
     when(() => downloads.cancelDownload('queued')).thenAnswer((_) async {});
     when(
@@ -149,7 +151,9 @@ void main() {
     await tester.tap(find.widgetWithText(TextButton, 'Delete'));
     await tester.pumpAndSettle();
 
-    verify(() => downloads.retryDownload('queued')).called(1);
+    verify(
+      () => downloads.retryDownload('queued', model: queuedInfo),
+    ).called(1);
     verify(() => downloads.resumeDownload('queued')).called(1);
     verify(() => downloads.cancelDownload('queued')).called(1);
     verify(() => downloads.downloadModel(installedInfo)).called(1);

--- a/packages/core_ai/lib/src/download/model_download_service.dart
+++ b/packages/core_ai/lib/src/download/model_download_service.dart
@@ -158,7 +158,21 @@ class ModelDownloadService {
 
   Future<void> resumeDownload(String modelId) => _downloads.resume(modelId);
 
-  Future<void> retryDownload(String modelId) => _downloads.retry(modelId);
+  Future<void> retryDownload(String modelId, {OfflineModelInfo? model}) async {
+    if (model == null) {
+      await _downloads.retry(modelId);
+      return;
+    }
+
+    // Re-enqueue with current catalog metadata so persisted requests from an
+    // older catalog cannot repeat a stale size or checksum failure.
+    await _downloads.cancel(modelId);
+    _scheduledIds.remove(modelId);
+    _scheduledModels.remove(modelId);
+    _scheduledIds.add(modelId);
+    _scheduledModels[modelId] = model;
+    await _prepareDownload(model);
+  }
 
   Future<void> cancelDownload(String modelId) => _downloads.cancel(modelId);
 

--- a/packages/core_ai/lib/src/intelligent_model_manager/intelligent_model_manager.dart
+++ b/packages/core_ai/lib/src/intelligent_model_manager/intelligent_model_manager.dart
@@ -150,8 +150,10 @@ class IntelligentModelManager {
   Future<void> resumeDownload(String modelId) =>
       _downloadService.resumeDownload(modelId);
 
-  Future<void> retryDownload(String modelId) =>
-      _downloadService.retryDownload(modelId);
+  Future<void> retryDownload(String modelId) {
+    final model = _requireModel(modelId);
+    return _downloadService.retryDownload(modelId, model: model);
+  }
 
   Future<void> cancelDownload(String modelId) =>
       _downloadService.cancelDownload(modelId);

--- a/packages/core_ai/lib/src/registry/model_catalog.dart
+++ b/packages/core_ai/lib/src/registry/model_catalog.dart
@@ -383,7 +383,6 @@ class ModelCatalog {
       .toList();
 
   /// Gets only models with a confirmed MediaPipe web (.task) bundle.
-  static List<OfflineModelInfo> get webRuntimeSupported => bundledModels
-      .where((m) => m.supportsWebRuntime)
-      .toList();
+  static List<OfflineModelInfo> get webRuntimeSupported =>
+      bundledModels.where((m) => m.supportsWebRuntime).toList();
 }

--- a/packages/core_ai/lib/src/registry/model_catalog.dart
+++ b/packages/core_ai/lib/src/registry/model_catalog.dart
@@ -17,7 +17,7 @@ class ModelCatalog {
       id: 'gemma-4-e2b-it-litertlm',
       name: 'Gemma-4-E2B-it',
       family: ModelFamily.gemma,
-      fileSizeBytes: 2583085056,
+      fileSizeBytes: 2588147712,
       downloadUrl:
           'https://huggingface.co/litert-community/gemma-4-E2B-it-litert-lm/resolve/main/gemma-4-E2B-it.litertlm',
       quantization: ModelQuantization.q4,

--- a/packages/core_ai/test/download/model_download_service_test.dart
+++ b/packages/core_ai/test/download/model_download_service_test.dart
@@ -243,6 +243,21 @@ void main() {
   });
 
   test(
+    'retry with the current catalog refreshes stale request metadata',
+    () async {
+      downloadService.downloadModel(model);
+      await Future<void>.delayed(Duration.zero);
+
+      await downloadService.retryDownload(model.id, model: model);
+      await Future<void>.delayed(Duration.zero);
+
+      expect(downloads.actions, contains('cancel:model-a'));
+      expect(downloads.requests, hasLength(2));
+      expect(downloads.requests.last.expectedBytes, model.fileSizeBytes);
+    },
+  );
+
+  test(
     'restoreQueue maps persisted platform state after engine restart',
     () async {
       downloads.queue = const DownloadQueueSnapshot(

--- a/packages/core_ai/test/intelligent_model_manager_test.dart
+++ b/packages/core_ai/test/intelligent_model_manager_test.dart
@@ -164,6 +164,7 @@ void main() {
     test(
       'queue controls delegate through the shared download contract',
       () async {
+        when(() => mockRegistry.getModel(testModel.id)).thenReturn(testModel);
         when(
           () => mockDownload.pauseDownload(testModel.id),
         ).thenAnswer((_) async {});
@@ -171,7 +172,7 @@ void main() {
           () => mockDownload.resumeDownload(testModel.id),
         ).thenAnswer((_) async {});
         when(
-          () => mockDownload.retryDownload(testModel.id),
+          () => mockDownload.retryDownload(testModel.id, model: testModel),
         ).thenAnswer((_) async {});
         when(
           () => mockDownload.cancelDownload(testModel.id),
@@ -184,7 +185,9 @@ void main() {
 
         verify(() => mockDownload.pauseDownload(testModel.id)).called(1);
         verify(() => mockDownload.resumeDownload(testModel.id)).called(1);
-        verify(() => mockDownload.retryDownload(testModel.id)).called(1);
+        verify(
+          () => mockDownload.retryDownload(testModel.id, model: testModel),
+        ).called(1);
         verify(() => mockDownload.cancelDownload(testModel.id)).called(1);
       },
     );

--- a/packages/core_ai/test/registry/model_catalog_test.dart
+++ b/packages/core_ai/test/registry/model_catalog_test.dart
@@ -3,6 +3,14 @@ import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   group('ModelCatalog web runtime support', () {
+    test('Gemma-4-E2B catalog size matches the published artifact', () {
+      final model = ModelCatalog.bundledModels.firstWhere(
+        (m) => m.id == 'gemma-4-e2b-it-litertlm',
+      );
+
+      expect(model.fileSizeBytes, 2588147712);
+    });
+
     test('Gemma-4-E2B is flagged web-capable with a .task asset URL', () {
       final model = ModelCatalog.bundledModels.firstWhere(
         (m) => m.id == 'gemma-4-e2b-it-litertlm',


### PR DESCRIPTION
## Summary
- sync the bundled Gemma-4-E2B artifact size with the published object
- refresh persisted download metadata when retrying through the current catalog
- cover catalog and retry behavior with regression tests

## Validation
- `flutter test test/download/model_download_service_test.dart test/intelligent_model_manager_test.dart test/registry/model_catalog_test.dart`
- `flutter test test/features/settings/presentation/screens/intelligent_model_manager_screen_test.dart`
- `git diff --check`
- Pixel 9 debug APK: request persisted `expectedBytes=2588147712` and entered `downloading`

## Deterministic use case
A previously failed Gemma request with stale expected bytes can be retried from Intelligent Model Manager; retry cancels the stale request and enqueues current catalog metadata, avoiding the immediate integrity mismatch.
