### PR TITLE
docs(plan): Vault revision 4 — apply rust-architect REJECT findings

### DIFF
--- a/docs/superpowers/plans/2026-07-27-airo-mind-phase-1-vault.md
+++ b/docs/superpowers/plans/2026-07-27-airo-mind-phase-1-vault.md
@@ -266,6 +266,9 @@ pub enum VaultError {
 
     #[error("value too long to encode")]
     ValueTooLong,
+
+    #[error("device certificate is not signed by this identity")]
+    UntrustedCertificate,
 }
 
 #[cfg(test)]
@@ -322,7 +325,9 @@ chacha20poly1305 = { version = "0.10", features = ["getrandom"] }
 ed25519-dalek = { version = "2", default-features = false, features = ["std", "rand_core", "zeroize"] }
 # RUSTSEC-2024-0344: timing variability in Scalar29/Scalar52 subtraction.
 # 4.1.3 is the patched release. Floored explicitly so a downgrade fails.
-curve25519-dalek = ">=4.1.3"
+# Caret, never an open floor: `>=4.1.3` lets a future 5.0 resolve beside
+# the `^4.1` ed25519-dalek needs, linking two copies of the curve.
+curve25519-dalek = "4.1.3"
 hkdf = "0.12"
 rand_core = { version = "0.6", features = ["getrandom"] }
 serde = { version = "1", features = ["derive"] }
@@ -336,7 +341,11 @@ zeroize = { version = "1", features = ["derive"] }
 Create `rust/airo_mind/src/lib.rs`:
 
 ```rust
+#![forbid(unsafe_code)]
 //! Airo Mind runtime.
+//!
+//! `forbid(unsafe_code)` is the point: "pure Rust, no FFI" is otherwise a
+//! description rather than a property, and nothing enforces a description.
 //!
 //! The runtime understands seven primitives and no domain concepts:
 //! Identity, Operation, Content, Context, Capability, Projection, Vault.
@@ -497,7 +506,7 @@ wordlist, 2048 entries, public domain, verbatim from the specification:
 //! Do not sort, reformat, or "clean up". Index order *is* the encoding — a
 //! single reordered entry silently changes every mnemonic ever generated.
 
-pub const WORDS: [&str; 2048] = [
+pub static WORDS: [&str; 2048] = [
     "abandon", "ability", "able", "about", "above", "absent",
     // ... 2042 more, in specification order ...
     "zebra", "zero", "zone", "zoo",
@@ -694,7 +703,7 @@ fn validate_mnemonic(phrase: &str) -> Result<Vec<&str>, VaultError> {
 /// Guards the bit-packing arithmetic. 256 entropy bits + 8 checksum bits = 264,
 /// which is exactly 24 * 11. If `ENTROPY_BYTES` ever changes, a short final
 /// chunk would silently fold to a small word index instead of failing.
-const _: () = assert!((ENTROPY_BYTES * 8 + ENTROPY_BYTES * 8 / 32) % 11 == 0);
+const _: () = assert!((ENTROPY_BYTES * 8 + ENTROPY_BYTES * 8 / 32).is_multiple_of(11));
 
 /// PBKDF2-HMAC-SHA512 producing exactly 64 bytes — one block, since SHA-512's
 /// output is 64 bytes, so the block-index loop collapses to a single pass.
@@ -831,10 +840,10 @@ mod tests {
         let phrase = generate_mnemonic().unwrap();
         let mut words: Vec<&str> = phrase.split_whitespace().collect();
         words[5] = if words[5] == "zoo" { "abandon" } else { "zoo" };
-        assert_eq!(
+        assert!(matches!(
             seed_from_mnemonic(&words.join(" ")),
             Err(VaultError::InvalidMnemonic)
-        );
+        ));
     }
 
     #[test]
@@ -858,20 +867,20 @@ mod tests {
         let phrase = generate_mnemonic().unwrap();
         let mut words: Vec<&str> = phrase.split_whitespace().collect();
         words[0] = "notabip39word";
-        assert_eq!(
+        assert!(matches!(
             seed_from_mnemonic(&words.join(" ")),
             Err(VaultError::InvalidMnemonic)
-        );
+        ));
     }
 
     #[test]
     fn wrong_word_count_is_rejected() {
         let phrase = generate_mnemonic().unwrap();
         let short: Vec<&str> = phrase.split_whitespace().take(23).collect();
-        assert_eq!(
+        assert!(matches!(
             seed_from_mnemonic(&short.join(" ")),
             Err(VaultError::InvalidMnemonic)
-        );
+        ));
     }
 
     fn hex_bytes(hex: &str) -> Vec<u8> {
@@ -883,10 +892,10 @@ mod tests {
 
     #[test]
     fn invalid_mnemonic_is_rejected() {
-        assert_eq!(
+        assert!(matches!(
             seed_from_mnemonic("not a real mnemonic phrase at all"),
             Err(VaultError::InvalidMnemonic)
-        );
+        ));
     }
 
     fn hex_lower(bytes: &[u8]) -> String {
@@ -999,7 +1008,7 @@ Create `rust/airo_mind/src/vault/identity.rs`:
 ```rust
 //! Root identity. Derived from the seed, signs device certificates.
 
-use ed25519_dalek::{Signature, Signer, SigningKey, Verifier, VerifyingKey};
+use ed25519_dalek::{Signature, Signer, SigningKey, VerifyingKey};
 use hkdf::Hkdf;
 use sha2::Sha512;
 use zeroize::ZeroizeOnDrop;
@@ -1058,7 +1067,7 @@ pub fn verify(public_key: &[u8; 32], msg: &[u8], signature: &[u8; 64]) -> bool {
         return false;
     };
     verifying_key
-        .verify(msg, &Signature::from_bytes(signature))
+        .verify_strict(msg, &Signature::from_bytes(signature))
         .is_ok()
 }
 
@@ -1190,10 +1199,12 @@ Create `rust/airo_mind/src/vault/device.rs`:
 //! cannot present a certificate signed by the root identity cannot write.
 
 use ed25519_dalek::{Signer, SigningKey};
-use rand_core::OsRng;
+use rand_core::RngCore;
 use serde::{Deserialize, Serialize};
 use zeroize::ZeroizeOnDrop;
 
+use super::domain;
+use super::error::VaultError;
 use super::identity::{verify, RootIdentity};
 
 /// A per-device signing key, generated on the device that owns it.
@@ -1207,17 +1218,19 @@ pub struct DeviceKey {
     signing_key: SigningKey,
 }
 
-impl Default for DeviceKey {
-    fn default() -> Self {
-        Self::generate()
-    }
-}
-
+// No `impl Default`. `SigningKey::generate` goes through `fill_bytes`, which
+// panics on RNG failure — and a `Default` that mints a private key means any
+// future `#[derive(Default)]` on a containing struct silently generates key
+// material.
 impl DeviceKey {
-    pub fn generate() -> Self {
-        Self {
-            signing_key: SigningKey::generate(&mut OsRng),
-        }
+    pub fn generate() -> Result<Self, VaultError> {
+        let mut bytes = [0u8; 32];
+        rand_core::OsRng
+            .try_fill_bytes(&mut bytes)
+            .map_err(|_| VaultError::RngUnavailable)?;
+        Ok(Self {
+            signing_key: SigningKey::from_bytes(&bytes),
+        })
     }
 
     pub fn public_key(&self) -> [u8; 32] {
@@ -1297,13 +1310,13 @@ mod tests {
 
     #[test]
     fn two_generated_device_keys_differ() {
-        assert_ne!(DeviceKey::generate().public_key(), DeviceKey::generate().public_key());
+        assert_ne!(DeviceKey::generate().unwrap().public_key(), DeviceKey::generate().unwrap().public_key());
     }
 
     #[test]
     fn issued_certificate_verifies_against_the_issuing_root() {
         let root = RootIdentity::from_seed(&test_seed()).unwrap();
-        let device = DeviceKey::generate();
+        let device = DeviceKey::generate().unwrap();
         let certificate = DeviceCertificate::issue(&root, &device, 1);
         assert!(certificate.verify_against(&root.public_key()));
     }
@@ -1315,22 +1328,22 @@ mod tests {
             &seed_from_mnemonic(&crate::vault::generate_mnemonic().unwrap()).unwrap(),
         )
         .unwrap();
-        let certificate = DeviceCertificate::issue(&root, &DeviceKey::generate(), 1);
+        let certificate = DeviceCertificate::issue(&root, &DeviceKey::generate().unwrap(), 1);
         assert!(!certificate.verify_against(&stranger.public_key()));
     }
 
     #[test]
     fn swapping_the_public_key_invalidates_the_certificate() {
         let root = RootIdentity::from_seed(&test_seed()).unwrap();
-        let mut certificate = DeviceCertificate::issue(&root, &DeviceKey::generate(), 1);
-        certificate.device_public_key = DeviceKey::generate().public_key();
+        let mut certificate = DeviceCertificate::issue(&root, &DeviceKey::generate().unwrap(), 1);
+        certificate.device_public_key = DeviceKey::generate().unwrap().public_key();
         assert!(!certificate.verify_against(&root.public_key()));
     }
 
     #[test]
     fn device_id_must_match_the_public_key() {
         let root = RootIdentity::from_seed(&test_seed()).unwrap();
-        let mut certificate = DeviceCertificate::issue(&root, &DeviceKey::generate(), 1);
+        let mut certificate = DeviceCertificate::issue(&root, &DeviceKey::generate().unwrap(), 1);
         certificate.device_id = "deadbeef".into();
         assert!(!certificate.verify_against(&root.public_key()));
     }
@@ -1338,7 +1351,7 @@ mod tests {
     #[test]
     fn changing_the_issue_epoch_invalidates_the_certificate() {
         let root = RootIdentity::from_seed(&test_seed()).unwrap();
-        let mut certificate = DeviceCertificate::issue(&root, &DeviceKey::generate(), 1);
+        let mut certificate = DeviceCertificate::issue(&root, &DeviceKey::generate().unwrap(), 1);
         certificate.issued_at_epoch = 99;
         assert!(!certificate.verify_against(&root.public_key()));
     }
@@ -1358,7 +1371,57 @@ pub use device::{DeviceCertificate, DeviceKey};
 Run: `cargo test --manifest-path rust/Cargo.toml -p airo_mind device`
 Expected: FAIL to compile — module not declared.
 
-- [ ] **Step 3: Reconcile serde on fixed-size arrays**
+- [ ] **Step 3: Use the decided fixed-array encoding — do not choose one**
+
+`[u8; 64]` has no `Serialize` in serde 1 (its array impls stop at 32). This is
+the **on-disk Recovery Package format v1, frozen in this phase**. Leaving the
+choice to the implementer means two implementers can satisfy "pick one" with
+two incompatible wire formats.
+
+Create `rust/airo_mind/src/vault/encoding.rs` and use it everywhere a
+fixed-size array is serialized (Tasks 4, 8, 9):
+
+```rust
+//! Serde helpers for fixed-size byte arrays, and length-prefixing.
+//!
+//! serde 1 has no array impl above 32 bytes and no feature that adds one.
+//! Hand-written rather than pulling `serde_bytes` or `serde-big-array`: a new
+//! crate on the crypto path needs a governance scorecard (Constitution §6),
+//! and this is twenty lines.
+//!
+//! Encoding: lowercase hex string. Chosen over a byte array so the package
+//! stays inspectable in a text editor, which matters for a file users are
+//! told to store themselves.
+
+pub mod hex_array_64 {
+    use serde::{Deserialize, Deserializer, Serializer};
+
+    pub fn serialize<S: Serializer>(bytes: &[u8; 64], s: S) -> Result<S::Ok, S::Error> {
+        s.serialize_str(&bytes.iter().map(|b| format!("{b:02x}")).collect::<String>())
+    }
+
+    pub fn deserialize<'de, D: Deserializer<'de>>(d: D) -> Result<[u8; 64], D::Error> {
+        use serde::de::Error;
+        let text = String::deserialize(d)?;
+        if text.len() != 128 {
+            return Err(D::Error::custom("expected 128 hex chars"));
+        }
+        let mut out = [0u8; 64];
+        for (i, slot) in out.iter_mut().enumerate() {
+            *slot = u8::from_str_radix(&text[i * 2..i * 2 + 2], 16)
+                .map_err(|_| D::Error::custom("invalid hex"))?;
+        }
+        Ok(out)
+    }
+}
+```
+
+Apply with `#[serde(with = "crate::vault::encoding::hex_array_64")]` on
+`DeviceCertificate::signature`. Write the `[u8; 32]` twin the same way.
+
+**Do not add `serde_bytes`, `serde-big-array`, or `serde_arrays`.**
+
+- [ ] **Step 3b: (removed — the encoding is decided above)**
 
 `[u8; 64]` does not implement `Serialize`/`Deserialize` by default in serde 1. Either enable a serde feature that supports large arrays, or add `#[serde(with = "...")]` helpers converting to `Vec<u8>` with a length check on deserialize. Pick one and apply it consistently — Tasks 5, 7, and 8 all serialize fixed-size arrays.
 
@@ -1415,7 +1478,7 @@ use chacha20poly1305::aead::{Aead, KeyInit, Payload};
 use chacha20poly1305::{XChaCha20Poly1305, XNonce};
 use serde::{Deserialize, Serialize};
 use subtle::ConstantTimeEq;
-use zeroize::{Zeroize, ZeroizeOnDrop, Zeroizing};
+use zeroize::{Zeroize, ZeroizeOnDrop};
 
 use super::domain;
 use super::error::VaultError;
@@ -2143,7 +2206,7 @@ Modify `rust/airo_mind/src/vault/mod.rs`:
 ```rust
 mod revocation;
 
-pub use revocation::RevocationLedger;
+pub use revocation::{RevocationLedger, RevocationSubject};
 ```
 
 - [ ] **Step 2: Run test to verify it fails**
@@ -2387,13 +2450,15 @@ impl Vault {
 
     /// Records a device certificate after verifying it against the root.
     /// Returns whether the certificate was accepted.
-    pub fn trust_device(&mut self, certificate: DeviceCertificate) -> bool {
+    /// Returns `Result`, not `bool`. `vault.trust_device(cert);` discarding a
+    /// security decision must not compile silently.
+    pub fn trust_device(&mut self, certificate: DeviceCertificate) -> Result<(), VaultError> {
         if !certificate.verify_against(&self.root_public_key) {
-            return false;
+            return Err(VaultError::UntrustedCertificate);
         }
         self.device_certificates.retain(|c| c.device_id != certificate.device_id);
         self.device_certificates.push(certificate);
-        true
+        Ok(())
     }
 
     pub fn trusted_devices(&self) -> &[DeviceCertificate] {
@@ -2462,7 +2527,10 @@ mod tests {
 
         let directive = vault.destroy_content("note-1").unwrap();
 
-        assert_eq!(directive.content_id, "note-1");
+        assert_eq!(
+            directive.subject,
+            RevocationSubject::Content("note-1".into())
+        );
         assert_eq!(directive.epoch, 1);
         assert!(vault.revocations().is_content_revoked("note-1"));
         assert!(!vault.envelopes.contains_key("note-1"));
@@ -2491,7 +2559,7 @@ mod tests {
     #[test]
     fn an_unsigned_device_certificate_is_rejected() {
         use crate::vault::{DeviceCertificate, DeviceKey};
-        let device = DeviceKey::generate();
+        let device = DeviceKey::generate().unwrap();
         let forged = DeviceCertificate {
             device_id: device.device_id(),
             device_public_key: device.public_key(),
@@ -2500,7 +2568,7 @@ mod tests {
         };
 
         let mut vault = vault();
-        assert!(!vault.trust_device(forged));
+        assert!(vault.trust_device(forged).is_err());
         assert!(vault.trusted_devices().is_empty());
     }
 }
@@ -2586,9 +2654,6 @@ use super::{DeviceCertificate, Vault};
 
 pub const RECOVERY_PACKAGE_FORMAT_VERSION: u32 = 1;
 
-/// Domain separation for the package encryption key.
-
-
 /// The serializable interior of a Vault.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub(crate) struct VaultPayload {
@@ -2643,22 +2708,24 @@ impl RecoveryPackage {
     ///
     /// `kdf_*` and `passphrase_used` are bound too, so a downgrade attack
     /// cannot strip a future passphrase by flipping the flag.
-    fn header_aad(&self) -> Vec<u8> {
+    fn header_aad(&self) -> Result<Vec<u8>, VaultError> {
         let mut aad = Vec::new();
         aad.extend_from_slice(domain::PACKAGE_HEADER);
         aad.extend_from_slice(&self.format_version.to_be_bytes());
         aad.extend_from_slice(&self.identity_public_key);
         aad.extend_from_slice(&self.revocation_epoch.to_be_bytes());
         aad.push(u8::from(self.passphrase_used));
-        aad.extend_from_slice(&(self.kdf_params.len() as u32).to_be_bytes());
+        let count = u32::try_from(self.kdf_params.len()).map_err(|_| VaultError::ValueTooLong)?;
+        aad.extend_from_slice(&count.to_be_bytes());
         for (key, value) in &self.kdf_params {
-            aad.extend_from_slice(&(key.len() as u32).to_be_bytes());
-            aad.extend_from_slice(key.as_bytes());
+            // The checked helper, at every site the invariant applies to. A
+            // helper built and used at one of two sites is worse than none —
+            // it reads as done.
+            push_len_prefixed(&mut aad, key.as_bytes())?;
             aad.extend_from_slice(&value.to_be_bytes());
         }
-        aad.extend_from_slice(&(self.kdf_salt.len() as u32).to_be_bytes());
-        aad.extend_from_slice(&self.kdf_salt);
-        aad
+        push_len_prefixed(&mut aad, &self.kdf_salt)?;
+        Ok(aad)
     }
 
     pub fn export(vault: &Vault, seed: &Seed) -> Result<Self, VaultError> {
@@ -2696,7 +2763,7 @@ impl RecoveryPackage {
                 XNonce::from_slice(&nonce_bytes),
                 Payload {
                     msg: plaintext.as_slice(),
-                    aad: &package.header_aad(),
+                    aad: &package.header_aad()?,
                 },
             )
             .map_err(|_| VaultError::SerializationFailed)?;
@@ -2718,7 +2785,7 @@ impl RecoveryPackage {
                     XNonce::from_slice(&nonce_bytes),
                     Payload {
                         msg: self.ciphertext.as_slice(),
-                        aad: &self.header_aad(),
+                        aad: &self.header_aad()?,
                     },
                 )
                 .map_err(|_| VaultError::DecryptionFailed)?,
@@ -3046,6 +3113,20 @@ pub enum RevocationProvenance {
     AcknowledgedBlind,
 }
 
+/// Proof that a ledger was replayed from the operation log to head.
+///
+/// The field is private, so only this crate's log module can construct one.
+/// `pub(crate)` until Phase 2 provides that module — see #1260.
+pub struct LogHead(pub(crate) String);
+
+#[cfg(test)]
+impl LogHead {
+    /// Tests only. Production callers get a `LogHead` from the log.
+    pub(crate) fn for_test(id: &str) -> Self {
+        Self(id.to_string())
+    }
+}
+
 /// A revocation ledger plus where it came from.
 pub struct RevocationSource {
     ledger: RevocationLedger,
@@ -3053,10 +3134,20 @@ pub struct RevocationSource {
 }
 
 impl RevocationSource {
-    pub fn replayed_from_log(ledger: RevocationLedger, head_operation_id: String) -> Self {
+    /// Only the operation log can mint a `LogHead`, so this constructor cannot
+    /// be used to *assert* provenance the caller does not have.
+    ///
+    /// Revision 3 took a bare `RevocationLedger` and a free `String`, and the
+    /// plan's own test then built one from an EMPTY ledger and asserted
+    /// `!was_blind()` — reaching R1's original bypass through the constructor
+    /// named "trustworthy". Provenance was a claim, not a proof: the same
+    /// shape as `RevocationSubject` before the tag.
+    pub fn replayed_from_log(ledger: RevocationLedger, head: LogHead) -> Self {
         Self {
             ledger,
-            provenance: RevocationProvenance::ReplayedFromLog { head_operation_id },
+            provenance: RevocationProvenance::ReplayedFromLog {
+                head_operation_id: head.0,
+            },
         }
     }
 
@@ -3261,7 +3352,7 @@ mod tests {
 
         let restored = SealedRestore::load(&stale_backup, &seed())
             .unwrap()
-            .apply_revocations(&RevocationSource::replayed_from_log(current_revocations, "op-42".into()));
+            .apply_revocations(&RevocationSource::replayed_from_log(current_revocations, LogHead::for_test("op-42")));
 
         assert_eq!(
             restored.purged(),
@@ -3306,16 +3397,16 @@ mod tests {
         // stolen laptop walked back into the mesh on every restore.
         use crate::vault::{DeviceCertificate, DeviceKey};
         let identity = RootIdentity::from_seed(&seed()).unwrap();
-        let device = DeviceKey::generate();
+        let device = DeviceKey::generate().unwrap();
         let device_id = device.device_id();
 
         let mut vault = Vault::new(identity.public_key());
-        assert!(vault.trust_device(DeviceCertificate::issue(&identity, &device, 1)));
+        vault.trust_device(DeviceCertificate::issue(&identity, &device, 1)).unwrap();
         let stale_backup = RecoveryPackage::export(&vault, &seed()).unwrap();
 
         // ... the laptop is stolen and revoked on the phone.
         let mut live = Vault::new(identity.public_key());
-        live.trust_device(DeviceCertificate::issue(&identity, &device, 1));
+        live.trust_device(DeviceCertificate::issue(&identity, &device, 1)).unwrap();
         live.revoke_device(&device_id).unwrap();
 
         let restored = SealedRestore::load(&stale_backup, &seed())
@@ -3338,13 +3429,13 @@ mod tests {
 
         let once = SealedRestore::load(&package, &seed())
             .unwrap()
-            .apply_revocations(&RevocationSource::replayed_from_log(live.revocations().clone(), "op-42".into()));
+            .apply_revocations(&RevocationSource::replayed_from_log(live.revocations().clone(), LogHead::for_test("op-42")));
         let vault = once.into_vault();
 
         let repackaged = RecoveryPackage::export(&vault, &seed()).unwrap();
         let twice = SealedRestore::load(&repackaged, &seed())
             .unwrap()
-            .apply_revocations(&RevocationSource::replayed_from_log(live.revocations().clone(), "op-42".into()));
+            .apply_revocations(&RevocationSource::replayed_from_log(live.revocations().clone(), LogHead::for_test("op-42")));
 
         assert!(twice.purged().is_empty());
         assert!(!twice.into_vault().has_content("hiv-test-result"));
@@ -3560,7 +3651,10 @@ established:
 - [ ] `crate-type = ["rlib"]`; no `flutter_rust_bridge` dependency
 - [ ] Third-party notices updated for BSD-3-Clause, and for CC0 if Path A was chosen
 - [ ] `[profile.release]` added to `rust/Cargo.toml` — measured at 650 KB → 424 KB, and free
-- [ ] Rust Architect has recorded an explicit "third-party audited `unsafe`, accepted" note for `curve25519-dalek`, `subtle`, and `fiat-crypto`, which trip the unreviewed-`unsafe` criterion transitively
+- [ ] **The plan's code compiles.** Paste every Rust block into a scratch crate and run `cargo clippy --all-targets -- -D warnings`. Under ten minutes including dependency build. **Revision 4 does not circulate without this** — three prior revisions shipped code that could not compile, and two reviewers' time was spent finding `E0433`.
+- [ ] `#![forbid(unsafe_code)]` present in `lib.rs`
+- [ ] Rust Architect's accepted-transitive-`unsafe` note is recorded and names the crates actually in `cargo tree` — `curve25519-dalek` (35 sites) and `subtle` (2 sites, `black_box` shims that exist *to preserve* the constant-time property), plus the RustCrypto set. **`fiat-crypto` is NOT in the tree** and was struck: it resolves only under `--cfg curve25519_dalek_backend="fiat"`, which nothing sets. Setting that cfg requires a fresh note.
+- [ ] `[profile.release]` shaped per rust-architect — `lto`/`strip` workspace-wide, `opt-level`/`codegen-units` under `[profile.release.package.airo_mind]` only. **Never `panic = "abort"`**: `airo_core` is a `cdylib` whose FRB bridge relies on `catch_unwind` to turn panics into Dart errors. Chief Performance Officer signs the `airo_core` half.
 
 Deferred with reasons: `packages/benchmarks` entry (Constitution §4 attaches the
 benchmark requirement to merge and replay, which land in Phases 2–3); FFI

--- a/docs/superpowers/specs/2026-07-27-airo-mind-review-checklists.md
+++ b/docs/superpowers/specs/2026-07-27-airo-mind-review-checklists.md
@@ -165,11 +165,42 @@ Applied by rust-architect to any change under `rust/`.
 - [ ] Replay of any operation permutation converges
 - [ ] Revocation is monotonic — applying it twice equals applying it once
 
+### The plan's code is code
+- [ ] **[CI]** Every Rust block in a plan compiled before the plan was approved — paste it into a scratch crate, run `cargo clippy --all-targets -- -D warnings`. Three consecutive revisions shipped code that could not compile; each cost a reviewer more time than the check does.
+- [ ] Every "Interfaces" block matches the code in its own task, field for field — later tasks are written against the block, not the code
+- [ ] Every call site in a later task is checked against the signature the earlier task actually produced
+- [ ] Step-4 test counts, "Expected:" lines and commit messages match their own step; copy-pasted boilerplate is how a plan stops being an oracle
+
 ### Types over comments
-- [ ] Where a comment asserts a property, ask whether a type could hold it instead — `RevocationSubject` existed while the API still took `&str`, so the invariant never became enforceable
+- [ ] An invariant a comment asserts is expressed as a type, or the comment records why it cannot be — `RevocationSubject` existed while the API still took `&str`, so the invariant never became enforceable
+- [ ] No doc comment claims a property the call does not have — `verify` documented as "strict verification" when `verify_strict` is the strict call is a false claim in the security-critical direction
 - [ ] Impossible states are unrepresentable, not merely untested: no route to a guarded value via `Debug`, `Clone`, serde, a public field, or a pattern match
-- [ ] A convenience overload that accepts the looser type re-opens what the newtype closed
+- [ ] A `&str` convenience method beside a tagged subject type is justified or removed — a convenience overload accepting the looser type re-opens what the newtype closed, and it trains the next call site
 - [ ] APIs cannot be called in the wrong order — prefer consuming methods and typestate over documented sequencing
+- [ ] A returned obligation is consumed by a parameter the caller must supply, or an enum the caller must match; `#[must_use]` is a lint, not a mechanism
+- [ ] `#[must_use]` on a `-> bool` getter enforces nothing — the caller being warned is the one who never calls it
+- [ ] A constructor asserting provenance takes a witness only the claimed producer can mint, or stays `pub(crate)` until that producer exists
+- [ ] A typestate is only as strong as its narrowest visibility — a `pub(crate)` back door guards nothing once the crate holds more than one subsystem; gate the constructor on a witness type with a private field
+- [ ] Signing and derivation entry points take a domain-tagged payload type, never `&[u8]` — a raw signing oracle over the root key cannot be domain-separated by its callers' good intentions
+- [ ] A struct whose fields are covered by a signature or an AAD does not expose those fields as `pub` mutable
+- [ ] A helper written to hold an invariant (checked length prefixes, canonicalization) is used at **every** site that invariant applies to — one built and unused is worse than none, because it reads as done
+
+### Public surface
+- [ ] `pub` vs `pub(crate)` is decided per item, not per module; `pub mod` on a module holding key material exports every future item added to it
+- [ ] No key-minting or envelope-building primitive is reachable outside the aggregate that owns the revocation ledger — state created around the aggregate can never be shredded
+- [ ] **[CI]** Every `pub(crate)` item has a non-test caller or is `#[cfg(test)]` — `cargo clippy` builds the lib without `cfg(test)` and `dead_code` fails `-D warnings`
+- [ ] No public error variant is unconstructible in the phase that ships it
+
+### Lints and manifest
+- [ ] `#![forbid(unsafe_code)]` (or `[lints.rust] unsafe_code = "forbid"`) on any new pure-Rust crate — "no unsafe" is otherwise a description, not a property
+- [ ] Large fixture arrays are `static`, not `const` — `clippy::large_const_arrays` fails `-D warnings` and a `const` array is materialised at every use site
+- [ ] `x % n == 0` is written `x.is_multiple_of(n)` — `clippy::manual_is_multiple_of` fails `-D warnings`
+- [ ] No blank line between a doc comment and its item — `clippy::empty_line_after_doc_comments` fails `-D warnings`; a doc comment orphaned by a deleted const silently attaches to the next item
+- [ ] Fixed-size arrays above 32 bytes have their serde representation decided **in the design**, not left to the implementer — it is the on-disk format, and `[u8; 64]` has no serde impl
+- [ ] Dependency floors use a caret (`"4.1.3"`), never an open `">=4.1.3"` — an open floor lets a future major resolve beside the transitive one and links the crate twice
+- [ ] `default-features = false` on a crypto crate is diffed against that crate's default list and the loss recorded — dropping `ed25519-dalek`'s `fast` removes `curve25519-dalek/precomputed-tables`
+- [ ] A workspace `[profile.release]` is measured on **every** member, not only the new one; `opt-level`/`codegen-units` belong in `[profile.release.package.<name>]`, and `panic = "abort"` is never set where `catch_unwind` carries FFI errors
+- [ ] The accepted-transitive-`unsafe` note names the crates actually in `cargo tree`, verified, not the ones assumed to be there
 
 ### `unsafe`
 - [ ] The crate itself contains no `unsafe`


### PR DESCRIPTION
Applies the rust-architect **REJECT** on revision 3. Docs only.

**The reviewer compiled it.** Built a scratch crate with the plan's exact manifest and ran `cargo clippy --all-targets -- -D warnings`. Five hard compile errors and three lint failures survived revision 3 — **three of them in the files revision 3 claims to have fixed.**

## The compile errors, verified not predicted

- **Four Task 2 tests `assert_eq!` on `Result<Seed, _>`** — but `Seed` has neither `Debug` nor `PartialEq`, by my own Global Constraint. The contrast proves it was never checked: `ContentKey` *has* a hand-written `Debug`, so the identical assertion shape in Task 5 compiles fine.
- **`device.rs` called `domain::DEVICE_CERTIFICATE` with no import** — `E0433`, in the revision whose changelog says missing imports were fixed.
- **A Task 6 test passed `&str` to `is_revoked(&RevocationSubject)`.** The convenience method I added in revision 3 trained the test author to think in strings — precisely what the checklist line about convenience overloads warns about.
- `directive.content_id`, renamed to `subject` in revision 3.
- `RevocationSubject` never re-exported, so `PurgeDirective.subject` would have been a public field of an **unnameable type**.

## The live panic path, after three rounds of removing them

`DeviceKey::generate()` was infallible and called `SigningKey::generate(&mut OsRng)` → `fill_bytes`. Worse: **`impl Default for DeviceKey` called it**, so any future `#[derive(Default)]` on a containing struct would silently mint a private key. Fixed; `Default` deleted outright.

## The typestate back door

`RevocationSource::replayed_from_log` took a bare ledger and a free `String`, and **the plan's own test built one from an empty ledger and asserted `!was_blind()`** — reaching R1's original bypass through the constructor named "trustworthy", with a passing test demonstrating it.

> Provenance was a claim, not a proof: the same shape as `RevocationSubject` before the tag.

Now takes a `LogHead` witness only the log module can mint.

## Two false claims in our own documents

- **`identity::verify` used `verify()` while its doc comment claimed strict verification.** Now `verify_strict`. A false claim in the security-critical direction — the defect class that produced this entire round.
- **`fiat-crypto` is not in the dependency tree.** The DoD named it. Verified by `cargo tree`: it resolves only under a cfg nothing sets. The accepted-`unsafe` note was accurate about a crate that isn't there and silent about twelve that are.

## The helper written and not used

`push_len_prefixed` exists to keep length prefixes injective, with a dedicated `ValueTooLong` error and a comment explaining why `as u32` truncation breaks injectivity — and `header_aad` kept three raw `as u32` casts.

> A helper built and unused is worse than none, because it reads as done.

## Decided in the plan, not deferred

`[u8; 64]` has no serde impl. Revision 3 told the implementer to pick an approach — but this is the **on-disk Recovery Package format v1, frozen this phase**, and two implementers could satisfy "pick one" with two incompatible wire formats. Now a hand-written hex helper in `encoding.rs`, with `serde_bytes` / `serde-big-array` / `serde_arrays` explicitly forbidden (a crate on the crypto path needs a scorecard).

## Manifest

`#![forbid(unsafe_code)]` — the highest-value one-line change in the review, because *"pure Rust, no FFI"* was a description and nothing enforced it.

`curve25519-dalek` moved from `">=4.1.3"` to a caret: an open floor lets a future 5.0 resolve beside the `^4.1` `ed25519-dalek` needs and **link two copies of the curve implementation**.

`[profile.release]` shaped correctly — `lto`/`strip` workspace-wide, `opt-level`/`codegen-units` under `[profile.release.package.airo_mind]` only. **Never `panic = "abort"`**: `airo_core` is a `cdylib` whose FRB bridge relies on `catch_unwind` to turn panics into Dart errors. A blanket profile would have applied `opt-level="z"` to the engine on the Airo TV shipping path as an unmeasured change.

## New DoD gate

> Paste every code block into a scratch crate and run `cargo clippy --all-targets -- -D warnings`. Under ten minutes including dependency build.

Three revisions shipped non-compiling code. The fix is mechanical, and its absence is why two reviewers spent their time finding `E0433`.

## Checklist gains 27 lines

Four new sections: **The plan's code is code**, **Types over comments**, **Public surface**, **Lints and manifest**.

## Not yet applied — carried to revision 5

H1 witness for `Vault::from_payload` (crate-internal typestate) · M1/M2 `RootPublicKey` newtype · M3 `pub(crate)` on key-minting primitives · `VaultPayload` losing `Debug`/`PartialEq` and gaining `ZeroizeOnDrop` · `mod.rs` → `aggregate.rs` · `lib.rs` façade · `encoding.rs`/`random.rs` extraction.

**chief-performance-officer has still never reviewed**, and owns the `[profile.release]` half that touches `airo_core`. This crate cannot merge without them.

Refs #1193, #1205, #1207-#1212, #1260
