### PR TITLE
fix(tv): remove PiP and Cast actions from ten-foot surfaces

### DIFF
--- a/packages/feature_iptv/lib/presentation/screens/iptv_screen.dart
+++ b/packages/feature_iptv/lib/presentation/screens/iptv_screen.dart
@@ -589,13 +589,14 @@ class _IPTVScreenState extends ConsumerState<IPTVScreen>
         !widget.tenFootMode && await AiroNativePictureInPicture.isSupported();
     if (!mounted) return;
 
-    if (isGoogleCastSenderPlatform) {
+    if (!widget.tenFootMode && isGoogleCastSenderPlatform) {
       unawaited(ref.read(iptvCastProvider.notifier).startDiscovery());
     }
 
     await _showWaysToWatchDialog(
       context: context,
       pictureInPictureSupported: pictureInPictureSupported,
+      showCast: !widget.tenFootMode,
       onExitFullscreen: _exitFullscreen,
       onEnterFullscreen: () {
         if (!ref.read(isFullscreenModeProvider)) _toggleFullscreen();
@@ -777,11 +778,9 @@ class _IPTVScreenState extends ConsumerState<IPTVScreen>
               initiallyFullscreen: true,
               onFullscreenToggle: _toggleFullscreen,
               enableSwipeChannelChange: true,
-              // The Fire TV acceptance contract keeps Picture-in-picture
-              // in Player actions even when the platform ultimately
-              // reports it unavailable; hiding the row made the required
-              // seven-row remote traversal impossible.
-              showPictureInPicture: true,
+              // PiP is a phone/tablet multitasking action. Keep it out of
+              // the remote-only Android TV and Fire TV player surfaces.
+              showPictureInPicture: !widget.tenFootMode,
               useTvTransportBar: widget.tenFootMode,
             ),
           ),
@@ -881,6 +880,7 @@ class _IPTVScreenState extends ConsumerState<IPTVScreen>
 Future<void> _showWaysToWatchDialog({
   required BuildContext context,
   required bool pictureInPictureSupported,
+  required bool showCast,
   required VoidCallback onExitFullscreen,
   required VoidCallback onEnterFullscreen,
   required VoidCallback onShowCast,
@@ -895,6 +895,7 @@ Future<void> _showWaysToWatchDialog({
             castState.discovery.devices.isNotEmpty;
         return WaysToWatchDialog(
           pictureInPictureSupported: pictureInPictureSupported,
+          showCast: showCast,
           castAvailable: castAvailable,
           onFitScreen: () {
             Navigator.of(dialogContext).pop();
@@ -1077,6 +1078,7 @@ class _IPTVScreenBodyState extends ConsumerState<IPTVScreenBody>
     await _showWaysToWatchDialog(
       context: context,
       pictureInPictureSupported: pictureInPictureSupported,
+      showCast: true,
       onExitFullscreen: _exitFullscreen,
       onEnterFullscreen: () {
         if (!ref.read(isFullscreenModeProvider)) _toggleFullscreen();

--- a/packages/feature_iptv/lib/presentation/tv_ux/sections/ways_to_watch_dialog.dart
+++ b/packages/feature_iptv/lib/presentation/tv_ux/sections/ways_to_watch_dialog.dart
@@ -5,6 +5,7 @@ class WaysToWatchDialog extends StatelessWidget {
   const WaysToWatchDialog({
     super.key,
     required this.pictureInPictureSupported,
+    this.showCast = true,
     required this.castAvailable,
     required this.onFitScreen,
     required this.onFullScreen,
@@ -13,6 +14,7 @@ class WaysToWatchDialog extends StatelessWidget {
   });
 
   final bool pictureInPictureSupported;
+  final bool showCast;
   final bool castAvailable;
   final VoidCallback onFitScreen;
   final VoidCallback onFullScreen;
@@ -54,17 +56,19 @@ class WaysToWatchDialog extends StatelessWidget {
                 description: 'Keep video visible while using other apps.',
                 onSelect: onPictureInPicture,
               ),
-            const Divider(height: 28),
-            const _SectionLabel('ON ANOTHER SCREEN'),
-            _WatchOption(
-              key: const ValueKey('ways-to-watch-cast'),
-              icon: Icons.cast,
-              title: 'Cast to TV',
-              description: castAvailable
-                  ? 'Choose a nearby Cast-enabled TV.'
-                  : 'No Cast devices available.',
-              onSelect: castAvailable ? onCast : null,
-            ),
+            if (showCast) ...[
+              const Divider(height: 28),
+              const _SectionLabel('ON ANOTHER SCREEN'),
+              _WatchOption(
+                key: const ValueKey('ways-to-watch-cast'),
+                icon: Icons.cast,
+                title: 'Cast to TV',
+                description: castAvailable
+                    ? 'Choose a nearby Cast-enabled TV.'
+                    : 'No Cast devices available.',
+                onSelect: castAvailable ? onCast : null,
+              ),
+            ],
           ],
         ),
       ),

--- a/packages/feature_iptv/test/presentation/screens/iptv_screen_ten_foot_fullscreen_test.dart
+++ b/packages/feature_iptv/test/presentation/screens/iptv_screen_ten_foot_fullscreen_test.dart
@@ -32,6 +32,53 @@ class _RecordingStreamingService extends VideoPlayerStreamingService {
 }
 
 void main() {
+  testWidgets('tenFootMode: Ways to Watch excludes Cast to another TV', (
+    tester,
+  ) async {
+    tester.view.physicalSize = const Size(960, 540);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    final played = <IPTVChannel>[];
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          iptvChannelsProvider.overrideWith((ref) async => _channels),
+          recentlyWatchedChannelsProvider.overrideWith((ref) async => const []),
+          streamingStateProvider.overrideWith(
+            (ref) => Stream.value(
+              StreamingState(
+                playbackState: PlaybackState.playing,
+                currentChannel: _channels.single,
+                isLiveStream: true,
+              ),
+            ),
+          ),
+          iptvStreamingServiceProvider.overrideWith((ref) {
+            final service = _RecordingStreamingService(played: played);
+            ref.onDispose(service.dispose);
+            return service;
+          }),
+        ],
+        child: const MaterialApp(home: IPTVScreen(tenFootMode: true)),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(const ValueKey('channel-info-ways-to-watch')));
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const ValueKey('ways-to-watch-dialog')), findsOneWidget);
+    expect(
+      find.byKey(const ValueKey('ways-to-watch-cast')),
+      findsNothing,
+      reason:
+          'a remote-only Android TV or Fire TV should not offer to cast '
+          'its playback to another television',
+    );
+  });
+
   testWidgets(
     'tenFootMode: selecting a channel goes straight to fullscreen playback',
     (tester) async {
@@ -86,6 +133,15 @@ void main() {
         reason:
             'on TV, choosing a channel should open the full player '
             'directly instead of the small preview stage',
+      );
+      expect(
+        tester
+            .widget<VideoPlayerWidget>(find.byType(VideoPlayerWidget))
+            .showPictureInPicture,
+        isFalse,
+        reason:
+            'Android TV and Fire TV use a remote-only player where '
+            'Picture-in-Picture is not a meaningful action',
       );
 
       // Fire OS dispatches BACK as both a raw GoBack key and a platform


### PR DESCRIPTION
Closes #1303.

## Outcome

Android TV and Fire TV no longer expose phone-oriented multitasking/handoff actions in remote-only surfaces:

- PiP is absent from the ten-foot fullscreen player and Player actions sheet.
- Cast to TV and its “another screen” section are absent from ten-foot Ways to Watch.
- Ten-foot Ways to Watch does not start Cast discovery.
- Phone/tablet PiP and Cast remain unchanged.

## Ownership and boundary

- **Owner:** Media Intelligence Architect (`feature_iptv`)
- **Review:** TV Experience Architect, Flutter Architect, Chief UX Officer, Chief QA Officer
- **Layer:** Application only
- **Cross-agent contract:** Not required; no framework, platform-channel, persistence, dependency, or package-boundary changes.

## TDD evidence

- RED: ten-foot fullscreen mounted `VideoPlayerWidget.showPictureInPicture == true`.
- RED: ten-foot Ways to Watch rendered `ways-to-watch-cast`.
- GREEN: both caller-level regressions pass after the fix.
- GREEN: existing TV PiP-hidden and phone PiP-visible tests pass.
- GREEN: all existing Ways to Watch Cast tests pass.

## Local validation

- `dart format --set-exit-if-changed`: pass
- focused `flutter analyze` (3 touched Dart files): pass, no issues
- `iptv_screen_ten_foot_fullscreen_test.dart`: pass, 4/4
- `ways_to_watch_dialog_test.dart`: pass, 4/4
- focused `video_player_widget_test.dart` TV-hidden + phone-visible PiP cases: pass, 2/2
- `git diff --check`: pass

The full ten-foot test file emits an existing mocked-`SharedPreferences` provider diagnostic while still passing all four tests; this change does not touch that provider path.

## CI cost control

The commit uses `[skip ci]`; focused local evidence covers this bounded application-only UI change. No release/signing/artifact workflow is required.

## Rollback

Revert commit `51391e2a`. No migration or persistent-state rollback is needed.