### PR TITLE
docs: invariant I7, snapshot decision settled, performance checklist

### DIFF
--- a/docs/superpowers/specs/2026-07-27-airo-mind-review-checklists.md
+++ b/docs/superpowers/specs/2026-07-27-airo-mind-review-checklists.md
@@ -106,12 +106,17 @@ Its six questions, in order:
 - [ ] State is derived from the log, never accumulated in place
 - [ ] Concurrent operations have a defined total order
 - [ ] **[CI]** Serialized structures use `BTreeMap`, never `HashMap`
+- [ ] Replay is a single pass over the log driving all projection sinks; the pass count is asserted, not documented
+- [ ] Signature verification does not repeat on every cold start — a persisted verified-prefix watermark bounds it
 
 ### Projection rebuilds
 - [ ] **[CI]** Every `projection` module has a rebuild-from-scratch test
 - [ ] Dropping the projection loses no data (invariant I1)
 - [ ] `DestroyContent` invalidates every projection derived from that content — including embeddings, search snippets, and caches
 - [ ] No value exists only in a projection
+- [ ] **[CI]** The module declares `rebuild: incremental | full_replay` and `invalidation: targeted | full`, and the declaration is tested
+- [ ] A projection that cannot be expressed as an `apply(&mut self, &Operation)` sink declares `full_replay` and carries its measured cost
+- [ ] `DestroyContent` against a `full`-invalidation projection has a bounded, deferred rebuild path — the purge is never skipped because it is expensive
 
 ### Migration determinism
 - [ ] Migrations transform interpretation at replay; the log is never rewritten
@@ -201,10 +206,92 @@ Applied by rust-architect to any change under `rust/`.
 - [ ] `default-features = false` on a crypto crate is diffed against that crate's default list and the loss recorded — dropping `ed25519-dalek`'s `fast` removes `curve25519-dalek/precomputed-tables`
 - [ ] A workspace `[profile.release]` is measured on **every** member, not only the new one; `opt-level`/`codegen-units` belong in `[profile.release.package.<name>]`, and `panic = "abort"` is never set where `catch_unwind` carries FFI errors
 - [ ] The accepted-transitive-`unsafe` note names the crates actually in `cargo tree`, verified, not the ones assumed to be there
+- [ ] A returned `Vec` that the caller only iterates is an iterator; a returned `Vec` built solely to call `.first()` is a defect
+- [ ] `entry(k.clone())` on a map is flagged — it allocates on the hit path; use `get_mut` then `insert` on miss
+- [ ] A `&str` convenience wrapper that constructs an owned key to perform a lookup allocates on every call and belongs on the hot-path review list
 
 ### `unsafe`
 - [ ] The crate itself contains no `unsafe`
 - [ ] Transitive `unsafe` in audited third-party crypto crates is explicitly accepted and named, not passed over in silence
+
+---
+
+## Performance checklist
+
+Applied by chief-performance-officer to every Rust change, every new
+dependency, and every format decision. Performance decisions at the runtime
+layer become ABI decisions — they freeze into the on-disk format and the
+operation log, which are explicitly unretrofittable. A number not measured
+before a format ships is a number nobody can change afterwards.
+
+### Budgets exist before the code does
+- [ ] Every new runtime path has a declared budget in `packages/benchmarks` before it merges, not after
+- [ ] The budget names its device class — host, Apple Silicon, Pixel 9, mid-range Android, armv7 TV — and says which are estimated and which are measured
+- [ ] A budget that cannot be met on the slowest supported device is a design finding, not a tuning task
+- [ ] Constitution §4's `packages/benchmarks` requirement is satisfied in the phase that **freezes the format**, not the phase that first exercises it
+
+### Streaming first (I7)
+- [ ] **[CI]** Peak RSS is O(1) in collection size: the same operation over a 10x larger input allocates within a constant factor
+- [ ] No path loads a whole log, vault, package, index, or content store into memory before processing it
+- [ ] Export, restore, sync, migration, and index rebuild are resumable — a process kill mid-operation does not restart from zero
+- [ ] A single-AEAD-blob format is flagged: one tag over the whole payload makes streaming decryption impossible for the life of the format
+- [ ] Bulk formats are framed — length-prefixed records with per-frame nonces derived from a frame index, plus a sealed trailer so truncation is detected
+
+### Serialization cost is format cost
+- [ ] **[CI]** Byte arrays and ciphertext never serialize as JSON decimal arrays — measured 2.5x for structured payloads and 3.57x for high-entropy bytes
+- [ ] The serialized size of any durable format is measured against a compact binary encoding and the ratio recorded in the design
+- [ ] Serialize/deserialize wall time is measured at the largest realistic input, not a unit-test-sized one
+- [ ] `to_vec` / `from_slice` over a large buffer is flagged — it doubles peak memory through reallocation and forecloses streaming
+
+### Allocation discipline
+- [ ] No per-call allocation to perform a lookup — building an owned key to query a map is a hot-path defect
+- [ ] No deep clone of an aggregate purely to serialize it; use a borrowing serializer type
+- [ ] Accessors return iterators or borrowed slices, not freshly allocated `Vec`s
+- [ ] Merge and union operations allocate only on the miss path
+- [ ] A collection materialized twice in one function is materialized once
+
+### Replay and projections
+- [ ] Signature verification is an ingest-time obligation with a persisted verified-prefix watermark; replay below the watermark does not re-verify
+- [ ] Replay is a **single pass** fanning out to N projection sinks — assert the pass count, do not document it
+- [ ] Every projection declares `rebuild: incremental | full_replay`, incremental by default
+- [ ] Every projection declares `invalidation: targeted | full` — the cost `DestroyContent` imposes on it
+- [ ] A `full` invalidation projection has its rebuild deferred to an idle window with a bounded budget; a destroy never blocks the UI on it
+- [ ] Snapshot restore time and projection rebuild time are budgeted separately from replay throughput
+
+### Storage and mobile flash
+- [ ] Writes are sequential and append-only; no in-place rewrite of durable state
+- [ ] Small writes are group-committed with a bounded latency window; per-operation `fsync` is reserved for explicit durability points
+- [ ] The group-commit window is tuned against **measured** device fsync latency, never an estimate — it ranges 0.5 ms to 50 ms across real devices
+- [ ] Write amplification is estimated for the smallest realistic record against a 4 KB page
+- [ ] Where compaction is architecturally forbidden, a signed-checkpoint format slot is reserved before the format freezes
+- [ ] Content deduplication is either supported or explicitly ruled out in the design, with the reason, so a later optimization pass cannot reintroduce convergent encryption
+
+### Sync cost
+- [ ] Reconciliation is O(device count), not O(operation count) — per-device monotonic sequence numbers, not set reconciliation over operation IDs
+- [ ] Content is chunked so transfer is resumable and decryption is streaming; chunk size is recorded in the design
+- [ ] Backpressure has a named owner; an unbounded producer cannot outrun the local apply path
+- [ ] A no-op sync between two large, converged replicas exchanges a bounded constant, not a function of history
+
+### Ownership and contention
+- [ ] The concurrency model is decided before the first concurrent caller, not after
+- [ ] No global `Mutex` sits on both the write path and the read path of the same aggregate
+- [ ] A lifecycle owner exists for cancellation — long-running work started from the UI can be cancelled when the user navigates away or the app backgrounds
+- [ ] One thread pool per process, owned centrally; subsystems do not each construct a runtime
+- [ ] A supervisor or coordinator is a **control plane only** — no payload, projection data, or key material passes through its lock
+
+### Compiler profile and dependency features
+- [ ] **[CI]** A workspace `[profile.release]` is benchmarked on **every** member before it merges; `opt-level` and `codegen-units` belong in `[profile.release.package.<name>]`
+- [ ] `opt-level = "z"` is never applied to a throughput crate — measured at 45–58% throughput loss on `airo_core`'s M3U parser
+- [ ] `panic = "abort"` is never set where a `cdylib` FFI bridge relies on `catch_unwind` — verified in the bridge source, not assumed
+- [ ] `lto` and `strip` changes record both the size win and the CI build-time cost across the full cross-compile matrix
+- [ ] `default-features = false` on a crypto crate has the throughput cost of each dropped feature **measured** and recorded in the manifest comment — dropping `ed25519-dalek`'s `fast` costs 2.65x on signing for 49,952 bytes
+- [ ] A profile or feature change affecting a crate on a shipping path is re-measured on that path's real target — `aarch64-linux-android` and `armv7-linux-androideabi`, not only the developer's host
+- [ ] `#![forbid(unsafe_code)]` on a crate that will own storage I/O is flagged — it permanently forecloses `mmap`, and the layering must be decided before the log format freezes
+
+### Numbers, not adjectives
+- [ ] Every performance claim in a plan or design cites a measurement, its hardware, and its method
+- [ ] "Negligible", "fast enough", and "free" are rejected without a number — three review cycles found properties recorded as applied that were absent from the code, and the same failure mode applies to performance claims
+- [ ] A measured figure is re-measured when the configuration it was measured under changes
 
 ---
 

--- a/docs/superpowers/specs/2026-07-27-airo-mind-runtime-design.md
+++ b/docs/superpowers/specs/2026-07-27-airo-mind-runtime-design.md
@@ -71,10 +71,16 @@ Operation
 │     deviceId
 │     timestamp
 │     versionVector
-│     payloadHash
+│     payloadHash      (over CIPHERTEXT, never plaintext — see below)
 │     signature
 └── ContentRef → ContentID
 ```
+
+`payloadHash` covers the **ciphertext**, or is a MAC keyed under the content
+key. Hashing the plaintext would make the header an **equality oracle** —
+confirmation-of-file against a crypto-shredded device, using exactly the
+headers this section admits survive shredding. Free to fix here, expensive
+once the format is frozen.
 
 The header stays plaintext so merge, ordering, and DAG traversal work without
 decrypting anything. **Known consequence:** a device that has been
@@ -743,6 +749,40 @@ A function that accepts a raw value **and** a canonical one at the same type is
 a defect: the type must distinguish them, or the raw form must be unreachable
 past the boundary.
 
+### I7 — Streaming first
+
+**The runtime processes operations as streams wherever possible.** Never
+"load everything, then process".
+
+```
+Load everything → Process          ✗
+Read → Validate → Replay → Discard  ✓
+```
+
+Applies to replay, sync, export, restore, migration, projections, and search
+indexing.
+
+**Status: adopted as an invariant, NOT yet satisfiable.** Per I5 this
+distinction is recorded rather than glossed — the Phase 1 Recovery Package
+format violates I7 by construction, and recording I7 as applied against it
+would be the fourth consecutive instance of the failure I5 exists to prevent.
+
+Measured violations, chief-performance-officer:
+
+| Site | Why |
+|---|---|
+| `RecoveryPackage::export` | Whole-vault materialization; **8.6× blow-up, ~450–600 MiB peak at 100k contents** |
+| `RecoveryPackage::to_bytes` | `serde_json::to_vec` over full ciphertext; 3.57× expansion, 444 ms/64 MiB |
+| `RecoveryPackage::from_bytes` | Whole file plus parsed copy resident before one byte is verified |
+| Single-blob AEAD | One tag over the whole payload — **this is why the three above cannot be fixed without a format change** |
+| `Vault` | Entire content-envelope index resident, no paging |
+| `#![forbid(unsafe_code)]` | Forecloses `mmap`, the primary zero-copy streaming mechanism |
+
+I7's **failing form**: export a synthetic 100k-content vault, assert peak RSS
+is within a constant of a 10k-content vault. It lands with the framed-package
+format (#1305) and the storage-layer split (#1307), in one change — never as
+prose against a format that cannot satisfy it.
+
 ## 11b. Architecture compliance
 
 Invariants that only a reviewer can check are invariants that erode. Every
@@ -867,7 +907,7 @@ evidence would be guessing.
 
 | Question | Decided in |
 |---|---|
-| Are snapshots authoritative or cache-only? Cache-only preserves the "log is truth" guarantee but makes cold start slow; authoritative reintroduces a second source of truth. Replay cost grows as `log_length × migration_chain_depth`. | Phase 3 |
+| ~~Are snapshots authoritative or cache-only?~~ **DECIDED: cache-only, with a persisted verified-prefix watermark.** Settled on measured grounds, not philosophical ones — ed25519 verification is 32.9–36.3 µs/op and 50–80× everything else combined, so cache-only cold start is 33 s per million operations *unless* verification is an ingest-time obligation. Without the watermark the pressure to make snapshots authoritative — voiding I1 — becomes irresistible. **The watermark is what protects the invariant.** | Resolved |
 | Header metadata leak. `entityId` / `schemaId` / `capabilityId` survive crypto-shredding in plaintext and may be observable on the wire. Existing redaction precedent: `platform_network_discovery` (`prohibitedFieldName`, `credentialLikeValue`). | Phases 2 and 7 |
 | Automation idempotency. Two devices replaying the same trigger must not produce two reminders. Single-executor election, or deterministic operation IDs derived from trigger state? | Phase 8 |
 | Conflict review UX. How a `manual`-merge conflict on a medical field is surfaced without training users to tap Accept. | Phase 7 |


### PR DESCRIPTION
Applies the chief-performance-officer review. Docs only. **REJECT** — three P0 findings, all measured against real benchmarks, all in v1-frozen formats.

## The profile question is settled, with numbers, and it is not a blocker

| `airo_core` bench | `opt-level=3` | `opt-level="z"` | delta |
|---|---|---|---|
| `iptv_org_index` | 4.870 ms | 7.700 ms | **+58.1%** |
| `iptv_org_index_channels` | 22.99 ms | 33.30 ms | **+44.9%** |

A blanket profile costs the TV playlist engine **45–58% of its throughput** to save binary on a crate that isn't the one growing. Rejected permanently.

`lto="fat"` + `codegen-units=1` + `strip` is a **7–11% throughput win** for `airo_core` plus **−474 KB (−31.7%)**. Approved workspace-wide, at +22% clean build across eight release jobs.

`panic="abort"` rejected and **independently verified in the FRB source** — `handler.rs:95` and `executor.rs:69` both wrap invocations in `catch_unwind`.

## P0-1 — the Recovery Package blows up 8.6× (#1305)

```
26 MB logical vault → 63 MiB JSON (2.51x) → 225 MiB file (3.57x)
= 8.6x, ~450-600 MiB peak RSS at 100k contents
```

**OOM on mid-range Android**, and the failure mode is "cannot export the Recovery Package" — the one artifact whose absence is unrecoverable.

The framing that explains it: §6.1 calls the package *"grants access; carries no data"*, but the Vault holds one `ContentEnvelope` per content object.

> **The Vault is O(all user content), not O(keys). The format was designed against the description, not the structure.**

## P0-2 — verification makes every replay budget unachievable (#1306)

ed25519 verify is **32.9–36.3 µs/op**; XChaCha20Poly1305 unwrap is **0.44 µs**. Verification is **50–80× everything else combined**.

"Replay 100k ops < 5s" spends **73% of its budget on verification alone, on the fastest device we ship.**

Fixed by making verification an ingest-time obligation with a persisted **verified-prefix watermark** — which also **settles §12's snapshot question as cache-only**, on measured grounds:

> Without the watermark, cold start is 33 s per million operations forever, and the pressure to make snapshots authoritative — voiding I1 — becomes irresistible. **The watermark is what protects the invariant.**

## P0-3 — `forbid(unsafe_code)` forecloses mmap on the log crate (#1307)

`forbid` cannot be locally overridden, and §9 puts the operation log in that crate. Not a request to weaken the lint — a request to decide the layering now. A sentence today; a crate split against a frozen format later.

## I7 — adopted, and explicitly recorded as not yet satisfiable

Eight measured violation sites enumerated. Per **I5** that distinction is the whole point:

> Recording I7 as applied against a format that violates it by construction would be the fourth consecutive instance of the failure I5 exists to prevent.

Failing form: export a 100k-content vault, assert peak RSS within a constant of a 10k-content vault.

## Two security crossovers, now fixed or filed

**`payloadHash` was over the plaintext** — an **equality oracle**, confirmation-of-file against a crypto-shredded device using exactly the headers §3.1 admits survive shredding. Now covers the ciphertext.

**`destroy_context` returns only the context ID** — content wrapped only under it is orphaned, and the caller is never told which, so shredding steps 4–8 cannot run for them. Both an O(all-content) scan and an incomplete-shred hole. Needs chief-security-officer.

## Measured, concern retired

PBKDF2 2048 rounds: **3.16 ms** Apple Silicon, ~19 ms pessimistic mid-range. Not a problem.

## The reviewer's own honest limit

> I can approve the profile *shape* from measured Apple Silicon data. I cannot approve its impact on the Airo TV shipping path from a Mac. I am naming it as an open obligation against my own approval rather than signing it blind.

Five measurements named as unobtainable from the host, including per-append fsync latency — which sets the group-commit window and ranges 0.5 ms to 50 ms across real devices.

## Performance checklist added

46 lines, eight subsections. The one that generalises the review:

> Every performance claim cites a measurement, its hardware, and its method. "Negligible", "fast enough", and "free" are rejected without a number.

Refs #1193, #1205, #1302, #1305, #1306, #1307, #1308
