### PR TITLE
Route Mind chat to installed Gemma

### DIFF
--- a/app/lib/features/agent_chat/presentation/screens/model_library_screen.dart
+++ b/app/lib/features/agent_chat/presentation/screens/model_library_screen.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:core_ai/core_ai.dart';
 import 'package:core_ui/core_ui.dart';
 import 'package:flutter/foundation.dart';
@@ -283,7 +285,7 @@ class AssistantModelLibraryState {
     }
     final candidates = candidatesById.values.toList();
 
-    final recommended = _recommend(candidates, task, defaultPackages);
+    final recommended = recommend(candidates, task, defaultPackages);
     return AssistantModelLibraryState(
       task: task,
       deviceLabel: deviceLabel.isEmpty ? 'Unknown device' : deviceLabel,
@@ -294,7 +296,7 @@ class AssistantModelLibraryState {
     );
   }
 
-  static AssistantModelCandidate _recommend(
+  static AssistantModelCandidate recommend(
     List<AssistantModelCandidate> candidates,
     AssistantTask task,
     Map<AssistantTask, OfflineModelInfo> packages,
@@ -302,8 +304,8 @@ class AssistantModelLibraryState {
     final package = packages[task];
     final preferredIds = switch (task) {
       AssistantTask.chat => [
-        geminiNanoAssistantModelId,
         litertGemmaAssistantModelId,
+        geminiNanoAssistantModelId,
         if (package != null) assistantModelIdForOfflineModel(package.id),
       ],
       AssistantTask.actions => [
@@ -361,7 +363,7 @@ class AssistantModelLibraryState {
   }
 
   AssistantModelCandidate recommendedFor(AssistantTask task) {
-    return _recommend(candidates, task, defaultPackages);
+    return recommend(candidates, task, defaultPackages);
   }
 
   OfflineModelInfo? packageFor(AssistantTask task) {
@@ -693,38 +695,40 @@ class _ModelLibraryContent extends ConsumerWidget {
     );
     var cancelRequested = false;
 
-    final dialogFuture = showDialog<void>(
-      context: context,
-      barrierDismissible: false,
-      builder: (context) {
-        return ValueListenableBuilder<AssistantRuntimePreparationProgress>(
-          valueListenable: progress,
-          builder: (context, value, _) {
-            return AlertDialog(
-              title: Text('${template.title} setup'),
-              content: Column(
-                mainAxisSize: MainAxisSize.min,
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Text(value.label),
-                  const SizedBox(height: 8),
-                  LinearProgressIndicator(value: value.progress),
-                  const SizedBox(height: 12),
-                  Text(value.detail),
-                ],
-              ),
-              actions: [
-                TextButton(
-                  onPressed: () {
-                    cancelRequested = true;
-                  },
-                  child: Text(cancelRequested ? 'Stopping…' : 'Cancel'),
+    unawaited(
+      showDialog<void>(
+        context: context,
+        barrierDismissible: false,
+        builder: (context) {
+          return ValueListenableBuilder<AssistantRuntimePreparationProgress>(
+            valueListenable: progress,
+            builder: (context, value, _) {
+              return AlertDialog(
+                title: Text('${template.title} setup'),
+                content: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(value.label),
+                    const SizedBox(height: 8),
+                    LinearProgressIndicator(value: value.progress),
+                    const SizedBox(height: 12),
+                    Text(value.detail),
+                  ],
                 ),
-              ],
-            );
-          },
-        );
-      },
+                actions: [
+                  TextButton(
+                    onPressed: () {
+                      cancelRequested = true;
+                    },
+                    child: Text(cancelRequested ? 'Stopping…' : 'Cancel'),
+                  ),
+                ],
+              );
+            },
+          );
+        },
+      ),
     );
 
     final result = await runtimeService.prepareRuntime(
@@ -736,7 +740,6 @@ class _ModelLibraryContent extends ConsumerWidget {
     progress.dispose();
     if (context.mounted) {
       Navigator.of(context, rootNavigator: true).pop();
-      await dialogFuture;
     }
 
     if (!context.mounted) {

--- a/app/test/features/agent_chat/presentation/screens/model_library_screen_test.dart
+++ b/app/test/features/agent_chat/presentation/screens/model_library_screen_test.dart
@@ -9,6 +9,44 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 void main() {
+  test('chat prefers an installed Gemma package over Gemini Nano', () {
+    const nano = AssistantModelCandidate(
+      id: geminiNanoAssistantModelId,
+      name: 'Gemini Nano',
+      runtime: 'AICore on-device',
+      description: 'System runtime',
+      bestFor: [AssistantTask.chat],
+      tags: ['Local'],
+      privacyLabel: 'Prompt stays on device',
+      sizeLabel: 'System managed',
+      available: true,
+      actionLabel: 'Start chat',
+      local: true,
+    );
+    const gemma = AssistantModelCandidate(
+      id: litertGemmaAssistantModelId,
+      name: 'Gemma mobile package',
+      runtime: 'LiteRT-LM local model',
+      description: 'Downloaded package',
+      bestFor: [AssistantTask.chat],
+      tags: ['Local', 'Gemma'],
+      privacyLabel: 'Prompt stays on device',
+      sizeLabel: '2.4 GB',
+      available: true,
+      actionLabel: 'Start chat',
+      local: true,
+    );
+
+    expect(
+      AssistantModelLibraryState.recommend(
+        [nano, gemma],
+        AssistantTask.chat,
+        const {},
+      ).id,
+      litertGemmaAssistantModelId,
+    );
+  });
+
   testWidgets(
     'shows diagnostics instead of launching unsupported local runtime',
     (tester) async {
@@ -289,6 +327,79 @@ void main() {
     expect(find.text('Device fit: Cannot load'), findsWidgets);
     expect(find.text('Insufficient memory.'), findsWidgets);
     expect(find.text('Needs 4096 MB, device has 1024 MB free.'), findsWidgets);
+  });
+  testWidgets('selects Gemma and closes setup after a successful warmup', (
+    tester,
+  ) async {
+    SharedPreferences.setMockInitialValues({});
+    final package = OfflineModelInfo(
+      id: 'gemma-4-e2b-it-litertlm',
+      name: 'Gemma 4 E2B',
+      family: ModelFamily.gemma,
+      fileSizeBytes: 2 * 1024 * 1024 * 1024,
+      backendPreference: ModelBackendPreference.gpu,
+      provider: AIProvider.gemma,
+      capabilities: const [ModelCapability.chat],
+      filePath: '/models/gemma-4-e2b-it.litertlm',
+    );
+    final candidate = AssistantModelCandidate(
+      id: litertGemmaAssistantModelId,
+      name: 'Gemma mobile package',
+      runtime: 'LiteRT-LM local model',
+      description: 'Local package',
+      bestFor: const [AssistantTask.chat],
+      tags: const ['Local', 'Gemma'],
+      privacyLabel: 'Prompt stays on device',
+      sizeLabel: package.fileSizeDisplay,
+      available: true,
+      actionLabel: 'Start',
+      local: true,
+      package: package,
+    );
+    final state = AssistantModelLibraryState(
+      task: AssistantTask.chat,
+      deviceLabel: 'Pixel 9',
+      platformLabel: 'ANDROID',
+      candidates: [candidate],
+      recommended: candidate,
+      defaultPackages: {AssistantTask.chat: package},
+    );
+    AssistantModelCandidate? selected;
+    final runtimeService = AssistantRuntimeService(
+      loadDeviceInfo: () async => {
+        'manufacturer': 'Google',
+        'model': 'Pixel 9',
+        'platform': 'android',
+      },
+      isLiteRtAvailable: () async => true,
+      checkModelCompatibility: (_) async => const ModelCompatibilityResult(
+        isCompatible: true,
+        memorySeverity: MemorySeverity.safe,
+      ),
+      warmupLiteRtModel: (_) async => true,
+    );
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          assistantModelLibraryProvider.overrideWith((ref) async => state),
+          selectedAssistantModelIdProvider.overrideWith(
+            (ref) => _SelectedAssistantModelNotifier(),
+          ),
+        ],
+        child: MaterialApp(
+          home: ModelLibraryScreen(
+            runtimeService: runtimeService,
+            onModelSelected: (value) => selected = value,
+            onOpenModelManager: () {},
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Start chat'));
+    await tester.pumpAndSettle();
+    expect(selected?.id, litertGemmaAssistantModelId);
+    expect(find.text('General Chat setup'), findsNothing);
   });
 }
 


### PR DESCRIPTION
## Summary
- prefer an installed Gemma package for General Chat over Gemini Nano
- close the local runtime setup dialog after warm-up so the chat composer opens
- add regression coverage for selection and successful warm-up transition

## Validation
- `flutter test test/features/agent_chat/presentation/screens/model_library_screen_test.dart`
- `flutter analyze lib/features/agent_chat/presentation/screens/model_library_screen.dart lib/features/agent_chat/data/services/assistant_runtime_service.dart test/features/agent_chat/presentation/screens/model_library_screen_test.dart`
- `flutter build apk --debug`
- Pixel 9: Mind General Chat card selected `Gemma mobile package`; warm-up attempted the LiteRT-Gemma path. Final prompt verification remains pending device reconnect after reboot.
