### PR TITLE
feat(iptv): expose source management extension seam

### DIFF
--- a/app/lib/features/settings/presentation/tv/tv_settings_screen.dart
+++ b/app/lib/features/settings/presentation/tv/tv_settings_screen.dart
@@ -108,7 +108,7 @@ class _TvSettingsScreenState extends ConsumerState<TvSettingsScreen> {
           key: ValueKey('tv_settings_section_playback'),
         );
       case IptvSettingsSectionId.sources:
-        return const TvSourceManagementSection(
+        return ref.watch(tvSourceManagementSectionBuilderProvider)(
           key: ValueKey('tv_settings_section_sources'),
         );
       case IptvSettingsSectionId.accessibility:

--- a/app/test/features/settings/presentation/tv/tv_settings_screen_test.dart
+++ b/app/test/features/settings/presentation/tv/tv_settings_screen_test.dart
@@ -63,4 +63,36 @@ void main() {
       findsNothing,
     );
   });
+
+  testWidgets('resolves the Sources pane through the composition provider', (
+    tester,
+  ) async {
+    final prefs = await SharedPreferences.getInstance();
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          sharedPreferencesProvider.overrideWithValue(prefs),
+          secureStoreProvider.overrideWithValue(InMemorySecureStore()),
+          tvSourceManagementSectionBuilderProvider.overrideWithValue(
+            ({key}) => SizedBox(
+              key: key,
+              child: const Text('Product source management'),
+            ),
+          ),
+        ],
+        child: const MaterialApp(home: TvSettingsScreen()),
+      ),
+    );
+    await tester.pump();
+
+    await tester.tap(find.text('Sources'));
+    await tester.pump();
+
+    expect(find.text('Product source management'), findsOneWidget);
+    expect(
+      find.byKey(const ValueKey('tv_settings_section_sources')),
+      findsOneWidget,
+    );
+    expect(find.byType(TvSourceManagementSection), findsNothing);
+  });
 }

--- a/packages/feature_iptv/lib/presentation/tv/settings/tv_source_management_section.dart
+++ b/packages/feature_iptv/lib/presentation/tv/settings/tv_source_management_section.dart
@@ -4,6 +4,33 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:platform_playlist/platform_playlist.dart';
 
+/// Adds product-owned actions to a configured source row.
+///
+/// [ContentSourceConfig] never contains raw Xtream/Jellyfin credentials.
+/// Consumers that need credentials must resolve them independently through
+/// [contentSourceCredentialStoreProvider] rather than widening this UI
+/// contract.
+typedef TvSourceActionsBuilder =
+    List<Widget> Function(
+      BuildContext context,
+      WidgetRef ref,
+      ContentSourceConfig source,
+    );
+
+/// Builds the Sources detail pane for the TV settings shell.
+typedef TvSourceManagementSectionBuilder = Widget Function({Key? key});
+
+/// Product-composition seam for the TV Sources detail pane.
+///
+/// The public product always resolves to [TvSourceManagementSection].
+/// Overlays may replace the pane while continuing to compose that baseline
+/// widget and its source-management behavior.
+final tvSourceManagementSectionBuilderProvider =
+    Provider<TvSourceManagementSectionBuilder>(
+      (ref) =>
+          ({Key? key}) => TvSourceManagementSection(key: key),
+    );
+
 /// Content-source management section (CV-022 + CV-032): list configured
 /// sources with their capability flags, add a source of any kind
 /// (M3U / Xtream / Stalker / Jellyfin), remove any source with
@@ -11,7 +38,12 @@ import 'package:platform_playlist/platform_playlist.dart';
 /// [XmltvSourceSheet] (a separate concept — EPG data, not a channel/VOD
 /// source).
 class TvSourceManagementSection extends ConsumerStatefulWidget {
-  const TvSourceManagementSection({super.key});
+  const TvSourceManagementSection({super.key, this.sourceActionsBuilder});
+
+  /// Optional product actions rendered before Remove on every source row.
+  ///
+  /// Returning an empty list preserves the baseline row exactly.
+  final TvSourceActionsBuilder? sourceActionsBuilder;
 
   @override
   ConsumerState<TvSourceManagementSection> createState() =>
@@ -345,17 +377,27 @@ class _TvSourceManagementSectionState
                           ),
                         ],
                       ),
-                      trailing: TvFocusable(
-                        onSelect: () => _confirmRemove(config),
-                        semanticLabel: 'Remove ${config.label}',
-                        semanticButton: true,
-                        child: IconButton(
-                          icon: Icon(
-                            Icons.delete_outline,
-                            color: colorScheme.onSurface,
+                      trailing: Row(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          ...?widget.sourceActionsBuilder?.call(
+                            context,
+                            ref,
+                            config,
                           ),
-                          onPressed: () => _confirmRemove(config),
-                        ),
+                          TvFocusable(
+                            onSelect: () => _confirmRemove(config),
+                            semanticLabel: 'Remove ${config.label}',
+                            semanticButton: true,
+                            child: IconButton(
+                              icon: Icon(
+                                Icons.delete_outline,
+                                color: colorScheme.onSurface,
+                              ),
+                              onPressed: () => _confirmRemove(config),
+                            ),
+                          ),
+                        ],
                       ),
                     ),
                 ],

--- a/packages/feature_iptv/test/iptv/presentation/tv/settings/tv_source_management_section_test.dart
+++ b/packages/feature_iptv/test/iptv/presentation/tv/settings/tv_source_management_section_test.dart
@@ -364,4 +364,45 @@ void main() {
       expect(sources, isEmpty);
     },
   );
+
+  testWidgets('renders injected actions beside each configured source', (
+    tester,
+  ) async {
+    final container = await buildContainer();
+    addTearDown(container.dispose);
+    await container.read(
+      addM3uContentSourceProvider((
+        label: 'Inspectable Playlist',
+        url: 'https://example.com/playlist.m3u',
+      )).future,
+    );
+    await tester.pump(const Duration(milliseconds: 1));
+    final source = (await container.read(
+      configuredContentSourcesProvider.future,
+    )).single;
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: MaterialApp(
+          home: Scaffold(
+            body: TvSourceManagementSection(
+              sourceActionsBuilder: (context, ref, source) => [
+                IconButton(
+                  key: ValueKey('inspect-${source.id}'),
+                  onPressed: () {},
+                  icon: const Icon(Icons.search),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+    await tester.pump();
+
+    expect(find.byKey(ValueKey('inspect-${source.id}')), findsOneWidget);
+    expect(find.byIcon(Icons.delete_outline), findsOneWidget);
+  });
 }

--- a/tasks/issue-1320-plan.md
+++ b/tasks/issue-1320-plan.md
@@ -1,0 +1,54 @@
+# Issue 1320 — Source-management composition seam
+
+## Objective
+
+Add a narrow, additive extension contract to the public TV source-management
+surface so product compositions can contribute per-source row actions and
+replace the section widget without copying the baseline implementation.
+
+## Ownership
+
+- Primary: Framework Agent (`feature_iptv` UI contract)
+- Review: Airo TV Application Agent, QA Automation Agent
+- Layer: framework contract consumed by application composition
+- Base: `DevelopersCoffee/airo@8d58b3a97d35cfb23d63e6fd13d6b00c5112affe`
+
+## Contract
+
+`TvSourceManagementSection` accepts an optional row-actions builder. The
+builder receives only the existing non-secret `ContentSourceConfig` and returns
+zero or more widgets rendered before the existing Remove action.
+
+`tvSourceManagementSectionBuilderProvider` returns the baseline section by
+default. `TvSettingsScreen` resolves its Sources detail through that provider,
+allowing a product-level `ProviderScope` override.
+
+No credentials, HTTP behavior, entitlement logic, persistence, or error
+mapping enters the public framework.
+
+## Red-green-refactor sequence
+
+1. Add failing feature widget coverage for an injected per-source action.
+2. Add failing app widget coverage for a section-builder provider override.
+3. Implement the smallest additive typedefs, constructor field, row rendering,
+   provider, and settings-screen consumption needed to pass.
+4. Run focused tests, format, analyze affected packages/app, and execute
+   repository contract checks.
+5. Review correctness, clarity, consistency, duplication, tests, and
+   performance before the atomic implementation commit.
+
+## Verification
+
+- `flutter test test/iptv/presentation/tv/settings/tv_source_management_section_test.dart`
+  from `packages/feature_iptv`
+- `flutter test test/features/settings/presentation/tv/tv_settings_screen_test.dart`
+  from `app`
+- `flutter analyze` for `packages/feature_iptv` and affected app files
+- `./scripts/validate_module_manifests.sh`
+- `./scripts/check_import_boundaries.sh`
+- `git diff --check`
+
+## Rollback
+
+Revert the additive implementation commit. The default provider and null row
+builder preserve baseline behavior, and there is no data migration.

--- a/tasks/issue-1320-todo.md
+++ b/tasks/issue-1320-todo.md
@@ -1,0 +1,16 @@
+# Issue 1320 checklist
+
+- [x] Confirm owning and reviewing agents.
+- [x] Pass the Critical Agent clarity gate.
+- [x] Define the cross-agent contract.
+- [x] Add deterministic use cases and host-only automation flow to #1320.
+- [x] Classify the work as a public framework contract.
+- [x] Fetch and verify the latest public `main` base.
+- [ ] Add the feature-package test and capture the expected red failure.
+- [ ] Add the app composition test and capture the expected red failure.
+- [ ] Implement the row-action builder contract.
+- [ ] Implement and consume the defaultable section-builder provider.
+- [ ] Pass focused feature and app widget tests.
+- [ ] Pass affected analysis and repository contract checks.
+- [ ] Complete the five-axis review and secret/diff checks.
+- [ ] Push a template-compliant PR and qualify relevant CI.

--- a/tasks/issue-1320-todo.md
+++ b/tasks/issue-1320-todo.md
@@ -6,11 +6,11 @@
 - [x] Add deterministic use cases and host-only automation flow to #1320.
 - [x] Classify the work as a public framework contract.
 - [x] Fetch and verify the latest public `main` base.
-- [ ] Add the feature-package test and capture the expected red failure.
-- [ ] Add the app composition test and capture the expected red failure.
-- [ ] Implement the row-action builder contract.
-- [ ] Implement and consume the defaultable section-builder provider.
-- [ ] Pass focused feature and app widget tests.
-- [ ] Pass affected analysis and repository contract checks.
-- [ ] Complete the five-axis review and secret/diff checks.
+- [x] Add the feature-package test and capture the expected red failure.
+- [x] Add the app composition test and capture the expected red failure.
+- [x] Implement the row-action builder contract.
+- [x] Implement and consume the defaultable section-builder provider.
+- [x] Pass focused feature and app widget tests.
+- [x] Pass affected analysis and repository contract checks.
+- [x] Complete the five-axis review and secret/diff checks.
 - [ ] Push a template-compliant PR and qualify relevant CI.


### PR DESCRIPTION
## Summary

- add a credential-safe `TvSourceActionsBuilder` extension point to configured source rows
- add a defaultable `tvSourceManagementSectionBuilderProvider` for product composition
- resolve the TV Sources detail through the provider while preserving the public default
- add focused feature/app widget contract coverage

Closes #1320. Unblocks DevelopersCoffee/airo-pro#31.

## Test Plan

- [x] `flutter analyze` or relevant package analyzer passed
- [x] `flutter test` or relevant package tests passed
- [x] CI-only change validated with local script/YAML checks
- [x] Manual device/simulator verification documented, or not applicable

**Verification environment:** Host-only

Evidence:
- `feature_iptv` focused widget tests: 10 passed
- app TV settings focused widget tests: 3 passed
- `flutter analyze --fatal-infos` for `feature_iptv`: no issues
- affected app analysis: no issues
- module manifests, edge import boundaries, and all variant dependency solves: passed

## Agent Policy

- [x] Linked issue includes a Critical Agent Gate.
- [x] Linked issue includes a Feature Packet or documents why one is not needed.
- [x] Cross-agent contract is documented for framework/application boundary work.
- [x] Deterministic use cases and automation flows are linked or included.
- [x] AI/tool/memory/routine changes include eval, trace, and redaction coverage. (Not applicable: no AI/tool/memory/routine change.)
- [x] Android Emulator was not used unless the linked issue explicitly accepted `AIRO_ALLOW_ANDROID_EMULATOR=true`.

## Council Review

- Flutter Architect: reviewed in Codex session; additive Riverpod provider and widget callback follow existing composition patterns, no blocker.
- Chief Performance Officer: reviewed in Codex session; callback work is O(configured sources), introduces no I/O or persistent listener, no blocker.
- Chief Open Source Officer: reviewed in Codex session; additive public API, no new dependency or license surface, no blocker.
- Security and Privacy Agent: reviewed credential boundary; callback receives `ContentSourceConfig` only and never raw secure-store values, no blocker.
- QA Automation Agent: reviewed red/green host-only widget flows and baseline regression coverage, no blocker.

- [x] I checked the Decision Matrix and listed every required role above.
- [x] Every package touched has a `module.yaml`; if not, this PR adds one (`scripts/check-module-manifests.py` enforces this in CI).
- [x] `owner`/`reviewers` in any touched `module.yaml` still match who actually reviewed this PR — no roster change required.

## User-Facing Documentation

- [ ] I updated `docs/wiki` for any user-visible feature, route, platform, install, AI/model, privacy, file-type, media, game, finance, or troubleshooting change.
- [x] No `docs/wiki` update is needed because this PR has no user-visible behavior or documentation impact.

## Plugin and Size Impact

- [ ] This PR adds new dependencies
- [x] This PR adds or grows app/packages/plugins code
- [x] Size impact is documented below
- [x] Any module over 3 MB is a plugin or has an explicit plugin marker
- [x] Any plugin over 5 MB has cache-management documentation

Size impact / plugin justification: approximately 134 changed lines of Dart/tests/docs; no binary asset, dependency, plugin, or runtime cache impact.

## Checklist

- [x] Code is formatted.
- [x] Tests or manual verification are included above.
- [x] Sensitive data, credentials, and signing artifacts are not committed.

## Release Notes

- [x] User-facing change documented, or not applicable