### PR TITLE
fix(ci): preserve untouched APK baselines

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -721,19 +721,11 @@ jobs:
 
       - name: Commit updated APK size baselines
         run: |
-          {
-            echo "# APK size guardrail baselines."
-            echo "#"
-            echo "# Columns:"
-            echo "# component: CI build component that produced the APK."
-            echo "# artifact: APK file name produced by Flutter."
-            echo "# baseline_bytes: approved baseline size in bytes."
-            echo "# budget_mb: absolute artifact budget in MiB."
-            echo "#"
-            echo "# This file is updated automatically after successful main builds."
-            echo -e "component\tartifact\tbaseline_bytes\tbudget_mb"
-            sort apk-size-baseline-updates/*.tsv
-          } > .github/apk-size-baselines.tsv
+          chmod +x scripts/merge-apk-size-baselines.py
+          scripts/merge-apk-size-baselines.py \
+            --baseline .github/apk-size-baselines.tsv \
+            --updates-dir apk-size-baseline-updates \
+            --output .github/apk-size-baselines.tsv
 
           if git diff --quiet -- .github/apk-size-baselines.tsv; then
             echo "APK size baselines are unchanged."

--- a/scripts/merge-apk-size-baselines.py
+++ b/scripts/merge-apk-size-baselines.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""Merge partial APK size measurements into the committed complete baseline."""
+
+from __future__ import annotations
+
+import argparse
+import os
+from pathlib import Path
+import tempfile
+
+HEADER = """# APK size guardrail baselines.
+#
+# Columns:
+# component: CI build component that produced the APK.
+# artifact: APK file name produced by Flutter.
+# baseline_bytes: approved baseline size in bytes.
+# budget_mb: absolute artifact budget in MiB.
+#
+# This file is updated automatically after successful main builds.
+component\tartifact\tbaseline_bytes\tbudget_mb
+"""
+
+BaselineKey = tuple[str, str]
+BaselineRow = tuple[str, str, int, str]
+
+
+def _read_rows(path: Path) -> list[BaselineRow]:
+    rows: list[BaselineRow] = []
+    for line_number, raw_line in enumerate(
+        path.read_text(encoding="utf-8").splitlines(),
+        start=1,
+    ):
+        line = raw_line.strip()
+        if not line or line.startswith("#") or line.startswith("component\t"):
+            continue
+        columns = line.split("\t")
+        if len(columns) != 4:
+            raise ValueError(
+                f"{path}:{line_number}: expected 4 tab-separated columns"
+            )
+        component, artifact, raw_bytes, budget_mb = columns
+        if not component or not artifact:
+            raise ValueError(
+                f"{path}:{line_number}: component and artifact are required"
+            )
+        try:
+            baseline_bytes = int(raw_bytes)
+            budget = float(budget_mb)
+        except ValueError as error:
+            raise ValueError(
+                f"{path}:{line_number}: bytes and budget must be numeric"
+            ) from error
+        if baseline_bytes <= 0 or budget <= 0:
+            raise ValueError(
+                f"{path}:{line_number}: bytes and budget must be positive"
+            )
+        rows.append((component, artifact, baseline_bytes, budget_mb))
+    return rows
+
+
+def merge_baselines(
+    baseline: Path,
+    updates_dir: Path,
+) -> dict[BaselineKey, BaselineRow]:
+    if not baseline.is_file():
+        raise ValueError(f"baseline file not found: {baseline}")
+    if not updates_dir.is_dir():
+        raise ValueError(f"updates directory not found: {updates_dir}")
+
+    update_files = sorted(updates_dir.glob("*.tsv"))
+    if not update_files:
+        raise ValueError(f"no baseline update files found in: {updates_dir}")
+
+    merged: dict[BaselineKey, BaselineRow] = {}
+    for row in _read_rows(baseline):
+        key = (row[0], row[1])
+        if key in merged:
+            raise ValueError(f"{baseline}: duplicate baseline key: {key}")
+        merged[key] = row
+
+    update_keys: set[BaselineKey] = set()
+    for update_file in update_files:
+        for row in _read_rows(update_file):
+            key = (row[0], row[1])
+            if key in update_keys:
+                raise ValueError(f"{update_file}: duplicate update key: {key}")
+            update_keys.add(key)
+            merged[key] = row
+
+    return merged
+
+
+def write_baselines(
+    output: Path,
+    rows: dict[BaselineKey, BaselineRow],
+) -> None:
+    output.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.NamedTemporaryFile(
+        mode="w",
+        encoding="utf-8",
+        dir=output.parent,
+        prefix=f".{output.name}.",
+        delete=False,
+    ) as temporary:
+        temporary.write(HEADER)
+        for key in sorted(rows):
+            component, artifact, baseline_bytes, budget_mb = rows[key]
+            temporary.write(
+                f"{component}\t{artifact}\t{baseline_bytes}\t{budget_mb}\n"
+            )
+        temporary_path = Path(temporary.name)
+    os.replace(temporary_path, output)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--baseline", type=Path, required=True)
+    parser.add_argument("--updates-dir", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+
+    try:
+        rows = merge_baselines(args.baseline, args.updates_dir)
+        write_baselines(args.output, rows)
+    except ValueError as error:
+        parser.error(str(error))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test-merge-apk-size-baselines.sh
+++ b/scripts/test-merge-apk-size-baselines.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+MERGER="$ROOT_DIR/scripts/merge-apk-size-baselines.py"
+TMP_DIR="$(mktemp -d)"
+
+cleanup() {
+  rm -rf "$TMP_DIR"
+}
+trap cleanup EXIT
+
+mkdir -p "$TMP_DIR/updates"
+
+cat >"$TMP_DIR/baseline.tsv" <<'EOF'
+# APK size guardrail baselines.
+component	artifact	baseline_bytes	budget_mb
+full	app-arm64-v8a-release.apk	100	35
+tv	app-arm64-v8a-release.apk	200	35
+coins	app-arm64-v8a-release.apk	300	25
+EOF
+
+cat >"$TMP_DIR/updates/full.tsv" <<'EOF'
+full	app-arm64-v8a-release.apk	110	35
+EOF
+
+cat >"$TMP_DIR/updates/tv.tsv" <<'EOF'
+tv	app-arm64-v8a-release.apk	220	35
+EOF
+
+python3 "$MERGER" \
+  --baseline "$TMP_DIR/baseline.tsv" \
+  --updates-dir "$TMP_DIR/updates" \
+  --output "$TMP_DIR/merged.tsv"
+
+cat >"$TMP_DIR/expected.tsv" <<'EOF'
+# APK size guardrail baselines.
+#
+# Columns:
+# component: CI build component that produced the APK.
+# artifact: APK file name produced by Flutter.
+# baseline_bytes: approved baseline size in bytes.
+# budget_mb: absolute artifact budget in MiB.
+#
+# This file is updated automatically after successful main builds.
+component	artifact	baseline_bytes	budget_mb
+coins	app-arm64-v8a-release.apk	300	25
+full	app-arm64-v8a-release.apk	110	35
+tv	app-arm64-v8a-release.apk	220	35
+EOF
+
+diff -u "$TMP_DIR/expected.tsv" "$TMP_DIR/merged.tsv"
+
+cat >"$TMP_DIR/updates/malformed.tsv" <<'EOF'
+broken	too-few-columns
+EOF
+
+if python3 "$MERGER" \
+  --baseline "$TMP_DIR/baseline.tsv" \
+  --updates-dir "$TMP_DIR/updates" \
+  --output "$TMP_DIR/invalid.tsv"; then
+  echo "FAIL: malformed update unexpectedly succeeded" >&2
+  exit 1
+fi
+rm "$TMP_DIR/updates/malformed.tsv"
+
+cat >"$TMP_DIR/updates/duplicate.tsv" <<'EOF'
+full	app-arm64-v8a-release.apk	115	35
+EOF
+
+if python3 "$MERGER" \
+  --baseline "$TMP_DIR/baseline.tsv" \
+  --updates-dir "$TMP_DIR/updates" \
+  --output "$TMP_DIR/duplicate.tsv"; then
+  echo "FAIL: duplicate update key unexpectedly succeeded" >&2
+  exit 1
+fi
+
+echo "merge APK size baseline tests passed"


### PR DESCRIPTION
## Summary

- replace destructive APK-baseline regeneration with a strict keyed upsert
- retain committed rows for matrix components skipped by path filtering
- fail before replacement on malformed or duplicate update rows
- add a deterministic regression covering Full/TV updates with an untouched Coins baseline

Closes #1324. Fixes the public root cause tracked by DevelopersCoffee/airo-pro#47.

## Test Plan

- [x] `flutter analyze` or relevant package analyzer passed (Not applicable: no Dart changes.)
- [x] `flutter test` or relevant package tests passed (Not applicable: host-only CI scripts.)
- [x] CI-only change validated with local script/YAML checks
- [x] Manual device/simulator verification documented, or not applicable

**Verification environment:** Host-only

Evidence:

- `bash scripts/test-merge-apk-size-baselines.sh` passed, including partial retention, malformed input, and duplicate-update rejection
- `python3 -m py_compile scripts/merge-apk-size-baselines.py` passed
- `bash scripts/test-check-apk-size.sh` passed
- `python3 scripts/check-build-profiles.py` reported every profile OK
- Ruby parsed `.github/workflows/ci.yml` successfully
- `git diff --check` passed

## Agent Policy

- [x] Linked issue includes a Critical Agent Gate.
- [x] Linked issue includes a Feature Packet or documents why one is not needed.
- [x] Cross-agent contract is documented for framework/application boundary work.
- [x] Deterministic use cases and automation flows are linked or included.
- [x] AI/tool/memory/routine changes include eval, trace, and redaction coverage. (Not applicable.)
- [x] Android Emulator was not used unless the linked issue explicitly accepted `AIRO_ALLOW_ANDROID_EMULATOR=true`.

## Council Review

- Release and DevEx Agent: reviewed workflow integration, failure atomicity, and CI cost.
- Chief QA Officer: reviewed deterministic partial/malformed/duplicate regression paths.
- Chief Performance Officer: reviewed keyed retention of all component size measurements.
- Chief Architect: reviewed the extracted script boundary and stable TSV contract.

- [x] I checked the Decision Matrix and listed every required role above.
- [x] Every package touched has a `module.yaml`; if not, this PR adds one. (No package touched.)
- [x] `owner`/`reviewers` in any touched `module.yaml` still match who actually reviewed this PR.

## User-Facing Documentation

- [x] No `docs/wiki` update is needed because this PR has no user-visible behavior or documentation impact.

## Plugin and Size Impact

- [ ] This PR adds new dependencies
- [ ] This PR adds or grows app/packages/plugins code
- [x] Size impact is documented below
- [x] Any module over 3 MB is a plugin or has an explicit plugin marker
- [x] Any plugin over 5 MB has cache-management documentation

Size impact / plugin justification:

No app/package/plugin or runtime dependency changes. The repository gains a 131-line standard-library Python CI utility and a host-only regression script.

## Checklist

- [x] Code is formatted.
- [x] Tests or manual verification are included above.
- [x] Sensitive data, credentials, and signing artifacts are not committed.

## Release Notes

- [x] User-facing change documented, or not applicable
