### PR TITLE
Compose optional enrichment in programme details

### DIFF
--- a/packages/feature_iptv/lib/presentation/tv/iptv_guide_screen.dart
+++ b/packages/feature_iptv/lib/presentation/tv/iptv_guide_screen.dart
@@ -12,6 +12,7 @@ import '../../application/providers/guide_providers.dart';
 import '../../application/providers/iptv_providers.dart';
 import '../widgets/epg_touch_timeline_grid.dart';
 import '../widgets/epg_timeline_grid.dart';
+import '../widgets/richer_context_prototype.dart';
 
 /// TV Guide: a virtualized horizontal-timeline EPG grid (CV-015 slice 2),
 /// sourced from [guidePagedWindowProvider]. Selecting a channel plays it and
@@ -269,6 +270,12 @@ class ProgrammeDetailsDialog extends StatelessWidget {
               Text('Categories: ${program.categories.join(', ')}'),
             if (program.rating != null) Text('Rating: ${program.rating}'),
             if (badges.isNotEmpty) Text(badges.join(' · ')),
+            ProgrammeEnrichmentPrototypeCard(
+              request: ProgrammeMetadataRequest(
+                title: program.title,
+                startsAt: program.startsAt,
+              ),
+            ),
           ],
         ),
       ),

--- a/packages/feature_iptv/test/iptv/presentation/tv/iptv_guide_screen_test.dart
+++ b/packages/feature_iptv/test/iptv/presentation/tv/iptv_guide_screen_test.dart
@@ -1,7 +1,9 @@
 import 'package:leak_tracker_flutter_testing/leak_tracker_flutter_testing.dart';
+import 'package:core_entitlements/core_entitlements.dart';
 import 'package:core_ui/core_ui.dart';
 import 'package:feature_iptv/application/providers/guide_providers.dart';
 import 'package:feature_iptv/application/providers/iptv_providers.dart';
+import 'package:feature_iptv/application/providers/richer_context_providers.dart';
 import 'package:feature_iptv/presentation/tv/iptv_guide_screen.dart';
 import 'package:feature_iptv/presentation/widgets/epg_timeline_grid.dart';
 import 'package:feature_iptv/presentation/widgets/epg_touch_timeline_grid.dart';
@@ -40,7 +42,13 @@ void main() {
     AiroFormFactor? overrideFormFactor,
     TextScaler textScaler = TextScaler.noScaling,
     CompactEpgProgram? guideProgram,
+    RicherContextProvider? richerContextProvider,
   }) async {
+    if (richerContextProvider != null) {
+      SharedPreferences.setMockInitialValues({
+        'richer_context.${richerContextProvider.descriptor.id}.metadata': true,
+      });
+    }
     final prefs = await SharedPreferences.getInstance();
     final channels = visibleChannels ?? [newsChannel, sportsChannel];
     final now = guideProgram == null
@@ -51,6 +59,14 @@ void main() {
       ProviderScope(
         overrides: [
           sharedPreferencesProvider.overrideWithValue(prefs),
+          if (richerContextProvider != null) ...[
+            richerContextEntitlementsProvider.overrideWithValue(
+              const LaunchPromoEntitlements(),
+            ),
+            richerContextAdapterProvider.overrideWithValue(
+              richerContextProvider,
+            ),
+          ],
           iptvChannelsProvider.overrideWith((ref) async => channels),
           streamingStateProvider.overrideWith(
             (ref) => Stream.value(
@@ -171,6 +187,41 @@ void main() {
     expect(find.text('City News Live'), findsOneWidget);
   });
 
+  testWidgets('programme enrichment is lazy and appears in details', (
+    tester,
+  ) async {
+    final provider = _RecordingRicherContextProvider();
+    final start = DateTime.now().toUtc().add(const Duration(hours: 1));
+    final program = CompactEpgProgram(
+      programId: 'enriched-program',
+      title: 'The Big Match',
+      startsAt: start,
+      endsAt: start.add(const Duration(hours: 1)),
+    );
+    await pumpScreen(
+      tester,
+      overrideFormFactor: AiroFormFactor.tv,
+      guideProgram: program,
+      richerContextProvider: provider,
+    );
+
+    expect(provider.programmeCalls, 0);
+
+    await tester.tap(find.text('The Big Match'));
+    await tester.pumpAndSettle();
+
+    expect(provider.programmeCalls, 1);
+    expect(
+      find.textContaining('An approved fixture synopsis.'),
+      findsOneWidget,
+    );
+    expect(find.textContaining('Fixture attribution'), findsOneWidget);
+    expect(find.text('Watch now'), findsOneWidget);
+
+    await tester.tap(find.text('Close'));
+    await tester.pumpAndSettle();
+  });
+
   testWidgets(
     'shows empty state when there are no channels',
     (tester) async {
@@ -250,4 +301,43 @@ class _FakePagedNotifier extends GuidePagedWindowNotifier {
 
   @override
   GuidePagedWindowState build() => _state;
+}
+
+final class _RecordingRicherContextProvider implements RicherContextProvider {
+  _RecordingRicherContextProvider()
+    : descriptor = RicherContextProviderDescriptor(
+        id: 'fixture',
+        name: 'Fixture Provider',
+        licenseDecision: ProviderLicenseDecision.approved,
+        licenseReviewedAt: DateTime.utc(2026, 7, 28),
+        attribution: RicherContextAttribution(
+          providerId: 'fixture',
+          providerName: 'Fixture Provider',
+          notice: 'Fixture attribution',
+          url: Uri.https('example.invalid', '/attribution'),
+        ),
+      );
+
+  @override
+  final RicherContextProviderDescriptor descriptor;
+
+  int programmeCalls = 0;
+
+  @override
+  Future<ProgrammeEnrichment?> enrichProgramme(
+    ProgrammeMetadataRequest request,
+  ) async {
+    programmeCalls++;
+    return ProgrammeEnrichment(
+      providerItemId: 'programme-1',
+      title: request.title,
+      synopsis: 'An approved fixture synopsis.',
+      attribution: descriptor.attribution,
+    );
+  }
+
+  @override
+  Future<AttributedSportsDeskRow?> fetchSportsFixtures(
+    SportsFixturesRequest request,
+  ) async => null;
 }


### PR DESCRIPTION
## Summary

- compose the existing provider-neutral enrichment card into the existing programme-details dialog
- build the lookup request only after the user opens programme details
- prove zero guide-row prefetch and exactly one attributed lookup after selection

Closes #1329.

## Test Plan

- [x] `flutter test test/iptv/presentation/tv/iptv_guide_screen_test.dart test/presentation/widgets/richer_context_prototype_test.dart` — 13 passed
- [x] `flutter analyze lib/presentation/tv/iptv_guide_screen.dart test/iptv/presentation/tv/iptv_guide_screen_test.dart` — no issues
- [x] `dart format` and `git diff --check` passed
- [x] Manual device/simulator verification is not applicable; host-only widget behavior is deterministic

**Verification environment:** Host-only

## Agent Policy

- [x] #1329 includes a Ready Critical Agent Gate.
- [x] #1329 includes the complete Feature Packet.
- [x] The cross-agent contract reuses the existing `platform_epg` request/result and fail-closed coordinator unchanged.
- [x] Deterministic use cases and host-only automation flows are included and implemented.
- [x] No AI/tool/memory/routine changes.
- [x] Android Emulator was not used.

## Council Review

- Media Intelligence Architect: confirmed the guide consumes the existing provider-neutral contract without provider policy leakage.
- Flutter Architect: confirmed the additive composition follows existing Riverpod/widget structure.
- Chief QA Officer: confirmed red-green proof for lazy invocation, attribution, and base-action preservation.
- Chief UX Officer: confirmed the existing accessible dialog, scroll behavior, and focusable actions are preserved.
- Chief Performance Officer: confirmed no guide-row lookup/prefetch and only one detail-time request.
- Chief Open Source Officer: confirmed no dependency, provider SDK, endpoint, key, or license assertion is added.
- Chief Architect: confirmed CE keeps null adapter/no entitlement and private adapters remain overlay-owned.

- [x] I checked the Decision Matrix and listed every required role above.
- [x] The touched `feature_iptv` package already has `module.yaml`; no manifest contract changes are needed.
- [x] Existing owner/reviewer declarations remain accurate.

## User-Facing Documentation

- [x] No `docs/wiki` update is needed because CE behavior remains unchanged with its null adapter; this only makes the existing private extension seam consumable.

## Plugin and Size Impact

- [ ] This PR adds new dependencies
- [x] This PR adds 7 production lines and focused widget-test coverage to an existing package
- [x] Size impact is negligible and no plugin/module threshold changes
- [x] No plugin cache-management change

Size impact / plugin justification: additive composition only; no asset or dependency growth.

## Checklist

- [x] Code is formatted.
- [x] Tests are included above.
- [x] Sensitive data, credentials, and signing artifacts are not committed.

## Release Notes

- [x] Not applicable to CE; its default remains title/base-details only.