### PR TITLE
fix(docs): actually reconcile the checklist runtime API and invariant range

### DIFF
--- a/docs/AIRO_MIND_ARCHITECTURE_FREEZE_v1.md
+++ b/docs/AIRO_MIND_ARCHITECTURE_FREEZE_v1.md
@@ -225,7 +225,7 @@ Recorded so far:
 | Date | Category | What |
 |---|---|---|
 | 2026-07-28 | **A1** | Phase 1 plan held content envelopes in the Vault after §4.1 forbade it — #1319 |
-| 2026-07-28 | **A2** | Review checklists quoted the pre-freeze runtime API and `I1–I6` — fixed before the freeze activated |
+| 2026-07-28 | **A2** | Review checklists quoted the pre-freeze runtime API and `I1–I6`. The fix was written before the freeze activated but **was not merged** — #1314 took the branch's earlier commits and closed while the reconciliation was still being pushed. It survived the freeze undetected and was found by an audit two days later. Fixed in #1322. |
 
 ## Decision hierarchy
 

--- a/docs/superpowers/specs/2026-07-27-airo-mind-review-checklists.md
+++ b/docs/superpowers/specs/2026-07-27-airo-mind-review-checklists.md
@@ -1,6 +1,9 @@
 # Airo Mind — Reusable Review Checklists
 
-Status: **Binding for every Airo Mind change.**
+Status: **Binding for every Airo Mind change.** The runtime API and invariant
+list quoted here are **frozen surfaces** — see
+`docs/AIRO_MIND_ARCHITECTURE_FREEZE_v1.md`. If they drift from the design spec,
+this file is wrong, not the spec.
 Date: 2026-07-27
 Owner: Airo Engineering Council
 
@@ -92,7 +95,7 @@ Its six questions, in order:
 3. Does this bypass the Vault?
 4. Does this bypass projections?
 5. Does this create feature-owned state?
-6. Does this violate I1–I6?
+6. Does this violate I1–I8?
 
 ### The question that governs everything
 - [ ] **Can this be implemented entirely by emitting operations and consuming projections?** If no: either the runtime is missing something generic that should be added once for everyone, or the feature is bypassing the runtime. There is no third branch and no "this feature is special".
@@ -100,7 +103,7 @@ Its six questions, in order:
 ### No direct persistence
 - [ ] **[CI]** The module declares `persistence: runtime | projection | ephemeral` and the declaration matches reality (§11b)
 - [ ] **[CI]** No SQLite, Drift, JSON file, preferences entry, or object store owned by a capability (invariants I2, I4)
-- [ ] The capability uses only the runtime API — `create_operation`, `attach_content`, `query_projection`, `instantiate_context`, `emit_event` — and names no storage engine
+- [ ] The capability uses only the runtime API — `emit_operation`, `attach_content`, `query_projection`, `instantiate_context`, `replay`, `sync` — and names no storage engine
 
 ### Replay determinism
 - [ ] State is derived from the log, never accumulated in place


### PR DESCRIPTION
**A2 drift that is live on main right now.** I reported this fixed twice. It was never merged.

## What is wrong on main today

`docs/superpowers/specs/2026-07-27-airo-mind-review-checklists.md` is **binding for every Airo Mind change**, and it says:

- The runtime API is `create_operation` · `attach_content` · `query_projection` · `instantiate_context` · `emit_event`
- The Runtime Architect's sixth question is *"Does this violate I1–I6?"*

Both are wrong against the **frozen** surfaces. The API froze at six functions — `emit_operation`, `attach_content`, `query_projection`, `instantiate_context`, `replay`, `sync`. There are **eight** invariants.

**I7 and I8 have had no reviewer assigned to them** since the freeze activated.

## Why it kept not landing

The reconciliation was written before the freeze activated. `#1314` took the branch's earlier commits and closed while it was still being pushed — the same race that had already cost `#1312` the freeze document one PR earlier, and that just cost `#1322` this same commit a third time.

So the fix existed in a branch, was reported as done, and was never on main.

## The drift record is corrected too

The A2 entry in the freeze document claimed this was *"fixed before the freeze activated"*. That was false. It now says what actually happened: written before the freeze, not merged, survived the freeze undetected, found by audit two days later.

A drift log that records a fix that did not happen is worse than no drift log.

## Also adds the precedence rule

> The runtime API and invariant list quoted here are frozen surfaces. If they drift from the design spec, **this file is wrong, not the spec.**

A binding document that paraphrases another binding document needs a stated winner.

Refs #1311, #1322