### PR TITLE
Complete optional programme enrichment metadata

### DIFF
--- a/packages/feature_iptv/lib/presentation/widgets/richer_context_prototype.dart
+++ b/packages/feature_iptv/lib/presentation/widgets/richer_context_prototype.dart
@@ -90,6 +90,7 @@ class ProgrammeEnrichmentPrototypeCard extends ConsumerWidget {
                 title: Text(value.title),
                 subtitle: Text(
                   '${value.synopsis}\n'
+                  '${_programmeMetadataLine(value)}'
                   '${value.attribution.notice} · '
                   '${value.attribution.providerName}',
                 ),
@@ -99,6 +100,15 @@ class ProgrammeEnrichmentPrototypeCard extends ConsumerWidget {
       orElse: () => const SizedBox.shrink(),
     );
   }
+}
+
+String _programmeMetadataLine(ProgrammeEnrichment value) {
+  final metadata = [
+    if (value.year != null) value.year.toString(),
+    if (value.rating != null) value.rating.toString(),
+    if (value.genres.isNotEmpty) value.genres.join(', '),
+  ];
+  return metadata.isEmpty ? '' : '${metadata.join(' · ')}\n';
 }
 
 class SportsFixturesPrototypeShelf extends ConsumerWidget {

--- a/packages/feature_iptv/test/presentation/widgets/richer_context_prototype_test.dart
+++ b/packages/feature_iptv/test/presentation/widgets/richer_context_prototype_test.dart
@@ -60,6 +60,7 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.textContaining('A fixture synopsis.'), findsOne);
+    expect(find.textContaining('2026 · 8.4 · Drama, Mystery'), findsOne);
     expect(find.text('India vs Australia'), findsOne);
     expect(find.textContaining('Prototype attribution'), findsWidgets);
     expect(
@@ -119,6 +120,9 @@ final class _FixtureProvider implements RicherContextProvider {
       providerItemId: 'programme-1',
       title: request.title,
       synopsis: 'A fixture synopsis.',
+      year: 2026,
+      rating: 8.4,
+      genres: const ['Drama', 'Mystery'],
       posterUrl: Uri.https('example.invalid', '/poster.jpg'),
       attribution: descriptor.attribution,
     );

--- a/packages/platform_epg/lib/src/richer_context_provider.dart
+++ b/packages/platform_epg/lib/src/richer_context_provider.dart
@@ -71,12 +71,18 @@ final class ProgrammeEnrichment extends Equatable {
     required this.synopsis,
     required this.attribution,
     this.posterUrl,
+    this.year,
+    this.rating,
+    this.genres = const [],
   });
 
   final String providerItemId;
   final String title;
   final String synopsis;
   final Uri? posterUrl;
+  final int? year;
+  final double? rating;
+  final List<String> genres;
   final RicherContextAttribution attribution;
 
   @override
@@ -85,6 +91,9 @@ final class ProgrammeEnrichment extends Equatable {
     title,
     synopsis,
     posterUrl,
+    year,
+    rating,
+    genres,
     attribution,
   ];
 }

--- a/packages/platform_epg/test/richer_context_provider_test.dart
+++ b/packages/platform_epg/test/richer_context_provider_test.dart
@@ -19,6 +19,22 @@ void main() {
     attribution: attribution,
   );
 
+  test('programme enrichment carries optional display metadata', () {
+    final enrichment = ProgrammeEnrichment(
+      providerItemId: 'programme-1',
+      title: 'Example Programme',
+      synopsis: 'Synopsis',
+      year: 2026,
+      rating: 8.4,
+      genres: const ['Drama', 'Mystery'],
+      attribution: attribution,
+    );
+
+    expect(enrichment.year, 2026);
+    expect(enrichment.rating, 8.4);
+    expect(enrichment.genres, const ['Drama', 'Mystery']);
+  });
+
   test('denied entitlement prevents programme adapter invocation', () async {
     final provider = _RecordingProvider(descriptor, attribution);
     final coordinator = RicherContextCoordinator(


### PR DESCRIPTION
## Summary

- extend the existing provider-neutral programme result with optional year, numeric rating, and genres
- render one concise metadata line only when values are present
- preserve all existing callers and CE/null-adapter behavior through safe defaults

Closes #1331.

## Test Plan

- [x] `platform_epg` richer-context tests: 8 passed
- [x] `feature_iptv` richer-context widget tests: 2 passed
- [x] focused analyzers: no issues
- [x] format and `git diff --check` passed
- [x] Host-only; device verification not applicable

## Agent Policy

- [x] #1331 includes Ready Critical Agent Gate and Feature Packet.
- [x] Cross-agent contract is additive and documented.
- [x] Deterministic model/UI cases are included.
- [x] No AI/tool/memory/routine change.
- [x] No Android Emulator used.

## Council Review

- Media Intelligence Architect: provider-neutral optional field semantics reviewed.
- Chief Architect: additive framework/application boundary reviewed.
- Flutter Architect and Chief UX Officer: concise conditional display reviewed.
- Chief QA Officer: model and widget coverage reviewed.
- Chief Performance Officer: three scalar/list fields and conditional text have negligible impact.
- Chief Open Source Officer: no provider code, endpoint, key, dependency, or license assertion added.

- [x] Decision Matrix roles listed above.
- [x] Existing package manifests cover both touched packages; no ownership/dependency changes.
- [x] Existing module rosters remain accurate.

## User-Facing Documentation

- [x] No wiki update needed: CE has no adapter and displays no new content.

## Plugin and Size Impact

- [ ] New dependencies
- [x] Existing package code grows by 39 focused lines including tests
- [x] Negligible size impact; no plugin threshold change
- [x] No cache-management change

## Checklist

- [x] Formatted
- [x] Tests included
- [x] No sensitive data or signing artifacts

## Release Notes

- [x] Not applicable to CE default behavior.