### PR TITLE
docs: record frozen package encodings, revocation-gate checklist lines

### DIFF
--- a/docs/AIRO_MIND_ARCHITECTURE_FREEZE_v1.md
+++ b/docs/AIRO_MIND_ARCHITECTURE_FREEZE_v1.md
@@ -62,6 +62,16 @@ Recovery Package `format_version: 1` — header fields, AAD binding, reserved
 `passphrase_used` / `kdf_params` / `kdf_salt` slots, revocation-epoch placement
 outside the ciphertext, and the framing decided in #1305.
 
+**Encodings, frozen with the format.** These were decided in implementation and
+are recorded here because they are as unreversible as the field list — a device
+that exported a package holds a copy we cannot reach.
+
+| Value | Encoding |
+|---|---|
+| `RevocationSubject` map key | Canonical string `kind:id`, where `kind` ∈ {`content`, `context`, `device`} and contains no `:`. First-colon split, so ids may contain `:`. Unknown kinds fail closed. |
+| `[u8; 32]` and `[u8; 64]` fields | Lowercase hex string, never a JSON decimal array — the package stays inspectable in a text editor, which matters for a file users are told to store themselves |
+| Subject ids | The design must state whether ids are NFC-normalized and control-character-free at the boundary (I6). Two ids differing by Unicode form are different subjects, so a destroy on one does not revoke the other — self-consistent on one device, a divergence source the moment C3 sync carries ids between devices. |
+
 The on-disk format is the least reversible thing in the system. Every device
 that has ever exported one holds a copy we cannot reach.
 

--- a/docs/superpowers/specs/2026-07-27-airo-mind-review-checklists.md
+++ b/docs/superpowers/specs/2026-07-27-airo-mind-review-checklists.md
@@ -31,6 +31,8 @@ and both wasted reviewer time on states that did not exist.
 - [ ] Every property described as applied is **read back from the file**, not from the summary that says it was applied
 - [ ] A changelog entry asserting a fix is checked against the code it claims to have changed
 - [ ] **[CI]** Where the property is mechanical, a check enforces it rather than a sentence claiming it (I5)
+- [ ] A **comment asserting a control that is absent** is treated as more serious than an omission, not less — it retires the question, so nobody looks again
+- [ ] A finding marked applied is checked clause by clause; "propagate the newtype **and** apply the encoding" is two claims and the second is the one that gets dropped
 
 > Four times in Phase 1 a property was recorded as applied and was absent: the
 > header AAD, the revocation-subject rewrite, error variants declared and never
@@ -77,6 +79,9 @@ operations, or the trust boundary.
 - [ ] A revocation source carries provenance; an empty ledger cannot silently pass as a checked one
 - [ ] Revoking a subject the local aggregate does not currently hold still records the revocation — gating the durable fact on local presence makes eviction depend on how far behind this device is
 - [ ] "No path reaches key material" is checked against every in-crate route, not only the aggregate constructor — a `pub(crate)` decrypt returning a payload with `pub(crate)` key accessors is the same bypass one type earlier
+- [ ] The ledger has a **single positive gate** every mutator that mints or admits must pass — a guarantee written as an absence is only maintainable when one function enforces it, or the next mutator added simply will not ask
+- [ ] Revocation is enforced on the **live** path, not only on restore; restore runs once, rarely, possibly never, while the live vault runs constantly
+- [ ] Re-creating a revoked subject id is rejected — minting a fresh key for a revoked context makes restore silently destroy every object wrapped under it
 - [ ] A provenance witness has a genuinely **private** field, not `pub(crate)` — crate visibility is not provenance in a crate that will hold more than one subsystem
 - [ ] Epoch or counter values from two independently-maintained ledgers are never compared — per-device counters are not a clock; freshness is decided by subject-set containment
 - [ ] Every enum arm a security decision switches on is reachable from a public API in the same phase, or is documented as reserved and asserted unreachable


### PR DESCRIPTION
Documentation fixes the Revision 7 security review classified as **land before the implementation PR**. Docs only.

## Freeze §4 gains the encodings

The `RevocationSubject` canonical string and the hex encoding for `[u8; N]` were decided in implementation and never recorded as frozen. They are as unreversible as the field list.

The review approved the encoding itself — injectivity holds, ids may contain `:`, unknown kinds fail closed, deterministic under `BTreeMap` ordering — and noted it was not written down.

Also records the open I6 question: **whether subject ids are NFC-normalized at the boundary.** Two ids differing by Unicode form are different subjects, so a destroy on one does not revoke the other. Self-consistent on one device; a divergence source the moment C3 sync carries ids between devices.

## The root cause, as a checklist line

> **The revocation ledger has no single choke point.** `apply_revocations` is comprehensive and runs on restore — a path taken once, rarely, possibly never. The live vault runs constantly and enforces the ledger for content and nothing else.
>
> A guarantee written as an absence is only maintainable when there is a single positive gate.

That is the shared root of **S14** (a revoked context can be re-created, and restore then silently destroys everything wrapped under it) and **S15** (a revoked device is re-admitted by `trust_device`, which never consults the ledger).

## Two reporting lines the fifth round of claim drift earned

> A **comment asserting a control that is absent** is treated as more serious than an omission — it retires the question, so nobody looks again.

> A finding marked applied is checked **clause by clause**; *"propagate the newtype **and** apply the encoding"* is two claims, and the second is the one that gets dropped.

Both are drawn from this round: `package.rs` says *"at every site the invariant applies to"* beside a third site that does not use the helper, and S12's second clause left `identity_public_key` serializing as a decimal array in the plaintext header.

Refs #1193, #1305