### PR TITLE
docs(governance): conformance tests name properties, not artifacts

### DIFF
--- a/docs/AIRO_MIND_ARCHITECTURE_FREEZE_v1.md
+++ b/docs/AIRO_MIND_ARCHITECTURE_FREEZE_v1.md
@@ -272,6 +272,40 @@ This is what allows the platform to evolve without churning. A contract that
 implementation proves wrong *should* change — that is what steps 2 through 4
 are for. A contract someone would prefer differently should not.
 
+## Conformance tests name properties, not artifacts
+
+**A conformance test must state the architectural property it protects, not the
+implementation artifact that once measured it.** Otherwise the architecture
+evolves, the artifact stops correlating with the property, and the test keeps
+passing while testing nothing. Nothing fails, so nothing draws attention — this
+is the only defect class in this document that gets *quieter* as it gets worse.
+
+Found the hard way. C1 carried *"a synthetic 100k-content vault serializes
+within a constant factor of a 10k-content vault."* That was a faithful proxy
+when the Vault held one envelope per content object. The §4.1 redesign removed
+content from the Vault, and the test began passing at a −0.8% delta — measuring
+a dimension the Vault no longer has, while the dimension that had replaced it
+(the revocation ledger) went unmeasured at +849%. The test did not break. It
+went hollow, and stayed green for three council reviews.
+
+Applying the rule as an audit immediately found two more:
+
+| Test | Artifact it measures | Property it should protect |
+|---|---|---|
+| C1 / S1 vault sizing | content count | **the growth dimension the Vault actually has** — now contexts, devices, and revocations |
+| C2 / S2 replay RSS | operation count | **peak RSS is O(1) in replayed state size** — a log of 1M no-op operations passes while unbounded state growth goes untested |
+| C3 no-op sync | bytes exchanged | **a converged sync costs nothing** — the exchange is bounded while `merge` is O(N), measured at 11.52 ms per replica at 100k entries |
+
+Two rules follow:
+
+1. **Write the property first and the measurement second**, so a reader can see
+   when the second stops serving the first. Every conformance test in this
+   system is stated in that order.
+2. **An ADR that changes a growth dimension, a storage class, or a data model
+   must re-audit the conformance tests that measured the old one.** Changing the
+   architecture without changing its tests is how a suite becomes decorative.
+   ADR-0017 is the first to carry this obligation.
+
 ## Runtime Validation — exit criteria
 
 The phase completes only when **every frozen contract** has all five. This is

--- a/docs/superpowers/specs/2026-07-27-airo-mind-review-checklists.md
+++ b/docs/superpowers/specs/2026-07-27-airo-mind-review-checklists.md
@@ -178,6 +178,13 @@ Its six questions, in order:
 - [ ] Every invariant this change claims has a **failing form**: a compile error or a test that fails when it is violated. Documentation alone is not evidence.
 - [ ] The test was written before the claim was recorded as applied — three review cycles found properties marked done that were absent from the code
 
+### Conformance tests name properties, not artifacts
+- [ ] Every conformance test states the **architectural property** it protects, then the measurement — in that order, so a reader can see when the second stops serving the first
+- [ ] No test asserts only over an implementation artifact (a count, a field, a wire size) that merely *correlated* with the property when it was written
+- [ ] A change to a growth dimension, storage class, or data model **re-audits the conformance tests that measured the old one** — C1's vault test kept passing at −0.8% for three council reviews after §4.1 removed the dimension it measured
+- [ ] Ask of each green test: *what would have to break for this to fail?* If the answer no longer describes the contract, the test is decorative
+- [ ] A test that goes hollow raises no alarm — this is the only defect class here that gets quieter as it gets worse, so it is checked deliberately or not at all
+
 ### Canonicalization (I6)
 - [ ] Externally-supplied values pass through a canonicalizer before anything else sees them; nothing below that layer receives raw input
 - [ ] Canonicalization happens **exactly once**, not defensively re-applied at each layer — re-canonicalizing hides the layer that forgot

--- a/docs/superpowers/specs/2026-07-28-airo-mind-conformance-suite.md
+++ b/docs/superpowers/specs/2026-07-28-airo-mind-conformance-suite.md
@@ -42,9 +42,24 @@ written against the implementation and is a unit test wearing the wrong label.
       including embeddings, search snippets, and caches
 - [ ] Recovery reproduces **identical** runtime state: same package + same seed
       + same ledger ⇒ byte-identical vault
-- [ ] The Vault is sized by contexts and devices, never by content — a
-      100k-content vault serializes within a constant factor of a 10k-content
-      vault
+- [ ] **The Vault holds authority, never inventory** — live content never enters
+      it. Measured: a 100k-content vault serializes within a constant factor of a
+      10k-content vault. *Retained as a regression guard on the §4.1 redesign,
+      which measurement confirms holds at −0.8%. It is no longer a growth test —
+      the Vault has no content dimension to grow in.*
+- [ ] **Peak memory during export and restore is O(1) in the Vault's actual
+      growth dimension**, which per ADR-0017 is contexts + devices + revocations.
+      Measured: export peak RSS at 100k revocation entries within 20% of peak RSS
+      at 10k, and the same for contexts. *This is the test the previous one
+      stopped being. It currently fails at +849%, which is why ADR-0017 requires
+      framing.*
+- [ ] **Retention-class expiry adds no ledger entry** — running a `recoverable`
+      object past its 30-day window, or an `ephemeral` object past its derived
+      artifact, destroys the content and leaves `head_epoch` unchanged (ADR-0017)
+- [ ] **Expiry is derived from logged time, never local wall clock** — two
+      devices with clocks skewed by a week reach byte-identical state from the
+      same log. *Without this, expiry is device-dependent, which makes it a
+      decision, which puts it back in the ledger and undoes ADR-0017 silently.*
 
 ## S2 — Replay conformance (contract C2)
 
@@ -56,8 +71,11 @@ written against the implementation and is a unit test wearing the wrong label.
 - [ ] Replay order invariants hold: any permutation of concurrent operations
       converges
 - [ ] `replay_passes == 1` — asserted, not documented
-- [ ] Peak RSS is O(1) in operation count — RSS at 1M operations within 10% of
-      RSS at 100k (I7)
+- [ ] **Peak RSS during replay is O(1) in replayed state size** (I7) — measured
+      as RSS at 1M operations within 10% of RSS at 100k, where the operations
+      *build state* rather than being no-ops. A log of 1M operations that creates
+      1M contexts is the case this protects; a log of 1M no-ops passes while
+      testing nothing
 - [ ] Signature verification does not repeat below the verified-prefix
       watermark
 

--- a/docs/superpowers/specs/2026-07-28-airo-mind-runtime-contracts.md
+++ b/docs/superpowers/specs/2026-07-28-airo-mind-runtime-contracts.md
@@ -101,9 +101,22 @@ metadata.
 - Small writes are group-committed with a bounded window; per-operation `fsync`
   is reserved for explicit durability points
 
+**Vault size class:** `O(contexts + devices + revocations)`. Amended by
+[ADR-0017](../../adr/0017-airo-mind-revocation-ledger-growth-and-package-framing.md);
+this contract previously read "sized by contexts and devices, never by user
+content" three lines after listing the revocation ledger among the Vault's
+contents. "Authority, not inventory" holds for *live* content — confirmed by
+measurement — and never applied to tombstones, which are retained permanently by
+design. Revocations are user-initiated destructions only; retention-class expiry
+is derived, not recorded.
+
 **Conformance tests:** a module declaring `persistence: runtime` opens no
-database · every durable object is reachable from a log replay · a synthetic
-100k-content vault serializes within a constant factor of a 10k-content vault.
+database · every durable object is reachable from a log replay · **the Vault
+holds authority, never inventory** — measured as a 100k-content vault
+serializing within a constant factor of a 10k-content vault, retained as a
+regression guard on the §4.1 redesign and *not* as a growth test · **peak memory
+during export and restore is O(1) in contexts + devices + revocations** —
+measured at 100k entries against 10k, in each dimension separately.
 
 ## C2 — Replay Contract `v1`
 
@@ -142,9 +155,16 @@ produces identical state.
 - Transport is interchangeable; the engine does not know what carried the bytes
 
 **Conformance tests:** property tests for merge commutativity, associativity,
-idempotence · two devices converge from any operation permutation · a no-op
-sync between two 1M-operation replicas exchanges a bounded constant · an
-unauthenticated peer exchanges nothing.
+idempotence · two devices converge from any operation permutation · **a
+converged sync costs nothing** — measured as both bytes exchanged *and CPU spent*
+between two 1M-operation replicas that already agree · an unauthenticated peer
+exchanges nothing.
+
+The CPU half was added after measurement: `RevocationLedger::merge` walks every
+entry of the peer's ledger unconditionally, so two replicas that already agree
+each pay **11.52 ms at 100k entries** and allocate a `String` per already-present
+subject. The bytes-exchanged test passed throughout. It measured the artifact —
+wire traffic — while the property it protects is that a converged sync is free.
 
 ## C4 — Projection Contract `v1`
 


### PR DESCRIPTION
Follow-on to ADR-0017 (#1345), which carries the obligation this PR discharges.

## The rule

**A conformance test must state the architectural property it protects, not the implementation artifact that once measured it.**

C1 carried *"a synthetic 100k-content vault serializes within a constant factor of a 10k-content vault."* That was a faithful proxy when the Vault held one envelope per content object. The §4.1 redesign removed content from the Vault, and the test began passing at a **−0.8% delta** — measuring a dimension the Vault no longer has, while the dimension that replaced it went unmeasured at **+849%**.

The test did not break. It went hollow, and stayed green for three council reviews.

> This is the only defect class in the freeze document that gets *quieter* as it gets worse. Nothing fails, so nothing draws attention.

## Applying it as an audit found two more

| Test | Artifact measured | Property it should protect |
|---|---|---|
| C1 / S1 vault sizing | content count | the growth dimension the Vault **actually has** |
| C2 / S2 replay RSS | operation count | peak RSS O(1) in **replayed state size** — 1M no-ops pass while unbounded state growth goes untested |
| C3 no-op sync | bytes exchanged | **a converged sync costs nothing** — exchange is bounded while `merge` is O(N), measured at 11.52 ms per replica at 100k entries |

Two found by measurement, one predicted by the rule and confirmed against Performance's numbers. The C3 case is the sharpest: the bytes-exchanged test passed throughout while both replicas paid O(N) CPU on every sync between replicas that already agreed.

## Changes

- **Freeze doc** — new governance section, with the obligation that makes it stick: *an ADR changing a growth dimension, storage class, or data model must re-audit the conformance tests that measured the old one.* ADR-0017 is the first to carry it.
- **Review checklists** — five lines under Runtime, including the one that operationalizes it: *ask of each green test, what would have to break for this to fail? If the answer no longer describes the contract, the test is decorative.*
- **C1** — size class amended to `O(contexts + devices + revocations)`; old test retained explicitly as a §4.1 regression guard rather than a growth test, plus the real growth test that fails today at +849%.
- **C3** — conformance test now measures bytes **and CPU**.
- **S1** — gains ADR-0017's two tests: retention expiry adds no ledger entry, and expiry derives from logged time rather than local wall clock. Without the second, expiry is device-dependent, which makes it a decision, which puts it back in the ledger and undoes ADR-0017 silently.
- **S2** — replay RSS restated over state size, with the no-op log named as the case that would pass while testing nothing.

Refs #1305, #1193, #1340

🤖 Generated with [Claude Code](https://claude.com/claude-code)