### PR TITLE
fix(android): qualify AGP rollback guard for stable releases

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -114,5 +114,6 @@ updates:
       # Reverted twice already: 9.3.0 in 249ad2eb (#1011), 9.3.1 from #1336.
       # The rule above names a different coordinate than the plugin id
       # Dependabot actually bumps, which is why both landed.
+      # Remove only after a stable AGP release passes Fire TV locally and main CI.
       - dependency-name: "com.android.application"
         versions: ["9.3.x"]


### PR DESCRIPTION
Refs #1348

## Summary

- Keeps the verified rollback to AGP 9.2.1 because Android's current stable release is 9.3.1 and no newer stable patch is available.
- Keeps `lintVital` enabled; no lint scope or detector is disabled.
- Guards `com.android.application` 9.3.x in Dependabot and documents the evidence required before removing that guard.
- This follow-up is necessary because the direct main commit `65ef7c54` accidentally included GitHub's workflow-suppression token in its body, so the required release matrix did not start.

## Test Plan

- [x] `scripts/test-check-build-profiles.sh`
- [x] `scripts/check-build-profiles.py`
- [x] Dependabot YAML parsed with Ruby
- [x] `git diff --check`
- [x] `AIRO_ALLOW_DEBUG_RELEASE_SIGNING=true make build-firetv`
  - `assembleRelease` completed in 303.9s
  - produced `app/build/app/outputs/flutter-apk/app-release.apk` (69.7 MB reported by Flutter; 66 MiB on disk)
  - SHA-256: `21c13ef66edb9ef2a9f1cae6818d7210fdea936d636208e49fffb59f48078e20`
- [ ] PR CI passes
- [ ] Post-merge main CI: `build-android (tv)`, `build-android (full)`, and `build-web` pass

**Verification environment:** Host-only macOS, Java 17, Flutter 3.44.4. Local non-distributable debug release signing was explicitly enabled; lint was not relaxed.

## Agent Policy

- [x] Linked issue includes a Critical Agent Gate.
- [x] Linked issue includes a Feature Packet.
- [x] Cross-agent contract is documented (release tooling only; no runtime API/data boundary).
- [x] Deterministic use cases and automation flows are included in #1348.
- [x] AI/tool/memory/routine coverage is not applicable.
- [x] Android Emulator was not used.

## Council Review

- Chief Release/DevOps Officer: primary owner; local release qualification completed.
- Chief QA Officer: deterministic build and CI acceptance defined in #1348.
- Flutter Architect: Android/Flutter build configuration remains on the last known-good AGP pairing.

- [x] Decision Matrix checked.
- [x] No package or `module.yaml` changes.
- [x] No ownership manifest changes required.

## User-Facing Documentation

- [x] No `docs/wiki` update is needed because this changes build tooling only.

## Plugin and Size Impact

- [x] No new dependencies.
- [x] No app/package/plugin source growth.
- [x] Size impact: none from this one-line qualification condition; local APK recorded above.

## Checklist

- [x] Configuration is valid.
- [x] Local release build verification is documented.
- [x] No sensitive data, credentials, or signing artifacts are committed.

## Release Notes

- [x] Not applicable; no user-facing behavior change.
