### PR TITLE
fix(web): make platform integer boundaries dart2js-safe

### DIFF
--- a/packages/core_native/lib/src/native_engine.dart
+++ b/packages/core_native/lib/src/native_engine.dart
@@ -1,3 +1,6 @@
+import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart'
+    show PlatformInt64Util;
+
 import 'api/native_engine.dart' as frb;
 import 'native_bridge.dart';
 
@@ -170,9 +173,13 @@ class FrbAiroNativeEngine implements AiroNativeEngine {
           frb.RecommendationCandidate(
             id: candidate.id,
             title: candidate.title,
-            genreAffinity: candidate.genreAffinity,
-            providerAffinity: candidate.providerAffinity,
-            languageAffinity: candidate.languageAffinity,
+            genreAffinity: PlatformInt64Util.from(candidate.genreAffinity),
+            providerAffinity: PlatformInt64Util.from(
+              candidate.providerAffinity,
+            ),
+            languageAffinity: PlatformInt64Util.from(
+              candidate.languageAffinity,
+            ),
             completionPermille: candidate.completionPermille,
             lastWatchedAgeDays: candidate.lastWatchedAgeDays,
             preferredTime: candidate.preferredTime,
@@ -184,14 +191,23 @@ class FrbAiroNativeEngine implements AiroNativeEngine {
       scores.map(
         (score) => AiroNativeRecommendationScore(
           id: score.id,
-          score: score.score,
-          genrePoints: score.genrePoints,
-          providerPoints: score.providerPoints,
-          languagePoints: score.languagePoints,
-          completionPoints: score.completionPoints,
-          recencyPoints: score.recencyPoints,
-          timeBucketPoints: score.timeBucketPoints,
-          deviceFitPoints: score.deviceFitPoints,
+          // PlatformInt64 is int on native and BigInt on web.
+          // ignore: noop_primitive_operations
+          score: score.score.toInt(),
+          // ignore: noop_primitive_operations
+          genrePoints: score.genrePoints.toInt(),
+          // ignore: noop_primitive_operations
+          providerPoints: score.providerPoints.toInt(),
+          // ignore: noop_primitive_operations
+          languagePoints: score.languagePoints.toInt(),
+          // ignore: noop_primitive_operations
+          completionPoints: score.completionPoints.toInt(),
+          // ignore: noop_primitive_operations
+          recencyPoints: score.recencyPoints.toInt(),
+          // ignore: noop_primitive_operations
+          timeBucketPoints: score.timeBucketPoints.toInt(),
+          // ignore: noop_primitive_operations
+          deviceFitPoints: score.deviceFitPoints.toInt(),
         ),
       ),
     );

--- a/packages/core_native/lib/src/relational_store.dart
+++ b/packages/core_native/lib/src/relational_store.dart
@@ -1,4 +1,6 @@
 import 'package:flutter/foundation.dart' show kIsWeb;
+import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart'
+    show PlatformInt64Util;
 
 import 'api/relational_store.dart' as native_store;
 import 'native_bridge.dart';
@@ -245,8 +247,10 @@ native_store.RelationalSyncEntity _toNativeEntity(
     entityType: entity.entityType,
     schemaVersion: entity.schemaVersion,
     entityVersion: entity.entityVersion,
-    updatedAtMicros: entity.updatedAtMicros,
-    deletedAtMicros: entity.deletedAtMicros,
+    updatedAtMicros: PlatformInt64Util.from(entity.updatedAtMicros),
+    deletedAtMicros: entity.deletedAtMicros == null
+        ? null
+        : PlatformInt64Util.from(entity.deletedAtMicros!),
     clock: _toNativeClock(entity.clock),
     deletionClock: _toNativeClock(entity.deletionClock),
     fields: entity.fields.map(_toNativeField).toList(growable: false),
@@ -266,10 +270,10 @@ native_store.RelationalSyncField _toNativeField(AiroRelationalSyncField field) {
       _ => throw ArgumentError.value(value, field.name, 'unsupported scalar'),
     },
     textValue: value is String ? value : null,
-    integerValue: value is int ? value : null,
+    integerValue: value is int ? PlatformInt64Util.from(value) : null,
     realValue: value is double ? value : null,
     booleanValue: value is bool ? value : null,
-    updatedAtMicros: field.updatedAtMicros,
+    updatedAtMicros: PlatformInt64Util.from(field.updatedAtMicros),
     originNodeId: field.originNodeId,
     clock: _toNativeClock(field.clock),
   );

--- a/packages/platform_downloads/lib/src/download_models.dart
+++ b/packages/platform_downloads/lib/src/download_models.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/foundation.dart';
 
 const int backgroundDownloadContractVersion = 1;
+const int _maxWireSafeInteger = 9007199254740991;
 
 @immutable
 class DownloadArtifactRequest {
@@ -263,8 +264,10 @@ int _nonNegativeInt(Map<Object?, Object?> map, String key) {
 
 int? _nullableNonNegativeInt(Map<Object?, Object?> map, String key) {
   final value = map[key];
-  if (value is! num) return null;
-  return value.toInt().clamp(0, 0x7fffffffffffffff);
+  if (value is! num || !value.isFinite) return null;
+  final integer = value.toInt();
+  if (integer < 0) return 0;
+  return integer > _maxWireSafeInteger ? _maxWireSafeInteger : integer;
 }
 
 double _nonNegativeDouble(Map<Object?, Object?> map, String key) {

--- a/packages/platform_downloads/test/background_download_contract_test.dart
+++ b/packages/platform_downloads/test/background_download_contract_test.dart
@@ -214,4 +214,18 @@ void main() {
     expect(progress.failure?.code, DownloadFailureCode.platformUnavailable);
     expect(progress.canRetry, isTrue);
   });
+
+  test('wire integers stay non-negative and exactly representable on web', () {
+    final progress = DownloadProgress.fromMap(<Object?, Object?>{
+      'artifactId': 'model-a',
+      'status': 'downloading',
+      'downloadedBytes': -1,
+      'totalBytes': double.maxFinite,
+      'retryCount': double.infinity,
+    });
+
+    expect(progress.downloadedBytes, 0);
+    expect(progress.totalBytes, 9007199254740991);
+    expect(progress.retryCount, 0);
+  });
 }

--- a/packages/platform_playlist_import/lib/src/channel_variant_classifier.dart
+++ b/packages/platform_playlist_import/lib/src/channel_variant_classifier.dart
@@ -8,6 +8,13 @@ enum ChannelVariantRelationship { distinct, duplicate, variant }
 final class ChannelVariantClassifier {
   const ChannelVariantClassifier();
 
+  static final BigInt _fnv64OffsetBasis = BigInt.parse(
+    'cbf29ce484222325',
+    radix: 16,
+  );
+  static final BigInt _fnv64Prime = BigInt.parse('100000001b3', radix: 16);
+  static final BigInt _uint64Mask = (BigInt.one << 64) - BigInt.one;
+
   String canonicalName(String value) {
     var normalized = value.trim().toLowerCase();
     normalized = normalized.replaceAll(
@@ -258,10 +265,10 @@ final class ChannelVariantClassifier {
   }
 
   String _stableId(String value) {
-    var hash = 0xcbf29ce484222325;
+    var hash = _fnv64OffsetBasis;
     for (final byte in value.codeUnits) {
-      hash ^= byte;
-      hash = (hash * 0x100000001b3) & 0xFFFFFFFFFFFFFFFF;
+      hash ^= BigInt.from(byte);
+      hash = (hash * _fnv64Prime) & _uint64Mask;
     }
     return 'byoc-${hash.toRadixString(16).padLeft(16, '0')}';
   }

--- a/packages/platform_playlist_import/test/channel_variant_classifier_test.dart
+++ b/packages/platform_playlist_import/test/channel_variant_classifier_test.dart
@@ -154,6 +154,7 @@ void main() {
       ]).single;
 
       expect(first.id, reordered.id);
+      expect(first.id, 'byoc-7605ee7b9a5d5ff8');
       expect(first.group, 'Odd Group');
       expect(first.provenance, ChannelImportProvenance.unmatched);
       expect(first.streamUrl, 'https://fast.example/live');


### PR DESCRIPTION
Refs #1348

## Summary

The AGP rollback made both Android release jobs green on `main`, then exposed three older dart2js blockers that had been masked by the earlier release failures.

- Preserve 64-bit FNV channel IDs with `BigInt` math, retaining the exact existing 16-digit IDs on native and web.
- Clamp download wire counters to JavaScript's exact non-negative integer range and fail closed for non-finite values.
- Convert app `int` values through flutter_rust_bridge's `PlatformInt64Util` and convert native result values back to app `int`s. The web path still returns before native bridge initialization.

## Test Plan

- [x] `packages/platform_playlist_import`: 44 tests passed; `flutter analyze` clean.
- [x] `packages/platform_downloads`: 9 tests passed; `flutter analyze` clean.
- [x] `packages/core_native`: 33 tests passed; 2 fixture-dependent native tests skipped as designed.
- [x] `packages/core_native`: `flutter analyze --no-fatal-infos` exits 0; only 64 pre-existing generated-code info lints remain, with no errors or warnings.
- [x] `git diff --check`.
- [x] Exact CI command `cd app && flutter build web --release` passed and produced `app/build/web` in 48.2s.
- [ ] PR CI passes.
- [ ] Post-merge main `build-android (tv)`, `build-android (full)`, and `build-web` pass.

**Verification environment:** Host-only macOS, Flutter 3.44.4; no emulator or simulator.

## Agent Policy

- [x] Linked issue contains the Critical Agent Gate, Feature Packet, cross-agent contract update, deterministic use cases, and automation flow.
- [x] No parsing or serialization moved onto the main isolate.
- [x] Web remains on Dart fallbacks and does not initialize native FFI.
- [x] Android Emulator was not used.

## Council Review

- Chief Release/DevOps Officer: release acceptance and CI owner.
- Media Intelligence Architect: stable channel identity behavior.
- Platform Architect: `platform_downloads` and `core_native` boundaries.
- Chief Performance Officer: cached FNV constants avoid reparsing per channel.
- Chief QA Officer: golden identity and invalid wire-value coverage.

- [x] Decision Matrix and touched `module.yaml` ownership checked.
- [x] No module ownership or dependency graph changes.

## User-Facing Documentation

- [x] No wiki update is needed; behavior and public APIs are unchanged. Commit carries the docs exemption marker.

## Plugin and Size Impact

- [x] No dependencies or plugins added.
- [x] No meaningful binary-size impact; changes are boundary conversions and two focused assertions.

## Checklist

- [x] Code is formatted.
- [x] Focused tests and a release web build are documented.
- [x] No sensitive data or generated signing artifacts are committed.

## Release Notes

- [x] Not applicable; build compatibility fix only.