### PR TITLE
feat(iptv): surface persistent provider health

### DIFF
--- a/docs/wiki/7.-Troubleshooting-and-FAQ.md
+++ b/docs/wiki/7.-Troubleshooting-and-FAQ.md
@@ -35,6 +35,13 @@ supported local command, Airo treats it as a general AI chat prompt.
 - Try a different channel or track.
 - Restart the app if the player state appears stuck.
 
+For configured Xtream sources, open TV settings and review the source health
+summary. Airo keeps a bounded, local history of categorical request outcomes
+and can distinguish recent credential, network, server, rejected-request, and
+unreadable-data failures. The summary never stores or displays source URLs,
+credentials, response bodies, or raw exception text. **Health not measured**
+means the source has not produced enough runtime evidence yet.
+
 ## Cast Button Is Missing on macOS
 
 Airo currently shows Google Cast controls only on Android and iOS, where the

--- a/packages/feature_iptv/lib/application/providers/content_source_management_providers.dart
+++ b/packages/feature_iptv/lib/application/providers/content_source_management_providers.dart
@@ -5,6 +5,7 @@ import '../content_source_store.dart';
 import '../mutable_xmltv_compact_epg_repository.dart';
 import 'content_source_providers.dart';
 import 'iptv_providers.dart';
+import 'provider_health_providers.dart';
 
 export 'content_source_providers.dart'
     show secureStoreProvider, contentSourceCredentialStoreProvider;
@@ -227,6 +228,7 @@ final removeContentSourceProvider = FutureProvider.autoDispose
         await ref
             .watch(contentSourceCredentialStoreProvider)
             .delete(ContentSourceCredentialRef(id));
+        ref.read(providerHealthTrackerProvider).clearFor(id);
         final epgRepository = ref.read(compactEpgRepositoryProvider);
         if (epgRepository is MutableXmltvCompactEpgRepository) {
           epgRepository.removeNamedSource('epg-$id');

--- a/packages/feature_iptv/lib/application/providers/iptv_providers.dart
+++ b/packages/feature_iptv/lib/application/providers/iptv_providers.dart
@@ -22,6 +22,7 @@ import '../../domain/favorite_reimport_coordinator.dart';
 import '../../domain/channel_region_availability.dart';
 import '../../domain/vod_resume_coordinator.dart';
 import 'content_source_providers.dart';
+import 'provider_health_providers.dart';
 
 export 'iptv_cast_providers.dart';
 export 'airo_tv_profile_provider.dart';
@@ -289,6 +290,7 @@ final configuredXtreamChannelsProvider = FutureProvider<List<IPTVChannel>>((
   if (xtreamConfigs.isEmpty) return const [];
   final credentials = ref.read(contentSourceCredentialStoreProvider);
   final dio = ref.read(dioProvider);
+  final healthTracker = ref.read(providerHealthTrackerProvider);
   final channels = <IPTVChannel>[];
   for (final config in xtreamConfigs) {
     final secret = await credentials.read(
@@ -301,6 +303,7 @@ final configuredXtreamChannelsProvider = FutureProvider<List<IPTVChannel>>((
         serverUrl: config.url,
         username: secret.username,
         password: secret.password,
+        healthTracker: healthTracker,
         sourceId: config.id,
       );
       channels.addAll(

--- a/packages/feature_iptv/lib/application/providers/provider_health_providers.dart
+++ b/packages/feature_iptv/lib/application/providers/provider_health_providers.dart
@@ -1,0 +1,98 @@
+import 'dart:convert';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_riverpod/legacy.dart';
+import 'package:platform_playlist/platform_playlist.dart';
+
+import 'iptv_providers.dart' show sharedPreferencesProvider;
+
+const providerHealthStorageKey = 'iptv.provider_health.v1';
+
+/// Changes whenever the shared tracker records or clears a sample.
+///
+/// Presentation code watches this revision before reading a snapshot so the
+/// pure platform tracker does not need a Flutter dependency.
+final providerHealthRevisionProvider = StateProvider<int>((ref) => 0);
+
+/// One privacy-safe, bounded provider-health tracker for the application.
+///
+/// The persisted payload contains source ids, categorical outcomes, timing,
+/// and timestamps only. Provider URLs, credentials, response bodies, and raw
+/// exception text never enter [ProviderHealthSample].
+final providerHealthTrackerProvider = Provider<ProviderHealthTracker>((ref) {
+  final preferences = ref.watch(sharedPreferencesProvider);
+  late final ProviderHealthTracker tracker;
+  tracker = ProviderHealthTracker(
+    initialSamples: _decodeSamples(
+      preferences.getString(providerHealthStorageKey),
+    ),
+    onChanged: () {
+      ref.read(providerHealthRevisionProvider.notifier).state++;
+      preferences.setString(
+        providerHealthStorageKey,
+        jsonEncode(tracker.samples.map(_encodeSample).toList(growable: false)),
+      );
+    },
+  );
+  return tracker;
+});
+
+Map<String, Object?> _encodeSample(ProviderHealthSample sample) => {
+  'sourceId': sample.sourceId,
+  'timestampUtc': sample.timestampUtc.toIso8601String(),
+  'kind': sample.kind.name,
+  if (sample.latency != null) 'latencyMicros': sample.latency!.inMicroseconds,
+  if (sample.httpStatus != null) 'httpStatus': sample.httpStatus,
+  if (sample.failureCategory != null) 'failureCategory': sample.failureCategory,
+};
+
+List<ProviderHealthSample> _decodeSamples(String? raw) {
+  if (raw == null || raw.isEmpty) return const [];
+  try {
+    final decoded = jsonDecode(raw);
+    if (decoded is! List) return const [];
+    return decoded
+        .whereType<Map>()
+        .map(_decodeSample)
+        .whereType<ProviderHealthSample>()
+        .toList(growable: false);
+  } catch (_) {
+    return const [];
+  }
+}
+
+ProviderHealthSample? _decodeSample(Map<dynamic, dynamic> value) {
+  final sourceId = value['sourceId'];
+  final timestampRaw = value['timestampUtc'];
+  final kindRaw = value['kind'];
+  if (sourceId is! String ||
+      sourceId.isEmpty ||
+      timestampRaw is! String ||
+      kindRaw is! String) {
+    return null;
+  }
+  final timestamp = DateTime.tryParse(timestampRaw)?.toUtc();
+  final kind = ProviderHealthEventKind.values
+      .where((candidate) => candidate.name == kindRaw)
+      .firstOrNull;
+  if (timestamp == null || kind == null) return null;
+
+  final latencyMicros = value['latencyMicros'];
+  final latency = latencyMicros is int
+      ? Duration(microseconds: latencyMicros)
+      : null;
+  final httpStatus = value['httpStatus'];
+  final failureCategory = value['failureCategory'];
+  if (kind == ProviderHealthEventKind.fetchFailure &&
+      failureCategory is! String) {
+    return null;
+  }
+  return ProviderHealthSample(
+    sourceId: sourceId,
+    timestampUtc: timestamp,
+    kind: kind,
+    latency: latency,
+    httpStatus: httpStatus is int ? httpStatus : null,
+    failureCategory: failureCategory is String ? failureCategory : null,
+  );
+}

--- a/packages/feature_iptv/lib/feature_iptv.dart
+++ b/packages/feature_iptv/lib/feature_iptv.dart
@@ -7,6 +7,7 @@ export "domain/local_iptv_search.dart";
 export "domain/vod_resume_coordinator.dart";
 export "domain/favorite_reimport_coordinator.dart";
 export "application/providers/iptv_providers.dart";
+export "application/providers/provider_health_providers.dart";
 export "application/providers/iptv_org_api_providers.dart";
 export "application/providers/last_channel_provider.dart";
 export "application/providers/rails_provider.dart";

--- a/packages/feature_iptv/lib/presentation/tv/settings/tv_source_management_section.dart
+++ b/packages/feature_iptv/lib/presentation/tv/settings/tv_source_management_section.dart
@@ -316,9 +316,65 @@ class _TvSourceManagementSectionState
     );
   }
 
+  Widget _healthSummary(BuildContext context, ProviderHealthSnapshot snapshot) {
+    final (label, icon, color) = switch (snapshot.healthClass) {
+      ProviderHealthClass.unknown => (
+        'Health not measured',
+        Icons.help_outline,
+        Theme.of(context).colorScheme.onSurfaceVariant,
+      ),
+      ProviderHealthClass.green => (
+        'Healthy',
+        Icons.check_circle_outline,
+        Colors.green,
+      ),
+      ProviderHealthClass.amber => (
+        'Intermittent issues',
+        Icons.warning_amber_outlined,
+        Colors.amber,
+      ),
+      ProviderHealthClass.red => (
+        'Frequent recent issues',
+        Icons.error_outline,
+        Theme.of(context).colorScheme.error,
+      ),
+    };
+    final hint = switch (snapshot.recentFailureCategory) {
+      ProviderHealthFailureCategory.auth =>
+        'Credentials rejected — reconnect the source.',
+      ProviderHealthFailureCategory.network => 'Cannot reach the server.',
+      ProviderHealthFailureCategory.server =>
+        'The source server is having issues.',
+      ProviderHealthFailureCategory.client => 'The request was rejected.',
+      ProviderHealthFailureCategory.malformed =>
+        'The source returned unreadable data.',
+      _ => null,
+    };
+    return Semantics(
+      label: hint == null ? label : '$label. $hint',
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(icon, size: 16, color: color),
+          const SizedBox(width: 6),
+          Flexible(
+            child: Text(
+              hint == null ? label : '$label • $hint',
+              style: Theme.of(
+                context,
+              ).textTheme.bodySmall?.copyWith(color: color),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     final sourcesAsync = ref.watch(configuredContentSourcesProvider);
+    ref.watch(providerHealthRevisionProvider);
+    final healthTracker = ref.watch(providerHealthTrackerProvider);
     final colorScheme = Theme.of(context).colorScheme;
 
     return SingleChildScrollView(
@@ -374,6 +430,11 @@ class _TvSourceManagementSectionState
                           _capabilityBadges(
                             context,
                             config.toContentSource().capabilities,
+                          ),
+                          const SizedBox(height: 4),
+                          _healthSummary(
+                            context,
+                            healthTracker.snapshotFor(config.id),
                           ),
                         ],
                       ),

--- a/packages/feature_iptv/test/iptv/application/providers/provider_health_providers_test.dart
+++ b/packages/feature_iptv/test/iptv/application/providers/provider_health_providers_test.dart
@@ -1,0 +1,69 @@
+import 'package:feature_iptv/feature_iptv.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:platform_playlist/platform_playlist.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  test(
+    'persists and rehydrates only redacted provider health samples',
+    () async {
+      SharedPreferences.setMockInitialValues({});
+      final preferences = await SharedPreferences.getInstance();
+      final first = ProviderContainer(
+        overrides: [sharedPreferencesProvider.overrideWithValue(preferences)],
+      );
+      first
+          .read(providerHealthTrackerProvider)
+          .record(
+            ProviderHealthSample.fetchFailure(
+              sourceId: 'xtream-1',
+              timestampUtc: DateTime.utc(2026, 7, 29),
+              failureCategory: ProviderHealthFailureCategory.auth,
+              httpStatus: 401,
+            ),
+          );
+      await Future<void>.delayed(Duration.zero);
+      first.dispose();
+
+      final raw = preferences.getString(providerHealthStorageKey);
+      expect(raw, isNotNull);
+      expect(raw, isNot(contains('https://')));
+      expect(raw, isNot(contains('password')));
+
+      final restarted = ProviderContainer(
+        overrides: [sharedPreferencesProvider.overrideWithValue(preferences)],
+      );
+      addTearDown(restarted.dispose);
+      final snapshot = restarted
+          .read(providerHealthTrackerProvider)
+          .snapshotFor('xtream-1');
+
+      expect(snapshot.totalSamples, 1);
+      expect(snapshot.healthClass, ProviderHealthClass.red);
+      expect(
+        snapshot.recentFailureCategory,
+        ProviderHealthFailureCategory.auth,
+      );
+    },
+  );
+
+  test('ignores corrupt persisted health data', () async {
+    SharedPreferences.setMockInitialValues({
+      providerHealthStorageKey: '{not-json',
+    });
+    final preferences = await SharedPreferences.getInstance();
+    final container = ProviderContainer(
+      overrides: [sharedPreferencesProvider.overrideWithValue(preferences)],
+    );
+    addTearDown(container.dispose);
+
+    expect(
+      container
+          .read(providerHealthTrackerProvider)
+          .snapshotFor('xtream-1')
+          .healthClass,
+      ProviderHealthClass.unknown,
+    );
+  });
+}

--- a/packages/feature_iptv/test/iptv/presentation/tv/settings/tv_source_management_section_test.dart
+++ b/packages/feature_iptv/test/iptv/presentation/tv/settings/tv_source_management_section_test.dart
@@ -218,6 +218,49 @@ void main() {
     expect(find.text('VOD'), findsOneWidget);
   });
 
+  testWidgets('source list shows a privacy-safe provider health hint', (
+    tester,
+  ) async {
+    final container = await buildContainer();
+    addTearDown(container.dispose);
+    await container.read(
+      addXtreamContentSourceProvider((
+        label: 'Xtream',
+        url: 'https://xtream.example.com',
+        username: 'u',
+        password: 'p',
+      )).future,
+    );
+    final source = (await container.read(
+      configuredContentSourcesProvider.future,
+    )).single;
+    container
+        .read(providerHealthTrackerProvider)
+        .record(
+          ProviderHealthSample.fetchFailure(
+            sourceId: source.id,
+            timestampUtc: DateTime.utc(2026, 7, 29),
+            failureCategory: ProviderHealthFailureCategory.auth,
+            httpStatus: 401,
+          ),
+        );
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: const MaterialApp(
+          home: Scaffold(body: TvSourceManagementSection()),
+        ),
+      ),
+    );
+    await tester.pump();
+    await tester.pump();
+
+    expect(find.textContaining('Frequent recent issues'), findsOneWidget);
+    expect(find.textContaining('Credentials rejected'), findsOneWidget);
+    expect(find.textContaining('xtream.example.com'), findsNothing);
+  });
+
   testWidgets('removing a source requires confirmation', (tester) async {
     final container = await buildContainer();
     addTearDown(container.dispose);

--- a/packages/platform_playlist/lib/src/provider_health.dart
+++ b/packages/platform_playlist/lib/src/provider_health.dart
@@ -174,21 +174,34 @@ class ProviderHealthSnapshot extends Equatable {
 
 /// In-memory ring-buffered health tracker.
 ///
-/// One instance per app; caller records samples via [record] and reads
-/// [snapshotFor] to derive a UI health class. Persistence and
-/// cross-restart continuity are deliberately deferred — this slice-1
-/// keeps the tracker pure and testable.
+/// One instance per app; callers record samples via [record] and read
+/// [snapshotFor] to derive a UI health class. [initialSamples], [samples], and
+/// [onChanged] let the application layer add bounded persistence without
+/// coupling this platform contract to a storage implementation.
 class ProviderHealthTracker {
-  ProviderHealthTracker({int maxSamplesPerSource = 100})
-    : assert(maxSamplesPerSource > 0),
-      _maxSamplesPerSource = maxSamplesPerSource;
+  ProviderHealthTracker({
+    int maxSamplesPerSource = 100,
+    Iterable<ProviderHealthSample> initialSamples = const [],
+    this.onChanged,
+  }) : assert(maxSamplesPerSource > 0),
+       _maxSamplesPerSource = maxSamplesPerSource {
+    for (final sample in initialSamples) {
+      _record(sample);
+    }
+  }
 
   final int _maxSamplesPerSource;
+  final void Function()? onChanged;
   final Map<String, Queue<ProviderHealthSample>> _samples = {};
 
   /// Adds [sample] to its source's ring buffer, evicting the oldest
   /// sample when the buffer is full.
   void record(ProviderHealthSample sample) {
+    _record(sample);
+    onChanged?.call();
+  }
+
+  void _record(ProviderHealthSample sample) {
     final buffer = _samples.putIfAbsent(sample.sourceId, Queue.new);
     buffer.addLast(sample);
     while (buffer.length > _maxSamplesPerSource) {
@@ -263,16 +276,27 @@ class ProviderHealthTracker {
   /// Drops all samples for [sourceId]. Used when a source is removed
   /// or the user asks to reset its diagnostics.
   void clearFor(String sourceId) {
-    _samples.remove(sourceId);
+    if (_samples.remove(sourceId) != null) {
+      onChanged?.call();
+    }
   }
 
   /// Drops every sample. Used by "Reset diagnostics" affordances.
   void clearAll() {
+    if (_samples.isEmpty) return;
     _samples.clear();
+    onChanged?.call();
   }
 
   /// Diagnostic-only view of the recorded sample count per source.
   int sampleCountFor(String sourceId) => _samples[sourceId]?.length ?? 0;
+
+  /// Redacted samples suitable for bounded local persistence.
+  ///
+  /// Samples never contain URLs, credentials, response bodies, or raw error
+  /// text. The returned list is detached from the tracker's ring buffers.
+  List<ProviderHealthSample> get samples =>
+      List.unmodifiable(_samples.values.expand((buffer) => buffer));
 }
 
 ProviderHealthClass _classify({

--- a/packages/platform_playlist/test/provider_health_test.dart
+++ b/packages/platform_playlist/test/provider_health_test.dart
@@ -20,6 +20,29 @@ void main() {
     });
   });
 
+  test('initial samples hydrate without firing change callback', () {
+    var changes = 0;
+    final sample = ProviderHealthSample.fetchSuccess(
+      sourceId: sourceId,
+      timestampUtc: t0,
+      latency: const Duration(milliseconds: 90),
+    );
+    final tracker = ProviderHealthTracker(
+      initialSamples: [sample],
+      onChanged: () => changes++,
+    );
+
+    expect(tracker.samples, [sample]);
+    expect(
+      tracker.snapshotFor(sourceId).healthClass,
+      ProviderHealthClass.green,
+    );
+    expect(changes, 0);
+
+    tracker.clearFor(sourceId);
+    expect(changes, 1);
+  });
+
   group('single sample paths', () {
     test('single fetchSuccess → green + lastSuccess set', () {
       final tracker = ProviderHealthTracker();


### PR DESCRIPTION
## Summary

Adopts the still-relevant bounded slice of milestone-5 issue #816 now that configured Xtream sources are wired into the app:

- injects one shared `ProviderHealthTracker` into runtime Xtream requests;
- persists a bounded, redacted sample window across restarts;
- clears diagnostics when a source is deleted;
- shows honest source-health and likely-cause hints in TV source settings;
- documents the privacy boundary in the public wiki.

This intentionally does not revive the old proxy/cache umbrella scope. Addresses #816.

## Test Plan

- [x] `packages/feature_iptv`: `flutter analyze` passed
- [x] `packages/feature_iptv`: provider persistence, IPTV provider, and TV source settings tests passed
- [x] `packages/platform_playlist`: provider health and recorder tests passed (24 tests)
- [x] `packages/platform_player`: full test suite passed (222 tests)
- [x] Adopted VOD/aspect/Cast widget tests passed (23 tests)
- [x] `git diff --check` passed
- [x] Manual device verification not applicable to this bounded host-only state/presentation slice

**Verification environment:** Host-only (macOS); no emulator or simulator used.

## Agent Policy

- [x] #816 includes a Critical Agent Gate and Feature Packet.
- [x] #816 documents the platform/application contract and deterministic automation flows.
- [x] Redaction behavior is covered by persistence and UI tests.
- [x] Android Emulator was not used.

## Council Review

- Media Intelligence Architect: contract and application composition reviewed in this Codex session.
- Flutter Architect: existing responsive source-row composition preserved; no fixed dimensions or new navigation pattern.
- Chief Performance Officer: bounded 100-sample-per-source ring retained; no parsing or heavy serialization path added.
- Chief Open Source Officer: no dependency changes.
- Chief Security Officer: persisted payload excludes URLs, credentials, bodies, and raw errors; tests assert the boundary.
- Chief QA Officer: focused platform and widget/provider suites passed.

- [x] Decision Matrix reviewed and required lanes listed above.
- [x] Both touched packages retain valid `module.yaml` ownership.

## User-Facing Documentation

- [x] Updated `docs/wiki/7.-Troubleshooting-and-FAQ.md` with the source-health and privacy behavior.

## Plugin and Size Impact

- [ ] This PR adds new dependencies
- [x] This PR grows existing package code only
- [x] Size impact is small Dart source/test code; no native binary or plugin impact

## Checklist

- [x] Code is formatted.
- [x] Tests and local verification are listed above.
- [x] Sensitive data, credentials, and signing artifacts are not committed.

## Release Notes

- [x] Airo TV source settings can now retain and explain recent privacy-safe Xtream health signals.