### PR TITLE
fix(coins): delegate notifications to global shell

### DIFF
--- a/app/lib/core/providers/navigation_provider.dart
+++ b/app/lib/core/providers/navigation_provider.dart
@@ -234,6 +234,10 @@ AppShellHeaderMode appShellHeaderModeForLocation(String location) {
 
   const shellOwnedExactLocations = {
     '/money',
+    // The legacy dashboard alias renders the same Coins root content. Keep
+    // both entry points under the super-app header so Coins gets the single
+    // global notification action instead of owning duplicate local chrome.
+    '/money/dashboard',
     '/mind',
     '/mind/chat',
     '/mind/models',

--- a/app/lib/features/coins/presentation/screens/coins_dashboard_screen.dart
+++ b/app/lib/features/coins/presentation/screens/coins_dashboard_screen.dart
@@ -39,23 +39,7 @@ class CoinsDashboardScreen extends ConsumerWidget {
     final dashboardAsync = ref.watch(dashboardDataProvider);
 
     return Scaffold(
-      appBar: AppBar(
-        title: const Text('Coins'),
-        actions: [
-          IconButton(
-            icon: const Icon(Icons.notifications_outlined),
-            onPressed: () {
-              // TODO: Navigate to notifications
-            },
-          ),
-          IconButton(
-            icon: const Icon(Icons.settings_outlined),
-            onPressed: () {
-              // TODO: Navigate to settings
-            },
-          ),
-        ],
-      ),
+      backgroundColor: Colors.transparent,
       body: dashboardAsync.when(
         loading: () => const Center(child: CircularProgressIndicator()),
         error: (error, stack) => Center(

--- a/app/test/core/app/app_shell_header_ownership_test.dart
+++ b/app/test/core/app/app_shell_header_ownership_test.dart
@@ -28,6 +28,13 @@ void main() {
                   path: '/money',
                   builder: (context, state) =>
                       const _ShellBodyScreen(label: 'Money body'),
+                  routes: [
+                    GoRoute(
+                      path: 'dashboard',
+                      builder: (context, state) =>
+                          const _ShellBodyScreen(label: 'Money dashboard body'),
+                    ),
+                  ],
                 ),
               ],
             ),
@@ -100,7 +107,26 @@ void main() {
     expect(find.byType(AppBar), findsOneWidget);
     expect(find.widgetWithText(AppBar, 'Mind'), findsOneWidget);
     expect(find.byKey(const ValueKey('app_shell_home_button')), findsOneWidget);
+    expect(
+      find.byKey(const ValueKey('app_shell_notifications_button')),
+      findsOneWidget,
+    );
     expect(find.text('Mind body'), findsOneWidget);
+  });
+
+  testWidgets('Coins dashboard alias delegates to one global shell header', (
+    tester,
+  ) async {
+    await pumpShellRoute(tester, initialLocation: '/money/dashboard');
+
+    expect(find.byType(AppBar), findsOneWidget);
+    expect(find.widgetWithText(AppBar, 'Coins'), findsOneWidget);
+    expect(
+      find.byKey(const ValueKey('app_shell_notifications_button')),
+      findsOneWidget,
+    );
+    expect(find.byIcon(Icons.notifications_outlined), findsOneWidget);
+    expect(find.text('Money dashboard body'), findsOneWidget);
   });
 
   testWidgets('hides shell chrome on route-owned root routes', (tester) async {

--- a/app/test/core/providers/navigation_provider_test.dart
+++ b/app/test/core/providers/navigation_provider_test.dart
@@ -203,7 +203,7 @@ void main() {
       );
       expect(
         appShellHeaderModeForLocation('/money/dashboard'),
-        AppShellHeaderMode.route,
+        AppShellHeaderMode.shell,
       );
       expect(
         appShellHeaderModeForLocation('/money/groups/alpha'),

--- a/app/test/features/coins/presentation/screens/coins_dashboard_screen_test.dart
+++ b/app/test/features/coins/presentation/screens/coins_dashboard_screen_test.dart
@@ -18,6 +18,26 @@ void main() {
     SharedPreferences.setMockInitialValues({});
   });
 
+  testWidgets('delegates header actions to the Airo super-app shell', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          dashboardDataProvider.overrideWith(
+            (ref) async => const DashboardData(),
+          ),
+        ],
+        child: const MaterialApp(home: CoinsDashboardScreen()),
+      ),
+    );
+    await tester.pump();
+
+    expect(find.byType(AppBar), findsNothing);
+    expect(find.byIcon(Icons.notifications_outlined), findsNothing);
+    expect(find.byIcon(Icons.settings_outlined), findsNothing);
+  });
+
   testWidgets('shows real safe-to-spend data in the user currency', (
     tester,
   ) async {


### PR DESCRIPTION
## Summary

- remove the legacy Coins dashboard AppBar that duplicated the Airo shell notification bell
- delegate both `/money` and `/money/dashboard` to the shell-owned header, matching Mind
- retain one functional global bell that routes to `/mind/notifications`
- remove the dead Coins-local notification/settings TODO actions

Closes #1359.

## Test Plan

- [x] Focused `flutter analyze --no-pub --no-fatal-infos --no-fatal-warnings` passed with no issues
- [x] 27 focused Flutter tests passed across Coins, shell chrome, route ownership, and navigation policy
- [x] `git diff --check` passed
- [x] Manual Pixel 9 verification completed

**Verification environment:** Host-only tests plus physical Pixel 9 / Android 17 (API 37). No emulator used.

Pixel evidence:
- final ARM64 debug APK SHA-256: `7fb2057a4709be043cd0b26f2cec268390870e7df593cc593cfb8757e62916c4`
- APK installed replace-in-place; original first-install timestamp and granted notification permission were preserved
- Coins UIAutomator tree exposed exactly one `Notifications` action
- tapping that sole action opened `Notifications (0)` / `No scheduled notifications`

## Agent Policy

- [x] Linked issue includes a Critical Agent Gate
- [x] Linked issue includes a Feature Packet
- [x] Cross-agent contract is documented for shell/Coins ownership
- [x] Deterministic use cases and automation flows are included
- [x] AI/tool/memory/routine eval requirement is not applicable
- [x] Android Emulator was not used

## Council Review

Required roles identified from `docs/agents/COUNCIL.md`:
- Chief Architect: primary owner; shell boundary implemented and contract recorded
- Coins / Finance Agent: domain review requested
- Flutter Architect: widget structure review requested
- Chief QA Officer: deterministic host/device evidence recorded
- Chief UX Officer: single-header interaction consistency review requested
- Chief Performance Officer: no new rendering layer/dependency; review requested
- Product Manager: end-user bug-fix scope recorded
- Security and Privacy Agent: no permission/data behavior changed; review requested

- [x] Decision Matrix checked and required roles listed
- [x] No package/module manifest is changed; only the existing host `app/` composition is touched
- [x] Existing ownership roster remains accurate

## User-Facing Documentation

- [x] No `docs/wiki` update is needed: this removes duplicate/dead chrome without changing a documented capability, route destination, permission, or finance behavior

## Plugin and Size Impact

- [ ] This PR adds new dependencies
- [ ] This PR adds or grows app/packages/plugins code
- [x] Size impact: net deletion in production code; no plugin impact
- [x] Module/plugin size thresholds are not affected

## Checklist

- [x] Code is formatted
- [x] Tests and physical verification are documented above
- [x] No sensitive data, credentials, or signing artifacts committed
- [x] Iterative commit uses `[skip ci]`; focused local evidence is sufficient for this bounded UI fix

## Release Notes

- [x] Coins now uses Airo's single global notification bell, matching Mind and eliminating the duplicate nonfunctional icon.