### PR TITLE
feat(notifications): add friendly permission prompt

### DIFF
--- a/app/lib/features/agent_chat/data/services/agent_notification_scheduler.dart
+++ b/app/lib/features/agent_chat/data/services/agent_notification_scheduler.dart
@@ -177,6 +177,14 @@ abstract interface class AgentNotificationRuntimeService {
   Future<String?> getLaunchPayload();
 }
 
+enum AgentNotificationPermissionStatus { enabled, disabled, unavailable }
+
+abstract interface class AgentNotificationPermissionService {
+  Future<AgentNotificationPermissionStatus> notificationPermissionStatus();
+
+  Future<bool> requestNotificationPermission();
+}
+
 class NotificationPermissionDeniedException implements Exception {
   const NotificationPermissionDeniedException();
 }
@@ -184,7 +192,8 @@ class NotificationPermissionDeniedException implements Exception {
 class LocalAgentNotificationScheduler
     implements
         AgentNotificationSchedulingService,
-        AgentNotificationRuntimeService {
+        AgentNotificationRuntimeService,
+        AgentNotificationPermissionService {
   LocalAgentNotificationScheduler({
     FlutterLocalNotificationsPlugin? notificationsPlugin,
     SharedPreferencesAsync? preferences,
@@ -257,7 +266,7 @@ class LocalAgentNotificationScheduler
     }
 
     await _ensureInitialized();
-    final hasPermission = await _requestNotificationPermission();
+    final hasPermission = await requestNotificationPermission();
     if (!hasPermission) {
       throw const NotificationPermissionDeniedException();
     }
@@ -412,41 +421,100 @@ class LocalAgentNotificationScheduler
     _initialized = true;
   }
 
-  Future<bool> _requestNotificationPermission() async {
+  @override
+  Future<AgentNotificationPermissionStatus>
+  notificationPermissionStatus() async {
+    if (kIsWeb) return AgentNotificationPermissionStatus.unavailable;
+    try {
+      await _ensureInitialized();
+      switch (defaultTargetPlatform) {
+        case TargetPlatform.android:
+          final android = _notificationsPlugin
+              .resolvePlatformSpecificImplementation<
+                AndroidFlutterLocalNotificationsPlugin
+              >();
+          final enabled = await android?.areNotificationsEnabled();
+          if (enabled == null) {
+            return AgentNotificationPermissionStatus.unavailable;
+          }
+          return enabled
+              ? AgentNotificationPermissionStatus.enabled
+              : AgentNotificationPermissionStatus.disabled;
+        case TargetPlatform.iOS:
+          final ios = _notificationsPlugin
+              .resolvePlatformSpecificImplementation<
+                IOSFlutterLocalNotificationsPlugin
+              >();
+          final permissions = await ios?.checkPermissions();
+          if (permissions == null) {
+            return AgentNotificationPermissionStatus.unavailable;
+          }
+          return permissions.isEnabled
+              ? AgentNotificationPermissionStatus.enabled
+              : AgentNotificationPermissionStatus.disabled;
+        case TargetPlatform.macOS:
+          final macos = _notificationsPlugin
+              .resolvePlatformSpecificImplementation<
+                MacOSFlutterLocalNotificationsPlugin
+              >();
+          final permissions = await macos?.checkPermissions();
+          if (permissions == null) {
+            return AgentNotificationPermissionStatus.unavailable;
+          }
+          return permissions.isEnabled
+              ? AgentNotificationPermissionStatus.enabled
+              : AgentNotificationPermissionStatus.disabled;
+        case TargetPlatform.fuchsia:
+        case TargetPlatform.linux:
+        case TargetPlatform.windows:
+          return AgentNotificationPermissionStatus.unavailable;
+      }
+    } catch (_) {
+      return AgentNotificationPermissionStatus.unavailable;
+    }
+  }
+
+  @override
+  Future<bool> requestNotificationPermission() async {
     if (kIsWeb) return false;
-    switch (defaultTargetPlatform) {
-      case TargetPlatform.android:
-        final android = _notificationsPlugin
-            .resolvePlatformSpecificImplementation<
-              AndroidFlutterLocalNotificationsPlugin
-            >();
-        return await android?.requestNotificationsPermission() ?? true;
-      case TargetPlatform.iOS:
-        final ios = _notificationsPlugin
-            .resolvePlatformSpecificImplementation<
-              IOSFlutterLocalNotificationsPlugin
-            >();
-        return await ios?.requestPermissions(
-              alert: true,
-              badge: true,
-              sound: true,
-            ) ??
-            false;
-      case TargetPlatform.macOS:
-        final macos = _notificationsPlugin
-            .resolvePlatformSpecificImplementation<
-              MacOSFlutterLocalNotificationsPlugin
-            >();
-        return await macos?.requestPermissions(
-              alert: true,
-              badge: true,
-              sound: true,
-            ) ??
-            false;
-      case TargetPlatform.fuchsia:
-      case TargetPlatform.linux:
-      case TargetPlatform.windows:
-        return false;
+    try {
+      await _ensureInitialized();
+      switch (defaultTargetPlatform) {
+        case TargetPlatform.android:
+          final android = _notificationsPlugin
+              .resolvePlatformSpecificImplementation<
+                AndroidFlutterLocalNotificationsPlugin
+              >();
+          return await android?.requestNotificationsPermission() ?? false;
+        case TargetPlatform.iOS:
+          final ios = _notificationsPlugin
+              .resolvePlatformSpecificImplementation<
+                IOSFlutterLocalNotificationsPlugin
+              >();
+          return await ios?.requestPermissions(
+                alert: true,
+                badge: true,
+                sound: true,
+              ) ??
+              false;
+        case TargetPlatform.macOS:
+          final macos = _notificationsPlugin
+              .resolvePlatformSpecificImplementation<
+                MacOSFlutterLocalNotificationsPlugin
+              >();
+          return await macos?.requestPermissions(
+                alert: true,
+                badge: true,
+                sound: true,
+              ) ??
+              false;
+        case TargetPlatform.fuchsia:
+        case TargetPlatform.linux:
+        case TargetPlatform.windows:
+          return false;
+      }
+    } catch (_) {
+      return false;
     }
   }
 

--- a/app/lib/features/agent_chat/presentation/screens/notifications_screen.dart
+++ b/app/lib/features/agent_chat/presentation/screens/notifications_screen.dart
@@ -4,9 +4,15 @@ import 'package:go_router/go_router.dart';
 import '../../data/services/agent_notification_scheduler.dart';
 
 class NotificationsScreen extends StatefulWidget {
-  const NotificationsScreen({super.key, this.scheduler, this.initialCategory});
+  const NotificationsScreen({
+    super.key,
+    this.scheduler,
+    this.permissionService,
+    this.initialCategory,
+  });
 
   final AgentNotificationSchedulingService? scheduler;
+  final AgentNotificationPermissionService? permissionService;
   final String? initialCategory;
 
   @override
@@ -15,13 +21,19 @@ class NotificationsScreen extends StatefulWidget {
 
 class _NotificationsScreenState extends State<NotificationsScreen> {
   late final AgentNotificationSchedulingService _scheduler;
+  late final AgentNotificationPermissionService _permissionService;
   late Future<List<ScheduledAgentNotification>> _notificationsFuture;
+  late Future<AgentNotificationPermissionStatus> _permissionStatusFuture;
+  bool _requestingPermission = false;
 
   @override
   void initState() {
     super.initState();
     _scheduler = widget.scheduler ?? LocalAgentNotificationScheduler.instance;
+    _permissionService =
+        widget.permissionService ?? LocalAgentNotificationScheduler.instance;
     _notificationsFuture = _scheduler.getScheduledNotifications();
+    _permissionStatusFuture = _permissionService.notificationPermissionStatus();
   }
 
   @override
@@ -49,10 +61,49 @@ class _NotificationsScreenState extends State<NotificationsScreen> {
           ),
           body: ColoredBox(
             color: Theme.of(context).colorScheme.surfaceContainerLowest,
-            child: _buildBody(context, snapshot, notifications),
+            child: Column(
+              children: [
+                FutureBuilder<AgentNotificationPermissionStatus>(
+                  future: _permissionStatusFuture,
+                  builder: (context, permissionSnapshot) {
+                    if (permissionSnapshot.data !=
+                        AgentNotificationPermissionStatus.disabled) {
+                      return const SizedBox.shrink();
+                    }
+                    return _NotificationPermissionCard(
+                      requesting: _requestingPermission,
+                      onRequest: _requestNotificationPermission,
+                    );
+                  },
+                ),
+                Expanded(child: _buildBody(context, snapshot, notifications)),
+              ],
+            ),
           ),
         );
       },
+    );
+  }
+
+  Future<void> _requestNotificationPermission() async {
+    if (_requestingPermission) return;
+    setState(() => _requestingPermission = true);
+    final granted = await _permissionService.requestNotificationPermission();
+    if (!mounted) return;
+
+    setState(() {
+      _requestingPermission = false;
+      _permissionStatusFuture = _permissionService
+          .notificationPermissionStatus();
+    });
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text(
+          granted
+              ? 'Bell acquired. Airo can now keep you posted.'
+              : 'No worries — Airo will keep updates inside the app.',
+        ),
+      ),
     );
   }
 
@@ -131,6 +182,70 @@ class _NotificationsScreenState extends State<NotificationsScreen> {
       return 'Notifications ($count)';
     }
     return '${_categoryLabel(category)} Notifications ($count)';
+  }
+}
+
+class _NotificationPermissionCard extends StatelessWidget {
+  const _NotificationPermissionCard({
+    required this.requesting,
+    required this.onRequest,
+  });
+
+  final bool requesting;
+  final VoidCallback onRequest;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).colorScheme;
+    return Semantics(
+      container: true,
+      label: 'Notification permission',
+      child: Card(
+        margin: const EdgeInsets.fromLTRB(16, 16, 16, 0),
+        color: colors.secondaryContainer,
+        child: Padding(
+          padding: const EdgeInsets.all(16),
+          child: Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Icon(Icons.notifications_active_outlined, color: colors.primary),
+              const SizedBox(width: 12),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      'Let Airo ring the tiny bell?',
+                      style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                        fontWeight: FontWeight.w700,
+                      ),
+                    ),
+                    const SizedBox(height: 6),
+                    const Text(
+                      'Turn on notifications so downloads, reminders, and '
+                      'recordings don’t finish in mysterious silence.',
+                    ),
+                    const SizedBox(height: 12),
+                    FilledButton.icon(
+                      onPressed: requesting ? null : onRequest,
+                      icon: requesting
+                          ? const SizedBox.square(
+                              dimension: 18,
+                              child: CircularProgressIndicator(strokeWidth: 2),
+                            )
+                          : const Icon(Icons.notifications_active_outlined),
+                      label: Text(
+                        requesting ? 'Asking nicely…' : 'Yes, keep me posted',
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
   }
 }
 

--- a/app/test/features/agent_chat/data/services/agent_notification_scheduler_test.dart
+++ b/app/test/features/agent_chat/data/services/agent_notification_scheduler_test.dart
@@ -35,6 +35,8 @@ void main() {
           switch (call.method) {
             case 'initialize':
               return true;
+            case 'areNotificationsEnabled':
+              return false;
             case 'requestNotificationsPermission':
               return true;
             case 'zonedSchedule':
@@ -47,6 +49,23 @@ void main() {
     scheduler = LocalAgentNotificationScheduler(
       notificationsPlugin: FlutterLocalNotificationsPlugin(),
       preferences: preferences,
+    );
+  });
+
+  test('reports and requests Android notification permission', () async {
+    expect(
+      await scheduler.notificationPermissionStatus(),
+      AgentNotificationPermissionStatus.disabled,
+    );
+    expect(await scheduler.requestNotificationPermission(), isTrue);
+
+    expect(
+      methodCalls.map((call) => call.method),
+      containsAllInOrder([
+        'initialize',
+        'areNotificationsEnabled',
+        'requestNotificationsPermission',
+      ]),
     );
   });
 

--- a/app/test/features/agent_chat/presentation/screens/notifications_screen_test.dart
+++ b/app/test/features/agent_chat/presentation/screens/notifications_screen_test.dart
@@ -133,6 +133,114 @@ void main() {
     expect(find.text('Recording reminder'), findsOneWidget);
     expect(find.text('Download reminder'), findsNothing);
   });
+
+  testWidgets('friendly permission card requests access and hides on grant', (
+    tester,
+  ) async {
+    final permissionService = _FakeNotificationPermissionService(
+      status: AgentNotificationPermissionStatus.disabled,
+      grantOnRequest: true,
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: NotificationsScreen(
+          scheduler: _FakeNotificationScheduler([]),
+          permissionService: permissionService,
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('Let Airo ring the tiny bell?'), findsOneWidget);
+    expect(find.text('Yes, keep me posted'), findsOneWidget);
+
+    await tester.tap(find.text('Yes, keep me posted'));
+    await tester.pumpAndSettle();
+
+    expect(permissionService.requestCount, 1);
+    expect(find.text('Let Airo ring the tiny bell?'), findsNothing);
+    expect(
+      find.text('Bell acquired. Airo can now keep you posted.'),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets('denial keeps in-app updates and the retry path available', (
+    tester,
+  ) async {
+    final permissionService = _FakeNotificationPermissionService(
+      status: AgentNotificationPermissionStatus.disabled,
+      grantOnRequest: false,
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: NotificationsScreen(
+          scheduler: _FakeNotificationScheduler([]),
+          permissionService: permissionService,
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Yes, keep me posted'));
+    await tester.pumpAndSettle();
+
+    expect(permissionService.requestCount, 1);
+    expect(find.text('Let Airo ring the tiny bell?'), findsOneWidget);
+    expect(
+      find.text('No worries — Airo will keep updates inside the app.'),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets('enabled and unavailable states do not show a permission card', (
+    tester,
+  ) async {
+    for (final status in [
+      AgentNotificationPermissionStatus.enabled,
+      AgentNotificationPermissionStatus.unavailable,
+    ]) {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: NotificationsScreen(
+            scheduler: _FakeNotificationScheduler([]),
+            permissionService: _FakeNotificationPermissionService(
+              status: status,
+              grantOnRequest: false,
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('Let Airo ring the tiny bell?'), findsNothing);
+    }
+  });
+
+  testWidgets('permission card remains usable at 200 percent text scale', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: MediaQuery(
+          data: const MediaQueryData(textScaler: TextScaler.linear(2)),
+          child: NotificationsScreen(
+            scheduler: _FakeNotificationScheduler([]),
+            permissionService: _FakeNotificationPermissionService(
+              status: AgentNotificationPermissionStatus.disabled,
+              grantOnRequest: false,
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(tester.takeException(), isNull);
+    expect(find.text('Yes, keep me posted'), findsOneWidget);
+  });
 }
 
 class _SelectedAssistantModelNotifier extends SelectedAssistantModelNotifier {
@@ -172,5 +280,30 @@ final class _FakeNotificationScheduler
     ScheduleAgentNotificationRequest request,
   ) {
     throw UnimplementedError();
+  }
+}
+
+final class _FakeNotificationPermissionService
+    implements AgentNotificationPermissionService {
+  _FakeNotificationPermissionService({
+    required this.status,
+    required this.grantOnRequest,
+  });
+
+  AgentNotificationPermissionStatus status;
+  final bool grantOnRequest;
+  int requestCount = 0;
+
+  @override
+  Future<AgentNotificationPermissionStatus>
+  notificationPermissionStatus() async => status;
+
+  @override
+  Future<bool> requestNotificationPermission() async {
+    requestCount += 1;
+    if (grantOnRequest) {
+      status = AgentNotificationPermissionStatus.enabled;
+    }
+    return grantOnRequest;
   }
 }


### PR DESCRIPTION
## Summary

- add a typed notification permission status/request interface to the existing scheduler service
- show a friendly, nonblocking Notification Center rationale card only when notifications are disabled
- request `POST_NOTIFICATIONS` only after the user taps `Yes, keep me posted`
- hide the card after grant, retain a safe retry path after denial, and suppress it on enabled/unsupported platforms

Related to #515. This PR completes only the permission-request UX slice; the broader delivery matrix remains tracked there.

## Test Plan

- [x] Focused Flutter analyzer passed with no issues
- [x] 16/16 focused scheduler, navigation, permission, denial, enabled/unavailable, and 200% text-scale tests passed
- [x] `git diff --check` passed
- [x] Mainline dry merge passed YAML, whitespace, and structural checks
- [x] Manual Pixel 9 verification completed

**Verification environment:** Host-only tests plus physical Pixel 9 / Android 17 (API 37). No emulator used.

Pixel evidence:
- ARM64 debug APK SHA-256: `e93ec45baf4c7eb29f7ad21ecc0e9b6f4a51167255865f10f9b18eec483214d9`
- installed replace-in-place without uninstall or data clear
- friendly card rendered without clipping and exposed accessible permission semantics
- CTA launched Android Permission Controller's real notification prompt
- Android recorded the user's Allow selection; `POST_NOTIFICATIONS` became granted and the card disappeared

## Agent Policy

- [x] Issue #515 includes the Critical Agent Gate and Feature Packet
- [x] Cross-agent permission/UI contract is documented
- [x] Deterministic use cases and automation flows are included
- [x] No AI/tool/memory/routine eval requirement applies
- [x] Android Emulator was not used

## Council Review

Required roles identified from `docs/agents/COUNCIL.md`:
- Flutter Architect: primary implementation owner
- Chief Architect: additive service/UI boundary
- Chief QA Officer: deterministic host and Pixel evidence
- Chief UX Officer: copy, accessibility, and retry behavior
- Product Manager: user-facing scope
- Security and Privacy Agent: `POST_NOTIFICATIONS` only; no content or response logging

- [x] Decision Matrix checked and required roles listed
- [x] No package/module manifest changed
- [x] Existing ownership roster remains accurate

## User-Facing Documentation

- [x] No `docs/wiki` update is needed: this improves an existing OS permission entry point without changing the documented notification capability or adding a permission

## Plugin and Size Impact

- [ ] This PR adds new dependencies
- [x] This PR adds a small app-owned rationale widget and permission adapter methods
- [x] No plugin/package size threshold is affected
- [x] No dependency or plugin changes

## Checklist

- [x] Code is formatted
- [x] Tests and manual verification are documented
- [x] No sensitive data, credentials, or signing artifacts committed
- [x] Commit uses `[skip ci]`; focused local and physical-device evidence covers this bounded slice

## Release Notes

- [x] Airo now explains notification access with friendly copy before invoking Android's permission prompt.