### PR TITLE
fix(feature_iptv): stop hammering an unreachable playlist source

### DIFF
--- a/packages/feature_iptv/lib/application/providers/iptv_providers.dart
+++ b/packages/feature_iptv/lib/application/providers/iptv_providers.dart
@@ -240,16 +240,26 @@ final iptvChannelsProvider = FutureProvider<List<IPTVChannel>>((ref) async {
     Error.throwWithStackTrace(configuredM3uFailure, configuredM3uTrace!);
   }
   return merged;
-}, retry: _surfaceFailureInsteadOfRetrying);
+}, retry: surfaceChannelFailureInsteadOfRetrying);
 
-/// Opts the channel libraries out of Riverpod's automatic retry.
+/// Opts a channel-derived provider out of Riverpod's automatic retry.
 ///
-/// A retrying provider stays in `AsyncLoading` with the error attached, so the
-/// screen shows its spinner forever and `_buildError`'s Retry button never
-/// renders. Channel loading is user-initiated and already has an explicit
-/// Retry, so a failure must settle as `AsyncError` and be shown.
-Duration? _surfaceFailureInsteadOfRetrying(int retryCount, Object error) =>
-    null;
+/// Two reasons, both observed on the rig Pixel 9 with an unreachable source:
+///
+/// * A retrying provider stays in `AsyncLoading` with the error attached, so
+///   the screen shows its spinner forever and the error state with its Retry
+///   button never renders.
+/// * Every dependent that retries re-drives the failed ancestor, which
+///   re-contacts the dead source. With rails, vod, guide, and metadata
+///   enrichment all retrying, one unreachable playlist was refetched several
+///   times a second.
+///
+/// Channel loading is user-initiated and already has an explicit Retry, so a
+/// failure must settle as `AsyncError` and stay settled.
+Duration? surfaceChannelFailureInsteadOfRetrying(
+  int retryCount,
+  Object error,
+) => null;
 
 /// Loads every configured M3U source with an independent cache namespace.
 ///
@@ -265,7 +275,7 @@ final configuredM3uChannelsProvider = FutureProvider<List<IPTVChannel>>((
     configs,
     ref.read(m3uSourceParserFactoryProvider),
   );
-}, retry: _surfaceFailureInsteadOfRetrying);
+}, retry: surfaceChannelFailureInsteadOfRetrying);
 
 final _refreshConfiguredM3uChannelsProvider =
     FutureProvider.family<List<IPTVChannel>, bool>((ref, forceRefresh) async {

--- a/packages/feature_iptv/lib/application/providers/rails_provider.dart
+++ b/packages/feature_iptv/lib/application/providers/rails_provider.dart
@@ -44,4 +44,4 @@ final railsProvider = FutureProvider<List<RailResult>>((ref) async {
         .toList(growable: false),
   );
   return [...personal, ...regional];
-});
+}, retry: surfaceChannelFailureInsteadOfRetrying);

--- a/packages/feature_iptv/lib/application/providers/regional_discovery_providers.dart
+++ b/packages/feature_iptv/lib/application/providers/regional_discovery_providers.dart
@@ -43,4 +43,4 @@ final regionalDiscoveryRailsProvider = FutureProvider<List<RailResult>>((
     },
     availabilityByChannelId: availability,
   );
-});
+}, retry: surfaceChannelFailureInsteadOfRetrying);

--- a/packages/feature_iptv/lib/application/providers/vod_providers.dart
+++ b/packages/feature_iptv/lib/application/providers/vod_providers.dart
@@ -22,7 +22,7 @@ final rawVodItemsProvider = FutureProvider<List<VodItem>>((ref) async {
   final channels = await ref.watch(iptvChannelsProvider.future);
   final adapter = ref.watch(_m3uVodAdapterProvider);
   return adapter.extractVodItems(channels);
-});
+}, retry: surfaceChannelFailureInsteadOfRetrying);
 
 final _vodSeriesGrouperProvider = Provider<VodSeriesGrouper>(
   (ref) => VodSeriesGrouper(),

--- a/packages/feature_iptv/lib/presentation/tv_ux/tv_loading_screen.dart
+++ b/packages/feature_iptv/lib/presentation/tv_ux/tv_loading_screen.dart
@@ -27,9 +27,9 @@ class TvLoadingScreen extends StatelessWidget {
             const SizedBox(height: 24),
             Text(
               message,
-              style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                color: Colors.white70,
-              ),
+              style: Theme.of(
+                context,
+              ).textTheme.bodyMedium?.copyWith(color: Colors.white70),
             ),
           ],
         ),

--- a/packages/feature_iptv/test/iptv/application/providers/configured_m3u_failure_test.dart
+++ b/packages/feature_iptv/test/iptv/application/providers/configured_m3u_failure_test.dart
@@ -240,6 +240,66 @@ void main() {
     );
   });
 
+  testWidgets(
+    'a dead source is fetched once, not re-driven by every dependent that '
+    'retries on the propagated error',
+    (tester) async {
+      var fetchAttempts = 0;
+      final container = ProviderContainer(
+        overrides: [
+          sharedPreferencesProvider.overrideWithValue(prefs),
+          m3uSourceParserFactoryProvider.overrideWithValue(
+            (sourceId) => _CountingSourceParser(
+              prefs: prefs,
+              sourceId: sourceId,
+              onFetch: () => fetchAttempts++,
+            ),
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+      await container.read(contentSourceStoreProvider).replaceAll([
+        source('m3u-dead'),
+      ]);
+      container.invalidate(configuredContentSourcesProvider);
+
+      // The channel screen watches the rails alongside the channels; rails
+      // await iptvChannelsProvider and so inherit its failure.
+      await tester.pumpWidget(
+        UncontrolledProviderScope(
+          container: container,
+          child: MaterialApp(
+            home: Consumer(
+              builder: (context, ref, _) {
+                ref.watch(railsProvider);
+                final channels = ref.watch(iptvChannelsProvider);
+                return Text(
+                  channels.hasError ? 'error' : 'pending',
+                  textDirection: TextDirection.ltr,
+                );
+              },
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+      expect(find.text('error'), findsOneWidget);
+
+      // Let every retry timer in the chain fire.
+      for (var i = 0; i < 10; i++) {
+        await tester.pump(const Duration(seconds: 1));
+      }
+
+      expect(
+        fetchAttempts,
+        1,
+        reason:
+            'an unreachable source must be contacted once per user-initiated '
+            'load, not hammered because dependents retry the error',
+      );
+    },
+  );
+
   test('the failure message names no source URL', () {
     expect(
       const PlaylistSourcesUnavailableException(3).toString(),

--- a/packages/feature_iptv/test/iptv/presentation/tv/settings/tv_playback_section_test.dart
+++ b/packages/feature_iptv/test/iptv/presentation/tv/settings/tv_playback_section_test.dart
@@ -40,24 +40,21 @@ void main() {
     expect(find.text('Stretch to fill'), findsOneWidget);
   });
 
-  testWidgets(
-    'does not offer Picture-in-picture -- no Android TV / Fire TV '
-    'multi-window model for it to float into',
-    (tester) async {
-      final container = await buildContainer();
-      addTearDown(container.dispose);
+  testWidgets('does not offer Picture-in-picture -- no Android TV / Fire TV '
+      'multi-window model for it to float into', (tester) async {
+    final container = await buildContainer();
+    addTearDown(container.dispose);
 
-      await tester.pumpWidget(
-        UncontrolledProviderScope(
-          container: container,
-          child: const MaterialApp(home: Scaffold(body: TvPlaybackSection())),
-        ),
-      );
-      await tester.pump();
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: const MaterialApp(home: Scaffold(body: TvPlaybackSection())),
+      ),
+    );
+    await tester.pump();
 
-      expect(find.text('Picture-in-picture'), findsNothing);
-    },
-  );
+    expect(find.text('Picture-in-picture'), findsNothing);
+  });
 
   testWidgets('selecting a fit option updates videoAspectRatioProvider', (
     tester,

--- a/packages/feature_iptv/test/presentation/tv_ux/filter_option_dialog_dpad_test.dart
+++ b/packages/feature_iptv/test/presentation/tv_ux/filter_option_dialog_dpad_test.dart
@@ -29,14 +29,7 @@ void main() {
     );
     await tester.pumpAndSettle();
 
-    const order = [
-      'All',
-      'Alpha',
-      'Bravo',
-      'Charlie',
-      'Delta',
-      'Echo',
-    ];
+    const order = ['All', 'Alpha', 'Bravo', 'Charlie', 'Delta', 'Echo'];
 
     // Which option row holds focus now? A row is "focused" when the focus
     // ancestor of its Text widget has primary focus.


### PR DESCRIPTION
Follow-up to #1362, found by instrumenting the rig Pixel 9 to settle the intermittency in #1363.

## What the instrumented run showed

With one unreachable M3U source configured, the channel chain behaves correctly on the first pass — `sources=1`, the loader counts the failure, `willThrow=true`, and the screen settles on `AsyncError` with its Retry button. That disproves the caching hypothesis in #1363.

What it also showed is that the app then re-fetches the dead source roughly **five times a second**, with the state flapping between `AsyncError isLoading=false` and `AsyncError isLoading=true`:

```
QAP3 configured=0 failure=PlaylistSourcesUnavailableException
QAP4 merged=0 byoc=0 willThrow=true
QAP5 screen state=AsyncError hasError=true isLoading=false
QAP5 screen state=AsyncError hasError=true isLoading=true    <- retry in flight
[Provider] M3U source <id> could not be refreshed.            <- source hit again
...repeating every ~150-200ms
```

## Cause

`iptvChannelsProvider` and `configuredM3uChannelsProvider` opted out of Riverpod's automatic retry in #1362, but the providers *above* them did not. `railsProvider`, `regionalDiscoveryRailsProvider`, and `rawVodItemsProvider` all `await ref.watch(iptvChannelsProvider.future)` and kept the default retry, and each retry re-drives the failed ancestor — which re-contacts the source. The channel screen watches the rails, so the loop is live on the main IPTV surface.

Disabling retry on the leaves was never going to be enough: the pressure came from below them.

## Change

All the channel-derived providers now share one policy, `surfaceChannelFailureInsteadOfRetrying` (previously private to `iptv_providers`), with the reasoning recorded on it. Guide and metadata enrichment are deliberately untouched: the guide window is a `Notifier` whose `build` does not await the channel future, and the enrichment provider catches its own failures and yields no metadata by design.

## Verification

- New test locks both halves: the source is contacted exactly once, and no retry timer is left pending. The pending-timer assertion is what the framework itself raised while the storm was live, so the test fails loudly on regression rather than silently counting fetches.
- `packages/feature_iptv`: 11 targeted tests pass; the full suite is 817 pass / 2 fail, and those 2 are a pre-existing leak-tracker teardown failure in `iptv_screen_touch_fullscreen_orientation_test.dart` that fails identically on `origin/main` (verified by stashing).
- Device, after the fix: **one fetch in 35 seconds**, down from five per second.

## Also verified on device in this pass, no change needed

Real playback against `https://iptv-org.github.io/iptv/index.m3u` (12,843 channels imported): Vevo Pop, YRF Music (1920x1080), and B4U Music (1024x576) all play, with the header, stats panel, and mini-player staying in sync across switches. Keeping a dead source alongside the working one confirmed the partial-failure contract from #1362 — `failure=null, willThrow=false` — so one bad source does not take its siblings down.

Closes #1363.

🤖 Generated with [Claude Code](https://claude.com/claude-code)