### PR TITLE
fix(android): drop non-target ABI plugin libs from single-ABI APKs

### DIFF
--- a/app/android/app/build.gradle.kts
+++ b/app/android/app/build.gradle.kts
@@ -16,6 +16,29 @@ fun dartDefine(name: String): String? {
         ?.substringAfter("=")
 }
 
+/// Every ABI an Android artifact in this project can carry.
+val ALL_ANDROID_ABIS = listOf("arm64-v8a", "armeabi-v7a", "x86_64", "x86")
+
+/// The one ABI this build targets, or null when it targets several.
+///
+/// Flutter passes its `--target-platform` values through the `target-platform`
+/// Gradle property; `--split-per-abi` passes all of them.
+val singleAbi: String? =
+    (providers.gradleProperty("target-platform").orNull ?: "")
+        .split(",")
+        .map { it.trim() }
+        .filter { it.isNotEmpty() }
+        .singleOrNull()
+        ?.let { platform ->
+            when (platform) {
+                "android-arm64" -> "arm64-v8a"
+                "android-arm" -> "armeabi-v7a"
+                "android-x64" -> "x86_64"
+                "android-x86" -> "x86"
+                else -> null
+            }
+        }
+
 val appVariant = dartDefine("APP_VARIANT") ?: "full"
 val isLeanVariant = appVariant != "full"
 val isTvVariant = appVariant == "tv"
@@ -186,6 +209,21 @@ android {
 
     packaging {
         jniLibs {
+            // Flutter's --target-platform filters only the libs Flutter itself
+            // contributes (libflutter.so, libapp.so). Native libs that arrive
+            // inside a plugin AAR keep every ABI they were published with, so a
+            // single-ABI build still ships the others as dead weight -- 2.9 MB
+            // of x86_64 and armeabi-v7a libsqlite3.so in the arm64-only TV APK.
+            //
+            // Drop them when the build declares exactly one ABI. A
+            // --split-per-abi build passes every platform, so singleAbi is null
+            // there and nothing is excluded; ABI splitting stays Flutter's job
+            // (see the splits.abi note above).
+            singleAbi?.let { abi ->
+                for (other in ALL_ANDROID_ABIS.filter { it != abi }) {
+                    excludes += "lib/$other/**"
+                }
+            }
             if (isLeanVariant) {
                 excludes += setOf(
                     "**/liblitertlm_jni.so",


### PR DESCRIPTION
Resolves the TV size-gate failure in #1364 by removing the growth instead of absorbing it into the baseline.

## What was in the APK

The TV leg builds with `--target-platform=android-arm64`, yet the arm64-only artifact shipped native libs for two other ABIs:

```
 1.48 MB  lib/x86_64/libsqlite3.so
 1.45 MB  lib/armeabi-v7a/libsqlite3.so
 0.10 MB  lib/x86_64/libdartjni.so
 0.07 MB  lib/armeabi-v7a/libdartjni.so
 0.01 MB  lib/x86_64/libdatastore_shared_counter.so
 0.00 MB  lib/armeabi-v7a/libdatastore_shared_counter.so
```

`--target-platform` filters only what Flutter itself contributes — `libflutter.so` and `libapp.so`. Anything delivered inside a plugin AAR (`sqlite3_flutter_libs` here) keeps every ABI it was published with.

## Change

`packaging.jniLibs` now excludes every non-target ABI when the build declares exactly one, derived from the `target-platform` Gradle property Flutter already passes. A `--split-per-abi` build passes all platforms, so `singleAbi` is null and nothing is excluded — ABI splitting stays Flutter's job, per the existing `splits.abi` note a few lines above.

## Measurement

TV release, built locally with the exact CI flags:

| | size | vs 29.63 MB baseline |
|---|---|---|
| before | 31.80 MB | +7.31% — **gate fails** |
| after | **28.62 MB** | −3.4% — passes |

A 3.18 MB cut, and it puts the artifact back under budget without moving the baseline. That also answers the open question in #1364: the accumulated 2.2 MB was this, not something any recent PR introduced. The `full` and `coins` legs pass the same single-ABI flags and gain the same reduction.

Verified after the change: `lib/` contains **only** `arm64-v8a`, and the existing lean-variant exclusions (mpv/media_kit, LiteRT-JNI) still hold — zero matches for `libmpv`, `libLiteRt`, `liblitertlm`. `scripts/check-build-profiles.py` passes.

Found while investigating why the TV gate blocked #1362 and #1365, neither of which changed TV size.

🤖 Generated with [Claude Code](https://claude.com/claude-code)