### PR TITLE
fix(ci): break the APK size baseline refresh deadlock

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -561,6 +561,13 @@ jobs:
           APK_SIZE_COMPONENT: ${{ matrix.platform.name }}
           APK_SIZE_APK_GLOB: app/build/app/outputs/flutter-apk/app-*-release.apk
           APK_SIZE_REPORT_FILE: apk-size-${{ matrix.platform.name }}.md
+          # Growth past the recorded baseline blocks a pull request, where a
+          # human can attribute it. On main it is reported instead: a failing
+          # run there skips "Generate APK baseline update" below and the
+          # update-apk-size-baselines job that consumes it, so enforcing the
+          # delta on main deadlocks the gate against a baseline it can never
+          # refresh. The absolute per-component budget stays enforced on both.
+          APK_SIZE_BASELINE_DELTA_ENFORCED: ${{ github.event_name == 'pull_request' }}
         run: |
           scripts/check-apk-size.sh
 

--- a/scripts/check-apk-size.sh
+++ b/scripts/check-apk-size.sh
@@ -9,6 +9,13 @@ COMPONENT="${APK_SIZE_COMPONENT:-default}"
 MAX_MB="${APK_SIZE_MAX_MB:-35}"
 MAX_BYTES="${APK_SIZE_MAX_BYTES:-}"
 MAX_INCREASE_PERCENT="${APK_SIZE_MAX_INCREASE_PERCENT:-5}"
+# Whether growth past the recorded baseline fails the run, as opposed to being
+# reported. The absolute budget is always enforced; only this delta is
+# switchable. CI enforces it on pull requests, where a human can react, and
+# reports it on main pushes -- a failing run on main skips the baseline refresh
+# that follows it, so enforcing there deadlocks the gate against a baseline it
+# can never update.
+BASELINE_DELTA_ENFORCED="${APK_SIZE_BASELINE_DELTA_ENFORCED:-true}"
 REPORT_FILE="${APK_SIZE_REPORT_FILE:-apk-size-report.md}"
 TOP_ENTRIES="${APK_SIZE_TOP_ENTRIES:-20}"
 
@@ -190,13 +197,22 @@ for apk in "${apk_files[@]}"; do
   fi
 
   if over_threshold "$size_bytes" "$threshold_bytes"; then
-    if [ "$status" = "OK" ]; then
-      status="FAIL: exceeds ${MAX_INCREASE_PERCENT}% baseline increase"
+    if [ "$BASELINE_DELTA_ENFORCED" = "true" ]; then
+      if [ "$status" = "OK" ]; then
+        status="FAIL: exceeds ${MAX_INCREASE_PERCENT}% baseline increase"
+      else
+        status="$status; exceeds ${MAX_INCREASE_PERCENT}% baseline increase"
+      fi
+      echo "::error file=$apk::$artifact is ${delta}% over baseline, exceeds ${MAX_INCREASE_PERCENT}% baseline increase"
+      failed=1
     else
-      status="$status; exceeds ${MAX_INCREASE_PERCENT}% baseline increase"
+      if [ "$status" = "OK" ]; then
+        status="WARN: exceeds ${MAX_INCREASE_PERCENT}% baseline increase"
+      else
+        status="$status; exceeds ${MAX_INCREASE_PERCENT}% baseline increase"
+      fi
+      echo "::warning file=$apk::$artifact is ${delta}% over baseline, exceeds ${MAX_INCREASE_PERCENT}% baseline increase (reported, not enforced)"
     fi
-    echo "::error file=$apk::$artifact is ${delta}% over baseline, exceeds ${MAX_INCREASE_PERCENT}% baseline increase"
-    failed=1
   fi
 
   echo "| $COMPONENT | $artifact | $(format_bytes "$size_bytes") | $(format_bytes "$budget_bytes") | $(format_bytes "$baseline_bytes") | ${delta}% | $status |" >>"$REPORT_FILE"

--- a/scripts/test-check-apk-size.sh
+++ b/scripts/test-check-apk-size.sh
@@ -90,6 +90,34 @@ run_case "fails-over-baseline-growth" 1 \
     "$SCRIPT"
 grep -q "exceeds 5% baseline increase" "$TMP_DIR/fails-over-baseline-growth.out"
 
+# Baseline growth is reportable rather than fatal when enforcement is off. CI
+# uses this on main pushes: a failing run there skips the baseline refresh that
+# follows it, so enforcing the delta would deadlock the gate against a baseline
+# it can never update.
+run_case "reports-baseline-growth-when-not-enforced" 0 \
+  env APK_SIZE_APK_GLOB="$growth_apk" \
+    APK_SIZE_COMPONENT=demo \
+    APK_SIZE_BASELINE_FILE="$baseline_file" \
+    APK_SIZE_REPORT_FILE="$TMP_DIR/growth-reported-report.md" \
+    APK_SIZE_MAX_BYTES=2000 \
+    APK_SIZE_MAX_INCREASE_PERCENT=5 \
+    APK_SIZE_BASELINE_DELTA_ENFORCED=false \
+    "$SCRIPT"
+grep -q "reported, not enforced" "$TMP_DIR/reports-baseline-growth-when-not-enforced.out"
+grep -q "WARN: exceeds 5% baseline increase" "$TMP_DIR/growth-reported-report.md"
+
+# The absolute budget stays fatal even with delta enforcement off.
+run_case "still-fails-absolute-cap-when-delta-not-enforced" 1 \
+  env APK_SIZE_APK_GLOB="$over_cap_apk" \
+    APK_SIZE_COMPONENT=demo \
+    APK_SIZE_BASELINE_FILE="$baseline_file" \
+    APK_SIZE_REPORT_FILE="$TMP_DIR/over-cap-unenforced-report.md" \
+    APK_SIZE_MAX_BYTES=1100 \
+    APK_SIZE_MAX_INCREASE_PERCENT=5 \
+    APK_SIZE_BASELINE_DELTA_ENFORCED=false \
+    "$SCRIPT"
+grep -q "exceeds max APK size" "$TMP_DIR/still-fails-absolute-cap-when-delta-not-enforced.out"
+
 run_case "fails-missing-baseline" 1 \
   env APK_SIZE_APK_GLOB="$missing_apk" \
     APK_SIZE_COMPONENT=demo \


### PR DESCRIPTION
Closes point 3 of #1364 — the part that survives #1366.

## The stuck state

On a main push, `Check APK sizes` fails the `build-android` job when an artifact is more than 5% over its recorded baseline. Two steps later in the same job, `Generate APK baseline update` produces the artifact that `update-apk-size-baselines` commits — but a failed step skips the steps after it, and that job `needs: [build-android]`, so neither runs. The baseline the run failed against is never refreshed, and every subsequent PR fails on growth it did not introduce.

That is exactly what happened to #1362 and #1365: both measured 31.80 MB against a 29.63 MB baseline last touched in `18200609`, and neither changed TV size. The 2.2 MB was non-target-ABI plugin libs (fixed in #1366) — but the deadlock itself is still live and will reproduce on the next genuine growth.

## Change

`APK_SIZE_BASELINE_DELTA_ENFORCED` decides whether baseline growth fails the run or is reported:

| | pull request | main push |
|---|---|---|
| absolute per-component budget | **fails** | **fails** |
| growth past recorded baseline | **fails** | reported (`WARN`, `::warning`) |

A PR still cannot add >5% without a human attributing it. Main records what it measured so the refresh can commit it. The absolute budget is deliberately left enforcing on main — a real budget breach should not be silently absorbed into the baseline, and skipping the refresh in that case is the correct outcome.

Default is `true`, so anyone running `scripts/check-apk-size.sh` locally still gets enforcement.

## Verification

`scripts/test-check-apk-size.sh` passes, with two cases added:

- `reports-baseline-growth-when-not-enforced` — the same over-baseline artifact that fails today exits 0 with enforcement off, logs "reported, not enforced", and the report row reads `WARN: exceeds 5% baseline increase`.
- `still-fails-absolute-cap-when-delta-not-enforced` — the absolute cap still exits 1 in that mode, so turning the delta off cannot mask a budget breach.

The PR-path report format is unchanged, so `comment-apk-size-report` keeps working; only main-push rows can now say `WARN`.

Ownership: this is release/devops surface. It changes *when* a guardrail blocks, not what it measures — flagging that explicitly for review rather than treating it as a routine fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)