### PR TITLE
fix(feature_iptv): finish opting channel consumers out of retry

### DIFF
--- a/app/lib/features/media_hub/application/providers/discovery_provider.dart
+++ b/app/lib/features/media_hub/application/providers/discovery_provider.dart
@@ -24,7 +24,7 @@ final mediaHubDiscoverySourceProvider =
           final channels = await ref.watch(iptvChannelsProvider.future);
           return channels.map(UnifiedMediaContent.fromChannel).toList();
       }
-    });
+    }, retry: surfaceChannelFailureInsteadOfRetrying);
 
 final mediaHubDiscoveryProvider =
     AsyncNotifierProvider.family<DiscoveryNotifier, DiscoveryState, MediaMode>(

--- a/packages/feature_iptv/lib/application/providers/iptv_providers.dart
+++ b/packages/feature_iptv/lib/application/providers/iptv_providers.dart
@@ -917,7 +917,7 @@ final favoriteChannelsProvider = FutureProvider<List<IPTVChannel>>((ref) async {
   return allChannels
       .where((channel) => favoriteIds.contains(channel.id))
       .toList(growable: false);
-});
+}, retry: surfaceChannelFailureInsteadOfRetrying);
 
 /// Toggles a channel's favorite state and returns the new state.
 ///

--- a/packages/feature_iptv/lib/application/providers/last_channel_provider.dart
+++ b/packages/feature_iptv/lib/application/providers/last_channel_provider.dart
@@ -63,4 +63,4 @@ final resumeChannelProvider = FutureProvider<IPTVChannel?>((ref) async {
 
   final channels = await ref.watch(iptvChannelsProvider.future);
   return findResumeChannel(lastChannelId: lastChannelId, channels: channels);
-});
+}, retry: surfaceChannelFailureInsteadOfRetrying);

--- a/packages/feature_iptv/lib/application/providers/local_iptv_search_providers.dart
+++ b/packages/feature_iptv/lib/application/providers/local_iptv_search_providers.dart
@@ -37,7 +37,7 @@ final localIptvSearchIndexProvider = FutureProvider<LocalIptvSearchIndex>((
     recentChannelIds: [for (final channel in recentChannels) channel.id],
     hiddenGroupIds: hiddenGroupIds,
   );
-});
+}, retry: surfaceChannelFailureInsteadOfRetrying);
 
 /// The search screen's query text. Independent of [channelSearchQueryProvider]
 /// (the Live TV grid's quick-filter) -- opening search must not perturb the

--- a/packages/feature_iptv/test/iptv/application/providers/configured_m3u_failure_test.dart
+++ b/packages/feature_iptv/test/iptv/application/providers/configured_m3u_failure_test.dart
@@ -300,6 +300,64 @@ void main() {
     },
   );
 
+  testWidgets(
+    'a consumer of the favorites list does not re-drive the dead source '
+    'either',
+    (tester) async {
+      var fetchAttempts = 0;
+      final container = ProviderContainer(
+        overrides: [
+          sharedPreferencesProvider.overrideWithValue(prefs),
+          favoriteChannelIdsProvider.overrideWith((ref) async => const {'x'}),
+          m3uSourceParserFactoryProvider.overrideWithValue(
+            (sourceId) => _CountingSourceParser(
+              prefs: prefs,
+              sourceId: sourceId,
+              onFetch: () => fetchAttempts++,
+            ),
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+      await container.read(contentSourceStoreProvider).replaceAll([
+        source('m3u-dead'),
+      ]);
+      container.invalidate(configuredContentSourcesProvider);
+
+      // The Favorites tab watches this and nothing else channel-shaped.
+      await tester.pumpWidget(
+        UncontrolledProviderScope(
+          container: container,
+          child: MaterialApp(
+            home: Consumer(
+              builder: (context, ref, _) {
+                final favorites = ref.watch(favoriteChannelsProvider);
+                return Text(
+                  favorites.hasError ? 'error' : 'pending',
+                  textDirection: TextDirection.ltr,
+                );
+              },
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+      expect(find.text('error'), findsOneWidget);
+
+      for (var i = 0; i < 10; i++) {
+        await tester.pump(const Duration(seconds: 1));
+      }
+
+      expect(
+        fetchAttempts,
+        1,
+        reason:
+            'favorites inherits the channel failure; retrying it re-contacts '
+            'the dead source just like the rails did',
+      );
+    },
+  );
+
   test('the failure message names no source URL', () {
     expect(
       const PlaylistSourcesUnavailableException(3).toString(),


### PR DESCRIPTION
Completes #1365 and closes the reporting half of #1363.

## What #1365 missed

#1365 stopped `railsProvider`, `regionalDiscoveryRailsProvider`, and `rawVodItemsProvider` from retrying a propagated channel failure. Enumerating every provider that awaits `iptvChannelsProvider.future` turned up four more that still did:

| provider | surface |
|---|---|
| `favoriteChannelsProvider` | **Favorites tab** — a user with favorites and one unreachable source retried indefinitely |
| `localIptvSearchIndexProvider` | channel/EPG search index |
| `resumeChannelProvider` | resume-last-channel on launch |
| `mediaHubDiscoverySourceProvider` (app side) | media hub, TV mode |

Each inherits the channel error, and each retry re-drives the failed ancestor, which re-contacts the dead source — the same mechanism proven in #1365, just reached through different consumers. Favorites is the one that matters most: it is a primary tab, and its retry path is live the moment a user with saved favorites has a source go down.

## How it was found

Checking #1363 ("Guide and Favorites say nothing-here instead of sources-are-down"). That reporting gap is **already closed by #1362**: `iptv_guide_screen` has an `error:` branch that renders "Could not load the guide: …", and `mobile_favorites_screen` renders "Could not load favorites: …". `favoriteChannelsProvider` awaits the channel future, so the failure reaches it — which is exactly what exposed the retry.

## Verification

New test drives `favoriteChannelsProvider` with a stored favorite id and a dead source. Before this change it fails with a pending **6.4s** retry timer — the same "A Timer is still pending" signal that caught the original storm. After, the source is contacted once.

- `packages/feature_iptv`: 818 pass, 2 fail — both the pre-existing #1367 pair, unchanged by this branch.
- `app/test/features`: 728 pass.
- `flutter analyze` clean on both touched trees.

## Deliberately untouched

- `channelBrowseMetadataProvider` catches its own failures and returns no metadata, so it never reaches an error state to retry.
- The guide window is a `Notifier` whose `build` does not await the channel future.

Both verified rather than assumed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)