### PR TITLE
feat(feature_iptv): give the guide and favorites a Retry on load failure

### DIFF
--- a/packages/feature_iptv/lib/presentation/screens/mobile_favorites_screen.dart
+++ b/packages/feature_iptv/lib/presentation/screens/mobile_favorites_screen.dart
@@ -5,6 +5,7 @@ import '../../application/providers/iptv_providers.dart';
 import '../widgets/favorite_reimport_review_banner.dart';
 import '../widgets/favorites_backup_menu.dart';
 import '../widgets/iptv_icon_placeholder.dart';
+import '../widgets/channel_load_error_view.dart';
 
 /// Mobile screen listing the user's favorited channels — the mobile
 /// counterpart to [TvFavoritesScreen], with a tap-to-unfavorite trailing
@@ -36,8 +37,15 @@ class MobileFavoritesScreen extends ConsumerWidget {
           Expanded(
             child: favoritesAsync.when(
               loading: () => const Center(child: CircularProgressIndicator()),
-              error: (error, _) =>
-                  Center(child: Text('Could not load favorites: $error')),
+              error: (error, _) => ChannelLoadErrorView(
+                message: 'Could not load favorites: $error',
+                onRetry: () {
+                  // Favorites can fail on its own stored list as well as on
+                  // the channels it resolves against, so invalidate both.
+                  invalidateChannelLibraries(ref);
+                  ref.invalidate(favoriteChannelsProvider);
+                },
+              ),
               data: (channels) {
                 if (channels.isEmpty) {
                   return Center(

--- a/packages/feature_iptv/lib/presentation/tv/iptv_guide_screen.dart
+++ b/packages/feature_iptv/lib/presentation/tv/iptv_guide_screen.dart
@@ -13,6 +13,7 @@ import '../../application/providers/iptv_providers.dart';
 import '../widgets/epg_touch_timeline_grid.dart';
 import '../widgets/epg_timeline_grid.dart';
 import '../widgets/richer_context_prototype.dart';
+import '../widgets/channel_load_error_view.dart';
 
 /// TV Guide: a virtualized horizontal-timeline EPG grid (CV-015 slice 2),
 /// sourced from [guidePagedWindowProvider]. Selecting a channel plays it and
@@ -52,11 +53,9 @@ class _IptvGuideScreenState extends ConsumerState<IptvGuideScreen> {
       body: SafeArea(
         child: channelsAsync.when(
           loading: () => const Center(child: CircularProgressIndicator()),
-          error: (error, _) => Center(
-            child: Text(
-              'Could not load the guide: $error',
-              textAlign: TextAlign.center,
-            ),
+          error: (error, _) => ChannelLoadErrorView(
+            message: 'Could not load the guide: $error',
+            onRetry: () => invalidateChannelLibraries(ref),
           ),
           data: (channels) {
             if (channels.isEmpty) {

--- a/packages/feature_iptv/lib/presentation/tv/tv_favorites_screen.dart
+++ b/packages/feature_iptv/lib/presentation/tv/tv_favorites_screen.dart
@@ -9,6 +9,7 @@ import '../../application/providers/iptv_providers.dart';
 import '../widgets/favorite_reimport_review_banner.dart';
 import '../widgets/favorites_backup_menu.dart';
 import '../widgets/iptv_icon_placeholder.dart';
+import '../widgets/channel_load_error_view.dart';
 
 /// Lists channels the user has favorited on TV, with a way to unfavorite
 /// and jump straight into playback. See CV-021 / issue #826.
@@ -53,8 +54,15 @@ class TvFavoritesScreen extends ConsumerWidget {
           Expanded(
             child: favoritesAsync.when(
               loading: () => const Center(child: CircularProgressIndicator()),
-              error: (error, _) =>
-                  Center(child: Text('Could not load favorites: $error')),
+              error: (error, _) => ChannelLoadErrorView(
+                message: 'Could not load favorites: $error',
+                onRetry: () {
+                  // Favorites can fail on its own stored list as well as on
+                  // the channels it resolves against, so invalidate both.
+                  invalidateChannelLibraries(ref);
+                  ref.invalidate(favoriteChannelsProvider);
+                },
+              ),
               data: (channels) {
                 if (channels.isEmpty) {
                   return Center(

--- a/packages/feature_iptv/lib/presentation/widgets/channel_load_error_view.dart
+++ b/packages/feature_iptv/lib/presentation/widgets/channel_load_error_view.dart
@@ -1,0 +1,54 @@
+import 'package:flutter/material.dart';
+
+/// Error state for a surface whose content comes from the channel libraries.
+///
+/// The channel screen has offered a Retry since the load failure started
+/// surfacing; the guide and favorites surfaces only printed the message, so a
+/// user whose playlist source was down had to leave the tab and come back.
+/// [onRetry] is supplied per surface because what needs invalidating differs:
+/// the guide only needs the channel libraries, favorites also needs its own
+/// list, whose error can come from storage rather than the channels.
+class ChannelLoadErrorView extends StatelessWidget {
+  const ChannelLoadErrorView({
+    super.key,
+    required this.message,
+    required this.onRetry,
+  });
+
+  /// User-facing reason. Callers pass the provider's message, which never
+  /// contains a source URL.
+  final String message;
+
+  final VoidCallback onRetry;
+
+  @override
+  Widget build(BuildContext context) {
+    final scheme = Theme.of(context).colorScheme;
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(24),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(Icons.cloud_off_outlined, size: 56, color: scheme.error),
+            const SizedBox(height: 16),
+            Text(
+              message,
+              textAlign: TextAlign.center,
+              style: Theme.of(context).textTheme.bodyMedium,
+            ),
+            const SizedBox(height: 20),
+            ElevatedButton.icon(
+              key: const ValueKey('channel-load-error-retry'),
+              // Land D-pad focus here: on TV this is the only action on screen.
+              autofocus: true,
+              onPressed: onRetry,
+              icon: const Icon(Icons.refresh),
+              label: const Text('Retry'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/packages/feature_iptv/test/presentation/widgets/channel_load_error_retry_test.dart
+++ b/packages/feature_iptv/test/presentation/widgets/channel_load_error_retry_test.dart
@@ -1,0 +1,151 @@
+import 'package:core_data/core_data.dart';
+import 'package:dio/dio.dart';
+import 'package:feature_iptv/feature_iptv.dart';
+import 'package:feature_iptv/presentation/screens/mobile_favorites_screen.dart';
+import 'package:feature_iptv/presentation/tv/iptv_guide_screen.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:platform_playlist/platform_playlist.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// Found on the rig Pixel 9: with every playlist source unreachable the guide
+/// and favorites surfaces printed the failure but offered no way to act on it,
+/// so a user had to leave the tab and come back. The channel screen has had a
+/// Retry since the failure started surfacing; these two now match it, and the
+/// Retry has to reach the source loaders rather than replay a cached error.
+void main() {
+  late SharedPreferences prefs;
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    prefs = await SharedPreferences.getInstance();
+  });
+
+  ProviderContainer containerWithDeadSource({
+    required void Function() onFetch,
+    Set<String> favoriteIds = const {},
+  }) {
+    return ProviderContainer(
+      overrides: [
+        sharedPreferencesProvider.overrideWithValue(prefs),
+        favoriteChannelIdsProvider.overrideWith((ref) async => favoriteIds),
+        m3uSourceParserFactoryProvider.overrideWithValue(
+          (sourceId) => _DeadSourceParser(
+            prefs: prefs,
+            sourceId: sourceId,
+            onFetch: onFetch,
+          ),
+        ),
+      ],
+    );
+  }
+
+  Future<void> seedDeadSource(ProviderContainer container) async {
+    await container.read(contentSourceStoreProvider).replaceAll([
+      const ContentSourceConfig(
+        id: 'm3u-dead',
+        kind: ContentSourceKind.m3u,
+        label: 'Dead',
+        url: 'https://example.com/dead.m3u',
+      ),
+    ]);
+    container.invalidate(configuredContentSourcesProvider);
+  }
+
+  testWidgets('the guide offers a Retry that re-runs the source loaders', (
+    tester,
+  ) async {
+    var fetchAttempts = 0;
+    final container = containerWithDeadSource(onFetch: () => fetchAttempts++);
+    addTearDown(container.dispose);
+    await seedDeadSource(container);
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: const MaterialApp(
+          home: IptvGuideScreen(onChannelSelected: _noop),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.textContaining('Could not load the guide'), findsOneWidget);
+    expect(
+      find.byKey(const ValueKey('channel-load-error-retry')),
+      findsOneWidget,
+    );
+    expect(fetchAttempts, 1);
+
+    await tester.tap(find.byKey(const ValueKey('channel-load-error-retry')));
+    await tester.pumpAndSettle();
+
+    expect(
+      fetchAttempts,
+      2,
+      reason: 'Retry must contact the source again, not replay its error',
+    );
+  });
+
+  testWidgets('favorites offers a Retry that re-runs the source loaders', (
+    tester,
+  ) async {
+    var fetchAttempts = 0;
+    final container = containerWithDeadSource(
+      onFetch: () => fetchAttempts++,
+      // A user with no favorites never reaches the channel list, so the error
+      // state needs a stored favorite to be reachable at all.
+      favoriteIds: const {'kept'},
+    );
+    addTearDown(container.dispose);
+    await seedDeadSource(container);
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: const MaterialApp(
+          home: MobileFavoritesScreen(onChannelSelected: _noop),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.textContaining('Could not load favorites'), findsOneWidget);
+    expect(fetchAttempts, 1);
+
+    await tester.tap(find.byKey(const ValueKey('channel-load-error-retry')));
+    await tester.pumpAndSettle();
+
+    expect(fetchAttempts, 2);
+  });
+}
+
+void _noop() {}
+
+class _DeadSourceParser extends M3UParserService {
+  _DeadSourceParser({
+    required super.prefs,
+    required String sourceId,
+    required this.onFetch,
+  }) : super(dio: Dio(), sourceId: sourceId);
+
+  final void Function() onFetch;
+  String? _url;
+
+  @override
+  String? getPlaylistUrl() => _url;
+
+  @override
+  Future<void> setPlaylistUrl(String url) async {
+    _url = url;
+  }
+
+  @override
+  Future<PlaylistFetchOutcome> fetchPlaylistOutcome({
+    bool forceRefresh = false,
+  }) async {
+    onFetch();
+    return const PlaylistFetchOutcome.unavailable();
+  }
+}


### PR DESCRIPTION
Closes the remaining half of #1363.

## What was left

The "shows nothing-here instead of an error" symptom in #1363 is already gone — #1362 made the channel failure reach `AsyncError`, so the `error:` branches in `iptv_guide_screen`, `mobile_favorites_screen`, and `tv_favorites_screen` now fire. But those branches print the reason and stop, so a user whose playlist source is down has to leave the tab and come back. The channel screen has had a Retry since #1362.

## Change

One shared `ChannelLoadErrorView` (icon, message, Retry) used by all three surfaces, so they cannot drift apart again. `onRetry` is passed per surface because the right invalidation differs:

- **guide** — the channel libraries.
- **favorites** — the channel libraries *and* `favoriteChannelsProvider`, since its error can come from the stored ids rather than from the channels it resolves against.

The retry goes through `invalidateChannelLibraries` rather than refreshing the merged provider. Refreshing only the merged provider replays its dependency's cached error without contacting the source — the exact trap fixed for the channel screen in #1365, and the reason the button would otherwise look like it did nothing.

The button autofocuses: on TV it is the only action on screen, so that is where D-pad focus should land.

## Verification

New `channel_load_error_retry_test.dart` drives both surfaces with a dead source and asserts the substance, not just the pixels: the source is contacted **once** for the initial failure and **twice** after the tap. A Retry wired to the merged provider alone would leave the count at one.

- `packages/feature_iptv`: 819 pass, 2 fail — the pre-existing #1367 pair, unchanged.
- `flutter analyze` clean on `lib/presentation`.

`tv_favorites_screen` uses the identical call as the mobile one and is covered by the shared widget rather than a third near-duplicate test.

Behaviour that deliberately did not change: a user with no favorites still sees "No favorite channels yet" — `favoriteChannelsProvider` short-circuits before touching the channel list, so that is not a failure state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)