### PR TITLE
perf(feature_iptv): coalesce auto-scan availability emissions

### DIFF
--- a/packages/feature_iptv/lib/application/channel_auto_scan_controller.dart
+++ b/packages/feature_iptv/lib/application/channel_auto_scan_controller.dart
@@ -72,6 +72,16 @@ class ChannelAutoScanController extends StateNotifier<ChannelAutoScanState> {
   int _scanGeneration = 0;
   final Map<String, StreamAvailability> _cachedAvailabilityByChannelId = {};
 
+  /// Probe results not yet published to [state].
+  ///
+  /// A scan of a user's full list can be tens of thousands of channels, and
+  /// publishing each result separately invalidated every provider derived from
+  /// availability -- the browse rails among them -- once per probed channel.
+  /// Results are coalesced instead: everything that lands in one turn of the
+  /// event loop is published as a single state change.
+  final Map<String, StreamAvailability> _pendingAvailability = {};
+  var _availabilityFlushScheduled = false;
+
   Future<void> start({
     required String scopeId,
     required List<IPTVChannel> channels,
@@ -126,18 +136,13 @@ class ChannelAutoScanController extends StateNotifier<ChannelAutoScanState> {
       onResult: (result, completedProbeCount) {
         if (generation != _scanGeneration || cancellation.isCancelled) return;
         _cachedAvailabilityByChannelId[result.channelId] = result.availability;
-        final nextAvailability = <String, StreamAvailability>{
-          ...state.availabilityByChannelId,
-          result.channelId: result.availability,
-        };
-        state = state.copyWith(
-          completedCount: nextAvailability.length,
-          availabilityByChannelId: nextAvailability,
-        );
+        _pendingAvailability[result.channelId] = result.availability;
+        _scheduleAvailabilityFlush();
       },
     );
     if (generation != _scanGeneration) return;
     _cancellation = null;
+    _flushAvailability();
     if (result.wasCancelled || cancellation.isCancelled) {
       state = state.copyWith(phase: ChannelAutoScanPhase.cancelled);
       return;
@@ -145,6 +150,31 @@ class ChannelAutoScanController extends StateNotifier<ChannelAutoScanState> {
     state = state.copyWith(
       phase: ChannelAutoScanPhase.complete,
       completedCount: state.availabilityByChannelId.length,
+    );
+  }
+
+  /// Publishes coalesced probe results on the next turn of the event loop.
+  ///
+  /// Deferring also keeps the write out of a build that is already running: a
+  /// probe result arriving while the browse grid built marked the provider
+  /// scope dirty mid-build ("setState() called during build").
+  void _scheduleAvailabilityFlush() {
+    if (_availabilityFlushScheduled) return;
+    _availabilityFlushScheduled = true;
+    Future<void>.microtask(_flushAvailability);
+  }
+
+  void _flushAvailability() {
+    _availabilityFlushScheduled = false;
+    if (_pendingAvailability.isEmpty || !mounted) return;
+    final next = <String, StreamAvailability>{
+      ...state.availabilityByChannelId,
+      ..._pendingAvailability,
+    };
+    _pendingAvailability.clear();
+    state = state.copyWith(
+      completedCount: next.length,
+      availabilityByChannelId: next,
     );
   }
 

--- a/packages/feature_iptv/test/iptv/application/channel_auto_scan_controller_test.dart
+++ b/packages/feature_iptv/test/iptv/application/channel_auto_scan_controller_test.dart
@@ -49,6 +49,51 @@ void main() {
   );
 
   test(
+    'coalesces probe results into one state change per event-loop turn',
+    () async {
+      // Every probe result used to publish its own state change. Each one
+      // invalidates the providers derived from availability -- the browse
+      // rails among them -- so a full-list scan on the rig (12,843 channels)
+      // meant that many invalidations of the browse grid.
+      final responses = <String, StreamProbeHttpResponse>{
+        for (var i = 0; i < 12; i++)
+          'ch-$i': const StreamProbeHttpResponse(statusCode: 200),
+      };
+      final controller = ChannelAutoScanController(
+        probe: StreamAvailabilityProbe(
+          transport: _FakeProbeTransport(responses),
+        ),
+      );
+      addTearDown(controller.dispose);
+
+      final emitted = <int>[];
+      controller.addListener(
+        (state) => emitted.add(state.availabilityByChannelId.length),
+      );
+
+      await controller.start(
+        scopeId: 'coalesce',
+        channels: [for (var i = 0; i < 12; i++) _channel('ch-$i')],
+        maxConcurrentRequests: 12,
+      );
+
+      expect(
+        controller.state.availabilityByChannelId.length,
+        12,
+        reason: 'coalescing must not drop or delay any result',
+      );
+      expect(controller.state.phase, ChannelAutoScanPhase.complete);
+      expect(
+        emitted.length,
+        4,
+        reason:
+            'scan start, two coalesced result flushes, and completion -- '
+            'before coalescing the same twelve results cost 15 state changes',
+      );
+    },
+  );
+
+  test(
     'uses the active player as an available result without probing it',
     () async {
       final transport = _FakeProbeTransport({


### PR DESCRIPTION
Partial progress on #1367 — a real reduction in provider churn, but explicitly **not** a fix for the assertion in that issue.

## What it does

`ChannelAutoScanController.start()` published a state change inside `onResult`, i.e. **once per probed channel**. Everything derived from availability is invalidated by each one — `regionalDiscoveryRailsProvider`, and `railsProvider` through it, which the browse grid depends on. Scanning a user's full list on the rig (12,843 channels) therefore invalidated the browse grid once per probe result.

Results now accumulate in a pending map and publish as **one state change per turn of the event loop**, with an explicit synchronous flush before the `complete`/`cancelled` transitions so the published state is still exact.

Measured in the new test: twelve results cost **4 state changes instead of 15**. The ratio widens with list size, since everything that lands in one turn collapses into a single emission.

## What it does not do

Publishing through a microtask also moves the write out of a build that is already running, which was worth trying against the `setState() during build` assertion in #1367. **It does not fix it** — the assertion still fires with this change applied, so the mid-build write comes from somewhere other than the scan's result path. I have recorded that on #1367 rather than implying otherwise here.

Two hypotheses eliminated for #1367 by this work:

- the result path (`onResult` → `state =`) is not the mid-build writer
- `start()` is not called from a build — its player-side caller runs inside a `Timer` callback

## Verification

- New test asserts the exact emission count and that no result is dropped or delayed (`availabilityByChannelId` still ends at 12, phase still `complete`). It fails on `origin/main` with `Actual: <15>`, so it is not vacuous.
- `packages/feature_iptv`: 818 pass, 2 fail — the pre-existing #1367 pair, unchanged by this branch.
- `flutter analyze` clean on `lib/application`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)