### PR TITLE
fix(feature_iptv): stop the browse grid depending on the rails

### DIFF
--- a/packages/feature_iptv/lib/presentation/screens/iptv_screen.dart
+++ b/packages/feature_iptv/lib/presentation/screens/iptv_screen.dart
@@ -1188,7 +1188,6 @@ class _StreamTabContent extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final channelsAsync = ref.watch(iptvChannelsProvider);
     final streamingState = ref.watch(streamingStateProvider);
-    ref.watch(railsProvider);
 
     return channelsAsync.when(
       data: (channels) => _buildContent(context, ref, channels, streamingState),

--- a/packages/feature_iptv/test/presentation/screens/iptv_screen_rails_independence_test.dart
+++ b/packages/feature_iptv/test/presentation/screens/iptv_screen_rails_independence_test.dart
@@ -1,0 +1,88 @@
+import 'package:feature_iptv/feature_iptv.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// The browse grid must not depend on [railsProvider].
+///
+/// It used to `ref.watch(railsProvider)` and discard the value, purely to keep
+/// the rails warm. Rails are invalidated by every auto-scan availability
+/// update, so that read both rebuilt the grid once per probed channel and --
+/// because a read forces a dirty provider to flush -- recomputed rails *inside*
+/// the grid's build, which tripped "setState() called during build" (issue
+/// #1367). The real rails consumers are `browse_screen` and `iptv_tv_screen`.
+///
+/// Overriding rails with a provider that throws is the cheapest way to assert
+/// the independence: if anything in this screen's build reads it, the build
+/// fails.
+final _channels = [
+  const IPTVChannel(
+    id: 'c1',
+    name: 'Channel One',
+    streamUrl: 'https://example.com/c1.m3u8',
+    group: 'News',
+    category: ChannelCategory.news,
+  ),
+];
+
+class _SilentStreamingService extends VideoPlayerStreamingService {
+  _SilentStreamingService() : super(engine: FakeAiroPlaybackEngine());
+
+  @override
+  Future<void> playChannel(IPTVChannel channel) async {}
+}
+
+void main() {
+  testWidgets('the browse grid renders without ever reading railsProvider', (
+    tester,
+  ) async {
+    // Watching an errored provider returns an AsyncValue rather than throwing,
+    // so a thrown override proves nothing. Record whether the provider is
+    // built at all instead: it is only built if something reads it.
+    var railsWereRead = false;
+    tester.view.physicalSize = const Size(1080, 2400);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          iptvChannelsProvider.overrideWith((ref) async => _channels),
+          recentlyWatchedChannelsProvider.overrideWith((ref) async => const []),
+          railsProvider.overrideWith((ref) async {
+            railsWereRead = true;
+            return const <RailResult>[];
+          }),
+          iptvStreamingServiceProvider.overrideWith((ref) {
+            final service = _SilentStreamingService();
+            ref.onDispose(service.dispose);
+            return service;
+          }),
+        ],
+        child: const MaterialApp(home: IPTVScreen()),
+      ),
+    );
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 400));
+
+    expect(
+      find.text('Channel One'),
+      findsOneWidget,
+      reason:
+          'channels come from iptvChannelsProvider; a rails failure must '
+          'not reach this screen at all',
+    );
+    expect(
+      railsWereRead,
+      isFalse,
+      reason:
+          'rails are invalidated by every auto-scan availability update; a '
+          'read here rebuilds the grid per probe and flushes rails inside the '
+          'grid build (issue #1367)',
+    );
+    expect(tester.takeException(), isNull);
+
+    await tester.pumpWidget(const SizedBox.shrink());
+  });
+}


### PR DESCRIPTION
Fixes #1367. `packages/feature_iptv` goes from **818 pass / 2 fail** to **818 pass / 0 fail** — the two tests that have been red on main all session.

## The one-line cause

`_StreamTabContent` did:

```dart
ref.watch(railsProvider);   // value discarded
```

The read existed only to keep the rails warm. Rails are invalidated by every auto-scan availability update, so it did two harmful things:

1. Rebuilt the whole browse grid **once per probed channel** — on the rig's 12,843-channel list, once per probe result.
2. Because reading a dirty provider forces it to flush, it recomputed rails **inside the grid's build**. The flush re-watched a dirty ancestor, which scheduled a refresh on `UncontrolledProviderScope` mid-build → `setState() called during build`.

That is why every earlier attempt missed. The *write* was always off-build — instrumenting it showed both writers at stack depth 2 inside Timer callbacks. The **flush** was the problem, and only a reader can cause one.

## Why removing it is right

`railsProvider`'s real consumers are `browse_screen` and `iptv_tv_screen`, which watch it and use the value. Nothing on the channel screen does. The cost is losing pre-warming while a user sits on the channel screen — a poor trade regardless, since keeping rails warm there is precisely what made the grid rebuild per probe.

## About the regression test

First version was **vacuous** and I caught it before landing: overriding `railsProvider` to throw passes with *or* without the fix, because watching an errored provider returns an `AsyncValue` rather than throwing. The committed test records whether the provider is *built at all* — it is built only if something reads it. Verified both directions:

- with the fix: passes
- with the read restored: `Expected: false  Actual: <true>`

## Verification

- `packages/feature_iptv`: 818 pass, 0 fail (was 2 fail).
- `test/presentation/screens/`: 16 pass.
- The 5168-object leak report in #1367 disappears with the assertion — it was a consequence of the aborted test, exactly as diagnosed on that issue.

Related: #1371 coalesces the auto-scan emissions that made rails churn in the first place. That reduces the invalidation rate; this removes the grid from the invalidation path entirely. They are independent and complementary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)