### PR TITLE
test(agent_chat): answer the Gemini Nano channel so bounded calls settle

### DIFF
--- a/app/test/features/agent_chat/presentation/screens/chat_screen_metadata_test.dart
+++ b/app/test/features/agent_chat/presentation/screens/chat_screen_metadata_test.dart
@@ -8,6 +8,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import '../../../../support/gemini_nano_channel.dart';
 
 void main() {
   test('buildRuntimeChatResponseMetadata records tokens and timings', () {
@@ -283,6 +284,8 @@ Future<void> _pumpChatScreen(
     tester.view.resetDevicePixelRatio();
     tester.view.resetPhysicalSize();
   });
+
+  stubGeminiNanoChannel();
 
   SharedPreferences.setMockInitialValues({
     'selected_assistant_model_id': geminiNanoAssistantModelId,

--- a/app/test/features/agent_chat/presentation/screens/notifications_screen_test.dart
+++ b/app/test/features/agent_chat/presentation/screens/notifications_screen_test.dart
@@ -8,6 +8,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import '../../../../support/gemini_nano_channel.dart';
 
 void main() {
   test('buildNotificationChatPrefill includes reminder context', () {
@@ -31,6 +32,7 @@ void main() {
   testWidgets('notification card opens chat with a prefilled composer', (
     tester,
   ) async {
+    stubGeminiNanoChannel();
     SharedPreferences.setMockInitialValues({
       'selected_assistant_model_id': geminiNanoAssistantModelId,
     });

--- a/app/test/support/gemini_nano_channel.dart
+++ b/app/test/support/gemini_nano_channel.dart
@@ -1,0 +1,34 @@
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// The platform channel `GeminiNanoService` talks to.
+const geminiNanoChannel = MethodChannel('com.airo.gemini_nano');
+
+/// Answers the Gemini Nano platform channel for the duration of a test.
+///
+/// Every call in `GeminiNanoService` is bounded with `.timeout(...)` so a wedged
+/// AICore cannot hang the app. Under `flutter_test` a channel with no handler
+/// never answers, so that timeout's `Timer` is still pending when the widget
+/// tree is torn down and the run fails on `!timersPending` — which is what took
+/// out ten tests across three chat suites.
+///
+/// Stubbing the channel lets those bounded calls complete. The defaults report
+/// Nano as unavailable, which is the truth for a test host: no AICore, no
+/// device info.
+void stubGeminiNanoChannel({bool available = false, bool initialized = false}) {
+  final messenger =
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger;
+  messenger.setMockMethodCallHandler(geminiNanoChannel, (call) async {
+    return switch (call.method) {
+      'isAvailable' => available,
+      'initialize' => initialized,
+      'getDeviceInfo' => <String, Object?>{},
+      // 'dispose' and anything else: acknowledge so the bounded call completes
+      // rather than leaving its timeout armed.
+      _ => null,
+    };
+  });
+  addTearDown(
+    () => messenger.setMockMethodCallHandler(geminiNanoChannel, null),
+  );
+}


### PR DESCRIPTION
**main is currently red**: 10 tests fail in `app/test/features/agent_chat/`. This recovers 8 of them and pins the cause of the other 2.

## Cause

`fix(android): bound app Gemini Nano calls` (3a0eef37) wrapped every `GeminiNanoService` platform call in `.timeout(...)`. That is the right hardening — a wedged AICore should not hang the app. But under `flutter_test` a `MethodChannel` with no registered handler never answers, so the timeout's `Timer` was still pending when the widget tree came down, and the run failed on:

```
A Timer is still pending even after the widget tree was disposed.
'package:flutter_test/src/binding.dart': Failed assertion: line 2542 pos 12: '!timersPending'
```

Bisected to that commit specifically. `chat_screen_metadata_test.dart` passes at its parent (`a6cb204a`, 9/9) and at every earlier commit in the bounding series — `cdafb5dc`, `c8a7d495`, `e97cd396`, `fa1987e6` — and fails from `3a0eef37` onward.

Production behaviour is fine: on a device the channel always answers, so nothing leaks. This is a test-host gap, so the fix is test-side.

## Change

`app/test/support/gemini_nano_channel.dart` adds `stubGeminiNanoChannel()`, which answers `com.airo.gemini_nano` for the duration of a test so the bounded calls complete instead of leaving a timer armed. Defaults report Nano as unavailable — the truth for a test host with no AICore. Wired into `chat_screen_metadata_test` and `notifications_screen_test`.

Result: **143 pass, 2 fail** in `test/features/agent_chat/`, down from 10 failures.

## The remaining two, deliberately untouched

`chat_screen_finance_ingestion_test.dart` fails for a different reason. Those two run `ChatScreen()` with AI initialization **enabled**, and they were passing only because the platform call never completed — `pumpAndSettle` returned with initialization still in flight, and the finance path ran. Once the channel answers at all, initialization completes and they reach their real assertion:

```
Expected: an object with length of <1>
  Actual: []
```

I verified this with both `available: false` and `available: true, initialized: true` — same empty result either way, so it is not a matter of picking the right stub answer. The suite needs the ingestion path exercised independently of Nano's state (overriding the assistant runtime service rather than relying on a hanging channel). That is a real fragility in the ingestion tests, in agent_chat's own area, and guessing at it here would be worse than naming it.

So this PR takes main from 10 red to 2 red, and the 2 have a precise diagnosis attached.

🤖 Generated with [Claude Code](https://claude.com/claude-code)