### PR TITLE
fix(ci): stop analysing patrol suites that cannot resolve

### DIFF
--- a/app/analysis_options.yaml
+++ b/app/analysis_options.yaml
@@ -20,6 +20,14 @@ analyzer:
     - "**/generated/**"
     - "**/*.g.dart"
     - "**/*.freezed.dart"
+    # Patrol suites resolve only under the patrol flavour. `patrol` is not a
+    # dependency of app/pubspec.yaml -- the flavour pubspecs are separate, so a
+    # dependency in one is invisible to the others -- which makes every symbol
+    # in these files unresolvable in the default analysis and produced 12 hard
+    # errors that failed `analyze` and `code-quality` on every PR. Analysing
+    # them here checks nothing; it only hides the errors that matter.
+    - "integration_test/patrol_test.dart"
+    - "patrol_test/**"
 
   # Treat warnings as info to prevent CI failures on non-critical issues
   # Errors will still cause CI to fail

--- a/app/test/features/agent_chat/presentation/screens/model_library_setup_dialog_test.dart
+++ b/app/test/features/agent_chat/presentation/screens/model_library_setup_dialog_test.dart
@@ -4,7 +4,6 @@ import 'package:airo_app/features/agent_chat/application/assistant_model_prefere
 import 'package:airo_app/features/agent_chat/data/services/assistant_runtime_service.dart';
 import 'package:airo_app/features/agent_chat/domain/models/assistant_runtime_ids.dart';
 import 'package:airo_app/features/agent_chat/presentation/screens/model_library_screen.dart';
-import 'package:core_ai/core_ai.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';


### PR DESCRIPTION
The `analyze` and `code-quality` gates are red on **every** PR right now, independent of its contents. #1374 was merged with both failing, and #1376 hits the same wall. This restores them.

## Cause

`flutter analyze` in `app/` reports 12 hard errors, every one an unresolved `patrol` symbol:

```
error • Target of URI doesn't exist: 'package:patrol/patrol.dart' • integration_test/patrol_test.dart:2:8
error • The function 'patrolTest' isn't defined • integration_test/patrol_test.dart:22:3
error • Undefined class 'PatrolIntegrationTester' • patrol_test/agent_skills_journey_test.dart:22:3
… 9 more
```

Errors are fatal to that step even with `--no-fatal-infos`, so the gate fails before it can say anything about the PR under review.

`patrol` is **not declared as a dependency anywhere in the repo**:

- `app/pubspec.yaml` carries only the top-level `patrol:` CLI configuration block (line 245) — not a dependency
- `app/pubspec_patrol.yaml` has it commented out (`# patrol: ^3.11.0`)

And per the flavour design, a dependency in one pubspec is invisible to the others. So nothing in those files can resolve under the default analysis — they have never been analysable, and analysing them checks nothing while burying every finding that matters under twelve that cannot be fixed from here.

## Change

Excludes `integration_test/patrol_test.dart` and `patrol_test/**` in `app/analysis_options.yaml`, with the reasoning recorded inline next to the existing excludes.

Result: **12 errors → 0**. The two remaining findings are `info` (`prefer_initializing_formals` in `llama_gguf_service.dart`, and one unused import), which the CI step already tolerates via `--no-fatal-infos`.

Also drops the unused `core_ai` import from `model_library_setup_dialog_test.dart` — the only info in code this branch owns. That suite still passes 2/2.

## What this does not do

It does not make the patrol suites work. They need `patrol` restored as a dependency of the patrol flavour and a CI job that analyses them under that resolution — worth doing, but a separate piece of work with an owner decision in it (which pubspec, which job). This change only stops a permanently-failing check from masking real ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)