### PR TITLE
refactor(coins): move CoinVaultModule into the package it registers

### DIFF
--- a/app/lib/core/routing/route_names.dart
+++ b/app/lib/core/routing/route_names.dart
@@ -1,3 +1,5 @@
+import 'package:feature_coin/feature_coin.dart';
+
 class RouteNames {
   // Private constructor to prevent instantiation
   RouteNames._();
@@ -20,9 +22,10 @@ class RouteNames {
   static const String coinsGroups = 'coins_groups';
   static const String coinsGroupDetail = 'coins_group_detail';
   static const String coinsAddSplit = 'coins_add_split';
-  static const String coinVault = 'coin_vault';
-  static const String coinVaultAdd = 'coin_vault_add';
-  static const String coinVaultEdit = 'coin_vault_edit';
+  // Owned by packages/feature_coin so both shells mount the same names.
+  static const String coinVault = CoinVaultRouteNames.vault;
+  static const String coinVaultAdd = CoinVaultRouteNames.add;
+  static const String coinVaultEdit = CoinVaultRouteNames.edit;
 
   // Coins Full Paths (for direct navigation)
   static const String coinsDashboardPath = '/money/dashboard';

--- a/app/lib/main.dart
+++ b/app/lib/main.dart
@@ -8,7 +8,6 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'core/app/airo_app.dart';
 import 'core/app/main_provider_overrides.dart';
-import 'core/coins/coin_vault_module.dart';
 import 'core/config/firebase_status.dart';
 import 'core/error/global_error_handler.dart';
 import 'core/routing/app_router.dart';
@@ -18,6 +17,7 @@ import 'features/iptv/epg_reminder_notification_gateway.dart';
 import 'features/iptv/iptv_feature_module.dart';
 import 'features/music/application/providers/beats_audio_provider.dart';
 import 'firebase_options.dart';
+import 'package:feature_coin/feature_coin.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();

--- a/app/lib/main_coins.dart
+++ b/app/lib/main_coins.dart
@@ -27,8 +27,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
-import 'core/coins/coin_vault_module.dart';
 import 'core/pro/pro_bootstrap_runner.dart';
+import 'package:feature_coin/feature_coin.dart';
 
 void main() {
   WidgetsFlutterBinding.ensureInitialized();

--- a/app/test/main_coins_shell_test.dart
+++ b/app/test/main_coins_shell_test.dart
@@ -1,4 +1,3 @@
-import 'package:airo_app/core/coins/coin_vault_module.dart';
 import 'package:airo_app/main_coins.dart';
 import 'package:core_product_shell/core_product_shell.dart';
 import 'package:feature_coin/feature_coin.dart';

--- a/packages/feature_coin/lib/feature_coin.dart
+++ b/packages/feature_coin/lib/feature_coin.dart
@@ -24,3 +24,4 @@ export 'src/presentation/widgets/forms/secure_document_form.dart';
 export 'src/presentation/widgets/masked_vault_field.dart';
 export 'src/presentation/widgets/record_detail_sheet.dart';
 export 'src/presentation/widgets/vault_lifecycle_observer.dart';
+export 'src/presentation/coin_vault_module.dart';

--- a/packages/feature_coin/lib/src/presentation/coin_vault_module.dart
+++ b/packages/feature_coin/lib/src/presentation/coin_vault_module.dart
@@ -1,9 +1,19 @@
 import 'package:core_product_shell/core_product_shell.dart';
-import 'package:feature_coin/feature_coin.dart';
 import 'package:flutter_riverpod/misc.dart';
 import 'package:go_router/go_router.dart';
 
-import '../routing/route_names.dart';
+import '../../feature_coin.dart';
+
+/// Route names for the vault bundle.
+///
+/// Owned by the feature rather than the host app so every shell that mounts
+/// [CoinVaultModule] refers to the same names. `app/lib/core/routing`
+/// re-exposes these for the super app's existing call sites.
+abstract final class CoinVaultRouteNames {
+  static const String vault = 'coin_vault';
+  static const String add = 'coin_vault_add';
+  static const String edit = 'coin_vault_edit';
+}
 
 /// The Airo Coin vault as a shell-registrable [AppModule].
 ///
@@ -44,12 +54,12 @@ class CoinVaultModule extends AppModule {
       // The super-app mounts the vault inside its existing /money shell
       // branch. Focused products mount the same bundle at an absolute path.
       path: shell == ShellId.mobile ? 'vault' : basePath,
-      name: RouteNames.coinVault,
+      name: CoinVaultRouteNames.vault,
       builder: (context, state) => const VaultGateScreen(),
       routes: [
         GoRoute(
           path: 'add/:type',
-          name: RouteNames.coinVaultAdd,
+          name: CoinVaultRouteNames.add,
           builder: (context, state) => VaultRecordFormScreen(
             recordType: VaultRecordType.values.byName(
               state.pathParameters['type']!,
@@ -58,7 +68,7 @@ class CoinVaultModule extends AppModule {
         ),
         GoRoute(
           path: 'edit/:type/:key',
-          name: RouteNames.coinVaultEdit,
+          name: CoinVaultRouteNames.edit,
           builder: (context, state) => VaultRecordFormScreen(
             recordType: VaultRecordType.values.byName(
               state.pathParameters['type']!,

--- a/packages/feature_coin/pubspec.yaml
+++ b/packages/feature_coin/pubspec.yaml
@@ -18,6 +18,8 @@ dependencies:
     path: ../platform_coin_vault
   equatable: ^2.0.8
   flutter_riverpod: 3.3.2
+  core_product_shell:
+    path: ../core_product_shell
   go_router: ^17.3.0
   local_auth: ^2.3.0
   path: 1.9.1


### PR DESCRIPTION
First step of #1379 (Coins single source of truth). Mechanical, no behaviour change.

## Why

`CoinVaultModule` lived in `app/lib/core/coins/` while the feature it mounts lives in `packages/feature_coin` — which declared **zero** `GoRoute`s of its own. So the wiring for a packaged feature was owned by the host app, and every shell had to know how to assemble it. That is the structural reason the standalone Coins app and the super app's Coins tab drifted apart.

## What moved

- `coin_vault_module.dart` → `packages/feature_coin/lib/src/presentation/`, next to the screens it routes to (git tracks it as a rename).
- The three route names move with it as `CoinVaultRouteNames`. `app/lib/core/routing/route_names.dart` keeps `coinVault` / `coinVaultAdd` / `coinVaultEdit` as aliases, so the super app's existing call sites are untouched.
- `feature_coin` gains `core_product_shell` for `AppModule` and `ShellId`.

## On that new dependency

It is the direction features already depend in: `core_product_shell` is a pure contract (`flutter`, `flutter_riverpod`, `go_router` — no feature dependencies), and `feature_iptv` depends on it exactly this way. No cycle.

## Mount points unchanged

`main.dart` mounts at `/money/vault`, `main_coins.dart` at `/vault`, both from the package barrel.

## Verification

- `app/test/main_coins_shell_test.dart` + `app/test/core/app/`: **32 pass**
- `packages/feature_coin`: **68 pass**
- `flutter analyze lib` clean (one pre-existing info in `llama_gguf_service.dart`)
- `scripts/check-module-manifests.py`: ok
- `dart format`: no changes

## Next

With ownership in the right place, step 2 of #1379 can add the dashboard, expense, and budget routes to this one module instead of maintaining them in the super app only — which is what currently leaves the standalone Coins app vault-only. Step 3 (groups/split) still needs the MLKit decision recorded in that issue, since receipt OCR would breach the Coins flavour's enforced 25 MB budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)