### PR TITLE
style(app): format three files blocking the CI format gate

### DIFF
--- a/app/lib/core/portability/airo_lan_sync_service.dart
+++ b/app/lib/core/portability/airo_lan_sync_service.dart
@@ -84,10 +84,9 @@ class AiroLanSyncService {
       if (response.contentLength > maxPayloadBytes) {
         throw const FormatException('LAN share is too large');
       }
-      final bytes = await response.fold<List<int>>(
-        <int>[],
-        (buffer, chunk) => buffer..addAll(chunk),
-      ).timeout(transferTimeout);
+      final bytes = await response
+          .fold<List<int>>(<int>[], (buffer, chunk) => buffer..addAll(chunk))
+          .timeout(transferTimeout);
       if (bytes.length > maxPayloadBytes) {
         throw const FormatException('LAN share is too large');
       }

--- a/app/lib/features/agent_chat/domain/services/remote_agent_skill_installer.dart
+++ b/app/lib/features/agent_chat/domain/services/remote_agent_skill_installer.dart
@@ -12,10 +12,8 @@ typedef RemoteSkillDocumentFetcher = Future<String> Function(Uri uri);
 /// Imported skills are quarantined (disabled) until the user explicitly
 /// enables them in the Agent Skills screen.
 class RemoteAgentSkillInstaller {
-  RemoteAgentSkillInstaller({
-    RemoteSkillDocumentFetcher? fetcher,
-    this._store,
-  }) : _fetcher = fetcher ?? _fetchOverHttps;
+  RemoteAgentSkillInstaller({RemoteSkillDocumentFetcher? fetcher, this._store})
+    : _fetcher = fetcher ?? _fetchOverHttps;
 
   static const maxDocumentBytes = RemoteAgentSkillStore.maxDocumentBytes;
   final RemoteSkillDocumentFetcher _fetcher;

--- a/app/lib/features/mind/presentation/screens/mobile_actions_screen.dart
+++ b/app/lib/features/mind/presentation/screens/mobile_actions_screen.dart
@@ -48,10 +48,7 @@ class _MobileActionsScreenState extends State<MobileActionsScreen> {
                         'Open Wi-Fi settings',
                         'Open WiFi settings.',
                       ),
-                      _commandChip(
-                        'Flashlight on',
-                        'Turn the flashlight on.',
-                      ),
+                      _commandChip('Flashlight on', 'Turn the flashlight on.'),
                       _commandChip(
                         'Flashlight off',
                         'Turn the flashlight off.',


### PR DESCRIPTION
`main` is red again, and it fails every PR branched from it — same shape as the patrol errors #1378 fixed, different step.

## Cause

The `analyze` job's **Check formatting** step runs

```
find lib -name "*.dart" ! -name "*.g.dart" ! -name "*.freezed.dart" -print0 \
  | xargs -0 dart format --set-exit-if-changed
```

and exits **123** on main. That failure is what shows up as `analyze: failure` — it is not the analyzer. Three files landed unformatted:

- `lib/core/portability/airo_lan_sync_service.dart`
- `lib/features/mind/presentation/screens/mobile_actions_screen.dart`
- `lib/features/agent_chat/domain/services/remote_agent_skill_installer.dart`

Confirmed on the last completed main run (`30547730339`) and again on the in-flight one (`30550973082`).

## Change

`dart format` on those three files. **6 insertions, 12 deletions, all whitespace and trailing commas** — no logic touched.

After it, the gate passes locally and `flutter analyze lib` reports only the pre-existing `prefer_initializing_formals` info in `llama_gguf_service.dart`.

## Why it matters beyond the red X

`update-apk-size-baselines` has `needs: [build-android]` and only runs on push to main. While main's CI keeps failing, that job never runs, so `.github/apk-size-baselines.tsv` stays frozen at values recorded in `18200609`:

| component | baseline | actual (measured with CI flags) |
|---|---|---|
| tv | 29.63 MB | 28.63 MB |
| full | **432.2 MB** | **80.93 MB** |

So the `full` component currently has no meaningful size guardrail at all — it could grow five-fold without tripping the delta check. That is the open half of #1364, and it cannot self-correct until a main build goes green. This PR is a precondition for that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)