### PR TITLE
fix(games): draw chess rank labels in the board's own orientation

### DIFF
--- a/app/lib/features/games/presentation/flame/chess_game.dart
+++ b/app/lib/features/games/presentation/flame/chess_game.dart
@@ -69,6 +69,17 @@ class ChessGameFlame extends FlameGame with TapCallbacks {
     return color == ChessColor.white ? ChessColor.black : ChessColor.white;
   }
 
+  /// The rank digit that belongs on [displayRow] for [playerColor].
+  ///
+  /// Ranks have to follow the same flip as the pieces. They did not: the
+  /// labels were drawn 8..1 top-to-bottom regardless of orientation, so a
+  /// black player -- half of all games, since the colour is random -- saw
+  /// rank 1's pieces at the top of the board under a label reading "8".
+  static String rankLabelForDisplayRow(int displayRow, ChessColor playerColor) {
+    final row = displayRowForPlayerPerspective(displayRow, playerColor);
+    return (row + 1).toString();
+  }
+
   static int displayRowForPlayerPerspective(int row, ChessColor playerColor) {
     return playerColor == ChessColor.white ? 7 - row : row;
   }
@@ -423,7 +434,7 @@ class ChessGameFlame extends FlameGame with TapCallbacks {
 
     // Draw rank labels (1-8) on left
     for (int row = 0; row < 8; row++) {
-      final rank = (8 - row).toString(); // 8-1 (top to bottom)
+      final rank = rankLabelForDisplayRow(row, playerColor);
       final textPainter = TextPainter(
         text: TextSpan(
           text: rank,

--- a/app/test/core/portability/airo_lan_sync_service_test.dart
+++ b/app/test/core/portability/airo_lan_sync_service_test.dart
@@ -51,9 +51,7 @@ void main() {
       transferTimeout: const Duration(milliseconds: 50),
     );
     await expectLater(
-      service.fetchShare(
-        Uri.parse('http://127.0.0.1:${server.port}/stalled'),
-      ),
+      service.fetchShare(Uri.parse('http://127.0.0.1:${server.port}/stalled')),
       throwsA(isA<TimeoutException>()),
     );
   });

--- a/app/test/features/games/chess_board_orientation_test.dart
+++ b/app/test/features/games/chess_board_orientation_test.dart
@@ -1,0 +1,63 @@
+import 'package:airo_app/features/games/domain/models/chess_models.dart';
+import 'package:airo_app/features/games/presentation/flame/chess_game.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// Rank labels have to follow the same flip as the pieces.
+///
+/// Found on the rig Pixel 9 (issue #1375): the board looked like it had pawns
+/// of the wrong colour on the a-file. The pieces were right — a device probe
+/// confirmed the engine held `a2=white/pawn, a7=black/pawn` — but the labels
+/// were drawn 8..1 top-to-bottom regardless of orientation, so the ranks read
+/// upside down against the pieces and the position looked illegal.
+///
+/// `playerColor` is `random.nextBool()`, so this was wrong in about half of
+/// all games, which is why it reproduced inconsistently.
+void main() {
+  group('rank labels match the rendered orientation', () {
+    test('white at the bottom puts rank 8 on top and rank 1 at the bottom', () {
+      final labels = [
+        for (var displayRow = 0; displayRow < 8; displayRow++)
+          ChessGameFlame.rankLabelForDisplayRow(displayRow, ChessColor.white),
+      ];
+
+      expect(labels, ['8', '7', '6', '5', '4', '3', '2', '1']);
+    });
+
+    test('black at the bottom puts rank 1 on top and rank 8 at the bottom', () {
+      final labels = [
+        for (var displayRow = 0; displayRow < 8; displayRow++)
+          ChessGameFlame.rankLabelForDisplayRow(displayRow, ChessColor.black),
+      ];
+
+      expect(
+        labels,
+        ['1', '2', '3', '4', '5', '6', '7', '8'],
+        reason:
+            'a black player sees the board from the other side, so rank 1 is '
+            'the far row; labelling it 8 is what made the position look wrong',
+      );
+    });
+  });
+
+  group('labels agree with where the pieces are drawn', () {
+    for (final playerColor in ChessColor.values) {
+      test('every rank label sits on that rank\'s own row for $playerColor', () {
+        for (var boardRow = 0; boardRow < 8; boardRow++) {
+          // Where _drawPieces puts this board row.
+          final displayRow = ChessGameFlame.displayRowForPlayerPerspective(
+            boardRow,
+            playerColor,
+          );
+          // Board row 0 is rank 1 in this project's 64-square indexing.
+          expect(
+            ChessGameFlame.rankLabelForDisplayRow(displayRow, playerColor),
+            '${boardRow + 1}',
+            reason:
+                'the digit drawn beside a row must name the rank whose pieces '
+                'are drawn on it',
+          );
+        }
+      });
+    }
+  });
+}


### PR DESCRIPTION
Fixes #1375, found on the rig Pixel 9.

## What was actually wrong

The board flips for a white player and does not for a black one. Squares, pieces, hit-testing and speech bubbles all route their row through `displayRowForPlayerPerspective`. **The rank labels did not** — they were drawn `8..1` top-to-bottom unconditionally:

```dart
for (int row = 0; row < 8; row++) {
  final rank = (8 - row).toString(); // 8-1 (top to bottom)
  ...Offset(4, boardOffset.dy + row * squareSize + 2)
```

`playerColor` is `random.nextBool()`, so in about half of all games a black player saw rank 1's pieces along the top of the board under a label reading "8". The position read as illegal — which is exactly how it was reported: pawns of the wrong colour on a file.

## How it was pinned down

A probe in `_drawPieces` on the device printed the engine's own view at first paint:

```
QACHESS a1=white/rook a2=white/pawn a7=black/pawn a8=black/rook
        b2=white/pawn b7=black/pawn player=ChessColor.black n=64
```

So the engine was correct all along, and the draw loop takes both the glyph and the colour from the same `piece.color`, which means it cannot tint one square differently from another. The pieces were never wrong; the ranks were numbered against them. The randomised player colour is why it reproduced on some launches and not others — my two screenshots of "the same" bug were actually two different orientations.

## The fix

`rankLabelForDisplayRow(displayRow, playerColor)` names the rank whose pieces occupy that row, and is public so the mapping can be asserted without rendering a frame.

File labels are deliberately untouched: columns are never mirrored, so `a-h` stays consistent with where the pieces are drawn.

## Verification

Four tests covering both orientations, plus a cross-check that every label agrees with `displayRowForPlayerPerspective` for the same board row. Non-vacuous — against the old expression they fail with:

```
Expected: ['1', '2', '3', '4', '5', '6', '7', '8']
  Actual: ['8', '7', '6', '5', '4', '3', '2', '1']
```

`flutter analyze` clean on `lib/features/games` and `test/features/games`.

The `QACHESS` probe was diagnostic only and is **not** in this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)