### PR TITLE
ci(size): record the measured full-app baseline and budget

### DIFF
--- a/.github/airo-build-profiles.json
+++ b/.github/airo-build-profiles.json
@@ -31,7 +31,7 @@
       "android": {
         "apkArtifact": "app-arm64-v8a-release.apk",
         "abiStrategy": "single-arm64-apk",
-        "releaseBudgetMb": 450,
+        "releaseBudgetMb": 120,
         "debugBudgetMb": 650,
         "enforceReleaseBudget": false
       }

--- a/.github/apk-size-baselines.tsv
+++ b/.github/apk-size-baselines.tsv
@@ -6,8 +6,12 @@
 # baseline_bytes: approved baseline size in bytes.
 # budget_mb: absolute artifact budget in MiB.
 #
-# This file is updated automatically after successful main builds.
+# This file is NOT updated automatically, despite what the CI job attempts.
+# update-apk-size-baselines measures each main build correctly, but its push is
+# rejected by branch protection on main (GH006) and the job only logs a warning,
+# so these numbers stay wherever they were last committed by hand. Refresh them
+# in a PR that cites the run they were measured on.
 component	artifact	baseline_bytes	budget_mb
-full	app-arm64-v8a-release.apk	453201577	450
-tv	app-arm64-v8a-release.apk	31071323	35
+full	app-arm64-v8a-release.apk	104141179	120
+tv	app-arm64-v8a-release.apk	30017835	35
 coins	app-arm64-v8a-release.apk	20745001	25


### PR DESCRIPTION
Refs #1364.

## The `full` row was never a guardrail

| | recorded | actual (CI, run [30613471907](https://github.com/DevelopersCoffee/airo/actions/runs/30613471907)) |
|---|---|---|
| baseline | 453,201,577 B (432.2 MB) | **104,141,179 B (99.32 MB)** |
| budget | 450 MB | — |

4.3x headroom. No plausible size regression could trip it. On top of that the full leg runs `enforce_size: false`, so it reports rather than blocks either way.

## `tv` moved down, not up

31,071,323 → **30,017,835 B** from the same run. The 2.2 MB growth #1364 opened over has since reversed, so there is nothing left to attribute — decision 1 in that issue is moot, and recording the measured size only tightens the gate.

## The file does not update itself

The header said *"updated automatically after successful main builds."* It isn't. `update-apk-size-baselines` measures each build correctly and uploads the artifact, but the push is rejected by branch protection:

```
remote: error: GH006: Protected branch update failed for refs/heads/main.
 ! [remote rejected] main -> main (protected branch hook declined)
```

The step catches that and emits a warning, so the run stays green and the baselines silently freeze at whatever was last committed by hand. I corrected the header to state this rather than leave a comment that reads like a working mechanism.

## What I did not do

I started changing `update-apk-size-baselines` to open a PR instead of a doomed direct push — that is the actual repair for the frozen-baseline problem. It needs `pull-requests: write` on that job, and editing workflow permissions was blocked in my session, so I reverted the half-applied change rather than leave a step that would fail at runtime. **That fix still needs to happen; this PR only makes the numbers honest.**

## Judgement call to confirm

`full` budget set to **120 MB** (~20% over the measured 99.32 MB), mirrored into `airo-build-profiles.json` so `check-build-profiles.py` keeps the two in step. That number is a decision, not a measurement — a release owner should confirm it is the ceiling they want for the phone app, and whether `enforce_size` should flip to `true` now that the budget means something.

## Verification

- `scripts/test-check-apk-size.sh` → passed
- `scripts/test-merge-apk-size-baselines.sh` → passed
- `scripts/check-build-profiles.py` → exit 0 (catches tsv/profile budget drift)
- `scripts/check-module-manifests.py` → 62 manifests valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)