### PR TITLE
test(iptv): re-enable the fullscreen player regression tests

### DIFF
--- a/packages/feature_iptv/test/iptv/presentation/screens/iptv_screen_test.dart
+++ b/packages/feature_iptv/test/iptv/presentation/screens/iptv_screen_test.dart
@@ -214,40 +214,37 @@ void main() {
     expect(find.byType(AppBar), findsOneWidget);
   });
 
-  testWidgets(
-    'browse preview exposes a full player entry point',
-    (tester) async {
-      await tester.pumpWidget(
-        createWidget(
-          streamingState: StreamingState(
-            playbackState: PlaybackState.playing,
-            isLiveStream: true,
-            liveDelay: const Duration(seconds: 1),
-            currentChannel: channels.first,
-          ),
+  testWidgets('browse preview exposes a full player entry point', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      createWidget(
+        streamingState: StreamingState(
+          playbackState: PlaybackState.playing,
+          isLiveStream: true,
+          liveDelay: const Duration(seconds: 1),
+          currentChannel: channels.first,
         ),
-      );
-      await tester.pump();
-      await tester.pump(const Duration(milliseconds: 300));
+      ),
+    );
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 300));
 
-      final fullscreenButton = find.byKey(
-        const ValueKey('iptv-preview-fullscreen-button'),
-      );
-      expect(fullscreenButton, findsOneWidget);
+    final fullscreenButton = find.byKey(
+      const ValueKey('iptv-preview-fullscreen-button'),
+    );
+    expect(fullscreenButton, findsOneWidget);
 
-      await tester.tap(fullscreenButton);
-      await tester.pump();
-      await tester.pump(const Duration(milliseconds: 300));
+    await tester.tap(fullscreenButton);
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 300));
 
-      expect(fullscreenButton, findsNothing);
-      expect(
-        find.byKey(const ValueKey('iptv-player-fullscreen-button')),
-        findsOneWidget,
-      );
-    },
-    // Tracked as Pixel 9 fullscreen overlay/back hit-test follow-up.
-    skip: true,
-  );
+    expect(fullscreenButton, findsNothing);
+    expect(
+      find.byKey(const ValueKey('iptv-player-fullscreen-button')),
+      findsOneWidget,
+    );
+  });
 
   testWidgets(
     'macOS full player owns one native transition and restores on native exit',
@@ -448,47 +445,44 @@ void main() {
     expect(tester.takeException(), isNull);
   });
 
-  testWidgets(
-    'system Back exits fullscreen playback before popping the app',
-    (tester) async {
-      await tester.pumpWidget(
-        createWidget(
-          streamingState: StreamingState(
-            playbackState: PlaybackState.playing,
-            isLiveStream: true,
-            liveDelay: const Duration(seconds: 1),
-            currentChannel: channels.first,
-          ),
+  testWidgets('system Back exits fullscreen playback before popping the app', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      createWidget(
+        streamingState: StreamingState(
+          playbackState: PlaybackState.playing,
+          isLiveStream: true,
+          liveDelay: const Duration(seconds: 1),
+          currentChannel: channels.first,
         ),
-      );
-      await tester.pump();
-      await tester.pump(const Duration(milliseconds: 300));
+      ),
+    );
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 300));
 
-      await tester.tap(
-        find.byKey(const ValueKey('iptv-preview-fullscreen-button')),
-      );
-      await tester.pump();
-      await tester.pump(const Duration(milliseconds: 300));
+    await tester.tap(
+      find.byKey(const ValueKey('iptv-preview-fullscreen-button')),
+    );
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 300));
 
-      expect(
-        find.byKey(const ValueKey('iptv-player-fullscreen-button')),
-        findsOneWidget,
-      );
+    expect(
+      find.byKey(const ValueKey('iptv-player-fullscreen-button')),
+      findsOneWidget,
+    );
 
-      final handled = await tester.binding.handlePopRoute();
-      await tester.pump();
-      await tester.pump(const Duration(milliseconds: 300));
+    final handled = await tester.binding.handlePopRoute();
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 300));
 
-      expect(handled, isTrue);
-      expect(find.text('Airo TV'), findsOneWidget);
-      expect(
-        find.byKey(const ValueKey('iptv-preview-fullscreen-button')),
-        findsOneWidget,
-      );
-    },
-    // Tracked as Pixel 9 fullscreen overlay/back hit-test follow-up.
-    skip: true,
-  );
+    expect(handled, isTrue);
+    expect(find.text('Airo TV'), findsOneWidget);
+    expect(
+      find.byKey(const ValueKey('iptv-preview-fullscreen-button')),
+      findsOneWidget,
+    );
+  });
 
   testWidgets(
     'hamburger menu opens the drawer and Guide pushes the guide screen',


### PR DESCRIPTION
Found while sweeping every package suite for the Pixel 9 QA loop: `feature_iptv` reported 2 skipped tests. Both were disabled unconditionally with the same note:

```dart
// Tracked as Pixel 9 fullscreen overlay/back hit-test follow-up.
skip: true,
```

That is the rig this QA loop runs on, so the coverage was switched off precisely where it was needed.

## The behaviour works now

Removing the skips:

- **25 tests pass** in this file, stable across three consecutive runs.
- **Not vacuous** — setting the preview button's `onPressed` to `null` fails 3 tests, both of these among them. They still detect a broken fullscreen entry point.

`feature_iptv` goes 826 → 828.

## Scope

Test-only. Nothing in `lib` changed. This just stops the suite from silently skipping coverage of a bug that has since been fixed.

`flutter analyze lib test` reports the same 4 pre-existing `unnecessary_import` infos with and without this change (CI runs `--no-fatal-infos`), so they are untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)