### PR TITLE
fix(release): don't self-copy pubspec for the full mobile profile

### DIFF
--- a/.github/workflows/airo-mobile-tablet-release.yml
+++ b/.github/workflows/airo-mobile-tablet-release.yml
@@ -409,8 +409,13 @@ jobs:
 
       - name: Apply mobile/tablet pubspec
         run: |
-          cp app/pubspec.yaml app/pubspec.yaml.backup
-          cp "app/$PROFILE_PUBSPEC" app/pubspec.yaml
+          # The full profile builds from pubspec.yaml itself; copying it onto
+          # itself errors under `set -e` ("same file"). Only swap when the
+          # profile uses a distinct pubspec (e.g. pubspec_coins.yaml).
+          if [ "$PROFILE_PUBSPEC" != "pubspec.yaml" ]; then
+            cp app/pubspec.yaml app/pubspec.yaml.backup
+            cp "app/$PROFILE_PUBSPEC" app/pubspec.yaml
+          fi
 
       - name: Get dependencies
         run: |


### PR DESCRIPTION
## Problem

The `full` mobile/tablet release leg has never built through the release orchestrator. The **Apply mobile/tablet pubspec** step runs:

```bash
cp app/pubspec.yaml app/pubspec.yaml.backup
cp "app/$PROFILE_PUBSPEC" app/pubspec.yaml
```

For `full`, `PROFILE_PUBSPEC=pubspec.yaml`, so the second line is `cp app/pubspec.yaml app/pubspec.yaml` — copying a file onto itself, which errors ("same file") under `set -e` and fails the build leg.

Surfaced by the v0.0.6-rc.1 orchestrator dry-run ([run 30665153212](https://github.com/DevelopersCoffee/airo/actions/runs/30665153212)): TV ✅ and macOS TV ✅ built and signed cleanly, full ❌ died at this step.

## Fix

Only swap the pubspec when the profile uses a distinct one (coins → `pubspec_coins.yaml`); the `full` profile builds from `pubspec.yaml` directly.

## Scope

- One workflow step, guarded by a string compare. No behavior change for coins/other profiles.
- Unblocks `full` in the v0.0.6-rc.1 preview wave (tv + full + macOS TV).

🤖 Generated with [Claude Code](https://claude.com/claude-code)