### PR TITLE
ci(size): park the APK baseline refresh on a branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -754,14 +754,22 @@ jobs:
           git add .github/apk-size-baselines.tsv
           git commit -m "ci: update APK size baselines"
 
-          # main is a protected branch requiring status checks,
-          # which a direct push here never satisfies. Don't fail the run for
-          # this best-effort housekeeping step; log it and let a human land
-          # the baseline update via PR instead.
-          if ! git push; then
-            echo "::warning::Could not push updated APK size baselines directly to protected main. Update .github/apk-size-baselines.tsv manually via PR."
-            exit 0
+          # main is a protected branch requiring status checks, which a direct
+          # push from here can never satisfy -- it fails with GH006 on every
+          # run. The old code pushed straight at main and downgraded the
+          # rejection to a warning, so the measurement was computed, thrown
+          # away, and the committed baselines silently froze (issue #1364).
+          #
+          # Park the refresh on a branch instead. Pushing a branch needs only
+          # the contents:write this job already has, so the measured numbers
+          # survive the run and a human can open the PR from them.
+          refresh_branch="chore/apk-size-baselines"
+          if git push --force origin "HEAD:$refresh_branch"; then
+            echo "::warning::APK size baselines changed. Refresh pushed to '$refresh_branch' -- open a PR from it to land the update (see $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/compare/$refresh_branch?expand=1)."
+          else
+            echo "::warning::Could not push the APK size baseline refresh to '$refresh_branch'. Update .github/apk-size-baselines.tsv manually via PR."
           fi
+          exit 0
 
   # ============================================
   # Build Summary Job


### PR DESCRIPTION
Refs #1364. Completes the half of that issue I could not finish earlier.

## The measurement was being computed, then discarded

`update-apk-size-baselines` measures every main build correctly and uploads the artifact. Then it pushed straight at `main`:

```
remote: error: GH006: Protected branch update failed for refs/heads/main.
 ! [remote rejected] main -> main (protected branch hook declined)
```

`main` is protected and requires status checks, so this push can never succeed. The step caught the failure, emitted a warning, and exited 0 — run stays green, baselines silently freeze at whatever was last committed by hand.

That is the root cause behind the `full` row sitting at 453,201,577 B against a real 104,141,179 B artifact until #1385 corrected it manually. A 4.3x gap that no size regression could ever trip.

## Fix: push to a branch, not to main

The refresh now lands on `chore/apk-size-baselines`. **A branch push needs only the `contents: write` this job already has** — no new permission, no workflow permission change. The measured numbers survive the run, and the warning carries a compare link to open the PR from.

## What this deliberately does not do

It does not auto-land baseline changes. Accepting a size increase is a decision, not housekeeping — the same reasoning #1364 gives for wanting growth attributed before it is absorbed. This only stops the measurement from being thrown away.

## Verification

- `ci.yml` parses: `ruby -e 'require "yaml"; YAML.load_file(...)'` → valid
- Job already declares `permissions: contents: write` and uses plain `actions/checkout@v7` (credentials persisted by default), so the branch push is authorized as-is

Note: an earlier attempt at this used `gh pr create`, which needs `pull-requests: write` on the job. That permission edit was blocked in my session, so I reverted it rather than leave a step that would fail at runtime. This version needs no permission change and is the better fix regardless — it keeps the accept/reject decision with a human.

🤖 Generated with [Claude Code](https://claude.com/claude-code)