### PR TITLE
ci: guard the Gson keep rules across every Android flavour

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,6 +94,14 @@ jobs:
           chmod +x scripts/check-bundled-model-artifacts.sh
           scripts/check-bundled-model-artifacts.sh
 
+      # Scheduled notifications deserialize through Gson, so R8 renaming the
+      # plugin's model fields breaks them in release builds only. No test layer
+      # can see that, which is why it needs a gate here.
+      - name: Enforce Gson keep rules for scheduled notifications
+        run: |
+          chmod +x scripts/check-gson-keep-rules.sh
+          scripts/check-gson-keep-rules.sh
+
       - name: Validate platform build profiles
         run: |
           chmod +x scripts/check-ci-cache-policy.py scripts/check-build-profiles.py scripts/generate-release-manifest.py scripts/test-generate-release-manifest.sh scripts/generate-release-qualification-report.py scripts/test-generate-release-qualification-report.sh

--- a/scripts/check-gson-keep-rules.sh
+++ b/scripts/check-gson-keep-rules.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# Guard the R8 keep rules that scheduled notifications depend on.
+#
+# flutter_local_notifications persists each scheduled notification as JSON and
+# reads it back with Gson when the alarm fires. Gson maps JSON keys onto field
+# names, so R8 renaming the fields of NotificationDetails turns every persisted
+# notification into null fields. The plugin ships no consumer ProGuard rules, so
+# the app's own proguard-rules.pro is the only thing holding this together.
+#
+# Nothing else can catch a regression here: debug builds have no R8, widget
+# tests never reach the Android receiver, and `show()` bypasses Gson entirely,
+# so immediate notifications keep working while scheduled ones silently die.
+# That makes these rules easy to "tidy up" and impossible to notice losing.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+RULES="$ROOT_DIR/app/android/app/proguard-rules.pro"
+
+if [ ! -f "$RULES" ]; then
+  echo "::error::ProGuard rules not found: $RULES"
+  exit 1
+fi
+
+# Every Android flavour builds from this one ProGuard file but declares its own
+# dependencies, so the plugin has to be looked for across all of them. Checking
+# only app/pubspec.yaml would let the guard fall silent if the phone flavour
+# dropped the plugin while Airo TV -- which schedules EPG reminders -- kept it.
+users=()
+for pubspec in "$ROOT_DIR"/app/pubspec*.yaml; do
+  [ -f "$pubspec" ] || continue
+  if grep -q "flutter_local_notifications" "$pubspec"; then
+    users+=("$(basename "$pubspec")")
+  fi
+done
+
+if [ ${#users[@]} -eq 0 ]; then
+  echo "No flavour depends on flutter_local_notifications; Gson keep rules not required."
+  exit 0
+fi
+
+echo "Flavours scheduling notifications: ${users[*]}"
+
+missing=()
+require() {
+  grep -qF -- "$1" "$RULES" || missing+=("$1")
+}
+
+# The Gson-serialized models and their fields. Both rules are checked in full
+# rather than by shared substring: the class-level and member-level rules share
+# the `...models.` prefix, so a prefix match would still pass with one of them
+# deleted -- which a mutation test caught.
+require "-keep class com.dexterous.flutterlocalnotifications.models.** { *; }"
+require "-keepclassmembers class com.dexterous.flutterlocalnotifications.models.** { <fields>; }"
+# Polymorphic style types (BigTextStyleInformation and friends) resolve by name.
+require "com.dexterous.flutterlocalnotifications.RuntimeTypeAdapterFactory"
+# Anonymous TypeToken subclasses carry the generic signature Gson needs.
+require "com.google.gson.reflect.TypeToken"
+# TypeToken cannot resolve generics without the Signature attribute.
+require "-keepattributes Signature"
+
+if [ ${#missing[@]} -gt 0 ]; then
+  for m in "${missing[@]}"; do
+    echo "::error file=app/android/app/proguard-rules.pro::Missing R8 keep rule: $m"
+  done
+  echo "::error::Scheduled notifications deserialize through Gson and will silently"
+  echo "::error::produce empty notifications in release builds without these rules."
+  exit 1
+fi
+
+echo "Gson keep rules for scheduled notifications are present."


### PR DESCRIPTION
Follow-up to the R8 keep rules that landed on main in `9868f48f` (#1394). The squash there captured only the first commit, so the guard and its wiring were left behind — this brings both.

## Why a guard at all

Those keep rules are the only thing keeping scheduled notifications alive in release builds, and **nothing in the test suite can notice if they disappear**:

- debug builds have no R8
- widget tests never reach the Android receiver
- `show()` bypasses Gson, so immediate notifications keep working either way

That combination makes the rules easy to remove during an unrelated ProGuard cleanup and impossible to miss losing until users stop getting reminders.

## Both halves, deliberately

The check **and** its workflow wiring are in this PR. A check no workflow references never runs — the same inert-gate shape this run of work has been unpicking (#1388, #1389, #1392). I caught myself shipping exactly that in the previous branch.

## Flavour-aware, not phone-only

The check looks for the plugin across every `app/pubspec*.yaml`, not just `app/pubspec.yaml`.

Flavours are separate pubspecs but share one `proguard-rules.pro`, and **Airo TV schedules EPG reminders**. Keying on the phone pubspec would let the guard fall silent if the phone flavour ever dropped the plugin while TV kept it. Current state:

| pubspec | declares plugin |
|---|---|
| `pubspec.yaml` | yes |
| `pubspec_tv.yaml` | yes |
| `pubspec_ios_spm.yaml` | yes |
| `pubspec_coins.yaml` | no |

Verified against a synthetic tree where **only** `pubspec_tv.yaml` declares it: the check still enforces, and exits 1 when the rules are stripped.

## Verification

| case | result |
|---|---|
| rules present | pass |
| any one of the 5 required rules deleted | fail (mutation tested, 5/5 caught) |
| only TV declares the plugin, rules stripped | fail — exit 1 |
| no flavour declares the plugin | skip, exit 0 |

An earlier version keyed on the shared `...models.` substring and **passed** with the class-level rule deleted, because the member-level rule still contained that text. Mutation testing caught it; each rule is now matched in full.

🤖 Generated with [Claude Code](https://claude.com/claude-code)