### PR TITLE
ci(release): let only the orchestrator publish on a version tag

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -1,9 +1,21 @@
 name: Build and Release
 
+# Not triggered by tags. release-orchestrator.yml also fires on `v*`, so while
+# both were tag-triggered a single version tag started two workflows that each
+# published a GitHub Release for it, last writer winning. They do not agree on
+# what a release is: the orchestrator fails closed (missing manifest, missing
+# required asset, or ungenerated notes each exit 1) and covers TV, mobile/tablet
+# and macOS with qualification reports, while this one was built to tolerate
+# partial platform failures.
+#
+# The collision has never actually fired: this workflow ran alone on
+# v0.0.4-rc.2 (2026-07-19), the orchestrator gained its `v*` trigger on
+# 2026-07-22, and no `v*` tag has been pushed since -- only `airo-tv-v*`, which
+# `v*` does not match. The next Airo version tag would have been the first.
+#
+# Kept on workflow_dispatch so the legacy path stays available deliberately
+# rather than by accident.
 on:
-  push:
-    tags:
-      - 'v*'
   workflow_dispatch:
     inputs:
       version:


### PR DESCRIPTION
Closes #1393. Filed as an issue earlier because retiring a release path is an ownership call — this is the change itself so accepting or rejecting it is one click. **Close this if you want both workflows tag-triggered.**

## The problem

Both workflows fire on `v*`, so one version tag starts two workflows that each create a GitHub Release for that tag. Last writer wins.

They disagree on what a release is:

| | `release-orchestrator.yml` | `build-and-release.yml` |
|---|---|---|
| missing manifest / required asset / notes | `exit 1` | publishes what exists |
| coverage | TV, mobile/tablet, macOS + qualification reports | phone + desktop |
| posture | fails closed | tolerates partial platform failures |

Tolerating partial failures is reasonable for desktop, but it means this workflow will publish whatever happens to be there.

## It has never actually fired

```
2026-07-19  v0.0.4-rc.2 tagged   -> build-and-release.yml ran alone and published
2026-07-22  orchestrator gains its v* trigger  (9e1fb5c2)
since       no v* tag pushed -- only airo-tv-v*, which `v*` does not match
```

So the collision is latent and untested, and **the next Airo version tag is the first time it fires** — with v0.0.6 work having just landed.

## Change

Remove the tag trigger here; keep `workflow_dispatch` so the legacy path stays available deliberately rather than by accident.

Verified after the change:

```
build-and-release:     triggers=workflow_dispatch  tags=(none)
release-orchestrator:  triggers=push,workflow_dispatch  tags=v*,airo-tv-v*
```

`scripts/check-build-profiles.py` still exits 0.

## If you'd rather keep both

The other resolution is to make `build-and-release.yml` fail closed like the orchestrator. #1392 already added the Android artifact guard and the signing hard-fail there, so it is closer than it was — but two workflows publishing the same tag would still race, and that is the part this PR is actually about.

🤖 Generated with [Claude Code](https://claude.com/claude-code)