### PR TITLE
feat(release): add coins profile to the mobile/tablet release workflow

### DIFF
--- a/.github/workflows/airo-mobile-tablet-release.yml
+++ b/.github/workflows/airo-mobile-tablet-release.yml
@@ -62,6 +62,7 @@ on:
         type: choice
         options:
           - full
+          - coins
       version:
         description: 'Artifact and release version label'
         required: true
@@ -218,6 +219,14 @@ jobs:
               echo "APP_PLATFORM=mobileFull" >> "$GITHUB_ENV"
               echo "PACKAGE_ID=io.airo.app" >> "$GITHUB_ENV"
               echo "ARTIFACT_PREFIX=Airo" >> "$GITHUB_ENV"
+              ;;
+            coins)
+              echo "TARGET_ENTRYPOINT=lib/main_coins.dart" >> "$GITHUB_ENV"
+              echo "PROFILE_PUBSPEC=pubspec_coins.yaml" >> "$GITHUB_ENV"
+              echo "APP_VARIANT=coins" >> "$GITHUB_ENV"
+              echo "APP_PLATFORM=mobileFull" >> "$GITHUB_ENV"
+              echo "PACKAGE_ID=io.airo.app.coins" >> "$GITHUB_ENV"
+              echo "ARTIFACT_PREFIX=AiroCoins" >> "$GITHUB_ENV"
               ;;
             *)
               echo "::error::Unsupported mobile/tablet profile: $PROFILE"
@@ -576,6 +585,10 @@ jobs:
               echo "PACKAGE_ID=io.airo.app" >> "$GITHUB_ENV"
               echo "ARTIFACT_PREFIX=Airo" >> "$GITHUB_ENV"
               ;;
+            coins)
+              echo "PACKAGE_ID=io.airo.app.coins" >> "$GITHUB_ENV"
+              echo "ARTIFACT_PREFIX=AiroCoins" >> "$GITHUB_ENV"
+              ;;
             *)
               echo "::error::Unsupported mobile/tablet profile for Play upload: $PROFILE"
               exit 1
@@ -666,6 +679,10 @@ jobs:
             full)
               echo "PACKAGE_ID=io.airo.app" >> "$GITHUB_ENV"
               echo "ARTIFACT_PREFIX=Airo" >> "$GITHUB_ENV"
+              ;;
+            coins)
+              echo "PACKAGE_ID=io.airo.app.coins" >> "$GITHUB_ENV"
+              echo "ARTIFACT_PREFIX=AiroCoins" >> "$GITHUB_ENV"
               ;;
             *)
               echo "::error::Unsupported mobile/tablet profile for Firebase distribution: $PROFILE"


### PR DESCRIPTION
## Why

Coins was deferred from the v0.0.6-rc.1 wave (CI qualification only). Reversing that — Coins should ship. This wires `coins` into the mobile/tablet release workflow so it builds signed through the same machinery as `full`.

## Change

`airo-mobile-tablet-release.yml`:
- `coins` added to the `workflow_dispatch` profile choice.
- `coins` case in the build, play-upload, and firebase profile-metadata switches → `PACKAGE_ID=io.airo.app.coins`, `ARTIFACT_PREFIX=AiroCoins`, `main_coins.dart`, `pubspec_coins.yaml`, `mobileFull`.

The #1387 pubspec-swap guard (`PROFILE_PUBSPEC != pubspec.yaml`) already lets the coins pubspec swap in.

## Result

`AiroCoins-<version>-<code>-arm64.apk` + AAB, dogfood/production-signed, SHA256-manifested — same shape as the full/TV artifacts. Enables a standalone coins dispatch to attach to `v0.0.6-rc.1`.

## Note

Open bug #1240 (Coins black screen on Pixel 9 / Android 17) still applies — coins ships as preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)