### PR TITLE
fix(tv): retain focus across playback and settings overlays

### DIFF
--- a/app/lib/core/app/tv_shell.dart
+++ b/app/lib/core/app/tv_shell.dart
@@ -77,7 +77,13 @@ class _TvShellState extends ConsumerState<TvShell> {
                 padding: EdgeInsets.only(
                   left: isPlayerFullscreen ? 0 : _tvNavigationRailWidth,
                 ),
-                child: widget.child,
+                // Non-live destinations are painted over the retained live
+                // surface. Keep that surface mounted for playback, but never
+                // leave its controls in the focus graph behind an overlay.
+                child: ExcludeFocus(
+                  excluding: _overlay != null,
+                  child: widget.child,
+                ),
               ),
             ),
           ),

--- a/app/lib/features/settings/presentation/tv/tv_settings_screen.dart
+++ b/app/lib/features/settings/presentation/tv/tv_settings_screen.dart
@@ -29,6 +29,35 @@ class _TvSettingsScreenState extends ConsumerState<TvSettingsScreen> {
   static final _sections = iptvSettingsSections
       .where((section) => section.isVisibleFor(ShellId.tv))
       .toList(growable: false);
+  late final Map<IptvSettingsSectionId, FocusNode> _sectionFocusNodes = {
+    for (final section in _sections)
+      section.id: FocusNode(debugLabel: 'TV settings ${section.id.name}'),
+  };
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      _sectionFocusNodes[_selected]?.requestFocus();
+      // Fire TV may restore the rail item that launched this overlay after
+      // its first frame. Reassert the section target once that restoration
+      // has completed so selected styling and actual D-pad focus cannot
+      // diverge.
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (!mounted) return;
+        _sectionFocusNodes[_selected]?.requestFocus();
+      });
+    });
+  }
+
+  @override
+  void dispose() {
+    for (final node in _sectionFocusNodes.values) {
+      node.dispose();
+    }
+    super.dispose();
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -48,6 +77,7 @@ class _TvSettingsScreenState extends ConsumerState<TvSettingsScreen> {
                     Padding(
                       padding: const EdgeInsets.only(bottom: 8),
                       child: TvFocusable(
+                        focusNode: _sectionFocusNodes[section.id],
                         autofocus: section.id == IptvSettingsSectionId.theme,
                         onSelect: () => setState(() => _selected = section.id),
                         semanticLabel: section.labelFor(ShellId.tv),

--- a/app/test/core/app/tv_shell_test.dart
+++ b/app/test/core/app/tv_shell_test.dart
@@ -1,8 +1,10 @@
 import 'package:airo_app/core/app/tv_router.dart';
 import 'package:airo_app/core/app/tv_shell.dart';
+import 'package:core_ui/core_ui.dart';
 import 'package:feature_iptv/feature_iptv.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
@@ -85,4 +87,80 @@ void main() {
 
     expect(find.byKey(const Key('tv-sidebar-nav')), findsOneWidget);
   });
+
+  testWidgets(
+    'Settings overlay claims Theme focus and excludes retained live controls',
+    (tester) async {
+      final liveFocus = FocusNode(debugLabel: 'retained live action');
+      addTearDown(liveFocus.dispose);
+      var liveActivations = 0;
+
+      await tester.pumpWidget(
+        ProviderScope(
+          child: MaterialApp(
+            home: TvShell(
+              child: Align(
+                alignment: Alignment.topLeft,
+                child: TvFocusable(
+                  focusNode: liveFocus,
+                  autofocus: true,
+                  onSelect: () => liveActivations++,
+                  child: const SizedBox(
+                    width: 160,
+                    height: 56,
+                    child: Text('Live action'),
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final settingsRailItem = tester.widget<TvFocusable>(
+        find.ancestor(
+          of: find.text('Settings'),
+          matching: find.byType(TvFocusable),
+        ),
+      );
+      settingsRailItem.focusNode!.requestFocus();
+      await tester.pump();
+      await tester.sendKeyEvent(LogicalKeyboardKey.select);
+      await tester.pump();
+
+      // Fire TV restores the launching rail item after the overlay's first
+      // frame. The overlay must reclaim focus on the following frame.
+      settingsRailItem.focusNode!.requestFocus();
+      await tester.pump();
+      await tester.pumpAndSettle();
+
+      final themeItem = tester.widget<TvFocusable>(
+        find.ancestor(
+          of: find.text('Theme'),
+          matching: find.byType(TvFocusable),
+        ),
+      );
+      expect(themeItem.focusNode?.hasPrimaryFocus, isTrue);
+      expect(liveFocus.canRequestFocus, isFalse);
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+      await tester.pump();
+      final playbackItem = tester.widget<TvFocusable>(
+        find.ancestor(
+          of: find.text('Playback'),
+          matching: find.byType(TvFocusable),
+        ),
+      );
+      expect(playbackItem.focusNode?.hasPrimaryFocus, isTrue);
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.select);
+      await tester.pumpAndSettle();
+      expect(
+        find.byKey(const ValueKey('tv_settings_section_playback')),
+        findsOneWidget,
+      );
+      expect(liveActivations, 0);
+    },
+  );
 }

--- a/packages/feature_iptv/lib/presentation/widgets/playlist_source_manager_sheet.dart
+++ b/packages/feature_iptv/lib/presentation/widgets/playlist_source_manager_sheet.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:core_ui/core_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -58,6 +60,7 @@ class _PlaylistSourceManagerSheetState
   final _cancelFocusNode = FocusNode(debugLabel: 'playlist source cancel');
   final _saveFocusNode = FocusNode(debugLabel: 'playlist source save');
   late final List<FocusNode> _presetFocusNodes;
+  Timer? _presetSaveFocusTimer;
   bool _showAddForm = false;
   bool _isSaving = false;
   bool _initialTvFocusScheduled = false;
@@ -91,6 +94,7 @@ class _PlaylistSourceManagerSheetState
 
   @override
   void dispose() {
+    _presetSaveFocusTimer?.cancel();
     _labelController.dispose();
     _urlController.dispose();
     _addSourceFocusNode.dispose();
@@ -134,17 +138,20 @@ class _PlaylistSourceManagerSheetState
   bool get _textFieldOwnsFocus =>
       _labelFocusNode.hasFocus || _urlFocusNode.hasFocus;
 
-  void _requestTvFocus(FocusNode focusNode) {
+  void _requestTvFocus(
+    FocusNode focusNode, {
+    bool preserveTextFieldFocus = true,
+  }) {
     if (!_isTenFootMode) return;
     WidgetsBinding.instance.addPostFrameCallback((_) {
-      if (!mounted || !focusNode.canRequestFocus || _textFieldOwnsFocus) return;
+      if (!mounted || !focusNode.canRequestFocus) return;
+      if (preserveTextFieldFocus && _textFieldOwnsFocus) return;
       focusNode.requestFocus();
       // Fire TV restores the launching control after the modal's first frame.
       // Reassert the sheet's first target once that restoration has completed.
       WidgetsBinding.instance.addPostFrameCallback((_) {
-        if (!mounted || !focusNode.canRequestFocus || _textFieldOwnsFocus) {
-          return;
-        }
+        if (!mounted || !focusNode.canRequestFocus) return;
+        if (preserveTextFieldFocus && _textFieldOwnsFocus) return;
         focusNode.requestFocus();
       });
     });
@@ -178,6 +185,15 @@ class _PlaylistSourceManagerSheetState
       _labelError = null;
       _urlError = null;
       _submitError = null;
+    });
+    // A preset is already complete. On TV, move straight to the save action
+    // instead of making the viewer traverse two populated text fields and
+    // unnecessarily opening the platform keyboard.
+    _requestTvFocus(_saveFocusNode, preserveTextFieldFocus: false);
+    _presetSaveFocusTimer?.cancel();
+    _presetSaveFocusTimer = Timer(const Duration(milliseconds: 250), () {
+      if (!mounted || !_saveFocusNode.canRequestFocus) return;
+      _saveFocusNode.requestFocus();
     });
   }
 

--- a/packages/feature_iptv/lib/presentation/widgets/video_player_widget.dart
+++ b/packages/feature_iptv/lib/presentation/widgets/video_player_widget.dart
@@ -167,6 +167,8 @@ class _VideoPlayerWidgetState extends ConsumerState<VideoPlayerWidget> {
   final FocusNode _genericRetryFocusNode = FocusNode(
     debugLabel: 'player recovery Try Again',
   );
+  Timer? _tvPlaybackFocusTimer;
+  String? _lastTvPlaybackFocusChannelId;
   FocusNode? _contextMenuRestoreFocusNode;
   bool _playerModalOpen = false;
   String? _lastRecoveryFocusToken;
@@ -244,6 +246,7 @@ class _VideoPlayerWidgetState extends ConsumerState<VideoPlayerWidget> {
     _channelChangeOverlayTimer?.cancel();
     _adjacentChannelWarmupDebounce?.cancel();
     _selectLongPressTimer?.cancel();
+    _tvPlaybackFocusTimer?.cancel();
     _playerFocusNode.dispose();
     _centerControlFocusNode.dispose();
     _restartTransportFocusNode.dispose();
@@ -929,6 +932,7 @@ class _VideoPlayerWidgetState extends ConsumerState<VideoPlayerWidget> {
     required bool isPipActive,
   }) {
     _scheduleRecoveryFocus(state);
+    _scheduleTvPlaybackFocus(state);
     // Update wakelock based on current playback state
     // This is called on every build when state changes
     WidgetsBinding.instance.addPostFrameCallback((_) {
@@ -1322,6 +1326,54 @@ class _VideoPlayerWidgetState extends ConsumerState<VideoPlayerWidget> {
       if (!mounted || _lastRecoveryFocusToken != token) return;
       if (target.canRequestFocus) target.requestFocus();
     });
+  }
+
+  void _scheduleTvPlaybackFocus(StreamingState state) {
+    if (!widget.useTvTransportBar) return;
+    final channelId = state.currentChannel?.id;
+    final readyForControls =
+        channelId != null &&
+        state.isPlaying &&
+        !state.hasError &&
+        !state.isLoading &&
+        !state.isBuffering;
+    if (!readyForControls) {
+      _lastTvPlaybackFocusChannelId = null;
+      _tvPlaybackFocusTimer?.cancel();
+      return;
+    }
+    if (_lastTvPlaybackFocusChannelId == channelId) return;
+    _lastTvPlaybackFocusChannelId = channelId;
+
+    void claimTransportFocus() {
+      if (!mounted || _lastTvPlaybackFocusChannelId != channelId) return;
+      // Never reset deliberate movement within the transport or steal from a
+      // player-owned modal. The delayed claim exists only to beat focus that
+      // escaped back to the retained channel grid.
+      if (_controlsHaveFocus || _playerModalOpen || _showContextMenu) return;
+      if (!_showControlsOverlay) {
+        setState(() => _showControlsOverlay = true);
+      }
+      if (_centerControlFocusNode.canRequestFocus) {
+        _centerControlFocusNode.requestFocus();
+      }
+    }
+
+    // The channel grid remains mounted behind fullscreen playback. Fire OS
+    // can restore its old card focus after Flutter's first frame, leaving the
+    // visible transport unable to receive CENTER. Reclaim once after layout,
+    // once after the following frame, and once after Fire's delayed restore.
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      claimTransportFocus();
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        claimTransportFocus();
+      });
+    });
+    _tvPlaybackFocusTimer?.cancel();
+    _tvPlaybackFocusTimer = Timer(
+      const Duration(milliseconds: 250),
+      claimTransportFocus,
+    );
   }
 
   void _scheduleGenericRecoveryFocus(String message) {

--- a/packages/feature_iptv/test/iptv/presentation/widgets/playlist_source_manager_sheet_test.dart
+++ b/packages/feature_iptv/test/iptv/presentation/widgets/playlist_source_manager_sheet_test.dart
@@ -255,6 +255,47 @@ void main() {
         urlField.controller?.text,
         'https://iptv-org.github.io/iptv/index.m3u',
       );
+      final saveButton = find.byKey(
+        const ValueKey('playlist-source-save-button'),
+      );
+      final saveFocusable = tester.widget<TvFocusable>(
+        find.ancestor(of: saveButton, matching: find.byType(TvFocusable)),
+      );
+      expect(saveFocusable.focusNode?.hasPrimaryFocus, isTrue);
     },
   );
+
+  testWidgets('TV preset takes save focus back from a stale text field', (
+    tester,
+  ) async {
+    final container = await buildContainer();
+    addTearDown(container.dispose);
+    await pumpTvManagerDialog(tester, container);
+
+    await tester.sendKeyEvent(LogicalKeyboardKey.select);
+    await tester.pumpAndSettle();
+
+    final labelField = tester.widget<TextField>(
+      find.byKey(const ValueKey('playlist-source-label-field')),
+    );
+    labelField.focusNode?.requestFocus();
+    await tester.pump();
+    expect(labelField.focusNode?.hasPrimaryFocus, isTrue);
+
+    await tester.tap(find.widgetWithText(ActionChip, 'All channels'));
+    await tester.pump(const Duration(milliseconds: 100));
+    // Fire OS can restore the field after Flutter's immediate post-frame
+    // requests. The delayed preset reassertion must still win.
+    labelField.focusNode?.requestFocus();
+    await tester.pump(const Duration(milliseconds: 200));
+    await tester.pumpAndSettle();
+
+    final saveButton = find.byKey(
+      const ValueKey('playlist-source-save-button'),
+    );
+    final saveFocusable = tester.widget<TvFocusable>(
+      find.ancestor(of: saveButton, matching: find.byType(TvFocusable)),
+    );
+    expect(saveFocusable.focusNode?.hasPrimaryFocus, isTrue);
+  });
 }

--- a/packages/feature_iptv/test/presentation/widgets/video_player_widget_tv_transport_bar_test.dart
+++ b/packages/feature_iptv/test/presentation/widgets/video_player_widget_tv_transport_bar_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:feature_iptv/feature_iptv.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -16,6 +18,8 @@ void main() {
     required double width,
     Duration liveDelay = Duration.zero,
     VideoPlayerStreamingService? service,
+    Stream<StreamingState>? states,
+    FocusNode? retainedFocusNode,
   }) async {
     SharedPreferences.setMockInitialValues({});
     final prefs = await SharedPreferences.getInstance();
@@ -25,20 +29,22 @@ void main() {
         if (service != null)
           iptvStreamingServiceProvider.overrideWithValue(service),
         streamingStateProvider.overrideWith(
-          (ref) => Stream.value(
-            StreamingState(
-              playbackState: PlaybackState.playing,
-              isLiveStream: true,
-              liveDelay: liveDelay,
-              currentQuality: VideoQuality.high,
-              currentChannel: IPTVChannel(
-                id: 'news-1',
-                name: 'City News Live',
-                streamUrl: 'https://example.com/news.m3u8',
-                group: 'News',
+          (ref) =>
+              states ??
+              Stream.value(
+                StreamingState(
+                  playbackState: PlaybackState.playing,
+                  isLiveStream: true,
+                  liveDelay: liveDelay,
+                  currentQuality: VideoQuality.high,
+                  currentChannel: IPTVChannel(
+                    id: 'news-1',
+                    name: 'City News Live',
+                    streamUrl: 'https://example.com/news.m3u8',
+                    group: 'News',
+                  ),
+                ),
               ),
-            ),
-          ),
         ),
       ],
     );
@@ -49,13 +55,22 @@ void main() {
         container: container,
         child: MaterialApp(
           home: Scaffold(
-            body: SizedBox(
-              width: width,
-              height: 540,
-              child: const VideoPlayerWidget(
-                initiallyFullscreen: true,
-                useTvTransportBar: true,
-              ),
+            body: Stack(
+              children: [
+                SizedBox(
+                  width: width,
+                  height: 540,
+                  child: const VideoPlayerWidget(
+                    initiallyFullscreen: true,
+                    useTvTransportBar: true,
+                  ),
+                ),
+                if (retainedFocusNode != null)
+                  Focus(
+                    focusNode: retainedFocusNode,
+                    child: const SizedBox.shrink(),
+                  ),
+              ],
             ),
           ),
         ),
@@ -136,6 +151,49 @@ void main() {
 
     expect(find.text('Actions for'), findsOneWidget);
   });
+
+  testWidgets(
+    'playing channel reclaims transport focus after retained-grid restore',
+    (tester) async {
+      final states = StreamController<StreamingState>();
+      final retainedFocusNode = FocusNode(debugLabel: 'retained channel card');
+      addTearDown(states.close);
+      addTearDown(retainedFocusNode.dispose);
+      await pumpTransportBar(
+        tester,
+        width: 960,
+        states: states.stream,
+        retainedFocusNode: retainedFocusNode,
+      );
+      retainedFocusNode.requestFocus();
+      await tester.pump();
+
+      states.add(
+        StreamingState(
+          playbackState: PlaybackState.playing,
+          isLiveStream: true,
+          currentChannel: IPTVChannel(
+            id: 'news-1',
+            name: 'City News Live',
+            streamUrl: 'https://example.com/news.m3u8',
+          ),
+        ),
+      );
+      await tester.pump();
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 100));
+      retainedFocusNode.requestFocus();
+      await tester.pump();
+      expect(retainedFocusNode.hasPrimaryFocus, isTrue);
+
+      await tester.pump(const Duration(milliseconds: 150));
+
+      expect(
+        FocusManager.instance.primaryFocus?.debugLabel,
+        'player center control',
+      );
+    },
+  );
 
   testWidgets(
     'transport stays visible beyond auto-hide while a D-pad control is focused',


### PR DESCRIPTION
Closes #1272

## What changed
- exclude retained playback from focus while the TV shell overlay is open
- reassert deterministic Theme focus when Settings opens over retained playback
- make IPTV.org presets land on Add source after Fire OS restores a stale text-field focus
- hand newly playing TV channels from the retained grid to the visible Pause transport control
- add regression coverage for delayed Fire OS focus restoration

## Qualification
- Physical device: Amazon Fire TV AFTSSS at 192.168.1.9:5555
- Candidate commit: 11831912b2158657ab1009ac0962da70530620ed
- v7a APK SHA-256: c5a941775a919133dea99ac4b23634dad8817dfdb0c88ea3eadcad0b4c5b9cae
- Official build: bash scripts/build-tv.sh --apk-only --split-per-abi
- Build checks: compileSdk 36, targetSdk 36, TV minimum check passed
- Hardware: delayed preset focus remains on Add source with no IME surface; TV ITN stable over 30 seconds; Pause visibly focused; MediaSession 3 -> 2 -> 3; Player Actions starts on Listen only and omits PiP; BACK restores playback/grid; sidebar bridge and Settings Theme focus verified over retained playback
- Local: 7 playlist-source widget tests, 34 player/recovery/modal tests, 3 TV shell/settings focus tests, and the ten-foot Ways-to-Watch exclusion test pass; targeted analyzer is clean
- Logcat: no Airo fatal exception, ANR, or playback-engine fatal found

QR/pairing safety: any capture that showed the Fire OS keyboard QR was deleted immediately and is not retained or attached.