### PR TITLE
fix(iptv): remove playlist sources consistently

### DIFF
--- a/packages/feature_iptv/lib/application/providers/content_source_management_providers.dart
+++ b/packages/feature_iptv/lib/application/providers/content_source_management_providers.dart
@@ -251,10 +251,10 @@ final addJellyfinContentSourceProvider = FutureProvider.autoDispose
       keepAlive.close();
     });
 
-/// Removes a content source by id and deletes any credential stored for it
-/// via [contentSourceCredentialStoreProvider] — otherwise a removed source
-/// leaves an orphaned secret behind with no owner. Invalidates
-/// [configuredContentSourcesProvider] afterwards.
+/// Removes a content source by id and deletes credentials for source kinds
+/// that own them. Credential cleanup happens before the source record is
+/// removed so a secure-store failure cannot report failure after deletion.
+/// Invalidates [configuredContentSourcesProvider] afterwards.
 final removeContentSourceProvider = FutureProvider.autoDispose
     .family<void, String>((ref, id) async {
       final keepAlive = ref.keepAlive();
@@ -275,14 +275,17 @@ final removeContentSourceProvider = FutureProvider.autoDispose
           }
           await ref.read(m3uSourceParserFactoryProvider)(id).clearPlaylist();
         }
+        if (removed?.kind == ContentSourceKind.xtream ||
+            removed?.kind == ContentSourceKind.jellyfin) {
+          await ref
+              .watch(contentSourceCredentialStoreProvider)
+              .delete(ContentSourceCredentialRef(id));
+        }
         final store = ref.watch(contentSourceStoreProvider);
         await store.remove(id);
         if (await store.getActiveSourceId() == id) {
           await store.setActiveSourceId(null);
         }
-        await ref
-            .watch(contentSourceCredentialStoreProvider)
-            .delete(ContentSourceCredentialRef(id));
         ref.read(providerHealthTrackerProvider).clearFor(id);
         final epgRepository = ref.read(compactEpgRepositoryProvider);
         if (epgRepository is MutableXmltvCompactEpgRepository) {

--- a/packages/feature_iptv/lib/presentation/widgets/playlist_source_manager_sheet.dart
+++ b/packages/feature_iptv/lib/presentation/widgets/playlist_source_manager_sheet.dart
@@ -64,6 +64,7 @@ class _PlaylistSourceManagerSheetState
   bool _showAddForm = false;
   bool _isSaving = false;
   bool _initialTvFocusScheduled = false;
+  final Set<String> _removedSourceIds = {};
   String? _labelError;
   String? _urlError;
   String? _submitError;
@@ -272,10 +273,12 @@ class _PlaylistSourceManagerSheetState
     );
     if (confirmed != true) return;
 
+    setState(() => _removedSourceIds.add(source.id));
     try {
       await ref.read(removeContentSourceProvider(source.id).future);
     } catch (_) {
       if (!mounted) return;
+      setState(() => _removedSourceIds.remove(source.id));
       ScaffoldMessenger.of(context).showSnackBar(
         const SnackBar(content: Text('Could not remove the playlist.')),
       );
@@ -344,7 +347,11 @@ class _PlaylistSourceManagerSheetState
                   ),
                   data: (allSources) {
                     final sources = allSources
-                        .where((source) => source.kind == ContentSourceKind.m3u)
+                        .where(
+                          (source) =>
+                              source.kind == ContentSourceKind.m3u &&
+                              !_removedSourceIds.contains(source.id),
+                        )
                         .toList(growable: false);
                     if (sources.isEmpty) {
                       return DecoratedBox(

--- a/packages/feature_iptv/test/iptv/application/providers/content_source_management_providers_test.dart
+++ b/packages/feature_iptv/test/iptv/application/providers/content_source_management_providers_test.dart
@@ -6,17 +6,26 @@ import 'package:core_data/core_data.dart';
 import 'package:platform_playlist/platform_playlist.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
+class _ThrowingDeleteSecureStore extends InMemorySecureStore {
+  @override
+  Future<void> delete({required String key}) {
+    throw StateError('Secure storage is unavailable.');
+  }
+}
+
 void main() {
   setUp(() {
     SharedPreferences.setMockInitialValues({});
   });
 
-  Future<ProviderContainer> buildContainer() async {
+  Future<ProviderContainer> buildContainer({SecureStore? secureStore}) async {
     final prefs = await SharedPreferences.getInstance();
     return ProviderContainer(
       overrides: [
         sharedPreferencesProvider.overrideWithValue(prefs),
-        secureStoreProvider.overrideWithValue(InMemorySecureStore()),
+        secureStoreProvider.overrideWithValue(
+          secureStore ?? InMemorySecureStore(),
+        ),
         xtreamAuthenticatorProvider.overrideWithValue(
           ({
             required String serverUrl,
@@ -309,21 +318,16 @@ void main() {
       final container = await buildContainer();
       addTearDown(container.dispose);
       await container.read(
-        addM3uContentSourceProvider((
-          label: 'My Playlist',
-          url: 'https://example.com/playlist.m3u',
+        addJellyfinContentSourceProvider((
+          label: 'Home Jellyfin',
+          url: 'https://jellyfin.example.com',
+          username: 'u',
+          password: 'p',
         )).future,
       );
       final id = (await container.read(
         configuredContentSourcesProvider.future,
       )).single.id;
-      await container
-          .read(contentSourceCredentialStoreProvider)
-          .save(
-            ContentSourceCredentialRef(id),
-            const ContentSourceCredentials(username: 'u', password: 'p'),
-          );
-
       await container.read(removeContentSourceProvider(id).future);
 
       final sources = await container.read(
@@ -336,6 +340,29 @@ void main() {
       expect(credential, isNull);
     },
   );
+
+  test('M3U removal does not require secure storage', () async {
+    final container = await buildContainer(
+      secureStore: _ThrowingDeleteSecureStore(),
+    );
+    addTearDown(container.dispose);
+    await container.read(
+      addM3uContentSourceProvider((
+        label: 'My Playlist',
+        url: 'https://example.com/playlist.m3u',
+      )).future,
+    );
+    final id = (await container.read(
+      configuredContentSourcesProvider.future,
+    )).single.id;
+
+    await container.read(removeContentSourceProvider(id).future);
+
+    expect(
+      await container.read(configuredContentSourcesProvider.future),
+      isEmpty,
+    );
+  });
 
   test('removing a migrated legacy playlist prevents remigration', () async {
     const legacyUrl = 'https://iptv-org.github.io/iptv/index.m3u';

--- a/packages/feature_iptv/test/iptv/presentation/widgets/playlist_source_manager_sheet_test.dart
+++ b/packages/feature_iptv/test/iptv/presentation/widgets/playlist_source_manager_sheet_test.dart
@@ -186,10 +186,11 @@ void main() {
       findsOneWidget,
     );
     await tester.tap(find.widgetWithText(FilledButton, 'Remove'));
-    await tester.pumpAndSettle();
+    await tester.pump();
 
     expect(find.widgetWithText(ListTile, 'News'), findsNothing);
     expect(find.widgetWithText(ListTile, 'Sports'), findsOneWidget);
+    await tester.pumpAndSettle();
     final sources = await container.read(
       configuredContentSourcesProvider.future,
     );


### PR DESCRIPTION
# Summary

This PR fixes playlist removal discovered during physical Pixel 9 qualification of the multi-playlist touch manager.

Core outcome:

* Removed playlist rows disappear immediately without reopening the sheet.
* M3U removal no longer depends on secure storage that M3U sources do not use.
* Credential cleanup remains enforced for Xtream and Jellyfin sources.

# Changes

### Code

* Added optimistic row removal with rollback on genuine persistence failure.
* Limited secure credential deletion to credential-bearing source kinds.
* Ordered credential cleanup before source deletion to avoid partial-failure reporting.

# Risks

* Low: changes are confined to source removal and its transient manager state.
* Rollback: revert this single commit.

# Testing

* Provider source-management suite: passed (12 tests).
* Playlist manager widget suite: passed (7 tests after current-main rebase).
* Targeted static analysis: no issues.
* Physical Pixel 9 / Android 17:
  * Added IPTV.org By country alongside All channels.
  * Confirmed both sources persist after relaunch.
  * Confirmed Vevo Pop playback from the configured source.
  * Added and removed a temporary By category source.
  * Confirmed the row changed from 3 to 2 in the still-open sheet and persisted storage retained only the intended two sources.

# Deployment Notes

No configuration or migration changes.