### PR TITLE
fix(mind): handle empty prompt lab image results

### DIFF
--- a/app/lib/features/mind/presentation/screens/prompt_lab_screen.dart
+++ b/app/lib/features/mind/presentation/screens/prompt_lab_screen.dart
@@ -290,14 +290,19 @@ class _GeneratedImageView extends StatelessWidget {
           child: Text('The image server returned malformed image data.'),
         );
       }
-    } else {
+    } else if (image.url?.trim().isNotEmpty == true) {
       child = Image.network(
-        image.url!,
+        image.url!.trim(),
         fit: BoxFit.contain,
         errorBuilder: (context, error, stackTrace) => const Padding(
           padding: EdgeInsets.all(16),
           child: Text('The image could not be loaded from the image server.'),
         ),
+      );
+    } else {
+      child = const Padding(
+        padding: EdgeInsets.all(16),
+        child: Text('The image server returned no renderable image.'),
       );
     }
     return Card(

--- a/app/test/features/mind/presentation/screens/prompt_lab_screen_test.dart
+++ b/app/test/features/mind/presentation/screens/prompt_lab_screen_test.dart
@@ -110,4 +110,42 @@ void main() {
     expect(find.text('Revised prompt: quiet garden revised'), findsOneWidget);
     expect(find.textContaining('Image generation failed'), findsNothing);
   });
+
+  testWidgets('image mode handles empty generated image payloads safely', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: PromptLabScreen(
+          initialImageMode: true,
+          generateImage: (_) async => const Success(
+            GeneratedImage(revisedPrompt: 'server accepted the prompt'),
+          ),
+        ),
+      ),
+    );
+
+    await tester.enterText(
+      find.byType(TextField).at(0),
+      'http://127.0.0.1:8188/v1',
+    );
+    await tester.enterText(find.byType(TextField).at(1), 'quiet garden');
+    await tester.scrollUntilVisible(
+      find.text('Generate image'),
+      300,
+      scrollable: find.byType(Scrollable).first,
+    );
+    await tester.tap(find.text('Generate image'));
+    await tester.pumpAndSettle();
+
+    expect(
+      find.text('The image server returned no renderable image.'),
+      findsOneWidget,
+    );
+    expect(
+      find.text('Revised prompt: server accepted the prompt'),
+      findsOneWidget,
+    );
+    expect(tester.takeException(), isNull);
+  });
 }

--- a/docs/wiki/4.-Using-Core-Capabilities.md
+++ b/docs/wiki/4.-Using-Core-Capabilities.md
@@ -93,6 +93,14 @@ Saved meeting intelligence also generates structured local sections for summary,
 decisions, risks, open questions, follow-ups, blockers, dependencies, and next
 steps from final redacted transcript content.
 
+## Prompt Lab
+
+Prompt Lab is a controlled workspace for testing prompts before sending them to
+the selected runtime. Text mode sends the composed prompt and runtime controls
+into AI Chat. Image mode validates the configured local/private image server URL
+before making a request and reports malformed or empty image responses in the
+screen instead of crashing.
+
 ## Mobile Actions
 
 The Assistant can explain or route supported Airo actions. Sensitive device


### PR DESCRIPTION
# Summary

This PR hardens Prompt Lab image mode so invalid custom image adapters or empty image payloads render a clear in-screen message instead of crashing.

Core outcome:

* Prompt Lab safely handles generated image responses with neither base64 data nor URL
* Added widget coverage for the empty image response path
* Documented Prompt Lab image-mode failure handling in the wiki

# Testing

* cd app && flutter analyze
* cd app && flutter test test/features/mind/presentation/screens/prompt_lab_screen_test.dart --reporter=compact
* scripts/check-docs-completeness.sh --base origin/main --head HEAD
* scripts/check-v2-merge-readiness.sh --skip-fetch --base origin/main --next HEAD
