### PR TITLE
fix(mind): label tiny garden plot state

### DIFF
--- a/app/lib/features/mind/presentation/screens/mobile_actions_screen.dart
+++ b/app/lib/features/mind/presentation/screens/mobile_actions_screen.dart
@@ -94,22 +94,36 @@ class _MobileActionsScreenState extends State<MobileActionsScreen> {
                           crossAxisSpacing: 8,
                           mainAxisSpacing: 8,
                         ),
-                    itemBuilder: (context, index) => InkWell(
-                      onTap: () => _plant(index),
-                      borderRadius: BorderRadius.circular(12),
-                      child: Container(
-                        decoration: BoxDecoration(
-                          color: Colors.brown.shade100,
+                    itemBuilder: (context, index) {
+                      final isPlanted = _plantedPlots.contains(index);
+                      final plotNumber = index + 1;
+                      return Semantics(
+                        button: true,
+                        selected: isPlanted,
+                        label: isPlanted
+                            ? 'Tiny Garden plot $plotNumber, planted'
+                            : 'Tiny Garden plot $plotNumber, empty',
+                        child: InkWell(
+                          onTap: () => _plant(index),
                           borderRadius: BorderRadius.circular(12),
-                          border: Border.all(color: Colors.brown.shade300),
+                          child: Container(
+                            decoration: BoxDecoration(
+                              color: Colors.brown.shade100,
+                              borderRadius: BorderRadius.circular(12),
+                              border: Border.all(color: Colors.brown.shade300),
+                            ),
+                            child: Center(
+                              child: isPlanted
+                                  ? const Text(
+                                      '🌱',
+                                      style: TextStyle(fontSize: 30),
+                                    )
+                                  : Text('$plotNumber'),
+                            ),
+                          ),
                         ),
-                        child: Center(
-                          child: _plantedPlots.contains(index)
-                              ? const Text('🌱', style: TextStyle(fontSize: 30))
-                              : Text('${index + 1}'),
-                        ),
-                      ),
-                    ),
+                      );
+                    },
                   ),
                   const SizedBox(height: 14),
                   Wrap(

--- a/app/test/features/mind/presentation/screens/mobile_actions_screen_test.dart
+++ b/app/test/features/mind/presentation/screens/mobile_actions_screen_test.dart
@@ -27,4 +27,27 @@ void main() {
     await tester.pump();
     expect(find.text('🌱'), findsOneWidget);
   });
+
+  testWidgets('Tiny Garden plots expose accessible planted state', (
+    tester,
+  ) async {
+    await tester.pumpWidget(const MaterialApp(home: MobileActionsScreen()));
+
+    expect(_plotSemantics('Tiny Garden plot 1, empty'), findsOneWidget);
+
+    await tester.scrollUntilVisible(
+      find.text('1'),
+      500,
+      scrollable: find.byType(Scrollable).first,
+    );
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('1'));
+    await tester.pump();
+
+    expect(_plotSemantics('Tiny Garden plot 1, planted'), findsOneWidget);
+  });
 }
+
+Finder _plotSemantics(String label) => find.byWidgetPredicate(
+  (widget) => widget is Semantics && widget.properties.label == label,
+);

--- a/docs/wiki/4.-Using-Core-Capabilities.md
+++ b/docs/wiki/4.-Using-Core-Capabilities.md
@@ -106,6 +106,10 @@ screen instead of crashing.
 The Assistant can explain or route supported Airo actions. Sensitive device
 actions should remain confirmation-gated before execution.
 
+Tiny Garden keeps plot state locally for the current session. Each plot exposes
+whether it is empty or planted for assistive technology, so the garden can be
+used without relying only on the visual seedling icon.
+
 ## Model Management
 
 Use the **Model Management** prompt card or Assistant profile to open AI model


### PR DESCRIPTION
# Summary

This PR improves Tiny Garden accessibility in Mobile Actions by exposing each garden plot state through explicit labels.

Core outcome:

* Empty and planted plot states are announced clearly
* Added widget coverage for plot state labels
* Updated the wiki Mobile Actions section

# Testing

* cd app && flutter analyze
* cd app && flutter test test/features/mind/presentation/screens/mobile_actions_screen_test.dart --reporter=compact
* scripts/check-docs-completeness.sh --base origin/main --head HEAD
* scripts/check-v2-merge-readiness.sh --skip-fetch --base origin/main --next HEAD
