### PR TITLE
fix(ai): show model download queue position

### DIFF
--- a/app/test/features/settings/presentation/screens/ai_models_screen_test.dart
+++ b/app/test/features/settings/presentation/screens/ai_models_screen_test.dart
@@ -197,6 +197,59 @@ void main() {
     expect(find.textContaining('remaining'), findsOneWidget);
   });
 
+  testWidgets('queued downloads show their queue position', (tester) async {
+    SharedPreferences.setMockInitialValues({});
+
+    final registry =
+        _FakeModelRegistry(
+          compatibilityByModelId: {
+            'gemma-queued': ModelCompatibilityResult.compatible(
+              MemorySeverity.safe,
+            ),
+          },
+        )..registerModel(
+          const OfflineModelInfo(
+            id: 'gemma-queued',
+            name: 'Gemma Queued',
+            family: ModelFamily.gemma,
+            fileSizeBytes: 2048,
+            provider: AIProvider.gemma,
+          ),
+        );
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          modelRegistryProvider.overrideWithValue(registry),
+          activeDownloadsProvider.overrideWith(
+            (ref) => ActiveDownloadsNotifier(ref)
+              ..state = {
+                'gemma-queued': const ModelDownloadProgress(
+                  modelId: 'gemma-queued',
+                  totalBytes: 100,
+                  downloadedBytes: 0,
+                  status: ModelDownloadStatus.pending,
+                  queuePosition: 1,
+                ),
+              },
+          ),
+        ],
+        child: const MaterialApp(home: AIModelsScreen()),
+      ),
+    );
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 100));
+
+    expect(find.text('Queued #2'), findsOneWidget);
+    expect(find.text('0%'), findsOneWidget);
+    expect(
+      find.bySemanticsLabel(
+        RegExp(r'Download progress: Queued #2 0 percent\.'),
+      ),
+      findsOneWidget,
+    );
+  });
+
   testWidgets(
     'model card actions route through download manager and registry',
     (tester) async {

--- a/docs/wiki/5.-AI-and-Model-Management.md
+++ b/docs/wiki/5.-AI-and-Model-Management.md
@@ -107,6 +107,10 @@ You can:
   use
 - download, delete, or activate supported offline packages from the browser
 
+Queued downloads show their current queue position when the platform reports
+one, so a model waiting behind another artifact does not look like a stuck 0%
+download.
+
 Downloaded offline packages are re-discovered when the app starts, so models
 that already exist on disk appear again in the **Downloaded** tab without
 requiring a second download. This applies to both current LiteRT package

--- a/packages/core_ai/lib/src/download/model_download_progress.dart
+++ b/packages/core_ai/lib/src/download/model_download_progress.dart
@@ -117,6 +117,9 @@ class ModelDownloadProgress {
   String get statusDisplay {
     switch (status) {
       case ModelDownloadStatus.pending:
+        if (queuePosition != null && queuePosition! >= 0) {
+          return 'Queued #${queuePosition! + 1}';
+        }
         return 'Queued';
       case ModelDownloadStatus.downloading:
         return 'Downloading';

--- a/packages/core_ai/test/download/model_download_progress_test.dart
+++ b/packages/core_ai/test/download/model_download_progress_test.dart
@@ -22,5 +22,18 @@ void main() {
       expect(pending.statusDisplay, 'Queued');
       expect(verifying.statusDisplay, 'Verifying');
     });
+
+    test('surfaces queued artifact position when available', () {
+      const progress = ModelDownloadProgress(
+        modelId: 'model-a',
+        totalBytes: 100,
+        downloadedBytes: 0,
+        status: ModelDownloadStatus.pending,
+        queuePosition: 2,
+      );
+
+      expect(progress.statusDisplay, 'Queued #3');
+      expect(progress.isActive, isTrue);
+    });
   });
 }


### PR DESCRIPTION
# Summary

This PR improves model download clarity by showing queue position when the download platform reports it.

Core outcome:

* Queued model downloads show labels like `Queued #2` instead of a generic 0% state
* The AI Models screen exposes the queued position in visible text and screen-reader progress labels
* Added core and app tests for queue-position display
* Updated the wiki model-management notes

# Testing

* cd packages/core_ai && flutter test test/download/model_download_progress_test.dart --reporter=compact
* cd app && flutter test test/features/settings/presentation/screens/ai_models_screen_test.dart --reporter=compact
* cd app && flutter analyze
* scripts/check-docs-completeness.sh --base origin/main --head HEAD
* scripts/check-v2-merge-readiness.sh --skip-fetch --base origin/main --next HEAD
