### PR TITLE
fix(mind): require LiteRT model path for default runtime

### DIFF
--- a/app/lib/features/agent_chat/data/services/assistant_runtime_service.dart
+++ b/app/lib/features/agent_chat/data/services/assistant_runtime_service.dart
@@ -506,14 +506,15 @@ class AssistantRuntimeService {
         final runtimeReportedAvailable =
             await (_isLiteRtAvailableOverride?.call() ??
                 _liteRtLm.isAvailable());
-        // A native channel may be present on the device even when no model
-        // source was configured. Treat that as unavailable in production;
-        // test overrides remain explicit and can model a ready backend.
+        // A native channel or configured download URL is not a runnable model.
+        // Default LiteRT startup requires either a verified package path or an
+        // explicit local artifact path. Test overrides remain explicit and can
+        // model a ready backend without depending on device storage.
         final available =
             (downloadedPackage?.filePath?.trim().isNotEmpty ?? false) ||
             (runtimeReportedAvailable &&
                 (_isLiteRtAvailableOverride != null ||
-                    _liteRtLm.hasConfiguredModel));
+                    _liteRtLm.hasConfiguredModelPath));
         if (!available) {
           return AssistantRuntimePreparationResult.blocked(
             AssistantRuntimeDiagnosticEnvelope(
@@ -527,7 +528,7 @@ class AssistantRuntimeService {
               reasonCode: 'runtime_unavailable',
               repairActions: const [
                 'Open Profile > AI Models and install a compatible package.',
-                'Set LITERT_LM_MODEL_PATH or LITERT_LM_MODEL_URL when launching locally.',
+                'Set LITERT_LM_MODEL_PATH to a verified local artifact when launching locally.',
               ],
             ),
           );

--- a/app/lib/features/agent_chat/domain/models/assistant_runtime_ids.dart
+++ b/app/lib/features/agent_chat/domain/models/assistant_runtime_ids.dart
@@ -10,7 +10,7 @@ const String geminiNanoUnavailableMessage =
 const String geminiNanoInitializationFailedMessage =
     'Gemini Nano did not initialize on this device. Open Model Library and choose another model.';
 const String litertGemmaUnavailableMessage =
-    'LiteRT-LM is not configured. Install a local model or set LITERT_LM_MODEL_PATH/LITERT_LM_MODEL_URL.';
+    'LiteRT-LM is not configured. Install a local model or set LITERT_LM_MODEL_PATH to a verified local artifact.';
 const String litertWebRuntimeInitFailedMessage =
     'The browser local model runtime failed to start (WebGPU and WASM both unavailable). '
     'Try a different browser or use Gemini Cloud for this session.';

--- a/app/test/features/agent_chat/data/services/assistant_runtime_service_test.dart
+++ b/app/test/features/agent_chat/data/services/assistant_runtime_service_test.dart
@@ -1,4 +1,5 @@
 import 'package:airo_app/core/services/llama_gguf_service.dart';
+import 'package:airo_app/core/services/litert_lm_service.dart';
 import 'package:airo_app/features/agent_chat/data/services/assistant_runtime_service.dart';
 import 'package:airo_app/features/agent_chat/domain/models/assistant_runtime_ids.dart';
 import 'package:airo_app/features/agent_chat/presentation/screens/model_library_screen.dart';
@@ -150,6 +151,50 @@ void main() {
 
         expect(result.status, AssistantRuntimePreparationStatus.blocked);
         expect(result.diagnostic?.reasonCode, 'native_backend_unavailable');
+      },
+    );
+
+    test(
+      'blocks default LiteRT when only a download URL is configured',
+      () async {
+        final service = AssistantRuntimeService(
+          liteRtLm: LiteRtLmService(
+            client: _UrlOnlyLiteRtClient(),
+            config: const LiteRtLmConfig(
+              modelUrl: 'https://example.com/gemma.task',
+            ),
+          ),
+          loadDeviceInfo: () async => const {
+            'manufacturer': 'Google',
+            'model': 'Pixel 9',
+            'platform': 'android',
+          },
+        );
+
+        final result = await service.prepareRuntime(
+          candidate: const AssistantModelCandidate(
+            id: litertGemmaAssistantModelId,
+            name: 'Gemma mobile package',
+            runtime: 'LiteRT-LM local model',
+            description: 'Local package',
+            bestFor: [AssistantTask.chat],
+            tags: ['Local'],
+            privacyLabel: 'Prompt stays on device',
+            sizeLabel: '2 GB',
+            available: true,
+            actionLabel: 'Start',
+            local: true,
+          ),
+        );
+
+        expect(result.status, AssistantRuntimePreparationStatus.blocked);
+        expect(result.diagnostic?.reasonCode, 'runtime_unavailable');
+        expect(
+          result.diagnostic?.repairActions,
+          contains(
+            'Set LITERT_LM_MODEL_PATH to a verified local artifact when launching locally.',
+          ),
+        );
       },
     );
 
@@ -1309,4 +1354,32 @@ class _FakeLlamaGgufService extends LlamaGgufService {
   }) {
     return Stream<String>.fromIterable(generatedChunks);
   }
+}
+
+class _UrlOnlyLiteRtClient implements LiteRtLmClient {
+  @override
+  Future<bool> activeModelExists({String? modelPath}) async => true;
+
+  @override
+  Future<String> generate({
+    required String prompt,
+    required LiteRtLmBackend backend,
+    required int maxTokens,
+    String? systemPrompt,
+  }) async => 'should-not-run';
+
+  @override
+  Future<void> initialize({
+    String? huggingFaceToken,
+    String? modelPath,
+    LiteRtLmBackend? backend,
+    int? maxTokens,
+  }) async {}
+
+  @override
+  Future<void> installModel({
+    required String url,
+    required LiteRtLmModelKind modelKind,
+    String? huggingFaceToken,
+  }) async {}
 }

--- a/docs/wiki/5.-AI-and-Model-Management.md
+++ b/docs/wiki/5.-AI-and-Model-Management.md
@@ -35,6 +35,11 @@ at which point chat opens with the chosen model already selected.
 - If preparation cannot finish, Airo shows the reason with the repair steps for
   that runtime instead of the chat thread.
 
+LiteRT-LM project startup is shown as ready only when Airo has a verified
+downloaded package path or an explicit `LITERT_LM_MODEL_PATH` pointing at a
+local artifact. A configured download URL is treated as an install source, not
+as proof that the model is already runnable on the device.
+
 ## LifeTrack Status Queries
 
 When the matching Agent Skill is enabled, Brain can answer LifeTrack goal


### PR DESCRIPTION
# Summary
This PR tightens Airo Mind's default LiteRT-LM readiness check.
Goal: prevent the Mind setup flow from showing/preparing LiteRT as runnable when no local LiteRT model path exists.

Core outcome:

* Default LiteRT startup now requires a verified downloaded package path or explicit `LITERT_LM_MODEL_PATH`.
* URL-only config is treated as an install source, not a ready runtime.
* The user-facing diagnostic now points to installing a model or setting a verified local artifact path.

# Changes

### Code

* Updated `AssistantRuntimeService` readiness logic for default LiteRT startup.
* Updated LiteRT unavailable copy to remove URL-only readiness guidance.
* Added a regression test for URL-only LiteRT config.

### Docs

* Updated AI/model management wiki with the runtime readiness rule.

# Testing

* `cd app && flutter test test/features/agent_chat/data/services/assistant_runtime_service_test.dart --reporter=compact`
* `cd app && flutter test test/features/agent_chat/presentation/screens/model_library_screen_test.dart test/core/services/litert_lm_service_test.dart --reporter=compact`
* `cd app && flutter analyze`
* `scripts/check-docs-completeness.sh --base origin/main --head HEAD`
* `scripts/check-v2-merge-readiness.sh --skip-fetch --base origin/main --next HEAD`

# Risks

* Low. This only blocks the default LiteRT runtime when no local model path is available. Explicit downloaded LiteRT packages still prepare normally.

Rollback plan:

* Revert this PR if a release profile intentionally relies on URL-only default LiteRT startup.