### PR TITLE
fix(mind): ignore stale audio capture results

### DIFF
--- a/app/lib/features/mind/presentation/screens/audio_scribe_screen.dart
+++ b/app/lib/features/mind/presentation/screens/audio_scribe_screen.dart
@@ -18,6 +18,7 @@ class _AudioScribeScreenState extends ConsumerState<AudioScribeScreen> {
   String _targetLanguage = 'English';
   bool _capturing = false;
   String? _error;
+  int _captureEpoch = 0;
 
   @override
   void dispose() {
@@ -27,12 +28,13 @@ class _AudioScribeScreenState extends ConsumerState<AudioScribeScreen> {
 
   Future<void> _capture() async {
     final service = ref.read(voiceSearchServiceProvider);
+    final captureEpoch = ++_captureEpoch;
     setState(() {
       _capturing = true;
       _error = null;
     });
     final result = await service.startListening();
-    if (!mounted) return;
+    if (!mounted || captureEpoch != _captureEpoch) return;
     setState(() {
       _capturing = false;
       if (result.isSuccess && result.text != null) {
@@ -50,6 +52,7 @@ class _AudioScribeScreenState extends ConsumerState<AudioScribeScreen> {
   }
 
   Future<void> _stop() async {
+    _captureEpoch++;
     await ref.read(voiceSearchServiceProvider).stopListening();
     if (mounted) setState(() => _capturing = false);
   }

--- a/app/test/features/mind/presentation/screens/audio_scribe_screen_test.dart
+++ b/app/test/features/mind/presentation/screens/audio_scribe_screen_test.dart
@@ -146,6 +146,33 @@ void main() {
     await tester.pumpAndSettle();
   });
 
+  testWidgets('late speech result after stop does not update transcript', (
+    tester,
+  ) async {
+    await _usePhoneSurface(tester);
+    final pending = Completer<VoiceSearchResult>();
+    final service = _FakeVoiceService(pendingResult: pending);
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [voiceSearchServiceProvider.overrideWithValue(service)],
+        child: const MaterialApp(home: AudioScribeScreen()),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(const Key('audio_scribe_capture_button')));
+    await tester.pump();
+    await tester.tap(find.byKey(const Key('audio_scribe_capture_button')));
+    await tester.pump();
+    pending.complete(VoiceSearchResult.success('Late transcript.'));
+    await tester.pumpAndSettle();
+
+    final field = tester.widget<TextField>(find.byType(TextField));
+    expect(field.controller?.text, isEmpty);
+    expect(find.text('Late transcript.'), findsNothing);
+    expect(find.text('No speech was recognized.'), findsNothing);
+  });
+
   testWidgets('translation and model management use typed Mind routes', (
     tester,
   ) async {

--- a/docs/wiki/4.-Using-Core-Capabilities.md
+++ b/docs/wiki/4.-Using-Core-Capabilities.md
@@ -84,6 +84,10 @@ Audio Scribe is planned as an offline transcription workflow. The current
 Assistant response maps this to Airo voice workflows and the future
 meeting-minutes pipeline.
 
+When a capture is stopped, Airo ignores any late speech-recognition result from
+that cancelled request so stale audio cannot append text to the transcript after
+the user has already stopped listening.
+
 Saved meeting intelligence search is validated locally against representative
 edge cases. The current in-memory contract supports title and project lookup,
 speaker-label lookup, representative typo recovery, mixed-language tokens, and


### PR DESCRIPTION
# Summary
This PR hardens Audio Scribe capture cancellation.
Goal: prevent stale speech-recognition results from mutating the transcript after the user stops capture.

Core outcome:

* Audio Scribe now tracks capture attempts and ignores late results from cancelled/stopped requests.
* Added a regression test for late speech results after Stop.
* Updated docs to describe the cancellation behavior.

# Testing

* `cd app && flutter test test/features/mind/presentation/screens/audio_scribe_screen_test.dart --reporter=compact`
* `cd app && flutter analyze`
* `scripts/check-docs-completeness.sh --base origin/main --head HEAD`
* `scripts/check-v2-merge-readiness.sh --skip-fetch --base origin/main --next HEAD`

# Risks

* Low. The change only ignores results from an obsolete capture attempt. Active captures still append successful transcripts normally.

Rollback plan:

* Revert this PR if a platform speech implementation depends on delivering Stop results as final transcripts.