### PR TITLE
fix(ai): flag missing remote model ids

### DIFF
--- a/app/lib/features/agent_chat/presentation/screens/profile_screen.dart
+++ b/app/lib/features/agent_chat/presentation/screens/profile_screen.dart
@@ -869,6 +869,8 @@ String _remoteServerRecommendation(RemoteServerDiagnostics diagnostics) {
       'Use the OpenAI-compatible base URL, usually ending in /v1.',
     RemoteServerHealth.invalidResponse =>
       'Check that Ollama, LM Studio, or llama.cpp is exposing a /models response.',
+    RemoteServerHealth.modelMissing =>
+      'Choose one of the reported model ids or load the requested model in the remote server.',
     RemoteServerHealth.unavailable =>
       'Confirm the server is running and reachable from this device.',
   };

--- a/docs/wiki/5.-AI-and-Model-Management.md
+++ b/docs/wiki/5.-AI-and-Model-Management.md
@@ -149,6 +149,12 @@ trace. Recovery actions can include retrying the runtime, resuming a download,
 repairing a model, retrying with reduced context, or choosing another installed
 model.
 
+OpenAI-compatible remote server diagnostics now also verify that the configured
+model id appears in the server's `/models` response. If LM Studio, Ollama, or a
+llama.cpp server is reachable but the requested model is not loaded, Airo marks
+the runtime as needing attention and suggests choosing one of the reported model
+ids or loading the requested model on the server.
+
 ## Device Capability Report
 
 The **Device Capability Report** shows the normalized hardware facts Airo uses

--- a/packages/core_ai/lib/src/llm/openai_compatible_client.dart
+++ b/packages/core_ai/lib/src/llm/openai_compatible_client.dart
@@ -30,6 +30,7 @@ enum RemoteServerHealth {
   notFound,
   unavailable,
   invalidResponse,
+  modelMissing,
 }
 
 /// Structured diagnostics for a remote runtime connection.
@@ -129,6 +130,19 @@ class OpenAICompatibleClient implements LLMClient {
         );
       }
       final modelIds = _extractModelIds(response.data);
+      final configuredModel = _model.trim();
+      if (modelIds.isNotEmpty &&
+          configuredModel.isNotEmpty &&
+          !modelIds.contains(configuredModel)) {
+        return RemoteServerDiagnostics(
+          health: RemoteServerHealth.modelMissing,
+          baseUrl: _baseUrl,
+          statusCode: statusCode,
+          modelIds: modelIds,
+          message:
+              'The server is reachable, but it did not report the configured model "$configuredModel".',
+        );
+      }
       return RemoteServerDiagnostics(
         health: modelIds.isEmpty
             ? RemoteServerHealth.invalidResponse

--- a/packages/core_ai/test/llm/openai_compatible_client_test.dart
+++ b/packages/core_ai/test/llm/openai_compatible_client_test.dart
@@ -76,4 +76,38 @@ void main() {
       expect(diagnostics.message, contains('API key'));
     },
   );
+
+  test(
+    'reports configured model missing from remote server model list',
+    () async {
+      final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+      addTearDown(server.close);
+      server.listen((request) async {
+        request.response
+          ..statusCode = HttpStatus.ok
+          ..headers.contentType = ContentType.json
+          ..write(
+            jsonEncode({
+              'data': [
+                {'id': 'llama3.2'},
+                {'id': 'qwen2.5:7b'},
+              ],
+            }),
+          );
+        await request.response.close();
+      });
+
+      final client = OpenAICompatibleClient(
+        baseUrl: 'http://127.0.0.1:${server.port}/v1',
+        model: 'missing-model',
+      );
+      final diagnostics = await client.diagnose();
+
+      expect(diagnostics.health, RemoteServerHealth.modelMissing);
+      expect(diagnostics.isReady, isFalse);
+      expect(diagnostics.modelIds, ['llama3.2', 'qwen2.5:7b']);
+      expect(diagnostics.message, contains('missing-model'));
+      expect(await client.isAvailable(), isFalse);
+    },
+  );
 }


### PR DESCRIPTION
# Summary
This PR improves OpenAI-compatible remote runtime diagnostics.
Goal: prevent remote setup from being marked ready when the server is reachable but the configured model id is not loaded/reported.

Core outcome:

* Adds a `modelMissing` remote health state.
* Marks `/models` responses as not ready when the configured model id is absent.
* Shows a direct next step in the profile diagnostics: choose a reported model id or load the requested model on the server.
* Documents the behavior in AI/model management docs.

# Testing

* `cd packages/core_ai && flutter test test/llm/openai_compatible_client_test.dart test/llm/gguf_model_client_test.dart --reporter=compact`
* `cd app && flutter test test/features/agent_chat/presentation/screens/profile_ai_preferences_test.dart test/core/ai/ai_router_service_test.dart --reporter=compact`
* `cd app && flutter analyze`
* `scripts/check-docs-completeness.sh --base origin/main --head HEAD`
* `scripts/check-v2-merge-readiness.sh --skip-fetch --base origin/main --next HEAD`

# Risks

* Low. Servers that report the configured model still remain ready. Servers with a mismatch now fail earlier with actionable diagnostics instead of failing later during generation.

Rollback plan:

* Revert this PR if a provider intentionally hides model ids from `/models` while still accepting them in `/chat/completions`.