### PR TITLE
fix(chat): avoid duplicating active prompt in context

### DIFF
--- a/app/lib/features/agent_chat/data/services/assistant_chat_context_builder.dart
+++ b/app/lib/features/agent_chat/data/services/assistant_chat_context_builder.dart
@@ -34,8 +34,14 @@ class AssistantChatContextBuilder {
     List<AssistantChatContextMessage> history,
     String currentUserPrompt,
   ) {
+    final normalizedCurrentPrompt = _normalizeForComparison(currentUserPrompt);
     final filtered = history
         .where((message) => message.text.trim().isNotEmpty)
+        .where(
+          (message) =>
+              !message.isUser ||
+              _normalizeForComparison(message.text) != normalizedCurrentPrompt,
+        )
         .toList();
     if (filtered.isEmpty) {
       return const [];
@@ -52,7 +58,6 @@ class AssistantChatContextBuilder {
               '${_preview(message.text.trim())}',
         )
         .where((entry) => entry.trim().isNotEmpty)
-        .where((entry) => entry != 'User: $currentUserPrompt')
         .toList(growable: false);
   }
 
@@ -62,6 +67,9 @@ class AssistantChatContextBuilder {
     }
     return '${value.substring(0, maxMessageChars)}...';
   }
+
+  String _normalizeForComparison(String value) =>
+      value.trim().replaceAll(RegExp(r'\s+'), ' ').toLowerCase();
 }
 
 const String _airoBaseContext =

--- a/app/test/features/agent_chat/data/services/assistant_chat_context_builder_test.dart
+++ b/app/test/features/agent_chat/data/services/assistant_chat_context_builder_test.dart
@@ -44,5 +44,32 @@ void main() {
         ),
       );
     });
+
+    test('excludes the in-flight user prompt from recent context', () {
+      final prompt = builder.buildSystemPrompt(
+        currentUserPrompt: 'What can Airo do for reminders?',
+        history: const [
+          AssistantChatContextMessage(text: 'What does Airo do?', isUser: true),
+          AssistantChatContextMessage(
+            text: 'Airo helps with planning and app workflows.',
+            isUser: false,
+          ),
+          AssistantChatContextMessage(
+            text: '  what   can airo do for reminders?  ',
+            isUser: true,
+          ),
+        ],
+      );
+
+      expect(prompt, contains('User: What does Airo do?'));
+      expect(
+        prompt,
+        contains('Airo: Airo helps with planning and app workflows.'),
+      );
+      expect(
+        prompt,
+        isNot(contains('User: what   can airo do for reminders?')),
+      );
+    });
   });
 }

--- a/docs/wiki/4.-Using-Core-Capabilities.md
+++ b/docs/wiki/4.-Using-Core-Capabilities.md
@@ -9,6 +9,11 @@ Use the Assistant tab for open-ended chat and supported app commands.
 3. Airo first checks whether the message matches a supported app action.
 4. If no local command matches, Airo asks the AI service for a response.
 
+AI Chat includes recent conversation context for continuity, but it excludes
+the active user prompt from that context before sending the request to the
+selected runtime. This prevents the current prompt from being duplicated in the
+system context and keeps model responses grounded in prior turns only.
+
 Examples:
 
 - `Help me think through a task`


### PR DESCRIPTION
# Summary

This PR fixes AI Chat context construction so the active user prompt is not also injected into the recent-conversation context.

Core outcome:

* prior turns remain available for continuity
* the in-flight prompt is excluded using normalized whitespace/case comparison
* model system prompts avoid duplicated current-user content

# Changes

### Code

* Updated AssistantChatContextBuilder to filter the active user prompt before building recent context.
* Added regression coverage for whitespace/case variants of the active prompt.

### Documentation

* Updated the core capabilities wiki to document the behavior.

# Testing

* cd app && flutter test test/features/agent_chat/data/services/assistant_chat_context_builder_test.dart --reporter=compact
* cd app && flutter analyze
* scripts/check-docs-completeness.sh --base origin/main --head HEAD
* scripts/check-v2-merge-readiness.sh --skip-fetch --base origin/main --next HEAD

# Risks

Low. The change only removes duplicate active user prompt content from generated context; prior assistant/user turns remain included.