### PR TITLE
fix(ai): surface stalled model downloads

### DIFF
--- a/docs/wiki/5.-AI-and-Model-Management.md
+++ b/docs/wiki/5.-AI-and-Model-Management.md
@@ -116,6 +116,11 @@ Queued downloads show their current queue position when the platform reports
 one, so a model waiting behind another artifact does not look like a stuck 0%
 download.
 
+Downloads that report no byte movement and no throughput past the stall window
+are labeled **Stalled**. The model manager keeps the transfer visible, reports
+**No throughput**, and exposes the retry path so the user can restart the
+artifact request instead of waiting on a silent transfer.
+
 Downloaded offline packages are re-discovered when the app starts, so models
 that already exist on disk appear again in the **Downloaded** tab without
 requiring a second download. This applies to both current LiteRT package

--- a/packages/core_ai/lib/src/download/model_download_progress.dart
+++ b/packages/core_ai/lib/src/download/model_download_progress.dart
@@ -39,6 +39,7 @@ class ModelDownloadProgress {
     required this.status,
     this.speedBytesPerSecond = 0,
     this.startTime,
+    this.lastProgressAt,
     this.error,
     this.failureCode,
     this.retryCount = 0,
@@ -63,6 +64,9 @@ class ModelDownloadProgress {
 
   /// Time when download started.
   final DateTime? startTime;
+
+  /// Last time downloaded bytes increased.
+  final DateTime? lastProgressAt;
 
   /// Error message if download failed.
   final String? error;
@@ -94,6 +98,22 @@ class ModelDownloadProgress {
   /// Whether the download is in progress.
   bool get isInProgress => status == ModelDownloadStatus.downloading;
 
+  /// Whether the platform still reports downloading but no bytes have moved
+  /// for long enough that the user should see retry/repair guidance.
+  bool get isStalled => isStalledAt(DateTime.now());
+
+  bool isStalledAt(
+    DateTime now, {
+    Duration threshold = const Duration(seconds: 90),
+  }) {
+    if (status != ModelDownloadStatus.downloading) return false;
+    if (isComplete || downloadedBytes >= totalBytes) return false;
+    if (speedBytesPerSecond > 0) return false;
+    final lastProgress = lastProgressAt ?? startTime;
+    if (lastProgress == null) return false;
+    return now.difference(lastProgress) >= threshold;
+  }
+
   /// Whether the download is still actively occupying the progress UI.
   bool get isActive =>
       status == ModelDownloadStatus.pending ||
@@ -101,13 +121,13 @@ class ModelDownloadProgress {
       status == ModelDownloadStatus.paused ||
       status == ModelDownloadStatus.verifying;
 
-  bool get canPause => status == ModelDownloadStatus.downloading;
+  bool get canPause => status == ModelDownloadStatus.downloading && !isStalled;
 
   bool get canResume =>
       status == ModelDownloadStatus.paused ||
       (status == ModelDownloadStatus.failed && resumeSupported);
 
-  bool get canRetry => status == ModelDownloadStatus.failed;
+  bool get canRetry => status == ModelDownloadStatus.failed || isStalled;
 
   bool get canCancel =>
       status != ModelDownloadStatus.completed &&
@@ -122,6 +142,7 @@ class ModelDownloadProgress {
         }
         return 'Queued';
       case ModelDownloadStatus.downloading:
+        if (isStalled) return 'Stalled';
         return 'Downloading';
       case ModelDownloadStatus.paused:
         return 'Paused';
@@ -145,6 +166,7 @@ class ModelDownloadProgress {
 
   /// Formatted download speed (e.g., "2.5 MB/s").
   String get speedDisplay {
+    if (isStalled) return 'No throughput';
     if (speedBytesPerSecond < 1024) {
       return '${speedBytesPerSecond.round()} B/s';
     } else if (speedBytesPerSecond < 1024 * 1024) {
@@ -211,6 +233,7 @@ class ModelDownloadProgress {
     ModelDownloadStatus? status,
     double? speedBytesPerSecond,
     DateTime? startTime,
+    DateTime? lastProgressAt,
     String? error,
     String? failureCode,
     int? retryCount,
@@ -224,6 +247,7 @@ class ModelDownloadProgress {
       status: status ?? this.status,
       speedBytesPerSecond: speedBytesPerSecond ?? this.speedBytesPerSecond,
       startTime: startTime ?? this.startTime,
+      lastProgressAt: lastProgressAt ?? this.lastProgressAt,
       error: error ?? this.error,
       failureCode: failureCode ?? this.failureCode,
       retryCount: retryCount ?? this.retryCount,

--- a/packages/core_ai/lib/src/download/model_download_service.dart
+++ b/packages/core_ai/lib/src/download/model_download_service.dart
@@ -50,6 +50,9 @@ class ModelDownloadService {
       {};
   final Set<String> _scheduledIds = {};
   final Map<String, OfflineModelInfo> _scheduledModels = {};
+  final Map<String, DateTime> _downloadStartedAt = {};
+  final Map<String, DateTime> _lastByteProgressAt = {};
+  final Map<String, int> _lastDownloadedBytes = {};
   final StreamController<ModelDownloadProgress> _globalProgressController =
       StreamController<ModelDownloadProgress>.broadcast();
 
@@ -96,6 +99,10 @@ class ModelDownloadService {
     }
 
     _emit(ModelDownloadProgress.starting(model.id, model.fileSizeBytes));
+    final now = DateTime.now();
+    _downloadStartedAt[model.id] = now;
+    _lastByteProgressAt[model.id] = now;
+    _lastDownloadedBytes[model.id] = 0;
     try {
       final destinationPath = await _storageManager.getModelPath(
         model.id,
@@ -152,6 +159,7 @@ class ModelDownloadService {
           );
           _scheduledIds.remove(progress.artifactId);
           _scheduledModels.remove(progress.artifactId);
+          _clearProgressTracking(progress.artifactId);
           return;
         }
         await _tryWriteReceipt(model);
@@ -159,13 +167,16 @@ class ModelDownloadService {
     }
     _emit(_toModelProgress(progress));
     if (progress.status == DownloadStatus.completed ||
-        progress.status == DownloadStatus.cancelled) {
+        progress.status == DownloadStatus.cancelled ||
+        progress.status == DownloadStatus.failed) {
       _scheduledIds.remove(progress.artifactId);
       _scheduledModels.remove(progress.artifactId);
+      _clearProgressTracking(progress.artifactId);
     }
   }
 
   ModelDownloadProgress _toModelProgress(DownloadProgress progress) {
+    final now = DateTime.now();
     final status = switch (progress.status) {
       DownloadStatus.queued => ModelDownloadStatus.pending,
       DownloadStatus.downloading => ModelDownloadStatus.downloading,
@@ -175,12 +186,27 @@ class ModelDownloadService {
       DownloadStatus.failed => ModelDownloadStatus.failed,
       DownloadStatus.cancelled => ModelDownloadStatus.cancelled,
     };
+    final startedAt = status == ModelDownloadStatus.downloading
+        ? _downloadStartedAt.putIfAbsent(progress.artifactId, () => now)
+        : _downloadStartedAt[progress.artifactId];
+    var lastProgressAt = _lastByteProgressAt[progress.artifactId];
+    if (status == ModelDownloadStatus.downloading) {
+      final previousBytes = _lastDownloadedBytes[progress.artifactId];
+      if (previousBytes == null || progress.downloadedBytes > previousBytes) {
+        _lastDownloadedBytes[progress.artifactId] = progress.downloadedBytes;
+        lastProgressAt = now;
+        _lastByteProgressAt[progress.artifactId] = now;
+      }
+      lastProgressAt ??= startedAt;
+    }
     return ModelDownloadProgress(
       modelId: progress.artifactId,
       totalBytes: progress.totalBytes,
       downloadedBytes: progress.downloadedBytes,
       status: status,
       speedBytesPerSecond: progress.speedBytesPerSecond,
+      startTime: startedAt,
+      lastProgressAt: lastProgressAt,
       error: progress.failure?.message,
       failureCode: progress.failure?.code.name,
       retryCount: progress.retryCount,
@@ -342,6 +368,12 @@ class ModelDownloadService {
     );
   }
 
+  void _clearProgressTracking(String modelId) {
+    _downloadStartedAt.remove(modelId);
+    _lastByteProgressAt.remove(modelId);
+    _lastDownloadedBytes.remove(modelId);
+  }
+
   Future<void> dispose() async {
     await _progressSubscription?.cancel();
     await _globalProgressController.close();
@@ -351,6 +383,9 @@ class ModelDownloadService {
     _progressStreams.clear();
     _scheduledIds.clear();
     _scheduledModels.clear();
+    _downloadStartedAt.clear();
+    _lastByteProgressAt.clear();
+    _lastDownloadedBytes.clear();
   }
 }
 

--- a/packages/core_ai/test/download/model_download_progress_test.dart
+++ b/packages/core_ai/test/download/model_download_progress_test.dart
@@ -35,5 +35,35 @@ void main() {
       expect(progress.statusDisplay, 'Queued #3');
       expect(progress.isActive, isTrue);
     });
+
+    test('flags zero-throughput downloads as stalled after threshold', () {
+      final lastProgress = DateTime.utc(2026, 8, 1, 10);
+      final progress = ModelDownloadProgress(
+        modelId: 'model-a',
+        totalBytes: 1000,
+        downloadedBytes: 400,
+        status: ModelDownloadStatus.downloading,
+        speedBytesPerSecond: 0,
+        lastProgressAt: lastProgress,
+      );
+
+      expect(
+        progress.isStalledAt(
+          DateTime.utc(2026, 8, 1, 10, 1),
+          threshold: const Duration(seconds: 90),
+        ),
+        isFalse,
+      );
+      expect(
+        progress.isStalledAt(
+          DateTime.utc(2026, 8, 1, 10, 2),
+          threshold: const Duration(seconds: 90),
+        ),
+        isTrue,
+      );
+      expect(progress.canPause, isFalse);
+      expect(progress.canRetry, isTrue);
+      expect(progress.speedDisplay, 'No throughput');
+    });
   });
 }

--- a/packages/core_ai/test/download/model_download_service_test.dart
+++ b/packages/core_ai/test/download/model_download_service_test.dart
@@ -148,6 +148,44 @@ void main() {
     },
   );
 
+  test(
+    'download progress records last byte movement for stall recovery',
+    () async {
+      final progressValues = <ModelDownloadProgress>[];
+      final subscription = downloadService
+          .downloadModel(model)
+          .listen(progressValues.add);
+      await Future<void>.delayed(Duration.zero);
+
+      downloads.eventController.add(
+        const DownloadProgress(
+          artifactId: 'model-a',
+          status: DownloadStatus.downloading,
+          downloadedBytes: 400,
+          totalBytes: 1000,
+          speedBytesPerSecond: 0,
+        ),
+      );
+      await Future<void>.delayed(Duration.zero);
+      final firstMovement = progressValues.last.lastProgressAt;
+
+      downloads.eventController.add(
+        const DownloadProgress(
+          artifactId: 'model-a',
+          status: DownloadStatus.downloading,
+          downloadedBytes: 400,
+          totalBytes: 1000,
+          speedBytesPerSecond: 0,
+        ),
+      );
+      await Future<void>.delayed(Duration.zero);
+
+      expect(progressValues.last.startTime, isNotNull);
+      expect(progressValues.last.lastProgressAt, firstMovement);
+      await subscription.cancel();
+    },
+  );
+
   test('completed platform transfer records an install receipt', () async {
     var verificationCalls = 0;
     when(


### PR DESCRIPTION
# Summary

This PR makes silent model download stalls visible and recoverable.

Core outcome:

* active model downloads track the last time bytes moved
* zero-throughput transfers past the stall window show as Stalled
* stalled transfers expose Retry instead of Pause
* model management docs describe the recovery behavior

# Changes

### Code

* Added stall detection to ModelDownloadProgress.
* Preserved start and last-byte-progress timestamps in ModelDownloadService.
* Cleared progress tracking state on terminal transfers and disposal.
* Added regression coverage for stalled progress and service timestamp tracking.

### Documentation

* Updated AI and Model Management wiki with stalled-download behavior.

# Testing

* cd packages/core_ai && flutter test test/download/model_download_progress_test.dart test/download/model_download_service_test.dart --reporter=compact
* cd app && flutter test test/features/settings/presentation/screens/ai_models_screen_test.dart test/features/settings/presentation/screens/intelligent_model_manager_screen_test.dart --reporter=compact
* cd app && flutter analyze
* scripts/check-docs-completeness.sh --base origin/main --head HEAD
* scripts/check-v2-merge-readiness.sh --skip-fetch --base origin/main --next HEAD

# Notes

packages/core_ai flutter analyze currently reports an existing unrelated lint in lib/src/llm/active_model_service.dart:138. App analysis is clean.