### PR TITLE
fix(ai): mark stalled downloads recoverable in health center

### DIFF
--- a/packages/core_ai/lib/src/health/model_health_report.dart
+++ b/packages/core_ai/lib/src/health/model_health_report.dart
@@ -118,6 +118,7 @@ class ModelHealthReport {
     final downloaded =
         downloadStatus == ModelDownloadStatus.completed ||
         (download == null && (artifactPresent ?? model.isDownloaded));
+    final stalled = download?.isStalled ?? false;
     final downloading =
         downloadStatus == ModelDownloadStatus.downloading ||
         downloadStatus == ModelDownloadStatus.pending ||
@@ -129,11 +130,15 @@ class ModelHealthReport {
         stage: ModelHealthStage.downloaded,
         status: downloaded
             ? ModelHealthStageStatus.passed
+            : stalled
+            ? ModelHealthStageStatus.blocked
             : downloading
             ? ModelHealthStageStatus.pending
             : ModelHealthStageStatus.blocked,
         detail: downloaded
             ? 'Model artifact is present on this device.'
+            : stalled
+            ? 'Download is stalled.'
             : downloading
             ? 'Download is ${download!.statusDisplay.toLowerCase()}.'
             : 'Model artifact is not downloaded.',
@@ -205,6 +210,8 @@ class ModelHealthReport {
         ? ModelHealthReportStatus.recoverable
         : stages.every((entry) => entry.isPassed)
         ? ModelHealthReportStatus.ready
+        : stalled
+        ? ModelHealthReportStatus.recoverable
         : downloading
         ? ModelHealthReportStatus.preparing
         : ModelHealthReportStatus.unknown;
@@ -221,7 +228,11 @@ class ModelHealthReport {
         runtimeHealth: runtimeHealth,
       ),
       failureCode: failureCode,
-      actions: _actions(failureCode: failureCode, downloading: downloading),
+      actions: _actions(
+        failureCode: failureCode,
+        downloading: downloading,
+        stalled: stalled,
+      ),
       availableMemoryMb: compatibility?.availableMemoryMB,
       requiredMemoryMb: compatibility?.requiredMemoryMB,
       runtime: plan?.ir.runtime,
@@ -271,6 +282,9 @@ class ModelHealthReport {
     // the file itself, so surface that state as recoverable instead of leaving
     // the Health Center stuck at "unknown".
     if (download == null && artifactPresent == false) {
+      return ModelHealthFailureCode.downloadIncomplete;
+    }
+    if (download?.isStalled ?? false) {
       return ModelHealthFailureCode.downloadIncomplete;
     }
     if (download?.status == ModelDownloadStatus.failed) {
@@ -369,7 +383,11 @@ class ModelHealthReport {
   static List<ModelHealthAction> _actions({
     required ModelHealthFailureCode failureCode,
     required bool downloading,
+    required bool stalled,
   }) {
+    if (stalled) {
+      return const [ModelHealthAction.retry, ModelHealthAction.resumeDownload];
+    }
     if (downloading) return const [ModelHealthAction.resumeDownload];
     return switch (failureCode) {
       ModelHealthFailureCode.insufficientMemory ||

--- a/packages/core_ai/test/health/model_health_report_test.dart
+++ b/packages/core_ai/test/health/model_health_report_test.dart
@@ -94,6 +94,33 @@ void main() {
     expect(report.actions, [ModelHealthAction.resumeDownload]);
   });
 
+  test('reports a stalled download as recoverable retry work', () {
+    final report = ModelHealthReport.fromFacts(
+      model: _model(),
+      download: ModelDownloadProgress(
+        modelId: 'gemma-4b',
+        totalBytes: 2_000,
+        downloadedBytes: 700,
+        status: ModelDownloadStatus.downloading,
+        speedBytesPerSecond: 0,
+        lastProgressAt: DateTime.now().subtract(const Duration(minutes: 5)),
+      ),
+    );
+
+    expect(report.status, ModelHealthReportStatus.recoverable);
+    expect(report.failureCode, ModelHealthFailureCode.downloadIncomplete);
+    expect(
+      report.stage(ModelHealthStage.downloaded).status,
+      ModelHealthStageStatus.blocked,
+    );
+    expect(
+      report.stage(ModelHealthStage.downloaded).detail,
+      'Download is stalled.',
+    );
+    expect(report.actions.first, ModelHealthAction.retry);
+    expect(report.actions, contains(ModelHealthAction.resumeDownload));
+  });
+
   test('does not trust a stale persisted path as a downloaded artifact', () {
     final report = ModelHealthReport.fromFacts(
       model: const OfflineModelInfo(


### PR DESCRIPTION
# Summary

This PR aligns Runtime Health Center recovery guidance with stalled download detection.

Core outcome:

* stalled transfers become recoverable health failures
* the Downloaded stage shows blocked when a transfer stops moving
* Retry is preferred before Resume for stalled transfers

# Changes

### Code

* Updated ModelHealthReport to recognize ModelDownloadProgress.isStalled.
* Added stalled health report regression coverage.

# Testing

* cd packages/core_ai && flutter test test/health/model_health_report_test.dart test/download/model_download_progress_test.dart --reporter=compact
* cd app && flutter analyze
* scripts/check-docs-completeness.sh --base origin/main --head HEAD
* scripts/check-v2-merge-readiness.sh --skip-fetch --base origin/main --next HEAD

# Risks

Low. This only changes recovery classification for already-detected stalled downloads.