### PR TITLE
fix(ai): show retry for stalled model cards

### DIFF
--- a/app/lib/features/settings/presentation/widgets/model_card.dart
+++ b/app/lib/features/settings/presentation/widgets/model_card.dart
@@ -244,8 +244,7 @@ class ModelCard extends StatelessWidget {
                   ),
                 ],
                 const Spacer(),
-                if ((downloadStatus ?? '').toLowerCase() == 'paused' &&
-                    onResumeDownload != null)
+                if (onResumeDownload != null)
                   IconButton(
                     onPressed: onResumeDownload,
                     icon: const Icon(Icons.play_arrow, size: 18),
@@ -254,8 +253,7 @@ class ModelCard extends StatelessWidget {
                     padding: EdgeInsets.zero,
                     constraints: const BoxConstraints(),
                   )
-                else if ((downloadStatus ?? '').toLowerCase() == 'failed' &&
-                    onRetryDownload != null)
+                else if (onRetryDownload != null)
                   IconButton(
                     onPressed: onRetryDownload,
                     icon: const Icon(Icons.refresh, size: 18),

--- a/app/test/features/settings/presentation/screens/ai_models_screen_test.dart
+++ b/app/test/features/settings/presentation/screens/ai_models_screen_test.dart
@@ -400,6 +400,63 @@ void main() {
     expect(downloadService.retriedModelIds, contains('gemma-progress'));
   });
 
+  testWidgets('stalled downloads expose retry instead of pause', (
+    tester,
+  ) async {
+    SharedPreferences.setMockInitialValues({});
+    final downloadService = _FakeModelDownloadService();
+    final registry =
+        _FakeModelRegistry(
+          compatibilityByModelId: {
+            'gemma-stalled': ModelCompatibilityResult.compatible(
+              MemorySeverity.safe,
+            ),
+          },
+        )..registerModel(
+          const OfflineModelInfo(
+            id: 'gemma-stalled',
+            name: 'Gemma Stalled',
+            family: ModelFamily.gemma,
+            fileSizeBytes: 2048,
+            provider: AIProvider.gemma,
+          ),
+        );
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          modelRegistryProvider.overrideWithValue(registry),
+          modelDownloadServiceProvider.overrideWithValue(downloadService),
+          activeDownloadsProvider.overrideWith(
+            (ref) => ActiveDownloadsNotifier(ref)
+              ..state = {
+                'gemma-stalled': ModelDownloadProgress(
+                  modelId: 'gemma-stalled',
+                  totalBytes: 100,
+                  downloadedBytes: 50,
+                  status: ModelDownloadStatus.downloading,
+                  speedBytesPerSecond: 0,
+                  lastProgressAt: DateTime.now().subtract(
+                    const Duration(minutes: 5),
+                  ),
+                ),
+              },
+          ),
+        ],
+        child: const MaterialApp(home: AIModelsScreen()),
+      ),
+    );
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 100));
+
+    expect(find.text('Stalled'), findsOneWidget);
+    expect(find.textContaining('No throughput'), findsOneWidget);
+    expect(find.byTooltip('Pause download'), findsNothing);
+    await tester.tap(find.byTooltip('Retry download'));
+    await tester.pump();
+    expect(downloadService.retriedModelIds, contains('gemma-stalled'));
+  });
+
   testWidgets('downloaded models can be activated and deleted', (tester) async {
     SharedPreferences.setMockInitialValues({});
     final downloadService = _FakeModelDownloadService(deleteResult: true);

--- a/docs/wiki/5.-AI-and-Model-Management.md
+++ b/docs/wiki/5.-AI-and-Model-Management.md
@@ -121,6 +121,10 @@ are labeled **Stalled**. The model manager keeps the transfer visible, reports
 **No throughput**, and exposes the retry path so the user can restart the
 artifact request instead of waiting on a silent transfer.
 
+AI Models cards use the same action policy: a stalled transfer exposes
+**Retry download** instead of **Pause download**, so keyboard and screen-reader
+users can recover the transfer from the card without opening another panel.
+
 Downloaded offline packages are re-discovered when the app starts, so models
 that already exist on disk appear again in the **Downloaded** tab without
 requiring a second download. This applies to both current LiteRT package


### PR DESCRIPTION
# Summary

This PR keeps stalled model downloads recoverable from AI Models cards.

Core outcome:

* stalled downloads show Retry instead of Pause on model cards
* action selection uses provided callbacks instead of brittle status-string checks
* docs clarify the card recovery behavior for keyboard and screen-reader users

# Changes

### Code

* Updated ModelCard download controls to prefer resume, then retry, then pause based on available callbacks.
* Added AI Models regression coverage for stalled downloads.

### Documentation

* Updated AI and Model Management wiki with stalled card recovery behavior.

# Testing

* cd app && flutter test test/features/settings/presentation/screens/ai_models_screen_test.dart --reporter=compact
* cd app && flutter analyze
* scripts/check-docs-completeness.sh --base origin/main --head HEAD
* scripts/check-v2-merge-readiness.sh --skip-fetch --base origin/main --next HEAD

# Risks

Low. The screen already computes the correct available callbacks; this removes duplicated status parsing in the card.