### PR TITLE
fix(mind): exclude main_mind.dart from the phone flavour's analysis

### DIFF
--- a/app/analysis_options.yaml
+++ b/app/analysis_options.yaml
@@ -28,6 +28,20 @@ analyzer:
     # them here checks nothing; it only hides the errors that matter.
     - "integration_test/patrol_test.dart"
     - "patrol_test/**"
+    # Same reason, same shape: `main_mind.dart` resolves only under
+    # pubspec_mind.yaml, and `feature_mind` is not a dependency of
+    # app/pubspec.yaml. Analysing it against the phone flavour checks it
+    # against a dependency set it was never meant to have.
+    #
+    # Adding feature_mind to app/pubspec.yaml the way feature_coin is there
+    # would fix the analysis and break the product: feature_mind declares
+    # cargokit hooks, so every phone build would cross-compile whisper.cpp and
+    # llama.cpp through the NDK and carry the native code for a feature this
+    # flavour does not ship.
+    #
+    # The entrypoint is still covered -- the macOS build compiles it, which is
+    # stronger than analysis.
+    - "lib/main_mind.dart"
 
   # Treat warnings as info to prevent CI failures on non-critical issues
   # Errors will still cause CI to fail


### PR DESCRIPTION
**`analyze` and `code-quality` are failing on `main`. This fixes them.**

[#1427](https://github.com/DevelopersCoffee/airo/pull/1427) squash-merged before this one-line fix was pushed, so main has `app/lib/main_mind.dart` importing `feature_mind` while `app/pubspec.yaml` does not depend on it:

```
error • Target of URI doesn't exist: 'package:feature_mind/feature_mind.dart'
error • The method 'MindService' isn't defined
error • The method 'MindHomeScreen' isn't defined
```

My breakage, from #1427.

## Why an exclusion rather than a dependency

`app/analysis_options.yaml` already solves this exact problem for the Patrol suites, in the same `exclude` list, with the reasoning written out — *"the flavour pubspecs are separate, so a dependency in one is invisible to the others"*. This sits next to that rather than inventing a second convention.

The other option is adding `feature_mind` to `app/pubspec.yaml` the way `feature_coin` is there. That would fix the analysis and **break the product**: `feature_mind` declares cargokit hooks for Android and iOS, so every phone build would cross-compile whisper.cpp and llama.cpp through the NDK and carry the native code for a feature that flavour does not ship. Milestone 2 claims macOS only.

The entrypoint is not going unchecked — the macOS build compiles it, which is stronger coverage than analysis.

## Verification

On this branch, with CI's exact flags:

```
flutter analyze --no-fatal-infos --no-fatal-warnings
No issues found! (ran in 32.6s)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
