### PR TITLE
fix(tv): hold the shell inside the horizontal title-safe band

### DIFF
--- a/app/lib/core/app/tv_shell.dart
+++ b/app/lib/core/app/tv_shell.dart
@@ -19,6 +19,40 @@ import '../../features/settings/presentation/tv/tv_settings_screen.dart';
 final tvNavigationIndexProvider = StateProvider<int>((ref) => 0);
 const _tvNavigationRailWidth = 88.0;
 
+/// Fraction of each edge a TV may crop. Televisions with overscan enabled
+/// discard roughly the outer 5%, which is why the Android TV guidance puts a
+/// 5% title-safe margin around anything the user has to see or reach.
+///
+/// Measured on the rig Fire TV Stick at 1920x1080 before this existed: the
+/// sidebar's leftmost pixel sat at x=32 against a 96px safe inset, so the whole
+/// navigation rail — and the cast/favourite actions on the right — were inside
+/// the croppable band (#1429).
+@visibleForTesting
+const tvTitleSafeFraction = 0.05;
+
+/// The inset the shell actually reserves.
+///
+/// Horizontal only, deliberately. The left band holds the navigation rail —
+/// the only way to move around the app — so cropping it is severe. The top and
+/// bottom bands hold a section label and a scrollable card row, where cropping
+/// costs far less.
+///
+/// Reserving the vertical band as well overflows several TV settings columns,
+/// which are laid out to the full panel height and do not scroll. Fixing those
+/// is a larger change than this defect warrants and is tracked separately;
+/// taking the horizontal half now fixes the case that actually strands a user.
+@visibleForTesting
+EdgeInsets tvTitleSafeInsets(Size size) =>
+    EdgeInsets.symmetric(horizontal: size.width * tvTitleSafeFraction);
+
+/// The full title-safe band, for reference and for tests that assert what the
+/// convention asks for as opposed to what the shell currently reserves.
+@visibleForTesting
+EdgeInsets tvFullTitleSafeInsets(Size size) => EdgeInsets.symmetric(
+  horizontal: size.width * tvTitleSafeFraction,
+  vertical: size.height * tvTitleSafeFraction,
+);
+
 /// Non-live destinations the sidebar can show. Rendered as an overlay on
 /// top of [TvShell.child] instead of being routed to — routing away would
 /// unmount whatever live playback [child] holds (AiroTV D-pad design:
@@ -63,65 +97,76 @@ class _TvShellState extends ConsumerState<TvShell> {
     // focus that should land on the player's own transport controls.
     final isPlayerFullscreen = ref.watch(isFullscreenModeProvider);
 
-    return Scaffold(
-      body: Stack(
-        children: [
-          // The routed content (the live TV screen on the common path).
-          // Never removed from the tree by a sidebar tap — only a direct
-          // deep link to a different route replaces it.
-          Positioned.fill(
-            child: Focus(
-              canRequestFocus: false,
-              onKeyEvent: _handleContentKeyEvent,
-              child: Padding(
-                padding: EdgeInsets.only(
-                  left: isPlayerFullscreen ? 0 : _tvNavigationRailWidth,
-                ),
-                // Non-live destinations are painted over the retained live
-                // surface. Keep that surface mounted for playback, but never
-                // leave its controls in the focus graph behind an overlay.
-                child: ExcludeFocus(
-                  excluding: _overlay != null,
-                  child: widget.child,
-                ),
+    // Hold the chrome inside the title-safe band so an overscanning TV cannot
+    // crop the navigation rail or the top-right actions. Fullscreen playback is
+    // deliberately exempt: video should fill the panel edge to edge, and losing
+    // a few pixels of picture to overscan is normal, whereas losing the only
+    // way to navigate is not.
+    final body = Stack(
+      children: [
+        // The routed content (the live TV screen on the common path).
+        // Never removed from the tree by a sidebar tap — only a direct
+        // deep link to a different route replaces it.
+        Positioned.fill(
+          child: Focus(
+            canRequestFocus: false,
+            onKeyEvent: _handleContentKeyEvent,
+            child: Padding(
+              padding: EdgeInsets.only(
+                left: isPlayerFullscreen ? 0 : _tvNavigationRailWidth,
+              ),
+              // Non-live destinations are painted over the retained live
+              // surface. Keep that surface mounted for playback, but never
+              // leave its controls in the focus graph behind an overlay.
+              child: ExcludeFocus(
+                excluding: _overlay != null,
+                child: widget.child,
               ),
             ),
           ),
-          if (!isPlayerFullscreen) ...[
-            if (_overlay != null)
-              Positioned.fill(
-                // The rail stays visible (painted after this, so on top) and
-                // isn't docked in a layout row anymore, so it no longer
-                // reserves space of its own — give overlay screens the same
-                // left inset the old Row gave them, so their content doesn't
-                // render underneath the now-floating rail.
-                child: Focus(
-                  canRequestFocus: false,
-                  onKeyEvent: _handleContentKeyEvent,
-                  child: Padding(
-                    padding: const EdgeInsets.only(
-                      left: _tvNavigationRailWidth,
-                    ),
-                    child: _buildOverlay(_overlay!),
-                  ),
+        ),
+        if (!isPlayerFullscreen) ...[
+          if (_overlay != null)
+            Positioned.fill(
+              // The rail stays visible (painted after this, so on top) and
+              // isn't docked in a layout row anymore, so it no longer
+              // reserves space of its own — give overlay screens the same
+              // left inset the old Row gave them, so their content doesn't
+              // render underneath the now-floating rail.
+              child: Focus(
+                canRequestFocus: false,
+                onKeyEvent: _handleContentKeyEvent,
+                child: Padding(
+                  padding: const EdgeInsets.only(left: _tvNavigationRailWidth),
+                  child: _buildOverlay(_overlay!),
                 ),
               ),
-            // The rail is painted on top instead of docked in a Row, so it
-            // never claims layout width from the content beneath it.
-            Positioned(
-              left: 0,
-              top: 0,
-              bottom: 0,
-              child: _TvNavigationRail(
-                currentIndex: currentIndex,
-                focusNodes: _railFocusNodes,
-                onDestinationSelected: (index) =>
-                    _selectDestination(context, index),
-              ),
             ),
-          ],
+          // The rail is painted on top instead of docked in a Row, so it
+          // never claims layout width from the content beneath it.
+          Positioned(
+            left: 0,
+            top: 0,
+            bottom: 0,
+            child: _TvNavigationRail(
+              currentIndex: currentIndex,
+              focusNodes: _railFocusNodes,
+              onDestinationSelected: (index) =>
+                  _selectDestination(context, index),
+            ),
+          ),
         ],
-      ),
+      ],
+    );
+
+    return Scaffold(
+      body: isPlayerFullscreen
+          ? body
+          : Padding(
+              key: const Key('tv-title-safe-inset'),
+              padding: tvTitleSafeInsets(MediaQuery.sizeOf(context)),
+              child: body,
+            ),
     );
   }
 

--- a/app/lib/features/settings/presentation/tv/tv_theme_section.dart
+++ b/app/lib/features/settings/presentation/tv/tv_theme_section.dart
@@ -38,14 +38,20 @@ class TvThemeSection extends ConsumerWidget {
               padding: const EdgeInsets.all(16),
               child: Row(
                 children: [
-                  Text(
-                    definition.name,
-                    style: TextStyle(
-                      color: colorScheme.onSurface,
-                      fontSize: 16,
+                  // Flexible rather than Text + Spacer: the row has to survive
+                  // a narrower viewport (the shell now reserves a title-safe
+                  // margin) and long localised theme names, either of which
+                  // overflowed a fixed-width label.
+                  Expanded(
+                    child: Text(
+                      definition.name,
+                      overflow: TextOverflow.ellipsis,
+                      style: TextStyle(
+                        color: colorScheme.onSurface,
+                        fontSize: 16,
+                      ),
                     ),
                   ),
-                  const Spacer(),
                   if (isSelected) Icon(Icons.check, color: colorScheme.primary),
                 ],
               ),

--- a/app/test/core/app/tv_title_safe_test.dart
+++ b/app/test/core/app/tv_title_safe_test.dart
@@ -1,0 +1,107 @@
+import 'package:airo_app/core/app/tv_shell.dart';
+import 'package:feature_iptv/feature_iptv.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// Televisions with overscan enabled crop roughly the outer 5% of the panel.
+///
+/// Measured on the rig Fire TV Stick at 1920x1080 before the inset existed
+/// (#1429): the sidebar's leftmost pixel sat at x=32 against a 96px safe inset,
+/// and the cast/favourite actions sat inside the right band. On a cropping TV
+/// that removes the only way to navigate the app.
+void main() {
+  group('title-safe geometry', () {
+    test('reserves the horizontal 5% band at 1080p', () {
+      final insets = tvTitleSafeInsets(const Size(1920, 1080));
+
+      expect(insets.left, 96);
+      expect(insets.right, 96);
+      // Vertical is deliberately not reserved yet -- see tvTitleSafeInsets.
+      expect(insets.top, 0);
+      expect(insets.bottom, 0);
+    });
+
+    test('the full convention is still expressed for reference', () {
+      final full = tvFullTitleSafeInsets(const Size(1920, 1080));
+
+      expect(full.left, 96);
+      expect(full.top, 54);
+    });
+
+    test('scales with the viewport rather than assuming 1080p', () {
+      final insets = tvTitleSafeInsets(const Size(3840, 2160));
+
+      expect(insets.left, 192);
+      expect(tvFullTitleSafeInsets(const Size(3840, 2160)).top, 108);
+    });
+
+    test('keeps the measured sidebar edge inside the safe band', () {
+      // The rail is 88pt wide and its logo began at x=32 of the raw panel.
+      // Once the shell is inset, the same rail starts at the inset instead,
+      // so its content can no longer land in the cropped band.
+      final insets = tvTitleSafeInsets(const Size(1920, 1080));
+      const measuredLeftmostContentBeforeFix = 32.0;
+
+      expect(
+        measuredLeftmostContentBeforeFix,
+        lessThan(insets.left),
+        reason: 'this is the regression the inset exists to prevent',
+      );
+      expect(
+        insets.left,
+        greaterThanOrEqualTo(measuredLeftmostContentBeforeFix),
+        reason: 'the inset has to be at least as wide as the observed overhang',
+      );
+    });
+  });
+
+  group('shell applies the inset', () {
+    Future<void> pumpShell(
+      WidgetTester tester, {
+      required bool fullscreen,
+    }) async {
+      tester.view.physicalSize = const Size(1920, 1080);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.reset);
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            isFullscreenModeProvider.overrideWith((ref) => fullscreen),
+          ],
+          child: const MaterialApp(home: TvShell(child: SizedBox.shrink())),
+        ),
+      );
+      await tester.pump();
+    }
+
+    testWidgets('chrome is inset when the player is not fullscreen', (
+      tester,
+    ) async {
+      await pumpShell(tester, fullscreen: false);
+
+      final padding = tester.widget<Padding>(
+        find.byKey(const Key('tv-title-safe-inset')),
+      );
+
+      expect(
+        padding.padding,
+        const EdgeInsets.symmetric(horizontal: 96),
+        reason: 'the rail must start inside the croppable band',
+      );
+    });
+
+    testWidgets('fullscreen playback is not inset', (tester) async {
+      await pumpShell(tester, fullscreen: true);
+
+      expect(
+        find.byKey(const Key('tv-title-safe-inset')),
+        findsNothing,
+        reason:
+            'video should fill the panel; losing picture to overscan is normal, '
+            'losing navigation is not',
+      );
+    });
+  });
+}

--- a/packages/feature_iptv/lib/presentation/tv/settings/tv_playback_section.dart
+++ b/packages/feature_iptv/lib/presentation/tv/settings/tv_playback_section.dart
@@ -93,11 +93,17 @@ class _AspectRatioOption extends StatelessWidget {
           padding: const EdgeInsets.all(16),
           child: Row(
             children: [
-              Text(
-                label,
-                style: TextStyle(color: colorScheme.onSurface, fontSize: 16),
+              // Flexible rather than Text + Spacer: the row has to survive a
+              // narrower viewport (the TV shell reserves a title-safe margin)
+              // and long localised labels, either of which overflowed a
+              // fixed-width label.
+              Expanded(
+                child: Text(
+                  label,
+                  overflow: TextOverflow.ellipsis,
+                  style: TextStyle(color: colorScheme.onSurface, fontSize: 16),
+                ),
               ),
-              const Spacer(),
               if (isSelected) Icon(Icons.check, color: colorScheme.primary),
             ],
           ),


### PR DESCRIPTION
Fixes the measured half of #1429.

## Measured on real TV hardware

Rig Fire TV Stick (AFTSSS, Android 9), 1920x1080, `io.airo.app.tv` 0.0.6-rc.1. UI pixels inside each title-safe margin (96 x 54):

| margin | UI pixels | extreme |
|---|---|---|
| left | 2438 | leftmost UI at **x=32** |
| top | 563 | topmost at **y=0** |
| right | 717 | — |
| bottom | 2488 | — |

The left band is the entire primary navigation rail (Home, Guide, Movies, Favorites, Settings). On a TV with overscan enabled that is the first thing cropped, and it is the only way to move around the app.

## Change

Reserve the conventional 5% **horizontally** at the shell root, so every leanback surface inherits it instead of each screen padding itself. Computed from the viewport, so a 4K panel gets 192 rather than a hardcoded 1080p value.

Fullscreen playback is exempt — video should fill the panel, and losing a few pixels of picture to overscan is normal where losing navigation is not.

## Why horizontal only

My first attempt reserved both axes and **broke `tv_router_test`** with a 48px bottom overflow: several TV settings columns are laid out to the full panel height and do not scroll, so a 108px vertical reservation does not fit. Fixing those columns is a bigger change than this defect justifies.

The top and bottom bands hold a section label and a scrollable card row — cropping those costs far less than losing the nav rail. `tvFullTitleSafeInsets` still expresses the full convention, so the deferred half is visible in code rather than quietly dropped. I have left #1429 open for it.

## Also fixed

Two TV settings rows were `Text + Spacer + Icon` with a non-flexible label and overflowed by 42px the moment the viewport narrowed. They would equally have overflowed on a narrower panel or with a long localised label, so the label is now `Expanded` with ellipsis. That is a robustness fix, not a workaround for the inset.

## Verification

- `app/test/core/app` — **36 pass** (was failing with the naive both-axes version)
- `feature_iptv` `tv_ux` — **84 pass**
- Mutation tested: removing the inset fails the non-fullscreen case; replacing `Padding` with a non-insetting `Container` also fails.

## Not verified

I have not re-measured on the Fire TV Stick after this change — that needs a TV build and install. The geometry is asserted in tests, but the on-panel confirmation is still outstanding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)