### PR TITLE
fix(app): move Guide/Favorites into IPTV, Settings under Profile

### DIFF
--- a/app/lib/core/providers/navigation_provider.dart
+++ b/app/lib/core/providers/navigation_provider.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_riverpod/legacy.dart';
-import '../routing/route_names.dart';
 
 /// NOTE (CV unified-browse Task 5): the first six members below (`coins`
 /// through `quest`) are the pre-existing super-app domains and are
@@ -10,9 +9,11 @@ import '../routing/route_names.dart';
 /// every index-based reference (`AppNavigationTab.beats.index`, etc.) keeps
 /// working exactly as before.
 ///
-/// `home`, `guide`, `favorites`, and `settings` are new: they back the
-/// 5-destination phone bottom nav that mirrors the TV sidebar
+/// `home` is new: it backs the phone bottom nav that mirrors the TV sidebar
 /// (`tv_shell.dart`) — see `appNavigationPolicy.compactPrimaryTabs` below.
+/// Guide, Favorites, and Settings are IPTV-internal / profile-reachable only
+/// (see `IptvNavigationDrawer` and `ProfileScreen`'s Settings entry) — they
+/// are not top-level nav destinations.
 /// `home` renders the same IPTVScreen as `live` (unified-browse Task 6):
 /// the source design's sidebar calls the identical `goToBrowse` handler for
 /// its Home and Live TV items, so they're the same destination here too;
@@ -60,24 +61,6 @@ enum AppNavigationTab {
     path: '/home',
     icon: Icons.home_outlined,
     selectedIcon: Icons.home,
-  ),
-  guide(
-    label: 'Guide',
-    path: '/guide',
-    icon: Icons.grid_view_outlined,
-    selectedIcon: Icons.grid_view,
-  ),
-  favorites(
-    label: 'Favorites',
-    path: '/favorites',
-    icon: Icons.favorite_border,
-    selectedIcon: Icons.favorite,
-  ),
-  settings(
-    label: 'Settings',
-    path: RouteNames.settings,
-    icon: Icons.settings_outlined,
-    selectedIcon: Icons.settings,
   );
 
   const AppNavigationTab({
@@ -96,7 +79,7 @@ enum AppNavigationTab {
 /// Current navigation tab index.
 ///
 /// Declaration/branch order: Coins | Mind | Beats | Live | Arena | Quest |
-/// Home | Guide | Favorites | Settings
+/// Home
 final currentNavigationTabProvider = StateProvider<int>(
   (ref) => AppNavigationTab.coins.index,
 );
@@ -168,16 +151,15 @@ class AppNavigationPolicy {
 /// Airo TV owns its separate navigation policy in `tv_shell.dart`.
 ///
 /// Wide (tablet/desktop) layouts get a *different* curated set, not the
-/// full ten-tab list: the original six super-app domains (Coins, Mind,
-/// Beats, Live, Arena, Quest) plus the two new IPTV-adjacent destinations
-/// worth persistent nav real estate on larger screens (Guide, Favorites).
-/// `home` is deliberately left out here — it's a phone-only placeholder for
-/// the unified browse entry point (see the enum doc above), and `mind`
-/// already covers that ground on wide layouts, so including both reads as
-/// a confusing duplicate. `settings` is left out too, matching the
-/// pre-unified-browse convention: it has never had a persistent nav slot
-/// and stays reachable via the profile menu (`AppShell.onProfileTap` ->
-/// `ProfileScreen`'s "Settings" entry) regardless of screen width.
+/// full seven-tab list: just the six super-app domains (Coins, Mind, Beats,
+/// Live, Arena, Quest). `home` is deliberately left out here — it's a
+/// phone-only placeholder for the unified browse entry point (see the enum
+/// doc above), and `mind` already covers that ground on wide layouts, so
+/// including both reads as a confusing duplicate. Guide, Favorites, and
+/// Settings are never top-level tabs on any width: Guide/Favorites live
+/// inside the IPTV section's own drawer (`IptvNavigationDrawer`), and
+/// Settings stays reachable via the profile menu (`AppShell.onProfileTap`
+/// -> `ProfileScreen`'s "Settings" entry).
 const appNavigationPolicy = AppNavigationPolicy(
   compactPrimaryTabs: [
     AppNavigationTab.coins,
@@ -192,16 +174,11 @@ const appNavigationPolicy = AppNavigationPolicy(
     AppNavigationTab.live,
     AppNavigationTab.arena,
     AppNavigationTab.quest,
-    AppNavigationTab.guide,
-    AppNavigationTab.favorites,
   ],
   overflowTabs: [
     AppNavigationTab.arena,
     AppNavigationTab.quest,
     AppNavigationTab.home,
-    AppNavigationTab.guide,
-    AppNavigationTab.favorites,
-    AppNavigationTab.settings,
   ],
 );
 

--- a/app/lib/core/routing/app_router.dart
+++ b/app/lib/core/routing/app_router.dart
@@ -1,6 +1,5 @@
 import 'package:core_product_shell/core_product_shell.dart';
 import 'package:core_ai/core_ai.dart';
-import 'package:feature_iptv/feature_iptv.dart';
 import 'package:go_router/go_router.dart';
 import '../../features/auth/screens/login_screen.dart';
 import '../../features/auth/screens/register_screen.dart';
@@ -125,9 +124,21 @@ class AppRouter {
           name: 'airo_explore',
           builder: (context, state) => const AiroExploreScreen(),
         ),
-        // Settings moved into the StatefulShellRoute below (CV unified-browse
-        // Task 5) so it's a persistent bottom-nav tab, matching the TV
-        // sidebar's Settings destination, instead of a one-off pushed route.
+        // Settings is a plain pushed route (not a shell branch/persistent
+        // tab): its only entry point is the "Settings" ListTile on
+        // ProfileScreen (`context.push(RouteNames.settings)`).
+        GoRoute(
+          path: RouteNames.settings,
+          name: RouteNames.settings,
+          builder: (context, state) => const SettingsHubScreen(),
+          routes: [
+            GoRoute(
+              path: 'airo-portability',
+              name: 'airo_portability',
+              builder: (context, state) => const AiroPortabilityScreen(),
+            ),
+          ],
+        ),
         GoRoute(
           path: RouteNames.login,
           name: RouteNames.login,
@@ -340,55 +351,6 @@ class AppRouter {
                   path: '/home',
                   name: 'Home',
                   builder: (context, state) => const HomeScreen(),
-                ),
-              ],
-            ),
-            // Guide branch (CV unified-browse Task 5): reuses the existing
-            // IptvGuideScreen (previously only reachable via an in-screen
-            // Navigator.push from IPTVScreen) as its own persistent tab.
-            StatefulShellBranch(
-              routes: [
-                GoRoute(
-                  path: '/guide',
-                  name: 'Guide',
-                  builder: (context, state) => IptvGuideScreen(
-                    onChannelSelected: () => context.go('/iptv'),
-                  ),
-                ),
-              ],
-            ),
-            // Favorites branch (CV unified-browse Task 5): uses the real
-            // mobile favorites screen (packages/feature_iptv/lib/presentation/
-            // screens/mobile_favorites_screen.dart), landed on main after this
-            // task's original TvFavoritesScreen stopgap — picked up on rebase.
-            StatefulShellBranch(
-              routes: [
-                GoRoute(
-                  path: '/favorites',
-                  name: 'Favorites',
-                  builder: (context, state) => MobileFavoritesScreen(
-                    onChannelSelected: () => context.go('/iptv'),
-                  ),
-                ),
-              ],
-            ),
-            // Settings branch (CV unified-browse Task 5): moved from a
-            // standalone pushed route (above) into the shell so it behaves as
-            // a persistent tab, matching the TV sidebar's Settings destination.
-            StatefulShellBranch(
-              routes: [
-                GoRoute(
-                  path: RouteNames.settings,
-                  name: RouteNames.settings,
-                  builder: (context, state) => const SettingsHubScreen(),
-                  routes: [
-                    GoRoute(
-                      path: 'airo-portability',
-                      name: 'airo_portability',
-                      builder: (context, state) =>
-                          const AiroPortabilityScreen(),
-                    ),
-                  ],
                 ),
               ],
             ),

--- a/app/lib/features/settings/presentation/screens/settings_hub_screen.dart
+++ b/app/lib/features/settings/presentation/screens/settings_hub_screen.dart
@@ -66,6 +66,15 @@ class SettingsHubScreen extends ConsumerWidget {
               onTap: () => context.push('/settings/airo-portability'),
             ),
 
+            const SizedBox(height: 24),
+
+            // Every tile below comes from the shared iptvSettingsSections
+            // manifest (SSOT with TvSettingsScreen) — grouped under one
+            // header so IPTV configuration reads as a single section instead
+            // of appearing inter-mixed with app-wide settings.
+            Text('IPTV', style: Theme.of(context).textTheme.titleMedium),
+            const SizedBox(height: 8),
+
             ListTile(
               leading: Icon(
                 _section(IptvSettingsSectionId.theme).iconFor(ShellId.mobile),

--- a/app/test/core/app/app_shell_navigation_policy_test.dart
+++ b/app/test/core/app/app_shell_navigation_policy_test.dart
@@ -19,7 +19,7 @@ void main() {
 
     // Branch order must mirror AppNavigationTab.values in
     // navigation_provider.dart: Coins | Mind | Beats | Live | Arena | Quest |
-    // Home | Guide | Favorites | Settings.
+    // Home.
     final router = GoRouter(
       initialLocation: initialLocation,
       routes: [
@@ -96,33 +96,6 @@ void main() {
                 ),
               ],
             ),
-            StatefulShellBranch(
-              routes: [
-                GoRoute(
-                  path: '/guide',
-                  builder: (context, state) =>
-                      const _ShellBodyScreen(label: 'Guide body'),
-                ),
-              ],
-            ),
-            StatefulShellBranch(
-              routes: [
-                GoRoute(
-                  path: '/favorites',
-                  builder: (context, state) =>
-                      const _ShellBodyScreen(label: 'Favorites body'),
-                ),
-              ],
-            ),
-            StatefulShellBranch(
-              routes: [
-                GoRoute(
-                  path: '/settings',
-                  builder: (context, state) =>
-                      const _RouteOwnedScreen(title: 'Settings'),
-                ),
-              ],
-            ),
           ],
         ),
       ],
@@ -150,9 +123,6 @@ void main() {
     expect(find.byKey(const ValueKey('app_nav_arena')), findsNothing);
     expect(find.byKey(const ValueKey('app_nav_quest')), findsNothing);
     expect(find.byKey(const ValueKey('app_nav_home')), findsNothing);
-    expect(find.byKey(const ValueKey('app_nav_guide')), findsNothing);
-    expect(find.byKey(const ValueKey('app_nav_favorites')), findsNothing);
-    expect(find.byKey(const ValueKey('app_nav_settings')), findsNothing);
 
     expect(find.text('Coins body'), findsOneWidget);
     expect(tester.takeException(), isNull);
@@ -166,16 +136,17 @@ void main() {
     await tester.tap(find.byKey(const ValueKey('app_nav_overflow')));
     await tester.pumpAndSettle();
     await tester.tap(
-      find.byKey(const ValueKey('app_nav_overflow_entry_guide')),
+      find.byKey(const ValueKey('app_nav_overflow_entry_home')),
     );
     await tester.pumpAndSettle();
 
-    expect(find.text('Guide body'), findsOneWidget);
+    expect(find.text('Home body'), findsOneWidget);
   });
 
   testWidgets(
-    'wider layouts show a curated 8-tab set, excluding the placeholder '
-    'Home tab and Settings (reachable via the profile menu instead)',
+    'wider layouts show a curated 6-tab set, excluding the placeholder '
+    'Home tab (Guide/Favorites live inside IPTV, Settings via the profile '
+    'menu)',
     (tester) async {
       // Wide layouts don't have a /home branch in their nav bar, so start
       // from a destination that is actually part of the wide tab set.
@@ -187,15 +158,12 @@ void main() {
       expect(find.byKey(const ValueKey('app_nav_live')), findsOneWidget);
       expect(find.byKey(const ValueKey('app_nav_arena')), findsOneWidget);
       expect(find.byKey(const ValueKey('app_nav_quest')), findsOneWidget);
-      expect(find.byKey(const ValueKey('app_nav_guide')), findsOneWidget);
-      expect(find.byKey(const ValueKey('app_nav_favorites')), findsOneWidget);
       expect(find.byKey(const ValueKey('app_nav_overflow')), findsNothing);
 
       // Home is a phone-only placeholder (Mind already covers this ground
-      // on wide layouts) and Settings stays reachable via the profile
-      // menu, so neither gets a persistent destination on wide layouts.
+      // on wide layouts), so it gets no persistent destination on wide
+      // layouts either.
       expect(find.byKey(const ValueKey('app_nav_home')), findsNothing);
-      expect(find.byKey(const ValueKey('app_nav_settings')), findsNothing);
     },
   );
 }

--- a/app/test/core/providers/navigation_provider_test.dart
+++ b/app/test/core/providers/navigation_provider_test.dart
@@ -4,7 +4,7 @@ import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   group('AppNavigationTab', () {
-    test('uses the ten-tab information architecture order', () {
+    test('uses the seven-tab information architecture order', () {
       expect(AppNavigationTab.values.map((tab) => tab.label), [
         'Coins',
         'Mind',
@@ -13,9 +13,6 @@ void main() {
         'Arena',
         'Quest',
         'Home',
-        'Guide',
-        'Favorites',
-        'Settings',
       ]);
     });
 
@@ -38,9 +35,6 @@ void main() {
         '/games',
         '/quest',
         '/home',
-        '/guide',
-        '/favorites',
-        '/settings',
       ]);
     });
 
@@ -48,7 +42,7 @@ void main() {
       final rootLabels = AppNavigationTab.values.map((tab) => tab.label);
       final rootPaths = AppNavigationTab.values.map((tab) => tab.path);
 
-      expect(AppNavigationTab.values.length, 10);
+      expect(AppNavigationTab.values.length, 7);
       expect(rootLabels, containsAll(['Beats', 'Live']));
       expect(rootPaths, containsAll(['/music', '/iptv']));
     });
@@ -127,9 +121,6 @@ void main() {
         'Arena',
         'Quest',
         'Home',
-        'Guide',
-        'Favorites',
-        'Settings',
       ]);
       expect(phoneLayout.usesOverflow, isTrue);
       expect({
@@ -138,7 +129,7 @@ void main() {
       }, containsAll(AppNavigationTab.values));
     });
 
-    test('wide layouts show the six core domains plus Guide and Favorites', () {
+    test('wide layouts show only the six core super-app domains', () {
       final container = ProviderContainer();
       addTearDown(container.dispose);
 
@@ -153,18 +144,10 @@ void main() {
         'Live',
         'Arena',
         'Quest',
-        'Guide',
-        'Favorites',
       ]);
       // Home remains reachable from the persistent shell identity, so wide
-      // navigation can prioritize the eight daily-use destinations.
+      // navigation can prioritize the six daily-use destinations.
       expect(wideLayout.persistentTabs, isNot(contains(AppNavigationTab.home)));
-      // Settings has never had a persistent nav slot; it stays reachable
-      // via the profile menu regardless of screen width.
-      expect(
-        wideLayout.persistentTabs,
-        isNot(contains(AppNavigationTab.settings)),
-      );
       expect(wideLayout.overflowTabs, isEmpty);
       expect(wideLayout.usesOverflow, isFalse);
     });

--- a/app/test/core/routing/guide_back_behavior_test.dart
+++ b/app/test/core/routing/guide_back_behavior_test.dart
@@ -29,7 +29,7 @@ void main() {
 
   Future<GoRouter> pumpApp(
     WidgetTester tester, {
-    String initialLocation = '/guide',
+    String initialLocation = '/iptv',
   }) async {
     SharedPreferences.setMockInitialValues({'is_logged_in': true});
     final prefs = await SharedPreferences.getInstance();
@@ -82,58 +82,44 @@ void main() {
     return router;
   }
 
-  testWidgets('guide tab renders the guide screen', (tester) async {
-    final router = await pumpApp(tester);
-
-    expect(_currentPath(router), '/guide');
-    expect(find.text('Search the guide'), findsOneWidget);
-  });
-
-  testWidgets('system back on the guide root tab keeps the shell sane', (
-    tester,
-  ) async {
-    final router = await pumpApp(tester);
-
-    expect(_currentPath(router), '/guide');
-    expect(find.text('Search the guide'), findsOneWidget);
-
-    final didPop = await tester.binding.handlePopRoute();
-    await tester.pump();
-    await tester.pump();
-
-    expect(tester.takeException(), isNull);
-    expect(didPop, isFalse);
-    expect(_currentPath(router), '/guide');
-    expect(find.text('Search the guide'), findsOneWidget);
-    expect(find.byType(Scaffold), findsAtLeastNWidgets(1));
-  });
-
-  testWidgets('back from a route pushed on top of guide returns to guide', (
-    tester,
-  ) async {
-    final router = await pumpApp(tester);
-    router.go('/guide');
-    await tester.pump();
-    await tester.pump();
-
-    expect(_currentPath(router), '/guide');
-    expect(router.canPop(), isFalse);
-
-    router.push('/mind/notifications');
+  // Guide is no longer a top-level GoRouter tab: it lives only inside the
+  // IPTV section's own drawer (IptvNavigationDrawer -> IPTVScreen._openGuide),
+  // pushed with a plain Navigator.push on the IPTV screen's own Navigator.
+  // The GoRouter location therefore stays at '/iptv' throughout.
+  Future<void> openGuideFromIptvDrawer(WidgetTester tester) async {
+    await tester.tap(find.byIcon(Icons.menu).first);
     await tester.pumpAndSettle();
+    await tester.tap(find.text('Guide'));
+    await tester.pumpAndSettle();
+  }
 
-    expect(router.canPop(), isTrue);
-    expect(find.text('Notifications (0)'), findsOneWidget);
+  testWidgets('opening Guide from the IPTV drawer renders the guide screen', (
+    tester,
+  ) async {
+    final router = await pumpApp(tester);
+
+    await openGuideFromIptvDrawer(tester);
+
+    expect(_currentPath(router), '/iptv');
+    expect(find.text('Search the guide'), findsOneWidget);
+  });
+
+  testWidgets('system back on a pushed guide screen returns to IPTV', (
+    tester,
+  ) async {
+    final router = await pumpApp(tester);
+
+    await openGuideFromIptvDrawer(tester);
+    expect(find.text('Search the guide'), findsOneWidget);
 
     final didPop = await tester.binding.handlePopRoute();
     await tester.pumpAndSettle();
 
     expect(tester.takeException(), isNull);
     expect(didPop, isTrue);
-    expect(_currentPath(router), '/guide');
-    expect(router.canPop(), isFalse);
-    expect(find.text('Notifications (0)'), findsNothing);
-    expect(find.text('Search the guide'), findsOneWidget);
+    expect(_currentPath(router), '/iptv');
+    expect(find.text('Search the guide'), findsNothing);
+    expect(find.byType(Scaffold), findsAtLeastNWidgets(1));
   });
 }
 

--- a/app/test/features/settings/presentation/screens/settings_hub_screen_test.dart
+++ b/app/test/features/settings/presentation/screens/settings_hub_screen_test.dart
@@ -55,6 +55,7 @@ void main() {
 
     expect(find.text('Settings'), findsOneWidget);
     expect(find.byTooltip('Back'), findsOneWidget);
+    expect(find.text('IPTV'), findsOneWidget);
     expect(find.text('Appearance'), findsOneWidget);
     expect(find.text('Choose your visual theme'), findsOneWidget);
     expect(find.text('Airo Cyber'), findsNothing);

--- a/docs/superpowers/specs/2026-08-02-iptv-nav-settings-regroup-design.md
+++ b/docs/superpowers/specs/2026-08-02-iptv-nav-settings-regroup-design.md
@@ -1,0 +1,103 @@
+# IPTV Nav Regroup + Settings-Under-Profile — Design
+
+Date: 2026-08-02
+
+## Problem
+
+Guide and Favorites were previously promoted from IPTV into top-level
+persistent nav tabs (`app_router.dart` comment at the Guide branch confirms
+this was deliberate). This duplicates navigation: the same screens
+(`IptvGuideScreen`, `MobileFavoritesScreen`) are reachable both from the
+top-level tab bar/overflow sheet and from `IptvNavigationDrawer` inside the
+IPTV section itself. Settings is also a top-level tab despite a code comment
+saying it "has never had a persistent nav slot and stays reachable via the
+profile menu" — the enum/overflow wiring contradicts that intent.
+
+## Goal
+
+1. Guide and Favorites become IPTV-internal only — reachable via the existing
+   `IptvNavigationDrawer`, not the top-level tab bar or the phone "More"
+   overflow sheet.
+2. Settings is removed from the top-level tab bar/overflow. Its sole entry
+   point becomes the existing "Settings" `ListTile` on `ProfileScreen`
+   (already present at `profile_screen.dart:65-72`, already navigates to
+   `RouteNames.settings`).
+3. IPTV-specific settings tiles (Theme, Audio, Playback, Playlist Source, EPG
+   Guide Source, Country — sourced from `feature_iptv_core`'s
+   `iptvSettingsSections` manifest) are visually grouped under one "IPTV"
+   section header in `SettingsHubScreen`, instead of appearing as a flat tile
+   list alongside non-IPTV settings.
+
+## Non-goals
+
+- No changes to `feature_iptv_core` (`iptv_settings_manifest.dart`,
+  `iptv_navigation_manifest.dart`) — manifests already correctly describe the
+  IPTV settings/nav destinations.
+- No new screens, no new routes, no change to `IptvGuideScreen`,
+  `MobileFavoritesScreen`, or `IptvNavigationDrawer` internals.
+- No change to `SettingsHubScreen`'s non-IPTV sections (Airo Mind
+  portability, Developer Tools, etc.) beyond making room for the new IPTV
+  group header.
+- TV shell (`tv_shell.dart` nav rail) is out of scope — it already mirrors
+  the IPTV drawer's Home/Guide/Movies/Favorites structure and is unaffected
+  by phone/tablet top-level tab changes.
+
+## Changes
+
+### 1. `app/lib/core/providers/navigation_provider.dart`
+- Remove `AppNavigationTab.guide`, `.favorites`, `.settings` enum entries (or
+  keep the enum values but stop referencing them in `widePrimaryTabs` /
+  `overflowTabs` — whichever keeps `app_router.dart` branch wiring simplest;
+  implementer's call after reading the current switch statements).
+- Remove their entries from `widePrimaryTabs` (lines ~195-196) and
+  `overflowTabs` (lines ~202-204).
+
+### 2. `app/lib/core/routing/app_router.dart`
+- Remove the top-level Guide branch (~349-359), Favorites branch (~364-374),
+  and Settings tab branch (~378-394) from the `StatefulShellRoute`.
+- Settings route (`/settings` + `airo-portability` sub-route) must still
+  exist and be reachable by direct push (from Profile) — move it to a plain
+  (non-shell-branch) route registration alongside `/mind/profile` so
+  `Navigator.pushNamed(RouteNames.settings)` from `ProfileScreen` keeps
+  working.
+- Guide/Favorites need no standalone route once removed from the shell —
+  they're pushed from within IPTV via `IptvNavigationDrawer`'s existing
+  `Navigator.push` calls (`iptv_screen.dart:617-635`), which build the
+  widgets directly rather than going through named routes. Confirm no other
+  code references `RouteNames.guide` / `RouteNames.favorites` before
+  deleting; if something does, keep a route but drop it from the shell
+  branches only.
+
+### 3. `app/lib/features/agent_chat/presentation/screens/profile_screen.dart`
+- No structural change — the existing Settings `ListTile` (lines 65-72)
+  already does the right thing. Verify after the router change that it still
+  resolves correctly now that Settings is a plain route, not a shell branch.
+
+### 4. `app/lib/features/settings/presentation/screens/settings_hub_screen.dart`
+- Wrap the IPTV-sourced tiles (Theme, Audio, Playback, `CountrySettingsTile`,
+  Playlist Source, EPG Guide Source — lines ~32-110) in a single labeled
+  section (header text "IPTV", consistent with whatever section-header
+  pattern the screen already uses for its other groups, e.g. Airo Mind
+  portability). Iterate `iptvSettingsSections` manifest entries under this
+  one header instead of rendering them inter-mixed with non-IPTV settings.
+- Non-IPTV sections (Airo Mind portability, Developer Tools) keep their
+  current headers/order relative to the new IPTV group.
+
+## Testing
+
+- `flutter analyze` clean on `app/`.
+- Existing widget/golden tests touching `navigation_provider.dart`,
+  `app_router.dart`, `settings_hub_screen.dart`, or bottom nav tab count must
+  be updated to reflect 3 fewer top-level tabs (or however many tabs remain)
+  — search for tests asserting on `AppNavigationTab` values or tab counts.
+- Manual check (documented in PR description, not necessarily device-tested
+  given worktree constraints): Profile → Settings → IPTV group visible;
+  IPTV section → drawer → Guide/Favorites open; top-level tab bar/overflow
+  no longer lists Guide/Favorites/Settings.
+
+## Risk
+
+Low — pure nav/route/UI-grouping change, no manifest or business-logic
+change, no cross-package boundary violation (all edits stay inside `app/`
+except reading — not modifying — `feature_iptv`/`feature_iptv_core`
+manifests already exported for this purpose).


### PR DESCRIPTION
## Summary
- Guide and Favorites are no longer top-level bottom-nav tabs / overflow-sheet entries — they were duplicated: also reachable via `IptvNavigationDrawer` inside the IPTV section, which is unchanged and now the sole entry point.
- Settings is no longer a top-level tab either; its sole entry point is the existing "Settings" `ListTile` on `ProfileScreen`.
- `SettingsHubScreen` groups its IPTV-sourced tiles (Theme, Audio, Playback, Country, Playlist Source, EPG Guide Source — all from the shared `iptvSettingsSections` manifest) under one "IPTV" header instead of a flat list.
- No changes to `feature_iptv` / `feature_iptv_core` manifests, no new screens/routes, no TV shell changes (out of scope).

Design doc: `docs/superpowers/specs/2026-08-02-iptv-nav-settings-regroup-design.md`

## Test plan
- [x] `flutter analyze` clean on `app/`
- [x] Updated + passing: `navigation_provider_test.dart`, `app_shell_navigation_policy_test.dart`, `guide_back_behavior_test.dart`, `settings_hub_screen_test.dart`
- [ ] Manual device check: Profile → Settings shows grouped IPTV section; IPTV → drawer → Guide/Favorites still open; top-level tab bar/overflow no longer lists Guide/Favorites/Settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)