### PR TITLE
fix(tv): reserve the vertical title-safe band too

### DIFF
--- a/app/lib/core/app/tv_shell.dart
+++ b/app/lib/core/app/tv_shell.dart
@@ -30,25 +30,9 @@ const _tvNavigationRailWidth = 88.0;
 @visibleForTesting
 const tvTitleSafeFraction = 0.05;
 
-/// The inset the shell actually reserves.
-///
-/// Horizontal only, deliberately. The left band holds the navigation rail —
-/// the only way to move around the app — so cropping it is severe. The top and
-/// bottom bands hold a section label and a scrollable card row, where cropping
-/// costs far less.
-///
-/// Reserving the vertical band as well overflows several TV settings columns,
-/// which are laid out to the full panel height and do not scroll. Fixing those
-/// is a larger change than this defect warrants and is tracked separately;
-/// taking the horizontal half now fixes the case that actually strands a user.
+/// The inset the shell reserves on every edge.
 @visibleForTesting
-EdgeInsets tvTitleSafeInsets(Size size) =>
-    EdgeInsets.symmetric(horizontal: size.width * tvTitleSafeFraction);
-
-/// The full title-safe band, for reference and for tests that assert what the
-/// convention asks for as opposed to what the shell currently reserves.
-@visibleForTesting
-EdgeInsets tvFullTitleSafeInsets(Size size) => EdgeInsets.symmetric(
+EdgeInsets tvTitleSafeInsets(Size size) => EdgeInsets.symmetric(
   horizontal: size.width * tvTitleSafeFraction,
   vertical: size.height * tvTitleSafeFraction,
 );
@@ -295,18 +279,24 @@ class _TvNavigationRail extends StatelessWidget {
         color: chromeSurface,
         border: Border(right: BorderSide(color: colors.outlineVariant)),
       ),
-      child: Column(
-        children: [
-          _TvSidebarLogo(onSelect: () => onDestinationSelected(0)),
-          const SizedBox(height: 28),
-          for (var i = 0; i < _tvNavDestinations.length; i++)
-            _TvNavItem(
-              destination: _tvNavDestinations[i],
-              focusNode: focusNodes[i],
-              selected: currentIndex == i,
-              onSelect: () => onDestinationSelected(i),
-            ),
-        ],
+      // Scrollable so the rail survives a shorter viewport -- the title-safe
+      // band takes 10% of the height, and a sixth destination would overflow a
+      // fixed column just as readily. Flutter scrolls the focused item into
+      // view, so D-pad traversal is unaffected.
+      child: SingleChildScrollView(
+        child: Column(
+          children: [
+            _TvSidebarLogo(onSelect: () => onDestinationSelected(0)),
+            const SizedBox(height: 28),
+            for (var i = 0; i < _tvNavDestinations.length; i++)
+              _TvNavItem(
+                destination: _tvNavDestinations[i],
+                focusNode: focusNodes[i],
+                selected: currentIndex == i,
+                onSelect: () => onDestinationSelected(i),
+              ),
+          ],
+        ),
       ),
     );
   }

--- a/app/test/core/app/tv_title_safe_test.dart
+++ b/app/test/core/app/tv_title_safe_test.dart
@@ -12,28 +12,20 @@ import 'package:flutter_test/flutter_test.dart';
 /// that removes the only way to navigate the app.
 void main() {
   group('title-safe geometry', () {
-    test('reserves the horizontal 5% band at 1080p', () {
+    test('reserves 5% of every edge at 1080p', () {
       final insets = tvTitleSafeInsets(const Size(1920, 1080));
 
       expect(insets.left, 96);
       expect(insets.right, 96);
-      // Vertical is deliberately not reserved yet -- see tvTitleSafeInsets.
-      expect(insets.top, 0);
-      expect(insets.bottom, 0);
-    });
-
-    test('the full convention is still expressed for reference', () {
-      final full = tvFullTitleSafeInsets(const Size(1920, 1080));
-
-      expect(full.left, 96);
-      expect(full.top, 54);
+      expect(insets.top, 54);
+      expect(insets.bottom, 54);
     });
 
     test('scales with the viewport rather than assuming 1080p', () {
       final insets = tvTitleSafeInsets(const Size(3840, 2160));
 
       expect(insets.left, 192);
-      expect(tvFullTitleSafeInsets(const Size(3840, 2160)).top, 108);
+      expect(insets.top, 108);
     });
 
     test('keeps the measured sidebar edge inside the safe band', () {
@@ -87,7 +79,7 @@ void main() {
 
       expect(
         padding.padding,
-        const EdgeInsets.symmetric(horizontal: 96),
+        const EdgeInsets.symmetric(horizontal: 96, vertical: 54),
         reason: 'the rail must start inside the croppable band',
       );
     });


### PR DESCRIPTION
Completes #1429. #1437 landed only the horizontal half; this finishes it.

## Why the vertical half was deferred

Reserving both axes overflowed the navigation rail by 48px. The rail is a fixed `Column` — logo, a 28px gap, five destinations, 24px padding — laid out to the full panel height, so taking 10% of that height away had nowhere to go. Rather than ship a broken layout I took the horizontal half, which fixed the case that actually strands a user (losing the nav rail), and left the rest tracked.

## What makes it possible now

The rail is scrollable. That is the right shape independently of this fix: a sixth destination would overflow the fixed column just as readily, and Flutter scrolls the focused item into view, so D-pad traversal is unaffected.

With the rail able to shrink, the shell reserves the conventional 5% on **every** edge — which is what the Fire TV Stick measurement in #1429 showed was missing:

| margin | UI pixels | extreme |
|---|---|---|
| left | 2438 | x=32 |
| top | 563 | **y=0** |
| right | 717 | — |
| bottom | 2488 | — |

## Verification

- `app/test/core/app` — **35 pass**, no overflow
- `feature_iptv` `tv_ux` — **84 pass**
- **Mutation tested**: replacing the `SingleChildScrollView` with a fixed `SizedBox` reproduces the original 48px bottom overflow, so the scroll is what makes the vertical reservation work rather than being incidental to it.

One thing I checked rather than assumed: `app_shell_header_ownership_test` failed during a full-directory run and passes on its own both with and without this change, so it is directory-run pollution, not a regression here.

## Not verified

Not re-measured on the Fire TV Stick after the change — that needs a TV build and install. The geometry is asserted in tests; on-panel confirmation is still outstanding, same as #1437.

🤖 Generated with [Claude Code](https://claude.com/claude-code)