### PR TITLE
fix(ai): surface runtime pressure in health reports

### DIFF
--- a/app/test/core/app/app_shell_navigation_policy_test.dart
+++ b/app/test/core/app/app_shell_navigation_policy_test.dart
@@ -135,9 +135,7 @@ void main() {
 
     await tester.tap(find.byKey(const ValueKey('app_nav_overflow')));
     await tester.pumpAndSettle();
-    await tester.tap(
-      find.byKey(const ValueKey('app_nav_overflow_entry_home')),
-    );
+    await tester.tap(find.byKey(const ValueKey('app_nav_overflow_entry_home')));
     await tester.pumpAndSettle();
 
     expect(find.text('Home body'), findsOneWidget);

--- a/packages/core_ai/lib/src/health/model_health_report.dart
+++ b/packages/core_ai/lib/src/health/model_health_report.dart
@@ -302,7 +302,7 @@ class ModelHealthReport {
         compatibility?.memorySeverity == MemorySeverity.critical) {
       return ModelHealthFailureCode.insufficientMemory;
     }
-    return switch (runtimeHealth?.error) {
+    final errorCode = switch (runtimeHealth?.error) {
       RuntimeErrorCode.outOfMemory => ModelHealthFailureCode.insufficientMemory,
       RuntimeErrorCode.runtimeUnavailable =>
         ModelHealthFailureCode.runtimeUnavailable,
@@ -323,6 +323,20 @@ class ModelHealthReport {
         ModelHealthFailureCode.contextTooLarge,
       RuntimeErrorCode.storageFailure => ModelHealthFailureCode.storageFailure,
       RuntimeErrorCode.unknown => ModelHealthFailureCode.unknown,
+      _ => ModelHealthFailureCode.none,
+    };
+    if (errorCode != ModelHealthFailureCode.none) return errorCode;
+
+    // Some native runtimes expose pressure as lifecycle state only. Treat those
+    // states as recoverable facts instead of leaving the Health Center stuck at
+    // "unknown" with a blocked timeline row.
+    return switch (runtimeHealth?.state) {
+      RuntimeHealthState.lowMemory => ModelHealthFailureCode.insufficientMemory,
+      RuntimeHealthState.thermallyLimited =>
+        ModelHealthFailureCode.thermalLimit,
+      RuntimeHealthState.unavailable =>
+        ModelHealthFailureCode.runtimeUnavailable,
+      RuntimeHealthState.failed => ModelHealthFailureCode.initializationFailed,
       _ => ModelHealthFailureCode.none,
     };
   }

--- a/packages/core_ai/test/health/model_health_report_test.dart
+++ b/packages/core_ai/test/health/model_health_report_test.dart
@@ -193,4 +193,65 @@ void main() {
     expect(report.failureCode, ModelHealthFailureCode.unknown);
     expect(report.explanation, contains('unknown failure'));
   });
+
+  test('maps low-memory runtime state to reduced-context recovery', () {
+    final report = ModelHealthReport.fromFacts(
+      model: _model(),
+      runtimeHealth: const RuntimeHealth(
+        state: RuntimeHealthState.lowMemory,
+        detail: 'Runtime paused because memory is low.',
+      ),
+    );
+
+    expect(report.status, ModelHealthReportStatus.recoverable);
+    expect(report.failureCode, ModelHealthFailureCode.insufficientMemory);
+    expect(report.explanation, contains('transient memory'));
+    expect(report.actions, contains(ModelHealthAction.reduceContext));
+    expect(report.actions, contains(ModelHealthAction.chooseAlternative));
+    expect(
+      report.stage(ModelHealthStage.runtimeReady).status,
+      ModelHealthStageStatus.blocked,
+    );
+  });
+
+  test('maps thermal runtime state to retry recovery', () {
+    final report = ModelHealthReport.fromFacts(
+      model: _model(),
+      runtimeHealth: const RuntimeHealth(
+        state: RuntimeHealthState.thermallyLimited,
+      ),
+    );
+
+    expect(report.status, ModelHealthReportStatus.recoverable);
+    expect(report.failureCode, ModelHealthFailureCode.thermalLimit);
+    expect(report.explanation, contains('thermally limited'));
+    expect(report.actions, contains(ModelHealthAction.retry));
+  });
+
+  test('maps unavailable runtime state without an error code', () {
+    final report = ModelHealthReport.fromFacts(
+      model: _model(),
+      runtimeHealth: const RuntimeHealth(state: RuntimeHealthState.unavailable),
+    );
+
+    expect(report.status, ModelHealthReportStatus.recoverable);
+    expect(report.failureCode, ModelHealthFailureCode.runtimeUnavailable);
+    expect(report.explanation, contains('No installed runtime'));
+    expect(report.actions, contains(ModelHealthAction.chooseAlternative));
+  });
+
+  test('maps failed runtime state without an error code', () {
+    final report = ModelHealthReport.fromFacts(
+      model: _model(),
+      runtimeHealth: const RuntimeHealth(
+        state: RuntimeHealthState.failed,
+        detail: 'LiteRT init failed before reporting a typed error.',
+      ),
+    );
+
+    expect(report.status, ModelHealthReportStatus.recoverable);
+    expect(report.failureCode, ModelHealthFailureCode.initializationFailed);
+    expect(report.explanation, contains('LiteRT init failed'));
+    expect(report.actions, contains(ModelHealthAction.retry));
+  });
 }


### PR DESCRIPTION
# Summary

This PR hardens Runtime Health Center diagnostics for state-only runtime pressure.
Goal: avoid showing an unknown health state when a native runtime reports low-memory, thermal, unavailable, or failed lifecycle states without a separate error code.

Core outcome:

* Low-memory runtime state now maps to a recoverable insufficient-memory report.
* Thermal, unavailable, and failed runtime states now map to typed recoverable failures.
* Reduced-context, retry, and alternative-model actions stay visible in the Health Center.

# Changes

### Code

* Updated:
  * packages/core_ai/lib/src/health/model_health_report.dart — maps runtime health lifecycle states to typed failure codes when no explicit runtime error is present.
  * packages/core_ai/test/health/model_health_report_test.dart — adds regression coverage for low-memory, thermal, unavailable, and failed state-only reports.

### Logic

* Runtime error codes still take priority.
* If no runtime error exists, blocked lifecycle states now produce recoverable diagnostics instead of unknown health.
* Low-memory state exposes reduced-context recovery.

# API Changes

None.

# Database Changes

None.

# Observability / Logging

No logging changes. Existing Runtime Health Center output becomes more accurate.

# Performance Impact

No measurable impact. Pure diagnostic mapping only.

# Risks

* Low risk: this changes only health-report classification, not runtime execution.
* Rollback plan: revert this commit if health classification becomes too aggressive.

# Testing

* Unit tests:
  * cd packages/core_ai && flutter analyze lib/src/health/model_health_report.dart test/health/model_health_report_test.dart
  * cd packages/core_ai && flutter test test/health/model_health_report_test.dart --reporter=compact
* UI tests:
  * cd app && flutter test test/features/agent_chat/presentation/screens/model_health_center_screen_test.dart test/features/settings/presentation/screens/intelligent_model_manager_screen_test.dart --reporter=compact
* Merge/release checks:
  * scripts/check-docs-completeness.sh --base origin/main --head HEAD
  * scripts/check-v2-merge-readiness.sh --skip-fetch --base origin/main --next HEAD

# Deployment Notes

None.
