### PR TITLE
ci: format app_shell_navigation_policy_test

### DIFF
--- a/app/test/core/app/app_shell_navigation_policy_test.dart
+++ b/app/test/core/app/app_shell_navigation_policy_test.dart
@@ -135,9 +135,7 @@ void main() {
 
     await tester.tap(find.byKey(const ValueKey('app_nav_overflow')));
     await tester.pumpAndSettle();
-    await tester.tap(
-      find.byKey(const ValueKey('app_nav_overflow_entry_home')),
-    );
+    await tester.tap(find.byKey(const ValueKey('app_nav_overflow_entry_home')));
     await tester.pumpAndSettle();
 
     expect(find.text('Home body'), findsOneWidget);


### PR DESCRIPTION
`app/test/core/app/app_shell_navigation_policy_test.dart` landed on main unformatted, so the `code-quality` gate — which runs `dart format --set-exit-if-changed` over `lib test` — fails on main **and on every pull request**, because a PR's CI builds a merge commit that includes main's copy.

Spotted on #1439, whose own diff does not touch this file:

```
Formatted test/core/app/app_shell_navigation_policy_test.dart
Formatted 628 files (1 changed)
##[error]Process completed with exit code 123
```

Locally on that branch the same sweep reported `628 files (0 changed)` — the difference is precisely main's copy arriving via the merge commit.

This is the same shape as the gate breakage fixed earlier today: the `analyze` job formats only `lib`, so test-only drift sails past it and surfaces one job later, where it reads as the PR's fault rather than main's.

Formatting only — one insertion, three deletions. The 3 tests in the file still pass, and the full `lib test` sweep is clean afterwards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)