### PR TITLE
fix(tv): keep Help reachable in grid-first layout

### DIFF
--- a/packages/feature_iptv/lib/presentation/tv_ux/airo_tv_shell.dart
+++ b/packages/feature_iptv/lib/presentation/tv_ux/airo_tv_shell.dart
@@ -148,6 +148,9 @@ class _AiroTvShellState extends ConsumerState<AiroTvShell> {
     );
     final infoBar = ChannelInfoBar(
       channel: widget.currentChannel,
+      onHelpTap: widget.showVideoStage
+          ? null
+          : () => showAiroTvShellHelpDialog(context),
       onPlaylistSourceTap: widget.onPlaylistSourceTap,
       onWaysToWatchTap: widget.onWaysToWatchTap,
       onScreenshotTap: widget.onShareVideoFrame == null

--- a/packages/feature_iptv/lib/presentation/tv_ux/sections/channel_info_bar.dart
+++ b/packages/feature_iptv/lib/presentation/tv_ux/sections/channel_info_bar.dart
@@ -14,12 +14,17 @@ class ChannelInfoBar extends ConsumerWidget {
   const ChannelInfoBar({
     super.key,
     this.channel,
+    this.onHelpTap,
     this.onPlaylistSourceTap,
     this.onWaysToWatchTap,
     this.onScreenshotTap,
   });
 
   final IPTVChannel? channel;
+
+  /// Opens Airo TV help when the video stage (and its overlay actions) is
+  /// hidden by a grid-first TV layout. Null hides the button.
+  final VoidCallback? onHelpTap;
 
   /// Opens the playlist-source sheet. Wired on TV where the phone app bar
   /// (the usual home of this action) is suppressed; null hides the button.
@@ -51,6 +56,17 @@ class ChannelInfoBar extends ConsumerWidget {
           const SizedBox(width: 8),
           Expanded(child: Text(name, overflow: TextOverflow.ellipsis)),
           const Chip(label: Text('LIVE')),
+          if (onHelpTap != null)
+            TvFocusable(
+              key: const ValueKey('airo-tv-shell-help-action'),
+              semanticLabel: 'Airo TV Help',
+              onSelect: onHelpTap,
+              child: IconButton(
+                onPressed: onHelpTap,
+                tooltip: 'Airo TV Help',
+                icon: const Icon(Icons.help_outline),
+              ),
+            ),
           if (onPlaylistSourceTap != null)
             TvFocusable(
               semanticLabel: 'Playlist source',

--- a/packages/feature_iptv/test/iptv/presentation/tv_ux/airo_tv_shell_test.dart
+++ b/packages/feature_iptv/test/iptv/presentation/tv_ux/airo_tv_shell_test.dart
@@ -7,10 +7,10 @@ import 'package:feature_iptv/application/services/wifi_settings_launcher.dart';
 import 'package:feature_iptv/presentation/tv_ux/airo_tv_shell.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'dart:async';
-import 'dart:typed_data';
 import 'package:platform_channels/platform_channels.dart';
 import 'package:platform_player/platform_player.dart';
 import 'package:platform_streams/platform_streams.dart';
@@ -131,6 +131,26 @@ void main() {
     expect(
       find.byKey(const ValueKey('airo-tv-channel-library')),
       findsOneWidget,
+    );
+    expect(
+      find.byKey(const ValueKey('airo-tv-shell-help-action')),
+      findsOneWidget,
+    );
+
+    await tester.tap(find.byKey(const ValueKey('airo-tv-shell-help-action')));
+    await tester.pumpAndSettle();
+
+    expect(
+      find.byKey(const ValueKey('airo-tv-shell-help-dialog')),
+      findsOneWidget,
+    );
+    expect(find.text('Airo TV Help'), findsOneWidget);
+
+    await tester.sendKeyEvent(LogicalKeyboardKey.escape);
+    await tester.pumpAndSettle();
+    expect(
+      find.byKey(const ValueKey('airo-tv-shell-help-dialog')),
+      findsNothing,
     );
   });
 


### PR DESCRIPTION
## Outcome

Keeps **Airo TV Help** reachable in the Fire TV grid-first layout, where the video stage is intentionally hidden.

## Change

- exposes a focusable Help action in the live channel info bar when `showVideoStage` is false
- reuses the existing Airo TV Help dialog
- avoids duplicating Help when the video-stage action remains visible
- adds a regression test covering open and Back/Escape dismissal

## Local verification

- `flutter test test/iptv/presentation/tv_ux/airo_tv_shell_test.dart test/iptv/presentation/tv_ux/channel_info_bar_test.dart` — 20 passed
- focused `flutter analyze --fatal-infos` — no issues
- exact Airo TV release APK built from `b90a9bb2`; physical Fire TV gate in progress on the shared device

Fire TV scope is exclusively the Airo TV flavor (`io.airo.app.tv`, `main_tv.dart`). The Airo Super App is not installed on Fire TV.