### PR TITLE
ci: check test formatting in the job that owns formatting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,10 +84,16 @@ jobs:
           cd app
           flutter analyze --no-fatal-infos --no-fatal-warnings
 
+      # Covers `lib test`, matching the code-quality job. When this checked only
+      # `lib`, test-file drift passed here and failed one job later -- and,
+      # because a pull request's CI builds a merge commit, it failed on whatever
+      # PR came next rather than the one that introduced it. That misattribution
+      # cost real time twice on 2026-08-01/02 (#1381, #1441) before the cause
+      # was clear. Catch it in the job that owns formatting.
       - name: Check formatting
         run: |
           cd app
-          find lib -name "*.dart" ! -name "*.g.dart" ! -name "*.freezed.dart" -print0 | xargs -0 dart format --set-exit-if-changed
+          find lib test -name "*.dart" ! -name "*.g.dart" ! -name "*.freezed.dart" -print0 | xargs -0 dart format --set-exit-if-changed
 
       - name: Enforce bundled model artifact guardrail
         run: |


### PR DESCRIPTION
The `analyze` job formats only `lib`; `code-quality` formats `lib test`. So drift in a test file passes the earlier job and fails the later one.

That gap is worse than a duplicated check, because **a pull request's CI builds a merge commit with main**. Unformatted test code sitting on main therefore fails whichever PR runs next — not the change that introduced it.

It has cost real time twice in two days:

- **#1381** (2026-08-01) — same shape
- **#1441** (today) — `#1439`'s `code-quality` failure pointed at `app_shell_navigation_policy_test.dart`, a file its diff never touches. The identical sweep on that branch alone reported `628 files (0 changed)`; with main merged in, `1 changed`.

Debugging that meant proving a failure *wasn't* mine before I could proceed, which is exactly the tax a misattributing gate imposes on everyone downstream.

## Change

Widen the `analyze` sweep to `lib test`, so formatting is enforced in the job that already owns it, on the change that causes it. `code-quality` keeps its own check — the duplication is deliberate and cheap; the misattribution was not.

## Verification

- `lib test` sweep clean: **628 files, 0 changed**
- Workflow parses; the `analyze` job's `Check formatting` step now covers `lib test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)