### PR TITLE
fix(ai): show memory details in setup failures

### DIFF
--- a/app/lib/features/agent_chat/presentation/screens/model_library_screen.dart
+++ b/app/lib/features/agent_chat/presentation/screens/model_library_screen.dart
@@ -1065,6 +1065,22 @@ class _ModelLibraryContent extends ConsumerWidget {
                 'Platform: ${diagnostic.platformLabel}',
                 style: Theme.of(context).textTheme.bodySmall,
               ),
+              Text(
+                'Runtime: ${diagnostic.runtimeName}',
+                style: Theme.of(context).textTheme.bodySmall,
+              ),
+              if (diagnostic.reasonCode != null)
+                Text(
+                  'Reason code: ${diagnostic.reasonCode}',
+                  style: Theme.of(context).textTheme.bodySmall,
+                ),
+              if (diagnostic.availableMemoryMB != null ||
+                  diagnostic.requiredMemoryMB != null)
+                Text(
+                  'Memory: ${diagnostic.availableMemoryMB?.toStringAsFixed(0) ?? 'n/a'} MB available · '
+                  '${diagnostic.requiredMemoryMB?.toStringAsFixed(0) ?? 'n/a'} MB estimated peak',
+                  style: Theme.of(context).textTheme.bodySmall,
+                ),
               if (diagnostic.repairActions.isNotEmpty) ...[
                 const SizedBox(height: 12),
                 Text(

--- a/app/test/features/agent_chat/presentation/screens/model_library_screen_test.dart
+++ b/app/test/features/agent_chat/presentation/screens/model_library_screen_test.dart
@@ -619,6 +619,93 @@ void main() {
     expect(find.text('General Chat setup'), findsNothing);
   });
 
+  testWidgets('setup failure dialog shows memory diagnostics', (tester) async {
+    SharedPreferences.setMockInitialValues({});
+    final package = OfflineModelInfo(
+      id: 'gemma-4-e2b-it-litertlm',
+      name: 'Gemma 4 E2B',
+      family: ModelFamily.gemma,
+      fileSizeBytes: 2 * 1024 * 1024 * 1024,
+      backendPreference: ModelBackendPreference.gpu,
+      provider: AIProvider.gemma,
+      capabilities: const [ModelCapability.chat],
+      filePath: '/models/gemma-4-e2b-it.litertlm',
+    );
+    final candidate = AssistantModelCandidate(
+      id: litertGemmaAssistantModelId,
+      name: 'Gemma mobile package',
+      runtime: 'LiteRT-LM local model',
+      description: 'Local package',
+      bestFor: const [AssistantTask.chat],
+      tags: const ['Local', 'Gemma'],
+      privacyLabel: 'Prompt stays on device',
+      sizeLabel: package.fileSizeDisplay,
+      available: true,
+      actionLabel: 'Start',
+      local: true,
+      package: package,
+    );
+    final state = AssistantModelLibraryState(
+      task: AssistantTask.chat,
+      deviceLabel: 'Pixel 9',
+      platformLabel: 'ANDROID',
+      candidates: [candidate],
+      recommended: candidate,
+      defaultPackages: {AssistantTask.chat: package},
+    );
+    final runtimeService = AssistantRuntimeService(
+      loadDeviceInfo: () async => {
+        'manufacturer': 'Google',
+        'model': 'Pixel 9',
+        'platform': 'android',
+      },
+      isLiteRtAvailable: () async => true,
+      checkModelCompatibility: (_) async => const ModelCompatibilityResult(
+        isCompatible: false,
+        memorySeverity: MemorySeverity.blocked,
+        reason: 'Not enough transient memory for warmup.',
+        availableMemoryMB: 1536,
+        requiredMemoryMB: 3072,
+      ),
+    );
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          assistantModelLibraryProvider.overrideWith((ref) async => state),
+          selectedAssistantModelIdProvider.overrideWith(
+            (ref) => _SelectedAssistantModelNotifier(),
+          ),
+        ],
+        child: MaterialApp(
+          home: ModelLibraryScreen(
+            runtimeService: runtimeService,
+            onModelSelected: (_) {},
+            onOpenModelManager: () {},
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Start chat'));
+    await tester.pumpAndSettle();
+
+    expect(
+      find.text('This local package exceeds the current device budget.'),
+      findsOneWidget,
+    );
+    expect(find.text('Runtime: Gemma mobile package'), findsOneWidget);
+    expect(find.text('Reason code: compatibility_blocked'), findsOneWidget);
+    expect(
+      find.text('Memory: 1536 MB available · 3072 MB estimated peak'),
+      findsOneWidget,
+    );
+    expect(
+      find.text('Not enough transient memory for warmup.'),
+      findsOneWidget,
+    );
+  });
+
   testWidgets('download setup dialog opens model management when confirmed', (
     tester,
   ) async {

--- a/docs/wiki/5.-AI-and-Model-Management.md
+++ b/docs/wiki/5.-AI-and-Model-Management.md
@@ -34,6 +34,9 @@ at which point chat opens with the chosen model already selected.
   list; nothing is selected and you can start the project again.
 - If preparation cannot finish, Airo shows the reason with the repair steps for
   that runtime instead of the chat thread.
+- Setup failure dialogs also show the runtime name, reason code, available
+  memory, and estimated peak memory when those diagnostics are available, so the
+  user can understand the failure without copying a debug report.
 
 LiteRT-LM project startup is shown as ready only when Airo has a verified
 downloaded package path or an explicit `LITERT_LM_MODEL_PATH` pointing at a


### PR DESCRIPTION
# Summary

This PR makes chat project setup failures more actionable.
Goal: when a local model cannot load, show the key runtime and memory facts directly in the failure dialog instead of requiring the user to copy diagnostics.

Core outcome:

* Setup failure dialogs now show runtime name, reason code, available memory, and estimated peak memory when available.
* The existing copy-diagnostics action remains available for full reports.
* Widget coverage verifies visible memory diagnostics for LiteRT compatibility failures.

# Changes

### Code

* Updated:
  * app/lib/features/agent_chat/presentation/screens/model_library_screen.dart — surfaces diagnostic runtime, reason, and memory fields in the setup failure dialog.
  * app/test/features/agent_chat/presentation/screens/model_library_screen_test.dart — adds a memory-failure dialog regression.
  * docs/wiki/5.-AI-and-Model-Management.md — documents visible setup failure diagnostics.

### Logic

* No runtime behavior change.
* Uses fields already present in AssistantRuntimeDiagnosticEnvelope.
* Keeps the existing full diagnostics copy path.

# API Changes

None.

# Database Changes

None.

# Observability / Logging

No logging changes. User-visible diagnostics are clearer.

# Performance Impact

No measurable impact. UI text only.

# Risks

* Low risk: this only displays existing diagnostic fields.
* Rollback plan: revert the commit if the dialog becomes too verbose.

# Testing

* cd app && flutter analyze lib/features/agent_chat/presentation/screens/model_library_screen.dart test/features/agent_chat/presentation/screens/model_library_screen_test.dart
* cd app && flutter test test/features/agent_chat/presentation/screens/model_library_screen_test.dart --reporter=compact
* cd app && dart format --set-exit-if-changed lib/features/agent_chat/presentation/screens/model_library_screen.dart test/features/agent_chat/presentation/screens/model_library_screen_test.dart
* scripts/check-docs-completeness.sh --base origin/main --head HEAD
* scripts/check-v2-merge-readiness.sh --skip-fetch --base origin/main --next HEAD

# Deployment Notes

None.
