### PR TITLE
fix(chat): skip empty streaming history entries

### DIFF
--- a/app/lib/features/agent_chat/data/services/chat_history_store.dart
+++ b/app/lib/features/agent_chat/data/services/chat_history_store.dart
@@ -76,6 +76,11 @@ class ChatHistoryStore {
 
   Future<void> save(Iterable<ChatHistoryEntry> entries) async {
     final bounded = entries
+        // Do not persist transient streaming placeholders. A generation can add
+        // an empty assistant bubble before the first token arrives; if the app
+        // is paused or killed at that point, restoring that placeholder creates
+        // a blank chat row on the next launch.
+        .where((entry) => entry.text.trim().isNotEmpty)
         .where((entry) => entry.text.length <= maxEntryCharacters)
         .toList(growable: false);
     final start = bounded.length > maxEntries ? bounded.length - maxEntries : 0;

--- a/app/test/features/agent_chat/data/services/chat_history_store_test.dart
+++ b/app/test/features/agent_chat/data/services/chat_history_store_test.dart
@@ -31,6 +31,23 @@ void main() {
     expect(await store.load(), isEmpty);
   });
 
+  test('chat history does not persist empty streaming placeholders', () async {
+    SharedPreferences.setMockInitialValues({});
+    final preferences = await SharedPreferences.getInstance();
+    final store = ChatHistoryStore(preferences: preferences);
+    final timestamp = DateTime.utc(2026, 7, 30, 2, 30);
+
+    await store.save([
+      ChatHistoryEntry(text: 'question', isUser: true, timestamp: timestamp),
+      ChatHistoryEntry(text: '', isUser: false, timestamp: timestamp),
+      ChatHistoryEntry(text: '   ', isUser: false, timestamp: timestamp),
+      ChatHistoryEntry(text: 'answer', isUser: false, timestamp: timestamp),
+    ]);
+
+    final loaded = await store.load();
+    expect(loaded.map((entry) => entry.text), ['question', 'answer']);
+  });
+
   test(
     'chat history serializes rapid saves so the newest snapshot wins',
     () async {

--- a/docs/wiki/4.-Using-Core-Capabilities.md
+++ b/docs/wiki/4.-Using-Core-Capabilities.md
@@ -14,6 +14,10 @@ the active user prompt from that context before sending the request to the
 selected runtime. This prevents the current prompt from being duplicated in the
 system context and keeps model responses grounded in prior turns only.
 
+Conversation history is saved locally using a bounded, versioned format. If the
+app is interrupted while a response is still streaming, Airo does not restore the
+temporary empty assistant bubble on the next launch.
+
 Examples:
 
 - `Help me think through a task`


### PR DESCRIPTION
# Summary
This PR prevents interrupted AI Chat generations from restoring as blank assistant bubbles.

Core outcome:

* filters transient empty streaming placeholders before chat history is persisted
* adds regression coverage for the restore behavior
* documents the local chat-history behavior in the core capabilities wiki

# Testing

* cd app && flutter analyze lib/features/agent_chat/data/services/chat_history_store.dart test/features/agent_chat/data/services/chat_history_store_test.dart
* cd app && flutter test test/features/agent_chat/data/services/chat_history_store_test.dart --reporter=compact
* scripts/check-docs-completeness.sh --base origin/main --head HEAD
* scripts/check-v2-merge-readiness.sh --skip-fetch --base origin/main --next HEAD