### PR TITLE
fix(ai): skip unconfigured LiteRT preload

### DIFF
--- a/app/lib/core/services/local_runtime_preloader_service.dart
+++ b/app/lib/core/services/local_runtime_preloader_service.dart
@@ -94,7 +94,7 @@ class LocalRuntimePreloaderService {
       if (selectedPackage != null &&
           selectedCandidate?.id != geminiNanoAssistantModelId)
         _LiteRtPackageWarmupAdapter(_liteRtLm, selectedPackage)
-      else if (frequentPackages.isEmpty)
+      else if (frequentPackages.isEmpty && _liteRtLm.hasConfiguredModel)
         _LiteRtInstalledWarmupAdapter(_liteRtLm),
       for (final model in frequentPackages)
         _LiteRtPackageWarmupAdapter(_liteRtLm, model),

--- a/app/test/core/services/local_runtime_preloader_service_test.dart
+++ b/app/test/core/services/local_runtime_preloader_service_test.dart
@@ -72,6 +72,21 @@ void main() {
       contains(frequentModel.id),
     );
   });
+
+  test(
+    'does not warm default LiteRT when no model source is configured',
+    () async {
+      final preloader = _RecordingPreloader();
+      final service = LocalRuntimePreloaderService(preloader: preloader);
+
+      await service.preloadSelectedModels();
+
+      expect(
+        preloader.lastAdapters.map((adapter) => adapter.residentSpec.id),
+        isNot(contains(litertGemmaAssistantModelId)),
+      );
+    },
+  );
 }
 
 class _FixedPreloadPreferences implements ModelPreloadPreferences {


### PR DESCRIPTION
# Summary
This PR prevents Pixel startup diagnostics from reporting the default LiteRT runtime as unavailable when no default LiteRT model path or URL is configured.

Core outcome:

* skips default LiteRT warm-up unless a default model source exists
* keeps selected/downloaded LiteRT packages eligible for warm-up
* adds regression coverage for preloader adapter selection

# Testing

* cd app && flutter analyze lib/core/services/local_runtime_preloader_service.dart test/core/services/local_runtime_preloader_service_test.dart
* cd app && flutter test test/core/services/local_runtime_preloader_service_test.dart --reporter=compact
* scripts/check-docs-completeness.sh --base origin/main --head HEAD
* scripts/check-v2-merge-readiness.sh --skip-fetch --base origin/main --next HEAD