### PR TITLE
fix(ai): distinguish unconfigured preload sidecars

### DIFF
--- a/packages/core_ai/lib/src/preload/model_preloader.dart
+++ b/packages/core_ai/lib/src/preload/model_preloader.dart
@@ -136,12 +136,15 @@ class ModelPreloader {
 
       final available = await adapter.isAvailable();
       if (!available) {
+        final reason = resident.sidecar
+            ? 'sidecar_unconfigured'
+            : 'runtime_unavailable';
         entries.add(
           ModelPreloadReportEntry(
             runtimeId: resident.id,
             residentType: resident.residentType,
             status: ModelPreloadEntryStatus.skipped,
-            reason: 'runtime_unavailable',
+            reason: reason,
             duration: DateTime.now().difference(stepStartedAt),
           ),
         );

--- a/packages/core_ai/test/preload/model_preloader_test.dart
+++ b/packages/core_ai/test/preload/model_preloader_test.dart
@@ -72,6 +72,26 @@ void main() {
       expect(report.entries.single.reason, 'image_models_preload_disabled');
     });
 
+    test('reports unavailable sidecars as unconfigured placeholders', () async {
+      final preloader = ModelPreloader(residencyManager: residencyManager);
+
+      final report = await preloader.preloadSelectedModels(
+        adapters: [
+          NoOpWarmupAdapter(
+            const ModelResidentSpec(
+              id: 'assistant-tts-hook',
+              residentType: ResidentRuntimeType.tts,
+              estimatedMemoryBytes: 128,
+              sidecar: true,
+            ),
+          ),
+        ],
+      );
+
+      expect(report.entries.single.status, ModelPreloadEntryStatus.skipped);
+      expect(report.entries.single.reason, 'sidecar_unconfigured');
+    });
+
     test('aborts remaining warmups after abortPreload is requested', () async {
       late ModelPreloader preloader;
       final warmed = <String>[];


### PR DESCRIPTION
# Summary
This PR makes startup preload diagnostics distinguish unconfigured sidecar placeholders from real unavailable runtimes.

Core outcome:

* TTS/STT placeholder hooks now report sidecar_unconfigured.
* Real unavailable generation runtimes continue to report runtime_unavailable.
* Adds regression coverage in core_ai preload tests.

# Testing

* cd packages/core_ai && flutter test test/preload/model_preloader_test.dart --reporter=compact
* cd packages/core_ai && flutter analyze lib/src/preload/model_preloader.dart test/preload/model_preloader_test.dart
* scripts/check-docs-completeness.sh --base origin/main --head HEAD
* scripts/check-v2-merge-readiness.sh --skip-fetch --base origin/main --next HEAD

# Notes

No docs update required: diagnostic reason-code only.