### PR TITLE
feat(ai): add copyable runtime health diagnostics

### DIFF
--- a/app/lib/features/agent_chat/presentation/screens/model_health_center_screen.dart
+++ b/app/lib/features/agent_chat/presentation/screens/model_health_center_screen.dart
@@ -1,5 +1,6 @@
 import 'package:core_ai/core_ai.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 
 /// Loads live compatibility facts without blocking navigation to the health
 /// center. Platform probes can be slow or unavailable after an OS update.
@@ -143,6 +144,24 @@ class ModelHealthCenterScreen extends StatelessWidget {
                       style: theme.textTheme.bodySmall,
                     ),
                   ],
+                  const SizedBox(height: 12),
+                  Align(
+                    alignment: Alignment.centerLeft,
+                    child: OutlinedButton.icon(
+                      onPressed: () {
+                        Clipboard.setData(
+                          ClipboardData(text: report.toMarkdown()),
+                        );
+                        ScaffoldMessenger.of(context).showSnackBar(
+                          const SnackBar(
+                            content: Text('Runtime diagnostics copied.'),
+                          ),
+                        );
+                      },
+                      icon: const Icon(Icons.copy),
+                      label: const Text('Copy diagnostics'),
+                    ),
+                  ),
                 ],
               ),
             ),

--- a/app/test/features/agent_chat/presentation/screens/model_health_center_screen_test.dart
+++ b/app/test/features/agent_chat/presentation/screens/model_health_center_screen_test.dart
@@ -71,6 +71,10 @@ void main() {
       find.text('Retry with a smaller context to free memory.'),
       findsOneWidget,
     );
+    expect(find.text('Copy diagnostics'), findsOneWidget);
+    await tester.tap(find.text('Copy diagnostics'));
+    await tester.pump();
+    expect(find.text('Runtime diagnostics copied.'), findsOneWidget);
     await tester.scrollUntilVisible(
       find.text('Recommended next steps'),
       300,

--- a/docs/wiki/5.-AI-and-Model-Management.md
+++ b/docs/wiki/5.-AI-and-Model-Management.md
@@ -161,6 +161,12 @@ trace. Recovery actions can include retrying the runtime, resuming a download,
 repairing a model, retrying with reduced context, or choosing another installed
 model.
 
+Use **Copy diagnostics** from the Health Center when reporting a model loading
+problem. The copied report includes support-safe typed facts: model id, runtime
+status, failure code, selected runtime, accelerator, context, memory, readiness
+timeline, recommended actions, and runtime trace. It does not include stack
+traces or local file paths.
+
 OpenAI-compatible remote server diagnostics now also verify that the configured
 model id appears in the server's `/models` response. If LM Studio, Ollama, or a
 llama.cpp server is reachable but the requested model is not loaded, Airo marks

--- a/packages/core_ai/lib/src/health/model_health_report.dart
+++ b/packages/core_ai/lib/src/health/model_health_report.dart
@@ -102,6 +102,67 @@ class ModelHealthReport {
   ModelHealthStageResult stage(ModelHealthStage value) =>
       stages.firstWhere((entry) => entry.stage == value);
 
+  /// Stable, support-safe diagnostics for the Health Center "Why?" panel.
+  ///
+  /// This intentionally contains typed runtime facts and user-visible
+  /// recommendations, not exception strings, stack traces, or local file paths.
+  String toMarkdown() {
+    final buffer = StringBuffer()
+      ..writeln('# Airo Runtime Health Diagnostics')
+      ..writeln()
+      ..writeln('| Field | Value |')
+      ..writeln('| --- | --- |')
+      ..writeln('| Model | `$modelName` (`$modelId`) |')
+      ..writeln('| Status | `${status.name}` |')
+      ..writeln('| Failure code | `${failureCode.name}` |')
+      ..writeln('| Runtime | `${runtime?.name ?? 'not_selected'}` |')
+      ..writeln('| Accelerator | `${accelerator?.name ?? 'automatic'}` |')
+      ..writeln('| Context | `${contextTokens ?? 'not_selected'}` |');
+    if (availableMemoryMb != null || requiredMemoryMb != null) {
+      buffer
+        ..writeln(
+          '| Available memory | `${availableMemoryMb?.toStringAsFixed(0) ?? 'unknown'} MB` |',
+        )
+        ..writeln(
+          '| Estimated peak memory | `${requiredMemoryMb?.toStringAsFixed(0) ?? 'unknown'} MB` |',
+        );
+    }
+    buffer
+      ..writeln()
+      ..writeln('## Why')
+      ..writeln()
+      ..writeln(explanation)
+      ..writeln()
+      ..writeln('## Readiness timeline')
+      ..writeln();
+    for (final entry in stages) {
+      buffer.writeln(
+        '- `${entry.stage.name}`: `${entry.status.name}` — ${entry.detail}',
+      );
+    }
+    if (actions.isNotEmpty) {
+      buffer
+        ..writeln()
+        ..writeln('## Recommended actions')
+        ..writeln();
+      for (final action in actions) {
+        buffer.writeln('- `${action.name}`');
+      }
+    }
+    if (trace != null && trace!.entries.isNotEmpty) {
+      buffer
+        ..writeln()
+        ..writeln('## Runtime trace')
+        ..writeln();
+      for (final entry in trace!.entries) {
+        buffer.writeln(
+          '- `${entry.sequence}` `${entry.event.name}` `${entry.elapsedMs} ms`',
+        );
+      }
+    }
+    return buffer.toString().trimRight();
+  }
+
   /// Composes a report exclusively from observed facts. It performs no I/O,
   /// platform calls, or runtime calls, so identical facts produce identical
   /// diagnostics in Airo and Airo Mind.

--- a/packages/core_ai/test/health/model_health_report_test.dart
+++ b/packages/core_ai/test/health/model_health_report_test.dart
@@ -254,4 +254,59 @@ void main() {
     expect(report.explanation, contains('LiteRT init failed'));
     expect(report.actions, contains(ModelHealthAction.retry));
   });
+
+  test('renders copy-safe markdown diagnostics for support', () {
+    final report = ModelHealthReport.fromFacts(
+      model: _model(),
+      compatibility: const ModelCompatibilityResult(
+        isCompatible: false,
+        memorySeverity: MemorySeverity.blocked,
+        reason: 'Budget exceeded',
+        availableMemoryMB: 2_100,
+        requiredMemoryMB: 3_338,
+      ),
+      runtimeHealth: const RuntimeHealth(
+        state: RuntimeHealthState.lowMemory,
+        detail: 'Runtime paused because memory is low.',
+      ),
+      plan: const ExecutionPlan(
+        ir: InferenceIr(
+          runtime: RuntimeId.liteRt,
+          accelerator: ComputeAccelerator.vulkan,
+          modelId: 'gemma-4b',
+          contextTokens: 4096,
+          outputTokens: 256,
+          temperature: 0.7,
+          topK: 40,
+          topP: 0.95,
+          priority: ExecutionPriority.interactive,
+        ),
+        batchSize: 1,
+        thermalLimited: false,
+        batterySaver: false,
+      ),
+      trace: ExecutionTrace(
+        entries: [
+          ExecutionTraceEntry(
+            sequence: 1,
+            event: ExecutionTraceEvent.initializing,
+            elapsedMs: BigInt.zero,
+          ),
+        ],
+      ),
+    );
+
+    final markdown = report.toMarkdown();
+
+    expect(markdown, contains('# Airo Runtime Health Diagnostics'));
+    expect(markdown, contains('| Model | `Gemma 4B` (`gemma-4b`) |'));
+    expect(markdown, contains('| Failure code | `insufficientMemory` |'));
+    expect(markdown, contains('| Runtime | `liteRt` |'));
+    expect(markdown, contains('| Accelerator | `vulkan` |'));
+    expect(markdown, contains('| Available memory | `2100 MB` |'));
+    expect(markdown, contains('- `compatible`: `blocked` — Budget exceeded'));
+    expect(markdown, contains('- `reduceContext`'));
+    expect(markdown, contains('- `1` `initializing` `0 ms`'));
+    expect(markdown, isNot(contains('/models/')));
+  });
 }


### PR DESCRIPTION
Summary

This PR adds a copyable Runtime Health diagnostics bundle for Airo/Airo Mind.
Goal: make the Health Center Why panel portable for support, debugging, and user-reported model loading failures.

Core outcome:

- Adds stable markdown diagnostics to ModelHealthReport.
- Adds a Copy diagnostics action to the Runtime Health Center.
- Keeps diagnostics support-safe: typed facts, no stack traces, no local file paths.

Changes

- Added ModelHealthReport.toMarkdown for stable health diagnostics.
- Added Health Center copy action using the framework-owned diagnostic report.
- Updated core health report tests for markdown diagnostics.
- Updated Health Center widget test for the copy action.

Testing

- cd packages/core_ai && flutter test test/health/model_health_report_test.dart --reporter=compact
- cd app && flutter test test/features/agent_chat/presentation/screens/model_health_center_screen_test.dart --reporter=compact
- cd packages/core_ai && dart analyze lib/src/health/model_health_report.dart
- cd app && flutter analyze lib/features/agent_chat/presentation/screens/model_health_center_screen.dart test/features/agent_chat/presentation/screens/model_health_center_screen_test.dart
- git diff --check

Notes

This is one bounded slice from the pasted Airo Mind reliability requirements: Runtime Diagnostics / Why panel supportability.