### PR TITLE
feat(ai): add copyable device capability report

### DIFF
--- a/app/lib/features/agent_chat/presentation/screens/device_capability_report_screen.dart
+++ b/app/lib/features/agent_chat/presentation/screens/device_capability_report_screen.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:core_ai/core_ai.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 
 /// Shows the normalized device facts consumed by the runtime planner.
 class DeviceCapabilityReportScreen extends StatelessWidget {
@@ -39,6 +40,24 @@ class DeviceCapabilityReportScreen extends StatelessWidget {
                   Text(
                     'On-device AI: ${report.device.supportsOnDeviceAI ? 'available' : 'not reported'}',
                     style: theme.textTheme.bodySmall,
+                  ),
+                  const SizedBox(height: 12),
+                  Align(
+                    alignment: Alignment.centerLeft,
+                    child: OutlinedButton.icon(
+                      onPressed: () {
+                        Clipboard.setData(
+                          ClipboardData(text: report.toMarkdown()),
+                        );
+                        ScaffoldMessenger.of(context).showSnackBar(
+                          const SnackBar(
+                            content: Text('Device report copied.'),
+                          ),
+                        );
+                      },
+                      icon: const Icon(Icons.copy),
+                      label: const Text('Copy report'),
+                    ),
                   ),
                 ],
               ),

--- a/app/test/features/agent_chat/presentation/screens/device_capability_report_screen_test.dart
+++ b/app/test/features/agent_chat/presentation/screens/device_capability_report_screen_test.dart
@@ -66,6 +66,10 @@ void main() {
     expect(find.text('On-device AI service'), findsOneWidget);
     expect(find.text('Pixel runtime profile'), findsOneWidget);
     expect(find.text('Final runtime preflight'), findsOneWidget);
+    expect(find.text('Copy report'), findsOneWidget);
+    await tester.tap(find.text('Copy report'));
+    await tester.pump();
+    expect(find.text('Device report copied.'), findsOneWidget);
     expect(find.text('Retry analysis'), findsNothing);
   });
 
@@ -112,6 +116,55 @@ void main() {
     );
     expect(find.textContaining('Expected 8.0 tok/s'), findsOneWidget);
     expect(find.textContaining('Expected 2.0 tok/s'), findsOneWidget);
+  });
+
+  test('renders support-safe device report markdown', () {
+    final report = DeviceCapabilityReport(
+      device: const DeviceInfo(
+        manufacturer: 'Google',
+        model: 'Pixel 9',
+        brand: 'Google',
+        osVersion: '15',
+        sdkVersion: 35,
+        isPixelDevice: true,
+        supportsOnDeviceAI: true,
+        cpuSummary: 'Tensor G4 · 8 cores',
+        gpuSummary: 'Vulkan capable',
+        npuSummary: 'On-device AI service reported',
+        storageSummary: '42.0 GB free of 128.0 GB',
+        thermalSummary: 'Nominal',
+      ),
+      memory: MemoryInfo.fromMegabytes(totalMB: 16384, availableMB: 8192),
+      recommendedModels: const [
+        DeviceModelRecommendation(
+          modelId: 'gemma-4b',
+          modelName: 'Gemma 4B',
+          severity: MemorySeverity.safe,
+          estimatedMemoryMb: 3338,
+          expectedTokensPerSecond: 12.4,
+        ),
+      ],
+      generatedAt: DateTime.utc(2026, 8, 2),
+    );
+
+    final markdown = report.toMarkdown();
+
+    expect(markdown, contains('# Airo Device Capability Report'));
+    expect(markdown, contains('| Device | `Google Pixel 9` |'));
+    expect(markdown, contains('| On-device AI | `true` |'));
+    expect(
+      markdown,
+      contains('| Memory | `8192 MB available of 16384 MB total.` |'),
+    );
+    expect(markdown, contains('- `safe` Pixel runtime profile:'));
+    expect(
+      markdown,
+      contains(
+        '- `gemma-4b` Gemma 4B: `safe`, 3338 MB estimated memory, 12.4 tok/s expected',
+      ),
+    );
+    expect(markdown, isNot(contains('/Users/')));
+    expect(markdown, isNot(contains('/storage/')));
   });
 
   testWidgets('shows a retry action when device analysis fails', (

--- a/docs/wiki/5.-AI-and-Model-Management.md
+++ b/docs/wiki/5.-AI-and-Model-Management.md
@@ -191,6 +191,11 @@ It now includes:
 If a platform adapter cannot report a fact yet, Airo shows that explicitly
 instead of silently hiding the category.
 
+Use **Copy report** when sharing device-analysis or model-fit issues. The copied
+report includes normalized device facts, runtime diagnostics, recommended
+models, estimated memory, and expected token speed without exposing local paths
+or raw platform handles.
+
 ## Intelligent Model Manager (Under Qualification)
 
 The consolidated model lifecycle manager is implemented on the current

--- a/packages/core_ai/lib/src/device/device_capability_report.dart
+++ b/packages/core_ai/lib/src/device/device_capability_report.dart
@@ -118,6 +118,55 @@ class DeviceCapabilityReport {
     return List.unmodifiable(diagnostics);
   }
 
+  /// Stable support-safe report for model advisor and device analysis issues.
+  ///
+  /// The report only includes normalized hardware/planner facts. It deliberately
+  /// avoids local paths, raw platform handles, and exception strings.
+  String toMarkdown() {
+    final buffer = StringBuffer()
+      ..writeln('# Airo Device Capability Report')
+      ..writeln()
+      ..writeln('| Field | Value |')
+      ..writeln('| --- | --- |')
+      ..writeln('| Device | `${device.displayName}` |')
+      ..writeln('| OS | `${device.osVersion}` |')
+      ..writeln('| SDK | `${device.sdkVersion}` |')
+      ..writeln('| Pixel profile | `${device.isPixelDevice}` |')
+      ..writeln('| On-device AI | `${device.supportsOnDeviceAI}` |')
+      ..writeln('| CPU | `${device.cpuDisplay}` |')
+      ..writeln('| GPU | `${device.gpuDisplay}` |')
+      ..writeln('| NPU | `${device.npuDisplay}` |')
+      ..writeln('| Memory | `$summary` |')
+      ..writeln('| Storage | `${device.storageDisplay}` |')
+      ..writeln('| Thermals | `${device.thermalDisplay}` |')
+      ..writeln('| Generated | `${generatedAt.toUtc().toIso8601String()}` |')
+      ..writeln()
+      ..writeln('## Runtime diagnostics')
+      ..writeln();
+    for (final diagnostic in diagnostics) {
+      buffer.writeln(
+        '- `${diagnostic.severity.name}` ${diagnostic.title}: ${diagnostic.detail}',
+      );
+    }
+    buffer
+      ..writeln()
+      ..writeln('## Recommended models')
+      ..writeln();
+    if (recommendedModels.isEmpty) {
+      buffer.writeln('- No model metadata loaded yet.');
+    } else {
+      for (final model in recommendedModels) {
+        final expected = model.expectedTokensPerSecond;
+        buffer.writeln(
+          '- `${model.modelId}` ${model.modelName}: `${model.severity.name}`, '
+          '${model.estimatedMemoryMb.toStringAsFixed(0)} MB estimated memory'
+          '${expected == null || expected <= 0 ? '' : ', ${expected.toStringAsFixed(1)} tok/s expected'}',
+        );
+      }
+    }
+    return buffer.toString().trimRight();
+  }
+
   static Future<DeviceCapabilityReport> collect({
     Iterable<OfflineModelInfo> models = const <OfflineModelInfo>[],
     DeviceCapabilityService? service,


### PR DESCRIPTION
Summary

This PR adds a copyable Device Capability Report for Airo/Airo Mind.
Goal: make device-analysis and model-fit issues easier to debug and share without exposing local paths or raw platform details.

Core outcome:

- Adds stable markdown diagnostics to DeviceCapabilityReport.
- Adds a Copy report action to the Device Capability Report screen.
- Documents the copy report behavior in the AI and Model Management wiki.

Changes

- Added DeviceCapabilityReport.toMarkdown for normalized hardware and planner facts.
- Added UI copy action for the report.
- Added widget and markdown coverage for the copied report.

Testing

- cd app && flutter test test/features/agent_chat/presentation/screens/device_capability_report_screen_test.dart --reporter=compact
- cd app && flutter analyze lib/features/agent_chat/presentation/screens/device_capability_report_screen.dart test/features/agent_chat/presentation/screens/device_capability_report_screen_test.dart
- dart analyze packages/core_ai/lib/src/device/device_capability_report.dart
- git diff --check

Notes

This is a bounded slice from the pasted Airo Mind reliability requirements: Device Capability Report and runtime explainability.