### PR TITLE
feat(ai): add copyable model advisor recommendation

### DIFF
--- a/app/lib/features/agent_chat/presentation/screens/model_advisor_screen.dart
+++ b/app/lib/features/agent_chat/presentation/screens/model_advisor_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 
 import 'model_library_screen.dart';
 
@@ -152,13 +153,46 @@ class _ModelAdvisorScreenState extends State<ModelAdvisorScreen> {
                               : '${candidate.actionLabel}. ${candidate.unavailableReason ?? 'Airo will guide you through setup.'}',
                         ),
                         const SizedBox(height: 14),
-                        FilledButton.icon(
-                          onPressed: () => Navigator.of(context).pop(candidate),
-                          icon: const Icon(Icons.open_in_new),
-                          label: Text(
-                            candidate.available
-                                ? 'Use this model'
-                                : 'Open model setup',
+                        Wrap(
+                          spacing: 10,
+                          runSpacing: 10,
+                          children: [
+                            FilledButton.icon(
+                              onPressed: () =>
+                                  Navigator.of(context).pop(candidate),
+                              icon: const Icon(Icons.open_in_new),
+                              label: Text(
+                                candidate.available
+                                    ? 'Use this model'
+                                    : 'Open model setup',
+                              ),
+                            ),
+                            OutlinedButton.icon(
+                              onPressed: () {
+                                Clipboard.setData(
+                                  ClipboardData(
+                                    text: _recommendationMarkdown(
+                                      state: state,
+                                      candidate: candidate,
+                                    ),
+                                  ),
+                                );
+                                ScaffoldMessenger.of(context).showSnackBar(
+                                  const SnackBar(
+                                    content: Text('Recommendation copied.'),
+                                  ),
+                                );
+                              },
+                              icon: const Icon(Icons.copy),
+                              label: const Text('Copy recommendation'),
+                            ),
+                          ],
+                        ),
+                        const SizedBox(height: 12),
+                        Text(
+                          'Copy recommendation creates a support-safe summary without file paths or logs.',
+                          style: theme.textTheme.bodySmall?.copyWith(
+                            color: theme.colorScheme.onSurfaceVariant,
                           ),
                         ),
                       ],
@@ -182,5 +216,79 @@ class _ModelAdvisorScreenState extends State<ModelAdvisorScreen> {
         '${candidate.privacyLabel}. '
         '${candidate.sizeLabel}. '
         '${candidate.available ? "Ready" : "Requires setup"}.';
+  }
+
+  String _recommendationMarkdown({
+    required AssistantModelLibraryState state,
+    required AssistantModelCandidate candidate,
+  }) {
+    final buffer = StringBuffer()
+      ..writeln('# Airo Model Advisor Recommendation')
+      ..writeln()
+      ..writeln('| Field | Value |')
+      ..writeln('| --- | --- |')
+      ..writeln('| Capability | `${_taskLabel(state.task)}` |')
+      ..writeln('| Device | `${state.deviceLabel}` |')
+      ..writeln('| Platform | `${state.platformLabel}` |')
+      ..writeln('| Recommended model | `${candidate.name}` |')
+      ..writeln('| Runtime | `${candidate.runtime}` |')
+      ..writeln(
+        '| Availability | `${candidate.available ? 'ready' : 'setup_required'}` |',
+      )
+      ..writeln('| Privacy | `${candidate.privacyLabel}` |')
+      ..writeln('| Size | `${candidate.sizeLabel}` |')
+      ..writeln('| Action | `${candidate.actionLabel}` |')
+      ..writeln()
+      ..writeln('## Why this choice')
+      ..writeln()
+      ..writeln(
+        candidate.available
+            ? '- ${candidate.runtime} is ready for this capability.'
+            : '- ${candidate.actionLabel}. ${candidate.unavailableReason ?? 'Airo will guide the setup flow.'}',
+      )
+      ..writeln('- ${candidate.privacyLabel}.')
+      ..writeln('- ${candidate.sizeLabel}.')
+      ..writeln()
+      ..writeln('## Candidate tags')
+      ..writeln();
+    for (final tag in candidate.tags) {
+      buffer.writeln('- `$tag`');
+    }
+    if (candidate.bestFor.isNotEmpty) {
+      buffer
+        ..writeln()
+        ..writeln('## Best for')
+        ..writeln();
+      for (final task in candidate.bestFor) {
+        buffer.writeln('- `${_taskLabel(task)}`');
+      }
+    }
+    final compatibility = candidate.compatibility;
+    if (compatibility != null) {
+      buffer
+        ..writeln()
+        ..writeln('## Compatibility')
+        ..writeln()
+        ..writeln('- Compatible: `${compatibility.isCompatible}`')
+        ..writeln('- Memory severity: `${compatibility.memorySeverity.name}`')
+        ..writeln(
+          '- Available memory: `${compatibility.availableMemoryMB.toStringAsFixed(0)} MB`',
+        )
+        ..writeln(
+          '- Required memory: `${compatibility.requiredMemoryMB.toStringAsFixed(0)} MB`',
+        );
+      final reason = compatibility.reason;
+      if (reason != null && reason.trim().isNotEmpty) {
+        buffer.writeln('- Reason: $reason');
+      }
+    }
+    if (!candidate.available && candidate.unavailableReason != null) {
+      buffer
+        ..writeln()
+        ..writeln('## Setup reason')
+        ..writeln()
+        ..writeln('- ${candidate.unavailableReason}');
+    }
+    return buffer.toString().trimRight();
   }
 }

--- a/app/test/features/agent_chat/presentation/screens/model_advisor_screen_test.dart
+++ b/app/test/features/agent_chat/presentation/screens/model_advisor_screen_test.dart
@@ -1,6 +1,7 @@
 import 'package:airo_app/features/agent_chat/presentation/screens/model_advisor_screen.dart';
 import 'package:airo_app/features/agent_chat/presentation/screens/model_library_screen.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
@@ -11,6 +12,23 @@ void main() {
 
   testWidgets('recommends a model by task capability', (tester) async {
     final semantics = tester.ensureSemantics();
+    String? copiedText;
+    tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+      SystemChannels.platform,
+      (call) async {
+        if (call.method == 'Clipboard.setData') {
+          final data = Map<String, dynamic>.from(call.arguments as Map);
+          copiedText = data['text'] as String?;
+        }
+        return null;
+      },
+    );
+    addTearDown(() {
+      tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+        SystemChannels.platform,
+        null,
+      );
+    });
     String selected = 'none';
     Future<AssistantModelLibraryState> load(AssistantTask task) async {
       final candidate = AssistantModelCandidate(
@@ -85,6 +103,23 @@ void main() {
       ),
       findsOneWidget,
     );
+    expect(find.text('Copy recommendation'), findsOneWidget);
+    await tester.tap(find.text('Copy recommendation'));
+    await tester.pump();
+
+    expect(find.text('Recommendation copied.'), findsOneWidget);
+    expect(copiedText, contains('# Airo Model Advisor Recommendation'));
+    expect(copiedText, contains('| Capability | `Chat` |'));
+    expect(copiedText, contains('| Device | `Pixel 9` |'));
+    expect(copiedText, contains('| Platform | `Android` |'));
+    expect(copiedText, contains('| Runtime | `MockRuntime` |'));
+    expect(copiedText, contains('- MockRuntime is ready for this capability.'));
+    expect(copiedText, isNot(contains('/Users/')));
+    expect(copiedText, isNot(contains('/storage/')));
+    ScaffoldMessenger.of(
+      tester.element(find.text('Model Advisor')),
+    ).hideCurrentSnackBar();
+    await tester.pumpAndSettle();
 
     await tester.tap(find.text('Image'));
     await tester.pump();
@@ -95,7 +130,7 @@ void main() {
       find.bySemanticsLabel('Capability: Image. Selected.'),
       findsOneWidget,
     );
-    await tester.tap(find.text('Use this model'));
+    await tester.tap(find.widgetWithText(FilledButton, 'Use this model'));
     await tester.pumpAndSettle();
 
     expect(find.text('Selected: mock-image'), findsOneWidget);

--- a/docs/wiki/5.-AI-and-Model-Management.md
+++ b/docs/wiki/5.-AI-and-Model-Management.md
@@ -140,6 +140,24 @@ the registry aligned with the actual file stored on the device.
 If a model is too large for the current device budget, Airo shows a compatibility
 warning directly in the model card before you try to activate it.
 
+## Model Advisor
+
+The **Model Advisor** recommends a model by capability instead of asking users
+to pick from runtime-specific names. For each recommendation it explains:
+
+- selected capability
+- device and platform label
+- recommended model and runtime
+- readiness state
+- privacy posture
+- local size or setup requirement
+- compatibility memory facts when available
+
+Use **Copy recommendation** when reporting why Airo chose a model. The copied
+report is support-safe: it includes task, device, platform, runtime, readiness,
+privacy, size, tags, and compatibility facts without stack traces or local file
+paths.
+
 ## Runtime Health Center
 
 The **Runtime Health Center** explains whether a local model is actually ready


### PR DESCRIPTION
# Summary

This PR adds a support-safe copy/export path to Model Advisor recommendations.
Goal: make model-choice issues reproducible without logs, stack traces, or local file paths.

Core outcome:

* Model Advisor now exposes **Copy recommendation** next to the selected model action.
* The copied report includes capability, device, platform, runtime, readiness, privacy, size, tags, best-fit tasks, and compatibility memory facts when available.
* Release docs now describe the Model Advisor diagnostic export.

# Changes

### Code

* Updated:
  * `app/lib/features/agent_chat/presentation/screens/model_advisor_screen.dart` — added support-safe recommendation markdown and copy action.
  * `app/test/features/agent_chat/presentation/screens/model_advisor_screen_test.dart` — verifies clipboard output and existing selection flow.
  * `docs/wiki/5.-AI-and-Model-Management.md` — documents Model Advisor diagnostic export.

### Logic

* Does not change planner/runtime policy.
* Does not add platform-specific code.
* Does not expose local file paths or runtime exception strings.

# Testing

* `cd app && flutter test test/features/agent_chat/presentation/screens/model_advisor_screen_test.dart --reporter=compact`
* `cd app && flutter analyze lib/features/agent_chat/presentation/screens/model_advisor_screen.dart test/features/agent_chat/presentation/screens/model_advisor_screen_test.dart`
* `git diff --check`

# Risks

* Low. This is a UI/supportability addition with no runtime selection behavior change.

Rollback plan:

* Revert this PR; Model Advisor falls back to the existing on-screen explanation only.
