### PR TITLE
feat(ai): add model manager diagnostics export

### DIFF
--- a/app/lib/features/settings/presentation/screens/intelligent_model_manager_screen.dart
+++ b/app/lib/features/settings/presentation/screens/intelligent_model_manager_screen.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:ui';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:core_ai/core_ai.dart';
 import 'package:core_ui/core_ui.dart';
@@ -63,7 +64,7 @@ class IntelligentModelManagerScreen extends ConsumerWidget {
             return ListView(
               padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 20),
               children: [
-                _buildManagerSummary(context, snapshot),
+                _buildManagerSummary(context, snapshot, visibleQueue),
                 if (visibleQueue.isNotEmpty) ...[
                   const SizedBox(height: 16),
                   _buildQueueSummary(context, visibleQueue),
@@ -114,6 +115,7 @@ class IntelligentModelManagerScreen extends ConsumerWidget {
   Widget _buildManagerSummary(
     BuildContext context,
     ModelManagerSnapshot snapshot,
+    List<ModelDownloadProgress> visibleQueue,
   ) {
     final theme = Theme.of(context);
     return Card(
@@ -144,6 +146,24 @@ class IntelligentModelManagerScreen extends ConsumerWidget {
             Text(
               'Downloads continue in the background and restore after restart.',
               style: theme.textTheme.bodySmall,
+            ),
+            OutlinedButton.icon(
+              onPressed: () {
+                Clipboard.setData(
+                  ClipboardData(
+                    text: snapshot.toMarkdown(
+                      downloadQueueOverride: visibleQueue,
+                    ),
+                  ),
+                );
+                ScaffoldMessenger.of(context).showSnackBar(
+                  const SnackBar(
+                    content: Text('Model manager diagnostics copied.'),
+                  ),
+                );
+              },
+              icon: const Icon(Icons.copy, size: 18),
+              label: const Text('Copy diagnostics'),
             ),
           ],
         ),

--- a/app/test/features/settings/presentation/screens/intelligent_model_manager_screen_test.dart
+++ b/app/test/features/settings/presentation/screens/intelligent_model_manager_screen_test.dart
@@ -6,6 +6,7 @@ import 'package:airo_app/features/settings/presentation/screens/intelligent_mode
 import 'package:core_ai/core_ai.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -124,6 +125,23 @@ void main() {
     tester.view.devicePixelRatio = 1;
     addTearDown(tester.view.resetPhysicalSize);
     addTearDown(tester.view.resetDevicePixelRatio);
+    String? copiedText;
+    tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+      SystemChannels.platform,
+      (call) async {
+        if (call.method == 'Clipboard.setData') {
+          final data = Map<String, dynamic>.from(call.arguments as Map);
+          copiedText = data['text'] as String?;
+        }
+        return null;
+      },
+    );
+    addTearDown(() {
+      tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+        SystemChannels.platform,
+        null,
+      );
+    });
 
     const modelInfo = OfflineModelInfo(
       id: 'downloading',
@@ -199,6 +217,22 @@ void main() {
     expect(find.text('Download queue'), findsOneWidget);
     expect(find.textContaining('#1 queued-before'), findsOneWidget);
     expect(find.textContaining('#2 downloading'), findsOneWidget);
+    expect(find.text('Copy diagnostics'), findsOneWidget);
+    await tester.tap(find.text('Copy diagnostics'));
+    await tester.pump();
+
+    expect(find.text('Model manager diagnostics copied.'), findsOneWidget);
+    expect(copiedText, contains('# Airo Model Manager Diagnostics'));
+    expect(copiedText, contains('| Download queue | `2` |'));
+    expect(copiedText, contains('- `queued-before`'));
+    expect(copiedText, contains('- `downloading`'));
+    expect(copiedText, contains('  - Downloaded: `2.0 KB / 4.0 KB`'));
+    expect(copiedText, isNot(contains('/Users/')));
+    expect(copiedText, isNot(contains('/storage/')));
+    ScaffoldMessenger.of(
+      tester.element(find.text('Intelligent Model Manager')),
+    ).hideCurrentSnackBar();
+    await tester.pumpAndSettle();
     expect(find.byType(LinearProgressIndicator), findsWidgets);
     await tester.ensureVisible(find.byTooltip('Pause'));
     await tester.tap(find.byTooltip('Pause'));

--- a/docs/wiki/5.-AI-and-Model-Management.md
+++ b/docs/wiki/5.-AI-and-Model-Management.md
@@ -227,6 +227,9 @@ In development builds that include the capability, the manager can:
 - show a per-model **Download Manager** status panel with artifact state,
   integrity state, local storage use, downloaded bytes, resume support, retry
   count, and failure detail
+- copy a support-safe **Model Manager diagnostics** report that includes model
+  lifecycle state, storage use, active queue ordering, progress, speed, ETA,
+  resume support, retry count, and integrity status without local file paths
 - pause, resume, retry, or cancel a model transfer
 - activate, update, delete, or warm an installed model
 - opt frequently used models into bounded startup preloading

--- a/packages/core_ai/lib/src/intelligent_model_manager/model_manager_contracts.dart
+++ b/packages/core_ai/lib/src/intelligent_model_manager/model_manager_contracts.dart
@@ -21,6 +21,106 @@ class ModelManagerSnapshot {
 
   List<ModelEntry> get recommendedModels =>
       models.where((model) => model.isRecommended).toList(growable: false);
+
+  /// Support-safe model/download diagnostics for release qualification.
+  ///
+  /// The report deliberately omits local file paths and raw platform errors.
+  /// Pass [downloadQueueOverride] when the UI has fresher in-memory progress
+  /// than the persisted snapshot.
+  String toMarkdown({
+    Iterable<ModelDownloadProgress>? downloadQueueOverride,
+    DateTime? generatedAt,
+  }) {
+    final queue = (downloadQueueOverride ?? downloadQueue).toList()
+      ..sort(
+        (left, right) => (left.queuePosition ?? 0x7fffffff).compareTo(
+          right.queuePosition ?? 0x7fffffff,
+        ),
+      );
+    final buffer = StringBuffer()
+      ..writeln('# Airo Model Manager Diagnostics')
+      ..writeln()
+      ..writeln('| Field | Value |')
+      ..writeln('| --- | --- |')
+      ..writeln('| Models | `${models.length}` |')
+      ..writeln('| Installed | `${installedModels.length}` |')
+      ..writeln('| Recommended | `${recommendedModels.length}` |')
+      ..writeln('| Download queue | `${queue.length}` |')
+      ..writeln('| Storage used | `${_formatBytes(storageUsedBytes)}` |')
+      ..writeln(
+        '| Generated | `${(generatedAt ?? DateTime.now()).toUtc().toIso8601String()}` |',
+      )
+      ..writeln()
+      ..writeln('## Download queue')
+      ..writeln();
+    if (queue.isEmpty) {
+      buffer.writeln('- No active or restored downloads.');
+    } else {
+      for (final progress in queue) {
+        buffer
+          ..writeln('- `${progress.modelId}`')
+          ..writeln('  - Status: `${progress.statusDisplay}`')
+          ..writeln(
+            '  - Downloaded: `${_formatBytes(progress.downloadedBytes)} / ${_formatBytes(progress.totalBytes)}`',
+          )
+          ..writeln('  - Speed: `${progress.speedDisplay}`')
+          ..writeln('  - ETA: `${progress.etaDisplay ?? 'not available'}`')
+          ..writeln('  - Resume supported: `${progress.resumeSupported}`')
+          ..writeln('  - Retry count: `${progress.retryCount}`')
+          ..writeln('  - Integrity: `${_integrityState(progress)}`');
+        final failureCode = progress.failureCode;
+        if (failureCode != null && failureCode.trim().isNotEmpty) {
+          buffer.writeln('  - Failure code: `$failureCode`');
+        }
+      }
+    }
+    buffer
+      ..writeln()
+      ..writeln('## Models')
+      ..writeln();
+    for (final model in models) {
+      buffer
+        ..writeln('- `${model.id}` ${model.name}')
+        ..writeln('  - Version: `${model.version}`')
+        ..writeln('  - Installed: `${model.isDownloaded}`')
+        ..writeln('  - Active: `${model.isActive}`')
+        ..writeln('  - Recommended: `${model.isRecommended}`')
+        ..writeln('  - Resident: `${model.isResident}`')
+        ..writeln('  - Update state: `${model.updateState.name}`')
+        ..writeln('  - Size: `${_formatBytes(model.sizeBytes)}`');
+      final installedVersion = model.installedVersion;
+      if (installedVersion != null && installedVersion.trim().isNotEmpty) {
+        buffer.writeln('  - Installed version: `$installedVersion`');
+      }
+    }
+    return buffer.toString().trimRight();
+  }
+
+  static String _integrityState(ModelDownloadProgress progress) {
+    final code = progress.failureCode?.toLowerCase();
+    final integrityFailure =
+        code == 'integritymismatch' ||
+        code == 'integrity_mismatch' ||
+        code == 'integrity-mismatch';
+    return switch (progress.status) {
+      ModelDownloadStatus.completed => 'verified',
+      ModelDownloadStatus.verifying => 'verifying',
+      ModelDownloadStatus.failed when integrityFailure => 'repair_required',
+      ModelDownloadStatus.failed => 'not_verified',
+      _ => 'pending_verification',
+    };
+  }
+
+  static String _formatBytes(int bytes) {
+    if (bytes < 1024) return '$bytes B';
+    if (bytes < 1024 * 1024) {
+      return '${(bytes / 1024).toStringAsFixed(1)} KB';
+    }
+    if (bytes < 1024 * 1024 * 1024) {
+      return '${(bytes / (1024 * 1024)).toStringAsFixed(1)} MB';
+    }
+    return '${(bytes / (1024 * 1024 * 1024)).toStringAsFixed(1)} GB';
+  }
 }
 
 enum ModelWarmupStatus { warmed, alreadyResident, unavailable, failed }

--- a/packages/core_ai/test/intelligent_model_manager_test.dart
+++ b/packages/core_ai/test/intelligent_model_manager_test.dart
@@ -73,6 +73,53 @@ void main() {
       when(() => mockWarmup.residentModelIds).thenReturn(<String>{});
     });
 
+    test('snapshot renders support-safe download diagnostics markdown', () {
+      final snapshot = ModelManagerSnapshot(
+        models: const [
+          ModelEntry(
+            id: 'gemma-4b',
+            name: 'Gemma 4B',
+            version: '1.0.0',
+            installedVersion: '1.0.0',
+            description: 'Local model.',
+            sizeBytes: 4 * 1024 * 1024 * 1024,
+            isDownloaded: true,
+            isActive: true,
+            isRecommended: true,
+            isResident: true,
+            updateState: ModelUpdateState.upToDate,
+          ),
+        ],
+        downloadQueue: const [
+          ModelDownloadProgress(
+            modelId: 'vision-pack',
+            totalBytes: 2048,
+            downloadedBytes: 1024,
+            status: ModelDownloadStatus.failed,
+            failureCode: 'integrity_mismatch',
+            retryCount: 2,
+            resumeSupported: true,
+          ),
+        ],
+        storageUsedBytes: 4 * 1024 * 1024 * 1024,
+      );
+
+      final markdown = snapshot.toMarkdown(
+        generatedAt: DateTime.utc(2026, 8, 2),
+      );
+
+      expect(markdown, contains('# Airo Model Manager Diagnostics'));
+      expect(markdown, contains('| Installed | `1` |'));
+      expect(markdown, contains('| Download queue | `1` |'));
+      expect(markdown, contains('- `vision-pack`'));
+      expect(markdown, contains('  - Integrity: `repair_required`'));
+      expect(markdown, contains('  - Failure code: `integrity_mismatch`'));
+      expect(markdown, contains('- `gemma-4b` Gemma 4B'));
+      expect(markdown, contains('  - Resident: `true`'));
+      expect(markdown, isNot(contains('/Users/')));
+      expect(markdown, isNot(contains('/storage/')));
+    });
+
     test(
       'listModels maps OfflineModelInfo to ModelEntry correctly when downloaded',
       () async {


### PR DESCRIPTION
# Summary

This PR adds a support-safe diagnostics export for the Intelligent Model Manager.
Goal: make download, repair, queue, integrity, and storage issues reproducible without exposing local paths or raw logs.

Core outcome:

* `ModelManagerSnapshot` can render a support-safe markdown diagnostics report.
* The manager screen exposes **Copy diagnostics** in the summary area.
* The copied report includes model lifecycle state, storage use, active queue ordering, progress, speed, ETA, resume support, retry count, and integrity status.

# Changes

### Code

* Added:
  * `ModelManagerSnapshot.toMarkdown()` in `packages/core_ai/lib/src/intelligent_model_manager/model_manager_contracts.dart`.
* Updated:
  * `app/lib/features/settings/presentation/screens/intelligent_model_manager_screen.dart` — copy action uses live visible queue progress.
  * `app/test/features/settings/presentation/screens/intelligent_model_manager_screen_test.dart` — verifies clipboard diagnostics include live queue state.
  * `packages/core_ai/test/intelligent_model_manager_test.dart` — verifies support-safe markdown output.
  * `docs/wiki/5.-AI-and-Model-Management.md` — documents diagnostics export.

### Logic

* No download behavior change.
* No runtime/planner policy change.
* Report omits local file paths and raw platform exception strings.

# Testing

* `cd packages/core_ai && flutter test test/intelligent_model_manager_test.dart --reporter=compact`
* `cd app && flutter test test/features/settings/presentation/screens/intelligent_model_manager_screen_test.dart --reporter=compact`
* `cd app && flutter analyze lib/features/settings/presentation/screens/intelligent_model_manager_screen.dart test/features/settings/presentation/screens/intelligent_model_manager_screen_test.dart`
* `dart analyze packages/core_ai/lib/src/intelligent_model_manager/model_manager_contracts.dart packages/core_ai/test/intelligent_model_manager_test.dart`
* `git diff --check`

# Risks

* Low. This adds diagnostics/export only and does not alter model download execution.

Rollback plan:

* Revert this PR; model manager returns to on-screen diagnostics only.
