### PR TITLE
fix(ai): improve diagnostic copy accessibility

### DIFF
--- a/app/lib/features/agent_chat/presentation/screens/device_capability_report_screen.dart
+++ b/app/lib/features/agent_chat/presentation/screens/device_capability_report_screen.dart
@@ -44,8 +44,9 @@ class DeviceCapabilityReportScreen extends StatelessWidget {
                   const SizedBox(height: 12),
                   Align(
                     alignment: Alignment.centerLeft,
-                    child: OutlinedButton.icon(
-                      onPressed: () {
+                    child: Semantics(
+                      button: true,
+                      onTap: () {
                         Clipboard.setData(
                           ClipboardData(text: report.toMarkdown()),
                         );
@@ -55,8 +56,25 @@ class DeviceCapabilityReportScreen extends StatelessWidget {
                           ),
                         );
                       },
-                      icon: const Icon(Icons.copy),
-                      label: const Text('Copy report'),
+                      excludeSemantics: true,
+                      label:
+                          'Copy device capability report for ${report.device.displayName}',
+                      hint:
+                          'Copies support-safe hardware and model fit diagnostics.',
+                      child: OutlinedButton.icon(
+                        onPressed: () {
+                          Clipboard.setData(
+                            ClipboardData(text: report.toMarkdown()),
+                          );
+                          ScaffoldMessenger.of(context).showSnackBar(
+                            const SnackBar(
+                              content: Text('Device report copied.'),
+                            ),
+                          );
+                        },
+                        icon: const Icon(Icons.copy),
+                        label: const Text('Copy report'),
+                      ),
                     ),
                   ),
                 ],

--- a/app/lib/features/agent_chat/presentation/screens/model_advisor_screen.dart
+++ b/app/lib/features/agent_chat/presentation/screens/model_advisor_screen.dart
@@ -167,8 +167,9 @@ class _ModelAdvisorScreenState extends State<ModelAdvisorScreen> {
                                     : 'Open model setup',
                               ),
                             ),
-                            OutlinedButton.icon(
-                              onPressed: () {
+                            Semantics(
+                              button: true,
+                              onTap: () {
                                 Clipboard.setData(
                                   ClipboardData(
                                     text: _recommendationMarkdown(
@@ -183,8 +184,30 @@ class _ModelAdvisorScreenState extends State<ModelAdvisorScreen> {
                                   ),
                                 );
                               },
-                              icon: const Icon(Icons.copy),
-                              label: const Text('Copy recommendation'),
+                              excludeSemantics: true,
+                              label:
+                                  'Copy recommendation for ${candidate.name}',
+                              hint:
+                                  'Copies a support-safe model advisor report for ${_taskLabel(state.task)}.',
+                              child: OutlinedButton.icon(
+                                onPressed: () {
+                                  Clipboard.setData(
+                                    ClipboardData(
+                                      text: _recommendationMarkdown(
+                                        state: state,
+                                        candidate: candidate,
+                                      ),
+                                    ),
+                                  );
+                                  ScaffoldMessenger.of(context).showSnackBar(
+                                    const SnackBar(
+                                      content: Text('Recommendation copied.'),
+                                    ),
+                                  );
+                                },
+                                icon: const Icon(Icons.copy),
+                                label: const Text('Copy recommendation'),
+                              ),
                             ),
                           ],
                         ),

--- a/app/lib/features/agent_chat/presentation/screens/model_health_center_screen.dart
+++ b/app/lib/features/agent_chat/presentation/screens/model_health_center_screen.dart
@@ -147,8 +147,9 @@ class ModelHealthCenterScreen extends StatelessWidget {
                   const SizedBox(height: 12),
                   Align(
                     alignment: Alignment.centerLeft,
-                    child: OutlinedButton.icon(
-                      onPressed: () {
+                    child: Semantics(
+                      button: true,
+                      onTap: () {
                         Clipboard.setData(
                           ClipboardData(text: report.toMarkdown()),
                         );
@@ -158,8 +159,24 @@ class ModelHealthCenterScreen extends StatelessWidget {
                           ),
                         );
                       },
-                      icon: const Icon(Icons.copy),
-                      label: const Text('Copy diagnostics'),
+                      excludeSemantics: true,
+                      label: 'Copy runtime diagnostics for ${report.modelName}',
+                      hint:
+                          'Copies a support-safe model health report without local file paths.',
+                      child: OutlinedButton.icon(
+                        onPressed: () {
+                          Clipboard.setData(
+                            ClipboardData(text: report.toMarkdown()),
+                          );
+                          ScaffoldMessenger.of(context).showSnackBar(
+                            const SnackBar(
+                              content: Text('Runtime diagnostics copied.'),
+                            ),
+                          );
+                        },
+                        icon: const Icon(Icons.copy),
+                        label: const Text('Copy diagnostics'),
+                      ),
                     ),
                   ),
                 ],

--- a/app/lib/features/settings/presentation/screens/intelligent_model_manager_screen.dart
+++ b/app/lib/features/settings/presentation/screens/intelligent_model_manager_screen.dart
@@ -147,8 +147,9 @@ class IntelligentModelManagerScreen extends ConsumerWidget {
               'Downloads continue in the background and restore after restart.',
               style: theme.textTheme.bodySmall,
             ),
-            OutlinedButton.icon(
-              onPressed: () {
+            Semantics(
+              button: true,
+              onTap: () {
                 Clipboard.setData(
                   ClipboardData(
                     text: snapshot.toMarkdown(
@@ -162,8 +163,28 @@ class IntelligentModelManagerScreen extends ConsumerWidget {
                   ),
                 );
               },
-              icon: const Icon(Icons.copy, size: 18),
-              label: const Text('Copy diagnostics'),
+              excludeSemantics: true,
+              label: 'Copy model manager diagnostics',
+              hint:
+                  'Copies support-safe download queue, storage, and model lifecycle diagnostics.',
+              child: OutlinedButton.icon(
+                onPressed: () {
+                  Clipboard.setData(
+                    ClipboardData(
+                      text: snapshot.toMarkdown(
+                        downloadQueueOverride: visibleQueue,
+                      ),
+                    ),
+                  );
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    const SnackBar(
+                      content: Text('Model manager diagnostics copied.'),
+                    ),
+                  );
+                },
+                icon: const Icon(Icons.copy, size: 18),
+                label: const Text('Copy diagnostics'),
+              ),
             ),
           ],
         ),

--- a/app/test/features/agent_chat/presentation/screens/device_capability_report_screen_test.dart
+++ b/app/test/features/agent_chat/presentation/screens/device_capability_report_screen_test.dart
@@ -67,6 +67,12 @@ void main() {
     expect(find.text('Pixel runtime profile'), findsOneWidget);
     expect(find.text('Final runtime preflight'), findsOneWidget);
     expect(find.text('Copy report'), findsOneWidget);
+    expect(
+      find.bySemanticsLabel(
+        RegExp('Copy device capability report for Google Pixel 9'),
+      ),
+      findsOneWidget,
+    );
     await tester.tap(find.text('Copy report'));
     await tester.pump();
     expect(find.text('Device report copied.'), findsOneWidget);

--- a/app/test/features/agent_chat/presentation/screens/model_advisor_screen_test.dart
+++ b/app/test/features/agent_chat/presentation/screens/model_advisor_screen_test.dart
@@ -104,6 +104,12 @@ void main() {
       findsOneWidget,
     );
     expect(find.text('Copy recommendation'), findsOneWidget);
+    expect(
+      find.bySemanticsLabel(
+        RegExp('Copy recommendation for Mock Chat Project'),
+      ),
+      findsOneWidget,
+    );
     await tester.tap(find.text('Copy recommendation'));
     await tester.pump();
 

--- a/app/test/features/agent_chat/presentation/screens/model_health_center_screen_test.dart
+++ b/app/test/features/agent_chat/presentation/screens/model_health_center_screen_test.dart
@@ -72,6 +72,10 @@ void main() {
       findsOneWidget,
     );
     expect(find.text('Copy diagnostics'), findsOneWidget);
+    expect(
+      find.bySemanticsLabel(RegExp('Copy runtime diagnostics for Gemma 4B')),
+      findsOneWidget,
+    );
     await tester.tap(find.text('Copy diagnostics'));
     await tester.pump();
     expect(find.text('Runtime diagnostics copied.'), findsOneWidget);

--- a/app/test/features/settings/presentation/screens/intelligent_model_manager_screen_test.dart
+++ b/app/test/features/settings/presentation/screens/intelligent_model_manager_screen_test.dart
@@ -218,6 +218,10 @@ void main() {
     expect(find.textContaining('#1 queued-before'), findsOneWidget);
     expect(find.textContaining('#2 downloading'), findsOneWidget);
     expect(find.text('Copy diagnostics'), findsOneWidget);
+    expect(
+      find.bySemanticsLabel(RegExp('Copy model manager diagnostics')),
+      findsOneWidget,
+    );
     await tester.tap(find.text('Copy diagnostics'));
     await tester.pump();
 


### PR DESCRIPTION
Summary

This PR improves accessibility for the Airo Mind diagnostic export/copy controls.
Goal: make support-safe diagnostic exports discoverable and actionable through assistive technologies.

Core outcome:
- Adds explicit screen-reader labels and hints for diagnostic copy controls.
- Adds semantic activation actions so screen readers can trigger the same copy behavior.
- Covers Runtime Health Center, Device Capability Report, Model Advisor, and Model Manager diagnostics.

Changes

Code:
- Updated diagnostic copy controls with typed semantics labels, hints, and tap actions.

Tests:
- Added widget assertions for accessible copy-control labels.
- Verified existing copy behavior still works.

Testing:
- flutter test: model_health_center_screen_test, device_capability_report_screen_test, model_advisor_screen_test, intelligent_model_manager_screen_test
- flutter analyze: the four touched screens and four touched tests
- git diff --check
