### PR TITLE
chore(release): cut v0.0.6 across TV, full, Coins, and macOS

### DIFF
--- a/.github/workflows/release-orchestrator.yml
+++ b/.github/workflows/release-orchestrator.yml
@@ -104,6 +104,14 @@ on:
         options:
           - none
           - full
+      coins_profile:
+        description: 'Optional Airo Coins profile to build'
+        required: true
+        default: none
+        type: choice
+        options:
+          - none
+          - coins
       macos_profile:
         description: 'Optional macOS profile to build'
         required: true
@@ -160,6 +168,7 @@ jobs:
       tv_firebase_app_id: ${{ steps.release.outputs.tv_firebase_app_id }}
       tv_firebase_tester_groups: ${{ steps.release.outputs.tv_firebase_tester_groups }}
       mobile_profile: ${{ steps.release.outputs.mobile_profile }}
+      coins_profile: ${{ steps.release.outputs.coins_profile }}
       macos_profile: ${{ steps.release.outputs.macos_profile }}
       macos_require_notarization: ${{ steps.release.outputs.macos_require_notarization }}
       qualification_mode: ${{ steps.release.outputs.qualification_mode }}
@@ -189,6 +198,7 @@ jobs:
           INPUT_TV_FIREBASE_APP_ID: ${{ inputs.tv_firebase_app_id }}
           INPUT_TV_FIREBASE_TESTER_GROUPS: ${{ inputs.tv_firebase_tester_groups }}
           INPUT_MOBILE_PROFILE: ${{ inputs.mobile_profile }}
+          INPUT_COINS_PROFILE: ${{ inputs.coins_profile }}
           INPUT_MACOS_PROFILE: ${{ inputs.macos_profile }}
           INPUT_MACOS_REQUIRE_NOTARIZATION: ${{ inputs.macos_require_notarization }}
           INPUT_QUALIFICATION_MODE: ${{ inputs.qualification_mode }}
@@ -212,6 +222,7 @@ jobs:
           tv_firebase_app_id="${INPUT_TV_FIREBASE_APP_ID:-}"
           tv_firebase_tester_groups="${INPUT_TV_FIREBASE_TESTER_GROUPS:-}"
           mobile_profile="${INPUT_MOBILE_PROFILE:-none}"
+          coins_profile="${INPUT_COINS_PROFILE:-none}"
           macos_profile="${INPUT_MACOS_PROFILE:-none}"
           macos_require_notarization="${INPUT_MACOS_REQUIRE_NOTARIZATION:-false}"
           qualification_mode="${INPUT_QUALIFICATION_MODE:-internal}"
@@ -263,6 +274,14 @@ jobs:
             fi
           fi
 
+          case "$coins_profile" in
+            none|coins) ;;
+            *)
+              echo "::error::Unsupported Airo Coins profile: $coins_profile"
+              exit 1
+              ;;
+          esac
+
           case "$macos_profile" in
             none|tv) ;;
             *)
@@ -312,6 +331,7 @@ jobs:
             echo "tv_firebase_app_id=$tv_firebase_app_id"
             echo "tv_firebase_tester_groups=$tv_firebase_tester_groups"
             echo "mobile_profile=$mobile_profile"
+            echo "coins_profile=$coins_profile"
             echo "macos_profile=$macos_profile"
             echo "macos_require_notarization=$macos_require_notarization"
             echo "qualification_mode=$qualification_mode"
@@ -335,6 +355,7 @@ jobs:
             echo "| Mobile/tablet Play track | $mobile_play_track |"
             echo "| Firebase distribution | $firebase_distribution |"
             echo "| Mobile/tablet profile | $mobile_profile |"
+            echo "| Airo Coins profile | $coins_profile |"
             echo "| macOS profile | $macos_profile |"
             echo "| macOS notarization required | $macos_require_notarization |"
             echo "| Qualification mode | $qualification_mode |"
@@ -386,6 +407,24 @@ jobs:
       firebase_tester_groups: ${{ needs.prepare.outputs.mobile_firebase_tester_groups }}
     secrets: inherit
 
+  coins-release:
+    name: Airo Coins release leg
+    if: needs.prepare.outputs.coins_profile != 'none'
+    needs: [prepare, release-contracts]
+    permissions:
+      contents: read
+    uses: ./.github/workflows/airo-mobile-tablet-release.yml
+    with:
+      profile: ${{ needs.prepare.outputs.coins_profile }}
+      version: ${{ needs.prepare.outputs.version }}
+      build_name: ${{ needs.prepare.outputs.build_name }}
+      build_number: ${{ needs.prepare.outputs.build_number }}
+      release_ref: ${{ needs.prepare.outputs.release_ref }}
+      production_signing: ${{ needs.prepare.outputs.production_signing == 'true' }}
+      play_track: none
+      firebase_distribution: none
+    secrets: inherit
+
   macos-release:
     name: macOS release leg
     if: needs.prepare.outputs.macos_profile != 'none'
@@ -427,7 +466,7 @@ jobs:
   release-summary:
     name: V2 release summary
     runs-on: ubuntu-latest
-    needs: [prepare, release-contracts, mobile-tablet-release, macos-release, tv-release]
+    needs: [prepare, release-contracts, mobile-tablet-release, coins-release, macos-release, tv-release]
     if: always()
     permissions:
       actions: read
@@ -450,6 +489,13 @@ jobs:
         with:
           name: airo-mobile-tablet-${{ needs.prepare.outputs.mobile_profile }}-${{ needs.prepare.outputs.version }}
           path: release-artifacts/mobile-tablet
+
+      - name: Download Airo Coins release artifacts
+        if: needs.coins-release.result == 'success'
+        uses: actions/download-artifact@v8
+        with:
+          name: airo-mobile-tablet-${{ needs.prepare.outputs.coins_profile }}-${{ needs.prepare.outputs.version }}
+          path: release-artifacts/coins
 
       - name: Download macOS release artifacts
         if: needs.macos-release.result == 'success'
@@ -486,6 +532,20 @@ jobs:
             --manifest "$manifest" \
             --mode "$QUALIFICATION_MODE"
 
+      - name: Generate Airo Coins qualification report
+        if: needs.coins-release.result == 'success'
+        env:
+          QUALIFICATION_MODE: ${{ needs.prepare.outputs.qualification_mode }}
+        run: |
+          manifest="$(find release-artifacts/coins -maxdepth 1 -name '*Release-Manifest.json' | head -n 1)"
+          if [ -z "$manifest" ]; then
+            echo "::error::Airo Coins release manifest was not found in downloaded artifacts."
+            exit 1
+          fi
+          scripts/generate-release-qualification-report.py \
+            --manifest "$manifest" \
+            --mode "$QUALIFICATION_MODE"
+
       - name: Upload top-level release evidence
         if: needs.tv-release.result == 'success'
         uses: actions/upload-artifact@v7
@@ -503,9 +563,11 @@ jobs:
           RELEASE_REF: ${{ needs.prepare.outputs.release_ref }}
           RELEASE_SHA: ${{ needs.prepare.outputs.release_sha }}
           MOBILE_PROFILE: ${{ needs.prepare.outputs.mobile_profile }}
+          COINS_PROFILE: ${{ needs.prepare.outputs.coins_profile }}
           MACOS_PROFILE: ${{ needs.prepare.outputs.macos_profile }}
           TV_SIGNING_CERT: ${{ needs.tv-release.outputs.signing_cert }}
           MOBILE_SIGNING_CERT: ${{ needs.mobile-tablet-release.outputs.signing_cert }}
+          COINS_SIGNING_CERT: ${{ needs.coins-release.outputs.signing_cert }}
         run: |
           rm -rf github-release-assets
           mkdir -p github-release-assets
@@ -533,6 +595,19 @@ jobs:
               ;;
             *)
               echo "::error::Unsupported mobile/tablet profile for release assets: $MOBILE_PROFILE"
+              exit 1
+              ;;
+          esac
+
+          case "$COINS_PROFILE" in
+            none)
+              ;;
+            coins)
+              require_asset "release-artifacts/coins/AiroCoins-${BUILD_NAME}-${BUILD_NUMBER}-arm64.apk"
+              require_asset "release-artifacts/coins/AiroCoins-${BUILD_NAME}-${BUILD_NUMBER}-Play-Store.aab"
+              ;;
+            *)
+              echo "::error::Unsupported Airo Coins profile for release assets: $COINS_PROFILE"
               exit 1
               ;;
           esac
@@ -591,6 +666,9 @@ jobs:
             fi
             if [ "$MOBILE_PROFILE" != "none" ]; then
               echo "- Mobile/tablet APK/AAB: $(describe_cert "$MOBILE_SIGNING_CERT")"
+            fi
+            if [ "$COINS_PROFILE" != "none" ]; then
+              echo "- Airo Coins APK/AAB: $(describe_cert "$COINS_SIGNING_CERT")"
             fi
             echo ""
             echo "## Verification"
@@ -667,6 +745,8 @@ jobs:
           TV_RESULT: ${{ needs.tv-release.result }}
           MOBILE_RESULT: ${{ needs.mobile-tablet-release.result }}
           MOBILE_PROFILE: ${{ needs.prepare.outputs.mobile_profile }}
+          COINS_RESULT: ${{ needs.coins-release.result }}
+          COINS_PROFILE: ${{ needs.prepare.outputs.coins_profile }}
           MACOS_RESULT: ${{ needs.macos-release.result }}
           MACOS_PROFILE: ${{ needs.prepare.outputs.macos_profile }}
           MACOS_SIGNING_STATUS: ${{ needs.macos-release.outputs.signing_status }}
@@ -698,6 +778,8 @@ jobs:
             echo "| Mobile/tablet profile | $MOBILE_PROFILE |"
             echo "| Mobile/tablet leg | $MOBILE_RESULT |"
             echo "| Mobile/tablet Play track | $MOBILE_PLAY_TRACK |"
+            echo "| Airo Coins profile | $COINS_PROFILE |"
+            echo "| Airo Coins leg | $COINS_RESULT |"
             echo "| macOS profile | $MACOS_PROFILE |"
             echo "| macOS leg | $MACOS_RESULT |"
             echo "| macOS signing | ${MACOS_SIGNING_STATUS:-none} |"
@@ -744,6 +826,21 @@ jobs:
             echo "Mobile/tablet artifacts were not available because the mobile/tablet leg result was $MOBILE_RESULT." >> "$GITHUB_STEP_SUMMARY"
           fi
 
+          if [ -d release-artifacts/coins ]; then
+            {
+              echo ""
+              echo "### Airo Coins"
+              echo ""
+              find release-artifacts/coins -maxdepth 1 -type f -printf '- %f\n' | sort
+              echo ""
+              echo "Airo Coins artifacts include APK/AAB files, SHA256SUMS, release manifest, and an internal qualification report when generated by this orchestrator."
+            } >> "$GITHUB_STEP_SUMMARY"
+          elif [ "$COINS_PROFILE" = "none" ]; then
+            echo "Airo Coins artifacts were not requested for this orchestrator run." >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "Airo Coins artifacts were not available because the Airo Coins leg result was $COINS_RESULT." >> "$GITHUB_STEP_SUMMARY"
+          fi
+
           if [ -d release-artifacts/macos ]; then
             {
               echo ""
@@ -775,6 +872,8 @@ jobs:
           TV_RESULT: ${{ needs.tv-release.result }}
           MOBILE_RESULT: ${{ needs.mobile-tablet-release.result }}
           MOBILE_PROFILE: ${{ needs.prepare.outputs.mobile_profile }}
+          COINS_RESULT: ${{ needs.coins-release.result }}
+          COINS_PROFILE: ${{ needs.prepare.outputs.coins_profile }}
           MACOS_RESULT: ${{ needs.macos-release.result }}
           MACOS_PROFILE: ${{ needs.prepare.outputs.macos_profile }}
           CONTRACT_RESULT: ${{ needs.release-contracts.result }}
@@ -789,6 +888,10 @@ jobs:
           fi
           if [ "$MOBILE_PROFILE" != "none" ] && [ "$MOBILE_RESULT" != "success" ]; then
             echo "::error::Mobile/tablet release leg did not pass: $MOBILE_RESULT"
+            exit 1
+          fi
+          if [ "$COINS_PROFILE" != "none" ] && [ "$COINS_RESULT" != "success" ]; then
+            echo "::error::Airo Coins release leg did not pass: $COINS_RESULT"
             exit 1
           fi
           if [ "$MACOS_PROFILE" != "none" ] && [ "$MACOS_RESULT" != "success" ]; then

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,40 @@ All notable changes to this project are documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html) for public release tags.
 
-## Unreleased — Airo TV v0.0.6 candidate
+## v0.0.6 — 2026-08-04
+
+Stable cut of the `0.0.6` line across Airo TV, the full app, Airo Coins, and
+macOS TV. Full notes: [docs/release/AIRO_v0.0.6.md](docs/release/AIRO_v0.0.6.md).
 
 ### Added
+
+- Airo Coins is a first-class release-orchestrator leg (`coins_profile`), so the
+  TV, full, Coins, and macOS artifacts all ship from one reproducible wave
+  instead of a hand-published Coins upload.
+- Offline Meeting Intelligence MVP — record, transcribe, summarise, search.
+- Airo Mind Vault phase 1 and the `MindRuntime` port frozen into eight sub-ports.
+- Copyable device-capability, runtime-health, and model-advisor diagnostics, plus
+  chat transcript export.
+- Portable shared channel imports for Airo TV.
+
+### Fixed
+
+- Fire TV D-pad focus and BACK paths restored after the #1244 regression.
+- TV shell held inside both horizontal and vertical title-safe bands.
+- Chess moves are applied instead of silently rejected.
+- Playlist source removal is consistent; local media IDs are web-safe.
+- Model download queue position, stalled-download recovery, and setup-failure
+  detail.
+
+### Known issues
+
+- #1240 Airo Coins can open to a persistent black screen on Pixel 9 / Android 17.
+- #1430 Airo TV BACK intermittently swallowed on the channel-browse grid.
+- #1243 Fire TV live playback emits repeated vendor property-denial log errors.
+
+### Also in this line, since v0.0.6-rc.1
+
+#### Added
 
 - Direct, permission-scoped USB/removable-media browsing on Android TV without
   converting local files into playlists, including deterministic sidecar
@@ -18,17 +49,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - Production Android signing setup, release provenance attestations, and
   repository license/notices preflight coverage.
 
-### Changed
+#### Changed
 
-- Release candidates remain dry-run / unpublished unless a maintainer
-  explicitly opts into publication. The version line stays `0.0.6-rc.1`;
-  promoting to `0.0.6` is a deliberate release cut, not a merge side-effect.
+- The version line is promoted from `0.0.6-rc.1` to `0.0.6` across
+  `pubspec.yaml`, `pubspec_tv.yaml`, and `pubspec_coins.yaml`, all at build
+  `+10`.
 - TV first-run setup offers URL, expiring phone QR, and USB only when the
   corresponding platform capability is real.
 - TV rail traversal now has a deterministic leading-edge focus bridge from
   Search, Name sort, and the first channel.
 
-### Fixed
+#### Fixed
 
 - Coins uses one launcher activity and validates the resolved component before
   artifact smoke tests, preventing the Pixel 9 black-screen launch path.
@@ -40,12 +71,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - Generated Pigeon/build-runner outputs and model warmup/activation boundaries
   compile and carry focused test coverage.
 
-### Qualification status
+#### Qualification status
 
 - Automated source, player, TV navigation, legal, provenance, native-media,
-  screenshot, and artifact checks are prepared locally.
-- Pixel 9, Fire TV Stick, and iPad physical-device sign-off remains required
-  before publishing. No release has been created.
+  screenshot, and artifact checks run in CI on every release wave.
+- Pixel 9, Fire TV Stick, and iPad physical-device sign-off was not repeated for
+  this cut; the known issues above are the outstanding device-verified defects.
 
 ## [Airo v0.0.6-rc.1] - 2026-07-30
 

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 0.0.6-rc.1+8
+version: 0.0.6+10
 
 environment:
   sdk: ">=3.12.2 <4.0.0"

--- a/app/pubspec_coins.yaml
+++ b/app/pubspec_coins.yaml
@@ -1,7 +1,7 @@
 name: airo_app
 description: "Airo Coins - focused local-first finance vault"
 publish_to: none
-version: 0.0.6+8
+version: 0.0.6+10
 
 environment:
   sdk: ">=3.12.2 <4.0.0"

--- a/app/pubspec_tv.yaml
+++ b/app/pubspec_tv.yaml
@@ -11,7 +11,7 @@
 name: airo_app
 description: "Airo TV - IPTV streaming for Android TV"
 publish_to: 'none'
-version: 0.0.6-rc.1+6
+version: 0.0.6+10
 
 environment:
   sdk: ">=3.12.2 <4.0.0"

--- a/docs/release/AIRO_v0.0.6.md
+++ b/docs/release/AIRO_v0.0.6.md
@@ -1,0 +1,96 @@
+# Airo v0.0.6 — Stable Release
+
+Stable cut for **direct download / APKPure**, promoting the `v0.0.6-rc.1`
+preview line. Google Play, App Store, Firebase App Distribution, iOS/iPadOS, and
+macOS notarization remain out of scope for this cut.
+
+## Release wave (published artifacts)
+
+| Profile | Package / bundle | Artifact | Version line |
+| --- | --- | --- | --- |
+| Android TV (`tv`) | `io.airo.app.tv` | `Airo-TV-0.0.6.apk` + per-ABI APKs + AAB | `0.0.6+10` |
+| Full app (`full`) | `io.airo.app` | `Airo-0.0.6-10-arm64.apk` + AAB | `0.0.6+10` |
+| Airo Coins (`coins`) | `io.airo.app.coins` | `AiroCoins-0.0.6-10-arm64.apk` + AAB | `0.0.6+10` |
+| macOS TV | `com.developerscoffee.airo.tv` | direct-download `.zip` / `.dmg` + Homebrew Cask | `0.0.6` |
+
+All four profiles ship from a single `release-orchestrator.yml` wave. Airo Coins
+was published by hand for `v0.0.6-rc.1`; it is now a first-class orchestrator leg
+(`coins_profile`), so the wave is reproducible end to end.
+
+Tag: `v0.0.6`.
+
+## Not in this release
+
+| Artifact / profile | Source | Status |
+| --- | --- | --- |
+| iOS / iPadOS SPM | `ios-spm` | Deferred — no Apple developer account. |
+| Web validation | `web-validation` | Local/CI browser-engine validation only; no public web deploy. |
+| Linux / Windows desktop | `app/linux`, `app/windows` | Build targets exist; no release workflow, no published artifact. |
+| Airo Mind runtime | `packages/feature_mind` | Milestone 22 work is in-tree behind the `MindRuntime` port; no separate shippable artifact. |
+| Raw gradle APKs | `app-release.apk`, `app-arm64-v8a-release.apk` | Renamed to `Airo-*` / `Airo-TV-*` / `AiroCoins-*` before publish. |
+| Debug symbols / obfuscation maps | `.symbols`, `.map` | Retained privately as a restricted workflow artifact for symbolication. |
+| Credentials & secrets | `*.jks`, `google-services.json`, service accounts | Never attached to public assets or the release manifest. |
+
+## What is new since v0.0.6-rc.1
+
+**Airo TV**
+
+- Fire TV D-pad focus and BACK paths restored after the #1244 regression.
+- The TV shell is held inside both the horizontal and vertical title-safe bands,
+  fixing overscan clipping on real Fire TV hardware.
+- Help stays reachable in the grid-first layout; settings focus survives
+  retained playback.
+- Local-file cast release and Fire TV release qualification hardened, including
+  ABI splits and physical-log classification.
+- Portable shared channel imports for moving a channel set between devices.
+
+**Airo (full app)**
+
+- Guide and Favorites moved into IPTV; Settings moved under Profile.
+- Chess moves are applied instead of being silently rejected.
+- Playlist source removal is now consistent; local media IDs are web-safe.
+
+**Airo Mind / AI**
+
+- Offline Meeting Intelligence MVP — record, transcribe, summarise, search.
+- Airo Mind Vault phase 1, and the `MindRuntime` port frozen into eight
+  sub-ports with fixture and partial Rust implementations behind it.
+- Device runtime readiness explained in-app, with copyable device-capability,
+  runtime-health, and model-advisor diagnostics plus chat transcript export.
+- Model download queue position, stalled-download recovery, and clearer setup
+  failure messages.
+
+**Airo Coins**
+
+- The standalone shell opens on a content-first money home.
+
+## Known issues
+
+| Issue | Impact |
+| --- | --- |
+| #1240 | Airo Coins can open to a persistent black screen on Pixel 9 / Android 17. Not re-verified against the new coins shell in this cut. |
+| #1430 | Airo TV: BACK is intermittently swallowed on the channel-browse grid after returning from playback. |
+| #1243 | Fire TV live playback emits repeated vendor property-denial errors in logcat; playback is unaffected. |
+| #1025 | `platform_player` overlays can stack — error state, idle play button, and hover controls render together. |
+| #1023 | `feature_iptv`: mini-player "Watch" does not open the fullscreen player on macOS. |
+
+## Signing and upgrade chain
+
+This cut uses the stable dogfood keystore (`production_signing=false` plus the
+four `DOGFOOD_*` secrets). Builds upgrade cleanly over other dogfood-signed
+builds, including `v0.0.6-rc.1`, but **not** over production-signed releases.
+The per-artifact signing certificate is recorded in the generated release notes
+and manifest.
+
+## Verification
+
+`SHA256SUMS` and `Airo-0.0.6-Release-Manifest.json` are published as release
+assets. The manifest maps every checksum to its profile, package ID, version,
+build number, source ref, and workflow run.
+
+## Related documents
+
+- [V2 release orchestrator](./V2_RELEASE_ORCHESTRATOR.md)
+- [v0.0.6-rc.1 preview notes](./AIRO_v0.0.6-rc.1.md)
+- [Airo TV release template](./AIRO_TV_RELEASE_TEMPLATE.md)
+- [Release checklist](./RELEASE_CHECKLIST.md)

--- a/docs/release/V2_RELEASE_ORCHESTRATOR.md
+++ b/docs/release/V2_RELEASE_ORCHESTRATOR.md
@@ -20,6 +20,8 @@ artifacts without creating public GitHub Releases or uploading to Google Play.
 The orchestrator currently validates the release contract, calls the existing
 Airo TV release workflow through `workflow_call`, optionally calls the
 mobile/tablet release workflow when a mobile profile is selected, optionally
+calls the same mobile/tablet workflow again for Airo Coins when
+`coins_profile` is selected, optionally
 calls the macOS release workflow when `macos_profile` is selected, downloads
 the selected profile artifacts, generates the top-level evidence bundle,
 optionally publishes a single aggregate GitHub Release, and writes the release
@@ -38,6 +40,16 @@ release manifest, retain obfuscation symbols, optionally upload the AAB to a
 selected Play track, and contribute mobile/tablet qualification evidence. Real
 store or Firebase publication still depends on the credential and destination
 setup tracked in #681 and #682.
+
+When `coins_profile` is `coins`, the orchestrator calls the same
+`.github/workflows/airo-mobile-tablet-release.yml` on the `coins` profile
+(`io.airo.app.coins`, `pubspec_coins.yaml`, `lib/main_coins.dart`) to build the
+`AiroCoins-*` APK and Play Store AAB alongside the mobile/tablet leg. The two
+legs are independent: `mobile_profile` and `coins_profile` are selected
+separately, and the reusable workflow's concurrency group is keyed by profile so
+they do not cancel each other. Airo Coins has no Play or Firebase destination in
+the orchestrator; the leg always runs with `play_track: none` and
+`firebase_distribution: none`.
 
 When `firebase_distribution` is `upload`, the reusable TV and mobile/tablet
 release workflows upload the final named APK artifacts to Firebase App
@@ -61,6 +73,8 @@ Successful orchestrator runs upload:
 - `airo-tv-release-<version>` from the TV workflow;
 - `airo-mobile-tablet-<profile>-<version>` from the mobile/tablet workflow when
   `mobile_profile` is not `none`;
+- `airo-mobile-tablet-coins-<version>` from the mobile/tablet workflow when
+  `coins_profile` is not `none`;
 - `airo-macos-<profile>-<version>` from the macOS workflow when
   `macos_profile` is not `none`;
 - `v2-release-evidence-<version>` from the orchestrator.
@@ -73,8 +87,8 @@ approved waiver is missing.
 When `publish_github_release` is enabled and `dry_run` is false, the
 orchestrator prepares a flat GitHub Release asset directory that contains:
 
-- every required APK and Play Store AAB for TV and the selected mobile/tablet
-  profile;
+- every required APK and Play Store AAB for TV, the selected mobile/tablet
+  profile, and the selected Airo Coins profile;
 - every required macOS ZIP/DMG artifact and generated Homebrew Cask file for
   the selected macOS profile;
 - a combined `SHA256SUMS` generated after final asset naming;


### PR DESCRIPTION
Prepares the stable `v0.0.6` cut and closes the gap that made `v0.0.6-rc.1` only partly reproducible.

## Why

Airo Coins was published in `v0.0.6-rc.1` by hand: someone dispatched `airo-mobile-tablet-release.yml` with `profile=coins` and uploaded the `AiroCoins-*` assets onto the release afterwards. The orchestrator could not do it — `mobile_profile` offered `none|full`, and the release-asset step `exit 1`s on anything else. #1404 added the `coins` profile to the reusable workflow only.

## What

**`feat(release)`** — `coins_profile` input (`none|coins`) plus a `coins-release` job calling the same reusable mobile/tablet workflow. The reusable workflow's concurrency group is keyed by profile, so the `full` and `coins` legs run concurrently without cancelling each other. Coins has no Play or Firebase destination, so the leg is pinned to `play_track: none` / `firebase_distribution: none`. `release-summary` gains the matching download, qualification report, `require_asset` pair, signing-cert note, evidence section, and result gate.

**`chore(release)`** — all three flavour pubspecs promoted `0.0.6-rc.1` → `0.0.6+10`. Build 10 clears the highest versionCode already on the line (coins shipped at 9 via the manual rc.1 leg), keeping sideload upgrades monotonic per package id. Adds `docs/release/AIRO_v0.0.6.md`; folds the standing "Airo TV v0.0.6 candidate" changelog section into a dated `v0.0.6` entry.

## Release wave this enables

| Profile | Package | Artifacts |
| --- | --- | --- |
| `tv` | `io.airo.app.tv` | universal + 3 ABI APKs + AAB |
| `full` | `io.airo.app` | arm64 APK + AAB |
| `coins` | `io.airo.app.coins` | arm64 APK + AAB |
| macOS TV | `com.developerscoffee.airo.tv` | .zip + .dmg + Homebrew Cask |

Out of scope, unchanged: iOS/iPadOS (no Apple account), web (CI validation only), Linux/Windows (no release workflow).

## Verification

The `release-contracts` gate was run locally against this branch and passes in full — workflow YAML parse for all four release workflows, `py_compile` on the three release scripts, `check-build-profiles.py`, and both generator test scripts.

## Known issues shipping with this cut

- #1240 — Airo Coins can open to a persistent black screen on Pixel 9 / Android 17. Not re-verified against the new coins shell.
- #1430 — Airo TV BACK intermittently swallowed on the channel-browse grid.

Both are recorded in the release doc and changelog. Publishing stable with #1240 open is a deliberate call by the release owner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)