### PR TITLE
ci(mind): actually run the Mind tests and the R03/R05 gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,6 +165,24 @@ jobs:
           wait
           echo "All core package tests completed!"
 
+      # feature_mind carries the M22 runtime port and the R01-R04 rule tests.
+      # Its *.freezed.dart is gitignored, so codegen must run before the tests
+      # can compile at all -- without this step the package fails with a
+      # misleading "Couldn't find constructor ProcessingEvent_*".
+      - name: Run Airo Mind package tests
+        run: |
+          cd packages/feature_mind
+          flutter pub get
+          dart run build_runner build
+          flutter test --reporter=compact
+
+      # Rules R03 and R05 are repo gates, not package tests. A gate CI never
+      # invokes is not a gate.
+      - name: Check Airo Mind design rules (R03, R05)
+        run: |
+          scripts/check-mind-projection-routes.sh
+          scripts/check-mind-private-devices.sh
+
   # ============================================
   # Variant Dependency Profiles
   # ============================================

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -201,6 +201,24 @@ jobs:
           wait
           echo "All core package tests completed!"
 
+      # feature_mind carries the M22 runtime port and the R01-R04 rule tests.
+      # Its *.freezed.dart is gitignored, so codegen must run before the tests
+      # can compile at all -- without this step the package fails with a
+      # misleading "Couldn't find constructor ProcessingEvent_*".
+      - name: Run Airo Mind package tests
+        run: |
+          cd packages/feature_mind
+          flutter pub get
+          dart run build_runner build
+          flutter test --reporter=compact
+
+      # Rules R03 and R05 are repo gates, not package tests. A gate CI never
+      # invokes is not a gate.
+      - name: Check Airo Mind design rules (R03, R05)
+        run: |
+          scripts/check-mind-projection-routes.sh
+          scripts/check-mind-private-devices.sh
+
   # ============================================
   # PR Summary Comment
   # ============================================

--- a/packages/feature_mind/test/rules/r03_route_gate_test.dart
+++ b/packages/feature_mind/test/rules/r03_route_gate_test.dart
@@ -59,4 +59,41 @@ const route = GoRoute(path: 'timeline', name: 'timeline');
       if (offender.existsSync()) offender.deleteSync();
     }
   });
+
+  test('the gate refuses to run without ripgrep rather than passing', () {
+    // Both gates find violations with rg inside `|| true`. Without rg that
+    // returns no matches and the gate would report OK having checked nothing —
+    // the exact failure these gates exist to prevent.
+    //
+    // A PATH holding only the tools the script needs to reach its own guard,
+    // and provably not rg. Pointing PATH at a nonexistent directory would hide
+    // bash too and the shebang would fail before the guard ran, which proves
+    // nothing; naming real bin directories would still find rg on Linux.
+    final bin = Directory.systemTemp.createTempSync('mind_no_rg');
+    for (final tool in ['bash', 'env', 'dirname', 'pwd']) {
+      final resolved = Process.runSync('which', [
+        tool,
+      ]).stdout.toString().trim();
+      if (resolved.isEmpty) continue;
+      Link('${bin.path}/$tool').createSync(resolved);
+    }
+
+    try {
+      final result = Process.runSync(
+        gate,
+        const [],
+        environment: {'PATH': bin.path},
+        includeParentEnvironment: false,
+      );
+
+      expect(
+        result.exitCode,
+        127,
+        reason: 'stdout: ${result.stdout}\nstderr: ${result.stderr}',
+      );
+      expect(result.stderr.toString(), contains('ripgrep'));
+    } finally {
+      bin.deleteSync(recursive: true);
+    }
+  });
 }

--- a/scripts/check-mind-private-devices.sh
+++ b/scripts/check-mind-private-devices.sh
@@ -11,6 +11,15 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT_DIR"
 
+# Both gates locate violations with ripgrep inside `|| true`, so a missing rg
+# would return no matches and the gate would pass having checked nothing. That
+# is the exact failure this file exists to prevent, so refuse to run instead.
+if ! command -v rg >/dev/null 2>&1; then
+  echo "FATAL: ripgrep (rg) is not installed. This gate cannot verify anything" >&2
+  echo "without it, and passing silently would be worse than failing." >&2
+  exit 127
+fi
+
 # Pubspecs whose builds reach a screen other people can see.
 shared_pubspecs=("app/pubspec_tv.yaml")
 

--- a/scripts/check-mind-projection-routes.sh
+++ b/scripts/check-mind-projection-routes.sh
@@ -8,6 +8,15 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT_DIR"
 
+# Both gates locate violations with ripgrep inside `|| true`, so a missing rg
+# would return no matches and the gate would pass having checked nothing. That
+# is the exact failure this file exists to prevent, so refuse to run instead.
+if ! command -v rg >/dev/null 2>&1; then
+  echo "FATAL: ripgrep (rg) is not installed. This gate cannot verify anything" >&2
+  echo "without it, and passing silently would be worse than failing." >&2
+  exit 127
+fi
+
 scan_paths=()
 for path in "app/lib" "packages"; do
   [[ -e "$path" ]] && scan_paths+=("$path")


### PR DESCRIPTION
## Summary

Follow-up to [#1474](https://github.com/DevelopersCoffee/airo/pull/1474), which
merged before this commit landed on the branch.

M22 P0 shipped the R03 and R05 gate scripts and 90 `feature_mind` tests. **Nothing
on `main` invokes any of them.**

- The `tests` job in `pr-checks.yml` and `test-core` in `ci.yml` both run a
  hardcoded list of six core packages. `feature_mind` is not among them, and app
  tests moved to the release workflow.
- `scripts/check-mind-projection-routes.sh` and
  `scripts/check-mind-private-devices.sh` are on `main` but no workflow calls
  them.

So `tests: pass` on #1474 covered none of what that PR added, and the two rules
it introduced are unenforced today. A gate CI never runs is not a gate — which
is precisely the defect class M22's governance is built to prevent, so leaving
it is not an option.

## What this changes

- Both jobs now run `feature_mind`, including the `dart run build_runner build`
  step it cannot compile without: `*.freezed.dart` is gitignored, so a fresh
  checkout fails with a misleading `Couldn't find constructor
  ProcessingEvent_*`.
- Both jobs invoke the R03 and R05 gates.
- Both gates are hardened. They locate violations with `rg` inside `|| true`,
  so on a runner without ripgrep they would match nothing and report OK having
  checked nothing. They now `exit 127` instead, with a test that proves it by
  running a gate against a `PATH` containing `bash` but provably not `rg` —
  pointing `PATH` at a nonexistent directory would hide `bash` too and the
  shebang would fail before the guard ran, which proves nothing.

## Test Plan

- [x] `flutter test` in `packages/feature_mind` — **90 pass** on this branch
      (`main` + this commit)
- [x] Both gates pass, and each still fails on its mutants
      (`packages/feature_mind/test/rules/`)
- [x] `flutter analyze --fatal-infos` clean
- [ ] Manual device verification — not applicable, CI configuration only

**Verification environment:** Host-only

The real proof is this PR's own CI: the `tests` and `test-core` jobs should now
show `Run Airo Mind package tests` and `Check Airo Mind design rules (R03, R05)`
steps. If those steps are absent from the run, this change did not work.

## Agent Policy

- [x] Linked issue includes a Critical Agent Gate — [#1449](https://github.com/DevelopersCoffee/airo/issues/1449)
- [x] Feature Packet — inherited from #1474's spec and plan
- [x] Cross-agent contract — not applicable, no contract change
- [x] Deterministic use cases — the gate mutation tests
- [x] AI/tool/memory/routine changes — none
- [x] Android Emulator not used

## Council Review

- **Chief Release DevOps Officer** — workflow change. **Not yet reviewed.**
- **Chief QA Officer** — test coverage gap this closes. **Not yet reviewed.**

- [ ] Checked the Decision Matrix and listed every required role above —
      **listed, neither has reviewed yet.**
- [x] No package manifests touched.

## User-Facing Documentation

- [x] No `docs/wiki` update needed — CI configuration has no user-visible
      behaviour.

## Plugin and Size Impact

- [ ] Adds new dependencies — no
- [ ] Adds or grows packages code — no, workflow and script changes only
- [x] Size impact: none

## Checklist

- [x] Code is formatted.
- [x] Tests included above.
- [x] No sensitive data committed.

## Release Notes

- [x] Not user-facing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
