### PR TITLE
fix(release): fold the coins leg into the mobile profile selector

### DIFF
--- a/.github/workflows/release-orchestrator.yml
+++ b/.github/workflows/release-orchestrator.yml
@@ -97,21 +97,15 @@ on:
         required: false
         default: ''
       mobile_profile:
-        description: 'Optional mobile/tablet profile to build'
+        description: 'Optional mobile/tablet profiles to build'
         required: true
         default: none
         type: choice
         options:
           - none
           - full
-      coins_profile:
-        description: 'Optional Airo Coins profile to build'
-        required: true
-        default: none
-        type: choice
-        options:
-          - none
           - coins
+          - full-and-coins
       macos_profile:
         description: 'Optional macOS profile to build'
         required: true
@@ -198,7 +192,6 @@ jobs:
           INPUT_TV_FIREBASE_APP_ID: ${{ inputs.tv_firebase_app_id }}
           INPUT_TV_FIREBASE_TESTER_GROUPS: ${{ inputs.tv_firebase_tester_groups }}
           INPUT_MOBILE_PROFILE: ${{ inputs.mobile_profile }}
-          INPUT_COINS_PROFILE: ${{ inputs.coins_profile }}
           INPUT_MACOS_PROFILE: ${{ inputs.macos_profile }}
           INPUT_MACOS_REQUIRE_NOTARIZATION: ${{ inputs.macos_require_notarization }}
           INPUT_QUALIFICATION_MODE: ${{ inputs.qualification_mode }}
@@ -221,8 +214,32 @@ jobs:
           mobile_firebase_tester_groups="${INPUT_MOBILE_FIREBASE_TESTER_GROUPS:-}"
           tv_firebase_app_id="${INPUT_TV_FIREBASE_APP_ID:-}"
           tv_firebase_tester_groups="${INPUT_TV_FIREBASE_TESTER_GROUPS:-}"
-          mobile_profile="${INPUT_MOBILE_PROFILE:-none}"
-          coins_profile="${INPUT_COINS_PROFILE:-none}"
+          # workflow_dispatch caps the number of inputs, so the Android
+          # application profiles share one selector instead of taking a field
+          # each. Split it back into the per-leg profiles the jobs consume.
+          mobile_selection="${INPUT_MOBILE_PROFILE:-none}"
+          case "$mobile_selection" in
+            none)
+              mobile_profile=none
+              coins_profile=none
+              ;;
+            full)
+              mobile_profile=full
+              coins_profile=none
+              ;;
+            coins)
+              mobile_profile=none
+              coins_profile=coins
+              ;;
+            full-and-coins)
+              mobile_profile=full
+              coins_profile=coins
+              ;;
+            *)
+              echo "::error::Unsupported mobile/tablet profile selection: $mobile_selection"
+              exit 1
+              ;;
+          esac
           macos_profile="${INPUT_MACOS_PROFILE:-none}"
           macos_require_notarization="${INPUT_MACOS_REQUIRE_NOTARIZATION:-false}"
           qualification_mode="${INPUT_QUALIFICATION_MODE:-internal}"
@@ -273,14 +290,6 @@ jobs:
               exit 1
             fi
           fi
-
-          case "$coins_profile" in
-            none|coins) ;;
-            *)
-              echo "::error::Unsupported Airo Coins profile: $coins_profile"
-              exit 1
-              ;;
-          esac
 
           case "$macos_profile" in
             none|tv) ;;

--- a/docs/release/V2_RELEASE_ORCHESTRATOR.md
+++ b/docs/release/V2_RELEASE_ORCHESTRATOR.md
@@ -20,8 +20,8 @@ artifacts without creating public GitHub Releases or uploading to Google Play.
 The orchestrator currently validates the release contract, calls the existing
 Airo TV release workflow through `workflow_call`, optionally calls the
 mobile/tablet release workflow when a mobile profile is selected, optionally
-calls the same mobile/tablet workflow again for Airo Coins when
-`coins_profile` is selected, optionally
+calls the same mobile/tablet workflow again for Airo Coins when the selection
+includes coins, optionally
 calls the macOS release workflow when `macos_profile` is selected, downloads
 the selected profile artifacts, generates the top-level evidence bundle,
 optionally publishes a single aggregate GitHub Release, and writes the release
@@ -41,15 +41,27 @@ selected Play track, and contribute mobile/tablet qualification evidence. Real
 store or Firebase publication still depends on the credential and destination
 setup tracked in #681 and #682.
 
-When `coins_profile` is `coins`, the orchestrator calls the same
+`mobile_profile` selects both Android application legs, because
+`workflow_dispatch` caps how many inputs a workflow may declare and the
+orchestrator is at that cap:
+
+| `mobile_profile` | Full app leg | Airo Coins leg |
+| --- | --- | --- |
+| `none` | — | — |
+| `full` | `io.airo.app` | — |
+| `coins` | — | `io.airo.app.coins` |
+| `full-and-coins` | `io.airo.app` | `io.airo.app.coins` |
+
+The `prepare` job splits that selection into the internal `mobile_profile` and
+`coins_profile` outputs the two jobs consume. The Airo Coins leg calls the same
 `.github/workflows/airo-mobile-tablet-release.yml` on the `coins` profile
-(`io.airo.app.coins`, `pubspec_coins.yaml`, `lib/main_coins.dart`) to build the
-`AiroCoins-*` APK and Play Store AAB alongside the mobile/tablet leg. The two
-legs are independent: `mobile_profile` and `coins_profile` are selected
-separately, and the reusable workflow's concurrency group is keyed by profile so
-they do not cancel each other. Airo Coins has no Play or Firebase destination in
-the orchestrator; the leg always runs with `play_track: none` and
-`firebase_distribution: none`.
+(`pubspec_coins.yaml`, `lib/main_coins.dart`) to build the `AiroCoins-*` APK and
+Play Store AAB. The reusable workflow's concurrency group is keyed by profile,
+so the two legs run side by side without cancelling each other. Airo Coins has
+no Play or Firebase destination in the orchestrator; the leg always runs with
+`play_track: none` and `firebase_distribution: none`. `mobile_play_track`
+applies to the full app leg only and still requires a selection that includes
+`full`.
 
 When `firebase_distribution` is `upload`, the reusable TV and mobile/tablet
 release workflows upload the final named APK artifacts to Firebase App
@@ -74,7 +86,7 @@ Successful orchestrator runs upload:
 - `airo-mobile-tablet-<profile>-<version>` from the mobile/tablet workflow when
   `mobile_profile` is not `none`;
 - `airo-mobile-tablet-coins-<version>` from the mobile/tablet workflow when
-  `coins_profile` is not `none`;
+  `mobile_profile` includes coins;
 - `airo-macos-<profile>-<version>` from the macOS workflow when
   `macos_profile` is not `none`;
 - `v2-release-evidence-<version>` from the orchestrator.


### PR DESCRIPTION
Unblocks the v0.0.6 cut. Every orchestrator dispatch since #1476 dies with `startup_failure`.

## Root cause

#1476 added a `coins_profile` input, taking `release-orchestrator.yml` to **21** `workflow_dispatch` inputs. GitHub caps how many inputs a workflow may declare; 20 was already the ceiling. Past the cap the run is created but no jobs ever are — [run 30846561753](https://github.com/DevelopersCoffee/airo/actions/runs/30846561753) has `startup_failure`, zero jobs, zero annotations, and zero check runs.

Evidence it is the input count and not the job wiring:
- 20 inputs dispatched successfully twice on 2026-08-01 (runs 30693913137, 30682576352) with the same job graph shape.
- The only orchestrator change between those runs and the failure is #1476.
- #1477, which merged in between, does not touch `release-orchestrator.yml`.

## Fix

Delete the extra input; let `mobile_profile` select both Android application legs:

| `mobile_profile` | Full app leg | Airo Coins leg |
| --- | --- | --- |
| `none` | — | — |
| `full` | `io.airo.app` | — |
| `coins` | — | `io.airo.app.coins` |
| `full-and-coins` | `io.airo.app` | `io.airo.app.coins` |

`prepare` splits the selection back into the `mobile_profile` and `coins_profile` **outputs** the jobs already consume, so the `coins-release` job, artifact download, qualification report, required assets, and result gate are all untouched. Input count returns to 20.

`mobile_play_track` still requires a selection that includes `full`, unchanged.

## Verification

`release-contracts` run locally against this branch and passes in full: YAML parse for all release workflows, `py_compile` on the three release scripts, `check-build-profiles.py`, and both generator test scripts. Input count asserted back at 20.

🤖 Generated with [Claude Code](https://claude.com/claude-code)