### PR TITLE
fix(ci): main is red — Mind gates require ripgrep, which ubuntu-latest lacks

### DIFF
--- a/packages/feature_mind/test/rules/r03_route_gate_test.dart
+++ b/packages/feature_mind/test/rules/r03_route_gate_test.dart
@@ -60,40 +60,41 @@ const route = GoRoute(path: 'timeline', name: 'timeline');
     }
   });
 
-  test('the gate refuses to run without ripgrep rather than passing', () {
-    // Both gates find violations with rg inside `|| true`. Without rg that
-    // returns no matches and the gate would report OK having checked nothing —
-    // the exact failure these gates exist to prevent.
+  test('the gate refuses to run when its search finds nothing at all', () {
+    // The gate's job is to find something that should not be there, so a
+    // broken search — missing tool, wrong flags, wrong paths — reports OK
+    // having checked nothing. The positive control must catch that.
     //
-    // A PATH holding only the tools the script needs to reach its own guard,
-    // and provably not rg. Pointing PATH at a nonexistent directory would hide
-    // bash too and the shebang would fail before the guard ran, which proves
-    // nothing; naming real bin directories would still find rg on Linux.
-    final bin = Directory.systemTemp.createTempSync('mind_no_rg');
-    for (final tool in ['bash', 'env', 'dirname', 'pwd']) {
-      final resolved = Process.runSync('which', [
-        tool,
-      ]).stdout.toString().trim();
-      if (resolved.isEmpty) continue;
-      Link('${bin.path}/$tool').createSync(resolved);
-    }
-
+    // Simulated by copying the gate into a tree whose sources exist but do not
+    // contain MindProjectionSwitcher, which is what a broken search looks like
+    // from the gate's point of view. This replaced a `command -v rg` check:
+    // GitHub's ubuntu-latest runner has no ripgrep, both gates exited 127 on
+    // their first real CI run, and the lesson was that asserting a tool exists
+    // is weaker than asserting the search actually finds a known string.
+    final fake = Directory.systemTemp.createTempSync('mind_broken_search');
     try {
-      final result = Process.runSync(
-        gate,
-        const [],
-        environment: {'PATH': bin.path},
-        includeParentEnvironment: false,
-      );
+      Directory('${fake.path}/scripts').createSync();
+      Directory('${fake.path}/packages').createSync();
+      File(
+        '${fake.path}/packages/unrelated.dart',
+      ).writeAsStringSync('class Unrelated {}');
+      final copied = File('${fake.path}/scripts/gate.sh')
+        ..writeAsStringSync(File(gate).readAsStringSync());
+      Process.runSync('chmod', ['+x', copied.path]);
+
+      final result = Process.runSync('bash', [copied.path]);
 
       expect(
         result.exitCode,
         127,
-        reason: 'stdout: ${result.stdout}\nstderr: ${result.stderr}',
+        reason:
+            'The gate reported OK from a tree where its positive control '
+            'cannot match.\nstdout: ${result.stdout}\n'
+            'stderr: ${result.stderr}',
       );
-      expect(result.stderr.toString(), contains('ripgrep'));
+      expect(result.stderr.toString(), contains('cannot verify anything'));
     } finally {
-      bin.deleteSync(recursive: true);
+      fake.deleteSync(recursive: true);
     }
   });
 }

--- a/scripts/check-mind-private-devices.sh
+++ b/scripts/check-mind-private-devices.sh
@@ -11,12 +11,12 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT_DIR"
 
-# Both gates locate violations with ripgrep inside `|| true`, so a missing rg
-# would return no matches and the gate would pass having checked nothing. That
-# is the exact failure this file exists to prevent, so refuse to run instead.
-if ! command -v rg >/dev/null 2>&1; then
-  echo "FATAL: ripgrep (rg) is not installed. This gate cannot verify anything" >&2
-  echo "without it, and passing silently would be worse than failing." >&2
+# Positive control. This gate's whole job is to find something that should not
+# be there, so a broken search reports OK having checked nothing. Prove the
+# search works against a file that must exist before trusting a clean result.
+if ! grep -q 'name: feature_mind' packages/stubs/feature_mind_stub/pubspec.yaml 2>/dev/null; then
+  echo "FATAL: could not read the feature_mind stub's pubspec, so this gate" >&2
+  echo "cannot verify anything. Passing silently would be worse than failing." >&2
   exit 127
 fi
 
@@ -28,14 +28,14 @@ failed=false
 for pubspec in "${shared_pubspecs[@]}"; do
   [[ -f "$pubspec" ]] || continue
 
-  if grep -qE '^\s+feature_mind:' "$pubspec"; then
+  if grep -qE '^[[:space:]]+feature_mind:' "$pubspec"; then
     # A dependency is only acceptable when the same flavor points it at the
     # stub, either inline or through its own overrides file.
     overrides="${pubspec%.yaml}_overrides.yaml"
-    if grep -qE 'feature_mind_stub' "$pubspec"; then
+    if grep -q 'feature_mind_stub' "$pubspec"; then
       continue
     fi
-    if [[ -f "$overrides" ]] && grep -qE 'feature_mind_stub' "$overrides"; then
+    if [[ -f "$overrides" ]] && grep -q 'feature_mind_stub' "$overrides"; then
       continue
     fi
     failed=true
@@ -48,7 +48,7 @@ done
 # sources a web build compiles: nothing under app/web may reach the module.
 if [[ -d "app/web" ]]; then
   web_imports="$(
-    rg -n --glob '*.dart' -e "package:feature_mind/" app/web 2>/dev/null || true
+    grep -rn --include='*.dart' -e "package:feature_mind/" app/web 2>/dev/null || true
   )"
   if [[ -n "$web_imports" ]]; then
     failed=true

--- a/scripts/check-mind-projection-routes.sh
+++ b/scripts/check-mind-projection-routes.sh
@@ -8,14 +8,17 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT_DIR"
 
-# Both gates locate violations with ripgrep inside `|| true`, so a missing rg
-# would return no matches and the gate would pass having checked nothing. That
-# is the exact failure this file exists to prevent, so refuse to run instead.
-if ! command -v rg >/dev/null 2>&1; then
-  echo "FATAL: ripgrep (rg) is not installed. This gate cannot verify anything" >&2
-  echo "without it, and passing silently would be worse than failing." >&2
-  exit 127
-fi
+# Portable POSIX grep, not ripgrep. GitHub's ubuntu-latest runner does not ship
+# rg, and a gate that only runs on a developer laptop is not a gate.
+scan() {
+  grep -rnE \
+    --include='*.dart' \
+    --exclude-dir=test \
+    --exclude-dir=cargokit \
+    --exclude-dir=build \
+    -e "$1" \
+    "${scan_paths[@]}" 2>/dev/null || true
+}
 
 scan_paths=()
 for path in "app/lib" "packages"; do
@@ -23,18 +26,26 @@ for path in "app/lib" "packages"; do
 done
 
 if [[ ${#scan_paths[@]} -eq 0 ]]; then
-  echo "No Dart sources to scan."
-  exit 0
+  echo "No Dart sources to scan." >&2
+  exit 1
+fi
+
+# Positive control. A `|| true` search that silently finds nothing -- missing
+# tool, wrong flags, wrong paths -- would report OK having checked nothing,
+# which is the exact failure this gate exists to prevent. So first prove the
+# search finds a string we know is there.
+if [[ -z "$(scan 'class MindProjectionSwitcher')" ]]; then
+  echo "FATAL: the search found no MindProjectionSwitcher, which must exist." >&2
+  echo "This gate cannot verify anything, and passing silently would be worse" >&2
+  echo "than failing. Check grep availability and the scan paths." >&2
+  exit 127
 fi
 
 violations="$(
-  rg -n \
-    --glob '*.dart' \
-    --glob '!**/test/**' \
-    --glob '!**/cargokit/**' \
-    -e "path:\s*'/?(mind/)?(graph|timeline|search)'" \
-    -e "name:\s*'(mind_)?(graph|timeline|search)'" \
-    "${scan_paths[@]}" || true
+  {
+    scan "path:[[:space:]]*'/?(mind/)?(graph|timeline|search)'"
+    scan "name:[[:space:]]*'(mind_)?(graph|timeline|search)'"
+  } | sort -u
 )"
 
 if [[ -n "$violations" ]]; then


### PR DESCRIPTION
## Urgent: this unbreaks `main`

**`main` currently fails `tests` and `test-core` on every PR.**

#1477 merged at `ddfab90`, which wired the Mind gates into both jobs. The
follow-up commit that removed their ripgrep dependency (`c0282440`) did not
make it into that merge. So `main` now has:

- `.github/workflows/pr-checks.yml` and `ci.yml` invoking
  `Run Airo Mind package tests` and `Check Airo Mind design rules (R03, R05)`
- gate scripts that `exit 127` unless `rg` is installed
- a `ubuntu-latest` runner that does not ship `rg`

Result: three rule tests fail with exit 127, the test step fails, and the gate
step is skipped. Every PR against `main` is affected, not just Mind work.

This PR is `c0282440` cherry-picked onto current `main`, unchanged.

## What it does

- Both gates use portable POSIX `grep -rnE --include --exclude-dir` instead of
  ripgrep. Installing `rg` in CI was the wrong fix: a gate that only runs on a
  developer laptop is not a gate.
- The tool-exists guard is replaced by a **positive control**. `command -v rg`
  only proved a binary was present; it would not have caught wrong flags, wrong
  scan paths, or a search that silently matched nothing — all of which look
  identical to a clean tree. Each gate now first proves its search finds a
  string that must exist (`class MindProjectionSwitcher` for R03, the stub's
  `name: feature_mind` for R05) and refuses to run otherwise.

## Test Plan

- [x] `flutter test` in `packages/feature_mind` — **90 pass** on `main` + this commit
- [x] Both gates pass, and each still fails on every mutant: a route targeting
      one projection, a bare `timeline` route, the TV flavor linking the real
      module, a web source importing it, and a broken search
- [x] `flutter analyze --fatal-infos` clean
- [ ] Manual device verification — not applicable, CI and scripts only

**Verification environment:** Host-only

The proof is this PR's own `tests` job: `Run Airo Mind package tests` and
`Check Airo Mind design rules (R03, R05)` must both be green. On `main` today
the first of those is red.

## Agent Policy

- [x] Linked issue — [#1449](https://github.com/DevelopersCoffee/airo/issues/1449)
- [x] Feature Packet — inherited from #1474
- [x] Cross-agent contract — none
- [x] Deterministic use cases — the five gate mutation tests
- [x] Android Emulator not used

## Council Review

- **Chief Release DevOps Officer** — CI restoration. **Not yet reviewed.**

- [ ] Listed every required role above — **listed, not yet reviewed.** Flagging
      that `main` is red now, so this may warrant landing ahead of review.
- [x] No package manifests touched.

## User-Facing Documentation

- [x] No `docs/wiki` change needed — CI and scripts only.

## Plugin and Size Impact

- [ ] New dependencies — no; this removes an implicit one (`rg`)
- [x] Size impact: none

## Checklist

- [x] Code is formatted.
- [x] Tests included above.
- [x] No sensitive data committed.

## Release Notes

- [x] Not user-facing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)