### PR TITLE
fix(release): grant the orchestrator legs their attestation permissions

### DIFF
--- a/.github/workflows/release-orchestrator.yml
+++ b/.github/workflows/release-orchestrator.yml
@@ -402,6 +402,9 @@ jobs:
     needs: [prepare, release-contracts]
     permissions:
       contents: read
+      id-token: write
+      attestations: write
+      artifact-metadata: write
     uses: ./.github/workflows/airo-mobile-tablet-release.yml
     with:
       profile: ${{ needs.prepare.outputs.mobile_profile }}
@@ -422,6 +425,9 @@ jobs:
     needs: [prepare, release-contracts]
     permissions:
       contents: read
+      id-token: write
+      attestations: write
+      artifact-metadata: write
     uses: ./.github/workflows/airo-mobile-tablet-release.yml
     with:
       profile: ${{ needs.prepare.outputs.coins_profile }}
@@ -457,6 +463,9 @@ jobs:
     permissions:
       actions: read
       contents: write
+      id-token: write
+      attestations: write
+      artifact-metadata: write
     uses: ./.github/workflows/airo-tv-release.yml
     with:
       version: ${{ needs.prepare.outputs.version }}


### PR DESCRIPTION
Unblocks the v0.0.6 cut. Every `release-orchestrator.yml` dispatch fails with `startup_failure` — no jobs, no annotations, no error text.

## Root cause

#1391 gave the TV and mobile/tablet **build** jobs release provenance attestations, so they now declare:

```yaml
    permissions:
      contents: read
      id-token: write
      attestations: write
      artifact-metadata: write
```

A called workflow may not request permissions its caller does not grant. The orchestrator's caller jobs granted only `contents: read` (mobile/coins) and `actions: read` + `contents: write` (TV). GitHub rejects the entire call graph at run-creation time, before any job exists — hence a `startup_failure` with nothing to read.

The break has been latent since #1391: the orchestrator had not been dispatched since 2026-08-01, and standalone dispatches of the two reusable workflows keep working because nothing caps their permissions there.

## How it was isolated

Failures cost no build minutes, so this was bisected by dispatch:

| Probe | Result |
| --- | --- |
| `airo-tv-release.yml` standalone | **starts** — callee is valid |
| `airo-macos-release.yml` standalone | **starts** — callee is valid |
| Orchestrator, `prepare` + `release-contracts` only | **starts** |
| Orchestrator, all legs, no `release-summary` | `startup_failure` |
| Orchestrator, TV leg only | `startup_failure` — narrowed to the call wiring |
| Orchestrator + these permissions, all four legs | **starts** |

Call contracts were also verified mechanically — no passed-but-undeclared or required-but-missing inputs on any of the four calls — which ruled out the input surface.

## Fix

Grant `id-token: write`, `attestations: write`, `artifact-metadata: write` on the `tv-release`, `mobile-tablet-release`, and `coins-release` caller jobs. `airo-macos-release.yml` declares no job-level permissions, so the macOS leg needs nothing.

Note for future edits: the same latency applies to any new permission a reusable release workflow starts requesting. It will pass its own standalone dispatch and break only the orchestrator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)