### PR TITLE
docs(wiki): fix the download links that have never resolved

### DIFF
--- a/docs/wiki/2.-Getting-Started.md
+++ b/docs/wiki/2.-Getting-Started.md
@@ -2,11 +2,23 @@
 
 ## Download Airo
 
-Use the latest GitHub release:
+Current release: **[v0.0.6](https://github.com/DevelopersCoffee/airo/releases/tag/v0.0.6)**,
+one release carrying every product line.
 
-- [Download latest Android APK](https://github.com/DevelopersCoffee/airo/releases/latest/download/app-release.apk)
-- [Download latest iOS IPA](https://github.com/DevelopersCoffee/airo/releases/latest/download/app-release.ipa)
-- [Download latest web build](https://github.com/DevelopersCoffee/airo/releases/latest/download/airo-web-release.zip)
+| Product | Package | Download |
+|---|---|---|
+| Airo TV (Android TV / Fire TV) | `io.airo.app.tv` | [Airo-TV-0.0.6.apk](https://github.com/DevelopersCoffee/airo/releases/download/v0.0.6/Airo-TV-0.0.6.apk) |
+| Airo (phone / tablet) | `io.airo.app` | [Airo-0.0.6-10-arm64.apk](https://github.com/DevelopersCoffee/airo/releases/download/v0.0.6/Airo-0.0.6-10-arm64.apk) |
+| Airo Coins | `io.airo.app.coins` | [AiroCoins-0.0.6-10-arm64.apk](https://github.com/DevelopersCoffee/airo/releases/download/v0.0.6/AiroCoins-0.0.6-10-arm64.apk) |
+| Airo TV for macOS | — | [DMG](https://github.com/DevelopersCoffee/airo/releases/download/v0.0.6/Airo-TV-0.0.6-macOS.dmg) · [ZIP](https://github.com/DevelopersCoffee/airo/releases/download/v0.0.6/Airo-TV-0.0.6-macOS.zip) |
+
+Airo TV also publishes per-ABI APKs (`arm64-v8a`, `armeabi-v7a`, `x86_64`) for
+devices that need a specific architecture — most people want the universal
+`Airo-TV-0.0.6.apk` above.
+
+There is no iOS or web download. iOS/iPadOS is deferred pending an Apple
+developer account, and web is CI validation only.
+
 - [View all releases](https://github.com/DevelopersCoffee/airo/releases)
 
 ## Android Installation

--- a/docs/wiki/3.-Navigating-Airo.md
+++ b/docs/wiki/3.-Navigating-Airo.md
@@ -103,7 +103,7 @@ streams on web, Android, and iOS; four on macOS, Windows, and Linux; and one on
 Fuchsia. The absolute limit is four, and the channel action reports when the
 current device limit has been reached.
 
-**Under qualification (not in the current Airo TV 0.0.5 release):** the Share
+**Under qualification (not in the current Airo TV 0.0.6 release):** the Share
 action is designed to copy a versioned Airo TV link instead of the playlist's
 raw stream URL. If Explorer filters are active, the link includes that filter
 combination; opening it restores the filters and tunes the channel through the


### PR DESCRIPTION
Follow-up to #1503, which merged before this commit landed on the branch.

## Problem

The wiki's Getting Started page pointed at three artifacts that return **404**:

| Link | Status |
| --- | --- |
| `releases/latest/download/app-release.apk` | 404 — Android artifacts are named per product line (`Airo-TV-*`, `Airo-*`, `AiroCoins-*`), never `app-release.apk` |
| `releases/latest/download/app-release.ipa` | 404 — no Apple developer account, no iOS release has ever been published |
| `releases/latest/download/airo-web-release.zip` | 404 — web is CI validation only |

This is the same defect #1503 fixed in the README. The `pr-validation` docs-completeness gate on that PR was correct to demand a matching wiki update — the wiki really was carrying the same broken links.

## Change

- Getting Started now shows the v0.0.6 per-product download table: Airo TV, Airo phone/tablet, Airo Coins, macOS DMG/ZIP.
- Notes that per-ABI TV APKs exist for devices that need a specific architecture, while pointing most people at the universal APK.
- States plainly that there is no iOS or web download, and why.
- Corrects a stale "Airo TV 0.0.5 release" qualification note in the navigation page.

## Verification

Every release link on the page fetched — all six return 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)