### PR TITLE
fix(release): resolve profile, package and ABI per artifact

### DIFF
--- a/scripts/generate-release-manifest.py
+++ b/scripts/generate-release-manifest.py
@@ -53,14 +53,29 @@ def resolve_under_root(path: Path, description: str) -> Path:
 
 
 def infer_profile_id(filename: str, profiles: dict[str, dict]) -> str | None:
+    """Resolve the build profile that produced an artifact, from its filename.
+
+    Artifact names share a prefix -- `Airo-TV-*`, `AiroCoins-*`, `Airo-*` -- so
+    matching must be longest-prefix-first. A plain substring scan in profile
+    order resolves every one of them to `full`, because "airo" is a prefix of
+    the others. That was harmless while each release wave published a single
+    profile, and wrong the moment the orchestrator started publishing TV, full,
+    and Coins into one directory.
+    """
     normalized = filename.lower().replace("_", "-")
     aliases = {
         "tv": ["airo-tv"],
-        "full": ["airo", "airo-full", "full"],
+        "coins": ["airocoins", "airo-coins"],
+        "full": ["airo"],
     }
+    candidates: list[tuple[str, str]] = []
     for profile_id in profiles:
-        candidates = aliases.get(profile_id, [profile_id])
-        if any(candidate in normalized for candidate in candidates):
+        for alias in aliases.get(profile_id, [profile_id]):
+            candidates.append((alias, profile_id))
+
+    # Longest alias wins, so `airo-tv-0.0.6.apk` cannot resolve to `full`.
+    for alias, profile_id in sorted(candidates, key=lambda item: -len(item[0])):
+        if normalized.startswith(alias):
             return profile_id
     return None
 
@@ -93,8 +108,17 @@ def infer_abi(path: Path, profile: dict) -> str:
         if "x64" in filename or "x86_64" in filename:
             return "macos-x64"
         return "macos-universal"
-    if "arm64" in filename or "arm64-v8a" in filename:
-        return "android-arm64"
+    # Explicit ABI in the filename always wins over the profile's default
+    # strategy. Checked longest-token-first so `x86_64` is not read as `x86`.
+    for token, abi in (
+        ("armeabi-v7a", "android-armeabi-v7a"),
+        ("arm64-v8a", "android-arm64"),
+        ("x86_64", "android-x86_64"),
+        ("arm64", "android-arm64"),
+        ("x86", "android-x86"),
+    ):
+        if token in filename:
+            return abi
     android = profile.get("android") or {}
     if android.get("abiStrategy") == "single-arm64-apk":
         return "android-arm64"

--- a/scripts/test-generate-release-manifest.sh
+++ b/scripts/test-generate-release-manifest.sh
@@ -99,6 +99,69 @@ assert artifact["macos"]["signingStatus"] == "signed"
 assert artifact["macos"]["notarizationStatus"] == "notarized"
 PY
 
+# The orchestrator's aggregate step runs without --profile-id over a directory
+# holding every profile at once, so profile, package, and ABI must be resolved
+# per artifact. Every other test here passes --profile-id and therefore never
+# exercises inference at all.
+mkdir -p "$TMP_DIR/mixed"
+for f in \
+  "Airo-TV-0.0.6.apk" \
+  "Airo-TV-0.0.6-arm64-v8a.apk" \
+  "Airo-TV-0.0.6-armeabi-v7a.apk" \
+  "Airo-TV-0.0.6-x86_64.apk" \
+  "Airo-TV-0.0.6-Play-Store.aab" \
+  "Airo-0.0.6-10-arm64.apk" \
+  "Airo-0.0.6-10-Play-Store.aab" \
+  "AiroCoins-0.0.6-10-arm64.apk" \
+  "AiroCoins-0.0.6-10-Play-Store.aab" \
+  "Airo-TV-0.0.6-macOS.dmg" ; do
+  printf 'content-%s' "$f" > "$TMP_DIR/mixed/$f"
+done
+
+python3 "$SCRIPT" \
+  --artifacts-dir "$TMP_DIR/mixed" \
+  --version 0.0.6 \
+  --build-number 10 \
+  > "$TMP_DIR/mixed.out"
+
+python3 - "$TMP_DIR/mixed/Release-Manifest.json" <<'PY'
+import json
+import sys
+
+manifest = json.load(open(sys.argv[1], encoding="utf-8"))
+byname = {a["filename"]: a for a in manifest["artifacts"]}
+
+expected_profile = {
+    "Airo-TV-0.0.6.apk": ("tv", "io.airo.app.tv"),
+    "Airo-TV-0.0.6-arm64-v8a.apk": ("tv", "io.airo.app.tv"),
+    "Airo-TV-0.0.6-armeabi-v7a.apk": ("tv", "io.airo.app.tv"),
+    "Airo-TV-0.0.6-x86_64.apk": ("tv", "io.airo.app.tv"),
+    "Airo-TV-0.0.6-Play-Store.aab": ("tv", "io.airo.app.tv"),
+    "Airo-0.0.6-10-arm64.apk": ("full", "io.airo.app"),
+    "Airo-0.0.6-10-Play-Store.aab": ("full", "io.airo.app"),
+    "AiroCoins-0.0.6-10-arm64.apk": ("coins", "io.airo.app.coins"),
+    "AiroCoins-0.0.6-10-Play-Store.aab": ("coins", "io.airo.app.coins"),
+}
+for name, (profile_id, package_id) in expected_profile.items():
+    got = byname[name]
+    assert got["profileId"] == profile_id, (name, got["profileId"], profile_id)
+    assert got["packageId"] == package_id, (name, got["packageId"], package_id)
+
+expected_abi = {
+    "Airo-TV-0.0.6-arm64-v8a.apk": "android-arm64",
+    "Airo-TV-0.0.6-armeabi-v7a.apk": "android-armeabi-v7a",
+    "Airo-TV-0.0.6-x86_64.apk": "android-x86_64",
+    "Airo-0.0.6-10-arm64.apk": "android-arm64",
+    "AiroCoins-0.0.6-10-arm64.apk": "android-arm64",
+}
+for name, abi in expected_abi.items():
+    assert byname[name]["abi"] == abi, (name, byname[name]["abi"], abi)
+
+macos = byname["Airo-TV-0.0.6-macOS.dmg"]
+assert macos["profileId"] == "tv", macos["profileId"]
+assert macos["packageId"] == "com.developerscoffee.airo.tv", macos["packageId"]
+PY
+
 mkdir -p "$TMP_DIR/empty"
 if python3 "$SCRIPT" \
   --artifacts-dir "$TMP_DIR/empty" \


### PR DESCRIPTION
Fixes #1504.

## The defect

`Airo-0.0.6-Release-Manifest.json`, published on the v0.0.6 release, describes most of its artifacts incorrectly:

```json
{ "filename": "Airo-TV-0.0.6-arm64-v8a.apk",   "packageId": "io.airo.app", "profileId": "full", "abi": "android-arm64" }
{ "filename": "AiroCoins-0.0.6-10-arm64.apk",  "packageId": "io.airo.app", "profileId": "full", "abi": "android-arm64" }
{ "filename": "Airo-TV-0.0.6-armeabi-v7a.apk", "packageId": "io.airo.app", "profileId": "full", "abi": "android-arm64" }
```

TV is `io.airo.app.tv`, Coins is `io.airo.app.coins`, and `armeabi-v7a` is not arm64.

Checksums are correct, so `SHA256SUMS` verification is unaffected and the release is not compromised. The damage is to anything that reads identity out of the manifest — a store submission, an APKPure mirror, an automated installer, a security review.

## Two independent causes

**1. Profile inference resolved everything to `full`.** `infer_profile_id()` substring-scanned profiles in declaration order with the alias set `full: ["airo", ...]`. Since `"airo"` is a prefix of both `"airo-tv"` and `"airocoins"`, `full` matched first for every artifact. `coins` had no alias at all. Now matches longest-alias-first against the filename prefix.

**2. ABI inference never looked for anything but arm64.** `infer_abi()` checked `"arm64"`, then fell back to the profile's `abiStrategy` — and both `tv` and `full` declare `single-arm64-apk`, so every split APK came out arm64 regardless. Now reads the explicit ABI token from the filename first, longest token first so `x86_64` is not truncated to `x86`.

Neither was reachable before the aggregate release: while each wave published one profile at a time, the single-identity assumption held. #1476 added the Coins leg and made `github-release-assets/` mixed.

## Why the tests missed it

Every existing case passes `--profile-id`, which bypasses inference completely. The orchestrator's aggregate step passes no profile — the one path that matters was the one path untested.

Added a mixed-profile case that runs exactly as the orchestrator does: ten artifacts across tv, full, coins, and macOS in one directory, no `--profile-id`, asserting profile, package ID, and ABI per file.

**Verified the test catches the bug** — against the unfixed generator it fails with `AssertionError: ('Airo-TV-0.0.6.apk', 'full', 'tv')`.

## Still to do

v0.0.6's published `Airo-0.0.6-Release-Manifest.json` remains wrong. Regenerating and re-uploading it modifies a published release asset, so I have not done it — say the word and I will.

🤖 Generated with [Claude Code](https://claude.com/claude-code)