### PR TITLE
feat(docs): shared landing-page template for search-intent pages

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -3,7 +3,7 @@
 # Site settings
 title: Airo Super App
 description: On-device AI platform for PDF/image/audio processing
-url: https://developerscoffee.github.io/airo
+url: https://developerscoffee.github.io
 baseurl: /airo
 
 # Theme

--- a/docs/_data/release.yml
+++ b/docs/_data/release.yml
@@ -1,0 +1,32 @@
+# Single source of truth for the current public release.
+#
+# Every download link and version string on the public site should render
+# from this file through _includes/download-block.html rather than being
+# hardcoded per page. The site has gone stale at the previous release three
+# separate times (README, wiki, and this page itself) because the tag and
+# artifact names were hand-typed in more than one place. Update this file on
+# every release; nothing else should need to change.
+tag: v0.0.6
+version: "0.0.6"
+build_number: "10"
+release_url: https://github.com/DevelopersCoffee/airo/releases/tag/v0.0.6
+products:
+  tv:
+    label: Airo TV
+    package_id: io.airo.app.tv
+    universal_apk: Airo-TV-0.0.6.apk
+    arm64_apk: Airo-TV-0.0.6-arm64-v8a.apk
+    armeabi_apk: Airo-TV-0.0.6-armeabi-v7a.apk
+    x86_64_apk: Airo-TV-0.0.6-x86_64.apk
+  full:
+    label: Airo
+    package_id: io.airo.app
+    arm64_apk: Airo-0.0.6-10-arm64.apk
+  coins:
+    label: Airo Coins
+    package_id: io.airo.app.coins
+    arm64_apk: AiroCoins-0.0.6-10-arm64.apk
+  macos:
+    label: Airo TV for macOS
+    dmg: Airo-TV-0.0.6-macOS.dmg
+    zip: Airo-TV-0.0.6-macOS.zip

--- a/docs/_includes/boundary-block.html
+++ b/docs/_includes/boundary-block.html
@@ -1,0 +1,12 @@
+<!--
+  The content boundary. Every page targeting an IPTV search term must state
+  this plainly and near the top -- these terms attract piracy-adjacent
+  traffic and the page must not read as a route to it. Single-sourced so the
+  wording cannot drift per page.
+-->
+<p class="boundary-note">
+  <i data-lucide="shield-check" aria-hidden="true"></i>
+  Airo TV ships no channels, playlists, subscriptions, or media catalog. It
+  plays M3U/M3U8 and XMLTV sources you already have and are authorized to
+  use.
+</p>

--- a/docs/_includes/download-block.html
+++ b/docs/_includes/download-block.html
@@ -1,0 +1,75 @@
+<!--
+  Single-source download block. Renders from _data/release.yml so every page
+  stays current from one edit. The site went stale at the previous release
+  three separate times (README, wiki, this page) because the tag and
+  artifact names were hand-typed in more than one place -- this include
+  exists specifically so a fourth place cannot happen.
+-->
+{% assign r = site.data.release %}
+<section class="band band-alt" id="download" aria-labelledby="download-title">
+  <div class="container">
+    <div class="section-intro">
+      <div>
+        <p class="eyebrow">Download</p>
+        <h2 id="download-title">Current release: {{ r.version }}</h2>
+      </div>
+      <p>
+        One release carries every product line, signed with the stable
+        dogfood keystore.
+        <a href="{{ r.release_url }}">Full release notes and checksums
+        <i data-lucide="arrow-up-right" aria-hidden="true"></i></a>
+      </p>
+    </div>
+    <div class="device-list">
+      <article class="device-row">
+        <h3>{{ r.products.tv.label }} — Android TV / Fire TV</h3>
+        <p>
+          <code>{{ r.products.tv.package_id }}</code>. Universal APK covers
+          most devices; per-ABI builds exist for devices that need one.
+        </p>
+        <div class="hero-actions">
+          <a class="button button-primary" href="{{ r.release_url | replace: '/tag/', '/download/' }}/{{ r.products.tv.universal_apk }}"
+            ><i data-lucide="download" aria-hidden="true"></i> Download Airo TV</a
+          >
+        </div>
+      </article>
+      <article class="device-row">
+        <h3>{{ r.products.full.label }} — phone / tablet</h3>
+        <p><code>{{ r.products.full.package_id }}</code>. arm64 only.</p>
+        <div class="hero-actions">
+          <a class="button button-secondary" href="{{ r.release_url | replace: '/tag/', '/download/' }}/{{ r.products.full.arm64_apk }}"
+            ><i data-lucide="download" aria-hidden="true"></i> Download Airo</a
+          >
+        </div>
+      </article>
+      <article class="device-row">
+        <h3>{{ r.products.coins.label }}</h3>
+        <p><code>{{ r.products.coins.package_id }}</code>. Preview; arm64 only.</p>
+        <div class="hero-actions">
+          <a class="button button-secondary" href="{{ r.release_url | replace: '/tag/', '/download/' }}/{{ r.products.coins.arm64_apk }}"
+            ><i data-lucide="download" aria-hidden="true"></i> Download Airo Coins</a
+          >
+        </div>
+      </article>
+      <article class="device-row">
+        <h3>{{ r.products.macos.label }}</h3>
+        <p>Unsigned and not notarized; Gatekeeper needs an explicit override.</p>
+        <div class="hero-actions">
+          <a class="button button-secondary" href="{{ r.release_url | replace: '/tag/', '/download/' }}/{{ r.products.macos.dmg }}"
+            >DMG</a
+          ><a class="button button-secondary" href="{{ r.release_url | replace: '/tag/', '/download/' }}/{{ r.products.macos.zip }}"
+            >ZIP</a
+          >
+        </div>
+      </article>
+    </div>
+    <p class="download-note">
+      Not published: iOS/iPadOS (no Apple developer account) and web (CI
+      validation only). Android builds carry the dogfood keystore and will
+      not upgrade over a future production-signed release. Verify any
+      direct-download APK against
+      <a href="https://github.com/DevelopersCoffee/airo/blob/main/VERIFY_DOWNLOAD.md">SHA256SUMS</a>
+      before installing.
+    </p>
+  </div>
+</section>

--- a/docs/_includes/site-footer.html
+++ b/docs/_includes/site-footer.html
@@ -1,0 +1,37 @@
+<footer class="site-footer">
+  <div class="container">
+    <div class="footer-grid">
+      <div>
+        <a class="brand" href="{{ '/' | relative_url }}"
+          ><img src="{{ '/assets/airo-tv/airo-icon.svg' | relative_url }}" alt="" /><span
+            >Airo</span
+          ></a
+        >
+        <h2>Your sources. Your screen.</h2>
+        <p>Airo TV is the first focused product born from Airo.</p>
+      </div>
+      <div class="footer-col">
+        <h3>Product</h3>
+        <a href="{{ '/tv/' | relative_url }}">Airo TV</a
+        ><a href="{{ '/tv/#devices' | relative_url }}">Devices</a
+        ><a href="{{ '/tv/#pro-vision' | relative_url }}">Airo TV Pro</a>
+      </div>
+      <div class="footer-col">
+        <h3>Support</h3>
+        <a href="{{ '/tv/guides/' | relative_url }}">Guides</a
+        ><a href="https://github.com/DevelopersCoffee/airo/issues?q=state%3Aopen%20label%3Acommunity-voice">Community Voice</a
+        ><a href="{{ '/tv/#roadmap' | relative_url }}">Roadmap</a>
+      </div>
+      <div class="footer-col">
+        <h3>Airo</h3>
+        <a href="{{ '/' | relative_url }}">Platform</a
+        ><a href="{{ '/legal/privacy-policy/' | relative_url }}">Privacy</a
+        ><a href="https://github.com/DevelopersCoffee/airo">Source repository</a>
+      </div>
+    </div>
+    <div class="footer-bottom">
+      <span>&copy; <span data-current-year>2026</span> DevelopersCoffee</span
+      ><span>Airo TV includes no channels. Use authorized sources only.</span>
+    </div>
+  </div>
+</footer>

--- a/docs/_includes/site-head.html
+++ b/docs/_includes/site-head.html
@@ -1,0 +1,49 @@
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>{{ page.title }}</title>
+<meta name="title" content="{{ page.title }}" />
+<meta name="description" content="{{ page.description }}" />
+<meta name="robots" content="index, follow" />
+<meta name="google-site-verification" content="WusRxM2aVnZImHcic5ehEu-ticQ4L645xgLhu13kmro" />
+<link rel="canonical" href="{{ page.url | absolute_url }}" />
+<meta name="theme-color" content="#071010" />
+<meta property="og:type" content="website" />
+<meta property="og:url" content="{{ page.url | absolute_url }}" />
+<meta property="og:title" content="{{ page.title }}" />
+<meta property="og:description" content="{{ page.description }}" />
+<meta
+  property="og:image"
+  content="{{ '/store-assets/airo-tv/feature-graphic-1024x500.png' | absolute_url }}"
+/>
+<meta name="twitter:card" content="summary_large_image" />
+<meta name="twitter:title" content="{{ page.title }}" />
+<meta name="twitter:description" content="{{ page.description }}" />
+<link rel="icon" type="image/svg+xml" href="{{ '/assets/airo-tv/airo-icon.svg' | relative_url }}" />
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link
+  href="https://fonts.googleapis.com/css2?family=DM+Sans:opsz,wght@9..40,400;9..40,500;9..40,600;9..40,700;9..40,800&display=swap"
+  rel="stylesheet"
+  media="print"
+  onload="this.media='all'"
+/>
+<noscript>
+  <link
+    href="https://fonts.googleapis.com/css2?family=DM+Sans:opsz,wght@9..40,400;9..40,500;9..40,600;9..40,700;9..40,800&display=swap"
+    rel="stylesheet"
+  />
+</noscript>
+<link
+  rel="preload"
+  href="{{ '/assets/airo-tv/site.css' | relative_url }}"
+  as="style"
+  onload="this.onload=null;this.rel='stylesheet'"
+/>
+<noscript><link rel="stylesheet" href="{{ '/assets/airo-tv/site.css' | relative_url }}" /></noscript>
+<script defer src="{{ '/assets/airo-tv/third-party/lucide.min.js' | relative_url }}"></script>
+<script defer src="{{ '/assets/airo-tv/site.js' | relative_url }}"></script>
+{% if page.structured_data %}
+<script type="application/ld+json">
+  {{ page.structured_data | jsonify }}
+</script>
+{% endif %}

--- a/docs/_includes/site-header.html
+++ b/docs/_includes/site-header.html
@@ -1,0 +1,27 @@
+<header class="site-header">
+  <div class="container nav-shell">
+    <a class="brand" href="{{ '/' | relative_url }}" aria-label="Airo platform home"
+      ><img src="{{ '/assets/airo-tv/airo-icon.svg' | relative_url }}" alt="" /><span
+        >Airo</span
+      ></a
+    ><button
+      class="menu-button"
+      type="button"
+      aria-label="Open navigation"
+      aria-controls="site-navigation"
+      aria-expanded="false"
+      data-menu-button
+    >
+      <i data-lucide="menu" aria-hidden="true"></i>
+    </button>
+    <nav id="site-navigation" class="site-nav" data-site-nav>
+      <a href="{{ '/tv/' | relative_url }}">Airo TV</a
+      ><a href="{{ '/tv/guides/' | relative_url }}">Guides</a
+      ><a
+        class="button button-primary"
+        href="#download"
+        ><i data-lucide="download" aria-hidden="true"></i> Download</a
+      >
+    </nav>
+  </div>
+</header>

--- a/docs/_layouts/landing.html
+++ b/docs/_layouts/landing.html
@@ -1,0 +1,113 @@
+---
+layout: null
+---
+<!--
+  Shared template for search-intent landing pages (#1485). A new page is
+  front matter plus body content -- it does not touch CSS, JS, the header,
+  the footer, or the download links. See docs/iptv-player/index.md for a
+  worked example and docs/_data/release.yml for the single-sourced release
+  data this layout renders.
+-->
+<!doctype html>
+<html lang="en">
+  <head>
+    {% include site-head.html %}
+  </head>
+  <body>
+    <a class="skip-link" href="#main-content">Skip to content</a>
+    {% include site-header.html %}
+
+    <main id="main-content">
+      <section class="intent-hero" id="top">
+        <div class="container">
+          {% if page.eyebrow %}<p class="eyebrow">{{ page.eyebrow }}</p>{% endif %}
+          <h1>{{ page.hero_title | default: page.title }}</h1>
+          {% if page.lede %}<p class="hero-lede">{{ page.lede }}</p>{% endif %}
+          {% include boundary-block.html %}
+          <div class="hero-actions" style="margin-top: 24px;">
+            <a class="button button-primary" href="#download"
+              ><i data-lucide="download" aria-hidden="true"></i>
+              {{ page.primary_cta | default: "Download Airo TV" }}</a
+            >
+          </div>
+        </div>
+      </section>
+
+      <section class="band" id="answer">
+        <div class="container intent-body">
+          {{ content }}
+        </div>
+      </section>
+
+      {% if page.capabilities %}
+      <section class="band band-alt" id="capability-matrix" aria-labelledby="capability-title">
+        <div class="container">
+          <div class="section-intro">
+            <div>
+              <p class="eyebrow">What Airo TV does here</p>
+              <h2 id="capability-title">{{ page.capabilities_title | default: "Available today" }}</h2>
+            </div>
+          </div>
+          <div class="capability-grid">
+            {% for item in page.capabilities %}
+            <article class="capability-item">
+              <span class="status status-{{ item.status | default: 'available' }}">{{ item.status_label | default: "Available" }}</span>
+              <h3>{{ item.title }}</h3>
+              <p>{{ item.text }}</p>
+            </article>
+            {% endfor %}
+          </div>
+        </div>
+      </section>
+      {% endif %}
+
+      {% if page.related %}
+      <section class="band" id="related" aria-labelledby="related-title">
+        <div class="container">
+          <div class="section-intro">
+            <div>
+              <p class="eyebrow">Related</p>
+              <h2 id="related-title">{{ page.related_title | default: "Go deeper" }}</h2>
+            </div>
+          </div>
+          <div class="guide-list">
+            {% for item in page.related %}
+            <a class="guide-item" href="{{ item.url | relative_url }}"
+              ><i data-lucide="{{ item.icon | default: 'arrow-right' }}" aria-hidden="true"></i>
+              <h3>{{ item.title }}</h3>
+              <p>{{ item.text }}</p>
+              <i data-lucide="arrow-right" aria-hidden="true"></i
+            ></a>
+            {% endfor %}
+          </div>
+        </div>
+      </section>
+      {% endif %}
+
+      {% if page.faq %}
+      <section class="band band-alt" id="faq" aria-labelledby="faq-title">
+        <div class="container">
+          <div class="section-intro">
+            <div>
+              <p class="eyebrow">Questions</p>
+              <h2 id="faq-title">Frequently asked</h2>
+            </div>
+          </div>
+          <div class="faq-list">
+            {% for item in page.faq %}
+            <details class="faq-item">
+              <summary>{{ item.q }}</summary>
+              <p>{{ item.a }}</p>
+            </details>
+            {% endfor %}
+          </div>
+        </div>
+      </section>
+      {% endif %}
+
+      {% include download-block.html %}
+    </main>
+
+    {% include site-footer.html %}
+  </body>
+</html>

--- a/docs/assets/airo-tv/site.css
+++ b/docs/assets/airo-tv/site.css
@@ -2411,3 +2411,128 @@ button,
     align-items: flex-start;
   }
 }
+
+/* Search-intent landing pages (docs/_layouts/landing.html) */
+
+.intent-hero {
+  position: relative;
+  padding: calc(var(--header) + 72px) 0 64px;
+  border-bottom: 1px solid var(--border);
+  background:
+    radial-gradient(circle at 14% 22%, color-mix(in oklch, var(--gold), transparent 88%), transparent 42%),
+    var(--bg);
+}
+
+.intent-hero .container {
+  max-width: 840px;
+}
+
+.intent-hero h1 {
+  max-width: 16ch;
+  margin: 14px 0 18px;
+  font-size: clamp(38px, 6vw, 64px);
+  line-height: 1.02;
+  letter-spacing: -0.03em;
+}
+
+.intent-hero .hero-lede {
+  max-width: 62ch;
+}
+
+.boundary-note {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  max-width: 62ch;
+  margin: 20px 0 0;
+  padding: 12px 14px;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  background: var(--surface);
+  color: var(--muted);
+  font-size: 14px;
+  line-height: 1.5;
+}
+
+.boundary-note i {
+  flex: none;
+  margin-top: 2px;
+  color: var(--gold);
+}
+
+.download-note {
+  max-width: 76ch;
+  margin-top: 24px;
+  color: var(--muted);
+  font-size: 13px;
+  line-height: 1.6;
+}
+
+.faq-list {
+  display: grid;
+  gap: 12px;
+}
+
+.faq-item {
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  background: var(--surface);
+}
+
+.faq-item summary {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  min-height: 44px;
+  padding: 16px 20px;
+  font-weight: 700;
+  cursor: pointer;
+  list-style: none;
+}
+
+.faq-item summary::-webkit-details-marker {
+  display: none;
+}
+
+.faq-item summary::after {
+  content: "+";
+  flex: none;
+  color: var(--quiet);
+  font-size: 20px;
+}
+
+.faq-item[open] summary::after {
+  content: "\2212";
+}
+
+.faq-item p {
+  margin: 0;
+  padding: 0 20px 18px;
+  color: var(--muted);
+  line-height: 1.6;
+}
+
+.related-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.intent-body {
+  max-width: 720px;
+}
+
+.intent-body p + p {
+  margin-top: 1.1em;
+}
+
+.intent-body a {
+  color: var(--green);
+}
+
+@media (max-width: 780px) {
+  .intent-hero {
+    padding: calc(var(--header) + 48px) 0 48px;
+  }
+}

--- a/docs/iptv-player/index.md
+++ b/docs/iptv-player/index.md
@@ -1,0 +1,75 @@
+---
+layout: landing
+permalink: /iptv-player/
+title: "IPTV Player — Open Source, Bring Your Own Playlist | Airo TV"
+description: "Airo TV is an open-source IPTV player for Android TV and Fire TV. Load your own M3U/M3U8 playlist and XMLTV guide. No bundled channels, no subscription."
+eyebrow: "Open-source IPTV player"
+hero_title: "An IPTV player that ships with no channels."
+lede: "Airo TV plays the M3U/M3U8 playlist and XMLTV guide you already have. Nothing is bundled, nothing is sold, and the source is public."
+primary_cta: "Download Airo TV"
+capabilities_title: "What Airo TV does as an IPTV player"
+capabilities:
+  - title: Playlist playback
+    text: User-supplied M3U playlists and M3U8 streams, subject to source and device codec support.
+    status: available
+    status_label: Available
+  - title: Channel search
+    text: Search loaded channels by name.
+    status: available
+    status_label: Available
+  - title: Favorites
+    text: Mark channels as favorites locally from browse and player flows.
+    status: available
+    status_label: Available
+  - title: XMLTV guide
+    text: Add an authorized XMLTV source for programme data and bounded, clearer playback-recovery states.
+    status: available
+    status_label: Available
+  - title: Smart playlists
+    text: Local rules and canonical channel matching help preserve a personal view across source refreshes.
+    status: available
+    status_label: Available
+  - title: Recording and cloud playlists
+    text: Airo TV does not record and does not run cloud playlist storage.
+    status: planned
+    status_label: Not supported
+related_title: "Set it up"
+related:
+  - title: Set up Android TV or Google TV
+    text: Install, add an authorized source, browse, search, and play.
+    url: /tv/guides/#android-tv
+    icon: tv
+  - title: Install on Fire TV
+    text: Use the compatible APK safely and understand experimental status.
+    url: /tv/guides/#fire-tv
+    icon: flame
+  - title: See the full Airo TV product page
+    text: Devices, capability matrix, and the public roadmap.
+    url: /tv/
+    icon: arrow-right
+faq:
+  - q: "Does Airo TV come with channels or a free trial subscription?"
+    a: "No. Airo TV includes no channels, playlists, subscriptions, or media catalog. You bring an M3U/M3U8 playlist and, optionally, an XMLTV guide from a source you are already authorized to use."
+  - q: "Is Airo TV free and open source?"
+    a: "Yes. Airo TV is published under an open-source licence, and the full source is on GitHub."
+  - q: "What devices does Airo TV support?"
+    a: "Android TV and Google TV are the primary supported platforms. Fire TV, phone/tablet, and macOS are available with documented limitations — see the device support table on the Airo TV product page."
+  - q: "Where do I get an M3U playlist or XMLTV guide to use with Airo TV?"
+    a: "Airo TV does not provide one. Use a playlist or guide URL from a source you already have the rights to access."
+---
+
+Most IPTV apps bundle a channel catalog, a subscription, or both. Airo TV
+does neither — it is a player, not a service. You supply an
+[M3U or M3U8 playlist](/tv/guides/#playlist) and, if you have one, an
+[XMLTV guide](/tv/#capability-matrix), and Airo TV turns that into a
+TV-first channel grid with search and favorites.
+
+That also means Airo TV can't tell you what to watch, because it has no
+idea what's in your playlist until you load it. What it can do is make a
+playlist with thousands of entries usable on an actual TV remote: fast
+search instead of scrolling, favorites that persist locally, and smart
+playlist rules that keep matching channels across source refreshes instead
+of losing your organization every time a provider changes their feed.
+
+The project is open source — the whole point of publishing the code is
+that you don't have to take "no bundled content" on faith.


### PR DESCRIPTION
First build against #1482 — closes #1485.

## What

A reusable Jekyll layout for search-intent landing pages (`iptv-player`, `m3u-player`, `android-tv-player`, ...), so writing one is content work, not an HTML fork of `docs/tv/index.html`.

This uses the pipeline GitHub Pages already runs for this repo — Jekyll, `jekyll-seo-tag`, `jekyll-sitemap` are all declared in `_config.yml` — rather than introducing a new one. The existing hub pages just never used Jekyll's layout/include system; they hand-roll full HTML with `layout: null`.

- **`docs/_data/release.yml`** — single source for the current release. The site has gone stale at the previous tag three separate times now (README in #1503, wiki in #1511, this page's own hardcoded links) because the version and artifact names were hand-typed in more than one place. `download-block.html` renders every product's download link from this one file.
- **`docs/_layouts/landing.html`** + `site-head`/`site-header`/`site-footer`/`boundary-block` includes — hero, optional capability ledger, related-guide cross-links, an FAQ (native `<details>`, no JS, keyboard-operable for free), and the download block, all driven by front matter over the existing `site.css` design tokens.
- Three new CSS additions only: `.intent-hero`, `.faq-item`, `.boundary-note` — appended in the file's existing per-feature-block convention, nothing else touched.
- **`docs/iptv-player/index.md`** — the worked proof. Real page, markdown + front matter, no hand-written HTML. Six capability claims reused verbatim from the TV page's already-audited capability matrix (not invented), four FAQ entries, the content-no-channels boundary stated near the top per every SEO issue's constraint.

## Two real bugs, found by actually building it

Not from reading the templates — from running `jekyll build` (Homebrew Ruby; system Ruby 2.6 is too old for current Jekyll) and inspecting output.

**1. `_config.yml`'s `url` already embedded `/airo`, and `baseurl` adds `/airo` again.** Any Liquid filter combining them doubles the path. This is already live in production: `{% seo %}`'s canonical and `og:url` tags on **both existing hub pages** currently publish `.../airo/airo/tv/` — a canonical URL that 404s, undermining the exact ranking signal the SEO milestone is about. Fixed by dropping the duplicated path from `url`. Verified both hub pages' canonicals are correct in the rebuilt output; nothing else in the codebase referenced `site.url` before this PR.

**2. The related-links loop emitted `item.url` raw instead of through `relative_url`.** Would have 404'd every related-guide link the moment this shipped. Caught and fixed before merge.

## Verification

- Local Jekyll build, zero unresolved Liquid tags in output.
- All 5 download links + all cross-links: `curl` 200.
- Capability/FAQ/related item counts match front matter exactly (DOM-verified).
- Zero browser console errors.
- No horizontal overflow at 375px viewport.
- `python3 .agents/skills/airo-release-branding/scripts/audit_public_page.py` — still passes (only touches the two fixed hub files, both improved by the canonical fix).

## Deliberately not done

`jekyll-sitemap` is declared active in `_config.yml` but a static `docs/sitemap.xml` shadows its build output — the plugin has never actually generated anything, confirmed by diffing the built sitemap against the static one (byte-identical, same stale `2026-07-29` timestamp). So `/iptv-player/` won't appear in the sitemap. That's a sitewide generation-strategy decision belonging to #1486, not this template — hand-adding one row here would repeat the exact single-source mistake this PR just fixed for downloads.

## Next

#1487/#1488/#1489/#1505 can now build their pages as front matter + markdown against this layout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)