### PR TITLE
feat(docs): core search-intent pages — m3u, xmltv, android-tv

### DIFF
--- a/docs/_layouts/landing.html
+++ b/docs/_layouts/landing.html
@@ -7,6 +7,15 @@ layout: null
   the footer, or the download links. See docs/iptv-player/index.md for a
   worked example and docs/_data/release.yml for the single-sourced release
   data this layout renders.
+
+  Cross-page links in front matter (`related[].url`) are already run
+  through `relative_url` by this layout -- write them site-relative, e.g.
+  `/tv/guides/#playlist`. Links written directly in the page's markdown
+  BODY are not: Kramdown renders `[text](/m3u-player/)` as a literal,
+  unprefixed href, which 404s once `site.baseurl` is non-empty. Every body
+  link to another page on this site must go through Liquid explicitly:
+  `[text]({{ '/m3u-player/' | relative_url }})`. This bit every one of the
+  first four intent pages before anyone rebuilt the site locally to check.
 -->
 <!doctype html>
 <html lang="en">

--- a/docs/android-tv-player/index.md
+++ b/docs/android-tv-player/index.md
@@ -1,0 +1,75 @@
+---
+layout: landing
+permalink: /android-tv-player/
+title: "Android TV Player Built for the Remote — Airo TV"
+description: "Airo TV is a leanback-first Android TV and Google TV player: D-pad navigation, title-safe layout, and direct-install or Play Store setup. Open source."
+eyebrow: "Android TV / Google TV player"
+hero_title: "Built for the remote, not ported to it."
+lede: "Airo TV is a leanback-first player: D-pad navigation, focus that survives playback, and layout that respects the TV-safe frame — on Android TV and Google TV, direct-install or through the Play Store."
+primary_cta: "Download Airo TV"
+capabilities_title: "What the Android TV build does"
+capabilities:
+  - title: Leanback D-pad navigation
+    text: Directional focus across search, browse, and playback, tuned specifically for a TV remote rather than a touchscreen layout stretched to fit.
+    status: available
+    status_label: Available
+  - title: Direct-install APK or Play Store AAB
+    text: Both a direct-install release APK and a Play Store AAB are published for the Android TV / Google TV profile.
+    status: available
+    status_label: Available
+  - title: Direct USB and removable-media browsing
+    text: Permission-scoped browsing of local files on connected USB or removable media, without converting them into a playlist first.
+    status: available
+    status_label: Available
+  - title: Google Cast support
+    text: Send playback to a Chromecast receiver, subject to local network discovery and receiver reachability.
+    status: available
+    status_label: Supported path
+  - title: Fire TV
+    text: A compatible APK path exists; Fire TV remains a separate, experimental qualification track rather than a fully supported target.
+    status: qualifying
+    status_label: Experimental
+related_title: "Set it up"
+related:
+  - title: Set up Android TV or Google TV
+    text: Install, add a source, browse, search, and play.
+    url: /tv/guides/#android-tv
+    icon: tv
+  - title: Bring an M3U/M3U8 playlist
+    text: Load a playlist source once Airo TV is installed.
+    url: /m3u-player/
+    icon: list-plus
+  - title: Install on Fire TV instead
+    text: Use the compatible APK path and understand the experimental status.
+    url: /tv/guides/#fire-tv
+    icon: flame
+faq:
+  - q: "Is Airo TV available on the Google Play Store?"
+    a: "Yes, a Play Store AAB is published for the Android TV / Google TV profile alongside a direct-install APK."
+  - q: "Does Airo TV work with a standard Android TV remote?"
+    a: "Yes. Navigation is built leanback-first for D-pad input, including focus that holds correctly through playback and returns to the right place afterward."
+  - q: "Can Airo TV play local files from a USB drive on Android TV?"
+    a: "Yes. Airo TV supports direct, permission-scoped browsing of USB and removable media on Android TV, separate from loading a playlist URL."
+  - q: "Is this the same app as the Fire TV version?"
+    a: "It's the same Android TV build, but Fire TV is tracked as a separate, experimental qualification path rather than a fully supported target — see the Fire TV install guide for current status."
+---
+
+Most "Android TV" apps are a phone layout with bigger buttons. The tell
+is always the remote: focus jumps to the wrong element, search wants a
+keyboard, or a full-screen player forgets where you were when you back
+out of it.
+
+Airo TV is built the other way — leanback first. Every screen is
+designed for directional D-pad navigation from the start, including the
+parts that are easy to get wrong: focus that survives returning from
+playback, layout that stays inside the TV-safe frame instead of
+clipping at the edges on real hardware, and search and settings that
+stay reachable no matter how the browse grid is arranged.
+
+It installs the way an Android TV app should — a direct APK for
+sideloading, or a Play Store AAB for Google TV devices — and once it's
+running, what you do with it is [load your own M3U/M3U8
+playlist]({{ '/m3u-player/' | relative_url }}) or browse local files directly from a
+connected USB drive. Either way, the point of this page is the
+platform experience underneath: Airo TV was written for a couch and a
+remote, not adapted to one.

--- a/docs/iptv-player/index.md
+++ b/docs/iptv-player/index.md
@@ -60,8 +60,8 @@ faq:
 
 Most IPTV apps bundle a channel catalog, a subscription, or both. Airo TV
 does neither — it is a player, not a service. You supply an
-[M3U or M3U8 playlist](/tv/guides/#playlist) and, if you have one, an
-[XMLTV guide](/tv/#capability-matrix), and Airo TV turns that into a
+[M3U or M3U8 playlist]({{ '/tv/guides/#playlist' | relative_url }}) and, if you have one, an
+[XMLTV guide]({{ '/tv/#capability-matrix' | relative_url }}), and Airo TV turns that into a
 TV-first channel grid with search and favorites.
 
 That also means Airo TV can't tell you what to watch, because it has no

--- a/docs/m3u-player/index.md
+++ b/docs/m3u-player/index.md
@@ -1,0 +1,76 @@
+---
+layout: landing
+permalink: /m3u-player/
+title: "M3U Player for Android TV — Open Any M3U/M3U8 Playlist | Airo TV"
+description: "Open an M3U or M3U8 playlist file or URL on Android TV, Fire TV, or macOS with Airo TV. Open-source, no bundled channels, no account required."
+eyebrow: "M3U / M3U8 player"
+hero_title: "You have an M3U file. Airo TV opens it."
+lede: "Point Airo TV at an M3U or M3U8 playlist URL and it becomes a searchable, TV-first channel grid — no conversion step, no account, no catalog of its own."
+primary_cta: "Download Airo TV"
+capabilities_title: "What happens to your M3U file"
+capabilities:
+  - title: M3U and M3U8 both read directly
+    text: Airo TV parses EXTINF metadata — channel name, group, logo — from standard M3U playlists and M3U8 (HLS) variants without a separate import step.
+    status: available
+    status_label: Available
+  - title: Large playlists stay searchable
+    text: Search loaded channels by name instead of scrolling a flat list, which matters once a playlist runs past a few hundred entries.
+    status: available
+    status_label: Available
+  - title: Favorites persist locally
+    text: Mark channels as favorites from browse and player flows; the list is stored on-device, not in an account.
+    status: available
+    status_label: Available
+  - title: Survives playlist refreshes
+    text: Smart playlists use local rules and canonical channel matching to keep your organization when a provider re-issues the same M3U with reordered or renamed entries.
+    status: available
+    status_label: Available
+  - title: One playlist file, multiple entries
+    text: Load more than one authorized M3U source and switch between them; source management stays local to the device.
+    status: available
+    status_label: Available
+  - title: Playlist editing or hosting
+    text: Airo TV does not create, edit, or host M3U files — it only plays a source you already have.
+    status: planned
+    status_label: Not supported
+related_title: "Load your playlist"
+related:
+  - title: Add an authorized M3U source
+    text: Use an M3U or M3U8 URL you are allowed to access.
+    url: /tv/guides/#playlist
+    icon: list-plus
+  - title: Set up Android TV or Google TV
+    text: Install, add your playlist, browse, search, and play.
+    url: /tv/guides/#android-tv
+    icon: tv
+  - title: Pair it with an XMLTV guide
+    text: Add programme data and clearer playback-recovery states alongside your M3U source.
+    url: /xmltv-player/
+    icon: calendar
+faq:
+  - q: "What is the difference between M3U and M3U8?"
+    a: "M3U is the original plain-text playlist format. M3U8 is the same format saved as UTF-8, and in practice usually signals an HLS (HTTP Live Streaming) source. Airo TV reads both without any extra setup."
+  - q: "Does Airo TV provide an M3U playlist?"
+    a: "No. Airo TV ships no channels, playlists, subscriptions, or media catalog. You supply an M3U/M3U8 URL from a source you are already authorized to use."
+  - q: "Can I load an M3U file from local storage instead of a URL?"
+    a: "Airo TV supports direct, permission-scoped USB and removable-media browsing on Android TV, in addition to loading a playlist URL."
+  - q: "Will Airo TV keep working if my provider changes the M3U file?"
+    a: "Smart playlists use canonical channel matching to preserve your favorites and organization across most reissues of the same source, though a completely restructured file may need re-review."
+---
+
+An M3U file is just a text list — a channel name, sometimes a group and a
+logo, and a stream URL, repeated per entry. What turns that list into
+something usable on a TV is everything *around* the parsing: search that
+works with a remote instead of a keyboard, favorites that don't reset
+every time the provider re-exports the file, and a grid that doesn't fall
+over at a few thousand entries.
+
+That's the part Airo TV focuses on. Point it at an M3U or M3U8 URL —
+`.m3u` and `.m3u8` are read the same way, the extension mostly just hints
+at whether the streams behind it are HLS — and it becomes a channel grid
+with local search and favorites. Nothing about the playlist is uploaded,
+stored remotely, or shared; the source lives only on your device.
+
+If your source also publishes an [XMLTV guide]({{ '/xmltv-player/' | relative_url }}), pairing
+the two adds programme data and more specific playback-recovery states
+when a stream fails, instead of a generic error.

--- a/docs/xmltv-player/index.md
+++ b/docs/xmltv-player/index.md
@@ -1,0 +1,69 @@
+---
+layout: landing
+permalink: /xmltv-player/
+title: "XMLTV Player — Add a Programme Guide to Your Playlist | Airo TV"
+description: "Airo TV pairs your M3U/M3U8 playlist with an authorized XMLTV guide for programme data and clearer playback diagnostics. Open source, no bundled EPG."
+eyebrow: "XMLTV guide player"
+hero_title: "An XMLTV guide, paired with your own playlist."
+lede: "Add an authorized XMLTV source next to your M3U/M3U8 playlist and Airo TV uses it for programme data and more specific playback-recovery states — not just a generic error when a stream fails."
+primary_cta: "Download Airo TV"
+capabilities_title: "What the XMLTV guide is used for"
+capabilities:
+  - title: Programme data alongside your playlist
+    text: Add an authorized XMLTV source and its programme listings attach to the channels in your existing M3U/M3U8 playlist.
+    status: available
+    status_label: Available
+  - title: Bounded, clearer playback diagnostics
+    text: With a guide present, playback problems get more specific, bounded recovery states instead of a single generic failure message.
+    status: available
+    status_label: Available
+  - title: Playlist playback stays the foundation
+    text: The guide is additive. Without an XMLTV source, playlist playback, search, and favorites work exactly the same.
+    status: available
+    status_label: Available
+  - title: Guide hosting or generation
+    text: Airo TV does not host, generate, or edit XMLTV files — it consumes a source URL you already have.
+    status: planned
+    status_label: Not supported
+related_title: "Set it up"
+related:
+  - title: Add an authorized XMLTV source
+    text: Pair a guide URL with your existing playlist.
+    url: /tv/guides/#playlist
+    icon: calendar
+  - title: Don't have a playlist yet?
+    text: Start with an M3U or M3U8 source — the guide pairs with it once both are loaded.
+    url: /m3u-player/
+    icon: list-plus
+  - title: Set up Android TV or Google TV
+    text: Install, add your sources, browse, search, and play.
+    url: /tv/guides/#android-tv
+    icon: tv
+faq:
+  - q: "Does Airo TV come with a built-in programme guide?"
+    a: "No. Airo TV ships no channels, playlists, subscriptions, or EPG data of its own. You supply an XMLTV source URL from a provider you are already authorized to use."
+  - q: "What does the XMLTV guide actually change in Airo TV?"
+    a: "It adds programme data to your existing playlist's channels, and it gives playback failures more specific, bounded recovery states instead of one generic error."
+  - q: "Do I need an XMLTV guide to use Airo TV?"
+    a: "No. Playlist playback, search, and favorites all work from an M3U/M3U8 source alone. The XMLTV guide is an addition, not a requirement."
+  - q: "What format does the XMLTV source need to be in?"
+    a: "A standard XMLTV-format URL, the same format used by most EPG providers and other TV player apps."
+---
+
+XMLTV is the de facto format for TV programme guides — a plain XML feed
+of channel listings and their programme schedules over a time window.
+Most IPTV and EPG providers publish one alongside their playlist.
+
+Airo TV treats it as exactly that: an addition to a playlist you've
+already loaded, not a separate product. Add the guide's URL and its
+programme data attaches to your channels; leave it out and playlist
+playback, search, and favorites work the same as they always did.
+
+The other effect of having a guide loaded is less obvious but more
+useful day to day — playback failures get bounded, specific
+recovery states instead of a flat error, because Airo TV has schedule
+context to reason about what should be playing.
+
+If you don't have a playlist loaded yet, [start with your M3U/M3U8
+source]({{ '/m3u-player/' | relative_url }}) first; the guide pairs with it once both are in
+place.


### PR DESCRIPTION
Closes #1487.

## What

Three new pages against the template from #1513 — `/m3u-player/`, `/xmltv-player/`, `/android-tv-player/`. `/iptv-player/` already shipped as that PR's proof page, so this completes the four-page row in #1487's table.

Each has a genuinely distinct first-screen answer, not a reworded copy of the others:

| Page | Angle |
| --- | --- |
| `/iptv-player/` | generic head term — open-source, no bundled catalog |
| `/m3u-player/` | already has a playlist file — format handling (M3U vs M3U8, large-list search, surviving re-exports) |
| `/xmltv-player/` | already has an EPG source — what pairing a guide actually changes, stated as additive, not required |
| `/android-tv-player/` | platform-first — leanback/D-pad experience, not the IPTV pitch a third time |

`/android-tv-player/` is deliberately kept distinct from the future `iptv-player-for-android-tv` in #1488: this page covers the platform generally (including local USB/removable-media browsing), the future one will be IPTV-specific on that platform.

Every capability claim is reused verbatim from the TV page's already-audited capability matrix and device table, or from the shipped v0.0.6 changelog — nothing new asserted. Four distinct `<title>`/`<h1>` pairs, confirmed in the built output.

## A bug the merged template PR already shipped, found by building this one

Markdown body-content links like `[XMLTV guide](/xmltv-player/)` are plain Kramdown, not Liquid — they render as a literal, unprefixed href and 404 once `site.baseurl` is non-empty. `related[]` front-matter links were already correct (the layout runs those through `relative_url`), but nothing caught body prose links, **including one already merged in `iptv-player/index.md`**.

Fixed all four instances — the shipped one plus three new — and added a comment to `landing.html` spelling out the fix (`{{ '/path/' | relative_url }}` inside the markdown link) so #1488/#1489/#1505 don't rediscover it the same way.

## Verification

- Local Jekyll build (Homebrew Ruby), zero unresolved Liquid across all four pages.
- Every internal `href` resolves to a real page in the built tree.
- Capability/FAQ item counts match front matter exactly.
- The fixed body links verified resolving correctly in a **live DOM check** in-browser, not just a grep on the built HTML — confirmed `href="/airo/xmltv-player/"` on the rendered anchor.
- Visual check at desktop and 375px mobile: renders correctly, no horizontal overflow, zero console errors.
- `python3 .agents/skills/airo-release-branding/scripts/audit_public_page.py` — still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)