### PR TITLE
feat(docs): platform and qualifier search-intent pages

### DIFF
--- a/docs/iptv-player-for-android-tv/index.md
+++ b/docs/iptv-player-for-android-tv/index.md
@@ -1,0 +1,66 @@
+---
+layout: landing
+permalink: /iptv-player-for-android-tv/
+title: "IPTV Player for Android TV — Install and Load Your Playlist | Airo TV"
+description: "Install Airo TV on Android TV or Google TV and load your M3U/M3U8 IPTV playlist. Direct APK or Play Store. Open source, no bundled channels."
+eyebrow: "IPTV player for Android TV"
+hero_title: "Your IPTV playlist, on your Android TV box."
+lede: "Install Airo TV on any Android TV or Google TV device, add the M3U/M3U8 playlist you already have, and get a TV-first channel grid with remote-friendly search."
+primary_cta: "Download Airo TV"
+capabilities_title: "Getting your IPTV playlist onto Android TV"
+capabilities:
+  - title: Two install paths
+    text: A direct-install release APK for sideloading, and a Play Store AAB for devices where the Play Store is the expected install route.
+    status: available
+    status_label: Available
+  - title: Add your playlist after install
+    text: Load an M3U or M3U8 URL from your existing IPTV source; Airo TV turns it into a searchable channel grid.
+    status: available
+    status_label: Available
+  - title: Built for the remote
+    text: Directional D-pad navigation across browse, search, and playback, including focus that returns correctly after you back out of a channel.
+    status: available
+    status_label: Available
+  - title: Google Cast
+    text: Send playback to a Chromecast receiver, subject to local network discovery and reachability.
+    status: available
+    status_label: Supported path
+related_title: "Next steps"
+related:
+  - title: Full Android TV setup guide
+    text: Step-by-step install, source, browse, search, and play.
+    url: /tv/guides/#android-tv
+    icon: tv
+  - title: More about the M3U/M3U8 format
+    text: What Airo TV does with the playlist file itself.
+    url: /m3u-player/
+    icon: list-plus
+  - title: Have a Fire TV instead?
+    text: Fire TV uses a separate, experimental install path.
+    url: /iptv-player-for-fire-tv/
+    icon: flame
+faq:
+  - q: "Do I need the Play Store to install Airo TV on Android TV?"
+    a: "No. A direct-install APK is published alongside the Play Store AAB, so you can sideload it on devices without Play Store access."
+  - q: "Does Airo TV include IPTV channels for Android TV?"
+    a: "No. Airo TV ships no channels, playlists, subscriptions, or media catalog on any platform. You load an M3U/M3U8 playlist from a source you're already authorized to use."
+  - q: "Will my existing IPTV playlist work on the Android TV version?"
+    a: "If it's a standard M3U or M3U8 playlist URL, yes — the same playlist works across every Airo TV platform without changes."
+  - q: "Is this different from the general Android TV player page?"
+    a: "This page is about getting an existing IPTV playlist running on Android TV specifically. See the Android TV player page for the platform experience itself — D-pad navigation, layout, and local file browsing."
+---
+
+If you already have an IPTV subscription or an M3U/M3U8 playlist and an
+Android TV or Google TV box, the path is short: install Airo TV, load
+the playlist, done. No account to create, no catalog to browse first —
+the app has no content of its own until you add a source.
+
+Installation depends on the device. Most Android TV and Google TV
+boxes can install the direct APK by sideloading it, or pull it from the
+Play Store where that's the expected path. Either way you land on the
+same app with the same playlist support.
+
+Once it's running, the difference from a phone-ported IPTV app shows up
+in daily use — search that works with a D-pad instead of an on-screen
+keyboard, and focus that goes back to where you were after you leave a
+channel, instead of resetting to the top of the grid.

--- a/docs/iptv-player-for-fire-tv/index.md
+++ b/docs/iptv-player-for-fire-tv/index.md
@@ -1,0 +1,78 @@
+---
+layout: landing
+permalink: /iptv-player-for-fire-tv/
+title: "IPTV Player for Fire TV — Compatible APK, Honest Status | Airo TV"
+description: "Airo TV runs on Fire TV through a compatible APK path. Experimental, with known issues stated plainly. Open source, no bundled IPTV channels."
+eyebrow: "IPTV player for Fire TV"
+hero_title: "Fire TV support, stated honestly."
+lede: "Airo TV runs on Fire TV through a compatible APK path. It is not a fully qualified target the way Android TV is, and the known rough edges are listed below rather than left for you to discover."
+primary_cta: "Download Airo TV"
+capabilities_title: "Fire TV status, as published"
+capabilities:
+  - title: Compatible APK path
+    text: The Android TV build installs and runs on Fire TV through a compatible APK, without a separate Fire TV-specific build.
+    status: qualifying
+    status_label: Experimental
+  - title: Playlist playback
+    text: M3U/M3U8 playlist loading, search, and favorites work the same as on Android TV once installed.
+    status: available
+    status_label: Available
+  - title: "Known issue: back navigation"
+    text: The BACK key is intermittently swallowed on the channel-browse grid after returning from playback (tracked as #1430).
+    status: qualifying
+    status_label: Open issue
+  - title: "Known issue: log noise"
+    text: Live playback emits frequent vendor property-denial messages in the device log during normal operation (tracked as #1243). Cosmetic — it does not affect playback.
+    status: qualifying
+    status_label: Open issue
+  - title: Dedicated Fire TV qualification
+    text: Full, dedicated Fire TV qualification — beyond the compatible APK path — remains outstanding.
+    status: planned
+    status_label: Not yet qualified
+related_title: "Set it up"
+related:
+  - title: Fire TV install guide
+    text: Use the compatible APK path safely and understand the experimental status.
+    url: /tv/guides/#fire-tv
+    icon: flame
+  - title: Prefer Android TV or Google TV?
+    text: The fully supported platform, same app.
+    url: /iptv-player-for-android-tv/
+    icon: tv
+  - title: "Track issue #1430: BACK key on browse grid"
+    text: Current status of the back-navigation issue.
+    url: https://github.com/DevelopersCoffee/airo/issues/1430
+    icon: bug
+  - title: "Track issue #1243: playback log noise"
+    text: Current status of the vendor log-message issue.
+    url: https://github.com/DevelopersCoffee/airo/issues/1243
+    icon: bug
+faq:
+  - q: "Is Airo TV fully supported on Fire TV?"
+    a: "No. Fire TV runs through a compatible APK path, tracked as experimental rather than fully qualified. Android TV and Google TV are the primary supported targets."
+  - q: "What actually goes wrong on Fire TV right now?"
+    a: "Two known issues are open: the BACK key is intermittently swallowed on the channel-browse grid after returning from playback, and live playback writes frequent vendor log messages that are cosmetic and don't affect playback."
+  - q: "Should I still try Airo TV on my Fire TV?"
+    a: "Core playback, playlist loading, search, and favorites work. If an occasional unresponsive BACK press on the browse grid is something you can work around, it's usable today; if you need a fully qualified experience, Android TV is the better target for now."
+  - q: "Does Airo TV include IPTV channels on Fire TV?"
+    a: "No. Airo TV ships no channels, playlists, subscriptions, or media catalog on any platform, including Fire TV."
+---
+
+Most player pages either skip Fire TV entirely or claim full support
+they haven't actually verified there. Airo TV does neither — it runs on
+Fire TV through the same Android TV build via a compatible APK path, and
+that status is labeled *experimental*, not *supported*, because that's
+what the qualification work actually shows so far.
+
+In practice that means core functionality works: install the compatible
+APK, load your M3U/M3U8 playlist, search, favorite channels, play. Two
+issues are open and worth knowing about before you install. The BACK key
+is intermittently swallowed on the channel-browse grid right after you
+return from playback — annoying, not blocking, and it's being tracked.
+Separately, live playback writes a stream of vendor property-denial
+messages to the device log; that one is purely cosmetic and doesn't
+touch playback.
+
+If either of those matters more to you than getting started today,
+Android TV or Google TV is the fully qualified target and the same
+playlist works there without changes.

--- a/docs/iptv-player-with-epg/index.md
+++ b/docs/iptv-player-with-epg/index.md
@@ -1,0 +1,70 @@
+---
+layout: landing
+permalink: /iptv-player-with-epg/
+title: "IPTV Player with EPG — Programme Guide Built In | Airo TV"
+description: "Airo TV supports an EPG (electronic programme guide) via XMLTV, paired with your own M3U/M3U8 playlist. Open source, no bundled guide data."
+eyebrow: "IPTV player with EPG"
+hero_title: "An IPTV player that supports a real programme guide."
+lede: "Airo TV supports an EPG through XMLTV — add a guide source next to your playlist and get programme data and clearer playback diagnostics, not just a bare channel list."
+primary_cta: "Download Airo TV"
+capabilities_title: "EPG support, specifically"
+capabilities:
+  - title: XMLTV-based guide
+    text: Airo TV reads standard XMLTV feeds, the format most EPG and IPTV providers already publish.
+    status: available
+    status_label: Available
+  - title: Programme data on your channels
+    text: Once a guide source is added, programme listings attach to the matching channels in your existing playlist.
+    status: available
+    status_label: Available
+  - title: Guide-aware playback diagnostics
+    text: With a guide present, playback failures get more specific, bounded recovery states instead of one generic error message.
+    status: available
+    status_label: Available
+  - title: EPG is optional
+    text: Playlist playback, search, and favorites all work without a guide loaded — EPG is an addition, not a requirement.
+    status: available
+    status_label: Available
+  - title: No guide data included
+    text: Airo TV does not publish, host, or bundle EPG/guide data of its own.
+    status: planned
+    status_label: Not supported
+related_title: "Set it up"
+related:
+  - title: XMLTV setup and format details
+    text: What Airo TV does with the guide feed, and how pairing works.
+    url: /xmltv-player/
+    icon: calendar
+  - title: Don't have a playlist yet?
+    text: A guide pairs with an M3U/M3U8 source once both are loaded.
+    url: /m3u-player/
+    icon: list-plus
+  - title: Add an authorized source
+    text: Step-by-step setup for playlist and guide sources.
+    url: /tv/guides/#playlist
+    icon: list-plus
+faq:
+  - q: "Does an IPTV player with EPG mean it comes with programme data included?"
+    a: "No, not for Airo TV. EPG support means Airo TV can read a guide feed you provide — it does not publish or bundle programme data of its own."
+  - q: "What guide format does Airo TV's EPG support use?"
+    a: "XMLTV, the standard format most EPG and IPTV providers already publish alongside their playlists."
+  - q: "Is EPG required to use Airo TV?"
+    a: "No. Playlist playback, search, and favorites work without a guide. The EPG is an addition on top of your existing playlist."
+  - q: "What's the actual benefit of adding a guide, beyond seeing programme names?"
+    a: "Playback failures get more specific, bounded recovery states when a guide is present, instead of a single generic error."
+---
+
+"Does it support EPG" is a fair filter when comparing IPTV players, and
+the honest answer for Airo TV is: yes, through XMLTV, and it's optional.
+
+A guide feed is not a separate product tier or a paid add-on — it's a
+second URL you add next to your playlist. Once it's there, programme
+listings attach to your channels, and playback failures get more useful,
+specific recovery states instead of one generic error message. Skip it
+and Airo TV still works exactly the same for playlist playback, search,
+and favorites.
+
+What it isn't: a source of guide data. Airo TV doesn't publish or bundle
+an EPG of its own, the same way it doesn't bundle channels. You bring a
+guide feed you're authorized to use, in standard XMLTV format, from
+whatever provider you already have.

--- a/docs/open-source-iptv-player/index.md
+++ b/docs/open-source-iptv-player/index.md
@@ -1,0 +1,80 @@
+---
+layout: landing
+permalink: /open-source-iptv-player/
+title: "Open Source IPTV Player — MIT Licensed | Airo TV"
+description: "Airo TV is an MIT-licensed, open-source IPTV player for Android TV, Fire TV, and macOS. Public source, public issues, no bundled channels."
+eyebrow: "Open-source IPTV player"
+hero_title: "Open source, MIT licensed, publicly built."
+lede: "Airo TV's source is public under the MIT licence — the same repository that ships the release also carries every open issue, every pull request, and the roadmap behind them."
+primary_cta: "Download Airo TV"
+capabilities_title: "What open source actually gets you here"
+capabilities:
+  - title: MIT licence
+    text: Airo TV is published under the MIT licence — permissive, with no requirement to open-source anything you build separately.
+    status: available
+    status_label: Available
+  - title: Public source, public history
+    text: The full source, commit history, and build workflow that produce the published release APKs are on GitHub.
+    status: available
+    status_label: Available
+  - title: Public issue tracking
+    text: Bugs and known limitations are tracked in the open, including the ones this site links to rather than hides.
+    status: available
+    status_label: Available
+  - title: Public roadmap
+    text: Planned, in-progress, and deliberately-not-adopted work is visible, not just shipped features.
+    status: available
+    status_label: Available
+  - title: Local-first data
+    text: Playlists and app data stay on the device unless you load a remote URL directly.
+    status: available
+    status_label: Available
+  - title: No hidden subscriptions
+    text: No mandatory account and no hidden subscription for the Airo TV player flow.
+    status: available
+    status_label: Available
+related_title: "See it yourself"
+related:
+  - title: Source repository
+    text: Full source, issues, and pull requests on GitHub.
+    url: https://github.com/DevelopersCoffee/airo
+    icon: github
+  - title: MIT licence text
+    text: Read the licence in full.
+    url: https://github.com/DevelopersCoffee/airo/blob/main/LICENSE
+    icon: scroll
+  - title: Public roadmap
+    text: What's shipped, in progress, planned, and not adopted.
+    url: /tv/#roadmap
+    icon: map
+faq:
+  - q: "What licence is Airo TV published under?"
+    a: "The MIT licence — permissive, and it does not require anything you build on top of Airo to also be open source."
+  - q: "Can I audit what Airo TV does with an IPTV playlist before installing it?"
+    a: "Yes. The full source that produces the published release builds is public on GitHub, including the release workflow that builds and signs the APKs."
+  - q: "Does open source mean Airo TV includes free IPTV channels?"
+    a: "No. Open source describes the licence and the code, not the content. Airo TV ships no channels, playlists, subscriptions, or media catalog on any platform."
+  - q: "Where are bugs and known issues tracked?"
+    a: "In the open, on the same GitHub repository as the source — including issues linked directly from this site rather than left undisclosed."
+---
+
+"Open source" gets used loosely enough that it's worth being specific.
+Airo TV is published under the [MIT
+licence](https://github.com/DevelopersCoffee/airo/blob/main/LICENSE) —
+about as permissive as licences get, and it puts no obligation on
+anything you build separately. The [full
+source](https://github.com/DevelopersCoffee/airo) is public: the app
+code, the release workflow that builds and signs the APKs you download,
+and the commit history behind all of it.
+
+The part that matters more day to day is what stays public alongside
+the code. Bugs are tracked as open issues, not hidden until a patch
+ships — this site links directly to a couple of them on the [Fire TV
+page]({{ '/iptv-player-for-fire-tv/' | relative_url }}) rather than pretending they don't
+exist. The roadmap is public too, including the things marked *not
+adopted* rather than only the shipped feature list.
+
+None of that changes what Airo TV actually plays: your own M3U/M3U8
+playlist and, optionally, an XMLTV guide. Open source is about the
+licence and the process, not a bundled channel catalog — Airo TV
+doesn't have one of those on any platform.


### PR DESCRIPTION
Closes #1488.

Stacked on #1514 (base branch `docs/seo-core-intent-pages`) — these pages link to `m3u-player` and `xmltv-player`, which only exist on that branch until it merges. This PR's diff will shrink to just its own four pages once #1514 lands; the base can be retargeted to `main` at that point.

## What

| Page | Distinct angle |
| --- | --- |
| `/iptv-player-for-android-tv/` | you already have a playlist — install-and-load path. Distinct from the shipped `/android-tv-player/`, which is platform-general (leanback engineering, local USB browsing) |
| `/iptv-player-for-fire-tv/` | states the real status plainly per the issue's constraint — compatible APK, labeled experimental, both open issues (#1430, #1243) named and linked, no claim exceeding what's published |
| `/iptv-player-with-epg/` | feature-qualifier framing ("does it support a guide at all"), distinct from `/xmltv-player/`'s format/setup framing. States EPG is additive and optional |
| `/open-source-iptv-player/` | MIT licence stated plainly, links to both the licence text and the source repo, per the issue's constraint. Capability list reuses README's already-published trust claims verbatim rather than inventing new ones |

Eight intent pages now exist total; eight genuinely distinct `<h1>`s, checked side by side.

## Verified assumption, not trusted assumption

The related-links loop applies `| relative_url` unconditionally, and these pages need absolute GitHub URLs (issue links, repo, LICENSE) to survive that. I checked the built output rather than trust memory here — Jekyll's `relative_url` is a documented no-op on already-absolute URLs, confirmed correct in the rendered HTML. Given the same category of assumption already produced a real shipped bug across the last two PRs, this got checked rather than assumed.

One body-content link needed the `relative_url` landmine fix documented in `landing.html`'s header comment (added in #1514) — applied on first write this time.

## Verification

- Local Jekyll build, zero unresolved Liquid across all four pages.
- Every internal `href` resolves to a real page; all four external GitHub links return 200.
- Capability/FAQ counts match front matter.
- No horizontal overflow at 375px, visually verified at desktop + mobile.
- `python3 .agents/skills/airo-release-branding/scripts/audit_public_page.py` — still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)