### PR TITLE
feat(docs): how-to pages — M3U, XMLTV, Android TV, large lists, legal

### DIFF
--- a/docs/_layouts/landing.html
+++ b/docs/_layouts/landing.html
@@ -16,6 +16,14 @@ layout: null
   link to another page on this site must go through Liquid explicitly:
   `[text]({{ '/m3u-player/' | relative_url }})`. This bit every one of the
   first four intent pages before anyone rebuilt the site locally to check.
+
+  Optional `steps` / `before_you_start` front matter (added for #1489)
+  render a procedure using the site's existing `.tutorial-content` CSS
+  from docs/airo-tv/guides/index.html, unchanged -- no new component. Use
+  it only for pages that are genuinely a procedure; keep `structured_data`
+  in sync by hand (type HowTo, one HowToStep per item in `steps`). Don't
+  add a HowTo type to a page that isn't a procedure -- see
+  how-to-use-iptv-legally/index.md, which uses `capabilities` instead.
 -->
 <!doctype html>
 <html lang="en">
@@ -47,6 +55,30 @@ layout: null
           {{ content }}
         </div>
       </section>
+
+      {% if page.steps %}
+      <section class="band band-alt" id="steps" aria-labelledby="steps-title">
+        <div class="container intent-body">
+          <div class="tutorial-content">
+            <h2 id="steps-title">{{ page.steps_title | default: "Steps" }}</h2>
+            {% if page.before_you_start %}
+            <h3>Before you start</h3>
+            <ul>
+              {% for item in page.before_you_start %}
+              <li>{{ item }}</li>
+              {% endfor %}
+            </ul>
+            {% endif %}
+            <h3>{{ page.steps_subtitle | default: "Do this" }}</h3>
+            <ol>
+              {% for item in page.steps %}
+              <li>{{ item }}</li>
+              {% endfor %}
+            </ol>
+          </div>
+        </div>
+      </section>
+      {% endif %}
 
       {% if page.capabilities %}
       <section class="band band-alt" id="capability-matrix" aria-labelledby="capability-title">

--- a/docs/how-to-add-m3u-playlist/index.md
+++ b/docs/how-to-add-m3u-playlist/index.md
@@ -1,0 +1,75 @@
+---
+layout: landing
+permalink: /how-to-add-m3u-playlist/
+title: "How to Add an M3U Playlist to Airo TV"
+description: "Step-by-step: add an authorized M3U or M3U8 playlist to Airo TV, browse channels, and test playback. Open source, no bundled channels."
+eyebrow: "How-to"
+hero_title: "How to add an M3U playlist to Airo TV."
+lede: "The same five steps work on every supported device: add the source, wait for it to load, then search and play."
+primary_cta: "Download Airo TV"
+steps_title: "Add the source"
+before_you_start:
+  - "Use an M3U or M3U8 URL supplied by a source you are authorized to access."
+  - "Keep private tokens and provider credentials out of screenshots and support posts."
+  - "Test with a small known-good playlist first if you're diagnosing a large or unreliable source."
+steps_subtitle: "Do this"
+steps:
+  - "Open Airo TV and choose the playlist or source action."
+  - "Enter the authorized playlist URL carefully."
+  - "Save the source and wait for channel loading to finish."
+  - "Open Live TV, then use Search if the playlist contains many channels."
+  - "Select a channel to test playback."
+structured_data:
+  "@context": "https://schema.org"
+  "@type": HowTo
+  name: How to Add an M3U Playlist to Airo TV
+  description: Add an authorized M3U or M3U8 playlist source to Airo TV and test playback.
+  step:
+    - "@type": HowToStep
+      text: Open Airo TV and choose the playlist or source action.
+    - "@type": HowToStep
+      text: Enter the authorized playlist URL carefully.
+    - "@type": HowToStep
+      text: Save the source and wait for channel loading to finish.
+    - "@type": HowToStep
+      text: Open Live TV, then use Search if the playlist contains many channels.
+    - "@type": HowToStep
+      text: Select a channel to test playback.
+related_title: "Related"
+related:
+  - title: Full Android TV / Fire TV device guide
+    text: Device-specific install steps, remote controls, and troubleshooting.
+    url: /tv/guides/#playlist
+    icon: book-open
+  - title: More about the M3U/M3U8 format
+    text: What Airo TV does with the playlist file itself.
+    url: /m3u-player/
+    icon: list-plus
+  - title: A playlist with thousands of channels?
+    text: Search, favorites, and smart playlists for large lists.
+    url: /how-to-organize-large-channel-lists/
+    icon: list-tree
+faq:
+  - q: "What if the playlist doesn't load?"
+    a: "Airo TV can't repair a provider outage, unsupported codec, expired token, or inaccessible stream. Try a second channel from the same source first, to tell a channel problem apart from a playlist problem."
+  - q: "Does Airo TV provide an M3U playlist for me to add?"
+    a: "No. Airo TV ships no channels, playlists, subscriptions, or media catalog. You supply the URL from a source you're already authorized to use."
+  - q: "Can I add more than one playlist?"
+    a: "Yes. Load more than one authorized source and switch between them; source management stays local to the device."
+  - q: "M3U or M3U8 — does it matter which one I have?"
+    a: "No, both are read the same way. M3U8 usually just signals the streams behind it are HLS."
+---
+
+Adding a playlist is the same five-step flow across every device Airo TV
+supports — the source screen, the URL field, and the load step don't
+change between Android TV, Fire TV, or macOS.
+
+The one thing worth doing before you start: if the playlist is large or
+you're not sure it's reliable, test with a small known-good one first.
+That way, if something doesn't load, you already know it isn't your Airo
+TV setup.
+
+Once a playlist loads, [Search]({{ '/how-to-organize-large-channel-lists/' | relative_url }})
+is the fastest way to find a channel in anything past a few dozen
+entries — scrolling a TV remote through a thousand-channel list is not
+where Airo TV wants you to spend your evening.

--- a/docs/how-to-import-xmltv/index.md
+++ b/docs/how-to-import-xmltv/index.md
@@ -1,0 +1,67 @@
+---
+layout: landing
+permalink: /how-to-import-xmltv/
+title: "How to Import an XMLTV Guide into Airo TV"
+description: "Add an authorized XMLTV guide to Airo TV alongside your M3U/M3U8 playlist for programme data and clearer playback diagnostics."
+eyebrow: "How-to"
+hero_title: "How to import an XMLTV guide."
+lede: "An XMLTV guide loads through the same source screen as your playlist — it's a second source, not a separate setup flow."
+primary_cta: "Download Airo TV"
+steps_title: "Add the guide"
+before_you_start:
+  - "You need an XMLTV guide URL from a provider you're authorized to use."
+  - "The guide is additive. Load your M3U/M3U8 playlist first if you haven't already — the guide pairs with channels already in your playlist."
+steps_subtitle: "Do this"
+steps:
+  - "Open Airo TV and choose the playlist or source action — the same screen used for playlists."
+  - "Add the XMLTV guide URL as a second source."
+  - "Save and wait for the guide to load."
+  - "Open a channel and confirm programme data now appears."
+structured_data:
+  "@context": "https://schema.org"
+  "@type": HowTo
+  name: How to Import an XMLTV Guide into Airo TV
+  description: Add an authorized XMLTV guide source to Airo TV alongside an existing playlist.
+  step:
+    - "@type": HowToStep
+      text: Open Airo TV and choose the playlist or source action — the same screen used for playlists.
+    - "@type": HowToStep
+      text: Add the XMLTV guide URL as a second source.
+    - "@type": HowToStep
+      text: Save and wait for the guide to load.
+    - "@type": HowToStep
+      text: Open a channel and confirm programme data now appears.
+related_title: "Related"
+related:
+  - title: What EPG support actually changes
+    text: Programme data and clearer playback diagnostics, explained.
+    url: /xmltv-player/
+    icon: calendar
+  - title: Don't have a playlist yet?
+    text: Add your M3U/M3U8 source first.
+    url: /how-to-add-m3u-playlist/
+    icon: list-plus
+  - title: Full device guide
+    text: Source setup, remote controls, and troubleshooting.
+    url: /tv/guides/#playlist
+    icon: book-open
+faq:
+  - q: "The guide loaded but shows no programme data. What's wrong?"
+    a: "Two common causes: confirm the Airo TV build you're running includes guide support, and confirm the XMLTV feed's channel identifiers actually match the channels in your playlist — a guide with no matching IDs will load but show nothing."
+  - q: "Do I need an XMLTV guide to use Airo TV?"
+    a: "No. Playlist playback, search, and favorites all work without one. The guide is an addition, not a requirement."
+  - q: "Does Airo TV provide XMLTV guide data?"
+    a: "No. Airo TV ships no EPG data of its own — you supply a guide URL from a provider you're already authorized to use, the same boundary that applies to playlists."
+---
+
+XMLTV import isn't a separate feature hiding in a different menu — it
+uses the exact same source screen as adding a playlist, because that's
+what it is: another source, just one that carries programme schedules
+instead of stream URLs.
+
+If the guide loads but channels show no programme data, the fix is
+almost always channel-identifier matching. XMLTV feeds identify channels
+by an ID string, and if that string doesn't match what's in your
+playlist, Airo TV has a guide with nothing to attach it to. Check that
+your playlist and guide come from a provider that keeps those IDs
+consistent between the two files.

--- a/docs/how-to-organize-large-channel-lists/index.md
+++ b/docs/how-to-organize-large-channel-lists/index.md
@@ -1,0 +1,72 @@
+---
+layout: landing
+permalink: /how-to-organize-large-channel-lists/
+title: "How to Organize a Large IPTV Channel List"
+description: "Search, favorites, and smart playlists — how Airo TV keeps a large IPTV playlist usable on a TV remote, without scrolling through everything."
+eyebrow: "How-to"
+hero_title: "How to organize a playlist with thousands of channels."
+lede: "A big playlist doesn't need to mean endless scrolling. Search, favorites, and smart playlists are the three tools that keep it usable on a remote."
+primary_cta: "Download Airo TV"
+steps_title: "Make a large list usable"
+steps_subtitle: "Do this"
+steps:
+  - "Use Search instead of scrolling once the playlist runs past a few dozen channels — it's faster on a D-pad than any amount of scrolling."
+  - "Mark the channels you actually watch as favorites, so they're reachable without searching every time."
+  - "Let smart playlists' local rules and canonical channel matching preserve that organization when your provider re-issues the same playlist with reordered or renamed entries."
+  - "If the list genuinely needs restructuring, edit it at the source — Airo TV doesn't edit or host playlists — then re-add the updated URL."
+structured_data:
+  "@context": "https://schema.org"
+  "@type": HowTo
+  name: How to Organize a Large IPTV Channel List in Airo TV
+  description: Use search, favorites, and smart playlists to keep a large IPTV playlist usable on a TV remote.
+  step:
+    - "@type": HowToStep
+      text: Use Search instead of scrolling once the playlist runs past a few dozen channels — it's faster on a D-pad than any amount of scrolling.
+    - "@type": HowToStep
+      text: Mark the channels you actually watch as favorites, so they're reachable without searching every time.
+    - "@type": HowToStep
+      text: Let smart playlists' local rules and canonical channel matching preserve that organization when your provider re-issues the same playlist with reordered or renamed entries.
+    - "@type": HowToStep
+      text: If the list genuinely needs restructuring, edit it at the source — Airo TV doesn't edit or host playlists — then re-add the updated URL.
+related_title: "Related"
+related:
+  - title: Add your playlist first
+    text: The five-step source setup.
+    url: /how-to-add-m3u-playlist/
+    icon: list-plus
+  - title: More on the M3U/M3U8 format
+    text: What Airo TV does with the playlist file.
+    url: /m3u-player/
+    icon: list-plus
+  - title: Full device guide
+    text: Source setup and troubleshooting, in detail.
+    url: /tv/guides/#playlist
+    icon: book-open
+faq:
+  - q: "What actually happens when my provider re-issues the playlist?"
+    a: "Smart playlists use local rules and canonical channel matching to try to preserve your favorites and organization across the same source being reordered or renamed, though a completely restructured file may need re-review."
+  - q: "Can Airo TV remove duplicate or dead channels from my playlist for me?"
+    a: "No. Airo TV doesn't edit or host playlists — it plays the source you give it. Cleanup happens at the source, then you re-add the updated URL."
+  - q: "Is there a limit to how many channels a playlist can have?"
+    a: "Airo TV is built to keep large playlists searchable rather than capping playlist size outright; very large or unreliable sources are still worth testing with a smaller known-good playlist first if something isn't loading correctly."
+  - q: "What's the single biggest improvement for a huge playlist?"
+    a: "Search. Scrolling a remote through thousands of entries is the actual problem being solved — favorites and smart playlists matter most once search has already gotten you to the channels you watch regularly."
+---
+
+A playlist with a few hundred channels and one with twenty thousand are
+different problems, and scrolling is the thing that breaks first. Airo
+TV's answer to that isn't a single feature — it's three tools used
+together.
+
+Search does most of the work day to day: typing a few letters on a
+remote beats directional-scrolling through a wall of entries every
+time. Favorites handle the channels you actually watch — mark them once
+and they're reachable without searching again. Smart playlists handle
+the part you don't control: when a provider re-issues the same source
+with things reordered or renamed, canonical channel matching tries to
+keep your favorites and organization intact instead of resetting it.
+
+What none of that does is edit the playlist itself — Airo TV plays a
+source, it doesn't maintain one. If the file genuinely needs cleanup,
+that happens wherever the playlist is generated, and you re-add the
+result.

--- a/docs/how-to-use-iptv-legally/index.md
+++ b/docs/how-to-use-iptv-legally/index.md
@@ -1,0 +1,74 @@
+---
+layout: landing
+permalink: /how-to-use-iptv-legally/
+title: "How to Use IPTV Legally — What Makes a Source Authorized"
+description: "What makes an IPTV source authorized, what Airo TV does and does not provide, and why the app ships no channel catalog. A trust page, not a disclaimer wall."
+eyebrow: "How-to"
+hero_title: "How to use IPTV legally."
+lede: "The short version: only load a playlist or guide from a source you already have the right to access. Everything below explains why Airo TV is built around that line instead of around a catalog."
+primary_cta: "Download Airo TV"
+capabilities_title: "What makes a source authorized"
+capabilities:
+  - title: You have a subscription or licence for it
+    text: A paid IPTV service, a broadcaster's own stream, or a service you're a legitimate customer of.
+    status: available
+    status_label: Authorized
+  - title: It's content you or your organization own or licence
+    text: A personal media server, a workplace's own broadcast feed, or anything you have explicit rights to distribute to yourself.
+    status: available
+    status_label: Authorized
+  - title: It's public or permissively licensed
+    text: Public-domain or openly licensed streams, published as such by their source.
+    status: available
+    status_label: Authorized
+  - title: A playlist someone shared without knowing its provenance
+    text: If you can't say where a stream actually comes from or whether the person sharing it had the right to, that's the case to be careful about.
+    status: qualifying
+    status_label: Verify first
+related_title: "Related"
+related:
+  - title: What Airo TV actually ships
+    text: The full product page and content boundary.
+    url: /tv/
+    icon: tv
+  - title: Add an authorized playlist
+    text: Once you have one, here's how.
+    url: /how-to-add-m3u-playlist/
+    icon: list-plus
+  - title: Privacy policy
+    text: What Airo TV does and doesn't collect.
+    url: /legal/privacy-policy/
+    icon: shield
+faq:
+  - q: "Does Airo TV provide IPTV channels or streams?"
+    a: "No. Airo TV ships no channels, playlists, subscriptions, or media catalog on any platform. It only plays M3U/M3U8 and XMLTV sources you supply yourself."
+  - q: "Why doesn't Airo TV include any channels at all?"
+    a: "Because it's a player, not a service. Shipping a catalog would mean Airo TV — or whoever built it — is making a claim about the right to distribute that content. Not shipping one keeps that question entirely with the source you choose to load."
+  - q: "Is it legal to use Airo TV?"
+    a: "Airo TV itself is open-source software with no content of its own — using it is no different from using any other media player. What matters is whether the specific playlist or stream you load is one you're authorized to access, which is true of any IPTV player, not something specific to Airo TV."
+  - q: "How do I know if a playlist I found online is authorized?"
+    a: "If you can't identify who operates the stream and whether they have the right to distribute it, treat that as a reason to look for the source directly — a licensed service, a broadcaster's own feed, or something clearly public — rather than a playlist of unknown origin."
+---
+
+Most "is IPTV legal" pages either dodge the question with a legal
+disclaimer, or quietly point you toward the thing they're supposedly
+warning you about. Neither is useful, so here's the actual distinction:
+**IPTV is a delivery method, not a content source.** The M3U/M3U8 and
+XMLTV formats Airo TV reads are used by legitimate services and pirated
+ones alike — the format tells you nothing about whether a given stream
+is authorized.
+
+What tells you that is provenance. A playlist from a service you pay
+for, a broadcaster's own published feed, your own media server, or
+something openly licensed — all fine, in the same way any media player
+playing those sources would be fine. A playlist someone forwarded you
+with no clear origin, promising every channel and sports package that
+normally costs money, is the case worth being skeptical of — not
+because of anything about the M3U format, but because of what it
+usually means when a stream that should require a paid licence is being
+handed around for free.
+
+Airo TV's own answer to this is structural, not just a policy: it ships
+no catalog at all. There is nothing to browse until you add a source,
+which means the authorization question is entirely yours to answer —
+Airo TV isn't making that call on your behalf by pre-loading anything.

--- a/docs/how-to-use-iptv-on-android-tv/index.md
+++ b/docs/how-to-use-iptv-on-android-tv/index.md
@@ -1,0 +1,72 @@
+---
+layout: landing
+permalink: /how-to-use-iptv-on-android-tv/
+title: "How to Use IPTV on Android TV — Install and Set Up Airo TV"
+description: "Install Airo TV on Android TV or Google TV, add your M3U/M3U8 IPTV playlist, and get playing. Direct APK or Play Store. Open source."
+eyebrow: "How-to"
+hero_title: "How to use IPTV on Android TV."
+lede: "Install, add your playlist, and you're browsing — the same five steps whether you sideload the APK or install through the Play Store."
+primary_cta: "Download Airo TV"
+steps_title: "Install and start"
+steps_subtitle: "Do this"
+steps:
+  - "Open the latest release on a trusted computer or device."
+  - "Choose the canonical APK unless your device requires a specific ABI build."
+  - "Install the APK through your approved device installation path."
+  - "Open Airo TV from the TV launcher."
+  - "Add your authorized playlist, browse channels, and test playback."
+structured_data:
+  "@context": "https://schema.org"
+  "@type": HowTo
+  name: How to Use IPTV on Android TV with Airo TV
+  description: Install Airo TV on Android TV or Google TV and add an IPTV playlist.
+  step:
+    - "@type": HowToStep
+      text: Open the latest release on a trusted computer or device.
+    - "@type": HowToStep
+      text: Choose the canonical APK unless your device requires a specific ABI build.
+    - "@type": HowToStep
+      text: Install the APK through your approved device installation path.
+    - "@type": HowToStep
+      text: Open Airo TV from the TV launcher.
+    - "@type": HowToStep
+      text: Add your authorized playlist, browse channels, and test playback.
+related_title: "Related"
+related:
+  - title: Full Android TV device guide
+    text: Remote controls and troubleshooting, in detail.
+    url: /tv/guides/#android-tv
+    icon: tv
+  - title: Add your M3U/M3U8 playlist
+    text: The playlist step, in detail.
+    url: /how-to-add-m3u-playlist/
+    icon: list-plus
+  - title: On Fire TV instead?
+    text: A separate, experimental install path.
+    url: /iptv-player-for-fire-tv/
+    icon: flame
+faq:
+  - q: "Do I need the Play Store to use IPTV on Android TV with Airo TV?"
+    a: "No. A direct-install APK is published alongside the Play Store AAB, so you can sideload it on any Android TV or Google TV device."
+  - q: "Which APK should I install?"
+    a: "The canonical/universal APK covers most devices. Only reach for a specific ABI build if your device documentation says it needs one."
+  - q: "How do I navigate once it's installed?"
+    a: "Use the D-pad to move focus and Select to activate the focused control. Use Back to leave playback or return to the previous screen, and Search instead of scrolling a large playlist."
+  - q: "Does Airo TV include IPTV channels?"
+    a: "No. Airo TV ships no channels, playlists, subscriptions, or media catalog on any platform. You add your own authorized M3U/M3U8 playlist after installing."
+---
+
+Getting IPTV working on Android TV is really two short procedures back
+to back: install the app, then add your playlist. Neither one needs
+anything beyond what's already on your device.
+
+Installing is a choice between two paths that land on the same app —
+sideload the direct APK from the release page, or install through the
+Play Store if that's the expected route for your device. Once it's
+open, adding a playlist is the same flow documented for every platform:
+the source screen, the playlist URL, and a moment for channels to load.
+
+The D-pad-first navigation is worth getting used to early: Select
+activates whatever has focus, Back always leaves playback cleanly, and
+Search beats scrolling the moment a playlist runs past a couple dozen
+channels.


### PR DESCRIPTION
Closes #1489.

## What

Five pages against the template from #1513, extending the existing device-guide surface (`docs/airo-tv/guides/`) to task intents instead of device intents, per the issue's framing. This lands cleanly on `main` — #1487/#1488 are already merged.

| Page | Source of the steps |
| --- | --- |
| `/how-to-add-m3u-playlist/` | near-verbatim from `docs/airo-tv/guides/index.html#playlist`'s "Add the source" |
| `/how-to-use-iptv-on-android-tv/` | near-verbatim from the same file's `#android-tv` "Install and start" |
| `/how-to-import-xmltv/` | no dedicated verified sequence exists in the guides file (only a troubleshooting note) — states honestly that XMLTV uses the same source screen as a playlist, rather than inventing a UI flow I haven't verified |
| `/how-to-organize-large-channel-lists/` | turns three already-published capabilities (search, favorites, smart playlists) into practice |
| `/how-to-use-iptv-legally/` | the one page built from `capabilities`/FAQ, not `steps` — it isn't a procedure |

## Template addition

`landing.html` gains an optional `steps`/`before_you_start` block, reusing `docs/airo-tv/guides/index.html`'s existing `.tutorial-content` CSS **verbatim** — no new component. That CSS was written for a different two-column layout, so I verified the reuse actually works in this single-column context via computed styles (22px `ol` padding, 10px `li` spacing match exactly), not just a visual glance.

## Two things I caught and fixed before committing, not after

**Structured-data drift.** Two of the four `HowTo` JSON-LD blocks had step text paraphrased slightly differently from the matching visible `<li>` text (`import-xmltv`, `organize-large-channel-lists`). Structured data disagreeing with visible content is exactly the defect class that gets a rich result distrusted or dropped by search engines. Verified programmatically — parsed the JSON-LD and checked every schema step string against the rendered `<li>` text — not eyeballed. Both now match exactly.

**An unverified benchmark claim.** The organize-page title originally asserted `10,000+ Channels` as if Airo TV had been tested at that scale. It hasn't — that figure traces back to aspirational future-work text I wrote for the `playlist_engine` extraction issue (#1508), not a shipped capability. Retitled without the number before it ever left this branch.

## Constraint compliance (`/how-to-use-iptv-legally/`)

Per #1489: "no step may instruct a user toward obtaining unauthorized content." The page states what makes a source authorized in the affirmative (paid subscription, own content, public/permissive licence), names IPTV as a delivery format rather than a content source, and does not name, link, or point toward any specific source of unauthorized streams.

## Verification

- Local Jekyll build, zero unresolved Liquid across all five pages.
- Every internal `href` resolves to a real page.
- `HowTo` JSON-LD present and valid JSON on the four procedural pages, correctly absent on the legal page.
- Every schema step **programmatically** confirmed to match its visible `<li>` text word for word.
- Five distinct `<h1>`s — 13 total across every shipped intent page now, still no duplicates.
- No horizontal overflow at 375px; `.tutorial-content` reuse confirmed via computed CSS values.
- `python3 .agents/skills/airo-release-branding/scripts/audit_public_page.py` — still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)