### PR TITLE
feat(release): multi-store APK publishing framework

### DIFF
--- a/.github/airo-publish-targets.json
+++ b/.github/airo-publish-targets.json
@@ -1,0 +1,186 @@
+{
+  "schemaVersion": 1,
+  "_comment": [
+    "Publish targets for tools/publish. Profile ids and package ids must match",
+    ".github/airo-build-profiles.json and docs/release/V2_DISTRIBUTION_MATRIX.md.",
+    "A target with enabled:false is listed but never run without an explicit --target."
+  ],
+  "targets": {
+    "github": {
+      "enabled": true,
+      "_note": "No packageId pin here: one release tag carries every artifact for the profile, and the macOS bundle uses com.developerscoffee.airo.tv rather than the Android app id.",
+      "profiles": {
+        "tv": {
+          "artifactSelector": {
+            "artifactType": ["apk", "aab", "macos_zip", "macos_dmg"],
+            "minCount": 1
+          },
+          "releaseNotes": {
+            "source": "changelog",
+            "path": "CHANGELOG.md",
+            "headingPattern": "^##\\s+v{version}\\b.*$",
+            "fallback": "See the release notes in CHANGELOG.md."
+          },
+          "options": {
+            "repository": "DevelopersCoffee/airo",
+            "tag": "v{version}"
+          }
+        },
+        "full": {
+          "artifactSelector": {
+            "artifactType": ["apk", "aab"],
+            "minCount": 1
+          },
+          "releaseNotes": {
+            "source": "changelog",
+            "path": "CHANGELOG.md",
+            "headingPattern": "^##\\s+v{version}\\b.*$",
+            "fallback": "See the release notes in CHANGELOG.md."
+          },
+          "options": {
+            "repository": "DevelopersCoffee/airo",
+            "tag": "v{version}"
+          }
+        }
+      }
+    },
+
+    "play": {
+      "enabled": false,
+      "_note": "Enable once GOOGLE_PLAY_SERVICE_ACCOUNT_JSON is provisioned for the TV listing.",
+      "profiles": {
+        "tv": {
+          "packageId": "io.airo.app.tv",
+          "artifactSelector": {
+            "artifactType": ["aab"],
+            "minCount": 1,
+            "maxCount": 1
+          },
+          "releaseNotes": {
+            "source": "changelog",
+            "path": "CHANGELOG.md",
+            "headingPattern": "^##\\s+v{version}\\b.*$",
+            "maxChars": 500,
+            "fallback": "Bug fixes and stability improvements."
+          },
+          "options": {
+            "track": "internal",
+            "rollout": null
+          }
+        }
+      }
+    },
+
+    "apkpure": {
+      "enabled": false,
+      "_note": "Enable after `python3 -m tools.publish doctor apkpure` proves the selectors against the live console. Selection is by exact filename, not by abi: the universal APK and the arm64-v8a APK share abi=android-arm64, so only the filename distinguishes them.",
+      "profiles": {
+        "tv": {
+          "packageId": "io.airo.app.tv",
+          "artifactSelector": {
+            "artifactType": ["apk"],
+            "filenamePattern": "^Airo-TV-{version}\\.apk$",
+            "minCount": 1,
+            "maxCount": 1
+          },
+          "releaseNotes": {
+            "source": "changelog",
+            "path": "CHANGELOG.md",
+            "headingPattern": "^##\\s+v{version}\\b.*$",
+            "maxChars": 4000,
+            "fallback": "Bug fixes and stability improvements."
+          },
+          "options": {
+            "headless": true
+          }
+        }
+      }
+    },
+
+    "amazon": {
+      "enabled": false,
+      "profiles": {
+        "tv": {
+          "packageId": "io.airo.app.tv",
+          "artifactSelector": {
+            "artifactType": ["apk"],
+            "filenamePattern": "^Airo-TV-{version}\\.apk$",
+            "minCount": 1,
+            "maxCount": 1
+          },
+          "releaseNotes": {
+            "source": "changelog",
+            "path": "CHANGELOG.md",
+            "headingPattern": "^##\\s+v{version}\\b.*$",
+            "maxChars": 4000,
+            "fallback": "Bug fixes and stability improvements."
+          }
+        }
+      }
+    },
+
+    "huawei": {
+      "enabled": false,
+      "profiles": {
+        "tv": {
+          "packageId": "io.airo.app.tv",
+          "artifactSelector": {
+            "artifactType": ["apk"],
+            "filenamePattern": "^Airo-TV-{version}\\.apk$",
+            "minCount": 1,
+            "maxCount": 1
+          },
+          "releaseNotes": {
+            "source": "changelog",
+            "path": "CHANGELOG.md",
+            "headingPattern": "^##\\s+v{version}\\b.*$",
+            "maxChars": 4000,
+            "fallback": "Bug fixes and stability improvements."
+          }
+        }
+      }
+    },
+
+    "fdroid": {
+      "enabled": false,
+      "profiles": {
+        "tv": {
+          "packageId": "io.airo.app.tv",
+          "artifactSelector": {
+            "artifactType": ["apk"],
+            "minCount": 1
+          },
+          "releaseNotes": {
+            "source": "changelog",
+            "path": "CHANGELOG.md",
+            "headingPattern": "^##\\s+v{version}\\b.*$",
+            "fallback": "See CHANGELOG.md."
+          }
+        }
+      }
+    },
+
+    "website": {
+      "enabled": false,
+      "_note": "Enable once docs/_data consumes the generated download metadata. No packageId pin: the macOS bundle id differs from the Android app id.",
+      "profiles": {
+        "tv": {
+          "artifactSelector": {
+            "artifactType": ["apk", "macos_zip", "macos_dmg"],
+            "minCount": 1
+          },
+          "releaseNotes": {
+            "source": "changelog",
+            "path": "CHANGELOG.md",
+            "headingPattern": "^##\\s+v{version}\\b.*$",
+            "fallback": "See CHANGELOG.md."
+          },
+          "options": {
+            "outputPath": "docs/_data/downloads_tv.json",
+            "downloadBaseUrl": "https://github.com/DevelopersCoffee/airo/releases/download/v{version}"
+          }
+        }
+      }
+    }
+  }
+}

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -77,6 +77,8 @@ jobs:
           scripts/check-build-profiles.py
           scripts/test-generate-release-manifest.sh
           scripts/test-generate-release-qualification-report.sh
+          chmod +x scripts/test-publish-framework.sh
+          scripts/test-publish-framework.sh
 
       - name: Validate Engineering Council module manifests
         run: |

--- a/.github/workflows/publish-stores.yml
+++ b/.github/workflows/publish-stores.yml
@@ -1,0 +1,139 @@
+name: Publish to stores
+
+# Opt-in only. Release workflows build and publish the GitHub Release; this
+# workflow takes an existing release's artifacts and pushes them to the stores
+# configured in .github/airo-publish-targets.json.
+#
+# Nothing irreversible happens unless `submit: true` is chosen explicitly.
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag whose assets should be published (e.g. v0.0.6)'
+        required: true
+      targets:
+        description: 'Comma-separated publish targets (e.g. apkpure,play). Empty = every enabled target.'
+        required: false
+        default: ''
+      profile:
+        description: 'Release profile id (tv, full). Empty = every profile present in the manifest.'
+        required: false
+        default: ''
+      mode:
+        description: 'plan = resolve only; stage = upload without submitting; submit = perform the store submission'
+        required: true
+        type: choice
+        options:
+          - plan
+          - stage
+          - submit
+        default: plan
+      runner:
+        description: 'Runner label. Use the self-hosted mac runner for browser-driven stores.'
+        required: true
+        type: choice
+        options:
+          - ubuntu-latest
+          - self-hosted
+        default: ubuntu-latest
+
+concurrency:
+  group: publish-stores-${{ inputs.tag }}
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+
+jobs:
+  publish:
+    name: Publish ${{ inputs.tag }} (${{ inputs.mode }})
+    runs-on: ${{ inputs.runner }}
+    timeout-minutes: 45
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
+      - name: Resolve target list
+        id: resolve
+        env:
+          RAW_TARGETS: ${{ inputs.targets }}
+          RAW_PROFILE: ${{ inputs.profile }}
+        run: |
+          set -euo pipefail
+          args=""
+          if [[ -n "$RAW_TARGETS" ]]; then
+            IFS=',' read -ra parts <<< "$RAW_TARGETS"
+            for part in "${parts[@]}"; do
+              trimmed="$(echo "$part" | tr -d '[:space:]')"
+              [[ -z "$trimmed" ]] && continue
+              if [[ ! "$trimmed" =~ ^[a-z0-9_-]+$ ]]; then
+                echo "::error::Invalid target name: $trimmed"
+                exit 1
+              fi
+              args+=" --target $trimmed"
+            done
+          fi
+          if [[ -n "$RAW_PROFILE" ]]; then
+            if [[ ! "$RAW_PROFILE" =~ ^[a-z0-9_-]+$ ]]; then
+              echo "::error::Invalid profile id: $RAW_PROFILE"
+              exit 1
+            fi
+            args+=" --profile $RAW_PROFILE"
+          fi
+          echo "args=$args" >> "$GITHUB_OUTPUT"
+
+      - name: Fetch release assets
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: python3 -m tools.publish fetch --tag "${{ inputs.tag }}" --clean
+
+      - name: Install Playwright
+        if: contains(inputs.targets, 'apkpure') || inputs.targets == ''
+        run: |
+          python3 -m pip install --upgrade pip
+          python3 -m pip install playwright
+          python3 -m playwright install --with-deps chromium
+
+      - name: Plan
+        if: inputs.mode == 'plan'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          python3 -m tools.publish plan \
+            --tag "${{ inputs.tag }}" \
+            ${{ steps.resolve.outputs.args }}
+
+      - name: Publish
+        if: inputs.mode != 'plan'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GOOGLE_PLAY_SERVICE_ACCOUNT_JSON: ${{ secrets.GOOGLE_PLAY_SERVICE_ACCOUNT_JSON }}
+          # Path to the session state a human created with
+          # `python3 -m tools.publish login apkpure`. Never a password.
+          APKPURE_STORAGE_STATE: ${{ secrets.APKPURE_STORAGE_STATE_PATH }}
+          APKPURE_SELECTORS_FILE: ${{ vars.APKPURE_SELECTORS_FILE }}
+        run: |
+          python3 -m tools.publish run \
+            --tag "${{ inputs.tag }}" \
+            ${{ steps.resolve.outputs.args }} \
+            --results-json build/publish-results.json \
+            ${{ inputs.mode == 'submit' && '--submit' || '' }}
+
+      - name: Upload publish evidence
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: publish-evidence-${{ inputs.tag }}-${{ inputs.mode }}
+          path: |
+            build/publish-evidence/
+            build/publish-results.json
+            build/release-artifacts/*Release-Manifest.json
+          if-no-files-found: ignore
+          retention-days: 30

--- a/docs/release/V2_DISTRIBUTION_MATRIX.md
+++ b/docs/release/V2_DISTRIBUTION_MATRIX.md
@@ -68,6 +68,24 @@ The canonical checksum and manifest generator is
 final artifact renaming so `SHA256SUMS` and the JSON manifest cover the exact
 APK/AAB filenames attached to GitHub Releases or passed to store upload jobs.
 
+## Store Upload Automation
+
+Store uploads run through `tools/publish`, which consumes the manifest above
+rather than re-deriving version, package id, ABI, or checksum data, and pulls
+artifacts from a published GitHub Release rather than a local build. Which
+stores run for a release is configured in `.github/airo-publish-targets.json`;
+the profile ids and package ids there must stay aligned with
+`.github/airo-build-profiles.json` and this table, and a test in
+`scripts/tests/test_publish_framework.py` enforces that.
+
+```bash
+python3 -m tools.publish plan --tag v0.0.6 --profile tv
+```
+
+Nothing irreversible happens without `--submit`. See
+[tools/publish/README.md](../../tools/publish/README.md) for the store-by-store
+behaviour, the APKPure browser-automation constraints, and the evidence layout.
+
 ## Artifact Naming
 
 Use stable, user-facing names:

--- a/scripts/test-publish-framework.sh
+++ b/scripts/test-publish-framework.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Narrow contract check for tools/publish: byte-compile, unit tests, and a
+# real dry-run plan against the repository's own publish config.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+python3 -m compileall -q tools/publish >/dev/null
+python3 -m unittest scripts.tests.test_publish_framework
+
+# The committed config must load and every target must resolve to a publisher.
+python3 -m tools.publish targets >/dev/null
+
+echo "PASS: tools/publish"

--- a/scripts/tests/test_publish_framework.py
+++ b/scripts/tests/test_publish_framework.py
@@ -1,0 +1,738 @@
+"""Tests for the tools/publish multi-store publishing framework.
+
+These cover the parts a broken release would actually hurt: manifest integrity,
+artifact selection, release-note resolution, submit gating, and the manual-store
+escape hatch. No test contacts a store.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT))
+
+from tools.publish.config import (  # noqa: E402
+    ArtifactSelector,
+    PublishConfig,
+    ReleaseNotesSource,
+)
+from tools.publish.errors import (  # noqa: E402
+    ArtifactIntegrityError,
+    ConfigError,
+    ManifestError,
+)
+from tools.publish.evidence import EvidenceRecorder  # noqa: E402
+from tools.publish.fetch import FetchedRelease, index_manifests  # noqa: E402
+from tools.publish.models import PublishStatus, ReleaseMetadata  # noqa: E402
+from tools.publish.publishers import PublishContext, PublishOptions, get_publisher  # noqa: E402
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+from resolve_release_tv_apk import resolve_canonical_tv_apk  # noqa: E402
+from tools.publish.runner import (  # noqa: E402
+    RunRequest,
+    exit_code_for,
+    plan,
+    run,
+    summarise,
+)
+
+TV_APK = "Airo-TV-0.0.6.apk"
+TV_AAB = "Airo-TV-0.0.6-Play-Store.aab"
+
+
+def sha256_of(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def write_release(root: Path, *, corrupt: bool = False) -> Path:
+    """Build a realistic artifacts directory plus its manifest."""
+    artifacts_dir = root / "release-artifacts"
+    artifacts_dir.mkdir(parents=True, exist_ok=True)
+
+    entries = []
+    for filename, payload, artifact_type, abi, channel in (
+        (TV_APK, b"apk-bytes", "apk", "android-arm64", "direct-apk"),
+        (TV_AAB, b"aab-bytes", "aab", "play-managed", "play-store"),
+    ):
+        path = artifacts_dir / filename
+        path.write_bytes(payload)
+        entries.append(
+            {
+                "filename": filename,
+                "profileId": "tv",
+                "packageId": "io.airo.app.tv",
+                "version": "0.0.6",
+                "buildNumber": "12",
+                "artifactType": artifact_type,
+                "abi": abi,
+                "distributionChannel": channel,
+                "sizeBytes": len(payload),
+                "sha256": sha256_of(payload if not corrupt else b"tampered"),
+            }
+        )
+
+    (artifacts_dir / "SHA256SUMS").write_text(
+        "\n".join(f"{entry['sha256']}  {entry['filename']}" for entry in entries) + "\n",
+        encoding="utf-8",
+    )
+    manifest = artifacts_dir / "Airo-TV-0.0.6-Release-Manifest.json"
+    manifest.write_text(
+        json.dumps(
+            {
+                "schemaVersion": 1,
+                "generatedAt": "2026-08-04T00:00:00+00:00",
+                "release": {
+                    "version": "0.0.6",
+                    "buildNumber": "12",
+                    "sourceRef": "main",
+                    "sourceSha": "deadbeef",
+                    "workflowName": "Airo TV Release",
+                    "workflowRun": "99",
+                    "workflowRunUrl": "https://example.invalid/run/99",
+                },
+                "artifacts": entries,
+            },
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+    return manifest
+
+
+def write_config(root: Path, targets: dict) -> Path:
+    path = root / "airo-publish-targets.json"
+    path.write_text(json.dumps({"schemaVersion": 1, "targets": targets}, indent=2), encoding="utf-8")
+    return path
+
+
+def website_target(output_path: str = "docs/_data/downloads_tv.json") -> dict:
+    return {
+        "enabled": True,
+        "profiles": {
+            "tv": {
+                "packageId": "io.airo.app.tv",
+                "artifactSelector": {"artifactType": ["apk"], "minCount": 1, "maxCount": 1},
+                "releaseNotes": {"source": "inline", "text": "Fixes and polish."},
+                "options": {
+                    "outputPath": output_path,
+                    "downloadBaseUrl": "https://example.invalid/{version}",
+                },
+            }
+        },
+    }
+
+
+class ManifestTests(unittest.TestCase):
+    def test_parses_real_shaped_manifest(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            release = ReleaseMetadata.from_manifest_file(write_release(Path(tmp)))
+            self.assertEqual(release.version, "0.0.6")
+            self.assertEqual(release.build_number, "12")
+            self.assertEqual(release.profile_ids(), ("tv",))
+            self.assertEqual(len(release.artifacts), 2)
+
+    def test_rejects_unsupported_schema_version(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            manifest = write_release(Path(tmp))
+            data = json.loads(manifest.read_text(encoding="utf-8"))
+            data["schemaVersion"] = 99
+            manifest.write_text(json.dumps(data), encoding="utf-8")
+            with self.assertRaises(ManifestError):
+                ReleaseMetadata.from_manifest_file(manifest)
+
+    def test_rejects_path_traversal_in_filename(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            manifest = write_release(Path(tmp))
+            data = json.loads(manifest.read_text(encoding="utf-8"))
+            data["artifacts"][0]["filename"] = "../escape.apk"
+            manifest.write_text(json.dumps(data), encoding="utf-8")
+            with self.assertRaises(ManifestError):
+                ReleaseMetadata.from_manifest_file(manifest)
+
+    def test_checksum_mismatch_is_caught_before_any_upload(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            release = ReleaseMetadata.from_manifest_file(write_release(Path(tmp), corrupt=True))
+            with self.assertRaises(ArtifactIntegrityError):
+                release.verify_artifacts()
+
+    def test_missing_artifact_file_is_caught(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            manifest = write_release(Path(tmp))
+            (manifest.parent / TV_APK).unlink()
+            release = ReleaseMetadata.from_manifest_file(manifest)
+            with self.assertRaises(ArtifactIntegrityError):
+                release.verify_artifacts()
+
+
+class SelectorTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.release = ReleaseMetadata.from_manifest_file(write_release(Path(self._tmp.name)))
+
+    def tearDown(self) -> None:
+        self._tmp.cleanup()
+
+    def test_selects_apk_only(self) -> None:
+        selector = ArtifactSelector(artifact_types=("apk",))
+        chosen = selector.select(self.release.artifacts, "test")
+        self.assertEqual([a.filename for a in chosen], [TV_APK])
+
+    def test_max_count_guards_ambiguous_selection(self) -> None:
+        selector = ArtifactSelector(max_count=1)
+        with self.assertRaises(ConfigError):
+            selector.select(self.release.artifacts, "test")
+
+    def test_min_count_guards_empty_selection(self) -> None:
+        selector = ArtifactSelector(artifact_types=("macos_dmg",))
+        with self.assertRaises(ConfigError):
+            selector.select(self.release.artifacts, "test")
+
+    def test_filename_pattern_picks_the_universal_apk(self) -> None:
+        """A TV release ships several APKs, two of which are legitimately arm64.
+
+        `Airo-TV-<v>.apk` (the universal build APKPure wants) and
+        `Airo-TV-<v>-arm64-v8a.apk` both carry `abi: android-arm64`, so no
+        `abi` selector can tell them apart. Selecting on the filename is exact.
+        """
+        artifacts = list(self.release.artifacts)
+        for suffix in ("-arm64-v8a", "-armeabi-v7a", "-x86_64"):
+            twin = artifacts[0]
+            artifacts.append(
+                type(twin)(
+                    **{
+                        **{f.name: getattr(twin, f.name) for f in twin.__dataclass_fields__.values()},
+                        "filename": f"Airo-TV-0.0.6{suffix}.apk",
+                    }
+                )
+            )
+        by_abi = ArtifactSelector(artifact_types=("apk",), abis=("android-arm64",))
+        self.assertEqual(len(by_abi.select(artifacts, "test")), 4)
+
+        by_name = ArtifactSelector(
+            artifact_types=("apk",), filename_pattern=r"^Airo-TV-{version}\.apk$", max_count=1
+        )
+        chosen = by_name.select(artifacts, "test")
+        self.assertEqual([a.filename for a in chosen], [TV_APK])
+
+    def test_filename_excludes_wins_over_contains(self) -> None:
+        selector = ArtifactSelector(filename_contains=("Airo-TV",), filename_excludes=("Play-Store",))
+        chosen = selector.select(self.release.artifacts, "test")
+        self.assertEqual([a.filename for a in chosen], [TV_APK])
+
+
+class ReleaseNotesTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self._tmp.name)
+        self.release = ReleaseMetadata.from_manifest_file(write_release(self.root))
+        (self.root / "CHANGELOG.md").write_text(
+            "# Changelog\n\n"
+            "## [Airo TV v0.0.6] - 2026-08-04\n\n"
+            "### Added\n\n- Guide favourites.\n\n"
+            "## [Airo TV v0.0.5] - 2026-07-22\n\n- Older stuff.\n",
+            encoding="utf-8",
+        )
+
+    def tearDown(self) -> None:
+        self._tmp.cleanup()
+
+    def test_extracts_only_the_matching_section(self) -> None:
+        source = ReleaseNotesSource(
+            source="changelog",
+            path="CHANGELOG.md",
+            heading_pattern=r"^##\s+\[Airo TV v{version}\].*$",
+        )
+        notes = source.resolve(self.release, "tv", repo_root=self.root)
+        self.assertIn("Guide favourites", notes)
+        self.assertNotIn("Older stuff", notes)
+
+    def test_truncates_to_max_chars(self) -> None:
+        source = ReleaseNotesSource(source="inline", text="x" * 100, max_chars=10)
+        notes = source.resolve(self.release, "tv", repo_root=self.root)
+        self.assertEqual(len(notes), 10)
+        self.assertTrue(notes.endswith("…"))
+
+    def test_falls_back_when_no_section_matches(self) -> None:
+        source = ReleaseNotesSource(
+            source="changelog",
+            path="CHANGELOG.md",
+            heading_pattern=r"^##\s+\[Nothing v{version}\]$",
+            fallback="Bug fixes.",
+        )
+        self.assertEqual(source.resolve(self.release, "tv", repo_root=self.root), "Bug fixes.")
+
+    def test_empty_notes_without_fallback_is_an_error(self) -> None:
+        source = ReleaseNotesSource(
+            source="changelog",
+            path="CHANGELOG.md",
+            heading_pattern=r"^##\s+\[Nothing v{version}\]$",
+        )
+        with self.assertRaises(ConfigError):
+            source.resolve(self.release, "tv", repo_root=self.root)
+
+    def test_path_escaping_the_repo_is_rejected(self) -> None:
+        source = ReleaseNotesSource(source="file", path="../../etc/passwd")
+        with self.assertRaises(ConfigError):
+            source.resolve(self.release, "tv", repo_root=self.root)
+
+
+class ConfigTests(unittest.TestCase):
+    def test_repo_config_is_valid_and_matches_build_profiles(self) -> None:
+        config = PublishConfig.load()
+        self.assertIn("github", config.target_names())
+        build_profiles = json.loads(
+            (REPO_ROOT / ".github" / "airo-build-profiles.json").read_text(encoding="utf-8")
+        )
+        known = {
+            profile["id"]: profile.get("appId") for profile in build_profiles["profiles"]
+        }
+        for target in config.target_names():
+            for profile in config.profiles_for(target):
+                self.assertIn(
+                    profile.profile_id,
+                    known,
+                    f"{profile.context} references a profile absent from airo-build-profiles.json",
+                )
+                if profile.package_id:
+                    self.assertEqual(
+                        profile.package_id,
+                        known[profile.profile_id],
+                        f"{profile.context} packageId disagrees with the build profile appId",
+                    )
+
+    def test_every_configured_target_has_a_publisher(self) -> None:
+        config = PublishConfig.load()
+        for target in config.target_names():
+            self.assertIsNotNone(get_publisher(target))
+
+    def test_unknown_target_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            path = write_config(Path(tmp), {"website": website_target()})
+            config = PublishConfig.load(path)
+            with self.assertRaises(ConfigError):
+                config.profiles_for("nope")
+
+    def test_unknown_profile_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            path = write_config(Path(tmp), {"website": website_target()})
+            config = PublishConfig.load(path)
+            with self.assertRaises(ConfigError):
+                config.profiles_for("website", ["coins"])
+
+    def test_bad_release_notes_source_is_rejected_at_load(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            target = website_target()
+            target["profiles"]["tv"]["releaseNotes"] = {"source": "carrier-pigeon"}
+            path = write_config(Path(tmp), {"website": target})
+            with self.assertRaises(ConfigError):
+                PublishConfig.load(path)
+
+
+class RunnerTests(unittest.TestCase):
+    def _request(self, root: Path, targets: dict, **option_kwargs) -> RunRequest:
+        release = ReleaseMetadata.from_manifest_file(write_release(root))
+        config = PublishConfig.load(write_config(root, targets))
+        return RunRequest(
+            release=release,
+            config=config,
+            targets=list(targets),
+            profiles=None,
+            options=PublishOptions(**option_kwargs),
+            evidence_dir=root / "evidence",
+            quiet=True,
+        )
+
+    def test_dry_run_needs_no_credentials_or_binaries(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            targets = {
+                "github": {
+                    "enabled": True,
+                    "profiles": {
+                        "tv": {
+                            "packageId": "io.airo.app.tv",
+                            "artifactSelector": {"artifactType": ["apk"]},
+                            "releaseNotes": {"source": "inline", "text": "Notes."},
+                        }
+                    },
+                }
+            }
+            results = run(self._request(root, targets, dry_run=True))
+            self.assertEqual([r.status for r in results], [PublishStatus.DRY_RUN])
+            self.assertEqual(exit_code_for(results), 0)
+
+    def test_disabled_target_is_skipped_not_run(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            targets = {"website": {**website_target(), "enabled": False}}
+            results = run(self._request(root, targets))
+            self.assertEqual([r.status for r in results], [PublishStatus.SKIPPED])
+
+    def test_manual_store_reports_blocked_with_a_checklist(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            targets = {
+                "amazon": {
+                    "enabled": True,
+                    "profiles": {
+                        "tv": {
+                            "packageId": "io.airo.app.tv",
+                            "artifactSelector": {"artifactType": ["apk"], "maxCount": 1},
+                            "releaseNotes": {"source": "inline", "text": "Notes."},
+                        }
+                    },
+                }
+            }
+            results = run(self._request(root, targets))
+            self.assertEqual([r.status for r in results], [PublishStatus.BLOCKED])
+            checklist = Path(results[0].details["checklist"])
+            self.assertTrue(checklist.is_file())
+            self.assertIn("Amazon Developer Console", checklist.read_text(encoding="utf-8"))
+            # Blocked must not read as success.
+            self.assertEqual(exit_code_for(results), 2)
+
+    def test_website_publisher_writes_download_metadata(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            relative = "build/test-downloads.json"
+            results = run(self._request(root, {"website": website_target(relative)}))
+            self.assertEqual([r.status for r in results], [PublishStatus.SUCCEEDED])
+            output = REPO_ROOT / relative
+            try:
+                payload = json.loads(output.read_text(encoding="utf-8"))
+                self.assertEqual(payload["version"], "0.0.6")
+                self.assertEqual(payload["downloads"][0]["filename"], TV_APK)
+                self.assertEqual(
+                    payload["downloads"][0]["url"],
+                    f"https://example.invalid/0.0.6/{TV_APK}",
+                )
+            finally:
+                output.unlink(missing_ok=True)
+
+    def test_website_output_path_cannot_escape_the_repository(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            results = run(self._request(root, {"website": website_target("../../escape.json")}))
+            self.assertEqual([r.status for r in results], [PublishStatus.FAILED])
+            self.assertIn("inside the repository", results[0].message)
+
+    def test_corrupt_artifact_stops_the_run_before_publishing(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            release = ReleaseMetadata.from_manifest_file(write_release(root, corrupt=True))
+            config = PublishConfig.load(write_config(root, {"website": website_target()}))
+            request = RunRequest(
+                release=release,
+                config=config,
+                targets=["website"],
+                profiles=None,
+                options=PublishOptions(dry_run=True),
+                evidence_dir=root / "evidence",
+                quiet=True,
+            )
+            with self.assertRaises(ArtifactIntegrityError):
+                run(request)
+
+    def test_profile_absent_from_manifest_is_dropped_not_failed(self) -> None:
+        """A TV-only release leg must not fail because the config also has `full`."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            targets = {"website": website_target()}
+            targets["website"]["profiles"]["full"] = {
+                "packageId": "io.airo.app",
+                "artifactSelector": {"artifactType": ["apk"], "maxCount": 1},
+                "releaseNotes": {"source": "inline", "text": "Notes."},
+                "options": {"outputPath": "build/test-full.json"},
+            }
+            request = self._request(root, targets, dry_run=True)
+            resolved = plan(request)
+            self.assertEqual([cfg.profile_id for cfg, _ in resolved.contexts], ["tv"])
+            self.assertEqual(
+                [cfg.profile_id for cfg, _ in resolved.not_in_manifest], ["full"]
+            )
+
+    def test_explicitly_named_missing_profile_still_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            request = self._request(root, {"website": website_target()}, dry_run=True)
+            request.profiles = ["coins"]
+            with self.assertRaises(ConfigError):
+                plan(request)
+
+    def test_summary_renders_one_row_per_result(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            request = self._request(root, {"website": website_target()}, dry_run=True)
+            results = run(request)
+            summary = summarise(results, request.release)
+            self.assertIn("| website | tv |", summary)
+            self.assertIn("0.0.6", summary)
+
+
+class SubmitGatingTests(unittest.TestCase):
+    """The irreversible step must never happen implicitly."""
+
+    def _context(self, root: Path, **option_kwargs) -> PublishContext:
+        release = ReleaseMetadata.from_manifest_file(write_release(root))
+        config = PublishConfig.load(
+            write_config(
+                root,
+                {
+                    "play": {
+                        "enabled": True,
+                        "profiles": {
+                            "tv": {
+                                "packageId": "io.airo.app.tv",
+                                "artifactSelector": {"artifactType": ["aab"], "maxCount": 1},
+                                "releaseNotes": {"source": "inline", "text": "Notes."},
+                                "options": {"track": "internal"},
+                            }
+                        },
+                    }
+                },
+            )
+        )
+        profile = config.profiles_for("play")[0]
+        return PublishContext(
+            release=release,
+            config=profile,
+            artifacts=profile.select_artifacts(release),
+            options=PublishOptions(**option_kwargs),
+            evidence=EvidenceRecorder(root=root / "evidence", quiet=True),
+            release_notes="Notes.",
+            env={"GOOGLE_PLAY_SERVICE_ACCOUNT_JSON": "{}"},
+        )
+
+    def test_without_submit_the_play_upload_only_stages(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            ctx = self._context(Path(tmp))
+            result = get_publisher("play").publish(ctx)
+            self.assertEqual(result.status, PublishStatus.STAGED)
+            self.assertIn("--submit", result.message)
+
+    def test_dry_run_beats_submit(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            ctx = self._context(Path(tmp), dry_run=True, submit=True)
+            self.assertFalse(ctx.options.may_submit)
+            self.assertEqual(get_publisher("play").publish(ctx).status, PublishStatus.DRY_RUN)
+
+    def test_play_rejects_a_non_aab_selection(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            release = ReleaseMetadata.from_manifest_file(write_release(root))
+            config = PublishConfig.load(
+                write_config(
+                    root,
+                    {
+                        "play": {
+                            "enabled": True,
+                            "profiles": {
+                                "tv": {
+                                    "packageId": "io.airo.app.tv",
+                                    "artifactSelector": {"artifactType": ["apk"], "maxCount": 1},
+                                    "releaseNotes": {"source": "inline", "text": "Notes."},
+                                    "options": {"track": "internal"},
+                                }
+                            },
+                        }
+                    },
+                )
+            )
+            profile = config.profiles_for("play")[0]
+            ctx = PublishContext(
+                release=release,
+                config=profile,
+                artifacts=profile.select_artifacts(release),
+                options=PublishOptions(submit=True),
+                evidence=EvidenceRecorder(root=root / "evidence", quiet=True),
+                release_notes="Notes.",
+                env={"GOOGLE_PLAY_SERVICE_ACCOUNT_JSON": "{}"},
+            )
+            with self.assertRaises(ConfigError):
+                get_publisher("play").publish(ctx)
+
+    def test_invalid_track_is_a_preflight_blocker(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            release = ReleaseMetadata.from_manifest_file(write_release(root))
+            config = PublishConfig.load(
+                write_config(
+                    root,
+                    {
+                        "play": {
+                            "enabled": True,
+                            "profiles": {
+                                "tv": {
+                                    "packageId": "io.airo.app.tv",
+                                    "artifactSelector": {"artifactType": ["aab"], "maxCount": 1},
+                                    "releaseNotes": {"source": "inline", "text": "Notes."},
+                                    "options": {"track": "everyone"},
+                                }
+                            },
+                        }
+                    },
+                )
+            )
+            profile = config.profiles_for("play")[0]
+            ctx = PublishContext(
+                release=release,
+                config=profile,
+                artifacts=profile.select_artifacts(release),
+                options=PublishOptions(submit=True),
+                evidence=EvidenceRecorder(root=root / "evidence", quiet=True),
+                release_notes="Notes.",
+                env={"GOOGLE_PLAY_SERVICE_ACCOUNT_JSON": "{}"},
+            )
+            blockers = get_publisher("play").preflight(ctx)
+            self.assertTrue(any("track" in blocker for blocker in blockers), blockers)
+
+
+class CanonicalApkAgreementTests(unittest.TestCase):
+    """The publish selector and the release workflow must pick the same APK.
+
+    `scripts/resolve_release_tv_apk.py` already defines "the canonical Airo TV
+    APK" for the release workflows. This framework expresses the same rule
+    declaratively as an `artifactSelector.filenamePattern`, so the two
+    definitions are pinned together here rather than left to drift.
+    """
+
+    ASSETS = [
+        "Airo-0.0.6-10-arm64.apk",
+        "Airo-0.0.6-10-Play-Store.aab",
+        "Airo-TV-0.0.6-arm64-v8a.apk",
+        "Airo-TV-0.0.6-armeabi-v7a.apk",
+        "Airo-TV-0.0.6-x86_64.apk",
+        "Airo-TV-0.0.6-macOS.dmg",
+        "Airo-TV-0.0.6.apk",
+        "AiroCoins-0.0.6-10-arm64.apk",
+    ]
+
+    def test_selector_matches_the_workflow_resolver(self) -> None:
+        expected = resolve_canonical_tv_apk(self.ASSETS)
+
+        pattern = (
+            PublishConfig.load()
+            .profiles_for("apkpure")[0]
+            .selector.filename_pattern
+        )
+        self.assertIsNotNone(pattern, "the apkpure selector must pin an exact filename")
+        rendered = pattern.format(version=re.escape("0.0.6"), buildNumber="", profileId="")
+        matched = [name for name in self.ASSETS if re.fullmatch(rendered, name)]
+
+        self.assertEqual(matched, [expected])
+
+
+class ManifestIndexTests(unittest.TestCase):
+    """A release tag can carry a per-leg manifest and a combined one."""
+
+    def _manifest(self, path: Path, entries: list[tuple[str, str]]) -> None:
+        path.write_text(
+            json.dumps(
+                {
+                    "schemaVersion": 1,
+                    "release": {"version": "0.0.6", "buildNumber": "10"},
+                    "artifacts": [
+                        {
+                            "filename": filename,
+                            "profileId": profile_id,
+                            "packageId": "io.airo.app.tv",
+                            "version": "0.0.6",
+                            "buildNumber": "10",
+                            "artifactType": "apk",
+                            "abi": "android-arm64",
+                            "distributionChannel": "direct-apk",
+                            "sizeBytes": 1,
+                            "sha256": sha256_of(b"x"),
+                        }
+                        for filename, profile_id in entries
+                    ],
+                }
+            ),
+            encoding="utf-8",
+        )
+
+    def test_prefers_the_manifest_covering_more_of_the_profile(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            self._manifest(root / "Airo-TV-0.0.6-Release-Manifest.json", [("a.apk", "tv"), ("b.apk", "tv")])
+            self._manifest(
+                root / "Airo-0.0.6-Release-Manifest.json",
+                [("a.apk", "tv"), ("b.apk", "tv"), ("c.zip", "tv"), ("d.apk", "full")],
+            )
+            index = index_manifests(root)
+            self.assertEqual(index["tv"].name, "Airo-0.0.6-Release-Manifest.json")
+            self.assertEqual(index["full"].name, "Airo-0.0.6-Release-Manifest.json")
+
+    def test_ambiguous_profile_requires_an_explicit_choice(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            self._manifest(root / "Airo-TV-0.0.6-Release-Manifest.json", [("a.apk", "tv")])
+            self._manifest(root / "Airo-0.0.6-Release-Manifest.json", [("d.apk", "full")])
+            fetched = FetchedRelease(tag="v0.0.6", directory=root, manifests=index_manifests(root))
+            with self.assertRaises(ManifestError):
+                fetched.manifest_for(None)
+            self.assertEqual(fetched.manifest_for("tv").name, "Airo-TV-0.0.6-Release-Manifest.json")
+
+    def test_unknown_profile_is_reported_with_the_available_ones(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            self._manifest(root / "Airo-TV-0.0.6-Release-Manifest.json", [("a.apk", "tv")])
+            fetched = FetchedRelease(tag="v0.0.6", directory=root, manifests=index_manifests(root))
+            with self.assertRaises(ManifestError) as caught:
+                fetched.manifest_for("coins")
+            self.assertIn("tv", str(caught.exception))
+
+    def test_malformed_manifest_is_ignored_not_fatal(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "Broken-Release-Manifest.json").write_text("{not json", encoding="utf-8")
+            self._manifest(root / "Airo-TV-0.0.6-Release-Manifest.json", [("a.apk", "tv")])
+            self.assertEqual(sorted(index_manifests(root)), ["tv"])
+
+
+class CliTests(unittest.TestCase):
+    def run_cli(self, *args: str) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [sys.executable, "-m", "tools.publish", *args],
+            cwd=REPO_ROOT,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+    def test_targets_lists_every_publisher(self) -> None:
+        result = self.run_cli("targets")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        for name in ("github", "play", "apkpure", "amazon", "huawei", "fdroid", "website"):
+            self.assertIn(name, result.stdout)
+
+    def test_plan_emits_json_for_the_repo_config(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            manifest = write_release(Path(tmp))
+            result = self.run_cli(
+                "plan",
+                "--manifest", str(manifest),
+                "--target", "github",
+                "--evidence-dir", str(Path(tmp) / "evidence"),
+            )
+            self.assertEqual(result.returncode, 0, result.stderr)
+            payload = json.loads(result.stdout)
+            self.assertEqual(payload["release"]["version"], "0.0.6")
+            self.assertEqual(payload["plan"][0]["target"], "github")
+            self.assertEqual(payload["plan"][0]["packageId"], "io.airo.app.tv")
+
+    def test_missing_manifest_exits_with_the_manifest_code(self) -> None:
+        result = self.run_cli("plan", "--manifest", "/nonexistent/Release-Manifest.json")
+        self.assertEqual(result.returncode, 2)
+        self.assertIn("ManifestError", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -1,0 +1,1 @@
+"""Airo repository tooling packages."""

--- a/tools/publish/README.md
+++ b/tools/publish/README.md
@@ -1,0 +1,206 @@
+# Airo publishing framework
+
+One release manifest in, one `Publisher` interface out. Every store — GitHub
+Releases, Google Play, APKPure, Amazon, Huawei, F-Droid, the docs site — reads
+the **same** `Release-Manifest.json` that `scripts/generate-release-manifest.py`
+already produces, so no store upload can ever describe bytes that were not built
+and hashed by the release workflow.
+
+**Publishing never builds.** Artifacts always come from a published GitHub
+Release, so a store and the release page cannot disagree about what shipped.
+
+```
+GitHub Release (v0.0.6)  →  gh release download  →  Release-Manifest.json + assets
+                                              │
+                                              ▼
+                              tools/publish (verify → select → publish)
+                                              │
+        ┌────────────┬────────────┬───────────┼───────────┬───────────┐
+        ▼            ▼            ▼           ▼           ▼           ▼
+     github        play        apkpure      amazon      huawei      website
+   (gh CLI)   (fastlane)   (Playwright)   (manual)    (manual)     (JSON)
+```
+
+## Why Python
+
+`scripts/` is already the home of Airo's release automation and it is Python.
+Playwright ships first-class Python bindings, so the APKPure leg needs no Node
+toolchain in a Flutter/Melos repo. A Rust `Publisher` trait was the original
+sketch, but `packages/core_native` still has no build wiring into the app, so a
+Rust binary would have added a toolchain before it added a release.
+
+## Commands
+
+```bash
+python3 -m tools.publish targets
+```
+
+```bash
+python3 -m tools.publish fetch --tag v0.0.6
+```
+
+```bash
+python3 -m tools.publish plan --tag v0.0.6 --profile tv --target apkpure
+```
+
+```bash
+python3 -m tools.publish run --tag v0.0.6 --profile tv --target apkpure
+```
+
+`--tag` downloads the release into `build/release-artifacts/` and resolves the
+manifest. Tags are v-prefixed (`v0.0.6`); manifest versions are not (`0.0.6`).
+`--manifest` still accepts an already-downloaded directory.
+
+`run` verifies every selected artifact's size and SHA-256 against the manifest
+before it contacts anything. A mismatch aborts the run.
+
+### Several manifests per tag
+
+An orchestrated release carries both per-leg manifests (`Airo-TV-…`) and a
+combined one (`Airo-…`). `fetch` indexes every manifest under each profile it
+covers and picks the one describing **more** of that profile's artifacts — a
+manifest that omits an artifact would silently omit it from the upload. Pass
+`--profile` when a tag carries more than one profile.
+
+### Do not select a single APK on `abi`
+
+A TV release ships `Airo-TV-<v>.apk` (universal) alongside
+`Airo-TV-<v>-arm64-v8a.apk`, and both legitimately carry `abi: android-arm64` —
+no `abi` selector can tell them apart. Store selectors that need one exact file
+therefore use `filenamePattern`:
+
+```jsonc
+"filenamePattern": "^Airo-TV-{version}\\.apk$"
+```
+
+Note that `Airo-TV-0.0.6-Release-Manifest.json` as published mislabels the
+armeabi-v7a and x86_64 APKs as `android-arm64`. That generator bug is fixed on
+main, but manifests already attached to older releases keep the wrong values —
+another reason store selection does not read the field.
+
+### Submit gating
+
+`run` uploads and stages, but does **not** perform the irreversible store
+submission unless `--submit` is passed. Without it:
+
+| Target | Without `--submit` | With `--submit` |
+| --- | --- | --- |
+| `github` | uploads assets (reversible) | same |
+| `play` | writes the plan, status `staged` | `fastlane supply` runs |
+| `apkpure` | APK uploaded, notes filled, **not submitted** | Submit for Review clicked |
+| `website` | writes the JSON | same |
+
+`--dry-run` overrides `--submit` and contacts nothing at all. It also skips the
+credential and binary preflight, so a release can be planned from a laptop that
+cannot publish one.
+
+### Exit codes
+
+| Code | Meaning |
+| --- | --- |
+| 0 | every target succeeded, was skipped, staged, or dry-ran |
+| 1 | at least one target failed |
+| 2 | at least one target was blocked (preflight, or a manual-only store) — also the manifest-error code from the CLI wrapper |
+
+## Configuration
+
+`.github/airo-publish-targets.json` decides which stores exist and what each one
+gets. Adding a listing is a config change, not a code change.
+
+```jsonc
+"apkpure": {
+  "enabled": false,
+  "profiles": {
+    "tv": {
+      "packageId": "io.airo.app.tv",
+      "artifactSelector": {
+        "artifactType": ["apk"],
+        "filenamePattern": "^Airo-TV-{version}\\.apk$",
+        "minCount": 1,
+        "maxCount": 1
+      },
+      "releaseNotes": {
+        "source": "changelog",
+        "path": "CHANGELOG.md",
+        "headingPattern": "^##\\s+v{version}\\b.*$",
+        "maxChars": 4000,
+        "fallback": "Bug fixes and stability improvements."
+      },
+      "options": { "headless": true }
+    }
+  }
+}
+```
+
+- `artifactSelector` — declarative, over `artifactType`, `abi`,
+  `distributionChannel`, `filenameContains`, `filenameExcludes`, and
+  `filenamePattern` (regex, with `{version}` substituted). `maxCount: 1` is what
+  stops "which APK did we upload?" from ever being a question.
+- `releaseNotes` — `changelog` (section extraction), `file`, or `inline`. Paths
+  are confined to the repository.
+- Profile ids and package ids must match `.github/airo-build-profiles.json`; a
+  test enforces that.
+
+## APKPure specifics
+
+APKPure has no publishing API, so `tools/publish/apkpure/` drives their
+Developer Console with Playwright. Three hard rules:
+
+1. **No password handling.** A human signs in once with
+   `python3 -m tools.publish login apkpure`, which opens a headed browser and
+   saves the resulting cookies to `~/.config/airo/apkpure-session.json`
+   (override with `APKPURE_STORAGE_STATE`). Credentials never pass through this
+   process, and no password belongs in a workflow secret.
+2. **No CAPTCHA or 2FA solving.** A challenge stops the run with a screenshot
+   and asks a human to take over.
+3. **Selectors are data, not code.** Every step has a list of candidates, and
+   `APKPURE_SELECTORS_FILE` can point at a JSON override — so a console redesign
+   is unblocked by a config file, not by a code review.
+
+### Selectors are UNVERIFIED
+
+The candidates in `apkpure/selectors.py` are written against the documented
+console flow but have **not** been recorded against the live DOM. Before the
+first real run:
+
+```bash
+python3 -m tools.publish doctor apkpure --package-id io.airo.app.tv
+```
+
+It reports which selector keys matched nothing, dumps the page HTML and
+screenshots into the evidence directory, and exits 2 if anything is unmapped.
+Map the gaps, write the overrides, then flip `enabled: true` in the config.
+
+### Where it should run
+
+Cloud runners trigger CAPTCHA and device checks far more often than a machine
+with a stable IP and a persistent profile. Run the APKPure leg on the self-hosted
+Mac mini runner, and keep only the session state on disk — never a password.
+
+## Evidence
+
+Every attempt writes `build/publish-evidence/<target>/<profile>/<version>/`:
+
+- `publish.log` — the full, credential-redacted command trail
+- `*-plan.json` / `*-result.json` — what was intended and what happened
+- `NN-*.png` / `NN-*.html` — browser stage snapshots (APKPure)
+- `MANUAL_CHECKLIST.md` — for stores with no automation yet
+
+## Adding a store
+
+1. Subclass `Publisher` in `tools/publish/publishers/`, set `name`,
+   `description`, and any `required_env` / `required_binaries`.
+2. Implement `publish(ctx)`. Use `ctx.artifacts`, `ctx.release_notes`,
+   `ctx.evidence`, and `self.run(...)` for subprocesses.
+3. Gate anything irreversible behind `ctx.options.may_submit`.
+4. Register it in `publishers/__init__.py` and add a config block.
+
+Stores that cannot be automated yet subclass `ManualPublisher` instead: they
+emit the human checklist and report `BLOCKED`, so a release run can never claim
+a store was published when it was not.
+
+## Tests
+
+```bash
+scripts/test-publish-framework.sh
+```

--- a/tools/publish/__init__.py
+++ b/tools/publish/__init__.py
@@ -1,0 +1,23 @@
+"""Airo multi-store publishing framework.
+
+One release manifest in, one `Publisher` interface out. Store-specific quirks —
+Play's fastlane lane, APKPure's browser-only console, AppGallery's two-step
+commit — stay inside their publisher and never leak into workflow YAML.
+"""
+
+from .config import PublishConfig, TargetProfileConfig
+from .models import Artifact, PublishResult, PublishStatus, ReleaseMetadata
+from .publishers import Publisher, PublishContext, PublishOptions, get_publisher
+
+__all__ = [
+    "Artifact",
+    "PublishConfig",
+    "PublishContext",
+    "PublishOptions",
+    "PublishResult",
+    "PublishStatus",
+    "Publisher",
+    "ReleaseMetadata",
+    "TargetProfileConfig",
+    "get_publisher",
+]

--- a/tools/publish/__main__.py
+++ b/tools/publish/__main__.py
@@ -1,0 +1,10 @@
+"""Entry point: ``python3 -m tools.publish``."""
+
+from __future__ import annotations
+
+import sys
+
+from .cli import main
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/publish/apkpure/__init__.py
+++ b/tools/publish/apkpure/__init__.py
@@ -1,0 +1,13 @@
+"""APKPure Developer Console automation (browser-driven; no public API)."""
+
+from .console import ConsoleSession, console_session, interactive_login
+from .selectors import CONSOLE_ORIGIN, SelectorSet, console_url
+
+__all__ = [
+    "CONSOLE_ORIGIN",
+    "ConsoleSession",
+    "SelectorSet",
+    "console_session",
+    "console_url",
+    "interactive_login",
+]

--- a/tools/publish/apkpure/console.py
+++ b/tools/publish/apkpure/console.py
@@ -1,0 +1,284 @@
+"""Playwright driver for the APKPure Developer Console.
+
+Scope boundaries, deliberately:
+
+* **No password handling.** This module never types credentials. A human signs
+  in once through ``python3 -m tools.publish login apkpure``, which opens a
+  headed browser and saves the resulting session state. CI reuses that state.
+* **No CAPTCHA or 2FA solving.** If a challenge appears, the run stops with a
+  screenshot and asks a human to take over.
+* **No final submit unless asked.** Upload and release notes are staged; the
+  irreversible "Submit for Review" click happens only with ``--submit``.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable, Iterator
+
+from ..errors import CredentialError, PreflightError, RemoteError
+from ..evidence import EvidenceRecorder
+from .selectors import SIGN_IN_URL, SelectorSet, console_url
+
+DEFAULT_VIEWPORT = {"width": 1440, "height": 900}
+
+
+def import_playwright() -> Any:
+    try:
+        from playwright.sync_api import sync_playwright  # noqa: PLC0415
+    except ImportError as exc:  # pragma: no cover - depends on the environment
+        raise PreflightError(
+            "playwright is not installed. Install it with:\n"
+            "  python3 -m pip install playwright\n"
+            "  python3 -m playwright install chromium"
+        ) from exc
+    return sync_playwright
+
+
+@dataclass
+class ConsoleSession:
+    """A signed-in APKPure console page plus the helpers the publisher needs."""
+
+    page: Any
+    selectors: SelectorSet
+    evidence: EvidenceRecorder
+    timeout_ms: int = 60_000
+    _snapshot_index: int = 0
+
+    # ---- low-level selector handling ----------------------------------------
+
+    def _first_visible(self, key: str, timeout_ms: int | None = None) -> Any | None:
+        """Return the first candidate locator that is actually visible."""
+        deadline = timeout_ms if timeout_ms is not None else self.timeout_ms
+        per_candidate = max(1_000, deadline // max(1, len(self.selectors.candidates(key))))
+        for candidate in self.selectors.candidates(key):
+            locator = self.page.locator(candidate).first
+            try:
+                locator.wait_for(state="visible", timeout=per_candidate)
+            except Exception:  # noqa: BLE001 - Playwright raises its own TimeoutError
+                continue
+            self.evidence.log(f"selector {key!r} matched: {candidate}")
+            return locator
+        return None
+
+    def require(self, key: str, what: str, timeout_ms: int | None = None) -> Any:
+        locator = self._first_visible(key, timeout_ms)
+        if locator is None:
+            self.snapshot(f"missing-{key}")
+            raise RemoteError(
+                f"Could not find {what} on the APKPure console "
+                f"(selector key {key!r}, source {self.selectors.source}). "
+                "The console DOM likely changed: re-run "
+                "`python3 -m tools.publish doctor apkpure` and update the selector override."
+            )
+        return locator
+
+    def present(self, key: str, timeout_ms: int = 3_000) -> bool:
+        return self._first_visible(key, timeout_ms) is not None
+
+    # ---- evidence -----------------------------------------------------------
+
+    def snapshot(self, label: str) -> list[Path]:
+        self._snapshot_index += 1
+        stem = f"{self._snapshot_index:02d}-{label}"
+        written: list[Path] = []
+        with contextlib.suppress(Exception):
+            png = self.evidence.file_path(f"{stem}.png")
+            self.page.screenshot(path=str(png), full_page=True)
+            written.append(png)
+        with contextlib.suppress(Exception):
+            written.append(self.evidence.write_text(f"{stem}.html", self.page.content()))
+        self.evidence.log(f"snapshot {stem} ({self.page.url})")
+        return written
+
+    # ---- flow steps ---------------------------------------------------------
+
+    def guard_human_gate(self, stage: str) -> None:
+        """Stop rather than attempt any CAPTCHA, 2FA, or device challenge."""
+        if self.present("human_gate_marker", timeout_ms=2_000):
+            self.snapshot(f"human-gate-{stage}")
+            raise CredentialError(
+                f"APKPure presented a human verification challenge at stage {stage!r}. "
+                "This tool does not solve challenges. Re-run "
+                "`python3 -m tools.publish login apkpure` on a machine with a display, "
+                "clear the challenge by hand, and retry with the refreshed session."
+            )
+
+    def open_app(self, package_id: str) -> None:
+        url = console_url(package_id)
+        self.evidence.log(f"opening {url}")
+        self.page.goto(url, wait_until="domcontentloaded", timeout=self.timeout_ms)
+        self.guard_human_gate("open")
+        if self.present("sign_in_marker", timeout_ms=5_000):
+            self.snapshot("signed-out")
+            raise CredentialError(
+                "APKPure session is not signed in or has expired. Run "
+                "`python3 -m tools.publish login apkpure` to refresh the saved session state."
+            )
+        self.require("signed_in_marker", "a signed-in console shell", timeout_ms=15_000)
+        self.snapshot("console")
+
+    def published_versions(self) -> list[str]:
+        """Best-effort read of the versions already listed for this app."""
+        rows = self._first_visible("version_row", timeout_ms=8_000)
+        if rows is None:
+            self.evidence.warn("Could not read the versions table; skipping duplicate check")
+            return []
+        texts: list[str] = []
+        for candidate in self.selectors.candidates("version_row"):
+            locator = self.page.locator(candidate)
+            count = locator.count()
+            if count:
+                texts = [(locator.nth(index).inner_text() or "").strip() for index in range(count)]
+                break
+        return [text for text in texts if text]
+
+    def open_upload_form(self) -> None:
+        link = self._first_visible("manage_versions_link", timeout_ms=10_000)
+        if link is not None:
+            link.click()
+            self.page.wait_for_load_state("domcontentloaded", timeout=self.timeout_ms)
+            self.snapshot("manage-versions")
+        button = self._first_visible("new_version_button", timeout_ms=10_000)
+        if button is not None:
+            button.click()
+            self.snapshot("new-version-form")
+        self.guard_human_gate("upload-form")
+
+    def upload_apk(self, apk_path: Path) -> None:
+        file_input = self.require("apk_file_input", "the APK file input")
+        self.evidence.log(f"attaching {apk_path.name} ({apk_path.stat().st_size} bytes)")
+        file_input.set_input_files(str(apk_path))
+        if self.present("upload_error_marker", timeout_ms=5_000):
+            self.snapshot("upload-error")
+            raise RemoteError(
+                "APKPure reported an error immediately after attaching the APK. "
+                "See the snapshot in the evidence directory."
+            )
+        if self._first_visible("upload_complete_marker", timeout_ms=self.timeout_ms) is None:
+            self.snapshot("upload-unconfirmed")
+            raise RemoteError(
+                "APK upload never reported completion within the timeout. "
+                "The console may still be processing; check the snapshot before retrying."
+            )
+        self.snapshot("upload-complete")
+
+    def fill_release_notes(self, notes: str) -> None:
+        field = self.require("release_notes_input", "the What's New field")
+        field.fill(notes)
+        self.snapshot("release-notes")
+
+    def submit_for_review(self) -> None:
+        button = self.require("submit_button", "the Submit for Review button")
+        button.click()
+        confirm = self._first_visible("submit_confirm_button", timeout_ms=5_000)
+        if confirm is not None:
+            confirm.click()
+        self.guard_human_gate("submit")
+        if self._first_visible("submit_success_marker", timeout_ms=self.timeout_ms) is None:
+            self.snapshot("submit-unconfirmed")
+            raise RemoteError(
+                "Submitted, but APKPure never showed a review-status confirmation. "
+                "Check the console by hand before re-running: a blind retry may create a "
+                "duplicate submission."
+            )
+        self.snapshot("submitted")
+
+
+@contextlib.contextmanager
+def console_session(
+    *,
+    storage_state: Path,
+    evidence: EvidenceRecorder,
+    selectors: SelectorSet,
+    headless: bool = True,
+    timeout_ms: int = 60_000,
+) -> Iterator[ConsoleSession]:
+    """Open a Chromium context restored from a saved, human-created session."""
+    if not storage_state.is_file():
+        raise CredentialError(
+            f"No APKPure session state at {storage_state}. Run "
+            "`python3 -m tools.publish login apkpure` on a machine with a display first."
+        )
+    sync_playwright = import_playwright()
+    with sync_playwright() as playwright:
+        browser = playwright.chromium.launch(headless=headless)
+        try:
+            context = browser.new_context(
+                storage_state=str(storage_state),
+                viewport=DEFAULT_VIEWPORT,
+                accept_downloads=False,
+            )
+            context.set_default_timeout(timeout_ms)
+            page = context.new_page()
+            page.on("console", lambda msg: evidence.log(f"browser console [{msg.type}] {msg.text}"))
+            try:
+                yield ConsoleSession(
+                    page=page, selectors=selectors, evidence=evidence, timeout_ms=timeout_ms
+                )
+            finally:
+                # Refresh the stored session so a rolling cookie does not expire
+                # the automation between releases.
+                with contextlib.suppress(Exception):
+                    context.storage_state(path=str(storage_state))
+                context.close()
+        finally:
+            browser.close()
+
+
+def interactive_login(
+    storage_state: Path,
+    evidence: EvidenceRecorder,
+    confirm: Callable[[str], object] = input,
+) -> Path:
+    """Open a headed browser so a human can sign in, then save the session.
+
+    The human types their own credentials into APKPure's own page. Nothing about
+    the credentials passes through this process — only the resulting cookies are
+    saved, and only after the human confirms in the terminal. Confirming there
+    rather than waiting for the window to close means the session is captured
+    while the browser is still alive, so closing the whole window (rather than
+    just the tab) does not throw the sign-in away.
+    """
+    sync_playwright = import_playwright()
+    storage_state.parent.mkdir(parents=True, exist_ok=True)
+    with sync_playwright() as playwright:
+        browser = playwright.chromium.launch(headless=False)
+        context = browser.new_context(viewport=DEFAULT_VIEWPORT)
+        page = context.new_page()
+        page.goto(SIGN_IN_URL, wait_until="domcontentloaded")
+        evidence.log(f"opened {SIGN_IN_URL} for interactive sign-in")
+        confirm(
+            "\nSign in to APKPure in the browser window that just opened.\n"
+            "Leave the window OPEN, then press Enter here to save the session: "
+        )
+        try:
+            context.storage_state(path=str(storage_state))
+        except Exception as exc:  # noqa: BLE001 - Playwright raises its own errors
+            raise CredentialError(
+                f"Could not read the browser session: {exc}. "
+                "Keep the browser window open until after you press Enter."
+            ) from exc
+        finally:
+            with contextlib.suppress(Exception):
+                context.close()
+            with contextlib.suppress(Exception):
+                browser.close()
+
+    if not storage_state.is_file():
+        raise CredentialError(f"No session state was written to {storage_state}.")
+    storage_state.chmod(0o600)
+    try:
+        cookies = json.loads(storage_state.read_text(encoding="utf-8")).get("cookies") or []
+    except (json.JSONDecodeError, AttributeError):
+        cookies = []
+    if not cookies:
+        raise CredentialError(
+            f"{storage_state} holds no cookies, so sign-in did not complete. "
+            "Re-run and press Enter only after the developer console is visible."
+        )
+    evidence.log(f"saved {len(cookies)} cookie(s) to {storage_state}")
+    return storage_state

--- a/tools/publish/apkpure/selectors.py
+++ b/tools/publish/apkpure/selectors.py
@@ -1,0 +1,148 @@
+"""APKPure Developer Console selectors.
+
+APKPure publishes no upload API, so this is browser automation against a DOM
+nobody controls but APKPure. Every selector below is therefore:
+
+* a *list* of candidates tried in order, so a markup change breaks one candidate
+  rather than the whole publisher;
+* overridable at runtime from a JSON file via ``APKPURE_SELECTORS_FILE``, so a
+  broken release can be unblocked without a code change and a PR.
+
+**Status: UNVERIFIED.** These candidates are written against the documented
+console flow (sign in -> app -> Manage Versions -> upload APK -> what's new ->
+submit) but have not been recorded against the live DOM. Run
+
+    python3 -m tools.publish doctor apkpure --profile tv
+
+to dump the real page and replace them. Until that dump exists, treat a
+successful run as unproven.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+CONSOLE_ORIGIN = "https://developer.apkpure.com"
+SIGN_IN_URL = f"{CONSOLE_ORIGIN}/login"
+CONSOLE_URL_TEMPLATE = f"{CONSOLE_ORIGIN}/console/{{package_id}}"
+
+#: Logical step -> ordered candidate selectors. Playwright selector syntax;
+#: ``text=`` and ``role=`` engines are allowed and preferred over brittle
+#: class-name chains.
+DEFAULT_SELECTORS: dict[str, list[str]] = {
+    # Proof that the stored session is still valid.
+    "signed_in_marker": [
+        "[data-testid='user-menu']",
+        "header :text-matches('(Sign out|Log out|Logout)', 'i')",
+        "a[href*='/console/']",
+    ],
+    # Shown when the session has expired and a human must re-authenticate.
+    "sign_in_marker": [
+        "form[action*='login']",
+        "input[type='password']",
+        ":text-matches('^(Sign in|Log in)$', 'i')",
+    ],
+    "manage_versions_link": [
+        "a:has-text('Manage Versions')",
+        "a:has-text('Versions')",
+        "[data-testid='manage-versions']",
+    ],
+    "new_version_button": [
+        "button:has-text('Upload APK')",
+        "button:has-text('New Version')",
+        "button:has-text('Add Version')",
+    ],
+    # The <input type=file>; Playwright sets files on it directly, no OS dialog.
+    "apk_file_input": [
+        "input[type='file'][accept*='apk']",
+        "input[type='file']",
+    ],
+    "upload_complete_marker": [
+        "[data-testid='upload-complete']",
+        ":text-matches('(Upload (complete|success)|100%)', 'i')",
+    ],
+    "upload_error_marker": [
+        "[role='alert']",
+        ".ant-message-error",
+        ":text-matches('(upload failed|invalid apk|signature mismatch)', 'i')",
+    ],
+    "release_notes_input": [
+        "textarea[name*='whatsnew' i]",
+        "textarea[name*='release' i]",
+        "textarea[placeholder*=\"What's New\" i]",
+        "textarea",
+    ],
+    "submit_button": [
+        "button:has-text('Submit for Review')",
+        "button:has-text('Submit')",
+        "button[type='submit']",
+    ],
+    "submit_confirm_button": [
+        "button:has-text('Confirm')",
+        "button:has-text('OK')",
+        ".ant-modal button:has-text('Submit')",
+    ],
+    "submit_success_marker": [
+        ":text-matches('(in review|under review|submitted)', 'i')",
+        "[data-testid='review-status']",
+    ],
+    # Rows in the versions table, used to detect an already-published version.
+    "version_row": [
+        "table tbody tr",
+        "[data-testid='version-row']",
+    ],
+    # Anything that means a human has to take over: captcha, 2FA, device check.
+    "human_gate_marker": [
+        "iframe[src*='recaptcha']",
+        "iframe[src*='hcaptcha']",
+        "iframe[title*='challenge' i]",
+        ":text-matches('(verification code|two-factor|2FA|captcha)', 'i')",
+    ],
+}
+
+
+@dataclass(frozen=True)
+class SelectorSet:
+    """Resolved selector candidates, defaults merged with any override file."""
+
+    mapping: dict[str, list[str]] = field(default_factory=lambda: dict(DEFAULT_SELECTORS))
+    source: str = "defaults"
+
+    @classmethod
+    def load(cls, override_path: str | os.PathLike[str] | None = None) -> "SelectorSet":
+        path_value = override_path or os.environ.get("APKPURE_SELECTORS_FILE", "")
+        if not path_value:
+            return cls()
+        path = Path(path_value).expanduser().resolve()
+        if not path.is_file():
+            raise FileNotFoundError(f"APKPure selector override file not found: {path}")
+        data: Any = json.loads(path.read_text(encoding="utf-8"))
+        if not isinstance(data, dict):
+            raise ValueError(f"APKPure selector override must be a JSON object: {path}")
+        merged = {key: list(value) for key, value in DEFAULT_SELECTORS.items()}
+        for key, value in data.items():
+            if isinstance(value, str):
+                merged[key] = [value]
+            elif isinstance(value, list) and all(isinstance(item, str) for item in value):
+                merged[key] = list(value)
+            else:
+                raise ValueError(
+                    f"APKPure selector override '{key}' must be a string or list of strings"
+                )
+        return cls(mapping=merged, source=str(path))
+
+    def candidates(self, key: str) -> list[str]:
+        if key not in self.mapping:
+            raise KeyError(f"Unknown APKPure selector key: {key}")
+        return self.mapping[key]
+
+    def keys(self) -> list[str]:
+        return sorted(self.mapping)
+
+
+def console_url(package_id: str) -> str:
+    return CONSOLE_URL_TEMPLATE.format(package_id=package_id)

--- a/tools/publish/cli.py
+++ b/tools/publish/cli.py
@@ -1,0 +1,319 @@
+"""Command line interface for the Airo publishing framework.
+
+    python3 -m tools.publish targets
+    python3 -m tools.publish fetch  --tag v0.0.6
+    python3 -m tools.publish plan   --tag v0.0.6 --profile tv --target apkpure
+    python3 -m tools.publish run    --tag v0.0.6 --profile tv --target apkpure --submit
+    python3 -m tools.publish login  apkpure
+    python3 -m tools.publish doctor apkpure --package-id io.airo.app.tv
+
+Artifacts always come from a published GitHub Release (`--tag`), never a local
+build; `--manifest` exists only for an already-downloaded release directory.
+`run` is submit-gated: it uploads and stages, and performs the irreversible
+store submission only when `--submit` is passed.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+
+from .apkpure.console import console_session, interactive_login
+from .apkpure.selectors import SelectorSet, console_url
+from .config import REPO_ROOT, PublishConfig
+from .errors import PublishError
+from .evidence import EvidenceRecorder
+from .fetch import fetch_release
+from .models import ReleaseMetadata
+from .publishers import PublishOptions, describe_targets
+from .publishers.apkpure import DEFAULT_STORAGE_STATE
+from .runner import RunRequest, exit_code_for, plan, run, summarise
+
+DEFAULT_EVIDENCE_DIR = REPO_ROOT / "build" / "publish-evidence"
+DEFAULT_DOWNLOAD_DIR = REPO_ROOT / "build" / "release-artifacts"
+DEFAULT_REPOSITORY = "DevelopersCoffee/airo"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="python3 -m tools.publish",
+        description="Publish Airo release artifacts to configured stores.",
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    sub.add_parser("targets", help="List configured publish targets.")
+
+    fetch = sub.add_parser("fetch", help="Download a GitHub Release's assets and list its manifests.")
+    fetch.add_argument("--tag", required=True, help="Release tag, e.g. v0.0.6")
+    fetch.add_argument("--repository", default=DEFAULT_REPOSITORY)
+    fetch.add_argument("--download-dir", type=Path, default=DEFAULT_DOWNLOAD_DIR)
+    fetch.add_argument("--clean", action="store_true", help="Empty the directory first.")
+
+    for name, help_text in (
+        ("plan", "Resolve manifest + config and print what would be published."),
+        ("run", "Publish to the selected targets."),
+    ):
+        cmd = sub.add_parser(name, help=help_text)
+        source = cmd.add_mutually_exclusive_group(required=True)
+        source.add_argument("--tag", help="GitHub Release tag to publish from, e.g. v0.0.6")
+        source.add_argument("--manifest", type=Path, help="Path to an already-downloaded Release-Manifest.json")
+        cmd.add_argument("--repository", default=DEFAULT_REPOSITORY)
+        cmd.add_argument("--download-dir", type=Path, default=DEFAULT_DOWNLOAD_DIR,
+                         help="Where --tag assets are downloaded.")
+        cmd.add_argument("--config", type=Path, default=None, help="Path to airo-publish-targets.json")
+        cmd.add_argument("--target", action="append", dest="targets", default=None,
+                         help="Target name; repeat for several. Default: every enabled target.")
+        cmd.add_argument("--profile", action="append", dest="profiles", default=None,
+                         help="Release profile id; repeat for several. Default: every configured profile.")
+        cmd.add_argument("--evidence-dir", type=Path, default=DEFAULT_EVIDENCE_DIR)
+        cmd.add_argument("--timeout-seconds", type=int, default=600)
+        cmd.add_argument("--quiet", action="store_true")
+        if name == "run":
+            cmd.add_argument("--dry-run", action="store_true",
+                             help="Resolve and log everything, contact no remote service.")
+            cmd.add_argument("--submit", action="store_true",
+                             help="Perform the irreversible store submission. Off by default.")
+            cmd.add_argument("--force", action="store_true",
+                             help="Re-upload even when the version already exists remotely.")
+            cmd.add_argument("--summary-file", type=Path, default=None,
+                             help="Write a markdown summary here (default: $GITHUB_STEP_SUMMARY).")
+            cmd.add_argument("--results-json", type=Path, default=None,
+                             help="Write machine-readable results here.")
+
+    login = sub.add_parser("login", help="Create or refresh a store browser session, by hand.")
+    login.add_argument("target", choices=["apkpure"])
+    login.add_argument("--storage-state", type=Path, default=None)
+
+    doctor = sub.add_parser("doctor", help="Dump a store console page so selectors can be re-mapped.")
+    doctor.add_argument("target", choices=["apkpure"])
+    doctor.add_argument("--package-id", default="io.airo.app.tv")
+    doctor.add_argument("--storage-state", type=Path, default=None)
+    doctor.add_argument("--evidence-dir", type=Path, default=DEFAULT_EVIDENCE_DIR)
+    doctor.add_argument("--headed", action="store_true")
+
+    return parser
+
+
+def cmd_targets(_args: argparse.Namespace) -> int:
+    print("Registered publishers:\n")
+    for name, description in describe_targets():
+        print(f"  {name:<10} {description}")
+    print(
+        "\nWhich of these actually run for a release is decided by "
+        ".github/airo-publish-targets.json."
+    )
+    return 0
+
+
+def _resolve_release(args: argparse.Namespace) -> ReleaseMetadata:
+    """Publishing sources artifacts from a GitHub Release, never a local build."""
+    if args.manifest:
+        return ReleaseMetadata.from_manifest_file(args.manifest)
+    only_profile = args.profiles[0] if args.profiles and len(args.profiles) == 1 else None
+    fetched = fetch_release(args.tag, args.download_dir, args.repository)
+    manifest = fetched.manifest_for(only_profile)
+    print(f"[info] {args.tag}: using {manifest.name} from {fetched.directory}", file=sys.stderr)
+    return ReleaseMetadata.from_manifest_file(manifest)
+
+
+def cmd_fetch(args: argparse.Namespace) -> int:
+    fetched = fetch_release(args.tag, args.download_dir, args.repository, clean=args.clean)
+    print(f"Downloaded {args.tag} to {fetched.directory}\n")
+    if not fetched.manifests:
+        print("No release manifest found in the assets.")
+        return 2
+    print("Manifests by profile:")
+    for profile_id, path in sorted(fetched.manifests.items()):
+        print(f"  {profile_id:<10} {path.name}")
+    return 0
+
+
+def _resolve_targets(config: PublishConfig, requested: list[str] | None) -> list[str]:
+    if requested:
+        return requested
+    return [name for name in config.target_names() if config.is_target_enabled(name)]
+
+
+def cmd_plan(args: argparse.Namespace) -> int:
+    release = _resolve_release(args)
+    config = PublishConfig.load(args.config)
+    request = RunRequest(
+        release=release,
+        config=config,
+        targets=_resolve_targets(config, args.targets),
+        profiles=args.profiles,
+        options=PublishOptions(dry_run=True, timeout_seconds=args.timeout_seconds),
+        evidence_dir=args.evidence_dir,
+        quiet=True,
+    )
+    resolved = plan(request)
+    entries = []
+    for profile_config, ctx in resolved.contexts:
+        entries.append(
+            {
+                "target": profile_config.target,
+                "targetEnabled": config.is_target_enabled(profile_config.target),
+                "profileId": profile_config.profile_id,
+                "profileEnabled": profile_config.enabled,
+                "packageId": profile_config.package_id or ctx.artifacts[0].package_id,
+                "artifacts": [artifact.to_dict() for artifact in ctx.artifacts],
+                "releaseNotesPreview": ctx.release_notes[:280],
+                "releaseNotesChars": len(ctx.release_notes),
+                "evidenceDir": str(ctx.evidence.root),
+            }
+        )
+    print(
+        json.dumps(
+            {
+                "release": {
+                    "version": release.version,
+                    "buildNumber": release.build_number,
+                    "sourceSha": release.source_sha,
+                    "manifest": str(release.manifest_path),
+                },
+                "plan": entries,
+                "notInManifest": [
+                    {"target": cfg.target, "profileId": cfg.profile_id, "reason": reason}
+                    for cfg, reason in resolved.not_in_manifest
+                ],
+            },
+            indent=2,
+        )
+    )
+    return 0
+
+
+def cmd_run(args: argparse.Namespace) -> int:
+    release = _resolve_release(args)
+    config = PublishConfig.load(args.config)
+    options = PublishOptions(
+        dry_run=args.dry_run,
+        submit=args.submit,
+        force=args.force,
+        timeout_seconds=args.timeout_seconds,
+    )
+    if options.submit and options.dry_run:
+        print("--submit is ignored with --dry-run", file=sys.stderr)
+
+    results = run(
+        RunRequest(
+            release=release,
+            config=config,
+            targets=_resolve_targets(config, args.targets),
+            profiles=args.profiles,
+            options=options,
+            evidence_dir=args.evidence_dir,
+            quiet=args.quiet,
+        )
+    )
+
+    summary = summarise(results, release)
+    summary_path = args.summary_file or (
+        Path(os.environ["GITHUB_STEP_SUMMARY"]) if os.environ.get("GITHUB_STEP_SUMMARY") else None
+    )
+    if summary_path:
+        with summary_path.open("a", encoding="utf-8") as handle:
+            handle.write(summary + "\n")
+    if not args.quiet:
+        print("\n" + summary)
+
+    payload = {
+        "version": release.version,
+        "buildNumber": release.build_number,
+        "results": [result.to_dict() for result in results],
+    }
+    if args.results_json:
+        args.results_json.parent.mkdir(parents=True, exist_ok=True)
+        args.results_json.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+    return exit_code_for(results)
+
+
+def _storage_state(args: argparse.Namespace) -> Path:
+    if args.storage_state:
+        return args.storage_state.expanduser()
+    configured = os.environ.get("APKPURE_STORAGE_STATE", "")
+    return Path(configured).expanduser() if configured else DEFAULT_STORAGE_STATE
+
+
+def cmd_login(args: argparse.Namespace) -> int:
+    state = _storage_state(args)
+    evidence = EvidenceRecorder(root=DEFAULT_EVIDENCE_DIR / "login" / args.target)
+    print(
+        "A browser window will open. Sign in to APKPure yourself — this tool never\n"
+        "reads, types, or stores your password. Only the resulting session cookies\n"
+        f"are saved, to:\n  {state}\n"
+    )
+    interactive_login(state, evidence)
+    print(f"\nSaved. Set APKPURE_STORAGE_STATE={state} for non-interactive runs.")
+    return 0
+
+
+def cmd_doctor(args: argparse.Namespace) -> int:
+    state = _storage_state(args)
+    evidence = EvidenceRecorder(root=args.evidence_dir / "doctor" / args.target)
+    selectors = SelectorSet.load()
+    evidence.log(f"selector source: {selectors.source}")
+    with console_session(
+        storage_state=state,
+        evidence=evidence,
+        selectors=selectors,
+        headless=not args.headed,
+    ) as session:
+        session.open_app(args.package_id)
+        report = {
+            "url": session.page.url,
+            "consoleUrl": console_url(args.package_id),
+            "selectorSource": selectors.source,
+            "matches": {
+                key: [
+                    candidate
+                    for candidate in selectors.candidates(key)
+                    if session.page.locator(candidate).count() > 0
+                ]
+                for key in selectors.keys()
+            },
+        }
+        session.open_upload_form()
+        session.snapshot("doctor-upload-form")
+        path = evidence.write_json("selector-report.json", report)
+    unmatched = [key for key, hits in report["matches"].items() if not hits]
+    print(f"Selector report: {path}")
+    if unmatched:
+        print("Selector keys with NO match on the live page:")
+        for key in unmatched:
+            print(f"  - {key}")
+        print(
+            "\nMap these against the HTML dumps in the evidence directory, write the new\n"
+            "selectors into a JSON file, and point APKPURE_SELECTORS_FILE at it."
+        )
+        return 2
+    print("Every selector key matched at least one element.")
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    handlers = {
+        "targets": cmd_targets,
+        "fetch": cmd_fetch,
+        "plan": cmd_plan,
+        "run": cmd_run,
+        "login": cmd_login,
+        "doctor": cmd_doctor,
+    }
+    try:
+        return handlers[args.command](args)
+    except PublishError as exc:
+        print(f"::error::{type(exc).__name__}: {exc}", file=sys.stderr)
+        return exc.exit_code
+    except KeyboardInterrupt:
+        print("interrupted", file=sys.stderr)
+        return 130
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/publish/config.py
+++ b/tools/publish/config.py
@@ -1,0 +1,349 @@
+"""Publish-target configuration.
+
+`.github/airo-publish-targets.json` says which stores exist, which release
+profile maps to which store listing, which artifact each store wants, and where
+release notes come from. Store-specific behaviour lives in a publisher; store
+*configuration* lives here so adding a listing never means editing Python.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Sequence
+
+from .errors import ConfigError
+from .models import Artifact, ReleaseMetadata
+
+SUPPORTED_SCHEMA_VERSIONS = frozenset({1})
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_CONFIG_PATH = REPO_ROOT / ".github" / "airo-publish-targets.json"
+
+
+def _as_tuple(value: Any, field_name: str) -> tuple[str, ...]:
+    if value is None:
+        return ()
+    if isinstance(value, str):
+        return (value,)
+    if isinstance(value, list) and all(isinstance(item, str) for item in value):
+        return tuple(value)
+    raise ConfigError(f"'{field_name}' must be a string or a list of strings, got {value!r}")
+
+
+@dataclass(frozen=True)
+class ArtifactSelector:
+    """Declarative rule picking this store's artifacts out of the manifest."""
+
+    artifact_types: tuple[str, ...] = ()
+    abis: tuple[str, ...] = ()
+    distribution_channels: tuple[str, ...] = ()
+    filename_contains: tuple[str, ...] = ()
+    filename_excludes: tuple[str, ...] = ()
+    #: Regex over the whole filename, with {version}/{buildNumber}/{profileId}
+    #: substituted from the artifact itself. Prefer this over `abi` when a store
+    #: needs one exact file: it does not depend on manifest-inferred fields.
+    filename_pattern: str | None = None
+    min_count: int = 1
+    max_count: int | None = None
+
+    @classmethod
+    def from_dict(cls, data: Any, context: str) -> "ArtifactSelector":
+        if data is None:
+            return cls()
+        if not isinstance(data, dict):
+            raise ConfigError(f"{context}.artifactSelector must be an object")
+        max_count = data.get("maxCount")
+        if max_count is not None and (not isinstance(max_count, int) or max_count < 1):
+            raise ConfigError(f"{context}.artifactSelector.maxCount must be a positive integer")
+        min_count = data.get("minCount", 1)
+        if not isinstance(min_count, int) or min_count < 0:
+            raise ConfigError(f"{context}.artifactSelector.minCount must be a non-negative integer")
+        pattern = data.get("filenamePattern")
+        if pattern is not None:
+            if not isinstance(pattern, str):
+                raise ConfigError(f"{context}.artifactSelector.filenamePattern must be a string")
+            try:
+                re.compile(pattern.format(version="0", buildNumber="0", profileId="x"))
+            except (re.error, KeyError, IndexError) as exc:
+                raise ConfigError(
+                    f"{context}.artifactSelector.filenamePattern is not a valid regex "
+                    f"template: {exc}"
+                ) from exc
+        return cls(
+            artifact_types=_as_tuple(data.get("artifactType"), f"{context}.artifactType"),
+            abis=_as_tuple(data.get("abi"), f"{context}.abi"),
+            distribution_channels=_as_tuple(
+                data.get("distributionChannel"), f"{context}.distributionChannel"
+            ),
+            filename_contains=_as_tuple(data.get("filenameContains"), f"{context}.filenameContains"),
+            filename_excludes=_as_tuple(data.get("filenameExcludes"), f"{context}.filenameExcludes"),
+            filename_pattern=pattern,
+            min_count=min_count,
+            max_count=max_count,
+        )
+
+    def matches(self, artifact: Artifact) -> bool:
+        name = artifact.filename.lower()
+        if self.filename_pattern is not None:
+            rendered = self.filename_pattern.format(
+                version=re.escape(artifact.version),
+                buildNumber=re.escape(artifact.build_number),
+                profileId=re.escape(artifact.profile_id),
+            )
+            if not re.fullmatch(rendered, artifact.filename):
+                return False
+        if self.artifact_types and artifact.artifact_type not in self.artifact_types:
+            return False
+        if self.abis and artifact.abi not in self.abis:
+            return False
+        if self.distribution_channels and artifact.distribution_channel not in self.distribution_channels:
+            return False
+        if self.filename_contains and not any(token.lower() in name for token in self.filename_contains):
+            return False
+        if any(token.lower() in name for token in self.filename_excludes):
+            return False
+        return True
+
+    def select(self, artifacts: Sequence[Artifact], context: str) -> list[Artifact]:
+        chosen = [artifact for artifact in artifacts if self.matches(artifact)]
+        if len(chosen) < self.min_count:
+            raise ConfigError(
+                f"{context}: artifact selector matched {len(chosen)} artifact(s), "
+                f"needs at least {self.min_count}. Available: "
+                + ", ".join(artifact.filename for artifact in artifacts)
+            )
+        if self.max_count is not None and len(chosen) > self.max_count:
+            raise ConfigError(
+                f"{context}: artifact selector matched {len(chosen)} artifact(s), "
+                f"at most {self.max_count} allowed: "
+                + ", ".join(artifact.filename for artifact in chosen)
+            )
+        return chosen
+
+
+@dataclass(frozen=True)
+class ReleaseNotesSource:
+    """Where the 'What's New' text for a listing comes from."""
+
+    source: str = "changelog"
+    path: str | None = None
+    text: str | None = None
+    heading_pattern: str | None = None
+    max_chars: int | None = None
+    fallback: str | None = None
+
+    @classmethod
+    def from_dict(cls, data: Any, context: str) -> "ReleaseNotesSource":
+        if data is None:
+            return cls()
+        if not isinstance(data, dict):
+            raise ConfigError(f"{context}.releaseNotes must be an object")
+        source = data.get("source", "changelog")
+        if source not in {"changelog", "file", "inline"}:
+            raise ConfigError(
+                f"{context}.releaseNotes.source must be one of changelog|file|inline, got {source!r}"
+            )
+        if source in {"changelog", "file"} and not data.get("path"):
+            raise ConfigError(f"{context}.releaseNotes.path is required for source={source}")
+        if source == "inline" and not data.get("text"):
+            raise ConfigError(f"{context}.releaseNotes.text is required for source=inline")
+        max_chars = data.get("maxChars")
+        if max_chars is not None and (not isinstance(max_chars, int) or max_chars < 1):
+            raise ConfigError(f"{context}.releaseNotes.maxChars must be a positive integer")
+        return cls(
+            source=source,
+            path=data.get("path"),
+            text=data.get("text"),
+            heading_pattern=data.get("headingPattern"),
+            max_chars=max_chars,
+            fallback=data.get("fallback"),
+        )
+
+    def resolve(self, release: ReleaseMetadata, profile_id: str, repo_root: Path = REPO_ROOT) -> str:
+        if self.source == "inline":
+            notes = (self.text or "").strip()
+        else:
+            notes = self._read_from_disk(release, profile_id, repo_root)
+        if not notes:
+            notes = (self.fallback or "").strip()
+        if not notes:
+            raise ConfigError(
+                f"Release notes for profile {profile_id!r} resolved to an empty string. "
+                "Add a matching CHANGELOG section, point releaseNotes.path at a real file, "
+                "or set releaseNotes.fallback."
+            )
+        if self.max_chars is not None and len(notes) > self.max_chars:
+            notes = notes[: self.max_chars - 1].rstrip() + "…"
+        return notes
+
+    def _read_from_disk(self, release: ReleaseMetadata, profile_id: str, repo_root: Path) -> str:
+        raw_path = (self.path or "").format(
+            version=release.version,
+            buildNumber=release.build_number,
+            profileId=profile_id,
+        )
+        # Resolve both sides: on macOS the temp dir and /var are symlinks, so an
+        # unresolved root would reject perfectly legitimate paths.
+        root = repo_root.resolve()
+        resolved = (root / raw_path).resolve()
+        try:
+            resolved.relative_to(root)
+        except ValueError as exc:
+            raise ConfigError(f"releaseNotes.path must stay inside the repository: {resolved}") from exc
+        if not resolved.is_file():
+            if self.fallback:
+                return ""
+            raise ConfigError(f"Release notes file not found: {resolved}")
+        content = resolved.read_text(encoding="utf-8")
+        if self.source == "file":
+            return content.strip()
+        return self._extract_changelog_section(content, release, profile_id)
+
+    def _extract_changelog_section(
+        self, content: str, release: ReleaseMetadata, profile_id: str
+    ) -> str:
+        pattern = self.heading_pattern or r"^##\s+.*{version}.*$"
+        rendered = pattern.format(
+            version=re.escape(release.version),
+            buildNumber=re.escape(release.build_number),
+            profileId=re.escape(profile_id),
+        )
+        try:
+            heading = re.compile(rendered, re.MULTILINE)
+        except re.error as exc:
+            raise ConfigError(f"releaseNotes.headingPattern is not a valid regex: {exc}") from exc
+        match = heading.search(content)
+        if not match:
+            return ""
+        rest = content[match.end() :]
+        next_heading = re.search(r"^##\s+", rest, re.MULTILINE)
+        section = rest[: next_heading.start()] if next_heading else rest
+        return section.strip()
+
+
+@dataclass(frozen=True)
+class TargetProfileConfig:
+    """One store listing for one release profile."""
+
+    target: str
+    profile_id: str
+    enabled: bool
+    package_id: str | None
+    selector: ArtifactSelector
+    release_notes: ReleaseNotesSource
+    options: dict[str, Any] = field(default_factory=dict)
+
+    @property
+    def context(self) -> str:
+        return f"targets.{self.target}.profiles.{self.profile_id}"
+
+    def option(self, key: str, default: Any = None) -> Any:
+        return self.options.get(key, default)
+
+    def require_option(self, key: str) -> Any:
+        if key not in self.options or self.options[key] in (None, ""):
+            raise ConfigError(f"{self.context}.options.{key} is required but not set")
+        return self.options[key]
+
+    def select_artifacts(self, release: ReleaseMetadata) -> list[Artifact]:
+        candidates = [a for a in release.artifacts if a.profile_id == self.profile_id]
+        if not candidates:
+            raise ConfigError(
+                f"{self.context}: release manifest has no artifacts for profile {self.profile_id!r}. "
+                f"Manifest profiles: {', '.join(release.profile_ids()) or '<none>'}"
+            )
+        if self.package_id:
+            mismatched = [a for a in candidates if a.package_id != self.package_id]
+            candidates = [a for a in candidates if a.package_id == self.package_id]
+            if not candidates:
+                raise ConfigError(
+                    f"{self.context}: no artifact has packageId {self.package_id!r}. "
+                    f"Saw: {', '.join(sorted({a.package_id for a in mismatched}))}"
+                )
+        return self.selector.select(candidates, self.context)
+
+
+@dataclass(frozen=True)
+class PublishConfig:
+    """The whole `.github/airo-publish-targets.json` file."""
+
+    path: Path
+    targets: dict[str, dict[str, TargetProfileConfig]]
+    target_enabled: dict[str, bool]
+
+    @classmethod
+    def load(cls, path: Path | None = None) -> "PublishConfig":
+        config_path = (path or DEFAULT_CONFIG_PATH).expanduser().resolve()
+        if not config_path.is_file():
+            raise ConfigError(f"Publish target config not found: {config_path}")
+        try:
+            data = json.loads(config_path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError as exc:
+            raise ConfigError(f"Publish target config is not valid JSON: {config_path}: {exc}") from exc
+        if not isinstance(data, dict):
+            raise ConfigError(f"Publish target config must be a JSON object: {config_path}")
+        if data.get("schemaVersion") not in SUPPORTED_SCHEMA_VERSIONS:
+            supported = ", ".join(str(value) for value in sorted(SUPPORTED_SCHEMA_VERSIONS))
+            raise ConfigError(
+                f"Unsupported publish config schemaVersion {data.get('schemaVersion')!r} "
+                f"(supported: {supported})"
+            )
+
+        raw_targets = data.get("targets")
+        if not isinstance(raw_targets, dict) or not raw_targets:
+            raise ConfigError("Publish target config needs a non-empty 'targets' object")
+
+        targets: dict[str, dict[str, TargetProfileConfig]] = {}
+        target_enabled: dict[str, bool] = {}
+        for target_name, raw_target in raw_targets.items():
+            if not isinstance(raw_target, dict):
+                raise ConfigError(f"targets.{target_name} must be an object")
+            target_enabled[target_name] = bool(raw_target.get("enabled", True))
+            raw_profiles = raw_target.get("profiles")
+            if not isinstance(raw_profiles, dict) or not raw_profiles:
+                raise ConfigError(f"targets.{target_name}.profiles must be a non-empty object")
+            profiles: dict[str, TargetProfileConfig] = {}
+            for profile_id, raw_profile in raw_profiles.items():
+                if not isinstance(raw_profile, dict):
+                    raise ConfigError(f"targets.{target_name}.profiles.{profile_id} must be an object")
+                context = f"targets.{target_name}.profiles.{profile_id}"
+                options = raw_profile.get("options", {})
+                if not isinstance(options, dict):
+                    raise ConfigError(f"{context}.options must be an object")
+                profiles[profile_id] = TargetProfileConfig(
+                    target=target_name,
+                    profile_id=profile_id,
+                    enabled=bool(raw_profile.get("enabled", True)),
+                    package_id=raw_profile.get("packageId"),
+                    selector=ArtifactSelector.from_dict(raw_profile.get("artifactSelector"), context),
+                    release_notes=ReleaseNotesSource.from_dict(raw_profile.get("releaseNotes"), context),
+                    options=options,
+                )
+            targets[target_name] = profiles
+
+        return cls(path=config_path, targets=targets, target_enabled=target_enabled)
+
+    def target_names(self) -> tuple[str, ...]:
+        return tuple(sorted(self.targets))
+
+    def is_target_enabled(self, target: str) -> bool:
+        return self.target_enabled.get(target, False)
+
+    def profiles_for(self, target: str, profile_filter: Sequence[str] | None = None) -> list[TargetProfileConfig]:
+        if target not in self.targets:
+            raise ConfigError(
+                f"Unknown publish target {target!r}. Configured: {', '.join(self.target_names())}"
+            )
+        profiles = self.targets[target]
+        if profile_filter:
+            missing = [p for p in profile_filter if p not in profiles]
+            if missing:
+                raise ConfigError(
+                    f"targets.{target} has no profile(s) {', '.join(missing)}. "
+                    f"Configured: {', '.join(sorted(profiles))}"
+                )
+            return [profiles[p] for p in profile_filter]
+        return [profiles[key] for key in sorted(profiles)]

--- a/tools/publish/errors.py
+++ b/tools/publish/errors.py
@@ -1,0 +1,49 @@
+"""Error types for the Airo publishing framework.
+
+Every failure path in this package raises one of these so the CLI can map a
+failure to an exit code without string-matching exception messages.
+"""
+
+from __future__ import annotations
+
+
+class PublishError(Exception):
+    """Base class for every publishing failure."""
+
+    exit_code = 1
+
+
+class ManifestError(PublishError):
+    """The release manifest is missing, malformed, or an unsupported schema."""
+
+    exit_code = 2
+
+
+class ArtifactIntegrityError(PublishError):
+    """An artifact is missing, the wrong size, or fails its recorded checksum."""
+
+    exit_code = 3
+
+
+class ConfigError(PublishError):
+    """The publish-targets configuration is missing, malformed, or incomplete."""
+
+    exit_code = 4
+
+
+class PreflightError(PublishError):
+    """A publisher refused to run because a precondition was not met."""
+
+    exit_code = 5
+
+
+class CredentialError(PreflightError):
+    """A required credential or session state is absent or unusable."""
+
+    exit_code = 6
+
+
+class RemoteError(PublishError):
+    """The remote store rejected the release or the automation lost its way."""
+
+    exit_code = 7

--- a/tools/publish/evidence.py
+++ b/tools/publish/evidence.py
@@ -1,0 +1,83 @@
+"""Audit evidence for every publish attempt.
+
+A store upload is an outward-facing, hard-to-reverse action. Each attempt writes
+a timestamped directory holding the resolved plan, the console log, and any
+screenshots or page dumps a browser-driven publisher captured, so a release can
+be reconstructed after the fact without re-opening the store console.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+@dataclass
+class EvidenceRecorder:
+    """Writes logs and files under one publish attempt's evidence directory."""
+
+    root: Path
+    quiet: bool = False
+
+    def __post_init__(self) -> None:
+        self.root = self.root.expanduser().resolve()
+        self.root.mkdir(parents=True, exist_ok=True)
+        self._log_path = self.root / "publish.log"
+        self._written: list[Path] = []
+
+    @classmethod
+    def for_attempt(
+        cls, base_dir: Path, target: str, profile_id: str, version: str, quiet: bool = False
+    ) -> "EvidenceRecorder":
+        safe = lambda value: "".join(c if c.isalnum() or c in "-._" else "-" for c in value)
+        return cls(root=base_dir / safe(target) / safe(profile_id) / safe(version), quiet=quiet)
+
+    def log(self, message: str, level: str = "info") -> None:
+        line = f"[{level}] {message}"
+        with self._log_path.open("a", encoding="utf-8") as handle:
+            handle.write(line + "\n")
+        if not self.quiet:
+            stream = sys.stderr if level in {"warn", "error"} else sys.stdout
+            print(line, file=stream, flush=True)
+
+    def warn(self, message: str) -> None:
+        self.log(message, level="warn")
+
+    def error(self, message: str) -> None:
+        self.log(message, level="error")
+
+    def write_json(self, name: str, payload: Any) -> Path:
+        path = self.root / name
+        path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+        self._written.append(path)
+        return path
+
+    def write_text(self, name: str, content: str) -> Path:
+        path = self.root / name
+        path.write_text(content, encoding="utf-8")
+        self._written.append(path)
+        return path
+
+    def write_bytes(self, name: str, content: bytes) -> Path:
+        path = self.root / name
+        path.write_bytes(content)
+        self._written.append(path)
+        return path
+
+    def file_path(self, name: str) -> Path:
+        """Reserve a path a third-party tool (Playwright, gh) will write to."""
+        path = self.root / name
+        self._written.append(path)
+        return path
+
+    def artifacts(self) -> list[str]:
+        seen: list[str] = []
+        for path in [self._log_path, *self._written]:
+            if path.exists():
+                text = str(path)
+                if text not in seen:
+                    seen.append(text)
+        return seen

--- a/tools/publish/fetch.py
+++ b/tools/publish/fetch.py
@@ -1,0 +1,115 @@
+"""Pull release artifacts from a GitHub Release.
+
+Publishing never builds. Every store upload starts from the exact assets that
+were attached to a published GitHub Release, so a store and the release page can
+never disagree about what shipped.
+
+One release tag can carry several profiles (`Airo-…`, `Airo-TV-…`,
+`AiroCoins-…`), each with its own `*-Release-Manifest.json`. This module
+downloads once and then resolves the right manifest for the profile you asked
+for.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import shutil
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+
+from .errors import ManifestError, PublishError, RemoteError
+
+MANIFEST_GLOB = "*Release-Manifest.json"
+
+
+@dataclass(frozen=True)
+class FetchedRelease:
+    tag: str
+    directory: Path
+    manifests: dict[str, Path]
+
+    def manifest_for(self, profile_id: str | None) -> Path:
+        if not self.manifests:
+            raise ManifestError(
+                f"No {MANIFEST_GLOB} asset found on release {self.tag}. "
+                "The release was published without a machine-readable manifest."
+            )
+        if profile_id:
+            if profile_id not in self.manifests:
+                raise ManifestError(
+                    f"Release {self.tag} has no manifest for profile {profile_id!r}. "
+                    f"Available: {', '.join(sorted(self.manifests))}"
+                )
+            return self.manifests[profile_id]
+        if len(self.manifests) > 1:
+            raise ManifestError(
+                f"Release {self.tag} carries {len(self.manifests)} manifests "
+                f"({', '.join(sorted(self.manifests))}). Pass --profile to choose one."
+            )
+        return next(iter(self.manifests.values()))
+
+
+def fetch_release(
+    tag: str,
+    destination: Path,
+    repository: str = "DevelopersCoffee/airo",
+    clean: bool = False,
+) -> FetchedRelease:
+    """Download every asset of `tag` into `destination` and index the manifests."""
+    if shutil.which("gh") is None:
+        raise PublishError("The GitHub CLI (`gh`) is required to fetch release assets.")
+    if not re.fullmatch(r"[A-Za-z0-9._/-]+", tag):
+        raise PublishError(f"Refusing to use an unsafe release tag: {tag!r}")
+
+    destination = destination.expanduser().resolve()
+    if clean and destination.exists():
+        shutil.rmtree(destination)
+    destination.mkdir(parents=True, exist_ok=True)
+
+    completed = subprocess.run(
+        ["gh", "release", "download", tag, "--repo", repository, "--dir", str(destination), "--clobber"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if completed.returncode != 0:
+        raise RemoteError(
+            f"gh release download {tag} failed: "
+            f"{(completed.stderr or completed.stdout).strip()[:1000]}"
+        )
+
+    return FetchedRelease(tag=tag, directory=destination, manifests=index_manifests(destination))
+
+
+def index_manifests(directory: Path) -> dict[str, Path]:
+    """Map profile id -> the most complete manifest covering that profile.
+
+    A release tag can carry both a per-leg manifest (`Airo-TV-…`) and a combined
+    orchestrator manifest (`Airo-…`) that covers several profiles. Both are
+    valid; the one describing more of the profile's artifacts is the one to
+    publish from, because a manifest that omits an artifact silently omits it
+    from the store upload too. Ties break on filename so the choice is stable.
+    """
+    coverage: dict[str, list[tuple[int, str, Path]]] = {}
+    for path in sorted(directory.glob(MANIFEST_GLOB)):
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+            entries = data.get("artifacts") or []
+        except (json.JSONDecodeError, AttributeError, TypeError):
+            continue
+        if not isinstance(entries, list):
+            continue
+        counts: dict[str, int] = {}
+        for entry in entries:
+            if isinstance(entry, dict) and entry.get("profileId"):
+                profile_id = str(entry["profileId"])
+                counts[profile_id] = counts.get(profile_id, 0) + 1
+        for profile_id, count in counts.items():
+            coverage.setdefault(profile_id, []).append((count, path.name, path))
+
+    return {
+        profile_id: max(candidates, key=lambda item: (item[0], item[1]))[2]
+        for profile_id, candidates in coverage.items()
+    }

--- a/tools/publish/models.py
+++ b/tools/publish/models.py
@@ -1,0 +1,238 @@
+"""Typed release metadata shared by every store publisher.
+
+The single source of truth is the release manifest already produced by
+``scripts/generate-release-manifest.py``. Publishers never re-derive version,
+package id, ABI, or checksum information: they read it from here so a store
+upload can only ever describe the exact bytes that were built and hashed.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass, field
+from enum import Enum
+from pathlib import Path
+from typing import Any, Iterable
+
+from .errors import ArtifactIntegrityError, ManifestError
+
+SUPPORTED_SCHEMA_VERSIONS = frozenset({1})
+
+_CHUNK = 1024 * 1024
+
+
+def _require(entry: dict[str, Any], key: str, context: str) -> Any:
+    if key not in entry:
+        raise ManifestError(f"{context} is missing required field '{key}'")
+    return entry[key]
+
+
+@dataclass(frozen=True)
+class Artifact:
+    """One built file plus everything a store needs to describe it."""
+
+    filename: str
+    profile_id: str
+    package_id: str
+    version: str
+    build_number: str
+    artifact_type: str
+    abi: str
+    distribution_channel: str
+    size_bytes: int
+    sha256: str
+    path: Path
+    extra: dict[str, Any] = field(default_factory=dict, repr=False)
+
+    @classmethod
+    def from_manifest_entry(cls, entry: dict[str, Any], artifacts_dir: Path) -> "Artifact":
+        context = f"Artifact entry {entry.get('filename', '<unnamed>')!r}"
+        known = {
+            "filename",
+            "profileId",
+            "packageId",
+            "version",
+            "buildNumber",
+            "artifactType",
+            "abi",
+            "distributionChannel",
+            "sizeBytes",
+            "sha256",
+        }
+        filename = str(_require(entry, "filename", context))
+        if "/" in filename or "\\" in filename or filename in {"", ".", ".."}:
+            raise ManifestError(f"{context} has an unsafe filename: {filename!r}")
+        return cls(
+            filename=filename,
+            profile_id=str(_require(entry, "profileId", context)),
+            package_id=str(_require(entry, "packageId", context)),
+            version=str(_require(entry, "version", context)),
+            build_number=str(_require(entry, "buildNumber", context)),
+            artifact_type=str(_require(entry, "artifactType", context)),
+            abi=str(entry.get("abi", "unknown")),
+            distribution_channel=str(entry.get("distributionChannel", "unknown")),
+            size_bytes=int(_require(entry, "sizeBytes", context)),
+            sha256=str(_require(entry, "sha256", context)).lower(),
+            path=artifacts_dir / filename,
+            extra={key: value for key, value in entry.items() if key not in known},
+        )
+
+    def verify(self) -> None:
+        """Fail loudly if the bytes on disk are not the bytes that were hashed."""
+        if not self.path.is_file():
+            raise ArtifactIntegrityError(f"Artifact is missing on disk: {self.path}")
+        actual_size = self.path.stat().st_size
+        if actual_size != self.size_bytes:
+            raise ArtifactIntegrityError(
+                f"{self.filename}: manifest says {self.size_bytes} bytes, "
+                f"file on disk is {actual_size} bytes"
+            )
+        digest = hashlib.sha256()
+        with self.path.open("rb") as handle:
+            for chunk in iter(lambda: handle.read(_CHUNK), b""):
+                digest.update(chunk)
+        actual_sha = digest.hexdigest()
+        if actual_sha != self.sha256:
+            raise ArtifactIntegrityError(
+                f"{self.filename}: manifest sha256 {self.sha256} != on-disk {actual_sha}"
+            )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "filename": self.filename,
+            "profileId": self.profile_id,
+            "packageId": self.package_id,
+            "version": self.version,
+            "buildNumber": self.build_number,
+            "artifactType": self.artifact_type,
+            "abi": self.abi,
+            "distributionChannel": self.distribution_channel,
+            "sizeBytes": self.size_bytes,
+            "sha256": self.sha256,
+        }
+
+
+@dataclass(frozen=True)
+class ReleaseMetadata:
+    """A parsed release manifest: the contract every publisher consumes."""
+
+    version: str
+    build_number: str
+    source_ref: str
+    source_sha: str
+    workflow_name: str
+    workflow_run: str
+    workflow_run_url: str
+    generated_at: str
+    artifacts: tuple[Artifact, ...]
+    manifest_path: Path
+    artifacts_dir: Path
+
+    @classmethod
+    def from_manifest_file(cls, manifest_path: Path) -> "ReleaseMetadata":
+        manifest_path = manifest_path.expanduser().resolve()
+        if not manifest_path.is_file():
+            raise ManifestError(f"Release manifest not found: {manifest_path}")
+        try:
+            data = json.loads(manifest_path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError as exc:
+            raise ManifestError(f"Release manifest is not valid JSON: {manifest_path}: {exc}") from exc
+        if not isinstance(data, dict):
+            raise ManifestError(f"Release manifest must be a JSON object: {manifest_path}")
+
+        schema_version = data.get("schemaVersion")
+        if schema_version not in SUPPORTED_SCHEMA_VERSIONS:
+            supported = ", ".join(str(value) for value in sorted(SUPPORTED_SCHEMA_VERSIONS))
+            raise ManifestError(
+                f"Unsupported release manifest schemaVersion {schema_version!r} "
+                f"(supported: {supported})"
+            )
+
+        release = data.get("release")
+        if not isinstance(release, dict):
+            raise ManifestError("Release manifest is missing the 'release' object")
+
+        raw_artifacts = data.get("artifacts")
+        if not isinstance(raw_artifacts, list):
+            raise ManifestError("Release manifest is missing the 'artifacts' array")
+
+        artifacts_dir = manifest_path.parent
+        artifacts = tuple(
+            Artifact.from_manifest_entry(entry, artifacts_dir) for entry in raw_artifacts
+        )
+
+        return cls(
+            version=str(_require(release, "version", "Release manifest 'release'")),
+            build_number=str(release.get("buildNumber", "unknown")),
+            source_ref=str(release.get("sourceRef", "unknown")),
+            source_sha=str(release.get("sourceSha", "unknown")),
+            workflow_name=str(release.get("workflowName", "unknown")),
+            workflow_run=str(release.get("workflowRun", "unknown")),
+            workflow_run_url=str(release.get("workflowRunUrl", "")),
+            generated_at=str(data.get("generatedAt", "unknown")),
+            artifacts=artifacts,
+            manifest_path=manifest_path,
+            artifacts_dir=artifacts_dir,
+        )
+
+    def verify_artifacts(self, artifacts: Iterable[Artifact] | None = None) -> None:
+        for artifact in artifacts if artifacts is not None else self.artifacts:
+            artifact.verify()
+
+    def profile_ids(self) -> tuple[str, ...]:
+        seen: list[str] = []
+        for artifact in self.artifacts:
+            if artifact.profile_id not in seen:
+                seen.append(artifact.profile_id)
+        return tuple(seen)
+
+    def tag(self) -> str:
+        """The GitHub Release tag this manifest describes."""
+        return self.version
+
+
+class PublishStatus(str, Enum):
+    SUCCEEDED = "succeeded"
+    SKIPPED = "skipped"
+    DRY_RUN = "dry_run"
+    STAGED = "staged"
+    BLOCKED = "blocked"
+    FAILED = "failed"
+
+    @property
+    def ok(self) -> bool:
+        return self in {
+            PublishStatus.SUCCEEDED,
+            PublishStatus.SKIPPED,
+            PublishStatus.DRY_RUN,
+            PublishStatus.STAGED,
+        }
+
+
+@dataclass
+class PublishResult:
+    """What a publisher did, in a form that survives into CI job summaries."""
+
+    target: str
+    profile_id: str
+    status: PublishStatus
+    message: str
+    artifacts: list[str] = field(default_factory=list)
+    evidence: list[str] = field(default_factory=list)
+    details: dict[str, Any] = field(default_factory=dict)
+
+    @property
+    def ok(self) -> bool:
+        return self.status.ok
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "target": self.target,
+            "profileId": self.profile_id,
+            "status": self.status.value,
+            "message": self.message,
+            "artifacts": list(self.artifacts),
+            "evidence": list(self.evidence),
+            "details": dict(self.details),
+        }

--- a/tools/publish/publishers/__init__.py
+++ b/tools/publish/publishers/__init__.py
@@ -1,0 +1,51 @@
+"""Store publishers and the registry that resolves them by name."""
+
+from __future__ import annotations
+
+from ..errors import ConfigError
+from .apkpure import ApkPurePublisher
+from .base import ManualPublisher, PublishContext, Publisher, PublishOptions
+from .github import GitHubPublisher
+from .manual_stores import AmazonAppstorePublisher, FDroidPublisher, HuaweiAppGalleryPublisher
+from .play_store import PlayStorePublisher
+from .website import WebsitePublisher
+
+_REGISTRY: dict[str, type[Publisher]] = {
+    publisher.name: publisher
+    for publisher in (
+        GitHubPublisher,
+        PlayStorePublisher,
+        ApkPurePublisher,
+        AmazonAppstorePublisher,
+        HuaweiAppGalleryPublisher,
+        FDroidPublisher,
+        WebsitePublisher,
+    )
+}
+
+
+def available_targets() -> tuple[str, ...]:
+    return tuple(sorted(_REGISTRY))
+
+
+def describe_targets() -> list[tuple[str, str]]:
+    return [(name, _REGISTRY[name].description) for name in available_targets()]
+
+
+def get_publisher(name: str) -> Publisher:
+    if name not in _REGISTRY:
+        raise ConfigError(
+            f"No publisher named {name!r}. Available: {', '.join(available_targets())}"
+        )
+    return _REGISTRY[name]()
+
+
+__all__ = [
+    "ManualPublisher",
+    "PublishContext",
+    "PublishOptions",
+    "Publisher",
+    "available_targets",
+    "describe_targets",
+    "get_publisher",
+]

--- a/tools/publish/publishers/apkpure.py
+++ b/tools/publish/publishers/apkpure.py
@@ -1,0 +1,129 @@
+"""APKPure publisher.
+
+APKPure exposes no publishing API, so this drives their Developer Console with
+Playwright. Two consequences shape the design:
+
+* The run is only as trustworthy as its evidence. Every stage writes a
+  screenshot and an HTML dump, and the final state is recorded as JSON.
+* Nothing irreversible happens by default. Without ``--submit`` the APK is
+  uploaded and the release notes are filled, but the version is left unsubmitted
+  for a human to review in the console.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import ClassVar
+
+from ..apkpure.console import console_session
+from ..apkpure.selectors import SelectorSet, console_url
+from ..errors import ConfigError
+from ..models import PublishResult, PublishStatus
+from .base import Publisher, PublishContext
+
+DEFAULT_STORAGE_STATE = Path.home() / ".config" / "airo" / "apkpure-session.json"
+
+
+def storage_state_path(ctx: PublishContext) -> Path:
+    configured = ctx.config.option("storageState") or ctx.env.get("APKPURE_STORAGE_STATE", "")
+    return Path(configured).expanduser() if configured else DEFAULT_STORAGE_STATE
+
+
+class ApkPurePublisher(Publisher):
+    name: ClassVar[str] = "apkpure"
+    description: ClassVar[str] = "APKPure Developer Console upload (Playwright, no public API)"
+    needs_browser_session: ClassVar[bool] = True
+
+    def preflight(self, ctx: PublishContext) -> list[str]:
+        blockers = super().preflight(ctx)
+        if not ctx.options.dry_run:
+            state = storage_state_path(ctx)
+            if not state.is_file():
+                blockers.append(
+                    f"no APKPure session state at {state}; run "
+                    "`python3 -m tools.publish login apkpure` first"
+                )
+        return blockers
+
+    def publish(self, ctx: PublishContext) -> PublishResult:
+        artifact = ctx.sole_artifact()
+        if artifact.artifact_type != "apk":
+            raise ConfigError(
+                f"{ctx.config.context}: APKPure distributes APKs, selector chose "
+                f"{artifact.filename} ({artifact.artifact_type})."
+            )
+        package_id = ctx.config.package_id or artifact.package_id
+        target_url = console_url(package_id)
+
+        plan = {
+            "packageId": package_id,
+            "consoleUrl": target_url,
+            "apk": artifact.filename,
+            "sha256": artifact.sha256,
+            "version": artifact.version,
+            "buildNumber": artifact.build_number,
+            "abi": artifact.abi,
+            "releaseNotesChars": len(ctx.release_notes),
+            "willSubmit": ctx.options.may_submit,
+        }
+        ctx.evidence.write_json("apkpure-plan.json", plan)
+        ctx.evidence.write_text("release-notes.txt", ctx.release_notes)
+
+        if ctx.options.dry_run:
+            return self.result(
+                ctx,
+                PublishStatus.DRY_RUN,
+                f"Would upload {artifact.filename} to {target_url}",
+                plan,
+            )
+
+        selectors = SelectorSet.load(ctx.config.option("selectorsFile"))
+        ctx.evidence.log(f"selector source: {selectors.source}")
+        headless = bool(ctx.config.option("headless", True))
+        state = storage_state_path(ctx)
+
+        with console_session(
+            storage_state=state,
+            evidence=ctx.evidence,
+            selectors=selectors,
+            headless=headless,
+            timeout_ms=ctx.options.timeout_seconds * 1000,
+        ) as session:
+            session.open_app(package_id)
+
+            existing = session.published_versions()
+            already = [row for row in existing if artifact.version in row]
+            if already and not ctx.options.force:
+                ctx.evidence.log(f"version {artifact.version} already listed: {already[0]!r}")
+                return self.result(
+                    ctx,
+                    PublishStatus.SKIPPED,
+                    f"Version {artifact.version} already present on APKPure; pass --force to upload anyway",
+                    {**plan, "existingRow": already[0]},
+                )
+
+            session.open_upload_form()
+            session.upload_apk(artifact.path)
+            session.fill_release_notes(ctx.release_notes)
+
+            if not ctx.options.may_submit:
+                ctx.evidence.warn(
+                    "Stopped before Submit for Review. The version is uploaded but not submitted; "
+                    "review it in the console, or re-run with --submit."
+                )
+                return self.result(
+                    ctx,
+                    PublishStatus.STAGED,
+                    f"Uploaded {artifact.filename} and staged release notes; not submitted",
+                    plan,
+                )
+
+            session.submit_for_review()
+
+        ctx.evidence.write_json("apkpure-result.json", {**plan, "submitted": True})
+        return self.result(
+            ctx,
+            PublishStatus.SUCCEEDED,
+            f"Submitted {artifact.filename} to APKPure review for {package_id}",
+            {**plan, "submitted": True},
+        )

--- a/tools/publish/publishers/base.py
+++ b/tools/publish/publishers/base.py
@@ -1,0 +1,203 @@
+"""The Publisher contract every store implementation satisfies.
+
+One interface, one manifest, one evidence trail. A publisher may not read the
+build tree, re-hash artifacts, or invent version strings: everything it needs
+arrives in `PublishContext`.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import ClassVar, Sequence
+
+from ..config import TargetProfileConfig
+from ..errors import CredentialError, PreflightError, RemoteError
+from ..evidence import EvidenceRecorder
+from ..models import Artifact, PublishResult, PublishStatus, ReleaseMetadata
+
+
+@dataclass(frozen=True)
+class PublishOptions:
+    """Caller-supplied switches shared by every publisher."""
+
+    dry_run: bool = False
+    # Browser-driven and store publishers stop before the irreversible final
+    # submit unless the caller explicitly opts in.
+    submit: bool = False
+    force: bool = False
+    timeout_seconds: int = 600
+
+    @property
+    def may_submit(self) -> bool:
+        return self.submit and not self.dry_run
+
+
+@dataclass
+class PublishContext:
+    """Everything one publisher needs for one profile."""
+
+    release: ReleaseMetadata
+    config: TargetProfileConfig
+    artifacts: list[Artifact]
+    options: PublishOptions
+    evidence: EvidenceRecorder
+    release_notes: str
+    env: dict[str, str] = field(default_factory=lambda: dict(os.environ))
+
+    @property
+    def profile_id(self) -> str:
+        return self.config.profile_id
+
+    @property
+    def version(self) -> str:
+        return self.release.version
+
+    def require_env(self, name: str, hint: str) -> str:
+        value = self.env.get(name, "").strip()
+        if not value:
+            raise CredentialError(f"{name} is not set. {hint}")
+        return value
+
+    def sole_artifact(self) -> Artifact:
+        if len(self.artifacts) != 1:
+            raise PreflightError(
+                f"{self.config.context}: expected exactly one artifact, got "
+                f"{len(self.artifacts)}: {', '.join(a.filename for a in self.artifacts)}. "
+                "Tighten artifactSelector."
+            )
+        return self.artifacts[0]
+
+
+class Publisher(ABC):
+    """Base class for every store publisher."""
+
+    name: ClassVar[str]
+    #: Human-readable description used by `publish targets`.
+    description: ClassVar[str] = ""
+    #: Env vars that must be present before this publisher will run for real.
+    required_env: ClassVar[tuple[str, ...]] = ()
+    #: External binaries this publisher shells out to.
+    required_binaries: ClassVar[tuple[str, ...]] = ()
+    #: True when the publisher drives a browser and needs a logged-in session.
+    needs_browser_session: ClassVar[bool] = False
+
+    def preflight(self, ctx: PublishContext) -> list[str]:
+        """Return blocking reasons. Empty list means good to go."""
+        blockers: list[str] = []
+        # A dry run contacts nothing and executes nothing, so missing tools and
+        # credentials must not block it — that is the whole point of planning
+        # a release from a machine that cannot publish one.
+        if ctx.options.dry_run:
+            return blockers
+        for binary in self.required_binaries:
+            if shutil.which(binary) is None:
+                blockers.append(f"required binary {binary!r} is not on PATH")
+        for name in self.required_env:
+            if not ctx.env.get(name, "").strip():
+                blockers.append(f"required environment variable {name} is not set")
+        return blockers
+
+    @abstractmethod
+    def publish(self, ctx: PublishContext) -> PublishResult:
+        """Do the upload. Must be safe to call twice for the same version."""
+
+    # ---- helpers shared by concrete publishers -------------------------------
+
+    def result(
+        self,
+        ctx: PublishContext,
+        status: PublishStatus,
+        message: str,
+        details: dict | None = None,
+    ) -> PublishResult:
+        return PublishResult(
+            target=self.name,
+            profile_id=ctx.profile_id,
+            status=status,
+            message=message,
+            artifacts=[artifact.filename for artifact in ctx.artifacts],
+            evidence=ctx.evidence.artifacts(),
+            details=details or {},
+        )
+
+    def run(
+        self,
+        ctx: PublishContext,
+        command: Sequence[str],
+        *,
+        cwd: Path | None = None,
+        env: dict[str, str] | None = None,
+        redact: Sequence[str] = (),
+    ) -> subprocess.CompletedProcess[str]:
+        """Run a subprocess, log a redacted command line, and fail loudly."""
+        printable = " ".join(_redact(part, redact) for part in command)
+        ctx.evidence.log(f"$ {printable}")
+        if ctx.options.dry_run:
+            ctx.evidence.log("dry-run: command not executed")
+            return subprocess.CompletedProcess(list(command), 0, "", "")
+        completed = subprocess.run(
+            list(command),
+            cwd=str(cwd) if cwd else None,
+            env={**ctx.env, **(env or {})},
+            capture_output=True,
+            text=True,
+            timeout=ctx.options.timeout_seconds,
+            check=False,
+        )
+        if completed.stdout:
+            ctx.evidence.log(completed.stdout.rstrip())
+        if completed.stderr:
+            ctx.evidence.log(completed.stderr.rstrip(), level="warn")
+        if completed.returncode != 0:
+            raise RemoteError(
+                f"{printable} exited {completed.returncode}: "
+                f"{(completed.stderr or completed.stdout).strip()[:2000]}"
+            )
+        return completed
+
+
+def _redact(value: str, secrets: Sequence[str]) -> str:
+    for secret in secrets:
+        if secret and secret in value:
+            value = value.replace(secret, "***")
+    return value
+
+
+class ManualPublisher(Publisher):
+    """A store with no automatable upload path yet.
+
+    Rather than pretend, this emits the exact checklist a human must follow and
+    reports BLOCKED so a release run never claims a store was published.
+    """
+
+    #: Ordered human steps, rendered into the evidence directory.
+    checklist: ClassVar[tuple[str, ...]] = ()
+    console_url: ClassVar[str] = ""
+
+    def publish(self, ctx: PublishContext) -> PublishResult:
+        lines = [
+            f"# Manual publish checklist — {self.name} / {ctx.profile_id} / {ctx.version}",
+            "",
+            f"Console: {self.console_url or '<not configured>'}",
+            "",
+            "## Artifacts",
+        ]
+        lines += [f"- `{a.filename}` (sha256 `{a.sha256}`)" for a in ctx.artifacts]
+        lines += ["", "## Steps"]
+        lines += [f"{index}. {step}" for index, step in enumerate(self.checklist, start=1)]
+        lines += ["", "## Release notes", "", "```text", ctx.release_notes, "```", ""]
+        path = ctx.evidence.write_text("MANUAL_CHECKLIST.md", "\n".join(lines))
+        ctx.evidence.warn(
+            f"{self.name} has no supported automation. Wrote manual checklist to {path}"
+        )
+        return self.result(
+            ctx,
+            PublishStatus.BLOCKED,
+            f"{self.name} requires a manual upload; checklist written to {path}",
+            {"checklist": str(path), "consoleUrl": self.console_url},
+        )

--- a/tools/publish/publishers/github.py
+++ b/tools/publish/publishers/github.py
@@ -1,0 +1,100 @@
+"""GitHub Releases publisher.
+
+Attaches the manifest-described artifacts (plus `SHA256SUMS` and the manifest
+itself) to the release tag. Idempotent: re-running uploads with `--clobber` only
+when `--force` is passed, otherwise existing assets are left alone.
+"""
+
+from __future__ import annotations
+
+from typing import ClassVar
+
+from ..errors import RemoteError
+from ..models import PublishResult, PublishStatus
+from .base import Publisher, PublishContext
+
+SIDECAR_FILENAMES = ("SHA256SUMS",)
+
+
+class GitHubPublisher(Publisher):
+    name: ClassVar[str] = "github"
+    description: ClassVar[str] = "GitHub Release assets for the release tag"
+    required_env: ClassVar[tuple[str, ...]] = ("GITHUB_TOKEN",)
+    required_binaries: ClassVar[tuple[str, ...]] = ("gh",)
+
+    def publish(self, ctx: PublishContext) -> PublishResult:
+        repository = ctx.config.option("repository") or ctx.env.get(
+            "GITHUB_REPOSITORY", "DevelopersCoffee/airo"
+        )
+        tag = str(ctx.config.option("tag", "{version}")).format(
+            version=ctx.version, buildNumber=ctx.release.build_number, profileId=ctx.profile_id
+        )
+
+        uploads = [artifact.path for artifact in ctx.artifacts]
+        for sidecar in SIDECAR_FILENAMES:
+            path = ctx.release.artifacts_dir / sidecar
+            if path.is_file():
+                uploads.append(path)
+            else:
+                ctx.evidence.warn(f"{sidecar} not found next to the manifest; not attaching")
+        uploads.append(ctx.release.manifest_path)
+
+        existing = self._existing_assets(ctx, repository, tag)
+        pending = [path for path in uploads if ctx.options.force or path.name not in existing]
+        skipped = [path.name for path in uploads if path.name in existing]
+        if skipped and not ctx.options.force:
+            ctx.evidence.log(f"already attached, skipping: {', '.join(skipped)}")
+
+        if not pending:
+            return self.result(
+                ctx,
+                PublishStatus.SKIPPED,
+                f"All {len(uploads)} asset(s) already attached to {tag}",
+                {"tag": tag, "repository": repository, "skipped": skipped},
+            )
+
+        if ctx.options.dry_run:
+            ctx.evidence.log(f"dry-run: would upload {len(pending)} asset(s) to {repository}@{tag}")
+            return self.result(
+                ctx,
+                PublishStatus.DRY_RUN,
+                f"Would upload {len(pending)} asset(s) to {repository}@{tag}",
+                {"tag": tag, "repository": repository, "pending": [p.name for p in pending]},
+            )
+
+        command = ["gh", "release", "upload", tag, *[str(path) for path in pending],
+                   "--repo", repository]
+        if ctx.options.force:
+            command.append("--clobber")
+        self.run(ctx, command)
+
+        ctx.evidence.write_json(
+            "github-upload.json",
+            {"tag": tag, "repository": repository, "uploaded": [p.name for p in pending]},
+        )
+        return self.result(
+            ctx,
+            PublishStatus.SUCCEEDED,
+            f"Uploaded {len(pending)} asset(s) to {repository}@{tag}",
+            {"tag": tag, "repository": repository, "uploaded": [p.name for p in pending]},
+        )
+
+    def _existing_assets(self, ctx: PublishContext, repository: str, tag: str) -> set[str]:
+        if ctx.options.dry_run:
+            return set()
+        try:
+            completed = self.run(
+                ctx,
+                [
+                    "gh", "release", "view", tag,
+                    "--repo", repository,
+                    "--json", "assets",
+                    "--jq", ".assets[].name",
+                ],
+            )
+        except RemoteError as exc:
+            raise RemoteError(
+                f"GitHub Release {tag!r} not found in {repository}. "
+                "Create the release before attaching assets."
+            ) from exc
+        return {line.strip() for line in completed.stdout.splitlines() if line.strip()}

--- a/tools/publish/publishers/manual_stores.py
+++ b/tools/publish/publishers/manual_stores.py
@@ -1,0 +1,71 @@
+"""Stores Airo does not automate yet.
+
+Each one records the real submission steps and reports BLOCKED, so a release run
+can never report a store as published when a human still has to click through a
+console. Promote one to a real publisher by replacing its class here once the
+upload path is proven by hand at least once.
+"""
+
+from __future__ import annotations
+
+from typing import ClassVar
+
+from .base import ManualPublisher
+
+
+class AmazonAppstorePublisher(ManualPublisher):
+    """Amazon has a Developer Services API; wire it once an account exists.
+
+    See https://developer.amazon.com/docs/app-submission-api/overview.html —
+    it needs a client id/secret, and the edit/commit lifecycle is transactional,
+    so a real publisher here is a genuine API integration rather than browser work.
+    """
+
+    name: ClassVar[str] = "amazon"
+    description: ClassVar[str] = "Amazon Appstore (manual until Developer Services API is wired)"
+    console_url: ClassVar[str] = "https://developer.amazon.com/apps-and-games/console/apps/list"
+    checklist: ClassVar[tuple[str, ...]] = (
+        "Open the Amazon Developer Console and select the Airo TV app.",
+        "Create a new upcoming version and set the version name and code from the artifact table above.",
+        "Upload the APK and wait for the binary checks to pass.",
+        "Paste the release notes into 'Release notes for this version'.",
+        "Confirm the Fire TV device support list still matches the qualification evidence.",
+        "Submit for review and record the submission id in the release issue.",
+    )
+
+
+class HuaweiAppGalleryPublisher(ManualPublisher):
+    """AppGallery Connect has a Publishing API worth wiring before Amazon.
+
+    https://developer.huawei.com/consumer/en/doc/AppGallery-connect-References/agcapi-getstarted
+    Needs a client id/secret pair and a two-step upload-url + commit flow.
+    """
+
+    name: ClassVar[str] = "huawei"
+    description: ClassVar[str] = "Huawei AppGallery (manual until the Publishing API is wired)"
+    console_url: ClassVar[str] = "https://developer.huawei.com/consumer/en/service/josp/agc/index.html"
+    checklist: ClassVar[tuple[str, ...]] = (
+        "Open AppGallery Connect and select the Airo TV app.",
+        "Create a new version, then upload the APK under Software Version.",
+        "Paste the release notes into 'New features'.",
+        "Re-confirm the privacy policy URL and data-collection answers.",
+        "Submit for review and record the submission id in the release issue.",
+    )
+
+
+class FDroidPublisher(ManualPublisher):
+    """F-Droid builds from source; there is nothing to upload.
+
+    The work is a metadata merge request against fdroiddata plus a reproducible
+    build recipe, which is a source-side contract rather than a release step.
+    """
+
+    name: ClassVar[str] = "fdroid"
+    description: ClassVar[str] = "F-Droid (source-built; metadata merge request, not an upload)"
+    console_url: ClassVar[str] = "https://gitlab.com/fdroid/fdroiddata"
+    checklist: ClassVar[tuple[str, ...]] = (
+        "Confirm the release tag is signed and reachable from a public branch.",
+        "Update the app metadata YAML in fdroiddata with the new versionName/versionCode.",
+        "Confirm the build recipe still resolves every dependency without prebuilt binaries.",
+        "Open the fdroiddata merge request and link it from the release issue.",
+    )

--- a/tools/publish/publishers/play_store.py
+++ b/tools/publish/publishers/play_store.py
@@ -1,0 +1,146 @@
+"""Google Play publisher.
+
+Wraps `fastlane supply`, which the release workflows already call, so the Play
+leg reads its package id, track, rollout, and AAB path from the same manifest
+and publish config as every other store instead of from inline workflow YAML.
+"""
+
+from __future__ import annotations
+
+import json
+import tempfile
+from pathlib import Path
+from typing import ClassVar
+
+from ..errors import ConfigError, CredentialError
+from ..models import PublishResult, PublishStatus
+from .base import Publisher, PublishContext
+
+VALID_TRACKS = {"internal", "alpha", "beta", "production"}
+
+
+class PlayStorePublisher(Publisher):
+    name: ClassVar[str] = "play"
+    description: ClassVar[str] = "Google Play track upload via fastlane supply"
+    required_env: ClassVar[tuple[str, ...]] = ("GOOGLE_PLAY_SERVICE_ACCOUNT_JSON",)
+    required_binaries: ClassVar[tuple[str, ...]] = ("fastlane",)
+
+    def preflight(self, ctx: PublishContext) -> list[str]:
+        blockers = super().preflight(ctx)
+        track = ctx.config.option("track")
+        if not track:
+            blockers.append(f"{ctx.config.context}.options.track is required")
+        elif track not in VALID_TRACKS:
+            blockers.append(
+                f"{ctx.config.context}.options.track must be one of "
+                f"{', '.join(sorted(VALID_TRACKS))}, got {track!r}"
+            )
+        rollout = ctx.config.option("rollout")
+        if rollout is not None:
+            try:
+                value = float(rollout)
+            except (TypeError, ValueError):
+                blockers.append(f"{ctx.config.context}.options.rollout must be a number 0..1")
+            else:
+                if not 0 <= value <= 1:
+                    blockers.append(f"{ctx.config.context}.options.rollout must be between 0 and 1")
+        return blockers
+
+    def publish(self, ctx: PublishContext) -> PublishResult:
+        artifact = ctx.sole_artifact()
+        if artifact.artifact_type != "aab":
+            raise ConfigError(
+                f"{ctx.config.context}: Play uploads require an .aab, selector chose "
+                f"{artifact.filename} ({artifact.artifact_type}). Set artifactSelector.artifactType to \"aab\"."
+            )
+        track = ctx.config.require_option("track")
+        rollout = ctx.config.option("rollout")
+        package_id = ctx.config.package_id or artifact.package_id
+
+        details = {
+            "packageName": package_id,
+            "track": track,
+            "rollout": rollout,
+            "aab": artifact.filename,
+            "versionName": artifact.version,
+            "buildNumber": artifact.build_number,
+        }
+
+        if ctx.options.dry_run:
+            ctx.evidence.write_json("play-plan.json", details)
+            return self.result(
+                ctx,
+                PublishStatus.DRY_RUN,
+                f"Would upload {artifact.filename} to Play {package_id} track={track}",
+                details,
+            )
+
+        if not ctx.options.may_submit:
+            ctx.evidence.write_json("play-plan.json", details)
+            ctx.evidence.warn(
+                "Play upload is an outward-facing action; re-run with --submit to perform it."
+            )
+            return self.result(
+                ctx,
+                PublishStatus.STAGED,
+                f"Plan written; pass --submit to upload {artifact.filename} to track={track}",
+                details,
+            )
+
+        credentials = ctx.require_env(
+            "GOOGLE_PLAY_SERVICE_ACCOUNT_JSON",
+            "Provide the Play service account JSON (raw JSON or a path to the key file).",
+        )
+        with _service_account_file(credentials) as key_path:
+            command = [
+                "fastlane", "supply",
+                "--package_name", package_id,
+                "--aab", str(artifact.path),
+                "--track", track,
+                "--json_key", str(key_path),
+                "--skip_upload_metadata", "true",
+                "--skip_upload_images", "true",
+                "--skip_upload_screenshots", "true",
+            ]
+            if rollout is not None:
+                command += ["--rollout", str(rollout)]
+            self.run(ctx, command, redact=(credentials, str(key_path)))
+
+        ctx.evidence.write_json("play-upload.json", details)
+        return self.result(
+            ctx,
+            PublishStatus.SUCCEEDED,
+            f"Uploaded {artifact.filename} to Play {package_id} track={track}",
+            details,
+        )
+
+
+class _service_account_file:
+    """Materialise the service account JSON into a private temp file."""
+
+    def __init__(self, credentials: str) -> None:
+        self._credentials = credentials
+        self._temp: Path | None = None
+
+    def __enter__(self) -> Path:
+        candidate = Path(self._credentials)
+        if len(self._credentials) < 4096 and candidate.is_file():
+            return candidate
+        try:
+            json.loads(self._credentials)
+        except json.JSONDecodeError as exc:
+            raise CredentialError(
+                "GOOGLE_PLAY_SERVICE_ACCOUNT_JSON is neither a readable file path nor valid JSON"
+            ) from exc
+        handle = tempfile.NamedTemporaryFile(
+            "w", suffix=".json", delete=False, encoding="utf-8"
+        )
+        with handle:
+            handle.write(self._credentials)
+        self._temp = Path(handle.name)
+        self._temp.chmod(0o600)
+        return self._temp
+
+    def __exit__(self, *_exc: object) -> None:
+        if self._temp is not None:
+            self._temp.unlink(missing_ok=True)

--- a/tools/publish/publishers/website.py
+++ b/tools/publish/publishers/website.py
@@ -1,0 +1,73 @@
+"""Website publisher.
+
+Writes the download metadata the public docs site reads, so the site's download
+links, versions, and checksums come from the same manifest the binaries were
+hashed with instead of from a hand-edited page.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import ClassVar
+
+from ..config import REPO_ROOT
+from ..errors import ConfigError
+from ..models import PublishResult, PublishStatus
+from .base import Publisher, PublishContext
+
+
+class WebsitePublisher(Publisher):
+    name: ClassVar[str] = "website"
+    description: ClassVar[str] = "Download metadata JSON for the public docs site"
+
+    def publish(self, ctx: PublishContext) -> PublishResult:
+        raw_output = ctx.config.require_option("outputPath")
+        repo_root = REPO_ROOT.resolve()
+        output = (repo_root / str(raw_output)).resolve()
+        try:
+            output.relative_to(repo_root)
+        except ValueError as exc:
+            raise ConfigError(
+                f"{ctx.config.context}.options.outputPath must stay inside the repository: {output}"
+            ) from exc
+
+        base_url = str(ctx.config.option("downloadBaseUrl", "")).format(
+            version=ctx.version, profileId=ctx.profile_id
+        )
+        payload = {
+            "schemaVersion": 1,
+            "profileId": ctx.profile_id,
+            "version": ctx.version,
+            "buildNumber": ctx.release.build_number,
+            "sourceSha": ctx.release.source_sha,
+            "releaseNotes": ctx.release_notes,
+            "downloads": [
+                {
+                    "filename": artifact.filename,
+                    "url": f"{base_url.rstrip('/')}/{artifact.filename}" if base_url else "",
+                    "packageId": artifact.package_id,
+                    "artifactType": artifact.artifact_type,
+                    "abi": artifact.abi,
+                    "sizeBytes": artifact.size_bytes,
+                    "sha256": artifact.sha256,
+                }
+                for artifact in ctx.artifacts
+            ],
+        }
+
+        if ctx.options.dry_run:
+            ctx.evidence.write_json("website-plan.json", payload)
+            return self.result(
+                ctx, PublishStatus.DRY_RUN, f"Would write {output}", {"outputPath": str(output)}
+            )
+
+        output.parent.mkdir(parents=True, exist_ok=True)
+        output.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+        ctx.evidence.log(f"wrote {output}")
+        ctx.evidence.write_json("website-result.json", payload)
+        return self.result(
+            ctx,
+            PublishStatus.SUCCEEDED,
+            f"Wrote download metadata for {len(ctx.artifacts)} artifact(s) to {output}",
+            {"outputPath": str(output)},
+        )

--- a/tools/publish/runner.py
+++ b/tools/publish/runner.py
@@ -1,0 +1,212 @@
+"""Orchestration: manifest + config + publisher -> results.
+
+The runner owns everything that must happen the same way for every store:
+artifact integrity verification, release-note resolution, preflight gating,
+evidence directories, and result aggregation. Publishers only implement the
+part that is genuinely store-specific.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Sequence
+
+from .config import PublishConfig, TargetProfileConfig
+from .errors import PublishError
+from .evidence import EvidenceRecorder
+from .models import PublishResult, PublishStatus, ReleaseMetadata
+from .publishers import PublishContext, PublishOptions, get_publisher
+
+
+@dataclass
+class RunRequest:
+    release: ReleaseMetadata
+    config: PublishConfig
+    targets: Sequence[str]
+    profiles: Sequence[str] | None
+    options: PublishOptions
+    evidence_dir: Path
+    quiet: bool = False
+
+
+@dataclass
+class Plan:
+    """What the runner resolved, and what it deliberately left out.
+
+    A release leg builds one profile at a time, so a config that also declares
+    other profiles must not fail the run — but a profile the caller asked for by
+    name and the manifest does not contain is a genuine error, raised by
+    `profiles_for`/`select_artifacts` rather than silently dropped here.
+    """
+
+    contexts: list[tuple[TargetProfileConfig, PublishContext]]
+    not_in_manifest: list[tuple[TargetProfileConfig, str]]
+
+
+def plan(request: RunRequest) -> Plan:
+    """Resolve every (target, profile) pair into a fully-populated context."""
+    contexts: list[tuple[TargetProfileConfig, PublishContext]] = []
+    absent: list[tuple[TargetProfileConfig, str]] = []
+    manifest_profiles = set(request.release.profile_ids())
+    for target in request.targets:
+        for profile_config in request.config.profiles_for(target, request.profiles):
+            if request.profiles is None and profile_config.profile_id not in manifest_profiles:
+                absent.append(
+                    (
+                        profile_config,
+                        f"release manifest has no {profile_config.profile_id!r} artifacts "
+                        f"(manifest profiles: {', '.join(sorted(manifest_profiles)) or 'none'})",
+                    )
+                )
+                continue
+            evidence = EvidenceRecorder.for_attempt(
+                request.evidence_dir,
+                target,
+                profile_config.profile_id,
+                request.release.version,
+                quiet=request.quiet,
+            )
+            artifacts = profile_config.select_artifacts(request.release)
+            request.release.verify_artifacts(artifacts)
+            notes = profile_config.release_notes.resolve(
+                request.release, profile_config.profile_id
+            )
+            contexts.append(
+                (
+                    profile_config,
+                    PublishContext(
+                        release=request.release,
+                        config=profile_config,
+                        artifacts=artifacts,
+                        options=request.options,
+                        evidence=evidence,
+                        release_notes=notes,
+                        env=dict(os.environ),
+                    ),
+                )
+            )
+    return Plan(contexts=contexts, not_in_manifest=absent)
+
+
+def run(request: RunRequest) -> list[PublishResult]:
+    resolved = plan(request)
+    results: list[PublishResult] = []
+    for profile_config, reason in resolved.not_in_manifest:
+        if not request.quiet:
+            print(f"[info] {profile_config.context}: skipped — {reason}")
+    for profile_config, ctx in resolved.contexts:
+        publisher = get_publisher(profile_config.target)
+
+        if not request.config.is_target_enabled(profile_config.target):
+            results.append(
+                _skipped(publisher.name, ctx, f"target {profile_config.target!r} is disabled in config")
+            )
+            continue
+        if not profile_config.enabled:
+            results.append(
+                _skipped(publisher.name, ctx, f"profile {ctx.profile_id!r} is disabled in config")
+            )
+            continue
+
+        ctx.evidence.log(
+            f"=== {publisher.name} / {ctx.profile_id} / {ctx.version} "
+            f"(dry_run={request.options.dry_run}, submit={request.options.submit}) ==="
+        )
+        for artifact in ctx.artifacts:
+            ctx.evidence.log(f"artifact {artifact.filename} sha256={artifact.sha256} verified")
+
+        blockers = publisher.preflight(ctx)
+        if blockers:
+            for blocker in blockers:
+                ctx.evidence.error(blocker)
+            results.append(
+                PublishResult(
+                    target=publisher.name,
+                    profile_id=ctx.profile_id,
+                    status=PublishStatus.BLOCKED,
+                    message="preflight failed: " + "; ".join(blockers),
+                    artifacts=[a.filename for a in ctx.artifacts],
+                    evidence=ctx.evidence.artifacts(),
+                    details={"blockers": blockers},
+                )
+            )
+            continue
+
+        try:
+            result = publisher.publish(ctx)
+        except PublishError as exc:
+            ctx.evidence.error(f"{type(exc).__name__}: {exc}")
+            result = PublishResult(
+                target=publisher.name,
+                profile_id=ctx.profile_id,
+                status=PublishStatus.FAILED,
+                message=f"{type(exc).__name__}: {exc}",
+                artifacts=[a.filename for a in ctx.artifacts],
+                evidence=ctx.evidence.artifacts(),
+                details={"errorType": type(exc).__name__},
+            )
+        except Exception as exc:  # noqa: BLE001 - never lose the evidence trail
+            ctx.evidence.error(f"unexpected {type(exc).__name__}: {exc}")
+            result = PublishResult(
+                target=publisher.name,
+                profile_id=ctx.profile_id,
+                status=PublishStatus.FAILED,
+                message=f"unexpected {type(exc).__name__}: {exc}",
+                artifacts=[a.filename for a in ctx.artifacts],
+                evidence=ctx.evidence.artifacts(),
+                details={"errorType": type(exc).__name__},
+            )
+
+        result.evidence = ctx.evidence.artifacts()
+        ctx.evidence.log(f"result: {result.status.value} — {result.message}")
+        results.append(result)
+    return results
+
+
+def _skipped(target: str, ctx: PublishContext, reason: str) -> PublishResult:
+    ctx.evidence.log(f"skipped: {reason}")
+    return PublishResult(
+        target=target,
+        profile_id=ctx.profile_id,
+        status=PublishStatus.SKIPPED,
+        message=reason,
+        artifacts=[a.filename for a in ctx.artifacts],
+        evidence=ctx.evidence.artifacts(),
+    )
+
+
+def summarise(results: Sequence[PublishResult], release: ReleaseMetadata) -> str:
+    """Markdown table suitable for `$GITHUB_STEP_SUMMARY`."""
+    lines = [
+        f"# Publish summary — {release.version} (build {release.build_number})",
+        "",
+        "| Target | Profile | Status | Artifacts | Detail |",
+        "| --- | --- | --- | --- | --- |",
+    ]
+    icons = {
+        PublishStatus.SUCCEEDED: "✅",
+        PublishStatus.SKIPPED: "⏭️",
+        PublishStatus.DRY_RUN: "🧪",
+        PublishStatus.STAGED: "🅿️",
+        PublishStatus.BLOCKED: "🚧",
+        PublishStatus.FAILED: "❌",
+    }
+    for result in results:
+        artifacts = ", ".join(f"`{name}`" for name in result.artifacts) or "—"
+        detail = result.message.replace("|", "\\|")
+        lines.append(
+            f"| {result.target} | {result.profile_id} | "
+            f"{icons[result.status]} {result.status.value} | {artifacts} | {detail} |"
+        )
+    lines.append("")
+    return "\n".join(lines)
+
+
+def exit_code_for(results: Sequence[PublishResult]) -> int:
+    if any(result.status is PublishStatus.FAILED for result in results):
+        return 1
+    if any(result.status is PublishStatus.BLOCKED for result in results):
+        return 2
+    return 0


### PR DESCRIPTION
## What

One framework every app store plugs into, driven by the release manifest that `scripts/generate-release-manifest.py` already produces.

```
GitHub Release (v0.0.6)  →  gh release download  →  Release-Manifest.json + assets
                                          │
                                          ▼
                          tools/publish (verify → select → publish)
                                          │
    ┌────────────┬────────────┬───────────┼───────────┬───────────┐
    ▼            ▼            ▼           ▼           ▼           ▼
 github        play        apkpure      amazon      huawei      website
(gh CLI)   (fastlane)  (Playwright)   (manual)    (manual)     (JSON)
```

## Why this shape

**Publishing never builds.** Artifacts come from a published GitHub Release, so a store listing and the release page cannot disagree about what shipped. Every selected artifact's size and SHA-256 is verified against the manifest before anything is contacted; a mismatch aborts.

**Submit-gated.** `run` uploads and stages. The irreversible store submission happens only with `--submit`. Without it, APKPure ends with the APK uploaded and release notes filled, but nothing submitted.

**No password passes through this code.** A human signs in once via `login apkpure`; only session cookies are stored. CAPTCHA and 2FA challenges stop the run with a screenshot rather than being solved.

**Un-automated stores report BLOCKED, not success.** Amazon, Huawei, and F-Droid subclass `ManualPublisher` — they emit a human checklist and exit non-zero, so a release run can never claim a store was published when a human still has to click through a console.

## APKPure is not ready to enable

APKPure has no publishing API, so this drives their console with Playwright. **The selectors are UNVERIFIED against the live DOM** — written against the documented flow, never recorded. The target is `enabled: false` in config until someone runs:

```bash
python3 -m tools.publish doctor apkpure --package-id io.airo.app.tv
```

which reports unmatched selector keys and exits 2. Selectors are data, overridable at runtime via `APKPURE_SELECTORS_FILE`, so a console redesign is a config fix rather than a PR.

## Notes for reviewers

- **Language**: Python, because `scripts/` is already where release automation lives and Playwright ships Python bindings — no Node toolchain added to a Flutter/Melos repo. A Rust `Publisher` trait was the original sketch, but `core_native` still has no build wiring into the app.
- **Store selection pins an exact filename, not `abi`.** `Airo-TV-<v>.apk` (universal) and `Airo-TV-<v>-arm64-v8a.apk` both legitimately carry `android-arm64`, so no ABI selector can separate them. `CanonicalApkAgreementTests` pins the selector to `scripts/resolve_release_tv_apk.py` so the two definitions cannot drift.
- **CI cost**: tests run inside the existing `pr-checks` release-script step. No new job.
- The `publish-stores.yml` workflow is `workflow_dispatch` only, defaults to `mode: plan`, and offers a `self-hosted` runner because cloud runners trigger APKPure's device checks.

## Verification

Against the real published `v0.0.6` release:

```
apkpure | ['Airo-TV-0.0.6.apk']            notes: 3240 chars from the CHANGELOG v0.0.6 section
github  | 7 artifacts incl. macOS zip/dmg
```

41 tests covering manifest integrity, path traversal, checksum mismatch, artifact selection, release-note resolution, submit gating, and the manual-store path. `check-build-profiles.py`, `check-module-manifests.py`, `check-ci-cache-policy.py`, and `check-docs-completeness.sh` all pass.

## Follow-ups, not in this PR

- Record the APKPure selectors and flip the target on.
- `infer_abi` in `generate-release-manifest.py` still returns `android-arm64` for `.aab` artifacts — the `play-managed` branch sits after the `abiStrategy` fallback and is unreachable. Harmless today (nothing reads the field) but worth a 3-line reorder.
- Provision Play credentials for the TV listing; wire Huawei's Publishing API and Amazon's Developer Services API as real publishers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
