### PR TITLE
feat(release): drive APKPure with a real browser instead of evading Cloudflare

### DIFF
--- a/scripts/tests/test_publish_framework.py
+++ b/scripts/tests/test_publish_framework.py
@@ -28,7 +28,9 @@ from tools.publish.errors import (  # noqa: E402
     ArtifactIntegrityError,
     ConfigError,
     ManifestError,
+    PreflightError,
 )
+from tools.publish.apkpure.console import BrowserMode, resolve_browser_mode  # noqa: E402
 from tools.publish.evidence import EvidenceRecorder  # noqa: E402
 from tools.publish.fetch import FetchedRelease, index_manifests  # noqa: E402
 from tools.publish.models import PublishStatus, ReleaseMetadata  # noqa: E402
@@ -592,6 +594,73 @@ class SubmitGatingTests(unittest.TestCase):
             )
             blockers = get_publisher("play").preflight(ctx)
             self.assertTrue(any("track" in blocker for blocker in blockers), blockers)
+
+
+class BrowserModeTests(unittest.TestCase):
+    """APKPure sits behind Cloudflare; the answer is a real browser, not stealth."""
+
+    def test_default_is_the_bundled_chromium(self) -> None:
+        self.assertIs(resolve_browser_mode(None, {}), BrowserMode.BUNDLED)
+
+    def test_env_selects_a_mode(self) -> None:
+        self.assertIs(resolve_browser_mode(None, {"APKPURE_BROWSER": "cdp"}), BrowserMode.CDP)
+
+    def test_config_beats_env(self) -> None:
+        self.assertIs(
+            resolve_browser_mode("chrome", {"APKPURE_BROWSER": "cdp"}), BrowserMode.CHROME
+        )
+
+    def test_unknown_mode_is_rejected(self) -> None:
+        with self.assertRaises(PreflightError):
+            resolve_browser_mode("firefox", {})
+
+    def _context(self, root: Path, options: dict) -> PublishContext:
+        release = ReleaseMetadata.from_manifest_file(write_release(root))
+        config = PublishConfig.load(
+            write_config(
+                root,
+                {
+                    "apkpure": {
+                        "enabled": True,
+                        "profiles": {
+                            "tv": {
+                                "packageId": "io.airo.app.tv",
+                                "artifactSelector": {"artifactType": ["apk"], "maxCount": 1},
+                                "releaseNotes": {"source": "inline", "text": "Notes."},
+                                "options": options,
+                            }
+                        },
+                    }
+                },
+            )
+        )
+        profile = config.profiles_for("apkpure")[0]
+        return PublishContext(
+            release=release,
+            config=profile,
+            artifacts=profile.select_artifacts(release),
+            options=PublishOptions(),
+            evidence=EvidenceRecorder(root=root / "evidence", quiet=True),
+            release_notes="Notes.",
+            env={},
+        )
+
+    def test_bundled_mode_still_requires_a_saved_session(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            ctx = self._context(root, {"storageState": str(root / "absent.json")})
+            blockers = get_publisher("apkpure").preflight(ctx)
+            self.assertTrue(any("session state" in b for b in blockers), blockers)
+
+    def test_chrome_and_cdp_modes_do_not_require_a_storage_state(self) -> None:
+        for mode in ("chrome", "cdp"):
+            with self.subTest(mode=mode), tempfile.TemporaryDirectory() as tmp:
+                root = Path(tmp)
+                ctx = self._context(
+                    root, {"browser": mode, "storageState": str(root / "absent.json")}
+                )
+                blockers = get_publisher("apkpure").preflight(ctx)
+                self.assertEqual(blockers, [], f"{mode}: {blockers}")
 
 
 class CanonicalApkAgreementTests(unittest.TestCase):

--- a/tools/publish/README.md
+++ b/tools/publish/README.md
@@ -157,6 +157,44 @@ Developer Console with Playwright. Three hard rules:
    `APKPURE_SELECTORS_FILE` can point at a JSON override — so a console redesign
    is unblocked by a config file, not by a code review.
 
+### Cloudflare, and what this tool will not do
+
+APKPure sits behind Cloudflare, which challenges Playwright's bundled Chromium.
+This code will not evade that: no stealth plugins, no fingerprint or user-agent
+spoofing, no automated challenge solving. What it does instead is let a human
+drive a real browser through the check, and work inside the session that human
+established. Pick a mode with `--browser`, the `browser` target option, or
+`APKPURE_BROWSER`:
+
+| Mode | What it does | When |
+| --- | --- | --- |
+| `bundled` (default) | Playwright Chromium replaying a saved storage state | Fast, headless-capable, most likely to be challenged |
+| `chrome` | Real Google Chrome with a persistent profile that survives runs | Cloudflare challenges the bundled browser |
+| `cdp` | Attaches to a Chrome you started and signed in yourself | Strongest option: nothing about the session is synthesised |
+
+`chrome` and `cdp` need no storage state — the session lives in the browser
+profile — and both run headed, because a human may need to clear a check.
+
+Sign in to a persistent Chrome profile:
+
+```bash
+python3 -m tools.publish login apkpure --browser chrome
+```
+
+Or attach to your own browser. Start Chrome with remote debugging, sign in to
+APKPure in that window, then run with `--browser cdp`:
+
+```bash
+'/Applications/Google Chrome.app/Contents/MacOS/Google Chrome' --remote-debugging-port=9222 --user-data-dir="$HOME/.config/airo/apkpure-chrome-profile"
+```
+
+In `cdp` mode the tool attaches to a tab and detaches when done; it never closes
+the browser you own.
+
+If Cloudflare still blocks a real, human-signed-in Chrome, treat that as APKPure
+declining automated uploads and publish that release by hand — `ManualPublisher`
+exists for exactly this outcome.
+
 ### Selectors are UNVERIFIED
 
 The candidates in `apkpure/selectors.py` are written against the documented

--- a/tools/publish/apkpure/console.py
+++ b/tools/publish/apkpure/console.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import contextlib
 import json
 from dataclasses import dataclass
+from enum import Enum
 from pathlib import Path
 from typing import Any, Callable, Iterator
 
@@ -188,6 +189,41 @@ class ConsoleSession:
         self.snapshot("submitted")
 
 
+class BrowserMode(str, Enum):
+    """How the driver gets a browser.
+
+    APKPure sits behind Cloudflare, which challenges Playwright's bundled
+    Chromium. The answer is not to disguise the automation — this code will not
+    spoof fingerprints or solve challenges — but to let a human drive a real
+    browser through the challenge and have the automation work inside the
+    browser they already trust.
+    """
+
+    #: Playwright's bundled Chromium plus a saved storage state. Fastest, and
+    #: the most likely to be challenged.
+    BUNDLED = "bundled"
+    #: The real Google Chrome install, with a persistent profile directory that
+    #: survives between runs, so Cloudflare sees a returning browser.
+    CHROME = "chrome"
+    #: Attach to a Chrome the human started with --remote-debugging-port and
+    #: signed in themselves. Nothing about the session is synthesised.
+    CDP = "cdp"
+
+
+def resolve_browser_mode(configured: object, env: dict[str, str] | None = None) -> "BrowserMode":
+    """Config value wins, then APKPURE_BROWSER, then the bundled default."""
+    raw = configured or (env or {}).get("APKPURE_BROWSER") or BrowserMode.BUNDLED.value
+    try:
+        return BrowserMode(str(raw).strip().lower())
+    except ValueError as exc:
+        valid = ", ".join(mode.value for mode in BrowserMode)
+        raise PreflightError(f"Unknown browser mode {raw!r}. Valid: {valid}") from exc
+
+
+DEFAULT_PROFILE_DIR = Path.home() / ".config" / "airo" / "apkpure-chrome-profile"
+DEFAULT_CDP_ENDPOINT = "http://127.0.0.1:9222"
+
+
 @contextlib.contextmanager
 def console_session(
     *,
@@ -196,37 +232,158 @@ def console_session(
     selectors: SelectorSet,
     headless: bool = True,
     timeout_ms: int = 60_000,
+    mode: BrowserMode = BrowserMode.BUNDLED,
+    profile_dir: Path | None = None,
+    cdp_endpoint: str = DEFAULT_CDP_ENDPOINT,
 ) -> Iterator[ConsoleSession]:
-    """Open a Chromium context restored from a saved, human-created session."""
-    if not storage_state.is_file():
-        raise CredentialError(
-            f"No APKPure session state at {storage_state}. Run "
-            "`python3 -m tools.publish login apkpure` on a machine with a display first."
-        )
+    """Open an APKPure console page using whichever browser `mode` selects."""
     sync_playwright = import_playwright()
+    evidence.log(f"browser mode: {mode.value}")
+
     with sync_playwright() as playwright:
-        browser = playwright.chromium.launch(headless=headless)
-        try:
-            context = browser.new_context(
-                storage_state=str(storage_state),
-                viewport=DEFAULT_VIEWPORT,
-                accept_downloads=False,
+        if mode is BrowserMode.CDP:
+            manager = _cdp_context(playwright, cdp_endpoint, evidence)
+        elif mode is BrowserMode.CHROME:
+            manager = _persistent_chrome_context(
+                playwright, profile_dir or DEFAULT_PROFILE_DIR, headless, evidence
             )
+        else:
+            manager = _bundled_context(playwright, storage_state, headless, evidence)
+
+        with manager as (context, persist_storage_state):
             context.set_default_timeout(timeout_ms)
-            page = context.new_page()
+            page = context.pages[0] if context.pages else context.new_page()
             page.on("console", lambda msg: evidence.log(f"browser console [{msg.type}] {msg.text}"))
             try:
                 yield ConsoleSession(
                     page=page, selectors=selectors, evidence=evidence, timeout_ms=timeout_ms
                 )
             finally:
-                # Refresh the stored session so a rolling cookie does not expire
-                # the automation between releases.
-                with contextlib.suppress(Exception):
-                    context.storage_state(path=str(storage_state))
-                context.close()
+                if persist_storage_state:
+                    # Refresh the stored session so a rolling cookie does not
+                    # expire the automation between releases.
+                    with contextlib.suppress(Exception):
+                        context.storage_state(path=str(storage_state))
+
+
+@contextlib.contextmanager
+def _bundled_context(playwright, storage_state: Path, headless: bool, evidence: EvidenceRecorder):
+    if not storage_state.is_file():
+        raise CredentialError(
+            f"No APKPure session state at {storage_state}. Run "
+            "`python3 -m tools.publish login apkpure` on a machine with a display first."
+        )
+    browser = playwright.chromium.launch(headless=headless)
+    try:
+        context = browser.new_context(
+            storage_state=str(storage_state),
+            viewport=DEFAULT_VIEWPORT,
+            accept_downloads=False,
+        )
+        try:
+            yield context, True
         finally:
+            context.close()
+    finally:
+        browser.close()
+
+
+@contextlib.contextmanager
+def _persistent_chrome_context(
+    playwright, profile_dir: Path, headless: bool, evidence: EvidenceRecorder
+):
+    """Real Chrome with a profile that persists between runs.
+
+    No stealth flags and no fingerprint patching: this is a genuine Chrome with
+    a genuine profile, which is simply a truer description of what is happening
+    than a throwaway Chromium is.
+    """
+    profile_dir = profile_dir.expanduser()
+    profile_dir.mkdir(parents=True, exist_ok=True)
+    evidence.log(f"chrome profile: {profile_dir}")
+    try:
+        context = playwright.chromium.launch_persistent_context(
+            str(profile_dir),
+            channel="chrome",
+            headless=headless,
+            viewport=DEFAULT_VIEWPORT,
+            accept_downloads=False,
+        )
+    except Exception as exc:  # noqa: BLE001 - Playwright raises its own errors
+        raise PreflightError(
+            f"Could not start Google Chrome ({exc}). Install Chrome, or use "
+            "--browser cdp to attach to a browser you started yourself."
+        ) from exc
+    try:
+        yield context, False
+    finally:
+        with contextlib.suppress(Exception):
+            context.close()
+
+
+@contextlib.contextmanager
+def _cdp_context(playwright, endpoint: str, evidence: EvidenceRecorder):
+    """Attach to a Chrome the human already started and signed in.
+
+    The human clears any Cloudflare or login challenge in their own browser.
+    This process never sees a credential and never answers a challenge; it only
+    drives a tab in a session that a human established.
+    """
+    evidence.log(f"attaching over CDP to {endpoint}")
+    try:
+        browser = playwright.chromium.connect_over_cdp(endpoint)
+    except Exception as exc:  # noqa: BLE001 - Playwright raises its own errors
+        raise PreflightError(
+            f"Could not attach to Chrome at {endpoint} ({exc}).\n"
+            "Start Chrome with remote debugging first, for example:\n"
+            "  /Applications/Google\\ Chrome.app/Contents/MacOS/Google\\ Chrome \\\n"
+            "    --remote-debugging-port=9222 --user-data-dir=\"$HOME/.config/airo/apkpure-chrome-profile\"\n"
+            "then sign in to APKPure in that window before re-running."
+        ) from exc
+    context = browser.contexts[0] if browser.contexts else browser.new_context()
+    try:
+        yield context, False
+    finally:
+        # The human owns this browser: detach, never close it.
+        with contextlib.suppress(Exception):
             browser.close()
+
+
+def interactive_chrome_login(
+    profile_dir: Path,
+    evidence: EvidenceRecorder,
+    confirm: Callable[[str], object] = input,
+) -> Path:
+    """Sign in inside a persistent real-Chrome profile.
+
+    Nothing is exported: the cookies stay in Chrome's own profile directory and
+    later runs reuse that same profile, so a Cloudflare challenge cleared by
+    hand here stays cleared. Use this when the bundled Chromium is challenged.
+    """
+    sync_playwright = import_playwright()
+    profile_dir = profile_dir.expanduser()
+    profile_dir.mkdir(parents=True, exist_ok=True)
+    with sync_playwright() as playwright:
+        try:
+            context = playwright.chromium.launch_persistent_context(
+                str(profile_dir), channel="chrome", headless=False, viewport=DEFAULT_VIEWPORT
+            )
+        except Exception as exc:  # noqa: BLE001 - Playwright raises its own errors
+            raise PreflightError(
+                f"Could not start Google Chrome ({exc}). Install Chrome, or sign in "
+                "with your own browser and use --browser cdp instead."
+            ) from exc
+        page = context.pages[0] if context.pages else context.new_page()
+        page.goto(SIGN_IN_URL, wait_until="domcontentloaded")
+        evidence.log(f"opened {SIGN_IN_URL} in persistent Chrome profile {profile_dir}")
+        confirm(
+            "\nSign in to APKPure in the Chrome window that just opened, clearing any\n"
+            "Cloudflare check yourself. Then press Enter here to close it: "
+        )
+        with contextlib.suppress(Exception):
+            context.close()
+    evidence.log(f"chrome profile retained at {profile_dir}")
+    return profile_dir
 
 
 def interactive_login(

--- a/tools/publish/cli.py
+++ b/tools/publish/cli.py
@@ -21,7 +21,15 @@ import os
 import sys
 from pathlib import Path
 
-from .apkpure.console import console_session, interactive_login
+from .apkpure.console import (
+    DEFAULT_CDP_ENDPOINT,
+    DEFAULT_PROFILE_DIR,
+    BrowserMode,
+    console_session,
+    interactive_chrome_login,
+    interactive_login,
+    resolve_browser_mode,
+)
 from .apkpure.selectors import SelectorSet, console_url
 from .config import REPO_ROOT, PublishConfig
 from .errors import PublishError
@@ -86,6 +94,13 @@ def build_parser() -> argparse.ArgumentParser:
     login = sub.add_parser("login", help="Create or refresh a store browser session, by hand.")
     login.add_argument("target", choices=["apkpure"])
     login.add_argument("--storage-state", type=Path, default=None)
+    login.add_argument(
+        "--browser",
+        choices=[mode.value for mode in BrowserMode],
+        default=None,
+        help="bundled saves a storage state; chrome signs in to a persistent Chrome profile.",
+    )
+    login.add_argument("--profile-dir", type=Path, default=None)
 
     doctor = sub.add_parser("doctor", help="Dump a store console page so selectors can be re-mapped.")
     doctor.add_argument("target", choices=["apkpure"])
@@ -93,6 +108,18 @@ def build_parser() -> argparse.ArgumentParser:
     doctor.add_argument("--storage-state", type=Path, default=None)
     doctor.add_argument("--evidence-dir", type=Path, default=DEFAULT_EVIDENCE_DIR)
     doctor.add_argument("--headed", action="store_true")
+    doctor.add_argument(
+        "--browser",
+        choices=[mode.value for mode in BrowserMode],
+        default=None,
+        help=(
+            "bundled = Playwright Chromium + saved session (default); "
+            "chrome = real Chrome with a persistent profile; "
+            "cdp = attach to a Chrome you started and signed in yourself."
+        ),
+    )
+    doctor.add_argument("--profile-dir", type=Path, default=None)
+    doctor.add_argument("--cdp-endpoint", default=DEFAULT_CDP_ENDPOINT)
 
     return parser
 
@@ -240,8 +267,32 @@ def _storage_state(args: argparse.Namespace) -> Path:
 
 
 def cmd_login(args: argparse.Namespace) -> int:
-    state = _storage_state(args)
+    mode = resolve_browser_mode(args.browser, dict(os.environ))
     evidence = EvidenceRecorder(root=DEFAULT_EVIDENCE_DIR / "login" / args.target)
+
+    if mode is BrowserMode.CDP:
+        print(
+            "Nothing to do for --browser cdp: you sign in to APKPure in your own Chrome.\n"
+            "Start it with remote debugging, sign in there, then run doctor/run with\n"
+            "--browser cdp:\n"
+            "  '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome' \\\n"
+            "    --remote-debugging-port=9222 \\\n"
+            f"    --user-data-dir=\"{DEFAULT_PROFILE_DIR}\"\n"
+        )
+        return 0
+
+    if mode is BrowserMode.CHROME:
+        profile = (args.profile_dir or DEFAULT_PROFILE_DIR).expanduser()
+        print(
+            "Real Chrome will open. Sign in to APKPure yourself and clear any Cloudflare\n"
+            "check — this tool never reads, types, or stores your password. The session\n"
+            f"stays inside the Chrome profile at:\n  {profile}\n"
+        )
+        interactive_chrome_login(profile, evidence)
+        print(f"\nDone. Re-run doctor/run with --browser chrome (profile: {profile}).")
+        return 0
+
+    state = _storage_state(args)
     print(
         "A browser window will open. Sign in to APKPure yourself — this tool never\n"
         "reads, types, or stores your password. Only the resulting session cookies\n"
@@ -257,11 +308,15 @@ def cmd_doctor(args: argparse.Namespace) -> int:
     evidence = EvidenceRecorder(root=args.evidence_dir / "doctor" / args.target)
     selectors = SelectorSet.load()
     evidence.log(f"selector source: {selectors.source}")
+    mode = resolve_browser_mode(args.browser, dict(os.environ))
     with console_session(
         storage_state=state,
         evidence=evidence,
         selectors=selectors,
-        headless=not args.headed,
+        headless=not args.headed and mode is BrowserMode.BUNDLED,
+        mode=mode,
+        profile_dir=args.profile_dir,
+        cdp_endpoint=args.cdp_endpoint,
     ) as session:
         session.open_app(args.package_id)
         report = {

--- a/tools/publish/publishers/apkpure.py
+++ b/tools/publish/publishers/apkpure.py
@@ -15,7 +15,8 @@ from __future__ import annotations
 from pathlib import Path
 from typing import ClassVar
 
-from ..apkpure.console import console_session
+from ..apkpure.console import BrowserMode, console_session, resolve_browser_mode
+from ..apkpure.console import DEFAULT_CDP_ENDPOINT
 from ..apkpure.selectors import SelectorSet, console_url
 from ..errors import ConfigError
 from ..models import PublishResult, PublishStatus
@@ -37,11 +38,15 @@ class ApkPurePublisher(Publisher):
     def preflight(self, ctx: PublishContext) -> list[str]:
         blockers = super().preflight(ctx)
         if not ctx.options.dry_run:
+            # Only the bundled-Chromium mode replays a saved storage state; the
+            # chrome and cdp modes carry their session in a real browser profile.
+            mode = resolve_browser_mode(ctx.config.option("browser"), ctx.env)
             state = storage_state_path(ctx)
-            if not state.is_file():
+            if mode is BrowserMode.BUNDLED and not state.is_file():
                 blockers.append(
                     f"no APKPure session state at {state}; run "
-                    "`python3 -m tools.publish login apkpure` first"
+                    "`python3 -m tools.publish login apkpure` first, or pass "
+                    "browser=chrome/cdp in the target options"
                 )
         return blockers
 
@@ -79,7 +84,9 @@ class ApkPurePublisher(Publisher):
 
         selectors = SelectorSet.load(ctx.config.option("selectorsFile"))
         ctx.evidence.log(f"selector source: {selectors.source}")
-        headless = bool(ctx.config.option("headless", True))
+        mode = resolve_browser_mode(ctx.config.option("browser"), ctx.env)
+        # A real browser must be visible: a human may need to clear a challenge.
+        headless = bool(ctx.config.option("headless", True)) and mode is BrowserMode.BUNDLED
         state = storage_state_path(ctx)
 
         with console_session(
@@ -88,6 +95,9 @@ class ApkPurePublisher(Publisher):
             selectors=selectors,
             headless=headless,
             timeout_ms=ctx.options.timeout_seconds * 1000,
+            mode=mode,
+            profile_dir=_optional_path(ctx.config.option("profileDir")),
+            cdp_endpoint=str(ctx.config.option("cdpEndpoint", DEFAULT_CDP_ENDPOINT)),
         ) as session:
             session.open_app(package_id)
 
@@ -127,3 +137,7 @@ class ApkPurePublisher(Publisher):
             f"Submitted {artifact.filename} to APKPure review for {package_id}",
             {**plan, "submitted": True},
         )
+
+
+def _optional_path(value: object) -> Path | None:
+    return Path(str(value)).expanduser() if value else None


### PR DESCRIPTION
## Problem

APKPure sits behind Cloudflare, which challenges Playwright's bundled Chromium before the developer console is reachable. `login apkpure` cannot get through.

## What this does *not* do

No stealth plugins, no fingerprint or user-agent spoofing, no automated challenge solving. Evading bot detection is not the fix here.

## What it does instead

Lets a human drive a real browser through the check, and runs the automation inside the session that human established. Three modes via `--browser`, the `browser` target option, or `APKPURE_BROWSER`:

| Mode | What it does | When |
| --- | --- | --- |
| `bundled` (default, unchanged) | Playwright Chromium replaying a saved storage state | Fast, headless-capable, the one that gets challenged |
| `chrome` | Real Google Chrome, persistent profile that survives runs | Cloudflare challenges the bundled browser |
| `cdp` | Attaches to a Chrome you started and signed in yourself | Strongest: nothing about the session is synthesised |

`chrome` and `cdp` carry their session in the browser profile, so preflight no longer demands a storage state in those modes. Both force headed operation, since a human may need to intervene.

```bash
python3 -m tools.publish login apkpure --browser chrome
python3 -m tools.publish doctor apkpure --browser cdp --package-id io.airo.app.tv
```

Under `--browser cdp`, `login` is a no-op that prints the Chrome invocation to use. In `cdp` mode the tool attaches to a tab and **detaches** when done — it never closes a browser it does not own.

## The honest exit

If Cloudflare still blocks a real, human-signed-in Chrome, that is APKPure declining automated uploads. The answer then is the existing `ManualPublisher` path — checklist, `BLOCKED` status, human upload — not a better disguise. That's documented in the README rather than left for someone to rediscover.

## Tests

47 (up from 41). New coverage: `bundled` still requires a saved session while `chrome`/`cdp` do not; mode precedence is config → env → default; an unknown mode is rejected.

Selectors remain UNVERIFIED and APKPure remains `enabled: false` — this unblocks reaching the console, nothing more.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
