### PR TITLE
feat(release): drive APKPure with any Chromium browser, defaulting to the system one

### DIFF
--- a/scripts/tests/test_publish_framework.py
+++ b/scripts/tests/test_publish_framework.py
@@ -30,7 +30,12 @@ from tools.publish.errors import (  # noqa: E402
     ManifestError,
     PreflightError,
 )
-from tools.publish.apkpure.console import BrowserMode, resolve_browser_mode  # noqa: E402
+from tools.publish.apkpure.console import (  # noqa: E402
+    KNOWN_CHROMIUM_BROWSERS,
+    BrowserMode,
+    resolve_browser_mode,
+    resolve_browser_path,
+)
 from tools.publish.evidence import EvidenceRecorder  # noqa: E402
 from tools.publish.fetch import FetchedRelease, index_manifests  # noqa: E402
 from tools.publish.models import PublishStatus, ReleaseMetadata  # noqa: E402
@@ -613,6 +618,31 @@ class BrowserModeTests(unittest.TestCase):
     def test_unknown_mode_is_rejected(self) -> None:
         with self.assertRaises(PreflightError):
             resolve_browser_mode("firefox", {})
+
+    def test_browser_path_shorthands_resolve_to_real_binaries(self) -> None:
+        for name in ("arc", "brave", "chrome", "edge"):
+            with self.subTest(browser=name):
+                path = Path(KNOWN_CHROMIUM_BROWSERS[name])
+                if not path.exists():
+                    self.skipTest(f"{name} is not installed on this machine")
+                self.assertEqual(resolve_browser_path(name), path)
+
+    def test_browser_path_accepts_an_explicit_path(self) -> None:
+        with tempfile.NamedTemporaryFile() as handle:
+            self.assertEqual(resolve_browser_path(handle.name), Path(handle.name))
+
+    def test_unknown_browser_path_is_rejected(self) -> None:
+        with self.assertRaises(PreflightError):
+            resolve_browser_path("/nonexistent/Browser.app/Contents/MacOS/Browser")
+
+    def test_no_browser_path_means_playwrights_own_chrome_channel(self) -> None:
+        self.assertIsNone(resolve_browser_path(None))
+
+    @unittest.skipUnless(sys.platform == "darwin", "LaunchServices is macOS-only")
+    def test_default_resolves_to_an_executable_browser(self) -> None:
+        resolved = resolve_browser_path("default")
+        self.assertIsNotNone(resolved)
+        self.assertTrue(resolved.is_file(), resolved)
 
     def _context(self, root: Path, options: dict) -> PublishContext:
         release = ReleaseMetadata.from_manifest_file(write_release(root))

--- a/tools/publish/README.md
+++ b/tools/publish/README.md
@@ -175,7 +175,20 @@ established. Pick a mode with `--browser`, the `browser` target option, or
 `chrome` and `cdp` need no storage state — the session lives in the browser
 profile — and both run headed, because a human may need to clear a check.
 
-Sign in to a persistent Chrome profile:
+`chrome` mode drives any Chromium-family browser, not just Google's. Point it
+with `--browser-path`, which defaults to `default` — this machine's actual
+default browser, read from LaunchServices rather than guessed:
+
+| `--browser-path` | Resolves to |
+| --- | --- |
+| `default` (the default) | whichever browser handles `https` on this Mac |
+| `arc`, `brave`, `chrome`, `edge` | that app's executable |
+| any path | used as-is |
+
+Arc, Brave, and Edge are all Chromium underneath, so they work here even though
+Playwright's own `channel=` only knows Google's builds.
+
+Sign in to a persistent profile in your default browser:
 
 ```bash
 python3 -m tools.publish login apkpure --browser chrome

--- a/tools/publish/apkpure/console.py
+++ b/tools/publish/apkpure/console.py
@@ -15,6 +15,8 @@ from __future__ import annotations
 
 import contextlib
 import json
+import plistlib
+import sys
 from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
@@ -223,6 +225,92 @@ def resolve_browser_mode(configured: object, env: dict[str, str] | None = None) 
 DEFAULT_PROFILE_DIR = Path.home() / ".config" / "airo" / "apkpure-chrome-profile"
 DEFAULT_CDP_ENDPOINT = "http://127.0.0.1:9222"
 
+#: Chromium-family browsers a user is likely to already have signed in. Any of
+#: these can back the `chrome` mode via --browser-path; Playwright's `channel`
+#: only knows about Google's own builds.
+KNOWN_CHROMIUM_BROWSERS = {
+    "arc": "/Applications/Arc.app/Contents/MacOS/Arc",
+    "brave": "/Applications/Brave Browser.app/Contents/MacOS/Brave Browser",
+    "chrome": "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+    "edge": "/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge",
+}
+
+
+LAUNCH_SERVICES_PLIST = (
+    "Library/Preferences/com.apple.LaunchServices/com.apple.launchservices.secure.plist"
+)
+
+
+def default_browser_path() -> Path:
+    """The executable of whichever browser handles https on this Mac.
+
+    Read from LaunchServices rather than guessed, then resolved to a real
+    binary by scanning app bundles for the matching identifier. Spotlight is
+    not consulted: `mdfind` returns nothing when indexing is off.
+    """
+    if sys.platform != "darwin":
+        raise PreflightError(
+            "--browser-path default only resolves the system browser on macOS. "
+            "Pass an explicit path, or one of: "
+            + ", ".join(sorted(KNOWN_CHROMIUM_BROWSERS))
+        )
+    plist = Path.home() / LAUNCH_SERVICES_PLIST
+    bundle_id = ""
+    if plist.is_file():
+        with contextlib.suppress(Exception):
+            handlers = plistlib.loads(plist.read_bytes()).get("LSHandlers", [])
+            for handler in handlers:
+                if handler.get("LSHandlerURLScheme") == "https":
+                    bundle_id = str(
+                        handler.get("LSHandlerRoleAll")
+                        or handler.get("LSHandlerRoleViewer")
+                        or ""
+                    ).lower()
+                    break
+    if not bundle_id:
+        raise PreflightError(
+            "Could not read the default browser from LaunchServices. Pass "
+            "--browser-path with an explicit browser instead."
+        )
+
+    for root in (Path("/Applications"), Path.home() / "Applications"):
+        if not root.is_dir():
+            continue
+        for app in sorted(root.glob("*.app")):
+            info = app / "Contents" / "Info.plist"
+            if not info.is_file():
+                continue
+            try:
+                data = plistlib.loads(info.read_bytes())
+            except Exception:  # noqa: BLE001 - a malformed bundle is not fatal
+                continue
+            if str(data.get("CFBundleIdentifier", "")).lower() != bundle_id:
+                continue
+            executable = app / "Contents" / "MacOS" / str(data.get("CFBundleExecutable", ""))
+            if executable.is_file():
+                return executable
+    raise PreflightError(
+        f"Default browser {bundle_id!r} is not an app bundle this tool can launch. "
+        "Pass --browser-path with an explicit Chromium-family browser."
+    )
+
+
+def resolve_browser_path(value: object) -> Path | None:
+    """Accept either a shorthand name (arc, brave, edge) or a full path."""
+    if not value:
+        return None
+    raw = str(value).strip()
+    if raw.lower() == "default":
+        return default_browser_path()
+    candidate = Path(KNOWN_CHROMIUM_BROWSERS.get(raw.lower(), raw)).expanduser()
+    if not candidate.exists():
+        known = ", ".join(sorted(KNOWN_CHROMIUM_BROWSERS))
+        raise PreflightError(
+            f"Browser executable not found: {candidate}. "
+            f"Pass a full path, or one of: {known}."
+        )
+    return candidate
+
 
 @contextlib.contextmanager
 def console_session(
@@ -235,6 +323,7 @@ def console_session(
     mode: BrowserMode = BrowserMode.BUNDLED,
     profile_dir: Path | None = None,
     cdp_endpoint: str = DEFAULT_CDP_ENDPOINT,
+    browser_path: Path | None = None,
 ) -> Iterator[ConsoleSession]:
     """Open an APKPure console page using whichever browser `mode` selects."""
     sync_playwright = import_playwright()
@@ -245,7 +334,11 @@ def console_session(
             manager = _cdp_context(playwright, cdp_endpoint, evidence)
         elif mode is BrowserMode.CHROME:
             manager = _persistent_chrome_context(
-                playwright, profile_dir or DEFAULT_PROFILE_DIR, headless, evidence
+                playwright,
+                profile_dir or DEFAULT_PROFILE_DIR,
+                headless,
+                evidence,
+                browser_path,
             )
         else:
             manager = _bundled_context(playwright, storage_state, headless, evidence)
@@ -290,7 +383,11 @@ def _bundled_context(playwright, storage_state: Path, headless: bool, evidence: 
 
 @contextlib.contextmanager
 def _persistent_chrome_context(
-    playwright, profile_dir: Path, headless: bool, evidence: EvidenceRecorder
+    playwright,
+    profile_dir: Path,
+    headless: bool,
+    evidence: EvidenceRecorder,
+    executable_path: Path | None = None,
 ):
     """Real Chrome with a profile that persists between runs.
 
@@ -300,18 +397,23 @@ def _persistent_chrome_context(
     """
     profile_dir = profile_dir.expanduser()
     profile_dir.mkdir(parents=True, exist_ok=True)
-    evidence.log(f"chrome profile: {profile_dir}")
+    evidence.log(f"browser profile: {profile_dir}")
+    launch: dict = {"channel": "chrome"} if executable_path is None else {
+        "executable_path": str(executable_path)
+    }
+    evidence.log(f"launching {executable_path or 'channel=chrome'}")
     try:
         context = playwright.chromium.launch_persistent_context(
             str(profile_dir),
-            channel="chrome",
             headless=headless,
             viewport=DEFAULT_VIEWPORT,
             accept_downloads=False,
+            **launch,
         )
     except Exception as exc:  # noqa: BLE001 - Playwright raises its own errors
         raise PreflightError(
-            f"Could not start Google Chrome ({exc}). Install Chrome, or use "
+            f"Could not start {executable_path or 'Google Chrome'} ({exc}). "
+            "Pass --browser-path arc|brave|edge or a full path, or use "
             "--browser cdp to attach to a browser you started yourself."
         ) from exc
     try:
@@ -353,6 +455,7 @@ def interactive_chrome_login(
     profile_dir: Path,
     evidence: EvidenceRecorder,
     confirm: Callable[[str], object] = input,
+    executable_path: Path | None = None,
 ) -> Path:
     """Sign in inside a persistent real-Chrome profile.
 
@@ -365,13 +468,17 @@ def interactive_chrome_login(
     profile_dir.mkdir(parents=True, exist_ok=True)
     with sync_playwright() as playwright:
         try:
+            launch: dict = {"channel": "chrome"} if executable_path is None else {
+                "executable_path": str(executable_path)
+            }
             context = playwright.chromium.launch_persistent_context(
-                str(profile_dir), channel="chrome", headless=False, viewport=DEFAULT_VIEWPORT
+                str(profile_dir), headless=False, viewport=DEFAULT_VIEWPORT, **launch
             )
         except Exception as exc:  # noqa: BLE001 - Playwright raises its own errors
             raise PreflightError(
-                f"Could not start Google Chrome ({exc}). Install Chrome, or sign in "
-                "with your own browser and use --browser cdp instead."
+                f"Could not start {executable_path or 'Google Chrome'} ({exc}). Pass "
+                "--browser-path arc|brave|edge, or sign in with your own browser and "
+                "use --browser cdp instead."
             ) from exc
         page = context.pages[0] if context.pages else context.new_page()
         page.goto(SIGN_IN_URL, wait_until="domcontentloaded")

--- a/tools/publish/cli.py
+++ b/tools/publish/cli.py
@@ -29,6 +29,7 @@ from .apkpure.console import (
     interactive_chrome_login,
     interactive_login,
     resolve_browser_mode,
+    resolve_browser_path,
 )
 from .apkpure.selectors import SelectorSet, console_url
 from .config import REPO_ROOT, PublishConfig
@@ -101,6 +102,14 @@ def build_parser() -> argparse.ArgumentParser:
         help="bundled saves a storage state; chrome signs in to a persistent Chrome profile.",
     )
     login.add_argument("--profile-dir", type=Path, default=None)
+    login.add_argument(
+        "--browser-path",
+        default="default",
+        help=(
+            "Chromium-family browser for --browser chrome. 'default' (the default) uses "
+            "this machine's default browser; or arc|brave|edge|chrome, or a full path."
+        ),
+    )
 
     doctor = sub.add_parser("doctor", help="Dump a store console page so selectors can be re-mapped.")
     doctor.add_argument("target", choices=["apkpure"])
@@ -120,6 +129,14 @@ def build_parser() -> argparse.ArgumentParser:
     )
     doctor.add_argument("--profile-dir", type=Path, default=None)
     doctor.add_argument("--cdp-endpoint", default=DEFAULT_CDP_ENDPOINT)
+    doctor.add_argument(
+        "--browser-path",
+        default="default",
+        help=(
+            "Chromium-family browser for --browser chrome. 'default' (the default) uses "
+            "this machine's default browser; or arc|brave|edge|chrome, or a full path."
+        ),
+    )
 
     return parser
 
@@ -288,7 +305,9 @@ def cmd_login(args: argparse.Namespace) -> int:
             "check — this tool never reads, types, or stores your password. The session\n"
             f"stays inside the Chrome profile at:\n  {profile}\n"
         )
-        interactive_chrome_login(profile, evidence)
+        interactive_chrome_login(
+            profile, evidence, executable_path=resolve_browser_path(args.browser_path)
+        )
         print(f"\nDone. Re-run doctor/run with --browser chrome (profile: {profile}).")
         return 0
 
@@ -317,6 +336,7 @@ def cmd_doctor(args: argparse.Namespace) -> int:
         mode=mode,
         profile_dir=args.profile_dir,
         cdp_endpoint=args.cdp_endpoint,
+        browser_path=resolve_browser_path(args.browser_path),
     ) as session:
         session.open_app(args.package_id)
         report = {

--- a/tools/publish/publishers/apkpure.py
+++ b/tools/publish/publishers/apkpure.py
@@ -15,7 +15,12 @@ from __future__ import annotations
 from pathlib import Path
 from typing import ClassVar
 
-from ..apkpure.console import BrowserMode, console_session, resolve_browser_mode
+from ..apkpure.console import (
+    BrowserMode,
+    console_session,
+    resolve_browser_mode,
+    resolve_browser_path,
+)
 from ..apkpure.console import DEFAULT_CDP_ENDPOINT
 from ..apkpure.selectors import SelectorSet, console_url
 from ..errors import ConfigError
@@ -98,6 +103,7 @@ class ApkPurePublisher(Publisher):
             mode=mode,
             profile_dir=_optional_path(ctx.config.option("profileDir")),
             cdp_endpoint=str(ctx.config.option("cdpEndpoint", DEFAULT_CDP_ENDPOINT)),
+            browser_path=resolve_browser_path(ctx.config.option("browserPath")),
         ) as session:
             session.open_app(package_id)
 


### PR DESCRIPTION
Follow-up to #1520.

## Problem

`--browser chrome` went through Playwright's `channel="chrome"`, which only targets Google's own builds. It cannot launch Arc, Brave, or Edge — all Chromium underneath, and far more likely to be the browser a maintainer is already signed in to. On a machine where Arc is the default browser, the `chrome` mode was unusable.

## Change

`--browser-path` (and the `browserPath` target option) now accepts:

| Value | Resolves to |
| --- | --- |
| `default` — **the new default** | whichever browser handles `https` on this Mac |
| `arc`, `brave`, `chrome`, `edge` | that app's executable |
| any path | used as-is |

`default` reads the https handler from LaunchServices and resolves it to a binary by matching `CFBundleIdentifier` across app bundles in `/Applications` and `~/Applications`.

**Spotlight is deliberately not used.** `mdfind` returns nothing when indexing is off — which is exactly the case on the machine this was built for, so the obvious implementation would have silently failed there. Verified end to end: `default` → `/Applications/Arc.app/Contents/MacOS/Arc`.

Non-macOS gets a clear error naming the explicit alternatives rather than a confusing failure.

## Still no stealth

This widens *which real browser a human can drive*. It changes nothing about how challenges are handled: no fingerprint spoofing, no automated CAPTCHA solving. If Cloudflare blocks a real, human-signed-in browser, the answer remains the `ManualPublisher` path.

## Tests

52. The shorthand test skips **per browser** rather than per case, so a machine without Edge reports one honest skip instead of quietly passing a loop that tested nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
