### PR TITLE
fix(release): name the browser APKPure login actually launches

### DIFF
--- a/tools/publish/apkpure/console.py
+++ b/tools/publish/apkpure/console.py
@@ -484,7 +484,7 @@ def interactive_chrome_login(
         page.goto(SIGN_IN_URL, wait_until="domcontentloaded")
         evidence.log(f"opened {SIGN_IN_URL} in persistent Chrome profile {profile_dir}")
         confirm(
-            "\nSign in to APKPure in the Chrome window that just opened, clearing any\n"
+            "\nSign in to APKPure in the browser window that just opened, clearing any\n"
             "Cloudflare check yourself. Then press Enter here to close it: "
         )
         with contextlib.suppress(Exception):

--- a/tools/publish/cli.py
+++ b/tools/publish/cli.py
@@ -300,14 +300,17 @@ def cmd_login(args: argparse.Namespace) -> int:
 
     if mode is BrowserMode.CHROME:
         profile = (args.profile_dir or DEFAULT_PROFILE_DIR).expanduser()
+        executable = resolve_browser_path(args.browser_path)
+        # Name the browser actually being launched: --browser-path defaults to
+        # this machine's default browser, which is often not Google Chrome.
+        browser_name = executable.name if executable else "Google Chrome"
         print(
-            "Real Chrome will open. Sign in to APKPure yourself and clear any Cloudflare\n"
-            "check — this tool never reads, types, or stores your password. The session\n"
-            f"stays inside the Chrome profile at:\n  {profile}\n"
+            f"Launching {browser_name} ({executable or 'via Playwright channel=chrome'}).\n"
+            "Sign in to APKPure yourself and clear any Cloudflare check — this tool never\n"
+            "reads, types, or stores your password. The session stays inside the browser\n"
+            f"profile at:\n  {profile}\n"
         )
-        interactive_chrome_login(
-            profile, evidence, executable_path=resolve_browser_path(args.browser_path)
-        )
+        interactive_chrome_login(profile, evidence, executable_path=executable)
         print(f"\nDone. Re-run doctor/run with --browser chrome (profile: {profile}).")
         return 0
 


### PR DESCRIPTION
Follow-up to #1521, found while running the flow for real.

`--browser-path` defaults to this machine's default browser. On a Mac where Arc is the default, `login apkpure --browser chrome` printed:

> Real Chrome will open.

…and then opened **Arc**.

That matters more than a wording nit: the very next instruction is "wait for a browser window to appear and sign in". If the named application never appears, a launch failure is indistinguishable from a slow start, and the user sits waiting on a prompt that will never arrive.

Both messages now name the resolved executable, or say plainly that Playwright's `chrome` channel is in use when no path resolved.

```
Launching Arc (/Applications/Arc.app/Contents/MacOS/Arc).
Sign in to APKPure yourself and clear any Cloudflare check — ...
```

The inner prompt drops "Chrome window" for "browser window" for the same reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
