### PR TITLE
fix(release): fail fast when the chosen browser cannot speak CDP

### DIFF
--- a/scripts/tests/test_publish_framework.py
+++ b/scripts/tests/test_publish_framework.py
@@ -35,6 +35,7 @@ from tools.publish.apkpure.console import (  # noqa: E402
     BrowserMode,
     resolve_browser_mode,
     resolve_browser_path,
+    supports_cdp,
 )
 from tools.publish.evidence import EvidenceRecorder  # noqa: E402
 from tools.publish.fetch import FetchedRelease, index_manifests  # noqa: E402
@@ -643,6 +644,24 @@ class BrowserModeTests(unittest.TestCase):
         resolved = resolve_browser_path("default")
         self.assertIsNotNone(resolved)
         self.assertTrue(resolved.is_file(), resolved)
+
+    def test_arc_is_known_not_to_expose_cdp(self) -> None:
+        """Arc accepts --remote-debugging-port and never opens the port.
+
+        Verified by probing Arc and Chrome identically: Chrome answered
+        /json/version, Arc refused the connection. Without this guard the only
+        symptom is ECONNREFUSED several steps after the real mistake.
+        """
+        arc = Path(KNOWN_CHROMIUM_BROWSERS["arc"])
+        self.assertFalse(supports_cdp(arc))
+
+    def test_mainstream_chromium_browsers_are_not_blocked(self) -> None:
+        for name in ("chrome", "brave", "edge"):
+            with self.subTest(browser=name):
+                self.assertTrue(supports_cdp(Path(KNOWN_CHROMIUM_BROWSERS[name])))
+
+    def test_bundled_chromium_is_not_blocked(self) -> None:
+        self.assertTrue(supports_cdp(None))
 
     def _context(self, root: Path, options: dict) -> PublishContext:
         release = ReleaseMetadata.from_manifest_file(write_release(root))

--- a/tools/publish/README.md
+++ b/tools/publish/README.md
@@ -185,8 +185,15 @@ default browser, read from LaunchServices rather than guessed:
 | `arc`, `brave`, `chrome`, `edge` | that app's executable |
 | any path | used as-is |
 
-Arc, Brave, and Edge are all Chromium underneath, so they work here even though
+Brave and Edge are Chromium underneath, so they work here even though
 Playwright's own `channel=` only knows Google's builds.
+
+**Arc is the exception.** It accepts `--remote-debugging-port` and then never
+opens the port, so `--browser cdp` against Arc can only ever fail with a
+connection refused several steps after the real mistake. Verified by probing
+Arc and Chrome identically: Chrome answered `/json/version`, Arc refused. If
+Arc is your default browser, pass `--browser-path chrome` explicitly — you sign
+in to APKPure there once, and it does not have to be your default browser.
 
 Sign in to a persistent profile in your default browser:
 

--- a/tools/publish/apkpure/console.py
+++ b/tools/publish/apkpure/console.py
@@ -295,6 +295,16 @@ def default_browser_path() -> Path:
     )
 
 
+#: Chromium forks that ship without the DevTools protocol. Arc launches
+#: happily with --remote-debugging-port and then never opens the port, so the
+#: only symptom is a connection refused several steps later.
+BROWSERS_WITHOUT_CDP = {"arc"}
+
+
+def supports_cdp(executable: Path | None) -> bool:
+    return not (executable and executable.name.lower() in BROWSERS_WITHOUT_CDP)
+
+
 def resolve_browser_path(value: object) -> Path | None:
     """Accept either a shorthand name (arc, brave, edge) or a full path."""
     if not value:
@@ -331,7 +341,7 @@ def console_session(
 
     with sync_playwright() as playwright:
         if mode is BrowserMode.CDP:
-            manager = _cdp_context(playwright, cdp_endpoint, evidence)
+            manager = _cdp_context(playwright, cdp_endpoint, evidence, browser_path)
         elif mode is BrowserMode.CHROME:
             manager = _persistent_chrome_context(
                 playwright,
@@ -424,7 +434,12 @@ def _persistent_chrome_context(
 
 
 @contextlib.contextmanager
-def _cdp_context(playwright, endpoint: str, evidence: EvidenceRecorder):
+def _cdp_context(
+    playwright,
+    endpoint: str,
+    evidence: EvidenceRecorder,
+    browser_path: Path | None = None,
+):
     """Attach to a Chrome the human already started and signed in.
 
     The human clears any Cloudflare or login challenge in their own browser.
@@ -432,15 +447,26 @@ def _cdp_context(playwright, endpoint: str, evidence: EvidenceRecorder):
     drives a tab in a session that a human established.
     """
     evidence.log(f"attaching over CDP to {endpoint}")
+    if not supports_cdp(browser_path):
+        raise PreflightError(
+            f"{browser_path.name} does not expose the DevTools protocol: it accepts "
+            "--remote-debugging-port and then never opens the port, so this attach can "
+            "only ever fail. Use a browser that does, for example:\n"
+            "  --browser cdp --browser-path chrome\n"
+            "You sign in to APKPure there once; it does not have to be your default browser."
+        )
     try:
         browser = playwright.chromium.connect_over_cdp(endpoint)
     except Exception as exc:  # noqa: BLE001 - Playwright raises its own errors
+        launcher = str(browser_path or "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome")
         raise PreflightError(
-            f"Could not attach to Chrome at {endpoint} ({exc}).\n"
-            "Start Chrome with remote debugging first, for example:\n"
-            "  /Applications/Google\\ Chrome.app/Contents/MacOS/Google\\ Chrome \\\n"
-            "    --remote-debugging-port=9222 --user-data-dir=\"$HOME/.config/airo/apkpure-chrome-profile\"\n"
-            "then sign in to APKPure in that window before re-running."
+            f"Could not attach to a browser at {endpoint} ({exc}).\n"
+            "Nothing is listening there. Start the browser with remote debugging first:\n"
+            f"  '{launcher}' \\\n"
+            "    --remote-debugging-port=9222 \\\n"
+            "    --user-data-dir=\"$HOME/.config/airo/apkpure-chrome-profile\"\n"
+            "then sign in to APKPure in that window and re-run this command.\n"
+            "Note: Arc accepts the flag but never opens the port -- use Chrome or Brave."
         ) from exc
     context = browser.contexts[0] if browser.contexts else browser.new_context()
     try:


### PR DESCRIPTION
Found by running the flow for real, not by reading code.

## What happened

`doctor apkpure --browser cdp` failed with:

```
PreflightError: Could not attach to Chrome at http://127.0.0.1:9222 (ECONNREFUSED)
Start Chrome with remote debugging first, for example:
  /Applications/Google\ Chrome.app/...
```

Two problems in one message. The user's default browser is **Arc**, so `--browser-path` had resolved to Arc — the error named the wrong browser. And Arc *cannot* satisfy the instruction anyway.

## The finding

Arc accepts `--remote-debugging-port`, launches normally, and **never opens the port**.

Probed Arc and Chrome identically, scratch profile each, same script:

| Browser | `/json/version` |
| --- | --- |
| Chrome | `{"Browser": "Chrome/150.0.7871.187", "Protocol-Version": "1.3", ...}` |
| Arc | connection refused |

The Chrome control is what makes this conclusive — without it, a failed probe would only have proved my probe was broken.

So this is a property of Arc, not something a user fixes by trying harder.

## Change

- CDP attach refuses **up front** for browsers known not to expose the protocol, naming one that does.
- The generic connection-refused path names the browser actually resolved, instead of hardcoding Google Chrome, and warns about the Arc trap.
- README says plainly that Arc is the exception among Chromium forks, and that the automation browser does not have to be your default.

## Tests

55. Arc is asserted unsupported; Chrome, Brave, Edge and the bundled Chromium are asserted unaffected, so the guard can't quietly widen into blocking working browsers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
