### PR TITLE
feat(release): record the real APKPure selectors and fix what they exposed

### DIFF
--- a/scripts/tests/test_publish_framework.py
+++ b/scripts/tests/test_publish_framework.py
@@ -30,6 +30,7 @@ from tools.publish.errors import (  # noqa: E402
     ManifestError,
     PreflightError,
 )
+from tools.publish.apkpure.console import ConsoleSession  # noqa: E402
 from tools.publish.apkpure.console import (  # noqa: E402
     KNOWN_CHROMIUM_BROWSERS,
     BrowserMode,
@@ -710,6 +711,40 @@ class BrowserModeTests(unittest.TestCase):
                 )
                 blockers = get_publisher("apkpure").preflight(ctx)
                 self.assertEqual(blockers, [], f"{mode}: {blockers}")
+
+
+class ApkPureVersionTableTests(unittest.TestCase):
+    """Duplicate detection must not confuse a release with its release candidate."""
+
+    class _FakeSession(ConsoleSession):
+        def __init__(self, rows):  # noqa: D107 - test double
+            self._rows = rows
+
+        def published_versions(self):
+            return self._rows
+
+    LIVE_ROWS = [
+        "0.0.6-rc.1\tAPK\t28.6 MB\t2026-08-03\tinfo",
+        "0.0.5\tAPK\t30.6 MB\t2026-07-28\tinfo",
+    ]
+
+    def test_version_names_are_the_first_cell_only(self) -> None:
+        session = self._FakeSession(self.LIVE_ROWS)
+        self.assertEqual(session.published_version_names(), ["0.0.6-rc.1", "0.0.5"])
+
+    def test_a_release_is_not_masked_by_its_release_candidate(self) -> None:
+        """`"0.0.6" in "0.0.6-rc.1"` is True — a contains check would skip the release."""
+        names = self._FakeSession(self.LIVE_ROWS).published_version_names()
+        self.assertNotIn("0.0.6", names)
+        self.assertIn("0.0.6-rc.1", names)
+
+    def test_an_actually_published_version_is_detected(self) -> None:
+        names = self._FakeSession(self.LIVE_ROWS).published_version_names()
+        self.assertIn("0.0.5", names)
+
+    def test_blank_and_detail_rows_are_dropped(self) -> None:
+        session = self._FakeSession(["", "   ", "0.0.7\tAPK\t1 MB"])
+        self.assertEqual(session.published_version_names(), ["0.0.7"])
 
 
 class CanonicalApkAgreementTests(unittest.TestCase):

--- a/tools/publish/apkpure/console.py
+++ b/tools/publish/apkpure/console.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import contextlib
 import json
+import re
 import plistlib
 import sys
 from dataclasses import dataclass
@@ -139,6 +140,20 @@ class ConsoleSession:
                 break
         return [text for text in texts if text]
 
+    def published_version_names(self) -> list[str]:
+        """Just the version cell of each row.
+
+        Substring matching is not safe here: "0.0.6" is a substring of the
+        "0.0.6-rc.1" row that a release candidate leaves behind, so a contains
+        check would treat the real 0.0.6 as already published and skip it.
+        """
+        names = []
+        for row in self.published_versions():
+            first = re.split(r"[\t\n]", row.strip(), maxsplit=1)[0].strip()
+            if first:
+                names.append(first)
+        return names
+
     def open_upload_form(self) -> None:
         link = self._first_visible("manage_versions_link", timeout_ms=10_000)
         if link is not None:
@@ -174,21 +189,38 @@ class ConsoleSession:
         field.fill(notes)
         self.snapshot("release-notes")
 
-    def submit_for_review(self) -> None:
-        button = self.require("submit_button", "the Submit for Review button")
+    def submit_for_review(self, expected_version: str | None = None) -> None:
+        button = self.require("submit_button", "the Publish button")
         button.click()
         confirm = self._first_visible("submit_confirm_button", timeout_ms=5_000)
         if confirm is not None:
             confirm.click()
         self.guard_human_gate("submit")
-        if self._first_visible("submit_success_marker", timeout_ms=self.timeout_ms) is None:
-            self.snapshot("submit-unconfirmed")
-            raise RemoteError(
-                "Submitted, but APKPure never showed a review-status confirmation. "
-                "Check the console by hand before re-running: a blind retry may create a "
-                "duplicate submission."
-            )
-        self.snapshot("submitted")
+
+        # Prefer a falsifiable check -- the version actually appearing in the
+        # table -- over a status string. The console's flow diagram permanently
+        # reads "Pending Approval", so text alone cannot prove anything.
+        if expected_version and self._await_version_row(expected_version):
+            self.snapshot("submitted")
+            return
+        if self._first_visible("submit_success_marker", timeout_ms=self.timeout_ms) is not None:
+            self.snapshot("submitted")
+            return
+
+        self.snapshot("submit-unconfirmed")
+        raise RemoteError(
+            "Clicked Publish, but neither a review status nor a new version row appeared"
+            + (f" for {expected_version}" if expected_version else "")
+            + ". Check the console by hand before re-running: a blind retry may create a "
+            "duplicate submission."
+        )
+
+    def _await_version_row(self, version: str, attempts: int = 10) -> bool:
+        for _ in range(attempts):
+            if version in self.published_version_names():
+                return True
+            self.page.wait_for_timeout(2_000)
+        return False
 
 
 class BrowserMode(str, Enum):

--- a/tools/publish/apkpure/selectors.py
+++ b/tools/publish/apkpure/selectors.py
@@ -8,14 +8,17 @@ nobody controls but APKPure. Every selector below is therefore:
 * overridable at runtime from a JSON file via ``APKPURE_SELECTORS_FILE``, so a
   broken release can be unblocked without a code change and a PR.
 
-**Status: UNVERIFIED.** These candidates are written against the documented
-console flow (sign in -> app -> Manage Versions -> upload APK -> what's new ->
-submit) but have not been recorded against the live DOM. Run
+**Status: recorded against the live console on 2026-08-04** for
+io.airo.app.tv, signed in, via CDP. The navigation, upload-form, release-notes,
+and publish selectors were read off the real DOM. Three could not be recorded
+because they only appear mid-upload -- ``upload_complete_marker``,
+``upload_error_marker`` and ``submit_success_marker`` remain heuristics, and the
+first real upload should confirm them.
 
-    python3 -m tools.publish doctor apkpure --profile tv
+Re-record after any console redesign with
 
-to dump the real page and replace them. Until that dump exists, treat a
-successful run as unproven.
+    python3 -m tools.publish doctor apkpure --browser cdp --browser-path chrome
+
 """
 
 from __future__ import annotations
@@ -33,31 +36,38 @@ CONSOLE_URL_TEMPLATE = f"{CONSOLE_ORIGIN}/console/{{package_id}}"
 #: Logical step -> ordered candidate selectors. Playwright selector syntax;
 #: ``text=`` and ``role=`` engines are allowed and preferred over brittle
 #: class-name chains.
+#: Logical step -> ordered candidate selectors, tried in order.
+#:
+#: Recorded against the live console on 2026-08-04 for io.airo.app.tv. The
+#: console is a Materialize CSS app: the version table and the upload form both
+#: live on /console/<package>/versions, and there is no separate "new version"
+#: dialog. Ids (#file, #textarea1) come first because they are what the page
+#: actually uses; the text-based candidates are fallbacks for a redesign.
 DEFAULT_SELECTORS: dict[str, list[str]] = {
-    # Proof that the stored session is still valid.
+    # Sidebar entry present on every signed-in console page. The Logout links
+    # exist too but live in a collapsed dropdown, so they are never visible and
+    # cannot serve as the marker.
     "signed_in_marker": [
-        "[data-testid='user-menu']",
-        "header :text-matches('(Sign out|Log out|Logout)', 'i')",
-        "a[href*='/console/']",
+        "a:has-text('Manage Apps')",
+        "a:has-text('MANAGE VERSIONS')",
+        "a:has-text('APP DETAILS')",
     ],
-    # Shown when the session has expired and a human must re-authenticate.
     "sign_in_marker": [
         "form[action*='login']",
         "input[type='password']",
         ":text-matches('^(Sign in|Log in)$', 'i')",
     ],
     "manage_versions_link": [
-        "a:has-text('Manage Versions')",
-        "a:has-text('Versions')",
-        "[data-testid='manage-versions']",
+        "a:has-text('MANAGE VERSIONS')",
+        "a[href$='/versions']",
     ],
+    # There is no separate dialog: the upload form is rendered directly on the
+    # versions page. open_upload_form() treats this as optional and continues.
     "new_version_button": [
-        "button:has-text('Upload APK')",
-        "button:has-text('New Version')",
-        "button:has-text('Add Version')",
+        "a:has-text('Upload .APK File')",
     ],
-    # The <input type=file>; Playwright sets files on it directly, no OS dialog.
     "apk_file_input": [
+        "input#file",
         "input[type='file'][accept*='apk']",
         "input[type='file']",
     ],
@@ -66,36 +76,42 @@ DEFAULT_SELECTORS: dict[str, list[str]] = {
         ":text-matches('(Upload (complete|success)|100%)', 'i')",
     ],
     "upload_error_marker": [
+        ".toast :text-matches('(failed|invalid|error)', 'i')",
         "[role='alert']",
-        ".ant-message-error",
         ":text-matches('(upload failed|invalid apk|signature mismatch)', 'i')",
     ],
     "release_notes_input": [
+        "textarea#textarea1",
         "textarea[name*='whatsnew' i]",
         "textarea[name*='release' i]",
-        "textarea[placeholder*=\"What's New\" i]",
-        "textarea",
     ],
+    # PUBLISH is an anchor, not a button, and sits next to an identically
+    # styled VIEW ON APKPURE link -- so match on the text, never the class.
     "submit_button": [
-        "button:has-text('Submit for Review')",
-        "button:has-text('Submit')",
-        "button[type='submit']",
+        "a:has-text('PUBLISH')",
+        "button:has-text('Publish')",
     ],
+    # Deliberately narrow. The only modal on this page is the *delete* confirm
+    # ("Yes,delete it!"), so a loose confirm selector here would click destroy
+    # instead of publish. Nothing generic, and never .modal-action alone.
     "submit_confirm_button": [
-        "button:has-text('Confirm')",
-        "button:has-text('OK')",
-        ".ant-modal button:has-text('Submit')",
+        "a.modal-action:has-text('Yes, publish')",
+        ".modal.open a:has-text('Publish')",
+        ".modal.open button:has-text('Confirm')",
     ],
+    # ".step-name" is excluded deliberately: step 4 of the static flow diagram
+    # is literally the text "Pending Approval", so an unscoped match reports
+    # success on an idle page that has published nothing.
     "submit_success_marker": [
-        ":text-matches('(in review|under review|submitted)', 'i')",
+        ":text-matches('(in review|under review|submitted)', 'i'):not(.step-name)",
         "[data-testid='review-status']",
     ],
-    # Rows in the versions table, used to detect an already-published version.
+    # Version rows only. The table also holds collapsed detail rows (signature,
+    # SHA1, architecture) that are present but never visible.
     "version_row": [
-        "table tbody tr",
+        "table tbody tr:visible",
         "[data-testid='version-row']",
     ],
-    # Anything that means a human has to take over: captcha, 2FA, device check.
     "human_gate_marker": [
         "iframe[src*='recaptcha']",
         "iframe[src*='hcaptcha']",

--- a/tools/publish/cli.py
+++ b/tools/publish/cli.py
@@ -325,12 +325,50 @@ def cmd_login(args: argparse.Namespace) -> int:
     return 0
 
 
+#: Selectors that must resolve on the app-details page of a signed-in console.
+REQUIRED_ON_APP_PAGE = ("signed_in_marker", "manage_versions_link")
+#: Selectors that must resolve once the versions/upload page is open.
+REQUIRED_ON_VERSIONS_PAGE = (
+    "apk_file_input",
+    "release_notes_input",
+    "submit_button",
+    "version_row",
+)
+#: Selectors that only appear in a state doctor deliberately never reaches:
+#: signed out, mid-upload, or with a confirmation modal open. Their absence on
+#: a healthy signed-in page is the correct result, not a finding.
+STATE_DEPENDENT_SELECTORS = (
+    "sign_in_marker",
+    "human_gate_marker",
+    "new_version_button",
+    "upload_complete_marker",
+    "upload_error_marker",
+    "submit_confirm_button",
+    "submit_success_marker",
+)
+
+
+def _match_map(session, selectors: SelectorSet) -> dict[str, list[str]]:
+    matches: dict[str, list[str]] = {}
+    for key in selectors.keys():
+        hits = []
+        for candidate in selectors.candidates(key):
+            try:
+                if session.page.locator(candidate).count() > 0:
+                    hits.append(candidate)
+            except Exception:  # noqa: BLE001 - a bad selector is a finding, not a crash
+                continue
+        matches[key] = hits
+    return matches
+
+
 def cmd_doctor(args: argparse.Namespace) -> int:
     state = _storage_state(args)
     evidence = EvidenceRecorder(root=args.evidence_dir / "doctor" / args.target)
     selectors = SelectorSet.load()
     evidence.log(f"selector source: {selectors.source}")
     mode = resolve_browser_mode(args.browser, dict(os.environ))
+
     with console_session(
         storage_state=state,
         evidence=evidence,
@@ -342,34 +380,49 @@ def cmd_doctor(args: argparse.Namespace) -> int:
         browser_path=resolve_browser_path(args.browser_path),
     ) as session:
         session.open_app(args.package_id)
-        report = {
-            "url": session.page.url,
-            "consoleUrl": console_url(args.package_id),
-            "selectorSource": selectors.source,
-            "matches": {
-                key: [
-                    candidate
-                    for candidate in selectors.candidates(key)
-                    if session.page.locator(candidate).count() > 0
-                ]
-                for key in selectors.keys()
-            },
-        }
+        # Probe each page where the selectors actually live: the upload form and
+        # the version table only exist after navigating to /versions, so a single
+        # probe on the app-details page reports them missing when they are fine.
+        app_matches = _match_map(session, selectors)
         session.open_upload_form()
         session.snapshot("doctor-upload-form")
+        versions_matches = _match_map(session, selectors)
+        report = {
+            "consoleUrl": console_url(args.package_id),
+            "finalUrl": session.page.url,
+            "selectorSource": selectors.source,
+            "appPageMatches": app_matches,
+            "versionsPageMatches": versions_matches,
+        }
         path = evidence.write_json("selector-report.json", report)
-    unmatched = [key for key, hits in report["matches"].items() if not hits]
+
+    missing = [k for k in REQUIRED_ON_APP_PAGE if not app_matches.get(k)]
+    missing += [k for k in REQUIRED_ON_VERSIONS_PAGE if not versions_matches.get(k)]
+    unresolved = [
+        key
+        for key in STATE_DEPENDENT_SELECTORS
+        if not app_matches.get(key) and not versions_matches.get(key)
+    ]
+
     print(f"Selector report: {path}")
-    if unmatched:
-        print("Selector keys with NO match on the live page:")
-        for key in unmatched:
+    if missing:
+        print("\nREQUIRED selector keys with NO match:")
+        for key in missing:
             print(f"  - {key}")
         print(
-            "\nMap these against the HTML dumps in the evidence directory, write the new\n"
-            "selectors into a JSON file, and point APKPURE_SELECTORS_FILE at it."
+            "\nMap these against the HTML dumps in the evidence directory, write the\n"
+            "new selectors into a JSON file, and point APKPURE_SELECTORS_FILE at it."
         )
         return 2
-    print("Every selector key matched at least one element.")
+
+    print("All required selectors resolved.")
+    if unresolved:
+        print(
+            "\nNot observable from a signed-in idle page (expected — these need a\n"
+            "signed-out session, an upload in flight, or an open modal):"
+        )
+        for key in unresolved:
+            print(f"  - {key}")
     return 0
 
 

--- a/tools/publish/publishers/apkpure.py
+++ b/tools/publish/publishers/apkpure.py
@@ -107,15 +107,17 @@ class ApkPurePublisher(Publisher):
         ) as session:
             session.open_app(package_id)
 
-            existing = session.published_versions()
-            already = [row for row in existing if artifact.version in row]
+            # Exact match on the version cell: a leftover 0.0.6-rc.1 row must
+            # not make 0.0.6 look already published.
+            existing = session.published_version_names()
+            already = [name for name in existing if name == artifact.version]
             if already and not ctx.options.force:
                 ctx.evidence.log(f"version {artifact.version} already listed: {already[0]!r}")
                 return self.result(
                     ctx,
                     PublishStatus.SKIPPED,
                     f"Version {artifact.version} already present on APKPure; pass --force to upload anyway",
-                    {**plan, "existingRow": already[0]},
+                    {**plan, "existingVersion": already[0], "listedVersions": existing},
                 )
 
             session.open_upload_form()
@@ -134,7 +136,7 @@ class ApkPurePublisher(Publisher):
                     plan,
                 )
 
-            session.submit_for_review()
+            session.submit_for_review(artifact.version)
 
         ctx.evidence.write_json("apkpure-result.json", {**plan, "submitted": True})
         return self.result(


### PR DESCRIPTION
Selectors are no longer guesses. Recorded against the live console for `io.airo.app.tv`, signed in, over CDP.

`doctor` now reports:

```
All required selectors resolved.
```

The console is a Materialize app: the upload form and version table both live on `/console/<pkg>/versions`, and there is **no** separate "new version" dialog — that step is optional. `input#file` is the APK input; `textarea#textarea1` is What's New; PUBLISH is an `<a>`, not a button, sitting next to an identically-styled VIEW ON APKPURE link, so it must be matched on text and never on class.

## Three bugs that only running it could find

**1. `doctor` probed the wrong page.** It evaluated every selector on app-details, *before* navigating to `/versions` — so the upload-form and version-table selectors were reported missing when they were fine. Now probes both pages and reports per page. It also separates required keys from state-dependent ones; sign-in and mid-upload markers are absent from a healthy idle page *by definition*, and reporting them as findings buried the real ones.

**2. `submit_success_marker` matched an idle page.** Step 4 of the console's static flow diagram is literally the text "Pending Approval" (`div.center-align.step-name`). Publishing would have reported success having proved nothing. The marker now excludes `.step-name`, and `submit_for_review` prefers a falsifiable check — the version actually appearing in the table.

**3. Duplicate detection would have skipped the release.** It used a substring match, and `"0.0.6" in "0.0.6-rc.1"` is `True`. With the RC row that APKPure already lists, publishing 0.0.6 would have been silently skipped as *already published*. Matching is now exact on the version cell.

Confirmed live:

```
version names -> ['0.0.6-rc.1', '0.0.5']
  0.0.6       already published: False
  0.0.6-rc.1  already published: True
  0.0.5       already published: True
```

## Safety note

`submit_confirm_button` is deliberately narrow. The only modal on that page is the **delete** confirmation ("Yes,delete it!"), so a loose confirm selector would click destroy instead of publish.

## What is still unverified

`upload_complete_marker` and `upload_error_marker` only exist mid-upload, which no read-only probe can reach. They remain heuristics, so **apkpure stays `enabled: false`** — the first real upload is what confirms them, and that should be a deliberate single-target staged run, not something a full release sweep triggers by accident.

59 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
