### PR TITLE
fix(release): give run the same browser flags as doctor

### DIFF
--- a/scripts/tests/test_publish_framework.py
+++ b/scripts/tests/test_publish_framework.py
@@ -41,6 +41,7 @@ from tools.publish.apkpure.console import (  # noqa: E402
 from tools.publish.evidence import EvidenceRecorder  # noqa: E402
 from tools.publish.fetch import FetchedRelease, index_manifests  # noqa: E402
 from tools.publish.models import PublishStatus, ReleaseMetadata  # noqa: E402
+from tools.publish.cli import build_parser  # noqa: E402
 from tools.publish.publishers import PublishContext, PublishOptions, get_publisher  # noqa: E402
 sys.path.insert(0, str(REPO_ROOT / "scripts"))
 from resolve_release_tv_apk import resolve_canonical_tv_apk  # noqa: E402
@@ -711,6 +712,70 @@ class BrowserModeTests(unittest.TestCase):
                 )
                 blockers = get_publisher("apkpure").preflight(ctx)
                 self.assertEqual(blockers, [], f"{mode}: {blockers}")
+
+
+class BrowserOptionPrecedenceTests(unittest.TestCase):
+    """`run` and `doctor` must accept the same flags for the same decision."""
+
+    def _ctx(self, root: Path, config_options: dict, cli: PublishOptions) -> PublishContext:
+        release = ReleaseMetadata.from_manifest_file(write_release(root))
+        config = PublishConfig.load(
+            write_config(
+                root,
+                {
+                    "apkpure": {
+                        "enabled": True,
+                        "profiles": {
+                            "tv": {
+                                "packageId": "io.airo.app.tv",
+                                "artifactSelector": {"artifactType": ["apk"], "maxCount": 1},
+                                "releaseNotes": {"source": "inline", "text": "Notes."},
+                                "options": config_options,
+                            }
+                        },
+                    }
+                },
+            )
+        )
+        profile = config.profiles_for("apkpure")[0]
+        return PublishContext(
+            release=release,
+            config=profile,
+            artifacts=profile.select_artifacts(release),
+            options=cli,
+            evidence=EvidenceRecorder(root=root / "evidence", quiet=True),
+            release_notes="Notes.",
+            env={},
+        )
+
+    def test_cli_browser_overrides_the_target_config(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            ctx = self._ctx(root, {"browser": "bundled"}, PublishOptions(browser="cdp"))
+            # bundled would demand a storage state; cdp must not.
+            self.assertEqual(get_publisher("apkpure").preflight(ctx), [])
+
+    def test_config_still_applies_when_the_cli_is_silent(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            ctx = self._ctx(
+                root,
+                {"browser": "bundled", "storageState": str(root / "absent.json")},
+                PublishOptions(),
+            )
+            blockers = get_publisher("apkpure").preflight(ctx)
+            self.assertTrue(any("session state" in b for b in blockers), blockers)
+
+    def test_run_accepts_the_same_browser_flags_as_doctor(self) -> None:
+        parser = build_parser()
+        for command in ("run", "doctor"):
+            with self.subTest(command=command):
+                args = parser.parse_args(
+                    ([command, "--manifest", "m.json"] if command == "run" else [command, "apkpure"])
+                    + ["--browser", "cdp", "--browser-path", "chrome"]
+                )
+                self.assertEqual(args.browser, "cdp")
+                self.assertEqual(args.browser_path, "chrome")
 
 
 class ApkPureVersionTableTests(unittest.TestCase):

--- a/tools/publish/cli.py
+++ b/tools/publish/cli.py
@@ -91,6 +91,18 @@ def build_parser() -> argparse.ArgumentParser:
                              help="Write a markdown summary here (default: $GITHUB_STEP_SUMMARY).")
             cmd.add_argument("--results-json", type=Path, default=None,
                              help="Write machine-readable results here.")
+            # Same flags as `doctor`, so proving a store and publishing to it do
+            # not take different arguments for the same decision.
+            cmd.add_argument(
+                "--browser",
+                choices=[mode.value for mode in BrowserMode],
+                default=None,
+                help="Browser for browser-driven stores. Overrides the target config.",
+            )
+            cmd.add_argument("--browser-path", default=None,
+                             help="default|arc|brave|chrome|edge or a full path.")
+            cmd.add_argument("--cdp-endpoint", default=None)
+            cmd.add_argument("--profile-dir", type=Path, default=None)
 
     login = sub.add_parser("login", help="Create or refresh a store browser session, by hand.")
     login.add_argument("target", choices=["apkpure"])
@@ -238,6 +250,10 @@ def cmd_run(args: argparse.Namespace) -> int:
         submit=args.submit,
         force=args.force,
         timeout_seconds=args.timeout_seconds,
+        browser=args.browser,
+        browser_path=args.browser_path,
+        cdp_endpoint=args.cdp_endpoint,
+        profile_dir=str(args.profile_dir) if args.profile_dir else None,
     )
     if options.submit and options.dry_run:
         print("--submit is ignored with --dry-run", file=sys.stderr)

--- a/tools/publish/publishers/apkpure.py
+++ b/tools/publish/publishers/apkpure.py
@@ -45,7 +45,9 @@ class ApkPurePublisher(Publisher):
         if not ctx.options.dry_run:
             # Only the bundled-Chromium mode replays a saved storage state; the
             # chrome and cdp modes carry their session in a real browser profile.
-            mode = resolve_browser_mode(ctx.config.option("browser"), ctx.env)
+            mode = resolve_browser_mode(
+            ctx.options.browser or ctx.config.option("browser"), ctx.env
+        )
             state = storage_state_path(ctx)
             if mode is BrowserMode.BUNDLED and not state.is_file():
                 blockers.append(
@@ -89,7 +91,9 @@ class ApkPurePublisher(Publisher):
 
         selectors = SelectorSet.load(ctx.config.option("selectorsFile"))
         ctx.evidence.log(f"selector source: {selectors.source}")
-        mode = resolve_browser_mode(ctx.config.option("browser"), ctx.env)
+        mode = resolve_browser_mode(
+            ctx.options.browser or ctx.config.option("browser"), ctx.env
+        )
         # A real browser must be visible: a human may need to clear a challenge.
         headless = bool(ctx.config.option("headless", True)) and mode is BrowserMode.BUNDLED
         state = storage_state_path(ctx)
@@ -101,9 +105,16 @@ class ApkPurePublisher(Publisher):
             headless=headless,
             timeout_ms=ctx.options.timeout_seconds * 1000,
             mode=mode,
-            profile_dir=_optional_path(ctx.config.option("profileDir")),
-            cdp_endpoint=str(ctx.config.option("cdpEndpoint", DEFAULT_CDP_ENDPOINT)),
-            browser_path=resolve_browser_path(ctx.config.option("browserPath")),
+            profile_dir=_optional_path(
+                ctx.options.profile_dir or ctx.config.option("profileDir")
+            ),
+            cdp_endpoint=str(
+                ctx.options.cdp_endpoint
+                or ctx.config.option("cdpEndpoint", DEFAULT_CDP_ENDPOINT)
+            ),
+            browser_path=resolve_browser_path(
+                ctx.options.browser_path or ctx.config.option("browserPath")
+            ),
         ) as session:
             session.open_app(package_id)
 

--- a/tools/publish/publishers/base.py
+++ b/tools/publish/publishers/base.py
@@ -31,6 +31,13 @@ class PublishOptions:
     submit: bool = False
     force: bool = False
     timeout_seconds: int = 600
+    # Browser selection for browser-driven publishers. Set from the CLI, and
+    # takes precedence over the target's config so `run` and `doctor` accept
+    # the same flags for the same job.
+    browser: str | None = None
+    browser_path: str | None = None
+    cdp_endpoint: str | None = None
+    profile_dir: str | None = None
 
     @property
     def may_submit(self) -> bool:


### PR DESCRIPTION
```
python3 -m tools.publish run --tag v0.0.6 --profile tv --target apkpure --browser cdp --browser-path chrome
error: unrecognized arguments: --browser cdp --browser-path chrome
```

`doctor` took `--browser` and `--browser-path`. `run` did not — it read the same choice only from the target config. So the command that *proves* a store works and the command that *publishes* to it needed different arguments for the same decision.

That asymmetry has no justification: it is the same browser, chosen for the same reason, and a user who has just run `doctor --browser cdp` will reasonably type the same flags on `run`.

## Change

`PublishOptions` now carries the browser selection, the CLI sets it on `run`, and the APKPure publisher prefers it over its config — so config stays the default for CI while a human can override per invocation.

## Tests

62. A parity test parses the same flags through both subcommands, so the two cannot drift apart again. Plus precedence: `--browser cdp` overrides a `bundled` config (and correctly drops the storage-state requirement), and config still applies when the CLI is silent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
