### PR TITLE
feat(release): upload every per-ABI APK as a resumable APKPure pipeline

### DIFF
--- a/.github/airo-publish-targets.json
+++ b/.github/airo-publish-targets.json
@@ -81,7 +81,7 @@
     },
     "apkpure": {
       "enabled": false,
-      "_note": "Enable after `python3 -m tools.publish doctor apkpure` proves the selectors against the live console. Selection is by exact filename, not by abi: the universal APK and the arm64-v8a APK share abi=android-arm64, so only the filename distinguishes them.",
+      "_note": "Uploads every per-ABI APK, universal first. APKPure allows one version in flight at a time, so a run handles one APK and records it in build/publish-state; re-run until the summary reports all accepted. io.airo.app and io.airo.app.coins have no APKPure listing yet, so their profiles stay disabled until someone registers them by hand.",
       "profiles": {
         "tv": {
           "packageId": "io.airo.app.tv",
@@ -89,9 +89,11 @@
             "artifactType": [
               "apk"
             ],
-            "filenamePattern": "^Airo-TV-{version}\\.apk$",
-            "minCount": 1,
-            "maxCount": 1
+            "filenameExcludes": [
+              "debug",
+              "profile"
+            ],
+            "minCount": 1
           },
           "releaseNotes": {
             "source": "changelog",
@@ -104,6 +106,48 @@
             "headless": true,
             "updateDescription": true,
             "descriptionMaxChars": 1200
+          }
+        },
+        "full": {
+          "enabled": false,
+          "packageId": "io.airo.app",
+          "artifactSelector": {
+            "artifactType": [
+              "apk"
+            ],
+            "filenamePattern": "^Airo-{version}-\\\\d+-arm64\\\\.apk$",
+            "minCount": 1
+          },
+          "releaseNotes": {
+            "source": "changelog",
+            "path": "CHANGELOG.md",
+            "headingPattern": "^##\\s+v{version}\\b.*$",
+            "maxChars": 4000,
+            "fallback": "Bug fixes and stability improvements."
+          },
+          "options": {
+            "headless": true
+          }
+        },
+        "coins": {
+          "enabled": false,
+          "packageId": "io.airo.app.coins",
+          "artifactSelector": {
+            "artifactType": [
+              "apk"
+            ],
+            "filenamePattern": "^AiroCoins-{version}-\\\\d+-arm64\\\\.apk$",
+            "minCount": 1
+          },
+          "releaseNotes": {
+            "source": "changelog",
+            "path": "CHANGELOG.md",
+            "headingPattern": "^##\\s+v{version}\\b.*$",
+            "maxChars": 4000,
+            "fallback": "Bug fixes and stability improvements."
+          },
+          "options": {
+            "headless": true
           }
         }
       }

--- a/scripts/tests/test_publish_framework.py
+++ b/scripts/tests/test_publish_framework.py
@@ -43,6 +43,7 @@ from tools.publish.fetch import FetchedRelease, index_manifests  # noqa: E402
 from tools.publish.models import PublishStatus, ReleaseMetadata  # noqa: E402
 from tools.publish.cli import build_parser  # noqa: E402
 from tools.publish.publishers import PublishContext, PublishOptions, get_publisher  # noqa: E402
+from tools.publish.publishers.apkpure import _is_universal  # noqa: E402
 sys.path.insert(0, str(REPO_ROOT / "scripts"))
 from resolve_release_tv_apk import resolve_canonical_tv_apk  # noqa: E402
 from tools.publish.runner import (  # noqa: E402
@@ -835,16 +836,12 @@ class CanonicalApkAgreementTests(unittest.TestCase):
     def test_selector_matches_the_workflow_resolver(self) -> None:
         expected = resolve_canonical_tv_apk(self.ASSETS)
 
-        pattern = (
-            PublishConfig.load()
-            .profiles_for("apkpure")[0]
-            .selector.filename_pattern
-        )
-        self.assertIsNotNone(pattern, "the apkpure selector must pin an exact filename")
-        rendered = pattern.format(version=re.escape("0.0.6"), buildNumber="", profileId="")
-        matched = [name for name in self.ASSETS if re.fullmatch(rendered, name)]
-
-        self.assertEqual(matched, [expected])
+        # APKPure now takes every per-ABI APK, so the guarantee is about
+        # *order*: the canonical universal APK must be uploaded first, so the
+        # listing is usable even if a later variant stalls in review.
+        tv_apks = [n for n in self.ASSETS if n.startswith("Airo-TV-") and n.endswith(".apk")]
+        first = sorted(tv_apks, key=lambda n: (0 if _is_universal(n) else 1, n))[0]
+        self.assertEqual(first, expected)
 
 
 class ManifestIndexTests(unittest.TestCase):

--- a/tools/publish/apkpure/console.py
+++ b/tools/publish/apkpure/console.py
@@ -199,6 +199,24 @@ class ConsoleSession:
             self.snapshot("new-version-form")
         self.guard_human_gate("upload-form")
 
+    def upload_form_is_ready(self) -> bool:
+        """True when the console will actually accept an upload right now.
+
+        The form is still rendered while a previous version is in review, but
+        its submit button carries Materialize's `disabled` class -- so presence
+        of the form proves nothing.
+        """
+        button = self._first_visible("upload_submit_button", timeout_ms=8_000)
+        if button is None:
+            return False
+        blocked = button.evaluate(
+            "e => (e.className || '').split(/\\s+/).includes('disabled') "
+            "|| e.disabled === true"
+        )
+        if blocked:
+            self.evidence.log("upload form present but its submit button is disabled")
+        return not blocked
+
     def upload_apk(self, apk_path: Path) -> None:
         """Attach the APK. Nothing is sent to APKPure by this step.
 

--- a/tools/publish/publishers/apkpure.py
+++ b/tools/publish/publishers/apkpure.py
@@ -12,6 +12,7 @@ Playwright. Two consequences shape the design:
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 from typing import ClassVar
 
@@ -23,7 +24,8 @@ from ..apkpure.console import (
 )
 from ..apkpure.console import DEFAULT_CDP_ENDPOINT
 from ..apkpure.selectors import SelectorSet, console_url
-from ..errors import ConfigError
+from ..upload_state import UploadState
+from ..errors import ConfigError, CredentialError, RemoteError
 from ..models import PublishResult, PublishStatus
 from .base import Publisher, PublishContext
 
@@ -58,13 +60,41 @@ class ApkPurePublisher(Publisher):
         return blockers
 
     def publish(self, ctx: PublishContext) -> PublishResult:
-        artifact = ctx.sole_artifact()
-        if artifact.artifact_type != "apk":
+        artifacts = list(ctx.artifacts)
+        wrong = [a for a in artifacts if a.artifact_type != "apk"]
+        if wrong:
             raise ConfigError(
-                f"{ctx.config.context}: APKPure distributes APKs, selector chose "
-                f"{artifact.filename} ({artifact.artifact_type})."
+                f"{ctx.config.context}: APKPure distributes APKs, selector also chose "
+                + ", ".join(f"{a.filename} ({a.artifact_type})" for a in wrong)
             )
-        package_id = ctx.config.package_id or artifact.package_id
+        # Upload order is deliberate: the universal APK first, so the listing is
+        # usable even if a later per-ABI upload is rejected or stalls in review.
+        artifacts.sort(key=lambda a: (0 if _is_universal(a.filename) else 1, a.filename))
+        package_id = ctx.config.package_id or artifacts[0].package_id
+
+        # APKPure allows one version in flight at a time, so a multi-APK
+        # release is many short runs rather than one long one. State is keyed
+        # by content hash so a rebuilt APK of the same name is not mistaken for
+        # one already accepted.
+        # evidence.root is build/publish-evidence/<target>/<profile>/<version>;
+        # the state belongs beside publish-evidence, not inside it.
+        state = UploadState.load(
+            ctx.evidence.root.parents[3] / "publish-state", self.name, package_id
+        )
+        remaining = state.pending(artifacts)
+        if not remaining:
+            return self.result(
+                ctx,
+                PublishStatus.SKIPPED,
+                f"All {len(artifacts)} APK(s) already accepted by APKPure for {package_id}",
+                {"packageId": package_id, "accepted": sorted(a.filename for a in artifacts)},
+            )
+        artifact = remaining[0]
+        ctx.evidence.log(
+            f"{len(remaining)} of {len(artifacts)} APK(s) left; this run handles {artifact.filename}"
+        )
+        self._state = state
+        self._remaining = remaining
         target_url = console_url(package_id)
 
         plan = {
@@ -127,14 +157,21 @@ class ApkPurePublisher(Publisher):
             # already published and there is nothing left to upload.
             if ctx.config.option("updateDescription"):
                 if ctx.options.may_submit:
-                    session.open_app_details(package_id)
-                    session.upsert_description_notes(
-                        artifact.version,
-                        ctx.release_notes,
-                        int(ctx.config.option("descriptionMaxChars", 1200)),
-                    )
-                    session.save_app_details()
-                    session.open_upload_form()
+                    # Best effort: the listing form is locked while a publish
+                    # review is in flight, and a cosmetic description update
+                    # must never block shipping a binary.
+                    try:
+                        session.open_app_details(package_id)
+                        session.upsert_description_notes(
+                            artifact.version,
+                            ctx.release_notes,
+                            int(ctx.config.option("descriptionMaxChars", 1200)),
+                        )
+                        session.save_app_details()
+                    except (RemoteError, CredentialError) as exc:
+                        ctx.evidence.warn(f"listing description not updated: {exc}")
+                    finally:
+                        session.open_upload_form()
                 else:
                     ctx.evidence.warn(
                         "skipping the listing description update: it edits public copy, "
@@ -155,6 +192,7 @@ class ApkPurePublisher(Publisher):
                         {**plan, "uploadState": "verified-awaiting-publish"},
                     )
                 session.submit_for_review(artifact.version)
+                self._state.record(artifact.sha256, artifact.filename, artifact.version, "published")
                 return self.result(
                     ctx,
                     PublishStatus.SUCCEEDED,
@@ -186,6 +224,23 @@ class ApkPurePublisher(Publisher):
                     {**plan, "existingVersion": already[0], "listedVersions": existing},
                 )
 
+            # APKPure permits one version in flight per app: while a previous
+            # version is in publishing review the upload form is rendered but
+            # its button is disabled. That is a queueing constraint, not a
+            # failure, so it must not read as a broken release.
+            if not session.upload_form_is_ready():
+                ctx.evidence.warn(
+                    "APKPure has a version in review; the upload form is locked. "
+                    f"{len(remaining)} APK(s) still to upload."
+                )
+                return self.result(
+                    ctx,
+                    PublishStatus.SKIPPED,
+                    f"APKPure is still reviewing a previous version; {len(remaining)} APK(s) "
+                    "remain. Re-run once review clears.",
+                    {**plan, "remaining": [a.filename for a in remaining], "blockedBy": "review"},
+                )
+
             session.upload_apk(artifact.path)
             session.fill_release_notes(ctx.release_notes)
 
@@ -208,6 +263,7 @@ class ApkPurePublisher(Publisher):
                 # binary clears verification, and clicking it now would prove
                 # nothing.
                 ctx.evidence.log("upload queued for APKPure verification; not clicking PUBLISH")
+                self._state.record(artifact.sha256, artifact.filename, artifact.version, "pending-verification")
                 return self.result(
                     ctx,
                     PublishStatus.SUCCEEDED,
@@ -227,3 +283,8 @@ class ApkPurePublisher(Publisher):
 
 def _optional_path(value: object) -> Path | None:
     return Path(str(value)).expanduser() if value else None
+
+
+def _is_universal(filename: str) -> bool:
+    """True for the ABI-less APK (Airo-TV-0.0.6.apk, not ...-x86_64.apk)."""
+    return not re.search(r"-(arm64-v8a|armeabi-v7a|x86_64|x86|arm64)\.apk$", filename, re.I)

--- a/tools/publish/upload_state.py
+++ b/tools/publish/upload_state.py
@@ -1,0 +1,63 @@
+"""Which artifacts a store has already accepted.
+
+APKPure serialises uploads behind a manual review: only one version can be in
+flight at a time, and the version table does not show a version until review
+clears. So a multi-APK release cannot be one long run -- it is many short runs,
+and each needs to know what the previous ones achieved.
+
+This records that, keyed by content hash rather than filename, so a rebuilt APK
+with the same name is correctly treated as a different artifact.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+SCHEMA_VERSION = 1
+
+
+@dataclass
+class UploadState:
+    path: Path
+    target: str
+    package_id: str
+    accepted: dict[str, dict[str, Any]] = field(default_factory=dict)
+
+    @classmethod
+    def load(cls, directory: Path, target: str, package_id: str) -> "UploadState":
+        safe = "".join(c if c.isalnum() or c in "-._" else "-" for c in f"{target}-{package_id}")
+        path = (directory / f"{safe}.json").expanduser()
+        accepted: dict[str, dict[str, Any]] = {}
+        if path.is_file():
+            try:
+                data = json.loads(path.read_text(encoding="utf-8"))
+                if data.get("schemaVersion") == SCHEMA_VERSION:
+                    accepted = data.get("accepted") or {}
+            except (json.JSONDecodeError, AttributeError):
+                # A corrupt state file must not block a release: the console is
+                # the source of truth, and re-checking there is cheap.
+                accepted = {}
+        return cls(path=path, target=target, package_id=package_id, accepted=accepted)
+
+    def is_accepted(self, sha256: str) -> bool:
+        return sha256 in self.accepted
+
+    def record(self, sha256: str, filename: str, version: str, state: str) -> None:
+        self.accepted[sha256] = {"filename": filename, "version": version, "state": state}
+        self.save()
+
+    def save(self) -> None:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        payload = {
+            "schemaVersion": SCHEMA_VERSION,
+            "target": self.target,
+            "packageId": self.package_id,
+            "accepted": self.accepted,
+        }
+        self.path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    def pending(self, artifacts) -> list:
+        return [a for a in artifacts if not self.is_accepted(a.sha256)]


### PR DESCRIPTION
A release ships four TV APKs — universal plus `arm64-v8a`, `armeabi-v7a`, `x86_64` — and only the universal one was being published.

## The constraint that shapes this

**APKPure permits exactly one version in flight per app.** While a version is in publishing review the upload form is still rendered, but its submit button carries Materialize's `disabled` class. Review is done by hand and takes hours or days.

So a multi-APK release cannot be one long run. It is a sequence of short, resumable ones.

## Design

**Upload state, keyed by content hash** — not filename. A rebuilt APK of the same name is a different artifact and must not be treated as already accepted. Each run uploads the first artifact not yet accepted and records the outcome; re-running advances to the next.

```
[info] 3 of 4 APK(s) left; this run handles Airo-TV-0.0.6-arm64-v8a.apk
```

**A review lock reports SKIPPED, not FAILED.** A queueing constraint is not a broken release and must not read like one:

```
| apkpure | tv | ⏭️ skipped | APKPure is still reviewing a previous version; 3 APK(s) remain.
```

**Universal APK uploads first**, so the listing is usable even if a per-ABI variant later stalls or is rejected.

**The description update is best effort.** It edits the same form review locks, and cosmetic copy must never block shipping a binary.

## Other flavors

Disabled profiles added for `io.airo.app` and `io.airo.app.coins`. Neither has an APKPure listing — `/console/io.airo.app` redirects to the console root — so the config is ready but inert until someone registers them by hand. Registering a listing means accepting terms and making content-rating and data-safety declarations, which is not an automation decision.

## Unproven

Whether APKPure accepts several APKs under one version code. The first per-ABI attempt could not run, because 0.0.6 is in review. If it rejects them, the pipeline surfaces it as an upload error rather than silently skipping — and the universal APK is live either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
