### PR TITLE
fix(release): upload the universal APK to APKPure, not the per-ABI splits

### DIFF
--- a/.github/airo-publish-targets.json
+++ b/.github/airo-publish-targets.json
@@ -81,7 +81,7 @@
     },
     "apkpure": {
       "enabled": false,
-      "_note": "Uploads every per-ABI APK, universal first. APKPure allows one version in flight at a time, so a run handles one APK and records it in build/publish-state; re-run until the summary reports all accepted. io.airo.app and io.airo.app.coins have no APKPure listing yet, so their profiles stay disabled until someone registers them by hand.",
+      "_note": "APKPure models one APK per version -- each version row carries a single Architecture field and the per-ABI splits all share versionCode 10, so they cannot coexist as variants of 0.0.6. The universal APK already contains arm64-v8a, armeabi-v7a and x86_64, so it is the correct upload; the splits stay on the GitHub release for people who want a smaller download. The pipeline still supports multiple APKs per profile if a store ever accepts them. io.airo.app and io.airo.app.coins have no APKPure listing, so their profiles stay disabled until someone registers them by hand.",
       "profiles": {
         "tv": {
           "packageId": "io.airo.app.tv",
@@ -89,11 +89,9 @@
             "artifactType": [
               "apk"
             ],
-            "filenameExcludes": [
-              "debug",
-              "profile"
-            ],
-            "minCount": 1
+            "filenamePattern": "^Airo-TV-{version}\\.apk$",
+            "minCount": 1,
+            "maxCount": 1
           },
           "releaseNotes": {
             "source": "changelog",


### PR DESCRIPTION
Correcting the target count in #1528. The pipeline was right; what it was aiming at was not.

## APKPure models one APK per version

Each version row carries a **single** `Architecture` field. The published 0.0.6 reads:

```
Architecture:  universal
Version Code:  10
```

All four TV APKs are version `0.0.6`, versionCode `10`. So `arm64-v8a`, `armeabi-v7a` and `x86_64` cannot coexist as variants of a version that is already published — there is no variant slot for them to occupy.

Play is the store that models splits. That is what the `.aab` is for; APKPure has no equivalent.

## The universal APK already covers them

It contains all three ABIs — which is why it is 28.6 MB against 26–30 MB for the individual splits. Old Fire TV sticks (armeabi-v7a) and emulators/Chromebooks (x86_64) are already served by what is published. The splits stay on the GitHub release, where a smaller download is the whole point.

## Why this is a fix, not a preference

Left alone, the loop from #1528 would have retried three impossible uploads every 30 minutes for a day and then reported failure — burning a day to discover something the console metadata already stated.

The pipeline keeps its multi-APK support: resumable, hash-keyed state and review-lock handling are all still there, and a store that does accept variants will use them. Only this profile's selector narrows.

## Result

```
| apkpure | tv | ⏭️ skipped | Airo-TV-0.0.6.apk | All 1 APK(s) already accepted for io.airo.app.tv |
```

TV is complete for 0.0.6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
