### PR TITLE
fix(release): verify what is inside an APK before uploading it to a store

### DIFF
--- a/.github/airo-publish-targets.json
+++ b/.github/airo-publish-targets.json
@@ -89,11 +89,9 @@
             "artifactType": [
               "apk"
             ],
-            "filenameExcludes": [
-              "debug",
-              "profile"
-            ],
-            "minCount": 1
+            "filenamePattern": "^Airo-TV-{version}\\.apk$",
+            "minCount": 1,
+            "maxCount": 1
           },
           "releaseNotes": {
             "source": "changelog",
@@ -105,7 +103,11 @@
           "options": {
             "headless": true,
             "updateDescription": true,
-            "descriptionMaxChars": 1200
+            "descriptionMaxChars": 1200,
+            "expectedAbis": [
+              "arm64-v8a"
+            ],
+            "maxSizeMb": 35
           }
         },
         "full": {
@@ -126,7 +128,10 @@
             "fallback": "Bug fixes and stability improvements."
           },
           "options": {
-            "headless": true
+            "headless": true,
+            "expectedAbis": [
+              "arm64-v8a"
+            ]
           }
         },
         "coins": {
@@ -147,7 +152,10 @@
             "fallback": "Bug fixes and stability improvements."
           },
           "options": {
-            "headless": true
+            "headless": true,
+            "expectedAbis": [
+              "arm64-v8a"
+            ]
           }
         }
       }

--- a/scripts/tests/test_publish_framework.py
+++ b/scripts/tests/test_publish_framework.py
@@ -14,6 +14,7 @@ import subprocess
 import sys
 import tempfile
 import unittest
+import zipfile
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -30,6 +31,7 @@ from tools.publish.errors import (  # noqa: E402
     ManifestError,
     PreflightError,
 )
+from tools.publish.apk_inspect import inspect_apk  # noqa: E402
 from tools.publish.apkpure.console import ConsoleSession  # noqa: E402
 from tools.publish.apkpure.console import (  # noqa: E402
     KNOWN_CHROMIUM_BROWSERS,
@@ -777,6 +779,46 @@ class BrowserOptionPrecedenceTests(unittest.TestCase):
                 )
                 self.assertEqual(args.browser, "cdp")
                 self.assertEqual(args.browser_path, "chrome")
+
+
+class ApkContentsTests(unittest.TestCase):
+    """A store upload is judged by contents, not filename."""
+
+    def _apk(self, root: Path, name: str, abis: list[str]) -> Path:
+        path = root / name
+        with zipfile.ZipFile(path, "w") as z:
+            z.writestr("AndroidManifest.xml", "x")
+            for abi in abis:
+                z.writestr(f"lib/{abi}/libflutter.so", b"\0" * 2048)
+        return path
+
+    def test_single_abi_apk_is_not_universal(self) -> None:
+        """Airo-TV-<v>.apk reads as universal and carries arm64 only."""
+        with tempfile.TemporaryDirectory() as tmp:
+            path = self._apk(Path(tmp), "Airo-TV-0.0.6.apk", ["arm64-v8a"])
+            contents = inspect_apk(path)
+            self.assertEqual(contents.abis, frozenset({"arm64-v8a"}))
+            self.assertFalse(contents.is_universal)
+
+    def test_multi_abi_apk_is_universal(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            path = self._apk(Path(tmp), "fat.apk", ["arm64-v8a", "armeabi-v7a", "x86_64"])
+            self.assertTrue(inspect_apk(path).is_universal)
+
+    def test_non_abi_lib_directories_are_ignored(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "a.apk"
+            with zipfile.ZipFile(path, "w") as z:
+                z.writestr("lib/flutter_assets/font.ttf", "x")
+                z.writestr("lib/arm64-v8a/libapp.so", b"\0" * 100)
+            self.assertEqual(inspect_apk(path).abis, frozenset({"arm64-v8a"}))
+
+    def test_apk_without_native_code_reports_none(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            path = self._apk(Path(tmp), "b.apk", [])
+            contents = inspect_apk(path)
+            self.assertEqual(contents.abis, frozenset())
+            self.assertFalse(contents.is_universal)
 
 
 class ApkPureVersionTableTests(unittest.TestCase):

--- a/tools/publish/apk_inspect.py
+++ b/tools/publish/apk_inspect.py
@@ -1,0 +1,53 @@
+"""Read what is actually inside an APK.
+
+A store upload is judged by its contents, not its filename. `Airo-TV-0.0.6.apk`
+reads as a universal build and is arm64-only; APKPure then labels it
+"Architecture: universal" on its own. Nothing in the release chain checks, so a
+build-config change could quietly ship a fat APK to a size-budgeted TV listing,
+or ship an arm64 slice to devices that cannot run it.
+"""
+
+from __future__ import annotations
+
+import zipfile
+from dataclasses import dataclass
+from pathlib import Path
+
+#: ABI directory names Android recognises under lib/.
+KNOWN_ABIS = frozenset(
+    {"arm64-v8a", "armeabi-v7a", "armeabi", "x86", "x86_64", "mips", "mips64"}
+)
+
+
+@dataclass(frozen=True)
+class ApkContents:
+    path: Path
+    abis: frozenset[str]
+    native_bytes: int
+    total_bytes: int
+
+    @property
+    def is_universal(self) -> bool:
+        """True when the APK carries native code for more than one ABI."""
+        return len(self.abis) > 1
+
+    def describe(self) -> str:
+        listed = ", ".join(sorted(self.abis)) if self.abis else "no native libs"
+        return f"{self.path.name}: {listed} ({self.native_bytes / 1e6:.1f} MB native)"
+
+
+def inspect_apk(path: Path) -> ApkContents:
+    abis: set[str] = set()
+    native = 0
+    with zipfile.ZipFile(path) as archive:
+        for info in archive.infolist():
+            parts = info.filename.split("/")
+            if len(parts) >= 3 and parts[0] == "lib" and parts[1] in KNOWN_ABIS:
+                abis.add(parts[1])
+                native += info.file_size
+    return ApkContents(
+        path=path,
+        abis=frozenset(abis),
+        native_bytes=native,
+        total_bytes=path.stat().st_size,
+    )

--- a/tools/publish/publishers/apkpure.py
+++ b/tools/publish/publishers/apkpure.py
@@ -24,6 +24,7 @@ from ..apkpure.console import (
 )
 from ..apkpure.console import DEFAULT_CDP_ENDPOINT
 from ..apkpure.selectors import SelectorSet, console_url
+from ..apk_inspect import inspect_apk
 from ..upload_state import UploadState
 from ..errors import ConfigError, CredentialError, RemoteError
 from ..models import PublishResult, PublishStatus
@@ -78,6 +79,33 @@ class ApkPurePublisher(Publisher):
         # one already accepted.
         # evidence.root is build/publish-evidence/<target>/<profile>/<version>;
         # the state belongs beside publish-evidence, not inside it.
+        # What is inside the APK decides what devices it serves, so check it
+        # before shipping rather than trusting the filename or the store's own
+        # inferred label.
+        expected = ctx.config.option("expectedAbis")
+        if expected:
+            expected_set = frozenset(expected)
+            for candidate in artifacts:
+                contents = inspect_apk(candidate.path)
+                ctx.evidence.log(contents.describe())
+                if contents.abis != expected_set:
+                    raise ConfigError(
+                        f"{ctx.config.context}: {candidate.filename} carries "
+                        f"[{', '.join(sorted(contents.abis)) or 'none'}] but the listing "
+                        f"expects [{', '.join(sorted(expected_set))}]. Refusing to upload: "
+                        "the wrong slice would fail to install on the devices this "
+                        "listing targets."
+                    )
+            max_mb = ctx.config.option("maxSizeMb")
+            if max_mb:
+                for candidate in artifacts:
+                    size_mb = candidate.size_bytes / 1e6
+                    if size_mb > float(max_mb):
+                        raise ConfigError(
+                            f"{ctx.config.context}: {candidate.filename} is "
+                            f"{size_mb:.1f} MB, over the {max_mb} MB listing budget."
+                        )
+
         state = UploadState.load(
             ctx.evidence.root.parents[3] / "publish-state", self.name, package_id
         )


### PR DESCRIPTION
## I got this wrong in #1530

I asserted there that `Airo-TV-0.0.6.apk` "already contains all three ABIs". **It does not.** It contains `arm64-v8a` only — its native libraries are byte-for-byte the arm64-v8a split's:

```
Airo-TV-0.0.6.apk             arm64-v8a     20.9 MB native
Airo-TV-0.0.6-arm64-v8a.apk   arm64-v8a     20.9 MB native   ← same content
Airo-TV-0.0.6-armeabi-v7a.apk armeabi-v7a   18.3 MB
Airo-TV-0.0.6-x86_64.apk      x86_64        22.5 MB
```

APKPure then labels the listing `Architecture: universal` on its own inference, which is where I took the claim from.

## The class of bug worth closing

The filename, the store's label, and the actual contents were **three different claims**, and only the last one decides which devices can install the thing. Nothing in the release chain checked.

The publisher now reads the APK's `lib/` entries and compares them against the listing's declared `expectedAbis`, refusing to upload a slice that would not install on the devices the listing targets. It also enforces the profile's size budget, so a build-config change cannot quietly push a fat APK into a size-budgeted TV listing.

Verified against the real artifact:

```
[info] Airo-TV-0.0.6.apk: arm64-v8a (20.9 MB native)
[info] result: skipped — All 1 APK(s) already accepted
```

And against the wrong one, now refused rather than uploaded:

```
ConfigError: Airo-TV-0.0.6-armeabi-v7a.apk carries [armeabi-v7a] but the listing
expects [arm64-v8a]. Refusing to upload: the wrong slice would fail to install
on the devices this listing targets.
```

## What this makes visible

**armeabi-v7a and x86_64 devices are not served by the APKPure listing.** That is a deliberate consequence of the `tv` profile's `single-arm64-apk` strategy, not something this change introduces — but it is now explicit in config instead of hidden behind a filename that reads as universal.

Fire TV Stick 4K / 4K Max and current Android TV boxes are arm64 and are served. Older 32-bit sticks are not.

## Tests

Cover single-ABI vs multi-ABI detection, `lib/flutter_assets` correctly ignored as a non-ABI directory, and APKs with no native code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
