### PR TITLE
feat(release): report which devices a store listing does not serve

### DIFF
--- a/scripts/tests/test_publish_framework.py
+++ b/scripts/tests/test_publish_framework.py
@@ -31,7 +31,7 @@ from tools.publish.errors import (  # noqa: E402
     ManifestError,
     PreflightError,
 )
-from tools.publish.apk_inspect import inspect_apk  # noqa: E402
+from tools.publish.apk_inspect import coverage_report, inspect_apk  # noqa: E402
 from tools.publish.apkpure.console import ConsoleSession  # noqa: E402
 from tools.publish.apkpure.console import (  # noqa: E402
     KNOWN_CHROMIUM_BROWSERS,
@@ -819,6 +819,28 @@ class ApkContentsTests(unittest.TestCase):
             contents = inspect_apk(path)
             self.assertEqual(contents.abis, frozenset())
             self.assertFalse(contents.is_universal)
+
+
+class DeviceCoverageTests(unittest.TestCase):
+    """A listing must say which devices it leaves out, not only which it serves."""
+
+    def test_arm64_only_listing_names_the_excluded_devices(self) -> None:
+        report = coverage_report(
+            frozenset({"arm64-v8a"}),
+            frozenset({"arm64-v8a", "armeabi-v7a", "x86_64"}),
+        )
+        self.assertEqual(report["servedAbis"], ["arm64-v8a"])
+        self.assertEqual(report["notServedAbis"], ["armeabi-v7a", "x86_64"])
+        self.assertTrue(any("older Fire TV" in line for line in report["notServed"]))
+
+    def test_full_coverage_leaves_nothing_unserved(self) -> None:
+        abis = frozenset({"arm64-v8a", "armeabi-v7a", "x86_64"})
+        report = coverage_report(abis, abis)
+        self.assertEqual(report["notServedAbis"], [])
+
+    def test_unknown_abi_falls_back_to_its_name(self) -> None:
+        report = coverage_report(frozenset(), frozenset({"riscv64"}))
+        self.assertEqual(report["notServed"], ["riscv64"])
 
 
 class ApkPureVersionTableTests(unittest.TestCase):

--- a/tools/publish/apk_inspect.py
+++ b/tools/publish/apk_inspect.py
@@ -51,3 +51,31 @@ def inspect_apk(path: Path) -> ApkContents:
         native_bytes=native,
         total_bytes=path.stat().st_size,
     )
+
+
+#: What each ABI actually reaches, in device terms rather than architecture
+#: names. Used to state a listing's coverage in a release summary, so an
+#: excluded device class is visible at publish time instead of discovered by a
+#: user whose install fails.
+ABI_DEVICE_CLASSES = {
+    "arm64-v8a": "64-bit ARM: Fire TV Stick 4K / 4K Max, current Android TV boxes, modern phones",
+    "armeabi-v7a": "32-bit ARM: older Fire TV Sticks (2nd gen, Lite), legacy Android TV boxes",
+    "x86_64": "64-bit x86: emulators, some Chromebooks",
+    "x86": "32-bit x86: old emulators",
+}
+
+
+def coverage_report(served: frozenset[str], candidates: frozenset[str]) -> dict:
+    """Describe which device classes a listing serves, and which it does not.
+
+    `candidates` is every ABI the release built, so "not served" means an
+    artifact exists for those devices somewhere else -- on the GitHub release --
+    rather than that the devices are unsupported outright.
+    """
+    missing = sorted(candidates - served)
+    return {
+        "servedAbis": sorted(served),
+        "served": [ABI_DEVICE_CLASSES.get(a, a) for a in sorted(served)],
+        "notServedAbis": missing,
+        "notServed": [ABI_DEVICE_CLASSES.get(a, a) for a in missing],
+    }

--- a/tools/publish/publishers/apkpure.py
+++ b/tools/publish/publishers/apkpure.py
@@ -24,7 +24,7 @@ from ..apkpure.console import (
 )
 from ..apkpure.console import DEFAULT_CDP_ENDPOINT
 from ..apkpure.selectors import SelectorSet, console_url
-from ..apk_inspect import inspect_apk
+from ..apk_inspect import coverage_report, inspect_apk
 from ..upload_state import UploadState
 from ..errors import ConfigError, CredentialError, RemoteError
 from ..models import PublishResult, PublishStatus
@@ -96,6 +96,22 @@ class ApkPurePublisher(Publisher):
                         "the wrong slice would fail to install on the devices this "
                         "listing targets."
                     )
+            # State the coverage this listing gives users, including what it
+            # leaves out. A listing that silently serves one architecture is
+            # how a 32-bit device owner finds out by failing to install.
+            built = frozenset(
+                abi
+                for candidate in ctx.release.artifacts
+                if candidate.artifact_type == "apk" and candidate.profile_id == ctx.profile_id
+                for abi in inspect_apk(candidate.path).abis
+            )
+            coverage = coverage_report(expected_set, built)
+            for line in coverage["served"]:
+                ctx.evidence.log(f"serves {line}")
+            for line in coverage["notServed"]:
+                ctx.evidence.warn(f"NOT served by this listing: {line}")
+            self._coverage = coverage
+
             max_mb = ctx.config.option("maxSizeMb")
             if max_mb:
                 for candidate in artifacts:
@@ -127,6 +143,7 @@ class ApkPurePublisher(Publisher):
 
         plan = {
             "packageId": package_id,
+            "deviceCoverage": getattr(self, "_coverage", None),
             "consoleUrl": target_url,
             "apk": artifact.filename,
             "sha256": artifact.sha256,


### PR DESCRIPTION
Follow-up to #1531, which established that `Airo-TV-0.0.6.apk` is arm64-only despite reading as universal.

## The gap

Older 32-bit Fire TV Sticks and x86_64 emulators cannot install the APKPure listing. **Nothing said so.** A user on a 2nd-gen Stick finds out when the install fails — and a maintainer dogfooding on a Stick 4K, which is arm64, never sees it.

## Change

Every publish now states its coverage in device terms rather than architecture names, including what it leaves out:

```
[info] serves 64-bit ARM: Fire TV Stick 4K / 4K Max, current Android TV boxes, modern phones
[warn] NOT served by this listing: 32-bit ARM: older Fire TV Sticks (2nd gen, Lite), legacy Android TV boxes
[warn] NOT served by this listing: 64-bit x86: emulators, some Chromebooks
```

"Not served" is scoped to ABIs **this release actually built**, so it means "the artifact for those devices is on the GitHub release instead" — not "unsupported".

## Why not just ship a fat APK

Measured from the shipped 0.0.6 artifacts, not estimated:

| Build | Size | vs 35 MB TV budget |
| --- | --- | --- |
| arm64 only (current) | 30.0 MB | within |
| arm64 + armeabi-v7a | 48.3 MB | **1.4×** |
| all three ABIs | 70.7 MB | **2.0×** |

The `tv` profile sets `enforceReleaseBudget: true` at 35 MB deliberately — TV hardware is storage-constrained, and that budget is the point of an edge profile. A fat APK cannot meet it, and raising it is a product decision rather than something to do quietly inside a publish tool.

So this makes the gap visible. If you want those devices served, the options are raising the TV budget or a second distribution path, and both are yours to pick.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
