### PR TITLE
fix(release): bump Airo Coins to 0.0.6+11 for APKPure re-upload

### DIFF
--- a/app/pubspec_coins.yaml
+++ b/app/pubspec_coins.yaml
@@ -1,7 +1,7 @@
 name: airo_app
 description: "Airo Coins - focused local-first finance vault"
 publish_to: none
-version: 0.0.6+10
+version: 0.0.6+11
 
 environment:
   sdk: ">=3.12.2 <4.0.0"


### PR DESCRIPTION
## Summary
- Sync main to latest release branch with corrected store assets
- Bump version to 0.0.6+11 to allow APKPure re-upload
- Resolves package name/signature mismatch on upload

## Root Cause
v0.0.6 shipped with misnamed store asset (coins-vault-home.png instead of coins-home.png), causing APKPure verification failure. Local main was 232 commits behind origin/main and had outdated version 0.0.1+1, compounding the issue.

## Changes
- Store asset renamed to coins-home.png (from commit 9a51c3ab)
- Version bumped to 0.0.6+11 for new build number
- Maintains monotonic versionCode across all distribution channels

## Testing
- [x] Store asset exists and is correctly named
- [x] Version code incremented for APKPure compatibility
- [x] No dependency conflicts

Related to recent APKPure upload verification failures for Airo Coins v0.0.6.