### PR TITLE
feat(app): select the mind Firebase client for APP_VARIANT=mind

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -299,7 +299,8 @@ jobs:
       - name: Run Mind shell tests
         run: |
           cd app
-          flutter test test_mind/ --reporter=compact
+          flutter test test_mind/ --reporter=compact \
+            --dart-define=APP_VARIANT=mind
 
       # `flutter test` compiles for the host only. This proves the profile also
       # compiles the entrypoint into a device bundle -- the whole point of

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -294,7 +294,8 @@ jobs:
       - name: Run Mind shell tests
         run: |
           cd app
-          flutter test test_mind/ --reporter=compact
+          flutter test test_mind/ --reporter=compact \
+            --dart-define=APP_VARIANT=mind
 
       # `flutter test` compiles for the host only. This proves the profile also
       # compiles the entrypoint into a device bundle -- the whole point of

--- a/app/analysis_options_mind.yaml
+++ b/app/analysis_options_mind.yaml
@@ -24,8 +24,11 @@
 #     `@visibleForTesting` access inside a directory literally named `test`, so
 #     analysing the Mind suite reports eleven
 #     `invalid_use_of_visible_for_testing_member` warnings for correct code.
-#     The suite is covered by `flutter test test_mind/` in the same CI job,
-#     which compiles every one of those files.
+#     The suite is covered by
+#     `flutter test test_mind/ --dart-define=APP_VARIANT=mind` in the same CI
+#     job, which compiles every one of those files. The define is not optional:
+#     `mind_firebase_variant_test.dart` asserts the Firebase variant selection,
+#     which `String.fromEnvironment` resolves at compile time.
 #   * `custom_lint` is not registered as a plugin -- it is a dev_dependency of
 #     `pubspec.yaml`, not of `pubspec_mind.yaml`, and an unresolvable plugin
 #     turns the whole analysis into a single confusing error.

--- a/app/lib/firebase_options.dart
+++ b/app/lib/firebase_options.dart
@@ -7,7 +7,8 @@
 // Do not commit real Firebase keys into this file.
 //
 // Supports: Mobile Full (io.airo.app), Mobile Streaming
-// (io.airo.app.streaming), Android TV (io.airo.app.tv)
+// (io.airo.app.streaming), Android TV (io.airo.app.tv), Airo Mind
+// (io.airo.app.mind)
 
 import 'package:firebase_core/firebase_core.dart' show FirebaseOptions;
 import 'package:flutter/foundation.dart'
@@ -19,6 +20,7 @@ enum AppVariant {
   full, // io.airo.app - All features
   streaming, // io.airo.app.streaming - Music + IPTV
   tv, // io.airo.app.tv - IPTV only
+  mind, // io.airo.app.mind - Airo Mind standalone shell
 }
 
 /// Default [FirebaseOptions] for use with your Firebase apps.
@@ -37,6 +39,8 @@ class DefaultFirebaseOptions {
         return AppVariant.tv;
       case 'streaming':
         return AppVariant.streaming;
+      case 'mind':
+        return AppVariant.mind;
       default:
         return AppVariant.full;
     }
@@ -114,6 +118,8 @@ class DefaultFirebaseOptions {
         return androidTv;
       case AppVariant.streaming:
         return androidStreaming;
+      case AppVariant.mind:
+        return androidMind;
       case AppVariant.full:
         return android;
     }
@@ -148,6 +154,22 @@ class DefaultFirebaseOptions {
   static const FirebaseOptions androidTv = FirebaseOptions(
     apiKey: 'YOUR_ANDROID_TV_API_KEY',
     appId: 'YOUR_ANDROID_TV_APP_ID',
+    messagingSenderId: 'YOUR_MESSAGING_SENDER_ID',
+    projectId: 'YOUR_PROJECT_ID',
+    storageBucket: 'YOUR_PROJECT_ID.firebasestorage.app',
+  );
+
+  /// Airo Mind - io.airo.app.mind
+  ///
+  /// The Mind shell initializes Firebase only for auth parity with the super
+  /// app (the assistant's profile screen signs in with Google). Gradle installs
+  /// this variant as `io.airo.app.mind`, so Dart must hand
+  /// `Firebase.initializeApp` that client's own appId -- handing it the
+  /// `io.airo.app` one instead resolves as a package/signature mismatch and
+  /// Google Sign-In fails with `ApiException: 10`.
+  static const FirebaseOptions androidMind = FirebaseOptions(
+    apiKey: 'YOUR_ANDROID_MIND_API_KEY',
+    appId: 'YOUR_ANDROID_MIND_APP_ID',
     messagingSenderId: 'YOUR_MESSAGING_SENDER_ID',
     projectId: 'YOUR_PROJECT_ID',
     storageBucket: 'YOUR_PROJECT_ID.firebasestorage.app',

--- a/app/lib/firebase_options.dart.template
+++ b/app/lib/firebase_options.dart.template
@@ -1,10 +1,12 @@
 // Firebase configuration with multi-platform variant support
 // Supports: Mobile Full (io.airo.app), Mobile Streaming
-// (io.airo.app.streaming), Android TV (io.airo.app.tv)
+// (io.airo.app.streaming), Android TV (io.airo.app.tv), Airo Mind
+// (io.airo.app.mind)
 //
 // This is a TEMPLATE. To use:
 // 1. Copy or write to app/lib/firebase_options.dart.
-// 2. Fill in the real `web`, `android`, and `androidTv` values from the Firebase
+// 2. Fill in the real `web`, `android`, `androidTv` and `androidMind` values
+//    from the Firebase
 //    Console (Project settings > Your apps) or from the `GOOGLE_SERVICES_JSON` /
 //    `FIREBASE_OPTIONS_DART` secrets used by the release workflows.
 // 3. Leave the `androidStreaming`, `ios`, `macos`, and `windows` entries as
@@ -16,6 +18,7 @@
 // Build with variant:
 //   flutter build apk --dart-define=APP_VARIANT=tv
 //   flutter build apk --dart-define=APP_VARIANT=streaming
+//   flutter build apk --dart-define=APP_VARIANT=mind
 //   flutter build apk --dart-define=APP_VARIANT=full (default)
 
 import 'package:firebase_core/firebase_core.dart' show FirebaseOptions;
@@ -28,6 +31,7 @@ enum AppVariant {
   full, // io.airo.app - All features
   streaming, // io.airo.app.streaming - Music + IPTV
   tv, // io.airo.app.tv - IPTV only
+  mind, // io.airo.app.mind - Airo Mind standalone shell
 }
 
 /// Default [FirebaseOptions] for use with your Firebase apps.
@@ -46,6 +50,8 @@ class DefaultFirebaseOptions {
         return AppVariant.tv;
       case 'streaming':
         return AppVariant.streaming;
+      case 'mind':
+        return AppVariant.mind;
       default:
         return AppVariant.full;
     }
@@ -123,6 +129,8 @@ class DefaultFirebaseOptions {
         return androidTv;
       case AppVariant.streaming:
         return androidStreaming;
+      case AppVariant.mind:
+        return androidMind;
       case AppVariant.full:
         return android;
     }
@@ -157,6 +165,22 @@ class DefaultFirebaseOptions {
   static const FirebaseOptions androidTv = FirebaseOptions(
     apiKey: 'YOUR_ANDROID_TV_API_KEY',
     appId: 'YOUR_ANDROID_TV_APP_ID',
+    messagingSenderId: 'YOUR_MESSAGING_SENDER_ID',
+    projectId: 'YOUR_PROJECT_ID',
+    storageBucket: 'YOUR_PROJECT_ID.firebasestorage.app',
+  );
+
+  /// Airo Mind - io.airo.app.mind
+  ///
+  /// The Mind shell initializes Firebase only for auth parity with the super
+  /// app (the assistant's profile screen signs in with Google). Gradle installs
+  /// this variant as `io.airo.app.mind`, so Dart must hand
+  /// `Firebase.initializeApp` that client's own appId -- handing it the
+  /// `io.airo.app` one instead resolves as a package/signature mismatch and
+  /// Google Sign-In fails with `ApiException: 10`.
+  static const FirebaseOptions androidMind = FirebaseOptions(
+    apiKey: 'YOUR_ANDROID_MIND_API_KEY',
+    appId: 'YOUR_ANDROID_MIND_APP_ID',
     messagingSenderId: 'YOUR_MESSAGING_SENDER_ID',
     projectId: 'YOUR_PROJECT_ID',
     storageBucket: 'YOUR_PROJECT_ID.firebasestorage.app',

--- a/app/test_mind/main_mind_shell_test.dart
+++ b/app/test_mind/main_mind_shell_test.dart
@@ -10,7 +10,8 @@
 ///
 /// ```bash
 /// cp app/pubspec_mind.yaml app/pubspec.yaml   # restored by run_mind_macos.sh
-/// cd app && flutter pub get && flutter test test_mind/
+/// cd app && flutter pub get
+/// flutter test test_mind/ --dart-define=APP_VARIANT=mind
 /// ```
 library;
 

--- a/app/test_mind/mind_firebase_variant_test.dart
+++ b/app/test_mind/mind_firebase_variant_test.dart
@@ -1,0 +1,78 @@
+/// Guards the Firebase variant selection for the Airo Mind shell.
+///
+/// Gradle installs this flavour as `io.airo.app.mind`
+/// (`app/android/app/build.gradle.kts`, `APP_VARIANT=mind`). Dart therefore has
+/// to hand `Firebase.initializeApp` *that* client's options. Before
+/// `AppVariant.mind` existed, `APP_VARIANT=mind` fell through
+/// `currentVariant`'s `default:` arm to `AppVariant.full` and the shell
+/// initialized as `io.airo.app` — a package/signature mismatch that surfaces
+/// only on a real device, as `ApiException: 10 (DEVELOPER_ERROR)` the first
+/// time someone taps Google Sign-In on the assistant's profile screen.
+///
+/// **This suite must run with `--dart-define=APP_VARIANT=mind`.** `APP_VARIANT`
+/// is read through `String.fromEnvironment`, which is resolved at compile time,
+/// so there is no way to vary it from inside a test. Running `test_mind/`
+/// without the define is running the wrong build, and the first test below says
+/// so rather than passing vacuously. Both CI jobs pass it.
+library;
+
+import 'package:airo_app/firebase_options.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  const variant = String.fromEnvironment('APP_VARIANT');
+
+  test('the suite is compiled as the mind flavour', () {
+    expect(
+      variant,
+      'mind',
+      reason:
+          'test_mind/ must run with --dart-define=APP_VARIANT=mind; '
+          'without it this suite exercises the phone flavour instead.',
+    );
+  });
+
+  test('APP_VARIANT=mind selects the mind variant', () {
+    expect(DefaultFirebaseOptions.currentVariant, AppVariant.mind);
+  });
+
+  test('the mind variant resolves to its own Android client', () {
+    // currentPlatform is the same accessor main_mind.dart calls. On the test
+    // host defaultTargetPlatform is android, so this walks the real
+    // _getAndroidOptions() switch rather than a re-implementation of it.
+    expect(
+      DefaultFirebaseOptions.currentPlatform.appId,
+      DefaultFirebaseOptions.androidMind.appId,
+    );
+  });
+
+  test('the mind client is distinct from the super app and TV clients', () {
+    // The bug this file exists for is silent reuse of another variant's appId,
+    // which is invisible unless the values are actually different.
+    expect(
+      DefaultFirebaseOptions.androidMind.appId,
+      isNot(DefaultFirebaseOptions.android.appId),
+    );
+    expect(
+      DefaultFirebaseOptions.androidMind.appId,
+      isNot(DefaultFirebaseOptions.androidTv.appId),
+    );
+  });
+
+  test('placeholder mind options are reported as unconfigured', () {
+    // The checked-in firebase_options.dart ships placeholders; real values
+    // arrive from FIREBASE_OPTIONS_DART_B64. isConfigured is what stops
+    // main_mind.dart calling Firebase.initializeApp with a placeholder appId,
+    // which would crash natively before Dart could recover.
+    final options = DefaultFirebaseOptions.androidMind;
+    final isPlaceholder =
+        options.appId.contains('YOUR_') || options.appId.contains('TODO');
+    expect(
+      DefaultFirebaseOptions.isConfigured(options),
+      !isPlaceholder,
+      reason:
+          'isConfigured must track whether androidMind still holds a '
+          'placeholder appId, in both directions.',
+    );
+  });
+}


### PR DESCRIPTION
Follow-up to #1542, which shipped the Mind shell but left its Firebase client selection wrong.

## The bug

`app/android/app/build.gradle.kts` installs this flavour as `io.airo.app.mind`. `firebase_options.dart` did not know the variant existed:

```dart
enum AppVariant { full, streaming, tv }   // no mind

static AppVariant get currentVariant {
  switch (_variantString) {
    case 'tv': return AppVariant.tv;
    case 'streaming': return AppVariant.streaming;
    default: return AppVariant.full;      // ← APP_VARIANT=mind lands here
  }
}
```

So the shell called `Firebase.initializeApp` with `io.airo.app`'s options while Android ran as `io.airo.app.mind`. Native google-services and Dart disagree on the package, and Google Sign-In on the assistant's profile screen fails with `ApiException: 10 (DEVELOPER_ERROR)`. It reproduces only on a real device — nothing in the analyzer, the test suite, or `flutter build bundle` can see it.

## The fix

`AppVariant.mind`, the `'mind'` parse arm, an `androidMind` client and its `_getAndroidOptions()` case — applied to both the checked-in placeholder `firebase_options.dart` and the `.template` it is generated from, so they cannot drift.

Values stay placeholders in the repo. Real ones come from `FIREBASE_OPTIONS_DART_B64`, and `isConfigured` already skips init while an appId still contains `YOUR_`/`TODO`.

`io.airo.app.mind` is now registered in the `devscoffee-airo` Firebase project and the `GOOGLE_SERVICES_JSON` secret has been updated with a client list that is a strict superset of the previous one.

## Test

`app/test_mind/mind_firebase_variant_test.dart`.

`APP_VARIANT` is read through `String.fromEnvironment`, resolved at compile time, so it cannot be varied from inside a test — the suite has to be *compiled* as the flavour it tests. Both CI jobs now pass `--dart-define=APP_VARIANT=mind`, and the first test asserts the define is present so the rest cannot pass vacuously against the phone flavour.

| Run | Result |
|---|---|
| `flutter test test_mind/mind_firebase_variant_test.dart --dart-define=APP_VARIANT=mind` | 5/5 pass |
| same, without the define | 3 fail — the guard is not vacuous |
| `flutter test test_mind/` (whole suite, with define) | 9/9 pass |
| `flutter analyze lib/main_mind.dart lib/core/mind lib/firebase_options.dart` | No issues found |

## Still open, not in this PR

`io.airo.app.mind` was registered without a SHA-1, so its `oauth_client` list has only `client_type: 3` (web) and no `client_type: 1` (Android) — compare `io.airo.app` and `io.airo.app.tv`, which have both. Google Sign-In will still fail on device until a fingerprint is added and `GOOGLE_SERVICES_JSON` is regenerated. Not blocking this PR: the variant selection is wrong either way and this fixes it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)