### PR TITLE
fix(app): green firebase_options_test against the mind variant

### DIFF
--- a/app/test/firebase_options_test.dart
+++ b/app/test/firebase_options_test.dart
@@ -24,7 +24,7 @@ void main() {
       );
     });
 
-    test('marks real Firebase app ids as configured', () {
+    test('marks the provisioned Android app ids as configured', () {
       if (usingPlaceholderConfig) {
         markTestSkipped(
           'firebase_options.dart is the placeholder template -- no '
@@ -32,16 +32,23 @@ void main() {
         );
         return;
       }
-      expect(
-        DefaultFirebaseOptions.isConfigured(DefaultFirebaseOptions.web),
-        isTrue,
-      );
+      // Android only. FIREBASE_OPTIONS_DART_B64 carries real values for the
+      // three registered Android clients; `web`, `ios`, `macos`, `windows` and
+      // `androidStreaming` are still placeholders because those apps are not
+      // registered in the Firebase project. `usingPlaceholderConfig` is read
+      // off `android`, so asserting `web` here would fail the moment the
+      // Android clients alone were provisioned -- which is exactly what
+      // happened.
       expect(
         DefaultFirebaseOptions.isConfigured(DefaultFirebaseOptions.android),
         isTrue,
       );
       expect(
         DefaultFirebaseOptions.isConfigured(DefaultFirebaseOptions.androidTv),
+        isTrue,
+      );
+      expect(
+        DefaultFirebaseOptions.isConfigured(DefaultFirebaseOptions.androidMind),
         isTrue,
       );
     });
@@ -60,12 +67,21 @@ void main() {
       );
     });
 
-    test('selects the supported full, streaming, and TV variants', () {
+    test('selects the supported full, streaming, TV, and Mind variants', () {
       expect(
         AppVariant.values,
-        containsAll([AppVariant.full, AppVariant.streaming, AppVariant.tv]),
+        containsAll([
+          AppVariant.full,
+          AppVariant.streaming,
+          AppVariant.tv,
+          AppVariant.mind,
+        ]),
       );
-      expect(AppVariant.values, hasLength(3));
+      // Exact length, not just containsAll: a new variant needs a matching
+      // `_getAndroidOptions()` arm and its own registered Firebase client, or
+      // it silently initializes as `io.airo.app` and Google Sign-In fails with
+      // `ApiException: 10` on device. Failing here is the cheap reminder.
+      expect(AppVariant.values, hasLength(4));
     });
   });
 }


### PR DESCRIPTION
`main` is red. #1543 added `AppVariant.mind`; `app/test/firebase_options_test.dart` asserts `hasLength(3)`. The Mind CI job runs `test_mind/`, which never loads that file, so the phone suite caught it only after merge.

Fixes that, plus a second failure that had not surfaced yet.

## Two bugs

**1. Exact-length assertion (the red one)**

`expect(AppVariant.values, hasLength(3))` → four variants now.

Kept as an exact length rather than relaxed to `containsAll`: a new variant needs a matching `_getAndroidOptions()` arm *and* its own registered Firebase client, or it silently initializes as `io.airo.app` and Google Sign-In fails with `ApiException: 10` — on device only. A failing length check is the cheapest possible reminder.

**2. `web` assertion, latent**

```dart
final usingPlaceholderConfig = !DefaultFirebaseOptions.isConfigured(
  DefaultFirebaseOptions.android,   // ← guard read off android
);
...
expect(DefaultFirebaseOptions.isConfigured(DefaultFirebaseOptions.web), isTrue);
```

The guard is derived from `android`, but the body asserted `web`. That was consistent only while `FIREBASE_OPTIONS_DART_B64` was unset and *everything* was a placeholder, so the test always skipped.

The secret now exists and carries real values for the three registered Android clients, leaving `web`, `ios`, `macos`, `windows` and `androidStreaming` as placeholders — those apps are not registered in the Firebase project. So the guard no longer trips, the body runs, and `web` fails. The failing `test-app` run predates the secret (12:26 vs 12:34), which is why only the length error showed.

The assertion now covers exactly what is provisioned: `android`, `androidTv`, `androidMind`.

## Verification

Ran both configurations, because one of them is what CI sees and the other is what release builds see:

| `firebase_options.dart` | Result |
|---|---|
| checked-in placeholder (what the phone CI suite loads) | 2 passed, 2 skipped |
| real values from `FIREBASE_OPTIONS_DART_B64` | 4 passed, 0 skipped |

The real-values run also passes `uses the registered Android TV Firebase app id`, which asserts a hardcoded appId — an independent check that the provisioned values are the right ones and not just internally consistent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)