### PR TITLE
fix(mind): unblock the Android Rust cross-compile up to the ggml conflict

### DIFF
--- a/packages/feature_mind/cargokit/build_tool/lib/src/android_environment.dart
+++ b/packages/feature_mind/cargokit/build_tool/lib/src/android_environment.dart
@@ -129,7 +129,8 @@ class AndroidEnvironment {
 
     final ndkVersionParsed = Version.parse(ndkVersion);
     final rustFlagsKey = 'CARGO_ENCODED_RUSTFLAGS';
-    final rustFlagsValue = _libGccWorkaround(targetTempDir, ndkVersionParsed);
+    var rustFlagsValue = _libGccWorkaround(targetTempDir, ndkVersionParsed);
+    rustFlagsValue = _ggmlBlasWorkaround(targetTempDir, rustFlagsValue);
 
     final runRustTool =
         Platform.isWindows ? 'run_build_tool.cmd' : 'run_build_tool.sh';
@@ -159,11 +160,62 @@ class AndroidEnvironment {
       ranlibKey: ranlibValue,
       rustFlagsKey: rustFlagsValue,
       linkerKey: selfPath,
+      // llama-cpp-sys-2's build script locates the NDK itself rather than
+      // using CC/CXX, and aborts with "Android NDK not found. Please set one
+      // of: ANDROID_NDK, NDK_ROOT, ANDROID_NDK_ROOT" when none is set.
+      // Cargokit knows the exact NDK it resolved, so it passes it on rather
+      // than leaving each -sys crate to guess. Every host is affected,
+      // including CI.
+      'ANDROID_NDK': ndkPath,
+      'ANDROID_NDK_ROOT': ndkPath,
+      'NDK_ROOT': ndkPath,
       // Recognized by main() so we know when we're acting as a wrapper
       '_CARGOKIT_NDK_LINK_TARGET': targetArg,
       '_CARGOKIT_NDK_LINK_CLANG': ccValue,
       'CARGOKIT_TOOL_TEMP_DIR': toolTempDir,
     };
+  }
+
+  /// Workaround for an upstream bug in `whisper-rs-sys` 0.15.0.
+  ///
+  /// Its `build.rs` decides whether whisper.cpp was built with a BLAS backend
+  /// using `cfg!(target_os = "macos")`. A build script is compiled for the
+  /// HOST, so on a Mac that is true no matter what the *target* is, and the
+  /// crate emits `cargo:rustc-link-lib=static=ggml-blas` for an Android build.
+  /// CMake never produced that library -- `CMakeCache.txt` from the same build
+  /// records `GGML_BLAS:BOOL=OFF` -- so the link fails with:
+  ///
+  ///     error: could not find native static library `ggml-blas`
+  ///
+  /// The same file gets it right elsewhere (`target.contains("apple")`), so
+  /// this is an inconsistency rather than a deliberate choice. 0.15.0 is the
+  /// latest release; there is no fixed version to move to.
+  ///
+  /// rustc resolves `-l static=` while *compiling the rlib*, not at final
+  /// link, so a `cargo:rustc-link-search` from a dependent crate is too late.
+  /// It has to arrive as a rustflag, which is also why this cannot live in
+  /// `.cargo/config.toml`: cargokit sets `CARGO_ENCODED_RUSTFLAGS`, and that
+  /// env var makes cargo ignore the config's `rustflags` entirely.
+  ///
+  /// An empty archive is a correct stand-in, not a lie: with BLAS off nothing
+  /// in whisper.cpp references a `ggml_backend_blas_*` symbol, so there is
+  /// nothing for the archive to provide. Same shape as the libgcc workaround
+  /// below, which fabricates a `libgcc.a` for a library NDK 23+ dropped.
+  ///
+  /// Linux and Windows hosts never see the bad flag, so they never get the
+  /// stub -- gating on the host keeps this from masking a genuine missing
+  /// BLAS build on a platform that really did ask for one.
+  String _ggmlBlasWorkaround(String buildDir, String rustFlags) {
+    if (!Platform.isMacOS) {
+      return rustFlags;
+    }
+    final workaroundDir = path.join(buildDir, 'cargokit', 'ggml_blas_stub');
+    Directory(workaroundDir).createSync(recursive: true);
+    // The 8-byte header of an archive with no members. `ar` writes exactly
+    // this for an empty archive, and both ld.lld and rustc accept it.
+    File(path.join(workaroundDir, 'libggml-blas.a'))
+        .writeAsStringSync('!<arch>\n');
+    return '$rustFlags\x1f-L\x1f$workaroundDir';
   }
 
   // Workaround for libgcc missing in NDK23, inspired by cargo-ndk

--- a/scripts/build-mind.sh
+++ b/scripts/build-mind.sh
@@ -31,6 +31,41 @@ if [[ -n "$BUILD_NUMBER" && ! "$BUILD_NUMBER" =~ ^[1-9][0-9]*$ ]]; then
   exit 2
 fi
 
+# The PATH note in this file's header was documentation, and documentation did
+# not stop the build from picking the wrong toolchain. Check it instead.
+#
+# A Homebrew `rust` provides /opt/homebrew/bin/cargo, which precedes
+# ~/.cargo/bin on a default macOS PATH. It has no Android std, so cargokit dies
+# with "can't find crate for `core`" naming a target that `rustup target list`
+# reports as installed -- an error that sends you looking at rustup, which is
+# not the problem.
+active_cargo="$(command -v cargo || true)"
+if [[ -z "$active_cargo" ]]; then
+  echo "cargo not found on PATH. Install rustup: https://rustup.rs" >&2
+  exit 1
+fi
+# Can the active toolchain actually target Android?
+#
+# `--print target-libdir` is not the test -- it happily prints a path for a
+# toolchain that has no Android std at all, which is precisely the Homebrew
+# case. The standard library has to be on disk, so look for libcore in it.
+android_libdir="$(rustc --target aarch64-linux-android --print target-libdir 2>/dev/null || true)"
+if [[ -z "$android_libdir" ]] || ! compgen -G "$android_libdir/libcore-*.rlib" >/dev/null; then
+  echo "The active Rust toolchain cannot target aarch64-linux-android." >&2
+  echo "  active cargo: $active_cargo" >&2
+  echo "  active rustc: $(command -v rustc || echo 'not found')" >&2
+  if [[ "$active_cargo" != "$HOME/.cargo/bin/cargo" && -x "$HOME/.cargo/bin/cargo" ]]; then
+    echo >&2
+    echo "A non-rustup cargo is shadowing rustup's shims (Homebrew installs one" >&2
+    echo "at /opt/homebrew/bin). Fix with 'brew unlink rust', or put" >&2
+    echo "\$HOME/.cargo/bin ahead of it on PATH." >&2
+  else
+    echo >&2
+    echo "Install the target: rustup target add aarch64-linux-android" >&2
+  fi
+  exit 1
+fi
+
 if [[ ! -f "$PROFILE_PUBSPEC" ]]; then
   echo "Airo Mind profile not found: $PROFILE_PUBSPEC" >&2
   exit 1
@@ -88,6 +123,21 @@ fi
 # llama-cpp-sys-2 and whisper-rs-sys read these two spellings instead.
 export ANDROID_NDK="${ANDROID_NDK:-$ANDROID_NDK_ROOT}"
 export NDK_ROOT="${NDK_ROOT:-$ANDROID_NDK_ROOT}"
+
+# feature_mind's *.freezed.dart is gitignored, so a fresh clone has none and the
+# Dart compile fails long before the Rust runtime is reached, with
+# "Couldn't find constructor ProcessingEvent_*" pointing at the package rather
+# than at the missing codegen. The CI job runs this as its own step; a local
+# build has nothing that would.
+#
+# Presence-checked, not up-to-date-checked: build_runner is the authority on
+# staleness, and re-running it on every build costs more than it saves. Run it
+# by hand after changing an annotated type.
+mind_pkg="$ROOT_DIR/packages/feature_mind"
+if [[ ! -f "$mind_pkg/lib/src/api/mind.freezed.dart" ]]; then
+  echo "Generating feature_mind code (freezed outputs are gitignored)"
+  (cd "$mind_pkg" && flutter pub get >/dev/null && dart run build_runner build)
+fi
 
 backup_dir="$(mktemp -d)"
 cp "$ACTIVE_PUBSPEC" "$backup_dir/pubspec.yaml"


### PR DESCRIPTION
The Mind APK could not be built on any host, which is why device dogfood has never happened. Four causes; three fixed here.

The previous note in `ci.yml` blamed the armv7 panic and a local environment. Neither holds: `build-mind.sh:121` already pins `--target-platform=android-arm64`, and two of these hit Linux CI too.

## Causes

| # | Cause | Scope | Here? |
|---|---|---|---|
| 1 | Homebrew `cargo` shadows rustup; no Android std | local | ✅ guard |
| 2 | `llama-cpp-sys-2` needs `ANDROID_NDK`; cargokit never set it | all hosts | ✅ |
| 3 | `whisper-rs-sys` emits `-l static=ggml-blas` from a **host** `cfg!` | macOS host | ✅ stub |
| 4 | whisper.cpp + llama.cpp vendor **different** ggml into one `.so` | all hosts | ❌ separate issue |
| 5 | gitignored `*.freezed.dart`; script never ran codegen | fresh clone | ✅ |

### 3 is an upstream bug worth stating precisely

```rust
// whisper-rs-sys 0.15.0 build.rs — a build script compiles for the HOST
if cfg!(target_os = "macos") || cfg!(feature = "openblas") {
    println!("cargo:rustc-link-lib=static=ggml-blas");
}
```

So a Mac emits this for an Android target. The same build's `CMakeCache.txt` records `GGML_BLAS:BOOL=OFF` — the library was never built. 0.15.0 is the latest release, and the file uses the correct `target.contains("apple")` idiom 300 lines earlier, so it is an inconsistency rather than a decision.

The stub must arrive as a **rustflag**: rustc resolves `-l static=` while compiling the rlib, so a dependent crate's `rustc-link-search` is too late, and `.cargo/config.toml` rustflags are ignored outright because cargokit sets `CARGO_ENCODED_RUSTFLAGS`. An empty archive is a correct stand-in — with BLAS off nothing references `ggml_backend_blas_*`. It sits next to the existing libgcc workaround, which fabricates a library the same way.

## Verification

Against the real `scripts/build-mind.sh` pipeline, not just direct cargo:

| Signal | Before | After |
|---|---|---|
| `ggml-blas` errors | present | **0** |
| `NDK not found` | present | **0** |
| duplicate `ggml_*` symbols | never reached | 20 (cause 4) |

Each engine also cross-compiles and links independently for `aarch64-linux-android` — whisper alone → 16.7 MB `.so`, llama alone → 48.7 MB. **These are the first Android artifacts this runtime has produced.**

The preflight guard was tested in both directions: it fails with an actionable PATH message under Homebrew's cargo, and passes under rustup's.

## What still fails, deliberately

Cause 4. Both engines statically link their own ggml into one cdylib → 20+ duplicate symbols. `diff -rq` on the two ggml trees: **348 differing or unique files**; `ggml.h` differs by 121 lines. So `-Wl,--allow-multiple-definition` is not an option — it would bind one library's callers to the other's ABI and corrupt memory at runtime instead of failing at build. The fix is splitting the runtime into two cdylibs.

## Related finding, not Android-specific

`packages/feature_mind/lib/src/library_loader.dart:26-29` already records that macOS ships a dylib *because* the two ggml copies collide. That means the collision was routed around, not resolved: on macOS the link succeeds only because static-archive members are pulled lazily, so one engine is probably already calling the other's ggml. Same symbol names, 348 files of difference. Worth confirming at symbol level on the macOS dylib — the two-cdylib split would fix it there too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)