### PR TITLE
fix(mind): make the Android APK build, install and run on a device

### DIFF
--- a/app/pubspec_mind.yaml
+++ b/app/pubspec_mind.yaml
@@ -172,6 +172,20 @@ dependency_overrides:
     path: ../packages/stubs/mlkit_image_labeling_stub
   media_kit_libs_android_video:
     path: ../packages/stubs/media_kit_libs_android_video_stub
+  # Same stub pubspec_tv.yaml uses, for the same reason. In this flavour's
+  # dependency set the real package's Android implementation does not resolve,
+  # and the generated registrant then names a class that is not on the compile
+  # classpath:
+  #
+  #   GeneratedPluginRegistrant.java: cannot find symbol
+  #     com.fluttercandies.flutter_image_compress.ImageCompressPlugin
+  #
+  # The cost is bounded and worth stating: image compression becomes a no-op,
+  # so a screenshot attached to a bug report from the Mind flavour is sent at
+  # full size. Nothing on the record -> transcribe -> minutes -> search journey
+  # touches it.
+  flutter_image_compress:
+    path: ../packages/stubs/flutter_image_compress_stub
 
 flutter:
   config:

--- a/packages/feature_mind/cargokit/gradle/plugin.gradle
+++ b/packages/feature_mind/cargokit/gradle/plugin.gradle
@@ -132,6 +132,58 @@ abstract class CargoKitBuildTask extends DefaultTask {
             environment "CARGOKIT_TARGET_PLATFORMS", targetPlatforms.join(",")
             environment "CARGOKIT_JAVA_HOME", System.properties['java.home']
         }
+
+        copyCxxSharedRuntime()
+    }
+
+    // PATCHED: ship the NDK's C++ runtime alongside the engines.
+    //
+    // whisper.cpp and llama.cpp are C++, and the Rust cdylibs link them against
+    // libc++_shared (see `get_cpp_link_stdlib` in whisper-rs-sys). Nothing else
+    // in this APK carries that library, so without this the app installs and
+    // launches and then fails the moment it opens the bridge:
+    //
+    //   dlopen failed: library "libc++_shared.so" not found:
+    //     needed by .../lib/arm64-v8a/libairo_mind_whisper.so
+    //
+    // It is taken from the SAME NDK cargokit just compiled with, rather than
+    // the one this Gradle module pins -- those two disagree in this repo, and
+    // pairing a C++ runtime with objects built by a different toolchain is the
+    // kind of mismatch that fails somewhere other than where it was caused.
+    private void copyCxxSharedRuntime() {
+        def hostTag = Os.isFamily(Os.FAMILY_MAC) ? "darwin-x86_64"
+            : (Os.isFamily(Os.FAMILY_WINDOWS) ? "windows-x86_64" : "linux-x86_64")
+
+        def abiForPlatform = [
+            "android-arm64": ["arm64-v8a", "aarch64-linux-android"],
+            "android-arm"  : ["armeabi-v7a", "arm-linux-androideabi"],
+            "android-x64"  : ["x86_64", "x86_64-linux-android"],
+            "android-x86"  : ["x86", "i686-linux-android"],
+        ]
+
+        targetPlatforms.each { platform ->
+            def entry = abiForPlatform[platform]
+            if (entry == null) {
+                return
+            }
+            def (abi, triple) = entry
+            def source = new File(
+                "$sdkDirectory/ndk/$ndkVersion/toolchains/llvm/prebuilt/$hostTag" +
+                "/sysroot/usr/lib/$triple/libc++_shared.so")
+            if (!source.exists()) {
+                throw new GradleException(
+                    "libc++_shared.so not found for $abi at $source. The engines " +
+                    "link it and will fail to dlopen without it.")
+            }
+            def destDir = new File("$outputDir/$abi")
+            destDir.mkdirs()
+            def dest = new File(destDir, "libc++_shared.so")
+            // Only when it changed: this runs per library, and the second copy
+            // would otherwise rewrite a file the packaging step already read.
+            if (!dest.exists() || dest.length() != source.length()) {
+                dest.bytes = source.bytes
+            }
+        }
     }
 }
 

--- a/scripts/build-mind.sh
+++ b/scripts/build-mind.sh
@@ -187,9 +187,14 @@ if [[ "$BUILD_MODE" == "debug" ]]; then
 else
   manifest_task="processReleaseManifest"
 fi
-merged_manifest="$APP_DIR/build/app/intermediates/merged_manifests/$BUILD_MODE/$manifest_task/AndroidManifest.xml"
-if [[ ! -f "$merged_manifest" ]]; then
-  echo "Airo Mind merged manifest missing: $merged_manifest" >&2
+# Found, not constructed. `--split-per-abi` adds an ABI segment to this path
+# (.../processReleaseManifest/arm64-v8a/AndroidManifest.xml) and a non-split
+# build does not, so a fixed path reports a missing manifest for a build that
+# succeeded -- which is exactly what it did.
+manifest_dir="$APP_DIR/build/app/intermediates/merged_manifests/$BUILD_MODE/$manifest_task"
+merged_manifest="$(find "$manifest_dir" -name AndroidManifest.xml 2>/dev/null | head -1)"
+if [[ -z "$merged_manifest" ]]; then
+  echo "Airo Mind merged manifest missing under: $manifest_dir" >&2
   exit 1
 fi
 # Mind reuses the product MainActivity; the assertion that matters is that the


### PR DESCRIPTION
**Airo Mind completes its whole journey on a Pixel 9** — record, transcribe, minutes, save, list, search. That has never happened before.

Follows #1549. Each fix here is something only a device could have found.

## Three fixes

**1. `libc++_shared.so` was never packaged.** Both engines are C++ and the Rust cdylibs link the NDK's shared C++ runtime, but nothing put it in the APK. The app installed, launched, drew its UI, and then failed the instant it opened the bridge:

```
dlopen failed: library "libc++_shared.so" not found:
  needed by .../lib/arm64-v8a/libairo_mind_whisper.so
```

Cargokit's build task now copies it per ABI, from the **same NDK it just compiled with** rather than the one the Gradle module pins. Those two disagree in this repo, and pairing a C++ runtime with objects built by another toolchain fails somewhere other than where it was caused.

**2. `flutter_image_compress` stubbed for this flavour**, as `pubspec_tv.yaml` already does. In this dependency set the real package's Android implementation doesn't resolve, and the generated registrant then names a class that isn't on the compile classpath. Cost is bounded and written into the pubspec: a bug report from the Mind flavour sends its screenshot uncompressed. Nothing on the Mind journey touches it.

**3. The merged-manifest check constructed a path instead of finding one.** `--split-per-abi` inserts an ABI segment, so the check reported a missing manifest for a build that had just succeeded — the script exited 1 while holding a working APK.

## Verified on the device, not inferred

| Step | Result |
|---|---|
| APK | 620 MB, arm64, installs as `io.airo.app.mind` |
| Packaging | `libc++_shared.so` present beside both engines |
| Record | mic captures, UI shows Recording |
| Transcribe | whisper → `[MUSIC PLAYING] [MUSIC PLAYING]` from live audio |
| Minutes | llama writes real Markdown — Decisions, Action Items, phased agenda |
| Save | "Meeting 1" appears in the library |
| Search | "MUSIC" returns it with the matching snippet |

Both engines ran in one process, from two separate libraries, entirely offline.

## Known and not addressed here

**Debug builds still fail.** Cargokit adds x86 ABIs for debug only, and `whisper-rs-sys` falls back to bundled 64-bit bindings that don't const-eval on i686 (`12_usize - 16_usize` overflow). Release is arm64-only and is what ships. Worth its own fix — debug builds target real devices in this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)