### PR TITLE
fix(mind): unblock debug builds by pinning the engines to arm64

### DIFF
--- a/packages/feature_mind/android/build.gradle
+++ b/packages/feature_mind/android/build.gradle
@@ -22,8 +22,27 @@ cargokit {
     //
     // Paths are relative to this file. The engines are in the cargo workspace
     // at <repo>/rust, not inside the package.
-    library("../../../rust/airo_mind_whisper", "airo_mind_whisper")
-    library("../../../rust/airo_mind_llama", "airo_mind_llama")
+    //
+    // arm64 only, and this is what makes a debug build possible at all.
+    // Cargokit adds x86 and x86_64 for debug builds (emulator ABIs), and
+    // neither engine can be built for 32-bit x86 here:
+    //
+    //   * whisper-rs-sys cannot generate bindings without a sysroot, falls back
+    //     to bindings pinned for 64-bit, and those fail const-eval on i686
+    //     ("attempt to compute 12_usize - 16_usize, which would overflow").
+    //     Supplying a sysroot fixes that, and then CMake fails separately with
+    //     "unsupported option '-arch' for target 'i686-linux-android24'" -- an
+    //     Apple flag reaching an Android cross-compile from a macOS host.
+    //   * llama-cpp-sys-2's build script panics outright on
+    //     armv7-linux-androideabi.
+    //
+    // x86 Android is emulator-only and no device in this project's test rig
+    // uses it, so the engines are not built for it. On an ABI without them the
+    // app degrades to MindUnavailable, which is a state the UI already
+    // explains -- rather than a build that cannot be produced.
+    def engineAbis = ["android-arm64"]
+    library("../../../rust/airo_mind_whisper", "airo_mind_whisper", engineAbis)
+    library("../../../rust/airo_mind_llama", "airo_mind_llama", engineAbis)
 }
 
 android {

--- a/packages/feature_mind/cargokit/gradle/plugin.gradle
+++ b/packages/feature_mind/cargokit/gradle/plugin.gradle
@@ -23,6 +23,11 @@ apply plugin: CargoKitPlugin
 class CargoKitLibrary {
     String manifestDir; // Relative path to folder containing Cargo.toml
     String libname; // Library name within Cargo.toml. Must be a cdylib
+    // Optional. When set, only these Flutter target platforms are built for
+    // this library; when null, whatever the build type asks for. Declared by
+    // the consumer rather than hardcoded here, so the reason lives with the
+    // package that has it.
+    List<String> platforms;
 }
 
 class CargoKitExtension {
@@ -31,10 +36,11 @@ class CargoKitExtension {
 
     final List<CargoKitLibrary> libraries = []
 
-    void library(String manifestDir, String libname) {
+    void library(String manifestDir, String libname, List<String> platforms = null) {
         def entry = new CargoKitLibrary()
         entry.manifestDir = manifestDir
         entry.libname = libname
+        entry.platforms = platforms
         libraries.add(entry)
     }
 
@@ -264,6 +270,13 @@ class CargoKitPlugin implements Plugin<Project> {
                         throw new GradleException("Please set 'android.ndkVersion' in 'app/build.gradle'.")
                     }
 
+                    // PATCHED: a library may narrow the ABI set. Intersected
+                    // rather than substituted, so declaring a platform the
+                    // build is not producing cannot conjure one.
+                    def libPlatforms = lib.platforms == null
+                        ? platforms
+                        : platforms.findAll { lib.platforms.contains(it) }
+
                     def task = project.tasks.create(taskName, CargoKitBuildTask.class) {
                         buildMode = variant.buildType.name
                         buildDir = cargoBuildDir
@@ -272,7 +285,7 @@ class CargoKitPlugin implements Plugin<Project> {
                         sdkDirectory = plugin.project.android.sdkDirectory
                         minSdkVersion = plugin.project.android.defaultConfig.minSdkVersion.apiLevel as int
                         compileSdkVersion = plugin.project.android.compileSdkVersion.substring(8) as int
-                        targetPlatforms = platforms
+                        targetPlatforms = libPlatforms
                         pluginFile = CargoKitPlugin.file
                         cargoManifestDir = lib.manifestDir
                     }


### PR DESCRIPTION
Phase 0 of the Airo Mind SSOT plan (`docs/superpowers/plans/2026-08-07-airo-mind-ssot-plan.md`). Blocks every later phase — the moment `feature_mind` enters `app/pubspec.yaml` (Phase 4), every super-app debug build breaks without this.

## The bug

`feature_mind` in a debug build has never succeeded. Cargokit adds x86 ABIs for debug builds (emulator support), and `whisper-rs-sys` cannot cross-compile to `i686-linux-android` on this host — two separate problems, found in sequence:

1. bindgen has no sysroot, falls back to bindings pinned for 64-bit, and those fail const-eval on i686: `attempt to compute 12_usize - 16_usize, which would overflow`.
2. Supplying a sysroot fixes that — and exposes a second failure underneath it: `clang: error: unsupported option '-arch' for target 'i686-linux-android24'`, an Apple-only flag reaching an Android cross-compile from a macOS host, inside whisper.cpp's CMake configure.

## The fix

x86 Android is emulator-only, and no device in this project's physical rig (Pixel 9 / iPad Air 4 / Fire TV Stick) uses it. Chasing the CMake bug further buys correctness for an ABI nothing here runs on, so the engines are declared **arm64-only**.

`cargokit`'s Gradle plugin gained an optional per-library platform list — `library(manifestDir, libname, platforms)` — so the restriction is declared where `feature_mind`'s `build.gradle` already declares its two libraries, not hardcoded into the vendored plugin. Platforms are **intersected** against what the build is already producing, never substituted, so a library can't conjure an ABI the build isn't building.

An ABI without the engines degrades to `MindUnavailable`, a state the UI already explains.

## Verified

| Check | Result |
|---|---|
| `AIRO_MIND_BUILD_MODE=debug scripts/build-mind.sh` | 707 MB debug APK, zero i686 references, zero `Cargokit BuildTool failed` |
| Install on Pixel 9 | `io.airo.app.mind` launched, process stayed alive |

**First debug build of this app to ever run.** Re-verified on this branch (cut fresh off `origin/main` after `#1549`/`#1550` auto-merged mid-session) before this commit — identical result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)