### PR TITLE
feat(mind): abstract model acquisition and engine calls behind interfaces

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -1,0 +1,39 @@
+# Airo Mind — single source of truth
+
+Gate file for `agent-skills:build auto`. Content lives where this repo's specs
+and plans already live — this file only points at it, per `docs/agents/CONTEXT_ENGINEERING.md`'s
+rule against a second rules file.
+
+## Objective
+
+Unify "Airo Mind" into one product: one package (`feature_mind`), one route
+namespace (`/mind`), one model-acquisition pipeline (download, not bundled, in
+both the super app and the standalone app), behind swappable abstractions
+(`ModelProvider`, `MindSpeechBridge`, `MindGenerationBridge`).
+
+## Specs
+
+- `docs/superpowers/specs/2026-08-06-airo-mind-journey-coverage.md` — the
+  engine-bridge seam (`MindSpeechBridge`/`MindGenerationBridge`) and the T3–T8
+  test list it unblocks, restoring coverage `#1549` removed.
+- `docs/superpowers/specs/2026-08-07-airo-mind-abstraction-layer.md` —
+  `ModelProvider` (model acquisition) and the same engine bridges, landed
+  together because both replace a concrete dependency in the same window.
+
+## Plan
+
+- `docs/superpowers/plans/2026-08-07-airo-mind-ssot-plan.md` — phases 0–4,
+  dependency graph, decisions taken, risks. **Approved.**
+- `docs/superpowers/plans/2026-08-07-airo-mind-ssot-todo.md` — the task
+  checklist `/build auto` executes, in order. Phase 0 is done and verified on
+  device; not yet committed.
+
+## Boundaries
+
+- `ADR-0018 §1` (runtime never acquires models) and `ADR-0021` (frozen
+  `MindRuntime` port) are not renegotiable by this work — see the plan's
+  "Hard constraints" section.
+- Merging `feature_assistant` into `feature_mind` (plan Phase 2) puts the
+  assistant hub under R05 (private-devices only), removing it from web and TV.
+  Accepted per the plan's Checkpoint 2 — do not silently proceed past it
+  without the stated council sign-off.

--- a/docs/superpowers/plans/2026-08-07-airo-mind-ssot-plan.md
+++ b/docs/superpowers/plans/2026-08-07-airo-mind-ssot-plan.md
@@ -1,0 +1,213 @@
+# Airo Mind — one package, one route tree, one model pipeline
+
+Full plan: see the Context, Dependency graph, Phases, Files, Verification and
+Risks sections below. Task checklist lives in `tasks/todo.md`.
+
+## Context
+
+"Airo Mind" means two different products depending on which app you open:
+
+| | Super app Mind tab | Airo Mind standalone |
+|---|---|---|
+| Assistant hub (chat, models, prompt lab, wellbeing) | ✅ `AssistantModule` | ✅ same module |
+| Scribe (record → transcribe → minutes → search) | ❌ absent | ✅ `MindScribeModule` |
+
+`feature_mind` is not in `app/pubspec.yaml` at all. The split shows in the names
+too: the product is Mind, the package is `feature_assistant`, the routes are
+`/assistant/*`, and `/mind` sits reserved and empty
+(`app/test/core/routing/mind_name_is_free_test.dart` — *"Airo Mind claims /mind
+in P4"*).
+
+**Outcome:** one package, one route namespace, one model pipeline, and a Mind
+tab in the super app that is the same product as the standalone app.
+
+### Decisions taken
+
+1. **One package** — `feature_assistant` (69 files, 15.6k lines) folds into
+   `feature_mind` (44 files, 6.9k lines).
+2. **Super app carries the engines** — real whisper + llama in the phone build.
+3. **Claim `/mind` now** — `/assistant/*` becomes `/mind/*`. This is P4.
+4. **Mind is private-devices only** — accepted consequence of R05: the assistant
+   hub leaves web and TV with the scribe. This removes shipped functionality
+   from two surfaces and is intended.
+5. **No bundled models in either app** — both the super app and the standalone
+   app move onto `core_ai`'s `ModelDownloadService`. Neither ships model
+   weights in the APK.
+6. **Both seams are abstracted, not hardcoded** — `ModelProvider` behind model
+   acquisition, `MindSpeechBridge`/`MindGenerationBridge` behind the engines.
+   Design: `docs/superpowers/specs/2026-08-07-airo-mind-abstraction-layer.md`.
+   This is what makes T3–T8 in the journey-coverage spec writable, and what
+   lets the download source change later without touching `MindService`.
+
+Decision 5 is what makes decision 2 affordable: the engines are ~5 MB of `.so`;
+the ~570 MB is model weights.
+
+## Dependency graph
+
+```
+core_ai (ModelDownloadService, ModelStorageManager, ModelDownloadProgress)
+   ↑
+feature_mind  ← merged: scribe + MindRuntime port + assistant hub
+   ↑                    module.yaml allowed_dependencies: [] must widen
+   ├── app (super app)      main.dart registers MindModule
+   ├── app (main_mind.dart) registers the same MindModule
+   └── packages/stubs/feature_mind_stub   ← web + TV swap it in (R05)
+
+rust/airo_mind_{core,whisper,llama}   unchanged by this work
+```
+
+Hard constraints, all pre-existing:
+
+- **R05 is gated** (`scripts/check-mind-private-devices.sh`). Web and TV must
+  not link the real `feature_mind`.
+- **`ADR-0018 §1`: the runtime never acquires models.** Downloading is Dart-side
+  in `core_ai`; Rust stays free of an HTTP client, which
+  `build_runtime_pod.sh` already checks on the shipped binary.
+- **`ADR-0021` freezes the `MindRuntime` port.** The merge must not edit it.
+- **Two council owners** — `feature_assistant` is AI/Brain Agent, `feature_mind`
+  is Product Manager. The merged package needs one, agreed before Phase 2.
+
+## Phases
+
+Each lands as its own PR off `origin/main`.
+
+### Phase 0 — unblock debug builds (blocks everything)
+
+`feature_mind` in a debug build fails today: cargokit adds x86 ABIs for debug
+only, and `whisper-rs-sys` falls back to bundled 64-bit bindings that fail
+const-eval on i686 (`12_usize - 16_usize` overflow). The moment `feature_mind`
+enters `app/pubspec.yaml`, every super-app debug build breaks.
+
+**Done.** Sysroot fix (`BINDGEN_EXTRA_CLANG_ARGS`) eliminated the const-eval
+crash, but exposed a second, host-specific CMake failure on i686
+(`unsupported option '-arch'` — an Apple flag reaching an Android cross-compile
+from macOS). x86 Android is emulator-only and no device in this project's rig
+uses it, so the engines are now declared `arm64` only, per library, in
+`packages/feature_mind/android/build.gradle` (cargokit's Gradle plugin gained
+an optional per-library platform list to express this).
+
+- **Acceptance:** `flutter build apk --debug` succeeds with `feature_mind` on
+  the dependency path. ✅ verified: 707 MB debug APK built, installed on the
+  Pixel 9, launched, PID stayed alive.
+- **Verify:** `AIRO_MIND_BUILD_MODE=debug scripts/build-mind.sh`. ✅
+
+### Phase 1 — model acquisition moves to `core_ai`, behind `ModelProvider`
+
+Design: `docs/superpowers/specs/2026-08-07-airo-mind-abstraction-layer.md`.
+
+Introduce `ModelProvider` (abstract). `ModelInstaller`'s bundled-asset behaviour
+becomes one implementation, demoted from the only path. `DownloadModelProvider`
+wraps `ModelDownloadService` + `ModelStorageManager`
+(`packages/core_ai/lib/src/download/` — already has pause/resume/retry/cancel/queue
+restore) and becomes the default for **both** apps — neither ships model weights
+in the APK. Keep the pinned SHA-256 digests in `rust/airo_mind_core/src/models.rs`
+as the verification; only the source of bytes changes. Drop `assets/models/`
+from `pubspec_mind.yaml`; keep `fetch_mind_models.sh` as a dev seeding
+convenience.
+
+At the same time, introduce `MindSpeechBridge` / `MindGenerationBridge` behind
+`MindService.process()` — same spec, §3. Both seams land in one PR: both
+concrete dependencies are being replaced in this window, and building the
+interface once is cheaper than building `DownloadModelProvider` against a
+concrete `ModelInstaller` and re-deriving the interface after.
+
+- **Acceptance:** fresh install downloads both models via `DownloadModelProvider`,
+  verifies them against the pinned digests, APK no longer carries ~570 MB;
+  `MindService` accepts a `ModelProvider` and both bridges via constructor
+  injection, defaults unchanged in production behaviour.
+- **Verify:** install on the Pixel, first-run download, then the full journey;
+  `verify_installed_models` reports both verified; `flutter test` in
+  `feature_mind` covers `DownloadModelProvider` and T3–T8 with fakes, no
+  network, no native library.
+
+**Checkpoint 1:** APK size before/after, and first-run on a real connection.
+
+### Phase 2 — merge `feature_assistant` into `feature_mind`
+
+`git mv` the four trees (`assistant`, `agent_chat`, `wellbeing`, `quotes`) into
+`packages/feature_mind/lib/src/`, same for `test/`. Merge the two `AppModule`s
+into one `MindModule` exporting the combined route table. `module.yaml` gains
+`core_ai`, `core_ui`, `core_product_shell`, `core_domain`, `core_data`.
+
+- **Acceptance:** one package, one module, both shells register `MindModule`,
+  `feature_assistant` gone, module-manifest gate passes.
+- **Verify:** `cd packages/feature_mind && flutter test`;
+  `assistant_route_parity_test.dart` passes unchanged.
+
+**Checkpoint 2:** council sign-off on the merged owner, and explicit
+confirmation that the assistant leaving web/TV is understood.
+
+### Phase 3 — claim `/mind`
+
+Move `/assistant/*` paths to `/mind/*`. **Keep every route *name* stable** —
+names are what notifications and deep links resolve, and changing paths and
+names together makes a failure impossible to attribute. Invert the legacy
+mapping in `notification_navigation_service.dart:91` (today `/mind` →
+`/assistant`). Retire `mind_name_is_free_test.dart`: the reservation has been
+claimed by its intended owner.
+
+- **Acceptance:** `/mind/*` resolves everywhere, old paths redirect, no route
+  name changed.
+- **Verify:** route-parity test, plus a notification payload with an old path
+  resolving to the new one.
+
+### Phase 4 — the super app carries Mind
+
+Add `feature_mind` to `app/pubspec.yaml`; register `MindModule` in `main.dart`
+beside `CoinVaultModule` and `IptvFeatureModule`. Web and TV keep the stub.
+
+- **Acceptance:** the super app's Mind tab is the same product as the standalone
+  app, scribe included; `check-mind-private-devices.sh` passes; web still builds.
+- **Verify:** `cd app && flutter build web --release`;
+  `scripts/check-mind-private-devices.sh`; device walk on both shells.
+
+**Checkpoint 3:** phone APK size and cold-build time before/after.
+
+## Files
+
+**Moved:** `packages/feature_assistant/lib/src/{assistant,agent_chat,wellbeing,quotes}`
+→ `packages/feature_mind/lib/src/`; same for `test/`.
+
+**Modified:** `packages/feature_mind/{module.yaml,pubspec.yaml}`,
+`app/lib/main.dart`, `app/lib/main_mind.dart`,
+`app/lib/core/routing/app_router.dart`, `app/pubspec.yaml`,
+`app/pubspec_mind.yaml`, `packages/feature_mind/lib/src/model_installer.dart`,
+`notification_navigation_service.dart`.
+
+**Deleted:** `packages/feature_assistant/`,
+`app/test/core/routing/mind_name_is_free_test.dart`, the `assets/models/`
+staging.
+
+**Reuse, do not reinvent:** `ModelDownloadService`, `ModelStorageManager`,
+`ModelDownloadProgress` (`packages/core_ai/lib/src/`); `MindScribeModule` and
+`AssistantModule` as the two halves of `MindModule`;
+`packages/stubs/feature_mind_stub` for web/TV; the `scripts/check-mind-*.sh`
+POSIX-grep idiom with a positive control (CI has no ripgrep).
+
+## Verification
+
+```bash
+cd packages/feature_mind && flutter test
+cd app && flutter test test/assistant_route_parity_test.dart
+cp app/pubspec_mind.yaml app/pubspec.yaml && cd app && flutter pub get
+flutter test test_mind/ --dart-define=APP_VARIANT=mind
+cd app && flutter build web --release
+scripts/check-mind-private-devices.sh
+AIRO_MIND_BUILD_MODE=release scripts/build-mind.sh
+```
+
+**End to end on the Pixel 9, both shells.** First-run model download, record →
+transcribe → minutes → search, and `/mind` → chat → model library → prompt lab →
+wellbeing. The super app is the case that has never existed; the standalone is
+the regression check.
+
+## Risks
+
+- **Removing the assistant from web and TV is a product regression**, accepted
+  under R05. Announce it, do not merely merge it.
+- **Debug builds are the blocker** (Phase 0). Merging first leaves the super app
+  unbuildable in debug.
+- **`feature_mind` becomes large** — ~113 files, ~22.5k lines, holding a frozen
+  runtime port and a large AI hub. Deliberate acceptance, not a later discovery.
+- **First run changes character**: models move from the APK to a download, so
+  offline first-run stops working until they land.

--- a/docs/superpowers/plans/2026-08-07-airo-mind-ssot-todo.md
+++ b/docs/superpowers/plans/2026-08-07-airo-mind-ssot-todo.md
@@ -1,0 +1,156 @@
+# Airo Mind SSOT — task list
+
+Plan: `tasks/plan.md`. One PR per phase, off `origin/main`.
+Checkpoints are stop-and-verify, not formalities.
+
+## Phase 0 — unblock debug builds ✅ DONE
+
+- [x] **0.1** Reproduced the i686 failure in isolation — bindgen has no sysroot,
+      falls back to bundled 64-bit bindings, `12_usize - 16_usize` overflow.
+- [x] **0.2** Sysroot fix (`BINDGEN_EXTRA_CLANG_ARGS`) eliminated the const-eval
+      crash — but exposed `clang: error: unsupported option '-arch' for target
+      'i686-linux-android24'`, a macOS-host-specific CMake failure, separate
+      from the original bug.
+- [x] **0.3** x86 Android is emulator-only, no device in this rig uses it — took
+      this path instead of chasing the CMake `-arch` issue. Declared `arm64`
+      only, per library, in `packages/feature_mind/android/build.gradle`.
+      Cargokit's Gradle plugin gained an optional per-library platform list
+      (`library(manifestDir, libname, platforms)`) to express it — intersected
+      against the build's platform set, not substituted, so a library cannot
+      conjure an ABI the build isn't producing.
+- [x] **0.4** `AIRO_MIND_BUILD_MODE=debug scripts/build-mind.sh` → 707 MB debug
+      APK, zero i686 references, zero `Cargokit BuildTool failed`.
+- [x] **0.5** Installed on the Pixel 9 (`io.airo.app.mind`), launched, PID stayed
+      alive. First debug build that has ever run.
+- [x] **0.6** PR + merge — PR #1551, branch `fix/mind-debug-abi`, cut fresh off
+      `origin/main` after `#1549`/`#1550` auto-merged mid-session.
+
+## Phase 1 — model acquisition + engine bridges, both behind abstractions
+
+Design: `docs/superpowers/specs/2026-08-07-airo-mind-abstraction-layer.md`.
+Direction confirmed: **neither app ships model weights** — both move onto
+`core_ai`'s download pipeline, behind a `ModelProvider` interface so the source
+can change later without touching `MindService`. Engine calls get the same
+treatment (`MindSpeechBridge`/`MindGenerationBridge`), landed in this phase
+because it's the same "replace a concrete dependency" motion and unblocks
+T3–T8 in the journey-coverage spec.
+
+### 1A — abstractions ✅ DONE
+
+- [x] **1A.1** Read `ModelDownloadService`, `ModelStorageManager`,
+      `OfflineModelInfo`. `OfflineModelInfo.sha256` carries the digest straight
+      through to `DownloadArtifactRequest.expectedSha256` — no second source.
+- [x] **1A.2** `ModelProvider` + `RequiredModel` + `InstalledModel` +
+      `ModelAcquisitionEvent` in `lib/src/models/model_provider.dart`. Own
+      lightweight types, not the FRB-generated `BigInt` wire types — a
+      provider must not know the bridge exists.
+- [x] **1A.3** `ModelInstaller implements ModelProvider` — bundled-asset
+      behaviour unchanged, now one implementation among several. No prior test
+      file existed for it; nothing broke.
+- [x] **1A.4** `DownloadModelProvider` (`lib/src/models/download_model_provider.dart`)
+      wraps `ModelDownloadService` + `ModelStorageManager`. `requiredModelsLookup`
+      and `downloadUrlFor` are both **injected functions**, not hardcoded — the
+      provider must not import the generated bridge, and `airo_mind_core::models`
+      pins no URL (`ADR-0018 §1`: hosting is a Dart-side decision).
+- [x] **1A.5** Test doubles in `test/models/download_model_provider_test.dart`
+      (`FakeBackgroundDownloads`, `MockModelStorageManager`) — no real network,
+      no platform channel.
+- [x] **1A.6** `MindSpeechBridge` / `MindGenerationBridge`
+      (`lib/src/bridges/`). `loadLibrary()` split from `initialize()` on the
+      speech bridge so `MindUnavailable.bridgeMissing` still fails fast, before
+      model acquisition — preserves the original ordering exactly.
+      `RustMindGenerationBridge.ensureLoaded` owns the lazy-load guard
+      previously inline in `MindService.process`.
+- [x] **1A.7** `MindService` constructor takes `modelProvider` + both bridges;
+      all default to the exact prior production path
+      (`ModelInstaller`/`RustMindSpeechBridge`/`RustMindGenerationBridge`).
+- [x] **1A.8** T3–T8 in `test/mind_service_test.dart`, all passing. T4 and T5
+      verified **non-vacuous** by mutation: breaking each enforcement (removing
+      the dual-cancel, forcing an eager load on cancel) makes its test fail;
+      restoring makes the full suite green again (101/101).
+
+Full-package regression: `flutter analyze` and `flutter test` both clean
+(101/101) after every change. Mind flavour's own suite
+(`flutter test test_mind/ --dart-define=APP_VARIANT=mind`) also green, 9/9,
+confirming the abstraction layer doesn't break the shell that already exists.
+
+### 1B — cut both apps over
+
+- [ ] **1B.1** Record baseline: current APK size (super app + standalone),
+      first-run behaviour
+- [ ] **1B.2** Wire `DownloadModelProvider` as the default in both shells
+      (`main.dart`, `main_mind.dart`) — the choice of provider is a shell
+      decision, not a `feature_mind` default
+- [ ] **1B.3** Surface download progress in the Mind UI — first run is now a
+      wait that needs a state, not a blank screen
+- [ ] **1B.4** Drop `assets/models/` from `pubspec_mind.yaml` (and from the
+      super app's pubspec once Phase 4 adds `feature_mind` there); keep
+      `fetch_mind_models.sh` as a dev seeding convenience, say so in its header
+- [ ] **1B.5** Confirm `ADR-0018 §1` still holds — no HTTP client in the Rust
+      binary (`build_runtime_pod.sh` already checks; run it)
+- [ ] **1B.6** Device: fresh install, first-run download, full journey on the
+      Pixel 9
+- [ ] **1B.7** PR + merge
+
+**Checkpoint 1** — APK size before/after (both apps), first-run on a real
+connection. Offline first-run stops working here; confirm that is accepted.
+
+## Phase 2 — merge feature_assistant into feature_mind
+
+- [ ] **2.1** Council: agree the merged package's owner (AI/Brain Agent vs
+      Product Manager). Blocks the rest of the phase.
+- [ ] **2.2** `git mv` the four trees (`assistant`, `agent_chat`, `wellbeing`,
+      `quotes`) into `packages/feature_mind/lib/src/`; same for `test/`
+- [ ] **2.3** Merge `AssistantModule` + `MindScribeModule` into one `MindModule`
+      exporting the combined route table
+- [ ] **2.4** Widen `packages/feature_mind/module.yaml` `allowed_dependencies`
+      to `core_ai`, `core_ui`, `core_product_shell`, `core_domain`, `core_data`;
+      keep `forbidden_dependencies: [app]`
+- [ ] **2.5** Update both shells to register `MindModule`
+- [ ] **2.6** Delete `packages/feature_assistant/`
+- [ ] **2.7** `cd packages/feature_mind && flutter test`;
+      `assistant_route_parity_test.dart` passes unchanged
+- [ ] **2.8** Module-manifest gate passes
+- [ ] **2.9** PR + merge
+
+**Checkpoint 2** — council sign-off on the owner, and explicit written
+confirmation that the assistant leaving web/TV is understood as removing shipped
+functionality from two surfaces.
+
+## Phase 3 — claim /mind
+
+- [ ] **3.1** Move `/assistant/*` paths to `/mind/*`, keeping every route
+      **name** unchanged (names are what notifications and deep links resolve)
+- [ ] **3.2** Redirect old `/assistant/*` paths
+- [ ] **3.3** Invert the legacy mapping in
+      `notification_navigation_service.dart:91` (`/mind` → `/assistant` becomes
+      the reverse)
+- [ ] **3.4** Retire `app/test/core/routing/mind_name_is_free_test.dart` — the
+      reservation has been claimed by its intended owner
+- [ ] **3.5** Tests: route parity, redirect coverage, and a notification payload
+      carrying an old path
+- [ ] **3.6** PR + merge
+
+## Phase 4 — the super app carries Mind
+
+- [ ] **4.1** Record the baseline: phone APK size and cold-build time
+- [ ] **4.2** Add `feature_mind` to `app/pubspec.yaml`
+- [ ] **4.3** Register `MindModule` in `main.dart` beside `CoinVaultModule` and
+      `IptvFeatureModule`
+- [ ] **4.4** Confirm web and TV still swap in `feature_mind_stub`
+- [ ] **4.5** `cd app && flutter build web --release` succeeds
+- [ ] **4.6** `scripts/check-mind-private-devices.sh` passes (R05)
+- [ ] **4.7** Device walk on **both** shells: first-run download, record →
+      transcribe → minutes → search, `/mind` → chat → models → prompt lab →
+      wellbeing
+- [ ] **4.8** PR + merge
+
+**Checkpoint 3** — phone APK size and cold-build time before/after. Two native
+engines now cross-compile on every super-app build.
+
+## Carried over, not part of this plan
+
+- [ ] Journey coverage spec
+      (`docs/superpowers/specs/2026-08-06-airo-mind-journey-coverage.md`) — T3/T4/T5
+      restore the tests deleted in #1549. Still an open regression.
+- [ ] iOS (#1546 phase 4) — has never built; needs dynamic frameworks.

--- a/docs/superpowers/specs/2026-08-06-airo-mind-journey-coverage.md
+++ b/docs/superpowers/specs/2026-08-06-airo-mind-journey-coverage.md
@@ -1,0 +1,199 @@
+# Airo Mind — restore the journey coverage the split removed
+
+**Date:** 2026-08-06
+**Status:** Draft, pre-implementation
+**Follows:** #1549 (the split), #1550 (Android device fixes)
+**Closes a regression introduced by:** #1549
+
+## 1. Objective
+
+Put the record → transcribe → minutes → save → search journey back under
+automated test.
+
+`#1549` split the runtime into two cdylibs because whisper.cpp and llama.cpp
+vendor incompatible copies of ggml. Two Rust tests could not survive that:
+
+| Deleted | Why it cannot exist |
+|---|---|
+| `tests/user_journey.rs` | loaded both engines into one test binary — the same one-definition-rule conflict that forced the split |
+| `generation_offline.rs::audio_becomes_minutes_offline` | same, for the audio → minutes join |
+
+Their coverage was declared as "moves to Dart and the device walk." The device
+walk has since happened, by hand, once — on a Pixel 9, and it passed. Nothing
+automated covers it. **This spec is the part that was promised and not
+delivered.**
+
+**Target users:** the engineers who will change `MindService`, the bridges, or
+either engine crate next, and currently have nothing that would tell them they
+broke the pipeline.
+
+## 2. Scope
+
+Two layers, because one cannot do both jobs:
+
+- **Composition tests** (fast, CI, no models, no native libraries) — the
+  sequencing `MindService` now owns.
+- **One device journey test** (real engines, real models, manual/gated) — the
+  thing only a device can prove, made repeatable so it is not a person with a
+  phone each time.
+
+**Out of scope:** the Rust-side tests that still exist and still pass
+(`speech_offline.rs`, `generation_offline.rs` minus the deleted case, the 44
+`airo_mind_core` tests). Widening engine coverage. Any change to the runtime's
+architecture or the frozen `MindRuntime` port.
+
+## 3. The seam
+
+`MindService.process()` calls top-level generated functions
+(`rust.transcribeRecording`, `llama.generateMinutes`, `rust.saveMeeting`), so
+there is nothing to fake. That is the blocker, and it is why these tests do not
+exist yet rather than an oversight.
+
+The constructor already takes its collaborators:
+
+```dart
+MindService({AudioRecorder? recorder, ModelInstaller? installer})
+  : _recorder = recorder ?? AudioRecorder(),
+    _installer = installer ?? const ModelInstaller();
+```
+
+Two more follow the same shape, not a new pattern:
+
+```dart
+abstract class MindSpeechBridge {
+  Stream<TranscriptEvent> transcribe({required String wavPath});
+  Future<String> save({ /* title, recordedAtMs, transcript, minutes, model */ });
+  void cancel();
+}
+
+abstract class MindGenerationBridge {
+  Future<void> ensureLoaded();          // the lazy load, observable
+  bool get isLoaded;
+  Stream<GenerationEvent> generate({required String transcript});
+  String modelId();
+  void cancel();
+}
+```
+
+Default implementations delegate to the generated functions and hold the
+`initializeLlamaBridge()` guard currently in `library_loader.dart`. The
+production path is unchanged; the tests get somewhere to stand.
+
+**This is the one design decision in this spec that adds indirection.** It is
+worth it only because the alternative is no coverage of the composition at all,
+and the composition is exactly what the split moved into Dart.
+
+## 4. Commands
+
+```bash
+# Composition tests — fast, no models, no device
+cd packages/feature_mind && flutter test
+
+# The Mind flavour's own suite (the define is not optional)
+cp app/pubspec_mind.yaml app/pubspec.yaml
+cp app/analysis_options_mind.yaml app/analysis_options.yaml
+cd app && flutter pub get
+flutter test test_mind/ --dart-define=APP_VARIANT=mind
+
+# Device journey — real engines, real models, a real phone
+app/tool/fetch_mind_models.sh          # ~570 MB, digest-verified
+AIRO_MIND_BUILD_MODE=release scripts/build-mind.sh
+cd app && flutter test integration_test/mind_journey_device_test.dart \
+  --dart-define=APP_VARIANT=mind -d <device-id>
+```
+
+## 5. Project structure
+
+```
+packages/feature_mind/
+  lib/src/
+    bridges/
+      mind_speech_bridge.dart        # abstraction + default delegating impl
+      mind_generation_bridge.dart    # abstraction + default, owns the lazy load
+    mind_service.dart                # takes both; process() unchanged in behaviour
+  test/
+    mind_composition_test.dart       # T3, T4, T5 and the error paths
+    support/fake_bridges.dart        # scripted event sequences, call recorders
+
+app/integration_test/
+  mind_journey_device_test.dart      # the replacement for user_journey.rs
+```
+
+## 6. Testing strategy
+
+### Composition, with fakes
+
+| # | Property | Replaces |
+|---|---|---|
+| T3 | the emitted `MindStage` sequence is exactly transcribing → generating → saving → done | `user_journey.rs` sequencing |
+| T4 | `cancelProcessing()` cancels **both** bridges, at every point in the pipeline | nothing — this is new, and is the risk the split created |
+| T5 | a transcribe-only run never loads the generation bridge | the lazy-load claim, currently unproven |
+| T6 | `TranscriptEvent_Cancelled` mid-transcribe yields `idle` and never reaches generation | `user_journey.rs` cancel path |
+| T7 | `saveMeeting` is called with the transcript, the minutes, and the model id from the generation bridge | `ADR-0018 §5` — what produced a summary is recorded |
+| T8 | a bridge that throws surfaces as `MindStage.failed` with the message, not an unhandled exception | existing behaviour, currently untested |
+
+T4 deserves its emphasis: cancellation used to be one `CancelToken` inside one
+Rust library. It is now two, coordinated from Dart, and the handover is both the
+most likely moment to press Stop and the easiest place to leave an engine
+running.
+
+### Device journey, with real engines
+
+One test, mirroring what was walked by hand: record a fixture through the
+recorder seam → transcribe → minutes → save → list → search → open. Asserts a
+meeting exists, its transcript is non-empty, its minutes are non-empty, and
+search returns it.
+
+**It is gated, not part of the default suite.** It needs ~570 MB of models, a
+device, and roughly a minute of inference. `flutter test integration_test/`
+already exists in the Makefile; this joins it behind the same explicit
+invocation, and CI does not run it until there is a device lane that can.
+
+### Honest limit
+
+The composition tests use fakes, so they prove sequencing, not inference. The
+device test proves inference but runs rarely. Neither replaces `user_journey.rs`
+exactly — that test ran real engines on every `cargo test`. **That specific
+property is gone and does not come back**, because the two engines cannot share
+a process at link time. Saying so here is better than implying parity.
+
+## 7. Boundaries
+
+**Always**
+
+- Keep `MindService`'s public API unchanged. The seam is constructor-injected
+  with working defaults; no caller passes anything new.
+- Assert the `MindStage` sequence, not internals. It is the contract widgets
+  bind to and the reason the split is invisible to the UI.
+- Fakes script event sequences and record calls. No mocking framework beyond
+  what the package already uses.
+
+**Ask first**
+
+- Any change to `process()`'s behaviour rather than its testability. This spec
+  is about restoring coverage, and a behavioural change hidden inside a test PR
+  is how the two get confused.
+- Moving more responsibility into Dart. Budget (`C6`) and cancellation (`I7`)
+  are runtime properties; T4 exists to hold that line, not to license crossing
+  it.
+
+**Never**
+
+- Recombine the engines to make a test easier. `check-mind-no-ggml-collision.sh`
+  fails the build, and on Apple the link would otherwise succeed and quietly run
+  one engine against the other's ggml.
+- Claim the device test ran when it did not. It is gated; a green default suite
+  says nothing about it.
+- Ship a fake as a production default.
+
+## 8. Acceptance criteria
+
+1. T3–T8 pass in `packages/feature_mind`'s default suite, with no models and no
+   native libraries present.
+2. Each of T4 and T5 fails if its enforcement is removed — checked by removing
+   it, not by assertion.
+3. The device journey test passes on the Pixel 9 against real engines.
+4. `MindService`'s public API is unchanged, proven by the existing tests passing
+   untouched.
+5. The Rust suites still pass: `cargo test --workspace`, plus each engine crate
+   with its feature.

--- a/packages/feature_mind/lib/src/bridges/mind_generation_bridge.dart
+++ b/packages/feature_mind/lib/src/bridges/mind_generation_bridge.dart
@@ -1,0 +1,95 @@
+import 'package:flutter/foundation.dart';
+
+import '../library_loader.dart';
+import '../llama/api/minutes.dart' as llama;
+
+@immutable
+sealed class GenerationEvent {
+  const GenerationEvent();
+}
+
+final class GenerationEventGenerating extends GenerationEvent {
+  const GenerationEventGenerating(this.text);
+  final String text;
+}
+
+final class GenerationEventMinutesReady extends GenerationEvent {
+  const GenerationEventMinutesReady(this.text);
+  final String text;
+}
+
+final class GenerationEventCancelled extends GenerationEvent {
+  const GenerationEventCancelled();
+}
+
+/// The generation half of the pipeline. See `MindSpeechBridge` for why this is
+/// an interface rather than a direct call.
+///
+/// [ensureLoaded] makes the lazy load — 48 MB that only minutes need,
+/// currently an inline guard in `library_loader.dart` — an observable, testable
+/// step rather than something buried inside `generate`.
+abstract interface class MindGenerationBridge {
+  bool get isLoaded;
+
+  /// Idempotent: loads the generation library and model on first call only.
+  Future<void> ensureLoaded({
+    required String modelsDir,
+    required int memoryBudgetMb,
+  });
+
+  Stream<GenerationEvent> generate({required String transcript});
+
+  /// What produced the last minutes, for [MindSpeechBridge.save] to record
+  /// (`ADR-0018 §5`). Empty before anything has been generated.
+  String modelId();
+
+  void cancel();
+}
+
+/// Delegates to the generated llama bridge, owning the lazy-load guard that
+/// used to live inline in `MindService.process`.
+class RustMindGenerationBridge implements MindGenerationBridge {
+  RustMindGenerationBridge();
+
+  var _loaded = false;
+
+  @override
+  bool get isLoaded => _loaded;
+
+  @override
+  Future<void> ensureLoaded({
+    required String modelsDir,
+    required int memoryBudgetMb,
+  }) async {
+    await initializeLlamaBridge();
+    if (llama.isReady()) {
+      _loaded = true;
+      return;
+    }
+    await llama.initialize(
+      config: llama.GenerationConfig(
+        modelsDir: modelsDir,
+        memoryBudgetMb: memoryBudgetMb,
+      ),
+    );
+    _loaded = true;
+  }
+
+  @override
+  Stream<GenerationEvent> generate({required String transcript}) =>
+      llama.generateMinutes(transcript: transcript).map((event) {
+        return switch (event) {
+          llama.GenerationEvent_Generating(:final text) =>
+            GenerationEventGenerating(text),
+          llama.GenerationEvent_MinutesReady(:final text) =>
+            GenerationEventMinutesReady(text),
+          llama.GenerationEvent_Cancelled() => const GenerationEventCancelled(),
+        };
+      });
+
+  @override
+  String modelId() => llama.generationModelId();
+
+  @override
+  void cancel() => llama.cancelGeneration();
+}

--- a/packages/feature_mind/lib/src/bridges/mind_speech_bridge.dart
+++ b/packages/feature_mind/lib/src/bridges/mind_speech_bridge.dart
@@ -1,0 +1,146 @@
+import 'package:flutter/foundation.dart';
+
+import '../library_loader.dart';
+import '../whisper/api/meetings.dart' as rust;
+
+/// Transcription progress, mirroring `rust.TranscriptEvent` one for one.
+///
+/// A distinct type rather than re-exporting the generated one: this is the
+/// abstraction's own contract, and it must not change shape just because
+/// `flutter_rust_bridge_codegen` regenerated its output.
+@immutable
+sealed class TranscriptEvent {
+  const TranscriptEvent();
+}
+
+final class TranscriptEventTranscribing extends TranscriptEvent {
+  const TranscriptEventTranscribing(this.text);
+  final String text;
+}
+
+final class TranscriptEventTranscriptReady extends TranscriptEvent {
+  const TranscriptEventTranscriptReady(this.text);
+  final String text;
+}
+
+final class TranscriptEventCancelled extends TranscriptEvent {
+  const TranscriptEventCancelled();
+}
+
+/// The speech half of the pipeline, and the meeting library. Behind this
+/// abstraction rather than called directly is what makes `MindService`'s
+/// sequencing testable at all — see
+/// `docs/superpowers/specs/2026-08-06-airo-mind-journey-coverage.md` §3, T3–T8.
+///
+/// Not a claim that a second speech engine is coming. Whisper stays pinned;
+/// this interface exists so a test can stand somewhere, not as a plugin
+/// system.
+abstract interface class MindSpeechBridge {
+  /// Loads the native library. Separate from [initialize] so
+  /// `MindService.initialize` can fail fast on a platform with no bridge
+  /// (`MindUnavailable.bridgeMissing`) before spending time acquiring model
+  /// weights that a working bridge would still need — the same order the
+  /// original inline implementation used.
+  Future<void> loadLibrary();
+
+  /// True once the speech model has loaded and the store is open.
+  bool isReady();
+
+  /// Loads the speech model and opens the store. Requires [loadLibrary] to
+  /// have already succeeded.
+  Future<void> initialize({
+    required String modelsDir,
+    required String storePath,
+    required int memoryBudgetMb,
+  });
+
+  Stream<TranscriptEvent> transcribe({required String wavPath});
+
+  /// Makes a meeting durable and searchable. Returns its id.
+  ///
+  /// `model` is the logical identity of whatever produced `minutes`
+  /// (`ADR-0018 §5`) — it comes from [MindGenerationBridge.modelId], not from
+  /// this bridge, because only the generation library knows it.
+  Future<String> save({
+    required String title,
+    required int recordedAtMs,
+    required String transcript,
+    required String minutes,
+    required String model,
+  });
+
+  void cancel();
+
+  // The meeting library. Reads, not part of the transcribe/generate/save
+  // pipeline, but owned by the same library that owns the store — kept on
+  // this bridge rather than left as a fourth, ungoverned direct call.
+  Future<List<rust.MeetingRecord>> meetings();
+  Future<List<rust.SearchHit>> search(String query);
+  Future<rust.MeetingRecord?> meeting(String id);
+}
+
+/// Delegates to the generated whisper bridge. The production default —
+/// nothing about `MindService`'s runtime behaviour changes by this type
+/// existing.
+class RustMindSpeechBridge implements MindSpeechBridge {
+  const RustMindSpeechBridge();
+
+  @override
+  Future<void> loadLibrary() => initializeWhisperBridge();
+
+  @override
+  bool isReady() => rust.isReady();
+
+  @override
+  Future<void> initialize({
+    required String modelsDir,
+    required String storePath,
+    required int memoryBudgetMb,
+  }) => rust.initialize(
+    config: rust.MindConfig(
+      modelsDir: modelsDir,
+      storePath: storePath,
+      memoryBudgetMb: memoryBudgetMb,
+    ),
+  );
+
+  @override
+  Stream<TranscriptEvent> transcribe({required String wavPath}) =>
+      rust.transcribeRecording(wavPath: wavPath).map((event) {
+        return switch (event) {
+          rust.TranscriptEvent_Transcribing(:final text) =>
+            TranscriptEventTranscribing(text),
+          rust.TranscriptEvent_TranscriptReady(:final text) =>
+            TranscriptEventTranscriptReady(text),
+          rust.TranscriptEvent_Cancelled() => const TranscriptEventCancelled(),
+        };
+      });
+
+  @override
+  Future<String> save({
+    required String title,
+    required int recordedAtMs,
+    required String transcript,
+    required String minutes,
+    required String model,
+  }) => rust.saveMeeting(
+    title: title,
+    recordedAtMs: BigInt.from(recordedAtMs),
+    transcript: transcript,
+    minutes: minutes,
+    model: model,
+  );
+
+  @override
+  void cancel() => rust.cancelProcessing();
+
+  @override
+  Future<List<rust.MeetingRecord>> meetings() => rust.listMeetings();
+
+  @override
+  Future<List<rust.SearchHit>> search(String query) =>
+      rust.searchMeetings(query: query);
+
+  @override
+  Future<rust.MeetingRecord?> meeting(String id) => rust.getMeeting(id: id);
+}

--- a/packages/feature_mind/lib/src/mind_service.dart
+++ b/packages/feature_mind/lib/src/mind_service.dart
@@ -6,9 +6,10 @@ import 'package:path/path.dart' as p;
 import 'package:path_provider/path_provider.dart';
 import 'package:record/record.dart';
 
-import 'library_loader.dart';
-import 'llama/api/minutes.dart' as llama;
+import 'bridges/mind_generation_bridge.dart';
+import 'bridges/mind_speech_bridge.dart';
 import 'model_installer.dart';
+import 'models/model_provider.dart';
 import 'whisper/api/meetings.dart' as rust;
 
 /// Why Airo Mind cannot start. Each case is one the user can act on, which is
@@ -90,12 +91,27 @@ class MindProgress {
 /// runnable without a Rust library present, and it means the day the bridge
 /// changes shape, one file changes.
 class MindService {
-  MindService({AudioRecorder? recorder, ModelInstaller? installer})
-    : _recorder = recorder ?? AudioRecorder(),
-      _installer = installer ?? const ModelInstaller();
+  /// Every collaborator is injectable, defaulting to the production path.
+  ///
+  /// [modelProvider] defaults to the bundled-asset [ModelInstaller] — the
+  /// behaviour this class always had. Which app ships which provider
+  /// (download vs. bundled) is a decision for the shell composing this
+  /// service, not a default `feature_mind` bakes in
+  /// (`docs/superpowers/specs/2026-08-07-airo-mind-abstraction-layer.md`).
+  MindService({
+    AudioRecorder? recorder,
+    ModelProvider? modelProvider,
+    MindSpeechBridge? speechBridge,
+    MindGenerationBridge? generationBridge,
+  }) : _recorder = recorder ?? AudioRecorder(),
+       _models = modelProvider ?? const ModelInstaller(),
+       _speech = speechBridge ?? const RustMindSpeechBridge(),
+       _generation = generationBridge ?? RustMindGenerationBridge();
 
   final AudioRecorder _recorder;
-  final ModelInstaller _installer;
+  final ModelProvider _models;
+  final MindSpeechBridge _speech;
+  final MindGenerationBridge _generation;
   String? _recordingPath;
 
   /// Loads the native library and the models.
@@ -107,20 +123,31 @@ class MindService {
     try {
       // Only the speech library. Generation is loaded on first use — see
       // `process`.
-      await initializeWhisperBridge();
+      await _speech.loadLibrary();
     } on Object catch (e) {
       return MindStatus.unavailable(MindUnavailable.bridgeMissing, '$e');
     }
 
     final dir = await modelsDirectory();
 
-    // `ADR-0018 §2`, Bundled: copy out of the app's own asset bundle. Not from
-    // the checkout -- that made a developer machine work and a device fail.
-    if (!await _installer.isInstalled(dir)) {
-      final failed = await _installer.install(
-        dir,
-        onProgress: onInstallProgress,
-      );
+    // `ModelProvider` — bundled asset by default, download in production
+    // (`docs/superpowers/specs/2026-08-07-airo-mind-abstraction-layer.md`).
+    // Not from the checkout: that made a developer machine work and a device
+    // fail.
+    if (!await _models.isInstalled(dir)) {
+      final failed = <String>[];
+      await for (final event in _models.acquire(dir)) {
+        switch (event) {
+          case ModelAcquisitionProgress(
+            :final fileName,
+            :final fetched,
+            :final total,
+          ):
+            onInstallProgress?.call(fileName, fetched, total);
+          case ModelAcquisitionDone(:final failedFileNames):
+            failed.addAll(failedFileNames);
+        }
+      }
       if (failed.isNotEmpty) {
         return MindStatus.unavailable(
           MindUnavailable.modelsMissing,
@@ -132,14 +159,12 @@ class MindService {
     try {
       // `ADR-0018 §1`: hand over a DIRECTORY and a budget. Which model serves
       // which task is the Model Manager's decision, not this layer's.
-      await rust.initialize(
-        config: rust.MindConfig(
-          modelsDir: dir.path,
-          storePath: p.join(dir.path, 'meetings.log'),
-          // Admission ceiling, not an allocation. The Supervisor refuses a
-          // model it cannot afford before anything is loaded.
-          memoryBudgetMb: 4096,
-        ),
+      await _speech.initialize(
+        modelsDir: dir.path,
+        storePath: p.join(dir.path, 'meetings.log'),
+        // Admission ceiling, not an allocation. The Supervisor refuses a
+        // model it cannot afford before anything is loaded.
+        memoryBudgetMb: 4096,
       );
       return const MindStatus.ready();
     } on Object catch (e) {
@@ -162,8 +187,8 @@ class MindService {
   void Function(String fileName, int copied, int total)? onInstallProgress;
 
   /// Hashes every installed model against the digest pinned in Rust source.
-  Future<List<dynamic>> verifyModels() async =>
-      _installer.verify(await modelsDirectory());
+  Future<List<InstalledModel>> verifyModels() async =>
+      _models.verify(await modelsDirectory());
 
   Future<bool> hasMicrophonePermission() => _recorder.hasPermission();
 
@@ -229,21 +254,21 @@ class MindService {
 
     try {
       // ── 1. Audio → transcript, in the speech library ───────────────────────
-      await for (final event in rust.transcribeRecording(wavPath: wavPath)) {
+      await for (final event in _speech.transcribe(wavPath: wavPath)) {
         switch (event) {
-          case rust.TranscriptEvent_Transcribing(:final text):
+          case TranscriptEventTranscribing(:final text):
             progress = progress.copyWith(
               stage: MindStage.transcribing,
               transcript: _append(progress.transcript, text),
             );
           // The joined transcript from Rust replaces what was accumulated, so a
           // dropped segment cannot leave the two out of step.
-          case rust.TranscriptEvent_TranscriptReady(:final text):
+          case TranscriptEventTranscriptReady(:final text):
             progress = progress.copyWith(
               stage: MindStage.generating,
               transcript: text,
             );
-          case rust.TranscriptEvent_Cancelled():
+          case TranscriptEventCancelled():
             yield progress.copyWith(stage: MindStage.idle);
             return;
         }
@@ -255,32 +280,24 @@ class MindService {
       // Loaded now rather than at startup: it is roughly 48 MB and only this
       // step needs it. The stage is already `generating`, so the wait is
       // visible rather than a silent pause.
-      await initializeLlamaBridge();
-      if (!llama.isReady()) {
-        final dir = await modelsDirectory();
-        await llama.initialize(
-          config: llama.GenerationConfig(
-            modelsDir: dir.path,
-            memoryBudgetMb: 4096,
-          ),
-        );
-      }
+      final dir = await modelsDirectory();
+      await _generation.ensureLoaded(modelsDir: dir.path, memoryBudgetMb: 4096);
 
-      await for (final event in llama.generateMinutes(
+      await for (final event in _generation.generate(
         transcript: progress.transcript,
       )) {
         switch (event) {
-          case llama.GenerationEvent_Generating(:final text):
+          case GenerationEventGenerating(:final text):
             progress = progress.copyWith(
               stage: MindStage.generating,
               minutes: progress.minutes + text,
             );
-          case llama.GenerationEvent_MinutesReady(:final text):
+          case GenerationEventMinutesReady(:final text):
             progress = progress.copyWith(
               stage: MindStage.saving,
               minutes: text,
             );
-          case llama.GenerationEvent_Cancelled():
+          case GenerationEventCancelled():
             yield progress.copyWith(stage: MindStage.idle);
             return;
         }
@@ -292,12 +309,12 @@ class MindService {
       // `model` comes from the generation library: only it knows which model
       // produced these minutes, and `ADR-0018 §5` records that with the content
       // rather than inferring it later.
-      final meetingId = await rust.saveMeeting(
+      final meetingId = await _speech.save(
         title: title,
-        recordedAtMs: BigInt.from(recordedAtMs),
+        recordedAtMs: recordedAtMs,
         transcript: progress.transcript,
         minutes: progress.minutes,
-        model: llama.generationModelId(),
+        model: _generation.modelId(),
       );
       yield progress.copyWith(stage: MindStage.done, meetingId: meetingId);
     } on Object catch (e) {
@@ -320,16 +337,15 @@ class MindService {
   /// was wrong — which is exactly at the handover, the moment most likely to be
   /// slow enough for someone to press Stop.
   void cancelProcessing() {
-    rust.cancelProcessing();
-    if (isLlamaLoaded) llama.cancelGeneration();
+    _speech.cancel();
+    if (_generation.isLoaded) _generation.cancel();
   }
 
-  Future<List<rust.MeetingRecord>> meetings() => rust.listMeetings();
+  Future<List<rust.MeetingRecord>> meetings() => _speech.meetings();
 
-  Future<List<rust.SearchHit>> search(String query) =>
-      rust.searchMeetings(query: query);
+  Future<List<rust.SearchHit>> search(String query) => _speech.search(query);
 
-  Future<rust.MeetingRecord?> meeting(String id) => rust.getMeeting(id: id);
+  Future<rust.MeetingRecord?> meeting(String id) => _speech.meeting(id);
 
   Future<void> dispose() => _recorder.dispose();
 }

--- a/packages/feature_mind/lib/src/model_installer.dart
+++ b/packages/feature_mind/lib/src/model_installer.dart
@@ -1,43 +1,80 @@
+import 'dart:async';
 import 'dart:io';
 
 import 'package:flutter/services.dart' show rootBundle;
 import 'package:path/path.dart' as p;
 
+import 'models/model_provider.dart';
 import 'whisper/api/setup.dart' as rust;
 
 /// Puts the bundled models on disk. `ADR-0018 §2`, the **Bundled** strategy.
 ///
-/// Bundled is the only strategy Milestone 2 ships, and §7 says why the sequence
-/// matters: *"bundling is the only strategy that proves the offline claim."*
-/// Import and download are declared in the Rust registry's
-/// `AcquisitionStrategy` so their verification difference is written down, and
-/// neither is implemented.
+/// One [ModelProvider] implementation among several
+/// (`docs/superpowers/specs/2026-08-07-airo-mind-abstraction-layer.md`), not
+/// the only path any more: both apps default to `DownloadModelProvider`
+/// instead, so neither ships model weights in the APK. This stays for a build
+/// that intentionally bundles, and for tests that need no network.
 ///
-/// # This replaces the development fallback
+/// # This replaced the development fallback
 ///
-/// Until now `MindService` reached into the checkout's `rust/.../models/`
-/// directory when nothing was installed. That made a developer machine work and
-/// a device fail, which is the worst arrangement: the failure only appears
-/// where it cannot be debugged. Models now come from the app's own asset
-/// bundle, on every platform, or they are absent and the UI says so.
-class ModelInstaller {
+/// Before this existed, `MindService` reached into the checkout's
+/// `rust/.../models/` directory when nothing was installed. That made a
+/// developer machine work and a device fail, which is the worst arrangement:
+/// the failure only appears where it cannot be debugged.
+class ModelInstaller implements ModelProvider {
   const ModelInstaller();
 
   /// Assets are addressed through the package, so the app that hosts Airo Mind
   /// does not have to re-declare them.
   static const String assetPrefix = 'packages/feature_mind/assets/models/';
 
+  @override
+  Future<List<RequiredModel>> requiredModels() async => [
+    for (final required in await rust.requiredModels())
+      RequiredModel(
+        fileName: required.fileName,
+        sizeBytes: required.sizeBytes.toInt(),
+        sha256: required.sha256,
+      ),
+  ];
+
   /// True when every required model is on disk at its pinned size.
   ///
   /// Size, not digest: hashing half a gigabyte on every launch costs about a
   /// second. Full verification is [verify], run after an install.
+  @override
   Future<bool> isInstalled(Directory modelsDir) async {
-    for (final required in await rust.requiredModels()) {
+    for (final required in await requiredModels()) {
       final file = File(p.join(modelsDir.path, required.fileName));
       if (!file.existsSync()) return false;
-      if (file.lengthSync() != required.sizeBytes.toInt()) return false;
+      if (file.lengthSync() != required.sizeBytes) return false;
     }
     return true;
+  }
+
+  /// [ModelProvider.acquire]. Runs [install] and translates its
+  /// copy-by-copy progress and its failed-file-name result into
+  /// [ModelAcquisitionEvent]s — the copy logic itself is unchanged, only how
+  /// its progress is reported.
+  @override
+  Stream<ModelAcquisitionEvent> acquire(Directory modelsDir) async* {
+    final events = StreamController<ModelAcquisitionEvent>();
+    final failedFuture = install(
+      modelsDir,
+      onProgress: (fileName, copied, total) {
+        events.add(ModelAcquisitionProgress(fileName, copied, total));
+      },
+    );
+    // The controller closes only after `install` has finished adding to it,
+    // so nothing is dropped between the last progress event and the done
+    // event that follows.
+    unawaited(
+      failedFuture.then((failed) {
+        events.add(ModelAcquisitionDone(failed));
+        events.close();
+      }),
+    );
+    yield* events.stream;
   }
 
   /// Copies any missing model out of the asset bundle.
@@ -139,6 +176,16 @@ class ModelInstaller {
   ///
   /// Off the launch path deliberately — see `models::resolve`, which documents
   /// the trade.
-  Future<List<rust.InstalledModel>> verify(Directory modelsDir) =>
-      rust.verifyInstalledModels(modelsDir: modelsDir.path);
+  @override
+  Future<List<InstalledModel>> verify(Directory modelsDir) async => [
+    for (final status in await rust.verifyInstalledModels(
+      modelsDir: modelsDir.path,
+    ))
+      InstalledModel(
+        fileName: status.fileName,
+        present: status.present,
+        verified: status.verified,
+        detail: status.detail,
+      ),
+  ];
 }

--- a/packages/feature_mind/lib/src/models/download_model_provider.dart
+++ b/packages/feature_mind/lib/src/models/download_model_provider.dart
@@ -1,0 +1,153 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:core_ai/core_ai.dart' as core_ai;
+import 'package:path/path.dart' as p;
+
+import 'model_provider.dart';
+
+/// [ModelProvider] backed by `core_ai`'s existing download pipeline — the same
+/// `ModelDownloadService`/`ModelStorageManager` Airo already uses for its own
+/// model catalog.
+///
+/// # Why the required-models lookup and the URL are both injected
+///
+/// `airo_mind_core::models` is the one pinned registry (file name, size,
+/// sha256) and this provider must read it, not restate it — but that registry
+/// crosses the bridge as `whisper.api.setup.requiredModels()`, and this class
+/// must not import the generated bridge module directly. A provider that knows
+/// the bridge exists is exactly the coupling the abstraction removes. The
+/// caller (`MindService`, or a shell's composition root) supplies the lookup.
+///
+/// Similarly, `airo_mind_core::models` pins no download URL — the registry
+/// only proves which bytes are correct, not where to find them, so hosting is
+/// a Dart-side decision by design (`ADR-0018 §1`: the runtime never acquires
+/// models). `downloadUrlFor` is where that decision is made, and it is a
+/// constructor parameter rather than a hardcoded host so it can change without
+/// touching this class.
+class DownloadModelProvider implements ModelProvider {
+  DownloadModelProvider({
+    required this._downloadService,
+    required this._requiredModelsLookup,
+    required this._downloadUrlFor,
+  });
+
+  final core_ai.ModelDownloadService _downloadService;
+  final Future<List<RequiredModel>> Function() _requiredModelsLookup;
+  final String? Function(RequiredModel) _downloadUrlFor;
+
+  @override
+  Future<List<RequiredModel>> requiredModels() => _requiredModelsLookup();
+
+  @override
+  Future<bool> isInstalled(Directory modelsDir) async {
+    for (final required in await requiredModels()) {
+      final file = File(p.join(modelsDir.path, required.fileName));
+      if (!file.existsSync()) return false;
+      if (file.lengthSync() != required.sizeBytes) return false;
+    }
+    return true;
+  }
+
+  /// `core_ai.OfflineModelInfo.id` is the download service's identity for a
+  /// model. The file name already is one, pinned in the same registry that
+  /// pins the digest, so nothing new is invented here.
+  core_ai.OfflineModelInfo _asOfflineModelInfo(
+    RequiredModel required,
+    Directory modelsDir,
+  ) {
+    return core_ai.OfflineModelInfo(
+      id: required.fileName,
+      name: required.fileName,
+      // `family` is a catalog concern the download service does not act on
+      // for a direct-URL fetch; `other` says so rather than guessing one.
+      family: core_ai.ModelFamily.other,
+      fileSizeBytes: required.sizeBytes,
+      filePath: p.join(modelsDir.path, required.fileName),
+      downloadUrl: _downloadUrlFor(required),
+      sha256: required.sha256,
+    );
+  }
+
+  @override
+  Stream<ModelAcquisitionEvent> acquire(Directory modelsDir) async* {
+    final required = await requiredModels();
+    final failed = <String>[];
+
+    // Sequential, not concurrent: the two Mind models together are ~570 MB,
+    // and running both downloads at once on a constrained connection is a
+    // worse experience than a predictable queue, not a faster one.
+    for (final model in required) {
+      final info = _asOfflineModelInfo(model, modelsDir);
+
+      if (info.downloadUrl == null) {
+        failed.add(model.fileName);
+        continue;
+      }
+
+      var succeeded = false;
+      var settled = false;
+      // The service's progress stream is a persistent broadcast stream keyed
+      // on model id -- it never closes on its own, so this loop breaks itself
+      // on the first terminal status rather than waiting on stream closure.
+      // `await for`'s implicit subscription is cancelled by `break`.
+      await for (final progress in _downloadService.downloadModel(info)) {
+        yield ModelAcquisitionProgress(
+          model.fileName,
+          progress.downloadedBytes,
+          progress.totalBytes,
+        );
+        switch (progress.status) {
+          case core_ai.ModelDownloadStatus.completed:
+            succeeded = true;
+            settled = true;
+          case core_ai.ModelDownloadStatus.failed:
+          case core_ai.ModelDownloadStatus.cancelled:
+            succeeded = false;
+            settled = true;
+          case core_ai.ModelDownloadStatus.pending:
+          case core_ai.ModelDownloadStatus.downloading:
+          case core_ai.ModelDownloadStatus.paused:
+          case core_ai.ModelDownloadStatus.verifying:
+            break;
+        }
+        if (settled) break;
+      }
+
+      if (!succeeded) failed.add(model.fileName);
+    }
+
+    yield ModelAcquisitionDone(failed);
+  }
+
+  @override
+  Future<List<InstalledModel>> verify(Directory modelsDir) async {
+    final required = await requiredModels();
+    final results = <InstalledModel>[];
+    for (final model in required) {
+      final file = File(p.join(modelsDir.path, model.fileName));
+      if (!file.existsSync()) {
+        results.add(
+          InstalledModel(
+            fileName: model.fileName,
+            present: false,
+            verified: false,
+            detail: 'not installed',
+          ),
+        );
+        continue;
+      }
+      final info = _asOfflineModelInfo(model, modelsDir);
+      final ok = await core_ai.ModelStorageManager().verifyModelIntegrity(info);
+      results.add(
+        InstalledModel(
+          fileName: model.fileName,
+          present: true,
+          verified: ok,
+          detail: ok ? 'verified' : 'digest mismatch',
+        ),
+      );
+    }
+    return results;
+  }
+}

--- a/packages/feature_mind/lib/src/models/model_provider.dart
+++ b/packages/feature_mind/lib/src/models/model_provider.dart
@@ -1,0 +1,92 @@
+import 'dart:io';
+
+import 'package:flutter/foundation.dart';
+
+/// A model that must be on disk, and what proves it is the right one.
+///
+/// Deliberately not the generated `whisper.api.setup.RequiredModel` (a
+/// `BigInt` wire type from the bridge): a `ModelProvider` must not know the
+/// bridge exists. `ModelInstaller` and `DownloadModelProvider` both translate
+/// the pinned Rust registry into this shape.
+@immutable
+class RequiredModel {
+  const RequiredModel({
+    required this.fileName,
+    required this.sizeBytes,
+    required this.sha256,
+  });
+
+  final String fileName;
+  final int sizeBytes;
+
+  /// Pinned in `airo_mind_core::models` (`ADR-0018 §2`). Every provider
+  /// verifies against this same value; none of them invent their own.
+  final String sha256;
+}
+
+/// What a model looks like right now, after [ModelProvider.verify].
+@immutable
+class InstalledModel {
+  const InstalledModel({
+    required this.fileName,
+    required this.present,
+    required this.verified,
+    required this.detail,
+  });
+
+  final String fileName;
+  final bool present;
+
+  /// Only meaningful when [present]. False means the bytes on disk are not
+  /// the bytes that were pinned.
+  final bool verified;
+  final String detail;
+}
+
+/// Progress through [ModelProvider.acquire], file by file.
+sealed class ModelAcquisitionEvent {
+  const ModelAcquisitionEvent();
+}
+
+/// One file, some fraction of its bytes obtained.
+final class ModelAcquisitionProgress extends ModelAcquisitionEvent {
+  const ModelAcquisitionProgress(this.fileName, this.fetched, this.total);
+
+  final String fileName;
+  final int fetched;
+  final int total;
+}
+
+/// Acquisition finished. [failedFileNames] is empty on full success — a real
+/// state (no network, no bundled asset, a corrupt file) that the UI must be
+/// able to explain rather than crash on.
+final class ModelAcquisitionDone extends ModelAcquisitionEvent {
+  const ModelAcquisitionDone(this.failedFileNames);
+
+  final List<String> failedFileNames;
+}
+
+/// Where model bytes come from. `MindService` and the UI depend on this,
+/// never on a concrete source — `ModelInstaller` (bundled asset) and
+/// `DownloadModelProvider` (Airo's existing download pipeline, `core_ai`) are
+/// two implementations, not two special cases the caller has to know about.
+///
+/// Neither implementation may reach into `airo_mind_core`'s Rust registry
+/// directly from this abstraction: the pinned digest crosses the bridge once,
+/// through the bridge's own `required_files`/`requiredModels`, and every
+/// provider verifies against that same value. See
+/// `docs/superpowers/specs/2026-08-07-airo-mind-abstraction-layer.md`.
+abstract interface class ModelProvider {
+  Future<List<RequiredModel>> requiredModels();
+
+  /// True when every required model is on disk at its pinned size.
+  ///
+  /// Size, not digest — hashing half a gigabyte on every launch costs about a
+  /// second. Full verification is [verify], run after an acquisition.
+  Future<bool> isInstalled(Directory modelsDir);
+
+  /// Puts missing models on disk, reporting progress as they arrive.
+  Stream<ModelAcquisitionEvent> acquire(Directory modelsDir);
+
+  Future<List<InstalledModel>> verify(Directory modelsDir);
+}

--- a/packages/feature_mind/module.yaml
+++ b/packages/feature_mind/module.yaml
@@ -4,7 +4,14 @@ reviewers:
   - Chief Architect
   - Platform Architect
   - Chief Security Officer
-allowed_dependencies: []
+allowed_dependencies:
+  # ModelDownloadService / ModelStorageManager: Airo Mind's model acquisition
+  # moves onto core_ai's existing download pipeline rather than shipping model
+  # weights in the APK (docs/superpowers/specs/2026-08-07-airo-mind-abstraction-layer.md).
+  - core_ai
+  # Dev-only: DownloadArtifactRequest/DownloadProgress, constructed directly by
+  # DownloadModelProvider's test doubles. Not linked into the shipped package.
+  - platform_downloads
 forbidden_dependencies:
   - app
 quality_gates: {}

--- a/packages/feature_mind/pubspec.lock
+++ b/packages/feature_mind/pubspec.lock
@@ -145,6 +145,27 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.1.2"
+  core_ai:
+    dependency: "direct main"
+    description:
+      path: "../core_ai"
+      relative: true
+    source: path
+    version: "0.0.1"
+  core_domain:
+    dependency: transitive
+    description:
+      path: "../core_domain"
+      relative: true
+    source: path
+    version: "0.0.1"
+  core_native:
+    dependency: transitive
+    description:
+      path: "../core_native"
+      relative: true
+    source: path
+    version: "0.1.0"
   crypto:
     dependency: transitive
     description:
@@ -161,6 +182,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.1.7"
+  dio:
+    dependency: transitive
+    description:
+      name: dio
+      sha256: "0df44ebba85e503958eb75d07eedd3c86275a58c1d3eda2f2ce8f0a2c3abbb3c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.11.0"
+  dio_web_adapter:
+    dependency: transitive
+    description:
+      name: dio_web_adapter
+      sha256: "0786d0b7295a373de356fc0af4f6f1d0ab2844ed31b19dfc5e7556b70e24212c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.1"
+  equatable:
+    dependency: transitive
+    description:
+      name: equatable
+      sha256: "3bce007a596ff8b3119c45d68aaef631272537c03d30e5d4534dd24bf4c5eaa2"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.0"
   fake_async:
     dependency: transitive
     description:
@@ -392,6 +437,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.0"
+  mocktail:
+    dependency: "direct dev"
+    description:
+      name: mocktail
+      sha256: "5e1bf53cc7baa8062a33b84424deb61513858ea05c601b8509e683815b5914aa"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.5"
   objective_c:
     dependency: transitive
     description:
@@ -449,7 +502,7 @@ packages:
     source: hosted
     version: "2.2.2"
   path_provider_platform_interface:
-    dependency: transitive
+    dependency: "direct dev"
     description:
       name: path_provider_platform_interface
       sha256: "484838772624c3a4b94f1e44a3e19897fee738f2d5c4ce448443b0417f7c9dda"
@@ -472,8 +525,15 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.1.6"
+  platform_downloads:
+    dependency: "direct dev"
+    description:
+      path: "../platform_downloads"
+      relative: true
+    source: path
+    version: "0.1.0"
   plugin_platform_interface:
-    dependency: transitive
+    dependency: "direct dev"
     description:
       name: plugin_platform_interface
       sha256: "4820fbfdb9478b1ebae27888254d445073732dae3d6ea81f0b7e06d5dedc3f02"
@@ -669,6 +729,70 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.0"
+  url_launcher:
+    dependency: transitive
+    description:
+      name: url_launcher
+      sha256: f6a7e5c4835bb4e3026a04793a4199ca2d14c739ec378fdfe23fc8075d0439f8
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.3.2"
+  url_launcher_android:
+    dependency: transitive
+    description:
+      name: url_launcher_android
+      sha256: b413d49b73867ac08dd2f9890efd3cc11f2a0e577618d50843440a1fb3776c32
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.3.32"
+  url_launcher_ios:
+    dependency: transitive
+    description:
+      name: url_launcher_ios
+      sha256: "580fe5dfb51671ae38191d316e027f6b76272b026370708c2d898799750a02b0"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.4.1"
+  url_launcher_linux:
+    dependency: transitive
+    description:
+      name: url_launcher_linux
+      sha256: d5e14138b3bc193a0f63c10a53c94b91d399df0512b1f29b94a043db7482384a
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.2"
+  url_launcher_macos:
+    dependency: transitive
+    description:
+      name: url_launcher_macos
+      sha256: "368adf46f71ad3c21b8f06614adb38346f193f3a59ba8fe9a2fd74133070ba18"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.5"
+  url_launcher_platform_interface:
+    dependency: transitive
+    description:
+      name: url_launcher_platform_interface
+      sha256: "552f8a1e663569be95a8190206a38187b531910283c3e982193e4f2733f01029"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.2"
+  url_launcher_web:
+    dependency: transitive
+    description:
+      name: url_launcher_web
+      sha256: "85c81589622fbc87c1c683aaea164d3604a7777495a79d91e39ffcdec39ddb34"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.3"
+  url_launcher_windows:
+    dependency: transitive
+    description:
+      name: url_launcher_windows
+      sha256: "712c70ab1b99744ff066053cbe3e80c73332b38d46e5e945c98689b2e66fc15f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.5"
   vector_math:
     dependency: transitive
     description:
@@ -735,4 +859,4 @@ packages:
     version: "3.1.3"
 sdks:
   dart: ">=3.12.2 <4.0.0"
-  flutter: ">=3.38.4"
+  flutter: ">=3.44.4"

--- a/packages/feature_mind/pubspec.yaml
+++ b/packages/feature_mind/pubspec.yaml
@@ -21,6 +21,11 @@ dependencies:
   # Required by flutter_rust_bridge for the generated sealed classes that carry
   # ProcessingEvent's variants.
   freezed_annotation: ^3.0.0
+  # ModelDownloadService / ModelStorageManager -- model acquisition moves onto
+  # the download pipeline Airo already uses, behind ModelProvider so the
+  # source can change without touching MindService. See module.yaml.
+  core_ai:
+    path: ../core_ai
 
 # An FFI plugin. Declaring the platforms is what makes the Flutter tool run
 # cargokit's podspec/gradle/cmake hooks during a normal build -- without this
@@ -53,3 +58,10 @@ dev_dependencies:
   flutter_lints: ^6.0.0
   freezed: ^3.0.0
   build_runner: ^2.4.13
+  mocktail: ^1.0.4
+  # Test doubles construct DownloadArtifactRequest/DownloadProgress directly.
+  platform_downloads:
+    path: ../platform_downloads
+  # mind_service_test.dart fakes path_provider's platform channel directly.
+  path_provider_platform_interface: ^2.1.2
+  plugin_platform_interface: ^2.1.8

--- a/packages/feature_mind/test/mind_service_test.dart
+++ b/packages/feature_mind/test/mind_service_test.dart
@@ -1,0 +1,224 @@
+import 'dart:io';
+
+import 'package:feature_mind/src/bridges/mind_generation_bridge.dart';
+import 'package:feature_mind/src/bridges/mind_speech_bridge.dart';
+import 'package:feature_mind/src/mind_service.dart';
+import 'package:feature_mind/src/models/model_provider.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
+import 'package:plugin_platform_interface/plugin_platform_interface.dart';
+import 'package:record/record.dart';
+
+import 'support/fake_bridges.dart';
+
+/// `AudioRecorder`'s real constructor talks to a platform channel, which does
+/// not exist in a plain `flutter_test` run. None of the tests here touch
+/// recording -- only `process()` and `cancelProcessing()` -- so a bare mock
+/// that never calls the real constructor is enough; nothing on it needs
+/// stubbing.
+class MockAudioRecorder extends Mock implements AudioRecorder {}
+
+/// `MindService.modelsDirectory()` calls `path_provider`, which needs a
+/// platform channel outside a real app. This is that channel, backed by a
+/// real temp directory so the file operations in `MindService.initialize`
+/// still exercise real I/O.
+class FakePathProviderPlatform extends PathProviderPlatform
+    with MockPlatformInterfaceMixin {
+  FakePathProviderPlatform(this.supportPath);
+  final String supportPath;
+
+  @override
+  Future<String?> getApplicationSupportPath() async => supportPath;
+}
+
+/// Reports every model as already installed, at the pinned size. `MindService`
+/// only calls [acquire] when [isInstalled] is false, so a fixed `true` keeps
+/// these tests inside `process()` rather than model acquisition, which
+/// `download_model_provider_test.dart` already covers.
+class FakeReadyModelProvider implements ModelProvider {
+  @override
+  Future<List<RequiredModel>> requiredModels() async => const [];
+
+  @override
+  Future<bool> isInstalled(Directory modelsDir) async => true;
+
+  @override
+  Stream<ModelAcquisitionEvent> acquire(Directory modelsDir) =>
+      const Stream.empty();
+
+  @override
+  Future<List<InstalledModel>> verify(Directory modelsDir) async => const [];
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late Directory tempDir;
+  late FakeMindSpeechBridge speech;
+  late FakeMindGenerationBridge generation;
+  late MindService service;
+
+  setUp(() {
+    tempDir = Directory.systemTemp.createTempSync('mind_service_test_');
+    PathProviderPlatform.instance = FakePathProviderPlatform(tempDir.path);
+    speech = FakeMindSpeechBridge();
+    generation = FakeMindGenerationBridge();
+    service = MindService(
+      recorder: MockAudioRecorder(),
+      modelProvider: FakeReadyModelProvider(),
+      speechBridge: speech,
+      generationBridge: generation,
+    );
+  });
+
+  tearDown(() {
+    tempDir.deleteSync(recursive: true);
+  });
+
+  // T3 — the emitted MindStage sequence is exactly transcribing -> generating
+  // -> saving -> done. This is the contract that used to be enforced by
+  // `user_journey.rs` running both real engines in one process; it cannot any
+  // more (#1549), so this is where that property now lives.
+  test(
+    'T3: process emits transcribing, generating, saving, done in that order',
+    () async {
+      speech.transcriptEvents = const [
+        TranscriptEventTranscribing('hello'),
+        TranscriptEventTranscriptReady('hello world'),
+      ];
+      generation.generationEvents = const [
+        GenerationEventGenerating('Min'),
+        GenerationEventMinutesReady('Minutes.'),
+      ];
+
+      final stages = await service
+          .process(wavPath: 'x.wav', title: 't')
+          .map((p) => p.stage)
+          .toList();
+
+      expect(stages, [
+        MindStage.transcribing,
+        MindStage.transcribing,
+        MindStage.generating,
+        MindStage.generating,
+        MindStage.saving,
+        MindStage.done,
+      ]);
+    },
+  );
+
+  // T4 — cancelProcessing() cancels BOTH bridges once the generation bridge
+  // has been loaded. Two engines now, two admission controls; a user who
+  // presses Stop should not care which one is running, and the split (#1549)
+  // is exactly what makes it possible to forget the second one.
+  test(
+    'T4: cancelProcessing cancels the generation bridge once it has loaded',
+    () async {
+      speech.transcriptEvents = const [
+        TranscriptEventTranscriptReady('hello world'),
+      ];
+      generation.generationEvents = const [
+        GenerationEventMinutesReady('Minutes.'),
+      ];
+
+      await service.process(wavPath: 'x.wav', title: 't').drain<void>();
+      service.cancelProcessing();
+
+      expect(speech.cancelCalls, 1);
+      expect(
+        generation.cancelCalls,
+        1,
+        reason:
+            'generation was loaded during process(), so cancel must '
+            'reach it too',
+      );
+    },
+  );
+
+  test(
+    'T4b: cancelProcessing does not touch the generation bridge before it has '
+    'ever loaded',
+    () async {
+      service.cancelProcessing();
+
+      expect(speech.cancelCalls, 1);
+      expect(generation.cancelCalls, 0);
+    },
+  );
+
+  // T5 — a transcribe-only run (cancelled before generation) never loads the
+  // 48 MB generation library. The lazy-load claim, made observable by
+  // `MindGenerationBridge.ensureLoaded` rather than asserted by reading logs.
+  test(
+    'T5: a transcript-cancelled run never loads the generation bridge',
+    () async {
+      speech.transcriptEvents = const [TranscriptEventCancelled()];
+
+      await service.process(wavPath: 'x.wav', title: 't').drain<void>();
+
+      expect(generation.ensureLoadedCalls, 0);
+      expect(generation.isLoaded, isFalse);
+    },
+  );
+
+  // T6 — cancelling mid-transcribe yields `idle` and never reaches
+  // generation. `user_journey.rs`'s cancel path, restated against the bridge
+  // seam.
+  test(
+    'T6: TranscriptEventCancelled yields idle and skips generation entirely',
+    () async {
+      speech.transcriptEvents = const [
+        TranscriptEventTranscribing('partial'),
+        TranscriptEventCancelled(),
+      ];
+
+      final stages = await service
+          .process(wavPath: 'x.wav', title: 't')
+          .map((p) => p.stage)
+          .toList();
+
+      expect(stages.last, MindStage.idle);
+      expect(generation.ensureLoadedCalls, 0);
+    },
+  );
+
+  // T7 — save() is called with the model id the GENERATION bridge reports,
+  // not something process() invents. `ADR-0018 §5`: what produced a summary
+  // is recorded with it.
+  test('T7: save receives the generation bridge\'s model id', () async {
+    speech.transcriptEvents = const [
+      TranscriptEventTranscriptReady('hello world'),
+    ];
+    generation.generationEvents = const [
+      GenerationEventMinutesReady('Minutes.'),
+    ];
+    generation.modelIdValue = 'airo.generation.compact@1';
+
+    await service.process(wavPath: 'x.wav', title: 't').drain<void>();
+
+    expect(speech.savedModel, 'airo.generation.compact@1');
+  });
+
+  // T8 — a bridge that throws surfaces as MindStage.failed with the message,
+  // not an unhandled exception reaching the widget layer.
+  test(
+    'T8: a save failure surfaces as MindStage.failed, not an exception',
+    () async {
+      speech.transcriptEvents = const [
+        TranscriptEventTranscriptReady('hello world'),
+      ];
+      generation.generationEvents = const [
+        GenerationEventMinutesReady('Minutes.'),
+      ];
+      speech.saveError = StateError('disk full');
+
+      final progresses = await service
+          .process(wavPath: 'x.wav', title: 't')
+          .toList();
+
+      expect(progresses.last.stage, MindStage.failed);
+      expect(progresses.last.error, contains('disk full'));
+    },
+  );
+}

--- a/packages/feature_mind/test/models/download_model_provider_test.dart
+++ b/packages/feature_mind/test/models/download_model_provider_test.dart
@@ -1,0 +1,209 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:core_ai/core_ai.dart';
+import 'package:feature_mind/src/models/download_model_provider.dart';
+import 'package:feature_mind/src/models/model_provider.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:platform_downloads/platform_downloads.dart';
+
+class MockModelStorageManager extends Mock implements ModelStorageManager {}
+
+/// Same shape as `core_ai`'s own test fake
+/// (`packages/core_ai/test/download/model_download_service_test.dart`), kept
+/// local rather than shared: a test double is not a dependency worth exporting
+/// across a package boundary.
+class FakeBackgroundDownloads implements BackgroundDownloads {
+  final eventController = StreamController<DownloadProgress>.broadcast();
+  final requests = <DownloadArtifactRequest>[];
+  var queue = const DownloadQueueSnapshot(entries: []);
+
+  @override
+  Stream<DownloadProgress> get events => eventController.stream;
+
+  @override
+  Future<void> enqueue(DownloadArtifactRequest request) async {
+    requests.add(request);
+  }
+
+  @override
+  Future<void> pause(String artifactId) async {}
+
+  @override
+  Future<void> resume(String artifactId) async {}
+
+  @override
+  Future<void> retry(String artifactId) async {}
+
+  @override
+  Future<void> cancel(String artifactId) async {}
+
+  @override
+  Future<DownloadQueueSnapshot> getQueue() async => queue;
+
+  @override
+  Future<int?> getAvailableBytes() async => null;
+}
+
+RequiredModel _whisper() => const RequiredModel(
+  fileName: 'ggml-tiny.en.bin',
+  sizeBytes: 77704715,
+  sha256: '921e4cf8686fdd993dcd081a5da5b6c365bfde1162e72b08d75ac75289920b1f',
+);
+
+void main() {
+  setUpAll(() {
+    registerFallbackValue(
+      const OfflineModelInfo(
+        id: 'fallback',
+        name: 'fallback',
+        family: ModelFamily.other,
+        fileSizeBytes: 0,
+      ),
+    );
+  });
+
+  late FakeBackgroundDownloads downloads;
+  late MockModelStorageManager storage;
+  late ModelDownloadService service;
+  late Directory modelsDir;
+
+  setUp(() {
+    downloads = FakeBackgroundDownloads();
+    storage = MockModelStorageManager();
+    service = ModelDownloadService(
+      downloads: downloads,
+      storageManager: storage,
+    );
+    modelsDir = Directory.systemTemp.createTempSync('mind_provider_test_');
+  });
+
+  tearDown(() {
+    modelsDir.deleteSync(recursive: true);
+  });
+
+  test('requiredModels reflects the pinned Rust registry', () async {
+    final provider = DownloadModelProvider(
+      downloadService: service,
+      requiredModelsLookup: () async => [_whisper()],
+      downloadUrlFor: (_) => 'https://example.test/ggml-tiny.en.bin',
+    );
+
+    final required = await provider.requiredModels();
+
+    expect(required, hasLength(1));
+    expect(required.single.fileName, 'ggml-tiny.en.bin');
+    expect(required.single.sha256, _whisper().sha256);
+  });
+
+  test(
+    'isInstalled is false until the pinned file is the pinned size',
+    () async {
+      final provider = DownloadModelProvider(
+        downloadService: service,
+        requiredModelsLookup: () async => [_whisper()],
+        downloadUrlFor: (_) => 'https://example.test/ggml-tiny.en.bin',
+      );
+
+      expect(await provider.isInstalled(modelsDir), isFalse);
+
+      File('${modelsDir.path}/ggml-tiny.en.bin')
+        ..createSync()
+        ..writeAsBytesSync(List.filled(_whisper().sizeBytes.toInt(), 0));
+
+      expect(await provider.isInstalled(modelsDir), isTrue);
+    },
+  );
+
+  test(
+    'acquire drives the download service and reports progress by file name',
+    () async {
+      final provider = DownloadModelProvider(
+        downloadService: service,
+        requiredModelsLookup: () async => [_whisper()],
+        downloadUrlFor: (_) => 'https://example.test/ggml-tiny.en.bin',
+      );
+      // The service checks integrity twice: once before downloading (to skip
+      // a model that is already correct on disk -- false here, this test
+      // wants the download path exercised) and once after the transport
+      // reports completion (true -- that is what "succeeded" means).
+      var integrityChecks = 0;
+      when(() => storage.verifyModelIntegrity(any())).thenAnswer((_) async {
+        integrityChecks++;
+        return integrityChecks > 1;
+      });
+      when(
+        () => storage.hasEnoughDiskSpace(any()),
+      ).thenAnswer((_) async => true);
+      when(
+        () => storage.getModelPath(any(), model: any(named: 'model')),
+      ).thenAnswer((_) async => '${modelsDir.path}/ggml-tiny.en.bin');
+      when(() => storage.writeInstallReceipt(any())).thenAnswer(
+        (_) async => ModelInstallReceipt(
+          modelId: _whisper().fileName,
+          catalogFingerprint: 'test',
+          installedAt: DateTime(2026),
+        ),
+      );
+
+      final events = <ModelAcquisitionEvent>[];
+      final acquisition = provider.acquire(modelsDir).forEach(events.add);
+
+      // The service enqueues asynchronously (scheduleMicrotask); give it a
+      // turn before asserting on what it queued.
+      await Future<void>.delayed(Duration.zero);
+
+      expect(downloads.requests, hasLength(1));
+      final request = downloads.requests.single;
+      expect(request.destinationPath, '${modelsDir.path}/ggml-tiny.en.bin');
+      expect(request.expectedSha256, _whisper().sha256);
+
+      // Drive the fake transport to completion -- the provider's `acquire`
+      // stream never closes on its own (the service's per-model stream is
+      // broadcast and persistent), so nothing here finishes without this.
+      downloads.eventController.add(
+        DownloadProgress(
+          artifactId: request.artifactId,
+          status: DownloadStatus.completed,
+          downloadedBytes: _whisper().sizeBytes,
+          totalBytes: _whisper().sizeBytes,
+        ),
+      );
+      await acquisition;
+
+      expect(
+        events.whereType<ModelAcquisitionProgress>(),
+        isNotEmpty,
+        reason: 'the completed status should still report as progress once',
+      );
+      expect(
+        events.last,
+        isA<ModelAcquisitionDone>().having(
+          (e) => e.failedFileNames,
+          'failedFileNames',
+          isEmpty,
+        ),
+      );
+    },
+  );
+
+  test(
+    'a model with no download URL fails closed rather than silently skipping',
+    () async {
+      final provider = DownloadModelProvider(
+        downloadService: service,
+        requiredModelsLookup: () async => [_whisper()],
+        downloadUrlFor: (_) => null,
+      );
+
+      final failed =
+          await provider
+                  .acquire(modelsDir)
+                  .firstWhere((e) => e is ModelAcquisitionDone)
+              as ModelAcquisitionDone;
+
+      expect(failed.failedFileNames, contains('ggml-tiny.en.bin'));
+    },
+  );
+}

--- a/packages/feature_mind/test/support/fake_bridges.dart
+++ b/packages/feature_mind/test/support/fake_bridges.dart
@@ -1,0 +1,89 @@
+import 'dart:async';
+
+import 'package:feature_mind/src/bridges/mind_generation_bridge.dart';
+import 'package:feature_mind/src/bridges/mind_speech_bridge.dart';
+import 'package:feature_mind/src/whisper/api/meetings.dart' as rust;
+
+/// Scripts a [TranscriptEvent] sequence for [MindSpeechBridge.transcribe] and
+/// records every call, so tests can assert on sequencing and cancellation
+/// without a native library.
+class FakeMindSpeechBridge implements MindSpeechBridge {
+  List<TranscriptEvent> transcriptEvents = const [];
+  Object? saveError;
+  var cancelCalls = 0;
+  String? savedModel;
+
+  @override
+  Future<void> loadLibrary() async {}
+
+  @override
+  bool isReady() => true;
+
+  @override
+  Future<void> initialize({
+    required String modelsDir,
+    required String storePath,
+    required int memoryBudgetMb,
+  }) async {}
+
+  @override
+  Stream<TranscriptEvent> transcribe({required String wavPath}) =>
+      Stream.fromIterable(transcriptEvents);
+
+  @override
+  Future<String> save({
+    required String title,
+    required int recordedAtMs,
+    required String transcript,
+    required String minutes,
+    required String model,
+  }) async {
+    if (saveError != null) throw saveError!;
+    savedModel = model;
+    return 'meeting-1';
+  }
+
+  @override
+  void cancel() => cancelCalls++;
+
+  @override
+  Future<List<rust.MeetingRecord>> meetings() async => [];
+
+  @override
+  Future<List<rust.SearchHit>> search(String query) async => [];
+
+  @override
+  Future<rust.MeetingRecord?> meeting(String id) async => null;
+}
+
+/// Same idea, for the generation half. [ensureLoaded] is tracked separately
+/// from construction so a test can assert it was never called (T5).
+class FakeMindGenerationBridge implements MindGenerationBridge {
+  List<GenerationEvent> generationEvents = const [];
+  String modelIdValue = 'test-model@1';
+  var ensureLoadedCalls = 0;
+  var cancelCalls = 0;
+  var _loaded = false;
+
+  @override
+  bool get isLoaded => _loaded;
+
+  @override
+  Future<void> ensureLoaded({
+    required String modelsDir,
+    required int memoryBudgetMb,
+  }) async {
+    ensureLoadedCalls++;
+    _loaded = true;
+  }
+
+  @override
+  Stream<GenerationEvent> generate({required String transcript}) =>
+      Stream.fromIterable(generationEvents);
+
+  @override
+  String modelId() => modelIdValue;
+
+  @override
+  void cancel() => cancelCalls++;
+}


### PR DESCRIPTION
Phase 1A of the Airo Mind SSOT plan (`docs/superpowers/plans/2026-08-07-airo-mind-ssot-plan.md`), following `#1551` (Phase 0, debug builds).

Two concrete dependencies inside `feature_mind` get an interface where a direct call used to be. **Production behaviour is unchanged** — every default preserves the exact prior path.

## `ModelProvider` — model acquisition

Replaces the hardcoded bundled-asset path. `ModelInstaller` now implements it (same behaviour, demoted to one implementation rather than the only one); `DownloadModelProvider` wraps `core_ai`'s existing `ModelDownloadService`/`ModelStorageManager` — the same download pipeline Airo already uses, so neither app has to ship model weights in the APK.

`requiredModelsLookup` and `downloadUrlFor` are **injected functions**, not hardcoded:
- a provider must not import the generated bridge module — that coupling is exactly what this removes
- `airo_mind_core::models` pins a digest but no URL by design (`ADR-0018 §1` — hosting is a Dart-side decision, not the runtime's)

## `MindSpeechBridge` / `MindGenerationBridge` — the engines

Replace direct calls to the generated whisper/llama functions inside `MindService.process()`. This is what makes the pipeline's sequencing testable at all — before this, there was nothing to fake.

`loadLibrary()` is split from `initialize()` on the speech bridge specifically to preserve an existing property: `MindUnavailable.bridgeMissing` must fail before model acquisition runs, not after. Collapsing the two into one call would have silently reordered that.

## Coverage restored

T3–T8 from `docs/superpowers/specs/2026-08-06-airo-mind-journey-coverage.md` now exist in `test/mind_service_test.dart` — the coverage `#1549` removed when `user_journey.rs` could no longer link both engines in one test binary.

**T4 and T5 verified non-vacuous by mutation**, not just written and trusted: breaking each enforcement in turn (removing the dual-cancel; forcing an eager load on cancel) makes its test fail, and restoring the code makes the full suite green again.

## Governance

`module.yaml` widens `allowed_dependencies` to `core_ai` (production) and `platform_downloads` (dev-only — test doubles construct its request/progress types directly). The module-manifest gate caught the omission on the first test run; both were added deliberately, not to silence it.

## Verified

| Check | Result |
|---|---|
| `flutter analyze` — `lib/` + `test/` | clean |
| `flutter test` — `feature_mind` | **101/101**, pre-existing suite unregressed |
| T4/T5 mutation check | both fail when broken, pass when restored |
| `flutter test test_mind/ --dart-define=APP_VARIANT=mind` | **9/9** — the Mind shell still works with the abstraction layer underneath it |

Also lands the planning artifacts this phase executes against: `docs/SPEC.md` (the `/build auto` gate file), the SSOT plan and task list, and the journey-coverage spec.

## Next

Phase 1B: wire `DownloadModelProvider` as the default in both shells, drop the bundled asset from `pubspec_mind.yaml`, device walk with the download path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)