### PR TITLE
feat(mind): cut the standalone shell over to downloaded models

### DIFF
--- a/app/android/app/src/mind/AndroidManifest.xml
+++ b/app/android/app/src/mind/AndroidManifest.xml
@@ -21,6 +21,16 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK"/>
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
     <uses-permission android:name="android.permission.WAKE_LOCK"/>
+    <!-- ModelDownloadService's WorkManager-backed background download
+         (platform_downloads) runs its worker in a foreground service. Android
+         14+ enforces that a foreground service's declared type is a superset
+         of what is requested at runtime. src/main declares this, but this
+         manifest replaces src/main rather than merging into it (see the file
+         header), so without a copy here the app crashes the instant a
+         download starts:
+           IllegalArgumentException: foregroundServiceType 0x00000001 is not
+           a subset of foregroundServiceType attribute 0x00000000 -->
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC"/>
 
     <application
         android:label="${appLabel}"
@@ -77,6 +87,15 @@
                 <action android:name="android.intent.action.MEDIA_BUTTON" />
             </intent-filter>
         </receiver>
+
+        <!-- WorkManager foreground service type mapping for
+             ModelDownloadService's downloads. See the permission comment
+             above for why this cannot rely on src/main's copy. -->
+        <service
+            android:name="androidx.work.impl.foreground.SystemForegroundService"
+            android:foregroundServiceType="dataSync"
+            android:exported="false"
+            tools:node="merge" />
     </application>
 
     <!-- Required to query activities that can process text, see:

--- a/app/lib/core/mind/mind_model_source.dart
+++ b/app/lib/core/mind/mind_model_source.dart
@@ -1,0 +1,46 @@
+import 'package:core_ai/core_ai.dart' show ModelDownloadService;
+import 'package:feature_mind/feature_mind.dart';
+
+/// Where the Mind shell's models come from: hosting is a Dart-side decision
+/// (`ADR-0018 §1`), and this is where the shell makes it.
+///
+/// `airo_mind_core::models` pins each model's file name, size and digest —
+/// [MindService] reads that registry through [ModelProvider.requiredModels]
+/// and never invents an entry — but pins no URL. The three lines below are the
+/// entire policy: which host serves the two files
+/// `app/tool/fetch_mind_models.sh` already downloads from for local dev.
+///
+/// A file it does not recognise fails closed (`null`) rather than guessing a
+/// URL, so [DownloadModelProvider.acquire] reports it in `failedFileNames`
+/// instead of enqueueing a request that can never resolve.
+String? mindModelDownloadUrl(RequiredModel model) {
+  const hosts = <String, String>{
+    'ggml-tiny.en.bin':
+        'https://huggingface.co/ggerganov/whisper.cpp/resolve/main/'
+        'ggml-tiny.en.bin',
+    'qwen2.5-0.5b-instruct-q4_k_m.gguf':
+        'https://huggingface.co/Qwen/Qwen2.5-0.5B-Instruct-GGUF/resolve/main/'
+        'qwen2.5-0.5b-instruct-q4_k_m.gguf',
+  };
+  return hosts[model.fileName];
+}
+
+/// Builds the [ModelProvider] the Mind shell installs by default: Airo's
+/// existing download pipeline (`core_ai.ModelDownloadService`), not the
+/// bundled asset. Neither app ships model weights in the APK any more
+/// (`docs/superpowers/specs/2026-08-07-airo-mind-abstraction-layer.md`).
+///
+/// [requiredModelsLookup] is `feature_mind`'s own registry accessor —
+/// supplied here rather than imported by `DownloadModelProvider` itself,
+/// because a provider must not know the generated bridge exists. `MindService`
+/// exposes it only indirectly (through whichever provider it holds), so this
+/// function reaches it the same way `MindService`'s bundled default always
+/// has: via `ModelInstaller`, which already does this translation.
+ModelProvider buildMindModelProvider() {
+  const bundled = ModelInstaller();
+  return DownloadModelProvider(
+    downloadService: ModelDownloadService(),
+    requiredModelsLookup: bundled.requiredModels,
+    downloadUrlFor: mindModelDownloadUrl,
+  );
+}

--- a/app/lib/core/mind/mind_scribe_module.dart
+++ b/app/lib/core/mind/mind_scribe_module.dart
@@ -2,6 +2,8 @@ import 'package:core_product_shell/core_product_shell.dart';
 import 'package:feature_mind/feature_mind.dart';
 import 'package:go_router/go_router.dart';
 
+import 'mind_model_source.dart';
+
 /// Wraps the `feature_mind` scribe journey — record a meeting, transcribe it,
 /// read the minutes, search what was said — as a shell-registrable module,
 /// the same way `CoinVaultModule` wraps `feature_coin`.
@@ -21,7 +23,14 @@ import 'package:go_router/go_router.dart';
 /// (models missing, bridge missing, ready) as its opening state.
 class MindScribeModule extends AppModule {
   MindScribeModule({MindService Function()? createService})
-    : _createService = createService ?? MindService.new;
+    : _createService = createService ?? _defaultService;
+
+  /// The shell's actual default: models come from Airo's existing download
+  /// pipeline, not the app bundle — neither this shell nor the super app
+  /// ships model weights in the APK
+  /// (`docs/superpowers/specs/2026-08-07-airo-mind-abstraction-layer.md`).
+  static MindService _defaultService() =>
+      MindService(modelProvider: buildMindModelProvider());
 
   final MindService Function() _createService;
 

--- a/app/tool/fetch_mind_models.sh
+++ b/app/tool/fetch_mind_models.sh
@@ -1,21 +1,30 @@
 #!/usr/bin/env bash
-# Fetches Airo Mind's bundled models into the asset directory the Flutter build
-# packages.
+# Seeds a local dev cache of Airo Mind's models. NOT part of the normal build
+# any more -- both apps default to `DownloadModelProvider`, which fetches
+# through Airo's existing download pipeline at first run instead of shipping
+# weights in the APK (docs/superpowers/specs/2026-08-07-airo-mind-abstraction-layer.md).
 #
-# BUILD TIME, NOT RUN TIME. `ADR-0018 §1` says the runtime never acquires
-# models -- and it cannot: llama-cpp-2 is built with `default-features = false`
-# precisely so llama.cpp's HuggingFace client is not compiled in. Getting a
-# bundled model into the bundle is an installation concern, which is what §2's
-# "Bundled" strategy means by *ships inside the app*.
+# What this script is still for:
+#   * Seeding `ModelInstaller`'s bundled path (`ADR-0018 §2`), for anyone
+#     building a flavour that intentionally bundles -- that also needs
+#     `packages/feature_mind/pubspec.yaml`'s `assets:` block restored.
+#     `DownloadModelProvider` does NOT consult this directory; it always
+#     fetches from `mindModelDownloadUrl`.
+#   * A fast way to get verified weights on disk for manual testing without
+#     waiting on a real download.
+#
+# `ADR-0018 §1` still holds either way: the runtime never acquires models.
+# llama-cpp-2 is built with `default-features = false` precisely so llama.cpp's
+# HuggingFace client is not compiled in; this script and
+# `DownloadModelProvider` are both Dart-side.
 #
 # The digests below are the same values pinned in
-# rust/airo_mind_core/src/models.rs. They are the contract: the upstream refs
-# are branch names and can move, so a changed file fails here loudly rather than
-# shipping weights nobody reviewed. If a digest mismatches, that is a decision
-# for a human, not a reason to pass --force.
-#
-# Weights are not in git. Half a gigabyte of binary is not source, and the
-# pinned digest is what makes an untracked artefact safe to ship.
+# rust/airo_mind_core/src/models.rs, and the same URLs
+# `app/lib/core/mind/mind_model_source.dart` uses for the real download path.
+# They are the contract: the upstream refs are branch names and can move, so a
+# changed file fails here loudly rather than shipping weights nobody reviewed.
+# If a digest mismatches, that is a decision for a human, not a reason to pass
+# --force.
 #
 # Usage:  app/tool/fetch_mind_models.sh
 set -euo pipefail

--- a/docs/superpowers/plans/2026-08-07-airo-mind-ssot-todo.md
+++ b/docs/superpowers/plans/2026-08-07-airo-mind-ssot-todo.md
@@ -129,8 +129,25 @@ time the connection was back, the same stalling pattern persisted across
 several clean install attempts. Decision: ship on the evidence already
 gathered (the bug is real, the fix is verified at the file level, the pipeline
 completed two full downloads earlier in the session before the connection
-incident) rather than keep re-touching a device in a bad state. **Redo the full
-clean walk before this is treated as fully proven.**
+incident) rather than keep re-touching a device in a bad state.
+
+**Redo attempt (same session, later)**: fresh reinstall of the actually-current
+APK (caught a stale-APK false negative first — the "final" build predated the
+`_Loading`/message-wording commits; rebuilt and confirmed via `strings` on
+`kernel_blob.bin` that the new copy was present). `_Loading` UI confirmed
+genuinely working on device — screenshots at 9% and 76% for
+`qwen2.5-0.5b-instruct-q4_k_m.gguf`. Run still ended in `modelsMissing` for
+both files. `adb logcat` root cause this time: `ActivityManager: Stop FGS
+timeout` fired on `SystemForegroundService` twice (8s and 94s after start),
+each immediately followed by `JobScheduler: Job didn't exist in JobStore` for
+`ProgressiveDownloadWorker` — the OS is tearing down the download's foreground
+service mid-run on this specific device, independent of anything this session
+changed. Decision (user-confirmed): ship on the evidence already gathered —
+the double-extension bug, the manifest fix, and the UI/message fixes are all
+independently verified; the remaining flakiness is WorkManager/device
+environment, not a `feature_mind`/`core_ai` defect. **Not** re-litigated
+further in this pass; worth a standalone investigation if it recurs on other
+hardware.
 
 **Checkpoint 1** — APK size before/after not fully re-measured (release build
 not re-run after the fix); first-run-on-a-real-connection story is proven

--- a/docs/superpowers/plans/2026-08-07-airo-mind-ssot-todo.md
+++ b/docs/superpowers/plans/2026-08-07-airo-mind-ssot-todo.md
@@ -74,26 +74,69 @@ Full-package regression: `flutter analyze` and `flutter test` both clean
 (`flutter test test_mind/ --dart-define=APP_VARIANT=mind`) also green, 9/9,
 confirming the abstraction layer doesn't break the shell that already exists.
 
-### 1B — cut both apps over
+### 1B — cut the standalone shell over ✅ DONE (super app is Phase 4)
 
-- [ ] **1B.1** Record baseline: current APK size (super app + standalone),
-      first-run behaviour
-- [ ] **1B.2** Wire `DownloadModelProvider` as the default in both shells
-      (`main.dart`, `main_mind.dart`) — the choice of provider is a shell
-      decision, not a `feature_mind` default
-- [ ] **1B.3** Surface download progress in the Mind UI — first run is now a
-      wait that needs a state, not a blank screen
-- [ ] **1B.4** Drop `assets/models/` from `pubspec_mind.yaml` (and from the
-      super app's pubspec once Phase 4 adds `feature_mind` there); keep
-      `fetch_mind_models.sh` as a dev seeding convenience, say so in its header
-- [ ] **1B.5** Confirm `ADR-0018 §1` still holds — no HTTP client in the Rust
-      binary (`build_runtime_pod.sh` already checks; run it)
-- [ ] **1B.6** Device: fresh install, first-run download, full journey on the
-      Pixel 9
-- [ ] **1B.7** PR + merge
+- [x] **1B.1** Baseline: standalone Mind release APK was 620 MB (bundled
+      models) before this session; 707 MB debug / to-be-measured release after
+      (see note below — this run only produced debug builds).
+- [x] **1B.2** `app/lib/core/mind/mind_model_source.dart` — new file, builds
+      `DownloadModelProvider` wired to the real HuggingFace URLs
+      `fetch_mind_models.sh` already used, keyed by the pinned file names.
+      `MindScribeModule._defaultService` wires it into `MindService`. The super
+      app has no `MindScribeModule` registration yet (Phase 4), so only the
+      standalone shell is cut over in this phase.
+- [x] **1B.3** `_Loading` widget in `mind_home_screen.dart` — file name +
+      `LinearProgressIndicator` + percentage during the download, falling back
+      to a bare spinner once nothing is downloading. `MindService.onInstallProgress`
+      wired in `initState`. Also fixed `modelsMissing`'s failure message,
+      written for the bundled-asset era ("this build does not carry") and
+      wrong for a download failure (no network, interrupted transfer, digest
+      mismatch).
+- [x] **1B.4** Dropped `assets/models/` from `packages/feature_mind/pubspec.yaml`
+      (the actual bundling declaration — not `app/pubspec_mind.yaml`, which
+      never declared it directly). `fetch_mind_models.sh` re-scoped as a dev
+      seeding convenience for `ModelInstaller`'s bundled path; `DownloadModelProvider`
+      does not consult it.
+- [x] **1B.5** Re-checked `nm -u` on both engine dylibs for `httplib` — 0, as
+      expected (nothing here touches Rust).
+- [x] **1B.6** Device walk — **partial**, see below.
+- [x] **1B.7** *(this commit; PR still to open)*
 
-**Checkpoint 1** — APK size before/after (both apps), first-run on a real
-connection. Offline first-run stops working here; confirm that is accepted.
+**A real bug was found and fixed on device, not simulated.** `DownloadModelProvider`
+set `OfflineModelInfo.id` to the full file name, already carrying its
+extension. `ModelStorageManager.getModelPath` appends an extension to `id`
+independently of `filePath` (`_artifactExtensionFor` infers it from `filePath`,
+but the destination path itself is `$id$extension`) — so the download landed at
+a **doubled extension** (`qwen….gguf.gguf`), a file neither `verifyModelIntegrity`
+nor the Rust bridge ever looks at. Fixed by deriving `id` via
+`p.basenameWithoutExtension(fileName)`, so the reconstructed path matches the
+original name exactly.
+
+**Verified on the Pixel 9 without relying on the flaky live retries**: after the
+fix, `adb shell run-as … ls` showed the file at the *correct* single-extension
+path, and `adb shell run-as … sha256sum` matched the pinned digest exactly
+(`921e4cf8…`) — byte-for-byte correct, independent of whatever the app's own
+progress stream reported.
+
+**What's not confirmed**: a full clean run — install → download both models →
+record → transcribe → minutes → search — end to end in one sitting. Repeated
+attempts hit intermittent WorkManager network-constraint stalls
+(`NetworkRequestConstraintController` reporting `blocked=true` for no
+observable reason; network was validated throughout) made worse by an
+`adb shell svc wifi disable` issued mid-session to probe the stall, which
+dropped the wireless-debugging link entirely and required re-pairing. By the
+time the connection was back, the same stalling pattern persisted across
+several clean install attempts. Decision: ship on the evidence already
+gathered (the bug is real, the fix is verified at the file level, the pipeline
+completed two full downloads earlier in the session before the connection
+incident) rather than keep re-touching a device in a bad state. **Redo the full
+clean walk before this is treated as fully proven.**
+
+**Checkpoint 1** — APK size before/after not fully re-measured (release build
+not re-run after the fix); first-run-on-a-real-connection story is proven
+piecewise (file+hash correctness) but not as one continuous walk. Offline
+first-run no longer works, as intended — confirm that trade is still accepted
+before Phase 4 repeats it for the super app.
 
 ## Phase 2 — merge feature_assistant into feature_mind
 

--- a/packages/feature_mind/lib/feature_mind.dart
+++ b/packages/feature_mind/lib/feature_mind.dart
@@ -22,6 +22,22 @@ export 'src/mind_home_screen.dart' show MindHomeScreen;
 export 'src/mind_service.dart'
     show MindProgress, MindService, MindStage, MindStatus, MindUnavailable;
 
+// Model acquisition. A shell composes `DownloadModelProvider` with its own
+// `downloadUrlFor` (hosting is a Dart-side decision, `ADR-0018 §1` — the
+// registry pins a digest, not a URL) and passes it to `MindService`. Neither
+// this package nor the shell is required to use it: `ModelInstaller` (the
+// bundled-asset default) still works unchanged.
+export 'src/model_installer.dart' show ModelInstaller;
+export 'src/models/download_model_provider.dart' show DownloadModelProvider;
+export 'src/models/model_provider.dart'
+    show
+        InstalledModel,
+        ModelAcquisitionDone,
+        ModelAcquisitionEvent,
+        ModelAcquisitionProgress,
+        ModelProvider,
+        RequiredModel;
+
 // Runtime — models.
 export 'src/runtime/models/capability_models.dart';
 export 'src/runtime/models/context_models.dart';

--- a/packages/feature_mind/lib/src/mind_home_screen.dart
+++ b/packages/feature_mind/lib/src/mind_home_screen.dart
@@ -27,9 +27,25 @@ class _MindHomeScreenState extends State<MindHomeScreen> {
   bool _recording = false;
   String? _error;
 
+  /// The file currently being fetched, and how far. First run is now a
+  /// download rather than an asset copy
+  /// (`docs/superpowers/specs/2026-08-07-airo-mind-abstraction-layer.md`), and
+  /// ~570 MB with nothing on screen reads as a hang, not progress.
+  String? _downloadingFile;
+  int _downloadedBytes = 0;
+  int _downloadTotalBytes = 0;
+
   @override
   void initState() {
     super.initState();
+    widget.service.onInstallProgress = (fileName, copied, total) {
+      if (!mounted) return;
+      setState(() {
+        _downloadingFile = fileName;
+        _downloadedBytes = copied;
+        _downloadTotalBytes = total;
+      });
+    };
     _start();
   }
 
@@ -42,7 +58,11 @@ class _MindHomeScreenState extends State<MindHomeScreen> {
   Future<void> _start() async {
     final status = await widget.service.initialize();
     if (!mounted) return;
-    setState(() => _status = status);
+    setState(() {
+      _status = status;
+      // Whatever the outcome, the download phase (if there was one) is over.
+      _downloadingFile = null;
+    });
     if (status.isReady) await _refresh();
   }
 
@@ -115,7 +135,11 @@ class _MindHomeScreenState extends State<MindHomeScreen> {
     return Scaffold(
       appBar: AppBar(title: const Text('Airo Mind')),
       body: switch (status) {
-        null => const Center(child: CircularProgressIndicator()),
+        null => _Loading(
+          fileName: _downloadingFile,
+          downloadedBytes: _downloadedBytes,
+          totalBytes: _downloadTotalBytes,
+        ),
         MindStatus(isReady: false) => _Unavailable(status: status),
         _ => _library(context),
       },
@@ -222,6 +246,55 @@ class _MindHomeScreenState extends State<MindHomeScreen> {
           onTap: () => _open(m.id),
         );
       },
+    );
+  }
+}
+
+/// Shown while [MindService.initialize] is in flight. Nothing to show yet
+/// (native library load, or a model already on disk) falls back to a bare
+/// spinner; a download in progress gets its own file name and percentage,
+/// because ~570 MB with no feedback reads as a hang, not progress.
+class _Loading extends StatelessWidget {
+  const _Loading({
+    required this.fileName,
+    required this.downloadedBytes,
+    required this.totalBytes,
+  });
+
+  final String? fileName;
+  final int downloadedBytes;
+  final int totalBytes;
+
+  @override
+  Widget build(BuildContext context) {
+    final name = fileName;
+    if (name == null) {
+      return const Center(child: CircularProgressIndicator());
+    }
+    final fraction = totalBytes > 0 ? downloadedBytes / totalBytes : 0.0;
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(32),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Text(
+              'Downloading $name',
+              style: Theme.of(context).textTheme.titleMedium,
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 16),
+            LinearProgressIndicator(value: totalBytes > 0 ? fraction : null),
+            const SizedBox(height: 8),
+            Text(
+              totalBytes > 0
+                  ? '${(fraction * 100).toStringAsFixed(0)}%'
+                  : 'Starting…',
+              style: Theme.of(context).textTheme.bodySmall,
+            ),
+          ],
+        ),
+      ),
     );
   }
 }

--- a/packages/feature_mind/lib/src/mind_service.dart
+++ b/packages/feature_mind/lib/src/mind_service.dart
@@ -149,9 +149,13 @@ class MindService {
         }
       }
       if (failed.isNotEmpty) {
+        // "This build does not carry" was accurate for the bundled-asset
+        // default; a download provider can also fail here from no network,
+        // an interrupted transfer, or a digest mismatch, none of which "not
+        // carried by this build" describes.
         return MindStatus.unavailable(
           MindUnavailable.modelsMissing,
-          'This build does not carry ${failed.join(', ')}.',
+          'Could not get ${failed.join(', ')}.',
         );
       }
     }

--- a/packages/feature_mind/lib/src/models/download_model_provider.dart
+++ b/packages/feature_mind/lib/src/models/download_model_provider.dart
@@ -50,14 +50,25 @@ class DownloadModelProvider implements ModelProvider {
   }
 
   /// `core_ai.OfflineModelInfo.id` is the download service's identity for a
-  /// model. The file name already is one, pinned in the same registry that
-  /// pins the digest, so nothing new is invented here.
+  /// model, and it must be the file name **without its extension**.
+  ///
+  /// `ModelStorageManager.getModelPath` -- which is what actually decides
+  /// where the download is written, independently of [OfflineModelInfo.filePath]
+  /// below -- builds the destination as `$id$extension`
+  /// (`_artifactExtensionFor` infers the extension from `filePath`). Passing
+  /// the full file name as `id` doubles the extension
+  /// (`qwen….gguf` → `qwen….gguf.gguf`), so the download lands somewhere
+  /// [ModelStorageManager.verifyModelIntegrity] never looks and the Rust
+  /// bridge never reads. Verified end to end on device: 491 MB of qwen
+  /// downloaded correctly, `verifyModelIntegrity` returned false instantly
+  /// because it was hashing a file that was never written.
   core_ai.OfflineModelInfo _asOfflineModelInfo(
     RequiredModel required,
     Directory modelsDir,
   ) {
+    final id = p.basenameWithoutExtension(required.fileName);
     return core_ai.OfflineModelInfo(
-      id: required.fileName,
+      id: id,
       name: required.fileName,
       // `family` is a catalog concern the download service does not act on
       // for a direct-URL fetch; `other` says so rather than guessing one.

--- a/packages/feature_mind/pubspec.yaml
+++ b/packages/feature_mind/pubspec.yaml
@@ -32,13 +32,12 @@ dependencies:
 # block the Rust is never compiled, which is precisely the state core_native
 # has been in.
 flutter:
-  # `ADR-0018 §2`, Bundled: the models ship inside the app. They are NOT in git
-  # -- half a gigabyte of weights is not source -- so `tool/fetch_models.sh`
-  # populates this directory before a build. A build without them still
-  # compiles; it reports `modelsMissing`, which is a state the UI explains.
-  assets:
-    - assets/models/
-
+  # No bundled `assets/models/` any more. Neither app ships model weights in
+  # the APK -- both default to `DownloadModelProvider`
+  # (`docs/superpowers/specs/2026-08-07-airo-mind-abstraction-layer.md`).
+  # `ModelInstaller` (`ADR-0018 §2`, Bundled) still exists as one
+  # `ModelProvider` implementation for a build that intentionally bundles; it
+  # needs its `assets:` block restored, and the assets it names, to work.
   plugin:
     platforms:
       android:


### PR DESCRIPTION
Phase 1B of the Airo Mind SSOT plan (`docs/superpowers/plans/2026-08-07-airo-mind-ssot-todo.md`), following `#1552` (the abstraction layer).

Neither app ships model weights in the APK any more — the **standalone shell** now defaults to `DownloadModelProvider` instead of the bundled asset. The super app isn't cut over here; it doesn't carry `feature_mind` yet (that's Phase 4).

## What changed

- **`app/lib/core/mind/mind_model_source.dart`** (new) — composes the shell's default provider. File names come from `ModelInstaller.requiredModels` (the same translation of `airo_mind_core`'s Rust registry the bundled path always used); download URLs are the ones `fetch_mind_models.sh` already used for local dev. Hosting is the only new decision, and `ADR-0018 §1` puts it on the Dart side by design.
- **`feature_mind.dart`** exports `ModelProvider`, `DownloadModelProvider`, `ModelInstaller` — previously internal, needed so a shell can compose without reaching into `src/`.
- **`packages/feature_mind/pubspec.yaml`** drops `assets/models/` — the actual bundling declaration lived here, not in `app/pubspec_mind.yaml`. `fetch_mind_models.sh` is re-scoped as a dev seeding convenience for `ModelInstaller`'s bundled path (kept, not deleted); `DownloadModelProvider` doesn't consult it.
- **`mind_home_screen.dart`** gets a real first-run state — a `_Loading` widget with file name, `LinearProgressIndicator`, and percentage. Before this, "downloading 570 MB" and "hung" looked identical. Also reworded `modelsMissing`'s message, written for the bundled-asset era and wrong for a download failure.

## Two real bugs found on device, not simulated

**1. Doubled file extension.** `DownloadModelProvider` set `OfflineModelInfo.id` to the full file name, already carrying its extension. `ModelStorageManager.getModelPath` appends an extension to `id` independently of `filePath` — so the download landed at `qwen….gguf.gguf`, a file neither `verifyModelIntegrity` nor the Rust bridge ever looks at. Fixed via `p.basenameWithoutExtension(fileName)`.

**2. Missing manifest permission.** The Mind flavour's `AndroidManifest.xml` fully *replaces* `src/main` (not a merge overlay), so it never inherited `FOREGROUND_SERVICE_DATA_SYNC` or the `SystemForegroundService` declaration WorkManager needs on Android 14+. Without it, the app crashed the instant a download started:
```
IllegalArgumentException: foregroundServiceType 0x00000001 is not a subset of
foregroundServiceType attribute 0x00000000
```

## Verified

| Check | Result |
|---|---|
| `flutter analyze` — `lib/` | clean |
| `flutter test` — `feature_mind` | **101/101** |
| Debug APK build with final code | clean |
| Fix confirmed on Pixel 9, independent of app self-reporting | `adb shell run-as … ls` — file at the correct single-extension path; `sha256sum` matched the pinned digest exactly, byte-for-byte |
| `nm -u` on both engine dylibs for `httplib` | 0 (unaffected — nothing here touches Rust) |

## Not verified — stated plainly

**One continuous clean run** (install → download both models → record → transcribe → minutes → search) in a single sitting. Repeated attempts hit intermittent WorkManager network-constraint stalls, made worse by an `adb shell svc wifi disable` I issued mid-session to probe one stall — that dropped the wireless-debugging link entirely and needed re-pairing. The same stalling pattern persisted across several clean-install attempts afterward.

This lands on the evidence already gathered: the bug is real, the fix is verified at the file level, and the pipeline completed two full downloads (77 MB + 491 MB) earlier in the same session before the connection incident — rather than continuing to retry against a device left in a bad state.

**The full clean walk should be redone before this is treated as fully proven end to end.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)