### PR TITLE
fix(mind): the R05 web gate could not fail, and R05 is currently violated

### DIFF
--- a/scripts/check-mind-private-devices.sh
+++ b/scripts/check-mind-private-devices.sh
@@ -43,17 +43,40 @@ for pubspec in "${shared_pubspecs[@]}"; do
   fi
 done
 
-# The web build uses app/pubspec.yaml, where Mind is a legitimate dependency
-# for the phone and desktop targets. The check for web is therefore on the
-# sources a web build compiles: nothing under app/web may reach the module.
-if [[ -d "app/web" ]]; then
-  web_imports="$(
-    grep -rn --include='*.dart' -e "package:feature_mind/" app/web 2>/dev/null || true
-  )"
-  if [[ -n "$web_imports" ]]; then
+# The web build uses app/pubspec.yaml, where Mind is a legitimate dependency for
+# the phone and desktop targets. So the web check cannot be "is feature_mind a
+# dependency" -- it has to be "does a web build REACH the module".
+#
+# This check used to grep `app/web` for `package:feature_mind/` imports.
+# `app/web` holds index.html, the manifest and icons: it has never contained a
+# single .dart file, so that search could not fail for any state of the
+# repository. It reported OK having checked nothing, which is the exact failure
+# the positive control above exists to prevent -- and the web half had no
+# positive control of its own.
+#
+# The real question is the entrypoint's module registry. `app/lib/main.dart` is
+# what a web build compiles, and registering MindModule there puts Mind in the
+# web binary.
+web_entrypoint="app/lib/main.dart"
+
+# Positive control, same reasoning as above: prove the search can find
+# something before trusting it to find nothing.
+if ! grep -q 'ModuleRegistry' "$web_entrypoint" 2>/dev/null; then
+  echo "FATAL: could not find a module registry in $web_entrypoint, so this" >&2
+  echo "gate cannot tell what a web build links. Passing silently would be" >&2
+  echo "worse than failing." >&2
+  exit 127
+fi
+
+if grep -qE '(^|[^_[:alnum:]])MindModule\(' "$web_entrypoint"; then
+  # Acceptable only when the same pubspec points feature_mind at the stub, so
+  # the symbol resolves to a module that renders nothing.
+  if ! { grep -q 'feature_mind_stub' app/pubspec.yaml 2>/dev/null ||
+         { [[ -f app/pubspec_overrides.yaml ]] &&
+           grep -q 'feature_mind_stub' app/pubspec_overrides.yaml; }; }; then
     failed=true
-    echo "R05 violation: web sources import feature_mind." >&2
-    echo "$web_imports" >&2
+    echo "R05 violation: $web_entrypoint registers MindModule and no stub swap" >&2
+    echo "is in place, so a web build links the real feature_mind." >&2
   fi
 fi
 


### PR DESCRIPTION
**The web half of the R05 gate was structurally incapable of failing, and it was hiding a live violation.**

R05: *"Airo Mind renders only on a device one person owns."* Web and TV are shared surfaces; Mind must be **absent** from those binaries, not disabled inside them — a runtime flag can be flipped, an absent package cannot be reached.

## The check

```bash
grep -rn --include='*.dart' "package:feature_mind/" app/web
```

`app/web` holds `index.html`, `manifest.json`, `favicon.png` and `icons/`. It contains **zero `.dart` files** and always has — Flutter's web target compiles `app/lib`, not `app/web`. That search could not match for any state of the repository. It reported OK having checked nothing.

Which is precisely what the script's own positive control, three lines above, exists to prevent:

> This gate's whole job is to find something that should not be there, so a broken search reports OK having checked nothing.

The TV half got that control. The web half never did, and drifted into exactly the state it warns about.

## What it was hiding

Phase 4 registered `MindModule` in `app/lib/main.dart` beside `CoinVaultModule`, and `feature_mind` is a dependency of `app/pubspec.yaml`. **Web builds from that pubspec and that entrypoint, so a web build links the real module today.**

Plan task 4.4 — *"confirm web and TV still swap in `feature_mind_stub`"* — is still unchecked, and nothing was going to catch that it had been skipped, because the gate said OK.

**This PR does not make the gate stricter. It makes it able to report the state the repository is already in.**

## The new check

The web question cannot be *"is `feature_mind` a dependency"* — for phone and desktop targets it legitimately is. It has to be *"does a web build **reach** the module"*, which is a question about the entrypoint's registry.

The gate now fails when `app/lib/main.dart` registers `MindModule` and no stub swap points `feature_mind` at `packages/stubs/feature_mind_stub` — in `pubspec.yaml` or `pubspec_overrides.yaml`. It carries its own positive control, matching the TV half: if it cannot find a module registry in the entrypoint at all, it exits 127 rather than passing.

## Calibration — demonstrated, not assumed

| State | Result | Exit |
|---|---|---|
| Stub swap present | `R05 OK` | 0 |
| No stub swap | names the violation | 1 |
| Registry unreadable | `FATAL`, refuses to judge | 127 |

The middle row is `main` as it stands.

## Scope

Fixing the violation itself is a product decision — either web swaps in the stub, or `MindModule` stops being registered unconditionally. That belongs to **task 4.4**, not to the gate that found it. This PR will go red on `main` until 4.4 lands, which is the correct signal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
