### PR TITLE
test(mind): add the deferred Phase 3 test coverage, fix two stale literals

### DIFF
--- a/app/lib/main_mind.dart
+++ b/app/lib/main_mind.dart
@@ -31,10 +31,10 @@
 /// not branch on which shell it is running in. The gap is closed here, at the
 /// shell, in two ways:
 ///
-/// * Paths with a real equivalent are redirected — [mindLegacyRedirects] maps
-///   the pre-extraction `/agent*` aliases (still emitted by the package's tool
-///   registry and route connector) onto `/assistant*`, mirroring the super
-///   app's router.
+/// * Paths with a real equivalent are redirected — [mindLegacyHubRoots] lists
+///   the legacy roots (`/agent`, still emitted by the package's tool registry
+///   and route connector, and `/assistant`, the hub's home before Phase 3),
+///   rewritten onto the current hub root, mirroring the super app's router.
 /// * Everything else degrades to [MindUnavailableScreen] via the router's
 ///   `errorBuilder`: `/games` and `/quest/new` (assistant hub and chat
 ///   screen), `/money*`, `/live/*`, `/offers`, `/reader` (tool registry), and
@@ -135,18 +135,36 @@ ModuleRegistry buildMindModuleRegistry() {
   return ModuleRegistry(shell: ShellId.mind)..register(mind);
 }
 
-/// Pre-extraction assistant paths, mapped onto the paths this shell mounts.
-///
-/// `feature_assistant`'s tool registry, route connector, and chat screen still
-/// answer with `/agent*`; the super app's router carries the same aliases. The
-/// map is public so a test can prove the two shells agree.
+/// Legacy hub roots this shell still needs to answer: `/agent` from the
+/// pre-extraction super app, and `/assistant` from before Phase 3 of the SSOT
+/// plan claimed `/mind`. The super app's router carries the same aliases
+/// (`app/lib/core/routing/app_router.dart`).
 @visibleForTesting
-const Map<String, String> mindLegacyRedirects = <String, String>{
-  '/agent': AssistantRouteNames.assistant,
-  '/agent/notifications': AssistantRouteNames.notifications,
-  '/agent/profile': AssistantRouteNames.profile,
-  '/agent/models': AssistantRouteNames.models,
-};
+const List<String> mindLegacyHubRoots = ['/agent', '/assistant'];
+
+/// Rewrites a legacy hub prefix onto the current hub root, preserving
+/// whatever follows it.
+///
+/// A PREFIX rewrite, not one route per destination. An earlier version of
+/// this enumerated four children (notifications, profile, models, the bare
+/// root) while the hub has eleven, so `/agent/prompt-lab`, `/agent/skills`
+/// and the rest fell through to a 404 — the same latent bug
+/// `app_router.dart`'s equivalent helper was written to fix, mirrored here.
+List<GoRoute> _legacyHubRedirects(String legacyRoot) => <GoRoute>[
+  GoRoute(
+    path: legacyRoot,
+    redirect: (context, state) => AssistantRouteNames.assistant,
+  ),
+  GoRoute(
+    path: '$legacyRoot/:rest(.*)',
+    redirect: (context, state) {
+      final rest = state.pathParameters['rest'] ?? '';
+      final query = state.uri.query;
+      final suffix = query.isEmpty ? '' : '?$query';
+      return '${AssistantRouteNames.assistant}/$rest$suffix';
+    },
+  ),
+];
 
 /// The Mind shell's complete route table: the navigation shell holding the
 /// three destinations, the legacy aliases, and the account screens the host
@@ -185,8 +203,8 @@ List<RouteBase> buildMindRoutes(ModuleRegistry registry) {
   }
 
   return <RouteBase>[
-    for (final MapEntry<String, String> alias in mindLegacyRedirects.entries)
-      GoRoute(path: alias.key, redirect: (context, state) => alias.value),
+    for (final legacyRoot in mindLegacyHubRoots)
+      ..._legacyHubRedirects(legacyRoot),
     GoRoute(
       path: RouteNames.login,
       name: 'login',

--- a/app/test/assistant_route_parity_test.dart
+++ b/app/test/assistant_route_parity_test.dart
@@ -3,6 +3,7 @@ import 'package:airo_app/main.dart';
 import 'package:core_product_shell/core_product_shell.dart';
 import 'package:feature_coin/feature_coin.dart';
 import 'package:feature_mind/feature_mind.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
 
@@ -34,6 +35,89 @@ final _preExtractionAssistantRoutes = <String, String>{
   'Wellbeing': AssistantRouteNames.wellbeing,
 };
 
+/// Every `/assistant/*` and `/agent/*` path a shipped deep link or a
+/// notification already sitting in the OS can carry, and where it must land
+/// now that `/mind` is the hub's root.
+const _legacyRedirects = <String, String>{
+  '/assistant': '/mind',
+  '/assistant/chat': '/mind/chat',
+  '/assistant/prompt-lab': '/mind/prompt-lab',
+  '/assistant/audio-scribe': '/mind/audio-scribe',
+  '/assistant/skills': '/mind/skills',
+  '/assistant/device-capabilities': '/mind/device-capabilities',
+  '/assistant/model-advisor': '/mind/model-advisor',
+  '/assistant/mobile-actions': '/mind/mobile-actions',
+  '/agent': '/mind',
+  '/agent/notifications': '/mind/notifications',
+  '/agent/profile': '/mind/profile',
+  '/agent/models': '/mind/models',
+  // Regression coverage for the latent bug fba57d6d found: the old `/agent`
+  // block only enumerated four children, so these seven fell through to a
+  // 404 despite `/agent -> /assistant` "working".
+  '/agent/skills': '/mind/skills',
+  '/agent/prompt-lab': '/mind/prompt-lab',
+  '/agent/audio-scribe': '/mind/audio-scribe',
+  '/agent/device-capabilities': '/mind/device-capabilities',
+  '/agent/model-advisor': '/mind/model-advisor',
+  '/agent/mobile-actions': '/mind/mobile-actions',
+  '/agent/chat': '/mind/chat',
+};
+
+/// Finds the `GoRoute` in [router] whose pattern matches [location] and
+/// invokes its `redirect` closure directly, returning the resolved location
+/// (there is exactly one redirect hop for every path in [_legacyRedirects]).
+Future<String?> _redirectFor(
+  GoRouter router,
+  BuildContext context,
+  String location,
+) async {
+  final uri = Uri.parse(location);
+  final path = uri.path;
+  final segments = path.split('/').where((s) => s.isNotEmpty).toList();
+
+  for (final route in router.configuration.routes.whereType<GoRoute>()) {
+    final routeSegments = route.path
+        .split('/')
+        .where((s) => s.isNotEmpty)
+        .toList();
+    if (routeSegments.length != segments.length) continue;
+
+    final pathParameters = <String, String>{};
+    var matches = true;
+    for (var i = 0; i < routeSegments.length; i++) {
+      final routeSegment = routeSegments[i];
+      if (routeSegment.startsWith(':')) {
+        // `:rest(.*)` — the parameter name is everything before an optional
+        // regex in parens.
+        final parenIndex = routeSegment.indexOf('(');
+        final name = routeSegment.substring(
+          1,
+          parenIndex == -1 ? routeSegment.length : parenIndex,
+        );
+        pathParameters[name] = segments
+            .sublist(i)
+            .join('/'); // the wildcard swallows the remainder
+        break;
+      } else if (routeSegment != segments[i]) {
+        matches = false;
+        break;
+      }
+    }
+    if (!matches || route.redirect == null) continue;
+
+    final state = GoRouterState(
+      router.configuration,
+      uri: uri,
+      matchedLocation: path,
+      fullPath: route.path,
+      pathParameters: pathParameters,
+      pageKey: const ValueKey('test'),
+    );
+    return route.redirect!(context, state);
+  }
+  return null;
+}
+
 void main() {
   test('every assistant route survives the feature_assistant extraction', () {
     final router = AppRouter.createRouter(
@@ -47,9 +131,55 @@ void main() {
         entry.value,
         reason:
             'route "${entry.key}" must still resolve to ${entry.value} after '
-            'the feature_assistant extraction',
+            'the feature_assistant extraction and the Phase 3 /mind move',
       );
     }
+  });
+
+  // These two tests call the router's own `redirect` closures directly
+  // rather than driving live navigation: `AppRouter.createRouter`'s top-level
+  // `redirect` awaits `AuthService.instance.initialize()` and bounces an
+  // unauthenticated test session to `/login` before a per-route redirect ever
+  // gets a look, which would make the assertion about auth state, not about
+  // the legacy-path rewrite these tests exist to cover.
+  testWidgets('legacy /assistant and /agent paths redirect to /mind', (
+    tester,
+  ) async {
+    await tester.pumpWidget(const MaterialApp(home: SizedBox()));
+    final context = tester.element(find.byType(SizedBox));
+
+    final router = AppRouter.createRouter(
+      moduleRegistry: buildMainModuleRegistry(),
+    );
+    addTearDown(router.dispose);
+
+    for (final entry in _legacyRedirects.entries) {
+      final resolved = await _redirectFor(router, context, entry.key);
+      expect(
+        resolved,
+        entry.value,
+        reason: '${entry.key} must redirect to ${entry.value}',
+      );
+    }
+  });
+
+  testWidgets('a legacy path preserves its query string across the redirect', (
+    tester,
+  ) async {
+    await tester.pumpWidget(const MaterialApp(home: SizedBox()));
+    final context = tester.element(find.byType(SizedBox));
+
+    final router = AppRouter.createRouter(
+      moduleRegistry: buildMainModuleRegistry(),
+    );
+    addTearDown(router.dispose);
+
+    final resolved = await _redirectFor(
+      router,
+      context,
+      '/assistant/chat?prefill=hello',
+    );
+    expect(resolved, '/mind/chat?prefill=hello');
   });
 
   test('wellbeing stays outside the Mind navigation branch', () {

--- a/app/test_mind/main_mind_shell_test.dart
+++ b/app/test_mind/main_mind_shell_test.dart
@@ -38,30 +38,75 @@ void main() {
     expect(paths, contains(AssistantRouteNames.assistant));
   });
 
-  test(
-    'mind shell mounts the legacy /agent aliases the package still emits',
-    () {
-      // The package's tool registry and route connector still answer with the
-      // pre-extraction `/agent*` paths, so the shell owns the same aliases the
-      // super app's router owns. The targets are read off
-      // [AssistantRouteNames] rather than spelled out: the hub's root moved
-      // once already (Phase 3 claimed `/mind`) and a literal here would have
-      // pinned the shell to the old one.
-      expect(mindLegacyRedirects['/agent'], AssistantRouteNames.assistant);
-      expect(
-        mindLegacyRedirects['/agent/profile'],
-        AssistantRouteNames.profile,
-      );
-      expect(mindLegacyRedirects['/agent/models'], AssistantRouteNames.models);
-      expect(
-        mindLegacyRedirects['/agent/notifications'],
-        AssistantRouteNames.notifications,
-      );
-
-      final paths = buildMindRoutes(
+  testWidgets(
+    'mind shell rewrites every legacy /agent and /assistant destination',
+    (tester) async {
+      // The assistant package's tool registry and route connector still answer
+      // with the pre-extraction `/agent*` paths, and `/assistant*` was the
+      // hub's home before Phase 3 claimed `/mind` — both must keep resolving,
+      // including the seven children an earlier, four-entry version of this
+      // redirect table let fall through to a 404.
+      //
+      // Calls each matching route's own `redirect` closure directly rather
+      // than driving live navigation: `/mind` and its children render real
+      // screens that need providers this test's bare `MaterialApp.router`
+      // does not set up, and none of that is what this test is checking.
+      await tester.pumpWidget(const MaterialApp(home: SizedBox()));
+      final context = tester.element(find.byType(SizedBox));
+      final router = buildMindRouter();
+      addTearDown(router.dispose);
+      final routes = buildMindRoutes(
         buildMindModuleRegistry(),
-      ).whereType<GoRoute>().map((route) => route.path).toSet();
-      expect(paths, containsAll(mindLegacyRedirects.keys));
+      ).whereType<GoRoute>().toList();
+
+      const cases = <String, String>{
+        '/agent': '/mind',
+        '/agent/notifications': '/mind/notifications',
+        '/agent/profile': '/mind/profile',
+        '/agent/models': '/mind/models',
+        '/agent/skills': '/mind/skills',
+        '/agent/prompt-lab': '/mind/prompt-lab',
+        '/assistant': '/mind',
+        '/assistant/chat': '/mind/chat',
+        '/assistant/audio-scribe': '/mind/audio-scribe',
+      };
+
+      for (final entry in cases.entries) {
+        final segments = entry.key
+            .split('/')
+            .where((s) => s.isNotEmpty)
+            .toList();
+        final route = routes.firstWhere((r) {
+          final routeSegments = r.path
+              .split('/')
+              .where((s) => s.isNotEmpty)
+              .toList();
+          if (routeSegments.length != segments.length) return false;
+          for (var i = 0; i < routeSegments.length; i++) {
+            if (!routeSegments[i].startsWith(':') &&
+                routeSegments[i] != segments[i]) {
+              return false;
+            }
+          }
+          return true;
+        });
+
+        final rest = segments.length > 1 ? segments.skip(1).join('/') : '';
+        final state = GoRouterState(
+          router.configuration,
+          uri: Uri.parse(entry.key),
+          matchedLocation: entry.key,
+          fullPath: route.path,
+          pathParameters: rest.isEmpty ? const {} : {'rest': rest},
+          pageKey: const ValueKey('test'),
+        );
+
+        expect(
+          await route.redirect!(context, state),
+          entry.value,
+          reason: '${entry.key} must redirect to ${entry.value}',
+        );
+      }
     },
   );
 

--- a/docs/superpowers/plans/2026-08-07-airo-mind-ssot-todo.md
+++ b/docs/superpowers/plans/2026-08-07-airo-mind-ssot-todo.md
@@ -226,7 +226,7 @@ web/TV" consequence was accepted by the user earlier in this plan, but is not
 yet *implemented* — web still ships the hub today (see above). Flag before
 Phase 3/4 close it out for real.
 
-## Phase 3 — claim /mind  (3.1-3.4 done; 3.5 tests deferred)
+## Phase 3 — claim /mind ✅ DONE
 
 - [x] **3.1** Move `/assistant/*` paths to `/mind/*`, keeping every route
       **name** unchanged (names are what notifications and deep links resolve)
@@ -236,9 +236,33 @@ Phase 3/4 close it out for real.
       the reverse)
 - [x] **3.4** Retire `app/test/core/routing/mind_name_is_free_test.dart` — the
       reservation has been claimed by its intended owner
-- [ ] **3.5** Tests: route parity, redirect coverage, and a notification payload
-      carrying an old path
-- [ ] **3.6** PR + merge
+- [x] **3.5** Route parity (`assistant_route_parity_test.dart`), redirect
+      coverage for every `/assistant/*` and `/agent/*` destination including
+      the seven that fell through the original four-entry `/agent` map,
+      and notification-payload migration coverage
+      (`notification_navigation_service_test.dart`).
+- [x] **3.6** *(this commit; PR to open)*
+
+**Two real bugs found while writing the deferred tests, both in the original
+Phase 3 commit**:
+
+1. `_legacyHubRedirects`'s wildcard rewrite was correct, but `main_mind.dart`
+   (the standalone shell) still used the old four-entry `mindLegacyRedirects`
+   map — the exact latent bug Phase 3's own commit found and fixed in
+   `app_router.dart`, unfixed in its sibling. Replaced with the same
+   prefix-rewrite helper, `_legacyHubRedirects`, covering both `/agent` and
+   `/assistant` roots.
+2. `routeFromNotificationPayload`'s `fallbackRoute` default parameter was
+   still the literal `'/assistant/notifications'` — a fifth stale literal the
+   commit's own "four literals that should not have been literals" pass
+   missed. Now `AssistantRouteNames.notifications`.
+
+Testing the redirects required going around `AppRouter`'s top-level
+`redirect:` callback (it awaits `AuthService.instance.initialize()` before any
+per-route redirect gets a look, which would make an unauthenticated test
+assert about login state, not the rewrite) — both route-parity test files call
+the matching `GoRoute.redirect` closures directly with a constructed
+`GoRouterState`, which is what the router itself would have called.
 
 ## Phase 4 — the super app carries Mind
 

--- a/packages/feature_mind/test/agent_chat/data/services/notification_navigation_service_test.dart
+++ b/packages/feature_mind/test/agent_chat/data/services/notification_navigation_service_test.dart
@@ -72,12 +72,15 @@ void main() {
     );
   });
 
-  test('migration does not touch a route that merely starts with mind', () {
-    expect(
-      routeFromNotificationPayload('/mindfulness/today'),
-      '/mindfulness/today',
-    );
-  });
+  test(
+    'migration does not touch a route that merely starts with assistant',
+    () {
+      expect(
+        routeFromNotificationPayload('/assistantship/today'),
+        '/assistantship/today',
+      );
+    },
+  );
 }
 
 final class _FakeNotificationRuntimeService


### PR DESCRIPTION
## Summary
Phase 3 of `docs/superpowers/plans/2026-08-07-airo-mind-ssot-plan.md` (`/mind` claim, merged in #1560) deferred its own test coverage (item 3.5). This adds it:

- Route parity test updated for `/mind` paths, plus full redirect coverage for every `/assistant/*` and `/agent/*` legacy destination on both the super app and the standalone Mind shell.
- Notification-payload migration tests updated for the inverted `/assistant` → `/mind` direction.

Writing that coverage found two more stale literals the original commit's "four literals that should not have been literals" pass missed:

1. `app/lib/main_mind.dart` (the standalone shell) still used a four-entry legacy redirect map — the same latent 404 bug (7 of 11 children falling through) that the original Phase 3 commit fixed in `app_router.dart`, left unfixed in its sibling. Replaced with the same prefix-rewrite helper.
2. `routeFromNotificationPayload`'s `fallbackRoute` default parameter was still the literal `'/assistant/notifications'`.

Testing the redirects required going around `AppRouter`'s top-level `redirect:` callback (it awaits `AuthService.instance.initialize()` before any per-route redirect gets a look) — both route-parity test files call the matching `GoRoute.redirect` closures directly with a constructed `GoRouterState`, the same call the router itself makes.

Note: `packages/feature_mind/test/rules/r05_private_devices_test.dart` has 2 pre-existing failures on `main` (from #1561) unrelated to this PR — R05 is a known, tracked violation pending Phase 4 task 4.4.

## Test plan
- [x] `cd packages/feature_mind && flutter test` — 343/345 (2 pre-existing R05 failures, confirmed present on `main` before this PR too)
- [x] `cd app && flutter analyze` — clean (phone + mind flavor)
- [x] `cd app && flutter test` — full suite passing
- [x] `cd app && flutter test test_mind/ --dart-define=APP_VARIANT=mind` — 9/9

🤖 Generated with [Claude Code](https://claude.com/claude-code)