### PR TITLE
feat(mind): AiroMindAbsent availability marker (task 4.4, partial)

### DIFF
--- a/docs/superpowers/plans/2026-08-07-airo-mind-ssot-todo.md
+++ b/docs/superpowers/plans/2026-08-07-airo-mind-ssot-todo.md
@@ -242,7 +242,53 @@ Phase 3/4 close it out for real.
 - [ ] **4.2** Add `feature_mind` to `app/pubspec.yaml`
 - [ ] **4.3** Register `MindModule` in `main.dart` beside `CoinVaultModule` and
       `IptvFeatureModule`
-- [ ] **4.4** Confirm web and TV still swap in `feature_mind_stub`
+- [ ] **4.4** Web does NOT swap in `feature_mind_stub` today -- R05 is
+      currently violated on `main`. TV never depended on `feature_mind` in the
+      first place, so it was never at risk.
+
+      **Two things tried, both instructive, neither shippable yet.**
+
+      The obvious fix -- swap `feature_mind` for `feature_mind_stub` via
+      `pubspec_overrides.yaml` -- does not work: the stub deliberately exports
+      no `MindModule` ("a shared-surface build should fail to compile if it
+      reaches for a Mind surface", its own doc comment), so the swap breaks the
+      web BUILD rather than silently stubbing it.
+
+      A `dart.library.html` conditional import
+      (`app/lib/core/mind/mind_registration.dart` /
+      `mind_registration_web.dart`, matching the pattern already used seven
+      times elsewhere in `app/lib` -- `app_database.dart`,
+      `money_provider.dart`, etc.) does correctly keep `main.dart` from
+      referencing `MindModule` on web, and it analyzed clean for the phone
+      target. That part is real progress and a smaller fix than the pubspec
+      idea: no CI wiring, no committed override file.
+
+      It is not sufficient by itself. `AppRouter.createRouter`
+      (`app/lib/core/routing/app_router.dart:50`) -- used by every shell, not
+      swapped per platform -- unconditionally does
+      `_requiredModule<MindModule>(moduleRegistry, 'mind')` to build the route
+      tree, for both the Mind branch AND the top-level Wellbeing destination.
+      If `registerMind` is a no-op on web, that lookup finds nothing and
+      THROWS AT RUNTIME. `flutter build web --release` would compile clean and
+      the app would crash on launch -- a green compile that hides the actual
+      failure, which is why the build was stopped rather than trusted to
+      "prove" the fix.
+
+      The router itself has to learn a module can legitimately be absent --
+      `_requiredModule<MindModule>` needs an optional counterpart, and the two
+      route groups built from it unconditionally
+      (`assistant.rootRoutesFor(...)`, `assistant.hubRoutesFor(...)`) need to
+      become conditional on whether it resolved. That is router surface used
+      by every shell, phone included, and is not a change to make without the
+      router's own test suite plus a real web smoke test.
+
+      One artefact survived and is real, safe, forward-compatible progress:
+      `packages/feature_mind/lib/src/mind_availability.dart` --
+      `AiroMindAbsent.value = false`, mirroring the stub's marker of the same
+      name and shape, exported from the package barrel. It is inert until
+      something reads it, which is exactly the point: whichever fix lands next
+      (router-level optional-module lookup, most likely) has an availability
+      signal to read that already exists on both sides of the pubspec swap.
 - [ ] **4.5** `cd app && flutter build web --release` succeeds
 - [ ] **4.6** `scripts/check-mind-private-devices.sh` passes (R05)
 - [ ] **4.7** Device walk on **both** shells: first-run download, record →

--- a/packages/feature_mind/lib/feature_mind.dart
+++ b/packages/feature_mind/lib/feature_mind.dart
@@ -16,6 +16,8 @@
 /// `MindService`, and the names exported here are unchanged.
 library;
 
+export 'src/mind_availability.dart';
+
 export 'src/whisper/api/meetings.dart' show MeetingRecord, SearchHit;
 export 'src/meeting_screen.dart' show MeetingScreen;
 export 'src/mind_home_screen.dart' show MindHomeScreen;

--- a/packages/feature_mind/lib/src/mind_availability.dart
+++ b/packages/feature_mind/lib/src/mind_availability.dart
@@ -1,0 +1,18 @@
+/// Whether this build carries Airo Mind. Real answer: yes.
+///
+/// Mirrors `AiroMindAbsent` in `packages/stubs/feature_mind_stub`, which
+/// answers `true`. Both variants export a symbol with this exact name and
+/// shape so a caller can reference it unconditionally regardless of which one
+/// `pubspec_overrides.yaml` resolves to -- Dart has no conditional import on
+/// "which package a name resolved to", only on `dart.library.*` and
+/// environment defines, neither of which fits a dependency-override swap.
+///
+/// `R05`: a shared-surface build (web, TV) must not offer a Mind destination.
+/// The product shell reads this rather than the module registry's contents,
+/// because a shell that reaches for `MindModule` when the stub is in place
+/// gets a compile error -- the stub deliberately exports no such class -- and
+/// this constant is what lets the shell avoid that reference in the first
+/// place.
+abstract final class AiroMindAbsent {
+  static const bool value = false;
+}


### PR DESCRIPTION
Investigated task 4.4 — web must not offer a Mind destination (R05, currently violated on `main`, see [#1561](https://github.com/DevelopersCoffee/airo/pull/1561)). This is the one piece that survived, safe and inert on its own.

## Two things tried, both reverted, both recorded

**1. Pubspec stub swap.** Doesn't work — `feature_mind_stub` deliberately exports no `MindModule` ("a shared-surface build should fail to compile if it reaches for a Mind surface," its own comment), so the swap breaks the web *build*, not silently stubs it.

**2. `dart.library.html` conditional import.** This is the repo's own established idiom — used seven times already in `app/lib` (`app_database.dart`, `money_provider.dart`, etc.) — and it works for what it targets: `main.dart`'s own `MindModule` reference. Analyzed clean for the phone target.

**It is not sufficient by itself, and I stopped before trusting a green build to prove otherwise.** `AppRouter.createRouter` (`app_router.dart:50`) — used by every shell, not swapped per platform — unconditionally does `_requiredModule<MindModule>(moduleRegistry, 'mind')` to build the route tree, for both the Mind branch and the top-level Wellbeing destination. Making `registerMind` a no-op on web without also making the router tolerate a missing module produces a client that **compiles clean and crashes on launch**. `flutter build web --release` would not have caught that — it's a runtime failure, not a compile error — so I stopped the build rather than let a green compile stand in for verification.

Fixing this needs `_requiredModule<MindModule>` to gain an optional counterpart and both route groups built from it to become conditional — router surface used by every shell, phone included, not a change to make without the router's own test suite plus a real web smoke test.

## What shipped

`packages/feature_mind/lib/src/mind_availability.dart` — `AiroMindAbsent.value = false`, mirroring the stub's marker of the same name and shape (`value = true`). Both variants exporting the identical symbol is what lets a future caller reference it regardless of which package `pubspec_overrides.yaml` resolves to — Dart has no conditional import keyed on *which package a name resolved to*, only on `dart.library.*`/environment defines, and neither fits a dependency-override swap. This marker is inert until something reads it.

## Extra confirmation, not from me

`packages/feature_mind/test/rules/r05_private_devices_test.dart` already exists on `main` and already fails at `'the gate passes the current tree'` — independent corroboration, from inside the package, of the same violation #1561 found from the gate side. Verified this and the other 4 pre-existing failures are unrelated to the two files in this PR (`git stash` + rerun).

## Full writeup

`docs/superpowers/plans/2026-08-07-airo-mind-ssot-todo.md`, task 4.4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
