### PR TITLE
fix(mind): web builds no longer link the real Mind module (R05 phase 4.4)

### DIFF
--- a/app/lib/core/mind/mind_registration.dart
+++ b/app/lib/core/mind/mind_registration.dart
@@ -1,0 +1,19 @@
+import 'package:core_product_shell/core_product_shell.dart';
+import 'package:feature_mind/feature_mind.dart';
+
+import '../assistant/app_assistant_host_adapter.dart';
+
+/// Registers Airo Mind into [registry]. Phone/desktop only.
+///
+/// `main.dart` imports this conditionally
+/// (`if (dart.library.html) 'mind_registration_stub.dart'`) so a web build
+/// never contains a `MindModule(` construction -- R05 requires a
+/// shared-surface build to be unable to reach the module, not merely refrain
+/// from calling it at runtime. See
+/// `packages/feature_mind/lib/src/mind_availability.dart` and
+/// `scripts/check-mind-private-devices.sh`.
+void registerMind(ModuleRegistry registry) {
+  registry.register(
+    MindModule(hostAdapterBuilder: AppAssistantHostAdapter.new),
+  );
+}

--- a/app/lib/core/mind/mind_registration_stub.dart
+++ b/app/lib/core/mind/mind_registration_stub.dart
@@ -1,0 +1,8 @@
+import 'package:core_product_shell/core_product_shell.dart';
+
+/// Web's counterpart to `mind_registration.dart`: does not link
+/// `feature_mind`, so nothing registers under module id `'mind'`.
+///
+/// `AppRouter.createRouter` treats a missing `'mind'` module as absent rather
+/// than a startup failure -- see `_optionalModule` in `app_router.dart`.
+void registerMind(ModuleRegistry registry) {}

--- a/app/lib/core/routing/app_router.dart
+++ b/app/lib/core/routing/app_router.dart
@@ -47,7 +47,13 @@ class AppRouter {
     // bundle: it owns two mount points (the Mind branch and a top-level
     // destination), and the module names them so the router does not have to
     // re-derive the split from route paths.
-    final assistant = _requiredModule<MindModule>(moduleRegistry, 'mind');
+    //
+    // Optional, not required: R05 keeps Mind off shared surfaces (web) by
+    // never registering it there (`main.dart`'s conditional import), and this
+    // router is the one entrypoint every surface shares. A missing module is
+    // a legitimate composition, not a startup failure -- see
+    // `_mindAbsentHubRoutes` for what the Mind branch renders instead.
+    final assistant = _optionalModule<MindModule>(moduleRegistry, 'mind');
 
     return GoRouter(
       initialLocation: initialLocation,
@@ -89,8 +95,9 @@ class AppRouter {
         ..._legacyHubRedirects('/assistant'),
         // Assistant destinations that are reached from the Mind hub but are
         // not part of it (Wellbeing), so they render full-screen instead of
-        // inside the bottom nav.
-        ...assistant.rootRoutesFor(moduleRegistry.shell),
+        // inside the bottom nav. Absent entirely when Mind itself is absent
+        // (web) -- there is no hub for them to be reached from.
+        if (assistant != null) ...assistant.rootRoutesFor(moduleRegistry.shell),
         GoRoute(path: '/beats', redirect: (context, state) => '/music'),
         GoRoute(path: '/stream', redirect: (context, state) => '/iptv'),
         GoRoute(
@@ -215,9 +222,15 @@ class AppRouter {
                 ),
               ],
             ),
-            // Mind branch
+            // Mind branch. Falls back to a redirect-only route when the
+            // module is absent (web) -- the branch itself stays present so
+            // `navigationShell.currentIndex` keeps lining up with
+            // `AppNavigationTab.values` (see navigation_provider.dart), and
+            // a stray `/mind` link resolves to something instead of a 404.
             StatefulShellBranch(
-              routes: assistant.hubRoutesFor(moduleRegistry.shell),
+              routes: assistant != null
+                  ? assistant.hubRoutesFor(moduleRegistry.shell)
+                  : _mindAbsentHubRoutes(),
             ),
             // Beats branch
             StatefulShellBranch(
@@ -287,27 +300,37 @@ class AppRouter {
     );
   }
 
-  /// Resolves a registered module the shell cannot start without, typed.
+  /// Resolves a registered module by id, typed, or `null` if it was never
+  /// registered for this shell.
   ///
-  /// Used instead of [_requiredModuleRoutes] when the router needs more from a
-  /// module than one flat route bundle — currently the assistant, which mounts
-  /// part of itself in a navigation branch and part at the top level.
-  static T _requiredModule<T extends AppModule>(
+  /// Used instead of [_requiredModuleRoutes] when the router needs more from
+  /// a module than one flat route bundle — currently the assistant, which
+  /// mounts part of itself in a navigation branch and part at the top level.
+  /// Nullable rather than throwing: composing without Mind is a legitimate
+  /// shape, not a misconfiguration (R05 -- absent from shared surfaces by
+  /// construction, not by choice).
+  static T? _optionalModule<T extends AppModule>(
     ModuleRegistry registry,
     String moduleId,
   ) {
-    final module = registry.registeredModules
+    return registry.registeredModules
         .whereType<T>()
         .where((candidate) => candidate.id == moduleId)
         .firstOrNull;
-    if (module == null) {
-      throw ModuleCompositionException(
-        'Required module "$moduleId" is not registered as a $T for '
-        'shell "${registry.shell.value}".',
-      );
-    }
-    return module;
   }
+
+  /// What the Mind branch renders when [MindModule] is absent (web, R05).
+  ///
+  /// A single redirect rather than an empty route list: `StatefulShellBranch`
+  /// requires at least one route, and a bare `/mind` visited directly (a
+  /// stale deep link, the legacy `/agent` and `/assistant` rewrites) should
+  /// land somewhere real instead of a 404.
+  static List<GoRoute> _mindAbsentHubRoutes() => [
+    GoRoute(
+      path: AssistantRouteNames.assistant,
+      redirect: (context, state) => '/money',
+    ),
+  ];
 
   static List<GoRoute> _requiredModuleRoutes(
     ModuleRegistry registry,

--- a/app/lib/main.dart
+++ b/app/lib/main.dart
@@ -6,12 +6,12 @@ import 'package:flutter/material.dart';
 import 'package:flutter/semantics.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:shared_preferences/shared_preferences.dart';
-import 'package:feature_mind/feature_mind.dart';
 import 'core/app/airo_app.dart';
 import 'core/app/main_provider_overrides.dart';
-import 'core/assistant/app_assistant_host_adapter.dart';
 import 'core/config/firebase_status.dart';
 import 'core/error/global_error_handler.dart';
+import 'core/mind/mind_registration.dart'
+    if (dart.library.html) 'core/mind/mind_registration_stub.dart';
 import 'core/routing/app_router.dart';
 import 'core/startup/app_startup_tasks.dart';
 import 'package:feature_iptv/feature_iptv.dart';
@@ -131,8 +131,9 @@ void main() async {
 /// owns module inclusion, routes, lifecycle, and provider overrides.
 @visibleForTesting
 ModuleRegistry buildMainModuleRegistry() {
-  return ModuleRegistry(shell: ShellId.mobile)
-    ..register(CoinVaultModule())
-    ..register(MindModule(hostAdapterBuilder: AppAssistantHostAdapter.new))
-    ..register(IptvFeatureModule());
+  final registry = ModuleRegistry(shell: ShellId.mobile)
+    ..register(CoinVaultModule());
+  registerMind(registry);
+  registry.register(IptvFeatureModule());
+  return registry;
 }

--- a/app/test/assistant_route_parity_test.dart
+++ b/app/test/assistant_route_parity_test.dart
@@ -77,20 +77,34 @@ void main() {
     );
   });
 
-  test('the router refuses to start without the mind module', () {
-    final registry = ModuleRegistry(shell: ShellId.mobile)
-      ..register(CoinVaultModule())
-      ..register(IptvFeatureModule());
+  test(
+    'the router starts without the mind module and falls back to a '
+    'redirect-only Mind branch (R05: web never registers it)',
+    () {
+      final registry = ModuleRegistry(shell: ShellId.mobile)
+        ..register(CoinVaultModule())
+        ..register(IptvFeatureModule());
 
-    expect(
-      () => AppRouter.createRouter(moduleRegistry: registry),
-      throwsA(
-        isA<ModuleCompositionException>().having(
-          (error) => error.message,
-          'message',
-          contains('mind'),
+      final router = AppRouter.createRouter(moduleRegistry: registry);
+      addTearDown(router.dispose);
+
+      final branchPaths = router.configuration.routes
+          .whereType<StatefulShellRoute>()
+          .expand((shell) => shell.branches)
+          .expand((branch) => branch.routes)
+          .whereType<GoRoute>()
+          .map((route) => route.path);
+
+      expect(branchPaths, contains(AssistantRouteNames.assistant));
+      expect(
+        router.configuration.routes.whereType<GoRoute>().map(
+          (route) => route.path,
         ),
-      ),
-    );
-  });
+        isNot(contains('/wellbeing')),
+        reason:
+            'Wellbeing is reached from the Mind hub; with no hub, it must '
+            'not be mounted at all.',
+      );
+    },
+  );
 }

--- a/app/test/core/providers/navigation_provider_test.dart
+++ b/app/test/core/providers/navigation_provider_test.dart
@@ -29,7 +29,7 @@ void main() {
     test('uses stable root paths for each tab', () {
       expect(AppNavigationTab.values.map((tab) => tab.path), [
         '/money',
-        '/assistant',
+        '/mind',
         '/music',
         '/iptv',
         '/games',

--- a/docs/superpowers/plans/2026-08-07-airo-mind-ssot-todo.md
+++ b/docs/superpowers/plans/2026-08-07-airo-mind-ssot-todo.md
@@ -293,12 +293,101 @@ Phase 3/4 close it out for real.
       something reads it, which is exactly the point: whichever fix lands next
       (router-level optional-module lookup, most likely) has an availability
       signal to read that already exists on both sides of the pubspec swap.
-- [ ] **4.5** `cd app && flutter build web --release` succeeds
-- [ ] **4.6** `scripts/check-mind-private-devices.sh` passes (R05)
+      **Resolved this session.** `AppRouter.createRouter` is the one
+      entrypoint every phone/web build shares (`ShellId.mobile` — there is no
+      separate web `ShellId`), so the fix has two parts:
+
+      1. `main.dart` no longer constructs `MindModule(...)` itself. The
+         construction moved into `app/lib/core/mind/mind_registration.dart`
+         (`registerMind(registry)`), conditionally imported
+         (`if (dart.library.html) 'mind_registration_stub.dart'`) exactly like
+         the seven existing examples this pattern is modeled on. The web
+         variant's `registerMind` is a no-op — nothing registers under module
+         id `'mind'`, and critically, the literal text `MindModule(` no longer
+         appears anywhere in `main.dart`, which is what
+         `check-mind-private-devices.sh` actually greps for.
+      2. `AppRouter.createRouter` gained `_optionalModule<T>` alongside the
+         existing `_requiredModule<T>`-shaped lookup (folded into one nullable
+         helper, since the module-typed lookup had exactly one caller). Mind
+         is now looked up as `assistant = _optionalModule<MindModule>(...)`.
+         `rootRoutesFor` (Wellbeing) is included only `if (assistant != null)`.
+         The Mind `StatefulShellBranch` itself stays present at its fixed
+         index even when the module is absent — removing it would shift
+         `navigationShell.currentIndex` out of sync with
+         `AppNavigationTab.values` in `navigation_provider.dart`, which is
+         indexed positionally and referenced elsewhere by `.index`
+         (`.beats.index`, `.live.index`) — instead its `routes` fall back to a
+         single `GoRoute(path: AssistantRouteNames.assistant, redirect: (_,
+         __) => '/money')`, so a stray `/mind` (including the `/agent` and
+         `/assistant` legacy rewrites, which target this same path) lands
+         somewhere real instead of a 404.
+
+      **A locked test had to change.**
+      `assistant_route_parity_test.dart` had `'the router refuses to start
+      without the mind module'`, asserting the exact opposite of the new
+      contract. Renamed to assert the router now starts successfully and
+      falls back correctly (Mind branch redirects, Wellbeing absent). This is
+      the deliberate behavior change task 4.4 called for, not a regression.
+
+      **Two bugs found only by running the full suites, not by analyze:**
+      - `buildMainModuleRegistry()`'s first attempt called `registerMind`
+        *after* `IptvFeatureModule`, changing `registry.moduleIds` from
+        `[coin_vault, mind, iptv]` to `[coin_vault, iptv, mind]`.
+        `main_super_app_shell_test.dart` asserts that order exactly (module
+        registration order, not route order) — fixed by registering Mind
+        between the two, preserving the original sequence.
+      - `navigation_provider_test.dart`'s `'uses stable root paths for each
+        tab'` asserted the Mind tab's path is `/assistant` — stale since
+        Phase 3 moved the hub root to `/mind`
+        (`AssistantRouteNames.assistant == '/mind'`). Confirmed failing on
+        unmodified `main` too (unrelated to this change, just never caught);
+        fixed the literal since it sits directly in the file this phase
+        touches.
+      - Not a code bug, but cost real time: a **fresh worktree has no
+        `build_runner` output**. `packages/feature_mind`'s freezed unions
+        (`minutes.freezed.dart`, `meetings.freezed.dart`) are gitignored and
+        only exist after `dart run build_runner build` — without them,
+        `flutter test` fails with "isn't a type" errors on generated
+        `GenerationEvent_*`/`TranscriptEvent_*` variants that look like a
+        real compile break but are actually just missing codegen. Analyze
+        doesn't hit this (no generated-code type checking on the files that
+        need it); only a real `flutter test` run surfaces it, which is part
+        of why this phase's instructions insist on running the suites and not
+        trusting a clean analyze.
+
+      **Verified, not just claimed clean:**
+      - `flutter analyze` on `app` — 0 issues.
+      - `flutter test` in `packages/feature_mind` — 357/357.
+      - `flutter test test/rules/r05_private_devices_test.dart` in
+        `feature_mind` — 6/6 (was 2 failing on `main` before this fix: `'the
+        gate passes the current tree'`, the direct R05 regression, plus
+        `'the gate fails when web sources reach the module'`, which was
+        separately stale — it wrote a probe file to `app/web/*.dart`, a check
+        `check-mind-private-devices.sh`'s own comments say was already
+        replaced by the `main.dart`-based check because `app/web` never
+        contains `.dart` files. Rewrote it to mutate `main.dart` with a
+        direct `MindModule(...)` construction instead, matching what the
+        script actually checks now).
+      - `scripts/check-mind-private-devices.sh` — exit 0, "R05 OK: no
+        shared-surface flavor links feature_mind."
+      - `flutter test` in `app` — 1040 passed, 0 failed, 2 skipped.
+      - `cd app && flutter build web --release` — real compiled build,
+        `✓ Built build/web` (not just analyze — task 4.4's own instructions
+        called out that a clean analyze isn't sufficient evidence, since a
+        prior attempt this session compiled clean and would have crashed at
+        runtime).
+- [x] **4.5** `cd app && flutter build web --release` succeeds — confirmed
+      above, satisfied by the 4.4 fix.
+- [x] **4.6** `scripts/check-mind-private-devices.sh` passes (R05) — confirmed
+      above, satisfied by the 4.4 fix.
 - [ ] **4.7** Device walk on **both** shells: first-run download, record →
       transcribe → minutes → search, `/mind` → chat → models → prompt lab →
-      wellbeing
-- [ ] **4.8** PR + merge
+      wellbeing. **Blocked**: no physical device attached to this session
+      (`adb devices` empty). This project's testing rig is physical hardware
+      only (Pixel 9 / iPad Air 4 / Fire TV Stick 4K) — no simulators/emulators
+      substitute for this step.
+- [ ] **4.8** PR + merge — PR opened this session covering 4.2-4.6; merge
+      gated on 4.7's device walk per this phase's own checkpoint below.
 
 **Checkpoint 3** — phone APK size and cold-build time before/after. Two native
 engines now cross-compile on every super-app build.

--- a/packages/feature_mind/test/rules/r05_private_devices_test.dart
+++ b/packages/feature_mind/test/rules/r05_private_devices_test.dart
@@ -63,17 +63,37 @@ void main() {
     }
   });
 
-  test('the gate fails when web sources reach the module', () {
-    final probe = File('${root.path}/app/web/r05_mutation_probe.dart');
-    probe.writeAsStringSync("import 'package:feature_mind/feature_mind.dart';");
+  test(
+    'the gate fails when the web entrypoint constructs MindModule directly',
+    () {
+      // The web build compiles app/lib/main.dart, not app/web (which holds
+      // only index.html and assets, never a .dart file) -- so the gate reads
+      // the entrypoint's module registry rather than scanning app/web. See
+      // the "real question" comment in check-mind-private-devices.sh for why
+      // the app/web scan this replaced was a vacuous positive control.
+      final entrypoint = File('${root.path}/app/lib/main.dart');
+      final original = entrypoint.readAsStringSync();
 
-    try {
-      final result = Process.runSync(gate, const []);
-      expect(result.exitCode, isNonZero);
-    } finally {
-      if (probe.existsSync()) probe.deleteSync();
-    }
-  });
+      entrypoint.writeAsStringSync(
+        '$original\n'
+        '// r05 mutation probe\n'
+        'final _r05Probe = MindModule(hostAdapterBuilder: (_, __) {});\n',
+      );
+
+      try {
+        final result = Process.runSync(gate, const []);
+        expect(
+          result.exitCode,
+          isNonZero,
+          reason:
+              'A web build that constructs MindModule directly -- bypassing '
+              'the conditional-import registration -- must fail the gate.',
+        );
+      } finally {
+        entrypoint.writeAsStringSync(original);
+      }
+    },
+  );
 
   test('the stub answers to the same package name', () {
     final stub = File(


### PR DESCRIPTION
## Summary

Phase 4.4 of the Airo Mind SSOT plan (`docs/superpowers/plans/2026-08-07-airo-mind-ssot-todo.md`). `main.dart` constructed `MindModule(...)` unconditionally, so every web build linked `feature_mind` despite R05 requiring Mind absent from shared surfaces (web, TV).

- Moved `MindModule` construction behind a conditional import: `app/lib/core/mind/mind_registration.dart` (real) / `mind_registration_stub.dart` (web no-op), matching the repo's existing `dart.library.html` conditional-import pattern used 7+ times elsewhere. The literal text `MindModule(` — what `scripts/check-mind-private-devices.sh` actually greps for — no longer appears in `main.dart`.
- `AppRouter.createRouter` gained an optional module lookup (`_optionalModule<T>`). The Mind `StatefulShellBranch` stays at its fixed index (removing it would desync `navigationShell.currentIndex` from `AppNavigationTab.values`, which several call sites reference by `.index`), but falls back to a redirect-only route (`/mind` → `/money`) when the module is absent. The top-level Wellbeing route is only added when Mind is present.
- Updated `assistant_route_parity_test.dart`'s test that asserted the router *must* throw without Mind — that was exactly the invariant this phase intentionally changes.
- Fixed two pre-existing bugs surfaced while verifying, unrelated to R05 itself: a stale `/assistant` literal in `navigation_provider_test.dart` (Phase 3 already moved the hub root to `/mind`), and a stale R05 test that probed `app/web/*.dart` — a check the gate script's own comments say was already replaced by the `main.dart`-based check.

## Test plan

- [x] `flutter analyze` (app) — 0 issues
- [x] `flutter test` in `packages/feature_mind` — 357/357
- [x] `flutter test test/rules/r05_private_devices_test.dart` — 6/6 (was 2 failing on `main`)
- [x] `scripts/check-mind-private-devices.sh` — exit 0
- [x] `flutter test` in `app` — 1040/1040 (2 skipped)
- [x] `cd app && flutter build web --release` — real compiled build (`✓ Built build/web`), not just analyze
- [ ] Device walk on both shells (blocked: no physical device attached to this session — project policy is physical hardware only, no simulators)

🤖 Generated with [Claude Code](https://claude.com/claude-code)