### PR TITLE
ci(app): run feature_mind codegen in build-web and full build-android

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,9 @@ jobs:
 
       - name: Run code generation
         run: |
+          # feature_mind's *.freezed.dart is gitignored; the app depends on
+          # feature_mind since SSOT Phase 3, so its codegen must run first.
+          (cd packages/feature_mind && flutter pub get && dart run build_runner build)
           cd app
           dart run build_runner build
 
@@ -652,6 +655,9 @@ jobs:
       - name: Run code generation
         if: steps.android_scope.outputs.should_build == 'true' && matrix.platform.name == 'full'
         run: |
+          # feature_mind's *.freezed.dart is gitignored; the app depends on
+          # feature_mind since SSOT Phase 3, so its codegen must run first.
+          (cd packages/feature_mind && flutter pub get && dart run build_runner build)
           cd app
           dart run build_runner build
 


### PR DESCRIPTION
Follow-up to #1567, which fixed the missing feature_mind codegen for `test-app` only. The merge run on main showed `build-web` and `build-android (full)` failing on the same gitignored `*.freezed.dart` parts — eleven `app/lib` files import the `feature_mind` barrel, so every job that compiles the app tree needs the package's build_runner output, regardless of target.

One-line addition to both jobs' codegen steps, identical to the `test-app` fix. After this, the merge run's only two red jobs should be green and main fully so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)