### PR TITLE
fix(ci): give build-web its own codegen; align feature_mind compileSdk

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -986,6 +986,14 @@ jobs:
           cd ../core_auth && flutter pub get
           cd ../../app && flutter pub get
 
+      - name: Run code generation
+        run: |
+          # feature_mind's *.freezed.dart is gitignored; the app depends on
+          # feature_mind since SSOT Phase 3, so its codegen must run first.
+          (cd packages/feature_mind && flutter pub get && dart run build_runner build)
+          cd app
+          dart run build_runner build
+
       - name: Configure firebase_options.dart
         env:
           FIREBASE_OPTIONS_DART_B64: ${{ secrets.FIREBASE_OPTIONS_DART_B64 }}

--- a/packages/feature_mind/android/build.gradle
+++ b/packages/feature_mind/android/build.gradle
@@ -47,7 +47,11 @@ cargokit {
 
 android {
     namespace = "com.developerscoffee.airo.mind"
-    compileSdk = 35
+    // Must track the app module's compileSdk (app/android/app/build.gradle.kts):
+    // flutter_local_notifications' AAR metadata requires compiling against 36+,
+    // and AGP's checkReleaseAarMetadata task fails the full-variant release
+    // build otherwise.
+    compileSdk = 36
     ndkVersion = "27.0.12077973"
 
     compileOptions {


### PR DESCRIPTION
Second follow-up to #1567/#1568. The prior codegen fix (#1568) patched the wrong job — I mistook the \`analyze\` job's codegen block (line ~64) for \`build-web\`'s, which is a separate, standalone job with no codegen step at all. Confirmed by re-running the merge: \`build-web\` failed with "isn't a type" (compiler saw the freezed *usage* but never generated the types), not "no such file" as in the jobs that already had the step.

Also hit a second, independent blocker on \`build-android (full)\` once codegen got that far: \`feature_mind\`'s \`compileSdk\` (35) trails the app module's (36). AGP's \`checkReleaseAarMetadata\` now enforces this because \`flutter_local_notifications\`' AAR requires 36+. One-line align, same class of drift as the NDK-27-vs-28.2 note from #1567.

## Verified this time

Traced every job in the merge run (\`31264614525\`) individually rather than trusting a green summary:
- \`build-web\`: had zero codegen steps — confirmed via \`gh run view --json jobs\`, not assumed.
- \`build-android (full)\`: codegen ran fine; failed later at Gradle's AAR metadata check, a genuinely different error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)