### PR TITLE
fix(app): override secureStoreProvider in phone shell

### DIFF
--- a/app/lib/core/app/main_provider_overrides.dart
+++ b/app/lib/core/app/main_provider_overrides.dart
@@ -1,3 +1,4 @@
+import 'package:core_data/core_data.dart';
 import 'package:core_product_shell/core_product_shell.dart';
 import 'package:feature_iptv/feature_iptv.dart';
 import 'package:flutter_riverpod/misc.dart';
@@ -22,6 +23,7 @@ List<Override> buildMainProviderOverrides({
 }) {
   return [
     sharedPreferencesProvider.overrideWithValue(prefs),
+    secureStoreProvider.overrideWithValue(SecureStoreFactory.createSecure()),
     epgReminderNotificationGatewayProvider.overrideWithValue(
       epgReminderGateway,
     ),


### PR DESCRIPTION
## Summary
- Live/IPTV tab crashed on phone: `ProviderException: secureStoreProvider must be overridden` (`UnimplementedError`)
- `buildMainProviderOverrides()` never overrode `secureStoreProvider` — only `main_tv.dart:188` did
- Added the same `SecureStoreFactory.createSecure()` override to the phone shell

## Test plan
- [x] `dart analyze` clean on changed file
- [x] Built phone debug APK, installed on real Pixel 9
- [x] Signed in (demo creds), tapped Live tab — renders "Add your playlist" instead of throwing
- [x] Confirmed no `ProviderException`/`UnimplementedError` in logcat

🤖 Generated with [Claude Code](https://claude.com/claude-code)