### PR TITLE
feat(mind): answer AiTask.speechToText/textToSpeech honestly (#497)

### DIFF
--- a/packages/feature_mind/lib/feature_mind.dart
+++ b/packages/feature_mind/lib/feature_mind.dart
@@ -24,6 +24,12 @@ export 'src/mind_home_screen.dart' show MindHomeScreen;
 export 'src/mind_service.dart'
     show MindProgress, MindService, MindStage, MindStatus, MindUnavailable;
 
+// Path A of the STT/TTS half of task-based model routing
+// (`tasks/mind-stt-tts-routing-plan.md`): a truthful availability answer for
+// core_ai's AiTask.speechToText/textToSpeech, not a chooser -- there is
+// exactly one speech engine and no TTS engine to choose between.
+export 'src/speech_task_availability.dart';
+
 // Module contract + host seam + routes — the assistant hub, merged in from
 // `feature_assistant` (`docs/superpowers/plans/2026-08-07-airo-mind-ssot-plan.md`,
 // Phase 2).

--- a/packages/feature_mind/lib/src/speech_task_availability.dart
+++ b/packages/feature_mind/lib/src/speech_task_availability.dart
@@ -1,0 +1,95 @@
+import 'dart:io';
+
+import 'package:flutter/foundation.dart';
+
+import 'bridges/mind_speech_bridge.dart';
+import 'mind_service.dart' show MindUnavailable;
+import 'model_installer.dart';
+import 'models/model_provider.dart';
+
+/// Whether a speech-shaped `AiTask` (`core_ai`'s `AiTask.speechToText` /
+/// `AiTask.textToSpeech`) can be served right now.
+///
+/// # Why this exists instead of a router
+///
+/// `core_ai`'s `TaskModelRouter` resolves text/vision tasks against
+/// `ModelCatalog`, choosing among *installed alternatives*. Airo Mind has
+/// exactly one speech engine (whisper.cpp, pinned — see
+/// `MindSpeechBridge`'s own doc comment) and no text-to-speech capability at
+/// all, so there is nothing to choose between. A chooser with one option
+/// would look complete while solving nothing; this answers the question
+/// `TaskModelRouter` throws `UnroutableTaskException` for instead —
+/// truthfully, not by faking a selection
+/// (`tasks/mind-stt-tts-routing-plan.md`, Phase 0).
+///
+/// [unavailableReason] is null in two different cases, distinguished by
+/// [available]: when [available] is true, it means "not applicable, this
+/// works." When [available] is false and [unavailableReason] is also null,
+/// it means the task has no implementation in Airo Mind at all, on any
+/// platform or build — not one of `MindService`'s startup failure modes.
+/// `AiTask.textToSpeech` is always this case: reusing a `MindUnavailable`
+/// value for it would misdescribe a permanent product gap as a fixable
+/// startup condition.
+@immutable
+class SpeechTaskAvailability {
+  const SpeechTaskAvailability.available()
+    : available = true,
+      unavailableReason = null,
+      detail = '';
+
+  const SpeechTaskAvailability.unavailable(this.unavailableReason, this.detail)
+    : available = false;
+
+  final bool available;
+  final MindUnavailable? unavailableReason;
+  final String detail;
+}
+
+/// Answers [SpeechTaskAvailability] for the speech-shaped `AiTask` values,
+/// without the side effects `MindService.initialize()` has: this checks
+/// whether the model is present, it does not download it, and it never loads
+/// the generation library.
+class SpeechTaskAvailabilityChecker {
+  const SpeechTaskAvailabilityChecker({
+    MindSpeechBridge? speechBridge,
+    ModelProvider? modelProvider,
+  }) : _speech = speechBridge ?? const RustMindSpeechBridge(),
+       _models = modelProvider ?? const ModelInstaller();
+
+  final MindSpeechBridge _speech;
+  final ModelProvider _models;
+
+  /// `AiTask.speechToText`'s availability, using the same checks
+  /// `MindService.initialize()` runs before it would start a model
+  /// acquisition or a load.
+  Future<SpeechTaskAvailability> speechToText(Directory modelsDir) async {
+    try {
+      await _speech.loadLibrary();
+    } on Object catch (e) {
+      return SpeechTaskAvailability.unavailable(
+        MindUnavailable.bridgeMissing,
+        '$e',
+      );
+    }
+
+    if (!await _models.isInstalled(modelsDir)) {
+      return const SpeechTaskAvailability.unavailable(
+        MindUnavailable.modelsMissing,
+        'The speech model is not installed yet.',
+      );
+    }
+
+    return const SpeechTaskAvailability.available();
+  }
+
+  /// `AiTask.textToSpeech` is not available for Airo Mind — there is no
+  /// text-to-speech engine in `feature_mind`. Airo's accessibility TTS
+  /// (`app/lib/core/accessibility/airo_speech_service.dart`) is a distinct
+  /// product surface and must not be reported here: doing so would claim a
+  /// capability this package does not have.
+  SpeechTaskAvailability textToSpeech() =>
+      const SpeechTaskAvailability.unavailable(
+        null,
+        'Airo Mind has no text-to-speech capability.',
+      );
+}

--- a/packages/feature_mind/test/speech_task_availability_test.dart
+++ b/packages/feature_mind/test/speech_task_availability_test.dart
@@ -1,0 +1,141 @@
+import 'dart:io';
+
+import 'package:feature_mind/src/mind_service.dart' show MindUnavailable;
+import 'package:feature_mind/src/models/model_provider.dart';
+import 'package:feature_mind/src/speech_task_availability.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'support/fake_bridges.dart';
+
+class _FakeModelProvider implements ModelProvider {
+  _FakeModelProvider({this.installed = true});
+
+  final bool installed;
+
+  @override
+  Future<void> dispose() async {}
+
+  @override
+  bool get acquiresWithoutNetwork => true;
+
+  @override
+  Future<List<RequiredModel>> requiredModels() async => const [];
+
+  @override
+  Future<bool> isInstalled(Directory modelsDir) async => installed;
+
+  @override
+  Future<List<RequiredModel>> missingModels(Directory modelsDir) async =>
+      const [];
+
+  @override
+  Stream<ModelAcquisitionEvent> acquire(Directory modelsDir) =>
+      const Stream.empty();
+
+  @override
+  Future<List<InstalledModel>> verify(Directory modelsDir) async => const [];
+}
+
+void main() {
+  late Directory tempDir;
+
+  setUp(() async {
+    tempDir = await Directory.systemTemp.createTemp('speech-availability');
+  });
+
+  tearDown(() async {
+    if (tempDir.existsSync()) await tempDir.delete(recursive: true);
+  });
+
+  group('SpeechTaskAvailabilityChecker.speechToText', () {
+    test('is available when the bridge loads and the model is installed', () async {
+      final checker = SpeechTaskAvailabilityChecker(
+        speechBridge: FakeMindSpeechBridge(),
+        modelProvider: _FakeModelProvider(installed: true),
+      );
+
+      final result = await checker.speechToText(tempDir);
+
+      expect(result.available, isTrue);
+      expect(result.unavailableReason, isNull);
+    });
+
+    test('reports bridgeMissing when the native library fails to load', () async {
+      final speech = FakeMindSpeechBridge()..loadLibraryError = StateError('no library');
+      final checker = SpeechTaskAvailabilityChecker(
+        speechBridge: speech,
+        modelProvider: _FakeModelProvider(installed: true),
+      );
+
+      final result = await checker.speechToText(tempDir);
+
+      expect(result.available, isFalse);
+      expect(result.unavailableReason, MindUnavailable.bridgeMissing);
+      expect(result.detail, contains('no library'));
+    });
+
+    test('reports modelsMissing without attempting to acquire anything', () async {
+      var acquireCalls = 0;
+      final provider = _AcquireTrackingModelProvider(
+        installed: false,
+        onAcquire: () => acquireCalls++,
+      );
+      final checker = SpeechTaskAvailabilityChecker(
+        speechBridge: FakeMindSpeechBridge(),
+        modelProvider: provider,
+      );
+
+      final result = await checker.speechToText(tempDir);
+
+      expect(result.available, isFalse);
+      expect(result.unavailableReason, MindUnavailable.modelsMissing);
+      expect(acquireCalls, 0);
+    });
+  });
+
+  group('SpeechTaskAvailabilityChecker.textToSpeech', () {
+    test('is always unavailable, for a reason outside MindUnavailable', () {
+      const checker = SpeechTaskAvailabilityChecker();
+
+      final result = checker.textToSpeech();
+
+      expect(result.available, isFalse);
+      // Null, not one of MindUnavailable's cases: this is a permanent
+      // product gap, not a startup failure -- see the class doc for why
+      // conflating the two would misdescribe it.
+      expect(result.unavailableReason, isNull);
+      expect(result.detail, isNotEmpty);
+    });
+  });
+}
+
+class _AcquireTrackingModelProvider implements ModelProvider {
+  _AcquireTrackingModelProvider({required this.installed, required this.onAcquire});
+
+  final bool installed;
+  final void Function() onAcquire;
+
+  @override
+  Future<void> dispose() async {}
+
+  @override
+  bool get acquiresWithoutNetwork => true;
+
+  @override
+  Future<List<RequiredModel>> requiredModels() async => const [];
+
+  @override
+  Future<bool> isInstalled(Directory modelsDir) async => installed;
+
+  @override
+  Future<List<RequiredModel>> missingModels(Directory modelsDir) async =>
+      const [];
+
+  @override
+  Stream<ModelAcquisitionEvent> acquire(Directory modelsDir) async* {
+    onAcquire();
+  }
+
+  @override
+  Future<List<InstalledModel>> verify(Directory modelsDir) async => const [];
+}

--- a/packages/feature_mind/test/support/fake_bridges.dart
+++ b/packages/feature_mind/test/support/fake_bridges.dart
@@ -13,8 +13,14 @@ class FakeMindSpeechBridge implements MindSpeechBridge {
   var cancelCalls = 0;
   String? savedModel;
 
+  /// Set to make [loadLibrary] throw, simulating a platform with no native
+  /// library (`MindUnavailable.bridgeMissing`).
+  Object? loadLibraryError;
+
   @override
-  Future<void> loadLibrary() async {}
+  Future<void> loadLibrary() async {
+    if (loadLibraryError != null) throw loadLibraryError!;
+  }
 
   @override
   bool isReady() => true;

--- a/tasks/mind-stt-tts-routing-plan.md
+++ b/tasks/mind-stt-tts-routing-plan.md
@@ -1,0 +1,187 @@
+# Implementation Plan: STT/TTS half of task-based model routing (#497)
+
+## Overview
+
+PR #1564 (merged) added `AiTask` + `TaskModelRouter` in `core_ai`, resolving
+text/vision tasks (chat, meeting summarization, translation, embeddings, OCR)
+against `ModelCatalog`. Two `AiTask` values — `speechToText` and
+`textToSpeech` — were deliberately left unresolvable: `TaskModelRouter` throws
+`UnroutableTaskException` for them rather than faking an answer, because
+speech lives in a different subsystem (`feature_mind`) that doesn't share
+`ModelCatalog`'s `OfflineModelInfo` shape at all.
+
+This plan investigates what "resolve the speech half" actually means given
+`feature_mind`'s current architecture, and finds the premise needs checking
+before code gets written: **there is nothing to route between yet.**
+
+## What's actually there today (read, not assumed)
+
+- **STT**: `MindSpeechBridge` (`packages/feature_mind/lib/src/bridges/mind_speech_bridge.dart`)
+  wraps exactly one engine — whisper.cpp, via the generated Rust bridge. Its
+  own doc comment: *"Not a claim that a second speech engine is coming.
+  Whisper stays pinned; this interface exists so a test can stand somewhere,
+  not as a plugin system."* This is an explicit, on-the-record design
+  decision, not an oversight.
+- **TTS**: `feature_mind` has no text-to-speech capability at all. The only
+  TTS in the codebase is `app/lib/core/accessibility/airo_speech_service.dart`,
+  an OS-level `flutter_tts` wrapper for screen-reader-style accessibility —
+  architecturally unrelated to `ModelCatalog`, `OfflineModelInfo`, or
+  `MindGenerationBridge` (which is LLM text generation for meeting minutes,
+  not audio synthesis).
+- **The model descriptor mismatch**: `feature_mind`'s model registry
+  (`packages/feature_mind/lib/src/models/model_provider.dart`'s
+  `RequiredModel`) has no capability/task tag and no engine identity field —
+  it's `fileName`/`sizeBytes`/`sha256` for download verification only.
+  `TaskModelRouter.resolve` expects `OfflineModelInfo` (with a `capabilities`
+  list); the two types don't overlap and weren't designed to.
+- **The extensibility seam already exists, one layer up**:
+  `MindService`'s constructor already takes injectable `speechBridge`/
+  `generationBridge` (`MindSpeechBridge`/`MindGenerationBridge` interfaces),
+  built in Mind SSOT Phase 1 specifically so a second engine *could* be
+  swapped in later. Nothing currently swaps it, because nothing else exists
+  to swap to.
+
+## The real question this plan can't answer alone
+
+Building a `TaskModelRouter`-shaped "choose among installed speech models"
+resolver for a subsystem that has exactly one non-swappable engine, by
+explicit design, means writing a chooser with nothing to choose. That's the
+same "looks complete, silently does nothing useful" failure mode #497's
+original comment already flagged and chose not to ship for this exact reason.
+
+Two honest paths forward, not one assumed answer:
+
+**Path A — descriptor only, no chooser (recommended default).** Give
+`AiTask.speechToText`/`textToSpeech` a real, typed answer instead of an
+exception — "here is the thing that serves this task, if the platform has
+it" — without pretending there's a selection among alternatives. A thin
+adapter in `feature_mind` (or `core_ai`, calling into `feature_mind`) that
+answers "can this device serve `AiTask.speechToText`?" and "get me the
+handle" using the existing `MindSpeechBridge`/`MindUnavailable.bridgeMissing`
+machinery already there. No new routing algorithm — the interface injection
+Phase 1 built already *is* the routing seam; this just makes it reachable
+through the same `AiTask` vocabulary the text/vision half uses.
+
+**Path B — build the real router now anyway**, treating this as
+forward-compat infrastructure for engines that don't exist yet. Larger, and
+speculative: it means designing capability tags for speech models before a
+second speech model is a real, funded piece of work, and maintaining code
+with no test scenario except "the one engine we have."
+
+**Recommendation: Path A.** It closes the actual gap (a caller asking "how do
+I get TTS/STT the same way I ask for chat" currently gets nothing consistent)
+without inventing a routing algorithm the codebase's own comments say isn't
+wanted yet. If a second speech engine becomes real work later, Path A's
+adapter is exactly where a real `SpeechTaskRouter` would slot in — this
+doesn't foreclose Path B, it just doesn't build it before there's a second
+option to route between.
+
+## Architecture Decisions
+
+- **Path A over Path B** (see above) — avoid building a chooser with one
+  choice.
+- **New type, not reused `OfflineModelInfo`** — `feature_mind`'s engines
+  aren't `ModelCatalog` entries and forcing them into that shape would be
+  lossy (no file hash/size fields that mean the same thing, no meaningful
+  `ModelFamily`). A small `SpeechEngineHandle` (or similar) describing
+  "available: yes/no, reason if no, and how to get the actual bridge" is its
+  own type.
+- **Lives in `feature_mind`, exported for `core_ai`/app callers** — the
+  adapter must own the `MindUnavailable`/bridge-missing logic already there;
+  putting it in `core_ai` would mean depending on `feature_mind`'s Rust
+  bridges from a package that currently has zero platform-specific code.
+
+## Dependency Graph
+
+```
+MindSpeechBridge / MindUnavailable            (existing, feature_mind)
+        │
+        ├── SpeechTaskAvailability descriptor  (new, feature_mind)
+        │       │
+        │       └── AiTask.speechToText/textToSpeech answer
+        │               (new: a function/class exported from feature_mind,
+        │                NOT added to TaskModelRouter — that stays
+        │                ModelCatalog-only per its own contract)
+        │
+        └── Callers (MindService today; any future non-Mind caller that
+              wants "is speech available" without importing feature_mind's
+              internals directly)
+```
+
+Nothing in `core_ai`'s `TaskModelRouter`/`AiTask` needs to change for Path A
+— `AiTask.speechToText.isCatalogResolvable` staying `false` is correct and
+should not flip. The new descriptor lives entirely in `feature_mind` and is
+reached separately, the same way a caller today already reaches
+`MindService.initialize()` rather than going through `AIRouter`.
+
+## Task List
+
+### Phase 0: Decision checkpoint ✅ DONE
+
+- [x] **Task 0.1**: **Path A confirmed.** One engine, one answer; a router
+      over a single choice adds abstraction without solving anything.
+- [x] **Task 0.2**: **TTS is not available for Airo Mind.** The existing
+      `airo_speech_service.dart` accessibility TTS is a separate product
+      surface and must not be mapped to `AiTask.textToSpeech` — doing so
+      would claim a capability Mind doesn't have.
+
+### Phase 1: The descriptor (Path A)
+
+- [ ] **Task 1.1**: Add `SpeechTaskAvailability` (or similar name) to
+      `packages/feature_mind/lib/src/`. Fields: whether the task
+      (`speechToText`/`textToSpeech`) is servable on this platform/build,
+      and if not, why (mirrors `MindUnavailable`'s existing cases —
+      `bridgeMissing`, `modelsMissing`, `loadFailed` — reuse that enum rather
+      than inventing a parallel one).
+- [ ] **Task 1.2**: A function/class that answers the descriptor for
+      `AiTask.speechToText`, backed by the existing `MindSpeechBridge`
+      surface (does not require an active `MindService` instance — should
+      answer from the bridge/model-provider state, the same checks
+      `MindService.initialize()` already does).
+- [ ] **Task 1.3**: The same for `AiTask.textToSpeech`. Given `feature_mind`
+      has no TTS today (see Overview), this answers "not available" honestly
+      — do not wire it to `airo_speech_service.dart`'s accessibility TTS
+      unless a maintainer confirms that's actually the intended meaning of
+      "TTS task" here (it's a different product surface: reading arbitrary
+      app text aloud vs. synthesizing meeting audio).
+
+### Checkpoint: Phase 1
+- [ ] `flutter analyze` clean in `feature_mind`.
+- [ ] Unit tests cover: available case, each `MindUnavailable` reason
+      surfaced correctly, textToSpeech's honest "not available."
+- [ ] No change to `core_ai`'s `AiTask`/`TaskModelRouter` — confirm via
+      `git diff` before commit that this phase touched `feature_mind` only.
+
+### Phase 2: Reachability from a caller's perspective
+
+- [ ] **Task 2.1**: Export the new descriptor/function from
+      `packages/feature_mind/lib/feature_mind.dart`'s public barrel.
+- [ ] **Task 2.2**: One real caller wired to it — likely `MindService` itself
+      or a settings/capability-report screen that currently hardcodes "Mind
+      is available" logic inline (check `device_capability_report_screen.dart`
+      and `model_health_center_screen.dart` for existing inline checks this
+      could replace, rather than adding a second, competing check).
+
+### Checkpoint: Phase 2 / Complete
+- [ ] `cd packages/feature_mind && flutter test` — full suite green.
+- [ ] `cd app && flutter analyze && flutter test` — no regressions.
+- [ ] Manual/documented check: the descriptor's "not available" path is
+      actually exercised somewhere (web build, or a build without the native
+      artifact) — not just the happy path.
+- [ ] PR opened, one logical commit, mirrors #1564's shape (small, tested,
+      honest about what it does and doesn't cover).
+
+## Risks and Mitigations
+
+| Risk | Impact | Mitigation |
+|---|---|---|
+| Building Path A's adapter turns into scope creep toward a full router | Med | Task 1.1-1.3 explicitly forbid touching `TaskModelRouter`/`AiTask.isCatalogResolvable` — checkpoint verifies via diff. |
+| "TTS task" is assumed to mean `airo_speech_service.dart`'s accessibility TTS when a maintainer actually meant something else (or nothing yet) | Med | Task 1.3 answers "not available" rather than guessing a wiring; Phase 0 checkpoint surfaces the ambiguity before code. |
+| No second speech engine ever materializes, making the whole descriptor dead weight | Low | Descriptor is small (one file, ~2 methods) and reuses `MindUnavailable` — low cost even if never extended. |
+
+## Open Questions — resolved
+
+- ~~Does "TTS routing" mean synthesizing audio for meetings, or surfacing
+  accessibility TTS?~~ **Neither, for now** — TTS is not available for Mind.
+- ~~Is a second STT/TTS engine on any roadmap?~~ **No** — routing is deferred
+  until a real second implementation exists.

--- a/tasks/mind-stt-tts-routing-todo.md
+++ b/tasks/mind-stt-tts-routing-todo.md
@@ -1,0 +1,73 @@
+# STT/TTS routing (#497) — task list
+
+Plan: `tasks/mind-stt-tts-routing-plan.md`. One PR for Phase 1+2 combined (small
+enough not to split); Phase 0 is a decision, not a diff.
+
+## Phase 0 — decision checkpoint ✅ DONE
+
+- [x] **0.1** Path A confirmed — thin availability descriptor, no chooser.
+      One engine, one answer; a router would add abstraction without a real
+      choice to make.
+- [x] **0.2** TTS confirmed **not available** for Airo Mind. The existing
+      `airo_speech_service.dart` is a distinct accessibility surface and must
+      not be surfaced as `AiTask.textToSpeech` — that would claim a
+      capability Mind doesn't have.
+
+Resolved shape (as shipped):
+
+```text
+AiTask.speechToText  -> available: true,  unavailableReason: null   (bridge ok, model installed)
+                      -> available: false, unavailableReason: MindUnavailable.bridgeMissing/modelsMissing
+AiTask.textToSpeech  -> available: false, unavailableReason: null   (no MindUnavailable case fits --
+                                                                      this is a permanent gap, not a
+                                                                      startup failure)
+```
+
+No `TaskModelRouter` equivalent. Future routing deferred until a second real
+implementation exists to choose between.
+
+## Phase 1 — the descriptor ✅ DONE
+
+- [x] **1.1** `SpeechTaskAvailability` in
+      `packages/feature_mind/lib/src/speech_task_availability.dart`. Reuses
+      `MindUnavailable` for the two STT failure modes; `unavailableReason:
+      null` + `available: false` is the distinct "not implemented" state for
+      TTS — a plain reuse of `MindUnavailable` couldn't express that without
+      picking a misleading case.
+- [x] **1.2** `SpeechTaskAvailabilityChecker.speechToText` — calls
+      `MindSpeechBridge.loadLibrary()` and `ModelProvider.isInstalled()`
+      only, no `acquire()`/download, no `MindService` instance.
+- [x] **1.3** `SpeechTaskAvailabilityChecker.textToSpeech` — always
+      unavailable, per 0.2.
+- [x] **1.4** `flutter analyze` clean; 4 tests in
+      `test/speech_task_availability_test.dart` (available, bridgeMissing,
+      modelsMissing — with an explicit assertion that `acquire()` is never
+      called, textToSpeech). Full package suite 365/365, zero regressions.
+- [x] **1.5** `git diff packages/core_ai` empty — confirmed before commit.
+
+## Phase 2 — reachability ✅ DONE (see note)
+
+- [x] **2.1** Exported from `packages/feature_mind/lib/feature_mind.dart`.
+- [x] **2.2** Checked `device_capability_report_screen.dart` and
+      `model_health_center_screen.dart` first, per the plan — neither has an
+      inline Mind-availability check (they're the LLM chat/model-catalog
+      side, unrelated to the scribe). No existing check to replace, so no
+      caller was wired to avoid inventing a UI hookup with no real need
+      behind it. The export + tests are the deliverable; a caller lands when
+      one actually needs "is speech available" outside `MindService`'s own
+      full `initialize()`.
+
+## Verification
+
+```bash
+cd packages/feature_mind && flutter analyze && flutter test   # 365/365
+cd app && flutter analyze                                     # clean
+git diff packages/core_ai                                     # empty
+```
+
+## Checkpoint: Complete
+
+- [x] Phase 1 + 2 acceptance criteria met (2.2 met via verified non-need
+      rather than a forced wiring — see note above).
+- [ ] PR opened, one logical commit (mirrors #1564's size/shape).
+- [ ] Ready for review.


### PR DESCRIPTION
## Summary
Closes the speech half of #497 (Model Routing) that PR #1564 deliberately left as `UnroutableTaskException` — with a decision, not just code (see `tasks/mind-stt-tts-routing-plan.md` for the investigation and `tasks/mind-stt-tts-routing-todo.md` for the resolved checklist).

**Decision (Path A)**: `feature_mind` has exactly one speech engine (whisper.cpp, explicitly pinned per `MindSpeechBridge`'s own doc comment — "not a claim that a second speech engine is coming... not as a plugin system") and no TTS engine at all. A `TaskModelRouter`-style chooser here would have one option — abstraction with nothing to select. Instead: `SpeechTaskAvailability` + `SpeechTaskAvailabilityChecker`, a truthful yes/no descriptor.

- `speechToText`: available iff the bridge loads and the model is installed — checked without side effects (no download, no `MindService` instance).
- `textToSpeech`: always unavailable. The existing accessibility TTS (`app/lib/core/accessibility/airo_speech_service.dart`) is a separate product surface and is **not** surfaced here — doing so would claim a capability Mind doesn't have.

Checked `device_capability_report_screen.dart` and `model_health_center_screen.dart` for an existing inline check to replace (per the plan) — neither has one (they're the LLM/chat side, unrelated to the scribe), so no caller was wired. Export + tests are the deliverable, not a forced UI hookup.

`core_ai`/`TaskModelRouter`/`AiTask` are untouched — confirmed via `git diff packages/core_ai` before commit.

## Test plan
- [x] `cd packages/feature_mind && flutter analyze` — clean
- [x] `cd packages/feature_mind && flutter test` — 365/365 (4 new)
- [x] `cd app && flutter analyze` — clean
- [x] `git diff packages/core_ai` — empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)