### PR TITLE
feat(ai-core): EmbeddingGemma catalog + native embedding plugin (#508, Phase 1)

### DIFF
--- a/app/android/app/build.gradle.kts
+++ b/app/android/app/build.gradle.kts
@@ -238,6 +238,20 @@ android {
                     else "src/withoutLitertlm/kotlin",
                 )
             }
+            // Same mechanism as LiteRT-LM above, a separate flag and a
+            // separate plugin (embeddings/semantic search -- see
+            // docs/superpowers/specs/2026-08-09-mind-scribe-semantic-search.md).
+            // Excluded from the Coins variant for the same reason LiteRT-LM
+            // is: Coins is a stripped-down flavor with no Mind surface to
+            // search.
+            val embeddingAvailable =
+                rootProject.extra.get("embeddingAvailable") as Boolean
+            if (!isCoinsVariant) {
+                kotlin.srcDir(
+                    if (embeddingAvailable) "src/withEmbedding/kotlin"
+                    else "src/withoutEmbedding/kotlin",
+                )
+            }
         }
     }
 
@@ -320,6 +334,18 @@ dependencies {
     // Contents.of, ConversationConfig) per developers.google.com/edge/litert-lm.
     if (!isCoinsVariant && rootProject.extra.get("liteRtLmAvailable") as Boolean) {
         implementation("com.google.ai.edge.litertlm:litertlm-android:0.15.0")
+    }
+
+    // AI Edge RAG SDK, for on-device text embeddings (semantic search --
+    // docs/superpowers/specs/2026-08-09-mind-scribe-semantic-search.md). A
+    // separate dependency from LiteRT-LM above: different Gradle coordinate,
+    // different native API (GeckoEmbeddingModel/Embedder<String>, not
+    // Engine/Conversation). Pinned explicitly, same reasoning as LiteRT-LM's
+    // pin above — see this file's LiteRT-LM comment for the incident that
+    // pin exists to prevent.
+    if (!isCoinsVariant && rootProject.extra.get("embeddingAvailable") as Boolean) {
+        implementation("com.google.ai.edge.localagents:localagents-rag:0.1.0")
+        implementation("com.google.mediapipe:tasks-genai:0.10.22")
     }
 
     if (!isCoinsVariant) {

--- a/app/android/app/src/product/kotlin/io/airo/app/MainActivity.kt
+++ b/app/android/app/src/product/kotlin/io/airo/app/MainActivity.kt
@@ -39,6 +39,7 @@ class MainActivity : AudioServiceFragmentActivity() {
     private val GEMINI_NANO_CHANNEL = "com.airo.gemini_nano"
     private val GEMINI_NANO_EVENT_CHANNEL = "com.airo.gemini_nano/stream"
     private val LITERT_LM_CHANNEL = "com.airo.litert_lm"
+    private val EMBEDDING_CHANNEL = "com.airo.embedding"
     private val AGENT_CONNECTORS_CHANNEL = "com.airo.agent_connectors"
     private val DEVICE_INFO_CHANNEL = "com.airo/device_info"
     private val CALENDAR_READ_PERMISSION_REQUEST = 9001
@@ -81,6 +82,9 @@ class MainActivity : AudioServiceFragmentActivity() {
 
         MethodChannel(flutterEngine.dartExecutor.binaryMessenger, LITERT_LM_CHANNEL)
             .setMethodCallHandler(LiteRtLmPlugin(this))
+
+        MethodChannel(flutterEngine.dartExecutor.binaryMessenger, EMBEDDING_CHANNEL)
+            .setMethodCallHandler(EmbeddingPlugin(this))
 
         MethodChannel(flutterEngine.dartExecutor.binaryMessenger, DEVICE_INFO_CHANNEL)
             .setMethodCallHandler { call, result ->

--- a/app/android/app/src/withEmbedding/kotlin/io/airo/app/EmbeddingPlugin.kt
+++ b/app/android/app/src/withEmbedding/kotlin/io/airo/app/EmbeddingPlugin.kt
@@ -1,0 +1,101 @@
+package io.airo.app
+
+import android.content.Context
+import android.util.Log
+import androidx.annotation.NonNull
+import com.google.ai.edge.localagents.rag.models.GeckoEmbeddingModel
+import io.flutter.plugin.common.MethodCall
+import io.flutter.plugin.common.MethodChannel
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import java.util.Optional
+
+/**
+ * Flutter MethodChannel bridge for on-device text embeddings, via Google's
+ * AI Edge RAG SDK (`GeckoEmbeddingModel`).
+ *
+ * A separate plugin from `LiteRtLmPlugin.kt` on purpose: EmbeddingGemma is
+ * not published as a `.litertlm` package (raw `.tflite` + a
+ * `sentencepiece.model` tokenizer instead), so it needs a different loader
+ * and a different SDK entirely
+ * (`docs/superpowers/specs/2026-08-09-mind-scribe-semantic-search.md`).
+ *
+ * VERIFICATION NEEDED before this ships: `GeckoEmbeddingModel`'s embed-call
+ * method name/signature below (`computeEmbeddings`) is inferred from the AI
+ * Edge RAG SDK's `Embedder<String>` interface convention (a
+ * `ListenableFuture`-returning async call, per Google's published samples
+ * for this SDK family) -- the public Android integration guide did not show
+ * a direct code sample for extracting a vector, only the constructor. Check
+ * this against the actual `com.google.ai.edge.localagents:localagents-rag`
+ * AAR's public API (e.g. via Android Studio's decompiled sources or the
+ * SDK's own javadoc) before merging. If the real method differs, only this
+ * one call site needs to change -- everything else in this file (channel
+ * contract, lifecycle, error handling) does not depend on the exact name.
+ */
+class EmbeddingPlugin(private val context: Context) : MethodChannel.MethodCallHandler {
+    companion object {
+        private const val TAG = "EmbeddingPlugin"
+    }
+
+    private val coroutineScope = CoroutineScope(Dispatchers.Main)
+    private var embedder: GeckoEmbeddingModel? = null
+
+    override fun onMethodCall(@NonNull call: MethodCall, @NonNull result: MethodChannel.Result) {
+        when (call.method) {
+            "initialize" -> initialize(call, result)
+            "isReady" -> result.success(embedder != null)
+            "embed" -> embed(call, result)
+            else -> result.notImplemented()
+        }
+    }
+
+    private fun initialize(call: MethodCall, result: MethodChannel.Result) {
+        coroutineScope.launch {
+            try {
+                val modelPath = call.argument<String>("modelPath")
+                    ?: throw IllegalArgumentException("modelPath is required")
+                val tokenizerPath = call.argument<String>("tokenizerPath")
+                    ?: throw IllegalArgumentException("tokenizerPath is required")
+                val useGpu = call.argument<Boolean>("useGpu") ?: false
+
+                withContext(Dispatchers.IO) {
+                    embedder = GeckoEmbeddingModel(
+                        modelPath,
+                        Optional.of(tokenizerPath),
+                        useGpu,
+                    )
+                }
+
+                result.success(null)
+            } catch (e: Exception) {
+                Log.e(TAG, "Embedding model initialization failed: ${e.message}", e)
+                embedder = null
+                result.error("INITIALIZATION_FAILED", e.message, null)
+            }
+        }
+    }
+
+    private fun embed(call: MethodCall, result: MethodChannel.Result) {
+        coroutineScope.launch {
+            try {
+                val text = call.argument<String>("text")
+                    ?: throw IllegalArgumentException("text is required")
+
+                val vector = withContext(Dispatchers.IO) {
+                    val activeEmbedder = embedder
+                        ?: throw IllegalStateException("Embedding model is not initialized")
+                    // See the class doc: this call needs verification against
+                    // the real AAR before shipping.
+                    activeEmbedder.computeEmbeddings(text).get()
+                }
+
+                result.success(vector.toList())
+            } catch (e: Exception) {
+                Log.e(TAG, "Embedding generation failed: ${e.message}", e)
+                result.error("EMBEDDING_FAILED", e.message, null)
+            }
+        }
+    }
+}

--- a/app/android/app/src/withoutEmbedding/kotlin/io/airo/app/EmbeddingPlugin.kt
+++ b/app/android/app/src/withoutEmbedding/kotlin/io/airo/app/EmbeddingPlugin.kt
@@ -1,0 +1,32 @@
+package io.airo.app
+
+import android.content.Context
+import androidx.annotation.NonNull
+import io.flutter.plugin.common.MethodCall
+import io.flutter.plugin.common.MethodChannel
+
+/**
+ * Stub replacement for the real embedding plugin, compiled in when
+ * `com.google.ai.edge.localagents:localagents-rag` is not available
+ * (`AIRO_USE_EMBEDDING_STUB=true` -- see `app/android/build.gradle.kts`).
+ *
+ * The Dart side (`EmbeddingService`, `core_ai`) treats `isReady -> false` as
+ * "no embedding model available" and falls back to keyword-only search
+ * (`SemanticSearchRanker`), so every method here reports the feature as
+ * unavailable instead of throwing.
+ */
+class EmbeddingPlugin(@Suppress("UNUSED_PARAMETER") private val context: Context) :
+    MethodChannel.MethodCallHandler {
+    override fun onMethodCall(@NonNull call: MethodCall, @NonNull result: MethodChannel.Result) {
+        when (call.method) {
+            "isReady" -> result.success(false)
+            "initialize", "embed" ->
+                result.error(
+                    "EMBEDDING_UNAVAILABLE",
+                    "The embedding plugin is not linked in this build.",
+                    null,
+                )
+            else -> result.notImplemented()
+        }
+    }
+}

--- a/app/android/build.gradle.kts
+++ b/app/android/build.gradle.kts
@@ -12,6 +12,19 @@ if (!liteRtLmAvailable) {
     logger.warn("AIRO_USE_LITERT_STUB=true — using the LiteRT-LM stub backend.")
 }
 
+// Same mechanism, a different dependency: the AI Edge RAG SDK
+// (embeddings, semantic search -- see
+// docs/superpowers/specs/2026-08-09-mind-scribe-semantic-search.md). A
+// separate flag rather than reusing liteRtLmAvailable: this is a distinct
+// Gradle dependency and a distinct native plugin, and toggling one must not
+// silently toggle the other.
+val embeddingAvailable: Boolean = System.getenv("AIRO_USE_EMBEDDING_STUB") != "true"
+extra["embeddingAvailable"] = embeddingAvailable
+
+if (!embeddingAvailable) {
+    logger.warn("AIRO_USE_EMBEDDING_STUB=true — using the embedding stub backend.")
+}
+
 allprojects {
     repositories {
         google()

--- a/docs/superpowers/specs/2026-08-09-mind-scribe-semantic-search.md
+++ b/docs/superpowers/specs/2026-08-09-mind-scribe-semantic-search.md
@@ -1,0 +1,207 @@
+# Semantic search for the Mind scribe (#508)
+
+## Objective
+
+Add semantic ranking on top of the scribe's existing full-text search
+(`searchMeetings`, Rust-side FTS over transcript + minutes), so a query like
+"the pricing discussion" surfaces a meeting that never used those exact words.
+
+**Target user**: someone with more than a screenful of recorded meetings, who
+remembers what a conversation was *about* but not the words used in it.
+
+**Scope, resolved after investigation** (see "What was ruled out" below):
+scribe meetings only (`MeetingRecord`/`searchMeetings`), not the Mind Runtime's
+`ProjectionPort.search`. Keyword search stays authoritative; semantic scoring
+re-ranks and supplements it. This is a smaller slice than #508's literal
+listed targets (Transcript, Summary, Participants, Topics, Projects, Tasks) —
+those live in the Mind Runtime, which has no working search backend yet (see
+below). Extending to the runtime is future work, not this spec.
+
+## What was ruled out, and why
+
+- **`ProjectionPort.search` (the Mind Runtime's graph/timeline/search
+  primitive)**: its own doc comment says "ranked locally by embedding plus
+  keyword" — the eventual design already matches this spec's shape — but
+  `RustMindRuntime`'s implementation is a stub (`_pending`, tracked by
+  #1218/#1219/#1220). #1220 (the search projection itself) depends on #1218
+  (replay pipeline), which depends on #1194 (Operation Log) and #1196
+  (Capability SDK). None of the four are built. `FixtureMindRuntime` is the
+  only working implementation today. Building semantic ranking on top of a
+  stub is building on a foundation that doesn't exist.
+- **A new Rust embedding engine inside `feature_mind`** (a third cdylib
+  alongside whisper/llama): rejected — a native Android SDK already does
+  exactly this (see Architecture), and adding a Rust engine would mean a
+  *second* new native surface for the same feature.
+- **Reusing `LiteRtLmPlugin.kt`'s existing `Engine`/`Conversation` API**
+  (this spec's first draft assumed this): investigated and ruled out.
+  EmbeddingGemma is not published as a `.litertlm` package — the
+  `litert-community/embeddinggemma-300m` HuggingFace repo has only raw
+  `.tflite` files (chip-specific and generic variants) plus a
+  `sentencepiece.model` tokenizer. `.litertlm` is what `LiteRtLmPlugin.kt`
+  loads via LiteRT-LM's `Engine`/`Conversation` API; a raw `.tflite` needs a
+  different loader. Confirmed before writing any Kotlin.
+- **`AiTask`/`TaskModelRouter` gains a new task for this**: not needed.
+  `AiTask.embeddings` already exists (PR #1564) and is exactly the right
+  shape — this spec is the first real caller of it, not a reason to add
+  another.
+
+## Architecture
+
+```
+MeetingRecord (transcript + minutes)
+        │
+        ▼
+EmbeddingService.embed(text) -> List<double>          [new, core_ai]
+        │  backed by a new EmbeddingPlugin method channel
+        │  wrapping Google's AI Edge RAG SDK GeckoEmbeddingModel [new native plugin]
+        │  resolved via TaskModelRouter(AiTask.embeddings, installed)
+        ▼
+MeetingEmbeddingStore                                  [new, feature_mind]
+   - one vector per meeting, keyed by meeting id
+   - persisted locally (see Storage)
+        │
+        ▼
+SemanticSearchRanker.rank(query, keywordHits)          [new, feature_mind]
+   - embeds the query
+   - cosine-similarity against stored vectors
+   - merges with searchMeetings' keyword hits (union, not replacement --
+     a keyword match a query didn't semantically resemble is still a real
+     match and must not disappear)
+        │
+        ▼
+MindHomeScreen's existing search box                   [existing, unchanged call site --
+                                                          only what backs it changes]
+```
+
+### The real native path — Google AI Edge RAG SDK, not LiteRT-LM
+
+Confirmed by reading the actual Android integration guide (not assumed):
+Google publishes an **AI Edge RAG SDK** (`com.google.ai.edge.localagents:localagents-rag:0.1.0`,
+alongside `com.google.mediapipe:tasks-genai:0.10.22`) with a `GeckoEmbeddingModel`
+class built exactly for this: `GeckoEmbeddingModel(modelPath, Optional.of(tokenizerPath), useGpu)`,
+consuming a `.tflite` file plus a `sentencepiece.model` tokenizer — precisely
+the file shape `litert-community/embeddinggemma-300m` ships. Output is a
+768-dimension vector.
+
+This is a **new native plugin**, not an addition to `LiteRtLmPlugin.kt` —
+different Gradle dependency, different Android API surface
+(`Embedder<String>`, not `Engine`/`Conversation`). Real new-dependency cost:
+one new AAR pair (small, code only) and a `ModelCatalog` entry for
+`embeddinggemma-300M_seq256_mixed-precision.tflite` (~179 MB, generic/
+no-chip-suffix variant — chosen over chip-specific variants for one
+consistent choice, and over longer `seq512`/`seq1024`/`seq2048` variants
+since search queries and meeting-chunk embeddings are short text).
+
+**Not bundled in the APK.** Same distribution as every other `ModelCatalog`
+entry (`ADR-0018 §1`/`§2` — neither app ships model weights in the binary):
+the model is a `ModelDownloadService` download the user opts into, discovered
+through the existing model-library UI the same way chat models already are —
+a card with a download button, not an automatic fetch. Semantic search
+degrades to keyword-only (see `SemanticSearchRanker`) until the user chooses
+to download it. The new Gradle/AAR dependency (code, not model weights) does
+land in the APK regardless of whether the user ever downloads the model —
+that part isn't optional the way the model itself is, and is the actual
+"deserves review before landing" cost (`chief-open-source-officer`'s usual
+scope for a new third-party dependency).
+
+### Storage
+
+Meeting count for a personal scribe is expected to stay in the hundreds, not
+millions. Brute-force cosine similarity over an in-memory list of vectors,
+loaded from a small local file (one JSON array per meeting, or a Drift table
+if `feature_mind` already has a local db dependency — check before adding
+one) is sufficient. No ANN index (e.g. HNSW) in this spec — premature for the
+expected scale, and it would be new infrastructure with no evidence it's
+needed yet.
+
+Embeddings regenerate, not sync: if the embedding model changes, existing
+vectors are stale and must be recomputed, not migrated. Store the model id
+that produced each vector (mirrors `ADR-0018 §5`'s "record what produced
+this, don't infer it later" pattern already used for `MeetingRecord.model`)
+so a version mismatch is detectable rather than silently wrong.
+
+## Commands
+
+```bash
+# feature_mind (new store, ranker)
+cd packages/feature_mind && flutter analyze && flutter test
+
+# core_ai (new EmbeddingService, ModelCatalog entry, EmbeddingClient)
+cd packages/core_ai && flutter analyze && flutter test
+
+# Android native change (new plugin, new Gradle dependency)
+cd app/android && ./gradlew :app:compileDebugKotlin   # exact task/module TBD
+
+# Full regression
+cd app && flutter analyze && flutter test
+```
+
+## Project Structure (files likely touched)
+
+- `packages/core_ai/lib/src/registry/model_catalog.dart` — add EmbeddingGemma
+  entry, `ModelCapability.embeddings`.
+- `packages/core_ai/lib/src/embeddings/embedding_client.dart` (new) — Dart
+  interface + `MethodChannel` implementation, mirrors `LiteRtLmClient`'s
+  shape but its own channel/plugin.
+- `app/android/app/src/.../EmbeddingPlugin.kt` (new — exact flavor source
+  set TBD, likely mirrors `withLitertlm`/`withoutLitertlm`'s split since this
+  is also a large optional native dependency) — wraps `GeckoEmbeddingModel`.
+- `app/android/app/build.gradle.kts` — add
+  `com.google.ai.edge.localagents:localagents-rag` +
+  `com.google.mediapipe:tasks-genai` dependencies.
+- `packages/core_ai/lib/src/embeddings/embedding_service.dart` (new) —
+  wraps `TaskModelRouter` + `EmbeddingClient`.
+- `packages/feature_mind/lib/src/search/meeting_embedding_store.dart` (new).
+- `packages/feature_mind/lib/src/search/semantic_search_ranker.dart` (new).
+- `packages/feature_mind/lib/src/mind_service.dart` — `search()` gains
+  semantic re-ranking, same public signature.
+- Tests alongside each new file.
+
+## Code Style
+
+Match what's already in `feature_mind`/`core_ai`: `@immutable` value types,
+constructor-injected collaborators defaulting to production implementations
+(the `ModelProvider`/`MindSpeechBridge` pattern), doc comments that explain
+*why* a design choice was made, not what the code does. No new state
+management framework — this is plain Dart classes, consistent with
+`MindService`.
+
+## Testing Strategy
+
+- `EmbeddingService`: fake `EmbeddingClient`/`TaskModelRouter`, no real model
+  load in unit tests (mirrors `download_model_provider_test.dart`'s no-real-
+  network approach).
+- `MeetingEmbeddingStore`: round-trip persistence, stale-model-id detection.
+- `SemanticSearchRanker`: keyword-only hit surfaces even with no embedding
+  match (union, not replacement) — this is the one behavior most likely to
+  regress silently if reimplemented carelessly, so it gets its own explicit
+  test, not just a snapshot of combined output.
+- No test may require a real on-device model or network access.
+
+## Boundaries
+
+- **Always**: keep `searchMeetings`'s keyword results in the final output.
+  Semantic scoring may reorder and add, never remove, a keyword match.
+- **Ask first**: any change to `ModelCatalog`'s existing entries, any new
+  native platform channel method beyond `embed`, moving this to sync across
+  devices (out of scope — embeddings are local-only, regenerable, and not an
+  op-log entity).
+- **Never**: touch `packages/core_ai/lib/src/router/task_model_router.dart`
+  or `ai_task.dart` for this — `AiTask.embeddings` already has the right
+  shape. Never add a vector index/ANN library without first confirming the
+  brute-force approach is actually too slow (measured, not assumed). Never
+  wire this into `ProjectionPort.search` until #1220 has a real
+  implementation — this spec's `MindService.search()` integration point is
+  deliberately the scribe's existing surface, not the runtime's.
+
+## Open Questions
+
+- Exact Android flavor source-set split for `EmbeddingPlugin.kt` — mirror
+  `withLitertlm`/`withoutLitertlm`, or does this new dependency warrant its
+  own flag? Decide during implementation, not guessed here.
+- Whether `feature_mind` already has a local db (Drift) dependency suitable
+  for the embedding store, or whether a flat file is simpler — check before
+  choosing.
+- Exact `Embedder<String>`/`GeckoEmbeddingModel` method signature for
+  extracting a vector (the Android guide didn't show a direct code sample) —
+  confirm against the actual AAR's API during implementation.

--- a/packages/core_ai/lib/core_ai.dart
+++ b/packages/core_ai/lib/core_ai.dart
@@ -25,6 +25,7 @@ export 'src/runtime/gemini_nano_service.dart' hide DeviceInfo, GenerationResult;
 export 'src/runtime/litert_lm_service.dart';
 export 'src/runtime/model_learn_more_launcher.dart';
 export 'src/litert/litert_lm_runtime_adapter.dart';
+export 'src/embeddings/embedding_client.dart';
 export 'src/litert/litert_lm_execution_adapter.dart';
 export 'src/litert/mediapipe_web_runtime_adapter.dart';
 

--- a/packages/core_ai/lib/src/embeddings/embedding_client.dart
+++ b/packages/core_ai/lib/src/embeddings/embedding_client.dart
@@ -1,0 +1,92 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+
+/// Loads an on-device text embedding model and turns text into vectors.
+///
+/// Backed by a **separate** native plugin from `LiteRtLmClient`'s
+/// (`docs/superpowers/specs/2026-08-09-mind-scribe-semantic-search.md`):
+/// EmbeddingGemma is not published as a `.litertlm` package, so it cannot go
+/// through `LiteRtLmPlugin.kt`'s `Engine`/`Conversation` API. This wraps
+/// Google's AI Edge RAG SDK (`GeckoEmbeddingModel`) instead, over its own
+/// method channel.
+abstract class EmbeddingClient {
+  /// Loads the model. [modelPath] and [tokenizerPath] are supplied by the
+  /// caller (the already-downloaded files' locations) — this client never
+  /// acquires a model itself, the same boundary `ModelProvider` draws for
+  /// every other model in this app.
+  Future<void> initialize({
+    required String modelPath,
+    required String tokenizerPath,
+    bool useGpu = false,
+  });
+
+  /// True once [initialize] has succeeded and the model is ready to embed.
+  Future<bool> isReady();
+
+  /// Turns [text] into its embedding vector. Throws if [initialize] has not
+  /// succeeded — callers that want a non-throwing "is this available" check
+  /// should call [isReady] first (mirrors `EmbeddingService`'s contract,
+  /// which is where that check actually lives for real callers).
+  Future<List<double>> embed({required String text});
+}
+
+/// Channel name is distinct from `com.airo.litert_lm`: a different plugin,
+/// a different SDK, a different failure mode (this one can be entirely
+/// absent from a build without affecting chat at all).
+class MethodChannelEmbeddingClient implements EmbeddingClient {
+  MethodChannelEmbeddingClient({
+    this.operationTimeout = const Duration(seconds: 30),
+    MethodChannel? channel,
+  }) : _channel = channel ?? const MethodChannel('com.airo.embedding');
+
+  final Duration operationTimeout;
+  final MethodChannel _channel;
+
+  @override
+  Future<void> initialize({
+    required String modelPath,
+    required String tokenizerPath,
+    bool useGpu = false,
+  }) async {
+    await _channel
+        .invokeMethod<void>('initialize', {
+          'modelPath': modelPath,
+          'tokenizerPath': tokenizerPath,
+          'useGpu': useGpu,
+        })
+        .timeout(operationTimeout);
+  }
+
+  @override
+  Future<bool> isReady() async {
+    try {
+      final ready = await _channel
+          .invokeMethod<bool>('isReady')
+          .timeout(operationTimeout);
+      return ready ?? false;
+    } on PlatformException catch (e) {
+      debugPrint('Embedding isReady check failed: ${e.message}');
+      return false;
+    } on MissingPluginException {
+      // No plugin registered for this build (the stub flavor, or a flavor
+      // that never wires the channel at all) -- not ready, not an error.
+      return false;
+    } on TimeoutException {
+      debugPrint('Embedding isReady check timed out.');
+      return false;
+    }
+  }
+
+  @override
+  Future<List<double>> embed({required String text}) async {
+    final result = await _channel
+        .invokeMethod<List<Object?>>('embed', {'text': text})
+        .timeout(operationTimeout);
+    if (result == null) {
+      throw StateError('Embedding plugin returned no vector for "$text"');
+    }
+    return result.cast<num>().map((v) => v.toDouble()).toList();
+  }
+}

--- a/packages/core_ai/lib/src/registry/model_catalog.dart
+++ b/packages/core_ai/lib/src/registry/model_catalog.dart
@@ -355,6 +355,67 @@ class ModelCatalog {
     // and SmolLM2-360M as .litertlm only (no .task file), and does not
     // publish a 1.7B variant at all, as of 2026-07-19. Re-check before
     // adding a web catalog entry for SmolLM2.
+
+    // EmbeddingGemma: the only catalog entry for AiTask.embeddings
+    // (docs/superpowers/specs/2026-08-09-mind-scribe-semantic-search.md).
+    // Ships as raw .tflite + a separate sentencepiece.model tokenizer, not
+    // the .litertlm package format every other entry above uses -- it is
+    // loaded through a different native plugin (Google's AI Edge RAG SDK,
+    // GeckoEmbeddingModel), not the LiteRT-LM Engine/Conversation plugin.
+    // `seq256` (not the longer seq512/seq1024/seq2048 variants) because
+    // search queries and meeting-chunk text are short. The generic
+    // (no-chip-suffix) build, not a chip-specific one, for one consistent
+    // download regardless of device silicon.
+    const OfflineModelInfo(
+      id: 'embeddinggemma-300m-embed',
+      name: 'EmbeddingGemma-300M',
+      family: ModelFamily.gemma,
+      fileSizeBytes: 187695104, // 179 MB, litert-community/embeddinggemma-300m
+      downloadUrl:
+          'https://huggingface.co/litert-community/embeddinggemma-300m/resolve/main/embeddinggemma-300M_seq256_mixed-precision.tflite',
+      quantization:
+          ModelQuantization.unknown, // mixed-precision, not a flat Q-level
+      parameterCount: 308000000,
+      contextLength: 256,
+      credibility: ModelCredibility.official,
+      provider: AIProvider.gemma,
+      description:
+          'On-device text embeddings for semantic search. Needs the paired '
+          "embeddinggemma-300m-tokenizer entry; TaskModelRouter resolves "
+          'AiTask.embeddings to this entry, never the tokenizer.',
+      author: 'Google',
+      license: 'Gemma',
+      huggingFaceId: 'litert-community/embeddinggemma-300m',
+      modalities: [ModelModality.text],
+      capabilities: [ModelCapability.embeddings],
+      tags: ['embeddings', 'semantic-search', 'gecko', 'rag'],
+      minMemoryBytes: 500000000,
+      recommendedMemoryBytes: 700000000,
+    ),
+    // The tokenizer EmbeddingGemma needs alongside the model above.
+    // Deliberately zero capabilities: TaskModelRouter.resolve matches on
+    // ModelCapability, and this must never be handed back as the answer to
+    // AiTask.embeddings -- it cannot produce an embedding by itself.
+    const OfflineModelInfo(
+      id: 'embeddinggemma-300m-tokenizer',
+      name: 'EmbeddingGemma-300M tokenizer',
+      family: ModelFamily.gemma,
+      fileSizeBytes: 4908892, // 4.68 MB, same HuggingFace repo
+      downloadUrl:
+          'https://huggingface.co/litert-community/embeddinggemma-300m/resolve/main/sentencepiece.model',
+      quantization: ModelQuantization.unknown,
+      credibility: ModelCredibility.official,
+      provider: AIProvider.gemma,
+      description:
+          'SentencePiece tokenizer required by embeddinggemma-300m-embed. '
+          'Not independently useful -- not routable via any AiTask.',
+      author: 'Google',
+      license: 'Gemma',
+      huggingFaceId: 'litert-community/embeddinggemma-300m',
+      modalities: [],
+      capabilities: [],
+      tags: ['embeddings', 'tokenizer', 'embeddinggemma-300m-embed'],
+    ),
   ];
 
   /// Gets recommended models for mobile devices (< 3GB).

--- a/packages/core_ai/test/embeddings/embedding_client_test.dart
+++ b/packages/core_ai/test/embeddings/embedding_client_test.dart
@@ -1,0 +1,96 @@
+import 'package:core_ai/src/embeddings/embedding_client.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const channel = MethodChannel('test.embedding');
+  final messenger =
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger;
+
+  tearDown(() => messenger.setMockMethodCallHandler(channel, null));
+
+  group('MethodChannelEmbeddingClient', () {
+    test('initialize forwards the model and tokenizer paths', () async {
+      MethodCall? captured;
+      messenger.setMockMethodCallHandler(channel, (call) async {
+        captured = call;
+        return null;
+      });
+
+      final client = MethodChannelEmbeddingClient(channel: channel);
+      await client.initialize(
+        modelPath: '/models/embed.tflite',
+        tokenizerPath: '/models/sentencepiece.model',
+        useGpu: true,
+      );
+
+      expect(captured?.method, 'initialize');
+      expect(captured?.arguments, {
+        'modelPath': '/models/embed.tflite',
+        'tokenizerPath': '/models/sentencepiece.model',
+        'useGpu': true,
+      });
+    });
+
+    test('embed converts the native vector to a List<double>', () async {
+      messenger.setMockMethodCallHandler(channel, (call) async {
+        expect(call.method, 'embed');
+        expect(call.arguments, {'text': 'hello'});
+        return [0.1, 0.2, 0.3];
+      });
+
+      final client = MethodChannelEmbeddingClient(channel: channel);
+      final vector = await client.embed(text: 'hello');
+
+      expect(vector, [0.1, 0.2, 0.3]);
+    });
+
+    test('embed throws when the native side returns nothing', () async {
+      messenger.setMockMethodCallHandler(channel, (call) async => null);
+
+      final client = MethodChannelEmbeddingClient(channel: channel);
+
+      expect(() => client.embed(text: 'hello'), throwsStateError);
+    });
+
+    test(
+      'isReady is false, not an error, when no plugin is registered',
+      () async {
+        // No handler set at all -- this is exactly what a build without the
+        // embedding plugin (the stub flavor) looks like from Dart's side.
+        final client = MethodChannelEmbeddingClient(channel: channel);
+
+        expect(await client.isReady(), isFalse);
+      },
+    );
+
+    test(
+      'isReady is false when the native side reports a platform error',
+      () async {
+        messenger.setMockMethodCallHandler(channel, (call) async {
+          throw PlatformException(code: 'NOT_INITIALIZED');
+        });
+
+        final client = MethodChannelEmbeddingClient(channel: channel);
+
+        expect(await client.isReady(), isFalse);
+      },
+    );
+
+    test('a wedged native call is bounded by the timeout', () async {
+      messenger.setMockMethodCallHandler(channel, (call) async {
+        await Future<void>.delayed(const Duration(milliseconds: 100));
+        return true;
+      });
+
+      final client = MethodChannelEmbeddingClient(
+        channel: channel,
+        operationTimeout: const Duration(milliseconds: 10),
+      );
+
+      expect(await client.isReady(), isFalse);
+    });
+  });
+}

--- a/packages/core_ai/test/registry/model_catalog_test.dart
+++ b/packages/core_ai/test/registry/model_catalog_test.dart
@@ -57,4 +57,45 @@ void main() {
       expect(webModels.every((m) => m.supportsWebRuntime), isTrue);
     });
   });
+
+  group('EmbeddingGemma catalog entry', () {
+    test('declares only the embeddings capability', () {
+      final model = ModelCatalog.bundledModels.firstWhere(
+        (m) => m.id == 'embeddinggemma-300m-embed',
+      );
+
+      expect(model.capabilities, [ModelCapability.embeddings]);
+      expect(model.fileSizeBytes, 187695104);
+      expect(model.downloadUrl, endsWith('.tflite'));
+    });
+
+    test('TaskModelRouter resolves AiTask.embeddings to the embed entry, '
+        'never the tokenizer', () {
+      const router = TaskModelRouter();
+
+      final resolved = router.resolve(
+        AiTask.embeddings,
+        ModelCatalog.bundledModels,
+      );
+
+      expect(resolved?.id, 'embeddinggemma-300m-embed');
+    });
+
+    test('the tokenizer entry is not routable via any AiTask', () {
+      final tokenizer = ModelCatalog.bundledModels.firstWhere(
+        (m) => m.id == 'embeddinggemma-300m-tokenizer',
+      );
+
+      expect(tokenizer.capabilities, isEmpty);
+      for (final task in AiTask.values.where((t) => t.isCatalogResolvable)) {
+        const router = TaskModelRouter();
+        final resolved = router.resolve(task, [tokenizer]);
+        expect(
+          resolved,
+          isNull,
+          reason: 'the tokenizer must never answer for $task',
+        );
+      }
+    });
+  });
 }

--- a/tasks/mind-scribe-semantic-search-plan.md
+++ b/tasks/mind-scribe-semantic-search-plan.md
@@ -1,0 +1,341 @@
+# Implementation Plan: Semantic search for the Mind scribe (#508)
+
+Spec: `docs/superpowers/specs/2026-08-09-mind-scribe-semantic-search.md`.
+
+## Overview
+
+Add semantic re-ranking on top of the scribe's existing keyword search
+(`searchMeetings`, Rust FTS), using Google's AI Edge RAG SDK
+(`GeckoEmbeddingModel`) to generate embeddings from the EmbeddingGemma model —
+a new native plugin, not an extension of the existing LiteRT-LM chat plugin
+(that assumption was investigated and ruled out — see Architecture Decisions).
+Keyword hits stay authoritative; semantic scoring adds and reorders, never
+removes. The model is a `ModelDownloadService` download the user opts into,
+same as every other `ModelCatalog` entry — never bundled in the APK.
+
+## Architecture Decisions
+
+- **Google AI Edge RAG SDK (`GeckoEmbeddingModel`), not `LiteRtLmPlugin.kt`** —
+  the first draft of this plan assumed reusing the existing LiteRT-LM
+  `Engine`/`Conversation` plugin by adding one `embed` method. Investigated
+  and ruled out: EmbeddingGemma ships as raw `.tflite` + `sentencepiece.model`
+  files, not the `.litertlm` package format `LiteRtLmPlugin.kt` loads. The
+  real integration is Google's `com.google.ai.edge.localagents:localagents-rag`
+  SDK's `GeckoEmbeddingModel(modelPath, Optional.of(tokenizerPath), useGpu)`,
+  a different Gradle dependency and a different native API surface
+  (`Embedder<String>`). This means a **new** native plugin, not a small
+  addition to an existing one — real new-dependency cost (new AAR pair),
+  flagged for review before landing.
+- **Not bundled in the APK** — the model (`embeddinggemma-300M_seq256_mixed-precision.tflite`,
+  ~179 MB, generic/no-chip-suffix variant, chosen for short-text queries over
+  longer `seq512`+ variants) downloads through the existing
+  `ModelDownloadService`/model-library UI, same as every other catalog entry.
+  Only the SDK's code (small) ships in the APK unconditionally.
+- **Brute-force cosine similarity, flat file storage** — meeting counts are
+  expected in the hundreds for a personal scribe; no ANN index, no new db
+  dependency (confirmed `feature_mind` has no Drift/sqflite today — a new
+  local store must justify its own weight, or stay a flat file).
+- **Union merge, not replacement** — a keyword match a query doesn't
+  semantically resemble is still a real match. This is the one behavior most
+  likely to regress silently, so it gets a dedicated test (Task 5).
+- **`AiTask.embeddings`/`TaskModelRouter` untouched** — already the right
+  shape from PR #1564; this is their first real caller, not a reason to
+  change them.
+
+## Dependency Graph
+
+```
+ModelCatalog: EmbeddingGemma entry           (Task 1, core_ai)
+        │
+        ├── EmbeddingClient (new plugin)      (Task 2, core_ai — Dart interface
+        │       │                              + MethodChannel implementation)
+        │       │
+        │       └── Android: new EmbeddingPlugin.kt
+        │             wrapping GeckoEmbeddingModel, new Gradle dependency
+        │             (com.google.ai.edge.localagents:localagents-rag +
+        │              com.google.mediapipe:tasks-genai)
+        │             (Task 2, native — flavor source-set split TBD)
+        │
+        └── EmbeddingService                  (Task 3, core_ai)
+                (wraps TaskModelRouter(AiTask.embeddings) + EmbeddingClient)
+                │
+                ▼
+        MeetingEmbeddingStore                 (Task 4, feature_mind)
+        (persist + load vectors, keyed by meeting id + model id)
+                │
+                ▼
+        SemanticSearchRanker                  (Task 5, feature_mind)
+        (embed query, cosine-similarity, union-merge with keyword hits)
+                │
+                ▼
+        MindService.search()                  (Task 6, feature_mind)
+        (existing signature; internals call the ranker)
+```
+
+Bottom-up order: the native/model layer must exist before anything in
+`feature_mind` can be tested against real behavior (though each Dart layer
+is unit-testable against fakes independently — see Testing Strategy).
+
+## Task List
+
+### Phase 1: Embedding generation (core_ai + new native plugin)
+
+- [ ] **Task 1: Add EmbeddingGemma to ModelCatalog**
+
+  **Description:** Add a real `OfflineModelInfo` entry for
+  `litert-community/embeddinggemma-300m`'s `embeddinggemma-300M_seq256_mixed-precision.tflite`
+  (~179 MB) plus its `sentencepiece.model` tokenizer (~4.68 MB — decide how
+  the tokenizer is modeled: a second `OfflineModelInfo`, or a field/companion
+  file on the same entry; check how multi-file models, if any, are already
+  represented in the catalog before inventing a new pattern), tagged
+  `ModelCapability.embeddings`.
+
+  **Acceptance criteria:**
+  - [ ] Entry follows the existing `OfflineModelInfo` shape (real HuggingFace
+        `resolve/main/` download URL, accurate file size, `ModelFamily.gemma`).
+  - [ ] `capabilities: [ModelCapability.embeddings]` only — this model is
+        not a chat model, don't over-tag it.
+  - [ ] Tokenizer file is downloadable/verifiable the same way the model file
+        is (whatever pattern is chosen).
+
+  **Verification:**
+  - [ ] `cd packages/core_ai && flutter analyze && flutter test`
+  - [ ] `TaskModelRouter().resolve(AiTask.embeddings, ModelCatalog.bundledModels)`
+        returns the new entry (add/extend a test for this).
+
+  **Dependencies:** None.
+
+  **Files likely touched:**
+  - `packages/core_ai/lib/src/registry/model_catalog.dart`
+  - `packages/core_ai/test/registry/model_catalog_test.dart` (or wherever
+    catalog tests live — check before creating a new file)
+
+  **Estimated scope:** Small (1-2 files).
+
+### Checkpoint: Task 1
+- [ ] `flutter test` green in `core_ai`.
+- [ ] Manual re-check: URLs/sizes confirmed against
+      `https://huggingface.co/litert-community/embeddinggemma-300m/tree/main`
+      at implementation time, not copied from this plan without re-verifying
+      (model repos change).
+
+- [ ] **Task 2: `EmbeddingClient` — new native plugin (native + Dart)**
+
+  **Description:** New Dart `EmbeddingClient` interface +
+  `MethodChannelEmbeddingClient` implementation, backed by a **new** Android
+  plugin (`EmbeddingPlugin.kt`, exact package/location TBD) wrapping
+  `GeckoEmbeddingModel` from `com.google.ai.edge.localagents:localagents-rag`.
+  Add the Gradle dependency
+  (`com.google.ai.edge.localagents:localagents-rag:0.1.0` +
+  `com.google.mediapipe:tasks-genai:0.10.22`) to `app/android/app/build.gradle.kts`.
+  Confirm `GeckoEmbeddingModel`'s actual embed-call method signature against
+  the real AAR (the public docs didn't show a direct code sample) before
+  finalizing the plugin's method-channel contract.
+
+  **Acceptance criteria:**
+  - [ ] `EmbeddingClient.embed({required String text}) -> Future<List<double>>`.
+  - [ ] Native plugin loads the `.tflite` + `sentencepiece.model` pair from
+        paths supplied by Dart (mirrors how `MindConfig` passes paths rather
+        than the native side assuming a location).
+  - [ ] Decide the flavor source-set story: mirror `withLitertlm`/
+        `withoutLitertlm`'s split (a `withoutEmbedding` stub flavor), or is a
+        runtime "SDK not present" check sufficient? This is a real decision,
+        not a copy of the existing pattern by default — the existing split
+        exists for a specific reason (bundle-size opt-out per flavor); check
+        whether that reason applies here before replicating the mechanism.
+
+  **Verification:**
+  - [ ] `cd packages/core_ai && flutter analyze && flutter test` (Dart side,
+        against a fake channel).
+  - [ ] `cd app/android && ./gradlew :app:compileDebugKotlin` (exact task TBD).
+  - [ ] Manual device check: `embed()` returns a non-empty, fixed-length
+        (768-dimension, per Google's published spec — confirm against the
+        real model) vector for real input on a device with the model
+        installed.
+
+  **Dependencies:** Task 1 (needs a real model to call `embed` against for
+  the manual check, though the Dart interface can be built in parallel).
+
+  **Files likely touched:**
+  - `packages/core_ai/lib/src/embeddings/embedding_client.dart` (new)
+  - `app/android/app/src/.../EmbeddingPlugin.kt` (new; location depends on
+    the flavor-split decision above)
+  - `app/android/app/build.gradle.kts`
+  - Corresponding Dart + (if the native test harness supports it) Kotlin
+    tests.
+
+  **Estimated scope:** Medium-Large (a new plugin end-to-end; genuinely the
+  biggest single task in this plan — consider splitting further once the
+  flavor-split decision is made, if it turns out to touch more than ~5 files).
+
+### Checkpoint: Phase 1
+- [ ] Plugin compiles in whatever flavor(s) it's wired into.
+- [ ] `flutter test` green in `core_ai`.
+- [ ] **Review with human before proceeding** — this phase adds a real new
+      third-party native dependency (Gradle/AAR) to the app. Confirm that's
+      still wanted at this point, not just at spec-approval time, since the
+      concrete size/shape is now known (Task 2's actual diff) rather than
+      estimated.
+
+### Phase 2: Embedding service + storage (core_ai + feature_mind)
+
+- [ ] **Task 3: `EmbeddingService`**
+
+  **Description:** `core_ai` service wrapping `TaskModelRouter().resolve(AiTask.embeddings, installed)`
+  + `EmbeddingClient.embed`. Returns a typed failure (not a thrown exception)
+  when no embedding model is installed — mirrors `MindService.initialize()`'s
+  "return a status, don't throw" pattern for an expected, actionable state.
+
+  **Acceptance criteria:**
+  - [ ] `embed(String text) -> Future<EmbeddingResult>` where the result is
+        either a vector or a typed "no model installed" / "model failed"
+        case.
+  - [ ] Does not download a model itself — same boundary `ModelProvider`
+        already draws (acquisition is a separate, explicit step).
+
+  **Verification:**
+  - [ ] `cd packages/core_ai && flutter analyze && flutter test` — fake
+        `TaskModelRouter`/`EmbeddingClient`, no real model load.
+
+  **Dependencies:** Task 1, Task 2.
+
+  **Files likely touched:**
+  - `packages/core_ai/lib/src/embeddings/embedding_service.dart` (new)
+  - `packages/core_ai/test/embeddings/embedding_service_test.dart` (new)
+
+  **Estimated scope:** Small (1-2 files).
+
+- [ ] **Task 4: `MeetingEmbeddingStore`**
+
+  **Description:** Persist one vector per meeting id, keyed with the model
+  id that produced it (stale-detection, mirrors `MeetingRecord.model`).
+  Flat-file storage (JSON) in the same models/support directory
+  `MindService.modelsDirectory()` already uses — do not introduce Drift/sqflite
+  for this unless Task 4's implementation genuinely can't express "load N
+  small vectors into memory" without one (unlikely).
+
+  **Acceptance criteria:**
+  - [ ] `put(meetingId, modelId, vector)`, `get(meetingId) -> (modelId, vector)?`,
+        `all() -> Map<String, (modelId, vector)>`.
+  - [ ] A vector whose `modelId` doesn't match the currently-resolved
+        embedding model is reported as stale by the caller (store itself
+        just returns what's on disk plus its modelId — staleness is Task
+        5's concern, not storage's).
+  - [ ] Survives a process restart (real file I/O in the test, temp dir —
+        same pattern as `mind_service_test.dart`'s `tempDir`).
+
+  **Verification:**
+  - [ ] `cd packages/feature_mind && flutter analyze && flutter test`
+
+  **Dependencies:** None (independent of Tasks 1-3; can be built in
+  parallel).
+
+  **Files likely touched:**
+  - `packages/feature_mind/lib/src/search/meeting_embedding_store.dart` (new)
+  - `packages/feature_mind/test/search/meeting_embedding_store_test.dart` (new)
+
+  **Estimated scope:** Small (1-2 files).
+
+### Checkpoint: Phase 2
+- [ ] `flutter test` green in both `core_ai` and `feature_mind`.
+- [ ] `git diff packages/core_ai/lib/src/router` empty — confirm `AiTask`/
+      `TaskModelRouter` untouched.
+
+### Phase 3: Ranking + integration
+
+- [ ] **Task 5: `SemanticSearchRanker`**
+
+  **Description:** Given a query and `searchMeetings`'s keyword hits, embed
+  the query, score every stored meeting vector by cosine similarity, and
+  produce a ranked, **union** result set.
+
+  **Acceptance criteria:**
+  - [ ] Every keyword hit appears in the output, even with zero semantic
+        similarity to the query.
+  - [ ] A semantic-only match (no keyword overlap) can appear if its
+        similarity clears a threshold — threshold value is a named constant,
+        not a magic number, and documented with why that value.
+  - [ ] Behaves correctly (falls back to keyword-only) when
+        `EmbeddingService` reports no model installed — this is the
+        expected common case before a user has downloaded the embedding
+        model, not an error path.
+
+  **Verification:**
+  - [ ] `cd packages/feature_mind && flutter analyze && flutter test`
+  - [ ] Dedicated test: keyword hit with no semantic similarity still
+        appears in output (the behavior most likely to silently regress).
+  - [ ] Dedicated test: no embedding model installed → keyword-only results,
+        no crash.
+
+  **Dependencies:** Task 3, Task 4.
+
+  **Files likely touched:**
+  - `packages/feature_mind/lib/src/search/semantic_search_ranker.dart` (new)
+  - `packages/feature_mind/test/search/semantic_search_ranker_test.dart` (new)
+
+  **Estimated scope:** Medium (2-3 files, the core logic of this feature).
+
+- [ ] **Task 6: Wire into `MindService.search()`**
+
+  **Description:** `MindService.search(query)` keeps its exact existing
+  signature; internally it now calls `searchMeetings` for keyword hits and
+  `SemanticSearchRanker` to merge in semantic results, instead of returning
+  `searchMeetings`'s output directly.
+
+  **Acceptance criteria:**
+  - [ ] `MindHomeScreen`'s search box works unchanged — no UI file needs to
+        change for this task.
+  - [ ] Existing `mind_service_test.dart` search tests still pass unmodified
+        (signature didn't change) or are updated only if their assertions
+        were specifically about keyword-only behavior that's now
+        (correctly) superseded.
+
+  **Verification:**
+  - [ ] `cd packages/feature_mind && flutter test`
+  - [ ] `cd app && flutter analyze && flutter test` — full regression.
+
+  **Dependencies:** Task 5.
+
+  **Files likely touched:**
+  - `packages/feature_mind/lib/src/mind_service.dart`
+  - `packages/feature_mind/test/mind_service_test.dart` (only if an existing
+    assertion needs updating — check before editing)
+
+  **Estimated scope:** Small (1-2 files).
+
+### Checkpoint: Complete
+- [ ] All acceptance criteria across Tasks 1-6 met.
+- [ ] `cd packages/core_ai && flutter analyze && flutter test`
+- [ ] `cd packages/feature_mind && flutter analyze && flutter test`
+- [ ] `cd app && flutter analyze && flutter test`
+- [ ] Every affected Android flavor variant compiles.
+- [ ] `git diff packages/core_ai/lib/src/router` empty.
+- [ ] Device walk: download the embedding model through the normal
+      model-library UI, record a meeting, search by meaning rather than
+      exact words, confirm a real semantic hit surfaces. Also confirm search
+      still works with the model *not* downloaded (keyword-only).
+- [ ] Ready for review — likely 2-3 PRs given the phase boundaries (Phase 1
+      is the natural first PR — new dependency, biggest review surface;
+      Phase 2+3 can be one or two more).
+
+## Risks and Mitigations
+
+| Risk | Impact | Mitigation |
+|---|---|---|
+| `GeckoEmbeddingModel`'s actual API doesn't match the constructor signature found in docs (no direct code sample was available) | Medium | Task 2 confirms against the real AAR before finalizing the plugin's method-channel contract; Phase 1 checkpoint is a human review gate before Phase 2+3 build on top. |
+| New Gradle dependency (AI Edge RAG SDK) turns out to have licensing, size, or maintenance concerns on closer inspection | Medium | Phase 1 checkpoint explicitly re-confirms the dependency is still wanted once its real diff is known, not just at spec-approval time. |
+| EmbeddingGemma file URLs/sizes go stale between planning and implementation | Low | Task 1's checkpoint calls for re-verifying against the live HuggingFace repo, not copying this plan's numbers blindly. |
+| Brute-force cosine similarity becomes slow at real scale | Low | Not designed against — flagged in the spec as "revisit if measured, not assumed" if it ever becomes a real complaint. |
+| Semantic ranking silently drops a keyword match during a future refactor | Medium | Task 5's dedicated union test exists specifically to catch this — treat it as a regression gate, not a one-time check. |
+
+## Open Questions
+
+- How the tokenizer file (`sentencepiece.model`) is modeled in `ModelCatalog`
+  — second entry, or a companion field — depends on whether any existing
+  entry already needs a paired file (check during Task 1).
+- Flavor source-set split for the new plugin — full mirror of
+  `withLitertlm`/`withoutLitertlm`, or something lighter (decide during
+  Task 2, with the actual reason for the existing split understood first,
+  not assumed to transfer).
+- `GeckoEmbeddingModel`'s exact embed-call method name/signature — confirm
+  against the real AAR, not the docs summary, during Task 2.

--- a/tasks/mind-scribe-semantic-search-todo.md
+++ b/tasks/mind-scribe-semantic-search-todo.md
@@ -1,0 +1,91 @@
+# Mind scribe semantic search (#508) — task list
+
+Plan: `tasks/mind-scribe-semantic-search-plan.md`. Spec:
+`docs/superpowers/specs/2026-08-09-mind-scribe-semantic-search.md`.
+
+**Revised after investigation**: not extending `LiteRtLmPlugin.kt`.
+EmbeddingGemma ships as raw `.tflite` + `sentencepiece.model`, not
+`.litertlm`. Real path is Google's AI Edge RAG SDK (`GeckoEmbeddingModel`) —
+a new native plugin and a new Gradle dependency. Model itself is a
+`ModelDownloadService` download, never bundled in the APK — same as every
+other `ModelCatalog` entry.
+
+Likely 2-3 PRs: Phase 1 (new native plugin + dependency) first, its own
+checkpoint before Phase 2+3.
+
+## Phase 1 — embedding generation (core_ai + new native plugin)
+
+- [ ] **1.1** Add EmbeddingGemma
+      (`embeddinggemma-300M_seq256_mixed-precision.tflite`, ~179 MB, generic
+      variant, from `litert-community/embeddinggemma-300m`) + its
+      `sentencepiece.model` tokenizer to `ModelCatalog`, tagged
+      `ModelCapability.embeddings` only. Re-verify URLs/sizes against the
+      live HuggingFace repo at implementation time.
+- [ ] **1.2** Verify `TaskModelRouter().resolve(AiTask.embeddings, ...)`
+      finds it (test).
+- [ ] **1.3** Add Gradle deps
+      (`com.google.ai.edge.localagents:localagents-rag:0.1.0`,
+      `com.google.mediapipe:tasks-genai:0.10.22`) to
+      `app/android/app/build.gradle.kts`.
+- [ ] **1.4** Confirm `GeckoEmbeddingModel`'s actual embed-call method
+      against the real AAR (public docs had no direct code sample) before
+      finalizing the plugin contract.
+- [ ] **1.5** `EmbeddingClient` Dart interface + `MethodChannel`
+      implementation in `core_ai`.
+- [ ] **1.6** New `EmbeddingPlugin.kt` wrapping `GeckoEmbeddingModel`.
+      Decide flavor source-set split (mirror `withLitertlm`/
+      `withoutLitertlm`, or something lighter) — understand *why* the
+      existing split exists before assuming it transfers.
+
+**Checkpoint — human review required.** This phase adds a real new
+third-party native dependency. Re-confirm it's still wanted once its actual
+diff/size is known, not just at spec-approval time.
+
+- [ ] `flutter test` green in `core_ai`.
+- [ ] New plugin compiles in its wired flavor(s).
+- [ ] 1.4's finding (real method signature) confirmed before Phase 2 assumes
+      a contract shape.
+
+## Phase 2 — embedding service + storage
+
+- [ ] **2.1** `EmbeddingService` in `core_ai` (`TaskModelRouter` +
+      `EmbeddingClient`, typed "no model installed" result, does not
+      download anything itself).
+- [ ] **2.2** `MeetingEmbeddingStore` in `feature_mind` — flat-file, keyed by
+      meeting id + producing model id, survives restart. No new db
+      dependency unless proven necessary.
+
+**Checkpoint**
+- [ ] `flutter test` green in both packages.
+- [ ] `git diff packages/core_ai/lib/src/router` — empty.
+
+## Phase 3 — ranking + integration
+
+- [ ] **3.1** `SemanticSearchRanker` — union merge (every keyword hit
+      survives), named similarity threshold constant, graceful keyword-only
+      fallback when no embedding model is installed.
+- [ ] **3.2** Dedicated test: keyword hit with zero semantic similarity
+      still appears in output.
+- [ ] **3.3** Dedicated test: no embedding model installed → keyword-only,
+      no crash.
+- [ ] **3.4** Wire into `MindService.search()` — signature unchanged,
+      `MindHomeScreen` untouched.
+
+## Verification (full)
+
+```bash
+cd packages/core_ai && flutter analyze && flutter test
+cd packages/feature_mind && flutter analyze && flutter test
+cd app && flutter analyze && flutter test
+git diff packages/core_ai/lib/src/router   # must be empty
+cd app/android && ./gradlew :app:compileDebugKotlin   # exact task TBD (1.6)
+```
+
+## Checkpoint: Complete
+
+- [ ] All tasks above checked.
+- [ ] Device walk: download embedding model through normal model-library UI,
+      record meeting, search by meaning not exact words, confirm real
+      semantic hit. Also confirm keyword-only search still works with the
+      model *not* downloaded.
+- [ ] PR(s) opened, reviewed.

--- a/tasks/mind-scribe-semantic-search-todo.md
+++ b/tasks/mind-scribe-semantic-search-todo.md
@@ -13,36 +13,53 @@ other `ModelCatalog` entry.
 Likely 2-3 PRs: Phase 1 (new native plugin + dependency) first, its own
 checkpoint before Phase 2+3.
 
-## Phase 1 — embedding generation (core_ai + new native plugin)
+## Phase 1 — embedding generation (core_ai + new native plugin) ✅ MOSTLY DONE
 
-- [ ] **1.1** Add EmbeddingGemma
+- [x] **1.1** Add EmbeddingGemma
       (`embeddinggemma-300M_seq256_mixed-precision.tflite`, ~179 MB, generic
       variant, from `litert-community/embeddinggemma-300m`) + its
       `sentencepiece.model` tokenizer to `ModelCatalog`, tagged
-      `ModelCapability.embeddings` only. Re-verify URLs/sizes against the
-      live HuggingFace repo at implementation time.
-- [ ] **1.2** Verify `TaskModelRouter().resolve(AiTask.embeddings, ...)`
-      finds it (test).
-- [ ] **1.3** Add Gradle deps
+      `ModelCapability.embeddings` only. Landed separately: PR #1573.
+- [x] **1.2** Verified `TaskModelRouter().resolve(AiTask.embeddings, ...)`
+      finds it, and never returns the tokenizer entry (PR #1573).
+- [x] **1.3** Gradle deps added
       (`com.google.ai.edge.localagents:localagents-rag:0.1.0`,
       `com.google.mediapipe:tasks-genai:0.10.22`) to
-      `app/android/app/build.gradle.kts`.
-- [ ] **1.4** Confirm `GeckoEmbeddingModel`'s actual embed-call method
-      against the real AAR (public docs had no direct code sample) before
-      finalizing the plugin contract.
-- [ ] **1.5** `EmbeddingClient` Dart interface + `MethodChannel`
-      implementation in `core_ai`.
-- [ ] **1.6** New `EmbeddingPlugin.kt` wrapping `GeckoEmbeddingModel`.
-      Decide flavor source-set split (mirror `withLitertlm`/
-      `withoutLitertlm`, or something lighter) — understand *why* the
-      existing split exists before assuming it transfers.
+      `app/android/app/build.gradle.kts`, gated behind a new
+      `embeddingAvailable` flag (`AIRO_USE_EMBEDDING_STUB` env var) mirroring
+      `liteRtLmAvailable`'s existing mechanism exactly — same reasoning,
+      separate flag so toggling one dependency never silently toggles the
+      other.
+- [ ] **1.4** `GeckoEmbeddingModel`'s embed-call method — **not confirmed
+      against the real AAR**. No source/javadoc access in this session; the
+      public integration guide showed only the constructor, not a call
+      site. Implemented as `computeEmbeddings(text).get()`, inferred from
+      the AI Edge RAG SDK's `Embedder<String>`/`ListenableFuture` convention
+      and clearly flagged in the plugin's own doc comment as the one thing
+      needing verification before this ships. Isolated to a single call
+      site — if wrong, only that line changes.
+- [x] **1.5** `EmbeddingClient` Dart interface + `MethodChannelEmbeddingClient`
+      in `core_ai`, mirroring `LiteRtLmClient`'s shape (timeout,
+      `PlatformException`/`MissingPluginException` handling). 6 tests.
+- [x] **1.6** New `EmbeddingPlugin.kt`, two flavor variants
+      (`withEmbedding`/`withoutEmbedding`), mirroring `withLitertlm`/
+      `withoutLitertlm` exactly — confirmed the existing split's real reason
+      first (a CI/stub-build toggle for a public-Maven dependency, per
+      `app/android/build.gradle.kts`'s own comment) before replicating the
+      mechanism, rather than assuming it transfers.
 
-**Checkpoint — human review required.** This phase adds a real new
-third-party native dependency. Re-confirm it's still wanted once its actual
-diff/size is known, not just at spec-approval time.
+**Checkpoint — human review required, and 1.4 is still open.** This phase
+adds a real new third-party native dependency and one unverified native API
+call. Do not proceed to Phase 2 assuming 1.4's contract shape is final —
+confirm it first (Android Studio decompiled sources, the SDK's own javadoc,
+or a real device build attempt).
 
-- [ ] `flutter test` green in `core_ai`.
-- [ ] New plugin compiles in its wired flavor(s).
+- [x] `flutter test` green in `core_ai` (326/326, all packages, zero
+      regressions).
+- [ ] New plugin compiles in its wired flavor(s) — **not verified**, no
+      `gradlew` wrapper present in this checkout (Flutter-generated, absent
+      until a `flutter pub get`/build runs in `app/`). Needs a real build
+      environment.
 - [ ] 1.4's finding (real method signature) confirmed before Phase 2 assumes
       a contract shape.
 


### PR DESCRIPTION
## Summary
Phase 1 of `tasks/mind-scribe-semantic-search-plan.md` (#508, Mind scribe semantic search) — two tasks, now both in this PR since they're the same review boundary (new third-party dependency).

**Task 1** — `ModelCatalog` entries:
- `embeddinggemma-300m-embed` — `embeddinggemma-300M_seq256_mixed-precision.tflite` (~179 MB, generic/no-chip-suffix variant), tagged `ModelCapability.embeddings` only.
- `embeddinggemma-300m-tokenizer` — the required `sentencepiece.model`, **zero capabilities** — can't produce an embedding by itself, must never be handed back by `TaskModelRouter.resolve`. Verified against every catalog-resolvable `AiTask`.

**Task 2** — new native plugin, not an extension of `LiteRtLmPlugin.kt`:
- EmbeddingGemma isn't published as a `.litertlm` package (confirmed before writing any Kotlin), so it can't go through the existing chat plugin's `Engine`/`Conversation` API.
- New `EmbeddingPlugin.kt` wraps Google's AI Edge RAG SDK (`GeckoEmbeddingModel`), two flavor variants (`withEmbedding`/`withoutEmbedding`) mirroring `withLitertlm`/`withoutLitertlm` — confirmed *why* that split exists (a CI/stub-build toggle for a public-Maven dependency) before replicating it, rather than assuming it transfers.
- New Gradle deps (`com.google.ai.edge.localagents:localagents-rag:0.1.0`, `com.google.mediapipe:tasks-genai:0.10.22`), gated behind a new `embeddingAvailable` flag (`AIRO_USE_EMBEDDING_STUB` env var), separate from `liteRtLmAvailable` on purpose.
- `EmbeddingClient` (Dart interface + `MethodChannelEmbeddingClient`), mirroring `LiteRtLmClient`'s shape exactly (timeout, `PlatformException`/`MissingPluginException` handling).

**Two things explicitly not verified, flagged rather than assumed:**
1. `GeckoEmbeddingModel`'s embed-call method (`computeEmbeddings(text).get()`) is inferred from the AI Edge RAG SDK's `Embedder<String>`/`ListenableFuture` convention — the public integration guide showed only the constructor, no call-site sample. No source/javadoc access this session to confirm. Flagged in the plugin's own doc comment; isolated to one call site if it needs to change.
2. Kotlin compilation itself — no `gradlew` wrapper present in this checkout (Flutter-generated). Needs a real build environment before merge.

Model itself is never bundled in the APK — same `ModelDownloadService` pipeline as every other `ModelCatalog` entry, user opts in through the model-library UI.

Spec/plan docs included, revised from their first draft after this investigation (original draft wrongly assumed extending `LiteRtLmPlugin.kt`).

## Test plan
- [x] `cd packages/core_ai && flutter analyze` — clean (one pre-existing, unrelated info-level lint)
- [x] `cd packages/core_ai && flutter test` — 326/326 passing, 9 new tests
- [ ] Android Kotlin compilation — **not verified in this session**, needs a real build environment
- [ ] `GeckoEmbeddingModel.computeEmbeddings` — **not verified against the real AAR**, needs confirmation before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)