### PR TITLE
docs(mind): correct stale journey-coverage regression status

### DIFF
--- a/docs/superpowers/plans/2026-08-07-airo-mind-ssot-todo.md
+++ b/docs/superpowers/plans/2026-08-07-airo-mind-ssot-todo.md
@@ -531,7 +531,15 @@ every super-app build.
 
 ## Carried over, not part of this plan
 
-- [ ] Journey coverage spec
-      (`docs/superpowers/specs/2026-08-06-airo-mind-journey-coverage.md`) — T3/T4/T5
-      restore the tests deleted in #1549. Still an open regression.
+- [x] Journey coverage spec — composition half
+      (`docs/superpowers/specs/2026-08-06-airo-mind-journey-coverage.md`,
+      T3–T8): implemented and verified on `main` as of 2026-08-09
+      (`packages/feature_mind/test/mind_service_test.dart`, 7/7 passing).
+      This entry was stale — the tests already existed when it was last
+      checked; re-verified by running them rather than assumed.
+- [ ] Journey coverage spec — device journey half: still not done.
+      `app/integration_test/mind_journey_device_test.dart` does not exist.
+      Needs a real device with the ~570 MB models installed to write *and*
+      run against — not attempted here, same discipline as not guessing at
+      an unverifiable native contract elsewhere in this plan.
 - [ ] iOS (#1546 phase 4) — has never built; needs dynamic frameworks.

--- a/docs/superpowers/specs/2026-08-06-airo-mind-journey-coverage.md
+++ b/docs/superpowers/specs/2026-08-06-airo-mind-journey-coverage.md
@@ -1,7 +1,13 @@
 # Airo Mind — restore the journey coverage the split removed
 
 **Date:** 2026-08-06
-**Status:** Draft, pre-implementation
+**Status:** Composition tests (§6, T3–T8) implemented and passing on
+`main` as of 2026-08-09 — verified by running
+`cd packages/feature_mind && flutter test test/mind_service_test.dart`
+(7/7 passing). Acceptance criteria 1, 2, 4 met. **Criterion 3 (the device
+journey test, `app/integration_test/mind_journey_device_test.dart`) is
+still not written** — no such file exists in the repo. This spec is not
+fully closed; only the part that runs in the default CI suite is done.
 **Follows:** #1549 (the split), #1550 (Android device fixes)
 **Closes a regression introduced by:** #1549
 


### PR DESCRIPTION
## Summary
Independent of #508/#1573 — surveyed for pending tasks that don't touch the blocked Android/embedding work and found this plan doc was stale.

`docs/superpowers/plans/2026-08-07-airo-mind-ssot-todo.md`'s "Carried over" section listed the journey-coverage regression (T3-T8, from `docs/superpowers/specs/2026-08-06-airo-mind-journey-coverage.md`) as "still an open regression." Checked actual code before trusting the doc: `packages/feature_mind/test/mind_service_test.dart` already has all of T3-T8, passing. Re-ran them (7/7) rather than assuming from history.

Split the stale bullet into what's actually true:
- Composition coverage (T3-T8): done, verified.
- Device journey test (`app/integration_test/mind_journey_device_test.dart`): still doesn't exist. Needs a real device with ~570 MB of models to write *and* run against meaningfully — not attempted here, same verify-before-claiming discipline currently applied to the embedding plugin's native contract.

Docs only, no code changes.

## Test plan
- [x] `cd packages/feature_mind && flutter test test/mind_service_test.dart` — 7/7 (T3-T8)
- [x] `cd packages/feature_mind && flutter test` — full suite, 365/365, zero regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)