### PR TITLE
feat(mind): SemanticSearchRanker + wire into MindService.search() (#508, Phase 3)

### DIFF
--- a/packages/core_ai/lib/src/embeddings/embedding_service.dart
+++ b/packages/core_ai/lib/src/embeddings/embedding_service.dart
@@ -21,14 +21,22 @@ enum EmbeddingUnavailable {
 /// The result of [EmbeddingService.embed].
 @immutable
 class EmbeddingResult {
-  const EmbeddingResult.ready(List<double> this.vector)
+  const EmbeddingResult.ready(List<double> this.vector, String this.modelId)
     : unavailable = null,
       detail = '';
 
   const EmbeddingResult.unavailable(this.unavailable, this.detail)
-    : vector = null;
+    : vector = null,
+      modelId = null;
 
   final List<double>? vector;
+
+  /// Which catalog entry produced [vector] — null unless [isReady]. Callers
+  /// that persist a vector (e.g. `MeetingEmbeddingStore`) need this to detect
+  /// staleness later (`ADR-0018 §5`'s "record what produced this" pattern);
+  /// `EmbeddingService` is the only thing that knows which model
+  /// `TaskModelRouter` actually resolved for a given call.
+  final String? modelId;
   final EmbeddingUnavailable? unavailable;
   final String detail;
 
@@ -121,7 +129,7 @@ class EmbeddingService {
       }
 
       final vector = await _client.embed(text: text);
-      return EmbeddingResult.ready(vector);
+      return EmbeddingResult.ready(vector, resolved.id);
     } on Object catch (e) {
       return EmbeddingResult.unavailable(
         EmbeddingUnavailable.modelFailed,

--- a/packages/core_ai/test/embeddings/embedding_service_test.dart
+++ b/packages/core_ai/test/embeddings/embedding_service_test.dart
@@ -78,6 +78,25 @@ void main() {
 
       expect(result.isReady, isTrue);
       expect(result.vector, [0.1, 0.2, 0.3]);
+      expect(
+        result.modelId,
+        'embed-model',
+        reason:
+            'callers that persist a vector need to know which model '
+            'produced it',
+      );
+    });
+
+    test('modelId is null when unavailable', () async {
+      final service = EmbeddingService(
+        client: _FakeEmbeddingClient(),
+        downloadService: _FakeModelDownloadService(downloaded: const {}),
+        catalog: [embedModel, tokenizerModel],
+      );
+
+      final result = await service.embed('hello');
+
+      expect(result.modelId, isNull);
     });
 
     test('only initializes the client once across repeated calls', () async {

--- a/packages/feature_mind/lib/src/mind_service.dart
+++ b/packages/feature_mind/lib/src/mind_service.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:io';
 
+import 'package:core_ai/core_ai.dart' show EmbeddingService;
 import 'package:flutter/foundation.dart';
 import 'package:path/path.dart' as p;
 import 'package:path_provider/path_provider.dart';
@@ -10,6 +11,8 @@ import 'bridges/mind_generation_bridge.dart';
 import 'bridges/mind_speech_bridge.dart';
 import 'model_installer.dart';
 import 'models/model_provider.dart';
+import 'search/meeting_embedding_store.dart';
+import 'search/semantic_search_ranker.dart';
 import 'whisper/api/meetings.dart' as rust;
 
 /// Why Airo Mind cannot start. Each case is one the user can act on, which is
@@ -103,15 +106,30 @@ class MindService {
     ModelProvider? modelProvider,
     MindSpeechBridge? speechBridge,
     MindGenerationBridge? generationBridge,
+    SemanticSearchRanker Function(Directory modelsDir)? rankerBuilder,
   }) : _recorder = recorder ?? AudioRecorder(),
        _models = modelProvider ?? const ModelInstaller(),
        _speech = speechBridge ?? const RustMindSpeechBridge(),
-       _generation = generationBridge ?? RustMindGenerationBridge();
+       _generation = generationBridge ?? RustMindGenerationBridge(),
+       _rankerBuilder =
+           rankerBuilder ??
+           ((dir) => SemanticSearchRanker(
+             embeddingService: EmbeddingService(),
+             embeddingStore: MeetingEmbeddingStore(dir),
+           ));
 
   final AudioRecorder _recorder;
   final ModelProvider _models;
   final MindSpeechBridge _speech;
   final MindGenerationBridge _generation;
+
+  /// Built lazily against [modelsDirectory] rather than in the constructor:
+  /// resolving that directory is async, and every other collaborator here is
+  /// a ready-made instance. [rankerBuilder] is the seam a test substitutes
+  /// to avoid touching `core_ai`'s real `EmbeddingService`/model download
+  /// pipeline (`docs/superpowers/specs/2026-08-09-mind-scribe-semantic-search.md`).
+  final SemanticSearchRanker Function(Directory modelsDir) _rankerBuilder;
+  SemanticSearchRanker? _ranker;
   String? _recordingPath;
 
   /// Loads the native library and the models.
@@ -381,7 +399,20 @@ class MindService {
 
   Future<List<rust.MeetingRecord>> meetings() => _speech.meetings();
 
-  Future<List<rust.SearchHit>> search(String query) => _speech.search(query);
+  /// Step 7 of the journey, now ranked by keyword **and** meaning
+  /// (`docs/superpowers/specs/2026-08-09-mind-scribe-semantic-search.md`).
+  /// Signature is unchanged from the keyword-only version this replaced —
+  /// [MindHomeScreen]'s search box needed no changes for this.
+  Future<List<rust.SearchHit>> search(String query) async {
+    final keywordHits = await _speech.search(query);
+    _ranker ??= _rankerBuilder(await modelsDirectory());
+    final allMeetings = await _speech.meetings();
+    return _ranker!.rank(
+      query: query,
+      keywordHits: keywordHits,
+      meetings: allMeetings,
+    );
+  }
 
   Future<rust.MeetingRecord?> meeting(String id) => _speech.meeting(id);
 

--- a/packages/feature_mind/lib/src/search/semantic_search_ranker.dart
+++ b/packages/feature_mind/lib/src/search/semantic_search_ranker.dart
@@ -1,0 +1,119 @@
+import 'dart:math' as math;
+
+import 'package:core_ai/core_ai.dart';
+
+import '../whisper/api/meetings.dart' as rust;
+import 'meeting_embedding_store.dart';
+
+/// Adds semantic ranking on top of `searchMeetings`'s keyword hits.
+///
+/// **Union, never replacement**: every keyword hit is returned, regardless
+/// of its semantic similarity to the query — a keyword match a query didn't
+/// resemble semantically is still a real match
+/// (`docs/superpowers/specs/2026-08-09-mind-scribe-semantic-search.md`).
+/// Semantic-only matches (no keyword overlap) are appended after, ranked by
+/// similarity, only when they clear [similarityThreshold].
+///
+/// Falls back to keyword-only, silently and correctly, when no embedding
+/// model is installed — the expected common state before a user downloads
+/// one, not an error condition this class treats specially.
+class SemanticSearchRanker {
+  SemanticSearchRanker({
+    required EmbeddingService embeddingService,
+    required MeetingEmbeddingStore embeddingStore,
+    this.similarityThreshold = 0.6,
+  }) : _embeddingService = embeddingService,
+       _embeddingStore = embeddingStore;
+
+  final EmbeddingService _embeddingService;
+  final MeetingEmbeddingStore _embeddingStore;
+
+  /// Cosine similarity (0–1) a semantic-only match must clear to appear.
+  /// 0.6 is a starting point, not a value tuned against this app's own
+  /// usage yet — revisit once there is real search history to measure
+  /// against, the same "don't build ahead of evidence" stance the spec
+  /// takes on skipping an ANN index.
+  final double similarityThreshold;
+
+  /// Ranks [meetings] against [query], returning [keywordHits] plus any
+  /// semantically similar meeting not already among them.
+  ///
+  /// Embeddings for meetings not yet in [MeetingEmbeddingStore] are computed
+  /// here, lazily, and cached for next time — there is no separate
+  /// save-time indexing step yet. That means the search *after* recording a
+  /// new meeting pays for embedding it; a background/save-time job would
+  /// remove that cost, and is a reasonable follow-up once this is real
+  /// usage, not a v1 requirement.
+  Future<List<rust.SearchHit>> rank({
+    required String query,
+    required List<rust.SearchHit> keywordHits,
+    required List<rust.MeetingRecord> meetings,
+  }) async {
+    final queryResult = await _embeddingService.embed(query);
+    if (!queryResult.isReady) return keywordHits;
+    final queryVector = queryResult.vector!;
+
+    final keywordIds = keywordHits.map((hit) => hit.meetingId).toSet();
+    final scored = <(double similarity, rust.SearchHit hit)>[];
+
+    for (final meeting in meetings) {
+      if (keywordIds.contains(meeting.id)) continue;
+
+      final vector = await _vectorFor(meeting);
+      if (vector == null) continue;
+
+      final similarity = _cosineSimilarity(queryVector, vector);
+      if (similarity < similarityThreshold) continue;
+
+      scored.add((similarity, _hitFor(meeting)));
+    }
+
+    scored.sort((a, b) => b.$1.compareTo(a.$1));
+    return [...keywordHits, for (final entry in scored) entry.$2];
+  }
+
+  Future<List<double>?> _vectorFor(rust.MeetingRecord meeting) async {
+    final stored = await _embeddingStore.get(meeting.id);
+    if (stored != null) return stored.vector;
+
+    final text = '${meeting.transcript} ${meeting.minutes}'.trim();
+    if (text.isEmpty) return null;
+
+    final result = await _embeddingService.embed(text);
+    if (!result.isReady) return null;
+
+    await _embeddingStore.put(meeting.id, result.modelId!, result.vector!);
+    return result.vector;
+  }
+
+  static const _maxSnippetLength = 160;
+
+  rust.SearchHit _hitFor(rust.MeetingRecord meeting) {
+    final source = meeting.minutes.trim().isNotEmpty
+        ? meeting.minutes.trim()
+        : meeting.transcript.trim();
+    final snippet = source.length > _maxSnippetLength
+        ? '${source.substring(0, _maxSnippetLength)}…'
+        : source;
+    return rust.SearchHit(
+      meetingId: meeting.id,
+      title: meeting.title,
+      recordedAt: meeting.recordedAt,
+      snippet: snippet,
+    );
+  }
+
+  double _cosineSimilarity(List<double> a, List<double> b) {
+    if (a.isEmpty || a.length != b.length) return 0;
+    var dot = 0.0;
+    var normA = 0.0;
+    var normB = 0.0;
+    for (var i = 0; i < a.length; i++) {
+      dot += a[i] * b[i];
+      normA += a[i] * a[i];
+      normB += b[i] * b[i];
+    }
+    if (normA == 0 || normB == 0) return 0;
+    return dot / (math.sqrt(normA) * math.sqrt(normB));
+  }
+}

--- a/packages/feature_mind/test/search/semantic_search_ranker_test.dart
+++ b/packages/feature_mind/test/search/semantic_search_ranker_test.dart
@@ -1,0 +1,241 @@
+import 'dart:io';
+
+import 'package:core_ai/core_ai.dart';
+import 'package:feature_mind/src/search/meeting_embedding_store.dart';
+import 'package:feature_mind/src/search/semantic_search_ranker.dart';
+import 'package:feature_mind/src/whisper/api/meetings.dart' as rust;
+import 'package:flutter_test/flutter_test.dart';
+
+rust.MeetingRecord _meeting(
+  String id, {
+  String title = 'Meeting',
+  String transcript = 'transcript text',
+  String minutes = 'minutes text',
+}) => rust.MeetingRecord(
+  id: id,
+  title: title,
+  recordedAt: BigInt.zero,
+  transcript: transcript,
+  minutes: minutes,
+  model: 'test-model',
+);
+
+rust.SearchHit _hit(String meetingId) => rust.SearchHit(
+  meetingId: meetingId,
+  title: 'Meeting $meetingId',
+  recordedAt: BigInt.zero,
+  snippet: 'matched line',
+);
+
+void main() {
+  late Directory tempDir;
+  late MeetingEmbeddingStore store;
+
+  setUp(() {
+    tempDir = Directory.systemTemp.createTempSync('semantic_ranker_test_');
+    store = MeetingEmbeddingStore(tempDir);
+  });
+
+  tearDown(() {
+    if (tempDir.existsSync()) tempDir.deleteSync(recursive: true);
+  });
+
+  group('SemanticSearchRanker.rank', () {
+    test(
+      'returns keyword hits unchanged when no embedding model is installed',
+      () async {
+        final ranker = SemanticSearchRanker(
+          embeddingService: _FakeEmbeddingService(),
+          embeddingStore: store,
+        );
+        final keywordHits = [_hit('m1')];
+
+        final result = await ranker.rank(
+          query: 'anything',
+          keywordHits: keywordHits,
+          meetings: [_meeting('m1'), _meeting('m2')],
+        );
+
+        expect(result, keywordHits);
+      },
+    );
+
+    test('a keyword hit survives even with zero semantic similarity', () async {
+      final ranker = SemanticSearchRanker(
+        embeddingService: _FakeEmbeddingService(
+          vectors: {
+            'pricing question': [1.0, 0.0],
+            'm1': [-1.0, 0.0], // opposite direction: similarity -1
+          },
+        ),
+        embeddingStore: store,
+      );
+      final keywordHits = [_hit('m1')];
+
+      final result = await ranker.rank(
+        query: 'pricing question',
+        keywordHits: keywordHits,
+        meetings: [_meeting('m1')],
+      );
+
+      expect(result.map((h) => h.meetingId), ['m1']);
+    });
+
+    test(
+      'adds a semantic-only match that clears the similarity threshold',
+      () async {
+        final ranker = SemanticSearchRanker(
+          embeddingService: _FakeEmbeddingService(
+            vectors: {
+              'pricing question': [1.0, 0.0],
+              // meeting text embeds to the same direction as the query.
+              'transcript text minutes text': [1.0, 0.0],
+            },
+          ),
+          embeddingStore: store,
+        );
+
+        final result = await ranker.rank(
+          query: 'pricing question',
+          keywordHits: const [],
+          meetings: [_meeting('m1')],
+        );
+
+        expect(result.map((h) => h.meetingId), ['m1']);
+      },
+    );
+
+    test(
+      'does not add a semantic match below the similarity threshold',
+      () async {
+        final ranker = SemanticSearchRanker(
+          embeddingService: _FakeEmbeddingService(
+            vectors: {
+              'pricing question': [1.0, 0.0],
+              'transcript text minutes text': [
+                0.0,
+                1.0,
+              ], // orthogonal: similarity 0
+            },
+          ),
+          embeddingStore: store,
+        );
+
+        final result = await ranker.rank(
+          query: 'pricing question',
+          keywordHits: const [],
+          meetings: [_meeting('m1')],
+        );
+
+        expect(result, isEmpty);
+      },
+    );
+
+    test(
+      'never duplicates a meeting that is both a keyword and semantic match',
+      () async {
+        final ranker = SemanticSearchRanker(
+          embeddingService: _FakeEmbeddingService(
+            vectors: {
+              'pricing question': [1.0, 0.0],
+              'transcript text minutes text': [1.0, 0.0],
+            },
+          ),
+          embeddingStore: store,
+        );
+        final keywordHits = [_hit('m1')];
+
+        final result = await ranker.rank(
+          query: 'pricing question',
+          keywordHits: keywordHits,
+          meetings: [_meeting('m1')],
+        );
+
+        expect(result.length, 1);
+        expect(result.first, keywordHits.first);
+      },
+    );
+
+    test('caches a computed meeting embedding for the next call', () async {
+      final embeddingService = _FakeEmbeddingService(
+        vectors: {
+          'pricing question': [1.0, 0.0],
+          'transcript text minutes text': [1.0, 0.0],
+        },
+      );
+      final ranker = SemanticSearchRanker(
+        embeddingService: embeddingService,
+        embeddingStore: store,
+      );
+      final meeting = _meeting('m1');
+
+      await ranker.rank(
+        query: 'pricing question',
+        keywordHits: const [],
+        meetings: [meeting],
+      );
+      final stored = await store.get('m1');
+
+      expect(stored, isNotNull);
+      expect(stored?.modelId, 'fake-embedding-model');
+
+      // Second call must not re-embed the meeting text -- only the query.
+      embeddingService.embedCallsByText.clear();
+      await ranker.rank(
+        query: 'pricing question',
+        keywordHits: const [],
+        meetings: [meeting],
+      );
+      expect(embeddingService.embedCallsByText, ['pricing question']);
+    });
+
+    test(
+      'ranks multiple semantic-only matches by descending similarity',
+      () async {
+        final ranker = SemanticSearchRanker(
+          embeddingService: _FakeEmbeddingService(
+            vectors: {
+              'query': [1.0, 0.0],
+              'close text': [0.9, 0.1], // higher similarity
+              'far text': [0.7, 0.3], // lower, still above threshold
+            },
+          ),
+          embeddingStore: store,
+        );
+
+        final result = await ranker.rank(
+          query: 'query',
+          keywordHits: const [],
+          meetings: [
+            _meeting('far', transcript: 'far', minutes: 'text'),
+            _meeting('close', transcript: 'close', minutes: 'text'),
+          ],
+        );
+
+        expect(result.map((h) => h.meetingId), ['close', 'far']);
+      },
+    );
+  });
+}
+
+class _FakeEmbeddingService implements EmbeddingService {
+  _FakeEmbeddingService({this.vectors = const {}});
+
+  /// Keyed by the exact text passed to [embed] — the test builds this map to
+  /// control what each call returns.
+  final Map<String, List<double>> vectors;
+  final embedCallsByText = <String>[];
+
+  @override
+  Future<EmbeddingResult> embed(String text) async {
+    embedCallsByText.add(text);
+    final vector = vectors[text];
+    if (vector == null) {
+      return const EmbeddingResult.unavailable(
+        EmbeddingUnavailable.noModelInstalled,
+        'no vector configured for this text in the fake',
+      );
+    }
+    return EmbeddingResult.ready(vector, 'fake-embedding-model');
+  }
+}

--- a/tasks/mind-scribe-semantic-search-todo.md
+++ b/tasks/mind-scribe-semantic-search-todo.md
@@ -163,13 +163,29 @@ git diff origin/main -- packages/core_ai/lib/src/router        # empty
 ## Checkpoint: Complete
 
 - [x] All Phase 1-3 tasks checked.
-- [ ] Device walk: download embedding model through normal model-library UI,
-      record meeting, search by meaning not exact words, confirm real
-      semantic hit. Also confirm keyword-only search still works with the
-      model *not* downloaded. **Not done in this session** — no meeting
-      exists yet to search on the connected Pixel 9, and this needs a full
-      record → transcribe → minutes → search walk, not just a build/install
-      check. Flagged rather than skipped silently.
+- [x] Device walk (partial, real, Pixel 9 USB, 2026-08-09): installed
+      `app-debug.apk`, launched `io.airo.app.mind`, recorded a real meeting
+      via the phone mic (audio source: nearby YouTube playback), stopped,
+      transcription ran (Whisper produced `[MUSIC]`/`[BLANK_AUDIO]` tags —
+      no clear speech in that clip, not a bug), minutes were generated
+      (LLM produced generic boilerplate from the near-empty transcript — a
+      real UX gap worth a separate issue, out of #508's scope), saved as
+      "Meeting 3". Searched via `MindService.search()`:
+      - keyword hit: query `"stakeholders"` returned Meeting 3 with the
+        correct matching snippet — confirms the full search path (keyword
+        → `SemanticSearchRanker.rank` → union merge) runs end to end on a
+        real device with zero logcat errors.
+      - no-match query (`"stakeholdersbudget"`, garbled by a mistyped
+        clear-field tap, incidentally still a valid no-hit case): returned
+        "No meeting mentions that." — clean empty state, no crash. This is
+        the "no embedding model installed → graceful keyword-only
+        behavior" acceptance criterion, confirmed for real.
+      **Not done**: a real semantic-only hit (query worded differently from
+      the transcript, model bridges the gap). Blocked on downloading
+      `embeddinggemma-300m-embed` (~179 MB) — there is no model-library UI
+      surface wired up yet to trigger that download; `EmbeddingService`
+      only *consumes* an already-downloaded model, it never downloads one
+      itself (by design). Flagged as a real gap, not silently skipped.
 - [x] PR(s) opened: #1573 (Task 1-2), #1576 (Task 1.4 fix + verification),
       #1577 (unrelated doc fix), #1578 (Task 3-4), this PR (Task 5-6 + the
       3.0 addendum).

--- a/tasks/mind-scribe-semantic-search-todo.md
+++ b/tasks/mind-scribe-semantic-search-todo.md
@@ -122,33 +122,54 @@ evidence (not a second guess), rebuild succeeded.
 - [x] `git diff origin/main -- packages/core_ai/lib/src/router` — confirmed
       empty.
 
-## Phase 3 — ranking + integration
+## Phase 3 — ranking + integration ✅ DONE
 
-- [ ] **3.1** `SemanticSearchRanker` — union merge (every keyword hit
-      survives), named similarity threshold constant, graceful keyword-only
-      fallback when no embedding model is installed.
-- [ ] **3.2** Dedicated test: keyword hit with zero semantic similarity
-      still appears in output.
-- [ ] **3.3** Dedicated test: no embedding model installed → keyword-only,
-      no crash.
-- [ ] **3.4** Wire into `MindService.search()` — signature unchanged,
-      `MindHomeScreen` untouched.
+- [x] **3.0** (found while implementing, not planned): `EmbeddingService`
+      (Task 3) didn't expose which model produced a vector —
+      `MeetingEmbeddingStore.put()` needs that for its staleness-detection
+      design. Added `EmbeddingResult.modelId`, 2 new tests in `core_ai`.
+- [x] **3.1** `SemanticSearchRanker` — union merge (every keyword hit
+      survives), named `similarityThreshold` constant (0.6, documented as a
+      starting point, not tuned against real usage yet), graceful
+      keyword-only fallback when no embedding model is installed. Also
+      handles the previously-unaddressed question of *when* a meeting gets
+      an embedding: lazily, on first search after it exists, cached in
+      `MeetingEmbeddingStore` — no save-time indexing step yet (documented
+      as a reasonable v1 tradeoff, not decided as final).
+- [x] **3.2** Dedicated test: keyword hit with zero (in fact negative)
+      semantic similarity still appears in output.
+- [x] **3.3** Dedicated test: no embedding model installed → keyword-only,
+      no crash. Plus: below-threshold semantic match excluded, no duplicate
+      when a meeting is both a keyword and semantic match, embeddings cache
+      across repeated calls (only the query re-embeds), multi-result
+      ranking by descending similarity. 7 tests total.
+- [x] **3.4** Wired into `MindService.search()` — signature unchanged
+      (`Future<List<rust.SearchHit>> search(String query)`), `MindHomeScreen`
+      untouched. Ranker built lazily via an injectable
+      `rankerBuilder(Directory)` (mirrors every other collaborator's
+      "injectable, defaults to production" pattern) since it needs
+      `modelsDirectory()`, which is async — can't build it in the
+      constructor the way the other collaborators are built.
 
 ## Verification (full)
 
 ```bash
-cd packages/core_ai && flutter analyze && flutter test
-cd packages/feature_mind && flutter analyze && flutter test
-cd app && flutter analyze && flutter test
-git diff packages/core_ai/lib/src/router   # must be empty
-cd app/android && ./gradlew :app:compileDebugKotlin   # exact task TBD (1.6)
+cd packages/core_ai && flutter analyze && flutter test         # 332/332
+cd packages/feature_mind && flutter analyze && flutter test    # 379/379
+cd app && flutter analyze                                      # clean
+git diff origin/main -- packages/core_ai/lib/src/router        # empty
 ```
 
 ## Checkpoint: Complete
 
-- [ ] All tasks above checked.
+- [x] All Phase 1-3 tasks checked.
 - [ ] Device walk: download embedding model through normal model-library UI,
       record meeting, search by meaning not exact words, confirm real
       semantic hit. Also confirm keyword-only search still works with the
-      model *not* downloaded.
-- [ ] PR(s) opened, reviewed.
+      model *not* downloaded. **Not done in this session** — no meeting
+      exists yet to search on the connected Pixel 9, and this needs a full
+      record → transcribe → minutes → search walk, not just a build/install
+      check. Flagged rather than skipped silently.
+- [x] PR(s) opened: #1573 (Task 1-2), #1576 (Task 1.4 fix + verification),
+      #1577 (unrelated doc fix), #1578 (Task 3-4), this PR (Task 5-6 + the
+      3.0 addendum).


### PR DESCRIPTION
## Summary
Phase 3 of `tasks/mind-scribe-semantic-search-plan.md` (#508, Mind scribe semantic search) — the final phase. Closes out the whole feature: search now ranks by keyword **and** meaning.

**`SemanticSearchRanker`**: union merge — every keyword hit from `searchMeetings` survives regardless of semantic similarity; semantic-only matches (no keyword overlap) are appended, ranked by cosine similarity, only above a named `similarityThreshold` (0.6, documented as a starting point pending real usage data, not tuned). Falls back to keyword-only, correctly and silently, when no embedding model is installed — the expected common state, not an error path.

**When meetings get embedded**: lazily, on first search after they exist, cached in `MeetingEmbeddingStore`. No save-time indexing step in this PR — documented as a v1 tradeoff (a background job removing the "first search pays for embedding" cost is reasonable follow-up, not decided as final here).

**Wired into `MindService.search()`** with its exact existing signature — `MindHomeScreen` needed zero changes. The ranker builds lazily via an injectable `rankerBuilder(Directory)` rather than in the constructor, since it needs `modelsDirectory()` (async) — every other `MindService` collaborator is a ready-made instance, this one couldn't be built that way.

**Addendum, found while implementing, not planned**: `EmbeddingService` (Task 3, already merged) didn't expose which model produced a vector — `MeetingEmbeddingStore.put()` needs that for its staleness-detection design. Added `EmbeddingResult.modelId`, 2 new tests.

`core_ai`'s router (`AiTask`/`TaskModelRouter`) is untouched — confirmed via diff.

**This completes Phase 1-3.** Not done, flagged rather than skipped: a full device walk (record → transcribe → minutes → semantic search) — no meeting exists yet on the Pixel 9 used for Phase 1's build verification, and confirming the search actually surfaces a real semantic hit needs one.

## Test plan
- [x] `cd packages/core_ai && flutter analyze && flutter test` — 332/332, zero regressions
- [x] `cd packages/feature_mind && flutter analyze && flutter test` — 379/379, zero regressions
- [x] `cd app && flutter analyze` — clean
- [x] `git diff origin/main -- packages/core_ai/lib/src/router` — empty
- [ ] Device walk — not done this session, see above

🤖 Generated with [Claude Code](https://claude.com/claude-code)