### PR TITLE
fix(mind): exclude AI Edge RAG SDK from TV, force embedding stub

### DIFF
--- a/app/android/app/build.gradle.kts
+++ b/app/android/app/build.gradle.kts
@@ -244,11 +244,19 @@ android {
             // Same mechanism as LiteRT-LM above, a separate flag and a
             // separate plugin (embeddings/semantic search -- see
             // docs/superpowers/specs/2026-08-09-mind-scribe-semantic-search.md).
-            // Excluded from the Coins variant for the same reason LiteRT-LM
-            // is: Coins is a stripped-down flavor with no Mind surface to
-            // search.
+            // Excluded from Coins entirely for the same reason LiteRT-LM is:
+            // Coins compiles its own `src/coins/kotlin` MainActivity that
+            // never references EmbeddingPlugin. TV shares `src/product/kotlin`
+            // with Mind and full (MainActivity registers EmbeddingPlugin
+            // unconditionally there), so TV still needs the stub compiled --
+            // it just must never get the real SDK. Unlike LiteRT-LM, the AI
+            // Edge RAG SDK's bundled protobuf classes fail R8 minification
+            // with "missing classes" (com.google.protobuf.Internal$ProtoNonnullApi)
+            // when nothing in the TV variant reaches them, so its Gradle
+            // dependency (below) cannot stay on TV's classpath the way
+            // LiteRT-LM's does; the stub keeps TV compiling without it.
             val embeddingAvailable =
-                rootProject.extra.get("embeddingAvailable") as Boolean
+                rootProject.extra.get("embeddingAvailable") as Boolean && !isTvVariant
             if (!isCoinsVariant) {
                 kotlin.srcDir(
                     if (embeddingAvailable) "src/withEmbedding/kotlin"
@@ -346,7 +354,14 @@ dependencies {
     // Engine/Conversation). Pinned explicitly, same reasoning as LiteRT-LM's
     // pin above — see this file's LiteRT-LM comment for the incident that
     // pin exists to prevent.
-    if (!isCoinsVariant && rootProject.extra.get("embeddingAvailable") as Boolean) {
+    //
+    // Excluded from TV as well as Coins, unlike LiteRT-LM: this SDK's bundled
+    // protobuf classes (com.google.ai.edge.localagents.rag.models.proto.*)
+    // fail R8 minification with "missing classes" on TV, where nothing
+    // reaches them, because the SDK doesn't ship its own protobuf runtime.
+    // LiteRT-LM's dependency has no such gap and can stay on TV's classpath
+    // unused; this one cannot.
+    if (!isCoinsVariant && !isTvVariant && rootProject.extra.get("embeddingAvailable") as Boolean) {
         implementation("com.google.ai.edge.localagents:localagents-rag:0.1.0")
         implementation("com.google.mediapipe:tasks-genai:0.10.22")
     }


### PR DESCRIPTION
## Summary
- #1579 merged with a TV release-build regression: the AI Edge RAG SDK
  (`localagents-rag`/`tasks-genai`, added for #508 semantic search) fails
  R8 minification on the TV variant with "missing classes"
  (`com.google.protobuf.Internal$ProtoNonnullApi`) since TV never reaches
  the embedding code path and the SDK doesn't ship its own protobuf runtime.
- Unlike LiteRT-LM's dependency, this one cannot stay unused on TV's
  classpath — it must be excluded outright.
- TV still compiles the `withoutEmbedding` stub (its `MainActivity`, shared
  `src/product/kotlin` with Mind and full, registers `EmbeddingPlugin`
  unconditionally), it just never links the real SDK or gets the Gradle
  dependency.

## Test plan
- [x] Confirmed the failure on the pre-fix commit via CI
      (`build-android (tv, ...)` job, R8 "missing classes" error)
- [ ] CI green on this branch, TV build passing