### PR TITLE
fix(mind): dontwarn missing protobuf classes from AI Edge RAG SDK

### DIFF
--- a/app/android/app/proguard-rules.pro
+++ b/app/android/app/proguard-rules.pro
@@ -24,6 +24,21 @@
 }
 
 # ============================================
+# AI Edge RAG SDK (on-device embeddings / semantic search)
+# ============================================
+# The SDK's bundled proto classes (EmbedText and friends) reference
+# full-protobuf-only marker types -- com.google.protobuf.Internal$ProtoNonnullApi,
+# com.google.protobuf.ProtoPresenceBits -- that aren't on the classpath: the
+# SDK ships protobuf-lite at runtime and never actually executes the paths
+# that touch these annotation-only classes through the single
+# EmbeddingRequest/EmbedData/GeckoEmbeddingModel call surface this app uses.
+# R8 still fails hard on the reference (its own suggested fix, generated in
+# missing_rules.txt, is exactly this -dontwarn pair) because the AAR's
+# consumer rules keep the whole proto package regardless of reachability.
+-dontwarn com.google.protobuf.Internal$ProtoNonnullApi
+-dontwarn com.google.protobuf.ProtoPresenceBits
+
+# ============================================
 # Google ML Kit (Gemini Nano)
 # ============================================
 -keep class com.google.mlkit.** { *; }


### PR DESCRIPTION
## Summary
- Main's post-merge CI for #1582 revealed the TV/Coins dependency
  exclusion wasn't the whole fix: the **full** variant's release build
  also fails R8 minification with the identical error
  (`com.google.protobuf.Internal$ProtoNonnullApi` missing), even though
  nothing in the full app calls the embedding path (feature_mind isn't in
  `app/pubspec.yaml` yet).
- Root cause: the AI Edge RAG SDK's own bundled consumer ProGuard rules
  keep its `proto` package unconditionally, independent of whether the
  app actually reaches it. Per-variant exclusion can't fix every variant
  that still carries the dependency (full and, presumably, mind's own
  release build would hit the same wall).
- Fix: `-dontwarn` the two specific missing classes — R8's own suggested
  remedy for this exact failure (generated in `missing_rules.txt`). These
  are full-protobuf-only marker types the SDK never actually executes
  through the single `EmbeddingRequest`/`EmbedData`/`GeckoEmbeddingModel`
  call surface this app uses.

## Test plan
- [ ] CI green: `build-android (full, ...)` and `build-android (tv, ...)`
      both pass