### PR TITLE
test(feature_iptv): close out #1025 — assert error overlay hides idle play button and hover chrome

### DIFF
--- a/packages/feature_iptv/test/presentation/widgets/video_player_widget_error_layout_test.dart
+++ b/packages/feature_iptv/test/presentation/widgets/video_player_widget_error_layout_test.dart
@@ -164,6 +164,12 @@ void main() {
         find.byKey(const ValueKey('iptv-player-lock-button')),
         findsNothing,
       );
+      // issues/1025: the idle center play button and hover chrome (volume,
+      // buffer label, PiP/track/fullscreen) must never composite on top of
+      // the error overlay — not just be faded out.
+      expect(find.byIcon(Icons.play_arrow_rounded), findsNothing);
+      expect(find.byIcon(Icons.play_arrow), findsNothing);
+      expect(find.textContaining('Buffer:'), findsNothing);
     },
   );
 


### PR DESCRIPTION
## Summary
- Investigated #1025 (player overlays stack: error + idle play button + hover chrome all visible at once). The actual fix already landed in `5a073375` (#1391, 2026-08-01): `blocksPlaybackChrome` now gates every overlay layer in `video_player_widget.dart` via `if` (removes from the tree, not just opacity 0), and the TV channel grid/list scrollbar duplication was fixed with a single `Scrollbar` wrapping a suppressed `ScrollConfiguration`.
- What was missing: no regression test asserted the exact scenario from the bug report (play button + hover chrome compositing over the error text). Existing test `diagnostic error replaces a retained video view and all player chrome` already checked the controls-opacity/lock-button keys are absent; this PR adds explicit icon/text assertions (`play_arrow`/`play_arrow_rounded`, `Buffer:` text) so a regression here fails CI instead of surfacing as a screenshot report again.
- Also checked the "track/film-strip button" sub-item from the issue: it's the Cinema Mode toggle (`theaters`/`wb_sunny` icons), correctly wired to `_isCinemaMode` and the vignette overlay — not broken, just unlabeled to the reporter. No change needed.

## Test plan
- [x] `flutter test test/presentation/widgets/video_player_widget_error_layout_test.dart` — 11/11 passing
- [x] `flutter analyze` on touched files — no issues
- [ ] Device/visual verification on macOS desktop + 1920x1080 TV profile — tracked separately in the QA issue below, since this thread only had CI/simulated coverage

Closes #1025 (pending QA sign-off issue below).

🤖 Generated with [Claude Code](https://claude.com/claude-code)