### PR TITLE
fix(feature_iptv): two-over-one layout for 3-tile multiview (#829)

### DIFF
--- a/packages/feature_iptv/lib/presentation/tv_ux/sections/multiview_stage.dart
+++ b/packages/feature_iptv/lib/presentation/tv_ux/sections/multiview_stage.dart
@@ -51,6 +51,32 @@ class MultiviewStage extends StatelessWidget {
       );
     }
 
+    if (activeSessions.length == 3) {
+      // A 2-column grid leaves a dead fourth cell for exactly three tiles;
+      // two-over-one keeps every tile equally sized with no empty space.
+      Widget tileFor(IptvMultiviewSession session) => _PromotableSurface(
+        session: session,
+        featured: session.id == featuredChannelId,
+        onPromote: onPromote,
+        onSwap: onSwap,
+        featuredChannelId: featuredChannelId,
+      );
+      return Column(
+        key: const ValueKey('multiview-layout-triple'),
+        children: [
+          Expanded(
+            child: Row(
+              children: [
+                Expanded(child: tileFor(activeSessions[0])),
+                Expanded(child: tileFor(activeSessions[1])),
+              ],
+            ),
+          ),
+          Expanded(child: tileFor(activeSessions[2])),
+        ],
+      );
+    }
+
     return GridView.count(
       key: ValueKey('multiview-layout-quad-${activeSessions.length}'),
       physics: const NeverScrollableScrollPhysics(),

--- a/packages/feature_iptv/test/iptv/presentation/tv_ux/multiview_stage_test.dart
+++ b/packages/feature_iptv/test/iptv/presentation/tv_ux/multiview_stage_test.dart
@@ -67,26 +67,45 @@ void main() {
     expect(find.byKey(const ValueKey('player-two')), findsOneWidget);
   });
 
-  for (final count in [3, 4]) {
-    testWidgets('$count channels use a stable quad layout', (tester) async {
-      final sessions = [
-        for (var index = 1; index <= count; index++) session('$index'),
-      ];
-      addTearDown(() => Future.wait(sessions.map((item) => item.close())));
-      await pump(tester, sessions);
+  testWidgets('3 channels use the two-over-one layout, no dead grid cell', (
+    tester,
+  ) async {
+    final sessions = [session('1'), session('2'), session('3')];
+    addTearDown(() => Future.wait(sessions.map((item) => item.close())));
+    await pump(tester, sessions);
 
-      expect(
-        find.byKey(ValueKey('multiview-layout-quad-$count')),
-        findsOneWidget,
-      );
-      expect(
-        find.byKey(const ValueKey('multiview-thumbnail-strip')),
-        findsNothing,
-      );
-      expect(find.byIcon(Icons.volume_up), findsOneWidget);
-      expect(find.byIcon(Icons.volume_off), findsNWidgets(count - 1));
-    });
-  }
+    expect(
+      find.byKey(const ValueKey('multiview-layout-triple')),
+      findsOneWidget,
+    );
+    expect(find.byKey(const ValueKey('multiview-layout-quad-3')), findsNothing);
+    expect(
+      find.byKey(const ValueKey('multiview-thumbnail-strip')),
+      findsNothing,
+    );
+    expect(find.byIcon(Icons.volume_up), findsOneWidget);
+    expect(find.byIcon(Icons.volume_off), findsNWidgets(2));
+  });
+
+  testWidgets('4 channels use a stable quad layout', (tester) async {
+    const count = 4;
+    final sessions = [
+      for (var index = 1; index <= count; index++) session('$index'),
+    ];
+    addTearDown(() => Future.wait(sessions.map((item) => item.close())));
+    await pump(tester, sessions);
+
+    expect(
+      find.byKey(ValueKey('multiview-layout-quad-$count')),
+      findsOneWidget,
+    );
+    expect(
+      find.byKey(const ValueKey('multiview-thumbnail-strip')),
+      findsNothing,
+    );
+    expect(find.byIcon(Icons.volume_up), findsOneWidget);
+    expect(find.byIcon(Icons.volume_off), findsNWidgets(count - 1));
+  });
 
   testWidgets('D-pad focus promotes the focused tile for audio', (
     tester,


### PR DESCRIPTION
## Summary
- #829 (V2 Local Multiview) was marked "Deferred" pending CV-001 (#805) and CV-016 (#820) — both now closed, so the tracking issue is stale/unblocking. Investigated whether the full "up to 9 tiles" scope is buildable now.
- It isn't, safely: #829's own Non-Goals explicitly forbid raising the tile cap without a resource-guard design ("no fixed N copied from a competitor"). CV-001 shipped reactive diagnostics/bounded retry only — no admission-control/capacity-check API exists anywhere in `platform_player`/`platform_media` to reuse. Raising `kAiroMultiviewHardCap` (currently 4) today would be exactly the thing the issue says not to do.
- What *is* safely buildable within the existing 4-tile cap: `MultiviewStage`'s 3-tile case rendered a 2-column grid with a dead fourth cell — not adaptive. Fixed with a two-over-one layout (all three tiles equal size, no empty space).

## Out of scope / follow-up needed
- Raising the tile cap toward 9 needs new predictive resource-guard/admission-control infrastructure (querying `AiroRuntimeDeviceProfile`/memory budget → decoder count) — doesn't exist today, is its own scoped follow-up.
- Left scoping comments on #1047 and #1048 (cast/mirror — need a cast-session contract that doesn't exist yet; likely overlaps the in-progress `tv-zero-copy-cast` work) and opened #1588 for #1462 device QA.

## Test plan
- [x] `flutter test test/iptv/presentation/tv_ux/multiview_stage_test.dart` — split the old 3/4 shared-case test into distinct 3-tile (`multiview-layout-triple`) and 4-tile (`multiview-layout-quad-4`) assertions
- [x] `flutter test` (full `feature_iptv` suite) — 865/865 passing
- [x] `flutter analyze` on touched files — no issues

Progresses #829 (does not close it — 9-tile scope needs the resource-guard follow-up first).

🤖 Generated with [Claude Code](https://claude.com/claude-code)