### PR TITLE
fix(coin-vault): bump flutter_secure_storage to ^11.0.0

### DIFF
--- a/packages/platform_coin_vault/pubspec.yaml
+++ b/packages/platform_coin_vault/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
     path: ../core_data
   cryptography: ^2.7.0
   local_auth: ^2.3.0
-  flutter_secure_storage: ^10.3.1
+  flutter_secure_storage: ^11.0.0
   sqflite: ^2.4.3
   equatable: ^2.1.0
 


### PR DESCRIPTION
## Summary
- `core_data` requires `flutter_secure_storage ^11.0.0` since PR #1608. `platform_coin_vault` was still pinned to `^10.3.1`, so `flutter pub get` fails for any flavor pulling both packages transitively (mind, coins). Found while running physical-device verification for milestone #22 (issue #1592).
- No API usage change: `VaultSecureStorage` only calls `read`/`write`/`delete`, unaffected by the 10→11 bump.

## Test plan
- [x] `flutter pub get` succeeds for `pubspec_mind.yaml`
- [x] `cd packages/platform_coin_vault && flutter analyze` — no issues found