### PR TITLE
fix(app): remove shadowing isFirebaseInitialized global; rename AppLogger collision

### DIFF
--- a/app/lib/core/providers/streaming_telemetry_consent_provider.dart
+++ b/app/lib/core/providers/streaming_telemetry_consent_provider.dart
@@ -41,7 +41,7 @@ const _consentWithheld = AiroAnalyticsConsentState(
 );
 
 /// Builds the initial consent state for
-/// `AppLogger.setAnalyticsService` at startup, before the
+/// `PlatformMediaLogger.setAnalyticsService` at startup, before the
 /// `ProviderScope` (and therefore [streamingTelemetryConsentProvider])
 /// exists.
 AiroAnalyticsConsentState loadStreamingTelemetryConsent(

--- a/app/lib/main_tv.dart
+++ b/app/lib/main_tv.dart
@@ -32,6 +32,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 
 import 'core/app/airo_tv_app.dart';
 import 'core/audio/tv_audio_service.dart';
+import 'core/config/firebase_status.dart';
 import 'core/config/platform_features.dart';
 import 'core/error/global_error_handler.dart';
 import 'core/platform/device_form_factor.dart';
@@ -44,8 +45,6 @@ import 'features/iptv/iptv_cast_provider_override.dart';
 import 'features/iptv/iptv_feature_module.dart';
 import 'firebase_options.dart';
 
-/// Global flag to track if Firebase is available
-bool isFirebaseInitialized = false;
 typedef TvFirebaseInitializer = Future<void> Function();
 typedef TvDebugPlaylistLoader =
     Future<List<IPTVChannel>> Function(
@@ -93,14 +92,14 @@ void main() async {
   // Phase 1 streaming telemetry (F7.1/F7.5) -- opt-in only, nothing
   // recorded until the user grants it in Settings. Constructed with
   // whatever was last persisted (withheld on a fresh install) and
-  // wired into AppLogger before anything else can call
-  // AppLogger.analytics(); the settings toggle later calls
+  // wired into PlatformMediaLogger before anything else can call
+  // PlatformMediaLogger.analytics(); the settings toggle later calls
   // .updateConsent() on this exact instance via
   // streamingTelemetryServiceProvider's override below.
   final streamingTelemetryService = AiroLocalDiagnosticsAnalyticsService(
     consent: loadStreamingTelemetryConsent(prefs),
   );
-  AppLogger.setAnalyticsService(streamingTelemetryService);
+  PlatformMediaLogger.setAnalyticsService(streamingTelemetryService);
 
   final shouldWarmDebugPlaylist = await seedTvDebugDefaultPlaylist(prefs);
   final mutableXmltvRepository = MutableXmltvCompactEpgRepository();

--- a/packages/feature_iptv_core/lib/src/iptv_settings_manifest.dart
+++ b/packages/feature_iptv_core/lib/src/iptv_settings_manifest.dart
@@ -128,7 +128,7 @@ final List<IptvSettingsSectionDescriptor> iptvSettingsSections = [
   ),
   // Phase 1 streaming telemetry consent (F7.5, tv-zero-copy-cast-phase1
   // Task 7). TV-only for now: only main_tv.dart bootstraps
-  // AppLogger.setAnalyticsService today, so a mobile toggle would
+  // PlatformMediaLogger.setAnalyticsService today, so a mobile toggle would
   // persist a preference with no live service to apply it to. Widen
   // visibleForShells once the phone entrypoint gets the same bootstrap.
   IptvSettingsSectionDescriptor(

--- a/packages/platform_media/lib/src/platform_media_logger.dart
+++ b/packages/platform_media/lib/src/platform_media_logger.dart
@@ -3,7 +3,7 @@ import 'dart:async';
 import 'package:core_analytics/core_analytics.dart';
 import 'package:flutter/foundation.dart';
 
-class AppLogger {
+class PlatformMediaLogger {
   static AiroAnalyticsService _analyticsService =
       const AiroNoOpAnalyticsService();
 

--- a/packages/platform_media/lib/src/video_player_streaming_service.dart
+++ b/packages/platform_media/lib/src/video_player_streaming_service.dart
@@ -86,7 +86,7 @@ class VideoPlayerStreamingService implements IPTVStreamingService {
     try {
       await call(delegate);
     } catch (e) {
-      AppLogger.info('Media session delegate error: $e', tag: 'MEDIA_SESSION');
+      PlatformMediaLogger.info('Media session delegate error: $e', tag: 'MEDIA_SESSION');
     }
   }
 
@@ -113,11 +113,11 @@ class VideoPlayerStreamingService implements IPTVStreamingService {
 
   /// M2: Handle drift warning before auto-resync
   void _handleDriftWarning(Duration delay) {
-    AppLogger.info(
+    PlatformMediaLogger.info(
       'Drift detected: ${delay.inSeconds}s behind live edge',
       tag: 'LIVE_DVR',
     );
-    AppLogger.analytics(
+    PlatformMediaLogger.analytics(
       'live_stream_drift_detected',
       params: {
         'channel': _state.currentChannel?.name,
@@ -130,7 +130,7 @@ class VideoPlayerStreamingService implements IPTVStreamingService {
     // Auto-resync to live edge when drift exceeds threshold
     // Only auto-resync if not paused by user
     if (_state.playbackState == PlaybackState.playing) {
-      AppLogger.analytics(
+      PlatformMediaLogger.analytics(
         'live_stream_auto_resync',
         params: {
           'channel': _state.currentChannel?.name,
@@ -663,7 +663,7 @@ class VideoPlayerStreamingService implements IPTVStreamingService {
           activeSourceId: sourceId,
           networkKey: _placeholderNetworkKey,
         )..sessionStarted();
-    AppLogger.analytics(
+    PlatformMediaLogger.analytics(
       'streaming_session_started',
       params: {'network_key': _placeholderNetworkKey},
     );
@@ -684,7 +684,7 @@ class VideoPlayerStreamingService implements IPTVStreamingService {
     _metricsActiveSourceId = null;
     if (collector == null) return;
     final summary = collector.sessionStopped();
-    AppLogger.analytics(
+    PlatformMediaLogger.analytics(
       'streaming_session_summary',
       params: summary.toAnalyticsEvent().params,
     );
@@ -804,13 +804,13 @@ class VideoPlayerStreamingService implements IPTVStreamingService {
 
       if (position < dvrStart) {
         clampedPosition = dvrStart;
-        AppLogger.info(
+        PlatformMediaLogger.info(
           'Seek clamped to DVR start: ${dvrStart.inSeconds}s',
           tag: 'LIVE_DVR',
         );
       } else if (position > liveEdge) {
         clampedPosition = liveEdge;
-        AppLogger.info(
+        PlatformMediaLogger.info(
           'Seek clamped to live edge: ${liveEdge.inSeconds}s',
           tag: 'LIVE_DVR',
         );
@@ -821,7 +821,7 @@ class VideoPlayerStreamingService implements IPTVStreamingService {
     _updateState(_state.copyWith(position: clampedPosition));
 
     if (_state.isLiveStream) {
-      AppLogger.analytics(
+      PlatformMediaLogger.analytics(
         'live_stream_seek',
         params: {
           'channel': _state.currentChannel?.name,
@@ -856,7 +856,7 @@ class VideoPlayerStreamingService implements IPTVStreamingService {
       ),
     );
 
-    AppLogger.analytics(
+    PlatformMediaLogger.analytics(
       'go_live_tapped',
       params: {
         'channel': _state.currentChannel?.name,

--- a/packages/platform_media/test/platform_media_test.dart
+++ b/packages/platform_media/test/platform_media_test.dart
@@ -20,7 +20,7 @@ void main() {
     };
     addTearDown(() => debugPrint = previousDebugPrint);
 
-    AppLogger.analytics(
+    PlatformMediaLogger.analytics(
       'live_stream_seek',
       params: const {'channel': 'City News Live', 'delay': 5},
     );

--- a/packages/platform_media/test/streaming_telemetry_leak_scan_test.dart
+++ b/packages/platform_media/test/streaming_telemetry_leak_scan_test.dart
@@ -22,7 +22,7 @@ class _RecordingAnalyticsService extends AiroNoOpAnalyticsService {
 /// Xtream-style path, or a query-string token never survives into an
 /// emitted analytics event -- run through the *real* wired path
 /// (VideoPlayerStreamingService -> StreamingSessionMetricsCollector ->
-/// AppLogger.analytics), not just the isolated model.
+/// PlatformMediaLogger.analytics), not just the isolated model.
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
@@ -37,12 +37,12 @@ void main() {
     engine = VideoPlayerAiroPlaybackEngine();
     service = VideoPlayerStreamingService(engine: engine);
     recordedEvents = [];
-    AppLogger.setAnalyticsService(_RecordingAnalyticsService(recordedEvents));
+    PlatformMediaLogger.setAnalyticsService(_RecordingAnalyticsService(recordedEvents));
   });
 
   tearDown(() async {
     await service.dispose();
-    AppLogger.setAnalyticsService(const AiroNoOpAnalyticsService());
+    PlatformMediaLogger.setAnalyticsService(const AiroNoOpAnalyticsService());
   });
 
   const hostileUrls = {

--- a/packages/platform_media/test/video_player_streaming_service_metrics_test.dart
+++ b/packages/platform_media/test/video_player_streaming_service_metrics_test.dart
@@ -38,12 +38,12 @@ void main() {
     engine = VideoPlayerAiroPlaybackEngine();
     service = VideoPlayerStreamingService(engine: engine);
     recordedEvents = [];
-    AppLogger.setAnalyticsService(_RecordingAnalyticsService(recordedEvents));
+    PlatformMediaLogger.setAnalyticsService(_RecordingAnalyticsService(recordedEvents));
   });
 
   tearDown(() async {
     await service.dispose();
-    AppLogger.setAnalyticsService(const AiroNoOpAnalyticsService());
+    PlatformMediaLogger.setAnalyticsService(const AiroNoOpAnalyticsService());
   });
 
   group('VideoPlayerStreamingService streaming QoE telemetry (F7.1)', () {
@@ -143,7 +143,7 @@ void main() {
 
         // The session started when the loop first attempted a source but
         // was never handed a first frame; it's only finalized -- and only
-        // then does the summary reach AppLogger -- once something ends it.
+        // then does the summary reach PlatformMediaLogger -- once something ends it.
         recordedEvents.clear();
         await service.stop();
 


### PR DESCRIPTION
## Summary
- `main_tv.dart` had a second, shadowing top-level `isFirebaseInitialized` instead of importing `core/config/firebase_status.dart` — TV shells could read a stale/wrong value depending on import path.
- Renamed `platform_media`'s `AppLogger` → `PlatformMediaLogger`. It collided by name with the unrelated ring-buffer `AppLogger` in `app/lib/core/utils/logger.dart`; any code pulling both barrels got whichever one won import resolution.

Closes #1674

## Test plan
- [x] `dart analyze app/lib/main_tv.dart` — clean
- [x] `dart analyze packages/platform_media` — clean
- [x] `flutter test packages/platform_media` — 170/170 pass
- [x] `grep -rn isFirebaseInitialized app/lib` — single declaration in `firebase_status.dart`
- [x] `grep -rn AppLogger` across app/packages — remaining hits are the unrelated ring-buffer logger only

🤖 Generated with [Claude Code](https://claude.com/claude-code)