### PR TITLE
docs(coins): production-harden receipt OCR devex — shim investigation, fixture verify, CI coverage (#257)

### DIFF
--- a/app/android/app/build.gradle.kts
+++ b/app/android/app/build.gradle.kts
@@ -432,6 +432,14 @@ flutter {
 
 tasks.withType<JavaCompile>().configureEach {
     doFirst {
+        // Temporary Android compatibility shim for v2 receipt/device hardening.
+        // The app still relies on the package:shared_preferences legacy API across
+        // startup and Coins flows. Keep registration on the legacy Android backend
+        // until emulator/device coverage proves the default DataStore-backed
+        // SharedPreferencesPlugin preserves existing preference reads and writes.
+        // Removal criteria: delete this rewrite only after the Android receipt
+        // parser integration test and a startup/preferences smoke test pass with
+        // the unmodified Flutter GeneratedPluginRegistrant.
         val registrant = file("src/main/java/io/flutter/plugins/GeneratedPluginRegistrant.java")
         if (!registrant.exists()) return@doFirst
 

--- a/app/android/app/build.gradle.kts
+++ b/app/android/app/build.gradle.kts
@@ -440,6 +440,16 @@ tasks.withType<JavaCompile>().configureEach {
         // Removal criteria: delete this rewrite only after the Android receipt
         // parser integration test and a startup/preferences smoke test pass with
         // the unmodified Flutter GeneratedPluginRegistrant.
+        //
+        // Investigated 2026-08-13 (issue #257): shared_preferences_android 2.4.27
+        // (pinned via pubspec.lock) has no Kotlin/Java constructor mismatch --
+        // SharedPreferencesPlugin's no-arg constructor is plain Java-callable, and
+        // LegacySharedPreferencesPlugin was itself converted to Kotlin in 2.4.27.
+        // There is no compiler-level bug left to fix by bumping/pinning the
+        // dependency; this is purely a behavior-parity guard (DataStore-backed
+        // reads/writes vs. the legacy SharedPreferences file) that only an
+        // emulator/device run can retire. No Android SDK/emulator was available on
+        // this host to perform that validation, so the shim stays.
         val registrant = file("src/main/java/io/flutter/plugins/GeneratedPluginRegistrant.java")
         if (!registrant.exists()) return@doFirst
 

--- a/docs/features/coins/TDD_OCR_RECEIPT_PROCESSING.md
+++ b/docs/features/coins/TDD_OCR_RECEIPT_PROCESSING.md
@@ -79,6 +79,42 @@ existing preference reads and writes. Remove it only after the Android receipt
 parser integration test and a startup/preferences smoke test pass with the
 unmodified Flutter `GeneratedPluginRegistrant`.
 
+**Investigation (2026-08-13, issue #257):** checked whether a
+`shared_preferences_android` version pin/upgrade removes the need for the
+shim. The pinned version (2.4.27, per `pubspec.lock`) shows no Kotlin/Java
+build incompatibility — `SharedPreferencesPlugin`'s constructor is a plain
+no-arg Java-callable constructor, and `LegacySharedPreferencesPlugin` was
+itself migrated to Kotlin in the same 2.4.27 release. There is no dependency
+version to bump that fixes a compile error, because there isn't one; the
+shim exists solely to freeze behavior during the DataStore migration until
+emulator/device coverage proves parity. That validation still requires an
+Android SDK + emulator, which was not available in this session — the
+removal criteria above remain the tracking mechanism.
+
+### 1.6 CI Coverage Decision (issue #257)
+
+Unit-level receipt parser tests are already exercised in CI with no extra
+wiring needed:
+
+- `test/features/bill_split/receipt_pdf_pipeline_test.dart`
+- `test/features/bill_split/receipt_invoice_layout_parser_test.dart`
+- `test/features/bill_split/receipt_parser_fallback_hook_test.dart`
+- `test/features/coins/coins_split_workflow_test.dart`
+
+The `test-app` job in `.github/workflows/ci.yml` runs `flutter test
+--coverage --reporter=compact` from `app/`, which picks up the whole
+`app/test/` tree by default — these four files run on every push and every
+PR targeting `main`/`v2`.
+
+The Android device/emulator integration test
+(`integration_test/receipt_on_device_parser_test.dart`, driven via `flutter
+drive`) stays manual/gated. No workflow in this repo currently provisions an
+Android emulator (`grep -rn integration_test .github/workflows/` returns no
+hits), and adding one is a real cost/maintenance decision (emulator boot
+time, KVM/HAXM availability on GitHub-hosted runners, flakiness) that is out
+of scope for this hardening pass. Run it manually per the commands in
+section 1.4 before a release that touches the receipt OCR pipeline.
+
 ---
 
 ## 2. Architecture

--- a/docs/features/coins/TDD_OCR_RECEIPT_PROCESSING.md
+++ b/docs/features/coins/TDD_OCR_RECEIPT_PROCESSING.md
@@ -33,6 +33,38 @@ The OCR Receipt Processing Pipeline enables users to scan physical receipts usin
 - Handwritten receipt recognition
 - Non-receipt document scanning (invoices, statements)
 
+### 1.4 Image-only PDF Fixture
+
+The PDF receipt integration test uses an image-only Urban Company invoice
+fixture so the parser must exercise the PDF renderer and OCR path. Generate it
+from the repository root:
+
+```bash
+python3 scripts/generate_receipt_pdf_fixture.py
+```
+
+The default output is:
+
+```text
+artifacts/fixtures/uc_invoice_image_only.pdf
+```
+
+Push it to an attached Android device or emulator before running the device
+test:
+
+```bash
+adb push artifacts/fixtures/uc_invoice_image_only.pdf /data/local/tmp/uc_invoice.pdf
+cd app
+flutter drive \
+  --driver=test_driver/integration_test.dart \
+  --target=integration_test/receipt_on_device_parser_test.dart \
+  -d emulator-5554 \
+  --dart-define=RECEIPT_PDF_PATH=/data/local/tmp/uc_invoice.pdf
+```
+
+The generator is dependency-free and writes PDF pages containing only raster
+image XObjects, not extractable PDF text.
+
 ---
 
 ## 2. Architecture
@@ -875,4 +907,3 @@ app/lib/features/coins/
 |------|---------|--------|---------|
 | 2026-02-15 | 1.0 | Airo Team | Initial draft |
 ```
-

--- a/docs/features/coins/TDD_OCR_RECEIPT_PROCESSING.md
+++ b/docs/features/coins/TDD_OCR_RECEIPT_PROCESSING.md
@@ -65,6 +65,20 @@ flutter drive \
 The generator is dependency-free and writes PDF pages containing only raster
 image XObjects, not extractable PDF text.
 
+### 1.5 Android Shared Preferences Registration Guard
+
+Android builds currently keep a temporary Gradle shim that rewrites Flutter's
+generated `shared_preferences_android` registration from the DataStore-backed
+`SharedPreferencesPlugin` to `LegacySharedPreferencesPlugin`. This is scoped to
+Android Java compilation and preserves the legacy `package:shared_preferences`
+backend used by startup, settings, and Coins flows while v2 receipt hardening is
+being validated on emulator/device.
+
+Do not treat this as receipt business logic. It is a compatibility guard for
+existing preference reads and writes. Remove it only after the Android receipt
+parser integration test and a startup/preferences smoke test pass with the
+unmodified Flutter `GeneratedPluginRegistrant`.
+
 ---
 
 ## 2. Architecture

--- a/scripts/generate_receipt_pdf_fixture.py
+++ b/scripts/generate_receipt_pdf_fixture.py
@@ -1,0 +1,226 @@
+#!/usr/bin/env python3
+"""Generate a deterministic image-only Urban Company receipt PDF fixture.
+
+The output PDF contains raster images only. It intentionally avoids PDF text
+operators so the receipt parser must go through the PDF-rendering + OCR path.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import zlib
+from dataclasses import dataclass
+
+
+FONT = {
+    " ": ["00000", "00000", "00000", "00000", "00000", "00000", "00000"],
+    "-": ["00000", "00000", "00000", "11111", "00000", "00000", "00000"],
+    ".": ["00000", "00000", "00000", "00000", "00000", "01100", "01100"],
+    "/": ["00001", "00010", "00100", "01000", "10000", "00000", "00000"],
+    ":": ["00000", "01100", "01100", "00000", "01100", "01100", "00000"],
+    "0": ["01110", "10001", "10011", "10101", "11001", "10001", "01110"],
+    "1": ["00100", "01100", "00100", "00100", "00100", "00100", "01110"],
+    "2": ["01110", "10001", "00001", "00010", "00100", "01000", "11111"],
+    "3": ["11110", "00001", "00001", "01110", "00001", "00001", "11110"],
+    "4": ["00010", "00110", "01010", "10010", "11111", "00010", "00010"],
+    "5": ["11111", "10000", "10000", "11110", "00001", "00001", "11110"],
+    "6": ["00110", "01000", "10000", "11110", "10001", "10001", "01110"],
+    "7": ["11111", "00001", "00010", "00100", "01000", "01000", "01000"],
+    "8": ["01110", "10001", "10001", "01110", "10001", "10001", "01110"],
+    "9": ["01110", "10001", "10001", "01111", "00001", "00010", "01100"],
+    "A": ["01110", "10001", "10001", "11111", "10001", "10001", "10001"],
+    "B": ["11110", "10001", "10001", "11110", "10001", "10001", "11110"],
+    "C": ["01110", "10001", "10000", "10000", "10000", "10001", "01110"],
+    "D": ["11110", "10001", "10001", "10001", "10001", "10001", "11110"],
+    "E": ["11111", "10000", "10000", "11110", "10000", "10000", "11111"],
+    "F": ["11111", "10000", "10000", "11110", "10000", "10000", "10000"],
+    "G": ["01110", "10001", "10000", "10111", "10001", "10001", "01110"],
+    "H": ["10001", "10001", "10001", "11111", "10001", "10001", "10001"],
+    "I": ["01110", "00100", "00100", "00100", "00100", "00100", "01110"],
+    "J": ["00001", "00001", "00001", "00001", "10001", "10001", "01110"],
+    "K": ["10001", "10010", "10100", "11000", "10100", "10010", "10001"],
+    "L": ["10000", "10000", "10000", "10000", "10000", "10000", "11111"],
+    "M": ["10001", "11011", "10101", "10101", "10001", "10001", "10001"],
+    "N": ["10001", "11001", "10101", "10011", "10001", "10001", "10001"],
+    "O": ["01110", "10001", "10001", "10001", "10001", "10001", "01110"],
+    "P": ["11110", "10001", "10001", "11110", "10000", "10000", "10000"],
+    "Q": ["01110", "10001", "10001", "10001", "10101", "10010", "01101"],
+    "R": ["11110", "10001", "10001", "11110", "10100", "10010", "10001"],
+    "S": ["01111", "10000", "10000", "01110", "00001", "00001", "11110"],
+    "T": ["11111", "00100", "00100", "00100", "00100", "00100", "00100"],
+    "U": ["10001", "10001", "10001", "10001", "10001", "10001", "01110"],
+    "V": ["10001", "10001", "10001", "10001", "10001", "01010", "00100"],
+    "W": ["10001", "10001", "10001", "10101", "10101", "10101", "01010"],
+    "X": ["10001", "10001", "01010", "00100", "01010", "10001", "10001"],
+    "Y": ["10001", "10001", "01010", "00100", "00100", "00100", "00100"],
+    "Z": ["11111", "00001", "00010", "00100", "01000", "10000", "11111"],
+}
+
+
+@dataclass(frozen=True)
+class Image:
+    width: int
+    height: int
+    pixels: bytearray
+
+
+def new_image(width: int, height: int) -> Image:
+    return Image(width, height, bytearray([255]) * width * height * 3)
+
+
+def fill_rect(image: Image, x: int, y: int, width: int, height: int, color: int) -> None:
+    for row in range(max(0, y), min(image.height, y + height)):
+        for col in range(max(0, x), min(image.width, x + width)):
+            index = (row * image.width + col) * 3
+            image.pixels[index : index + 3] = bytes((color, color, color))
+
+
+def draw_text(image: Image, x: int, y: int, text: str, scale: int = 4) -> None:
+    cursor = x
+    for char in text.upper():
+        glyph = FONT.get(char, FONT[" "])
+        for glyph_y, row in enumerate(glyph):
+            for glyph_x, bit in enumerate(row):
+                if bit == "1":
+                    fill_rect(
+                        image,
+                        cursor + glyph_x * scale,
+                        y + glyph_y * scale,
+                        scale,
+                        scale,
+                        0,
+                    )
+        cursor += 6 * scale
+
+
+def receipt_page(lines: list[str], page_number: int) -> Image:
+    image = new_image(900, 1200)
+    fill_rect(image, 48, 48, 804, 1104, 245)
+    fill_rect(image, 70, 70, 760, 1060, 255)
+    fill_rect(image, 70, 70, 760, 8, 0)
+    fill_rect(image, 70, 1122, 760, 8, 0)
+    fill_rect(image, 70, 70, 8, 1060, 0)
+    fill_rect(image, 822, 70, 8, 1060, 0)
+
+    y = 120
+    for index, line in enumerate(lines):
+        scale = 5 if index == 0 else 4
+        draw_text(image, 115, y, line, scale=scale)
+        y += 58 if scale == 5 else 48
+
+    draw_text(image, 115, 1060, f"PAGE {page_number} / 2", scale=3)
+    return image
+
+
+def pdf_bytes(images: list[Image]) -> bytes:
+    objects: list[bytes] = []
+    page_ids = []
+    next_id = 3
+
+    for image in images:
+        page_id = next_id
+        contents_id = next_id + 1
+        image_id = next_id + 2
+        next_id += 3
+        page_ids.append(page_id)
+
+        compressed = zlib.compress(bytes(image.pixels), level=9)
+        image_object = (
+            f"<< /Type /XObject /Subtype /Image /Width {image.width} "
+            f"/Height {image.height} /ColorSpace /DeviceRGB "
+            f"/BitsPerComponent 8 /Filter /FlateDecode /Length {len(compressed)} >>\n"
+        ).encode("ascii") + b"stream\n" + compressed + b"\nendstream"
+
+        commands = (
+            f"q\n{image.width} 0 0 {image.height} 0 0 cm\n/Im0 Do\nQ\n"
+        ).encode("ascii")
+        contents_object = (
+            f"<< /Length {len(commands)} >>\n".encode("ascii")
+            + b"stream\n"
+            + commands
+            + b"endstream"
+        )
+        page_object = (
+            f"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 {image.width} {image.height}] "
+            f"/Resources << /XObject << /Im0 {image_id} 0 R >> >> "
+            f"/Contents {contents_id} 0 R >>"
+        ).encode("ascii")
+        objects.extend([page_object, contents_object, image_object])
+
+    kids = " ".join(f"{page_id} 0 R" for page_id in page_ids)
+    objects.insert(0, b"<< /Type /Catalog /Pages 2 0 R >>")
+    objects.insert(1, f"<< /Type /Pages /Kids [{kids}] /Count {len(page_ids)} >>".encode("ascii"))
+
+    output = bytearray(b"%PDF-1.4\n%\xe2\xe3\xcf\xd3\n")
+    offsets = [0]
+    for object_id, obj in enumerate(objects, start=1):
+        offsets.append(len(output))
+        output.extend(f"{object_id} 0 obj\n".encode("ascii"))
+        output.extend(obj)
+        output.extend(b"\nendobj\n")
+
+    xref_offset = len(output)
+    output.extend(f"xref\n0 {len(objects) + 1}\n".encode("ascii"))
+    output.extend(b"0000000000 65535 f \n")
+    for offset in offsets[1:]:
+        output.extend(f"{offset:010d} 00000 n \n".encode("ascii"))
+    output.extend(
+        f"trailer\n<< /Size {len(objects) + 1} /Root 1 0 R >>\n"
+        f"startxref\n{xref_offset}\n%%EOF\n".encode("ascii")
+    )
+    return bytes(output)
+
+
+def generate(output_path: str) -> None:
+    pages = [
+        receipt_page(
+            [
+                "URBAN COMPANY",
+                "TAX INVOICE",
+                "INVOICE NO UCIC260010284981",
+                "ITEMS",
+                "CONVENIENCE AND PLATFORM FEE - PLUMBER",
+                "SAC 999799",
+                "TAXABLE VALUE RS 7.63",
+                "IGST 18 PERCENT RS 1.37",
+                "TOTAL AMOUNT RS 9",
+            ],
+            1,
+        ),
+        receipt_page(
+            [
+                "URBAN COMPANY",
+                "TAX INVOICE",
+                "INVOICE NO UCIC260010284982",
+                "ITEMS",
+                "MINOR PLUMBING REPAIR",
+                "SAC 998719",
+                "TAXABLE VALUE RS 377.12",
+                "IGST 18 PERCENT RS 68.88",
+                "TOTAL AMOUNT RS 446",
+                "GRAND TOTAL RS 455",
+            ],
+            2,
+        ),
+    ]
+    os.makedirs(os.path.dirname(os.path.abspath(output_path)), exist_ok=True)
+    with open(output_path, "wb") as handle:
+        handle.write(pdf_bytes(pages))
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "output",
+        nargs="?",
+        default="artifacts/fixtures/uc_invoice_image_only.pdf",
+        help="Output PDF path.",
+    )
+    args = parser.parse_args()
+    generate(args.output)
+    print(args.output)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Continues issue #257 hardening. Update: since this PR was first opened, Android SDK + emulator tooling was installed on this host, which unblocked the two previously-blocked acceptance criteria (emulator integration test, UI smoke test). Running the real device test surfaced **two genuine bugs** neither the existing unit tests nor the never-actually-run fixture generator had caught — both fixed and verified on-device below.

Merged the two commits from the abandoned `codex/v2-receipt-pdf-fixture` branch (cherry-picked by SHA, branch no longer exists):
- `1e6ae4f5` — PDF fixture generator script
- `dc9177f9` — Gradle shim rationale doc

Then investigated the Gradle shim, got a real emulator running, and iterated against real on-device OCR failures until the integration test passed.

## What was done

**1. Gradle shim investigation** (`app/android/app/build.gradle.kts`, unchanged this round)
Checked whether `shared_preferences_android` needs a version pin/upgrade/downgrade. The pinned 2.4.27 shows no Kotlin/Java compile incompatibility — `SharedPreferencesPlugin`'s constructor is plain Java-callable, and `LegacySharedPreferencesPlugin` was itself converted to Kotlin in the same release, so the original "Legacy = Java-compatible" premise is stale. No version bump fixes a compile error that doesn't exist; the shim's real remaining purpose is behavior-parity pending emulator/device validation. Left in place, corrected the rationale comment/doc (see `82a954cb`'s sibling commit `5298377d`).

**2. Fixture generator — verified working, then found genuinely broken against real OCR**
```
$ python3 scripts/generate_receipt_pdf_fixture.py /tmp/uc_invoice.pdf
$ head -c 20 /tmp/uc_invoice.pdf | strings
%PDF-1.4
$ strings /tmp/uc_invoice.pdf | grep -i /Count
<< /Type /Pages /Kids [3 0 R 6 0 R] /Count 2 >>
$ strings /tmp/uc_invoice.pdf | grep -Ei "urban|company|invoice|total"
(no output — confirms image-only, no extractable text)
```
Structurally correct (PDF 1.4, 2 pages, image-only) — but this generator had **never actually been run through ML Kit on a device** before this session. Once an emulator existed, running it exposed real problems: text overflowing the card border (silently truncating an item name) and glyphs too tightly spaced, causing ML Kit to hallucinate extra letters ("INVOICE" → "INHUOI CE"). Fixed in `c645109d` — widened canvas/scale/spacing, iterated against real device OCR output (captured via temporary diagnostic logging, removed before the final commit) until output was stable and correct.

**3. Android emulator integration test — now installed, run, and passing**
Installed Android SDK/cmdline-tools + emulator via Homebrew (already partially present on this host), booted the existing `airo_api36` AVD, pushed the regenerated fixture, and ran:
```
$ adb push /tmp/uc_invoice.pdf /data/local/tmp/uc_invoice.pdf
$ cd app && flutter drive --driver=test_driver/integration_test.dart \
    --target=integration_test/receipt_on_device_parser_test.dart \
    -d emulator-5554 --dart-define=RECEIPT_PDF_PATH=/data/local/tmp/uc_invoice.pdf
...
00:02 +2: All tests passed!
```
Getting here required three additional fixes, none receipt-specific:
- **`dc8e9fc3`** — `flutter_secure_storage` 11.0.0 (already required by `pubspec.yaml` on `main`, but the checked-in `pubspec.lock` was stale) needs `compileSdk 37`; the repo baseline was 36, so **any** Android build on `main` was currently broken. Bumped the single-source-of-truth baseline in `gradle/libs.versions.toml` (guarded by `scripts/check-android-sdk-baseline.sh`, the same mechanism built for the identical prior incident #1575) and synced the 4 flagged library modules.
- **`82a954cb`** — that baseline bump exposed a latent bug in vendored `cargokit`: AGP reports `compileSdkVersion` as `"android-37.0"` for this SDK's minor-version-notation platform, and cargokit's naive `.substring(8) as int` throws on `"37.0"`. One-line parsing fix.
- Also found and fixed a **real receipt-parsing bug**: `82a954cb`'s neighbor, **`8de397a2`** — real OCR consistently misreads "TAX INVOICE" (e.g. "TAX INHUOI CE"), so the multi-invoice section-splitter never split the two pages apart, and the parser silently kept only page 1's total (900 paise) instead of summing both pages (45500 paise). This is exactly the "no cross-page total bleed" failure class the issue's own acceptance criteria call out — the existing unit tests couldn't catch it because they feed in hand-written, already-clean OCR text. Hardened the splitter to also trigger on a repeated "ITEMS" marker (a short word real OCR read reliably, unlike the multi-word "TAX INVOICE"/"INVOICE NO" phrases).

**4. Manual UI smoke test — attempted, blocked by an unrelated pre-existing issue**
Built and installed the integration-test APK (shows the test-runner's "Test finished" screen, not the real app, by design). Rebuilt the real `lib/main.dart` debug APK for the actual smoke test; it failed to compile for two reasons, both **pre-existing on `main`, unrelated to this branch's changes** (confirmed via `git log`/`git status` on the affected files):
- `feature_mind` codegen (`dart run build_runner build`) hadn't been run in this fresh worktree — ran it per the documented CI step.
- After that, `packages/feature_mind/lib/feature_mind.dart` fails to compile: `formatBytes` is exported from both `byte_format.dart` and `format_bytes.dart` — a duplicate-export conflict pre-existing on `main`, unrelated to receipt OCR.
Did not chase this further (out of scope for #257). The on-device *integration test* — the primary, automated proof that the parse pipeline works — does pass; the manual tap-through UI smoke test remains unverified pending a fix to that unrelated `feature_mind` export conflict.

**5. CI coverage — documented, no new wiring needed**
The four unit-level receipt tests already run in CI via `ci.yml`'s `test-app` job (`flutter test --coverage --reporter=compact` from `app/`, which covers the whole `app/test/` tree by default):
```
$ cd app && flutter test \
    test/features/bill_split/receipt_pdf_pipeline_test.dart \
    test/features/bill_split/receipt_invoice_layout_parser_test.dart \
    test/features/bill_split/receipt_parser_fallback_hook_test.dart \
    test/features/coins/coins_split_workflow_test.dart
...
00:00 +10: All tests passed!
```
No workflow in this repo provisions an Android emulator, so the device integration test stays manual/gated — documented as a deliberate decision in TDD doc §1.6.

**6. Analyze / diff-check — clean**
```
$ cd app && flutter analyze \
    lib/features/bill_split/domain/services/receipt_parser_service.dart \
    lib/features/bill_split/domain/services/receipt_pdf_renderer_service.dart \
    lib/features/bill_split/presentation/screens/itemized_split_screen.dart \
    test/features/bill_split/receipt_pdf_pipeline_test.dart \
    test/features/bill_split/receipt_invoice_layout_parser_test.dart \
    test/features/bill_split/receipt_parser_fallback_hook_test.dart \
    integration_test/receipt_on_device_parser_test.dart \
    test_driver/integration_test.dart
Analyzing 8 items...
No issues found! (ran in 3.7s)

$ git diff --check
(clean, exit 0)
```

## Acceptance criteria (#257) status

- [ ] Normal Android build/test path passes without manual generated-file edits — the *integration test* build path now passes clean; the separate `lib/main.dart` full-app build path hits an unrelated pre-existing `feature_mind` export conflict (see §4)
- [x] `GeneratedPluginRegistrant` workaround removed or documented with a strong reason if no better fix exists — documented; no better fix found
- [x] Reproducible image-only Urban Company PDF fixture/generator exists in the repo — verified working, and now verified legible to real on-device OCR
- [x] Unit tests cover PDF renderer route for bytes/file, multi-page OCR ordering, multi-invoice no cross-page total bleed, fallback hook unused by default — all present and passing (10/10)
- [ ] Repeated parse returns the same vendor/total/item names/prices — the on-device integration test asserts this explicitly (`first == second` for every field) and it passes; no separate unit test asserts it against synthetic OCR text
- [x] **Android integration test passes on emulator against the fixture** — `00:02 +2: All tests passed!` on a Pixel 6 (API 36) emulator, real ML Kit OCR, real grand-total math (45500 paise across 2 pages)
- [ ] Itemized split UI clearly handles local PDF parse failure and allows manual entry — implementation exists per prior work, not re-verified via UI smoke test (blocked, see §4)
- [x] No cloud/API fallback introduced — none added, fallback hook stays disabled by default
- [x] `flutter analyze` is clean for touched files
- [x] `git diff --check` is clean
- [x] PR notes include exact commands run and results — see above

## Out of scope (kept out per the issue)
- No cloud/API fallback added.
- No changes to LLM classification follow-up (#1646).
- The `feature_mind` duplicate-export build break (§4) — pre-existing on `main`, unrelated to receipt OCR, needs its own issue.

## Follow-up recommendation
File a separate issue for the `feature_mind` `formatBytes` duplicate-export conflict blocking full-app debug builds on `main` — it blocked the manual UI smoke test here and will block any future full-app build until fixed.

Ref #257.
