### PR TITLE
fix(release): drop dead v2 branch fallbacks, close milestone 11 doc gaps

### DIFF
--- a/.github/workflows/airo-tv-release.yml
+++ b/.github/workflows/airo-tv-release.yml
@@ -147,7 +147,7 @@ jobs:
         if: github.event_name != 'workflow_dispatch' && github.event_name != 'workflow_call'
         run: echo "ref=${GITHUB_REF}" >> "$GITHUB_OUTPUT"
 
-      - name: Create release branch from v2 base
+      - name: Create release branch from main base
         id: release_ref
         if: github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_call'
         env:
@@ -837,7 +837,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
-          ref: ${{ needs.prepare-release-branch.outputs.release_ref || inputs.release_ref || github.event.inputs.release_ref || 'v2' }}
+          ref: ${{ needs.prepare-release-branch.outputs.release_ref || inputs.release_ref || github.event.inputs.release_ref || 'main' }}
 
       - name: Download release artifacts
         uses: actions/download-artifact@v8

--- a/.github/workflows/release-device-qualification.yml
+++ b/.github/workflows/release-device-qualification.yml
@@ -58,9 +58,9 @@ jobs:
 
       - name: Verify release-line base context
         run: |
-          git fetch origin main v2
+          git fetch origin main
           git merge-base --is-ancestor origin/main HEAD || {
-            echo "::warning::This qualification run is not based on origin/main. Use origin/v2 only for explicit v2 releases."
+            echo "::warning::This qualification run is not based on origin/main."
           }
 
       - name: Setup Flutter

--- a/docs/release/RELEASE_DEVICE_QUALIFICATION.md
+++ b/docs/release/RELEASE_DEVICE_QUALIFICATION.md
@@ -26,8 +26,9 @@ change.
 Patrol E2E tests, artifact smoke scripts, release device matrix, and release
 checklist.
 
-**Base branch/worktree:** Confirmed from latest `origin/main` for v1/full app
-release work. Use `origin/v2` only for explicit v2 modular/TV issues.
+**Base branch/worktree:** Confirmed from latest `origin/main` for all release
+work (v2 branch/tag strategy dropped 2026-08-13; current release line is
+`0.0.7-preview`).
 
 **Decision:** Ready.
 

--- a/docs/release/V2_HUMAN_IN_LOOP_BLOCKERS.md
+++ b/docs/release/V2_HUMAN_IN_LOOP_BLOCKERS.md
@@ -1,6 +1,8 @@
 # V2 Human-In-Loop Blocker Index
 
-Last checked: 2026-07-15
+Last checked: 2026-08-13. v2 branch/tag strategy dropped this date — base
+branch is `main`, release line is `0.0.7-preview`; blockers below are
+unaffected by the rename.
 
 This index lists open v2 release blockers that cannot be completed by code
 alone. They require account ownership, credentials, store-console actions,
@@ -19,6 +21,7 @@ exports, playlist URLs, local IP addresses, or private device logs.
 | — | Stable dogfood keystore | Without `DOGFOOD_KEYSTORE_BASE64` set, every non-production-signed RC build gets a fresh throwaway cert and RCs cannot upgrade over each other (`INSTALL_FAILED_UPDATE_INCOMPATIBLE`). Generate a stable keystore reserved for dogfood/RC builds (separate from the production release keystore) and add it as a secret. |
 | #585 | Store automation credentials | Create/confirm Play Console service account, app access, upload permissions, first tracks, and App Store Connect credentials only if iOS/iPadOS enters scope. |
 | #682 | Firebase App Distribution | Create/confirm Firebase apps, app IDs, tester groups, and service account/token for internal QA uploads. |
+| #803 | macOS notarization | Provide Apple Developer ID application certificate + notarization credentials (`APPLE_ID`, app-specific password, Team ID) so `airo-macos-release.yml` can sign and notarize the Airo TV DMG. |
 
 ## Recently Resolved Release Setup
 

--- a/docs/release/V2_LICENSE_REVIEW.md
+++ b/docs/release/V2_LICENSE_REVIEW.md
@@ -66,6 +66,8 @@ hive_flutter
 image_picker
 intl
 just_audio
+media_kit
+media_kit_libs_video
 package_info_plus
 path
 path_provider

--- a/docs/release/V2_THIRD_PARTY_NOTICES.md
+++ b/docs/release/V2_THIRD_PARTY_NOTICES.md
@@ -124,6 +124,8 @@ hive_flutter
 image_picker
 intl
 just_audio
+media_kit
+media_kit_libs_video
 package_info_plus
 path
 path_provider


### PR DESCRIPTION
## Summary
- `release-device-qualification.yml` unconditionally fetched a nonexistent `origin/v2` branch — hard-fails the workflow now that v2 is dropped. Fetch `main` only.
- `airo-tv-release.yml` github-release job's final ref fallback pointed at the nonexistent `v2` branch. Falls back to `main`.
- `V2_LICENSE_REVIEW.md` / `V2_THIRD_PARTY_NOTICES.md` dependency list omitted `media_kit`/`media_kit_libs_video`, the most license-sensitive dependency (LGPL libmpv), despite being discussed elsewhere in the same docs.
- `V2_HUMAN_IN_LOOP_BLOCKERS.md` was missing #803 (macOS notarization) and stale-dated before the v2-strategy-drop decision on 2026-08-13.

Part of milestone 11 (epic #674), now targeting base `main` / release line `0.0.7-preview`.

Refs #674 #687 #683

## Test plan
- [x] `python3 -c yaml.safe_load` on both edited workflow files
- [x] `git ls-remote --heads origin v2` confirms no v2 branch exists (reproduces the bug this fixes)
- Docs-only changes otherwise, no app code touched

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>