### PR TITLE
style(app): fix dart format drift from provider pruning (#1669)

### DIFF
--- a/app/lib/core/audio/audio_context_provider.dart
+++ b/app/lib/core/audio/audio_context_provider.dart
@@ -22,4 +22,3 @@ final currentAudioFocusProvider = Provider<AudioFocusType?>((ref) {
   ref.watch(audioContextChangesProvider);
   return manager.currentFocus;
 });
-

--- a/app/lib/core/providers/bedtime_mode_provider.dart
+++ b/app/lib/core/providers/bedtime_mode_provider.dart
@@ -132,4 +132,3 @@ class SleepTimerNotifier extends StateNotifier<int> {
     super.dispose();
   }
 }
-

--- a/app/lib/features/coins/application/providers/dashboard_providers.dart
+++ b/app/lib/features/coins/application/providers/dashboard_providers.dart
@@ -120,4 +120,3 @@ final dashboardRefreshProvider = FutureProvider<void>((ref) async {
   ref.invalidate(spentThisMonthProvider);
   ref.invalidate(pendingTransactionReviewsProvider);
 });
-

--- a/app/lib/features/music/application/providers/beats_audio_provider.dart
+++ b/app/lib/features/music/application/providers/beats_audio_provider.dart
@@ -67,4 +67,3 @@ final beatsAudioHandlerProvider = Provider<BeatsAudioHandler>((ref) {
   }
   return _audioHandler!;
 });
-


### PR DESCRIPTION
## Summary
CI's \`dart format --set-exit-if-changed\` gate started failing on \`main\` (surfaced while reviewing #1707's checks) — 4 files left a trailing blank line after the dead-provider pruning in #1701. Trivial whitespace-only fix.

## Test plan
- [x] \`dart format --set-exit-if-changed\` clean on all 4 files