### PR TITLE
decision: orchestration island seam (#1675) + wire core_native ffiPlugin (#1677)

### DIFF
--- a/app/linux/flutter/generated_plugins.cmake
+++ b/app/linux/flutter/generated_plugins.cmake
@@ -13,6 +13,7 @@ list(APPEND FLUTTER_PLUGIN_LIST
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST
+  core_native
   feature_mind
   jni
   media_kit_native_event_loop

--- a/app/windows/flutter/generated_plugins.cmake
+++ b/app/windows/flutter/generated_plugins.cmake
@@ -22,6 +22,7 @@ list(APPEND FLUTTER_PLUGIN_LIST
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST
+  core_native
   feature_mind
   flutter_local_notifications_windows
   jni

--- a/docs/agents/COUNCIL.md
+++ b/docs/agents/COUNCIL.md
@@ -159,6 +159,8 @@ forbidden_dependencies:
   - <packages this module must never depend on>
 quality_gates:
   test_coverage: ">NN%"   # omit fields with no measured baseline
+status: <optional; e.g. "pre-wired" for a package built ahead of the app
+  flavor that reaches it (#1675) — omit entirely once a package is reachable>
 ```
 
 Reference examples: `packages/platform_epg/module.yaml`,

--- a/packages/core_cloud_orchestration/module.yaml
+++ b/packages/core_cloud_orchestration/module.yaml
@@ -9,3 +9,5 @@ allowed_dependencies:
 forbidden_dependencies:
   - app
 quality_gates: {}
+
+status: pre-wired  # unwired orchestration island (#1675) — built for Play Anywhere (milestone 10), no app flavor reaches it yet. Excluded from the #1681 reachability gate; do not delete without a Play Anywhere activation decision.

--- a/packages/core_commands/module.yaml
+++ b/packages/core_commands/module.yaml
@@ -9,3 +9,5 @@ allowed_dependencies:
 forbidden_dependencies:
   - app
 quality_gates: {}
+
+status: pre-wired  # unwired orchestration island (#1675) — built for Play Anywhere (milestone 10), no app flavor reaches it yet. Excluded from the #1681 reachability gate; do not delete without a Play Anywhere activation decision.

--- a/packages/core_device_identity/module.yaml
+++ b/packages/core_device_identity/module.yaml
@@ -9,3 +9,5 @@ allowed_dependencies:
 forbidden_dependencies:
   - app
 quality_gates: {}
+
+status: pre-wired  # unwired orchestration island (#1675) — built for Play Anywhere (milestone 10), no app flavor reaches it yet. Excluded from the #1681 reachability gate; do not delete without a Play Anywhere activation decision.

--- a/packages/core_device_merge/module.yaml
+++ b/packages/core_device_merge/module.yaml
@@ -10,3 +10,5 @@ allowed_dependencies:
 forbidden_dependencies:
   - app
 quality_gates: {}
+
+status: pre-wired  # unwired orchestration island (#1675) — built for Play Anywhere (milestone 10), no app flavor reaches it yet. Excluded from the #1681 reachability gate; do not delete without a Play Anywhere activation decision.

--- a/packages/core_media_data/module.yaml
+++ b/packages/core_media_data/module.yaml
@@ -8,3 +8,4 @@ allowed_dependencies:
 forbidden_dependencies:
   - app
 quality_gates: {}
+status: pre-wired  # relational-store models for core_native's native path (#1677); only reached today via platform_benchmarks (tool-only), no app flavor consumes it yet. Not archived — it's what exercises the native path this issue just wired.

--- a/packages/core_native/android/.gitignore
+++ b/packages/core_native/android/.gitignore
@@ -1,0 +1,9 @@
+*.iml
+.gradle
+/local.properties
+/.idea/workspace.xml
+/.idea/libraries
+.DS_Store
+/build
+/captures
+.cxx

--- a/packages/core_native/android/build.gradle
+++ b/packages/core_native/android/build.gradle
@@ -1,0 +1,41 @@
+// Cargokit cross-compiles airo_core for each Android ABI using the NDK as
+// part of the ordinary Gradle build (#1677 — wiring the phantom native path
+// feature_mind already proved out; see that package's android/build.gradle
+// for the two-library variant this pattern is mirrored from).
+group = "com.developerscoffee.airo.core_native"
+version = "0.1.0"
+
+buildscript {
+    repositories { google(); mavenCentral() }
+    dependencies { classpath("com.android.tools.build:gradle:8.7.3") }
+}
+
+rootProject.allprojects {
+    repositories { google(); mavenCentral() }
+}
+
+apply plugin: "com.android.library"
+apply from: "../cargokit/gradle/plugin.gradle"
+
+cargokit {
+    // The crate lives in the cargo workspace at <repo>/rust, not inside this
+    // package. Path is relative to this file.
+    manifestDir = "../../../rust/airo_core"
+    libname = "airo_core"
+}
+
+android {
+    namespace = "com.developerscoffee.airo.core_native"
+    // Must track gradle/libs.versions.toml airo-compile-sdk (#1575).
+    compileSdk = 36
+    ndkVersion = "27.0.12077973"
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+
+    defaultConfig {
+        minSdk = 24
+    }
+}

--- a/packages/core_native/android/settings.gradle
+++ b/packages/core_native/android/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'core_native'

--- a/packages/core_native/android/src/main/AndroidManifest.xml
+++ b/packages/core_native/android/src/main/AndroidManifest.xml
@@ -1,0 +1,3 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+        package="com.developerscoffee.airo.core_native">
+</manifest>

--- a/packages/core_native/cargokit/.gitignore
+++ b/packages/core_native/cargokit/.gitignore
@@ -1,0 +1,4 @@
+target
+.dart_tool
+*.iml
+!pubspec.lock

--- a/packages/core_native/cargokit/LICENSE
+++ b/packages/core_native/cargokit/LICENSE
@@ -1,0 +1,42 @@
+/// This is copied from Cargokit (which is the official way to use it currently)
+/// Details: https://fzyzcjy.github.io/flutter_rust_bridge/manual/integrate/builtin
+
+Copyright 2022 Matej Knopp
+
+================================================================================
+
+MIT LICENSE
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS
+OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+================================================================================
+
+APACHE LICENSE, VERSION 2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+

--- a/packages/core_native/cargokit/README
+++ b/packages/core_native/cargokit/README
@@ -1,0 +1,11 @@
+/// This is copied from Cargokit (which is the official way to use it currently)
+/// Details: https://fzyzcjy.github.io/flutter_rust_bridge/manual/integrate/builtin
+
+Experimental repository to provide glue for seamlessly integrating cargo build
+with flutter plugins and packages.
+
+See https://matejknopp.com/post/flutter_plugin_in_rust_with_no_prebuilt_binaries/
+for a tutorial on how to use Cargokit.
+
+Example plugin available at https://github.com/irondash/hello_rust_ffi_plugin.
+

--- a/packages/core_native/cargokit/build_pod.sh
+++ b/packages/core_native/cargokit/build_pod.sh
@@ -1,0 +1,58 @@
+#!/bin/sh
+set -e
+
+BASEDIR=$(dirname "$0")
+
+# Workaround for https://github.com/dart-lang/pub/issues/4010
+BASEDIR=$(cd "$BASEDIR" ; pwd -P)
+
+# Remove XCode SDK from path. Otherwise this breaks tool compilation when building iOS project
+NEW_PATH=`echo $PATH | tr ":" "\n" | grep -v "Contents/Developer/" | tr "\n" ":"`
+
+export PATH=${NEW_PATH%?} # remove trailing :
+
+env
+
+# Platform name (macosx, iphoneos, iphonesimulator)
+export CARGOKIT_DARWIN_PLATFORM_NAME=$PLATFORM_NAME
+
+# Arctive architectures (arm64, armv7, x86_64), space separated.
+export CARGOKIT_DARWIN_ARCHS=$ARCHS
+
+# Current build configuration (Debug, Release)
+export CARGOKIT_CONFIGURATION=$CONFIGURATION
+
+# Path to directory containing Cargo.toml.
+export CARGOKIT_MANIFEST_DIR=$PODS_TARGET_SRCROOT/$1
+
+# Temporary directory for build artifacts.
+export CARGOKIT_TARGET_TEMP_DIR=$TARGET_TEMP_DIR
+
+# Output directory for final artifacts.
+export CARGOKIT_OUTPUT_DIR=$PODS_CONFIGURATION_BUILD_DIR/$PRODUCT_NAME
+
+# Directory to store built tool artifacts.
+export CARGOKIT_TOOL_TEMP_DIR=$TARGET_TEMP_DIR/build_tool
+
+# Directory inside root project. Not necessarily the top level directory of root project.
+export CARGOKIT_ROOT_PROJECT_DIR=$SRCROOT
+
+FLUTTER_EXPORT_BUILD_ENVIRONMENT=(
+  "$PODS_ROOT/../Flutter/ephemeral/flutter_export_environment.sh" # macOS
+  "$PODS_ROOT/../Flutter/flutter_export_environment.sh" # iOS
+)
+
+for path in "${FLUTTER_EXPORT_BUILD_ENVIRONMENT[@]}"
+do
+  if [[ -f "$path" ]]; then
+    source "$path"
+  fi
+done
+
+sh "$BASEDIR/run_build_tool.sh" build-pod "$@"
+
+# Make a symlink from built framework to phony file, which will be used as input to
+# build script. This should force rebuild (podspec currently doesn't support alwaysOutOfDate
+# attribute on custom build phase)
+ln -fs "$OBJROOT/XCBuildData/build.db" "${BUILT_PRODUCTS_DIR}/cargokit_phony"
+ln -fs "${BUILT_PRODUCTS_DIR}/${EXECUTABLE_PATH}" "${BUILT_PRODUCTS_DIR}/cargokit_phony_out"

--- a/packages/core_native/cargokit/build_tool/README.md
+++ b/packages/core_native/cargokit/build_tool/README.md
@@ -1,0 +1,5 @@
+/// This is copied from Cargokit (which is the official way to use it currently)
+/// Details: https://fzyzcjy.github.io/flutter_rust_bridge/manual/integrate/builtin
+
+A sample command-line application with an entrypoint in `bin/`, library code
+in `lib/`, and example unit test in `test/`.

--- a/packages/core_native/cargokit/build_tool/analysis_options.yaml
+++ b/packages/core_native/cargokit/build_tool/analysis_options.yaml
@@ -1,0 +1,34 @@
+# This is copied from Cargokit (which is the official way to use it currently)
+# Details: https://fzyzcjy.github.io/flutter_rust_bridge/manual/integrate/builtin
+
+# This file configures the static analysis results for your project (errors,
+# warnings, and lints).
+#
+# This enables the 'recommended' set of lints from `package:lints`.
+# This set helps identify many issues that may lead to problems when running
+# or consuming Dart code, and enforces writing Dart using a single, idiomatic
+# style and format.
+#
+# If you want a smaller set of lints you can change this to specify
+# 'package:lints/core.yaml'. These are just the most critical lints
+# (the recommended set includes the core lints).
+# The core lints are also what is used by pub.dev for scoring packages.
+
+include: package:lints/recommended.yaml
+
+# Uncomment the following section to specify additional rules.
+
+linter:
+  rules:
+    - prefer_relative_imports
+    - directives_ordering
+
+# analyzer:
+#   exclude:
+#     - path/to/excluded/files/**
+
+# For more information about the core and recommended set of lints, see
+# https://dart.dev/go/core-lints
+
+# For additional information about configuring this file, see
+# https://dart.dev/guides/language/analysis-options

--- a/packages/core_native/cargokit/build_tool/bin/build_tool.dart
+++ b/packages/core_native/cargokit/build_tool/bin/build_tool.dart
@@ -1,0 +1,8 @@
+/// This is copied from Cargokit (which is the official way to use it currently)
+/// Details: https://fzyzcjy.github.io/flutter_rust_bridge/manual/integrate/builtin
+
+import 'package:build_tool/build_tool.dart' as build_tool;
+
+void main(List<String> arguments) {
+  build_tool.runMain(arguments);
+}

--- a/packages/core_native/cargokit/build_tool/lib/build_tool.dart
+++ b/packages/core_native/cargokit/build_tool/lib/build_tool.dart
@@ -1,0 +1,8 @@
+/// This is copied from Cargokit (which is the official way to use it currently)
+/// Details: https://fzyzcjy.github.io/flutter_rust_bridge/manual/integrate/builtin
+
+import 'src/build_tool.dart' as build_tool;
+
+Future<void> runMain(List<String> args) async {
+  return build_tool.runMain(args);
+}

--- a/packages/core_native/cargokit/build_tool/lib/src/android_environment.dart
+++ b/packages/core_native/cargokit/build_tool/lib/src/android_environment.dart
@@ -1,0 +1,247 @@
+/// This is copied from Cargokit (which is the official way to use it currently)
+/// Details: https://fzyzcjy.github.io/flutter_rust_bridge/manual/integrate/builtin
+
+import 'dart:io';
+import 'dart:isolate';
+import 'dart:math' as math;
+
+import 'package:collection/collection.dart';
+import 'package:path/path.dart' as path;
+import 'package:version/version.dart';
+
+import 'target.dart';
+import 'util.dart';
+
+class AndroidEnvironment {
+  AndroidEnvironment({
+    required this.sdkPath,
+    required this.ndkVersion,
+    required this.minSdkVersion,
+    required this.targetTempDir,
+    required this.target,
+  });
+
+  static void clangLinkerWrapper(List<String> args) {
+    final clang = Platform.environment['_CARGOKIT_NDK_LINK_CLANG'];
+    if (clang == null) {
+      throw Exception(
+          "cargo-ndk rustc linker: didn't find _CARGOKIT_NDK_LINK_CLANG env var");
+    }
+    final target = Platform.environment['_CARGOKIT_NDK_LINK_TARGET'];
+    if (target == null) {
+      throw Exception(
+          "cargo-ndk rustc linker: didn't find _CARGOKIT_NDK_LINK_TARGET env var");
+    }
+
+    runCommand(clang, [
+      target,
+      ...args,
+    ]);
+  }
+
+  /// Full path to Android SDK.
+  final String sdkPath;
+
+  /// Full version of Android NDK.
+  final String ndkVersion;
+
+  /// Minimum supported SDK version.
+  final int minSdkVersion;
+
+  /// Target directory for build artifacts.
+  final String targetTempDir;
+
+  /// Target being built.
+  final Target target;
+
+  bool ndkIsInstalled() {
+    final ndkPath = path.join(sdkPath, 'ndk', ndkVersion);
+    final ndkPackageXml = File(path.join(ndkPath, 'package.xml'));
+    return ndkPackageXml.existsSync();
+  }
+
+  void installNdk({
+    required String javaHome,
+  }) {
+    final sdkManagerExtension = Platform.isWindows ? '.bat' : '';
+    final sdkManager = path.join(
+      sdkPath,
+      'cmdline-tools',
+      'latest',
+      'bin',
+      'sdkmanager$sdkManagerExtension',
+    );
+
+    log.info('Installing NDK $ndkVersion');
+    runCommand(sdkManager, [
+      '--install',
+      'ndk;$ndkVersion',
+    ], environment: {
+      'JAVA_HOME': javaHome,
+    });
+  }
+
+  Future<Map<String, String>> buildEnvironment() async {
+    final hostArch = Platform.isMacOS
+        ? "darwin-x86_64"
+        : (Platform.isLinux ? "linux-x86_64" : "windows-x86_64");
+
+    final ndkPath = path.join(sdkPath, 'ndk', ndkVersion);
+    final toolchainPath = path.join(
+      ndkPath,
+      'toolchains',
+      'llvm',
+      'prebuilt',
+      hostArch,
+      'bin',
+    );
+
+    final minSdkVersion =
+        math.max(target.androidMinSdkVersion!, this.minSdkVersion);
+
+    final exe = Platform.isWindows ? '.exe' : '';
+
+    final arKey = 'AR_${target.rust}';
+    final arValue = ['${target.rust}-ar', 'llvm-ar', 'llvm-ar.exe']
+        .map((e) => path.join(toolchainPath, e))
+        .firstWhereOrNull((element) => File(element).existsSync());
+    if (arValue == null) {
+      throw Exception('Failed to find ar for $target in $toolchainPath');
+    }
+
+    final targetArg = '--target=${target.rust}$minSdkVersion';
+
+    final ccKey = 'CC_${target.rust}';
+    final ccValue = path.join(toolchainPath, 'clang$exe');
+    final cfFlagsKey = 'CFLAGS_${target.rust}';
+    final cFlagsValue = targetArg;
+
+    final cxxKey = 'CXX_${target.rust}';
+    final cxxValue = path.join(toolchainPath, 'clang++$exe');
+    final cxxFlagsKey = 'CXXFLAGS_${target.rust}';
+    final cxxFlagsValue = targetArg;
+
+    final linkerKey =
+        'cargo_target_${target.rust.replaceAll('-', '_')}_linker'.toUpperCase();
+
+    final ranlibKey = 'RANLIB_${target.rust}';
+    final ranlibValue = path.join(toolchainPath, 'llvm-ranlib$exe');
+
+    final ndkVersionParsed = Version.parse(ndkVersion);
+    final rustFlagsKey = 'CARGO_ENCODED_RUSTFLAGS';
+    var rustFlagsValue = _libGccWorkaround(targetTempDir, ndkVersionParsed);
+    rustFlagsValue = _ggmlBlasWorkaround(targetTempDir, rustFlagsValue);
+
+    final runRustTool =
+        Platform.isWindows ? 'run_build_tool.cmd' : 'run_build_tool.sh';
+
+    final packagePath = (await Isolate.resolvePackageUri(
+            Uri.parse('package:build_tool/buildtool.dart')))!
+        .toFilePath();
+    final selfPath = path.canonicalize(path.join(
+      packagePath,
+      '..',
+      '..',
+      '..',
+      runRustTool,
+    ));
+
+    // Make sure that run_build_tool is working properly even initially launched directly
+    // through dart run.
+    final toolTempDir =
+        Platform.environment['CARGOKIT_TOOL_TEMP_DIR'] ?? targetTempDir;
+
+    return {
+      arKey: arValue,
+      ccKey: ccValue,
+      cfFlagsKey: cFlagsValue,
+      cxxKey: cxxValue,
+      cxxFlagsKey: cxxFlagsValue,
+      ranlibKey: ranlibValue,
+      rustFlagsKey: rustFlagsValue,
+      linkerKey: selfPath,
+      // llama-cpp-sys-2's build script locates the NDK itself rather than
+      // using CC/CXX, and aborts with "Android NDK not found. Please set one
+      // of: ANDROID_NDK, NDK_ROOT, ANDROID_NDK_ROOT" when none is set.
+      // Cargokit knows the exact NDK it resolved, so it passes it on rather
+      // than leaving each -sys crate to guess. Every host is affected,
+      // including CI.
+      'ANDROID_NDK': ndkPath,
+      'ANDROID_NDK_ROOT': ndkPath,
+      'NDK_ROOT': ndkPath,
+      // Recognized by main() so we know when we're acting as a wrapper
+      '_CARGOKIT_NDK_LINK_TARGET': targetArg,
+      '_CARGOKIT_NDK_LINK_CLANG': ccValue,
+      'CARGOKIT_TOOL_TEMP_DIR': toolTempDir,
+    };
+  }
+
+  /// Workaround for an upstream bug in `whisper-rs-sys` 0.15.0.
+  ///
+  /// Its `build.rs` decides whether whisper.cpp was built with a BLAS backend
+  /// using `cfg!(target_os = "macos")`. A build script is compiled for the
+  /// HOST, so on a Mac that is true no matter what the *target* is, and the
+  /// crate emits `cargo:rustc-link-lib=static=ggml-blas` for an Android build.
+  /// CMake never produced that library -- `CMakeCache.txt` from the same build
+  /// records `GGML_BLAS:BOOL=OFF` -- so the link fails with:
+  ///
+  ///     error: could not find native static library `ggml-blas`
+  ///
+  /// The same file gets it right elsewhere (`target.contains("apple")`), so
+  /// this is an inconsistency rather than a deliberate choice. 0.15.0 is the
+  /// latest release; there is no fixed version to move to.
+  ///
+  /// rustc resolves `-l static=` while *compiling the rlib*, not at final
+  /// link, so a `cargo:rustc-link-search` from a dependent crate is too late.
+  /// It has to arrive as a rustflag, which is also why this cannot live in
+  /// `.cargo/config.toml`: cargokit sets `CARGO_ENCODED_RUSTFLAGS`, and that
+  /// env var makes cargo ignore the config's `rustflags` entirely.
+  ///
+  /// An empty archive is a correct stand-in, not a lie: with BLAS off nothing
+  /// in whisper.cpp references a `ggml_backend_blas_*` symbol, so there is
+  /// nothing for the archive to provide. Same shape as the libgcc workaround
+  /// below, which fabricates a `libgcc.a` for a library NDK 23+ dropped.
+  ///
+  /// Linux and Windows hosts never see the bad flag, so they never get the
+  /// stub -- gating on the host keeps this from masking a genuine missing
+  /// BLAS build on a platform that really did ask for one.
+  String _ggmlBlasWorkaround(String buildDir, String rustFlags) {
+    if (!Platform.isMacOS) {
+      return rustFlags;
+    }
+    final workaroundDir = path.join(buildDir, 'cargokit', 'ggml_blas_stub');
+    Directory(workaroundDir).createSync(recursive: true);
+    // The 8-byte header of an archive with no members. `ar` writes exactly
+    // this for an empty archive, and both ld.lld and rustc accept it.
+    File(path.join(workaroundDir, 'libggml-blas.a'))
+        .writeAsStringSync('!<arch>\n');
+    return '$rustFlags\x1f-L\x1f$workaroundDir';
+  }
+
+  // Workaround for libgcc missing in NDK23, inspired by cargo-ndk
+  String _libGccWorkaround(String buildDir, Version ndkVersion) {
+    final workaroundDir = path.join(
+      buildDir,
+      'cargokit',
+      'libgcc_workaround',
+      '${ndkVersion.major}',
+    );
+    Directory(workaroundDir).createSync(recursive: true);
+    if (ndkVersion.major >= 23) {
+      File(path.join(workaroundDir, 'libgcc.a'))
+          .writeAsStringSync('INPUT(-lunwind)');
+    } else {
+      // Other way around, untested, forward libgcc.a from libunwind once Rust
+      // gets updated for NDK23+.
+      File(path.join(workaroundDir, 'libunwind.a'))
+          .writeAsStringSync('INPUT(-lgcc)');
+    }
+
+    var rustFlags = Platform.environment['CARGO_ENCODED_RUSTFLAGS'] ?? '';
+    if (rustFlags.isNotEmpty) {
+      rustFlags = '$rustFlags\x1f';
+    }
+    rustFlags = '$rustFlags-L\x1f$workaroundDir';
+    return rustFlags;
+  }
+}

--- a/packages/core_native/cargokit/build_tool/lib/src/artifacts_provider.dart
+++ b/packages/core_native/cargokit/build_tool/lib/src/artifacts_provider.dart
@@ -1,0 +1,266 @@
+/// This is copied from Cargokit (which is the official way to use it currently)
+/// Details: https://fzyzcjy.github.io/flutter_rust_bridge/manual/integrate/builtin
+
+import 'dart:io';
+
+import 'package:ed25519_edwards/ed25519_edwards.dart';
+import 'package:http/http.dart';
+import 'package:logging/logging.dart';
+import 'package:path/path.dart' as path;
+
+import 'builder.dart';
+import 'crate_hash.dart';
+import 'options.dart';
+import 'precompile_binaries.dart';
+import 'rustup.dart';
+import 'target.dart';
+
+class Artifact {
+  /// File system location of the artifact.
+  final String path;
+
+  /// Actual file name that the artifact should have in destination folder.
+  final String finalFileName;
+
+  AritifactType get type {
+    if (finalFileName.endsWith('.dll') ||
+        finalFileName.endsWith('.dll.lib') ||
+        finalFileName.endsWith('.pdb') ||
+        finalFileName.endsWith('.so') ||
+        finalFileName.endsWith('.dylib')) {
+      return AritifactType.dylib;
+    } else if (finalFileName.endsWith('.lib') || finalFileName.endsWith('.a')) {
+      return AritifactType.staticlib;
+    } else {
+      throw Exception('Unknown artifact type for $finalFileName');
+    }
+  }
+
+  Artifact({
+    required this.path,
+    required this.finalFileName,
+  });
+}
+
+final _log = Logger('artifacts_provider');
+
+class ArtifactProvider {
+  ArtifactProvider({
+    required this.environment,
+    required this.userOptions,
+  });
+
+  final BuildEnvironment environment;
+  final CargokitUserOptions userOptions;
+
+  Future<Map<Target, List<Artifact>>> getArtifacts(List<Target> targets) async {
+    final result = await _getPrecompiledArtifacts(targets);
+
+    final pendingTargets = List.of(targets);
+    pendingTargets.removeWhere((element) => result.containsKey(element));
+
+    if (pendingTargets.isEmpty) {
+      return result;
+    }
+
+    final rustup = Rustup();
+    for (final target in targets) {
+      final builder = RustBuilder(target: target, environment: environment);
+      builder.prepare(rustup);
+      _log.info('Building ${environment.crateInfo.packageName} for $target');
+      final targetDir = await builder.build();
+      // For local build accept both static and dynamic libraries.
+      final artifactNames = <String>{
+        ...getArtifactNames(
+          target: target,
+          libraryName: environment.crateInfo.packageName,
+          aritifactType: AritifactType.dylib,
+          remote: false,
+        ),
+        ...getArtifactNames(
+          target: target,
+          libraryName: environment.crateInfo.packageName,
+          aritifactType: AritifactType.staticlib,
+          remote: false,
+        )
+      };
+      final artifacts = artifactNames
+          .map((artifactName) => Artifact(
+                path: path.join(targetDir, artifactName),
+                finalFileName: artifactName,
+              ))
+          .where((element) => File(element.path).existsSync())
+          .toList();
+      result[target] = artifacts;
+    }
+    return result;
+  }
+
+  Future<Map<Target, List<Artifact>>> _getPrecompiledArtifacts(
+      List<Target> targets) async {
+    if (userOptions.usePrecompiledBinaries == false) {
+      _log.info('Precompiled binaries are disabled');
+      return {};
+    }
+    if (environment.crateOptions.precompiledBinaries == null) {
+      _log.fine('Precompiled binaries not enabled for this crate');
+      return {};
+    }
+
+    final start = Stopwatch()..start();
+    final crateHash = CrateHash.compute(environment.manifestDir,
+        tempStorage: environment.targetTempDir);
+    _log.fine(
+        'Computed crate hash $crateHash in ${start.elapsedMilliseconds}ms');
+
+    final downloadedArtifactsDir =
+        path.join(environment.targetTempDir, 'precompiled', crateHash);
+    Directory(downloadedArtifactsDir).createSync(recursive: true);
+
+    final res = <Target, List<Artifact>>{};
+
+    for (final target in targets) {
+      final requiredArtifacts = getArtifactNames(
+        target: target,
+        libraryName: environment.crateInfo.packageName,
+        remote: true,
+      );
+      final artifactsForTarget = <Artifact>[];
+
+      for (final artifact in requiredArtifacts) {
+        final fileName = PrecompileBinaries.fileName(target, artifact);
+        final downloadedPath = path.join(downloadedArtifactsDir, fileName);
+        if (!File(downloadedPath).existsSync()) {
+          final signatureFileName =
+              PrecompileBinaries.signatureFileName(target, artifact);
+          await _tryDownloadArtifacts(
+            crateHash: crateHash,
+            fileName: fileName,
+            signatureFileName: signatureFileName,
+            finalPath: downloadedPath,
+          );
+        }
+        if (File(downloadedPath).existsSync()) {
+          artifactsForTarget.add(Artifact(
+            path: downloadedPath,
+            finalFileName: artifact,
+          ));
+        } else {
+          break;
+        }
+      }
+
+      // Only provide complete set of artifacts.
+      if (artifactsForTarget.length == requiredArtifacts.length) {
+        _log.fine('Found precompiled artifacts for $target');
+        res[target] = artifactsForTarget;
+      }
+    }
+
+    return res;
+  }
+
+  static Future<Response> _get(Uri url, {Map<String, String>? headers}) async {
+    int attempt = 0;
+    const maxAttempts = 10;
+    while (true) {
+      try {
+        return await get(url, headers: headers);
+      } on SocketException catch (e) {
+        // Try to detect reset by peer error and retry.
+        if (attempt++ < maxAttempts &&
+            (e.osError?.errorCode == 54 || e.osError?.errorCode == 10054)) {
+          _log.severe(
+              'Failed to download $url: $e, attempt $attempt of $maxAttempts, will retry...');
+          await Future.delayed(Duration(seconds: 1));
+          continue;
+        } else {
+          rethrow;
+        }
+      }
+    }
+  }
+
+  Future<void> _tryDownloadArtifacts({
+    required String crateHash,
+    required String fileName,
+    required String signatureFileName,
+    required String finalPath,
+  }) async {
+    final precompiledBinaries = environment.crateOptions.precompiledBinaries!;
+    final prefix = precompiledBinaries.uriPrefix;
+    final url = Uri.parse('$prefix$crateHash/$fileName');
+    final signatureUrl = Uri.parse('$prefix$crateHash/$signatureFileName');
+    _log.fine('Downloading signature from $signatureUrl');
+    final signature = await _get(signatureUrl);
+    if (signature.statusCode == 404) {
+      _log.warning(
+          'Precompiled binaries not available for crate hash $crateHash ($fileName)');
+      return;
+    }
+    if (signature.statusCode != 200) {
+      _log.severe(
+          'Failed to download signature $signatureUrl: status ${signature.statusCode}');
+      return;
+    }
+    _log.fine('Downloading binary from $url');
+    final res = await _get(url);
+    if (res.statusCode != 200) {
+      _log.severe('Failed to download binary $url: status ${res.statusCode}');
+      return;
+    }
+    if (verify(
+        precompiledBinaries.publicKey, res.bodyBytes, signature.bodyBytes)) {
+      File(finalPath).writeAsBytesSync(res.bodyBytes);
+    } else {
+      _log.shout('Signature verification failed! Ignoring binary.');
+    }
+  }
+}
+
+enum AritifactType {
+  staticlib,
+  dylib,
+}
+
+AritifactType artifactTypeForTarget(Target target) {
+  if (target.darwinPlatform != null) {
+    return AritifactType.staticlib;
+  } else {
+    return AritifactType.dylib;
+  }
+}
+
+List<String> getArtifactNames({
+  required Target target,
+  required String libraryName,
+  required bool remote,
+  AritifactType? aritifactType,
+}) {
+  aritifactType ??= artifactTypeForTarget(target);
+  if (target.darwinArch != null) {
+    if (aritifactType == AritifactType.staticlib) {
+      return ['lib$libraryName.a'];
+    } else {
+      return ['lib$libraryName.dylib'];
+    }
+  } else if (target.rust.contains('-windows-')) {
+    if (aritifactType == AritifactType.staticlib) {
+      return ['$libraryName.lib'];
+    } else {
+      return [
+        '$libraryName.dll',
+        '$libraryName.dll.lib',
+        if (!remote) '$libraryName.pdb'
+      ];
+    }
+  } else if (target.rust.contains('-linux-')) {
+    if (aritifactType == AritifactType.staticlib) {
+      return ['lib$libraryName.a'];
+    } else {
+      return ['lib$libraryName.so'];
+    }
+  } else {
+    throw Exception("Unsupported target: ${target.rust}");
+  }
+}

--- a/packages/core_native/cargokit/build_tool/lib/src/build_cmake.dart
+++ b/packages/core_native/cargokit/build_tool/lib/src/build_cmake.dart
@@ -1,0 +1,40 @@
+/// This is copied from Cargokit (which is the official way to use it currently)
+/// Details: https://fzyzcjy.github.io/flutter_rust_bridge/manual/integrate/builtin
+
+import 'dart:io';
+
+import 'package:path/path.dart' as path;
+
+import 'artifacts_provider.dart';
+import 'builder.dart';
+import 'environment.dart';
+import 'options.dart';
+import 'target.dart';
+
+class BuildCMake {
+  final CargokitUserOptions userOptions;
+
+  BuildCMake({required this.userOptions});
+
+  Future<void> build() async {
+    final targetPlatform = Environment.targetPlatform;
+    final target = Target.forFlutterName(Environment.targetPlatform);
+    if (target == null) {
+      throw Exception("Unknown target platform: $targetPlatform");
+    }
+
+    final environment = BuildEnvironment.fromEnvironment(isAndroid: false);
+    final provider =
+        ArtifactProvider(environment: environment, userOptions: userOptions);
+    final artifacts = await provider.getArtifacts([target]);
+
+    final libs = artifacts[target]!;
+
+    for (final lib in libs) {
+      if (lib.type == AritifactType.dylib) {
+        File(lib.path)
+            .copySync(path.join(Environment.outputDir, lib.finalFileName));
+      }
+    }
+  }
+}

--- a/packages/core_native/cargokit/build_tool/lib/src/build_gradle.dart
+++ b/packages/core_native/cargokit/build_tool/lib/src/build_gradle.dart
@@ -1,0 +1,49 @@
+/// This is copied from Cargokit (which is the official way to use it currently)
+/// Details: https://fzyzcjy.github.io/flutter_rust_bridge/manual/integrate/builtin
+
+import 'dart:io';
+
+import 'package:logging/logging.dart';
+import 'package:path/path.dart' as path;
+
+import 'artifacts_provider.dart';
+import 'builder.dart';
+import 'environment.dart';
+import 'options.dart';
+import 'target.dart';
+
+final log = Logger('build_gradle');
+
+class BuildGradle {
+  BuildGradle({required this.userOptions});
+
+  final CargokitUserOptions userOptions;
+
+  Future<void> build() async {
+    final targets = Environment.targetPlatforms.map((arch) {
+      final target = Target.forFlutterName(arch);
+      if (target == null) {
+        throw Exception(
+            "Unknown darwin target or platform: $arch, ${Environment.darwinPlatformName}");
+      }
+      return target;
+    }).toList();
+
+    final environment = BuildEnvironment.fromEnvironment(isAndroid: true);
+    final provider =
+        ArtifactProvider(environment: environment, userOptions: userOptions);
+    final artifacts = await provider.getArtifacts(targets);
+
+    for (final target in targets) {
+      final libs = artifacts[target]!;
+      final outputDir = path.join(Environment.outputDir, target.android!);
+      Directory(outputDir).createSync(recursive: true);
+
+      for (final lib in libs) {
+        if (lib.type == AritifactType.dylib) {
+          File(lib.path).copySync(path.join(outputDir, lib.finalFileName));
+        }
+      }
+    }
+  }
+}

--- a/packages/core_native/cargokit/build_tool/lib/src/build_pod.dart
+++ b/packages/core_native/cargokit/build_tool/lib/src/build_pod.dart
@@ -1,0 +1,89 @@
+/// This is copied from Cargokit (which is the official way to use it currently)
+/// Details: https://fzyzcjy.github.io/flutter_rust_bridge/manual/integrate/builtin
+
+import 'dart:io';
+
+import 'package:path/path.dart' as path;
+
+import 'artifacts_provider.dart';
+import 'builder.dart';
+import 'environment.dart';
+import 'options.dart';
+import 'target.dart';
+import 'util.dart';
+
+class BuildPod {
+  BuildPod({required this.userOptions});
+
+  final CargokitUserOptions userOptions;
+
+  Future<void> build() async {
+    final targets = Environment.darwinArchs.map((arch) {
+      final target = Target.forDarwin(
+          platformName: Environment.darwinPlatformName, darwinAarch: arch);
+      if (target == null) {
+        throw Exception(
+            "Unknown darwin target or platform: $arch, ${Environment.darwinPlatformName}");
+      }
+      return target;
+    }).toList();
+
+    final environment = BuildEnvironment.fromEnvironment(isAndroid: false);
+    final provider =
+        ArtifactProvider(environment: environment, userOptions: userOptions);
+    final artifacts = await provider.getArtifacts(targets);
+
+    void performLipo(String targetFile, Iterable<String> sourceFiles) {
+      runCommand("lipo", [
+        '-create',
+        ...sourceFiles,
+        '-output',
+        targetFile,
+      ]);
+    }
+
+    final outputDir = Environment.outputDir;
+
+    Directory(outputDir).createSync(recursive: true);
+
+    final staticLibs = artifacts.values
+        .expand((element) => element)
+        .where((element) => element.type == AritifactType.staticlib)
+        .toList();
+    final dynamicLibs = artifacts.values
+        .expand((element) => element)
+        .where((element) => element.type == AritifactType.dylib)
+        .toList();
+
+    final libName = environment.crateInfo.packageName;
+
+    // If there is static lib, use it and link it with pod
+    if (staticLibs.isNotEmpty) {
+      final finalTargetFile = path.join(outputDir, "lib$libName.a");
+      performLipo(finalTargetFile, staticLibs.map((e) => e.path));
+    } else {
+      // Otherwise try to replace bundle dylib with our dylib
+      final bundlePaths = [
+        '$libName.framework/Versions/A/$libName',
+        '$libName.framework/$libName',
+      ];
+
+      for (final bundlePath in bundlePaths) {
+        final targetFile = path.join(outputDir, bundlePath);
+        if (File(targetFile).existsSync()) {
+          performLipo(targetFile, dynamicLibs.map((e) => e.path));
+
+          // Replace absolute id with @rpath one so that it works properly
+          // when moved to Frameworks.
+          runCommand("install_name_tool", [
+            '-id',
+            '@rpath/$bundlePath',
+            targetFile,
+          ]);
+          return;
+        }
+      }
+      throw Exception('Unable to find bundle for dynamic library');
+    }
+  }
+}

--- a/packages/core_native/cargokit/build_tool/lib/src/build_tool.dart
+++ b/packages/core_native/cargokit/build_tool/lib/src/build_tool.dart
@@ -1,0 +1,271 @@
+/// This is copied from Cargokit (which is the official way to use it currently)
+/// Details: https://fzyzcjy.github.io/flutter_rust_bridge/manual/integrate/builtin
+
+import 'dart:io';
+
+import 'package:args/command_runner.dart';
+import 'package:ed25519_edwards/ed25519_edwards.dart';
+import 'package:github/github.dart';
+import 'package:hex/hex.dart';
+import 'package:logging/logging.dart';
+
+import 'android_environment.dart';
+import 'build_cmake.dart';
+import 'build_gradle.dart';
+import 'build_pod.dart';
+import 'logging.dart';
+import 'options.dart';
+import 'precompile_binaries.dart';
+import 'target.dart';
+import 'util.dart';
+import 'verify_binaries.dart';
+
+final log = Logger('build_tool');
+
+abstract class BuildCommand extends Command {
+  Future<void> runBuildCommand(CargokitUserOptions options);
+
+  @override
+  Future<void> run() async {
+    final options = CargokitUserOptions.load();
+
+    if (options.verboseLogging ||
+        Platform.environment['CARGOKIT_VERBOSE'] == '1') {
+      enableVerboseLogging();
+    }
+
+    await runBuildCommand(options);
+  }
+}
+
+class BuildPodCommand extends BuildCommand {
+  @override
+  final name = 'build-pod';
+
+  @override
+  final description = 'Build cocoa pod library';
+
+  @override
+  Future<void> runBuildCommand(CargokitUserOptions options) async {
+    final build = BuildPod(userOptions: options);
+    await build.build();
+  }
+}
+
+class BuildGradleCommand extends BuildCommand {
+  @override
+  final name = 'build-gradle';
+
+  @override
+  final description = 'Build android library';
+
+  @override
+  Future<void> runBuildCommand(CargokitUserOptions options) async {
+    final build = BuildGradle(userOptions: options);
+    await build.build();
+  }
+}
+
+class BuildCMakeCommand extends BuildCommand {
+  @override
+  final name = 'build-cmake';
+
+  @override
+  final description = 'Build CMake library';
+
+  @override
+  Future<void> runBuildCommand(CargokitUserOptions options) async {
+    final build = BuildCMake(userOptions: options);
+    await build.build();
+  }
+}
+
+class GenKeyCommand extends Command {
+  @override
+  final name = 'gen-key';
+
+  @override
+  final description = 'Generate key pair for signing precompiled binaries';
+
+  @override
+  void run() {
+    final kp = generateKey();
+    final private = HEX.encode(kp.privateKey.bytes);
+    final public = HEX.encode(kp.publicKey.bytes);
+    print("Private Key: $private");
+    print("Public Key: $public");
+  }
+}
+
+class PrecompileBinariesCommand extends Command {
+  PrecompileBinariesCommand() {
+    argParser
+      ..addOption(
+        'repository',
+        mandatory: true,
+        help: 'Github repository slug in format owner/name',
+      )
+      ..addOption(
+        'manifest-dir',
+        mandatory: true,
+        help: 'Directory containing Cargo.toml',
+      )
+      ..addMultiOption('target',
+          help: 'Rust target triple of artifact to build.\n'
+              'Can be specified multiple times or omitted in which case\n'
+              'all targets for current platform will be built.')
+      ..addOption(
+        'android-sdk-location',
+        help: 'Location of Android SDK (if available)',
+      )
+      ..addOption(
+        'android-ndk-version',
+        help: 'Android NDK version (if available)',
+      )
+      ..addOption(
+        'android-min-sdk-version',
+        help: 'Android minimum rquired version (if available)',
+      )
+      ..addOption(
+        'temp-dir',
+        help: 'Directory to store temporary build artifacts',
+      )
+      ..addFlag(
+        "verbose",
+        abbr: "v",
+        defaultsTo: false,
+        help: "Enable verbose logging",
+      );
+  }
+
+  @override
+  final name = 'precompile-binaries';
+
+  @override
+  final description = 'Prebuild and upload binaries\n'
+      'Private key must be passed through PRIVATE_KEY environment variable. '
+      'Use gen_key through generate priave key.\n'
+      'Github token must be passed as GITHUB_TOKEN environment variable.\n';
+
+  @override
+  Future<void> run() async {
+    final verbose = argResults!['verbose'] as bool;
+    if (verbose) {
+      enableVerboseLogging();
+    }
+
+    final privateKeyString = Platform.environment['PRIVATE_KEY'];
+    if (privateKeyString == null) {
+      throw ArgumentError('Missing PRIVATE_KEY environment variable');
+    }
+    final githubToken = Platform.environment['GITHUB_TOKEN'];
+    if (githubToken == null) {
+      throw ArgumentError('Missing GITHUB_TOKEN environment variable');
+    }
+    final privateKey = HEX.decode(privateKeyString);
+    if (privateKey.length != 64) {
+      throw ArgumentError('Private key must be 64 bytes long');
+    }
+    final manifestDir = argResults!['manifest-dir'] as String;
+    if (!Directory(manifestDir).existsSync()) {
+      throw ArgumentError('Manifest directory does not exist: $manifestDir');
+    }
+    String? androidMinSdkVersionString =
+        argResults!['android-min-sdk-version'] as String?;
+    int? androidMinSdkVersion;
+    if (androidMinSdkVersionString != null) {
+      androidMinSdkVersion = int.tryParse(androidMinSdkVersionString);
+      if (androidMinSdkVersion == null) {
+        throw ArgumentError(
+            'Invalid android-min-sdk-version: $androidMinSdkVersionString');
+      }
+    }
+    final targetStrigns = argResults!['target'] as List<String>;
+    final targets = targetStrigns.map((target) {
+      final res = Target.forRustTriple(target);
+      if (res == null) {
+        throw ArgumentError('Invalid target: $target');
+      }
+      return res;
+    }).toList(growable: false);
+    final precompileBinaries = PrecompileBinaries(
+      privateKey: PrivateKey(privateKey),
+      githubToken: githubToken,
+      manifestDir: manifestDir,
+      repositorySlug: RepositorySlug.full(argResults!['repository'] as String),
+      targets: targets,
+      androidSdkLocation: argResults!['android-sdk-location'] as String?,
+      androidNdkVersion: argResults!['android-ndk-version'] as String?,
+      androidMinSdkVersion: androidMinSdkVersion,
+      tempDir: argResults!['temp-dir'] as String?,
+    );
+
+    await precompileBinaries.run();
+  }
+}
+
+class VerifyBinariesCommand extends Command {
+  VerifyBinariesCommand() {
+    argParser.addOption(
+      'manifest-dir',
+      mandatory: true,
+      help: 'Directory containing Cargo.toml',
+    );
+  }
+
+  @override
+  final name = "verify-binaries";
+
+  @override
+  final description = 'Verifies published binaries\n'
+      'Checks whether there is a binary published for each targets\n'
+      'and checks the signature.';
+
+  @override
+  Future<void> run() async {
+    final manifestDir = argResults!['manifest-dir'] as String;
+    final verifyBinaries = VerifyBinaries(
+      manifestDir: manifestDir,
+    );
+    await verifyBinaries.run();
+  }
+}
+
+Future<void> runMain(List<String> args) async {
+  try {
+    // Init logging before options are loaded
+    initLogging();
+
+    if (Platform.environment['_CARGOKIT_NDK_LINK_TARGET'] != null) {
+      return AndroidEnvironment.clangLinkerWrapper(args);
+    }
+
+    final runner = CommandRunner('build_tool', 'Cargokit built_tool')
+      ..addCommand(BuildPodCommand())
+      ..addCommand(BuildGradleCommand())
+      ..addCommand(BuildCMakeCommand())
+      ..addCommand(GenKeyCommand())
+      ..addCommand(PrecompileBinariesCommand())
+      ..addCommand(VerifyBinariesCommand());
+
+    await runner.run(args);
+  } on ArgumentError catch (e) {
+    stderr.writeln(e.toString());
+    exit(1);
+  } catch (e, s) {
+    log.severe(kDoubleSeparator);
+    log.severe('Cargokit BuildTool failed with error:');
+    log.severe(kSeparator);
+    log.severe(e);
+    // This tells user to install Rust, there's no need to pollute the log with
+    // stack trace.
+    if (e is! RustupNotFoundException) {
+      log.severe(kSeparator);
+      log.severe(s);
+      log.severe(kSeparator);
+      log.severe('BuildTool arguments: $args');
+    }
+    log.severe(kDoubleSeparator);
+    exit(1);
+  }
+}

--- a/packages/core_native/cargokit/build_tool/lib/src/builder.dart
+++ b/packages/core_native/cargokit/build_tool/lib/src/builder.dart
@@ -1,0 +1,198 @@
+/// This is copied from Cargokit (which is the official way to use it currently)
+/// Details: https://fzyzcjy.github.io/flutter_rust_bridge/manual/integrate/builtin
+
+import 'package:collection/collection.dart';
+import 'package:logging/logging.dart';
+import 'package:path/path.dart' as path;
+
+import 'android_environment.dart';
+import 'cargo.dart';
+import 'environment.dart';
+import 'options.dart';
+import 'rustup.dart';
+import 'target.dart';
+import 'util.dart';
+
+final _log = Logger('builder');
+
+enum BuildConfiguration {
+  debug,
+  release,
+  profile,
+}
+
+extension on BuildConfiguration {
+  bool get isDebug => this == BuildConfiguration.debug;
+  String get rustName => switch (this) {
+        BuildConfiguration.debug => 'debug',
+        BuildConfiguration.release => 'release',
+        BuildConfiguration.profile => 'release',
+      };
+}
+
+class BuildException implements Exception {
+  final String message;
+
+  BuildException(this.message);
+
+  @override
+  String toString() {
+    return 'BuildException: $message';
+  }
+}
+
+class BuildEnvironment {
+  final BuildConfiguration configuration;
+  final CargokitCrateOptions crateOptions;
+  final String targetTempDir;
+  final String manifestDir;
+  final CrateInfo crateInfo;
+
+  final bool isAndroid;
+  final String? androidSdkPath;
+  final String? androidNdkVersion;
+  final int? androidMinSdkVersion;
+  final String? javaHome;
+
+  BuildEnvironment({
+    required this.configuration,
+    required this.crateOptions,
+    required this.targetTempDir,
+    required this.manifestDir,
+    required this.crateInfo,
+    required this.isAndroid,
+    this.androidSdkPath,
+    this.androidNdkVersion,
+    this.androidMinSdkVersion,
+    this.javaHome,
+  });
+
+  static BuildConfiguration parseBuildConfiguration(String value) {
+    // XCode configuration adds the flavor to configuration name.
+    final firstSegment = value.split('-').first;
+    final buildConfiguration = BuildConfiguration.values.firstWhereOrNull(
+      (e) => e.name == firstSegment,
+    );
+    if (buildConfiguration == null) {
+      _log.warning('Unknown build configuraiton $value, will assume release');
+      return BuildConfiguration.release;
+    }
+    return buildConfiguration;
+  }
+
+  static BuildEnvironment fromEnvironment({
+    required bool isAndroid,
+  }) {
+    final buildConfiguration =
+        parseBuildConfiguration(Environment.configuration);
+    final manifestDir = Environment.manifestDir;
+    final crateOptions = CargokitCrateOptions.load(
+      manifestDir: manifestDir,
+    );
+    final crateInfo = CrateInfo.load(manifestDir);
+    return BuildEnvironment(
+      configuration: buildConfiguration,
+      crateOptions: crateOptions,
+      targetTempDir: Environment.targetTempDir,
+      manifestDir: manifestDir,
+      crateInfo: crateInfo,
+      isAndroid: isAndroid,
+      androidSdkPath: isAndroid ? Environment.sdkPath : null,
+      androidNdkVersion: isAndroid ? Environment.ndkVersion : null,
+      androidMinSdkVersion:
+          isAndroid ? int.parse(Environment.minSdkVersion) : null,
+      javaHome: isAndroid ? Environment.javaHome : null,
+    );
+  }
+}
+
+class RustBuilder {
+  final Target target;
+  final BuildEnvironment environment;
+
+  RustBuilder({
+    required this.target,
+    required this.environment,
+  });
+
+  void prepare(
+    Rustup rustup,
+  ) {
+    final toolchain = _toolchain;
+    if (rustup.installedTargets(toolchain) == null) {
+      rustup.installToolchain(toolchain);
+    }
+    if (toolchain == 'nightly') {
+      rustup.installRustSrcForNightly();
+    }
+    if (!rustup.installedTargets(toolchain)!.contains(target.rust)) {
+      rustup.installTarget(target.rust, toolchain: toolchain);
+    }
+  }
+
+  CargoBuildOptions? get _buildOptions =>
+      environment.crateOptions.cargo[environment.configuration];
+
+  String get _toolchain => _buildOptions?.toolchain.name ?? 'stable';
+
+  /// Returns the path of directory containing build artifacts.
+  Future<String> build() async {
+    final extraArgs = _buildOptions?.flags ?? [];
+    final manifestPath = path.join(environment.manifestDir, 'Cargo.toml');
+    runCommand(
+      'rustup',
+      [
+        'run',
+        _toolchain,
+        'cargo',
+        'build',
+        ...extraArgs,
+        '--manifest-path',
+        manifestPath,
+        '-p',
+        environment.crateInfo.packageName,
+        if (!environment.configuration.isDebug) '--release',
+        '--target',
+        target.rust,
+        '--target-dir',
+        environment.targetTempDir,
+      ],
+      environment: await _buildEnvironment(),
+    );
+    return path.join(
+      environment.targetTempDir,
+      target.rust,
+      environment.configuration.rustName,
+    );
+  }
+
+  Future<Map<String, String>> _buildEnvironment() async {
+    if (target.android == null) {
+      return {};
+    } else {
+      final sdkPath = environment.androidSdkPath;
+      final ndkVersion = environment.androidNdkVersion;
+      final minSdkVersion = environment.androidMinSdkVersion;
+      if (sdkPath == null) {
+        throw BuildException('androidSdkPath is not set');
+      }
+      if (ndkVersion == null) {
+        throw BuildException('androidNdkVersion is not set');
+      }
+      if (minSdkVersion == null) {
+        throw BuildException('androidMinSdkVersion is not set');
+      }
+      final env = AndroidEnvironment(
+        sdkPath: sdkPath,
+        ndkVersion: ndkVersion,
+        minSdkVersion: minSdkVersion,
+        targetTempDir: environment.targetTempDir,
+        target: target,
+      );
+      if (!env.ndkIsInstalled() && environment.javaHome != null) {
+        env.installNdk(javaHome: environment.javaHome!);
+      }
+      return env.buildEnvironment();
+    }
+  }
+}

--- a/packages/core_native/cargokit/build_tool/lib/src/cargo.dart
+++ b/packages/core_native/cargokit/build_tool/lib/src/cargo.dart
@@ -1,0 +1,48 @@
+/// This is copied from Cargokit (which is the official way to use it currently)
+/// Details: https://fzyzcjy.github.io/flutter_rust_bridge/manual/integrate/builtin
+
+import 'dart:io';
+
+import 'package:path/path.dart' as path;
+import 'package:toml/toml.dart';
+
+class ManifestException {
+  ManifestException(this.message, {required this.fileName});
+
+  final String? fileName;
+  final String message;
+
+  @override
+  String toString() {
+    if (fileName != null) {
+      return 'Failed to parse package manifest at $fileName: $message';
+    } else {
+      return 'Failed to parse package manifest: $message';
+    }
+  }
+}
+
+class CrateInfo {
+  CrateInfo({required this.packageName});
+
+  final String packageName;
+
+  static CrateInfo parseManifest(String manifest, {final String? fileName}) {
+    final toml = TomlDocument.parse(manifest);
+    final package = toml.toMap()['package'];
+    if (package == null) {
+      throw ManifestException('Missing package section', fileName: fileName);
+    }
+    final name = package['name'];
+    if (name == null) {
+      throw ManifestException('Missing package name', fileName: fileName);
+    }
+    return CrateInfo(packageName: name);
+  }
+
+  static CrateInfo load(String manifestDir) {
+    final manifestFile = File(path.join(manifestDir, 'Cargo.toml'));
+    final manifest = manifestFile.readAsStringSync();
+    return parseManifest(manifest, fileName: manifestFile.path);
+  }
+}

--- a/packages/core_native/cargokit/build_tool/lib/src/crate_hash.dart
+++ b/packages/core_native/cargokit/build_tool/lib/src/crate_hash.dart
@@ -1,0 +1,124 @@
+/// This is copied from Cargokit (which is the official way to use it currently)
+/// Details: https://fzyzcjy.github.io/flutter_rust_bridge/manual/integrate/builtin
+
+import 'dart:convert';
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:collection/collection.dart';
+import 'package:convert/convert.dart';
+import 'package:crypto/crypto.dart';
+import 'package:path/path.dart' as path;
+
+class CrateHash {
+  /// Computes a hash uniquely identifying crate content. This takes into account
+  /// content all all .rs files inside the src directory, as well as Cargo.toml,
+  /// Cargo.lock, build.rs and cargokit.yaml.
+  ///
+  /// If [tempStorage] is provided, computed hash is stored in a file in that directory
+  /// and reused on subsequent calls if the crate content hasn't changed.
+  static String compute(String manifestDir, {String? tempStorage}) {
+    return CrateHash._(
+      manifestDir: manifestDir,
+      tempStorage: tempStorage,
+    )._compute();
+  }
+
+  CrateHash._({
+    required this.manifestDir,
+    required this.tempStorage,
+  });
+
+  String _compute() {
+    final files = getFiles();
+    final tempStorage = this.tempStorage;
+    if (tempStorage != null) {
+      final quickHash = _computeQuickHash(files);
+      final quickHashFolder = Directory(path.join(tempStorage, 'crate_hash'));
+      quickHashFolder.createSync(recursive: true);
+      final quickHashFile = File(path.join(quickHashFolder.path, quickHash));
+      if (quickHashFile.existsSync()) {
+        return quickHashFile.readAsStringSync();
+      }
+      final hash = _computeHash(files);
+      quickHashFile.writeAsStringSync(hash);
+      return hash;
+    } else {
+      return _computeHash(files);
+    }
+  }
+
+  /// Computes a quick hash based on files stat (without reading contents). This
+  /// is used to cache the real hash, which is slower to compute since it involves
+  /// reading every single file.
+  String _computeQuickHash(List<File> files) {
+    final output = AccumulatorSink<Digest>();
+    final input = sha256.startChunkedConversion(output);
+
+    final data = ByteData(8);
+    for (final file in files) {
+      input.add(utf8.encode(file.path));
+      final stat = file.statSync();
+      data.setUint64(0, stat.size);
+      input.add(data.buffer.asUint8List());
+      data.setUint64(0, stat.modified.millisecondsSinceEpoch);
+      input.add(data.buffer.asUint8List());
+    }
+
+    input.close();
+    return base64Url.encode(output.events.single.bytes);
+  }
+
+  String _computeHash(List<File> files) {
+    final output = AccumulatorSink<Digest>();
+    final input = sha256.startChunkedConversion(output);
+
+    void addTextFile(File file) {
+      // text Files are hashed by lines in case we're dealing with github checkout
+      // that auto-converts line endings.
+      final splitter = LineSplitter();
+      if (file.existsSync()) {
+        final data = file.readAsStringSync();
+        final lines = splitter.convert(data);
+        for (final line in lines) {
+          input.add(utf8.encode(line));
+        }
+      }
+    }
+
+    for (final file in files) {
+      addTextFile(file);
+    }
+
+    input.close();
+    final res = output.events.single;
+
+    // Truncate to 128bits.
+    final hash = res.bytes.sublist(0, 16);
+    return hex.encode(hash);
+  }
+
+  List<File> getFiles() {
+    final src = Directory(path.join(manifestDir, 'src'));
+    final files = src
+        .listSync(recursive: true, followLinks: false)
+        .whereType<File>()
+        .toList();
+    files.sortBy((element) => element.path);
+    void addFile(String relative) {
+      final file = File(path.join(manifestDir, relative));
+      if (file.existsSync()) {
+        files.add(file);
+      }
+    }
+
+    addFile('Cargo.toml');
+    addFile('Cargo.lock');
+    addFile('build.rs');
+    addFile('cargokit.yaml');
+    return files;
+  }
+
+  final String manifestDir;
+  final String? tempStorage;
+}

--- a/packages/core_native/cargokit/build_tool/lib/src/environment.dart
+++ b/packages/core_native/cargokit/build_tool/lib/src/environment.dart
@@ -1,0 +1,68 @@
+/// This is copied from Cargokit (which is the official way to use it currently)
+/// Details: https://fzyzcjy.github.io/flutter_rust_bridge/manual/integrate/builtin
+
+import 'dart:io';
+
+extension on String {
+  String resolveSymlink() => File(this).resolveSymbolicLinksSync();
+}
+
+class Environment {
+  /// Current build configuration (debug or release).
+  static String get configuration =>
+      _getEnv("CARGOKIT_CONFIGURATION").toLowerCase();
+
+  static bool get isDebug => configuration == 'debug';
+  static bool get isRelease => configuration == 'release';
+
+  /// Temporary directory where Rust build artifacts are placed.
+  static String get targetTempDir => _getEnv("CARGOKIT_TARGET_TEMP_DIR");
+
+  /// Final output directory where the build artifacts are placed.
+  static String get outputDir => _getEnvPath('CARGOKIT_OUTPUT_DIR');
+
+  /// Path to the crate manifest (containing Cargo.toml).
+  static String get manifestDir => _getEnvPath('CARGOKIT_MANIFEST_DIR');
+
+  /// Directory inside root project. Not necessarily root folder. Symlinks are
+  /// not resolved on purpose.
+  static String get rootProjectDir => _getEnv('CARGOKIT_ROOT_PROJECT_DIR');
+
+  // Pod
+
+  /// Platform name (macosx, iphoneos, iphonesimulator).
+  static String get darwinPlatformName =>
+      _getEnv("CARGOKIT_DARWIN_PLATFORM_NAME");
+
+  /// List of architectures to build for (arm64, armv7, x86_64).
+  static List<String> get darwinArchs =>
+      _getEnv("CARGOKIT_DARWIN_ARCHS").split(' ');
+
+  // Gradle
+  static String get minSdkVersion => _getEnv("CARGOKIT_MIN_SDK_VERSION");
+  static String get ndkVersion => _getEnv("CARGOKIT_NDK_VERSION");
+  static String get sdkPath => _getEnvPath("CARGOKIT_SDK_DIR");
+  static String get javaHome => _getEnvPath("CARGOKIT_JAVA_HOME");
+  static List<String> get targetPlatforms =>
+      _getEnv("CARGOKIT_TARGET_PLATFORMS").split(',');
+
+  // CMAKE
+  static String get targetPlatform => _getEnv("CARGOKIT_TARGET_PLATFORM");
+
+  static String _getEnv(String key) {
+    final res = Platform.environment[key];
+    if (res == null) {
+      throw Exception("Missing environment variable $key");
+    }
+    return res;
+  }
+
+  static String _getEnvPath(String key) {
+    final res = _getEnv(key);
+    if (Directory(res).existsSync()) {
+      return res.resolveSymlink();
+    } else {
+      return res;
+    }
+  }
+}

--- a/packages/core_native/cargokit/build_tool/lib/src/logging.dart
+++ b/packages/core_native/cargokit/build_tool/lib/src/logging.dart
@@ -1,0 +1,52 @@
+/// This is copied from Cargokit (which is the official way to use it currently)
+/// Details: https://fzyzcjy.github.io/flutter_rust_bridge/manual/integrate/builtin
+
+import 'dart:io';
+
+import 'package:logging/logging.dart';
+
+const String kSeparator = "--";
+const String kDoubleSeparator = "==";
+
+bool _lastMessageWasSeparator = false;
+
+void _log(LogRecord rec) {
+  final prefix = '${rec.level.name}: ';
+  final out = rec.level == Level.SEVERE ? stderr : stdout;
+  if (rec.message == kSeparator) {
+    if (!_lastMessageWasSeparator) {
+      out.write(prefix);
+      out.writeln('-' * 80);
+      _lastMessageWasSeparator = true;
+    }
+    return;
+  } else if (rec.message == kDoubleSeparator) {
+    out.write(prefix);
+    out.writeln('=' * 80);
+    _lastMessageWasSeparator = true;
+    return;
+  }
+  out.write(prefix);
+  out.writeln(rec.message);
+  _lastMessageWasSeparator = false;
+}
+
+void initLogging() {
+  Logger.root.level = Level.INFO;
+  Logger.root.onRecord.listen((LogRecord rec) {
+    final lines = rec.message.split('\n');
+    for (final line in lines) {
+      if (line.isNotEmpty || lines.length == 1 || line != lines.last) {
+        _log(LogRecord(
+          rec.level,
+          line,
+          rec.loggerName,
+        ));
+      }
+    }
+  });
+}
+
+void enableVerboseLogging() {
+  Logger.root.level = Level.ALL;
+}

--- a/packages/core_native/cargokit/build_tool/lib/src/options.dart
+++ b/packages/core_native/cargokit/build_tool/lib/src/options.dart
@@ -1,0 +1,309 @@
+/// This is copied from Cargokit (which is the official way to use it currently)
+/// Details: https://fzyzcjy.github.io/flutter_rust_bridge/manual/integrate/builtin
+
+import 'dart:io';
+
+import 'package:collection/collection.dart';
+import 'package:ed25519_edwards/ed25519_edwards.dart';
+import 'package:hex/hex.dart';
+import 'package:logging/logging.dart';
+import 'package:path/path.dart' as path;
+import 'package:source_span/source_span.dart';
+import 'package:yaml/yaml.dart';
+
+import 'builder.dart';
+import 'environment.dart';
+import 'rustup.dart';
+
+final _log = Logger('options');
+
+/// A class for exceptions that have source span information attached.
+class SourceSpanException implements Exception {
+  // This is a getter so that subclasses can override it.
+  /// A message describing the exception.
+  String get message => _message;
+  final String _message;
+
+  // This is a getter so that subclasses can override it.
+  /// The span associated with this exception.
+  ///
+  /// This may be `null` if the source location can't be determined.
+  SourceSpan? get span => _span;
+  final SourceSpan? _span;
+
+  SourceSpanException(this._message, this._span);
+
+  /// Returns a string representation of `this`.
+  ///
+  /// [color] may either be a [String], a [bool], or `null`. If it's a string,
+  /// it indicates an ANSI terminal color escape that should be used to
+  /// highlight the span's text. If it's `true`, it indicates that the text
+  /// should be highlighted using the default color. If it's `false` or `null`,
+  /// it indicates that the text shouldn't be highlighted.
+  @override
+  String toString({Object? color}) {
+    if (span == null) return message;
+    return 'Error on ${span!.message(message, color: color)}';
+  }
+}
+
+enum Toolchain {
+  stable,
+  beta,
+  nightly,
+}
+
+class CargoBuildOptions {
+  final Toolchain toolchain;
+  final List<String> flags;
+
+  CargoBuildOptions({
+    required this.toolchain,
+    required this.flags,
+  });
+
+  static Toolchain _toolchainFromNode(YamlNode node) {
+    if (node case YamlScalar(value: String name)) {
+      final toolchain =
+          Toolchain.values.firstWhereOrNull((element) => element.name == name);
+      if (toolchain != null) {
+        return toolchain;
+      }
+    }
+    throw SourceSpanException(
+        'Unknown toolchain. Must be one of ${Toolchain.values.map((e) => e.name)}.',
+        node.span);
+  }
+
+  static CargoBuildOptions parse(YamlNode node) {
+    if (node is! YamlMap) {
+      throw SourceSpanException('Cargo options must be a map', node.span);
+    }
+    Toolchain toolchain = Toolchain.stable;
+    List<String> flags = [];
+    for (final MapEntry(:key, :value) in node.nodes.entries) {
+      if (key case YamlScalar(value: 'toolchain')) {
+        toolchain = _toolchainFromNode(value);
+      } else if (key case YamlScalar(value: 'extra_flags')) {
+        if (value case YamlList(nodes: List<YamlNode> list)) {
+          if (list.every((element) {
+            if (element case YamlScalar(value: String _)) {
+              return true;
+            }
+            return false;
+          })) {
+            flags = list.map((e) => e.value as String).toList();
+            continue;
+          }
+        }
+        throw SourceSpanException(
+            'Extra flags must be a list of strings', value.span);
+      } else {
+        throw SourceSpanException(
+            'Unknown cargo option type. Must be "toolchain" or "extra_flags".',
+            key.span);
+      }
+    }
+    return CargoBuildOptions(toolchain: toolchain, flags: flags);
+  }
+}
+
+extension on YamlMap {
+  /// Map that extracts keys so that we can do map case check on them.
+  Map<dynamic, YamlNode> get valueMap =>
+      nodes.map((key, value) => MapEntry(key.value, value));
+}
+
+class PrecompiledBinaries {
+  final String uriPrefix;
+  final PublicKey publicKey;
+
+  PrecompiledBinaries({
+    required this.uriPrefix,
+    required this.publicKey,
+  });
+
+  static PublicKey _publicKeyFromHex(String key, SourceSpan? span) {
+    final bytes = HEX.decode(key);
+    if (bytes.length != 32) {
+      throw SourceSpanException(
+          'Invalid public key. Must be 32 bytes long.', span);
+    }
+    return PublicKey(bytes);
+  }
+
+  static PrecompiledBinaries parse(YamlNode node) {
+    if (node case YamlMap(valueMap: Map<dynamic, YamlNode> map)) {
+      if (map
+          case {
+            'url_prefix': YamlNode urlPrefixNode,
+            'public_key': YamlNode publicKeyNode,
+          }) {
+        final urlPrefix = switch (urlPrefixNode) {
+          YamlScalar(value: String urlPrefix) => urlPrefix,
+          _ => throw SourceSpanException(
+              'Invalid URL prefix value.', urlPrefixNode.span),
+        };
+        final publicKey = switch (publicKeyNode) {
+          YamlScalar(value: String publicKey) =>
+            _publicKeyFromHex(publicKey, publicKeyNode.span),
+          _ => throw SourceSpanException(
+              'Invalid public key value.', publicKeyNode.span),
+        };
+        return PrecompiledBinaries(
+          uriPrefix: urlPrefix,
+          publicKey: publicKey,
+        );
+      }
+    }
+    throw SourceSpanException(
+        'Invalid precompiled binaries value. '
+        'Expected Map with "url_prefix" and "public_key".',
+        node.span);
+  }
+}
+
+/// Cargokit options specified for Rust crate.
+class CargokitCrateOptions {
+  CargokitCrateOptions({
+    this.cargo = const {},
+    this.precompiledBinaries,
+  });
+
+  final Map<BuildConfiguration, CargoBuildOptions> cargo;
+  final PrecompiledBinaries? precompiledBinaries;
+
+  static CargokitCrateOptions parse(YamlNode node) {
+    if (node is! YamlMap) {
+      throw SourceSpanException('Cargokit options must be a map', node.span);
+    }
+    final options = <BuildConfiguration, CargoBuildOptions>{};
+    PrecompiledBinaries? precompiledBinaries;
+
+    for (final entry in node.nodes.entries) {
+      if (entry
+          case MapEntry(
+            key: YamlScalar(value: 'cargo'),
+            value: YamlNode node,
+          )) {
+        if (node is! YamlMap) {
+          throw SourceSpanException('Cargo options must be a map', node.span);
+        }
+        for (final MapEntry(:YamlNode key, :value) in node.nodes.entries) {
+          if (key case YamlScalar(value: String name)) {
+            final configuration = BuildConfiguration.values
+                .firstWhereOrNull((element) => element.name == name);
+            if (configuration != null) {
+              options[configuration] = CargoBuildOptions.parse(value);
+              continue;
+            }
+          }
+          throw SourceSpanException(
+              'Unknown build configuration. Must be one of ${BuildConfiguration.values.map((e) => e.name)}.',
+              key.span);
+        }
+      } else if (entry.key case YamlScalar(value: 'precompiled_binaries')) {
+        precompiledBinaries = PrecompiledBinaries.parse(entry.value);
+      } else {
+        throw SourceSpanException(
+            'Unknown cargokit option type. Must be "cargo" or "precompiled_binaries".',
+            entry.key.span);
+      }
+    }
+    return CargokitCrateOptions(
+      cargo: options,
+      precompiledBinaries: precompiledBinaries,
+    );
+  }
+
+  static CargokitCrateOptions load({
+    required String manifestDir,
+  }) {
+    final uri = Uri.file(path.join(manifestDir, "cargokit.yaml"));
+    final file = File.fromUri(uri);
+    if (file.existsSync()) {
+      final contents = loadYamlNode(file.readAsStringSync(), sourceUrl: uri);
+      return parse(contents);
+    } else {
+      return CargokitCrateOptions();
+    }
+  }
+}
+
+class CargokitUserOptions {
+  // When Rustup is installed always build locally unless user opts into
+  // using precompiled binaries.
+  static bool defaultUsePrecompiledBinaries() {
+    return Rustup.executablePath() == null;
+  }
+
+  CargokitUserOptions({
+    required this.usePrecompiledBinaries,
+    required this.verboseLogging,
+  });
+
+  CargokitUserOptions._()
+      : usePrecompiledBinaries = defaultUsePrecompiledBinaries(),
+        verboseLogging = false;
+
+  static CargokitUserOptions parse(YamlNode node) {
+    if (node is! YamlMap) {
+      throw SourceSpanException('Cargokit options must be a map', node.span);
+    }
+    bool usePrecompiledBinaries = defaultUsePrecompiledBinaries();
+    bool verboseLogging = false;
+
+    for (final entry in node.nodes.entries) {
+      if (entry.key case YamlScalar(value: 'use_precompiled_binaries')) {
+        if (entry.value case YamlScalar(value: bool value)) {
+          usePrecompiledBinaries = value;
+          continue;
+        }
+        throw SourceSpanException(
+            'Invalid value for "use_precompiled_binaries". Must be a boolean.',
+            entry.value.span);
+      } else if (entry.key case YamlScalar(value: 'verbose_logging')) {
+        if (entry.value case YamlScalar(value: bool value)) {
+          verboseLogging = value;
+          continue;
+        }
+        throw SourceSpanException(
+            'Invalid value for "verbose_logging". Must be a boolean.',
+            entry.value.span);
+      } else {
+        throw SourceSpanException(
+            'Unknown cargokit option type. Must be "use_precompiled_binaries" or "verbose_logging".',
+            entry.key.span);
+      }
+    }
+    return CargokitUserOptions(
+      usePrecompiledBinaries: usePrecompiledBinaries,
+      verboseLogging: verboseLogging,
+    );
+  }
+
+  static CargokitUserOptions load() {
+    String fileName = "cargokit_options.yaml";
+    var userProjectDir = Directory(Environment.rootProjectDir);
+
+    while (userProjectDir.parent.path != userProjectDir.path) {
+      final configFile = File(path.join(userProjectDir.path, fileName));
+      if (configFile.existsSync()) {
+        final contents = loadYamlNode(
+          configFile.readAsStringSync(),
+          sourceUrl: configFile.uri,
+        );
+        final res = parse(contents);
+        if (res.verboseLogging) {
+          _log.info('Found user options file at ${configFile.path}');
+        }
+        return res;
+      }
+      userProjectDir = userProjectDir.parent;
+    }
+    return CargokitUserOptions._();
+  }
+
+  final bool usePrecompiledBinaries;
+  final bool verboseLogging;
+}

--- a/packages/core_native/cargokit/build_tool/lib/src/precompile_binaries.dart
+++ b/packages/core_native/cargokit/build_tool/lib/src/precompile_binaries.dart
@@ -1,0 +1,202 @@
+/// This is copied from Cargokit (which is the official way to use it currently)
+/// Details: https://fzyzcjy.github.io/flutter_rust_bridge/manual/integrate/builtin
+
+import 'dart:io';
+
+import 'package:ed25519_edwards/ed25519_edwards.dart';
+import 'package:github/github.dart';
+import 'package:logging/logging.dart';
+import 'package:path/path.dart' as path;
+
+import 'artifacts_provider.dart';
+import 'builder.dart';
+import 'cargo.dart';
+import 'crate_hash.dart';
+import 'options.dart';
+import 'rustup.dart';
+import 'target.dart';
+
+final _log = Logger('precompile_binaries');
+
+class PrecompileBinaries {
+  PrecompileBinaries({
+    required this.privateKey,
+    required this.githubToken,
+    required this.repositorySlug,
+    required this.manifestDir,
+    required this.targets,
+    this.androidSdkLocation,
+    this.androidNdkVersion,
+    this.androidMinSdkVersion,
+    this.tempDir,
+  });
+
+  final PrivateKey privateKey;
+  final String githubToken;
+  final RepositorySlug repositorySlug;
+  final String manifestDir;
+  final List<Target> targets;
+  final String? androidSdkLocation;
+  final String? androidNdkVersion;
+  final int? androidMinSdkVersion;
+  final String? tempDir;
+
+  static String fileName(Target target, String name) {
+    return '${target.rust}_$name';
+  }
+
+  static String signatureFileName(Target target, String name) {
+    return '${target.rust}_$name.sig';
+  }
+
+  Future<void> run() async {
+    final crateInfo = CrateInfo.load(manifestDir);
+
+    final targets = List.of(this.targets);
+    if (targets.isEmpty) {
+      targets.addAll([
+        ...Target.buildableTargets(),
+        if (androidSdkLocation != null) ...Target.androidTargets(),
+      ]);
+    }
+
+    _log.info('Precompiling binaries for $targets');
+
+    final hash = CrateHash.compute(manifestDir);
+    _log.info('Computed crate hash: $hash');
+
+    final String tagName = 'precompiled_$hash';
+
+    final github = GitHub(auth: Authentication.withToken(githubToken));
+    final repo = github.repositories;
+    final release = await _getOrCreateRelease(
+      repo: repo,
+      tagName: tagName,
+      packageName: crateInfo.packageName,
+      hash: hash,
+    );
+
+    final tempDir = this.tempDir != null
+        ? Directory(this.tempDir!)
+        : Directory.systemTemp.createTempSync('precompiled_');
+
+    tempDir.createSync(recursive: true);
+
+    final crateOptions = CargokitCrateOptions.load(
+      manifestDir: manifestDir,
+    );
+
+    final buildEnvironment = BuildEnvironment(
+      configuration: BuildConfiguration.release,
+      crateOptions: crateOptions,
+      targetTempDir: tempDir.path,
+      manifestDir: manifestDir,
+      crateInfo: crateInfo,
+      isAndroid: androidSdkLocation != null,
+      androidSdkPath: androidSdkLocation,
+      androidNdkVersion: androidNdkVersion,
+      androidMinSdkVersion: androidMinSdkVersion,
+    );
+
+    final rustup = Rustup();
+
+    for (final target in targets) {
+      final artifactNames = getArtifactNames(
+        target: target,
+        libraryName: crateInfo.packageName,
+        remote: true,
+      );
+
+      if (artifactNames.every((name) {
+        final fileName = PrecompileBinaries.fileName(target, name);
+        return (release.assets ?? []).any((e) => e.name == fileName);
+      })) {
+        _log.info("All artifacts for $target already exist - skipping");
+        continue;
+      }
+
+      _log.info('Building for $target');
+
+      final builder =
+          RustBuilder(target: target, environment: buildEnvironment);
+      builder.prepare(rustup);
+      final res = await builder.build();
+
+      final assets = <CreateReleaseAsset>[];
+      for (final name in artifactNames) {
+        final file = File(path.join(res, name));
+        if (!file.existsSync()) {
+          throw Exception('Missing artifact: ${file.path}');
+        }
+
+        final data = file.readAsBytesSync();
+        final create = CreateReleaseAsset(
+          name: PrecompileBinaries.fileName(target, name),
+          contentType: "application/octet-stream",
+          assetData: data,
+        );
+        final signature = sign(privateKey, data);
+        final signatureCreate = CreateReleaseAsset(
+          name: signatureFileName(target, name),
+          contentType: "application/octet-stream",
+          assetData: signature,
+        );
+        bool verified = verify(public(privateKey), data, signature);
+        if (!verified) {
+          throw Exception('Signature verification failed');
+        }
+        assets.add(create);
+        assets.add(signatureCreate);
+      }
+      _log.info('Uploading assets: ${assets.map((e) => e.name)}');
+      for (final asset in assets) {
+        // This seems to be failing on CI so do it one by one
+        int retryCount = 0;
+        while (true) {
+          try {
+            await repo.uploadReleaseAssets(release, [asset]);
+            break;
+          } on Exception catch (e) {
+            if (retryCount == 10) {
+              rethrow;
+            }
+            ++retryCount;
+            _log.shout(
+                'Upload failed (attempt $retryCount, will retry): ${e.toString()}');
+            await Future.delayed(Duration(seconds: 2));
+          }
+        }
+      }
+    }
+
+    _log.info('Cleaning up');
+    tempDir.deleteSync(recursive: true);
+  }
+
+  Future<Release> _getOrCreateRelease({
+    required RepositoriesService repo,
+    required String tagName,
+    required String packageName,
+    required String hash,
+  }) async {
+    Release release;
+    try {
+      _log.info('Fetching release $tagName');
+      release = await repo.getReleaseByTagName(repositorySlug, tagName);
+    } on ReleaseNotFound {
+      _log.info('Release not found - creating release $tagName');
+      release = await repo.createRelease(
+          repositorySlug,
+          CreateRelease.from(
+            tagName: tagName,
+            name: 'Precompiled binaries ${hash.substring(0, 8)}',
+            targetCommitish: null,
+            isDraft: false,
+            isPrerelease: false,
+            body: 'Precompiled binaries for crate $packageName, '
+                'crate hash $hash.',
+          ));
+    }
+    return release;
+  }
+}

--- a/packages/core_native/cargokit/build_tool/lib/src/rustup.dart
+++ b/packages/core_native/cargokit/build_tool/lib/src/rustup.dart
@@ -1,0 +1,136 @@
+/// This is copied from Cargokit (which is the official way to use it currently)
+/// Details: https://fzyzcjy.github.io/flutter_rust_bridge/manual/integrate/builtin
+
+import 'dart:io';
+
+import 'package:collection/collection.dart';
+import 'package:path/path.dart' as path;
+
+import 'util.dart';
+
+class _Toolchain {
+  _Toolchain(
+    this.name,
+    this.targets,
+  );
+
+  final String name;
+  final List<String> targets;
+}
+
+class Rustup {
+  List<String>? installedTargets(String toolchain) {
+    final targets = _installedTargets(toolchain);
+    return targets != null ? List.unmodifiable(targets) : null;
+  }
+
+  void installToolchain(String toolchain) {
+    log.info("Installing Rust toolchain: $toolchain");
+    runCommand("rustup", ['toolchain', 'install', toolchain]);
+    _installedToolchains
+        .add(_Toolchain(toolchain, _getInstalledTargets(toolchain)));
+  }
+
+  void installTarget(
+    String target, {
+    required String toolchain,
+  }) {
+    log.info("Installing Rust target: $target");
+    runCommand("rustup", [
+      'target',
+      'add',
+      '--toolchain',
+      toolchain,
+      target,
+    ]);
+    _installedTargets(toolchain)?.add(target);
+  }
+
+  final List<_Toolchain> _installedToolchains;
+
+  Rustup() : _installedToolchains = _getInstalledToolchains();
+
+  List<String>? _installedTargets(String toolchain) => _installedToolchains
+      .firstWhereOrNull(
+          (e) => e.name == toolchain || e.name.startsWith('$toolchain-'))
+      ?.targets;
+
+  static List<_Toolchain> _getInstalledToolchains() {
+    String extractToolchainName(String line) {
+      // ignore (default) after toolchain name
+      final parts = line.split(' ');
+      return parts[0];
+    }
+
+    final res = runCommand("rustup", ['toolchain', 'list']);
+
+    // To list all non-custom toolchains, we need to filter out lines that
+    // don't start with "stable", "beta", or "nightly".
+    Pattern nonCustom = RegExp(r"^(stable|beta|nightly)");
+    final lines = res.stdout
+        .toString()
+        .split('\n')
+        .where((e) => e.isNotEmpty && e.startsWith(nonCustom))
+        .map(extractToolchainName)
+        .toList(growable: true);
+
+    return lines
+        .map(
+          (name) => _Toolchain(
+            name,
+            _getInstalledTargets(name),
+          ),
+        )
+        .toList(growable: true);
+  }
+
+  static List<String> _getInstalledTargets(String toolchain) {
+    final res = runCommand("rustup", [
+      'target',
+      'list',
+      '--toolchain',
+      toolchain,
+      '--installed',
+    ]);
+    final lines = res.stdout
+        .toString()
+        .split('\n')
+        .where((e) => e.isNotEmpty)
+        .toList(growable: true);
+    return lines;
+  }
+
+  bool _didInstallRustSrcForNightly = false;
+
+  void installRustSrcForNightly() {
+    if (_didInstallRustSrcForNightly) {
+      return;
+    }
+    // Useful for -Z build-std
+    runCommand(
+      "rustup",
+      ['component', 'add', 'rust-src', '--toolchain', 'nightly'],
+    );
+    _didInstallRustSrcForNightly = true;
+  }
+
+  static String? executablePath() {
+    final envPath = Platform.environment['PATH'];
+    final envPathSeparator = Platform.isWindows ? ';' : ':';
+    final home = Platform.isWindows
+        ? Platform.environment['USERPROFILE']
+        : Platform.environment['HOME'];
+    final paths = [
+      if (home != null) path.join(home, '.cargo', 'bin'),
+      if (envPath != null) ...envPath.split(envPathSeparator),
+    ];
+    for (final p in paths) {
+      final rustup = Platform.isWindows ? 'rustup.exe' : 'rustup';
+      final rustupPath = path.join(p, rustup);
+      if (File(rustupPath).existsSync()) {
+        return rustupPath;
+      }
+    }
+    return null;
+  }
+}

--- a/packages/core_native/cargokit/build_tool/lib/src/target.dart
+++ b/packages/core_native/cargokit/build_tool/lib/src/target.dart
@@ -1,0 +1,140 @@
+/// This is copied from Cargokit (which is the official way to use it currently)
+/// Details: https://fzyzcjy.github.io/flutter_rust_bridge/manual/integrate/builtin
+
+import 'dart:io';
+
+import 'package:collection/collection.dart';
+
+import 'util.dart';
+
+class Target {
+  Target({
+    required this.rust,
+    this.flutter,
+    this.android,
+    this.androidMinSdkVersion,
+    this.darwinPlatform,
+    this.darwinArch,
+  });
+
+  static final all = [
+    Target(
+      rust: 'armv7-linux-androideabi',
+      flutter: 'android-arm',
+      android: 'armeabi-v7a',
+      androidMinSdkVersion: 16,
+    ),
+    Target(
+      rust: 'aarch64-linux-android',
+      flutter: 'android-arm64',
+      android: 'arm64-v8a',
+      androidMinSdkVersion: 21,
+    ),
+    Target(
+      rust: 'i686-linux-android',
+      flutter: 'android-x86',
+      android: 'x86',
+      androidMinSdkVersion: 16,
+    ),
+    Target(
+      rust: 'x86_64-linux-android',
+      flutter: 'android-x64',
+      android: 'x86_64',
+      androidMinSdkVersion: 21,
+    ),
+    Target(
+      rust: 'x86_64-pc-windows-msvc',
+      flutter: 'windows-x64',
+    ),
+    Target(
+      rust: 'x86_64-unknown-linux-gnu',
+      flutter: 'linux-x64',
+    ),
+    Target(
+      rust: 'aarch64-unknown-linux-gnu',
+      flutter: 'linux-arm64',
+    ),
+    Target(
+      rust: 'x86_64-apple-darwin',
+      darwinPlatform: 'macosx',
+      darwinArch: 'x86_64',
+    ),
+    Target(
+      rust: 'aarch64-apple-darwin',
+      darwinPlatform: 'macosx',
+      darwinArch: 'arm64',
+    ),
+    Target(
+      rust: 'aarch64-apple-ios',
+      darwinPlatform: 'iphoneos',
+      darwinArch: 'arm64',
+    ),
+    Target(
+      rust: 'aarch64-apple-ios-sim',
+      darwinPlatform: 'iphonesimulator',
+      darwinArch: 'arm64',
+    ),
+    Target(
+      rust: 'x86_64-apple-ios',
+      darwinPlatform: 'iphonesimulator',
+      darwinArch: 'x86_64',
+    ),
+  ];
+
+  static Target? forFlutterName(String flutterName) {
+    return all.firstWhereOrNull((element) => element.flutter == flutterName);
+  }
+
+  static Target? forDarwin({
+    required String platformName,
+    required String darwinAarch,
+  }) {
+    return all.firstWhereOrNull((element) => //
+        element.darwinPlatform == platformName &&
+        element.darwinArch == darwinAarch);
+  }
+
+  static Target? forRustTriple(String triple) {
+    return all.firstWhereOrNull((element) => element.rust == triple);
+  }
+
+  static List<Target> androidTargets() {
+    return all
+        .where((element) => element.android != null)
+        .toList(growable: false);
+  }
+
+  /// Returns buildable targets on current host platform ignoring Android targets.
+  static List<Target> buildableTargets() {
+    if (Platform.isLinux) {
+      // Right now we don't support cross-compiling on Linux. So we just return
+      // the host target.
+      final arch = runCommand('arch', []).stdout as String;
+      if (arch.trim() == 'aarch64') {
+        return [Target.forRustTriple('aarch64-unknown-linux-gnu')!];
+      } else {
+        return [Target.forRustTriple('x86_64-unknown-linux-gnu')!];
+      }
+    }
+    return all.where((target) {
+      if (Platform.isWindows) {
+        return target.rust.contains('-windows-');
+      } else if (Platform.isMacOS) {
+        return target.darwinPlatform != null;
+      }
+      return false;
+    }).toList(growable: false);
+  }
+
+  @override
+  String toString() {
+    return rust;
+  }
+
+  final String? flutter;
+  final String rust;
+  final String? android;
+  final int? androidMinSdkVersion;
+  final String? darwinPlatform;
+  final String? darwinArch;
+}

--- a/packages/core_native/cargokit/build_tool/lib/src/util.dart
+++ b/packages/core_native/cargokit/build_tool/lib/src/util.dart
@@ -1,0 +1,172 @@
+/// This is copied from Cargokit (which is the official way to use it currently)
+/// Details: https://fzyzcjy.github.io/flutter_rust_bridge/manual/integrate/builtin
+
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:logging/logging.dart';
+import 'package:path/path.dart' as path;
+
+import 'logging.dart';
+import 'rustup.dart';
+
+final log = Logger("process");
+
+class CommandFailedException implements Exception {
+  final String executable;
+  final List<String> arguments;
+  final ProcessResult result;
+
+  CommandFailedException({
+    required this.executable,
+    required this.arguments,
+    required this.result,
+  });
+
+  @override
+  String toString() {
+    final stdout = result.stdout.toString().trim();
+    final stderr = result.stderr.toString().trim();
+    return [
+      "External Command: $executable ${arguments.map((e) => '"$e"').join(' ')}",
+      "Returned Exit Code: ${result.exitCode}",
+      kSeparator,
+      "STDOUT:",
+      if (stdout.isNotEmpty) stdout,
+      kSeparator,
+      "STDERR:",
+      if (stderr.isNotEmpty) stderr,
+    ].join('\n');
+  }
+}
+
+class TestRunCommandArgs {
+  final String executable;
+  final List<String> arguments;
+  final String? workingDirectory;
+  final Map<String, String>? environment;
+  final bool includeParentEnvironment;
+  final bool runInShell;
+  final Encoding? stdoutEncoding;
+  final Encoding? stderrEncoding;
+
+  TestRunCommandArgs({
+    required this.executable,
+    required this.arguments,
+    this.workingDirectory,
+    this.environment,
+    this.includeParentEnvironment = true,
+    this.runInShell = false,
+    this.stdoutEncoding,
+    this.stderrEncoding,
+  });
+}
+
+class TestRunCommandResult {
+  TestRunCommandResult({
+    this.pid = 1,
+    this.exitCode = 0,
+    this.stdout = '',
+    this.stderr = '',
+  });
+
+  final int pid;
+  final int exitCode;
+  final String stdout;
+  final String stderr;
+}
+
+TestRunCommandResult Function(TestRunCommandArgs args)? testRunCommandOverride;
+
+ProcessResult runCommand(
+  String executable,
+  List<String> arguments, {
+  String? workingDirectory,
+  Map<String, String>? environment,
+  bool includeParentEnvironment = true,
+  bool runInShell = false,
+  Encoding? stdoutEncoding = systemEncoding,
+  Encoding? stderrEncoding = systemEncoding,
+}) {
+  if (testRunCommandOverride != null) {
+    final result = testRunCommandOverride!(TestRunCommandArgs(
+      executable: executable,
+      arguments: arguments,
+      workingDirectory: workingDirectory,
+      environment: environment,
+      includeParentEnvironment: includeParentEnvironment,
+      runInShell: runInShell,
+      stdoutEncoding: stdoutEncoding,
+      stderrEncoding: stderrEncoding,
+    ));
+    return ProcessResult(
+      result.pid,
+      result.exitCode,
+      result.stdout,
+      result.stderr,
+    );
+  }
+  log.finer('Running command $executable ${arguments.join(' ')}');
+  final res = Process.runSync(
+    _resolveExecutable(executable),
+    arguments,
+    workingDirectory: workingDirectory,
+    environment: environment,
+    includeParentEnvironment: includeParentEnvironment,
+    runInShell: runInShell,
+    stderrEncoding: stderrEncoding,
+    stdoutEncoding: stdoutEncoding,
+  );
+  if (res.exitCode != 0) {
+    throw CommandFailedException(
+      executable: executable,
+      arguments: arguments,
+      result: res,
+    );
+  } else {
+    return res;
+  }
+}
+
+class RustupNotFoundException implements Exception {
+  @override
+  String toString() {
+    return [
+      ' ',
+      'rustup not found in PATH.',
+      ' ',
+      'Maybe you need to install Rust? It only takes a minute:',
+      ' ',
+      if (Platform.isWindows) 'https://www.rust-lang.org/tools/install',
+      if (hasHomebrewRustInPath()) ...[
+        '\$ brew unlink rust # Unlink homebrew Rust from PATH',
+      ],
+      if (!Platform.isWindows)
+        "\$ curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh",
+      ' ',
+    ].join('\n');
+  }
+
+  static bool hasHomebrewRustInPath() {
+    if (!Platform.isMacOS) {
+      return false;
+    }
+    final envPath = Platform.environment['PATH'] ?? '';
+    final paths = envPath.split(':');
+    return paths.any((p) {
+      return p.contains('homebrew') && File(path.join(p, 'rustc')).existsSync();
+    });
+  }
+}
+
+String _resolveExecutable(String executable) {
+  if (executable == 'rustup') {
+    final resolved = Rustup.executablePath();
+    if (resolved != null) {
+      return resolved;
+    }
+    throw RustupNotFoundException();
+  } else {
+    return executable;
+  }
+}

--- a/packages/core_native/cargokit/build_tool/lib/src/verify_binaries.dart
+++ b/packages/core_native/cargokit/build_tool/lib/src/verify_binaries.dart
@@ -1,0 +1,84 @@
+/// This is copied from Cargokit (which is the official way to use it currently)
+/// Details: https://fzyzcjy.github.io/flutter_rust_bridge/manual/integrate/builtin
+
+import 'dart:io';
+
+import 'package:ed25519_edwards/ed25519_edwards.dart';
+import 'package:http/http.dart';
+
+import 'artifacts_provider.dart';
+import 'cargo.dart';
+import 'crate_hash.dart';
+import 'options.dart';
+import 'precompile_binaries.dart';
+import 'target.dart';
+
+class VerifyBinaries {
+  VerifyBinaries({
+    required this.manifestDir,
+  });
+
+  final String manifestDir;
+
+  Future<void> run() async {
+    final crateInfo = CrateInfo.load(manifestDir);
+
+    final config = CargokitCrateOptions.load(manifestDir: manifestDir);
+    final precompiledBinaries = config.precompiledBinaries;
+    if (precompiledBinaries == null) {
+      stdout.writeln('Crate does not support precompiled binaries.');
+    } else {
+      final crateHash = CrateHash.compute(manifestDir);
+      stdout.writeln('Crate hash: $crateHash');
+
+      for (final target in Target.all) {
+        final message = 'Checking ${target.rust}...';
+        stdout.write(message.padRight(40));
+        stdout.flush();
+
+        final artifacts = getArtifactNames(
+          target: target,
+          libraryName: crateInfo.packageName,
+          remote: true,
+        );
+
+        final prefix = precompiledBinaries.uriPrefix;
+
+        bool ok = true;
+
+        for (final artifact in artifacts) {
+          final fileName = PrecompileBinaries.fileName(target, artifact);
+          final signatureFileName =
+              PrecompileBinaries.signatureFileName(target, artifact);
+
+          final url = Uri.parse('$prefix$crateHash/$fileName');
+          final signatureUrl =
+              Uri.parse('$prefix$crateHash/$signatureFileName');
+
+          final signature = await get(signatureUrl);
+          if (signature.statusCode != 200) {
+            stdout.writeln('MISSING');
+            ok = false;
+            break;
+          }
+          final asset = await get(url);
+          if (asset.statusCode != 200) {
+            stdout.writeln('MISSING');
+            ok = false;
+            break;
+          }
+
+          if (!verify(precompiledBinaries.publicKey, asset.bodyBytes,
+              signature.bodyBytes)) {
+            stdout.writeln('INVALID SIGNATURE');
+            ok = false;
+          }
+        }
+
+        if (ok) {
+          stdout.writeln('OK');
+        }
+      }
+    }
+  }
+}

--- a/packages/core_native/cargokit/build_tool/pubspec.yaml
+++ b/packages/core_native/cargokit/build_tool/pubspec.yaml
@@ -1,0 +1,33 @@
+# This is copied from Cargokit (which is the official way to use it currently)
+# Details: https://fzyzcjy.github.io/flutter_rust_bridge/manual/integrate/builtin
+
+name: build_tool
+description: Cargokit build_tool. Facilitates the build of Rust crate during Flutter application build.
+publish_to: none
+version: 1.0.0
+
+environment:
+  sdk: ">=3.0.0 <4.0.0"
+
+# Add regular dependencies here.
+dependencies:
+  # these are pinned on purpose because the bundle_tool_runner doesn't have
+  # pubspec.lock. See run_build_tool.sh
+  logging: 1.2.0
+  path: 1.8.0
+  version: 3.0.0
+  collection: 1.18.0
+  ed25519_edwards: 0.3.1
+  hex: 0.2.0
+  yaml: 3.1.2
+  source_span: 1.10.0
+  github: 9.17.0
+  args: 2.4.2
+  crypto: 3.0.3
+  convert: 3.1.1
+  http: 1.1.0
+  toml: 0.14.0
+
+dev_dependencies:
+  lints: ^2.1.0
+  test: ^1.24.0

--- a/packages/core_native/cargokit/cmake/cargokit.cmake
+++ b/packages/core_native/cargokit/cmake/cargokit.cmake
@@ -1,0 +1,99 @@
+SET(cargokit_cmake_root "${CMAKE_CURRENT_LIST_DIR}/..")
+
+# Workaround for https://github.com/dart-lang/pub/issues/4010
+get_filename_component(cargokit_cmake_root "${cargokit_cmake_root}" REALPATH)
+
+if(WIN32)
+    # REALPATH does not properly resolve symlinks on windows :-/
+    execute_process(COMMAND powershell -ExecutionPolicy Bypass -File "${CMAKE_CURRENT_LIST_DIR}/resolve_symlinks.ps1" "${cargokit_cmake_root}" OUTPUT_VARIABLE cargokit_cmake_root OUTPUT_STRIP_TRAILING_WHITESPACE)
+endif()
+
+# Arguments
+# - target: CMAKE target to which rust library is linked
+# - manifest_dir: relative path from current folder to directory containing cargo manifest
+# - lib_name: cargo package name
+# - any_symbol_name: name of any exported symbol from the library.
+#                    used on windows to force linking with library.
+function(apply_cargokit target manifest_dir lib_name any_symbol_name)
+
+    set(CARGOKIT_LIB_NAME "${lib_name}")
+    set(CARGOKIT_LIB_FULL_NAME "${CMAKE_SHARED_MODULE_PREFIX}${CARGOKIT_LIB_NAME}${CMAKE_SHARED_MODULE_SUFFIX}")
+    if (CMAKE_CONFIGURATION_TYPES)
+        set(CARGOKIT_OUTPUT_DIR "${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>")
+        set(OUTPUT_LIB "${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/${CARGOKIT_LIB_FULL_NAME}")
+    else()
+        set(CARGOKIT_OUTPUT_DIR "${CMAKE_CURRENT_BINARY_DIR}")
+        set(OUTPUT_LIB "${CMAKE_CURRENT_BINARY_DIR}/${CARGOKIT_LIB_FULL_NAME}")
+    endif()
+    set(CARGOKIT_TEMP_DIR "${CMAKE_CURRENT_BINARY_DIR}/cargokit_build")
+
+    if (FLUTTER_TARGET_PLATFORM)
+        set(CARGOKIT_TARGET_PLATFORM "${FLUTTER_TARGET_PLATFORM}")
+    else()
+        set(CARGOKIT_TARGET_PLATFORM "windows-x64")
+    endif()
+
+    set(CARGOKIT_ENV
+        "CARGOKIT_CMAKE=${CMAKE_COMMAND}"
+        "CARGOKIT_CONFIGURATION=$<CONFIG>"
+        "CARGOKIT_MANIFEST_DIR=${CMAKE_CURRENT_SOURCE_DIR}/${manifest_dir}"
+        "CARGOKIT_TARGET_TEMP_DIR=${CARGOKIT_TEMP_DIR}"
+        "CARGOKIT_OUTPUT_DIR=${CARGOKIT_OUTPUT_DIR}"
+        "CARGOKIT_TARGET_PLATFORM=${CARGOKIT_TARGET_PLATFORM}"
+        "CARGOKIT_TOOL_TEMP_DIR=${CARGOKIT_TEMP_DIR}/tool"
+        "CARGOKIT_ROOT_PROJECT_DIR=${CMAKE_SOURCE_DIR}"
+    )
+
+    if (WIN32)
+        set(SCRIPT_EXTENSION ".cmd")
+        set(IMPORT_LIB_EXTENSION ".lib")
+    else()
+        set(SCRIPT_EXTENSION ".sh")
+        set(IMPORT_LIB_EXTENSION "")
+        execute_process(COMMAND chmod +x "${cargokit_cmake_root}/run_build_tool${SCRIPT_EXTENSION}")
+    endif()
+
+    # Using generators in custom command is only supported in CMake 3.20+
+    if (CMAKE_CONFIGURATION_TYPES AND ${CMAKE_VERSION} VERSION_LESS "3.20.0")
+        foreach(CONFIG IN LISTS CMAKE_CONFIGURATION_TYPES)
+            add_custom_command(
+                OUTPUT
+                "${CMAKE_CURRENT_BINARY_DIR}/${CONFIG}/${CARGOKIT_LIB_FULL_NAME}"
+                "${CMAKE_CURRENT_BINARY_DIR}/_phony_"
+                COMMAND ${CMAKE_COMMAND} -E env ${CARGOKIT_ENV}
+                "${cargokit_cmake_root}/run_build_tool${SCRIPT_EXTENSION}" build-cmake
+                VERBATIM
+            )
+        endforeach()
+    else()
+        add_custom_command(
+            OUTPUT
+            ${OUTPUT_LIB}
+            "${CMAKE_CURRENT_BINARY_DIR}/_phony_"
+            COMMAND ${CMAKE_COMMAND} -E env ${CARGOKIT_ENV}
+            "${cargokit_cmake_root}/run_build_tool${SCRIPT_EXTENSION}" build-cmake
+            VERBATIM
+        )
+    endif()
+
+
+    set_source_files_properties("${CMAKE_CURRENT_BINARY_DIR}/_phony_" PROPERTIES SYMBOLIC TRUE)
+
+    if (TARGET ${target})
+        # If we have actual cmake target provided create target and make existing
+        # target depend on it
+        add_custom_target("${target}_cargokit" DEPENDS ${OUTPUT_LIB})
+        add_dependencies("${target}" "${target}_cargokit")
+        target_link_libraries("${target}" PRIVATE "${OUTPUT_LIB}${IMPORT_LIB_EXTENSION}")
+        if(WIN32)
+            target_link_options(${target} PRIVATE "/INCLUDE:${any_symbol_name}")
+        endif()
+    else()
+        # Otherwise (FFI) just use ALL to force building always
+        add_custom_target("${target}_cargokit" ALL DEPENDS ${OUTPUT_LIB})
+    endif()
+
+    # Allow adding the output library to plugin bundled libraries
+    set("${target}_cargokit_lib" ${OUTPUT_LIB} PARENT_SCOPE)
+
+endfunction()

--- a/packages/core_native/cargokit/cmake/resolve_symlinks.ps1
+++ b/packages/core_native/cargokit/cmake/resolve_symlinks.ps1
@@ -1,0 +1,34 @@
+function Resolve-Symlinks {
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Position = 0, Mandatory, ValueFromPipeline, ValueFromPipelineByPropertyName)]
+        [string] $Path
+    )
+
+    [string] $separator = '/'
+    [string[]] $parts = $Path.Split($separator)
+
+    [string] $realPath = ''
+    foreach ($part in $parts) {
+        if ($realPath -and !$realPath.EndsWith($separator)) {
+            $realPath += $separator
+        }
+
+        $realPath += $part.Replace('\', '/')
+
+        # The slash is important when using Get-Item on Drive letters in pwsh.
+        if (-not($realPath.Contains($separator)) -and $realPath.EndsWith(':')) {
+            $realPath += '/'
+        }
+
+        $item = Get-Item $realPath
+        if ($item.LinkTarget) {
+            $realPath = $item.LinkTarget.Replace('\', '/')
+        }
+    }
+    $realPath
+}
+
+$path = Resolve-Symlinks -Path $args[0]
+Write-Host $path

--- a/packages/core_native/cargokit/gradle/plugin.gradle
+++ b/packages/core_native/cargokit/gradle/plugin.gradle
@@ -1,0 +1,305 @@
+/// This is copied from Cargokit (which is the official way to use it currently)
+/// Details: https://fzyzcjy.github.io/flutter_rust_bridge/manual/integrate/builtin
+
+import java.nio.file.Paths
+import javax.inject.Inject
+import org.apache.tools.ant.taskdefs.condition.Os
+// PATCHED for Gradle 9: `Project.exec` was removed in Gradle 9, so the build
+// task takes the injected `ExecOperations` service instead.
+import org.gradle.process.ExecOperations
+
+CargoKitPlugin.file = buildscript.sourceFile
+
+apply plugin: CargoKitPlugin
+
+// PATCHED: upstream cargokit builds exactly one library per Gradle module.
+// Airo Mind needs two -- whisper.cpp and llama.cpp each statically vendor their
+// own ggml and cannot share a linked image (#1546) -- and they belong to one
+// Flutter plugin, so splitting them across two Gradle modules would mean two
+// packages for one feature.
+//
+// The single-library form still works and is what every other cargokit
+// consumer uses. `library(manifestDir, libname)` is additive.
+class CargoKitLibrary {
+    String manifestDir; // Relative path to folder containing Cargo.toml
+    String libname; // Library name within Cargo.toml. Must be a cdylib
+    // Optional. When set, only these Flutter target platforms are built for
+    // this library; when null, whatever the build type asks for. Declared by
+    // the consumer rather than hardcoded here, so the reason lives with the
+    // package that has it.
+    List<String> platforms;
+}
+
+class CargoKitExtension {
+    String manifestDir;
+    String libname;
+
+    final List<CargoKitLibrary> libraries = []
+
+    void library(String manifestDir, String libname, List<String> platforms = null) {
+        def entry = new CargoKitLibrary()
+        entry.manifestDir = manifestDir
+        entry.libname = libname
+        entry.platforms = platforms
+        libraries.add(entry)
+    }
+
+    /// Every library to build: the explicit list when one was declared, and the
+    /// single-library properties otherwise. Never both -- declaring the list
+    /// and the properties would leave which one wins to reading order.
+    List<CargoKitLibrary> allLibraries() {
+        if (!libraries.isEmpty()) {
+            if (manifestDir != null || libname != null) {
+                throw new GradleException(
+                    "cargokit: use either library(...) entries or the " +
+                    "manifestDir/libname properties, not both.")
+            }
+            return libraries
+        }
+        def single = new CargoKitLibrary()
+        single.manifestDir = manifestDir
+        single.libname = libname
+        return [single]
+    }
+}
+
+abstract class CargoKitBuildTask extends DefaultTask {
+
+    @Input
+    String buildMode
+
+    @Input
+    String buildDir
+
+    @Input
+    String outputDir
+
+    @Input
+    String ndkVersion
+
+    @Input
+    String sdkDirectory
+
+    @Input
+    int compileSdkVersion;
+
+    @Input
+    int minSdkVersion;
+
+    @Input
+    String pluginFile
+
+    @Input
+    List<String> targetPlatforms
+
+    // PATCHED for Gradle 9: injected replacement for the removed `project.exec`.
+    @Inject
+    abstract ExecOperations getExecOperations()
+
+    // PATCHED: carried on the task rather than read back off the extension, so
+    // that one module can build several libraries -- each task knows its own.
+    @Input
+    String cargoManifestDir
+
+    @TaskAction
+    def build() {
+        if (cargoManifestDir == null) {
+            throw new GradleException("Property 'manifestDir' must be set on cargokit extension");
+        }
+
+        def executableName = Os.isFamily(Os.FAMILY_WINDOWS) ? "run_build_tool.cmd" : "run_build_tool.sh"
+        def path = Paths.get(new File(pluginFile).parent, "..", executableName);
+
+        def manifestDir = Paths.get(project.buildscript.sourceFile.parent, cargoManifestDir)
+
+        def rootProjectDir = project.rootProject.projectDir
+
+        if (!Os.isFamily(Os.FAMILY_WINDOWS)) {
+            // PATCHED for Gradle 9: was `project.exec`.
+            execOperations.exec {
+                commandLine 'chmod', '+x', path
+            }
+        }
+
+        // PATCHED for Gradle 9: was `project.exec`.
+        execOperations.exec {
+            executable path
+            args "build-gradle"
+            environment "CARGOKIT_ROOT_PROJECT_DIR", rootProjectDir
+            environment "CARGOKIT_TOOL_TEMP_DIR", "${buildDir}/build_tool"
+            environment "CARGOKIT_MANIFEST_DIR", manifestDir
+            environment "CARGOKIT_CONFIGURATION", buildMode
+            environment "CARGOKIT_TARGET_TEMP_DIR", buildDir
+            environment "CARGOKIT_OUTPUT_DIR", outputDir
+            environment "CARGOKIT_NDK_VERSION", ndkVersion
+            environment "CARGOKIT_SDK_DIR", sdkDirectory
+            environment "CARGOKIT_COMPILE_SDK_VERSION", compileSdkVersion
+            environment "CARGOKIT_MIN_SDK_VERSION", minSdkVersion
+            environment "CARGOKIT_TARGET_PLATFORMS", targetPlatforms.join(",")
+            environment "CARGOKIT_JAVA_HOME", System.properties['java.home']
+        }
+
+        copyCxxSharedRuntime()
+    }
+
+    // PATCHED: ship the NDK's C++ runtime alongside the engines.
+    //
+    // whisper.cpp and llama.cpp are C++, and the Rust cdylibs link them against
+    // libc++_shared (see `get_cpp_link_stdlib` in whisper-rs-sys). Nothing else
+    // in this APK carries that library, so without this the app installs and
+    // launches and then fails the moment it opens the bridge:
+    //
+    //   dlopen failed: library "libc++_shared.so" not found:
+    //     needed by .../lib/arm64-v8a/libairo_mind_whisper.so
+    //
+    // It is taken from the SAME NDK cargokit just compiled with, rather than
+    // the one this Gradle module pins -- those two disagree in this repo, and
+    // pairing a C++ runtime with objects built by a different toolchain is the
+    // kind of mismatch that fails somewhere other than where it was caused.
+    private void copyCxxSharedRuntime() {
+        def hostTag = Os.isFamily(Os.FAMILY_MAC) ? "darwin-x86_64"
+            : (Os.isFamily(Os.FAMILY_WINDOWS) ? "windows-x86_64" : "linux-x86_64")
+
+        def abiForPlatform = [
+            "android-arm64": ["arm64-v8a", "aarch64-linux-android"],
+            "android-arm"  : ["armeabi-v7a", "arm-linux-androideabi"],
+            "android-x64"  : ["x86_64", "x86_64-linux-android"],
+            "android-x86"  : ["x86", "i686-linux-android"],
+        ]
+
+        targetPlatforms.each { platform ->
+            def entry = abiForPlatform[platform]
+            if (entry == null) {
+                return
+            }
+            def (abi, triple) = entry
+            def source = new File(
+                "$sdkDirectory/ndk/$ndkVersion/toolchains/llvm/prebuilt/$hostTag" +
+                "/sysroot/usr/lib/$triple/libc++_shared.so")
+            if (!source.exists()) {
+                throw new GradleException(
+                    "libc++_shared.so not found for $abi at $source. The engines " +
+                    "link it and will fail to dlopen without it.")
+            }
+            def destDir = new File("$outputDir/$abi")
+            destDir.mkdirs()
+            def dest = new File(destDir, "libc++_shared.so")
+            // Only when it changed: this runs per library, and the second copy
+            // would otherwise rewrite a file the packaging step already read.
+            if (!dest.exists() || dest.length() != source.length()) {
+                dest.bytes = source.bytes
+            }
+        }
+    }
+}
+
+class CargoKitPlugin implements Plugin<Project> {
+
+    static String file;
+
+    private Plugin findFlutterPlugin(Project rootProject) {
+        _findFlutterPlugin(rootProject.childProjects)
+    }
+
+   private Plugin _findFlutterPlugin(Map projects) {
+        for (project in projects) {
+            for (plugin in project.value.getPlugins()) {
+                if (plugin.class.name == "com.flutter.gradle.FlutterPlugin") {
+                    return plugin;
+                }
+            }
+            def plugin = _findFlutterPlugin(project.value.childProjects);
+            if (plugin != null) {
+                return plugin;
+            }
+        }
+        return null;
+    }
+
+    @Override
+    void apply(Project project) {
+        def plugin = findFlutterPlugin(project.rootProject);
+
+        project.extensions.create("cargokit", CargoKitExtension)
+
+        if (plugin == null) {
+            print("Flutter plugin not found, CargoKit plugin will not be applied.")
+            return;
+        }
+
+        def cargoBuildDir = "${project.buildDir}/build"
+
+        // Determine if the project is an application or library
+        def isApplication = plugin.project.plugins.hasPlugin('com.android.application')
+        def variants = isApplication ? plugin.project.android.applicationVariants : plugin.project.android.libraryVariants
+
+        variants.all { variant ->
+
+            final buildType = variant.buildType.name
+
+            def cargoOutputDir = "${project.buildDir}/jniLibs/${buildType}";
+            def jniLibs = project.android.sourceSets.maybeCreate(buildType).jniLibs;
+            jniLibs.srcDir(new File(cargoOutputDir))
+
+            def platforms = com.flutter.gradle.FlutterPluginUtils.getTargetPlatforms(project).collect()
+
+            // Same thing addFlutterDependencies does in flutter.gradle
+            if (buildType == "debug") {
+                platforms.add("android-x86")
+                platforms.add("android-x64")
+            }
+
+            // The task name depends on plugin properties, which are not available
+            // at this point
+            project.getGradle().afterProject {
+                // PATCHED: one task per declared library. Each carries its own
+                // manifest directory, and the library name keeps the task names
+                // distinct.
+                project.cargokit.allLibraries().each { lib ->
+                    if (lib.libname == null) {
+                        throw new GradleException("Property 'libname' must be set on cargokit extension");
+                    }
+
+                    def taskName = "cargokitCargoBuild${lib.libname.capitalize()}${buildType.capitalize()}";
+
+                    if (project.tasks.findByName(taskName)) {
+                        return
+                    }
+
+                    if (plugin.project.android.ndkVersion == null) {
+                        throw new GradleException("Please set 'android.ndkVersion' in 'app/build.gradle'.")
+                    }
+
+                    // PATCHED: a library may narrow the ABI set. Intersected
+                    // rather than substituted, so declaring a platform the
+                    // build is not producing cannot conjure one.
+                    def libPlatforms = lib.platforms == null
+                        ? platforms
+                        : platforms.findAll { lib.platforms.contains(it) }
+
+                    def task = project.tasks.create(taskName, CargoKitBuildTask.class) {
+                        buildMode = variant.buildType.name
+                        buildDir = cargoBuildDir
+                        outputDir = cargoOutputDir
+                        ndkVersion = plugin.project.android.ndkVersion
+                        sdkDirectory = plugin.project.android.sdkDirectory
+                        minSdkVersion = plugin.project.android.defaultConfig.minSdkVersion.apiLevel as int
+                        compileSdkVersion = plugin.project.android.compileSdkVersion.substring(8) as int
+                        targetPlatforms = libPlatforms
+                        pluginFile = CargoKitPlugin.file
+                        cargoManifestDir = lib.manifestDir
+                    }
+                    def onTask = { newTask ->
+                        if (newTask.name == "merge${buildType.capitalize()}NativeLibs") {
+                            newTask.dependsOn task
+                            // Fix gradle 7.4.2 not picking up JNI library changes
+                            newTask.outputs.upToDateWhen { false }
+                        }
+                    }
+                    project.tasks.each onTask
+                    project.tasks.whenTaskAdded onTask
+                }
+            }
+        }
+    }
+}

--- a/packages/core_native/cargokit/run_build_tool.cmd
+++ b/packages/core_native/cargokit/run_build_tool.cmd
@@ -1,0 +1,91 @@
+@echo off
+setlocal
+
+setlocal ENABLEDELAYEDEXPANSION
+
+SET BASEDIR=%~dp0
+
+if not exist "%CARGOKIT_TOOL_TEMP_DIR%" (
+    mkdir "%CARGOKIT_TOOL_TEMP_DIR%"
+)
+cd /D "%CARGOKIT_TOOL_TEMP_DIR%"
+
+SET BUILD_TOOL_PKG_DIR=%BASEDIR%build_tool
+SET DART=%FLUTTER_ROOT%\bin\cache\dart-sdk\bin\dart
+
+set BUILD_TOOL_PKG_DIR_POSIX=%BUILD_TOOL_PKG_DIR:\=/%
+
+(
+    echo name: build_tool_runner
+    echo version: 1.0.0
+    echo publish_to: none
+    echo.
+    echo environment:
+    echo   sdk: '^>=3.0.0 ^<4.0.0'
+    echo.
+    echo dependencies:
+    echo   build_tool:
+    echo     path: %BUILD_TOOL_PKG_DIR_POSIX%
+) >pubspec.yaml
+
+if not exist bin (
+    mkdir bin
+)
+
+(
+    echo import 'package:build_tool/build_tool.dart' as build_tool;
+    echo void main^(List^<String^> args^) ^{
+    echo    build_tool.runMain^(args^);
+    echo ^}
+) >bin\build_tool_runner.dart
+
+SET PRECOMPILED=bin\build_tool_runner.dill
+
+REM To detect changes in package we compare output of DIR /s (recursive)
+set PREV_PACKAGE_INFO=.dart_tool\package_info.prev
+set CUR_PACKAGE_INFO=.dart_tool\package_info.cur
+
+DIR "%BUILD_TOOL_PKG_DIR%" /s > "%CUR_PACKAGE_INFO%_orig"
+
+REM Last line in dir output is free space on harddrive. That is bound to
+REM change between invocation so we need to remove it
+(
+    Set "Line="
+    For /F "UseBackQ Delims=" %%A In ("%CUR_PACKAGE_INFO%_orig") Do (
+        SetLocal EnableDelayedExpansion
+        If Defined Line Echo !Line!
+        EndLocal
+        Set "Line=%%A")
+) >"%CUR_PACKAGE_INFO%"
+DEL "%CUR_PACKAGE_INFO%_orig"
+
+REM Compare current directory listing with previous
+FC /B "%CUR_PACKAGE_INFO%" "%PREV_PACKAGE_INFO%" > nul 2>&1
+
+If %ERRORLEVEL% neq 0 (
+    REM Changed - copy current to previous and remove precompiled kernel
+    if exist "%PREV_PACKAGE_INFO%" (
+        DEL "%PREV_PACKAGE_INFO%"
+    )
+    MOVE /Y "%CUR_PACKAGE_INFO%" "%PREV_PACKAGE_INFO%"
+    if exist "%PRECOMPILED%" (
+        DEL "%PRECOMPILED%"
+    )
+)
+
+REM There is no CUR_PACKAGE_INFO it was renamed in previous step to %PREV_PACKAGE_INFO%
+REM which means  we need to do pub get and precompile
+if not exist "%PRECOMPILED%" (
+    echo Running pub get in "%cd%"
+    "%DART%" pub get --no-precompile
+    "%DART%" compile kernel bin/build_tool_runner.dart
+)
+
+"%DART%" "%PRECOMPILED%" %*
+
+REM 253 means invalid snapshot version.
+If %ERRORLEVEL% equ 253 (
+    "%DART%" pub get --no-precompile
+    "%DART%" compile kernel bin/build_tool_runner.dart
+    "%DART%" "%PRECOMPILED%" %*
+)

--- a/packages/core_native/cargokit/run_build_tool.sh
+++ b/packages/core_native/cargokit/run_build_tool.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+
+set -e
+
+BASEDIR=$(dirname "$0")
+
+mkdir -p "$CARGOKIT_TOOL_TEMP_DIR"
+
+cd "$CARGOKIT_TOOL_TEMP_DIR"
+
+# Write a very simple bin package in temp folder that depends on build_tool package
+# from Cargokit. This is done to ensure that we don't pollute Cargokit folder
+# with .dart_tool contents.
+
+BUILD_TOOL_PKG_DIR="$BASEDIR/build_tool"
+
+if [[ -z $FLUTTER_ROOT ]]; then # not defined
+  DART=dart
+else
+  DART="$FLUTTER_ROOT/bin/cache/dart-sdk/bin/dart"
+fi
+
+cat << EOF > "pubspec.yaml"
+name: build_tool_runner
+version: 1.0.0
+publish_to: none
+
+environment:
+  sdk: '>=3.0.0 <4.0.0'
+
+dependencies:
+  build_tool:
+    path: "$BUILD_TOOL_PKG_DIR"
+EOF
+
+mkdir -p "bin"
+
+cat << EOF > "bin/build_tool_runner.dart"
+import 'package:build_tool/build_tool.dart' as build_tool;
+void main(List<String> args) {
+  build_tool.runMain(args);
+}
+EOF
+
+# Create alias for `shasum` if it does not exist and `sha1sum` exists
+if ! [ -x "$(command -v shasum)" ] && [ -x "$(command -v sha1sum)" ]; then
+  shopt -s expand_aliases
+  alias shasum="sha1sum"
+fi
+
+# Dart run will not cache any package that has a path dependency, which
+# is the case for our build_tool_runner. So instead we precompile the package
+# ourselves.
+# To invalidate the cached kernel we use the hash of ls -LR of the build_tool
+# package directory. This should be good enough, as the build_tool package
+# itself is not meant to have any path dependencies.
+
+if [[ "$OSTYPE" == "darwin"* ]]; then
+  PACKAGE_HASH=$(ls -lTR "$BUILD_TOOL_PKG_DIR" | shasum)
+else
+  PACKAGE_HASH=$(ls -lR --full-time "$BUILD_TOOL_PKG_DIR" | shasum)
+fi
+
+PACKAGE_HASH_FILE=".package_hash"
+
+if [ -f "$PACKAGE_HASH_FILE" ]; then
+    EXISTING_HASH=$(cat "$PACKAGE_HASH_FILE")
+    if [ "$PACKAGE_HASH" != "$EXISTING_HASH" ]; then
+        rm "$PACKAGE_HASH_FILE"
+    fi
+fi
+
+# Run pub get if needed.
+if [ ! -f "$PACKAGE_HASH_FILE" ]; then
+    "$DART" pub get --no-precompile
+    "$DART" compile kernel bin/build_tool_runner.dart
+    echo "$PACKAGE_HASH" > "$PACKAGE_HASH_FILE"
+fi
+
+# Rebuild the tool if it was deleted by Android Studio
+if [ ! -f "bin/build_tool_runner.dill" ]; then
+  "$DART" compile kernel bin/build_tool_runner.dart
+fi
+
+set +e
+
+"$DART" bin/build_tool_runner.dill "$@"
+
+exit_code=$?
+
+# 253 means invalid snapshot version.
+if [ $exit_code == 253 ]; then
+  "$DART" pub get --no-precompile
+  "$DART" compile kernel bin/build_tool_runner.dart
+  "$DART" bin/build_tool_runner.dill "$@"
+  exit_code=$?
+fi
+
+exit $exit_code

--- a/packages/core_native/ios/Classes/dummy_file.c
+++ b/packages/core_native/ios/Classes/dummy_file.c
@@ -1,0 +1,3 @@
+// CocoaPods requires at least one source file in a pod. The runtime itself
+// is a Rust static library that cargokit builds and force-loads; nothing
+// here is called at run time.

--- a/packages/core_native/ios/core_native.podspec
+++ b/packages/core_native/ios/core_native.podspec
@@ -1,0 +1,40 @@
+#
+# Cargokit builds airo_core as part of the Xcode build, so it's compiled by
+# the normal Flutter build rather than by a script someone has to remember
+# to run. Wired for #1677 — mirrors feature_mind's proven pattern, minus
+# the dual-engine complexity (this is a single crate, so the standard
+# force-load-the-static-archive shape applies unmodified).
+#
+Pod::Spec.new do |s|
+  s.name             = 'core_native'
+  s.version          = '0.1.0'
+  s.summary          = 'Flutter bindings for the airo_core Rust crate.'
+  s.description      = <<-DESC
+High-performance native engines for playlist, EPG, search, and dedup —
+falls back to pure Dart when the bridge is unavailable.
+                       DESC
+  s.homepage         = 'https://github.com/DevelopersCoffee/airo'
+  s.license          = { :type => 'MIT' }
+  s.author           = { 'DevelopersCoffee' => 'coffee.devloper@gmail.com' }
+  s.source           = { :path => '.' }
+  s.source_files     = 'Classes/**/*'
+  s.dependency 'Flutter'
+  s.platform = :ios, '11.0'
+
+  s.script_phase = {
+    :name => 'Build airo_core',
+    # The crate lives in the cargo workspace at <repo>/rust, not inside this
+    # package, so the manifest path climbs out of packages/core_native.
+    :script => 'sh "$PODS_TARGET_SRCROOT/../cargokit/build_pod.sh" ../../../rust/airo_core airo_core',
+    :execution_position => :before_compile,
+    :input_files => ['${BUILT_PRODUCTS_DIR}/cargokit_phony'],
+    :output_files => ["${BUILT_PRODUCTS_DIR}/libairo_core.a"],
+  }
+  s.pod_target_xcconfig = {
+    'DEFINES_MODULE' => 'YES',
+    # Flutter.framework does not contain an i386 slice.
+    'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386',
+    'OTHER_LDFLAGS' => '-force_load ${BUILT_PRODUCTS_DIR}/libairo_core.a',
+  }
+  s.swift_version = '5.0'
+end

--- a/packages/core_native/linux/CMakeLists.txt
+++ b/packages/core_native/linux/CMakeLists.txt
@@ -1,0 +1,15 @@
+# Cargokit builds airo_core as part of the CMake configure/build, so the
+# desktop targets need no separate step (#1677).
+cmake_minimum_required(VERSION 3.10)
+
+set(PROJECT_NAME "core_native")
+project(${PROJECT_NAME} LANGUAGES CXX)
+
+include("${CMAKE_CURRENT_SOURCE_DIR}/../cargokit/cmake/cargokit.cmake")
+# The crate is in the cargo workspace at <repo>/rust, not in this package.
+apply_cargokit(${PROJECT_NAME} ../../../rust/airo_core airo_core "")
+
+set(core_native_bundled_libraries
+  "${core_native_cargokit_lib}"
+  PARENT_SCOPE
+)

--- a/packages/core_native/macos/Classes/dummy_file.c
+++ b/packages/core_native/macos/Classes/dummy_file.c
@@ -1,0 +1,3 @@
+// CocoaPods requires at least one source file in a pod. The runtime itself
+// is a Rust static library that cargokit builds and force-loads; nothing
+// here is called at run time.

--- a/packages/core_native/macos/core_native.podspec
+++ b/packages/core_native/macos/core_native.podspec
@@ -1,0 +1,39 @@
+#
+# Cargokit builds airo_core as part of the Xcode build, so it's compiled by
+# the normal Flutter build rather than by a script someone has to remember
+# to run. Wired for #1677 — mirrors feature_mind's proven pattern, minus
+# the dual-engine complexity (this is a single crate, so the standard
+# force-load-the-static-archive shape applies unmodified).
+#
+Pod::Spec.new do |s|
+  s.name             = 'core_native'
+  s.version          = '0.1.0'
+  s.summary          = 'Flutter bindings for the airo_core Rust crate.'
+  s.description      = <<-DESC
+High-performance native engines for playlist, EPG, search, and dedup —
+falls back to pure Dart when the bridge is unavailable.
+                       DESC
+  s.homepage         = 'https://github.com/DevelopersCoffee/airo'
+  s.license          = { :type => 'MIT' }
+  s.author           = { 'DevelopersCoffee' => 'coffee.devloper@gmail.com' }
+  s.source           = { :path => '.' }
+  s.source_files     = 'Classes/**/*'
+  s.dependency 'FlutterMacOS'
+  s.platform = :osx, '10.15'
+  s.swift_version = '5.0'
+
+  s.script_phase = {
+    :name => 'Build airo_core',
+    # The crate lives in the cargo workspace at <repo>/rust, not inside this
+    # package, so the manifest path climbs out of packages/core_native.
+    :script => 'sh "$PODS_TARGET_SRCROOT/../cargokit/build_pod.sh" ../../../rust/airo_core airo_core',
+    :execution_position => :before_compile,
+    :input_files => ['${BUILT_PRODUCTS_DIR}/cargokit_phony'],
+    :output_files => ["${BUILT_PRODUCTS_DIR}/libairo_core.a"],
+  }
+  s.pod_target_xcconfig = {
+    'DEFINES_MODULE' => 'YES',
+    'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386',
+    'OTHER_LDFLAGS' => '-force_load ${BUILT_PRODUCTS_DIR}/libairo_core.a',
+  }
+end

--- a/packages/core_native/pubspec.yaml
+++ b/packages/core_native/pubspec.yaml
@@ -16,3 +16,26 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   flutter_lints: ^6.0.0
+
+flutter:
+  # Wired for #1677: airo_core was a phantom native path (real FRB bindings,
+  # 6 consuming Dart packages, no build wiring — RustLib.init() always threw
+  # and every call site silently took its Dart fallback). Mirrors
+  # feature_mind's cargokit pattern. Unlike feature_mind, iOS IS declared
+  # here — this is a single crate (`crate-type = ["cdylib", "staticlib",
+  # "rlib"]` in rust/airo_core/Cargo.toml), so it has none of feature_mind's
+  # whisper.cpp/llama.cpp duplicate-ggml-symbol conflict that forced iOS off
+  # there. There is still no iOS CI in this repo to catch a regression here
+  # (see #1704) — a device build is the only thing that will.
+  plugin:
+    platforms:
+      android:
+        ffiPlugin: true
+      ios:
+        ffiPlugin: true
+      macos:
+        ffiPlugin: true
+      linux:
+        ffiPlugin: true
+      windows:
+        ffiPlugin: true

--- a/packages/core_native/windows/.gitignore
+++ b/packages/core_native/windows/.gitignore
@@ -1,0 +1,17 @@
+flutter/
+
+# Visual Studio user-specific files.
+*.suo
+*.user
+*.userosscache
+*.sln.docstates
+
+# Visual Studio build-related files.
+x64/
+x86/
+
+# Visual Studio cache files
+# files ending in .cache can be ignored
+*.[Cc]ache
+# but keep track of directories ending in .cache
+!*.[Cc]ache/

--- a/packages/core_native/windows/CMakeLists.txt
+++ b/packages/core_native/windows/CMakeLists.txt
@@ -1,0 +1,15 @@
+# Cargokit builds airo_core as part of the CMake configure/build, so the
+# desktop targets need no separate step (#1677).
+cmake_minimum_required(VERSION 3.14)
+
+set(PROJECT_NAME "core_native")
+project(${PROJECT_NAME} LANGUAGES CXX)
+
+include("${CMAKE_CURRENT_SOURCE_DIR}/../cargokit/cmake/cargokit.cmake")
+# The crate is in the cargo workspace at <repo>/rust, not in this package.
+apply_cargokit(${PROJECT_NAME} ../../../rust/airo_core airo_core "")
+
+set(core_native_bundled_libraries
+  "${core_native_cargokit_lib}"
+  PARENT_SCOPE
+)

--- a/packages/core_orchestration_storage/module.yaml
+++ b/packages/core_orchestration_storage/module.yaml
@@ -14,3 +14,5 @@ allowed_dependencies:
 forbidden_dependencies:
   - app
 quality_gates: {}
+
+status: pre-wired  # unwired orchestration island (#1675) — built for Play Anywhere (milestone 10), no app flavor reaches it yet. Excluded from the #1681 reachability gate; do not delete without a Play Anywhere activation decision.

--- a/packages/core_pairing/module.yaml
+++ b/packages/core_pairing/module.yaml
@@ -7,3 +7,5 @@ allowed_dependencies: []
 forbidden_dependencies:
   - app
 quality_gates: {}
+
+status: pre-wired  # unwired orchestration island (#1675) — built for Play Anywhere (milestone 10), no app flavor reaches it yet. Excluded from the #1681 reachability gate; do not delete without a Play Anywhere activation decision.

--- a/packages/core_presence/module.yaml
+++ b/packages/core_presence/module.yaml
@@ -10,3 +10,5 @@ allowed_dependencies:
 forbidden_dependencies:
   - app
 quality_gates: {}
+
+status: pre-wired  # unwired orchestration island (#1675) — built for Play Anywhere (milestone 10), no app flavor reaches it yet. Excluded from the #1681 reachability gate; do not delete without a Play Anywhere activation decision.

--- a/packages/core_push_wake/module.yaml
+++ b/packages/core_push_wake/module.yaml
@@ -9,3 +9,5 @@ allowed_dependencies:
 forbidden_dependencies:
   - app
 quality_gates: {}
+
+status: pre-wired  # unwired orchestration island (#1675) — built for Play Anywhere (milestone 10), no app flavor reaches it yet. Excluded from the #1681 reachability gate; do not delete without a Play Anywhere activation decision.

--- a/packages/core_remote_control/module.yaml
+++ b/packages/core_remote_control/module.yaml
@@ -12,3 +12,5 @@ allowed_dependencies:
 forbidden_dependencies:
   - app
 quality_gates: {}
+
+status: pre-wired  # unwired orchestration island (#1675) — built for Play Anywhere (milestone 10), no app flavor reaches it yet. Excluded from the #1681 reachability gate; do not delete without a Play Anywhere activation decision.

--- a/packages/core_sessions/module.yaml
+++ b/packages/core_sessions/module.yaml
@@ -11,3 +11,5 @@ allowed_dependencies:
 forbidden_dependencies:
   - app
 quality_gates: {}
+
+status: pre-wired  # unwired orchestration island (#1675) — built for Play Anywhere (milestone 10), no app flavor reaches it yet. Excluded from the #1681 reachability gate; do not delete without a Play Anywhere activation decision.

--- a/packages/core_watch_progress/module.yaml
+++ b/packages/core_watch_progress/module.yaml
@@ -9,3 +9,5 @@ allowed_dependencies:
 forbidden_dependencies:
   - app
 quality_gates: {}
+
+status: pre-wired  # unwired orchestration island (#1675) — built for Play Anywhere (milestone 10), no app flavor reaches it yet. Excluded from the #1681 reachability gate; do not delete without a Play Anywhere activation decision.


### PR DESCRIPTION
## Summary

Two coupled decision issues, one PR (core_media_data's fate ties #1675 and #1677 together per both issue bodies).

### #1675 — orchestration island: keep-as-seam
11 packages (~9.4k LOC) implement multi-device orchestration for the Play Anywhere roadmap (milestone 10) — no app flavor reaches them, but their edges point INTO the live graph (`core_protocol`, `core_media_routing`), so archiving isn't free and Play Anywhere isn't imminent enough to justify wiring now.
- `status: pre-wired` added to all 11 `module.yaml` files, each pointing back to this issue and to milestone 10 as the revisit trigger.
- `docs/agents/COUNCIL.md` documents the new optional `status` field.

### #1677 — core_native phantom native path: wire it
`airo_core` had real FRB bindings and 6 consuming Dart packages, but no plugin platform block — every `initializeCoreNativeBridge()` call (~20 sites) silently took the Dart fallback in every shipped build.
- Vendored feature_mind's proven cargokit tooling verbatim (engine-agnostic, already CI-tested).
- Generated android/ios/macos/linux/windows wiring from the official `flutter_rust_bridge_codegen` 2.11.1 single-crate template — feature_mind's own build files are customized for its two-engine whisper.cpp/llama.cpp symbol collision, which doesn't apply to airo_core's single ordinary crate.
- Unlike feature_mind, **iOS is wired** — no duplicate-symbol conflict here to force it off.
- `core_media_data` marked `status: pre-wired` too: it's the relational-store model layer for this native path, reached today only via `platform_benchmarks` (tool-only). Not archived — it's what exercises the path this PR just wired.

## Test plan
- [x] `python3 scripts/check-module-manifests.py` — 57/57 manifests valid
- [x] `flutter pub get` (core_native, app) — resolves clean, `core_native` registers as an Android + iOS plugin in `.flutter-plugins-dependencies`
- [x] `cd app && flutter analyze lib` — clean
- [x] `cd app && flutter build web --release` — succeeds (no web plugin declared, unaffected)
- [x] **`./gradlew :core_native:cargokitCargoBuildAiro_coreDebug` — BUILD SUCCESSFUL.** Produces real `libairo_core.so` for all 4 Android ABIs (arm64-v8a, armeabi-v7a, x86, x86_64); each exports 14 `frb_*` entry points (verified via `nm -D`, the same check feature_mind's own build script uses).

## What I could NOT verify locally
- iOS / macOS / Linux / Windows builds — no toolchain/runner access here for those platforms, and this repo has no iOS CI (#1704) to catch a regression automatically. Flagging for human review, same caveat #1704's author raised for the Rust-toolchain CI work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)