### PR TITLE
fix(android): bump compileSdk 36->37, fix cargokit minor-version parsing (#1712)

### DIFF
--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -968,18 +968,18 @@ packages:
     dependency: transitive
     description:
       name: flutter_secure_storage
-      sha256: "7686b1d6a29985dcbb808c59518226e603e3bfa7c0ddfd1a0d00e4cda77c868e"
+      sha256: "15e8c8fe269fdf7d469b23008ab3df521c8b826ed345820532364c31bdebace6"
       url: "https://pub.dev"
     source: hosted
-    version: "10.3.1"
+    version: "11.0.0"
   flutter_secure_storage_darwin:
     dependency: transitive
     description:
       name: flutter_secure_storage_darwin
-      sha256: "82329fa5cdf343773b1b6897dea959105a29f092454259edff92f9f6637e8149"
+      sha256: ac6d76a752de0cd738334eb4b21743fc4943f449f5b6e308f18838b048c02ac0
       url: "https://pub.dev"
     source: hosted
-    version: "0.3.2"
+    version: "0.4.0"
   flutter_secure_storage_linux:
     dependency: transitive
     description:

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,6 +8,6 @@
 # minSdk     = lowest Android API the product supports.
 
 [versions]
-airo-compile-sdk = "36"
+airo-compile-sdk = "37"
 airo-target-sdk = "36"
 airo-min-sdk = "26"

--- a/packages/core_native/android/build.gradle
+++ b/packages/core_native/android/build.gradle
@@ -27,7 +27,7 @@ cargokit {
 android {
     namespace = "com.developerscoffee.airo.core_native"
     // Must track gradle/libs.versions.toml airo-compile-sdk (#1575).
-    compileSdk = 36
+    compileSdk = 37
     ndkVersion = "27.0.12077973"
 
     compileOptions {

--- a/packages/core_native/cargokit/gradle/plugin.gradle
+++ b/packages/core_native/cargokit/gradle/plugin.gradle
@@ -284,7 +284,12 @@ class CargoKitPlugin implements Plugin<Project> {
                         ndkVersion = plugin.project.android.ndkVersion
                         sdkDirectory = plugin.project.android.sdkDirectory
                         minSdkVersion = plugin.project.android.defaultConfig.minSdkVersion.apiLevel as int
-                        compileSdkVersion = plugin.project.android.compileSdkVersion.substring(8) as int
+                        // PATCHED: AGP reports compileSdkVersion as "android-37.0" for
+                        // platforms that use minor-version notation (e.g. android-37.0,
+                        // installed as `platforms;android-37.0`), not just plain
+                        // "android-37". Naive `as int` on "37.0" throws
+                        // NumberFormatException, so take the leading integer segment.
+                        compileSdkVersion = plugin.project.android.compileSdkVersion.substring(8).split('\\.')[0] as int
                         targetPlatforms = libPlatforms
                         pluginFile = CargoKitPlugin.file
                         cargoManifestDir = lib.manifestDir

--- a/packages/feature_mind/android/build.gradle
+++ b/packages/feature_mind/android/build.gradle
@@ -50,7 +50,7 @@ android {
     // Must track gradle/libs.versions.toml airo-compile-sdk (#1575). The app
     // module's compileSdk does not override library modules — AGP validates
     // AAR metadata per module. flutter_local_notifications requires 36+.
-    compileSdk = 36
+    compileSdk = 37
     ndkVersion = "27.0.12077973"
 
     compileOptions {

--- a/packages/feature_mind/cargokit/gradle/plugin.gradle
+++ b/packages/feature_mind/cargokit/gradle/plugin.gradle
@@ -284,7 +284,12 @@ class CargoKitPlugin implements Plugin<Project> {
                         ndkVersion = plugin.project.android.ndkVersion
                         sdkDirectory = plugin.project.android.sdkDirectory
                         minSdkVersion = plugin.project.android.defaultConfig.minSdkVersion.apiLevel as int
-                        compileSdkVersion = plugin.project.android.compileSdkVersion.substring(8) as int
+                        // PATCHED: AGP reports compileSdkVersion as "android-37.0" for
+                        // platforms that use minor-version notation (e.g. android-37.0,
+                        // installed as `platforms;android-37.0`), not just plain
+                        // "android-37". Naive `as int` on "37.0" throws
+                        // NumberFormatException, so take the leading integer segment.
+                        compileSdkVersion = plugin.project.android.compileSdkVersion.substring(8).split('\\.')[0] as int
                         targetPlatforms = libPlatforms
                         pluginFile = CargoKitPlugin.file
                         cargoManifestDir = lib.manifestDir

--- a/packages/feature_mind/pubspec.lock
+++ b/packages/feature_mind/pubspec.lock
@@ -443,18 +443,18 @@ packages:
     dependency: transitive
     description:
       name: flutter_secure_storage
-      sha256: "7686b1d6a29985dcbb808c59518226e603e3bfa7c0ddfd1a0d00e4cda77c868e"
+      sha256: "15e8c8fe269fdf7d469b23008ab3df521c8b826ed345820532364c31bdebace6"
       url: "https://pub.dev"
     source: hosted
-    version: "10.3.1"
+    version: "11.0.0"
   flutter_secure_storage_darwin:
     dependency: transitive
     description:
       name: flutter_secure_storage_darwin
-      sha256: "82329fa5cdf343773b1b6897dea959105a29f092454259edff92f9f6637e8149"
+      sha256: ac6d76a752de0cd738334eb4b21743fc4943f449f5b6e308f18838b048c02ac0
       url: "https://pub.dev"
     source: hosted
-    version: "0.3.2"
+    version: "0.4.0"
   flutter_secure_storage_linux:
     dependency: transitive
     description:

--- a/packages/platform_downloads/android/build.gradle
+++ b/packages/platform_downloads/android/build.gradle
@@ -22,7 +22,7 @@ kotlin {
 android {
     namespace = "io.airo.platform_downloads"
     // Must track gradle/libs.versions.toml airo-compile-sdk (#1575).
-    compileSdk = 36
+    compileSdk = 37
 
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_17

--- a/packages/platform_player/third_party/flutter_chrome_cast/android/build.gradle
+++ b/packages/platform_player/third_party/flutter_chrome_cast/android/build.gradle
@@ -25,7 +25,7 @@ apply plugin: 'com.android.library'
 android {
     namespace = "com.felnanuke.google_cast"
     // Must track gradle/libs.versions.toml airo-compile-sdk (see #1575).
-    compileSdk = 36
+    compileSdk = 37
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_11

--- a/packages/platform_player/third_party/screen_protector/android/build.gradle
+++ b/packages/platform_player/third_party/screen_protector/android/build.gradle
@@ -20,7 +20,7 @@ group 'com.prongbang.screen_protector'
 
 android {
     namespace 'com.prongbang.screen_protector'
-    compileSdk 36
+    compileSdk 37
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_17


### PR DESCRIPTION
## Summary

Fixes #1712 — Android builds were broken on `main` for every flavor.

- `flutter_secure_storage: ^11.0.0` (pinned in `core_data`/`platform_coin_vault`) requires compileSdk 37; repo baseline was 36. Bumped the single-source-of-truth (`gradle/libs.versions.toml`), synced the 5 flagged library modules per `scripts/check-android-sdk-baseline.sh` (feature_mind, flutter_chrome_cast, platform_downloads, screen_protector, core_native — the last is new since the original fix attempt, wasn't flagged yet then).
- The installed local SDK 37 platform reports as `android-37.0` (minor-version notation). Both vendored cargokit copies (`packages/feature_mind/cargokit`, `packages/core_native/cargokit`) did a naive `.substring(8) as int` on that string, throwing `NumberFormatException`. Take the leading integer segment instead.

First two commits are a straight cherry-pick of `dc8e9fc3`/`82a954cb` — work already done and described in #1694's PR body but never actually part of that PR's merged diff (those two objects existed locally but not on any remote branch). Third commit is the missing `core_native` module sync.

## Test plan
- [x] `./scripts/check-android-sdk-baseline.sh` passes clean (was failing before core_native's fix)
- [x] `flutter build apk --debug --target=lib/main.dart` succeeds from a clean state
- [x] Installed and launched on a physical Pixel 9 (Android 17 preview) — `MainActivity` started, media session initialized, zero `FATAL`/`AndroidRuntime` exceptions in logcat
- [x] `dart run build_runner build` in `packages/feature_mind` (pre-req, documented CI step, unrelated to this fix)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>