### PR TITLE
ci(native): add Rust toolchain to build-windows/build-linux jobs (#1705)

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -634,6 +634,15 @@ jobs:
           cd ../core_auth; flutter pub get
           cd ../../app; flutter pub get
 
+      # app/pubspec.yaml (used unmodified in this job) depends on feature_mind
+      # and core_native, both FFI plugins whose Windows build wires in
+      # cargokit -- it shells out to `cargo` for the host target. Same gap
+      # #1678/#1704 fixed for the Android/macOS jobs (#1705), no explicit
+      # `targets:` needed here since cargokit builds for the host triple on
+      # desktop, matching rust-core.yml's build-desktop job.
+      - name: Install Rust toolchain (for cargokit / feature_mind / core_native)
+        uses: dtolnay/rust-toolchain@stable
+
       - name: Run code generation
         run: |
           cd app
@@ -695,6 +704,15 @@ jobs:
           cd ../core_ai && flutter pub get
           cd ../core_auth && flutter pub get
           cd ../../app && flutter pub get
+
+      # app/pubspec.yaml (used unmodified in this job) depends on feature_mind
+      # and core_native, both FFI plugins whose Linux build wires in cargokit
+      # -- it shells out to `cargo` for the host target. Same gap #1678/#1704
+      # fixed for the Android/macOS jobs (#1705), no explicit `targets:`
+      # needed here since cargokit builds for the host triple on desktop,
+      # matching rust-core.yml's build-desktop job.
+      - name: Install Rust toolchain (for cargokit / feature_mind / core_native)
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Run code generation
         run: |


### PR DESCRIPTION
## Summary
Closes #1705. Same gap #1678/#1704 fixed for the Android/macOS app-building jobs — `app/pubspec.yaml` (used unmodified in `build-windows`/`build-linux`) depends on `feature_mind` and, since #1677, `core_native` too. Both are FFI plugins whose desktop build wires in cargokit and shells out to `cargo`; neither job had a pinned Rust toolchain before this. #1704 explicitly scoped these two jobs out as a fast-follow.

No explicit `targets:` needed (unlike the Android jobs) — cargokit builds for the host triple on desktop. Matched `rust-core.yml`'s `build-desktop` job exactly (`ubuntu-latest`/`windows-latest` matrix, plain `dtolnay/rust-toolchain@stable`).

## Test plan
- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/build-and-release.yml'))"` — parses clean
- [ ] Could not run `build-windows`/`build-linux` directly — no Windows/Linux release-build runner access here. Matched the proven `rust-core.yml` pattern; flagging for a live CI run to confirm, same caveat #1704 raised for its own changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)