### PR TITLE
fix(deps): resolve pubspec_ios_spm.yaml version conflict blocking CI

### DIFF
--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -2152,7 +2152,7 @@ packages:
   screen_protector:
     dependency: "direct overridden"
     description:
-      path: "../packages/third_party/screen_protector"
+      path: "../packages/platform_player/third_party/screen_protector"
       relative: true
     source: path
     version: "1.5.3"

--- a/app/pubspec_ios_spm.yaml
+++ b/app/pubspec_ios_spm.yaml
@@ -88,8 +88,8 @@ dependencies:
   google_mlkit_image_labeling: 0.15.0
   video_player: ^2.13.0
   flutter_chrome_cast: ^1.4.6
-  wakelock_plus: 1.5.2
-  package_info_plus: 9.0.1
+  wakelock_plus: 1.6.1
+  package_info_plus: 10.2.0
   screenshot: 3.0.0
   flutter_image_compress: 2.4.0
   llama_flutter_android: ^0.2.6


### PR DESCRIPTION
## Summary
`variant-dependencies` has been failing on every PR and on `main` itself since #1608: `core_data`'s `flutter_secure_storage ^11.0.0` pulls in `flutter_secure_storage_windows ^4.2.2` (needs `win32 ^6.0.1`), but `pubspec_ios_spm.yaml` pinned `wakelock_plus` at the exact old `1.5.2` (needs `win32 ^5.6.1`) and `package_info_plus` at `9.0.1` (needs `win32 ^5.5.3`) — both incompatible, so `flutter pub get` on this variant fails version solving outright, not just a lint/analyze issue.

Bumped both to the versions already proven working in `pubspec_tv.yaml`/`pubspec.yaml` (`wakelock_plus 1.6.1`, `package_info_plus 10.2.0`) rather than picking new pins blind.

## Test plan
- [x] `bash scripts/check-variant-pubspecs.sh` — all variant pubspecs resolve clean (was failing on `pubspec_ios_spm.yaml` before this fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)