### PR TITLE
fix(iptv): drop redundant vertical padding on FILTER row causing local overflow

### DIFF
--- a/packages/feature_iptv/lib/presentation/tv_ux/sections/filter_row.dart
+++ b/packages/feature_iptv/lib/presentation/tv_ux/sections/filter_row.dart
@@ -111,7 +111,7 @@ class FilterRow extends ConsumerWidget {
       builder: (context, constraints) {
         if (constraints.maxWidth >= 760 && chips.length >= 4) {
           return Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 4),
+            padding: const EdgeInsets.symmetric(horizontal: 12),
             child: Row(
               children: [
                 Expanded(flex: 12, child: _expandChip(chips[0])),
@@ -128,7 +128,7 @@ class FilterRow extends ConsumerWidget {
 
         return SingleChildScrollView(
           scrollDirection: Axis.horizontal,
-          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 4),
+          padding: const EdgeInsets.symmetric(horizontal: 12),
           child: Row(
             children: [
               for (final chip in chips) ...[chip, const SizedBox(width: 8)],


### PR DESCRIPTION
## Summary

The FILTER chip \`Container\` (\`filter_row.dart:215\`) is fixed \`height: 48\`, but both branches of \`FilterRow\`'s \`LayoutBuilder\` (wide-mode \`Row\`, narrow-mode \`SingleChildScrollView\`) wrapped it in \`Padding(vertical: 4)\` — 4px top + 4px bottom, demanding 56px total. The parent slot (\`_ExplorerSection\` in \`airo_tv_shell.dart\`) allocates exactly 48px via \`SizedBox(height: 48)\`, so this padding guaranteed an 8px local overflow, independent of any other layout state.

Found while diagnosing #1721 (a visible \`BOTTOM OVERFLOWED\` debug banner reproduced on a physical Pixel 9). This fix alone does **not** resolve that banner — confirmed via rebuild + reinstall on-device, identical overflow amount persisted — the real cause there is a separate outer \`Column\` sizing issue, tracked in #1721. Landing this anyway since it's a real, always-present bug regardless.

## Test plan
- [x] Diff is a 2-line padding change, no logic change
- [ ] Would need a golden/widget test asserting no RenderFlex overflow in the FILTER row at 48px height — didn't add one, out of scope for this narrow fix; flagging for whoever picks up #1721