### PR TITLE
feat(mind): enable Metal acceleration for macOS llama/whisper builds

### DIFF
--- a/rust/airo_mind_llama/Cargo.toml
+++ b/rust/airo_mind_llama/Cargo.toml
@@ -31,10 +31,42 @@ llama-cpp-2 = { version = "0.1.153", optional = true, default-features = false }
 # Re-exported by llama-cpp-2 for token_to_piece; pinned to the version it uses.
 encoding_rs = { version = "0.8", optional = true }
 
+# Metal acceleration, macOS only.
+#
+# llama-cpp-sys-2's build.rs does not read a Rust-level `metal` feature at
+# all -- llama.cpp's own CMakeLists.txt defaults GGML_METAL to ON for every
+# Apple target, so this crate has in practice already been linking Metal on
+# macOS regardless of any Cargo feature. This entry makes that an explicit,
+# checked contract instead of an implicit upstream default, and future-proofs
+# against llama-cpp-2 someday consuming its own declared
+# `metal = ["llama-cpp-sys-2/metal"]` feature (present in its Cargo.toml but
+# currently unread by the sys crate's build script).
+#
+# This is a target-specific *addition* to the `llama-cpp-2` dependency above,
+# not a second copy of it -- Cargo unifies the feature set for a resolved
+# target across every table naming the dependency, and this table is gated on
+# `cfg(target_os = "macos")` so it never reaches the Android cargokit build
+# (`android-arm64` only, see `android/build.gradle`) or the default (no
+# `llama` feature) boundary build. iOS is out of scope --
+# `packages/feature_mind/ios/feature_mind.podspec` documents iOS as not
+# building at all yet (#1546 phase 4).
+[target.'cfg(target_os = "macos")'.dependencies]
+llama-cpp-2 = { version = "0.1.153", optional = true, default-features = false, features = [
+  "metal",
+] }
+
 [features]
 default = []
 # Real offline generation. Requires cmake and a C++ toolchain.
 llama = ["dep:llama-cpp-2", "dep:encoding_rs"]
+# Documents the macOS Metal contract explicitly (see the target-specific
+# dependency table above); does not change what gets linked on macOS, since
+# Metal is already unified in automatically for `cfg(target_os = "macos")`
+# builds. Kept as a real, buildable feature name so `cargo build --features
+# "llama,metal"` matches this milestone's stated acceptance check, and so a
+# non-macOS build has a named flag available (a no-op there, since the
+# target-specific table above simply does not apply).
+metal = ["llama"]
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(frb_expand)'] }

--- a/rust/airo_mind_whisper/Cargo.toml
+++ b/rust/airo_mind_whisper/Cargo.toml
@@ -32,11 +32,59 @@ airo_mind_core = { path = "../airo_mind_core" }
 flutter_rust_bridge = "=2.11.1"
 whisper-rs = { version = "0.16", optional = true }
 
+# Metal acceleration, macOS only.
+#
+# Unlike llama.cpp (whose CMakeLists.txt defaults GGML_METAL to ON for every
+# Apple target regardless of any Rust-level feature), whisper.cpp's build does
+# NOT default it on: `whisper-rs-sys`'s build.rs explicitly sets
+# `GGML_METAL OFF` unless the crate's `metal` feature is present. So this
+# crate was genuinely CPU-only on macOS until this entry.
+#
+# This is a target-specific *addition* to the `whisper-rs` dependency above,
+# not a second copy of it -- Cargo unifies the feature set for a resolved
+# target across every table naming the dependency, and this table is gated on
+# `cfg(target_os = "macos")` so it never reaches the Android cargokit build
+# (`android-arm64` only, see `android/build.gradle`) or the default (no
+# `whisper` feature) boundary build. `whisper-rs`'s `WhisperContextParameters`
+# defaults `use_gpu` to `cfg!(feature = "_gpu")` (see
+# `whisper-rs-0.16.0/src/whisper_ctx.rs`), and both `metal`/`coreml` alias
+# that internal `_gpu` feature -- so enabling `metal` here is sufficient for
+# `WhisperContext::new_with_params(..., WhisperContextParameters::default())`
+# in `src/whisper.rs` to request GPU offload without any code change. iOS is
+# out of scope -- `packages/feature_mind/ios/feature_mind.podspec` documents
+# iOS as not building at all yet (#1546 phase 4).
+#
+# CoreML (`whisper-rs`'s `coreml` feature) is deliberately NOT enabled here.
+# `whisper-rs-sys`'s build.rs turns on `WHISPER_COREML` behind that feature
+# cleanly enough, but whisper.cpp's CoreML path needs a SECOND model artifact
+# alongside the GGML `.bin` weights -- a CoreML-compiled encoder
+# (`ggml-<model>-encoder.mlmodelc`, a directory, produced by whisper.cpp's
+# `generate-coreml-model.sh`) -- and this repo's model registry/download
+# pipeline (`airo_mind_core::models::Bundled`, the FRB `RequiredModel` bridge
+# struct, `packages/feature_mind/lib/src/models/download_model_provider.dart`)
+# is a strict one-file-per-model design with no slot for it. Turning the
+# feature on today would compile and link cleanly (`WHISPER_COREML_ALLOW_FALLBACK`
+# means a missing `.mlmodelc` falls back to Metal/CPU instead of crashing) but
+# would be permanently dead weight: nothing in the repo ever produces or
+# distributes that companion file. Tracked as a distinctly-scoped follow-up:
+# https://github.com/DevelopersCoffee/airo/issues/1723
+[target.'cfg(target_os = "macos")'.dependencies]
+whisper-rs = { version = "0.16", optional = true, features = ["metal"] }
+
 [features]
 # CI keeps the default so a boundary check does not compile whisper.cpp.
 default = []
 # Real offline transcription. Requires cmake and a C++ toolchain.
 whisper = ["dep:whisper-rs"]
+# Documents the macOS Metal contract explicitly (see the target-specific
+# dependency table above); does not change what gets linked on macOS, since
+# Metal is already unified in automatically for `cfg(target_os = "macos")`
+# builds. Kept as a real, buildable feature name so `cargo build --features
+# "whisper,metal"` matches this milestone's stated acceptance check, and so a
+# non-macOS build has a named flag available (a no-op there, since the
+# target-specific table above simply does not apply). CoreML is intentionally
+# not exposed as a feature here -- see the comment above and issue #1723.
+metal = ["whisper"]
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(frb_expand)'] }


### PR DESCRIPTION
## Summary

Wave 1 of #1655 (epic #1627): enable Metal/CoreML acceleration for `rust/airo_mind_llama` (llama.cpp) and `rust/airo_mind_whisper` (whisper.cpp) on macOS. Scoped to the Cargo-feature/build-config gap the Wave-0 audit found — no new-crate scaffolding, that's deferred to Wave 2 per the audit.

## Metal — llama.cpp: enabled, with runtime evidence

- `llama-cpp-sys-2`'s build.rs never reads a Rust-level `metal` feature — llama.cpp's own `CMakeLists.txt` defaults `GGML_METAL` to ON for every Apple target, so this crate had in practice always linked Metal on macOS. This PR makes that an explicit, checked Cargo contract (`--features llama,metal`) instead of an implicit upstream default, via a `[target.'cfg(target_os = "macos")'.dependencies]` table.
- **GPU-layer offload check (the gotcha called out in the issue):** `LlamaModelParams::default()` — used unchanged in `rust/airo_mind_llama/src/llama.rs` — calls llama.cpp's own `llama_model_default_params()`, which sets `n_gpu_layers = -1` ("offload every layer"). No code change was needed; the default was already "offload everything," it just wasn't compiled with a GPU backend as an explicit contract before.
- **Runtime evidence gathered:** `otool -L target/debug/libairo_mind_llama.dylib` after `cargo build -p airo_mind_llama --features llama,metal` shows `Metal.framework` and `MetalKit.framework` linked into the binary — this wasn't true before the target-specific feature was added as an explicit build contract (structurally it always would compile Metal in on macOS per llama.cpp's CMake default, but there was no Rust-level guarantee of that).
- `cargo test -p airo_mind_llama --features llama,metal`: 7 passed, 0 failed.

## Metal — whisper.cpp: enabled, with runtime evidence

- `whisper-rs-sys`'s build.rs **explicitly disables** `GGML_METAL` unless the `metal` feature is present — this crate was genuinely CPU-only until this change, unlike llama.cpp.
- `WhisperContextParameters::default()` — used unchanged in `rust/airo_mind_whisper/src/whisper.rs` — sets `use_gpu: cfg!(feature = "_gpu")`, which the crate's `metal`/`coreml` features both alias. Enabling `metal` makes `use_gpu` default to `true` with no code change.
- **Runtime evidence gathered:** `otool -L target/debug/libairo_mind_whisper.dylib` after `cargo build -p airo_mind_whisper --features whisper,metal` shows `Metal.framework`/`MetalKit.framework` linked; `CoreML.framework` correctly absent (feature not turned on — see below).
- `cargo test -p airo_mind_whisper --features whisper,metal`: 11 passed, 0 failed.

No GPU hardware benchmark (tok/s or utilization) was gathered — this session has no macOS GPU access to run the actual model. The evidence bar met here is code-level (`n_gpu_layers`/`use_gpu` defaults) + link-level (Metal.framework present in the built dylib), per the issue's stated acceptance floor ("at minimum a code-level confirmation").

## CoreML — investigated, deliberately not enabled, follow-up filed: #1723

`whisper-rs`'s `coreml` Cargo feature is a clean flag to flip at the build level (`whisper-rs-sys`'s build.rs turns on `WHISPER_COREML` the same way `metal` turns on `GGML_METAL`). The blocker is at runtime: whisper.cpp's CoreML path needs a **second model artifact** next to the GGML `.bin` weights — a CoreML-compiled encoder (`ggml-<model>-encoder.mlmodelc`, a directory, produced by whisper.cpp's `generate-coreml-model.sh`).

Traced this repo's model handling end to end and confirmed it's a strict one-file-per-model design with no slot for a companion artifact:
- `rust/airo_mind_core/src/models.rs::Bundled` — single `file_name` field
- `rust/airo_mind_whisper/src/api/setup.rs::RequiredModel` — same shape across the FRB bridge
- `packages/feature_mind/lib/src/models/download_model_provider.dart` — downloads/verifies exactly one file per model

Turning the Cargo feature on today would compile and link cleanly (`WHISPER_COREML_ALLOW_FALLBACK` means a missing `.mlmodelc` silently falls back to Metal/CPU rather than crashing) but would be permanently dead weight — nothing in the repo produces or distributes that second file. Rather than half-implement this, filed **#1723** scoping the actual work (registry schema, FRB bridge, Dart download pipeline, and distribution of the `.mlmodelc` itself), linked to the broader #1290.

iOS stays out of scope for both engines, as already documented in `packages/feature_mind/ios/feature_mind.podspec` (#1546 phase 4 — iOS has never built).

## Verified

- `cargo build -p airo_mind_llama --features llama,metal` — compiles clean
- `cargo build -p airo_mind_whisper --features whisper,metal` — compiles clean
- `cargo build -p airo_mind_llama -p airo_mind_whisper` (default, no backend — CI boundary build) — still compiles clean, unaffected
- `cargo test -p airo_mind_llama --features llama,metal` — 7 passed
- `cargo test -p airo_mind_whisper --features whisper,metal` — 11 passed
- `cargo fmt --check` on both crates — clean
- `cd app && flutter build web --release` — `✓ Built build/web` (unaffected; these are Rust-only Cargo.toml changes)

## Scope note

Addresses #1655's Metal/CoreML enablement item only. #1655 also tracks a Wave-2 decision (where new Mind crates like GBNF-extraction/validator/eval should live) that this PR does not touch — not claiming "Closes".
