### PR TITLE
fix(mind): harden model manager -- remove Llama, disk eviction, real ModelPort

### DIFF
--- a/packages/core_ai/lib/src/download/model_download_service.dart
+++ b/packages/core_ai/lib/src/download/model_download_service.dart
@@ -14,17 +14,29 @@ class ModelDownloadService {
     ModelStorageManager? storageManager,
     ModelStorageLocation storageLocation =
         ModelStorageLocation.applicationDocuments,
+    int storageBudgetBytes = ModelStorageManager.defaultStorageBudgetBytes,
   }) : this._from(
          _resolveDependencies(
            downloads: downloads,
            storageManager: storageManager,
            storageLocation: storageLocation,
          ),
+         storageBudgetBytes,
        );
 
-  ModelDownloadService._from(_ResolvedDependencies dependencies)
-    : _downloads = dependencies.downloads,
+  ModelDownloadService._from(
+    _ResolvedDependencies dependencies,
+    this.storageBudgetBytes,
+  ) : _downloads = dependencies.downloads,
       _storageManager = dependencies.storageManager;
+
+  /// The enforced on-device ceiling for downloaded model artifacts.
+  ///
+  /// Checked -- and enforced by deleting the least-recently-installed models
+  /// that are not [model] itself -- before every new download starts, so the
+  /// quota is a real disk limit rather than a number the storage UI merely
+  /// displays.
+  final int storageBudgetBytes;
 
   static _ResolvedDependencies _resolveDependencies({
     BackgroundDownloads? downloads,
@@ -45,6 +57,11 @@ class ModelDownloadService {
 
   final BackgroundDownloads _downloads;
   final ModelStorageManager _storageManager;
+
+  /// The storage manager backing this service, for callers (e.g.
+  /// `ModelPort` implementations) that need real on-disk usage/quota figures
+  /// without duplicating a second manager pointed at a different directory.
+  ModelStorageManager get storageManager => _storageManager;
   StreamSubscription<DownloadProgress>? _progressSubscription;
   final Map<String, StreamController<ModelDownloadProgress>> _progressStreams =
       {};
@@ -85,6 +102,18 @@ class ModelDownloadService {
       _scheduledIds.remove(model.id);
       return;
     }
+
+    // Real disk-level eviction: free room within the storage budget before
+    // a new download starts, rather than letting every past download
+    // accumulate on disk forever. Never evicts the model about to be
+    // fetched, even if a stale artifact for it happens to be the oldest.
+    final roomForIncoming = (storageBudgetBytes - model.fileSizeBytes) < 0
+        ? 0
+        : storageBudgetBytes - model.fileSizeBytes;
+    await _storageManager.enforceStorageQuota(
+      maxTotalBytes: roomForIncoming,
+      protectedModelIds: {model.id},
+    );
 
     final source = Uri.tryParse(model.downloadUrl ?? '');
     if (source == null || source.scheme != 'https' || source.host.isEmpty) {

--- a/packages/core_ai/lib/src/registry/model_catalog.dart
+++ b/packages/core_ai/lib/src/registry/model_catalog.dart
@@ -246,53 +246,17 @@ class ModelCatalog {
       tags: ['chat', 'instruction', 'reasoning', 'mobile-friendly'],
     ),
 
-    // Llama 3.2 1B (Meta's smallest Llama)
-    const OfflineModelInfo(
-      id: 'llama-3.2-1b-q4',
-      name: 'Llama 3.2 1B',
-      family: ModelFamily.llama,
-      fileSizeBytes: 700000000, // ~700 MB
-      downloadUrl:
-          'https://huggingface.co/meta-llama/Llama-3.2-1B-Instruct-GGUF/resolve/main/Llama-3.2-1B-Instruct-Q4_K_M.gguf',
-      quantization: ModelQuantization.q4,
-      parameterCount: 1000000000,
-      contextLength: 8192,
-      credibility: ModelCredibility.official,
-      provider: AIProvider.llama,
-      description: 'Meta Llama 3.2 1B. Ultra-compact for mobile.',
-      author: 'Meta',
-      license: 'Llama 3.2 Community',
-      huggingFaceId: 'meta-llama/Llama-3.2-1B-Instruct-GGUF',
-      modalities: [ModelModality.text],
-      capabilities: [ModelCapability.chat, ModelCapability.promptLab],
-      tags: ['chat', 'instruction', 'ultra-small', 'mobile-friendly'],
-    ),
-
-    // Llama 3.2 3B (balanced option)
-    const OfflineModelInfo(
-      id: 'llama-3.2-3b-q4',
-      name: 'Llama 3.2 3B',
-      family: ModelFamily.llama,
-      fileSizeBytes: 2000000000, // ~2 GB
-      downloadUrl:
-          'https://huggingface.co/meta-llama/Llama-3.2-3B-Instruct-GGUF/resolve/main/Llama-3.2-3B-Instruct-Q4_K_M.gguf',
-      quantization: ModelQuantization.q4,
-      parameterCount: 3000000000,
-      contextLength: 8192,
-      credibility: ModelCredibility.official,
-      provider: AIProvider.llama,
-      description: 'Meta Llama 3.2 3B. Good balance of size and capability.',
-      author: 'Meta',
-      license: 'Llama 3.2 Community',
-      huggingFaceId: 'meta-llama/Llama-3.2-3B-Instruct-GGUF',
-      modalities: [ModelModality.text],
-      capabilities: [
-        ModelCapability.chat,
-        ModelCapability.reasoning,
-        ModelCapability.promptLab,
-      ],
-      tags: ['chat', 'instruction', 'balanced', 'mobile-friendly'],
-    ),
+    // Llama 3.2 1B/3B (#1718): deliberately not in the default catalog.
+    // Meta's Llama 3.2 Community License carries redistribution and
+    // attribution terms (including a use-based restriction and a naming
+    // requirement for derivatives) that do not fit an unconditional default
+    // registry the way the Apache-2.0/MIT/Gemma-licensed entries above do
+    // (#1630's "no Llama-licensed model in default registry" acceptance
+    // criterion). No opt-in/advanced-config surface exists in this codebase
+    // to gate a licensed-but-not-default entry behind, and building one for
+    // two models with no other consumer is out of scope here -- if a real
+    // use case shows up, reintroduce them through such a mechanism rather
+    // than back in this list.
 
     // Qwen2 1.5B (Alibaba's compact model)
     const OfflineModelInfo(

--- a/packages/core_ai/lib/src/storage/model_storage_manager.dart
+++ b/packages/core_ai/lib/src/storage/model_storage_manager.dart
@@ -36,6 +36,16 @@ class ModelStorageManager {
     '.onnx',
   ];
 
+  /// Default on-device ceiling for downloaded model artifacts.
+  ///
+  /// A heuristic pending a dedicated device-tier storage policy (#1631
+  /// tracks device-tier gating more broadly) -- 8 GB accommodates two or
+  /// three mid-size quantized models without silently consuming a phone's
+  /// entire free space. [enforceStorageQuota] is what makes this a real
+  /// ceiling rather than a suggestion: it deletes files, not just evicts a
+  /// RAM-resident cache entry.
+  static const int defaultStorageBudgetBytes = 8 * 1024 * 1024 * 1024;
+
   final BackgroundDownloads _downloads;
   final ModelStorageLocation location;
 
@@ -260,6 +270,99 @@ class ModelStorageManager {
     return deletedPaths;
   }
 
+  /// Total bytes currently occupied by installed (fully written) model
+  /// artifacts -- the real, on-disk figure, not a catalog estimate.
+  ///
+  /// Excludes `.tmp`/`.part` staging files: an in-flight download is not
+  /// "installed" and must not count against the quota it is trying to fit
+  /// inside of.
+  Future<int> installedArtifactsTotalBytes() async {
+    var totalBytes = 0;
+    for (final artifact in await _installedArtifacts()) {
+      totalBytes += artifact.sizeBytes;
+    }
+    return totalBytes;
+  }
+
+  /// Deletes installed model artifacts, oldest first, until total on-disk
+  /// usage is at or under [maxTotalBytes].
+  ///
+  /// This is disk-level eviction: unlike [ModelResidencyManager] (which only
+  /// evicts a model from RAM so a new one fits in the memory budget), this
+  /// removes the file from storage, so a device's quota is an enforceable
+  /// ceiling instead of a cache that leaves every download on disk forever.
+  ///
+  /// Oldest is approximated by each artifact's filesystem modification time
+  /// (i.e. roughly "installed longest ago"), since `atime` is unreliable
+  /// across platforms (several mount models disable it). [protectedModelIds]
+  /// (typically the model about to be downloaded, or one a caller knows is
+  /// actively in use) is never evicted, even if it is the oldest artifact on
+  /// disk -- eviction does not delete a protected file to satisfy a quota it
+  /// never agreed to; if that leaves usage over [maxTotalBytes], the
+  /// remainder is left in place and reported as unreachable via the returned
+  /// list falling short of covering the shortfall.
+  ///
+  /// Returns the ids of every model actually deleted, oldest evicted first.
+  Future<List<String>> enforceStorageQuota({
+    int maxTotalBytes = defaultStorageBudgetBytes,
+    Set<String> protectedModelIds = const {},
+  }) async {
+    final artifacts = await _installedArtifacts();
+    var totalBytes = artifacts.fold<int>(0, (sum, a) => sum + a.sizeBytes);
+    if (totalBytes <= maxTotalBytes) return const [];
+
+    artifacts.sort((a, b) => a.modified.compareTo(b.modified));
+
+    final evictedIds = <String>[];
+    for (final artifact in artifacts) {
+      if (totalBytes <= maxTotalBytes) break;
+      if (protectedModelIds.contains(artifact.modelId)) continue;
+
+      final file = File(artifact.path);
+      if (await file.exists()) {
+        await file.delete();
+      }
+      await deleteInstallReceipt(artifact.modelId);
+      totalBytes -= artifact.sizeBytes;
+      evictedIds.add(artifact.modelId);
+    }
+    return evictedIds;
+  }
+
+  /// Scans the models directory for completed (non-`.tmp`/`.part`) artifact
+  /// files, resolving each to the model id its file name encodes.
+  Future<List<_InstalledArtifact>> _installedArtifacts() async {
+    final dir = await getModelsDirectory();
+    if (!await dir.exists()) return [];
+
+    final artifacts = <_InstalledArtifact>[];
+    await for (final entity in dir.list()) {
+      if (entity is! File) continue;
+      final fileName = path.basename(entity.path);
+      if (fileName.endsWith('.tmp') || fileName.endsWith('.part')) continue;
+
+      String? modelId;
+      for (final extension in supportedArtifactExtensions) {
+        if (fileName.endsWith(extension)) {
+          modelId = fileName.substring(0, fileName.length - extension.length);
+          break;
+        }
+      }
+      if (modelId == null) continue;
+
+      final stat = await entity.stat();
+      artifacts.add(
+        _InstalledArtifact(
+          modelId: modelId,
+          path: entity.path,
+          sizeBytes: stat.size,
+          modified: stat.modified,
+        ),
+      );
+    }
+    return artifacts;
+  }
+
   String _artifactExtensionFor(OfflineModelInfo? model) {
     final explicitPath = model?.filePath?.trim().toLowerCase();
     if (explicitPath != null && explicitPath.isNotEmpty) {
@@ -279,4 +382,19 @@ class ModelStorageManager {
 
     return '.gguf';
   }
+}
+
+/// A completed model artifact found on disk during an eviction scan.
+class _InstalledArtifact {
+  const _InstalledArtifact({
+    required this.modelId,
+    required this.path,
+    required this.sizeBytes,
+    required this.modified,
+  });
+
+  final String modelId;
+  final String path;
+  final int sizeBytes;
+  final DateTime modified;
 }

--- a/packages/core_ai/test/download/model_download_service_test.dart
+++ b/packages/core_ai/test/download/model_download_service_test.dart
@@ -89,6 +89,12 @@ void main() {
       ),
     );
     when(() => storage.deleteInstallReceipt(any())).thenAnswer((_) async {});
+    when(
+      () => storage.enforceStorageQuota(
+        maxTotalBytes: any(named: 'maxTotalBytes'),
+        protectedModelIds: any(named: 'protectedModelIds'),
+      ),
+    ).thenAnswer((_) async => <String>[]);
     downloadService = ModelDownloadService(
       downloads: downloads,
       storageManager: storage,
@@ -332,6 +338,43 @@ void main() {
     expect(progress.status, ModelDownloadStatus.failed);
     expect(progress.error, contains('Insufficient disk space'));
     expect(downloads.requests, isEmpty);
+  });
+
+  test('downloadModel enforces the storage quota, protecting the incoming '
+      'model, before enqueuing', () async {
+    downloadService.downloadModel(model);
+    await Future<void>.delayed(Duration.zero);
+
+    final captured = verify(
+      () => storage.enforceStorageQuota(
+        maxTotalBytes: any(named: 'maxTotalBytes'),
+        protectedModelIds: captureAny(named: 'protectedModelIds'),
+      ),
+    ).captured;
+
+    expect(captured.single, {model.id});
+    expect(downloads.requests, hasLength(1));
+  });
+
+  test('a quota-exceeding model still fails cleanly if eviction cannot make '
+      'room', () async {
+    // Even after enforceStorageQuota runs, disk space can still be short
+    // (e.g. every other artifact was protected). hasEnoughDiskSpace is the
+    // final gate and must still fail the download rather than silently
+    // downloading over budget.
+    when(
+      () => storage.hasEnoughDiskSpace(model.fileSizeBytes),
+    ).thenAnswer((_) async => false);
+
+    final progress = await downloadService.downloadModel(model).first;
+
+    expect(progress.status, ModelDownloadStatus.failed);
+    verifyNever(
+      () => storage.enforceStorageQuota(
+        maxTotalBytes: any(named: 'maxTotalBytes'),
+        protectedModelIds: any(named: 'protectedModelIds'),
+      ),
+    );
   });
 
   test('downloadModel preserves LiteRT destination extension', () async {

--- a/packages/core_ai/test/registry/model_catalog_test.dart
+++ b/packages/core_ai/test/registry/model_catalog_test.dart
@@ -58,6 +58,33 @@ void main() {
     });
   });
 
+  group('License compliance (#1630, #1718)', () {
+    test('the default catalog contains no Llama-licensed model', () {
+      expect(
+        ModelCatalog.bundledModels.where(
+          (m) =>
+              m.family == ModelFamily.llama ||
+              (m.license ?? '').toLowerCase().contains('llama'),
+        ),
+        isEmpty,
+        reason:
+            'Llama 3.2 Community License terms do not fit an unconditional '
+            'default registry -- see #1718.',
+      );
+    });
+
+    test('every bundled model declares a structured license string', () {
+      for (final model in ModelCatalog.bundledModels) {
+        expect(
+          model.license,
+          isNotNull,
+          reason: '${model.id} is missing structured license metadata.',
+        );
+        expect(model.license, isNotEmpty);
+      }
+    });
+  });
+
   group('EmbeddingGemma catalog entry', () {
     test('declares only the embeddings capability', () {
       final model = ModelCatalog.bundledModels.firstWhere(

--- a/packages/core_ai/test/storage/model_storage_manager_test.dart
+++ b/packages/core_ai/test/storage/model_storage_manager_test.dart
@@ -267,4 +267,115 @@ void main() {
       expect(await orphanedTmpFile.exists(), isFalse);
     },
   );
+
+  group('enforceStorageQuota (disk-level eviction, #1630)', () {
+    Future<File> writeArtifact(
+      Directory modelsDir,
+      String id,
+      int sizeBytes,
+      DateTime modified,
+    ) async {
+      final file = File(path.join(modelsDir.path, '$id.gguf'));
+      await file.writeAsBytes(List<int>.filled(sizeBytes, 0));
+      await file.setLastModified(modified);
+      return file;
+    }
+
+    test('does nothing while usage is within budget', () async {
+      final modelsDir = Directory(path.join(tempDir.path, 'models'));
+      await modelsDir.create(recursive: true);
+      await writeArtifact(modelsDir, 'a', 100, DateTime(2026));
+
+      final evicted = await storageManager.enforceStorageQuota(
+        maxTotalBytes: 1000,
+      );
+
+      expect(evicted, isEmpty);
+    });
+
+    test(
+      'deletes the oldest-installed artifacts first until under budget',
+      () async {
+        final modelsDir = Directory(path.join(tempDir.path, 'models'));
+        await modelsDir.create(recursive: true);
+        await writeArtifact(modelsDir, 'oldest', 100, DateTime(2026, 1, 1));
+        await writeArtifact(modelsDir, 'middle', 100, DateTime(2026, 1, 2));
+        final newestFile = await writeArtifact(
+          modelsDir,
+          'newest',
+          100,
+          DateTime(2026, 1, 3),
+        );
+
+        final evicted = await storageManager.enforceStorageQuota(
+          maxTotalBytes: 150,
+        );
+
+        expect(evicted, ['oldest', 'middle']);
+        expect(await newestFile.exists(), isTrue);
+        expect(
+          await File(path.join(modelsDir.path, 'oldest.gguf')).exists(),
+          isFalse,
+        );
+        expect(
+          await File(path.join(modelsDir.path, 'middle.gguf')).exists(),
+          isFalse,
+        );
+      },
+    );
+
+    test('never evicts a protected model even if it is oldest', () async {
+      final modelsDir = Directory(path.join(tempDir.path, 'models'));
+      await modelsDir.create(recursive: true);
+      final protectedFile = await writeArtifact(
+        modelsDir,
+        'in-use',
+        100,
+        DateTime(2026, 1, 1),
+      );
+      await writeArtifact(modelsDir, 'newer', 100, DateTime(2026, 1, 2));
+
+      final evicted = await storageManager.enforceStorageQuota(
+        maxTotalBytes: 50,
+        protectedModelIds: {'in-use'},
+      );
+
+      expect(evicted, ['newer']);
+      expect(await protectedFile.exists(), isTrue);
+    });
+
+    test('deletes the install receipt alongside an evicted artifact', () async {
+      final modelsDir = Directory(path.join(tempDir.path, 'models'));
+      await modelsDir.create(recursive: true);
+      await writeArtifact(modelsDir, 'evict-me', 100, DateTime(2026, 1, 1));
+      await storageManager.writeInstallReceipt(
+        const OfflineModelInfo(
+          id: 'evict-me',
+          name: 'Evict Me',
+          family: ModelFamily.gemma,
+          fileSizeBytes: 100,
+        ),
+      );
+
+      await storageManager.enforceStorageQuota(maxTotalBytes: 0);
+
+      expect(await storageManager.readInstallReceipt('evict-me'), isNull);
+    });
+
+    test('ignores in-flight .tmp/.part staging files', () async {
+      final modelsDir = Directory(path.join(tempDir.path, 'models'));
+      await modelsDir.create(recursive: true);
+      final staging = File(path.join(modelsDir.path, 'downloading.gguf.tmp'));
+      await staging.writeAsBytes(List<int>.filled(500, 0));
+
+      final total = await storageManager.installedArtifactsTotalBytes();
+      final evicted = await storageManager.enforceStorageQuota(
+        maxTotalBytes: 0,
+      );
+
+      expect(total, 0);
+      expect(evicted, isEmpty);
+      expect(await staging.exists(), isTrue);
+    });
+  });
 }

--- a/packages/feature_mind/lib/src/runtime/rust/rust_mind_runtime.dart
+++ b/packages/feature_mind/lib/src/runtime/rust/rust_mind_runtime.dart
@@ -1,3 +1,7 @@
+import 'dart:async';
+
+import 'package:core_ai/core_ai.dart' as core_ai;
+
 import '../mind_runtime.dart';
 import '../models/capability_models.dart';
 import '../models/context_models.dart';
@@ -26,7 +30,7 @@ import '../ports/vault_port.dart';
 /// This is the only file in the module allowed to import the generated bridge.
 /// Nothing else may reach `src/api/` or `frb_generated`.
 class RustMindRuntime implements MindRuntime {
-  RustMindRuntime();
+  RustMindRuntime({ModelPort? models}) : models = models ?? _RustModels();
 
   @override
   final VaultPort vault = const _RustVault();
@@ -47,7 +51,7 @@ class RustMindRuntime implements MindRuntime {
   final CapabilityPort capabilities = const _RustCapabilities();
 
   @override
-  final ModelPort models = const _RustModels();
+  final ModelPort models;
 
   @override
   final PortabilityPort portability = const _RustPortability();
@@ -217,34 +221,146 @@ class _RustCapabilities implements CapabilityPort {
   Future<void> remove(String id) async => _pending('CapabilityPort', _issue);
 }
 
+/// Real (non-fixture) [ModelPort], backed by `core_ai`'s already-proven
+/// download/storage pipeline -- the same `ModelDownloadService` and
+/// `ModelStorageManager` `model_provider.dart`'s `DownloadModelProvider`
+/// already uses for Mind's own whisper models.
+///
+/// # What is real here, and what still is not
+///
+/// [all], [storage], and [download] only need a catalog and a disk, so they
+/// are implemented for real: resumable, checksum-verified, atomically
+/// installed downloads, and an on-disk storage budget [core_ai]'s
+/// `ModelStorageManager.enforceStorageQuota` actually enforces by deleting
+/// files, not merely a RAM-residency cache that leaves every past download
+/// on disk forever. [ModelManagementPanel] no longer has to run against
+/// [FixtureMindRuntime] to exercise that behavior.
+///
+/// [load], [unload], [benchmark], and [thermal] all require a model running
+/// in real inference memory, which needs the Rust engine bindings tracked by
+/// #1628 (`LlmBackend` trait + llama.cpp GGUF backend) and #1638 (the Flutter
+/// plugin seam over that FFI) -- neither has landed, so these four stay
+/// honest [MindPortUnavailable] stubs naming those issues. (The blanket
+/// "#1260" every method here used to cite is Vault/Operation-Log FFI, not
+/// model management -- it never actually gated this port; #1628/#1638 are
+/// the issues that do.)
+///
+/// [ModelResidency] has three states -- `loaded` (in inference memory),
+/// `resident` (held on disk by a specific capability), and `available` (not
+/// on disk). Without a wired inference engine or a [CapabilityPort] that
+/// tracks which capability holds which model (#1222, also unimplemented),
+/// this class can only tell the true two-state story disk access gives it:
+/// a downloaded, verified model reports as `resident` with an empty
+/// [MindModel.heldBy] (nothing artificially blocks unloading it), never as
+/// `loaded`.
 class _RustModels implements ModelPort {
-  const _RustModels();
+  _RustModels({
+    core_ai.ModelDownloadService? downloadService,
+    List<core_ai.OfflineModelInfo>? catalog,
+  }) : _downloadService = downloadService ?? core_ai.ModelDownloadService(),
+       _catalog = catalog ?? core_ai.ModelCatalog.bundledModels;
 
-  static const String _issue = '#1260';
+  static const String _runtimeIssue = '#1628, #1638';
+
+  final core_ai.ModelDownloadService _downloadService;
+  final List<core_ai.OfflineModelInfo> _catalog;
+
+  core_ai.OfflineModelInfo? _findCatalogModel(String modelId) {
+    for (final model in _catalog) {
+      if (model.id == modelId) return model;
+    }
+    return null;
+  }
 
   @override
-  Future<List<MindModel>> all() async => _pending('ModelPort', _issue);
+  Future<List<MindModel>> all() async {
+    final results = await Future.wait(
+      _catalog.map((model) async {
+        final downloaded = await _downloadService.isModelDownloaded(
+          model.id,
+          model: model,
+        );
+        return MindModel(
+          id: model.id,
+          name: model.name,
+          sizeBytes: model.fileSizeBytes,
+          residency: downloaded
+              ? ModelResidency.resident
+              : ModelResidency.available,
+        );
+      }),
+    );
+    return results;
+  }
 
   @override
-  Future<({int budgetBytes, int usedBytes})> storage() async =>
-      _pending('ModelPort', _issue);
+  Future<({int budgetBytes, int usedBytes})> storage() async {
+    final usedBytes = await _downloadService.storageManager
+        .installedArtifactsTotalBytes();
+    return (
+      usedBytes: usedBytes,
+      budgetBytes: _downloadService.storageBudgetBytes,
+    );
+  }
 
   @override
-  Future<void> load(String modelId) async => _pending('ModelPort', _issue);
+  Future<void> load(String modelId) async =>
+      _pending('ModelPort', _runtimeIssue);
 
   @override
-  Future<void> unload(String modelId) async => _pending('ModelPort', _issue);
+  Future<void> unload(String modelId) async =>
+      _pending('ModelPort', _runtimeIssue);
 
   @override
-  Stream<({int received, int total})> download(String modelId) =>
-      _pendingStream('ModelPort', _issue);
+  Stream<({int received, int total})> download(String modelId) {
+    final model = _findCatalogModel(modelId);
+    if (model == null) {
+      return _pendingStream(
+        'ModelPort',
+        'unknown model id "$modelId" -- not in the catalog',
+      );
+    }
+    return _downloadService
+        .downloadModel(model)
+        .transform(
+          StreamTransformer<
+            core_ai.ModelDownloadProgress,
+            ({int received, int total})
+          >.fromHandlers(
+            handleData: (progress, sink) {
+              sink.add((
+                received: progress.downloadedBytes,
+                total: progress.totalBytes,
+              ));
+              switch (progress.status) {
+                case core_ai.ModelDownloadStatus.completed:
+                  sink.close();
+                case core_ai.ModelDownloadStatus.failed:
+                case core_ai.ModelDownloadStatus.cancelled:
+                  sink.addError(
+                    MindPortUnavailable(
+                      'ModelPort',
+                      progress.error ?? 'download did not complete',
+                    ),
+                  );
+                  sink.close();
+                case core_ai.ModelDownloadStatus.pending:
+                case core_ai.ModelDownloadStatus.downloading:
+                case core_ai.ModelDownloadStatus.paused:
+                case core_ai.ModelDownloadStatus.verifying:
+                  break;
+              }
+            },
+          ),
+        );
+  }
 
   @override
   Future<ModelBench> benchmark(String modelId) async =>
-      _pending('ModelPort', _issue);
+      _pending('ModelPort', _runtimeIssue);
 
   @override
-  Stream<ThermalState> thermal() => _pendingStream('ModelPort', _issue);
+  Stream<ThermalState> thermal() => _pendingStream('ModelPort', _runtimeIssue);
 }
 
 class _RustPortability implements PortabilityPort {

--- a/packages/feature_mind/test/models/download_model_provider_test.dart
+++ b/packages/feature_mind/test/models/download_model_provider_test.dart
@@ -73,6 +73,12 @@ void main() {
   setUp(() {
     downloads = FakeBackgroundDownloads();
     storage = MockModelStorageManager();
+    when(
+      () => storage.enforceStorageQuota(
+        maxTotalBytes: any(named: 'maxTotalBytes'),
+        protectedModelIds: any(named: 'protectedModelIds'),
+      ),
+    ).thenAnswer((_) async => <String>[]);
     service = ModelDownloadService(
       downloads: downloads,
       storageManager: storage,

--- a/packages/feature_mind/test/runtime/rust_mind_runtime_test.dart
+++ b/packages/feature_mind/test/runtime/rust_mind_runtime_test.dart
@@ -1,7 +1,14 @@
+import 'dart:io';
+
+import 'package:core_ai/core_ai.dart' as core_ai;
 import 'package:feature_mind/feature_mind.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:path/path.dart' as path;
 
 void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
   late RustMindRuntime runtime;
 
   setUp(() => runtime = RustMindRuntime());
@@ -68,7 +75,11 @@ void main() {
         const PairingRequest(deviceName: 'x', code: '000000', requestedAtMs: 0),
       ),
       'capabilities': runtime.capabilities.installed(),
-      'models': runtime.models.all(),
+      // load/unload/benchmark/thermal, not all/storage/download: those three
+      // are real now (#1630) -- see the dedicated group below. load/unload/
+      // benchmark/thermal still need the Rust inference engine (#1628,
+      // #1638), so they are the honest "still unavailable" probe for models.
+      'models': runtime.models.load('whatever-model-id'),
       'portability': runtime.portability.plan(const []),
     };
 
@@ -81,5 +92,107 @@ void main() {
         reason: '${entry.key} resolved instead of reporting unavailable.',
       );
     }
+  });
+
+  test('models.unload/benchmark/thermal still report unavailable', () async {
+    await expectLater(
+      runtime.models.unload('whatever-model-id'),
+      throwsA(isA<MindPortUnavailable>()),
+    );
+    await expectLater(
+      runtime.models.benchmark('whatever-model-id'),
+      throwsA(isA<MindPortUnavailable>()),
+    );
+    await expectLater(
+      runtime.models.thermal(),
+      emitsError(isA<MindPortUnavailable>()),
+    );
+  });
+
+  group('models.all/storage/download are real, not stubs (#1630)', () {
+    late Directory tempDir;
+
+    setUp(() async {
+      tempDir = await Directory.systemTemp.createTemp('rust_models_test');
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(
+            const MethodChannel('plugins.flutter.io/path_provider'),
+            (MethodCall methodCall) async {
+              if (methodCall.method == 'getApplicationDocumentsDirectory') {
+                return tempDir.path;
+              }
+              return null;
+            },
+          );
+    });
+
+    tearDown(() async {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(
+            const MethodChannel('plugins.flutter.io/path_provider'),
+            null,
+          );
+      if (await tempDir.exists()) {
+        await tempDir.delete(recursive: true);
+      }
+    });
+
+    test('all() reports the default catalog, nothing on disk yet', () async {
+      final models = await runtime.models.all();
+
+      expect(models, isNotEmpty);
+      expect(models.length, core_ai.ModelCatalog.bundledModels.length);
+      expect(
+        models.every((m) => m.residency == ModelResidency.available),
+        isTrue,
+      );
+    });
+
+    test('a model downloaded to disk reports as resident', () async {
+      // The smallest catalog entry: writing a file matching a multi-GB
+      // model's fileSizeBytes here would allocate gigabytes for no reason.
+      final catalogModel = core_ai.ModelCatalog.bundledModels.firstWhere(
+        (m) => m.id == 'embeddinggemma-300m-tokenizer',
+      );
+      final modelsDir = Directory(path.join(tempDir.path, 'models'));
+      await modelsDir.create(recursive: true);
+      await File(
+        path.join(modelsDir.path, '${catalogModel.id}.gguf'),
+      ).writeAsBytes(List<int>.filled(catalogModel.fileSizeBytes, 0));
+
+      final models = await runtime.models.all();
+      final resident = models.firstWhere((m) => m.id == catalogModel.id);
+
+      expect(resident.residency, ModelResidency.resident);
+      expect(resident.heldBy, isEmpty);
+    });
+
+    test(
+      'storage() reports the real on-disk usage against the real quota',
+      () async {
+        final catalogModel = core_ai.ModelCatalog.bundledModels.first;
+        final modelsDir = Directory(path.join(tempDir.path, 'models'));
+        await modelsDir.create(recursive: true);
+        await File(
+          path.join(modelsDir.path, '${catalogModel.id}.gguf'),
+        ).writeAsBytes(List<int>.filled(1234, 0));
+
+        final storage = await runtime.models.storage();
+
+        expect(storage.usedBytes, 1234);
+        expect(
+          storage.budgetBytes,
+          core_ai.ModelStorageManager.defaultStorageBudgetBytes,
+        );
+      },
+    );
+
+    test('download() errors on the stream for an id absent from the '
+        'catalog, never at call time', () async {
+      await expectLater(
+        runtime.models.download('not-a-real-model-id'),
+        emitsError(isA<MindPortUnavailable>()),
+      );
+    });
   });
 }


### PR DESCRIPTION
## Summary

Wave-1 foundation work on the Mind model manager (#1630), following up on the Wave-0 audit posted to that issue. Closes #1718. Three of #1630's four gaps are fully closed; the fourth (ModelPort's `load`/`unload`/`benchmark`/`thermal`) is honestly partial -- see below.

### 1. Llama removal (closes #1718)

Removed `llama-3.2-1b-q4` and `llama-3.2-3b-q4` from `ModelCatalog.bundledModels` (`packages/core_ai/lib/src/registry/model_catalog.dart`). Llama 3.2's Community License terms don't fit an unconditional default registry the way Apache-2.0/MIT/Gemma-licensed entries do. No opt-in/advanced-config surface exists in this codebase to gate a licensed-but-not-default entry behind, and building one for two models with no other consumer was out of scope for this issue -- they're simply removed. A regression test locks this in (`ModelCatalog` contains no Llama-licensed model, and every bundled model carries a non-empty `license` string).

### 2. License metadata schema

Already present: `OfflineModelInfo.license` is a structured `String` field (not derived from filtering), populated for every bundled model -- Gemma variants (`Apache-2.0`/`Gemma`), Qwen (`Apache-2.0`), Phi-3 Mini (`MIT`), Mistral (`Apache-2.0`). Confirmed by a new regression test rather than assumed from the prior audit.

### 3. Disk-level eviction policy (real gap, now implemented)

`ModelStorageManager` (`packages/core_ai/lib/src/storage/model_storage_manager.dart`) gained:
- `installedArtifactsTotalBytes()` -- real on-disk usage, excluding in-flight `.tmp`/`.part` staging files.
- `enforceStorageQuota({maxTotalBytes, protectedModelIds})` -- deletes the oldest-installed artifacts (by file mtime, since `atime` is unreliable across platforms) until usage is at or under budget. Actual file + install-receipt deletion, not the RAM-residency-only eviction `ModelResidencyManager` already had (that class is untouched and still does its own job for in-memory budget).

`ModelDownloadService` now calls `enforceStorageQuota` before every new download starts (protecting the model about to be fetched), so the quota is a real ceiling instead of a number the UI merely displays. Default budget: `ModelStorageManager.defaultStorageBudgetBytes` = 8 GB, a heuristic pending a dedicated device-tier storage policy (#1631).

### 4. Real download path: checksum + atomic install

Verified, not assumed: `core_ai.ModelDownloadService` verifies SHA-256 (or size, when no hash is pinned) before writing an install receipt, and never marks a corrupt/partial file as installed. Both native download workers already promote the file atomically after integrity verification:
- Android (`ProgressiveDownloadWorker.kt`): `Files.move(partial, destination, StandardCopyOption.ATOMIC_MOVE, REPLACE_EXISTING)`.
- iOS (`PlatformDownloadsPlugin.swift`): `moveItem`/`replaceItemAt` after SHA-256 verification in native code.

No app-level changes were needed here -- this AC was already satisfied on the real (non-fixture) path, confirmed by reading the native implementations directly.

### 5. ModelPort / `_RustModels` production implementation (partial -- honest accounting)

`RustMindRuntime`'s `_RustModels` (`packages/feature_mind/lib/src/runtime/rust/rust_mind_runtime.dart`) was pure `_pending(...)` stubs for all seven `ModelPort` methods, all citing `#1260`. **`#1260` is actually "[MIND-33] Phase 2: FFI surface for Vault and Operation Log"** -- it never really gated model management; it's the generic issue every stub in this file happened to cite.

Now real:
- `all()` -- builds `MindModel`s from the real `ModelCatalog`, checking real on-disk presence via `ModelDownloadService.isModelDownloaded`.
- `storage()` -- real on-disk usage vs. the real enforced quota (item 3 above).
- `download()` -- delegates to the same proven `ModelDownloadService` pipeline `DownloadModelProvider` already uses for Mind's whisper models: resumable, checksum-verified, atomically installed. Errors on the stream (not at call time) for an id absent from the catalog.

`ModelManagementPanel` no longer needs `FixtureMindRuntime` to exercise real download/quota/eviction behavior against an actual device.

**Still stubs, and why:** `load`, `unload`, `benchmark`, and `thermal` all require a model resident in real inference memory. That needs the Rust engine bindings tracked by **#1628** (`LlmBackend` trait + llama.cpp GGUF backend in Rust core) and **#1638** (the Flutter plugin seam over that FFI) -- neither has landed yet (confirmed: no wired inference runtime exists in this repo today). Fully implementing these four methods is a separate, larger effort gated on that Rust work landing first, not something #1630 can reasonably absorb. The stub messages now cite #1628/#1638 instead of the inaccurate #1260.

`MindModel.residency` has three states (`loaded`/`resident`/`available`); without a wired inference engine or a working `CapabilityPort` (#1222, also stubbed) to say which capability holds a model resident, a downloaded model now reports `resident` with an empty `heldBy` -- the honest two-state story disk access alone can tell. This doesn't regress the UI: `ModelManagementPanel` already guards `heldBy.isNotEmpty` before showing a "held by" line.

## Test plan

- [x] `packages/core_ai`: `flutter test test/storage test/registry test/download` -- new eviction/quota/license tests pass, all pre-existing tests still pass.
- [x] `packages/feature_mind`: `flutter test test/runtime/rust_mind_runtime_test.dart test/models/` -- new real all()/storage()/download() tests pass; `load`/`unload`/`benchmark`/`thermal` still assert `MindPortUnavailable`.
- [x] `cd app && flutter analyze lib` -- clean.
- [x] `cd packages/core_ai && flutter analyze lib` / `cd packages/feature_mind && flutter analyze lib test` -- clean (feature_mind required a `dart run build_runner build` first for stale generated `.freezed.dart` files -- a pre-existing local-codegen gap, not something this PR introduced).
- [x] `cd app && flutter build web --release` -- passes.
- [x] Confirmed via `git stash` that `feature_mind`'s `runtime_console_table_test.dart` (12 failing tests, a null-check bug in `_RuntimeConsoleRow`) fails identically on `main`, unrelated to and untouched by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)