### PR TITLE
feat(mind): GBNF grammar sampling, RuntimeStats, unload() for the llama engine

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -157,6 +157,7 @@ artifacts/release/
 # Airo Mind model weights — 74 MB+, fetched by the Model Manager, never committed
 rust/airo_mind_runtime/models/*.bin
 rust/airo_mind_runtime/models/*.gguf
+rust/airo_mind_llama/models/*.gguf
 
 # `airo_mind_whisper`'s offline integration tests (tests/speech_offline.rs)
 # look for a real GGML model here and skip gracefully when it is absent — a

--- a/packages/feature_mind/lib/src/bridges/mind_generation_bridge.dart
+++ b/packages/feature_mind/lib/src/bridges/mind_generation_bridge.dart
@@ -3,6 +3,29 @@ import 'package:flutter/foundation.dart';
 import '../library_loader.dart';
 import '../llama/api/minutes.dart' as llama;
 
+/// Timing and memory from the most recently completed [MindGenerationBridge.
+/// generate] call. All zero before anything has generated -- a state the
+/// caller can act on (nothing to show yet) rather than a lie about a
+/// generation that never happened.
+@immutable
+class GenerationStats {
+  const GenerationStats({
+    required this.prefillMs,
+    required this.prefillTokens,
+    required this.generationMs,
+    required this.generatedTokens,
+    required this.tokensPerSecond,
+    required this.peakRssBytes,
+  });
+
+  final int prefillMs;
+  final int prefillTokens;
+  final int generationMs;
+  final int generatedTokens;
+  final double tokensPerSecond;
+  final int peakRssBytes;
+}
+
 @immutable
 sealed class GenerationEvent {
   const GenerationEvent();
@@ -37,11 +60,22 @@ abstract interface class MindGenerationBridge {
     required int memoryBudgetMb,
   });
 
-  Stream<GenerationEvent> generate({required String transcript});
+  /// [grammar] is a GBNF grammar (start symbol `root`) constraining the
+  /// token stream, or `null` for the model's normal unconstrained output.
+  /// Plumbing only -- this bridge does not know or care what the grammar
+  /// encodes.
+  Stream<GenerationEvent> generate({required String transcript, String? grammar});
 
   /// What produced the last minutes, for [MindSpeechBridge.save] to record
   /// (`ADR-0018 §5`). Empty before anything has been generated.
   String modelId();
+
+  /// Timing and memory from the most recently completed [generate] call.
+  GenerationStats stats();
+
+  /// Releases the loaded generation model. Safe to call when nothing is
+  /// loaded.
+  void unload();
 
   void cancel();
 }
@@ -76,19 +110,41 @@ class RustMindGenerationBridge implements MindGenerationBridge {
   }
 
   @override
-  Stream<GenerationEvent> generate({required String transcript}) =>
-      llama.generateMinutes(transcript: transcript).map((event) {
-        return switch (event) {
-          llama.GenerationEvent_Generating(:final text) =>
-            GenerationEventGenerating(text),
-          llama.GenerationEvent_MinutesReady(:final text) =>
-            GenerationEventMinutesReady(text),
-          llama.GenerationEvent_Cancelled() => const GenerationEventCancelled(),
-        };
-      });
+  Stream<GenerationEvent> generate({
+    required String transcript,
+    String? grammar,
+  }) =>
+      llama
+          .generateMinutes(transcript: transcript, grammar: grammar)
+          .map((event) {
+            return switch (event) {
+              llama.GenerationEvent_Generating(:final text) =>
+                GenerationEventGenerating(text),
+              llama.GenerationEvent_MinutesReady(:final text) =>
+                GenerationEventMinutesReady(text),
+              llama.GenerationEvent_Cancelled() =>
+                const GenerationEventCancelled(),
+            };
+          });
 
   @override
   String modelId() => llama.generationModelId();
+
+  @override
+  GenerationStats stats() {
+    final s = llama.generationStats();
+    return GenerationStats(
+      prefillMs: s.prefillMs.toInt(),
+      prefillTokens: s.prefillTokens,
+      generationMs: s.generationMs.toInt(),
+      generatedTokens: s.generatedTokens,
+      tokensPerSecond: s.tokensPerSecond,
+      peakRssBytes: s.peakRssBytes.toInt(),
+    );
+  }
+
+  @override
+  void unload() => llama.unloadGeneration();
 
   @override
   void cancel() => llama.cancelGeneration();

--- a/packages/feature_mind/lib/src/llama/api/minutes.dart
+++ b/packages/feature_mind/lib/src/llama/api/minutes.dart
@@ -9,6 +9,7 @@ import 'package:freezed_annotation/freezed_annotation.dart' hide protected;
 part 'minutes.freezed.dart';
 
 // These functions are ignored because they are not marked as `pub`: `lock`, `minutes_prompt`
+// These function are ignored because they are on traits that is not defined in current crate (put an empty `#[frb]` on it to unignore): `from`
 
 /// Loads the generation model. Called on first use, not at startup: this
 /// library is large and only minutes need it.
@@ -28,12 +29,38 @@ String generationModelId() =>
     RustLib.instance.api.crateApiMinutesGenerationModelId();
 
 /// Transcript → minutes, streaming throughout.
-Stream<GenerationEvent> generateMinutes({required String transcript}) =>
-    RustLib.instance.api.crateApiMinutesGenerateMinutes(transcript: transcript);
+///
+/// `grammar` is a GBNF grammar (start symbol `root`) constraining the token
+/// stream to a caller-chosen shape, or `None` for the model's normal
+/// unconstrained Markdown output. It is plumbing, not policy: this function
+/// does not know or care what the grammar encodes -- turning "Meeting IR as
+/// JSON" into a concrete GBNF string is a capability decision for whichever
+/// caller passes one in, not something minutes.rs decides.
+Stream<GenerationEvent> generateMinutes({
+  required String transcript,
+  String? grammar,
+}) => RustLib.instance.api.crateApiMinutesGenerateMinutes(
+  transcript: transcript,
+  grammar: grammar,
+);
 
 /// Stops the in-flight generation at the next token.
 void cancelGeneration() =>
     RustLib.instance.api.crateApiMinutesCancelGeneration();
+
+/// Timing and memory from the most recently completed `generate_minutes`
+/// call. All zero before anything has generated, or if `initialize` was
+/// never called — a state the caller can act on rather than an error.
+GenerationStats generationStats() =>
+    RustLib.instance.api.crateApiMinutesGenerationStats();
+
+/// Releases the loaded generation model. Safe to call when nothing is
+/// loaded, and safe to call again after `initialize` reloads a model — this
+/// only clears the Supervisor's generation slot, not the speech one (there
+/// is none here) or the recorded `MODEL_ID`, so `generation_model_id`
+/// continues to describe whatever was last generated until something new is.
+void unloadGeneration() =>
+    RustLib.instance.api.crateApiMinutesUnloadGeneration();
 
 /// Where the models live and what the engine may spend.
 class GenerationConfig {
@@ -72,4 +99,48 @@ sealed class GenerationEvent with _$GenerationEvent {
 
   /// The user navigated away. Nothing was saved.
   const factory GenerationEvent.cancelled() = GenerationEvent_Cancelled;
+}
+
+/// `RuntimeStats`, crossing the FFI boundary. A separate wire type rather
+/// than deriving FRB bindings directly on `airo_mind_core::RuntimeStats`:
+/// that type lives in the domain-free runtime crate, and this crate's `api`
+/// module is the one place a Dart-shaped mirror of a core type is expected to
+/// live (same pattern `GenerationEvent` already follows for `GenerationChunk`).
+class GenerationStats {
+  final BigInt prefillMs;
+  final int prefillTokens;
+  final BigInt generationMs;
+  final int generatedTokens;
+  final double tokensPerSecond;
+  final BigInt peakRssBytes;
+
+  const GenerationStats({
+    required this.prefillMs,
+    required this.prefillTokens,
+    required this.generationMs,
+    required this.generatedTokens,
+    required this.tokensPerSecond,
+    required this.peakRssBytes,
+  });
+
+  @override
+  int get hashCode =>
+      prefillMs.hashCode ^
+      prefillTokens.hashCode ^
+      generationMs.hashCode ^
+      generatedTokens.hashCode ^
+      tokensPerSecond.hashCode ^
+      peakRssBytes.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is GenerationStats &&
+          runtimeType == other.runtimeType &&
+          prefillMs == other.prefillMs &&
+          prefillTokens == other.prefillTokens &&
+          generationMs == other.generationMs &&
+          generatedTokens == other.generatedTokens &&
+          tokensPerSecond == other.tokensPerSecond &&
+          peakRssBytes == other.peakRssBytes;
 }

--- a/packages/feature_mind/lib/src/llama/frb_generated.dart
+++ b/packages/feature_mind/lib/src/llama/frb_generated.dart
@@ -64,7 +64,7 @@ class RustLib extends BaseEntrypoint<RustLibApi, RustLibApiImpl, RustLibWire> {
   String get codegenVersion => '2.11.1';
 
   @override
-  int get rustContentHash => -650311619;
+  int get rustContentHash => -1593969673;
 
   static const kDefaultExternalLibraryLoaderConfig =
       ExternalLibraryLoaderConfig(
@@ -79,13 +79,18 @@ abstract class RustLibApi extends BaseApi {
 
   Stream<GenerationEvent> crateApiMinutesGenerateMinutes({
     required String transcript,
+    String? grammar,
   });
 
   String crateApiMinutesGenerationModelId();
 
+  GenerationStats crateApiMinutesGenerationStats();
+
   Future<void> crateApiMinutesInitialize({required GenerationConfig config});
 
   bool crateApiMinutesIsReady();
+
+  void crateApiMinutesUnloadGeneration();
 }
 
 class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
@@ -121,6 +126,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @override
   Stream<GenerationEvent> crateApiMinutesGenerateMinutes({
     required String transcript,
+    String? grammar,
   }) {
     final sink = RustStreamSink<GenerationEvent>();
     unawaited(
@@ -129,6 +135,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           callFfi: (port_) {
             final serializer = SseSerializer(generalizedFrbRustBinding);
             sse_encode_String(transcript, serializer);
+            sse_encode_opt_String(grammar, serializer);
             sse_encode_StreamSink_generation_event_Sse(sink, serializer);
             pdeCallFfi(
               generalizedFrbRustBinding,
@@ -142,7 +149,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             decodeErrorData: sse_decode_String,
           ),
           constMeta: kCrateApiMinutesGenerateMinutesConstMeta,
-          argValues: [transcript, sink],
+          argValues: [transcript, grammar, sink],
           apiImpl: this,
         ),
       ),
@@ -153,7 +160,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   TaskConstMeta get kCrateApiMinutesGenerateMinutesConstMeta =>
       const TaskConstMeta(
         debugName: "generate_minutes",
-        argNames: ["transcript", "sink"],
+        argNames: ["transcript", "grammar", "sink"],
       );
 
   @override
@@ -179,6 +186,28 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       const TaskConstMeta(debugName: "generation_model_id", argNames: []);
 
   @override
+  GenerationStats crateApiMinutesGenerationStats() {
+    return handler.executeSync(
+      SyncTask(
+        callFfi: () {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 4)!;
+        },
+        codec: SseCodec(
+          decodeSuccessData: sse_decode_generation_stats,
+          decodeErrorData: null,
+        ),
+        constMeta: kCrateApiMinutesGenerationStatsConstMeta,
+        argValues: [],
+        apiImpl: this,
+      ),
+    );
+  }
+
+  TaskConstMeta get kCrateApiMinutesGenerationStatsConstMeta =>
+      const TaskConstMeta(debugName: "generation_stats", argNames: []);
+
+  @override
   Future<void> crateApiMinutesInitialize({required GenerationConfig config}) {
     return handler.executeNormal(
       NormalTask(
@@ -188,7 +217,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 4,
+            funcId: 5,
             port: port_,
           );
         },
@@ -212,7 +241,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       SyncTask(
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 5)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 6)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_bool,
@@ -227,6 +256,28 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
 
   TaskConstMeta get kCrateApiMinutesIsReadyConstMeta =>
       const TaskConstMeta(debugName: "is_ready", argNames: []);
+
+  @override
+  void crateApiMinutesUnloadGeneration() {
+    return handler.executeSync(
+      SyncTask(
+        callFfi: () {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 7)!;
+        },
+        codec: SseCodec(
+          decodeSuccessData: sse_decode_unit,
+          decodeErrorData: null,
+        ),
+        constMeta: kCrateApiMinutesUnloadGenerationConstMeta,
+        argValues: [],
+        apiImpl: this,
+      ),
+    );
+  }
+
+  TaskConstMeta get kCrateApiMinutesUnloadGenerationConstMeta =>
+      const TaskConstMeta(debugName: "unload_generation", argNames: []);
 
   @protected
   AnyhowException dco_decode_AnyhowException(dynamic raw) {
@@ -261,6 +312,12 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  double dco_decode_f_64(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return raw as double;
+  }
+
+  @protected
   GenerationConfig dco_decode_generation_config(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     final arr = raw as List<dynamic>;
@@ -288,15 +345,43 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  GenerationStats dco_decode_generation_stats(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    final arr = raw as List<dynamic>;
+    if (arr.length != 6)
+      throw Exception('unexpected arr length: expect 6 but see ${arr.length}');
+    return GenerationStats(
+      prefillMs: dco_decode_u_64(arr[0]),
+      prefillTokens: dco_decode_u_32(arr[1]),
+      generationMs: dco_decode_u_64(arr[2]),
+      generatedTokens: dco_decode_u_32(arr[3]),
+      tokensPerSecond: dco_decode_f_64(arr[4]),
+      peakRssBytes: dco_decode_u_64(arr[5]),
+    );
+  }
+
+  @protected
   Uint8List dco_decode_list_prim_u_8_strict(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return raw as Uint8List;
   }
 
   @protected
+  String? dco_decode_opt_String(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return raw == null ? null : dco_decode_String(raw);
+  }
+
+  @protected
   int dco_decode_u_32(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return raw as int;
+  }
+
+  @protected
+  BigInt dco_decode_u_64(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return dcoDecodeU64(raw);
   }
 
   @protected
@@ -348,6 +433,12 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  double sse_decode_f_64(SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    return deserializer.buffer.getFloat64();
+  }
+
+  @protected
   GenerationConfig sse_decode_generation_config(SseDeserializer deserializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     var var_modelsDir = sse_decode_String(deserializer);
@@ -378,6 +469,25 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  GenerationStats sse_decode_generation_stats(SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    var var_prefillMs = sse_decode_u_64(deserializer);
+    var var_prefillTokens = sse_decode_u_32(deserializer);
+    var var_generationMs = sse_decode_u_64(deserializer);
+    var var_generatedTokens = sse_decode_u_32(deserializer);
+    var var_tokensPerSecond = sse_decode_f_64(deserializer);
+    var var_peakRssBytes = sse_decode_u_64(deserializer);
+    return GenerationStats(
+      prefillMs: var_prefillMs,
+      prefillTokens: var_prefillTokens,
+      generationMs: var_generationMs,
+      generatedTokens: var_generatedTokens,
+      tokensPerSecond: var_tokensPerSecond,
+      peakRssBytes: var_peakRssBytes,
+    );
+  }
+
+  @protected
   Uint8List sse_decode_list_prim_u_8_strict(SseDeserializer deserializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     var len_ = sse_decode_i_32(deserializer);
@@ -385,9 +495,26 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  String? sse_decode_opt_String(SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+
+    if (sse_decode_bool(deserializer)) {
+      return (sse_decode_String(deserializer));
+    } else {
+      return null;
+    }
+  }
+
+  @protected
   int sse_decode_u_32(SseDeserializer deserializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     return deserializer.buffer.getUint32();
+  }
+
+  @protected
+  BigInt sse_decode_u_64(SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    return deserializer.buffer.getBigUint64();
   }
 
   @protected
@@ -455,6 +582,12 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  void sse_encode_f_64(double self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    serializer.buffer.putFloat64(self);
+  }
+
+  @protected
   void sse_encode_generation_config(
     GenerationConfig self,
     SseSerializer serializer,
@@ -483,6 +616,20 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  void sse_encode_generation_stats(
+    GenerationStats self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_u_64(self.prefillMs, serializer);
+    sse_encode_u_32(self.prefillTokens, serializer);
+    sse_encode_u_64(self.generationMs, serializer);
+    sse_encode_u_32(self.generatedTokens, serializer);
+    sse_encode_f_64(self.tokensPerSecond, serializer);
+    sse_encode_u_64(self.peakRssBytes, serializer);
+  }
+
+  @protected
   void sse_encode_list_prim_u_8_strict(
     Uint8List self,
     SseSerializer serializer,
@@ -493,9 +640,25 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  void sse_encode_opt_String(String? self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+
+    sse_encode_bool(self != null, serializer);
+    if (self != null) {
+      sse_encode_String(self, serializer);
+    }
+  }
+
+  @protected
   void sse_encode_u_32(int self, SseSerializer serializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     serializer.buffer.putUint32(self);
+  }
+
+  @protected
+  void sse_encode_u_64(BigInt self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    serializer.buffer.putBigUint64(self);
   }
 
   @protected

--- a/packages/feature_mind/lib/src/llama/frb_generated.io.dart
+++ b/packages/feature_mind/lib/src/llama/frb_generated.io.dart
@@ -36,16 +36,28 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   GenerationConfig dco_decode_box_autoadd_generation_config(dynamic raw);
 
   @protected
+  double dco_decode_f_64(dynamic raw);
+
+  @protected
   GenerationConfig dco_decode_generation_config(dynamic raw);
 
   @protected
   GenerationEvent dco_decode_generation_event(dynamic raw);
 
   @protected
+  GenerationStats dco_decode_generation_stats(dynamic raw);
+
+  @protected
   Uint8List dco_decode_list_prim_u_8_strict(dynamic raw);
 
   @protected
+  String? dco_decode_opt_String(dynamic raw);
+
+  @protected
   int dco_decode_u_32(dynamic raw);
+
+  @protected
+  BigInt dco_decode_u_64(dynamic raw);
 
   @protected
   int dco_decode_u_8(dynamic raw);
@@ -73,16 +85,28 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  double sse_decode_f_64(SseDeserializer deserializer);
+
+  @protected
   GenerationConfig sse_decode_generation_config(SseDeserializer deserializer);
 
   @protected
   GenerationEvent sse_decode_generation_event(SseDeserializer deserializer);
 
   @protected
+  GenerationStats sse_decode_generation_stats(SseDeserializer deserializer);
+
+  @protected
   Uint8List sse_decode_list_prim_u_8_strict(SseDeserializer deserializer);
 
   @protected
+  String? sse_decode_opt_String(SseDeserializer deserializer);
+
+  @protected
   int sse_decode_u_32(SseDeserializer deserializer);
+
+  @protected
+  BigInt sse_decode_u_64(SseDeserializer deserializer);
 
   @protected
   int sse_decode_u_8(SseDeserializer deserializer);
@@ -118,6 +142,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  void sse_encode_f_64(double self, SseSerializer serializer);
+
+  @protected
   void sse_encode_generation_config(
     GenerationConfig self,
     SseSerializer serializer,
@@ -130,13 +157,25 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  void sse_encode_generation_stats(
+    GenerationStats self,
+    SseSerializer serializer,
+  );
+
+  @protected
   void sse_encode_list_prim_u_8_strict(
     Uint8List self,
     SseSerializer serializer,
   );
 
   @protected
+  void sse_encode_opt_String(String? self, SseSerializer serializer);
+
+  @protected
   void sse_encode_u_32(int self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_u_64(BigInt self, SseSerializer serializer);
 
   @protected
   void sse_encode_u_8(int self, SseSerializer serializer);

--- a/packages/feature_mind/lib/src/llama/frb_generated.web.dart
+++ b/packages/feature_mind/lib/src/llama/frb_generated.web.dart
@@ -38,16 +38,28 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   GenerationConfig dco_decode_box_autoadd_generation_config(dynamic raw);
 
   @protected
+  double dco_decode_f_64(dynamic raw);
+
+  @protected
   GenerationConfig dco_decode_generation_config(dynamic raw);
 
   @protected
   GenerationEvent dco_decode_generation_event(dynamic raw);
 
   @protected
+  GenerationStats dco_decode_generation_stats(dynamic raw);
+
+  @protected
   Uint8List dco_decode_list_prim_u_8_strict(dynamic raw);
 
   @protected
+  String? dco_decode_opt_String(dynamic raw);
+
+  @protected
   int dco_decode_u_32(dynamic raw);
+
+  @protected
+  BigInt dco_decode_u_64(dynamic raw);
 
   @protected
   int dco_decode_u_8(dynamic raw);
@@ -75,16 +87,28 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  double sse_decode_f_64(SseDeserializer deserializer);
+
+  @protected
   GenerationConfig sse_decode_generation_config(SseDeserializer deserializer);
 
   @protected
   GenerationEvent sse_decode_generation_event(SseDeserializer deserializer);
 
   @protected
+  GenerationStats sse_decode_generation_stats(SseDeserializer deserializer);
+
+  @protected
   Uint8List sse_decode_list_prim_u_8_strict(SseDeserializer deserializer);
 
   @protected
+  String? sse_decode_opt_String(SseDeserializer deserializer);
+
+  @protected
   int sse_decode_u_32(SseDeserializer deserializer);
+
+  @protected
+  BigInt sse_decode_u_64(SseDeserializer deserializer);
 
   @protected
   int sse_decode_u_8(SseDeserializer deserializer);
@@ -120,6 +144,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  void sse_encode_f_64(double self, SseSerializer serializer);
+
+  @protected
   void sse_encode_generation_config(
     GenerationConfig self,
     SseSerializer serializer,
@@ -132,13 +159,25 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  void sse_encode_generation_stats(
+    GenerationStats self,
+    SseSerializer serializer,
+  );
+
+  @protected
   void sse_encode_list_prim_u_8_strict(
     Uint8List self,
     SseSerializer serializer,
   );
 
   @protected
+  void sse_encode_opt_String(String? self, SseSerializer serializer);
+
+  @protected
   void sse_encode_u_32(int self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_u_64(BigInt self, SseSerializer serializer);
 
   @protected
   void sse_encode_u_8(int self, SseSerializer serializer);

--- a/packages/feature_mind/test/support/fake_bridges.dart
+++ b/packages/feature_mind/test/support/fake_bridges.dart
@@ -86,8 +86,18 @@ class FakeMindSpeechBridge implements MindSpeechBridge {
 class FakeMindGenerationBridge implements MindGenerationBridge {
   List<GenerationEvent> generationEvents = const [];
   String modelIdValue = 'test-model@1';
+  GenerationStats statsValue = const GenerationStats(
+    prefillMs: 0,
+    prefillTokens: 0,
+    generationMs: 0,
+    generatedTokens: 0,
+    tokensPerSecond: 0,
+    peakRssBytes: 0,
+  );
   var ensureLoadedCalls = 0;
   var cancelCalls = 0;
+  var unloadCalls = 0;
+  String? lastGrammar;
   var _loaded = false;
 
   @override
@@ -103,11 +113,25 @@ class FakeMindGenerationBridge implements MindGenerationBridge {
   }
 
   @override
-  Stream<GenerationEvent> generate({required String transcript}) =>
-      Stream.fromIterable(generationEvents);
+  Stream<GenerationEvent> generate({
+    required String transcript,
+    String? grammar,
+  }) {
+    lastGrammar = grammar;
+    return Stream.fromIterable(generationEvents);
+  }
 
   @override
   String modelId() => modelIdValue;
+
+  @override
+  GenerationStats stats() => statsValue;
+
+  @override
+  void unload() {
+    unloadCalls++;
+    _loaded = false;
+  }
 
   @override
   void cancel() => cancelCalls++;

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -65,6 +65,7 @@ dependencies = [
  "airo_mind_core",
  "encoding_rs",
  "flutter_rust_bridge",
+ "libc",
  "llama-cpp-2",
 ]
 

--- a/rust/airo_mind_core/src/engine.rs
+++ b/rust/airo_mind_core/src/engine.rs
@@ -63,12 +63,48 @@ pub struct TranscriptSegment {
 pub struct GenerationRequest {
     pub prompt: String,
     pub max_output_tokens: u32,
+    /// A GBNF grammar constraining the token stream, or `None` for
+    /// unconstrained (greedy) sampling. The grammar's start symbol must be a
+    /// rule named `root` — that is the convention every caller of this field
+    /// is expected to follow, and the one the engine assumes when building
+    /// the constrained sampler.
+    ///
+    /// The runtime knows no domains (`C5`): this carries a grammar TEXT, not
+    /// a schema or a capability name. Turning "Meeting IR as JSON" into a
+    /// GBNF string is the capability's job, not this crate's.
+    pub grammar: Option<String>,
 }
 
 /// One piece of generated output.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct GenerationChunk {
     pub text: String,
+}
+
+/// Timing and memory measurements from the most recently completed
+/// generation. Zeroed before anything has run — that is a state callers can
+/// act on (nothing to show yet), not a lie about a generation that never
+/// happened.
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+pub struct RuntimeStats {
+    /// Wall-clock time to decode the prompt (prefill), before the first
+    /// output token.
+    pub prefill_ms: u64,
+    /// Tokens the prompt tokenised to.
+    pub prefill_tokens: u32,
+    /// Wall-clock time spent producing output tokens, excluding prefill.
+    pub generation_ms: u64,
+    /// Output tokens produced.
+    pub generated_tokens: u32,
+    /// `generated_tokens / (generation_ms / 1000)`. `0.0` when nothing has
+    /// been generated yet or generation completed in under a millisecond.
+    pub tokens_per_second: f64,
+    /// Peak resident set size of the whole process, in bytes, sampled at the
+    /// end of the generation call. Process-wide, not model-only — no API in
+    /// the platforms this targets (`getrusage`, `/proc/self/status`) reports
+    /// per-allocation attribution, and a whole-process reading is still the
+    /// number that determines whether the device survives the call.
+    pub peak_rss_bytes: u64,
 }
 
 /// Audio to transcript.
@@ -99,4 +135,16 @@ pub trait GenerationEngine: Send + Sync {
         cancel: &CancelToken,
         sink: &mut dyn FnMut(GenerationChunk) -> Result<(), EngineError>,
     ) -> Result<(), EngineError>;
+
+    /// Measurements from the most recently completed `generate` call.
+    /// `RuntimeStats::default()` before anything has run.
+    ///
+    /// Widening the trait rather than bolting this onto `LlamaGenerationEngine`
+    /// alone: `Supervisor` holds `Box<dyn GenerationEngine>`, and a stats
+    /// surface reachable only on the concrete type would be unreachable
+    /// through the one handle the Dart bridge actually has. The cost is that
+    /// every implementor (today: `LlamaGenerationEngine` and the test fixture
+    /// in `supervisor.rs`) must answer this — `RuntimeStats::default()` is a
+    /// legitimate answer for one that does not measure itself.
+    fn stats(&self) -> RuntimeStats;
 }

--- a/rust/airo_mind_core/src/lib.rs
+++ b/rust/airo_mind_core/src/lib.rs
@@ -65,8 +65,8 @@ pub use budget::{ResourceBudget, ResourceRequest};
 pub use cancel::CancelToken;
 pub use digest::file_digest;
 pub use engine::{
-    AudioInput, EngineError, GenerationChunk, GenerationEngine, GenerationRequest, SpeechEngine,
-    TranscriptSegment,
+    AudioInput, EngineError, GenerationChunk, GenerationEngine, GenerationRequest, RuntimeStats,
+    SpeechEngine, TranscriptSegment,
 };
 pub use search::{Hit, SearchIndex};
 pub use store::{Meeting, MeetingStore, StoreError};

--- a/rust/airo_mind_core/src/supervisor.rs
+++ b/rust/airo_mind_core/src/supervisor.rs
@@ -9,8 +9,8 @@
 use crate::budget::ResourceBudget;
 use crate::cancel::CancelToken;
 use crate::engine::{
-    AudioInput, EngineError, GenerationChunk, GenerationEngine, GenerationRequest, SpeechEngine,
-    TranscriptSegment,
+    AudioInput, EngineError, GenerationChunk, GenerationEngine, GenerationRequest, RuntimeStats,
+    SpeechEngine, TranscriptSegment,
 };
 
 /// Why the Supervisor refused or stopped a job.
@@ -74,6 +74,22 @@ impl Supervisor {
 
     pub fn register_generation(&mut self, engine: Box<dyn GenerationEngine>) {
         self.generation = Some(engine);
+    }
+
+    /// Drops the registered generation engine, releasing whatever memory it
+    /// holds. There is no separate "unload" verb on the Supervisor: the
+    /// engine's own `Drop` (and, on `LlamaGenerationEngine`, its explicit
+    /// `unload`) does the real free either way, and a `Box<dyn _>` cannot be
+    /// asked to unload itself through the trait without widening
+    /// `GenerationEngine` for every implementor just to serve one caller.
+    pub fn unregister_generation(&mut self) {
+        self.generation = None;
+    }
+
+    /// Stats from the registered generation engine's most recent `generate`
+    /// call, or `None` if no generation engine is registered.
+    pub fn generation_stats(&self) -> Option<RuntimeStats> {
+        self.generation.as_ref().map(|e| e.stats())
     }
 
     pub fn budget(&self) -> ResourceBudget {
@@ -193,6 +209,12 @@ mod tests {
             }
             Ok(())
         }
+
+        fn stats(&self) -> RuntimeStats {
+            // Deterministic and cheap to construct is the point of a fake --
+            // this fixture does not measure anything real.
+            RuntimeStats::default()
+        }
     }
 
     fn audio() -> [i16; 4] {
@@ -243,6 +265,7 @@ mod tests {
             &GenerationRequest {
                 prompt: "agenda decisions actions owners".into(),
                 max_output_tokens: 256,
+                grammar: None,
             },
             &CancelToken::new(),
             &mut |chunk| {
@@ -362,5 +385,40 @@ mod tests {
             Err(RuntimeError::Engine(EngineError::Backend(_)))
         ));
         assert_eq!(seen, 1, "the engine must stop on the first refusal");
+    }
+
+    #[test]
+    fn generation_stats_is_reachable_through_the_supervisor_and_none_when_unregistered() {
+        let mut s = Supervisor::new(ResourceBudget::new(2048));
+        assert_eq!(
+            s.generation_stats(),
+            None,
+            "nothing registered yet -- there is nothing to report"
+        );
+
+        s.register_generation(Box::new(FakeGeneration { memory_mb: 512 }));
+        assert_eq!(
+            s.generation_stats(),
+            Some(RuntimeStats::default()),
+            "the fake does not measure itself, so its answer is the zero value"
+        );
+    }
+
+    #[test]
+    fn unregister_generation_drops_the_engine_and_the_next_run_is_refused() {
+        let mut s = supervisor(2048, 512);
+        s.unregister_generation();
+
+        let r = s.run_generation(
+            &GenerationRequest {
+                prompt: "anything".into(),
+                max_output_tokens: 8,
+                grammar: None,
+            },
+            &CancelToken::new(),
+            &mut |_| Ok(()),
+        );
+        assert_eq!(r, Err(RuntimeError::NoEngine("generation")));
+        assert_eq!(s.generation_stats(), None);
     }
 }

--- a/rust/airo_mind_llama/Cargo.toml
+++ b/rust/airo_mind_llama/Cargo.toml
@@ -18,18 +18,33 @@ airo_mind_core = { path = "../airo_mind_core" }
 flutter_rust_bridge = "=2.11.1"
 # `default-features = false` is a CORRECTNESS setting, not a size one.
 #
-# llama-cpp-2's default features include `common`, which compiles llama.cpp's
-# `download.cpp` and `hf-cache.cpp` -- a HuggingFace HTTP client -- into the
-# binary. `ADR-0018 §1` says the runtime never acquires models, and "cloud
-# optional, never cloud required" is not a claim a binary carrying a model
-# downloader can make. It also does not link: httplib is not in the archive,
-# so the offline product and the building product happen to be the same one.
+# llama-cpp-2's default features include `openmp` and `android-shared-stdcxx`,
+# neither of which this crate wants: `openmp` costs nothing to drop because the
+# Supervisor owns the CPU budget (`C6`) and the engine is pinned to one thread,
+# and the Android stdc++ linkage is a per-target concern this Cargo.toml does
+# not decide unilaterally.
 #
-# Dropping the default `openmp` costs nothing here: the Supervisor owns the CPU
-# budget (`C6`) and the engine is pinned to one thread.
+# `common` is re-enabled explicitly below, in the `llama` feature union, purely
+# for `LlamaSampler::grammar` -- the GBNF-constrained sampler -- which llama-cpp-2
+# 0.1.153 only exposes behind it (the vocab pointer a manual FFI call would need
+# is `pub(crate)` inside llama-cpp-2 itself; there is no way to call the
+# grammar-init C API from outside the crate without this feature). Enabling
+# `common` DOES compile `download.cpp` and `hf-cache.cpp` into the binary --
+# they are unconditional sources in llama.cpp's own `common/CMakeLists.txt`,
+# not gated on curl -- but `llama-cpp-sys-2`'s build.rs sets `LLAMA_CURL=OFF`
+# unconditionally regardless of this feature (verified in its `build.rs`), so
+# no HTTP client is linked and no network capability is compiled in. `ADR-0018
+# §1`'s "cloud optional, never cloud required" claim survives: the extra
+# source is dead code with no way to reach the network, not a live downloader.
+# Flagged here because it is a real, if inert, growth in what's linked -- worth
+# knowing about at the next binary-size review.
 llama-cpp-2 = { version = "0.1.153", optional = true, default-features = false }
 # Re-exported by llama-cpp-2 for token_to_piece; pinned to the version it uses.
 encoding_rs = { version = "0.8", optional = true }
+# RuntimeStats' peak-RSS reading (`getrusage` on macOS/iOS/Linux/Android).
+# Already a workspace dependency (`airo_core`), so this adds no new crate to
+# the lockfile, only a new consumer of one already vetted and pinned.
+libc = { version = "0.2", optional = true }
 
 # Metal acceleration, macOS only.
 #
@@ -58,7 +73,7 @@ llama-cpp-2 = { version = "0.1.153", optional = true, default-features = false, 
 [features]
 default = []
 # Real offline generation. Requires cmake and a C++ toolchain.
-llama = ["dep:llama-cpp-2", "dep:encoding_rs"]
+llama = ["dep:llama-cpp-2", "dep:encoding_rs", "dep:libc", "llama-cpp-2/common"]
 # Documents the macOS Metal contract explicitly (see the target-specific
 # dependency table above); does not change what gets linked on macOS, since
 # Metal is already unified in automatically for `cfg(target_os = "macos")`

--- a/rust/airo_mind_llama/src/api/minutes.rs
+++ b/rust/airo_mind_llama/src/api/minutes.rs
@@ -24,7 +24,7 @@ use crate::frb_generated::StreamSink;
 
 use crate::LlamaGenerationEngine;
 use airo_mind_core::models;
-use airo_mind_core::{CancelToken, GenerationRequest, ResourceBudget, Supervisor};
+use airo_mind_core::{CancelToken, GenerationRequest, ResourceBudget, RuntimeStats, Supervisor};
 
 // ---------------------------------------------------------------------------
 // Wire types
@@ -49,6 +49,33 @@ pub enum GenerationEvent {
     },
     /// The user navigated away. Nothing was saved.
     Cancelled,
+}
+
+/// `RuntimeStats`, crossing the FFI boundary. A separate wire type rather
+/// than deriving FRB bindings directly on `airo_mind_core::RuntimeStats`:
+/// that type lives in the domain-free runtime crate, and this crate's `api`
+/// module is the one place a Dart-shaped mirror of a core type is expected to
+/// live (same pattern `GenerationEvent` already follows for `GenerationChunk`).
+pub struct GenerationStats {
+    pub prefill_ms: u64,
+    pub prefill_tokens: u32,
+    pub generation_ms: u64,
+    pub generated_tokens: u32,
+    pub tokens_per_second: f64,
+    pub peak_rss_bytes: u64,
+}
+
+impl From<RuntimeStats> for GenerationStats {
+    fn from(s: RuntimeStats) -> Self {
+        Self {
+            prefill_ms: s.prefill_ms,
+            prefill_tokens: s.prefill_tokens,
+            generation_ms: s.generation_ms,
+            generated_tokens: s.generated_tokens,
+            tokens_per_second: s.tokens_per_second,
+            peak_rss_bytes: s.peak_rss_bytes,
+        }
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -143,8 +170,16 @@ pub fn generation_model_id() -> String {
 }
 
 /// Transcript → minutes, streaming throughout.
+///
+/// `grammar` is a GBNF grammar (start symbol `root`) constraining the token
+/// stream to a caller-chosen shape, or `None` for the model's normal
+/// unconstrained Markdown output. It is plumbing, not policy: this function
+/// does not know or care what the grammar encodes -- turning "Meeting IR as
+/// JSON" into a concrete GBNF string is a capability decision for whichever
+/// caller passes one in, not something minutes.rs decides.
 pub fn generate_minutes(
     transcript: String,
+    grammar: Option<String>,
     sink: StreamSink<GenerationEvent>,
 ) -> Result<(), String> {
     let emit = |event: GenerationEvent| -> Result<(), String> {
@@ -163,6 +198,7 @@ pub fn generate_minutes(
             &GenerationRequest {
                 prompt: minutes_prompt(&transcript),
                 max_output_tokens: 320,
+                grammar,
             },
             &cancel,
             &mut |chunk| {
@@ -188,6 +224,30 @@ pub fn generate_minutes(
 pub fn cancel_generation() {
     if let Some(token) = lock(&CANCEL).as_ref() {
         token.cancel();
+    }
+}
+
+/// Timing and memory from the most recently completed `generate_minutes`
+/// call. All zero before anything has generated, or if `initialize` was
+/// never called — a state the caller can act on rather than an error.
+#[frb(sync)]
+pub fn generation_stats() -> GenerationStats {
+    lock(&ENGINE)
+        .as_ref()
+        .and_then(Supervisor::generation_stats)
+        .unwrap_or_default()
+        .into()
+}
+
+/// Releases the loaded generation model. Safe to call when nothing is
+/// loaded, and safe to call again after `initialize` reloads a model — this
+/// only clears the Supervisor's generation slot, not the speech one (there
+/// is none here) or the recorded `MODEL_ID`, so `generation_model_id`
+/// continues to describe whatever was last generated until something new is.
+#[frb(sync)]
+pub fn unload_generation() {
+    if let Some(supervisor) = lock(&ENGINE).as_mut() {
+        supervisor.unregister_generation();
     }
 }
 

--- a/rust/airo_mind_llama/src/frb_generated.rs
+++ b/rust/airo_mind_llama/src/frb_generated.rs
@@ -37,7 +37,7 @@ flutter_rust_bridge::frb_generated_boilerplate!(
     default_rust_auto_opaque = RustAutoOpaqueMoi,
 );
 pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_VERSION: &str = "2.11.1";
-pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = -650311619;
+pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = -1593969673;
 
 // Section: executor
 
@@ -99,6 +99,7 @@ fn wire__crate__api__minutes__generate_minutes_impl(
             let mut deserializer =
                 flutter_rust_bridge::for_generated::SseDeserializer::new(message);
             let api_transcript = <String>::sse_decode(&mut deserializer);
+            let api_grammar = <Option<String>>::sse_decode(&mut deserializer);
             let api_sink = <StreamSink<
                 crate::api::minutes::GenerationEvent,
                 flutter_rust_bridge::for_generated::SseCodec,
@@ -106,8 +107,11 @@ fn wire__crate__api__minutes__generate_minutes_impl(
             deserializer.end();
             move |context| {
                 transform_result_sse::<_, String>((move || {
-                    let output_ok =
-                        crate::api::minutes::generate_minutes(api_transcript, api_sink)?;
+                    let output_ok = crate::api::minutes::generate_minutes(
+                        api_transcript,
+                        api_grammar,
+                        api_sink,
+                    )?;
                     Ok(output_ok)
                 })())
             }
@@ -138,6 +142,35 @@ fn wire__crate__api__minutes__generation_model_id_impl(
             deserializer.end();
             transform_result_sse::<_, ()>((move || {
                 let output_ok = Result::<_, ()>::Ok(crate::api::minutes::generation_model_id())?;
+                Ok(output_ok)
+            })())
+        },
+    )
+}
+fn wire__crate__api__minutes__generation_stats_impl(
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) -> flutter_rust_bridge::for_generated::WireSyncRust2DartSse {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_sync::<flutter_rust_bridge::for_generated::SseCodec, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "generation_stats",
+            port: None,
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Sync,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            deserializer.end();
+            transform_result_sse::<_, ()>((move || {
+                let output_ok = Result::<_, ()>::Ok(crate::api::minutes::generation_stats())?;
                 Ok(output_ok)
             })())
         },
@@ -205,6 +238,37 @@ fn wire__crate__api__minutes__is_ready_impl(
         },
     )
 }
+fn wire__crate__api__minutes__unload_generation_impl(
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) -> flutter_rust_bridge::for_generated::WireSyncRust2DartSse {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_sync::<flutter_rust_bridge::for_generated::SseCodec, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "unload_generation",
+            port: None,
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Sync,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            deserializer.end();
+            transform_result_sse::<_, ()>((move || {
+                let output_ok = Result::<_, ()>::Ok({
+                    crate::api::minutes::unload_generation();
+                })?;
+                Ok(output_ok)
+            })())
+        },
+    )
+}
 
 // Section: dart2rust
 
@@ -244,6 +308,13 @@ impl SseDecode for bool {
     }
 }
 
+impl SseDecode for f64 {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        deserializer.cursor.read_f64::<NativeEndian>().unwrap()
+    }
+}
+
 impl SseDecode for crate::api::minutes::GenerationConfig {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
@@ -279,6 +350,26 @@ impl SseDecode for crate::api::minutes::GenerationEvent {
     }
 }
 
+impl SseDecode for crate::api::minutes::GenerationStats {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut var_prefillMs = <u64>::sse_decode(deserializer);
+        let mut var_prefillTokens = <u32>::sse_decode(deserializer);
+        let mut var_generationMs = <u64>::sse_decode(deserializer);
+        let mut var_generatedTokens = <u32>::sse_decode(deserializer);
+        let mut var_tokensPerSecond = <f64>::sse_decode(deserializer);
+        let mut var_peakRssBytes = <u64>::sse_decode(deserializer);
+        return crate::api::minutes::GenerationStats {
+            prefill_ms: var_prefillMs,
+            prefill_tokens: var_prefillTokens,
+            generation_ms: var_generationMs,
+            generated_tokens: var_generatedTokens,
+            tokens_per_second: var_tokensPerSecond,
+            peak_rss_bytes: var_peakRssBytes,
+        };
+    }
+}
+
 impl SseDecode for Vec<u8> {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
@@ -291,10 +382,28 @@ impl SseDecode for Vec<u8> {
     }
 }
 
+impl SseDecode for Option<String> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        if (<bool>::sse_decode(deserializer)) {
+            return Some(<String>::sse_decode(deserializer));
+        } else {
+            return None;
+        }
+    }
+}
+
 impl SseDecode for u32 {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
         deserializer.cursor.read_u32::<NativeEndian>().unwrap()
+    }
+}
+
+impl SseDecode for u64 {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        deserializer.cursor.read_u64::<NativeEndian>().unwrap()
     }
 }
 
@@ -327,7 +436,7 @@ fn pde_ffi_dispatcher_primary_impl(
     // Codec=Pde (Serialization + dispatch), see doc to use other codecs
     match func_id {
         2 => wire__crate__api__minutes__generate_minutes_impl(port, ptr, rust_vec_len, data_len),
-        4 => wire__crate__api__minutes__initialize_impl(port, ptr, rust_vec_len, data_len),
+        5 => wire__crate__api__minutes__initialize_impl(port, ptr, rust_vec_len, data_len),
         _ => unreachable!(),
     }
 }
@@ -342,7 +451,9 @@ fn pde_ffi_dispatcher_sync_impl(
     match func_id {
         1 => wire__crate__api__minutes__cancel_generation_impl(ptr, rust_vec_len, data_len),
         3 => wire__crate__api__minutes__generation_model_id_impl(ptr, rust_vec_len, data_len),
-        5 => wire__crate__api__minutes__is_ready_impl(ptr, rust_vec_len, data_len),
+        4 => wire__crate__api__minutes__generation_stats_impl(ptr, rust_vec_len, data_len),
+        6 => wire__crate__api__minutes__is_ready_impl(ptr, rust_vec_len, data_len),
+        7 => wire__crate__api__minutes__unload_generation_impl(ptr, rust_vec_len, data_len),
         _ => unreachable!(),
     }
 }
@@ -398,6 +509,31 @@ impl flutter_rust_bridge::IntoIntoDart<crate::api::minutes::GenerationEvent>
         self
     }
 }
+// Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for crate::api::minutes::GenerationStats {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        [
+            self.prefill_ms.into_into_dart().into_dart(),
+            self.prefill_tokens.into_into_dart().into_dart(),
+            self.generation_ms.into_into_dart().into_dart(),
+            self.generated_tokens.into_into_dart().into_dart(),
+            self.tokens_per_second.into_into_dart().into_dart(),
+            self.peak_rss_bytes.into_into_dart().into_dart(),
+        ]
+        .into_dart()
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
+    for crate::api::minutes::GenerationStats
+{
+}
+impl flutter_rust_bridge::IntoIntoDart<crate::api::minutes::GenerationStats>
+    for crate::api::minutes::GenerationStats
+{
+    fn into_into_dart(self) -> crate::api::minutes::GenerationStats {
+        self
+    }
+}
 
 impl SseEncode for flutter_rust_bridge::for_generated::anyhow::Error {
     // Codec=Sse (Serialization based), see doc to use other codecs
@@ -432,6 +568,13 @@ impl SseEncode for bool {
     }
 }
 
+impl SseEncode for f64 {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        serializer.cursor.write_f64::<NativeEndian>(self).unwrap();
+    }
+}
+
 impl SseEncode for crate::api::minutes::GenerationConfig {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
@@ -462,6 +605,18 @@ impl SseEncode for crate::api::minutes::GenerationEvent {
     }
 }
 
+impl SseEncode for crate::api::minutes::GenerationStats {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <u64>::sse_encode(self.prefill_ms, serializer);
+        <u32>::sse_encode(self.prefill_tokens, serializer);
+        <u64>::sse_encode(self.generation_ms, serializer);
+        <u32>::sse_encode(self.generated_tokens, serializer);
+        <f64>::sse_encode(self.tokens_per_second, serializer);
+        <u64>::sse_encode(self.peak_rss_bytes, serializer);
+    }
+}
+
 impl SseEncode for Vec<u8> {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
@@ -472,10 +627,27 @@ impl SseEncode for Vec<u8> {
     }
 }
 
+impl SseEncode for Option<String> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <bool>::sse_encode(self.is_some(), serializer);
+        if let Some(value) = self {
+            <String>::sse_encode(value, serializer);
+        }
+    }
+}
+
 impl SseEncode for u32 {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
         serializer.cursor.write_u32::<NativeEndian>(self).unwrap();
+    }
+}
+
+impl SseEncode for u64 {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        serializer.cursor.write_u64::<NativeEndian>(self).unwrap();
     }
 }
 

--- a/rust/airo_mind_llama/src/lib.rs
+++ b/rust/airo_mind_llama/src/lib.rs
@@ -50,5 +50,5 @@ pub use llama::LlamaGenerationEngine;
 
 pub use airo_mind_core::{
     CancelToken, EngineError, GenerationChunk, GenerationEngine, GenerationRequest, ResourceBudget,
-    ResourceRequest, RuntimeError, Supervisor,
+    ResourceRequest, RuntimeError, RuntimeStats, Supervisor,
 };

--- a/rust/airo_mind_llama/src/llama.rs
+++ b/rust/airo_mind_llama/src/llama.rs
@@ -14,7 +14,8 @@
 
 use std::num::NonZeroU32;
 use std::path::Path;
-use std::sync::OnceLock;
+use std::sync::{Mutex, OnceLock};
+use std::time::Instant;
 
 use llama_cpp_2::context::params::LlamaContextParams;
 use llama_cpp_2::llama_backend::LlamaBackend;
@@ -25,7 +26,49 @@ use llama_cpp_2::sampling::LlamaSampler;
 
 use crate::budget::ResourceRequest;
 use crate::cancel::CancelToken;
-use crate::engine::{EngineError, GenerationChunk, GenerationEngine, GenerationRequest};
+use crate::engine::{
+    EngineError, GenerationChunk, GenerationEngine, GenerationRequest, RuntimeStats,
+};
+
+/// The start symbol every `GenerationRequest::grammar` is expected to define.
+/// Documented once, here, rather than as a magic string at each call site.
+const GRAMMAR_ROOT: &str = "root";
+
+/// Peak resident set size of the whole process, in bytes.
+///
+/// `getrusage` is the second point of `unsafe` in this crate (the first is
+/// the FFI the generated bridge dereferences into) -- worth calling out
+/// explicitly rather than letting `#[allow(unsafe_code)]` pass unremarked.
+/// `ru_maxrss` is bytes on Darwin and kibibytes on Linux; POSIX does not fix
+/// the unit, so the two platforms are converted to the same one here rather
+/// than leaving the caller to guess which build produced a given number.
+#[cfg(unix)]
+#[allow(unsafe_code)]
+fn peak_rss_bytes() -> u64 {
+    use std::mem::MaybeUninit;
+
+    let mut usage = MaybeUninit::<libc::rusage>::zeroed();
+    let ok = unsafe { libc::getrusage(libc::RUSAGE_SELF, usage.as_mut_ptr()) } == 0;
+    if !ok {
+        return 0;
+    }
+    // SAFETY: `getrusage` returning `0` means it filled `usage` completely.
+    let maxrss = unsafe { usage.assume_init() }.ru_maxrss;
+    let maxrss = u64::try_from(maxrss).unwrap_or(0);
+    if cfg!(target_os = "macos") || cfg!(target_os = "ios") {
+        maxrss
+    } else {
+        maxrss * 1024
+    }
+}
+
+/// No `getrusage` off `unix` (e.g. Windows). `0` is the same "nothing
+/// measured yet" state `RuntimeStats::default()` already uses elsewhere, not
+/// a fabricated number.
+#[cfg(not(unix))]
+fn peak_rss_bytes() -> u64 {
+    0
+}
 
 /// llama.cpp's backend is **process-global** — `init` returns
 /// `BackendAlreadyInitialized` on a second call, and it is not per-model state.
@@ -46,6 +89,14 @@ pub struct LlamaGenerationEngine {
     model: LlamaModel,
     memory_mb: u32,
     context_tokens: u32,
+    /// Measurements from the most recently completed `generate` call.
+    /// `generate` takes `&self` (the trait requires it, and `Supervisor`
+    /// holds this behind a shared reference), so recording anything requires
+    /// interior mutability. A `Mutex` over a `Copy` struct rather than an
+    /// atomic-per-field: `RuntimeStats` is written and read as one unit, and
+    /// splitting it into five atomics would let a reader observe a torn
+    /// mix of two different generations' numbers.
+    stats: Mutex<RuntimeStats>,
 }
 
 impl LlamaGenerationEngine {
@@ -68,7 +119,22 @@ impl LlamaGenerationEngine {
             model,
             memory_mb,
             context_tokens,
+            stats: Mutex::new(RuntimeStats::default()),
         })
+    }
+
+    /// Releases the loaded model explicitly.
+    ///
+    /// `LlamaModel`'s own `Drop` already frees the underlying `llama_model`
+    /// when this value goes out of scope, so on its own this method does no
+    /// more than that. It exists as a named, callable step anyway: the target
+    /// `LlmBackend` shape calls for an explicit `unload`, and a caller
+    /// choosing the moment memory is released -- rather than however long the
+    /// last `Box`/`Arc`/stack frame happens to live -- is a real property to
+    /// be able to name, even when today's implementation is "drop it now
+    /// instead of later."
+    pub fn unload(self) {
+        drop(self);
     }
 }
 
@@ -120,17 +186,37 @@ impl GenerationEngine for LlamaGenerationEngine {
                 .add(*token, i as i32, &[0], i == last)
                 .map_err(|e| EngineError::Backend(format!("batch add: {e}")))?;
         }
+
+        // Prefill: decoding the whole prompt before the first output token.
+        // Timed separately from generation because the two have very
+        // different cost profiles -- prefill is one batched decode over the
+        // full prompt, generation is one decode per output token -- and a
+        // combined number would hide which half a regression came from.
+        let prefill_started = Instant::now();
         ctx.decode(&mut batch)
             .map_err(|e| EngineError::Backend(format!("decode: {e}")))?;
+        let prefill_ms = elapsed_ms(prefill_started);
 
         // The decoder carries UTF-8 continuation state across tokens: a
         // multi-byte character can straddle a token boundary, and decoding each
         // token independently would emit replacement characters mid-word.
         let mut decoder = encoding_rs::UTF_8.new_decoder();
-        let mut sampler = LlamaSampler::greedy();
+        let mut sampler = match &request.grammar {
+            // The chain must end in a token-selecting sampler (`greedy`,
+            // `dist`, ...) per `LlamaSampler::chain`'s own contract -- the
+            // grammar sampler only narrows the candidate set, it does not
+            // pick from it.
+            Some(grammar) => LlamaSampler::chain_simple([
+                LlamaSampler::grammar(&self.model, grammar, GRAMMAR_ROOT)
+                    .map_err(|e| EngineError::InvalidInput(format!("invalid GBNF grammar: {e}")))?,
+                LlamaSampler::greedy(),
+            ]),
+            None => LlamaSampler::greedy(),
+        };
         let mut position = batch.n_tokens();
         let mut produced = 0u32;
 
+        let generation_started = Instant::now();
         while produced < request.max_output_tokens {
             // Between tokens, per `C6`: generation is the long-running half of
             // the pipeline and must stop when the user navigates away.
@@ -164,8 +250,38 @@ impl GenerationEngine for LlamaGenerationEngine {
             position += 1;
             produced += 1;
         }
+        let generation_ms = elapsed_ms(generation_started);
+
+        let tokens_per_second = if generation_ms > 0 {
+            f64::from(produced) / (generation_ms as f64 / 1000.0)
+        } else {
+            0.0
+        };
+        *self
+            .stats
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner()) = RuntimeStats {
+            prefill_ms,
+            prefill_tokens: u32::try_from(tokens.len()).unwrap_or(u32::MAX),
+            generation_ms,
+            generated_tokens: produced,
+            tokens_per_second,
+            peak_rss_bytes: peak_rss_bytes(),
+        };
+
         Ok(())
     }
+
+    fn stats(&self) -> RuntimeStats {
+        *self
+            .stats
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+}
+
+fn elapsed_ms(started: Instant) -> u64 {
+    u64::try_from(started.elapsed().as_millis()).unwrap_or(u64::MAX)
 }
 
 #[cfg(test)]

--- a/rust/airo_mind_llama/tests/generation_offline.rs
+++ b/rust/airo_mind_llama/tests/generation_offline.rs
@@ -51,6 +51,7 @@ fn transcript_becomes_minutes_offline() {
             &GenerationRequest {
                 prompt: minutes_prompt(TRANSCRIPT),
                 max_output_tokens: 160,
+                grammar: None,
             },
             &CancelToken::new(),
             &mut |chunk| {
@@ -92,6 +93,7 @@ fn a_cancelled_generation_stops_and_reports_it() {
         &GenerationRequest {
             prompt: minutes_prompt(TRANSCRIPT),
             max_output_tokens: 200,
+            grammar: None,
         },
         &cancel,
         &mut |_| {
@@ -128,6 +130,7 @@ fn a_real_engine_over_budget_is_refused_before_it_runs() {
         &GenerationRequest {
             prompt: minutes_prompt(TRANSCRIPT),
             max_output_tokens: 32,
+            grammar: None,
         },
         &CancelToken::new(),
         &mut |_| {
@@ -143,6 +146,188 @@ fn a_real_engine_over_budget_is_refused_before_it_runs() {
         })
     );
     assert!(!called, "refused before the engine produced anything");
+}
+
+/// `#1628` Wave 1 acceptance: a GBNF grammar actually constrains the token
+/// stream, not just compiles. A digits-only grammar is deliberately much
+/// stricter than the model's natural continuation of a numeric prompt would
+/// be on its own -- if the grammar were a no-op, the model would drift into
+/// prose almost immediately.
+#[test]
+fn a_gbnf_grammar_constrains_every_generated_character() {
+    let model = model();
+    if !model.exists() {
+        eprintln!("skipping: no model at {}", model.display());
+        return;
+    }
+
+    let engine = LlamaGenerationEngine::load(&model, 1024, 2048).expect("model loads");
+    let mut supervisor = Supervisor::new(ResourceBudget::new(4096));
+    supervisor.register_generation(Box::new(engine));
+
+    // `root` is the symbol name `LlamaGenerationEngine::generate` requires --
+    // one or more ASCII digits, nothing else. A general-knowledge question
+    // has no natural all-digit answer, so any conforming output here was
+    // shaped by the grammar, not by the model happening to agree with it.
+    //
+    // This does NOT prove the grammar forces a minimum length: llama.cpp's
+    // grammar sampler deliberately lets the model's own end-of-generation
+    // token through even mid-grammar (confirmed empirically -- an earlier,
+    // stricter version of this test requiring exactly 8 digits produced only
+    // 4 before stopping), so "how much output" stays the model's call.
+    // "What character set the output uses" is what the grammar owns, and
+    // that is what this asserts.
+    const PROMPT: &str = "<|im_start|>user\nWhat is the capital of France?<|im_end|>\n\
+                           <|im_start|>assistant\n";
+    let digits_only_grammar = r#"root ::= [0-9]+"#;
+
+    let mut unconstrained = String::new();
+    supervisor
+        .run_generation(
+            &GenerationRequest {
+                prompt: PROMPT.to_string(),
+                max_output_tokens: 24,
+                grammar: None,
+            },
+            &CancelToken::new(),
+            &mut |chunk| {
+                unconstrained.push_str(&chunk.text);
+                Ok(())
+            },
+        )
+        .expect("unconstrained generation succeeds");
+    eprintln!("--- unconstrained output ---\n{unconstrained:?}\n---");
+    assert!(
+        unconstrained.chars().any(|c| !c.is_ascii_digit()),
+        "test prompt needs a genuinely non-numeric natural answer to be a \
+         meaningful baseline -- got {unconstrained:?}"
+    );
+
+    let mut output = String::new();
+    supervisor
+        .run_generation(
+            &GenerationRequest {
+                prompt: PROMPT.to_string(),
+                max_output_tokens: 24,
+                grammar: Some(digits_only_grammar.to_string()),
+            },
+            &CancelToken::new(),
+            &mut |chunk| {
+                output.push_str(&chunk.text);
+                Ok(())
+            },
+        )
+        .expect("grammar-constrained generation succeeds");
+    eprintln!("--- grammar-constrained output ---\n{output:?}\n---");
+
+    assert!(
+        !output.is_empty(),
+        "the grammar-constrained call produced no output at all"
+    );
+    assert!(
+        output.chars().all(|c| c.is_ascii_digit()),
+        "grammar did not constrain the output -- got {output:?}"
+    );
+}
+
+/// `#1628` Wave 1 acceptance: an invalid grammar is a normal `InvalidInput`
+/// refusal, not a panic -- the same shape every other malformed-request path
+/// in this engine already uses.
+#[test]
+fn a_grammar_missing_its_root_rule_is_refused_not_a_panic() {
+    let model = model();
+    if !model.exists() {
+        return;
+    }
+
+    let engine = LlamaGenerationEngine::load(&model, 1024, 2048).expect("model loads");
+    let mut supervisor = Supervisor::new(ResourceBudget::new(4096));
+    supervisor.register_generation(Box::new(engine));
+
+    let r = supervisor.run_generation(
+        &GenerationRequest {
+            prompt: "hello".into(),
+            max_output_tokens: 8,
+            // No `root` rule -- the grammar's own start symbol is missing.
+            grammar: Some("digits ::= [0-9]+".into()),
+        },
+        &CancelToken::new(),
+        &mut |_| Ok(()),
+    );
+
+    assert!(matches!(
+        r,
+        Err(RuntimeError::Engine(
+            airo_mind_llama::EngineError::InvalidInput(_)
+        ))
+    ));
+}
+
+/// `#1628` Wave 1 acceptance: `RuntimeStats` reports real, non-zero
+/// measurements after a real generation call -- not hardcoded placeholders.
+#[test]
+fn runtime_stats_are_real_after_a_generation_call() {
+    let model = model();
+    if !model.exists() {
+        eprintln!("skipping: no model at {}", model.display());
+        return;
+    }
+
+    let engine = LlamaGenerationEngine::load(&model, 1024, 2048).expect("model loads");
+    let mut supervisor = Supervisor::new(ResourceBudget::new(4096));
+    supervisor.register_generation(Box::new(engine));
+
+    assert_eq!(
+        supervisor.generation_stats(),
+        Some(airo_mind_llama::RuntimeStats::default()),
+        "nothing has generated yet -- stats must read as the zero state, not garbage"
+    );
+
+    supervisor
+        .run_generation(
+            &GenerationRequest {
+                prompt: minutes_prompt(TRANSCRIPT),
+                max_output_tokens: 64,
+                grammar: None,
+            },
+            &CancelToken::new(),
+            &mut |_| Ok(()),
+        )
+        .expect("generation succeeds");
+
+    let stats = supervisor
+        .generation_stats()
+        .expect("a generation engine is registered");
+
+    assert!(stats.prefill_tokens > 0, "prefill tokenised nothing?");
+    assert!(stats.generated_tokens > 0, "generation produced no tokens?");
+    // Timing on a real backend is never provably non-zero at millisecond
+    // resolution (a fast enough call could round to 0ms), but tokens/sec is
+    // derived FROM those timings and generated_tokens, so a non-zero rate is
+    // the strongest single proof that real instrumentation ran, not a
+    // hardcoded stand-in.
+    assert!(
+        stats.tokens_per_second > 0.0,
+        "tokens/sec was not computed from a real measurement: {stats:?}"
+    );
+    assert!(
+        stats.peak_rss_bytes > 0,
+        "peak RSS was not read from the process"
+    );
+
+    eprintln!("--- runtime stats ---\n{stats:?}\n---");
+}
+
+/// `#1628` Wave 1 acceptance: `unload()` exists, is callable, and does not
+/// panic or leak.
+#[test]
+fn unload_is_callable_and_does_not_panic() {
+    let model = model();
+    if !model.exists() {
+        return;
+    }
+    let engine = LlamaGenerationEngine::load(&model, 1024, 2048).expect("model loads");
+    engine.unload();
 }
 
 // The end-to-end join (audio -> transcript -> minutes) used to live here as


### PR DESCRIPTION
## Summary

Wave 1 (Foundation) implementation for #1628, part of the Mind epic #1627. Closes the two hard gaps the Wave-0 audit found in `airo_mind_llama` versus the target `LlmBackend` shape (GBNF-constrained generation, RuntimeStats), plus the missing `unload()`. Additive only -- no rewrite of the trait's `load`/`generate` signatures.

- **GBNF grammar-constrained generation**: `GenerationRequest.grammar: Option<String>` (GBNF text, start symbol `root`) threads through `LlamaGenerationEngine::generate`, `generate_minutes` in `api/minutes.rs`, and the Dart bridge. Falls back to the original unconstrained `LlamaSampler::greedy()` when absent.
- **RuntimeStats**: real prefill-ms, prefill-tokens, generation-ms, generated-tokens, tokens/sec, and peak-RSS, recorded at the end of every `generate` call and readable via a new `stats()` method on the (widened) `GenerationEngine` trait, `Supervisor::generation_stats()`, and `MindGenerationBridge.stats()` in Dart.
- **`unload()`**: `LlamaGenerationEngine::unload(self)` (explicit, callable, consumes and drops) plus `Supervisor::unregister_generation()`, exposed as `unload_generation()` / `MindGenerationBridge.unload()`.

## A dependency finding worth flagging

The pinned `llama-cpp-2 = "0.1.153"` only exposes the safe grammar-sampler wrapper (`LlamaSampler::grammar`) behind its `common` Cargo feature -- the raw vocab pointer a manual FFI call to `llama_sampler_init_grammar` would need is `pub(crate)` inside `llama-cpp-2` itself, so there's no way to reach GBNF grammar init from outside the crate without it. I enabled `common` in `airo_mind_llama`'s `llama` feature union (no version bump).

Enabling `common` does compile `download.cpp`/`hf-cache.cpp` as unconditional sources in llama.cpp's own `common/CMakeLists.txt` -- but I verified in `llama-cpp-sys-2`'s `build.rs` that `LLAMA_CURL` is set to `"OFF"` **unconditionally**, regardless of the `common` feature. No HTTP client links, no network capability compiles in. `ADR-0018 §1`'s "cloud optional, never cloud required" claim survives -- it's dead code with no reachable network path, not a live downloader. Documented at length in `rust/airo_mind_llama/Cargo.toml`. Flagging for Chief Performance Officer / Chief Security Officer awareness at the next binary-size or dependency review, since it is a real (if inert) growth in what's linked.

## GBNF proof

`a_gbnf_grammar_constrains_every_generated_character` (`rust/airo_mind_llama/tests/generation_offline.rs`) runs the identical prompt ("What is the capital of France?") twice against the bundled Qwen2.5 0.5B model:

- **Unconstrained**: `"The capital of France is Paris."`
- **Grammar `root ::= [0-9]+`**: `"202202222"`

All-digit conformance after a natural-language prompt is causal proof the grammar shaped the output, not the model coincidentally agreeing with it. `a_grammar_missing_its_root_rule_is_refused_not_a_panic` covers the malformed-grammar error path (`EngineError::InvalidInput`, not a panic).

## RuntimeStats proof

`runtime_stats_are_real_after_a_generation_call` asserts `RuntimeStats::default()` (all zero) before anything has generated, then asserts real, non-zero `prefill_tokens`, `generated_tokens`, `tokens_per_second`, and `peak_rss_bytes` after a real generation call. Observed values on this run:

```
RuntimeStats { prefill_ms: 8, prefill_tokens: 73, generation_ms: 761, generated_tokens: 64, tokens_per_second: 84.09986859395532, peak_rss_bytes: 618201088 }
```

Not hardcoded -- `tokens_per_second` is derived from `generated_tokens / (generation_ms / 1000)` inside the engine, and `peak_rss_bytes` comes from a real `getrusage(RUSAGE_SELF, ...)` call (unix; `0` elsewhere, same "nothing measured" state as the zero default, not a fabricated number).

## unload() confirmation

`unload_is_callable_and_does_not_panic` loads a real model and calls `engine.unload()`. `unregister_generation_drops_the_engine_and_the_next_run_is_refused` (in `airo_mind_core/src/supervisor.rs`) proves `Supervisor::unregister_generation()` actually clears the slot -- a subsequent `run_generation` is refused with `RuntimeError::NoEngine("generation")`.

## Explicitly deferred (per issue scope)

Full `LlmBackend` trait-signature unification (`ModelRef`/`LoadParams`/`Result<Generation>`) is **not** attempted here -- this pass is additive gap-filling on top of the existing `GenerationEngine` trait, not a rewrite of `load`/`generate`'s shape. A backend registry unifying llama.cpp and LiteRT-LM, and Gemma 3 1B / Qwen3 1.5B model registry entries, are also out of scope; the crate remains proven only against the bundled Qwen2.5 0.5B GGUF (confirmed in the Wave-0 audit, unchanged by this PR).

## Test plan

- [x] `cargo test -p airo_mind_core` -- 48 passed
- [x] `cargo test -p airo_mind_llama --features llama` -- 7 passed (includes both new GBNF tests and the RuntimeStats test, using the bundled Qwen2.5 0.5B GGUF)
- [x] `cargo test --workspace` -- green
- [x] `cargo clippy -p airo_mind_core -p airo_mind_llama --features llama --all-targets` -- clean (one pre-existing unused-import warning in `lib.rs`, unrelated to this change)
- [x] `cargo fmt --check` -- clean
- [x] FRB bindings regenerated (`flutter_rust_bridge_codegen generate --config-file flutter_rust_bridge_mind_llama.yaml`) -- `Done!`, Dart diff reviewed
- [x] `flutter test` for `feature_mind`'s `mind_service_test.dart` and `model_acquisition_test.dart` (the suites that exercise `MindGenerationBridge`) -- green
- [x] `dart analyze` on touched Dart files -- no issues
- [x] Confirmed the package's broader `flutter test` suite has 12 pre-existing, unrelated failures (golden/layout tests in `runtime_console` and `wellbeing`) present on `origin/main` before this change (verified via `git stash`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)