### PR TITLE
[MIND-LLM-7] Transcript processor -- dual raw/normalized text + semantic chunking with overlap

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -70,6 +70,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "airo_mind_transcript"
+version = "0.1.0"
+
+[[package]]
 name = "airo_mind_whisper"
 version = "0.1.0"
 dependencies = [

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,3 +1,9 @@
 [workspace]
-members = ["airo_core", "airo_mind_core", "airo_mind_llama", "airo_mind_whisper"]
+members = [
+  "airo_core",
+  "airo_mind_core",
+  "airo_mind_llama",
+  "airo_mind_transcript",
+  "airo_mind_whisper",
+]
 resolver = "2"

--- a/rust/airo_mind_transcript/Cargo.toml
+++ b/rust/airo_mind_transcript/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "airo_mind_transcript"
+version = "0.1.0"
+edition = "2021"
+description = "Airo Mind transcript processor — raw/normalized text and evidence-linked semantic chunking. #1632."
+license = "MIT"
+
+[lib]
+name = "airo_mind_transcript"
+# rlib only. This crate has no FFI surface of its own -- it is pure
+# transformation logic (string in, structured chunks out) meant to be called
+# from whichever engine crate drives the extraction pipeline (`#1633`), the
+# same way `airo_mind_core` is linked rather than loaded standalone. No
+# native dependency, no `unsafe`, so unlike `airo_mind_whisper`/
+# `airo_mind_llama` there is no vendored-ggml conflict to isolate it from.
+crate-type = ["rlib"]
+
+# Deliberately nothing beyond std. This crate is pure text/timestamp
+# transformation -- the same "safe to link anywhere" property
+# `airo_mind_core`'s doc comment asks for, kept here on purpose since a future
+# engine crate may want to call it from inside its own cdylib without pulling
+# in anything extra.
+[dependencies]
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(frb_expand)'] }

--- a/rust/airo_mind_transcript/src/chunk.rs
+++ b/rust/airo_mind_transcript/src/chunk.rs
@@ -1,0 +1,154 @@
+//! Semantic chunking with overlap, per `#1632`.
+//!
+//! Not fixed-size windows: a chunk boundary is chosen at a segment/timestamp
+//! and paragraph boundary (a segment ending in terminal punctuation, followed
+//! by a pause) inside a 5–10 minute window, so a topic in progress is not cut
+//! mid-sentence just because a clock ran out. Each chunk overlaps the next by
+//! roughly a minute so a fact whose evidence sits right at a boundary is
+//! still fully inside at least one chunk on either side (this is what the
+//! issue's golden-test requirement — a boundary fact present in two adjacent
+//! chunks — is checking).
+//!
+//! Every chunk carries the ids of every segment that contributed to it.
+//! That is the evidence-grounding link the rest of this milestone needs: a
+//! fact extracted from a chunk cites a segment id, never bare chunk text.
+
+/// One unit of input to the chunker: a segment id, its timestamps, and the
+/// text to include in the chunk (normalized text, per this crate's contract
+/// that normalized — not raw — feeds anything downstream of preprocessing).
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ChunkInput {
+    pub id: String,
+    pub start_ms: u64,
+    pub end_ms: u64,
+    pub text: String,
+}
+
+/// Chunk sizing. Defaults match the issue: 5–10 minute chunks, ~1 minute
+/// overlap, a boundary only counts as a paragraph break if there is a
+/// half-second-plus pause after it (a shorter gap is normal mid-sentence
+/// breathing room, not a topic change).
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ChunkConfig {
+    pub min_len_ms: u64,
+    pub max_len_ms: u64,
+    pub overlap_ms: u64,
+    pub pause_gap_ms: u64,
+}
+
+impl Default for ChunkConfig {
+    fn default() -> Self {
+        Self {
+            min_len_ms: 5 * 60_000,
+            max_len_ms: 10 * 60_000,
+            overlap_ms: 60_000,
+            pause_gap_ms: 500,
+        }
+    }
+}
+
+/// One semantic chunk: its span, the normalized text an LLM extraction pass
+/// would read, and the segment ids that back every sentence in it.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Chunk {
+    pub id: String,
+    pub start_ms: u64,
+    pub end_ms: u64,
+    pub segment_ids: Vec<String>,
+    pub text: String,
+}
+
+/// Splits `inputs` (already in ascending-timestamp order, as ASR produces
+/// them) into overlapping semantic chunks. Deterministic: the same input
+/// slice always produces the same chunks, since the only inputs to the
+/// decision are the segments' own timestamps and text.
+pub fn chunk_segments(inputs: &[ChunkInput], config: &ChunkConfig) -> Vec<Chunk> {
+    if inputs.is_empty() {
+        return Vec::new();
+    }
+
+    let mut chunks = Vec::new();
+    let mut start_idx = 0usize;
+    let mut chunk_no = 0usize;
+
+    while start_idx < inputs.len() {
+        let chunk_start_ms = inputs[start_idx].start_ms;
+        let max_end_ms = chunk_start_ms + config.max_len_ms;
+        let min_end_ms = chunk_start_ms + config.min_len_ms;
+
+        // The last index still inside the max-length window (always at least
+        // `start_idx`, even if that one segment alone overruns it).
+        let mut window_end_idx = start_idx;
+        // The first good paragraph boundary at/after the min-length mark,
+        // preferred over just running to the max-length edge.
+        let mut boundary_idx: Option<usize> = None;
+
+        for i in start_idx..inputs.len() {
+            if i > start_idx && inputs[i].end_ms > max_end_ms {
+                break;
+            }
+            window_end_idx = i;
+            if boundary_idx.is_none() && inputs[i].end_ms >= min_end_ms {
+                let gap_after = inputs
+                    .get(i + 1)
+                    .map(|next| next.start_ms.saturating_sub(inputs[i].end_ms))
+                    .unwrap_or(u64::MAX);
+                if ends_with_terminal_punctuation(&inputs[i].text)
+                    && gap_after >= config.pause_gap_ms
+                {
+                    boundary_idx = Some(i);
+                    break;
+                }
+            }
+        }
+
+        let end_idx = boundary_idx.unwrap_or(window_end_idx);
+        let chunk_end_ms = inputs[end_idx].end_ms;
+
+        let segment_ids: Vec<String> = inputs[start_idx..=end_idx]
+            .iter()
+            .map(|s| s.id.clone())
+            .collect();
+        let text = inputs[start_idx..=end_idx]
+            .iter()
+            .map(|s| s.text.as_str())
+            .collect::<Vec<_>>()
+            .join(" ");
+
+        chunks.push(Chunk {
+            id: format!("chunk-{chunk_no}"),
+            start_ms: chunk_start_ms,
+            end_ms: chunk_end_ms,
+            segment_ids,
+            text,
+        });
+        chunk_no += 1;
+
+        if end_idx + 1 >= inputs.len() {
+            break;
+        }
+
+        // Next chunk starts inside the overlap window: the first segment
+        // whose start falls within the last `overlap_ms` of this chunk. If
+        // this chunk was a single segment spanning the whole window, there is
+        // no room to overlap — advance by one segment so the loop still
+        // terminates.
+        let overlap_from_ms = chunk_end_ms.saturating_sub(config.overlap_ms);
+        start_idx = if end_idx == start_idx {
+            start_idx + 1
+        } else {
+            (start_idx..=end_idx)
+                .find(|&i| inputs[i].start_ms >= overlap_from_ms)
+                .unwrap_or(end_idx)
+        };
+    }
+
+    chunks
+}
+
+fn ends_with_terminal_punctuation(text: &str) -> bool {
+    matches!(
+        text.trim_end().chars().last(),
+        Some('.') | Some('?') | Some('!')
+    )
+}

--- a/rust/airo_mind_transcript/src/lib.rs
+++ b/rust/airo_mind_transcript/src/lib.rs
@@ -1,0 +1,192 @@
+#![deny(unsafe_code)]
+//! Airo Mind transcript processor. `#1632`, Milestone 26 Phase 2/Wave 2.
+//!
+//! The preprocessing stage between ASR (`airo_mind_whisper`, `#1629`) and
+//! extraction (`#1633`). It produces two things and nothing else:
+//!
+//! 1. **Raw + normalized text**, per segment and for the whole transcript.
+//!    `raw` is evidence — untouched, always traceable back to what whisper
+//!    actually produced. `normalized` corrects a known technical-term
+//!    vocabulary and number formatting, and is what extraction reads.
+//! 2. **Overlapping semantic chunks**, each carrying the segment ids that
+//!    back it, so a downstream fact can cite a segment id rather than bare
+//!    LLM output — the evidence-grounding rule this whole milestone runs on.
+//!
+//! Nothing here summarizes or extracts a fact. That is `#1633`'s job, on the
+//! other side of this stage's output — the "LLM never summarizes the
+//! transcript directly" rule the epic states applies to the boundary right
+//! here: this crate does not call an LLM at all.
+//!
+//! # Off the main isolate
+//!
+//! This crate is pure Rust with no FFI surface (see `Cargo.toml`'s `crate-type`
+//! note). It is not itself compiled into a Flutter-reachable cdylib; whichever
+//! engine crate wires `#1633`'s extraction pass will call [`process`] from
+//! Rust, which already runs off the Flutter main isolate the same way every
+//! other engine call does (`packages/core_native`'s FFI boundary runs on a
+//! background isolate/thread by construction — see `AGENTS.md`'s "parsing
+//! never runs on the main isolate" rule). There is no synchronous call site
+//! into this crate from Dart to guard against.
+
+pub mod chunk;
+pub mod normalize;
+pub mod segment;
+
+pub use chunk::{Chunk, ChunkConfig, ChunkInput};
+pub use normalize::{NormalizationResult, NumberNormalization, TermCorrection};
+pub use segment::Segment;
+
+/// One segment's raw and normalized text side by side, with its timestamps
+/// and id carried through unchanged.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ProcessedSegment {
+    pub id: String,
+    pub start_ms: u64,
+    pub end_ms: u64,
+    pub raw: String,
+    pub normalized: String,
+    pub terms_corrected: Vec<TermCorrection>,
+    pub numbers: Vec<NumberNormalization>,
+}
+
+/// The full output of preprocessing one transcript: raw and normalized text
+/// (both whole-transcript and per-segment), and the overlapping chunks built
+/// from the normalized segments.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ProcessedTranscript {
+    pub raw: String,
+    pub normalized: String,
+    pub segments: Vec<ProcessedSegment>,
+    pub chunks: Vec<Chunk>,
+}
+
+/// Runs the full pipeline: normalize every segment, then chunk the
+/// normalized segments. Deterministic — depends only on `segments`' own
+/// content and `config`.
+pub fn process(segments: &[Segment], config: &ChunkConfig) -> ProcessedTranscript {
+    let processed: Vec<ProcessedSegment> = segments
+        .iter()
+        .map(|s| {
+            let result = normalize::normalize(&s.text);
+            ProcessedSegment {
+                id: s.id.clone(),
+                start_ms: s.start_ms,
+                end_ms: s.end_ms,
+                raw: result.raw,
+                normalized: result.normalized,
+                terms_corrected: result.terms_corrected,
+                numbers: result.numbers,
+            }
+        })
+        .collect();
+
+    let chunk_inputs: Vec<ChunkInput> = processed
+        .iter()
+        .map(|s| ChunkInput {
+            id: s.id.clone(),
+            start_ms: s.start_ms,
+            end_ms: s.end_ms,
+            text: s.normalized.clone(),
+        })
+        .collect();
+    let chunks = chunk::chunk_segments(&chunk_inputs, config);
+
+    // Raw stays a plain join of each segment's untouched text — the same
+    // "join what the engine gave you" rule `TranscriptEvent::TranscriptReady`
+    // already applies to the flat `text` field in
+    // `airo_mind_whisper::api::meetings`.
+    let raw = segments
+        .iter()
+        .map(|s| s.text.as_str())
+        .collect::<Vec<_>>()
+        .join(" ");
+    let normalized = processed
+        .iter()
+        .map(|s| s.normalized.as_str())
+        .collect::<Vec<_>>()
+        .join(" ");
+
+    ProcessedTranscript {
+        raw,
+        normalized,
+        segments: processed,
+        chunks,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn seg(id: &str, start_ms: u64, end_ms: u64, text: &str) -> Segment {
+        Segment {
+            id: id.to_string(),
+            start_ms,
+            end_ms,
+            text: text.to_string(),
+        }
+    }
+
+    #[test]
+    fn raw_is_untouched_while_normalized_corrects_known_terms() {
+        let segments = vec![seg(
+            "s0",
+            0,
+            2_000,
+            "we moved the temple workspace onto GCP and fixed the worklows.",
+        )];
+        let out = process(&segments, &ChunkConfig::default());
+
+        assert_eq!(
+            out.segments[0].raw,
+            "we moved the temple workspace onto GCP and fixed the worklows."
+        );
+        assert_eq!(
+            out.segments[0].normalized,
+            "we moved the Temporal workspace onto GCP and fixed the workflows."
+        );
+        assert!(out.raw.contains("temple workspace"));
+        assert!(!out.normalized.contains("temple workspace"));
+    }
+
+    #[test]
+    fn number_normalization_reports_canonical_and_display() {
+        let segments = vec![seg(
+            "s0",
+            0,
+            2_000,
+            "the migration touched about 500,000 rows and 1200000 events.",
+        )];
+        let out = process(&segments, &ChunkConfig::default());
+        let numbers = &out.segments[0].numbers;
+
+        let rows = numbers.iter().find(|n| n.raw == "500,000").unwrap();
+        assert_eq!(rows.canonical, 500_000);
+        assert_eq!(rows.display, "500,000");
+
+        let events = numbers.iter().find(|n| n.raw == "1200000").unwrap();
+        assert_eq!(events.canonical, 1_200_000);
+        assert_eq!(events.display, "1,200,000");
+        assert!(out.segments[0].normalized.contains("1,200,000"));
+    }
+
+    #[test]
+    fn same_transcript_produces_identical_chunks_every_time() {
+        let segments: Vec<Segment> = (0..50)
+            .map(|i| {
+                seg(
+                    &format!("s{i}"),
+                    i * 10_000,
+                    i * 10_000 + 9_500,
+                    "we discussed the plan.",
+                )
+            })
+            .collect();
+
+        let first = process(&segments, &ChunkConfig::default());
+        let second = process(&segments, &ChunkConfig::default());
+
+        assert_eq!(first.chunks, second.chunks);
+        assert!(!first.chunks.is_empty());
+    }
+}

--- a/rust/airo_mind_transcript/src/normalize.rs
+++ b/rust/airo_mind_transcript/src/normalize.rs
@@ -1,0 +1,306 @@
+//! Raw/normalized text, per `#1632`.
+//!
+//! `raw` is never touched — it is the evidence text a fact's segment id
+//! ultimately points back to, and "aggressively rewriting raw" is the
+//! specific mistake the issue calls out. `normalized` is a corrected copy
+//! built alongside it, fed to extraction instead.
+//!
+//! Two kinds of correction, run in a fixed order so the result is
+//! deterministic for a given input:
+//!
+//! 1. **Technical-term dictionary** — ASR mishears a fixed vocabulary of
+//!    product/infra nouns in predictable ways ("temple workspace" for
+//!    "Temporal workspace", "worklows" for "workflows"). Phrase-level
+//!    corrections run first (multi-word ASR damage), then single-word
+//!    corrections (casing/known misspellings of one term).
+//! 2. **Number normalization** — a digit run gets a canonical integer value
+//!    and a comma-grouped display form. `"500,000"` round-trips to the same
+//!    display; an ungrouped `"500000"` gets grouped for readability. Only
+//!    the *normalized* text changes — `raw` still has whatever digits ASR
+//!    produced.
+//!
+//! Both passes are ASCII-oriented (the technical terms and digit grouping
+//! this crate corrects are ASCII by construction); a transcript is assumed
+//! English for the extent that matters to matching case-insensitively.
+
+use std::collections::HashMap;
+
+/// One phrase-level correction applied to the text: what ASR produced, and
+/// what it was corrected to. `raw` is the exact matched substring — kept so
+/// a caller (or a test) can show its provenance, not just the outcome.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TermCorrection {
+    pub raw: String,
+    pub corrected: String,
+}
+
+/// One number found in the text: the literal digits ASR/the source produced,
+/// the canonical integer value, and a comma-grouped display form.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct NumberNormalization {
+    pub raw: String,
+    pub canonical: i64,
+    pub display: String,
+}
+
+/// The result of normalizing one piece of text (typically one segment's
+/// `text`, but the same function works on a joined transcript).
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct NormalizationResult {
+    /// Byte-for-byte identical to the input. Never mutated.
+    pub raw: String,
+    /// The corrected copy, fed to extraction.
+    pub normalized: String,
+    pub terms_corrected: Vec<TermCorrection>,
+    pub numbers: Vec<NumberNormalization>,
+}
+
+/// Multi-word ASR damage: phrases whisper is known to mis-transcribe as a
+/// whole, corrected before single-word lookup runs. Matched case-insensitively
+/// against contiguous text (`replace_ci`), longest-first so a longer phrase
+/// is not shadowed by a shorter one nested inside it.
+const PHRASE_CORRECTIONS: &[(&str, &str)] = &[
+    ("temple workspace", "Temporal workspace"),
+    ("temple work space", "Temporal workspace"),
+    ("temporal work space", "Temporal workspace"),
+    ("yuga byte db", "YugabyteDB"),
+    ("yugabyte db", "YugabyteDB"),
+    ("g rpc", "gRPC"),
+    ("name space", "namespace"),
+];
+
+/// Single-token technical-term dictionary. Keys are matched case-insensitively
+/// against a whole word; the value is what the word becomes in `normalized`.
+/// Extend this list as new ASR-damaged or inconsistently-cased terms show up
+/// in real meetings — it is intentionally a flat, easy-to-append table rather
+/// than anything cleverer.
+const TERM_CORRECTIONS: &[(&str, &str)] = &[
+    ("temporal", "Temporal"),
+    ("yugabytedb", "YugabyteDB"),
+    ("yugabyte", "Yugabyte"),
+    ("gcp", "GCP"),
+    ("jvm", "JVM"),
+    ("kubernetes", "Kubernetes"),
+    ("kubernettis", "Kubernetes"),
+    ("kubernetees", "Kubernetes"),
+    ("k8s", "K8s"),
+    ("namespace", "namespace"),
+    ("namespaces", "namespaces"),
+    ("signalling", "signaling"),
+    ("signaling", "signaling"),
+    ("worklows", "workflows"),
+    ("worklfows", "workflows"),
+    ("workflow", "workflow"),
+    ("workflows", "workflows"),
+    ("grpc", "gRPC"),
+    ("postgres", "PostgreSQL"),
+    ("postgresql", "PostgreSQL"),
+    ("redis", "Redis"),
+    ("kafka", "Kafka"),
+    ("docker", "Docker"),
+    ("terraform", "Terraform"),
+    ("oauth", "OAuth"),
+    ("api", "API"),
+    ("apis", "APIs"),
+    ("sdk", "SDK"),
+    ("cicd", "CI/CD"),
+    ("tls", "TLS"),
+    ("ssl", "SSL"),
+];
+
+/// Normalizes one piece of text: phrase corrections, then single-word
+/// corrections, then number normalization. `raw` in the result is the
+/// caller's `text` unchanged.
+pub fn normalize(text: &str) -> NormalizationResult {
+    let mut terms_corrected = Vec::new();
+
+    let mut working = text.to_string();
+    for (phrase, replacement) in PHRASE_CORRECTIONS {
+        working = replace_ci(&working, phrase, replacement, &mut terms_corrected);
+    }
+    working = correct_words(&working, &mut terms_corrected);
+
+    let (working, numbers) = normalize_numbers(&working);
+
+    NormalizationResult {
+        raw: text.to_string(),
+        normalized: working,
+        terms_corrected,
+        numbers,
+    }
+}
+
+/// Case-insensitive, non-overlapping find-and-replace of `needle` in `text`,
+/// recording each match as a [`TermCorrection`]. ASCII-oriented: byte offsets
+/// from the lowercased haystack are assumed to line up with the original,
+/// which holds for the ASCII technical terms this crate corrects.
+fn replace_ci(
+    text: &str,
+    needle: &str,
+    replacement: &str,
+    corrections: &mut Vec<TermCorrection>,
+) -> String {
+    if needle.is_empty() {
+        return text.to_string();
+    }
+    let lower_text = text.to_lowercase();
+    let lower_needle = needle.to_lowercase();
+    let mut result = String::with_capacity(text.len());
+    let mut i = 0usize;
+    while let Some(pos) = lower_text[i..].find(&lower_needle) {
+        let start = i + pos;
+        let end = start + lower_needle.len();
+        result.push_str(&text[i..start]);
+        result.push_str(replacement);
+        corrections.push(TermCorrection {
+            raw: text[start..end].to_string(),
+            corrected: replacement.to_string(),
+        });
+        i = end;
+    }
+    result.push_str(&text[i..]);
+    result
+}
+
+/// Word-boundary tokenizer: splits `text` into alphanumeric "word" runs and
+/// everything else ("separator" runs — spaces, punctuation), preserving
+/// separators exactly so the text can be reconstructed byte-for-byte from its
+/// pieces when nothing is corrected.
+fn tokenize_words(text: &str) -> Vec<(bool, String)> {
+    let mut pieces = Vec::new();
+    let mut current = String::new();
+    let mut current_is_word: Option<bool> = None;
+    for ch in text.chars() {
+        let is_word = ch.is_alphanumeric();
+        match current_is_word {
+            Some(w) if w == is_word => current.push(ch),
+            _ => {
+                if !current.is_empty() {
+                    pieces.push((current_is_word.unwrap(), std::mem::take(&mut current)));
+                }
+                current.push(ch);
+                current_is_word = Some(is_word);
+            }
+        }
+    }
+    if !current.is_empty() {
+        pieces.push((current_is_word.unwrap(), current));
+    }
+    pieces
+}
+
+/// Applies [`TERM_CORRECTIONS`] to every word token in `text`, case-insensitively.
+fn correct_words(text: &str, corrections: &mut Vec<TermCorrection>) -> String {
+    let dict: HashMap<&str, &str> = TERM_CORRECTIONS.iter().copied().collect();
+    let mut out = String::with_capacity(text.len());
+    for (is_word, piece) in tokenize_words(text) {
+        if is_word {
+            if let Some(replacement) = dict.get(piece.to_lowercase().as_str()) {
+                if *replacement != piece {
+                    corrections.push(TermCorrection {
+                        raw: piece.clone(),
+                        corrected: replacement.to_string(),
+                    });
+                }
+                out.push_str(replacement);
+                continue;
+            }
+        }
+        out.push_str(&piece);
+    }
+    out
+}
+
+/// Finds digit runs (optionally comma-grouped) worth normalizing, and
+/// rewrites the text so every one is displayed comma-grouped. A run is
+/// "worth normalizing" if it already contains a comma (the source clearly
+/// intended a grouped number) or has 4+ digits (large enough that grouping
+/// helps readability) — small figures like "2 people" are left alone.
+fn normalize_numbers(text: &str) -> (String, Vec<NumberNormalization>) {
+    let mut numbers = Vec::new();
+    let mut out = String::with_capacity(text.len());
+    let chars: Vec<char> = text.chars().collect();
+    let mut i = 0usize;
+    while i < chars.len() {
+        if chars[i].is_ascii_digit() {
+            let start = i;
+            let mut j = i;
+            while j < chars.len() && (chars[j].is_ascii_digit() || chars[j] == ',') {
+                j += 1;
+            }
+            // Trailing comma (e.g. "500," at end of a clause) is not part of
+            // the number; back it off the run.
+            while j > start && chars[j - 1] == ',' {
+                j -= 1;
+            }
+            let raw: String = chars[start..j].iter().collect();
+            if let Some((canonical, display)) = parse_grouped_number(&raw) {
+                out.push_str(&display);
+                numbers.push(NumberNormalization {
+                    raw,
+                    canonical,
+                    display,
+                });
+            } else {
+                out.push_str(&raw);
+            }
+            i = j;
+            continue;
+        }
+        out.push(chars[i]);
+        i += 1;
+    }
+    (out, numbers)
+}
+
+/// Validates and parses a digit-and-comma run as a number, returning its
+/// canonical integer value and a canonical comma-grouped display form.
+/// Rejects malformed grouping (e.g. `"500,00"`) by returning `None` — an
+/// ambiguous token is left in the text untouched rather than guessed at.
+/// Only numbers with 4+ digits or an existing comma are treated as worth
+/// normalizing, matching `normalize_numbers`'s call site.
+fn parse_grouped_number(raw: &str) -> Option<(i64, String)> {
+    let has_comma = raw.contains(',');
+    let digits: String = raw.chars().filter(|c| *c != ',').collect();
+    if digits.is_empty() || digits.len() > 18 {
+        return None;
+    }
+    if !has_comma && digits.len() < 4 {
+        return None;
+    }
+    if has_comma {
+        let groups: Vec<&str> = raw.split(',').collect();
+        if groups.iter().any(|g| g.is_empty()) {
+            return None;
+        }
+        if groups[0].len() > 3 || groups[0].is_empty() {
+            return None;
+        }
+        if groups[1..].iter().any(|g| g.len() != 3) {
+            return None;
+        }
+    }
+    let canonical: i64 = digits.parse().ok()?;
+    Some((canonical, group_thousands(canonical)))
+}
+
+/// Formats a non-negative integer with `,` every three digits from the right.
+///
+/// `% 3 == 0` rather than `is_multiple_of` (clippy's suggestion) — this
+/// workspace does not pin an MSRV above the one that predates that method.
+#[allow(clippy::manual_is_multiple_of)]
+fn group_thousands(value: i64) -> String {
+    let digits = value.abs().to_string();
+    let mut grouped = String::with_capacity(digits.len() + digits.len() / 3);
+    for (i, ch) in digits.chars().enumerate() {
+        if i > 0 && (digits.len() - i) % 3 == 0 {
+            grouped.push(',');
+        }
+        grouped.push(ch);
+    }
+    if value < 0 {
+        format!("-{grouped}")
+    } else {
+        grouped
+    }
+}

--- a/rust/airo_mind_transcript/src/segment.rs
+++ b/rust/airo_mind_transcript/src/segment.rs
@@ -1,0 +1,20 @@
+//! The input shape this crate consumes.
+//!
+//! A local mirror of `airo_mind_whisper::api::meetings::TranscriptSegmentRecord`
+//! / `airo_mind_whisper::transcript_store::StoredSegment` (`#1629`), not a
+//! re-export: this crate has no dependency on `airo_mind_whisper` and should
+//! not gain one just to borrow a struct. All three shapes carry the same four
+//! fields for the same reason -- `id`/`start_ms`/`end_ms`/`text` is the
+//! smallest evidence-grounding contract a downstream consumer needs, and
+//! whoever calls this crate already has whisper's `TranscriptSegmentRecord`
+//! in hand and can build this from it field-for-field.
+
+/// One ASR segment as whisper produced it: a stable id scoped to the
+/// recording (`"s0"`, `"s1"`, …) and the timestamps/text that came with it.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Segment {
+    pub id: String,
+    pub start_ms: u64,
+    pub end_ms: u64,
+    pub text: String,
+}

--- a/rust/airo_mind_transcript/tests/golden.rs
+++ b/rust/airo_mind_transcript/tests/golden.rs
@@ -1,0 +1,139 @@
+//! Golden tests on a reference (synthetic but fully specified) transcript, per
+//! `#1632`'s verification section:
+//!
+//! - known ASR errors corrected in `normalized`, untouched in `raw`
+//! - a boundary fact (one that sits at a chunk boundary) present in both
+//!   adjacent overlapping chunks
+//!
+//! The reference transcript is built programmatically rather than checked in
+//! as a fixture file: every segment's timestamp and text is a deterministic
+//! function of its index, so the exact chunk boundary this test asserts on is
+//! derived in the comments below rather than guessed at, and the whole
+//! transcript is reproducible by reading this file alone.
+
+use airo_mind_transcript::{process, ChunkConfig, Segment};
+
+/// Builds the reference transcript: 120 segments, 8s apart, each 7.5s long
+/// (a 500ms gap to the next — exactly `ChunkConfig::default().pause_gap_ms`,
+/// so every segment boundary is eligible to be a pause). Every 5th segment
+/// (`i % 5 == 4`) ends with a period — a paragraph boundary; the rest end
+/// with a comma, so the chunker has to skip past several non-boundary
+/// segments to find the next real one, the way real meeting speech does.
+///
+/// One segment carries a distinctive "boundary fact" sentence plus a couple
+/// of known ASR errors, placed at `i = 39` — worked out below to land
+/// exactly on the boundary between the first two chunks under
+/// `ChunkConfig::default()` (5 min min / 10 min max / 1 min overlap):
+///
+/// - `min_end_ms` for chunk 0 is `300_000`ms. The first `i % 5 == 4` segment
+///   whose `end_ms >= 300_000` is `i = 39` (`end_ms = 39*8000 + 7500 =
+///   319_500`); `i = 34` (`end_ms = 279_500`) is too early. So chunk 0 is
+///   `s0..=s39`, ending at `319_500`ms.
+/// - The overlap window is the last 60s of chunk 0: `overlap_from_ms =
+///   319_500 - 60_000 = 259_500`. The first segment whose `start_ms >=
+///   259_500` is `i = 33` (`start_ms = 264_000`; `i = 32` starts at
+///   `256_000`, too early). So chunk 1 starts at `s33`.
+///
+/// `s33..=s39` is therefore in both chunks, and `s39` — the boundary fact —
+/// is the last segment of chunk 0 and inside chunk 1's overlap.
+fn reference_transcript() -> Vec<Segment> {
+    (0..120)
+        .map(|i: u64| {
+            let start_ms = i * 8_000;
+            let end_ms = start_ms + 7_500;
+            let text = if i == 39 {
+                "the temple workspace budget line item is exactly 500,000 dollars.".to_string()
+            } else if i % 5 == 4 {
+                format!("segment {i} closes this part of the discussion.")
+            } else {
+                format!("segment {i} continues the discussion,")
+            };
+            Segment {
+                id: format!("s{i}"),
+                start_ms,
+                end_ms,
+                text,
+            }
+        })
+        .collect()
+}
+
+#[test]
+fn asr_errors_are_corrected_in_normalized_but_untouched_in_raw() {
+    let transcript = reference_transcript();
+    let out = process(&transcript, &ChunkConfig::default());
+
+    let boundary_segment = out.segments.iter().find(|s| s.id == "s39").unwrap();
+
+    // Raw is byte-for-byte what the reference transcript specified — the ASR
+    // damage stays.
+    assert_eq!(
+        boundary_segment.raw,
+        "the temple workspace budget line item is exactly 500,000 dollars."
+    );
+
+    // Normalized corrects the technical term and reports the number, without
+    // mutating raw.
+    assert_eq!(
+        boundary_segment.normalized,
+        "the Temporal workspace budget line item is exactly 500,000 dollars."
+    );
+    assert!(out.raw.contains("temple workspace"));
+    assert!(!out.normalized.contains("temple workspace"));
+
+    let number = boundary_segment
+        .numbers
+        .iter()
+        .find(|n| n.raw == "500,000")
+        .expect("500,000 should be reported as a normalized number");
+    assert_eq!(number.canonical, 500_000);
+    assert_eq!(number.display, "500,000");
+}
+
+#[test]
+fn a_fact_at_a_chunk_boundary_survives_in_both_adjacent_chunks() {
+    let transcript = reference_transcript();
+    let out = process(&transcript, &ChunkConfig::default());
+
+    assert!(
+        out.chunks.len() >= 2,
+        "reference transcript should produce at least two chunks, got {}",
+        out.chunks.len()
+    );
+
+    let chunk0 = &out.chunks[0];
+    let chunk1 = &out.chunks[1];
+
+    assert!(
+        chunk0.segment_ids.iter().any(|id| id == "s39"),
+        "boundary fact segment s39 should be in chunk 0, got {:?}",
+        chunk0.segment_ids
+    );
+    assert!(
+        chunk1.segment_ids.iter().any(|id| id == "s39"),
+        "boundary fact segment s39 should also be in chunk 1's overlap, got {:?}",
+        chunk1.segment_ids
+    );
+
+    // The fact's own text is present in both chunks' extraction-facing text,
+    // not just its segment id.
+    assert!(chunk0.text.contains("500,000 dollars"));
+    assert!(chunk1.text.contains("500,000 dollars"));
+
+    // The two chunks are not identical — genuine overlap, not duplication of
+    // the whole transcript.
+    assert_ne!(chunk0.segment_ids, chunk1.segment_ids);
+    assert!(
+        chunk1.start_ms < chunk0.end_ms,
+        "chunk 1 should start before chunk 0 ends (overlap)"
+    );
+}
+
+#[test]
+fn processing_the_same_transcript_twice_is_byte_identical() {
+    let transcript = reference_transcript();
+    let first = process(&transcript, &ChunkConfig::default());
+    let second = process(&transcript, &ChunkConfig::default());
+
+    assert_eq!(first, second);
+}


### PR DESCRIPTION
## Summary

Implements #1632 (Milestone 26, epic #1627, Phase 2/Wave 2 — pipeline core): the preprocessing stage that sits between ASR (#1629, just merged as #1727) and extraction (#1633). New crate `rust/airo_mind_transcript`.

- **Normalizer** (`src/normalize.rs`): technical-term dictionary correction (Temporal, YugabyteDB, GCP, JVM, Kubernetes, namespace, gRPC, PostgreSQL, Redis, Kafka, Docker, Terraform, OAuth, API/SDK, TLS/SSL, plus multi-word ASR damage like "temple workspace" → "Temporal workspace", "worklows" → "workflows"), number normalization ("500,000" → canonical `500000` + display `"500,000"`; ungrouped `1200000` gets grouped to `"1,200,000"` in `normalized`). `raw` is never touched — it stays byte-for-byte what the segment produced.
- **Chunker** (`src/chunk.rs`): overlapping 5–10 minute semantic chunks chosen at segment/timestamp + paragraph-boundary pauses (not fixed windows), ~1 minute overlap. Each `Chunk` carries `segment_ids` — the evidence-grounding link the rest of the milestone needs (a fact cites a segment id, never bare LLM output).
- **Deterministic**: `process()` depends only on the input segments and config; same transcript → same chunks, byte-identical across runs (tested).
- **Off main isolate**: rlib only, no FFI surface. Whichever engine crate wires #1633's extraction will call `process()` from Rust, already off the Flutter main isolate the same way every other engine call is.

## Segment format grounding

Read #1629/PR #1727's actual shipped shape rather than inventing one — `rust/airo_mind_whisper/src/transcript_store.rs::StoredSegment` and `rust/airo_mind_whisper/src/api/meetings.rs::TranscriptSegmentRecord` both carry `{ id: String, start_ms: u64, end_ms: u64, text: String }` (id scheme `"s{index}"`, scoped to one recording). `airo_mind_transcript::Segment` is a local mirror of that shape, matching this repo's existing convention (`StoredSegment` itself is documented as "a local mirror... rather than a re-export").

## Scope

M, per the issue. No Track A runtime-substrate work. No summarization/extraction logic — that's explicitly #1633's job; the epic's "LLM never summarizes the transcript directly" rule is enforced by this crate not calling an LLM at all.

## Test plan

- [x] `cargo test -p airo_mind_transcript` — 6/6 pass (3 unit + 3 golden integration tests)
- [x] `cargo clippy -p airo_mind_transcript --all-targets -- -D warnings` — clean
- [x] `cargo fmt -p airo_mind_transcript -- --check` — clean
- [x] `cargo check --workspace` — whole Rust workspace still builds
- [x] Golden test: known ASR errors ("temple workspace" → "Temporal workspace") corrected in `normalized`, untouched in `raw`
- [x] Golden test: a boundary fact (500,000-dollar budget line, `s39`) present in both adjacent overlapping chunks, with the derivation of the exact boundary indices documented in the test file
- [x] Golden test: same transcript processed twice is byte-identical (determinism)

## Review needed

Per the delegation matrix on #1627, this issue is chief-qa-officer territory (conformance/eval — ASR term accuracy and evidence accuracy gates apply downstream of this preprocessing stage, not within it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)