### PR TITLE
feat(mind): operation log (#1194) + projection engine (#1195) — Runtime v1 conditions 4/5

### DIFF
--- a/packages/feature_mind/lib/feature_mind.dart
+++ b/packages/feature_mind/lib/feature_mind.dart
@@ -215,3 +215,18 @@ export 'src/surfaces/mind_home_surface.dart';
 export 'src/surfaces/portability_surface.dart';
 export 'src/surfaces/mind_surface_scaffold.dart';
 export 'src/surfaces/context_workspace_surface.dart';
+
+// The runtime skeleton (#1338): Operation → Persist → Replay → Projection
+// through a minimal Notes capability, proving the vertical slice end to end.
+// Not yet wired into `mind_module.dart`'s routes -- this is the architecture
+// proof, not a shipped journey. The Rust-side twin
+// (`rust/airo_mind_core/src/{runtime,notes}.rs`) is what registers through
+// the real `#1302` Supervisor/EngineRegistry; this Dart half is an
+// independent implementation of the same contract, not yet bridged to it
+// through FFI (see the module docs on `NotesOperationLog` for why).
+export 'src/notes/domain/note.dart';
+export 'src/notes/domain/notes_operation.dart';
+export 'src/notes/domain/notes_operation_log.dart';
+export 'src/notes/domain/notes_projection.dart';
+export 'src/notes/notes_capability.dart';
+export 'src/notes/presentation/notes_screen.dart';

--- a/packages/feature_mind/lib/src/notes/domain/note.dart
+++ b/packages/feature_mind/lib/src/notes/domain/note.dart
@@ -1,0 +1,38 @@
+/// One note, as the projection holds it. `#1338`'s runtime skeleton.
+///
+/// Never constructed by hand outside [NotesOperationLog] replay -- the only
+/// way a [Note] comes to exist in a [NotesProjection] is by folding operation
+/// log entries. Mirrors `airo_mind_core::notes::Note` on the Rust side of the
+/// vertical slice; see `rust/airo_mind_core/src/notes.rs` for the twin
+/// implementation this one is deliberately kept in lockstep with.
+class Note {
+  const Note({
+    required this.id,
+    required this.title,
+    required this.body,
+    required this.updatedAtMs,
+  });
+
+  final String id;
+  final String title;
+  final String body;
+
+  /// The operation's `recordedAtMs` at the time of the mutation that most
+  /// recently touched this note. Supplied by the caller, never sampled from
+  /// the wall clock on the replay path (`C2`).
+  final int updatedAtMs;
+
+  @override
+  bool operator ==(Object other) =>
+      other is Note &&
+      other.id == id &&
+      other.title == title &&
+      other.body == body &&
+      other.updatedAtMs == updatedAtMs;
+
+  @override
+  int get hashCode => Object.hash(id, title, body, updatedAtMs);
+
+  @override
+  String toString() => 'Note($id, "$title", updatedAtMs: $updatedAtMs)';
+}

--- a/packages/feature_mind/lib/src/notes/domain/notes_operation.dart
+++ b/packages/feature_mind/lib/src/notes/domain/notes_operation.dart
@@ -1,0 +1,86 @@
+/// What a Notes operation records. Closed set, matching
+/// `airo_mind_core::notes`'s `note.create` / `note.edit` / `note.delete`
+/// kinds -- a capability's vocabulary is opaque to the runtime (`C5`), but it
+/// is not arbitrary: this is the entire set of things Notes can cause to be
+/// durable.
+enum NoteOpKind {
+  create,
+  edit,
+  delete;
+
+  String get wireName => switch (this) {
+    NoteOpKind.create => 'create',
+    NoteOpKind.edit => 'edit',
+    NoteOpKind.delete => 'delete',
+  };
+
+  static NoteOpKind fromWireName(String name) => switch (name) {
+    'create' => NoteOpKind.create,
+    'edit' => NoteOpKind.edit,
+    'delete' => NoteOpKind.delete,
+    _ => throw FormatException('unknown note operation kind: $name'),
+  };
+}
+
+/// One durable entry in the Notes operation log.
+///
+/// The beginning of the operation log condition (`#1194`) at skeleton scale:
+/// a minimal, local, unsigned record -- not the signed, synced log Phase 2
+/// builds. What it proves is the shape everything after it depends on: a
+/// capability's mutation becomes one immutable, ordered, replayable fact.
+class NotesOperation {
+  const NotesOperation({
+    required this.seq,
+    required this.kind,
+    required this.id,
+    required this.title,
+    required this.body,
+    required this.recordedAtMs,
+  });
+
+  /// Monotonic, gap-free, assigned by [NotesOperationLog.append].
+  final int seq;
+  final NoteOpKind kind;
+
+  /// The note this operation is about. Empty title/body are valid for
+  /// [NoteOpKind.delete], which carries only [id].
+  final String id;
+  final String title;
+  final String body;
+
+  /// Supplied by the caller, never sampled from the wall clock inside the
+  /// log (`C2`'s determinism discipline, kept even though this Dart log is
+  /// not yet on a byte-identical-replay path shared across devices).
+  final int recordedAtMs;
+
+  Map<String, Object?> toJson() => {
+    'seq': seq,
+    'kind': kind.wireName,
+    'id': id,
+    'title': title,
+    'body': body,
+    'recordedAtMs': recordedAtMs,
+  };
+
+  factory NotesOperation.fromJson(Map<String, Object?> json) => NotesOperation(
+    seq: json['seq']! as int,
+    kind: NoteOpKind.fromWireName(json['kind']! as String),
+    id: json['id']! as String,
+    title: json['title']! as String,
+    body: json['body']! as String,
+    recordedAtMs: json['recordedAtMs']! as int,
+  );
+
+  @override
+  bool operator ==(Object other) =>
+      other is NotesOperation &&
+      other.seq == seq &&
+      other.kind == kind &&
+      other.id == id &&
+      other.title == title &&
+      other.body == body &&
+      other.recordedAtMs == recordedAtMs;
+
+  @override
+  int get hashCode => Object.hash(seq, kind, id, title, body, recordedAtMs);
+}

--- a/packages/feature_mind/lib/src/notes/domain/notes_operation_log.dart
+++ b/packages/feature_mind/lib/src/notes/domain/notes_operation_log.dart
@@ -1,0 +1,102 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'notes_operation.dart';
+
+/// Sequential, append-only, file-backed operation log for the Notes
+/// capability. `#1338`'s runtime skeleton, Dart half.
+///
+/// This is the UI-facing twin of `airo_mind_core::runtime::OperationLog`
+/// (`rust/airo_mind_core/src/runtime.rs`). The two are independent
+/// implementations of the same contract rather than one bridged through FFI
+/// -- wiring a new `flutter_rust_bridge` engine crate (cargokit, Android
+/// Gradle, iOS podspec, codegen) is real platform-integration work this pass
+/// deliberately did not attempt; see the `#1338` completion notes for why.
+/// What this type proves on the Dart side is the property the UI actually
+/// needs: notes persist, survive a projection wipe, and are replayable from
+/// scratch, in one pass, in write order.
+///
+/// `C1`: *"writes are sequential and append-only; no in-place rewrite."*
+/// Each [append] opens the file in append mode, writes one JSON-lines
+/// record, and flushes before returning -- there is no separate durability
+/// point deferred to later.
+class NotesOperationLog {
+  NotesOperationLog._(this._file);
+
+  final File _file;
+  int _nextSeq = 0;
+
+  /// Opens the log at [path], creating it if absent. If it already has
+  /// entries, replays them once to recover the next sequence number, so a
+  /// restart resumes numbering rather than colliding with what is durable.
+  static Future<NotesOperationLog> open(String path) async {
+    final file = File(path);
+    if (!await file.exists()) {
+      await file.create(recursive: true);
+    }
+    final log = NotesOperationLog._(file);
+    final existing = await log.replay();
+    log._nextSeq = existing.isEmpty ? 0 : existing.last.seq + 1;
+    return log;
+  }
+
+  /// Appends one operation and returns it with its assigned [NotesOperation.seq].
+  Future<NotesOperation> append({
+    required NoteOpKind kind,
+    required String id,
+    required int recordedAtMs,
+    String title = '',
+    String body = '',
+  }) async {
+    final op = NotesOperation(
+      seq: _nextSeq++,
+      kind: kind,
+      id: id,
+      title: title,
+      body: body,
+      recordedAtMs: recordedAtMs,
+    );
+    final raf = await _file.open(mode: FileMode.writeOnlyAppend);
+    try {
+      await raf.writeString('${jsonEncode(op.toJson())}\n');
+      await raf.flush();
+    } finally {
+      await raf.close();
+    }
+    return op;
+  }
+
+  /// Replays every durable operation, in write order, in a single pass over
+  /// the file. `C2`: *"replay is a single pass"* -- one read of the file,
+  /// one iteration over its lines.
+  ///
+  /// A torn final line -- a write interrupted mid-flush -- is treated as the
+  /// end of the durable log rather than a hard failure, the same recovery
+  /// rule `airo_mind_core::runtime::OperationLog` uses for a torn tail.
+  Future<List<NotesOperation>> replay() async {
+    if (!await _file.exists()) {
+      return const [];
+    }
+    final lines = await _file
+        .openRead()
+        .transform(utf8.decoder)
+        .transform(const LineSplitter())
+        .toList();
+
+    final ops = <NotesOperation>[];
+    for (final line in lines) {
+      if (line.isEmpty) continue;
+      try {
+        final json = jsonDecode(line) as Map<String, Object?>;
+        ops.add(NotesOperation.fromJson(json));
+      } on FormatException {
+        // Torn tail: stop at the last complete record, matching what a
+        // reader restarting after a kill would see as durable.
+        break;
+      }
+    }
+    return ops;
+  }
+
+  Future<int> count() async => (await replay()).length;
+}

--- a/packages/feature_mind/lib/src/notes/domain/notes_projection.dart
+++ b/packages/feature_mind/lib/src/notes/domain/notes_projection.dart
@@ -1,0 +1,67 @@
+import 'dart:collection';
+
+import 'note.dart';
+import 'notes_operation.dart';
+
+/// The Notes read-model. `C4`: cache-only, rebuildable, disposable -- never
+/// written to directly, only ever produced by [NotesProjection.rebuild]
+/// folding the log.
+///
+/// Backed by a [SplayTreeMap] (ordered by key), not a [Map] built from hash
+/// iteration -- the same discipline `airo_mind_core::notes::NotesProjection`
+/// applies with `BTreeMap` on the Rust side (`C2` forbids `HashMap`
+/// iteration on a path whose output must be compared for equality
+/// deterministically).
+class NotesProjection {
+  NotesProjection._(this._notes);
+
+  /// Folds the log in one pass, in order. `replay_passes == 1` (`C2`): one
+  /// `for` loop over [ops], each operation visited exactly once.
+  factory NotesProjection.rebuild(List<NotesOperation> ops) {
+    final notes = SplayTreeMap<String, Note>();
+    for (final op in ops) {
+      switch (op.kind) {
+        case NoteOpKind.create:
+        case NoteOpKind.edit:
+          notes[op.id] = Note(
+            id: op.id,
+            title: op.title,
+            body: op.body,
+            updatedAtMs: op.recordedAtMs,
+          );
+        case NoteOpKind.delete:
+          notes.remove(op.id);
+      }
+    }
+    return NotesProjection._(notes);
+  }
+
+  static final NotesProjection empty = NotesProjection.rebuild(const []);
+
+  final SplayTreeMap<String, Note> _notes;
+
+  Note? get(String id) => _notes[id];
+
+  /// Every note, ordered by id -- deterministic, matching what the
+  /// `SplayTreeMap` already gives for free.
+  List<Note> get all => List.unmodifiable(_notes.values);
+
+  int get length => _notes.length;
+
+  bool get isEmpty => _notes.isEmpty;
+
+  @override
+  bool operator ==(Object other) {
+    if (other is! NotesProjection) return false;
+    if (other._notes.length != _notes.length) return false;
+    for (final entry in _notes.entries) {
+      if (other._notes[entry.key] != entry.value) return false;
+    }
+    return true;
+  }
+
+  @override
+  int get hashCode => Object.hashAllUnordered(
+    _notes.entries.map((e) => Object.hash(e.key, e.value)),
+  );
+}

--- a/packages/feature_mind/lib/src/notes/notes_capability.dart
+++ b/packages/feature_mind/lib/src/notes/notes_capability.dart
@@ -1,0 +1,57 @@
+import 'domain/notes_operation.dart';
+import 'domain/notes_operation_log.dart';
+import 'domain/notes_projection.dart';
+
+/// The Notes capability. `#1338`'s vertical slice: the one capability that
+/// exercises Operation → Persist → Replay → Projection end to end.
+///
+/// `C5`: a capability emits operations and consumes projections, nothing
+/// else. [NotesCapability] holds a [NotesOperationLog] handle and nothing
+/// else durable (`I2`, `I4`) -- every note it creates, edits, or deletes
+/// exists only as a [NotesOperation] in the log. There is no cache field on
+/// this class for [notes] to read from; every call is a fresh fold.
+class NotesCapability {
+  const NotesCapability(this._log);
+
+  final NotesOperationLog _log;
+
+  /// Emits a `create` operation. The only way a note comes into existence --
+  /// there is no direct write path to [NotesProjection].
+  Future<NotesOperation> createNote({
+    required String id,
+    required String title,
+    required String body,
+    required int recordedAtMs,
+  }) => _log.append(
+    kind: NoteOpKind.create,
+    id: id,
+    title: title,
+    body: body,
+    recordedAtMs: recordedAtMs,
+  );
+
+  Future<NotesOperation> editNote({
+    required String id,
+    required String title,
+    required String body,
+    required int recordedAtMs,
+  }) => _log.append(
+    kind: NoteOpKind.edit,
+    id: id,
+    title: title,
+    body: body,
+    recordedAtMs: recordedAtMs,
+  );
+
+  Future<NotesOperation> deleteNote({
+    required String id,
+    required int recordedAtMs,
+  }) =>
+      _log.append(kind: NoteOpKind.delete, id: id, recordedAtMs: recordedAtMs);
+
+  /// Reads the current projection. Always a fresh fold of the log -- never a
+  /// cache this capability keeps itself, because keeping one would be
+  /// exactly the durable state `C5` forbids it from owning.
+  Future<NotesProjection> notes() async =>
+      NotesProjection.rebuild(await _log.replay());
+}

--- a/packages/feature_mind/lib/src/notes/presentation/notes_screen.dart
+++ b/packages/feature_mind/lib/src/notes/presentation/notes_screen.dart
@@ -1,0 +1,142 @@
+import 'package:flutter/material.dart';
+
+import '../domain/note.dart';
+import '../domain/notes_projection.dart';
+import '../notes_capability.dart';
+
+/// The minimal Notes screen: list + create/edit. `#1338`'s UI leg of the
+/// runtime skeleton.
+///
+/// Renders from [NotesProjection], never from the operation log directly --
+/// this widget never imports [NotesOperationLog]; the only way it sees
+/// durable state is through [NotesCapability.notes]. Every mutation
+/// (`create`/`edit`/`delete`) goes back through [NotesCapability] and the
+/// screen reloads the projection afterward, rather than mutating local
+/// widget state as if it were the source of truth.
+class NotesScreen extends StatefulWidget {
+  const NotesScreen({super.key, required this.capability});
+
+  final NotesCapability capability;
+
+  @override
+  State<NotesScreen> createState() => _NotesScreenState();
+}
+
+class _NotesScreenState extends State<NotesScreen> {
+  NotesProjection _projection = NotesProjection.empty;
+  bool _loading = true;
+
+  @override
+  void initState() {
+    super.initState();
+    _reload();
+  }
+
+  Future<void> _reload() async {
+    final projection = await widget.capability.notes();
+    if (!mounted) return;
+    setState(() {
+      _projection = projection;
+      _loading = false;
+    });
+  }
+
+  Future<void> _openEditor({Note? existing}) async {
+    final titleController = TextEditingController(text: existing?.title ?? '');
+    final bodyController = TextEditingController(text: existing?.body ?? '');
+
+    final saved = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: Text(existing == null ? 'New note' : 'Edit note'),
+        content: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            TextField(
+              controller: titleController,
+              key: const Key('notes_screen_title_field'),
+              decoration: const InputDecoration(labelText: 'Title'),
+            ),
+            TextField(
+              controller: bodyController,
+              key: const Key('notes_screen_body_field'),
+              decoration: const InputDecoration(labelText: 'Body'),
+              maxLines: 3,
+            ),
+          ],
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(false),
+            child: const Text('Cancel'),
+          ),
+          FilledButton(
+            key: const Key('notes_screen_save_button'),
+            onPressed: () => Navigator.of(context).pop(true),
+            child: const Text('Save'),
+          ),
+        ],
+      ),
+    );
+
+    if (saved != true) return;
+
+    final now = DateTime.now().millisecondsSinceEpoch;
+    if (existing == null) {
+      await widget.capability.createNote(
+        id: 'note_$now',
+        title: titleController.text,
+        body: bodyController.text,
+        recordedAtMs: now,
+      );
+    } else {
+      await widget.capability.editNote(
+        id: existing.id,
+        title: titleController.text,
+        body: bodyController.text,
+        recordedAtMs: now,
+      );
+    }
+    await _reload();
+  }
+
+  Future<void> _delete(Note note) async {
+    await widget.capability.deleteNote(
+      id: note.id,
+      recordedAtMs: DateTime.now().millisecondsSinceEpoch,
+    );
+    await _reload();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Notes')),
+      body: _loading
+          ? const Center(child: CircularProgressIndicator())
+          : _projection.isEmpty
+          ? const Center(child: Text('No notes yet'))
+          : ListView.builder(
+              itemCount: _projection.all.length,
+              itemBuilder: (context, index) {
+                final note = _projection.all[index];
+                return ListTile(
+                  key: Key('notes_screen_note_${note.id}'),
+                  title: Text(note.title),
+                  subtitle: Text(note.body),
+                  onTap: () => _openEditor(existing: note),
+                  trailing: IconButton(
+                    icon: const Icon(Icons.delete_outline),
+                    onPressed: () => _delete(note),
+                  ),
+                );
+              },
+            ),
+      floatingActionButton: FloatingActionButton(
+        key: const Key('notes_screen_create_button'),
+        onPressed: () => _openEditor(),
+        child: const Icon(Icons.add),
+      ),
+    );
+  }
+}

--- a/packages/feature_mind/test/notes/notes_screen_test.dart
+++ b/packages/feature_mind/test/notes/notes_screen_test.dart
@@ -1,0 +1,165 @@
+import 'dart:io';
+
+import 'package:feature_mind/feature_mind.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  late Directory tempDir;
+  late NotesCapability capability;
+
+  setUp(() async {
+    tempDir = await Directory.systemTemp.createTemp('notes_screen_');
+    final log = await NotesOperationLog.open('${tempDir.path}/notes.log');
+    capability = NotesCapability(log);
+  });
+
+  tearDown(() async {
+    if (await tempDir.exists()) {
+      await tempDir.delete(recursive: true);
+    }
+  });
+
+  Widget wrap(Widget child) => MaterialApp(home: child);
+
+  // `NotesScreen` does real `dart:io` file I/O (through `NotesCapability` /
+  // `NotesOperationLog`) on load and after every mutation. Everything inside
+  // a `testWidgets` body -- not just `pump` calls -- runs inside
+  // `AutomatedTestWidgetsFlutterBinding`'s fake-async zone, and a real (not
+  // `Timer`-based) I/O future never resolves there: it needs an actual event
+  // -loop turn the fake zone does not deliver. Two consequences, both worked
+  // around below:
+  //
+  // - `pumpAndSettle` alone either times out (the initial load's
+  //   indeterminate `CircularProgressIndicator` schedules frames forever) or
+  //   returns before the I/O actually lands -- [settle] uses
+  //   `WidgetTester.runAsync` to step outside the fake zone so the real
+  //   future genuinely completes, then pumps to apply the `setState` it
+  //   triggered.
+  // - Any *direct* `await` on [NotesCapability] from inside a `testWidgets`
+  //   body (setup fixtures, or reading the projection to assert against) has
+  //   the same problem and needs the same `runAsync` wrapper -- see
+  //   `directly` below. `setUp`/`tearDown` are unaffected: `package:test`
+  //   runs those outside the per-test fake zone.
+  Future<void> settle(WidgetTester tester) async {
+    for (var i = 0; i < 25; i++) {
+      await tester.runAsync(
+        () => Future<void>.delayed(const Duration(milliseconds: 20)),
+      );
+      await tester.pump();
+    }
+    // Whatever is left at this point is pure animation (dialog transitions),
+    // which -- unlike the spinner above -- does settle.
+    await tester.pumpAndSettle();
+  }
+
+  /// Runs a real `NotesCapability`/`NotesOperationLog` future from inside a
+  /// `testWidgets` body, outside the fake-async zone that would otherwise
+  /// hang it forever.
+  Future<T> directly<T>(WidgetTester tester, Future<T> Function() body) async {
+    final result = await tester.runAsync(body);
+    return result as T;
+  }
+
+  testWidgets('renders from the projection: empty log shows the empty state', (
+    tester,
+  ) async {
+    await tester.pumpWidget(wrap(NotesScreen(capability: capability)));
+    await settle(tester);
+
+    expect(find.text('No notes yet'), findsOneWidget);
+  });
+
+  testWidgets(
+    'creating a note through the UI persists it and the list reflects the projection',
+    (tester) async {
+      await tester.pumpWidget(wrap(NotesScreen(capability: capability)));
+      await settle(tester);
+
+      await tester.tap(find.byKey(const Key('notes_screen_create_button')));
+      await settle(tester);
+
+      await tester.enterText(
+        find.byKey(const Key('notes_screen_title_field')),
+        'Weekend plan',
+      );
+      await tester.enterText(
+        find.byKey(const Key('notes_screen_body_field')),
+        'Hike then brunch',
+      );
+      await tester.tap(find.byKey(const Key('notes_screen_save_button')));
+      await settle(tester);
+
+      expect(find.text('Weekend plan'), findsOneWidget);
+      expect(find.text('Hike then brunch'), findsOneWidget);
+
+      // The UI's own state came from a fresh projection read, not from
+      // holding onto what it just wrote -- prove the capability's log
+      // actually has it, independent of the widget under test.
+      final projection = await directly(tester, capability.notes);
+      expect(projection.length, 1);
+      expect(projection.all.single.title, 'Weekend plan');
+    },
+  );
+
+  testWidgets('editing a note through the UI updates the projection', (
+    tester,
+  ) async {
+    await directly(
+      tester,
+      () => capability.createNote(
+        id: 'n1',
+        title: 'Original',
+        body: 'first draft',
+        recordedAtMs: 1,
+      ),
+    );
+
+    await tester.pumpWidget(wrap(NotesScreen(capability: capability)));
+    await settle(tester);
+
+    await tester.tap(find.text('Original'));
+    await settle(tester);
+
+    await tester.enterText(
+      find.byKey(const Key('notes_screen_title_field')),
+      'Revised',
+    );
+    await tester.tap(find.byKey(const Key('notes_screen_save_button')));
+    await settle(tester);
+
+    expect(find.text('Revised'), findsOneWidget);
+    expect(find.text('Original'), findsNothing);
+
+    final projection = await directly(tester, capability.notes);
+    expect(projection.get('n1')!.title, 'Revised');
+  });
+
+  testWidgets('deleting a note through the UI removes it from the projection', (
+    tester,
+  ) async {
+    await directly(
+      tester,
+      () => capability.createNote(
+        id: 'n1',
+        title: 'Gone soon',
+        body: '',
+        recordedAtMs: 1,
+      ),
+    );
+
+    await tester.pumpWidget(wrap(NotesScreen(capability: capability)));
+    await settle(tester);
+
+    expect(find.text('Gone soon'), findsOneWidget);
+
+    await tester.tap(find.byIcon(Icons.delete_outline));
+    await settle(tester);
+
+    expect(find.text('Gone soon'), findsNothing);
+    expect(find.text('No notes yet'), findsOneWidget);
+
+    final projection = await directly(tester, capability.notes);
+    expect(projection.isEmpty, isTrue);
+  });
+}

--- a/packages/feature_mind/test/notes/notes_vertical_slice_conformance_test.dart
+++ b/packages/feature_mind/test/notes/notes_vertical_slice_conformance_test.dart
@@ -1,0 +1,148 @@
+import 'dart:io';
+
+import 'package:feature_mind/feature_mind.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  late Directory tempDir;
+
+  setUp(() async {
+    tempDir = await Directory.systemTemp.createTemp('notes_vertical_slice_');
+  });
+
+  tearDown(() async {
+    if (await tempDir.exists()) {
+      await tempDir.delete(recursive: true);
+    }
+  });
+
+  /// The single most important test in `#1338`: create a note, confirm it is
+  /// durable, wipe the in-memory projection, replay the persisted
+  /// operations, and confirm the rebuilt projection is identical to what
+  /// existed before the wipe. `C4`'s "delete and rebuild with zero data
+  /// loss" and condition 5 of `#1311`, proven rather than asserted by
+  /// comment -- the Dart twin of
+  /// `airo_mind_core::notes::tests::a_note_survives_projection_deletion_and_replay`.
+  test('a note survives projection deletion and replay', () async {
+    final log = await NotesOperationLog.open('${tempDir.path}/notes.log');
+    final capability = NotesCapability(log);
+
+    await capability.createNote(
+      id: 'n1',
+      title: 'Groceries',
+      body: 'milk, eggs',
+      recordedAtMs: 1000,
+    );
+    await capability.createNote(
+      id: 'n2',
+      title: 'Throwaway',
+      body: 'delete me',
+      recordedAtMs: 2000,
+    );
+    await capability.editNote(
+      id: 'n1',
+      title: 'Groceries',
+      body: 'milk, eggs, bread',
+      recordedAtMs: 3000,
+    );
+    await capability.deleteNote(id: 'n2', recordedAtMs: 4000);
+
+    // 1. Confirm persisted: the log itself, independent of any projection,
+    //    holds every operation.
+    expect(await log.count(), 4);
+
+    // 2. The projection before the wipe.
+    final before = await capability.notes();
+    expect(before.length, 1, reason: 'n2 was deleted, only n1 should remain');
+    final n1Before = before.get('n1')!;
+    expect(n1Before.title, 'Groceries');
+    expect(n1Before.body, 'milk, eggs, bread');
+    expect(before.get('n2'), isNull);
+
+    // 3. "Wipe" the in-memory projection: nothing after this line reads
+    //    `before` again. `NotesCapability` itself holds no cache to fall
+    //    back on (`I2`, `I4`) -- the only durable copy is the log.
+
+    // 4. Replay from persisted operations and rebuild.
+    final ops = await log.replay();
+    final after = NotesProjection.rebuild(ops);
+
+    // 5. Zero data loss: identical state.
+    expect(after.get('n1'), n1Before);
+    expect(after.length, 1);
+    expect(after.get('n2'), isNull);
+    expect(after, before);
+
+    // Also identical through the capability's own read path.
+    final viaCapability = await capability.notes();
+    expect(viaCapability, after);
+  });
+
+  test(
+    'replay visits every notes operation exactly once, and rebuild is idempotent',
+    () async {
+      final log = await NotesOperationLog.open('${tempDir.path}/notes.log');
+      final capability = NotesCapability(log);
+
+      for (var i = 0; i < 25; i++) {
+        await capability.createNote(
+          id: 'n$i',
+          title: 'title $i',
+          body: 'body',
+          recordedAtMs: i,
+        );
+      }
+
+      final ops = await log.replay();
+      expect(ops.length, 25);
+
+      final first = NotesProjection.rebuild(ops);
+      final second = NotesProjection.rebuild(ops);
+      expect(first, second);
+      expect(first.length, 25);
+    },
+  );
+
+  test('reopening the log resumes sequence numbering', () async {
+    final path = '${tempDir.path}/notes.log';
+    {
+      final log = await NotesOperationLog.open(path);
+      await log.append(kind: NoteOpKind.create, id: 'a', recordedAtMs: 1);
+      await log.append(kind: NoteOpKind.create, id: 'b', recordedAtMs: 2);
+    }
+    final reopened = await NotesOperationLog.open(path);
+    final third = await reopened.append(
+      kind: NoteOpKind.create,
+      id: 'c',
+      recordedAtMs: 3,
+    );
+    expect(third.seq, 2, reason: 'sequence numbering must survive a restart');
+  });
+
+  test('a torn tail is treated as the end of the durable log', () async {
+    final path = '${tempDir.path}/notes.log';
+    final log = await NotesOperationLog.open(path);
+    await log.append(
+      kind: NoteOpKind.create,
+      id: 'whole',
+      title: 'Whole record',
+      recordedAtMs: 1,
+    );
+
+    // Simulate a crash mid-write: append a partial JSON line with no
+    // trailing newline.
+    final file = File(path);
+    await file.writeAsString('{"seq":1,"kind":"cre', mode: FileMode.append);
+
+    final recovered = await NotesOperationLog.open(path);
+    final ops = await recovered.replay();
+    expect(ops.length, 1);
+    expect(ops.first.id, 'whole');
+  });
+
+  test('empty log replays to nothing', () async {
+    final log = await NotesOperationLog.open('${tempDir.path}/notes.log');
+    expect(await log.replay(), isEmpty);
+    expect(NotesProjection.rebuild(const []), NotesProjection.empty);
+  });
+}

--- a/rust/airo_mind_core/src/content.rs
+++ b/rust/airo_mind_core/src/content.rs
@@ -1,0 +1,305 @@
+//! The content store. `#1194`'s other half of `C1`: *"the content store holds
+//! encrypted content objects and their wrapping sets"* and design doc §3.1:
+//! *"Payload behind `ContentID`, never inlined."*
+//!
+//! # What this is, and what it is not
+//!
+//! Content-addressed, deduplicating, file-backed: `put` hashes the bytes and
+//! writes them once under that hash; a second `put` of identical bytes is a
+//! no-op that returns the same [`ContentId`]. That shape is what design §4.1
+//! needs — a hospital bill wrapped by three contexts is one object, not
+//! three — even before any context ever wraps anything.
+//!
+//! It is **not encrypted yet**. §4.1's envelope encryption (`wrap(CK,
+//! ContextKey)`, the wrapping set living with the object) is Phase 1's Vault:
+//! identity and the key hierarchy do not exist in this crate, and encrypting
+//! against a key nobody can rotate or revoke would be theatre. Every object
+//! here is plaintext-on-disk today. The shape does not change when Vault
+//! lands — `put`/`get`/[`ContentId`] stay the same signatures, `put` starts
+//! sealing under a content key instead of writing bytes verbatim — which is
+//! the same "build the shape now, fill in the semantics later" trade
+//! [`crate::store::MeetingStore`]'s doc comment already makes explicit.
+//!
+//! # A known, documented gap this creates
+//!
+//! §3.1's header-disclosure rule requires `payloadHash` to cover the
+//! **ciphertext**, never the plaintext, because a plaintext hash is an
+//! equality oracle — two operations with the same hash reveal identical
+//! content even after crypto-shredding, using exactly the header field the
+//! rule was written to police. [`OperationHeader::payload_hash`] in
+//! [`crate::runtime`] currently hashes plaintext, because there is no
+//! ciphertext yet to hash. This must move the moment content encryption
+//! lands; it is called out again at that field's definition so it cannot be
+//! missed twice.
+
+use std::fs::{self, File};
+use std::io::{Read, Write};
+use std::path::{Path, PathBuf};
+
+use crate::digest::Sha256;
+
+/// A content-addressed identifier: lowercase hex SHA-256 of the object's
+/// bytes as stored (plaintext today; ciphertext once Vault lands — see the
+/// module doc). Two objects with the same bytes always share one id, which is
+/// what makes storage content-addressed rather than merely file-backed.
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct ContentId(String);
+
+impl ContentId {
+    /// For a caller that already has a hash (e.g. a header's `payload_hash`)
+    /// and wants to address the store without re-hashing. Does not verify
+    /// anything is stored under it — [`ContentStore::get`] is the only check
+    /// that matters.
+    pub fn from_hex(hex: impl Into<String>) -> Self {
+        Self(hex.into())
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl std::fmt::Display for ContentId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+#[derive(Debug)]
+pub enum ContentStoreError {
+    Io(String),
+    /// The bytes read back from disk do not hash to the file's own name.
+    /// Content-addressed storage makes this a **corruption** signal, not a
+    /// business error: nothing but disk damage or an out-of-band edit
+    /// produces it, because `put` never writes to a path whose hash does not
+    /// match.
+    Corrupt {
+        id: String,
+        found: String,
+    },
+}
+
+impl std::fmt::Display for ContentStoreError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Io(m) => write!(f, "content store I/O error: {m}"),
+            Self::Corrupt { id, found } => write!(
+                f,
+                "content object {id} is corrupt: bytes on disk hash to {found}"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for ContentStoreError {}
+
+impl From<std::io::Error> for ContentStoreError {
+    fn from(e: std::io::Error) -> Self {
+        Self::Io(e.to_string())
+    }
+}
+
+fn sha256_hex(bytes: &[u8]) -> String {
+    let mut h = Sha256::new();
+    h.update(bytes);
+    h.finish()
+}
+
+/// Content-addressed, deduplicating, file-backed. One file per distinct
+/// object, named by its own hash — a directory listing this store is already
+/// a manifest of every `ContentId` durable on this device.
+pub struct ContentStore {
+    dir: PathBuf,
+}
+
+impl ContentStore {
+    pub fn open(dir: impl Into<PathBuf>) -> Result<Self, ContentStoreError> {
+        let dir = dir.into();
+        fs::create_dir_all(&dir)?;
+        Ok(Self { dir })
+    }
+
+    fn path_for(&self, id: &ContentId) -> PathBuf {
+        self.dir.join(id.as_str())
+    }
+
+    /// Stores `bytes` under their own hash. Content-addressed: writing the
+    /// same bytes twice is idempotent and touches disk once — `put` checks
+    /// existence before writing, so a second `put` of an already-stored
+    /// object is a stat, not a write.
+    ///
+    /// Written to a temp file and renamed into place, so a reader can never
+    /// observe a partially written object at its final path — `rename` is
+    /// atomic on every platform this crate ships to.
+    pub fn put(&self, bytes: &[u8]) -> Result<ContentId, ContentStoreError> {
+        let id = ContentId(sha256_hex(bytes));
+        let path = self.path_for(&id);
+        if path.exists() {
+            return Ok(id);
+        }
+        let tmp = self
+            .dir
+            .join(format!("{}.tmp-{}", id.as_str(), std::process::id()));
+        {
+            let mut f = File::create(&tmp)?;
+            f.write_all(bytes)?;
+            f.sync_data()?;
+        }
+        fs::rename(&tmp, &path)?;
+        Ok(id)
+    }
+
+    /// Reads an object back, verifying it still hashes to its own name.
+    /// `None` if nothing is stored under `id` — a missing object is a normal
+    /// outcome (never written, or already destroyed), distinct from
+    /// [`ContentStoreError::Corrupt`], which means something *is* there and
+    /// it is wrong.
+    pub fn get(&self, id: &ContentId) -> Result<Option<Vec<u8>>, ContentStoreError> {
+        let path = self.path_for(id);
+        let mut file = match File::open(&path) {
+            Ok(f) => f,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+            Err(e) => return Err(e.into()),
+        };
+        let mut bytes = Vec::new();
+        file.read_to_end(&mut bytes)?;
+        let found = sha256_hex(&bytes);
+        if found != id.as_str() {
+            return Err(ContentStoreError::Corrupt {
+                id: id.to_string(),
+                found,
+            });
+        }
+        Ok(Some(bytes))
+    }
+
+    pub fn contains(&self, id: &ContentId) -> bool {
+        self.path_for(id).exists()
+    }
+
+    /// Deletes the local blob. `#1194`'s mechanical half of `DestroyContent`
+    /// (design §4.3 step 3): removing the encrypted blob. The rest of §4.3 —
+    /// destroying every wrapping, appending `RevokeContentKey`, sweeping
+    /// derived state — needs the Vault's revocation ledger and does not exist
+    /// in this crate yet; a caller relying on this alone for real destruction
+    /// is relying on convention, exactly as `crate::runtime`'s module doc and
+    /// design §4.3's own closing paragraph already say plainly.
+    ///
+    /// Idempotent: removing an already-absent object is not an error, the
+    /// same "no file yet is empty, not broken" discipline
+    /// [`crate::store::MeetingStore`] uses.
+    pub fn remove(&self, id: &ContentId) -> Result<(), ContentStoreError> {
+        match fs::remove_file(self.path_for(id)) {
+            Ok(()) => Ok(()),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(e) => Err(e.into()),
+        }
+    }
+
+    pub fn dir(&self) -> &Path {
+        &self.dir
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn temp_dir(name: &str) -> PathBuf {
+        let unique = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        std::env::temp_dir().join(format!("airo_mind_content_{name}_{unique}"))
+    }
+
+    #[test]
+    fn put_then_get_round_trips() {
+        let dir = temp_dir("roundtrip");
+        let store = ContentStore::open(&dir).unwrap();
+        let id = store.put(b"hello content").unwrap();
+        assert_eq!(store.get(&id).unwrap().unwrap(), b"hello content");
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    /// Design §4.1: content is addressed by its own bytes, so identical
+    /// objects always collapse to one id and one file on disk.
+    #[test]
+    fn identical_bytes_deduplicate_to_the_same_id_and_one_file() {
+        let dir = temp_dir("dedup");
+        let store = ContentStore::open(&dir).unwrap();
+        let first = store.put(b"same bytes").unwrap();
+        let second = store.put(b"same bytes").unwrap();
+        assert_eq!(first, second);
+        assert_eq!(fs::read_dir(&dir).unwrap().count(), 1);
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn different_bytes_get_different_ids() {
+        let dir = temp_dir("distinct");
+        let store = ContentStore::open(&dir).unwrap();
+        let a = store.put(b"a").unwrap();
+        let b = store.put(b"b").unwrap();
+        assert_ne!(a, b);
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn a_missing_object_is_none_not_an_error() {
+        let dir = temp_dir("missing");
+        let store = ContentStore::open(&dir).unwrap();
+        let ghost = ContentId::from_hex("0".repeat(64));
+        assert!(store.get(&ghost).unwrap().is_none());
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    /// The corruption case: a file on disk whose bytes no longer hash to its
+    /// own filename. Content-addressed storage turns this into a checkable
+    /// fact instead of a silent wrong-content bug.
+    #[test]
+    fn tampered_bytes_are_detected_as_corruption_not_returned_silently() {
+        let dir = temp_dir("corrupt");
+        let store = ContentStore::open(&dir).unwrap();
+        let id = store.put(b"original").unwrap();
+        fs::write(dir.join(id.as_str()), b"tampered").unwrap();
+
+        let err = store.get(&id).unwrap_err();
+        assert!(matches!(err, ContentStoreError::Corrupt { .. }));
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    /// `#1194` / design §4.3 step 3: the mechanical piece of `DestroyContent`
+    /// this crate can perform today.
+    #[test]
+    fn remove_deletes_the_blob_and_is_idempotent() {
+        let dir = temp_dir("remove");
+        let store = ContentStore::open(&dir).unwrap();
+        let id = store.put(b"to be destroyed").unwrap();
+        assert!(store.contains(&id));
+
+        store.remove(&id).unwrap();
+        assert!(!store.contains(&id));
+        assert!(store.get(&id).unwrap().is_none());
+
+        // Removing again is not an error.
+        store.remove(&id).unwrap();
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    /// A store reopened at the same path (a restarted process) sees what an
+    /// earlier handle wrote — the durability property the operation log
+    /// already proves for itself, needed here too because content is the
+    /// other durable store `C1` names.
+    #[test]
+    fn content_survives_reopening_the_store() {
+        let dir = temp_dir("reopen");
+        let id = {
+            let store = ContentStore::open(&dir).unwrap();
+            store.put(b"persisted").unwrap()
+        };
+        let reopened = ContentStore::open(&dir).unwrap();
+        assert_eq!(reopened.get(&id).unwrap().unwrap(), b"persisted");
+        let _ = fs::remove_dir_all(&dir);
+    }
+}

--- a/rust/airo_mind_core/src/lib.rs
+++ b/rust/airo_mind_core/src/lib.rs
@@ -57,6 +57,15 @@ pub mod engine;
 /// `#1302`'s half of `C6` — see the module docs for why this is split from
 /// [`supervisor`], which owns `#1396`'s per-call job execution.
 pub mod lifecycle;
+
+/// The Notes capability (`#1338`) — the one capability the runtime skeleton
+/// exercises. Emits operations, reads a projection, holds nothing durable of
+/// its own.
+pub mod notes;
+
+/// The `#1338` runtime skeleton: `Operation → Persist → Replay → Projection`,
+/// wired through [`lifecycle::EngineRegistry`] rather than around it.
+pub mod runtime;
 pub mod search;
 pub mod store;
 pub mod supervisor;
@@ -75,6 +84,10 @@ pub use engine::{
 };
 pub use lifecycle::{
     EngineMetrics, EngineName, EngineState, GroupCommitBuffer, LifecycleError, ManagedEngine,
+};
+pub use notes::{Note, NotesCapability, NotesProjection, NOTES_CAPABILITY};
+pub use runtime::{
+    Operation, OperationLog, OperationLogError, Projection, Runtime, RuntimeApiError,
 };
 pub use search::{Hit, SearchIndex};
 pub use store::{Meeting, MeetingStore, StoreError};

--- a/rust/airo_mind_core/src/lib.rs
+++ b/rust/airo_mind_core/src/lib.rs
@@ -51,6 +51,10 @@ pub mod models;
 
 pub mod budget;
 pub mod cancel;
+
+/// Content-addressed storage. `#1194`'s content-store half of `C1`: payload
+/// held out of line, addressed by [`content::ContentId`].
+pub mod content;
 pub mod engine;
 
 /// Engine lifecycle: state, dependency ordering, and graceful shutdown.
@@ -63,12 +67,26 @@ pub mod lifecycle;
 /// its own.
 pub mod notes;
 
-/// The `#1338` runtime skeleton: `Operation → Persist → Replay → Projection`,
-/// wired through [`lifecycle::EngineRegistry`] rather than around it.
+/// The generalized projection engine. `#1195`'s condition-5 machinery:
+/// [`projection::EntityGraphProjection`], the multi-capability projection
+/// that proves delete-and-rebuild is a property of the engine, not an
+/// accident of Notes' own shape.
+pub mod projection;
+
+/// The `Operation → Persist → Replay → Projection` substrate, formalized
+/// against `C1`/`C2` for `#1194`/`#1195`, wired through
+/// [`lifecycle::EngineRegistry`] rather than around it.
 pub mod runtime;
 pub mod search;
+
+/// Operation signing. `#1194`'s `signature` header field — see the module
+/// doc for exactly what this proves today and what it does not.
+pub mod signing;
 pub mod store;
 pub mod supervisor;
+
+/// The fixed, nineteen-verb runtime vocabulary `#1194`'s scope table names.
+pub mod verb;
 
 /// WAV decoding for the capability layer. A container format is an input
 /// detail, not part of the runtime's surface, so it is reachable only from the
@@ -77,6 +95,7 @@ pub mod wav;
 
 pub use budget::{ResourceBudget, ResourceRequest};
 pub use cancel::CancelToken;
+pub use content::{ContentId, ContentStore, ContentStoreError};
 pub use digest::file_digest;
 pub use engine::{
     AudioInput, EngineError, GenerationChunk, GenerationEngine, GenerationRequest, RuntimeStats,
@@ -86,9 +105,15 @@ pub use lifecycle::{
     EngineMetrics, EngineName, EngineState, GroupCommitBuffer, LifecycleError, ManagedEngine,
 };
 pub use notes::{Note, NotesCapability, NotesProjection, NOTES_CAPABILITY};
+pub use projection::{
+    encode_relation, encode_set_property, rebuild_from_scratch, EntityGraphProjection, EntityRecord,
+};
 pub use runtime::{
-    Operation, OperationLog, OperationLogError, Projection, Runtime, RuntimeApiError,
+    AppendRequest, Operation, OperationLog, OperationLogError, OperationRequest, Projection,
+    ReplayVerifyError, Runtime, RuntimeApiError,
 };
 pub use search::{Hit, SearchIndex};
+pub use signing::{DeviceKeySigner, Signer, SignerVerifier, Verifier};
 pub use store::{Meeting, MeetingStore, StoreError};
 pub use supervisor::{RuntimeError, Supervisor};
+pub use verb::{Verb, VerbPrimitive};

--- a/rust/airo_mind_core/src/lib.rs
+++ b/rust/airo_mind_core/src/lib.rs
@@ -52,6 +52,11 @@ pub mod models;
 pub mod budget;
 pub mod cancel;
 pub mod engine;
+
+/// Engine lifecycle: state, dependency ordering, and graceful shutdown.
+/// `#1302`'s half of `C6` — see the module docs for why this is split from
+/// [`supervisor`], which owns `#1396`'s per-call job execution.
+pub mod lifecycle;
 pub mod search;
 pub mod store;
 pub mod supervisor;
@@ -67,6 +72,9 @@ pub use digest::file_digest;
 pub use engine::{
     AudioInput, EngineError, GenerationChunk, GenerationEngine, GenerationRequest, RuntimeStats,
     SpeechEngine, TranscriptSegment,
+};
+pub use lifecycle::{
+    EngineMetrics, EngineName, EngineState, GroupCommitBuffer, LifecycleError, ManagedEngine,
 };
 pub use search::{Hit, SearchIndex};
 pub use store::{Meeting, MeetingStore, StoreError};

--- a/rust/airo_mind_core/src/lifecycle.rs
+++ b/rust/airo_mind_core/src/lifecycle.rs
@@ -1,0 +1,564 @@
+//! Engine lifecycle: state, dependency ordering, and graceful shutdown.
+//!
+//! `C6`: *"every engine requests resources; the Supervisor grants them,"* and
+//! specifically the half of that contract [`supervisor`] did not yet cover --
+//! `#1396` scoped the Supervisor to two job slots (speech, generation)
+//! executing one pipeline. This module is the generalization `#1302` asks
+//! for: an arbitrary number of **stateful** engines -- Vault, Replay, Sync,
+//! Projection, and so on, per the diagram in `#1302` -- each with a lifecycle
+//! (start, stop, restart), a place in a dependency order, and a health state
+//! the Supervisor can report without guessing.
+//!
+//! # Why this is a separate concern from job execution
+//!
+//! [`SpeechEngine`](crate::engine::SpeechEngine) and
+//! [`GenerationEngine`](crate::engine::GenerationEngine) are **stateless per
+//! call**: `transcribe`/`generate` run to completion or cancellation and hold
+//! no state between calls. Vault, Replay, Sync, and Projection are the
+//! opposite -- they are **started once and run for the life of the process**,
+//! and other engines depend on them being up. Modeling both as the same kind
+//! of "engine" would force a job-shaped API onto a service-shaped problem, or
+//! vice versa. `C6` owns both; this module is the second half.
+//!
+//! # What this deliberately does not do
+//!
+//! It does not implement Vault, Replay, Sync, or Projection -- those are
+//! `#1338`'s vertical slice, greenfield today. This module is the contract
+//! shape they will register into: a real dependency graph, real state
+//! transitions, and a real graceful-shutdown path, proven here against fake
+//! engines the same way [`supervisor`]'s job tests use `FakeSpeech`.
+
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicU32, AtomicU64, Ordering};
+use std::sync::Mutex;
+
+use crate::engine::EngineError;
+
+/// A registered engine's name. `&'static str` rather than an enum: the six
+/// Phase 1-9 engines (Vault, Replay, Sync, Projection, AI, Capture) are not
+/// exhaustive, and a new one should be a registration call, not an enum
+/// variant added to this crate.
+pub type EngineName = &'static str;
+
+/// Where an engine is in its lifecycle. `C6`: *"health -- which engines are
+/// up, which are degraded."*
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum EngineState {
+    /// Registered, never started.
+    NotStarted,
+    /// `start()` is running.
+    Starting,
+    /// Started and healthy. Its dependents may start.
+    Running,
+    /// `stop()` is running.
+    Stopping,
+    /// Stopped cleanly. Distinct from `Failed`: a stopped engine chose to
+    /// stop, a failed one did not.
+    Stopped,
+    /// `start()` or `stop()` returned an error. Degraded, per `C6`'s health
+    /// vocabulary -- not a panic, not silently `Stopped`.
+    Failed,
+}
+
+/// A stateful engine the Supervisor starts once and runs for the life of the
+/// process. Unlike [`SpeechEngine`](crate::engine::SpeechEngine), there is no
+/// per-call input/output -- `start` brings it up, `stop` brings it down, and
+/// whatever work it does in between is its own concern.
+pub trait ManagedEngine: Send + Sync {
+    /// Brings the engine up. Called only after every dependency is
+    /// [`EngineState::Running`] -- an engine implementation never has to
+    /// check its own dependencies are ready.
+    fn start(&self) -> Result<(), EngineError>;
+
+    /// Brings the engine down. Infallible: `C6`'s graceful shutdown must
+    /// complete even if a subsystem is unhappy about being stopped, because
+    /// the alternative is a shutdown that hangs or a segment that is never
+    /// sealed.
+    fn stop(&self);
+}
+
+/// What the Supervisor knows about one engine beyond its current state.
+/// `C6`: *"metrics -- one place that knows operations/sec and memory, rather
+/// than six."* `ops` and `elapsed since `started_at`* give a caller
+/// operations/sec without this module inventing a policy for how often to
+/// sample it; `restarts` is what turns "an engine restarted" from a log line
+/// grepped for after the fact into a queryable fact.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct EngineMetrics {
+    pub ops: u64,
+    pub restarts: u32,
+}
+
+struct ManagedSlot {
+    depends_on: Vec<EngineName>,
+    state: EngineState,
+    engine: Box<dyn ManagedEngine>,
+    ops: AtomicU64,
+    restarts: u32,
+}
+
+/// Errors specific to lifecycle management. Folded into
+/// [`RuntimeError`](crate::supervisor::RuntimeError) at the Supervisor
+/// boundary so callers see one error type.
+#[derive(Debug, PartialEq, Eq)]
+pub enum LifecycleError {
+    /// No engine was registered under this name.
+    UnknownEngine(EngineName),
+    /// `start` was called before every dependency reached `Running`. `C6`:
+    /// *"dependency ordering is enforced: Vault before Replay before
+    /// Projection."*
+    DependencyNotReady {
+        engine: EngineName,
+        waiting_on: EngineName,
+    },
+    /// The engine's own `start` or `stop` returned an error.
+    Engine(EngineError),
+}
+
+impl std::fmt::Display for LifecycleError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::UnknownEngine(name) => write!(f, "no engine registered as {name:?}"),
+            Self::DependencyNotReady { engine, waiting_on } => {
+                write!(f, "{engine:?} cannot start: {waiting_on:?} is not Running")
+            }
+            Self::Engine(e) => write!(f, "{e}"),
+        }
+    }
+}
+
+impl std::error::Error for LifecycleError {}
+
+/// The dependency-ordered registry of stateful engines. Owned by
+/// [`Supervisor`](crate::supervisor::Supervisor); kept as its own type
+/// because the graph algorithms (dependency checks, reverse-order shutdown)
+/// are a self-contained concern that does not need to know about
+/// [`ResourceBudget`](crate::budget::ResourceBudget) or job admission.
+#[derive(Default)]
+pub struct EngineRegistry {
+    // `Vec` preserves registration order, which doubles as the deterministic
+    // tie-break for shutdown ordering among engines with no dependency
+    // relationship to each other.
+    slots: Vec<(EngineName, Mutex<ManagedSlot>)>,
+}
+
+impl EngineRegistry {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Registers an engine with its dependencies. Panics on a duplicate name
+    /// or an unregistered dependency -- both are programmer errors caught at
+    /// startup, not conditions a caller should be asked to handle at every
+    /// call site.
+    pub fn register(
+        &mut self,
+        name: EngineName,
+        depends_on: &[EngineName],
+        engine: Box<dyn ManagedEngine>,
+    ) {
+        assert!(
+            self.index_of(name).is_none(),
+            "engine {name:?} is already registered"
+        );
+        for dep in depends_on {
+            assert!(
+                self.index_of(dep).is_some(),
+                "engine {name:?} depends on unregistered engine {dep:?} -- register dependencies first"
+            );
+        }
+        self.slots.push((
+            name,
+            Mutex::new(ManagedSlot {
+                depends_on: depends_on.to_vec(),
+                state: EngineState::NotStarted,
+                engine,
+                ops: AtomicU64::new(0),
+                restarts: 0,
+            }),
+        ));
+    }
+
+    fn index_of(&self, name: EngineName) -> Option<usize> {
+        self.slots.iter().position(|(n, _)| *n == name)
+    }
+
+    /// Starts one engine. Refuses if any dependency is not `Running` -- this
+    /// is what makes "Vault before Replay before Projection" an enforced
+    /// order rather than a comment.
+    pub fn start(&self, name: EngineName) -> Result<(), LifecycleError> {
+        let idx = self
+            .index_of(name)
+            .ok_or(LifecycleError::UnknownEngine(name))?;
+
+        // Dependency check reads other slots' state before locking this one,
+        // so a dependency that is itself being started concurrently is not
+        // deadlocked against.
+        {
+            let (_, slot) = &self.slots[idx];
+            let deps = slot.lock().unwrap().depends_on.clone();
+            for dep in &deps {
+                let dep_idx = self.index_of(dep).expect("validated at registration");
+                let dep_state = self.slots[dep_idx].1.lock().unwrap().state;
+                if dep_state != EngineState::Running {
+                    return Err(LifecycleError::DependencyNotReady {
+                        engine: name,
+                        waiting_on: dep,
+                    });
+                }
+            }
+        }
+
+        let (_, slot) = &self.slots[idx];
+        let mut guard = slot.lock().unwrap();
+        guard.state = EngineState::Starting;
+        let engine_ref = &guard.engine;
+        match engine_ref.start() {
+            Ok(()) => {
+                guard.state = EngineState::Running;
+                Ok(())
+            }
+            Err(e) => {
+                guard.state = EngineState::Failed;
+                Err(LifecycleError::Engine(e))
+            }
+        }
+    }
+
+    /// Stops one engine unconditionally. Callers that must respect dependency
+    /// order (a running Vault while Replay still depends on it) use
+    /// [`Self::shutdown_all`], which computes that order; a targeted `stop`
+    /// is for the restart path, where the caller already knows what depends
+    /// on what.
+    pub fn stop(&self, name: EngineName) -> Result<(), LifecycleError> {
+        let idx = self
+            .index_of(name)
+            .ok_or(LifecycleError::UnknownEngine(name))?;
+        let (_, slot) = &self.slots[idx];
+        let mut guard = slot.lock().unwrap();
+        guard.state = EngineState::Stopping;
+        guard.engine.stop();
+        guard.state = EngineState::Stopped;
+        Ok(())
+    }
+
+    /// Stops then starts one engine. `C6` / S4: *"a failed engine restarts
+    /// without corrupting the state of the engines around it"* -- this
+    /// touches only `name`'s slot; every other slot's state and metrics are
+    /// untouched, which is the property the conformance test asserts.
+    pub fn restart(&self, name: EngineName) -> Result<(), LifecycleError> {
+        let idx = self
+            .index_of(name)
+            .ok_or(LifecycleError::UnknownEngine(name))?;
+        self.stop(name)?;
+        let result = self.start(name);
+        self.slots[idx].1.lock().unwrap().restarts += 1;
+        result
+    }
+
+    /// Current state of one engine, or `None` if nothing is registered under
+    /// that name.
+    pub fn state_of(&self, name: EngineName) -> Option<EngineState> {
+        let idx = self.index_of(name)?;
+        Some(self.slots[idx].1.lock().unwrap().state)
+    }
+
+    /// Every registered engine's health, in registration order. `C6`:
+    /// *"health -- which engines are up, which are degraded."*
+    pub fn health(&self) -> Vec<(EngineName, EngineState)> {
+        self.slots
+            .iter()
+            .map(|(name, slot)| (*name, slot.lock().unwrap().state))
+            .collect()
+    }
+
+    /// Records one unit of work against an engine, for the operations/sec
+    /// half of `C6`'s metrics guarantee.
+    pub fn record_op(&self, name: EngineName) {
+        if let Some(idx) = self.index_of(name) {
+            self.slots[idx]
+                .1
+                .lock()
+                .unwrap()
+                .ops
+                .fetch_add(1, Ordering::Relaxed);
+        }
+    }
+
+    pub fn metrics_of(&self, name: EngineName) -> Option<EngineMetrics> {
+        let idx = self.index_of(name)?;
+        let guard = self.slots[idx].1.lock().unwrap();
+        Some(EngineMetrics {
+            ops: guard.ops.load(Ordering::Relaxed),
+            restarts: guard.restarts,
+        })
+    }
+
+    /// Stops every `Running` engine in **reverse dependency order** -- a
+    /// dependent stops before what it depends on, so nothing is left
+    /// running against a Vault that already went down. `C6`: *"shutdown is
+    /// graceful ... no half-applied revocation, no torn projection."*
+    ///
+    /// Engines that were never started, or already stopped, are left alone.
+    pub fn shutdown_all(&self) {
+        for name in self.reverse_dependency_order() {
+            let idx = self.index_of(name).expect("just enumerated");
+            let mut guard = self.slots[idx].1.lock().unwrap();
+            if guard.state == EngineState::Running {
+                guard.state = EngineState::Stopping;
+                guard.engine.stop();
+                guard.state = EngineState::Stopped;
+            }
+        }
+    }
+
+    /// Topological order (dependencies before dependents), reversed. A
+    /// dependent always appears before what it depends on -- the order
+    /// [`Self::shutdown_all`] needs, and the order [`Self::start`] would need
+    /// too if a caller wanted "start everything" rather than one engine at a
+    /// time.
+    fn reverse_dependency_order(&self) -> Vec<EngineName> {
+        let mut in_degree: HashMap<EngineName, usize> = HashMap::new();
+        let mut dependents: HashMap<EngineName, Vec<EngineName>> = HashMap::new();
+        for (name, slot) in &self.slots {
+            in_degree.entry(name).or_insert(0);
+            for dep in &slot.lock().unwrap().depends_on {
+                *in_degree.entry(name).or_insert(0) += 1;
+                dependents.entry(*dep).or_default().push(*name);
+            }
+        }
+
+        // Kahn's algorithm, seeded in registration order so ties are
+        // deterministic rather than HashMap-order-dependent (`C2`'s
+        // determinism discipline applies here too: this is control-plane
+        // ordering, not replay, but a nondeterministic shutdown order is
+        // exactly the kind of flake that discipline exists to prevent).
+        let mut ready: Vec<EngineName> = self
+            .slots
+            .iter()
+            .map(|(name, _)| *name)
+            .filter(|name| in_degree[name] == 0)
+            .collect();
+        let mut order = Vec::with_capacity(self.slots.len());
+        while let Some(name) = ready.first().copied() {
+            ready.remove(0);
+            order.push(name);
+            if let Some(next) = dependents.get(name) {
+                for dependent in next {
+                    let entry = in_degree.get_mut(dependent).unwrap();
+                    *entry -= 1;
+                    if *entry == 0 {
+                        ready.push(*dependent);
+                    }
+                }
+            }
+        }
+        order.reverse();
+        order
+    }
+}
+
+/// A stand-in for the operation log's group-commit buffer (`C1`). The real
+/// log is `#1338`'s -- Phase 2 in the roadmap -- but `C6`'s graceful-shutdown
+/// guarantee ("the group-commit buffer flushes and the active segment
+/// seals") is the Supervisor's to coordinate regardless of what backs the
+/// buffer, so the coordination is proven here against this minimal stand-in.
+/// When the real log lands, this struct is deleted and the Supervisor's
+/// shutdown path points at it instead -- the call sites do not change.
+pub struct GroupCommitBuffer {
+    pending: Mutex<Vec<u8>>,
+    flushed: Mutex<Vec<u8>>,
+    sealed: std::sync::atomic::AtomicBool,
+}
+
+impl Default for GroupCommitBuffer {
+    fn default() -> Self {
+        Self {
+            pending: Mutex::new(Vec::new()),
+            flushed: Mutex::new(Vec::new()),
+            sealed: std::sync::atomic::AtomicBool::new(false),
+        }
+    }
+}
+
+impl GroupCommitBuffer {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Buffers a write the way a group-commit window would, before its
+    /// bounded flush interval elapses.
+    pub fn write(&self, bytes: &[u8]) {
+        self.pending.lock().unwrap().extend_from_slice(bytes);
+    }
+
+    /// Moves every pending byte to the durable side atomically -- there is
+    /// no window in which some pending bytes are durable and others are not,
+    /// which is what "recovers cleanly on next start" requires: a reader
+    /// after `flush` sees everything or (before `flush` is called) nothing
+    /// pending, never a partial write.
+    pub fn flush(&self) {
+        let mut pending = self.pending.lock().unwrap();
+        let mut flushed = self.flushed.lock().unwrap();
+        flushed.extend(pending.drain(..));
+    }
+
+    /// Seals the active segment. Called after `flush`, never before -- a
+    /// segment sealed with unflushed bytes still pending is exactly the torn
+    /// state this exists to prevent.
+    pub fn seal(&self) {
+        self.sealed.store(true, Ordering::SeqCst);
+    }
+
+    pub fn is_sealed(&self) -> bool {
+        self.sealed.load(Ordering::SeqCst)
+    }
+
+    /// What a fresh reader would see on restart: the durable bytes only.
+    pub fn durable(&self) -> Vec<u8> {
+        self.flushed.lock().unwrap().clone()
+    }
+
+    /// What is buffered but not yet durable. Exposed for the conformance
+    /// test to prove `flush` leaves nothing behind, not for production use.
+    pub fn pending_len(&self) -> usize {
+        self.pending.lock().unwrap().len()
+    }
+}
+
+/// A per-Supervisor concurrency cap. `C6` / `#1302`: *"resource limits --
+/// memory ceilings and concurrency caps, enforced centrally."* The memory
+/// half already existed in [`ResourceBudget`](crate::budget::ResourceBudget);
+/// this is the concurrency half, admission-checked the same way -- refused
+/// before the engine runs, not torn down after it is already using the CPU.
+pub struct ConcurrencyLimiter {
+    max: u32,
+    active: AtomicU32,
+}
+
+/// Held for the duration of one admitted job. Dropping it -- including via
+/// an early return or a panic unwind -- releases the slot, so a job that
+/// errors out cannot leak capacity that starves every job after it.
+pub struct ConcurrencySlot<'a>(&'a AtomicU32);
+
+impl Drop for ConcurrencySlot<'_> {
+    fn drop(&mut self) {
+        self.0.fetch_sub(1, Ordering::SeqCst);
+    }
+}
+
+impl ConcurrencyLimiter {
+    pub fn new(max: u32) -> Self {
+        Self {
+            max,
+            active: AtomicU32::new(0),
+        }
+    }
+
+    pub fn unbounded() -> Self {
+        Self::new(u32::MAX)
+    }
+
+    /// Admits one job if under the cap, incrementing `active` atomically so
+    /// two callers racing to take the last slot cannot both succeed.
+    pub fn admit(&self) -> Result<ConcurrencySlot<'_>, (u32, u32)> {
+        loop {
+            let current = self.active.load(Ordering::SeqCst);
+            if current >= self.max {
+                return Err((current, self.max));
+            }
+            if self
+                .active
+                .compare_exchange(current, current + 1, Ordering::SeqCst, Ordering::SeqCst)
+                .is_ok()
+            {
+                return Ok(ConcurrencySlot(&self.active));
+            }
+        }
+    }
+
+    pub fn active(&self) -> u32 {
+        self.active.load(Ordering::SeqCst)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct FakeManaged {
+        fail: bool,
+    }
+
+    impl ManagedEngine for FakeManaged {
+        fn start(&self) -> Result<(), EngineError> {
+            if self.fail {
+                Err(EngineError::Backend("fake failure".into()))
+            } else {
+                Ok(())
+            }
+        }
+
+        fn stop(&self) {}
+    }
+
+    fn ok() -> Box<dyn ManagedEngine> {
+        Box::new(FakeManaged { fail: false })
+    }
+
+    #[test]
+    fn a_dependent_refuses_to_start_before_its_dependency_is_running() {
+        let mut reg = EngineRegistry::new();
+        reg.register("vault", &[], ok());
+        reg.register("replay", &["vault"], ok());
+
+        let err = reg.start("replay").unwrap_err();
+        assert_eq!(
+            err,
+            LifecycleError::DependencyNotReady {
+                engine: "replay",
+                waiting_on: "vault",
+            }
+        );
+        assert_eq!(reg.state_of("replay"), Some(EngineState::NotStarted));
+    }
+
+    #[test]
+    fn vault_before_replay_before_projection() {
+        let mut reg = EngineRegistry::new();
+        reg.register("vault", &[], ok());
+        reg.register("replay", &["vault"], ok());
+        reg.register("projection", &["replay"], ok());
+
+        assert!(reg.start("replay").is_err());
+        assert!(reg.start("projection").is_err());
+
+        reg.start("vault").unwrap();
+        assert_eq!(reg.state_of("vault"), Some(EngineState::Running));
+        assert!(
+            reg.start("projection").is_err(),
+            "projection depends on replay, not just vault"
+        );
+
+        reg.start("replay").unwrap();
+        reg.start("projection").unwrap();
+        assert_eq!(reg.state_of("projection"), Some(EngineState::Running));
+    }
+
+    #[test]
+    fn an_unknown_engine_is_a_refusal_not_a_panic() {
+        let reg = EngineRegistry::new();
+        assert_eq!(
+            reg.start("nothing"),
+            Err(LifecycleError::UnknownEngine("nothing"))
+        );
+    }
+
+    #[test]
+    fn a_start_failure_reports_failed_health() {
+        let mut reg = EngineRegistry::new();
+        reg.register("flaky", &[], Box::new(FakeManaged { fail: true }));
+        assert!(reg.start("flaky").is_err());
+        assert_eq!(reg.state_of("flaky"), Some(EngineState::Failed));
+    }
+}

--- a/rust/airo_mind_core/src/lifecycle.rs
+++ b/rust/airo_mind_core/src/lifecycle.rs
@@ -22,11 +22,15 @@
 //!
 //! # What this deliberately does not do
 //!
-//! It does not implement Vault, Replay, Sync, or Projection -- those are
-//! `#1338`'s vertical slice, greenfield today. This module is the contract
-//! shape they will register into: a real dependency graph, real state
-//! transitions, and a real graceful-shutdown path, proven here against fake
-//! engines the same way [`supervisor`]'s job tests use `FakeSpeech`.
+//! It does not implement Sync -- that is still future work. `#1338`'s
+//! runtime skeleton (`crate::runtime`) registers Vault, Replay, and the
+//! (deliberately empty) Projection engine into this registry -- a minimal
+//! lifecycle placeholder for Vault, a real file-backed operation log for
+//! Replay, nothing at all for Projection but the lifecycle slot itself. This
+//! module is the contract shape they register into: a real dependency graph,
+//! real state transitions, and a real graceful-shutdown path, proven here
+//! against fake engines the same way [`supervisor`]'s job tests use
+//! `FakeSpeech`.
 
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicU32, AtomicU64, Ordering};

--- a/rust/airo_mind_core/src/notes.rs
+++ b/rust/airo_mind_core/src/notes.rs
@@ -1,0 +1,429 @@
+//! The Notes capability. `#1338`'s vertical slice: the one capability that
+//! exercises `Operation → Persist → Replay → Projection` end to end.
+//!
+//! `C5`: a capability emits operations and consumes projections, nothing
+//! else. [`NotesCapability`] holds a `&Runtime` and nothing durable of its
+//! own (`I2`, `I4`) — every note it creates, edits, or deletes exists only
+//! as an [`crate::runtime::Operation`] in [`Runtime`]'s log. Delete the
+//! [`NotesProjection`] this module returns and rebuild it from
+//! [`Runtime::replay`]; the result is required to be identical, and the
+//! conformance test in this module's `tests` proves it, not documents it.
+
+use std::collections::BTreeMap;
+
+use crate::runtime::{Operation, Projection, Runtime, RuntimeApiError};
+
+/// The capability name every Notes operation is tagged with in the log.
+pub const NOTES_CAPABILITY: &str = "notes";
+
+const KIND_CREATE: &str = "note.create";
+const KIND_EDIT: &str = "note.edit";
+const KIND_DELETE: &str = "note.delete";
+
+/// One note mutation, as the capability encodes it into an operation's
+/// payload. The runtime never decodes this — `C5`: it knows no domains.
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum NoteOp {
+    Create {
+        id: String,
+        title: String,
+        body: String,
+    },
+    Edit {
+        id: String,
+        title: String,
+        body: String,
+    },
+    Delete {
+        id: String,
+    },
+}
+
+impl NoteOp {
+    fn kind(&self) -> &'static str {
+        match self {
+            Self::Create { .. } => KIND_CREATE,
+            Self::Edit { .. } => KIND_EDIT,
+            Self::Delete { .. } => KIND_DELETE,
+        }
+    }
+
+    /// Hand-rolled, matching [`crate::runtime`]'s wire-format discipline:
+    /// this crate carries zero dependencies, so no serde. `id`/`title`/`body`
+    /// are each length-prefixed UTF-8.
+    fn encode(&self) -> Vec<u8> {
+        match self {
+            Self::Create { id, title, body } | Self::Edit { id, title, body } => {
+                let mut out = Vec::new();
+                push_str(&mut out, id);
+                push_str(&mut out, title);
+                push_str(&mut out, body);
+                out
+            }
+            Self::Delete { id } => {
+                let mut out = Vec::new();
+                push_str(&mut out, id);
+                out
+            }
+        }
+    }
+
+    fn decode(kind: &str, payload: &[u8]) -> Option<Self> {
+        let mut pos = 0usize;
+        match kind {
+            KIND_CREATE | KIND_EDIT => {
+                let id = pop_str(payload, &mut pos)?;
+                let title = pop_str(payload, &mut pos)?;
+                let body = pop_str(payload, &mut pos)?;
+                Some(if kind == KIND_CREATE {
+                    Self::Create { id, title, body }
+                } else {
+                    Self::Edit { id, title, body }
+                })
+            }
+            KIND_DELETE => {
+                let id = pop_str(payload, &mut pos)?;
+                Some(Self::Delete { id })
+            }
+            _ => None,
+        }
+    }
+}
+
+fn push_str(out: &mut Vec<u8>, s: &str) {
+    let bytes = s.as_bytes();
+    out.extend_from_slice(&(bytes.len() as u32).to_be_bytes());
+    out.extend_from_slice(bytes);
+}
+
+fn pop_str(bytes: &[u8], pos: &mut usize) -> Option<String> {
+    let len_bytes: [u8; 4] = bytes.get(*pos..*pos + 4)?.try_into().ok()?;
+    let len = u32::from_be_bytes(len_bytes) as usize;
+    *pos += 4;
+    let s = bytes.get(*pos..*pos + len)?;
+    *pos += len;
+    String::from_utf8(s.to_vec()).ok()
+}
+
+/// One note, as the projection holds it.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Note {
+    pub id: String,
+    pub title: String,
+    pub body: String,
+    /// The operation's `recorded_at_ms` at the time of the mutation that most
+    /// recently touched this note.
+    pub updated_at_ms: u64,
+}
+
+/// The Notes read-model. `C4`: cache-only, rebuildable, disposable — this is
+/// never written to directly, only ever produced by
+/// [`Projection::rebuild`] folding the log.
+///
+/// `BTreeMap`, not `HashMap`: `C2` forbids `HashMap` iteration on a path
+/// that must be byte-identical across platforms, and while this type is not
+/// itself replayed, `Eq` over it (which the conformance test relies on) must
+/// not depend on hash-iteration order either.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct NotesProjection {
+    notes: BTreeMap<String, Note>,
+}
+
+impl NotesProjection {
+    pub fn get(&self, id: &str) -> Option<&Note> {
+        self.notes.get(id)
+    }
+
+    /// Every note, ordered by id — deterministic, and matching the
+    /// determinism the underlying `BTreeMap` already gives for free.
+    pub fn all(&self) -> Vec<&Note> {
+        self.notes.values().collect()
+    }
+
+    pub fn len(&self) -> usize {
+        self.notes.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.notes.is_empty()
+    }
+}
+
+impl Projection for NotesProjection {
+    /// Folds the log in one pass, in order. `replay_passes == 1`, `C2`: this
+    /// is a single `for` loop over `ops`, and `rebuild_counting` (private,
+    /// used by the conformance test) proves each operation is visited
+    /// exactly once rather than merely asserting the code looks like it
+    /// should.
+    fn rebuild(ops: &[Operation]) -> Self {
+        Self::rebuild_counting(ops).0
+    }
+}
+
+impl NotesProjection {
+    /// Same fold as [`Projection::rebuild`], plus the number of operations
+    /// visited. Not part of the public seam — `query_projection::<P>` only
+    /// ever calls `rebuild` — but the one way a conformance test can assert
+    /// "single pass" as a measured fact rather than an assumption about the
+    /// implementation.
+    fn rebuild_counting(ops: &[Operation]) -> (Self, usize) {
+        let mut notes = BTreeMap::new();
+        let mut visits = 0usize;
+        for op in ops {
+            if op.capability != NOTES_CAPABILITY {
+                continue;
+            }
+            visits += 1;
+            let Some(note_op) = NoteOp::decode(&op.kind, &op.payload) else {
+                continue;
+            };
+            match note_op {
+                NoteOp::Create { id, title, body } | NoteOp::Edit { id, title, body } => {
+                    notes.insert(
+                        id.clone(),
+                        Note {
+                            id,
+                            title,
+                            body,
+                            updated_at_ms: op.recorded_at_ms,
+                        },
+                    );
+                }
+                NoteOp::Delete { id } => {
+                    notes.remove(&id);
+                }
+            }
+        }
+        (Self { notes }, visits)
+    }
+}
+
+/// The Notes capability. `C5`: passive, holds no durable state of its own —
+/// every method here either calls [`Runtime::emit_operation`] or
+/// [`Runtime::query_projection`], and nothing else. There is no field on
+/// this type besides the runtime reference, which is what makes "the
+/// capability holds no durable storage of its own" (`I2`, `I4`) true by
+/// construction rather than by convention.
+pub struct NotesCapability<'a> {
+    runtime: &'a Runtime,
+}
+
+impl<'a> NotesCapability<'a> {
+    pub fn new(runtime: &'a Runtime) -> Self {
+        Self { runtime }
+    }
+
+    /// Emits a `note.create` operation. The only way a note comes into
+    /// existence — there is no direct write path to [`NotesProjection`].
+    pub fn create_note(
+        &self,
+        id: impl Into<String>,
+        title: impl Into<String>,
+        body: impl Into<String>,
+        recorded_at_ms: u64,
+    ) -> Result<Operation, RuntimeApiError> {
+        let op = NoteOp::Create {
+            id: id.into(),
+            title: title.into(),
+            body: body.into(),
+        };
+        self.runtime
+            .emit_operation(NOTES_CAPABILITY, op.kind(), &op.encode(), recorded_at_ms)
+    }
+
+    pub fn edit_note(
+        &self,
+        id: impl Into<String>,
+        title: impl Into<String>,
+        body: impl Into<String>,
+        recorded_at_ms: u64,
+    ) -> Result<Operation, RuntimeApiError> {
+        let op = NoteOp::Edit {
+            id: id.into(),
+            title: title.into(),
+            body: body.into(),
+        };
+        self.runtime
+            .emit_operation(NOTES_CAPABILITY, op.kind(), &op.encode(), recorded_at_ms)
+    }
+
+    pub fn delete_note(
+        &self,
+        id: impl Into<String>,
+        recorded_at_ms: u64,
+    ) -> Result<Operation, RuntimeApiError> {
+        let op = NoteOp::Delete { id: id.into() };
+        self.runtime
+            .emit_operation(NOTES_CAPABILITY, op.kind(), &op.encode(), recorded_at_ms)
+    }
+
+    /// Reads the current projection. Always a fresh fold of the log
+    /// (`Runtime::query_projection`) — never a cache this capability keeps
+    /// itself, because keeping one would be exactly the durable state `C5`
+    /// forbids it from owning.
+    pub fn notes(&self) -> Result<NotesProjection, RuntimeApiError> {
+        self.runtime.query_projection::<NotesProjection>()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::budget::ResourceBudget;
+    use crate::runtime::Runtime;
+
+    fn temp_log_path(name: &str) -> std::path::PathBuf {
+        let unique = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        std::env::temp_dir().join(format!("airo_mind_notes_test_{name}_{unique}.log"))
+    }
+
+    /// The single most important test in `#1338`: create a note, confirm it
+    /// is durable, wipe the in-memory projection, replay the persisted
+    /// operations, and confirm the rebuilt projection is identical to what
+    /// existed before the wipe. This is `C4`'s "delete and rebuild with zero
+    /// data loss" and condition 5 of `#1311`, proven rather than asserted by
+    /// comment.
+    #[test]
+    fn a_note_survives_projection_deletion_and_replay() {
+        let path = temp_log_path("survive");
+        let runtime = Runtime::boot(ResourceBudget::new(2048), &path).unwrap();
+        let notes = NotesCapability::new(&runtime);
+
+        notes
+            .create_note("n1", "Groceries", "milk, eggs", 1_000)
+            .unwrap();
+        notes
+            .create_note("n2", "Throwaway", "delete me", 2_000)
+            .unwrap();
+        notes
+            .edit_note("n1", "Groceries", "milk, eggs, bread", 3_000)
+            .unwrap();
+        notes.delete_note("n2", 4_000).unwrap();
+
+        // 1. Confirm persisted: the log itself, independent of any
+        //    projection, holds every operation.
+        assert_eq!(runtime.replay().unwrap().len(), 4);
+
+        // 2. The projection before the wipe.
+        let before = notes.notes().unwrap();
+        assert_eq!(before.len(), 1, "n2 was deleted, only n1 should remain");
+        let n1_before = before.get("n1").cloned().unwrap();
+        assert_eq!(n1_before.title, "Groceries");
+        assert_eq!(n1_before.body, "milk, eggs, bread");
+        assert!(before.get("n2").is_none());
+
+        // 3. "Wipe" the in-memory projection: `before` goes out of scope
+        //    here (nothing retains it), simulating `C4`'s "deleted at any
+        //    time." There is no cache anywhere else to fall back on --
+        //    `NotesCapability` holds none (`I2`, `I4`).
+        drop(before);
+
+        // 4. Replay from persisted operations and rebuild.
+        let ops = runtime.replay().unwrap();
+        let after = NotesProjection::rebuild(&ops);
+
+        // 5. Zero data loss: identical state.
+        let n1_after = after.get("n1").cloned().unwrap();
+        assert_eq!(n1_before, n1_after);
+        assert_eq!(after.len(), 1);
+        assert!(after.get("n2").is_none());
+
+        // Also identical through the capability's own read path, not just
+        // the type under test directly.
+        let via_capability = notes.notes().unwrap();
+        assert_eq!(via_capability, after);
+
+        let _ = std::fs::remove_file(&path);
+    }
+
+    /// `C2`: `replay_passes == 1`, asserted rather than documented. Every
+    /// Notes operation in the log is visited exactly once while folding —
+    /// not zero (a bug that would drop it), not two (a bug that would
+    /// double-apply it).
+    #[test]
+    fn replay_visits_every_notes_operation_exactly_once() {
+        let path = temp_log_path("single_pass");
+        let runtime = Runtime::boot(ResourceBudget::new(2048), &path).unwrap();
+        let notes = NotesCapability::new(&runtime);
+
+        for i in 0..25 {
+            notes
+                .create_note(format!("n{i}"), format!("title {i}"), "body", i)
+                .unwrap();
+        }
+
+        let ops = runtime.replay().unwrap();
+        let (_, visits) = NotesProjection::rebuild_counting(&ops);
+        assert_eq!(
+            visits,
+            ops.len(),
+            "every operation in a single-capability log must be visited exactly once per rebuild"
+        );
+
+        // Rebuilding twice from the same ops must be idempotent -- another
+        // face of `replay_passes == 1`: a second rebuild is a second single
+        // pass, not a continuation of the first.
+        let first = NotesProjection::rebuild(&ops);
+        let second = NotesProjection::rebuild(&ops);
+        assert_eq!(first, second);
+
+        let _ = std::fs::remove_file(&path);
+    }
+
+    /// `C5` / `I2` / `I4`: the capability holds no durable storage of its
+    /// own. Mechanically, not just by convention: its only field is the
+    /// runtime reference, so its size is exactly one pointer.
+    #[test]
+    fn the_capability_holds_nothing_but_a_runtime_reference() {
+        assert_eq!(
+            std::mem::size_of::<NotesCapability<'_>>(),
+            std::mem::size_of::<&Runtime>(),
+            "NotesCapability must carry no field besides the runtime reference"
+        );
+    }
+
+    /// A capability denied all filesystem access still passes its own
+    /// suite (`S3`): `NotesCapability` never calls `std::fs` itself --
+    /// grep-verified, the same technique `airo_mind_whisper::api::meetings`
+    /// uses to keep `ADR-0018 §4` honest.
+    #[test]
+    fn the_capability_never_touches_the_filesystem_directly() {
+        let source = include_str!("notes.rs");
+        // The only `std::fs`/file mentions allowed are in this very
+        // assertion's string literals and the `#[cfg(test)]` helpers below
+        // it, which is why the check runs against everything ABOVE the test
+        // module rather than the whole file.
+        let production_code = source.split("#[cfg(test)]").next().unwrap();
+        assert!(
+            !production_code.contains("std::fs"),
+            "NotesCapability must reach storage only through Runtime::emit_operation / query_projection"
+        );
+    }
+
+    #[test]
+    fn uninstalling_the_capability_leaves_the_log_untouched() {
+        // "Uninstall" has no code path yet at this skeleton stage -- there is
+        // no registry to remove a capability from. What is proven here is
+        // the property that will make uninstall safe once one exists: the
+        // capability itself owns nothing that a real uninstall would need to
+        // clean up. Dropping it (`_capability` going out of scope) is a
+        // no-op against durable state.
+        let path = temp_log_path("uninstall");
+        let runtime = Runtime::boot(ResourceBudget::new(2048), &path).unwrap();
+        {
+            let capability = NotesCapability::new(&runtime);
+            capability
+                .create_note("n1", "Survives", "uninstall", 1)
+                .unwrap();
+        }
+        // The capability value is gone; the operation is not.
+        assert_eq!(runtime.replay().unwrap().len(), 1);
+        let notes = NotesCapability::new(&runtime).notes().unwrap();
+        assert_eq!(notes.len(), 1);
+
+        let _ = std::fs::remove_file(&path);
+    }
+}

--- a/rust/airo_mind_core/src/projection.rs
+++ b/rust/airo_mind_core/src/projection.rs
@@ -1,0 +1,500 @@
+//! The projection engine. `#1195` (condition 5: *"every projection can be
+//! deleted and rebuilt"*), the other half of `C4` from
+//! [`crate::runtime::Projection`].
+//!
+//! # What `#1338` already proved, and what was missing
+//!
+//! [`crate::runtime::Runtime::query_projection`] already never caches: every
+//! call is a fresh [`crate::runtime::Runtime::replay`] folded through
+//! [`crate::runtime::Projection::rebuild`]. `C4`'s *"delete at any time and
+//! rebuild with zero data loss"* was true by construction from `#1338`
+//! onward — there was never anything to delete in the first place, which is
+//! the strongest form of "cache-only" there is.
+//!
+//! What `#1338` proved this property for was exactly one projection
+//! ([`crate::notes::NotesProjection`]) fed by exactly one capability. `#1195`
+//! asks the harder question the design doc's own diagram implies: *"the
+//! graph is not synchronized... the graph is rebuilt"* — one shared entity
+//! graph, folded from operations that many different capabilities emit. This
+//! module is that second projection: [`EntityGraphProjection`], built from
+//! [`crate::verb::Verb::CreateEntity`] / `SetProperty` / `AddRelation` /
+//! `RemoveRelation`, independent of which capability emitted them — proof
+//! that `#1195`'s "delete and rebuild" is a property of the **engine**, not
+//! an accident of Notes' own shape.
+//!
+//! # Still explicitly deferred
+//!
+//! - **Knowledge graph / timeline / full-text search projections** named in
+//!   `#1195`'s scope table beyond the generic entity graph this module adds.
+//!   [`EntityGraphProjection`] is the substrate a timeline or search index
+//!   would fold further; building those specific views is follow-on work,
+//!   not a substrate question.
+//! - **Snapshotting.** `#1195`'s own "open decision" — cache-only vs.
+//!   authoritative snapshots — says to *"decide with measurements from a
+//!   realistic log, not in the abstract."* There is no realistic log to
+//!   measure yet, so no snapshot cache exists. Every projection here is a
+//!   full replay, which trivially satisfies "cache-only" and "zero data
+//!   loss" but does not yet address the cold-start-bounded half of the
+//!   contract at scale.
+//! - **Targeted invalidation.** With no cache, every "invalidation" is
+//!   already the whole projection, which is `C4`'s `invalidation: full` —
+//!   the correct default, per the contract, until a specific projection
+//!   needs `targeted` and the cache to make it meaningful.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use crate::runtime::{Operation, Projection};
+use crate::verb::Verb;
+
+fn push_str(out: &mut Vec<u8>, s: &str) {
+    let bytes = s.as_bytes();
+    out.extend_from_slice(&(bytes.len() as u32).to_be_bytes());
+    out.extend_from_slice(bytes);
+}
+
+fn pop_str(bytes: &[u8], pos: &mut usize) -> Option<String> {
+    let len_bytes: [u8; 4] = bytes.get(*pos..*pos + 4)?.try_into().ok()?;
+    let len = u32::from_be_bytes(len_bytes) as usize;
+    *pos += 4;
+    let s = bytes.get(*pos..*pos + len)?;
+    *pos += len;
+    String::from_utf8(s.to_vec()).ok()
+}
+
+fn pop_bytes(bytes: &[u8], pos: &mut usize) -> Option<Vec<u8>> {
+    let len_bytes: [u8; 4] = bytes.get(*pos..*pos + 4)?.try_into().ok()?;
+    let len = u32::from_be_bytes(len_bytes) as usize;
+    *pos += 4;
+    let s = bytes.get(*pos..*pos + len)?;
+    *pos += len;
+    Some(s.to_vec())
+}
+
+/// A `SetProperty` operation's payload: one property name and its raw value.
+/// Encoded the same length-prefixed way every other wire shape in this crate
+/// is — see [`crate::runtime`]'s module doc for why (no serde dependency).
+pub fn encode_set_property(name: &str, value: &[u8]) -> Vec<u8> {
+    let mut out = Vec::new();
+    push_str(&mut out, name);
+    out.extend_from_slice(&(value.len() as u32).to_be_bytes());
+    out.extend_from_slice(value);
+    out
+}
+
+fn decode_set_property(payload: &[u8]) -> Option<(String, Vec<u8>)> {
+    let mut pos = 0usize;
+    let name = pop_str(payload, &mut pos)?;
+    let value = pop_bytes(payload, &mut pos)?;
+    Some((name, value))
+}
+
+/// An `AddRelation`/`RemoveRelation` operation's payload: the relation's name
+/// and the target entity id. The **source** entity is the operation's
+/// `entity_id` header field, not repeated in the payload.
+pub fn encode_relation(relation_name: &str, target_entity_id: &str) -> Vec<u8> {
+    let mut out = Vec::new();
+    push_str(&mut out, relation_name);
+    push_str(&mut out, target_entity_id);
+    out
+}
+
+fn decode_relation(payload: &[u8]) -> Option<(String, String)> {
+    let mut pos = 0usize;
+    let relation_name = pop_str(payload, &mut pos)?;
+    let target = pop_str(payload, &mut pos)?;
+    Some((relation_name, target))
+}
+
+/// One entity's fold state: its label (from `CreateEntity`'s payload, when
+/// non-empty), its properties, and its outgoing relations.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct EntityRecord {
+    pub label: String,
+    /// `BTreeMap`, not `HashMap`: `C2` forbids hash-iteration order on any
+    /// path whose equality a conformance test relies on.
+    pub properties: BTreeMap<String, Vec<u8>>,
+    /// `(relation_name, target_entity_id)`. A `BTreeSet` so `AddRelation`
+    /// twice with the same pair is idempotent by construction — matching
+    /// the `reference` primitive's `union` default merge (design §5.3).
+    pub relations: BTreeSet<(String, String)>,
+}
+
+/// The shared entity graph. `C4` / design §3: *"the graph is rebuilt"* — this
+/// is that graph, folded from every capability's `CreateEntity` /
+/// `SetProperty` / `AddRelation` / `RemoveRelation` operations, regardless of
+/// which capability emitted them. Never written to directly; only ever
+/// produced by [`Projection::rebuild`] folding the log, the same discipline
+/// [`crate::notes::NotesProjection`] already follows.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct EntityGraphProjection {
+    entities: BTreeMap<String, EntityRecord>,
+}
+
+impl EntityGraphProjection {
+    pub fn get(&self, entity_id: &str) -> Option<&EntityRecord> {
+        self.entities.get(entity_id)
+    }
+
+    pub fn len(&self) -> usize {
+        self.entities.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.entities.is_empty()
+    }
+
+    pub fn entity_ids(&self) -> Vec<&str> {
+        self.entities.keys().map(String::as_str).collect()
+    }
+}
+
+impl Projection for EntityGraphProjection {
+    /// Folds the log in one pass, in order (`C2`: `replay_passes == 1`).
+    /// Operations with no `entity_id`, or whose `kind` is not one of the
+    /// four entity verbs, are skipped — a mixed-capability log (Notes plus
+    /// entity-graph operations) folds correctly because this projection
+    /// simply ignores what is not its concern, the same way
+    /// [`crate::notes::NotesProjection::rebuild`] ignores every operation
+    /// whose `capability` is not `"notes"`.
+    fn rebuild(ops: &[Operation]) -> Self {
+        Self::rebuild_counting(ops).0
+    }
+}
+
+impl EntityGraphProjection {
+    /// Same fold as [`Projection::rebuild`], plus the number of entity-verb
+    /// operations visited — the measured, not assumed, single-pass proof a
+    /// conformance test relies on.
+    pub fn rebuild_counting(ops: &[Operation]) -> (Self, usize) {
+        let mut entities: BTreeMap<String, EntityRecord> = BTreeMap::new();
+        let mut visits = 0usize;
+
+        for op in ops {
+            let Some(verb) = op.verb() else { continue };
+            if op.entity_id.is_empty() {
+                continue;
+            }
+            match verb {
+                Verb::CreateEntity => {
+                    visits += 1;
+                    let record = entities.entry(op.entity_id.clone()).or_default();
+                    if !op.payload.is_empty() {
+                        if let Ok(label) = String::from_utf8(op.payload.clone()) {
+                            record.label = label;
+                        }
+                    }
+                }
+                Verb::SetProperty => {
+                    if let Some((name, value)) = decode_set_property(&op.payload) {
+                        visits += 1;
+                        entities
+                            .entry(op.entity_id.clone())
+                            .or_default()
+                            .properties
+                            .insert(name, value);
+                    }
+                }
+                Verb::AddRelation => {
+                    if let Some((relation, target)) = decode_relation(&op.payload) {
+                        visits += 1;
+                        entities
+                            .entry(op.entity_id.clone())
+                            .or_default()
+                            .relations
+                            .insert((relation, target));
+                    }
+                }
+                Verb::RemoveRelation => {
+                    if let Some((relation, target)) = decode_relation(&op.payload) {
+                        visits += 1;
+                        if let Some(record) = entities.get_mut(&op.entity_id) {
+                            record.relations.remove(&(relation, target));
+                        }
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        (Self { entities }, visits)
+    }
+}
+
+/// `#1195`'s explicit, supported, tested rebuild-from-scratch operation:
+/// drop whatever projection state a caller was holding, replay the log, and
+/// fold it fresh. This is a thin, documented name for what
+/// [`crate::runtime::Runtime::query_projection`] already does — the point is
+/// that it has a name and is called out as a first-class operation rather
+/// than an incidental consequence of never caching.
+pub fn rebuild_from_scratch<P: Projection>(ops: &[Operation]) -> P {
+    P::rebuild(ops)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::budget::ResourceBudget;
+    use crate::runtime::Runtime;
+
+    fn temp_log_path(name: &str) -> std::path::PathBuf {
+        let unique = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        std::env::temp_dir().join(format!("airo_mind_projection_test_{name}_{unique}.log"))
+    }
+
+    fn cleanup(path: &std::path::Path) {
+        let _ = std::fs::remove_file(path);
+        let mut device_id = path.file_name().unwrap().to_string_lossy().into_owned();
+        device_id.push_str(".device_id");
+        let _ = std::fs::remove_file(path.with_file_name(device_id));
+        let mut content = path.file_name().unwrap().to_string_lossy().into_owned();
+        content.push_str(".content");
+        let _ = std::fs::remove_dir_all(path.with_file_name(content));
+    }
+
+    #[test]
+    fn create_entity_set_property_and_relations_fold_into_one_graph() {
+        let path = temp_log_path("fold");
+        let runtime = Runtime::boot(ResourceBudget::new(2048), &path).unwrap();
+
+        runtime
+            .emit_verb_operation(
+                "notes",
+                Verb::CreateEntity,
+                "note-1",
+                &[],
+                "",
+                b"Note",
+                None,
+                1,
+            )
+            .unwrap();
+        runtime
+            .emit_verb_operation(
+                "notes",
+                Verb::SetProperty,
+                "note-1",
+                &[],
+                "",
+                &encode_set_property("title", b"Groceries"),
+                None,
+                2,
+            )
+            .unwrap();
+        runtime
+            .emit_verb_operation(
+                "notes",
+                Verb::CreateEntity,
+                "person-1",
+                &[],
+                "",
+                b"Person",
+                None,
+                3,
+            )
+            .unwrap();
+        runtime
+            .emit_verb_operation(
+                "notes",
+                Verb::AddRelation,
+                "note-1",
+                &[],
+                "",
+                &encode_relation("authoredBy", "person-1"),
+                None,
+                4,
+            )
+            .unwrap();
+
+        let graph: EntityGraphProjection = runtime.query_projection().unwrap();
+        assert_eq!(graph.len(), 2);
+        let note = graph.get("note-1").unwrap();
+        assert_eq!(note.label, "Note");
+        assert_eq!(note.properties.get("title").unwrap(), b"Groceries");
+        assert!(note
+            .relations
+            .contains(&("authoredBy".to_string(), "person-1".to_string())));
+
+        cleanup(&path);
+    }
+
+    #[test]
+    fn remove_relation_undoes_a_prior_add_relation() {
+        let path = temp_log_path("remove_relation");
+        let runtime = Runtime::boot(ResourceBudget::new(2048), &path).unwrap();
+
+        runtime
+            .emit_verb_operation("notes", Verb::CreateEntity, "a", &[], "", b"", None, 1)
+            .unwrap();
+        runtime
+            .emit_verb_operation(
+                "notes",
+                Verb::AddRelation,
+                "a",
+                &[],
+                "",
+                &encode_relation("links", "b"),
+                None,
+                2,
+            )
+            .unwrap();
+        runtime
+            .emit_verb_operation(
+                "notes",
+                Verb::RemoveRelation,
+                "a",
+                &[],
+                "",
+                &encode_relation("links", "b"),
+                None,
+                3,
+            )
+            .unwrap();
+
+        let graph: EntityGraphProjection = runtime.query_projection().unwrap();
+        assert!(graph.get("a").unwrap().relations.is_empty());
+
+        cleanup(&path);
+    }
+
+    /// `#1195`'s core proof, generalized beyond Notes: **two independent
+    /// projections**, fed from a **mixed-capability log**, both survive
+    /// delete-and-rebuild with zero data loss. This is condition 5 of
+    /// `#1311` proven at the engine level, not only for the one capability
+    /// `#1338` shipped it against.
+    #[test]
+    fn two_projections_survive_delete_and_rebuild_with_zero_data_loss() {
+        let path = temp_log_path("two_projections");
+        let runtime = Runtime::boot(ResourceBudget::new(2048), &path).unwrap();
+        let notes = crate::notes::NotesCapability::new(&runtime);
+
+        // Notes capability operations (opaque `kind` strings).
+        notes
+            .create_note("n1", "Groceries", "milk, eggs", 1_000)
+            .unwrap();
+        notes
+            .edit_note("n1", "Groceries", "milk, eggs, bread", 2_000)
+            .unwrap();
+
+        // Entity-graph verb operations, interleaved in the same log.
+        runtime
+            .emit_verb_operation(
+                "relationships",
+                Verb::CreateEntity,
+                "person-1",
+                &[],
+                "",
+                b"Person",
+                None,
+                3_000,
+            )
+            .unwrap();
+        runtime
+            .emit_verb_operation(
+                "relationships",
+                Verb::SetProperty,
+                "person-1",
+                &[],
+                "",
+                &encode_set_property("name", b"Ada"),
+                None,
+                4_000,
+            )
+            .unwrap();
+
+        // State before any "deletion".
+        let notes_before = notes.notes().unwrap();
+        let graph_before: EntityGraphProjection = runtime.query_projection().unwrap();
+        assert_eq!(notes_before.len(), 1);
+        assert_eq!(graph_before.len(), 1);
+
+        // "Delete": drop every in-memory projection. Nothing else retains
+        // this state -- both projection types hold no cache of their own
+        // (`I2`, `I4`), and `NotesCapability` holds only the runtime
+        // reference.
+        drop(notes_before);
+        drop(graph_before);
+
+        // Rebuild from the log alone, via #1195's named operation.
+        let ops = runtime.replay().unwrap();
+        let notes_after: crate::notes::NotesProjection = rebuild_from_scratch(&ops);
+        let graph_after: EntityGraphProjection = rebuild_from_scratch(&ops);
+
+        // Zero data loss, for both projections independently.
+        assert_eq!(notes_after.len(), 1);
+        let n1 = notes_after.get("n1").unwrap();
+        assert_eq!(n1.title, "Groceries");
+        assert_eq!(n1.body, "milk, eggs, bread");
+
+        assert_eq!(graph_after.len(), 1);
+        assert_eq!(
+            graph_after
+                .get("person-1")
+                .unwrap()
+                .properties
+                .get("name")
+                .unwrap(),
+            b"Ada"
+        );
+
+        // And through the ordinary query path too, not just the direct
+        // `rebuild_from_scratch` call.
+        assert_eq!(notes.notes().unwrap(), notes_after);
+        let graph_via_query: EntityGraphProjection = runtime.query_projection().unwrap();
+        assert_eq!(graph_via_query, graph_after);
+
+        cleanup(&path);
+    }
+
+    /// `C2`: `replay_passes == 1`. Every entity-verb operation is visited
+    /// exactly once; a mixed-capability log (Notes operations present too)
+    /// must not inflate the count.
+    #[test]
+    fn rebuild_visits_every_entity_verb_operation_exactly_once() {
+        let path = temp_log_path("single_pass");
+        let runtime = Runtime::boot(ResourceBudget::new(2048), &path).unwrap();
+        let notes = crate::notes::NotesCapability::new(&runtime);
+
+        for i in 0..10 {
+            notes.create_note(format!("n{i}"), "t", "b", i).unwrap();
+        }
+        for i in 0..15 {
+            runtime
+                .emit_verb_operation(
+                    "relationships",
+                    Verb::CreateEntity,
+                    &format!("e{i}"),
+                    &[],
+                    "",
+                    b"",
+                    None,
+                    i,
+                )
+                .unwrap();
+        }
+
+        let ops = runtime.replay().unwrap();
+        let (_, visits) = EntityGraphProjection::rebuild_counting(&ops);
+        assert_eq!(
+            visits, 15,
+            "only the fifteen entity-verb operations should be visited"
+        );
+
+        let first = EntityGraphProjection::rebuild(&ops);
+        let second = EntityGraphProjection::rebuild(&ops);
+        assert_eq!(first, second, "rebuild must be a pure function of the log");
+
+        cleanup(&path);
+    }
+
+    #[test]
+    fn an_empty_log_rebuilds_to_an_empty_graph() {
+        let path = temp_log_path("empty");
+        let runtime = Runtime::boot(ResourceBudget::new(2048), &path).unwrap();
+        let graph: EntityGraphProjection = runtime.query_projection().unwrap();
+        assert!(graph.is_empty());
+        cleanup(&path);
+    }
+}

--- a/rust/airo_mind_core/src/runtime.rs
+++ b/rust/airo_mind_core/src/runtime.rs
@@ -1,80 +1,234 @@
-//! The Operation → Persist → Replay → Projection vertical slice. `#1338`.
+//! The Operation → Persist → Replay → Projection substrate. `#1194`
+//! (condition 4: *"every durable object is reachable from the operation
+//! log"*) and half of `#1195` (condition 5: *"every projection can be
+//! deleted and rebuilt"* — the other half lives in [`crate::projection`]).
 //!
-//! `#1338` is the runtime skeleton: the smallest thing that proves the
-//! Supervisor (`#1302`) and a real replay engine can carry one capability
-//! end to end, through the Supervisor's own lifecycle rather than around it.
-//! It is deliberately narrow — see the module docs on [`crate::lifecycle`]
-//! for what this greenfields and what it still leaves for later phases:
+//! `#1338` shipped this as a deliberately minimal skeleton: a local, unsigned
+//! record with no content store, so a single capability (Notes) could prove
+//! `Operation → Persist → Replay → Projection` end to end through the
+//! Supervisor's own lifecycle. This module is that skeleton formalized against
+//! `C1`'s and `C2`'s actual text and `#1194`'s scope table:
 //!
-//! - **Vault** here is a lifecycle placeholder only. No identity, no key
-//!   hierarchy, no revocation ledger — that is Phase 1's full scope
-//!   (`docs/superpowers/specs/2026-07-27-airo-mind-roadmap.md`). What the
-//!   skeleton needs from Vault is one thing: that it exists as a dependency
-//!   `Replay` cannot start ahead of, per `C6`'s *"Vault before Replay before
-//!   Projection."*
-//! - **The operation log is real** — sequential, append-only, durable to a
-//!   file, replayable from scratch. What it is missing against `C1`'s full
-//!   contract: no group-commit window (each `append` is written and flushed
-//!   immediately), no signatures (`C7` is a later phase), no content store.
-//! - **The projection engine is empty on purpose** (per `#1338`'s issue
-//!   body): this module registers it as a lifecycle participant and nothing
-//!   more. What a projection actually contains is
-//!   [`crate::notes::NotesProjection`] — a concrete type built by folding the
-//!   log, owned by the capability that needs it, not by this module.
+//! - **The full header** design doc §3.1 specifies — `operationId`,
+//!   `parentOperationId`, `entityId`, `contextIds[]`, `schemaId`,
+//!   `capabilityId`, `deviceId`, `timestamp`, `versionVector`, `payloadHash`,
+//!   `signature` — is now on [`Operation`], not just `seq`/`capability`/
+//!   `kind`/`payload`/`recorded_at_ms`.
+//! - **A content store** ([`crate::content::ContentStore`]) exists, and
+//!   [`Runtime::attach_content`] is implemented rather than declared
+//!   out-of-scope.
+//! - **Every operation is signed** ([`crate::signing`]) and a tampered header
+//!   fails verification — with the honest caveat, documented at
+//!   [`crate::signing`]'s module doc, that the signer is a placeholder until
+//!   Phase 1's Vault exists.
+//! - **The wire format is versioned** (a leading format-version byte), so a
+//!   future incompatible change has somewhere to signal it rather than
+//!   silently misparsing an old log.
+//! - **Concurrent writers are safe.** `Self::append` used to open a fresh
+//!   file handle per call and assign `seq` with an independent atomic —two
+//!   threads could interleave a write with a `seq` assignment from the other,
+//!   producing a log whose on-disk order did not match its `seq` order. Both
+//!   now happen under one lock ([`LogWriterState`]), so `seq` assignment and
+//!   the byte write it labels are one atomic step.
+//!
+//! # Still explicitly deferred (not this phase's job)
+//!
+//! - **Real device identity and signing keys.** Phase 1 (Vault). This
+//!   module's `device_id` is generated locally and persisted beside the log;
+//!   it is not issued by anything and proves nothing about the device to a
+//!   peer. See [`crate::signing`].
+//! - **Content encryption.** Phase 1 (Vault's key hierarchy). The content
+//!   store holds plaintext; see [`crate::content`]'s module doc for the
+//!   `payload_hash`-over-plaintext gap this creates and why it is called out
+//!   twice rather than fixed by working around it here.
+//! - **Group-commit batching.** Each `append` still flushes and `fsync`s
+//!   immediately (`C1` allows batching within a bounded window; it does not
+//!   require it). Batching is a throughput optimization behind the same
+//!   `OperationLog::append` signature, not a shape change.
+//! - **Sync, contexts, capability packs, and Vault verbs** — `AuthorizeDevice`
+//!   / `RevokeDevice` / `RevokeContentKey` in [`crate::verb::Verb`] have no
+//!   handler here beyond being valid wire values. They are Phase 1/7's verbs,
+//!   declared now (so the format does not have to change to add them) and
+//!   implemented later.
 //!
 //! # Determinism (`C2`)
 //!
 //! [`OperationLog::replay`] reads the file front-to-back once and returns
-//! operations in the order they were written. No `HashMap` iteration, no
-//! wall-clock read, on this path. `recorded_at_ms` is supplied by the caller
-//! (ultimately Dart, which owns the platform's notion of "now") and never
-//! sampled inside the runtime — the same discipline
-//! `airo_mind_whisper::api::meetings` already documents for
-//! `recorded_at_ms`.
+//! operations in the order they were written. No `HashMap` iteration
+//! (`version_vector` is a `BTreeMap`), no wall-clock read, no locale, on this
+//! path. `recorded_at_ms` is supplied by the caller and never sampled inside
+//! the runtime.
 
+use std::collections::BTreeMap;
 use std::fs::{File, OpenOptions};
 use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
-use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
+use std::sync::Mutex;
 
+use crate::content::{ContentId, ContentStore, ContentStoreError};
+use crate::digest::Sha256;
 use crate::engine::EngineError;
 use crate::lifecycle::{EngineName, ManagedEngine};
+use crate::signing::{DeviceKeySigner, SignerVerifier};
 use crate::supervisor::Supervisor;
+use crate::verb::Verb;
+
+fn sha256_hex(bytes: &[u8]) -> String {
+    let mut h = Sha256::new();
+    h.update(bytes);
+    h.finish()
+}
 
 // ---------------------------------------------------------------------------
 // Operation
 // ---------------------------------------------------------------------------
 
-/// One durable entry in the operation log.
+/// One durable entry in the operation log. Design doc §3.1's full header,
+/// plus the payload/content-id pair that carries the capability's own data.
 ///
-/// This is the beginning of the operation log condition (`#1194`) — a
-/// minimal, local, unsigned record. It is not that log: there is no device
-/// identity, no signature, no sync. What it proves is the shape everything
-/// after it depends on: a capability's mutation becomes one immutable,
-/// ordered, replayable fact.
+/// `capability`/`kind`/`payload`/`recorded_at_ms` are the four fields
+/// `#1338`'s skeleton already shipped and [`crate::notes`] already depends on
+/// by name — unchanged, so nothing that already reads them needed to move.
+/// Everything else is new with this formalization.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Operation {
-    /// Monotonic, gap-free, assigned by [`OperationLog::append`]. The
-    /// product-facing citation everything else (a projection row, a UI
-    /// element) can point back at.
+    /// Monotonic, gap-free, assigned by [`OperationLog::append`] under one
+    /// lock shared with the byte write it labels — see the module doc.
     pub seq: u64,
-    /// Which capability emitted this. `"notes"` for every operation this
-    /// module's tests write.
+    /// `operationId` (§3.1). Content-derived: `sha256(device_id, seq,
+    /// capability, kind, payload_hash, recorded_at_ms)`. Deterministic and
+    /// citable without depending on a signature having been produced yet.
+    pub operation_id: String,
+    /// `parentOperationId` (§3.1). `None` for every operation this phase
+    /// emits — no capability shipped here threads causal parentage yet — but
+    /// the field exists so a future capability does not need a format
+    /// change to start setting it.
+    pub parent_operation_id: Option<String>,
+    /// `entityId` (§3.1). Empty string for a capability that has not adopted
+    /// the entity/property model (`""` rather than `Option` — an operation
+    /// with no entity, like `InstallPack`, has this by construction rather
+    /// than as a documented magic value).
+    pub entity_id: String,
+    /// `contextIds[]` (§3.1). Empty for the same reason.
+    pub context_ids: Vec<String>,
+    /// `schemaId` (§3.1). Empty until a capability declares a real schema
+    /// fingerprint (§5.5) — not yet in scope.
+    pub schema_id: String,
+    /// `capabilityId` (§3.1). Kept named `capability` — the name
+    /// `#1338`/`crate::notes` already uses.
     pub capability: String,
-    /// The capability's own vocabulary for what happened —
-    /// `"note.create"`, `"note.delete"`, and so on. Opaque to the runtme;
-    /// only the capability that wrote it knows how to decode `payload`.
+    /// The verb or the capability's own vocabulary. [`Self::verb`] parses
+    /// this against [`crate::verb::Verb`] when it is one of the nineteen
+    /// canonical verbs; a capability's free-form string (`"note.create"`)
+    /// simply does not match, which is not an error — `C5`: the runtime
+    /// knows no domains, and both forms share this one field.
     pub kind: String,
-    /// The capability's own encoding. The runtime never looks inside this —
-    /// `C5`: the runtime knows no domains.
-    pub payload: Vec<u8>,
-    /// Supplied by the caller, never sampled here (`C2`).
+    /// `deviceId` (§3.1). See the module doc: locally generated, not
+    /// Vault-issued, this phase.
+    pub device_id: String,
+    /// `timestamp` (§3.1). Supplied by the caller, never sampled here
+    /// (`C2`). Kept named `recorded_at_ms` for the same reason `capability`
+    /// keeps its name.
     pub recorded_at_ms: u64,
+    /// `versionVector` (§3.1). Single-device today: `{device_id: seq + 1}`,
+    /// this device's own operation count after this one. Multi-device merge
+    /// is Phase 3's sync work and is explicitly out of scope here (both
+    /// `#1194` and `#1195` name Sync as blocked-on / out-of-scope).
+    pub version_vector: BTreeMap<String, u64>,
+    /// `payloadHash` (§3.1). Hex SHA-256. **Known gap**, documented in full
+    /// at [`crate::content`]'s module doc: this hashes `payload` as written
+    /// — plaintext today, because there is no ciphertext yet — which is
+    /// exactly the equality-oracle risk §3.1 warns against. Must move to
+    /// hashing ciphertext the moment content encryption lands.
+    pub payload_hash: String,
+    /// `signature` (§3.1). See [`crate::signing`] for what this does and
+    /// does not prove today.
+    pub signature: Vec<u8>,
+    /// The capability's own small, inline arguments (a note's title and
+    /// body, a property's new value). Not routed through the content store —
+    /// §3.1's "payload behind `ContentID`, never inlined" describes the
+    /// **Content primitive** (design §2's table: potentially large,
+    /// independently addressable user data), not every operation's
+    /// arguments. `SetProperty` carrying one property inline is the shape
+    /// §3.2 itself describes.
+    pub payload: Vec<u8>,
+    /// Set when this operation's real payload lives in the content store
+    /// (`CreateContent`, `LinkContent`, and similar) rather than inline.
+    /// `payload` is empty when this is `Some`.
+    pub content_id: Option<ContentId>,
+}
+
+impl Operation {
+    /// Parses [`Self::kind`] against the fixed verb set, when it is one of
+    /// the nineteen. `None` for a capability's own free-form vocabulary.
+    pub fn verb(&self) -> Option<Verb> {
+        Verb::parse_kind(&self.kind)
+    }
+
+    /// The exact bytes [`Self::signature`] was produced over. Reconstructible
+    /// from the operation alone — needed so a verifier does not have to be
+    /// the same object that produced the signature.
+    pub fn canonical_header(&self) -> Vec<u8> {
+        canonical_header_bytes(
+            self.seq,
+            &self.operation_id,
+            self.parent_operation_id.as_deref(),
+            &self.entity_id,
+            &self.context_ids,
+            &self.schema_id,
+            &self.capability,
+            &self.kind,
+            &self.device_id,
+            self.recorded_at_ms,
+            &self.version_vector,
+            &self.payload_hash,
+        )
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn canonical_header_bytes(
+    seq: u64,
+    operation_id: &str,
+    parent_operation_id: Option<&str>,
+    entity_id: &str,
+    context_ids: &[String],
+    schema_id: &str,
+    capability: &str,
+    kind: &str,
+    device_id: &str,
+    recorded_at_ms: u64,
+    version_vector: &BTreeMap<String, u64>,
+    payload_hash: &str,
+) -> Vec<u8> {
+    let mut out = Vec::new();
+    out.extend_from_slice(&seq.to_be_bytes());
+    push_str(&mut out, operation_id);
+    push_opt_str(&mut out, parent_operation_id);
+    push_str(&mut out, entity_id);
+    out.extend_from_slice(&(context_ids.len() as u32).to_be_bytes());
+    for c in context_ids {
+        push_str(&mut out, c);
+    }
+    push_str(&mut out, schema_id);
+    push_str(&mut out, capability);
+    push_str(&mut out, kind);
+    push_str(&mut out, device_id);
+    out.extend_from_slice(&recorded_at_ms.to_be_bytes());
+    // `BTreeMap` iterates in key order — deterministic, `C2`-safe, unlike a
+    // `HashMap` this same field would tempt someone to reach for.
+    out.extend_from_slice(&(version_vector.len() as u32).to_be_bytes());
+    for (device, count) in version_vector {
+        push_str(&mut out, device);
+        out.extend_from_slice(&count.to_be_bytes());
+    }
+    push_str(&mut out, payload_hash);
+    out
 }
 
 // ---------------------------------------------------------------------------
-// Operation log — the data-plane half of `C1` this skeleton implements
+// Operation log — the data-plane half of `C1` this module implements
 // ---------------------------------------------------------------------------
 
 /// Why a log operation failed.
@@ -85,10 +239,17 @@ pub enum OperationLogError {
     /// end of the durable log rather than a hard failure — a process killed
     /// mid-`write` leaves a torn tail, and `C6`'s graceful-shutdown guarantee
     /// is what is supposed to prevent this in the real group-commit buffer.
-    /// A skeleton without that buffer still must not crash on the case it
-    /// exists to handle, so a torn tail here is treated as "everything up to
-    /// here is durable" instead.
     TornTail,
+    /// The log's leading format-version byte does not match anything this
+    /// build understands. Refused rather than misparsed — a wire-format
+    /// change is a decision `#1194`'s scope table asks for, not a silent
+    /// reinterpretation of old bytes.
+    UnsupportedVersion(u8),
+    /// The header this record just produced does not verify under its own
+    /// signature immediately after being written. Defensive: proves the
+    /// sign/verify round trip on every single append rather than trusting it
+    /// abstractly — see the ingest-time obligation in `C2`.
+    SignatureMismatchOnWrite,
 }
 
 impl std::fmt::Display for OperationLogError {
@@ -96,6 +257,15 @@ impl std::fmt::Display for OperationLogError {
         match self {
             Self::Io(m) => write!(f, "operation log I/O error: {m}"),
             Self::TornTail => write!(f, "operation log tail is truncated"),
+            Self::UnsupportedVersion(v) => {
+                write!(f, "operation log format version {v} is not supported")
+            }
+            Self::SignatureMismatchOnWrite => {
+                write!(
+                    f,
+                    "a freshly written operation failed its own signature check"
+                )
+            }
         }
     }
 }
@@ -108,67 +278,189 @@ impl From<std::io::Error> for OperationLogError {
     }
 }
 
+/// The only format version this build writes or accepts.
+const FORMAT_VERSION: u8 = 1;
+
+/// What [`OperationLog::append`] needs beyond what only the log itself
+/// knows (`seq`, `device_id`, `version_vector`, `operation_id`, `signature`).
+#[allow(clippy::too_many_arguments)]
+pub struct AppendRequest<'a> {
+    pub capability: &'a str,
+    pub kind: &'a str,
+    pub payload: &'a [u8],
+    pub recorded_at_ms: u64,
+    pub entity_id: &'a str,
+    pub parent_operation_id: Option<&'a str>,
+    pub context_ids: &'a [&'a str],
+    pub schema_id: &'a str,
+    pub content_id: Option<ContentId>,
+}
+
+/// The mutable, lock-guarded half of [`OperationLog`]: the persistent write
+/// handle and the next sequence number, updated together. This is what makes
+/// concurrent appends safe — two threads racing `OperationLog::append` take
+/// this lock in turn, so `seq` assignment and the byte write it labels can
+/// never interleave with another thread's.
+struct LogWriterState {
+    next_seq: u64,
+    file: File,
+}
+
 /// Sequential, append-only, file-backed operation log.
 ///
 /// `C1`: *"writes are sequential and append-only; no in-place rewrite."*
-/// Every [`Self::append`] opens the file in append mode, writes one encoded
-/// record, and flushes before returning — the skeleton's stand-in for the
-/// group-commit buffer's bounded flush window (`C1`, `C6`). There is no
-/// separate durability point to widen later without changing this type's
-/// public shape.
+/// Every [`Self::append`] writes one encoded record under
+/// [`LogWriterState`]'s lock and flushes + `fsync`s before returning.
 pub struct OperationLog {
     path: PathBuf,
-    next_seq: AtomicU64,
+    device_id: String,
+    signer: Arc<dyn SignerVerifier>,
+    state: Mutex<LogWriterState>,
 }
 
 impl OperationLog {
-    /// Opens the log at `path`, creating it if absent. If it already has
-    /// entries, replays them once to recover the next sequence number — the
-    /// same replay [`Self::replay`] performs, run once at open time so a
-    /// restart resumes numbering rather than colliding with what is already
-    /// durable.
+    /// Opens the log at `path`, creating it (and a format-version byte) if
+    /// absent. `device_id` is persisted beside the log
+    /// ([`load_or_create_device_id`]) so restarts keep the same identity —
+    /// load-bearing for [`Operation::version_vector`] to mean anything across
+    /// a restart.
     pub fn open(path: impl Into<PathBuf>) -> Result<Self, OperationLogError> {
         let path = path.into();
-        OpenOptions::new().create(true).append(true).open(&path)?;
+        let device_id = load_or_create_device_id(&path)?;
+        let signer: Arc<dyn SignerVerifier> =
+            Arc::new(DeviceKeySigner::new(device_id.as_bytes().to_vec()));
+        Self::open_with_identity(path, device_id, signer)
+    }
+
+    /// As [`Self::open`], with an explicit device id and signer — the seam a
+    /// test (or, later, Phase 1's Vault) uses to control identity rather than
+    /// accept whatever was generated on first open.
+    pub fn open_with_identity(
+        path: impl Into<PathBuf>,
+        device_id: String,
+        signer: Arc<dyn SignerVerifier>,
+    ) -> Result<Self, OperationLogError> {
+        let path = path.into();
+        let is_new = !path.exists();
+        if is_new {
+            let mut f = OpenOptions::new()
+                .create(true)
+                .write(true)
+                .truncate(true)
+                .open(&path)?;
+            f.write_all(&[FORMAT_VERSION])?;
+            f.sync_data()?;
+        }
         let existing = Self::read_all(&path)?;
         let next_seq = existing.last().map(|op| op.seq + 1).unwrap_or(0);
+        let file = OpenOptions::new().append(true).open(&path)?;
         Ok(Self {
             path,
-            next_seq: AtomicU64::new(next_seq),
+            device_id,
+            signer,
+            state: Mutex::new(LogWriterState { next_seq, file }),
         })
     }
 
+    pub fn device_id(&self) -> &str {
+        &self.device_id
+    }
+
     /// Appends one operation and returns it with its assigned `seq`.
-    pub fn append(
-        &self,
-        capability: &str,
-        kind: &str,
-        payload: &[u8],
-        recorded_at_ms: u64,
-    ) -> Result<Operation, OperationLogError> {
+    /// `seq` assignment, header construction, signing, the byte write, and
+    /// the durability sync all happen under one lock — see the module doc's
+    /// concurrent-writer-safety note.
+    pub fn append(&self, req: AppendRequest<'_>) -> Result<Operation, OperationLogError> {
+        let mut guard = self.state.lock().unwrap();
+        let seq = guard.next_seq;
+
+        let payload_hash = sha256_hex(req.payload);
+        let operation_id = sha256_hex(
+            format!(
+                "{}\u{1f}{}\u{1f}{}\u{1f}{}\u{1f}{}\u{1f}{}",
+                self.device_id, seq, req.capability, req.kind, payload_hash, req.recorded_at_ms
+            )
+            .as_bytes(),
+        );
+        let context_ids: Vec<String> = req.context_ids.iter().map(|s| s.to_string()).collect();
+        let mut version_vector = BTreeMap::new();
+        version_vector.insert(self.device_id.clone(), seq + 1);
+
+        let canonical = canonical_header_bytes(
+            seq,
+            &operation_id,
+            req.parent_operation_id,
+            req.entity_id,
+            &context_ids,
+            req.schema_id,
+            req.capability,
+            req.kind,
+            &self.device_id,
+            req.recorded_at_ms,
+            &version_vector,
+            &payload_hash,
+        );
+        let signature = self.signer.sign(&canonical);
+        // Ingest-time obligation (`C2`): verify before the record is
+        // considered durable, not after.
+        if !self.signer.verify(&canonical, &signature) {
+            return Err(OperationLogError::SignatureMismatchOnWrite);
+        }
+
         let op = Operation {
-            seq: self.next_seq.fetch_add(1, Ordering::SeqCst),
-            capability: capability.to_string(),
-            kind: kind.to_string(),
-            payload: payload.to_vec(),
-            recorded_at_ms,
+            seq,
+            operation_id,
+            parent_operation_id: req.parent_operation_id.map(str::to_string),
+            entity_id: req.entity_id.to_string(),
+            context_ids,
+            schema_id: req.schema_id.to_string(),
+            capability: req.capability.to_string(),
+            kind: req.kind.to_string(),
+            device_id: self.device_id.clone(),
+            recorded_at_ms: req.recorded_at_ms,
+            version_vector,
+            payload_hash,
+            signature,
+            payload: req.payload.to_vec(),
+            content_id: req.content_id,
         };
-        let mut file = OpenOptions::new().append(true).open(&self.path)?;
-        file.write_all(&encode(&op))?;
-        file.flush()?;
-        file.sync_data()?;
+
+        guard.file.write_all(&encode(&op))?;
+        guard.file.flush()?;
+        guard.file.sync_data()?;
+        guard.next_seq = seq + 1;
+
         Ok(op)
     }
 
     /// Replays every durable operation, in write order, in a single pass over
     /// the file. `C2`: *"replay is a single pass"* · *"the same log produces
-    /// byte-identical state on every device."*
+    /// byte-identical state on every device."* Does **not** re-verify
+    /// signatures — `C2`: *"replay below the watermark does not re-verify"*;
+    /// every record here was already verified at [`Self::append`] time. Use
+    /// [`Self::replay_reverifying`] to check anyway (what the conformance
+    /// suite uses to prove tamper detection on the file itself).
     pub fn replay(&self) -> Result<Vec<Operation>, OperationLogError> {
         Self::read_all(&self.path)
     }
 
-    /// How many operations are durable right now. Used by tests to assert
-    /// persistence happened, without going through replay.
+    /// As [`Self::replay`], but re-verifies every signature against
+    /// [`Self::device_id`]'s signer. Not the normal path (`C2` explicitly
+    /// forbids re-verifying below the watermark, for cost reasons on a large
+    /// log) — this exists so the conformance suite can prove a tampered file
+    /// is detectable at all, rather than merely trusting the in-memory
+    /// `Signer`/`Verifier` unit tests.
+    pub fn replay_reverifying(&self) -> Result<Vec<Operation>, ReplayVerifyError> {
+        let ops = self.replay().map_err(ReplayVerifyError::Log)?;
+        for op in &ops {
+            if !self.signer.verify(&op.canonical_header(), &op.signature) {
+                return Err(ReplayVerifyError::Unverifiable(op.seq));
+            }
+        }
+        Ok(ops)
+    }
+
+    /// How many operations are durable right now.
     pub fn len(&self) -> Result<usize, OperationLogError> {
         Ok(Self::read_all(&self.path)?.len())
     }
@@ -185,39 +477,141 @@ impl OperationLog {
         };
         let mut bytes = Vec::new();
         file.read_to_end(&mut bytes)?;
-        decode_all(&bytes)
+        if bytes.is_empty() {
+            return Ok(Vec::new());
+        }
+        let version = bytes[0];
+        if version != FORMAT_VERSION {
+            return Err(OperationLogError::UnsupportedVersion(version));
+        }
+        decode_all(&bytes[1..])
     }
+}
+
+#[derive(Debug)]
+pub enum ReplayVerifyError {
+    Log(OperationLogError),
+    /// `op.seq` failed its signature check on replay.
+    Unverifiable(u64),
+}
+
+impl std::fmt::Display for ReplayVerifyError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Log(e) => write!(f, "{e}"),
+            Self::Unverifiable(seq) => write!(f, "operation {seq} failed signature verification"),
+        }
+    }
+}
+
+impl std::error::Error for ReplayVerifyError {}
+
+/// Reads (or generates and persists) a per-log device id, in a sibling file
+/// `<path>.device_id`. Not Vault-issued (see the module doc) — generated
+/// once from the path, the process id, and the current time, which is enough
+/// entropy to make two freshly created logs on the same machine unlikely to
+/// collide without pulling in a UUID/RNG dependency this crate does not
+/// carry.
+fn load_or_create_device_id(log_path: &Path) -> Result<String, OperationLogError> {
+    let id_path = device_id_path(log_path);
+    if let Ok(existing) = std::fs::read_to_string(&id_path) {
+        let trimmed = existing.trim();
+        if !trimmed.is_empty() {
+            return Ok(trimmed.to_string());
+        }
+    }
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos();
+    let seed = format!(
+        "{}\u{1f}{}\u{1f}{}",
+        log_path.display(),
+        std::process::id(),
+        nanos
+    );
+    let device_id = sha256_hex(seed.as_bytes())[..16].to_string();
+    std::fs::write(&id_path, &device_id)?;
+    Ok(device_id)
+}
+
+fn device_id_path(log_path: &Path) -> PathBuf {
+    let mut name = log_path
+        .file_name()
+        .map(|n| n.to_string_lossy().into_owned())
+        .unwrap_or_default();
+    name.push_str(".device_id");
+    log_path.with_file_name(name)
+}
+
+fn content_dir_for(log_path: &Path) -> PathBuf {
+    let mut name = log_path
+        .file_name()
+        .map(|n| n.to_string_lossy().into_owned())
+        .unwrap_or_default();
+    name.push_str(".content");
+    log_path.with_file_name(name)
 }
 
 // ---------------------------------------------------------------------------
 // Wire format — hand-rolled: this crate carries zero dependencies (see the
-// note in `Cargo.toml`), so no serde, no bincode. Every field is
-// length-prefixed and fixed-width integers are big-endian, which is what
-// makes the format itself platform-independent — part of `C2`'s
-// byte-identical-on-every-platform guarantee.
+// note in `Cargo.toml`), so no serde. Every field is length-prefixed and
+// fixed-width integers are big-endian, which is what makes the format itself
+// platform-independent — part of `C2`'s byte-identical-on-every-platform
+// guarantee. `FORMAT_VERSION` (currently `1`) gates this whole shape; a
+// future incompatible change bumps it and adds a branch, per `C1`'s
+// "migrations are pure, total, forward-only" (`crate::projection` — not this
+// module's job, since this module never rewrites the log itself).
 // ---------------------------------------------------------------------------
 
+fn push_str(out: &mut Vec<u8>, s: &str) {
+    let bytes = s.as_bytes();
+    out.extend_from_slice(&(bytes.len() as u32).to_be_bytes());
+    out.extend_from_slice(bytes);
+}
+
+fn push_opt_str(out: &mut Vec<u8>, s: Option<&str>) {
+    match s {
+        Some(s) => {
+            out.push(1);
+            push_str(out, s);
+        }
+        None => out.push(0),
+    }
+}
+
 fn encode(op: &Operation) -> Vec<u8> {
-    let capability = op.capability.as_bytes();
-    let kind = op.kind.as_bytes();
-    let mut out =
-        Vec::with_capacity(8 + 8 + 4 + capability.len() + 4 + kind.len() + 4 + op.payload.len());
+    let mut out = Vec::new();
     out.extend_from_slice(&op.seq.to_be_bytes());
+    push_str(&mut out, &op.operation_id);
+    push_opt_str(&mut out, op.parent_operation_id.as_deref());
+    push_str(&mut out, &op.entity_id);
+    out.extend_from_slice(&(op.context_ids.len() as u32).to_be_bytes());
+    for c in &op.context_ids {
+        push_str(&mut out, c);
+    }
+    push_str(&mut out, &op.schema_id);
+    push_str(&mut out, &op.capability);
+    push_str(&mut out, &op.kind);
+    push_str(&mut out, &op.device_id);
     out.extend_from_slice(&op.recorded_at_ms.to_be_bytes());
-    out.extend_from_slice(&(capability.len() as u32).to_be_bytes());
-    out.extend_from_slice(capability);
-    out.extend_from_slice(&(kind.len() as u32).to_be_bytes());
-    out.extend_from_slice(kind);
+    out.extend_from_slice(&(op.version_vector.len() as u32).to_be_bytes());
+    for (device, count) in &op.version_vector {
+        push_str(&mut out, device);
+        out.extend_from_slice(&count.to_be_bytes());
+    }
+    push_str(&mut out, &op.payload_hash);
+    out.extend_from_slice(&(op.signature.len() as u32).to_be_bytes());
+    out.extend_from_slice(&op.signature);
     out.extend_from_slice(&(op.payload.len() as u32).to_be_bytes());
     out.extend_from_slice(&op.payload);
+    push_opt_str(&mut out, op.content_id.as_ref().map(|c| c.as_str()));
     out
 }
 
 /// Decodes every complete record in `bytes`, in order. A torn tail (fewer
-/// bytes than the last record's declared length — the crash-mid-write case)
-/// stops decoding at the last complete record rather than erroring: what
-/// survived is exactly what a reader restarting after a kill would see as
-/// durable.
+/// bytes than the last record's declared length) stops decoding at the last
+/// complete record rather than erroring.
 fn decode_all(bytes: &[u8]) -> Result<Vec<Operation>, OperationLogError> {
     let mut ops = Vec::new();
     let mut cursor = 0usize;
@@ -232,18 +626,48 @@ fn decode_one(bytes: &[u8]) -> Option<(Operation, usize)> {
     let mut pos = 0usize;
 
     let seq = read_u64(bytes, &mut pos)?;
+    let operation_id = read_string(bytes, &mut pos)?;
+    let parent_operation_id = read_opt_string(bytes, &mut pos)?;
+    let entity_id = read_string(bytes, &mut pos)?;
+    let context_count = read_u32(bytes, &mut pos)? as usize;
+    let mut context_ids = Vec::with_capacity(context_count);
+    for _ in 0..context_count {
+        context_ids.push(read_string(bytes, &mut pos)?);
+    }
+    let schema_id = read_string(bytes, &mut pos)?;
+    let capability = read_string(bytes, &mut pos)?;
+    let kind = read_string(bytes, &mut pos)?;
+    let device_id = read_string(bytes, &mut pos)?;
     let recorded_at_ms = read_u64(bytes, &mut pos)?;
-    let capability = read_bytes(bytes, &mut pos)?;
-    let kind = read_bytes(bytes, &mut pos)?;
+    let vv_count = read_u32(bytes, &mut pos)? as usize;
+    let mut version_vector = BTreeMap::new();
+    for _ in 0..vv_count {
+        let device = read_string(bytes, &mut pos)?;
+        let count = read_u64(bytes, &mut pos)?;
+        version_vector.insert(device, count);
+    }
+    let payload_hash = read_string(bytes, &mut pos)?;
+    let signature = read_bytes(bytes, &mut pos)?;
     let payload = read_bytes(bytes, &mut pos)?;
+    let content_id = read_opt_string(bytes, &mut pos)?.map(ContentId::from_hex);
 
     Some((
         Operation {
             seq,
-            capability: String::from_utf8(capability).ok()?,
-            kind: String::from_utf8(kind).ok()?,
-            payload,
+            operation_id,
+            parent_operation_id,
+            entity_id,
+            context_ids,
+            schema_id,
+            capability,
+            kind,
+            device_id,
             recorded_at_ms,
+            version_vector,
+            payload_hash,
+            signature,
+            payload,
+            content_id,
         },
         pos,
     ))
@@ -271,6 +695,20 @@ fn read_bytes(bytes: &[u8], pos: &mut usize) -> Option<Vec<u8>> {
     Some(slice.to_vec())
 }
 
+fn read_string(bytes: &[u8], pos: &mut usize) -> Option<String> {
+    String::from_utf8(read_bytes(bytes, pos)?).ok()
+}
+
+fn read_opt_string(bytes: &[u8], pos: &mut usize) -> Option<Option<String>> {
+    let tag = *bytes.get(*pos)?;
+    *pos += 1;
+    match tag {
+        0 => Some(None),
+        1 => Some(Some(read_string(bytes, pos)?)),
+        _ => None,
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Managed engines — the `#1302` lifecycle seam this module fills in
 // ---------------------------------------------------------------------------
@@ -289,18 +727,13 @@ impl ManagedEngine for VaultEngine {
 
 /// Wraps [`OperationLog`] as a `#1302` [`ManagedEngine`]: `start` proves the
 /// log is openable before anything depends on it being up, `stop` is a no-op
-/// because every write already synced itself (`C1`'s durability point is
-/// per-`append`, not deferred to shutdown, in this skeleton).
+/// because every write already synced itself.
 struct ReplayEngine {
     log: Arc<OperationLog>,
 }
 
 impl ManagedEngine for ReplayEngine {
     fn start(&self) -> Result<(), EngineError> {
-        // The log is already open by the time this runs (`Runtime::boot`
-        // opens it before registering the engine) — this call proves it by
-        // replaying once, so a corrupt log fails lifecycle start rather than
-        // the first read a capability performs.
         self.log
             .replay()
             .map(|_| ())
@@ -310,13 +743,11 @@ impl ManagedEngine for ReplayEngine {
     fn stop(&self) {}
 }
 
-/// The empty projection engine (`#1338`'s issue body: *"empty on purpose"*).
-/// It has no state and does no work — what it proves is that the seam exists
-/// and can be driven, rebuilt, and dropped through the same lifecycle every
-/// other engine goes through. Concrete projections, like
-/// [`crate::notes::NotesProjection`], are built directly from
-/// [`OperationLog::replay`] by the capability that owns them; they do not
-/// register anything here.
+/// The projection engine's lifecycle slot. [`crate::projection`] is where
+/// concrete projections and the delete-and-rebuild machinery for `#1195`
+/// live; this stays a lifecycle placeholder for the same reason it was one in
+/// `#1338` — a projection is folded fresh from [`Runtime::replay`] on every
+/// query, so there is no cached state for this slot to own or restart.
 struct ProjectionEngine;
 
 impl ManagedEngine for ProjectionEngine {
@@ -339,14 +770,13 @@ pub const PROJECTION_ENGINE: EngineName = "projection";
 #[derive(Debug)]
 pub enum RuntimeApiError {
     Log(OperationLogError),
-    /// The Supervisor's engine lifecycle refused the call — a dependency was
-    /// not `Running`, or an engine's own `start`/`stop` failed.
+    Content(ContentStoreError),
+    /// The Supervisor's engine lifecycle refused the call.
     Lifecycle(crate::supervisor::RuntimeError),
-    /// The function exists on the six-function surface (`C5`) but this
-    /// skeleton does not implement it — `attach_content`, `instantiate_context`
-    /// and `sync` are explicitly out of `#1338`'s scope (see the epic's
-    /// scope table). Returning this rather than `unimplemented!()` keeps the
-    /// surface callable and testable instead of a panic waiting to happen.
+    /// The function exists on the six-function surface (`C5`) but is not
+    /// implemented yet. `instantiate_context` (contexts are Phase 5) and
+    /// `sync` (Phase 3+, explicitly out of scope for `#1194`/`#1195`)
+    /// remain here; `attach_content` no longer does.
     OutOfScope(&'static str),
 }
 
@@ -354,9 +784,10 @@ impl std::fmt::Display for RuntimeApiError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::Log(e) => write!(f, "{e}"),
+            Self::Content(e) => write!(f, "{e}"),
             Self::Lifecycle(e) => write!(f, "{e}"),
             Self::OutOfScope(what) => {
-                write!(f, "{what} is out of scope for the runtime skeleton (#1338)")
+                write!(f, "{what} is out of scope for this phase")
             }
         }
     }
@@ -370,46 +801,68 @@ impl From<OperationLogError> for RuntimeApiError {
     }
 }
 
+impl From<ContentStoreError> for RuntimeApiError {
+    fn from(e: ContentStoreError) -> Self {
+        Self::Content(e)
+    }
+}
+
 /// A read-model built by folding an operation log. `C4`: *"every projection
-/// is rebuildable, cache-only, and disposable."* [`Runtime::query_projection`]
-/// is the seam this module said it would prove exists — a projection is
-/// never anything but the fold of a replay.
+/// is rebuildable, cache-only, and disposable."* [`crate::projection`] is
+/// where `#1195`'s generalized engine and conformance tests live; this trait
+/// is the seam they and [`Runtime::query_projection`] share.
 pub trait Projection: Sized {
     fn rebuild(ops: &[Operation]) -> Self;
 }
 
-/// The runtime skeleton: `Operation → Persist → Replay → Projection`, wired
-/// through the `#1302` Supervisor's engine lifecycle rather than around it.
-///
-/// `C5`'s six-function surface, exactly: [`Self::emit_operation`],
-/// [`Self::attach_content`], [`Self::query_projection`],
-/// [`Self::instantiate_context`], [`Self::replay`], [`Self::sync`]. The last
-/// three of those six are declared but intentionally return
-/// [`RuntimeApiError::OutOfScope`] — see the epic's scope table (Vault, the
-/// Operation Log, and the empty Projection Engine are "In"; Sync, AI and
-/// Workflows are "Out").
+/// A capability-facing request to emit an operation. Everything beyond the
+/// four fields `#1338` already had (`capability`/`kind`/`payload`/
+/// `recorded_at_ms`) defaults to empty/`None` through
+/// [`Runtime::emit_operation`] — a capability that has not adopted the
+/// entity/property model pays nothing for the fields it does not use.
+#[allow(clippy::too_many_arguments)]
+pub struct OperationRequest<'a> {
+    pub capability: &'a str,
+    pub kind: &'a str,
+    pub payload: &'a [u8],
+    pub recorded_at_ms: u64,
+    pub entity_id: &'a str,
+    pub parent_operation_id: Option<&'a str>,
+    pub context_ids: &'a [&'a str],
+    pub schema_id: &'a str,
+    /// When set, stored in the content store first; the resulting
+    /// [`ContentId`] is attached to the operation and `payload` is expected
+    /// to carry only small structural arguments (or be empty).
+    pub content: Option<&'a [u8]>,
+}
+
+/// `Operation → Persist → Replay → Projection`, wired through the `#1302`
+/// Supervisor's engine lifecycle. `C5`'s six-function surface:
+/// [`Self::emit_operation`], [`Self::attach_content`],
+/// [`Self::query_projection`], [`Self::instantiate_context`],
+/// [`Self::replay`], [`Self::sync`].
 pub struct Runtime {
     supervisor: Supervisor,
     log: Arc<OperationLog>,
+    content: Arc<ContentStore>,
 }
 
 impl Runtime {
     /// Boots the runtime with only the Supervisor and the three lifecycle
-    /// engines this skeleton needs — condition 1 of `#1311`: *"the runtime
-    /// boots with only the Supervisor."* No AI engine, no sync engine, is
-    /// registered here; there is nothing in this module that could register
-    /// one.
+    /// engines this phase needs — condition 1 of `#1311`: *"the runtime boots
+    /// with only the Supervisor."*
     pub fn boot(
         budget: crate::budget::ResourceBudget,
         log_path: impl Into<PathBuf>,
     ) -> Result<Self, RuntimeApiError> {
-        let log = Arc::new(OperationLog::open(log_path)?);
+        let log_path = log_path.into();
+        let content_dir = content_dir_for(&log_path);
+        let log = Arc::new(OperationLog::open(&log_path)?);
+        let content = Arc::new(ContentStore::open(&content_dir)?);
         let mut supervisor = Supervisor::new(budget);
 
         // `C6`: "dependency ordering is enforced: Vault before Replay before
-        // Projection." Registration order alone does not enforce this --
-        // `depends_on` does, and `EngineRegistry::start` refuses out-of-order
-        // starts even if a caller tries.
+        // Projection."
         supervisor.register_engine(VAULT_ENGINE, &[], Box::new(VaultEngine));
         supervisor.register_engine(
             REPLAY_ENGINE,
@@ -432,18 +885,28 @@ impl Runtime {
             .start_engine(PROJECTION_ENGINE)
             .map_err(RuntimeApiError::Lifecycle)?;
 
-        Ok(Self { supervisor, log })
+        Ok(Self {
+            supervisor,
+            log,
+            content,
+        })
     }
 
-    /// Every engine's lifecycle state, in registration order. Lets a caller
-    /// (or a test) prove the boot order actually happened, rather than
-    /// trusting `boot` did not silently skip a step.
+    /// Every engine's lifecycle state, in registration order.
     pub fn engine_health(&self) -> Vec<(EngineName, crate::lifecycle::EngineState)> {
         self.supervisor.health()
     }
 
-    /// The only write path onto the log. `C5`: a capability's entire
-    /// surface for causing a durable effect.
+    /// This device's id, as persisted beside the log. See the module doc:
+    /// locally generated, not yet Vault-issued.
+    pub fn device_id(&self) -> &str {
+        self.log.device_id()
+    }
+
+    /// The only write path onto the log for a capability that has not
+    /// adopted the entity/property/verb model — `#1338`'s original
+    /// signature, unchanged, so [`crate::notes`] needed no edits for this
+    /// formalization.
     pub fn emit_operation(
         &self,
         capability: &str,
@@ -451,45 +914,136 @@ impl Runtime {
         payload: &[u8],
         recorded_at_ms: u64,
     ) -> Result<Operation, RuntimeApiError> {
-        let op = self.log.append(capability, kind, payload, recorded_at_ms)?;
-        // `C6`: "metrics -- one place that knows operations/sec." Recorded
-        // against the replay engine, which is what actually persisted it.
+        self.emit_operation_ex(OperationRequest {
+            capability,
+            kind,
+            payload,
+            recorded_at_ms,
+            entity_id: "",
+            parent_operation_id: None,
+            context_ids: &[],
+            schema_id: "",
+            content: None,
+        })
+    }
+
+    /// Emits one of the nineteen fixed [`Verb`]s (`#1194`'s scope table),
+    /// with a real entity/context/schema header. The verb-based counterpart
+    /// to [`Self::emit_operation`], for a capability built against the
+    /// formal graph vocabulary rather than free-form `kind` strings.
+    #[allow(clippy::too_many_arguments)]
+    pub fn emit_verb_operation(
+        &self,
+        capability: &str,
+        verb: Verb,
+        entity_id: &str,
+        context_ids: &[&str],
+        schema_id: &str,
+        payload: &[u8],
+        content: Option<&[u8]>,
+        recorded_at_ms: u64,
+    ) -> Result<Operation, RuntimeApiError> {
+        self.emit_operation_ex(OperationRequest {
+            capability,
+            kind: verb.as_str(),
+            payload,
+            recorded_at_ms,
+            entity_id,
+            parent_operation_id: None,
+            context_ids,
+            schema_id,
+            content,
+        })
+    }
+
+    /// The full seam both [`Self::emit_operation`] and
+    /// [`Self::emit_verb_operation`] funnel through. When `req.content` is
+    /// set it is written to the content store first and the operation
+    /// carries only its [`ContentId`] — §3.1's "payload behind `ContentID`,
+    /// never inlined" for the Content primitive.
+    pub fn emit_operation_ex(
+        &self,
+        req: OperationRequest<'_>,
+    ) -> Result<Operation, RuntimeApiError> {
+        let content_id = match req.content {
+            Some(bytes) => Some(self.content.put(bytes)?),
+            None => None,
+        };
+        let op = self.log.append(AppendRequest {
+            capability: req.capability,
+            kind: req.kind,
+            payload: req.payload,
+            recorded_at_ms: req.recorded_at_ms,
+            entity_id: req.entity_id,
+            parent_operation_id: req.parent_operation_id,
+            context_ids: req.context_ids,
+            schema_id: req.schema_id,
+            content_id,
+        })?;
+        // `C6`: "metrics -- one place that knows operations/sec."
         self.supervisor.record_op(REPLAY_ENGINE);
         Ok(op)
     }
 
-    /// Replays the entire durable log, in write order, in one pass. What
-    /// [`Self::query_projection`] is built on, and what a conformance test
-    /// calls directly to prove replay-after-delete equals the original.
+    /// Replays the entire durable log, in write order, in one pass.
     pub fn replay(&self) -> Result<Vec<Operation>, RuntimeApiError> {
         Ok(self.log.replay()?)
     }
 
-    /// Rebuilds a projection from a fresh replay. Never from cached state --
+    /// Rebuilds a projection from a fresh replay. Never from cached state —
     /// `C4`: *"a projection may be deleted at any time and rebuilt from the
-    /// log with zero data loss."* There is nothing else this could read from,
-    /// because nothing else durable exists (`C1`).
+    /// log with zero data loss."*
     pub fn query_projection<P: Projection>(&self) -> Result<P, RuntimeApiError> {
         let ops = self.replay()?;
         Ok(P::rebuild(&ops))
     }
 
-    /// Out of scope for `#1338` (see the epic's scope table: the content
-    /// store is Phase 3). Declared so the six-function surface is complete
-    /// and callable, not so it does anything yet.
-    pub fn attach_content(&self) -> Result<(), RuntimeApiError> {
-        Err(RuntimeApiError::OutOfScope("attach_content"))
+    /// Stores `bytes` in the content store, content-addressed. `#1194`'s
+    /// scope: *"content-addressed encrypted content store"* (encrypted is
+    /// Phase 1's Vault — see [`crate::content`]'s module doc for the gap this
+    /// leaves today). This does **not** append an operation; a capability
+    /// that wants the attachment reachable from the log emits `CreateContent`
+    /// via [`Self::emit_verb_operation`] with `content: Some(bytes)`, which
+    /// calls this internally and links the resulting id into the header —
+    /// this method alone is for a capability that needs a `ContentId` before
+    /// it knows what operation will reference it.
+    pub fn attach_content(&self, bytes: &[u8]) -> Result<ContentId, RuntimeApiError> {
+        Ok(self.content.put(bytes)?)
     }
 
-    /// Out of scope for `#1338`. Contexts are Phase 5.
+    /// Reads content back by id.
+    pub fn read_content(&self, id: &ContentId) -> Result<Option<Vec<u8>>, RuntimeApiError> {
+        Ok(self.content.get(id)?)
+    }
+
+    /// Out of scope for this phase. Contexts are Phase 5.
     pub fn instantiate_context(&self) -> Result<(), RuntimeApiError> {
         Err(RuntimeApiError::OutOfScope("instantiate_context"))
     }
 
-    /// Out of scope for `#1338`. Sync is explicitly excluded by the epic's
-    /// scope table.
+    /// Out of scope for this phase. Both `#1194` and `#1195` name Sync as
+    /// blocked-on / explicitly excluded.
     pub fn sync(&self) -> Result<(), RuntimeApiError> {
         Err(RuntimeApiError::OutOfScope("sync"))
+    }
+
+    /// Re-verifies one operation against this runtime's signer, **and**
+    /// that `payload_hash` still matches `payload` — the signature alone
+    /// only covers the header (`payload_hash` is what the header commits to,
+    /// per §3.1; the raw payload bytes are not themselves signed), so a
+    /// payload tampered without updating its hash would pass a
+    /// signature-only check while still being wrong. Not the normal replay
+    /// path (`C2` forbids re-verifying below the watermark) — the seam a
+    /// conformance test uses to prove a tampered operation is detectable at
+    /// all.
+    pub fn verify_operation(&self, op: &Operation) -> bool {
+        sha256_hex(&op.payload) == op.payload_hash && self.log_verify(op)
+    }
+
+    fn log_verify(&self, op: &Operation) -> bool {
+        self.log
+            .signer
+            .verify(&op.canonical_header(), &op.signature)
     }
 
     /// Stops every engine in reverse dependency order and seals the
@@ -512,6 +1066,12 @@ mod tests {
         std::env::temp_dir().join(format!("airo_mind_runtime_test_{name}_{unique}.log"))
     }
 
+    fn cleanup(path: &Path) {
+        let _ = std::fs::remove_file(path);
+        let _ = std::fs::remove_file(device_id_path(path));
+        let _ = std::fs::remove_dir_all(content_dir_for(path));
+    }
+
     #[test]
     fn boots_with_only_the_supervisor_and_its_three_lifecycle_engines() {
         let path = temp_log_path("boot");
@@ -524,15 +1084,11 @@ mod tests {
                 (PROJECTION_ENGINE, crate::lifecycle::EngineState::Running),
             ]
         );
-        let _ = std::fs::remove_file(&path);
+        cleanup(&path);
     }
 
     #[test]
     fn vault_starts_before_replay_before_projection() {
-        // `boot` panics-free registration order alone would not catch a
-        // dependency mistake -- this asserts the registry actually enforced
-        // it, by checking the states are what only a correct start order
-        // produces.
         let path = temp_log_path("order");
         let runtime = Runtime::boot(ResourceBudget::new(2048), &path).unwrap();
         for (name, state) in runtime.engine_health() {
@@ -542,7 +1098,7 @@ mod tests {
                 "{name} did not reach Running"
             );
         }
-        let _ = std::fs::remove_file(&path);
+        cleanup(&path);
     }
 
     #[test]
@@ -564,7 +1120,7 @@ mod tests {
         assert_eq!(replayed[1].seq, 1);
         assert_eq!(replayed[1].payload, b"second");
 
-        let _ = std::fs::remove_file(&path);
+        cleanup(&path);
     }
 
     #[test]
@@ -586,17 +1142,30 @@ mod tests {
             .unwrap();
         assert_eq!(third.seq, 2, "sequence numbering must survive a restart");
 
-        let _ = std::fs::remove_file(&path);
+        cleanup(&path);
+    }
+
+    /// `#1194`: `device_id` must also survive a restart, or `version_vector`
+    /// means nothing across sessions.
+    #[test]
+    fn reopening_the_log_keeps_the_same_device_id() {
+        let path = temp_log_path("device_id_stable");
+        let first_id = {
+            let runtime = Runtime::boot(ResourceBudget::new(2048), &path).unwrap();
+            runtime.device_id().to_string()
+        };
+        let second_id = {
+            let runtime = Runtime::boot(ResourceBudget::new(2048), &path).unwrap();
+            runtime.device_id().to_string()
+        };
+        assert_eq!(first_id, second_id);
+        cleanup(&path);
     }
 
     #[test]
-    fn attach_content_instantiate_context_and_sync_are_explicitly_out_of_scope() {
+    fn instantiate_context_and_sync_are_explicitly_out_of_scope() {
         let path = temp_log_path("out_of_scope");
         let runtime = Runtime::boot(ResourceBudget::new(2048), &path).unwrap();
-        assert!(matches!(
-            runtime.attach_content(),
-            Err(RuntimeApiError::OutOfScope("attach_content"))
-        ));
         assert!(matches!(
             runtime.instantiate_context(),
             Err(RuntimeApiError::OutOfScope("instantiate_context"))
@@ -605,7 +1174,172 @@ mod tests {
             runtime.sync(),
             Err(RuntimeApiError::OutOfScope("sync"))
         ));
-        let _ = std::fs::remove_file(&path);
+        cleanup(&path);
+    }
+
+    /// `#1194`: `attach_content` is implemented, not declared out-of-scope,
+    /// as of this formalization.
+    #[test]
+    fn attach_content_round_trips_through_read_content() {
+        let path = temp_log_path("attach_content");
+        let runtime = Runtime::boot(ResourceBudget::new(2048), &path).unwrap();
+        let id = runtime.attach_content(b"a real content object").unwrap();
+        assert_eq!(
+            runtime.read_content(&id).unwrap().unwrap(),
+            b"a real content object"
+        );
+        cleanup(&path);
+    }
+
+    /// `#1194` scope: *"payload behind `ContentID`, never inlined"* for the
+    /// Content primitive. Emitting `CreateContent` with `content: Some(..)`
+    /// stores the bytes in the content store and the operation carries only
+    /// the resulting id.
+    #[test]
+    fn create_content_stores_bytes_out_of_line_and_links_the_content_id() {
+        let path = temp_log_path("create_content");
+        let runtime = Runtime::boot(ResourceBudget::new(2048), &path).unwrap();
+
+        let op = runtime
+            .emit_verb_operation(
+                "notes",
+                Verb::CreateContent,
+                "content-1",
+                &[],
+                "",
+                b"",
+                Some(b"the actual bytes"),
+                1,
+            )
+            .unwrap();
+
+        assert!(op.payload.is_empty(), "payload stays inline-empty");
+        let content_id = op
+            .content_id
+            .expect("CreateContent must attach a content id");
+        assert_eq!(
+            runtime.read_content(&content_id).unwrap().unwrap(),
+            b"the actual bytes"
+        );
+        cleanup(&path);
+    }
+
+    #[test]
+    fn every_operation_header_field_is_populated() {
+        let path = temp_log_path("full_header");
+        let runtime = Runtime::boot(ResourceBudget::new(2048), &path).unwrap();
+        let op = runtime
+            .emit_verb_operation(
+                "notes",
+                Verb::CreateEntity,
+                "n1",
+                &["ctx-a", "ctx-b"],
+                "schema-1",
+                b"payload",
+                None,
+                42,
+            )
+            .unwrap();
+
+        assert!(!op.operation_id.is_empty());
+        assert_eq!(op.parent_operation_id, None);
+        assert_eq!(op.entity_id, "n1");
+        assert_eq!(
+            op.context_ids,
+            vec!["ctx-a".to_string(), "ctx-b".to_string()]
+        );
+        assert_eq!(op.schema_id, "schema-1");
+        assert_eq!(op.capability, "notes");
+        assert_eq!(op.kind, "CreateEntity");
+        assert_eq!(op.verb(), Some(Verb::CreateEntity));
+        assert_eq!(op.device_id, runtime.device_id());
+        assert_eq!(op.recorded_at_ms, 42);
+        assert_eq!(op.version_vector.get(runtime.device_id()), Some(&1));
+        assert_eq!(op.payload_hash, sha256_hex(b"payload"));
+        assert!(!op.signature.is_empty());
+        assert!(runtime.verify_operation(&op));
+
+        cleanup(&path);
+    }
+
+    /// `#1194`: a tampered operation must fail verification. Proven against
+    /// the log's own re-verifying replay, not only the `Signer` unit tests.
+    #[test]
+    fn a_tampered_operation_fails_verification() {
+        let path = temp_log_path("tamper");
+        let runtime = Runtime::boot(ResourceBudget::new(2048), &path).unwrap();
+        let op = runtime
+            .emit_operation("notes", "note.create", b"original", 1)
+            .unwrap();
+        assert!(runtime.verify_operation(&op));
+
+        let mut tampered = op.clone();
+        tampered.payload = b"forged".to_vec();
+        assert!(
+            !runtime.verify_operation(&tampered),
+            "changing the payload must invalidate the signature"
+        );
+
+        let mut tampered_entity = op.clone();
+        tampered_entity.entity_id = "someone-elses-entity".to_string();
+        assert!(!runtime.verify_operation(&tampered_entity));
+
+        cleanup(&path);
+    }
+
+    /// `#1194`'s concurrent-writer-safety requirement: `seq` assignment and
+    /// the byte write it labels are one atomic step, so N threads appending
+    /// concurrently produce a contiguous, gap-free, non-corrupt log.
+    #[test]
+    fn concurrent_appends_from_multiple_threads_produce_a_gap_free_uncorrupted_log() {
+        let path = temp_log_path("concurrent");
+        let runtime = Arc::new(Runtime::boot(ResourceBudget::new(2048), &path).unwrap());
+
+        const THREADS: usize = 8;
+        const PER_THREAD: usize = 25;
+        let mut handles = Vec::new();
+        for t in 0..THREADS {
+            let runtime = runtime.clone();
+            handles.push(std::thread::spawn(move || {
+                for i in 0..PER_THREAD {
+                    runtime
+                        .emit_operation(
+                            "notes",
+                            "note.create",
+                            format!("t{t}-{i}").as_bytes(),
+                            (t * PER_THREAD + i) as u64,
+                        )
+                        .unwrap();
+                }
+            }));
+        }
+        for h in handles {
+            h.join().unwrap();
+        }
+
+        let ops = runtime.replay().unwrap();
+        assert_eq!(ops.len(), THREADS * PER_THREAD);
+
+        let mut seqs: Vec<u64> = ops.iter().map(|op| op.seq).collect();
+        seqs.sort_unstable();
+        let expected: Vec<u64> = (0..(THREADS * PER_THREAD) as u64).collect();
+        assert_eq!(seqs, expected, "seq must be contiguous and gap-free");
+
+        // Every record decoded cleanly (no interleaved/corrupt bytes) and
+        // every signature verifies -- a corrupted interleave would produce
+        // either a decode failure (already ruled out by the length check
+        // above) or a header that no longer matches its signature.
+        assert!(runtime.log.replay_reverifying().is_ok());
+
+        cleanup(&path);
+    }
+
+    #[test]
+    fn empty_log_replays_to_nothing() {
+        let path = temp_log_path("empty");
+        let runtime = Runtime::boot(ResourceBudget::new(2048), &path).unwrap();
+        assert!(runtime.replay().unwrap().is_empty());
+        cleanup(&path);
     }
 
     #[test]
@@ -617,8 +1351,6 @@ mod tests {
                 .emit_operation("notes", "note.create", b"whole", 1)
                 .unwrap();
         }
-        // Simulate a crash mid-write: append a few garbage bytes shorter than
-        // any valid record.
         {
             let mut file = OpenOptions::new().append(true).open(&path).unwrap();
             file.write_all(&[1, 2, 3]).unwrap();
@@ -627,14 +1359,18 @@ mod tests {
         assert_eq!(recovered.len(), 1);
         assert_eq!(recovered[0].payload, b"whole");
 
-        let _ = std::fs::remove_file(&path);
+        cleanup(&path);
     }
 
     #[test]
-    fn empty_log_replays_to_nothing() {
-        let path = temp_log_path("empty");
-        let runtime = Runtime::boot(ResourceBudget::new(2048), &path).unwrap();
-        assert!(runtime.replay().unwrap().is_empty());
-        let _ = std::fs::remove_file(&path);
+    fn an_unsupported_format_version_is_refused_rather_than_misparsed() {
+        let path = temp_log_path("bad_version");
+        std::fs::write(&path, [99u8]).unwrap();
+        let err = match OperationLog::open(&path) {
+            Ok(_) => panic!("expected an unsupported-version error"),
+            Err(e) => e,
+        };
+        assert!(matches!(err, OperationLogError::UnsupportedVersion(99)));
+        cleanup(&path);
     }
 }

--- a/rust/airo_mind_core/src/runtime.rs
+++ b/rust/airo_mind_core/src/runtime.rs
@@ -1,0 +1,640 @@
+//! The Operation → Persist → Replay → Projection vertical slice. `#1338`.
+//!
+//! `#1338` is the runtime skeleton: the smallest thing that proves the
+//! Supervisor (`#1302`) and a real replay engine can carry one capability
+//! end to end, through the Supervisor's own lifecycle rather than around it.
+//! It is deliberately narrow — see the module docs on [`crate::lifecycle`]
+//! for what this greenfields and what it still leaves for later phases:
+//!
+//! - **Vault** here is a lifecycle placeholder only. No identity, no key
+//!   hierarchy, no revocation ledger — that is Phase 1's full scope
+//!   (`docs/superpowers/specs/2026-07-27-airo-mind-roadmap.md`). What the
+//!   skeleton needs from Vault is one thing: that it exists as a dependency
+//!   `Replay` cannot start ahead of, per `C6`'s *"Vault before Replay before
+//!   Projection."*
+//! - **The operation log is real** — sequential, append-only, durable to a
+//!   file, replayable from scratch. What it is missing against `C1`'s full
+//!   contract: no group-commit window (each `append` is written and flushed
+//!   immediately), no signatures (`C7` is a later phase), no content store.
+//! - **The projection engine is empty on purpose** (per `#1338`'s issue
+//!   body): this module registers it as a lifecycle participant and nothing
+//!   more. What a projection actually contains is
+//!   [`crate::notes::NotesProjection`] — a concrete type built by folding the
+//!   log, owned by the capability that needs it, not by this module.
+//!
+//! # Determinism (`C2`)
+//!
+//! [`OperationLog::replay`] reads the file front-to-back once and returns
+//! operations in the order they were written. No `HashMap` iteration, no
+//! wall-clock read, on this path. `recorded_at_ms` is supplied by the caller
+//! (ultimately Dart, which owns the platform's notion of "now") and never
+//! sampled inside the runtime — the same discipline
+//! `airo_mind_whisper::api::meetings` already documents for
+//! `recorded_at_ms`.
+
+use std::fs::{File, OpenOptions};
+use std::io::{Read, Write};
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+
+use crate::engine::EngineError;
+use crate::lifecycle::{EngineName, ManagedEngine};
+use crate::supervisor::Supervisor;
+
+// ---------------------------------------------------------------------------
+// Operation
+// ---------------------------------------------------------------------------
+
+/// One durable entry in the operation log.
+///
+/// This is the beginning of the operation log condition (`#1194`) — a
+/// minimal, local, unsigned record. It is not that log: there is no device
+/// identity, no signature, no sync. What it proves is the shape everything
+/// after it depends on: a capability's mutation becomes one immutable,
+/// ordered, replayable fact.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Operation {
+    /// Monotonic, gap-free, assigned by [`OperationLog::append`]. The
+    /// product-facing citation everything else (a projection row, a UI
+    /// element) can point back at.
+    pub seq: u64,
+    /// Which capability emitted this. `"notes"` for every operation this
+    /// module's tests write.
+    pub capability: String,
+    /// The capability's own vocabulary for what happened —
+    /// `"note.create"`, `"note.delete"`, and so on. Opaque to the runtme;
+    /// only the capability that wrote it knows how to decode `payload`.
+    pub kind: String,
+    /// The capability's own encoding. The runtime never looks inside this —
+    /// `C5`: the runtime knows no domains.
+    pub payload: Vec<u8>,
+    /// Supplied by the caller, never sampled here (`C2`).
+    pub recorded_at_ms: u64,
+}
+
+// ---------------------------------------------------------------------------
+// Operation log — the data-plane half of `C1` this skeleton implements
+// ---------------------------------------------------------------------------
+
+/// Why a log operation failed.
+#[derive(Debug)]
+pub enum OperationLogError {
+    Io(String),
+    /// The file's tail did not parse as a complete record. Treated as the
+    /// end of the durable log rather than a hard failure — a process killed
+    /// mid-`write` leaves a torn tail, and `C6`'s graceful-shutdown guarantee
+    /// is what is supposed to prevent this in the real group-commit buffer.
+    /// A skeleton without that buffer still must not crash on the case it
+    /// exists to handle, so a torn tail here is treated as "everything up to
+    /// here is durable" instead.
+    TornTail,
+}
+
+impl std::fmt::Display for OperationLogError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Io(m) => write!(f, "operation log I/O error: {m}"),
+            Self::TornTail => write!(f, "operation log tail is truncated"),
+        }
+    }
+}
+
+impl std::error::Error for OperationLogError {}
+
+impl From<std::io::Error> for OperationLogError {
+    fn from(e: std::io::Error) -> Self {
+        Self::Io(e.to_string())
+    }
+}
+
+/// Sequential, append-only, file-backed operation log.
+///
+/// `C1`: *"writes are sequential and append-only; no in-place rewrite."*
+/// Every [`Self::append`] opens the file in append mode, writes one encoded
+/// record, and flushes before returning — the skeleton's stand-in for the
+/// group-commit buffer's bounded flush window (`C1`, `C6`). There is no
+/// separate durability point to widen later without changing this type's
+/// public shape.
+pub struct OperationLog {
+    path: PathBuf,
+    next_seq: AtomicU64,
+}
+
+impl OperationLog {
+    /// Opens the log at `path`, creating it if absent. If it already has
+    /// entries, replays them once to recover the next sequence number — the
+    /// same replay [`Self::replay`] performs, run once at open time so a
+    /// restart resumes numbering rather than colliding with what is already
+    /// durable.
+    pub fn open(path: impl Into<PathBuf>) -> Result<Self, OperationLogError> {
+        let path = path.into();
+        OpenOptions::new().create(true).append(true).open(&path)?;
+        let existing = Self::read_all(&path)?;
+        let next_seq = existing.last().map(|op| op.seq + 1).unwrap_or(0);
+        Ok(Self {
+            path,
+            next_seq: AtomicU64::new(next_seq),
+        })
+    }
+
+    /// Appends one operation and returns it with its assigned `seq`.
+    pub fn append(
+        &self,
+        capability: &str,
+        kind: &str,
+        payload: &[u8],
+        recorded_at_ms: u64,
+    ) -> Result<Operation, OperationLogError> {
+        let op = Operation {
+            seq: self.next_seq.fetch_add(1, Ordering::SeqCst),
+            capability: capability.to_string(),
+            kind: kind.to_string(),
+            payload: payload.to_vec(),
+            recorded_at_ms,
+        };
+        let mut file = OpenOptions::new().append(true).open(&self.path)?;
+        file.write_all(&encode(&op))?;
+        file.flush()?;
+        file.sync_data()?;
+        Ok(op)
+    }
+
+    /// Replays every durable operation, in write order, in a single pass over
+    /// the file. `C2`: *"replay is a single pass"* · *"the same log produces
+    /// byte-identical state on every device."*
+    pub fn replay(&self) -> Result<Vec<Operation>, OperationLogError> {
+        Self::read_all(&self.path)
+    }
+
+    /// How many operations are durable right now. Used by tests to assert
+    /// persistence happened, without going through replay.
+    pub fn len(&self) -> Result<usize, OperationLogError> {
+        Ok(Self::read_all(&self.path)?.len())
+    }
+
+    pub fn is_empty(&self) -> Result<bool, OperationLogError> {
+        Ok(self.len()? == 0)
+    }
+
+    fn read_all(path: &Path) -> Result<Vec<Operation>, OperationLogError> {
+        let mut file = match File::open(path) {
+            Ok(f) => f,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+            Err(e) => return Err(e.into()),
+        };
+        let mut bytes = Vec::new();
+        file.read_to_end(&mut bytes)?;
+        decode_all(&bytes)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Wire format — hand-rolled: this crate carries zero dependencies (see the
+// note in `Cargo.toml`), so no serde, no bincode. Every field is
+// length-prefixed and fixed-width integers are big-endian, which is what
+// makes the format itself platform-independent — part of `C2`'s
+// byte-identical-on-every-platform guarantee.
+// ---------------------------------------------------------------------------
+
+fn encode(op: &Operation) -> Vec<u8> {
+    let capability = op.capability.as_bytes();
+    let kind = op.kind.as_bytes();
+    let mut out =
+        Vec::with_capacity(8 + 8 + 4 + capability.len() + 4 + kind.len() + 4 + op.payload.len());
+    out.extend_from_slice(&op.seq.to_be_bytes());
+    out.extend_from_slice(&op.recorded_at_ms.to_be_bytes());
+    out.extend_from_slice(&(capability.len() as u32).to_be_bytes());
+    out.extend_from_slice(capability);
+    out.extend_from_slice(&(kind.len() as u32).to_be_bytes());
+    out.extend_from_slice(kind);
+    out.extend_from_slice(&(op.payload.len() as u32).to_be_bytes());
+    out.extend_from_slice(&op.payload);
+    out
+}
+
+/// Decodes every complete record in `bytes`, in order. A torn tail (fewer
+/// bytes than the last record's declared length — the crash-mid-write case)
+/// stops decoding at the last complete record rather than erroring: what
+/// survived is exactly what a reader restarting after a kill would see as
+/// durable.
+fn decode_all(bytes: &[u8]) -> Result<Vec<Operation>, OperationLogError> {
+    let mut ops = Vec::new();
+    let mut cursor = 0usize;
+    while let Some((op, consumed)) = decode_one(&bytes[cursor..]) {
+        ops.push(op);
+        cursor += consumed;
+    }
+    Ok(ops)
+}
+
+fn decode_one(bytes: &[u8]) -> Option<(Operation, usize)> {
+    let mut pos = 0usize;
+
+    let seq = read_u64(bytes, &mut pos)?;
+    let recorded_at_ms = read_u64(bytes, &mut pos)?;
+    let capability = read_bytes(bytes, &mut pos)?;
+    let kind = read_bytes(bytes, &mut pos)?;
+    let payload = read_bytes(bytes, &mut pos)?;
+
+    Some((
+        Operation {
+            seq,
+            capability: String::from_utf8(capability).ok()?,
+            kind: String::from_utf8(kind).ok()?,
+            payload,
+            recorded_at_ms,
+        },
+        pos,
+    ))
+}
+
+fn read_u64(bytes: &[u8], pos: &mut usize) -> Option<u64> {
+    let end = *pos + 8;
+    let slice: [u8; 8] = bytes.get(*pos..end)?.try_into().ok()?;
+    *pos = end;
+    Some(u64::from_be_bytes(slice))
+}
+
+fn read_u32(bytes: &[u8], pos: &mut usize) -> Option<u32> {
+    let end = *pos + 4;
+    let slice: [u8; 4] = bytes.get(*pos..end)?.try_into().ok()?;
+    *pos = end;
+    Some(u32::from_be_bytes(slice))
+}
+
+fn read_bytes(bytes: &[u8], pos: &mut usize) -> Option<Vec<u8>> {
+    let len = read_u32(bytes, pos)? as usize;
+    let end = *pos + len;
+    let slice = bytes.get(*pos..end)?;
+    *pos = end;
+    Some(slice.to_vec())
+}
+
+// ---------------------------------------------------------------------------
+// Managed engines — the `#1302` lifecycle seam this module fills in
+// ---------------------------------------------------------------------------
+
+/// The Vault lifecycle placeholder. See the module docs: this is not Phase
+/// 1's Vault, only the dependency slot `Replay` must wait on.
+struct VaultEngine;
+
+impl ManagedEngine for VaultEngine {
+    fn start(&self) -> Result<(), EngineError> {
+        Ok(())
+    }
+
+    fn stop(&self) {}
+}
+
+/// Wraps [`OperationLog`] as a `#1302` [`ManagedEngine`]: `start` proves the
+/// log is openable before anything depends on it being up, `stop` is a no-op
+/// because every write already synced itself (`C1`'s durability point is
+/// per-`append`, not deferred to shutdown, in this skeleton).
+struct ReplayEngine {
+    log: Arc<OperationLog>,
+}
+
+impl ManagedEngine for ReplayEngine {
+    fn start(&self) -> Result<(), EngineError> {
+        // The log is already open by the time this runs (`Runtime::boot`
+        // opens it before registering the engine) — this call proves it by
+        // replaying once, so a corrupt log fails lifecycle start rather than
+        // the first read a capability performs.
+        self.log
+            .replay()
+            .map(|_| ())
+            .map_err(|e| EngineError::Backend(e.to_string()))
+    }
+
+    fn stop(&self) {}
+}
+
+/// The empty projection engine (`#1338`'s issue body: *"empty on purpose"*).
+/// It has no state and does no work — what it proves is that the seam exists
+/// and can be driven, rebuilt, and dropped through the same lifecycle every
+/// other engine goes through. Concrete projections, like
+/// [`crate::notes::NotesProjection`], are built directly from
+/// [`OperationLog::replay`] by the capability that owns them; they do not
+/// register anything here.
+struct ProjectionEngine;
+
+impl ManagedEngine for ProjectionEngine {
+    fn start(&self) -> Result<(), EngineError> {
+        Ok(())
+    }
+
+    fn stop(&self) {}
+}
+
+pub const VAULT_ENGINE: EngineName = "vault";
+pub const REPLAY_ENGINE: EngineName = "replay";
+pub const PROJECTION_ENGINE: EngineName = "projection";
+
+// ---------------------------------------------------------------------------
+// Runtime — the six-function surface, `C5`
+// ---------------------------------------------------------------------------
+
+/// Why a Runtime API call failed.
+#[derive(Debug)]
+pub enum RuntimeApiError {
+    Log(OperationLogError),
+    /// The Supervisor's engine lifecycle refused the call — a dependency was
+    /// not `Running`, or an engine's own `start`/`stop` failed.
+    Lifecycle(crate::supervisor::RuntimeError),
+    /// The function exists on the six-function surface (`C5`) but this
+    /// skeleton does not implement it — `attach_content`, `instantiate_context`
+    /// and `sync` are explicitly out of `#1338`'s scope (see the epic's
+    /// scope table). Returning this rather than `unimplemented!()` keeps the
+    /// surface callable and testable instead of a panic waiting to happen.
+    OutOfScope(&'static str),
+}
+
+impl std::fmt::Display for RuntimeApiError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Log(e) => write!(f, "{e}"),
+            Self::Lifecycle(e) => write!(f, "{e}"),
+            Self::OutOfScope(what) => {
+                write!(f, "{what} is out of scope for the runtime skeleton (#1338)")
+            }
+        }
+    }
+}
+
+impl std::error::Error for RuntimeApiError {}
+
+impl From<OperationLogError> for RuntimeApiError {
+    fn from(e: OperationLogError) -> Self {
+        Self::Log(e)
+    }
+}
+
+/// A read-model built by folding an operation log. `C4`: *"every projection
+/// is rebuildable, cache-only, and disposable."* [`Runtime::query_projection`]
+/// is the seam this module said it would prove exists — a projection is
+/// never anything but the fold of a replay.
+pub trait Projection: Sized {
+    fn rebuild(ops: &[Operation]) -> Self;
+}
+
+/// The runtime skeleton: `Operation → Persist → Replay → Projection`, wired
+/// through the `#1302` Supervisor's engine lifecycle rather than around it.
+///
+/// `C5`'s six-function surface, exactly: [`Self::emit_operation`],
+/// [`Self::attach_content`], [`Self::query_projection`],
+/// [`Self::instantiate_context`], [`Self::replay`], [`Self::sync`]. The last
+/// three of those six are declared but intentionally return
+/// [`RuntimeApiError::OutOfScope`] — see the epic's scope table (Vault, the
+/// Operation Log, and the empty Projection Engine are "In"; Sync, AI and
+/// Workflows are "Out").
+pub struct Runtime {
+    supervisor: Supervisor,
+    log: Arc<OperationLog>,
+}
+
+impl Runtime {
+    /// Boots the runtime with only the Supervisor and the three lifecycle
+    /// engines this skeleton needs — condition 1 of `#1311`: *"the runtime
+    /// boots with only the Supervisor."* No AI engine, no sync engine, is
+    /// registered here; there is nothing in this module that could register
+    /// one.
+    pub fn boot(
+        budget: crate::budget::ResourceBudget,
+        log_path: impl Into<PathBuf>,
+    ) -> Result<Self, RuntimeApiError> {
+        let log = Arc::new(OperationLog::open(log_path)?);
+        let mut supervisor = Supervisor::new(budget);
+
+        // `C6`: "dependency ordering is enforced: Vault before Replay before
+        // Projection." Registration order alone does not enforce this --
+        // `depends_on` does, and `EngineRegistry::start` refuses out-of-order
+        // starts even if a caller tries.
+        supervisor.register_engine(VAULT_ENGINE, &[], Box::new(VaultEngine));
+        supervisor.register_engine(
+            REPLAY_ENGINE,
+            &[VAULT_ENGINE],
+            Box::new(ReplayEngine { log: log.clone() }),
+        );
+        supervisor.register_engine(
+            PROJECTION_ENGINE,
+            &[REPLAY_ENGINE],
+            Box::new(ProjectionEngine),
+        );
+
+        supervisor
+            .start_engine(VAULT_ENGINE)
+            .map_err(RuntimeApiError::Lifecycle)?;
+        supervisor
+            .start_engine(REPLAY_ENGINE)
+            .map_err(RuntimeApiError::Lifecycle)?;
+        supervisor
+            .start_engine(PROJECTION_ENGINE)
+            .map_err(RuntimeApiError::Lifecycle)?;
+
+        Ok(Self { supervisor, log })
+    }
+
+    /// Every engine's lifecycle state, in registration order. Lets a caller
+    /// (or a test) prove the boot order actually happened, rather than
+    /// trusting `boot` did not silently skip a step.
+    pub fn engine_health(&self) -> Vec<(EngineName, crate::lifecycle::EngineState)> {
+        self.supervisor.health()
+    }
+
+    /// The only write path onto the log. `C5`: a capability's entire
+    /// surface for causing a durable effect.
+    pub fn emit_operation(
+        &self,
+        capability: &str,
+        kind: &str,
+        payload: &[u8],
+        recorded_at_ms: u64,
+    ) -> Result<Operation, RuntimeApiError> {
+        let op = self.log.append(capability, kind, payload, recorded_at_ms)?;
+        // `C6`: "metrics -- one place that knows operations/sec." Recorded
+        // against the replay engine, which is what actually persisted it.
+        self.supervisor.record_op(REPLAY_ENGINE);
+        Ok(op)
+    }
+
+    /// Replays the entire durable log, in write order, in one pass. What
+    /// [`Self::query_projection`] is built on, and what a conformance test
+    /// calls directly to prove replay-after-delete equals the original.
+    pub fn replay(&self) -> Result<Vec<Operation>, RuntimeApiError> {
+        Ok(self.log.replay()?)
+    }
+
+    /// Rebuilds a projection from a fresh replay. Never from cached state --
+    /// `C4`: *"a projection may be deleted at any time and rebuilt from the
+    /// log with zero data loss."* There is nothing else this could read from,
+    /// because nothing else durable exists (`C1`).
+    pub fn query_projection<P: Projection>(&self) -> Result<P, RuntimeApiError> {
+        let ops = self.replay()?;
+        Ok(P::rebuild(&ops))
+    }
+
+    /// Out of scope for `#1338` (see the epic's scope table: the content
+    /// store is Phase 3). Declared so the six-function surface is complete
+    /// and callable, not so it does anything yet.
+    pub fn attach_content(&self) -> Result<(), RuntimeApiError> {
+        Err(RuntimeApiError::OutOfScope("attach_content"))
+    }
+
+    /// Out of scope for `#1338`. Contexts are Phase 5.
+    pub fn instantiate_context(&self) -> Result<(), RuntimeApiError> {
+        Err(RuntimeApiError::OutOfScope("instantiate_context"))
+    }
+
+    /// Out of scope for `#1338`. Sync is explicitly excluded by the epic's
+    /// scope table.
+    pub fn sync(&self) -> Result<(), RuntimeApiError> {
+        Err(RuntimeApiError::OutOfScope("sync"))
+    }
+
+    /// Stops every engine in reverse dependency order and seals the
+    /// Supervisor's shutdown buffer. `C6`: graceful shutdown.
+    pub fn shutdown(&self) {
+        self.supervisor.shutdown();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::budget::ResourceBudget;
+
+    fn temp_log_path(name: &str) -> PathBuf {
+        let unique = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        std::env::temp_dir().join(format!("airo_mind_runtime_test_{name}_{unique}.log"))
+    }
+
+    #[test]
+    fn boots_with_only_the_supervisor_and_its_three_lifecycle_engines() {
+        let path = temp_log_path("boot");
+        let runtime = Runtime::boot(ResourceBudget::new(2048), &path).unwrap();
+        assert_eq!(
+            runtime.engine_health(),
+            vec![
+                (VAULT_ENGINE, crate::lifecycle::EngineState::Running),
+                (REPLAY_ENGINE, crate::lifecycle::EngineState::Running),
+                (PROJECTION_ENGINE, crate::lifecycle::EngineState::Running),
+            ]
+        );
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn vault_starts_before_replay_before_projection() {
+        // `boot` panics-free registration order alone would not catch a
+        // dependency mistake -- this asserts the registry actually enforced
+        // it, by checking the states are what only a correct start order
+        // produces.
+        let path = temp_log_path("order");
+        let runtime = Runtime::boot(ResourceBudget::new(2048), &path).unwrap();
+        for (name, state) in runtime.engine_health() {
+            assert_eq!(
+                state,
+                crate::lifecycle::EngineState::Running,
+                "{name} did not reach Running"
+            );
+        }
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn emit_operation_persists_and_replay_returns_it_in_order() {
+        let path = temp_log_path("persist");
+        let runtime = Runtime::boot(ResourceBudget::new(2048), &path).unwrap();
+
+        runtime
+            .emit_operation("notes", "note.create", b"first", 1000)
+            .unwrap();
+        runtime
+            .emit_operation("notes", "note.create", b"second", 2000)
+            .unwrap();
+
+        let replayed = runtime.replay().unwrap();
+        assert_eq!(replayed.len(), 2);
+        assert_eq!(replayed[0].seq, 0);
+        assert_eq!(replayed[0].payload, b"first");
+        assert_eq!(replayed[1].seq, 1);
+        assert_eq!(replayed[1].payload, b"second");
+
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn reopening_the_log_resumes_sequence_numbering() {
+        let path = temp_log_path("resume");
+        {
+            let runtime = Runtime::boot(ResourceBudget::new(2048), &path).unwrap();
+            runtime
+                .emit_operation("notes", "note.create", b"a", 1)
+                .unwrap();
+            runtime
+                .emit_operation("notes", "note.create", b"b", 2)
+                .unwrap();
+            runtime.shutdown();
+        }
+        let runtime = Runtime::boot(ResourceBudget::new(2048), &path).unwrap();
+        let third = runtime
+            .emit_operation("notes", "note.create", b"c", 3)
+            .unwrap();
+        assert_eq!(third.seq, 2, "sequence numbering must survive a restart");
+
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn attach_content_instantiate_context_and_sync_are_explicitly_out_of_scope() {
+        let path = temp_log_path("out_of_scope");
+        let runtime = Runtime::boot(ResourceBudget::new(2048), &path).unwrap();
+        assert!(matches!(
+            runtime.attach_content(),
+            Err(RuntimeApiError::OutOfScope("attach_content"))
+        ));
+        assert!(matches!(
+            runtime.instantiate_context(),
+            Err(RuntimeApiError::OutOfScope("instantiate_context"))
+        ));
+        assert!(matches!(
+            runtime.sync(),
+            Err(RuntimeApiError::OutOfScope("sync"))
+        ));
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn a_torn_tail_is_treated_as_the_end_of_the_durable_log() {
+        let path = temp_log_path("torn");
+        {
+            let runtime = Runtime::boot(ResourceBudget::new(2048), &path).unwrap();
+            runtime
+                .emit_operation("notes", "note.create", b"whole", 1)
+                .unwrap();
+        }
+        // Simulate a crash mid-write: append a few garbage bytes shorter than
+        // any valid record.
+        {
+            let mut file = OpenOptions::new().append(true).open(&path).unwrap();
+            file.write_all(&[1, 2, 3]).unwrap();
+        }
+        let recovered = OperationLog::open(&path).unwrap().replay().unwrap();
+        assert_eq!(recovered.len(), 1);
+        assert_eq!(recovered[0].payload, b"whole");
+
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn empty_log_replays_to_nothing() {
+        let path = temp_log_path("empty");
+        let runtime = Runtime::boot(ResourceBudget::new(2048), &path).unwrap();
+        assert!(runtime.replay().unwrap().is_empty());
+        let _ = std::fs::remove_file(&path);
+    }
+}

--- a/rust/airo_mind_core/src/signing.rs
+++ b/rust/airo_mind_core/src/signing.rs
@@ -1,0 +1,172 @@
+//! Operation signing. `#1194`'s header field `signature`, and `C1`'s
+//! "durable state exists only as Operations" reading requires every one of
+//! them to carry one.
+//!
+//! # What this is, and what it is not
+//!
+//! `#1194`'s own issue body says it plainly: *"Blocked by Phase 1 (Vault) —
+//! operations are signed and payloads are encrypted."* There is no device
+//! identity or key hierarchy in this crate yet — Vault is a lifecycle
+//! placeholder in [`crate::runtime`], nothing more. Shipping *"signed"* as a
+//! checkbox with no verifiable mechanism behind it would be worse than
+//! marking it undone, so this module gives every operation something real to
+//! carry and verify today — a keyed digest over the header, keyed by the
+//! device id the log already carries — while being explicit that
+//! [`DeviceKeySigner`] is **not** a device certificate and does not resist an
+//! attacker who can read the device id.
+//!
+//! What is real: [`Signer::sign`]/[`Verifier::verify`] are exercised on every
+//! append, a tampered header fails verification (there is a test for it), and
+//! the trait boundary is exactly where Phase 1's real Ed25519-over-device-
+//! certificate signer plugs in — [`Runtime`](crate::runtime::Runtime) takes a
+//! `Box<dyn Signer>`, so swapping the implementation is a constructor
+//! argument, not a rewrite of anything that calls it.
+//!
+//! # Why a keyed digest and not a real signature scheme
+//!
+//! This crate carries zero dependencies (see `Cargo.toml`), so no ed25519
+//! crate. A hand-rolled elliptic-curve implementation is exactly the kind of
+//! `unsafe`-adjacent, security-critical code `C7` says must be *"isolated,
+//! documented, benchmarked, fuzzed, audited"* before it is trusted with a
+//! Vault's device keys — not something to improvise here as a side effect of
+//! formalizing the operation log. [`Sha256`] already exists for a different
+//! reason and is reused rather than adding a second hash implementation.
+
+use crate::digest::Sha256;
+
+/// Produces a signature over an operation header's canonical bytes
+/// (`crate::runtime::canonical_header_bytes`, the same bytes
+/// [`Verifier::verify`] must be given). Implementations decide what "signing"
+/// means; the runtime never inspects the output beyond passing it back to a
+/// matching [`Verifier`].
+pub trait Signer: Send + Sync {
+    fn sign(&self, canonical_header: &[u8]) -> Vec<u8>;
+}
+
+/// Checks a [`Signer`]'s output. Split from `Signer` because Phase 1's real
+/// implementation verifies against a device's *public* certificate without
+/// holding its private key — signing and verifying are different
+/// capabilities even when, as here, one placeholder type implements both.
+pub trait Verifier: Send + Sync {
+    fn verify(&self, canonical_header: &[u8], signature: &[u8]) -> bool;
+}
+
+/// A type that can both sign and verify — what [`crate::runtime::OperationLog`]
+/// needs, since this phase has one placeholder identity acting as both
+/// parties. Blanket-implemented; nothing implements this trait directly.
+pub trait SignerVerifier: Signer + Verifier {}
+impl<T: Signer + Verifier> SignerVerifier for T {}
+
+/// `sha256(device_key || canonical_header)`. Keyed by a per-device secret so
+/// two devices produce different signatures over the same header — the
+/// property a conformance test can check — without being anything close to a
+/// real signature scheme: **no non-repudiation, no asymmetric verification
+/// key, no resistance to an attacker who reads `device_key` off disk.**
+///
+/// `device_key` is deliberately not called a "private key" anywhere in this
+/// module's public API, to avoid implying a guarantee it does not carry.
+pub struct DeviceKeySigner {
+    device_key: Vec<u8>,
+}
+
+impl DeviceKeySigner {
+    pub fn new(device_key: impl Into<Vec<u8>>) -> Self {
+        Self {
+            device_key: device_key.into(),
+        }
+    }
+
+    fn digest(&self, canonical_header: &[u8]) -> Vec<u8> {
+        let mut h = Sha256::new();
+        // Domain-separated and length-prefixed: `C7`'s "injective,
+        // length-prefixed, domain-separated construction" for AAD-bound
+        // fields applies here too, even though this is a placeholder --
+        // getting the construction shape right now is free and is exactly
+        // what makes swapping in a real MAC later a drop-in.
+        h.update(b"airo-mind-op-sig-v1");
+        h.update(&(self.device_key.len() as u32).to_be_bytes());
+        h.update(&self.device_key);
+        h.update(&(canonical_header.len() as u32).to_be_bytes());
+        h.update(canonical_header);
+        hex_to_bytes(&h.finish())
+    }
+}
+
+impl Signer for DeviceKeySigner {
+    fn sign(&self, canonical_header: &[u8]) -> Vec<u8> {
+        self.digest(canonical_header)
+    }
+}
+
+impl Verifier for DeviceKeySigner {
+    fn verify(&self, canonical_header: &[u8], signature: &[u8]) -> bool {
+        // Not constant-time: `C7` requires that of secret-vs-secret
+        // comparisons. This compares a locally recomputed digest to a value
+        // that already traveled in plaintext on this log, so timing leaks
+        // nothing an attacker could not already read directly.
+        self.digest(canonical_header) == signature
+    }
+}
+
+fn hex_to_bytes(hex: &str) -> Vec<u8> {
+    (0..hex.len())
+        .step_by(2)
+        .map(|i| {
+            u8::from_str_radix(&hex[i..i + 2], 16).expect("Sha256::finish is always valid hex")
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_signature_verifies_against_the_same_header_it_was_taken_over() {
+        let signer = DeviceKeySigner::new(b"device-a".to_vec());
+        let header = b"seq=0;capability=notes;kind=note.create";
+        let sig = signer.sign(header);
+        assert!(signer.verify(header, &sig));
+    }
+
+    /// `C1`: durable state must be verifiable, and a verifier that accepts
+    /// anything is not one. A single flipped byte in the header must be
+    /// caught -- this is the "signature detects tampering" property `#1194`
+    /// exists to make provable rather than assumed.
+    #[test]
+    fn a_tampered_header_fails_verification() {
+        let signer = DeviceKeySigner::new(b"device-a".to_vec());
+        let header = b"seq=0;capability=notes;kind=note.create".to_vec();
+        let sig = signer.sign(&header);
+
+        let mut tampered = header.clone();
+        tampered[0] ^= 0x01;
+        assert!(!signer.verify(&tampered, &sig));
+    }
+
+    #[test]
+    fn a_tampered_signature_fails_verification() {
+        let signer = DeviceKeySigner::new(b"device-a".to_vec());
+        let header = b"seq=0;capability=notes;kind=note.create";
+        let mut sig = signer.sign(header);
+        sig[0] ^= 0x01;
+        assert!(!signer.verify(header, &sig));
+    }
+
+    /// Two devices must not be interchangeable signers -- the property that
+    /// makes `device_id` meaningful on the header at all.
+    #[test]
+    fn two_devices_produce_different_signatures_over_the_same_header() {
+        let a = DeviceKeySigner::new(b"device-a".to_vec());
+        let b = DeviceKeySigner::new(b"device-b".to_vec());
+        let header = b"seq=0;capability=notes;kind=note.create";
+        assert_ne!(a.sign(header), b.sign(header));
+    }
+
+    #[test]
+    fn signing_is_deterministic_for_the_same_key_and_header() {
+        let signer = DeviceKeySigner::new(b"device-a".to_vec());
+        let header = b"seq=0;capability=notes;kind=note.create";
+        assert_eq!(signer.sign(header), signer.sign(header));
+    }
+}

--- a/rust/airo_mind_core/src/supervisor.rs
+++ b/rust/airo_mind_core/src/supervisor.rs
@@ -2,15 +2,27 @@
 //!
 //! `C6`: *"every engine requests resources; the Supervisor grants them."*
 //!
-//! Scope is `#1396` — execute one pipeline. Two registration slots, not a
-//! registry; two run methods, not a job graph. A generic engine registry would
-//! not move the meeting pipeline this week, so it is backlog.
+//! Two concerns, both `C6`'s:
+//!
+//! - **Job execution** — `#1396`'s scope. Two registration slots (speech,
+//!   generation), admission against a memory budget, cooperative
+//!   cancellation. Unchanged by `#1302`.
+//! - **Engine lifecycle** — `#1302`'s scope. An arbitrary number of stateful
+//!   engines (Vault, Replay, Sync, Projection, ...) registered with
+//!   dependencies, started, stopped, restarted, and shut down in dependency
+//!   order. Delegated to [`crate::lifecycle::EngineRegistry`], which is where
+//!   the algorithms live; this module is the single point both concerns are
+//!   reached through, per `C6`'s *"one place"* framing.
 
 use crate::budget::ResourceBudget;
 use crate::cancel::CancelToken;
 use crate::engine::{
     AudioInput, EngineError, GenerationChunk, GenerationEngine, GenerationRequest, RuntimeStats,
     SpeechEngine, TranscriptSegment,
+};
+use crate::lifecycle::{
+    ConcurrencyLimiter, EngineMetrics, EngineName, EngineRegistry, EngineState, GroupCommitBuffer,
+    LifecycleError, ManagedEngine,
 };
 
 /// Why the Supervisor refused or stopped a job.
@@ -22,8 +34,16 @@ pub enum RuntimeError {
     /// it allocates, which is the only point where this is recoverable —
     /// afterwards it is an OOM kill, and on Android that takes the whole app.
     OverBudget { needs_mb: u32, budget_mb: u32 },
+    /// The concurrency cap (`C6`: *"resource limits ... concurrency caps"*)
+    /// is already at capacity. Refused before the job starts, the same way
+    /// `OverBudget` is — a job admitted then torn down mid-flight has already
+    /// spent the CPU this cap exists to bound.
+    OverCapacity { active: u32, max: u32 },
     /// The engine stopped.
     Engine(EngineError),
+    /// A lifecycle operation (start/stop/restart on a managed engine)
+    /// failed. See [`LifecycleError`] for the specific reason.
+    Lifecycle(LifecycleError),
 }
 
 impl std::fmt::Display for RuntimeError {
@@ -34,7 +54,11 @@ impl std::fmt::Display for RuntimeError {
                 needs_mb,
                 budget_mb,
             } => write!(f, "engine needs {needs_mb} MB, budget is {budget_mb} MB"),
+            Self::OverCapacity { active, max } => {
+                write!(f, "{active} jobs already active, cap is {max}")
+            }
             Self::Engine(e) => write!(f, "{e}"),
+            Self::Lifecycle(e) => write!(f, "{e}"),
         }
     }
 }
@@ -44,6 +68,12 @@ impl std::error::Error for RuntimeError {}
 impl From<EngineError> for RuntimeError {
     fn from(e: EngineError) -> Self {
         Self::Engine(e)
+    }
+}
+
+impl From<LifecycleError> for RuntimeError {
+    fn from(e: LifecycleError) -> Self {
+        Self::Lifecycle(e)
     }
 }
 
@@ -57,6 +87,9 @@ pub struct Supervisor {
     speech: Option<Box<dyn SpeechEngine>>,
     generation: Option<Box<dyn GenerationEngine>>,
     budget: ResourceBudget,
+    concurrency: ConcurrencyLimiter,
+    engines: EngineRegistry,
+    shutdown_buffer: GroupCommitBuffer,
 }
 
 impl Supervisor {
@@ -65,7 +98,21 @@ impl Supervisor {
             speech: None,
             generation: None,
             budget,
+            // Unbounded by default: existing callers (`#1396`'s meeting
+            // pipeline) never set a cap, and a cap that appears under them
+            // without being asked for would be a silent behavior change.
+            concurrency: ConcurrencyLimiter::unbounded(),
+            engines: EngineRegistry::new(),
+            shutdown_buffer: GroupCommitBuffer::new(),
         }
+    }
+
+    /// Caps how many jobs (`run_speech` + `run_generation` combined) may run
+    /// at once. `C6` / `#1302`: *"resource limits — memory ceilings and
+    /// concurrency caps, enforced centrally."*
+    pub fn with_max_concurrent_jobs(mut self, max: u32) -> Self {
+        self.concurrency = ConcurrencyLimiter::new(max);
+        self
     }
 
     pub fn register_speech(&mut self, engine: Box<dyn SpeechEngine>) {
@@ -96,6 +143,11 @@ impl Supervisor {
         self.budget
     }
 
+    /// How many jobs are currently admitted and running.
+    pub fn active_jobs(&self) -> u32 {
+        self.concurrency.active()
+    }
+
     /// Runs one speech job.
     ///
     /// Admission first, then execution. Segments reach the caller through
@@ -113,6 +165,7 @@ impl Supervisor {
             .as_ref()
             .ok_or(RuntimeError::NoEngine("speech"))?;
         self.admit(engine.resource_request().memory_mb)?;
+        let _slot = self.admit_concurrency()?;
         engine.transcribe(audio, cancel, sink)?;
         Ok(())
     }
@@ -129,6 +182,7 @@ impl Supervisor {
             .as_ref()
             .ok_or(RuntimeError::NoEngine("generation"))?;
         self.admit(engine.resource_request().memory_mb)?;
+        let _slot = self.admit_concurrency()?;
         engine.generate(request, cancel, sink)?;
         Ok(())
     }
@@ -141,6 +195,103 @@ impl Supervisor {
             });
         }
         Ok(())
+    }
+
+    fn admit_concurrency(&self) -> Result<crate::lifecycle::ConcurrencySlot<'_>, RuntimeError> {
+        self.concurrency
+            .admit()
+            .map_err(|(active, max)| RuntimeError::OverCapacity { active, max })
+    }
+
+    // -- Engine lifecycle (`C6`, `#1302`) -----------------------------------
+    //
+    // A second, independent registry from `speech`/`generation` above: those
+    // are per-call job slots, these are long-lived stateful engines (Vault,
+    // Replay, Sync, Projection, ...) with a dependency order between them.
+    // See `crate::lifecycle` for why the two are not modeled the same way.
+
+    /// Registers a stateful engine with the dependencies it needs `Running`
+    /// before it may start. Panics on a duplicate name or an unregistered
+    /// dependency — see [`EngineRegistry::register`].
+    pub fn register_engine(
+        &mut self,
+        name: EngineName,
+        depends_on: &[EngineName],
+        engine: Box<dyn ManagedEngine>,
+    ) {
+        self.engines.register(name, depends_on, engine);
+    }
+
+    /// Starts one registered engine. Refuses with
+    /// [`LifecycleError::DependencyNotReady`] if any dependency has not
+    /// reached [`EngineState::Running`] — this is the enforcement point for
+    /// *"Vault before Replay before Projection."*
+    pub fn start_engine(&self, name: EngineName) -> Result<(), RuntimeError> {
+        Ok(self.engines.start(name)?)
+    }
+
+    /// Stops one registered engine, ignoring dependency order. For an
+    /// ordered stop of everything, use [`Self::shutdown`].
+    pub fn stop_engine(&self, name: EngineName) -> Result<(), RuntimeError> {
+        Ok(self.engines.stop(name)?)
+    }
+
+    /// Stops then starts one engine, touching no other engine's state. `C6` /
+    /// S4: *"a failed engine restarts without corrupting the state of the
+    /// engines around it."*
+    pub fn restart_engine(&self, name: EngineName) -> Result<(), RuntimeError> {
+        Ok(self.engines.restart(name)?)
+    }
+
+    pub fn engine_state(&self, name: EngineName) -> Option<EngineState> {
+        self.engines.state_of(name)
+    }
+
+    /// Every registered engine's lifecycle state. `C6`: *"health — which
+    /// engines are up, which are degraded."*
+    pub fn health(&self) -> Vec<(EngineName, EngineState)> {
+        self.engines.health()
+    }
+
+    /// Records one unit of work against an engine, feeding
+    /// [`Self::engine_metrics`]'s operations count.
+    pub fn record_op(&self, name: EngineName) {
+        self.engines.record_op(name);
+    }
+
+    pub fn engine_metrics(&self, name: EngineName) -> Option<EngineMetrics> {
+        self.engines.metrics_of(name)
+    }
+
+    /// Stops every running engine in reverse dependency order, then flushes
+    /// and seals the group-commit buffer. `C6`: *"shutdown is graceful: the
+    /// group-commit buffer flushes and the active segment seals."*
+    ///
+    /// The buffer here is [`crate::lifecycle::GroupCommitBuffer`], the stand-
+    /// in for the operation log's real buffer until `#1338` lands it — see
+    /// that type's docs for why the stand-in is where it is.
+    pub fn shutdown(&self) {
+        self.engines.shutdown_all();
+        self.shutdown_buffer.flush();
+        self.shutdown_buffer.seal();
+    }
+
+    /// Buffers a write the way the pending operation log would, ahead of its
+    /// bounded group-commit window. Exposed so a caller — or a conformance
+    /// test — can simulate pending work that [`Self::shutdown`] must not
+    /// lose.
+    pub fn buffer_write(&self, bytes: &[u8]) {
+        self.shutdown_buffer.write(bytes);
+    }
+
+    /// What is durable after [`Self::shutdown`] — everything that was
+    /// buffered via [`Self::buffer_write`], nothing more and nothing less.
+    pub fn durable_buffer(&self) -> Vec<u8> {
+        self.shutdown_buffer.durable()
+    }
+
+    pub fn buffer_sealed(&self) -> bool {
+        self.shutdown_buffer.is_sealed()
     }
 }
 

--- a/rust/airo_mind_core/src/verb.rs
+++ b/rust/airo_mind_core/src/verb.rs
@@ -1,0 +1,182 @@
+//! The fixed verb set. `#1194`'s scope table, restated as a type instead of a
+//! bag of strings.
+//!
+//! Design doc §3.2: *"There is no `Delete`. Deletion is ambiguous and the
+//! ambiguity is dangerous."* Content is destroyed (`DestroyContent`, and only
+//! by crypto-shredding — Phase 1/Vault's job, not this one's); entities and
+//! relations are only ever created, set, added, or removed as **links** —
+//! `RemoveRelation` removes a relation, never the entities it joined.
+//!
+//! This is the runtime-level vocabulary. A capability's own domain vocabulary
+//! (`"note.create"`, in [`crate::notes`]) stays free-form on the wire — `C5`:
+//! *"the runtime knows no domains"* — but every capability that wants to
+//! participate in the entity/context graph the design describes emits one of
+//! these, and [`Runtime::emit_verb_operation`](crate::runtime::Runtime::emit_verb_operation)
+//! is the seam that requires it.
+
+/// One runtime verb, exactly the set `#1194` scopes. `as_str`/`from_str`
+/// round-trip through the wire format's `kind` field, so a verb-based
+/// operation and a capability's free-form `kind` string share one encoding —
+/// there is no second field to keep in sync.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum Verb {
+    CreateEntity,
+    SetProperty,
+    AddRelation,
+    RemoveRelation,
+    CreateContent,
+    LinkContent,
+    UnlinkContent,
+    DestroyContent,
+    CreateContext,
+    LinkContext,
+    UnlinkContext,
+    InstallPack,
+    UpgradePack,
+    RemovePack,
+    EnablePack,
+    DisablePack,
+    AuthorizeDevice,
+    RevokeDevice,
+    RevokeContentKey,
+}
+
+/// Every verb, in the order the design doc lists them. Exhaustive on purpose:
+/// [`Verb::all`], the round-trip test, and any future exhaustiveness check
+/// all read from one place.
+pub const ALL_VERBS: &[Verb] = &[
+    Verb::CreateEntity,
+    Verb::SetProperty,
+    Verb::AddRelation,
+    Verb::RemoveRelation,
+    Verb::CreateContent,
+    Verb::LinkContent,
+    Verb::UnlinkContent,
+    Verb::DestroyContent,
+    Verb::CreateContext,
+    Verb::LinkContext,
+    Verb::UnlinkContext,
+    Verb::InstallPack,
+    Verb::UpgradePack,
+    Verb::RemovePack,
+    Verb::EnablePack,
+    Verb::DisablePack,
+    Verb::AuthorizeDevice,
+    Verb::RevokeDevice,
+    Verb::RevokeContentKey,
+];
+
+impl Verb {
+    pub fn all() -> &'static [Verb] {
+        ALL_VERBS
+    }
+
+    /// The wire spelling. Matches the design doc's own `PascalCase` naming
+    /// exactly, so a captured operation log reads the same on the wire as it
+    /// does in the spec.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::CreateEntity => "CreateEntity",
+            Self::SetProperty => "SetProperty",
+            Self::AddRelation => "AddRelation",
+            Self::RemoveRelation => "RemoveRelation",
+            Self::CreateContent => "CreateContent",
+            Self::LinkContent => "LinkContent",
+            Self::UnlinkContent => "UnlinkContent",
+            Self::DestroyContent => "DestroyContent",
+            Self::CreateContext => "CreateContext",
+            Self::LinkContext => "LinkContext",
+            Self::UnlinkContext => "UnlinkContext",
+            Self::InstallPack => "InstallPack",
+            Self::UpgradePack => "UpgradePack",
+            Self::RemovePack => "RemovePack",
+            Self::EnablePack => "EnablePack",
+            Self::DisablePack => "DisablePack",
+            Self::AuthorizeDevice => "AuthorizeDevice",
+            Self::RevokeDevice => "RevokeDevice",
+            Self::RevokeContentKey => "RevokeContentKey",
+        }
+    }
+
+    /// Parses a `kind` string back into a verb, when it is one. A capability
+    /// emitting its own free-form `kind` (`"note.create"`) simply never
+    /// matches here — that is not an error, it is a capability that has not
+    /// opted into the formal graph vocabulary yet.
+    pub fn parse_kind(s: &str) -> Option<Self> {
+        ALL_VERBS.iter().copied().find(|v| v.as_str() == s)
+    }
+
+    /// Which primitive a verb mutates. Not load-bearing today, but the
+    /// grouping the design doc's table (§3.2) already implies, made checkable
+    /// rather than only visible in prose.
+    pub fn primitive(self) -> VerbPrimitive {
+        use Verb::*;
+        match self {
+            CreateEntity | SetProperty | AddRelation | RemoveRelation => VerbPrimitive::Entity,
+            CreateContent | LinkContent | UnlinkContent | DestroyContent => VerbPrimitive::Content,
+            CreateContext | LinkContext | UnlinkContext => VerbPrimitive::Context,
+            InstallPack | UpgradePack | RemovePack | EnablePack | DisablePack => {
+                VerbPrimitive::Capability
+            }
+            AuthorizeDevice | RevokeDevice | RevokeContentKey => VerbPrimitive::Vault,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum VerbPrimitive {
+    Entity,
+    Content,
+    Context,
+    Capability,
+    Vault,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `#1194`'s scope table, verbatim: nineteen names across five groups
+    /// spelled out in the design doc. A verb added or removed here without a
+    /// matching design-doc change is exactly the drift this test exists to
+    /// catch.
+    #[test]
+    fn the_scope_table_has_exactly_nineteen_verbs() {
+        assert_eq!(ALL_VERBS.len(), 19);
+    }
+
+    #[test]
+    fn every_verb_round_trips_through_its_wire_spelling() {
+        for verb in Verb::all() {
+            let spelled = verb.as_str();
+            assert_eq!(
+                Verb::parse_kind(spelled),
+                Some(*verb),
+                "{spelled} did not round-trip"
+            );
+        }
+    }
+
+    #[test]
+    fn an_unknown_kind_string_is_not_a_verb() {
+        assert_eq!(Verb::parse_kind("note.create"), None);
+        assert_eq!(Verb::parse_kind(""), None);
+    }
+
+    #[test]
+    fn there_is_no_delete_verb() {
+        assert!(
+            Verb::all().iter().all(|v| v.as_str() != "Delete"),
+            "design doc §3.2: deletion is ambiguous and intentionally absent"
+        );
+    }
+
+    #[test]
+    fn every_verb_names_the_primitive_it_mutates() {
+        assert_eq!(Verb::CreateEntity.primitive(), VerbPrimitive::Entity);
+        assert_eq!(Verb::DestroyContent.primitive(), VerbPrimitive::Content);
+        assert_eq!(Verb::CreateContext.primitive(), VerbPrimitive::Context);
+        assert_eq!(Verb::InstallPack.primitive(), VerbPrimitive::Capability);
+        assert_eq!(Verb::RevokeContentKey.primitive(), VerbPrimitive::Vault);
+    }
+}

--- a/rust/airo_mind_core/tests/operation_log_and_projection_conformance.rs
+++ b/rust/airo_mind_core/tests/operation_log_and_projection_conformance.rs
@@ -1,0 +1,364 @@
+//! Operation log and projection conformance — contract `C1`/`C2`/`C4`,
+//! `#1194` and `#1195`.
+//!
+//! Black-box, against `airo_mind_core`'s public API only, the same style as
+//! `tests/supervisor_conformance.rs`. Written against the contracts, not the
+//! implementation — a real Vault-issued device identity or a real signature
+//! scheme should not require rewriting these tests, only the `Runtime`
+//! construction they start from.
+//!
+//! Two groups:
+//! - **Operation log** (`#1194`, condition 4): the full header exists, is
+//!   signed, is content-addressed for out-of-line content, and survives
+//!   concurrent writers.
+//! - **Projection engine** (`#1195`, condition 5): the delete-and-rebuild,
+//!   zero-data-loss proof, generalized across two independent projections
+//!   fed by a mixed-capability log — not just Notes.
+
+use std::sync::Arc;
+
+use airo_mind_core::{
+    encode_relation, encode_set_property, rebuild_from_scratch, EntityGraphProjection,
+    NotesCapability, NotesProjection, ResourceBudget, Runtime, Verb,
+};
+
+fn temp_log_path(name: &str) -> std::path::PathBuf {
+    let unique = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    std::env::temp_dir().join(format!("airo_mind_conformance_{name}_{unique}.log"))
+}
+
+fn cleanup(path: &std::path::Path) {
+    let _ = std::fs::remove_file(path);
+    let mut device_id = path.file_name().unwrap().to_string_lossy().into_owned();
+    device_id.push_str(".device_id");
+    let _ = std::fs::remove_file(path.with_file_name(device_id));
+    let mut content = path.file_name().unwrap().to_string_lossy().into_owned();
+    content.push_str(".content");
+    let _ = std::fs::remove_dir_all(path.with_file_name(content));
+}
+
+// ---------------------------------------------------------------------------
+// #1194 — Operation log
+// ---------------------------------------------------------------------------
+
+/// Design doc §3.1's full header — condition 4's *"every durable object is
+/// reachable from the operation log"* is only meaningful if the object
+/// reachable there actually carries the fields the design promises.
+#[test]
+fn an_operation_carries_the_full_c1_header() {
+    let path = temp_log_path("full_header");
+    let runtime = Runtime::boot(ResourceBudget::new(2048), &path).unwrap();
+
+    let op = runtime
+        .emit_verb_operation(
+            "notes",
+            Verb::CreateEntity,
+            "entity-1",
+            &["context-a"],
+            "schema-1",
+            b"payload bytes",
+            None,
+            1_700_000_000,
+        )
+        .unwrap();
+
+    assert!(!op.operation_id.is_empty(), "operationId");
+    assert_eq!(op.parent_operation_id, None, "parentOperationId");
+    assert_eq!(op.entity_id, "entity-1", "entityId");
+    assert_eq!(
+        op.context_ids,
+        vec!["context-a".to_string()],
+        "contextIds[]"
+    );
+    assert_eq!(op.schema_id, "schema-1", "schemaId");
+    assert_eq!(op.capability, "notes", "capabilityId");
+    assert_eq!(op.device_id, runtime.device_id(), "deviceId");
+    assert_eq!(op.recorded_at_ms, 1_700_000_000, "timestamp");
+    assert!(!op.version_vector.is_empty(), "versionVector");
+    assert!(!op.payload_hash.is_empty(), "payloadHash");
+    assert!(!op.signature.is_empty(), "signature");
+
+    cleanup(&path);
+}
+
+/// `#1194`'s scope table names nineteen verbs across five groups. Every one
+/// of them must be a valid `kind` on the wire — a round trip through the log
+/// proves the format accepts all nineteen, not just the four this crate has
+/// a projection for.
+#[test]
+fn every_scoped_verb_round_trips_through_the_log() {
+    let path = temp_log_path("all_verbs");
+    let runtime = Runtime::boot(ResourceBudget::new(2048), &path).unwrap();
+
+    for verb in Verb::all() {
+        runtime
+            .emit_verb_operation("capabilities-probe", *verb, "e", &[], "", b"", None, 1)
+            .unwrap();
+    }
+
+    let ops = runtime.replay().unwrap();
+    assert_eq!(ops.len(), Verb::all().len());
+    for (op, verb) in ops.iter().zip(Verb::all()) {
+        assert_eq!(op.verb(), Some(*verb));
+    }
+
+    cleanup(&path);
+}
+
+/// §3.1: *"payload behind `ContentID`, never inlined"* for the Content
+/// primitive, over a content-addressed store — `#1194`'s scope names this
+/// explicitly.
+#[test]
+fn content_is_addressed_and_deduplicated_across_operations() {
+    let path = temp_log_path("content_addressed");
+    let runtime = Runtime::boot(ResourceBudget::new(2048), &path).unwrap();
+
+    let first = runtime
+        .emit_verb_operation(
+            "notes",
+            Verb::CreateContent,
+            "c1",
+            &[],
+            "",
+            b"",
+            Some(b"identical bytes"),
+            1,
+        )
+        .unwrap();
+    let second = runtime
+        .emit_verb_operation(
+            "notes",
+            Verb::CreateContent,
+            "c2",
+            &[],
+            "",
+            b"",
+            Some(b"identical bytes"),
+            2,
+        )
+        .unwrap();
+
+    assert_eq!(
+        first.content_id, second.content_id,
+        "identical content must share one content id"
+    );
+    assert_eq!(
+        runtime
+            .read_content(&first.content_id.unwrap())
+            .unwrap()
+            .unwrap(),
+        b"identical bytes"
+    );
+
+    cleanup(&path);
+}
+
+/// The concurrent-writer-safety requirement, stated as a black-box property:
+/// many capabilities, many threads, one runtime, and the resulting log has
+/// exactly the right number of operations with a contiguous `seq` — no lost
+/// writes, no duplicated `seq`, no torn records.
+#[test]
+fn many_capabilities_writing_concurrently_produce_one_consistent_log() {
+    let path = temp_log_path("many_capabilities");
+    let runtime = Arc::new(Runtime::boot(ResourceBudget::new(2048), &path).unwrap());
+
+    const CAPABILITIES: usize = 4;
+    const OPS_PER_CAPABILITY: usize = 40;
+    let mut handles = Vec::new();
+    for c in 0..CAPABILITIES {
+        let runtime = runtime.clone();
+        handles.push(std::thread::spawn(move || {
+            let capability = format!("capability-{c}");
+            for i in 0..OPS_PER_CAPABILITY {
+                runtime
+                    .emit_verb_operation(
+                        &capability,
+                        Verb::CreateEntity,
+                        &format!("e-{c}-{i}"),
+                        &[],
+                        "",
+                        b"",
+                        None,
+                        i as u64,
+                    )
+                    .unwrap();
+            }
+        }));
+    }
+    for h in handles {
+        h.join().unwrap();
+    }
+
+    let ops = runtime.replay().unwrap();
+    assert_eq!(ops.len(), CAPABILITIES * OPS_PER_CAPABILITY);
+
+    let mut seqs: Vec<u64> = ops.iter().map(|op| op.seq).collect();
+    seqs.sort_unstable();
+    seqs.dedup();
+    assert_eq!(
+        seqs.len(),
+        CAPABILITIES * OPS_PER_CAPABILITY,
+        "no duplicate seq under concurrent writers"
+    );
+    assert_eq!(seqs.first(), Some(&0));
+    assert_eq!(
+        seqs.last(),
+        Some(&((CAPABILITIES * OPS_PER_CAPABILITY - 1) as u64))
+    );
+
+    cleanup(&path);
+}
+
+// ---------------------------------------------------------------------------
+// #1195 — Projection engine
+// ---------------------------------------------------------------------------
+
+/// **The headline proof for condition 5.** Two independent projections, fed
+/// from one mixed-capability log, both survive their in-memory state being
+/// dropped entirely and rebuilding from the persisted log alone — with
+/// identical results. Generalizes `#1338`'s Notes-only proof to the engine
+/// itself.
+#[test]
+fn two_independent_projections_survive_full_deletion_and_rebuild_with_zero_data_loss() {
+    let path = temp_log_path("zero_data_loss");
+    let runtime = Runtime::boot(ResourceBudget::new(2048), &path).unwrap();
+    let notes = NotesCapability::new(&runtime);
+
+    notes
+        .create_note("n1", "Groceries", "milk, eggs", 1_000)
+        .unwrap();
+    notes
+        .create_note("n2", "Throwaway", "delete me", 2_000)
+        .unwrap();
+    notes.delete_note("n2", 3_000).unwrap();
+
+    runtime
+        .emit_verb_operation(
+            "graph",
+            Verb::CreateEntity,
+            "person-1",
+            &[],
+            "",
+            b"Person",
+            None,
+            4_000,
+        )
+        .unwrap();
+    runtime
+        .emit_verb_operation(
+            "graph",
+            Verb::SetProperty,
+            "person-1",
+            &[],
+            "",
+            &encode_set_property("name", b"Ada Lovelace"),
+            None,
+            5_000,
+        )
+        .unwrap();
+    runtime
+        .emit_verb_operation(
+            "graph",
+            Verb::AddRelation,
+            "person-1",
+            &[],
+            "",
+            &encode_relation("wrote", "note-n1"),
+            None,
+            6_000,
+        )
+        .unwrap();
+
+    // Snapshot both projections before any "deletion".
+    let notes_before = notes.notes().unwrap();
+    let graph_before: EntityGraphProjection = runtime.query_projection().unwrap();
+    assert_eq!(notes_before.len(), 1);
+    assert_eq!(graph_before.len(), 1);
+
+    // Delete: every in-memory projection this test held goes out of scope.
+    // Neither projection type, nor `NotesCapability`, retains a cache of its
+    // own (`I2`, `I4`) -- there is nothing else durable to fall back on.
+    drop(notes_before);
+    drop(graph_before);
+
+    // Rebuild from the persisted log alone, via #1195's named operation.
+    let ops = runtime.replay().unwrap();
+    let notes_after: NotesProjection = rebuild_from_scratch(&ops);
+    let graph_after: EntityGraphProjection = rebuild_from_scratch(&ops);
+
+    assert_eq!(notes_after.len(), 1, "n2 was deleted, only n1 survives");
+    let n1 = notes_after.get("n1").unwrap();
+    assert_eq!(n1.title, "Groceries");
+    assert_eq!(n1.body, "milk, eggs");
+    assert!(notes_after.get("n2").is_none());
+
+    assert_eq!(graph_after.len(), 1);
+    let person = graph_after.get("person-1").unwrap();
+    assert_eq!(person.label, "Person");
+    assert_eq!(person.properties.get("name").unwrap(), b"Ada Lovelace");
+    assert!(person
+        .relations
+        .contains(&("wrote".to_string(), "note-n1".to_string())));
+
+    // And the ordinary query path reaches the same state -- rebuilding is
+    // not a special code path, it is the only code path.
+    assert_eq!(notes.notes().unwrap(), notes_after);
+    let graph_via_query: EntityGraphProjection = runtime.query_projection().unwrap();
+    assert_eq!(graph_via_query, graph_after);
+
+    cleanup(&path);
+}
+
+/// `C4`: rebuild is a pure function of the log — running it twice from the
+/// same operations must not depend on anything but the operations
+/// themselves.
+#[test]
+fn rebuilding_the_same_log_twice_produces_identical_projections() {
+    let path = temp_log_path("pure_function");
+    let runtime = Runtime::boot(ResourceBudget::new(2048), &path).unwrap();
+    let notes = NotesCapability::new(&runtime);
+    for i in 0..12 {
+        notes
+            .create_note(format!("n{i}"), format!("title {i}"), "body", i)
+            .unwrap();
+    }
+
+    let ops = runtime.replay().unwrap();
+    let first: NotesProjection = rebuild_from_scratch(&ops);
+    let second: NotesProjection = rebuild_from_scratch(&ops);
+    assert_eq!(first, second);
+
+    let first_graph: EntityGraphProjection = rebuild_from_scratch(&ops);
+    let second_graph: EntityGraphProjection = rebuild_from_scratch(&ops);
+    assert_eq!(first_graph, second_graph);
+
+    cleanup(&path);
+}
+
+/// A rebuilt projection must not see operations from a capability it does
+/// not own — `EntityGraphProjection` folding over a log that also contains
+/// Notes operations must ignore them entirely, and vice versa.
+#[test]
+fn a_projection_ignores_operations_outside_its_own_concern() {
+    let path = temp_log_path("ignores_foreign_ops");
+    let runtime = Runtime::boot(ResourceBudget::new(2048), &path).unwrap();
+    let notes = NotesCapability::new(&runtime);
+
+    notes.create_note("n1", "t", "b", 1).unwrap();
+    runtime
+        .emit_verb_operation("graph", Verb::CreateEntity, "e1", &[], "", b"", None, 2)
+        .unwrap();
+
+    let notes_projection = notes.notes().unwrap();
+    assert_eq!(notes_projection.len(), 1);
+    assert!(notes_projection.get("e1").is_none());
+
+    let graph: EntityGraphProjection = runtime.query_projection().unwrap();
+    assert_eq!(graph.len(), 1);
+    assert!(graph.get("n1").is_none());
+
+    cleanup(&path);
+}

--- a/rust/airo_mind_core/tests/supervisor_conformance.rs
+++ b/rust/airo_mind_core/tests/supervisor_conformance.rs
@@ -1,0 +1,529 @@
+//! Supervisor conformance — contract `C6`, checklist `S4`.
+//!
+//! Black-box, against `airo_mind_core`'s public API only, the same style as
+//! `rust/airo_core/tests/runtime_conformance.rs`. Per the conformance-suite
+//! doc, these are written against C6 itself, not against `Supervisor`'s
+//! current implementation — replacing the implementation (a real Vault, a
+//! real Replay engine) should not require rewriting these tests.
+//!
+//! One item per `S4` bullet:
+//!
+//! - Lifecycle ordering (Vault before Replay before Projection; sync waits
+//!   for replay to reach head)
+//! - Cancellation leaves no torn state
+//! - Backpressure
+//! - Resource limits (memory, and concurrency)
+//! - Engine restart without corrupting the engines around it
+//! - Graceful shutdown flushes the group-commit buffer and seals the segment
+//!
+//! `#1302`'s open question — Rust or Dart — is answered by this file
+//! existing: the Supervisor lives in `airo_mind_core`, which already backs
+//! two production call sites (`airo_mind_whisper`, `airo_mind_llama`) over
+//! FRB. Nothing here reaches across an FFI boundary because the contract
+//! itself does not need to; wiring a `Supervisor` handle through FRB's
+//! stateless call model is `#1338`'s integration concern, not this one's.
+
+use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
+use std::sync::{Arc, Barrier};
+
+use airo_mind_core::{
+    AudioInput, CancelToken, EngineError, EngineState, ManagedEngine, ResourceBudget, RuntimeError,
+    Supervisor, TranscriptSegment,
+};
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+/// A managed engine that records every `start`/`stop` call it received, so a
+/// test can assert precisely what happened to *this* engine and, just as
+/// importantly, that nothing happened to any other.
+struct RecordingEngine {
+    starts: AtomicU32,
+    stops: AtomicU32,
+    fail_next_start: AtomicBool,
+}
+
+impl RecordingEngine {
+    fn new() -> Self {
+        Self {
+            starts: AtomicU32::new(0),
+            stops: AtomicU32::new(0),
+            fail_next_start: AtomicBool::new(false),
+        }
+    }
+}
+
+impl ManagedEngine for RecordingEngine {
+    fn start(&self) -> Result<(), EngineError> {
+        if self.fail_next_start.swap(false, Ordering::SeqCst) {
+            return Err(EngineError::Backend("simulated crash".into()));
+        }
+        self.starts.fetch_add(1, Ordering::SeqCst);
+        Ok(())
+    }
+
+    fn stop(&self) {
+        self.stops.fetch_add(1, Ordering::SeqCst);
+    }
+}
+
+/// A speech engine that yields one segment per call and, optionally, blocks
+/// on a barrier inside the sink — used to hold a job "in flight" so a second
+/// job can be attempted against a concurrency cap while the first is still
+/// running.
+struct BlockingSpeech {
+    memory_mb: u32,
+    barrier: Option<Arc<Barrier>>,
+}
+
+impl airo_mind_core::SpeechEngine for BlockingSpeech {
+    fn resource_request(&self) -> airo_mind_core::ResourceRequest {
+        airo_mind_core::ResourceRequest::new(self.memory_mb)
+    }
+
+    fn transcribe(
+        &self,
+        _audio: AudioInput<'_>,
+        _cancel: &CancelToken,
+        sink: &mut dyn FnMut(TranscriptSegment) -> Result<(), EngineError>,
+    ) -> Result<(), EngineError> {
+        if let Some(barrier) = &self.barrier {
+            barrier.wait();
+        }
+        sink(TranscriptSegment {
+            start_ms: 0,
+            end_ms: 1000,
+            text: "one segment".into(),
+        })
+    }
+}
+
+fn audio() -> [i16; 4] {
+    [0, 1, 2, 3]
+}
+
+// ---------------------------------------------------------------------------
+// Lifecycle ordering — "Vault before Replay before Projection; sync does not
+// start before replay reaches head"
+// ---------------------------------------------------------------------------
+
+#[test]
+fn dependency_order_is_enforced_vault_replay_projection() {
+    let mut supervisor = Supervisor::new(ResourceBudget::new(2048));
+    supervisor.register_engine("vault", &[], Box::new(RecordingEngine::new()));
+    supervisor.register_engine("replay", &["vault"], Box::new(RecordingEngine::new()));
+    supervisor.register_engine("projection", &["replay"], Box::new(RecordingEngine::new()));
+
+    // Starting out of order is refused, not merely inadvisable.
+    assert!(matches!(
+        supervisor.start_engine("replay"),
+        Err(RuntimeError::Lifecycle(_))
+    ));
+    assert!(matches!(
+        supervisor.start_engine("projection"),
+        Err(RuntimeError::Lifecycle(_))
+    ));
+    assert_eq!(
+        supervisor.engine_state("replay"),
+        Some(EngineState::NotStarted)
+    );
+
+    // In order, each becomes startable exactly when its dependency is
+    // Running -- not before.
+    supervisor.start_engine("vault").unwrap();
+    assert_eq!(supervisor.engine_state("vault"), Some(EngineState::Running));
+    assert!(
+        supervisor.start_engine("projection").is_err(),
+        "projection depends on replay, which vault being up does not satisfy"
+    );
+
+    supervisor.start_engine("replay").unwrap();
+    supervisor.start_engine("projection").unwrap();
+
+    assert_eq!(
+        supervisor.health(),
+        vec![
+            ("vault", EngineState::Running),
+            ("replay", EngineState::Running),
+            ("projection", EngineState::Running),
+        ]
+    );
+}
+
+/// "Sync does not start before replay reaches head" — modeled as sync
+/// depending on replay the same way projection does. The dependency
+/// mechanism is generic; this proves it holds for the second named case in
+/// `C6`, not just the first.
+#[test]
+fn sync_does_not_start_before_replay() {
+    let mut supervisor = Supervisor::new(ResourceBudget::new(2048));
+    supervisor.register_engine("vault", &[], Box::new(RecordingEngine::new()));
+    supervisor.register_engine("replay", &["vault"], Box::new(RecordingEngine::new()));
+    supervisor.register_engine("sync", &["replay"], Box::new(RecordingEngine::new()));
+
+    supervisor.start_engine("vault").unwrap();
+    let err = supervisor.start_engine("sync").unwrap_err();
+    assert!(matches!(err, RuntimeError::Lifecycle(_)));
+
+    supervisor.start_engine("replay").unwrap();
+    supervisor.start_engine("sync").unwrap();
+    assert_eq!(supervisor.engine_state("sync"), Some(EngineState::Running));
+}
+
+// ---------------------------------------------------------------------------
+// Cancellation — "leaves no torn state"
+// ---------------------------------------------------------------------------
+
+#[test]
+fn a_cancelled_job_leaves_no_torn_state() {
+    let mut supervisor = Supervisor::new(ResourceBudget::new(2048));
+    supervisor.register_speech(Box::new(BlockingSpeech {
+        memory_mb: 512,
+        barrier: None,
+    }));
+
+    let cancel = CancelToken::new();
+    cancel.cancel();
+
+    // "Torn state" for a single-segment engine means: some of a segment's
+    // effect was applied and some was not. The only way to prove none of it
+    // was applied is a sink that is never called once cancellation has
+    // already been requested before the job starts.
+    let mut applied = false;
+    let result = supervisor.run_speech(
+        AudioInput {
+            samples: &audio(),
+            sample_rate_hz: 16_000,
+            channels: 1,
+        },
+        &cancel,
+        &mut |_| {
+            applied = true;
+            Ok(())
+        },
+    );
+
+    // A real engine checks `cancel` before doing any work; `BlockingSpeech`
+    // does not, so this test instead proves the property at the level the
+    // Supervisor is answerable for: cancellation is visible to the engine
+    // before the sink is invoked is the engine's contract (proven in
+    // `supervisor::tests` against `FakeSpeech`, which does check). What this
+    // test adds is the multi-engine case: cancelling one job's token must
+    // not affect a second, independent job.
+    let _ = result;
+    assert!(
+        !applied || result.is_ok(),
+        "a call that both ran the sink and reported cancellation would be torn"
+    );
+
+    // Independence: a fresh token for a second job is unaffected by the
+    // first job's cancellation.
+    let second_cancel = CancelToken::new();
+    let mut second_applied = false;
+    supervisor
+        .run_speech(
+            AudioInput {
+                samples: &audio(),
+                sample_rate_hz: 16_000,
+                channels: 1,
+            },
+            &second_cancel,
+            &mut |_| {
+                second_applied = true;
+                Ok(())
+            },
+        )
+        .unwrap();
+    assert!(second_applied, "an uncancelled job must still complete");
+}
+
+// ---------------------------------------------------------------------------
+// Backpressure — a refusing sink stops the engine, not buffered without
+// bound (existing coverage in `supervisor::tests`; this file's job is the
+// four properties that module could not exercise without lifecycle support)
+// ---------------------------------------------------------------------------
+
+// ---------------------------------------------------------------------------
+// Resource limits — memory (existing) and concurrency (new for `#1302`)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn a_job_over_the_concurrency_cap_is_refused_while_another_is_in_flight() {
+    let mut supervisor = Supervisor::new(ResourceBudget::new(2048)).with_max_concurrent_jobs(1);
+    let barrier = Arc::new(Barrier::new(2));
+    supervisor.register_speech(Box::new(BlockingSpeech {
+        memory_mb: 512,
+        barrier: Some(barrier.clone()),
+    }));
+    let supervisor = Arc::new(supervisor);
+
+    let first = {
+        let supervisor = supervisor.clone();
+        std::thread::spawn(move || {
+            supervisor.run_speech(
+                AudioInput {
+                    samples: &audio(),
+                    sample_rate_hz: 16_000,
+                    channels: 1,
+                },
+                &CancelToken::new(),
+                &mut |_| Ok(()),
+            )
+        })
+    };
+
+    // Block until the first job is admitted and inside its sink -- i.e.
+    // definitely still "active" from the Supervisor's point of view -- before
+    // the second job is attempted.
+    while supervisor.active_jobs() == 0 {
+        std::thread::yield_now();
+    }
+
+    let second = supervisor.run_speech(
+        AudioInput {
+            samples: &audio(),
+            sample_rate_hz: 16_000,
+            channels: 1,
+        },
+        &CancelToken::new(),
+        &mut |_| Ok(()),
+    );
+    assert_eq!(
+        second,
+        Err(RuntimeError::OverCapacity { active: 1, max: 1 }),
+        "a second job must be refused while the cap is already spent, not queued silently"
+    );
+
+    // Release the first job so the barrier wait completes and the thread
+    // joins.
+    barrier.wait();
+    first.join().unwrap().unwrap();
+    assert_eq!(
+        supervisor.active_jobs(),
+        0,
+        "the slot must be released once the job that held it finishes"
+    );
+}
+
+#[test]
+fn an_engine_over_the_memory_budget_is_refused_before_it_allocates() {
+    let mut supervisor = Supervisor::new(ResourceBudget::new(512));
+    supervisor.register_speech(Box::new(BlockingSpeech {
+        memory_mb: 4096,
+        barrier: None,
+    }));
+    let mut called = false;
+    let result = supervisor.run_speech(
+        AudioInput {
+            samples: &audio(),
+            sample_rate_hz: 16_000,
+            channels: 1,
+        },
+        &CancelToken::new(),
+        &mut |_| {
+            called = true;
+            Ok(())
+        },
+    );
+    assert_eq!(
+        result,
+        Err(RuntimeError::OverBudget {
+            needs_mb: 4096,
+            budget_mb: 512
+        })
+    );
+    assert!(!called);
+}
+
+// ---------------------------------------------------------------------------
+// Engine restart — without corrupting the engines around it
+// ---------------------------------------------------------------------------
+
+#[test]
+fn a_failed_engine_restarts_without_touching_its_neighbors() {
+    let mut supervisor = Supervisor::new(ResourceBudget::new(2048));
+    supervisor.register_engine("vault", &[], Box::new(RecordingEngine::new()));
+    supervisor.register_engine("replay", &["vault"], Box::new(RecordingEngine::new()));
+    supervisor.register_engine("projection", &["replay"], Box::new(RecordingEngine::new()));
+
+    supervisor.start_engine("vault").unwrap();
+    supervisor.start_engine("replay").unwrap();
+    supervisor.start_engine("projection").unwrap();
+
+    let vault_metrics_before = supervisor.engine_metrics("vault").unwrap();
+    let replay_metrics_before = supervisor.engine_metrics("replay").unwrap();
+
+    // Restart the leaf engine. Neighbors it depends on must be untouched.
+    supervisor.restart_engine("projection").unwrap();
+
+    assert_eq!(
+        supervisor.engine_state("vault"),
+        Some(EngineState::Running),
+        "restarting projection must not stop vault"
+    );
+    assert_eq!(
+        supervisor.engine_state("replay"),
+        Some(EngineState::Running),
+        "restarting projection must not stop replay"
+    );
+    assert_eq!(
+        supervisor.engine_metrics("vault").unwrap(),
+        vault_metrics_before
+    );
+    assert_eq!(
+        supervisor.engine_metrics("replay").unwrap(),
+        replay_metrics_before
+    );
+    assert_eq!(supervisor.engine_metrics("projection").unwrap().restarts, 1);
+    assert_eq!(
+        supervisor.engine_state("projection"),
+        Some(EngineState::Running),
+        "a restart must leave the engine itself running again, not stuck Stopped"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Graceful shutdown — flushes the group-commit buffer, seals the segment,
+// stops engines in reverse dependency order
+// ---------------------------------------------------------------------------
+
+#[test]
+fn graceful_shutdown_flushes_the_buffer_and_seals_the_segment() {
+    let mut supervisor = Supervisor::new(ResourceBudget::new(2048));
+    supervisor.register_engine("vault", &[], Box::new(RecordingEngine::new()));
+    supervisor.register_engine("replay", &["vault"], Box::new(RecordingEngine::new()));
+
+    supervisor.start_engine("vault").unwrap();
+    supervisor.start_engine("replay").unwrap();
+
+    // Simulate operations pending in the group-commit window at the moment
+    // shutdown is requested -- the case "a kill during group commit recovers
+    // cleanly on next start" protects against losing.
+    supervisor.buffer_write(b"op-1;");
+    supervisor.buffer_write(b"op-2;");
+
+    assert!(!supervisor.buffer_sealed());
+    assert!(
+        supervisor.durable_buffer().is_empty(),
+        "nothing durable yet"
+    );
+
+    supervisor.shutdown();
+
+    assert!(
+        supervisor.buffer_sealed(),
+        "the active segment must be sealed once shutdown completes"
+    );
+    assert_eq!(
+        supervisor.durable_buffer(),
+        b"op-1;op-2;".to_vec(),
+        "every byte pending at shutdown must be durable after it -- a kill \
+         here must recover cleanly, not lose the group-commit window"
+    );
+
+    assert_eq!(supervisor.engine_state("vault"), Some(EngineState::Stopped));
+    assert_eq!(
+        supervisor.engine_state("replay"),
+        Some(EngineState::Stopped)
+    );
+}
+
+#[test]
+fn shutdown_stops_engines_in_reverse_dependency_order() {
+    // A dependent stopping after what it depends on is the failure mode this
+    // guards: replay stopped first while projection is still reading from it
+    // is exactly the "torn projection" `C6` names. Observed indirectly,
+    // since `RecordingEngine::stop` does not record order by itself -- a
+    // shared sequence counter does.
+    struct OrderRecordingEngine {
+        sequence: Arc<std::sync::Mutex<Vec<&'static str>>>,
+        name: &'static str,
+    }
+    impl ManagedEngine for OrderRecordingEngine {
+        fn start(&self) -> Result<(), EngineError> {
+            Ok(())
+        }
+        fn stop(&self) {
+            self.sequence.lock().unwrap().push(self.name);
+        }
+    }
+
+    let sequence = Arc::new(std::sync::Mutex::new(Vec::new()));
+    let mut supervisor = Supervisor::new(ResourceBudget::new(2048));
+    supervisor.register_engine(
+        "vault",
+        &[],
+        Box::new(OrderRecordingEngine {
+            sequence: sequence.clone(),
+            name: "vault",
+        }),
+    );
+    supervisor.register_engine(
+        "replay",
+        &["vault"],
+        Box::new(OrderRecordingEngine {
+            sequence: sequence.clone(),
+            name: "replay",
+        }),
+    );
+    supervisor.register_engine(
+        "projection",
+        &["replay"],
+        Box::new(OrderRecordingEngine {
+            sequence: sequence.clone(),
+            name: "projection",
+        }),
+    );
+
+    supervisor.start_engine("vault").unwrap();
+    supervisor.start_engine("replay").unwrap();
+    supervisor.start_engine("projection").unwrap();
+
+    supervisor.shutdown();
+
+    assert_eq!(
+        *sequence.lock().unwrap(),
+        vec!["projection", "replay", "vault"],
+        "shutdown must stop the most-dependent engine first"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Control plane only — no payload passes through the Supervisor's lock
+// ---------------------------------------------------------------------------
+
+/// Not a runtime-checkable property in the way the others are -- there is no
+/// value to inspect and assert "this is not a payload." The proof is
+/// structural: every Supervisor method that touches durable-shaped data
+/// (`buffer_write`, `durable_buffer`) operates on a caller-supplied
+/// `GroupCommitBuffer` stand-in, and every job-execution method
+/// (`run_speech`, `run_generation`) streams through a caller-supplied `sink`
+/// it never stores. This test asserts the shape that keeps that true: a
+/// second, independent Supervisor sharing no buffer with the first is
+/// unaffected by the first's writes, which would not hold if payload data
+/// routed through Supervisor-owned state rather than the caller's.
+#[test]
+fn two_supervisors_share_no_state() {
+    let a = Supervisor::new(ResourceBudget::new(2048));
+    let b = Supervisor::new(ResourceBudget::new(2048));
+    a.buffer_write(b"a-only");
+    assert!(b.durable_buffer().is_empty());
+    a.shutdown();
+    assert!(b.durable_buffer().is_empty());
+    assert!(!b.buffer_sealed());
+}
+
+// ---------------------------------------------------------------------------
+// Unregistered / unknown engine names are refusals, not panics
+// ---------------------------------------------------------------------------
+
+#[test]
+fn an_unregistered_engine_name_is_a_refusal_not_a_panic() {
+    let supervisor = Supervisor::new(ResourceBudget::new(2048));
+    assert!(matches!(
+        supervisor.start_engine("nothing"),
+        Err(RuntimeError::Lifecycle(_))
+    ));
+    assert_eq!(supervisor.engine_state("nothing"), None);
+}


### PR DESCRIPTION
Formalizes #1338's runtime skeleton against the frozen C1/C2/C4 contracts. Third and largest piece of Track A Step 1 (Milestone 19 Runtime v1) — proves conditions 4 and 5 of the ten-conditions gate (#1311) with real conformance tests, not just claimed.

Originally built in a separate session that ended before shipping. Found the work sitting complete and committed but unpushed, ~15 commits behind main (predating today's whisper multilingual / transcript processor / model manager / vault crate merges — its raw diff would have deleted `airo_mind_transcript` and reverted whisper's multilingual work). Rebased clean onto current main, re-verified: no conflicts, diff now scoped to `airo_mind_core` + `feature_mind` Notes only, zero touch on any Track B crate.

## What this adds

- **Operation** carries the full design-doc §3.1 header (`operationId`, `parentOperationId`, `entityId`, `contextIds[]`, `schemaId`, `capabilityId`, `deviceId`, `timestamp`, `versionVector`, `payloadHash`, `signature`) — backward compatible with #1338's four original fields, `notes.rs` needed no changes.
- **Verb enum**: the fixed 19-verb set from #1194's scope table, round-trips against an operation's `kind`.
- **Content-addressed ContentStore** (`src/content.rs`): `CreateContent` now stores payload out of line via a real `ContentId`, per §3.1 "payload behind ContentID, never inlined."
- **Signing** (`src/signing.rs`): every operation signed and verified at ingest; tampered header or payload fails verification. Documented as a placeholder pending Phase 1 Vault-issued device identity (now that #1733 landed the vault crate, this is the next seam to wire up).
- **OperationLog**: versioned wire format; seq assignment and durable write are one atomic step under a single lock, proven with a multi-thread conformance test.
- **Generalized projection engine** (`src/projection.rs`): `EntityGraphProjection` folds `CreateEntity`/`SetProperty`/`AddRelation`/`RemoveRelation` from any capability — proves condition 5's delete-and-rebuild guarantee is a property of the engine, not an accident of Notes' shape.
- **Black-box conformance suite** (`tests/operation_log_and_projection_conformance.rs`): full header presence, all 19 verbs round-trip, content dedup, concurrent-writer safety, and the headline proof — two independent projections fed by a mixed-capability log both survive complete deletion and rebuild from the log alone with zero data loss.

## Verification (re-run post-rebase, not just trusted from the original session)

- `cargo check --workspace` clean
- `cargo test -p airo_mind_core`: **112 passed, 0 failed** (95 unit + 7 op-log/projection conformance + 10 supervisor conformance)
- `cargo clippy -p airo_mind_core --all-targets -- -D warnings` clean
- `cargo fmt --check -p airo_mind_core` clean
- Diff confirmed scoped to `airo_mind_core` + `feature_mind/notes` only — no Track B crate touched

## Review routing

chief-architect (contracts/conditions 4-5), rust-architect (crate structure), chief-security-officer (signing placeholder, ties to #1731/#1733 vault identity)