### PR TITLE
feat(mind): Meeting IR schema + two-pass evidence-grounded extraction (#1633)

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -98,6 +98,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "airo_mind_meeting"
+version = "0.1.0"
+dependencies = [
+ "airo_mind_core",
+ "airo_mind_transcript",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "airo_mind_transcript"
 version = "0.1.0"
 

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -4,6 +4,7 @@ members = [
   "airo_mind",
   "airo_mind_core",
   "airo_mind_llama",
+  "airo_mind_meeting",
   "airo_mind_transcript",
   "airo_mind_whisper",
 ]

--- a/rust/airo_mind_meeting/Cargo.toml
+++ b/rust/airo_mind_meeting/Cargo.toml
@@ -1,0 +1,36 @@
+[package]
+name = "airo_mind_meeting"
+version = "0.1.0"
+edition = "2021"
+description = "Airo Mind Meeting capability — Meeting IR schema and two-pass evidence-grounded extraction. #1633."
+license = "MIT"
+
+[lib]
+name = "airo_mind_meeting"
+# rlib only, and deliberately no FFI surface. This crate is the *capability*
+# above the runtime's engine boundary (`C5`): it owns the prompt, the grammar,
+# the output schema and the meeting vocabulary, and it drives a
+# `&dyn GenerationEngine` it does not construct. Whichever cdylib owns a real
+# engine (`airo_mind_llama`) links this and exposes it to Dart; nothing here
+# needs its own bridge, and declaring one would link a second empty artifact
+# on every CI push (same reasoning as `airo_mind`'s Cargo.toml).
+crate-type = ["rlib"]
+
+[dependencies]
+# The engine boundary only. NOT `airo_mind_llama`: depending on the llama
+# cdylib would drag cmake and a vendored ggml into every build of this crate,
+# including the ones that only want to parse an IR. Extraction is written
+# against `GenerationEngine`, so the real engine and the test double are the
+# same shape to it.
+airo_mind_core = { path = "../airo_mind_core" }
+# `Chunk` and `ProcessedTranscript` (#1632). Pass 1 consumes chunks as
+# produced; this crate never re-chunks.
+airo_mind_transcript = { path = "../airo_mind_transcript" }
+# Already in the workspace lockfile via `airo_core` and `airo_mind`; no new
+# tree. The IR is a wire format with a published JSON Schema, so it is
+# serde-shaped rather than hand-written.
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(frb_expand)'] }

--- a/rust/airo_mind_meeting/prompts/extraction/chunk_facts.v1.gbnf
+++ b/rust/airo_mind_meeting/prompts/extraction/chunk_facts.v1.gbnf
@@ -1,0 +1,66 @@
+# Airo Meeting IR — Pass 1 chunk-facts grammar, v1. `#1633`.
+#
+# GBNF, consumed by `LlamaSampler::grammar` through
+# `GenerationRequest::grammar` (start symbol `root`, per that field's contract).
+# Constraining the sampler is what makes Pass 1 output schema-valid by
+# construction rather than by hope: an unparseable object is not a token
+# sequence this grammar can produce.
+#
+# Two things this grammar enforces that the prompt only asks for:
+#
+#   * `evidence` is a NON-EMPTY array. An uncited fact is not expressible.
+#   * Every key is present and in a fixed order, so `serde` sees all eight
+#     categories and the model spends no tokens deciding what to emit next.
+#
+# It deliberately does NOT offer an `id` field: item identity is assigned by
+# `airo_mind_meeting`, never by the model (see `ir.rs`).
+#
+# Keep in step with `crate::ir::Facts`. `tests/contracts.rs` checks that every
+# rule referenced here is defined and that `root` exists; the F1 harness
+# (MIND-LLM-11) is what checks it against a real model.
+
+root ::= "{" ws
+  "\"topics\":" ws topic-array "," ws
+  "\"observations\":" ws observation-array "," ws
+  "\"decisions\":" ws decision-array "," ws
+  "\"action_items\":" ws action-item-array "," ws
+  "\"metrics\":" ws metric-array "," ws
+  "\"risks\":" ws risk-array "," ws
+  "\"questions\":" ws question-array "," ws
+  "\"next_steps\":" ws next-step-array ws
+"}"
+
+topic-array ::= "[" ws (topic (ws "," ws topic)*)? ws "]"
+topic ::= "{" ws "\"title\":" ws string "," ws "\"evidence\":" ws evidence ws "}"
+
+observation-array ::= "[" ws (observation (ws "," ws observation)*)? ws "]"
+observation ::= "{" ws "\"statement\":" ws string "," ws "\"evidence\":" ws evidence ws "}"
+
+decision-array ::= "[" ws (decision (ws "," ws decision)*)? ws "]"
+decision ::= "{" ws "\"statement\":" ws string "," ws "\"status\":" ws decision-status "," ws "\"evidence\":" ws evidence ws "}"
+decision-status ::= "\"proposed\"" | "\"agreed\"" | "\"rejected\"" | "\"deferred\""
+
+action-item-array ::= "[" ws (action-item (ws "," ws action-item)*)? ws "]"
+action-item ::= "{" ws "\"task\":" ws string "," ws "\"owner\":" ws nullable-string "," ws "\"due\":" ws nullable-string "," ws "\"status\":" ws action-status "," ws "\"evidence\":" ws evidence ws "}"
+action-status ::= "\"open\"" | "\"in_progress\"" | "\"done\"" | "\"blocked\""
+
+metric-array ::= "[" ws (metric (ws "," ws metric)*)? ws "]"
+metric ::= "{" ws "\"name\":" ws string "," ws "\"value\":" ws string "," ws "\"evidence\":" ws evidence ws "}"
+
+risk-array ::= "[" ws (risk (ws "," ws risk)*)? ws "]"
+risk ::= "{" ws "\"statement\":" ws string "," ws "\"evidence\":" ws evidence ws "}"
+
+question-array ::= "[" ws (question (ws "," ws question)*)? ws "]"
+question ::= "{" ws "\"question\":" ws string "," ws "\"answer\":" ws nullable-string "," ws "\"evidence\":" ws evidence ws "}"
+
+next-step-array ::= "[" ws (next-step (ws "," ws next-step)*)? ws "]"
+next-step ::= "{" ws "\"statement\":" ws string "," ws "\"evidence\":" ws evidence ws "}"
+
+# Non-empty by construction: at least one segment id, always.
+evidence ::= "[" ws string (ws "," ws string)* ws "]"
+
+nullable-string ::= "null" | string
+string ::= "\"" char* "\""
+char ::= [^"\\\x00-\x1F] | "\\" (["\\/bfnrt] | "u" hex hex hex hex)
+hex ::= [0-9a-fA-F]
+ws ::= [ \t\n]*

--- a/rust/airo_mind_meeting/prompts/extraction/chunk_facts.v1.md
+++ b/rust/airo_mind_meeting/prompts/extraction/chunk_facts.v1.md
@@ -1,0 +1,58 @@
+<|im_start|>system
+You are a meeting fact extractor. You do not summarise. You do not write prose.
+You copy facts that were actually stated, and you cite where each one came from.
+
+You are given one part of a meeting transcript, as numbered segments:
+
+    [segment_id] what was said in that segment
+
+Return ONE JSON object and nothing else. No prose before it, no prose after it,
+no code fences.
+
+Rules, in order of importance:
+
+1. EXTRACT, NEVER SUMMARISE. Every item is one atomic fact that was stated in
+   these segments. If you find yourself writing "the team discussed" or "overall",
+   stop: that is a summary, not a fact.
+2. NEVER INVENT. If it was not said in these segments, it does not exist. An
+   empty list is a correct answer. Eight empty lists is a correct answer for a
+   chunk of small talk.
+3. ALWAYS CITE. Every item's `evidence` is a non-empty list of the segment ids
+   it came from, copied exactly from the `[segment_id]` labels above. Cite only
+   ids that appear above. If you cannot cite an item, do not emit it.
+4. OWNER IS NULL UNLESS NAMED. `owner` is the person the transcript explicitly
+   put on the hook, spelled as the transcript spells them. If nobody was named,
+   `owner` is `null`. Never guess from who was speaking, who usually does this,
+   or who was in the room. `null` is the correct, expected answer most of the
+   time.
+5. `due` is `null` unless the transcript said when. Copy the words that were
+   said ("Friday", "before the release"). Do not convert them to a date.
+6. `answer` on a question is `null` unless these segments answered it.
+
+Where each fact goes:
+
+- `topics`: a subject these segments spent time on. `title` is a short noun
+  phrase, not a sentence.
+- `observations`: a stated fact that is not any of the categories below.
+- `decisions`: something settled, or explicitly not settled. `status` is
+  `proposed` when it was raised but not resolved, `agreed` when the meeting
+  agreed, `rejected` when the meeting turned it down, `deferred` when the
+  meeting explicitly put it off. Default to `proposed`: silence is not
+  agreement.
+- `action_items`: work someone is expected to do after the meeting. `status` is
+  `open`, `in_progress`, `done` or `blocked`.
+- `metrics`: a number that was quoted. `value` is the number exactly as spoken,
+  including its unit ("500,000 rows", "under a second").
+- `risks`: something stated as able to go wrong.
+- `questions`: something asked.
+- `next_steps`: what happens next where nobody was named and no task was
+  assigned. If a person was named, it is an `action_items` entry instead.
+
+Output shape — every key present, every list possibly empty:
+
+{"topics":[{"title":"","evidence":[]}],"observations":[{"statement":"","evidence":[]}],"decisions":[{"statement":"","status":"proposed","evidence":[]}],"action_items":[{"task":"","owner":null,"due":null,"status":"open","evidence":[]}],"metrics":[{"name":"","value":"","evidence":[]}],"risks":[{"statement":"","evidence":[]}],"questions":[{"question":"","answer":null,"evidence":[]}],"next_steps":[{"statement":"","evidence":[]}]}
+<|im_end|>
+<|im_start|>user
+{{SEGMENTS}}
+<|im_end|>
+<|im_start|>assistant

--- a/rust/airo_mind_meeting/schemas/meeting_ir.schema.json
+++ b/rust/airo_mind_meeting/schemas/meeting_ir.schema.json
@@ -1,0 +1,182 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://airo.app/schemas/meeting_ir/1.0.0",
+  "title": "Airo Meeting IR",
+  "description": "Evidence-grounded intermediate representation of one meeting, produced by two-pass extraction (#1633). Every item cites the transcript segment ids it came from. Minutes, action-item lists and meeting search are projections of this document; none of them is stored here, and no field in it is prose written by a model about the meeting as a whole.",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "meeting",
+    "topics",
+    "observations",
+    "decisions",
+    "action_items",
+    "metrics",
+    "risks",
+    "questions",
+    "next_steps"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "schema_version": {
+      "type": "string",
+      "const": "1.0.0",
+      "description": "Matches airo_mind_meeting::ir::IR_SCHEMA_VERSION. A reader that does not recognise it must refuse the document rather than guess."
+    },
+    "meeting": { "$ref": "#/$defs/meeting" },
+    "topics": { "type": "array", "items": { "$ref": "#/$defs/topic" } },
+    "observations": { "type": "array", "items": { "$ref": "#/$defs/observation" } },
+    "decisions": { "type": "array", "items": { "$ref": "#/$defs/decision" } },
+    "action_items": { "type": "array", "items": { "$ref": "#/$defs/action_item" } },
+    "metrics": { "type": "array", "items": { "$ref": "#/$defs/metric" } },
+    "risks": { "type": "array", "items": { "$ref": "#/$defs/risk" } },
+    "questions": { "type": "array", "items": { "$ref": "#/$defs/question" } },
+    "next_steps": { "type": "array", "items": { "$ref": "#/$defs/next_step" } }
+  },
+  "$defs": {
+    "evidence": {
+      "type": "array",
+      "description": "Transcript segment ids backing this item. Non-empty: an uncited item is dropped during extraction, never stored. Segment ids rather than snippets, on purpose — a snippet copies secret-class transcript text into every projection that touches the IR, while an id is a pointer the holder of the transcript can resolve under that transcript's own access rules.",
+      "minItems": 1,
+      "items": { "type": "string", "minLength": 1 }
+    },
+    "id": {
+      "type": "string",
+      "description": "Assigned by the extractor, never by the model — `<category>-<index>` within this document.",
+      "minLength": 1
+    },
+    "meeting": {
+      "type": "object",
+      "description": "Identity and provenance. None of it is extracted: it is supplied by the caller or derived from the transcript.",
+      "required": [
+        "id",
+        "title",
+        "started_at_ms",
+        "ended_at_ms",
+        "chunk_count",
+        "segment_count",
+        "model_id",
+        "prompt_version"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "id": { "type": "string", "minLength": 1 },
+        "title": { "type": ["string", "null"] },
+        "started_at_ms": { "type": "integer", "minimum": 0 },
+        "ended_at_ms": { "type": "integer", "minimum": 0 },
+        "chunk_count": { "type": "integer", "minimum": 0 },
+        "segment_count": { "type": "integer", "minimum": 0 },
+        "model_id": {
+          "type": ["string", "null"],
+          "description": "Logical model id and version that produced the facts (ADR-0018 §5). Null means the provenance is unknown, which is stated rather than invented."
+        },
+        "prompt_version": {
+          "type": "string",
+          "description": "The versioned extraction prompt that ran, e.g. `chunk_facts.v1`.",
+          "minLength": 1
+        }
+      }
+    },
+    "topic": {
+      "type": "object",
+      "required": ["id", "title", "evidence"],
+      "additionalProperties": false,
+      "properties": {
+        "id": { "$ref": "#/$defs/id" },
+        "title": { "type": "string", "minLength": 1 },
+        "evidence": { "$ref": "#/$defs/evidence" }
+      }
+    },
+    "observation": {
+      "type": "object",
+      "required": ["id", "statement", "evidence"],
+      "additionalProperties": false,
+      "properties": {
+        "id": { "$ref": "#/$defs/id" },
+        "statement": { "type": "string", "minLength": 1 },
+        "evidence": { "$ref": "#/$defs/evidence" }
+      }
+    },
+    "decision": {
+      "type": "object",
+      "required": ["id", "statement", "status", "evidence"],
+      "additionalProperties": false,
+      "properties": {
+        "id": { "$ref": "#/$defs/id" },
+        "statement": { "type": "string", "minLength": 1 },
+        "status": {
+          "enum": ["proposed", "agreed", "rejected", "deferred"],
+          "description": "`proposed` is the default: silence is not agreement."
+        },
+        "evidence": { "$ref": "#/$defs/evidence" }
+      }
+    },
+    "action_item": {
+      "type": "object",
+      "required": ["id", "task", "owner", "due", "status", "evidence"],
+      "additionalProperties": false,
+      "properties": {
+        "id": { "$ref": "#/$defs/id" },
+        "task": { "type": "string", "minLength": 1 },
+        "owner": {
+          "type": ["string", "null"],
+          "description": "Null when the transcript names nobody. NEVER inferred — extraction erases any owner whose name does not appear as a whole word in the chunk the item came from."
+        },
+        "due": {
+          "type": ["string", "null"],
+          "description": "As spoken (\"Friday\", \"before the release\"). Not resolved to a date: that needs a meeting date and a timezone the extractor does not have, and a wrong date is worse than the words that were said."
+        },
+        "status": { "enum": ["open", "in_progress", "done", "blocked"] },
+        "evidence": { "$ref": "#/$defs/evidence" }
+      }
+    },
+    "metric": {
+      "type": "object",
+      "required": ["id", "name", "value", "evidence"],
+      "additionalProperties": false,
+      "properties": {
+        "id": { "$ref": "#/$defs/id" },
+        "name": { "type": "string", "minLength": 1 },
+        "value": {
+          "type": "string",
+          "description": "As quoted, including any unit. A string because \"about 500,000\", \"2x\" and \"under a second\" are all real answers and none of them is a number."
+        },
+        "evidence": { "$ref": "#/$defs/evidence" }
+      }
+    },
+    "risk": {
+      "type": "object",
+      "required": ["id", "statement", "evidence"],
+      "additionalProperties": false,
+      "properties": {
+        "id": { "$ref": "#/$defs/id" },
+        "statement": { "type": "string", "minLength": 1 },
+        "evidence": { "$ref": "#/$defs/evidence" }
+      }
+    },
+    "question": {
+      "type": "object",
+      "required": ["id", "question", "answer", "evidence"],
+      "additionalProperties": false,
+      "properties": {
+        "id": { "$ref": "#/$defs/id" },
+        "question": { "type": "string", "minLength": 1 },
+        "answer": {
+          "type": ["string", "null"],
+          "description": "Null when the meeting never answered it. An open question is a result, not a gap to fill in."
+        },
+        "evidence": { "$ref": "#/$defs/evidence" }
+      }
+    },
+    "next_step": {
+      "type": "object",
+      "required": ["id", "statement", "evidence"],
+      "additionalProperties": false,
+      "properties": {
+        "id": { "$ref": "#/$defs/id" },
+        "statement": { "type": "string", "minLength": 1 },
+        "evidence": { "$ref": "#/$defs/evidence" }
+      }
+    }
+  }
+}

--- a/rust/airo_mind_meeting/src/dedup.rs
+++ b/rust/airo_mind_meeting/src/dedup.rs
@@ -1,0 +1,345 @@
+//! Near-duplicate detection for Pass 2.
+//!
+//! # Why this is not a second LLM call
+//!
+//! The obvious implementation of "dedupe semantically" is to hand every
+//! candidate pair back to the model. That costs a second full generation pass
+//! over an O(n²) pair set, on a device already budgeted for one — and it makes
+//! consolidation non-deterministic, which means the same meeting can produce two
+//! different IRs and neither the golden test here nor the F1 harness
+//! (MIND-LLM-11) can tell a regression from sampling noise.
+//!
+//! # Why not embeddings
+//!
+//! Checked first, as the cheaper-primitive rule requires: there is no
+//! embedding primitive available to this crate. `packages/core_ai` has an
+//! `EmbeddingService`, but it is Dart and above the FFI boundary — calling *up*
+//! into it from an extraction pass would invert the dependency and put a
+//! network-capable client on a local-first path. Nothing in `rust/` produces
+//! vectors (`airo_core`'s "dedup" is `normalize_channel_name`, an alphanumeric
+//! squash for channel titles). Adding an embedding model would mean a second
+//! model download, a second memory budget and a new dependency — a large
+//! decision that belongs to the milestone, not to this function.
+//!
+//! # What this is instead
+//!
+//! Token-set (Jaccard) similarity over a normalised, lightly stemmed token
+//! stream, with a small synonym lexicon that collapses the phrasings meeting
+//! speech actually varies on. The issue's own example is the design target:
+//!
+//! ```text
+//! "Check Temporal signalling limit"      -> {@inquire, temporal, signal, @capacity}
+//! "Confirm Temporal signalling capacity" -> {@inquire, temporal, signal, @capacity}
+//! "Ask Temporal team about signalling"   -> {@inquire, temporal, signal}
+//! ```
+//!
+//! all of which pass the threshold against each other, while
+//! `"Check the Kafka retention limit"` — same verb class, same `@capacity`
+//! class, different subject — does not.
+//!
+//! **A similarity score is not enough on its own.** Two items must also share a
+//! *domain* token (one that is not a synonym-class placeholder) before they can
+//! merge, so "confirm the limit" and "confirm the budget" cannot collapse into
+//! each other on the strength of their verbs.
+//!
+//! This is a first cut with an explicitly tunable threshold, not a claim to have
+//! solved semantic equivalence. MIND-LLM-11's F1 harness is where the threshold
+//! and the lexicon get measured against real meetings; this module is written to
+//! be tuned from outside rather than to be right by assertion.
+
+use std::collections::BTreeSet;
+
+/// How aggressively Pass 2 merges.
+#[derive(Clone, Debug, PartialEq)]
+pub struct DedupConfig {
+    /// Minimum Jaccard similarity between two items' token sets.
+    ///
+    /// `0.5` — measured against the issue's worked example, whose weakest pair
+    /// scores `0.75`, and against the near-miss guard in this module's tests,
+    /// which scores `0.33`. There is real room on both sides of it, which is
+    /// what makes it a threshold rather than a fitted constant.
+    pub similarity_threshold: f64,
+    /// When false, only byte-identical text merges. An escape hatch for a
+    /// caller that would rather see duplicates than risk a wrong merge.
+    pub semantic: bool,
+}
+
+impl Default for DedupConfig {
+    fn default() -> Self {
+        Self {
+            similarity_threshold: 0.5,
+            semantic: true,
+        }
+    }
+}
+
+/// Words carrying no discriminating content in meeting speech. Removing them
+/// keeps a shared "the" from inflating similarity between unrelated items.
+const STOPWORDS: &[&str] = &[
+    "a", "about", "again", "against", "all", "also", "an", "and", "any", "are", "as", "at", "back",
+    "be", "been", "being", "both", "but", "by", "can", "could", "did", "do", "does", "doing",
+    "down", "each", "for", "from", "further", "guys", "had", "has", "have", "he", "her", "here",
+    "hers", "him", "his", "how", "i", "if", "in", "into", "is", "it", "its", "just", "like", "me",
+    "more", "most", "my", "no", "nor", "not", "now", "of", "off", "on", "once", "only", "or",
+    "other", "our", "ours", "out", "over", "own", "people", "person", "same", "she", "should",
+    "side", "so", "some", "still", "such", "team", "teams", "than", "that", "the", "their",
+    "theirs", "them", "then", "there", "these", "they", "thing", "things", "this", "those",
+    "through", "to", "too", "under", "until", "up", "us", "very", "was", "we", "were", "what",
+    "when", "where", "which", "while", "who", "whom", "why", "will", "with", "would", "you",
+    "your", "yours",
+];
+
+/// Phrasings that mean the same act. The canonical form starts with `@` so it
+/// can never collide with a real transcript word, and so
+/// [`shares_a_domain_token`] can tell a subject apart from a verb.
+///
+/// Deliberately small and boring. Every entry is a phrasing meeting speech
+/// actually alternates between; this is not a thesaurus, and a broad one would
+/// merge things that differ.
+const SYNONYMS: &[(&str, &[&str])] = &[
+    (
+        "@inquire",
+        &[
+            "ask",
+            "check",
+            "chase",
+            "clarify",
+            "confirm",
+            "follow",
+            "investigate",
+            "query",
+            "validate",
+            "verify",
+        ],
+    ),
+    (
+        "@capacity",
+        &[
+            "cap",
+            "capacity",
+            "ceiling",
+            "headroom",
+            "limit",
+            "max",
+            "maximum",
+            "quota",
+            "threshold",
+        ],
+    ),
+    (
+        "@decide",
+        &["agree", "approve", "decide", "decision", "settle", "sign"],
+    ),
+    ("@ship", &["deploy", "launch", "release", "rollout", "ship"]),
+    ("@fix", &["fix", "patch", "repair", "resolve", "unblock"]),
+    ("@write", &["doc", "document", "draft", "note", "write"]),
+    ("@send", &["email", "message", "post", "send", "share"]),
+    ("@meet", &["call", "meet", "meeting", "schedule", "sync"]),
+];
+
+/// Lowercases, splits on anything non-alphanumeric, stems, drops stopwords,
+/// and folds synonyms to their class.
+///
+/// Returns a set, not a list: repetition inside one statement says nothing
+/// about whether it matches another one.
+pub(crate) fn tokenize(text: &str) -> BTreeSet<String> {
+    text.split(|c: char| !c.is_alphanumeric())
+        .filter(|w| !w.is_empty())
+        .map(|w| w.to_lowercase())
+        .map(|w| stem(&w))
+        .filter(|w| w.chars().count() > 1 && !STOPWORDS.contains(&w.as_str()))
+        .map(|w| synonym_class(&w).unwrap_or(w))
+        .collect()
+}
+
+/// A deliberately minimal suffix stripper — the first step of a Porter stemmer
+/// and nothing more.
+///
+/// It exists for one case that matters here: a meeting says "signalling" in one
+/// chunk and "signalled" in another, and those must land on the same token.
+/// Anything more aggressive starts conflating words that differ.
+fn stem(word: &str) -> String {
+    // Byte slicing below is only sound on ASCII, and the suffix rules are
+    // English ones anyway — a non-ASCII token is returned untouched rather
+    // than mangled or panicked on.
+    if !word.is_ascii() {
+        return word.to_string();
+    }
+    let len = word.len();
+    let stemmed: String = if len > 4 && (word.ends_with("ies") || word.ends_with("ied")) {
+        format!("{}y", &word[..len - 3])
+    } else if len > 5 && word.ends_with("ing") {
+        word[..len - 3].to_string()
+    } else if len > 5 && word.ends_with("ed") {
+        word[..len - 2].to_string()
+    } else if len > 3 && word.ends_with('s') && !word.ends_with("ss") {
+        word[..len - 1].to_string()
+    } else {
+        word.to_string()
+    };
+    collapse_doubled_ending(&stemmed)
+}
+
+/// `signall` -> `signal`, `shipp` -> `ship`. English doubles a final consonant
+/// before `-ing`/`-ed`; stripping the suffix leaves the double behind.
+fn collapse_doubled_ending(word: &str) -> String {
+    let chars: Vec<char> = word.chars().collect();
+    let n = chars.len();
+    if n >= 3 && chars[n - 1] == chars[n - 2] && !matches!(chars[n - 1], 's' | 'l' | 'e' | 'o') {
+        return chars[..n - 1].iter().collect();
+    }
+    // `-ll` is the common English doubling (`signalling`, `cancelled`) and is
+    // safe to collapse when what remains is still a plausible stem; `-ss`
+    // (`discuss`, `process`) is not a doubling at all.
+    if n >= 4 && chars[n - 1] == 'l' && chars[n - 2] == 'l' {
+        return chars[..n - 1].iter().collect();
+    }
+    word.to_string()
+}
+
+fn synonym_class(word: &str) -> Option<String> {
+    SYNONYMS
+        .iter()
+        .find_map(|(class, members)| members.contains(&word).then(|| (*class).to_string()))
+}
+
+fn jaccard(a: &BTreeSet<String>, b: &BTreeSet<String>) -> f64 {
+    if a.is_empty() && b.is_empty() {
+        return 1.0;
+    }
+    let intersection = a.intersection(b).count();
+    let union = a.union(b).count();
+    if union == 0 {
+        return 0.0;
+    }
+    intersection as f64 / union as f64
+}
+
+/// True when the two sets share at least one token that is a real word rather
+/// than a synonym-class placeholder — i.e. they are about the same *thing*, not
+/// merely the same kind of act.
+fn shares_a_domain_token(a: &BTreeSet<String>, b: &BTreeSet<String>) -> bool {
+    a.intersection(b).any(|t| !t.starts_with('@'))
+}
+
+/// Whether two items' texts should be treated as the same fact.
+///
+/// Byte-identical text (what overlapping chunks produce for a fact sitting on a
+/// boundary) short-circuits, so the exact-duplicate case never depends on the
+/// heuristic at all.
+pub(crate) fn is_near_duplicate(left: &str, right: &str, config: &DedupConfig) -> bool {
+    if left.eq_ignore_ascii_case(right) {
+        return true;
+    }
+    if !config.semantic {
+        return false;
+    }
+    let a = tokenize(left);
+    let b = tokenize(right);
+    if a.is_empty() || b.is_empty() {
+        return false;
+    }
+    jaccard(&a, &b) >= config.similarity_threshold && shares_a_domain_token(&a, &b)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tokens(text: &str) -> Vec<String> {
+        tokenize(text).into_iter().collect()
+    }
+
+    #[test]
+    fn the_issues_worked_example_collapses_to_one_item() {
+        let config = DedupConfig::default();
+        let phrasings = [
+            "Check Temporal signalling limit",
+            "Confirm Temporal signalling capacity",
+            "Ask Temporal team about signalling",
+        ];
+        for (i, left) in phrasings.iter().enumerate() {
+            for right in phrasings.iter().skip(i + 1) {
+                assert!(
+                    is_near_duplicate(left, right, &config),
+                    "`{left}` and `{right}` should be one item"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn the_same_verb_class_on_a_different_subject_does_not_merge() {
+        let config = DedupConfig::default();
+        assert!(!is_near_duplicate(
+            "Check the Temporal signalling limit",
+            "Check the Kafka retention limit",
+            &config
+        ));
+        assert!(!is_near_duplicate(
+            "Confirm the budget",
+            "Confirm the limit",
+            &config
+        ));
+    }
+
+    #[test]
+    fn identical_text_merges_without_consulting_the_heuristic() {
+        let strict = DedupConfig {
+            semantic: false,
+            ..DedupConfig::default()
+        };
+        assert!(is_near_duplicate(
+            "Ship the release on Friday",
+            "ship the release on friday",
+            &strict
+        ));
+        assert!(!is_near_duplicate(
+            "Check Temporal signalling limit",
+            "Confirm Temporal signalling capacity",
+            &strict
+        ));
+    }
+
+    #[test]
+    fn inflections_of_the_same_word_land_on_the_same_token() {
+        assert_eq!(stem("signalling"), "signal");
+        assert_eq!(stem("signalled"), "signal");
+        assert_eq!(stem("signals"), "signal");
+        assert_eq!(stem("shipping"), "ship");
+        assert_eq!(stem("verified"), "verify");
+        assert_eq!(stem("queries"), "query");
+        // Not a doubling — must survive intact.
+        assert_eq!(stem("process"), "process");
+        assert_eq!(stem("discuss"), "discuss");
+    }
+
+    #[test]
+    fn stopwords_and_synonym_classes_leave_only_the_subject_behind() {
+        assert_eq!(
+            tokens("Ask the Temporal team about signalling"),
+            vec![
+                "@inquire".to_string(),
+                "signal".to_string(),
+                "temporal".to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn an_item_that_is_only_stopwords_never_merges_with_anything() {
+        let config = DedupConfig::default();
+        assert!(!is_near_duplicate("the it a", "Check the limit", &config));
+    }
+
+    #[test]
+    fn similarity_is_symmetric() {
+        let config = DedupConfig::default();
+        let a = "Confirm Temporal signalling capacity";
+        let b = "Ask Temporal team about signalling";
+        assert_eq!(
+            is_near_duplicate(a, b, &config),
+            is_near_duplicate(b, a, &config)
+        );
+    }
+}

--- a/rust/airo_mind_meeting/src/diagnostics.rs
+++ b/rust/airo_mind_meeting/src/diagnostics.rs
@@ -1,0 +1,67 @@
+//! What extraction discarded, and why.
+//!
+//! Grounding is enforced by *dropping* things: an item that cites a segment it
+//! could not have come from, an owner the transcript never named, a chunk whose
+//! output never parsed. Dropping silently would make the IR look cleaner than
+//! the run that produced it actually was, so every drop and every merge leaves
+//! a record here.
+//!
+//! These are observations about one run, not errors — a run with diagnostics
+//! still produced a usable IR. [`crate::ExtractionError`] is for the cases
+//! where it did not.
+
+/// One thing extraction changed or refused, with enough context to check it
+/// against the transcript by hand.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum Diagnostic {
+    /// The model's output for this attempt was not a parseable `Facts` object.
+    /// Expected to be rare with the grammar attached; the usual real cause is
+    /// output truncated by `max_output_tokens`, which produces valid-so-far
+    /// JSON that simply stops.
+    UnparseableOutput {
+        chunk_id: String,
+        attempt: u32,
+        detail: String,
+    },
+    /// Every attempt for this chunk failed to parse. The chunk contributes no
+    /// facts; the rest of the meeting still extracts.
+    ChunkAbandoned { chunk_id: String, attempts: u32 },
+    /// An item cited no segment id belonging to its own chunk. Ungrounded, so
+    /// dropped — this is the rule the whole milestone runs on.
+    UngroundedItemDropped {
+        chunk_id: String,
+        category: &'static str,
+        text: String,
+    },
+    /// An item cited a segment id that is not in its chunk. The id is removed;
+    /// the item survives if it cited at least one real one.
+    UnknownEvidenceDropped {
+        chunk_id: String,
+        category: &'static str,
+        segment_id: String,
+    },
+    /// The model named an owner whose name does not appear in the chunk it
+    /// extracted from. The owner is reset to `None` rather than trusted — an
+    /// owner is only ever copied from the transcript, never inferred.
+    OwnerNotInTranscript {
+        chunk_id: String,
+        task: String,
+        owner: String,
+    },
+    /// Pass 2 folded a near-duplicate into an earlier item.
+    ItemsMerged {
+        category: &'static str,
+        kept: String,
+        merged: String,
+    },
+    /// Two merged items named different owners (or dues, or answers). The
+    /// earlier one is kept. Worth surfacing: it can equally mean the dedup
+    /// threshold merged two items that were not the same thing.
+    ConflictingDetail {
+        category: &'static str,
+        item: String,
+        field: &'static str,
+        kept: String,
+        discarded: String,
+    },
+}

--- a/rust/airo_mind_meeting/src/fact.rs
+++ b/rust/airo_mind_meeting/src/fact.rs
@@ -1,0 +1,379 @@
+//! The one thing all eight IR categories have in common.
+//!
+//! Grounding, id assignment and consolidation are the same operation for a
+//! `Decision` as for a `Risk` — only the field names differ. [`Fact`] is the
+//! seam that lets each of those be written once. It is `pub(crate)`: it exists
+//! to remove triplicated code, not to become a public extension point.
+
+use crate::diagnostics::Diagnostic;
+use crate::ir::{
+    ActionItem, ActionStatus, Decision, DecisionStatus, Metric, NextStep, Observation, Question,
+    Risk, Topic,
+};
+
+pub(crate) trait Fact: Sized {
+    /// Singular, snake_case. Used for item ids (`decision-0`) and in
+    /// diagnostics.
+    const CATEGORY: &'static str;
+
+    fn set_id(&mut self, id: String);
+    /// The natural-language content the dedup heuristic compares.
+    fn text(&self) -> &str;
+    fn evidence(&self) -> &[String];
+    fn evidence_mut(&mut self) -> &mut Vec<String>;
+
+    /// Folds a later near-duplicate into this item.
+    ///
+    /// Evidence is always unioned. Everything else is category-specific and
+    /// overridden below; the default handles the categories that carry nothing
+    /// but text and evidence.
+    fn absorb(&mut self, other: Self, diagnostics: &mut Vec<Diagnostic>) {
+        let _ = diagnostics;
+        union_evidence(self.evidence_mut(), other.evidence());
+    }
+}
+
+/// Appends `incoming`'s ids that `into` does not already have, preserving
+/// first-seen order.
+///
+/// First-seen order rather than sorted: segment ids are produced in transcript
+/// order, so encounter order *is* chronological order, while sorting them
+/// lexicographically would put `s10` before `s2`.
+pub(crate) fn union_evidence(into: &mut Vec<String>, incoming: &[String]) {
+    for id in incoming {
+        if !into.iter().any(|existing| existing == id) {
+            into.push(id.clone());
+        }
+    }
+}
+
+/// Keeps the earlier value when two merged items disagree, and says so.
+///
+/// The earlier one wins because it is the one said closest to where the fact
+/// was established; a later mention is usually a recap. A conflict here is also
+/// a signal that the dedup threshold may have merged two different things,
+/// which is why it is reported rather than resolved quietly.
+fn keep_earlier<T: PartialEq + std::fmt::Display>(
+    kept: &mut Option<T>,
+    incoming: Option<T>,
+    category: &'static str,
+    item: &str,
+    field: &'static str,
+    diagnostics: &mut Vec<Diagnostic>,
+) {
+    match (&*kept, incoming) {
+        (None, incoming) => *kept = incoming,
+        (Some(_), None) => {}
+        (Some(existing), Some(incoming)) => {
+            if *existing != incoming {
+                diagnostics.push(Diagnostic::ConflictingDetail {
+                    category,
+                    item: item.to_string(),
+                    field,
+                    kept: existing.to_string(),
+                    discarded: incoming.to_string(),
+                });
+            }
+        }
+    }
+}
+
+impl Fact for Topic {
+    const CATEGORY: &'static str = "topic";
+    fn set_id(&mut self, id: String) {
+        self.id = id;
+    }
+    fn text(&self) -> &str {
+        &self.title
+    }
+    fn evidence(&self) -> &[String] {
+        &self.evidence
+    }
+    fn evidence_mut(&mut self) -> &mut Vec<String> {
+        &mut self.evidence
+    }
+}
+
+impl Fact for Observation {
+    const CATEGORY: &'static str = "observation";
+    fn set_id(&mut self, id: String) {
+        self.id = id;
+    }
+    fn text(&self) -> &str {
+        &self.statement
+    }
+    fn evidence(&self) -> &[String] {
+        &self.evidence
+    }
+    fn evidence_mut(&mut self) -> &mut Vec<String> {
+        &mut self.evidence
+    }
+}
+
+impl Fact for Decision {
+    const CATEGORY: &'static str = "decision";
+    fn set_id(&mut self, id: String) {
+        self.id = id;
+    }
+    fn text(&self) -> &str {
+        &self.statement
+    }
+    fn evidence(&self) -> &[String] {
+        &self.evidence
+    }
+    fn evidence_mut(&mut self) -> &mut Vec<String> {
+        &mut self.evidence
+    }
+
+    /// Status resolution across chunks: a **resolved** status beats
+    /// `Proposed`, and among resolved statuses the later mention wins.
+    ///
+    /// Not simply "later wins": a decision agreed in chunk 1 and recapped in
+    /// chunk 4 ("so we're doing X?") would be demoted back to `Proposed` by
+    /// that rule, which is the wrong answer. `Proposed` is the "not settled
+    /// yet" default, so a chunk that carries it adds no information about
+    /// resolution.
+    fn absorb(&mut self, other: Self, diagnostics: &mut Vec<Diagnostic>) {
+        union_evidence(&mut self.evidence, &other.evidence);
+        if other.status != DecisionStatus::Proposed {
+            self.status = other.status;
+        }
+        let _ = diagnostics;
+    }
+}
+
+impl Fact for ActionItem {
+    const CATEGORY: &'static str = "action_item";
+    fn set_id(&mut self, id: String) {
+        self.id = id;
+    }
+    fn text(&self) -> &str {
+        &self.task
+    }
+    fn evidence(&self) -> &[String] {
+        &self.evidence
+    }
+    fn evidence_mut(&mut self) -> &mut Vec<String> {
+        &mut self.evidence
+    }
+
+    /// An owner named in *any* chunk fills a `None` — the transcript naming
+    /// somebody once is enough, and the chunks that did not name them are not
+    /// evidence that nobody was named. What this must never do is invent one:
+    /// two items both carrying `None` still merge to `None`.
+    fn absorb(&mut self, other: Self, diagnostics: &mut Vec<Diagnostic>) {
+        union_evidence(&mut self.evidence, &other.evidence);
+        let task = self.task.clone();
+        keep_earlier(
+            &mut self.owner,
+            other.owner,
+            Self::CATEGORY,
+            &task,
+            "owner",
+            diagnostics,
+        );
+        keep_earlier(
+            &mut self.due,
+            other.due,
+            Self::CATEGORY,
+            &task,
+            "due",
+            diagnostics,
+        );
+        if other.status != ActionStatus::Open {
+            self.status = other.status;
+        }
+    }
+}
+
+impl Fact for Metric {
+    const CATEGORY: &'static str = "metric";
+    fn set_id(&mut self, id: String) {
+        self.id = id;
+    }
+    fn text(&self) -> &str {
+        &self.name
+    }
+    fn evidence(&self) -> &[String] {
+        &self.evidence
+    }
+    fn evidence_mut(&mut self) -> &mut Vec<String> {
+        &mut self.evidence
+    }
+}
+
+impl Fact for Risk {
+    const CATEGORY: &'static str = "risk";
+    fn set_id(&mut self, id: String) {
+        self.id = id;
+    }
+    fn text(&self) -> &str {
+        &self.statement
+    }
+    fn evidence(&self) -> &[String] {
+        &self.evidence
+    }
+    fn evidence_mut(&mut self) -> &mut Vec<String> {
+        &mut self.evidence
+    }
+}
+
+impl Fact for Question {
+    const CATEGORY: &'static str = "question";
+    fn set_id(&mut self, id: String) {
+        self.id = id;
+    }
+    fn text(&self) -> &str {
+        &self.question
+    }
+    fn evidence(&self) -> &[String] {
+        &self.evidence
+    }
+    fn evidence_mut(&mut self) -> &mut Vec<String> {
+        &mut self.evidence
+    }
+
+    /// A question answered in a later chunk is answered, full stop.
+    fn absorb(&mut self, other: Self, diagnostics: &mut Vec<Diagnostic>) {
+        union_evidence(&mut self.evidence, &other.evidence);
+        let question = self.question.clone();
+        keep_earlier(
+            &mut self.answer,
+            other.answer,
+            Self::CATEGORY,
+            &question,
+            "answer",
+            diagnostics,
+        );
+    }
+}
+
+impl Fact for NextStep {
+    const CATEGORY: &'static str = "next_step";
+    fn set_id(&mut self, id: String) {
+        self.id = id;
+    }
+    fn text(&self) -> &str {
+        &self.statement
+    }
+    fn evidence(&self) -> &[String] {
+        &self.evidence
+    }
+    fn evidence_mut(&mut self) -> &mut Vec<String> {
+        &mut self.evidence
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn evidence_unions_without_reordering_what_was_already_there() {
+        let mut into = vec!["s2".to_string(), "s10".to_string()];
+        union_evidence(&mut into, &["s10".to_string(), "s11".to_string()]);
+        assert_eq!(into, vec!["s2", "s10", "s11"]);
+    }
+
+    #[test]
+    fn an_agreed_decision_is_not_demoted_by_a_later_recap() {
+        let mut agreed = Decision {
+            statement: "move signalling to the queue".into(),
+            status: DecisionStatus::Agreed,
+            evidence: vec!["s1".into()],
+            ..Decision::default()
+        };
+        let recap = Decision {
+            statement: "move signalling to the queue".into(),
+            status: DecisionStatus::Proposed,
+            evidence: vec!["s9".into()],
+            ..Decision::default()
+        };
+        agreed.absorb(recap, &mut Vec::new());
+        assert_eq!(agreed.status, DecisionStatus::Agreed);
+        assert_eq!(agreed.evidence, vec!["s1", "s9"]);
+    }
+
+    #[test]
+    fn a_later_rejection_overrides_an_earlier_proposal() {
+        let mut proposed = Decision {
+            statement: "add a second region".into(),
+            status: DecisionStatus::Proposed,
+            ..Decision::default()
+        };
+        proposed.absorb(
+            Decision {
+                statement: "add a second region".into(),
+                status: DecisionStatus::Rejected,
+                ..Decision::default()
+            },
+            &mut Vec::new(),
+        );
+        assert_eq!(proposed.status, DecisionStatus::Rejected);
+    }
+
+    #[test]
+    fn two_ownerless_action_items_merge_to_an_ownerless_action_item() {
+        let mut first = ActionItem {
+            task: "check the signalling limit".into(),
+            owner: None,
+            ..ActionItem::default()
+        };
+        first.absorb(
+            ActionItem {
+                task: "confirm the signalling limit".into(),
+                owner: None,
+                ..ActionItem::default()
+            },
+            &mut Vec::new(),
+        );
+        assert_eq!(first.owner, None);
+    }
+
+    #[test]
+    fn an_owner_named_in_a_later_chunk_fills_an_empty_one() {
+        let mut first = ActionItem {
+            task: "check the signalling limit".into(),
+            owner: None,
+            ..ActionItem::default()
+        };
+        first.absorb(
+            ActionItem {
+                task: "check the signalling limit".into(),
+                owner: Some("Priya".into()),
+                ..ActionItem::default()
+            },
+            &mut Vec::new(),
+        );
+        assert_eq!(first.owner.as_deref(), Some("Priya"));
+    }
+
+    #[test]
+    fn conflicting_owners_keep_the_earlier_one_and_report_it() {
+        let mut first = ActionItem {
+            task: "check the signalling limit".into(),
+            owner: Some("Priya".into()),
+            ..ActionItem::default()
+        };
+        let mut diagnostics = Vec::new();
+        first.absorb(
+            ActionItem {
+                task: "check the signalling limit".into(),
+                owner: Some("Dev".into()),
+                ..ActionItem::default()
+            },
+            &mut diagnostics,
+        );
+        assert_eq!(first.owner.as_deref(), Some("Priya"));
+        assert_eq!(
+            diagnostics,
+            vec![Diagnostic::ConflictingDetail {
+                category: "action_item",
+                item: "check the signalling limit".into(),
+                field: "owner",
+                kept: "Priya".into(),
+                discarded: "Dev".into(),
+            }]
+        );
+    }
+}

--- a/rust/airo_mind_meeting/src/ir.rs
+++ b/rust/airo_mind_meeting/src/ir.rs
@@ -1,0 +1,312 @@
+//! The Meeting IR. `#1633`.
+//!
+//! One versioned, evidence-grounded structure that every downstream meeting
+//! surface — minutes, action-item lists, search — is a *projection* of. The
+//! LLM never writes prose here: Pass 1 extracts atomic facts, Pass 2
+//! consolidates them, and neither pass produces a summary.
+//!
+//! # Evidence is segment ids, not snippets
+//!
+//! The issue allows "optionally short snippets; privacy-aware". This schema
+//! carries segment ids only, on purpose. A snippet is a verbatim copy of
+//! `secret`-class transcript text, and copying it into the IR means every
+//! projection, export and index that touches the IR now carries meeting
+//! speech it did not need. A segment id is a pointer: a caller that legitimately
+//! wants the words looks them up in the transcript it already holds, under
+//! whatever access rules apply there. Grounding is not weakened by this — the
+//! id is what makes the claim checkable, the snippet is only a convenience.
+//!
+//! # Ids are assigned by this crate, never by the model
+//!
+//! Item `id`s are `#[serde(default)]` and are overwritten after parsing (Pass 1
+//! assigns chunk-scoped ids, Pass 2 assigns meeting-scoped ones). A model that
+//! invents ids cannot collide with, overwrite or forge another item's identity,
+//! and the extraction grammar does not even offer it the field.
+
+use serde::{Deserialize, Serialize};
+
+/// The IR contract version. Bump the major on any change that an existing
+/// reader could misinterpret; the minor on additive fields.
+///
+/// Kept in lockstep with `schemas/meeting_ir.schema.json`'s `$id` — a test
+/// asserts the two agree, so the published schema can never silently describe
+/// a different version than the types.
+pub const IR_SCHEMA_VERSION: &str = "1.0.0";
+
+/// What a decision was, at the last point the transcript mentioned it.
+#[derive(Serialize, Deserialize, Clone, Copy, Debug, Default, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum DecisionStatus {
+    /// Raised, not settled. The default: silence is not agreement.
+    #[default]
+    Proposed,
+    Agreed,
+    Rejected,
+    Deferred,
+}
+
+/// Where an action item stood at the last point the transcript mentioned it.
+#[derive(Serialize, Deserialize, Clone, Copy, Debug, Default, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ActionStatus {
+    #[default]
+    Open,
+    InProgress,
+    Done,
+    Blocked,
+}
+
+/// A subject the meeting spent time on.
+#[derive(Serialize, Deserialize, Clone, Debug, Default, PartialEq, Eq)]
+pub struct Topic {
+    #[serde(default)]
+    pub id: String,
+    pub title: String,
+    #[serde(default)]
+    pub evidence: Vec<String>,
+}
+
+/// A stated fact that is not a decision, action, metric, risk or question —
+/// the catch-all for "someone said this and it matters".
+#[derive(Serialize, Deserialize, Clone, Debug, Default, PartialEq, Eq)]
+pub struct Observation {
+    #[serde(default)]
+    pub id: String,
+    pub statement: String,
+    #[serde(default)]
+    pub evidence: Vec<String>,
+}
+
+/// Something the meeting settled (or explicitly did not).
+#[derive(Serialize, Deserialize, Clone, Debug, Default, PartialEq, Eq)]
+pub struct Decision {
+    #[serde(default)]
+    pub id: String,
+    pub statement: String,
+    #[serde(default)]
+    pub status: DecisionStatus,
+    #[serde(default)]
+    pub evidence: Vec<String>,
+}
+
+/// Work someone is expected to do after the meeting.
+#[derive(Serialize, Deserialize, Clone, Debug, Default, PartialEq, Eq)]
+pub struct ActionItem {
+    #[serde(default)]
+    pub id: String,
+    pub task: String,
+    /// `None` when the transcript names nobody. **Never inferred.** Pass 1
+    /// drops any owner whose name does not literally appear in the chunk the
+    /// item came from — see `pass1::ground_owner`.
+    #[serde(default)]
+    pub owner: Option<String>,
+    /// Whatever the transcript said, as it said it ("Friday", "end of the
+    /// quarter"). Not parsed into a date: resolving "Friday" needs a meeting
+    /// date and a timezone this crate does not have, and a wrong date is worse
+    /// than the words that were actually spoken.
+    #[serde(default)]
+    pub due: Option<String>,
+    #[serde(default)]
+    pub status: ActionStatus,
+    #[serde(default)]
+    pub evidence: Vec<String>,
+}
+
+/// A number the meeting quoted. `value` stays a string for the same reason
+/// `due` does — "about 500,000", "2x", "under a second" are all real answers
+/// and none of them is an `f64`.
+#[derive(Serialize, Deserialize, Clone, Debug, Default, PartialEq, Eq)]
+pub struct Metric {
+    #[serde(default)]
+    pub id: String,
+    pub name: String,
+    pub value: String,
+    #[serde(default)]
+    pub evidence: Vec<String>,
+}
+
+/// Something that could go wrong, as stated.
+#[derive(Serialize, Deserialize, Clone, Debug, Default, PartialEq, Eq)]
+pub struct Risk {
+    #[serde(default)]
+    pub id: String,
+    pub statement: String,
+    #[serde(default)]
+    pub evidence: Vec<String>,
+}
+
+/// Something asked. `answer` is `None` when the transcript never answered it —
+/// an open question is a result, not a gap to fill in.
+#[derive(Serialize, Deserialize, Clone, Debug, Default, PartialEq, Eq)]
+pub struct Question {
+    #[serde(default)]
+    pub id: String,
+    pub question: String,
+    #[serde(default)]
+    pub answer: Option<String>,
+    #[serde(default)]
+    pub evidence: Vec<String>,
+}
+
+/// What happens next, where nobody was named and no task was assigned. An
+/// action item with an owner belongs in `action_items`.
+#[derive(Serialize, Deserialize, Clone, Debug, Default, PartialEq, Eq)]
+pub struct NextStep {
+    #[serde(default)]
+    pub id: String,
+    pub statement: String,
+    #[serde(default)]
+    pub evidence: Vec<String>,
+}
+
+/// The eight fact categories, shared by the per-chunk IR (Pass 1) and the
+/// consolidated meeting IR (Pass 2). One type, so a category can never exist
+/// in one pass and be forgotten in the other.
+///
+/// Every field is `#[serde(default)]`: a chunk that contains no risks emits
+/// `"risks": []`, but a hand-written fixture or an older payload that omits the
+/// key entirely is still readable rather than a parse error.
+#[derive(Serialize, Deserialize, Clone, Debug, Default, PartialEq, Eq)]
+pub struct Facts {
+    #[serde(default)]
+    pub topics: Vec<Topic>,
+    #[serde(default)]
+    pub observations: Vec<Observation>,
+    #[serde(default)]
+    pub decisions: Vec<Decision>,
+    #[serde(default)]
+    pub action_items: Vec<ActionItem>,
+    #[serde(default)]
+    pub metrics: Vec<Metric>,
+    #[serde(default)]
+    pub risks: Vec<Risk>,
+    #[serde(default)]
+    pub questions: Vec<Question>,
+    #[serde(default)]
+    pub next_steps: Vec<NextStep>,
+}
+
+impl Facts {
+    /// Total items across every category. Used by tests and diagnostics; not
+    /// a quality signal on its own.
+    pub fn len(&self) -> usize {
+        self.topics.len()
+            + self.observations.len()
+            + self.decisions.len()
+            + self.action_items.len()
+            + self.metrics.len()
+            + self.risks.len()
+            + self.questions.len()
+            + self.next_steps.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}
+
+/// Pass 1's output for one chunk: the facts the model extracted from it, still
+/// scoped to that chunk and not yet deduped against any other.
+#[derive(Serialize, Deserialize, Clone, Debug, Default, PartialEq, Eq)]
+pub struct ChunkIr {
+    pub chunk_id: String,
+    /// The segment ids this chunk covered. Retained so a consumer can check
+    /// grounding without holding the transcript.
+    #[serde(default)]
+    pub segment_ids: Vec<String>,
+    #[serde(flatten)]
+    pub facts: Facts,
+}
+
+/// What the IR is about and what produced it.
+///
+/// None of this is extracted by the model — it is either supplied by the
+/// caller (id, title) or derived from the transcript (`chunk_count`, span).
+/// `ADR-0018 §5`: content records what produced it, so `model_id` and
+/// `prompt_version` travel with the IR rather than being reconstructed later.
+#[derive(Serialize, Deserialize, Clone, Debug, Default, PartialEq, Eq)]
+pub struct Meeting {
+    pub id: String,
+    #[serde(default)]
+    pub title: Option<String>,
+    pub started_at_ms: u64,
+    pub ended_at_ms: u64,
+    pub chunk_count: u32,
+    pub segment_count: u32,
+    /// The logical model id and version, as `airo_mind_llama` reports it.
+    /// `None` when extraction ran against a double (tests) or the caller did
+    /// not record one — an absent provenance is stated, never invented.
+    #[serde(default)]
+    pub model_id: Option<String>,
+    /// The extraction prompt template version that produced this IR.
+    pub prompt_version: String,
+}
+
+/// The consolidated meeting IR: one `Meeting` and one set of deduped,
+/// evidence-grounded facts.
+#[derive(Serialize, Deserialize, Clone, Debug, Default, PartialEq, Eq)]
+pub struct MeetingIr {
+    /// Always [`IR_SCHEMA_VERSION`] on write. Present on the wire so a reader
+    /// can refuse a payload it does not understand instead of guessing.
+    pub schema_version: String,
+    pub meeting: Meeting,
+    #[serde(flatten)]
+    pub facts: Facts,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn an_action_item_with_no_owner_round_trips_as_null() {
+        let item = ActionItem {
+            id: "action-0".into(),
+            task: "check the Temporal signalling limit".into(),
+            owner: None,
+            due: None,
+            status: ActionStatus::Open,
+            evidence: vec!["s3".into()],
+        };
+        let json = serde_json::to_string(&item).unwrap();
+        assert!(json.contains("\"owner\":null"), "{json}");
+
+        let back: ActionItem = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, item);
+    }
+
+    #[test]
+    fn a_missing_category_reads_as_empty_rather_than_failing() {
+        let facts: Facts = serde_json::from_str("{\"decisions\":[]}").unwrap();
+        assert!(facts.is_empty());
+    }
+
+    #[test]
+    fn statuses_are_snake_case_on_the_wire() {
+        let json = serde_json::to_string(&ActionStatus::InProgress).unwrap();
+        assert_eq!(json, "\"in_progress\"");
+    }
+
+    #[test]
+    fn the_meeting_ir_flattens_its_categories_to_the_top_level() {
+        let ir = MeetingIr {
+            schema_version: IR_SCHEMA_VERSION.into(),
+            meeting: Meeting::default(),
+            facts: Facts::default(),
+        };
+        let value: serde_json::Value = serde_json::to_value(&ir).unwrap();
+        for key in [
+            "meeting",
+            "topics",
+            "observations",
+            "decisions",
+            "action_items",
+            "metrics",
+            "risks",
+            "questions",
+            "next_steps",
+        ] {
+            assert!(value.get(key).is_some(), "missing `{key}`");
+        }
+    }
+}

--- a/rust/airo_mind_meeting/src/lib.rs
+++ b/rust/airo_mind_meeting/src/lib.rs
@@ -1,0 +1,165 @@
+#![deny(unsafe_code)]
+//! Airo Mind Meeting capability — Meeting IR and two-pass extraction. `#1633`,
+//! Milestone 26 Phase 2/Wave 2.
+//!
+//! # The rule this crate exists to keep
+//!
+//! **The LLM never summarises the transcript.** Pass 1 extracts atomic facts
+//! from one chunk at a time, each citing the segment ids it came from. Pass 2
+//! consolidates those facts into one meeting IR. Neither pass produces prose.
+//! Minutes, action-item lists and meeting search are *projections* of the IR,
+//! built elsewhere (`#1634` onward) — a projection can be regenerated, argued
+//! with, and traced back to a timestamp in the recording. A summary cannot.
+//!
+//! # Where this sits
+//!
+//! ```text
+//! airo_mind_whisper  #1629   audio        -> segments
+//! airo_mind_transcript #1632 segments     -> normalized text + chunks (segment_ids)
+//! airo_mind_meeting  #1633   chunks       -> MeetingIr          <- this crate
+//! (projections)      #1634+  MeetingIr    -> minutes / actions / search
+//! ```
+//!
+//! It is the **capability**, above the runtime's engine boundary. `C5` keeps
+//! meeting vocabulary out of `airo_mind_core`/`airo_mind_llama`, so the prompt,
+//! the GBNF grammar, the IR schema and the word "meeting" all live here, and
+//! the engine below only ever sees a `GenerationRequest`. That is also why this
+//! crate takes a `&dyn GenerationEngine` rather than constructing one: the real
+//! llama engine and a test double are the same shape to it, and nothing here
+//! needs cmake to compile or a 4 GB model to test.
+//!
+//! # Persistence is somewhere else
+//!
+//! Nothing here writes anything. Recording a `MeetingIr` into the operation log
+//! is `#1657`; this crate is pure transformation, which is what makes both
+//! passes testable without a vault.
+//!
+//! # Off the main isolate
+//!
+//! Same as `airo_mind_transcript`: no FFI surface of its own, called from Rust
+//! by whichever engine crate drives extraction, already off the Flutter main
+//! isolate at the `core_native` boundary. There is no synchronous path from
+//! Dart into this crate to guard.
+
+pub mod dedup;
+pub mod diagnostics;
+mod fact;
+pub mod ir;
+pub mod pass1;
+pub mod pass2;
+pub mod prompt;
+
+use std::collections::BTreeMap;
+
+use airo_mind_core::{CancelToken, GenerationEngine};
+use airo_mind_transcript::ProcessedTranscript;
+
+pub use dedup::DedupConfig;
+pub use diagnostics::Diagnostic;
+pub use ir::{
+    ActionItem, ActionStatus, ChunkIr, Decision, DecisionStatus, Facts, Meeting, MeetingIr, Metric,
+    NextStep, Observation, Question, Risk, Topic, IR_SCHEMA_VERSION,
+};
+pub use pass1::{extract_chunk, ExtractionConfig};
+pub use pass2::consolidate;
+pub use prompt::{CHUNK_FACTS_GRAMMAR, PROMPT_VERSION};
+
+/// Why extraction could not finish at all.
+///
+/// Deliberately short. A chunk whose output would not parse, an item that cited
+/// a segment it could not have, an owner the transcript never named — none of
+/// those are errors. They are [`Diagnostic`]s, and the run still produces an IR.
+/// These two are the cases where there is nothing to produce.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum ExtractionError {
+    /// The user navigated away. Nothing partial should be treated as a result.
+    Cancelled,
+    /// The generation backend failed or has no model. Reported once, with the
+    /// engine's own message, rather than retried per chunk — every remaining
+    /// chunk would fail the same way.
+    Engine(String),
+}
+
+impl std::fmt::Display for ExtractionError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Cancelled => write!(f, "cancelled"),
+            Self::Engine(message) => write!(f, "generation engine failed: {message}"),
+        }
+    }
+}
+
+impl std::error::Error for ExtractionError {}
+
+/// What the caller knows about the meeting that the transcript does not.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct MeetingInput {
+    pub id: String,
+    pub title: Option<String>,
+    /// The logical model id and version that will do the extracting, as
+    /// `airo_mind_llama::generation_model_id` reports it. `None` records
+    /// "unknown provenance" honestly rather than inventing one.
+    pub model_id: Option<String>,
+}
+
+/// One completed extraction: the IR, and everything the run discarded.
+#[derive(Clone, Debug, PartialEq)]
+pub struct Extraction {
+    pub ir: MeetingIr,
+    /// Pass 1's per-chunk output, before consolidation. Kept because it is what
+    /// makes a consolidation decision reviewable after the fact — and what
+    /// MIND-LLM-11 needs to score the two passes separately.
+    pub chunk_irs: Vec<ChunkIr>,
+    pub diagnostics: Vec<Diagnostic>,
+}
+
+/// Runs both passes over a processed transcript.
+///
+/// This is the entry point; [`extract_chunk`] and [`consolidate`] are exposed
+/// underneath it for callers that need to drive the passes separately (an eval
+/// harness scoring Pass 1 on its own, for instance).
+///
+/// A transcript with no chunks yields an empty IR rather than an error — a
+/// recording of silence is a legitimate meeting with nothing in it.
+pub fn extract(
+    engine: &dyn GenerationEngine,
+    transcript: &ProcessedTranscript,
+    meeting: &MeetingInput,
+    config: &ExtractionConfig,
+    cancel: &CancelToken,
+) -> Result<Extraction, ExtractionError> {
+    let segment_text: BTreeMap<&str, &str> = transcript
+        .segments
+        .iter()
+        .map(|s| (s.id.as_str(), s.normalized.as_str()))
+        .collect();
+
+    let mut chunk_irs = Vec::with_capacity(transcript.chunks.len());
+    let mut diagnostics = Vec::new();
+    for chunk in &transcript.chunks {
+        let (chunk_ir, chunk_diagnostics) =
+            extract_chunk(engine, chunk, &segment_text, config, cancel)?;
+        chunk_irs.push(chunk_ir);
+        diagnostics.extend(chunk_diagnostics);
+    }
+
+    let meta = Meeting {
+        id: meeting.id.clone(),
+        title: meeting.title.clone(),
+        started_at_ms: transcript.segments.first().map(|s| s.start_ms).unwrap_or(0),
+        ended_at_ms: transcript.segments.last().map(|s| s.end_ms).unwrap_or(0),
+        chunk_count: u32::try_from(transcript.chunks.len()).unwrap_or(u32::MAX),
+        segment_count: u32::try_from(transcript.segments.len()).unwrap_or(u32::MAX),
+        model_id: meeting.model_id.clone(),
+        prompt_version: PROMPT_VERSION.to_string(),
+    };
+
+    let (ir, merge_diagnostics) = consolidate(&chunk_irs, meta, &config.dedup);
+    diagnostics.extend(merge_diagnostics);
+
+    Ok(Extraction {
+        ir,
+        chunk_irs,
+        diagnostics,
+    })
+}

--- a/rust/airo_mind_meeting/src/pass1.rs
+++ b/rust/airo_mind_meeting/src/pass1.rs
@@ -1,0 +1,386 @@
+//! Pass 1 — per-chunk fact extraction.
+//!
+//! One grammar-constrained generation per chunk, then a grounding pass that
+//! throws away anything the chunk cannot back up. The model proposes; this
+//! module is what decides.
+//!
+//! # Three separate guarantees, in order
+//!
+//! 1. **Shape** is the grammar's job. `GenerationRequest::grammar` constrains
+//!    the sampler to a valid `Facts` object, so "the model returned prose" is
+//!    not a state that can occur.
+//! 2. **Parse** is bounded-retry's job. The grammar cannot prevent output being
+//!    cut off at `max_output_tokens` mid-object, which yields JSON that is valid
+//!    right up to where it stops. That retries, a fixed number of times, and
+//!    then the chunk is abandoned with a diagnostic — never an unbounded loop.
+//! 3. **Grounding** is this module's job, and is not delegated to the model at
+//!    all. An item citing a segment outside its own chunk is dropped. An owner
+//!    whose name does not appear in the chunk is erased. Both are mechanical
+//!    checks against the transcript, which is the only kind of check that
+//!    actually holds.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use airo_mind_core::{CancelToken, EngineError, GenerationEngine, GenerationRequest};
+use airo_mind_transcript::Chunk;
+
+use crate::dedup::DedupConfig;
+use crate::diagnostics::Diagnostic;
+use crate::fact::Fact;
+use crate::ir::{ChunkIr, Facts};
+use crate::prompt;
+use crate::ExtractionError;
+
+/// What Pass 1 and Pass 2 are allowed to spend and how hard they try.
+#[derive(Clone, Debug, PartialEq)]
+pub struct ExtractionConfig {
+    /// Output-token ceiling per chunk.
+    ///
+    /// `1024` fits the eight categories for a 5–10 minute chunk with room to
+    /// spare; a chunk dense enough to overrun it is exactly the case the retry
+    /// path exists for.
+    pub max_output_tokens: u32,
+    /// How many times one chunk may be generated before it is abandoned.
+    /// Must be at least 1; `0` is treated as 1 rather than silently extracting
+    /// nothing.
+    pub max_attempts: u32,
+    /// Pass 2's merge behaviour.
+    pub dedup: DedupConfig,
+}
+
+impl Default for ExtractionConfig {
+    fn default() -> Self {
+        Self {
+            max_output_tokens: 1024,
+            max_attempts: 3,
+            dedup: DedupConfig::default(),
+        }
+    }
+}
+
+/// Extracts facts from one chunk.
+///
+/// `segment_text` maps segment id to the normalized text of that segment; it
+/// supplies the `[id] text` lines the prompt asks the model to cite from. Ids
+/// in `chunk.segment_ids` that are missing from the map are simply not shown to
+/// the model.
+///
+/// Returns the chunk's IR and everything that was dropped getting there. An
+/// engine failure is an error (the backend is broken, and the next chunk will
+/// fail the same way); an unparseable *chunk* is not — it contributes no facts
+/// and the meeting carries on.
+pub fn extract_chunk(
+    engine: &dyn GenerationEngine,
+    chunk: &Chunk,
+    segment_text: &BTreeMap<&str, &str>,
+    config: &ExtractionConfig,
+    cancel: &CancelToken,
+) -> Result<(ChunkIr, Vec<Diagnostic>), ExtractionError> {
+    let mut diagnostics = Vec::new();
+
+    let lines: Vec<(&str, &str)> = chunk
+        .segment_ids
+        .iter()
+        .filter_map(|id| {
+            segment_text
+                .get(id.as_str())
+                .map(|text| (id.as_str(), *text))
+        })
+        .collect();
+
+    let request = GenerationRequest {
+        prompt: prompt::render_chunk_facts(&lines),
+        max_output_tokens: config.max_output_tokens,
+        grammar: Some(prompt::CHUNK_FACTS_GRAMMAR.to_string()),
+    };
+
+    let attempts = config.max_attempts.max(1);
+    let mut facts: Option<Facts> = None;
+    for attempt in 1..=attempts {
+        if cancel.is_cancelled() {
+            return Err(ExtractionError::Cancelled);
+        }
+        let raw = generate(engine, &request, cancel)?;
+        match parse_facts(&raw) {
+            Ok(parsed) => {
+                facts = Some(parsed);
+                break;
+            }
+            Err(detail) => diagnostics.push(Diagnostic::UnparseableOutput {
+                chunk_id: chunk.id.clone(),
+                attempt,
+                detail,
+            }),
+        }
+    }
+
+    let facts = match facts {
+        Some(facts) => facts,
+        None => {
+            diagnostics.push(Diagnostic::ChunkAbandoned {
+                chunk_id: chunk.id.clone(),
+                attempts,
+            });
+            Facts::default()
+        }
+    };
+
+    let facts = ground(facts, chunk, &mut diagnostics);
+
+    Ok((
+        ChunkIr {
+            chunk_id: chunk.id.clone(),
+            segment_ids: chunk.segment_ids.clone(),
+            facts,
+        },
+        diagnostics,
+    ))
+}
+
+/// Runs one generation and collects the streamed tokens.
+///
+/// Streaming is the engine's contract (`I7`), and Pass 1 genuinely needs the
+/// whole object before it can parse anything — so this is the one place the
+/// stream is joined, deliberately and at chunk scale, not meeting scale.
+fn generate(
+    engine: &dyn GenerationEngine,
+    request: &GenerationRequest,
+    cancel: &CancelToken,
+) -> Result<String, ExtractionError> {
+    let mut raw = String::new();
+    engine
+        .generate(request, cancel, &mut |chunk| {
+            raw.push_str(&chunk.text);
+            Ok(())
+        })
+        .map_err(|e| match e {
+            EngineError::Cancelled => ExtractionError::Cancelled,
+            other => ExtractionError::Engine(other.to_string()),
+        })?;
+    Ok(raw)
+}
+
+/// Parses the model's output into `Facts`.
+///
+/// Trims to the outermost `{ … }` first. With the grammar attached there is
+/// nothing outside it to trim, but an engine that ignores the grammar (a test
+/// double, or a backend without grammar support) commonly wraps the object in a
+/// code fence, and recovering from that is free.
+fn parse_facts(raw: &str) -> Result<Facts, String> {
+    let start = raw.find('{').ok_or("no JSON object in output")?;
+    let end = raw.rfind('}').ok_or("unterminated JSON object")?;
+    if end < start {
+        return Err("unterminated JSON object".to_string());
+    }
+    serde_json::from_str(&raw[start..=end]).map_err(|e| e.to_string())
+}
+
+/// Drops everything the chunk cannot back up, and assigns chunk-scoped ids.
+fn ground(facts: Facts, chunk: &Chunk, diagnostics: &mut Vec<Diagnostic>) -> Facts {
+    let allowed: BTreeSet<&str> = chunk.segment_ids.iter().map(String::as_str).collect();
+    let mut grounded = Facts {
+        topics: ground_items(facts.topics, &chunk.id, &allowed, diagnostics),
+        observations: ground_items(facts.observations, &chunk.id, &allowed, diagnostics),
+        decisions: ground_items(facts.decisions, &chunk.id, &allowed, diagnostics),
+        action_items: ground_items(facts.action_items, &chunk.id, &allowed, diagnostics),
+        metrics: ground_items(facts.metrics, &chunk.id, &allowed, diagnostics),
+        risks: ground_items(facts.risks, &chunk.id, &allowed, diagnostics),
+        questions: ground_items(facts.questions, &chunk.id, &allowed, diagnostics),
+        next_steps: ground_items(facts.next_steps, &chunk.id, &allowed, diagnostics),
+    };
+
+    for item in &mut grounded.action_items {
+        if let Some(owner) = item.owner.take() {
+            if names_appear_in(&owner, &chunk.text) {
+                item.owner = Some(owner);
+            } else {
+                diagnostics.push(Diagnostic::OwnerNotInTranscript {
+                    chunk_id: chunk.id.clone(),
+                    task: item.task.clone(),
+                    owner,
+                });
+            }
+        }
+    }
+
+    grounded
+}
+
+fn ground_items<F: Fact>(
+    items: Vec<F>,
+    chunk_id: &str,
+    allowed: &BTreeSet<&str>,
+    diagnostics: &mut Vec<Diagnostic>,
+) -> Vec<F> {
+    let mut kept: Vec<F> = Vec::with_capacity(items.len());
+    for mut item in items {
+        if item.text().trim().is_empty() {
+            diagnostics.push(Diagnostic::UngroundedItemDropped {
+                chunk_id: chunk_id.to_string(),
+                category: F::CATEGORY,
+                text: String::new(),
+            });
+            continue;
+        }
+
+        let mut evidence = Vec::with_capacity(item.evidence().len());
+        for id in item.evidence() {
+            if !allowed.contains(id.as_str()) {
+                diagnostics.push(Diagnostic::UnknownEvidenceDropped {
+                    chunk_id: chunk_id.to_string(),
+                    category: F::CATEGORY,
+                    segment_id: id.clone(),
+                });
+                continue;
+            }
+            if !evidence.iter().any(|existing| existing == id) {
+                evidence.push(id.clone());
+            }
+        }
+
+        if evidence.is_empty() {
+            diagnostics.push(Diagnostic::UngroundedItemDropped {
+                chunk_id: chunk_id.to_string(),
+                category: F::CATEGORY,
+                text: item.text().to_string(),
+            });
+            continue;
+        }
+
+        *item.evidence_mut() = evidence;
+        item.set_id(format!("{chunk_id}:{}-{}", F::CATEGORY, kept.len()));
+        kept.push(item);
+    }
+    kept
+}
+
+/// Whether every word of `owner` appears as a whole word in `text`,
+/// case-insensitively.
+///
+/// Word-wise rather than whole-string: the transcript says "Priya said she'd
+/// take it", and a model may only write "Priya Nair" if it read "Nair" too.
+/// Whole words rather than substrings, so "Dev" cannot be justified by the word
+/// "device". It is a containment test, not a name parser — its whole job is to
+/// make an invented owner impossible to keep, and an owner it wrongly rejects
+/// becomes `None`, which is the safe direction to be wrong in.
+fn names_appear_in(owner: &str, text: &str) -> bool {
+    let words = |s: &str| -> Vec<String> {
+        s.split(|c: char| !c.is_alphanumeric())
+            .filter(|w| !w.is_empty())
+            .map(str::to_lowercase)
+            .collect()
+    };
+    let spoken: BTreeSet<String> = words(text).into_iter().collect();
+    let named = words(owner);
+    !named.is_empty() && named.iter().all(|word| spoken.contains(word))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ir::{ActionItem, Decision};
+
+    fn chunk() -> Chunk {
+        Chunk {
+            id: "chunk-0".into(),
+            start_ms: 0,
+            end_ms: 1_000,
+            segment_ids: vec!["s0".into(), "s1".into()],
+            text: "Priya will check the signalling limit.".into(),
+        }
+    }
+
+    #[test]
+    fn an_item_citing_a_segment_outside_its_chunk_is_dropped() {
+        let facts = Facts {
+            decisions: vec![Decision {
+                statement: "we will ship on Friday".into(),
+                evidence: vec!["s99".into()],
+                ..Decision::default()
+            }],
+            ..Facts::default()
+        };
+        let mut diagnostics = Vec::new();
+        let grounded = ground(facts, &chunk(), &mut diagnostics);
+
+        assert!(grounded.decisions.is_empty());
+        assert!(diagnostics.iter().any(|d| matches!(
+            d,
+            Diagnostic::UngroundedItemDropped {
+                category: "decision",
+                ..
+            }
+        )));
+    }
+
+    #[test]
+    fn an_item_citing_one_real_and_one_invented_segment_keeps_the_real_one() {
+        let facts = Facts {
+            decisions: vec![Decision {
+                statement: "we will ship on Friday".into(),
+                evidence: vec!["s1".into(), "s99".into(), "s1".into()],
+                ..Decision::default()
+            }],
+            ..Facts::default()
+        };
+        let mut diagnostics = Vec::new();
+        let grounded = ground(facts, &chunk(), &mut diagnostics);
+
+        assert_eq!(grounded.decisions.len(), 1);
+        assert_eq!(grounded.decisions[0].evidence, vec!["s1"]);
+        assert_eq!(grounded.decisions[0].id, "chunk-0:decision-0");
+    }
+
+    #[test]
+    fn an_owner_the_chunk_never_names_is_erased_not_kept() {
+        let facts = Facts {
+            action_items: vec![ActionItem {
+                task: "check the signalling limit".into(),
+                owner: Some("Dev".into()),
+                evidence: vec!["s0".into()],
+                ..ActionItem::default()
+            }],
+            ..Facts::default()
+        };
+        let mut diagnostics = Vec::new();
+        let grounded = ground(facts, &chunk(), &mut diagnostics);
+
+        assert_eq!(grounded.action_items[0].owner, None);
+        assert!(diagnostics
+            .iter()
+            .any(|d| matches!(d, Diagnostic::OwnerNotInTranscript { .. })));
+    }
+
+    #[test]
+    fn an_owner_the_chunk_does_name_survives() {
+        let facts = Facts {
+            action_items: vec![ActionItem {
+                task: "check the signalling limit".into(),
+                owner: Some("priya".into()),
+                evidence: vec!["s0".into()],
+                ..ActionItem::default()
+            }],
+            ..Facts::default()
+        };
+        let grounded = ground(facts, &chunk(), &mut Vec::new());
+        assert_eq!(grounded.action_items[0].owner.as_deref(), Some("priya"));
+    }
+
+    #[test]
+    fn output_wrapped_in_prose_or_a_code_fence_still_parses() {
+        let raw = "Here you go:\n```json\n{\"decisions\":[]}\n```\n";
+        assert_eq!(parse_facts(raw).unwrap(), Facts::default());
+    }
+
+    #[test]
+    fn truncated_output_is_a_parse_error_rather_than_a_panic() {
+        let raw = "{\"decisions\":[{\"statement\":\"we will";
+        assert!(parse_facts(raw).is_err());
+    }
+
+    #[test]
+    fn an_empty_owner_string_does_not_count_as_named() {
+        assert!(!names_appear_in("", "Priya will check it."));
+        assert!(!names_appear_in("   ", "Priya will check it."));
+    }
+}

--- a/rust/airo_mind_meeting/src/pass2.rs
+++ b/rust/airo_mind_meeting/src/pass2.rs
@@ -1,0 +1,304 @@
+//! Pass 2 — consolidation.
+//!
+//! Merges every chunk's facts into one meeting IR: near-duplicates collapse,
+//! their evidence unions, and their statuses resolve. No model is involved and
+//! nothing is rewritten — a consolidated item's text is text that was extracted
+//! verbatim from some chunk, never a phrasing invented to cover several.
+//!
+//! # Deterministic by construction
+//!
+//! Chunks are visited in transcript order, items within a chunk in extraction
+//! order, and an item joins the **first** existing cluster it matches. The same
+//! chunk IRs therefore always produce the same meeting IR, byte for byte —
+//! which is what lets the golden test here, and MIND-LLM-11's F1 gates, tell a
+//! regression from noise.
+//!
+//! # Why the earliest phrasing wins
+//!
+//! When "Check Temporal signalling limit" and "Ask Temporal team about
+//! signalling" collapse, the surviving text is the first one. It is the one said
+//! closest to where the fact was established; later mentions are usually recaps,
+//! and choosing e.g. the longest would let a rambling restatement replace a
+//! crisp original.
+
+use crate::dedup::{is_near_duplicate, DedupConfig};
+use crate::diagnostics::Diagnostic;
+use crate::fact::Fact;
+use crate::ir::{ChunkIr, Facts, Meeting, MeetingIr, IR_SCHEMA_VERSION};
+
+/// Merges chunk IRs into one meeting IR.
+///
+/// `meeting` carries the identity and provenance the model has no part in
+/// (`ADR-0018 §5`); the facts come entirely from `chunk_irs`.
+pub fn consolidate(
+    chunk_irs: &[ChunkIr],
+    meeting: Meeting,
+    config: &DedupConfig,
+) -> (MeetingIr, Vec<Diagnostic>) {
+    let mut diagnostics = Vec::new();
+
+    let facts = Facts {
+        topics: merge(
+            chunk_irs.iter().map(|c| &c.facts.topics),
+            config,
+            &mut diagnostics,
+        ),
+        observations: merge(
+            chunk_irs.iter().map(|c| &c.facts.observations),
+            config,
+            &mut diagnostics,
+        ),
+        decisions: merge(
+            chunk_irs.iter().map(|c| &c.facts.decisions),
+            config,
+            &mut diagnostics,
+        ),
+        action_items: merge(
+            chunk_irs.iter().map(|c| &c.facts.action_items),
+            config,
+            &mut diagnostics,
+        ),
+        metrics: merge(
+            chunk_irs.iter().map(|c| &c.facts.metrics),
+            config,
+            &mut diagnostics,
+        ),
+        risks: merge(
+            chunk_irs.iter().map(|c| &c.facts.risks),
+            config,
+            &mut diagnostics,
+        ),
+        questions: merge(
+            chunk_irs.iter().map(|c| &c.facts.questions),
+            config,
+            &mut diagnostics,
+        ),
+        next_steps: merge(
+            chunk_irs.iter().map(|c| &c.facts.next_steps),
+            config,
+            &mut diagnostics,
+        ),
+    };
+
+    (
+        MeetingIr {
+            schema_version: IR_SCHEMA_VERSION.to_string(),
+            meeting,
+            facts,
+        },
+        diagnostics,
+    )
+}
+
+/// Greedy first-match clustering over one category, in transcript order.
+///
+/// Greedy rather than optimal: an optimal clustering would need a global
+/// objective nobody has defined, would not be stable under adding one chunk,
+/// and is O(n³) territory for a gain no meeting-sized input would notice.
+fn merge<'a, F, I>(chunks: I, config: &DedupConfig, diagnostics: &mut Vec<Diagnostic>) -> Vec<F>
+where
+    F: Fact + Clone + 'a,
+    I: Iterator<Item = &'a Vec<F>>,
+{
+    let mut merged: Vec<F> = Vec::new();
+    for items in chunks {
+        for item in items {
+            match merged
+                .iter()
+                .position(|existing| is_near_duplicate(existing.text(), item.text(), config))
+            {
+                Some(index) => {
+                    if !merged[index].text().eq_ignore_ascii_case(item.text()) {
+                        diagnostics.push(Diagnostic::ItemsMerged {
+                            category: F::CATEGORY,
+                            kept: merged[index].text().to_string(),
+                            merged: item.text().to_string(),
+                        });
+                    }
+                    let absorbed = item.clone();
+                    merged[index].absorb(absorbed, diagnostics);
+                }
+                None => merged.push(item.clone()),
+            }
+        }
+    }
+
+    // Meeting-scoped ids, assigned last so they number the consolidated set
+    // rather than whatever chunk each item happened to come from.
+    for (index, item) in merged.iter_mut().enumerate() {
+        item.set_id(format!("{}-{index}", F::CATEGORY));
+    }
+    merged
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ir::{ActionItem, ActionStatus, Decision, DecisionStatus};
+
+    fn chunk_ir(id: &str, action_items: Vec<ActionItem>, decisions: Vec<Decision>) -> ChunkIr {
+        ChunkIr {
+            chunk_id: id.into(),
+            segment_ids: Vec::new(),
+            facts: Facts {
+                action_items,
+                decisions,
+                ..Facts::default()
+            },
+        }
+    }
+
+    fn action(task: &str, owner: Option<&str>, evidence: &[&str]) -> ActionItem {
+        ActionItem {
+            id: String::new(),
+            task: task.into(),
+            owner: owner.map(str::to_string),
+            due: None,
+            status: ActionStatus::Open,
+            evidence: evidence.iter().map(|s| (*s).to_string()).collect(),
+        }
+    }
+
+    #[test]
+    fn three_phrasings_of_one_action_become_one_item_with_all_the_evidence() {
+        let chunk_irs = vec![
+            chunk_ir(
+                "chunk-0",
+                vec![action("Check Temporal signalling limit", None, &["s3"])],
+                Vec::new(),
+            ),
+            chunk_ir(
+                "chunk-1",
+                vec![action(
+                    "Confirm Temporal signalling capacity",
+                    None,
+                    &["s11"],
+                )],
+                Vec::new(),
+            ),
+            chunk_ir(
+                "chunk-2",
+                vec![action("Ask Temporal team about signalling", None, &["s20"])],
+                Vec::new(),
+            ),
+        ];
+
+        let (ir, diagnostics) =
+            consolidate(&chunk_irs, Meeting::default(), &DedupConfig::default());
+
+        assert_eq!(ir.facts.action_items.len(), 1);
+        let item = &ir.facts.action_items[0];
+        assert_eq!(item.task, "Check Temporal signalling limit");
+        assert_eq!(item.evidence, vec!["s3", "s11", "s20"]);
+        assert_eq!(item.id, "action_item-0");
+        assert_eq!(
+            diagnostics
+                .iter()
+                .filter(|d| matches!(d, Diagnostic::ItemsMerged { .. }))
+                .count(),
+            2
+        );
+    }
+
+    #[test]
+    fn unrelated_actions_stay_separate_and_are_numbered_in_transcript_order() {
+        let chunk_irs = vec![chunk_ir(
+            "chunk-0",
+            vec![
+                action("Check the Temporal signalling limit", None, &["s1"]),
+                action("Check the Kafka retention limit", None, &["s2"]),
+            ],
+            Vec::new(),
+        )];
+
+        let (ir, _) = consolidate(&chunk_irs, Meeting::default(), &DedupConfig::default());
+
+        assert_eq!(ir.facts.action_items.len(), 2);
+        assert_eq!(ir.facts.action_items[0].id, "action_item-0");
+        assert_eq!(ir.facts.action_items[1].id, "action_item-1");
+    }
+
+    #[test]
+    fn an_ownerless_action_stays_ownerless_through_consolidation() {
+        let chunk_irs = vec![
+            chunk_ir(
+                "chunk-0",
+                vec![action("Check Temporal signalling limit", None, &["s3"])],
+                Vec::new(),
+            ),
+            chunk_ir(
+                "chunk-1",
+                vec![action(
+                    "Confirm Temporal signalling capacity",
+                    None,
+                    &["s11"],
+                )],
+                Vec::new(),
+            ),
+        ];
+        let (ir, _) = consolidate(&chunk_irs, Meeting::default(), &DedupConfig::default());
+        assert_eq!(ir.facts.action_items[0].owner, None);
+    }
+
+    #[test]
+    fn a_decision_proposed_early_and_agreed_late_consolidates_as_agreed() {
+        let decision = |statement: &str, status, evidence: &str| Decision {
+            id: String::new(),
+            statement: statement.into(),
+            status,
+            evidence: vec![evidence.into()],
+        };
+        let chunk_irs = vec![
+            chunk_ir(
+                "chunk-0",
+                Vec::new(),
+                vec![decision(
+                    "move signalling onto the queue",
+                    DecisionStatus::Proposed,
+                    "s2",
+                )],
+            ),
+            chunk_ir(
+                "chunk-1",
+                Vec::new(),
+                vec![decision(
+                    "move signalling onto the queue",
+                    DecisionStatus::Agreed,
+                    "s30",
+                )],
+            ),
+        ];
+
+        let (ir, _) = consolidate(&chunk_irs, Meeting::default(), &DedupConfig::default());
+        assert_eq!(ir.facts.decisions.len(), 1);
+        assert_eq!(ir.facts.decisions[0].status, DecisionStatus::Agreed);
+        assert_eq!(ir.facts.decisions[0].evidence, vec!["s2", "s30"]);
+    }
+
+    #[test]
+    fn consolidation_is_deterministic() {
+        let chunk_irs = vec![
+            chunk_ir(
+                "chunk-0",
+                vec![action("Check Temporal signalling limit", None, &["s3"])],
+                Vec::new(),
+            ),
+            chunk_ir(
+                "chunk-1",
+                vec![action("Ask Temporal team about signalling", None, &["s11"])],
+                Vec::new(),
+            ),
+        ];
+        let first = consolidate(&chunk_irs, Meeting::default(), &DedupConfig::default());
+        let second = consolidate(&chunk_irs, Meeting::default(), &DedupConfig::default());
+        assert_eq!(first.0, second.0);
+        assert_eq!(first.1, second.1);
+    }
+
+    #[test]
+    fn the_consolidated_ir_stamps_the_schema_version() {
+        let (ir, _) = consolidate(&[], Meeting::default(), &DedupConfig::default());
+        assert_eq!(ir.schema_version, IR_SCHEMA_VERSION);
+        assert!(ir.facts.is_empty());
+    }
+}

--- a/rust/airo_mind_meeting/src/prompt.rs
+++ b/rust/airo_mind_meeting/src/prompt.rs
@@ -1,0 +1,87 @@
+//! The extraction prompt and its grammar, loaded from `prompts/extraction/`.
+//!
+//! # Why these are files, not string literals
+//!
+//! A prompt is part of what produced the IR (`ADR-0018 §5` records it with the
+//! content). It is also the thing most likely to be argued about in review, and
+//! a 60-line `format!` literal buried in a Rust function is neither reviewable
+//! nor diffable. `include_str!` keeps them compiled in — no runtime file I/O,
+//! no way to ship a binary whose prompt file went missing — while leaving them
+//! as plain text a reviewer can read on its own.
+//!
+//! # Versioning
+//!
+//! The version is in the **file name**, and [`PROMPT_VERSION`] names which file
+//! is current. Editing a prompt in place changes what every future extraction
+//! produces while claiming to be the same version, so a semantic change to the
+//! wording lands as `chunk_facts.v2.md` plus a bump here — the IR it produced
+//! records which one ran (`Meeting::prompt_version`).
+
+/// The current extraction prompt version, recorded in every `MeetingIr`.
+pub const PROMPT_VERSION: &str = "chunk_facts.v1";
+
+/// The Pass 1 prompt template. `{{SEGMENTS}}` is the only placeholder.
+const CHUNK_FACTS_TEMPLATE: &str = include_str!("../prompts/extraction/chunk_facts.v1.md");
+
+/// The GBNF grammar constraining Pass 1's output to a valid [`crate::ir::Facts`]
+/// object. Start symbol `root`, per `GenerationRequest::grammar`'s contract.
+pub const CHUNK_FACTS_GRAMMAR: &str = include_str!("../prompts/extraction/chunk_facts.v1.gbnf");
+
+/// The placeholder the rendered transcript replaces.
+const SEGMENTS_PLACEHOLDER: &str = "{{SEGMENTS}}";
+
+/// Renders the Pass 1 prompt for one chunk's segments.
+///
+/// `segments` is `(segment_id, text)` in transcript order. The ids are rendered
+/// as `[id]` labels because that is what rule 3 of the prompt tells the model to
+/// copy into `evidence` — the labels and the citation format are one decision,
+/// so they live next to each other.
+pub fn render_chunk_facts(segments: &[(&str, &str)]) -> String {
+    let mut rendered = String::new();
+    for (id, text) in segments {
+        rendered.push('[');
+        rendered.push_str(id);
+        rendered.push_str("] ");
+        rendered.push_str(text.trim());
+        rendered.push('\n');
+    }
+    CHUNK_FACTS_TEMPLATE.replace(SEGMENTS_PLACEHOLDER, rendered.trim_end())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn the_rendered_prompt_carries_every_segment_with_its_id() {
+        let prompt = render_chunk_facts(&[
+            ("s0", "we should check the Temporal signalling limit."),
+            ("s1", "Priya will own that."),
+        ]);
+        assert!(prompt.contains("[s0] we should check the Temporal signalling limit."));
+        assert!(prompt.contains("[s1] Priya will own that."));
+        assert!(!prompt.contains(SEGMENTS_PLACEHOLDER));
+    }
+
+    #[test]
+    fn the_prompt_forbids_summarising_inventing_and_guessed_owners() {
+        let prompt = render_chunk_facts(&[("s0", "anything")]);
+        assert!(prompt.contains("EXTRACT, NEVER SUMMARISE"));
+        assert!(prompt.contains("NEVER INVENT"));
+        assert!(prompt.contains("ALWAYS CITE"));
+        assert!(prompt.contains("OWNER IS NULL UNLESS NAMED"));
+    }
+
+    /// The whole point of storing the prompt as a file is that it can be
+    /// changed without touching Rust. This asserts the seam still exists.
+    #[test]
+    fn the_template_is_loaded_from_the_versioned_file_named_by_the_constant() {
+        assert!(CHUNK_FACTS_TEMPLATE.contains(SEGMENTS_PLACEHOLDER));
+        assert_eq!(PROMPT_VERSION, "chunk_facts.v1");
+    }
+
+    #[test]
+    fn the_grammar_declares_the_root_symbol_the_engine_expects() {
+        assert!(CHUNK_FACTS_GRAMMAR.contains("\nroot ::="));
+    }
+}

--- a/rust/airo_mind_meeting/tests/contracts.rs
+++ b/rust/airo_mind_meeting/tests/contracts.rs
@@ -1,0 +1,446 @@
+//! The two contracts this crate publishes to things it cannot compile against:
+//! the GBNF grammar (consumed by llama.cpp) and the JSON Schema (consumed by
+//! validators and by MIND-LLM-11's eval harness).
+//!
+//! Both are plain text files. Nothing in the Rust type system stops either one
+//! drifting from `ir.rs`, so the checks are here instead.
+
+use std::collections::BTreeSet;
+
+use airo_mind_meeting::ir::{
+    ActionItem, ActionStatus, Decision, DecisionStatus, Facts, Meeting, MeetingIr, Metric,
+    NextStep, Observation, Question, Risk, Topic,
+};
+use airo_mind_meeting::{CHUNK_FACTS_GRAMMAR, IR_SCHEMA_VERSION, PROMPT_VERSION};
+use serde_json::Value;
+
+// ---------------------------------------------------------------------------
+// GBNF
+// ---------------------------------------------------------------------------
+
+/// Splits a GBNF file into (rule name, right-hand side), ignoring `#` comments.
+///
+/// A rule's body continues onto following lines until the next `name ::=`, which
+/// is how `root` is written across several lines in the grammar file.
+fn rules(grammar: &str) -> Vec<(String, String)> {
+    let mut rules: Vec<(String, String)> = Vec::new();
+    for line in grammar.lines() {
+        let line = match line.split_once('#') {
+            Some((before, _)) => before,
+            None => line,
+        }
+        .trim_end();
+        if line.trim().is_empty() {
+            continue;
+        }
+        match line.split_once("::=") {
+            Some((name, body))
+                if !name.trim().is_empty() && !name.starts_with(char::is_whitespace) =>
+            {
+                rules.push((name.trim().to_string(), body.to_string()));
+            }
+            _ => {
+                if let Some(last) = rules.last_mut() {
+                    last.1.push(' ');
+                    last.1.push_str(line);
+                }
+            }
+        }
+    }
+    rules
+}
+
+/// Every rule name referenced in a right-hand side.
+///
+/// Skips quoted literals (`"\"topics\":"` contains no rule references) and
+/// character classes (`[a-fA-F]` is not a reference to a rule called `a`).
+fn references(body: &str) -> BTreeSet<String> {
+    let mut found = BTreeSet::new();
+    let chars: Vec<char> = body.chars().collect();
+    let mut i = 0;
+    while i < chars.len() {
+        match chars[i] {
+            '"' => {
+                i += 1;
+                while i < chars.len() && chars[i] != '"' {
+                    i += if chars[i] == '\\' { 2 } else { 1 };
+                }
+                i += 1;
+            }
+            '[' => {
+                i += 1;
+                while i < chars.len() && chars[i] != ']' {
+                    i += if chars[i] == '\\' { 2 } else { 1 };
+                }
+                i += 1;
+            }
+            c if c.is_ascii_alphabetic() => {
+                let start = i;
+                while i < chars.len() && (chars[i].is_ascii_alphanumeric() || chars[i] == '-') {
+                    i += 1;
+                }
+                found.insert(chars[start..i].iter().collect::<String>());
+            }
+            _ => i += 1,
+        }
+    }
+    found
+}
+
+#[test]
+fn the_grammar_defines_the_root_symbol_the_engine_looks_for() {
+    // `LlamaGenerationEngine` builds its sampler with the start symbol `root`
+    // (`GRAMMAR_ROOT` in `airo_mind_llama/src/llama.rs`). A grammar without one
+    // fails at generation time, on device, with a model already loaded.
+    let names: BTreeSet<String> = rules(CHUNK_FACTS_GRAMMAR)
+        .into_iter()
+        .map(|(name, _)| name)
+        .collect();
+    assert!(names.contains("root"), "defined rules: {names:?}");
+}
+
+#[test]
+fn every_rule_the_grammar_references_is_defined_and_every_rule_is_reachable() {
+    let rules = rules(CHUNK_FACTS_GRAMMAR);
+    let defined: BTreeSet<String> = rules.iter().map(|(name, _)| name.clone()).collect();
+    let referenced: BTreeSet<String> = rules
+        .iter()
+        .flat_map(|(_, body)| references(body))
+        .collect();
+
+    let undefined: Vec<&String> = referenced.difference(&defined).collect();
+    assert!(
+        undefined.is_empty(),
+        "referenced but never defined: {undefined:?}"
+    );
+
+    let unreachable: Vec<&String> = defined
+        .iter()
+        .filter(|name| name.as_str() != "root" && !referenced.contains(*name))
+        .collect();
+    assert!(
+        unreachable.is_empty(),
+        "defined but never used: {unreachable:?}"
+    );
+}
+
+#[test]
+fn the_grammar_names_every_category_the_ir_has() {
+    let root = rules(CHUNK_FACTS_GRAMMAR)
+        .into_iter()
+        .find(|(name, _)| name == "root")
+        .expect("root rule")
+        .1;
+    for category in [
+        "topics",
+        "observations",
+        "decisions",
+        "action_items",
+        "metrics",
+        "risks",
+        "questions",
+        "next_steps",
+    ] {
+        assert!(
+            root.contains(&format!("\\\"{category}\\\":")),
+            "`root` does not emit `{category}`"
+        );
+    }
+}
+
+#[test]
+fn the_grammar_makes_an_uncited_item_inexpressible() {
+    let evidence = rules(CHUNK_FACTS_GRAMMAR)
+        .into_iter()
+        .find(|(name, _)| name == "evidence")
+        .expect("evidence rule")
+        .1;
+    // `"[" ws string (…)* ws "]"` — one `string` is mandatory. An optional
+    // group (`(string …)?`) here would let the model emit `"evidence": []`,
+    // which is the one thing grounding exists to prevent.
+    assert!(
+        !evidence.contains("(string"),
+        "`evidence` must require at least one segment id, got: {evidence}"
+    );
+    assert!(evidence.contains("ws string"));
+}
+
+#[test]
+fn the_grammar_offers_no_id_field_for_the_model_to_invent() {
+    assert!(
+        !CHUNK_FACTS_GRAMMAR.contains("\\\"id\\\":"),
+        "item ids are assigned by this crate, never sampled"
+    );
+}
+
+#[test]
+fn the_grammars_statuses_are_exactly_the_ones_serde_accepts() {
+    let body = |name: &str| {
+        rules(CHUNK_FACTS_GRAMMAR)
+            .into_iter()
+            .find(|(rule, _)| rule == name)
+            .unwrap_or_else(|| panic!("`{name}` rule"))
+            .1
+    };
+
+    let decision = body("decision-status");
+    for status in [
+        DecisionStatus::Proposed,
+        DecisionStatus::Agreed,
+        DecisionStatus::Rejected,
+        DecisionStatus::Deferred,
+    ] {
+        let wire = serde_json::to_string(&status).unwrap();
+        assert!(
+            decision.contains(&wire.replace('"', "\\\"")),
+            "`decision-status` cannot produce {wire}"
+        );
+    }
+
+    let action = body("action-status");
+    for status in [
+        ActionStatus::Open,
+        ActionStatus::InProgress,
+        ActionStatus::Done,
+        ActionStatus::Blocked,
+    ] {
+        let wire = serde_json::to_string(&status).unwrap();
+        assert!(
+            action.contains(&wire.replace('"', "\\\"")),
+            "`action-status` cannot produce {wire}"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// JSON Schema
+// ---------------------------------------------------------------------------
+
+const SCHEMA: &str = include_str!("../schemas/meeting_ir.schema.json");
+
+fn schema() -> Value {
+    serde_json::from_str(SCHEMA).expect("the published schema is valid JSON")
+}
+
+/// One of every item, every optional field populated, so key-set comparison
+/// sees the full shape rather than whatever `#[serde(skip)]` might have hidden.
+fn fully_populated_ir() -> MeetingIr {
+    let evidence = || vec!["s0".to_string()];
+    MeetingIr {
+        schema_version: IR_SCHEMA_VERSION.to_string(),
+        meeting: Meeting {
+            id: "meeting-0".into(),
+            title: Some("Signaling capacity review".into()),
+            started_at_ms: 0,
+            ended_at_ms: 59_500,
+            chunk_count: 4,
+            segment_count: 12,
+            model_id: Some("model@1".into()),
+            prompt_version: PROMPT_VERSION.into(),
+        },
+        facts: Facts {
+            topics: vec![Topic {
+                id: "topic-0".into(),
+                title: "signalling".into(),
+                evidence: evidence(),
+            }],
+            observations: vec![Observation {
+                id: "observation-0".into(),
+                statement: "the workflow is at capacity".into(),
+                evidence: evidence(),
+            }],
+            decisions: vec![Decision {
+                id: "decision-0".into(),
+                statement: "move signalling onto the queue".into(),
+                status: DecisionStatus::Agreed,
+                evidence: evidence(),
+            }],
+            action_items: vec![ActionItem {
+                id: "action_item-0".into(),
+                task: "update the runbook".into(),
+                owner: Some("Dev".into()),
+                due: Some("Friday".into()),
+                status: ActionStatus::Done,
+                evidence: evidence(),
+            }],
+            metrics: vec![Metric {
+                id: "metric-0".into(),
+                name: "signals per day".into(),
+                value: "about 500,000".into(),
+                evidence: evidence(),
+            }],
+            risks: vec![Risk {
+                id: "risk-0".into(),
+                statement: "the migration doubles the event volume".into(),
+                evidence: evidence(),
+            }],
+            questions: vec![Question {
+                id: "question-0".into(),
+                question: "what is the documented limit?".into(),
+                answer: Some("nobody knew".into()),
+                evidence: evidence(),
+            }],
+            next_steps: vec![NextStep {
+                id: "next_step-0".into(),
+                statement: "review the rollout plan".into(),
+                evidence: evidence(),
+            }],
+        },
+    }
+}
+
+fn keys(value: &Value) -> BTreeSet<String> {
+    value.as_object().expect("object").keys().cloned().collect()
+}
+
+fn schema_keys(definition: &Value) -> BTreeSet<String> {
+    keys(&definition["properties"])
+}
+
+fn required(definition: &Value) -> BTreeSet<String> {
+    definition["required"]
+        .as_array()
+        .expect("required")
+        .iter()
+        .map(|v| v.as_str().expect("string").to_string())
+        .collect()
+}
+
+#[test]
+fn the_published_schema_declares_the_version_the_types_stamp() {
+    let schema = schema();
+    assert_eq!(
+        schema["$id"].as_str().unwrap(),
+        format!("https://airo.app/schemas/meeting_ir/{IR_SCHEMA_VERSION}")
+    );
+    assert_eq!(
+        schema["properties"]["schema_version"]["const"]
+            .as_str()
+            .unwrap(),
+        IR_SCHEMA_VERSION
+    );
+}
+
+#[test]
+fn the_schemas_top_level_matches_what_the_types_serialize() {
+    let schema = schema();
+    let serialized = serde_json::to_value(fully_populated_ir()).unwrap();
+
+    assert_eq!(
+        schema_keys(&schema),
+        keys(&serialized),
+        "schema properties and serialized keys disagree"
+    );
+    // Everything is required: `Facts`' categories serialize as `[]` rather than
+    // being omitted, so a document missing one is a document produced by
+    // something other than this crate.
+    assert_eq!(required(&schema), keys(&serialized));
+}
+
+#[test]
+fn every_item_type_matches_its_definition_in_the_schema() {
+    let schema = schema();
+    let serialized = serde_json::to_value(fully_populated_ir()).unwrap();
+
+    let cases = [
+        ("meeting", "meeting"),
+        ("topics", "topic"),
+        ("observations", "observation"),
+        ("decisions", "decision"),
+        ("action_items", "action_item"),
+        ("metrics", "metric"),
+        ("risks", "risk"),
+        ("questions", "question"),
+        ("next_steps", "next_step"),
+    ];
+
+    for (field, definition_name) in cases {
+        let definition = &schema["$defs"][definition_name];
+        assert!(
+            definition.is_object(),
+            "the schema has no `$defs/{definition_name}`"
+        );
+        let value = match &serialized[field] {
+            Value::Array(items) => items.first().expect("populated fixture").clone(),
+            object => object.clone(),
+        };
+        assert_eq!(
+            schema_keys(definition),
+            keys(&value),
+            "`{definition_name}` properties disagree with `{field}`"
+        );
+        assert_eq!(
+            required(definition),
+            keys(&value),
+            "`{definition_name}` required-set disagrees with `{field}`"
+        );
+    }
+}
+
+#[test]
+fn the_schema_refuses_fields_it_does_not_describe() {
+    let schema = schema();
+    assert_eq!(schema["additionalProperties"], Value::Bool(false));
+    for (name, definition) in schema["$defs"].as_object().unwrap() {
+        if definition.get("properties").is_some() {
+            assert_eq!(
+                definition["additionalProperties"],
+                Value::Bool(false),
+                "`$defs/{name}` would accept undescribed fields"
+            );
+        }
+    }
+}
+
+#[test]
+fn the_schema_requires_evidence_on_every_item() {
+    let schema = schema();
+    assert_eq!(schema["$defs"]["evidence"]["minItems"], Value::from(1));
+    for (name, definition) in schema["$defs"].as_object().unwrap() {
+        if name == "evidence" || name == "id" || name == "meeting" {
+            continue;
+        }
+        assert!(
+            required(definition).contains("evidence"),
+            "`$defs/{name}` does not require evidence"
+        );
+    }
+}
+
+#[test]
+fn the_golden_ir_fixture_validates_against_the_shape_the_schema_describes() {
+    // Not a full JSON Schema validation -- that would mean a new dependency for
+    // one assertion. This checks the part that actually drifts: that every
+    // object in the golden document carries exactly the keys the schema names.
+    let schema = schema();
+    let golden: Value = serde_json::from_str(include_str!("fixtures/golden_ir.json")).unwrap();
+
+    assert_eq!(keys(&golden), schema_keys(&schema));
+    assert_eq!(
+        keys(&golden["meeting"]),
+        schema_keys(&schema["$defs"]["meeting"])
+    );
+
+    for (field, definition_name) in [
+        ("topics", "topic"),
+        ("observations", "observation"),
+        ("decisions", "decision"),
+        ("action_items", "action_item"),
+        ("metrics", "metric"),
+        ("risks", "risk"),
+        ("questions", "question"),
+        ("next_steps", "next_step"),
+    ] {
+        for item in golden[field].as_array().unwrap() {
+            assert_eq!(
+                keys(item),
+                schema_keys(&schema["$defs"][definition_name]),
+                "golden `{field}` item does not match `$defs/{definition_name}`"
+            );
+            assert!(
+                !item["evidence"].as_array().unwrap().is_empty(),
+                "golden `{field}` item cites nothing"
+            );
+        }
+    }
+}

--- a/rust/airo_mind_meeting/tests/fixtures/golden_ir.json
+++ b/rust/airo_mind_meeting/tests/fixtures/golden_ir.json
@@ -1,0 +1,73 @@
+{
+  "schema_version": "1.0.0",
+  "meeting": {
+    "id": "meeting-1633-reference",
+    "title": "Signaling capacity review",
+    "started_at_ms": 0,
+    "ended_at_ms": 59500,
+    "chunk_count": 4,
+    "segment_count": 12,
+    "model_id": "model-under-test@0.0.0",
+    "prompt_version": "chunk_facts.v1"
+  },
+  "topics": [
+    { "id": "topic-0", "title": "Temporal signaling limit", "evidence": ["s0"] }
+  ],
+  "observations": [],
+  "decisions": [
+    {
+      "id": "decision-0",
+      "statement": "move signaling onto the queue before the release",
+      "status": "agreed",
+      "evidence": ["s4"]
+    }
+  ],
+  "action_items": [
+    {
+      "id": "action_item-0",
+      "task": "check the Temporal signaling limit",
+      "owner": null,
+      "due": "Friday",
+      "status": "open",
+      "evidence": ["s3", "s6", "s9"]
+    },
+    {
+      "id": "action_item-1",
+      "task": "update the runbook",
+      "owner": "Dev",
+      "due": "Friday",
+      "status": "done",
+      "evidence": ["s7", "s10"]
+    }
+  ],
+  "metrics": [
+    {
+      "id": "metric-0",
+      "name": "signals per day",
+      "value": "about 500,000",
+      "evidence": ["s1"]
+    }
+  ],
+  "risks": [
+    {
+      "id": "risk-0",
+      "statement": "the migration doubles the event volume",
+      "evidence": ["s8"]
+    }
+  ],
+  "questions": [
+    {
+      "id": "question-0",
+      "question": "What is the documented Temporal signaling limit?",
+      "answer": null,
+      "evidence": ["s2"]
+    }
+  ],
+  "next_steps": [
+    {
+      "id": "next_step-0",
+      "statement": "review the rollout plan",
+      "evidence": ["s11"]
+    }
+  ]
+}

--- a/rust/airo_mind_meeting/tests/fixtures/model_output/chunk-0.json
+++ b/rust/airo_mind_meeting/tests/fixtures/model_output/chunk-0.json
@@ -1,0 +1,20 @@
+{
+  "topics": [
+    { "title": "Temporal signaling limit", "evidence": ["s0"] }
+  ],
+  "observations": [],
+  "decisions": [
+    { "statement": "move signaling onto the queue before the release", "status": "agreed", "evidence": ["s4"] }
+  ],
+  "action_items": [
+    { "task": "check the Temporal signaling limit", "owner": null, "due": null, "status": "open", "evidence": ["s3"] }
+  ],
+  "metrics": [
+    { "name": "signals per day", "value": "about 500,000", "evidence": ["s1"] }
+  ],
+  "risks": [],
+  "questions": [
+    { "question": "What is the documented Temporal signaling limit?", "answer": null, "evidence": ["s2"] }
+  ],
+  "next_steps": []
+}

--- a/rust/airo_mind_meeting/tests/fixtures/model_output/chunk-1.json
+++ b/rust/airo_mind_meeting/tests/fixtures/model_output/chunk-1.json
@@ -1,0 +1,16 @@
+{
+  "topics": [],
+  "observations": [],
+  "decisions": [
+    { "statement": "move signaling onto the queue before the release", "status": "agreed", "evidence": ["s4"] }
+  ],
+  "action_items": [
+    { "task": "check the Temporal signaling limit", "owner": null, "due": null, "status": "open", "evidence": ["s3"] },
+    { "task": "confirm the Temporal signaling capacity", "owner": null, "due": "Friday", "status": "open", "evidence": ["s6"] },
+    { "task": "update the runbook", "owner": "Dev", "due": "Friday", "status": "open", "evidence": ["s7"] }
+  ],
+  "metrics": [],
+  "risks": [],
+  "questions": [],
+  "next_steps": []
+}

--- a/rust/airo_mind_meeting/tests/fixtures/model_output/chunk-2.json
+++ b/rust/airo_mind_meeting/tests/fixtures/model_output/chunk-2.json
@@ -1,0 +1,17 @@
+{
+  "topics": [],
+  "observations": [
+    { "statement": "the runbook update was finished off-camera", "evidence": ["s42"] }
+  ],
+  "decisions": [],
+  "action_items": [
+    { "task": "confirm the Temporal signaling capacity", "owner": null, "due": "Friday", "status": "open", "evidence": ["s6"] },
+    { "task": "update the runbook", "owner": "Dev", "due": "Friday", "status": "done", "evidence": ["s7", "s10"] }
+  ],
+  "metrics": [],
+  "risks": [
+    { "statement": "the migration doubles the event volume", "evidence": ["s8"] }
+  ],
+  "questions": [],
+  "next_steps": []
+}

--- a/rust/airo_mind_meeting/tests/fixtures/model_output/chunk-3.json
+++ b/rust/airo_mind_meeting/tests/fixtures/model_output/chunk-3.json
@@ -1,0 +1,14 @@
+{
+  "topics": [],
+  "observations": [],
+  "decisions": [],
+  "action_items": [
+    { "task": "ask the Temporal team about signaling", "owner": "Sameer", "due": null, "status": "open", "evidence": ["s9"] }
+  ],
+  "metrics": [],
+  "risks": [],
+  "questions": [],
+  "next_steps": [
+    { "statement": "review the rollout plan", "evidence": ["s11"] }
+  ]
+}

--- a/rust/airo_mind_meeting/tests/fixtures/reference_meeting.json
+++ b/rust/airo_mind_meeting/tests/fixtures/reference_meeting.json
@@ -1,0 +1,37 @@
+{
+  "_comment": [
+    "The reference meeting for #1633. Small, but it contains one instance of",
+    "every property the two passes have to get right:",
+    "",
+    "  * an action item nobody was put on the hook for (s2/s3) -- the null-owner",
+    "    case, which must survive both passes as null,",
+    "  * the same action said three different ways across three chunks",
+    "    (s3, s6, s9) -- the issue's own dedup example, verbatim,",
+    "  * an action item that does name an owner (s7) and whose status changes",
+    "    later in the meeting (s10),",
+    "  * a decision, a metric, a risk, an unanswered question and a next step,",
+    "  * segments that land inside two chunks at once (s3, s6, s9, s10), which",
+    "    is what makes the cross-chunk dedup real rather than staged.",
+    "",
+    "Timings are deliberate: 5s segments with a 500ms gap, so",
+    "ChunkConfig { min 20s, max 40s, overlap 10s } splits it into four",
+    "overlapping chunks. See tests/golden.rs.",
+    "",
+    "MIND-LLM-11's F1 harness is expected to grow this file rather than start a",
+    "new one."
+  ],
+  "segments": [
+    { "id": "s0",  "start_ms": 0,     "end_ms": 4500,  "text": "Right, let us start with the Temporal signalling limit." },
+    { "id": "s1",  "start_ms": 5000,  "end_ms": 9500,  "text": "Priya said the current workflow hits about 500,000 signals a day." },
+    { "id": "s2",  "start_ms": 10000, "end_ms": 14500, "text": "The documented limit is unclear, so we need to find out." },
+    { "id": "s3",  "start_ms": 15000, "end_ms": 19500, "text": "Someone should check the Temporal signalling limit." },
+    { "id": "s4",  "start_ms": 20000, "end_ms": 24500, "text": "We agreed to move signalling onto the queue before the release." },
+    { "id": "s5",  "start_ms": 25000, "end_ms": 29500, "text": "Alright, that is the first half done." },
+    { "id": "s6",  "start_ms": 30000, "end_ms": 34500, "text": "Can we confirm the Temporal signalling capacity before Friday?" },
+    { "id": "s7",  "start_ms": 35000, "end_ms": 39500, "text": "Dev will update the runbook by Friday." },
+    { "id": "s8",  "start_ms": 40000, "end_ms": 44500, "text": "There is a risk the migration doubles the event volume." },
+    { "id": "s9",  "start_ms": 45000, "end_ms": 49500, "text": "Let us ask the Temporal team about signalling." },
+    { "id": "s10", "start_ms": 50000, "end_ms": 54500, "text": "Dev confirmed the runbook update is done." },
+    { "id": "s11", "start_ms": 55000, "end_ms": 59500, "text": "Next we will review the rollout plan." }
+  ]
+}

--- a/rust/airo_mind_meeting/tests/golden.rs
+++ b/rust/airo_mind_meeting/tests/golden.rs
@@ -1,0 +1,627 @@
+//! End-to-end: a reference meeting transcript through both passes, against a
+//! golden IR. `#1633`.
+//!
+//! # Why a scripted engine and not a real model
+//!
+//! The engine below returns fixed JSON from `tests/fixtures/model_output/`. That
+//! makes this a test of the **pipeline** — grounding, owner erasure, retry,
+//! consolidation, dedup, id assignment, provenance — all of which are this
+//! crate's own logic and all of which must be exactly reproducible. Whether a
+//! 3B model actually extracts these facts from this transcript is a different
+//! question, measured by F1 against the same fixtures in MIND-LLM-11; putting a
+//! real model here would make a dedup regression indistinguishable from the
+//! model having a bad day.
+//!
+//! The fixtures are written the way a model behaving badly would write them:
+//! overlapping chunks restate the same facts in different words, one item cites
+//! a segment that is not in its chunk, and one names an owner nobody in the
+//! meeting mentioned. All three are things extraction has to survive.
+
+use std::collections::BTreeMap;
+use std::sync::Mutex;
+
+use airo_mind_core::{
+    CancelToken, EngineError, GenerationChunk, GenerationEngine, GenerationRequest,
+    ResourceRequest, RuntimeStats,
+};
+use airo_mind_meeting::{
+    consolidate, extract, DedupConfig, Diagnostic, ExtractionConfig, ExtractionError, Meeting,
+    MeetingInput, MeetingIr,
+};
+use airo_mind_transcript::{ChunkConfig, ProcessedTranscript, Segment};
+use serde::Deserialize;
+
+// ---------------------------------------------------------------------------
+// The reference transcript
+// ---------------------------------------------------------------------------
+
+#[derive(Deserialize)]
+struct RefSegment {
+    id: String,
+    start_ms: u64,
+    end_ms: u64,
+    text: String,
+}
+
+#[derive(Deserialize)]
+struct RefMeeting {
+    segments: Vec<RefSegment>,
+}
+
+/// 20s–40s chunks with a 10s overlap. Real meetings use 5–10 minutes
+/// (`ChunkConfig::default`); the reference transcript is a minute long, and
+/// scaling the window down is what gives it the same *shape* — four chunks,
+/// each overlapping its neighbour — at a size a reviewer can read in full.
+fn reference_chunk_config() -> ChunkConfig {
+    ChunkConfig {
+        min_len_ms: 20_000,
+        max_len_ms: 40_000,
+        overlap_ms: 10_000,
+        pause_gap_ms: 500,
+    }
+}
+
+fn reference_transcript() -> ProcessedTranscript {
+    let meeting: RefMeeting =
+        serde_json::from_str(include_str!("fixtures/reference_meeting.json")).unwrap();
+    let segments: Vec<Segment> = meeting
+        .segments
+        .into_iter()
+        .map(|s| Segment {
+            id: s.id,
+            start_ms: s.start_ms,
+            end_ms: s.end_ms,
+            text: s.text,
+        })
+        .collect();
+    airo_mind_transcript::process(&segments, &reference_chunk_config())
+}
+
+fn reference_meeting_input() -> MeetingInput {
+    MeetingInput {
+        id: "meeting-1633-reference".into(),
+        title: Some("Signaling capacity review".into()),
+        model_id: Some("model-under-test@0.0.0".into()),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// The scripted engine
+// ---------------------------------------------------------------------------
+
+/// A `GenerationEngine` that answers from a script keyed by the first segment
+/// id in the prompt.
+///
+/// Keyed rather than call-ordered so a change to the chunker surfaces as an
+/// unmatched key ("no script for s6") instead of quietly shifting every
+/// response one chunk to the left. Each key holds a queue, which is how the
+/// retry path is scripted: the first entry is what the model returns on attempt
+/// one, the next on attempt two.
+struct ScriptedEngine {
+    script: Mutex<BTreeMap<String, Vec<String>>>,
+    /// Every prompt it was given, so a test can assert on what the model was
+    /// actually asked.
+    prompts: Mutex<Vec<String>>,
+}
+
+impl ScriptedEngine {
+    fn new(script: &[(&str, &[&str])]) -> Self {
+        Self {
+            script: Mutex::new(
+                script
+                    .iter()
+                    .map(|(key, responses)| {
+                        (
+                            (*key).to_string(),
+                            responses.iter().map(|r| (*r).to_string()).collect(),
+                        )
+                    })
+                    .collect(),
+            ),
+            prompts: Mutex::new(Vec::new()),
+        }
+    }
+
+    /// The four reference chunks, each answering with the fixture named after
+    /// it. Keys are the first segment of each chunk: `chunk-0` starts at `s0`,
+    /// `chunk-1` at `s3`, `chunk-2` at `s6`, `chunk-3` at `s9`.
+    fn reference() -> Self {
+        Self::new(&[
+            ("s0", &[include_str!("fixtures/model_output/chunk-0.json")]),
+            ("s3", &[include_str!("fixtures/model_output/chunk-1.json")]),
+            ("s6", &[include_str!("fixtures/model_output/chunk-2.json")]),
+            ("s9", &[include_str!("fixtures/model_output/chunk-3.json")]),
+        ])
+    }
+
+    fn prompts(&self) -> Vec<String> {
+        self.prompts.lock().unwrap().clone()
+    }
+}
+
+/// The `[sN]` label of the first segment shown in a prompt.
+fn first_segment_id(prompt: &str) -> String {
+    let start = prompt.find("\n[").expect("prompt has no segment labels") + 2;
+    let end = start + prompt[start..].find(']').expect("unterminated label");
+    prompt[start..end].to_string()
+}
+
+impl GenerationEngine for ScriptedEngine {
+    fn resource_request(&self) -> ResourceRequest {
+        ResourceRequest::new(0)
+    }
+
+    fn generate(
+        &self,
+        request: &GenerationRequest,
+        cancel: &CancelToken,
+        sink: &mut dyn FnMut(GenerationChunk) -> Result<(), EngineError>,
+    ) -> Result<(), EngineError> {
+        if cancel.is_cancelled() {
+            return Err(EngineError::Cancelled);
+        }
+        assert!(
+            request.grammar.is_some(),
+            "extraction must always constrain the sampler with a grammar"
+        );
+        self.prompts.lock().unwrap().push(request.prompt.clone());
+
+        let key = first_segment_id(&request.prompt);
+        let mut script = self.script.lock().unwrap();
+        let queue = script
+            .get_mut(&key)
+            .unwrap_or_else(|| panic!("no scripted response for a chunk starting at `{key}`"));
+        let response = if queue.len() > 1 {
+            queue.remove(0)
+        } else {
+            queue
+                .first()
+                .unwrap_or_else(|| panic!("script for `{key}` is exhausted"))
+                .clone()
+        };
+        drop(script);
+
+        // Streamed a few characters at a time, so the collector in Pass 1 is
+        // exercised the way a real token stream would exercise it rather than
+        // handed one whole string.
+        for piece in response.as_bytes().chunks(7) {
+            sink(GenerationChunk {
+                text: String::from_utf8_lossy(piece).into_owned(),
+            })?;
+        }
+        Ok(())
+    }
+
+    fn stats(&self) -> RuntimeStats {
+        RuntimeStats::default()
+    }
+}
+
+/// An engine that always fails, to prove a broken backend is an error rather
+/// than an empty IR that looks like a meeting where nothing was said.
+struct BrokenEngine;
+
+impl GenerationEngine for BrokenEngine {
+    fn resource_request(&self) -> ResourceRequest {
+        ResourceRequest::new(0)
+    }
+    fn generate(
+        &self,
+        _request: &GenerationRequest,
+        _cancel: &CancelToken,
+        _sink: &mut dyn FnMut(GenerationChunk) -> Result<(), EngineError>,
+    ) -> Result<(), EngineError> {
+        Err(EngineError::ModelUnavailable)
+    }
+    fn stats(&self) -> RuntimeStats {
+        RuntimeStats::default()
+    }
+}
+
+fn run_reference(engine: &dyn GenerationEngine) -> airo_mind_meeting::Extraction {
+    extract(
+        engine,
+        &reference_transcript(),
+        &reference_meeting_input(),
+        &ExtractionConfig::default(),
+        &CancelToken::new(),
+    )
+    .expect("reference extraction should succeed")
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+/// The whole point of the fixture: four chunks, each overlapping the next, so
+/// the dedup cases below are cross-chunk rather than staged inside one.
+#[test]
+fn the_reference_transcript_chunks_into_four_overlapping_windows() {
+    let transcript = reference_transcript();
+    let ids: Vec<Vec<&str>> = transcript
+        .chunks
+        .iter()
+        .map(|c| c.segment_ids.iter().map(String::as_str).collect())
+        .collect();
+    assert_eq!(
+        ids,
+        vec![
+            vec!["s0", "s1", "s2", "s3", "s4"],
+            vec!["s3", "s4", "s5", "s6", "s7"],
+            vec!["s6", "s7", "s8", "s9", "s10"],
+            vec!["s9", "s10", "s11"],
+        ]
+    );
+}
+
+#[test]
+fn the_reference_meeting_produces_the_golden_ir() {
+    let extraction = run_reference(&ScriptedEngine::reference());
+    let golden: MeetingIr =
+        serde_json::from_str(include_str!("fixtures/golden_ir.json")).expect("golden IR parses");
+
+    // Compared as JSON, not as Rust values: the assertion is about the document
+    // the rest of the milestone consumes, and a `Value` diff is readable.
+    assert_eq!(
+        serde_json::to_value(&extraction.ir).unwrap(),
+        serde_json::to_value(&golden).unwrap()
+    );
+}
+
+/// The acceptance criterion, on its own, with the reason it holds spelled out:
+/// nobody was named in s2/s3, one chunk's model output invented "Sameer", and
+/// the consolidated item is still `null`.
+#[test]
+fn an_action_item_the_meeting_never_assigned_stays_ownerless() {
+    let extraction = run_reference(&ScriptedEngine::reference());
+
+    let unassigned = extraction
+        .ir
+        .facts
+        .action_items
+        .iter()
+        .find(|a| a.task.contains("signaling limit"))
+        .expect("the signalling action survived consolidation");
+    assert_eq!(
+        unassigned.owner, None,
+        "an ownerless action item must never acquire an owner"
+    );
+
+    assert!(
+        extraction
+            .diagnostics
+            .contains(&Diagnostic::OwnerNotInTranscript {
+                chunk_id: "chunk-3".into(),
+                task: "ask the Temporal team about signaling".into(),
+                owner: "Sameer".into(),
+            }),
+        "the invented owner should have been erased and reported: {:#?}",
+        extraction.diagnostics
+    );
+
+    // ...while an owner the transcript *does* name survives untouched.
+    let runbook = extraction
+        .ir
+        .facts
+        .action_items
+        .iter()
+        .find(|a| a.task.contains("runbook"))
+        .expect("the runbook action survived consolidation");
+    assert_eq!(runbook.owner.as_deref(), Some("Dev"));
+}
+
+/// The issue's worked example, running across three real chunks.
+#[test]
+fn three_phrasings_across_three_chunks_consolidate_into_one_action_item() {
+    let extraction = run_reference(&ScriptedEngine::reference());
+
+    let phrasings: Vec<&str> = extraction
+        .chunk_irs
+        .iter()
+        .flat_map(|c| c.facts.action_items.iter())
+        .map(|a| a.task.as_str())
+        .filter(|task| task.contains("signaling") || task.contains("signalling"))
+        .collect();
+    assert_eq!(
+        phrasings,
+        vec![
+            "check the Temporal signaling limit",
+            "check the Temporal signaling limit",
+            "confirm the Temporal signaling capacity",
+            "confirm the Temporal signaling capacity",
+            "ask the Temporal team about signaling",
+        ],
+        "Pass 1 should extract every phrasing as it was said"
+    );
+
+    let consolidated: Vec<&str> = extraction
+        .ir
+        .facts
+        .action_items
+        .iter()
+        .map(|a| a.task.as_str())
+        .filter(|task| task.contains("signaling"))
+        .collect();
+    assert_eq!(
+        consolidated,
+        vec!["check the Temporal signaling limit"],
+        "Pass 2 should collapse them to one"
+    );
+
+    // Every segment that contributed is still cited, in transcript order.
+    assert_eq!(
+        extraction.ir.facts.action_items[0].evidence,
+        vec!["s3", "s6", "s9"]
+    );
+}
+
+#[test]
+fn an_item_citing_a_segment_outside_its_chunk_never_reaches_the_ir() {
+    let extraction = run_reference(&ScriptedEngine::reference());
+
+    assert!(
+        extraction.ir.facts.observations.is_empty(),
+        "the only observation in the fixtures cites `s42`, which is in no chunk"
+    );
+    assert!(extraction.diagnostics.iter().any(|d| matches!(
+        d,
+        Diagnostic::UnknownEvidenceDropped { segment_id, .. } if segment_id == "s42"
+    )));
+    assert!(extraction.diagnostics.iter().any(|d| matches!(
+        d,
+        Diagnostic::UngroundedItemDropped {
+            category: "observation",
+            ..
+        }
+    )));
+}
+
+#[test]
+fn every_item_in_the_ir_cites_a_segment_the_transcript_actually_has() {
+    let transcript = reference_transcript();
+    let known: Vec<&str> = transcript.segments.iter().map(|s| s.id.as_str()).collect();
+    let extraction = run_reference(&ScriptedEngine::reference());
+    let facts = &extraction.ir.facts;
+
+    let mut cited: Vec<(&str, &[String])> = Vec::new();
+    cited.extend(
+        facts
+            .topics
+            .iter()
+            .map(|i| (i.id.as_str(), &i.evidence[..])),
+    );
+    cited.extend(
+        facts
+            .observations
+            .iter()
+            .map(|i| (i.id.as_str(), &i.evidence[..])),
+    );
+    cited.extend(
+        facts
+            .decisions
+            .iter()
+            .map(|i| (i.id.as_str(), &i.evidence[..])),
+    );
+    cited.extend(
+        facts
+            .action_items
+            .iter()
+            .map(|i| (i.id.as_str(), &i.evidence[..])),
+    );
+    cited.extend(
+        facts
+            .metrics
+            .iter()
+            .map(|i| (i.id.as_str(), &i.evidence[..])),
+    );
+    cited.extend(facts.risks.iter().map(|i| (i.id.as_str(), &i.evidence[..])));
+    cited.extend(
+        facts
+            .questions
+            .iter()
+            .map(|i| (i.id.as_str(), &i.evidence[..])),
+    );
+    cited.extend(
+        facts
+            .next_steps
+            .iter()
+            .map(|i| (i.id.as_str(), &i.evidence[..])),
+    );
+
+    assert!(!cited.is_empty());
+    for (id, evidence) in cited {
+        assert!(!evidence.is_empty(), "`{id}` cites nothing");
+        for segment in evidence {
+            assert!(
+                known.contains(&segment.as_str()),
+                "`{id}` cites `{segment}`, which is not in the transcript"
+            );
+        }
+    }
+}
+
+/// Truncated output is the realistic grammar-era failure: the sampler cannot
+/// emit an invalid object, but it can be stopped mid-object by the token
+/// ceiling. That retries, and the retry's result is what lands in the IR.
+#[test]
+fn a_chunk_whose_first_attempt_is_truncated_is_retried_and_succeeds() {
+    let truncated = "{\"topics\":[{\"title\":\"Temporal signaling li";
+    let engine = ScriptedEngine::new(&[
+        (
+            "s0",
+            &[
+                truncated,
+                include_str!("fixtures/model_output/chunk-0.json"),
+            ],
+        ),
+        ("s3", &[include_str!("fixtures/model_output/chunk-1.json")]),
+        ("s6", &[include_str!("fixtures/model_output/chunk-2.json")]),
+        ("s9", &[include_str!("fixtures/model_output/chunk-3.json")]),
+    ]);
+
+    let extraction = run_reference(&engine);
+
+    assert!(extraction.diagnostics.iter().any(|d| matches!(
+        d,
+        Diagnostic::UnparseableOutput { chunk_id, attempt: 1, .. } if chunk_id == "chunk-0"
+    )));
+    let golden: MeetingIr = serde_json::from_str(include_str!("fixtures/golden_ir.json")).unwrap();
+    assert_eq!(
+        serde_json::to_value(&extraction.ir).unwrap(),
+        serde_json::to_value(&golden).unwrap(),
+        "a retried chunk should land on exactly the same IR"
+    );
+}
+
+/// The bound in "bounded retries": a chunk that never parses is abandoned after
+/// `max_attempts`, and the rest of the meeting still extracts.
+#[test]
+fn a_chunk_that_never_parses_is_abandoned_after_a_fixed_number_of_attempts() {
+    let junk = "{\"topics\":[{\"title\":";
+    let engine = ScriptedEngine::new(&[
+        ("s0", &[junk]),
+        ("s3", &[include_str!("fixtures/model_output/chunk-1.json")]),
+        ("s6", &[include_str!("fixtures/model_output/chunk-2.json")]),
+        ("s9", &[include_str!("fixtures/model_output/chunk-3.json")]),
+    ]);
+
+    let extraction = run_reference(&engine);
+
+    assert_eq!(
+        extraction
+            .diagnostics
+            .iter()
+            .filter(|d| matches!(
+                d,
+                Diagnostic::UnparseableOutput { chunk_id, .. } if chunk_id == "chunk-0"
+            ))
+            .count(),
+        ExtractionConfig::default().max_attempts as usize
+    );
+    assert!(extraction
+        .diagnostics
+        .contains(&Diagnostic::ChunkAbandoned {
+            chunk_id: "chunk-0".into(),
+            attempts: ExtractionConfig::default().max_attempts,
+        }));
+
+    // Chunk 0 contributed nothing, so the metric and the question that only it
+    // saw are gone -- but the rest of the meeting is intact.
+    assert!(extraction.ir.facts.metrics.is_empty());
+    assert!(extraction.ir.facts.questions.is_empty());
+    assert_eq!(extraction.ir.facts.action_items.len(), 2);
+    assert_eq!(extraction.ir.facts.decisions.len(), 1);
+}
+
+#[test]
+fn a_broken_backend_is_an_error_not_an_empty_meeting() {
+    let result = extract(
+        &BrokenEngine,
+        &reference_transcript(),
+        &reference_meeting_input(),
+        &ExtractionConfig::default(),
+        &CancelToken::new(),
+    );
+    assert_eq!(
+        result,
+        Err(ExtractionError::Engine(
+            EngineError::ModelUnavailable.to_string()
+        ))
+    );
+}
+
+#[test]
+fn a_cancelled_run_yields_nothing_rather_than_a_partial_ir() {
+    let cancel = CancelToken::new();
+    cancel.cancel();
+    let result = extract(
+        &ScriptedEngine::reference(),
+        &reference_transcript(),
+        &reference_meeting_input(),
+        &ExtractionConfig::default(),
+        &cancel,
+    );
+    assert_eq!(result, Err(ExtractionError::Cancelled));
+}
+
+#[test]
+fn a_transcript_with_nothing_in_it_is_an_empty_ir_not_an_error() {
+    let empty = airo_mind_transcript::process(&[], &reference_chunk_config());
+    let extraction = extract(
+        &ScriptedEngine::reference(),
+        &empty,
+        &reference_meeting_input(),
+        &ExtractionConfig::default(),
+        &CancelToken::new(),
+    )
+    .expect("silence is a legitimate meeting");
+    assert!(extraction.ir.facts.is_empty());
+    assert_eq!(extraction.ir.meeting.chunk_count, 0);
+}
+
+/// `ADR-0018 §5`: the IR records what produced it.
+#[test]
+fn the_ir_records_the_model_and_prompt_version_that_produced_it() {
+    let extraction = run_reference(&ScriptedEngine::reference());
+    assert_eq!(
+        extraction.ir.meeting.model_id.as_deref(),
+        Some("model-under-test@0.0.0")
+    );
+    assert_eq!(
+        extraction.ir.meeting.prompt_version,
+        airo_mind_meeting::PROMPT_VERSION
+    );
+    assert_eq!(
+        extraction.ir.schema_version,
+        airo_mind_meeting::IR_SCHEMA_VERSION
+    );
+}
+
+/// The model must never be handed the whole meeting — that is the one shape
+/// this milestone forbids, and it is checkable directly on the prompts.
+#[test]
+fn no_prompt_ever_contains_the_whole_transcript() {
+    let engine = ScriptedEngine::reference();
+    run_reference(&engine);
+
+    let transcript = reference_transcript();
+    let prompts = engine.prompts();
+    assert_eq!(prompts.len(), transcript.chunks.len());
+    for prompt in &prompts {
+        assert!(
+            !prompt.contains(&transcript.normalized),
+            "a prompt carried the entire transcript"
+        );
+        assert!(prompt.contains("EXTRACT, NEVER SUMMARISE"));
+    }
+}
+
+#[test]
+fn the_same_transcript_and_the_same_script_produce_the_same_ir_every_time() {
+    let first = run_reference(&ScriptedEngine::reference());
+    let second = run_reference(&ScriptedEngine::reference());
+    assert_eq!(first.ir, second.ir);
+    assert_eq!(first.chunk_irs, second.chunk_irs);
+    assert_eq!(first.diagnostics, second.diagnostics);
+}
+
+/// Pass 2 is usable on its own — an eval harness scores the passes separately.
+#[test]
+fn consolidation_can_be_run_on_pass_one_output_alone() {
+    let extraction = run_reference(&ScriptedEngine::reference());
+    let (ir, _) = consolidate(
+        &extraction.chunk_irs,
+        Meeting {
+            id: "meeting-1633-reference".into(),
+            title: Some("Signaling capacity review".into()),
+            started_at_ms: 0,
+            ended_at_ms: 59_500,
+            chunk_count: 4,
+            segment_count: 12,
+            model_id: Some("model-under-test@0.0.0".into()),
+            prompt_version: airo_mind_meeting::PROMPT_VERSION.into(),
+        },
+        &DedupConfig::default(),
+    );
+    assert_eq!(ir, extraction.ir);
+}


### PR DESCRIPTION
Closes #1633. Part of epic #1627 (Milestone 26, Phase 2 / Wave 2).

The LLM never summarises the transcript. Pass 1 extracts atomic facts from one
chunk at a time, each citing the segment ids it came from; Pass 2 consolidates
those facts. Neither pass produces prose. MoM, action-item lists and meeting
search are projections of this IR, built elsewhere.

## Acceptance criteria

- [x] **IR schema versioned + serde types in Rust; JSON Schema published for
      validator + evals** — `src/ir.rs` (`IR_SCHEMA_VERSION = "1.0.0"`) and
      `schemas/meeting_ir.schema.json`. `tests/contracts.rs` asserts the two
      cannot drift: same `$id` version, same key sets, same required sets, same
      `additionalProperties: false` posture, evidence required everywhere.
- [x] **Pass 1 output always schema-valid (grammar-constrained; retry on
      violation)** — every request carries
      `prompts/extraction/chunk_facts.v1.gbnf` as `GenerationRequest::grammar`
      (start symbol `root`, per that field's contract from #1728). Bounded
      retries (`max_attempts`, default 3) cover the one failure the grammar
      cannot prevent — output truncated at `max_output_tokens`. A chunk that
      never parses is abandoned with a diagnostic; the rest of the meeting
      still extracts.
- [x] **Pass 2 dedupes near-duplicate decisions/actions across chunks** — the
      issue's own example is a test, running across three real chunks of the
      reference transcript.
- [x] **Owner field null when transcript names no owner — never guessed** —
      enforced mechanically, not just asked for in the prompt: Pass 1 erases
      any owner whose name does not appear as a whole word in the chunk it was
      extracted from. The golden fixtures deliberately hallucinate an owner
      ("Sameer") in chunk 3; the consolidated action item is still `null`.
- [x] **Prompts stored in-repo, versioned** —
      `prompts/extraction/chunk_facts.v1.{md,gbnf}`, `include_str!`d, version in
      the file name and recorded in the IR as `Meeting::prompt_version`.

## Decisions worth reviewing

**New crate `rust/airo_mind_meeting`, not an extension of `airo_mind_llama`.**
This is the *capability* above the runtime's engine boundary. `C5` keeps meeting
vocabulary out of `airo_mind_core`/`airo_mind_llama` — `llama.rs` says so in its
own header — so the prompt, grammar, IR and the word "meeting" belong on this
side of the line. Named `airo_mind_meeting` rather than `airo_mind_llm` for the
same reason: `_llm` would read as a runtime/engine layer, which is exactly what
this is not. It takes a `&dyn GenerationEngine`, so it depends on
`airo_mind_core` (trait) and `airo_mind_transcript` (`Chunk`) but **not** on
`airo_mind_llama` — no cmake, no vendored ggml, no model needed to run its
tests. Real engine and test double are the same shape to it.

**Evidence is segment ids, no snippets.** The issue allows "optionally short
snippets; privacy-aware". Omitted on purpose: a snippet copies `secret`-class
transcript text into every projection, export and index that touches the IR,
while an id is a pointer the holder of the transcript resolves under that
transcript's own rules. Grounding is unaffected — the id is what makes a claim
checkable.

**Dedup is a heuristic, not a second LLM call.** Checked for a cheaper primitive
first, as required: nothing in `rust/` produces embeddings (`airo_core`'s
"dedup" is `normalize_channel_name`), and `core_ai`'s `EmbeddingService` is Dart
above the FFI boundary — calling up into it would invert the dependency and put
a network-capable client on a local-first path. A second LLM pass would cost an
O(n²) pair set on a device budgeted for one generation and would make
consolidation non-deterministic, which would leave the F1 gates unable to
distinguish a regression from sampling noise. So: Jaccard similarity over
stopword-stripped, lightly stemmed tokens with a small documented synonym
lexicon, plus a guard that two items must share a non-synonym *domain* token
before merging. Threshold `0.5`, with the issue's example scoring 0.75–1.0 and
the near-miss guard ("Check the Kafka retention limit") scoring 0.33 — real room
on both sides. **This is a first cut written to be tuned from outside**;
MIND-LLM-11 is where the threshold and lexicon get measured against real
meetings.

**Item ids are assigned by this crate, never sampled.** The grammar does not
offer an `id` field at all, so a model cannot collide with or forge another
item's identity.

**Status resolution across chunks** is not "last wins": a resolved status beats
`proposed`/`open`, and among resolved statuses the later mention wins. Plain
last-wins would demote a decision agreed in chunk 1 back to `proposed` when
chunk 4 recaps it.

## Verification

`cargo test -p airo_mind_meeting` — 61 tests.

The golden test drives a scripted engine over a hand-crafted reference
transcript (`tests/fixtures/reference_meeting.json`, 12 segments → 4
overlapping chunks) and compares the output to `tests/fixtures/golden_ir.json`.
The scripted model output is written the way a badly-behaved model would write
it: overlapping chunks restate facts in different words, one item cites a
segment that is not in its chunk, one invents an owner. Covered:

- the null-owner case survives both passes,
- three phrasings across three chunks collapse to one action item with all
  three segments cited, in transcript order,
- an item citing `s42` never reaches the IR,
- a truncated first attempt retries and lands on the identical IR,
- a chunk that never parses is abandoned after exactly `max_attempts`,
- a broken backend is an error, not an empty meeting that looks like silence,
- no prompt ever contains the whole transcript,
- the same input produces the same IR every time.

Fixtures are deliberately shaped to be grown by MIND-LLM-11 rather than
replaced.

Narrow CI run locally: `cargo fmt --check`, `cargo clippy -p airo_mind_meeting
--all-targets -- -D warnings`, `cargo test -p airo_mind_meeting`,
`cargo check --workspace`, plus the exact `--all` commands `rust-core.yml` runs.
No workflow change needed — the workspace jobs use `--all` and pick the new
member up.

## Out of scope

No Track A work. Persisting a `MeetingIr` into the operation log is #1657;
projections (MoM, action items, search) are #1634+. This crate writes nothing
and has no FFI surface.

## Review requested

- **chief-qa-officer** — evidence-grounding and F1-gate territory: whether the
  golden fixtures cover the right failure modes, and whether the mechanical
  owner/evidence checks are the right guarantees to be making here.
- **chief-architect** — new crate placement and name, the capability/runtime
  boundary it claims, and the IR + JSON Schema shape that #1634+ and #1657 will
  build on.
- **chief-open-source-officer** (light) — `serde`/`serde_json` only, both
  already in the workspace lockfile; no new tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
