### PR TITLE
feat(mind): Runtime v1 follow-up — capability API, purge/destroy, type system, conformance gates (#1295/#1217/#1223/#1287/#1294)

### DIFF
--- a/.github/workflows/rust-core.yml
+++ b/.github/workflows/rust-core.yml
@@ -47,6 +47,36 @@ jobs:
       # which reads like a broken checkout rather than a missing flag.
       - run: cargo fmt --manifest-path rust/Cargo.toml --all --check
 
+      # Runtime v1 condition 9 (#1311, tracked on #1340): "every runtime
+      # contract has automated conformance tests." `cargo test --all` above
+      # already runs these as ordinary tests -- this step is the mechanical
+      # gate on top of that: it *discovers* every `tests/*conformance*.rs`
+      # file in the workspace structurally (so a new one lands covered
+      # without editing this workflow) and reports which of the spec's S1-S5
+      # suites currently have a tagged test, so a suite silently having zero
+      # coverage is a build artifact a human can see, not something only a
+      # council review would catch. See
+      # docs/superpowers/specs/2026-07-28-airo-mind-conformance-suite.md.
+      - name: Airo Mind runtime conformance suite (#1311 condition 9)
+        run: scripts/run-mind-conformance-suite.sh
+
+      # Condition 10 (#1311): "every performance contract has benchmark gates
+      # in CI." `benchmark_gate_conformance.rs` (discovered and run above as
+      # part of the conformance suite, since its filename matches
+      # `*conformance*.rs`) asserts operation-log append and projection
+      # rebuild cost scale linearly, not worse, with input size -- a
+      # relative, scale-invariant claim chosen specifically because it is
+      # reliable on a shared runner, unlike an absolute wall-clock budget.
+      # This step exists only to name the gate explicitly in the job log; the
+      # test itself already ran and already failed the step above if it
+      # regressed.
+      - name: Benchmark gate — scaling regression check (#1311 condition 10)
+        run: |
+          echo "Verified above by scripts/run-mind-conformance-suite.sh:"
+          echo "  operation_log_append_scales_linearly_not_worse"
+          echo "  projection_rebuild_from_scratch_scales_linearly_not_worse"
+          echo "See rust/airo_mind_core/tests/benchmark_gate_conformance.rs for the threshold and why it is ratio-based rather than absolute."
+
   # ── Android cross-compile ──────────────────────────────────────────────────
   build-android:
     name: Android (${{ matrix.target }})

--- a/rust/airo_mind_core/src/capability_api.rs
+++ b/rust/airo_mind_core/src/capability_api.rs
@@ -319,6 +319,40 @@ impl<'a> CapabilityApi<'a> {
         });
     }
 
+    /// Physically and durably destroys a piece of content — condition 8 of
+    /// `#1311` (`#1217`). Deliberately **not** one of `#1295`'s original five
+    /// functions: [`Self::create_operation`] alone cannot honestly implement
+    /// this (see [`Runtime::destroy_content`]'s doc for why an append-only
+    /// log cannot make its own past bytes disappear by appending to itself),
+    /// so per `C5`'s own governing question this is the generic primitive the
+    /// runtime was missing, added once here rather than worked around by any
+    /// one capability.
+    ///
+    /// **Guarantee**: on `Ok`, the content's bytes have already been
+    /// overwritten and removed from disk, and a `DestroyContent` operation
+    /// naming the (now-destroyed) content id is durable in the log — both
+    /// steps completed, in that order, before this call returns. A capability
+    /// never sees a file path or key material to do this itself; this is the
+    /// only door.
+    pub fn destroy_content(
+        &self,
+        content_id: ContentId,
+        entity_id: &str,
+        recorded_at_ms: u64,
+    ) -> Result<OperationReceipt, CapabilityApiError> {
+        let op = self.runtime.destroy_content(
+            &self.capability_id,
+            content_id,
+            entity_id,
+            recorded_at_ms,
+        )?;
+        Ok(OperationReceipt {
+            operation_id: op.operation_id,
+            seq: op.seq,
+            content_id: op.content_id,
+        })
+    }
+
     /// **Stubbed.** `#1295` is blocked by `#1197` (Context Runtime), and the
     /// substrate `#1197` actually requires — the context hypergraph,
     /// `LinkContent`/`UnlinkContent`/`DestroyContent` end-to-end semantics,

--- a/rust/airo_mind_core/src/capability_api.rs
+++ b/rust/airo_mind_core/src/capability_api.rs
@@ -1,0 +1,632 @@
+//! `#1295`: the capability-facing runtime API surface. Five entry points and
+//! nothing else.
+//!
+//! # Why this exists
+//!
+//! `I2`/`I4` say a capability must not create durable storage and that all
+//! durable state originates from the runtime — today nothing *structurally*
+//! prevented that beyond review. [`CapabilityApi`] is the fix: a capability
+//! built against this type alone cannot reach [`crate::runtime::OperationLog`],
+//! [`crate::content::ContentStore`], or [`crate::signing`] — there is no path
+//! from here to any of them except through the five methods below, each of
+//! which returns an opaque result rather than a handle to the thing that
+//! produced it. `notes::NotesCapability`'s own conformance test already
+//! proves it never reaches the filesystem directly, for one capability, by
+//! convention; this module is the same property enforced by the type system
+//! for every capability built after it, because `CapabilityApi` is the only
+//! door.
+//!
+//! # The five functions, and where each one stands
+//!
+//! | Function | Status | Backed by |
+//! |---|---|---|
+//! | [`CapabilityApi::create_operation`] | **Real** | [`crate::runtime::Runtime::emit_operation_ex`] |
+//! | [`CapabilityApi::attach_content`] | **Real** | [`crate::runtime::Runtime::attach_content`] |
+//! | [`CapabilityApi::query_projection`] | **Real** | [`crate::runtime::Runtime::query_projection`] |
+//! | [`CapabilityApi::emit_event`] | **Real** | [`crate::event::EventBus`] |
+//! | [`CapabilityApi::instantiate_context`] | **Stubbed** | nothing — always `Err` |
+//!
+//! `instantiate_context` is the one function this module declares but does
+//! not implement. `#1295` is blocked by `#1197` (Context Runtime), and
+//! `#1197`'s actual scope — a context hypergraph, `LinkContent` /
+//! `UnlinkContent` / `DestroyContent` end-to-end semantics, "what survives
+//! elsewhere" computation for any destructive action, context templates
+//! shipped by capabilities — has no substrate in this crate yet beyond the
+//! three [`crate::verb::Verb`] variants (`CreateContext`, `LinkContext`,
+//! `UnlinkContext`) declared and unimplemented on the wire format. A stub
+//! that quietly created a bare entity and called it a "context" would satisfy
+//! the type signature while lying about the guarantee `#1197` exists to
+//! provide (that uninstalling a capability never deletes the contexts it
+//! created, and that the runtime can compute what survives when content is
+//! unlinked from one). Better to fail loudly with
+//! [`CapabilityApiError::NotImplemented`] than to ship a context that only
+//! *looks* like the real thing.
+//!
+//! # What is honestly still missing
+//!
+//! [`CapabilityApi::query_projection`] does not (cannot yet) isolate one
+//! capability's data from another's — [`crate::projection::EntityGraphProjection`]
+//! is deliberately shared across every capability that emits entity-graph
+//! verbs (`#1195`'s own proof depends on that). Per-capability query
+//! isolation is part of what `#1197`'s context boundary is supposed to
+//! provide once it lands; until then, `query_projection` is real and useful,
+//! but not yet the isolation boundary the design doc's endgame describes.
+
+use crate::content::ContentId;
+use crate::event::CapabilityEvent;
+use crate::runtime::{OperationRequest, Projection, Runtime, RuntimeApiError};
+use crate::verb::Verb;
+
+/// What a capability names the operation it is creating: one of the
+/// nineteen fixed verbs (`#1194`'s scope table), or a capability's own
+/// free-form vocabulary (`"note.create"`) for one that has not adopted the
+/// entity/property graph model. Both share the wire's one `kind` field —
+/// see [`crate::verb::Verb`]'s module doc.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum OperationKind<'a> {
+    Verb(Verb),
+    Custom(&'a str),
+}
+
+impl<'a> OperationKind<'a> {
+    fn as_wire(&self) -> &str {
+        match self {
+            Self::Verb(v) => v.as_str(),
+            Self::Custom(s) => s,
+        }
+    }
+}
+
+/// Everything [`CapabilityApi::create_operation`] needs beyond the
+/// capability id, which is bound once at [`CapabilityApi::new`] and cannot be
+/// overridden per call — a capability cannot emit an operation under another
+/// capability's name.
+#[derive(Clone, Copy, Debug)]
+pub struct CreateOperationRequest<'a> {
+    pub kind: OperationKind<'a>,
+    /// `entityId` (design §3.1). Empty string for an operation that does not
+    /// touch the entity/property graph.
+    pub entity_id: &'a str,
+    /// `contextIds[]` (design §3.1). Empty until `#1197` lands.
+    pub context_ids: &'a [&'a str],
+    /// `schemaId` (design §5.5). Empty until a capability declares a real
+    /// schema fingerprint — `#1196`'s job, not this one's.
+    pub schema_id: &'a str,
+    /// This operation's causal parent, when it has one.
+    pub parent_operation_id: Option<&'a str>,
+    /// Small, inline structural arguments — a note's title, a property's new
+    /// value. Not routed through the content store; see
+    /// [`crate::runtime::Operation::payload`]'s doc for the line between this
+    /// and `content`.
+    pub payload: &'a [u8],
+    /// When set, stored in the content store first and linked into the
+    /// operation as a [`ContentId`] — the capability never inlines large
+    /// data directly into `payload`.
+    pub content: Option<&'a [u8]>,
+    pub recorded_at_ms: u64,
+}
+
+impl<'a> CreateOperationRequest<'a> {
+    /// The common case: a verb-based operation with no context, schema, or
+    /// parent yet. `entity_id`/`payload` still need setting for anything but
+    /// a bare marker operation.
+    pub fn verb(kind: Verb, recorded_at_ms: u64) -> Self {
+        Self {
+            kind: OperationKind::Verb(kind),
+            entity_id: "",
+            context_ids: &[],
+            schema_id: "",
+            parent_operation_id: None,
+            payload: &[],
+            content: None,
+            recorded_at_ms,
+        }
+    }
+
+    /// As [`Self::verb`], for a capability using its own free-form `kind`
+    /// string rather than one of the nineteen fixed verbs.
+    pub fn custom(kind: &'a str, recorded_at_ms: u64) -> Self {
+        Self {
+            kind: OperationKind::Custom(kind),
+            entity_id: "",
+            context_ids: &[],
+            schema_id: "",
+            parent_operation_id: None,
+            payload: &[],
+            content: None,
+            recorded_at_ms,
+        }
+    }
+}
+
+/// What [`CapabilityApi::create_operation`] hands back. Deliberately not
+/// [`crate::runtime::Operation`] itself — that type carries `signature`,
+/// `device_id`, and `version_vector`, none of which a capability needs and
+/// all of which are exactly the kind of storage-shape detail this surface
+/// exists to keep a capability from depending on.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct OperationReceipt {
+    /// Citable as a future operation's `parent_operation_id`.
+    pub operation_id: String,
+    /// This device's local ordering position. Not a cross-device fact —
+    /// `#1194`'s module doc: multi-device merge is Phase 3's job.
+    pub seq: u64,
+    /// Set when `content` was provided and stored.
+    pub content_id: Option<ContentId>,
+}
+
+/// An opaque handle to an instantiated context. No method on this type
+/// returns it today — [`CapabilityApi::instantiate_context`] is stubbed —
+/// but the shape is declared now (per `#1295`'s scope: "define the five
+/// entry points precisely: signatures, error types, and what each
+/// guarantees") so the eventual `#1197` implementation is not a breaking
+/// change to this surface.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ContextId(pub String);
+
+/// Why a call against [`CapabilityApi`] failed. Deliberately narrower than
+/// [`RuntimeApiError`]: no [`crate::runtime::OperationLogError`] variant, no
+/// [`crate::content::ContentStoreError`] variant, reaches a capability —
+/// those name I/O paths and on-disk shapes a capability must not be able to
+/// depend on (`#1295`'s "a capability that learns it is querying SQL will
+/// eventually depend on SQL", generalized to every storage detail, not only
+/// SQL).
+#[derive(Debug)]
+pub enum CapabilityApiError {
+    /// The operation could not be durably recorded. The message is a display
+    /// string for logging/debugging — a capability must not pattern-match
+    /// it to make a decision, since its exact wording is not part of this
+    /// surface's contract.
+    Operation(String),
+    /// The function exists on the five-function surface but is not
+    /// implemented for the reason stated in the message. Currently only
+    /// [`CapabilityApi::instantiate_context`] returns this.
+    NotImplemented(&'static str),
+}
+
+impl std::fmt::Display for CapabilityApiError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Operation(m) => write!(f, "{m}"),
+            Self::NotImplemented(what) => write!(f, "{what}"),
+        }
+    }
+}
+
+impl std::error::Error for CapabilityApiError {}
+
+impl From<RuntimeApiError> for CapabilityApiError {
+    fn from(e: RuntimeApiError) -> Self {
+        match e {
+            RuntimeApiError::OutOfScope(what) => Self::NotImplemented(what),
+            other => Self::Operation(other.to_string()),
+        }
+    }
+}
+
+/// The only door. `#1295`: *"a capability never knows where data lives. It
+/// receives a small, fixed surface and nothing else."* `C5`/`I2`/`I4`: this
+/// type holds nothing durable of its own — its only fields are a runtime
+/// reference and the capability's own id, bound once at construction so a
+/// capability cannot emit an operation, or an event, under another
+/// capability's name.
+pub struct CapabilityApi<'a> {
+    runtime: &'a Runtime,
+    capability_id: String,
+}
+
+impl<'a> CapabilityApi<'a> {
+    /// Binds this handle to one capability id for its whole lifetime. A
+    /// capability author calls this once (typically in its own
+    /// `MyCapability::new`, the same pattern [`crate::notes::NotesCapability`]
+    /// already follows) and keeps the result — every subsequent call is
+    /// stamped with `capability_id`, never a caller-supplied one.
+    pub fn new(runtime: &'a Runtime, capability_id: impl Into<String>) -> Self {
+        Self {
+            runtime,
+            capability_id: capability_id.into(),
+        }
+    }
+
+    pub fn capability_id(&self) -> &str {
+        &self.capability_id
+    }
+
+    /// Appends one durable operation to the log, under this handle's bound
+    /// capability id. The only write path a capability has onto durable
+    /// state — there is no `attach_content` call that also appends an
+    /// operation on its own; a capability that wants stored content
+    /// reachable from the log sets `content` on this request rather than
+    /// calling [`Self::attach_content`] first (though it may, if it needs a
+    /// [`ContentId`] before it knows what operation will reference it).
+    ///
+    /// **Guarantee**: on `Ok`, the operation is durable and signed — it has
+    /// already passed the ingest-time signature check `#1194`'s module doc
+    /// describes — before this call returns.
+    pub fn create_operation(
+        &self,
+        req: CreateOperationRequest<'_>,
+    ) -> Result<OperationReceipt, CapabilityApiError> {
+        let op = self.runtime.emit_operation_ex(OperationRequest {
+            capability: &self.capability_id,
+            kind: req.kind.as_wire(),
+            payload: req.payload,
+            recorded_at_ms: req.recorded_at_ms,
+            entity_id: req.entity_id,
+            parent_operation_id: req.parent_operation_id,
+            context_ids: req.context_ids,
+            schema_id: req.schema_id,
+            content: req.content,
+        })?;
+        Ok(OperationReceipt {
+            operation_id: op.operation_id,
+            seq: op.seq,
+            content_id: op.content_id,
+        })
+    }
+
+    /// Stores `bytes` in the content store, content-addressed, and returns
+    /// only the resulting [`ContentId`] — never a file path, never key
+    /// material (there is none yet; see [`crate::content`]'s module doc for
+    /// the encryption gap this leaves, which is Phase 1's job, not this
+    /// surface's). `#1295`'s scope, verbatim: *"the capability never sees
+    /// key material or a file path."*
+    ///
+    /// This alone does not make the content reachable from the operation
+    /// log — pass it as `content` on a [`CreateOperationRequest`] (typically
+    /// with `kind: OperationKind::Verb(Verb::CreateContent)`) for that, or
+    /// call this first and thread the id through if the operation that will
+    /// reference it is not known yet.
+    pub fn attach_content(&self, bytes: &[u8]) -> Result<ContentId, CapabilityApiError> {
+        Ok(self.runtime.attach_content(bytes)?)
+    }
+
+    /// Rebuilds and returns a read-model of type `P`, always from a fresh
+    /// replay of the log — never a cache this call could have returned
+    /// stale. **Guarantee**: `query_projection` does not leak the
+    /// projection's storage shape — `P` is folded in memory from
+    /// [`crate::runtime::Operation`] values; there is no SQL, no query
+    /// language, and no way for a capability calling this to learn or depend
+    /// on how (or whether) a projection is ever cached or indexed
+    /// internally.
+    ///
+    /// **Known gap** (see the module doc): this does not yet isolate one
+    /// capability's projection data from another's. A capability holding a
+    /// `CapabilityApi` can request any [`Projection`] type in the crate,
+    /// including one fed by other capabilities' operations — the
+    /// per-capability isolation `#1197`'s context boundary is meant to add
+    /// does not exist yet.
+    pub fn query_projection<P: Projection>(&self) -> Result<P, CapabilityApiError> {
+        Ok(self.runtime.query_projection::<P>()?)
+    }
+
+    /// Publishes one in-process, non-durable event. **Guarantee, stated
+    /// explicitly per `#1295`'s scope**: this is *not* a persistence path.
+    /// Nothing published here is ever written to the operation log, ever
+    /// replayed, or survives a process restart — see [`crate::event`]'s
+    /// module doc for exactly what "in-process and non-durable" means
+    /// mechanically. A capability that needs the event to still be true
+    /// tomorrow, or on another device, must call [`Self::create_operation`]
+    /// instead.
+    ///
+    /// This call cannot fail — a publish with zero live subscribers is a
+    /// normal outcome (nobody is listening right now), not an error.
+    pub fn emit_event(&self, topic: &str, payload: &[u8]) {
+        self.runtime.publish_event(CapabilityEvent {
+            capability: self.capability_id.clone(),
+            topic: topic.to_string(),
+            payload: payload.to_vec(),
+        });
+    }
+
+    /// **Stubbed.** `#1295` is blocked by `#1197` (Context Runtime), and the
+    /// substrate `#1197` actually requires — the context hypergraph,
+    /// `LinkContent`/`UnlinkContent`/`DestroyContent` end-to-end semantics,
+    /// "what survives elsewhere" computation, context templates — does not
+    /// exist in this crate yet. This always returns
+    /// [`CapabilityApiError::NotImplemented`] rather than faking a context
+    /// with a bare entity, which would satisfy the type signature while
+    /// lying about the guarantee `#1197` exists to provide. See this
+    /// module's doc for the full reasoning.
+    pub fn instantiate_context(
+        &self,
+        _template_id: &str,
+        _recorded_at_ms: u64,
+    ) -> Result<ContextId, CapabilityApiError> {
+        Err(CapabilityApiError::NotImplemented(
+            "instantiate_context is blocked on #1197 (Context Runtime): the context \
+             hypergraph and LinkContent/UnlinkContent/DestroyContent semantics do not \
+             exist yet, so this surface cannot yet let a capability organize data into \
+             a user-owned context",
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::budget::ResourceBudget;
+    use crate::projection::{encode_relation, encode_set_property, EntityGraphProjection};
+    use crate::runtime::Runtime;
+
+    fn temp_log_path(name: &str) -> std::path::PathBuf {
+        let unique = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        std::env::temp_dir().join(format!("airo_mind_capability_api_test_{name}_{unique}.log"))
+    }
+
+    fn cleanup(path: &std::path::Path) {
+        let _ = std::fs::remove_file(path);
+        let mut device_id = path.file_name().unwrap().to_string_lossy().into_owned();
+        device_id.push_str(".device_id");
+        let _ = std::fs::remove_file(path.with_file_name(device_id));
+        let mut content = path.file_name().unwrap().to_string_lossy().into_owned();
+        content.push_str(".content");
+        let _ = std::fs::remove_dir_all(path.with_file_name(content));
+    }
+
+    /// A fake minimal capability, built to prove `CapabilityApi` is usable
+    /// end to end without reaching into `crate::runtime` or
+    /// `crate::projection` directly. It holds nothing but the handle, the
+    /// same `I2`/`I4` discipline `NotesCapability` follows.
+    struct FakeContactCapability<'a> {
+        api: CapabilityApi<'a>,
+    }
+
+    impl<'a> FakeContactCapability<'a> {
+        const CAPABILITY_ID: &'static str = "fake_contacts";
+
+        fn new(runtime: &'a Runtime) -> Self {
+            Self {
+                api: CapabilityApi::new(runtime, Self::CAPABILITY_ID),
+            }
+        }
+
+        fn create_contact(
+            &self,
+            id: &str,
+            name: &str,
+            recorded_at_ms: u64,
+        ) -> Result<OperationReceipt, CapabilityApiError> {
+            let mut req = CreateOperationRequest::verb(Verb::CreateEntity, recorded_at_ms);
+            req.entity_id = id;
+            req.payload = b"Contact";
+            let create_receipt = self.api.create_operation(req)?;
+
+            let mut set_name = CreateOperationRequest::verb(Verb::SetProperty, recorded_at_ms + 1);
+            set_name.entity_id = id;
+            let encoded = encode_set_property("name", name.as_bytes());
+            set_name.payload = &encoded;
+            self.api.create_operation(set_name)?;
+
+            self.api.emit_event("contact.created", id.as_bytes());
+            Ok(create_receipt)
+        }
+
+        fn link_contact(
+            &self,
+            from: &str,
+            relation: &str,
+            to: &str,
+            recorded_at_ms: u64,
+        ) -> Result<OperationReceipt, CapabilityApiError> {
+            let mut req = CreateOperationRequest::verb(Verb::AddRelation, recorded_at_ms);
+            req.entity_id = from;
+            let encoded = encode_relation(relation, to);
+            req.payload = &encoded;
+            self.api.create_operation(req)
+        }
+
+        fn contacts(&self) -> Result<EntityGraphProjection, CapabilityApiError> {
+            self.api.query_projection::<EntityGraphProjection>()
+        }
+    }
+
+    /// The conformance test `#1295` asks for: a fake capability using
+    /// *only* `CapabilityApi` writes an operation, reads it back via a
+    /// projection, and the round trip holds.
+    #[test]
+    fn a_fake_capability_using_only_the_capability_api_writes_and_reads_back_through_a_projection()
+    {
+        let path = temp_log_path("roundtrip");
+        let runtime = Runtime::boot(ResourceBudget::new(2048), &path).unwrap();
+        let contacts = FakeContactCapability::new(&runtime);
+
+        contacts
+            .create_contact("c1", "Ada Lovelace", 1_000)
+            .unwrap();
+        contacts.create_contact("c2", "Alan Turing", 2_000).unwrap();
+        contacts.link_contact("c1", "knows", "c2", 3_000).unwrap();
+
+        let graph = contacts.contacts().unwrap();
+        assert_eq!(graph.len(), 2);
+        let ada = graph.get("c1").unwrap();
+        assert_eq!(ada.label, "Contact");
+        assert_eq!(ada.properties.get("name").unwrap(), b"Ada Lovelace");
+        assert!(ada
+            .relations
+            .contains(&("knows".to_string(), "c2".to_string())));
+
+        // Independently, the underlying operation log actually holds these
+        // durably -- not just visible through the one projection type this
+        // test happened to query.
+        assert_eq!(runtime.replay().unwrap().len(), 5);
+
+        cleanup(&path);
+    }
+
+    /// Deleting the in-memory projection and rebuilding from the log alone
+    /// must reproduce the same state -- `C4` proven through the capability
+    /// surface, not only through `Runtime`/`EntityGraphProjection` directly.
+    #[test]
+    fn projection_state_survives_deletion_and_rebuild_through_the_capability_api() {
+        let path = temp_log_path("survive");
+        let runtime = Runtime::boot(ResourceBudget::new(2048), &path).unwrap();
+        let contacts = FakeContactCapability::new(&runtime);
+        contacts.create_contact("c1", "Grace Hopper", 1).unwrap();
+
+        let before = contacts.contacts().unwrap();
+        drop(before);
+
+        let after = contacts.contacts().unwrap();
+        assert_eq!(
+            after.get("c1").unwrap().properties.get("name").unwrap(),
+            b"Grace Hopper"
+        );
+
+        cleanup(&path);
+    }
+
+    /// `create_operation` stores large content out of line and links only
+    /// the `ContentId` into the operation -- proven through the capability
+    /// surface's own request/response types, not `crate::runtime::Operation`.
+    #[test]
+    fn create_operation_with_content_round_trips_through_attach_and_read() {
+        let path = temp_log_path("content");
+        let runtime = Runtime::boot(ResourceBudget::new(2048), &path).unwrap();
+        let api = CapabilityApi::new(&runtime, "fake_docs");
+
+        let mut req = CreateOperationRequest::verb(Verb::CreateContent, 1);
+        req.entity_id = "doc-1";
+        req.content = Some(b"a whole document's bytes");
+        let receipt = api.create_operation(req).unwrap();
+
+        let content_id = receipt
+            .content_id
+            .expect("CreateContent must attach a content id");
+        // The capability never sees a path -- only the id it can hand back
+        // to `attach_content`'s sibling read path on `Runtime` (content
+        // reading is intentionally not part of the five-function surface;
+        // a capability threads the id it needs into further operations or
+        // its own projection instead). This assertion goes through
+        // `Runtime` only to prove the bytes are really there -- the
+        // capability itself never does this.
+        assert_eq!(
+            runtime.read_content(&content_id).unwrap().unwrap(),
+            b"a whole document's bytes"
+        );
+
+        cleanup(&path);
+    }
+
+    /// `attach_content` alone: a capability that needs a `ContentId` before
+    /// it knows what operation will reference it.
+    #[test]
+    fn attach_content_returns_only_an_opaque_content_id() {
+        let path = temp_log_path("attach");
+        let runtime = Runtime::boot(ResourceBudget::new(2048), &path).unwrap();
+        let api = CapabilityApi::new(&runtime, "fake_docs");
+        let id = api.attach_content(b"pre-attached bytes").unwrap();
+        assert_eq!(
+            runtime.read_content(&id).unwrap().unwrap(),
+            b"pre-attached bytes"
+        );
+        cleanup(&path);
+    }
+
+    /// `emit_event` is real: a subscriber registered on the runtime observes
+    /// what the capability publishes, in-process.
+    #[test]
+    fn emit_event_reaches_a_runtime_level_subscriber() {
+        let path = temp_log_path("event");
+        let runtime = Runtime::boot(ResourceBudget::new(2048), &path).unwrap();
+        let rx = runtime.subscribe_events();
+        let api = CapabilityApi::new(&runtime, "fake_contacts");
+
+        api.emit_event("contact.created", b"c1");
+
+        let event = rx.recv().unwrap();
+        assert_eq!(event.capability, "fake_contacts");
+        assert_eq!(event.topic, "contact.created");
+        assert_eq!(event.payload, b"c1");
+
+        cleanup(&path);
+    }
+
+    /// `emit_event` is explicitly not a persistence path: publishing does
+    /// not append anything to the operation log.
+    #[test]
+    fn emit_event_never_touches_the_operation_log() {
+        let path = temp_log_path("event_not_durable");
+        let runtime = Runtime::boot(ResourceBudget::new(2048), &path).unwrap();
+        let api = CapabilityApi::new(&runtime, "fake_contacts");
+        api.emit_event("t", b"payload");
+        assert!(runtime.replay().unwrap().is_empty());
+        cleanup(&path);
+    }
+
+    /// `instantiate_context` is honestly stubbed, not faked -- calling it
+    /// always fails with a message naming exactly what is missing.
+    #[test]
+    fn instantiate_context_is_explicitly_not_implemented() {
+        let path = temp_log_path("context_stub");
+        let runtime = Runtime::boot(ResourceBudget::new(2048), &path).unwrap();
+        let api = CapabilityApi::new(&runtime, "fake_contacts");
+        let err = api.instantiate_context("some-template", 1).unwrap_err();
+        assert!(matches!(err, CapabilityApiError::NotImplemented(_)));
+        assert!(err.to_string().contains("#1197"));
+        cleanup(&path);
+    }
+
+    /// A capability cannot spoof another capability's id -- `capability_id`
+    /// is bound once at construction and every subsequent operation is
+    /// stamped with it, never a caller-supplied value.
+    #[test]
+    fn every_operation_is_stamped_with_the_bound_capability_id_not_a_caller_supplied_one() {
+        let path = temp_log_path("capability_id_bound");
+        let runtime = Runtime::boot(ResourceBudget::new(2048), &path).unwrap();
+        let api = CapabilityApi::new(&runtime, "honest_capability");
+
+        let req = CreateOperationRequest::verb(Verb::CreateEntity, 1);
+        api.create_operation(req).unwrap();
+
+        let ops = runtime.replay().unwrap();
+        assert_eq!(ops.len(), 1);
+        assert_eq!(ops[0].capability, "honest_capability");
+
+        cleanup(&path);
+    }
+
+    /// `C5`/`I2`/`I4`: this type holds nothing durable of its own -- its
+    /// only fields are the runtime reference and the bound capability id
+    /// string, the same shape discipline `NotesCapability`'s own test
+    /// enforces for itself (there, `size_of` proves a single pointer; here
+    /// the id is owned `String` rather than `&'static str`, so the
+    /// equivalent proof is structural: grep, not `size_of`).
+    #[test]
+    fn the_capability_api_never_touches_the_filesystem_directly() {
+        let source = include_str!("capability_api.rs");
+        let production_code = source.split("#[cfg(test)]").next().unwrap();
+        assert!(
+            !production_code.contains("std::fs"),
+            "CapabilityApi must reach storage only through Runtime's own methods"
+        );
+    }
+
+    /// A capability using a free-form `kind` string (not one of the
+    /// nineteen fixed verbs) works the same way `NotesCapability` already
+    /// relies on for `Runtime::emit_operation`.
+    #[test]
+    fn custom_kind_operations_work_the_same_as_verb_operations() {
+        let path = temp_log_path("custom_kind");
+        let runtime = Runtime::boot(ResourceBudget::new(2048), &path).unwrap();
+        let api = CapabilityApi::new(&runtime, "fake_freeform");
+
+        let mut req = CreateOperationRequest::custom("freeform.thing", 1);
+        req.payload = b"hello";
+        let receipt = api.create_operation(req).unwrap();
+        assert!(!receipt.operation_id.is_empty());
+
+        let ops = runtime.replay().unwrap();
+        assert_eq!(ops[0].kind, "freeform.thing");
+        assert_eq!(
+            ops[0].verb(),
+            None,
+            "a free-form kind is not one of the fixed verbs"
+        );
+
+        cleanup(&path);
+    }
+}

--- a/rust/airo_mind_core/src/content.rs
+++ b/rust/airo_mind_core/src/content.rs
@@ -33,10 +33,30 @@
 //! missed twice.
 
 use std::fs::{self, File};
-use std::io::{Read, Write};
+use std::io::{Read, Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
 
 use crate::digest::Sha256;
+
+/// Overwrites every byte of the file at `path` with `fill`, then `fsync`s.
+/// Used by [`ContentStore::remove`]'s secure-erase pass — see its doc for why
+/// a plain unlink is not enough. Writes in fixed-size chunks rather than
+/// building one `len`-sized buffer, so destroying a large object does not
+/// require allocating a same-sized scratch buffer.
+fn overwrite_in_place(path: &Path, len: u64, fill: u8) -> Result<(), ContentStoreError> {
+    const CHUNK: usize = 64 * 1024;
+    let mut f = File::options().write(true).open(path)?;
+    f.seek(SeekFrom::Start(0))?;
+    let buf = [fill; CHUNK];
+    let mut remaining = len;
+    while remaining > 0 {
+        let n = remaining.min(CHUNK as u64) as usize;
+        f.write_all(&buf[..n])?;
+        remaining -= n as u64;
+    }
+    f.sync_data()?;
+    Ok(())
+}
 
 /// A content-addressed identifier: lowercase hex SHA-256 of the object's
 /// bytes as stored (plaintext today; ciphertext once Vault lands — see the
@@ -185,11 +205,44 @@ impl ContentStore {
     /// is relying on convention, exactly as `crate::runtime`'s module doc and
     /// design §4.3's own closing paragraph already say plainly.
     ///
+    /// `#1217` closed the honesty gap this left: a plain `fs::remove_file`
+    /// only unlinks a directory entry — the bytes themselves can still sit on
+    /// disk until the filesystem reuses the blocks, readable by anything that
+    /// walks raw disk sectors or an undelete tool. This now overwrites the
+    /// object's bytes in place (twice — once with zeros, once with `0xFF`,
+    /// each `fsync`'d) and truncates to zero length *before* unlinking, so a
+    /// reader who reopens the path a moment later, or recovers the inode
+    /// after the unlink, finds no trace of the original content. This is a
+    /// best-effort software erasure, not a cryptographic guarantee — it does
+    /// not defend against flash-storage wear-leveling relocating a block
+    /// before the overwrite reaches it, filesystem snapshots, or a backup
+    /// taken before this ran. `#1193` (Vault, crypto-shredding) is what makes
+    /// destruction unconditional regardless of medium; this is the
+    /// conservative, real thing this crate can do without it.
+    ///
     /// Idempotent: removing an already-absent object is not an error, the
     /// same "no file yet is empty, not broken" discipline
     /// [`crate::store::MeetingStore`] uses.
     pub fn remove(&self, id: &ContentId) -> Result<(), ContentStoreError> {
-        match fs::remove_file(self.path_for(id)) {
+        let path = self.path_for(id);
+        let len = match fs::metadata(&path) {
+            Ok(meta) => meta.len(),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+            Err(e) => return Err(e.into()),
+        };
+        if len > 0 {
+            overwrite_in_place(&path, len, 0x00)?;
+            overwrite_in_place(&path, len, 0xFF)?;
+        }
+        // Truncate to zero length before unlinking: on a filesystem where the
+        // unlink alone leaves a recoverable inode (a still-open handle
+        // elsewhere, a crash between overwrite and unlink), a zero-length
+        // file has nothing left to recover from that path either.
+        if let Ok(f) = File::options().write(true).open(&path) {
+            let _ = f.set_len(0);
+            let _ = f.sync_data();
+        }
+        match fs::remove_file(&path) {
             Ok(()) => Ok(()),
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
             Err(e) => Err(e.into()),

--- a/rust/airo_mind_core/src/event.rs
+++ b/rust/airo_mind_core/src/event.rs
@@ -1,0 +1,165 @@
+//! The in-process, non-durable half of `#1295`'s capability-facing API
+//! surface: `emit_event`.
+//!
+//! `#1295`'s scope, verbatim: *"`emit_event` is in-process and non-durable —
+//! it is explicitly **not** a persistence path, and that must be stated so
+//! nobody uses it as one."* This module is that statement made mechanical
+//! rather than only documented:
+//!
+//! - [`EventBus::publish`] never touches [`crate::runtime::OperationLog`] or
+//!   [`crate::content::ContentStore`] — there is no `std::fs` anywhere in
+//!   this file, grep-verified the same way [`crate::notes`]'s conformance
+//!   test verifies it for `NotesCapability`.
+//! - A subscriber that is not listening when [`EventBus::publish`] runs
+//!   simply misses the event. There is no queue-forever buffer, no replay,
+//!   no way to ask "what did I miss while I was gone" — that question only
+//!   has an answer for operations, via [`crate::runtime::Runtime::replay`].
+//! - Restarting the process (or even just dropping every [`EventBus`]
+//!   subscriber and creating a new one) loses every event that was ever
+//!   published. Nothing here claims otherwise.
+//!
+//! A capability that needs the *other* thing — "this must still be true
+//! after a restart, and every device must agree on it" — wants an Operation,
+//! not an event. That is exactly the distinction `#1295` draws, and exactly
+//! why `emit_event` and `create_operation` are two different functions on
+//! [`crate::capability_api::CapabilityApi`] rather than one with a durability
+//! flag.
+
+use std::sync::mpsc::{self, Receiver, Sender};
+use std::sync::Mutex;
+
+/// One event, as a live subscriber observes it. Carries the emitting
+/// capability's id (so a listener fanning in events from many capabilities
+/// can tell them apart) and a free-form `topic` the capability chooses —
+/// `C5`: the runtime knows no domains, so it does not interpret `topic` or
+/// `payload` at all, only routes them.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CapabilityEvent {
+    pub capability: String,
+    pub topic: String,
+    pub payload: Vec<u8>,
+}
+
+/// Fan-out publish, in-process, best-effort. Every [`Self::subscribe`] call
+/// registers a fresh channel; [`Self::publish`] sends to every channel still
+/// alive and silently drops any whose receiver has gone away — the bus never
+/// accumulates dead subscribers, and never blocks a publisher on a slow or
+/// absent listener beyond the channel's own (unbounded) queuing.
+#[derive(Default)]
+pub struct EventBus {
+    subscribers: Mutex<Vec<Sender<CapabilityEvent>>>,
+}
+
+impl EventBus {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Registers a new listener and returns the `Receiver` half. There is no
+    /// unsubscribe call — a subscriber that wants to stop listening simply
+    /// drops the `Receiver`; the next [`Self::publish`] notices the send
+    /// failed and removes it.
+    pub fn subscribe(&self) -> Receiver<CapabilityEvent> {
+        let (tx, rx) = mpsc::channel();
+        self.subscribers.lock().unwrap().push(tx);
+        rx
+    }
+
+    /// Publishes to every live subscriber. Not durable (see the module
+    /// doc): nothing here is written to disk, and a subscriber registered
+    /// after this call never sees this event.
+    pub fn publish(&self, event: CapabilityEvent) {
+        let mut subs = self.subscribers.lock().unwrap();
+        subs.retain(|tx| tx.send(event.clone()).is_ok());
+    }
+
+    /// How many subscribers are currently registered. Test/diagnostic use —
+    /// not part of the capability-facing surface.
+    pub fn subscriber_count(&self) -> usize {
+        self.subscribers.lock().unwrap().len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_published_event_reaches_a_live_subscriber() {
+        let bus = EventBus::new();
+        let rx = bus.subscribe();
+        bus.publish(CapabilityEvent {
+            capability: "notes".into(),
+            topic: "note.created".into(),
+            payload: b"n1".to_vec(),
+        });
+        let received = rx.recv().unwrap();
+        assert_eq!(received.capability, "notes");
+        assert_eq!(received.topic, "note.created");
+        assert_eq!(received.payload, b"n1");
+    }
+
+    #[test]
+    fn every_live_subscriber_gets_its_own_copy() {
+        let bus = EventBus::new();
+        let rx1 = bus.subscribe();
+        let rx2 = bus.subscribe();
+        bus.publish(CapabilityEvent {
+            capability: "notes".into(),
+            topic: "t".into(),
+            payload: vec![1, 2, 3],
+        });
+        assert_eq!(rx1.recv().unwrap().payload, vec![1, 2, 3]);
+        assert_eq!(rx2.recv().unwrap().payload, vec![1, 2, 3]);
+    }
+
+    /// Nothing published before `subscribe` is ever delivered — there is no
+    /// replay buffer, matching the module doc's "not a persistence path."
+    #[test]
+    fn a_subscriber_never_sees_events_published_before_it_subscribed() {
+        let bus = EventBus::new();
+        bus.publish(CapabilityEvent {
+            capability: "notes".into(),
+            topic: "missed".into(),
+            payload: vec![],
+        });
+        let rx = bus.subscribe();
+        bus.publish(CapabilityEvent {
+            capability: "notes".into(),
+            topic: "seen".into(),
+            payload: vec![],
+        });
+        let received = rx.recv().unwrap();
+        assert_eq!(received.topic, "seen");
+        assert!(rx.try_recv().is_err(), "no second event should arrive");
+    }
+
+    /// A dropped receiver is pruned on the next publish rather than
+    /// accumulating forever as a dead subscriber.
+    #[test]
+    fn a_dropped_subscriber_is_pruned_on_the_next_publish() {
+        let bus = EventBus::new();
+        {
+            let _rx = bus.subscribe();
+            assert_eq!(bus.subscriber_count(), 1);
+        }
+        // `_rx` is dropped; the bus does not know yet.
+        assert_eq!(bus.subscriber_count(), 1);
+        bus.publish(CapabilityEvent {
+            capability: "notes".into(),
+            topic: "t".into(),
+            payload: vec![],
+        });
+        assert_eq!(
+            bus.subscriber_count(),
+            0,
+            "publish must prune subscribers whose receiver is gone"
+        );
+    }
+
+    #[test]
+    fn a_fresh_bus_has_no_subscribers() {
+        let bus = EventBus::new();
+        assert_eq!(bus.subscriber_count(), 0);
+    }
+}

--- a/rust/airo_mind_core/src/lib.rs
+++ b/rust/airo_mind_core/src/lib.rs
@@ -78,6 +78,16 @@ pub mod lifecycle;
 /// its own.
 pub mod notes;
 
+/// `#1223`'s type system: [`ontology::Primitive`] (the nine leaf value
+/// types and their default merge), [`ontology::Archetype`] (the twelve
+/// abstract shapes, never in user data), [`ontology::CoreEntityType`] (the
+/// twelve concrete types a capability actually extends), and
+/// [`ontology::EntityTypeDef`] (what a capability declares). Additive: it
+/// encodes into the same `&[u8]` [`projection::encode_set_property`] already
+/// accepts, and does not change [`verb::Verb`] or
+/// [`projection::EntityGraphProjection`]'s wire shape — see the module doc.
+pub mod ontology;
+
 /// The generalized projection engine. `#1195`'s condition-5 machinery:
 /// [`projection::EntityGraphProjection`], the multi-capability projection
 /// that proves delete-and-rebuild is a property of the engine, not an
@@ -121,6 +131,10 @@ pub use lifecycle::{
     EngineMetrics, EngineName, EngineState, GroupCommitBuffer, LifecycleError, ManagedEngine,
 };
 pub use notes::{Note, NotesCapability, NotesProjection, NOTES_CAPABILITY};
+pub use ontology::{
+    parse_extends, validate_relation_endpoints, validate_user_facing_label, Archetype,
+    CoreEntityType, EntityTypeDef, MergeStrategy, OntologyError, Primitive, Value,
+};
 pub use projection::{
     encode_relation, encode_set_property, rebuild_from_scratch, ContentLedgerProjection,
     EntityGraphProjection, EntityRecord,

--- a/rust/airo_mind_core/src/lib.rs
+++ b/rust/airo_mind_core/src/lib.rs
@@ -52,10 +52,21 @@ pub mod models;
 pub mod budget;
 pub mod cancel;
 
+/// `#1295`'s capability-facing runtime API surface: `create_operation`,
+/// `attach_content`, `query_projection`, `instantiate_context`, `emit_event`.
+/// The only door a capability built after `#1338`'s [`notes`] should use —
+/// see the module doc for what is real and what is honestly stubbed.
+pub mod capability_api;
+
 /// Content-addressed storage. `#1194`'s content-store half of `C1`: payload
 /// held out of line, addressed by [`content::ContentId`].
 pub mod content;
 pub mod engine;
+
+/// The in-process, non-durable event bus behind
+/// [`capability_api::CapabilityApi::emit_event`]. See the module doc for
+/// exactly what "non-durable" means mechanically.
+pub mod event;
 
 /// Engine lifecycle: state, dependency ordering, and graceful shutdown.
 /// `#1302`'s half of `C6` — see the module docs for why this is split from
@@ -95,12 +106,17 @@ pub mod wav;
 
 pub use budget::{ResourceBudget, ResourceRequest};
 pub use cancel::CancelToken;
+pub use capability_api::{
+    CapabilityApi, CapabilityApiError, ContextId, CreateOperationRequest, OperationKind,
+    OperationReceipt,
+};
 pub use content::{ContentId, ContentStore, ContentStoreError};
 pub use digest::file_digest;
 pub use engine::{
     AudioInput, EngineError, GenerationChunk, GenerationEngine, GenerationRequest, RuntimeStats,
     SpeechEngine, TranscriptSegment,
 };
+pub use event::{CapabilityEvent, EventBus};
 pub use lifecycle::{
     EngineMetrics, EngineName, EngineState, GroupCommitBuffer, LifecycleError, ManagedEngine,
 };

--- a/rust/airo_mind_core/src/lib.rs
+++ b/rust/airo_mind_core/src/lib.rs
@@ -122,7 +122,8 @@ pub use lifecycle::{
 };
 pub use notes::{Note, NotesCapability, NotesProjection, NOTES_CAPABILITY};
 pub use projection::{
-    encode_relation, encode_set_property, rebuild_from_scratch, EntityGraphProjection, EntityRecord,
+    encode_relation, encode_set_property, rebuild_from_scratch, ContentLedgerProjection,
+    EntityGraphProjection, EntityRecord,
 };
 pub use runtime::{
     AppendRequest, Operation, OperationLog, OperationLogError, OperationRequest, Projection,

--- a/rust/airo_mind_core/src/ontology.rs
+++ b/rust/airo_mind_core/src/ontology.rs
@@ -1,0 +1,1095 @@
+//! The type system: primitives, archetypes, and the core ontology. `#1223`'s
+//! scope, restated as types instead of the issue's prose table.
+//!
+//! ```text
+//! Primitive Types → Archetypes → Core Ontology → Capability Entities → Property Overrides
+//! ```
+//!
+//! # Why this exists
+//!
+//! Design doc `C5`: *"capability entities extend the fixed core ontology,
+//! never an archetype directly."* Twelve independently authored capabilities
+//! (Home Buying, Finance, whatever comes after) each want a `Person`. If each
+//! were free to define its own `Person` shape, "the same person" would need
+//! translation at every capability boundary the entity graph is supposed to
+//! remove. This module is the vocabulary all of them share, and cannot
+//! redefine: [`Primitive`] is the leaf value grammar, [`Archetype`] is the
+//! twelve abstract shapes that carry merge/timeline/storage policy and *never
+//! appear in user data*, [`CoreEntityType`] is the twelve concrete types a
+//! capability is actually allowed to extend, and [`EntityTypeDef`] is what a
+//! capability declares (design doc's `Doctor extends Person` example).
+//!
+//! # Additive, not a retrofit
+//!
+//! [`crate::verb::Verb::CreateEntity`]/`SetProperty` and
+//! [`crate::projection::EntityGraphProjection`] already ship, with raw
+//! `Vec<u8>` payloads Notes and the entity-graph conformance suite depend on
+//! by shape. This module does not touch either — [`Value::encode`] produces
+//! exactly the `&[u8]` [`crate::projection::encode_set_property`] already
+//! accepts, so a capability opts into typed values by encoding through here
+//! before calling the verb it already had, not by a payload format that
+//! breaks anything that came before `#1223`. The [`Verb`](crate::verb::Verb)
+//! and [`EntityGraphProjection`](crate::projection::EntityGraphProjection)
+//! wire shapes are unchanged.
+//!
+//! # The rule is structural, not just checked
+//!
+//! [`EntityTypeDef::extends`] is typed `CoreEntityType`, not `Archetype` and
+//! not a free string — a capability author cannot even *construct* an entity
+//! type that extends `Actor` directly; the field simply has no value that
+//! means that. [`parse_extends`] is the boundary where that guarantee meets
+//! the outside world (a capability's own YAML/config, the same shape as the
+//! issue's `Doctor extends Person` example): it is where "structurally
+//! impossible in Rust" becomes "loudly rejected" for data that did not come
+//! through the type checker.
+//!
+//! # The `#1226` seam
+//!
+//! Every named thing here — [`Primitive::as_str`], [`Archetype::as_str`],
+//! [`CoreEntityType::as_str`]/[`CoreEntityType::schema_id`],
+//! [`EntityTypeDef::schema_id`] — has a stable, round-trippable name.
+//! `#1226` ("schema fingerprint + compatibility classes") is deliberately
+//! not implemented here, but [`crate::runtime::Operation::schema_id`]
+//! already exists as a header field for a capability to populate from
+//! exactly these names, so nothing in this module is anonymous or
+//! unnameable for `#1226` to hang a real fingerprint on later.
+//!
+//! # Honestly incomplete
+//!
+//! The issue's archetype table lists eight policy categories an archetype
+//! defines — merge, timeline behavior, indexing, storage, retention, search,
+//! audit, permissions. Only **merge** has a stated table (on [`Primitive`],
+//! not `Archetype` — merge is a primitive-level default in the issue's own
+//! text). The other seven are named as *what archetypes are for*, not given
+//! concrete values, so this module does not invent an eight-field policy
+//! struct with unspecified enum variants for them. [`Archetype`] is a closed,
+//! nameable vocabulary today; attaching the remaining policy fields is
+//! follow-on work once something (the projection engine, most likely) has
+//! spec'd what "timeline behavior" or "retention" actually mean as data.
+//!
+//! Eight of the twelve `extends` edges below are this module's own inference
+//! from archetype semantics, not text the issue states — see
+//! [`CoreEntityType::extends`]'s doc for exactly which four are given and
+//! which eight are inferred.
+
+use std::collections::BTreeMap;
+
+// ---------------------------------------------------------------------------
+// Primitive
+// ---------------------------------------------------------------------------
+
+/// The nine leaf value types every property in the entity graph is made of.
+/// Issue `#1223`'s table, verbatim.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum Primitive {
+    String,
+    Text,
+    Bool,
+    Number,
+    Datetime,
+    List,
+    Set,
+    Reference,
+    Blob,
+}
+
+/// The nine primitives, in the issue table's own order.
+pub const ALL_PRIMITIVES: &[Primitive] = &[
+    Primitive::String,
+    Primitive::Text,
+    Primitive::Bool,
+    Primitive::Number,
+    Primitive::Datetime,
+    Primitive::List,
+    Primitive::Set,
+    Primitive::Reference,
+    Primitive::Blob,
+];
+
+/// A primitive's default merge behavior (design §5.3's precedence chain:
+/// *"safety-class veto → property override → archetype rule → primitive
+/// default"* — this is that last, lowest-precedence link).
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum MergeStrategy {
+    /// Last write wins.
+    Lww,
+    /// Every write is kept, in order — `text`'s "revisions" default.
+    Revisions,
+    /// Merges toward whichever value is "more resolved"; issue text names it
+    /// only for `bool` and does not spell out the direction, so this crate
+    /// does not encode one — see the module's "Honestly incomplete" note.
+    Monotonic,
+    /// Set union — the collection primitives and `reference`.
+    Union,
+    /// Content-addressed: identical bytes hash identically, so merge is
+    /// idempotent by construction — `blob`'s default.
+    Hash,
+}
+
+impl MergeStrategy {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Lww => "lww",
+            Self::Revisions => "revisions",
+            Self::Monotonic => "monotonic",
+            Self::Union => "union",
+            Self::Hash => "hash",
+        }
+    }
+}
+
+impl Primitive {
+    pub fn all() -> &'static [Primitive] {
+        ALL_PRIMITIVES
+    }
+
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::String => "string",
+            Self::Text => "text",
+            Self::Bool => "bool",
+            Self::Number => "number",
+            Self::Datetime => "datetime",
+            Self::List => "list",
+            Self::Set => "set",
+            Self::Reference => "reference",
+            Self::Blob => "blob",
+        }
+    }
+
+    pub fn parse(s: &str) -> Option<Self> {
+        ALL_PRIMITIVES.iter().copied().find(|p| p.as_str() == s)
+    }
+
+    /// The issue's merge table, verbatim: `string`→lww, `text`→revisions,
+    /// `bool`→monotonic, `number`→lww, `datetime`→lww, `list`→union,
+    /// `set`→union, `reference`→union, `blob`→hash.
+    pub fn default_merge(self) -> MergeStrategy {
+        match self {
+            Self::String => MergeStrategy::Lww,
+            Self::Text => MergeStrategy::Revisions,
+            Self::Bool => MergeStrategy::Monotonic,
+            Self::Number => MergeStrategy::Lww,
+            Self::Datetime => MergeStrategy::Lww,
+            Self::List => MergeStrategy::Union,
+            Self::Set => MergeStrategy::Union,
+            Self::Reference => MergeStrategy::Union,
+            Self::Blob => MergeStrategy::Hash,
+        }
+    }
+
+    /// Shape checks beyond "the tag matches" — the part of "reject
+    /// wrong-shaped data" a bare enum-variant comparison cannot express.
+    fn validate_shape(self, value: &Value) -> Result<(), String> {
+        match (self, value) {
+            (Self::Reference, Value::Reference(id)) if id.is_empty() => {
+                Err("a reference value must name a non-empty entity id".to_string())
+            }
+            (Self::Number, Value::Number(n)) if !n.is_finite() => {
+                Err(format!("a number value must be finite, got {n}"))
+            }
+            _ => Ok(()),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Value
+// ---------------------------------------------------------------------------
+
+/// A typed property value — the runtime counterpart of [`Primitive`]. Not
+/// `Eq` because [`Value::Number`] carries `f64`, the same reason nothing else
+/// in this crate stores floats in an ordered collection.
+#[derive(Clone, Debug, PartialEq)]
+pub enum Value {
+    Str(String),
+    Text(String),
+    Bool(bool),
+    Number(f64),
+    /// Milliseconds since the Unix epoch — the same unit every
+    /// `recorded_at_ms` in this crate already uses.
+    Datetime(i64),
+    Reference(String),
+    Blob(Vec<u8>),
+    List(Vec<Value>),
+    /// Canonicalized at [`Value::encode`] time (sorted, deduplicated by
+    /// encoded bytes), not at construction — see that method's doc.
+    Set(Vec<Value>),
+}
+
+const TAG_STR: u8 = 0;
+const TAG_TEXT: u8 = 1;
+const TAG_BOOL: u8 = 2;
+const TAG_NUMBER: u8 = 3;
+const TAG_DATETIME: u8 = 4;
+const TAG_REFERENCE: u8 = 5;
+const TAG_BLOB: u8 = 6;
+const TAG_LIST: u8 = 7;
+const TAG_SET: u8 = 8;
+
+fn push_str(out: &mut Vec<u8>, s: &str) {
+    let bytes = s.as_bytes();
+    out.extend_from_slice(&(bytes.len() as u32).to_be_bytes());
+    out.extend_from_slice(bytes);
+}
+
+fn pop_str(bytes: &[u8], pos: &mut usize) -> Option<String> {
+    let s = pop_bytes(bytes, pos)?;
+    String::from_utf8(s).ok()
+}
+
+fn pop_bytes(bytes: &[u8], pos: &mut usize) -> Option<Vec<u8>> {
+    let len_bytes: [u8; 4] = bytes.get(*pos..*pos + 4)?.try_into().ok()?;
+    let len = u32::from_be_bytes(len_bytes) as usize;
+    *pos += 4;
+    let s = bytes.get(*pos..*pos + len)?;
+    *pos += len;
+    Some(s.to_vec())
+}
+
+fn read_u32(bytes: &[u8], pos: &mut usize) -> Option<u32> {
+    let arr: [u8; 4] = bytes.get(*pos..*pos + 4)?.try_into().ok()?;
+    *pos += 4;
+    Some(u32::from_be_bytes(arr))
+}
+
+impl Value {
+    pub fn primitive(&self) -> Primitive {
+        match self {
+            Self::Str(_) => Primitive::String,
+            Self::Text(_) => Primitive::Text,
+            Self::Bool(_) => Primitive::Bool,
+            Self::Number(_) => Primitive::Number,
+            Self::Datetime(_) => Primitive::Datetime,
+            Self::Reference(_) => Primitive::Reference,
+            Self::Blob(_) => Primitive::Blob,
+            Self::List(_) => Primitive::List,
+            Self::Set(_) => Primitive::Set,
+        }
+    }
+
+    /// Encodes into exactly the `&[u8]` shape
+    /// [`crate::projection::encode_set_property`]'s `value` parameter already
+    /// takes — length-prefixed, no serde, the same wire discipline every
+    /// other payload in this crate follows. Self-describing (a leading tag
+    /// byte), so [`Value::decode`] never needs an out-of-band [`Primitive`]
+    /// to know what it is reading.
+    ///
+    /// [`Value::Set`] is sorted and deduplicated by encoded bytes here, not
+    /// at construction — two `Set` values built from the same elements in a
+    /// different order encode identically, which is what makes `union` merge
+    /// (`C3`: *"merge is commutative, associative, and idempotent"*)
+    /// meaningful for a primitive with no separate merge implementation yet.
+    pub fn encode(&self) -> Vec<u8> {
+        let mut out = Vec::new();
+        self.encode_into(&mut out);
+        out
+    }
+
+    fn encode_into(&self, out: &mut Vec<u8>) {
+        match self {
+            Self::Str(s) => {
+                out.push(TAG_STR);
+                push_str(out, s);
+            }
+            Self::Text(s) => {
+                out.push(TAG_TEXT);
+                push_str(out, s);
+            }
+            Self::Bool(b) => {
+                out.push(TAG_BOOL);
+                out.push(u8::from(*b));
+            }
+            Self::Number(n) => {
+                out.push(TAG_NUMBER);
+                out.extend_from_slice(&n.to_bits().to_be_bytes());
+            }
+            Self::Datetime(ms) => {
+                out.push(TAG_DATETIME);
+                out.extend_from_slice(&ms.to_be_bytes());
+            }
+            Self::Reference(id) => {
+                out.push(TAG_REFERENCE);
+                push_str(out, id);
+            }
+            Self::Blob(bytes) => {
+                out.push(TAG_BLOB);
+                out.extend_from_slice(&(bytes.len() as u32).to_be_bytes());
+                out.extend_from_slice(bytes);
+            }
+            Self::List(items) => {
+                out.push(TAG_LIST);
+                out.extend_from_slice(&(items.len() as u32).to_be_bytes());
+                for item in items {
+                    item.encode_into(out);
+                }
+            }
+            Self::Set(items) => {
+                out.push(TAG_SET);
+                let mut encoded: Vec<Vec<u8>> = items.iter().map(Value::encode).collect();
+                encoded.sort();
+                encoded.dedup();
+                out.extend_from_slice(&(encoded.len() as u32).to_be_bytes());
+                for e in encoded {
+                    out.extend_from_slice(&e);
+                }
+            }
+        }
+    }
+
+    /// The inverse of [`Value::encode`]. `None` for truncated or malformed
+    /// bytes, or trailing bytes after a complete value — the wire-level half
+    /// of "reject wrong-shaped data": a payload that does not parse never
+    /// becomes a [`Value`] at all, let alone one whose primitive tag is
+    /// checked against a schema.
+    pub fn decode(bytes: &[u8]) -> Option<Value> {
+        let mut pos = 0usize;
+        let value = Self::decode_at(bytes, &mut pos)?;
+        if pos == bytes.len() {
+            Some(value)
+        } else {
+            None
+        }
+    }
+
+    fn decode_at(bytes: &[u8], pos: &mut usize) -> Option<Value> {
+        let tag = *bytes.get(*pos)?;
+        *pos += 1;
+        match tag {
+            TAG_STR => Some(Value::Str(pop_str(bytes, pos)?)),
+            TAG_TEXT => Some(Value::Text(pop_str(bytes, pos)?)),
+            TAG_BOOL => {
+                let b = *bytes.get(*pos)?;
+                *pos += 1;
+                Some(Value::Bool(b != 0))
+            }
+            TAG_NUMBER => {
+                let arr: [u8; 8] = bytes.get(*pos..*pos + 8)?.try_into().ok()?;
+                *pos += 8;
+                Some(Value::Number(f64::from_bits(u64::from_be_bytes(arr))))
+            }
+            TAG_DATETIME => {
+                let arr: [u8; 8] = bytes.get(*pos..*pos + 8)?.try_into().ok()?;
+                *pos += 8;
+                Some(Value::Datetime(i64::from_be_bytes(arr)))
+            }
+            TAG_REFERENCE => Some(Value::Reference(pop_str(bytes, pos)?)),
+            TAG_BLOB => Some(Value::Blob(pop_bytes(bytes, pos)?)),
+            TAG_LIST => {
+                let count = read_u32(bytes, pos)?;
+                let mut items = Vec::with_capacity(count as usize);
+                for _ in 0..count {
+                    items.push(Self::decode_at(bytes, pos)?);
+                }
+                Some(Value::List(items))
+            }
+            TAG_SET => {
+                let count = read_u32(bytes, pos)?;
+                let mut items = Vec::with_capacity(count as usize);
+                for _ in 0..count {
+                    items.push(Self::decode_at(bytes, pos)?);
+                }
+                Some(Value::Set(items))
+            }
+            _ => None,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Archetype
+// ---------------------------------------------------------------------------
+
+/// The twelve abstract shapes. **Never appear in user data** — no capability
+/// ever creates an entity whose type *is* an archetype; see
+/// [`CoreEntityType::extends`] and [`EntityTypeDef`] for the concrete layer a
+/// capability actually extends. Carries the runtime-level policy category
+/// names the issue lists (merge, timeline behavior, indexing, storage,
+/// retention, search, audit, permissions) — see the module doc's "Honestly
+/// incomplete" note for which of those has a concrete value today.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum Archetype {
+    Actor,
+    Artifact,
+    Activity,
+    Record,
+    Measurement,
+    Event,
+    Workflow,
+    Collection,
+    Location,
+    Resource,
+    Relationship,
+    Configuration,
+}
+
+pub const ALL_ARCHETYPES: &[Archetype] = &[
+    Archetype::Actor,
+    Archetype::Artifact,
+    Archetype::Activity,
+    Archetype::Record,
+    Archetype::Measurement,
+    Archetype::Event,
+    Archetype::Workflow,
+    Archetype::Collection,
+    Archetype::Location,
+    Archetype::Resource,
+    Archetype::Relationship,
+    Archetype::Configuration,
+];
+
+impl Archetype {
+    pub fn all() -> &'static [Archetype] {
+        ALL_ARCHETYPES
+    }
+
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Actor => "Actor",
+            Self::Artifact => "Artifact",
+            Self::Activity => "Activity",
+            Self::Record => "Record",
+            Self::Measurement => "Measurement",
+            Self::Event => "Event",
+            Self::Workflow => "Workflow",
+            Self::Collection => "Collection",
+            Self::Location => "Location",
+            Self::Resource => "Resource",
+            Self::Relationship => "Relationship",
+            Self::Configuration => "Configuration",
+        }
+    }
+
+    pub fn parse(s: &str) -> Option<Self> {
+        ALL_ARCHETYPES.iter().copied().find(|a| a.as_str() == s)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// CoreEntityType
+// ---------------------------------------------------------------------------
+
+/// The twelve concrete types built into the runtime, never redefinable — a
+/// capability cannot register a thirteenth; this is a closed Rust enum, not
+/// an open registry, which is what "never redefinable" means mechanically.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum CoreEntityType {
+    Person,
+    Organization,
+    Conversation,
+    Document,
+    Task,
+    Journey,
+    CalendarEvent,
+    Reminder,
+    Place,
+    Device,
+    Media,
+    Note,
+}
+
+pub const ALL_CORE_ENTITY_TYPES: &[CoreEntityType] = &[
+    CoreEntityType::Person,
+    CoreEntityType::Organization,
+    CoreEntityType::Conversation,
+    CoreEntityType::Document,
+    CoreEntityType::Task,
+    CoreEntityType::Journey,
+    CoreEntityType::CalendarEvent,
+    CoreEntityType::Reminder,
+    CoreEntityType::Place,
+    CoreEntityType::Device,
+    CoreEntityType::Media,
+    CoreEntityType::Note,
+];
+
+impl CoreEntityType {
+    pub fn all() -> &'static [CoreEntityType] {
+        ALL_CORE_ENTITY_TYPES
+    }
+
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Person => "Person",
+            Self::Organization => "Organization",
+            Self::Conversation => "Conversation",
+            Self::Document => "Document",
+            Self::Task => "Task",
+            Self::Journey => "Journey",
+            Self::CalendarEvent => "CalendarEvent",
+            Self::Reminder => "Reminder",
+            Self::Place => "Place",
+            Self::Device => "Device",
+            Self::Media => "Media",
+            Self::Note => "Note",
+        }
+    }
+
+    pub fn parse(s: &str) -> Option<Self> {
+        ALL_CORE_ENTITY_TYPES
+            .iter()
+            .copied()
+            .find(|t| t.as_str() == s)
+    }
+
+    /// Which archetype this core type extends.
+    ///
+    /// **Four edges are `#1223`'s own text, verbatim:** `Person extends
+    /// Actor` · `Task extends Workflow` · `Document extends Artifact` ·
+    /// `Conversation extends Activity`.
+    ///
+    /// **The remaining eight are this module's inference**, not issue text —
+    /// reasoned from archetype semantics (an org acts, so `Actor`; a place
+    /// is a location, so `Location`; a device is consumed/scheduled like a
+    /// resource, so `Resource`) rather than specified anywhere. Flagged here,
+    /// in the module doc, and in `#1223`'s tracking comment so a maintainer
+    /// with the actual intended mapping can correct it in one place — the
+    /// enforcement rule these values feed (never extend an archetype
+    /// directly) holds regardless of which archetype each inferred edge
+    /// eventually resolves to.
+    pub fn extends(self) -> Archetype {
+        match self {
+            // Given by the issue.
+            Self::Person => Archetype::Actor,
+            Self::Task => Archetype::Workflow,
+            Self::Document => Archetype::Artifact,
+            Self::Conversation => Archetype::Activity,
+            // Inferred — see doc above.
+            Self::Organization => Archetype::Actor,
+            Self::Journey => Archetype::Workflow,
+            Self::CalendarEvent => Archetype::Event,
+            Self::Reminder => Archetype::Event,
+            Self::Place => Archetype::Location,
+            Self::Device => Archetype::Resource,
+            Self::Media => Archetype::Artifact,
+            Self::Note => Archetype::Artifact,
+        }
+    }
+
+    /// The `#1226` seam: a stable, nameable id this type can be cited by
+    /// before a real fingerprint exists. Not a hash, not a version — just a
+    /// name that will not silently change out from under a capability that
+    /// stored it in [`crate::runtime::Operation::schema_id`].
+    pub fn schema_id(self) -> String {
+        format!("core.{}", self.as_str())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// EntityTypeDef — the layer a capability actually extends
+// ---------------------------------------------------------------------------
+
+/// One capability-declared entity type, the issue's own example:
+///
+/// ```yaml
+/// entity: Doctor
+/// extends: Person
+/// labels: [Doctor, Clinician]
+/// properties:
+///   speciality: { type: string }
+/// ```
+///
+/// `extends` is typed [`CoreEntityType`], not [`Archetype`] and not a free
+/// string — see the module doc's "The rule is structural, not just checked".
+/// `labels` carry the domain meaning (`C5`/issue: *"domain meaning is
+/// carried by labels, not types"*); `name`/`extends`/`properties` carry
+/// none.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct EntityTypeDef {
+    pub name: String,
+    pub extends: CoreEntityType,
+    pub labels: Vec<String>,
+    /// `BTreeMap`: deterministic iteration, matching `C2`'s ban on
+    /// `HashMap` iteration order on any path a conformance test relies on.
+    pub properties: BTreeMap<String, Primitive>,
+}
+
+impl EntityTypeDef {
+    pub fn new(name: impl Into<String>, extends: CoreEntityType) -> Self {
+        Self {
+            name: name.into(),
+            extends,
+            labels: Vec::new(),
+            properties: BTreeMap::new(),
+        }
+    }
+
+    pub fn with_label(mut self, label: impl Into<String>) -> Self {
+        self.labels.push(label.into());
+        self
+    }
+
+    pub fn with_property(mut self, name: impl Into<String>, primitive: Primitive) -> Self {
+        self.properties.insert(name.into(), primitive);
+        self
+    }
+
+    /// Type-checks one property write against this entity type's schema:
+    /// the property must be declared, and the value's [`Primitive`] must
+    /// match — "archetypes can be composed from primitives" made checkable,
+    /// one property at a time, plus the [`Primitive::validate_shape`] checks
+    /// a bare tag comparison cannot express.
+    pub fn validate_property(&self, property: &str, value: &Value) -> Result<(), OntologyError> {
+        let expected = self
+            .properties
+            .get(property)
+            .ok_or_else(|| OntologyError::UnknownProperty(property.to_string()))?;
+        let found = value.primitive();
+        if found != *expected {
+            return Err(OntologyError::TypeMismatch {
+                property: property.to_string(),
+                expected: *expected,
+                found,
+            });
+        }
+        expected
+            .validate_shape(value)
+            .map_err(|reason| OntologyError::InvalidValue {
+                property: property.to_string(),
+                reason,
+            })
+    }
+
+    /// The `#1226` seam for a capability-declared type, mirroring
+    /// [`CoreEntityType::schema_id`].
+    pub fn schema_id(&self) -> String {
+        format!("capability.{}", self.name)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Ontology-level validation — the rule enforced, not just declared
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum OntologyError {
+    /// `extends: <name>` named something that is neither a core ontology
+    /// type nor an archetype at all.
+    UnknownCoreType(String),
+    /// `extends: <name>` named one of the twelve archetypes directly —
+    /// exactly the violation `#1223`'s Rule section forbids.
+    CannotExtendArchetypeDirectly(String),
+    /// A capability tried to label an entity with a bare archetype name —
+    /// "archetypes never appear in user data" applied to the label a
+    /// [`crate::verb::Verb::CreateEntity`] payload would carry.
+    ArchetypeUsedAsUserFacingLabel(String),
+    UnknownProperty(String),
+    TypeMismatch {
+        property: String,
+        expected: Primitive,
+        found: Primitive,
+    },
+    InvalidValue {
+        property: String,
+        reason: String,
+    },
+}
+
+impl std::fmt::Display for OntologyError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::UnknownCoreType(s) => write!(f, "'{s}' is not a core ontology type"),
+            Self::CannotExtendArchetypeDirectly(s) => write!(
+                f,
+                "'{s}' is an archetype; capability entities must extend the core ontology, never an archetype directly"
+            ),
+            Self::ArchetypeUsedAsUserFacingLabel(s) => write!(
+                f,
+                "'{s}' is an archetype; archetypes never appear in user data"
+            ),
+            Self::UnknownProperty(p) => write!(f, "property '{p}' is not declared on this entity type"),
+            Self::TypeMismatch {
+                property,
+                expected,
+                found,
+            } => write!(
+                f,
+                "property '{property}' expects {}, got {}",
+                expected.as_str(),
+                found.as_str()
+            ),
+            Self::InvalidValue { property, reason } => {
+                write!(f, "property '{property}' is invalid: {reason}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for OntologyError {}
+
+/// Parses an `extends:` value from a capability's own config (the issue's
+/// YAML example) into a [`CoreEntityType`] — the runtime-checked boundary
+/// where `EntityTypeDef::extends`'s compile-time guarantee (it can only ever
+/// *be* a `CoreEntityType`) meets data that did not go through the Rust type
+/// checker to get here. An archetype name gets its own error variant rather
+/// than folding into "unknown", because "you wrote a real name, just the
+/// wrong layer of the vocabulary" is a different, more specific mistake than
+/// "you wrote a name this ontology has never heard of".
+pub fn parse_extends(s: &str) -> Result<CoreEntityType, OntologyError> {
+    if let Some(core) = CoreEntityType::parse(s) {
+        return Ok(core);
+    }
+    if Archetype::parse(s).is_some() {
+        return Err(OntologyError::CannotExtendArchetypeDirectly(s.to_string()));
+    }
+    Err(OntologyError::UnknownCoreType(s.to_string()))
+}
+
+/// "Archetypes never appear in user data" as a runnable check: a capability
+/// calls this on a label (or a `CreateEntity` payload's label string, before
+/// emitting it) to reject exactly the string that would leak the abstract
+/// layer into the concrete one. Additive — [`crate::projection`] does not
+/// call this itself; it stays free-form label storage, per the module doc.
+pub fn validate_user_facing_label(label: &str) -> Result<(), OntologyError> {
+    if Archetype::parse(label).is_some() {
+        return Err(OntologyError::ArchetypeUsedAsUserFacingLabel(
+            label.to_string(),
+        ));
+    }
+    Ok(())
+}
+
+/// Validates a proposed relation's two endpoints against the ontology:
+/// `C5`'s "extend the core ontology only" rule, applied to *both* sides of a
+/// relation rather than one entity's own declaration. Both fields being
+/// [`CoreEntityType`] already makes this true by construction for any
+/// in-process-built [`EntityTypeDef`] — this function is the same guarantee
+/// re-affirmed at the boundary a config-loaded pair of definitions actually
+/// needs it checked, mirroring [`parse_extends`].
+pub fn validate_relation_endpoints(
+    source: &EntityTypeDef,
+    target: &EntityTypeDef,
+) -> Result<(), OntologyError> {
+    let _: Archetype = source.extends.extends();
+    let _: Archetype = target.extends.extends();
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn every_primitive_round_trips_through_its_wire_spelling() {
+        for p in Primitive::all() {
+            assert_eq!(Primitive::parse(p.as_str()), Some(*p));
+        }
+    }
+
+    #[test]
+    fn the_issue_merge_table_is_exact() {
+        assert_eq!(Primitive::String.default_merge(), MergeStrategy::Lww);
+        assert_eq!(Primitive::Text.default_merge(), MergeStrategy::Revisions);
+        assert_eq!(Primitive::Bool.default_merge(), MergeStrategy::Monotonic);
+        assert_eq!(Primitive::Number.default_merge(), MergeStrategy::Lww);
+        assert_eq!(Primitive::Datetime.default_merge(), MergeStrategy::Lww);
+        assert_eq!(Primitive::List.default_merge(), MergeStrategy::Union);
+        assert_eq!(Primitive::Set.default_merge(), MergeStrategy::Union);
+        assert_eq!(Primitive::Reference.default_merge(), MergeStrategy::Union);
+        assert_eq!(Primitive::Blob.default_merge(), MergeStrategy::Hash);
+    }
+
+    #[test]
+    fn there_are_exactly_nine_primitives_twelve_archetypes_and_twelve_core_types() {
+        assert_eq!(Primitive::all().len(), 9);
+        assert_eq!(Archetype::all().len(), 12);
+        assert_eq!(CoreEntityType::all().len(), 12);
+    }
+
+    #[test]
+    fn every_archetype_round_trips_through_its_wire_spelling() {
+        for a in Archetype::all() {
+            assert_eq!(Archetype::parse(a.as_str()), Some(*a));
+        }
+    }
+
+    #[test]
+    fn every_core_entity_type_round_trips_through_its_wire_spelling() {
+        for t in CoreEntityType::all() {
+            assert_eq!(CoreEntityType::parse(t.as_str()), Some(*t));
+        }
+    }
+
+    #[test]
+    fn archetype_and_core_ontology_names_never_collide() {
+        for a in Archetype::all() {
+            assert!(
+                CoreEntityType::parse(a.as_str()).is_none(),
+                "archetype name '{}' must not also be a core ontology name",
+                a.as_str()
+            );
+        }
+    }
+
+    #[test]
+    fn the_four_issue_given_extends_edges_are_exact() {
+        assert_eq!(CoreEntityType::Person.extends(), Archetype::Actor);
+        assert_eq!(CoreEntityType::Task.extends(), Archetype::Workflow);
+        assert_eq!(CoreEntityType::Document.extends(), Archetype::Artifact);
+        assert_eq!(CoreEntityType::Conversation.extends(), Archetype::Activity);
+    }
+
+    #[test]
+    fn every_core_entity_type_extends_exactly_one_archetype() {
+        // Exercises every arm of `extends()` so an unmapped variant is a
+        // compile error, not a silent gap.
+        for t in CoreEntityType::all() {
+            let _ = t.extends();
+        }
+    }
+
+    // -- Primitive type-checking: reject wrong-shaped data --------------
+
+    #[test]
+    fn a_value_of_the_wrong_primitive_is_rejected() {
+        let doctor = EntityTypeDef::new("Doctor", CoreEntityType::Person)
+            .with_label("Doctor")
+            .with_label("Clinician")
+            .with_property("speciality", Primitive::String);
+
+        let err = doctor
+            .validate_property("speciality", &Value::Number(1.0))
+            .unwrap_err();
+        assert_eq!(
+            err,
+            OntologyError::TypeMismatch {
+                property: "speciality".to_string(),
+                expected: Primitive::String,
+                found: Primitive::Number,
+            }
+        );
+    }
+
+    #[test]
+    fn a_correctly_typed_value_is_accepted() {
+        let doctor = EntityTypeDef::new("Doctor", CoreEntityType::Person)
+            .with_property("speciality", Primitive::String);
+        assert!(doctor
+            .validate_property("speciality", &Value::Str("Cardiology".to_string()))
+            .is_ok());
+    }
+
+    #[test]
+    fn an_undeclared_property_is_rejected() {
+        let doctor = EntityTypeDef::new("Doctor", CoreEntityType::Person);
+        let err = doctor
+            .validate_property("speciality", &Value::Str("Cardiology".to_string()))
+            .unwrap_err();
+        assert_eq!(
+            err,
+            OntologyError::UnknownProperty("speciality".to_string())
+        );
+    }
+
+    #[test]
+    fn an_empty_reference_is_rejected_as_wrong_shaped() {
+        let t = EntityTypeDef::new("Task", CoreEntityType::Task)
+            .with_property("assignee", Primitive::Reference);
+        let err = t
+            .validate_property("assignee", &Value::Reference(String::new()))
+            .unwrap_err();
+        assert!(matches!(err, OntologyError::InvalidValue { .. }));
+    }
+
+    #[test]
+    fn a_non_finite_number_is_rejected_as_wrong_shaped() {
+        let t = EntityTypeDef::new("Measurement", CoreEntityType::Task)
+            .with_property("value", Primitive::Number);
+        let err = t
+            .validate_property("value", &Value::Number(f64::NAN))
+            .unwrap_err();
+        assert!(matches!(err, OntologyError::InvalidValue { .. }));
+    }
+
+    // -- Archetypes composed from primitives -----------------------------
+
+    #[test]
+    fn an_entity_type_composes_several_primitives_and_validates_each_independently() {
+        let doctor = EntityTypeDef::new("Doctor", CoreEntityType::Person)
+            .with_property("speciality", Primitive::String)
+            .with_property("yearsPracticing", Primitive::Number)
+            .with_property("boardCertified", Primitive::Bool)
+            .with_property("clinic", Primitive::Reference)
+            .with_property("languages", Primitive::List);
+
+        assert!(doctor
+            .validate_property("speciality", &Value::Str("Cardiology".to_string()))
+            .is_ok());
+        assert!(doctor
+            .validate_property("yearsPracticing", &Value::Number(12.0))
+            .is_ok());
+        assert!(doctor
+            .validate_property("boardCertified", &Value::Bool(true))
+            .is_ok());
+        assert!(doctor
+            .validate_property("clinic", &Value::Reference("clinic-1".to_string()))
+            .is_ok());
+        assert!(doctor
+            .validate_property(
+                "languages",
+                &Value::List(vec![
+                    Value::Str("en".to_string()),
+                    Value::Str("hi".to_string())
+                ])
+            )
+            .is_ok());
+
+        // Swap two properties' values and both now fail independently.
+        assert!(doctor
+            .validate_property("speciality", &Value::Bool(true))
+            .is_err());
+        assert!(doctor
+            .validate_property("boardCertified", &Value::Str("yes".to_string()))
+            .is_err());
+    }
+
+    // -- Ontology rules enforced, not just declared -----------------------
+
+    #[test]
+    fn extending_an_archetype_directly_is_rejected_at_the_config_boundary() {
+        let err = parse_extends("Actor").unwrap_err();
+        assert_eq!(
+            err,
+            OntologyError::CannotExtendArchetypeDirectly("Actor".to_string())
+        );
+    }
+
+    #[test]
+    fn extending_the_core_ontology_is_accepted_at_the_config_boundary() {
+        assert_eq!(parse_extends("Person"), Ok(CoreEntityType::Person));
+    }
+
+    #[test]
+    fn an_unknown_extends_target_is_rejected_distinctly_from_an_archetype() {
+        let err = parse_extends("Doctor").unwrap_err();
+        assert_eq!(err, OntologyError::UnknownCoreType("Doctor".to_string()));
+    }
+
+    #[test]
+    fn an_entity_type_def_cannot_be_constructed_extending_an_archetype() {
+        // Not a runtime assertion -- `EntityTypeDef::extends` is typed
+        // `CoreEntityType`, so `EntityTypeDef::new("x", Archetype::Actor)`
+        // is a compile error. This test exists so the guarantee has a place
+        // in the suite even though nothing here can fail at runtime.
+        let def = EntityTypeDef::new("Doctor", CoreEntityType::Person);
+        assert_eq!(def.extends, CoreEntityType::Person);
+    }
+
+    #[test]
+    fn a_bare_archetype_name_is_rejected_as_a_user_facing_label() {
+        let err = validate_user_facing_label("Actor").unwrap_err();
+        assert_eq!(
+            err,
+            OntologyError::ArchetypeUsedAsUserFacingLabel("Actor".to_string())
+        );
+    }
+
+    #[test]
+    fn a_core_ontology_or_capability_label_is_accepted() {
+        assert!(validate_user_facing_label("Person").is_ok());
+        assert!(validate_user_facing_label("Doctor").is_ok());
+    }
+
+    #[test]
+    fn relation_endpoints_extending_the_core_ontology_validate() {
+        let doctor = EntityTypeDef::new("Doctor", CoreEntityType::Person);
+        let clinic = EntityTypeDef::new("Clinic", CoreEntityType::Organization);
+        assert!(validate_relation_endpoints(&doctor, &clinic).is_ok());
+    }
+
+    // -- Round-trip through the wire format --------------------------------
+
+    #[test]
+    fn every_scalar_primitive_round_trips_through_encode_decode() {
+        let values = vec![
+            Value::Str("hello".to_string()),
+            Value::Text("a longer body of revisable text".to_string()),
+            Value::Bool(true),
+            Value::Bool(false),
+            Value::Number(3.5),
+            Value::Number(-1.0),
+            Value::Datetime(1_723_000_000_000),
+            Value::Reference("entity-42".to_string()),
+            Value::Blob(vec![0, 1, 2, 255]),
+        ];
+        for v in values {
+            let encoded = v.encode();
+            assert_eq!(
+                Value::decode(&encoded),
+                Some(v.clone()),
+                "round-trip failed for {v:?}"
+            );
+            assert_eq!(Value::decode(&encoded).unwrap().primitive(), v.primitive());
+        }
+    }
+
+    #[test]
+    fn a_list_round_trips_preserving_order() {
+        let list = Value::List(vec![
+            Value::Str("first".to_string()),
+            Value::Number(2.0),
+            Value::Bool(false),
+        ]);
+        let encoded = list.encode();
+        assert_eq!(Value::decode(&encoded), Some(list));
+    }
+
+    #[test]
+    fn a_set_round_trips_deduplicated_and_order_independent() {
+        let a = Value::Set(vec![
+            Value::Str("x".to_string()),
+            Value::Str("y".to_string()),
+            Value::Str("x".to_string()), // duplicate
+        ]);
+        let b = Value::Set(vec![
+            Value::Str("y".to_string()),
+            Value::Str("x".to_string()),
+        ]);
+        // Different insertion order, one has a duplicate: both encode to the
+        // same canonical bytes (`C3`: merge must be idempotent).
+        assert_eq!(a.encode(), b.encode());
+        let decoded = Value::decode(&a.encode()).unwrap();
+        if let Value::Set(items) = decoded {
+            assert_eq!(items.len(), 2);
+        } else {
+            panic!("expected a Set");
+        }
+    }
+
+    #[test]
+    fn a_nested_list_of_lists_round_trips() {
+        let nested = Value::List(vec![
+            Value::List(vec![Value::Number(1.0), Value::Number(2.0)]),
+            Value::List(vec![Value::Str("nested".to_string())]),
+        ]);
+        let encoded = nested.encode();
+        assert_eq!(Value::decode(&encoded), Some(nested));
+    }
+
+    #[test]
+    fn truncated_or_trailing_bytes_fail_to_decode() {
+        let encoded = Value::Str("hi".to_string()).encode();
+        assert_eq!(Value::decode(&encoded[..encoded.len() - 1]), None);
+        let mut with_trailer = encoded.clone();
+        with_trailer.push(0xFF);
+        assert_eq!(Value::decode(&with_trailer), None);
+    }
+
+    #[test]
+    fn value_encode_is_compatible_with_encode_set_property() {
+        // The additive-integration proof: a typed `Value` encodes into
+        // exactly the `&[u8]` `crate::projection::encode_set_property`
+        // already accepts, with no format change to that function at all.
+        let value = Value::Str("Cardiology".to_string());
+        let payload = crate::projection::encode_set_property("speciality", &value.encode());
+        assert!(!payload.is_empty());
+    }
+
+    #[test]
+    fn schema_ids_are_stable_and_distinct_between_core_and_capability_types() {
+        assert_eq!(CoreEntityType::Person.schema_id(), "core.Person");
+        let doctor = EntityTypeDef::new("Doctor", CoreEntityType::Person);
+        assert_eq!(doctor.schema_id(), "capability.Doctor");
+        assert_ne!(CoreEntityType::Person.schema_id(), doctor.schema_id());
+    }
+}

--- a/rust/airo_mind_core/src/projection.rs
+++ b/rust/airo_mind_core/src/projection.rs
@@ -43,6 +43,7 @@
 
 use std::collections::{BTreeMap, BTreeSet};
 
+use crate::content::ContentId;
 use crate::runtime::{Operation, Projection};
 use crate::verb::Verb;
 
@@ -217,6 +218,102 @@ impl EntityGraphProjection {
         }
 
         (Self { entities }, visits)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Content ledger — condition 8 (`#1217`): `DestroyContent` invalidates every
+// projection derived from that content.
+// ---------------------------------------------------------------------------
+
+/// Which content ids the log currently considers reachable, folded from
+/// `CreateContent` and `DestroyContent` operations alone. `C4`: *"`DestroyContent`
+/// invalidates every projection derived from that content"* — this is the
+/// projection that statement is about at the Content primitive's own level,
+/// underneath any capability-specific view built on top of it.
+///
+/// A content id present here is *reachable* — `Runtime::read_content` is
+/// expected to return `Some` for it (assuming the bytes are actually still on
+/// disk, which [`crate::content::ContentStore`] guarantees for anything not
+/// yet destroyed). A content id in [`Self::destroyed`] is exactly the
+/// opposite: [`crate::runtime::Runtime::destroy_content`] already erased the
+/// bytes before this operation was even appended (see that method's doc for
+/// why that ordering, not the reverse, is what makes the guarantee real
+/// rather than a race), so this projection is confirming a fact that is
+/// already true on disk, not the thing that makes it true.
+///
+/// `DestroyContent` is terminal: once a content id is destroyed, a later
+/// `CreateContent` bearing the *same* id cannot resurrect it — the bytes it
+/// would need to re-derive that id from are gone, so nothing can actually
+/// produce them again. Order in the log still matters for what this
+/// projection reports, which is why `destroyed` always wins regardless of
+/// which operation comes first structurally.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct ContentLedgerProjection {
+    live: BTreeSet<ContentId>,
+    destroyed: BTreeSet<ContentId>,
+}
+
+impl ContentLedgerProjection {
+    /// `true` only for a content id this log has seen created and never seen
+    /// destroyed. A content id this projection never heard of at all (never
+    /// created through the verb-based path) is also `false` here — this
+    /// projection can only speak to what it was told.
+    pub fn is_live(&self, id: &ContentId) -> bool {
+        self.live.contains(id)
+    }
+
+    /// `true` for a content id this log has recorded a `DestroyContent` for.
+    pub fn is_destroyed(&self, id: &ContentId) -> bool {
+        self.destroyed.contains(id)
+    }
+
+    pub fn live_content_ids(&self) -> impl Iterator<Item = &ContentId> {
+        self.live.iter()
+    }
+
+    pub fn destroyed_content_ids(&self) -> impl Iterator<Item = &ContentId> {
+        self.destroyed.iter()
+    }
+
+    pub fn live_count(&self) -> usize {
+        self.live.len()
+    }
+
+    pub fn destroyed_count(&self) -> usize {
+        self.destroyed.len()
+    }
+}
+
+impl Projection for ContentLedgerProjection {
+    /// Single pass, `C2`: visits `CreateContent` and `DestroyContent`
+    /// operations only, in log order, and nothing else — a mixed-capability
+    /// log folds correctly the same way [`EntityGraphProjection::rebuild`]
+    /// does.
+    fn rebuild(ops: &[Operation]) -> Self {
+        let mut live = BTreeSet::new();
+        let mut destroyed = BTreeSet::new();
+
+        for op in ops {
+            let Some(verb) = op.verb() else { continue };
+            let Some(content_id) = &op.content_id else {
+                continue;
+            };
+            match verb {
+                Verb::CreateContent => {
+                    if !destroyed.contains(content_id) {
+                        live.insert(content_id.clone());
+                    }
+                }
+                Verb::DestroyContent => {
+                    live.remove(content_id);
+                    destroyed.insert(content_id.clone());
+                }
+                _ => {}
+            }
+        }
+
+        Self { live, destroyed }
     }
 }
 

--- a/rust/airo_mind_core/src/runtime.rs
+++ b/rust/airo_mind_core/src/runtime.rs
@@ -69,6 +69,7 @@ use std::sync::Mutex;
 use crate::content::{ContentId, ContentStore, ContentStoreError};
 use crate::digest::Sha256;
 use crate::engine::EngineError;
+use crate::event::{CapabilityEvent, EventBus};
 use crate::lifecycle::{EngineName, ManagedEngine};
 use crate::signing::{DeviceKeySigner, SignerVerifier};
 use crate::supervisor::Supervisor;
@@ -845,6 +846,12 @@ pub struct Runtime {
     supervisor: Supervisor,
     log: Arc<OperationLog>,
     content: Arc<ContentStore>,
+    /// The in-process, non-durable event bus `#1295`'s `emit_event` publishes
+    /// to. Not a lifecycle engine (`ProjectionEngine`'s reasoning applies
+    /// here too — no durable state for a Supervisor slot to own or restart)
+    /// and not reachable from a capability except through
+    /// [`crate::capability_api::CapabilityApi::emit_event`].
+    event_bus: Arc<EventBus>,
 }
 
 impl Runtime {
@@ -889,6 +896,7 @@ impl Runtime {
             supervisor,
             log,
             content,
+            event_bus: Arc::new(EventBus::new()),
         })
     }
 
@@ -1019,6 +1027,26 @@ impl Runtime {
     /// Out of scope for this phase. Contexts are Phase 5.
     pub fn instantiate_context(&self) -> Result<(), RuntimeApiError> {
         Err(RuntimeApiError::OutOfScope("instantiate_context"))
+    }
+
+    /// Registers a new listener on the in-process event bus. Not part of
+    /// `#1295`'s five-function capability surface (that surface only exposes
+    /// the write side, `emit_event`, via
+    /// [`crate::capability_api::CapabilityApi`]) — this is the runtime-level
+    /// read side something outside a capability (a UI layer, a test) uses to
+    /// observe what capabilities publish. See [`crate::event`]'s module doc
+    /// for exactly what this does and does not guarantee.
+    pub fn subscribe_events(&self) -> std::sync::mpsc::Receiver<CapabilityEvent> {
+        self.event_bus.subscribe()
+    }
+
+    /// Publishes one event to every live subscriber. `pub(crate)`, not
+    /// `pub`: the only intended caller is
+    /// [`crate::capability_api::CapabilityApi::emit_event`] — a capability
+    /// reaches this exclusively through that narrower surface, never
+    /// [`Runtime`] directly.
+    pub(crate) fn publish_event(&self, event: CapabilityEvent) {
+        self.event_bus.publish(event);
     }
 
     /// Out of scope for this phase. Both `#1194` and `#1195` name Sync as

--- a/rust/airo_mind_core/src/runtime.rs
+++ b/rust/airo_mind_core/src/runtime.rs
@@ -1024,6 +1024,86 @@ impl Runtime {
         Ok(self.content.get(id)?)
     }
 
+    /// Condition 8 of `#1311` (`#1217`): *"`DestroyContent` removes every
+    /// reachable representation of user content, except immutable structural
+    /// metadata intentionally retained by design."*
+    ///
+    /// # Why this cannot be `emit_verb_operation(Verb::DestroyContent, ...)`
+    ///
+    /// `C5`'s governing question: *"can it be implemented entirely by
+    /// emitting operations and consuming projections? If no, either the
+    /// runtime is missing a generic primitive that should be added once for
+    /// everyone, or the capability is bypassing the runtime."* An append-only
+    /// operation log cannot make its own past payload bytes disappear by
+    /// appending a new operation — the physical erasure this condition
+    /// requires happens in [`ContentStore`], which no operation, by itself,
+    /// touches. This method is that missing generic primitive: the one seam
+    /// that reaches both the content store and the log in one durability
+    /// boundary, so no capability needs (or is able) to reach the content
+    /// store directly to get real destruction.
+    ///
+    /// # What actually happens, in order, and why the order is load-bearing
+    ///
+    /// 1. **The bytes are physically erased first**
+    ///    ([`ContentStore::remove`]'s secure overwrite-then-unlink — see its
+    ///    doc). Before anything durable records that this happened.
+    /// 2. **Only then** is a `DestroyContent` operation appended, carrying
+    ///    `content_id` (already-public content-addressed metadata — the hash
+    ///    of bytes that no longer exist proves nothing about them, which is
+    ///    exactly the "immutable structural metadata intentionally retained"
+    ///    this condition's own carve-out names) but **no payload**: nothing
+    ///    about the destroyed bytes is copied into the log by the act of
+    ///    destroying them.
+    ///
+    ///    Reversing this order would mean a crash between the two steps could
+    ///    leave a log that *claims* content is destroyed while the bytes are
+    ///    still fully readable on disk — a false guarantee is worse than a
+    ///    missing one. This order's failure mode is the opposite and
+    ///    safe-by-default: a crash after step 1 but before step 2 leaves the
+    ///    bytes gone and the log not yet reflecting it, which a caller can
+    ///    safely retry (removing already-absent bytes is idempotent).
+    ///
+    /// # What this does not (yet) do
+    ///
+    /// `#1217`'s eight steps assume Phase 1's Vault (crypto-shredding a
+    /// content key, `RevokeContentKey` on a revocation ledger) and Phase 3's
+    /// derived-state sweep (embeddings, search index, AI caches) — neither
+    /// exists in this crate yet (see [`crate::content`]'s and this module's
+    /// own "still explicitly deferred" notes). What this method provides
+    /// instead, conservatively, for what *does* exist here: the content
+    /// store's bytes are genuinely gone from disk (not merely logically
+    /// deleted), and [`crate::projection::ContentLedgerProjection`] — the one
+    /// derived-state projection this phase's substrate has — reflects the
+    /// destruction on every rebuild.
+    pub fn destroy_content(
+        &self,
+        capability: &str,
+        content_id: ContentId,
+        entity_id: &str,
+        recorded_at_ms: u64,
+    ) -> Result<Operation, RuntimeApiError> {
+        // Step 1: physically unrecoverable first (idempotent if already
+        // gone — see `ContentStore::remove`'s doc).
+        self.content.remove(&content_id)?;
+
+        // Step 2: the tombstone. No payload, no bytes -- only the id of what
+        // was destroyed, which is exactly the structural metadata condition
+        // 8's carve-out names.
+        let op = self.log.append(AppendRequest {
+            capability,
+            kind: Verb::DestroyContent.as_str(),
+            payload: &[],
+            recorded_at_ms,
+            entity_id,
+            parent_operation_id: None,
+            context_ids: &[],
+            schema_id: "",
+            content_id: Some(content_id),
+        })?;
+        self.supervisor.record_op(REPLAY_ENGINE);
+        Ok(op)
+    }
+
     /// Out of scope for this phase. Contexts are Phase 5.
     pub fn instantiate_context(&self) -> Result<(), RuntimeApiError> {
         Err(RuntimeApiError::OutOfScope("instantiate_context"))

--- a/rust/airo_mind_core/tests/benchmark_gate_conformance.rs
+++ b/rust/airo_mind_core/tests/benchmark_gate_conformance.rs
@@ -1,0 +1,174 @@
+//! Benchmark gate conformance — condition 10 (#1311): "every performance
+//! contract has benchmark gates in CI." Checklist `S2`, complexity-class
+//! bullets ("peak RSS during replay is O(1) in replayed state size", the S1
+//! vault-sizing "constant factor" regression guard).
+//!
+//! # Why this is a scaling assertion, not a `criterion` wall-clock budget
+//!
+//! `rust/airo_core/benches/m3u_parser.rs` already shows this workspace's
+//! pattern for a `criterion` micro-benchmark, and that pattern is right for
+//! its purpose: a developer watching absolute throughput on their own
+//! machine. It is the wrong tool for a **CI gate**, because a hard
+//! wall-clock or ops/sec threshold on a shared GitHub Actions runner is
+//! exactly the kind of check that is flaky by construction — the runner's
+//! noisy-neighbor variance can be larger than the regression you're trying
+//! to catch, which either makes the gate useless (threshold set so loose it
+//! never fires) or a source of false-positive PR blocks (threshold set
+//! tight enough to matter).
+//!
+//! What *is* reliable in CI is a **relative** claim: does cost grow linearly
+//! with input size, or worse? That question is scale-invariant — it holds
+//! whether the runner is fast or slow today — which is exactly the property
+//! `AIRO_MIND_ARCHITECTURE_FREEZE_v1`'s existing S1 bullet already measures
+//! this way ("a 100k-content vault serializes within a constant factor of a
+//! 10k-content vault"). These two tests are that pattern, applied to the
+//! operation log and the projection engine, the two runtime surfaces that
+//! exist on this branch today.
+//!
+//! **Judgment call, stated plainly**: #1294 (as filed) does not specify
+//! numeric performance targets for the operation log or projection engine —
+//! its actual scope is module-persistence-class CI enforcement, not runtime
+//! benchmarking. In the absence of stated targets, the threshold below
+//! (`MAX_SCALING_RATIO`) is chosen generously: 10x the input should cost at
+//! most `MAX_SCALING_RATIO`x the time. Linear cost predicts ~10x; this
+//! allows more than 2x that before failing, which still catches a
+//! quadratic-or-worse regression (~100x) while tolerating one order of
+//! magnitude of CI noise and constant-factor overhead. If a future issue
+//! states an exact target, replace this ratio rather than tightening it
+//! blind.
+
+use std::time::Instant;
+
+use airo_mind_core::{
+    rebuild_from_scratch, NotesCapability, NotesProjection, ResourceBudget, Runtime,
+};
+
+/// Linear cost predicts this multiplier for 10x the input; anything
+/// meaningfully above it (quadratic would be ~100x) is a real regression,
+/// not runner noise.
+const MAX_SCALING_RATIO: f64 = 25.0;
+
+/// A run so fast that ratio math is dominated by clock-resolution and
+/// process-startup noise rather than the workload -- below this, skip the
+/// ratio assertion rather than let noise fail the gate.
+const MIN_RELIABLE_MICROS: u128 = 500;
+
+fn temp_log_path(name: &str) -> std::path::PathBuf {
+    let unique = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    std::env::temp_dir().join(format!("airo_mind_benchmark_gate_{name}_{unique}.log"))
+}
+
+fn cleanup(path: &std::path::Path) {
+    let _ = std::fs::remove_file(path);
+    let mut device_id = path.file_name().unwrap().to_string_lossy().into_owned();
+    device_id.push_str(".device_id");
+    let _ = std::fs::remove_file(path.with_file_name(device_id));
+    let mut content = path.file_name().unwrap().to_string_lossy().into_owned();
+    content.push_str(".content");
+    let _ = std::fs::remove_dir_all(path.with_file_name(content));
+}
+
+fn append_notes(runtime: &Runtime, count: usize) {
+    let notes = NotesCapability::new(runtime);
+    for i in 0..count {
+        notes
+            .create_note(format!("n{i}"), format!("title {i}"), "body text", i as u64)
+            .unwrap();
+    }
+}
+
+/// Guards against an accidental O(n^2) (or worse) append path -- e.g. a full
+/// log rescan on every write, which would pass every correctness test in
+/// `operation_log_and_projection_conformance.rs` while making the log
+/// unusable past a few thousand operations.
+#[test]
+fn operation_log_append_scales_linearly_not_worse() {
+    const SMALL: usize = 150;
+    const LARGE: usize = SMALL * 10;
+
+    let small_path = temp_log_path("append_small");
+    let small_runtime = Runtime::boot(ResourceBudget::new(4096), &small_path).unwrap();
+    let small_start = Instant::now();
+    append_notes(&small_runtime, SMALL);
+    let small_elapsed = small_start.elapsed();
+    drop(small_runtime);
+    cleanup(&small_path);
+
+    let large_path = temp_log_path("append_large");
+    let large_runtime = Runtime::boot(ResourceBudget::new(4096), &large_path).unwrap();
+    let large_start = Instant::now();
+    append_notes(&large_runtime, LARGE);
+    let large_elapsed = large_start.elapsed();
+    drop(large_runtime);
+    cleanup(&large_path);
+
+    if small_elapsed.as_micros() < MIN_RELIABLE_MICROS {
+        eprintln!(
+            "operation_log_append_scales_linearly_not_worse: small run took only \
+             {small_elapsed:?}, below the {MIN_RELIABLE_MICROS}us noise floor -- skipping the \
+             ratio assertion rather than gating on clock noise."
+        );
+        return;
+    }
+
+    let ratio = large_elapsed.as_secs_f64() / small_elapsed.as_secs_f64();
+    assert!(
+        ratio < MAX_SCALING_RATIO,
+        "appending {LARGE} operations took {large_elapsed:?} vs {small_elapsed:?} for {SMALL} \
+         -- a {ratio:.1}x slowdown for 10x the input exceeds the {MAX_SCALING_RATIO}x linear-cost \
+         budget. This looks like a superlinear regression in the append path, not noise."
+    );
+}
+
+/// Guards against an accidental O(n^2) (or worse) rebuild path -- the
+/// projection engine's headline property (condition 5, `#1195`) is that
+/// delete-and-rebuild is safe to do routinely, which is false in practice if
+/// rebuilding scales worse than linearly with log size.
+#[test]
+fn projection_rebuild_from_scratch_scales_linearly_not_worse() {
+    const SMALL: usize = 150;
+    const LARGE: usize = SMALL * 10;
+
+    let small_path = temp_log_path("rebuild_small");
+    let small_runtime = Runtime::boot(ResourceBudget::new(4096), &small_path).unwrap();
+    append_notes(&small_runtime, SMALL);
+    let small_ops = small_runtime.replay().unwrap();
+    let small_start = Instant::now();
+    let small_projection: NotesProjection = rebuild_from_scratch(&small_ops);
+    let small_elapsed = small_start.elapsed();
+    assert_eq!(small_projection.len(), SMALL);
+    drop(small_runtime);
+    cleanup(&small_path);
+
+    let large_path = temp_log_path("rebuild_large");
+    let large_runtime = Runtime::boot(ResourceBudget::new(4096), &large_path).unwrap();
+    append_notes(&large_runtime, LARGE);
+    let large_ops = large_runtime.replay().unwrap();
+    let large_start = Instant::now();
+    let large_projection: NotesProjection = rebuild_from_scratch(&large_ops);
+    let large_elapsed = large_start.elapsed();
+    assert_eq!(large_projection.len(), LARGE);
+    drop(large_runtime);
+    cleanup(&large_path);
+
+    if small_elapsed.as_micros() < MIN_RELIABLE_MICROS {
+        eprintln!(
+            "projection_rebuild_from_scratch_scales_linearly_not_worse: small run took only \
+             {small_elapsed:?}, below the {MIN_RELIABLE_MICROS}us noise floor -- skipping the \
+             ratio assertion rather than gating on clock noise."
+        );
+        return;
+    }
+
+    let ratio = large_elapsed.as_secs_f64() / small_elapsed.as_secs_f64();
+    assert!(
+        ratio < MAX_SCALING_RATIO,
+        "rebuilding from {LARGE} operations took {large_elapsed:?} vs {small_elapsed:?} for \
+         {SMALL} -- a {ratio:.1}x slowdown for 10x the input exceeds the {MAX_SCALING_RATIO}x \
+         linear-cost budget. This looks like a superlinear regression in rebuild_from_scratch, \
+         not noise."
+    );
+}

--- a/rust/airo_mind_core/tests/capability_conformance.rs
+++ b/rust/airo_mind_core/tests/capability_conformance.rs
@@ -1,0 +1,197 @@
+//! Capability conformance — contract `C5`, checklist `S3`, `#1295`.
+//!
+//! Black-box, against `airo_mind_core`'s public API only, the same style as
+//! `tests/supervisor_conformance.rs` and
+//! `tests/operation_log_and_projection_conformance.rs`. A capability under
+//! test here is built the same way a real one is: it holds nothing but a
+//! [`CapabilityApi`] handle, the way `#1295`'s module doc describes and the
+//! way `NotesCapability` (`#1338`) already does in production.
+//!
+//! Per the conformance-suite doc's S3 note: *"the strongest form of the S3
+//! storage check is negative: a capability denied all filesystem and
+//! database access still passes its own suite. If it does not, it was
+//! reaching around the runtime."* The filesystem-isolation test below is
+//! that negative check, run black-box against the public surface rather than
+//! `capability_api`'s own internal unit tests (which exist too, and prove
+//! the same properties white-box, from inside the crate that must not leak
+//! them).
+//!
+//! What this file does **not** attempt: the "declares a safety class looser
+//! than its ontology lineage" bullet needs a safety-class/ontology system
+//! that does not exist on this branch yet (`#1223`'s territory), and
+//! "uninstalling it leaves its contexts, entities, and content intact" needs
+//! an uninstall path this crate has not built. Both are left as gaps in the
+//! conformance-suite report rather than faked here.
+
+use airo_mind_core::{
+    encode_relation, encode_set_property, CapabilityApi, CreateOperationRequest,
+    EntityGraphProjection, ResourceBudget, Runtime, Verb,
+};
+
+fn temp_log_path(name: &str) -> std::path::PathBuf {
+    let unique = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    std::env::temp_dir().join(format!(
+        "airo_mind_capability_conformance_{name}_{unique}.log"
+    ))
+}
+
+fn cleanup(path: &std::path::Path) {
+    let _ = std::fs::remove_file(path);
+    let mut device_id = path.file_name().unwrap().to_string_lossy().into_owned();
+    device_id.push_str(".device_id");
+    let _ = std::fs::remove_file(path.with_file_name(device_id));
+    let mut content = path.file_name().unwrap().to_string_lossy().into_owned();
+    content.push_str(".content");
+    let _ = std::fs::remove_dir_all(path.with_file_name(content));
+}
+
+/// A capability built the way `#1295`'s module doc prescribes: nothing but
+/// the bound handle. If this struct compiled with a field reaching into
+/// `airo_mind_core::runtime`, `airo_mind_core::content`, or
+/// `airo_mind_core::signing` directly, that would already be the S3
+/// violation — those modules are not `pub use`d, so nothing outside the
+/// crate can name their types at all. The type system is the first
+/// enforcement layer; the tests below are the runtime-behavior layer on top
+/// of it.
+struct FakeCrmCapability<'a> {
+    api: CapabilityApi<'a>,
+}
+
+impl<'a> FakeCrmCapability<'a> {
+    const ID: &'static str = "fake_crm";
+
+    fn new(runtime: &'a Runtime) -> Self {
+        Self {
+            api: CapabilityApi::new(runtime, Self::ID),
+        }
+    }
+
+    fn create_person(&self, id: &str, name: &str, at_ms: u64) -> String {
+        let mut req = CreateOperationRequest::verb(Verb::CreateEntity, at_ms);
+        req.entity_id = id;
+        req.payload = b"Person";
+        let receipt = self.api.create_operation(req).unwrap();
+
+        let mut set_name = CreateOperationRequest::verb(Verb::SetProperty, at_ms + 1);
+        set_name.entity_id = id;
+        let encoded = encode_set_property("name", name.as_bytes());
+        set_name.payload = &encoded;
+        self.api.create_operation(set_name).unwrap();
+
+        receipt.operation_id
+    }
+
+    fn link(&self, from: &str, relation: &str, to: &str, at_ms: u64) {
+        let mut req = CreateOperationRequest::verb(Verb::AddRelation, at_ms);
+        req.entity_id = from;
+        let encoded = encode_relation(relation, to);
+        req.payload = &encoded;
+        self.api.create_operation(req).unwrap();
+    }
+
+    fn people(&self) -> EntityGraphProjection {
+        self.api.query_projection().unwrap()
+    }
+}
+
+/// S3, bullet 1 and 2: "emits operations only" / "reads projections only".
+/// A capability restricted to `CapabilityApi` can still do everything a real
+/// capability needs — write structured state and read it back — without
+/// ever touching `Runtime`, `OperationLog`, or `ContentStore` directly.
+#[test]
+fn a_capability_using_only_the_public_capability_api_writes_and_reads_through_a_projection() {
+    let path = temp_log_path("write_and_read");
+    let runtime = Runtime::boot(ResourceBudget::new(2048), &path).unwrap();
+    let crm = FakeCrmCapability::new(&runtime);
+
+    crm.create_person("p1", "Ada Lovelace", 1_000);
+    crm.create_person("p2", "Alan Turing", 2_000);
+    crm.link("p1", "colleague_of", "p2", 3_000);
+
+    let people = crm.people();
+    assert_eq!(people.len(), 2);
+    let ada = people.get("p1").unwrap();
+    assert_eq!(ada.properties.get("name").unwrap(), b"Ada Lovelace");
+    assert!(ada
+        .relations
+        .contains(&("colleague_of".to_string(), "p2".to_string())));
+
+    cleanup(&path);
+}
+
+/// S3, bullet 3, stated negatively per the conformance-suite doc: a
+/// capability denied all filesystem access beyond the one log path the
+/// runtime itself owns still passes. This proves `CapabilityApi` opens no
+/// database, writes no file, and touches no preferences of its own —
+/// everything durable it produced lives only inside the single log file
+/// `Runtime::boot` was given.
+#[test]
+fn the_capability_writes_nothing_outside_the_runtimes_own_log_path() {
+    let dir = std::env::temp_dir().join(format!(
+        "airo_mind_capability_conformance_isolation_{}",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    std::fs::create_dir_all(&dir).unwrap();
+    let log_path = dir.join("runtime.log");
+
+    let before: std::collections::BTreeSet<_> = std::fs::read_dir(&dir)
+        .unwrap()
+        .map(|e| e.unwrap().file_name())
+        .collect();
+    assert!(before.is_empty(), "the directory must start empty");
+
+    let runtime = Runtime::boot(ResourceBudget::new(2048), &log_path).unwrap();
+    let crm = FakeCrmCapability::new(&runtime);
+    for i in 0..10 {
+        crm.create_person(&format!("p{i}"), &format!("Person {i}"), i as u64);
+    }
+    drop(runtime);
+
+    // Every entry the capability's activity produced must be a file the
+    // runtime itself named after `log_path` (the log, its device-id
+    // sidecar, its content directory) -- never a path the capability chose.
+    let after: std::collections::BTreeSet<_> = std::fs::read_dir(&dir)
+        .unwrap()
+        .map(|e| e.unwrap().file_name())
+        .collect();
+    let log_name = log_path.file_name().unwrap().to_os_string();
+    for entry in &after {
+        let entry_str = entry.to_string_lossy();
+        assert!(
+            entry_str.starts_with(&*log_name.to_string_lossy()),
+            "unexpected filesystem entry {entry_str:?} outside the runtime's own log family \
+             -- a capability built only against CapabilityApi must not be able to create this"
+        );
+    }
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+/// S3, bullet: "cannot bypass the Supervisor — it has no route to schedule,
+/// spawn, or persist on its own". Every operation a capability emits is
+/// stamped with the id bound at construction, never one it can pick per
+/// call -- so nothing built against `CapabilityApi` can forge writes under
+/// another capability's identity, which is the write-side half of "no route
+/// around the runtime's bookkeeping."
+#[test]
+fn a_capability_cannot_emit_an_operation_under_another_capabilitys_identity() {
+    let path = temp_log_path("no_forged_identity");
+    let runtime = Runtime::boot(ResourceBudget::new(2048), &path).unwrap();
+    let crm = FakeCrmCapability::new(&runtime);
+    assert_eq!(crm.api.capability_id(), FakeCrmCapability::ID);
+
+    crm.create_person("p1", "Grace Hopper", 1_000);
+    let ops = runtime.replay().unwrap();
+    assert!(
+        ops.iter().all(|op| op.capability == FakeCrmCapability::ID),
+        "every operation this capability produced must be stamped with its own bound id"
+    );
+
+    cleanup(&path);
+}

--- a/rust/airo_mind_core/tests/destroy_content_conformance.rs
+++ b/rust/airo_mind_core/tests/destroy_content_conformance.rs
@@ -1,0 +1,437 @@
+//! `DestroyContent` conformance — condition 8 of `#1311` (`#1217`), contracts
+//! `C4` and `C7`.
+//!
+//! Black-box, against `airo_mind_core`'s public API only, the same style as
+//! `tests/operation_log_and_projection_conformance.rs`.
+//!
+//! Condition 8, verbatim: *"`DestroyContent` removes every reachable
+//! representation of user content, except immutable structural metadata
+//! intentionally retained by design."*
+//!
+//! `C7`'s conformance bar, verbatim: *"destroy then assert no reachable
+//! representation survives."* Per this suite's own stated philosophy (the
+//! conformance-suite doc's opening section), a test that only calls the API
+//! and checks the API's own claim about itself is not proof — this file
+//! reads the content store's directory on disk directly, the same way an
+//! attacker or a forensic recovery tool would, rather than trusting
+//! `read_content`'s `None` alone.
+
+use std::io::Read;
+
+use airo_mind_core::{CapabilityApi, ContentLedgerProjection, ResourceBudget, Runtime, Verb};
+
+fn temp_log_path(name: &str) -> std::path::PathBuf {
+    let unique = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    std::env::temp_dir().join(format!("airo_mind_destroy_conformance_{name}_{unique}.log"))
+}
+
+fn content_dir_for(path: &std::path::Path) -> std::path::PathBuf {
+    let mut content = path.file_name().unwrap().to_string_lossy().into_owned();
+    content.push_str(".content");
+    path.with_file_name(content)
+}
+
+fn cleanup(path: &std::path::Path) {
+    let _ = std::fs::remove_file(path);
+    let mut device_id = path.file_name().unwrap().to_string_lossy().into_owned();
+    device_id.push_str(".device_id");
+    let _ = std::fs::remove_file(path.with_file_name(device_id));
+    let _ = std::fs::remove_dir_all(content_dir_for(path));
+}
+
+/// **The critical proof.** Destroyed content must be gone from the raw bytes
+/// on disk, not merely unreachable through the API. This test writes content
+/// containing a unique marker, destroys it, then walks the content store's
+/// directory itself (every file, every byte) and asserts the marker appears
+/// nowhere — the file is gone, and nothing else in the directory carries a
+/// copy of it either.
+#[test]
+fn destroyed_content_bytes_are_not_recoverable_from_disk() {
+    let path = temp_log_path("disk_unrecoverable");
+    let runtime = Runtime::boot(ResourceBudget::new(2048), &path).unwrap();
+
+    let marker = b"UNIQUE-MARKER-that-must-never-survive-a-destroy-9f3c7a";
+    let op = runtime
+        .emit_verb_operation(
+            "notes",
+            Verb::CreateContent,
+            "doc-1",
+            &[],
+            "",
+            b"",
+            Some(marker),
+            1,
+        )
+        .unwrap();
+    let content_id = op.content_id.clone().unwrap();
+
+    // Before destruction: the file exists and really does contain the
+    // marker -- proves the "not found" assertion below is meaningful rather
+    // than trivially true because nothing was ever written.
+    let dir = content_dir_for(&path);
+    let path_on_disk = dir.join(content_id.as_str());
+    assert!(
+        path_on_disk.exists(),
+        "content file must exist before destroy"
+    );
+    let mut before_bytes = Vec::new();
+    std::fs::File::open(&path_on_disk)
+        .unwrap()
+        .read_to_end(&mut before_bytes)
+        .unwrap();
+    assert_eq!(before_bytes, marker);
+
+    runtime
+        .destroy_content("notes", content_id.clone(), "doc-1", 2)
+        .unwrap();
+
+    // (a) The API says it's gone.
+    assert!(runtime.read_content(&content_id).unwrap().is_none());
+
+    // (b) The file itself is gone -- not present under its content-addressed
+    // name at all.
+    assert!(
+        !path_on_disk.exists(),
+        "the destroyed object's file must not exist on disk"
+    );
+
+    // (c) The marker does not appear anywhere else in the content
+    // directory -- no stray temp file, no leftover copy under a different
+    // name. This is the actual disk inspection: read every remaining file
+    // in the directory and search its raw bytes for the marker.
+    let mut found_marker_anywhere = false;
+    for entry in std::fs::read_dir(&dir).unwrap() {
+        let entry = entry.unwrap();
+        if entry.path().is_file() {
+            let mut bytes = Vec::new();
+            if std::fs::File::open(entry.path())
+                .and_then(|mut f| f.read_to_end(&mut bytes))
+                .is_ok()
+                && bytes.windows(marker.len()).any(|w| w == marker.as_slice())
+            {
+                found_marker_anywhere = true;
+            }
+        }
+    }
+    assert!(
+        !found_marker_anywhere,
+        "the destroyed content's bytes must not survive anywhere in the content store's directory"
+    );
+
+    cleanup(&path);
+}
+
+/// The tombstone operation itself never carries the destroyed bytes. Proven
+/// by replaying the log and confirming no operation's payload contains the
+/// marker -- the log growing by exactly one small record, not by
+/// re-embedding what was just destroyed.
+#[test]
+fn the_destroy_operation_does_not_carry_the_destroyed_bytes() {
+    let path = temp_log_path("no_payload_leak");
+    let runtime = Runtime::boot(ResourceBudget::new(2048), &path).unwrap();
+
+    let marker = b"payload-must-not-leak-into-the-tombstone-op";
+    let op = runtime
+        .emit_verb_operation(
+            "notes",
+            Verb::CreateContent,
+            "doc-1",
+            &[],
+            "",
+            b"",
+            Some(marker),
+            1,
+        )
+        .unwrap();
+    let content_id = op.content_id.clone().unwrap();
+
+    let destroy_op = runtime
+        .destroy_content("notes", content_id, "doc-1", 2)
+        .unwrap();
+
+    assert!(
+        destroy_op.payload.is_empty(),
+        "the tombstone operation must carry no payload"
+    );
+    assert_eq!(destroy_op.verb(), Some(Verb::DestroyContent));
+
+    let ops = runtime.replay().unwrap();
+    for replayed in &ops {
+        let contains_marker = replayed.payload.len() >= marker.len()
+            && replayed
+                .payload
+                .windows(marker.len())
+                .any(|w| w == marker.as_slice());
+        assert!(
+            !contains_marker,
+            "no operation in the log may carry the destroyed bytes in its payload"
+        );
+    }
+
+    cleanup(&path);
+}
+
+/// Condition 8's own text: *"the operation log survives intact — signatures
+/// still verify, structure is preserved."* A destroy must not corrupt, skip,
+/// or invalidate anything about the log's own signing/replay guarantees.
+#[test]
+fn destroy_leaves_the_operation_log_internally_consistent() {
+    let path = temp_log_path("log_consistent");
+    let runtime = Runtime::boot(ResourceBudget::new(2048), &path).unwrap();
+
+    let op = runtime
+        .emit_verb_operation(
+            "notes",
+            Verb::CreateContent,
+            "doc-1",
+            &[],
+            "",
+            b"",
+            Some(b"some content"),
+            1,
+        )
+        .unwrap();
+    let content_id = op.content_id.clone().unwrap();
+
+    let destroy_op = runtime
+        .destroy_content("notes", content_id, "doc-1", 2)
+        .unwrap();
+
+    // The tombstone operation is itself signed and verifies, same as any
+    // other operation -- destruction is not a special, unsigned path.
+    assert!(runtime.verify_operation(&destroy_op));
+
+    // Every operation in the log, including the tombstone, re-verifies under
+    // a full re-verifying replay -- C2's ingest-time guarantee was not
+    // bypassed for this operation.
+    let ops = runtime.replay().unwrap();
+    assert_eq!(ops.len(), 2, "CreateContent + DestroyContent, both durable");
+    assert_eq!(ops[1].seq, 1, "seq is contiguous across the destroy");
+
+    cleanup(&path);
+}
+
+/// **Zero-data-loss for everything else** (condition 5 must not regress).
+/// Destroying one piece of content must not touch any other content, entity,
+/// or note in the log -- proven by rebuilding every projection after the
+/// destroy and confirming the untouched data is byte-identical to before.
+#[test]
+fn destroying_one_object_leaves_all_other_data_intact_through_delete_and_rebuild() {
+    use airo_mind_core::{encode_set_property, rebuild_from_scratch, EntityGraphProjection};
+
+    let path = temp_log_path("other_data_survives");
+    let runtime = Runtime::boot(ResourceBudget::new(2048), &path).unwrap();
+
+    // A note, untouched by anything below.
+    let notes = airo_mind_core::NotesCapability::new(&runtime);
+    notes
+        .create_note("n1", "Groceries", "milk, eggs", 1)
+        .unwrap();
+
+    // An entity-graph fact, untouched.
+    runtime
+        .emit_verb_operation(
+            "graph",
+            Verb::CreateEntity,
+            "person-1",
+            &[],
+            "",
+            b"Person",
+            None,
+            2,
+        )
+        .unwrap();
+    runtime
+        .emit_verb_operation(
+            "graph",
+            Verb::SetProperty,
+            "person-1",
+            &[],
+            "",
+            &encode_set_property("name", b"Ada"),
+            None,
+            3,
+        )
+        .unwrap();
+
+    // Two content objects: one destroyed, one left alone.
+    let keep = runtime
+        .emit_verb_operation(
+            "notes",
+            Verb::CreateContent,
+            "doc-keep",
+            &[],
+            "",
+            b"",
+            Some(b"keep me"),
+            4,
+        )
+        .unwrap()
+        .content_id
+        .unwrap();
+    let destroy = runtime
+        .emit_verb_operation(
+            "notes",
+            Verb::CreateContent,
+            "doc-destroy",
+            &[],
+            "",
+            b"",
+            Some(b"destroy me"),
+            5,
+        )
+        .unwrap()
+        .content_id
+        .unwrap();
+
+    runtime
+        .destroy_content("notes", destroy.clone(), "doc-destroy", 6)
+        .unwrap();
+
+    // Drop everything in-memory and rebuild purely from the persisted log.
+    let ops = runtime.replay().unwrap();
+    let notes_after: airo_mind_core::NotesProjection = rebuild_from_scratch(&ops);
+    let graph_after: EntityGraphProjection = rebuild_from_scratch(&ops);
+    let ledger_after: ContentLedgerProjection = rebuild_from_scratch(&ops);
+
+    // The note survives identically.
+    let n1 = notes_after.get("n1").unwrap();
+    assert_eq!(n1.title, "Groceries");
+    assert_eq!(n1.body, "milk, eggs");
+
+    // The entity-graph fact survives identically.
+    let person = graph_after.get("person-1").unwrap();
+    assert_eq!(person.properties.get("name").unwrap(), b"Ada");
+
+    // The kept content is still live and readable.
+    assert!(ledger_after.is_live(&keep));
+    assert_eq!(runtime.read_content(&keep).unwrap().unwrap(), b"keep me");
+
+    // The destroyed content is gone, and only it.
+    assert!(ledger_after.is_destroyed(&destroy));
+    assert!(!ledger_after.is_live(&destroy));
+    assert!(runtime.read_content(&destroy).unwrap().is_none());
+    assert_eq!(ledger_after.live_count(), 1);
+    assert_eq!(ledger_after.destroyed_count(), 1);
+
+    cleanup(&path);
+}
+
+/// `C4`: *"`DestroyContent` invalidates every projection derived from that
+/// content."* [`ContentLedgerProjection`] is that projection at the Content
+/// primitive's own level -- destroyed content must be absent from a fresh
+/// rebuild, not merely absent from a projection instance that happened to be
+/// built before the destroy.
+#[test]
+fn a_fresh_projection_rebuild_never_shows_destroyed_content_as_live() {
+    let path = temp_log_path("projection_never_resurrects");
+    let runtime = Runtime::boot(ResourceBudget::new(2048), &path).unwrap();
+
+    let content_id = runtime
+        .emit_verb_operation(
+            "notes",
+            Verb::CreateContent,
+            "doc-1",
+            &[],
+            "",
+            b"",
+            Some(b"sensitive"),
+            1,
+        )
+        .unwrap()
+        .content_id
+        .unwrap();
+
+    let before: ContentLedgerProjection = runtime.query_projection().unwrap();
+    assert!(before.is_live(&content_id));
+    drop(before);
+
+    runtime
+        .destroy_content("notes", content_id.clone(), "doc-1", 2)
+        .unwrap();
+
+    // Many independent rebuilds -- not just the first one after the
+    // destroy -- must all agree the content is gone. A projection is a pure
+    // function of the log (`C4`), so this is deterministic, not a race.
+    for _ in 0..5 {
+        let after: ContentLedgerProjection = runtime.query_projection().unwrap();
+        assert!(!after.is_live(&content_id));
+        assert!(after.is_destroyed(&content_id));
+    }
+
+    cleanup(&path);
+}
+
+/// A `DestroyContent` for a content id that was never created (or already
+/// destroyed) is safe -- idempotent, like `ContentStore::remove` itself, not
+/// a hard failure a capability has to special-case.
+#[test]
+fn destroying_the_same_content_twice_is_idempotent() {
+    let path = temp_log_path("idempotent_destroy");
+    let runtime = Runtime::boot(ResourceBudget::new(2048), &path).unwrap();
+
+    let content_id = runtime
+        .emit_verb_operation(
+            "notes",
+            Verb::CreateContent,
+            "doc-1",
+            &[],
+            "",
+            b"",
+            Some(b"bytes"),
+            1,
+        )
+        .unwrap()
+        .content_id
+        .unwrap();
+
+    runtime
+        .destroy_content("notes", content_id.clone(), "doc-1", 2)
+        .unwrap();
+    // Destroying again must not error, even though the bytes are already
+    // gone.
+    runtime
+        .destroy_content("notes", content_id.clone(), "doc-1", 3)
+        .unwrap();
+
+    let ledger: ContentLedgerProjection = runtime.query_projection().unwrap();
+    assert!(ledger.is_destroyed(&content_id));
+    assert!(!ledger.is_live(&content_id));
+
+    cleanup(&path);
+}
+
+/// The `CapabilityApi` surface: a capability that only ever touches
+/// `CapabilityApi` (never `Runtime`, never `ContentStore`) can still destroy
+/// content for real, and the destroyed bytes are unreachable through the
+/// capability surface too.
+#[test]
+fn a_capability_can_destroy_content_through_the_capability_api_alone() {
+    use airo_mind_core::CreateOperationRequest;
+
+    let path = temp_log_path("capability_api_destroy");
+    let runtime = Runtime::boot(ResourceBudget::new(2048), &path).unwrap();
+    let api = CapabilityApi::new(&runtime, "fake_docs");
+
+    let mut req = CreateOperationRequest::verb(Verb::CreateContent, 1);
+    req.entity_id = "doc-1";
+    req.content = Some(b"capability-owned bytes");
+    let receipt = api.create_operation(req).unwrap();
+    let content_id = receipt.content_id.unwrap();
+
+    api.destroy_content(content_id.clone(), "doc-1", 2).unwrap();
+
+    // Runtime-level check: the bytes are really gone (a capability itself
+    // has no read path to prove this -- content reading is intentionally
+    // not on the five/six-function surface, same as `attach_content`'s
+    // sibling read path).
+    assert!(runtime.read_content(&content_id).unwrap().is_none());
+
+    let ledger: ContentLedgerProjection = api.query_projection().unwrap();
+    assert!(ledger.is_destroyed(&content_id));
+
+    cleanup(&path);
+}

--- a/rust/airo_mind_core/tests/operation_log_and_projection_conformance.rs
+++ b/rust/airo_mind_core/tests/operation_log_and_projection_conformance.rs
@@ -1,5 +1,5 @@
 //! Operation log and projection conformance — contract `C1`/`C2`/`C4`,
-//! `#1194` and `#1195`.
+//! checklist `S1`/`S2`, `#1194` and `#1195`.
 //!
 //! Black-box, against `airo_mind_core`'s public API only, the same style as
 //! `tests/supervisor_conformance.rs`. Written against the contracts, not the
@@ -8,12 +8,24 @@
 //! construction they start from.
 //!
 //! Two groups:
-//! - **Operation log** (`#1194`, condition 4): the full header exists, is
+//! - **Operation log** (`#1194`, condition 4, part of `S1` — "every durable
+//!   object is reachable from a log replay"): the full header exists, is
 //!   signed, is content-addressed for out-of-line content, and survives
 //!   concurrent writers.
-//! - **Projection engine** (`#1195`, condition 5): the delete-and-rebuild,
-//!   zero-data-loss proof, generalized across two independent projections
-//!   fed by a mixed-capability log — not just Notes.
+//! - **Projection engine** (`#1195`, condition 5, `S2` — "replay is
+//!   deterministic" and "any permutation of concurrent operations
+//!   converges"): the delete-and-rebuild, zero-data-loss proof, generalized
+//!   across two independent projections fed by a mixed-capability log — not
+//!   just Notes.
+//!
+//! This file does not attempt the rest of `S1` (Vault-owned properties —
+//! recovery, retention-class expiry, export memory bounds) or the rest of
+//! `S2` (peak-RSS-is-O(1), snapshot-equals-full-replay) — those need
+//! surfaces (`Vault`, snapshotting) this branch does not have yet. Per
+//! `docs/superpowers/specs/2026-07-28-airo-mind-conformance-suite.md`, a
+//! suite is a checklist of independent bullets, not a single pass/fail; this
+//! file covers a strict subset of `S1`/`S2` today, honestly, rather than
+//! claiming the whole suite.
 
 use std::sync::Arc;
 

--- a/rust/airo_mind_core/tests/type_system_conformance.rs
+++ b/rust/airo_mind_core/tests/type_system_conformance.rs
@@ -1,0 +1,212 @@
+//! Type system conformance — `#1223`: primitives, archetypes, core ontology.
+//!
+//! Black-box, against `airo_mind_core`'s public API only, the same style as
+//! `tests/operation_log_and_projection_conformance.rs`. Proves the four
+//! things the issue asks for, plus the additive claim: a typed [`Value`]
+//! integrates with the already-shipped [`Runtime`] / [`EntityGraphProjection`]
+//! (`#1194`/`#1195`) through the existing `encode_set_property` seam, with no
+//! change to either's wire format.
+
+use airo_mind_core::{
+    parse_extends, validate_relation_endpoints, validate_user_facing_label, Archetype,
+    CoreEntityType, EntityGraphProjection, EntityTypeDef, OntologyError, Primitive, ResourceBudget,
+    Runtime, Value, Verb,
+};
+
+fn temp_log_path(name: &str) -> std::path::PathBuf {
+    let unique = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    std::env::temp_dir().join(format!(
+        "airo_mind_type_system_conformance_{name}_{unique}.log"
+    ))
+}
+
+fn cleanup(path: &std::path::Path) {
+    let _ = std::fs::remove_file(path);
+    let mut device_id = path.file_name().unwrap().to_string_lossy().into_owned();
+    device_id.push_str(".device_id");
+    let _ = std::fs::remove_file(path.with_file_name(device_id));
+    let mut content = path.file_name().unwrap().to_string_lossy().into_owned();
+    content.push_str(".content");
+    let _ = std::fs::remove_dir_all(path.with_file_name(content));
+}
+
+// ---------------------------------------------------------------------------
+// Primitives type-check correctly
+// ---------------------------------------------------------------------------
+
+#[test]
+fn a_doctor_entity_type_rejects_a_wrong_shaped_speciality() {
+    let doctor = EntityTypeDef::new("Doctor", CoreEntityType::Person)
+        .with_label("Doctor")
+        .with_label("Clinician")
+        .with_property("speciality", Primitive::String);
+
+    assert!(doctor
+        .validate_property("speciality", &Value::Str("Cardiology".to_string()))
+        .is_ok());
+    assert!(doctor
+        .validate_property("speciality", &Value::Number(42.0))
+        .is_err());
+}
+
+// ---------------------------------------------------------------------------
+// Archetypes can be composed from primitives
+// ---------------------------------------------------------------------------
+
+#[test]
+fn a_capability_entity_composes_multiple_primitives_under_one_core_type() {
+    let doctor = EntityTypeDef::new("Doctor", CoreEntityType::Person)
+        .with_property("speciality", Primitive::String)
+        .with_property("boardCertified", Primitive::Bool)
+        .with_property("yearsPracticing", Primitive::Number)
+        .with_property("clinic", Primitive::Reference)
+        .with_property("languages", Primitive::List);
+
+    assert_eq!(doctor.extends, CoreEntityType::Person);
+    assert_eq!(doctor.extends.extends(), Archetype::Actor);
+
+    assert!(doctor
+        .validate_property("speciality", &Value::Str("Cardiology".to_string()))
+        .is_ok());
+    assert!(doctor
+        .validate_property("boardCertified", &Value::Bool(true))
+        .is_ok());
+    assert!(doctor
+        .validate_property("yearsPracticing", &Value::Number(9.0))
+        .is_ok());
+    assert!(doctor
+        .validate_property("clinic", &Value::Reference("clinic-1".to_string()))
+        .is_ok());
+    assert!(doctor
+        .validate_property(
+            "languages",
+            &Value::List(vec![Value::Str("en".to_string())])
+        )
+        .is_ok());
+}
+
+// ---------------------------------------------------------------------------
+// The ontology's relationship rules are enforced, not just declared
+// ---------------------------------------------------------------------------
+
+#[test]
+fn extending_an_archetype_directly_is_rejected_by_a_real_check() {
+    // The design-doc "Rule": capability entities extend the core ontology
+    // only, never an archetype directly. `EntityTypeDef::extends` makes this
+    // impossible to construct in Rust; `parse_extends` is the boundary that
+    // enforces the same rule against a capability's own config data.
+    assert_eq!(
+        parse_extends("Actor"),
+        Err(OntologyError::CannotExtendArchetypeDirectly(
+            "Actor".to_string()
+        ))
+    );
+    assert_eq!(parse_extends("Person"), Ok(CoreEntityType::Person));
+}
+
+#[test]
+fn an_archetype_name_cannot_be_used_as_a_user_facing_label() {
+    // "Archetypes... never appear in user data" enforced, not just stated.
+    assert!(validate_user_facing_label("Actor").is_err());
+    assert!(validate_user_facing_label("Doctor").is_ok());
+}
+
+#[test]
+fn relation_endpoints_must_both_resolve_through_the_core_ontology() {
+    let doctor = EntityTypeDef::new("Doctor", CoreEntityType::Person);
+    let clinic = EntityTypeDef::new("Clinic", CoreEntityType::Organization);
+    assert!(validate_relation_endpoints(&doctor, &clinic).is_ok());
+}
+
+// ---------------------------------------------------------------------------
+// Round-trip through serialization (the operation-log wire format)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn every_primitive_value_round_trips_through_encode_decode() {
+    let samples = vec![
+        Value::Str("Cardiology".to_string()),
+        Value::Text("a much longer revisable note body".to_string()),
+        Value::Bool(true),
+        Value::Number(98.6),
+        Value::Datetime(1_723_000_000_000),
+        Value::Reference("patient-1".to_string()),
+        Value::Blob(vec![1, 2, 3]),
+        Value::List(vec![
+            Value::Str("en".to_string()),
+            Value::Str("hi".to_string()),
+        ]),
+        Value::Set(vec![Value::Str("cardiology".to_string())]),
+    ];
+    for value in samples {
+        let encoded = value.encode();
+        let decoded = Value::decode(&encoded).expect("round-trip must decode");
+        assert_eq!(decoded, value);
+        assert_eq!(decoded.primitive(), value.primitive());
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Additive integration: typed values ride the existing #1194/#1195 substrate
+// ---------------------------------------------------------------------------
+
+/// The additive claim made concrete: a capability encodes a typed [`Value`]
+/// and hands its bytes to the same `SetProperty` verb / `EntityGraphProjection`
+/// that shipped in `#1194`/`#1195`, unmodified. Nothing about the runtime
+/// or projection engine's wire format changed for `#1223` to exist.
+#[test]
+fn a_typed_value_flows_through_the_existing_runtime_and_projection_unmodified() {
+    let path = temp_log_path("typed_value_flow");
+    let runtime = Runtime::boot(ResourceBudget::new(2048), &path).unwrap();
+
+    let doctor = EntityTypeDef::new("Doctor", CoreEntityType::Person)
+        .with_label("Doctor")
+        .with_property("speciality", Primitive::String);
+
+    let speciality = Value::Str("Cardiology".to_string());
+    doctor
+        .validate_property("speciality", &speciality)
+        .expect("well-typed value must validate before it is emitted");
+
+    runtime
+        .emit_verb_operation(
+            "clinic",
+            Verb::CreateEntity,
+            "doctor-1",
+            &[],
+            &doctor.schema_id(),
+            b"Doctor",
+            None,
+            1,
+        )
+        .unwrap();
+    runtime
+        .emit_verb_operation(
+            "clinic",
+            Verb::SetProperty,
+            "doctor-1",
+            &[],
+            &doctor.schema_id(),
+            &airo_mind_core::encode_set_property("speciality", &speciality.encode()),
+            None,
+            2,
+        )
+        .unwrap();
+
+    let graph: EntityGraphProjection = runtime.query_projection().unwrap();
+    let record = graph.get("doctor-1").unwrap();
+    assert_eq!(record.label, "Doctor");
+
+    let stored_bytes = record.properties.get("speciality").unwrap();
+    let decoded = Value::decode(stored_bytes).unwrap();
+    assert_eq!(decoded, Value::Str("Cardiology".to_string()));
+
+    // The operation carries #1223's schema-id seam for #1226 to build on.
+    let ops = runtime.replay().unwrap();
+    assert!(ops.iter().any(|op| op.schema_id == "capability.Doctor"));
+
+    cleanup(&path);
+}

--- a/scripts/run-mind-conformance-suite.sh
+++ b/scripts/run-mind-conformance-suite.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Runtime v1 condition 9 (#1311): "every runtime contract has automated
+# conformance tests." Per docs/superpowers/specs/2026-07-28-airo-mind-conformance-suite.md
+# (tracked on #1340), the suite is S1-S5, one per contract C1/C2/C5/C6/C7 --
+# and per that doc, "a conformance test that has to change when the storage
+# engine changes was written against the implementation and is a unit test
+# wearing the wrong label."
+#
+# Conformance tests for this suite land scattered across several PRs and,
+# per this session's own briefing, two more are landing in parallel from
+# other agents (#1217 purge/destroy, #1223 type system) whose file names this
+# script cannot know in advance. So this is a *discovery* aggregator, not a
+# hardcoded list: any file matching `rust/*/tests/*conformance*.rs` is a
+# member of the suite, structurally, the same way `module.yaml` discovery
+# works for the Engineering Council gate.
+#
+# This is the single entry point condition 9 needs: one command that finds
+# every conformance test in the workspace, runs it, and reports which of the
+# five lettered suites (S1-S5) currently has coverage -- so a suite silently
+# having zero tests is visible instead of assumed.
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+CARGO_MANIFEST="rust/Cargo.toml"
+
+if [[ ! -f "$CARGO_MANIFEST" ]]; then
+  echo "FATAL: $CARGO_MANIFEST not found -- run from the repo root." >&2
+  exit 1
+fi
+
+# --- Discover -----------------------------------------------------------
+# Structural discovery: any tests/*conformance*.rs under any rust/ crate.
+# Portable `find` piped into a `while read` loop rather than `mapfile` --
+# `mapfile`/`readarray` need bash 4+, and macOS still ships bash 3.2 as
+# `/bin/bash`, the same portability constraint the module-manifest and
+# projection-route gates already work around.
+conformance_files=()
+while IFS= read -r f; do
+  [[ -n "$f" ]] && conformance_files+=("$f")
+done < <(
+  find rust -type d -name tests -mindepth 2 -maxdepth 2 \
+    -exec find {} -maxdepth 1 -type f -iname '*conformance*.rs' \; \
+    2>/dev/null | sort
+)
+
+# Positive control. A `find` that silently matches nothing -- wrong path,
+# renamed directory, moved crate -- would report "0 failures" having checked
+# nothing, which is worse than failing loudly. The suite is known to have at
+# least two files today (#1194/#1195, #1302); if discovery finds none, the
+# discovery mechanism itself is broken, not the codebase.
+if [[ ${#conformance_files[@]} -eq 0 ]]; then
+  echo "FATAL: no rust/*/tests/*conformance*.rs files were discovered." >&2
+  echo "This suite is known to have conformance tests today -- discovery is broken." >&2
+  exit 1
+fi
+
+echo "Discovered ${#conformance_files[@]} conformance test file(s):"
+for f in "${conformance_files[@]}"; do
+  echo "  - $f"
+done
+echo
+
+# --- Suite tag coverage ---------------------------------------------------
+# Each conformance file's header comment names the suite(s) it proves, e.g.
+# "contract `C6`, checklist `S4`". Extract that so a suite going to zero
+# files is a visible line in the report, not something only a human auditing
+# the spec doc by hand would notice.
+#
+# Plain variables, not an associative array: bash 3.2 (still `/bin/bash` on
+# macOS) has no `declare -A`, the same constraint the discovery loop above
+# works around.
+echo "Suite coverage (S1-S5, per docs/superpowers/specs/2026-07-28-airo-mind-conformance-suite.md):"
+missing_suites=()
+for suite in S1 S2 S3 S4 S5; do
+  matches=""
+  for f in "${conformance_files[@]}"; do
+    header="$(head -n 20 "$f")"
+    if grep -qE "\`${suite}\`|checklist ${suite}\b" <<<"$header"; then
+      matches+="$f "
+    fi
+  done
+  if [[ -z "$matches" ]]; then
+    echo "  $suite: NO CONFORMANCE FILE TAGS ITSELF WITH $suite"
+    missing_suites+=("$suite")
+  else
+    echo "  $suite: $matches"
+  fi
+done
+echo
+
+if [[ ${#missing_suites[@]} -gt 0 ]]; then
+  echo "WARNING: ${#missing_suites[@]} suite(s) have no tagged conformance test yet: ${missing_suites[*]}" >&2
+  echo "Per condition 9, this is not a pass -- it is a known, visible gap. Non-blocking" >&2
+  echo "here because some suites (S1/S5) depend on runtime surfaces (Vault) not yet" >&2
+  echo "built on this branch; landing this gate is what makes the gap mechanical" >&2
+  echo "instead of something only a council review would catch." >&2
+  echo >&2
+fi
+
+# --- Run --------------------------------------------------------------
+# One `cargo test` invocation per discovered crate, filtered to only the
+# conformance test binaries so this doesn't silently widen into "run every
+# test in the workspace" (that's rust-core.yml's separate, existing job).
+failures=0
+for f in "${conformance_files[@]}"; do
+  # rust/<crate>/tests/<name>.rs -> crate=<crate>, test binary=<name>
+  crate="$(echo "$f" | cut -d/ -f2)"
+  name="$(basename "$f" .rs)"
+  echo "== cargo test -p $crate --test $name =="
+  if ! cargo test --manifest-path "$CARGO_MANIFEST" -p "$crate" --test "$name"; then
+    echo "FAILED: $f" >&2
+    failures=$((failures + 1))
+  fi
+  echo
+done
+
+if [[ $failures -gt 0 ]]; then
+  echo "FATAL: $failures conformance test file(s) failed." >&2
+  exit 1
+fi
+
+echo "All discovered conformance tests passed."


### PR DESCRIPTION
## Summary

This is the non-duplicate remainder of the now-closed PR #1740
(`agent/mind/runtime-v1-m19`). That branch built Runtime v1 milestone work
on top of an older `main`, but a parallel session independently landed most
of the same issues (#1302, #1338, #1194, #1195) directly on `main` via
PRs #1736/#1737/etc — confirmed identical in content by diff. PR #1740 was
closed as superseded.

Four items from that closed branch were **not** duplicated on `main` and are
still real, needed work. This PR cherry-picks exactly those five commits
(in dependency order) onto current `main`:

- **#1295** — capability-facing runtime API surface
  (`capability_api.rs`, `event.rs`): `create_operation` / `attach_content` /
  `query_projection` / `emit_event` are real; `instantiate_context` is
  honestly stubbed pending #1197.
- **#1217** — purge/destroy mechanism, condition 8 enforcement
  (`destroy_content_conformance.rs` + `ContentStore::remove` secure erase:
  zero+0xFF overwrite, fsync, unlink; `ContentLedgerProjection`).
- **#1223** — type system (`ontology.rs`: primitives / archetypes /
  ontology, additive design).
- **#1287** — conformance suite aggregator
  (`scripts/run-mind-conformance-suite.sh`), structural discovery of any
  `rust/*/tests/*conformance*.rs` file.
- **#1294** — wires the conformance suite + benchmark gate into
  `.github/workflows/rust-core.yml`, plus `benchmark_gate_conformance.rs`.

## Notes

- All 5 cherry-picks applied **cleanly** onto current `main` — no conflicts,
  despite `main`'s `rust/airo_mind_core` having diverged history from the
  independently-landed #1302/#1338/#1194/#1195 work.
- `cargo build --workspace`: clean.
- `cargo test -p airo_mind_core`: 138 unit tests + all conformance test
  binaries (capability, destroy_content, operation_log_and_projection,
  supervisor, type_system, benchmark_gate) — **all passing**, 174 tests
  total, 0 failures.
- `scripts/run-mind-conformance-suite.sh`: all discovered conformance tests
  pass. It reports suite `S5` has no tagged conformance test yet — this is
  a **pre-existing, documented** condition in the script itself (depends on
  runtime surfaces not yet available), not a regression introduced here.

## Test plan

- [x] `cargo build --workspace` succeeds
- [x] `cargo test -p airo_mind_core` — 174/174 passing
- [x] `scripts/run-mind-conformance-suite.sh` — all discovered tests pass
- [x] Verified via diff that #1302/#1338/#1194/#1195 content is not
      re-duplicated by this PR (only the four non-duplicate items above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
