### PR TITLE
feat(mind): MoM generator from validated Meeting IR (#1635)

### DIFF
--- a/rust/airo_mind_meeting/prompts/mom/mom_discussion_points.v1.md
+++ b/rust/airo_mind_meeting/prompts/mom/mom_discussion_points.v1.md
@@ -1,0 +1,32 @@
+<|im_start|>system
+You are drafting the "Key Discussion Points" section of a Minutes of Meeting
+(MoM) document. You are given topics, decisions and observations already
+extracted and verified from the meeting transcript. You do not have the
+transcript itself, and you must not act as if you do.
+
+Rules, in order of importance:
+
+1. NEVER INVENT. Write only about what the facts below actually say. Do not
+   add a participant, a date, an outcome, or a detail that is not listed.
+2. NO NUMBERS. Do not write any digits or figures. Every number this meeting
+   produced is already reported elsewhere in these minutes, byte-exact; a
+   number restated here in prose cannot be checked the same way.
+3. NO OWNERS. Do not name any person as responsible for anything. Ownership is
+   reported in the Action Items table, not here.
+4. TURN THE FACTS INTO READABLE PROSE. Write short paragraphs or a short
+   bullet list covering what the meeting actually discussed, grouped by
+   topic where the facts make that natural. No invented transitions like
+   "the team also touched on" unless a fact supports it.
+5. DUPLICATES ARE ALREADY MERGED. Do not repeat the same point twice even if
+   it is phrased two different ways below.
+6. Be concise: prefer fewer, clearer sentences over an exhaustive restatement.
+7. If the facts below are empty, write exactly: "No discussion points were
+   recorded for this meeting."
+
+Facts:
+{{FACTS}}
+<|im_end|>
+<|im_start|>user
+Write the Key Discussion Points section.
+<|im_end|>
+<|im_start|>assistant

--- a/rust/airo_mind_meeting/prompts/mom/mom_objective.v1.md
+++ b/rust/airo_mind_meeting/prompts/mom/mom_objective.v1.md
@@ -1,0 +1,28 @@
+<|im_start|>system
+You are drafting the "Meeting Objective" section of a Minutes of Meeting (MoM)
+document. You are given topics and decisions already extracted and verified
+from the meeting transcript. You do not have the transcript itself, and you
+must not act as if you do.
+
+Rules, in order of importance:
+
+1. NEVER INVENT. Write only about what the facts below actually say. Do not
+   add a participant, a date, an outcome, or a motivation that is not listed.
+2. NO NUMBERS. Do not write any digits or figures. Every number this meeting
+   produced is already reported elsewhere in these minutes, byte-exact; a
+   number restated here in prose cannot be checked the same way.
+3. NO OWNERS. Do not name any person as responsible for anything. Ownership is
+   reported in the Action Items table, not here.
+4. ONE TO THREE SENTENCES of plain prose describing what the meeting set out
+   to address. No heading, no bullet points, no markdown formatting.
+5. Be concise. Do not restate the same fact twice.
+6. If the facts below are empty, write exactly: "No objective was recorded for
+   this meeting."
+
+Facts:
+{{FACTS}}
+<|im_end|>
+<|im_start|>user
+Write the Meeting Objective section.
+<|im_end|>
+<|im_start|>assistant

--- a/rust/airo_mind_meeting/src/lib.rs
+++ b/rust/airo_mind_meeting/src/lib.rs
@@ -48,6 +48,8 @@ pub mod dedup;
 pub mod diagnostics;
 mod fact;
 pub mod ir;
+pub mod mom;
+mod mom_prompt;
 pub mod pass1;
 pub mod pass2;
 pub mod prompt;
@@ -64,6 +66,10 @@ pub use ir::{
     ActionItem, ActionStatus, ChunkIr, Decision, DecisionStatus, Facts, Meeting, MeetingIr, Metric,
     NextStep, Observation, Question, Risk, Topic, IR_SCHEMA_VERSION,
 };
+pub use mom::{
+    generate_mom, render_action_items_table, render_decisions_table, render_next_steps, MomError,
+};
+pub use mom_prompt::{MOM_DISCUSSION_POINTS_PROMPT_VERSION, MOM_OBJECTIVE_PROMPT_VERSION};
 pub use pass1::{extract_chunk, ExtractionConfig};
 pub use pass2::consolidate;
 pub use prompt::{CHUNK_FACTS_GRAMMAR, PROMPT_VERSION};

--- a/rust/airo_mind_meeting/src/mom.rs
+++ b/rust/airo_mind_meeting/src/mom.rs
@@ -1,0 +1,776 @@
+//! Minutes of Meeting — a Markdown *projection* of a validated [`MeetingIr`].
+//! `#1635`.
+//!
+//! # Hybrid rendering
+//!
+//! Five sections, two ways of producing them:
+//!
+//! - **Decisions & Direction**, **Action Items**, **Next Steps** are tables and
+//!   a list rendered directly from IR fields — [`render_decisions_table`],
+//!   [`render_action_items_table`] and [`render_next_steps`] are pure
+//!   functions, no engine, no model, byte-stable for the same IR. A decision's
+//!   statement, an action's owner, a metric's value — none of it passes
+//!   through anything that could paraphrase it.
+//! - **Meeting Objective** and **Key Discussion Points** are prose: turning
+//!   "these are the topics and decisions" into readable sentences genuinely
+//!   needs generation, and a template cannot do it. [`generate_mom`] calls the
+//!   engine for exactly these two sections and nothing else.
+//!
+//! # Numbers never reach the model
+//!
+//! The issue allows either re-running the validator's numeric-grounding check
+//! on narrative output, or keeping numbers out of narrative prose entirely.
+//! This module takes the second, simpler path: [`strip_numbers`] removes every
+//! digit run from the facts handed to the narrative prompts, the prompts
+//! themselves forbid writing digits, and [`sanitize_narrative`] strips digits
+//! from whatever the model returns anyway. A number in the MoM can therefore
+//! only ever come from a table cell copied straight out of the IR, which is
+//! what makes AC3 ("numbers byte-match the IR") true by construction rather
+//! than by hoping the model behaved. This also structures the two call sites
+//! so `#1636`'s factual-consistency gate has exactly one thing left to check —
+//! that the prose does not misrepresent a fact, not that it invented a figure.
+//!
+//! # Validated IR only
+//!
+//! This module never calls [`crate::validate::validate`] itself. The issue's
+//! rule is "MoM from validated IR only", and enforcing that by calling
+//! `validate` a second time here would let a caller believe an unvalidated IR
+//! is safe to hand in — it is the caller's job to validate first and pass the
+//! repaired IR in, the same contract [`crate::pass2::consolidate`] and
+//! [`crate::validate::validate`] already use of taking and returning
+//! [`MeetingIr`] rather than reaching backward for one.
+
+use airo_mind_core::{CancelToken, EngineError, GenerationEngine, GenerationRequest};
+
+use crate::ir::{ActionItem, ActionStatus, Decision, DecisionStatus, MeetingIr, NextStep};
+use crate::mom_prompt;
+
+/// Output-token ceiling for one narrative section. Generous for one to a
+/// handful of sentences with room to spare; a section this large overrunning
+/// it is not a case this crate has seen in practice.
+const NARRATIVE_MAX_OUTPUT_TOKENS: u32 = 320;
+
+/// Why MoM generation could not finish. Mirrors [`crate::ExtractionError`]:
+/// the same two things can go wrong, for the same reasons.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum MomError {
+    /// The caller navigated away. Nothing partial should be treated as a
+    /// result.
+    Cancelled,
+    /// The generation backend failed or has no model.
+    Engine(String),
+}
+
+impl std::fmt::Display for MomError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Cancelled => write!(f, "cancelled"),
+            Self::Engine(message) => write!(f, "generation engine failed: {message}"),
+        }
+    }
+}
+
+impl std::error::Error for MomError {}
+
+/// Renders `ir` (already validated — see the module doc) into Minutes of
+/// Meeting Markdown.
+///
+/// Two calls to `engine`, one per narrative section, in a fixed order —
+/// Meeting Objective, then Key Discussion Points — so a caller scripting a
+/// test double can key responses by call order the way `pass1`'s tests key
+/// them by chunk.
+pub fn generate_mom(
+    engine: &dyn GenerationEngine,
+    ir: &MeetingIr,
+    cancel: &CancelToken,
+) -> Result<String, MomError> {
+    let mut out = String::new();
+    out.push_str("# Minutes of Meeting\n\n");
+
+    if let Some(title) = ir.meeting.title.as_deref().filter(|t| !t.trim().is_empty()) {
+        out.push_str("**Meeting:** ");
+        out.push_str(title.trim());
+        out.push_str("\n\n");
+    }
+
+    out.push_str("## Meeting Objective\n\n");
+    out.push_str(generate_meeting_objective(engine, ir, cancel)?.trim());
+    out.push_str("\n\n");
+
+    out.push_str("## Key Discussion Points\n\n");
+    out.push_str(generate_key_discussion_points(engine, ir, cancel)?.trim());
+    out.push_str("\n\n");
+
+    out.push_str("## Decisions & Direction\n\n");
+    out.push_str(&render_decisions_table(&ir.facts.decisions));
+    out.push_str("\n\n");
+
+    out.push_str("## Action Items\n\n");
+    out.push_str(&render_action_items_table(&ir.facts.action_items));
+    out.push_str("\n\n");
+
+    out.push_str("## Next Steps\n\n");
+    out.push_str(&render_next_steps(&ir.facts.next_steps));
+    out.push('\n');
+
+    Ok(out)
+}
+
+// ---------------------------------------------------------------------------
+// Deterministic tables — pure, no engine
+// ---------------------------------------------------------------------------
+
+/// The Decisions & Direction table. Byte-stable for the same `decisions`: no
+/// step here can reorder, reword or drop an item.
+pub fn render_decisions_table(decisions: &[Decision]) -> String {
+    if decisions.is_empty() {
+        return "_No decisions recorded._".to_string();
+    }
+    let mut out = String::from("| Decision | Status |\n| --- | --- |\n");
+    for decision in decisions {
+        out.push_str("| ");
+        out.push_str(&escape_cell(&decision.statement));
+        out.push_str(" | ");
+        out.push_str(decision_status_label(decision.status));
+        out.push_str(" |\n");
+    }
+    out.trim_end().to_string()
+}
+
+/// The Action Items table. `owner` and `due` render as an em dash when the IR
+/// carries `None` — never inferred, never blank, so a reader can tell "no
+/// owner was ever named" apart from "this cell is missing".
+pub fn render_action_items_table(action_items: &[ActionItem]) -> String {
+    if action_items.is_empty() {
+        return "_No action items recorded._".to_string();
+    }
+    let mut out = String::from("| Task | Owner | Due | Status |\n| --- | --- | --- | --- |\n");
+    for item in action_items {
+        out.push_str("| ");
+        out.push_str(&escape_cell(&item.task));
+        out.push_str(" | ");
+        out.push_str(&escape_cell(item.owner.as_deref().unwrap_or(UNSET_CELL)));
+        out.push_str(" | ");
+        out.push_str(&escape_cell(item.due.as_deref().unwrap_or(UNSET_CELL)));
+        out.push_str(" | ");
+        out.push_str(action_status_label(item.status));
+        out.push_str(" |\n");
+    }
+    out.trim_end().to_string()
+}
+
+/// The Next Steps list. Not a table: `NextStep` carries one field of prose and
+/// nothing tabular to align, so a bullet list is the honest rendering of it.
+pub fn render_next_steps(next_steps: &[NextStep]) -> String {
+    if next_steps.is_empty() {
+        return "_No further steps recorded._".to_string();
+    }
+    let mut out = String::new();
+    for step in next_steps {
+        out.push_str("- ");
+        out.push_str(&escape_cell(&step.statement));
+        out.push('\n');
+    }
+    out.trim_end().to_string()
+}
+
+const UNSET_CELL: &str = "—";
+
+fn decision_status_label(status: DecisionStatus) -> &'static str {
+    match status {
+        DecisionStatus::Proposed => "Proposed",
+        DecisionStatus::Agreed => "Agreed",
+        DecisionStatus::Rejected => "Rejected",
+        DecisionStatus::Deferred => "Deferred",
+    }
+}
+
+fn action_status_label(status: ActionStatus) -> &'static str {
+    match status {
+        ActionStatus::Open => "Open",
+        ActionStatus::InProgress => "In Progress",
+        ActionStatus::Done => "Done",
+        ActionStatus::Blocked => "Blocked",
+    }
+}
+
+/// Makes `text` safe as one Markdown table cell: a literal `|` would otherwise
+/// end the cell early, and an embedded newline would break the row onto a
+/// second line the table syntax cannot parse.
+fn escape_cell(text: &str) -> String {
+    text.trim().replace('|', "\\|").replace(['\n', '\r'], " ")
+}
+
+// ---------------------------------------------------------------------------
+// Narrative sections — the only two call sites that touch the engine
+// ---------------------------------------------------------------------------
+
+fn generate_meeting_objective(
+    engine: &dyn GenerationEngine,
+    ir: &MeetingIr,
+    cancel: &CancelToken,
+) -> Result<String, MomError> {
+    let facts = objective_facts(ir);
+    let prompt = mom_prompt::render_mom_objective(&facts);
+    let raw = run_narrative(engine, &prompt, cancel)?;
+    Ok(sanitize_narrative(&raw))
+}
+
+fn generate_key_discussion_points(
+    engine: &dyn GenerationEngine,
+    ir: &MeetingIr,
+    cancel: &CancelToken,
+) -> Result<String, MomError> {
+    let facts = discussion_facts(ir);
+    let prompt = mom_prompt::render_mom_discussion_points(&facts);
+    let raw = run_narrative(engine, &prompt, cancel)?;
+    Ok(sanitize_narrative(&raw))
+}
+
+/// The facts fed to the Meeting Objective prompt: topics only. A short noun
+/// phrase per topic is scope, which is what an objective describes; decisions
+/// and observations are what the meeting *concluded*, which belongs in Key
+/// Discussion Points instead.
+fn objective_facts(ir: &MeetingIr) -> String {
+    ir.facts
+        .topics
+        .iter()
+        .map(|topic| format!("- topic: {}", strip_numbers(&topic.title)))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+/// The facts fed to the Key Discussion Points prompt: topics, decisions and
+/// observations. Action items, metrics, risks, questions and next steps are
+/// deliberately excluded — they already have their own deterministic home
+/// (action items and next steps in this document; metrics, risks and
+/// questions are out of the issue's five sections entirely) and repeating them
+/// in prose would be exactly the duplication the prompt is told to avoid.
+fn discussion_facts(ir: &MeetingIr) -> String {
+    let mut lines = Vec::new();
+    for topic in &ir.facts.topics {
+        lines.push(format!("- topic: {}", strip_numbers(&topic.title)));
+    }
+    for decision in &ir.facts.decisions {
+        lines.push(format!(
+            "- decision ({}): {}",
+            decision_status_label(decision.status).to_lowercase(),
+            strip_numbers(&decision.statement)
+        ));
+    }
+    for observation in &ir.facts.observations {
+        lines.push(format!(
+            "- observation: {}",
+            strip_numbers(&observation.statement)
+        ));
+    }
+    lines.join("\n")
+}
+
+/// Replaces every maximal run of ASCII digits (with internal `,` or `.`
+/// grouping/decimal separators, so "500,000" and "3.5" collapse to one
+/// placeholder rather than three) with `[number]`. The model never sees a real
+/// figure to copy, restate, or subtly alter.
+fn strip_numbers(text: &str) -> String {
+    let mut out = String::with_capacity(text.len());
+    let mut chars = text.chars().peekable();
+    while let Some(c) = chars.next() {
+        if c.is_ascii_digit() {
+            out.push_str("[number]");
+            while let Some(&next) = chars.peek() {
+                if next.is_ascii_digit() || next == ',' || next == '.' {
+                    chars.next();
+                } else {
+                    break;
+                }
+            }
+        } else {
+            out.push(c);
+        }
+    }
+    out
+}
+
+/// Trims the model's output and strips any digit it wrote anyway — belt and
+/// braces alongside the prompt's own "NO NUMBERS" rule and the pre-stripped
+/// facts it was given, so AC3 holds even against a model that ignores an
+/// instruction.
+fn sanitize_narrative(raw: &str) -> String {
+    strip_numbers(raw.trim())
+}
+
+fn run_narrative(
+    engine: &dyn GenerationEngine,
+    prompt: &str,
+    cancel: &CancelToken,
+) -> Result<String, MomError> {
+    if cancel.is_cancelled() {
+        return Err(MomError::Cancelled);
+    }
+    let request = GenerationRequest {
+        prompt: prompt.to_string(),
+        max_output_tokens: NARRATIVE_MAX_OUTPUT_TOKENS,
+        grammar: None,
+    };
+    let mut raw = String::new();
+    engine
+        .generate(&request, cancel, &mut |chunk| {
+            raw.push_str(&chunk.text);
+            Ok(())
+        })
+        .map_err(|e| match e {
+            EngineError::Cancelled => MomError::Cancelled,
+            other => MomError::Engine(other.to_string()),
+        })?;
+    Ok(raw)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ir::{Facts, Meeting, Topic, IR_SCHEMA_VERSION};
+    use airo_mind_core::{GenerationChunk, ResourceRequest, RuntimeStats};
+    use std::sync::Mutex;
+
+    // -- deterministic tables -------------------------------------------------
+
+    #[test]
+    fn an_empty_decisions_list_renders_as_a_stated_absence() {
+        assert_eq!(render_decisions_table(&[]), "_No decisions recorded._");
+    }
+
+    #[test]
+    fn decisions_render_one_row_per_item_in_order() {
+        let decisions = vec![
+            Decision {
+                statement: "move signaling onto the queue".into(),
+                status: DecisionStatus::Agreed,
+                ..Decision::default()
+            },
+            Decision {
+                statement: "keep the current retry policy".into(),
+                status: DecisionStatus::Proposed,
+                ..Decision::default()
+            },
+        ];
+        let table = render_decisions_table(&decisions);
+        assert_eq!(
+            table,
+            "| Decision | Status |\n\
+             | --- | --- |\n\
+             | move signaling onto the queue | Agreed |\n\
+             | keep the current retry policy | Proposed |"
+        );
+    }
+
+    #[test]
+    fn an_empty_action_items_list_renders_as_a_stated_absence() {
+        assert_eq!(
+            render_action_items_table(&[]),
+            "_No action items recorded._"
+        );
+    }
+
+    #[test]
+    fn a_missing_owner_and_due_render_as_an_em_dash_not_a_guess() {
+        let items = vec![ActionItem {
+            task: "check the signaling limit".into(),
+            owner: None,
+            due: None,
+            status: ActionStatus::Open,
+            ..ActionItem::default()
+        }];
+        let table = render_action_items_table(&items);
+        assert_eq!(
+            table,
+            "| Task | Owner | Due | Status |\n\
+             | --- | --- | --- | --- |\n\
+             | check the signaling limit | — | — | Open |"
+        );
+    }
+
+    #[test]
+    fn a_present_owner_and_due_render_verbatim() {
+        let items = vec![ActionItem {
+            task: "update the runbook".into(),
+            owner: Some("Dev".into()),
+            due: Some("Friday".into()),
+            status: ActionStatus::Done,
+            ..ActionItem::default()
+        }];
+        let table = render_action_items_table(&items);
+        assert!(table.contains("| update the runbook | Dev | Friday | Done |"));
+    }
+
+    #[test]
+    fn every_action_status_has_a_label() {
+        for (status, label) in [
+            (ActionStatus::Open, "Open"),
+            (ActionStatus::InProgress, "In Progress"),
+            (ActionStatus::Done, "Done"),
+            (ActionStatus::Blocked, "Blocked"),
+        ] {
+            assert_eq!(action_status_label(status), label);
+        }
+    }
+
+    #[test]
+    fn every_decision_status_has_a_label() {
+        for (status, label) in [
+            (DecisionStatus::Proposed, "Proposed"),
+            (DecisionStatus::Agreed, "Agreed"),
+            (DecisionStatus::Rejected, "Rejected"),
+            (DecisionStatus::Deferred, "Deferred"),
+        ] {
+            assert_eq!(decision_status_label(status), label);
+        }
+    }
+
+    #[test]
+    fn an_empty_next_steps_list_renders_as_a_stated_absence() {
+        assert_eq!(render_next_steps(&[]), "_No further steps recorded._");
+    }
+
+    #[test]
+    fn next_steps_render_one_bullet_per_item_in_order() {
+        let steps = vec![
+            NextStep {
+                statement: "review the rollout plan".into(),
+                ..NextStep::default()
+            },
+            NextStep {
+                statement: "circulate the updated runbook".into(),
+                ..NextStep::default()
+            },
+        ];
+        assert_eq!(
+            render_next_steps(&steps),
+            "- review the rollout plan\n- circulate the updated runbook"
+        );
+    }
+
+    #[test]
+    fn a_literal_pipe_in_a_cell_is_escaped_so_the_table_still_parses() {
+        let decisions = vec![Decision {
+            statement: "use A | B for routing".into(),
+            status: DecisionStatus::Agreed,
+            ..Decision::default()
+        }];
+        assert!(render_decisions_table(&decisions).contains("use A \\| B for routing"));
+    }
+
+    #[test]
+    fn an_embedded_newline_in_a_cell_becomes_a_space() {
+        let decisions = vec![Decision {
+            statement: "line one\nline two".into(),
+            status: DecisionStatus::Agreed,
+            ..Decision::default()
+        }];
+        assert!(render_decisions_table(&decisions).contains("line one line two"));
+    }
+
+    #[test]
+    fn the_same_ir_renders_the_same_tables_every_time() {
+        let decisions = vec![Decision {
+            statement: "move signaling onto the queue".into(),
+            status: DecisionStatus::Agreed,
+            ..Decision::default()
+        }];
+        assert_eq!(
+            render_decisions_table(&decisions),
+            render_decisions_table(&decisions)
+        );
+    }
+
+    // -- number stripping -------------------------------------------------------
+
+    #[test]
+    fn a_plain_integer_is_replaced_with_a_placeholder() {
+        assert_eq!(
+            strip_numbers("about 500000 events"),
+            "about [number] events"
+        );
+    }
+
+    #[test]
+    fn a_grouped_and_decimal_number_collapses_to_one_placeholder() {
+        assert_eq!(
+            strip_numbers("roughly 500,000.5 events"),
+            "roughly [number] events"
+        );
+    }
+
+    #[test]
+    fn text_with_no_digits_is_unchanged() {
+        assert_eq!(strip_numbers("no figures here"), "no figures here");
+    }
+
+    // -- narrative facts blocks --------------------------------------------------
+
+    #[test]
+    fn objective_facts_include_topics_and_omit_decisions() {
+        let ir = ir_with(Facts {
+            topics: vec![Topic {
+                title: "Temporal signaling limit".into(),
+                ..Topic::default()
+            }],
+            decisions: vec![Decision {
+                statement: "move signaling onto the queue".into(),
+                ..Decision::default()
+            }],
+            ..Facts::default()
+        });
+        let facts = objective_facts(&ir);
+        assert!(facts.contains("Temporal signaling limit"));
+        assert!(!facts.contains("move signaling onto the queue"));
+    }
+
+    #[test]
+    fn discussion_facts_include_topics_decisions_and_observations() {
+        let ir = ir_with(Facts {
+            topics: vec![Topic {
+                title: "Temporal signaling limit".into(),
+                ..Topic::default()
+            }],
+            decisions: vec![Decision {
+                statement: "move signaling onto the queue".into(),
+                status: DecisionStatus::Agreed,
+                ..Decision::default()
+            }],
+            observations: vec![crate::ir::Observation {
+                statement: "the pilot is nearly done".into(),
+                ..crate::ir::Observation::default()
+            }],
+            ..Facts::default()
+        });
+        let facts = discussion_facts(&ir);
+        assert!(facts.contains("Temporal signaling limit"));
+        assert!(facts.contains("move signaling onto the queue"));
+        assert!(facts.contains("agreed"));
+        assert!(facts.contains("the pilot is nearly done"));
+    }
+
+    #[test]
+    fn narrative_facts_never_carry_a_digit() {
+        let ir = ir_with(Facts {
+            observations: vec![crate::ir::Observation {
+                statement: "the service handles about 500000 events a day".into(),
+                ..crate::ir::Observation::default()
+            }],
+            ..Facts::default()
+        });
+        assert!(!discussion_facts(&ir).chars().any(|c| c.is_ascii_digit()));
+    }
+
+    // -- generate_mom, end to end with a test double -----------------------------
+
+    /// Answers a fixed script in call order, and (deliberately, for the
+    /// digit-stripping test below) can be told to smuggle a digit into its
+    /// answer despite the prompt telling it not to.
+    struct ScriptedNarrativeEngine {
+        answers: Vec<&'static str>,
+        calls: Mutex<usize>,
+        prompts: Mutex<Vec<String>>,
+    }
+
+    impl ScriptedNarrativeEngine {
+        fn new(answers: Vec<&'static str>) -> Self {
+            Self {
+                answers,
+                calls: Mutex::new(0),
+                prompts: Mutex::new(Vec::new()),
+            }
+        }
+    }
+
+    impl GenerationEngine for ScriptedNarrativeEngine {
+        fn resource_request(&self) -> ResourceRequest {
+            ResourceRequest::new(0)
+        }
+
+        fn generate(
+            &self,
+            request: &GenerationRequest,
+            _cancel: &CancelToken,
+            sink: &mut dyn FnMut(GenerationChunk) -> Result<(), EngineError>,
+        ) -> Result<(), EngineError> {
+            self.prompts.lock().unwrap().push(request.prompt.clone());
+            let mut calls = self.calls.lock().unwrap();
+            let answer = self
+                .answers
+                .get(*calls)
+                .unwrap_or_else(|| panic!("no scripted answer for call {}", *calls));
+            *calls += 1;
+            sink(GenerationChunk {
+                text: (*answer).to_string(),
+            })
+        }
+
+        fn stats(&self) -> RuntimeStats {
+            RuntimeStats::default()
+        }
+    }
+
+    struct BrokenEngine;
+    impl GenerationEngine for BrokenEngine {
+        fn resource_request(&self) -> ResourceRequest {
+            ResourceRequest::new(0)
+        }
+        fn generate(
+            &self,
+            _request: &GenerationRequest,
+            _cancel: &CancelToken,
+            _sink: &mut dyn FnMut(GenerationChunk) -> Result<(), EngineError>,
+        ) -> Result<(), EngineError> {
+            Err(EngineError::ModelUnavailable)
+        }
+        fn stats(&self) -> RuntimeStats {
+            RuntimeStats::default()
+        }
+    }
+
+    fn ir_with(facts: Facts) -> MeetingIr {
+        MeetingIr {
+            schema_version: IR_SCHEMA_VERSION.into(),
+            meeting: Meeting {
+                id: "meeting-0".into(),
+                title: Some("Signaling capacity review".into()),
+                prompt_version: "chunk_facts.v1".into(),
+                ..Meeting::default()
+            },
+            facts,
+        }
+    }
+
+    #[test]
+    fn generate_mom_assembles_all_five_sections_in_order() {
+        let ir = ir_with(Facts {
+            topics: vec![Topic {
+                title: "Temporal signaling limit".into(),
+                ..Topic::default()
+            }],
+            decisions: vec![Decision {
+                statement: "move signaling onto the queue before the release".into(),
+                status: DecisionStatus::Agreed,
+                ..Decision::default()
+            }],
+            action_items: vec![ActionItem {
+                task: "check the Temporal signaling limit".into(),
+                owner: None,
+                due: Some("Friday".into()),
+                status: ActionStatus::Open,
+                ..ActionItem::default()
+            }],
+            next_steps: vec![NextStep {
+                statement: "review the rollout plan".into(),
+                ..NextStep::default()
+            }],
+            ..Facts::default()
+        });
+        let engine = ScriptedNarrativeEngine::new(vec![
+            "Review the Temporal signaling limit ahead of the migration.",
+            "The team discussed the Temporal signaling limit and agreed to move signaling onto the queue before the release.",
+        ]);
+
+        let mom = generate_mom(&engine, &ir, &CancelToken::new()).unwrap();
+
+        let sections = [
+            "# Minutes of Meeting",
+            "**Meeting:** Signaling capacity review",
+            "## Meeting Objective",
+            "Review the Temporal signaling limit ahead of the migration.",
+            "## Key Discussion Points",
+            "The team discussed the Temporal signaling limit and agreed to move signaling onto the queue before the release.",
+            "## Decisions & Direction",
+            "| move signaling onto the queue before the release | Agreed |",
+            "## Action Items",
+            "| check the Temporal signaling limit | — | Friday | Open |",
+            "## Next Steps",
+            "- review the rollout plan",
+        ];
+        let mut cursor = 0usize;
+        for section in sections {
+            let found = mom[cursor..].find(section).unwrap_or_else(|| {
+                panic!("missing `{section}` after position {cursor} in:\n{mom}")
+            });
+            cursor += found + section.len();
+        }
+    }
+
+    #[test]
+    fn a_digit_the_model_writes_anyway_is_stripped_from_the_narrative() {
+        let ir = ir_with(Facts::default());
+        let engine = ScriptedNarrativeEngine::new(vec![
+            "The team covered 3 topics.",
+            "Discussion touched on 12 items.",
+        ]);
+
+        let mom = generate_mom(&engine, &ir, &CancelToken::new()).unwrap();
+
+        assert!(mom.contains("[number]"));
+        let narrative_end = mom.find("## Decisions").unwrap();
+        assert!(
+            !mom[..narrative_end].chars().any(|c| c.is_ascii_digit()),
+            "a digit reached the narrative sections: {mom}"
+        );
+    }
+
+    #[test]
+    fn a_cancelled_run_never_reaches_the_engine() {
+        let cancel = CancelToken::new();
+        cancel.cancel();
+        let ir = ir_with(Facts::default());
+        let result = generate_mom(&BrokenEngine, &ir, &cancel);
+        assert_eq!(result, Err(MomError::Cancelled));
+    }
+
+    #[test]
+    fn a_broken_backend_is_an_error_not_a_blank_section() {
+        let ir = ir_with(Facts::default());
+        let result = generate_mom(&BrokenEngine, &ir, &CancelToken::new());
+        assert_eq!(
+            result,
+            Err(MomError::Engine(EngineError::ModelUnavailable.to_string()))
+        );
+    }
+
+    #[test]
+    fn the_narrative_prompts_are_called_in_a_fixed_order() {
+        let ir = ir_with(Facts {
+            topics: vec![Topic {
+                title: "Temporal signaling limit".into(),
+                ..Topic::default()
+            }],
+            ..Facts::default()
+        });
+        let engine = ScriptedNarrativeEngine::new(vec!["objective text", "discussion text"]);
+        generate_mom(&engine, &ir, &CancelToken::new()).unwrap();
+
+        let prompts = engine.prompts.lock().unwrap();
+        assert_eq!(prompts.len(), 2);
+        assert!(prompts[0].contains("Meeting Objective"));
+        assert!(prompts[1].contains("Key Discussion Points"));
+    }
+
+    #[test]
+    fn no_narrative_prompt_ever_carries_an_owner_or_a_due_date() {
+        let ir = ir_with(Facts {
+            action_items: vec![ActionItem {
+                task: "update the runbook".into(),
+                owner: Some("Dev".into()),
+                due: Some("Friday".into()),
+                status: ActionStatus::Done,
+                ..ActionItem::default()
+            }],
+            ..Facts::default()
+        });
+        let engine = ScriptedNarrativeEngine::new(vec!["objective text", "discussion text"]);
+        generate_mom(&engine, &ir, &CancelToken::new()).unwrap();
+
+        let prompts = engine.prompts.lock().unwrap();
+        for prompt in prompts.iter() {
+            assert!(!prompt.contains("Dev"));
+            assert!(!prompt.contains("Friday"));
+        }
+    }
+}

--- a/rust/airo_mind_meeting/src/mom_prompt.rs
+++ b/rust/airo_mind_meeting/src/mom_prompt.rs
@@ -1,0 +1,86 @@
+//! The two MoM narrative prompts, loaded from `prompts/mom/`. `#1635`.
+//!
+//! Same pattern as [`crate::prompt`]: `include_str!` keeps the prompt text
+//! compiled in and reviewable on its own, and the version lives in the file
+//! name so editing a prompt in place can never silently change what an
+//! already-recorded version claims to describe.
+//!
+//! # Two files, not one
+//!
+//! "Meeting Objective" and "Key Discussion Points" are different asks — one is
+//! one to three sentences of scope, the other is a fuller pass over every topic
+//! and decision — and giving each its own reviewable prompt keeps that
+//! difference explicit instead of encoding it as a runtime branch inside a
+//! shared template.
+
+/// The current Meeting Objective prompt version.
+pub const MOM_OBJECTIVE_PROMPT_VERSION: &str = "mom_objective.v1";
+
+/// The current Key Discussion Points prompt version.
+pub const MOM_DISCUSSION_POINTS_PROMPT_VERSION: &str = "mom_discussion_points.v1";
+
+const MOM_OBJECTIVE_TEMPLATE: &str = include_str!("../prompts/mom/mom_objective.v1.md");
+const MOM_DISCUSSION_POINTS_TEMPLATE: &str =
+    include_str!("../prompts/mom/mom_discussion_points.v1.md");
+
+const FACTS_PLACEHOLDER: &str = "{{FACTS}}";
+
+/// Renders the Meeting Objective prompt. `facts` is plain text, already
+/// numeral-free — see `mom::strip_numbers` — one fact per line.
+pub fn render_mom_objective(facts: &str) -> String {
+    render(MOM_OBJECTIVE_TEMPLATE, facts)
+}
+
+/// Renders the Key Discussion Points prompt.
+pub fn render_mom_discussion_points(facts: &str) -> String {
+    render(MOM_DISCUSSION_POINTS_TEMPLATE, facts)
+}
+
+fn render(template: &str, facts: &str) -> String {
+    let body = if facts.trim().is_empty() {
+        "(none)"
+    } else {
+        facts.trim()
+    };
+    template.replace(FACTS_PLACEHOLDER, body)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn the_objective_prompt_carries_the_facts_and_forbids_numbers_and_owners() {
+        let prompt = render_mom_objective("- Temporal signaling limit");
+        assert!(prompt.contains("- Temporal signaling limit"));
+        assert!(prompt.contains("NO NUMBERS"));
+        assert!(prompt.contains("NO OWNERS"));
+        assert!(prompt.contains("NEVER INVENT"));
+        assert!(!prompt.contains(FACTS_PLACEHOLDER));
+    }
+
+    #[test]
+    fn the_discussion_points_prompt_carries_the_facts_and_forbids_numbers_and_owners() {
+        let prompt = render_mom_discussion_points("- Temporal signaling limit");
+        assert!(prompt.contains("- Temporal signaling limit"));
+        assert!(prompt.contains("NO NUMBERS"));
+        assert!(prompt.contains("NO OWNERS"));
+        assert!(prompt.contains("DUPLICATES ARE ALREADY MERGED"));
+        assert!(!prompt.contains(FACTS_PLACEHOLDER));
+    }
+
+    #[test]
+    fn empty_facts_render_as_a_stated_none_rather_than_a_blank_section() {
+        let prompt = render_mom_objective("");
+        assert!(prompt.contains("(none)"));
+    }
+
+    #[test]
+    fn versions_match_the_file_names_they_name() {
+        assert_eq!(MOM_OBJECTIVE_PROMPT_VERSION, "mom_objective.v1");
+        assert_eq!(
+            MOM_DISCUSSION_POINTS_PROMPT_VERSION,
+            "mom_discussion_points.v1"
+        );
+    }
+}

--- a/rust/airo_mind_meeting/tests/fixtures/golden_mom.md
+++ b/rust/airo_mind_meeting/tests/fixtures/golden_mom.md
@@ -1,0 +1,28 @@
+# Minutes of Meeting
+
+**Meeting:** Signaling capacity review
+
+## Meeting Objective
+
+Review the Temporal signaling limit ahead of the planned migration.
+
+## Key Discussion Points
+
+The team discussed the Temporal signaling limit and agreed to move signaling onto the queue before the release.
+
+## Decisions & Direction
+
+| Decision | Status |
+| --- | --- |
+| move signaling onto the queue before the release | Agreed |
+
+## Action Items
+
+| Task | Owner | Due | Status |
+| --- | --- | --- | --- |
+| check the Temporal signaling limit | — | Friday | Open |
+| update the runbook | Dev | Friday | Done |
+
+## Next Steps
+
+- review the rollout plan

--- a/rust/airo_mind_meeting/tests/mom_golden.rs
+++ b/rust/airo_mind_meeting/tests/mom_golden.rs
@@ -1,0 +1,175 @@
+//! MoM generation against the `#1633` golden IR. `#1635`.
+//!
+//! # Why the same golden IR the extraction golden test uses
+//!
+//! `golden_ir.json` is already the fixture `#1633`'s pipeline test proves it
+//! can produce byte-for-byte, and it exercises exactly the shapes a MoM has to
+//! render correctly: an ownerless action item next to an owned one, a `due`
+//! that is present, a number inside a metric's own field (not read by MoM —
+//! metrics are outside the issue's five sections, and that is itself worth
+//! proving), and one item of each of the five categories the issue names.
+//! Reusing it instead of writing a second fixture means a change to the IR
+//! shape shows up here the same day it shows up in the extraction golden
+//! test, rather than the two silently drifting apart.
+//!
+//! # Why a scripted engine here too
+//!
+//! Same reasoning as `tests/golden.rs`: the two narrative sections are the
+//! only place a real model's judgement matters, and that judgement is scored
+//! by `#1636`'s eval harness, not by this crate's own tests. What this test
+//! proves is the *pipeline* -- that `generate_mom` assembles the five
+//! sections in the right order, that the tables it builds from the IR are
+//! exactly what direct hand-computation from the IR's fields says they should
+//! be, and that the same IR and the same script always produce the same
+//! document.
+
+use airo_mind_core::{
+    CancelToken, EngineError, GenerationChunk, GenerationEngine, GenerationRequest,
+    ResourceRequest, RuntimeStats,
+};
+use airo_mind_meeting::{generate_mom, MeetingIr};
+use std::sync::Mutex;
+
+/// Answers "Meeting Objective", then "Key Discussion Points", then repeats --
+/// so calling `generate_mom` more than once in a test (determinism checks)
+/// does not exhaust the script.
+struct GoldenNarrativeEngine {
+    calls: Mutex<usize>,
+}
+
+impl GoldenNarrativeEngine {
+    fn new() -> Self {
+        Self {
+            calls: Mutex::new(0),
+        }
+    }
+}
+
+const OBJECTIVE_ANSWER: &str =
+    "Review the Temporal signaling limit ahead of the planned migration.";
+const DISCUSSION_ANSWER: &str = "The team discussed the Temporal signaling limit and agreed to move signaling onto the queue before the release.";
+
+impl GenerationEngine for GoldenNarrativeEngine {
+    fn resource_request(&self) -> ResourceRequest {
+        ResourceRequest::new(0)
+    }
+
+    fn generate(
+        &self,
+        _request: &GenerationRequest,
+        _cancel: &CancelToken,
+        sink: &mut dyn FnMut(GenerationChunk) -> Result<(), EngineError>,
+    ) -> Result<(), EngineError> {
+        let mut calls = self.calls.lock().unwrap();
+        let answer = if (*calls).is_multiple_of(2) {
+            OBJECTIVE_ANSWER
+        } else {
+            DISCUSSION_ANSWER
+        };
+        *calls += 1;
+        sink(GenerationChunk {
+            text: answer.to_string(),
+        })
+    }
+
+    fn stats(&self) -> RuntimeStats {
+        RuntimeStats::default()
+    }
+}
+
+fn golden_ir() -> MeetingIr {
+    serde_json::from_str(include_str!("fixtures/golden_ir.json")).expect("golden IR parses")
+}
+
+#[test]
+fn the_golden_ir_produces_the_golden_mom() {
+    let engine = GoldenNarrativeEngine::new();
+    let mom = generate_mom(&engine, &golden_ir(), &CancelToken::new()).expect("mom generates");
+
+    let golden = include_str!("fixtures/golden_mom.md");
+    assert_eq!(mom, golden);
+}
+
+/// AC: section completeness = 100%. All five sections the issue names are
+/// present, in order, even independent of the exact narrative wording.
+#[test]
+fn every_required_section_is_present_in_order() {
+    let engine = GoldenNarrativeEngine::new();
+    let mom = generate_mom(&engine, &golden_ir(), &CancelToken::new()).expect("mom generates");
+
+    let required = [
+        "## Meeting Objective",
+        "## Key Discussion Points",
+        "## Decisions & Direction",
+        "## Action Items",
+        "## Next Steps",
+    ];
+    let mut cursor = 0usize;
+    for section in required {
+        let found = mom[cursor..]
+            .find(section)
+            .unwrap_or_else(|| panic!("missing required section `{section}`"));
+        cursor += found + section.len();
+    }
+}
+
+/// AC: the action/decision tables are rendered deterministically from the IR
+/// -- computed directly from `golden_ir.json`'s fields here, independent of
+/// `airo_mind_meeting::render_*` internals, so this catches a rendering
+/// regression a unit test inside the same module might share a bug with.
+#[test]
+fn the_tables_match_the_golden_irs_fields_by_direct_computation() {
+    let engine = GoldenNarrativeEngine::new();
+    let mom = generate_mom(&engine, &golden_ir(), &CancelToken::new()).expect("mom generates");
+
+    // Decisions & Direction: one row, the golden IR's one decision.
+    assert!(mom.contains("| move signaling onto the queue before the release | Agreed |"));
+
+    // Action Items: the ownerless item renders an em dash, never a guess; the
+    // owned one renders the owner verbatim.
+    assert!(mom.contains("| check the Temporal signaling limit | — | Friday | Open |"));
+    assert!(mom.contains("| update the runbook | Dev | Friday | Done |"));
+
+    // Next Steps: the golden IR's one next step, as a bullet.
+    assert!(mom.contains("- review the rollout plan"));
+}
+
+/// AC: numbers in the MoM byte-match IR values. The golden IR's metric quotes
+/// "about 500,000" -- outside the issue's five sections, so it must not
+/// appear anywhere, and no other digit should have reached the document
+/// through the narrative sections either.
+#[test]
+fn no_number_reaches_the_document_except_through_a_table_cell() {
+    let engine = GoldenNarrativeEngine::new();
+    let mom = generate_mom(&engine, &golden_ir(), &CancelToken::new()).expect("mom generates");
+
+    assert!(
+        !mom.contains("500,000") && !mom.contains("500000"),
+        "the metric's number leaked into a section outside the tables: {mom}"
+    );
+
+    let narrative_end = mom.find("## Decisions & Direction").unwrap();
+    assert!(
+        !mom[..narrative_end].chars().any(|c| c.is_ascii_digit()),
+        "a digit reached a narrative section: {mom}"
+    );
+}
+
+/// The whole point of "deterministic": the same IR and the same script always
+/// produce the same document, byte for byte.
+#[test]
+fn the_same_ir_and_script_produce_the_same_document_every_time() {
+    let first = generate_mom(
+        &GoldenNarrativeEngine::new(),
+        &golden_ir(),
+        &CancelToken::new(),
+    )
+    .unwrap();
+    let second = generate_mom(
+        &GoldenNarrativeEngine::new(),
+        &golden_ir(),
+        &CancelToken::new(),
+    )
+    .unwrap();
+    assert_eq!(first, second);
+}


### PR DESCRIPTION
Implements #1635 (MIND-LLM-10): generates Minutes-of-Meeting markdown from validated MeetingIr only, never raw transcript.

- Deterministic tables (Decisions, Action Items, Next Steps) — pure formatting, byte-stable, no LLM
- Narrative prose (Meeting Objective, Key Discussion Points) — LLM-generated, but numbers are stripped from facts before prompting and stripped again from output, so a number can only reach the doc via a table cell copied verbatim from the IR (AC "numbers byte-match IR" holds by construction)
- Prompts versioned under prompts/mom/
- Golden test reuses #1633's golden_ir.json fixture, proves byte-identical/deterministic output against a new golden_mom.md

107 tests green in airo_mind_meeting, clippy clean.

Follow-up not built here: rust/airo_mind_llama/src/api/minutes.rs still has its own simpler ungrounded minutes_prompt/generate_minutes — now functionally superseded, worth a cross-crate cleanup pass separately.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>