### PR TITLE
feat(mind): markdown/Obsidian export -- transcripts as portable local files (#1663)

### DIFF
--- a/packages/feature_mind/lib/src/export/application/meeting_export_service.dart
+++ b/packages/feature_mind/lib/src/export/application/meeting_export_service.dart
@@ -1,0 +1,125 @@
+import 'package:core_workers/core_workers.dart';
+
+import '../../mind_service.dart';
+import '../../whisper/api/meetings.dart' as rust;
+import '../domain/meeting_export_models.dart';
+import '../domain/meeting_markdown_renderer.dart';
+
+/// Turns stored meetings into export bundles.
+///
+/// This is the seam #1657 and a future MoM-FFI-wiring issue land in without
+/// touching the renderer: [_buildInput] is the only place that reads off
+/// `MindService`, and today it can only fill [MeetingExportInput.momMarkdown]
+/// and `.actionItems` with nothing, because:
+///
+/// - `#1657` (Stage 2, in flight as of this writing) is what puts
+///   `decisions`/`action_items`/`metrics` onto the persisted `Meeting`
+///   record and exposes them to Dart. Until it lands there is no Dart-side
+///   action-item data to read.
+/// - MoM generation (`#1635`, landed) lives entirely in
+///   `rust/airo_mind_meeting`, an `rlib` with no FFI/cdylib surface — nothing
+///   in Dart can call it yet. Follow-up to file: "Wire
+///   `airo_mind_meeting`'s MoM generator through FFI (flutter_rust_bridge)
+///   so Dart can request minutes for a saved meeting" — until that exists,
+///   `momMarkdown` has nothing to be populated from either.
+///
+/// Once both exist, the fix here is two lines: fetch the fields in
+/// [_buildInput] and pass them into [MeetingExportInput]. Nothing in
+/// `meeting_markdown_renderer.dart` changes.
+class MeetingExportService {
+  const MeetingExportService(this._mindService);
+
+  final MindService _mindService;
+
+  /// Same policy as everywhere else in the repo: parsing/serialization past
+  /// ~50 KB moves off the main isolate via `runOffMain`
+  /// (`packages/core_workers`), not a screen-local `compute()`. A hard
+  /// character count on the transcript body approximates that threshold well
+  /// enough — rendering markdown is proportional to input size, not content.
+  static const _offMainThresholdChars = 50 * 1024;
+
+  /// Builds the export bundle for one meeting, or `null` if it no longer
+  /// exists (deleted between listing and export).
+  Future<MeetingExportBundle?> exportMeeting(String meetingId) async {
+    final input = await _buildInput(meetingId);
+    if (input == null) return null;
+    return _render(input);
+  }
+
+  /// Batch export: one bundle per meeting that still exists, same order as
+  /// [meetingIds]. Missing meetings are skipped rather than failing the
+  /// whole batch — the common case is "export everything", and one deleted
+  /// meeting should not block the rest.
+  Future<List<MeetingExportBundle>> exportMeetings(
+    List<String> meetingIds,
+  ) async {
+    final inputs = <MeetingExportInput>[];
+    for (final id in meetingIds) {
+      final input = await _buildInput(id);
+      if (input != null) inputs.add(input);
+    }
+    if (inputs.isEmpty) return const [];
+
+    final size = inputs.fold<int>(0, (sum, i) => sum + _approximateSize(i));
+    if (size > _offMainThresholdChars) {
+      return runOffMain(() => composeBatchExport(inputs));
+    }
+    return composeBatchExport(inputs);
+  }
+
+  Future<MeetingExportInput?> _buildInput(String meetingId) async {
+    final meeting = await _mindService.meeting(meetingId);
+    if (meeting == null) return null;
+
+    final doc = await _mindService.transcriptDocument(meetingId);
+    final lines = _linesFrom(doc);
+    final duration = _durationFrom(doc);
+
+    return MeetingExportInput(
+      meetingId: meeting.id,
+      title: meeting.title,
+      recordedAt: DateTime.fromMillisecondsSinceEpoch(
+        meeting.recordedAt.toInt(),
+      ),
+      duration: duration,
+      transcriptLines: lines,
+      fallbackTranscript: meeting.transcript,
+      // momMarkdown / actionItems: intentionally left unset. See the class
+      // doc comment for why, and what the follow-up wiring looks like.
+    );
+  }
+
+  static List<TranscriptExportLine> _linesFrom(
+    rust.TranscriptDocumentRecord? doc,
+  ) {
+    if (doc == null) return const [];
+    return [
+      for (final segment in doc.segments)
+        TranscriptExportLine(
+          startMs: segment.startMs.toInt(),
+          text: segment.text,
+        ),
+    ];
+  }
+
+  static Duration? _durationFrom(rust.TranscriptDocumentRecord? doc) {
+    if (doc == null || doc.segments.isEmpty) return null;
+    return Duration(milliseconds: doc.segments.last.endMs.toInt());
+  }
+
+  static int _approximateSize(MeetingExportInput input) {
+    var size =
+        input.fallbackTranscript.length + (input.momMarkdown?.length ?? 0);
+    for (final line in input.transcriptLines) {
+      size += line.text.length;
+    }
+    return size;
+  }
+
+  Future<MeetingExportBundle> _render(MeetingExportInput input) async {
+    if (_approximateSize(input) > _offMainThresholdChars) {
+      return runOffMain(() => composeMeetingExportBundle(input));
+    }
+    return composeMeetingExportBundle(input);
+  }
+}

--- a/packages/feature_mind/lib/src/export/data/meeting_export_gateway.dart
+++ b/packages/feature_mind/lib/src/export/data/meeting_export_gateway.dart
@@ -1,0 +1,114 @@
+import 'dart:convert';
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:file_picker/file_picker.dart';
+import 'package:flutter/foundation.dart' show kIsWeb;
+import 'package:path/path.dart' as p;
+import 'package:share_plus/share_plus.dart';
+
+import '../domain/meeting_export_models.dart';
+
+/// Where an export bundle ends up: on disk, or through the platform share
+/// sheet.
+///
+/// Mirrors `PlatformBackupDocumentGateway`
+/// (`feature_iptv/lib/application/platform_backup_document_gateway.dart`) —
+/// same injectable-function shape over the same two plugins, so the
+/// orchestration in `_save`/`_share` is swappable in a test without a
+/// platform channel. That existing gateway is this feature's house pattern
+/// for share-sheet + save-to-folder.
+typedef MeetingExportSaver =
+    Future<bool> Function(List<MeetingExportBundle> bundles);
+typedef MeetingExportSharer =
+    Future<bool> Function(List<MeetingExportBundle> bundles);
+
+abstract interface class MeetingExportGateway {
+  /// Writes every bundle to disk. Returns `false` if the user cancelled the
+  /// folder/file picker, or there was nothing to save.
+  Future<bool> saveToFolder(List<MeetingExportBundle> bundles);
+
+  /// Hands every bundle's files to the platform share sheet in one call.
+  Future<bool> share(List<MeetingExportBundle> bundles);
+}
+
+class PlatformMeetingExportGateway implements MeetingExportGateway {
+  const PlatformMeetingExportGateway({
+    this.saver = _save,
+    this.sharer = _share,
+  });
+
+  final MeetingExportSaver saver;
+  final MeetingExportSharer sharer;
+
+  @override
+  Future<bool> saveToFolder(List<MeetingExportBundle> bundles) =>
+      saver(bundles);
+
+  @override
+  Future<bool> share(List<MeetingExportBundle> bundles) => sharer(bundles);
+
+  /// Real folder-per-meeting on every platform with a filesystem the user can
+  /// browse. Browsers have no folder to write into, so on web this falls
+  /// back to one download per file, named `{folder}-{file}` so which meeting
+  /// it came from is still obvious once it lands in Downloads.
+  static Future<bool> _save(List<MeetingExportBundle> bundles) async {
+    if (bundles.isEmpty) return false;
+
+    if (kIsWeb) {
+      var savedAny = false;
+      for (final bundle in bundles) {
+        for (final entry in bundle.files.entries) {
+          final saved = await FilePicker.saveFile(
+            dialogTitle: 'Save ${bundle.folderName}/${entry.key}',
+            fileName: '${bundle.folderName}-${entry.key}',
+            bytes: Uint8List.fromList(utf8.encode(entry.value)),
+          );
+          savedAny = savedAny || saved != null;
+        }
+      }
+      return savedAny;
+    }
+
+    final root = await FilePicker.getDirectoryPath(
+      dialogTitle: bundles.length == 1
+          ? 'Choose a folder to export "${bundles.single.folderName}" into'
+          : 'Choose a folder to export ${bundles.length} meetings into',
+    );
+    if (root == null) return false;
+
+    for (final bundle in bundles) {
+      final dir = Directory(p.join(root, bundle.folderName));
+      await dir.create(recursive: true);
+      for (final entry in bundle.files.entries) {
+        await File(p.join(dir.path, entry.key)).writeAsString(entry.value);
+      }
+    }
+    return true;
+  }
+
+  /// One share-sheet invocation for every file across every bundle. Most
+  /// share targets have no concept of a folder, so files are flattened with
+  /// the meeting's folder name as a prefix rather than nested.
+  static Future<bool> _share(List<MeetingExportBundle> bundles) async {
+    if (bundles.isEmpty) return false;
+    final files = <XFile>[
+      for (final bundle in bundles)
+        for (final entry in bundle.files.entries)
+          XFile.fromData(
+            Uint8List.fromList(utf8.encode(entry.value)),
+            mimeType: 'text/markdown',
+            name: '${bundle.folderName}-${entry.key}',
+          ),
+    ];
+    final result = await SharePlus.instance.share(
+      ShareParams(
+        subject: bundles.length == 1
+            ? bundles.single.folderName
+            : '${bundles.length} meetings',
+        files: files,
+      ),
+    );
+    return result.status != ShareResultStatus.unavailable;
+  }
+}

--- a/packages/feature_mind/lib/src/export/domain/meeting_export_models.dart
+++ b/packages/feature_mind/lib/src/export/domain/meeting_export_models.dart
@@ -1,0 +1,119 @@
+import 'package:flutter/foundation.dart';
+
+/// One line of a rendered transcript body: the audio timestamp it started at,
+/// and the words said in that window.
+///
+/// Deliberately not `rust.TranscriptSegmentRecord` — the renderer in this
+/// directory is pure Dart with no Rust import, so it stays testable without a
+/// native library and reusable the day transcript storage changes shape.
+@immutable
+class TranscriptExportLine {
+  const TranscriptExportLine({required this.startMs, required this.text});
+
+  /// Milliseconds from the start of the recording.
+  final int startMs;
+  final String text;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is TranscriptExportLine &&
+          startMs == other.startMs &&
+          text == other.text;
+
+  @override
+  int get hashCode => Object.hash(startMs, text);
+}
+
+/// A task pulled out of a meeting, shaped for markdown export.
+///
+/// Deliberately not `airo_mind_meeting`'s `ActionItem` — that type lives on
+/// `MeetingIr` (Rust-only; `rust/airo_mind_meeting` is an `rlib`, not yet
+/// wired through FFI) and, once it is, will not reach Dart until #1657's
+/// `Meeting.action_items` field lands. This is the shape the renderer needs;
+/// mapping the real type onto this one is the whole connective change (see
+/// `meeting_export_service.dart`).
+@immutable
+class ExportActionItem {
+  const ExportActionItem({
+    required this.task,
+    this.owner,
+    this.due,
+    this.status,
+  });
+
+  final String task;
+  final String? owner;
+  final String? due;
+  final String? status;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is ExportActionItem &&
+          task == other.task &&
+          owner == other.owner &&
+          due == other.due &&
+          status == other.status;
+
+  @override
+  int get hashCode => Object.hash(task, owner, due, status);
+}
+
+/// Everything the renderer needs for one meeting. Built by
+/// `MeetingExportService` from `MindService`'s records; consumed only by pure
+/// functions in `meeting_markdown_renderer.dart`.
+@immutable
+class MeetingExportInput {
+  const MeetingExportInput({
+    required this.meetingId,
+    required this.title,
+    required this.recordedAt,
+    this.duration,
+    this.transcriptLines = const [],
+    this.fallbackTranscript = '',
+    this.momMarkdown,
+    this.actionItems = const [],
+  });
+
+  final String meetingId;
+  final String title;
+  final DateTime recordedAt;
+
+  /// Null when no transcript document exists to derive it from (a meeting
+  /// saved before `#1629`, or one whose document has no segments).
+  final Duration? duration;
+
+  /// Timestamped lines, when a `transcript.json` document is available.
+  final List<TranscriptExportLine> transcriptLines;
+
+  /// The flat transcript string every `MeetingRecord` carries. Used when
+  /// [transcriptLines] is empty, so a pre-`#1629` meeting still exports —
+  /// without timestamps, which is the honest degradation, not a blocker.
+  final String fallbackTranscript;
+
+  /// Minutes-of-Meeting markdown, already rendered (`rust/airo_mind_meeting`'s
+  /// `mom.rs` produces a complete document, action-items table included).
+  /// Null until MoM generation gets an FFI surface — see
+  /// `meeting_export_service.dart` for the concrete blocker.
+  final String? momMarkdown;
+
+  /// A standalone action-item list, used only when there is no
+  /// [momMarkdown] to carry its own table (or the caller wants a
+  /// dedicated `action-items.md`, e.g. for piping into a task manager).
+  final List<ExportActionItem> actionItems;
+}
+
+/// A folder-per-meeting export: a stable folder name and the markdown files
+/// that go in it (`transcript.md` always; `mom.md` and/or `action-items.md`
+/// when the data exists).
+@immutable
+class MeetingExportBundle {
+  const MeetingExportBundle({required this.folderName, required this.files});
+
+  final String folderName;
+
+  /// File name -> markdown contents. Ordered (insertion order preserved by
+  /// `Map` in Dart) so `transcript.md` renders/saves before `mom.md`.
+  final Map<String, String> files;
+}

--- a/packages/feature_mind/lib/src/export/domain/meeting_markdown_renderer.dart
+++ b/packages/feature_mind/lib/src/export/domain/meeting_markdown_renderer.dart
@@ -1,0 +1,202 @@
+import 'meeting_export_models.dart';
+
+/// Pure markdown rendering for meeting export (#1663).
+///
+/// Nothing in this file touches a plugin, `dart:io`, or a Rust binding —
+/// every function here is a `String Function(...)` so it is unit-testable
+/// directly, and safe to run on a worker isolate via `runOffMain`
+/// (`meeting_export_service.dart` does that once a transcript crosses ~50 KB,
+/// per the repo's parsing rule).
+
+/// `123456` ms -> `[00:02:03]`. Plain text, not an app deep link: a markdown
+/// file opened outside Airo has no `airo://` target to jump to (#1663 AC4 —
+/// evidence links degrade gracefully).
+String formatTimestamp(int ms) {
+  final totalSeconds = ms ~/ 1000;
+  final hours = totalSeconds ~/ 3600;
+  final minutes = (totalSeconds % 3600) ~/ 60;
+  final seconds = totalSeconds % 60;
+  return '[${_pad2(hours)}:${_pad2(minutes)}:${_pad2(seconds)}]';
+}
+
+String _pad2(int n) => n.toString().padLeft(2, '0');
+
+/// `1h 2m 3s` — human duration for frontmatter. Omits leading zero units so
+/// a five-minute meeting reads `5m 12s`, not `0h 5m 12s`.
+String formatDurationHms(Duration d) {
+  final hours = d.inHours;
+  final minutes = d.inMinutes % 60;
+  final seconds = d.inSeconds % 60;
+  final parts = <String>[
+    if (hours > 0) '${hours}h',
+    if (hours > 0 || minutes > 0) '${minutes}m',
+    '${seconds}s',
+  ];
+  return parts.join(' ');
+}
+
+/// YAML frontmatter block: `date`, `duration`, `title` — the fields Obsidian
+/// and most PKM tools index on out of the box (#1663 scope: "YAML
+/// frontmatter (date, duration, title) for PKM/Obsidian compatibility").
+String renderFrontmatter({
+  required String title,
+  required DateTime date,
+  Duration? duration,
+}) {
+  final buf = StringBuffer('---\n')
+    ..writeln('title: "${_escapeYaml(title)}"')
+    ..writeln('date: ${date.toUtc().toIso8601String()}');
+  if (duration != null) {
+    buf.writeln('duration: "${formatDurationHms(duration)}"');
+  }
+  buf.writeln('---');
+  return buf.toString();
+}
+
+String _escapeYaml(String s) =>
+    s.replaceAll('\\', r'\\').replaceAll('"', r'\"');
+
+/// `transcript.md`'s body: frontmatter, a heading, then the transcript.
+///
+/// Prefers timestamped [lines] (from `transcript.json`, `#1629`); falls back
+/// to [fallbackTranscript] — the flat string every `MeetingRecord` carries —
+/// for a meeting saved before that landed, or whose document has no
+/// segments. That fallback is the honest degradation this issue's scope note
+/// calls out, not a missing feature.
+String renderTranscriptMarkdown({
+  required String title,
+  required DateTime recordedAt,
+  Duration? duration,
+  List<TranscriptExportLine> lines = const [],
+  String fallbackTranscript = '',
+}) {
+  final buf = StringBuffer()
+    ..write(
+      renderFrontmatter(title: title, date: recordedAt, duration: duration),
+    )
+    ..writeln()
+    ..writeln('# $title')
+    ..writeln()
+    ..writeln('## Transcript')
+    ..writeln();
+
+  if (lines.isNotEmpty) {
+    for (final line in lines) {
+      final text = line.text.trim();
+      if (text.isEmpty) continue;
+      buf
+        ..writeln('${formatTimestamp(line.startMs)} $text')
+        ..writeln();
+    }
+  } else if (fallbackTranscript.trim().isNotEmpty) {
+    buf.writeln(fallbackTranscript.trim());
+  } else {
+    buf.writeln('_No transcript available._');
+  }
+
+  return '${buf.toString().trimRight()}\n';
+}
+
+/// A standalone `## Action Items` table. Empty string for an empty list, so
+/// callers can unconditionally append the result without a length check.
+String renderActionItemsMarkdown(List<ExportActionItem> items) {
+  if (items.isEmpty) return '';
+  final buf = StringBuffer()
+    ..writeln('## Action Items')
+    ..writeln()
+    ..writeln('| Task | Owner | Due | Status |')
+    ..writeln('| --- | --- | --- | --- |');
+  for (final item in items) {
+    buf.writeln(
+      '| ${item.task} | ${item.owner ?? '—'} | ${item.due ?? '—'} | '
+      '${item.status ?? 'Open'} |',
+    );
+  }
+  return buf.toString();
+}
+
+/// `2026-08-14-friday-standup` — stable, filesystem-safe, sorts
+/// chronologically in a flat vault folder.
+String meetingExportFolderName({
+  required String title,
+  required DateTime date,
+}) {
+  final datePart =
+      '${date.year.toString().padLeft(4, '0')}-'
+      '${date.month.toString().padLeft(2, '0')}-'
+      '${date.day.toString().padLeft(2, '0')}';
+  final slug = _slugify(title);
+  return slug.isEmpty ? datePart : '$datePart-$slug';
+}
+
+String _slugify(String input) {
+  final lower = input.toLowerCase().trim();
+  final dashed = lower.replaceAll(RegExp(r'[^a-z0-9]+'), '-');
+  return dashed.replaceAll(RegExp(r'^-+|-+$'), '');
+}
+
+/// One meeting's folder-per-meeting export bundle.
+///
+/// `transcript.md` is always present. `mom.md` appears only when
+/// [MeetingExportInput.momMarkdown] is set — not yet reachable from Dart
+/// (see the model's doc comment) — in which case any [ExportActionItem]s
+/// are appended to it only if its own text has no `Action Items` section
+/// already (Rust's `mom.rs` renders one itself). With no MoM but action
+/// items supplied on their own, they get a dedicated `action-items.md`
+/// instead of being silently dropped.
+MeetingExportBundle composeMeetingExportBundle(MeetingExportInput input) {
+  final files = <String, String>{
+    'transcript.md': renderTranscriptMarkdown(
+      title: input.title,
+      recordedAt: input.recordedAt,
+      duration: input.duration,
+      lines: input.transcriptLines,
+      fallbackTranscript: input.fallbackTranscript,
+    ),
+  };
+
+  final mom = input.momMarkdown?.trim();
+  if (mom != null && mom.isNotEmpty) {
+    final buf =
+        StringBuffer(
+            renderFrontmatter(
+              title: input.title,
+              date: input.recordedAt,
+              duration: input.duration,
+            ),
+          )
+          ..writeln()
+          ..writeln(mom);
+    if (input.actionItems.isNotEmpty && !mom.contains('Action Items')) {
+      buf
+        ..writeln()
+        ..write(renderActionItemsMarkdown(input.actionItems));
+    }
+    files['mom.md'] = '${buf.toString().trimRight()}\n';
+  } else if (input.actionItems.isNotEmpty) {
+    final buf =
+        StringBuffer(
+            renderFrontmatter(
+              title: input.title,
+              date: input.recordedAt,
+              duration: input.duration,
+            ),
+          )
+          ..writeln()
+          ..write(renderActionItemsMarkdown(input.actionItems));
+    files['action-items.md'] = '${buf.toString().trimRight()}\n';
+  }
+
+  return MeetingExportBundle(
+    folderName: meetingExportFolderName(
+      title: input.title,
+      date: input.recordedAt,
+    ),
+    files: files,
+  );
+}
+
+/// Batch export: one bundle per input, same order. A loop, not a special
+/// case — kept simple per this issue's scope note on batch export.
+List<MeetingExportBundle> composeBatchExport(List<MeetingExportInput> inputs) =>
+    inputs.map(composeMeetingExportBundle).toList(growable: false);

--- a/packages/feature_mind/lib/src/meeting_screen.dart
+++ b/packages/feature_mind/lib/src/meeting_screen.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 
+import 'export/application/meeting_export_service.dart';
+import 'export/data/meeting_export_gateway.dart';
 import 'whisper/api/meetings.dart' as rust;
 import 'mind_service.dart';
 
@@ -38,6 +40,14 @@ class MeetingScreen extends StatefulWidget {
 class _MeetingScreenState extends State<MeetingScreen> {
   late MindProgress _progress;
 
+  // #1663: markdown export. Constructed here rather than injected — like
+  // `MindService`'s own defaults, the production path is the only path this
+  // screen needs; a test exercises the service/gateway directly instead of
+  // through the widget (see `test/export/`).
+  late final _exportService = MeetingExportService(widget.service);
+  final _exportGateway = const PlatformMeetingExportGateway();
+  bool _exporting = false;
+
   @override
   void initState() {
     super.initState();
@@ -74,6 +84,41 @@ class _MeetingScreenState extends State<MeetingScreen> {
       _progress.stage == MindStage.generating ||
       _progress.stage == MindStage.saving;
 
+  /// Exports the stored meeting as markdown, then either hands it to the
+  /// share sheet or writes it to a folder the user picks. A no-op for a live
+  /// (not-yet-saved) meeting — there is no [MeetingScreen.stored]'s
+  /// `_meeting.id` to export until the pipeline finishes.
+  Future<void> _export({required bool share}) async {
+    final meetingId = widget._meeting?.id ?? _progress.meetingId;
+    if (meetingId == null || _exporting) return;
+
+    setState(() => _exporting = true);
+    try {
+      final bundle = await _exportService.exportMeeting(meetingId);
+      if (bundle == null) {
+        _notify('That meeting could not be found.');
+        return;
+      }
+      final ok = share
+          ? await _exportGateway.share([bundle])
+          : await _exportGateway.saveToFolder([bundle]);
+      if (ok) {
+        _notify(share ? 'Shared as markdown.' : 'Saved as markdown.');
+      }
+    } on Object catch (e) {
+      _notify('Export failed: $e');
+    } finally {
+      if (mounted) setState(() => _exporting = false);
+    }
+  }
+
+  void _notify(String message) {
+    if (!mounted) return;
+    ScaffoldMessenger.of(
+      context,
+    ).showSnackBar(SnackBar(content: Text(message)));
+  }
+
   String get _stageLabel => switch (_progress.stage) {
     MindStage.transcribing => 'Transcribing…',
     MindStage.generating => 'Writing minutes…',
@@ -97,6 +142,24 @@ class _MeetingScreenState extends State<MeetingScreen> {
                 Navigator.of(context).pop();
               },
               child: const Text('Stop'),
+            )
+          // Export needs a saved meeting id -- available once processing
+          // reaches `done`, or always for a reopened meeting.
+          else if (stored != null || _progress.meetingId != null)
+            PopupMenuButton<bool>(
+              icon: _exporting
+                  ? const SizedBox(
+                      width: 20,
+                      height: 20,
+                      child: CircularProgressIndicator(strokeWidth: 2),
+                    )
+                  : const Icon(Icons.ios_share),
+              tooltip: 'Export as markdown',
+              onSelected: (share) => _export(share: share),
+              itemBuilder: (_) => const [
+                PopupMenuItem(value: false, child: Text('Save to folder')),
+                PopupMenuItem(value: true, child: Text('Share')),
+              ],
             ),
         ],
       ),

--- a/packages/feature_mind/lib/src/mind_home_screen.dart
+++ b/packages/feature_mind/lib/src/mind_home_screen.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 
 import 'whisper/api/meetings.dart' as rust;
+import 'export/application/meeting_export_service.dart';
+import 'export/data/meeting_export_gateway.dart';
 import 'meeting_screen.dart';
 import 'mind_service.dart';
 import 'models/model_provider.dart';
@@ -21,6 +23,11 @@ class MindHomeScreen extends StatefulWidget {
 
 class _MindHomeScreenState extends State<MindHomeScreen> {
   final _query = TextEditingController();
+
+  // #1663: batch markdown export of every meeting currently listed.
+  late final _exportService = MeetingExportService(widget.service);
+  final _exportGateway = const PlatformMeetingExportGateway();
+  bool _exportingAll = false;
 
   MindStatus? _status;
   List<rust.MeetingRecord> _meetings = const [];
@@ -127,6 +134,44 @@ class _MindHomeScreenState extends State<MindHomeScreen> {
     if (mounted) setState(() => _recording = true);
   }
 
+  /// Exports every meeting in [_meetings] as markdown in one action (#1663
+  /// batch export). Shares rather than saves-to-folder by default — the
+  /// share sheet is one prompt regardless of how many meetings are in the
+  /// batch, where a folder picker still needs the caller to have somewhere
+  /// in mind to put it. Long-pressing offers the folder instead.
+  Future<void> _exportAll({required bool share}) async {
+    if (_meetings.isEmpty || _exportingAll) return;
+    setState(() => _exportingAll = true);
+    try {
+      final bundles = await _exportService.exportMeetings(
+        _meetings.map((m) => m.id).toList(),
+      );
+      if (bundles.isEmpty) return;
+      final ok = share
+          ? await _exportGateway.share(bundles)
+          : await _exportGateway.saveToFolder(bundles);
+      if (ok && mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text(
+              share
+                  ? 'Shared ${bundles.length} meetings as markdown.'
+                  : 'Saved ${bundles.length} meetings as markdown.',
+            ),
+          ),
+        );
+      }
+    } on Object catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(
+          context,
+        ).showSnackBar(SnackBar(content: Text('Export failed: $e')));
+      }
+    } finally {
+      if (mounted) setState(() => _exportingAll = false);
+    }
+  }
+
   Future<void> _open(String id) async {
     final meeting = await widget.service.meeting(id);
     if (!mounted || meeting == null) return;
@@ -142,7 +187,27 @@ class _MindHomeScreenState extends State<MindHomeScreen> {
   Widget build(BuildContext context) {
     final status = _status;
     return Scaffold(
-      appBar: AppBar(title: const Text('Airo Mind')),
+      appBar: AppBar(
+        title: const Text('Airo Mind'),
+        actions: [
+          if (status != null && status.isReady && _meetings.isNotEmpty)
+            PopupMenuButton<bool>(
+              icon: _exportingAll
+                  ? const SizedBox(
+                      width: 20,
+                      height: 20,
+                      child: CircularProgressIndicator(strokeWidth: 2),
+                    )
+                  : const Icon(Icons.ios_share),
+              tooltip: 'Export all as markdown',
+              onSelected: (share) => _exportAll(share: share),
+              itemBuilder: (_) => const [
+                PopupMenuItem(value: true, child: Text('Share all')),
+                PopupMenuItem(value: false, child: Text('Save all to folder')),
+              ],
+            ),
+        ],
+      ),
       body: switch (status) {
         // Startup. A provider that installs on its own (the bundled copy, or
         // a resumed download) reports through `onInstallProgress`, and

--- a/packages/feature_mind/module.yaml
+++ b/packages/feature_mind/module.yaml
@@ -36,6 +36,9 @@ allowed_dependencies:
   - core_product_shell
   - core_domain
   - core_data
+  # Markdown export (#1663): renders transcript.md/mom.md off the main
+  # isolate once a meeting crosses ~50 KB, per the repo's own parsing rule.
+  - core_workers
 forbidden_dependencies:
   - app
 quality_gates: {}

--- a/packages/feature_mind/pubspec.lock
+++ b/packages/feature_mind/pubspec.lock
@@ -218,6 +218,13 @@ packages:
       relative: true
     source: path
     version: "0.0.1"
+  core_workers:
+    dependency: "direct main"
+    description:
+      path: "../core_workers"
+      relative: true
+    source: path
+    version: "0.1.0"
   coverage:
     dependency: transitive
     description:
@@ -322,6 +329,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "7.0.1"
+  file_picker:
+    dependency: "direct main"
+    description:
+      name: file_picker
+      sha256: fdc6a37f715d19f35b131decf1ce39242eeed5ddae18c0818c3eccb731ab76be
+      url: "https://pub.dev"
+    source: hosted
+    version: "12.0.0-beta.7"
   file_selector_linux:
     dependency: transitive
     description:
@@ -354,6 +369,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.9.3+5"
+  firebase_core:
+    dependency: transitive
+    description:
+      name: firebase_core
+      sha256: "9478ca6700c02d315c6aba37e206e612317f98bb4f335bb1cbd6e0ce67dcf764"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.13.0"
+  firebase_core_platform_interface:
+    dependency: transitive
+    description:
+      name: firebase_core_platform_interface
+      sha256: e28f9afdcb5b0f0a8ea74ea3b322f5a7592c81cb45dd9d189913bdae08a2089a
+      url: "https://pub.dev"
+    source: hosted
+    version: "8.1.0"
+  firebase_core_web:
+    dependency: transitive
+    description:
+      name: firebase_core_web
+      sha256: f471a288b0101a45567548322ac4a5ad31e3ecbf87a576dcc0e424e6a11e04ea
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.10.0"
   fixnum:
     dependency: transitive
     description:
@@ -1006,6 +1045,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.3.2"
+  share_plus:
+    dependency: "direct main"
+    description:
+      name: share_plus
+      sha256: "34f00f9becd2743c1fb05363d624f9f70d37f7ccdcdda47450bc0b8c9d327b8c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "13.3.0"
+  share_plus_platform_interface:
+    dependency: transitive
+    description:
+      name: share_plus_platform_interface
+      sha256: "365ef7379fc22507256adda3385152942ffce08935452bc972c2e52a0bebae41"
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.2.0"
   shared_preferences:
     dependency: "direct main"
     description:

--- a/packages/feature_mind/pubspec.yaml
+++ b/packages/feature_mind/pubspec.yaml
@@ -50,6 +50,17 @@ dependencies:
   # same package and version core_data, platform_player and feature_iptv
   # already use for the same purpose.
   connectivity_plus: ^7.2.0
+  # Markdown export (#1663): rendering the transcript body runs off the main
+  # isolate once it crosses ~50 KB, per the repo's own parsing rule.
+  core_workers:
+    path: ../core_workers
+  # Share-sheet + save-to-folder for markdown export (#1663). Same package,
+  # same pinned version, as feature_iptv's backup/restore export -- see
+  # platform_backup_document_gateway.dart there for the house pattern this
+  # follows. TV builds swap both for packages/stubs/*_stub via
+  # app/pubspec_overrides.yaml, same as feature_iptv.
+  file_picker: 12.0.0-beta.7
+  share_plus: 13.3.0
 
 # An FFI plugin. Declaring the platforms is what makes the Flutter tool run
 # cargokit's podspec/gradle/cmake hooks during a normal build -- without this

--- a/packages/feature_mind/test/export/meeting_export_service_test.dart
+++ b/packages/feature_mind/test/export/meeting_export_service_test.dart
@@ -1,0 +1,179 @@
+import 'package:feature_mind/src/export/application/meeting_export_service.dart';
+import 'package:feature_mind/src/mind_service.dart';
+import 'package:feature_mind/src/whisper/api/meetings.dart' as rust;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+/// `MindService` isn't an interface — it's mocked directly, same as
+/// `mind_service_test.dart` mocks its own collaborators (`fake_bridges.dart`)
+/// rather than standing up the real Rust bridge.
+class MockMindService extends Mock implements MindService {}
+
+rust.MeetingRecord _meeting({
+  required String id,
+  String title = 'Standup',
+  int recordedAtMs = 1755000000000,
+  String transcript = 'the flat transcript',
+}) => rust.MeetingRecord(
+  id: id,
+  title: title,
+  recordedAt: BigInt.from(recordedAtMs),
+  transcript: transcript,
+  minutes: '',
+  model: 'qwen',
+);
+
+rust.TranscriptDocumentRecord _doc({
+  required String meetingId,
+  List<rust.TranscriptSegmentRecord> segments = const [],
+}) => rust.TranscriptDocumentRecord(
+  meetingId: meetingId,
+  audioPath: '/tmp/$meetingId.wav',
+  modelVersion: 'whisper-multilingual',
+  segments: segments,
+);
+
+void main() {
+  late MockMindService mind;
+  late MeetingExportService service;
+
+  setUp(() {
+    mind = MockMindService();
+    service = MeetingExportService(mind);
+  });
+
+  group('exportMeeting', () {
+    test('returns null when the meeting no longer exists', () async {
+      when(() => mind.meeting('gone')).thenAnswer((_) async => null);
+      final result = await service.exportMeeting('gone');
+      expect(result, isNull);
+    });
+
+    test(
+      'uses timestamped segments when a transcript document exists',
+      () async {
+        when(
+          () => mind.meeting('m1'),
+        ).thenAnswer((_) async => _meeting(id: 'm1'));
+        when(() => mind.transcriptDocument('m1')).thenAnswer(
+          (_) async => _doc(
+            meetingId: 'm1',
+            segments: [
+              rust.TranscriptSegmentRecord(
+                id: 's1',
+                startMs: BigInt.zero,
+                endMs: BigInt.from(2000),
+                text: 'Hello team.',
+              ),
+              rust.TranscriptSegmentRecord(
+                id: 's2',
+                startMs: BigInt.from(2000),
+                endMs: BigInt.from(5000),
+                text: 'Let’s begin.',
+              ),
+            ],
+          ),
+        );
+
+        final bundle = await service.exportMeeting('m1');
+
+        expect(bundle, isNotNull);
+        expect(bundle!.folderName, contains('standup'));
+        final transcript = bundle.files['transcript.md']!;
+        expect(transcript, contains('[00:00:00] Hello team.'));
+        expect(transcript, contains('[00:00:02] Let’s begin.'));
+        // The flat MeetingRecord.transcript is not used when segments exist.
+        expect(transcript, isNot(contains('the flat transcript')));
+      },
+    );
+
+    test(
+      'falls back to the flat transcript when no document is stored',
+      () async {
+        when(
+          () => mind.meeting('m2'),
+        ).thenAnswer((_) async => _meeting(id: 'm2'));
+        when(() => mind.transcriptDocument('m2')).thenAnswer((_) async => null);
+
+        final bundle = await service.exportMeeting('m2');
+
+        expect(bundle, isNotNull);
+        final transcript = bundle!.files['transcript.md']!;
+        expect(transcript, contains('the flat transcript'));
+        expect(transcript, isNot(contains('[00:')));
+        // No document -> no derivable duration.
+        expect(transcript, isNot(contains('duration:')));
+      },
+    );
+
+    test(
+      'does not yet populate mom.md -- no FFI surface for MoM generation',
+      () async {
+        when(
+          () => mind.meeting('m3'),
+        ).thenAnswer((_) async => _meeting(id: 'm3'));
+        when(() => mind.transcriptDocument('m3')).thenAnswer((_) async => null);
+
+        final bundle = await service.exportMeeting('m3');
+
+        expect(bundle!.files.keys, ['transcript.md']);
+      },
+    );
+
+    test(
+      'renders correctly even past the off-main isolate threshold',
+      () async {
+        final longText = 'word ' * 20000; // well past 50 KB
+        when(
+          () => mind.meeting('big'),
+        ).thenAnswer((_) async => _meeting(id: 'big', transcript: longText));
+        when(
+          () => mind.transcriptDocument('big'),
+        ).thenAnswer((_) async => null);
+
+        final bundle = await service.exportMeeting('big');
+
+        expect(bundle, isNotNull);
+        expect(bundle!.files['transcript.md'], contains(longText.trim()));
+      },
+    );
+  });
+
+  group('exportMeetings (batch)', () {
+    test(
+      'skips meetings that no longer exist, keeps the rest in order',
+      () async {
+        when(
+          () => mind.meeting('a'),
+        ).thenAnswer((_) async => _meeting(id: 'a', title: 'First'));
+        when(() => mind.transcriptDocument('a')).thenAnswer((_) async => null);
+        when(() => mind.meeting('missing')).thenAnswer((_) async => null);
+        when(
+          () => mind.meeting('b'),
+        ).thenAnswer((_) async => _meeting(id: 'b', title: 'Second'));
+        when(() => mind.transcriptDocument('b')).thenAnswer((_) async => null);
+
+        final bundles = await service.exportMeetings(['a', 'missing', 'b']);
+
+        expect(bundles, hasLength(2));
+        expect(bundles[0].folderName, contains('first'));
+        expect(bundles[1].folderName, contains('second'));
+      },
+    );
+
+    test('empty id list returns no bundles and touches nothing', () async {
+      final bundles = await service.exportMeetings(const []);
+      expect(bundles, isEmpty);
+      verifyNever(() => mind.meeting(any()));
+    });
+
+    test(
+      'all-missing ids return an empty batch rather than throwing',
+      () async {
+        when(() => mind.meeting('x')).thenAnswer((_) async => null);
+        final bundles = await service.exportMeetings(['x']);
+        expect(bundles, isEmpty);
+      },
+    );
+  });
+}

--- a/packages/feature_mind/test/export/meeting_markdown_renderer_test.dart
+++ b/packages/feature_mind/test/export/meeting_markdown_renderer_test.dart
@@ -1,0 +1,282 @@
+import 'package:feature_mind/src/export/domain/meeting_export_models.dart';
+import 'package:feature_mind/src/export/domain/meeting_markdown_renderer.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('formatTimestamp', () {
+    test('renders plain bracketed HH:MM:SS, not a deep link', () {
+      expect(formatTimestamp(0), '[00:00:00]');
+      expect(formatTimestamp(754000), '[00:12:34]');
+      expect(formatTimestamp(3661000), '[01:01:01]');
+    });
+
+    test('never emits an app URI scheme', () {
+      final result = formatTimestamp(754000);
+      expect(result, isNot(contains('://')));
+      expect(result, isNot(contains('airo')));
+    });
+  });
+
+  group('formatDurationHms', () {
+    test('omits the hour unit under an hour', () {
+      expect(
+        formatDurationHms(const Duration(minutes: 5, seconds: 12)),
+        '5m 12s',
+      );
+    });
+
+    test('omits leading zero units but keeps seconds', () {
+      expect(formatDurationHms(Duration.zero), '0s');
+      expect(formatDurationHms(const Duration(seconds: 9)), '9s');
+    });
+
+    test('includes hours once the meeting is that long', () {
+      expect(
+        formatDurationHms(const Duration(hours: 1, minutes: 2, seconds: 3)),
+        '1h 2m 3s',
+      );
+    });
+  });
+
+  group('renderFrontmatter', () {
+    test('emits a YAML block with title, date and duration', () {
+      final fm = renderFrontmatter(
+        title: 'Signaling capacity review',
+        date: DateTime.utc(2026, 8, 14, 9, 30),
+        duration: const Duration(minutes: 42),
+      );
+      expect(fm, startsWith('---\n'));
+      expect(fm, contains('title: "Signaling capacity review"'));
+      expect(fm, contains('date: 2026-08-14T09:30:00.000Z'));
+      expect(fm, contains('duration: "42m 0s"'));
+      expect(fm.trimRight(), endsWith('---'));
+    });
+
+    test('omits duration when null', () {
+      final fm = renderFrontmatter(title: 'x', date: DateTime.utc(2026, 1, 1));
+      expect(fm, isNot(contains('duration:')));
+    });
+
+    test('escapes double quotes in the title', () {
+      final fm = renderFrontmatter(
+        title: 'The "big" sync',
+        date: DateTime.utc(2026, 1, 1),
+      );
+      expect(fm, contains(r'title: "The \"big\" sync"'));
+    });
+  });
+
+  group('renderTranscriptMarkdown', () {
+    test('renders timestamped lines when segments are available', () {
+      final md = renderTranscriptMarkdown(
+        title: 'Standup',
+        recordedAt: DateTime.utc(2026, 8, 14),
+        lines: const [
+          TranscriptExportLine(startMs: 0, text: 'Let’s get started.'),
+          TranscriptExportLine(
+            startMs: 5000,
+            text: 'First up, the signaling limit.',
+          ),
+        ],
+      );
+      expect(md, contains('## Transcript'));
+      expect(md, contains('[00:00:00] Let’s get started.'));
+      expect(md, contains('[00:00:05] First up, the signaling limit.'));
+    });
+
+    test('skips blank lines', () {
+      final md = renderTranscriptMarkdown(
+        title: 'Standup',
+        recordedAt: DateTime.utc(2026, 8, 14),
+        lines: const [
+          TranscriptExportLine(startMs: 0, text: '   '),
+          TranscriptExportLine(startMs: 1000, text: 'Real line'),
+        ],
+      );
+      expect(md, isNot(contains('[00:00:00]')));
+      expect(md, contains('[00:00:01] Real line'));
+    });
+
+    test('falls back to the flat transcript when there are no segments', () {
+      final md = renderTranscriptMarkdown(
+        title: 'Old meeting',
+        recordedAt: DateTime.utc(2026, 1, 1),
+        fallbackTranscript: 'Everything said, with no timestamps at all.',
+      );
+      expect(md, contains('Everything said, with no timestamps at all.'));
+      expect(md, isNot(contains('[00:')));
+    });
+
+    test('says so when there is nothing to export', () {
+      final md = renderTranscriptMarkdown(
+        title: 'Empty',
+        recordedAt: DateTime.utc(2026, 1, 1),
+      );
+      expect(md, contains('_No transcript available._'));
+    });
+
+    test('leads with frontmatter before the heading', () {
+      final md = renderTranscriptMarkdown(
+        title: 'Standup',
+        recordedAt: DateTime.utc(2026, 8, 14),
+        fallbackTranscript: 'hi',
+      );
+      final frontmatterEnd = md.indexOf('---', 4);
+      final headingStart = md.indexOf('# Standup');
+      expect(frontmatterEnd, greaterThan(0));
+      expect(headingStart, greaterThan(frontmatterEnd));
+    });
+  });
+
+  group('renderActionItemsMarkdown', () {
+    test('empty list renders nothing', () {
+      expect(renderActionItemsMarkdown(const []), '');
+    });
+
+    test('renders a table with placeholders for missing fields', () {
+      final md = renderActionItemsMarkdown(const [
+        ExportActionItem(
+          task: 'Check the signaling limit',
+          owner: 'Dev',
+          due: 'Friday',
+        ),
+        ExportActionItem(task: 'Update the runbook'),
+      ]);
+      expect(md, contains('## Action Items'));
+      expect(
+        md,
+        contains('| Check the signaling limit | Dev | Friday | Open |'),
+      );
+      expect(md, contains('| Update the runbook | — | — | Open |'));
+    });
+
+    test('uses the supplied status when present', () {
+      final md = renderActionItemsMarkdown(const [
+        ExportActionItem(task: 'Ship it', status: 'Done'),
+      ]);
+      expect(md, contains('| Ship it | — | — | Done |'));
+    });
+  });
+
+  group('meetingExportFolderName', () {
+    test('combines date and a slugified title', () {
+      expect(
+        meetingExportFolderName(
+          title: 'Friday Standup!',
+          date: DateTime.utc(2026, 8, 14),
+        ),
+        '2026-08-14-friday-standup',
+      );
+    });
+
+    test('falls back to the date alone for an empty/symbol-only title', () {
+      expect(
+        meetingExportFolderName(title: '!!!', date: DateTime.utc(2026, 8, 14)),
+        '2026-08-14',
+      );
+    });
+
+    test('collapses repeated separators and pads single digits', () {
+      expect(
+        meetingExportFolderName(
+          title: 'Q3   Review -- v2',
+          date: DateTime.utc(2026, 1, 2),
+        ),
+        '2026-01-02-q3-review-v2',
+      );
+    });
+  });
+
+  group('composeMeetingExportBundle', () {
+    test('always renders transcript.md', () {
+      final bundle = composeMeetingExportBundle(
+        MeetingExportInput(
+          meetingId: 'm1',
+          title: 'Standup',
+          recordedAt: DateTime.utc(2026, 8, 14),
+          fallbackTranscript: 'hello',
+        ),
+      );
+      expect(bundle.folderName, '2026-08-14-standup');
+      expect(bundle.files.keys, ['transcript.md']);
+      expect(bundle.files['transcript.md'], contains('hello'));
+    });
+
+    test('adds mom.md when momMarkdown is present, action items untouched '
+        'because the MoM text already has its own table', () {
+      final bundle = composeMeetingExportBundle(
+        MeetingExportInput(
+          meetingId: 'm1',
+          title: 'Standup',
+          recordedAt: DateTime.utc(2026, 8, 14),
+          momMarkdown:
+              '# Minutes of Meeting\n\n## Action Items\n\n| Task | Owner | Due | Status |\n',
+          actionItems: const [ExportActionItem(task: 'duplicate?')],
+        ),
+      );
+      expect(bundle.files.keys, containsAll(['transcript.md', 'mom.md']));
+      // Only one "Action Items" section -- the MoM's own, not a second one
+      // appended from `actionItems`.
+      final momFile = bundle.files['mom.md']!;
+      expect('Action Items'.allMatches(momFile).length, 1);
+    });
+
+    test('appends actionItems to mom.md when the MoM text has no table of '
+        'its own', () {
+      final bundle = composeMeetingExportBundle(
+        MeetingExportInput(
+          meetingId: 'm1',
+          title: 'Standup',
+          recordedAt: DateTime.utc(2026, 8, 14),
+          momMarkdown: '# Minutes of Meeting\n\nJust prose, no table.',
+          actionItems: const [ExportActionItem(task: 'Follow up')],
+        ),
+      );
+      final momFile = bundle.files['mom.md']!;
+      expect(momFile, contains('## Action Items'));
+      expect(momFile, contains('Follow up'));
+    });
+
+    test('gives action items their own file when there is no MoM at all', () {
+      final bundle = composeMeetingExportBundle(
+        MeetingExportInput(
+          meetingId: 'm1',
+          title: 'Standup',
+          recordedAt: DateTime.utc(2026, 8, 14),
+          actionItems: const [ExportActionItem(task: 'Solo item')],
+        ),
+      );
+      expect(
+        bundle.files.keys,
+        containsAll(['transcript.md', 'action-items.md']),
+      );
+      expect(bundle.files['action-items.md'], contains('Solo item'));
+    });
+  });
+
+  group('composeBatchExport', () {
+    test('renders one bundle per input, preserving order', () {
+      final bundles = composeBatchExport([
+        MeetingExportInput(
+          meetingId: 'a',
+          title: 'First',
+          recordedAt: DateTime.utc(2026, 1, 1),
+          fallbackTranscript: 'one',
+        ),
+        MeetingExportInput(
+          meetingId: 'b',
+          title: 'Second',
+          recordedAt: DateTime.utc(2026, 1, 2),
+          fallbackTranscript: 'two',
+        ),
+      ]);
+      expect(bundles, hasLength(2));
+      expect(bundles[0].folderName, '2026-01-01-first');
+      expect(bundles[1].folderName, '2026-01-02-second');
+    });
+
+    test('empty input list renders no bundles', () {
+      expect(composeBatchExport(const []), isEmpty);
+    });
+  });
+}


### PR DESCRIPTION
Implements #1663 (MIND-LLM-18), scoped to what's buildable now without colliding with #1657's in-flight files or a nonexistent MoM FFI surface.

- Pure markdown renderer: YAML frontmatter (title/date/duration), timestamped transcript body, action-items section — isolate-safe, no plugin deps
- `MeetingExportService` builds bundles from `MindService`, routes through `core_workers.runOffMain` once transcript text exceeds ~50KB per CLAUDE.md's parsing rule
- `PlatformMeetingExportGateway` mirrors feature_iptv's `PlatformBackupDocumentGateway` pattern over file_picker/share_plus; real folder-per-meeting on native, per-file on web
- Wired into meeting_screen.dart (single-meeting) and mind_home_screen.dart (batch export)

Deferred, flagged in code: `momMarkdown`/`actionItems` fields exist on the composer and are tested, but unset in the service — #1657 hasn't landed `Meeting.action_items`/`decisions` on the Dart record yet, and `airo_mind_meeting`'s MoM generator has no FFI surface. Follow-up to file: wire MoM generation through flutter_rust_bridge.

33 new tests, 761/761 package suite passing, flutter analyze clean.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>