### PR TITLE
fix(mind): stop grammar generation at its terminal state instead of aborting the process (#1739)

### DIFF
--- a/rust/airo_mind_llama/Cargo.toml
+++ b/rust/airo_mind_llama/Cargo.toml
@@ -24,11 +24,22 @@ flutter_rust_bridge = "=2.11.1"
 # and the Android stdc++ linkage is a per-target concern this Cargo.toml does
 # not decide unilaterally.
 #
-# `common` is re-enabled explicitly below, in the `llama` feature union, purely
-# for `LlamaSampler::grammar` -- the GBNF-constrained sampler -- which llama-cpp-2
-# 0.1.153 only exposes behind it (the vocab pointer a manual FFI call would need
-# is `pub(crate)` inside llama-cpp-2 itself; there is no way to call the
-# grammar-init C API from outside the crate without this feature). Enabling
+# `common` is re-enabled explicitly below, in the `llama` feature union, for two
+# things, and the second one is a safety requirement rather than a convenience:
+#
+#  1. `LlamaSampler::grammar` -- the GBNF-constrained sampler -- which
+#     llama-cpp-2 0.1.153 only exposes behind it (the vocab pointer a manual FFI
+#     call would need is `pub(crate)` inside llama-cpp-2 itself; there is no way
+#     to call the grammar-init C API from outside the crate without it).
+#  2. `LlamaSampler::try_accept`, which is the ONLY way to see that a grammar has
+#     reached a terminal state (`#1739`). Without it, `accept` silently swallows
+#     llama.cpp's "empty grammar stack" exception, the stacks stay empty, and the
+#     next `sample` hits `GGML_ASSERT(!stacks.empty())` -- an `abort()` that takes
+#     the whole app process down. `llama.rs`'s generation loop depends on this;
+#     dropping `common` while `grammar` is still reachable reintroduces a
+#     process-crash bug, it does not merely shrink the binary.
+#
+# Enabling
 # `common` DOES compile `download.cpp` and `hf-cache.cpp` into the binary --
 # they are unconditional sources in llama.cpp's own `common/CMakeLists.txt`,
 # not gated on curl -- but `llama-cpp-sys-2`'s build.rs sets `LLAMA_CURL=OFF`

--- a/rust/airo_mind_llama/src/llama.rs
+++ b/rust/airo_mind_llama/src/llama.rs
@@ -225,11 +225,35 @@ impl GenerationEngine for LlamaGenerationEngine {
             }
 
             let token = sampler.sample(&ctx, -1);
-            sampler.accept(token);
 
+            // End-of-generation is checked BEFORE the token reaches the
+            // sampler chain, not after. `llama_grammar_accept_impl` calls
+            // `GGML_ABORT` -- an `abort()`, not a catchable exception -- if it
+            // is handed an EOG token while every grammar stack still has
+            // something outstanding. A token that is never emitted leaves
+            // nothing worth recording in sampler state, so there is no reason
+            // to hand it over first.
             if self.model.is_eog_token(token) {
                 break;
             }
+
+            // `try_accept`, not `accept` (`#1739`). When a token completes the
+            // grammar, llama.cpp empties the grammar's stacks and throws;
+            // `LlamaSampler::accept` swallows that (`let _ = self.try_accept`),
+            // leaving the stacks empty. The NEXT `sample` then trips
+            // `GGML_ASSERT(!stacks.empty())` in
+            // `llama_grammar_reject_candidates`, which aborts the whole OS
+            // process -- it is not a Rust panic and nothing upstream can catch
+            // it. Every grammar with a terminal state hits this: `root ::= "{"
+            // "}"` crashes on the token after the closing brace, and so does
+            // any finite JSON grammar.
+            //
+            // An error here means the grammar has no continuation from this
+            // token, which is exactly "the constrained output is finished".
+            // The token itself is valid and in-grammar (the same chain's
+            // grammar sampler is what allowed it), so it is emitted, and then
+            // generation stops for the same reason EOG stops it.
+            let grammar_finished = sampler.try_accept(token).is_err();
 
             let text = self
                 .model
@@ -240,6 +264,16 @@ impl GenerationEngine for LlamaGenerationEngine {
             // engine never builds the whole output.
             sink(GenerationChunk { text })?;
 
+            produced += 1;
+
+            // Stop after emitting, not before: the token is in-grammar and
+            // belongs in the output. Nothing after this point is worth doing --
+            // decoding it would only prepare a next token that must never be
+            // sampled.
+            if grammar_finished {
+                break;
+            }
+
             batch.clear();
             batch
                 .add(token, position, &[0], true)
@@ -248,7 +282,6 @@ impl GenerationEngine for LlamaGenerationEngine {
                 .map_err(|e| EngineError::Backend(format!("decode: {e}")))?;
 
             position += 1;
-            produced += 1;
         }
         let generation_ms = elapsed_ms(generation_started);
 

--- a/rust/airo_mind_llama/tests/generation_offline.rs
+++ b/rust/airo_mind_llama/tests/generation_offline.rs
@@ -318,6 +318,65 @@ fn runtime_stats_are_real_after_a_generation_call() {
     eprintln!("--- runtime stats ---\n{stats:?}\n---");
 }
 
+/// **The `#1739` regression test.** A grammar with a terminal state used to
+/// abort the whole OS process one token past completion:
+///
+/// ```text
+/// llama-grammar.cpp:940: GGML_ASSERT(!stacks.empty()) failed
+/// ```
+///
+/// `root ::= "{" "}"` is the minimal reproduction — the crash landed on the
+/// token immediately after the closing brace, every time, because generation
+/// only stopped on EOG or `max_output_tokens` and both are checked *after*
+/// sampling. `#1628`'s `[0-9]+` grammar never caught it: it has no terminal
+/// state, so there is always a "one more digit" continuation and the stacks
+/// never empty.
+///
+/// `max_output_tokens` is deliberately far higher than the grammar can consume.
+/// If the driver did not stop at the terminal state, the run would reach the
+/// assert long before the ceiling, and this test would not fail — it would take
+/// the test binary down with `SIGABRT`. Surviving to the assertions IS the
+/// result being asserted.
+///
+/// Skipped without a model, like every test in this file. That means CI does
+/// not prove this; a dev-loop or device run with a real GGUF does.
+#[test]
+fn a_grammar_that_can_finish_does_not_abort_the_process() {
+    let model = model();
+    if !model.exists() {
+        eprintln!("skipping: no model at {}", model.display());
+        return;
+    }
+
+    let engine = LlamaGenerationEngine::load(&model, 1024, 2048).expect("model loads");
+    let mut supervisor = Supervisor::new(ResourceBudget::new(4096));
+    supervisor.register_generation(Box::new(engine));
+
+    let mut output = String::new();
+    supervisor
+        .run_generation(
+            &GenerationRequest {
+                prompt: "<|im_start|>user\nEmit an empty JSON object.<|im_end|>\n\
+                         <|im_start|>assistant\n"
+                    .to_string(),
+                max_output_tokens: 64,
+                grammar: Some(r#"root ::= "{" "}""#.to_string()),
+            },
+            &CancelToken::new(),
+            &mut |chunk| {
+                output.push_str(&chunk.text);
+                Ok(())
+            },
+        )
+        .expect("a terminating grammar generates and returns");
+
+    assert_eq!(
+        output.trim(),
+        "{}",
+        "the grammar admits exactly one string, and generation must stop at it"
+    );
+}
+
 /// `#1628` Wave 1 acceptance: `unload()` exists, is callable, and does not
 /// panic or leak.
 #[test]

--- a/rust/airo_mind_meeting/src/pass1.rs
+++ b/rust/airo_mind_meeting/src/pass1.rs
@@ -6,13 +6,20 @@
 //!
 //! # Three separate guarantees, in order
 //!
-//! 1. **Shape** is the grammar's job. `GenerationRequest::grammar` constrains
-//!    the sampler to a valid `Facts` object, so "the model returned prose" is
-//!    not a state that can occur.
-//! 2. **Parse** is bounded-retry's job. The grammar cannot prevent output being
-//!    cut off at `max_output_tokens` mid-object, which yields JSON that is valid
-//!    right up to where it stops. That retries, a fixed number of times, and
-//!    then the chunk is abandoned with a diagnostic — never an unbounded loop.
+//! 1. **Shape** is the grammar's job, *when the grammar is switched on*.
+//!    `GenerationRequest::grammar` constrains the sampler to a valid `Facts`
+//!    object. It is off by default (`ExtractionConfig::use_gbnf_grammar`, see
+//!    `#1739`), so "the model returned prose" is a state that can occur and
+//!    guarantee 2 is what has to survive it.
+//! 2. **Parse** is bounded-retry's job, and it is the load-bearing guarantee
+//!    rather than a mop-up for one edge case. Unconstrained, the model can
+//!    return prose, a fenced object, or nothing usable; constrained, it can
+//!    still be cut off at `max_output_tokens` mid-object. Either way the output
+//!    is parsed into `Facts` — which is a schema check, since a field of the
+//!    wrong shape is a serde error, not a silently accepted value — and a
+//!    failure retries a fixed number of times with a repair note appended to
+//!    the prompt, after which the chunk is abandoned with a diagnostic. Never
+//!    an unbounded loop.
 //! 3. **Grounding** is this module's job, and is not delegated to the model at
 //!    all. An item citing a segment outside its own chunk is dropped. An owner
 //!    whose name does not appear in the chunk is erased. Both are mechanical
@@ -44,6 +51,23 @@ pub struct ExtractionConfig {
     /// Must be at least 1; `0` is treated as 1 rather than silently extracting
     /// nothing.
     pub max_attempts: u32,
+    /// Whether the sampler is constrained by [`prompt::CHUNK_FACTS_GRAMMAR`].
+    ///
+    /// **Defaults to `false`, and that is a safety default, not a preference**
+    /// (`#1739`). llama.cpp aborts the OS process — `GGML_ASSERT`, not a
+    /// catchable Rust panic — when a GBNF grammar with a terminal state is
+    /// sampled one token past completion, and a JSON-object grammar always has
+    /// a terminal state. `airo_mind_llama`'s driver now stops at that point
+    /// instead of sampling into the assert, but that fix has only been proven
+    /// by reading llama.cpp's own source, not yet on a device with a real GGUF
+    /// model. Until it has been, extraction does not put a terminating grammar
+    /// in front of a real sampler by default, and leans on bounded retry
+    /// (guarantee 2 above) for shape instead.
+    ///
+    /// Flip it on to exercise the constrained path — it is the stronger
+    /// guarantee, and the intended default once `#1739` is confirmed fixed on
+    /// a device.
+    pub use_gbnf_grammar: bool,
     /// Pass 2's merge behaviour.
     pub dedup: DedupConfig,
 }
@@ -53,6 +77,7 @@ impl Default for ExtractionConfig {
         Self {
             max_output_tokens: 1024,
             max_attempts: 3,
+            use_gbnf_grammar: false,
             dedup: DedupConfig::default(),
         }
     }
@@ -88,10 +113,13 @@ pub fn extract_chunk(
         })
         .collect();
 
-    let request = GenerationRequest {
-        prompt: prompt::render_chunk_facts(&lines),
+    let rendered = prompt::render_chunk_facts(&lines);
+    let mut request = GenerationRequest {
+        prompt: rendered.clone(),
         max_output_tokens: config.max_output_tokens,
-        grammar: Some(prompt::CHUNK_FACTS_GRAMMAR.to_string()),
+        grammar: config
+            .use_gbnf_grammar
+            .then(|| prompt::CHUNK_FACTS_GRAMMAR.to_string()),
     };
 
     let attempts = config.max_attempts.max(1);
@@ -106,11 +134,20 @@ pub fn extract_chunk(
                 facts = Some(parsed);
                 break;
             }
-            Err(detail) => diagnostics.push(Diagnostic::UnparseableOutput {
-                chunk_id: chunk.id.clone(),
-                attempt,
-                detail,
-            }),
+            Err(detail) => {
+                diagnostics.push(Diagnostic::UnparseableOutput {
+                    chunk_id: chunk.id.clone(),
+                    attempt,
+                    detail,
+                });
+                // The retry asks a different question, because re-asking the
+                // same one would not be a retry. Generation is greedy and
+                // deterministic: an identical prompt produces an identical
+                // reply, so a loop that resent `rendered` verbatim would burn
+                // every attempt on the same unparseable output. Appending the
+                // repair note is what makes the bound worth having.
+                request.prompt = prompt::with_repair_note(&rendered);
+            }
         }
     }
 
@@ -163,9 +200,13 @@ fn generate(
 /// Parses the model's output into `Facts`.
 ///
 /// Trims to the outermost `{ … }` first. With the grammar attached there is
-/// nothing outside it to trim, but an engine that ignores the grammar (a test
-/// double, or a backend without grammar support) commonly wraps the object in a
-/// code fence, and recovering from that is free.
+/// nothing outside it to trim; unconstrained — which is the default, per
+/// `#1739` — a model very commonly wraps the object in a code fence or a line
+/// of preamble, and recovering from that costs nothing and saves an attempt.
+///
+/// `serde_json` into [`Facts`] is also the schema check: a category that came
+/// back as a string instead of a list, or an item missing `evidence`, is a
+/// parse error here rather than a value that reaches grounding.
 fn parse_facts(raw: &str) -> Result<Facts, String> {
     let start = raw.find('{').ok_or("no JSON object in output")?;
     let end = raw.rfind('}').ok_or("unterminated JSON object")?;

--- a/rust/airo_mind_meeting/src/prompt.rs
+++ b/rust/airo_mind_meeting/src/prompt.rs
@@ -48,6 +48,28 @@ pub fn render_chunk_facts(segments: &[(&str, &str)]) -> String {
     CHUNK_FACTS_TEMPLATE.replace(SEGMENTS_PLACEHOLDER, rendered.trim_end())
 }
 
+/// What a retry appends to a prompt whose previous answer did not parse.
+///
+/// Deliberately says nothing about the meeting: it corrects the *format* of the
+/// reply and nothing else, so it cannot nudge the model toward inventing
+/// content it did not extract the first time. Not versioned alongside
+/// [`PROMPT_VERSION`] for the same reason — it adds no extraction instruction,
+/// so it does not change what a given prompt version means.
+const REPAIR_NOTE: &str = concat!(
+    "\n\nYour previous reply could not be parsed. ",
+    "Reply with the JSON object only — no explanation, no code fence, ",
+    "no text before or after it. Start at `{` and end at `}`."
+);
+
+/// The same prompt, with the repair note appended.
+///
+/// Used only by Pass 1's retry path (`#1739`): unconstrained generation is
+/// greedy and deterministic, so an identical prompt yields an identical
+/// unparseable reply and the retry bound would be spent for nothing.
+pub fn with_repair_note(prompt: &str) -> String {
+    format!("{}{REPAIR_NOTE}", prompt.trim_end())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -78,6 +100,23 @@ mod tests {
     fn the_template_is_loaded_from_the_versioned_file_named_by_the_constant() {
         assert!(CHUNK_FACTS_TEMPLATE.contains(SEGMENTS_PLACEHOLDER));
         assert_eq!(PROMPT_VERSION, "chunk_facts.v1");
+    }
+
+    #[test]
+    fn the_repair_note_changes_the_prompt_without_changing_what_was_asked_for() {
+        let first = render_chunk_facts(&[("s0", "Priya will own the rollout.")]);
+        let retry = with_repair_note(&first);
+
+        assert_ne!(
+            retry, first,
+            "a retry that sends the same prompt is not a retry"
+        );
+        // Everything the first attempt asked for is still being asked for.
+        assert!(retry.contains("[s0] Priya will own the rollout."));
+        assert!(retry.contains("EXTRACT, NEVER SUMMARISE"));
+        assert!(retry.contains("NEVER INVENT"));
+        // And the note itself corrects format, not content.
+        assert!(retry.ends_with("Start at `{` and end at `}`."));
     }
 
     #[test]

--- a/rust/airo_mind_meeting/tests/golden.rs
+++ b/rust/airo_mind_meeting/tests/golden.rs
@@ -102,6 +102,9 @@ struct ScriptedEngine {
     /// Every prompt it was given, so a test can assert on what the model was
     /// actually asked.
     prompts: Mutex<Vec<String>>,
+    /// Every request's `grammar`, so a test can assert whether the sampler was
+    /// constrained — which `#1739` makes a safety property, not a detail.
+    grammars: Mutex<Vec<Option<String>>>,
 }
 
 impl ScriptedEngine {
@@ -119,6 +122,7 @@ impl ScriptedEngine {
                     .collect(),
             ),
             prompts: Mutex::new(Vec::new()),
+            grammars: Mutex::new(Vec::new()),
         }
     }
 
@@ -136,6 +140,10 @@ impl ScriptedEngine {
 
     fn prompts(&self) -> Vec<String> {
         self.prompts.lock().unwrap().clone()
+    }
+
+    fn grammars(&self) -> Vec<Option<String>> {
+        self.grammars.lock().unwrap().clone()
     }
 }
 
@@ -160,10 +168,7 @@ impl GenerationEngine for ScriptedEngine {
         if cancel.is_cancelled() {
             return Err(EngineError::Cancelled);
         }
-        assert!(
-            request.grammar.is_some(),
-            "extraction must always constrain the sampler with a grammar"
-        );
+        self.grammars.lock().unwrap().push(request.grammar.clone());
         self.prompts.lock().unwrap().push(request.prompt.clone());
 
         let key = first_segment_id(&request.prompt);
@@ -219,11 +224,18 @@ impl GenerationEngine for BrokenEngine {
 }
 
 fn run_reference(engine: &dyn GenerationEngine) -> airo_mind_meeting::Extraction {
+    run_reference_with(engine, &ExtractionConfig::default())
+}
+
+fn run_reference_with(
+    engine: &dyn GenerationEngine,
+    config: &ExtractionConfig,
+) -> airo_mind_meeting::Extraction {
     extract(
         engine,
         &reference_transcript(),
         &reference_meeting_input(),
-        &ExtractionConfig::default(),
+        config,
         &CancelToken::new(),
     )
     .expect("reference extraction should succeed")
@@ -438,6 +450,157 @@ fn every_item_in_the_ir_cites_a_segment_the_transcript_actually_has() {
             );
         }
     }
+}
+
+// ---------------------------------------------------------------------------
+// `#1739`: no terminating grammar reaches a real sampler by default
+// ---------------------------------------------------------------------------
+
+/// The regression test for `#1739`. A GBNF grammar with a terminal state — and
+/// `CHUNK_FACTS_GRAMMAR` closes with `}`, so it has one — makes llama.cpp
+/// `abort()` the whole OS process one token past completion. That is not a Rust
+/// panic and nothing above it can catch it, so the only assertion that means
+/// anything is that the default configuration never puts such a grammar in
+/// front of the sampler at all.
+#[test]
+fn extraction_does_not_constrain_the_sampler_by_default() {
+    let engine = ScriptedEngine::reference();
+    run_reference_with(&engine, &ExtractionConfig::default());
+
+    let grammars = engine.grammars();
+    assert!(!grammars.is_empty(), "no generation ran");
+    assert!(
+        grammars.iter().all(Option::is_none),
+        "the default config attached a grammar: {grammars:?}"
+    );
+}
+
+/// The other half of the same contract: the constrained path is still wired,
+/// still reaches the engine, and still produces the identical IR — it is opt-in
+/// pending a device confirmation of the driver fix, not deleted.
+#[test]
+fn the_grammar_still_reaches_the_engine_when_it_is_opted_into() {
+    let engine = ScriptedEngine::reference();
+    let extraction = run_reference_with(
+        &engine,
+        &ExtractionConfig {
+            use_gbnf_grammar: true,
+            ..ExtractionConfig::default()
+        },
+    );
+
+    let grammars = engine.grammars();
+    assert!(!grammars.is_empty(), "no generation ran");
+    assert!(
+        grammars
+            .iter()
+            .all(|g| g.as_deref() == Some(airo_mind_meeting::CHUNK_FACTS_GRAMMAR)),
+        "opting in did not attach the grammar: {grammars:?}"
+    );
+
+    let golden: MeetingIr = serde_json::from_str(include_str!("fixtures/golden_ir.json")).unwrap();
+    assert_eq!(
+        serde_json::to_value(&extraction.ir).unwrap(),
+        serde_json::to_value(&golden).unwrap(),
+        "constraining the sampler must not change the IR"
+    );
+}
+
+/// What the mitigation actually costs, and that it is paid. Unconstrained, the
+/// model can answer with prose — the failure mode the grammar existed to make
+/// impossible. The retry path has to absorb that and still land on the golden
+/// IR, or "default the grammar off" is not a mitigation, it is a regression.
+#[test]
+fn a_chunk_answered_with_prose_is_retried_and_still_lands_on_the_golden_ir() {
+    let prose = "Sure! In this part of the meeting the team talked about Kafka consumer lag \
+                 and agreed to add more pods.";
+    let engine = ScriptedEngine::new(&[
+        (
+            "s0",
+            &[prose, include_str!("fixtures/model_output/chunk-0.json")],
+        ),
+        ("s3", &[include_str!("fixtures/model_output/chunk-1.json")]),
+        ("s6", &[include_str!("fixtures/model_output/chunk-2.json")]),
+        ("s9", &[include_str!("fixtures/model_output/chunk-3.json")]),
+    ]);
+
+    let extraction = run_reference_with(&engine, &ExtractionConfig::default());
+
+    assert!(extraction.diagnostics.iter().any(|d| matches!(
+        d,
+        Diagnostic::UnparseableOutput { chunk_id, attempt: 1, .. } if chunk_id == "chunk-0"
+    )));
+    let golden: MeetingIr = serde_json::from_str(include_str!("fixtures/golden_ir.json")).unwrap();
+    assert_eq!(
+        serde_json::to_value(&extraction.ir).unwrap(),
+        serde_json::to_value(&golden).unwrap(),
+        "unconstrained generation plus retry must reach the same IR the grammar would have"
+    );
+}
+
+/// Output that parses as JSON but not as `Facts` is caught by the same path:
+/// `serde_json` into the IR types is the schema check, so a category of the
+/// wrong shape is an unparseable attempt rather than a value that survives
+/// into grounding.
+#[test]
+fn output_that_is_json_but_not_the_ir_schema_is_a_retryable_failure() {
+    let wrong_shape = "{\"decisions\": \"we agreed to add three more pods\"}";
+    let engine = ScriptedEngine::new(&[
+        (
+            "s0",
+            &[
+                wrong_shape,
+                include_str!("fixtures/model_output/chunk-0.json"),
+            ],
+        ),
+        ("s3", &[include_str!("fixtures/model_output/chunk-1.json")]),
+        ("s6", &[include_str!("fixtures/model_output/chunk-2.json")]),
+        ("s9", &[include_str!("fixtures/model_output/chunk-3.json")]),
+    ]);
+
+    let extraction = run_reference_with(&engine, &ExtractionConfig::default());
+
+    assert!(extraction.diagnostics.iter().any(|d| matches!(
+        d,
+        Diagnostic::UnparseableOutput { chunk_id, attempt: 1, .. } if chunk_id == "chunk-0"
+    )));
+    let golden: MeetingIr = serde_json::from_str(include_str!("fixtures/golden_ir.json")).unwrap();
+    assert_eq!(
+        serde_json::to_value(&extraction.ir).unwrap(),
+        serde_json::to_value(&golden).unwrap()
+    );
+}
+
+/// Without the grammar, retry is the only thing standing between a bad reply
+/// and an abandoned chunk — so a retry that re-sent the identical prompt would
+/// be worthless against a greedy, deterministic sampler. The second attempt
+/// must ask something the first did not.
+#[test]
+fn a_retry_asks_a_different_question_than_the_attempt_that_failed() {
+    let engine = ScriptedEngine::new(&[
+        (
+            "s0",
+            &[
+                "not json at all",
+                include_str!("fixtures/model_output/chunk-0.json"),
+            ],
+        ),
+        ("s3", &[include_str!("fixtures/model_output/chunk-1.json")]),
+        ("s6", &[include_str!("fixtures/model_output/chunk-2.json")]),
+        ("s9", &[include_str!("fixtures/model_output/chunk-3.json")]),
+    ]);
+
+    run_reference_with(&engine, &ExtractionConfig::default());
+
+    let prompts = engine.prompts();
+    let chunk_0: Vec<&String> = prompts.iter().filter(|p| p.contains("\n[s0] ")).collect();
+    assert_eq!(chunk_0.len(), 2, "chunk-0 should have been asked twice");
+    assert_ne!(
+        chunk_0[0], chunk_0[1],
+        "the retry re-sent the prompt that just failed"
+    );
+    // Still the same extraction task, only a corrected reply format.
+    assert!(chunk_0[1].starts_with(chunk_0[0].trim_end()));
 }
 
 /// Truncated output is the realistic grammar-era failure: the sampler cannot


### PR DESCRIPTION
Closes #1739 partially — see "Fix or mitigation?" below, which is the part worth reading.

## The bug

`llama-cpp-2` 0.1.153 aborts the whole OS process the moment a GBNF grammar reaches a fully-matched terminal state and the sampler is asked for one more token:

```
llama-cpp-sys-2-0.1.153/llama.cpp/src/llama-grammar.cpp:940: GGML_ASSERT(!stacks.empty()) failed
```

This is live on `main` right now, not theoretical: `rust/airo_mind_meeting/src/pass1.rs` unconditionally set `grammar: Some(CHUNK_FACTS_GRAMMAR)` on every generation request, and `CHUNK_FACTS_GRAMMAR` is a JSON-object grammar that closes with `}`. Every real on-device extraction call was one generation away from taking the app process down. `#1628`'s acceptance test never caught it because its `[0-9]+` grammar has no terminal state — there is always a "one more digit" continuation, so the stacks never empty.

## Root cause

Read out of the vendored llama.cpp in `llama-cpp-sys-2` 0.1.153 (not guessed):

1. `llama_grammar_accept_token` (`llama-grammar.cpp:1503`) does `grammar.stacks = std::move(stacks_new)` and **then** throws `std::runtime_error("Unexpected empty grammar stack")` when the accepted token left no viable continuation. The state is already corrupted at the point the exception is raised.
2. `llama-cpp-2`'s `LlamaSampler::accept` is `{ let _ = self.try_accept(token); }` — it discards the status the C++ shim (`wrapper_common.cpp:113`) went to the trouble of catching.
3. So the grammar carries empty stacks into the next `sample`, `llama_grammar_apply_impl` calls `llama_grammar_reject_candidates`, and its first line is `GGML_ASSERT(!stacks.empty())`.

It is an `abort()`. Not a Rust panic, not a catchable FFI error at that point — nothing above it can recover.

## The fix (`airo_mind_llama/src/llama.rs`)

Use `try_accept` instead of `accept`. Its `Err` **is** the "grammar reached a terminal state" signal, and it arrives one step *before* the aborting `sample`. The token is emitted (it is in-grammar — the same chain's grammar sampler is what allowed it) and generation stops, for the same reason EOG stops it.

The EOG check also moves ahead of `accept`, closing a second, independent abort path: `llama_grammar_accept_impl` calls `GGML_ABORT` (line 1434) if handed an EOG token while no grammar stack is complete. A token that is never emitted has nothing worth recording in sampler state, so there was never a reason to hand it over first.

This is issue #1739's own suggested project-side workaround, and it turns out to need no unsafe FFI and no fork — just the error value the binding already computes and throws away. **No dependency bump is involved:** the assert is present verbatim through at least b10200, and utilityai/llama-cpp-rs#1007 is still open. Confirmed by prior investigation; not re-litigated here.

`try_accept` is gated on `llama-cpp-2`'s `common` feature, which this crate already enables. `Cargo.toml`'s justification comment for `common` is updated — it is now a correctness dependency, not only the way to reach `LlamaSampler::grammar`, and dropping it would silently reintroduce a process crash.

## Fix or mitigation?

**Both, deliberately, and the honest answer is "the fix is unverified here".**

The driver change above is a real fix. But it is proven by reading llama.cpp's source, not by running it: there is no GGUF model in this checkout (`rust/airo_mind_llama/models/` does not exist), so every test in `generation_offline.rs` skips, including the new one. An unverified fix to a path that aborts the app process is not something to leave switched on by default.

So `airo_mind_meeting` also stops putting a terminating grammar in front of a real sampler:

- `ExtractionConfig::use_gbnf_grammar` is new and **defaults to `false`**. Documented as a safety default with an explicit note that it is the intended default again once #1739 is confirmed on a device.
- Pass 1's existing bounded-retry loop becomes the load-bearing shape guarantee instead of a mop-up for truncation. `serde_json` into `Facts` is the schema check — a category of the wrong shape is a retryable failure, not a value that reaches grounding.
- Retries now append a **format-only** repair note. This matters: sampling is greedy and deterministic, so a retry that re-sent the identical prompt would spend the entire attempt bound receiving the identical unparseable reply. The note corrects reply format and says nothing about the meeting, so it cannot nudge the model toward inventing content.

Together: the crash path is fixed, *and* nothing reaches the crash path by default until someone confirms the fix on hardware.

## Tests

- `a_grammar_that_can_finish_does_not_abort_the_process` — the exact `root ::= "{" "}"` reproduction from the issue, with `max_output_tokens` far above what the grammar can consume. Surviving to the assertions is the result. Skips without a model, so **CI does not prove this**; a dev-loop or device run does.
- `extraction_does_not_constrain_the_sampler_by_default` — the default config attaches no grammar to any request.
- `the_grammar_still_reaches_the_engine_when_it_is_opted_into` — the constrained path is opt-in, not deleted, and produces the byte-identical golden IR.
- `a_chunk_answered_with_prose_is_retried_and_still_lands_on_the_golden_ir` — what the mitigation costs, and that it is paid. Prose is the failure mode the grammar existed to prevent; retry must absorb it or defaulting off is a regression, not a mitigation.
- `output_that_is_json_but_not_the_ir_schema_is_a_retryable_failure`
- `a_retry_asks_a_different_question_than_the_attempt_that_failed`
- `the_repair_note_changes_the_prompt_without_changing_what_was_asked_for`

## Blast radius

`ExtractionConfig` has one new field; it is `Clone + Debug + PartialEq` with a `Default`, and every construction site in the tree uses `..Default::default()` or `ExtractionConfig::default()`. No caller anywhere else in the repo passes a grammar (`airo_mind_cli`, `mom.rs`, `airo_mind_eval` all pass `None`). #1634 / #1635 / #1657 logic is untouched, and open PR #1760 does not overlap these files.

## Checks

```
cargo fmt --all -- --check                                        clean
cargo clippy -p airo_mind_meeting --all-targets -- -D warnings    clean
cargo clippy -p airo_mind_llama --features llama --all-targets    clean  (builds llama.cpp; proves the driver change compiles)
cargo test -p airo_mind_meeting                                   113 passed
cargo check --workspace --exclude airo_mind_cli                   clean
```

`cargo check --workspace` fails in `airo_mind_cli` (an `E0061` arity mismatch on a whisper cancel-token argument). **Pre-existing on `origin/main`** — verified by stashing this branch's changes and re-running. Untouched here; it wants its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
