### PR TITLE
feat(mind): in-app meeting audio capture + resumable background processing (#1656)

### DIFF
--- a/app/android/app/src/main/AndroidManifest.xml
+++ b/app/android/app/src/main/AndroidManifest.xml
@@ -22,6 +22,9 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC"/>
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
     <uses-permission android:name="android.permission.WAKE_LOCK"/>
+    <!-- MeetingRecordingService (#1656 AC2): required on Android 14+ to run
+         a foreground service of type microphone. -->
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MICROPHONE"/>
 
     <application
         android:label="${appLabel}"
@@ -124,6 +127,12 @@
             android:foregroundServiceType="dataSync"
             android:exported="false"
             tools:node="merge" />
+
+        <!-- Mic-use notification for in-app meeting capture (#1656 AC2). -->
+        <service
+            android:name=".MeetingRecordingService"
+            android:foregroundServiceType="microphone"
+            android:exported="false" />
     </application>
     <!-- Required to query activities that can process text, see:
          https://developer.android.com/training/package-visibility and

--- a/app/android/app/src/mind/AndroidManifest.xml
+++ b/app/android/app/src/mind/AndroidManifest.xml
@@ -25,6 +25,9 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC"/>
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
     <uses-permission android:name="android.permission.WAKE_LOCK"/>
+    <!-- MeetingRecordingService (#1656 AC2): required on Android 14+ to run
+         a foreground service of type microphone. -->
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MICROPHONE"/>
 
     <application
         android:label="${appLabel}"
@@ -90,6 +93,12 @@
                 <action android:name="android.intent.action.MEDIA_BUTTON" />
             </intent-filter>
         </receiver>
+
+        <!-- Mic-use notification for in-app meeting capture (#1656 AC2). -->
+        <service
+            android:name=".MeetingRecordingService"
+            android:foregroundServiceType="microphone"
+            android:exported="false" />
     </application>
 
     <!-- Required to query activities that can process text, see:

--- a/app/android/app/src/product/kotlin/io/airo/app/MainActivity.kt
+++ b/app/android/app/src/product/kotlin/io/airo/app/MainActivity.kt
@@ -11,6 +11,7 @@ import android.content.pm.PackageManager
 import android.hardware.camera2.CameraCharacteristics
 import android.hardware.camera2.CameraManager
 import android.net.Uri
+import android.os.Build
 import android.os.Bundle
 import android.provider.CalendarContract
 import android.provider.ContactsContract
@@ -42,6 +43,10 @@ class MainActivity : AudioServiceFragmentActivity() {
     private val EMBEDDING_CHANNEL = "com.airo.embedding"
     private val AGENT_CONNECTORS_CHANNEL = "com.airo.agent_connectors"
     private val DEVICE_INFO_CHANNEL = "com.airo/device_info"
+    // Foreground-service mic-use notification for in-app meeting capture
+    // (#1656 AC2). See MeetingRecordingService's doc comment for why this is
+    // a plain start/stop Intent pair rather than a bound service.
+    private val MEETING_RECORDING_CHANNEL = "com.airo.meeting_recording"
     private val CALENDAR_READ_PERMISSION_REQUEST = 9001
     private val CALENDAR_WRITE_PERMISSION_REQUEST = 9002
     private val VOICE_PERMISSION_REQUEST = 9003
@@ -113,6 +118,28 @@ class MainActivity : AudioServiceFragmentActivity() {
                     )
                     "startListening" -> startVoiceListening(result)
                     "stopListening" -> stopVoiceListening(result)
+                    else -> result.notImplemented()
+                }
+            }
+
+        MethodChannel(flutterEngine.dartExecutor.binaryMessenger, MEETING_RECORDING_CHANNEL)
+            .setMethodCallHandler { call, result ->
+                when (call.method) {
+                    "start" -> {
+                        val title = call.argument<String>("title") ?: "Recording meeting audio"
+                        val text = call.argument<String>("text")
+                        val intent = MeetingRecordingService.startIntent(this, title, text)
+                        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                            startForegroundService(intent)
+                        } else {
+                            startService(intent)
+                        }
+                        result.success(null)
+                    }
+                    "stop" -> {
+                        startService(MeetingRecordingService.stopIntent(this))
+                        result.success(null)
+                    }
                     else -> result.notImplemented()
                 }
             }

--- a/app/android/app/src/product/kotlin/io/airo/app/MeetingRecordingService.kt
+++ b/app/android/app/src/product/kotlin/io/airo/app/MeetingRecordingService.kt
@@ -1,0 +1,127 @@
+package io.airo.app
+
+import android.app.Notification
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.app.Service
+import android.content.Context
+import android.content.Intent
+import android.content.pm.ServiceInfo
+import android.os.Build
+import android.os.IBinder
+
+/**
+ * Foreground service backing #1656 AC2 -- "Android: foreground service with
+ * mic-use notification; respect OS mic privacy indicators".
+ *
+ * This service does not touch the microphone itself: `record`'s
+ * `AudioRecorder` (invoked from Dart, `AudioRecorderPort`) does the actual
+ * capture. This class exists purely so Android does not kill the recording
+ * process the moment the app backgrounds -- a `RECORD_AUDIO`-holding process
+ * with no foreground service of type `microphone` is exactly what Android
+ * 14+'s background-mic restrictions kill first. Because
+ * `MeetingCaptureController.start` calls
+ * `MeetingRecordingServiceGateway.start` immediately before
+ * `AudioRecorderPort.start`, this service's persistent notification is up
+ * *before* the encoder opens the mic, and Android's own mic-privacy
+ * indicator (the green dot / status-bar icon) is driven entirely by the OS
+ * from the `RECORD_AUDIO` permission grant -- nothing in this class can
+ * suppress or route around it, by design (AC2's "respect OS mic privacy
+ * indicators" is therefore automatic, not something this service implements).
+ *
+ * Started/stopped from Dart via `MeetingRecordingServiceGateway`
+ * (`com.airo.meeting_recording` MethodChannel, wired in
+ * `MainActivity.configureFlutterEngine`) rather than bound -- there is
+ * nothing for Dart to call back into once the notification is showing, so a
+ * fire-and-forget start/stop `Intent` pair is the whole contract.
+ */
+class MeetingRecordingService : Service() {
+    companion object {
+        const val ACTION_START = "io.airo.app.MEETING_RECORDING_START"
+        const val ACTION_STOP = "io.airo.app.MEETING_RECORDING_STOP"
+        const val EXTRA_TITLE = "title"
+        const val EXTRA_TEXT = "text"
+
+        private const val CHANNEL_ID = "meeting_recording"
+        private const val NOTIFICATION_ID = 4201
+
+        fun startIntent(context: Context, title: String, text: String?): Intent {
+            return Intent(context, MeetingRecordingService::class.java).apply {
+                action = ACTION_START
+                putExtra(EXTRA_TITLE, title)
+                putExtra(EXTRA_TEXT, text)
+            }
+        }
+
+        fun stopIntent(context: Context): Intent {
+            return Intent(context, MeetingRecordingService::class.java).apply {
+                action = ACTION_STOP
+            }
+        }
+    }
+
+    override fun onBind(intent: Intent?): IBinder? = null
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        when (intent?.action) {
+            ACTION_STOP -> {
+                stopForeground(STOP_FOREGROUND_REMOVE)
+                stopSelf()
+            }
+            else -> {
+                val title = intent?.getStringExtra(EXTRA_TITLE) ?: "Recording meeting audio"
+                val text = intent?.getStringExtra(EXTRA_TEXT)
+                startForegroundWithNotification(title, text)
+            }
+        }
+        // Not sticky: if the OS kills this service, the recording it was
+        // covering has already stopped (the process died), so there is
+        // nothing meaningful to restart into.
+        return START_NOT_STICKY
+    }
+
+    private fun startForegroundWithNotification(title: String, text: String?) {
+        ensureChannel()
+        val openApp = packageManager.getLaunchIntentForPackage(packageName)
+        val contentIntent = openApp?.let {
+            PendingIntent.getActivity(
+                this,
+                0,
+                it,
+                PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
+            )
+        }
+        val notification = Notification.Builder(this, CHANNEL_ID)
+            .setContentTitle(title)
+            .setContentText(text ?: "")
+            .setSmallIcon(applicationInfo.icon)
+            .setOngoing(true)
+            .apply { if (contentIntent != null) setContentIntent(contentIntent) }
+            .build()
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            startForeground(
+                NOTIFICATION_ID,
+                notification,
+                ServiceInfo.FOREGROUND_SERVICE_TYPE_MICROPHONE,
+            )
+        } else {
+            startForeground(NOTIFICATION_ID, notification)
+        }
+    }
+
+    private fun ensureChannel() {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return
+        val manager = getSystemService(NotificationManager::class.java) ?: return
+        if (manager.getNotificationChannel(CHANNEL_ID) != null) return
+        val channel = NotificationChannel(
+            CHANNEL_ID,
+            "Meeting recording",
+            NotificationManager.IMPORTANCE_LOW,
+        ).apply {
+            description = "Shown while Airo Mind is recording a meeting."
+        }
+        manager.createNotificationChannel(channel)
+    }
+}

--- a/app/ios/Runner/Info.plist
+++ b/app/ios/Runner/Info.plist
@@ -70,7 +70,7 @@
 	<key>NSCameraUsageDescription</key>
 	<string>This app needs camera access for AI features</string>
 	<key>NSMicrophoneUsageDescription</key>
-	<string>This app needs microphone access for voice commands</string>
+	<string>This app needs microphone access for voice commands and to record meeting audio you start in Airo Mind.</string>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string>This app needs location access for location-based features</string>
 	<key>NSCalendarsUsageDescription</key>

--- a/app/lib/core/mind/mind_processing_queue.dart
+++ b/app/lib/core/mind/mind_processing_queue.dart
@@ -17,14 +17,12 @@ import 'package:path_provider/path_provider.dart';
 List<Override> mindMeetingProcessingOverrides(MindService service) => [
   meetingProcessingQueueProvider.overrideWith((ref) async {
     final path = await _processingQueuePath();
-    final retentionPolicyState = ref.watch(audioRetentionPolicyProvider);
     final runner = MeetingProcessingJobRunner(
       mindService: service,
-      // A closure that reads current Riverpod state, not the value at
-      // override time -- ref.watch above only re-creates the queue when the
-      // toggle flips, but `MeetingProcessingJobRunner` reads this per job it
-      // runs, so a job that finishes long after the toggle changed still
-      // gets today's answer.
+      // A closure that reads current Riverpod state at call time, not a
+      // value captured once here, so a person who flips the Settings toggle
+      // mid-queue has it apply to the very next job that finishes or fails,
+      // not just ones enqueued after the change.
       retentionPolicy: () => ref.read(audioRetentionPolicyProvider),
     );
     final queue = MeetingProcessingQueue(
@@ -37,6 +35,10 @@ List<Override> mindMeetingProcessingOverrides(MindService service) => [
         availableStorageMb: () async => 4096,
       ),
       processJob: runner.call,
+      // chief-security-officer review (#1656): a job that exhausts its
+      // retry budget must still honour a delete-after-transcript policy --
+      // see `MeetingProcessingJobRunner.cleanupAfterTerminalFailure`'s doc.
+      onTerminalFailure: runner.cleanupAfterTerminalFailure,
     );
     ref.onDispose(() {
       // ignore: discarded_futures

--- a/app/lib/core/mind/mind_processing_queue.dart
+++ b/app/lib/core/mind/mind_processing_queue.dart
@@ -1,0 +1,56 @@
+import 'package:feature_mind/feature_mind.dart';
+import 'package:flutter_riverpod/misc.dart';
+import 'package:path/path.dart' as p;
+import 'package:path_provider/path_provider.dart';
+
+/// Wires #1656's resumable post-meeting processing queue to this shell's real
+/// [MindService] — the same instance [buildMindDownloadService] built for the
+/// scribe journey, so a job the queue processes lands in the same store the
+/// rest of Airo Mind reads from.
+///
+/// Mirrors [mindModelRegistryOverrides]'s shape: a `List<Override>` built
+/// from the already-constructed [MindService], contributed at the shell's
+/// composition root because `feature_mind`'s own
+/// `meetingProcessingQueueProvider` deliberately ships with no real
+/// `processJob` (see that provider's doc comment) — only the app knows which
+/// `MindService` instance is "the" one.
+List<Override> mindMeetingProcessingOverrides(MindService service) => [
+  meetingProcessingQueueProvider.overrideWith((ref) async {
+    final path = await _processingQueuePath();
+    final retentionPolicyState = ref.watch(audioRetentionPolicyProvider);
+    final runner = MeetingProcessingJobRunner(
+      mindService: service,
+      // A closure that reads current Riverpod state, not the value at
+      // override time -- ref.watch above only re-creates the queue when the
+      // toggle flips, but `MeetingProcessingJobRunner` reads this per job it
+      // runs, so a job that finishes long after the toggle changed still
+      // gets today's answer.
+      retentionPolicy: () => ref.read(audioRetentionPolicyProvider),
+    );
+    final queue = MeetingProcessingQueue(
+      store: FileMeetingProcessingQueueStore(path),
+      // No real free-disk-space probe exists in this codebase yet -- see
+      // `RealLlmDeviceSignalsProbe.availableStorageMb`'s doc comment and
+      // `meeting_capture_providers.dart`'s matching note. Thermal pressure,
+      // the signal this queue actually gates on, does not depend on it.
+      deviceSignalsProbe: RealLlmDeviceSignalsProbe(
+        availableStorageMb: () async => 4096,
+      ),
+      processJob: runner.call,
+    );
+    ref.onDispose(() {
+      // ignore: discarded_futures
+      queue.dispose();
+    });
+    await queue.restore();
+    return queue;
+  }),
+];
+
+/// Same base directory `nextMeetingRecordingPath()`
+/// (`capture/application/meeting_capture_providers.dart`) writes recordings
+/// into -- the queue file lives next to the audio it tracks.
+Future<String> _processingQueuePath() async {
+  final dir = await getApplicationSupportDirectory();
+  return p.join(dir.path, 'mind_recordings', 'processing_queue.json');
+}

--- a/app/lib/main_mind.dart
+++ b/app/lib/main_mind.dart
@@ -66,6 +66,7 @@ import 'core/config/firebase_status.dart';
 import 'core/error/global_error_handler.dart';
 import 'core/mind/mind_model_catalog.dart';
 import 'core/mind/mind_model_sources.dart';
+import 'core/mind/mind_processing_queue.dart';
 import 'core/mind/mind_shell.dart';
 import 'core/mind/mind_unavailable_screen.dart';
 import 'core/pro/pro_bootstrap_runner.dart';
@@ -123,8 +124,13 @@ ModuleRegistry buildMindModuleRegistry() {
     // here rather than by the package because the provider being overridden is
     // this app's, and because only this shell wants the rows — the super app's
     // model manager lists its own chat models and nothing else.
-    scribeOverrides: (service) =>
-        mindModelRegistryOverrides(modelsDirectory: service.modelsDirectory),
+    scribeOverrides: (service) => [
+      ...mindModelRegistryOverrides(modelsDirectory: service.modelsDirectory),
+      // #1656: the resumable post-meeting processing queue runs the same
+      // MindService instance the scribe journey uses, so a job it processes
+      // lands in the one store this shell reads from.
+      ...mindMeetingProcessingOverrides(service),
+    ],
   );
   return ModuleRegistry(shell: ShellId.mind)..register(mind);
 }

--- a/packages/feature_mind/lib/feature_mind.dart
+++ b/packages/feature_mind/lib/feature_mind.dart
@@ -243,6 +243,7 @@ export 'src/capture/data/meeting_recording_service_gateway.dart';
 export 'src/capture/data/meeting_processing_queue_store.dart';
 export 'src/capture/application/meeting_capture_controller.dart';
 export 'src/capture/application/meeting_processing_queue.dart';
+export 'src/capture/application/meeting_processing_job_runner.dart';
 export 'src/capture/application/meeting_capture_providers.dart';
 export 'src/capture/application/audio_retention_preference.dart';
 export 'src/capture/presentation/meeting_capture_screen.dart';

--- a/packages/feature_mind/lib/feature_mind.dart
+++ b/packages/feature_mind/lib/feature_mind.dart
@@ -230,3 +230,20 @@ export 'src/notes/domain/notes_operation_log.dart';
 export 'src/notes/domain/notes_projection.dart';
 export 'src/notes/notes_capability.dart';
 export 'src/notes/presentation/notes_screen.dart';
+
+// In-app meeting audio capture + resumable background processing (#1656).
+// Feeds `meetings.dart`'s `transcribeRecording`/`saveMeeting` (the ".m4a in"
+// pipeline) with a file this package now records itself, instead of only
+// accepting one that already exists on disk.
+export 'src/capture/domain/meeting_recording_state.dart';
+export 'src/capture/domain/audio_retention_policy.dart';
+export 'src/capture/domain/meeting_processing_job.dart';
+export 'src/capture/data/audio_recorder_port.dart';
+export 'src/capture/data/meeting_recording_service_gateway.dart';
+export 'src/capture/data/meeting_processing_queue_store.dart';
+export 'src/capture/application/meeting_capture_controller.dart';
+export 'src/capture/application/meeting_processing_queue.dart';
+export 'src/capture/application/meeting_capture_providers.dart';
+export 'src/capture/application/audio_retention_preference.dart';
+export 'src/capture/presentation/meeting_capture_screen.dart';
+export 'src/capture/presentation/audio_retention_settings_tile.dart';

--- a/packages/feature_mind/lib/src/agent_chat/presentation/screens/profile_screen.dart
+++ b/packages/feature_mind/lib/src/agent_chat/presentation/screens/profile_screen.dart
@@ -73,7 +73,10 @@ class ProfileScreen extends ConsumerWidget {
             const SizedBox(height: 24),
             // #1656 AC5: raw-audio retention is a Settings toggle, not
             // hardcoded.
-            Text('Meeting recordings', style: Theme.of(context).textTheme.titleMedium),
+            Text(
+              'Meeting recordings',
+              style: Theme.of(context).textTheme.titleMedium,
+            ),
             const AudioRetentionSettingsTile(),
 
             const SizedBox(height: 32),

--- a/packages/feature_mind/lib/src/agent_chat/presentation/screens/profile_screen.dart
+++ b/packages/feature_mind/lib/src/agent_chat/presentation/screens/profile_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
+import '../../../capture/presentation/audio_retention_settings_tile.dart';
 import '../../../host/assistant_host_adapter.dart';
 import '../../../quotes/presentation/widgets/daily_quote_card.dart';
 import '../../../routing/assistant_route_names.dart';
@@ -68,6 +69,12 @@ class ProfileScreen extends ConsumerWidget {
 
             const SizedBox(height: 24),
             host.aiPreferencesSection(),
+
+            const SizedBox(height: 24),
+            // #1656 AC5: raw-audio retention is a Settings toggle, not
+            // hardcoded.
+            Text('Meeting recordings', style: Theme.of(context).textTheme.titleMedium),
+            const AudioRetentionSettingsTile(),
 
             const SizedBox(height: 32),
 

--- a/packages/feature_mind/lib/src/capture/application/audio_retention_preference.dart
+++ b/packages/feature_mind/lib/src/capture/application/audio_retention_preference.dart
@@ -1,0 +1,33 @@
+import 'package:flutter_riverpod/legacy.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../domain/audio_retention_policy.dart';
+
+/// Persistence key for the Settings toggle (#1656 AC5). Same
+/// `SharedPreferences` house pattern as `selectedAssistantModelIdProvider`
+/// (`agent_chat/application/assistant_model_preferences.dart`).
+const String audioRetentionPolicyKey = 'mind_audio_retention_policy';
+
+final audioRetentionPolicyProvider =
+    StateNotifierProvider<AudioRetentionPolicyNotifier, AudioRetentionPolicy>(
+      (ref) => AudioRetentionPolicyNotifier(),
+    );
+
+class AudioRetentionPolicyNotifier extends StateNotifier<AudioRetentionPolicy> {
+  AudioRetentionPolicyNotifier() : super(AudioRetentionPolicy.fallback) {
+    _load();
+  }
+
+  Future<void> _load() async {
+    final prefs = await SharedPreferences.getInstance();
+    state = AudioRetentionPolicy.fromStorageValue(
+      prefs.getString(audioRetentionPolicyKey),
+    );
+  }
+
+  Future<void> select(AudioRetentionPolicy policy) async {
+    state = policy;
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(audioRetentionPolicyKey, policy.storageValue);
+  }
+}

--- a/packages/feature_mind/lib/src/capture/application/meeting_capture_controller.dart
+++ b/packages/feature_mind/lib/src/capture/application/meeting_capture_controller.dart
@@ -1,0 +1,215 @@
+import 'dart:async';
+
+import '../data/audio_recorder_port.dart';
+import '../data/meeting_recording_service_gateway.dart';
+import '../domain/meeting_recording_state.dart';
+
+/// Drives one meeting-capture session: start → (pause ⇄ resume)* → stop.
+///
+/// This is the object `MeetingCaptureScreen` holds — everything it needs to
+/// know about the in-progress recording comes from [snapshots], and every
+/// action it can take is one of the four methods below. It never touches
+/// [AudioRecorderPort] directly, mirroring `AudioScribeConsentGate`'s "no
+/// bypass to reach for" shape: this controller *is* the gate for the file
+/// encoder, the same way that gate is the gate for the streaming one, and a
+/// caller wanting to record a meeting has exactly one door.
+///
+/// Consent: this controller does not itself hold an
+/// `AudioScribeConsentGate` — file capture and live dictation are different
+/// screens with independent consent grants, so the caller owns the gate and
+/// is expected to call `start` only after `AudioScribeConsentGate.grant` has
+/// succeeded (`MeetingCaptureScreen` wires this the same way
+/// `AudioScribeScreen` already does for the streaming path). Duplicating a
+/// second internal gate here would just be a second door that could get out
+/// of sync with the first.
+class MeetingCaptureController {
+  MeetingCaptureController({
+    required AudioRecorderPort recorder,
+    MeetingRecordingServiceGateway? serviceGateway,
+    Duration tickInterval = const Duration(seconds: 1),
+  }) : _recorder = recorder,
+       _serviceGateway = serviceGateway ?? const NoopMeetingRecordingServiceGateway(),
+       _tickInterval = tickInterval {
+    _osSub = _recorder.osEvents.listen(_onOsEvent);
+  }
+
+  // Not initializing-formals (`this._recorder`, ...): the named-parameter
+  // names below (`recorder`, `serviceGateway`, `tickInterval`) are the public
+  // constructor API, and an initializing formal on a private field forces the
+  // parameter name to match the field name -- which would make the
+  // parameters unusable as named arguments from any other library. Kept
+  // explicit on purpose.
+  final AudioRecorderPort _recorder;
+  final MeetingRecordingServiceGateway _serviceGateway;
+  final Duration _tickInterval;
+
+  final _controller = StreamController<MeetingRecordingSnapshot>.broadcast();
+  StreamSubscription<RecorderOsEvent>? _osSub;
+  Timer? _ticker;
+
+  MeetingRecordingSnapshot _snapshot = MeetingRecordingSnapshot.idle;
+  DateTime? _segmentStartedAt;
+
+  Stream<MeetingRecordingSnapshot> get snapshots => _controller.stream;
+
+  MeetingRecordingSnapshot get current => _snapshot;
+
+  bool get isRecording =>
+      _snapshot.lifecycle == MeetingRecordingLifecycle.recording;
+
+  /// Begins encoding to [path]. Throws [StateError] if a session is already
+  /// active — callers create a fresh controller (or call [reset]) per
+  /// recording, the same one-consent-per-session shape
+  /// `AudioScribeConsentGate.reset` documents.
+  Future<void> start(String path) async {
+    if (_snapshot.lifecycle != MeetingRecordingLifecycle.idle) {
+      throw StateError(
+        'MeetingCaptureController.start called from ${_snapshot.lifecycle.name}; '
+        'a controller records one session. Create a new controller for the '
+        'next one.',
+      );
+    }
+    final granted = await _recorder.hasPermission();
+    if (!granted) {
+      _emit(
+        _snapshot.copyWith(
+          lifecycle: MeetingRecordingLifecycle.failed,
+          error: 'Microphone permission was not granted.',
+        ),
+      );
+      return;
+    }
+    await _serviceGateway.start(
+      notificationTitle: 'Recording meeting audio',
+      notificationText: 'Airo Mind is recording. Tap to return to the app.',
+    );
+    await _recorder.start(path);
+    _segmentStartedAt = DateTime.now();
+    _emit(
+      MeetingRecordingSnapshot(
+        lifecycle: MeetingRecordingLifecycle.recording,
+        filePath: path,
+        elapsedMs: 0,
+      ),
+    );
+    _startTicker();
+  }
+
+  Future<void> pause() async {
+    if (_snapshot.lifecycle != MeetingRecordingLifecycle.recording) return;
+    await _recorder.pause();
+    _freezeElapsed();
+    _emit(
+      _snapshot.copyWith(
+        lifecycle: MeetingRecordingLifecycle.paused,
+        pausedByOs: false,
+      ),
+    );
+    _stopTicker();
+  }
+
+  Future<void> resume() async {
+    if (_snapshot.lifecycle != MeetingRecordingLifecycle.paused) return;
+    await _recorder.resume();
+    _segmentStartedAt = DateTime.now();
+    _emit(
+      _snapshot.copyWith(
+        lifecycle: MeetingRecordingLifecycle.recording,
+        pausedByOs: false,
+      ),
+    );
+    _startTicker();
+  }
+
+  /// Finalises the file and returns its path, or null if nothing was ever
+  /// recorded. Terminal — this controller cannot be restarted afterwards.
+  Future<String?> stop() async {
+    if (_snapshot.lifecycle != MeetingRecordingLifecycle.recording &&
+        _snapshot.lifecycle != MeetingRecordingLifecycle.paused) {
+      return null;
+    }
+    _freezeElapsed();
+    _stopTicker();
+    final path = await _recorder.stop();
+    await _serviceGateway.stop();
+    _emit(_snapshot.copyWith(lifecycle: MeetingRecordingLifecycle.stopped));
+    return path;
+  }
+
+  void _onOsEvent(RecorderOsEvent event) {
+    switch (event) {
+      case RecorderOsEvent.osPaused:
+        if (_snapshot.lifecycle == MeetingRecordingLifecycle.recording) {
+          _freezeElapsed();
+          _stopTicker();
+          _emit(
+            _snapshot.copyWith(
+              lifecycle: MeetingRecordingLifecycle.paused,
+              pausedByOs: true,
+            ),
+          );
+        }
+      case RecorderOsEvent.osResumed:
+        if (_snapshot.lifecycle == MeetingRecordingLifecycle.paused &&
+            _snapshot.pausedByOs) {
+          _segmentStartedAt = DateTime.now();
+          _emit(
+            _snapshot.copyWith(
+              lifecycle: MeetingRecordingLifecycle.recording,
+              pausedByOs: false,
+            ),
+          );
+          _startTicker();
+        }
+      case RecorderOsEvent.osStopped:
+        // The OS ended the session entirely (rare — e.g. another app seized
+        // exclusive audio input). Treat it like `stop()` without a file
+        // handle to return; the caller's `stop()` call still runs and simply
+        // finds nothing further to finalise.
+        if (_snapshot.lifecycle == MeetingRecordingLifecycle.recording ||
+            _snapshot.lifecycle == MeetingRecordingLifecycle.paused) {
+          _freezeElapsed();
+          _stopTicker();
+          _emit(
+            _snapshot.copyWith(lifecycle: MeetingRecordingLifecycle.stopped),
+          );
+        }
+    }
+  }
+
+  void _startTicker() {
+    _stopTicker();
+    _ticker = Timer.periodic(_tickInterval, (_) {
+      if (_snapshot.lifecycle != MeetingRecordingLifecycle.recording) return;
+      _emit(_snapshot.copyWith(elapsedMs: _liveElapsedMs()));
+    });
+  }
+
+  void _stopTicker() {
+    _ticker?.cancel();
+    _ticker = null;
+  }
+
+  int _liveElapsedMs() {
+    final startedAt = _segmentStartedAt;
+    if (startedAt == null) return _snapshot.elapsedMs;
+    return _snapshot.elapsedMs + DateTime.now().difference(startedAt).inMilliseconds;
+  }
+
+  void _freezeElapsed() {
+    _snapshot = _snapshot.copyWith(elapsedMs: _liveElapsedMs());
+    _segmentStartedAt = null;
+  }
+
+  void _emit(MeetingRecordingSnapshot snapshot) {
+    _snapshot = snapshot;
+    if (!_controller.isClosed) _controller.add(snapshot);
+  }
+
+  Future<void> dispose() async {
+    _stopTicker();
+    await _osSub?.cancel();
+    await _controller.close();
+    await _recorder.dispose();
+  }
+}

--- a/packages/feature_mind/lib/src/capture/application/meeting_capture_controller.dart
+++ b/packages/feature_mind/lib/src/capture/application/meeting_capture_controller.dart
@@ -28,7 +28,8 @@ class MeetingCaptureController {
     MeetingRecordingServiceGateway? serviceGateway,
     Duration tickInterval = const Duration(seconds: 1),
   }) : _recorder = recorder,
-       _serviceGateway = serviceGateway ?? const NoopMeetingRecordingServiceGateway(),
+       _serviceGateway =
+           serviceGateway ?? const NoopMeetingRecordingServiceGateway(),
        _tickInterval = tickInterval {
     _osSub = _recorder.osEvents.listen(_onOsEvent);
   }
@@ -193,7 +194,8 @@ class MeetingCaptureController {
   int _liveElapsedMs() {
     final startedAt = _segmentStartedAt;
     if (startedAt == null) return _snapshot.elapsedMs;
-    return _snapshot.elapsedMs + DateTime.now().difference(startedAt).inMilliseconds;
+    return _snapshot.elapsedMs +
+        DateTime.now().difference(startedAt).inMilliseconds;
   }
 
   void _freezeElapsed() {

--- a/packages/feature_mind/lib/src/capture/application/meeting_capture_providers.dart
+++ b/packages/feature_mind/lib/src/capture/application/meeting_capture_providers.dart
@@ -1,0 +1,110 @@
+/// Wiring for #1656's capture + processing seam. Kept in one file, the same
+/// way `mindRuntimeProvider` is the one place `AudioScribeScreen` looks for
+/// its runtime — a screen that wants to record a meeting only ever reads
+/// these providers, never constructs `AudioRecorderPort` or
+/// `MeetingProcessingQueue` itself.
+library;
+
+import 'dart:io';
+
+import 'package:core_ai/core_ai.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:path/path.dart' as p;
+import 'package:path_provider/path_provider.dart';
+
+import '../data/audio_recorder_port.dart';
+import '../data/meeting_processing_queue_store.dart';
+import '../data/meeting_recording_service_gateway.dart';
+import '../domain/meeting_processing_job.dart';
+import 'meeting_capture_controller.dart';
+import 'meeting_processing_queue.dart';
+
+/// Real microphone encoder. Overridden with a fake in widget tests.
+final audioRecorderPortProvider = Provider<AudioRecorderPort>(
+  (ref) => PlatformAudioRecorderPort(),
+);
+
+/// Android foreground-service notification gateway. `NoopMeetingRecordingServiceGateway`
+/// on platforms with no such concept (see the gateway's own doc).
+final meetingRecordingServiceGatewayProvider =
+    Provider<MeetingRecordingServiceGateway>(
+      (ref) => const PlatformMeetingRecordingServiceGateway(),
+    );
+
+/// One controller per recording session. `family`-less and `autoDispose`
+/// because a screen creates exactly one session at a time and should dispose
+/// it (stopping the encoder cleanly) the moment it's no longer watched.
+final meetingCaptureControllerProvider =
+    Provider.autoDispose<MeetingCaptureController>((ref) {
+      final controller = MeetingCaptureController(
+        recorder: ref.watch(audioRecorderPortProvider),
+        serviceGateway: ref.watch(meetingRecordingServiceGatewayProvider),
+      );
+      ref.onDispose(controller.dispose);
+      return controller;
+    });
+
+/// Where a session's `.m4a` is written. One file per session, named by
+/// start time so two sessions never collide even if the app is killed
+/// between them without a clean stop.
+Future<String> nextMeetingRecordingPath() async {
+  final dir = await getApplicationSupportDirectory();
+  final recordingsDir = Directory(p.join(dir.path, 'mind_recordings'));
+  await recordingsDir.create(recursive: true);
+  final stamp = DateTime.now().millisecondsSinceEpoch;
+  return p.join(recordingsDir.path, 'meeting-$stamp.m4a');
+}
+
+Future<String> _processingQueuePath() async {
+  final dir = await getApplicationSupportDirectory();
+  return p.join(dir.path, 'mind_recordings', 'processing_queue.json');
+}
+
+/// The resumable post-meeting processing queue (AC4). `FutureProvider`
+/// because construction needs an async path lookup and, on first read, a call
+/// to `restore()` to reconcile any jobs left over from a previous run —
+/// exactly the "survives an app restart" behaviour the design note on
+/// `MeetingProcessingQueue` describes.
+///
+/// [processJob] is supplied by the app shell (it wires the real
+/// `transcribeRecording` + `saveMeeting` pipeline from `meetings.dart`, plus
+/// the retention-policy cleanup) rather than being hardcoded here, so this
+/// package stays free of a compile-time dependency on any one processing
+/// strategy — the same reasoning `MindConfig` keeps model/store paths
+/// injected rather than assumed.
+final meetingProcessingQueueProvider =
+    FutureProvider.autoDispose<MeetingProcessingQueue>((ref) async {
+      final path = await _processingQueuePath();
+      final queue = MeetingProcessingQueue(
+        store: FileMeetingProcessingQueueStore(path),
+        deviceSignalsProbe: RealLlmDeviceSignalsProbe(
+          // No platform channel in this codebase exposes free filesystem
+          // bytes yet (see `RealLlmDeviceSignalsProbe`'s own doc on
+          // `availableStorageMb` -- this is the first real caller and hits
+          // that documented gap directly). A fixed generous headroom rather
+          // than a fabricated precise reading: this queue's thermal gate
+          // (`LlmThermalPolicy`) only ever reads `thermalPressure`, so
+          // storage headroom being approximate here does not affect AC4's
+          // pause/resume behaviour -- it only matters once a caller adds a
+          // storage-pressure policy, which does not exist today.
+          availableStorageMb: () async => 4096,
+        ),
+        processJob: (MeetingProcessingJob job) async {
+          // Overridden by the app shell's own provider override once a real
+          // processing pipeline is wired in. Left as a no-op-that-throws
+          // here rather than silently "succeeding" a job it never processed,
+          // so a missing override fails loudly instead of marking every
+          // meeting completed without a transcript.
+          throw UnimplementedError(
+            'meetingProcessingQueueProvider needs a processJob override — '
+            'see meetingProcessingQueueProvider doc comment.',
+          );
+        },
+      );
+      ref.onDispose(() {
+        // ignore: discarded_futures
+        queue.dispose();
+      });
+      await queue.restore();
+      return queue;
+    });

--- a/packages/feature_mind/lib/src/capture/application/meeting_processing_job_runner.dart
+++ b/packages/feature_mind/lib/src/capture/application/meeting_processing_job_runner.dart
@@ -1,0 +1,50 @@
+import 'dart:io';
+
+import '../../mind_service.dart';
+import '../domain/audio_retention_policy.dart';
+import '../domain/meeting_processing_job.dart';
+
+/// Adapts [MindService.process] (the existing "transcribe → minutes → save"
+/// pipeline, `mind_service.dart`) into the
+/// `Future<void> Function(MeetingProcessingJob)` shape
+/// `MeetingProcessingQueue` calls. This is the piece that closes the loop
+/// #1656 opens with: the pipeline "starts from an existing .m4a file"
+/// (`MindService.process(wavPath: ...)`), and this runner is what hands it
+/// the file [MeetingCaptureController] just recorded, one queued job at a
+/// time.
+///
+/// Also applies AC5's retention policy: once a job completes, the source
+/// audio file is deleted if [retentionPolicy] currently says
+/// [AudioRetentionPolicy.deleteAfterTranscript]. Read fresh on every job
+/// (not captured at construction) so a person can change the Settings toggle
+/// mid-queue and have it apply to the very next meeting that finishes, not
+/// just ones enqueued after the change.
+class MeetingProcessingJobRunner {
+  MeetingProcessingJobRunner({
+    required MindService mindService,
+    required AudioRetentionPolicy Function() retentionPolicy,
+  }) : _mindService = mindService,
+       _retentionPolicy = retentionPolicy;
+
+  final MindService _mindService;
+  final AudioRetentionPolicy Function() _retentionPolicy;
+
+  Future<void> call(MeetingProcessingJob job) async {
+    MindProgress? last;
+    await for (final progress in _mindService.process(
+      wavPath: job.audioPath,
+      title: job.title,
+    )) {
+      last = progress;
+    }
+    if (last == null || last.stage == MindStage.failed) {
+      throw StateError(last?.error ?? 'Processing produced no result.');
+    }
+    if (_retentionPolicy() == AudioRetentionPolicy.deleteAfterTranscript) {
+      final file = File(job.audioPath);
+      if (file.existsSync()) {
+        await file.delete();
+      }
+    }
+  }
+}

--- a/packages/feature_mind/lib/src/capture/application/meeting_processing_job_runner.dart
+++ b/packages/feature_mind/lib/src/capture/application/meeting_processing_job_runner.dart
@@ -19,6 +19,14 @@ import '../domain/meeting_processing_job.dart';
 /// (not captured at construction) so a person can change the Settings toggle
 /// mid-queue and have it apply to the very next meeting that finishes, not
 /// just ones enqueued after the change.
+///
+/// [cleanupAfterTerminalFailure] applies the same policy when a job instead
+/// exhausts its retry budget and is never going to produce a transcript
+/// (chief-security-officer review, #1656): without it, a
+/// `deleteAfterTranscript` user's raw audio for an untranscribable recording
+/// would sit on disk forever, since the success-only path above never runs
+/// for a job that keeps failing. Wire it as
+/// `MeetingProcessingQueue(onTerminalFailure: runner.cleanupAfterTerminalFailure)`.
 class MeetingProcessingJobRunner {
   MeetingProcessingJobRunner({
     required MindService mindService,
@@ -40,6 +48,16 @@ class MeetingProcessingJobRunner {
     if (last == null || last.stage == MindStage.failed) {
       throw StateError(last?.error ?? 'Processing produced no result.');
     }
+    await _deleteAudioIfPolicySaysDelete(job);
+  }
+
+  /// See the class doc's note on [cleanupAfterTerminalFailure] — applies
+  /// AC5's retention policy to a job that will never produce a transcript,
+  /// the same way [call] does for one that just did.
+  Future<void> cleanupAfterTerminalFailure(MeetingProcessingJob job) =>
+      _deleteAudioIfPolicySaysDelete(job);
+
+  Future<void> _deleteAudioIfPolicySaysDelete(MeetingProcessingJob job) async {
     if (_retentionPolicy() == AudioRetentionPolicy.deleteAfterTranscript) {
       final file = File(job.audioPath);
       if (file.existsSync()) {

--- a/packages/feature_mind/lib/src/capture/application/meeting_processing_queue.dart
+++ b/packages/feature_mind/lib/src/capture/application/meeting_processing_queue.dart
@@ -86,6 +86,25 @@ import '../domain/meeting_processing_job.dart';
 ///   (the app's main isolate); it is not safe to construct two instances
 ///   against the same store file concurrently. Nothing in this codebase does
 ///   that today.
+///
+/// ## Retention discipline (chief-security-officer review, #1656)
+///
+/// [MeetingProcessingJobRunner] applies AC5's retention policy (delete the
+/// source audio once a transcript exists) only on the *success* path — a
+/// job that keeps failing never reaches that code, which would otherwise
+/// leave a `deleteAfterTranscript` user's raw audio on disk indefinitely
+/// past their chosen policy the moment a recording happens to be
+/// untranscribable. [onTerminalFailure] closes that gap: it is invoked with
+/// the same retention decision a caller would otherwise only get on success,
+/// the moment a job is marked [MeetingProcessingStatus.failed] for good.
+/// Completed jobs are also dropped from the persisted list right after
+/// [onJobSettled] runs (see [_advance]) rather than kept forever — the queue
+/// is in-flight/retry state, not a permanent history, and an unbounded
+/// `processing_queue.json` would otherwise retain every past meeting's
+/// title and audio path outside the retention toggle's reach even after the
+/// audio itself is gone. Failed jobs are kept (so a future "needs attention"
+/// surface has something to show), which is a smaller residual footprint —
+/// path and title, never audio content — than before this review.
 class MeetingProcessingQueue {
   MeetingProcessingQueue({
     required MeetingProcessingQueueStore store,
@@ -94,12 +113,14 @@ class MeetingProcessingQueue {
     LlmThermalPolicy thermalPolicy = const LlmThermalPolicy(),
     int maxAttempts = 3,
     Duration thermalPollInterval = const Duration(seconds: 30),
+    Future<void> Function(MeetingProcessingJob job)? onTerminalFailure,
   }) : _store = store,
        _deviceSignalsProbe = deviceSignalsProbe,
        _processJob = processJob,
        _thermalPolicy = thermalPolicy,
        _maxAttempts = maxAttempts,
-       _thermalPollInterval = thermalPollInterval;
+       _thermalPollInterval = thermalPollInterval,
+       _onTerminalFailure = onTerminalFailure;
 
   final MeetingProcessingQueueStore _store;
   final LlmDeviceSignalsProbe _deviceSignalsProbe;
@@ -107,6 +128,16 @@ class MeetingProcessingQueue {
   final LlmThermalPolicy _thermalPolicy;
   final int _maxAttempts;
   final Duration _thermalPollInterval;
+
+  /// Runs once a job is marked [MeetingProcessingStatus.failed] for good
+  /// (retry budget exhausted). Intended for the same retention-policy cleanup
+  /// the success path runs, so AC5's toggle is honoured on every terminal
+  /// outcome, not only the happy one — see the class doc's "Retention
+  /// discipline" section. Errors from this callback are logged to the job's
+  /// `lastError`-adjacent state only via best-effort catch; they never crash
+  /// the queue's advance loop, because a cleanup failure must not also take
+  /// down processing of the *next* queued job.
+  final Future<void> Function(MeetingProcessingJob job)? _onTerminalFailure;
 
   final _jobsController =
       StreamController<List<MeetingProcessingJob>>.broadcast();
@@ -194,21 +225,30 @@ class MeetingProcessingQueue {
 
         try {
           await _processJob(job);
-          _jobs = _replace(
-            _jobs.indexWhere((j) => j.id == job.id),
-            job.copyWith(status: MeetingProcessingStatus.completed),
-          );
+          // Pruned rather than kept as `completed`: nothing reads a
+          // completed job back out of this queue (the meeting itself lives
+          // in MindService's store from here on), and keeping it would grow
+          // `processing_queue.json` — including the job's title and audio
+          // path — forever, outside the retention toggle's reach. See the
+          // class doc's "Retention discipline" section.
+          _jobs = _jobs.where((j) => j.id != job.id).toList(growable: false);
         } catch (error) {
           final failedTerminally = job.attempt >= _maxAttempts;
-          _jobs = _replace(
-            _jobs.indexWhere((j) => j.id == job.id),
-            job.copyWith(
-              status: failedTerminally
-                  ? MeetingProcessingStatus.failed
-                  : MeetingProcessingStatus.queued,
-              lastError: error.toString(),
-            ),
+          final failedJob = job.copyWith(
+            status: failedTerminally
+                ? MeetingProcessingStatus.failed
+                : MeetingProcessingStatus.queued,
+            lastError: error.toString(),
           );
+          _jobs = _replace(_jobs.indexWhere((j) => j.id == job.id), failedJob);
+          if (failedTerminally && _onTerminalFailure != null) {
+            try {
+              await _onTerminalFailure(failedJob);
+            } catch (_) {
+              // Best-effort: a cleanup failure must not stop the queue from
+              // moving on to the next job.
+            }
+          }
         }
         await _persist();
         // Loop again: another job may be waiting, and thermal state may have

--- a/packages/feature_mind/lib/src/capture/application/meeting_processing_queue.dart
+++ b/packages/feature_mind/lib/src/capture/application/meeting_processing_queue.dart
@@ -1,0 +1,262 @@
+import 'dart:async';
+
+import 'package:core_ai/core_ai.dart';
+
+import '../data/meeting_processing_queue_store.dart';
+import '../domain/meeting_processing_job.dart';
+
+/// # Design note — post-meeting processing job orchestration (#1656 AC4)
+///
+/// This is the "job orchestration design = Claude" half of #1656's
+/// delegation split. It is deliberately a comment block, not an ADR: the
+/// issue asks for "a page, not an ADR", and the shape below is small enough
+/// that a page of prose next to the class it describes is more useful than a
+/// separate document that can drift from the code.
+///
+/// ## Why a queue exists at all
+///
+/// A meeting can run 90 minutes; ASR + extraction over that much audio is
+/// itself a multi-minute job on-device. Two things can go wrong if this runs
+/// naively: (1) the user records a second meeting before the first finishes
+/// processing, and a naive implementation starts both transcriptions at once
+/// — competing for the same CPU/NPU budget, doubling thermal load, and
+/// finishing both *later* than running them back to back would have; (2) the
+/// app is killed (OS memory pressure, user swipe-away, crash) mid-job, and a
+/// naive implementation has no record that the job ever existed, silently
+/// dropping a recording the user believes is "processing".
+///
+/// ## 1. Surviving an app restart
+///
+/// Every mutation to the queue (`enqueue`, and every status transition
+/// `_advance` makes) is followed by a call to
+/// [MeetingProcessingQueueStore.save], which writes the *entire* job list —
+/// not a delta — to one JSON file via a write-to-temp-then-rename (see
+/// `FileMeetingProcessingQueueStore.save`), so a process death mid-write
+/// cannot leave a half-written, unparsable queue file behind. On
+/// construction, [MeetingProcessingQueue.restore] reads that file back and
+/// resumes: any job that was `processing` when the app died is demoted to
+/// `queued` (`_reconcileAfterRestart`) rather than resumed mid-transcription,
+/// because whisper.cpp's `transcribeRecording` (`meetings.dart`) has no
+/// mid-stream checkpoint to resume *from* — the resumable unit is "process
+/// this recording", not "process this recording from segment 40". A job is
+/// therefore resumable at job granularity: nothing is lost (the audio file
+/// referenced by `MeetingProcessingJob.audioPath` is untouched by a partial
+/// attempt), but a job that was 90% through transcription before the kill
+/// restarts from 0% rather than 90%. `attempt` increments each time a job is
+/// picked up, and a job that fails [_maxAttempts] times moves to `failed`
+/// terminally rather than looping forever on an audio file that will never
+/// transcribe (e.g. corrupt file, model uninstalled mid-job).
+///
+/// ## 2. Queueing rather than concurrently processing
+///
+/// [_advance] holds an internal `_processing` guard: at most one job may be
+/// in [MeetingProcessingStatus.processing] at a time, full stop — not "one
+/// job per core" or "N jobs throttled to fit a budget". A second recording
+/// finishing while the first is still transcribing enqueues behind it
+/// ([MeetingProcessingStatus.queued]) and waits. This is the literal AC4
+/// requirement ("queue rather than crawl") applied one level up from where
+/// `LlmThermalPolicy`'s own doc comment applies it (that policy already
+/// rejects *throttling a single running job's rate*; this queue's job is to
+/// make sure a second job never starts throttling turns with it in the first
+/// place).
+///
+/// ## 3. Consulting thermal/device-tier gating
+///
+/// Before starting or continuing any job, [_advance] asks
+/// [LlmDeviceSignalsProbe.probe] for current signals and runs them through
+/// the *existing*, already-shipped `LlmThermalPolicy.decide` (MIND-LLM-4,
+/// `packages/core_ai/lib/src/device_tier/llm_thermal_policy.dart`) — this
+/// queue does not reimplement thermal gating, it is a second caller of the
+/// same policy the local/cloud router already uses. `LlmBatchJobAction.pause`
+/// demotes the in-flight job to [MeetingProcessingStatus.paused] and stops
+/// the queue's advance loop entirely (no job starts, no job continues) until
+/// a later probe reports `LlmBatchJobAction.resume`, at which point the
+/// paused job re-enters `processing` from job-granularity zero, per §1. This
+/// queue polls the probe on every `enqueue` and every job completion, plus a
+/// timer (`_thermalPollInterval`) while a job is paused, so a queue stuck
+/// paused behind sustained thermal pressure notices the moment pressure
+/// eases instead of waiting for the next unrelated queue event.
+///
+/// ## Non-goals
+///
+/// - No priority ordering — FIFO by `enqueuedAtMs`. Nothing in #1656 asks
+///   for "most recent meeting first", and guessing at a priority scheme here
+///   would be speculative.
+/// - No cross-process locking. This queue assumes one Dart isolate owns it
+///   (the app's main isolate); it is not safe to construct two instances
+///   against the same store file concurrently. Nothing in this codebase does
+///   that today.
+class MeetingProcessingQueue {
+  MeetingProcessingQueue({
+    required MeetingProcessingQueueStore store,
+    required LlmDeviceSignalsProbe deviceSignalsProbe,
+    required Future<void> Function(MeetingProcessingJob job) processJob,
+    LlmThermalPolicy thermalPolicy = const LlmThermalPolicy(),
+    int maxAttempts = 3,
+    Duration thermalPollInterval = const Duration(seconds: 30),
+  }) : _store = store,
+       _deviceSignalsProbe = deviceSignalsProbe,
+       _processJob = processJob,
+       _thermalPolicy = thermalPolicy,
+       _maxAttempts = maxAttempts,
+       _thermalPollInterval = thermalPollInterval;
+
+  final MeetingProcessingQueueStore _store;
+  final LlmDeviceSignalsProbe _deviceSignalsProbe;
+  final Future<void> Function(MeetingProcessingJob job) _processJob;
+  final LlmThermalPolicy _thermalPolicy;
+  final int _maxAttempts;
+  final Duration _thermalPollInterval;
+
+  final _jobsController = StreamController<List<MeetingProcessingJob>>.broadcast();
+  List<MeetingProcessingJob> _jobs = const [];
+  bool _running = false;
+  bool _thermallyPaused = false;
+  Timer? _thermalPollTimer;
+
+  Stream<List<MeetingProcessingJob>> get jobs => _jobsController.stream;
+
+  List<MeetingProcessingJob> get current => List.unmodifiable(_jobs);
+
+  /// Loads any jobs left over from a previous run and reconciles them. Call
+  /// once at startup before [enqueue].
+  Future<void> restore() async {
+    final loaded = await _store.load();
+    _jobs = _reconcileAfterRestart(loaded);
+    await _persist();
+    unawaited(_advance());
+  }
+
+  List<MeetingProcessingJob> _reconcileAfterRestart(
+    List<MeetingProcessingJob> loaded,
+  ) {
+    return [
+      for (final job in loaded)
+        if (job.status == MeetingProcessingStatus.processing)
+          // See §1: no mid-job resume point, so a job that was actively
+          // processing when the app died goes back to the end of the queue.
+          job.copyWith(status: MeetingProcessingStatus.queued)
+        else
+          job,
+    ];
+  }
+
+  /// Adds a newly recorded meeting to the queue. Safe to call while other
+  /// jobs are queued or processing — this job simply waits its turn.
+  Future<void> enqueue(MeetingProcessingJob job) async {
+    _jobs = [..._jobs, job];
+    await _persist();
+    unawaited(_advance());
+  }
+
+  /// Runs (at most) the queue's forward progress: probes thermal state,
+  /// pauses the whole queue if pressure demands it, otherwise starts the next
+  /// queued job if nothing is currently processing.
+  Future<void> _advance() async {
+    if (_running) return;
+    _running = true;
+    try {
+      while (true) {
+        final signals = await _deviceSignalsProbe.probe();
+        final action = _thermalPolicy.decide(
+          pressure: signals.thermalPressure,
+          jobCurrentlyPaused: _thermallyPaused,
+        );
+        if (action == LlmBatchJobAction.pause) {
+          await _pauseForThermal();
+          return;
+        }
+        if (action == LlmBatchJobAction.resume) {
+          _thermallyPaused = false;
+          _stopThermalPolling();
+        }
+
+        if (_jobs.any((j) => j.status == MeetingProcessingStatus.processing)) {
+          // A job is already running — §2's one-at-a-time invariant. Nothing
+          // more to do until it finishes and calls `_advance` again.
+          return;
+        }
+
+        final nextIndex = _jobs.indexWhere(
+          (j) =>
+              j.status == MeetingProcessingStatus.queued ||
+              j.status == MeetingProcessingStatus.paused,
+        );
+        if (nextIndex == -1) return; // Nothing left to do.
+
+        var job = _jobs[nextIndex].copyWith(
+          status: MeetingProcessingStatus.processing,
+          attempt: _jobs[nextIndex].attempt + 1,
+        );
+        _jobs = _replace(nextIndex, job);
+        await _persist();
+
+        try {
+          await _processJob(job);
+          _jobs = _replace(
+            _jobs.indexWhere((j) => j.id == job.id),
+            job.copyWith(status: MeetingProcessingStatus.completed),
+          );
+        } catch (error) {
+          final failedTerminally = job.attempt >= _maxAttempts;
+          _jobs = _replace(
+            _jobs.indexWhere((j) => j.id == job.id),
+            job.copyWith(
+              status: failedTerminally
+                  ? MeetingProcessingStatus.failed
+                  : MeetingProcessingStatus.queued,
+              lastError: error.toString(),
+            ),
+          );
+        }
+        await _persist();
+        // Loop again: another job may be waiting, and thermal state may have
+        // changed while this one ran.
+      }
+    } finally {
+      _running = false;
+    }
+  }
+
+  Future<void> _pauseForThermal() async {
+    _thermallyPaused = true;
+    final processingIndex = _jobs.indexWhere(
+      (j) => j.status == MeetingProcessingStatus.processing,
+    );
+    if (processingIndex != -1) {
+      _jobs = _replace(
+        processingIndex,
+        _jobs[processingIndex].copyWith(status: MeetingProcessingStatus.paused),
+      );
+      await _persist();
+    }
+    _startThermalPolling();
+  }
+
+  void _startThermalPolling() {
+    _thermalPollTimer ??= Timer.periodic(_thermalPollInterval, (_) {
+      unawaited(_advance());
+    });
+  }
+
+  void _stopThermalPolling() {
+    _thermalPollTimer?.cancel();
+    _thermalPollTimer = null;
+  }
+
+  List<MeetingProcessingJob> _replace(int index, MeetingProcessingJob job) {
+    final next = [..._jobs];
+    next[index] = job;
+    return next;
+  }
+
+  Future<void> _persist() async {
+    await _store.save(_jobs);
+    if (!_jobsController.isClosed) _jobsController.add(current);
+  }
+
+  Future<void> dispose() async {
+    _stopThermalPolling();
+    await _jobsController.close();
+  }
+}

--- a/packages/feature_mind/lib/src/capture/application/meeting_processing_queue.dart
+++ b/packages/feature_mind/lib/src/capture/application/meeting_processing_queue.dart
@@ -108,7 +108,8 @@ class MeetingProcessingQueue {
   final int _maxAttempts;
   final Duration _thermalPollInterval;
 
-  final _jobsController = StreamController<List<MeetingProcessingJob>>.broadcast();
+  final _jobsController =
+      StreamController<List<MeetingProcessingJob>>.broadcast();
   List<MeetingProcessingJob> _jobs = const [];
   bool _running = false;
   bool _thermallyPaused = false;

--- a/packages/feature_mind/lib/src/capture/data/audio_recorder_port.dart
+++ b/packages/feature_mind/lib/src/capture/data/audio_recorder_port.dart
@@ -1,0 +1,125 @@
+import 'package:record/record.dart';
+
+/// The seam between [MeetingCaptureController] and the microphone encoder.
+///
+/// Same shape as `MeetingExportGateway`
+/// (`feature_mind/lib/src/export/data/meeting_export_gateway.dart`) and
+/// `PlatformBackupDocumentGateway` (`feature_iptv`) — an interface a fake can
+/// implement in a test, and a thin platform-plugin adapter implements for
+/// real. [PlatformAudioRecorderPort] wraps `package:record`'s `AudioRecorder`,
+/// which already streams straight to the file named by `start()` rather than
+/// buffering in Dart memory (native `MediaRecorder`/`AVAudioRecorder`
+/// encoders write incrementally) — that native behaviour is what makes AC1
+/// (a 90-minute recording survives an app kill) true without this layer doing
+/// any extra work to get it.
+abstract interface class AudioRecorderPort {
+  /// Starts encoding to [path]. The file exists and grows from this call
+  /// onward — nothing buffers until `stop()`.
+  Future<void> start(String path);
+
+  Future<void> pause();
+
+  Future<void> resume();
+
+  /// Finalises the file and returns its path (or null if nothing was
+  /// recorded).
+  Future<String?> stop();
+
+  /// True if the platform granted microphone access. Callers check this
+  /// before `start()` rather than reading the exception `start()` throws
+  /// when it's denied, so the UI can show a permission prompt instead of an
+  /// error banner.
+  Future<bool> hasPermission();
+
+  /// OS-driven state changes — most importantly, an interruption (incoming
+  /// call, Siri, another app's recording) pausing or resuming the encoder out
+  /// from under the controller. [MeetingCaptureController] listens to this to
+  /// keep [MeetingRecordingSnapshot.pausedByOs] accurate.
+  Stream<RecorderOsEvent> get osEvents;
+
+  Future<void> dispose();
+}
+
+/// One OS-driven transition the port reports, decoupled from
+/// `package:record`'s own `RecordState` so nothing outside this file imports
+/// that package.
+enum RecorderOsEvent { osPaused, osResumed, osStopped }
+
+/// Real microphone capture via `package:record`.
+///
+/// iOS: `RecordConfig.audioInterruption` is set to
+/// `AudioInterruptionMode.pauseResume` below (see `record_ios`'s
+/// `RecorderSessionExtension`), which is what makes AC3 (handle interruption
+/// — call, Siri) true at the native layer: the plugin pauses the encoder when
+/// `AVAudioSession.interruptionNotification` fires with `.began` and resumes
+/// it on `.ended` if the OS reports the interruption is resumable. This class
+/// only has to *observe* that through [osEvents] and reflect it in the
+/// session snapshot, not implement interruption handling itself.
+///
+/// Android: `package:record`'s own foreground-service option is deprecated in
+/// favour of an external package (see `AndroidRecordConfig.service` doc); this
+/// codebase's answer to that is `MeetingRecordingServiceGateway`, called
+/// alongside this port by `MeetingCaptureController` rather than folded into
+/// it — recording and "keep the OS from killing the process while recording"
+/// are separate concerns with separate platform surfaces.
+class PlatformAudioRecorderPort implements AudioRecorderPort {
+  PlatformAudioRecorderPort({AudioRecorder? recorder})
+    : _recorder = recorder ?? AudioRecorder();
+
+  final AudioRecorder _recorder;
+
+  static const _config = RecordConfig(
+    encoder: AudioEncoder.aacLc,
+    // AAC-LC in an m4a container: matches what `meetings.dart`'s
+    // `transcribeRecording` (whisper.cpp via the Rust bridge) already expects
+    // from every other entry point into the pipeline.
+    bitRate: 128000,
+    sampleRate: 16000,
+    numChannels: 1,
+    androidConfig: AndroidRecordConfig(
+      // Mic use must be visible to the OS privacy indicator, so this stays a
+      // normal `mic` source rather than anything that could route around it.
+      audioSource: AndroidAudioSource.mic,
+    ),
+    // `RecordConfig.audioInterruption` (not `IosRecordConfig`, despite the
+    // doc mentioning iOS most prominently — it applies on Android too, per
+    // `record_platform_interface`'s `RecordConfig.audioInterruption` doc).
+    // `pauseResume` rather than the plugin default (`pause`, which leaves the
+    // session paused forever once a call ends) is what makes AC3's
+    // "handles interruption" mean the recording actually continues once the
+    // call/Siri session ends, not just that it survives being paused.
+    audioInterruption: AudioInterruptionMode.pauseResume,
+  );
+
+  @override
+  Future<bool> hasPermission() => _recorder.hasPermission();
+
+  @override
+  Future<void> start(String path) => _recorder.start(_config, path: path);
+
+  @override
+  Future<void> pause() => _recorder.pause();
+
+  @override
+  Future<void> resume() => _recorder.resume();
+
+  @override
+  Future<String?> stop() => _recorder.stop();
+
+  @override
+  Stream<RecorderOsEvent> get osEvents => _recorder.onStateChanged().map((
+    state,
+  ) {
+    switch (state) {
+      case RecordState.pause:
+        return RecorderOsEvent.osPaused;
+      case RecordState.record:
+        return RecorderOsEvent.osResumed;
+      case RecordState.stop:
+        return RecorderOsEvent.osStopped;
+    }
+  });
+
+  @override
+  Future<void> dispose() => _recorder.dispose();
+}

--- a/packages/feature_mind/lib/src/capture/data/audio_recorder_port.dart
+++ b/packages/feature_mind/lib/src/capture/data/audio_recorder_port.dart
@@ -107,18 +107,17 @@ class PlatformAudioRecorderPort implements AudioRecorderPort {
   Future<String?> stop() => _recorder.stop();
 
   @override
-  Stream<RecorderOsEvent> get osEvents => _recorder.onStateChanged().map((
-    state,
-  ) {
-    switch (state) {
-      case RecordState.pause:
-        return RecorderOsEvent.osPaused;
-      case RecordState.record:
-        return RecorderOsEvent.osResumed;
-      case RecordState.stop:
-        return RecorderOsEvent.osStopped;
-    }
-  });
+  Stream<RecorderOsEvent> get osEvents =>
+      _recorder.onStateChanged().map((state) {
+        switch (state) {
+          case RecordState.pause:
+            return RecorderOsEvent.osPaused;
+          case RecordState.record:
+            return RecorderOsEvent.osResumed;
+          case RecordState.stop:
+            return RecorderOsEvent.osStopped;
+        }
+      });
 
   @override
   Future<void> dispose() => _recorder.dispose();

--- a/packages/feature_mind/lib/src/capture/data/meeting_processing_queue_store.dart
+++ b/packages/feature_mind/lib/src/capture/data/meeting_processing_queue_store.dart
@@ -1,0 +1,54 @@
+import 'dart:convert';
+import 'dart:io';
+
+import '../domain/meeting_processing_job.dart';
+
+/// Where `MeetingProcessingQueue` persists its job list, so it survives an
+/// app restart (#1656 AC4).
+///
+/// Kept as an interface — not just a `File` inline in the queue — for the
+/// same reason `AudioRecorderPort` and `MeetingRecordingServiceGateway` are:
+/// a fake in-memory store lets the queue's resume-after-restart behaviour be
+/// asserted in a test without touching a real filesystem.
+abstract interface class MeetingProcessingQueueStore {
+  Future<List<MeetingProcessingJob>> load();
+
+  Future<void> save(List<MeetingProcessingJob> jobs);
+}
+
+/// Real persistence: one JSON file under the app's support directory.
+///
+/// A flat file rather than a database because the whole payload is small
+/// (a handful of pending meetings at most — this is not an event log) and
+/// the read/write pattern is "load everything once at startup, rewrite
+/// everything on every mutation", which a single JSON array serves fine.
+class FileMeetingProcessingQueueStore implements MeetingProcessingQueueStore {
+  const FileMeetingProcessingQueueStore(this.filePath);
+
+  final String filePath;
+
+  @override
+  Future<List<MeetingProcessingJob>> load() async {
+    final file = File(filePath);
+    if (!file.existsSync()) return const [];
+    final raw = await file.readAsString();
+    if (raw.trim().isEmpty) return const [];
+    final decoded = jsonDecode(raw) as List<Object?>;
+    return decoded
+        .map((e) => MeetingProcessingJob.fromJson(e! as Map<String, Object?>))
+        .toList(growable: false);
+  }
+
+  @override
+  Future<void> save(List<MeetingProcessingJob> jobs) async {
+    final file = File(filePath);
+    await file.parent.create(recursive: true);
+    final encoded = jsonEncode(jobs.map((j) => j.toJson()).toList());
+    // Write to a sibling temp file and rename, so a process death mid-write
+    // never leaves the queue file half-written and unparsable on the next
+    // launch — the failure mode this whole store exists to survive.
+    final tmp = File('$filePath.tmp');
+    await tmp.writeAsString(encoded, flush: true);
+    await tmp.rename(filePath);
+  }
+}

--- a/packages/feature_mind/lib/src/capture/data/meeting_recording_service_gateway.dart
+++ b/packages/feature_mind/lib/src/capture/data/meeting_recording_service_gateway.dart
@@ -1,0 +1,76 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+
+/// Starts/stops the Android mic-use foreground notification (#1656 AC2).
+///
+/// A `MethodChannel` rather than a Flutter plugin because this is one app's
+/// own service, not a reusable capability — same reasoning `MainActivity.kt`
+/// already applies to `com.airo.gemini_nano` and its siblings. The native
+/// side is `MeetingRecordingService`
+/// (`app/android/app/src/product/kotlin/io/airo/app/MeetingRecordingService.kt`),
+/// registered from `MainActivity.configureFlutterEngine`.
+///
+/// iOS and other platforms have no equivalent foreground-service concept —
+/// [NoopMeetingRecordingServiceGateway] is what they get. `record_ios` itself
+/// keeps the process alive via the audio session's background mode
+/// (`UIBackgroundModes: audio` in `Info.plist`), so there is nothing for this
+/// gateway to start there.
+abstract interface class MeetingRecordingServiceGateway {
+  /// Shows the persistent "recording meeting audio" notification and starts
+  /// the foreground service backing it. Must be called before (or in the
+  /// same frame as) [AudioRecorderPort.start] — Android kills a background
+  /// process's microphone access almost immediately without an active
+  /// foreground service of type `microphone`.
+  Future<void> start({required String notificationTitle, String? notificationText});
+
+  /// Stops the foreground service and dismisses the notification. Idempotent
+  /// — safe to call even if [start] was never called.
+  Future<void> stop();
+}
+
+class PlatformMeetingRecordingServiceGateway
+    implements MeetingRecordingServiceGateway {
+  const PlatformMeetingRecordingServiceGateway({
+    MethodChannel? channel,
+  }) : _channel = channel ?? _defaultChannel;
+
+  static const MethodChannel _defaultChannel = MethodChannel(
+    'com.airo.meeting_recording',
+  );
+
+  final MethodChannel _channel;
+
+  @override
+  Future<void> start({
+    required String notificationTitle,
+    String? notificationText,
+  }) async {
+    if (!(defaultTargetPlatform == TargetPlatform.android)) return;
+    await _channel.invokeMethod<void>('start', {
+      'title': notificationTitle,
+      'text': notificationText,
+    });
+  }
+
+  @override
+  Future<void> stop() async {
+    if (!(defaultTargetPlatform == TargetPlatform.android)) return;
+    await _channel.invokeMethod<void>('stop');
+  }
+}
+
+/// Platforms with no foreground-service concept (iOS, desktop, web, tests
+/// that don't care about the service). See class doc on the interface.
+class NoopMeetingRecordingServiceGateway
+    implements MeetingRecordingServiceGateway {
+  const NoopMeetingRecordingServiceGateway();
+
+  @override
+  Future<void> start({
+    required String notificationTitle,
+    String? notificationText,
+  }) async {}
+
+  @override
+  Future<void> stop() async {}
+}

--- a/packages/feature_mind/lib/src/capture/data/meeting_recording_service_gateway.dart
+++ b/packages/feature_mind/lib/src/capture/data/meeting_recording_service_gateway.dart
@@ -21,7 +21,10 @@ abstract interface class MeetingRecordingServiceGateway {
   /// same frame as) [AudioRecorderPort.start] — Android kills a background
   /// process's microphone access almost immediately without an active
   /// foreground service of type `microphone`.
-  Future<void> start({required String notificationTitle, String? notificationText});
+  Future<void> start({
+    required String notificationTitle,
+    String? notificationText,
+  });
 
   /// Stops the foreground service and dismisses the notification. Idempotent
   /// — safe to call even if [start] was never called.
@@ -30,9 +33,8 @@ abstract interface class MeetingRecordingServiceGateway {
 
 class PlatformMeetingRecordingServiceGateway
     implements MeetingRecordingServiceGateway {
-  const PlatformMeetingRecordingServiceGateway({
-    MethodChannel? channel,
-  }) : _channel = channel ?? _defaultChannel;
+  const PlatformMeetingRecordingServiceGateway({MethodChannel? channel})
+    : _channel = channel ?? _defaultChannel;
 
   static const MethodChannel _defaultChannel = MethodChannel(
     'com.airo.meeting_recording',

--- a/packages/feature_mind/lib/src/capture/domain/audio_retention_policy.dart
+++ b/packages/feature_mind/lib/src/capture/domain/audio_retention_policy.dart
@@ -1,0 +1,30 @@
+/// Raw-audio retention policy (#1656 AC5).
+///
+/// Product decision, not a hardcoded constant: a person who records meetings
+/// may want the source audio kept (to re-play a moment the transcript
+/// flattened) or deleted the moment a transcript exists (storage budget, or
+/// just not wanting a room's raw audio sitting on disk indefinitely). Settings
+/// exposes this as a toggle backed by [AudioRetentionPreference]; nothing in
+/// the processing queue decides this on its own.
+library;
+
+/// What happens to a meeting's source `.m4a` once its transcript is durable.
+enum AudioRetentionPolicy {
+  /// Keep the raw audio alongside the transcript indefinitely.
+  keepAfterTranscript,
+
+  /// Delete the raw audio as soon as the transcript is saved. The transcript
+  /// and minutes remain; only the source recording is reclaimed.
+  deleteAfterTranscript;
+
+  static const AudioRetentionPolicy fallback = keepAfterTranscript;
+
+  String get storageValue => name;
+
+  static AudioRetentionPolicy fromStorageValue(String? value) {
+    return AudioRetentionPolicy.values.firstWhere(
+      (policy) => policy.storageValue == value,
+      orElse: () => fallback,
+    );
+  }
+}

--- a/packages/feature_mind/lib/src/capture/domain/meeting_processing_job.dart
+++ b/packages/feature_mind/lib/src/capture/domain/meeting_processing_job.dart
@@ -1,0 +1,108 @@
+/// A queued unit of post-meeting processing (ASR + extraction), #1656 AC4.
+library;
+
+/// Where one job is in its lifecycle.
+enum MeetingProcessingStatus {
+  /// Waiting for its turn — either because another job is running, or
+  /// because thermal/battery pressure has the whole queue paused.
+  queued,
+
+  /// Actively transcribing/extracting right now. At most one job in the
+  /// queue may hold this status at a time — see
+  /// `MeetingProcessingQueue`'s class doc for why.
+  processing,
+
+  /// Was `processing`, thermal pressure told the queue to stop, and it has
+  /// not resumed yet. Distinct from `queued` so the UI can say "paused —
+  /// device is hot" instead of just "waiting".
+  paused,
+
+  /// Finished. Terminal.
+  completed,
+
+  /// Failed in a way retrying will not fix (e.g. the audio file is gone).
+  /// Terminal.
+  failed;
+
+  bool get isTerminal =>
+      this == MeetingProcessingStatus.completed ||
+      this == MeetingProcessingStatus.failed;
+}
+
+/// One recording's trip through transcription + extraction.
+///
+/// Everything here is plain data so it round-trips through JSON — the whole
+/// point of this type is that it survives a process death
+/// (`MeetingProcessingQueue`'s persistence).
+class MeetingProcessingJob {
+  const MeetingProcessingJob({
+    required this.id,
+    required this.audioPath,
+    required this.title,
+    required this.enqueuedAtMs,
+    this.status = MeetingProcessingStatus.queued,
+    this.attempt = 0,
+    this.lastError,
+  });
+
+  /// Stable id for this job — the recording session id it was enqueued from.
+  final String id;
+
+  /// Path to the finalised `.m4a`/`.wav` this job transcribes.
+  final String audioPath;
+
+  /// Display title (meeting name, or a timestamp fallback).
+  final String title;
+
+  final int enqueuedAtMs;
+
+  final MeetingProcessingStatus status;
+
+  /// How many times this job has been picked up for processing. Used only
+  /// for a bounded-retry cutoff (`MeetingProcessingQueue._maxAttempts`) —
+  /// this is not exposed as a user-facing retry count.
+  final int attempt;
+
+  final String? lastError;
+
+  MeetingProcessingJob copyWith({
+    MeetingProcessingStatus? status,
+    int? attempt,
+    String? lastError,
+  }) {
+    return MeetingProcessingJob(
+      id: id,
+      audioPath: audioPath,
+      title: title,
+      enqueuedAtMs: enqueuedAtMs,
+      status: status ?? this.status,
+      attempt: attempt ?? this.attempt,
+      lastError: lastError ?? this.lastError,
+    );
+  }
+
+  Map<String, Object?> toJson() => {
+    'id': id,
+    'audioPath': audioPath,
+    'title': title,
+    'enqueuedAtMs': enqueuedAtMs,
+    'status': status.name,
+    'attempt': attempt,
+    'lastError': lastError,
+  };
+
+  static MeetingProcessingJob fromJson(Map<String, Object?> json) {
+    return MeetingProcessingJob(
+      id: json['id']! as String,
+      audioPath: json['audioPath']! as String,
+      title: json['title']! as String,
+      enqueuedAtMs: json['enqueuedAtMs']! as int,
+      status: MeetingProcessingStatus.values.firstWhere(
+        (s) => s.name == json['status'],
+        orElse: () => MeetingProcessingStatus.queued,
+      ),
+      attempt: json['attempt'] as int? ?? 0,
+      lastError: json['lastError'] as String?,
+    );
+  }
+}

--- a/packages/feature_mind/lib/src/capture/domain/meeting_recording_state.dart
+++ b/packages/feature_mind/lib/src/capture/domain/meeting_recording_state.dart
@@ -1,0 +1,92 @@
+/// State machine for in-app meeting capture (#1656).
+///
+/// The encoder (`AudioRecorderPort`) writes straight to disk from the moment
+/// [MeetingRecordingLifecycle.recording] is entered — this enum tracks
+/// *control* state (what the user, or the OS on their behalf, asked for), not
+/// whether bytes are buffered anywhere. There is no `MeetingRecordingLifecycle`
+/// value that means "recording, but only in memory": that state does not
+/// exist in this design, which is the point (AC1 — a 90-minute recording
+/// survives an app kill because the file on disk is never more than one
+/// encoder buffer behind the microphone).
+library;
+
+/// Where a capture session currently is.
+enum MeetingRecordingLifecycle {
+  /// No session started yet.
+  idle,
+
+  /// Encoder is running and appending to the session's file.
+  recording,
+
+  /// Encoder is suspended — either the user tapped pause, or the OS paused it
+  /// for them (a call arrived, Siri woke up, another app grabbed the audio
+  /// session). [MeetingRecordingSnapshot.pausedByOs] tells the two apart.
+  paused,
+
+  /// Encoder has stopped and the file is finalised. Terminal.
+  stopped,
+
+  /// The encoder reported an error it cannot recover from. Terminal.
+  failed,
+}
+
+/// A point-in-time read of a capture session, as the controller broadcasts it.
+///
+/// Deliberately does not carry raw audio bytes — those went straight to
+/// [filePath] via the platform encoder and this snapshot is UI/queue state
+/// only.
+class MeetingRecordingSnapshot {
+  const MeetingRecordingSnapshot({
+    required this.lifecycle,
+    required this.filePath,
+    required this.elapsedMs,
+    this.pausedByOs = false,
+    this.error,
+  });
+
+  final MeetingRecordingLifecycle lifecycle;
+
+  /// Where the encoder is writing. Set as soon as recording starts and never
+  /// changes for the life of one session — pause/resume reuses the same file,
+  /// it does not start a new one.
+  final String filePath;
+
+  /// Wall-clock milliseconds of *recorded* audio — time spent paused is
+  /// excluded, so this is what ends up as the file's actual duration.
+  final int elapsedMs;
+
+  /// True when the current (or most recent) pause was triggered by the OS —
+  /// an incoming call, Siri, another app taking the audio focus — rather than
+  /// the user tapping the pause button. The capture screen uses this to show
+  /// "Paused — call in progress" instead of the ordinary pause affordance.
+  final bool pausedByOs;
+
+  final String? error;
+
+  MeetingRecordingSnapshot copyWith({
+    MeetingRecordingLifecycle? lifecycle,
+    String? filePath,
+    int? elapsedMs,
+    bool? pausedByOs,
+    String? error,
+  }) {
+    return MeetingRecordingSnapshot(
+      lifecycle: lifecycle ?? this.lifecycle,
+      filePath: filePath ?? this.filePath,
+      elapsedMs: elapsedMs ?? this.elapsedMs,
+      pausedByOs: pausedByOs ?? this.pausedByOs,
+      error: error ?? this.error,
+    );
+  }
+
+  static const idle = MeetingRecordingSnapshot(
+    lifecycle: MeetingRecordingLifecycle.idle,
+    filePath: '',
+    elapsedMs: 0,
+  );
+
+  @override
+  String toString() =>
+      'MeetingRecordingSnapshot(${lifecycle.name}, ${elapsedMs}ms, '
+      'path: $filePath, pausedByOs: $pausedByOs)';
+}

--- a/packages/feature_mind/lib/src/capture/presentation/audio_retention_settings_tile.dart
+++ b/packages/feature_mind/lib/src/capture/presentation/audio_retention_settings_tile.dart
@@ -1,0 +1,38 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../application/audio_retention_preference.dart';
+import '../domain/audio_retention_policy.dart';
+
+/// Settings toggle for #1656 AC5 — "raw audio retention policy... a Settings
+/// toggle, not hardcoded". Drop this into whichever screen owns Airo Mind's
+/// Settings surface.
+class AudioRetentionSettingsTile extends ConsumerWidget {
+  const AudioRetentionSettingsTile({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final policy = ref.watch(audioRetentionPolicyProvider);
+    final keepAfter = policy == AudioRetentionPolicy.keepAfterTranscript;
+
+    return SwitchListTile(
+      title: const Text('Keep meeting recordings'),
+      subtitle: Text(
+        keepAfter
+            ? 'Raw audio stays on this device after the transcript is ready.'
+            : 'Raw audio is deleted once the transcript is saved. Transcripts '
+                  'and minutes are kept either way.',
+      ),
+      value: keepAfter,
+      onChanged: (value) {
+        ref
+            .read(audioRetentionPolicyProvider.notifier)
+            .select(
+              value
+                  ? AudioRetentionPolicy.keepAfterTranscript
+                  : AudioRetentionPolicy.deleteAfterTranscript,
+            );
+      },
+    );
+  }
+}

--- a/packages/feature_mind/lib/src/capture/presentation/meeting_capture_screen.dart
+++ b/packages/feature_mind/lib/src/capture/presentation/meeting_capture_screen.dart
@@ -1,0 +1,334 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../assistant/consent/audio_scribe_consent_gate.dart';
+import '../../assistant/consent/jurisdiction_consent_rules.dart';
+import '../../assistant/consent/mind_runtime_provider.dart';
+import '../application/meeting_capture_controller.dart';
+import '../application/meeting_capture_providers.dart';
+import '../domain/meeting_processing_job.dart';
+import '../domain/meeting_recording_state.dart';
+
+/// In-app meeting capture (#1656 AC1, AC6).
+///
+/// Reuses `AudioScribeConsentGate` — the same gate `AudioScribeScreen` uses
+/// for live dictation — as the one door to the encoder, per that gate's own
+/// doc: "a screen that wants to record audio has no other route to the
+/// encoder available to it". This screen's [MeetingCaptureController] is
+/// only ever started from inside [AudioScribeConsentGate.startRecording], the
+/// same shape `AudioScribeScreen._capture` already uses for the streaming
+/// path.
+///
+/// AC6's "explicit recording-consent UX copy" lives in [_ConsentReminder]
+/// below: a plain-language reminder that recording consent law varies by
+/// where the meeting happens, and that checking it is the person's
+/// responsibility — this screen shows a jurisdiction picker and (for
+/// two-party jurisdictions) blocks on an "I notified everyone" acknowledgment
+/// before starting, but it is not a legal gate; nothing here verifies the
+/// acknowledgment is true.
+class MeetingCaptureScreen extends ConsumerStatefulWidget {
+  const MeetingCaptureScreen({super.key});
+
+  @override
+  ConsumerState<MeetingCaptureScreen> createState() =>
+      _MeetingCaptureScreenState();
+}
+
+class _MeetingCaptureScreenState extends ConsumerState<MeetingCaptureScreen> {
+  static const _contextId = 'meeting-capture';
+
+  final _consentGate = AudioScribeConsentGate();
+  ConsentJurisdiction _jurisdiction = unselectedJurisdiction;
+  bool _allPartiesAck = false;
+  bool _consentBusy = false;
+  String? _consentError;
+
+  MeetingCaptureController? _controller;
+  MeetingRecordingSnapshot _snapshot = MeetingRecordingSnapshot.idle;
+  String? _startError;
+
+  @override
+  void dispose() {
+    _controller?.dispose();
+    super.dispose();
+  }
+
+  Future<void> _confirmConsent() async {
+    setState(() {
+      _consentBusy = true;
+      _consentError = null;
+    });
+    try {
+      await _consentGate.grant(
+        log: ref.read(mindRuntimeProvider).log,
+        contextId: _contextId,
+        jurisdiction: _jurisdiction,
+        allPartiesNotified: _allPartiesAck,
+        nowMs: DateTime.now().millisecondsSinceEpoch,
+      );
+    } on ConsentRequiredException catch (error) {
+      if (!mounted) return;
+      setState(() => _consentError = error.reason);
+      return;
+    } finally {
+      if (mounted) setState(() => _consentBusy = false);
+    }
+    if (mounted) setState(() {});
+  }
+
+  Future<void> _start() async {
+    if (!_consentGate.isGranted) return;
+    setState(() => _startError = null);
+    final controller = ref.read(meetingCaptureControllerProvider);
+    _controller = controller;
+    controller.snapshots.listen((snapshot) {
+      if (mounted) setState(() => _snapshot = snapshot);
+    });
+    final path = await nextMeetingRecordingPath();
+    try {
+      await _consentGate.startRecording(() => controller.start(path));
+    } on ConsentRequiredException catch (error) {
+      if (!mounted) return;
+      setState(() => _startError = error.reason);
+      return;
+    }
+    if (!mounted) return;
+    setState(() => _snapshot = controller.current);
+    if (_snapshot.lifecycle == MeetingRecordingLifecycle.failed) {
+      setState(
+        () => _startError = _snapshot.error ?? 'Could not start recording.',
+      );
+    }
+  }
+
+  Future<void> _pause() async => _controller?.pause();
+
+  Future<void> _resume() async => _controller?.resume();
+
+  Future<void> _stop() async {
+    final controller = _controller;
+    if (controller == null) return;
+    final path = await controller.stop();
+    if (path == null) return;
+    final queue = await ref.read(meetingProcessingQueueProvider.future);
+    await queue.enqueue(
+      MeetingProcessingJob(
+        id: 'meeting-${DateTime.now().millisecondsSinceEpoch}',
+        audioPath: path,
+        title: 'Meeting ${DateTime.now().toLocal()}',
+        enqueuedAtMs: DateTime.now().millisecondsSinceEpoch,
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final consentGranted = _consentGate.isGranted;
+    final lifecycle = _snapshot.lifecycle;
+    final recording = lifecycle == MeetingRecordingLifecycle.recording;
+    final paused = lifecycle == MeetingRecordingLifecycle.paused;
+    final active = recording || paused;
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Record meeting')),
+      body: ListView(
+        padding: const EdgeInsets.fromLTRB(16, 12, 16, 32),
+        children: [
+          const _ConsentReminder(),
+          const SizedBox(height: 12),
+          _ConsentJurisdictionPicker(
+            jurisdiction: _jurisdiction,
+            allPartiesAck: _allPartiesAck,
+            granted: consentGranted,
+            busy: _consentBusy,
+            error: _consentError,
+            onJurisdictionChanged: (jurisdiction) => setState(() {
+              _jurisdiction = jurisdiction;
+              if (!jurisdiction.requiresAllPartyNotification) {
+                _allPartiesAck = false;
+              }
+            }),
+            onAllPartiesAckChanged: (value) =>
+                setState(() => _allPartiesAck = value),
+            onConfirm: _confirmConsent,
+          ),
+          const SizedBox(height: 20),
+          if (paused && _snapshot.pausedByOs)
+            const Padding(
+              padding: EdgeInsets.only(bottom: 12),
+              child: Text(
+                key: Key('meeting_capture_os_pause_notice'),
+                'Paused automatically — a call or Siri interrupted the '
+                'microphone. Recording will resume when it ends.',
+              ),
+            ),
+          Text(
+            _formatElapsed(_snapshot.elapsedMs),
+            key: const Key('meeting_capture_elapsed'),
+            style: Theme.of(context).textTheme.displaySmall,
+          ),
+          const SizedBox(height: 12),
+          Wrap(
+            spacing: 12,
+            children: [
+              if (!active)
+                FilledButton.icon(
+                  key: const Key('meeting_capture_start_button'),
+                  onPressed: consentGranted ? _start : null,
+                  icon: const Icon(Icons.mic),
+                  label: const Text('Start recording'),
+                ),
+              if (recording)
+                OutlinedButton.icon(
+                  key: const Key('meeting_capture_pause_button'),
+                  onPressed: _pause,
+                  icon: const Icon(Icons.pause),
+                  label: const Text('Pause'),
+                ),
+              if (paused && !_snapshot.pausedByOs)
+                OutlinedButton.icon(
+                  key: const Key('meeting_capture_resume_button'),
+                  onPressed: _resume,
+                  icon: const Icon(Icons.play_arrow),
+                  label: const Text('Resume'),
+                ),
+              if (active)
+                FilledButton.icon(
+                  key: const Key('meeting_capture_stop_button'),
+                  onPressed: _stop,
+                  icon: const Icon(Icons.stop),
+                  label: const Text('Stop'),
+                ),
+            ],
+          ),
+          if (_startError != null) ...[
+            const SizedBox(height: 12),
+            Text(
+              _startError!,
+              key: const Key('meeting_capture_error'),
+              style: TextStyle(color: Theme.of(context).colorScheme.error),
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+
+  static String _formatElapsed(int elapsedMs) {
+    final seconds = elapsedMs ~/ 1000;
+    final minutes = seconds ~/ 60;
+    final remSeconds = seconds % 60;
+    return '${minutes.toString().padLeft(2, '0')}:${remSeconds.toString().padLeft(2, '0')}';
+  }
+}
+
+/// AC6's explicit consent-reminder copy. Not a legal gate — see class doc on
+/// [MeetingCaptureScreen].
+class _ConsentReminder extends StatelessWidget {
+  const _ConsentReminder();
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      color: Theme.of(context).colorScheme.surfaceContainerHighest,
+      child: const Padding(
+        padding: EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              'Before you record',
+              style: TextStyle(fontWeight: FontWeight.bold),
+            ),
+            SizedBox(height: 8),
+            Text(
+              'Recording a conversation without telling the other people in '
+              'it is illegal in some places — Airo Mind cannot know the law '
+              'where you are, so checking it is on you. Pick where this '
+              'meeting is happening below; if it requires telling everyone '
+              'first, do that before you start.',
+              key: Key('meeting_capture_consent_reminder_copy'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _ConsentJurisdictionPicker extends StatelessWidget {
+  const _ConsentJurisdictionPicker({
+    required this.jurisdiction,
+    required this.allPartiesAck,
+    required this.granted,
+    required this.busy,
+    required this.error,
+    required this.onJurisdictionChanged,
+    required this.onAllPartiesAckChanged,
+    required this.onConfirm,
+  });
+
+  final ConsentJurisdiction jurisdiction;
+  final bool allPartiesAck;
+  final bool granted;
+  final bool busy;
+  final String? error;
+  final ValueChanged<ConsentJurisdiction> onJurisdictionChanged;
+  final ValueChanged<bool> onAllPartiesAckChanged;
+  final VoidCallback onConfirm;
+
+  @override
+  Widget build(BuildContext context) {
+    if (granted) {
+      return Text(
+        'Consent recorded for ${jurisdiction.label}.',
+        key: const Key('meeting_capture_consent_granted'),
+      );
+    }
+    final requiresAck = jurisdiction.requiresAllPartyNotification;
+    final canConfirm = !busy && (!requiresAck || allPartiesAck);
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        DropdownButtonFormField<ConsentJurisdiction>(
+          key: const Key('meeting_capture_jurisdiction_dropdown'),
+          initialValue: jurisdiction,
+          isExpanded: true,
+          decoration: const InputDecoration(
+            labelText: 'Where is this meeting taking place?',
+            border: OutlineInputBorder(),
+          ),
+          items: [unselectedJurisdiction, ...knownJurisdictions]
+              .map(
+                (j) => DropdownMenuItem(
+                  value: j,
+                  child: Text(j.label, overflow: TextOverflow.ellipsis),
+                ),
+              )
+              .toList(),
+          onChanged: (value) {
+            if (value != null) onJurisdictionChanged(value);
+          },
+        ),
+        if (requiresAck)
+          CheckboxListTile(
+            key: const Key('meeting_capture_all_parties_checkbox'),
+            value: allPartiesAck,
+            onChanged: (value) => onAllPartiesAckChanged(value ?? false),
+            title: const Text('I have told everyone in this meeting they are being recorded'),
+            controlAffinity: ListTileControlAffinity.leading,
+          ),
+        const SizedBox(height: 8),
+        FilledButton(
+          key: const Key('meeting_capture_confirm_consent_button'),
+          onPressed: canConfirm ? onConfirm : null,
+          child: const Text('Confirm and enable recording'),
+        ),
+        if (error != null) ...[
+          const SizedBox(height: 8),
+          Text(error!, style: TextStyle(color: Theme.of(context).colorScheme.error)),
+        ],
+      ],
+    );
+  }
+}

--- a/packages/feature_mind/lib/src/capture/presentation/meeting_capture_screen.dart
+++ b/packages/feature_mind/lib/src/capture/presentation/meeting_capture_screen.dart
@@ -315,7 +315,9 @@ class _ConsentJurisdictionPicker extends StatelessWidget {
             key: const Key('meeting_capture_all_parties_checkbox'),
             value: allPartiesAck,
             onChanged: (value) => onAllPartiesAckChanged(value ?? false),
-            title: const Text('I have told everyone in this meeting they are being recorded'),
+            title: const Text(
+              'I have told everyone in this meeting they are being recorded',
+            ),
             controlAffinity: ListTileControlAffinity.leading,
           ),
         const SizedBox(height: 8),
@@ -326,7 +328,10 @@ class _ConsentJurisdictionPicker extends StatelessWidget {
         ),
         if (error != null) ...[
           const SizedBox(height: 8),
-          Text(error!, style: TextStyle(color: Theme.of(context).colorScheme.error)),
+          Text(
+            error!,
+            style: TextStyle(color: Theme.of(context).colorScheme.error),
+          ),
         ],
       ],
     );

--- a/packages/feature_mind/lib/src/mind_home_screen.dart
+++ b/packages/feature_mind/lib/src/mind_home_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 
 import 'whisper/api/meetings.dart' as rust;
 import 'export/application/meeting_export_service.dart';
@@ -190,6 +191,13 @@ class _MindHomeScreenState extends State<MindHomeScreen> {
       appBar: AppBar(
         title: const Text('Airo Mind'),
         actions: [
+          if (status != null && status.isReady)
+            IconButton(
+              key: const Key('mind_home_record_meeting_button'),
+              tooltip: 'Record a meeting',
+              icon: const Icon(Icons.mic_none),
+              onPressed: () => context.push('/record'),
+            ),
           if (status != null && status.isReady && _meetings.isNotEmpty)
             PopupMenuButton<bool>(
               icon: _exportingAll

--- a/packages/feature_mind/lib/src/mind_module.dart
+++ b/packages/feature_mind/lib/src/mind_module.dart
@@ -15,6 +15,7 @@ import 'assistant/presentation/screens/assistant_screen.dart';
 import 'assistant/presentation/screens/audio_scribe_screen.dart';
 import 'assistant/presentation/screens/mobile_actions_screen.dart';
 import 'assistant/presentation/screens/prompt_lab_screen.dart';
+import 'capture/presentation/meeting_capture_screen.dart';
 import 'host/assistant_host_adapter.dart';
 import 'mind_home_screen.dart';
 import 'mind_service.dart';
@@ -143,6 +144,19 @@ class MindModule extends AppModule {
         path: '/',
         name: 'mind_scribe',
         builder: (context, state) => MindHomeScreen(service: service),
+        routes: [
+          // In-app capture (#1656): pause/resume, incremental disk writes,
+          // consent UX, the mic-privacy-respecting Android foreground
+          // service, and hand-off to the resumable processing queue.
+          // `MindHomeScreen`'s own record button (`MindService.startRecording`)
+          // is the pre-#1656 single-shot path and is left as-is; this is the
+          // upgraded route.
+          GoRoute(
+            path: 'record',
+            name: 'mind_meeting_capture',
+            builder: (context, state) => const MeetingCaptureScreen(),
+          ),
+        ],
       ),
   ];
 

--- a/packages/feature_mind/test/capture/application/meeting_capture_controller_test.dart
+++ b/packages/feature_mind/test/capture/application/meeting_capture_controller_test.dart
@@ -1,0 +1,133 @@
+import 'package:feature_mind/src/capture/application/meeting_capture_controller.dart';
+import 'package:feature_mind/src/capture/data/audio_recorder_port.dart';
+import 'package:feature_mind/src/capture/domain/meeting_recording_state.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../support/fake_audio_recorder_port.dart';
+
+void main() {
+  group('MeetingCaptureController', () {
+    late FakeAudioRecorderPort recorder;
+    late MeetingCaptureController controller;
+
+    setUp(() {
+      recorder = FakeAudioRecorderPort();
+      controller = MeetingCaptureController(
+        recorder: recorder,
+        tickInterval: const Duration(milliseconds: 5),
+      );
+    });
+
+    tearDown(() async {
+      await controller.dispose();
+    });
+
+    test('idle before start', () {
+      expect(controller.current.lifecycle, MeetingRecordingLifecycle.idle);
+      expect(controller.isRecording, isFalse);
+    });
+
+    test('start begins encoding immediately -- no buffering step', () async {
+      await controller.start('/tmp/meeting.m4a');
+
+      expect(recorder.calls, contains('start:/tmp/meeting.m4a'));
+      expect(recorder.startedPath, '/tmp/meeting.m4a');
+      expect(controller.current.lifecycle, MeetingRecordingLifecycle.recording);
+      expect(controller.current.filePath, '/tmp/meeting.m4a');
+      expect(controller.isRecording, isTrue);
+    });
+
+    test('start refuses when microphone permission is not granted', () async {
+      recorder.permissionGranted = false;
+
+      await controller.start('/tmp/meeting.m4a');
+
+      expect(recorder.calls, isNot(contains('start:/tmp/meeting.m4a')));
+      expect(controller.current.lifecycle, MeetingRecordingLifecycle.failed);
+      expect(controller.current.error, isNotNull);
+    });
+
+    test('start twice on one controller throws', () async {
+      await controller.start('/tmp/a.m4a');
+
+      expect(() => controller.start('/tmp/b.m4a'), throwsStateError);
+    });
+
+    test('pause then resume round-trips through the port', () async {
+      await controller.start('/tmp/meeting.m4a');
+
+      await controller.pause();
+      expect(recorder.calls, contains('pause'));
+      expect(controller.current.lifecycle, MeetingRecordingLifecycle.paused);
+      expect(controller.current.pausedByOs, isFalse);
+
+      await controller.resume();
+      expect(recorder.calls, contains('resume'));
+      expect(controller.current.lifecycle, MeetingRecordingLifecycle.recording);
+    });
+
+    test('elapsed time accumulates across a pause/resume cycle', () async {
+      await controller.start('/tmp/meeting.m4a');
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+      await controller.pause();
+      final pausedElapsed = controller.current.elapsedMs;
+      expect(pausedElapsed, greaterThan(0));
+
+      // Time passing while paused must not count.
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+      expect(controller.current.elapsedMs, pausedElapsed);
+
+      await controller.resume();
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+      final resumedElapsed = controller.current.elapsedMs;
+      expect(resumedElapsed, greaterThan(pausedElapsed));
+    });
+
+    test('stop finalises the file and returns its path', () async {
+      await controller.start('/tmp/meeting.m4a');
+
+      final path = await controller.stop();
+
+      expect(path, '/tmp/meeting.m4a');
+      expect(recorder.calls, contains('stop'));
+      expect(controller.current.lifecycle, MeetingRecordingLifecycle.stopped);
+    });
+
+    test('stop before start returns null and does not call the port', () async {
+      final path = await controller.stop();
+
+      expect(path, isNull);
+      expect(recorder.calls, isEmpty);
+    });
+
+    test('an OS-driven pause (call/Siri interruption) is reflected as pausedByOs', () async {
+      await controller.start('/tmp/meeting.m4a');
+
+      recorder.emitOsEvent(RecorderOsEvent.osPaused);
+      await pumpEventQueue();
+
+      expect(controller.current.lifecycle, MeetingRecordingLifecycle.paused);
+      expect(controller.current.pausedByOs, isTrue);
+    });
+
+    test('the OS resuming after an interruption returns to recording', () async {
+      await controller.start('/tmp/meeting.m4a');
+      recorder.emitOsEvent(RecorderOsEvent.osPaused);
+      await pumpEventQueue();
+
+      recorder.emitOsEvent(RecorderOsEvent.osResumed);
+      await pumpEventQueue();
+
+      expect(controller.current.lifecycle, MeetingRecordingLifecycle.recording);
+      expect(controller.current.pausedByOs, isFalse);
+    });
+
+    test('a user-initiated pause is not mistaken for an OS pause', () async {
+      await controller.start('/tmp/meeting.m4a');
+
+      await controller.pause();
+
+      expect(controller.current.pausedByOs, isFalse);
+    });
+  });
+}

--- a/packages/feature_mind/test/capture/application/meeting_capture_controller_test.dart
+++ b/packages/feature_mind/test/capture/application/meeting_capture_controller_test.dart
@@ -100,27 +100,36 @@ void main() {
       expect(recorder.calls, isEmpty);
     });
 
-    test('an OS-driven pause (call/Siri interruption) is reflected as pausedByOs', () async {
-      await controller.start('/tmp/meeting.m4a');
+    test(
+      'an OS-driven pause (call/Siri interruption) is reflected as pausedByOs',
+      () async {
+        await controller.start('/tmp/meeting.m4a');
 
-      recorder.emitOsEvent(RecorderOsEvent.osPaused);
-      await pumpEventQueue();
+        recorder.emitOsEvent(RecorderOsEvent.osPaused);
+        await pumpEventQueue();
 
-      expect(controller.current.lifecycle, MeetingRecordingLifecycle.paused);
-      expect(controller.current.pausedByOs, isTrue);
-    });
+        expect(controller.current.lifecycle, MeetingRecordingLifecycle.paused);
+        expect(controller.current.pausedByOs, isTrue);
+      },
+    );
 
-    test('the OS resuming after an interruption returns to recording', () async {
-      await controller.start('/tmp/meeting.m4a');
-      recorder.emitOsEvent(RecorderOsEvent.osPaused);
-      await pumpEventQueue();
+    test(
+      'the OS resuming after an interruption returns to recording',
+      () async {
+        await controller.start('/tmp/meeting.m4a');
+        recorder.emitOsEvent(RecorderOsEvent.osPaused);
+        await pumpEventQueue();
 
-      recorder.emitOsEvent(RecorderOsEvent.osResumed);
-      await pumpEventQueue();
+        recorder.emitOsEvent(RecorderOsEvent.osResumed);
+        await pumpEventQueue();
 
-      expect(controller.current.lifecycle, MeetingRecordingLifecycle.recording);
-      expect(controller.current.pausedByOs, isFalse);
-    });
+        expect(
+          controller.current.lifecycle,
+          MeetingRecordingLifecycle.recording,
+        );
+        expect(controller.current.pausedByOs, isFalse);
+      },
+    );
 
     test('a user-initiated pause is not mistaken for an OS pause', () async {
       await controller.start('/tmp/meeting.m4a');

--- a/packages/feature_mind/test/capture/application/meeting_processing_job_runner_test.dart
+++ b/packages/feature_mind/test/capture/application/meeting_processing_job_runner_test.dart
@@ -59,13 +59,19 @@ void main() {
   test('runs the meeting through MindService.process and completes', () async {
     speech.transcriptEvents = const [
       TranscriptEventTranscriptReady('hello world', [
-        TranscriptSegment(id: 's0', startMs: 0, endMs: 500, text: 'hello world'),
+        TranscriptSegment(
+          id: 's0',
+          startMs: 0,
+          endMs: 500,
+          text: 'hello world',
+        ),
       ]),
     ];
     generation.generationEvents = const [
       GenerationEventMinutesReady('Minutes.'),
     ];
-    final audioFile = File('${tempDir.path}/meeting.wav')..writeAsStringSync('audio');
+    final audioFile = File('${tempDir.path}/meeting.wav')
+      ..writeAsStringSync('audio');
     final runner = MeetingProcessingJobRunner(
       mindService: mindService,
       retentionPolicy: () => AudioRetentionPolicy.keepAfterTranscript,
@@ -85,63 +91,81 @@ void main() {
     expect(audioFile.existsSync(), isTrue);
   });
 
-  test('deletes the source audio when retention policy says delete-after-transcript', () async {
-    speech.transcriptEvents = const [
-      TranscriptEventTranscriptReady('hello world', [
-        TranscriptSegment(id: 's0', startMs: 0, endMs: 500, text: 'hello world'),
-      ]),
-    ];
-    generation.generationEvents = const [
-      GenerationEventMinutesReady('Minutes.'),
-    ];
-    final audioFile = File('${tempDir.path}/meeting.wav')..writeAsStringSync('audio');
-    final runner = MeetingProcessingJobRunner(
-      mindService: mindService,
-      retentionPolicy: () => AudioRetentionPolicy.deleteAfterTranscript,
-    );
+  test(
+    'deletes the source audio when retention policy says delete-after-transcript',
+    () async {
+      speech.transcriptEvents = const [
+        TranscriptEventTranscriptReady('hello world', [
+          TranscriptSegment(
+            id: 's0',
+            startMs: 0,
+            endMs: 500,
+            text: 'hello world',
+          ),
+        ]),
+      ];
+      generation.generationEvents = const [
+        GenerationEventMinutesReady('Minutes.'),
+      ];
+      final audioFile = File('${tempDir.path}/meeting.wav')
+        ..writeAsStringSync('audio');
+      final runner = MeetingProcessingJobRunner(
+        mindService: mindService,
+        retentionPolicy: () => AudioRetentionPolicy.deleteAfterTranscript,
+      );
 
-    await runner.call(
-      MeetingProcessingJob(
-        id: 'm1',
-        audioPath: audioFile.path,
-        title: 'Standup',
-        enqueuedAtMs: 0,
-      ),
-    );
-
-    expect(audioFile.existsSync(), isFalse);
-  });
-
-  test('a failed pipeline stage throws, so the queue marks the job failed/retries it', () async {
-    speech.transcriptEvents = const [
-      TranscriptEventTranscriptReady('hello world', [
-        TranscriptSegment(id: 's0', startMs: 0, endMs: 500, text: 'hello world'),
-      ]),
-    ];
-    speech.saveError = Exception('store unavailable');
-    generation.generationEvents = const [
-      GenerationEventMinutesReady('Minutes.'),
-    ];
-    final audioFile = File('${tempDir.path}/meeting.wav')..writeAsStringSync('audio');
-    final runner = MeetingProcessingJobRunner(
-      mindService: mindService,
-      retentionPolicy: () => AudioRetentionPolicy.deleteAfterTranscript,
-    );
-
-    await expectLater(
-      runner.call(
+      await runner.call(
         MeetingProcessingJob(
           id: 'm1',
           audioPath: audioFile.path,
           title: 'Standup',
           enqueuedAtMs: 0,
         ),
-      ),
-      throwsA(anything),
-    );
+      );
 
-    // A failed run must not delete the only copy of the audio -- there is
-    // nothing to fall back on if it did.
-    expect(audioFile.existsSync(), isTrue);
-  });
+      expect(audioFile.existsSync(), isFalse);
+    },
+  );
+
+  test(
+    'a failed pipeline stage throws, so the queue marks the job failed/retries it',
+    () async {
+      speech.transcriptEvents = const [
+        TranscriptEventTranscriptReady('hello world', [
+          TranscriptSegment(
+            id: 's0',
+            startMs: 0,
+            endMs: 500,
+            text: 'hello world',
+          ),
+        ]),
+      ];
+      speech.saveError = Exception('store unavailable');
+      generation.generationEvents = const [
+        GenerationEventMinutesReady('Minutes.'),
+      ];
+      final audioFile = File('${tempDir.path}/meeting.wav')
+        ..writeAsStringSync('audio');
+      final runner = MeetingProcessingJobRunner(
+        mindService: mindService,
+        retentionPolicy: () => AudioRetentionPolicy.deleteAfterTranscript,
+      );
+
+      await expectLater(
+        runner.call(
+          MeetingProcessingJob(
+            id: 'm1',
+            audioPath: audioFile.path,
+            title: 'Standup',
+            enqueuedAtMs: 0,
+          ),
+        ),
+        throwsA(anything),
+      );
+
+      // A failed run must not delete the only copy of the audio -- there is
+      // nothing to fall back on if it did.
+      expect(audioFile.existsSync(), isTrue);
+    },
+  );
 }

--- a/packages/feature_mind/test/capture/application/meeting_processing_job_runner_test.dart
+++ b/packages/feature_mind/test/capture/application/meeting_processing_job_runner_test.dart
@@ -1,0 +1,147 @@
+import 'dart:io';
+
+import 'package:feature_mind/src/bridges/mind_generation_bridge.dart';
+import 'package:feature_mind/src/bridges/mind_speech_bridge.dart';
+import 'package:feature_mind/src/capture/application/meeting_processing_job_runner.dart';
+import 'package:feature_mind/src/capture/domain/audio_retention_policy.dart';
+import 'package:feature_mind/src/capture/domain/meeting_processing_job.dart';
+import 'package:feature_mind/src/mind_service.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
+import 'package:plugin_platform_interface/plugin_platform_interface.dart';
+import 'package:record/record.dart';
+
+import '../../support/fake_bridges.dart';
+
+/// `AudioRecorder`'s real constructor talks to a platform channel that does
+/// not exist in a plain `flutter_test` run. Same shape `mind_service_test.dart`
+/// already uses -- this runner never calls `MindService.start/stopRecording`,
+/// so nothing on the mock needs stubbing.
+class _MockAudioRecorder extends Mock implements AudioRecorder {}
+
+/// Minimal fake so `MindService.modelsDirectory()` resolves without a real
+/// platform channel -- same shape `mind_service_test.dart` already uses.
+class _FakePathProviderPlatform extends PathProviderPlatform
+    with MockPlatformInterfaceMixin {
+  _FakePathProviderPlatform(this.basePath);
+
+  final String basePath;
+
+  @override
+  Future<String?> getApplicationSupportPath() async => basePath;
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late Directory tempDir;
+  late FakeMindSpeechBridge speech;
+  late FakeMindGenerationBridge generation;
+  late MindService mindService;
+
+  setUp(() {
+    tempDir = Directory.systemTemp.createTempSync('job_runner_test_');
+    PathProviderPlatform.instance = _FakePathProviderPlatform(tempDir.path);
+    speech = FakeMindSpeechBridge();
+    generation = FakeMindGenerationBridge();
+    mindService = MindService(
+      recorder: _MockAudioRecorder(),
+      speechBridge: speech,
+      generationBridge: generation,
+    );
+  });
+
+  tearDown(() {
+    if (tempDir.existsSync()) tempDir.deleteSync(recursive: true);
+  });
+
+  test('runs the meeting through MindService.process and completes', () async {
+    speech.transcriptEvents = const [
+      TranscriptEventTranscriptReady('hello world', [
+        TranscriptSegment(id: 's0', startMs: 0, endMs: 500, text: 'hello world'),
+      ]),
+    ];
+    generation.generationEvents = const [
+      GenerationEventMinutesReady('Minutes.'),
+    ];
+    final audioFile = File('${tempDir.path}/meeting.wav')..writeAsStringSync('audio');
+    final runner = MeetingProcessingJobRunner(
+      mindService: mindService,
+      retentionPolicy: () => AudioRetentionPolicy.keepAfterTranscript,
+    );
+
+    await runner.call(
+      MeetingProcessingJob(
+        id: 'm1',
+        audioPath: audioFile.path,
+        title: 'Standup',
+        enqueuedAtMs: 0,
+      ),
+    );
+
+    expect(speech.savedWavPath, audioFile.path);
+    // Kept: the file must still exist.
+    expect(audioFile.existsSync(), isTrue);
+  });
+
+  test('deletes the source audio when retention policy says delete-after-transcript', () async {
+    speech.transcriptEvents = const [
+      TranscriptEventTranscriptReady('hello world', [
+        TranscriptSegment(id: 's0', startMs: 0, endMs: 500, text: 'hello world'),
+      ]),
+    ];
+    generation.generationEvents = const [
+      GenerationEventMinutesReady('Minutes.'),
+    ];
+    final audioFile = File('${tempDir.path}/meeting.wav')..writeAsStringSync('audio');
+    final runner = MeetingProcessingJobRunner(
+      mindService: mindService,
+      retentionPolicy: () => AudioRetentionPolicy.deleteAfterTranscript,
+    );
+
+    await runner.call(
+      MeetingProcessingJob(
+        id: 'm1',
+        audioPath: audioFile.path,
+        title: 'Standup',
+        enqueuedAtMs: 0,
+      ),
+    );
+
+    expect(audioFile.existsSync(), isFalse);
+  });
+
+  test('a failed pipeline stage throws, so the queue marks the job failed/retries it', () async {
+    speech.transcriptEvents = const [
+      TranscriptEventTranscriptReady('hello world', [
+        TranscriptSegment(id: 's0', startMs: 0, endMs: 500, text: 'hello world'),
+      ]),
+    ];
+    speech.saveError = Exception('store unavailable');
+    generation.generationEvents = const [
+      GenerationEventMinutesReady('Minutes.'),
+    ];
+    final audioFile = File('${tempDir.path}/meeting.wav')..writeAsStringSync('audio');
+    final runner = MeetingProcessingJobRunner(
+      mindService: mindService,
+      retentionPolicy: () => AudioRetentionPolicy.deleteAfterTranscript,
+    );
+
+    await expectLater(
+      runner.call(
+        MeetingProcessingJob(
+          id: 'm1',
+          audioPath: audioFile.path,
+          title: 'Standup',
+          enqueuedAtMs: 0,
+        ),
+      ),
+      throwsA(anything),
+    );
+
+    // A failed run must not delete the only copy of the audio -- there is
+    // nothing to fall back on if it did.
+    expect(audioFile.existsSync(), isTrue);
+  });
+}

--- a/packages/feature_mind/test/capture/application/meeting_processing_job_runner_test.dart
+++ b/packages/feature_mind/test/capture/application/meeting_processing_job_runner_test.dart
@@ -168,4 +168,48 @@ void main() {
       expect(audioFile.existsSync(), isTrue);
     },
   );
+
+  test('cleanupAfterTerminalFailure deletes the audio when policy says delete '
+      '(chief-security-officer review, #1656)', () async {
+    final audioFile = File('${tempDir.path}/meeting.wav')
+      ..writeAsStringSync('audio');
+    final runner = MeetingProcessingJobRunner(
+      mindService: mindService,
+      retentionPolicy: () => AudioRetentionPolicy.deleteAfterTranscript,
+    );
+
+    await runner.cleanupAfterTerminalFailure(
+      MeetingProcessingJob(
+        id: 'm1',
+        audioPath: audioFile.path,
+        title: 'Standup',
+        enqueuedAtMs: 0,
+      ),
+    );
+
+    expect(audioFile.existsSync(), isFalse);
+  });
+
+  test(
+    'cleanupAfterTerminalFailure keeps the audio when policy says keep',
+    () async {
+      final audioFile = File('${tempDir.path}/meeting.wav')
+        ..writeAsStringSync('audio');
+      final runner = MeetingProcessingJobRunner(
+        mindService: mindService,
+        retentionPolicy: () => AudioRetentionPolicy.keepAfterTranscript,
+      );
+
+      await runner.cleanupAfterTerminalFailure(
+        MeetingProcessingJob(
+          id: 'm1',
+          audioPath: audioFile.path,
+          title: 'Standup',
+          enqueuedAtMs: 0,
+        ),
+      );
+
+      expect(audioFile.existsSync(), isTrue);
+    },
+  );
 }

--- a/packages/feature_mind/test/capture/application/meeting_processing_queue_test.dart
+++ b/packages/feature_mind/test/capture/application/meeting_processing_queue_test.dart
@@ -1,0 +1,220 @@
+import 'dart:async';
+
+import 'package:core_ai/core_ai.dart';
+import 'package:feature_mind/src/capture/application/meeting_processing_queue.dart';
+import 'package:feature_mind/src/capture/domain/meeting_processing_job.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../support/in_memory_processing_queue_store.dart';
+
+MeetingProcessingJob _job(String id, {int enqueuedAtMs = 0}) {
+  return MeetingProcessingJob(
+    id: id,
+    audioPath: '/tmp/$id.m4a',
+    title: id,
+    enqueuedAtMs: enqueuedAtMs,
+  );
+}
+
+void main() {
+  group('MeetingProcessingQueue', () {
+    test('processes a single enqueued job to completion', () async {
+      final store = InMemoryProcessingQueueStore();
+      final processed = <String>[];
+      final queue = MeetingProcessingQueue(
+        store: store,
+        deviceSignalsProbe: const FakeLlmDeviceSignalsProbe(
+          LlmDeviceSignals(totalRamMb: 8000, availableStorageMb: 8000),
+        ),
+        processJob: (job) async {
+          processed.add(job.id);
+        },
+      );
+      await queue.restore();
+
+      await queue.enqueue(_job('m1'));
+      await pumpEventQueue();
+
+      expect(processed, ['m1']);
+      expect(queue.current.single.status, MeetingProcessingStatus.completed);
+
+      await queue.dispose();
+    });
+
+    test('never runs two jobs concurrently -- second waits behind the first', () async {
+      final store = InMemoryProcessingQueueStore();
+      final started = <String>[];
+      final completers = <String, Completer<void>>{};
+      final queue = MeetingProcessingQueue(
+        store: store,
+        deviceSignalsProbe: const FakeLlmDeviceSignalsProbe(
+          LlmDeviceSignals(totalRamMb: 8000, availableStorageMb: 8000),
+        ),
+        processJob: (job) async {
+          started.add(job.id);
+          final completer = Completer<void>();
+          completers[job.id] = completer;
+          await completer.future;
+        },
+      );
+      await queue.restore();
+
+      await queue.enqueue(_job('first'));
+      await queue.enqueue(_job('second'));
+      await pumpEventQueue();
+
+      // Only the first job may be running -- the second must still be queued.
+      expect(started, ['first']);
+      expect(
+        queue.current.firstWhere((j) => j.id == 'second').status,
+        MeetingProcessingStatus.queued,
+      );
+
+      completers['first']!.complete();
+      await pumpEventQueue();
+
+      expect(started, ['first', 'second']);
+      completers['second']!.complete();
+      await pumpEventQueue();
+
+      expect(
+        queue.current.every((j) => j.status == MeetingProcessingStatus.completed),
+        isTrue,
+      );
+
+      await queue.dispose();
+    });
+
+    test('pauses the whole queue under thermal pressure instead of throttling', () async {
+      final store = InMemoryProcessingQueueStore();
+      var pressure = LlmThermalPressure.critical;
+      final processed = <String>[];
+      final queue = MeetingProcessingQueue(
+        store: store,
+        deviceSignalsProbe: _DynamicProbe(() => pressure),
+        thermalPollInterval: const Duration(milliseconds: 5),
+        processJob: (job) async {
+          processed.add(job.id);
+        },
+      );
+      await queue.restore();
+
+      await queue.enqueue(_job('hot'));
+      await pumpEventQueue();
+
+      // Thermal pressure is critical -- nothing should have run.
+      expect(processed, isEmpty);
+      expect(
+        queue.current.single.status,
+        MeetingProcessingStatus.queued,
+      );
+
+      // Pressure eases; the poll timer should pick the job back up.
+      pressure = LlmThermalPressure.nominal;
+      await Future<void>.delayed(const Duration(milliseconds: 30));
+      await pumpEventQueue();
+
+      expect(processed, ['hot']);
+
+      await queue.dispose();
+    });
+
+    test('restore demotes a job left in "processing" back to queued', () async {
+      final store = InMemoryProcessingQueueStore([
+        _job('orphaned').copyWith(status: MeetingProcessingStatus.processing),
+      ]);
+      final processed = <String>[];
+      final queue = MeetingProcessingQueue(
+        store: store,
+        deviceSignalsProbe: const FakeLlmDeviceSignalsProbe(
+          LlmDeviceSignals(totalRamMb: 8000, availableStorageMb: 8000),
+        ),
+        processJob: (job) async {
+          processed.add(job.id);
+        },
+      );
+
+      await queue.restore();
+      await pumpEventQueue();
+
+      // The job that "died" mid-process is picked back up from scratch, not
+      // left stuck in `processing` forever.
+      expect(processed, ['orphaned']);
+      expect(queue.current.single.status, MeetingProcessingStatus.completed);
+
+      await queue.dispose();
+    });
+
+    test('a job that keeps failing stops retrying after the attempt cap', () async {
+      final store = InMemoryProcessingQueueStore();
+      var attempts = 0;
+      final queue = MeetingProcessingQueue(
+        store: store,
+        deviceSignalsProbe: const FakeLlmDeviceSignalsProbe(
+          LlmDeviceSignals(totalRamMb: 8000, availableStorageMb: 8000),
+        ),
+        maxAttempts: 2,
+        processJob: (job) async {
+          attempts++;
+          throw Exception('boom');
+        },
+      );
+      await queue.restore();
+
+      await queue.enqueue(_job('doomed'));
+      await pumpEventQueue();
+      await pumpEventQueue();
+      await pumpEventQueue();
+
+      expect(attempts, 2);
+      expect(queue.current.single.status, MeetingProcessingStatus.failed);
+      expect(queue.current.single.lastError, contains('boom'));
+
+      await queue.dispose();
+    });
+
+    test('the queue file round-trips a job list across a fresh queue instance', () async {
+      final store = InMemoryProcessingQueueStore();
+      final firstLifetime = MeetingProcessingQueue(
+        store: store,
+        deviceSignalsProbe: const FakeLlmDeviceSignalsProbe(
+          LlmDeviceSignals(
+            totalRamMb: 8000,
+            availableStorageMb: 8000,
+            thermalPressure: LlmThermalPressure.critical,
+          ),
+        ),
+        processJob: (job) async {},
+      );
+      await firstLifetime.restore();
+      await firstLifetime.enqueue(_job('survives-restart'));
+      await pumpEventQueue();
+      await firstLifetime.dispose();
+
+      final secondLifetime = MeetingProcessingQueue(
+        store: store,
+        deviceSignalsProbe: const FakeLlmDeviceSignalsProbe(
+          LlmDeviceSignals(totalRamMb: 8000, availableStorageMb: 8000),
+        ),
+        processJob: (job) async {},
+      );
+      await secondLifetime.restore();
+
+      expect(secondLifetime.current.single.id, 'survives-restart');
+      await secondLifetime.dispose();
+    });
+  });
+}
+
+class _DynamicProbe implements LlmDeviceSignalsProbe {
+  _DynamicProbe(this._read);
+
+  final LlmThermalPressure Function() _read;
+
+  @override
+  Future<LlmDeviceSignals> probe() async => LlmDeviceSignals(
+    totalRamMb: 8000,
+    availableStorageMb: 8000,
+    thermalPressure: _read(),
+  );
+}

--- a/packages/feature_mind/test/capture/application/meeting_processing_queue_test.dart
+++ b/packages/feature_mind/test/capture/application/meeting_processing_queue_test.dart
@@ -41,83 +41,88 @@ void main() {
       await queue.dispose();
     });
 
-    test('never runs two jobs concurrently -- second waits behind the first', () async {
-      final store = InMemoryProcessingQueueStore();
-      final started = <String>[];
-      final completers = <String, Completer<void>>{};
-      final queue = MeetingProcessingQueue(
-        store: store,
-        deviceSignalsProbe: const FakeLlmDeviceSignalsProbe(
-          LlmDeviceSignals(totalRamMb: 8000, availableStorageMb: 8000),
-        ),
-        processJob: (job) async {
-          started.add(job.id);
-          final completer = Completer<void>();
-          completers[job.id] = completer;
-          await completer.future;
-        },
-      );
-      await queue.restore();
+    test(
+      'never runs two jobs concurrently -- second waits behind the first',
+      () async {
+        final store = InMemoryProcessingQueueStore();
+        final started = <String>[];
+        final completers = <String, Completer<void>>{};
+        final queue = MeetingProcessingQueue(
+          store: store,
+          deviceSignalsProbe: const FakeLlmDeviceSignalsProbe(
+            LlmDeviceSignals(totalRamMb: 8000, availableStorageMb: 8000),
+          ),
+          processJob: (job) async {
+            started.add(job.id);
+            final completer = Completer<void>();
+            completers[job.id] = completer;
+            await completer.future;
+          },
+        );
+        await queue.restore();
 
-      await queue.enqueue(_job('first'));
-      await queue.enqueue(_job('second'));
-      await pumpEventQueue();
+        await queue.enqueue(_job('first'));
+        await queue.enqueue(_job('second'));
+        await pumpEventQueue();
 
-      // Only the first job may be running -- the second must still be queued.
-      expect(started, ['first']);
-      expect(
-        queue.current.firstWhere((j) => j.id == 'second').status,
-        MeetingProcessingStatus.queued,
-      );
+        // Only the first job may be running -- the second must still be queued.
+        expect(started, ['first']);
+        expect(
+          queue.current.firstWhere((j) => j.id == 'second').status,
+          MeetingProcessingStatus.queued,
+        );
 
-      completers['first']!.complete();
-      await pumpEventQueue();
+        completers['first']!.complete();
+        await pumpEventQueue();
 
-      expect(started, ['first', 'second']);
-      completers['second']!.complete();
-      await pumpEventQueue();
+        expect(started, ['first', 'second']);
+        completers['second']!.complete();
+        await pumpEventQueue();
 
-      expect(
-        queue.current.every((j) => j.status == MeetingProcessingStatus.completed),
-        isTrue,
-      );
+        expect(
+          queue.current.every(
+            (j) => j.status == MeetingProcessingStatus.completed,
+          ),
+          isTrue,
+        );
 
-      await queue.dispose();
-    });
+        await queue.dispose();
+      },
+    );
 
-    test('pauses the whole queue under thermal pressure instead of throttling', () async {
-      final store = InMemoryProcessingQueueStore();
-      var pressure = LlmThermalPressure.critical;
-      final processed = <String>[];
-      final queue = MeetingProcessingQueue(
-        store: store,
-        deviceSignalsProbe: _DynamicProbe(() => pressure),
-        thermalPollInterval: const Duration(milliseconds: 5),
-        processJob: (job) async {
-          processed.add(job.id);
-        },
-      );
-      await queue.restore();
+    test(
+      'pauses the whole queue under thermal pressure instead of throttling',
+      () async {
+        final store = InMemoryProcessingQueueStore();
+        var pressure = LlmThermalPressure.critical;
+        final processed = <String>[];
+        final queue = MeetingProcessingQueue(
+          store: store,
+          deviceSignalsProbe: _DynamicProbe(() => pressure),
+          thermalPollInterval: const Duration(milliseconds: 5),
+          processJob: (job) async {
+            processed.add(job.id);
+          },
+        );
+        await queue.restore();
 
-      await queue.enqueue(_job('hot'));
-      await pumpEventQueue();
+        await queue.enqueue(_job('hot'));
+        await pumpEventQueue();
 
-      // Thermal pressure is critical -- nothing should have run.
-      expect(processed, isEmpty);
-      expect(
-        queue.current.single.status,
-        MeetingProcessingStatus.queued,
-      );
+        // Thermal pressure is critical -- nothing should have run.
+        expect(processed, isEmpty);
+        expect(queue.current.single.status, MeetingProcessingStatus.queued);
 
-      // Pressure eases; the poll timer should pick the job back up.
-      pressure = LlmThermalPressure.nominal;
-      await Future<void>.delayed(const Duration(milliseconds: 30));
-      await pumpEventQueue();
+        // Pressure eases; the poll timer should pick the job back up.
+        pressure = LlmThermalPressure.nominal;
+        await Future<void>.delayed(const Duration(milliseconds: 30));
+        await pumpEventQueue();
 
-      expect(processed, ['hot']);
+        expect(processed, ['hot']);
 
-      await queue.dispose();
-    });
+        await queue.dispose();
+      },
+    );
 
     test('restore demotes a job left in "processing" back to queued', () async {
       final store = InMemoryProcessingQueueStore([
@@ -145,64 +150,70 @@ void main() {
       await queue.dispose();
     });
 
-    test('a job that keeps failing stops retrying after the attempt cap', () async {
-      final store = InMemoryProcessingQueueStore();
-      var attempts = 0;
-      final queue = MeetingProcessingQueue(
-        store: store,
-        deviceSignalsProbe: const FakeLlmDeviceSignalsProbe(
-          LlmDeviceSignals(totalRamMb: 8000, availableStorageMb: 8000),
-        ),
-        maxAttempts: 2,
-        processJob: (job) async {
-          attempts++;
-          throw Exception('boom');
-        },
-      );
-      await queue.restore();
-
-      await queue.enqueue(_job('doomed'));
-      await pumpEventQueue();
-      await pumpEventQueue();
-      await pumpEventQueue();
-
-      expect(attempts, 2);
-      expect(queue.current.single.status, MeetingProcessingStatus.failed);
-      expect(queue.current.single.lastError, contains('boom'));
-
-      await queue.dispose();
-    });
-
-    test('the queue file round-trips a job list across a fresh queue instance', () async {
-      final store = InMemoryProcessingQueueStore();
-      final firstLifetime = MeetingProcessingQueue(
-        store: store,
-        deviceSignalsProbe: const FakeLlmDeviceSignalsProbe(
-          LlmDeviceSignals(
-            totalRamMb: 8000,
-            availableStorageMb: 8000,
-            thermalPressure: LlmThermalPressure.critical,
+    test(
+      'a job that keeps failing stops retrying after the attempt cap',
+      () async {
+        final store = InMemoryProcessingQueueStore();
+        var attempts = 0;
+        final queue = MeetingProcessingQueue(
+          store: store,
+          deviceSignalsProbe: const FakeLlmDeviceSignalsProbe(
+            LlmDeviceSignals(totalRamMb: 8000, availableStorageMb: 8000),
           ),
-        ),
-        processJob: (job) async {},
-      );
-      await firstLifetime.restore();
-      await firstLifetime.enqueue(_job('survives-restart'));
-      await pumpEventQueue();
-      await firstLifetime.dispose();
+          maxAttempts: 2,
+          processJob: (job) async {
+            attempts++;
+            throw Exception('boom');
+          },
+        );
+        await queue.restore();
 
-      final secondLifetime = MeetingProcessingQueue(
-        store: store,
-        deviceSignalsProbe: const FakeLlmDeviceSignalsProbe(
-          LlmDeviceSignals(totalRamMb: 8000, availableStorageMb: 8000),
-        ),
-        processJob: (job) async {},
-      );
-      await secondLifetime.restore();
+        await queue.enqueue(_job('doomed'));
+        await pumpEventQueue();
+        await pumpEventQueue();
+        await pumpEventQueue();
 
-      expect(secondLifetime.current.single.id, 'survives-restart');
-      await secondLifetime.dispose();
-    });
+        expect(attempts, 2);
+        expect(queue.current.single.status, MeetingProcessingStatus.failed);
+        expect(queue.current.single.lastError, contains('boom'));
+
+        await queue.dispose();
+      },
+    );
+
+    test(
+      'the queue file round-trips a job list across a fresh queue instance',
+      () async {
+        final store = InMemoryProcessingQueueStore();
+        final firstLifetime = MeetingProcessingQueue(
+          store: store,
+          deviceSignalsProbe: const FakeLlmDeviceSignalsProbe(
+            LlmDeviceSignals(
+              totalRamMb: 8000,
+              availableStorageMb: 8000,
+              thermalPressure: LlmThermalPressure.critical,
+            ),
+          ),
+          processJob: (job) async {},
+        );
+        await firstLifetime.restore();
+        await firstLifetime.enqueue(_job('survives-restart'));
+        await pumpEventQueue();
+        await firstLifetime.dispose();
+
+        final secondLifetime = MeetingProcessingQueue(
+          store: store,
+          deviceSignalsProbe: const FakeLlmDeviceSignalsProbe(
+            LlmDeviceSignals(totalRamMb: 8000, availableStorageMb: 8000),
+          ),
+          processJob: (job) async {},
+        );
+        await secondLifetime.restore();
+
+        expect(secondLifetime.current.single.id, 'survives-restart');
+        await secondLifetime.dispose();
+      },
+    );
   });
 }
 

--- a/packages/feature_mind/test/capture/application/meeting_processing_queue_test.dart
+++ b/packages/feature_mind/test/capture/application/meeting_processing_queue_test.dart
@@ -36,7 +36,10 @@ void main() {
       await pumpEventQueue();
 
       expect(processed, ['m1']);
-      expect(queue.current.single.status, MeetingProcessingStatus.completed);
+      // Completed jobs are pruned, not kept as `completed` -- see the
+      // dedicated pruning test below and the class doc's "Retention
+      // discipline" section.
+      expect(queue.current, isEmpty);
 
       await queue.dispose();
     });
@@ -79,12 +82,8 @@ void main() {
         completers['second']!.complete();
         await pumpEventQueue();
 
-        expect(
-          queue.current.every(
-            (j) => j.status == MeetingProcessingStatus.completed,
-          ),
-          isTrue,
-        );
+        // Both completed -- and pruned, so nothing is left in the queue.
+        expect(queue.current, isEmpty);
 
         await queue.dispose();
       },
@@ -145,7 +144,90 @@ void main() {
       // The job that "died" mid-process is picked back up from scratch, not
       // left stuck in `processing` forever.
       expect(processed, ['orphaned']);
-      expect(queue.current.single.status, MeetingProcessingStatus.completed);
+      expect(queue.current, isEmpty);
+
+      await queue.dispose();
+    });
+
+    test(
+      'completed jobs are pruned from the persisted list, not kept forever',
+      () async {
+        final store = InMemoryProcessingQueueStore();
+        final queue = MeetingProcessingQueue(
+          store: store,
+          deviceSignalsProbe: const FakeLlmDeviceSignalsProbe(
+            LlmDeviceSignals(totalRamMb: 8000, availableStorageMb: 8000),
+          ),
+          processJob: (job) async {},
+        );
+        await queue.restore();
+
+        await queue.enqueue(_job('m1'));
+        await pumpEventQueue();
+
+        expect(queue.current, isEmpty);
+        // Also gone from disk, not just the in-memory list -- a fresh queue
+        // reading the same store must not see it either.
+        expect(await store.load(), isEmpty);
+
+        await queue.dispose();
+      },
+    );
+
+    test('a terminally-failed job still runs the retention cleanup callback '
+        '(chief-security-officer review, #1656)', () async {
+      final store = InMemoryProcessingQueueStore();
+      final cleanedUp = <String>[];
+      final queue = MeetingProcessingQueue(
+        store: store,
+        deviceSignalsProbe: const FakeLlmDeviceSignalsProbe(
+          LlmDeviceSignals(totalRamMb: 8000, availableStorageMb: 8000),
+        ),
+        maxAttempts: 1,
+        processJob: (job) async => throw Exception('unrecoverable'),
+        onTerminalFailure: (job) async => cleanedUp.add(job.id),
+      );
+      await queue.restore();
+
+      await queue.enqueue(_job('doomed'));
+      await pumpEventQueue();
+      await pumpEventQueue();
+
+      expect(cleanedUp, ['doomed']);
+      // Unlike a completed job, a failed one stays visible -- it is
+      // diagnostic state a future "needs attention" surface can show, not
+      // a job the person can act on again automatically.
+      expect(queue.current.single.status, MeetingProcessingStatus.failed);
+
+      await queue.dispose();
+    });
+
+    test('a throwing onTerminalFailure callback does not stop the queue '
+        'from moving on to the next job', () async {
+      final store = InMemoryProcessingQueueStore();
+      final processed = <String>[];
+      final queue = MeetingProcessingQueue(
+        store: store,
+        deviceSignalsProbe: const FakeLlmDeviceSignalsProbe(
+          LlmDeviceSignals(totalRamMb: 8000, availableStorageMb: 8000),
+        ),
+        maxAttempts: 1,
+        processJob: (job) async {
+          if (job.id == 'doomed') throw Exception('unrecoverable');
+          processed.add(job.id);
+        },
+        onTerminalFailure: (job) async =>
+            throw Exception('cleanup also failed'),
+      );
+      await queue.restore();
+
+      await queue.enqueue(_job('doomed'));
+      await queue.enqueue(_job('fine'));
+      await pumpEventQueue();
+      await pumpEventQueue();
+      await pumpEventQueue();
+
+      expect(processed, ['fine']);
 
       await queue.dispose();
     });

--- a/packages/feature_mind/test/capture/data/meeting_processing_queue_store_test.dart
+++ b/packages/feature_mind/test/capture/data/meeting_processing_queue_store_test.dart
@@ -1,0 +1,66 @@
+import 'dart:io';
+
+import 'package:feature_mind/src/capture/data/meeting_processing_queue_store.dart';
+import 'package:feature_mind/src/capture/domain/meeting_processing_job.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('FileMeetingProcessingQueueStore', () {
+    late Directory tempDir;
+
+    setUp(() {
+      tempDir = Directory.systemTemp.createTempSync('mind_queue_store_test');
+    });
+
+    tearDown(() {
+      if (tempDir.existsSync()) tempDir.deleteSync(recursive: true);
+    });
+
+    test('load returns empty when no file exists yet', () async {
+      final store = FileMeetingProcessingQueueStore(
+        '${tempDir.path}/queue.json',
+      );
+
+      expect(await store.load(), isEmpty);
+    });
+
+    test('save then load round-trips the job list', () async {
+      final store = FileMeetingProcessingQueueStore(
+        '${tempDir.path}/queue.json',
+      );
+      final jobs = [
+        const MeetingProcessingJob(
+          id: 'm1',
+          audioPath: '/tmp/m1.m4a',
+          title: 'Standup',
+          enqueuedAtMs: 1,
+          status: MeetingProcessingStatus.queued,
+        ),
+        const MeetingProcessingJob(
+          id: 'm2',
+          audioPath: '/tmp/m2.m4a',
+          title: '1:1',
+          enqueuedAtMs: 2,
+          status: MeetingProcessingStatus.completed,
+        ),
+      ];
+
+      await store.save(jobs);
+      final loaded = await store.load();
+
+      expect(loaded.map((j) => j.id), ['m1', 'm2']);
+      expect(loaded[1].status, MeetingProcessingStatus.completed);
+    });
+
+    test('save leaves no dangling temp file behind', () async {
+      final store = FileMeetingProcessingQueueStore(
+        '${tempDir.path}/queue.json',
+      );
+
+      await store.save(const []);
+
+      expect(File('${tempDir.path}/queue.json.tmp').existsSync(), isFalse);
+      expect(File('${tempDir.path}/queue.json').existsSync(), isTrue);
+    });
+  });
+}

--- a/packages/feature_mind/test/capture/domain/audio_retention_policy_test.dart
+++ b/packages/feature_mind/test/capture/domain/audio_retention_policy_test.dart
@@ -1,0 +1,26 @@
+import 'package:feature_mind/src/capture/domain/audio_retention_policy.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('AudioRetentionPolicy', () {
+    test('round-trips through its storage value', () {
+      for (final policy in AudioRetentionPolicy.values) {
+        expect(
+          AudioRetentionPolicy.fromStorageValue(policy.storageValue),
+          policy,
+        );
+      }
+    });
+
+    test('an unknown or missing stored value falls back to keep', () {
+      expect(
+        AudioRetentionPolicy.fromStorageValue(null),
+        AudioRetentionPolicy.keepAfterTranscript,
+      );
+      expect(
+        AudioRetentionPolicy.fromStorageValue('not-a-real-value'),
+        AudioRetentionPolicy.keepAfterTranscript,
+      );
+    });
+  });
+}

--- a/packages/feature_mind/test/capture/domain/meeting_processing_job_test.dart
+++ b/packages/feature_mind/test/capture/domain/meeting_processing_job_test.dart
@@ -1,0 +1,46 @@
+import 'package:feature_mind/src/capture/domain/meeting_processing_job.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('MeetingProcessingJob round-trips through JSON', () {
+    const job = MeetingProcessingJob(
+      id: 'm1',
+      audioPath: '/tmp/m1.m4a',
+      title: 'Standup',
+      enqueuedAtMs: 12345,
+      status: MeetingProcessingStatus.paused,
+      attempt: 2,
+      lastError: 'thermal pause',
+    );
+
+    final decoded = MeetingProcessingJob.fromJson(job.toJson());
+
+    expect(decoded.id, job.id);
+    expect(decoded.audioPath, job.audioPath);
+    expect(decoded.title, job.title);
+    expect(decoded.enqueuedAtMs, job.enqueuedAtMs);
+    expect(decoded.status, job.status);
+    expect(decoded.attempt, job.attempt);
+    expect(decoded.lastError, job.lastError);
+  });
+
+  test('an unrecognised status in storage falls back to queued', () {
+    final decoded = MeetingProcessingJob.fromJson({
+      'id': 'm1',
+      'audioPath': '/tmp/m1.m4a',
+      'title': 'Standup',
+      'enqueuedAtMs': 1,
+      'status': 'something-future-code-added',
+    });
+
+    expect(decoded.status, MeetingProcessingStatus.queued);
+  });
+
+  test('isTerminal is true only for completed/failed', () {
+    expect(MeetingProcessingStatus.queued.isTerminal, isFalse);
+    expect(MeetingProcessingStatus.processing.isTerminal, isFalse);
+    expect(MeetingProcessingStatus.paused.isTerminal, isFalse);
+    expect(MeetingProcessingStatus.completed.isTerminal, isTrue);
+    expect(MeetingProcessingStatus.failed.isTerminal, isTrue);
+  });
+}

--- a/packages/feature_mind/test/capture/presentation/audio_retention_settings_tile_test.dart
+++ b/packages/feature_mind/test/capture/presentation/audio_retention_settings_tile_test.dart
@@ -9,9 +9,7 @@ void main() {
   Future<void> pumpTile(WidgetTester tester) async {
     await tester.pumpWidget(
       const ProviderScope(
-        child: MaterialApp(
-          home: Scaffold(body: AudioRetentionSettingsTile()),
-        ),
+        child: MaterialApp(home: Scaffold(body: AudioRetentionSettingsTile())),
       ),
     );
     await tester.pumpAndSettle();
@@ -27,7 +25,9 @@ void main() {
     expect(find.textContaining('stays on this device'), findsOneWidget);
   });
 
-  testWidgets('reflects a previously saved "delete" preference', (tester) async {
+  testWidgets('reflects a previously saved "delete" preference', (
+    tester,
+  ) async {
     SharedPreferences.setMockInitialValues({
       'mind_audio_retention_policy':
           AudioRetentionPolicy.deleteAfterTranscript.storageValue,
@@ -40,24 +40,25 @@ void main() {
     expect(find.textContaining('is deleted once'), findsOneWidget);
   });
 
-  testWidgets('toggling off switches to delete-after-transcript and persists it', (
-    tester,
-  ) async {
-    SharedPreferences.setMockInitialValues({});
+  testWidgets(
+    'toggling off switches to delete-after-transcript and persists it',
+    (tester) async {
+      SharedPreferences.setMockInitialValues({});
 
-    await pumpTile(tester);
-    await tester.tap(find.byType(SwitchListTile));
-    await tester.pumpAndSettle();
+      await pumpTile(tester);
+      await tester.tap(find.byType(SwitchListTile));
+      await tester.pumpAndSettle();
 
-    expect(
-      tester.widget<SwitchListTile>(find.byType(SwitchListTile)).value,
-      isFalse,
-    );
+      expect(
+        tester.widget<SwitchListTile>(find.byType(SwitchListTile)).value,
+        isFalse,
+      );
 
-    final prefs = await SharedPreferences.getInstance();
-    expect(
-      prefs.getString('mind_audio_retention_policy'),
-      AudioRetentionPolicy.deleteAfterTranscript.storageValue,
-    );
-  });
+      final prefs = await SharedPreferences.getInstance();
+      expect(
+        prefs.getString('mind_audio_retention_policy'),
+        AudioRetentionPolicy.deleteAfterTranscript.storageValue,
+      );
+    },
+  );
 }

--- a/packages/feature_mind/test/capture/presentation/audio_retention_settings_tile_test.dart
+++ b/packages/feature_mind/test/capture/presentation/audio_retention_settings_tile_test.dart
@@ -1,0 +1,63 @@
+import 'package:feature_mind/src/capture/domain/audio_retention_policy.dart';
+import 'package:feature_mind/src/capture/presentation/audio_retention_settings_tile.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  Future<void> pumpTile(WidgetTester tester) async {
+    await tester.pumpWidget(
+      const ProviderScope(
+        child: MaterialApp(
+          home: Scaffold(body: AudioRetentionSettingsTile()),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  testWidgets('defaults to "keep" and shows the keep copy', (tester) async {
+    SharedPreferences.setMockInitialValues({});
+
+    await pumpTile(tester);
+
+    final tile = tester.widget<SwitchListTile>(find.byType(SwitchListTile));
+    expect(tile.value, isTrue);
+    expect(find.textContaining('stays on this device'), findsOneWidget);
+  });
+
+  testWidgets('reflects a previously saved "delete" preference', (tester) async {
+    SharedPreferences.setMockInitialValues({
+      'mind_audio_retention_policy':
+          AudioRetentionPolicy.deleteAfterTranscript.storageValue,
+    });
+
+    await pumpTile(tester);
+
+    final tile = tester.widget<SwitchListTile>(find.byType(SwitchListTile));
+    expect(tile.value, isFalse);
+    expect(find.textContaining('is deleted once'), findsOneWidget);
+  });
+
+  testWidgets('toggling off switches to delete-after-transcript and persists it', (
+    tester,
+  ) async {
+    SharedPreferences.setMockInitialValues({});
+
+    await pumpTile(tester);
+    await tester.tap(find.byType(SwitchListTile));
+    await tester.pumpAndSettle();
+
+    expect(
+      tester.widget<SwitchListTile>(find.byType(SwitchListTile)).value,
+      isFalse,
+    );
+
+    final prefs = await SharedPreferences.getInstance();
+    expect(
+      prefs.getString('mind_audio_retention_policy'),
+      AudioRetentionPolicy.deleteAfterTranscript.storageValue,
+    );
+  });
+}

--- a/packages/feature_mind/test/capture/presentation/meeting_capture_screen_test.dart
+++ b/packages/feature_mind/test/capture/presentation/meeting_capture_screen_test.dart
@@ -6,29 +6,27 @@ import 'package:flutter_test/flutter_test.dart';
 void main() {
   Future<void> pumpScreen(WidgetTester tester) async {
     await tester.pumpWidget(
-      const ProviderScope(
-        child: MaterialApp(home: MeetingCaptureScreen()),
-      ),
+      const ProviderScope(child: MaterialApp(home: MeetingCaptureScreen())),
     );
     await tester.pumpAndSettle();
   }
 
-  testWidgets('shows the explicit consent-reminder copy before anything else (AC6)', (
+  testWidgets(
+    'shows the explicit consent-reminder copy before anything else (AC6)',
+    (tester) async {
+      await pumpScreen(tester);
+
+      expect(
+        find.byKey(const Key('meeting_capture_consent_reminder_copy')),
+        findsOneWidget,
+      );
+      expect(find.textContaining('checking it is on you'), findsOneWidget);
+    },
+  );
+
+  testWidgets('start recording is disabled until consent is confirmed', (
     tester,
   ) async {
-    await pumpScreen(tester);
-
-    expect(
-      find.byKey(const Key('meeting_capture_consent_reminder_copy')),
-      findsOneWidget,
-    );
-    expect(
-      find.textContaining('checking it is on you'),
-      findsOneWidget,
-    );
-  });
-
-  testWidgets('start recording is disabled until consent is confirmed', (tester) async {
     await pumpScreen(tester);
 
     final startButton = tester.widget<FilledButton>(
@@ -42,7 +40,9 @@ void main() {
     (tester) async {
       await pumpScreen(tester);
 
-      await tester.tap(find.byKey(const Key('meeting_capture_jurisdiction_dropdown')));
+      await tester.tap(
+        find.byKey(const Key('meeting_capture_jurisdiction_dropdown')),
+      );
       await tester.pumpAndSettle();
       // California is a two-party consent jurisdiction.
       await tester.tap(find.text('United States — California').last);
@@ -53,7 +53,9 @@ void main() {
       );
       expect(confirmButton.onPressed, isNull);
 
-      await tester.tap(find.byKey(const Key('meeting_capture_all_parties_checkbox')));
+      await tester.tap(
+        find.byKey(const Key('meeting_capture_all_parties_checkbox')),
+      );
       await tester.pumpAndSettle();
 
       final confirmAfterAck = tester.widget<FilledButton>(
@@ -63,51 +65,65 @@ void main() {
     },
   );
 
-  testWidgets('confirming consent unlocks the start-recording button', (tester) async {
+  testWidgets('confirming consent unlocks the start-recording button', (
+    tester,
+  ) async {
     await pumpScreen(tester);
 
-    await tester.tap(find.byKey(const Key('meeting_capture_jurisdiction_dropdown')));
+    await tester.tap(
+      find.byKey(const Key('meeting_capture_jurisdiction_dropdown')),
+    );
     await tester.pumpAndSettle();
     await tester.tap(find.text('United States — California').last);
     await tester.pumpAndSettle();
-    await tester.tap(find.byKey(const Key('meeting_capture_all_parties_checkbox')));
+    await tester.tap(
+      find.byKey(const Key('meeting_capture_all_parties_checkbox')),
+    );
     await tester.pumpAndSettle();
-    await tester.tap(find.byKey(const Key('meeting_capture_confirm_consent_button')));
+    await tester.tap(
+      find.byKey(const Key('meeting_capture_confirm_consent_button')),
+    );
     await tester.pumpAndSettle();
 
-    expect(find.byKey(const Key('meeting_capture_consent_granted')), findsOneWidget);
+    expect(
+      find.byKey(const Key('meeting_capture_consent_granted')),
+      findsOneWidget,
+    );
     final startButton = tester.widget<FilledButton>(
       find.byKey(const Key('meeting_capture_start_button')),
     );
     expect(startButton.onPressed, isNotNull);
   });
 
-  testWidgets('a one-party jurisdiction confirms without the notify-everyone box', (
-    tester,
-  ) async {
-    await pumpScreen(tester);
+  testWidgets(
+    'a one-party jurisdiction confirms without the notify-everyone box',
+    (tester) async {
+      await pumpScreen(tester);
 
-    await tester.tap(find.byKey(const Key('meeting_capture_jurisdiction_dropdown')));
-    await tester.pumpAndSettle();
-    // United Kingdom is a one-party consent jurisdiction -- no checkbox
-    // should even appear. It's low in a long dropdown list, so scroll it
-    // into view first (the menu is a lazily-built ListView, so it isn't in
-    // the tree at all until scrolled close enough to build).
-    await tester.scrollUntilVisible(
-      find.text('United Kingdom'),
-      200,
-      scrollable: find.byType(Scrollable).last,
-    );
-    await tester.tap(find.text('United Kingdom'));
-    await tester.pumpAndSettle();
+      await tester.tap(
+        find.byKey(const Key('meeting_capture_jurisdiction_dropdown')),
+      );
+      await tester.pumpAndSettle();
+      // United Kingdom is a one-party consent jurisdiction -- no checkbox
+      // should even appear. It's low in a long dropdown list, so scroll it
+      // into view first (the menu is a lazily-built ListView, so it isn't in
+      // the tree at all until scrolled close enough to build).
+      await tester.scrollUntilVisible(
+        find.text('United Kingdom'),
+        200,
+        scrollable: find.byType(Scrollable).last,
+      );
+      await tester.tap(find.text('United Kingdom'));
+      await tester.pumpAndSettle();
 
-    expect(
-      find.byKey(const Key('meeting_capture_all_parties_checkbox')),
-      findsNothing,
-    );
-    final confirmButton = tester.widget<FilledButton>(
-      find.byKey(const Key('meeting_capture_confirm_consent_button')),
-    );
-    expect(confirmButton.onPressed, isNotNull);
-  });
+      expect(
+        find.byKey(const Key('meeting_capture_all_parties_checkbox')),
+        findsNothing,
+      );
+      final confirmButton = tester.widget<FilledButton>(
+        find.byKey(const Key('meeting_capture_confirm_consent_button')),
+      );
+      expect(confirmButton.onPressed, isNotNull);
+    },
+  );
 }

--- a/packages/feature_mind/test/capture/presentation/meeting_capture_screen_test.dart
+++ b/packages/feature_mind/test/capture/presentation/meeting_capture_screen_test.dart
@@ -1,0 +1,113 @@
+import 'package:feature_mind/src/capture/presentation/meeting_capture_screen.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  Future<void> pumpScreen(WidgetTester tester) async {
+    await tester.pumpWidget(
+      const ProviderScope(
+        child: MaterialApp(home: MeetingCaptureScreen()),
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  testWidgets('shows the explicit consent-reminder copy before anything else (AC6)', (
+    tester,
+  ) async {
+    await pumpScreen(tester);
+
+    expect(
+      find.byKey(const Key('meeting_capture_consent_reminder_copy')),
+      findsOneWidget,
+    );
+    expect(
+      find.textContaining('checking it is on you'),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets('start recording is disabled until consent is confirmed', (tester) async {
+    await pumpScreen(tester);
+
+    final startButton = tester.widget<FilledButton>(
+      find.byKey(const Key('meeting_capture_start_button')),
+    );
+    expect(startButton.onPressed, isNull);
+  });
+
+  testWidgets(
+    'a two-party jurisdiction blocks confirm until the notify-everyone box is checked',
+    (tester) async {
+      await pumpScreen(tester);
+
+      await tester.tap(find.byKey(const Key('meeting_capture_jurisdiction_dropdown')));
+      await tester.pumpAndSettle();
+      // California is a two-party consent jurisdiction.
+      await tester.tap(find.text('United States — California').last);
+      await tester.pumpAndSettle();
+
+      final confirmButton = tester.widget<FilledButton>(
+        find.byKey(const Key('meeting_capture_confirm_consent_button')),
+      );
+      expect(confirmButton.onPressed, isNull);
+
+      await tester.tap(find.byKey(const Key('meeting_capture_all_parties_checkbox')));
+      await tester.pumpAndSettle();
+
+      final confirmAfterAck = tester.widget<FilledButton>(
+        find.byKey(const Key('meeting_capture_confirm_consent_button')),
+      );
+      expect(confirmAfterAck.onPressed, isNotNull);
+    },
+  );
+
+  testWidgets('confirming consent unlocks the start-recording button', (tester) async {
+    await pumpScreen(tester);
+
+    await tester.tap(find.byKey(const Key('meeting_capture_jurisdiction_dropdown')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('United States — California').last);
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('meeting_capture_all_parties_checkbox')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('meeting_capture_confirm_consent_button')));
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const Key('meeting_capture_consent_granted')), findsOneWidget);
+    final startButton = tester.widget<FilledButton>(
+      find.byKey(const Key('meeting_capture_start_button')),
+    );
+    expect(startButton.onPressed, isNotNull);
+  });
+
+  testWidgets('a one-party jurisdiction confirms without the notify-everyone box', (
+    tester,
+  ) async {
+    await pumpScreen(tester);
+
+    await tester.tap(find.byKey(const Key('meeting_capture_jurisdiction_dropdown')));
+    await tester.pumpAndSettle();
+    // United Kingdom is a one-party consent jurisdiction -- no checkbox
+    // should even appear. It's low in a long dropdown list, so scroll it
+    // into view first (the menu is a lazily-built ListView, so it isn't in
+    // the tree at all until scrolled close enough to build).
+    await tester.scrollUntilVisible(
+      find.text('United Kingdom'),
+      200,
+      scrollable: find.byType(Scrollable).last,
+    );
+    await tester.tap(find.text('United Kingdom'));
+    await tester.pumpAndSettle();
+
+    expect(
+      find.byKey(const Key('meeting_capture_all_parties_checkbox')),
+      findsNothing,
+    );
+    final confirmButton = tester.widget<FilledButton>(
+      find.byKey(const Key('meeting_capture_confirm_consent_button')),
+    );
+    expect(confirmButton.onPressed, isNotNull);
+  });
+}

--- a/packages/feature_mind/test/capture/support/fake_audio_recorder_port.dart
+++ b/packages/feature_mind/test/capture/support/fake_audio_recorder_port.dart
@@ -1,0 +1,54 @@
+import 'dart:async';
+
+import 'package:feature_mind/src/capture/data/audio_recorder_port.dart';
+
+/// In-memory double for [AudioRecorderPort]. Tracks calls and lets a test
+/// simulate an OS-driven interruption via [emitOsEvent] — the seam
+/// `MeetingCaptureController`'s pause/resume-from-interruption logic is
+/// tested through.
+class FakeAudioRecorderPort implements AudioRecorderPort {
+  bool permissionGranted = true;
+  final List<String> calls = [];
+  String? startedPath;
+
+  final _osEvents = StreamController<RecorderOsEvent>.broadcast();
+
+  @override
+  Future<bool> hasPermission() async {
+    calls.add('hasPermission');
+    return permissionGranted;
+  }
+
+  @override
+  Future<void> start(String path) async {
+    calls.add('start:$path');
+    startedPath = path;
+  }
+
+  @override
+  Future<void> pause() async {
+    calls.add('pause');
+  }
+
+  @override
+  Future<void> resume() async {
+    calls.add('resume');
+  }
+
+  @override
+  Future<String?> stop() async {
+    calls.add('stop');
+    return startedPath;
+  }
+
+  @override
+  Stream<RecorderOsEvent> get osEvents => _osEvents.stream;
+
+  void emitOsEvent(RecorderOsEvent event) => _osEvents.add(event);
+
+  @override
+  Future<void> dispose() async {
+    calls.add('dispose');
+    await _osEvents.close();
+  }
+}

--- a/packages/feature_mind/test/capture/support/in_memory_processing_queue_store.dart
+++ b/packages/feature_mind/test/capture/support/in_memory_processing_queue_store.dart
@@ -1,0 +1,22 @@
+import 'package:feature_mind/src/capture/data/meeting_processing_queue_store.dart';
+import 'package:feature_mind/src/capture/domain/meeting_processing_job.dart';
+
+/// In-memory [MeetingProcessingQueueStore] whose saved list survives being
+/// handed to a *new* store instance — the shape a test needs to prove
+/// `MeetingProcessingQueue.restore()` really reads back what a previous
+/// "process lifetime" wrote, the same restart scenario a real
+/// `FileMeetingProcessingQueueStore` on disk provides.
+class InMemoryProcessingQueueStore implements MeetingProcessingQueueStore {
+  InMemoryProcessingQueueStore([List<MeetingProcessingJob>? seed])
+    : _jobs = seed ?? [];
+
+  List<MeetingProcessingJob> _jobs;
+
+  @override
+  Future<List<MeetingProcessingJob>> load() async => List.of(_jobs);
+
+  @override
+  Future<void> save(List<MeetingProcessingJob> jobs) async {
+    _jobs = List.of(jobs);
+  }
+}


### PR DESCRIPTION
Implements #1656 (MIND-LLM-15). chief-security-officer reviewed (mic access approved; two retention gaps found and fixed).

- MeetingCaptureController: start/pause/resume/stop, native encoder writes straight to disk (never buffered in Dart)
- Android: foreground service (`FOREGROUND_SERVICE_MICROPHONE`, persistent notification) via new MethodChannel
- iOS: AVAudioSession interruption pause/resume (call/Siri) via record_ios -- Dart-side wiring complete, but feature_mind isn't an iOS FFI plugin yet (pre-existing #1546 blocker), so this AC is code-complete but unbuildable/unverifiable on iOS until that lands
- MeetingProcessingQueue: disk-persisted, resumable across app restart, one job at a time, thermal-gated via existing LlmThermalPolicy (#1631) -- design note in the file per the issue's delegation instructions
- Retention: Settings toggle (keep/delete raw audio after transcript); CSO review found and fixed two gaps -- terminal job failure skipped cleanup, and processing_queue.json retained completed-job audio paths indefinitely outside the toggle
- Consent: reuses the existing AudioScribeConsentGate/jurisdiction-rules pattern

41 new tests, full feature_mind suite (804 tests) green, flutter analyze clean (pre-existing style infos only).

**Not verified — needs Pixel 9 / iPad physical device**, no device in this environment: foreground service surviving backgrounding + real mic-privacy indicator display; real AVAudioSession interruption behavior; a real 90-min recording surviving an actual app kill; real thermal-pressure signal quality under sustained load. This is exactly what the issue's own verification section asks for.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>