### PR TITLE
feat(mind): HF GGUF discovery + offline catalog cache (#1773)

### DIFF
--- a/app/lib/core/mind/mind_model_catalog.dart
+++ b/app/lib/core/mind/mind_model_catalog.dart
@@ -31,7 +31,14 @@ List<Override> mindModelRegistryOverrides({
     unawaited(
       hydrateDownloadedModels(registry, ref.read(modelDownloadServiceProvider)),
     );
-    unawaited(hydratePublicHuggingFaceModels(registry));
+    unawaited(() async {
+      final result = await hydratePublicHuggingFaceModels(registry);
+      if (!ref.mounted) return;
+      ref.read(huggingFaceCatalogAvailabilityProvider.notifier).state =
+          result.availability;
+      ref.read(huggingFaceCatalogErrorProvider.notifier).state =
+          result.errorMessage;
+    }());
     unawaited(
       hydrateMindScribeModels(
         registry,

--- a/app/lib/core/mind/mind_models_screen.dart
+++ b/app/lib/core/mind/mind_models_screen.dart
@@ -26,16 +26,14 @@ class MindModelsScreen extends ConsumerWidget {
     final activeDownloads = ref.watch(activeDownloadsProvider);
 
     return AiroResponsiveScaffold(
-      appBar: AppBar(
-        title: const Text('On-device models'),
-        centerTitle: false,
-      ),
+      appBar: AppBar(title: const Text('On-device models'), centerTitle: false),
       body: ListView(
         padding: const EdgeInsets.fromLTRB(16, 8, 16, 24),
         children: [
           Text(
-            'Choose a model from Hugging Face, download it, then warm it before '
-            'chatting. Nothing runs until you pick one.',
+            'Browse curated packages, litert-community releases, and public GGUF '
+            'models from Hugging Face. Download one, warm it, then chat — '
+            'nothing runs until you pick a model.',
             style: theme.textTheme.bodyMedium?.copyWith(
               color: theme.colorScheme.onSurfaceVariant,
             ),
@@ -61,7 +59,7 @@ class MindModelsScreen extends ConsumerWidget {
             icon: Icons.cloud_download_outlined,
             title: 'Browse Hugging Face catalog',
             subtitle:
-                'Curated packages plus the latest public litert-community releases',
+                'Curated, litert-community, and public GGUF — cached for offline browse',
             onTap: () => Navigator.of(context).push(
               MaterialPageRoute<void>(builder: (_) => const AIModelsScreen()),
             ),
@@ -102,7 +100,8 @@ class _ActiveModelCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    final name = catalogModel?.name ?? assistantRuntimeId ?? 'No model selected';
+    final name =
+        catalogModel?.name ?? assistantRuntimeId ?? 'No model selected';
     final statusLabel = switch (readiness.phase) {
       AssistantRuntimeReadinessPhase.idle => 'Choose a model to begin',
       AssistantRuntimeReadinessPhase.loading => 'Loading weights…',
@@ -158,7 +157,10 @@ class _ProgressCard extends StatelessWidget {
             Row(
               children: [
                 Expanded(
-                  child: Text(readiness.label, style: theme.textTheme.titleSmall),
+                  child: Text(
+                    readiness.label,
+                    style: theme.textTheme.titleSmall,
+                  ),
                 ),
                 Text('$percent%', style: theme.textTheme.titleSmall),
               ],

--- a/app/lib/features/settings/application/ai_model_management.dart
+++ b/app/lib/features/settings/application/ai_model_management.dart
@@ -23,17 +23,41 @@ import 'ai_preferences_settings.dart';
 /// imported it would stop compiling for three of the four apps.
 const String mindScribeModelTag = 'mind-scribe';
 
+/// Availability of live Hugging Face catalog rows (GGUF + litert-community).
+///
+/// Starts as [HuggingFaceCatalogAvailability.neverFetched] until hydrate
+/// finishes. Offline browse of previously seen entries sets [offlineCached].
+final huggingFaceCatalogAvailabilityProvider =
+    StateProvider<HuggingFaceCatalogAvailability>(
+      (ref) => HuggingFaceCatalogAvailability.neverFetched,
+    );
+
+/// Optional error from the last HF catalog hydrate (network / parse).
+final huggingFaceCatalogErrorProvider = StateProvider<String?>((ref) => null);
+
 /// Provider for the model registry singleton.
 final modelRegistryProvider = Provider<ModelRegistry>((ref) {
   final registry = ModelRegistry();
-    registry.registerModels(ModelCatalog.bundledModels);
-    unawaited(
-      hydrateDownloadedModels(registry, ref.read(modelDownloadServiceProvider)),
-    );
-    unawaited(hydratePublicHuggingFaceModels(registry));
+  registry.registerModels(ModelCatalog.bundledModels);
+  unawaited(
+    hydrateDownloadedModels(registry, ref.read(modelDownloadServiceProvider)),
+  );
+  unawaited(_hydratePublicHuggingFaceCatalog(ref, registry));
   ref.onDispose(registry.dispose);
   return registry;
 });
+
+Future<void> _hydratePublicHuggingFaceCatalog(
+  Ref ref,
+  ModelRegistry registry,
+) async {
+  final result = await hydratePublicHuggingFaceModels(registry);
+  if (!ref.mounted) return;
+  ref.read(huggingFaceCatalogAvailabilityProvider.notifier).state =
+      result.availability;
+  ref.read(huggingFaceCatalogErrorProvider.notifier).state =
+      result.errorMessage;
+}
 
 final modelRegistryEventsProvider = StreamProvider<ModelRegistryEvent>((ref) {
   final registry = ref.watch(modelRegistryProvider);

--- a/app/lib/features/settings/presentation/screens/ai_models_screen.dart
+++ b/app/lib/features/settings/presentation/screens/ai_models_screen.dart
@@ -137,6 +137,7 @@ class _AIModelsScreenState extends ConsumerState<AIModelsScreen>
             },
           ),
           const Divider(height: 1),
+          _HuggingFaceCatalogStatusBanner(),
 
           // Tab content
           Expanded(
@@ -434,5 +435,59 @@ class _AIModelsScreenState extends ConsumerState<AIModelsScreen>
         ),
       );
     }
+  }
+}
+
+/// Clear empty/error vs offline-cached messaging for the HF catalog feed.
+class _HuggingFaceCatalogStatusBanner extends ConsumerWidget {
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final availability = ref.watch(huggingFaceCatalogAvailabilityProvider);
+    final error = ref.watch(huggingFaceCatalogErrorProvider);
+    final theme = Theme.of(context);
+
+    final String? message = switch (availability) {
+      HuggingFaceCatalogAvailability.online => null,
+      HuggingFaceCatalogAvailability.offlineCached =>
+        'Showing previously fetched Hugging Face catalog entries offline.',
+      HuggingFaceCatalogAvailability.neverFetched =>
+        error == null
+            ? 'Hugging Face catalog not fetched yet. Connect once to discover '
+                  'public GGUF and litert-community packages.'
+            : 'Could not reach Hugging Face. No cached catalog entries yet.',
+    };
+    if (message == null) return const SizedBox.shrink();
+
+    final isError = availability == HuggingFaceCatalogAvailability.neverFetched;
+    return Material(
+      color: isError
+          ? theme.colorScheme.errorContainer
+          : theme.colorScheme.surfaceContainerHighest,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 10),
+        child: Row(
+          children: [
+            Icon(
+              isError ? Icons.cloud_off_outlined : Icons.offline_bolt_outlined,
+              size: 18,
+              color: isError
+                  ? theme.colorScheme.onErrorContainer
+                  : theme.colorScheme.onSurfaceVariant,
+            ),
+            const SizedBox(width: 8),
+            Expanded(
+              child: Text(
+                message,
+                style: theme.textTheme.bodySmall?.copyWith(
+                  color: isError
+                      ? theme.colorScheme.onErrorContainer
+                      : theme.colorScheme.onSurfaceVariant,
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
   }
 }

--- a/packages/core_ai/lib/core_ai.dart
+++ b/packages/core_ai/lib/core_ai.dart
@@ -70,6 +70,7 @@ export 'src/models/model_credibility.dart';
 export 'src/models/offline_model_info.dart';
 export 'src/registry/model_registry.dart';
 export 'src/registry/model_catalog.dart';
+export 'src/huggingface/huggingface_catalog_cache.dart';
 export 'src/huggingface/huggingface_catalog_service.dart';
 
 // Model Download

--- a/packages/core_ai/lib/src/huggingface/huggingface_catalog_cache.dart
+++ b/packages/core_ai/lib/src/huggingface/huggingface_catalog_cache.dart
@@ -1,0 +1,133 @@
+import 'dart:convert';
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:core_workers/core_workers.dart';
+import 'package:path/path.dart' as p;
+import 'package:path_provider/path_provider.dart';
+
+import '../models/offline_model_info.dart';
+
+/// Bytes above which catalog JSON parse/encode must leave the UI isolate.
+const int kHuggingFaceCatalogOffMainThresholdBytes = 50 * 1024;
+
+/// Disk cache of Hugging Face catalog metadata for offline browse.
+///
+/// Stores previously fetched [OfflineModelInfo] rows (not model weights).
+/// A missing file means the catalog was never successfully fetched — callers
+/// must surface a clear empty/error state rather than inventing entries.
+class HuggingFaceCatalogCache {
+  HuggingFaceCatalogCache({
+    this.resolveRoot,
+    this.fileName = 'hf_catalog_metadata.json',
+  });
+
+  final Directory? Function()? resolveRoot;
+  final String fileName;
+
+  Future<File> _cacheFile() async {
+    final root = resolveRoot?.call() ?? await getApplicationSupportDirectory();
+    final dir = Directory(p.join(root.path, 'model_catalog'));
+    if (!await dir.exists()) {
+      await dir.create(recursive: true);
+    }
+    return File(p.join(dir.path, fileName));
+  }
+
+  /// Whether a non-empty cache file exists from a prior successful fetch.
+  Future<bool> hasCachedEntries() async {
+    final file = await _cacheFile();
+    if (!await file.exists()) return false;
+    return (await file.length()) > 2;
+  }
+
+  /// Loads cached catalog rows, or an empty list when never fetched / corrupt.
+  Future<List<OfflineModelInfo>> load() async {
+    final file = await _cacheFile();
+    if (!await file.exists()) return const [];
+
+    final bytes = await file.readAsBytes();
+    if (bytes.isEmpty) return const [];
+
+    try {
+      final decoded = await decodeCatalogJson(bytes);
+      final models = <OfflineModelInfo>[];
+      for (final raw in decoded) {
+        if (raw is! Map) continue;
+        models.add(OfflineModelInfo.fromJson(Map<String, dynamic>.from(raw)));
+      }
+      return models;
+    } on Object {
+      return const [];
+    }
+  }
+
+  /// Persists [models] for offline browse of already-seen catalog entries.
+  Future<void> save(List<OfflineModelInfo> models) async {
+    final file = await _cacheFile();
+    final payload = models
+        .map((model) => model.toJson())
+        .toList(growable: false);
+    final encoded = await encodeCatalogJson(payload);
+    final temporary = File('${file.path}.tmp');
+    await temporary.writeAsBytes(encoded, flush: true);
+    if (await file.exists()) {
+      await file.delete();
+    }
+    await temporary.rename(file.path);
+  }
+
+  /// Clears the cache so the next offline open reports never-fetched.
+  Future<void> clear() async {
+    final file = await _cacheFile();
+    if (await file.exists()) {
+      await file.delete();
+    }
+  }
+}
+
+/// Decode catalog JSON, offloading when the payload exceeds ~50 KB.
+Future<List<dynamic>> decodeCatalogJson(Uint8List bytes) async {
+  if (bytes.lengthInBytes > kHuggingFaceCatalogOffMainThresholdBytes) {
+    return runOffMain(() => _decodeCatalogJsonSync(bytes));
+  }
+  return _decodeCatalogJsonSync(bytes);
+}
+
+/// Decode a JSON object or list payload (model card or listing).
+Future<Object?> decodeCatalogJsonObject(Uint8List bytes) async {
+  if (bytes.lengthInBytes > kHuggingFaceCatalogOffMainThresholdBytes) {
+    return runOffMain(() => jsonDecode(utf8.decode(bytes)));
+  }
+  return jsonDecode(utf8.decode(bytes));
+}
+
+List<dynamic> _decodeCatalogJsonSync(Uint8List bytes) {
+  final decoded = jsonDecode(utf8.decode(bytes));
+  if (decoded is List) return decoded;
+  if (decoded is Map && decoded['models'] is List) {
+    return decoded['models'] as List<dynamic>;
+  }
+  return const [];
+}
+
+/// Encode catalog JSON, offloading when the payload exceeds ~50 KB.
+Future<Uint8List> encodeCatalogJson(List<Map<String, dynamic>> models) async {
+  if (models.isEmpty) {
+    return Uint8List.fromList(utf8.encode('{"version":1,"models":[]}'));
+  }
+  // Prefer leaving the UI isolate before a large encode, not after.
+  if (models.length >= 8) {
+    return runOffMain(() => _encodeCatalogJsonSync(models));
+  }
+  final encoded = _encodeCatalogJsonSync(models);
+  if (encoded.lengthInBytes > kHuggingFaceCatalogOffMainThresholdBytes) {
+    return runOffMain(() => _encodeCatalogJsonSync(models));
+  }
+  return encoded;
+}
+
+Uint8List _encodeCatalogJsonSync(List<Map<String, dynamic>> models) {
+  final json = jsonEncode({'version': 1, 'models': models});
+  return Uint8List.fromList(utf8.encode(json));
+}

--- a/packages/core_ai/lib/src/huggingface/huggingface_catalog_service.dart
+++ b/packages/core_ai/lib/src/huggingface/huggingface_catalog_service.dart
@@ -1,3 +1,5 @@
+import 'dart:typed_data';
+
 import 'package:dio/dio.dart';
 
 import '../models/model_credibility.dart';
@@ -5,11 +7,42 @@ import '../models/offline_model_info.dart';
 import '../provider/ai_provider.dart';
 import '../registry/model_catalog.dart';
 import '../registry/model_registry.dart';
+import 'huggingface_catalog_cache.dart';
+
+/// How Hugging Face catalog rows were resolved for the model explorer.
+enum HuggingFaceCatalogAvailability {
+  /// Live fetch succeeded and the disk cache was refreshed.
+  online,
+
+  /// Network failed; previously cached metadata is shown.
+  offlineCached,
+
+  /// Never successfully fetched — show a clear empty/error state.
+  neverFetched,
+}
+
+/// Outcome of hydrating public Hugging Face rows into [ModelRegistry].
+class HuggingFaceCatalogHydration {
+  const HuggingFaceCatalogHydration({
+    required this.availability,
+    required this.models,
+    this.errorMessage,
+  });
+
+  final HuggingFaceCatalogAvailability availability;
+  final List<OfflineModelInfo> models;
+  final String? errorMessage;
+
+  bool get hasRemoteEntries => models.isNotEmpty;
+}
 
 /// Fetches public Hugging Face model repos so users can try new releases
 /// without waiting for a static catalog update.
+///
+/// Extends the litert-community feed from #1769 with a GGUF discovery path and
+/// an offline metadata cache for already-seen entries.
 class HuggingFaceCatalogService {
-  HuggingFaceCatalogService({Dio? dio})
+  HuggingFaceCatalogService({Dio? dio, HuggingFaceCatalogCache? cache})
     : _dio =
           dio ??
           Dio(
@@ -17,10 +50,13 @@ class HuggingFaceCatalogService {
               connectTimeout: const Duration(seconds: 15),
               receiveTimeout: const Duration(seconds: 30),
               headers: const {'Accept': 'application/json'},
+              responseType: ResponseType.bytes,
             ),
-          );
+          ),
+      _cache = cache ?? HuggingFaceCatalogCache();
 
   final Dio _dio;
+  final HuggingFaceCatalogCache _cache;
 
   static const _supportedArtifactSuffixes = [
     '.litertlm',
@@ -28,6 +64,8 @@ class HuggingFaceCatalogService {
     '.tflite',
     '.gguf',
   ];
+
+  HuggingFaceCatalogCache get cache => _cache;
 
   /// Loads runnable artifacts from a public Hugging Face organization feed.
   ///
@@ -38,7 +76,7 @@ class HuggingFaceCatalogService {
     int limit = 50,
     Set<String> knownHuggingFaceIds = const {},
   }) async {
-    final response = await _dio.get<List<dynamic>>(
+    final entries = await _getJsonList(
       'https://huggingface.co/api/models',
       queryParameters: {
         'author': author,
@@ -47,14 +85,149 @@ class HuggingFaceCatalogService {
         'limit': limit,
       },
     );
-    final entries = response.data ?? const [];
+    return _modelsFromEntries(
+      entries,
+      knownHuggingFaceIds: knownHuggingFaceIds,
+    );
+  }
+
+  /// Discovers public GGUF packages beyond the litert-community LiteRT feed.
+  ///
+  /// Uses the Hugging Face `gguf` filter and prefers mobile-friendly quants
+  /// (Q4_K_M → Q4 → Q5 → smallest remaining GGUF). When [authors] is non-empty,
+  /// queries each author separately (HF accepts one `author` per request).
+  Future<List<OfflineModelInfo>> fetchGgufModels({
+    int limit = 40,
+    Set<String> knownHuggingFaceIds = const {},
+    String sort = 'downloads',
+    String? search,
+    List<String> authors = const [],
+  }) async {
+    if (authors.isEmpty) {
+      return _fetchGgufPage(
+        limit: limit,
+        knownHuggingFaceIds: knownHuggingFaceIds,
+        sort: sort,
+        search: search,
+      );
+    }
+
+    final perAuthor = (limit / authors.length).ceil().clamp(1, limit);
+    final merged = <OfflineModelInfo>[];
+    final seen = <String>{...knownHuggingFaceIds};
+    for (final author in authors) {
+      final page = await _fetchGgufPage(
+        limit: perAuthor,
+        knownHuggingFaceIds: seen,
+        sort: sort,
+        search: search,
+        author: author,
+      );
+      for (final model in page) {
+        final hfId = model.huggingFaceId;
+        if (hfId != null) seen.add(hfId);
+        merged.add(model);
+      }
+      if (merged.length >= limit) break;
+    }
+    return merged.take(limit).toList(growable: false);
+  }
+
+  Future<List<OfflineModelInfo>> _fetchGgufPage({
+    required int limit,
+    required Set<String> knownHuggingFaceIds,
+    required String sort,
+    String? search,
+    String? author,
+  }) async {
+    final query = <String, dynamic>{
+      'filter': 'gguf',
+      'sort': sort,
+      'direction': '-1',
+      'limit': limit,
+    };
+    if (search != null && search.isNotEmpty) {
+      query['search'] = search;
+    }
+    if (author != null && author.isNotEmpty) {
+      query['author'] = author;
+    }
+    final entries = await _getJsonList(
+      'https://huggingface.co/api/models',
+      queryParameters: query,
+    );
+    return _modelsFromEntries(
+      entries,
+      knownHuggingFaceIds: knownHuggingFaceIds,
+      ggufOnly: true,
+    );
+  }
+
+  /// Resolves a pasted Hugging Face repo URL or bare `author/name` id.
+  ///
+  /// Does not download weights — only builds an [OfflineModelInfo] catalog row
+  /// when a supported artifact exists in the repo tree.
+  Future<OfflineModelInfo?> resolveFromRepoUrl(
+    String urlOrId, {
+    Set<String> knownHuggingFaceIds = const {},
+  }) async {
+    final huggingFaceId = parseHuggingFaceRepoId(urlOrId);
+    if (huggingFaceId == null) return null;
+    if (knownHuggingFaceIds.contains(huggingFaceId)) return null;
+
+    Map<String, dynamic> raw = {'id': huggingFaceId};
+    try {
+      final card = await _getJsonMap(
+        'https://huggingface.co/api/models/$huggingFaceId',
+      );
+      if (card != null) raw = card;
+    } on DioException {
+      // Tree fetch below still works when the card endpoint fails.
+    }
+
+    return _modelFromRepo(raw);
+  }
+
+  /// Parses `https://huggingface.co/org/repo` (and `/tree/...`) or bare
+  /// `org/repo`. Returns null when the string is not a repo reference.
+  static String? parseHuggingFaceRepoId(String input) {
+    final trimmed = input.trim();
+    if (trimmed.isEmpty) return null;
+
+    final asUri = Uri.tryParse(trimmed);
+    if (asUri != null &&
+        asUri.hasScheme &&
+        (asUri.host == 'huggingface.co' ||
+            asUri.host == 'www.huggingface.co' ||
+            asUri.host == 'hf.co')) {
+      final segments = asUri.pathSegments
+          .where((segment) => segment.isNotEmpty)
+          .toList(growable: false);
+      if (segments.length >= 2) {
+        return '${segments[0]}/${segments[1]}';
+      }
+      return null;
+    }
+
+    if (RegExp(r'^[\w.-]+/[\w.-]+$').hasMatch(trimmed)) {
+      return trimmed;
+    }
+    return null;
+  }
+
+  Future<List<OfflineModelInfo>> _modelsFromEntries(
+    List<dynamic> entries, {
+    required Set<String> knownHuggingFaceIds,
+    bool ggufOnly = false,
+  }) async {
     final models = <OfflineModelInfo>[];
     for (final raw in entries) {
-      if (raw is! Map<String, dynamic>) continue;
-      final modelId = raw['id'] as String?;
+      if (raw is! Map) continue;
+      final map = Map<String, dynamic>.from(raw);
+      final modelId = map['id'] as String?;
       if (modelId == null || modelId.isEmpty) continue;
       if (knownHuggingFaceIds.contains(modelId)) continue;
-      final parsed = await _modelFromRepo(raw);
+      final parsed = await _modelFromRepo(map, ggufOnly: ggufOnly);
       if (parsed != null) {
         models.add(parsed);
       }
@@ -62,14 +235,19 @@ class HuggingFaceCatalogService {
     return models;
   }
 
-  Future<OfflineModelInfo?> _modelFromRepo(Map<String, dynamic> raw) async {
+  Future<OfflineModelInfo?> _modelFromRepo(
+    Map<String, dynamic> raw, {
+    bool ggufOnly = false,
+  }) async {
     final huggingFaceId = raw['id'] as String?;
     if (huggingFaceId == null || huggingFaceId.isEmpty) return null;
 
     final tree = await _fetchMainTree(huggingFaceId);
     if (tree.isEmpty) return null;
 
-    final artifact = _selectArtifact(tree);
+    final artifact = ggufOnly
+        ? _selectGgufArtifact(tree)
+        : _selectArtifact(tree);
     if (artifact == null) return null;
 
     final fileName = artifact['path'] as String;
@@ -82,51 +260,94 @@ class HuggingFaceCatalogService {
         .toList(growable: false);
     final pipelineTag = raw['pipeline_tag'] as String? ?? '';
     final libraryName = raw['library_name'] as String? ?? '';
+    final isGguf = fileName.toLowerCase().endsWith('.gguf');
+    final license = _licenseFromTags(tags);
+    final quantization = isGguf
+        ? quantizationFromFileName(fileName)
+        : ModelQuantization.unknown;
 
     return OfflineModelInfo(
       id: 'hf-$slug',
       name: _displayName(slug),
-      family: _familyFromTags(tags),
+      family: _familyFromTags(tags, slug),
       fileSizeBytes: size,
       downloadUrl:
           'https://huggingface.co/$huggingFaceId/resolve/main/$fileName',
+      quantization: quantization,
+      parameterCount: parameterCountFromSlug(slug),
       credibility: authorCredibility(huggingFaceId),
-      provider: AIProvider.custom,
-      description:
-          'Public Hugging Face release from $huggingFaceId. '
-          'Fetched live so new LiteRT/GGUF packages appear without an app update.',
+      provider: isGguf ? AIProvider.gguf : AIProvider.custom,
+      description: isGguf
+          ? 'Public GGUF package from $huggingFaceId '
+                '(${quantization.displayName}, ${license ?? 'license unknown'}). '
+                'Fetched live so new GGUF releases appear without an app update.'
+          : 'Public Hugging Face release from $huggingFaceId. '
+                'Fetched live so new LiteRT/GGUF packages appear without an app update.',
       author: huggingFaceId.split('/').first,
-      license: _licenseFromTags(tags),
+      license: license,
+      licenseState: _licenseStateFromTags(tags),
       huggingFaceId: huggingFaceId,
       modalities: _modalitiesFromTags(tags, pipelineTag),
       capabilities: _capabilitiesFromTags(tags, pipelineTag, libraryName),
-      tags: ['huggingface', 'community-feed', ...tags.take(6)],
-      backendPreference: fileName.endsWith('.gguf')
+      tags: [
+        'huggingface',
+        if (isGguf) 'gguf' else 'community-feed',
+        ...tags.take(6),
+      ],
+      backendPreference: isGguf
           ? ModelBackendPreference.cpu
           : ModelBackendPreference.gpu,
     );
   }
 
-  Future<List<Map<String, dynamic>>> _fetchMainTree(String huggingFaceId) async {
+  Future<List<Map<String, dynamic>>> _fetchMainTree(
+    String huggingFaceId,
+  ) async {
     try {
-      final response = await _dio.get<List<dynamic>>(
+      final entries = await _getJsonList(
         'https://huggingface.co/api/models/$huggingFaceId/tree/main',
       );
-      return response.data
-              ?.whereType<Map<String, dynamic>>()
-              .where((entry) => entry['type'] == 'file')
-              .toList(growable: false) ??
-          const [];
+      return entries
+          .whereType<Map>()
+          .map((entry) => Map<String, dynamic>.from(entry))
+          .where((entry) => entry['type'] == 'file')
+          .toList(growable: false);
     } on DioException {
       return const [];
     }
+  }
+
+  Future<List<dynamic>> _getJsonList(
+    String url, {
+    Map<String, dynamic>? queryParameters,
+  }) async {
+    final response = await _dio.get<List<int>>(
+      url,
+      queryParameters: queryParameters,
+      options: Options(responseType: ResponseType.bytes),
+    );
+    final bytes = Uint8List.fromList(response.data ?? const <int>[]);
+    return decodeCatalogJson(bytes);
+  }
+
+  Future<Map<String, dynamic>?> _getJsonMap(String url) async {
+    final response = await _dio.get<List<int>>(
+      url,
+      options: Options(responseType: ResponseType.bytes),
+    );
+    final bytes = Uint8List.fromList(response.data ?? const <int>[]);
+    if (bytes.isEmpty) return null;
+    final decoded = await decodeCatalogJsonObject(bytes);
+    if (decoded is Map<String, dynamic>) return decoded;
+    if (decoded is Map) return Map<String, dynamic>.from(decoded);
+    return null;
   }
 
   Map<String, dynamic>? _selectArtifact(List<Map<String, dynamic>> tree) {
     for (final suffix in _supportedArtifactSuffixes) {
       for (final entry in tree) {
         final path = entry['path'] as String?;
-        if (path != null && path.endsWith(suffix)) {
+        if (path != null && path.toLowerCase().endsWith(suffix)) {
           return entry;
         }
       }
@@ -134,12 +355,117 @@ class HuggingFaceCatalogService {
     return null;
   }
 
+  /// Prefers mobile-friendly GGUF quants over the first file in the tree.
+  Map<String, dynamic>? _selectGgufArtifact(List<Map<String, dynamic>> tree) {
+    final ggufs = tree
+        .where((entry) {
+          final path = entry['path'] as String?;
+          return path != null && _isPrimaryGguf(path);
+        })
+        .toList(growable: false);
+    if (ggufs.isEmpty) return null;
+
+    int score(Map<String, dynamic> entry) {
+      final path = (entry['path'] as String).toLowerCase();
+      if (path.contains('q4_k_m')) return 0;
+      if (path.contains('q4_k_s')) return 1;
+      if (path.contains('q4_0') || path.contains('q4_1')) return 2;
+      if (RegExp(r'q4[^0-9]').hasMatch(path) || path.contains('-q4')) {
+        return 3;
+      }
+      if (path.contains('q5_k_m')) return 4;
+      if (path.contains('q5')) return 5;
+      if (path.contains('q3')) return 6;
+      if (path.contains('q6') || path.contains('q8')) return 7;
+      return 8;
+    }
+
+    ggufs.sort((a, b) {
+      final byScore = score(a).compareTo(score(b));
+      if (byScore != 0) return byScore;
+      final sizeA = (a['size'] as num?)?.toInt() ?? 1 << 62;
+      final sizeB = (b['size'] as num?)?.toInt() ?? 1 << 62;
+      return sizeA.compareTo(sizeB);
+    });
+    return ggufs.first;
+  }
+
+  static bool _isPrimaryGguf(String path) {
+    final lower = path.toLowerCase();
+    if (!lower.endsWith('.gguf')) return false;
+    if (lower.contains('mmproj')) return false;
+    if (lower.contains('imatrix')) return false;
+    if (lower.contains('ggml-vocab')) return false;
+    return true;
+  }
+
+  /// Authors treated as official vendors / first-party orgs.
+  static const officialAuthors = {
+    'litert-community',
+    'google',
+    'google-bert',
+    'meta-llama',
+    'microsoft',
+    'qwen',
+    'mistralai',
+  };
+
+  /// Authors with a strong track record for GGUF packaging / conversion.
+  static const verifiedAuthors = {
+    'bartowski',
+    'thebloke',
+    'lmstudio-community',
+    'unsloth',
+    'ggerganov',
+    'mlx-community',
+  };
+
+  /// Widely used community orgs (not formally verified packaging).
+  static const popularAuthors = {
+    'nousresearch',
+    'huggingfaceh4',
+    'tiiuae',
+    'openchat',
+  };
+
   static ModelCredibility authorCredibility(String huggingFaceId) {
-    final author = huggingFaceId.split('/').first;
-    if (author == 'litert-community' || author == 'google') {
+    final author = huggingFaceId.split('/').first.toLowerCase();
+    if (officialAuthors.contains(author)) {
       return ModelCredibility.official;
     }
+    if (verifiedAuthors.contains(author)) {
+      return ModelCredibility.verified;
+    }
+    if (popularAuthors.contains(author)) {
+      return ModelCredibility.popular;
+    }
     return ModelCredibility.community;
+  }
+
+  /// Maps a GGUF file name to [ModelQuantization] for model-manager display.
+  static ModelQuantization quantizationFromFileName(String fileName) {
+    final lower = fileName.toLowerCase();
+    if (lower.contains('q2')) return ModelQuantization.q2;
+    if (lower.contains('q3')) return ModelQuantization.q3;
+    if (lower.contains('q4')) return ModelQuantization.q4;
+    if (lower.contains('q5')) return ModelQuantization.q5;
+    if (lower.contains('q6')) return ModelQuantization.q6;
+    if (lower.contains('q8')) return ModelQuantization.q8;
+    if (lower.contains('f16') || lower.contains('fp16')) {
+      return ModelQuantization.fp16;
+    }
+    return ModelQuantization.unknown;
+  }
+
+  /// Best-effort parameter count from repo slugs like `Qwen2.5-0.5B-Instruct`.
+  static int? parameterCountFromSlug(String slug) {
+    final match = RegExp(
+      r'(\d+(?:\.\d+)?)\s*[bB](?:-|_|\.|$)',
+    ).firstMatch(slug.replaceAll('_', '-'));
+    if (match == null) return null;
+    final billions = double.tryParse(match.group(1)!);
+    if (billions == null) return null;
+    return (billions * 1000000000).round();
   }
 
   static String _displayName(String slug) =>
@@ -154,15 +480,34 @@ class HuggingFaceCatalogService {
     return null;
   }
 
-  static ModelFamily _familyFromTags(List<String> tags) {
-    for (final tag in tags) {
-      final lower = tag.toLowerCase();
-      if (lower.contains('gemma')) return ModelFamily.gemma;
-      if (lower.contains('qwen')) return ModelFamily.qwen;
-      if (lower.contains('phi')) return ModelFamily.phi;
-      if (lower.contains('llama')) return ModelFamily.llama;
-      if (lower.contains('mistral')) return ModelFamily.mistral;
+  static ModelLicenseState _licenseStateFromTags(List<String> tags) {
+    final joined = tags.join(' ').toLowerCase();
+    if (joined.contains('gated') ||
+        joined.contains('license:other') ||
+        joined.contains('llama2') ||
+        joined.contains('llama-2') ||
+        joined.contains('llama3') ||
+        joined.contains('llama-3')) {
+      return ModelLicenseState.gated;
     }
+    if (tags.any((tag) => tag.startsWith('license:'))) {
+      return ModelLicenseState.open;
+    }
+    return ModelLicenseState.unknown;
+  }
+
+  static ModelFamily _familyFromTags(List<String> tags, String slug) {
+    final haystack = '${tags.join(' ')} $slug'.toLowerCase();
+    if (haystack.contains('gemma')) return ModelFamily.gemma;
+    if (haystack.contains('qwen')) return ModelFamily.qwen;
+    if (haystack.contains('phi')) return ModelFamily.phi;
+    if (haystack.contains('llama')) return ModelFamily.llama;
+    if (haystack.contains('mistral')) return ModelFamily.mistral;
+    if (haystack.contains('stablelm') || haystack.contains('stable-lm')) {
+      return ModelFamily.stableLM;
+    }
+    if (haystack.contains('falcon')) return ModelFamily.falcon;
+    if (haystack.contains('mpt')) return ModelFamily.mpt;
     return ModelFamily.other;
   }
 
@@ -189,8 +534,7 @@ class HuggingFaceCatalogService {
     String pipelineTag,
     String libraryName,
   ) {
-    final joined =
-        '${tags.join(' ')} $pipelineTag $libraryName'.toLowerCase();
+    final joined = '${tags.join(' ')} $pipelineTag $libraryName'.toLowerCase();
     final capabilities = <ModelCapability>[ModelCapability.chat];
     if (joined.contains('embed')) {
       capabilities
@@ -210,30 +554,112 @@ class HuggingFaceCatalogService {
   }
 }
 
-/// Registers freshly released public Hugging Face repos into [registry].
+/// Registers public Hugging Face repos into [registry], extending the #1769 hub.
 ///
-/// Failures are silent: the bundled catalog still works when offline.
-Future<void> hydratePublicHuggingFaceModels(
+/// Flow:
+/// 1. Register cached metadata immediately when present (offline browse).
+/// 2. Fetch litert-community + GGUF discovery in parallel.
+/// 3. On success, merge into the registry and refresh the disk cache.
+/// 4. On failure with no cache, leave availability as [neverFetched].
+Future<HuggingFaceCatalogHydration> hydratePublicHuggingFaceModels(
   ModelRegistry registry, {
   HuggingFaceCatalogService? service,
+  HuggingFaceCatalogCache? cache,
   String author = 'litert-community',
-  int limit = 50,
+  int organizationLimit = 50,
+  int ggufLimit = 40,
 }) async {
-  final knownIds = {
+  final catalogService = service ?? HuggingFaceCatalogService(cache: cache);
+  final catalogCache = cache ?? catalogService.cache;
+
+  final bundledIds = {
     for (final model in ModelCatalog.bundledModels)
       if (model.huggingFaceId != null) model.huggingFaceId!,
   };
+
+  final cached = await catalogCache.load();
+  final cachedWithoutBundled = cached
+      .where(
+        (model) =>
+            model.huggingFaceId == null ||
+            !bundledIds.contains(model.huggingFaceId),
+      )
+      .toList(growable: false);
+  if (cachedWithoutBundled.isNotEmpty) {
+    registry.registerModels(cachedWithoutBundled);
+  }
+
+  final knownIds = {
+    ...bundledIds,
+    for (final model in cachedWithoutBundled)
+      if (model.huggingFaceId != null) model.huggingFaceId!,
+  };
+
   try {
-    final fetched =
-        await (service ?? HuggingFaceCatalogService()).fetchOrganizationModels(
-          author: author,
-          limit: limit,
-          knownHuggingFaceIds: knownIds,
-        );
+    final results = await Future.wait([
+      catalogService.fetchOrganizationModels(
+        author: author,
+        limit: organizationLimit,
+        knownHuggingFaceIds: knownIds,
+      ),
+      catalogService.fetchGgufModels(
+        limit: ggufLimit,
+        knownHuggingFaceIds: knownIds,
+      ),
+    ]);
+    final fetched = _dedupeById([...results[0], ...results[1]]);
     if (fetched.isNotEmpty) {
       registry.registerModels(fetched);
+      final merged = _dedupeById([...cachedWithoutBundled, ...fetched]);
+      await catalogCache.save(merged);
+      return HuggingFaceCatalogHydration(
+        availability: HuggingFaceCatalogAvailability.online,
+        models: merged,
+      );
     }
-  } on Object {
-    // Offline or API errors must not block the model explorer.
+
+    // Network reached HF but returned nothing new — still "online".
+    if (cachedWithoutBundled.isNotEmpty) {
+      return HuggingFaceCatalogHydration(
+        availability: HuggingFaceCatalogAvailability.online,
+        models: cachedWithoutBundled,
+      );
+    }
+    return const HuggingFaceCatalogHydration(
+      availability: HuggingFaceCatalogAvailability.neverFetched,
+      models: [],
+    );
+  } on Object catch (error) {
+    if (cachedWithoutBundled.isNotEmpty) {
+      return HuggingFaceCatalogHydration(
+        availability: HuggingFaceCatalogAvailability.offlineCached,
+        models: cachedWithoutBundled,
+        errorMessage: error.toString(),
+      );
+    }
+    return HuggingFaceCatalogHydration(
+      availability: HuggingFaceCatalogAvailability.neverFetched,
+      models: const [],
+      errorMessage: error.toString(),
+    );
   }
 }
+
+List<OfflineModelInfo> _dedupeById(List<OfflineModelInfo> models) {
+  final seen = <String>{};
+  final out = <OfflineModelInfo>[];
+  for (final model in models) {
+    if (seen.add(model.id)) {
+      out.add(model);
+    }
+  }
+  return out;
+}
+
+// Keep Isolate-safe JSON helpers reachable for tests that import this library.
+Future<List<dynamic>> decodeHuggingFaceApiJson(Uint8List bytes) =>
+    decodeCatalogJson(bytes);
+
+Future<Uint8List> encodeHuggingFaceCatalogJson(
+  List<Map<String, dynamic>> models,
+) => encodeCatalogJson(models);

--- a/packages/core_ai/module.yaml
+++ b/packages/core_ai/module.yaml
@@ -7,6 +7,7 @@ reviewers:
 allowed_dependencies:
   - core_domain
   - core_native
+  - core_workers
   - platform_downloads
 forbidden_dependencies:
   - app

--- a/packages/core_ai/pubspec.yaml
+++ b/packages/core_ai/pubspec.yaml
@@ -14,6 +14,8 @@ dependencies:
     path: ../core_domain
   core_native:
     path: ../core_native
+  core_workers:
+    path: ../core_workers
   dio: ^5.10.0
   meta: ^1.18.0
   path: 1.9.1

--- a/packages/core_ai/test/huggingface/huggingface_catalog_service_test.dart
+++ b/packages/core_ai/test/huggingface/huggingface_catalog_service_test.dart
@@ -1,69 +1,72 @@
 import 'dart:convert';
+import 'dart:io';
+import 'dart:typed_data';
 
 import 'package:core_ai/core_ai.dart';
 import 'package:dio/dio.dart';
 import 'package:flutter_test/flutter_test.dart';
-
-import 'package:core_ai/src/huggingface/huggingface_catalog_service.dart';
+import 'package:path/path.dart' as p;
 
 void main() {
-  group('HuggingFaceCatalogService', () {
-    test('maps a litert-community repo to OfflineModelInfo', () async {
-      final dio = Dio();
-      dio.interceptors.add(
-        InterceptorsWrapper(
-          onRequest: (options, handler) {
-            final path = options.uri.path;
-            if (path == '/api/models') {
-              handler.resolve(
-                Response(
-                  requestOptions: options,
-                  data: [
-                    {
-                      'id': 'litert-community/Demo-1B',
-                      'tags': [
-                        'litert-lm',
-                        'license:apache-2.0',
-                        'text-generation',
-                      ],
-                      'pipeline_tag': 'text-generation',
-                      'library_name': 'litert-lm',
-                    },
-                  ],
-                ),
-              );
-              return;
-            }
-            if (path == '/api/models/litert-community/Demo-1B/tree/main') {
-              handler.resolve(
-                Response(
-                  requestOptions: options,
-                  data: [
-                    {
-                      'type': 'file',
-                      'path': 'demo-1b.litertlm',
-                      'size': 123456789,
-                    },
-                  ],
-                ),
-              );
-              return;
-            }
+  List<int> jsonBytes(Object data) => utf8.encode(jsonEncode(data));
+
+  Dio mockDio(List<int> Function(RequestOptions options) responder) {
+    final dio = Dio(BaseOptions(responseType: ResponseType.bytes));
+    dio.interceptors.add(
+      InterceptorsWrapper(
+        onRequest: (options, handler) {
+          try {
+            handler.resolve(
+              Response<List<int>>(
+                requestOptions: options,
+                data: responder(options),
+                statusCode: 200,
+              ),
+            );
+          } on Object catch (error) {
             handler.reject(
               DioException(
                 requestOptions: options,
-                response: Response(
-                  requestOptions: options,
-                  statusCode: 404,
-                  data: jsonEncode([]),
-                ),
+                error: error,
+                type: DioExceptionType.badResponse,
               ),
             );
-          },
+          }
+        },
+      ),
+    );
+    return dio;
+  }
+
+  group('HuggingFaceCatalogService', () {
+    test('maps a litert-community repo to OfflineModelInfo', () async {
+      final dio = mockDio((options) {
+        final path = options.uri.path;
+        if (path == '/api/models') {
+          return jsonBytes([
+            {
+              'id': 'litert-community/Demo-1B',
+              'tags': ['litert-lm', 'license:apache-2.0', 'text-generation'],
+              'pipeline_tag': 'text-generation',
+              'library_name': 'litert-lm',
+            },
+          ]);
+        }
+        if (path == '/api/models/litert-community/Demo-1B/tree/main') {
+          return jsonBytes([
+            {'type': 'file', 'path': 'demo-1b.litertlm', 'size': 123456789},
+          ]);
+        }
+        throw StateError('unexpected ${options.uri}');
+      });
+
+      final service = HuggingFaceCatalogService(
+        dio: dio,
+        cache: HuggingFaceCatalogCache(
+          resolveRoot: () => Directory.systemTemp,
+          fileName: 'unused-litert.json',
         ),
       );
-
-      final service = HuggingFaceCatalogService(dio: dio);
       final models = await service.fetchOrganizationModels(limit: 1);
 
       expect(models, hasLength(1));
@@ -76,27 +79,18 @@ void main() {
         'https://huggingface.co/litert-community/Demo-1B/resolve/main/demo-1b.litertlm',
       );
       expect(model.credibility, ModelCredibility.official);
+      expect(model.license, 'apache-2.0');
     });
 
     test('skips repos already in the bundled catalog', () async {
       final bundled = ModelCatalog.bundledModels.firstWhere(
         (m) => m.huggingFaceId != null,
       );
-      final dio = Dio();
-      dio.interceptors.add(
-        InterceptorsWrapper(
-          onRequest: (options, handler) {
-            handler.resolve(
-              Response(
-                requestOptions: options,
-                data: [
-                  {'id': bundled.huggingFaceId},
-                ],
-              ),
-            );
-          },
-        ),
-      );
+      final dio = mockDio((options) {
+        return jsonBytes([
+          {'id': bundled.huggingFaceId},
+        ]);
+      });
 
       final service = HuggingFaceCatalogService(dio: dio);
       final models = await service.fetchOrganizationModels(
@@ -104,6 +98,349 @@ void main() {
       );
 
       expect(models, isEmpty);
+    });
+
+    test(
+      'fetchGgufModels filters gguf, prefers Q4, maps bartowski credibility',
+      () async {
+        final dio = mockDio((options) {
+          final path = options.uri.path;
+          if (path == '/api/models') {
+            expect(options.queryParameters['filter'], 'gguf');
+            expect(options.queryParameters['sort'], 'downloads');
+            return jsonBytes([
+              {
+                'id': 'bartowski/Tiny-Qwen-GGUF',
+                'tags': ['gguf', 'license:apache-2.0', 'qwen'],
+                'pipeline_tag': 'text-generation',
+                'library_name': 'gguf',
+              },
+            ]);
+          }
+          if (path == '/api/models/bartowski/Tiny-Qwen-GGUF/tree/main') {
+            return jsonBytes([
+              {
+                'type': 'file',
+                'path': 'Tiny-Qwen-Q8_0.gguf',
+                'size': 900000000,
+              },
+              {
+                'type': 'file',
+                'path': 'Tiny-Qwen-Q4_K_M.gguf',
+                'size': 400000000,
+              },
+              {'type': 'file', 'path': 'Tiny-Qwen.mmproj.gguf', 'size': 1000},
+            ]);
+          }
+          throw StateError('unexpected ${options.uri}');
+        });
+
+        final service = HuggingFaceCatalogService(dio: dio);
+        final models = await service.fetchGgufModels(limit: 5);
+
+        expect(models, hasLength(1));
+        final model = models.single;
+        expect(model.huggingFaceId, 'bartowski/Tiny-Qwen-GGUF');
+        expect(model.credibility, ModelCredibility.verified);
+        expect(model.quantization, ModelQuantization.q4);
+        expect(model.provider, AIProvider.gguf);
+        expect(model.tags, contains('gguf'));
+        expect(model.downloadUrl, contains('Tiny-Qwen-Q4_K_M.gguf'));
+        expect(model.description, contains('Q4'));
+        expect(model.description, contains('apache-2.0'));
+      },
+    );
+
+    test('fetchGgufModels applies author filter query param', () async {
+      var sawAuthor = false;
+      final dio = mockDio((options) {
+        if (options.uri.path == '/api/models') {
+          expect(options.queryParameters['author'], 'bartowski');
+          expect(options.queryParameters['filter'], 'gguf');
+          sawAuthor = true;
+          return jsonBytes(const []);
+        }
+        throw StateError('unexpected ${options.uri}');
+      });
+
+      final service = HuggingFaceCatalogService(dio: dio);
+      await service.fetchGgufModels(authors: const ['bartowski'], limit: 3);
+      expect(sawAuthor, isTrue);
+    });
+
+    test('resolveFromRepoUrl parses URL and builds OfflineModelInfo', () async {
+      final dio = mockDio((options) {
+        final path = options.uri.path;
+        if (path == '/api/models/bartowski/Demo-GGUF') {
+          return jsonBytes({
+            'id': 'bartowski/Demo-GGUF',
+            'tags': ['gguf', 'license:mit'],
+            'pipeline_tag': 'text-generation',
+          });
+        }
+        if (path == '/api/models/bartowski/Demo-GGUF/tree/main') {
+          return jsonBytes([
+            {'type': 'file', 'path': 'demo-q5_k_m.gguf', 'size': 555000000},
+          ]);
+        }
+        throw StateError('unexpected ${options.uri}');
+      });
+
+      final service = HuggingFaceCatalogService(dio: dio);
+      final model = await service.resolveFromRepoUrl(
+        'https://huggingface.co/bartowski/Demo-GGUF/tree/main',
+      );
+
+      expect(model, isNotNull);
+      expect(model!.huggingFaceId, 'bartowski/Demo-GGUF');
+      expect(model.quantization, ModelQuantization.q5);
+      expect(model.provider, AIProvider.gguf);
+    });
+
+    test('parseHuggingFaceRepoId accepts URL and bare id', () {
+      expect(
+        HuggingFaceCatalogService.parseHuggingFaceRepoId(
+          'https://huggingface.co/org/model',
+        ),
+        'org/model',
+      );
+      expect(
+        HuggingFaceCatalogService.parseHuggingFaceRepoId('org/model'),
+        'org/model',
+      );
+      expect(
+        HuggingFaceCatalogService.parseHuggingFaceRepoId('not a repo'),
+        isNull,
+      );
+    });
+
+    test('authorCredibility maps known authors', () {
+      expect(
+        HuggingFaceCatalogService.authorCredibility('litert-community/x'),
+        ModelCredibility.official,
+      );
+      expect(
+        HuggingFaceCatalogService.authorCredibility('bartowski/x'),
+        ModelCredibility.verified,
+      );
+      expect(
+        HuggingFaceCatalogService.authorCredibility('TheBloke/x'),
+        ModelCredibility.verified,
+      );
+      expect(
+        HuggingFaceCatalogService.authorCredibility('random-user/x'),
+        ModelCredibility.community,
+      );
+    });
+  });
+
+  group('HuggingFaceCatalogCache', () {
+    test('file cache survives a second instance (restart)', () async {
+      final temp = await Directory.systemTemp.createTemp('hf_catalog_cache_');
+      addTearDown(() async {
+        if (await temp.exists()) await temp.delete(recursive: true);
+      });
+
+      final cacheA = HuggingFaceCatalogCache(resolveRoot: () => temp);
+      final sample = OfflineModelInfo(
+        id: 'hf-cached',
+        name: 'Cached',
+        family: ModelFamily.other,
+        fileSizeBytes: 42,
+        downloadUrl: 'https://example.com/model.gguf',
+        huggingFaceId: 'org/cached',
+        credibility: ModelCredibility.community,
+        provider: AIProvider.gguf,
+        tags: const ['huggingface', 'gguf'],
+      );
+      await cacheA.save([sample]);
+
+      final cacheB = HuggingFaceCatalogCache(resolveRoot: () => temp);
+      final restored = await cacheB.load();
+      expect(restored, hasLength(1));
+      expect(restored.single.huggingFaceId, 'org/cached');
+      expect(
+        await File(
+          p.join(temp.path, 'model_catalog', 'hf_catalog_metadata.json'),
+        ).exists(),
+        isTrue,
+      );
+      expect(await cacheB.hasCachedEntries(), isTrue);
+    });
+  });
+
+  group('hydratePublicHuggingFaceModels', () {
+    test('registers cache when network fails and skips bundled ids', () async {
+      final bundled = ModelCatalog.bundledModels.firstWhere(
+        (m) => m.huggingFaceId != null,
+      );
+      final temp = await Directory.systemTemp.createTemp('hf_hydrate_offline_');
+      addTearDown(() async {
+        if (await temp.exists()) await temp.delete(recursive: true);
+      });
+      final cache = HuggingFaceCatalogCache(resolveRoot: () => temp);
+      await cache.save([
+        OfflineModelInfo(
+          id: 'hf-bundled-dup',
+          name: 'Dup',
+          family: ModelFamily.other,
+          fileSizeBytes: 1,
+          huggingFaceId: bundled.huggingFaceId,
+          credibility: ModelCredibility.community,
+        ),
+        OfflineModelInfo(
+          id: 'hf-offline-only',
+          name: 'Offline Only',
+          family: ModelFamily.qwen,
+          fileSizeBytes: 99,
+          huggingFaceId: 'bartowski/offline-only',
+          credibility: ModelCredibility.verified,
+          provider: AIProvider.gguf,
+          tags: const ['gguf'],
+        ),
+      ]);
+
+      final dio = Dio(BaseOptions(responseType: ResponseType.bytes));
+      dio.interceptors.add(
+        InterceptorsWrapper(
+          onRequest: (options, handler) {
+            handler.reject(
+              DioException(
+                requestOptions: options,
+                type: DioExceptionType.connectionError,
+                error: 'offline',
+              ),
+            );
+          },
+        ),
+      );
+
+      final registry = ModelRegistry();
+      registry.registerModels(ModelCatalog.bundledModels);
+
+      final hydration = await hydratePublicHuggingFaceModels(
+        registry,
+        service: HuggingFaceCatalogService(dio: dio, cache: cache),
+        cache: cache,
+      );
+
+      expect(
+        hydration.availability,
+        HuggingFaceCatalogAvailability.offlineCached,
+      );
+      expect(registry.getModel('hf-offline-only'), isNotNull);
+      expect(registry.getModel('hf-bundled-dup'), isNull);
+    });
+
+    test('writes merged live feed to cache', () async {
+      final temp = await Directory.systemTemp.createTemp('hf_hydrate_online_');
+      addTearDown(() async {
+        if (await temp.exists()) await temp.delete(recursive: true);
+      });
+      final cache = HuggingFaceCatalogCache(resolveRoot: () => temp);
+
+      final dio = mockDio((options) {
+        final path = options.uri.path;
+        final filter = options.queryParameters['filter'];
+        if (path == '/api/models' && filter == 'gguf') {
+          return jsonBytes([
+            {
+              'id': 'bartowski/Live-GGUF',
+              'tags': ['gguf', 'license:apache-2.0'],
+            },
+          ]);
+        }
+        if (path == '/api/models') {
+          return jsonBytes([
+            {
+              'id': 'litert-community/Live-LiteRT',
+              'tags': ['litert-lm', 'license:apache-2.0'],
+            },
+          ]);
+        }
+        if (path.endsWith('/tree/main')) {
+          final isGguf = path.contains('Live-GGUF');
+          return jsonBytes([
+            {
+              'type': 'file',
+              'path': isGguf ? 'model-Q4_K_M.gguf' : 'model.litertlm',
+              'size': isGguf ? 111 : 222,
+            },
+          ]);
+        }
+        throw StateError('unexpected ${options.uri}');
+      });
+
+      final registry = ModelRegistry();
+      final hydration = await hydratePublicHuggingFaceModels(
+        registry,
+        service: HuggingFaceCatalogService(dio: dio, cache: cache),
+        cache: cache,
+        organizationLimit: 5,
+        ggufLimit: 5,
+      );
+
+      expect(hydration.availability, HuggingFaceCatalogAvailability.online);
+      final cached = await cache.load();
+      expect(cached.length, greaterThanOrEqualTo(2));
+      expect(
+        cached.any((m) => m.huggingFaceId == 'bartowski/Live-GGUF'),
+        isTrue,
+      );
+      expect(
+        cached.any((m) => m.huggingFaceId == 'litert-community/Live-LiteRT'),
+        isTrue,
+      );
+      expect(registry.getModel('hf-Live-GGUF'), isNotNull);
+      expect(registry.getModel('hf-Live-LiteRT'), isNotNull);
+    });
+
+    test('neverFetched when offline with empty cache', () async {
+      final temp = await Directory.systemTemp.createTemp('hf_hydrate_empty_');
+      addTearDown(() async {
+        if (await temp.exists()) await temp.delete(recursive: true);
+      });
+      final cache = HuggingFaceCatalogCache(resolveRoot: () => temp);
+      final dio = Dio(BaseOptions(responseType: ResponseType.bytes));
+      dio.interceptors.add(
+        InterceptorsWrapper(
+          onRequest: (options, handler) {
+            handler.reject(
+              DioException(
+                requestOptions: options,
+                type: DioExceptionType.connectionError,
+              ),
+            );
+          },
+        ),
+      );
+
+      final hydration = await hydratePublicHuggingFaceModels(
+        ModelRegistry(),
+        service: HuggingFaceCatalogService(dio: dio, cache: cache),
+        cache: cache,
+      );
+      expect(
+        hydration.availability,
+        HuggingFaceCatalogAvailability.neverFetched,
+      );
+      expect(hydration.models, isEmpty);
+    });
+  });
+
+  group('catalog JSON off-main helpers', () {
+    test('decodeCatalogJson handles payloads over 50KB', () async {
+      final entries = List.generate(
+        1200,
+        (i) => {
+          'id': 'org/model-$i-with-extra-padding-for-size',
+          'tags': ['gguf', 'license:mit', 'text-generation', 'qwen'],
+        },
+      );
+      final bytes = Uint8List.fromList(utf8.encode(jsonEncode(entries)));
+      expect(bytes.lengthInBytes, greaterThan(50 * 1024));
+      final decoded = await decodeCatalogJson(bytes);
+      expect(decoded, hasLength(1200));
     });
   });
 }


### PR DESCRIPTION
## Summary
- Extends the #1769 Hugging Face Models/catalog hub with public **GGUF discovery** (`filter=gguf`, sort by downloads, optional author filters, Q4_K_M preference, license/size/quant metadata).
- Adds **offline disk cache** of previously fetched catalog metadata (app support); clear never-fetched vs offline-cached UX banners.
- Optional paste HF repo URL / bare `org/repo` → resolve tree → `OfflineModelInfo` (no auto-download).
- Credibility mapping for known authors (`litert-community`, `bartowski`, `TheBloke`, etc.).
- Skips `ModelCatalog.bundledModels` Hugging Face ids so the registry does not duplicate curated rows.
- Large catalog JSON parse/encode via `runOffMain` / `core_workers` when >50KB.

## Test plan
- [x] `cd packages/core_ai && flutter test test/huggingface/huggingface_catalog_service_test.dart` (12/12)
- [x] `dart analyze` on `packages/core_ai` huggingface sources
- [ ] Device: Models → Browse catalog online → airplane mode → previously seen HF rows still listed
- [ ] Device: fresh install offline → never-fetched banner, no invented HF rows
- [ ] Device: paste a public GGUF repo URL → catalog row appears; download only on user tap

Closes #1773
Part of #1770
References offline-llm-09 Hugging Face integration (see #1769).