### PR TITLE
feat(mind): chunked EmbeddingGemma semantic meeting search (#508)

### DIFF
--- a/app/android/app/src/withEmbedding/kotlin/io/airo/app/EmbeddingPlugin.kt
+++ b/app/android/app/src/withEmbedding/kotlin/io/airo/app/EmbeddingPlugin.kt
@@ -28,13 +28,11 @@ import java.util.Optional
  * against the real `com.google.ai.edge.localagents:localagents-rag:0.1.0`
  * AAR (`javap` on its decompiled `classes.jar`, on a Pixel 9 build attempt)
  * -- the first version of this file guessed `computeEmbeddings(text)`,
- * which failed `compileDebugKotlin` with "Unresolved reference." `TaskType`
- * is `SEMANTIC_SIMILARITY` for every call: the SDK also offers
- * `RETRIEVAL_QUERY`/`RETRIEVAL_DOCUMENT` for asymmetric query-vs-document
- * encoding, which would improve search quality, but this plugin's
- * `embed(text)` channel method doesn't yet distinguish a query from a
- * document -- that's a real refinement for whoever builds
- * `SemanticSearchRanker` (Phase 3), not invented here.
+ * which failed `compileDebugKotlin` with "Unresolved reference."
+ *
+ * `taskType` on the channel maps to Gecko's `EmbedData.TaskType` by the
+ * same wire names Dart sends (`RETRIEVAL_QUERY`, `RETRIEVAL_DOCUMENT`,
+ * `SEMANTIC_SIMILARITY`).
  */
 class EmbeddingPlugin(private val context: Context) : MethodChannel.MethodCallHandler {
     companion object {
@@ -84,12 +82,13 @@ class EmbeddingPlugin(private val context: Context) : MethodChannel.MethodCallHa
             try {
                 val text = call.argument<String>("text")
                     ?: throw IllegalArgumentException("text is required")
+                val taskType = taskTypeFromWire(call.argument<String>("taskType"))
 
                 val vector = withContext(Dispatchers.IO) {
                     val activeEmbedder = embedder
                         ?: throw IllegalStateException("Embedding model is not initialized")
                     val request = EmbeddingRequest.create(
-                        listOf(EmbedData.create(text, EmbedData.TaskType.SEMANTIC_SIMILARITY)),
+                        listOf(EmbedData.create(text, taskType)),
                     )
                     activeEmbedder.getEmbeddings(request).get()
                 }
@@ -100,5 +99,11 @@ class EmbeddingPlugin(private val context: Context) : MethodChannel.MethodCallHa
                 result.error("EMBEDDING_FAILED", e.message, null)
             }
         }
+    }
+
+    private fun taskTypeFromWire(wire: String?): EmbedData.TaskType = when (wire) {
+        "RETRIEVAL_QUERY", "retrievalQuery" -> EmbedData.TaskType.RETRIEVAL_QUERY
+        "RETRIEVAL_DOCUMENT", "retrievalDocument" -> EmbedData.TaskType.RETRIEVAL_DOCUMENT
+        else -> EmbedData.TaskType.SEMANTIC_SIMILARITY
     }
 }

--- a/app/lib/features/settings/application/ai_model_management.dart
+++ b/app/lib/features/settings/application/ai_model_management.dart
@@ -167,6 +167,12 @@ class ActiveDownloadsNotifier
   void startDownload(OfflineModelInfo model) {
     final service = _ref.read(modelDownloadServiceProvider);
     service.downloadModel(model);
+    // EmbeddingGemma needs its SentencePiece tokenizer beside the .tflite;
+    // queue companions so semantic search is usable after one tap
+    // (`docs/superpowers/specs/2026-08-09-mind-scribe-semantic-search.md`).
+    for (final companion in ModelCatalog.companionsFor(model)) {
+      service.downloadModel(companion);
+    }
   }
 
   Future<void> pauseDownload(String modelId) {

--- a/packages/core_ai/lib/src/embeddings/embedding_client.dart
+++ b/packages/core_ai/lib/src/embeddings/embedding_client.dart
@@ -3,6 +3,28 @@ import 'dart:async';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 
+/// How the native embedder should treat [EmbeddingClient.embed]'s text.
+///
+/// Maps to Google's AI Edge RAG SDK `EmbedData.TaskType`. Query vs document
+/// asymmetry improves retrieval quality over always using semantic
+/// similarity — the plugin originally always used `SEMANTIC_SIMILARITY`
+/// and flagged this as a follow-up for `SemanticSearchRanker`.
+enum EmbeddingTaskType {
+  /// Short search query text.
+  retrievalQuery('retrievalQuery'),
+
+  /// Meeting chunk / document text being indexed.
+  retrievalDocument('retrievalDocument'),
+
+  /// Symmetric similarity (legacy default).
+  semanticSimilarity('semanticSimilarity');
+
+  const EmbeddingTaskType(this.wireName);
+
+  /// Value sent across the method channel / understood by Kotlin.
+  final String wireName;
+}
+
 /// Loads an on-device text embedding model and turns text into vectors.
 ///
 /// Backed by a **separate** native plugin from `LiteRtLmClient`'s
@@ -29,7 +51,10 @@ abstract class EmbeddingClient {
   /// succeeded — callers that want a non-throwing "is this available" check
   /// should call [isReady] first (mirrors `EmbeddingService`'s contract,
   /// which is where that check actually lives for real callers).
-  Future<List<double>> embed({required String text});
+  Future<List<double>> embed({
+    required String text,
+    EmbeddingTaskType taskType = EmbeddingTaskType.semanticSimilarity,
+  });
 }
 
 /// Channel name is distinct from `com.airo.litert_lm`: a different plugin,
@@ -80,9 +105,15 @@ class MethodChannelEmbeddingClient implements EmbeddingClient {
   }
 
   @override
-  Future<List<double>> embed({required String text}) async {
+  Future<List<double>> embed({
+    required String text,
+    EmbeddingTaskType taskType = EmbeddingTaskType.semanticSimilarity,
+  }) async {
     final result = await _channel
-        .invokeMethod<List<Object?>>('embed', {'text': text})
+        .invokeMethod<List<Object?>>('embed', {
+          'text': text,
+          'taskType': taskType.wireName,
+        })
         .timeout(operationTimeout);
     if (result == null) {
       throw StateError('Embedding plugin returned no vector for "$text"');

--- a/packages/core_ai/lib/src/embeddings/embedding_service.dart
+++ b/packages/core_ai/lib/src/embeddings/embedding_service.dart
@@ -80,7 +80,14 @@ class EmbeddingService {
   /// Never throws: an expected "nothing installed yet" state and an
   /// unexpected native failure are both a typed [EmbeddingResult], not an
   /// exception a caller must remember to catch.
-  Future<EmbeddingResult> embed(String text) async {
+  ///
+  /// [taskType] selects query vs document encoding when the native plugin
+  /// supports it — defaults to symmetric similarity for callers that do not
+  /// care.
+  Future<EmbeddingResult> embed(
+    String text, {
+    EmbeddingTaskType taskType = EmbeddingTaskType.semanticSimilarity,
+  }) async {
     final installed = <OfflineModelInfo>[];
     for (final candidate in _catalog) {
       // Skip capability-less entries (the tokenizer) before ever asking the
@@ -128,7 +135,7 @@ class EmbeddingService {
         _initialized = true;
       }
 
-      final vector = await _client.embed(text: text);
+      final vector = await _client.embed(text: text, taskType: taskType);
       return EmbeddingResult.ready(vector, resolved.id);
     } on Object catch (e) {
       return EmbeddingResult.unavailable(

--- a/packages/core_ai/lib/src/registry/model_catalog.dart
+++ b/packages/core_ai/lib/src/registry/model_catalog.dart
@@ -398,6 +398,27 @@ class ModelCatalog {
           .where((model) => model.modalities.contains(modality))
           .toList();
 
+  /// Companion artifacts that must be downloaded with [model].
+  ///
+  /// EmbeddingGemma's tokenizer is a separate catalog entry with empty
+  /// capabilities (so it never resolves `AiTask.embeddings`) but tags that
+  /// name the embed model id. Downloading the embed weights without the
+  /// tokenizer leaves `EmbeddingService` unable to initialize — so the
+  /// model-library download path queues companions automatically.
+  static List<OfflineModelInfo> companionsFor(OfflineModelInfo model) {
+    if (!model.capabilities.contains(ModelCapability.embeddings)) {
+      return const [];
+    }
+    return bundledModels
+        .where(
+          (candidate) =>
+              candidate.id != model.id &&
+              candidate.tags.contains('tokenizer') &&
+              candidate.tags.contains(model.id),
+        )
+        .toList(growable: false);
+  }
+
   /// Gets models by family.
   static List<OfflineModelInfo> byFamily(ModelFamily family) =>
       bundledModels.where((m) => m.family == family).toList();

--- a/packages/core_ai/test/embeddings/embedding_client_test.dart
+++ b/packages/core_ai/test/embeddings/embedding_client_test.dart
@@ -37,7 +37,10 @@ void main() {
     test('embed converts the native vector to a List<double>', () async {
       messenger.setMockMethodCallHandler(channel, (call) async {
         expect(call.method, 'embed');
-        expect(call.arguments, {'text': 'hello'});
+        expect(call.arguments, {
+          'text': 'hello',
+          'taskType': 'semanticSimilarity',
+        });
         return [0.1, 0.2, 0.3];
       });
 
@@ -45,6 +48,33 @@ void main() {
       final vector = await client.embed(text: 'hello');
 
       expect(vector, [0.1, 0.2, 0.3]);
+    });
+
+    test('embed forwards retrievalQuery / retrievalDocument task types', () async {
+      MethodCall? captured;
+      messenger.setMockMethodCallHandler(channel, (call) async {
+        captured = call;
+        return [0.0];
+      });
+
+      final client = MethodChannelEmbeddingClient(channel: channel);
+      await client.embed(
+        text: 'query',
+        taskType: EmbeddingTaskType.retrievalQuery,
+      );
+      expect(captured?.arguments, {
+        'text': 'query',
+        'taskType': 'retrievalQuery',
+      });
+
+      await client.embed(
+        text: 'doc',
+        taskType: EmbeddingTaskType.retrievalDocument,
+      );
+      expect(captured?.arguments, {
+        'text': 'doc',
+        'taskType': 'retrievalDocument',
+      });
     });
 
     test('embed throws when the native side returns nothing', () async {

--- a/packages/core_ai/test/embeddings/embedding_service_test.dart
+++ b/packages/core_ai/test/embeddings/embedding_service_test.dart
@@ -119,6 +119,27 @@ void main() {
       expect(client.embedCalls, 2);
     });
 
+    test('forwards EmbeddingTaskType to the client', () async {
+      final client = _FakeEmbeddingClient();
+      final service = EmbeddingService(
+        client: client,
+        downloadService: _FakeModelDownloadService(
+          downloaded: {
+            'embed-model': '/models/embed-model.tflite',
+            'tokenizer-model': '/models/sentencepiece.model',
+          },
+        ),
+        catalog: [embedModel, tokenizerModel],
+      );
+
+      await service.embed(
+        'hello',
+        taskType: EmbeddingTaskType.retrievalQuery,
+      );
+
+      expect(client.lastTaskType, EmbeddingTaskType.retrievalQuery);
+    });
+
     test(
       'reports modelFailed, not an exception, when the client throws',
       () async {
@@ -168,11 +189,17 @@ class _FakeEmbeddingClient implements EmbeddingClient {
   Future<bool> isReady() async => initializeCalls > 0;
 
   @override
-  Future<List<double>> embed({required String text}) async {
+  Future<List<double>> embed({
+    required String text,
+    EmbeddingTaskType taskType = EmbeddingTaskType.semanticSimilarity,
+  }) async {
     embedCalls++;
+    lastTaskType = taskType;
     if (embedError != null) throw embedError!;
     return vector;
   }
+
+  EmbeddingTaskType? lastTaskType;
 }
 
 class _FakeModelDownloadService extends ModelDownloadService {

--- a/packages/core_ai/test/registry/model_catalog_test.dart
+++ b/packages/core_ai/test/registry/model_catalog_test.dart
@@ -124,5 +124,16 @@ void main() {
         );
       }
     });
+
+    test('companionsFor queues the tokenizer with the embed model', () {
+      final embed = ModelCatalog.bundledModels.firstWhere(
+        (m) => m.id == 'embeddinggemma-300m-embed',
+      );
+
+      final companions = ModelCatalog.companionsFor(embed);
+
+      expect(companions.map((m) => m.id), ['embeddinggemma-300m-tokenizer']);
+      expect(ModelCatalog.companionsFor(companions.single), isEmpty);
+    });
   });
 }

--- a/packages/feature_mind/lib/feature_mind.dart
+++ b/packages/feature_mind/lib/feature_mind.dart
@@ -30,11 +30,12 @@ export 'src/mind_service.dart'
 // exactly one speech engine and no TTS engine to choose between.
 export 'src/speech_task_availability.dart';
 
-// Phase 2 of the Mind scribe semantic search plan
-// (`tasks/mind-scribe-semantic-search-plan.md`): persists one embedding
-// vector per meeting. Not yet wired to a real caller -- that's Phase 3's
-// SemanticSearchRanker.
+// Scribe semantic search (#508): store + ranker. MindService.search() is the
+// product call site; indexMeetingForSearch / SemanticSearchRanker.indexMeeting
+// are the Wave 2 Agent G seams for chat-over-meetings.
 export 'src/search/meeting_embedding_store.dart';
+export 'src/search/meeting_text_chunker.dart';
+export 'src/search/semantic_search_ranker.dart';
 
 // Module contract + host seam + routes — the assistant hub, merged in from
 // `feature_assistant` (`docs/superpowers/plans/2026-08-07-airo-mind-ssot-plan.md`,

--- a/packages/feature_mind/lib/src/mind_service.dart
+++ b/packages/feature_mind/lib/src/mind_service.dart
@@ -451,11 +451,36 @@ class MindService {
     final keywordHits = await _speech.search(query);
     _ranker ??= _rankerBuilder(await modelsDirectory());
     final allMeetings = await _speech.meetings();
+    final segmentTextsByMeetingId = <String, List<String>>{};
+    for (final meeting in allMeetings) {
+      final doc = await _speech.getTranscript(meeting.id);
+      if (doc == null || doc.segments.isEmpty) continue;
+      segmentTextsByMeetingId[meeting.id] = [
+        for (final segment in doc.segments) segment.text,
+      ];
+    }
     return _ranker!.rank(
       query: query,
       keywordHits: keywordHits,
       meetings: allMeetings,
+      segmentTextsByMeetingId: segmentTextsByMeetingId,
     );
+  }
+
+  /// Indexes [meeting] for EmbeddingGemma semantic search.
+  ///
+  /// **Agent G seam** (`#1770` Wave 2 chat-over-meetings): call after a
+  /// meeting is saved/processed, or from a chat tool that needs the archive
+  /// already embedded. [search] still indexes lazily when a meeting was
+  /// never passed here. Returns `false` when no embedding model is
+  /// installed — keyword search continues to work.
+  Future<bool> indexMeetingForSearch(rust.MeetingRecord meeting) async {
+    _ranker ??= _rankerBuilder(await modelsDirectory());
+    final doc = await _speech.getTranscript(meeting.id);
+    final segmentTexts = doc == null
+        ? const <String>[]
+        : [for (final segment in doc.segments) segment.text];
+    return _ranker!.indexMeeting(meeting, segmentTexts: segmentTexts);
   }
 
   Future<rust.MeetingRecord?> meeting(String id) => _speech.meeting(id);

--- a/packages/feature_mind/lib/src/search/meeting_embedding_store.dart
+++ b/packages/feature_mind/lib/src/search/meeting_embedding_store.dart
@@ -1,26 +1,37 @@
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:core_workers/core_workers.dart';
 import 'package:flutter/foundation.dart';
 import 'package:path/path.dart' as p;
 
-/// A meeting's embedding vector, and which model produced it.
+/// A meeting's embedding vector(s), and which model produced them.
 ///
-/// Storing the model id alongside the vector mirrors `MeetingRecord.model`
+/// Storing the model id alongside the vectors mirrors `MeetingRecord.model`
 /// (`ADR-0018 §5`): what produced a piece of derived content is recorded,
 /// not inferred later. If the embedding model changes, a caller compares
-/// [modelId] against the currently-resolved model and knows this vector is
-/// stale — [MeetingEmbeddingStore] itself does not judge staleness, it only
-/// reports what is on disk.
+/// [modelId] against the currently-resolved model and knows these vectors
+/// are stale — [MeetingEmbeddingStore] itself does not judge staleness, it
+/// only reports what is on disk.
+///
+/// [vectors] is one entry per text chunk (see `MeetingTextChunker`). A
+/// single-element list is the common short-meeting case and also the shape
+/// read back from stores written before chunking landed.
 @immutable
 class StoredEmbedding {
-  const StoredEmbedding({required this.modelId, required this.vector});
+  const StoredEmbedding({required this.modelId, required this.vectors})
+    : assert(vectors.length > 0);
 
   final String modelId;
-  final List<double> vector;
+
+  /// One embedding per chunk, in chunk order. Never empty.
+  final List<List<double>> vectors;
+
+  /// Convenience for the single-vector / legacy shape.
+  List<double> get vector => vectors.first;
 }
 
-/// Persists one embedding vector per meeting, keyed by meeting id.
+/// Persists embedding vectors per meeting, keyed by meeting id.
 ///
 /// A flat JSON file, not a database: meeting counts for a personal scribe
 /// are expected in the hundreds, and `feature_mind` has no Drift/sqflite
@@ -32,22 +43,49 @@ class StoredEmbedding {
 /// for models and the meeting store, rather than inventing a second
 /// location — the caller passes that `Directory` in, this class does not
 /// resolve it itself.
+///
+/// JSON decode/encode over ~50 KB runs via [runOffMain] — each 768-d vector
+/// is already ~10 KB of JSON, so a modest archive crosses the repo's
+/// main-isolate parsing rule quickly.
 class MeetingEmbeddingStore {
   MeetingEmbeddingStore(this._dir);
 
   final Directory _dir;
 
+  static const _offMainBytes = 50 * 1024;
+
   File get _file => File(p.join(_dir.path, 'meeting_embeddings.json'));
 
-  /// Stores [vector] for [meetingId], produced by [modelId]. Overwrites
-  /// whatever was stored for that meeting before.
+  /// Stores a single [vector] for [meetingId], produced by [modelId].
+  /// Overwrites whatever was stored for that meeting before.
   Future<void> put(
     String meetingId,
     String modelId,
     List<double> vector,
+  ) => putChunks(meetingId, modelId, [vector]);
+
+  /// Stores one vector per chunk for [meetingId]. [chunkVectors] must be
+  /// non-empty — call [remove] to clear instead of writing an empty list.
+  Future<void> putChunks(
+    String meetingId,
+    String modelId,
+    List<List<double>> chunkVectors,
   ) async {
+    if (chunkVectors.isEmpty) {
+      throw ArgumentError.value(
+        chunkVectors,
+        'chunkVectors',
+        'Use remove() to clear; an empty chunk list is not a valid store write.',
+      );
+    }
     final data = await _readAll();
-    data[meetingId] = {'modelId': modelId, 'vector': vector};
+    data[meetingId] = {
+      'modelId': modelId,
+      'vectors': chunkVectors,
+      // Legacy single-vector field kept so older readers (and hand-inspected
+      // JSON) still see a useful primary vector.
+      'vector': chunkVectors.first,
+    };
     await _writeAll(data);
   }
 
@@ -88,11 +126,24 @@ class MeetingEmbeddingStore {
   StoredEmbedding? _decode(Object? raw) {
     if (raw is! Map) return null;
     final modelId = raw['modelId'];
+    if (modelId is! String) return null;
+
+    final vectorsRaw = raw['vectors'];
+    if (vectorsRaw is List && vectorsRaw.isNotEmpty) {
+      final vectors = <List<double>>[];
+      for (final item in vectorsRaw) {
+        if (item is! List) return null;
+        vectors.add(item.cast<num>().map((v) => v.toDouble()).toList());
+      }
+      return StoredEmbedding(modelId: modelId, vectors: vectors);
+    }
+
+    // Pre-chunking schema: a single `vector` field.
     final vector = raw['vector'];
-    if (modelId is! String || vector is! List) return null;
+    if (vector is! List) return null;
     return StoredEmbedding(
       modelId: modelId,
-      vector: vector.cast<num>().map((v) => v.toDouble()).toList(),
+      vectors: [vector.cast<num>().map((v) => v.toDouble()).toList()],
     );
   }
 
@@ -101,7 +152,9 @@ class MeetingEmbeddingStore {
     final content = await _file.readAsString();
     if (content.trim().isEmpty) return {};
     try {
-      final decoded = jsonDecode(content);
+      final decoded = content.length > _offMainBytes
+          ? await runOffMain(() => jsonDecode(content))
+          : jsonDecode(content);
       return decoded is Map<String, dynamic> ? decoded : {};
     } on FormatException {
       // A corrupt file degrades to "nothing stored yet," the same as a
@@ -113,6 +166,33 @@ class MeetingEmbeddingStore {
 
   Future<void> _writeAll(Map<String, dynamic> data) async {
     if (!await _dir.exists()) await _dir.create(recursive: true);
-    await _file.writeAsString(jsonEncode(data));
+    final encoded = _estimateEncodedBytes(data) > _offMainBytes
+        ? await runOffMain(() => jsonEncode(data))
+        : jsonEncode(data);
+    await _file.writeAsString(encoded);
+  }
+
+  /// Rough JSON size before encoding: each float ~12 chars plus key overhead.
+  /// Prefer overshooting into [runOffMain] over decoding hundreds of KB on
+  /// the UI isolate.
+  int _estimateEncodedBytes(Map<String, dynamic> data) {
+    var estimate = 2;
+    for (final entry in data.entries) {
+      estimate += entry.key.length + 16;
+      final value = entry.value;
+      if (value is! Map) continue;
+      final vectors = value['vectors'];
+      if (vectors is List) {
+        for (final vector in vectors) {
+          if (vector is List) estimate += vector.length * 12 + 8;
+        }
+        estimate += 64;
+        continue;
+      }
+      if (value['vector'] is List) {
+        estimate += (value['vector'] as List).length * 12 + 64;
+      }
+    }
+    return estimate;
   }
 }

--- a/packages/feature_mind/lib/src/search/meeting_text_chunker.dart
+++ b/packages/feature_mind/lib/src/search/meeting_text_chunker.dart
@@ -1,0 +1,138 @@
+import 'package:flutter/foundation.dart';
+
+/// One text window ready to embed for semantic search.
+///
+/// Sized for EmbeddingGemma's `seq256` context
+/// (`docs/superpowers/specs/2026-08-09-mind-scribe-semantic-search.md`): a
+/// single whole-meeting embed truncates long transcripts, so topics that
+/// appear after the first ~256 tokens never enter the vector. Chunking
+/// keeps each window short enough to fit, and overlapping windows keep a
+/// fact that sits on a boundary inside at least one chunk.
+@immutable
+class MeetingTextChunk {
+  const MeetingTextChunk({required this.id, required this.text});
+
+  final String id;
+  final String text;
+}
+
+/// Splits meeting text into overlapping windows for [EmbeddingService].
+///
+/// Prefers ASR [segments] when present (the same evidence units
+/// `airo_mind_transcript`'s chunker consumes in Rust — no FFI to that crate
+/// yet, so this is a Dart-side reuse of the segment list, not a second
+/// algorithm invented from scratch). Falls back to paragraph/sentence
+/// windows over [fallbackText] when segments are empty.
+///
+/// Pure and isolate-safe: no I/O, no Flutter bindings beyond `@immutable`.
+class MeetingTextChunker {
+  const MeetingTextChunker({
+    this.maxChars = 700,
+    this.overlapChars = 120,
+  });
+
+  /// Soft ceiling per chunk. ~700 Latin characters is comfortably under
+  /// EmbeddingGemma's 256-token window for English meeting prose; keep it
+  /// conservative rather than packing to the hard limit.
+  final int maxChars;
+
+  /// Characters of previous-chunk tail prepended to the next chunk so a
+  /// topic straddling a boundary is not lost.
+  final int overlapChars;
+
+  /// Builds embeddable chunks from [segments] and/or [fallbackText].
+  ///
+  /// Empty input yields an empty list — callers treat that as "nothing to
+  /// embed," not an error.
+  List<MeetingTextChunk> chunk({
+    List<String> segments = const [],
+    String fallbackText = '',
+  }) {
+    final cleanedSegments = [
+      for (final segment in segments)
+        if (segment.trim().isNotEmpty) segment.trim(),
+    ];
+    if (cleanedSegments.isNotEmpty) {
+      return _chunkParts(cleanedSegments);
+    }
+
+    final text = fallbackText.trim();
+    if (text.isEmpty) return const [];
+
+    final parts = _splitFallback(text);
+    return _chunkParts(parts);
+  }
+
+  List<MeetingTextChunk> _chunkParts(List<String> parts) {
+    final chunks = <MeetingTextChunk>[];
+    var start = 0;
+    var chunkNo = 0;
+
+    while (start < parts.length) {
+      final buffer = StringBuffer();
+      var end = start;
+      while (end < parts.length) {
+        final piece = parts[end];
+        final nextLength =
+            buffer.length + (buffer.isEmpty ? 0 : 1) + piece.length;
+        if (buffer.isNotEmpty && nextLength > maxChars) break;
+        if (buffer.isNotEmpty) buffer.write(' ');
+        buffer.write(piece);
+        end++;
+        if (buffer.length >= maxChars) break;
+      }
+
+      final text = buffer.toString().trim();
+      if (text.isNotEmpty) {
+        chunks.add(MeetingTextChunk(id: 'chunk-$chunkNo', text: text));
+        chunkNo++;
+      }
+
+      if (end >= parts.length) break;
+
+      // Walk back ~overlapChars of content for the next window start.
+      var overlapBudget = overlapChars;
+      var nextStart = end;
+      while (nextStart > start + 1 && overlapBudget > 0) {
+        nextStart--;
+        overlapBudget -= parts[nextStart].length + 1;
+      }
+      start = nextStart <= start ? start + 1 : nextStart;
+    }
+
+    return chunks;
+  }
+
+  /// Paragraphs first, then sentences, then hard splits — enough structure
+  /// for a flat transcript/minutes string without inventing a second
+  /// semantic-boundary heuristic beyond what segments already give us.
+  List<String> _splitFallback(String text) {
+    final paragraphs = text
+        .split(RegExp(r'\n\s*\n'))
+        .map((p) => p.trim())
+        .where((p) => p.isNotEmpty)
+        .toList();
+    final parts = <String>[];
+    for (final paragraph in paragraphs) {
+      if (paragraph.length <= maxChars) {
+        parts.add(paragraph);
+        continue;
+      }
+      final sentences = paragraph
+          .split(RegExp(r'(?<=[.!?])\s+'))
+          .map((s) => s.trim())
+          .where((s) => s.isNotEmpty);
+      for (final sentence in sentences) {
+        if (sentence.length <= maxChars) {
+          parts.add(sentence);
+          continue;
+        }
+        for (var i = 0; i < sentence.length; i += maxChars) {
+          final end = (i + maxChars).clamp(0, sentence.length);
+          parts.add(sentence.substring(i, end));
+        }
+      }
+    }
+    return parts;
+  }
+}

--- a/packages/feature_mind/lib/src/search/semantic_search_ranker.dart
+++ b/packages/feature_mind/lib/src/search/semantic_search_ranker.dart
@@ -1,9 +1,11 @@
 import 'dart:math' as math;
 
 import 'package:core_ai/core_ai.dart';
+import 'package:core_workers/core_workers.dart';
 
 import '../whisper/api/meetings.dart' as rust;
 import 'meeting_embedding_store.dart';
+import 'meeting_text_chunker.dart';
 
 /// Adds semantic ranking on top of `searchMeetings`'s keyword hits.
 ///
@@ -11,22 +13,32 @@ import 'meeting_embedding_store.dart';
 /// of its semantic similarity to the query — a keyword match a query didn't
 /// resemble semantically is still a real match
 /// (`docs/superpowers/specs/2026-08-09-mind-scribe-semantic-search.md`).
-/// Semantic-only matches (no keyword overlap) are appended after, ranked by
-/// similarity, only when they clear [similarityThreshold].
+/// Keyword hits are re-ordered by descending semantic score when vectors
+/// exist; semantic-only matches (no keyword overlap) are appended after,
+/// ranked by similarity, only when they clear [similarityThreshold].
 ///
 /// Falls back to keyword-only, silently and correctly, when no embedding
 /// model is installed — the expected common state before a user downloads
 /// one, not an error condition this class treats specially.
+///
+/// Meetings are chunked before embedding (`MeetingTextChunker`) so long
+/// transcripts fit EmbeddingGemma's `seq256` window. A meeting's score is
+/// the **max** cosine similarity across its chunk vectors — one on-topic
+/// chunk is enough to surface it.
 class SemanticSearchRanker {
   SemanticSearchRanker({
     required EmbeddingService embeddingService,
     required MeetingEmbeddingStore embeddingStore,
+    MeetingTextChunker chunker = const MeetingTextChunker(),
     this.similarityThreshold = 0.6,
+    this.offMainCorpusSize = 32,
   }) : _embeddingService = embeddingService,
-       _embeddingStore = embeddingStore;
+       _embeddingStore = embeddingStore,
+       _chunker = chunker;
 
   final EmbeddingService _embeddingService;
   final MeetingEmbeddingStore _embeddingStore;
+  final MeetingTextChunker _chunker;
 
   /// Cosine similarity (0–1) a semantic-only match must clear to appear.
   /// 0.6 is a starting point, not a value tuned against this app's own
@@ -35,64 +47,213 @@ class SemanticSearchRanker {
   /// takes on skipping an ANN index.
   final double similarityThreshold;
 
-  /// Ranks [meetings] against [query], returning [keywordHits] plus any
-  /// semantically similar meeting not already among them.
+  /// When at least this many meetings need cosine scoring, ranking runs via
+  /// [runOffMain] so a large local corpus cannot stall the UI isolate.
+  /// Embedding inference itself already leaves the main isolate through the
+  /// native plugin's IO dispatcher.
+  final int offMainCorpusSize;
+
+  /// Ranks [meetings] against [query], returning [keywordHits] (re-ordered
+  /// by semantic score when available) plus any semantically similar
+  /// meeting not already among them.
   ///
-  /// Embeddings for meetings not yet in [MeetingEmbeddingStore] are computed
-  /// here, lazily, and cached for next time — there is no separate
-  /// save-time indexing step yet. That means the search *after* recording a
-  /// new meeting pays for embedding it; a background/save-time job would
-  /// remove that cost, and is a reasonable follow-up once this is real
-  /// usage, not a v1 requirement.
+  /// Optional [segmentTextsByMeetingId] feeds [MeetingTextChunker] the same
+  /// ASR segment units the Rust transcript processor chunks. Absent for
+  /// meetings that predate `#1629` Gap D — those fall back to flat text.
   Future<List<rust.SearchHit>> rank({
     required String query,
     required List<rust.SearchHit> keywordHits,
     required List<rust.MeetingRecord> meetings,
+    Map<String, List<String>> segmentTextsByMeetingId = const {},
   }) async {
-    final queryResult = await _embeddingService.embed(query);
+    final queryResult = await _embeddingService.embed(
+      query,
+      taskType: EmbeddingTaskType.retrievalQuery,
+    );
     if (!queryResult.isReady) return keywordHits;
     final queryVector = queryResult.vector!;
+    final activeModelId = queryResult.modelId!;
 
+    final meetingsById = {for (final m in meetings) m.id: m};
     final keywordIds = keywordHits.map((hit) => hit.meetingId).toSet();
-    final scored = <(double similarity, rust.SearchHit hit)>[];
 
-    for (final meeting in meetings) {
-      if (keywordIds.contains(meeting.id)) continue;
-
-      final vector = await _vectorFor(meeting);
-      if (vector == null) continue;
-
-      final similarity = _cosineSimilarity(queryVector, vector);
-      if (similarity < similarityThreshold) continue;
-
-      scored.add((similarity, _hitFor(meeting)));
+    final keywordCandidates = <_ScoredCandidate>[];
+    for (final hit in keywordHits) {
+      final meeting = meetingsById[hit.meetingId];
+      final vectors = meeting == null
+          ? null
+          : await _vectorsFor(
+              meeting,
+              activeModelId: activeModelId,
+              segmentTexts: segmentTextsByMeetingId[meeting.id] ?? const [],
+            );
+      keywordCandidates.add(
+        _ScoredCandidate(
+          meetingId: hit.meetingId,
+          chunkVectors: vectors ?? const [],
+          hit: hit,
+        ),
+      );
     }
 
-    scored.sort((a, b) => b.$1.compareTo(a.$1));
-    return [...keywordHits, for (final entry in scored) entry.$2];
+    final semanticCandidates = <_ScoredCandidate>[];
+    for (final meeting in meetings) {
+      if (keywordIds.contains(meeting.id)) continue;
+      final vectors = await _vectorsFor(
+        meeting,
+        activeModelId: activeModelId,
+        segmentTexts: segmentTextsByMeetingId[meeting.id] ?? const [],
+      );
+      if (vectors == null || vectors.isEmpty) continue;
+      semanticCandidates.add(
+        _ScoredCandidate(
+          meetingId: meeting.id,
+          chunkVectors: vectors,
+          hit: _hitFor(meeting),
+        ),
+      );
+    }
+
+    final keywordScored = List<(double, rust.SearchHit)>.of(
+      await _scoreCandidates(
+        queryVector,
+        keywordCandidates,
+        applyThreshold: false,
+      ),
+    );
+    keywordScored.sort((a, b) => b.$1.compareTo(a.$1));
+
+    final semanticScored = List<(double, rust.SearchHit)>.of(
+      await _scoreCandidates(
+        queryVector,
+        semanticCandidates,
+        applyThreshold: true,
+      ),
+    );
+    semanticScored.sort((a, b) => b.$1.compareTo(a.$1));
+
+    return [
+      for (final entry in keywordScored) entry.$2,
+      for (final entry in semanticScored) entry.$2,
+    ];
   }
 
-  Future<List<double>?> _vectorFor(rust.MeetingRecord meeting) async {
+  /// Eagerly embeds [meeting] so a later [rank] call does not pay for it.
+  ///
+  /// Returns `false` when no embedding model is installed — the caller
+  /// (Wave 2 Agent G / `MindService.indexMeetingForSearch`) treats that as
+  /// "keyword search still works," not an error.
+  Future<bool> indexMeeting(
+    rust.MeetingRecord meeting, {
+    List<String> segmentTexts = const [],
+  }) async {
+    final vectors = await _computeAndStore(
+      meeting,
+      segmentTexts: segmentTexts,
+    );
+    return vectors != null;
+  }
+
+  Future<List<(double, rust.SearchHit)>> _scoreCandidates(
+    List<double> queryVector,
+    List<_ScoredCandidate> candidates, {
+    required bool applyThreshold,
+  }) async {
+    if (candidates.isEmpty) return <(double, rust.SearchHit)>[];
+
+    if (candidates.length < offMainCorpusSize) {
+      final scored = <(double, rust.SearchHit)>[];
+      for (final candidate in candidates) {
+        final similarity = candidate.chunkVectors.isEmpty
+            ? 0.0
+            : _maxCosineSimilarity(queryVector, candidate.chunkVectors);
+        if (applyThreshold && similarity < similarityThreshold) continue;
+        scored.add((similarity, candidate.hit));
+      }
+      return scored;
+    }
+
+    final payload = (
+      query: List<double>.from(queryVector),
+      threshold: applyThreshold ? similarityThreshold : double.negativeInfinity,
+      meetings: [
+        for (final candidate in candidates)
+          (
+            id: candidate.meetingId,
+            chunks: [
+              for (final vector in candidate.chunkVectors)
+                List<double>.from(vector),
+            ],
+          ),
+      ],
+    );
+
+    final ranked = await runOffMain(() {
+      final scored = <(double, String)>[];
+      for (final meeting in payload.meetings) {
+        final similarity = meeting.chunks.isEmpty
+            ? 0.0
+            : _maxCosineSimilarity(payload.query, meeting.chunks);
+        if (similarity >= payload.threshold) {
+          scored.add((similarity, meeting.id));
+        }
+      }
+      return scored;
+    });
+
+    final byId = {for (final c in candidates) c.meetingId: c.hit};
+    return [
+      for (final entry in ranked)
+        if (byId.containsKey(entry.$2)) (entry.$1, byId[entry.$2]!),
+    ];
+  }
+
+  Future<List<List<double>>?> _vectorsFor(
+    rust.MeetingRecord meeting, {
+    required String activeModelId,
+    required List<String> segmentTexts,
+  }) async {
     final stored = await _embeddingStore.get(meeting.id);
-    if (stored != null) return stored.vector;
+    if (stored != null && stored.modelId == activeModelId) {
+      return stored.vectors;
+    }
 
-    final text = _embeddableText(meeting);
-    if (text.isEmpty) return null;
-
-    final result = await _embeddingService.embed(text);
-    if (!result.isReady) return null;
-
-    await _embeddingStore.put(meeting.id, result.modelId!, result.vector!);
-    return result.vector;
+    return _computeAndStore(meeting, segmentTexts: segmentTexts);
   }
 
-  /// The text embedded and cached per meeting.
+  Future<List<List<double>>?> _computeAndStore(
+    rust.MeetingRecord meeting, {
+    required List<String> segmentTexts,
+  }) async {
+    final chunks = _chunker.chunk(
+      segments: segmentTexts,
+      fallbackText: _embeddableText(meeting),
+    );
+    if (chunks.isEmpty) return null;
+
+    final vectors = <List<double>>[];
+    String? modelId;
+    for (final chunk in chunks) {
+      final result = await _embeddingService.embed(
+        chunk.text,
+        taskType: EmbeddingTaskType.retrievalDocument,
+      );
+      if (!result.isReady) return null;
+      modelId = result.modelId;
+      vectors.add(result.vector!);
+    }
+
+    await _embeddingStore.putChunks(meeting.id, modelId!, vectors);
+    return vectors;
+  }
+
+  /// The text embedded and cached per meeting when segments are unavailable.
   ///
   /// `ADR-0022 §3`: extends `'${transcript} ${minutes}'` with the same IR
   /// text `SearchIndex::insert` (`rust/airo_mind_core/src/search.rs`) feeds
   /// its lexical index -- decision statements and action-item task/owner
-  /// text -- one extra string concatenated into the same embed call, not a
-  /// second embedding path. Metrics are not included, matching the FTS
+  /// text -- one extra string concatenated into the same embed path, not a
+  /// second embedding pipeline. Metrics are not included, matching the FTS
   /// extension's scope exactly.
   String _embeddableText(rust.MeetingRecord meeting) {
     final parts = [meeting.transcript, meeting.minutes];
@@ -122,18 +283,43 @@ class SemanticSearchRanker {
       snippet: snippet,
     );
   }
+}
 
-  double _cosineSimilarity(List<double> a, List<double> b) {
-    if (a.isEmpty || a.length != b.length) return 0;
-    var dot = 0.0;
-    var normA = 0.0;
-    var normB = 0.0;
-    for (var i = 0; i < a.length; i++) {
-      dot += a[i] * b[i];
-      normA += a[i] * a[i];
-      normB += b[i] * b[i];
-    }
-    if (normA == 0 || normB == 0) return 0;
-    return dot / (math.sqrt(normA) * math.sqrt(normB));
+class _ScoredCandidate {
+  const _ScoredCandidate({
+    required this.meetingId,
+    required this.chunkVectors,
+    required this.hit,
+  });
+
+  final String meetingId;
+  final List<List<double>> chunkVectors;
+  final rust.SearchHit hit;
+}
+
+/// Max cosine similarity of [query] against any vector in [chunks].
+///
+/// Top-level so [runOffMain] / `Isolate.run` can invoke it without capturing
+/// instance state.
+double _maxCosineSimilarity(List<double> query, List<List<double>> chunks) {
+  var best = 0.0;
+  for (final chunk in chunks) {
+    final score = _cosineSimilarity(query, chunk);
+    if (score > best) best = score;
   }
+  return best;
+}
+
+double _cosineSimilarity(List<double> a, List<double> b) {
+  if (a.isEmpty || a.length != b.length) return 0;
+  var dot = 0.0;
+  var normA = 0.0;
+  var normB = 0.0;
+  for (var i = 0; i < a.length; i++) {
+    dot += a[i] * b[i];
+    normA += a[i] * a[i];
+    normB += b[i] * b[i];
+  }
+  if (normA == 0 || normB == 0) return 0;
+  return dot / (math.sqrt(normA) * math.sqrt(normB));
 }

--- a/packages/feature_mind/test/search/meeting_embedding_store_test.dart
+++ b/packages/feature_mind/test/search/meeting_embedding_store_test.dart
@@ -31,6 +31,40 @@ void main() {
 
       expect(result?.modelId, 'embed-model-v1');
       expect(result?.vector, [0.1, 0.2, 0.3]);
+      expect(result?.vectors, [
+        [0.1, 0.2, 0.3],
+      ]);
+    });
+
+    test('putChunks round-trips multiple vectors per meeting', () async {
+      final store = MeetingEmbeddingStore(tempDir);
+
+      await store.putChunks('meeting-1', 'embed-model', [
+        [0.1, 0.2],
+        [0.3, 0.4],
+      ]);
+      final result = await store.get('meeting-1');
+
+      expect(result?.vectors, [
+        [0.1, 0.2],
+        [0.3, 0.4],
+      ]);
+      expect(result?.vector, [0.1, 0.2]);
+    });
+
+    test('reads a legacy single-vector JSON entry as one chunk', () async {
+      final file = File('${tempDir.path}/meeting_embeddings.json');
+      file.writeAsStringSync(
+        '{"meeting-1":{"modelId":"legacy","vector":[0.5,0.6]}}',
+      );
+      final store = MeetingEmbeddingStore(tempDir);
+
+      final result = await store.get('meeting-1');
+
+      expect(result?.modelId, 'legacy');
+      expect(result?.vectors, [
+        [0.5, 0.6],
+      ]);
     });
 
     test('put overwrites a previous entry for the same meeting', () async {

--- a/packages/feature_mind/test/search/meeting_text_chunker_test.dart
+++ b/packages/feature_mind/test/search/meeting_text_chunker_test.dart
@@ -1,0 +1,48 @@
+import 'package:feature_mind/src/search/meeting_text_chunker.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('MeetingTextChunker', () {
+    const chunker = MeetingTextChunker(maxChars: 40, overlapChars: 10);
+
+    test('returns empty for empty input', () {
+      expect(chunker.chunk(), isEmpty);
+      expect(chunker.chunk(fallbackText: '   '), isEmpty);
+    });
+
+    test('prefers segments over fallback text', () {
+      final chunks = chunker.chunk(
+        segments: const ['alpha.', 'beta.', 'gamma.'],
+        fallbackText: 'this fallback must not appear',
+      );
+
+      expect(chunks, isNotEmpty);
+      expect(
+        chunks.every((c) => !c.text.contains('fallback')),
+        isTrue,
+      );
+      expect(chunks.map((c) => c.text).join(' '), contains('alpha'));
+      expect(chunks.map((c) => c.text).join(' '), contains('gamma'));
+    });
+
+    test('splits long segment lists into overlapping windows', () {
+      final chunks = chunker.chunk(
+        segments: List.generate(12, (i) => 'segment$i'),
+      );
+
+      expect(chunks.length, greaterThan(1));
+      expect(chunks.first.id, 'chunk-0');
+      // Overlap walks back prior segments into the next window.
+      final firstParts = chunks.first.text.split(' ').toSet();
+      final secondParts = chunks[1].text.split(' ').toSet();
+      expect(firstParts.intersection(secondParts), isNotEmpty);
+    });
+
+    test('keeps a short meeting as a single chunk', () {
+      final chunks = chunker.chunk(fallbackText: 'short meeting notes');
+
+      expect(chunks, hasLength(1));
+      expect(chunks.single.text, 'short meeting notes');
+    });
+  });
+}

--- a/packages/feature_mind/test/search/semantic_search_ranker_test.dart
+++ b/packages/feature_mind/test/search/semantic_search_ranker_test.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 
 import 'package:core_ai/core_ai.dart';
 import 'package:feature_mind/src/search/meeting_embedding_store.dart';
+import 'package:feature_mind/src/search/meeting_text_chunker.dart';
 import 'package:feature_mind/src/search/semantic_search_ranker.dart';
 import 'package:feature_mind/src/whisper/api/meetings.dart' as rust;
 import 'package:flutter_test/flutter_test.dart';
@@ -70,7 +71,7 @@ void main() {
         embeddingService: _FakeEmbeddingService(
           vectors: {
             'pricing question': [1.0, 0.0],
-            'm1': [-1.0, 0.0], // opposite direction: similarity -1
+            'transcript text minutes text': [-1.0, 0.0],
           },
         ),
         embeddingStore: store,
@@ -87,13 +88,39 @@ void main() {
     });
 
     test(
+      're-ranks keyword hits by descending semantic similarity',
+      () async {
+        final ranker = SemanticSearchRanker(
+          embeddingService: _FakeEmbeddingService(
+            vectors: {
+              'query': [1.0, 0.0],
+              'far text': [0.7, 0.3],
+              'close text': [0.9, 0.1],
+            },
+          ),
+          embeddingStore: store,
+        );
+
+        final result = await ranker.rank(
+          query: 'query',
+          keywordHits: [_hit('far'), _hit('close')],
+          meetings: [
+            _meeting('far', transcript: 'far', minutes: 'text'),
+            _meeting('close', transcript: 'close', minutes: 'text'),
+          ],
+        );
+
+        expect(result.map((h) => h.meetingId), ['close', 'far']);
+      },
+    );
+
+    test(
       'adds a semantic-only match that clears the similarity threshold',
       () async {
         final ranker = SemanticSearchRanker(
           embeddingService: _FakeEmbeddingService(
             vectors: {
               'pricing question': [1.0, 0.0],
-              // meeting text embeds to the same direction as the query.
               'transcript text minutes text': [1.0, 0.0],
             },
           ),
@@ -117,10 +144,7 @@ void main() {
           embeddingService: _FakeEmbeddingService(
             vectors: {
               'pricing question': [1.0, 0.0],
-              'transcript text minutes text': [
-                0.0,
-                1.0,
-              ], // orthogonal: similarity 0
+              'transcript text minutes text': [0.0, 1.0],
             },
           ),
           embeddingStore: store,
@@ -183,21 +207,77 @@ void main() {
 
       expect(stored, isNotNull);
       expect(stored?.modelId, 'fake-embedding-model');
+      expect(stored?.vectors, [
+        [1.0, 0.0],
+      ]);
 
-      // Second call must not re-embed the meeting text -- only the query.
       embeddingService.embedCallsByText.clear();
+      embeddingService.taskTypes.clear();
       await ranker.rank(
         query: 'pricing question',
         keywordHits: const [],
         meetings: [meeting],
       );
       expect(embeddingService.embedCallsByText, ['pricing question']);
+      expect(embeddingService.taskTypes, [EmbeddingTaskType.retrievalQuery]);
+    });
+
+    test('re-embeds when the stored model id is stale', () async {
+      await store.put('m1', 'old-model', [0.0, 1.0]);
+      final embeddingService = _FakeEmbeddingService(
+        vectors: {
+          'pricing question': [1.0, 0.0],
+          'transcript text minutes text': [1.0, 0.0],
+        },
+      );
+      final ranker = SemanticSearchRanker(
+        embeddingService: embeddingService,
+        embeddingStore: store,
+      );
+
+      await ranker.rank(
+        query: 'pricing question',
+        keywordHits: const [],
+        meetings: [_meeting('m1')],
+      );
+
+      final stored = await store.get('m1');
+      expect(stored?.modelId, 'fake-embedding-model');
+      expect(stored?.vector, [1.0, 0.0]);
+      expect(
+        embeddingService.embedCallsByText,
+        contains('transcript text minutes text'),
+      );
     });
 
     test(
-      // `ADR-0022 §3`: the embedded text extends to decision statements and
-      // action-item task/owner text, the same text `SearchIndex::insert`
-      // feeds its lexical index -- union, not a second embedding path.
+      'uses retrievalQuery for the query and retrievalDocument for meetings',
+      () async {
+        final embeddingService = _FakeEmbeddingService(
+          vectors: {
+            'pricing question': [1.0, 0.0],
+            'transcript text minutes text': [1.0, 0.0],
+          },
+        );
+        final ranker = SemanticSearchRanker(
+          embeddingService: embeddingService,
+          embeddingStore: store,
+        );
+
+        await ranker.rank(
+          query: 'pricing question',
+          keywordHits: const [],
+          meetings: [_meeting('m1')],
+        );
+
+        expect(embeddingService.taskTypes, [
+          EmbeddingTaskType.retrievalQuery,
+          EmbeddingTaskType.retrievalDocument,
+        ]);
+      },
+    );
+
+    test(
       'embeds decision statements and action-item task/owner text',
       () async {
         final ranker = SemanticSearchRanker(
@@ -250,8 +330,8 @@ void main() {
           embeddingService: _FakeEmbeddingService(
             vectors: {
               'query': [1.0, 0.0],
-              'close text': [0.9, 0.1], // higher similarity
-              'far text': [0.7, 0.3], // lower, still above threshold
+              'close text': [0.9, 0.1],
+              'far text': [0.7, 0.3],
             },
           ),
           embeddingStore: store,
@@ -269,20 +349,135 @@ void main() {
         expect(result.map((h) => h.meetingId), ['close', 'far']);
       },
     );
+
+    test('scores a meeting by max similarity across chunks', () async {
+      final ranker = SemanticSearchRanker(
+        embeddingService: _FakeEmbeddingService(
+          vectors: {
+            'pricing': [1.0, 0.0],
+            'early fluff': [0.0, 1.0],
+            'the pricing discussion': [1.0, 0.0],
+          },
+        ),
+        embeddingStore: store,
+        // Force one segment per chunk so max-across-chunks is observable.
+        chunker: const MeetingTextChunker(maxChars: 12, overlapChars: 0),
+      );
+
+      final result = await ranker.rank(
+        query: 'pricing',
+        keywordHits: const [],
+        meetings: [_meeting('m1')],
+        segmentTextsByMeetingId: {
+          'm1': ['early fluff', 'the pricing discussion'],
+        },
+      );
+
+      expect(result.map((h) => h.meetingId), ['m1']);
+      final stored = await store.get('m1');
+      expect(stored?.vectors, hasLength(2));
+    });
+
+    test(
+      // Acceptance (#508): "pricing decision" finds a meeting about that
+      // topic without those exact keywords — the fake embedder stands in
+      // for EmbeddingGemma so CI never needs the 179 MB weights.
+      'query "pricing decision" finds a meeting without those exact keywords',
+      () async {
+        final ranker = SemanticSearchRanker(
+          embeddingService: _FakeEmbeddingService(
+            vectors: {
+              'pricing decision': [1.0, 0.0],
+              'We agreed on the Q3 cost structure for enterprise seats '
+                      'minutes text':
+                  [0.95, 0.05],
+            },
+          ),
+          embeddingStore: store,
+        );
+
+        final result = await ranker.rank(
+          query: 'pricing decision',
+          keywordHits: const [],
+          meetings: [
+            _meeting(
+              'budget',
+              transcript:
+                  'We agreed on the Q3 cost structure for enterprise seats',
+            ),
+            _meeting(
+              'unrelated',
+              transcript: 'standup notes about the deploy pipeline',
+              minutes: 'no budget talk',
+            ),
+          ],
+        );
+
+        expect(result.map((h) => h.meetingId), ['budget']);
+        expect(
+          result.first.snippet.toLowerCase().contains('pricing'),
+          isFalse,
+        );
+      },
+    );
+  });
+
+  group('SemanticSearchRanker.indexMeeting', () {
+    test('caches a document embedding for later rank calls', () async {
+      final embeddingService = _FakeEmbeddingService(
+        vectors: {
+          'pricing question': [1.0, 0.0],
+          'transcript text minutes text': [1.0, 0.0],
+        },
+      );
+      final ranker = SemanticSearchRanker(
+        embeddingService: embeddingService,
+        embeddingStore: store,
+      );
+      final meeting = _meeting('m1');
+
+      expect(await ranker.indexMeeting(meeting), isTrue);
+      expect(await store.get('m1'), isNotNull);
+      expect(embeddingService.taskTypes, [
+        EmbeddingTaskType.retrievalDocument,
+      ]);
+
+      embeddingService.embedCallsByText.clear();
+      embeddingService.taskTypes.clear();
+      await ranker.rank(
+        query: 'pricing question',
+        keywordHits: const [],
+        meetings: [meeting],
+      );
+      expect(embeddingService.embedCallsByText, ['pricing question']);
+    });
+
+    test('returns false when no embedding model is installed', () async {
+      final ranker = SemanticSearchRanker(
+        embeddingService: _FakeEmbeddingService(),
+        embeddingStore: store,
+      );
+
+      expect(await ranker.indexMeeting(_meeting('m1')), isFalse);
+      expect(await store.get('m1'), isNull);
+    });
   });
 }
 
 class _FakeEmbeddingService implements EmbeddingService {
   _FakeEmbeddingService({this.vectors = const {}});
 
-  /// Keyed by the exact text passed to [embed] — the test builds this map to
-  /// control what each call returns.
   final Map<String, List<double>> vectors;
   final embedCallsByText = <String>[];
+  final taskTypes = <EmbeddingTaskType>[];
 
   @override
-  Future<EmbeddingResult> embed(String text) async {
+  Future<EmbeddingResult> embed(
+    String text, {
+    EmbeddingTaskType taskType = EmbeddingTaskType.semanticSimilarity,
+  }) async {
     embedCallsByText.add(text);
+    taskTypes.add(taskType);
     final vector = vectors[text];
     if (vector == null) {
       return const EmbeddingResult.unavailable(


### PR DESCRIPTION
## Summary
- Chunk meeting text (ASR segments when available, overlapping windows otherwise) before EmbeddingGemma `seq256` embeds; score meetings by **max** chunk cosine similarity so late topics are not truncated away.
- Wire query/document `EmbeddingTaskType` through Dart + `EmbeddingPlugin`, auto-queue the SentencePiece tokenizer when EmbeddingGemma is downloaded, and keep large-corpus cosine ranking / JSON I/O off the UI isolate via `runOffMain`.
- `MindService.search` still unions lexical `searchMeetings` hits with semantic matches (never removes keyword hits) and falls back to lexical-only when no embedding model is installed. Adds `indexMeetingForSearch` for Wave 2 eager indexing.

Closes the remaining Agent E acceptance gaps on top of merged Phases 1–3 (#1573/#1578/#1579). Relates to #508.

## Test plan
- [x] `cd packages/core_ai && flutter test test/embeddings test/registry/model_catalog_test.dart`
- [x] `cd packages/feature_mind && flutter test test/search` (fake embedder only; no 179 MB model)
- [ ] Device: download EmbeddingGemma + tokenizer from model library, record a meeting about costs/budget, search `pricing decision` and confirm a semantic hit
- [ ] Confirm search with model uninstalled still returns keyword hits only


Made with [Cursor](https://cursor.com)