### PR TITLE
feat(mind): Meeting IR UI — MoM sections, checkable actions, evidence (#1658)

### DIFF
--- a/app/integration_test/mind_journey_device_test.dart
+++ b/app/integration_test/mind_journey_device_test.dart
@@ -64,7 +64,6 @@ import 'dart:io';
 
 import 'package:airo_app/core/mind/mind_model_sources.dart';
 import 'package:feature_mind/feature_mind.dart';
-import 'package:feature_mind/src/export/application/meeting_export_service.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
@@ -84,8 +83,7 @@ void main() {
       Platform.environment['CI'] == 'true' ||
       Platform.environment['GITHUB_ACTIONS'] == 'true';
   final fixtureExists = File(fixturePath).existsSync();
-  final shouldSkip =
-      !runJourney || isCi || (!fixtureExists && !allowRecord);
+  final shouldSkip = !runJourney || isCi || (!fixtureExists && !allowRecord);
 
   if (shouldSkip) {
     final reason = (!runJourney || isCi)
@@ -201,7 +199,9 @@ void main() {
       );
 
       // ── 8. Export markdown (durable evidence; uses #1768 mom.md path) ────
-      final bundle = await MeetingExportService(service).exportMeeting(meetingId);
+      final bundle = await MeetingExportService(
+        service,
+      ).exportMeeting(meetingId);
       expect(bundle, isNotNull);
       expect(bundle!.files.containsKey('transcript.md'), isTrue);
       expect(bundle.files['transcript.md']!.trim(), isNotEmpty);

--- a/app/lib/core/mind/mind_model_sources.dart
+++ b/app/lib/core/mind/mind_model_sources.dart
@@ -1,6 +1,5 @@
 import 'package:core_ai/core_ai.dart';
 import 'package:feature_mind/feature_mind.dart';
-import 'package:feature_mind/src/whisper/api/meetings.dart' as rust;
 
 /// Where Airo Mind's models are fetched from, and the provider that fetches
 /// them.
@@ -67,7 +66,7 @@ MindService buildMindDownloadService() {
     // whisper weights and auto-detect per recording (`#1629`, `#1664`).
     // Settings can opt into English-only; [requiredModelsLookup] re-reads
     // that preference so the multilingual file is not forced on download.
-    defaultSpeechLanguage: rust.SpeechLanguage.multilingual,
+    defaultSpeechLanguage: SpeechLanguage.multilingual,
     modelProvider: DownloadModelProvider(
       // Application support, not documents. Airo Mind keeps its models in the
       // app's support directory on purpose (`MindService.modelsDirectory`) —

--- a/packages/feature_mind/lib/feature_mind.dart
+++ b/packages/feature_mind/lib/feature_mind.dart
@@ -21,7 +21,9 @@ export 'src/mind_availability.dart';
 export 'src/whisper/api/meetings.dart'
     show MeetingRecord, SearchHit, SpeechLanguage;
 export 'src/meeting_screen.dart' show MeetingScreen;
-export 'src/mind_home_screen.dart' show MindHomeScreen;
+export 'src/mind_home_screen.dart' show MindHomeScreen, meetingListPreview;
+export 'src/export/application/meeting_export_service.dart'
+    show MeetingExportService;
 export 'src/mind_service.dart'
     show MindProgress, MindService, MindStage, MindStatus, MindUnavailable;
 

--- a/packages/feature_mind/lib/feature_mind.dart
+++ b/packages/feature_mind/lib/feature_mind.dart
@@ -18,7 +18,8 @@ library;
 
 export 'src/mind_availability.dart';
 
-export 'src/whisper/api/meetings.dart' show MeetingRecord, SearchHit;
+export 'src/whisper/api/meetings.dart'
+    show MeetingRecord, SearchHit, SpeechLanguage;
 export 'src/meeting_screen.dart' show MeetingScreen;
 export 'src/mind_home_screen.dart' show MindHomeScreen;
 export 'src/mind_service.dart'

--- a/packages/feature_mind/lib/src/export/application/meeting_export_service.dart
+++ b/packages/feature_mind/lib/src/export/application/meeting_export_service.dart
@@ -7,21 +7,10 @@ import '../domain/meeting_markdown_renderer.dart';
 
 /// Turns stored meetings into export bundles.
 ///
-/// This is the seam #1657 and a future MoM-FFI-wiring issue land in without
-/// touching the renderer: [_buildInput] is the only place that reads off
-/// `MindService`, and today it can only fill [MeetingExportInput.momMarkdown]
-/// and `.actionItems` with nothing, because:
-///
-/// - `#1657` (Stage 2, in flight as of this writing) is what puts
-///   `decisions`/`action_items`/`metrics` onto the persisted `Meeting`
-///   record and exposes them to Dart. Until it lands there is no Dart-side
-///   action-item data to read.
-/// - Saved minutes come from the scribe pipeline (`MindService.process` →
-///   `llama.generateMinutes`) and are persisted on `MeetingRecord.minutes`.
-///   Export reads that field today. Structured Meeting-IR action items still
-///   wait on `#1657`; once they land on the persisted record, map them onto
-///   [MeetingExportInput.actionItems] here — the renderer already knows what
-///   to do with them.
+/// [_buildInput] is the only place that reads off [MindService]: minutes from
+/// `MeetingRecord.minutes`, structured action items from
+/// `MeetingRecord.actionItems` (#1657 Stage 2), and timestamped transcript
+/// lines from `transcriptDocument` (#1629). The renderer stays pure Dart.
 class MeetingExportService {
   const MeetingExportService(this._mindService);
 
@@ -83,9 +72,25 @@ class MeetingExportService {
       transcriptLines: lines,
       fallbackTranscript: meeting.transcript,
       momMarkdown: minutes.isEmpty ? null : minutes,
-      // actionItems: waits on #1657 Meeting-IR persistence.
+      actionItems: [
+        for (final item in meeting.actionItems)
+          ExportActionItem(
+            task: item.task,
+            owner: item.owner,
+            due: item.due,
+            status: _actionStatusLabel(item.status),
+          ),
+      ],
     );
   }
+
+  static String _actionStatusLabel(rust.MeetingActionStatus status) =>
+      switch (status) {
+        rust.MeetingActionStatus.open => 'Open',
+        rust.MeetingActionStatus.inProgress => 'In progress',
+        rust.MeetingActionStatus.done => 'Done',
+        rust.MeetingActionStatus.blocked => 'Blocked',
+      };
 
   static List<TranscriptExportLine> _linesFrom(
     rust.TranscriptDocumentRecord? doc,

--- a/packages/feature_mind/lib/src/meeting_ir/evidence_resolver.dart
+++ b/packages/feature_mind/lib/src/meeting_ir/evidence_resolver.dart
@@ -1,0 +1,75 @@
+import 'package:flutter/foundation.dart';
+
+import '../bridges/mind_speech_bridge.dart';
+import '../whisper/api/meetings.dart' as rust;
+
+/// Resolves Meeting-IR evidence segment ids against a transcript document
+/// (`ADR-0022 §4`). Pure lookup — no I/O.
+@immutable
+class EvidenceHit {
+  const EvidenceHit({
+    required this.segmentId,
+    required this.startMs,
+    required this.endMs,
+    required this.text,
+  });
+
+  final String segmentId;
+  final int startMs;
+  final int endMs;
+  final String text;
+}
+
+/// Maps `evidenceSegmentIds` → transcript segments for highlighting / seek.
+class EvidenceResolver {
+  const EvidenceResolver();
+
+  /// Builds an id → segment index from a structured transcript document.
+  Map<String, TranscriptSegment> indexFromDocument(
+    rust.TranscriptDocumentRecord? doc,
+  ) {
+    if (doc == null) return const {};
+    return {
+      for (final s in doc.segments) s.id: toTranscriptSegment(s),
+    };
+  }
+
+  /// Builds an id → segment index from in-memory [TranscriptSegment]s
+  /// (live processing before `transcript.json` exists).
+  Map<String, TranscriptSegment> indexFromSegments(
+    List<TranscriptSegment> segments,
+  ) => {for (final s in segments) s.id: s};
+
+  /// Resolves [evidenceSegmentIds] in order, skipping unknown ids.
+  List<EvidenceHit> resolve({
+    required List<String> evidenceSegmentIds,
+    required Map<String, TranscriptSegment> byId,
+  }) {
+    final hits = <EvidenceHit>[];
+    for (final id in evidenceSegmentIds) {
+      final segment = byId[id];
+      if (segment == null) continue;
+      hits.add(
+        EvidenceHit(
+          segmentId: id,
+          startMs: segment.startMs,
+          endMs: segment.endMs,
+          text: segment.text,
+        ),
+      );
+    }
+    return hits;
+  }
+
+  /// First hit's start ms — for optional audio seek. Null when unresolved.
+  int? firstStartMs({
+    required List<String> evidenceSegmentIds,
+    required Map<String, TranscriptSegment> byId,
+  }) {
+    final hits = resolve(
+      evidenceSegmentIds: evidenceSegmentIds,
+      byId: byId,
+    );
+    return hits.isEmpty ? null : hits.first.startMs;
+  }
+}

--- a/packages/feature_mind/lib/src/meeting_ir/evidence_resolver.dart
+++ b/packages/feature_mind/lib/src/meeting_ir/evidence_resolver.dart
@@ -29,9 +29,7 @@ class EvidenceResolver {
     rust.TranscriptDocumentRecord? doc,
   ) {
     if (doc == null) return const {};
-    return {
-      for (final s in doc.segments) s.id: toTranscriptSegment(s),
-    };
+    return {for (final s in doc.segments) s.id: toTranscriptSegment(s)};
   }
 
   /// Builds an id → segment index from in-memory [TranscriptSegment]s
@@ -66,10 +64,7 @@ class EvidenceResolver {
     required List<String> evidenceSegmentIds,
     required Map<String, TranscriptSegment> byId,
   }) {
-    final hits = resolve(
-      evidenceSegmentIds: evidenceSegmentIds,
-      byId: byId,
-    );
+    final hits = resolve(evidenceSegmentIds: evidenceSegmentIds, byId: byId);
     return hits.isEmpty ? null : hits.first.startMs;
   }
 }

--- a/packages/feature_mind/lib/src/meeting_ir/meeting_ir_status_writer.dart
+++ b/packages/feature_mind/lib/src/meeting_ir/meeting_ir_status_writer.dart
@@ -1,0 +1,75 @@
+import '../bridges/mind_speech_bridge.dart';
+import '../whisper/api/meetings.dart' as rust;
+
+/// Writes action-item status back through the MIND-LLM-16 / ADR-0022 path:
+/// re-`save` the same meeting id with updated `actionItems` (append-only
+/// store, latest wins on read). No new Rust API.
+class MeetingIrStatusWriter {
+  const MeetingIrStatusWriter(this._speech);
+
+  final MindSpeechBridge _speech;
+
+  /// Parses `m{recordedAtMs}` back to the millisecond identity `saveMeeting`
+  /// used. Falls back to `recordedAt * 1000` for legacy ids.
+  static int recordedAtMsFor(rust.MeetingRecord meeting) {
+    final id = meeting.id;
+    if (id.startsWith('m')) {
+      final parsed = int.tryParse(id.substring(1));
+      if (parsed != null) return parsed;
+    }
+    return meeting.recordedAt.toInt() * 1000;
+  }
+
+  /// Toggles / sets one action item's [status], re-saving the full meeting.
+  Future<rust.MeetingRecord> updateActionStatus({
+    required rust.MeetingRecord meeting,
+    required String actionItemId,
+    required rust.MeetingActionStatus status,
+  }) async {
+    final updatedItems = [
+      for (final item in meeting.actionItems)
+        if (item.id == actionItemId)
+          rust.MeetingActionItemRecord(
+            id: item.id,
+            task: item.task,
+            owner: item.owner,
+            due: item.due,
+            status: status,
+            evidenceSegmentIds: item.evidenceSegmentIds,
+          )
+        else
+          item,
+    ];
+
+    final doc = await _speech.getTranscript(meeting.id);
+    final segments = doc == null
+        ? const <TranscriptSegment>[]
+        : doc.segments.map(toTranscriptSegment).toList(growable: false);
+    final wavPath = doc?.audioPath ?? '';
+
+    await _speech.save(
+      title: meeting.title,
+      recordedAtMs: recordedAtMsFor(meeting),
+      transcript: meeting.transcript,
+      minutes: meeting.minutes,
+      model: meeting.model,
+      segments: segments,
+      wavPath: wavPath,
+      decisions: meeting.decisions,
+      actionItems: updatedItems,
+      metrics: meeting.metrics,
+    );
+
+    return rust.MeetingRecord(
+      id: meeting.id,
+      title: meeting.title,
+      recordedAt: meeting.recordedAt,
+      transcript: meeting.transcript,
+      minutes: meeting.minutes,
+      model: meeting.model,
+      decisions: meeting.decisions,
+      actionItems: updatedItems,
+      metrics: meeting.metrics,
+    );
+  }
+}

--- a/packages/feature_mind/lib/src/meeting_ir/meeting_ir_user_edits.dart
+++ b/packages/feature_mind/lib/src/meeting_ir/meeting_ir_user_edits.dart
@@ -56,9 +56,7 @@ class MeetingIrUserEdits {
   final Map<String, MeetingActionUserEdit> byActionId;
 
   MeetingIrUserEdits upsert(String actionId, MeetingActionUserEdit edit) =>
-      MeetingIrUserEdits(
-        byActionId: {...byActionId, actionId: edit},
-      );
+      MeetingIrUserEdits(byActionId: {...byActionId, actionId: edit});
 
   MeetingActionUserEdit? operator [](String actionId) => byActionId[actionId];
 
@@ -105,8 +103,7 @@ class MeetingIrUserEdits {
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
-      other is MeetingIrUserEdits &&
-          mapEquals(byActionId, other.byActionId);
+      other is MeetingIrUserEdits && mapEquals(byActionId, other.byActionId);
 
   @override
   int get hashCode => Object.hashAll(byActionId.entries);

--- a/packages/feature_mind/lib/src/meeting_ir/meeting_ir_user_edits.dart
+++ b/packages/feature_mind/lib/src/meeting_ir/meeting_ir_user_edits.dart
@@ -1,0 +1,113 @@
+import 'dart:convert';
+
+import 'package:flutter/foundation.dart';
+
+import '../whisper/api/meetings.dart' as rust;
+
+/// One user correction to an extracted action item (#1658).
+///
+/// Stored separately from the Meeting IR write path so a later re-extraction
+/// (which re-saves via `saveMeeting`) never silently overwrites the person's
+/// edits. Display merges these over the persisted IR fields.
+@immutable
+class MeetingActionUserEdit {
+  const MeetingActionUserEdit({this.task, this.owner});
+
+  /// Corrected task text. Null means "keep the IR value".
+  final String? task;
+
+  /// Corrected owner. Empty string clears an inferred/wrong owner; null means
+  /// "keep the IR value".
+  final String? owner;
+
+  MeetingActionUserEdit copyWith({String? task, String? owner}) =>
+      MeetingActionUserEdit(
+        task: task ?? this.task,
+        owner: owner ?? this.owner,
+      );
+
+  Map<String, Object?> toJson() => {
+    if (task != null) 'task': task,
+    if (owner != null) 'owner': owner,
+  };
+
+  static MeetingActionUserEdit fromJson(Map<String, Object?> json) =>
+      MeetingActionUserEdit(
+        task: json['task'] as String?,
+        owner: json['owner'] as String?,
+      );
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is MeetingActionUserEdit &&
+          task == other.task &&
+          owner == other.owner;
+
+  @override
+  int get hashCode => Object.hash(task, owner);
+}
+
+/// Per-meeting map of action-item id → user edit.
+@immutable
+class MeetingIrUserEdits {
+  const MeetingIrUserEdits({this.byActionId = const {}});
+
+  final Map<String, MeetingActionUserEdit> byActionId;
+
+  MeetingIrUserEdits upsert(String actionId, MeetingActionUserEdit edit) =>
+      MeetingIrUserEdits(
+        byActionId: {...byActionId, actionId: edit},
+      );
+
+  MeetingActionUserEdit? operator [](String actionId) => byActionId[actionId];
+
+  /// Display task: user edit wins, else IR.
+  String taskFor(rust.MeetingActionItemRecord item) =>
+      byActionId[item.id]?.task ?? item.task;
+
+  /// Display owner: user edit wins (including explicit clear via ''), else IR.
+  String? ownerFor(rust.MeetingActionItemRecord item) {
+    final edit = byActionId[item.id];
+    if (edit == null || edit.owner == null) return item.owner;
+    final owner = edit.owner!;
+    return owner.isEmpty ? null : owner;
+  }
+
+  Map<String, Object?> toJson() => {
+    for (final e in byActionId.entries) e.key: e.value.toJson(),
+  };
+
+  static MeetingIrUserEdits fromJson(Map<String, Object?> json) {
+    final map = <String, MeetingActionUserEdit>{};
+    for (final e in json.entries) {
+      final value = e.value;
+      if (value is Map<String, Object?>) {
+        map[e.key] = MeetingActionUserEdit.fromJson(value);
+      } else if (value is Map) {
+        map[e.key] = MeetingActionUserEdit.fromJson(
+          value.cast<String, Object?>(),
+        );
+      }
+    }
+    return MeetingIrUserEdits(byActionId: map);
+  }
+
+  static MeetingIrUserEdits decode(String? raw) {
+    if (raw == null || raw.isEmpty) return const MeetingIrUserEdits();
+    final decoded = jsonDecode(raw);
+    if (decoded is! Map) return const MeetingIrUserEdits();
+    return MeetingIrUserEdits.fromJson(decoded.cast<String, Object?>());
+  }
+
+  String encode() => jsonEncode(toJson());
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is MeetingIrUserEdits &&
+          mapEquals(byActionId, other.byActionId);
+
+  @override
+  int get hashCode => Object.hashAll(byActionId.entries);
+}

--- a/packages/feature_mind/lib/src/meeting_ir/meeting_ir_user_edits_store.dart
+++ b/packages/feature_mind/lib/src/meeting_ir/meeting_ir_user_edits_store.dart
@@ -1,0 +1,49 @@
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'meeting_ir_user_edits.dart';
+
+/// Persists [#1658] user corrections to action-item task/owner text.
+///
+/// Deliberately not the Meeting store (`saveMeeting`): IR re-extraction
+/// appends a new latest-wins record and would overwrite in-place field edits.
+/// Preferences survive re-extraction because they are keyed by meeting id +
+/// action id, not rewritten by the extraction pipeline.
+class MeetingIrUserEditsStore {
+  MeetingIrUserEditsStore([SharedPreferences? preferences])
+    : _preferences = preferences;
+
+  static const _keyPrefix = 'mind.meeting_ir.user_edits.';
+
+  SharedPreferences? _preferences;
+
+  Future<SharedPreferences> _prefs() async {
+    return _preferences ??= await SharedPreferences.getInstance();
+  }
+
+  String _key(String meetingId) => '$_keyPrefix$meetingId';
+
+  Future<MeetingIrUserEdits> load(String meetingId) async {
+    final prefs = await _prefs();
+    return MeetingIrUserEdits.decode(prefs.getString(_key(meetingId)));
+  }
+
+  Future<void> save(String meetingId, MeetingIrUserEdits edits) async {
+    final prefs = await _prefs();
+    if (edits.byActionId.isEmpty) {
+      await prefs.remove(_key(meetingId));
+      return;
+    }
+    await prefs.setString(_key(meetingId), edits.encode());
+  }
+
+  Future<MeetingIrUserEdits> upsert({
+    required String meetingId,
+    required String actionId,
+    required MeetingActionUserEdit edit,
+  }) async {
+    final current = await load(meetingId);
+    final next = current.upsert(actionId, edit);
+    await save(meetingId, next);
+    return next;
+  }
+}

--- a/packages/feature_mind/lib/src/meeting_ir/meeting_ir_widgets.dart
+++ b/packages/feature_mind/lib/src/meeting_ir/meeting_ir_widgets.dart
@@ -161,10 +161,7 @@ class _DecisionTile extends StatelessWidget {
                 children: [
                   Text(decision.statement),
                   const SizedBox(height: 4),
-                  Text(
-                    status,
-                    style: Theme.of(context).textTheme.labelMedium,
-                  ),
+                  Text(status, style: Theme.of(context).textTheme.labelMedium),
                 ],
               ),
             ),
@@ -291,8 +288,7 @@ class _MetricTile extends StatelessWidget {
     return AiroSurface(
       level: AiroSurfaceLevel.raised,
       onTap: onTap,
-      semanticLabel:
-          'Number: ${metric.name} ${metric.value}. Show evidence.',
+      semanticLabel: 'Number: ${metric.name} ${metric.value}. Show evidence.',
       child: Padding(
         padding: const EdgeInsets.symmetric(vertical: 4),
         child: Row(
@@ -303,9 +299,7 @@ class _MetricTile extends StatelessWidget {
               color: AiroDomainTokens.of(context).accent,
             ),
             const SizedBox(width: 12),
-            Expanded(
-              child: Text('${metric.name}: ${metric.value}'),
-            ),
+            Expanded(child: Text('${metric.name}: ${metric.value}')),
             const Icon(Icons.link, size: 18),
           ],
         ),

--- a/packages/feature_mind/lib/src/meeting_ir/meeting_ir_widgets.dart
+++ b/packages/feature_mind/lib/src/meeting_ir/meeting_ir_widgets.dart
@@ -1,0 +1,442 @@
+import 'package:core_ui/core_ui.dart';
+import 'package:flutter/material.dart';
+
+import '../export/domain/meeting_markdown_renderer.dart' show formatTimestamp;
+import '../whisper/api/meetings.dart' as rust;
+import 'evidence_resolver.dart';
+import 'meeting_ir_user_edits.dart';
+
+/// MoM sections rendered from Meeting IR (#1657 UI / #1658), not free-form
+/// minutes text.
+///
+/// Decisions, action items, and metrics each carry evidence segment ids.
+/// Empty lists still render a section title + empty hint so the product
+/// surface is discoverable. Tapping evidence notifies [onEvidence] so the
+/// transcript can highlight / optionally seek; action rows also show a
+/// copyable/tappable clock when a segment resolves.
+class MeetingIrMomSections extends StatelessWidget {
+  const MeetingIrMomSections({
+    super.key,
+    required this.decisions,
+    required this.actionItems,
+    required this.metrics,
+    required this.edits,
+    required this.segmentsById,
+    required this.onEvidence,
+    required this.onToggleAction,
+    required this.onEditAction,
+    this.busyActionId,
+    this.formatClock = _defaultEvidenceClock,
+  });
+
+  final List<rust.MeetingDecisionRecord> decisions;
+  final List<rust.MeetingActionItemRecord> actionItems;
+  final List<rust.MeetingMetricRecord> metrics;
+  final MeetingIrUserEdits edits;
+  final Map<String, TranscriptSegmentView> segmentsById;
+  final void Function(List<String> evidenceSegmentIds) onEvidence;
+  final void Function(rust.MeetingActionItemRecord item) onToggleAction;
+  final void Function(rust.MeetingActionItemRecord item) onEditAction;
+  final String? busyActionId;
+  final String Function(int startMs) formatClock;
+
+  static String _defaultEvidenceClock(int ms) {
+    final totalSeconds = (ms < 0 ? 0 : ms) ~/ 1000;
+    final minutes = totalSeconds ~/ 60;
+    final seconds = totalSeconds % 60;
+    return '${minutes.toString().padLeft(2, '0')}:'
+        '${seconds.toString().padLeft(2, '0')}';
+  }
+
+  String? _clockFor(List<String> evidenceSegmentIds) {
+    for (final id in evidenceSegmentIds) {
+      final segment = segmentsById[id];
+      if (segment != null) return formatClock(segment.startMs);
+    }
+    return null;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        const _IrSectionTitle('Decisions'),
+        if (decisions.isEmpty)
+          const _IrEmptyHint('No decisions recorded.')
+        else
+          for (final d in decisions)
+            _DecisionTile(
+              decision: d,
+              onTap: () => onEvidence(d.evidenceSegmentIds),
+            ),
+        const SizedBox(height: 16),
+        const _IrSectionTitle('Action items'),
+        if (actionItems.isEmpty)
+          const _IrEmptyHint('No action items recorded.')
+        else
+          for (final item in actionItems)
+            _ActionTile(
+              item: item,
+              task: edits.taskFor(item),
+              owner: edits.ownerFor(item),
+              evidenceClock: _clockFor(item.evidenceSegmentIds),
+              busy: busyActionId == item.id,
+              onToggle: () => onToggleAction(item),
+              onEvidence: () => onEvidence(item.evidenceSegmentIds),
+              onEdit: () => onEditAction(item),
+            ),
+        const SizedBox(height: 16),
+        const _IrSectionTitle('Metrics'),
+        if (metrics.isEmpty)
+          const _IrEmptyHint('No metrics recorded.')
+        else
+          for (final m in metrics)
+            _MetricTile(
+              metric: m,
+              onTap: () => onEvidence(m.evidenceSegmentIds),
+            ),
+        const SizedBox(height: 16),
+      ],
+    );
+  }
+}
+
+class _IrEmptyHint extends StatelessWidget {
+  const _IrEmptyHint(this.text);
+  final String text;
+
+  @override
+  Widget build(BuildContext context) => Text(
+    text,
+    style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+      color: Theme.of(context).colorScheme.onSurfaceVariant,
+    ),
+  );
+}
+
+class _IrSectionTitle extends StatelessWidget {
+  const _IrSectionTitle(this.text);
+  final String text;
+
+  @override
+  Widget build(BuildContext context) => Padding(
+    padding: const EdgeInsets.only(bottom: 8),
+    child: Text(text, style: Theme.of(context).textTheme.titleMedium),
+  );
+}
+
+class _DecisionTile extends StatelessWidget {
+  const _DecisionTile({required this.decision, required this.onTap});
+
+  final rust.MeetingDecisionRecord decision;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final status = switch (decision.status) {
+      rust.MeetingDecisionStatus.proposed => 'Proposed',
+      rust.MeetingDecisionStatus.agreed => 'Agreed',
+      rust.MeetingDecisionStatus.rejected => 'Rejected',
+      rust.MeetingDecisionStatus.deferred_ => 'Deferred',
+    };
+    return AiroSurface(
+      level: AiroSurfaceLevel.raised,
+      onTap: onTap,
+      semanticLabel: 'Decision: ${decision.statement}. $status. Show evidence.',
+      child: Padding(
+        padding: const EdgeInsets.symmetric(vertical: 4),
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Icon(
+              Icons.gavel_outlined,
+              size: 20,
+              color: AiroDomainTokens.of(context).accent,
+            ),
+            const SizedBox(width: 12),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(decision.statement),
+                  const SizedBox(height: 4),
+                  Text(
+                    status,
+                    style: Theme.of(context).textTheme.labelMedium,
+                  ),
+                ],
+              ),
+            ),
+            const Icon(Icons.link, size: 18),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _ActionTile extends StatelessWidget {
+  const _ActionTile({
+    required this.item,
+    required this.task,
+    required this.owner,
+    required this.evidenceClock,
+    required this.busy,
+    required this.onToggle,
+    required this.onEvidence,
+    required this.onEdit,
+  });
+
+  final rust.MeetingActionItemRecord item;
+  final String task;
+  final String? owner;
+  final String? evidenceClock;
+  final bool busy;
+  final VoidCallback onToggle;
+  final VoidCallback onEvidence;
+  final VoidCallback onEdit;
+
+  @override
+  Widget build(BuildContext context) {
+    final done = item.status == rust.MeetingActionStatus.done;
+    return AiroSurface(
+      level: AiroSurfaceLevel.raised,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(vertical: 2),
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            if (busy)
+              const Padding(
+                padding: EdgeInsets.all(12),
+                child: SizedBox(
+                  width: 24,
+                  height: 24,
+                  child: CircularProgressIndicator(strokeWidth: 2),
+                ),
+              )
+            else
+              Checkbox(
+                key: Key('meeting_ir_action_check_${item.id}'),
+                value: done,
+                onChanged: (_) => onToggle(),
+              ),
+            Expanded(
+              child: InkWell(
+                onTap: onEvidence,
+                onLongPress: onEdit,
+                child: Padding(
+                  padding: const EdgeInsets.symmetric(vertical: 10),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        task,
+                        style: done
+                            ? Theme.of(context).textTheme.bodyLarge?.copyWith(
+                                decoration: TextDecoration.lineThrough,
+                                color: Theme.of(
+                                  context,
+                                ).colorScheme.onSurfaceVariant,
+                              )
+                            : Theme.of(context).textTheme.bodyLarge,
+                      ),
+                      if (owner != null && owner!.isNotEmpty) ...[
+                        const SizedBox(height: 2),
+                        Text(
+                          owner!,
+                          style: Theme.of(context).textTheme.labelMedium,
+                        ),
+                      ],
+                      if (item.due != null && item.due!.isNotEmpty) ...[
+                        const SizedBox(height: 2),
+                        Text(
+                          'Due ${item.due}',
+                          style: Theme.of(context).textTheme.labelSmall,
+                        ),
+                      ],
+                    ],
+                  ),
+                ),
+              ),
+            ),
+            if (evidenceClock != null)
+              TextButton(
+                key: Key('meeting_ir_action_clock_${item.id}'),
+                onPressed: onEvidence,
+                child: Text(evidenceClock!),
+              ),
+            IconButton(
+              key: Key('meeting_ir_action_edit_${item.id}'),
+              tooltip: 'Edit action',
+              onPressed: onEdit,
+              icon: const Icon(Icons.edit_outlined, size: 20),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _MetricTile extends StatelessWidget {
+  const _MetricTile({required this.metric, required this.onTap});
+
+  final rust.MeetingMetricRecord metric;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return AiroSurface(
+      level: AiroSurfaceLevel.raised,
+      onTap: onTap,
+      semanticLabel:
+          'Number: ${metric.name} ${metric.value}. Show evidence.',
+      child: Padding(
+        padding: const EdgeInsets.symmetric(vertical: 4),
+        child: Row(
+          children: [
+            Icon(
+              Icons.numbers,
+              size: 20,
+              color: AiroDomainTokens.of(context).accent,
+            ),
+            const SizedBox(width: 12),
+            Expanded(
+              child: Text('${metric.name}: ${metric.value}'),
+            ),
+            const Icon(Icons.link, size: 18),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// Timestamped transcript lines with optional evidence highlighting.
+class MeetingIrTranscriptList extends StatelessWidget {
+  const MeetingIrTranscriptList({
+    super.key,
+    required this.segments,
+    required this.highlightedIds,
+    required this.segmentKeys,
+    this.fallbackTranscript = '',
+  });
+
+  final List<TranscriptSegmentView> segments;
+  final Set<String> highlightedIds;
+  final Map<String, GlobalKey> segmentKeys;
+  final String fallbackTranscript;
+
+  @override
+  Widget build(BuildContext context) {
+    if (segments.isEmpty) {
+      if (fallbackTranscript.trim().isEmpty) {
+        return const SizedBox.shrink();
+      }
+      return SelectableText(fallbackTranscript.trim());
+    }
+
+    final scheme = Theme.of(context).colorScheme;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        for (final segment in segments)
+          Container(
+            key: segmentKeys[segment.id],
+            margin: const EdgeInsets.only(bottom: 8),
+            padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 8),
+            decoration: BoxDecoration(
+              color: highlightedIds.contains(segment.id)
+                  ? scheme.tertiaryContainer
+                  : null,
+              borderRadius: BorderRadius.circular(8),
+              border: highlightedIds.contains(segment.id)
+                  ? Border.all(color: scheme.tertiary)
+                  : null,
+            ),
+            child: SelectableText(
+              '${formatTimestamp(segment.startMs)} ${segment.text.trim()}',
+              style: Theme.of(context).textTheme.bodyMedium,
+            ),
+          ),
+      ],
+    );
+  }
+}
+
+/// Lightweight view of a transcript segment for the MoM UI (no Rust import
+/// required by callers that already mapped wire types).
+@immutable
+class TranscriptSegmentView {
+  const TranscriptSegmentView({
+    required this.id,
+    required this.startMs,
+    required this.endMs,
+    required this.text,
+  });
+
+  final String id;
+  final int startMs;
+  final int endMs;
+  final String text;
+
+  factory TranscriptSegmentView.fromEvidence(EvidenceHit hit) =>
+      TranscriptSegmentView(
+        id: hit.segmentId,
+        startMs: hit.startMs,
+        endMs: hit.endMs,
+        text: hit.text,
+      );
+}
+
+/// Banner when the device cannot run a local LLM for extraction (#1658).
+class MeetingIrLowTierBanner extends StatelessWidget {
+  const MeetingIrLowTierBanner({
+    super.key,
+    required this.onUseCloud,
+    required this.onStayLocal,
+  });
+
+  final VoidCallback onUseCloud;
+  final VoidCallback onStayLocal;
+
+  @override
+  Widget build(BuildContext context) {
+    return AiroSurface(
+      level: AiroSurfaceLevel.raised,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            'This device is below the on-device LLM tier',
+            style: Theme.of(context).textTheme.titleSmall,
+          ),
+          const SizedBox(height: 6),
+          Text(
+            'Meeting extraction can run in the cloud with your consent, '
+            'or you can keep everything local and review the transcript only.',
+            style: Theme.of(context).textTheme.bodyMedium,
+          ),
+          const SizedBox(height: 12),
+          Wrap(
+            spacing: 8,
+            children: [
+              FilledButton(
+                key: const Key('meeting_ir_cloud_fallback'),
+                onPressed: onUseCloud,
+                child: const Text('Use cloud'),
+              ),
+              OutlinedButton(
+                key: const Key('meeting_ir_stay_local'),
+                onPressed: onStayLocal,
+                child: const Text('Stay local'),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/packages/feature_mind/lib/src/meeting_screen.dart
+++ b/packages/feature_mind/lib/src/meeting_screen.dart
@@ -1,7 +1,13 @@
+import 'package:core_ui/core_ui.dart';
 import 'package:flutter/material.dart';
 
+import 'bridges/mind_speech_bridge.dart' show TranscriptSegment;
 import 'export/application/meeting_export_service.dart';
 import 'export/data/meeting_export_gateway.dart';
+import 'meeting_ir/evidence_resolver.dart';
+import 'meeting_ir/meeting_ir_user_edits.dart';
+import 'meeting_ir/meeting_ir_user_edits_store.dart';
+import 'meeting_ir/meeting_ir_widgets.dart';
 import 'whisper/api/meetings.dart' as rust;
 import 'mind_service.dart';
 import 'trust/scribe_trust_signals.dart';
@@ -12,12 +18,20 @@ import 'trust/scribe_trust_signals.dart';
 /// times: "watch processing" is reading the transcript early. A separate
 /// progress screen would mean two layouts to keep in step and a jarring swap at
 /// the moment the user is most attentive.
+///
+/// #1658 extends this screen (does not replace it) with Meeting-IR MoM
+/// sections, checkable actions, evidence tracing, and user-edit overlays.
 class MeetingScreen extends StatefulWidget {
   /// Live: the pipeline is running and this stream is producing it.
   const MeetingScreen.live({
     required this.service,
     required this.title,
     required Stream<MindProgress> this._progress,
+    this.meetingIntelligenceEnabled = true,
+    this.showLowTierCloudChoice = false,
+    this.onCloudFallback,
+    this.onSeekAudio,
+    this.userEditsStore,
     super.key,
   }) : _meeting = null;
 
@@ -25,6 +39,11 @@ class MeetingScreen extends StatefulWidget {
   const MeetingScreen.stored({
     required this.service,
     required rust.MeetingRecord this._meeting,
+    this.meetingIntelligenceEnabled = true,
+    this.showLowTierCloudChoice = false,
+    this.onCloudFallback,
+    this.onSeekAudio,
+    this.userEditsStore,
     super.key,
   }) : _progress = null,
        title = '';
@@ -34,12 +53,30 @@ class MeetingScreen extends StatefulWidget {
   final Stream<MindProgress>? _progress;
   final rust.MeetingRecord? _meeting;
 
+  /// Pro / launch-promo seam: when false, IR MoM review is locked (AC).
+  /// Open-source builds leave this true (`LaunchPromoEntitlements`).
+  final bool meetingIntelligenceEnabled;
+
+  /// Device below LLM tier (#1658): show cloud-fallback choice, not a crash.
+  final bool showLowTierCloudChoice;
+
+  /// Invoked when the user picks cloud fallback from the low-tier banner.
+  final VoidCallback? onCloudFallback;
+
+  /// Optional audio seek when evidence is tapped (`startMs`). No player is
+  /// wired in feature_mind yet — shells may supply one.
+  final void Function(int startMs)? onSeekAudio;
+
+  /// Override for tests. Defaults to a SharedPreferences-backed store.
+  final MeetingIrUserEditsStore? userEditsStore;
+
   @override
   State<MeetingScreen> createState() => _MeetingScreenState();
 }
 
 class _MeetingScreenState extends State<MeetingScreen> {
   late MindProgress _progress;
+  rust.MeetingRecord? _meeting;
 
   // #1663: markdown export. Constructed here rather than injected — like
   // `MindService`'s own defaults, the production path is the only path this
@@ -49,10 +86,24 @@ class _MeetingScreenState extends State<MeetingScreen> {
   final _exportGateway = const PlatformMeetingExportGateway();
   bool _exporting = false;
 
+  late final MeetingIrUserEditsStore _editsStore =
+      widget.userEditsStore ?? MeetingIrUserEditsStore();
+  MeetingIrUserEdits _edits = const MeetingIrUserEdits();
+  final _evidence = const EvidenceResolver();
+
+  Map<String, TranscriptSegmentView> _segmentsById = const {};
+  List<TranscriptSegmentView> _orderedSegments = const [];
+  Set<String> _highlightedIds = const {};
+  final Map<String, GlobalKey> _segmentKeys = {};
+  String? _busyActionId;
+  bool _dismissedLowTier = false;
+  int? _pendingSeekMs;
+
   @override
   void initState() {
     super.initState();
     final stored = widget._meeting;
+    _meeting = stored;
     _progress = stored == null
         ? const MindProgress(stage: MindStage.transcribing)
         : MindProgress(
@@ -63,7 +114,15 @@ class _MeetingScreenState extends State<MeetingScreen> {
           );
     widget._progress?.listen(
       (p) {
-        if (mounted) setState(() => _progress = p);
+        if (mounted) {
+          setState(() {
+            _progress = p;
+            _syncLiveSegments();
+          });
+          if (p.meetingId != null && _meeting == null) {
+            _reloadMeeting(p.meetingId!);
+          }
+        }
       },
       // A stream error still has to reach the screen: silently ending on a
       // half-finished transcript is the failure that looks like a hang.
@@ -78,6 +137,71 @@ class _MeetingScreenState extends State<MeetingScreen> {
         }
       },
     );
+    if (stored != null) {
+      _loadIrContext(stored);
+    } else {
+      _syncLiveSegments();
+    }
+  }
+
+  void _syncLiveSegments() {
+    if (_progress.segments.isEmpty) return;
+    _orderedSegments = [
+      for (final s in _progress.segments)
+        TranscriptSegmentView(
+          id: s.id,
+          startMs: s.startMs,
+          endMs: s.endMs,
+          text: s.text,
+        ),
+    ];
+    _segmentsById = {for (final s in _orderedSegments) s.id: s};
+    for (final s in _orderedSegments) {
+      _segmentKeys.putIfAbsent(s.id, GlobalKey.new);
+    }
+  }
+
+  Future<void> _loadIrContext(rust.MeetingRecord meeting) async {
+    final edits = await _editsStore.load(meeting.id);
+    final doc = await widget.service.transcriptDocument(meeting.id);
+    final byId = _evidence.indexFromDocument(doc);
+    final ordered = [
+      for (final s in doc?.segments ?? const <rust.TranscriptSegmentRecord>[])
+        TranscriptSegmentView(
+          id: s.id,
+          startMs: s.startMs.toInt(),
+          endMs: s.endMs.toInt(),
+          text: s.text,
+        ),
+    ];
+    if (!mounted) return;
+    setState(() {
+      _edits = edits;
+      _orderedSegments = ordered.isNotEmpty
+          ? ordered
+          : [
+              // Flat transcript only — no segment ids to highlight against.
+            ];
+      _segmentsById = {
+        for (final e in byId.entries)
+          e.key: TranscriptSegmentView(
+            id: e.value.id,
+            startMs: e.value.startMs,
+            endMs: e.value.endMs,
+            text: e.value.text,
+          ),
+      };
+      for (final s in _orderedSegments) {
+        _segmentKeys.putIfAbsent(s.id, GlobalKey.new);
+      }
+    });
+  }
+
+  Future<void> _reloadMeeting(String id) async {
+    final meeting = await widget.service.meeting(id);
+    if (meeting == null || !mounted) return;
+    setState(() => _meeting = meeting);
+    await _loadIrContext(meeting);
   }
 
   bool get _isRunning =>
@@ -90,7 +214,7 @@ class _MeetingScreenState extends State<MeetingScreen> {
   /// (not-yet-saved) meeting — there is no [MeetingScreen.stored]'s
   /// `_meeting.id` to export until the pipeline finishes.
   Future<void> _export({required bool share}) async {
-    final meetingId = widget._meeting?.id ?? _progress.meetingId;
+    final meetingId = _meeting?.id ?? _progress.meetingId;
     if (meetingId == null || _exporting) return;
 
     setState(() => _exporting = true);
@@ -122,16 +246,148 @@ class _MeetingScreenState extends State<MeetingScreen> {
 
   String get _stageLabel => switch (_progress.stage) {
     MindStage.transcribing => 'Transcribing…',
-    MindStage.generating => 'Writing minutes…',
+    MindStage.generating => 'Extracting…',
     MindStage.saving => 'Saving…',
-    MindStage.done => 'Saved on this device',
+    MindStage.done => 'Ready',
     MindStage.failed => 'Failed',
     _ => '',
   };
 
+  void _onEvidence(List<String> evidenceSegmentIds) {
+    final hits = _evidence.resolve(
+      evidenceSegmentIds: evidenceSegmentIds,
+      byId: {
+        for (final e in _segmentsById.entries)
+          e.key: TranscriptSegment(
+            id: e.value.id,
+            startMs: e.value.startMs,
+            endMs: e.value.endMs,
+            text: e.value.text,
+          ),
+      },
+    );
+    final ids = {for (final h in hits) h.segmentId};
+    final seekMs = hits.isEmpty ? null : hits.first.startMs;
+    setState(() {
+      _highlightedIds = ids;
+      _pendingSeekMs = seekMs;
+    });
+    if (seekMs != null) {
+      widget.onSeekAudio?.call(seekMs);
+    }
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted || ids.isEmpty) return;
+      final key = _segmentKeys[ids.first];
+      final ctx = key?.currentContext;
+      if (ctx != null) {
+        Scrollable.ensureVisible(
+          ctx,
+          duration: const Duration(milliseconds: 280),
+          alignment: 0.2,
+          curve: Curves.easeOut,
+        );
+      }
+    });
+  }
+
+  Future<void> _toggleAction(rust.MeetingActionItemRecord item) async {
+    final meeting = _meeting;
+    if (meeting == null || _busyActionId != null) return;
+    final next = item.status == rust.MeetingActionStatus.done
+        ? rust.MeetingActionStatus.open
+        : rust.MeetingActionStatus.done;
+    setState(() => _busyActionId = item.id);
+    try {
+      final updated = await widget.service.updateActionItemStatus(
+        meeting: meeting,
+        actionItemId: item.id,
+        status: next,
+      );
+      if (!mounted) return;
+      setState(() {
+        _meeting = updated;
+        _busyActionId = null;
+      });
+    } on Object catch (e) {
+      if (!mounted) return;
+      setState(() => _busyActionId = null);
+      _notify('Could not update action: $e');
+    }
+  }
+
+  Future<void> _editAction(rust.MeetingActionItemRecord item) async {
+    final meeting = _meeting;
+    if (meeting == null) return;
+    final taskController = TextEditingController(text: _edits.taskFor(item));
+    final ownerController = TextEditingController(
+      text: _edits.ownerFor(item) ?? item.owner ?? '',
+    );
+    final saved = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: const Text('Edit action'),
+        content: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            TextField(
+              key: const Key('meeting_ir_edit_task'),
+              controller: taskController,
+              decoration: const InputDecoration(labelText: 'Task'),
+              maxLines: 3,
+            ),
+            TextField(
+              key: const Key('meeting_ir_edit_owner'),
+              controller: ownerController,
+              decoration: const InputDecoration(labelText: 'Owner'),
+            ),
+          ],
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(ctx).pop(false),
+            child: const Text('Cancel'),
+          ),
+          FilledButton(
+            key: const Key('meeting_ir_edit_save'),
+            onPressed: () => Navigator.of(ctx).pop(true),
+            child: const Text('Save'),
+          ),
+        ],
+      ),
+    );
+    if (saved != true || !mounted) {
+      taskController.dispose();
+      ownerController.dispose();
+      return;
+    }
+    final next = await _editsStore.upsert(
+      meetingId: meeting.id,
+      actionId: item.id,
+      edit: MeetingActionUserEdit(
+        task: taskController.text.trim().isEmpty
+            ? item.task
+            : taskController.text.trim(),
+        owner: ownerController.text.trim(),
+      ),
+    );
+    taskController.dispose();
+    ownerController.dispose();
+    if (!mounted) return;
+    setState(() => _edits = next);
+  }
+
   @override
   Widget build(BuildContext context) {
-    final stored = widget._meeting;
+    final stored = _meeting ?? widget._meeting;
+    final hasIr =
+        stored != null &&
+        (stored.decisions.isNotEmpty ||
+            stored.actionItems.isNotEmpty ||
+            stored.metrics.isNotEmpty);
+    final showMinutesFallback =
+        _progress.minutes.isNotEmpty &&
+        (!hasIr || !widget.meetingIntelligenceEnabled);
+
     return Scaffold(
       appBar: AppBar(
         title: Text(stored?.title ?? widget.title),
@@ -164,53 +420,117 @@ class _MeetingScreenState extends State<MeetingScreen> {
             ),
         ],
       ),
-      body: ListView(
-        padding: const EdgeInsets.all(16),
-        children: [
-          ScribeTrustSignals(
-            state: widget.service.scribeTrustState(),
+      // ResponsiveStandards: constrain reading width on tablet/desktop.
+      body: Center(
+        child: ConstrainedBox(
+          constraints: const BoxConstraints(maxWidth: 800),
+          child: ListView(
+            padding: const EdgeInsets.all(16),
+            children: [
+              ScribeTrustSignals(
+                state: widget.service.scribeTrustState(),
+              ),
+              const SizedBox(height: 12),
+              if (_isRunning) const LinearProgressIndicator(),
+              if (_stageLabel.isNotEmpty)
+                Padding(
+                  padding: const EdgeInsets.symmetric(vertical: 12),
+                  child: Text(
+                    _stageLabel,
+                    style: Theme.of(context).textTheme.labelLarge,
+                  ),
+                ),
+              if (widget.showLowTierCloudChoice && !_dismissedLowTier) ...[
+                MeetingIrLowTierBanner(
+                  onUseCloud: () {
+                    widget.onCloudFallback?.call();
+                    setState(() => _dismissedLowTier = true);
+                  },
+                  onStayLocal: () => setState(() => _dismissedLowTier = true),
+                ),
+                const SizedBox(height: 16),
+              ],
+              if (_progress.error != null)
+                Card(
+                  color: Theme.of(context).colorScheme.errorContainer,
+                  child: Padding(
+                    padding: const EdgeInsets.all(12),
+                    child: Text(_progress.error!),
+                  ),
+                ),
+              if (!widget.meetingIntelligenceEnabled && stored != null)
+                Padding(
+                  padding: const EdgeInsets.only(bottom: 16),
+                  child: AiroSurface(
+                    level: AiroSurfaceLevel.raised,
+                    child: Text(
+                      'Meeting intelligence is a Pro feature on this build.',
+                      style: Theme.of(context).textTheme.bodyMedium,
+                    ),
+                  ),
+                ),
+              if (widget.meetingIntelligenceEnabled && stored != null)
+                MeetingIrMomSections(
+                  decisions: stored.decisions,
+                  actionItems: stored.actionItems,
+                  metrics: stored.metrics,
+                  edits: _edits,
+                  segmentsById: _segmentsById,
+                  busyActionId: _busyActionId,
+                  onEvidence: _onEvidence,
+                  onToggleAction: _toggleAction,
+                  onEditAction: _editAction,
+                  formatClock: formatEvidenceClock,
+                ),
+              if (showMinutesFallback) ...[
+                const _SectionTitle('Minutes'),
+                SelectableText(_progress.minutes.trim()),
+                const SizedBox(height: 24),
+              ],
+              if (_progress.transcript.isNotEmpty ||
+                  _orderedSegments.isNotEmpty) ...[
+                const _SectionTitle('Transcript'),
+                if (_pendingSeekMs != null)
+                  Padding(
+                    padding: const EdgeInsets.only(bottom: 8),
+                    child: Text(
+                      'Evidence at ${formatEvidenceClock(_pendingSeekMs!)}',
+                      key: const Key('meeting_ir_evidence_clock'),
+                      style: Theme.of(context).textTheme.labelMedium,
+                    ),
+                  ),
+                MeetingIrTranscriptList(
+                  segments: _orderedSegments,
+                  highlightedIds: _highlightedIds,
+                  segmentKeys: _segmentKeys,
+                  fallbackTranscript: _progress.transcript,
+                ),
+              ],
+              if (stored != null) ...[
+                const SizedBox(height: 24),
+                // Which model wrote the minutes, per ADR-0018. Shown rather than
+                // stored-and-hidden: a summary is a model's reading of a meeting,
+                // and the user is entitled to know whose reading it was.
+                Text(
+                  'Minutes by ${stored.model}',
+                  style: Theme.of(context).textTheme.bodySmall,
+                ),
+              ],
+            ],
           ),
-          const SizedBox(height: 12),
-          if (_isRunning) const LinearProgressIndicator(),
-          if (_stageLabel.isNotEmpty)
-            Padding(
-              padding: const EdgeInsets.symmetric(vertical: 12),
-              child: Text(
-                _stageLabel,
-                style: Theme.of(context).textTheme.labelLarge,
-              ),
-            ),
-          if (_progress.error != null)
-            Card(
-              color: Theme.of(context).colorScheme.errorContainer,
-              child: Padding(
-                padding: const EdgeInsets.all(12),
-                child: Text(_progress.error!),
-              ),
-            ),
-          if (_progress.minutes.isNotEmpty) ...[
-            const _SectionTitle('Minutes'),
-            SelectableText(_progress.minutes.trim()),
-            const SizedBox(height: 24),
-          ],
-          if (_progress.transcript.isNotEmpty) ...[
-            const _SectionTitle('Transcript'),
-            SelectableText(_progress.transcript.trim()),
-          ],
-          if (stored != null) ...[
-            const SizedBox(height: 24),
-            // Which model wrote the minutes, per ADR-0018. Shown rather than
-            // stored-and-hidden: a summary is a model's reading of a meeting,
-            // and the user is entitled to know whose reading it was.
-            Text(
-              'Minutes by ${stored.model}',
-              style: Theme.of(context).textTheme.bodySmall,
-            ),
-          ],
-        ],
+        ),
       ),
     );
   }
+}
+
+/// `mm:ss` for the evidence clock chip (shorter than export's `[hh:mm:ss]`).
+String formatEvidenceClock(int ms) {
+  final totalSeconds = ms ~/ 1000;
+  final minutes = totalSeconds ~/ 60;
+  final seconds = totalSeconds % 60;
+  return '${minutes.toString().padLeft(2, '0')}:'
+      '${seconds.toString().padLeft(2, '0')}';
 }
 
 class _SectionTitle extends StatelessWidget {

--- a/packages/feature_mind/lib/src/meeting_screen.dart
+++ b/packages/feature_mind/lib/src/meeting_screen.dart
@@ -427,9 +427,7 @@ class _MeetingScreenState extends State<MeetingScreen> {
           child: ListView(
             padding: const EdgeInsets.all(16),
             children: [
-              ScribeTrustSignals(
-                state: widget.service.scribeTrustState(),
-              ),
+              ScribeTrustSignals(state: widget.service.scribeTrustState()),
               const SizedBox(height: 12),
               if (_isRunning) const LinearProgressIndicator(),
               if (_stageLabel.isNotEmpty)

--- a/packages/feature_mind/lib/src/mind_home_screen.dart
+++ b/packages/feature_mind/lib/src/mind_home_screen.dart
@@ -349,7 +349,7 @@ class _MindHomeScreenState extends State<MindHomeScreen> {
         return ListTile(
           title: Text(m.title),
           subtitle: Text(
-            m.minutes.trim().isEmpty ? m.transcript : m.minutes.trim(),
+            meetingListPreview(m),
             maxLines: 2,
             overflow: TextOverflow.ellipsis,
           ),
@@ -358,6 +358,24 @@ class _MindHomeScreenState extends State<MindHomeScreen> {
       },
     );
   }
+}
+
+/// Cheap list subtitle: minutes first, else first action/decision text, else
+/// transcript. Keeps IR discoverable without an extra store round-trip.
+@visibleForTesting
+String meetingListPreview(rust.MeetingRecord meeting) {
+  final minutes = meeting.minutes.trim();
+  if (minutes.isNotEmpty) return minutes;
+
+  if (meeting.actionItems.isNotEmpty) {
+    final item = meeting.actionItems.first;
+    final owner = item.owner?.trim();
+    return owner == null || owner.isEmpty ? item.task : '${item.task} — $owner';
+  }
+  if (meeting.decisions.isNotEmpty) {
+    return meeting.decisions.first.statement;
+  }
+  return meeting.transcript;
 }
 
 /// Shown while [MindService.initialize] is in flight. Nothing to show yet

--- a/packages/feature_mind/lib/src/mind_home_screen.dart
+++ b/packages/feature_mind/lib/src/mind_home_screen.dart
@@ -263,9 +263,7 @@ class _MindHomeScreenState extends State<MindHomeScreen> {
       children: [
         Padding(
           padding: const EdgeInsets.fromLTRB(12, 12, 12, 0),
-          child: ScribeTrustSignals(
-            state: widget.service.scribeTrustState(),
-          ),
+          child: ScribeTrustSignals(state: widget.service.scribeTrustState()),
         ),
         Padding(
           padding: const EdgeInsets.all(12),

--- a/packages/feature_mind/lib/src/mind_service.dart
+++ b/packages/feature_mind/lib/src/mind_service.dart
@@ -9,6 +9,7 @@ import 'package:record/record.dart';
 
 import 'bridges/mind_generation_bridge.dart';
 import 'bridges/mind_speech_bridge.dart';
+import 'meeting_ir/meeting_ir_status_writer.dart';
 import 'model_installer.dart';
 import 'models/model_provider.dart';
 import 'search/meeting_embedding_store.dart';
@@ -519,6 +520,18 @@ class MindService {
   /// (a meeting saved before this feature shipped, or an unknown id).
   Future<rust.TranscriptDocumentRecord?> transcriptDocument(String meetingId) =>
       _speech.getTranscript(meetingId);
+
+  /// #1658 / MIND-LLM-16: checkable action status writes back through the
+  /// existing `saveMeeting` path (append-only, latest wins) — no new store.
+  Future<rust.MeetingRecord> updateActionItemStatus({
+    required rust.MeetingRecord meeting,
+    required String actionItemId,
+    required rust.MeetingActionStatus status,
+  }) => MeetingIrStatusWriter(_speech).updateActionStatus(
+    meeting: meeting,
+    actionItemId: actionItemId,
+    status: status,
+  );
 
   /// Releases the microphone and the model provider. The provider matters
   /// because the download-backed one holds a subscription to the platform

--- a/packages/feature_mind/lib/src/search/semantic_search_ranker.dart
+++ b/packages/feature_mind/lib/src/search/semantic_search_ranker.dart
@@ -147,10 +147,7 @@ class SemanticSearchRanker {
     rust.MeetingRecord meeting, {
     List<String> segmentTexts = const [],
   }) async {
-    final vectors = await _computeAndStore(
-      meeting,
-      segmentTexts: segmentTexts,
-    );
+    final vectors = await _computeAndStore(meeting, segmentTexts: segmentTexts);
     return vectors != null;
   }
 

--- a/packages/feature_mind/lib/src/search/semantic_search_ranker.dart
+++ b/packages/feature_mind/lib/src/search/semantic_search_ranker.dart
@@ -270,9 +270,7 @@ class SemanticSearchRanker {
   static const _maxSnippetLength = 160;
 
   rust.SearchHit _hitFor(rust.MeetingRecord meeting) {
-    final source = meeting.minutes.trim().isNotEmpty
-        ? meeting.minutes.trim()
-        : meeting.transcript.trim();
+    final source = _snippetSource(meeting);
     final snippet = source.length > _maxSnippetLength
         ? '${source.substring(0, _maxSnippetLength)}…'
         : source;
@@ -282,6 +280,21 @@ class SemanticSearchRanker {
       recordedAt: meeting.recordedAt,
       snippet: snippet,
     );
+  }
+
+  /// Prefer minutes, then first action/decision, then transcript — same cheap
+  /// order as the meeting list preview so IR-only meetings still show why
+  /// they matched.
+  String _snippetSource(rust.MeetingRecord meeting) {
+    final minutes = meeting.minutes.trim();
+    if (minutes.isNotEmpty) return minutes;
+    if (meeting.actionItems.isNotEmpty) {
+      return meeting.actionItems.first.task.trim();
+    }
+    if (meeting.decisions.isNotEmpty) {
+      return meeting.decisions.first.statement.trim();
+    }
+    return meeting.transcript.trim();
   }
 }
 

--- a/packages/feature_mind/test/export/meeting_export_service_test.dart
+++ b/packages/feature_mind/test/export/meeting_export_service_test.dart
@@ -143,6 +143,73 @@ void main() {
     });
 
     test(
+      'includes structured action items in mom.md when minutes have no '
+      'Action Items section',
+      () async {
+        when(() => mind.meeting('m5')).thenAnswer(
+          (_) async => _meeting(
+            id: 'm5',
+            minutes: '## Summary\n\nShip the IR UI.',
+            actionItems: const [
+              rust.MeetingActionItemRecord(
+                id: 'a0',
+                task: 'Wire evidence timestamps',
+                owner: 'Priya',
+                due: 'Friday',
+                status: rust.MeetingActionStatus.open,
+                evidenceSegmentIds: ['s2'],
+              ),
+            ],
+          ),
+        );
+        when(() => mind.transcriptDocument('m5')).thenAnswer((_) async => null);
+
+        final bundle = await service.exportMeeting('m5');
+
+        expect(bundle!.files.keys, containsAll(['transcript.md', 'mom.md']));
+        final mom = bundle.files['mom.md']!;
+        expect(mom, contains('## Action Items'));
+        expect(mom, contains('Wire evidence timestamps'));
+        expect(mom, contains('Priya'));
+        expect(mom, contains('Friday'));
+        expect(mom, contains('Open'));
+      },
+    );
+
+    test(
+      'writes action-items.md when minutes are empty but IR actions exist',
+      () async {
+        when(() => mind.meeting('m6')).thenAnswer(
+          (_) async => _meeting(
+            id: 'm6',
+            actionItems: const [
+              rust.MeetingActionItemRecord(
+                id: 'a0',
+                task: 'Follow up with design',
+                status: rust.MeetingActionStatus.inProgress,
+                evidenceSegmentIds: [],
+              ),
+            ],
+          ),
+        );
+        when(() => mind.transcriptDocument('m6')).thenAnswer((_) async => null);
+
+        final bundle = await service.exportMeeting('m6');
+
+        expect(
+          bundle!.files.keys,
+          containsAll(['transcript.md', 'action-items.md']),
+        );
+        expect(bundle.files.containsKey('mom.md'), isFalse);
+        expect(
+          bundle.files['action-items.md'],
+          contains('Follow up with design'),
+        );
+        expect(bundle.files['action-items.md'], contains('In progress'));
+      },
+    );
+
+    test(
       'renders correctly even past the off-main isolate threshold',
       () async {
         final longText = 'word ' * 20000; // well past 50 KB

--- a/packages/feature_mind/test/export/meeting_export_service_test.dart
+++ b/packages/feature_mind/test/export/meeting_export_service_test.dart
@@ -142,39 +142,36 @@ void main() {
       expect(bundle!.files.keys, ['transcript.md']);
     });
 
-    test(
-      'includes structured action items in mom.md when minutes have no '
-      'Action Items section',
-      () async {
-        when(() => mind.meeting('m5')).thenAnswer(
-          (_) async => _meeting(
-            id: 'm5',
-            minutes: '## Summary\n\nShip the IR UI.',
-            actionItems: const [
-              rust.MeetingActionItemRecord(
-                id: 'a0',
-                task: 'Wire evidence timestamps',
-                owner: 'Priya',
-                due: 'Friday',
-                status: rust.MeetingActionStatus.open,
-                evidenceSegmentIds: ['s2'],
-              ),
-            ],
-          ),
-        );
-        when(() => mind.transcriptDocument('m5')).thenAnswer((_) async => null);
+    test('includes structured action items in mom.md when minutes have no '
+        'Action Items section', () async {
+      when(() => mind.meeting('m5')).thenAnswer(
+        (_) async => _meeting(
+          id: 'm5',
+          minutes: '## Summary\n\nShip the IR UI.',
+          actionItems: const [
+            rust.MeetingActionItemRecord(
+              id: 'a0',
+              task: 'Wire evidence timestamps',
+              owner: 'Priya',
+              due: 'Friday',
+              status: rust.MeetingActionStatus.open,
+              evidenceSegmentIds: ['s2'],
+            ),
+          ],
+        ),
+      );
+      when(() => mind.transcriptDocument('m5')).thenAnswer((_) async => null);
 
-        final bundle = await service.exportMeeting('m5');
+      final bundle = await service.exportMeeting('m5');
 
-        expect(bundle!.files.keys, containsAll(['transcript.md', 'mom.md']));
-        final mom = bundle.files['mom.md']!;
-        expect(mom, contains('## Action Items'));
-        expect(mom, contains('Wire evidence timestamps'));
-        expect(mom, contains('Priya'));
-        expect(mom, contains('Friday'));
-        expect(mom, contains('Open'));
-      },
-    );
+      expect(bundle!.files.keys, containsAll(['transcript.md', 'mom.md']));
+      final mom = bundle.files['mom.md']!;
+      expect(mom, contains('## Action Items'));
+      expect(mom, contains('Wire evidence timestamps'));
+      expect(mom, contains('Priya'));
+      expect(mom, contains('Friday'));
+      expect(mom, contains('Open'));
+    });
 
     test(
       'writes action-items.md when minutes are empty but IR actions exist',

--- a/packages/feature_mind/test/meeting_ir/evidence_resolver_test.dart
+++ b/packages/feature_mind/test/meeting_ir/evidence_resolver_test.dart
@@ -1,0 +1,53 @@
+import 'package:feature_mind/src/bridges/mind_speech_bridge.dart';
+import 'package:feature_mind/src/meeting_ir/evidence_resolver.dart';
+import 'package:feature_mind/src/whisper/api/meetings.dart' as rust;
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  const resolver = EvidenceResolver();
+
+  test('indexFromDocument maps segment ids', () {
+    final doc = rust.TranscriptDocumentRecord(
+      meetingId: 'm1',
+      audioPath: '/tmp/a.wav',
+      modelVersion: 'whisper@1',
+      segments: [
+        rust.TranscriptSegmentRecord(
+          id: 's0',
+          startMs: BigInt.from(0),
+          endMs: BigInt.from(500),
+          text: 'hello',
+        ),
+        rust.TranscriptSegmentRecord(
+          id: 's1',
+          startMs: BigInt.from(500),
+          endMs: BigInt.from(900),
+          text: 'world',
+        ),
+      ],
+    );
+    final byId = resolver.indexFromDocument(doc);
+    expect(byId.keys, ['s0', 's1']);
+    expect(byId['s1']!.text, 'world');
+  });
+
+  test('resolve skips unknown evidence ids and preserves order', () {
+    final byId = resolver.indexFromSegments(const [
+      TranscriptSegment(id: 's0', startMs: 0, endMs: 100, text: 'a'),
+      TranscriptSegment(id: 's2', startMs: 200, endMs: 300, text: 'c'),
+    ]);
+    final hits = resolver.resolve(
+      evidenceSegmentIds: const ['s2', 'missing', 's0'],
+      byId: byId,
+    );
+    expect(hits.map((h) => h.segmentId), ['s2', 's0']);
+    expect(hits.first.startMs, 200);
+  });
+
+  test('firstStartMs is null when nothing resolves', () {
+    expect(
+      resolver.firstStartMs(evidenceSegmentIds: const ['x'], byId: const {}),
+      isNull,
+    );
+  });
+}

--- a/packages/feature_mind/test/meeting_ir/meeting_ir_status_writer_test.dart
+++ b/packages/feature_mind/test/meeting_ir/meeting_ir_status_writer_test.dart
@@ -1,0 +1,73 @@
+import 'package:feature_mind/src/meeting_ir/meeting_ir_status_writer.dart';
+import 'package:feature_mind/src/whisper/api/meetings.dart' as rust;
+import 'package:flutter_test/flutter_test.dart';
+
+import '../support/fake_bridges.dart';
+
+void main() {
+  test('recordedAtMsFor parses m{ms} ids', () {
+    final meeting = rust.MeetingRecord(
+      id: 'm1700000000123',
+      title: 't',
+      recordedAt: BigInt.from(1700000000),
+      transcript: '',
+      minutes: '',
+      model: 'm',
+      decisions: const [],
+      actionItems: const [],
+      metrics: const [],
+    );
+    expect(MeetingIrStatusWriter.recordedAtMsFor(meeting), 1700000000123);
+  });
+
+  test('updateActionStatus re-saves through the speech bridge', () async {
+    final speech = FakeMindSpeechBridge()
+      ..transcriptDocumentToReturn = rust.TranscriptDocumentRecord(
+        meetingId: 'm1700000000123',
+        audioPath: '/tmp/a.wav',
+        modelVersion: 'w',
+        segments: [
+          rust.TranscriptSegmentRecord(
+            id: 's0',
+            startMs: BigInt.zero,
+            endMs: BigInt.from(100),
+            text: 'hi',
+          ),
+        ],
+      );
+
+    final meeting = rust.MeetingRecord(
+      id: 'm1700000000123',
+      title: 'Standup',
+      recordedAt: BigInt.from(1700000000),
+      transcript: 'hi',
+      minutes: '- x',
+      model: 'qwen',
+      decisions: const [],
+      actionItems: const [
+        rust.MeetingActionItemRecord(
+          id: 'a1',
+          task: 'Ship it',
+          owner: 'Dev',
+          status: rust.MeetingActionStatus.open,
+          evidenceSegmentIds: ['s0'],
+        ),
+      ],
+      metrics: const [],
+    );
+
+    final updated = await MeetingIrStatusWriter(speech).updateActionStatus(
+      meeting: meeting,
+      actionItemId: 'a1',
+      status: rust.MeetingActionStatus.done,
+    );
+
+    expect(updated.actionItems.single.status, rust.MeetingActionStatus.done);
+    expect(
+      speech.savedActionItems!.single.status,
+      rust.MeetingActionStatus.done,
+    );
+    expect(speech.savedWavPath, '/tmp/a.wav');
+    expect(speech.savedSegments, isNotEmpty);
+  });
+}

--- a/packages/feature_mind/test/meeting_ir/meeting_ir_user_edits_test.dart
+++ b/packages/feature_mind/test/meeting_ir/meeting_ir_user_edits_test.dart
@@ -1,0 +1,58 @@
+import 'package:feature_mind/src/meeting_ir/meeting_ir_user_edits.dart';
+import 'package:feature_mind/src/whisper/api/meetings.dart' as rust;
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  const item = rust.MeetingActionItemRecord(
+    id: 'a1',
+    task: 'Ship pods',
+    owner: 'Priya',
+    status: rust.MeetingActionStatus.open,
+    evidenceSegmentIds: ['s0'],
+  );
+
+  test('display helpers prefer user edits over IR', () {
+    final edits = const MeetingIrUserEdits().upsert(
+      'a1',
+      const MeetingActionUserEdit(task: 'Ship three pods', owner: 'Dev'),
+    );
+    expect(edits.taskFor(item), 'Ship three pods');
+    expect(edits.ownerFor(item), 'Dev');
+  });
+
+  test('empty-string owner clears the IR owner', () {
+    final edits = const MeetingIrUserEdits().upsert(
+      'a1',
+      const MeetingActionUserEdit(owner: ''),
+    );
+    expect(edits.ownerFor(item), isNull);
+    expect(edits.taskFor(item), 'Ship pods');
+  });
+
+  test('round-trips through JSON without dropping edits', () {
+    final edits = const MeetingIrUserEdits().upsert(
+      'a1',
+      const MeetingActionUserEdit(task: 'Fixed', owner: 'Sam'),
+    );
+    final again = MeetingIrUserEdits.decode(edits.encode());
+    expect(again.taskFor(item), 'Fixed');
+    expect(again.ownerFor(item), 'Sam');
+  });
+
+  test('re-extraction with same action id keeps user edits', () {
+    // Simulated: extraction rewrote task text on the Meeting record, but the
+    // user edit overlay still wins on display.
+    final edits = const MeetingIrUserEdits().upsert(
+      'a1',
+      const MeetingActionUserEdit(task: 'User correction'),
+    );
+    const reextracted = rust.MeetingActionItemRecord(
+      id: 'a1',
+      task: 'Model said something else',
+      owner: 'Priya',
+      status: rust.MeetingActionStatus.open,
+      evidenceSegmentIds: ['s0'],
+    );
+    expect(edits.taskFor(reextracted), 'User correction');
+  });
+}

--- a/packages/feature_mind/test/meeting_ir/meeting_screen_ir_test.dart
+++ b/packages/feature_mind/test/meeting_ir/meeting_screen_ir_test.dart
@@ -14,9 +14,8 @@ class _FakeMind extends MindService {
   rust.MeetingRecord? lastStatusUpdate;
 
   @override
-  Future<MindStatus> initialize({
-    rust.SpeechLanguage? speechLanguage,
-  }) async => const MindStatus.ready();
+  Future<MindStatus> initialize({rust.SpeechLanguage? speechLanguage}) async =>
+      const MindStatus.ready();
 
   @override
   Future<List<rust.MeetingRecord>> meetings() async => library;
@@ -233,13 +232,9 @@ void main() {
   testWidgets('user edit overlay wins over IR task text', (tester) async {
     final meeting = _irMeeting();
     SharedPreferences.setMockInitialValues({
-      'mind.meeting_ir.user_edits.m1700000000123':
-          const MeetingIrUserEdits()
-              .upsert(
-                'a1',
-                const MeetingActionUserEdit(task: 'Ship four pods'),
-              )
-              .encode(),
+      'mind.meeting_ir.user_edits.m1700000000123': const MeetingIrUserEdits()
+          .upsert('a1', const MeetingActionUserEdit(task: 'Ship four pods'))
+          .encode(),
     });
     await tester.pumpWidget(
       _app(

--- a/packages/feature_mind/test/meeting_ir/meeting_screen_ir_test.dart
+++ b/packages/feature_mind/test/meeting_ir/meeting_screen_ir_test.dart
@@ -1,0 +1,282 @@
+import 'package:feature_mind/feature_mind.dart';
+import 'package:feature_mind/src/meeting_ir/meeting_ir_user_edits.dart';
+import 'package:feature_mind/src/meeting_ir/meeting_ir_user_edits_store.dart';
+import 'package:feature_mind/src/whisper/api/meetings.dart' as rust;
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class _FakeMind extends MindService {
+  _FakeMind({this.library = const [], this.doc});
+
+  final List<rust.MeetingRecord> library;
+  final rust.TranscriptDocumentRecord? doc;
+  rust.MeetingRecord? lastStatusUpdate;
+
+  @override
+  Future<MindStatus> initialize({
+    rust.SpeechLanguage? speechLanguage,
+  }) async => const MindStatus.ready();
+
+  @override
+  Future<List<rust.MeetingRecord>> meetings() async => library;
+
+  @override
+  Future<rust.MeetingRecord?> meeting(String id) async =>
+      library.where((m) => m.id == id).firstOrNull;
+
+  @override
+  Future<rust.TranscriptDocumentRecord?> transcriptDocument(
+    String meetingId,
+  ) async => doc;
+
+  @override
+  Future<rust.MeetingRecord> updateActionItemStatus({
+    required rust.MeetingRecord meeting,
+    required String actionItemId,
+    required rust.MeetingActionStatus status,
+  }) async {
+    final updated = rust.MeetingRecord(
+      id: meeting.id,
+      title: meeting.title,
+      recordedAt: meeting.recordedAt,
+      transcript: meeting.transcript,
+      minutes: meeting.minutes,
+      model: meeting.model,
+      decisions: meeting.decisions,
+      actionItems: [
+        for (final item in meeting.actionItems)
+          if (item.id == actionItemId)
+            rust.MeetingActionItemRecord(
+              id: item.id,
+              task: item.task,
+              owner: item.owner,
+              due: item.due,
+              status: status,
+              evidenceSegmentIds: item.evidenceSegmentIds,
+            )
+          else
+            item,
+      ],
+      metrics: meeting.metrics,
+    );
+    lastStatusUpdate = updated;
+    return updated;
+  }
+
+  @override
+  Future<void> dispose() async {}
+}
+
+rust.MeetingRecord _irMeeting() => rust.MeetingRecord(
+  id: 'm1700000000123',
+  title: 'Platform standup',
+  recordedAt: BigInt.from(1700000000),
+  transcript: 'Priya said the Kafka consumer lag is the bottleneck.',
+  minutes: '- Add three pods before Friday',
+  model: 'qwen2.5-0.5b-instruct-q4_k_m',
+  decisions: const [
+    rust.MeetingDecisionRecord(
+      id: 'd1',
+      statement: 'Add three pods before Friday',
+      status: rust.MeetingDecisionStatus.agreed,
+      evidenceSegmentIds: ['s0'],
+    ),
+  ],
+  actionItems: const [
+    rust.MeetingActionItemRecord(
+      id: 'a1',
+      task: 'Add three pods',
+      owner: 'Priya',
+      status: rust.MeetingActionStatus.open,
+      evidenceSegmentIds: ['s0'],
+    ),
+  ],
+  metrics: const [
+    rust.MeetingMetricRecord(
+      id: 'n1',
+      name: 'lag',
+      value: '2s',
+      evidenceSegmentIds: ['s0'],
+    ),
+  ],
+);
+
+rust.TranscriptDocumentRecord _doc() => rust.TranscriptDocumentRecord(
+  meetingId: 'm1700000000123',
+  audioPath: '/tmp/a.wav',
+  modelVersion: 'whisper',
+  segments: [
+    rust.TranscriptSegmentRecord(
+      id: 's0',
+      startMs: BigInt.from(65000),
+      endMs: BigInt.from(70000),
+      text: 'Priya said the Kafka consumer lag is the bottleneck.',
+    ),
+  ],
+);
+
+Widget _app(Widget home) => MaterialApp(home: home);
+
+void main() {
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  testWidgets('renders MoM sections from IR and hides free-form minutes', (
+    tester,
+  ) async {
+    final meeting = _irMeeting();
+    await tester.pumpWidget(
+      _app(
+        MeetingScreen.stored(
+          service: _FakeMind(library: [meeting], doc: _doc()),
+          meeting: meeting,
+          userEditsStore: MeetingIrUserEditsStore(),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('Decisions'), findsOneWidget);
+    expect(find.text('Action items'), findsOneWidget);
+    expect(find.text('Metrics'), findsOneWidget);
+    expect(find.text('Add three pods before Friday'), findsOneWidget);
+    expect(find.text('Add three pods'), findsOneWidget);
+    expect(find.text('lag: 2s'), findsOneWidget);
+    // Evidence clock on the action row (65_000 ms → 01:05).
+    expect(find.text('01:05'), findsOneWidget);
+    // Free-form minutes fallback is suppressed when IR is present.
+    expect(find.text('Minutes'), findsNothing);
+  });
+
+  testWidgets('empty IR still shows Decisions / Action items / Metrics', (
+    tester,
+  ) async {
+    final meeting = rust.MeetingRecord(
+      id: 'm-empty',
+      title: 'Empty IR',
+      recordedAt: BigInt.from(1700000000),
+      transcript: 'hello',
+      minutes: 'notes',
+      model: 'qwen',
+      decisions: const [],
+      actionItems: const [],
+      metrics: const [],
+    );
+    await tester.pumpWidget(
+      _app(
+        MeetingScreen.stored(
+          service: _FakeMind(library: [meeting]),
+          meeting: meeting,
+          userEditsStore: MeetingIrUserEditsStore(),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('No decisions recorded.'), findsOneWidget);
+    expect(find.text('No action items recorded.'), findsOneWidget);
+    expect(find.text('No metrics recorded.'), findsOneWidget);
+  });
+
+  testWidgets('checking an action writes status through the service', (
+    tester,
+  ) async {
+    final meeting = _irMeeting();
+    final service = _FakeMind(library: [meeting], doc: _doc());
+    await tester.pumpWidget(
+      _app(
+        MeetingScreen.stored(
+          service: service,
+          meeting: meeting,
+          userEditsStore: MeetingIrUserEditsStore(),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(const Key('meeting_ir_action_check_a1')));
+    await tester.pumpAndSettle();
+
+    expect(
+      service.lastStatusUpdate!.actionItems.single.status,
+      rust.MeetingActionStatus.done,
+    );
+  });
+
+  testWidgets('tapping a decision highlights evidence and reports seek ms', (
+    tester,
+  ) async {
+    final meeting = _irMeeting();
+    int? seekMs;
+    await tester.pumpWidget(
+      _app(
+        MeetingScreen.stored(
+          service: _FakeMind(library: [meeting], doc: _doc()),
+          meeting: meeting,
+          userEditsStore: MeetingIrUserEditsStore(),
+          onSeekAudio: (ms) => seekMs = ms,
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Add three pods before Friday'));
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const Key('meeting_ir_evidence_clock')), findsOneWidget);
+    expect(find.textContaining('Evidence at 01:05'), findsOneWidget);
+    expect(seekMs, 65000);
+  });
+
+  testWidgets('user edit overlay wins over IR task text', (tester) async {
+    final meeting = _irMeeting();
+    SharedPreferences.setMockInitialValues({
+      'mind.meeting_ir.user_edits.m1700000000123':
+          const MeetingIrUserEdits()
+              .upsert(
+                'a1',
+                const MeetingActionUserEdit(task: 'Ship four pods'),
+              )
+              .encode(),
+    });
+    await tester.pumpWidget(
+      _app(
+        MeetingScreen.stored(
+          service: _FakeMind(library: [meeting], doc: _doc()),
+          meeting: meeting,
+          userEditsStore: MeetingIrUserEditsStore(),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('Ship four pods'), findsOneWidget);
+    expect(find.text('Add three pods'), findsNothing);
+  });
+
+  testWidgets('low-tier banner offers cloud fallback without crashing', (
+    tester,
+  ) async {
+    final meeting = _irMeeting();
+    var cloud = false;
+    await tester.pumpWidget(
+      _app(
+        MeetingScreen.stored(
+          service: _FakeMind(library: [meeting], doc: _doc()),
+          meeting: meeting,
+          showLowTierCloudChoice: true,
+          onCloudFallback: () => cloud = true,
+          userEditsStore: MeetingIrUserEditsStore(),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const Key('meeting_ir_cloud_fallback')), findsOneWidget);
+    await tester.tap(find.byKey(const Key('meeting_ir_cloud_fallback')));
+    await tester.pumpAndSettle();
+    expect(cloud, isTrue);
+  });
+}

--- a/packages/feature_mind/test/mind_journey_test.dart
+++ b/packages/feature_mind/test/mind_journey_test.dart
@@ -304,7 +304,7 @@ void main() {
         ),
       );
       await tester.pump();
-      expect(find.text('Writing minutes…'), findsOneWidget);
+      expect(find.text('Extracting…'), findsOneWidget);
       expect(find.text('- Add three pods'), findsOneWidget);
 
       controller.add(
@@ -316,7 +316,7 @@ void main() {
         ),
       );
       await tester.pump();
-      expect(find.text('Saved on this device'), findsOneWidget);
+      expect(find.text('Ready'), findsOneWidget);
       expect(find.text('Stop'), findsNothing);
 
       await controller.close();

--- a/packages/feature_mind/test/mind_journey_test.dart
+++ b/packages/feature_mind/test/mind_journey_test.dart
@@ -4,6 +4,7 @@ import 'package:feature_mind/feature_mind.dart';
 import 'package:feature_mind/src/whisper/api/meetings.dart' as rust;
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 /// A [MindService] with the native library removed.
 ///
@@ -44,6 +45,11 @@ class _FakeMind extends MindService {
       library.where((m) => m.id == id).firstOrNull;
 
   @override
+  Future<rust.TranscriptDocumentRecord?> transcriptDocument(
+    String meetingId,
+  ) async => null;
+
+  @override
   void cancelProcessing() => cancelled = true;
 
   @override
@@ -79,6 +85,10 @@ rust.MeetingRecord _meeting({
 Widget _app(Widget home) => MaterialApp(home: home);
 
 void main() {
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
   group('the library', () {
     testWidgets('an empty library says how to start one', (tester) async {
       await tester.pumpWidget(_app(MindHomeScreen(service: _FakeMind())));

--- a/packages/feature_mind/test/mind_journey_test.dart
+++ b/packages/feature_mind/test/mind_journey_test.dart
@@ -27,9 +27,8 @@ class _FakeMind extends MindService {
   String? searched;
 
   @override
-  Future<MindStatus> initialize({
-    rust.SpeechLanguage? speechLanguage,
-  }) async => status;
+  Future<MindStatus> initialize({rust.SpeechLanguage? speechLanguage}) async =>
+      status;
 
   @override
   Future<List<rust.MeetingRecord>> meetings() async => library;


### PR DESCRIPTION
## Summary
- Extend `meeting_screen.dart` (do not replace) with MoM sections rendered from Meeting IR: decisions, checkable action items, metrics
- Evidence tracing: tap decision/action/metric → transcript segment highlight + optional `onSeekAudio(startMs)`
- Action status writes back through MIND-LLM-16 / ADR-0022 path (`saveMeeting` re-save, latest wins)
- User edits for task/owner stored in a prefs overlay so re-extraction cannot overwrite corrections
- Low-tier cloud-fallback banner + Pro gate seam (`meetingIntelligenceEnabled`); reading width constrained to 800px

Depends on #1760 (#1657 Stage 2 write path) already on main — no write-path reimplementation.

Closes #1658. Part of #1770 / epic #1627.

## Test plan
- [x] `flutter test packages/feature_mind/test/meeting_ir/`
- [x] `flutter test packages/feature_mind/test/mind_journey_test.dart`
- [x] `flutter analyze` on touched lib paths
- [ ] Manual: open stored meeting with IR → MoM sections
- [ ] Manual: checkbox action → status persists via re-save
- [ ] Manual: tap decision → evidence clock + highlight
- [ ] Manual: edit action task/owner → overlay survives re-open