### PR TITLE
fix(mind): first-run model download stall recovery (#1772)

### DIFF
--- a/packages/core_ai/lib/src/download/model_download_service.dart
+++ b/packages/core_ai/lib/src/download/model_download_service.dart
@@ -274,6 +274,37 @@ class ModelDownloadService {
     await _prepareDownload(model);
   }
 
+  /// Recovers a stalled or failed transfer without discarding a usable partial.
+  ///
+  /// Prefers platform [resumeDownload] when the queue (or last progress)
+  /// retained resume state; otherwise falls back to [retryDownload] with the
+  /// current catalog metadata when [model] is provided.
+  Future<void> recoverDownload(
+    String modelId, {
+    OfflineModelInfo? model,
+    bool resumeSupported = false,
+  }) async {
+    if (resumeSupported) {
+      await resumeDownload(modelId);
+      return;
+    }
+
+    final snapshot = await _downloads.getQueue();
+    for (final entry in snapshot.entries) {
+      if (entry.artifactId != modelId) continue;
+      if (entry.resumeSupported ||
+          entry.status == DownloadStatus.paused ||
+          (entry.status == DownloadStatus.failed &&
+              entry.downloadedBytes > 0)) {
+        await resumeDownload(modelId);
+        return;
+      }
+      break;
+    }
+
+    await retryDownload(modelId, model: model);
+  }
+
   Future<void> cancelDownload(String modelId) => _downloads.cancel(modelId);
 
   Future<DownloadQueueSnapshot> getQueue() => _downloads.getQueue();
@@ -291,6 +322,11 @@ class ModelDownloadService {
       if (model == null) continue;
       if (entry.status == DownloadStatus.completed) {
         await _tryWriteReceipt(model);
+      } else if (entry.status == DownloadStatus.failed) {
+        // Keep catalog metadata for resume/retry, but do not mark the id as
+        // already scheduled — otherwise a later [downloadModel] call would
+        // skip re-enqueue and hang waiting for a dead WorkManager job.
+        _scheduledModels[model.id] = model;
       } else if (entry.status != DownloadStatus.cancelled) {
         _scheduledModels[model.id] = model;
         _scheduledIds.add(model.id);

--- a/packages/core_ai/test/download/model_download_service_test.dart
+++ b/packages/core_ai/test/download/model_download_service_test.dart
@@ -458,4 +458,63 @@ void main() {
       expect(restored.single.resumeSupported, isTrue);
     },
   );
+
+  test(
+    'restoreQueue keeps failed entries resumable without blocking re-enqueue',
+    () async {
+      downloads.queue = DownloadQueueSnapshot(
+        entries: [
+          DownloadProgress(
+            artifactId: model.id,
+            status: DownloadStatus.failed,
+            downloadedBytes: 400,
+            totalBytes: 1000,
+            resumeSupported: true,
+          ),
+        ],
+      );
+
+      final restored = await downloadService.restoreQueue(
+        catalogModels: [model],
+      );
+
+      expect(restored.single.status, ModelDownloadStatus.failed);
+      expect(restored.single.resumeSupported, isTrue);
+
+      downloadService.downloadModel(model);
+      await Future<void>.delayed(Duration.zero);
+
+      expect(downloads.requests, hasLength(1));
+    },
+  );
+
+  test(
+    'recoverDownload resumes when the platform retained a partial',
+    () async {
+      downloads.queue = DownloadQueueSnapshot(
+        entries: [
+          DownloadProgress(
+            artifactId: model.id,
+            status: DownloadStatus.failed,
+            downloadedBytes: 400,
+            totalBytes: 1000,
+            resumeSupported: true,
+          ),
+        ],
+      );
+
+      await downloadService.recoverDownload(model.id, model: model);
+
+      expect(downloads.actions, ['resume:model-a']);
+      expect(downloads.requests, isEmpty);
+    },
+  );
+
+  test('recoverDownload retries when resume is not available', () async {
+    await downloadService.recoverDownload(model.id, model: model);
+    await Future<void>.delayed(Duration.zero);
+
+    expect(downloads.actions, contains('cancel:model-a'));
+    expect(downloads.requests, hasLength(1));
+  });
 }

--- a/packages/feature_mind/lib/src/mind_home_screen.dart
+++ b/packages/feature_mind/lib/src/mind_home_screen.dart
@@ -431,6 +431,7 @@ class _ModelDownloadState extends State<_ModelDownload> {
   ModelAcquisitionProgress? _progress;
   List<String> _failed = const [];
   String? _error;
+  bool _resumeSupported = false;
 
   @override
   void initState() {
@@ -454,6 +455,7 @@ class _ModelDownloadState extends State<_ModelDownload> {
       _failed = const [];
       _error = null;
       _progress = null;
+      _resumeSupported = false;
     });
 
     try {
@@ -462,8 +464,14 @@ class _ModelDownloadState extends State<_ModelDownload> {
         switch (event) {
           case ModelAcquisitionProgress():
             setState(() => _progress = event);
-          case ModelAcquisitionDone(:final failedFileNames):
-            setState(() => _failed = failedFileNames);
+          case ModelAcquisitionDone(
+            :final failedFileNames,
+            :final resumeSupported,
+          ):
+            setState(() {
+              _failed = failedFileNames;
+              _resumeSupported = resumeSupported;
+            });
         }
       }
     } on Object catch (e) {
@@ -478,11 +486,15 @@ class _ModelDownloadState extends State<_ModelDownload> {
   static String _megabytes(int bytes) =>
       '${(bytes / (1000 * 1000)).round()} MB';
 
+  bool get _canResume =>
+      _resumeSupported || (_progress != null && _progress!.fetched > 0);
+
   @override
   Widget build(BuildContext context) {
     final required = _required;
     final total = required?.fold<int>(0, (sum, m) => sum + m.sizeBytes);
     final failed = _failed.isNotEmpty;
+    final needsRecovery = failed || _error != null;
 
     return Center(
       child: Padding(
@@ -512,7 +524,7 @@ class _ModelDownloadState extends State<_ModelDownload> {
               const SizedBox(height: 16),
               Text(
                 'Could not download ${_failed.join(', ')}. Check the '
-                'connection and try again.',
+                'connection and ${_canResume ? 'resume' : 'try again'}.',
                 textAlign: TextAlign.center,
                 style: TextStyle(color: Theme.of(context).colorScheme.error),
               ),
@@ -525,6 +537,16 @@ class _ModelDownloadState extends State<_ModelDownload> {
                 style: Theme.of(context).textTheme.bodySmall,
               ),
             ],
+            if (!_running && needsRecovery) ...[
+              const SizedBox(height: 8),
+              Text(
+                _canResume
+                    ? 'Partial download kept where the platform allows it.'
+                    : 'No partial download to resume on this device.',
+                textAlign: TextAlign.center,
+                style: Theme.of(context).textTheme.bodySmall,
+              ),
+            ],
           ],
         ),
       ),
@@ -532,13 +554,30 @@ class _ModelDownloadState extends State<_ModelDownload> {
   }
 
   Widget _action(int? total) {
-    final label = total == null
-        ? 'Download models'
-        : 'Download models (~${_megabytes(total)})';
+    final needsRecovery = _failed.isNotEmpty || _error != null;
+    final String label;
+    final IconData icon;
+    if (!needsRecovery) {
+      label = total == null
+          ? 'Download models'
+          : 'Download models (~${_megabytes(total)})';
+      icon = Icons.download;
+    } else if (_canResume) {
+      label = 'Resume download';
+      icon = Icons.download;
+    } else {
+      label = 'Try again';
+      icon = Icons.refresh;
+    }
     return FilledButton.icon(
+      key: Key(
+        needsRecovery
+            ? 'mind_model_download_retry'
+            : 'mind_model_download_start',
+      ),
       onPressed: _download,
-      icon: const Icon(Icons.download),
-      label: Text(_failed.isEmpty && _error == null ? label : 'Retry'),
+      icon: Icon(icon),
+      label: Text(label),
     );
   }
 

--- a/packages/feature_mind/lib/src/model_installer.dart
+++ b/packages/feature_mind/lib/src/model_installer.dart
@@ -83,6 +83,25 @@ class ModelInstaller with PinnedModelFiles implements ModelProvider {
       final expected = required.sizeBytes;
       if (target.existsSync() && target.lengthSync() == expected) continue;
 
+      // Wrong-sized residue is corrupt — clear before atomic reinstall so
+      // a half-written file cannot pass the size check on a later launch.
+      if (target.existsSync()) {
+        try {
+          target.deleteSync();
+        } on Object {
+          failed.add(required.fileName);
+          continue;
+        }
+      }
+      final leftoverPartial = File('${target.path}.partial');
+      if (leftoverPartial.existsSync()) {
+        try {
+          leftoverPartial.deleteSync();
+        } on Object {
+          // Best-effort; the write path below recreates the partial.
+        }
+      }
+
       try {
         // Desktop bundles keep assets as real files. Copying file-to-file
         // streams; `rootBundle.load` would pull a 469 MB model entirely into

--- a/packages/feature_mind/lib/src/models/download_model_provider.dart
+++ b/packages/feature_mind/lib/src/models/download_model_provider.dart
@@ -31,9 +31,22 @@ class DownloadModelProvider with PinnedModelFiles implements ModelProvider {
     required this._downloadService,
     required this._requiredModelsLookup,
     required this._downloadUrlFor,
-  });
+    Duration stallThreshold = const Duration(seconds: 90),
+    Duration stallPollInterval = const Duration(seconds: 2),
+  }) : _stallThreshold = stallThreshold,
+       _stallPollInterval = stallPollInterval;
 
   final core_ai.ModelDownloadService _downloadService;
+
+  /// How long a transfer may report downloading with no byte movement before
+  /// acquisition treats it as stalled. Matches `ModelDownloadProgress`'s
+  /// default stall window so Mind first-run and the shared model explorer
+  /// agree on when to offer recovery.
+  final Duration _stallThreshold;
+
+  /// How often the stall watchdog re-checks [ModelDownloadProgress.isStalledAt]
+  /// even when the platform stops emitting progress (WorkManager FGS timeout).
+  final Duration _stallPollInterval;
 
   /// Closes the download pipeline this provider was composed over: it holds a
   /// subscription to the platform download stream and a progress controller
@@ -103,6 +116,12 @@ class DownloadModelProvider with PinnedModelFiles implements ModelProvider {
   /// Moves a verified artifact out of `core_ai`'s staging directory and into
   /// Mind's models directory, under its pinned file name.
   ///
+  /// Staging lands at `$target.partial` first, then is renamed into place —
+  /// the same atomic pattern as [ModelInstaller] — so a kill mid-install
+  /// cannot leave a wrong-sized file that [PinnedModelFiles.isPresent] would
+  /// treat as installed on the next launch. Wrong-sized leftovers (partial
+  /// or final) are deleted before promotion; corrupt never becomes loadable.
+  ///
   /// A rename, not a copy: both directories live under the same app container
   /// on every platform Mind ships to, so this is a metadata operation rather
   /// than half a gigabyte read and written again. The copy path is the honest
@@ -114,9 +133,19 @@ class DownloadModelProvider with PinnedModelFiles implements ModelProvider {
   /// exception on screen instead of a retry.
   Future<bool> _install(RequiredModel required, Directory modelsDir) async {
     final target = File(p.join(modelsDir.path, required.fileName));
+    final partial = File('${target.path}.partial');
 
     try {
       if (PinnedModelFiles.isPresent(modelsDir, required)) return true;
+
+      // Wrong-sized final or leftover partial is corrupt residue — never
+      // treat it as installed, and clear it before promoting a fresh artifact.
+      if (target.existsSync()) {
+        target.deleteSync();
+      }
+      if (partial.existsSync()) {
+        partial.deleteSync();
+      }
 
       // The same id the download was enqueued under — anything else asks the
       // storage manager about a model it never wrote.
@@ -128,21 +157,178 @@ class DownloadModelProvider with PinnedModelFiles implements ModelProvider {
 
       final staged = File(stagedPath);
       try {
-        staged.renameSync(target.path);
+        staged.renameSync(partial.path);
       } on FileSystemException {
-        staged.copySync(target.path);
+        staged.copySync(partial.path);
         staged.deleteSync();
       }
+
+      if (!partial.existsSync() || partial.lengthSync() != required.sizeBytes) {
+        if (partial.existsSync()) partial.deleteSync();
+        return false;
+      }
+
+      partial.renameSync(target.path);
       return PinnedModelFiles.isPresent(modelsDir, required);
     } on Object {
+      if (partial.existsSync()) {
+        try {
+          partial.deleteSync();
+        } on Object {
+          // Best-effort cleanup; the next acquire clears leftovers above.
+        }
+      }
       return false;
     }
+  }
+
+  /// Re-attaches to WorkManager / URLSession state left from a previous
+  /// process, and kicks resume/retry when the platform retained a partial.
+  Future<Map<String, core_ai.ModelDownloadProgress>> _restorePersisted({
+    required List<RequiredModel> required,
+  }) async {
+    final catalog = [for (final model in required) _stagedInfo(model)];
+    final restored = await _downloadService.restoreQueue(
+      catalogModels: catalog,
+    );
+    return {for (final progress in restored) progress.modelId: progress};
+  }
+
+  Future<void> _resumeOrRetryIfNeeded(
+    RequiredModel model,
+    core_ai.OfflineModelInfo info,
+    core_ai.ModelDownloadProgress? prior,
+  ) async {
+    if (prior == null) return;
+    // An in-flight restored transfer needs no kick — only paused / failed /
+    // stalled entries are recovered so we do not cancel live WorkManager work.
+    final needsRecovery =
+        prior.status == core_ai.ModelDownloadStatus.paused ||
+        prior.status == core_ai.ModelDownloadStatus.failed ||
+        prior.isStalled;
+    if (!needsRecovery) return;
+
+    await _downloadService.recoverDownload(
+      info.id,
+      model: info,
+      resumeSupported:
+          prior.resumeSupported ||
+          prior.status == core_ai.ModelDownloadStatus.paused ||
+          prior.downloadedBytes > 0,
+    );
+  }
+
+  /// Listens to [ModelDownloadService.downloadModel] until a terminal status,
+  /// synthesizing failure when bytes stop moving — including when the
+  /// platform stops emitting events after an FGS / WorkManager timeout.
+  Stream<core_ai.ModelDownloadProgress> _watchDownload(
+    core_ai.OfflineModelInfo info,
+  ) {
+    late final StreamController<core_ai.ModelDownloadProgress> controller;
+    StreamSubscription<core_ai.ModelDownloadProgress>? subscription;
+    Timer? watchdog;
+    core_ai.ModelDownloadProgress? latest;
+    final watchStartedAt = DateTime.now();
+    var closed = false;
+
+    Future<void> close() async {
+      if (closed) return;
+      closed = true;
+      watchdog?.cancel();
+      await subscription?.cancel();
+      await controller.close();
+    }
+
+    void emitStallFailure(core_ai.ModelDownloadProgress? progress) {
+      if (closed || controller.isClosed) return;
+      final bytes = progress?.downloadedBytes ?? 0;
+      final total = progress?.totalBytes ?? info.fileSizeBytes;
+      controller.add(
+        core_ai.ModelDownloadProgress(
+          modelId: info.id,
+          totalBytes: total,
+          downloadedBytes: bytes,
+          status: core_ai.ModelDownloadStatus.failed,
+          startTime: progress?.startTime ?? watchStartedAt,
+          lastProgressAt: progress?.lastProgressAt ?? watchStartedAt,
+          error:
+              'Download stalled — no progress for '
+              '${_stallThreshold.inSeconds}s.',
+          failureCode: 'stalled',
+          retryCount: progress?.retryCount ?? 0,
+          queuePosition: progress?.queuePosition,
+          resumeSupported: progress?.resumeSupported == true || bytes > 0,
+        ),
+      );
+      unawaited(close());
+    }
+
+    void armWatchdog() {
+      watchdog?.cancel();
+      watchdog = Timer.periodic(_stallPollInterval, (_) {
+        if (closed) return;
+        final now = DateTime.now();
+        final progress = latest;
+        if (progress != null) {
+          if (progress.isStalledAt(now, threshold: _stallThreshold)) {
+            emitStallFailure(progress);
+          }
+          return;
+        }
+        // Enqueued but silent — the platform never reported a first byte.
+        if (now.difference(watchStartedAt) >= _stallThreshold) {
+          emitStallFailure(null);
+        }
+      });
+    }
+
+    controller = StreamController<core_ai.ModelDownloadProgress>(
+      onListen: () {
+        armWatchdog();
+        subscription = _downloadService
+            .downloadModel(info)
+            .listen(
+              (progress) {
+                latest = progress;
+                if (closed || controller.isClosed) return;
+                controller.add(progress);
+                final terminal =
+                    progress.status == core_ai.ModelDownloadStatus.completed ||
+                    progress.status == core_ai.ModelDownloadStatus.failed ||
+                    progress.status == core_ai.ModelDownloadStatus.cancelled;
+                if (terminal) {
+                  unawaited(close());
+                  return;
+                }
+                if (progress.isStalled) {
+                  emitStallFailure(progress);
+                  return;
+                }
+                armWatchdog();
+              },
+              onError: (Object error, StackTrace stackTrace) {
+                if (!closed && !controller.isClosed) {
+                  controller.addError(error, stackTrace);
+                }
+                unawaited(close());
+              },
+              onDone: () => unawaited(close()),
+            );
+      },
+      onCancel: close,
+    );
+    return controller.stream;
   }
 
   @override
   Stream<ModelAcquisitionEvent> acquire(Directory modelsDir) async* {
     final required = await requiredModels();
     final failed = <String>[];
+    var resumeSupported = false;
+
+    // Rehydrate WorkManager / URLSession queue so a cold start can continue
+    // a ~570 MB scribe transfer instead of discarding the partial.
+    final restored = await _restorePersisted(required: required);
 
     // Sequential, not concurrent: the two Mind models together are ~570 MB,
     // and running both downloads at once on a constrained connection is a
@@ -167,17 +353,31 @@ class DownloadModelProvider with PinnedModelFiles implements ModelProvider {
         continue;
       }
 
+      final prior = restored[info.id];
+      if (prior != null && prior.downloadedBytes > 0) {
+        resumeSupported = true;
+        yield ModelAcquisitionProgress(
+          model.fileName,
+          prior.downloadedBytes,
+          prior.totalBytes > 0 ? prior.totalBytes : model.sizeBytes,
+        );
+      }
+      await _resumeOrRetryIfNeeded(model, info, prior);
+
       var succeeded = false;
       var settled = false;
       // The service's progress stream is a persistent broadcast stream keyed
       // on model id -- it never closes on its own, so this loop breaks itself
       // on the first terminal status rather than waiting on stream closure.
       // `await for`'s implicit subscription is cancelled by `break`.
-      await for (final progress in _downloadService.downloadModel(info)) {
+      await for (final progress in _watchDownload(info)) {
+        if (progress.downloadedBytes > 0 && progress.resumeSupported) {
+          resumeSupported = true;
+        }
         yield ModelAcquisitionProgress(
           model.fileName,
           progress.downloadedBytes,
-          progress.totalBytes,
+          progress.totalBytes > 0 ? progress.totalBytes : model.sizeBytes,
         );
         switch (progress.status) {
           case core_ai.ModelDownloadStatus.completed:
@@ -187,6 +387,9 @@ class DownloadModelProvider with PinnedModelFiles implements ModelProvider {
           case core_ai.ModelDownloadStatus.cancelled:
             succeeded = false;
             settled = true;
+            if (progress.resumeSupported || progress.downloadedBytes > 0) {
+              resumeSupported = true;
+            }
           case core_ai.ModelDownloadStatus.pending:
           case core_ai.ModelDownloadStatus.downloading:
           case core_ai.ModelDownloadStatus.paused:
@@ -203,7 +406,7 @@ class DownloadModelProvider with PinnedModelFiles implements ModelProvider {
       if (!succeeded) failed.add(model.fileName);
     }
 
-    yield ModelAcquisitionDone(failed);
+    yield ModelAcquisitionDone(failed, resumeSupported: resumeSupported);
   }
 
   @override

--- a/packages/feature_mind/lib/src/models/model_download_coordinator.dart
+++ b/packages/feature_mind/lib/src/models/model_download_coordinator.dart
@@ -87,47 +87,49 @@ class ModelDownloadCoordinator {
 
     void startDownload() {
       armStallWatchdog();
-      downloadSub = models.download(modelId).listen(
-        (progress) {
-          if (progress.received > received) {
-            lastByteAt = DateTime.now();
-            stalled = false;
-          }
-          received = progress.received;
-          if (progress.total > 0) total = progress.total;
-          if (metered && !allowMetered) {
-            emit(
-              ModelDownloadPausedForMetered(
-                received: progress.received,
-                total: progress.total,
-              ),
-            );
-            return;
-          }
-          if (progress.total > 0 && progress.received >= progress.total) {
-            emit(const ModelDownloadCompleted());
-            unawaited(close());
-            return;
-          }
-          emit(
-            ModelDownloadInProgress(
-              received: progress.received,
-              total: progress.total,
-            ),
+      downloadSub = models
+          .download(modelId)
+          .listen(
+            (progress) {
+              if (progress.received > received) {
+                lastByteAt = DateTime.now();
+                stalled = false;
+              }
+              received = progress.received;
+              if (progress.total > 0) total = progress.total;
+              if (metered && !allowMetered) {
+                emit(
+                  ModelDownloadPausedForMetered(
+                    received: progress.received,
+                    total: progress.total,
+                  ),
+                );
+                return;
+              }
+              if (progress.total > 0 && progress.received >= progress.total) {
+                emit(const ModelDownloadCompleted());
+                unawaited(close());
+                return;
+              }
+              emit(
+                ModelDownloadInProgress(
+                  received: progress.received,
+                  total: progress.total,
+                ),
+              );
+              armStallWatchdog();
+            },
+            onError: (Object error, StackTrace _) {
+              emit(ModelDownloadFailed(error.toString()));
+              unawaited(close());
+            },
+            onDone: () {
+              if (!closed) {
+                emit(const ModelDownloadCompleted());
+                unawaited(close());
+              }
+            },
           );
-          armStallWatchdog();
-        },
-        onError: (Object error, StackTrace _) {
-          emit(ModelDownloadFailed(error.toString()));
-          unawaited(close());
-        },
-        onDone: () {
-          if (!closed) {
-            emit(const ModelDownloadCompleted());
-            unawaited(close());
-          }
-        },
-      );
     }
 
     controller = StreamController<ModelDownloadState>(
@@ -185,9 +187,7 @@ class ModelDownloadCoordinator {
           });
 
           if (metered) {
-            emit(
-              ModelDownloadPausedForMetered(received: 0, total: sizeBytes),
-            );
+            emit(ModelDownloadPausedForMetered(received: 0, total: sizeBytes));
           }
           startDownload();
         }());

--- a/packages/feature_mind/lib/src/models/model_download_coordinator.dart
+++ b/packages/feature_mind/lib/src/models/model_download_coordinator.dart
@@ -15,11 +15,27 @@ import 'model_download_state.dart';
 /// This coordinator does not rely on that alone: it watches connectivity
 /// directly, so a caller always gets a state that names the reason, even if
 /// the underlying port never emits anything while paused.
+///
+/// It also watches byte movement. When [ModelPort.download] stops emitting
+/// after a WorkManager FGS timeout, the stall watchdog still flips the row to
+/// [ModelDownloadStalled] so the shell can offer resume / try-again.
 class ModelDownloadCoordinator {
-  ModelDownloadCoordinator({required this.models, required this.connectivity});
+  ModelDownloadCoordinator({
+    required this.models,
+    required this.connectivity,
+    this.stallThreshold = const Duration(seconds: 90),
+    this.stallPollInterval = const Duration(seconds: 2),
+  });
 
   final ModelPort models;
   final ModelDownloadConnectivity connectivity;
+
+  /// How long [received] may stay unchanged while a download is active before
+  /// the coordinator emits [ModelDownloadStalled].
+  final Duration stallThreshold;
+
+  /// How often the stall watchdog re-checks when the port is silent.
+  final Duration stallPollInterval;
 
   /// Emits the states of downloading [modelId], whose full size is
   /// [sizeBytes] — read from [ModelPort.all] by the caller, since the port
@@ -37,9 +53,13 @@ class ModelDownloadCoordinator {
     late final StreamController<ModelDownloadState> controller;
     StreamSubscription<({int received, int total})>? downloadSub;
     StreamSubscription<bool>? meteredSub;
+    Timer? stallWatchdog;
     var metered = false;
     var received = 0;
+    var total = sizeBytes;
+    var lastByteAt = DateTime.now();
     var closed = false;
+    var stalled = false;
 
     void emit(ModelDownloadState state) {
       if (!closed && !controller.isClosed) controller.add(state);
@@ -48,15 +68,33 @@ class ModelDownloadCoordinator {
     Future<void> close() async {
       if (closed) return;
       closed = true;
+      stallWatchdog?.cancel();
       await downloadSub?.cancel();
       await meteredSub?.cancel();
       await controller.close();
     }
 
+    void armStallWatchdog() {
+      stallWatchdog?.cancel();
+      stallWatchdog = Timer.periodic(stallPollInterval, (_) {
+        if (closed || metered && !allowMetered || stalled) return;
+        if (DateTime.now().difference(lastByteAt) < stallThreshold) return;
+        stalled = true;
+        emit(ModelDownloadStalled(received: received, total: total));
+        unawaited(close());
+      });
+    }
+
     void startDownload() {
+      armStallWatchdog();
       downloadSub = models.download(modelId).listen(
         (progress) {
+          if (progress.received > received) {
+            lastByteAt = DateTime.now();
+            stalled = false;
+          }
           received = progress.received;
+          if (progress.total > 0) total = progress.total;
           if (metered && !allowMetered) {
             emit(
               ModelDownloadPausedForMetered(
@@ -77,6 +115,7 @@ class ModelDownloadCoordinator {
               total: progress.total,
             ),
           );
+          armStallWatchdog();
         },
         onError: (Object error, StackTrace _) {
           emit(ModelDownloadFailed(error.toString()));
@@ -137,9 +176,11 @@ class ModelDownloadCoordinator {
                 ),
               );
             } else {
+              lastByteAt = DateTime.now();
               emit(
                 ModelDownloadInProgress(received: received, total: sizeBytes),
               );
+              armStallWatchdog();
             }
           });
 

--- a/packages/feature_mind/lib/src/models/model_download_state.dart
+++ b/packages/feature_mind/lib/src/models/model_download_state.dart
@@ -95,6 +95,25 @@ final class ModelDownloadInProgress extends ModelDownloadState {
   int get hashCode => Object.hash(ModelDownloadInProgress, received, total);
 }
 
+/// Platform still reports an active transfer but bytes have not moved for the
+/// stall window. Distinct from [ModelDownloadFailed] so the row can offer
+/// "Resume download" while naming the hang rather than a generic error.
+final class ModelDownloadStalled extends ModelDownloadState {
+  const ModelDownloadStalled({required this.received, required this.total});
+
+  final int received;
+  final int total;
+
+  @override
+  bool operator ==(Object other) =>
+      other is ModelDownloadStalled &&
+      other.received == received &&
+      other.total == total;
+
+  @override
+  int get hashCode => Object.hash(ModelDownloadStalled, received, total);
+}
+
 final class ModelDownloadCompleted extends ModelDownloadState {
   const ModelDownloadCompleted();
 

--- a/packages/feature_mind/lib/src/models/model_management_panel.dart
+++ b/packages/feature_mind/lib/src/models/model_management_panel.dart
@@ -314,6 +314,29 @@ class ModelDownloadRow extends StatelessWidget {
           ),
         ],
       ),
+      ModelDownloadStalled(:final received, :final total) => Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          LinearProgressIndicator(value: total > 0 ? received / total : null),
+          const SizedBox(height: 4),
+          Semantics(
+            liveRegion: true,
+            child: Text(
+              'Download stalled (${formatBytesOf(received, total)})',
+              style: theme.textTheme.bodySmall?.copyWith(
+                color: MindPalette.alarm,
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+          ),
+          TextButton(
+            onPressed: onDownload,
+            child: Text(
+              received > 0 ? 'Resume download' : 'Try again',
+            ),
+          ),
+        ],
+      ),
       ModelDownloadCompleted() => Text(
         'Download complete',
         style: theme.textTheme.bodySmall,
@@ -330,7 +353,10 @@ class ModelDownloadRow extends StatelessWidget {
               ),
             ),
           ),
-          TextButton(onPressed: onDownload, child: const Text('Retry')),
+          TextButton(
+            onPressed: onDownload,
+            child: const Text('Try again'),
+          ),
         ],
       ),
     };

--- a/packages/feature_mind/lib/src/models/model_provider.dart
+++ b/packages/feature_mind/lib/src/models/model_provider.dart
@@ -59,12 +59,22 @@ final class ModelAcquisitionProgress extends ModelAcquisitionEvent {
 }
 
 /// Acquisition finished. [failedFileNames] is empty on full success — a real
-/// state (no network, no bundled asset, a corrupt file) that the UI must be
-/// able to explain rather than crash on.
+/// state (no network, no bundled asset, a corrupt file, a stalled transfer)
+/// that the UI must be able to explain rather than crash on.
+///
+/// [resumeSupported] is true when the platform retained partial bytes for at
+/// least one failure, so the shell can offer "Resume download" instead of a
+/// cold "Try again".
 final class ModelAcquisitionDone extends ModelAcquisitionEvent {
-  const ModelAcquisitionDone(this.failedFileNames);
+  const ModelAcquisitionDone(
+    this.failedFileNames, {
+    this.resumeSupported = false,
+  });
 
   final List<String> failedFileNames;
+
+  /// Whether a later acquire can continue from retained partial files.
+  final bool resumeSupported;
 }
 
 /// Where model bytes come from. `MindService` and the UI depend on this,

--- a/packages/feature_mind/test/mind_journey_test.dart
+++ b/packages/feature_mind/test/mind_journey_test.dart
@@ -28,7 +28,7 @@ class _FakeMind extends MindService {
 
   @override
   Future<MindStatus> initialize({
-    rust.SpeechLanguage speechLanguage = rust.SpeechLanguage.englishOnly,
+    rust.SpeechLanguage? speechLanguage,
   }) async => status;
 
   @override

--- a/packages/feature_mind/test/model_acquisition_test.dart
+++ b/packages/feature_mind/test/model_acquisition_test.dart
@@ -66,9 +66,11 @@ class FakeDownloadProvider implements ModelProvider {
   }
 
   /// Ends the acquisition the way the real provider does.
-  Future<void> finish() async {
+  Future<void> finish({bool resumeSupported = false}) async {
     installed = failures.isEmpty;
-    events.add(ModelAcquisitionDone(failures));
+    events.add(
+      ModelAcquisitionDone(failures, resumeSupported: resumeSupported),
+    );
     await events.close();
   }
 
@@ -169,7 +171,7 @@ void main() {
     expect(find.text('Record'), findsOneWidget);
   });
 
-  testWidgets('a failed download names the file and offers a retry', (
+  testWidgets('a failed download names the file and offers Try again', (
     tester,
   ) async {
     final provider = FakeDownloadProvider(failures: const ['ggml-tiny.en.bin']);
@@ -187,7 +189,32 @@ void main() {
       find.textContaining('Could not download ggml-tiny.en.bin'),
       findsOneWidget,
     );
-    expect(find.text('Retry'), findsOneWidget);
+    expect(find.text('Try again'), findsOneWidget);
+  });
+
+  testWidgets('a stalled partial download offers Resume download', (
+    tester,
+  ) async {
+    final provider = FakeDownloadProvider(failures: const ['ggml-tiny.en.bin']);
+    await tester.pumpWidget(
+      MaterialApp(home: MindHomeScreen(service: serviceFor(provider))),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Download models (~78 MB)'));
+    await tester.pump();
+    provider.events.add(
+      const ModelAcquisitionProgress('ggml-tiny.en.bin', 38852357, 77704715),
+    );
+    await tester.pump();
+    await provider.finish(resumeSupported: true);
+    await tester.pumpAndSettle();
+
+    expect(find.text('Resume download'), findsOneWidget);
+    expect(
+      find.textContaining('Partial download kept'),
+      findsOneWidget,
+    );
   });
 }
 

--- a/packages/feature_mind/test/models/download_model_provider_test.dart
+++ b/packages/feature_mind/test/models/download_model_provider_test.dart
@@ -17,6 +17,7 @@ class MockModelStorageManager extends Mock implements ModelStorageManager {}
 class FakeBackgroundDownloads implements BackgroundDownloads {
   final eventController = StreamController<DownloadProgress>.broadcast();
   final requests = <DownloadArtifactRequest>[];
+  final actions = <String>[];
   var queue = const DownloadQueueSnapshot(entries: []);
 
   @override
@@ -28,16 +29,24 @@ class FakeBackgroundDownloads implements BackgroundDownloads {
   }
 
   @override
-  Future<void> pause(String artifactId) async {}
+  Future<void> pause(String artifactId) async {
+    actions.add('pause:$artifactId');
+  }
 
   @override
-  Future<void> resume(String artifactId) async {}
+  Future<void> resume(String artifactId) async {
+    actions.add('resume:$artifactId');
+  }
 
   @override
-  Future<void> retry(String artifactId) async {}
+  Future<void> retry(String artifactId) async {
+    actions.add('retry:$artifactId');
+  }
 
   @override
-  Future<void> cancel(String artifactId) async {}
+  Future<void> cancel(String artifactId) async {
+    actions.add('cancel:$artifactId');
+  }
 
   @override
   Future<DownloadQueueSnapshot> getQueue() async => queue;
@@ -360,6 +369,209 @@ void main() {
               as ModelAcquisitionDone;
 
       expect(failed.failedFileNames, contains('ggml-tiny.en.bin'));
+    },
+  );
+
+  test(
+    'airplane mode: a completed install still reports installed without network',
+    () async {
+      final provider = DownloadModelProvider(
+        downloadService: service,
+        requiredModelsLookup: () async => [_whisper()],
+        downloadUrlFor: (_) => 'https://example.test/ggml-tiny.en.bin',
+      );
+      File('${modelsDir.path}/ggml-tiny.en.bin')
+        ..createSync()
+        ..writeAsBytesSync(List.filled(_whisper().sizeBytes.toInt(), 0));
+
+      expect(await provider.isInstalled(modelsDir), isTrue);
+
+      final events = await provider.acquire(modelsDir).toList();
+
+      expect(downloads.requests, isEmpty);
+      expect(
+        events.last,
+        isA<ModelAcquisitionDone>().having(
+          (e) => e.failedFileNames,
+          'failedFileNames',
+          isEmpty,
+        ),
+      );
+    },
+  );
+
+  test(
+    'acquire resumes a paused platform queue entry from retained partial bytes',
+    () async {
+      final provider = DownloadModelProvider(
+        downloadService: service,
+        requiredModelsLookup: () async => [_whisper()],
+        downloadUrlFor: (_) => 'https://example.test/ggml-tiny.en.bin',
+        stallThreshold: const Duration(days: 1),
+      );
+      when(
+        () => storage.verifyModelIntegrity(any()),
+      ).thenAnswer((_) async => false);
+      when(
+        () => storage.hasEnoughDiskSpace(any()),
+      ).thenAnswer((_) async => true);
+      when(
+        () => storage.getModelPath(any(), model: any(named: 'model')),
+      ).thenAnswer((_) async => '${stagingDir.path}/ggml-tiny.en.bin');
+      when(
+        () => storage.findExistingModelPath(any(), model: any(named: 'model')),
+      ).thenAnswer((_) async => null);
+
+      downloads.queue = const DownloadQueueSnapshot(
+        entries: [
+          DownloadProgress(
+            artifactId: 'ggml-tiny.en',
+            status: DownloadStatus.paused,
+            downloadedBytes: 40_000_000,
+            totalBytes: 77704715,
+            resumeSupported: true,
+          ),
+        ],
+      );
+
+      final events = <ModelAcquisitionEvent>[];
+      final acquisition = provider.acquire(modelsDir).forEach(events.add);
+      await Future<void>.delayed(Duration.zero);
+
+      expect(downloads.actions, contains('resume:ggml-tiny.en'));
+      expect(
+        events.whereType<ModelAcquisitionProgress>().first.fetched,
+        40_000_000,
+      );
+
+      downloads.eventController.add(
+        const DownloadProgress(
+          artifactId: 'ggml-tiny.en',
+          status: DownloadStatus.failed,
+          downloadedBytes: 40_000_000,
+          totalBytes: 77704715,
+          resumeSupported: true,
+        ),
+      );
+      await acquisition;
+
+      final done = events.last as ModelAcquisitionDone;
+      expect(done.failedFileNames, contains('ggml-tiny.en.bin'));
+      expect(done.resumeSupported, isTrue);
+    },
+  );
+
+  test(
+    'stall watchdog fails a silent transfer so the UI can offer resume',
+    () async {
+      final provider = DownloadModelProvider(
+        downloadService: service,
+        requiredModelsLookup: () async => [_whisper()],
+        downloadUrlFor: (_) => 'https://example.test/ggml-tiny.en.bin',
+        stallThreshold: const Duration(milliseconds: 40),
+        stallPollInterval: const Duration(milliseconds: 10),
+      );
+      when(
+        () => storage.verifyModelIntegrity(any()),
+      ).thenAnswer((_) async => false);
+      when(
+        () => storage.hasEnoughDiskSpace(any()),
+      ).thenAnswer((_) async => true);
+      when(
+        () => storage.getModelPath(any(), model: any(named: 'model')),
+      ).thenAnswer((_) async => '${stagingDir.path}/ggml-tiny.en.bin');
+      when(
+        () => storage.findExistingModelPath(any(), model: any(named: 'model')),
+      ).thenAnswer((_) async => null);
+
+      final events = <ModelAcquisitionEvent>[];
+      final acquisition = provider.acquire(modelsDir).forEach(events.add);
+      await Future<void>.delayed(Duration.zero);
+      expect(downloads.requests, hasLength(1));
+
+      // Platform reports downloading with no further byte movement.
+      downloads.eventController.add(
+        const DownloadProgress(
+          artifactId: 'ggml-tiny.en',
+          status: DownloadStatus.downloading,
+          downloadedBytes: 1_000_000,
+          totalBytes: 77704715,
+          speedBytesPerSecond: 0,
+        ),
+      );
+      await acquisition.timeout(const Duration(seconds: 2));
+
+      final done = events.last as ModelAcquisitionDone;
+      expect(done.failedFileNames, contains('ggml-tiny.en.bin'));
+      expect(done.resumeSupported, isTrue);
+    },
+  );
+
+  test(
+    'wrong-sized leftover is not treated as installed and is replaced atomically',
+    () async {
+      final provider = DownloadModelProvider(
+        downloadService: service,
+        requiredModelsLookup: () async => [_whisper()],
+        downloadUrlFor: (_) => 'https://example.test/ggml-tiny.en.bin',
+      );
+      File('${modelsDir.path}/ggml-tiny.en.bin')
+        ..createSync()
+        ..writeAsBytesSync(const [1, 2, 3]);
+      File('${modelsDir.path}/ggml-tiny.en.bin.partial')
+        ..createSync()
+        ..writeAsBytesSync(const [9]);
+
+      expect(await provider.isInstalled(modelsDir), isFalse);
+
+      var integrityChecks = 0;
+      when(() => storage.verifyModelIntegrity(any())).thenAnswer((_) async {
+        integrityChecks++;
+        return integrityChecks > 1;
+      });
+      when(
+        () => storage.hasEnoughDiskSpace(any()),
+      ).thenAnswer((_) async => true);
+      String stagingPathFor(Invocation invocation) =>
+          '${stagingDir.path}/${invocation.positionalArguments.first}.bin';
+      when(
+        () => storage.getModelPath(any(), model: any(named: 'model')),
+      ).thenAnswer((invocation) async => stagingPathFor(invocation));
+      when(
+        () => storage.findExistingModelPath(any(), model: any(named: 'model')),
+      ).thenAnswer((invocation) async {
+        final candidate = File(stagingPathFor(invocation));
+        return candidate.existsSync() ? candidate.path : null;
+      });
+      when(() => storage.writeInstallReceipt(any())).thenAnswer(
+        (_) async => ModelInstallReceipt(
+          modelId: _whisper().fileName,
+          catalogFingerprint: 'test',
+          installedAt: DateTime(2026),
+        ),
+      );
+
+      final staged = File('${stagingDir.path}/ggml-tiny.en.bin');
+      final events = <ModelAcquisitionEvent>[];
+      final acquisition = provider.acquire(modelsDir).forEach(events.add);
+      await Future<void>.delayed(Duration.zero);
+      staged.writeAsBytesSync(List.filled(_whisper().sizeBytes.toInt(), 0));
+      downloads.eventController.add(
+        DownloadProgress(
+          artifactId: downloads.requests.single.artifactId,
+          status: DownloadStatus.completed,
+          downloadedBytes: _whisper().sizeBytes,
+          totalBytes: _whisper().sizeBytes,
+        ),
+      );
+      await acquisition;
+
+      expect((events.last as ModelAcquisitionDone).failedFileNames, isEmpty);
+      expect(await provider.isInstalled(modelsDir), isTrue);
+      expect(
+        File('${modelsDir.path}/ggml-tiny.en.bin.partial').existsSync(),
+        isFalse,
+      );
     },
   );
 }

--- a/packages/feature_mind/test/models/download_reliability_manual.md
+++ b/packages/feature_mind/test/models/download_reliability_manual.md
@@ -1,0 +1,27 @@
+# Mind first-run download reliability — manual note
+
+## Acceptance
+
+- Retry UI shows **Resume download** / **Try again** after fail or stall
+- Progress persists across restart when WorkManager / URLSession retains partials
+- Failed file names are named on screen (not silent skip)
+- Unit tests cover coordinator + provider stall watchdogs (no 570 MB CI download)
+
+## Device verification
+
+**Blocked on Pixel 9 for this agent pass:** `adb devices` listed no
+attached devices (daemon started empty). No emulator was provisioned for the
+~570 MB scribe bundle walk.
+
+Covered instead by:
+
+```bash
+cd packages/core_ai && flutter test test/download/
+cd packages/feature_mind && flutter test test/models/download_model_provider_test.dart
+cd packages/feature_mind && flutter test test/models/model_download_coordinator_test.dart
+cd packages/feature_mind && flutter test test/model_acquisition_test.dart
+```
+
+Re-run on Pixel 9 before release dogfood: kill the app mid-download of the
+scribe bundle, relaunch Mind, confirm **Resume download** continues from the
+`.part` file rather than `modelsMissing` with a silent hang.

--- a/packages/feature_mind/test/models/model_download_coordinator_test.dart
+++ b/packages/feature_mind/test/models/model_download_coordinator_test.dart
@@ -311,5 +311,35 @@ void main() {
       );
       await sub.cancel();
     });
+
+    test('emits stalled when bytes stop moving for the stall window', () async {
+      final port = FakeModelPort(usedBytes: 0, budgetBytes: 1000);
+      final coordinator = ModelDownloadCoordinator(
+        models: port,
+        connectivity: FakeConnectivity(),
+        stallThreshold: const Duration(milliseconds: 40),
+        stallPollInterval: const Duration(milliseconds: 10),
+      );
+
+      final states = <ModelDownloadState>[];
+      final sub = coordinator
+          .download('m1', sizeBytes: 500)
+          .listen(states.add);
+      await Future<void>.delayed(Duration.zero);
+
+      port.controllerFor('m1').add((received: 100, total: 500));
+      await Future<void>.delayed(Duration.zero);
+      expect(
+        states,
+        contains(const ModelDownloadInProgress(received: 100, total: 500)),
+      );
+
+      await Future<void>.delayed(const Duration(milliseconds: 80));
+      expect(
+        states.last,
+        const ModelDownloadStalled(received: 100, total: 500),
+      );
+      await sub.cancel();
+    });
   });
 }


### PR DESCRIPTION
## Summary
- Stall watchdogs on `DownloadModelProvider` / `ModelDownloadCoordinator` fail silent transfers after the no-progress window and keep resume metadata for partials.
- `ModelDownloadService.recoverDownload` prefers platform resume over cold retry; `restoreQueue` no longer blocks re-enqueue of failed jobs.
- Atomic `.partial` → final install (provider + bundled installer) clears wrong-sized leftovers so corrupt files never load; first-run UI offers **Resume download** / **Try again**.

Closes #1772. Part of #1770. Related: #1630, #1769.

## Test plan
- [x] `cd packages/core_ai && flutter test test/download/` (22)
- [x] `cd packages/feature_mind && flutter test test/models/download_model_provider_test.dart test/models/model_download_coordinator_test.dart test/model_acquisition_test.dart`
- [x] `flutter analyze` on touched download/mind paths (info-only initializing-formals)
- [ ] Pixel 9: interrupt mid-download → relaunch → Resume → verified install (post-merge / device gate)


Made with [Cursor](https://cursor.com)