### PR TITLE
feat(mind): multilingual badge + honest on-device copy (#1774)

### DIFF
--- a/app/lib/core/mind/mind_model_sources.dart
+++ b/app/lib/core/mind/mind_model_sources.dart
@@ -65,6 +65,8 @@ MindService buildMindDownloadService() {
   return MindService(
     // Hindi/Marathi/English code-switching in meetings needs multilingual
     // whisper weights and auto-detect per recording (`#1629`, `#1664`).
+    // Settings can opt into English-only; [requiredModelsLookup] re-reads
+    // that preference so the multilingual file is not forced on download.
     defaultSpeechLanguage: rust.SpeechLanguage.multilingual,
     modelProvider: DownloadModelProvider(
       // Application support, not documents. Airo Mind keeps its models in the
@@ -76,9 +78,15 @@ MindService buildMindDownloadService() {
       downloadService: ModelDownloadService(
         storageLocation: ModelStorageLocation.applicationSupport,
       ),
-      // Default weights plus the optional multilingual speech model Mind
-      // always ships (`mindScribeRequiredModels`).
-      requiredModelsLookup: mindScribeRequiredModels,
+      // Default weights plus multilingual when Settings is on Auto (mixed).
+      // English opt-in (#1774) drops the multilingual row so first-run never
+      // spends ~78 MB the user did not ask for.
+      requiredModelsLookup: () async {
+        final mode = await loadSpeechLanguageMode();
+        return mindScribeRequiredModels(
+          includeMultilingual: mode.includesMultilingualModel,
+        );
+      },
       downloadUrlFor: mindModelDownloadUrlFor,
     ),
   );

--- a/app/lib/core/mind/mind_processing_queue.dart
+++ b/app/lib/core/mind/mind_processing_queue.dart
@@ -24,6 +24,9 @@ List<Override> mindMeetingProcessingOverrides(MindService service) => [
       // mid-queue has it apply to the very next job that finishes or fails,
       // not just ones enqueued after the change.
       retentionPolicy: () => ref.read(audioRetentionPolicyProvider),
+      // Same live-read pattern for #1664 language mode → process(language:)
+      // and ensureReady(speechLanguage:).
+      languageMode: () => ref.read(speechLanguageModeProvider),
     );
     final queue = MeetingProcessingQueue(
       store: FileMeetingProcessingQueueStore(path),

--- a/packages/feature_mind/lib/feature_mind.dart
+++ b/packages/feature_mind/lib/feature_mind.dart
@@ -119,7 +119,11 @@ export 'src/models/model_provider.dart'
 // model-descriptor boundary adapter (#1673) alongside the rest of the
 // bridge <-> RequiredModel/InstalledModel/OfflineModelInfo translation.
 export 'src/models/model_descriptor_adapter.dart'
-    show pinnedRequiredModels, mindScribeRequiredModels, pinnedMultilingualSpeechModel, offlineModelInfoFromRequiredModel;
+    show
+        pinnedRequiredModels,
+        mindScribeRequiredModels,
+        pinnedMultilingualSpeechModel,
+        offlineModelInfoFromRequiredModel;
 
 // Model download manager (#1457): progress in bytes, mobile-data pause,
 // storage budget — built on `ModelPort` rather than on `ModelProvider`
@@ -201,6 +205,11 @@ export 'src/widgets/mind_everything_browser.dart';
 export 'src/widgets/mind_command_palette_scope.dart';
 export 'src/widgets/mind_native_menu_bar.dart';
 
+// #1774 trust UX — multilingual / language badge + honest offline copy on
+// scribe and meeting surfaces. Complements #1664 without shipping the pin UI.
+export 'src/trust/scribe_trust_state.dart';
+export 'src/trust/scribe_trust_signals.dart';
+
 // Provenance — on-device entity extraction and the Inspector (surfaces 09
 // and 11, issue #1463).
 export 'src/provenance/domain/models/extracted_entity.dart';
@@ -238,6 +247,7 @@ export 'src/notes/presentation/notes_screen.dart';
 // accepting one that already exists on disk.
 export 'src/capture/domain/meeting_recording_state.dart';
 export 'src/capture/domain/audio_retention_policy.dart';
+export 'src/capture/domain/speech_language_mode.dart';
 export 'src/capture/domain/meeting_processing_job.dart';
 export 'src/capture/data/audio_recorder_port.dart';
 export 'src/capture/data/meeting_recording_service_gateway.dart';
@@ -247,5 +257,9 @@ export 'src/capture/application/meeting_processing_queue.dart';
 export 'src/capture/application/meeting_processing_job_runner.dart';
 export 'src/capture/application/meeting_capture_providers.dart';
 export 'src/capture/application/audio_retention_preference.dart';
+export 'src/capture/application/speech_language_preference.dart';
 export 'src/capture/presentation/meeting_capture_screen.dart';
 export 'src/capture/presentation/audio_retention_settings_tile.dart';
+export 'src/capture/presentation/speech_language_settings_tile.dart';
+export 'src/trust/scribe_trust_signals.dart';
+export 'src/trust/scribe_trust_state.dart';

--- a/packages/feature_mind/lib/src/agent_chat/presentation/screens/profile_screen.dart
+++ b/packages/feature_mind/lib/src/agent_chat/presentation/screens/profile_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import '../../../capture/presentation/audio_retention_settings_tile.dart';
+import '../../../capture/presentation/speech_language_settings_tile.dart';
 import '../../../host/assistant_host_adapter.dart';
 import '../../../quotes/presentation/widgets/daily_quote_card.dart';
 import '../../../routing/assistant_route_names.dart';
@@ -78,6 +79,7 @@ class ProfileScreen extends ConsumerWidget {
               style: Theme.of(context).textTheme.titleMedium,
             ),
             const AudioRetentionSettingsTile(),
+            const SpeechLanguageSettingsTile(),
 
             const SizedBox(height: 32),
 

--- a/packages/feature_mind/lib/src/assistant/presentation/screens/audio_scribe_screen.dart
+++ b/packages/feature_mind/lib/src/assistant/presentation/screens/audio_scribe_screen.dart
@@ -3,6 +3,8 @@ import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import '../../../services/voice_search_service.dart';
+import '../../../trust/scribe_trust_signals.dart';
+import '../../../trust/scribe_trust_state.dart';
 import '../../consent/audio_scribe_consent_gate.dart';
 import '../../consent/jurisdiction_consent_rules.dart';
 import '../../consent/mind_runtime_provider.dart';
@@ -180,6 +182,10 @@ class _AudioScribeScreenState extends ConsumerState<AudioScribeScreen> {
           const Text(
             'Capture speech, review the transcript, then send it to an installed model for translation or summarisation.',
           ),
+          const SizedBox(height: 12),
+          // #1774: listen-mode prefers India locales (#1769); capture itself
+          // is on-device. Translation is a separate, explicit hand-off.
+          const ScribeTrustSignals(state: ScribeTrustState.audioScribeListen()),
           const SizedBox(height: 12),
           _VoiceHealthPanel(
             availability: available,

--- a/packages/feature_mind/lib/src/capture/application/meeting_processing_job_runner.dart
+++ b/packages/feature_mind/lib/src/capture/application/meeting_processing_job_runner.dart
@@ -3,6 +3,8 @@ import 'dart:io';
 import '../../mind_service.dart';
 import '../domain/audio_retention_policy.dart';
 import '../domain/meeting_processing_job.dart';
+import '../domain/speech_language_mode.dart';
+import 'speech_language_preference.dart';
 
 /// Adapts [MindService.process] (the existing "transcribe → minutes → save"
 /// pipeline, `mind_service.dart`) into the
@@ -31,14 +33,20 @@ class MeetingProcessingJobRunner {
   MeetingProcessingJobRunner({
     required MindService mindService,
     required AudioRetentionPolicy Function() retentionPolicy,
+    SpeechLanguageMode Function()? languageMode,
   }) : _mindService = mindService,
-       _retentionPolicy = retentionPolicy;
+       _retentionPolicy = retentionPolicy,
+       _languageMode = languageMode ?? (() => SpeechLanguageMode.fallback);
 
   final MindService _mindService;
   final AudioRetentionPolicy Function() _retentionPolicy;
+  final SpeechLanguageMode Function() _languageMode;
 
   Future<void> call(MeetingProcessingJob job) async {
-    final ready = await _mindService.ensureReady();
+    final mode = _languageMode();
+    final ready = await _mindService.ensureReady(
+      speechLanguage: mode.speechLanguage,
+    );
     if (!ready.isReady) {
       throw StateError(ready.detail.isNotEmpty ? ready.detail : 'Mind is not ready.');
     }
@@ -46,6 +54,7 @@ class MeetingProcessingJobRunner {
     await for (final progress in _mindService.process(
       wavPath: job.audioPath,
       title: job.title,
+      language: mode.processLanguageCode,
     )) {
       last = progress;
     }

--- a/packages/feature_mind/lib/src/capture/application/speech_language_preference.dart
+++ b/packages/feature_mind/lib/src/capture/application/speech_language_preference.dart
@@ -1,0 +1,51 @@
+import 'package:flutter_riverpod/legacy.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../../whisper/api/meetings.dart' as rust;
+import '../domain/speech_language_mode.dart';
+
+/// Persistence key for the Mind capture language Settings tile (#1664 / #1774).
+/// Same `SharedPreferences` house pattern as [audioRetentionPolicyKey].
+const String speechLanguageModeKey = 'mind_speech_language_mode';
+
+final speechLanguageModeProvider =
+    StateNotifierProvider<SpeechLanguageModeNotifier, SpeechLanguageMode>(
+      (ref) => SpeechLanguageModeNotifier(),
+    );
+
+class SpeechLanguageModeNotifier extends StateNotifier<SpeechLanguageMode> {
+  SpeechLanguageModeNotifier() : super(SpeechLanguageMode.fallback) {
+    _load();
+  }
+
+  Future<void> _load() async {
+    final prefs = await SharedPreferences.getInstance();
+    state = SpeechLanguageMode.fromStorageValue(
+      prefs.getString(speechLanguageModeKey),
+    );
+  }
+
+  Future<void> select(SpeechLanguageMode mode) async {
+    state = mode;
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(speechLanguageModeKey, mode.storageValue);
+  }
+}
+
+/// Bridge mapping kept next to the preference so domain stays free of FRB types.
+extension SpeechLanguageModeBridge on SpeechLanguageMode {
+  rust.SpeechLanguage get speechLanguage => switch (this) {
+    SpeechLanguageMode.auto => rust.SpeechLanguage.multilingual,
+    SpeechLanguageMode.english => rust.SpeechLanguage.englishOnly,
+  };
+}
+
+/// Reads the persisted mode without Riverpod — used by shell composition
+/// (`requiredModelsLookup`, `MindModule.initialize`) before a widget tree
+/// exists.
+Future<SpeechLanguageMode> loadSpeechLanguageMode() async {
+  final prefs = await SharedPreferences.getInstance();
+  return SpeechLanguageMode.fromStorageValue(
+    prefs.getString(speechLanguageModeKey),
+  );
+}

--- a/packages/feature_mind/lib/src/capture/domain/speech_language_mode.dart
+++ b/packages/feature_mind/lib/src/capture/domain/speech_language_mode.dart
@@ -1,0 +1,47 @@
+/// Transcription language mode for meeting capture (#1664 / #1774).
+///
+/// Two product choices, not a full language picker:
+/// - [auto] — multilingual whisper weights and per-recording auto-detect
+///   (mixed Marathi / Hindi / English and similar code-switching).
+/// - [english] — English-only weights and a pinned `"en"` hint, so English-only
+///   users never have to download the multilingual model.
+///
+/// Maps to `MindService.initialize(speechLanguage:)` (which model loads) and
+/// `MindService.process(language:)` (whisper.cpp language pin / auto-detect).
+library;
+
+enum SpeechLanguageMode {
+  /// Multilingual model + auto-detect. Default for the Mind shell.
+  auto,
+
+  /// English-only model + pin `en`. Opt-in to skip the multilingual download.
+  english;
+
+  /// Product default: mixed-language meetings are first-class (#1629).
+  static const SpeechLanguageMode fallback = SpeechLanguageMode.auto;
+
+  String get storageValue => name;
+
+  /// Badge / chip label on record surfaces.
+  String get badgeLabel => switch (this) {
+    SpeechLanguageMode.auto => 'Multilingual · auto-detect',
+    SpeechLanguageMode.english => 'English',
+  };
+
+  /// Whisper.cpp language code for [MindService.process], or `null` to leave
+  /// auto-detect on.
+  String? get processLanguageCode => switch (this) {
+    SpeechLanguageMode.auto => null,
+    SpeechLanguageMode.english => 'en',
+  };
+
+  /// Whether first-run download must include the multilingual speech weights.
+  bool get includesMultilingualModel => this == SpeechLanguageMode.auto;
+
+  static SpeechLanguageMode fromStorageValue(String? value) {
+    return SpeechLanguageMode.values.firstWhere(
+      (mode) => mode.storageValue == value,
+      orElse: () => fallback,
+    );
+  }
+}

--- a/packages/feature_mind/lib/src/capture/presentation/meeting_capture_screen.dart
+++ b/packages/feature_mind/lib/src/capture/presentation/meeting_capture_screen.dart
@@ -4,8 +4,11 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../assistant/consent/audio_scribe_consent_gate.dart';
 import '../../assistant/consent/jurisdiction_consent_rules.dart';
 import '../../assistant/consent/mind_runtime_provider.dart';
+import '../../trust/scribe_trust_signals.dart';
+import '../../trust/scribe_trust_state.dart';
 import '../application/meeting_capture_controller.dart';
 import '../application/meeting_capture_providers.dart';
+import '../application/speech_language_preference.dart';
 import '../domain/meeting_processing_job.dart';
 import '../domain/meeting_recording_state.dart';
 
@@ -128,6 +131,7 @@ class _MeetingCaptureScreenState extends ConsumerState<MeetingCaptureScreen> {
     final recording = lifecycle == MeetingRecordingLifecycle.recording;
     final paused = lifecycle == MeetingRecordingLifecycle.paused;
     final active = recording || paused;
+    final languageMode = ref.watch(speechLanguageModeProvider);
 
     return Scaffold(
       appBar: AppBar(title: const Text('Record meeting')),
@@ -135,6 +139,11 @@ class _MeetingCaptureScreenState extends ConsumerState<MeetingCaptureScreen> {
         padding: const EdgeInsets.fromLTRB(16, 12, 16, 32),
         children: [
           const _ConsentReminder(),
+          const SizedBox(height: 12),
+          // #1774: settings-driven multilingual / English badge + offline copy.
+          ScribeTrustSignals(
+            state: ScribeTrustState.fromSpeechLanguageMode(languageMode),
+          ),
           const SizedBox(height: 12),
           _ConsentJurisdictionPicker(
             jurisdiction: _jurisdiction,

--- a/packages/feature_mind/lib/src/capture/presentation/speech_language_settings_tile.dart
+++ b/packages/feature_mind/lib/src/capture/presentation/speech_language_settings_tile.dart
@@ -1,0 +1,49 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../application/speech_language_preference.dart';
+import '../domain/speech_language_mode.dart';
+
+/// Settings control for #1664 / #1774 — Primary language vs Auto (mixed).
+///
+/// Drop into the Mind Profile / capture settings surface next to
+/// [AudioRetentionSettingsTile]. Choosing English skips the multilingual
+/// whisper download on the next model acquisition; Auto keeps mixed-language
+/// auto-detect.
+class SpeechLanguageSettingsTile extends ConsumerWidget {
+  const SpeechLanguageSettingsTile({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final mode = ref.watch(speechLanguageModeProvider);
+
+    return ListTile(
+      key: const Key('speech_language_settings_tile'),
+      title: const Text('Meeting transcription language'),
+      subtitle: Text(
+        mode == SpeechLanguageMode.auto
+            ? 'Auto (mixed) — multilingual model, auto-detect per recording. '
+                  'Best for Marathi / Hindi / English code-switching.'
+            : 'English — English-only model. Skips the multilingual download.',
+      ),
+      trailing: DropdownButton<SpeechLanguageMode>(
+        key: const Key('speech_language_settings_dropdown'),
+        value: mode,
+        onChanged: (value) {
+          if (value == null) return;
+          ref.read(speechLanguageModeProvider.notifier).select(value);
+        },
+        items: const [
+          DropdownMenuItem(
+            value: SpeechLanguageMode.auto,
+            child: Text('Auto (mixed)'),
+          ),
+          DropdownMenuItem(
+            value: SpeechLanguageMode.english,
+            child: Text('English'),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/packages/feature_mind/lib/src/meeting_screen.dart
+++ b/packages/feature_mind/lib/src/meeting_screen.dart
@@ -4,6 +4,7 @@ import 'export/application/meeting_export_service.dart';
 import 'export/data/meeting_export_gateway.dart';
 import 'whisper/api/meetings.dart' as rust;
 import 'mind_service.dart';
+import 'trust/scribe_trust_signals.dart';
 
 /// Transcript and minutes — live, or reopened.
 ///
@@ -166,6 +167,10 @@ class _MeetingScreenState extends State<MeetingScreen> {
       body: ListView(
         padding: const EdgeInsets.all(16),
         children: [
+          ScribeTrustSignals(
+            state: widget.service.scribeTrustState(),
+          ),
+          const SizedBox(height: 12),
           if (_isRunning) const LinearProgressIndicator(),
           if (_stageLabel.isNotEmpty)
             Padding(

--- a/packages/feature_mind/lib/src/mind_home_screen.dart
+++ b/packages/feature_mind/lib/src/mind_home_screen.dart
@@ -2,11 +2,13 @@ import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 
 import 'whisper/api/meetings.dart' as rust;
+import 'capture/application/speech_language_preference.dart';
 import 'export/application/meeting_export_service.dart';
 import 'export/data/meeting_export_gateway.dart';
 import 'meeting_screen.dart';
 import 'mind_service.dart';
 import 'models/model_provider.dart';
+import 'trust/scribe_trust_signals.dart';
 
 /// The whole app. Record, search, open.
 ///
@@ -65,7 +67,10 @@ class _MindHomeScreenState extends State<MindHomeScreen> {
   }
 
   Future<void> _start() async {
-    final status = await widget.service.initialize();
+    final mode = await loadSpeechLanguageMode();
+    final status = await widget.service.initialize(
+      speechLanguage: mode.speechLanguage,
+    );
     if (!mounted) return;
     setState(() {
       _status = status;
@@ -109,7 +114,13 @@ class _MindHomeScreenState extends State<MindHomeScreen> {
       if (path == null) return;
 
       final title = 'Meeting ${_meetings.length + 1}';
-      final progress = widget.service.process(wavPath: path, title: title);
+      final mode = await loadSpeechLanguageMode();
+      if (!mounted) return;
+      final progress = widget.service.process(
+        wavPath: path,
+        title: title,
+        language: mode.processLanguageCode,
+      );
       await Navigator.of(context).push(
         MaterialPageRoute<void>(
           builder: (_) => MeetingScreen.live(
@@ -250,6 +261,12 @@ class _MindHomeScreenState extends State<MindHomeScreen> {
     final hits = _hits;
     return Column(
       children: [
+        Padding(
+          padding: const EdgeInsets.fromLTRB(12, 12, 12, 0),
+          child: ScribeTrustSignals(
+            state: widget.service.scribeTrustState(),
+          ),
+        ),
         Padding(
           padding: const EdgeInsets.all(12),
           child: TextField(
@@ -500,6 +517,10 @@ class _ModelDownloadState extends State<_ModelDownload> {
               'and writing models on disk before it can record. They are '
               'downloaded once and never leave this device.',
               textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 12),
+            ScribeTrustSignals(
+              state: widget.service.scribeTrustState(modelMissing: true),
             ),
             const SizedBox(height: 8),
             const Text(

--- a/packages/feature_mind/lib/src/mind_module.dart
+++ b/packages/feature_mind/lib/src/mind_module.dart
@@ -15,6 +15,7 @@ import 'assistant/presentation/screens/assistant_screen.dart';
 import 'assistant/presentation/screens/audio_scribe_screen.dart';
 import 'assistant/presentation/screens/mobile_actions_screen.dart';
 import 'assistant/presentation/screens/prompt_lab_screen.dart';
+import 'capture/application/speech_language_preference.dart';
 import 'capture/presentation/meeting_capture_screen.dart';
 import 'host/assistant_host_adapter.dart';
 import 'mind_home_screen.dart';
@@ -118,8 +119,11 @@ class MindModule extends AppModule {
   Future<void> initialize() async {
     if (createService != null) {
       // Warm the scribe pipeline so queued meeting jobs and the first Record
-      // tap do not hit an uninitialized whisper runtime.
-      await service.ensureReady();
+      // tap do not hit an uninitialized whisper runtime. Honour Settings'
+      // language mode (#1664) so an English-only opt-in does not load the
+      // multilingual weights on cold start.
+      final mode = await loadSpeechLanguageMode();
+      await service.ensureReady(speechLanguage: mode.speechLanguage);
     }
   }
 

--- a/packages/feature_mind/lib/src/mind_service.dart
+++ b/packages/feature_mind/lib/src/mind_service.dart
@@ -13,6 +13,7 @@ import 'model_installer.dart';
 import 'models/model_provider.dart';
 import 'search/meeting_embedding_store.dart';
 import 'search/semantic_search_ranker.dart';
+import 'trust/scribe_trust_state.dart';
 import 'whisper/api/meetings.dart' as rust;
 
 /// Why Airo Mind cannot start. Each case is one the user can act on, which is
@@ -135,6 +136,28 @@ class MindService {
   final MindGenerationBridge _generation;
   final rust.SpeechLanguage _defaultSpeechLanguage;
 
+  /// Last language mode handed to [MindSpeechBridge.initialize], or the
+  /// constructor default before the first successful init. Read-only seam
+  /// for #1774 trust badges — not the #1664 pin UI.
+  rust.SpeechLanguage? _activeSpeechLanguage;
+
+  /// Speech-model language mode the pipeline is configured for (#1629).
+  ///
+  /// Thin read-only seam for multilingual / language badges (#1774). Does
+  /// not expose or set a per-recording whisper.cpp pin — that remains #1664.
+  rust.SpeechLanguage get speechLanguage =>
+      _activeSpeechLanguage ?? _defaultSpeechLanguage;
+
+  /// Trust UX snapshot for scribe/meeting surfaces (#1774).
+  ScribeTrustState scribeTrustState({
+    bool modelMissing = false,
+    String? pinnedLanguageCode,
+  }) => ScribeTrustState.forSpeechModel(
+    multilingual: speechLanguage == rust.SpeechLanguage.multilingual,
+    modelMissing: modelMissing,
+    pinnedLanguageCode: pinnedLanguageCode,
+  );
+
   /// Built lazily against [modelsDirectory] rather than in the constructor:
   /// resolving that directory is async, and every other collaborator here is
   /// a ready-made instance. [rankerBuilder] is the seam a test substitutes
@@ -149,21 +172,26 @@ class MindService {
   /// Returns a status rather than throwing: on a real device "the models are
   /// not downloaded yet" is the ordinary first-run state, and an exception
   /// would make the app's normal opening move look like a crash.
-  /// [speechLanguage] is `#1629`: defaults to the bundled English-only model,
-  /// unchanged from before this parameter existed. Passing `multilingual`
-  /// requires the multilingual weights to already be installed — this method
-  /// does not acquire them; it only asks the Model Manager to resolve against
-  /// them. Choosing this per user is #1664's job.
-  /// Loads speech if needed. Safe to call before every pipeline run — a no-op
-  /// when [initialize] already succeeded.
-  Future<MindStatus> ensureReady() async {
-    if (_speech.isReady()) return const MindStatus.ready();
-    return initialize();
+  ///
+  /// [speechLanguage] is `#1629` / `#1664`: defaults to
+  /// [_defaultSpeechLanguage] (English-only unless the shell overrides).
+  /// Passing `multilingual` requires the multilingual weights to already be
+  /// installed — this method does not acquire them; it only asks the Model
+  /// Manager to resolve against them.
+  ///
+  /// [ensureReady] is safe to call before every pipeline run — a no-op when
+  /// [initialize] already succeeded for the same [speechLanguage]. A Settings
+  /// change (#1664) that picks a different mode re-runs initialize so the
+  /// speech bridge sees the new weights / pin.
+  Future<MindStatus> ensureReady({rust.SpeechLanguage? speechLanguage}) async {
+    final desired = speechLanguage ?? _defaultSpeechLanguage;
+    if (_speech.isReady() && _activeSpeechLanguage == desired) {
+      return const MindStatus.ready();
+    }
+    return initialize(speechLanguage: desired);
   }
 
-  Future<MindStatus> initialize({
-    rust.SpeechLanguage? speechLanguage,
-  }) async {
+  Future<MindStatus> initialize({rust.SpeechLanguage? speechLanguage}) async {
     final language = speechLanguage ?? _defaultSpeechLanguage;
     try {
       // Only the speech library. Generation is loaded on first use — see
@@ -229,6 +257,7 @@ class MindService {
         memoryBudgetMb: 4096,
         speechLanguage: language,
       );
+      _activeSpeechLanguage = language;
       return const MindStatus.ready();
     } on Object catch (e) {
       return MindStatus.unavailable(MindUnavailable.loadFailed, '$e');

--- a/packages/feature_mind/lib/src/models/model_descriptor_adapter.dart
+++ b/packages/feature_mind/lib/src/models/model_descriptor_adapter.dart
@@ -81,12 +81,17 @@ const RequiredModel pinnedMultilingualSpeechModel = RequiredModel(
 );
 
 /// Everything the standalone Mind scribe downloads: default Milestone 2 weights
-/// plus the multilingual speech model Hindi/Marathi/English code-switching
-/// needs (`#1629`). The English-only row stays in the default registry for
-/// shells that never opt in; Mind ships both so auto-detect transcription
-/// works on first run.
-Future<List<RequiredModel>> mindScribeRequiredModels() async {
+/// plus, when [includeMultilingual] is true, the multilingual speech model
+/// Hindi/Marathi/English code-switching needs (`#1629`). The English-only row
+/// stays in the default registry for shells that never opt in; Mind's Auto
+/// (mixed) language preference (#1664 / #1774) includes both so auto-detect
+/// works on first run. English-only Settings opt-in sets
+/// [includeMultilingual] false so that download is never forced.
+Future<List<RequiredModel>> mindScribeRequiredModels({
+  bool includeMultilingual = true,
+}) async {
   final required = await pinnedRequiredModels();
+  if (!includeMultilingual) return required;
   if (required.any((m) => m.fileName == pinnedMultilingualSpeechModel.fileName)) {
     return required;
   }

--- a/packages/feature_mind/lib/src/trust/scribe_trust_signals.dart
+++ b/packages/feature_mind/lib/src/trust/scribe_trust_signals.dart
@@ -1,0 +1,116 @@
+import 'package:flutter/material.dart';
+
+import '../widgets/mind_palette.dart';
+import 'scribe_trust_state.dart';
+
+/// Language badge + honest offline/on-device copy for scribe/meeting surfaces.
+///
+/// #1774 trust UX. Uses [MindPalette] rather than Living Console tokens so
+/// Mind screens stay on the device-system visual language.
+class ScribeTrustSignals extends StatelessWidget {
+  const ScribeTrustSignals({required this.state, super.key});
+
+  final ScribeTrustState state;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final isAlarm =
+        state.languageMode == ScribeLanguageMode.modelMissing ||
+        state.languageMode == ScribeLanguageMode.unknown;
+    final badgeColor = isAlarm ? MindPalette.alarm : MindPalette.local;
+    final honesty = state.honestyNote;
+
+    return Semantics(
+      container: true,
+      label:
+          '${state.languageBadgeLabel}. '
+          '${state.offlineCopy}'
+          '${honesty == null ? '' : ' $honesty'}',
+      child: DecoratedBox(
+        key: const Key('scribe_trust_signals'),
+        decoration: BoxDecoration(
+          border: Border.all(color: MindPalette.grid),
+          color: MindPalette.surface.withValues(alpha: 0.35),
+        ),
+        child: Padding(
+          padding: const EdgeInsets.fromLTRB(12, 10, 12, 12),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Wrap(
+                spacing: 8,
+                runSpacing: 8,
+                crossAxisAlignment: WrapCrossAlignment.center,
+                children: [
+                  if (state.showLanguageBadge)
+                    _TrustBadge(
+                      key: const Key('scribe_trust_language_badge'),
+                      label: state.languageBadgeLabel,
+                      color: badgeColor,
+                    ),
+                  _TrustBadge(
+                    key: const Key('scribe_trust_offline_badge'),
+                    label: state.processingOnDevice
+                        ? 'On this device'
+                        : 'Network model',
+                    color: state.processingOnDevice
+                        ? MindPalette.local
+                        : MindPalette.remote,
+                  ),
+                ],
+              ),
+              const SizedBox(height: 8),
+              Text(
+                state.offlineCopy,
+                key: const Key('scribe_trust_offline_copy'),
+                style: theme.textTheme.bodySmall?.copyWith(
+                  color: theme.colorScheme.onSurface.withValues(alpha: 0.85),
+                ),
+              ),
+              if (honesty != null) ...[
+                const SizedBox(height: 6),
+                Text(
+                  honesty,
+                  key: const Key('scribe_trust_honesty_note'),
+                  style: theme.textTheme.bodySmall?.copyWith(
+                    color: isAlarm
+                        ? MindPalette.alarm
+                        : theme.colorScheme.onSurface.withValues(alpha: 0.7),
+                  ),
+                ),
+              ],
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _TrustBadge extends StatelessWidget {
+  const _TrustBadge({required this.label, required this.color, super.key});
+
+  final String label;
+  final Color color;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+      decoration: BoxDecoration(
+        border: Border.all(color: color.withValues(alpha: 0.7)),
+        color: color.withValues(alpha: 0.14),
+      ),
+      child: Text(
+        label,
+        style: TextStyle(
+          fontSize: 11,
+          fontWeight: FontWeight.w700,
+          letterSpacing: 0.4,
+          color: color,
+        ),
+      ),
+    );
+  }
+}

--- a/packages/feature_mind/lib/src/trust/scribe_trust_state.dart
+++ b/packages/feature_mind/lib/src/trust/scribe_trust_state.dart
@@ -1,0 +1,155 @@
+import '../capture/domain/speech_language_mode.dart';
+
+/// How language is being handled for a scribe/meeting surface (#1774).
+///
+/// Product UX only — the #1664 whisper language-pin plumbing stays out of
+/// scope unless a thin read-only seam feeds [pinnedLanguageCode].
+enum ScribeLanguageMode {
+  /// English-only speech weights (historical MindService default).
+  englishOnly,
+
+  /// Multilingual weights / multi-locale capture (Mind shell default after
+  /// #1769). Badge is shown because multi-language is active.
+  multilingual,
+
+  /// An explicit whisper.cpp language pin (`en`, `hi`, …). Badge shows the
+  /// code so the person can see what was requested.
+  pinned,
+
+  /// Auto-detect still running, or no language signal available yet.
+  unknown,
+
+  /// Multilingual (or pinned) processing needs a model that is not on disk.
+  modelMissing,
+}
+
+/// Immutable trust copy for scribe/meeting surfaces (#1774).
+///
+/// Keeps badge visibility and offline wording in one place so Audio Scribe,
+/// meeting capture, and the meeting reader cannot drift into false cloud
+/// claims or silent English-only assumptions.
+///
+/// Deliberately free of whisper FRB / freezed types so host widget tests can
+/// exercise this without codegen.
+class ScribeTrustState {
+  const ScribeTrustState({
+    required this.languageMode,
+    this.pinnedLanguageCode,
+    this.processingOnDevice = true,
+    this.modelMissingDetail,
+  });
+
+  /// Meeting / whisper path with multilingual weights (#1769).
+  const ScribeTrustState.meetingMultilingual()
+    : languageMode = ScribeLanguageMode.multilingual,
+      pinnedLanguageCode = null,
+      processingOnDevice = true,
+      modelMissingDetail = null;
+
+  /// Audio Scribe listen-mode: platform STT with India locale preference.
+  const ScribeTrustState.audioScribeListen()
+    : languageMode = ScribeLanguageMode.multilingual,
+      pinnedLanguageCode = null,
+      processingOnDevice = true,
+      modelMissingDetail = null;
+
+  /// Maps Settings' [SpeechLanguageMode] (#1664 thin seam) into trust UX.
+  factory ScribeTrustState.fromSpeechLanguageMode(
+    SpeechLanguageMode mode, {
+    bool modelMissing = false,
+  }) {
+    return ScribeTrustState.forSpeechModel(
+      multilingual: mode.includesMultilingualModel,
+      // English opt-in is english-only weights, not a visible `en` pin badge.
+      pinnedLanguageCode: null,
+      modelMissing: modelMissing,
+    );
+  }
+
+  /// Maps the #1629 speech-model selector into trust UX without requiring
+  /// the full #1664 pin UI. [multilingual] is true when multilingual whisper
+  /// weights (or multi-locale STT) are active.
+  factory ScribeTrustState.forSpeechModel({
+    required bool multilingual,
+    String? pinnedLanguageCode,
+    bool modelMissing = false,
+  }) {
+    if (modelMissing) {
+      return ScribeTrustState(
+        languageMode: ScribeLanguageMode.modelMissing,
+        pinnedLanguageCode: pinnedLanguageCode,
+        processingOnDevice: true,
+        modelMissingDetail: multilingual
+            ? 'The multilingual speech model is not installed yet. '
+                  'Install ggml-tiny.bin before recording Hindi, Marathi, '
+                  'or mixed-language meetings.'
+            : 'The speech model is not installed yet. Download it before '
+                  'recording — transcription runs only after the weights '
+                  'are on this device.',
+      );
+    }
+    if (pinnedLanguageCode != null && pinnedLanguageCode.trim().isNotEmpty) {
+      return ScribeTrustState(
+        languageMode: ScribeLanguageMode.pinned,
+        pinnedLanguageCode: pinnedLanguageCode.trim().toLowerCase(),
+      );
+    }
+    return ScribeTrustState(
+      languageMode: multilingual
+          ? ScribeLanguageMode.multilingual
+          : ScribeLanguageMode.englishOnly,
+    );
+  }
+
+  final ScribeLanguageMode languageMode;
+  final String? pinnedLanguageCode;
+  final bool processingOnDevice;
+  final String? modelMissingDetail;
+
+  /// Settings-driven badge (#1774): always show so Auto vs English is never
+  /// ambiguous on record surfaces. Unknown / model-missing stay visible too.
+  bool get showLanguageBadge => true;
+
+  String get languageBadgeLabel => switch (languageMode) {
+    ScribeLanguageMode.englishOnly => SpeechLanguageMode.english.badgeLabel,
+    ScribeLanguageMode.multilingual => SpeechLanguageMode.auto.badgeLabel,
+    ScribeLanguageMode.pinned => 'Language: ${pinnedLanguageCode ?? 'unknown'}',
+    ScribeLanguageMode.unknown => 'Language unknown',
+    ScribeLanguageMode.modelMissing => 'Speech model missing',
+  };
+
+  /// Short supporting line under the badge — never claims cloud processing
+  /// for the on-device meeting / scribe capture path.
+  String get offlineCopy {
+    if (languageMode == ScribeLanguageMode.modelMissing) {
+      return modelMissingDetail ??
+          'Speech models are not on this device yet. Nothing is uploaded '
+              'while they are missing.';
+    }
+    if (!processingOnDevice) {
+      // Reserved for a future hybrid path; meeting/scribe surfaces today
+      // always pass true so this branch stays unused in production.
+      return 'Processing may use a networked model you selected.';
+    }
+    if (languageMode == ScribeLanguageMode.unknown) {
+      return 'Transcription stays on this device. Language has not been '
+          'confirmed yet — auto-detect can mislabel short utterances.';
+    }
+    return 'Transcription runs on this device. Sharing is always an '
+        'explicit action.';
+  }
+
+  /// Optional second line for unknown / missing / multilingual honesty.
+  String? get honestyNote => switch (languageMode) {
+    ScribeLanguageMode.unknown =>
+      'Translation is never applied automatically — only when you ask.',
+    ScribeLanguageMode.modelMissing =>
+      'Airo Mind will not pretend multilingual capture works until the '
+          'weights are installed.',
+    ScribeLanguageMode.multilingual =>
+      'Spoken language is kept as-is. Translate only when you choose to.',
+    ScribeLanguageMode.pinned =>
+      'Pinned language is a hint to the on-device model, not a cloud translate.',
+    ScribeLanguageMode.englishOnly => null,
+  };
+}

--- a/packages/feature_mind/test/assistant/presentation/screens/audio_scribe_screen_test.dart
+++ b/packages/feature_mind/test/assistant/presentation/screens/audio_scribe_screen_test.dart
@@ -80,6 +80,9 @@ void main() {
       find.text('Speech recognition is ready on this device.'),
       findsOneWidget,
     );
+    expect(find.byKey(const Key('scribe_trust_signals')), findsOneWidget);
+    expect(find.text('Multilingual · auto-detect'), findsOneWidget);
+    expect(find.text('On this device'), findsOneWidget);
     expect(find.byKey(const Key('audio_scribe_voice_health')), findsOneWidget);
     expect(find.text('Speech service'), findsOneWidget);
     expect(find.text('Ready'), findsWidgets);

--- a/packages/feature_mind/test/capture/application/meeting_processing_job_runner_test.dart
+++ b/packages/feature_mind/test/capture/application/meeting_processing_job_runner_test.dart
@@ -8,6 +8,7 @@ import 'package:feature_mind/src/capture/domain/meeting_processing_job.dart';
 import 'package:feature_mind/src/capture/domain/speech_language_mode.dart';
 import 'package:feature_mind/src/mind_service.dart';
 import 'package:feature_mind/src/models/model_provider.dart';
+import 'package:feature_mind/src/whisper/api/meetings.dart' as rust;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
@@ -276,7 +277,10 @@ void main() {
 
       // ensureReady now re-inits when Settings picks a new speechLanguage;
       // with FakeReadyModelProvider that reaches the fake bridge.
-      expect(speech.initializedSpeechLanguage, isNotNull);
+      expect(
+        speech.initializedSpeechLanguage,
+        rust.SpeechLanguage.englishOnly,
+      );
       expect(speech.transcribeLanguage, 'en');
     },
   );

--- a/packages/feature_mind/test/capture/application/meeting_processing_job_runner_test.dart
+++ b/packages/feature_mind/test/capture/application/meeting_processing_job_runner_test.dart
@@ -5,7 +5,9 @@ import 'package:feature_mind/src/bridges/mind_speech_bridge.dart';
 import 'package:feature_mind/src/capture/application/meeting_processing_job_runner.dart';
 import 'package:feature_mind/src/capture/domain/audio_retention_policy.dart';
 import 'package:feature_mind/src/capture/domain/meeting_processing_job.dart';
+import 'package:feature_mind/src/capture/domain/speech_language_mode.dart';
 import 'package:feature_mind/src/mind_service.dart';
+import 'package:feature_mind/src/models/model_provider.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
@@ -19,6 +21,31 @@ import '../../support/fake_bridges.dart';
 /// already uses -- this runner never calls `MindService.start/stopRecording`,
 /// so nothing on the mock needs stubbing.
 class _MockAudioRecorder extends Mock implements AudioRecorder {}
+
+/// Models already on disk — avoids `ModelInstaller` hitting FRB in host tests.
+class _FakeReadyModelProvider implements ModelProvider {
+  @override
+  bool get acquiresWithoutNetwork => true;
+
+  @override
+  Future<List<RequiredModel>> requiredModels() async => const [];
+
+  @override
+  Future<List<RequiredModel>> missingModels(Directory modelsDir) async =>
+      const [];
+
+  @override
+  Future<bool> isInstalled(Directory modelsDir) async => true;
+
+  @override
+  Stream<ModelAcquisitionEvent> acquire(Directory modelsDir) async* {}
+
+  @override
+  Future<List<InstalledModel>> verify(Directory modelsDir) async => const [];
+
+  @override
+  Future<void> dispose() async {}
+}
 
 /// Minimal fake so `MindService.modelsDirectory()` resolves without a real
 /// platform channel -- same shape `mind_service_test.dart` already uses.
@@ -47,6 +74,7 @@ void main() {
     generation = FakeMindGenerationBridge();
     mindService = MindService(
       recorder: _MockAudioRecorder(),
+      modelProvider: _FakeReadyModelProvider(),
       speechBridge: speech,
       generationBridge: generation,
     );
@@ -210,6 +238,46 @@ void main() {
       );
 
       expect(audioFile.existsSync(), isTrue);
+    },
+  );
+
+  test(
+    'threads Settings language mode to ensureReady + process (#1664)',
+    () async {
+      speech.transcriptEvents = const [
+        TranscriptEventTranscriptReady('hello world', [
+          TranscriptSegment(
+            id: 's0',
+            startMs: 0,
+            endMs: 500,
+            text: 'hello world',
+          ),
+        ]),
+      ];
+      generation.generationEvents = const [
+        GenerationEventMinutesReady('Minutes.'),
+      ];
+      final audioFile = File('${tempDir.path}/meeting.wav')
+        ..writeAsStringSync('audio');
+      final runner = MeetingProcessingJobRunner(
+        mindService: mindService,
+        retentionPolicy: () => AudioRetentionPolicy.keepAfterTranscript,
+        languageMode: () => SpeechLanguageMode.english,
+      );
+
+      await runner.call(
+        MeetingProcessingJob(
+          id: 'm1',
+          audioPath: audioFile.path,
+          title: 'Standup',
+          enqueuedAtMs: 0,
+        ),
+      );
+
+      // ensureReady now re-inits when Settings picks a new speechLanguage;
+      // with FakeReadyModelProvider that reaches the fake bridge.
+      expect(speech.initializedSpeechLanguage, isNotNull);
+      expect(speech.transcribeLanguage, 'en');
     },
   );
 }

--- a/packages/feature_mind/test/capture/domain/speech_language_mode_test.dart
+++ b/packages/feature_mind/test/capture/domain/speech_language_mode_test.dart
@@ -1,0 +1,17 @@
+import 'package:feature_mind/src/capture/domain/speech_language_mode.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('Auto is the product default and requests multilingual weights', () {
+    expect(SpeechLanguageMode.fallback, SpeechLanguageMode.auto);
+    expect(SpeechLanguageMode.auto.includesMultilingualModel, isTrue);
+    expect(SpeechLanguageMode.auto.processLanguageCode, isNull);
+    expect(SpeechLanguageMode.auto.badgeLabel, 'Multilingual · auto-detect');
+  });
+
+  test('English opt-in skips multilingual download and pins en', () {
+    expect(SpeechLanguageMode.english.includesMultilingualModel, isFalse);
+    expect(SpeechLanguageMode.english.processLanguageCode, 'en');
+    expect(SpeechLanguageMode.english.badgeLabel, 'English');
+  });
+}

--- a/packages/feature_mind/test/capture/presentation/meeting_capture_screen_test.dart
+++ b/packages/feature_mind/test/capture/presentation/meeting_capture_screen_test.dart
@@ -5,6 +5,11 @@ import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   Future<void> pumpScreen(WidgetTester tester) async {
+    // Tall surface so consent + trust strip + controls fit without scrolling
+    // (the trust strip (#1774) pushed the start button off a default phone
+    // viewport and broke key lookups).
+    await tester.binding.setSurfaceSize(const Size(400, 1400));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
     await tester.pumpWidget(
       const ProviderScope(child: MaterialApp(home: MeetingCaptureScreen())),
     );
@@ -21,6 +26,29 @@ void main() {
         findsOneWidget,
       );
       expect(find.textContaining('checking it is on you'), findsOneWidget);
+    },
+  );
+
+  testWidgets(
+    'shows Multilingual · auto-detect badge and offline copy by default (#1774)',
+    (tester) async {
+      await pumpScreen(tester);
+
+      expect(find.byKey(const Key('scribe_trust_signals')), findsOneWidget);
+      expect(
+        find.byKey(const Key('scribe_trust_language_badge')),
+        findsOneWidget,
+      );
+      expect(find.text('Multilingual · auto-detect'), findsOneWidget);
+      expect(find.text('On this device'), findsOneWidget);
+      expect(
+        find.byKey(const Key('scribe_trust_offline_copy')),
+        findsOneWidget,
+      );
+      expect(
+        find.textContaining('Sharing is always an explicit'),
+        findsOneWidget,
+      );
     },
   );
 

--- a/packages/feature_mind/test/capture/presentation/speech_language_settings_tile_test.dart
+++ b/packages/feature_mind/test/capture/presentation/speech_language_settings_tile_test.dart
@@ -1,0 +1,62 @@
+import 'package:feature_mind/src/capture/domain/speech_language_mode.dart';
+import 'package:feature_mind/src/capture/presentation/speech_language_settings_tile.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  Future<void> pumpTile(WidgetTester tester) async {
+    await tester.pumpWidget(
+      const ProviderScope(
+        child: MaterialApp(home: Scaffold(body: SpeechLanguageSettingsTile())),
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  testWidgets('defaults to Auto (mixed)', (tester) async {
+    SharedPreferences.setMockInitialValues({});
+
+    await pumpTile(tester);
+
+    expect(
+      find.byKey(const Key('speech_language_settings_tile')),
+      findsOneWidget,
+    );
+    expect(find.text('Auto (mixed)'), findsOneWidget);
+    expect(find.textContaining('multilingual model'), findsOneWidget);
+  });
+
+  testWidgets('reflects a previously saved English preference', (tester) async {
+    SharedPreferences.setMockInitialValues({
+      'mind_speech_language_mode': SpeechLanguageMode.english.storageValue,
+    });
+
+    await pumpTile(tester);
+
+    expect(find.text('English'), findsWidgets);
+    expect(
+      find.textContaining('Skips the multilingual download'),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets('selecting English persists the preference', (tester) async {
+    SharedPreferences.setMockInitialValues({});
+
+    await pumpTile(tester);
+    await tester.tap(
+      find.byKey(const Key('speech_language_settings_dropdown')),
+    );
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('English').last);
+    await tester.pumpAndSettle();
+
+    final prefs = await SharedPreferences.getInstance();
+    expect(
+      prefs.getString('mind_speech_language_mode'),
+      SpeechLanguageMode.english.storageValue,
+    );
+  });
+}

--- a/packages/feature_mind/test/mind_service_test.dart
+++ b/packages/feature_mind/test/mind_service_test.dart
@@ -99,7 +99,12 @@ void main() {
           TranscriptSegment(id: 's0', startMs: 0, endMs: 500, text: 'hello'),
         ),
         TranscriptEventTranscriptReady('hello world', [
-          TranscriptSegment(id: 's0', startMs: 0, endMs: 500, text: 'hello world'),
+          TranscriptSegment(
+            id: 's0',
+            startMs: 0,
+            endMs: 500,
+            text: 'hello world',
+          ),
         ]),
       ];
       generation.generationEvents = const [
@@ -132,7 +137,12 @@ void main() {
     () async {
       speech.transcriptEvents = const [
         TranscriptEventTranscriptReady('hello world', [
-          TranscriptSegment(id: 's0', startMs: 0, endMs: 500, text: 'hello world'),
+          TranscriptSegment(
+            id: 's0',
+            startMs: 0,
+            endMs: 500,
+            text: 'hello world',
+          ),
         ]),
       ];
       generation.generationEvents = const [
@@ -208,8 +218,13 @@ void main() {
   test('T7: save receives the generation bridge\'s model id', () async {
     speech.transcriptEvents = const [
       TranscriptEventTranscriptReady('hello world', [
-          TranscriptSegment(id: 's0', startMs: 0, endMs: 500, text: 'hello world'),
-        ]),
+        TranscriptSegment(
+          id: 's0',
+          startMs: 0,
+          endMs: 500,
+          text: 'hello world',
+        ),
+      ]),
     ];
     generation.generationEvents = const [
       GenerationEventMinutesReady('Minutes.'),
@@ -257,7 +272,12 @@ void main() {
     () async {
       speech.transcriptEvents = const [
         TranscriptEventTranscriptReady('hello world', [
-          TranscriptSegment(id: 's0', startMs: 0, endMs: 500, text: 'hello world'),
+          TranscriptSegment(
+            id: 's0',
+            startMs: 0,
+            endMs: 500,
+            text: 'hello world',
+          ),
         ]),
       ];
       generation.generationEvents = const [
@@ -287,22 +307,45 @@ void main() {
     });
 
     test('passes multilingual through unchanged when requested', () async {
-      await service.initialize(speechLanguage: rust.SpeechLanguage.multilingual);
+      await service.initialize(
+        speechLanguage: rust.SpeechLanguage.multilingual,
+      );
 
-      expect(speech.initializedSpeechLanguage, rust.SpeechLanguage.multilingual);
+      expect(
+        speech.initializedSpeechLanguage,
+        rust.SpeechLanguage.multilingual,
+      );
     });
 
-    test('uses defaultSpeechLanguage when initialize omits speechLanguage', () async {
-      final multilingualDefault = MindService(
-        recorder: MockAudioRecorder(),
-        modelProvider: FakeReadyModelProvider(),
-        speechBridge: speech,
-        generationBridge: generation,
-        defaultSpeechLanguage: rust.SpeechLanguage.multilingual,
-      );
-      await multilingualDefault.initialize();
+    test(
+      'uses defaultSpeechLanguage when initialize omits speechLanguage',
+      () async {
+        final multilingualDefault = MindService(
+          recorder: MockAudioRecorder(),
+          modelProvider: FakeReadyModelProvider(),
+          speechBridge: speech,
+          generationBridge: generation,
+          defaultSpeechLanguage: rust.SpeechLanguage.multilingual,
+        );
+        await multilingualDefault.initialize();
 
-      expect(speech.initializedSpeechLanguage, rust.SpeechLanguage.multilingual);
+        expect(
+          speech.initializedSpeechLanguage,
+          rust.SpeechLanguage.multilingual,
+        );
+      },
+    );
+
+    test('exposes speechLanguage for trust UX (#1774)', () async {
+      expect(service.speechLanguage, rust.SpeechLanguage.englishOnly);
+      await service.initialize(
+        speechLanguage: rust.SpeechLanguage.multilingual,
+      );
+      expect(service.speechLanguage, rust.SpeechLanguage.multilingual);
+      expect(
+        service.scribeTrustState().languageBadgeLabel,
+        'Multilingual · auto-detect',
+      );
     });
   });
 
@@ -317,9 +360,13 @@ void main() {
           TranscriptSegment(id: 's0', startMs: 0, endMs: 500, text: 'namaste'),
         ]),
       ];
-      generation.generationEvents = const [GenerationEventMinutesReady('Minutes.')];
+      generation.generationEvents = const [
+        GenerationEventMinutesReady('Minutes.'),
+      ];
 
-      await service.process(wavPath: 'x.wav', title: 't', language: 'hi').drain<void>();
+      await service
+          .process(wavPath: 'x.wav', title: 't', language: 'hi')
+          .drain<void>();
 
       expect(speech.transcribeLanguage, 'hi');
     });
@@ -327,17 +374,25 @@ void main() {
     test('no language chosen leaves the bridge on auto-detect (null)', () async {
       speech.transcriptEvents = const [
         TranscriptEventTranscriptReady('hello world', [
-          TranscriptSegment(id: 's0', startMs: 0, endMs: 500, text: 'hello world'),
+          TranscriptSegment(
+            id: 's0',
+            startMs: 0,
+            endMs: 500,
+            text: 'hello world',
+          ),
         ]),
       ];
-      generation.generationEvents = const [GenerationEventMinutesReady('Minutes.')];
+      generation.generationEvents = const [
+        GenerationEventMinutesReady('Minutes.'),
+      ];
 
       await service.process(wavPath: 'x.wav', title: 't').drain<void>();
 
       expect(
         speech.transcribeLanguage,
         isNull,
-        reason: 'omitting language must not silently pin one -- auto-detect stays the default',
+        reason:
+            'omitting language must not silently pin one -- auto-detect stays the default',
       );
     });
   });

--- a/packages/feature_mind/test/support/fake_bridges.dart
+++ b/packages/feature_mind/test/support/fake_bridges.dart
@@ -32,13 +32,15 @@ class FakeMindSpeechBridge implements MindSpeechBridge {
   /// library (`MindUnavailable.bridgeMissing`).
   Object? loadLibraryError;
 
+  var _ready = false;
+
   @override
   Future<void> loadLibrary() async {
     if (loadLibraryError != null) throw loadLibraryError!;
   }
 
   @override
-  bool isReady() => true;
+  bool isReady() => _ready;
 
   @override
   Future<void> initialize({
@@ -48,6 +50,7 @@ class FakeMindSpeechBridge implements MindSpeechBridge {
     rust.SpeechLanguage speechLanguage = rust.SpeechLanguage.englishOnly,
   }) async {
     initializedSpeechLanguage = speechLanguage;
+    _ready = true;
   }
 
   @override

--- a/packages/feature_mind/test/trust/scribe_trust_signals_test.dart
+++ b/packages/feature_mind/test/trust/scribe_trust_signals_test.dart
@@ -1,0 +1,126 @@
+import 'package:feature_mind/src/trust/scribe_trust_signals.dart';
+import 'package:feature_mind/src/trust/scribe_trust_state.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('ScribeTrustState', () {
+    test('multilingual shows a language badge', () {
+      const state = ScribeTrustState.meetingMultilingual();
+      expect(state.showLanguageBadge, isTrue);
+      expect(state.languageBadgeLabel, 'Multilingual · auto-detect');
+      expect(state.offlineCopy, contains('on this device'));
+      expect(state.offlineCopy.toLowerCase(), isNot(contains('cloud')));
+    });
+
+    test('english-only still shows an English badge (settings-driven)', () {
+      final state = ScribeTrustState.forSpeechModel(multilingual: false);
+      expect(state.showLanguageBadge, isTrue);
+      expect(state.languageBadgeLabel, 'English');
+      expect(state.honestyNote, isNull);
+    });
+
+    test('pinned language shows an explicit badge', () {
+      final state = ScribeTrustState.forSpeechModel(
+        multilingual: true,
+        pinnedLanguageCode: 'hi',
+      );
+      expect(state.showLanguageBadge, isTrue);
+      expect(state.languageBadgeLabel, 'Language: hi');
+      expect(state.honestyNote, contains('on-device'));
+    });
+
+    test('model-missing stays honest and never claims cloud', () {
+      final state = ScribeTrustState.forSpeechModel(
+        multilingual: true,
+        modelMissing: true,
+      );
+      expect(state.showLanguageBadge, isTrue);
+      expect(state.languageBadgeLabel, 'Speech model missing');
+      expect(state.offlineCopy, contains('ggml-tiny.bin'));
+      expect(state.offlineCopy.toLowerCase(), isNot(contains('cloud')));
+      expect(state.honestyNote, contains('will not pretend'));
+    });
+
+    test('unknown language warns about auto-detect', () {
+      const state = ScribeTrustState(languageMode: ScribeLanguageMode.unknown);
+      expect(state.showLanguageBadge, isTrue);
+      expect(state.languageBadgeLabel, 'Language unknown');
+      expect(state.offlineCopy, contains('auto-detect'));
+      expect(state.honestyNote, contains('Translation is never applied'));
+    });
+  });
+
+  group('ScribeTrustSignals', () {
+    Future<void> pump(WidgetTester tester, ScribeTrustState state) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: SingleChildScrollView(
+              child: ScribeTrustSignals(state: state),
+            ),
+          ),
+        ),
+      );
+    }
+
+    testWidgets('renders multilingual badge and on-device copy', (tester) async {
+      await pump(tester, const ScribeTrustState.meetingMultilingual());
+
+      expect(find.byKey(const Key('scribe_trust_signals')), findsOneWidget);
+      expect(
+        find.byKey(const Key('scribe_trust_language_badge')),
+        findsOneWidget,
+      );
+      expect(find.text('Multilingual · auto-detect'), findsOneWidget);
+      expect(find.text('On this device'), findsOneWidget);
+      expect(
+        find.byKey(const Key('scribe_trust_offline_copy')),
+        findsOneWidget,
+      );
+      expect(
+        find.textContaining('Sharing is always an explicit'),
+        findsOneWidget,
+      );
+      expect(
+        find.byKey(const Key('scribe_trust_honesty_note')),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('english-only shows English badge and offline copy', (
+      tester,
+    ) async {
+      await pump(tester, ScribeTrustState.forSpeechModel(multilingual: false));
+
+      expect(
+        find.byKey(const Key('scribe_trust_language_badge')),
+        findsOneWidget,
+      );
+      expect(find.text('English'), findsOneWidget);
+      expect(find.text('On this device'), findsOneWidget);
+      expect(find.byKey(const Key('scribe_trust_honesty_note')), findsNothing);
+    });
+
+    testWidgets('model-missing surfaces an honest error badge', (tester) async {
+      await pump(
+        tester,
+        ScribeTrustState.forSpeechModel(multilingual: true, modelMissing: true),
+      );
+
+      expect(find.text('Speech model missing'), findsOneWidget);
+      expect(find.textContaining('ggml-tiny.bin'), findsOneWidget);
+      expect(find.textContaining('will not pretend'), findsOneWidget);
+    });
+
+    testWidgets('unknown language keeps auto-detect honesty', (tester) async {
+      await pump(
+        tester,
+        const ScribeTrustState(languageMode: ScribeLanguageMode.unknown),
+      );
+
+      expect(find.text('Language unknown'), findsOneWidget);
+      expect(find.textContaining('auto-detect'), findsOneWidget);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Adds `ScribeTrustSignals` on meeting capture, meeting reader, Mind home, and Audio Scribe: **Multilingual · auto-detect** / **English** badges plus honest on-device processing copy (sharing is always explicit; no false cloud claims).
- Thin Settings seam (`SpeechLanguageMode` Auto vs English) drives the badge, first-run multilingual download inclusion, and `process(language:)` / `ensureReady(speechLanguage:)` — English opt-in skips the multilingual whisper download.
- Host widget/unit tests for trust copy, settings tile, capture screen, and job runner language threading.

Closes #1774. UI remainder of #1664. Contributes to #1629 validation. Part of #1770 / #1627.

## Test plan
- [x] `packages/feature_mind` — `test/trust/scribe_trust_signals_test.dart`
- [x] `test/capture/domain/speech_language_mode_test.dart`
- [x] `test/capture/presentation/speech_language_settings_tile_test.dart`
- [x] `test/capture/presentation/meeting_capture_screen_test.dart`
- [x] `test/capture/application/meeting_processing_job_runner_test.dart`
- [x] `test/mind_service_test.dart`
- [x] `test/assistant/presentation/screens/audio_scribe_screen_test.dart`

## Device test — Pixel 9 (mixed Marathi / Hindi / English)
Pending Wave 1 device validation per #1770. Protocol after merge:

1. Fresh install (or clear Mind models) with **Auto (mixed)** — confirm multilingual weights download and record screen shows `Multilingual · auto-detect`.
2. Record ~60–90s of code-switched Marathi/Hindi/English speech on-device.
3. Assert transcript keeps original scripts (no silent English-only translation); segments non-empty.
4. Switch Settings → **English**, confirm next missing-model path does **not** require `ggml-tiny.bin`, badge shows `English`, and `process` pins `en`.
5. Record result here:

| Step | Result |
|------|--------|
| Auto badge + offline copy | _pending_ |
| Mixed Mr/Hi/En transcript (no silent translate) | _pending_ |
| English opt-in skips multilingual download | _pending_ |