### PR TITLE
test(mind): gated Pixel 9 device journey (#1771)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -312,10 +312,16 @@ jobs:
 
       # Same flags as the `code-quality` job: infos and warnings are advisory
       # in this repo, errors are not.
+      #
+      # `integration_test/mind_journey_device_test.dart` is analysed here so
+      # the gated Pixel 9 journey (#1771) cannot drift against the Mind
+      # pubspec. Opt-in via AIRO_RUN_MIND_JOURNEY; CI never executes it.
       - name: Analyze the Mind shell
         run: |
           cd app
-          flutter analyze --no-fatal-infos --no-fatal-warnings lib/main_mind.dart lib/core/mind
+          flutter analyze --no-fatal-infos --no-fatal-warnings \
+            lib/main_mind.dart lib/core/mind \
+            integration_test/mind_journey_device_test.dart
 
       - name: Run Mind shell tests
         run: |

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -307,10 +307,16 @@ jobs:
 
       # Same flags as the `code-quality` job: infos and warnings are advisory
       # in this repo, errors are not.
+      #
+      # `integration_test/mind_journey_device_test.dart` is analysed here so
+      # the gated Pixel 9 journey (#1771) cannot drift against the Mind
+      # pubspec. Opt-in via AIRO_RUN_MIND_JOURNEY; CI never executes it.
       - name: Analyze the Mind shell
         run: |
           cd app
-          flutter analyze --no-fatal-infos --no-fatal-warnings lib/main_mind.dart lib/core/mind
+          flutter analyze --no-fatal-infos --no-fatal-warnings \
+            lib/main_mind.dart lib/core/mind \
+            integration_test/mind_journey_device_test.dart
 
       - name: Run Mind shell tests
         run: |

--- a/app/analysis_options_mind.yaml
+++ b/app/analysis_options_mind.yaml
@@ -13,11 +13,16 @@
 #
 #   cp app/pubspec_mind.yaml app/pubspec.yaml
 #   cp app/analysis_options_mind.yaml app/analysis_options.yaml
-#   cd app && flutter pub get && flutter analyze lib/main_mind.dart lib/core/mind
+#   cd app && flutter pub get && flutter analyze \
+#     lib/main_mind.dart lib/core/mind \
+#     integration_test/mind_journey_device_test.dart
 #
 # Everything below mirrors `analysis_options.yaml` except:
 #   * `lib/main_mind.dart` and `lib/core/mind/**` are NOT excluded -- that is
 #     the whole point;
+#   * `integration_test/mind_journey_device_test.dart` is kept (Mind device
+#     journey, #1771); other integration_test / patrol files stay excluded
+#     because they resolve only under the phone / patrol pubspecs;
 #   * the paths that do not resolve under this flavour ARE excluded: the patrol
 #     suites and the phone flavour's `test/` tree;
 #   * `test_mind/**` stays excluded. The analyzer only grants
@@ -42,8 +47,15 @@ analyzer:
     - "**/generated/**"
     - "**/*.g.dart"
     - "**/*.freezed.dart"
-    # Resolve only under pubspec_patrol.yaml.
-    - "integration_test/**"
+    # Phone / patrol integration suites — not the Mind device journey.
+    - "integration_test/agent_skills_journey_test.dart"
+    - "integration_test/coins_user_journeys_test.dart"
+    - "integration_test/edge_intelligence_native_pack_test.dart"
+    - "integration_test/finance_chat_ingestion_test.dart"
+    - "integration_test/gemini_nano_warmup_mobile_run_test.dart"
+    - "integration_test/media_asset_analyzer_device_test.dart"
+    - "integration_test/patrol_test.dart"
+    - "integration_test/receipt_on_device_parser_test.dart"
     - "patrol_test/**"
     # The phone flavour's suite. It imports packages this profile does not
     # carry (games, IPTV playback, media), so analysing it here reports the

--- a/app/integration_test/mind_journey_device_test.dart
+++ b/app/integration_test/mind_journey_device_test.dart
@@ -1,0 +1,257 @@
+/// Device journey for Airo Mind — the gated replacement for the deleted
+/// Rust `user_journey.rs` (#1549 / #1771).
+///
+/// ## What this proves
+///
+/// Real engines, real models, one scripted path:
+/// acquire scribe models (if missing) → initialize [MindService] →
+/// fixture wav (or short mic capture) → transcribe → minutes → save →
+/// search → open. Optionally asserts markdown export (`transcript.md` +
+/// `mom.md`) once the meeting is durable.
+///
+/// Composition coverage (fakes) lives in `packages/feature_mind` and does
+/// **not** replace this. This file must not use a fake that always passes.
+///
+/// ## Gate
+///
+/// Opt-in only. Default `flutter test integration_test/` and CI skip this
+/// test — it needs ~570 MB of models and a physical device (Pixel 9).
+///
+/// Pass `--dart-define=AIRO_RUN_MIND_JOURNEY=true` to enable. The Mind shell
+/// CI job analyses this file against `pubspec_mind.yaml` but never executes
+/// it.
+///
+/// ## Prerequisites (~570 MB)
+///
+/// First enabled run downloads Multilingual Whisper tiny (`ggml-tiny.bin`)
+/// plus the Qwen 0.5B GGUF through [buildMindDownloadService], then reuses
+/// them from app support. Host-side seed (optional):
+/// `app/tool/fetch_mind_models.sh`.
+///
+/// Push the whisper.cpp JFK fixture before a fixture-backed run:
+///
+/// ```bash
+/// adb -s <pixel9-id> push rust/fixtures/jfk.wav \
+///   /data/local/tmp/airo_mind_jfk.wav
+/// ```
+///
+/// ## How to run (Pixel 9)
+///
+/// ```bash
+/// cp app/pubspec_mind.yaml app/pubspec.yaml
+/// cp app/analysis_options_mind.yaml app/analysis_options.yaml
+/// cd app && flutter pub get
+/// flutter test integration_test/mind_journey_device_test.dart \
+///   --dart-define=APP_VARIANT=mind \
+///   --dart-define=AIRO_RUN_MIND_JOURNEY=true \
+///   -d <pixel9-id>
+/// ```
+///
+/// Restore `app/pubspec.yaml` / `app/analysis_options.yaml` afterwards (they
+/// must stay the phone profile by default). Or use
+/// `AIRO_MIND_BUILD_MODE=release scripts/build-mind.sh` for an APK install,
+/// then the same `flutter test …` command against the device.
+///
+/// Optional dart-defines:
+/// - `AIRO_MIND_WAV_PATH` — device path to a 16 kHz mono WAV (default
+///   `/data/local/tmp/airo_mind_jfk.wav`)
+/// - `AIRO_MIND_DEVICE_RECORD=true` — short mic capture when no fixture
+///
+/// See `docs/superpowers/specs/2026-08-06-airo-mind-journey-coverage.md`.
+library;
+
+import 'dart:io';
+
+import 'package:airo_app/core/mind/mind_model_sources.dart';
+import 'package:feature_mind/feature_mind.dart';
+import 'package:feature_mind/src/export/application/meeting_export_service.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:path/path.dart' as p;
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  const runJourney = bool.fromEnvironment('AIRO_RUN_MIND_JOURNEY');
+  const fixturePath = String.fromEnvironment(
+    'AIRO_MIND_WAV_PATH',
+    defaultValue: '/data/local/tmp/airo_mind_jfk.wav',
+  );
+  const allowRecord = bool.fromEnvironment('AIRO_MIND_DEVICE_RECORD');
+
+  final isCi =
+      Platform.environment['CI'] == 'true' ||
+      Platform.environment['GITHUB_ACTIONS'] == 'true';
+  final fixtureExists = File(fixturePath).existsSync();
+  final shouldSkip =
+      !runJourney || isCi || (!fixtureExists && !allowRecord);
+
+  if (shouldSkip) {
+    final reason = (!runJourney || isCi)
+        ? 'Opt-in device journey (#1771): pass '
+              '--dart-define=AIRO_RUN_MIND_JOURNEY=true on Pixel 9 with '
+              'models; never executed in default CI.'
+        : 'Push rust/fixtures/jfk.wav to $fixturePath, or pass '
+              '--dart-define=AIRO_MIND_DEVICE_RECORD=true.';
+    debugPrint('AIRO_MIND_DEVICE_JOURNEY skip: $reason');
+  }
+
+  testWidgets(
+    'record → transcribe → minutes → save → search (real engines)',
+    (tester) async {
+      final service = buildMindDownloadService();
+      addTearDown(service.dispose);
+
+      // ── 1. Models (~570 MB on first run) ─────────────────────────────────
+      final missing = await service.missingModels();
+      if (missing.isNotEmpty) {
+        debugPrint(
+          'AIRO_MIND_DEVICE_JOURNEY downloading '
+          '${missing.map((m) => m.fileName).join(', ')} '
+          '(~${missing.fold<int>(0, (s, m) => s + m.sizeBytes) ~/ (1024 * 1024)} MB)',
+        );
+        final failed = <String>[];
+        await for (final event in service.acquireModels()) {
+          switch (event) {
+            case ModelAcquisitionProgress(
+              :final fileName,
+              :final fetched,
+              :final total,
+            ):
+              if (total > 0 && fetched % (16 * 1024 * 1024) < 64 * 1024) {
+                debugPrint(
+                  'AIRO_MIND_DEVICE_JOURNEY $fileName '
+                  '${(100 * fetched / total).toStringAsFixed(0)}%',
+                );
+              }
+            case ModelAcquisitionDone(:final failedFileNames):
+              failed.addAll(failedFileNames);
+          }
+        }
+        expect(
+          failed,
+          isEmpty,
+          reason: 'Model download failed: ${failed.join(', ')}',
+        );
+      }
+
+      // ── 2. Initialize (multilingual whisper default) ─────────────────────
+      final status = await service.initialize();
+      expect(
+        status.isReady,
+        isTrue,
+        reason:
+            'MindService.initialize failed: '
+            '${status.unavailable} ${status.detail}',
+      );
+
+      // ── 3. Audio: fixture wav, else short record ─────────────────────────
+      final wavPath = await _resolveWavPath(
+        service: service,
+        fixturePath: fixturePath,
+        allowRecord: allowRecord,
+      );
+
+      // ── 4–6. Transcribe → minutes → save ─────────────────────────────────
+      final title = 'MindJourney${DateTime.now().millisecondsSinceEpoch}';
+      MindProgress? last;
+      final stages = <MindStage>[];
+      await for (final progress in service.process(
+        wavPath: wavPath,
+        title: title,
+      )) {
+        last = progress;
+        if (stages.isEmpty || stages.last != progress.stage) {
+          stages.add(progress.stage);
+        }
+        debugPrint(
+          'AIRO_MIND_DEVICE_JOURNEY stage=${progress.stage.name} '
+          'transcriptChars=${progress.transcript.length} '
+          'minutesChars=${progress.minutes.length}',
+        );
+      }
+
+      expect(last, isNotNull);
+      expect(
+        last!.stage,
+        MindStage.done,
+        reason: last.error ?? 'pipeline ended at ${last.stage}',
+      );
+      expect(last.meetingId, isNotNull);
+      expect(last.transcript.trim(), isNotEmpty);
+      expect(last.minutes.trim(), isNotEmpty);
+      expect(stages, contains(MindStage.transcribing));
+      expect(stages, contains(MindStage.generating));
+      expect(stages, contains(MindStage.saving));
+      expect(stages.last, MindStage.done);
+
+      final meetingId = last.meetingId!;
+      final meeting = await service.meeting(meetingId);
+      expect(meeting, isNotNull);
+      expect(meeting!.transcript.trim(), isNotEmpty);
+      expect(meeting.minutes.trim(), isNotEmpty);
+
+      // ── 7. Search ────────────────────────────────────────────────────────
+      final hits = await service.search(title);
+      expect(
+        hits.any((hit) => hit.meetingId == meetingId),
+        isTrue,
+        reason: 'search("$title") did not return meeting $meetingId',
+      );
+
+      // ── 8. Export markdown (durable evidence; uses #1768 mom.md path) ────
+      final bundle = await MeetingExportService(service).exportMeeting(meetingId);
+      expect(bundle, isNotNull);
+      expect(bundle!.files.containsKey('transcript.md'), isTrue);
+      expect(bundle.files['transcript.md']!.trim(), isNotEmpty);
+      expect(bundle.files.containsKey('mom.md'), isTrue);
+      expect(bundle.files['mom.md']!.trim(), isNotEmpty);
+
+      debugPrint(
+        'AIRO_MIND_DEVICE_JOURNEY ok meetingId=$meetingId '
+        'folder=${bundle.folderName} '
+        'files=${bundle.files.keys.join(',')}',
+      );
+    },
+    skip: shouldSkip,
+    timeout: const Timeout(Duration(minutes: 30)),
+  );
+}
+
+Future<String> _resolveWavPath({
+  required MindService service,
+  required String fixturePath,
+  required bool allowRecord,
+}) async {
+  final fixture = File(fixturePath);
+  if (fixture.existsSync()) {
+    final dir = await service.modelsDirectory();
+    final dest = File(
+      p.join(
+        dir.path,
+        'journey-fixture-${DateTime.now().millisecondsSinceEpoch}.wav',
+      ),
+    );
+    await fixture.copy(dest.path);
+    return dest.path;
+  }
+
+  expect(
+    allowRecord,
+    isTrue,
+    reason: 'No fixture at $fixturePath and AIRO_MIND_DEVICE_RECORD is false.',
+  );
+  expect(
+    await service.hasMicrophonePermission(),
+    isTrue,
+    reason: 'Microphone permission required for record fallback.',
+  );
+
+  await service.startRecording();
+  await Future<void>.delayed(const Duration(seconds: 3));
+  final path = await service.stopRecording();
+  expect(path, isNotNull);
+  expect(File(path!).existsSync(), isTrue);
+  return path;
+}

--- a/app/pubspec_mind.yaml
+++ b/app/pubspec_mind.yaml
@@ -135,6 +135,10 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
+  # Device journey (#1771 / mind_journey_device_test.dart). Host/CI never
+  # executes it; the Mind shell job only analyses the file.
+  integration_test:
+    sdk: flutter
   flutter_lints: 6.0.0
 
 dependency_overrides:


### PR DESCRIPTION
## Summary
- Adds `app/integration_test/mind_journey_device_test.dart` covering record → transcribe → minutes → save → search (real engines/models), with markdown export evidence.
- Gates execution behind `--dart-define=AIRO_RUN_MIND_JOURNEY=true` (also skips under `CI`/`GITHUB_ACTIONS`) so default CI / `make test-integration` never requires models or a phone.
- Mind shell CI analyses the new file against `pubspec_mind.yaml`; phone integration suites stay excluded from the Mind analyzer profile.

Closes #1771. Part of Wave 1 under #1770 / epic #1627.

## Pixel 9 run steps
```bash
# 1) Fixture
adb -s <pixel9-id> push rust/fixtures/jfk.wav /data/local/tmp/airo_mind_jfk.wav

# 2) Mind flavour
cp app/pubspec_mind.yaml app/pubspec.yaml
cp app/analysis_options_mind.yaml app/analysis_options.yaml
cd app && flutter pub get

# 3) Run (~570 MB model download on first run)
flutter test integration_test/mind_journey_device_test.dart \
  --dart-define=APP_VARIANT=mind \
  --dart-define=AIRO_RUN_MIND_JOURNEY=true \
  -d <pixel9-id>

# 4) Restore phone pubspec/analysis_options afterwards
```

Optional: `--dart-define=AIRO_MIND_DEVICE_RECORD=true` for mic capture instead of the JFK fixture; `app/tool/fetch_mind_models.sh` for a host-side model seed.

## Test plan
- [x] `flutter analyze … integration_test/mind_journey_device_test.dart` (clean)
- [x] `flutter test integration_test/mind_journey_device_test.dart -d macos` → skipped without `AIRO_RUN_MIND_JOURNEY`
- [ ] Pixel 9 enabled run (blocked here — no Pixel attached; record after merge per issue acceptance)


Made with [Cursor](https://cursor.com)