### PR TITLE
fix(mind): unblock device journey CI after #1780 merge

### DIFF
--- a/app/lib/core/mind/mind_processing_queue.dart
+++ b/app/lib/core/mind/mind_processing_queue.dart
@@ -1,3 +1,4 @@
+import 'package:core_ai/core_ai.dart';
 import 'package:feature_mind/feature_mind.dart';
 import 'package:flutter_riverpod/misc.dart';
 import 'package:path/path.dart' as p;

--- a/app/lib/main_mind.dart
+++ b/app/lib/main_mind.dart
@@ -101,10 +101,7 @@ Future<void> main() {
       prefs = await SharedPreferences.getInstance();
       registry = buildMindModuleRegistry();
       return ProviderScope(
-        overrides: buildMindProviderOverrides(
-          prefs: prefs,
-          registry: registry,
-        ),
+        overrides: buildMindProviderOverrides(prefs: prefs, registry: registry),
         child: AiroMindApp(registry: registry),
       );
     },

--- a/app/test_mind/mind_model_catalog_test.dart
+++ b/app/test_mind/mind_model_catalog_test.dart
@@ -40,6 +40,8 @@ class _EmptyDownloadService implements ModelDownloadService {
 }
 
 void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
   late Directory modelsDir;
 
   setUp(() {

--- a/packages/feature_mind/lib/feature_mind.dart
+++ b/packages/feature_mind/lib/feature_mind.dart
@@ -24,6 +24,8 @@ export 'src/meeting_screen.dart' show MeetingScreen;
 export 'src/mind_home_screen.dart' show MindHomeScreen, meetingListPreview;
 export 'src/export/application/meeting_export_service.dart'
     show MeetingExportService;
+export 'src/export/domain/meeting_export_models.dart'
+    show MeetingExportBundle;
 export 'src/mind_service.dart'
     show MindProgress, MindService, MindStage, MindStatus, MindUnavailable;
 


### PR DESCRIPTION
## Summary
- Export `MeetingExportService`, `MeetingExportBundle`, and `SpeechLanguage` from `feature_mind` so the device journey integration test and Mind shell avoid private `src/` imports (#1681).
- Add missing `core_ai` import in `mind_processing_queue.dart` so Mind shell analyze passes.
- Align `mind_journey_test` fake `initialize` override with nullable `SpeechLanguage?`.

Follow-up to #1780 / #1771 — the journey test landed on main but CI was red on private-src and airo-mind-shell analyze.

## Test plan
- [x] `python3 scripts/check-private-src-imports.py` — 0 new violations
- [x] Mind flavour `flutter analyze lib/main_mind.dart lib/core/mind integration_test/mind_journey_device_test.dart` — clean
- [x] `packages/feature_mind` `test/mind_journey_test.dart` — passes locally


Made with [Cursor](https://cursor.com)