### PR TITLE
fix(mind): init whisper bridge in device journey test

### DIFF
--- a/app/integration_test/mind_journey_device_test.dart
+++ b/app/integration_test/mind_journey_device_test.dart
@@ -64,6 +64,7 @@ import 'dart:io';
 
 import 'package:airo_app/core/mind/mind_model_sources.dart';
 import 'package:feature_mind/feature_mind.dart';
+import 'package:feature_mind/src/library_loader.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
@@ -100,6 +101,9 @@ void main() {
     (tester) async {
       final service = buildMindDownloadService();
       addTearDown(service.dispose);
+
+      // requiredModels() reads the whisper registry; load the library first.
+      await initializeWhisperBridge();
 
       // ── 1. Models (~570 MB on first run) ─────────────────────────────────
       final missing = await service.missingModels();


### PR DESCRIPTION
## Summary
- Call `initializeWhisperBridge()` before `missingModels()` in the gated Pixel 9 integration test
- Proven on device: run #3 failed without it; run #4+ progressed through transcribe + LLM generation

## Test plan
- [x] Pixel 9 run #4: transcribe + minutes generation started (whisper init OK)
- [ ] Pixel 9 run #5: full journey green (in progress — ~616 MB model download)

Links #1771 / #1663.

Made with [Cursor](https://cursor.com)