### PR TITLE
fix(mind): J0 gap-fill — wire operation log for IR extraction

### DIFF
--- a/app/lib/core/mind/mind_model_sources.dart
+++ b/app/lib/core/mind/mind_model_sources.dart
@@ -67,6 +67,10 @@ MindService buildMindDownloadService() {
     // Settings can opt into English-only; [requiredModelsLookup] re-reads
     // that preference so the multilingual file is not forced on download.
     defaultSpeechLanguage: SpeechLanguage.multilingual,
+    // ADR-0022 §1.2: append `meetingIrExtracted` after IR lands on the meeting
+    // record. Fixture log until #1213 wires the real Rust operation log.
+    operationLog: FixtureMindRuntime().log,
+    meetingContextId: 'scribe',
     modelProvider: DownloadModelProvider(
       // Application support, not documents. Airo Mind keeps its models in the
       // app's support directory on purpose (`MindService.modelsDirectory`) —

--- a/packages/feature_mind/test/mind_service_test.dart
+++ b/packages/feature_mind/test/mind_service_test.dart
@@ -4,6 +4,7 @@ import 'package:feature_mind/src/bridges/mind_generation_bridge.dart';
 import 'package:feature_mind/src/bridges/mind_speech_bridge.dart';
 import 'package:feature_mind/src/mind_service.dart';
 import 'package:feature_mind/src/models/model_provider.dart';
+import 'package:feature_mind/src/runtime/models/log_models.dart';
 import 'package:feature_mind/src/whisper/api/meetings.dart' as rust;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
@@ -12,6 +13,7 @@ import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 import 'package:record/record.dart';
 
 import 'support/fake_bridges.dart';
+import 'support/recording_operation_log.dart';
 
 /// `AudioRecorder`'s real constructor talks to a platform channel, which does
 /// not exist in a plain `flutter_test` run. None of the tests here touch
@@ -319,6 +321,68 @@ void main() {
     expect(speech.savedDecisions!.single.statement, 'ship it');
     expect(speech.savedActionItems!.single.task, 'write tests');
   });
+
+  test(
+    'T7d: process appends meetingIrExtracted to the operation log on success',
+    () async {
+      final log = RecordingOperationLog();
+      final serviceWithLog = MindService(
+        recorder: MockAudioRecorder(),
+        modelProvider: FakeReadyModelProvider(),
+        speechBridge: speech,
+        generationBridge: generation,
+        operationLog: log,
+        meetingContextId: 'scribe-test',
+      );
+      speech.transcriptEvents = const [
+        TranscriptEventTranscriptReady('hello world', [
+          TranscriptSegment(
+            id: 's0',
+            startMs: 0,
+            endMs: 500,
+            text: 'hello world',
+          ),
+        ]),
+      ];
+      generation.meetingIntelligenceEvents = const [
+        MeetingIntelligenceEventIrReady(
+          decisions: [
+            rust.MeetingDecisionRecord(
+              id: 'd1',
+              statement: 'ship it',
+              status: rust.MeetingDecisionStatus.agreed,
+              evidenceSegmentIds: ['s0'],
+            ),
+          ],
+          actionItems: [
+            rust.MeetingActionItemRecord(
+              id: 'a1',
+              task: 'write tests',
+              owner: 'Priya',
+              due: 'Friday',
+              status: rust.MeetingActionStatus.open,
+              evidenceSegmentIds: ['s0'],
+            ),
+          ],
+          metrics: const [],
+        ),
+        MeetingIntelligenceEventMinutesReady('Minutes.'),
+      ];
+
+      await serviceWithLog
+          .process(wavPath: 'x.wav', title: 'Standup')
+          .drain<void>();
+
+      expect(log.appended, hasLength(1));
+      final op = log.appended.single;
+      expect(op.kind, MindOpKind.meetingIrExtracted);
+      expect(op.title, 'Standup minutes extracted');
+      expect(op.contextId, 'scribe-test');
+      expect(op.detail, contains('decisions=1'));
+      expect(op.detail, contains('action_items=1'));
+      expect(op.detail, contains('metrics=0'));
+    },
+  );
 
   // T8 — a bridge that throws surfaces as MindStage.failed with the message,
   // not an unhandled exception reaching the widget layer.

--- a/packages/feature_mind/test/support/recording_operation_log.dart
+++ b/packages/feature_mind/test/support/recording_operation_log.dart
@@ -1,0 +1,50 @@
+import 'package:feature_mind/src/runtime/models/log_models.dart';
+import 'package:feature_mind/src/runtime/ports/operation_log_port.dart';
+
+/// In-memory [OperationLogPort] for tests that assert on appended ops.
+class RecordingOperationLog implements OperationLogPort {
+  final List<MindOp> appended = [];
+
+  @override
+  Future<int> append({
+    required MindOpKind kind,
+    required String title,
+    required String contextId,
+    String detail = '',
+  }) async {
+    final sequence = appended.length + 1;
+    appended.add(
+      MindOp(
+        sequence: sequence,
+        kind: kind,
+        title: title,
+        contextId: contextId,
+        deviceName: 'Test device',
+        signature: SignatureState.verified,
+        recordedAtMs: 1000 + sequence,
+        detail: detail,
+      ),
+    );
+    return sequence;
+  }
+
+  @override
+  Future<int> count() async => appended.length;
+
+  @override
+  Future<List<MindOp>> range({required int offset, required int limit}) async =>
+      appended.reversed.skip(offset).take(limit).toList();
+
+  @override
+  Future<MindOp?> bySequence(int sequence) async =>
+      appended.where((op) => op.sequence == sequence).firstOrNull;
+
+  @override
+  Future<SignatureState> verify(int sequence) async =>
+      (await bySequence(sequence))?.signature ?? SignatureState.unsigned;
+
+  @override
+  Stream<double> replayFrom(int sequence) async* {
+    yield 1.0;
+  }
+}

--- a/packages/feature_mind/test/whisper/meeting_ir_op_log_test.dart
+++ b/packages/feature_mind/test/whisper/meeting_ir_op_log_test.dart
@@ -4,52 +4,7 @@ import 'package:feature_mind/src/runtime/ports/operation_log_port.dart';
 import 'package:feature_mind/src/whisper/meeting_ir_op_log.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-class _RecordingLog implements OperationLogPort {
-  final List<MindOp> appended = [];
-
-  @override
-  Future<int> append({
-    required MindOpKind kind,
-    required String title,
-    required String contextId,
-    String detail = '',
-  }) async {
-    final sequence = appended.length + 1;
-    appended.add(
-      MindOp(
-        sequence: sequence,
-        kind: kind,
-        title: title,
-        contextId: contextId,
-        deviceName: 'Test device',
-        signature: SignatureState.verified,
-        recordedAtMs: 1000 + sequence,
-        detail: detail,
-      ),
-    );
-    return sequence;
-  }
-
-  @override
-  Future<int> count() async => appended.length;
-
-  @override
-  Future<List<MindOp>> range({required int offset, required int limit}) async =>
-      appended.reversed.skip(offset).take(limit).toList();
-
-  @override
-  Future<MindOp?> bySequence(int sequence) async =>
-      appended.where((op) => op.sequence == sequence).firstOrNull;
-
-  @override
-  Future<SignatureState> verify(int sequence) async =>
-      (await bySequence(sequence))?.signature ?? SignatureState.unsigned;
-
-  @override
-  Stream<double> replayFrom(int sequence) async* {
-    yield 1.0;
-  }
-}
+import '../support/recording_operation_log.dart';
 
 class _UnavailableLog implements OperationLogPort {
   @override
@@ -85,7 +40,7 @@ class _UnavailableLog implements OperationLogPort {
 void main() {
   group('appendMeetingIrExtractedOp', () {
     test('appends a meetingIrExtracted op with the expected shape', () async {
-      final log = _RecordingLog();
+      final log = RecordingOperationLog();
 
       final sequence = await appendMeetingIrExtractedOp(
         log: log,


### PR DESCRIPTION
## Summary

J0 (#1794) wired the IR meeting-intelligence pipeline into `MindService`. This gap-fill PR closes the remaining ADR-0022 §1.2 seam: the Mind shell now passes an `OperationLogPort` so `process()` can append `meetingIrExtracted` after IR lands on the meeting record.

- `buildMindDownloadService()` passes `FixtureMindRuntime().log` + `meetingContextId: 'scribe'`
- **T7d** proves `process()` appends one `meetingIrExtracted` op on success
- Shared `RecordingOperationLog` test helper extracted for reuse

## Architecture (J0 pipeline — merged in #1794)

```
transcribing (whisper) → extracting → generating → saving → done
                              ↓
              process_meeting_intelligence (llama)
              transcript::process → extract → validate → generate_mom
```

| Rust event | Dart `MindStage` |
|---|---|
| `TranscriptEventTranscriptReady` | `extracting` |
| `MeetingIntelligenceEventExtracting` | `extracting` |
| `MeetingIntelligenceEventGenerating` | `generating` |
| `MeetingIntelligenceEventMinutesReady` | `saving` |
| save complete | `done` |

**FFI contract:** `process_meeting_intelligence(meetingId, title, segments) → Stream<MeetingIntelligenceEvent>`

**Deferred (not in this PR):**
- Separate `validating` Dart stage (validate runs inside Rust)
- `.m4a` preprocess before `process()` — J1 (#1786)
- Strict device IR assertions — POC-2 gate on #1784

## Verification

| Check | Result |
|---|---|
| `cargo test -p airo_mind_meeting -p airo_mind_transcript` | 120 tests green |
| `flutter test packages/feature_mind/test/mind_service_test.dart` | 16/16 green (incl. T7d) |
| Pixel 9 device journey (`AIRO_RUN_MIND_JOURNEY=true`) | green — `extracting` stage observed; IR lenient (0/0/0 on JFK fixture, expected pre-POC-2) |

Closes #1785 (gap-fill follow-up to J0 orchestration).

## Test plan

- [x] `cargo test -p airo_mind_meeting -p airo_mind_transcript`
- [x] `cd packages/feature_mind && flutter test test/mind_service_test.dart`
- [x] Device journey on Pixel 9 `4C031VDAQ000GG` with JFK fixture

Made with [Cursor](https://cursor.com)