### PR TITLE
feat(mind): Wave 2 POC-2 CLI, golden eval, scribe tab, chat-over-meetings (#1787)

### DIFF
--- a/app/lib/core/mind/mind_registration.dart
+++ b/app/lib/core/mind/mind_registration.dart
@@ -2,6 +2,9 @@ import 'package:core_product_shell/core_product_shell.dart';
 import 'package:feature_mind/feature_mind.dart';
 
 import '../assistant/app_assistant_host_adapter.dart';
+import 'mind_model_sources.dart';
+import 'mind_processing_queue.dart';
+import 'mind_model_catalog.dart';
 
 /// Registers Airo Mind into [registry]. Phone/desktop only.
 ///
@@ -14,6 +17,13 @@ import '../assistant/app_assistant_host_adapter.dart';
 /// `scripts/check-mind-private-devices.sh`.
 void registerMind(ModuleRegistry registry) {
   registry.register(
-    MindModule(hostAdapterBuilder: AppAssistantHostAdapter.new),
+    MindModule(
+      hostAdapterBuilder: AppAssistantHostAdapter.new,
+      createService: buildMindDownloadService,
+      scribeOverrides: (service) => [
+        ...mindModelRegistryOverrides(modelsDirectory: service.modelsDirectory),
+        ...mindMeetingProcessingOverrides(service),
+      ],
+    ),
   );
 }

--- a/app/lib/core/routing/app_router.dart
+++ b/app/lib/core/routing/app_router.dart
@@ -98,6 +98,10 @@ class AppRouter {
         // inside the bottom nav. Absent entirely when Mind itself is absent
         // (web) -- there is no hub for them to be reached from.
         if (assistant != null) ...assistant.rootRoutesFor(moduleRegistry.shell),
+        // Meeting scribe (record → transcribe → IR → MoM). Top-level so it
+        // renders full-screen outside the bottom nav, same as Wellbeing.
+        if (assistant != null && assistant.createService != null)
+          ...assistant.scribeRoutesFor(moduleRegistry.shell),
         GoRoute(path: '/beats', redirect: (context, state) => '/music'),
         GoRoute(path: '/stream', redirect: (context, state) => '/iptv'),
         GoRoute(

--- a/app/test/assistant_route_parity_test.dart
+++ b/app/test/assistant_route_parity_test.dart
@@ -197,14 +197,15 @@ void main() {
         .whereType<GoRoute>()
         .map((route) => route.path);
 
+    final topLevelPaths = router.configuration.routes
+        .whereType<GoRoute>()
+        .map((route) => route.path);
+
     expect(branchPaths, contains(AssistantRouteNames.assistant));
     expect(branchPaths, isNot(contains(AssistantRouteNames.wellbeing)));
-    expect(
-      router.configuration.routes.whereType<GoRoute>().map(
-        (route) => route.path,
-      ),
-      contains('/wellbeing'),
-    );
+    expect(topLevelPaths, contains('/wellbeing'));
+    expect(branchPaths, isNot(contains('/scribe')));
+    expect(topLevelPaths, contains('/scribe'));
   });
 
   test('the router starts without the mind module and falls back to a '

--- a/app/test/main_super_app_shell_test.dart
+++ b/app/test/main_super_app_shell_test.dart
@@ -27,6 +27,7 @@ void main() {
       'vault',
       AssistantRouteNames.assistant,
       AssistantRouteNames.wellbeing,
+      '/scribe',
       '/iptv',
       '/iptv/player',
       '/vod',

--- a/packages/feature_mind/lib/src/agent_chat/domain/services/intent_parser.dart
+++ b/packages/feature_mind/lib/src/agent_chat/domain/services/intent_parser.dart
@@ -16,6 +16,9 @@ enum IntentType {
   playGame,
   askImage,
   audioScribe,
+  searchMeetings,
+  openMeetingScribe,
+  myActionItems,
   mobileActions,
   openWifiSettings,
   setFlashlight,
@@ -97,6 +100,12 @@ class IntentParser {
     'describe image': IntentType.askImage,
     'audio scribe': IntentType.audioScribe,
     'transcribe audio': IntentType.audioScribe,
+    'search meetings': IntentType.searchMeetings,
+    'find meeting': IntentType.searchMeetings,
+    'open scribe': IntentType.openMeetingScribe,
+    'record meeting': IntentType.openMeetingScribe,
+    'my action items': IntentType.myActionItems,
+    'what is assigned to me': IntentType.myActionItems,
     'mobile actions': IntentType.mobileActions,
     'open mobile actions': IntentType.mobileActions,
     'open wifi settings': IntentType.openWifiSettings,
@@ -207,6 +216,30 @@ class IntentParser {
       return IntentType.audioScribe;
     }
 
+    if (_containsAny(text, [
+      'search meeting',
+      'find meeting',
+      'what did we decide',
+      'decide about',
+      'standup',
+      'last week',
+    ])) {
+      return IntentType.searchMeetings;
+    }
+
+    if (_containsAny(text, ['open scribe', 'record meeting', 'meeting scribe'])) {
+      return IntentType.openMeetingScribe;
+    }
+
+    if (_containsAny(text, [
+      'assigned to me',
+      'my action items',
+      'my tasks',
+      'action items',
+    ])) {
+      return IntentType.myActionItems;
+    }
+
     if (_containsAny(text, ['mobile actions', 'device control'])) {
       return IntentType.mobileActions;
     }
@@ -298,6 +331,22 @@ class IntentParser {
       params['enabled'] = !lowerText.contains(' off');
     }
 
+    if (lowerText.contains('assigned to me') ||
+        lowerText.contains('my action items')) {
+      params['owner'] = 'me';
+    }
+
+    if (lowerText.contains('decide about') ||
+        lowerText.contains('what did we decide') ||
+        lowerText.contains('search meeting') ||
+        lowerText.contains('find meeting')) {
+      final about = RegExp(
+        r'(?:decide about|decided about|about)\s+(.+)$',
+        caseSensitive: false,
+      ).firstMatch(text);
+      params['query'] = about?.group(1)?.trim() ?? text.trim();
+    }
+
     return params;
   }
 
@@ -373,6 +422,12 @@ class IntentParser {
         return 'Opening Ask Image';
       case IntentType.audioScribe:
         return 'Opening Audio Scribe';
+      case IntentType.searchMeetings:
+        return 'Searching meeting archive';
+      case IntentType.openMeetingScribe:
+        return 'Opening Meeting Scribe';
+      case IntentType.myActionItems:
+        return 'Listing action items from meetings';
       case IntentType.mobileActions:
         return 'Opening Mobile Actions';
       case IntentType.openWifiSettings:

--- a/packages/feature_mind/lib/src/agent_chat/domain/services/tool_registry.dart
+++ b/packages/feature_mind/lib/src/agent_chat/domain/services/tool_registry.dart
@@ -1,4 +1,5 @@
 import 'package:equatable/equatable.dart';
+import '../../../meeting_archive/meeting_archive_port.dart';
 import '../../../services/device_actions_service.dart';
 import 'intent_parser.dart';
 
@@ -407,6 +408,85 @@ class ReaderTool implements Tool {
   }
 }
 
+/// Queries the offline meeting archive via [MeetingArchivePort] (#1770).
+class MeetingArchiveTool implements Tool {
+  MeetingArchiveTool(this._port);
+
+  final MeetingArchivePort? _port;
+
+  @override
+  String get key => 'meeting_archive';
+
+  @override
+  String get name => 'Meeting Archive';
+
+  @override
+  bool canHandle(Intent intent) {
+    return intent.type == IntentType.searchMeetings ||
+        intent.type == IntentType.openMeetingScribe ||
+        intent.type == IntentType.myActionItems;
+  }
+
+  @override
+  Future<AgentToolResult?> handle(Intent intent) async {
+    final port = _port;
+    if (port == null) {
+      return const AgentToolResult(
+        route: '/scribe',
+        message:
+            'Meeting Scribe is not available in this shell. Open the Mind tab on phone.',
+      );
+    }
+
+    switch (intent.type) {
+      case IntentType.openMeetingScribe:
+        return const AgentToolResult(
+          route: '/scribe',
+          message: 'Opening Meeting Scribe.',
+        );
+      case IntentType.searchMeetings:
+        final query = (intent.parameters['query'] as String?)?.trim() ?? '';
+        if (query.isEmpty) {
+          return const AgentToolResult(
+            route: '/scribe',
+            message: 'Opening Meeting Scribe to search your archive.',
+          );
+        }
+        final hits = await port.search(query);
+        if (hits.isEmpty) {
+          return AgentToolResult(
+            message: 'No meetings matched "$query" in your local archive.',
+          );
+        }
+        final lines = hits
+            .take(5)
+            .map((hit) => '• ${hit.title}: ${hit.snippet}')
+            .join('\n');
+        return AgentToolResult(
+          message: 'Found ${hits.length} meeting(s) for "$query":\n$lines',
+        );
+      case IntentType.myActionItems:
+        final owner =
+            (intent.parameters['owner'] as String?)?.trim() ?? 'me';
+        final items = await port.actionItemsForOwner(owner);
+        if (items.isEmpty) {
+          return AgentToolResult(
+            message: owner == 'me'
+                ? 'No open action items assigned to you in saved meetings.'
+                : 'No action items found for $owner.',
+          );
+        }
+        final lines = items
+            .take(8)
+            .map((item) => '• ${item.task}${item.due == null ? '' : ' (due ${item.due})'}')
+            .join('\n');
+        return AgentToolResult(message: 'Action items:\n$lines');
+      default:
+        return null;
+    }
+  }
+}
+
 /// Social/Chat tool.
 class SocialTool implements Tool {
   @override
@@ -454,6 +534,8 @@ class SocialTool implements Tool {
 class ToolRegistry {
   static final ToolRegistry _instance = ToolRegistry._internal();
 
+  MeetingArchivePort? _meetingArchive;
+
   final Map<String, Tool> _tools = {
     'split_bill': SplitBillTool(),
     'diet_plan': DietPlanTool(),
@@ -467,7 +549,16 @@ class ToolRegistry {
     'social': SocialTool(),
   };
 
-  ToolRegistry._internal();
+  ToolRegistry._internal() {
+    _tools['meeting_archive'] = MeetingArchiveTool(_meetingArchive);
+  }
+
+  /// Wires the offline meeting archive for chat tools (#1770). Called from
+  /// [MindModule.initialize] when the scribe is mounted.
+  void configureMeetingArchive(MeetingArchivePort? port) {
+    _meetingArchive = port;
+    _tools['meeting_archive'] = MeetingArchiveTool(port);
+  }
 
   factory ToolRegistry() {
     return _instance;

--- a/packages/feature_mind/lib/src/assistant/presentation/screens/assistant_screen.dart
+++ b/packages/feature_mind/lib/src/assistant/presentation/screens/assistant_screen.dart
@@ -52,6 +52,14 @@ class AssistantScreen extends ConsumerWidget {
           ),
           const SizedBox(height: 10),
           AiroActionCard(
+            title: 'Meeting Scribe',
+            subtitle:
+                'Record meetings, extract decisions and action items offline.',
+            icon: Icons.record_voice_over_outlined,
+            onTap: () => context.push('/scribe'),
+          ),
+          const SizedBox(height: 10),
+          AiroActionCard(
             title: 'Audio Scribe',
             subtitle:
                 'Capture speech, review the transcript, and translate with Airo.',

--- a/packages/feature_mind/lib/src/meeting_archive/meeting_archive_port.dart
+++ b/packages/feature_mind/lib/src/meeting_archive/meeting_archive_port.dart
@@ -1,0 +1,56 @@
+import '../mind_service.dart';
+import '../whisper/api/meetings.dart' as rust;
+
+/// Shell-provided seam for chat/tools to query the meeting archive (#1770).
+///
+/// Null when the composing shell did not mount the scribe (`createService`
+/// absent). Tools degrade to navigation rather than inventing transcript text.
+abstract class MeetingArchivePort {
+  Future<List<rust.SearchHit>> search(String query);
+
+  Future<rust.MeetingRecord?> meeting(String id);
+
+  /// Action items assigned to [ownerName], case-insensitive; null owner matches
+  /// unassigned rows only when [ownerName] is empty.
+  Future<List<rust.MeetingActionItemRecord>> actionItemsForOwner(
+    String ownerName,
+  );
+}
+
+/// Adapts [MindService] to [MeetingArchivePort].
+class MindServiceMeetingArchivePort implements MeetingArchivePort {
+  MindServiceMeetingArchivePort(this._service);
+
+  final MindService _service;
+
+  @override
+  Future<List<rust.SearchHit>> search(String query) => _service.search(query);
+
+  @override
+  Future<rust.MeetingRecord?> meeting(String id) => _service.meeting(id);
+
+  @override
+  Future<List<rust.MeetingActionItemRecord>> actionItemsForOwner(
+    String ownerName,
+  ) async {
+    final meetings = await _service.meetings();
+    final normalized = ownerName.trim().toLowerCase();
+    final hits = <rust.MeetingActionItemRecord>[];
+    for (final meeting in meetings) {
+      for (final item in meeting.actionItems) {
+        if (normalized == 'me') {
+          if (item.status == rust.MeetingActionStatus.open ||
+              item.status == rust.MeetingActionStatus.inProgress) {
+            hits.add(item);
+          }
+          continue;
+        }
+        final owner = item.owner?.trim().toLowerCase() ?? '';
+        if (owner == normalized) {
+          hits.add(item);
+        }
+      }
+    }
+    return hits;
+  }
+}

--- a/packages/feature_mind/lib/src/mind_module.dart
+++ b/packages/feature_mind/lib/src/mind_module.dart
@@ -4,6 +4,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_riverpod/misc.dart' show Override;
 import 'package:go_router/go_router.dart';
 
+import 'agent_chat/domain/services/tool_registry.dart';
 import 'agent_chat/presentation/screens/agent_skills_screen.dart';
 import 'agent_chat/presentation/screens/chat_screen.dart';
 import 'agent_chat/presentation/screens/device_capability_report_screen.dart';
@@ -18,6 +19,7 @@ import 'assistant/presentation/screens/prompt_lab_screen.dart';
 import 'capture/application/speech_language_preference.dart';
 import 'capture/presentation/meeting_capture_screen.dart';
 import 'host/assistant_host_adapter.dart';
+import 'meeting_archive/meeting_archive_port.dart';
 import 'mind_home_screen.dart';
 import 'mind_service.dart';
 import 'routing/assistant_route_names.dart';
@@ -50,7 +52,7 @@ typedef AssistantHostAdapterBuilder = AssistantHostAdapter Function(Ref ref);
 ///   Mind branch would wrap it in the super app's bottom navigation.
 /// * [scribeRoutesFor] — the meeting recorder, mounted at `/` and only
 ///   contributed when [createService] is supplied. The standalone shell reaches
-///   the scribe this way; the super app does not yet (Phase 4).
+///   the scribe this way; the super app mounts the same journey at `/scribe`.
 ///
 /// [routesFor] returns all three, so [ModuleRegistry] still sees the module's
 /// complete path/name surface for conflict detection. Shells that need the
@@ -124,6 +126,9 @@ class MindModule extends AppModule {
       // multilingual weights on cold start.
       final mode = await loadSpeechLanguageMode();
       await service.ensureReady(speechLanguage: mode.speechLanguage);
+      ToolRegistry().configureMeetingArchive(
+        MindServiceMeetingArchivePort(service),
+      );
     }
   }
 
@@ -140,13 +145,15 @@ class MindModule extends AppModule {
     ...scribeRoutesFor(shell),
   ];
 
-  /// The meeting recorder, mounted at the shell's root. Contributed only when
-  /// [createService] was supplied — today, the standalone Mind shell.
+  /// The meeting recorder. Contributed only when [createService] was supplied.
+  ///
+  /// Standalone Mind shell (`ShellId.mind`) mounts at `/`; the phone super app
+  /// mounts at `/scribe` so it does not collide with `/` → `/money`.
   List<RouteBase> scribeRoutesFor(ShellId shell) => [
     if (createService != null)
       GoRoute(
-        path: '/',
-        name: 'mind_scribe',
+        path: shell == ShellId.mind ? '/' : '/scribe',
+        name: shell == ShellId.mind ? 'mind_scribe' : 'superapp_scribe',
         builder: (context, state) => MindHomeScreen(service: service),
         routes: [
           // In-app capture (#1656): pause/resume, incremental disk writes,

--- a/packages/feature_mind/lib/src/mind_service.dart
+++ b/packages/feature_mind/lib/src/mind_service.dart
@@ -473,6 +473,12 @@ class MindService {
         metrics: metrics,
       );
 
+      final savedMeeting = await _speech.meeting(savedMeetingId);
+      if (savedMeeting != null) {
+        // Agent G (#1770): warm semantic search index after each save.
+        await indexMeetingForSearch(savedMeeting);
+      }
+
       final log = _operationLog;
       if (log != null) {
         await appendMeetingIrExtractedOp(

--- a/packages/feature_mind/test/agent_chat/domain/services/tool_registry_test.dart
+++ b/packages/feature_mind/test/agent_chat/domain/services/tool_registry_test.dart
@@ -1,8 +1,32 @@
 import 'package:feature_mind/src/agent_chat/domain/services/intent_parser.dart';
 import 'package:feature_mind/src/agent_chat/domain/services/tool_registry.dart';
+import 'package:feature_mind/src/meeting_archive/meeting_archive_port.dart';
 import 'package:feature_mind/src/services/device_actions_service.dart';
+import 'package:feature_mind/src/whisper/api/meetings.dart' as rust;
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
+
+class _FakeMeetingArchivePort implements MeetingArchivePort {
+  _FakeMeetingArchivePort({
+    this.hits = const [],
+    this.items = const [],
+  });
+
+  final List<rust.SearchHit> hits;
+  final List<rust.MeetingActionItemRecord> items;
+
+  @override
+  Future<List<rust.MeetingActionItemRecord>> actionItemsForOwner(
+    String ownerName,
+  ) async =>
+      items;
+
+  @override
+  Future<rust.MeetingRecord?> meeting(String id) async => null;
+
+  @override
+  Future<List<rust.SearchHit>> search(String query) async => hits;
+}
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -78,6 +102,38 @@ void main() {
 
       expect(result.route, '/assistant/audio-scribe');
       expect(result.message, contains('on-device capture'));
+    });
+
+    test('searches the meeting archive when a port is configured', () async {
+      registry.configureMeetingArchive(
+        _FakeMeetingArchivePort(
+          hits: [
+            rust.SearchHit(
+              meetingId: 'm1',
+              title: 'Infra standup',
+              recordedAt: BigInt.zero,
+              snippet: 'Temporal signalling limit',
+            ),
+          ],
+        ),
+      );
+
+      final result = await registry.executeIntent(
+        IntentParser.parse('what did we decide about Temporal signalling'),
+      );
+
+      expect(result.shouldNavigate, isFalse);
+      expect(result.message, contains('Temporal signalling'));
+    });
+
+    test('routes open scribe to /scribe', () async {
+      registry.configureMeetingArchive(_FakeMeetingArchivePort());
+
+      final result = await registry.executeIntent(
+        IntentParser.parse('record meeting'),
+      );
+
+      expect(result.route, '/scribe');
     });
 
     test('routes game and model management requests to Airo screens', () async {

--- a/packages/feature_mind/test/mind_service_test.dart
+++ b/packages/feature_mind/test/mind_service_test.dart
@@ -228,6 +228,28 @@ void main() {
     },
   );
 
+  test(
+    'T6b: MeetingIntelligenceEventCancelled yields idle and skips save',
+    () async {
+      speech.transcriptEvents = const [
+        TranscriptEventTranscriptReady('hello', [
+          TranscriptSegment(id: 's0', startMs: 0, endMs: 500, text: 'hello'),
+        ]),
+      ];
+      generation.meetingIntelligenceEvents = const [
+        MeetingIntelligenceEventCancelled(),
+      ];
+
+      final stages = await service
+          .process(wavPath: 'x.wav', title: 't')
+          .map((p) => p.stage)
+          .toList();
+
+      expect(stages.last, MindStage.idle);
+      expect(speech.savedModel, isNull);
+    },
+  );
+
   // T7 — save() is called with the model id the GENERATION bridge reports,
   // not something process() invents. `ADR-0018 §5`: what produced a summary
   // is recorded with it.

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -97,8 +97,13 @@ version = "0.1.0"
 dependencies = [
  "airo_mind_audio",
  "airo_mind_core",
+ "airo_mind_eval",
  "airo_mind_llama",
+ "airo_mind_meeting",
+ "airo_mind_transcript",
  "airo_mind_whisper",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/rust/airo_mind_cli/Cargo.toml
+++ b/rust/airo_mind_cli/Cargo.toml
@@ -2,7 +2,7 @@
 name = "airo_mind_cli"
 version = "0.1.0"
 edition = "2021"
-description = "Cross-platform dev-loop smoke test: real .m4a/.wav -> ASR transcript (with timestamps) -> LLM generation. Not shipped product code -- see README.md in this crate."
+description = "Cross-platform dev-loop and POC-2 offline pipeline: .m4a/.wav -> ASR -> meeting IR -> MoM -> eval gates. Not shipped product code -- see README.md."
 license = "MIT"
 publish = false
 
@@ -13,8 +13,13 @@ path = "src/main.rs"
 [dependencies]
 airo_mind_audio = { path = "../airo_mind_audio" }
 airo_mind_core = { path = "../airo_mind_core" }
+airo_mind_eval = { path = "../airo_mind_eval" }
+airo_mind_meeting = { path = "../airo_mind_meeting" }
+airo_mind_transcript = { path = "../airo_mind_transcript" }
 airo_mind_whisper = { path = "../airo_mind_whisper", features = ["whisper", "metal"] }
 airo_mind_llama = { path = "../airo_mind_llama", features = ["llama", "metal"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(frb_expand)'] }

--- a/rust/airo_mind_cli/README.md
+++ b/rust/airo_mind_cli/README.md
@@ -9,6 +9,8 @@ app builds pick the same libraries up.
 
 ## What it does
 
+### Legacy dev loop (default)
+
 1. Decodes the input audio to 16 kHz mono 16-bit PCM via `airo_mind_audio`
    (symphonia + rubato — no platform `afconvert` / ffmpeg binary).
 2. Runs it through `WhisperSpeechEngine` behind the real `Supervisor` /
@@ -19,6 +21,36 @@ app builds pick the same libraries up.
    summarization prompt, streaming the generated text to stdout chunk by
    chunk as `GenerationChunk`s arrive.
 4. Prints load/inference timings for both engines.
+
+### POC-2 full offline path (`--out`)
+
+One command runs the product pipeline end to end:
+
+1. preprocess → whisper ASR (segment ids `s0`, `s1`, …)
+2. `airo_mind_transcript::process`
+3. `airo_mind_meeting::extract` → `validate` → `generate_mom`
+4. Writes artifacts under `--out/`:
+   `transcript.json`, `predicted_ir.json`, `mom.md`, `hypothesis_transcript.txt`
+5. Runs `airo_mind_eval` gates (unless `--skip-eval`) and writes
+   `out/eval/run-NNN.json`. Exits non-zero when any gate fails.
+
+```sh
+cd rust
+mkdir -p models   # put ggml-tiny.en.bin and qwen2.5-0.5b-instruct-q4_k_m.gguf here
+cargo run -p airo_mind_cli -- fixtures/speech.m4a \
+  --models-dir models \
+  --out ./out/
+```
+
+`--models-dir` must contain **both** the whisper `.bin` and llama `.gguf` (or the first
+`.bin` / `.gguf` found). For separate locations, omit `--models-dir` and set
+`AIRO_MIND_WHISPER_MODEL` / `AIRO_MIND_LLAMA_MODEL` instead.
+
+Eval defaults score against the reference-meeting golden set in
+`airo_mind_eval/golden/reference_meeting/` and
+`airo_mind_meeting/tests/fixtures/golden_ir.json` — expect gate failures
+when the input audio is unrelated (e.g. `speech.m4a`). That is normal; the
+report still proves the wiring.
 
 On macOS, both crates are built with their `metal` cargo feature when available.
 

--- a/rust/airo_mind_cli/README.md
+++ b/rust/airo_mind_cli/README.md
@@ -30,9 +30,14 @@ One command runs the product pipeline end to end:
 2. `airo_mind_transcript::process`
 3. `airo_mind_meeting::extract` → `validate` → `generate_mom`
 4. Writes artifacts under `--out/`:
-   `transcript.json`, `predicted_ir.json`, `mom.md`, `hypothesis_transcript.txt`
+   `transcript.json` (raw + normalized segments), `chunks.json`,
+   `meeting_ir.json`, `predicted_ir.json`, `mom.md`, `hypothesis_transcript.txt`
 5. Runs `airo_mind_eval` gates (unless `--skip-eval`) and writes
    `out/eval/run-NNN.json`. Exits non-zero when any gate fails.
+
+Whisper defaults to multilingual `ggml-tiny.bin` with auto language detection.
+Place user meeting audio at `rust/fixtures/meeting_001.m4a` (or pass path as
+first arg); no checked-in user recording — download models per table below.
 
 ```sh
 cd rust

--- a/rust/airo_mind_cli/src/args.rs
+++ b/rust/airo_mind_cli/src/args.rs
@@ -127,9 +127,11 @@ EXAMPLE (POC-2):
 
 pub fn resolve_whisper_model(models_dir: Option<&PathBuf>) -> PathBuf {
     if let Some(dir) = models_dir {
-        let tiny = dir.join("ggml-tiny.en.bin");
-        if tiny.exists() {
-            return tiny;
+        for name in ["ggml-tiny.bin", "ggml-tiny.en.bin"] {
+            let path = dir.join(name);
+            if path.exists() {
+                return path;
+            }
         }
         if let Ok(entries) = std::fs::read_dir(dir) {
             for entry in entries.flatten() {
@@ -139,11 +141,11 @@ pub fn resolve_whisper_model(models_dir: Option<&PathBuf>) -> PathBuf {
                 }
             }
         }
-        return tiny;
+        return dir.join("ggml-tiny.bin");
     }
     env::var("AIRO_MIND_WHISPER_MODEL")
         .map(PathBuf::from)
-        .unwrap_or_else(|_| manifest_dir().join("../airo_mind_whisper/models/ggml-tiny.en.bin"))
+        .unwrap_or_else(|_| manifest_dir().join("../airo_mind_whisper/models/ggml-tiny.bin"))
 }
 
 pub fn resolve_llama_model(models_dir: Option<&PathBuf>) -> PathBuf {

--- a/rust/airo_mind_cli/src/args.rs
+++ b/rust/airo_mind_cli/src/args.rs
@@ -1,0 +1,189 @@
+//! Plain flag parsing for the dev CLI — no `clap` dependency (Constitution §6).
+
+use std::env;
+use std::path::PathBuf;
+
+#[derive(Clone, Debug)]
+pub struct CliArgs {
+    pub audio: PathBuf,
+    pub models_dir: Option<PathBuf>,
+    pub out: Option<PathBuf>,
+    pub skip_eval: bool,
+    pub meeting_id: String,
+    pub golden_transcript: Option<PathBuf>,
+    pub golden_ir: Option<PathBuf>,
+    pub golden_mom: Option<PathBuf>,
+    pub help: bool,
+}
+
+fn manifest_dir() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+}
+
+fn flag(args: &[String], name: &str) -> Option<PathBuf> {
+    args.iter()
+        .position(|a| a == name)
+        .and_then(|i| args.get(i + 1))
+        .map(PathBuf::from)
+}
+
+fn has_flag(args: &[String], name: &str) -> bool {
+    args.iter().any(|a| a == name)
+}
+
+/// First positional argument that is not a flag or a flag's value.
+fn positional_audio(args: &[String]) -> Option<PathBuf> {
+    let mut skip_next = false;
+    for arg in args.iter().skip(1) {
+        if skip_next {
+            skip_next = false;
+            continue;
+        }
+        if arg.starts_with('-') {
+            if arg == "--models-dir"
+                || arg == "--out"
+                || arg == "--meeting-id"
+                || arg == "--golden-transcript"
+                || arg == "--golden-ir"
+                || arg == "--golden-mom"
+            {
+                skip_next = true;
+            }
+            continue;
+        }
+        return Some(PathBuf::from(arg));
+    }
+    None
+}
+
+pub fn parse() -> CliArgs {
+    let args: Vec<String> = env::args().collect();
+
+    let audio = env::var("AIRO_MIND_CLI_AUDIO")
+        .map(PathBuf::from)
+        .ok()
+        .or_else(|| positional_audio(&args))
+        .unwrap_or_else(|| manifest_dir().join("../fixtures/speech.m4a"));
+
+    let meeting_fixtures = manifest_dir().join("../airo_mind_meeting/tests/fixtures");
+    let own_golden_dir = manifest_dir().join("../airo_mind_eval/golden/reference_meeting");
+
+    CliArgs {
+        audio,
+        models_dir: flag(&args, "--models-dir"),
+        out: flag(&args, "--out"),
+        skip_eval: has_flag(&args, "--skip-eval"),
+        meeting_id: flag(&args, "--meeting-id")
+            .and_then(|p| p.into_os_string().into_string().ok())
+            .unwrap_or_else(|| "cli-run".to_string()),
+        golden_transcript: flag(&args, "--golden-transcript")
+            .or_else(|| Some(own_golden_dir.join("transcript.json"))),
+        golden_ir: flag(&args, "--golden-ir")
+            .or_else(|| Some(meeting_fixtures.join("golden_ir.json"))),
+        golden_mom: flag(&args, "--golden-mom")
+            .or_else(|| Some(meeting_fixtures.join("golden_mom.md"))),
+        help: has_flag(&args, "--help") || has_flag(&args, "-h"),
+    }
+}
+
+pub fn print_help() {
+    println!(
+        "\
+airo_mind_cli — local dev loop for Airo Mind speech + generation
+
+USAGE:
+    cargo run -p airo_mind_cli -- [OPTIONS] [AUDIO]
+
+ARGS:
+    AUDIO    Input .m4a or .wav (default: rust/fixtures/speech.m4a)
+
+OPTIONS:
+    -h, --help                 Print this help
+    --models-dir DIR           Directory with whisper .bin and llama .gguf models
+    --out DIR                  Run full POC-2 pipeline and write artifacts here
+    --skip-eval                With --out, skip eval gates (artifacts only)
+    --meeting-id ID            Meeting id for transcript/IR (default: cli-run)
+    --golden-transcript PATH   Golden transcript.json for eval
+    --golden-ir PATH           Golden IR JSON for eval
+    --golden-mom PATH          Golden MoM markdown for eval
+
+ENV (used when --models-dir is absent):
+    AIRO_MIND_CLI_AUDIO        Default audio path
+    AIRO_MIND_WHISPER_MODEL    Whisper ggml model path
+    AIRO_MIND_LLAMA_MODEL      Llama gguf model path
+
+MODES:
+    Without --out: legacy summarize smoke test (ASR → one-line LLM summary).
+    With --out:    preprocess → whisper → transcript::process → extract →
+                   validate → generate_mom → eval gates (unless --skip-eval).
+
+EXAMPLE (POC-2):
+    cargo run -p airo_mind_cli -- rust/fixtures/speech.m4a \\
+      --models-dir rust/airo_mind_whisper/models \\
+      --out ./out/
+"
+    );
+}
+
+pub fn resolve_whisper_model(models_dir: Option<&PathBuf>) -> PathBuf {
+    if let Some(dir) = models_dir {
+        let tiny = dir.join("ggml-tiny.en.bin");
+        if tiny.exists() {
+            return tiny;
+        }
+        if let Ok(entries) = std::fs::read_dir(dir) {
+            for entry in entries.flatten() {
+                let path = entry.path();
+                if path.extension().is_some_and(|e| e == "bin") {
+                    return path;
+                }
+            }
+        }
+        return tiny;
+    }
+    env::var("AIRO_MIND_WHISPER_MODEL")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| manifest_dir().join("../airo_mind_whisper/models/ggml-tiny.en.bin"))
+}
+
+pub fn resolve_llama_model(models_dir: Option<&PathBuf>) -> PathBuf {
+    if let Some(dir) = models_dir {
+        let qwen = dir.join("qwen2.5-0.5b-instruct-q4_k_m.gguf");
+        if qwen.exists() {
+            return qwen;
+        }
+        if let Ok(entries) = std::fs::read_dir(dir) {
+            for entry in entries.flatten() {
+                let path = entry.path();
+                if path.extension().is_some_and(|e| e == "gguf") {
+                    return path;
+                }
+            }
+        }
+        return qwen;
+    }
+    env::var("AIRO_MIND_LLAMA_MODEL")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| {
+            manifest_dir().join("../airo_mind_llama/models/qwen2.5-0.5b-instruct-q4_k_m.gguf")
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn positional_audio_skips_flags_and_values() {
+        let args = vec![
+            "airo_mind_cli".into(),
+            "--out".into(),
+            "./out".into(),
+            "speech.m4a".into(),
+        ];
+        assert_eq!(
+            positional_audio(&args).map(|p| p.to_string_lossy().into_owned()),
+            Some("speech.m4a".into())
+        );
+    }
+}

--- a/rust/airo_mind_cli/src/eval_run.rs
+++ b/rust/airo_mind_cli/src/eval_run.rs
@@ -1,0 +1,104 @@
+//! Runs `airo_mind_eval` gates against CLI pipeline outputs.
+
+use std::path::{Path, PathBuf};
+use std::time::Instant;
+
+use airo_mind_eval::extraction::score_extraction;
+use airo_mind_eval::factual_consistency::factual_consistency;
+use airo_mind_eval::golden::{self, GoldenPaths};
+use airo_mind_eval::grounding::evaluate_mom_grounding;
+use airo_mind_eval::mom_quality::section_completeness;
+use airo_mind_eval::numeric::numeric_accuracy;
+use airo_mind_eval::performance;
+use airo_mind_eval::report;
+use airo_mind_eval::term_accuracy::term_accuracy;
+use airo_mind_eval::wer::word_error_rate;
+use airo_mind_meeting::dedup::DedupConfig;
+use airo_mind_meeting::MeetingIr;
+use airo_mind_transcript::normalize::technical_terms;
+
+use crate::args::CliArgs;
+use crate::pipeline::PipelineOutput;
+
+pub struct EvalResult {
+    pub report_path: PathBuf,
+    pub passed: bool,
+}
+
+pub fn run_eval(args: &CliArgs, out_dir: &Path, output: &PipelineOutput) -> EvalResult {
+    let golden_paths = GoldenPaths {
+        transcript: args
+            .golden_transcript
+            .clone()
+            .expect("golden transcript path"),
+        golden_ir: args.golden_ir.clone().expect("golden ir path"),
+        golden_mom: args.golden_mom.clone().expect("golden mom path"),
+        audio: args.audio.clone(),
+    };
+
+    let golden = golden::load(&golden_paths).expect("golden set loads");
+
+    let predicted_ir: MeetingIr = output.ir.clone();
+    let predicted_mom = output.mom.clone();
+    let hypothesis_transcript = output.hypothesis_text.clone();
+
+    let start = Instant::now();
+    let wer = word_error_rate(&golden.transcript.reference_text(), &hypothesis_transcript);
+    let terms = technical_terms();
+    let term_result = term_accuracy(
+        &golden.transcript.reference_text(),
+        &hypothesis_transcript,
+        &terms,
+    );
+
+    let extraction = score_extraction(
+        &predicted_ir.facts,
+        &golden.golden_ir.facts,
+        &DedupConfig::default(),
+    );
+
+    let golden_ir_json = serde_json::to_string(&golden.golden_ir).unwrap_or_default();
+    let predicted_ir_json = serde_json::to_string(&predicted_ir).unwrap_or_default();
+    let numeric = numeric_accuracy(&golden_ir_json, &predicted_ir_json);
+
+    let segments = golden.transcript.segments();
+    let grounding = evaluate_mom_grounding(&predicted_ir, &segments, &predicted_mom);
+
+    let completeness = section_completeness(&predicted_mom);
+    let consistency = factual_consistency(&predicted_ir, &predicted_mom);
+
+    let processing = start.elapsed();
+    let perf = performance::measure(golden.transcript.duration_ms(), processing, &[]);
+
+    let eval_reports = out_dir.join("eval");
+    let run_number = report::next_run_number(&eval_reports);
+    let run_report = report::build(
+        run_number,
+        &golden.golden_ir.meeting.id,
+        wer,
+        term_result,
+        extraction,
+        numeric,
+        grounding,
+        completeness,
+        consistency,
+        perf,
+        vec![],
+    );
+
+    let report_path = report::write(&eval_reports, &run_report).expect("eval report written");
+
+    println!("\n-- gates --");
+    for gate in &run_report.gates {
+        let status = if gate.passed { "PASS" } else { "FAIL" };
+        println!(
+            "[{status}] {:<20} {:.4} (threshold {:.4})",
+            gate.name, gate.value, gate.threshold
+        );
+    }
+
+    EvalResult {
+        report_path,
+        passed: run_report.passed,
+    }
+}

--- a/rust/airo_mind_cli/src/main.rs
+++ b/rust/airo_mind_cli/src/main.rs
@@ -1,17 +1,14 @@
-//! Dev-loop smoke test for Airo Mind's two engines.
+//! Dev-loop smoke test and POC-2 offline pipeline for Airo Mind.
 //!
-//! `.m4a` / `.wav` in, timestamped transcript out (`airo_mind_whisper`), transcript in,
-//! generated text out (`airo_mind_llama`) -- both engines running the exact
-//! same `Supervisor` / `SpeechEngine` / `GenerationEngine` contract the app
-//! consumes, both Metal-accelerated on this machine. See `README.md` in this
-//! crate for how to re-run it.
-//!
-//! Not shipped product code. It is a fast local feedback loop for iterating on
-//! `airo_mind_whisper` / `airo_mind_llama` before the Android/iOS app builds
-//! pick the same libraries up -- see milestone 26, Wave 1 exit gate.
+//! Without `--out`: legacy ASR → one-line LLM summary (Wave 1 dev loop).
+//! With `--out`: preprocess → whisper → transcript::process → extract →
+//! validate → generate_mom → `airo_mind_eval` gates. See `README.md`.
 
-use std::env;
-use std::path::PathBuf;
+mod args;
+mod eval_run;
+mod pipeline;
+
+use std::io::Write;
 use std::time::Instant;
 
 use airo_mind_audio::preprocess_path;
@@ -21,44 +18,11 @@ use airo_mind_llama::{
 };
 use airo_mind_whisper::{
     AudioInput, CancelToken as WhisperCancelToken, ResourceBudget as WhisperBudget,
-    Supervisor as WhisperSupervisor, TranscriptSegment, TranscriptionOptions,
-    WhisperSpeechEngine,
+    Supervisor as WhisperSupervisor, TranscriptSegment, TranscriptionOptions, WhisperSpeechEngine,
 };
 
-fn manifest_dir() -> PathBuf {
-    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-}
-
-/// `AIRO_MIND_CLI_AUDIO`, else the first CLI arg, else the repo's own
-/// synthesized fixture (`rust/fixtures/speech.m4a` -- see this crate's
-/// README for how it was made).
-fn audio_path() -> PathBuf {
-    if let Ok(p) = env::var("AIRO_MIND_CLI_AUDIO") {
-        return PathBuf::from(p);
-    }
-    if let Some(arg) = env::args().nth(1) {
-        return PathBuf::from(arg);
-    }
-    manifest_dir().join("../fixtures/speech.m4a")
-}
-
-/// `AIRO_MIND_WHISPER_MODEL`, else the path the crate's own `#1397` test
-/// suite already uses (`rust/airo_mind_whisper/models/ggml-tiny.en.bin`).
-fn whisper_model_path() -> PathBuf {
-    env::var("AIRO_MIND_WHISPER_MODEL")
-        .map(PathBuf::from)
-        .unwrap_or_else(|_| manifest_dir().join("../airo_mind_whisper/models/ggml-tiny.en.bin"))
-}
-
-/// `AIRO_MIND_LLAMA_MODEL`, else the path the crate's own `#1398` test suite
-/// already uses (`rust/airo_mind_llama/models/qwen2.5-0.5b-instruct-q4_k_m.gguf`).
-fn llama_model_path() -> PathBuf {
-    env::var("AIRO_MIND_LLAMA_MODEL")
-        .map(PathBuf::from)
-        .unwrap_or_else(|_| {
-            manifest_dir().join("../airo_mind_llama/models/qwen2.5-0.5b-instruct-q4_k_m.gguf")
-        })
-}
+use args::{parse, print_help, resolve_llama_model, resolve_whisper_model, CliArgs};
+use pipeline::{run_poc2, write_artifacts};
 
 fn format_ts(ms: u64) -> String {
     let total_secs = ms / 1000;
@@ -70,10 +34,6 @@ fn format_ts(ms: u64) -> String {
     )
 }
 
-/// The prompt sent to the LLM: a chat-formatted request to summarize the ASR
-/// output. Prompt shape (`<|im_start|>` / `<|im_end|>`) matches Qwen2.5's
-/// instruct chat template -- the same one `generation_offline.rs`'s
-/// `minutes_prompt` uses for the same model family.
 fn summarize_prompt(transcript: &str) -> String {
     format!(
         "<|im_start|>system\nYou are a concise assistant. Summarize the transcript in one \
@@ -83,23 +43,11 @@ fn summarize_prompt(transcript: &str) -> String {
     )
 }
 
-fn main() {
-    let audio = audio_path();
-    let whisper_model = whisper_model_path();
-    let llama_model = llama_model_path();
-
-    println!("== Airo Mind dev loop ==");
-    println!("audio:         {}", audio.display());
-    println!("whisper model: {}", whisper_model.display());
-    println!("llama model:   {}", llama_model.display());
-    println!(
-        "acceleration:  compiled with `metal` feature on both engines (macOS Metal + CoreML \
-         per Cargo.toml); watch stderr above for ggml's own \
-         `whisper_backend_init_gpu` / `ggml_metal_init` load-time log lines to confirm the \
-         runtime actually picked Metal up."
-    );
-    println!();
-
+fn validate_models(
+    audio: &std::path::Path,
+    whisper_model: &std::path::Path,
+    llama_model: &std::path::Path,
+) {
     if !audio.exists() {
         eprintln!("no audio at {} -- see README.md", audio.display());
         std::process::exit(1);
@@ -118,9 +66,16 @@ fn main() {
         );
         std::process::exit(1);
     }
+}
 
-    // --- decode -------------------------------------------------------
-    let pcm = match preprocess_path(&audio) {
+fn run_legacy(args: &CliArgs, whisper_model: &std::path::Path, llama_model: &std::path::Path) {
+    println!("== Airo Mind dev loop ==");
+    println!("audio:         {}", args.audio.display());
+    println!("whisper model: {}", whisper_model.display());
+    println!("llama model:   {}", llama_model.display());
+    println!();
+
+    let pcm = match preprocess_path(&args.audio) {
         Ok(pcm) => pcm,
         Err(e) => {
             eprintln!("decode failed: {e}");
@@ -134,11 +89,9 @@ fn main() {
         pcm.channels
     );
 
-    // --- ASR ------------------------------------------------------------
     println!("\n-- loading whisper.cpp (Metal) --");
     let t0 = Instant::now();
-    let speech_engine =
-        WhisperSpeechEngine::load(&whisper_model, 512).expect("whisper model loads");
+    let speech_engine = WhisperSpeechEngine::load(whisper_model, 512).expect("whisper model loads");
     println!("whisper load: {:?}", t0.elapsed());
 
     let mut whisper_supervisor = WhisperSupervisor::new(WhisperBudget::new(2048));
@@ -184,11 +137,10 @@ fn main() {
         std::process::exit(1);
     }
 
-    // --- generation -------------------------------------------------------
     println!("\n-- loading llama.cpp (Metal) --");
     let t0 = Instant::now();
     let generation_engine =
-        LlamaGenerationEngine::load(&llama_model, 1024, 2048).expect("llama model loads");
+        LlamaGenerationEngine::load(llama_model, 1024, 2048).expect("llama model loads");
     println!("llama load: {:?}", t0.elapsed());
 
     let mut llama_supervisor = LlamaSupervisor::new(LlamaBudget::new(4096));
@@ -202,16 +154,11 @@ fn main() {
             &GenerationRequest {
                 prompt: summarize_prompt(&transcript),
                 max_output_tokens: 160,
-                // Unconstrained sampling -- this CLI is a free-text
-                // dev-loop smoke test, not a capability building a
-                // schema-constrained prompt like Meeting IR's extraction
-                // pass (`airo_mind_meeting`, `#1633`).
                 grammar: None,
             },
             &LlamaCancelToken::new(),
             &mut |chunk| {
                 print!("{}", chunk.text);
-                use std::io::Write;
                 let _ = std::io::stdout().flush();
                 generated.push_str(&chunk.text);
                 Ok(())
@@ -223,4 +170,58 @@ fn main() {
     println!("\n== done ==");
     println!("transcript chars: {}", transcript.len());
     println!("generated chars:  {}", generated.len());
+}
+
+fn run_poc2_mode(args: &CliArgs, whisper_model: &std::path::Path, llama_model: &std::path::Path) {
+    let out_dir = args.out.as_ref().expect("--out required for poc2 mode");
+
+    println!("== Airo Mind POC-2 pipeline ==");
+    println!("audio:         {}", args.audio.display());
+    println!("whisper model: {}", whisper_model.display());
+    println!("llama model:   {}", llama_model.display());
+    println!("out:           {}", out_dir.display());
+    println!();
+
+    let output = run_poc2(args, whisper_model, llama_model);
+    write_artifacts(out_dir, args, &output);
+
+    println!("wrote {}/transcript.json", out_dir.display());
+    println!("wrote {}/predicted_ir.json", out_dir.display());
+    println!("wrote {}/mom.md", out_dir.display());
+    println!("wrote {}/hypothesis_transcript.txt", out_dir.display());
+    println!("pipeline: {} ms", output.processing_ms);
+
+    if args.skip_eval {
+        println!("\n== done (eval skipped) ==");
+        return;
+    }
+
+    let eval = eval_run::run_eval(args, out_dir, &output);
+    println!("wrote {}", eval.report_path.display());
+
+    if eval.passed {
+        println!("\nall gates passed");
+        std::process::exit(0);
+    } else {
+        println!("\nGATE FAILURE");
+        std::process::exit(1);
+    }
+}
+
+fn main() {
+    let args = parse();
+    if args.help {
+        print_help();
+        return;
+    }
+
+    let whisper_model = resolve_whisper_model(args.models_dir.as_ref());
+    let llama_model = resolve_llama_model(args.models_dir.as_ref());
+    validate_models(&args.audio, &whisper_model, &llama_model);
+
+    if args.out.is_some() {
+        run_poc2_mode(&args, &whisper_model, &llama_model);
+    } else {
+        run_legacy(&args, &whisper_model, &llama_model);
+    }
 }

--- a/rust/airo_mind_cli/src/main.rs
+++ b/rust/airo_mind_cli/src/main.rs
@@ -186,6 +186,8 @@ fn run_poc2_mode(args: &CliArgs, whisper_model: &std::path::Path, llama_model: &
     write_artifacts(out_dir, args, &output);
 
     println!("wrote {}/transcript.json", out_dir.display());
+    println!("wrote {}/chunks.json", out_dir.display());
+    println!("wrote {}/meeting_ir.json", out_dir.display());
     println!("wrote {}/predicted_ir.json", out_dir.display());
     println!("wrote {}/mom.md", out_dir.display());
     println!("wrote {}/hypothesis_transcript.txt", out_dir.display());

--- a/rust/airo_mind_cli/src/pipeline.rs
+++ b/rust/airo_mind_cli/src/pipeline.rs
@@ -1,0 +1,244 @@
+//! Full offline meeting-intelligence pipeline for the CLI.
+
+use std::path::{Path, PathBuf};
+use std::time::Instant;
+
+use airo_mind_audio::preprocess_path;
+use airo_mind_core::{
+    CancelToken, EngineError, GenerationChunk, GenerationEngine, GenerationRequest,
+    ResourceRequest, RuntimeError, RuntimeStats, Supervisor, TranscriptSegment,
+};
+use airo_mind_llama::{LlamaGenerationEngine, ResourceBudget, Supervisor as LlamaSupervisor};
+use airo_mind_meeting::{
+    extract, generate_mom, validate, ExtractionConfig, MeetingInput, MeetingIr, MomError,
+};
+use airo_mind_transcript::{process, ChunkConfig, Segment};
+use airo_mind_whisper::{
+    AudioInput, CancelToken as WhisperCancelToken, ResourceBudget as WhisperBudget,
+    Supervisor as WhisperSupervisor, TranscriptionOptions, WhisperSpeechEngine,
+};
+use serde::Serialize;
+
+use crate::args::CliArgs;
+
+#[derive(Debug)]
+pub struct PipelineOutput {
+    pub segments: Vec<Segment>,
+    pub hypothesis_text: String,
+    pub ir: MeetingIr,
+    pub mom: String,
+    pub whisper_model: PathBuf,
+    #[allow(dead_code)]
+    pub llama_model: PathBuf,
+    pub processing_ms: u64,
+}
+
+#[derive(Serialize)]
+struct StoredSegmentArtifact {
+    id: String,
+    start_ms: u64,
+    end_ms: u64,
+    text: String,
+}
+
+#[derive(Serialize)]
+struct TranscriptArtifact {
+    meeting_id: String,
+    audio_path: String,
+    model_version: String,
+    segments: Vec<StoredSegmentArtifact>,
+}
+
+fn segments_with_ids(raw: &[TranscriptSegment]) -> Vec<Segment> {
+    raw.iter()
+        .enumerate()
+        .map(|(i, s)| Segment {
+            id: format!("s{i}"),
+            start_ms: s.start_ms,
+            end_ms: s.end_ms,
+            text: s.text.trim().to_string(),
+        })
+        .collect()
+}
+
+fn hypothesis_text(segments: &[Segment]) -> String {
+    segments
+        .iter()
+        .map(|s| s.text.as_str())
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+struct SupervisorGenerationEngine<'a> {
+    supervisor: &'a Supervisor,
+}
+
+impl GenerationEngine for SupervisorGenerationEngine<'_> {
+    fn resource_request(&self) -> ResourceRequest {
+        ResourceRequest::new(0)
+    }
+
+    fn stats(&self) -> RuntimeStats {
+        self.supervisor.generation_stats().unwrap_or_default()
+    }
+
+    fn generate(
+        &self,
+        request: &GenerationRequest,
+        cancel: &CancelToken,
+        sink: &mut dyn FnMut(GenerationChunk) -> Result<(), EngineError>,
+    ) -> Result<(), EngineError> {
+        self.supervisor
+            .run_generation(request, cancel, sink)
+            .map_err(runtime_to_engine)
+    }
+}
+
+fn runtime_to_engine(error: RuntimeError) -> EngineError {
+    match error {
+        RuntimeError::Engine(e) => e,
+        other => EngineError::Backend(other.to_string()),
+    }
+}
+
+fn mom_to_string(error: MomError) -> String {
+    match error {
+        MomError::Cancelled => "cancelled".into(),
+        MomError::Engine(message) => message,
+    }
+}
+
+pub fn run_poc2(args: &CliArgs, whisper_model: &Path, llama_model: &Path) -> PipelineOutput {
+    let start = Instant::now();
+
+    let pcm = preprocess_path(&args.audio).expect("audio preprocess succeeds");
+
+    let speech_engine = WhisperSpeechEngine::load(whisper_model, 512).expect("whisper loads");
+    let mut whisper_supervisor = WhisperSupervisor::new(WhisperBudget::new(2048));
+    whisper_supervisor.register_speech(Box::new(speech_engine));
+
+    let mut raw_segments: Vec<TranscriptSegment> = Vec::new();
+    whisper_supervisor
+        .run_speech(
+            AudioInput {
+                samples: &pcm.samples,
+                sample_rate_hz: pcm.sample_rate_hz,
+                channels: pcm.channels,
+            },
+            &TranscriptionOptions::default(),
+            &WhisperCancelToken::new(),
+            &mut |segment| {
+                raw_segments.push(segment);
+                Ok(())
+            },
+        )
+        .expect("transcription succeeds");
+
+    let segments = segments_with_ids(&raw_segments);
+    let hypothesis = hypothesis_text(&segments);
+    if hypothesis.trim().is_empty() {
+        panic!("whisper produced no text");
+    }
+
+    let processed = process(&segments, &ChunkConfig::default());
+
+    let generation_engine =
+        LlamaGenerationEngine::load(llama_model, 1024, 2048).expect("llama loads");
+    let mut llama_supervisor = LlamaSupervisor::new(ResourceBudget::new(4096));
+    llama_supervisor.register_generation(Box::new(generation_engine));
+
+    let cancel = CancelToken::new();
+    let model_id = format!(
+        "cli@{}",
+        llama_model
+            .file_stem()
+            .and_then(|s| s.to_str())
+            .unwrap_or("llama")
+    );
+
+    let extraction = {
+        let engine = SupervisorGenerationEngine {
+            supervisor: &llama_supervisor,
+        };
+        extract(
+            &engine,
+            &processed,
+            &MeetingInput {
+                id: args.meeting_id.clone(),
+                title: None,
+                model_id: Some(model_id),
+            },
+            &ExtractionConfig::default(),
+            &cancel,
+        )
+        .expect("extraction succeeds")
+    };
+
+    let (validated_ir, _report) = validate(&extraction.ir, &segments);
+
+    let mom = {
+        let engine = SupervisorGenerationEngine {
+            supervisor: &llama_supervisor,
+        };
+        generate_mom(&engine, &validated_ir, &cancel)
+            .map_err(mom_to_string)
+            .expect("mom succeeds")
+    };
+
+    PipelineOutput {
+        segments,
+        hypothesis_text: hypothesis,
+        ir: validated_ir,
+        mom,
+        whisper_model: whisper_model.to_path_buf(),
+        llama_model: llama_model.to_path_buf(),
+        processing_ms: start.elapsed().as_millis() as u64,
+    }
+}
+
+pub fn write_artifacts(out_dir: &Path, args: &CliArgs, output: &PipelineOutput) {
+    std::fs::create_dir_all(out_dir).expect("out dir created");
+
+    let transcript_path = out_dir.join("transcript.json");
+    let artifact = TranscriptArtifact {
+        meeting_id: args.meeting_id.clone(),
+        audio_path: args.audio.display().to_string(),
+        model_version: format!(
+            "whisper@{}",
+            output
+                .whisper_model
+                .file_stem()
+                .and_then(|s| s.to_str())
+                .unwrap_or("model")
+        ),
+        segments: output
+            .segments
+            .iter()
+            .map(|s| StoredSegmentArtifact {
+                id: s.id.clone(),
+                start_ms: s.start_ms,
+                end_ms: s.end_ms,
+                text: s.text.clone(),
+            })
+            .collect(),
+    };
+    std::fs::write(
+        &transcript_path,
+        serde_json::to_string_pretty(&artifact).expect("transcript serializes"),
+    )
+    .expect("transcript.json written");
+
+    let ir_path = out_dir.join("predicted_ir.json");
+    std::fs::write(
+        &ir_path,
+        serde_json::to_string_pretty(&output.ir).expect("ir serializes"),
+    )
+    .expect("predicted_ir.json written");
+
+    let mom_path = out_dir.join("mom.md");
+    std::fs::write(&mom_path, &output.mom).expect("mom.md written");
+
+    let hypothesis_path = out_dir.join("hypothesis_transcript.txt");
+    std::fs::write(&hypothesis_path, &output.hypothesis_text)
+        .expect("hypothesis_transcript.txt written");
+}

--- a/rust/airo_mind_cli/src/pipeline.rs
+++ b/rust/airo_mind_cli/src/pipeline.rs
@@ -12,7 +12,7 @@ use airo_mind_llama::{LlamaGenerationEngine, ResourceBudget, Supervisor as Llama
 use airo_mind_meeting::{
     extract, generate_mom, validate, ExtractionConfig, MeetingInput, MeetingIr, MomError,
 };
-use airo_mind_transcript::{process, ChunkConfig, Segment};
+use airo_mind_transcript::{process, Chunk, ChunkConfig, ProcessedTranscript, Segment};
 use airo_mind_whisper::{
     AudioInput, CancelToken as WhisperCancelToken, ResourceBudget as WhisperBudget,
     Supervisor as WhisperSupervisor, TranscriptionOptions, WhisperSpeechEngine,
@@ -23,7 +23,7 @@ use crate::args::CliArgs;
 
 #[derive(Debug)]
 pub struct PipelineOutput {
-    pub segments: Vec<Segment>,
+    pub processed: ProcessedTranscript,
     pub hypothesis_text: String,
     pub ir: MeetingIr,
     pub mom: String,
@@ -38,7 +38,8 @@ struct StoredSegmentArtifact {
     id: String,
     start_ms: u64,
     end_ms: u64,
-    text: String,
+    raw: String,
+    normalized: String,
 }
 
 #[derive(Serialize)]
@@ -46,7 +47,18 @@ struct TranscriptArtifact {
     meeting_id: String,
     audio_path: String,
     model_version: String,
+    raw: String,
+    normalized: String,
     segments: Vec<StoredSegmentArtifact>,
+}
+
+#[derive(Serialize)]
+struct ChunkArtifact {
+    id: String,
+    start_ms: u64,
+    end_ms: u64,
+    segment_ids: Vec<String>,
+    text: String,
 }
 
 fn segments_with_ids(raw: &[TranscriptSegment]) -> Vec<Segment> {
@@ -67,6 +79,19 @@ fn hypothesis_text(segments: &[Segment]) -> String {
         .map(|s| s.text.as_str())
         .collect::<Vec<_>>()
         .join(" ")
+}
+
+fn chunk_artifacts(chunks: &[Chunk]) -> Vec<ChunkArtifact> {
+    chunks
+        .iter()
+        .map(|c| ChunkArtifact {
+            id: c.id.clone(),
+            start_ms: c.start_ms,
+            end_ms: c.end_ms,
+            segment_ids: c.segment_ids.clone(),
+            text: c.text.clone(),
+        })
+        .collect()
 }
 
 struct SupervisorGenerationEngine<'a> {
@@ -117,6 +142,9 @@ pub fn run_poc2(args: &CliArgs, whisper_model: &Path, llama_model: &Path) -> Pip
     let mut whisper_supervisor = WhisperSupervisor::new(WhisperBudget::new(2048));
     whisper_supervisor.register_speech(Box::new(speech_engine));
 
+    // Multilingual auto-detect — same default as product (`language: None`).
+    let asr_options = TranscriptionOptions { language: None };
+
     let mut raw_segments: Vec<TranscriptSegment> = Vec::new();
     whisper_supervisor
         .run_speech(
@@ -125,7 +153,7 @@ pub fn run_poc2(args: &CliArgs, whisper_model: &Path, llama_model: &Path) -> Pip
                 sample_rate_hz: pcm.sample_rate_hz,
                 channels: pcm.channels,
             },
-            &TranscriptionOptions::default(),
+            &asr_options,
             &WhisperCancelToken::new(),
             &mut |segment| {
                 raw_segments.push(segment);
@@ -186,7 +214,7 @@ pub fn run_poc2(args: &CliArgs, whisper_model: &Path, llama_model: &Path) -> Pip
     };
 
     PipelineOutput {
-        segments,
+        processed,
         hypothesis_text: hypothesis,
         ir: validated_ir,
         mom,
@@ -211,14 +239,18 @@ pub fn write_artifacts(out_dir: &Path, args: &CliArgs, output: &PipelineOutput) 
                 .and_then(|s| s.to_str())
                 .unwrap_or("model")
         ),
+        raw: output.processed.raw.clone(),
+        normalized: output.processed.normalized.clone(),
         segments: output
+            .processed
             .segments
             .iter()
             .map(|s| StoredSegmentArtifact {
                 id: s.id.clone(),
                 start_ms: s.start_ms,
                 end_ms: s.end_ms,
-                text: s.text.clone(),
+                raw: s.raw.clone(),
+                normalized: s.normalized.clone(),
             })
             .collect(),
     };
@@ -228,12 +260,18 @@ pub fn write_artifacts(out_dir: &Path, args: &CliArgs, output: &PipelineOutput) 
     )
     .expect("transcript.json written");
 
-    let ir_path = out_dir.join("predicted_ir.json");
+    let chunks_path = out_dir.join("chunks.json");
     std::fs::write(
-        &ir_path,
-        serde_json::to_string_pretty(&output.ir).expect("ir serializes"),
+        &chunks_path,
+        serde_json::to_string_pretty(&chunk_artifacts(&output.processed.chunks))
+            .expect("chunks serializes"),
     )
-    .expect("predicted_ir.json written");
+    .expect("chunks.json written");
+
+    let ir_json = serde_json::to_string_pretty(&output.ir).expect("ir serializes");
+
+    std::fs::write(out_dir.join("meeting_ir.json"), &ir_json).expect("meeting_ir.json written");
+    std::fs::write(out_dir.join("predicted_ir.json"), &ir_json).expect("predicted_ir.json written");
 
     let mom_path = out_dir.join("mom.md");
     std::fs::write(&mom_path, &output.mom).expect("mom.md written");

--- a/rust/airo_mind_eval/golden/meeting_001/golden_ir.json
+++ b/rust/airo_mind_eval/golden/meeting_001/golden_ir.json
@@ -1,0 +1,51 @@
+{
+  "schema_version": "1.0.0",
+  "meeting": {
+    "id": "meeting-001-multilingual",
+    "title": "Multilingual infra standup",
+    "started_at_ms": 0,
+    "ended_at_ms": 19500,
+    "chunk_count": 1,
+    "segment_count": 4,
+    "model_id": "model-under-test@0.0.0",
+    "prompt_version": "chunk_facts.v1"
+  },
+  "topics": [
+    {
+      "id": "topic-0",
+      "title": "YugabyteDB connection pool",
+      "evidence": ["s0"]
+    }
+  ],
+  "observations": [],
+  "decisions": [
+    {
+      "id": "decision-0",
+      "statement": "move signalling onto the queue before the release",
+      "status": "agreed",
+      "evidence": ["s3"]
+    }
+  ],
+  "action_items": [
+    {
+      "id": "action_item-0",
+      "task": "check the Temporal signalling limit",
+      "owner": null,
+      "due": "Friday",
+      "status": "open",
+      "evidence": ["s1"]
+    },
+    {
+      "id": "action_item-1",
+      "task": "update the runbook",
+      "owner": "Priya",
+      "due": "Monday",
+      "status": "open",
+      "evidence": ["s2"]
+    }
+  ],
+  "metrics": [],
+  "risks": [],
+  "questions": [],
+  "next_steps": []
+}

--- a/rust/airo_mind_eval/golden/meeting_001/golden_mom.md
+++ b/rust/airo_mind_eval/golden/meeting_001/golden_mom.md
@@ -1,0 +1,28 @@
+# Minutes of Meeting
+
+**Meeting:** Multilingual infra standup
+
+## Meeting Objective
+
+Review YugabyteDB connection pool performance and the Temporal signalling limit ahead of the release.
+
+## Key Discussion Points
+
+The team discussed YugabyteDB connection pool slowness in production and the need to verify the Temporal signalling limit before the release.
+
+## Decisions & Direction
+
+| Decision | Status |
+| --- | --- |
+| move signalling onto the queue before the release | Agreed |
+
+## Action Items
+
+| Task | Owner | Due | Status |
+| --- | --- | --- | --- |
+| check the Temporal signalling limit | — | Friday | Open |
+| update the runbook | Priya | Monday | Open |
+
+## Next Steps
+
+_No next steps recorded._

--- a/rust/airo_mind_eval/golden/meeting_001/technical_terms.txt
+++ b/rust/airo_mind_eval/golden/meeting_001/technical_terms.txt
@@ -1,0 +1,4 @@
+# Per-meeting technical vocabulary for term-accuracy scoring (J3).
+Temporal
+YugabyteDB
+signalling

--- a/rust/airo_mind_eval/golden/meeting_001/transcript.json
+++ b/rust/airo_mind_eval/golden/meeting_001/transcript.json
@@ -1,0 +1,29 @@
+{
+  "meeting_id": "meeting-001-multilingual",
+  "segments": [
+    {
+      "id": "s0",
+      "start_ms": 0,
+      "end_ms": 4500,
+      "text": "Right, YugabyteDB का connection pool बहुत slow है production में।"
+    },
+    {
+      "id": "s1",
+      "start_ms": 5000,
+      "end_ms": 9500,
+      "text": "We need to check the Temporal signalling limit before Friday."
+    },
+    {
+      "id": "s2",
+      "start_ms": 10000,
+      "end_ms": 14500,
+      "text": "Priya will update the runbook by Monday."
+    },
+    {
+      "id": "s3",
+      "start_ms": 15000,
+      "end_ms": 19500,
+      "text": "Agreed — move signalling onto the queue before the release."
+    }
+  ]
+}

--- a/rust/airo_mind_eval/src/golden.rs
+++ b/rust/airo_mind_eval/src/golden.rs
@@ -142,6 +142,29 @@ fn parse_json<T: serde::de::DeserializeOwned>(
     })
 }
 
+/// Resolves the four artifact paths for a named golden meeting under
+/// `golden/<meeting_id>/`.
+pub fn paths_for_meeting(eval_manifest: &Path, meeting_id: &str) -> GoldenPaths {
+    let dir = eval_manifest.join("golden").join(meeting_id);
+    GoldenPaths {
+        transcript: dir.join("transcript.json"),
+        golden_ir: dir.join("golden_ir.json"),
+        golden_mom: dir.join("golden_mom.md"),
+        audio: dir.join("audio.m4a"),
+    }
+}
+
+/// One term per line; `#` starts a comment. Used by `meeting_001` and friends.
+pub fn load_technical_terms(path: &Path) -> Result<Vec<String>, GoldenLoadError> {
+    let raw = read(path)?;
+    Ok(raw
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty() && !line.starts_with('#'))
+        .map(str::to_string)
+        .collect())
+}
+
 /// Loads a golden set from `paths`. `audio` is not required to exist -- see
 /// the module doc comment.
 pub fn load(paths: &GoldenPaths) -> Result<GoldenSet, GoldenLoadError> {
@@ -208,6 +231,40 @@ mod tests {
         assert_eq!(set.audio_path, dir.join("audio.m4a"));
 
         std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn meeting_001_golden_mom_passes_self_consistency_checks() {
+        let manifest = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        let paths = paths_for_meeting(&manifest, "meeting_001");
+        let set = load(&paths).expect("meeting_001 loads");
+        let consistency =
+            crate::factual_consistency::factual_consistency(&set.golden_ir, &set.golden_mom);
+        assert_eq!(
+            consistency.score, 1.0,
+            "golden MoM must match golden IR for smoke runs: {:?}",
+            consistency.checks
+        );
+        let completeness = crate::mom_quality::section_completeness(&set.golden_mom);
+        assert_eq!(completeness.coverage, 1.0, "missing: {:?}", completeness.missing);
+    }
+
+    #[test]
+    fn meeting_001_fixture_loads_from_repo() {
+        let manifest = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        let paths = paths_for_meeting(&manifest, "meeting_001");
+        let set = load(&paths).expect("meeting_001 golden set loads");
+        assert_eq!(set.transcript.meeting_id, "meeting-001-multilingual");
+        assert_eq!(set.golden_ir.meeting.id, "meeting-001-multilingual");
+        let terms = load_technical_terms(
+            &paths
+                .transcript
+                .parent()
+                .unwrap()
+                .join("technical_terms.txt"),
+        )
+        .expect("technical terms load");
+        assert!(terms.contains(&"Temporal".to_string()));
     }
 
     #[test]

--- a/rust/airo_mind_eval/src/main.rs
+++ b/rust/airo_mind_eval/src/main.rs
@@ -50,23 +50,31 @@ fn flag(args: &[String], name: &str) -> Option<PathBuf> {
         .map(PathBuf::from)
 }
 
+fn flag_string(args: &[String], name: &str) -> Option<String> {
+    args.iter()
+        .position(|a| a == name)
+        .and_then(|i| args.get(i + 1))
+        .cloned()
+}
+
 fn main() {
     let args: Vec<String> = std::env::args().collect();
 
-    // golden_ir.json / golden_mom.md live in airo_mind_meeting's own fixture
-    // directory -- see golden.rs's module doc comment for why this crate
-    // reads them by relative path instead of keeping a second copy.
     let meeting_fixtures = manifest_dir().join("../airo_mind_meeting/tests/fixtures");
     let own_golden_dir = manifest_dir().join("golden/reference_meeting");
 
-    let golden_paths = GoldenPaths {
-        transcript: flag(&args, "--transcript")
-            .unwrap_or_else(|| own_golden_dir.join("transcript.json")),
-        golden_ir: flag(&args, "--golden-ir")
-            .unwrap_or_else(|| meeting_fixtures.join("golden_ir.json")),
-        golden_mom: flag(&args, "--golden-mom")
-            .unwrap_or_else(|| meeting_fixtures.join("golden_mom.md")),
-        audio: flag(&args, "--audio").unwrap_or_else(|| own_golden_dir.join("audio.m4a")),
+    let golden_paths = if let Some(meeting_id) = flag_string(&args, "--meeting") {
+        golden::paths_for_meeting(&manifest_dir(), &meeting_id)
+    } else {
+        GoldenPaths {
+            transcript: flag(&args, "--transcript")
+                .unwrap_or_else(|| own_golden_dir.join("transcript.json")),
+            golden_ir: flag(&args, "--golden-ir")
+                .unwrap_or_else(|| meeting_fixtures.join("golden_ir.json")),
+            golden_mom: flag(&args, "--golden-mom")
+                .unwrap_or_else(|| meeting_fixtures.join("golden_mom.md")),
+            audio: flag(&args, "--audio").unwrap_or_else(|| own_golden_dir.join("audio.m4a")),
+        }
     };
     let out_dir = flag(&args, "--out-dir").unwrap_or_else(|| manifest_dir().join("evals/reports"));
 
@@ -160,11 +168,29 @@ fn main() {
     let start = Instant::now();
 
     let wer = word_error_rate(&golden.transcript.reference_text(), &hypothesis_transcript);
-    let terms = airo_mind_transcript::normalize::technical_terms();
+    let terms: Vec<String> = flag(&args, "--technical-terms")
+        .map(|path| golden::load_technical_terms(&path).expect("technical terms file loads"))
+        .or_else(|| {
+            let auto = golden_paths
+                .transcript
+                .parent()
+                .map(|dir| dir.join("technical_terms.txt"))
+                .filter(|path| path.is_file());
+            auto.map(|path| {
+                golden::load_technical_terms(&path).expect("technical terms file loads")
+            })
+        })
+        .unwrap_or_else(|| {
+            airo_mind_transcript::normalize::technical_terms()
+                .iter()
+                .map(|s| (*s).to_string())
+                .collect()
+        });
+    let term_refs: Vec<&str> = terms.iter().map(String::as_str).collect();
     let term_result = term_accuracy(
         &golden.transcript.reference_text(),
         &hypothesis_transcript,
-        &terms,
+        &term_refs,
     );
 
     let extraction = score_extraction(


### PR DESCRIPTION
## Summary

Wave 2 offline meeting-intelligence slice — one PR spanning CLI proof, eval golden set, and product wiring:

### J2 — CLI full offline pipeline (POC-2) `#1787`
- `cargo run -p airo_mind_cli -- <audio> --models-dir … --out ./out/`
- Pipeline: preprocess → whisper (multilingual `ggml-tiny.bin`, auto language detect) → `transcript::process` → extract → validate → `generate_mom` → `airo_mind_eval` gates
- Writes: `transcript.json` (raw+normalized segments), `chunks.json`, `meeting_ir.json`, `predicted_ir.json`, `mom.md`, `hypothesis_transcript.txt`, `out/eval/run-NNN.json`
- Exit `1` on gate failure; `--skip-eval` for artifacts-only runs

### J3 — Golden multilingual eval
- `rust/airo_mind_eval/golden/meeting_001/` — Hindi+English transcript, IR, MoM, `technical_terms.txt`
- `cargo run -p airo_mind_eval -- --meeting meeting_001` — all 9 gates pass (golden-vs-golden smoke)
- `--meeting` flag + auto-load `technical_terms.txt` from golden dir

### H — Super-app Meeting Scribe tab `#1770`
- `mind_registration.dart` wires `createService` + processing queue (same as standalone Mind shell)
- `/scribe` mounted full-screen in phone super app (outside bottom nav)
- “Meeting Scribe” entry on assistant hub → record → full IR pipeline (not legacy summarize)

### G — Chat over meetings `#1770`
- Intents: `searchMeetings`, `openMeetingScribe`, `myActionItems`
- `MeetingArchiveTool` queries local archive via `MeetingArchivePort` (no cloud, no full-transcript dump)
- `indexMeetingForSearch()` after each successful `process()` save

### J0 polish
- `mind_service_test` T6b: `MeetingIntelligenceEventCancelled` → `idle`, no save

## Architecture note

Product path remains: **Audio → ASR → transcript processor → extract → validate → MoM from IR** — never summarize transcript for minutes. J0 orchestration was already on `main` (`#1785`); this PR proves it end-to-end in CLI and wires scribe + chat seams in the super app.

## Test plan

- [x] `cargo test -p airo_mind_cli -p airo_mind_eval` (72 tests)
- [x] `cargo run -p airo_mind_cli -- --help`
- [x] `cargo run -p airo_mind_eval -- --meeting meeting_001` (all gates pass)
- [x] `tool_registry_test` — meeting archive search + `/scribe` routing
- [x] `main_super_app_shell_test` + `assistant_route_parity_test` — `/scribe` top-level, outside Mind branch
- [ ] With local models: `cargo run -p airo_mind_cli -- fixtures/speech.m4a --models-dir models --out ./out/`
- [ ] Device: Pixel 9 / iPad — Assistant → Meeting Scribe → record → process → IR on meeting screen
- [ ] `dart test packages/feature_mind/test/mind_service_test.dart` (T6b)

Closes #1787