### PR TITLE
feat(mind): chat MoM retrieval and agnostic meeting fixtures

### DIFF
--- a/packages/feature_mind/lib/src/agent_chat/domain/services/intent_parser.dart
+++ b/packages/feature_mind/lib/src/agent_chat/domain/services/intent_parser.dart
@@ -223,6 +223,21 @@ class IntentParser {
     }
 
     if (_containsAny(text, [
+      'give me mom',
+      'get mom',
+      'get minutes',
+      'show minutes',
+      'minutes of meeting',
+      'meeting minutes',
+      'share the mom',
+      'share minutes',
+      'mom for',
+      'minutes for',
+    ])) {
+      return IntentType.getMeetingMom;
+    }
+
+    if (_containsAny(text, [
       'search meeting',
       'find meeting',
       'what did we decide',

--- a/packages/feature_mind/lib/src/agent_chat/domain/services/intent_parser.dart
+++ b/packages/feature_mind/lib/src/agent_chat/domain/services/intent_parser.dart
@@ -18,6 +18,7 @@ enum IntentType {
   audioScribe,
   searchMeetings,
   openMeetingScribe,
+  getMeetingMom,
   myActionItems,
   mobileActions,
   openWifiSettings,
@@ -104,6 +105,11 @@ class IntentParser {
     'find meeting': IntentType.searchMeetings,
     'open scribe': IntentType.openMeetingScribe,
     'record meeting': IntentType.openMeetingScribe,
+    'give me mom': IntentType.getMeetingMom,
+    'get mom': IntentType.getMeetingMom,
+    'get minutes': IntentType.getMeetingMom,
+    'show minutes': IntentType.getMeetingMom,
+    'meeting minutes': IntentType.getMeetingMom,
     'my action items': IntentType.myActionItems,
     'what is assigned to me': IntentType.myActionItems,
     'mobile actions': IntentType.mobileActions,
@@ -232,6 +238,19 @@ class IntentParser {
     }
 
     if (_containsAny(text, [
+      'give me mom',
+      'get mom',
+      'get minutes',
+      'show minutes',
+      'minutes of meeting',
+      'meeting minutes',
+      'share the mom',
+      'share minutes',
+    ])) {
+      return IntentType.getMeetingMom;
+    }
+
+    if (_containsAny(text, [
       'assigned to me',
       'my action items',
       'my tasks',
@@ -347,6 +366,14 @@ class IntentParser {
       params['query'] = about?.group(1)?.trim() ?? text.trim();
     }
 
+    if (lowerText.contains('mom for') || lowerText.contains('minutes for')) {
+      final match = RegExp(
+        r'(?:mom|minutes)\s+for\s+(.+)$',
+        caseSensitive: false,
+      ).firstMatch(text);
+      params['query'] = match?.group(1)?.trim() ?? text.trim();
+    }
+
     return params;
   }
 
@@ -426,6 +453,8 @@ class IntentParser {
         return 'Searching meeting archive';
       case IntentType.openMeetingScribe:
         return 'Opening Meeting Scribe';
+      case IntentType.getMeetingMom:
+        return 'Fetching minutes of meeting';
       case IntentType.myActionItems:
         return 'Listing action items from meetings';
       case IntentType.mobileActions:

--- a/packages/feature_mind/lib/src/agent_chat/domain/services/tool_registry.dart
+++ b/packages/feature_mind/lib/src/agent_chat/domain/services/tool_registry.dart
@@ -424,6 +424,7 @@ class MeetingArchiveTool implements Tool {
   bool canHandle(Intent intent) {
     return intent.type == IntentType.searchMeetings ||
         intent.type == IntentType.openMeetingScribe ||
+        intent.type == IntentType.getMeetingMom ||
         intent.type == IntentType.myActionItems;
   }
 
@@ -465,6 +466,35 @@ class MeetingArchiveTool implements Tool {
         return AgentToolResult(
           message: 'Found ${hits.length} meeting(s) for "$query":\n$lines',
         );
+      case IntentType.getMeetingMom:
+        final query = (intent.parameters['query'] as String?)?.trim() ?? '';
+        if (query.isNotEmpty) {
+          final hits = await port.search(query);
+          if (hits.isEmpty) {
+            return AgentToolResult(
+              message:
+                  'No saved meeting matched "$query". Record or process a meeting in Scribe first.',
+            );
+          }
+          final minutes = await port.minutesForMeeting(hits.first.meetingId);
+          if (minutes == null) {
+            return AgentToolResult(
+              message:
+                  'Found "${hits.first.title}" but minutes are not ready yet. Open Meeting Scribe to finish processing.',
+              route: '/scribe',
+            );
+          }
+          return AgentToolResult(message: minutes);
+        }
+        final latest = await port.latestWithMinutes();
+        if (latest == null) {
+          return const AgentToolResult(
+            route: '/scribe',
+            message:
+                'No minutes found yet. Record a meeting in Scribe and wait for processing to finish.',
+          );
+        }
+        return AgentToolResult(message: latest.minutes);
       case IntentType.myActionItems:
         final owner =
             (intent.parameters['owner'] as String?)?.trim() ?? 'me';

--- a/packages/feature_mind/lib/src/meeting_archive/meeting_archive_port.dart
+++ b/packages/feature_mind/lib/src/meeting_archive/meeting_archive_port.dart
@@ -15,6 +15,12 @@ abstract class MeetingArchivePort {
   Future<List<rust.MeetingActionItemRecord>> actionItemsForOwner(
     String ownerName,
   );
+
+  /// Latest saved meeting with non-empty [rust.MeetingRecord.minutes], or null.
+  Future<rust.MeetingRecord?> latestWithMinutes();
+
+  /// Minutes for [meetingId], or null when missing or empty.
+  Future<String?> minutesForMeeting(String meetingId);
 }
 
 /// Adapts [MindService] to [MeetingArchivePort].
@@ -52,5 +58,25 @@ class MindServiceMeetingArchivePort implements MeetingArchivePort {
       }
     }
     return hits;
+  }
+
+  @override
+  Future<rust.MeetingRecord?> latestWithMinutes() async {
+    final meetings = await _service.meetings();
+    if (meetings.isEmpty) return null;
+    meetings.sort((a, b) => b.recordedAt.compareTo(a.recordedAt));
+    for (final meeting in meetings) {
+      if (meeting.minutes.trim().isNotEmpty) {
+        return meeting;
+      }
+    }
+    return null;
+  }
+
+  @override
+  Future<String?> minutesForMeeting(String meetingId) async {
+    final meeting = await _service.meeting(meetingId);
+    final minutes = meeting?.minutes.trim() ?? '';
+    return minutes.isEmpty ? null : minutes;
   }
 }

--- a/packages/feature_mind/test/agent_chat/domain/services/intent_parser_test.dart
+++ b/packages/feature_mind/test/agent_chat/domain/services/intent_parser_test.dart
@@ -86,6 +86,11 @@ void main() {
         IntentParser.parse('manage offline models').type,
         IntentType.modelManagement,
       );
+      expect(IntentParser.parse('give me mom').type, IntentType.getMeetingMom);
+      expect(
+        IntentParser.parse('minutes for standup').type,
+        IntentType.getMeetingMom,
+      );
     });
   });
 }

--- a/packages/feature_mind/test/agent_chat/domain/services/tool_registry_test.dart
+++ b/packages/feature_mind/test/agent_chat/domain/services/tool_registry_test.dart
@@ -10,10 +10,14 @@ class _FakeMeetingArchivePort implements MeetingArchivePort {
   _FakeMeetingArchivePort({
     this.hits = const [],
     this.items = const [],
+    this.latestMeeting,
+    this.minutesById = const {},
   });
 
   final List<rust.SearchHit> hits;
   final List<rust.MeetingActionItemRecord> items;
+  final rust.MeetingRecord? latestMeeting;
+  final Map<String, String> minutesById;
 
   @override
   Future<List<rust.MeetingActionItemRecord>> actionItemsForOwner(
@@ -22,10 +26,31 @@ class _FakeMeetingArchivePort implements MeetingArchivePort {
       items;
 
   @override
-  Future<rust.MeetingRecord?> meeting(String id) async => null;
+  Future<rust.MeetingRecord?> meeting(String id) async {
+    final minutes = minutesById[id];
+    if (minutes == null) return null;
+    return rust.MeetingRecord(
+      id: id,
+      title: 'Test meeting',
+      recordedAt: BigInt.zero,
+      transcript: '',
+      minutes: minutes,
+      model: 'test',
+      decisions: const [],
+      actionItems: const [],
+      metrics: const [],
+    );
+  }
 
   @override
   Future<List<rust.SearchHit>> search(String query) async => hits;
+
+  @override
+  Future<rust.MeetingRecord?> latestWithMinutes() async => latestMeeting;
+
+  @override
+  Future<String?> minutesForMeeting(String meetingId) async =>
+      minutesById[meetingId];
 }
 
 void main() {
@@ -124,6 +149,32 @@ void main() {
 
       expect(result.shouldNavigate, isFalse);
       expect(result.message, contains('Temporal signalling'));
+    });
+
+    test('returns saved minutes when user asks for mom', () async {
+      const mom = '# Minutes of Meeting\n\n**Meeting:** Infra standup';
+      registry.configureMeetingArchive(
+        _FakeMeetingArchivePort(
+          latestMeeting: rust.MeetingRecord(
+            id: 'm1',
+            title: 'Infra standup',
+            recordedAt: BigInt.from(1),
+            transcript: '',
+            minutes: mom,
+            model: 'test',
+            decisions: const [],
+            actionItems: const [],
+            metrics: const [],
+          ),
+        ),
+      );
+
+      final result = await registry.executeIntent(
+        IntentParser.parse('give me mom'),
+      );
+
+      expect(result.shouldNavigate, isFalse);
+      expect(result.message, contains('Infra standup'));
     });
 
     test('routes open scribe to /scribe', () async {

--- a/rust/airo_mind_audio/tests/meeting_001_m4a.rs
+++ b/rust/airo_mind_audio/tests/meeting_001_m4a.rs
@@ -1,0 +1,32 @@
+//! Optional local smoke test when `fixtures/meeting_001.m4a` is present.
+
+use std::path::PathBuf;
+
+use airo_mind_audio::{preprocess_path, TARGET_CHANNELS, TARGET_SAMPLE_RATE};
+
+fn meeting_001_path() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../fixtures/meeting_001.m4a")
+}
+
+#[test]
+fn meeting_001_voice_memo_preprocesses_when_present() {
+    let path = meeting_001_path();
+    if !path.exists() {
+        eprintln!(
+            "skip: no {} — symlink a local .m4a per airo_mind_cli README",
+            path.display()
+        );
+        return;
+    }
+
+    let pcm = preprocess_path(&path).expect("meeting_001.m4a preprocesses");
+    assert_eq!(pcm.sample_rate_hz, TARGET_SAMPLE_RATE);
+    assert_eq!(pcm.channels, TARGET_CHANNELS);
+    assert!(!pcm.samples.is_empty());
+
+    let duration_secs = pcm.samples.len() as f64 / TARGET_SAMPLE_RATE as f64;
+    assert!(
+        duration_secs > 60.0,
+        "expected a long recording, got {duration_secs}s"
+    );
+}

--- a/rust/airo_mind_cli/README.md
+++ b/rust/airo_mind_cli/README.md
@@ -36,12 +36,39 @@ One command runs the product pipeline end to end:
    `out/eval/run-NNN.json`. Exits non-zero when any gate fails.
 
 Whisper defaults to multilingual `ggml-tiny.bin` with auto language detection.
-Place user meeting audio at `rust/fixtures/meeting_001.m4a` (or pass path as
-first arg); no checked-in user recording — download models per table below.
+
+### Optional user recording (`meeting_001`)
+
+For real-device POC-2 runs, symlink any local `.m4a` (not committed):
+
+```sh
+ln -sf /path/to/your/recording.m4a rust/fixtures/meeting_001.m4a
+```
+
+Preprocess-only smoke test (no models):
+
+```sh
+cd rust && cargo test -p airo_mind_audio --test meeting_001_m4a
+```
+
+Then run against the `meeting_001` eval golden set (see
+`airo_mind_eval/golden/meeting_001/README.md`):
 
 ```sh
 cd rust
-mkdir -p models   # put ggml-tiny.en.bin and qwen2.5-0.5b-instruct-q4_k_m.gguf here
+cargo run -p airo_mind_cli -- \
+  --models-dir models \
+  --out ./out/meeting_001/ \
+  --golden-meeting meeting_001
+```
+
+The hand-authored `meeting_001` transcript is domain-agnostic fixture text;
+whisper on unrelated audio will fail WER until goldens match a real pass — use
+`--skip-eval` to inspect artifacts only.
+
+```sh
+cd rust
+mkdir -p models   # put ggml-tiny.bin and qwen2.5-0.5b-instruct-q4_k_m.gguf here
 cargo run -p airo_mind_cli -- fixtures/speech.m4a \
   --models-dir models \
   --out ./out/

--- a/rust/airo_mind_cli/src/args.rs
+++ b/rust/airo_mind_cli/src/args.rs
@@ -31,6 +31,13 @@ fn has_flag(args: &[String], name: &str) -> bool {
     args.iter().any(|a| a == name)
 }
 
+fn flag_string(args: &[String], name: &str) -> Option<String> {
+    args.iter()
+        .position(|a| a == name)
+        .and_then(|i| args.get(i + 1))
+        .cloned()
+}
+
 /// First positional argument that is not a flag or a flag's value.
 fn positional_audio(args: &[String]) -> Option<PathBuf> {
     let mut skip_next = false;
@@ -43,6 +50,7 @@ fn positional_audio(args: &[String]) -> Option<PathBuf> {
             if arg == "--models-dir"
                 || arg == "--out"
                 || arg == "--meeting-id"
+                || arg == "--golden-meeting"
                 || arg == "--golden-transcript"
                 || arg == "--golden-ir"
                 || arg == "--golden-mom"
@@ -56,17 +64,38 @@ fn positional_audio(args: &[String]) -> Option<PathBuf> {
     None
 }
 
+fn default_audio_for_golden_meeting(meeting_id: &str) -> Option<PathBuf> {
+    if meeting_id == "meeting_001" {
+        let path = manifest_dir().join("../fixtures/meeting_001.m4a");
+        if path.exists() {
+            return Some(path);
+        }
+    }
+    None
+}
+
 pub fn parse() -> CliArgs {
     let args: Vec<String> = env::args().collect();
+    let golden_meeting = flag_string(&args, "--golden-meeting");
 
     let audio = env::var("AIRO_MIND_CLI_AUDIO")
         .map(PathBuf::from)
         .ok()
         .or_else(|| positional_audio(&args))
+        .or_else(|| {
+            golden_meeting
+                .as_deref()
+                .and_then(default_audio_for_golden_meeting)
+        })
         .unwrap_or_else(|| manifest_dir().join("../fixtures/speech.m4a"));
 
     let meeting_fixtures = manifest_dir().join("../airo_mind_meeting/tests/fixtures");
-    let own_golden_dir = manifest_dir().join("../airo_mind_eval/golden/reference_meeting");
+    let eval_manifest = manifest_dir().join("../airo_mind_eval");
+    let own_golden_dir = eval_manifest.join("golden/reference_meeting");
+
+    let golden_from_meeting = golden_meeting
+        .as_deref()
+        .map(|id| airo_mind_eval::golden::paths_for_meeting(&eval_manifest, id));
 
     CliArgs {
         audio,
@@ -75,13 +104,26 @@ pub fn parse() -> CliArgs {
         skip_eval: has_flag(&args, "--skip-eval"),
         meeting_id: flag(&args, "--meeting-id")
             .and_then(|p| p.into_os_string().into_string().ok())
+            .or(golden_meeting)
             .unwrap_or_else(|| "cli-run".to_string()),
-        golden_transcript: flag(&args, "--golden-transcript")
-            .or_else(|| Some(own_golden_dir.join("transcript.json"))),
-        golden_ir: flag(&args, "--golden-ir")
-            .or_else(|| Some(meeting_fixtures.join("golden_ir.json"))),
-        golden_mom: flag(&args, "--golden-mom")
-            .or_else(|| Some(meeting_fixtures.join("golden_mom.md"))),
+        golden_transcript: flag(&args, "--golden-transcript").or_else(|| {
+            golden_from_meeting
+                .as_ref()
+                .map(|p| p.transcript.clone())
+                .or_else(|| Some(own_golden_dir.join("transcript.json")))
+        }),
+        golden_ir: flag(&args, "--golden-ir").or_else(|| {
+            golden_from_meeting
+                .as_ref()
+                .map(|p| p.golden_ir.clone())
+                .or_else(|| Some(meeting_fixtures.join("golden_ir.json")))
+        }),
+        golden_mom: flag(&args, "--golden-mom").or_else(|| {
+            golden_from_meeting
+                .as_ref()
+                .map(|p| p.golden_mom.clone())
+                .or_else(|| Some(meeting_fixtures.join("golden_mom.md")))
+        }),
         help: has_flag(&args, "--help") || has_flag(&args, "-h"),
     }
 }
@@ -103,6 +145,7 @@ OPTIONS:
     --out DIR                  Run full POC-2 pipeline and write artifacts here
     --skip-eval                With --out, skip eval gates (artifacts only)
     --meeting-id ID            Meeting id for transcript/IR (default: cli-run)
+    --golden-meeting ID        Load eval goldens from airo_mind_eval/golden/ID/
     --golden-transcript PATH   Golden transcript.json for eval
     --golden-ir PATH           Golden IR JSON for eval
     --golden-mom PATH          Golden MoM markdown for eval
@@ -121,6 +164,12 @@ EXAMPLE (POC-2):
     cargo run -p airo_mind_cli -- rust/fixtures/speech.m4a \\
       --models-dir rust/airo_mind_whisper/models \\
       --out ./out/
+
+EXAMPLE (user recording, meeting_001 goldens):
+    ln -sf /path/to/your/recording.m4a rust/fixtures/meeting_001.m4a
+    cargo run -p airo_mind_cli -- \\
+      --models-dir models --out ./out/meeting_001/ \\
+      --golden-meeting meeting_001
 "
     );
 }
@@ -187,5 +236,17 @@ mod tests {
             positional_audio(&args).map(|p| p.to_string_lossy().into_owned()),
             Some("speech.m4a".into())
         );
+    }
+
+    #[test]
+    fn default_audio_for_meeting_001_when_fixture_present() {
+        let path = default_audio_for_golden_meeting("meeting_001");
+        if manifest_dir()
+            .join("../fixtures/meeting_001.m4a")
+            .exists()
+        {
+            assert!(path.is_some());
+            assert!(path.unwrap().ends_with("meeting_001.m4a"));
+        }
     }
 }

--- a/rust/airo_mind_eval/golden/meeting_001/README.md
+++ b/rust/airo_mind_eval/golden/meeting_001/README.md
@@ -1,0 +1,35 @@
+# meeting_001 golden set
+
+Hand-authored transcript, IR, and MoM for a small multilingual (Hindi +
+English) standup-style meeting. Used by `airo_mind_eval --meeting meeting_001`
+and by `airo_mind_cli --golden-meeting meeting_001`.
+
+This fixture is **domain-agnostic** — it exercises the pipeline shape (WER,
+term accuracy, IR/MoM consistency) without encoding a specific customer meeting.
+
+## Optional local audio (not in repo)
+
+For real ASR runs, symlink or copy any Apple Voice Memo / `.m4a` export:
+
+```sh
+ln -sf /path/to/your/recording.m4a rust/fixtures/meeting_001.m4a
+```
+
+Or pass the file path as the first CLI argument. The hand-authored
+`transcript.json` is the reference for eval gates; whisper output on unrelated
+audio will fail WER until you align goldens with a real pass or use
+`--skip-eval`.
+
+```sh
+cd rust
+cargo run -p airo_mind_cli -- /path/to/your/recording.m4a \
+  --models-dir models \
+  --out ./out/meeting_001/ \
+  --golden-meeting meeting_001
+```
+
+Preprocess-only smoke (no models):
+
+```sh
+cargo test -p airo_mind_audio --test meeting_001_m4a
+```

--- a/rust/fixtures/.gitignore
+++ b/rust/fixtures/.gitignore
@@ -1,0 +1,2 @@
+# Local symlink or copy of Apple Voice Memo test audio (~36 MB). Not committed.
+meeting_001.m4a


### PR DESCRIPTION
## Summary
- Add `getMeetingMom` chat intent so "give me mom" returns saved minutes from the latest or matching meeting in the archive.
- Add `--golden-meeting` to `airo_mind_cli` and optional `fixtures/meeting_001.m4a` dev-loop wiring (gitignored).
- Keep `meeting_001` golden set domain-agnostic; document optional local `.m4a` without customer-specific content.

## Test plan
- [x] `cargo test -p airo_mind_eval meeting_001`
- [x] `cargo test -p airo_mind_cli`
- [ ] `dart test packages/feature_mind/test/agent_chat/domain/services/intent_parser_test.dart`
- [ ] `dart test packages/feature_mind/test/agent_chat/domain/services/tool_registry_test.dart`


Made with [Cursor](https://cursor.com)