### PR TITLE
feat(mind): Indic settings UI and scribe panel tests

### DIFF
--- a/app/lib/core/mind/mind_models_screen.dart
+++ b/app/lib/core/mind/mind_models_screen.dart
@@ -1,4 +1,3 @@
-import 'package:airo_pro_bootstrap/airo_pro_bootstrap.dart' as pro_bootstrap;
 import 'package:core_ai/core_ai.dart';
 import 'package:core_ui/core_ui.dart';
 import 'package:feature_mind/feature_mind.dart';
@@ -88,7 +87,7 @@ class _MindModelsScreenState extends ConsumerState<MindModelsScreen> {
           else
             MindScribeModelsPanel(
               scribeModelsById: _scribeModelsById(),
-              entitlements: pro_bootstrap.createEntitlements(),
+              entitlements: ref.watch(mindEntitlementsProvider),
               memoryInfo: _memoryInfo,
               onTryStack: () => context.go('/'),
               onAcquireComplete: () async {

--- a/app/lib/core/mind/mind_provider_overrides.dart
+++ b/app/lib/core/mind/mind_provider_overrides.dart
@@ -1,5 +1,7 @@
+import 'package:airo_pro_bootstrap/airo_pro_bootstrap.dart' as pro_bootstrap;
 import 'package:core_product_shell/core_product_shell.dart';
 import 'package:feature_iptv/feature_iptv.dart';
+import 'package:feature_mind/feature_mind.dart';
 import 'package:flutter_riverpod/misc.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
@@ -16,6 +18,9 @@ List<Override> buildMindProviderOverrides({
 }) {
   return [
     sharedPreferencesProvider.overrideWithValue(prefs),
+    mindEntitlementsProvider.overrideWithValue(
+      pro_bootstrap.createEntitlements(),
+    ),
     ...registry.allProviderOverrides,
   ];
 }

--- a/docs/wiki/5.-AI-and-Model-Management.md
+++ b/docs/wiki/5.-AI-and-Model-Management.md
@@ -239,14 +239,20 @@ In development builds that include the capability, the manager can:
 
 ### Scribe models in the Airo Mind shell
 
-In the standalone Airo Mind app, the manager also lists the two on-device
-scribe models (the speech model and the compact writing model) alongside the
-assistant catalog. These rows show real install state read from the scribe's
-own storage, but they are managed by the Scribe journey rather than the
-manager: they appear as **Managed by Scribe** status rows without Start,
-Benchmark, or Delete actions, because they run on the Mind runtime's own
-engines rather than the assistant's chat runtimes. The super app's manager is
-unchanged and does not list them.
+In the standalone Airo Mind app, the **Models** tab lists assistant chat
+weights and a **Meeting scribe picks** section: a featured ★ stack (speech +
+minutes), alternates, and optional Sarvam-1 for desktop Pro users with enough
+RAM. Profile → **Meeting recordings** exposes transcription language, minutes
+model (Auto / Qwen / Enhanced Indic), and the reserved Indic speech backend
+seam (Whisper today; Sarvam Edge when public weights ship).
+
+The manager also lists the on-device scribe weights (speech + compact writing
+model) alongside the assistant catalog. These rows show real install state
+read from the scribe's own storage, but they are managed by the Scribe journey
+rather than the manager: they appear as **Managed by Scribe** status rows
+without Start, Benchmark, or Delete actions, because they run on the Mind
+runtime's own engines rather than the assistant's chat runtimes. The super
+app's manager is unchanged and does not list them.
 
 The transfer contract lives in a product-neutral platform package so focused
 Airo profiles such as Coins, and future Mind modules, can consume the same

--- a/packages/feature_mind/lib/feature_mind.dart
+++ b/packages/feature_mind/lib/feature_mind.dart
@@ -51,6 +51,15 @@ export 'src/mind_scribe_models_panel.dart'
         mindScribeServiceProvider,
         MindScribeModelsPanel,
         scribeCatalogIdToFileName;
+
+export 'src/settings/indic_generation_settings_tile.dart'
+    show IndicGenerationSettingsTile;
+export 'src/settings/indic_speech_backend_settings_tile.dart'
+    show IndicSpeechBackendSettingsTile;
+export 'src/settings/indic_intelligence_preferences.dart'
+    show indicGenerationModeProvider, indicSpeechModeProvider;
+export 'src/settings/mind_entitlements_provider.dart'
+    show mindEntitlementsProvider;
 export 'src/mind_service.dart'
     show MindProgress, MindService, MindStage, MindStatus, MindUnavailable;
 

--- a/packages/feature_mind/lib/src/agent_chat/presentation/screens/profile_screen.dart
+++ b/packages/feature_mind/lib/src/agent_chat/presentation/screens/profile_screen.dart
@@ -3,6 +3,8 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import '../../../capture/presentation/audio_retention_settings_tile.dart';
 import '../../../capture/presentation/speech_language_settings_tile.dart';
+import '../../../settings/indic_generation_settings_tile.dart';
+import '../../../settings/indic_speech_backend_settings_tile.dart';
 import '../../../host/assistant_host_adapter.dart';
 import '../../../quotes/presentation/widgets/daily_quote_card.dart';
 import '../../../routing/assistant_route_names.dart';
@@ -80,6 +82,8 @@ class ProfileScreen extends ConsumerWidget {
             ),
             const AudioRetentionSettingsTile(),
             const SpeechLanguageSettingsTile(),
+            const IndicGenerationSettingsTile(),
+            const IndicSpeechBackendSettingsTile(),
 
             const SizedBox(height: 32),
 

--- a/packages/feature_mind/lib/src/mind_scribe_models_panel.dart
+++ b/packages/feature_mind/lib/src/mind_scribe_models_panel.dart
@@ -10,6 +10,7 @@ import 'mind_model_advisor.dart';
 import 'mind_service.dart';
 import 'models/model_descriptor_adapter.dart';
 import 'models/model_provider.dart';
+import 'settings/indic_intelligence_preferences.dart';
 
 /// Shell override supplies the live scribe [MindService] (optional downloads,
 /// Try it navigation). Mind shell overrides this at composition root.
@@ -42,43 +43,19 @@ class MindScribeModelsPanel extends ConsumerStatefulWidget {
 }
 
 class _MindScribeModelsPanelState extends ConsumerState<MindScribeModelsPanel> {
-  MindIndicGenerationMode _generationMode = MindIndicGenerationMode.auto;
-  bool _loadingPrefs = true;
-
   String? _downloadingStackId;
   ModelAcquisitionProgress? _downloadProgress;
   String? _downloadError;
   List<String> _downloadFailed = const [];
 
-  @override
-  void initState() {
-    super.initState();
-    unawaited(_loadPrefs());
-  }
-
-  Future<void> _loadPrefs() async {
-    final mode = await MindIndicPreferences.readGenerationMode();
-    if (!mounted) return;
-    setState(() {
-      _generationMode = mode;
-      _loadingPrefs = false;
-    });
-  }
-
-  Future<void> _setGenerationMode(MindIndicGenerationMode mode) async {
-    await MindIndicPreferences.writeGenerationMode(mode);
-    if (!mounted) return;
-    setState(() => _generationMode = mode);
-  }
-
-  MindScribeStackRecommendation _recommendation() {
+  MindScribeStackRecommendation _recommendation(MindIndicGenerationMode mode) {
     final capability = MindIndicCapability(
       entitlements: widget.entitlements,
       memoryInfo: widget.memoryInfo,
     );
     return const MindModelAdvisor().recommend(
       capability: capability,
-      generationMode: _generationMode,
+      generationMode: mode,
       scribeModelsById: widget.scribeModelsById,
     );
   }
@@ -142,14 +119,8 @@ class _MindScribeModelsPanelState extends ConsumerState<MindScribeModelsPanel> {
 
   @override
   Widget build(BuildContext context) {
-    if (_loadingPrefs) {
-      return const Padding(
-        padding: EdgeInsets.symmetric(vertical: 24),
-        child: Center(child: CircularProgressIndicator()),
-      );
-    }
-
-    final recommendation = _recommendation();
+    final generationMode = ref.watch(indicGenerationModeProvider);
+    final recommendation = _recommendation(generationMode);
     final capability = MindIndicCapability(
       entitlements: widget.entitlements,
       memoryInfo: widget.memoryInfo,
@@ -174,8 +145,9 @@ class _MindScribeModelsPanelState extends ConsumerState<MindScribeModelsPanel> {
         if (capability.proEnabled && capability.isDesktopHost) ...[
           const SizedBox(height: 12),
           _GenerationModeSelector(
-            value: _generationMode,
-            onChanged: _setGenerationMode,
+            value: generationMode,
+            onChanged: (mode) =>
+                ref.read(indicGenerationModeProvider.notifier).select(mode),
           ),
         ],
         const SizedBox(height: 16),

--- a/packages/feature_mind/lib/src/settings/indic_generation_settings_tile.dart
+++ b/packages/feature_mind/lib/src/settings/indic_generation_settings_tile.dart
@@ -1,0 +1,76 @@
+import 'package:core_entitlements/core_entitlements.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../mind_indic_intelligence.dart';
+import 'indic_intelligence_preferences.dart';
+import 'mind_entitlements_provider.dart';
+
+/// Profile setting for meeting minutes generation: Auto, Qwen, or Sarvam-1.
+///
+/// Mirrors the generation mode chips on the Mind Models scribe panel so
+/// capture settings and the model hub stay aligned.
+class IndicGenerationSettingsTile extends ConsumerWidget {
+  const IndicGenerationSettingsTile({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final entitlements = ref.watch(mindEntitlementsProvider);
+    if (!entitlements.isEnabled(ProFeature.mindIndicIntelligence)) {
+      return const ListTile(
+        key: Key('indic_generation_settings_tile'),
+        title: Text('Meeting minutes model'),
+        subtitle: Text('Indic intelligence packs require Airo Mind Pro.'),
+      );
+    }
+
+    final mode = ref.watch(indicGenerationModeProvider);
+    final capability = MindIndicCapability(entitlements: entitlements);
+    final showEnhanced = capability.isDesktopHost;
+
+    return ListTile(
+      key: const Key('indic_generation_settings_tile'),
+      title: const Text('Meeting minutes model'),
+      subtitle: Text(_subtitle(mode, capability)),
+      trailing: DropdownButton<MindIndicGenerationMode>(
+        key: const Key('indic_generation_settings_dropdown'),
+        value: mode,
+        onChanged: (value) {
+          if (value == null) return;
+          ref.read(indicGenerationModeProvider.notifier).select(value);
+        },
+        items: [
+          const DropdownMenuItem(
+            value: MindIndicGenerationMode.auto,
+            child: Text('Auto'),
+          ),
+          const DropdownMenuItem(
+            value: MindIndicGenerationMode.standard,
+            child: Text('Standard (Qwen)'),
+          ),
+          if (showEnhanced)
+            const DropdownMenuItem(
+              value: MindIndicGenerationMode.enhancedIndic,
+              child: Text('Enhanced Indic (Sarvam)'),
+            ),
+        ],
+      ),
+    );
+  }
+
+  static String _subtitle(
+    MindIndicGenerationMode mode,
+    MindIndicCapability capability,
+  ) {
+    if (!capability.isDesktopHost) {
+      return 'Mobile uses Qwen for minutes. Enhanced Indic is desktop-only.';
+    }
+    return switch (mode) {
+      MindIndicGenerationMode.auto =>
+        'Sarvam-1 when RAM and install allow; otherwise Qwen 0.5B.',
+      MindIndicGenerationMode.standard => 'Always Qwen 0.5B for minutes.',
+      MindIndicGenerationMode.enhancedIndic =>
+        'Sarvam-1 when installed; fails if missing.',
+    };
+  }
+}

--- a/packages/feature_mind/lib/src/settings/indic_intelligence_preferences.dart
+++ b/packages/feature_mind/lib/src/settings/indic_intelligence_preferences.dart
@@ -1,0 +1,43 @@
+import 'package:flutter_riverpod/legacy.dart';
+
+import '../mind_indic_intelligence.dart';
+
+final indicGenerationModeProvider =
+    StateNotifierProvider<IndicGenerationModeNotifier, MindIndicGenerationMode>(
+      (ref) => IndicGenerationModeNotifier(),
+    );
+
+final indicSpeechModeProvider =
+    StateNotifierProvider<IndicSpeechModeNotifier, MindIndicSpeechMode>(
+      (ref) => IndicSpeechModeNotifier(),
+    );
+
+class IndicGenerationModeNotifier extends StateNotifier<MindIndicGenerationMode> {
+  IndicGenerationModeNotifier() : super(MindIndicGenerationMode.auto) {
+    _load();
+  }
+
+  Future<void> _load() async {
+    state = await MindIndicPreferences.readGenerationMode();
+  }
+
+  Future<void> select(MindIndicGenerationMode mode) async {
+    state = mode;
+    await MindIndicPreferences.writeGenerationMode(mode);
+  }
+}
+
+class IndicSpeechModeNotifier extends StateNotifier<MindIndicSpeechMode> {
+  IndicSpeechModeNotifier() : super(MindIndicSpeechMode.auto) {
+    _load();
+  }
+
+  Future<void> _load() async {
+    state = await MindIndicPreferences.readSpeechMode();
+  }
+
+  Future<void> select(MindIndicSpeechMode mode) async {
+    state = mode;
+    await MindIndicPreferences.writeSpeechMode(mode);
+  }
+}

--- a/packages/feature_mind/lib/src/settings/indic_speech_backend_settings_tile.dart
+++ b/packages/feature_mind/lib/src/settings/indic_speech_backend_settings_tile.dart
@@ -1,0 +1,65 @@
+import 'package:core_entitlements/core_entitlements.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../mind_indic_intelligence.dart';
+import 'indic_intelligence_preferences.dart';
+import 'mind_entitlements_provider.dart';
+
+/// Reserved seam for a future on-device Indic ASR backend (Sarvam Edge).
+///
+/// Today every path uses Whisper; Sarvam Edge is not publicly downloadable.
+class IndicSpeechBackendSettingsTile extends ConsumerWidget {
+  const IndicSpeechBackendSettingsTile({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final entitlements = ref.watch(mindEntitlementsProvider);
+    if (!entitlements.isEnabled(ProFeature.mindIndicIntelligence)) {
+      return const SizedBox.shrink();
+    }
+
+    final mode = ref.watch(indicSpeechModeProvider);
+    final capability = MindIndicCapability(entitlements: entitlements);
+
+    return ListTile(
+      key: const Key('indic_speech_backend_settings_tile'),
+      title: const Text('Indic speech backend (preview)'),
+      subtitle: Text(
+        _subtitle(mode, capability),
+      ),
+      trailing: DropdownButton<MindIndicSpeechMode>(
+        key: const Key('indic_speech_backend_settings_dropdown'),
+        value: mode,
+        onChanged: (value) {
+          if (value == null) return;
+          ref.read(indicSpeechModeProvider.notifier).select(value);
+        },
+        items: [
+          const DropdownMenuItem(
+            value: MindIndicSpeechMode.auto,
+            child: Text('Auto (Whisper)'),
+          ),
+          const DropdownMenuItem(
+            value: MindIndicSpeechMode.whisper,
+            child: Text('Whisper only'),
+          ),
+          DropdownMenuItem(
+            value: MindIndicSpeechMode.sarvamEdge,
+            enabled: capability.shouldPreferIndicSpeech(
+              MindIndicSpeechMode.sarvamEdge,
+            ),
+            child: const Text('Sarvam Edge (not available)'),
+          ),
+        ],
+      ),
+    );
+  }
+
+  static String _subtitle(MindIndicSpeechMode mode, MindIndicCapability capability) {
+    if (mode == MindIndicSpeechMode.sarvamEdge) {
+      return 'Sarvam Edge is not publicly downloadable yet — Whisper stays active.';
+    }
+    return 'Whisper multilingual is the on-device speech engine today.';
+  }
+}

--- a/packages/feature_mind/lib/src/settings/mind_entitlements_provider.dart
+++ b/packages/feature_mind/lib/src/settings/mind_entitlements_provider.dart
@@ -1,0 +1,10 @@
+import 'package:core_entitlements/core_entitlements.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+/// Entitlement policy for Mind surfaces that gate pro packs (Indic intelligence).
+///
+/// Defaults to the launch promo in open-source builds. Shells may override
+/// with [createEntitlements] from `airo_pro_bootstrap` at composition root.
+final mindEntitlementsProvider = Provider<Entitlements>(
+  (ref) => const LaunchPromoEntitlements(),
+);

--- a/packages/feature_mind/test/mind_scribe_models_panel_test.dart
+++ b/packages/feature_mind/test/mind_scribe_models_panel_test.dart
@@ -1,0 +1,63 @@
+import 'package:core_ai/core_ai.dart';
+import 'package:core_entitlements/core_entitlements.dart';
+import 'package:feature_mind/src/mind_model_advisor.dart';
+import 'package:feature_mind/src/mind_scribe_models_panel.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+OfflineModelInfo _model({
+  required String id,
+  required String name,
+  bool downloaded = false,
+}) => OfflineModelInfo(
+  id: id,
+  name: name,
+  family: ModelFamily.other,
+  fileSizeBytes: 1000,
+  filePath: downloaded ? '/tmp/$id' : null,
+);
+
+Map<String, OfflineModelInfo> _catalog() => {
+  MindScribeModelIds.whisperMultilingual: _model(
+    id: MindScribeModelIds.whisperMultilingual,
+    name: 'Whisper Tiny (Multilingual)',
+    downloaded: true,
+  ),
+  MindScribeModelIds.qwenGeneration: _model(
+    id: MindScribeModelIds.qwenGeneration,
+    name: 'Qwen2.5 0.5B Instruct (Q4_K_M)',
+    downloaded: true,
+  ),
+  MindScribeModelIds.sarvamGeneration: _model(
+    id: MindScribeModelIds.sarvamGeneration,
+    name: 'Sarvam-1 (Q4_K_M)',
+  ),
+};
+
+void main() {
+  testWidgets('shows featured best-overall recommendation', (tester) async {
+    SharedPreferences.setMockInitialValues({});
+
+    await tester.pumpWidget(
+      ProviderScope(
+        child: MaterialApp(
+          home: Scaffold(
+            body: SingleChildScrollView(
+              child: MindScribeModelsPanel(
+                scribeModelsById: _catalog(),
+                entitlements: const LaunchPromoEntitlements(),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.textContaining('Best overall'), findsOneWidget);
+    expect(find.text('Meeting scribe picks'), findsOneWidget);
+    expect(find.text('Sarvam Edge ASR'), findsOneWidget);
+  });
+}

--- a/packages/feature_mind/test/settings/indic_generation_settings_tile_test.dart
+++ b/packages/feature_mind/test/settings/indic_generation_settings_tile_test.dart
@@ -1,0 +1,83 @@
+import 'package:core_entitlements/core_entitlements.dart';
+import 'package:feature_mind/src/mind_indic_intelligence.dart';
+import 'package:feature_mind/src/settings/indic_generation_settings_tile.dart';
+import 'package:feature_mind/src/settings/mind_entitlements_provider.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  Future<void> pumpTile(WidgetTester tester) async {
+    await tester.pumpWidget(
+      const ProviderScope(
+        child: MaterialApp(home: Scaffold(body: IndicGenerationSettingsTile())),
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  testWidgets('defaults to Auto generation mode', (tester) async {
+    debugDefaultTargetPlatformOverride = TargetPlatform.macOS;
+    SharedPreferences.setMockInitialValues({});
+
+    await pumpTile(tester);
+
+    expect(
+      find.byKey(const Key('indic_generation_settings_tile')),
+      findsOneWidget,
+    );
+    expect(find.text('Auto'), findsOneWidget);
+    expect(
+      find.textContaining('otherwise Qwen 0.5B'),
+      findsOneWidget,
+    );
+    debugDefaultTargetPlatformOverride = null;
+  });
+
+  testWidgets('shows pro gate when Indic intelligence is disabled', (
+    tester,
+  ) async {
+    SharedPreferences.setMockInitialValues({});
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          mindEntitlementsProvider.overrideWithValue(const NoEntitlements()),
+        ],
+        child: const MaterialApp(
+          home: Scaffold(body: IndicGenerationSettingsTile()),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(
+      find.text('Indic intelligence packs require Airo Mind Pro.'),
+      findsOneWidget,
+    );
+    expect(
+      find.byKey(const Key('indic_generation_settings_dropdown')),
+      findsNothing,
+    );
+  });
+
+  testWidgets('selecting Standard persists preference', (tester) async {
+    SharedPreferences.setMockInitialValues({});
+
+    await pumpTile(tester);
+    await tester.tap(
+      find.byKey(const Key('indic_generation_settings_dropdown')),
+    );
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Standard (Qwen)').last);
+    await tester.pumpAndSettle();
+
+    final prefs = await SharedPreferences.getInstance();
+    expect(
+      prefs.getString('mind_indic_generation_mode'),
+      MindIndicGenerationMode.standard.stableId,
+    );
+  });
+}

--- a/packages/feature_mind/test/settings/indic_speech_backend_settings_tile_test.dart
+++ b/packages/feature_mind/test/settings/indic_speech_backend_settings_tile_test.dart
@@ -1,0 +1,43 @@
+import 'package:feature_mind/src/mind_indic_intelligence.dart';
+import 'package:feature_mind/src/settings/indic_speech_backend_settings_tile.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  Future<void> pumpTile(WidgetTester tester) async {
+    await tester.pumpWidget(
+      const ProviderScope(
+        child: MaterialApp(
+          home: Scaffold(body: IndicSpeechBackendSettingsTile()),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  testWidgets('defaults to Auto speech backend', (tester) async {
+    SharedPreferences.setMockInitialValues({});
+
+    await pumpTile(tester);
+
+    expect(
+      find.byKey(const Key('indic_speech_backend_settings_tile')),
+      findsOneWidget,
+    );
+    expect(find.text('Auto (Whisper)'), findsOneWidget);
+  });
+
+  testWidgets('Sarvam Edge option is disabled', (tester) async {
+    SharedPreferences.setMockInitialValues({});
+
+    await pumpTile(tester);
+    await tester.tap(
+      find.byKey(const Key('indic_speech_backend_settings_dropdown')),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('Sarvam Edge (not available)'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Completes planned follow-ups from the Sarvam / Mind model advisor discussion (public seam only):

- **Profile → Meeting recordings**: `IndicGenerationSettingsTile` (Auto / Standard Qwen / Enhanced Indic Sarvam) and `IndicSpeechBackendSettingsTile` (Whisper today; Sarvam Edge disabled until public weights ship).
- **Shared Riverpod providers** (`indicGenerationModeProvider`, `indicSpeechModeProvider`) so Profile and the Models **Meeting scribe picks** panel stay in sync.
- **`mindEntitlementsProvider`** — Mind shell overrides via `createEntitlements()`; Models screen uses the provider instead of calling bootstrap directly.
- **Widget tests** for generation tile, speech backend tile, and `MindScribeModelsPanel` featured card.
- **Wiki** update for scribe recommendations on the Mind Models tab.

## Still out of scope (as planned)

- Sarvam Edge ASR integration (no public HF weights)
- Cloud Sarvam API
- Wave 3 diarization (`airo_mind_diarize`)
- `airo-pro` overlay polish
- Snapdragon-specific routing

## Test plan

- [x] `flutter test packages/feature_mind/test/settings/indic_generation_settings_tile_test.dart`
- [x] `flutter test packages/feature_mind/test/settings/indic_speech_backend_settings_tile_test.dart`
- [x] `flutter test packages/feature_mind/test/mind_scribe_models_panel_test.dart`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a00604-29c4-7777-b4de-f94c24e30a99?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a00604-29c4-7777-b4de-f94c24e30a99&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

