### PR TITLE
feat(mind): Wave 3 speaker diarization scaffolding (airo_mind_diarize)

### DIFF
--- a/packages/feature_mind/lib/feature_mind.dart
+++ b/packages/feature_mind/lib/feature_mind.dart
@@ -302,5 +302,3 @@ export 'src/capture/application/speech_language_preference.dart';
 export 'src/capture/presentation/meeting_capture_screen.dart';
 export 'src/capture/presentation/audio_retention_settings_tile.dart';
 export 'src/capture/presentation/speech_language_settings_tile.dart';
-export 'src/trust/scribe_trust_signals.dart';
-export 'src/trust/scribe_trust_state.dart';

--- a/packages/feature_mind/module.yaml
+++ b/packages/feature_mind/module.yaml
@@ -26,6 +26,8 @@ allowed_dependencies:
   # moves onto core_ai's existing download pipeline rather than shipping model
   # weights in the APK (docs/superpowers/specs/2026-08-07-airo-mind-abstraction-layer.md).
   - core_ai
+  # Pro Indic intelligence gates (Sarvam-1 optional generation, Profile settings).
+  - core_entitlements
   # Dev-only: DownloadArtifactRequest/DownloadProgress, constructed directly by
   # DownloadModelProvider's test doubles. Not linked into the shipped package.
   - platform_downloads

--- a/packages/feature_mind/test/capture/application/meeting_processing_job_runner_test.dart
+++ b/packages/feature_mind/test/capture/application/meeting_processing_job_runner_test.dart
@@ -14,6 +14,7 @@ import 'package:mocktail/mocktail.dart';
 import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
 import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 import 'package:record/record.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 import '../../support/fake_bridges.dart';
 
@@ -69,6 +70,7 @@ void main() {
   late MindService mindService;
 
   setUp(() {
+    SharedPreferences.setMockInitialValues({});
     tempDir = Directory.systemTemp.createTempSync('job_runner_test_');
     PathProviderPlatform.instance = _FakePathProviderPlatform(tempDir.path);
     speech = FakeMindSpeechBridge();

--- a/packages/feature_mind/test/host/assistant_host_adapter_test.dart
+++ b/packages/feature_mind/test/host/assistant_host_adapter_test.dart
@@ -1,6 +1,7 @@
 import 'package:feature_mind/src/agent_chat/application/assistant_model_preferences.dart';
 import 'package:feature_mind/src/agent_chat/domain/models/assistant_runtime_ids.dart';
 import 'package:feature_mind/src/agent_chat/presentation/screens/chat_screen.dart';
+import 'package:feature_mind/src/agent_chat/presentation/screens/model_library_screen.dart';
 import 'package:feature_mind/src/host/assistant_host_adapter.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -8,11 +9,12 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import '../support/fake_assistant_host_adapter.dart';
+import '../support/gemini_nano_channel.dart';
 
 void main() {
   setUp(() {
     SharedPreferences.setMockInitialValues({
-      'selected_assistant_model_id': geminiNanoAssistantModelId,
+      'selected_assistant_model_id': _cloudChatModelId,
     });
   });
 
@@ -65,6 +67,7 @@ void main() {
   testWidgets('a finance-shaped message is routed through the host adapter', (
     tester,
   ) async {
+    stubGeminiNanoChannel();
     tester.view.devicePixelRatio = 1.0;
     tester.view.physicalSize = const Size(1200, 1000);
     addTearDown(() {
@@ -88,11 +91,16 @@ void main() {
       ProviderScope(
         overrides: [
           assistantHostAdapterProvider.overrideWithValue(adapter),
+          assistantModelLibraryProvider.overrideWith(
+            (ref) async => _financeChatLibraryState,
+          ),
           selectedAssistantModelIdProvider.overrideWith(
-            (ref) => _SelectedAssistantModelNotifier(),
+            (ref) => _FinanceChatModelNotifier(),
           ),
         ],
-        child: const MaterialApp(home: ChatScreen()),
+        child: const MaterialApp(
+          home: ChatScreen(enableAiInitialization: false),
+        ),
       ),
     );
     await tester.pumpAndSettle();
@@ -125,3 +133,34 @@ class _SelectedAssistantModelNotifier extends SelectedAssistantModelNotifier {
     state = geminiNanoAssistantModelId;
   }
 }
+
+class _FinanceChatModelNotifier extends SelectedAssistantModelNotifier {
+  _FinanceChatModelNotifier() {
+    state = _cloudChatModelId;
+  }
+}
+
+const _cloudChatModelId = 'cloud-chat-test';
+
+const _financeChatCandidate = AssistantModelCandidate(
+  id: _cloudChatModelId,
+  name: 'Cloud chat',
+  runtime: 'Network',
+  description: 'Remote model for tests',
+  bestFor: [AssistantTask.chat],
+  tags: ['Cloud'],
+  privacyLabel: 'Processed remotely',
+  sizeLabel: 'No download',
+  available: true,
+  actionLabel: 'Use',
+  local: false,
+);
+
+const _financeChatLibraryState = AssistantModelLibraryState(
+  task: AssistantTask.chat,
+  deviceLabel: 'Test host',
+  platformLabel: 'TEST',
+  candidates: [_financeChatCandidate],
+  recommended: _financeChatCandidate,
+  defaultPackages: {},
+);

--- a/packages/feature_mind/test/model_acquisition_test.dart
+++ b/packages/feature_mind/test/model_acquisition_test.dart
@@ -10,6 +10,7 @@ import 'package:mocktail/mocktail.dart';
 import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
 import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 import 'package:record/record.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 import 'support/fake_bridges.dart';
 
@@ -85,6 +86,7 @@ void main() {
   late FakeMindSpeechBridge speech;
 
   setUp(() {
+    SharedPreferences.setMockInitialValues({});
     tempDir = Directory.systemTemp.createTempSync('mind_acquisition_test_');
     PathProviderPlatform.instance = FakePathProviderPlatform(tempDir.path);
     speech = FakeMindSpeechBridge();

--- a/packages/feature_mind/test/settings/indic_speech_backend_settings_tile_test.dart
+++ b/packages/feature_mind/test/settings/indic_speech_backend_settings_tile_test.dart
@@ -1,4 +1,3 @@
-import 'package:feature_mind/src/mind_indic_intelligence.dart';
 import 'package:feature_mind/src/settings/indic_speech_backend_settings_tile.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -111,6 +111,14 @@ name = "airo_mind_core"
 version = "0.1.0"
 
 [[package]]
+name = "airo_mind_diarize"
+version = "0.1.0"
+dependencies = [
+ "airo_mind_core",
+ "airo_mind_transcript",
+]
+
+[[package]]
 name = "airo_mind_eval"
 version = "0.1.0"
 dependencies = [

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -5,6 +5,7 @@ members = [
   "airo_mind_audio",
   "airo_mind_cli",
   "airo_mind_core",
+  "airo_mind_diarize",
   "airo_mind_eval",
   "airo_mind_llama",
   "airo_mind_meeting",

--- a/rust/airo_mind_diarize/Cargo.toml
+++ b/rust/airo_mind_diarize/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "airo_mind_diarize"
+version = "0.1.0"
+edition = "2021"
+description = "Airo Mind speaker diarization — Wave 3 scaffolding between ASR segments and Meeting IR."
+license = "MIT"
+publish = false
+
+[lib]
+name = "airo_mind_diarize"
+# rlib only. ECAPA-TDNN / online clustering will link here later; no FFI
+# surface until a cdylib owner needs one.
+crate-type = ["rlib"]
+
+[dependencies]
+airo_mind_core = { path = "../airo_mind_core" }
+airo_mind_transcript = { path = "../airo_mind_transcript" }
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(frb_expand)'] }

--- a/rust/airo_mind_diarize/README.md
+++ b/rust/airo_mind_diarize/README.md
@@ -1,0 +1,41 @@
+# airo_mind_diarize
+
+Wave 3 scaffolding for on-device speaker diarization in Airo Mind.
+
+Sits between whisper ASR (`airo_mind_whisper`) and transcript processing
+(`airo_mind_transcript`). Today ships a deterministic **single-speaker**
+fallback so the pipeline can carry `speaker_id` through segments before
+ECAPA-TDNN embeddings and online clustering land.
+
+## Pipeline position
+
+```text
+audio → airo_mind_audio (16 kHz PCM)
+     → whisper (segments: id, start_ms, end_ms, text)
+     → airo_mind_diarize (segments + speaker_id)
+     → airo_mind_transcript (normalize + chunk)
+     → Meeting IR / minutes
+```
+
+## API
+
+```rust
+use airo_mind_diarize::{Diarizer, SingleSpeakerDiarizer, DiarizationInput};
+
+let result = SingleSpeakerDiarizer::new().diarize(&DiarizationInput {
+    segments: &transcript_segments,
+    pcm: None, // required for future embedders
+})?;
+```
+
+## Verify
+
+```bash
+cargo test -p airo_mind_diarize
+```
+
+## Non-goals (this crate)
+
+- Sarvam Edge ASR or cloud diarization APIs
+- Full ECAPA-TDNN / ONNX runtime (planned follow-up)
+- Word-level diarization (segment-level v1 only)

--- a/rust/airo_mind_diarize/src/diarizer.rs
+++ b/rust/airo_mind_diarize/src/diarizer.rs
@@ -1,0 +1,40 @@
+//! [`Diarizer`] trait and input bundle.
+
+use airo_mind_core::wav::Pcm;
+use airo_mind_transcript::Segment;
+
+use crate::result::DiarizationResult;
+
+/// Why diarization refused to run.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum DiarizationError {
+    EmptyInput,
+    PcmRequired,
+    Internal(String),
+}
+
+impl std::fmt::Display for DiarizationError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            DiarizationError::EmptyInput => f.write_str("no transcript segments to diarize"),
+            DiarizationError::PcmRequired => {
+                f.write_str("this diarizer requires 16 kHz mono PCM")
+            }
+            DiarizationError::Internal(msg) => f.write_str(msg),
+        }
+    }
+}
+
+impl std::error::Error for DiarizationError {}
+
+/// Everything a diarizer may need: whisper segments plus optional PCM for
+/// embedding backends.
+pub struct DiarizationInput<'a> {
+    pub segments: &'a [Segment],
+    pub pcm: Option<&'a Pcm>,
+}
+
+/// Assigns speakers to whisper segments.
+pub trait Diarizer {
+    fn diarize(&self, input: &DiarizationInput<'_>) -> Result<DiarizationResult, DiarizationError>;
+}

--- a/rust/airo_mind_diarize/src/lib.rs
+++ b/rust/airo_mind_diarize/src/lib.rs
@@ -1,0 +1,23 @@
+//! Speaker diarization for Airo Mind — Wave 3 scaffolding.
+//!
+//! Whisper produces time-bounded segments with text but no speaker identity.
+//! This crate assigns a stable [`SpeakerId`] per segment so downstream Meeting
+//! IR, persistence (`speakerLabel` columns in the app DB), and export can cite
+//! who spoke without re-running ASR.
+//!
+//! The shipped [`SingleSpeakerDiarizer`] is the v0 fallback: one speaker for
+//! the whole recording. Future embedders (ECAPA-TDNN tiny, online clustering)
+//! implement the same [`Diarizer`] trait and consume optional 16 kHz PCM from
+//! [`airo_mind_audio`] / [`airo_mind_core::wav::Pcm`].
+
+#![deny(unsafe_code)]
+
+mod diarizer;
+mod result;
+mod segment;
+mod single_speaker;
+
+pub use diarizer::{Diarizer, DiarizationError, DiarizationInput};
+pub use result::DiarizationResult;
+pub use segment::{DiarizedSegment, SpeakerId};
+pub use single_speaker::SingleSpeakerDiarizer;

--- a/rust/airo_mind_diarize/src/result.rs
+++ b/rust/airo_mind_diarize/src/result.rs
@@ -1,0 +1,25 @@
+//! Diarization output.
+
+use std::collections::BTreeSet;
+
+use crate::segment::{DiarizedSegment, SpeakerId};
+
+/// Every segment from the input transcript, each tagged with a speaker, plus
+/// the distinct speaker set for UI rollups.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct DiarizationResult {
+    pub segments: Vec<DiarizedSegment>,
+    pub speakers: Vec<SpeakerId>,
+}
+
+impl DiarizationResult {
+    pub fn from_segments(segments: Vec<DiarizedSegment>) -> Self {
+        let speakers: Vec<SpeakerId> = segments
+            .iter()
+            .map(|s| s.speaker)
+            .collect::<BTreeSet<_>>()
+            .into_iter()
+            .collect();
+        Self { segments, speakers }
+    }
+}

--- a/rust/airo_mind_diarize/src/segment.rs
+++ b/rust/airo_mind_diarize/src/segment.rs
@@ -1,0 +1,38 @@
+//! Segment + speaker identity types.
+
+use airo_mind_transcript::Segment;
+
+/// Stable speaker label within one recording (`sp0`, `sp1`, …).
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct SpeakerId(pub u32);
+
+impl SpeakerId {
+    pub const SOLO: SpeakerId = SpeakerId(0);
+
+    /// Wire/storage label used by Dart persistence seams.
+    pub fn label(self) -> String {
+        format!("sp{}", self.0)
+    }
+}
+
+/// One ASR segment with an assigned speaker.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct DiarizedSegment {
+    pub id: String,
+    pub start_ms: u64,
+    pub end_ms: u64,
+    pub text: String,
+    pub speaker: SpeakerId,
+}
+
+impl DiarizedSegment {
+    pub fn from_segment(segment: &Segment, speaker: SpeakerId) -> Self {
+        Self {
+            id: segment.id.clone(),
+            start_ms: segment.start_ms,
+            end_ms: segment.end_ms,
+            text: segment.text.clone(),
+            speaker,
+        }
+    }
+}

--- a/rust/airo_mind_diarize/src/single_speaker.rs
+++ b/rust/airo_mind_diarize/src/single_speaker.rs
@@ -1,0 +1,83 @@
+//! v0 fallback: every segment belongs to one speaker.
+
+use crate::diarizer::{DiarizationError, DiarizationInput, Diarizer};
+use crate::result::DiarizationResult;
+use crate::segment::{DiarizedSegment, SpeakerId};
+
+/// Assigns [`SpeakerId::SOLO`] to every segment. Deterministic and needs no
+/// PCM — suitable for solo recordings and pipeline wiring before ECAPA lands.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct SingleSpeakerDiarizer;
+
+impl SingleSpeakerDiarizer {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Diarizer for SingleSpeakerDiarizer {
+    fn diarize(&self, input: &DiarizationInput<'_>) -> Result<DiarizationResult, DiarizationError> {
+        if input.segments.is_empty() {
+            return Err(DiarizationError::EmptyInput);
+        }
+
+        let segments: Vec<DiarizedSegment> = input
+            .segments
+            .iter()
+            .map(|s| DiarizedSegment::from_segment(s, SpeakerId::SOLO))
+            .collect();
+
+        Ok(DiarizationResult::from_segments(segments))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use airo_mind_transcript::Segment;
+
+    fn seg(id: &str, start_ms: u64, end_ms: u64, text: &str) -> Segment {
+        Segment {
+            id: id.to_string(),
+            start_ms,
+            end_ms,
+            text: text.to_string(),
+        }
+    }
+
+    #[test]
+    fn empty_input_is_rejected() {
+        let err = SingleSpeakerDiarizer::new()
+            .diarize(&DiarizationInput {
+                segments: &[],
+                pcm: None,
+            })
+            .unwrap_err();
+        assert_eq!(err, DiarizationError::EmptyInput);
+    }
+
+    #[test]
+    fn assigns_solo_speaker_to_every_segment() {
+        let segments = [
+            seg("s0", 0, 1_000, "hello"),
+            seg("s1", 1_000, 2_000, "world"),
+        ];
+        let result = SingleSpeakerDiarizer::new()
+            .diarize(&DiarizationInput {
+                segments: &segments,
+                pcm: None,
+            })
+            .expect("diarize");
+
+        assert_eq!(result.speakers, vec![SpeakerId::SOLO]);
+        assert_eq!(result.segments.len(), 2);
+        assert!(result.segments.iter().all(|s| s.speaker == SpeakerId::SOLO));
+        assert_eq!(result.segments[0].id, "s0");
+        assert_eq!(result.segments[1].text, "world");
+    }
+
+    #[test]
+    fn speaker_label_is_stable_for_persistence() {
+        assert_eq!(SpeakerId::SOLO.label(), "sp0");
+    }
+}

--- a/rust/airo_mind_diarize/tests/golden_single_speaker.rs
+++ b/rust/airo_mind_diarize/tests/golden_single_speaker.rs
@@ -1,0 +1,39 @@
+//! Integration-style check that diarization preserves segment evidence fields.
+
+use airo_mind_diarize::{
+    DiarizationInput, Diarizer, SingleSpeakerDiarizer, SpeakerId,
+};
+use airo_mind_transcript::Segment;
+
+#[test]
+fn preserves_segment_ids_and_timestamps() {
+    let segments = [
+        Segment {
+            id: "s0".into(),
+            start_ms: 120,
+            end_ms: 450,
+            text: "we agreed to ship".into(),
+        },
+        Segment {
+            id: "s1".into(),
+            start_ms: 450,
+            end_ms: 900,
+            text: "next Tuesday".into(),
+        },
+    ];
+
+    let result = SingleSpeakerDiarizer::new()
+        .diarize(&DiarizationInput {
+            segments: &segments,
+            pcm: None,
+        })
+        .expect("diarize");
+
+    assert_eq!(result.speakers, vec![SpeakerId::SOLO]);
+    let first = &result.segments[0];
+    assert_eq!(first.id, "s0");
+    assert_eq!(first.start_ms, 120);
+    assert_eq!(first.end_ms, 450);
+    assert_eq!(first.text, "we agreed to ship");
+    assert_eq!(first.speaker.label(), "sp0");
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Two slices from the Mind production follow-up:

### Wave 3 diarization scaffolding
Adds `rust/airo_mind_diarize` with:
- `Diarizer` trait and `DiarizationInput` (segments + optional PCM)
- `SingleSpeakerDiarizer` v0 fallback (`sp0` on every segment)
- `DiarizedSegment`, `SpeakerId`, `DiarizationResult` types aligned with whisper segment evidence
- Unit + integration tests; crate registered in `rust/Cargo.toml` workspace

```text
whisper segments → airo_mind_diarize → airo_mind_transcript → Meeting IR
```

### CI fixes (post-#1800)
- `core_entitlements` in `module.yaml` allowed_dependencies
- SharedPreferences mocks in acquisition / job-runner tests
- Finance host-adapter test uses non-local model library override
- Remove duplicate `scribe_trust` exports

## Non-goals
- ECAPA-TDNN / ONNX embedder
- Word-level diarization
- Dart FFI surface

## Test plan
- [x] `cargo test -p airo_mind_diarize`
- [x] `flutter test` on fixed Mind package tests
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a00604-29c4-7777-b4de-f94c24e30a99?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a00604-29c4-7777-b4de-f94c24e30a99&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

