### PR TITLE
feat(mind): diarize at transcribe + embedding strategy seam

### DIFF
--- a/packages/feature_mind/lib/src/mind_diarization.dart
+++ b/packages/feature_mind/lib/src/mind_diarization.dart
@@ -13,8 +13,8 @@ String formatMindSpeakerLabel(String label) {
   return label;
 }
 
-/// v0 on-device diarization — mirrors `SingleSpeakerDiarizer` in Rust until
-/// ECAPA clustering ships. Assigns one speaker to every segment.
+/// v0 on-device diarization — mirrors Rust `SingleSpeakerDiarizer` until ECAPA
+/// clustering ships. Assigns one speaker to every segment missing a label.
 List<TranscriptSegment> applySoloSpeakerDiarization(
   List<TranscriptSegment> segments,
 ) {
@@ -26,7 +26,15 @@ List<TranscriptSegment> applySoloSpeakerDiarization(
         startMs: segment.startMs,
         endMs: segment.endMs,
         text: segment.text,
-        speakerLabel: kMindSoloSpeakerLabel,
+        speakerLabel: segment.speakerLabel ?? kMindSoloSpeakerLabel,
       ),
   ];
+}
+
+/// Ensures every segment has a speaker label — Rust ASR sets labels at
+/// transcribe; fake bridges and legacy paths still get solo fallback.
+List<TranscriptSegment> ensureSpeakerLabels(List<TranscriptSegment> segments) {
+  if (segments.isEmpty) return segments;
+  if (segments.every((s) => s.speakerLabel != null)) return segments;
+  return applySoloSpeakerDiarization(segments);
 }

--- a/packages/feature_mind/lib/src/mind_service.dart
+++ b/packages/feature_mind/lib/src/mind_service.dart
@@ -432,7 +432,7 @@ class MindService {
             progress = progress.copyWith(
               stage: MindStage.extracting,
               transcript: text,
-              segments: applySoloSpeakerDiarization(segments),
+              segments: ensureSpeakerLabels(segments),
             );
           case TranscriptEventCancelled():
             yield progress.copyWith(stage: MindStage.idle);

--- a/packages/feature_mind/test/mind_diarization_test.dart
+++ b/packages/feature_mind/test/mind_diarization_test.dart
@@ -36,6 +36,28 @@ void main() {
     expect(applySoloSpeakerDiarization(const []), isEmpty);
   });
 
+  test('ensureSpeakerLabels keeps rust-assigned labels', () {
+    const segments = [
+      TranscriptSegment(
+        id: 's0',
+        startMs: 0,
+        endMs: 500,
+        text: 'hello',
+        speakerLabel: 'sp1',
+      ),
+    ];
+    final labeled = ensureSpeakerLabels(segments);
+    expect(labeled.single.speakerLabel, 'sp1');
+  });
+
+  test('ensureSpeakerLabels applies solo fallback when labels missing', () {
+    const segments = [
+      TranscriptSegment(id: 's0', startMs: 0, endMs: 500, text: 'hello'),
+    ];
+    final labeled = ensureSpeakerLabels(segments);
+    expect(labeled.single.speakerLabel, kMindSoloSpeakerLabel);
+  });
+
   test('formatMindSpeakerLabel maps spN to Speaker N+1', () {
     expect(formatMindSpeakerLabel('sp0'), 'Speaker 1');
     expect(formatMindSpeakerLabel('sp2'), 'Speaker 3');

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -164,6 +164,8 @@ version = "0.1.0"
 dependencies = [
  "airo_mind_audio",
  "airo_mind_core",
+ "airo_mind_diarize",
+ "airo_mind_transcript",
  "flutter_rust_bridge",
  "serde",
  "serde_json",

--- a/rust/airo_mind_cli/src/pipeline.rs
+++ b/rust/airo_mind_cli/src/pipeline.rs
@@ -8,7 +8,7 @@ use airo_mind_core::{
     CancelToken, EngineError, GenerationChunk, GenerationEngine, GenerationRequest,
     ResourceRequest, RuntimeError, RuntimeStats, Supervisor, TranscriptSegment,
 };
-use airo_mind_diarize::diarize_single_speaker;
+use airo_mind_diarize::{diarize_segments, DiarizationStrategy};
 use airo_mind_llama::{LlamaGenerationEngine, ResourceBudget, Supervisor as LlamaSupervisor};
 use airo_mind_meeting::{
     extract, generate_mom, validate, ExtractionConfig, MeetingInput, MeetingIr, MomError,
@@ -171,7 +171,14 @@ pub fn run_poc2(args: &CliArgs, whisper_model: &Path, llama_model: &Path) -> Pip
         panic!("whisper produced no text");
     }
 
-    let diarized = diarize_single_speaker(&segments).expect("diarization succeeds");
+    let diarized = diarize_segments(
+        &segments,
+        Some(&pcm),
+        DiarizationStrategy::StubEmbedding {
+            similarity_threshold: 0.85,
+        },
+    )
+    .expect("diarization succeeds");
     let speaker_by_id: std::collections::HashMap<String, String> = diarized
         .segments
         .iter()

--- a/rust/airo_mind_diarize/README.md
+++ b/rust/airo_mind_diarize/README.md
@@ -20,11 +20,29 @@ audio → airo_mind_audio (16 kHz PCM)
 ## API
 
 ```rust
+use airo_mind_diarize::{diarize_segments, DiarizationStrategy};
+
+// Product transcribe path (solo v0):
+let result = diarize_segments(&segments, Some(&pcm), DiarizationStrategy::Solo)?;
+
+// CLI / dev tests (stub embedder + clustering):
+let result = diarize_segments(
+    &segments,
+    Some(&pcm),
+    DiarizationStrategy::StubEmbedding {
+        similarity_threshold: 0.85,
+    },
+)?;
+```
+
+Legacy helper:
+
+```rust
 use airo_mind_diarize::{Diarizer, SingleSpeakerDiarizer, DiarizationInput};
 
 let result = SingleSpeakerDiarizer::new().diarize(&DiarizationInput {
     segments: &transcript_segments,
-    pcm: None, // required for future embedders
+    pcm: None,
 })?;
 ```
 

--- a/rust/airo_mind_diarize/src/lib.rs
+++ b/rust/airo_mind_diarize/src/lib.rs
@@ -20,6 +20,7 @@ mod pcm_slice;
 mod result;
 mod segment;
 mod single_speaker;
+mod strategy;
 mod stub_embedder;
 
 pub use cluster::cluster_embeddings_greedy;
@@ -30,6 +31,7 @@ pub use pcm_slice::slice_segment_pcm;
 pub use result::DiarizationResult;
 pub use segment::{DiarizedSegment, SpeakerId};
 pub use single_speaker::SingleSpeakerDiarizer;
+pub use strategy::{diarize_segments, DiarizationStrategy};
 pub use stub_embedder::StubSpeakerEmbedder;
 
 /// Runs the default v0 diarizer (`SingleSpeakerDiarizer`) on transcript segments.

--- a/rust/airo_mind_diarize/src/strategy.rs
+++ b/rust/airo_mind_diarize/src/strategy.rs
@@ -1,0 +1,116 @@
+//! Product-facing diarization strategy selector — solo today, embedding when PCM
+//! and a real embedder are available.
+
+use airo_mind_core::wav::Pcm;
+use airo_mind_transcript::Segment;
+
+use crate::diarizer::{DiarizationError, DiarizationInput, Diarizer};
+use crate::embedding_diarizer::EmbeddingDiarizer;
+use crate::result::DiarizationResult;
+use crate::single_speaker::SingleSpeakerDiarizer;
+use crate::stub_embedder::StubSpeakerEmbedder;
+
+/// Which diarizer runs for a recording.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum DiarizationStrategy {
+    /// v0 product default — one speaker for the whole recording (`sp0`).
+    Solo,
+    /// Dev/CLI path: deterministic stub embedder + greedy clustering.
+    StubEmbedding {
+        similarity_threshold: f32,
+    },
+}
+
+impl Default for DiarizationStrategy {
+    fn default() -> Self {
+        Self::Solo
+    }
+}
+
+/// Runs the selected strategy on ASR segments and optional 16 kHz mono PCM.
+pub fn diarize_segments(
+    segments: &[Segment],
+    pcm: Option<&Pcm>,
+    strategy: DiarizationStrategy,
+) -> Result<DiarizationResult, DiarizationError> {
+    match strategy {
+        DiarizationStrategy::Solo => SingleSpeakerDiarizer::new().diarize(&DiarizationInput {
+            segments,
+            pcm: None,
+        }),
+        DiarizationStrategy::StubEmbedding {
+            similarity_threshold,
+        } => {
+            let pcm = pcm.ok_or(DiarizationError::PcmRequired)?;
+            EmbeddingDiarizer::new(StubSpeakerEmbedder::new(8), similarity_threshold).diarize(
+                &DiarizationInput {
+                    segments,
+                    pcm: Some(pcm),
+                },
+            )
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use airo_mind_core::wav::Pcm;
+
+    fn seg(id: &str, start: u64, end: u64) -> Segment {
+        Segment {
+            id: id.into(),
+            start_ms: start,
+            end_ms: end,
+            text: format!("segment {id}"),
+        }
+    }
+
+    #[test]
+    fn solo_strategy_needs_no_pcm() {
+        let result = diarize_segments(
+            &[seg("s0", 0, 1000)],
+            None,
+            DiarizationStrategy::Solo,
+        )
+        .expect("solo diarize");
+        assert_eq!(result.segments[0].speaker.label(), "sp0");
+    }
+
+    #[test]
+    fn stub_embedding_requires_pcm() {
+        let err = diarize_segments(
+            &[seg("s0", 0, 1000)],
+            None,
+            DiarizationStrategy::StubEmbedding {
+                similarity_threshold: 0.85,
+            },
+        )
+        .unwrap_err();
+        assert_eq!(err, DiarizationError::PcmRequired);
+    }
+
+    #[test]
+    fn stub_embedding_assigns_speakers_from_pcm() {
+        let pcm = Pcm {
+            samples: (0..48_000).map(|i| (i % 100) as i16).collect(),
+            sample_rate_hz: 16_000,
+            channels: 1,
+        };
+        let segments = [
+            seg("s0", 0, 1_000),
+            seg("s1", 1_000, 2_000),
+            seg("s2", 2_000, 3_000),
+        ];
+        let result = diarize_segments(
+            &segments,
+            Some(&pcm),
+            DiarizationStrategy::StubEmbedding {
+                similarity_threshold: 0.85,
+            },
+        )
+        .expect("stub embedding diarize");
+        assert_eq!(result.segments.len(), 3);
+        assert!(!result.speakers.is_empty());
+    }
+}

--- a/rust/airo_mind_whisper/Cargo.toml
+++ b/rust/airo_mind_whisper/Cargo.toml
@@ -28,6 +28,8 @@ crate-type = ["cdylib", "staticlib", "rlib"]
 [dependencies]
 airo_mind_audio = { path = "../airo_mind_audio" }
 airo_mind_core = { path = "../airo_mind_core" }
+airo_mind_diarize = { path = "../airo_mind_diarize" }
+airo_mind_transcript = { path = "../airo_mind_transcript" }
 # Pinned to the exact version core_native already uses. Two flutter_rust_bridge
 # versions in one Flutter app is a link-time conflict, not a warning.
 flutter_rust_bridge = "=2.11.1"

--- a/rust/airo_mind_whisper/src/api/meetings.rs
+++ b/rust/airo_mind_whisper/src/api/meetings.rs
@@ -44,11 +44,14 @@ use crate::frb_generated::StreamSink;
 use crate::transcript_store;
 use crate::WhisperSpeechEngine;
 use airo_mind_core::models;
+use airo_mind_core::wav::Pcm;
 use airo_mind_core::{
     ActionStatus, AudioInput, CancelToken, DecisionStatus, Meeting, MeetingActionItem,
     MeetingDecision, MeetingMetric, MeetingStore, ResourceBudget, SearchIndex, Supervisor,
     TranscriptSegment, TranscriptionOptions,
 };
+use airo_mind_diarize::{diarize_segments, DiarizationStrategy};
+use airo_mind_transcript::Segment;
 
 // ---------------------------------------------------------------------------
 // Wire types
@@ -311,6 +314,32 @@ fn transcript_segment_record(index: usize, segment: &TranscriptSegment) -> Trans
     }
 }
 
+/// Assigns `speaker_label` on wire segments after ASR, using the PCM whisper
+/// already preprocessed for transcription.
+fn apply_diarization_labels(
+    records: &mut [TranscriptSegmentRecord],
+    pcm: &Pcm,
+    strategy: DiarizationStrategy,
+) -> Result<(), String> {
+    if records.is_empty() {
+        return Ok(());
+    }
+    let segments: Vec<Segment> = records
+        .iter()
+        .map(|record| Segment {
+            id: record.id.clone(),
+            start_ms: record.start_ms,
+            end_ms: record.end_ms,
+            text: record.text.clone(),
+        })
+        .collect();
+    let result = diarize_segments(&segments, Some(pcm), strategy).map_err(|e| e.to_string())?;
+    for (record, diarized) in records.iter_mut().zip(result.segments.iter()) {
+        record.speaker_label = Some(diarized.speaker.label());
+    }
+    Ok(())
+}
+
 impl From<Meeting> for MeetingRecord {
     fn from(m: Meeting) -> Self {
         Self {
@@ -530,6 +559,9 @@ pub fn transcribe_recording(
     if transcript.trim().is_empty() {
         return Err("No speech was found in the recording.".into());
     }
+
+    apply_diarization_labels(&mut segments, &pcm, DiarizationStrategy::Solo)?;
+
     emit(TranscriptEvent::TranscriptReady {
         text: transcript,
         segments,
@@ -787,6 +819,35 @@ mod tests {
         assert_eq!(record.start_ms, 0);
         assert_eq!(record.end_ms, 900);
         assert_eq!(record.text, "hello");
+    }
+
+    #[test]
+    fn apply_diarization_labels_assigns_solo_speaker_on_segments() {
+        let pcm = Pcm {
+            samples: vec![0, 1, 2, 3],
+            sample_rate_hz: 16_000,
+            channels: 1,
+        };
+        let mut records = vec![
+            TranscriptSegmentRecord {
+                id: "s0".into(),
+                start_ms: 0,
+                end_ms: 500,
+                text: "hello".into(),
+                speaker_label: None,
+            },
+            TranscriptSegmentRecord {
+                id: "s1".into(),
+                start_ms: 500,
+                end_ms: 900,
+                text: "world".into(),
+                speaker_label: None,
+            },
+        ];
+        apply_diarization_labels(&mut records, &pcm, DiarizationStrategy::Solo)
+            .expect("solo labels apply");
+        assert_eq!(records[0].speaker_label.as_deref(), Some("sp0"));
+        assert_eq!(records[1].speaker_label.as_deref(), Some("sp0"));
     }
 
     /// Every call must say what is wrong rather than panicking on `None`, since


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Next Wave 3 step after #1802: diarization runs in Rust at the transcribe boundary (where PCM is already available), with a strategy enum ready for real ECAPA embedders.

### Rust transcribe path
- After ASR, `transcribe_recording` assigns `speaker_label` (`sp0`) on every segment before `TranscriptReady`
- Uses PCM already preprocessed for whisper — no second decode pass
- `apply_diarization_labels` helper in `airo_mind_whisper`

### Diarization strategy (`airo_mind_diarize`)
- `DiarizationStrategy::Solo` — product default (v0)
- `DiarizationStrategy::StubEmbedding` — stub embedder + greedy clustering for dev/CLI
- `diarize_segments(segments, pcm, strategy)` unifies both paths

### CLI
- POC-2 pipeline uses `StubEmbedding` with the meeting PCM (exercises multi-speaker scaffolding)

### Dart
- `ensureSpeakerLabels()` — keeps Rust-assigned labels; solo fallback only when labels are missing (fake bridges / legacy)

## Test plan
- [x] `cargo test -p airo_mind_diarize`
- [x] `flutter test` — `mind_diarization_test`, `mind_service_test`
- [ ] `cargo test -p airo_mind_whisper --features whisper` (needs rustc 1.88+ in CI)

## Follow-up
- Swap `StubSpeakerEmbedder` for ECAPA-TDNN ONNX when weights ship
- Product multi-speaker: switch transcribe strategy when embedder is real (not stub)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a00604-29c4-7777-b4de-f94c24e30a99?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a00604-29c4-7777-b4de-f94c24e30a99&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

