### PR TITLE
feat(mind): Wave 3 diarization sequence — ECAPA seam, speaker UI, Sarvam stub

### DIFF
--- a/app/integration_test/mind_journey_device_test.dart
+++ b/app/integration_test/mind_journey_device_test.dart
@@ -64,7 +64,6 @@ import 'dart:io';
 
 import 'package:airo_app/core/mind/mind_model_sources.dart';
 import 'package:feature_mind/feature_mind.dart';
-import 'package:feature_mind/src/library_loader.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';

--- a/app/lib/core/mind/mind_model_sources.dart
+++ b/app/lib/core/mind/mind_model_sources.dart
@@ -1,6 +1,5 @@
 import 'package:core_ai/core_ai.dart';
 import 'package:feature_mind/feature_mind.dart';
-import 'package:feature_mind/src/runtime/persistent/persistent_operation_log.dart';
 
 /// Where Airo Mind's models are fetched from, and the provider that fetches
 /// them.

--- a/app/lib/core/mind/mind_models_screen.dart
+++ b/app/lib/core/mind/mind_models_screen.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:core_ai/core_ai.dart';
 import 'package:core_ui/core_ui.dart';
 import 'package:feature_mind/feature_mind.dart';

--- a/packages/feature_mind/lib/feature_mind.dart
+++ b/packages/feature_mind/lib/feature_mind.dart
@@ -200,6 +200,10 @@ export 'src/runtime/ports/vault_port.dart';
 export 'src/runtime/fixture/fixture_data.dart';
 export 'src/runtime/fixture/fixture_mind_runtime.dart';
 export 'src/runtime/rust/rust_mind_runtime.dart';
+export 'src/runtime/persistent/persistent_operation_log.dart'
+    show LazyPersistentOperationLog, sharedMindOperationLog;
+export 'src/library_loader.dart'
+    show initializeLlamaBridge, initializeWhisperBridge, isLlamaLoaded, isWhisperLoaded;
 
 // Portability -- surface 08's ".airobackup" envelope-sealing flow: pick
 // contexts, set the phrase, choose a destination on your own network.

--- a/packages/feature_mind/lib/src/export/application/meeting_export_service.dart
+++ b/packages/feature_mind/lib/src/export/application/meeting_export_service.dart
@@ -2,6 +2,8 @@ import 'package:core_workers/core_workers.dart';
 
 import '../../mind_service.dart';
 import '../../whisper/api/meetings.dart' as rust;
+import '../../speaker/meeting_speaker_registry.dart';
+import '../../speaker/meeting_speaker_registry_store.dart';
 import '../domain/meeting_export_models.dart';
 import '../domain/meeting_markdown_renderer.dart';
 
@@ -12,9 +14,13 @@ import '../domain/meeting_markdown_renderer.dart';
 /// `MeetingRecord.actionItems` (#1657 Stage 2), and timestamped transcript
 /// lines from `transcriptDocument` (#1629). The renderer stays pure Dart.
 class MeetingExportService {
-  const MeetingExportService(this._mindService);
+  const MeetingExportService(
+    this._mindService, {
+    this.speakerRegistryStore,
+  });
 
   final MindService _mindService;
+  final MeetingSpeakerRegistryStore? speakerRegistryStore;
 
   /// Same policy as everywhere else in the repo: parsing/serialization past
   /// ~50 KB moves off the main isolate via `runOffMain`
@@ -59,6 +65,9 @@ class MeetingExportService {
     final doc = await _mindService.transcriptDocument(meetingId);
     final lines = _linesFrom(doc);
     final duration = _durationFrom(doc);
+    final speakerRegistry = speakerRegistryStore == null
+        ? MeetingSpeakerRegistry.empty
+        : await speakerRegistryStore!.load(meetingId);
 
     final minutes = meeting.minutes.trim();
 
@@ -72,6 +81,7 @@ class MeetingExportService {
       transcriptLines: lines,
       fallbackTranscript: meeting.transcript,
       momMarkdown: minutes.isEmpty ? null : minutes,
+      speakerRegistry: speakerRegistry,
       actionItems: [
         for (final item in meeting.actionItems)
           ExportActionItem(

--- a/packages/feature_mind/lib/src/export/domain/meeting_export_models.dart
+++ b/packages/feature_mind/lib/src/export/domain/meeting_export_models.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/foundation.dart';
 
+import '../../speaker/meeting_speaker_registry.dart';
+
 /// One line of a rendered transcript body: the audio timestamp it started at,
 /// and the words said in that window.
 ///
@@ -82,6 +84,7 @@ class MeetingExportInput {
     this.fallbackTranscript = '',
     this.momMarkdown,
     this.actionItems = const [],
+    this.speakerRegistry = MeetingSpeakerRegistry.empty,
   });
 
   final String meetingId;
@@ -110,6 +113,9 @@ class MeetingExportInput {
   /// [momMarkdown] to carry its own table (or the caller wants a
   /// dedicated `action-items.md`, e.g. for piping into a task manager).
   final List<ExportActionItem> actionItems;
+
+  /// User-assigned speaker names and merge aliases for export rendering.
+  final MeetingSpeakerRegistry speakerRegistry;
 }
 
 /// A folder-per-meeting export: a stable folder name and the markdown files

--- a/packages/feature_mind/lib/src/export/domain/meeting_markdown_renderer.dart
+++ b/packages/feature_mind/lib/src/export/domain/meeting_markdown_renderer.dart
@@ -1,4 +1,6 @@
+import '../../mind_diarization.dart';
 import 'meeting_export_models.dart';
+import '../../speaker/meeting_speaker_registry.dart';
 
 /// Pure markdown rendering for meeting export (#1663).
 ///
@@ -69,6 +71,7 @@ String renderTranscriptMarkdown({
   Duration? duration,
   List<TranscriptExportLine> lines = const [],
   String fallbackTranscript = '',
+  MeetingSpeakerRegistry speakerRegistry = MeetingSpeakerRegistry.empty,
 }) {
   final buf = StringBuffer()
     ..write(
@@ -86,7 +89,7 @@ String renderTranscriptMarkdown({
       if (text.isEmpty) continue;
       final speakerPrefix = line.speakerLabel == null
           ? ''
-          : '${line.speakerLabel}: ';
+          : '${_exportSpeakerPrefix(line.speakerLabel!, speakerRegistry)}: ';
       buf
         ..writeln('${formatTimestamp(line.startMs)} $speakerPrefix$text')
         ..writeln();
@@ -155,6 +158,7 @@ MeetingExportBundle composeMeetingExportBundle(MeetingExportInput input) {
       duration: input.duration,
       lines: input.transcriptLines,
       fallbackTranscript: input.fallbackTranscript,
+      speakerRegistry: input.speakerRegistry,
     ),
   };
 
@@ -203,3 +207,15 @@ MeetingExportBundle composeMeetingExportBundle(MeetingExportInput input) {
 /// case — kept simple per this issue's scope note on batch export.
 List<MeetingExportBundle> composeBatchExport(List<MeetingExportInput> inputs) =>
     inputs.map(composeMeetingExportBundle).toList(growable: false);
+
+String _exportSpeakerPrefix(
+  String label,
+  MeetingSpeakerRegistry registry,
+) {
+  final canonical = registry.canonicalLabel(label);
+  final display = mindSpeakerDisplayLabel(canonical, registry: registry);
+  if (display != formatMindSpeakerLabel(canonical)) {
+    return '$canonical ($display)';
+  }
+  return canonical;
+}

--- a/packages/feature_mind/lib/src/meeting_ir/meeting_ir_widgets.dart
+++ b/packages/feature_mind/lib/src/meeting_ir/meeting_ir_widgets.dart
@@ -2,7 +2,9 @@ import 'package:core_ui/core_ui.dart';
 import 'package:flutter/material.dart';
 
 import '../export/domain/meeting_markdown_renderer.dart' show formatTimestamp;
-import '../mind_diarization.dart' show formatMindSpeakerLabel;
+import '../mind_diarization.dart';
+import '../speaker/meeting_speaker_registry.dart';
+import '../speaker/mind_speaker_palette.dart';
 import '../whisper/api/meetings.dart' as rust;
 import 'evidence_resolver.dart';
 import 'meeting_ir_user_edits.dart';
@@ -317,12 +319,18 @@ class MeetingIrTranscriptList extends StatelessWidget {
     required this.highlightedIds,
     required this.segmentKeys,
     this.fallbackTranscript = '',
+    this.speakerRegistry = MeetingSpeakerRegistry.empty,
+    this.onRenameSpeaker,
+    this.onMergeSpeaker,
   });
 
   final List<TranscriptSegmentView> segments;
   final Set<String> highlightedIds;
   final Map<String, GlobalKey> segmentKeys;
   final String fallbackTranscript;
+  final MeetingSpeakerRegistry speakerRegistry;
+  final void Function(String speakerLabel)? onRenameSpeaker;
+  final void Function(String fromLabel)? onMergeSpeaker;
 
   @override
   Widget build(BuildContext context) {
@@ -360,15 +368,68 @@ class MeetingIrTranscriptList extends StatelessWidget {
                 ),
                 if (segment.speakerLabel != null) ...[
                   const SizedBox(width: 8),
-                  Chip(
-                    key: Key('meeting_ir_speaker_${segment.id}'),
-                    label: Text(
-                      formatMindSpeakerLabel(segment.speakerLabel!),
-                      style: Theme.of(context).textTheme.labelSmall,
+                  GestureDetector(
+                    onLongPress: onRenameSpeaker == null
+                        ? null
+                        : () async {
+                            final label = speakerRegistry.canonicalLabel(
+                              segment.speakerLabel!,
+                            );
+                            if (onMergeSpeaker == null) {
+                              onRenameSpeaker!(label);
+                              return;
+                            }
+                            await showModalBottomSheet<void>(
+                              context: context,
+                              builder: (context) => SafeArea(
+                                child: Column(
+                                  mainAxisSize: MainAxisSize.min,
+                                  children: [
+                                    ListTile(
+                                      leading: const Icon(Icons.edit_outlined),
+                                      title: const Text('Rename speaker'),
+                                      onTap: () {
+                                        Navigator.pop(context);
+                                        onRenameSpeaker!(label);
+                                      },
+                                    ),
+                                    ListTile(
+                                      leading: const Icon(Icons.merge_type),
+                                      title: const Text('Merge into another'),
+                                      onTap: () {
+                                        Navigator.pop(context);
+                                        onMergeSpeaker!(label);
+                                      },
+                                    ),
+                                  ],
+                                ),
+                              ),
+                            );
+                          },
+                    child: Chip(
+                      key: Key('meeting_ir_speaker_${segment.id}'),
+                      label: Text(
+                        mindSpeakerDisplayLabel(
+                          segment.speakerLabel!,
+                          registry: speakerRegistry,
+                        ),
+                        style: Theme.of(context).textTheme.labelSmall?.copyWith(
+                          color: mindSpeakerChipForeground(
+                            mindSpeakerChipColor(
+                              speakerRegistry.canonicalLabel(
+                                segment.speakerLabel!,
+                              ),
+                            ),
+                          ),
+                        ),
+                      ),
+                      backgroundColor: mindSpeakerChipColor(
+                        speakerRegistry.canonicalLabel(segment.speakerLabel!),
+                      ),
+                      visualDensity: VisualDensity.compact,
+                      materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                      padding: const EdgeInsets.symmetric(horizontal: 4),
                     ),
-                    visualDensity: VisualDensity.compact,
-                    materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
-                    padding: const EdgeInsets.symmetric(horizontal: 4),
                   ),
                 ],
                 const SizedBox(width: 8),

--- a/packages/feature_mind/lib/src/meeting_screen.dart
+++ b/packages/feature_mind/lib/src/meeting_screen.dart
@@ -8,6 +8,9 @@ import 'meeting_ir/evidence_resolver.dart';
 import 'meeting_ir/meeting_ir_user_edits.dart';
 import 'meeting_ir/meeting_ir_user_edits_store.dart';
 import 'meeting_ir/meeting_ir_widgets.dart';
+import 'speaker/meeting_speaker_registry.dart';
+import 'speaker/meeting_speaker_registry_store.dart';
+import 'speaker/speaker_rename_dialog.dart';
 import 'whisper/api/meetings.dart' as rust;
 import 'mind_service.dart';
 import 'trust/scribe_trust_signals.dart';
@@ -32,6 +35,7 @@ class MeetingScreen extends StatefulWidget {
     this.onCloudFallback,
     this.onSeekAudio,
     this.userEditsStore,
+    this.speakerRegistryStore,
     super.key,
   }) : _meeting = null;
 
@@ -44,6 +48,7 @@ class MeetingScreen extends StatefulWidget {
     this.onCloudFallback,
     this.onSeekAudio,
     this.userEditsStore,
+    this.speakerRegistryStore,
     super.key,
   }) : _progress = null,
        title = '';
@@ -70,6 +75,9 @@ class MeetingScreen extends StatefulWidget {
   /// Override for tests. Defaults to a SharedPreferences-backed store.
   final MeetingIrUserEditsStore? userEditsStore;
 
+  /// Per-meeting speaker rename / merge overlays.
+  final MeetingSpeakerRegistryStore? speakerRegistryStore;
+
   @override
   State<MeetingScreen> createState() => _MeetingScreenState();
 }
@@ -82,13 +90,19 @@ class _MeetingScreenState extends State<MeetingScreen> {
   // `MindService`'s own defaults, the production path is the only path this
   // screen needs; a test exercises the service/gateway directly instead of
   // through the widget (see `test/export/`).
-  late final _exportService = MeetingExportService(widget.service);
+  late final MeetingIrUserEditsStore _editsStore =
+      widget.userEditsStore ?? MeetingIrUserEditsStore();
+  late final MeetingSpeakerRegistryStore _speakerStore =
+      widget.speakerRegistryStore ?? MeetingSpeakerRegistryStore();
+  late final _exportService = MeetingExportService(
+    widget.service,
+    speakerRegistryStore: _speakerStore,
+  );
   final _exportGateway = const PlatformMeetingExportGateway();
   bool _exporting = false;
 
-  late final MeetingIrUserEditsStore _editsStore =
-      widget.userEditsStore ?? MeetingIrUserEditsStore();
   MeetingIrUserEdits _edits = const MeetingIrUserEdits();
+  MeetingSpeakerRegistry _speakerRegistry = MeetingSpeakerRegistry.empty;
   final _evidence = const EvidenceResolver();
 
   Map<String, TranscriptSegmentView> _segmentsById = const {};
@@ -164,6 +178,7 @@ class _MeetingScreenState extends State<MeetingScreen> {
 
   Future<void> _loadIrContext(rust.MeetingRecord meeting) async {
     final edits = await _editsStore.load(meeting.id);
+    final speakers = await _speakerStore.load(meeting.id);
     final doc = await widget.service.transcriptDocument(meeting.id);
     final byId = _evidence.indexFromDocument(doc);
     final ordered = [
@@ -179,6 +194,7 @@ class _MeetingScreenState extends State<MeetingScreen> {
     if (!mounted) return;
     setState(() {
       _edits = edits;
+      _speakerRegistry = speakers;
       _orderedSegments = ordered.isNotEmpty
           ? ordered
           : [
@@ -381,6 +397,48 @@ class _MeetingScreenState extends State<MeetingScreen> {
     setState(() => _edits = next);
   }
 
+  Future<void> _renameSpeaker(String speakerLabel) async {
+    final meetingId = _meeting?.id ?? _progress.meetingId;
+    if (meetingId == null) return;
+    final name = await showSpeakerRenameDialog(
+      context: context,
+      speakerLabel: speakerLabel,
+      registry: _speakerRegistry,
+    );
+    if (name == null || !mounted) return;
+    final next = _speakerRegistry.renameSpeaker(
+      label: speakerLabel,
+      displayName: name,
+    );
+    await _speakerStore.save(meetingId, next);
+    if (!mounted) return;
+    setState(() => _speakerRegistry = next);
+  }
+
+  Future<void> _mergeSpeaker(String fromLabel) async {
+    final meetingId = _meeting?.id ?? _progress.meetingId;
+    if (meetingId == null) return;
+    final labels = {
+      for (final segment in _orderedSegments)
+        if (segment.speakerLabel != null)
+          _speakerRegistry.canonicalLabel(segment.speakerLabel!),
+    }.toList();
+    final into = await showSpeakerMergeDialog(
+      context: context,
+      fromLabel: fromLabel,
+      candidateLabels: labels,
+      registry: _speakerRegistry,
+    );
+    if (into == null || !mounted) return;
+    final next = _speakerRegistry.mergeSpeakers(
+      fromLabel: fromLabel,
+      intoLabel: into,
+    );
+    await _speakerStore.save(meetingId, next);
+    if (!mounted) return;
+    setState(() => _speakerRegistry = next);
+  }
+
   @override
   Widget build(BuildContext context) {
     final stored = _meeting ?? widget._meeting;
@@ -507,6 +565,9 @@ class _MeetingScreenState extends State<MeetingScreen> {
                   highlightedIds: _highlightedIds,
                   segmentKeys: _segmentKeys,
                   fallbackTranscript: _progress.transcript,
+                  speakerRegistry: _speakerRegistry,
+                  onRenameSpeaker: _renameSpeaker,
+                  onMergeSpeaker: _mergeSpeaker,
                 ),
               ],
               if (stored != null) ...[

--- a/packages/feature_mind/lib/src/mind_diarization.dart
+++ b/packages/feature_mind/lib/src/mind_diarization.dart
@@ -1,4 +1,5 @@
 import 'bridges/mind_speech_bridge.dart';
+import 'speaker/meeting_speaker_registry.dart';
 
 /// Stable speaker label for solo recordings (`sp0` in `airo_mind_diarize`).
 const String kMindSoloSpeakerLabel = 'sp0';
@@ -11,6 +12,19 @@ String formatMindSpeakerLabel(String label) {
     return 'Speaker ${index + 1}';
   }
   return label;
+}
+
+/// Display name with optional registry overlay (rename + merge).
+String mindSpeakerDisplayLabel(
+  String label, {
+  MeetingSpeakerRegistry registry = MeetingSpeakerRegistry.empty,
+}) {
+  final canonical = registry.canonicalLabel(label);
+  final custom = registry.displayNameFor(canonical);
+  if (custom != null && custom.isNotEmpty) {
+    return custom;
+  }
+  return formatMindSpeakerLabel(canonical);
 }
 
 /// v0 on-device diarization — mirrors Rust `SingleSpeakerDiarizer` until ECAPA

--- a/packages/feature_mind/lib/src/mind_service.dart
+++ b/packages/feature_mind/lib/src/mind_service.dart
@@ -413,6 +413,16 @@ class MindService {
     var metrics = const <rust.MeetingMetricRecord>[];
 
     try {
+      final speechMode = await MindIndicPreferences.readSpeechMode();
+      if (speechMode == MindIndicSpeechMode.sarvamEdge) {
+        yield progress.copyWith(
+          stage: MindStage.failed,
+          error:
+              'Sarvam Edge on-device ASR is not available in this build yet.',
+        );
+        return;
+      }
+
       // ── 1. Audio → transcript, in the speech library ───────────────────────
       await for (final event in _speech.transcribe(
         wavPath: wavPath,

--- a/packages/feature_mind/lib/src/models/model_descriptor_adapter.dart
+++ b/packages/feature_mind/lib/src/models/model_descriptor_adapter.dart
@@ -102,6 +102,14 @@ Future<List<RequiredModel>> mindScribeRequiredModels({
 /// Optional pro Indic generation pack — not required for first-run scribe.
 List<RequiredModel> mindIndicOptionalModels() => [pinnedIndicGenerationModel];
 
+/// Optional ECAPA diarization weights — file name only until a public pin ships.
+///
+/// Rust checks `ecapa_tdnn_tiny_int8.onnx` in the models directory; download
+/// URL and digest land when weights are verified on Hugging Face.
+const String kMindEcapaOnnxFileName = 'ecapa_tdnn_tiny_int8.onnx';
+
+List<RequiredModel> mindDiarizeOptionalModels() => const [];
+
 /// Full verification of what is installed, translated into the shape a
 /// [ModelProvider] speaks.
 ///

--- a/packages/feature_mind/lib/src/speaker/meeting_speaker_registry.dart
+++ b/packages/feature_mind/lib/src/speaker/meeting_speaker_registry.dart
@@ -1,0 +1,106 @@
+import 'dart:convert';
+
+import 'package:flutter/foundation.dart';
+
+/// Per-meeting speaker display names and merge aliases (`sp2` → `sp0`).
+@immutable
+class MeetingSpeakerRegistry {
+  const MeetingSpeakerRegistry({
+    this.displayNames = const {},
+    this.mergeInto = const {},
+  });
+
+  final Map<String, String> displayNames;
+  final Map<String, String> mergeInto;
+
+  static const empty = MeetingSpeakerRegistry();
+
+  String canonicalLabel(String label) {
+    final merged = mergeInto[label];
+    if (merged != null && merged.isNotEmpty) {
+      return canonicalLabel(merged);
+    }
+    return label;
+  }
+
+  String? displayNameFor(String label) {
+    final canonical = canonicalLabel(label);
+    return displayNames[canonical];
+  }
+
+  MeetingSpeakerRegistry renameSpeaker({
+    required String label,
+    required String displayName,
+  }) {
+    final canonical = canonicalLabel(label);
+    final trimmed = displayName.trim();
+    final nextNames = Map<String, String>.from(displayNames);
+    if (trimmed.isEmpty) {
+      nextNames.remove(canonical);
+    } else {
+      nextNames[canonical] = trimmed;
+    }
+    return MeetingSpeakerRegistry(
+      displayNames: nextNames,
+      mergeInto: mergeInto,
+    );
+  }
+
+  MeetingSpeakerRegistry mergeSpeakers({
+    required String fromLabel,
+    required String intoLabel,
+  }) {
+    final from = canonicalLabel(fromLabel);
+    final into = canonicalLabel(intoLabel);
+    if (from == into) return this;
+    final nextMerge = Map<String, String>.from(mergeInto);
+    nextMerge[from] = into;
+    return MeetingSpeakerRegistry(
+      displayNames: displayNames,
+      mergeInto: nextMerge,
+    );
+  }
+
+  Map<String, Object?> toJson() => {
+    'displayNames': displayNames,
+    'mergeInto': mergeInto,
+  };
+
+  factory MeetingSpeakerRegistry.fromJson(Map<String, Object?> json) =>
+      MeetingSpeakerRegistry(
+        displayNames: Map<String, String>.from(
+          (json['displayNames'] as Map?)?.cast<String, String>() ?? const {},
+        ),
+        mergeInto: Map<String, String>.from(
+          (json['mergeInto'] as Map?)?.cast<String, String>() ?? const {},
+        ),
+      );
+
+  String encode() => jsonEncode(toJson());
+
+  static MeetingSpeakerRegistry decode(String? raw) {
+    if (raw == null || raw.trim().isEmpty) return empty;
+    try {
+      final decoded = jsonDecode(raw);
+      if (decoded is Map<String, Object?>) {
+        return MeetingSpeakerRegistry.fromJson(decoded);
+      }
+      if (decoded is Map) {
+        return MeetingSpeakerRegistry.fromJson(decoded.cast<String, Object?>());
+      }
+    } catch (_) {
+      return empty;
+    }
+    return empty;
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is MeetingSpeakerRegistry &&
+          displayNames == other.displayNames &&
+          mergeInto == other.mergeInto;
+
+  @override
+  int get hashCode => Object.hash(displayNames, mergeInto);
+}

--- a/packages/feature_mind/lib/src/speaker/meeting_speaker_registry_store.dart
+++ b/packages/feature_mind/lib/src/speaker/meeting_speaker_registry_store.dart
@@ -1,0 +1,33 @@
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'meeting_speaker_registry.dart';
+
+/// Persists per-meeting speaker display names and merge aliases.
+class MeetingSpeakerRegistryStore {
+  MeetingSpeakerRegistryStore([SharedPreferences? preferences])
+    : _preferences = preferences;
+
+  static const _keyPrefix = 'mind.meeting_speakers.';
+
+  SharedPreferences? _preferences;
+
+  Future<SharedPreferences> _prefs() async {
+    return _preferences ??= await SharedPreferences.getInstance();
+  }
+
+  String _key(String meetingId) => '$_keyPrefix$meetingId';
+
+  Future<MeetingSpeakerRegistry> load(String meetingId) async {
+    final prefs = await _prefs();
+    return MeetingSpeakerRegistry.decode(prefs.getString(_key(meetingId)));
+  }
+
+  Future<void> save(String meetingId, MeetingSpeakerRegistry registry) async {
+    final prefs = await _prefs();
+    if (registry == MeetingSpeakerRegistry.empty) {
+      await prefs.remove(_key(meetingId));
+      return;
+    }
+    await prefs.setString(_key(meetingId), registry.encode());
+  }
+}

--- a/packages/feature_mind/lib/src/speaker/mind_speaker_palette.dart
+++ b/packages/feature_mind/lib/src/speaker/mind_speaker_palette.dart
@@ -1,0 +1,34 @@
+import 'package:flutter/material.dart';
+
+/// Color-blind-safe speaker chip palette (Paul Tol–style distinct hues).
+///
+/// Indexed by `spN` numeric suffix; wraps when meetings exceed palette length.
+const List<Color> kMindSpeakerPalette = [
+  Color(0xFF0072B2), // blue
+  Color(0xFFE69F00), // orange
+  Color(0xFF009E73), // green
+  Color(0xFFCC79A7), // reddish purple
+  Color(0xFF56B4E9), // sky blue
+  Color(0xFFD55E00), // vermillion
+  Color(0xFF000000), // black
+];
+
+/// Parses `sp0` → `0`. Non-matching labels map to `0`.
+int mindSpeakerPaletteIndex(String label) {
+  final match = RegExp(r'^sp(\d+)$').firstMatch(label);
+  if (match == null) return 0;
+  return int.parse(match.group(1)!);
+}
+
+Color mindSpeakerChipColor(String label) {
+  final index = mindSpeakerPaletteIndex(label);
+  return kMindSpeakerPalette[index % kMindSpeakerPalette.length];
+}
+
+Color mindSpeakerChipForeground(Color background) {
+  // Black chip needs a light label; others use near-white on saturated hues.
+  if (background == const Color(0xFF000000)) {
+    return const Color(0xFFF5F5F5);
+  }
+  return const Color(0xFFFAFAFA);
+}

--- a/packages/feature_mind/lib/src/speaker/speaker_rename_dialog.dart
+++ b/packages/feature_mind/lib/src/speaker/speaker_rename_dialog.dart
@@ -1,0 +1,68 @@
+import 'package:flutter/material.dart';
+
+import '../mind_diarization.dart';
+import '../speaker/meeting_speaker_registry.dart';
+
+/// Dialog to rename a diarized speaker label for one meeting.
+Future<String?> showSpeakerRenameDialog({
+  required BuildContext context,
+  required String speakerLabel,
+  MeetingSpeakerRegistry registry = MeetingSpeakerRegistry.empty,
+}) async {
+  final initial = mindSpeakerDisplayLabel(speakerLabel, registry: registry);
+  final controller = TextEditingController(text: initial);
+  return showDialog<String>(
+    context: context,
+    builder: (context) => AlertDialog(
+      title: const Text('Rename speaker'),
+      content: TextField(
+        controller: controller,
+        decoration: InputDecoration(
+          labelText: 'Display name',
+          hintText: formatMindSpeakerLabel(speakerLabel),
+        ),
+        autofocus: true,
+        onSubmitted: (value) => Navigator.of(context).pop(value),
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(),
+          child: const Text('Cancel'),
+        ),
+        FilledButton(
+          onPressed: () => Navigator.of(context).pop(controller.text),
+          child: const Text('Save'),
+        ),
+      ],
+    ),
+  );
+}
+
+/// Pick which speaker label merged segments should display as.
+Future<String?> showSpeakerMergeDialog({
+  required BuildContext context,
+  required String fromLabel,
+  required List<String> candidateLabels,
+  MeetingSpeakerRegistry registry = MeetingSpeakerRegistry.empty,
+}) async {
+  final targets = [
+    for (final label in candidateLabels)
+      if (label != fromLabel) label,
+  ];
+  if (targets.isEmpty) return null;
+  return showDialog<String>(
+    context: context,
+    builder: (context) => SimpleDialog(
+      title: Text(
+        'Merge ${formatMindSpeakerLabel(fromLabel)} into…',
+      ),
+      children: [
+        for (final label in targets)
+          SimpleDialogOption(
+            onPressed: () => Navigator.of(context).pop(label),
+            child: Text(mindSpeakerDisplayLabel(label, registry: registry)),
+          ),
+      ],
+    ),
+  );
+}

--- a/packages/feature_mind/test/assistant/presentation/screens/audio_scribe_screen_test.dart
+++ b/packages/feature_mind/test/assistant/presentation/screens/audio_scribe_screen_test.dart
@@ -1,5 +1,8 @@
 import 'dart:async';
 
+import 'package:feature_mind/src/assistant/consent/mind_runtime_provider.dart';
+import 'package:feature_mind/src/runtime/fixture/fixture_mind_runtime.dart';
+import 'package:feature_mind/src/runtime/scribe_mind_runtime.dart';
 import 'package:feature_mind/src/services/voice_search_service.dart';
 import 'package:feature_mind/src/assistant/consent/jurisdiction_consent_rules.dart';
 import 'package:feature_mind/src/assistant/presentation/screens/audio_scribe_screen.dart';
@@ -58,6 +61,21 @@ class _FakeVoiceService implements VoiceSearchService {
   void dispose() {}
 }
 
+Widget _scribeScope({
+  required VoiceSearchService voice,
+  required Widget child,
+}) {
+  return ProviderScope(
+    overrides: [
+      voiceSearchServiceProvider.overrideWithValue(voice),
+      mindRuntimeProvider.overrideWithValue(
+        ScribeMindRuntime(log: FixtureMindRuntime().log),
+      ),
+    ],
+    child: child,
+  );
+}
+
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
@@ -66,10 +84,8 @@ void main() {
   ) async {
     await _usePhoneSurface(tester);
     await tester.pumpWidget(
-      ProviderScope(
-        overrides: [
-          voiceSearchServiceProvider.overrideWithValue(_FakeVoiceService()),
-        ],
+      _scribeScope(
+        voice: _FakeVoiceService(),
         child: const MaterialApp(home: AudioScribeScreen()),
       ),
     );
@@ -108,8 +124,8 @@ void main() {
       ],
     );
     await tester.pumpWidget(
-      ProviderScope(
-        overrides: [voiceSearchServiceProvider.overrideWithValue(service)],
+      _scribeScope(
+        voice: service,
         child: const MaterialApp(home: AudioScribeScreen()),
       ),
     );
@@ -133,8 +149,8 @@ void main() {
     final pending = Completer<VoiceSearchResult>();
     final service = _FakeVoiceService(pendingResult: pending);
     await tester.pumpWidget(
-      ProviderScope(
-        overrides: [voiceSearchServiceProvider.overrideWithValue(service)],
+      _scribeScope(
+        voice: service,
         child: const MaterialApp(home: AudioScribeScreen()),
       ),
     );
@@ -160,8 +176,8 @@ void main() {
     final pending = Completer<VoiceSearchResult>();
     final service = _FakeVoiceService(pendingResult: pending);
     await tester.pumpWidget(
-      ProviderScope(
-        overrides: [voiceSearchServiceProvider.overrideWithValue(service)],
+      _scribeScope(
+        voice: service,
         child: const MaterialApp(home: AudioScribeScreen()),
       ),
     );
@@ -205,10 +221,8 @@ void main() {
       ],
     );
     await tester.pumpWidget(
-      ProviderScope(
-        overrides: [
-          voiceSearchServiceProvider.overrideWithValue(_FakeVoiceService()),
-        ],
+      _scribeScope(
+        voice: _FakeVoiceService(),
         child: MaterialApp.router(routerConfig: router),
       ),
     );
@@ -253,12 +267,8 @@ void main() {
   ) async {
     await _usePhoneSurface(tester);
     await tester.pumpWidget(
-      ProviderScope(
-        overrides: [
-          voiceSearchServiceProvider.overrideWithValue(
-            _FakeVoiceService(availabilityError: StateError('no recognizer')),
-          ),
-        ],
+      _scribeScope(
+        voice: _FakeVoiceService(availabilityError: StateError('no recognizer')),
         child: const MaterialApp(home: AudioScribeScreen()),
       ),
     );
@@ -287,8 +297,8 @@ void main() {
       await _usePhoneSurface(tester);
       final service = _FakeVoiceService(available: false);
       await tester.pumpWidget(
-        ProviderScope(
-          overrides: [voiceSearchServiceProvider.overrideWithValue(service)],
+        _scribeScope(
+          voice: service,
           child: const MaterialApp(home: AudioScribeScreen()),
         ),
       );
@@ -316,8 +326,8 @@ void main() {
     await _usePhoneSurface(tester);
     final service = _FakeVoiceService();
     await tester.pumpWidget(
-      ProviderScope(
-        overrides: [voiceSearchServiceProvider.overrideWithValue(service)],
+      _scribeScope(
+        voice: service,
         child: const MaterialApp(home: AudioScribeScreen()),
       ),
     );
@@ -352,10 +362,8 @@ void main() {
       'acknowledged as notified', (tester) async {
     await _usePhoneSurface(tester);
     await tester.pumpWidget(
-      ProviderScope(
-        overrides: [
-          voiceSearchServiceProvider.overrideWithValue(_FakeVoiceService()),
-        ],
+      _scribeScope(
+        voice: _FakeVoiceService(),
         child: const MaterialApp(home: AudioScribeScreen()),
       ),
     );
@@ -402,8 +410,8 @@ void main() {
     final pending = Completer<VoiceSearchResult>();
     final service = _FakeVoiceService(pendingResult: pending);
     await tester.pumpWidget(
-      ProviderScope(
-        overrides: [voiceSearchServiceProvider.overrideWithValue(service)],
+      _scribeScope(
+        voice: service,
         child: const MaterialApp(home: AudioScribeScreen()),
       ),
     );

--- a/packages/feature_mind/test/speaker/meeting_speaker_registry_test.dart
+++ b/packages/feature_mind/test/speaker/meeting_speaker_registry_test.dart
@@ -1,0 +1,20 @@
+import 'package:feature_mind/src/speaker/meeting_speaker_registry.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('renameSpeaker stores display name on canonical label', () {
+    const registry = MeetingSpeakerRegistry();
+    final next = registry.renameSpeaker(label: 'sp0', displayName: 'Priya');
+    expect(next.displayNameFor('sp0'), 'Priya');
+    expect(next.encode(), contains('Priya'));
+  });
+
+  test('mergeSpeakers aliases labels for display', () {
+    const registry = MeetingSpeakerRegistry(
+      displayNames: {'sp0': 'Alice'},
+    );
+    final merged = registry.mergeSpeakers(fromLabel: 'sp2', intoLabel: 'sp0');
+    expect(merged.canonicalLabel('sp2'), 'sp0');
+    expect(merged.displayNameFor('sp2'), 'Alice');
+  });
+}

--- a/packages/feature_mind/test/speaker/mind_speaker_display_test.dart
+++ b/packages/feature_mind/test/speaker/mind_speaker_display_test.dart
@@ -1,0 +1,16 @@
+import 'package:feature_mind/src/mind_diarization.dart';
+import 'package:feature_mind/src/speaker/meeting_speaker_registry.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('mindSpeakerDisplayLabel uses registry name when set', () {
+    final registry = MeetingSpeakerRegistry.empty.renameSpeaker(
+      label: 'sp1',
+      displayName: 'Raj',
+    );
+    expect(
+      mindSpeakerDisplayLabel('sp1', registry: registry),
+      'Raj',
+    );
+  });
+}

--- a/rust/airo_mind_cli/src/pipeline.rs
+++ b/rust/airo_mind_cli/src/pipeline.rs
@@ -177,6 +177,7 @@ pub fn run_poc2(args: &CliArgs, whisper_model: &Path, llama_model: &Path) -> Pip
         DiarizationStrategy::StubEmbedding {
             similarity_threshold: 0.85,
         },
+        None,
     )
     .expect("diarization succeeds");
     let speaker_by_id: std::collections::HashMap<String, String> = diarized

--- a/rust/airo_mind_diarize/module.yaml
+++ b/rust/airo_mind_diarize/module.yaml
@@ -1,0 +1,4 @@
+owner: Rust Architect
+description: >
+  On-device speaker diarization between whisper ASR and Meeting IR —
+  solo fallback, embedding clustering, ECAPA ONNX seam.

--- a/rust/airo_mind_diarize/src/ecapa_onnx.rs
+++ b/rust/airo_mind_diarize/src/ecapa_onnx.rs
@@ -1,0 +1,39 @@
+//! ECAPA-TDNN ONNX embedder scaffold — loads when weights are on disk.
+
+use std::path::PathBuf;
+
+use airo_mind_core::wav::Pcm;
+
+use crate::diarizer::DiarizationError;
+use crate::embedder::{SpeakerEmbedder, SpeakerEmbedding};
+
+/// Speaker embedder backed by an ECAPA-TDNN ONNX file.
+///
+/// Inference is not wired yet (`ort` / ONNX Runtime lands in a follow-up once
+/// the pinned weights are distributed). The struct exists so product code can
+/// select the embedding path when the file is installed and fail gracefully
+/// until runtime inference ships.
+#[derive(Clone, Debug)]
+pub struct EcapaOnnxEmbedder {
+    pub path: PathBuf,
+}
+
+impl EcapaOnnxEmbedder {
+    pub fn new(path: PathBuf) -> Self {
+        Self { path }
+    }
+}
+
+impl SpeakerEmbedder for EcapaOnnxEmbedder {
+    fn embed_segment(
+        &self,
+        _pcm: &Pcm,
+        _start_ms: u64,
+        _end_ms: u64,
+    ) -> Result<SpeakerEmbedding, DiarizationError> {
+        Err(DiarizationError::Internal(format!(
+            "ECAPA ONNX inference is not linked yet (model at {})",
+            self.path.display()
+        )))
+    }
+}

--- a/rust/airo_mind_diarize/src/embedder_factory.rs
+++ b/rust/airo_mind_diarize/src/embedder_factory.rs
@@ -1,0 +1,46 @@
+//! Resolves which [`SpeakerEmbedder`] runs for a recording.
+
+use std::path::Path;
+
+use airo_mind_core::wav::Pcm;
+
+use crate::diarizer::DiarizationError;
+use crate::ecapa_onnx::EcapaOnnxEmbedder;
+use crate::embedder::{SpeakerEmbedder, SpeakerEmbedding};
+use crate::model_files::ecapa_model_path;
+use crate::stub_embedder::StubSpeakerEmbedder;
+
+/// Embedder selected for one diarization run.
+pub enum ResolvedEmbedder {
+    Stub(StubSpeakerEmbedder),
+    EcapaOnnx(EcapaOnnxEmbedder),
+}
+
+impl SpeakerEmbedder for ResolvedEmbedder {
+    fn embed_segment(
+        &self,
+        pcm: &Pcm,
+        start_ms: u64,
+        end_ms: u64,
+    ) -> Result<SpeakerEmbedding, DiarizationError> {
+        match self {
+            ResolvedEmbedder::Stub(embedder) => embedder.embed_segment(pcm, start_ms, end_ms),
+            ResolvedEmbedder::EcapaOnnx(embedder) => embedder.embed_segment(pcm, start_ms, end_ms),
+        }
+    }
+}
+
+/// Dev/tests default — deterministic hash vectors.
+pub fn stub_embedder() -> ResolvedEmbedder {
+    ResolvedEmbedder::Stub(StubSpeakerEmbedder::new(8))
+}
+
+/// ECAPA when the optional ONNX file is installed; stub otherwise (dev/tests).
+pub fn resolve_embedder(models_dir: Option<&Path>) -> ResolvedEmbedder {
+    if let Some(dir) = models_dir {
+        if let Some(path) = ecapa_model_path(dir) {
+            return ResolvedEmbedder::EcapaOnnx(EcapaOnnxEmbedder::new(path));
+        }
+    }
+    stub_embedder()
+}

--- a/rust/airo_mind_diarize/src/lib.rs
+++ b/rust/airo_mind_diarize/src/lib.rs
@@ -14,8 +14,11 @@
 
 mod cluster;
 mod diarizer;
+mod ecapa_onnx;
 mod embedder;
+mod embedder_factory;
 mod embedding_diarizer;
+mod model_files;
 mod pcm_slice;
 mod result;
 mod segment;
@@ -29,9 +32,14 @@ pub use embedder::{SpeakerEmbedder, SpeakerEmbedding};
 pub use embedding_diarizer::EmbeddingDiarizer;
 pub use pcm_slice::slice_segment_pcm;
 pub use result::DiarizationResult;
+pub use embedder_factory::{resolve_embedder, stub_embedder, ResolvedEmbedder};
+pub use ecapa_onnx::EcapaOnnxEmbedder;
+pub use model_files::{ecapa_model_path, ECAPA_TINY_ONNX_FILE};
 pub use segment::{DiarizedSegment, SpeakerId};
 pub use single_speaker::SingleSpeakerDiarizer;
-pub use strategy::{diarize_segments, DiarizationStrategy};
+pub use strategy::{
+    diarize_segments, product_diarization_strategy, DiarizationStrategy,
+};
 pub use stub_embedder::StubSpeakerEmbedder;
 
 /// Runs the default v0 diarizer (`SingleSpeakerDiarizer`) on transcript segments.

--- a/rust/airo_mind_diarize/src/model_files.rs
+++ b/rust/airo_mind_diarize/src/model_files.rs
@@ -1,0 +1,17 @@
+//! Pinned diarization model file identity — mirrors `airo_mind_core::models` pins.
+
+use std::path::{Path, PathBuf};
+
+/// ONNX int8 ECAPA-TDNN tiny weights (optional download). Pin syncs with Dart
+/// `pinnedEcapaDiarizeModel` in `model_descriptor_adapter.dart`.
+pub const ECAPA_TINY_ONNX_FILE: &str = "ecapa_tdnn_tiny_int8.onnx";
+
+/// Returns the path when the ECAPA file is present on disk.
+pub fn ecapa_model_path(models_dir: &Path) -> Option<PathBuf> {
+    let path = models_dir.join(ECAPA_TINY_ONNX_FILE);
+    if path.is_file() {
+        Some(path)
+    } else {
+        None
+    }
+}

--- a/rust/airo_mind_diarize/src/strategy.rs
+++ b/rust/airo_mind_diarize/src/strategy.rs
@@ -1,11 +1,15 @@
 //! Product-facing diarization strategy selector — solo today, embedding when PCM
 //! and a real embedder are available.
 
+use std::path::Path;
+
 use airo_mind_core::wav::Pcm;
 use airo_mind_transcript::Segment;
 
 use crate::diarizer::{DiarizationError, DiarizationInput, Diarizer};
+use crate::embedder_factory::{resolve_embedder, ResolvedEmbedder};
 use crate::embedding_diarizer::EmbeddingDiarizer;
+use crate::model_files::ecapa_model_path;
 use crate::result::DiarizationResult;
 use crate::single_speaker::SingleSpeakerDiarizer;
 use crate::stub_embedder::StubSpeakerEmbedder;
@@ -19,6 +23,10 @@ pub enum DiarizationStrategy {
     StubEmbedding {
         similarity_threshold: f32,
     },
+    /// Product embedding path — ECAPA when installed, stub in tests without weights.
+    Embedding {
+        similarity_threshold: f32,
+    },
 }
 
 impl Default for DiarizationStrategy {
@@ -27,11 +35,23 @@ impl Default for DiarizationStrategy {
     }
 }
 
+/// Strategy for transcribe: embedding when ECAPA weights are on disk, else solo.
+pub fn product_diarization_strategy(models_dir: &Path) -> DiarizationStrategy {
+    if ecapa_model_path(models_dir).is_some() {
+        DiarizationStrategy::Embedding {
+            similarity_threshold: 0.85,
+        }
+    } else {
+        DiarizationStrategy::Solo
+    }
+}
+
 /// Runs the selected strategy on ASR segments and optional 16 kHz mono PCM.
 pub fn diarize_segments(
     segments: &[Segment],
     pcm: Option<&Pcm>,
     strategy: DiarizationStrategy,
+    models_dir: Option<&Path>,
 ) -> Result<DiarizationResult, DiarizationError> {
     match strategy {
         DiarizationStrategy::Solo => SingleSpeakerDiarizer::new().diarize(&DiarizationInput {
@@ -49,6 +69,35 @@ pub fn diarize_segments(
                 },
             )
         }
+        DiarizationStrategy::Embedding {
+            similarity_threshold,
+        } => {
+            let pcm = pcm.ok_or(DiarizationError::PcmRequired)?;
+            let embedder = resolve_embedder(models_dir);
+            run_embedding_diarizer(embedder, segments, pcm, similarity_threshold)
+        }
+    }
+}
+
+fn run_embedding_diarizer(
+    embedder: ResolvedEmbedder,
+    segments: &[Segment],
+    pcm: &Pcm,
+    similarity_threshold: f32,
+) -> Result<DiarizationResult, DiarizationError> {
+    match embedder {
+        ResolvedEmbedder::Stub(stub) => {
+            EmbeddingDiarizer::new(stub, similarity_threshold).diarize(&DiarizationInput {
+                segments,
+                pcm: Some(pcm),
+            })
+        }
+        ResolvedEmbedder::EcapaOnnx(onnx) => {
+            EmbeddingDiarizer::new(onnx, similarity_threshold).diarize(&DiarizationInput {
+                segments,
+                pcm: Some(pcm),
+            })
+        }
     }
 }
 
@@ -56,6 +105,7 @@ pub fn diarize_segments(
 mod tests {
     use super::*;
     use airo_mind_core::wav::Pcm;
+    use std::path::PathBuf;
 
     fn seg(id: &str, start: u64, end: u64) -> Segment {
         Segment {
@@ -72,6 +122,7 @@ mod tests {
             &[seg("s0", 0, 1000)],
             None,
             DiarizationStrategy::Solo,
+            None,
         )
         .expect("solo diarize");
         assert_eq!(result.segments[0].speaker.label(), "sp0");
@@ -85,6 +136,7 @@ mod tests {
             DiarizationStrategy::StubEmbedding {
                 similarity_threshold: 0.85,
             },
+            None,
         )
         .unwrap_err();
         assert_eq!(err, DiarizationError::PcmRequired);
@@ -108,9 +160,37 @@ mod tests {
             DiarizationStrategy::StubEmbedding {
                 similarity_threshold: 0.85,
             },
+            None,
         )
         .expect("stub embedding diarize");
         assert_eq!(result.segments.len(), 3);
         assert!(!result.speakers.is_empty());
+    }
+
+    #[test]
+    fn product_strategy_picks_embedding_when_ecapa_file_present() {
+        let dir = std::env::temp_dir().join(format!(
+            "airo_diarize_strategy_{}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).expect("temp dir");
+        std::fs::write(dir.join(crate::model_files::ECAPA_TINY_ONNX_FILE), [0u8; 8])
+            .expect("write ecapa stub file");
+
+        assert_eq!(
+            product_diarization_strategy(&dir),
+            DiarizationStrategy::Embedding {
+                similarity_threshold: 0.85,
+            }
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn product_strategy_defaults_to_solo_without_ecapa() {
+        let dir = PathBuf::from("/tmp/airo-mind-no-ecapa-dir-never-exists");
+        assert_eq!(product_diarization_strategy(&dir), DiarizationStrategy::Solo);
     }
 }

--- a/rust/airo_mind_whisper/src/api/meetings.rs
+++ b/rust/airo_mind_whisper/src/api/meetings.rs
@@ -495,7 +495,7 @@ pub fn initialize(config: MindConfig) -> Result<(), String> {
         "{}@{}",
         speech_model.logical_id, speech_model.version
     ));
-    *lock(&MODELS_DIR) = Some(config.models_dir.clone());
+    *lock(&MODELS_DIR) = Some(PathBuf::from(config.models_dir.clone()));
     *lock(&LIBRARY) = Some(Library { store, index });
     Ok(())
 }
@@ -583,7 +583,8 @@ pub fn transcribe_recording(
         return Err("No speech was found in the recording.".into());
     }
 
-    let models_dir = lock(&MODELS_DIR).as_deref();
+    let models_dir_guard = lock(&MODELS_DIR);
+    let models_dir = models_dir_guard.as_deref();
     let strategy = models_dir
         .map(product_diarization_strategy)
         .unwrap_or(DiarizationStrategy::Solo);

--- a/rust/airo_mind_whisper/src/api/meetings.rs
+++ b/rust/airo_mind_whisper/src/api/meetings.rs
@@ -32,6 +32,7 @@
 //! `recorded_at_ms` comes from Dart. `C2` forbids reading a wall clock on a
 //! path that replay must reproduce, and this is that path.
 
+use std::path::{Path, PathBuf};
 use std::sync::Mutex;
 
 use flutter_rust_bridge::frb;
@@ -50,7 +51,7 @@ use airo_mind_core::{
     MeetingDecision, MeetingMetric, MeetingStore, ResourceBudget, SearchIndex, Supervisor,
     TranscriptSegment, TranscriptionOptions,
 };
-use airo_mind_diarize::{diarize_segments, DiarizationStrategy};
+use airo_mind_diarize::{diarize_segments, product_diarization_strategy, DiarizationStrategy};
 use airo_mind_transcript::Segment;
 
 // ---------------------------------------------------------------------------
@@ -320,6 +321,7 @@ fn apply_diarization_labels(
     records: &mut [TranscriptSegmentRecord],
     pcm: &Pcm,
     strategy: DiarizationStrategy,
+    models_dir: Option<&Path>,
 ) -> Result<(), String> {
     if records.is_empty() {
         return Ok(());
@@ -333,7 +335,17 @@ fn apply_diarization_labels(
             text: record.text.clone(),
         })
         .collect();
-    let result = diarize_segments(&segments, Some(pcm), strategy).map_err(|e| e.to_string())?;
+    let result = match diarize_segments(&segments, Some(pcm), strategy, models_dir) {
+        Ok(result) => result,
+        Err(error) if !matches!(strategy, DiarizationStrategy::Solo) => diarize_segments(
+            &segments,
+            None,
+            DiarizationStrategy::Solo,
+            None,
+        )
+        .map_err(|e| format!("diarization failed ({error}); solo fallback failed: {e}"))?,
+        Err(error) => return Err(error.to_string()),
+    };
     for (record, diarized) in records.iter_mut().zip(result.segments.iter()) {
         record.speaker_label = Some(diarized.speaker.label());
     }
@@ -418,6 +430,10 @@ static SPEECH_MODEL_VERSION: Mutex<Option<String>> = Mutex::new(None);
 /// The store and its projection.
 static LIBRARY: Mutex<Option<Library>> = Mutex::new(None);
 
+/// Models directory from the last successful `initialize` — used to pick
+/// diarization strategy (ECAPA optional weights).
+static MODELS_DIR: Mutex<Option<PathBuf>> = Mutex::new(None);
+
 /// The in-flight job's token, so the UI can stop it.
 static CANCEL: Mutex<Option<CancelToken>> = Mutex::new(None);
 
@@ -479,6 +495,7 @@ pub fn initialize(config: MindConfig) -> Result<(), String> {
         "{}@{}",
         speech_model.logical_id, speech_model.version
     ));
+    *lock(&MODELS_DIR) = Some(config.models_dir.clone());
     *lock(&LIBRARY) = Some(Library { store, index });
     Ok(())
 }
@@ -488,6 +505,12 @@ pub fn initialize(config: MindConfig) -> Result<(), String> {
 #[frb(sync)]
 pub fn is_ready() -> bool {
     lock(&ENGINES).is_some()
+}
+
+/// Sarvam Edge on-device ASR — reserved until public weights ship (`#1664`).
+#[frb(sync)]
+pub fn sarvam_edge_speech_available() -> bool {
+    false
 }
 
 /// Recording → transcript, streaming throughout.
@@ -560,7 +583,11 @@ pub fn transcribe_recording(
         return Err("No speech was found in the recording.".into());
     }
 
-    apply_diarization_labels(&mut segments, &pcm, DiarizationStrategy::Solo)?;
+    let models_dir = lock(&MODELS_DIR).as_deref();
+    let strategy = models_dir
+        .map(product_diarization_strategy)
+        .unwrap_or(DiarizationStrategy::Solo);
+    apply_diarization_labels(&mut segments, &pcm, strategy, models_dir)?;
 
     emit(TranscriptEvent::TranscriptReady {
         text: transcript,
@@ -844,7 +871,7 @@ mod tests {
                 speaker_label: None,
             },
         ];
-        apply_diarization_labels(&mut records, &pcm, DiarizationStrategy::Solo)
+        apply_diarization_labels(&mut records, &pcm, DiarizationStrategy::Solo, None)
             .expect("solo labels apply");
         assert_eq!(records[0].speaker_label.as_deref(), Some("sp0"));
         assert_eq!(records[1].speaker_label.as_deref(), Some("sp0"));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Wave 3 diarization sequence after #1802 — diarize at transcribe, embedding strategy seam, speaker identity UI, and Sarvam Edge guardrails.

### Phase A — Transcribe boundary
- `DiarizationStrategy` (`Solo`, `StubEmbedding`, `Embedding`)
- Whisper assigns `speaker_label` at transcribe using in-memory PCM
- CLI POC-2 uses `StubEmbedding`; Dart `ensureSpeakerLabels()` fallback

### Phase B — ECAPA / embedding seam
- `EcapaOnnxEmbedder` scaffold (inference pending `ort` + weights)
- `product_diarization_strategy()` — `Embedding` when `ecapa_tdnn_tiny_int8.onnx` exists in models dir
- Solo fallback if embedding diarization fails (e.g. ONNX not linked yet)
- `module.yaml` for `airo_mind_diarize`

### Phase C — Speaker identity UI
- `MeetingSpeakerRegistry` — rename + merge aliases (SharedPreferences)
- Color-blind speaker chips; long-press → rename / merge
- Markdown export: `sp0 (Alice): …` when named

### Phase D — Sarvam Edge seam
- `sarvam_edge_speech_available()` → `false` in Rust
- `MindService.process` fails fast when user selects Sarvam Edge ASR

## Test plan
- [x] `cargo test -p airo_mind_diarize`
- [x] `flutter test` — speaker registry, diarization, meeting IR, export, mind_service

## Still blocked on external artifacts
- ECAPA-TDNN ONNX weights + `ort` runtime → real multi-speaker labels in product
- Sarvam Edge public weights → enable ASR backend
- Cross-meeting speaker enrollment (#504)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a00604-29c4-7777-b4de-f94c24e30a99?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a00604-29c4-7777-b4de-f94c24e30a99&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

