### PR TITLE
feat(mind): ECAPA ORT production follow-ups — ORT install, e2e, FRB regen, Sarvam seam

### DIFF
--- a/.github/workflows/rust-core.yml
+++ b/.github/workflows/rust-core.yml
@@ -47,6 +47,21 @@ jobs:
       # which reads like a broken checkout rather than a missing flag.
       - run: cargo fmt --manifest-path rust/Cargo.toml --all --check
 
+      # ECAPA ONNX tests — optional feature, requires preinstalled ORT (no download-binaries).
+      - name: ECAPA ort tests (airo_mind_diarize)
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq build-essential g++ libstdc++-13-dev
+          chmod +x scripts/install-onnxruntime.sh scripts/run-ecapa-ort-tests.sh scripts/download-ecapa-model.sh
+          scripts/run-ecapa-ort-tests.sh
+          AIRO_ECAPA_E2E=1 scripts/run-ecapa-ort-tests.sh
+
+      # Mind whisper FRB — requires Rust 1.88+ and cargo-expand; host stable is 1.83.
+      - name: Mind whisper FRB bindings check
+        run: |
+          chmod +x scripts/regenerate-mind-whisper-frb.sh scripts/check-mind-whisper-frb.sh
+          scripts/check-mind-whisper-frb.sh
+
       # Runtime v1 condition 9 (#1311, tracked on #1340): "every runtime
       # contract has automated conformance tests." `cargo test --all` above
       # already runs these as ordinary tests -- this step is the mechanical

--- a/packages/feature_mind/lib/src/whisper/api/meetings.dart
+++ b/packages/feature_mind/lib/src/whisper/api/meetings.dart
@@ -8,9 +8,9 @@ import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart';
 import 'package:freezed_annotation/freezed_annotation.dart' hide protected;
 part 'meetings.freezed.dart';
 
-// These functions are ignored because they are not marked as `pub`: `lock`, `transcript_segment_record`
-// These types are ignored because they are neither used by any `pub` functions nor (for structs and enums) marked `#[frb(unignore)]`: `Library`
-// These function are ignored because they are on traits that is not defined in current crate (put an empty `#[frb]` on it to unignore): `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `clone`, `clone`, `clone`, `clone`, `clone`, `eq`, `eq`, `eq`, `eq`, `eq`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`
+// These functions are ignored because they are not marked as `pub`: `apply_diarization_labels`, `lock`, `sarvam_edge_speech_model_path`, `transcript_segment_record`
+// These types are ignored because they are neither used by any `pub` functions nor (for structs and enums) marked `#[frb(unignore)]`: `EnrolledSpeakerRecord`, `Library`
+// These function are ignored because they are on traits that is not defined in current crate (put an empty `#[frb]` on it to unignore): `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `eq`, `eq`, `eq`, `eq`, `eq`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`
 
 /// Loads the speech model and opens the store. Safe to call again — a Flutter
 /// hot restart runs it a second time, and refusing would make development
@@ -24,6 +24,17 @@ Future<void> initialize({required MindConfig config}) =>
 /// True once `initialize` has succeeded. Lets the UI show why it cannot record
 /// instead of failing at the moment the user presses the button.
 bool isReady() => RustLib.instance.api.crateApiMeetingsIsReady();
+
+/// Sarvam Edge on-device ASR — true when public weights are installed (`#1664`).
+///
+/// Flip is automatic once `sarvam_edge_speech.onnx` is in the models directory
+/// (future HF pin). Dev override: `AIRO_SARVAM_EDGE_SPEECH=1`.
+bool sarvamEdgeSpeechAvailable() =>
+    RustLib.instance.api.crateApiMeetingsSarvamEdgeSpeechAvailable();
+
+/// Replaces the in-memory enrollment store used during diarization.
+Future<void> syncSpeakerEnrollmentJson({required String raw}) =>
+    RustLib.instance.api.crateApiMeetingsSyncSpeakerEnrollmentJson(raw: raw);
 
 /// Recording → transcript, streaming throughout.
 ///
@@ -379,9 +390,7 @@ class SearchHit {
 /// row — it does not download anything by itself, and `initialize` reports
 /// `NotInstalled` naming the missing multilingual weight file the same way it
 /// would for any other unresolved model (`ADR-0018 §4`: that name is the
-/// Model Manager's to know, not this capability's). Wiring an install/
-/// preference flow for this is #1664's job; this is the mechanism it selects
-/// through.
+/// Model Manager's to know, not this capability's).
 ///
 /// Not to be confused with `TranscriptionOptions::language` (`#1664`), which
 /// this field feeds but does not replace: `SpeechLanguage` picks *which
@@ -470,6 +479,8 @@ class TranscriptSegmentRecord {
   final BigInt startMs;
   final BigInt endMs;
   final String text;
+
+  /// Diarization label (`sp0`, `sp1`, …). None for legacy segments.
   final String? speakerLabel;
 
   const TranscriptSegmentRecord({

--- a/packages/feature_mind/lib/src/whisper/frb_generated.dart
+++ b/packages/feature_mind/lib/src/whisper/frb_generated.dart
@@ -65,7 +65,7 @@ class RustLib extends BaseEntrypoint<RustLibApi, RustLibApiImpl, RustLibWire> {
   String get codegenVersion => '2.11.1';
 
   @override
-  int get rustContentHash => 191481972;
+  int get rustContentHash => -699939418;
 
   static const kDefaultExternalLibraryLoaderConfig =
       ExternalLibraryLoaderConfig(
@@ -88,13 +88,11 @@ abstract class RustLibApi extends BaseApi {
 
   bool crateApiMeetingsIsReady();
 
-  bool crateApiMeetingsSarvamEdgeSpeechAvailable();
-
-  void crateApiMeetingsSyncSpeakerEnrollmentJson({required String json});
-
   Future<List<MeetingRecord>> crateApiMeetingsListMeetings();
 
   Future<List<RequiredModel>> crateApiSetupRequiredModels();
+
+  bool crateApiMeetingsSarvamEdgeSpeechAvailable();
 
   Future<String> crateApiMeetingsSaveMeeting({
     required String title,
@@ -114,6 +112,8 @@ abstract class RustLibApi extends BaseApi {
   });
 
   Future<SpeechLanguage> crateApiMeetingsSpeechLanguageDefault();
+
+  Future<void> crateApiMeetingsSyncSpeakerEnrollmentJson({required String raw});
 
   Stream<TranscriptEvent> crateApiMeetingsTranscribeRecording({
     required String wavPath,
@@ -265,54 +265,6 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       const TaskConstMeta(debugName: "is_ready", argNames: []);
 
   @override
-  bool crateApiMeetingsSarvamEdgeSpeechAvailable() {
-    return handler.executeSync(
-      SyncTask(
-        callFfi: () {
-          final serializer = SseSerializer(generalizedFrbRustBinding);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 13)!;
-        },
-        codec: SseCodec(
-          decodeSuccessData: sse_decode_bool,
-          decodeErrorData: null,
-        ),
-        constMeta: kCrateApiMeetingsSarvamEdgeSpeechAvailableConstMeta,
-        argValues: [],
-        apiImpl: this,
-      ),
-    );
-  }
-
-  TaskConstMeta get kCrateApiMeetingsSarvamEdgeSpeechAvailableConstMeta =>
-      const TaskConstMeta(debugName: "sarvam_edge_speech_available", argNames: []);
-
-  @override
-  void crateApiMeetingsSyncSpeakerEnrollmentJson({required String json}) {
-    handler.executeSync(
-      SyncTask(
-        callFfi: () {
-          final serializer = SseSerializer(generalizedFrbRustBinding);
-          sse_encode_String(json, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 14)!;
-        },
-        codec: SseCodec(
-          decodeSuccessData: sse_decode_unit,
-          decodeErrorData: null,
-        ),
-        constMeta: kCrateApiMeetingsSyncSpeakerEnrollmentJsonConstMeta,
-        argValues: [json],
-        apiImpl: this,
-      ),
-    );
-  }
-
-  TaskConstMeta get kCrateApiMeetingsSyncSpeakerEnrollmentJsonConstMeta =>
-      const TaskConstMeta(
-        debugName: "sync_speaker_enrollment_json",
-        argNames: ["json"],
-      );
-
-  @override
   Future<List<MeetingRecord>> crateApiMeetingsListMeetings() {
     return handler.executeNormal(
       NormalTask(
@@ -367,6 +319,31 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       const TaskConstMeta(debugName: "required_models", argNames: []);
 
   @override
+  bool crateApiMeetingsSarvamEdgeSpeechAvailable() {
+    return handler.executeSync(
+      SyncTask(
+        callFfi: () {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 8)!;
+        },
+        codec: SseCodec(
+          decodeSuccessData: sse_decode_bool,
+          decodeErrorData: null,
+        ),
+        constMeta: kCrateApiMeetingsSarvamEdgeSpeechAvailableConstMeta,
+        argValues: [],
+        apiImpl: this,
+      ),
+    );
+  }
+
+  TaskConstMeta get kCrateApiMeetingsSarvamEdgeSpeechAvailableConstMeta =>
+      const TaskConstMeta(
+        debugName: "sarvam_edge_speech_available",
+        argNames: [],
+      );
+
+  @override
   Future<String> crateApiMeetingsSaveMeeting({
     required String title,
     required BigInt recordedAtMs,
@@ -396,7 +373,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 8,
+            funcId: 9,
             port: port_,
           );
         },
@@ -451,7 +428,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 9,
+            funcId: 10,
             port: port_,
           );
         },
@@ -478,7 +455,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 10,
+            funcId: 11,
             port: port_,
           );
         },
@@ -497,6 +474,39 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       const TaskConstMeta(debugName: "speech_language_default", argNames: []);
 
   @override
+  Future<void> crateApiMeetingsSyncSpeakerEnrollmentJson({
+    required String raw,
+  }) {
+    return handler.executeNormal(
+      NormalTask(
+        callFfi: (port_) {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          sse_encode_String(raw, serializer);
+          pdeCallFfi(
+            generalizedFrbRustBinding,
+            serializer,
+            funcId: 12,
+            port: port_,
+          );
+        },
+        codec: SseCodec(
+          decodeSuccessData: sse_decode_unit,
+          decodeErrorData: null,
+        ),
+        constMeta: kCrateApiMeetingsSyncSpeakerEnrollmentJsonConstMeta,
+        argValues: [raw],
+        apiImpl: this,
+      ),
+    );
+  }
+
+  TaskConstMeta get kCrateApiMeetingsSyncSpeakerEnrollmentJsonConstMeta =>
+      const TaskConstMeta(
+        debugName: "sync_speaker_enrollment_json",
+        argNames: ["raw"],
+      );
+
+  @override
   Stream<TranscriptEvent> crateApiMeetingsTranscribeRecording({
     required String wavPath,
     String? language,
@@ -513,7 +523,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             pdeCallFfi(
               generalizedFrbRustBinding,
               serializer,
-              funcId: 11,
+              funcId: 13,
               port: port_,
             );
           },
@@ -548,7 +558,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 12,
+            funcId: 14,
             port: port_,
           );
         },

--- a/rust/airo_mind_diarize/Cargo.toml
+++ b/rust/airo_mind_diarize/Cargo.toml
@@ -23,6 +23,12 @@ rustfft = "6"
 default = []
 # ONNX Runtime ECAPA inference — enabled on product whisper builds that bundle ORT.
 ecapa-ort = ["dep:ort"]
+# Copy ORT dylibs next to build artifacts — set ORT_LIB_LOCATION before building.
+ecapa-ort-bundle = ["ecapa-ort", "ort/copy-dylibs"]
+
+[[test]]
+name = "ecapa_onnx_e2e"
+required-features = ["ecapa-ort"]
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(frb_expand)'] }

--- a/rust/airo_mind_diarize/README.md
+++ b/rust/airo_mind_diarize/README.md
@@ -1,60 +1,53 @@
 # airo_mind_diarize
 
-Wave 3 scaffolding for on-device speaker diarization in Airo Mind.
+Wave 3 on-device speaker diarization for Airo Mind.
 
-Sits between whisper ASR (`airo_mind_whisper`) and transcript processing
-(`airo_mind_transcript`). Today ships a deterministic **single-speaker**
-fallback so the pipeline can carry `speaker_id` through segments before
-ECAPA-TDNN embeddings and online clustering land.
-
-## Pipeline position
+## Pipeline
 
 ```text
-audio → airo_mind_audio (16 kHz PCM)
-     → whisper (segments: id, start_ms, end_ms, text)
-     → airo_mind_diarize (segments + speaker_id)
-     → airo_mind_transcript (normalize + chunk)
-     → Meeting IR / minutes
+audio → whisper (segments)
+     → airo_mind_diarize (speaker labels)
+     → Meeting IR / export
 ```
 
-## API
+## ECAPA ONNX (optional)
 
-```rust
-use airo_mind_diarize::{diarize_segments, DiarizationStrategy};
+Multi-speaker labels use vedk00 ECAPA ONNX weights (`ecapa_tdnn_tiny_int8.onnx`).
+Inference is gated behind the `ecapa-ort` feature and links against ONNX Runtime
+1.20 — **not** `download-binaries` (edition2024 deps on older Rust).
 
-// Product transcribe path (solo v0):
-let result = diarize_segments(&segments, Some(&pcm), DiarizationStrategy::Solo)?;
+### Link ONNX Runtime
 
-// CLI / dev tests (stub embedder + clustering):
-let result = diarize_segments(
-    &segments,
-    Some(&pcm),
-    DiarizationStrategy::StubEmbedding {
-        similarity_threshold: 0.85,
-    },
-)?;
+```bash
+source scripts/install-onnxruntime.sh   # sets ORT_LIB_LOCATION
 ```
 
-Legacy helper:
+### Product whisper + ECAPA (desktop)
 
-```rust
-use airo_mind_diarize::{Diarizer, SingleSpeakerDiarizer, DiarizationInput};
-
-let result = SingleSpeakerDiarizer::new().diarize(&DiarizationInput {
-    segments: &transcript_segments,
-    pcm: None,
-})?;
+```bash
+source scripts/install-onnxruntime.sh
+scripts/build-whisper-ecapa-desktop.sh
 ```
 
-## Verify
+Android cargokit builds stay on `whisper` only until ORT is bundled for arm64.
+
+### Test
+
+```bash
+scripts/run-ecapa-ort-tests.sh
+# With real weights (downloads pinned HF file once):
+AIRO_ECAPA_E2E=1 scripts/run-ecapa-ort-tests.sh
+```
+
+### FRB regen (whisper bridge)
+
+```bash
+scripts/regenerate-mind-whisper-frb.sh   # requires Rust 1.88+ and cargo-expand
+scripts/check-mind-whisper-frb.sh        # CI gate — bindings must match committed output
+```
+
+## Verify (no ORT)
 
 ```bash
 cargo test -p airo_mind_diarize
 ```
-
-## Non-goals (this crate)
-
-- Sarvam Edge ASR or cloud diarization APIs
-- Full ECAPA-TDNN / ONNX runtime (planned follow-up)
-- `EmbeddingDiarizer` + `StubSpeakerEmbedder` for dev/tests; swap embedder for ONNX
-- Word-level diarization (segment-level v1 only)

--- a/rust/airo_mind_diarize/src/embedding_diarizer.rs
+++ b/rust/airo_mind_diarize/src/embedding_diarizer.rs
@@ -1,6 +1,5 @@
 //! Embedding + online clustering diarizer.
 
-use crate::cluster::cluster_embeddings_greedy_with_enrollment;
 use crate::diarizer::{DiarizationError, DiarizationInput, Diarizer};
 use crate::embedder::SpeakerEmbedder;
 use crate::result::DiarizationResult;

--- a/rust/airo_mind_diarize/tests/ecapa_onnx_e2e/main.rs
+++ b/rust/airo_mind_diarize/tests/ecapa_onnx_e2e/main.rs
@@ -1,0 +1,85 @@
+//! ECAPA ONNX end-to-end test — requires ONNX Runtime and pinned weights.
+//!
+//! Run locally:
+//!   AIRO_ECAPA_E2E=1 scripts/run-ecapa-ort-tests.sh
+//!   # downloads pinned weights via scripts/download-ecapa-model.sh
+
+use std::path::PathBuf;
+
+use airo_mind_core::wav::Pcm;
+use airo_mind_diarize::{
+    diarize_segments, product_diarization_strategy, DiarizationStrategy, EcapaOnnxEmbedder,
+    SpeakerEmbedder,
+};
+
+fn synthetic_pcm() -> Pcm {
+    let samples: Vec<i16> = (0..48_000)
+        .map(|i| ((i % 200) as i16) - 100)
+        .collect();
+    Pcm {
+        samples,
+        sample_rate_hz: 16_000,
+        channels: 1,
+    }
+}
+
+#[test]
+#[ignore = "requires ORT_LIB_LOCATION and AIRO_ECAPA_MODEL_PATH — see scripts/run-ecapa-ort-tests.sh"]
+fn ecapa_onnx_produces_192_dim_normalized_embedding() {
+    let model_path = std::env::var("AIRO_ECAPA_MODEL_PATH")
+        .map(PathBuf::from)
+        .expect("set AIRO_ECAPA_MODEL_PATH to ecapa_tdnn_tiny_int8.onnx");
+
+    let embedder = EcapaOnnxEmbedder::try_new(model_path).expect("load ECAPA ONNX");
+    let pcm = synthetic_pcm();
+    let embedding = embedder
+        .embed_segment(&pcm, 0, 2_000)
+        .expect("embed segment");
+
+    assert_eq!(embedding.len(), 192);
+    let norm = embedding.iter().map(|x| x * x).sum::<f32>().sqrt();
+    assert!((norm - 1.0).abs() < 0.01, "expected L2-normalized embedding, norm={norm}");
+}
+
+#[test]
+#[ignore = "requires ORT_LIB_LOCATION and AIRO_ECAPA_MODEL_PATH — see scripts/run-ecapa-ort-tests.sh"]
+fn ecapa_product_diarization_splits_or_labels_speakers() {
+    let model_path = std::env::var("AIRO_ECAPA_MODEL_PATH")
+        .map(PathBuf::from)
+        .expect("set AIRO_ECAPA_MODEL_PATH");
+    let models_dir = model_path.parent().expect("model parent dir");
+
+    let pcm = synthetic_pcm();
+    let segments = [
+        airo_mind_transcript::Segment {
+            id: "s0".into(),
+            start_ms: 0,
+            end_ms: 1_000,
+            text: "hello".into(),
+        },
+        airo_mind_transcript::Segment {
+            id: "s1".into(),
+            start_ms: 1_000,
+            end_ms: 2_000,
+            text: "world".into(),
+        },
+    ];
+
+    let strategy = product_diarization_strategy(models_dir);
+    assert!(
+        matches!(strategy, DiarizationStrategy::Embedding { .. }),
+        "expected embedding strategy when ECAPA file is present"
+    );
+
+    let result = diarize_segments(
+        &segments,
+        Some(&pcm),
+        strategy,
+        Some(models_dir),
+        None,
+    )
+    .expect("diarize with ECAPA");
+
+    assert_eq!(result.segments.len(), 2);
+    assert!(!result.speakers.is_empty());
+}

--- a/rust/airo_mind_whisper/Cargo.toml
+++ b/rust/airo_mind_whisper/Cargo.toml
@@ -28,7 +28,7 @@ crate-type = ["cdylib", "staticlib", "rlib"]
 [dependencies]
 airo_mind_audio = { path = "../airo_mind_audio" }
 airo_mind_core = { path = "../airo_mind_core" }
-airo_mind_diarize = { path = "../airo_mind_diarize", features = ["ecapa-ort"] }
+airo_mind_diarize = { path = "../airo_mind_diarize" }
 airo_mind_transcript = { path = "../airo_mind_transcript" }
 # Pinned to the exact version core_native already uses. Two flutter_rust_bridge
 # versions in one Flutter app is a link-time conflict, not a warning.
@@ -85,6 +85,10 @@ whisper-rs = { version = "0.16", optional = true, features = ["metal"] }
 default = []
 # Real offline transcription. Requires cmake and a C++ toolchain.
 whisper = ["dep:whisper-rs"]
+# ECAPA diarization — link ONNX Runtime via ORT_LIB_LOCATION (see scripts/install-onnxruntime.sh).
+ecapa = ["airo_mind_diarize/ecapa-ort"]
+# Desktop release: copy ORT dylibs beside whisper cdylib when ORT_LIB_LOCATION is set.
+ecapa-bundle = ["ecapa", "airo_mind_diarize/ecapa-ort-bundle"]
 # Documents the macOS Metal contract explicitly (see the target-specific
 # dependency table above); does not change what gets linked on macOS, since
 # Metal is already unified in automatically for `cfg(target_os = "macos")`

--- a/rust/airo_mind_whisper/cargokit.yaml
+++ b/rust/airo_mind_whisper/cargokit.yaml
@@ -12,3 +12,5 @@ cargo:
     extra_flags: ["--features", "whisper"]
   profile:
     extra_flags: ["--features", "whisper"]
+  # Desktop ECAPA (optional): install ORT via scripts/install-onnxruntime.sh then
+  # build with --features whisper,ecapa,ecapa-bundle (see airo_mind_whisper/Cargo.toml).

--- a/rust/airo_mind_whisper/src/api/meetings.rs
+++ b/rust/airo_mind_whisper/src/api/meetings.rs
@@ -522,10 +522,32 @@ pub fn is_ready() -> bool {
     lock(&ENGINES).is_some()
 }
 
-/// Sarvam Edge on-device ASR — reserved until public weights ship (`#1664`).
+/// Sarvam Edge on-device ASR — true when public weights are installed (`#1664`).
+///
+/// Flip is automatic once `sarvam_edge_speech.onnx` is in the models directory
+/// (future HF pin). Dev override: `AIRO_SARVAM_EDGE_SPEECH=1`.
 #[frb(sync)]
 pub fn sarvam_edge_speech_available() -> bool {
-    false
+    if std::env::var("AIRO_SARVAM_EDGE_SPEECH").as_deref() == Ok("1") {
+        return true;
+    }
+    let models_dir = lock(&MODELS_DIR);
+    match models_dir.as_deref() {
+        Some(dir) => sarvam_edge_speech_model_path(dir).is_some(),
+        None => false,
+    }
+}
+
+/// Expected on-disk name for Sarvam Edge ASR when public weights ship.
+pub const SARVAM_EDGE_SPEECH_FILE: &str = "sarvam_edge_speech.onnx";
+
+fn sarvam_edge_speech_model_path(models_dir: &Path) -> Option<PathBuf> {
+    let path = models_dir.join(SARVAM_EDGE_SPEECH_FILE);
+    if path.is_file() {
+        Some(path)
+    } else {
+        None
+    }
 }
 
 /// Wire profile for cross-meeting speaker enrollment (#504).
@@ -808,6 +830,35 @@ pub fn get_meeting(id: String) -> Result<Option<MeetingRecord>, String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn sarvam_edge_speech_available_when_model_file_present() {
+        let dir = std::env::temp_dir().join(format!(
+            "airo_sarvam_edge_test_{}",
+            std::process::id()
+        ));
+        std::fs::create_dir_all(&dir).expect("tempdir");
+        let model_path = dir.join(SARVAM_EDGE_SPEECH_FILE);
+        std::fs::write(&model_path, b"stub").expect("write stub onnx");
+
+        assert!(sarvam_edge_speech_model_path(&dir).is_some());
+        assert_eq!(
+            sarvam_edge_speech_model_path(&dir).as_ref(),
+            Some(&model_path)
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn sarvam_edge_speech_unavailable_without_model_file() {
+        let dir = std::env::temp_dir().join(format!(
+            "airo_sarvam_edge_empty_{}",
+            std::process::id()
+        ));
+        std::fs::create_dir_all(&dir).expect("tempdir");
+        assert!(sarvam_edge_speech_model_path(&dir).is_none());
+        let _ = std::fs::remove_dir_all(&dir);
+    }
 
     /// `#1629`: `transcribe_recording` computed `start_ms`/`end_ms` correctly
     /// at the engine layer (`WhisperSpeechEngine`) but discarded them before

--- a/rust/airo_mind_whisper/src/frb_generated.rs
+++ b/rust/airo_mind_whisper/src/frb_generated.rs
@@ -37,7 +37,7 @@ flutter_rust_bridge::frb_generated_boilerplate!(
     default_rust_auto_opaque = RustAutoOpaqueMoi,
 );
 pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_VERSION: &str = "2.11.1";
-pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = 191481972;
+pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = -699939418;
 
 // Section: executor
 
@@ -204,69 +204,6 @@ fn wire__crate__api__meetings__is_ready_impl(
         },
     )
 }
-fn wire__crate__api__meetings__sarvam_edge_speech_available_impl(
-    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
-    rust_vec_len_: i32,
-    data_len_: i32,
-) -> flutter_rust_bridge::for_generated::WireSyncRust2DartSse {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap_sync::<flutter_rust_bridge::for_generated::SseCodec, _>(
-        flutter_rust_bridge::for_generated::TaskInfo {
-            debug_name: "sarvam_edge_speech_available",
-            port: None,
-            mode: flutter_rust_bridge::for_generated::FfiCallMode::Sync,
-        },
-        move || {
-            let message = unsafe {
-                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
-                    ptr_,
-                    rust_vec_len_,
-                    data_len_,
-                )
-            };
-            let mut deserializer =
-                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
-            deserializer.end();
-            transform_result_sse::<_, ()>((move || {
-                let output_ok =
-                    Result::<_, ()>::Ok(crate::api::meetings::sarvam_edge_speech_available())?;
-                Ok(output_ok)
-            })())
-        },
-    )
-}
-fn wire__crate__api__meetings__sync_speaker_enrollment_json_impl(
-    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
-    rust_vec_len_: i32,
-    data_len_: i32,
-) -> flutter_rust_bridge::for_generated::WireSyncRust2DartSse {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap_sync::<flutter_rust_bridge::for_generated::SseCodec, _>(
-        flutter_rust_bridge::for_generated::TaskInfo {
-            debug_name: "sync_speaker_enrollment_json",
-            port: None,
-            mode: flutter_rust_bridge::for_generated::FfiCallMode::Sync,
-        },
-        move || {
-            let message = unsafe {
-                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
-                    ptr_,
-                    rust_vec_len_,
-                    data_len_,
-                )
-            };
-            let mut deserializer =
-                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
-            let api_raw = <String>::sse_decode(&mut deserializer);
-            deserializer.end();
-            transform_result_sse::<_, ()>((move || {
-                let output_ok =
-                    Result::<_, ()>::Ok(crate::api::meetings::sync_speaker_enrollment_json(
-                        api_raw,
-                    ))?;
-                Ok(output_ok)
-            })())
-        },
-    )
-}
 fn wire__crate__api__meetings__list_meetings_impl(
     port_: flutter_rust_bridge::for_generated::MessagePort,
     ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
@@ -328,6 +265,36 @@ fn wire__crate__api__setup__required_models_impl(
                     Ok(output_ok)
                 })())
             }
+        },
+    )
+}
+fn wire__crate__api__meetings__sarvam_edge_speech_available_impl(
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) -> flutter_rust_bridge::for_generated::WireSyncRust2DartSse {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_sync::<flutter_rust_bridge::for_generated::SseCodec, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "sarvam_edge_speech_available",
+            port: None,
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Sync,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            deserializer.end();
+            transform_result_sse::<_, ()>((move || {
+                let output_ok =
+                    Result::<_, ()>::Ok(crate::api::meetings::sarvam_edge_speech_available())?;
+                Ok(output_ok)
+            })())
         },
     )
 }
@@ -448,6 +415,41 @@ fn wire__crate__api__meetings__speech_language_default_impl(
                 transform_result_sse::<_, ()>((move || {
                     let output_ok =
                         Result::<_, ()>::Ok(crate::api::meetings::SpeechLanguage::default())?;
+                    Ok(output_ok)
+                })())
+            }
+        },
+    )
+}
+fn wire__crate__api__meetings__sync_speaker_enrollment_json_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "sync_speaker_enrollment_json",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_raw = <String>::sse_decode(&mut deserializer);
+            deserializer.end();
+            move |context| {
+                transform_result_sse::<_, ()>((move || {
+                    let output_ok = Result::<_, ()>::Ok({
+                        crate::api::meetings::sync_speaker_enrollment_json(api_raw);
+                    })?;
                     Ok(output_ok)
                 })())
             }
@@ -1037,18 +1039,24 @@ fn pde_ffi_dispatcher_primary_impl(
         4 => wire__crate__api__meetings__initialize_impl(port, ptr, rust_vec_len, data_len),
         6 => wire__crate__api__meetings__list_meetings_impl(port, ptr, rust_vec_len, data_len),
         7 => wire__crate__api__setup__required_models_impl(port, ptr, rust_vec_len, data_len),
-        8 => wire__crate__api__meetings__save_meeting_impl(port, ptr, rust_vec_len, data_len),
-        9 => wire__crate__api__meetings__search_meetings_impl(port, ptr, rust_vec_len, data_len),
-        10 => wire__crate__api__meetings__speech_language_default_impl(
+        9 => wire__crate__api__meetings__save_meeting_impl(port, ptr, rust_vec_len, data_len),
+        10 => wire__crate__api__meetings__search_meetings_impl(port, ptr, rust_vec_len, data_len),
+        11 => wire__crate__api__meetings__speech_language_default_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        11 => {
+        12 => wire__crate__api__meetings__sync_speaker_enrollment_json_impl(
+            port,
+            ptr,
+            rust_vec_len,
+            data_len,
+        ),
+        13 => {
             wire__crate__api__meetings__transcribe_recording_impl(port, ptr, rust_vec_len, data_len)
         }
-        12 => {
+        14 => {
             wire__crate__api__setup__verify_installed_models_impl(port, ptr, rust_vec_len, data_len)
         }
         _ => unreachable!(),
@@ -1065,12 +1073,11 @@ fn pde_ffi_dispatcher_sync_impl(
     match func_id {
         1 => wire__crate__api__meetings__cancel_processing_impl(ptr, rust_vec_len, data_len),
         5 => wire__crate__api__meetings__is_ready_impl(ptr, rust_vec_len, data_len),
-        13 => {
-            wire__crate__api__meetings__sarvam_edge_speech_available_impl(ptr, rust_vec_len, data_len)
-        }
-        14 => {
-            wire__crate__api__meetings__sync_speaker_enrollment_json_impl(ptr, rust_vec_len, data_len)
-        }
+        8 => wire__crate__api__meetings__sarvam_edge_speech_available_impl(
+            ptr,
+            rust_vec_len,
+            data_len,
+        ),
         _ => unreachable!(),
     }
 }

--- a/scripts/build-whisper-ecapa-desktop.sh
+++ b/scripts/build-whisper-ecapa-desktop.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Product desktop build: whisper + ECAPA diarization with bundled ORT dylibs.
+#
+# Requires: source scripts/install-onnxruntime.sh (sets ORT_LIB_LOCATION, CXX, LIBRARY_PATH)
+#
+# Usage:
+#   source scripts/install-onnxruntime.sh
+#   scripts/build-whisper-ecapa-desktop.sh [extra cargo args...]
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck source=/dev/null
+source "${ROOT}/scripts/install-onnxruntime.sh"
+
+if [[ -z "${ORT_LIB_LOCATION:-}" ]]; then
+  echo "ORT_LIB_LOCATION is not set — run: source scripts/install-onnxruntime.sh" >&2
+  exit 1
+fi
+
+cd "${ROOT}/rust"
+echo "Building airo_mind_whisper with whisper,ecapa,ecapa-bundle (ORT_LIB_LOCATION=${ORT_LIB_LOCATION})..."
+cargo build -p airo_mind_whisper --release --features whisper,ecapa,ecapa-bundle "$@"

--- a/scripts/check-mind-whisper-frb.sh
+++ b/scripts/check-mind-whisper-frb.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# CI gate: regenerated whisper FRB bindings must match committed output.
+#
+# Requires Rust >= 1.88 and cargo-expand (see regenerate-mind-whisper-frb.sh).
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+"${ROOT}/scripts/regenerate-mind-whisper-frb.sh"
+
+cd "${ROOT}"
+if git diff --quiet -- packages/feature_mind/lib/src/whisper rust/airo_mind_whisper/src/frb_generated.rs; then
+  echo "Mind whisper FRB bindings are up to date."
+else
+  echo "Mind whisper FRB bindings are stale. Run scripts/regenerate-mind-whisper-frb.sh and commit." >&2
+  git diff --stat -- packages/feature_mind/lib/src/whisper rust/airo_mind_whisper/src/frb_generated.rs >&2
+  exit 1
+fi

--- a/scripts/download-ecapa-model.sh
+++ b/scripts/download-ecapa-model.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Downloads pinned ECAPA ONNX weights for local e2e / CI (vedk00 HF mirror).
+#
+# Usage:
+#   source scripts/download-ecapa-model.sh
+#   # sets AIRO_ECAPA_MODEL_PATH to $HOME/.airo/models/ecapa_tdnn_tiny_int8.onnx
+
+set -euo pipefail
+
+MODEL_DIR="${AIRO_MODELS_DIR:-${HOME}/.airo/models}"
+MODEL_FILE="ecapa_tdnn_tiny_int8.onnx"
+MODEL_PATH="${MODEL_DIR}/${MODEL_FILE}"
+EXPECTED_SHA="f46380bbaeddb929fb3a10ab63a4b1877a50e3d1e5fdd55a1b618d5651d3f64e"
+EXPECTED_BYTES=83476039
+URL="https://huggingface.co/vedk00/ecapa-voxceleb-speaker-embedding-onnx/resolve/main/model/ecapa-speaker-v1.onnx"
+
+verify_model() {
+  local path="$1"
+  [[ -f "${path}" ]] || return 1
+  local size
+  size="$(stat -c%s "${path}" 2>/dev/null || stat -f%z "${path}")"
+  [[ "${size}" -eq "${EXPECTED_BYTES}" ]] || return 1
+  local actual
+  actual="$(sha256sum "${path}" | awk '{print $1}')"
+  [[ "${actual}" == "${EXPECTED_SHA}" ]]
+}
+
+if verify_model "${MODEL_PATH}"; then
+  echo "ECAPA model already present at ${MODEL_PATH}"
+else
+  mkdir -p "${MODEL_DIR}"
+  TMP="$(mktemp)"
+  echo "Downloading ECAPA ONNX (${EXPECTED_BYTES} bytes)..."
+  curl -fsSL "${URL}" -o "${TMP}"
+  actual_sha="$(sha256sum "${TMP}" | awk '{print $1}')"
+  if [[ "${actual_sha}" != "${EXPECTED_SHA}" ]]; then
+    echo "ECAPA hash mismatch: expected ${EXPECTED_SHA}, got ${actual_sha}" >&2
+    rm -f "${TMP}"
+    exit 1
+  fi
+  mv "${TMP}" "${MODEL_PATH}"
+  echo "Installed ECAPA model to ${MODEL_PATH}"
+fi
+
+export AIRO_ECAPA_MODEL_PATH="${MODEL_PATH}"
+
+if [[ "${BASH_SOURCE[0]}" != "${0}" ]]; then
+  : # sourced
+else
+  echo "AIRO_ECAPA_MODEL_PATH=${AIRO_ECAPA_MODEL_PATH}"
+fi

--- a/scripts/install-onnxruntime.sh
+++ b/scripts/install-onnxruntime.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# Installs ONNX Runtime 1.20 static libs for ort 2.0.0-rc.9 / ort-sys linking.
+#
+# Usage:
+#   source scripts/install-onnxruntime.sh
+#   # or: scripts/install-onnxruntime.sh && export ORT_LIB_LOCATION=...
+#
+# Sets ORT_LIB_LOCATION when sourced. Does not use ort's download-binaries feature
+# (avoids edition2024 transitive deps on older Rust toolchains).
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ORT_VERSION="1.20.0"
+ORT_HASH="F88A8C1E4B4813A1CFA79AF3F35B23ADDF2F0F36E66C5CD7C88103CB9B30509D"
+ORT_URL="https://parcel.pyke.io/v2/delivery/ortrs/packages/msort-binary/${ORT_VERSION}/ortrs_static-v${ORT_VERSION}-x86_64-unknown-linux-gnu.tgz"
+
+case "$(uname -s)-$(uname -m)" in
+  Linux-x86_64) TARGET_DIR="${HOME}/.airo/onnxruntime/${ORT_VERSION}/linux-x64" ;;
+  Linux-aarch64)
+    ORT_HASH="76F8BAD14294874115F687DF7C09FB4EF0800ED928096F504AE666298E31A136"
+    ORT_URL="https://parcel.pyke.io/v2/delivery/ortrs/packages/msort-binary/${ORT_VERSION}/ortrs_static-v${ORT_VERSION}-aarch64-unknown-linux-gnu.tgz"
+    TARGET_DIR="${HOME}/.airo/onnxruntime/${ORT_VERSION}/linux-arm64"
+    ;;
+  Darwin-arm64)
+    ORT_HASH="5EAFA0AF54D630C4D4D9F459CB95E3CFF442993F0FFA50402695186F9B1A38A5"
+    ORT_URL="https://parcel.pyke.io/v2/delivery/ortrs/packages/msort-binary/${ORT_VERSION}/ortrs_static-v${ORT_VERSION}-aarch64-apple-darwin.tgz"
+    TARGET_DIR="${HOME}/.airo/onnxruntime/${ORT_VERSION}/macos-arm64"
+    ;;
+  Darwin-x86_64)
+    ORT_HASH="876174AEC9DC8422E9A757A0D1C5F0DF4F0A32B2FED6E4C7E4183DFD80F65AEF"
+    ORT_URL="https://parcel.pyke.io/v2/delivery/ortrs/packages/msort-binary/${ORT_VERSION}/ortrs_static-v${ORT_VERSION}-x86_64-apple-darwin.tgz"
+    TARGET_DIR="${HOME}/.airo/onnxruntime/${ORT_VERSION}/macos-x64"
+    ;;
+  *)
+    echo "install-onnxruntime.sh: unsupported platform $(uname -s)-$(uname -m)" >&2
+    exit 1
+    ;;
+esac
+
+MARKER="${TARGET_DIR}/.installed"
+if [[ -f "${MARKER}" ]]; then
+  echo "ONNX Runtime ${ORT_VERSION} already installed at ${TARGET_DIR}"
+else
+  TMP="$(mktemp -d)"
+  echo "Downloading ONNX Runtime ${ORT_VERSION} static libs..."
+  curl -fsSL "${ORT_URL}" -o "${TMP}/ort.tgz"
+  ACTUAL_HASH="$(sha256sum "${TMP}/ort.tgz" | awk '{print $1}')"
+  if [[ "${ACTUAL_HASH}" != "$(echo "${ORT_HASH}" | tr '[:upper:]' '[:lower:]')" ]]; then
+    echo "ORT archive hash mismatch: expected ${ORT_HASH}, got ${ACTUAL_HASH}" >&2
+    exit 1
+  fi
+  rm -rf "${TARGET_DIR}"
+  mkdir -p "${TARGET_DIR}"
+  tar -xzf "${TMP}/ort.tgz" -C "${TARGET_DIR}" --strip-components=1
+  touch "${MARKER}"
+  rm -rf "${TMP}"
+  echo "Installed ONNX Runtime ${ORT_VERSION} to ${TARGET_DIR}"
+fi
+
+export ORT_LIB_LOCATION="${TARGET_DIR}"
+export ORT_CXX_STDLIB="stdc++"
+
+# Static ORT links libstdc++; rustc invokes `cc` by default, so point at g++'s
+# lib search path (same fix as product whisper builds with ecapa-ort).
+export CXX="${CXX:-g++}"
+_gcc_libdir="$(gcc -print-file-name=libstdc++.a 2>/dev/null | xargs dirname 2>/dev/null || true)"
+if [[ -n "${_gcc_libdir}" && -d "${_gcc_libdir}" ]]; then
+  export LIBRARY_PATH="${_gcc_libdir}${LIBRARY_PATH:+:${LIBRARY_PATH}}"
+fi
+
+if [[ "${BASH_SOURCE[0]}" != "${0}" ]]; then
+  : # sourced — ORT_LIB_LOCATION is now set in the caller shell
+else
+  echo "ORT_LIB_LOCATION=${ORT_LIB_LOCATION}"
+  echo "Export before building: export ORT_LIB_LOCATION=\"${ORT_LIB_LOCATION}\""
+fi

--- a/scripts/regenerate-mind-whisper-frb.sh
+++ b/scripts/regenerate-mind-whisper-frb.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Regenerates feature_mind whisper FRB bindings from rust/airo_mind_whisper.
+#
+# Requires Rust >= 1.88 and cargo-expand (for flutter_rust_bridge_codegen 2.11.1).
+# On older toolchains, install explicitly:
+#   rustup toolchain install 1.88.0
+#   cargo +1.88.0 install cargo-expand --version 1.0.118 --locked
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+FRB_TOOLCHAIN="${FRB_TOOLCHAIN:-1.88.0}"
+CONFIG="${ROOT}/flutter_rust_bridge_mind_whisper.yaml"
+
+if ! rustup toolchain list | grep -q "${FRB_TOOLCHAIN}"; then
+  echo "Installing Rust ${FRB_TOOLCHAIN} for FRB codegen..."
+  rustup toolchain install "${FRB_TOOLCHAIN}" --profile minimal
+fi
+
+rustup component add --toolchain "${FRB_TOOLCHAIN}" rustfmt 2>/dev/null || true
+
+if ! cargo "+${FRB_TOOLCHAIN}" expand --version >/dev/null 2>&1; then
+  echo "Installing cargo-expand for ${FRB_TOOLCHAIN}..."
+  cargo "+${FRB_TOOLCHAIN}" install cargo-expand --version 1.0.118 --locked --force
+fi
+
+if ! command -v flutter_rust_bridge_codegen >/dev/null 2>&1; then
+  echo "Installing flutter_rust_bridge_codegen 2.11.1..."
+  cargo install flutter_rust_bridge_codegen --version 2.11.1 --locked --force
+fi
+
+export PATH="${HOME}/.cargo/bin:${PATH}"
+
+echo "Regenerating whisper FRB (Rust ${FRB_TOOLCHAIN})..."
+cd "${ROOT}"
+RUSTUP_TOOLCHAIN="${FRB_TOOLCHAIN}" flutter_rust_bridge_codegen generate --config-file "${CONFIG}"
+
+echo "Done. Review diffs in:"
+echo "  packages/feature_mind/lib/src/whisper/"
+echo "  rust/airo_mind_whisper/src/frb_generated.rs"

--- a/scripts/run-ecapa-ort-tests.sh
+++ b/scripts/run-ecapa-ort-tests.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Runs airo_mind_diarize tests with ecapa-ort linked against system ONNX Runtime.
+#
+# CI and local dev: avoids ort's download-binaries (edition2024 deps on Rust 1.83).
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+if command -v apt-get >/dev/null 2>&1; then
+  if ! command -v g++ >/dev/null 2>&1; then
+    echo "Installing C++ toolchain for ort static link..."
+    if command -v sudo >/dev/null 2>&1; then
+      sudo apt-get update -qq
+      sudo apt-get install -y -qq build-essential g++ libstdc++-13-dev
+    else
+      apt-get update -qq
+      apt-get install -y -qq build-essential g++ libstdc++-13-dev
+    fi
+  fi
+fi
+
+# shellcheck source=/dev/null
+source "${ROOT}/scripts/install-onnxruntime.sh"
+
+cd "${ROOT}/rust"
+
+echo "Running airo_mind_diarize tests with ecapa-ort (ORT_LIB_LOCATION=${ORT_LIB_LOCATION})..."
+cargo test -p airo_mind_diarize --features ecapa-ort
+
+if [[ "${AIRO_ECAPA_E2E:-}" == "1" ]]; then
+  echo "Running ECAPA e2e tests (ignored by default)..."
+  # shellcheck source=/dev/null
+  source "${ROOT}/scripts/download-ecapa-model.sh"
+  cargo test -p airo_mind_diarize --features ecapa-ort --test ecapa_onnx_e2e -- --ignored --test-threads=1
+fi


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Production-readiness follow-ups for Wave 3 ECAPA diarization and Sarvam Edge seam.

### ORT linking (product builds)

- `scripts/install-onnxruntime.sh` — ONNX Runtime 1.20 static libs (avoids `ort` `download-binaries` / edition2024 on Rust 1.83).
- Sets `ORT_LIB_LOCATION`, `CXX=g++`, and `LIBRARY_PATH` for `libstdc++` when rustc links via `cc`.
- `airo_mind_whisper` features: `ecapa`, `ecapa-bundle` (copy dylibs).
- `scripts/build-whisper-ecapa-desktop.sh` — release whisper + ECAPA with bundled ORT.

### CI

- `scripts/run-ecapa-ort-tests.sh` — unit tests with `ecapa-ort`.
- `AIRO_ECAPA_E2E=1` runs ignored e2e against pinned HF weights (`scripts/download-ecapa-model.sh`).
- `scripts/check-mind-whisper-frb.sh` — FRB regen gate (Rust 1.88 + `cargo-expand`).

### Sarvam Edge

- `sarvam_edge_speech_available()` returns true when `sarvam_edge_speech.onnx` is in the models dir (or `AIRO_SARVAM_EDGE_SPEECH=1` for dev).

### FRB

- Full regen of whisper bridge bindings including `sarvamEdgeSpeechAvailable()`.

## Verify locally

```bash
scripts/run-ecapa-ort-tests.sh
AIRO_ECAPA_E2E=1 scripts/run-ecapa-ort-tests.sh
scripts/check-mind-whisper-frb.sh
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a00604-29c4-7777-b4de-f94c24e30a99?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a00604-29c4-7777-b4de-f94c24e30a99&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

