### PR TITLE
fix(mind): CI fixes for ECAPA ORT merge — LazyLock, FRB seam, format

### DIFF
--- a/app/test/assistant_route_parity_test.dart
+++ b/app/test/assistant_route_parity_test.dart
@@ -197,9 +197,9 @@ void main() {
         .whereType<GoRoute>()
         .map((route) => route.path);
 
-    final topLevelPaths = router.configuration.routes
-        .whereType<GoRoute>()
-        .map((route) => route.path);
+    final topLevelPaths = router.configuration.routes.whereType<GoRoute>().map(
+      (route) => route.path,
+    );
 
     expect(branchPaths, contains(AssistantRouteNames.assistant));
     expect(branchPaths, isNot(contains(AssistantRouteNames.wellbeing)));

--- a/packages/feature_mind/lib/src/whisper/api/meetings_seam.dart
+++ b/packages/feature_mind/lib/src/whisper/api/meetings_seam.dart
@@ -12,6 +12,6 @@ bool sarvamEdgeSpeechAvailable() =>
 /// Syncs cross-meeting speaker enrollment profiles into the Rust diarizer (#504).
 void syncSpeakerEnrollmentJson(List<Map<String, Object?>> profiles) {
   RustLib.instance.api.crateApiMeetingsSyncSpeakerEnrollmentJson(
-    json: jsonEncode(profiles),
+    raw: jsonEncode(profiles),
   );
 }

--- a/rust/airo_mind_whisper/src/api/meetings.rs
+++ b/rust/airo_mind_whisper/src/api/meetings.rs
@@ -33,7 +33,7 @@
 //! path that replay must reproduce, and this is that path.
 
 use std::path::{Path, PathBuf};
-use std::sync::Mutex;
+use std::sync::{LazyLock, Mutex};
 
 use flutter_rust_bridge::frb;
 
@@ -338,7 +338,7 @@ fn apply_diarization_labels(
             text: record.text.clone(),
         })
         .collect();
-    let enrollment = lock(&SPEAKER_ENROLLMENT);
+    let enrollment = lock(&*SPEAKER_ENROLLMENT);
     let result = match diarize_segments(
         &segments,
         Some(pcm),
@@ -449,8 +449,8 @@ static MODELS_DIR: Mutex<Option<PathBuf>> = Mutex::new(None);
 static CANCEL: Mutex<Option<CancelToken>> = Mutex::new(None);
 
 /// Cross-meeting speaker enrollment profiles synced from Dart (#504).
-static SPEAKER_ENROLLMENT: Mutex<SpeakerEnrollmentStore> =
-    Mutex::new(SpeakerEnrollmentStore::new());
+static SPEAKER_ENROLLMENT: LazyLock<Mutex<SpeakerEnrollmentStore>> =
+    LazyLock::new(|| Mutex::new(SpeakerEnrollmentStore::new()));
 
 struct Library {
     store: MeetingStore,
@@ -570,7 +570,7 @@ pub fn sync_speaker_enrollment_json(raw: String) {
             profile.embedding,
         );
     }
-    *lock(&SPEAKER_ENROLLMENT) = store;
+    *lock(&*SPEAKER_ENROLLMENT) = store;
 }
 
 /// Recording → transcript, streaming throughout.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes CI regressions from the ECAPA ORT production follow-ups merge (#1805 / #1806).

### Rust
- `SpeakerEnrollmentStore` static uses `LazyLock` — `SpeakerEnrollmentStore::new()` is not const on Rust 1.83 host CI.

### Dart
- `meetings_seam.dart` — `syncSpeakerEnrollmentJson` passes `raw:` to match regenerated FRB (`json:` was stale).
- Format `app/test/assistant_route_parity_test.dart` for the code-quality gate.

## Verify

```bash
cd rust && cargo +1.88.0 check -p airo_mind_whisper --features whisper
cd packages/feature_mind && dart analyze lib/src/whisper/api/meetings_seam.dart
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a00604-29c4-7777-b4de-f94c24e30a99?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a00604-29c4-7777-b4de-f94c24e30a99&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

