### PR TITLE
feat(mind): Speaker learning — enroll, persist, Android ECAPA (#504)

### DIFF
--- a/packages/feature_mind/cargokit/build_tool/lib/src/builder.dart
+++ b/packages/feature_mind/cargokit/build_tool/lib/src/builder.dart
@@ -1,6 +1,8 @@
 /// This is copied from Cargokit (which is the official way to use it currently)
 /// Details: https://fzyzcjy.github.io/flutter_rust_bridge/manual/integrate/builtin
 
+import 'dart:io';
+
 import 'package:collection/collection.dart';
 import 'package:logging/logging.dart';
 import 'package:path/path.dart' as path;
@@ -137,7 +139,7 @@ class RustBuilder {
 
   /// Returns the path of directory containing build artifacts.
   Future<String> build() async {
-    final extraArgs = _buildOptions?.flags ?? [];
+    final extraArgs = _androidEcapaArgs(_buildOptions?.flags ?? []);
     final manifestPath = path.join(environment.manifestDir, 'Cargo.toml');
     runCommand(
       'rustup',
@@ -192,7 +194,51 @@ class RustBuilder {
       if (!env.ndkIsInstalled() && environment.javaHome != null) {
         env.installNdk(javaHome: environment.javaHome!);
       }
-      return env.buildEnvironment();
+      final buildEnv = await env.buildEnvironment();
+      final ortLib = _resolveOrtLibLocation();
+      if (ortLib != null) {
+        buildEnv['ORT_LIB_LOCATION'] = ortLib;
+        buildEnv['ORT_CXX_STDLIB'] = 'c++_shared';
+      }
+      return buildEnv;
     }
+  }
+
+  /// When Android ORT static libs are installed, link ECAPA into whisper.
+  List<String> _androidEcapaArgs(List<String> flags) {
+    if (target.android == null || _resolveOrtLibLocation() == null) {
+      return flags;
+    }
+    final args = List<String>.from(flags);
+    final featureIndex = args.indexOf('--features');
+    if (featureIndex >= 0 && featureIndex + 1 < args.length) {
+      final current = args[featureIndex + 1];
+      if (!current.contains('ecapa')) {
+        args[featureIndex + 1] = '$current,ecapa';
+      }
+    }
+    return args;
+  }
+
+  String? _resolveOrtLibLocation() {
+    final fromEnv = Platform.environment['ORT_LIB_LOCATION'];
+    if (fromEnv != null && fromEnv.isNotEmpty) {
+      return fromEnv;
+    }
+    final home = Platform.environment['HOME'];
+    if (home == null) return null;
+    final defaultRoot = path.join(
+      home,
+      '.airo',
+      'onnxruntime',
+      '1.20.0',
+      'android-arm64',
+      'onnxruntime-android-arm64-v8a-static_lib-1.20.0',
+    );
+    final lib = path.join(defaultRoot, 'lib', 'libonnxruntime.a');
+    if (File(lib).existsSync()) {
+      return defaultRoot;
+    }
+    return null;
   }
 }

--- a/packages/feature_mind/lib/src/meeting_ir/meeting_ir_widgets.dart
+++ b/packages/feature_mind/lib/src/meeting_ir/meeting_ir_widgets.dart
@@ -322,6 +322,8 @@ class MeetingIrTranscriptList extends StatelessWidget {
     this.speakerRegistry = MeetingSpeakerRegistry.empty,
     this.onRenameSpeaker,
     this.onMergeSpeaker,
+    this.onRememberSpeaker,
+    this.globalEnrolledNames = const {},
   });
 
   final List<TranscriptSegmentView> segments;
@@ -331,6 +333,8 @@ class MeetingIrTranscriptList extends StatelessWidget {
   final MeetingSpeakerRegistry speakerRegistry;
   final void Function(String speakerLabel)? onRenameSpeaker;
   final void Function(String fromLabel)? onMergeSpeaker;
+  final void Function(String speakerLabel)? onRememberSpeaker;
+  final Map<String, String> globalEnrolledNames;
 
   @override
   Widget build(BuildContext context) {
@@ -401,6 +405,17 @@ class MeetingIrTranscriptList extends StatelessWidget {
                                         onMergeSpeaker!(label);
                                       },
                                     ),
+                                    if (onRememberSpeaker != null)
+                                      ListTile(
+                                        leading: const Icon(Icons.badge_outlined),
+                                        title: const Text(
+                                          'Remember for future meetings',
+                                        ),
+                                        onTap: () {
+                                          Navigator.pop(context);
+                                          onRememberSpeaker!(label);
+                                        },
+                                      ),
                                   ],
                                 ),
                               ),
@@ -412,6 +427,7 @@ class MeetingIrTranscriptList extends StatelessWidget {
                         mindSpeakerDisplayLabel(
                           segment.speakerLabel!,
                           registry: speakerRegistry,
+                          globalEnrolledNames: globalEnrolledNames,
                         ),
                         style: Theme.of(context).textTheme.labelSmall?.copyWith(
                           color: mindSpeakerChipForeground(

--- a/packages/feature_mind/lib/src/meeting_screen.dart
+++ b/packages/feature_mind/lib/src/meeting_screen.dart
@@ -10,8 +10,11 @@ import 'meeting_ir/meeting_ir_user_edits_store.dart';
 import 'meeting_ir/meeting_ir_widgets.dart';
 import 'speaker/meeting_speaker_registry.dart';
 import 'speaker/meeting_speaker_registry_store.dart';
+import 'speaker/global_speaker_enrollment_store.dart';
 import 'speaker/speaker_rename_dialog.dart';
+import 'speaker/speaker_remember_dialog.dart';
 import 'whisper/api/meetings.dart' as rust;
+import 'mind_diarization.dart';
 import 'mind_service.dart';
 import 'trust/scribe_trust_signals.dart';
 
@@ -94,6 +97,7 @@ class _MeetingScreenState extends State<MeetingScreen> {
       widget.userEditsStore ?? MeetingIrUserEditsStore();
   late final MeetingSpeakerRegistryStore _speakerStore =
       widget.speakerRegistryStore ?? MeetingSpeakerRegistryStore();
+  final _globalEnrollmentStore = GlobalSpeakerEnrollmentStore();
   late final _exportService = MeetingExportService(
     widget.service,
     speakerRegistryStore: _speakerStore,
@@ -103,6 +107,8 @@ class _MeetingScreenState extends State<MeetingScreen> {
 
   MeetingIrUserEdits _edits = const MeetingIrUserEdits();
   MeetingSpeakerRegistry _speakerRegistry = MeetingSpeakerRegistry.empty;
+  List<GlobalEnrolledSpeaker> _globalProfiles = const [];
+  String? _audioPath;
   final _evidence = const EvidenceResolver();
 
   Map<String, TranscriptSegmentView> _segmentsById = const {};
@@ -156,6 +162,13 @@ class _MeetingScreenState extends State<MeetingScreen> {
     } else {
       _syncLiveSegments();
     }
+    _loadGlobalEnrollment();
+  }
+
+  Future<void> _loadGlobalEnrollment() async {
+    final profiles = await _globalEnrollmentStore.loadProfiles();
+    if (!mounted) return;
+    setState(() => _globalProfiles = profiles);
   }
 
   void _syncLiveSegments() {
@@ -195,6 +208,7 @@ class _MeetingScreenState extends State<MeetingScreen> {
     setState(() {
       _edits = edits;
       _speakerRegistry = speakers;
+      _audioPath = doc?.audioPath;
       _orderedSegments = ordered.isNotEmpty
           ? ordered
           : [
@@ -439,6 +453,54 @@ class _MeetingScreenState extends State<MeetingScreen> {
     setState(() => _speakerRegistry = next);
   }
 
+  TranscriptSegmentView? _segmentForSpeaker(String speakerLabel) {
+    final canonical = _speakerRegistry.canonicalLabel(speakerLabel);
+    for (final segment in _orderedSegments) {
+      final label = segment.speakerLabel;
+      if (label != null &&
+          _speakerRegistry.canonicalLabel(label) == canonical) {
+        return segment;
+      }
+    }
+    return null;
+  }
+
+  Future<void> _rememberSpeaker(String speakerLabel) async {
+    final audioPath = _audioPath;
+    if (audioPath == null || audioPath.isEmpty) {
+      _notify('Audio is not available yet for speaker enrollment.');
+      return;
+    }
+    final segment = _segmentForSpeaker(speakerLabel);
+    if (segment == null) {
+      _notify('No transcript segment found for this speaker.');
+      return;
+    }
+    final name = await showSpeakerRememberDialog(
+      context: context,
+      speakerLabel: speakerLabel,
+      registry: _speakerRegistry,
+    );
+    if (name == null || !mounted) return;
+    final trimmed = name.trim();
+    if (trimmed.isEmpty) return;
+
+    final profile = await _globalEnrollmentStore.enrollFromSegment(
+      displayName: trimmed,
+      wavPath: audioPath,
+      startMs: segment.startMs,
+      endMs: segment.endMs,
+    );
+    if (!mounted) return;
+    if (profile == null) {
+      _notify('Could not compute a voice profile for this segment.');
+      return;
+    }
+    await _loadGlobalEnrollment();
+    if (!mounted) return;
+    _notify('Remembered ${profile.displayName} for future meetings.');
+  }
+
   @override
   Widget build(BuildContext context) {
     final stored = _meeting ?? widget._meeting;
@@ -568,6 +630,10 @@ class _MeetingScreenState extends State<MeetingScreen> {
                   speakerRegistry: _speakerRegistry,
                   onRenameSpeaker: _renameSpeaker,
                   onMergeSpeaker: _mergeSpeaker,
+                  onRememberSpeaker:
+                      _audioPath != null ? _rememberSpeaker : null,
+                  globalEnrolledNames:
+                      globalEnrolledSpeakerNames(_globalProfiles),
                 ),
               ],
               if (stored != null) ...[

--- a/packages/feature_mind/lib/src/meeting_screen.dart
+++ b/packages/feature_mind/lib/src/meeting_screen.dart
@@ -33,6 +33,7 @@ class MeetingScreen extends StatefulWidget {
     required this.service,
     required this.title,
     required Stream<MindProgress> this._progress,
+    this.audioPath,
     this.meetingIntelligenceEnabled = true,
     this.showLowTierCloudChoice = false,
     this.onCloudFallback,
@@ -54,12 +55,17 @@ class MeetingScreen extends StatefulWidget {
     this.speakerRegistryStore,
     super.key,
   }) : _progress = null,
-       title = '';
+       title = '',
+       audioPath = null;
 
   final MindService service;
   final String title;
   final Stream<MindProgress>? _progress;
   final rust.MeetingRecord? _meeting;
+
+  /// Recording path while [MindService.process] is running — enables speaker
+  /// enrollment before the transcript document is saved (#504).
+  final String? audioPath;
 
   /// Pro / launch-promo seam: when false, IR MoM review is locked (AC).
   /// Open-source builds leave this true (`LaunchPromoEntitlements`).
@@ -161,6 +167,7 @@ class _MeetingScreenState extends State<MeetingScreen> {
       _loadIrContext(stored);
     } else {
       _syncLiveSegments();
+      _audioPath = widget.audioPath;
     }
     _loadGlobalEnrollment();
   }

--- a/packages/feature_mind/lib/src/mind_diarization.dart
+++ b/packages/feature_mind/lib/src/mind_diarization.dart
@@ -1,4 +1,5 @@
 import 'bridges/mind_speech_bridge.dart';
+import 'speaker/global_speaker_enrollment_store.dart';
 import 'speaker/meeting_speaker_registry.dart';
 
 /// Stable speaker label for solo recordings (`sp0` in `airo_mind_diarize`).
@@ -18,7 +19,12 @@ String formatMindSpeakerLabel(String label) {
 String mindSpeakerDisplayLabel(
   String label, {
   MeetingSpeakerRegistry registry = MeetingSpeakerRegistry.empty,
+  Map<String, String> globalEnrolledNames = const {},
 }) {
+  final enrolledName = globalEnrolledNames[label];
+  if (enrolledName != null && enrolledName.isNotEmpty) {
+    return enrolledName;
+  }
   final canonical = registry.canonicalLabel(label);
   final custom = registry.displayNameFor(canonical);
   if (custom != null && custom.isNotEmpty) {
@@ -26,6 +32,15 @@ String mindSpeakerDisplayLabel(
   }
   return formatMindSpeakerLabel(canonical);
 }
+
+/// Display names keyed by enrolled speaker id (`enrolled_0`, …).
+Map<String, String> globalEnrolledSpeakerNames(
+  List<GlobalEnrolledSpeaker> profiles,
+) => {
+  for (final profile in profiles)
+    if (profile.id.isNotEmpty && profile.displayName.isNotEmpty)
+      profile.id: profile.displayName,
+};
 
 /// v0 on-device diarization — mirrors Rust `SingleSpeakerDiarizer` until ECAPA
 /// clustering ships. Assigns one speaker to every segment missing a label.

--- a/packages/feature_mind/lib/src/mind_home_screen.dart
+++ b/packages/feature_mind/lib/src/mind_home_screen.dart
@@ -127,6 +127,7 @@ class _MindHomeScreenState extends State<MindHomeScreen> {
             service: widget.service,
             title: title,
             progress: progress,
+            audioPath: path,
           ),
         ),
       );

--- a/packages/feature_mind/lib/src/runtime/models/log_models.dart
+++ b/packages/feature_mind/lib/src/runtime/models/log_models.dart
@@ -39,6 +39,9 @@ enum MindOpKind {
   /// land: an op that never happened cannot appear on a replay-built
   /// timeline.
   meetingIrExtracted,
+
+  /// A speaker voice profile was enrolled for cross-meeting recognition (#504).
+  speakerEnrolled,
 }
 
 /// Whether this operation's signature checked out.

--- a/packages/feature_mind/lib/src/runtime_console/runtime_console_table.dart
+++ b/packages/feature_mind/lib/src/runtime_console/runtime_console_table.dart
@@ -240,6 +240,7 @@ class _RuntimeConsoleRow extends StatelessWidget {
     MindOpKind.consent: 'consent',
     MindOpKind.consentRevoked: 'consent revoked',
     MindOpKind.meetingIrExtracted: 'meeting IR extracted',
+    MindOpKind.speakerEnrolled: 'speaker enrolled',
   };
 
   static const Map<SignatureState, String> _signatureLabels = {

--- a/packages/feature_mind/lib/src/speaker/global_speaker_enrollment_store.dart
+++ b/packages/feature_mind/lib/src/speaker/global_speaker_enrollment_store.dart
@@ -1,8 +1,16 @@
 import 'dart:convert';
 
+import 'package:path/path.dart' as p;
+import 'package:path_provider/path_provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
-import '../whisper/api/meetings_seam.dart' show embedSpeakerSegment, syncSpeakerEnrollmentJson;
+import '../runtime/persistent/persistent_operation_log.dart'
+    show sharedMindOperationLog;
+import '../runtime/ports/operation_log_port.dart';
+import '../whisper/api/meetings_seam.dart'
+    show embedSpeakerSegment, syncSpeakerEnrollmentJson;
+import '../whisper/speaker_enrollment_op_log.dart';
+import 'speaker_enrollment_operation_log.dart';
 
 /// A globally enrolled speaker profile (#504) — survives across meetings.
 class GlobalEnrolledSpeaker {
@@ -33,41 +41,88 @@ class GlobalEnrolledSpeaker {
       );
 }
 
-/// Durable cross-meeting enrollment scaffold — syncs embeddings to Rust (#504).
+/// Durable cross-meeting enrollment — op log + content store (#504).
+///
+/// SharedPreferences (`mind_global_speaker_enrollment_v1`) is migrated once on
+/// first open; new enrollments append to `speaker_enrollment/ops.jsonl`.
 class GlobalSpeakerEnrollmentStore {
-  GlobalSpeakerEnrollmentStore([SharedPreferences? preferences])
-    : _preferences = preferences;
+  GlobalSpeakerEnrollmentStore({
+    SharedPreferences? preferences,
+    Future<SpeakerEnrollmentOperationLog>? logOpener,
+    OperationLogPort? timelineLog,
+  }) : _preferences = preferences,
+       _logOpener = logOpener,
+       _timelineLog = timelineLog ?? sharedMindOperationLog();
 
-  static const _storageKey = 'mind_global_speaker_enrollment_v1';
+  static OperationLogPort sharedTimelineLog() => sharedMindOperationLog();
+
+  static const _legacyStorageKey = 'mind_global_speaker_enrollment_v1';
 
   SharedPreferences? _preferences;
+  final Future<SpeakerEnrollmentOperationLog>? _logOpener;
+  final OperationLogPort _timelineLog;
+  SpeakerEnrollmentOperationLog? _log;
+  bool _migrated = false;
 
   Future<SharedPreferences> _prefs() async =>
       _preferences ??= await SharedPreferences.getInstance();
 
-  Future<List<GlobalEnrolledSpeaker>> loadProfiles() async {
+  Future<SpeakerEnrollmentOperationLog> _ensureLog() async {
+    if (_log != null) return _log!;
+    if (_logOpener != null) {
+      _log = await _logOpener;
+    } else {
+      final base = await getApplicationSupportDirectory();
+      final root = p.join(base.path, 'airo_mind', 'speaker_enrollment');
+      _log = await SpeakerEnrollmentOperationLog.open(
+        logPath: p.join(root, 'ops.jsonl'),
+        contentDirPath: p.join(root, 'content'),
+      );
+    }
+    if (!_migrated) {
+      await _migrateLegacyPrefs();
+      _migrated = true;
+    }
+    return _log!;
+  }
+
+  Future<void> _migrateLegacyPrefs() async {
+    final log = _log!;
+    final existing = await log.replay();
+    if (existing.isNotEmpty) return;
+
     final prefs = await _prefs();
-    final raw = prefs.getString(_storageKey);
-    if (raw == null || raw.isEmpty) return const [];
+    final raw = prefs.getString(_legacyStorageKey);
+    if (raw == null || raw.isEmpty) return;
+
     try {
       final decoded = jsonDecode(raw);
-      if (decoded is! List) return const [];
-      return decoded
-          .whereType<Map>()
-          .map((entry) => GlobalEnrolledSpeaker.fromJson(entry.cast<String, Object?>()))
-          .where((profile) => profile.id.isNotEmpty && profile.embedding.isNotEmpty)
-          .toList(growable: false);
+      if (decoded is! List) return;
+      final now = DateTime.now().millisecondsSinceEpoch;
+      for (final entry in decoded.whereType<Map>()) {
+        final profile = GlobalEnrolledSpeaker.fromJson(
+          entry.cast<String, Object?>(),
+        );
+        if (profile.id.isEmpty || profile.embedding.isEmpty) continue;
+        await log.appendEnroll(
+          id: profile.id,
+          displayName: profile.displayName,
+          embedding: profile.embedding,
+          recordedAtMs: now,
+        );
+      }
+      await prefs.remove(_legacyStorageKey);
     } catch (_) {
-      return const [];
+      // Corrupt legacy blob — leave it; do not block enrollment.
     }
   }
 
-  Future<void> saveProfiles(List<GlobalEnrolledSpeaker> profiles) async {
-    final prefs = await _prefs();
-    await prefs.setString(
-      _storageKey,
-      jsonEncode(profiles.map((profile) => profile.toJson()).toList()),
-    );
+  Future<List<GlobalEnrolledSpeaker>> loadProfiles() async {
+    final log = await _ensureLog();
+    return await log.projectProfiles();
+  }
+
+  Future<void> _syncRuntime(List<GlobalEnrolledSpeaker> profiles) async {
     syncSpeakerEnrollmentJson(
       profiles
           .map(
@@ -84,7 +139,7 @@ class GlobalSpeakerEnrollmentStore {
   /// Loads from disk and pushes profiles into the Rust diarizer.
   Future<void> syncToRuntime() async {
     final profiles = await loadProfiles();
-    await saveProfiles(profiles);
+    await _syncRuntime(profiles);
   }
 
   /// Enrolls a speaker from one meeting segment (#504).
@@ -95,6 +150,7 @@ class GlobalSpeakerEnrollmentStore {
     required String wavPath,
     required int startMs,
     required int endMs,
+    String timelineContextId = '',
   }) async {
     final trimmed = displayName.trim();
     if (trimmed.isEmpty) return null;
@@ -112,8 +168,22 @@ class GlobalSpeakerEnrollmentStore {
       displayName: trimmed,
       embedding: embedding,
     );
-    final next = [...profiles, profile];
-    await saveProfiles(next);
+
+    final log = await _ensureLog();
+    final now = DateTime.now().millisecondsSinceEpoch;
+    await log.appendEnroll(
+      id: profile.id,
+      displayName: profile.displayName,
+      embedding: profile.embedding,
+      recordedAtMs: now,
+    );
+    await _syncRuntime(await log.projectProfiles());
+    await appendSpeakerEnrolledOp(
+      log: _timelineLog,
+      profileId: profile.id,
+      displayName: profile.displayName,
+      contextId: timelineContextId,
+    );
     return profile;
   }
 

--- a/packages/feature_mind/lib/src/speaker/global_speaker_enrollment_store.dart
+++ b/packages/feature_mind/lib/src/speaker/global_speaker_enrollment_store.dart
@@ -2,7 +2,7 @@ import 'dart:convert';
 
 import 'package:shared_preferences/shared_preferences.dart';
 
-import '../whisper/api/meetings_seam.dart';
+import '../whisper/api/meetings_seam.dart' show embedSpeakerSegment, syncSpeakerEnrollmentJson;
 
 /// A globally enrolled speaker profile (#504) — survives across meetings.
 class GlobalEnrolledSpeaker {
@@ -85,5 +85,49 @@ class GlobalSpeakerEnrollmentStore {
   Future<void> syncToRuntime() async {
     final profiles = await loadProfiles();
     await saveProfiles(profiles);
+  }
+
+  /// Enrolls a speaker from one meeting segment (#504).
+  ///
+  /// Returns the saved profile, or null when embedding could not be computed.
+  Future<GlobalEnrolledSpeaker?> enrollFromSegment({
+    required String displayName,
+    required String wavPath,
+    required int startMs,
+    required int endMs,
+  }) async {
+    final trimmed = displayName.trim();
+    if (trimmed.isEmpty) return null;
+    final embedding = embedSpeakerSegment(
+      wavPath: wavPath,
+      startMs: startMs,
+      endMs: endMs,
+    );
+    if (embedding.isEmpty) return null;
+
+    final profiles = await loadProfiles();
+    final id = _nextEnrolledId(profiles);
+    final profile = GlobalEnrolledSpeaker(
+      id: id,
+      displayName: trimmed,
+      embedding: embedding,
+    );
+    final next = [...profiles, profile];
+    await saveProfiles(next);
+    return profile;
+  }
+
+  String _nextEnrolledId(List<GlobalEnrolledSpeaker> profiles) {
+    var max = -1;
+    for (final profile in profiles) {
+      final suffix = profile.id.startsWith('enrolled_')
+          ? profile.id.substring('enrolled_'.length)
+          : null;
+      final parsed = suffix != null ? int.tryParse(suffix) : null;
+      if (parsed != null && parsed > max) {
+        max = parsed;
+      }
+    }
+    return 'enrolled_${max + 1}';
   }
 }

--- a/packages/feature_mind/lib/src/speaker/speaker_enrollment_content_store.dart
+++ b/packages/feature_mind/lib/src/speaker/speaker_enrollment_content_store.dart
@@ -1,0 +1,53 @@
+import 'dart:io';
+import 'dart:typed_data';
+
+/// Content-addressed embedding blobs for enrolled speakers (#504).
+///
+/// Embeddings live beside the enrollment op log — not inlined in JSONL — so
+/// replay stays cheap and the shape matches future Vault content storage.
+class SpeakerEnrollmentContentStore {
+  SpeakerEnrollmentContentStore(this._contentDir);
+
+  final Directory _contentDir;
+
+  static Future<SpeakerEnrollmentContentStore> open(String contentDirPath) async {
+    final dir = Directory(contentDirPath);
+    if (!await dir.exists()) {
+      await dir.create(recursive: true);
+    }
+    return SpeakerEnrollmentContentStore(dir);
+  }
+
+  File _fileFor(String profileId) => File('${_contentDir.path}/$profileId.bin');
+
+  Future<void> put(String profileId, List<double> embedding) async {
+    if (profileId.isEmpty || embedding.isEmpty) return;
+    final bytes = ByteData(embedding.length * 4);
+    for (var i = 0; i < embedding.length; i++) {
+      bytes.setFloat32(i * 4, embedding[i], Endian.little);
+    }
+    await _fileFor(profileId).writeAsBytes(
+      bytes.buffer.asUint8List(),
+      flush: true,
+    );
+  }
+
+  Future<List<double>?> get(String profileId) async {
+    final file = _fileFor(profileId);
+    if (!await file.exists()) return null;
+    final raw = await file.readAsBytes();
+    if (raw.isEmpty || raw.length % 4 != 0) return null;
+    final data = ByteData.sublistView(raw);
+    return [
+      for (var i = 0; i < data.lengthInBytes ~/ 4; i++)
+        data.getFloat32(i * 4, Endian.little),
+    ];
+  }
+
+  Future<void> remove(String profileId) async {
+    final file = _fileFor(profileId);
+    if (await file.exists()) {
+      await file.delete();
+    }
+  }
+}

--- a/packages/feature_mind/lib/src/speaker/speaker_enrollment_operation.dart
+++ b/packages/feature_mind/lib/src/speaker/speaker_enrollment_operation.dart
@@ -1,0 +1,50 @@
+/// Durable speaker enrollment operation kinds (#504).
+///
+/// Closed set — matches the Notes capability pattern until Rust #1213 owns the
+/// log.
+enum SpeakerEnrollmentOpKind {
+  enroll,
+  remove;
+
+  String get wireName => name;
+
+  static SpeakerEnrollmentOpKind fromWireName(String name) =>
+      SpeakerEnrollmentOpKind.values.firstWhere(
+        (kind) => kind.name == name,
+        orElse: () => throw FormatException('unknown speaker enrollment op: $name'),
+      );
+}
+
+/// One append-only enrollment log entry (#504).
+class SpeakerEnrollmentOperation {
+  const SpeakerEnrollmentOperation({
+    required this.seq,
+    required this.kind,
+    required this.id,
+    required this.displayName,
+    required this.recordedAtMs,
+  });
+
+  final int seq;
+  final SpeakerEnrollmentOpKind kind;
+  final String id;
+  final String displayName;
+  final int recordedAtMs;
+
+  Map<String, Object?> toJson() => {
+    'seq': seq,
+    'kind': kind.wireName,
+    'id': id,
+    'displayName': displayName,
+    'recordedAtMs': recordedAtMs,
+  };
+
+  factory SpeakerEnrollmentOperation.fromJson(Map<String, Object?> json) =>
+      SpeakerEnrollmentOperation(
+        seq: json['seq'] as int,
+        kind: SpeakerEnrollmentOpKind.fromWireName(json['kind'] as String),
+        id: json['id'] as String? ?? '',
+        displayName: json['displayName'] as String? ?? '',
+        recordedAtMs: json['recordedAtMs'] as int? ?? 0,
+      );
+}

--- a/packages/feature_mind/lib/src/speaker/speaker_enrollment_operation_log.dart
+++ b/packages/feature_mind/lib/src/speaker/speaker_enrollment_operation_log.dart
@@ -1,0 +1,130 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'speaker_enrollment_content_store.dart';
+import 'speaker_enrollment_operation.dart';
+import 'global_speaker_enrollment_store.dart';
+
+/// Append-only enrollment log — durable cross-meeting speaker profiles (#504).
+///
+/// Twin of [NotesOperationLog]: replay builds the enrolled profile projection
+/// until Rust #1213 owns the operation log.
+class SpeakerEnrollmentOperationLog {
+  SpeakerEnrollmentOperationLog._(this._file, this._content);
+
+  final File _file;
+  final SpeakerEnrollmentContentStore _content;
+  int _nextSeq = 0;
+
+  static Future<SpeakerEnrollmentOperationLog> open({
+    required String logPath,
+    required String contentDirPath,
+  }) async {
+    final file = File(logPath);
+    if (!await file.parent.exists()) {
+      await file.parent.create(recursive: true);
+    }
+    if (!await file.exists()) {
+      await file.create(recursive: true);
+    }
+    final content = await SpeakerEnrollmentContentStore.open(contentDirPath);
+    final log = SpeakerEnrollmentOperationLog._(file, content);
+    final existing = await log.replay();
+    log._nextSeq = existing.isEmpty ? 0 : existing.last.seq + 1;
+    return log;
+  }
+
+  SpeakerEnrollmentContentStore get contentStore => _content;
+
+  Future<SpeakerEnrollmentOperation> appendEnroll({
+    required String id,
+    required String displayName,
+    required List<double> embedding,
+    required int recordedAtMs,
+  }) async {
+    await _content.put(id, embedding);
+    return await _append(
+      kind: SpeakerEnrollmentOpKind.enroll,
+      id: id,
+      displayName: displayName,
+      recordedAtMs: recordedAtMs,
+    );
+  }
+
+  Future<SpeakerEnrollmentOperation> appendRemove({
+    required String id,
+    required int recordedAtMs,
+  }) async {
+    await _content.remove(id);
+    return await _append(
+      kind: SpeakerEnrollmentOpKind.remove,
+      id: id,
+      displayName: '',
+      recordedAtMs: recordedAtMs,
+    );
+  }
+
+  Future<SpeakerEnrollmentOperation> _append({
+    required SpeakerEnrollmentOpKind kind,
+    required String id,
+    required String displayName,
+    required int recordedAtMs,
+  }) async {
+    final op = SpeakerEnrollmentOperation(
+      seq: _nextSeq++,
+      kind: kind,
+      id: id,
+      displayName: displayName,
+      recordedAtMs: recordedAtMs,
+    );
+    final raf = await _file.open(mode: FileMode.writeOnlyAppend);
+    try {
+      await raf.writeString('${jsonEncode(op.toJson())}\n');
+      await raf.flush();
+    } finally {
+      await raf.close();
+    }
+    return op;
+  }
+
+  Future<List<SpeakerEnrollmentOperation>> replay() async {
+    if (!await _file.exists()) return const [];
+    final lines = await _file
+        .openRead()
+        .transform(utf8.decoder)
+        .transform(const LineSplitter())
+        .toList();
+
+    final ops = <SpeakerEnrollmentOperation>[];
+    for (final line in lines) {
+      if (line.isEmpty) continue;
+      try {
+        final json = jsonDecode(line) as Map<String, Object?>;
+        ops.add(SpeakerEnrollmentOperation.fromJson(json));
+      } on FormatException {
+        break;
+      }
+    }
+    return ops;
+  }
+
+  Future<List<GlobalEnrolledSpeaker>> projectProfiles() async {
+    final ops = await replay();
+    final byId = <String, GlobalEnrolledSpeaker>{};
+    for (final op in ops) {
+      switch (op.kind) {
+        case SpeakerEnrollmentOpKind.enroll:
+          final embedding = await _content.get(op.id);
+          if (embedding == null || embedding.isEmpty) continue;
+          byId[op.id] = GlobalEnrolledSpeaker(
+            id: op.id,
+            displayName: op.displayName,
+            embedding: embedding,
+          );
+        case SpeakerEnrollmentOpKind.remove:
+          byId.remove(op.id);
+      }
+    }
+    return byId.values.toList(growable: false);
+  }
+}

--- a/packages/feature_mind/lib/src/speaker/speaker_remember_dialog.dart
+++ b/packages/feature_mind/lib/src/speaker/speaker_remember_dialog.dart
@@ -1,0 +1,50 @@
+import 'package:flutter/material.dart';
+
+import '../mind_diarization.dart';
+import 'meeting_speaker_registry.dart';
+
+/// Dialog to enroll a speaker for cross-meeting recognition (#504).
+Future<String?> showSpeakerRememberDialog({
+  required BuildContext context,
+  required String speakerLabel,
+  MeetingSpeakerRegistry registry = MeetingSpeakerRegistry.empty,
+}) async {
+  final initial = mindSpeakerDisplayLabel(speakerLabel, registry: registry);
+  final controller = TextEditingController(text: initial);
+  return showDialog<String>(
+    context: context,
+    builder: (context) => AlertDialog(
+      title: const Text('Remember speaker'),
+      content: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Text(
+            'Recognize this voice automatically in future meetings.',
+            style: Theme.of(context).textTheme.bodyMedium,
+          ),
+          const SizedBox(height: 12),
+          TextField(
+            controller: controller,
+            decoration: InputDecoration(
+              labelText: 'Name',
+              hintText: formatMindSpeakerLabel(speakerLabel),
+            ),
+            autofocus: true,
+            onSubmitted: (value) => Navigator.of(context).pop(value),
+          ),
+        ],
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(),
+          child: const Text('Cancel'),
+        ),
+        FilledButton(
+          onPressed: () => Navigator.of(context).pop(controller.text),
+          child: const Text('Remember'),
+        ),
+      ],
+    ),
+  );
+}

--- a/packages/feature_mind/lib/src/whisper/api/meetings.dart
+++ b/packages/feature_mind/lib/src/whisper/api/meetings.dart
@@ -36,6 +36,19 @@ bool sarvamEdgeSpeechAvailable() =>
 Future<void> syncSpeakerEnrollmentJson({required String raw}) =>
     RustLib.instance.api.crateApiMeetingsSyncSpeakerEnrollmentJson(raw: raw);
 
+/// Speaker embedding for one transcript time range (#504).
+///
+/// Uses ECAPA when the optional ONNX file is installed; stub embedder otherwise.
+Float32List embedSpeakerSegment({
+  required String wavPath,
+  required BigInt startMs,
+  required BigInt endMs,
+}) => RustLib.instance.api.crateApiMeetingsEmbedSpeakerSegment(
+  wavPath: wavPath,
+  startMs: startMs,
+  endMs: endMs,
+);
+
 /// Recording → transcript, streaming throughout.
 ///
 /// Runs on a `flutter_rust_bridge` worker thread, never the Dart main isolate.

--- a/packages/feature_mind/lib/src/whisper/api/meetings_seam.dart
+++ b/packages/feature_mind/lib/src/whisper/api/meetings_seam.dart
@@ -9,6 +9,20 @@ import '../frb_generated.dart';
 bool sarvamEdgeSpeechAvailable() =>
     RustLib.instance.api.crateApiMeetingsSarvamEdgeSpeechAvailable();
 
+/// Speaker embedding for a transcript time range (#504).
+List<double> embedSpeakerSegment({
+  required String wavPath,
+  required int startMs,
+  required int endMs,
+}) {
+  final embedding = RustLib.instance.api.crateApiMeetingsEmbedSpeakerSegment(
+    wavPath: wavPath,
+    startMs: BigInt.from(startMs),
+    endMs: BigInt.from(endMs),
+  );
+  return embedding.map((value) => value.toDouble()).toList(growable: false);
+}
+
 /// Syncs cross-meeting speaker enrollment profiles into the Rust diarizer (#504).
 void syncSpeakerEnrollmentJson(List<Map<String, Object?>> profiles) {
   RustLib.instance.api.crateApiMeetingsSyncSpeakerEnrollmentJson(

--- a/packages/feature_mind/lib/src/whisper/frb_generated.dart
+++ b/packages/feature_mind/lib/src/whisper/frb_generated.dart
@@ -65,7 +65,7 @@ class RustLib extends BaseEntrypoint<RustLibApi, RustLibApiImpl, RustLibWire> {
   String get codegenVersion => '2.11.1';
 
   @override
-  int get rustContentHash => -699939418;
+  int get rustContentHash => 147163789;
 
   static const kDefaultExternalLibraryLoaderConfig =
       ExternalLibraryLoaderConfig(
@@ -77,6 +77,12 @@ class RustLib extends BaseEntrypoint<RustLibApi, RustLibApiImpl, RustLibWire> {
 
 abstract class RustLibApi extends BaseApi {
   void crateApiMeetingsCancelProcessing();
+
+  Float32List crateApiMeetingsEmbedSpeakerSegment({
+    required String wavPath,
+    required BigInt startMs,
+    required BigInt endMs,
+  });
 
   Future<MeetingRecord?> crateApiMeetingsGetMeeting({required String id});
 
@@ -156,6 +162,38 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       const TaskConstMeta(debugName: "cancel_processing", argNames: []);
 
   @override
+  Float32List crateApiMeetingsEmbedSpeakerSegment({
+    required String wavPath,
+    required BigInt startMs,
+    required BigInt endMs,
+  }) {
+    return handler.executeSync(
+      SyncTask(
+        callFfi: () {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          sse_encode_String(wavPath, serializer);
+          sse_encode_u_64(startMs, serializer);
+          sse_encode_u_64(endMs, serializer);
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 2)!;
+        },
+        codec: SseCodec(
+          decodeSuccessData: sse_decode_list_prim_f_32_strict,
+          decodeErrorData: sse_decode_String,
+        ),
+        constMeta: kCrateApiMeetingsEmbedSpeakerSegmentConstMeta,
+        argValues: [wavPath, startMs, endMs],
+        apiImpl: this,
+      ),
+    );
+  }
+
+  TaskConstMeta get kCrateApiMeetingsEmbedSpeakerSegmentConstMeta =>
+      const TaskConstMeta(
+        debugName: "embed_speaker_segment",
+        argNames: ["wavPath", "startMs", "endMs"],
+      );
+
+  @override
   Future<MeetingRecord?> crateApiMeetingsGetMeeting({required String id}) {
     return handler.executeNormal(
       NormalTask(
@@ -165,7 +203,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 2,
+            funcId: 3,
             port: port_,
           );
         },
@@ -195,7 +233,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 3,
+            funcId: 4,
             port: port_,
           );
         },
@@ -224,7 +262,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 4,
+            funcId: 5,
             port: port_,
           );
         },
@@ -248,7 +286,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       SyncTask(
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 5)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 6)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_bool,
@@ -273,7 +311,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 6,
+            funcId: 7,
             port: port_,
           );
         },
@@ -300,7 +338,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 7,
+            funcId: 8,
             port: port_,
           );
         },
@@ -324,7 +362,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       SyncTask(
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 8)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 9)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_bool,
@@ -373,7 +411,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 9,
+            funcId: 10,
             port: port_,
           );
         },
@@ -428,7 +466,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 10,
+            funcId: 11,
             port: port_,
           );
         },
@@ -455,7 +493,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 11,
+            funcId: 12,
             port: port_,
           );
         },
@@ -485,7 +523,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 12,
+            funcId: 13,
             port: port_,
           );
         },
@@ -523,7 +561,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             pdeCallFfi(
               generalizedFrbRustBinding,
               serializer,
-              funcId: 13,
+              funcId: 14,
               port: port_,
             );
           },
@@ -558,7 +596,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 14,
+            funcId: 15,
             port: port_,
           );
         },
@@ -634,6 +672,12 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  double dco_decode_f_32(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return raw as double;
+  }
+
+  @protected
   int dco_decode_i_32(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return raw as int;
@@ -697,6 +741,12 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   List<MeetingRecord> dco_decode_list_meeting_record(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return (raw as List<dynamic>).map(dco_decode_meeting_record).toList();
+  }
+
+  @protected
+  Float32List dco_decode_list_prim_f_32_strict(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return raw as Float32List;
   }
 
   @protected
@@ -1002,6 +1052,12 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  double sse_decode_f_32(SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    return deserializer.buffer.getFloat32();
+  }
+
+  @protected
   int sse_decode_i_32(SseDeserializer deserializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     return deserializer.buffer.getInt32();
@@ -1102,6 +1158,13 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       ans_.add(sse_decode_meeting_record(deserializer));
     }
     return ans_;
+  }
+
+  @protected
+  Float32List sse_decode_list_prim_f_32_strict(SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    var len_ = sse_decode_i_32(deserializer);
+    return deserializer.buffer.getFloat32List(len_);
   }
 
   @protected
@@ -1500,6 +1563,12 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  void sse_encode_f_32(double self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    serializer.buffer.putFloat32(self);
+  }
+
+  @protected
   void sse_encode_i_32(int self, SseSerializer serializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     serializer.buffer.putInt32(self);
@@ -1584,6 +1653,16 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     for (final item in self) {
       sse_encode_meeting_record(item, serializer);
     }
+  }
+
+  @protected
+  void sse_encode_list_prim_f_32_strict(
+    Float32List self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_i_32(self.length, serializer);
+    serializer.buffer.putFloat32List(self);
   }
 
   @protected

--- a/packages/feature_mind/lib/src/whisper/frb_generated.io.dart
+++ b/packages/feature_mind/lib/src/whisper/frb_generated.io.dart
@@ -50,6 +50,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  double dco_decode_f_32(dynamic raw);
+
+  @protected
   int dco_decode_i_32(dynamic raw);
 
   @protected
@@ -76,6 +79,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   List<MeetingRecord> dco_decode_list_meeting_record(dynamic raw);
+
+  @protected
+  Float32List dco_decode_list_prim_f_32_strict(dynamic raw);
 
   @protected
   Uint8List dco_decode_list_prim_u_8_strict(dynamic raw);
@@ -185,6 +191,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  double sse_decode_f_32(SseDeserializer deserializer);
+
+  @protected
   int sse_decode_i_32(SseDeserializer deserializer);
 
   @protected
@@ -217,6 +226,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   List<MeetingRecord> sse_decode_list_meeting_record(
     SseDeserializer deserializer,
   );
+
+  @protected
+  Float32List sse_decode_list_prim_f_32_strict(SseDeserializer deserializer);
 
   @protected
   Uint8List sse_decode_list_prim_u_8_strict(SseDeserializer deserializer);
@@ -356,6 +368,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  void sse_encode_f_32(double self, SseSerializer serializer);
+
+  @protected
   void sse_encode_i_32(int self, SseSerializer serializer);
 
   @protected
@@ -394,6 +409,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   void sse_encode_list_meeting_record(
     List<MeetingRecord> self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_list_prim_f_32_strict(
+    Float32List self,
     SseSerializer serializer,
   );
 

--- a/packages/feature_mind/lib/src/whisper/frb_generated.web.dart
+++ b/packages/feature_mind/lib/src/whisper/frb_generated.web.dart
@@ -52,6 +52,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  double dco_decode_f_32(dynamic raw);
+
+  @protected
   int dco_decode_i_32(dynamic raw);
 
   @protected
@@ -78,6 +81,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   List<MeetingRecord> dco_decode_list_meeting_record(dynamic raw);
+
+  @protected
+  Float32List dco_decode_list_prim_f_32_strict(dynamic raw);
 
   @protected
   Uint8List dco_decode_list_prim_u_8_strict(dynamic raw);
@@ -187,6 +193,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  double sse_decode_f_32(SseDeserializer deserializer);
+
+  @protected
   int sse_decode_i_32(SseDeserializer deserializer);
 
   @protected
@@ -219,6 +228,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   List<MeetingRecord> sse_decode_list_meeting_record(
     SseDeserializer deserializer,
   );
+
+  @protected
+  Float32List sse_decode_list_prim_f_32_strict(SseDeserializer deserializer);
 
   @protected
   Uint8List sse_decode_list_prim_u_8_strict(SseDeserializer deserializer);
@@ -358,6 +370,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  void sse_encode_f_32(double self, SseSerializer serializer);
+
+  @protected
   void sse_encode_i_32(int self, SseSerializer serializer);
 
   @protected
@@ -396,6 +411,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   void sse_encode_list_meeting_record(
     List<MeetingRecord> self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_list_prim_f_32_strict(
+    Float32List self,
     SseSerializer serializer,
   );
 

--- a/packages/feature_mind/lib/src/whisper/speaker_enrollment_op_log.dart
+++ b/packages/feature_mind/lib/src/whisper/speaker_enrollment_op_log.dart
@@ -1,0 +1,26 @@
+import '../runtime/mind_runtime.dart' show MindPortUnavailable;
+import '../runtime/models/log_models.dart';
+import '../runtime/ports/operation_log_port.dart';
+
+/// Appends the timeline-visible half of a speaker enrollment (#504).
+///
+/// The embedding content is durable in [SpeakerEnrollmentOperationLog]; this
+/// op makes "remembered speaker" visible on the Mind timeline the same way
+/// [appendMeetingIrExtractedOp] does for Meeting IR.
+Future<int?> appendSpeakerEnrolledOp({
+  required OperationLogPort log,
+  required String profileId,
+  required String displayName,
+  String contextId = '',
+}) async {
+  try {
+    return await log.append(
+      kind: MindOpKind.speakerEnrolled,
+      title: 'Remembered $displayName',
+      contextId: contextId,
+      detail: '$profileId;$displayName',
+    );
+  } on MindPortUnavailable {
+    return null;
+  }
+}

--- a/packages/feature_mind/test/mind_diarization_test.dart
+++ b/packages/feature_mind/test/mind_diarization_test.dart
@@ -1,5 +1,6 @@
 import 'package:feature_mind/src/bridges/mind_speech_bridge.dart';
 import 'package:feature_mind/src/mind_diarization.dart';
+import 'package:feature_mind/src/speaker/global_speaker_enrollment_store.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
@@ -62,5 +63,31 @@ void main() {
     expect(formatMindSpeakerLabel('sp0'), 'Speaker 1');
     expect(formatMindSpeakerLabel('sp2'), 'Speaker 3');
     expect(formatMindSpeakerLabel('guest'), 'guest');
+  });
+
+  test('mindSpeakerDisplayLabel prefers global enrolled name', () {
+    expect(
+      mindSpeakerDisplayLabel(
+        'enrolled_0',
+        globalEnrolledNames: {'enrolled_0': 'Alice'},
+      ),
+      'Alice',
+    );
+  });
+
+  test('globalEnrolledSpeakerNames maps profile ids to display names', () {
+    final names = globalEnrolledSpeakerNames([
+      const GlobalEnrolledSpeaker(
+        id: 'enrolled_0',
+        displayName: 'Bob',
+        embedding: [0.1, 0.2],
+      ),
+      const GlobalEnrolledSpeaker(
+        id: 'enrolled_1',
+        displayName: '',
+        embedding: [0.3],
+      ),
+    ]);
+    expect(names, {'enrolled_0': 'Bob'});
   });
 }

--- a/packages/feature_mind/test/speaker/global_speaker_enrollment_store_test.dart
+++ b/packages/feature_mind/test/speaker/global_speaker_enrollment_store_test.dart
@@ -1,0 +1,75 @@
+import 'dart:io';
+
+import 'package:feature_mind/src/speaker/global_speaker_enrollment_store.dart';
+import 'package:feature_mind/src/speaker/speaker_enrollment_operation_log.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../support/recording_operation_log.dart';
+
+void main() {
+  late Directory tempDir;
+
+  setUp(() async {
+    tempDir = await Directory.systemTemp.createTemp('speaker_enrollment_test_');
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  tearDown(() async {
+    if (await tempDir.exists()) {
+      await tempDir.delete(recursive: true);
+    }
+  });
+
+  test('operation log replays enroll and remove', () async {
+    final root = '${tempDir.path}/enrollment';
+    final log = await SpeakerEnrollmentOperationLog.open(
+      logPath: '$root/ops.jsonl',
+      contentDirPath: '$root/content',
+    );
+
+    await log.appendEnroll(
+      id: 'enrolled_0',
+      displayName: 'Alice',
+      embedding: [0.1, 0.2, 0.3],
+      recordedAtMs: 1000,
+    );
+    await log.appendEnroll(
+      id: 'enrolled_1',
+      displayName: 'Bob',
+      embedding: [0.4, 0.5],
+      recordedAtMs: 2000,
+    );
+    await log.appendRemove(id: 'enrolled_0', recordedAtMs: 3000);
+
+    final profiles = await log.projectProfiles();
+    expect(profiles, hasLength(1));
+    expect(profiles.single.id, 'enrolled_1');
+    expect(profiles.single.displayName, 'Bob');
+    expect(profiles.single.embedding, [0.4, 0.5]);
+  });
+
+  test('GlobalSpeakerEnrollmentStore migrates legacy SharedPreferences', () async {
+    SharedPreferences.setMockInitialValues({
+      'mind_global_speaker_enrollment_v1':
+          '[{"id":"enrolled_0","displayName":"Legacy","embedding":[0.9]}]',
+    });
+    final prefs = await SharedPreferences.getInstance();
+
+    final root = '${tempDir.path}/store';
+    final timeline = RecordingOperationLog();
+    final store = GlobalSpeakerEnrollmentStore(
+      preferences: prefs,
+      logOpener: SpeakerEnrollmentOperationLog.open(
+        logPath: '$root/ops.jsonl',
+        contentDirPath: '$root/content',
+      ),
+      timelineLog: timeline,
+    );
+    final profiles = await store.loadProfiles();
+    expect(profiles, hasLength(1));
+    expect(profiles.single.displayName, 'Legacy');
+    expect(profiles.single.embedding, [0.9]);
+    expect(prefs.getString('mind_global_speaker_enrollment_v1'), isNull);
+  });
+}

--- a/packages/feature_mind/test/whisper/speaker_enrollment_op_log_test.dart
+++ b/packages/feature_mind/test/whisper/speaker_enrollment_op_log_test.dart
@@ -1,0 +1,24 @@
+import 'package:feature_mind/src/runtime/models/log_models.dart';
+import 'package:feature_mind/src/whisper/speaker_enrollment_op_log.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../support/recording_operation_log.dart';
+
+void main() {
+  test('appendSpeakerEnrolledOp records speakerEnrolled kind', () async {
+    final log = RecordingOperationLog();
+
+    final sequence = await appendSpeakerEnrolledOp(
+      log: log,
+      profileId: 'enrolled_0',
+      displayName: 'Alice',
+      contextId: 'meeting-capture',
+    );
+
+    expect(sequence, 1);
+    expect(log.appended.single.kind, MindOpKind.speakerEnrolled);
+    expect(log.appended.single.title, 'Remembered Alice');
+    expect(log.appended.single.detail, 'enrolled_0;Alice');
+    expect(log.appended.single.contextId, 'meeting-capture');
+  });
+}

--- a/rust/airo_mind_diarize/README.md
+++ b/rust/airo_mind_diarize/README.md
@@ -29,7 +29,9 @@ source scripts/install-onnxruntime.sh
 scripts/build-whisper-ecapa-desktop.sh
 ```
 
-Android cargokit builds stay on `whisper` only until ORT is bundled for arm64.
+Android cargokit builds enable `ecapa` when Android ORT static libs are
+installed (`scripts/install-onnxruntime-android.sh`). Without ORT, builds stay
+on `whisper` only (stub embedder at runtime).
 
 ### Test
 

--- a/rust/airo_mind_diarize/src/enrollment.rs
+++ b/rust/airo_mind_diarize/src/enrollment.rs
@@ -10,7 +10,7 @@ pub struct EnrolledSpeaker {
     pub embedding: SpeakerEmbedding,
 }
 
-/// In-memory enrollment store — durable persistence lands in Vault / op log (#504).
+/// In-memory enrollment store — durable persistence via Dart op log (#504).
 #[derive(Clone, Debug, Default)]
 pub struct SpeakerEnrollmentStore {
     profiles: Vec<EnrolledSpeaker>,

--- a/rust/airo_mind_whisper/cargokit.yaml
+++ b/rust/airo_mind_whisper/cargokit.yaml
@@ -14,3 +14,5 @@ cargo:
     extra_flags: ["--features", "whisper"]
   # Desktop ECAPA (optional): install ORT via scripts/install-onnxruntime.sh then
   # build with --features whisper,ecapa,ecapa-bundle (see airo_mind_whisper/Cargo.toml).
+  # Android ECAPA: install scripts/install-onnxruntime-android.sh — cargokit enables
+  # ecapa automatically when ORT_LIB_LOCATION is present.

--- a/rust/airo_mind_whisper/src/api/meetings.rs
+++ b/rust/airo_mind_whisper/src/api/meetings.rs
@@ -52,8 +52,8 @@ use airo_mind_core::{
     TranscriptSegment, TranscriptionOptions,
 };
 use airo_mind_diarize::{
-    diarize_segments, product_diarization_strategy, DiarizationStrategy,
-    SpeakerEnrollmentStore,
+    diarize_segments, product_diarization_strategy, resolve_embedder, DiarizationStrategy,
+    SpeakerEmbedder, SpeakerEnrollmentStore,
 };
 use airo_mind_transcript::Segment;
 
@@ -573,6 +573,29 @@ pub fn sync_speaker_enrollment_json(raw: String) {
     *lock(&*SPEAKER_ENROLLMENT) = store;
 }
 
+/// Speaker embedding for one transcript time range (#504).
+///
+/// Uses ECAPA when the optional ONNX file is installed; stub embedder otherwise.
+#[frb(sync)]
+pub fn embed_speaker_segment(
+    wav_path: String,
+    start_ms: u64,
+    end_ms: u64,
+) -> Result<Vec<f32>, String> {
+    let pcm = airo_mind_audio::preprocess_path(Path::new(&wav_path))
+        .map_err(|e| e.to_string())?;
+    let core_pcm = Pcm {
+        samples: pcm.samples,
+        sample_rate_hz: pcm.sample_rate_hz,
+        channels: pcm.channels,
+    };
+    let models_dir = lock(&MODELS_DIR).clone();
+    let embedder = resolve_embedder(models_dir.as_deref());
+    embedder
+        .embed_segment(&core_pcm, start_ms, end_ms)
+        .map_err(|e| e.to_string())
+}
+
 /// Recording → transcript, streaming throughout.
 ///
 /// Runs on a `flutter_rust_bridge` worker thread, never the Dart main isolate.
@@ -858,6 +881,50 @@ mod tests {
         std::fs::create_dir_all(&dir).expect("tempdir");
         assert!(sarvam_edge_speech_model_path(&dir).is_none());
         let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn embed_speaker_segment_returns_stub_vector_without_ecapa() {
+        let dir = std::env::temp_dir().join(format!(
+            "airo_embed_segment_test_{}",
+            std::process::id()
+        ));
+        std::fs::create_dir_all(&dir).expect("tempdir");
+        let wav_path = dir.join("tone.wav");
+        write_test_wav_i16(
+            &wav_path,
+            &(0..16_000).map(|i| ((i % 200) as i16) - 100).collect::<Vec<_>>(),
+            16_000,
+        );
+
+        let embedding =
+            embed_speaker_segment(wav_path.to_string_lossy().into_owned(), 0, 1_000)
+                .expect("embed segment");
+        assert!(!embedding.is_empty());
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    fn write_test_wav_i16(path: &Path, samples: &[i16], sample_rate_hz: u32) {
+        let num_samples = samples.len();
+        let data_bytes = num_samples * 2;
+        let byte_rate = sample_rate_hz * 2;
+        let mut bytes = Vec::with_capacity(44 + data_bytes);
+        bytes.extend_from_slice(b"RIFF");
+        bytes.extend_from_slice(&(36 + data_bytes as u32).to_le_bytes());
+        bytes.extend_from_slice(b"WAVEfmt ");
+        bytes.extend_from_slice(&16u32.to_le_bytes());
+        bytes.extend_from_slice(&1u16.to_le_bytes());
+        bytes.extend_from_slice(&1u16.to_le_bytes());
+        bytes.extend_from_slice(&sample_rate_hz.to_le_bytes());
+        bytes.extend_from_slice(&byte_rate.to_le_bytes());
+        bytes.extend_from_slice(&2u16.to_le_bytes());
+        bytes.extend_from_slice(&16u16.to_le_bytes());
+        bytes.extend_from_slice(b"data");
+        bytes.extend_from_slice(&(data_bytes as u32).to_le_bytes());
+        for sample in samples {
+            bytes.extend_from_slice(&sample.to_le_bytes());
+        }
+        std::fs::write(path, bytes).expect("write wav");
     }
 
     /// `#1629`: `transcribe_recording` computed `start_ms`/`end_ms` correctly

--- a/rust/airo_mind_whisper/src/frb_generated.rs
+++ b/rust/airo_mind_whisper/src/frb_generated.rs
@@ -37,7 +37,7 @@ flutter_rust_bridge::frb_generated_boilerplate!(
     default_rust_auto_opaque = RustAutoOpaqueMoi,
 );
 pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_VERSION: &str = "2.11.1";
-pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = -699939418;
+pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = 147163789;
 
 // Section: executor
 
@@ -71,6 +71,42 @@ fn wire__crate__api__meetings__cancel_processing_impl(
                 let output_ok = Result::<_, ()>::Ok({
                     crate::api::meetings::cancel_processing();
                 })?;
+                Ok(output_ok)
+            })())
+        },
+    )
+}
+fn wire__crate__api__meetings__embed_speaker_segment_impl(
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) -> flutter_rust_bridge::for_generated::WireSyncRust2DartSse {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_sync::<flutter_rust_bridge::for_generated::SseCodec, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "embed_speaker_segment",
+            port: None,
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Sync,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_wav_path = <String>::sse_decode(&mut deserializer);
+            let api_start_ms = <u64>::sse_decode(&mut deserializer);
+            let api_end_ms = <u64>::sse_decode(&mut deserializer);
+            deserializer.end();
+            transform_result_sse::<_, String>((move || {
+                let output_ok = crate::api::meetings::embed_speaker_segment(
+                    api_wav_path,
+                    api_start_ms,
+                    api_end_ms,
+                )?;
                 Ok(output_ok)
             })())
         },
@@ -572,6 +608,13 @@ impl SseDecode for bool {
     }
 }
 
+impl SseDecode for f32 {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        deserializer.cursor.read_f32::<NativeEndian>().unwrap()
+    }
+}
+
 impl SseDecode for i32 {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
@@ -672,6 +715,18 @@ impl SseDecode for Vec<crate::api::meetings::MeetingRecord> {
             ans_.push(<crate::api::meetings::MeetingRecord>::sse_decode(
                 deserializer,
             ));
+        }
+        return ans_;
+    }
+}
+
+impl SseDecode for Vec<f32> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut len_ = <i32>::sse_decode(deserializer);
+        let mut ans_ = vec![];
+        for idx_ in 0..len_ {
+            ans_.push(<f32>::sse_decode(deserializer));
         }
         return ans_;
     }
@@ -1034,29 +1089,29 @@ fn pde_ffi_dispatcher_primary_impl(
 ) {
     // Codec=Pde (Serialization + dispatch), see doc to use other codecs
     match func_id {
-        2 => wire__crate__api__meetings__get_meeting_impl(port, ptr, rust_vec_len, data_len),
-        3 => wire__crate__api__meetings__get_transcript_impl(port, ptr, rust_vec_len, data_len),
-        4 => wire__crate__api__meetings__initialize_impl(port, ptr, rust_vec_len, data_len),
-        6 => wire__crate__api__meetings__list_meetings_impl(port, ptr, rust_vec_len, data_len),
-        7 => wire__crate__api__setup__required_models_impl(port, ptr, rust_vec_len, data_len),
-        9 => wire__crate__api__meetings__save_meeting_impl(port, ptr, rust_vec_len, data_len),
-        10 => wire__crate__api__meetings__search_meetings_impl(port, ptr, rust_vec_len, data_len),
-        11 => wire__crate__api__meetings__speech_language_default_impl(
+        3 => wire__crate__api__meetings__get_meeting_impl(port, ptr, rust_vec_len, data_len),
+        4 => wire__crate__api__meetings__get_transcript_impl(port, ptr, rust_vec_len, data_len),
+        5 => wire__crate__api__meetings__initialize_impl(port, ptr, rust_vec_len, data_len),
+        7 => wire__crate__api__meetings__list_meetings_impl(port, ptr, rust_vec_len, data_len),
+        8 => wire__crate__api__setup__required_models_impl(port, ptr, rust_vec_len, data_len),
+        10 => wire__crate__api__meetings__save_meeting_impl(port, ptr, rust_vec_len, data_len),
+        11 => wire__crate__api__meetings__search_meetings_impl(port, ptr, rust_vec_len, data_len),
+        12 => wire__crate__api__meetings__speech_language_default_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        12 => wire__crate__api__meetings__sync_speaker_enrollment_json_impl(
+        13 => wire__crate__api__meetings__sync_speaker_enrollment_json_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        13 => {
+        14 => {
             wire__crate__api__meetings__transcribe_recording_impl(port, ptr, rust_vec_len, data_len)
         }
-        14 => {
+        15 => {
             wire__crate__api__setup__verify_installed_models_impl(port, ptr, rust_vec_len, data_len)
         }
         _ => unreachable!(),
@@ -1072,8 +1127,9 @@ fn pde_ffi_dispatcher_sync_impl(
     // Codec=Pde (Serialization + dispatch), see doc to use other codecs
     match func_id {
         1 => wire__crate__api__meetings__cancel_processing_impl(ptr, rust_vec_len, data_len),
-        5 => wire__crate__api__meetings__is_ready_impl(ptr, rust_vec_len, data_len),
-        8 => wire__crate__api__meetings__sarvam_edge_speech_available_impl(
+        2 => wire__crate__api__meetings__embed_speaker_segment_impl(ptr, rust_vec_len, data_len),
+        6 => wire__crate__api__meetings__is_ready_impl(ptr, rust_vec_len, data_len),
+        9 => wire__crate__api__meetings__sarvam_edge_speech_available_impl(
             ptr,
             rust_vec_len,
             data_len,
@@ -1453,6 +1509,13 @@ impl SseEncode for bool {
     }
 }
 
+impl SseEncode for f32 {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        serializer.cursor.write_f32::<NativeEndian>(self).unwrap();
+    }
+}
+
 impl SseEncode for i32 {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
@@ -1526,6 +1589,16 @@ impl SseEncode for Vec<crate::api::meetings::MeetingRecord> {
         <i32>::sse_encode(self.len() as _, serializer);
         for item in self {
             <crate::api::meetings::MeetingRecord>::sse_encode(item, serializer);
+        }
+    }
+}
+
+impl SseEncode for Vec<f32> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <i32>::sse_encode(self.len() as _, serializer);
+        for item in self {
+            <f32>::sse_encode(item, serializer);
         }
     }
 }

--- a/scripts/install-onnxruntime-android.sh
+++ b/scripts/install-onnxruntime-android.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Installs ONNX Runtime 1.20 static libs for Android arm64-v8a (ort 2.0.0-rc.9).
+#
+# Source: csukuangfj/onnxruntime-libs (community static builds matching ORT 1.20).
+# Product Mind Android builds pick this up automatically when present — see
+# packages/feature_mind/cargokit/build_tool/lib/src/builder.dart.
+#
+# Usage:
+#   source scripts/install-onnxruntime-android.sh
+#   # or: scripts/install-onnxruntime-android.sh && export ORT_LIB_LOCATION=...
+
+set -euo pipefail
+
+ORT_VERSION="1.20.0"
+ORT_ZIP="onnxruntime-android-arm64-v8a-static_lib-${ORT_VERSION}.zip"
+ORT_URL="https://huggingface.co/csukuangfj/onnxruntime-libs/resolve/main/${ORT_ZIP}"
+ORT_HASH="e97c30611318aaf9fb25b8782f6744e5f29f3f18caf8bf4eb0ca564afc50e77e"
+TARGET_DIR="${HOME}/.airo/onnxruntime/${ORT_VERSION}/android-arm64"
+EXTRACT_ROOT="${TARGET_DIR}/${ORT_ZIP%.zip}"
+MARKER="${TARGET_DIR}/.installed"
+
+if [[ -f "${MARKER}" && -f "${EXTRACT_ROOT}/lib/libonnxruntime.a" ]]; then
+  echo "ONNX Runtime Android ${ORT_VERSION} already installed at ${EXTRACT_ROOT}"
+else
+  TMP="$(mktemp -d)"
+  echo "Downloading ONNX Runtime Android ${ORT_VERSION} static libs (~170 MB)..."
+  curl -fsSL "${ORT_URL}" -o "${TMP}/ort.zip"
+  ACTUAL_HASH="$(sha256sum "${TMP}/ort.zip" | awk '{print $1}')"
+  if [[ "${ACTUAL_HASH}" != "${ORT_HASH}" ]]; then
+    echo "ORT archive hash mismatch: expected ${ORT_HASH}, got ${ACTUAL_HASH}" >&2
+    exit 1
+  fi
+  rm -rf "${TARGET_DIR}"
+  mkdir -p "${TARGET_DIR}"
+  unzip -q "${TMP}/ort.zip" -d "${TARGET_DIR}"
+  touch "${MARKER}"
+  rm -rf "${TMP}"
+  echo "Installed ONNX Runtime Android ${ORT_VERSION} to ${EXTRACT_ROOT}"
+fi
+
+export ORT_LIB_LOCATION="${EXTRACT_ROOT}"
+export ORT_CXX_STDLIB="c++_shared"
+
+if [[ "${BASH_SOURCE[0]}" != "${0}" ]]; then
+  : # sourced
+else
+  echo "ORT_LIB_LOCATION=${ORT_LIB_LOCATION}"
+  echo "Export before building: export ORT_LIB_LOCATION=\"${ORT_LIB_LOCATION}\""
+fi


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements **#504 Speaker Learning**: enroll diarized speakers from meeting segments, persist voice embeddings durably, recognize them in future meetings, and enable real ECAPA embeddings on Android when ORT is installed.

## Changes

### Enrollment UI + Rust API (first commit)
- `embed_speaker_segment` FRB API + stub/ECAPA embedder path
- **Remember for future meetings** on transcript speaker chips
- `GlobalSpeakerEnrollmentStore.enrollFromSegment()` with Rust sync

### Durable persistence (this commit)
- **Append-only op log** at `{appSupport}/airo_mind/speaker_enrollment/ops.jsonl`
- **Content store** for embedding blobs (`content/{id}.bin`)
- One-time migration from legacy `SharedPreferences` key
- `MindOpKind.speakerEnrolled` timeline ops via `appendSpeakerEnrolledOp`

### Live processing
- `MeetingScreen.live(audioPath: …)` — remember speakers while pipeline runs (before transcript doc exists)

### Android ECAPA
- `scripts/install-onnxruntime-android.sh` — ONNX Runtime 1.20 static libs for arm64-v8a (pinned SHA)
- Cargokit `builder.dart` auto-enables `ecapa` + sets `ORT_LIB_LOCATION` when libs are present

## How it works

1. Long-press speaker chip → **Remember for future meetings**
2. App embeds segment audio → appends enroll op + content blob → syncs Rust `SpeakerEnrollmentStore`
3. Timeline records `speakerEnrolled` MindOp
4. Future meetings: diarization matches → `enrolled_*` labels → display names

## Verification

- `cargo +1.88.0 test -p airo_mind_whisper --features whisper embed_speaker_segment`
- `dart analyze` on touched `feature_mind` files
- `scripts/check-mind-whisper-frb.sh`

## Android product build with ECAPA

```bash
source scripts/install-onnxruntime-android.sh
# then flutter build apk (cargokit picks up ecapa automatically)
```

## Follow-ups

- Rust #1213 operation log ownership (Dart interim log today)
- Vault encryption wrapper for content blobs
- iOS cargokit ECAPA parity (macOS pod still whisper-only unless ORT installed)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a00604-29c4-7777-b4de-f94c24e30a99?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a00604-29c4-7777-b4de-f94c24e30a99&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

