### PR TITLE
test(mind): macOS verify script + Rust runtime E2E

### DIFF
--- a/app/tool/run_mind_macos.sh
+++ b/app/tool/run_mind_macos.sh
@@ -46,6 +46,8 @@ echo "==> Generating feature_mind code"
 (cd "$ROOT/packages/feature_mind" && flutter pub get && dart run build_runner build)
 
 echo "==> Building (cargokit compiles the Rust as part of this)"
+# Optional preflight (Rust vault/notes/replay + macOS compile):
+#   scripts/verify-mind-macos-e2e.sh
 # Flavors are separate pubspecs in this repo, so selecting one means swapping
 # the file. Restored on exit, including on failure.
 cp app/pubspec_mind.yaml app/pubspec.yaml

--- a/rust/airo_mind_whisper/src/mind_runtime_state.rs
+++ b/rust/airo_mind_whisper/src/mind_runtime_state.rs
@@ -902,3 +902,90 @@ fn runtime_state() -> Result<Arc<MindRuntimeState>, String> {
 fn lock_runtime() -> std::sync::MutexGuard<'static, Option<Arc<MindRuntimeState>>> {
     MIND_RUNTIME.lock().unwrap_or_else(|e| e.into_inner())
 }
+
+#[cfg(test)]
+mod e2e_tests {
+    use super::*;
+    use std::io::Write;
+
+    fn temp_mind_dir(name: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!(
+            "airo_mind_runtime_e2e_{}_{}",
+            name,
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).expect("temp dir");
+        dir
+    }
+
+    fn write_legacy_notes_log(path: &Path) {
+        let file = File::create(path).expect("notes.log");
+        let mut file = file;
+        writeln!(
+            file,
+            r#"{{"seq":0,"kind":"create","id":"note-1","title":"Hello","body":"World","recordedAtMs":1000}}"#
+        )
+        .expect("write");
+        writeln!(
+            file,
+            r#"{{"seq":1,"kind":"edit","id":"note-1","title":"Hello","body":"Updated","recordedAtMs":2000}}"#
+        )
+        .expect("write");
+        file.flush().expect("flush");
+    }
+
+    #[test]
+    fn mind_runtime_vault_notes_replay_end_to_end() {
+        let base = temp_mind_dir("core");
+        write_legacy_notes_log(&base.join("notes.log"));
+
+        open_mind_runtime(base.to_str().expect("utf8 path")).expect("open");
+
+        let vault = vault_state().expect("vault state");
+        assert!(vault.is_sealed);
+        assert!(vault.key_count >= 1);
+
+        let devices = vault_devices().expect("devices");
+        assert!(!devices.is_empty());
+        assert!(devices.iter().any(|d| d.is_this_device));
+
+        let notes_raw = notes_json().expect("notes json");
+        assert!(notes_raw.contains("note-1"));
+        assert!(notes_raw.contains("Updated"));
+
+        create_note(
+            "note-2".to_string(),
+            "Second".to_string(),
+            "Body".to_string(),
+            3000,
+        )
+        .expect("create note");
+        let after_create = notes_json().expect("notes after create");
+        assert!(after_create.contains("note-2"));
+
+        let seq1 = append_scribe_op(
+            "inference".to_string(),
+            "First".to_string(),
+            "ctx-1".to_string(),
+            "detail-a".to_string(),
+        )
+        .expect("append 1");
+        let seq2 = append_scribe_op(
+            "inference".to_string(),
+            "Second".to_string(),
+            "ctx-2".to_string(),
+            "detail-b".to_string(),
+        )
+        .expect("append 2");
+        assert_eq!(scribe_op_count().expect("count"), 2);
+
+        let replay_tail = replay_from(seq2).expect("replay from seq2");
+        assert!(!replay_tail.is_empty());
+        assert_eq!(replay_tail.last().copied(), Some(1.0));
+
+        let replay_mid = replay_from(seq1).expect("replay from seq1");
+        assert!(replay_mid.len() >= 2);
+        assert_eq!(replay_mid.last().copied(), Some(1.0));
+    }
+}

--- a/scripts/verify-mind-macos-e2e.sh
+++ b/scripts/verify-mind-macos-e2e.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# Verifies Mind runtime follow-ups end-to-end on macOS (vault, notes, replay, ECAPA build).
+#
+# Run on your Mac after merging #1810 / mind-followups:
+#   scripts/verify-mind-macos-e2e.sh
+#
+# Optional: full UI journey with models (~570 MB first run):
+#   scripts/verify-mind-macos-e2e.sh --journey
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+RUN_JOURNEY=false
+if [[ "${1:-}" == "--journey" ]]; then
+  RUN_JOURNEY=true
+fi
+
+if [[ "$(uname -s)" != "Darwin" ]]; then
+  echo "This script targets macOS (Darwin). On Linux use the Rust test only:" >&2
+  echo "  cd rust && cargo +1.88.0 test -p airo_mind_whisper --features whisper mind_runtime_vault_notes_replay_end_to_end" >&2
+  exit 1
+fi
+
+export FRB_TOOLCHAIN="${FRB_TOOLCHAIN:-1.88.0}"
+export PATH="${HOME}/.cargo/bin:${PATH}"
+
+echo "==> 1/5 Rust mind runtime E2E (vault, notes migration, replayFrom)"
+cd "${ROOT}/rust"
+cargo "+${FRB_TOOLCHAIN}" test -p airo_mind_whisper --features whisper mind_runtime_vault_notes_replay_end_to_end
+
+echo "==> 2/5 FRB bindings in sync"
+"${ROOT}/scripts/check-mind-whisper-frb.sh"
+
+echo "==> 3/5 ONNX Runtime macOS (ECAPA link check)"
+# shellcheck source=/dev/null
+source "${ROOT}/scripts/install-onnxruntime.sh"
+"${ROOT}/scripts/build-whisper-ecapa-desktop.sh"
+
+echo "==> 4/5 feature_mind unit tests (notes + runtime)"
+cd "${ROOT}/packages/feature_mind"
+flutter pub get
+flutter test test/notes/ test/runtime/rust_mind_runtime_test.dart --plain-name "the failure is per port" --plain-name "every unimplemented" 2>/dev/null || \
+  flutter test test/notes/
+
+echo "==> 5/5 Mind shell compile (macOS)"
+"${ROOT}/app/tool/fetch_mind_models.sh"
+cd "${ROOT}/packages/feature_mind"
+dart run build_runner build --delete-conflicting-outputs
+cd "${ROOT}/app"
+cp pubspec_mind.yaml pubspec.yaml
+trap 'git -C "${ROOT}" checkout app/pubspec.yaml app/pubspec.lock 2>/dev/null || true' EXIT
+flutter pub get
+flutter build macos -t lib/main_mind.dart
+
+if [[ "${RUN_JOURNEY}" == "true" ]]; then
+  echo "==> Optional device journey (models + transcribe pipeline)"
+  cp "${ROOT}/app/analysis_options_mind.yaml" "${ROOT}/app/analysis_options.yaml"
+  JFK="${ROOT}/rust/fixtures/jfk.wav"
+  if [[ ! -f "${JFK}" ]]; then
+    echo "Missing ${JFK} — fetch fixtures or pass AIRO_MIND_DEVICE_RECORD=true" >&2
+    exit 1
+  fi
+  export AIRO_MIND_WAV_PATH="${JFK}"
+  flutter test integration_test/mind_journey_device_test.dart \
+    --dart-define=APP_VARIANT=mind \
+    --dart-define=AIRO_RUN_MIND_JOURNEY=true \
+    -d macos
+fi
+
+cat <<'EOF'
+
+✓ macOS verification passed (Rust runtime, FRB, ECAPA build, Mind macOS compile).
+
+Manual UI checks (launch Mind shell):
+  app/tool/run_mind_macos.sh
+
+Then verify in the app:
+  • Record a short meeting → transcript + minutes save (scribe op log → Rust)
+  • Devices surface → vault shows "This device" with fingerprint groups
+  • Notes (if routed in shell) → create/edit persists across restart
+  • Runtime console → right-click op row → replayFrom shows progress
+
+Speaker enrollment (#504) needs ECAPA model on disk; install via Models tab
+or app/tool/fetch_mind_models.sh, then enroll a speaker in a meeting.
+
+EOF

--- a/scripts/verify-mind-macos-e2e.sh
+++ b/scripts/verify-mind-macos-e2e.sh
@@ -1,32 +1,75 @@
 #!/usr/bin/env bash
-# Verifies Mind runtime follow-ups end-to-end on macOS (vault, notes, replay, ECAPA build).
+# Verifies Mind runtime follow-ups end-to-end (vault, notes, replay, ECAPA build).
 #
-# Run on your Mac after merging #1810 / mind-followups:
+# macOS (full native stack):
 #   scripts/verify-mind-macos-e2e.sh
+#   scripts/verify-mind-macos-e2e.sh --journey   # + transcribe pipeline (~570 MB)
 #
-# Optional: full UI journey with models (~570 MB first run):
-#   scripts/verify-mind-macos-e2e.sh --journey
+# Linux / CI (Rust runtime + optional browser smoke):
+#   scripts/verify-mind-macos-e2e.sh --linux
+#   scripts/verify-mind-macos-e2e.sh --linux --browser
+#
+# After automated checks pass on macOS, launch the GUI for manual UI proof:
+#   app/tool/run_mind_macos.sh
+#
+# Known gaps (not covered here — separate follow-ups):
+#   • Qwen 0.5B cannot summarize 74+ min transcripts (2048 ctx; needs chunking).
+#   • Whisper tiny loops on long meetings; use small/base + chunking for prod quality.
+#   • Speaker enroll (#504) and Devices (#1592) need on-device GUI verification.
 
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 RUN_JOURNEY=false
-if [[ "${1:-}" == "--journey" ]]; then
-  RUN_JOURNEY=true
-fi
+RUN_LINUX=false
+RUN_BROWSER=false
 
-if [[ "$(uname -s)" != "Darwin" ]]; then
-  echo "This script targets macOS (Darwin). On Linux use the Rust test only:" >&2
-  echo "  cd rust && cargo +1.88.0 test -p airo_mind_whisper --features whisper mind_runtime_vault_notes_replay_end_to_end" >&2
-  exit 1
-fi
+for arg in "$@"; do
+  case "$arg" in
+    --journey) RUN_JOURNEY=true ;;
+    --linux) RUN_LINUX=true ;;
+    --browser) RUN_BROWSER=true ;;
+    --help|-h)
+      sed -n '2,20p' "$0" | sed 's/^# \{0,1\}//'
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $arg (try --help)" >&2
+      exit 1
+      ;;
+  esac
+done
 
 export FRB_TOOLCHAIN="${FRB_TOOLCHAIN:-1.88.0}"
 export PATH="${HOME}/.cargo/bin:${PATH}"
 
-echo "==> 1/5 Rust mind runtime E2E (vault, notes migration, replayFrom)"
-cd "${ROOT}/rust"
-cargo "+${FRB_TOOLCHAIN}" test -p airo_mind_whisper --features whisper mind_runtime_vault_notes_replay_end_to_end
+run_rust_e2e() {
+  echo "==> Rust mind runtime E2E (vault, notes migration, replayFrom)"
+  cd "${ROOT}/rust"
+  cargo "+${FRB_TOOLCHAIN}" test -p airo_mind_whisper --features whisper mind_runtime_vault_notes_replay_end_to_end
+}
+
+if [[ "${RUN_LINUX}" == "true" ]] || [[ "$(uname -s)" != "Darwin" ]]; then
+  run_rust_e2e
+  if [[ "${RUN_BROWSER}" == "true" ]]; then
+    echo "==> Mind web smoke (Playwright)"
+    "${ROOT}/scripts/validate_airo_mind_browser.sh"
+  fi
+  cat <<'EOF'
+
+✓ Linux verification passed (Rust runtime E2E).
+
+For native vault UI, Devices surface, Notes persist, Runtime Console replayFrom,
+and speaker enroll (#504), run on macOS:
+  scripts/verify-mind-macos-e2e.sh
+  app/tool/run_mind_macos.sh
+
+EOF
+  exit 0
+fi
+
+echo "==> 1/5 Rust mind runtime E2E"
+run_rust_e2e
 
 echo "==> 2/5 FRB bindings in sync"
 "${ROOT}/scripts/check-mind-whisper-frb.sh"
@@ -36,11 +79,10 @@ echo "==> 3/5 ONNX Runtime macOS (ECAPA link check)"
 source "${ROOT}/scripts/install-onnxruntime.sh"
 "${ROOT}/scripts/build-whisper-ecapa-desktop.sh"
 
-echo "==> 4/5 feature_mind unit tests (notes + runtime)"
+echo "==> 4/5 feature_mind unit tests (notes)"
 cd "${ROOT}/packages/feature_mind"
 flutter pub get
-flutter test test/notes/ test/runtime/rust_mind_runtime_test.dart --plain-name "the failure is per port" --plain-name "every unimplemented" 2>/dev/null || \
-  flutter test test/notes/
+flutter test test/notes/
 
 echo "==> 5/5 Mind shell compile (macOS)"
 "${ROOT}/app/tool/fetch_mind_models.sh"
@@ -53,7 +95,7 @@ flutter pub get
 flutter build macos -t lib/main_mind.dart
 
 if [[ "${RUN_JOURNEY}" == "true" ]]; then
-  echo "==> Optional device journey (models + transcribe pipeline)"
+  echo "==> Optional journey (models + transcribe; use short audio — tiny loops on 70+ min)"
   cp "${ROOT}/app/analysis_options_mind.yaml" "${ROOT}/app/analysis_options.yaml"
   JFK="${ROOT}/rust/fixtures/jfk.wav"
   if [[ ! -f "${JFK}" ]]; then
@@ -69,18 +111,21 @@ fi
 
 cat <<'EOF'
 
-✓ macOS verification passed (Rust runtime, FRB, ECAPA build, Mind macOS compile).
+✓ macOS automated verification passed (Rust runtime, FRB, ECAPA build, Mind compile).
 
-Manual UI checks (launch Mind shell):
+Manual UI checklist — launch:
   app/tool/run_mind_macos.sh
 
-Then verify in the app:
-  • Record a short meeting → transcript + minutes save (scribe op log → Rust)
-  • Devices surface → vault shows "This device" with fingerprint groups
-  • Notes (if routed in shell) → create/edit persists across restart
-  • Runtime console → right-click op row → replayFrom shows progress
+  [ ] Scribe: record short meeting → transcript + minutes persist (#1213)
+  [ ] Devices: "This device" + fingerprint groups (#1592 / vault UI)
+  [ ] Notes: create → restart app → note still there (Rust notes log)
+  [ ] Runtime console: right-click op → replayFrom progress (#1216)
+  [ ] Speaker: enroll with ECAPA model → recognized in next meeting (#504)
 
-Speaker enrollment (#504) needs ECAPA model on disk; install via Models tab
-or app/tool/fetch_mind_models.sh, then enroll a speaker in a meeting.
+Long meetings (74 min Voice Memo): decode is fine; Whisper tiny loops after ~27 min
+and Qwen 0.5B exceeds 2048-token context — use larger ASR + chunked summarization.
+
+Optional browser smoke (shell routes, assistant catalog):
+  scripts/validate_airo_mind_browser.sh
 
 EOF


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Cherry-picks verification work that was left on `cursor/mind-followups-0a99` after #1810 merged.

## Adds

- **Rust E2E test** `mind_runtime_vault_notes_replay_end_to_end` in `mind_runtime_state.rs` — vault bootstrap, `notes.log` migration, notes CRUD, scribe append, `replay_from` progress.
- **`scripts/verify-mind-macos-e2e.sh`** — orchestrates automated checks on macOS (Rust, FRB, ECAPA build, Mind macOS compile, optional journey). **`--linux`** runs the Rust test; **`--linux --browser`** also runs `validate_airo_mind_browser.sh`.
- Pointer in `app/tool/run_mind_macos.sh` to run verify before GUI launch.

## Still manual on macOS (documented in script footer)

- Scribe save, Devices “This device”, Notes across restart, Runtime Console `replayFrom`, speaker enroll (#504).

## Out of scope (documented, not fixed here)

- Long meetings: Whisper tiny loops after ~27 min; Qwen 0.5B exceeds 2048 ctx on 74 min audio — needs larger ASR + chunked LLM follow-up.

## Verification

```bash
scripts/verify-mind-macos-e2e.sh --linux
cargo +1.88.0 test -p airo_mind_whisper --features whisper mind_runtime_vault_notes_replay_end_to_end
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a00604-29c4-7777-b4de-f94c24e30a99?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a00604-29c4-7777-b4de-f94c24e30a99&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

