### PR TITLE
fix(mind): macOS runtime surfaces for on-device verification

### DIFF
--- a/app/lib/main_mind.dart
+++ b/app/lib/main_mind.dart
@@ -102,7 +102,9 @@ Future<void> main() {
       registry = buildMindModuleRegistry();
       return ProviderScope(
         overrides: buildMindProviderOverrides(prefs: prefs, registry: registry),
-        child: AiroMindApp(registry: registry),
+        child: MindMacOsRoot(
+          child: AiroMindApp(registry: registry),
+        ),
       );
     },
     afterRunApp: () {
@@ -224,6 +226,28 @@ List<RouteBase> buildMindRoutes(ModuleRegistry registry) {
       name: 'register',
       builder: (context, state) => const RegisterScreen(),
     ),
+    GoRoute(
+      path: '/runtime',
+      name: 'mind_runtime_hub',
+      builder: (context, state) => const MindRuntimeHubScreen(),
+      routes: [
+        GoRoute(
+          path: 'devices',
+          name: 'mind_runtime_devices',
+          builder: (context, state) => const MindRuntimeDevicesScreen(),
+        ),
+        GoRoute(
+          path: 'notes',
+          name: 'mind_runtime_notes',
+          builder: (context, state) => const MindRuntimeNotesScreen(),
+        ),
+        GoRoute(
+          path: 'console',
+          name: 'mind_runtime_console',
+          builder: (context, state) => const MindRuntimeConsoleScreen(),
+        ),
+      ],
+    ),
     StatefulShellRoute.indexedStack(
       builder: (context, state, navigationShell) =>
           MindShell(navigationShell: navigationShell),
@@ -274,7 +298,14 @@ class _AiroMindAppState extends State<AiroMindApp> {
   late final GoRouter _router = buildMindRouter(registry: widget.registry);
 
   @override
+  void initState() {
+    super.initState();
+    MindRuntimeNavigation.openHub = () => _router.go('/runtime');
+  }
+
+  @override
   void dispose() {
+    MindRuntimeNavigation.openHub = null;
     // The registry owns module teardown, and MindModule's is real work: it
     // releases the microphone and the loaded models. `State.dispose` cannot
     // await, so this is fire-and-forget — the shell is going away either way.

--- a/app/tool/fetch_mind_models.sh
+++ b/app/tool/fetch_mind_models.sh
@@ -38,6 +38,7 @@ MODELS=(
   "ggml-tiny.en.bin|921e4cf8686fdd993dcd081a5da5b6c365bfde1162e72b08d75ac75289920b1f|https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-tiny.en.bin"
   "ggml-tiny.bin|be07e048e1e599ad46341c8d2a135645097a538221678b7acdd1b1919c6e1b21|https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-tiny.bin"
   "qwen2.5-0.5b-instruct-q4_k_m.gguf|74a4da8c9fdbcd15bd1f6d01d621410d31c6fc00986f5eb687824e7b93d7a9db|https://huggingface.co/Qwen/Qwen2.5-0.5B-Instruct-GGUF/resolve/main/qwen2.5-0.5b-instruct-q4_k_m.gguf"
+  "ecapa_tdnn_tiny_int8.onnx|f46380bbaeddb929fb3a10ab63a4b1877a50e3d1e5fdd55a1b618d5651d3f64e|https://huggingface.co/vedk00/ecapa-voxceleb-speaker-embedding-onnx/resolve/main/model/ecapa-speaker-v1.onnx"
 )
 
 digest_of() {

--- a/app/tool/run_mind_macos.sh
+++ b/app/tool/run_mind_macos.sh
@@ -35,7 +35,7 @@ sed -i '' 's/^PRODUCT_NAME = .*/PRODUCT_NAME = Airo Mind/' "$APP_INFO_XCCONFIG"
 # does not depend on platform_downloads (mobile-only) or a hot restart.
 MIND_SUPPORT="$HOME/Library/Containers/com.developerscoffee.airo.tv/Data/Library/Application Support/com.developerscoffee.airo.tv/airo_mind"
 mkdir -p "$MIND_SUPPORT"
-for model in ggml-tiny.en.bin ggml-tiny.bin qwen2.5-0.5b-instruct-q4_k_m.gguf; do
+for model in ggml-tiny.en.bin ggml-tiny.bin qwen2.5-0.5b-instruct-q4_k_m.gguf ecapa_tdnn_tiny_int8.onnx; do
   src="$ROOT/packages/feature_mind/assets/models/$model"
   if [ -f "$src" ]; then
     cp -f "$src" "$MIND_SUPPORT/$model"

--- a/packages/feature_mind/lib/feature_mind.dart
+++ b/packages/feature_mind/lib/feature_mind.dart
@@ -277,6 +277,9 @@ export 'src/surfaces/mind_home_surface.dart';
 export 'src/surfaces/portability_surface.dart';
 export 'src/surfaces/mind_surface_scaffold.dart';
 export 'src/surfaces/context_workspace_surface.dart';
+export 'src/surfaces/mind_runtime_hub_screen.dart';
+
+export 'src/widgets/mind_macos_root.dart';
 
 // The runtime skeleton (#1338): Operation → Persist → Replay → Projection
 // through a minimal Notes capability, proving the vertical slice end to end.

--- a/packages/feature_mind/lib/src/assistant/consent/mind_runtime_provider.dart
+++ b/packages/feature_mind/lib/src/assistant/consent/mind_runtime_provider.dart
@@ -7,9 +7,8 @@ import '../../runtime/mind_runtime.dart';
 /// The [MindRuntime] Audio Scribe (and, as they land, other assistant
 /// surfaces) writes operations against.
 ///
-/// Uses [ScribeMindRuntime] with a durable JSON-lines log shared with
-/// [MindService] (`sharedMindOperationLog`). `RustMindRuntime.log` remains
-/// unimplemented (#1213); this is the Wave 2 wire-up until that lands.
+/// Uses [ScribeMindRuntime] with [RustPreferredOperationLog] and
+/// [RustMindRuntimeVault] shared with [MindService] (`sharedMindOperationLog`).
 final mindRuntimeProvider = Provider<MindRuntime>(
   (ref) => ScribeMindRuntime(log: sharedMindOperationLog()),
 );

--- a/packages/feature_mind/lib/src/runtime/scribe_mind_runtime.dart
+++ b/packages/feature_mind/lib/src/runtime/scribe_mind_runtime.dart
@@ -8,21 +8,27 @@ import 'ports/operation_log_port.dart';
 import 'ports/portability_port.dart';
 import 'ports/projection_port.dart';
 import 'ports/vault_port.dart';
+import 'rust/rust_mind_runtime_vault.dart';
 
-/// Mind runtime for the standalone scribe shell: real durable log, fixture elsewhere.
+/// Mind runtime for the standalone scribe shell: Rust vault + op log, fixture elsewhere.
 ///
-/// Wave 2 wire-up until `RustMindRuntime.log` ships (#1213). Assistant consent
-/// and meeting IR extraction append to the same file [MindService] uses.
+/// [VaultPort] reads the vault opened when [MindService.initialize] boots the
+/// whisper library (`meetings::initialize` → `open_mind_runtime`). Contexts,
+/// projections, and mesh stay on fixtures until their issues land.
 class ScribeMindRuntime implements MindRuntime {
-  ScribeMindRuntime({required OperationLogPort log})
-    : _inner = FixtureMindRuntime(),
-      _log = log;
+  ScribeMindRuntime({
+    required OperationLogPort log,
+    VaultPort? vault,
+  }) : _inner = FixtureMindRuntime(),
+       _log = log,
+       _vault = vault ?? const RustMindRuntimeVault();
 
   final FixtureMindRuntime _inner;
   final OperationLogPort _log;
+  final VaultPort _vault;
 
   @override
-  VaultPort get vault => _inner.vault;
+  VaultPort get vault => _vault;
 
   @override
   OperationLogPort get log => _log;

--- a/packages/feature_mind/lib/src/runtime_console/runtime_console_availability.dart
+++ b/packages/feature_mind/lib/src/runtime_console/runtime_console_availability.dart
@@ -2,19 +2,15 @@ import 'package:flutter/foundation.dart';
 
 /// Whether the Runtime Console (surface 13) renders on this platform.
 ///
-/// The design puts the dense operator table on Windows and Linux only — macOS
-/// takes the platform-chrome "Everything Browser" instead (surface 8), and
-/// phone/tablet/web/TV never get a 12,000-row signed log table at all.
-/// Mirrors the platform-gating shape in `mind_availability.dart`: a plain
-/// function over `defaultTargetPlatform` rather than a widget that silently
-/// renders nothing, so a caller can branch on it before building anything.
+/// Windows, Linux, and macOS ship the dense operator table for local
+/// verification (`replayFrom`, #1216). Phone/tablet/web/TV use lighter surfaces.
 bool isRuntimeConsolePlatform([TargetPlatform? platform]) {
   if (kIsWeb) return false;
   switch (platform ?? defaultTargetPlatform) {
     case TargetPlatform.windows:
     case TargetPlatform.linux:
-      return true;
     case TargetPlatform.macOS:
+      return true;
     case TargetPlatform.android:
     case TargetPlatform.iOS:
     case TargetPlatform.fuchsia:

--- a/packages/feature_mind/lib/src/surfaces/mind_runtime_hub_screen.dart
+++ b/packages/feature_mind/lib/src/surfaces/mind_runtime_hub_screen.dart
@@ -1,0 +1,177 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:path/path.dart' as p;
+import 'package:path_provider/path_provider.dart';
+
+import '../assistant/consent/mind_runtime_provider.dart';
+import '../notes/domain/notes_operation_log.dart';
+import '../notes/notes_capability.dart';
+import '../notes/presentation/notes_screen.dart';
+import '../runtime_console/runtime_console_controller.dart';
+import '../runtime_console/runtime_console_table.dart';
+import 'devices_surface.dart';
+
+/// macOS / desktop entry for Wave 2 runtime surfaces used in on-device verification.
+///
+/// Scribe home stays minimal; Devices (#1592), Notes, and Runtime Console
+/// (#1216 `replayFrom`) live here until the Everything Browser wires them in.
+class MindRuntimeHubScreen extends ConsumerWidget {
+  const MindRuntimeHubScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Mind runtime')),
+      body: ListView(
+        children: [
+          ListTile(
+            leading: const Icon(Icons.devices),
+            title: const Text('Devices'),
+            subtitle: const Text('This device + vault fingerprints (#1592)'),
+            onTap: () => context.push('/runtime/devices'),
+          ),
+          ListTile(
+            leading: const Icon(Icons.edit_note),
+            title: const Text('Notes'),
+            subtitle: const Text('Rust notes log + restart persistence'),
+            onTap: () => context.push('/runtime/notes'),
+          ),
+          ListTile(
+            leading: const Icon(Icons.terminal),
+            title: const Text('Runtime console'),
+            subtitle: const Text('Right-click op → replayFrom (#1216)'),
+            onTap: () => context.push('/runtime/console'),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// Devices surface with a live wall clock for [DevicesSurface].
+class MindRuntimeDevicesScreen extends ConsumerWidget {
+  const MindRuntimeDevicesScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final runtime = ref.watch(mindRuntimeProvider);
+    return DevicesSurface(
+      runtime: runtime,
+      nowMs: DateTime.now().millisecondsSinceEpoch,
+      onBack: () => context.pop(),
+    );
+  }
+}
+
+/// Notes with Rust preferred path when Mind has booted.
+class MindRuntimeNotesScreen extends StatefulWidget {
+  const MindRuntimeNotesScreen({super.key});
+
+  @override
+  State<MindRuntimeNotesScreen> createState() => _MindRuntimeNotesScreenState();
+}
+
+class _MindRuntimeNotesScreenState extends State<MindRuntimeNotesScreen> {
+  NotesCapability? _capability;
+  Object? _error;
+
+  @override
+  void initState() {
+    super.initState();
+    unawaited(_open());
+  }
+
+  Future<void> _open() async {
+    try {
+      final base = await getApplicationSupportDirectory();
+      final path = p.join(base.path, 'airo_mind', 'notes.log');
+      final log = await NotesOperationLog.open(path);
+      if (!mounted) return;
+      setState(
+        () => _capability = NotesCapability.rustPreferred(log),
+      );
+    } on Object catch (error) {
+      if (!mounted) return;
+      setState(() => _error = error);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (_error != null) {
+      return Scaffold(
+        appBar: AppBar(title: const Text('Notes')),
+        body: Center(child: Text('Could not open notes log: $_error')),
+      );
+    }
+    if (_capability == null) {
+      return const Scaffold(
+        body: Center(child: CircularProgressIndicator()),
+      );
+    }
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Notes'),
+        leading: IconButton(
+          icon: const Icon(Icons.arrow_back),
+          onPressed: () => Navigator.of(context).maybePop(),
+        ),
+      ),
+      body: NotesScreen(capability: _capability!),
+    );
+  }
+}
+
+/// Runtime console backed by the shared [mindRuntimeProvider] log.
+class MindRuntimeConsoleScreen extends ConsumerStatefulWidget {
+  const MindRuntimeConsoleScreen({super.key});
+
+  @override
+  ConsumerState<MindRuntimeConsoleScreen> createState() =>
+      _MindRuntimeConsoleScreenState();
+}
+
+class _MindRuntimeConsoleScreenState
+    extends ConsumerState<MindRuntimeConsoleScreen> {
+  RuntimeConsoleController? _controller;
+  bool _initialized = false;
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    if (_initialized) return;
+    _initialized = true;
+    final log = ref.read(mindRuntimeProvider).log;
+    _controller = RuntimeConsoleController(log: log);
+    unawaited(_controller!.loadInitial());
+  }
+
+  @override
+  void dispose() {
+    _controller?.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final controller = _controller;
+    if (controller == null) {
+      return const Scaffold(
+        body: Center(child: CircularProgressIndicator()),
+      );
+    }
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Runtime console'),
+        leading: IconButton(
+          icon: const Icon(Icons.arrow_back),
+          onPressed: () => Navigator.of(context).maybePop(),
+        ),
+      ),
+      body: RuntimeConsoleTable(controller: controller),
+    );
+  }
+}

--- a/packages/feature_mind/lib/src/widgets/mind_macos_root.dart
+++ b/packages/feature_mind/lib/src/widgets/mind_macos_root.dart
@@ -1,0 +1,44 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../assistant/consent/mind_runtime_provider.dart';
+import 'mind_command_palette_scope.dart';
+import 'mind_native_menu_bar.dart';
+
+/// macOS chrome for the standalone Mind shell: native menu bar + ⌘K palette.
+///
+/// Wraps at the app root so File/Edit/Window actions and the Everything
+/// Browser are reachable from every destination (#1461).
+class MindMacOsRoot extends ConsumerStatefulWidget {
+  const MindMacOsRoot({super.key, required this.child});
+
+  final Widget child;
+
+  @override
+  ConsumerState<MindMacOsRoot> createState() => _MindMacOsRootState();
+}
+
+class _MindMacOsRootState extends ConsumerState<MindMacOsRoot> {
+  final _paletteKey = GlobalKey<MindCommandPaletteScopeState>();
+
+  bool get _useMacChrome =>
+      !kIsWeb && defaultTargetPlatform == TargetPlatform.macOS;
+
+  @override
+  Widget build(BuildContext context) {
+    if (!_useMacChrome) return widget.child;
+
+    final runtime = ref.watch(mindRuntimeProvider);
+    return MindCommandPaletteScope(
+      key: _paletteKey,
+      runtime: runtime,
+      child: MindNativeMenuBar(
+        runtime: runtime,
+        onOpenEverythingBrowser: () =>
+            _paletteKey.currentState?.openPalette(),
+        child: widget.child,
+      ),
+    );
+  }
+}

--- a/packages/feature_mind/lib/src/widgets/mind_native_menu_bar.dart
+++ b/packages/feature_mind/lib/src/widgets/mind_native_menu_bar.dart
@@ -6,6 +6,11 @@ import 'package:flutter/services.dart';
 import '../runtime/mind_runtime.dart';
 import '../runtime/models/log_models.dart';
 
+/// Optional navigation hook for shell routes the menu bar cannot import.
+abstract final class MindRuntimeNavigation {
+  static void Function()? openHub;
+}
+
 /// The macOS native menu bar for a Mind surface.
 ///
 /// File, Edit, Capture, Context, Model, Window, Help — the design's own list.
@@ -109,6 +114,13 @@ class MindNativeMenuBar extends StatelessWidget {
               label: 'Everything Browser',
               shortcut: _summonShortcut,
               onSelected: onOpenEverythingBrowser,
+            ),
+            PlatformMenuItem(
+              label: 'Mind Runtime…',
+              onSelected: () {
+                // Shell-owned route — menu cannot import go_router here.
+                MindRuntimeNavigation.openHub?.call();
+              },
             ),
           ],
         ),

--- a/rust/airo_mind_cli/src/main.rs
+++ b/rust/airo_mind_cli/src/main.rs
@@ -43,6 +43,10 @@ fn summarize_prompt(transcript: &str) -> String {
     )
 }
 
+/// Qwen 0.5B in the legacy dev loop uses a 2048-token context. Full meeting
+/// transcripts exceed that; chunked POC-2 extraction stays within budget.
+const LEGACY_MAX_TRANSCRIPT_CHARS: usize = 6000;
+
 fn validate_models(
     audio: &std::path::Path,
     whisper_model: &std::path::Path,
@@ -135,6 +139,31 @@ fn run_legacy(args: &CliArgs, whisper_model: &std::path::Path, llama_model: &std
     if transcript.trim().is_empty() {
         eprintln!("\nwhisper produced no text -- nothing to feed the LLM, stopping here.");
         std::process::exit(1);
+    }
+
+    if transcript.len() > LEGACY_MAX_TRANSCRIPT_CHARS {
+        println!(
+            "\n-- transcript is {} chars; running chunked meeting pipeline (use --out for artifacts) --",
+            transcript.len()
+        );
+        let poc_args = CliArgs {
+            audio: args.audio.clone(),
+            models_dir: args.models_dir.clone(),
+            out: None,
+            skip_eval: true,
+            meeting_id: args.meeting_id.clone(),
+            golden_transcript: None,
+            golden_ir: None,
+            golden_mom: None,
+            help: false,
+        };
+        let output = run_poc2(&poc_args, whisper_model, llama_model);
+        println!("\n== minutes of meeting (chunked) ==\n");
+        println!("{}", output.mom);
+        println!("\n== done ==");
+        println!("transcript chars: {}", transcript.len());
+        println!("mom chars:        {}", output.mom.len());
+        return;
     }
 
     println!("\n-- loading llama.cpp (Metal) --");

--- a/scripts/verify-mind-macos-e2e.sh
+++ b/scripts/verify-mind-macos-e2e.sh
@@ -116,14 +116,18 @@ cat <<'EOF'
 Manual UI checklist — launch:
   app/tool/run_mind_macos.sh
 
-  [ ] Scribe: record short meeting → transcript + minutes persist (#1213)
+  Window > Mind Runtime… (or /runtime):
   [ ] Devices: "This device" + fingerprint groups (#1592 / vault UI)
   [ ] Notes: create → restart app → note still there (Rust notes log)
   [ ] Runtime console: right-click op → replayFrom progress (#1216)
+
+  Scribe tab:
+  [ ] Record short meeting → transcript + minutes persist (#1213)
   [ ] Speaker: enroll with ECAPA model → recognized in next meeting (#504)
 
-Long meetings (74 min Voice Memo): decode is fine; Whisper tiny loops after ~27 min
-and Qwen 0.5B exceeds 2048-token context — use larger ASR + chunked summarization.
+Long meetings (74 min Voice Memo): decode is fine; prefer small/base ASR +
+chunked LLM (--out / GUI meeting intelligence). Legacy CLI auto-chunks when
+transcript exceeds Qwen context.
 
 Optional browser smoke (shell routes, assistant catalog):
   scripts/validate_airo_mind_browser.sh


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Unblocks Mac GUI verification for merged Wave 2 runtime work (#504, #1592, #1216) by wiring real Rust vault data into the Mind shell and exposing verification surfaces in the macOS app.

## Changes

- **ScribeMindRuntime** uses `RustMindRuntimeVault` (vault opens when `MindService.initialize` runs) instead of fixture vault data.
- **Runtime hub** at `/runtime` with Devices, Notes (Rust-preferred), and Runtime console routes; reachable via Window → Mind Runtime…
- **macOS chrome**: `MindMacOsRoot` wraps the Mind shell with native menu bar + ⌘K Everything Browser.
- **Runtime console on macOS** enabled for `replayFrom` UI proof (#1216).
- **ECAPA model** added to `fetch_mind_models.sh` and copied in `run_mind_macos.sh` for speaker enroll (#504).
- **CLI legacy path**: auto-runs chunked POC-2 when transcript exceeds Qwen 0.5B context instead of panicking.
- Updated `verify-mind-macos-e2e.sh` manual checklist.

## Mac verification steps

```bash
scripts/verify-mind-macos-e2e.sh
app/tool/run_mind_macos.sh
```

Then: Window → **Mind Runtime…** (or navigate to `/runtime`) and complete the checklist in the verify script.

## Test plan

- [x] `scripts/verify-mind-macos-e2e.sh --linux`
- [x] `flutter test` runtime console + devices surface tests
- [x] `dart analyze` on touched Dart files
- [ ] Full `scripts/verify-mind-macos-e2e.sh` on macOS
- [ ] Manual UI checklist (Devices, Notes, replayFrom, Scribe, speaker enroll)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a00604-29c4-7777-b4de-f94c24e30a99?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a00604-29c4-7777-b4de-f94c24e30a99&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

