### PR TITLE
Prepare v0.0.7-preview: unblock Rust CI and version bump

### DIFF
--- a/.github/workflows/release-orchestrator.yml
+++ b/.github/workflows/release-orchestrator.yml
@@ -8,17 +8,17 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Release version label, for example v0.0.6'
+        description: 'Release version label, for example v0.0.7-preview'
         required: true
-        default: 'airo-tv-v0.0.6'
+        default: 'v0.0.7-preview'
       build_name:
-        description: 'Android versionName, for example 0.0.6'
+        description: 'Android versionName, for example 0.0.7-preview'
         required: true
-        default: '0.0.6'
+        default: '0.0.7-preview'
       build_number:
         description: 'Android versionCode shared by Android artifacts'
         required: true
-        default: '8'
+        default: '12'
       release_ref:
         description: 'Git ref to release; must be based on origin/main'
         required: true
@@ -26,7 +26,7 @@ on:
       release_branch:
         description: 'Release branch to create/update from release_ref'
         required: true
-        default: 'release/airo-tv-v0.0.6'
+        default: 'release/v0.0.7-preview'
       dry_run:
         description: 'Build and upload workflow artifacts without public/store publishing'
         required: true
@@ -133,9 +133,9 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  DEFAULT_VERSION: airo-tv-v0.0.6
-  DEFAULT_BUILD_NAME: 0.0.6
-  DEFAULT_BUILD_NUMBER: '8'
+  DEFAULT_VERSION: v0.0.7-preview
+  DEFAULT_BUILD_NAME: 0.0.7-preview
+  DEFAULT_BUILD_NUMBER: '12'
 
 jobs:
   prepare:

--- a/.github/workflows/rust-core.yml
+++ b/.github/workflows/rust-core.yml
@@ -39,12 +39,19 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ hashFiles('rust/Cargo.lock') }}
           restore-keys: ${{ runner.os }}-cargo-
 
-      - run: cargo test --manifest-path rust/Cargo.toml --all
-      - run: cargo clippy --manifest-path rust/Cargo.toml --all -- -D warnings
-      # `--all` is required now that the workspace has more than one member.
-      # Without it, cargo fmt looks for a package in the working directory,
-      # finds a virtual manifest, and exits with "Failed to find targets" --
-      # which reads like a broken checkout rather than a missing flag.
+      # `--workspace` is required on a virtual manifest. `--exclude airo_mind_cli`
+      # is required because that bin statically links whisper.cpp and llama.cpp
+      # in one image; each vendors ggml under the same symbol names, and Linux
+      # lld refuses the duplicate (see rust/airo_mind_cli/README.md). macOS ld
+      # is lenient, which is why the local dev loop still builds on this Mac.
+      # Engines stay independently testable via their own packages.
+      - run: cargo test --manifest-path rust/Cargo.toml --workspace --exclude airo_mind_cli
+      - run: cargo clippy --manifest-path rust/Cargo.toml --workspace --exclude airo_mind_cli -- -D warnings
+      # `--all`/`--workspace` is required now that the workspace has more than
+      # one member. Without it, cargo fmt looks for a package in the working
+      # directory, finds a virtual manifest, and exits with "Failed to find
+      # targets" -- which reads like a broken checkout rather than a missing
+      # flag. fmt does not link, so the CLI stays included.
       - run: cargo fmt --manifest-path rust/Cargo.toml --all --check
 
       # ECAPA ONNX tests — optional feature, requires preinstalled ORT (no download-binaries).
@@ -63,8 +70,8 @@ jobs:
           scripts/check-mind-whisper-frb.sh
 
       # Runtime v1 condition 9 (#1311, tracked on #1340): "every runtime
-      # contract has automated conformance tests." `cargo test --all` above
-      # already runs these as ordinary tests -- this step is the mechanical
+      # contract has automated conformance tests." `cargo test --workspace`
+      # above already runs these as ordinary tests -- this step is the mechanical
       # gate on top of that: it *discovers* every `tests/*conformance*.rs`
       # file in the workspace structurally (so a new one lands covered
       # without editing this workflow) and reports which of the spec's S1-S5
@@ -210,4 +217,6 @@ jobs:
           key: desktop-${{ matrix.os }}-cargo-${{ hashFiles('rust/Cargo.lock') }}
           restore-keys: desktop-${{ matrix.os }}-cargo-
 
-      - run: cargo build --release --manifest-path rust/Cargo.toml --all
+      # Same ggml ODR exclusion as test-host: the CLI is a macOS-lenient
+      # combined link and must not be part of Linux/Windows `--workspace`.
+      - run: cargo build --release --manifest-path rust/Cargo.toml --workspace --exclude airo_mind_cli

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,32 @@ All notable changes to this project are documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html) for public release tags.
 
+## v0.0.7-preview — unreleased
+
+Preview cut of the `0.0.7` line across Airo TV, the full app, Airo Coins, and
+macOS TV. Prepared notes: [docs/release/AIRO_v0.0.7-preview.md](docs/release/AIRO_v0.0.7-preview.md).
+Not tagged until Rust Core CI is green on the freeze SHA.
+
+### Added
+
+- Unified live playlist merge across M3U, Xtream, and Stalker sources.
+- Coins embeddings auto-categorization, recurrence/anomaly detection, and
+  `DraftConfirmCard`.
+- Meeting IR / MoM / speaker enrollment land in the full app behind
+  Under-qualification copy. No standalone Mind APK.
+
+### Fixed
+
+- Airo TV BACK on the channel-browse grid after playback (#1430).
+- Rust Core CI no longer links `airo_mind_cli` into Linux workspace
+  `--workspace` jobs (whisper.cpp / llama.cpp ggml duplicate symbols).
+
+### Known issues
+
+- #1240 Airo Coins can open to a persistent black screen on Pixel 9 / Android 17.
+- #1243 Fire TV live playback emits repeated vendor property-denial log errors.
+- #1023 macOS mini-player Watch does not open fullscreen.
+
 ## v0.0.6 — 2026-08-04
 
 Stable cut of the `0.0.6` line across Airo TV, the full app, Airo Coins, and

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 0.0.6+10
+version: 0.0.7-preview+12
 
 environment:
   sdk: ">=3.12.2 <4.0.0"

--- a/app/pubspec_coins.yaml
+++ b/app/pubspec_coins.yaml
@@ -1,7 +1,7 @@
 name: airo_app
 description: "Airo Coins - focused local-first finance vault"
 publish_to: none
-version: 0.0.6+11
+version: 0.0.7-preview+12
 
 environment:
   sdk: ">=3.12.2 <4.0.0"

--- a/app/pubspec_tv.yaml
+++ b/app/pubspec_tv.yaml
@@ -11,7 +11,7 @@
 name: airo_app
 description: "Airo TV - IPTV streaming for Android TV"
 publish_to: 'none'
-version: 0.0.6+10
+version: 0.0.7-preview+12
 
 environment:
   sdk: ">=3.12.2 <4.0.0"

--- a/docs/release/AIRO_TV_FEATURE_MATRIX.md
+++ b/docs/release/AIRO_TV_FEATURE_MATRIX.md
@@ -1,6 +1,7 @@
 # Airo TV Feature Matrix
 
-Current public release: [`airo-tv-v0.0.5`](https://github.com/DevelopersCoffee/airo/releases/tag/airo-tv-v0.0.5).
+Current public release: [`v0.0.6`](https://github.com/DevelopersCoffee/airo/releases/tag/v0.0.6).
+Next candidate: [`v0.0.7-preview`](./AIRO_v0.0.7-preview.md) (prepared, not tagged).
 
 | Feature | Status | Notes |
 | --- | --- | --- |
@@ -14,6 +15,7 @@ Current public release: [`airo-tv-v0.0.5`](https://github.com/DevelopersCoffee/a
 | XMLTV guide | Supported | User-configured XMLTV sources only; no bundled guide feed. |
 | Smart playlists and canonical channels | Supported | Local filtering and canonical identity matching help preserve personal organization across imports. |
 | Provider add-flows | Supported | User-authorized Xtream, Stalker, Jellyfin, and M3U sources. |
+| Unified live playlist merge | Under qualification | M3U, Xtream, and Stalker live sources merge into one browse list in 0.0.7-preview; device evidence is still being gathered. |
 | Channel health warmup | Supported | Visible channels are warmed with bounded async stream checks so unavailable streams can be signaled before playback. |
 | Picture-in-picture | Under qualification | Video-only PiP layout is test-covered; full device evidence is still being gathered. |
 | Phone-hosted TV streaming | Under qualification | Debug entry point and protocol tests exist; real phone-to-receiver dogfood is not yet complete. |

--- a/docs/release/AIRO_v0.0.7-preview.md
+++ b/docs/release/AIRO_v0.0.7-preview.md
@@ -1,0 +1,133 @@
+# Airo v0.0.7-preview — Preview Release
+
+Status: **prepared, not released** until a green freeze SHA is tagged.
+Preview (release-candidate) cut for **direct download / APKPure**, not a store
+submission. Google Play, App Store, Firebase App Distribution, iOS/iPadOS, and
+macOS notarization stay out of scope for this cut.
+
+Same four SKUs as [`v0.0.6`](./AIRO_v0.0.6.md). Standalone Airo Mind
+(`io.airo.app.mind`) is not an orchestrator leg.
+
+## Release wave (intended artifacts)
+
+| Profile | Package / bundle | Artifact | Version line |
+| --- | --- | --- | --- |
+| Android TV (`tv`) | `io.airo.app.tv` | `Airo-TV-0.0.7-preview.apk` + per-ABI APKs + AAB | `0.0.7-preview+12` |
+| Full app (`full`) | `io.airo.app` | `Airo-0.0.7-preview-12-arm64.apk` + AAB | `0.0.7-preview+12` |
+| Airo Coins (`coins`) | `io.airo.app.coins` | `AiroCoins-0.0.7-preview-12-arm64.apk` + AAB | `0.0.7-preview+12` |
+| macOS TV | `com.developerscoffee.airo.tv` | direct-download `.zip` / `.dmg` + Homebrew Cask | `0.0.7-preview` |
+
+Tag: `v0.0.7-preview`. Branch: `release/v0.0.7-preview`.
+`versionCode` is **12** so Android upgrades over Coins `0.0.6+11`.
+
+## Claim state
+
+Classify before any public copy. Merged code is not Available.
+
+| Surface | State | Notes |
+| --- | --- | --- |
+| Airo TV BACK after playback (#1430) | Available after Fire TV evidence | Closed in tree; attach Stick install + D-pad + BACK proof before calling it Available on the site. |
+| Unified live playlist merge (M3U / Xtream / Stalker) | Under qualification | In tree; needs Fire TV / Pixel playlist smoke. |
+| Cast splice-on-keyframe, 3-tile multiview, fold crease | Under qualification | Physical Device QA #1603 / #1601 / #1588 still open. |
+| Design-system pass across flavors | Under qualification | Visual, not a store listing claim. |
+| Meeting Intelligence already in 0.0.6 | Available (unchanged) | Record / transcribe / summarise / search as shipped in 0.0.6. |
+| New Mind work (Meeting IR, MoM, speaker learning, Indic, chat-over-meetings) | Under qualification | Rides in the full app. Do not advertise. #1592 still open. |
+| Coins embeddings auto-categorize / recurrence / anomaly | Under qualification | In tree; #1240 still open. |
+| Standalone Mind APK | Not adopted this wave | `ciBuild: false`, still `0.0.1+1`. |
+| Play / notarized macOS / Firebase testers | Deferred | #576, #803, #756, #585. |
+
+## Not in this release
+
+| Artifact / profile | Source | Status |
+| --- | --- | --- |
+| Airo Mind standalone (`mind`) | `app/pubspec_mind.yaml` | Not building in CI; public distribution deferred. |
+| iOS / iPadOS SPM | `ios-spm` | Deferred — no Apple developer account. |
+| Web validation | `web-validation` | Local/CI browser-engine validation only. |
+| Linux / Windows desktop | `app/linux`, `app/windows` | No release workflow. |
+| Production-signed Play upload | orchestrator Play tracks | Human blockers in `V2_HUMAN_IN_LOOP_BLOCKERS.md`. |
+| Notarized macOS | `#803` | `macos_require_notarization=false`. |
+
+## What is new since v0.0.6
+
+**Airo TV**
+
+- BACK on the channel-browse grid after returning from playback (#1430).
+- Unified live playlist merge across M3U, Xtream, and Stalker sources.
+- Cast splice-on-keyframe, hover-chrome zones, 3-tile multiview, fold crease rule.
+- Shared design-system typography, color, and spacing across flavors.
+
+**Airo (full app)**
+
+- Shared `AiroBootstrap` runner and a large dead-code / provider purge.
+- Web wasm leak gate on unsafe `dart.library.html` conditional imports.
+- Meeting Intelligence remains in the full app. New Mind surfaces listed above
+  ship in the binary as Under qualification, not as Available.
+
+**Airo Coins**
+
+- Embeddings-first auto-categorization, recurrence and anomaly detection, and
+  the shared `DraftConfirmCard` confirm step.
+- Store-asset name correction from the `0.0.6+11` dogfood bump, rebased onto
+  `+12`.
+
+**Airo Mind / AI (full app only)**
+
+- In-tree: Meeting IR, MoM generation, speaker enrollment / ECAPA, Indic
+  settings, chat-over-meetings, vault UI, macOS verify scripts.
+- Rust Core CI no longer links `airo_mind_cli` into the workspace `--workspace`
+  jobs. That bin still combines whisper.cpp and llama.cpp ggml copies; Linux
+  `lld` rejects it. The Flutter app keeps the two engines as separate cdylibs.
+
+## Known issues
+
+| Issue | Impact |
+| --- | --- |
+| #1240 | Airo Coins can open to a persistent black screen on Pixel 9 / Android 17. |
+| #1243 | Fire TV live playback emits repeated vendor property-denial errors in logcat; playback is unaffected. |
+| #1023 | `feature_iptv`: mini-player "Watch" does not open the fullscreen player on macOS. |
+| Rust ggml ODR | `airo_mind_cli` is excluded from Linux/Windows workspace CI. Local macOS `cargo build -p airo_mind_cli` remains the supported combined-engine loop. |
+
+#1430 and #1025 were open on the 0.0.6 notes and are closed in tree. Confirm on
+device before dropping them from public known-limitations copy.
+
+## Signing and upgrade chain
+
+Dogfood keystore (`production_signing=false` plus the four `DOGFOOD_*`
+secrets). Builds upgrade over other dogfood-signed builds, including `v0.0.6`,
+but **not** over production-signed releases.
+
+## Freeze and dispatch
+
+Do not tag until Rust Core CI and Continuous Integration are green on the
+freeze SHA.
+
+```text
+version:                 v0.0.7-preview
+build_name:              0.0.7-preview
+build_number:            12
+release_ref:             <freeze SHA>
+release_branch:          release/v0.0.7-preview
+dry_run:                 true first, then false
+publish_github_release:  false first, then true
+github_release_mode:     draft
+production_signing:      false
+mobile_profile:          full-and-coins
+macos_profile:           tv
+macos_require_notarization: false
+tv_play_track:           none
+mobile_play_track:       none
+firebase_distribution:   none
+```
+
+Preview bar before flipping the GitHub Release from draft to published
+prerelease: Fire TV Stick install + Leanback + BACK; Pixel 9 full-app launch
++ Coins home + Mind record/transcribe smoke; macOS TV app opens. Waive iPad
+soak in writing if timeboxed.
+
+## Related documents
+
+- [V2 release orchestrator](./V2_RELEASE_ORCHESTRATOR.md)
+- [v0.0.6 stable notes](./AIRO_v0.0.6.md)
+- [Airo TV feature matrix](./AIRO_TV_FEATURE_MATRIX.md)
+- [Human-in-loop blockers](./V2_HUMAN_IN_LOOP_BLOCKERS.md)
+- [Release checklist](./RELEASE_CHECKLIST.md)

--- a/docs/release/README.md
+++ b/docs/release/README.md
@@ -8,6 +8,8 @@ Documentation for Airo releases and version history.
 
 | Version | Date | Highlights |
 |---------|------|------------|
+| [Airo v0.0.7-preview](./AIRO_v0.0.7-preview.md) | prepared | TV BACK fix, playlist merge, Coins AI; Mind under qualification |
+| [Airo v0.0.6](./AIRO_v0.0.6.md) | 2026-08-04 | Aggregate TV / full / Coins / macOS TV wave |
 | [Airo TV v0.0.5](./AIRO_TV_v0.0.5.md) | 2026-07-22 | Product target consolidation, TV controls, filters, channel warmup |
 | [Airo TV v0.0.4](./AIRO_TV_v0.0.4.md) | 2026-07-22 | Search, favorites, guide setup, provider add-flows, diagnostics |
 | [Airo TV v0.0.2](./AIRO_TV_v0.0.2.md) | 2026-07-14 | Release trust update, checksums, clean assets, documentation |
@@ -17,7 +19,28 @@ Documentation for Airo releases and version history.
 
 ---
 
-## Latest Release: Airo TV v0.0.5
+## Latest public release: Airo v0.0.6
+
+Next candidate: [Airo v0.0.7-preview](./AIRO_v0.0.7-preview.md) (prepared, not tagged).
+
+### v0.0.6 highlights
+- **Four SKUs from one orchestrator wave** — Airo TV, full app, Airo Coins, macOS TV.
+- **Offline Meeting Intelligence MVP** in the full app — record, transcribe, summarise, search.
+- **Fire TV D-pad and title-safe** fixes from the 0.0.6-rc.1 soak.
+
+### Quick Links
+- [Airo v0.0.6 Notes](./AIRO_v0.0.6.md)
+- [Airo v0.0.7-preview Notes](./AIRO_v0.0.7-preview.md)
+- [Airo TV Release Template](./AIRO_TV_RELEASE_TEMPLATE.md)
+- [Airo TV Feature Matrix](./AIRO_TV_FEATURE_MATRIX.md)
+- [GitHub Releases](https://github.com/DevelopersCoffee/airo/releases)
+- [Download Airo TV APK](https://github.com/DevelopersCoffee/airo/releases/download/v0.0.6/Airo-TV-0.0.6.apk)
+- [Verify direct APK downloads](../../VERIFY_DOWNLOAD.md)
+- [Trust and transparency](../../TRUST.md)
+
+---
+
+## Previous: Airo TV v0.0.5
 
 ### New Features
 - **Focused product surface** - Airo TV is the active IPTV product target; obsolete Streaming/IPTV release targets are removed.
@@ -41,6 +64,8 @@ Documentation for Airo releases and version history.
 
 | Document | Description |
 |----------|-------------|
+| [Airo v0.0.7-preview](./AIRO_v0.0.7-preview.md) | Next candidate: TV BACK, playlist merge, Coins AI; prepared, not tagged |
+| [Airo v0.0.6](./AIRO_v0.0.6.md) | Aggregate TV / full / Coins / macOS TV stable wave |
 | [Airo TV v0.0.5](./AIRO_TV_v0.0.5.md) | Product target consolidation, TV controls, filters, channel warmup |
 | [Airo TV v0.0.4](./AIRO_TV_v0.0.4.md) | Search, favorites, guide setup, provider add-flows, diagnostics |
 | [Airo TV v0.0.2](./AIRO_TV_v0.0.2.md) | Professional release notes, checksums, limitations, installation |
@@ -82,7 +107,7 @@ Documentation for Airo releases and version history.
 
 - **GitHub Releases**: https://github.com/DevelopersCoffee/airo/releases
 - **GitHub Actions**: https://github.com/DevelopersCoffee/airo/actions
-- **Airo TV APK**: https://github.com/DevelopersCoffee/airo/releases/download/airo-tv-v0.0.5/Airo-TV-0.0.5.apk
+- **Airo TV APK**: https://github.com/DevelopersCoffee/airo/releases/download/v0.0.6/Airo-TV-0.0.6.apk
 
 ---
 

--- a/docs/release/VERSION_LINES.md
+++ b/docs/release/VERSION_LINES.md
@@ -97,8 +97,9 @@ device class, or store listing.
   are retained for history and are no longer minted per wave. Anything that
   resolves "the current Airo TV release" must therefore match on the published
   `Airo-TV-*` assets, not on the tag prefix.
-- The current release train advances from `airo-tv-v0.0.5` to the aggregate
-  `v0.0.6`.
+- The current release train is the aggregate `v0.0.6` line. The next
+  candidate is `v0.0.7-preview` (same four SKUs: TV, full, Coins, macOS TV).
+  `airo-tv-v*` tags are retained for history and are no longer minted per wave.
 - Treat package contracts, feature registry APIs, and build target manifests as
   V2 compatibility surfaces.
 

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -12,6 +12,23 @@ members = [
   "airo_mind_transcript",
   "airo_mind_whisper",
 ]
+# airo_mind_cli is a member so `cargo build -p airo_mind_cli` stays one command,
+# but it is not a default-member: it statically links both whisper.cpp and
+# llama.cpp ggml copies into one bin. Linux lld rejects that as duplicate
+# symbols; macOS ld picks a winner. `cd rust && cargo test` must not pull it
+# in. CI uses `--workspace --exclude airo_mind_cli` for the same reason.
+default-members = [
+  "airo_core",
+  "airo_mind",
+  "airo_mind_audio",
+  "airo_mind_core",
+  "airo_mind_diarize",
+  "airo_mind_eval",
+  "airo_mind_llama",
+  "airo_mind_meeting",
+  "airo_mind_transcript",
+  "airo_mind_whisper",
+]
 resolver = "2"
 
 # Measured by chief-performance-officer on Apple Silicon against the real

--- a/rust/airo_mind_cli/Cargo.toml
+++ b/rust/airo_mind_cli/Cargo.toml
@@ -17,6 +17,11 @@ airo_mind_diarize = { path = "../airo_mind_diarize" }
 airo_mind_eval = { path = "../airo_mind_eval" }
 airo_mind_meeting = { path = "../airo_mind_meeting" }
 airo_mind_transcript = { path = "../airo_mind_transcript" }
+# Both engines in one bin is an ODR conflict on Linux lld (duplicate ggml
+# symbols). macOS ld still links this for the local dev loop. Do not add this
+# package to `cargo test --workspace` / `cargo clippy --workspace` / Linux
+# `cargo build --release --workspace`. See README.md and rust/Cargo.toml
+# `default-members`.
 airo_mind_whisper = { path = "../airo_mind_whisper", features = ["whisper", "metal"] }
 airo_mind_llama = { path = "../airo_mind_llama", features = ["llama", "metal"] }
 serde = { version = "1", features = ["derive"] }

--- a/rust/airo_mind_cli/README.md
+++ b/rust/airo_mind_cli/README.md
@@ -110,11 +110,15 @@ above that block), and full LTO across two rlibs that each carry their own
 `flutter_rust_bridge`-generated `frb_generated` module (`airo_mind_whisper`
 and `airo_mind_llama`, both cdylib-shaped by design, statically linked into
 one bin here) fails at the bitcode-merge step with a duplicate-symbol error
-on `frb_dart_fn_deliver_output`. Not a regression from anything this crate
-does — the two libraries were never meant to share a link unit — and not
-worth chasing for a dev-only tool: `cargo build -p airo_mind_cli` (dev
-profile) links them fine and every model-load/inference cost dominates the
-missing optimization anyway.
+on `frb_dart_fn_deliver_output`. Linux `lld` also refuses the *dev* link:
+whisper.cpp and llama.cpp each vendor ggml under the same symbol names, so
+`cargo test --workspace` on Ubuntu emits `duplicate symbol: ggml_backend_*`.
+macOS `ld` is lenient and still produces a working local binary. The two
+libraries were never meant to share a link unit — that is why the Flutter
+app loads them as separate cdylibs. This crate stays a macOS-oriented
+dev-loop tool: `cargo build -p airo_mind_cli` (dev profile, this Mac) is the
+supported invocation. CI uses `--workspace --exclude airo_mind_cli`.
+Every model-load/inference cost dominates the missing optimization anyway.
 
 By default it uses:
 


### PR DESCRIPTION
## Summary
- Exclude `airo_mind_cli` from Linux/Windows workspace Cargo jobs so Rust Core CI can go green. That bin still statically links whisper.cpp and llama.cpp (duplicate ggml symbols); the Flutter app already loads them as separate cdylibs.
- Bump TV / full / Coins to `0.0.7-preview+12` and add prepared release notes. Same four SKUs as 0.0.6. New Mind and Coins-AI surfaces stay Under qualification.

## Test plan
- [ ] Rust Core CI green on this branch (`cargo test --workspace --exclude airo_mind_cli`)
- [ ] Continuous Integration green
- [ ] Confirm pubspecs are `0.0.7-preview+12` for TV, full, and Coins
- [ ] Do **not** tag or dispatch the orchestrator from this PR; freeze SHA comes after merge + green `main`


Made with [Cursor](https://cursor.com)