### PR TITLE
feat(mind): production Model Bench and Whisper RTFx protocol

### DIFF
--- a/docs/features/airo-mind/GENERATION_BENCH_PROTOCOL.md
+++ b/docs/features/airo-mind/GENERATION_BENCH_PROTOCOL.md
@@ -45,7 +45,16 @@ kernel work on a datacenter GPU, not llama.cpp decode on a phone.
 - Rust: `airo_mind_core::bench` (`run_generation_bench`, `aggregate`)
 - Dart: `packages/feature_mind/lib/src/model_bench/model_bench_protocol.dart`
 - Product port: `ModelPort.benchmark()` on `RustMindRuntime` — runs the
-  protocol when a `GenerationBenchRunner` is injected (production:
-  `BridgeGenerationBenchRunner` over a loaded llama engine). Stays
-  `MindPortUnavailable` rather than inventing tok/s when no runner is
-  present. `ModelPort.thermal()` probes `DeviceCapabilityService`.
+  protocol when a `GenerationBenchRunner` is injected. Production
+  (`mindRuntimeProvider` → `ScribeMindRuntime`) injects
+  `createProductionModelPort`: `LlamaGgufEngineController` for
+  load/unload and `LlamaGgufBenchRunner` for sampling.
+  - Desktop: llama.cpp `RuntimeStats` (prefill vs decode) after
+    `generateCompletion`.
+  - Android: wall-clock time to first chunk and chunk-rate for the rest
+    of the stream (`llama_flutter_android` has no `RuntimeStats` split).
+  Stays `MindPortUnavailable` rather than inventing tok/s when no runner
+  is present, the catalog id is unknown, or the artifact is not on disk.
+  `ModelPort.thermal()` probes `DeviceCapabilityService`.
+- Surface: `ModelManagementPanel` **Run bench** on resident/loaded rows;
+  **Load** puts a resident GGUF into inference memory first.

--- a/docs/features/airo-mind/GENERATION_BENCH_PROTOCOL.md
+++ b/docs/features/airo-mind/GENERATION_BENCH_PROTOCOL.md
@@ -40,10 +40,33 @@ What we deliberately do **not** port from Jan: CUDA events, L2 cache
 flush, dummy 4096² FP32 matmul, `ncu` as a CI tool. Those belong to custom
 kernel work on a datacenter GPU, not llama.cpp decode on a phone.
 
+## Speech RTFx
+
+Same warmup + median protocol; different headline. Whisper has no
+prefill/decode split. One timed `transcribe()` yields:
+
+`RTFx = wall_ms / audio_duration_ms`
+
+Below 1.0 is faster than real time (whisper.cpp's real-time factor). Empty
+PCM is rejected rather than reported as RTFx 0 (which would look infinitely
+fast). Peak RSS stays 0 unless the caller measured it — `airo_mind_core`
+stays std-only.
+
+The speech engine trait is **not** widened with `stats()`. The protocol owns
+the wall clock (`sample_speech_engine` / Dart `Stopwatch`) so every
+`SpeechEngine` implementor does not have to answer a measurement question.
+
+Production: `BridgeSpeechBenchRunner` times `MindSpeechBridge.transcribe`
+when `isReady()`, using a caller-supplied clip duration (WAV/recorder),
+never transcript timestamps. Not wired into `ModelPort` — that port is
+generation.
+
 ## Code
 
-- Rust: `airo_mind_core::bench` (`run_generation_bench`, `aggregate`)
+- Rust: `airo_mind_core::bench` (`run_generation_bench`, `run_speech_bench`,
+  `aggregate` / `aggregate_speech`)
 - Dart: `packages/feature_mind/lib/src/model_bench/model_bench_protocol.dart`
+  (generation) and `speech_bench_protocol.dart` (RTFx)
 - Product port: `ModelPort.benchmark()` on `RustMindRuntime` — runs the
   protocol when a `GenerationBenchRunner` is injected. Production
   (`mindRuntimeProvider` → `ScribeMindRuntime`) injects

--- a/packages/feature_mind/lib/feature_mind.dart
+++ b/packages/feature_mind/lib/feature_mind.dart
@@ -207,6 +207,7 @@ export 'src/runtime/models/vault_models.dart';
 export 'src/model_bench/model_bench_controller.dart';
 export 'src/model_bench/model_bench_display.dart';
 export 'src/model_bench/model_bench_protocol.dart';
+export 'src/model_bench/speech_bench_protocol.dart';
 
 // Runtime — the port milestone 19 implements against.
 export 'src/runtime/mind_runtime.dart';

--- a/packages/feature_mind/lib/src/assistant/consent/mind_runtime_provider.dart
+++ b/packages/feature_mind/lib/src/assistant/consent/mind_runtime_provider.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../model_bench/production_model_port.dart';
 import '../../runtime/persistent/persistent_operation_log.dart';
 import '../../runtime/scribe_mind_runtime.dart';
 import '../../runtime/mind_runtime.dart';
@@ -9,6 +10,11 @@ import '../../runtime/mind_runtime.dart';
 ///
 /// Uses [ScribeMindRuntime] with [RustPreferredOperationLog] and
 /// [RustMindRuntimeVault] shared with [MindService] (`sharedMindOperationLog`).
+/// [ModelPort] is the production GGUF-backed port (load + warmed median bench),
+/// not the fixture catalog.
 final mindRuntimeProvider = Provider<MindRuntime>(
-  (ref) => ScribeMindRuntime(log: sharedMindOperationLog()),
+  (ref) => ScribeMindRuntime(
+    log: sharedMindOperationLog(),
+    models: createProductionModelPort(),
+  ),
 );

--- a/packages/feature_mind/lib/src/bridges/mind_generation_bridge.dart
+++ b/packages/feature_mind/lib/src/bridges/mind_generation_bridge.dart
@@ -130,6 +130,10 @@ rust.MeetingMetricRecord toWhisperMetric(llama_mi.MeetingMetricRecord record) =>
 abstract interface class MindGenerationBridge {
   bool get isLoaded;
 
+  /// True when a generate() would hit a live engine, including one this
+  /// Dart instance did not itself load (the llama slot is process-global).
+  bool get isEngineReady;
+
   Future<void> ensureLoaded({
     required String modelsDir,
     required int memoryBudgetMb,
@@ -173,6 +177,16 @@ class RustMindGenerationBridge implements MindGenerationBridge {
 
   @override
   bool get isLoaded => _loaded;
+
+  @override
+  bool get isEngineReady {
+    if (_loaded) return true;
+    try {
+      return llama.isReady();
+    } on Object {
+      return false;
+    }
+  }
 
   @override
   Future<void> ensureLoaded({

--- a/packages/feature_mind/lib/src/model_bench/bridge_generation_bench_runner.dart
+++ b/packages/feature_mind/lib/src/model_bench/bridge_generation_bench_runner.dart
@@ -16,6 +16,9 @@ class BridgeGenerationBenchRunner implements GenerationBenchRunner {
 
   @override
   Future<GenerationBenchSample> sample() async {
+    if (!_bridge.isEngineReady) {
+      throw StateError('generation engine is not loaded');
+    }
     await _bridge
         .complete(prompt: prompt, maxOutputTokens: maxOutputTokens)
         .drain<void>();

--- a/packages/feature_mind/lib/src/model_bench/bridge_speech_bench_runner.dart
+++ b/packages/feature_mind/lib/src/model_bench/bridge_speech_bench_runner.dart
@@ -1,0 +1,39 @@
+import '../bridges/mind_speech_bridge.dart';
+import 'speech_bench_protocol.dart';
+import 'speech_bench_runner.dart';
+
+/// Drains one [MindSpeechBridge.transcribe] and times it on the Dart wall
+/// clock. [audioDurationMs] is the clip length the caller already knows
+/// (WAV header / recorder duration) — not inferred from transcript
+/// timestamps, which can be shorter than the file.
+class BridgeSpeechBenchRunner implements SpeechBenchRunner {
+  BridgeSpeechBenchRunner(
+    this._bridge, {
+    required this.wavPath,
+    required this.audioDurationMs,
+    this.language,
+  });
+
+  final MindSpeechBridge _bridge;
+  final String wavPath;
+  final int audioDurationMs;
+  final String? language;
+
+  @override
+  Future<SpeechBenchSample> sample() async {
+    if (!_bridge.isReady()) {
+      throw StateError('speech engine is not loaded');
+    }
+    if (audioDurationMs <= 0) {
+      throw StateError('audio duration is zero');
+    }
+    final sw = Stopwatch()..start();
+    await _bridge
+        .transcribe(wavPath: wavPath, language: language)
+        .drain<void>();
+    return SpeechBenchSample(
+      audioDurationMs: audioDurationMs,
+      wallMs: sw.elapsedMilliseconds,
+    );
+  }
+}

--- a/packages/feature_mind/lib/src/model_bench/generation_engine_controller.dart
+++ b/packages/feature_mind/lib/src/model_bench/generation_engine_controller.dart
@@ -1,0 +1,17 @@
+import 'package:core_ai/core_ai.dart' as core_ai;
+
+/// Loads a catalog GGUF into inference memory and unloads it.
+///
+/// Kept free of the generated llama bridge so [RustMindRuntime] can take an
+/// injected controller (tests, or [LlamaGgufEngineController] in production)
+/// without compiling FRB output into every ModelPort construction.
+abstract interface class GenerationEngineController {
+  bool get isLoaded;
+
+  /// Catalog id currently in inference memory, or null if none.
+  String? get loadedModelId;
+
+  Future<void> load(core_ai.OfflineModelInfo model);
+
+  Future<void> unload();
+}

--- a/packages/feature_mind/lib/src/model_bench/llama_gguf_bench_runner.dart
+++ b/packages/feature_mind/lib/src/model_bench/llama_gguf_bench_runner.dart
@@ -20,7 +20,7 @@ class LlamaGgufBenchRunner implements GenerationBenchRunner {
   final int maxOutputTokens;
 
   @override
-  Future<GenerationBenchSample> sample() {
+  Future<GenerationBenchSample> sample() async {
     if (!_gguf.isLoaded) {
       throw StateError('gguf_model_not_loaded');
     }

--- a/packages/feature_mind/lib/src/model_bench/llama_gguf_bench_runner.dart
+++ b/packages/feature_mind/lib/src/model_bench/llama_gguf_bench_runner.dart
@@ -1,0 +1,32 @@
+import '../services/llama_gguf_service.dart';
+import 'generation_bench_runner.dart';
+import 'model_bench_protocol.dart';
+
+/// Samples the GGUF engine currently loaded by [LlamaGgufService].
+///
+/// Desktop uses llama.cpp [RuntimeStats] (prefill vs decode). Android has no
+/// engine-side split, so the sample is wall-clock TTFT (first chunk) and a
+/// chunk-rate for decode — never a spec-sheet figure, and never invented
+/// when the engine is not loaded.
+class LlamaGgufBenchRunner implements GenerationBenchRunner {
+  LlamaGgufBenchRunner(
+    this._gguf, {
+    this.prompt = kModelBenchPrompt,
+    this.maxOutputTokens = kModelBenchMaxOutputTokens,
+  });
+
+  final LlamaGgufService _gguf;
+  final String prompt;
+  final int maxOutputTokens;
+
+  @override
+  Future<GenerationBenchSample> sample() {
+    if (!_gguf.isLoaded) {
+      throw StateError('gguf_model_not_loaded');
+    }
+    return _gguf.collectBenchSample(
+      prompt: prompt,
+      maxOutputTokens: maxOutputTokens,
+    );
+  }
+}

--- a/packages/feature_mind/lib/src/model_bench/llama_gguf_engine_controller.dart
+++ b/packages/feature_mind/lib/src/model_bench/llama_gguf_engine_controller.dart
@@ -1,0 +1,39 @@
+import 'package:core_ai/core_ai.dart' as core_ai;
+
+import '../services/llama_gguf_service.dart';
+import 'generation_engine_controller.dart';
+
+/// [GenerationEngineController] over the existing GGUF adapter.
+///
+/// Desktop load initialises the Rust llama slot ([DesktopGgufBackend]);
+/// Android load uses `llama_flutter_android`. Either path is enough for
+/// [LlamaGgufBenchRunner] to sample the same engine.
+class LlamaGgufEngineController implements GenerationEngineController {
+  LlamaGgufEngineController(this._gguf);
+
+  final LlamaGgufService _gguf;
+  String? _loadedModelId;
+
+  @override
+  bool get isLoaded => _gguf.isLoaded;
+
+  @override
+  String? get loadedModelId => isLoaded ? _loadedModelId : null;
+
+  @override
+  Future<void> load(core_ai.OfflineModelInfo model) async {
+    final outcome = await _gguf.loadModelOutcome(model);
+    if (!outcome.succeeded) {
+      final detail =
+          outcome.technicalDetail ?? outcome.reasonCode ?? 'load_failed';
+      throw StateError(detail);
+    }
+    _loadedModelId = model.id;
+  }
+
+  @override
+  Future<void> unload() async {
+    await _gguf.unload();
+    _loadedModelId = null;
+  }
+}

--- a/packages/feature_mind/lib/src/model_bench/model_bench_protocol.dart
+++ b/packages/feature_mind/lib/src/model_bench/model_bench_protocol.dart
@@ -1,3 +1,5 @@
+import 'package:flutter/foundation.dart';
+
 import '../runtime/models/model_models.dart';
 
 /// Default warmup / timed counts. Matches `airo_mind_core::BenchProtocol`.
@@ -195,5 +197,25 @@ Future<GenerationBenchReport> runGenerationBench({
     warmupIterations: warmupIterations,
     timedIterations: timedIterations,
     metadata: metadata,
+  );
+}
+
+/// Backend / thread labels for a production Model Bench reading.
+///
+/// macOS llama.cpp is built with Metal. Windows CUDA is a named seam, not a
+/// claim that this build linked `llama-cpp-2/cuda` — unlabeled Windows stays
+/// [InferenceAccelBackend.auto] until a CUDA-enabled binary records `cuda`.
+/// Supervisor pins generation to one thread.
+GenerationBenchMetadata productionGenerationBenchMetadata() {
+  final backend = switch (defaultTargetPlatform) {
+    TargetPlatform.macOS || TargetPlatform.iOS => InferenceAccelBackend.metal,
+    TargetPlatform.android => InferenceAccelBackend.auto,
+    _ => InferenceAccelBackend.auto,
+  };
+  return GenerationBenchMetadata(
+    backend: backend,
+    clockControl: GpuClockControl.unlocked,
+    gpuLayers: backend == InferenceAccelBackend.metal ? -1 : 0,
+    threadCount: 1,
   );
 }

--- a/packages/feature_mind/lib/src/model_bench/production_model_port.dart
+++ b/packages/feature_mind/lib/src/model_bench/production_model_port.dart
@@ -1,0 +1,28 @@
+import '../runtime/ports/model_port.dart';
+import '../runtime/rust/rust_mind_runtime.dart';
+import '../services/llama_gguf_service.dart';
+import 'generation_bench_runner.dart';
+import 'generation_engine_controller.dart';
+import 'llama_gguf_bench_runner.dart';
+import 'llama_gguf_engine_controller.dart';
+import 'model_bench_protocol.dart';
+
+/// Production [ModelPort]: real catalog/disk plus GGUF load + warmed median
+/// bench when the engine is loaded.
+///
+/// Lives outside `lib/src/runtime/` so the runtime layer stays free of the
+/// generated llama bridge. Tests inject [benchRunner] and [engine] without
+/// constructing [LlamaGgufService].
+ModelPort createProductionModelPort({
+  LlamaGgufService? gguf,
+  GenerationBenchRunner? benchRunner,
+  GenerationEngineController? engine,
+  GenerationBenchMetadata? benchMetadata,
+}) {
+  late final service = gguf ?? LlamaGgufService();
+  return RustMindRuntime(
+    benchRunner: benchRunner ?? LlamaGgufBenchRunner(service),
+    engine: engine ?? LlamaGgufEngineController(service),
+    benchMetadata: benchMetadata ?? productionGenerationBenchMetadata(),
+  ).models;
+}

--- a/packages/feature_mind/lib/src/model_bench/speech_bench_protocol.dart
+++ b/packages/feature_mind/lib/src/model_bench/speech_bench_protocol.dart
@@ -1,0 +1,102 @@
+import 'model_bench_protocol.dart';
+
+/// Default warmup / timed counts. Matches generation Model Bench.
+const int kSpeechBenchWarmupIterations = kModelBenchWarmupIterations;
+const int kSpeechBenchTimedIterations = kModelBenchTimedIterations;
+
+/// One timed transcribe() observation.
+///
+/// RTFx is [rtf] = `wallMs / audioDurationMs` (whisper.cpp's real-time
+/// factor). Below 1.0 is faster than real time. Peak RSS stays 0 unless the
+/// caller measured it — Dart does not invent a process RSS.
+class SpeechBenchSample {
+  const SpeechBenchSample({
+    required this.audioDurationMs,
+    required this.wallMs,
+    this.peakRssBytes = 0,
+  });
+
+  final int audioDurationMs;
+  final int wallMs;
+  final int peakRssBytes;
+
+  /// `wallMs / audioDurationMs`. Zero duration → 0, which must not be shown
+  /// as a measurement; [runSpeechBench] rejects empty timed sets, and
+  /// runners must reject zero-duration clips.
+  double get rtf => audioDurationMs == 0 ? 0 : wallMs / audioDurationMs;
+}
+
+/// Median-reduced result of a warmed speech bench.
+class SpeechBenchReport {
+  const SpeechBenchReport({
+    required this.medianRtf,
+    required this.medianWallMs,
+    required this.audioDurationMs,
+    required this.peakRssBytes,
+    required this.warmupIterations,
+    required this.timedIterations,
+    required this.metadata,
+  });
+
+  final double medianRtf;
+  final int medianWallMs;
+  final int audioDurationMs;
+  final int peakRssBytes;
+  final int warmupIterations;
+  final int timedIterations;
+  final GenerationBenchMetadata metadata;
+}
+
+/// Reduce already-timed samples. Warmup must have been discarded by the
+/// caller. Empty → throw, never a zero RTFx that looks measured.
+SpeechBenchReport aggregateSpeechBench({
+  required List<SpeechBenchSample> samples,
+  required int warmupIterations,
+  required int timedIterations,
+  GenerationBenchMetadata metadata = const GenerationBenchMetadata(),
+}) {
+  if (samples.isEmpty) {
+    throw StateError(
+      'benchmark produced no timed samples (timedIterations must be > 0)',
+    );
+  }
+  return SpeechBenchReport(
+    medianRtf: medianF64([for (final s in samples) s.rtf]),
+    medianWallMs: medianU64([for (final s in samples) s.wallMs]),
+    audioDurationMs: samples
+        .map((s) => s.audioDurationMs)
+        .reduce((a, b) => a > b ? a : b),
+    peakRssBytes: samples
+        .map((s) => s.peakRssBytes)
+        .reduce((a, b) => a > b ? a : b),
+    warmupIterations: warmupIterations,
+    timedIterations: timedIterations,
+    metadata: metadata,
+  );
+}
+
+/// Runs warmup + timed transcribe() calls against [sample].
+Future<SpeechBenchReport> runSpeechBench({
+  required Future<SpeechBenchSample> Function() sample,
+  int warmupIterations = kSpeechBenchWarmupIterations,
+  int timedIterations = kSpeechBenchTimedIterations,
+  GenerationBenchMetadata metadata = const GenerationBenchMetadata(),
+}) async {
+  if (timedIterations <= 0) {
+    throw StateError(
+      'benchmark produced no timed samples (timedIterations must be > 0)',
+    );
+  }
+  for (var i = 0; i < warmupIterations; i++) {
+    await sample();
+  }
+  final samples = <SpeechBenchSample>[
+    for (var i = 0; i < timedIterations; i++) await sample(),
+  ];
+  return aggregateSpeechBench(
+    samples: samples,
+    warmupIterations: warmupIterations,
+    timedIterations: timedIterations,
+    metadata: metadata,
+  );
+}

--- a/packages/feature_mind/lib/src/model_bench/speech_bench_runner.dart
+++ b/packages/feature_mind/lib/src/model_bench/speech_bench_runner.dart
@@ -1,0 +1,9 @@
+import 'speech_bench_protocol.dart';
+
+/// One transcribe() cycle used by [runSpeechBench].
+///
+/// Throws rather than inventing RTFx when the speech engine is not loaded.
+/// This file does not import the generated whisper bridge.
+abstract interface class SpeechBenchRunner {
+  Future<SpeechBenchSample> sample();
+}

--- a/packages/feature_mind/lib/src/models/model_management_panel.dart
+++ b/packages/feature_mind/lib/src/models/model_management_panel.dart
@@ -47,8 +47,8 @@ class _ModelManagementPanelState extends State<ModelManagementPanel> {
   /// One active download's state, by model id. A model absent from this map
   /// has not been asked for and shows its plain "available" row.
   final Map<String, ModelDownloadState> _downloads = {};
-  final Map<String, StreamSubscription<ModelDownloadState>> _subscriptions =
-      {};
+  final Map<String, StreamSubscription<ModelDownloadState>> _subscriptions = {};
+  final Map<String, _BenchRowState> _benches = {};
 
   @override
   void initState() {
@@ -66,10 +66,7 @@ class _ModelManagementPanelState extends State<ModelManagementPanel> {
 
   Future<void> _load() async {
     try {
-      final results = await (
-        widget.models.all(),
-        widget.models.storage(),
-      ).wait;
+      final results = await (widget.models.all(), widget.models.storage()).wait;
       if (!mounted) return;
       setState(() {
         _mindModels = results.$1;
@@ -85,12 +82,28 @@ class _ModelManagementPanelState extends State<ModelManagementPanel> {
   void _startDownload(MindModel model, {bool allowMetered = false}) {
     unawaited(_subscriptions[model.id]?.cancel());
     _subscriptions[model.id] = _coordinator
-        .download(model.id, sizeBytes: model.sizeBytes, allowMetered: allowMetered)
+        .download(
+          model.id,
+          sizeBytes: model.sizeBytes,
+          allowMetered: allowMetered,
+        )
         .listen((state) {
           if (!mounted) return;
           setState(() => _downloads[model.id] = state);
           if (state is ModelDownloadCompleted) unawaited(_load());
         });
+  }
+
+  Future<void> _loadModel(MindModel model) async {
+    try {
+      await widget.models.load(model.id);
+      await _load();
+    } on Object catch (error) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(SnackBar(content: Text(error.toString())));
+    }
   }
 
   Future<void> _unload(MindModel model) async {
@@ -102,6 +115,18 @@ class _ModelManagementPanelState extends State<ModelManagementPanel> {
       ScaffoldMessenger.of(
         context,
       ).showSnackBar(SnackBar(content: Text(error.toString())));
+    }
+  }
+
+  Future<void> _runBench(MindModel model) async {
+    setState(() => _benches[model.id] = const _BenchRowState.running());
+    try {
+      final bench = await widget.models.benchmark(model.id);
+      if (!mounted) return;
+      setState(() => _benches[model.id] = _BenchRowState.measured(bench));
+    } on Object catch (error) {
+      if (!mounted) return;
+      setState(() => _benches[model.id] = _BenchRowState.failed('$error'));
     }
   }
 
@@ -128,10 +153,12 @@ class _ModelManagementPanelState extends State<ModelManagementPanel> {
             child: ModelDownloadRow(
               model: model,
               downloadState: _downloads[model.id],
+              benchState: _benches[model.id],
               onDownload: () => _startDownload(model),
-              onDownloadAnyway: () =>
-                  _startDownload(model, allowMetered: true),
+              onDownloadAnyway: () => _startDownload(model, allowMetered: true),
               onUnload: () => _unload(model),
+              onLoad: () => _loadModel(model),
+              onBenchmark: () => _runBench(model),
             ),
           ),
       ],
@@ -155,10 +182,7 @@ class _StorageBudgetBar extends StatelessWidget {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          Text(
-            'Model storage',
-            style: Theme.of(context).textTheme.titleSmall,
-          ),
+          Text('Model storage', style: Theme.of(context).textTheme.titleSmall),
           const SizedBox(height: 6),
           ClipRRect(
             borderRadius: BorderRadius.circular(4),
@@ -190,13 +214,19 @@ class ModelDownloadRow extends StatelessWidget {
     required this.onDownload,
     required this.onDownloadAnyway,
     required this.onUnload,
+    this.onLoad,
+    this.benchState,
+    this.onBenchmark,
   });
 
   final MindModel model;
   final ModelDownloadState? downloadState;
+  final _BenchRowState? benchState;
   final VoidCallback onDownload;
   final VoidCallback onDownloadAnyway;
   final VoidCallback onUnload;
+  final VoidCallback? onLoad;
+  final VoidCallback? onBenchmark;
 
   static const Map<ModelResidency, String> _residencyLabels = {
     ModelResidency.loaded: 'Loaded',
@@ -240,9 +270,68 @@ class ModelDownloadRow extends StatelessWidget {
             ],
             const SizedBox(height: 8),
             _body(context, state),
+            if (_showBench) ...[const SizedBox(height: 8), _benchBody(context)],
           ],
         ),
       ),
+    );
+  }
+
+  bool get _showBench {
+    if (onBenchmark == null) return false;
+    if (model.residency == ModelResidency.available) return false;
+    final state = downloadState;
+    return state == null || state is ModelDownloadIdle;
+  }
+
+  Widget _benchBody(BuildContext context) {
+    final theme = Theme.of(context);
+    final bench = benchState;
+    final running = bench?.phase == _BenchPhase.running;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        OutlinedButton.icon(
+          key: Key('model_bench_${model.id}'),
+          onPressed: running ? null : onBenchmark,
+          icon: const Icon(Icons.speed_outlined, size: 18),
+          label: const Text('Run bench'),
+        ),
+        if (running) ...[
+          const SizedBox(height: 8),
+          const Row(
+            children: [
+              SizedBox(
+                width: 14,
+                height: 14,
+                child: CircularProgressIndicator(strokeWidth: 2),
+              ),
+              SizedBox(width: 8),
+              Text('Measuring…'),
+            ],
+          ),
+        ],
+        if (bench?.phase == _BenchPhase.measured && bench?.bench != null) ...[
+          const SizedBox(height: 8),
+          Text(
+            '${bench!.bench!.tokensPerSecond.toStringAsFixed(1)} tok/s · '
+            '${bench.bench!.firstTokenMs} ms to first token',
+            style: theme.textTheme.bodySmall,
+          ),
+        ],
+        if (bench?.phase == _BenchPhase.failed) ...[
+          const SizedBox(height: 8),
+          Semantics(
+            liveRegion: true,
+            child: Text(
+              'Bench unavailable: ${bench!.reason}',
+              style: theme.textTheme.bodySmall?.copyWith(
+                color: MindPalette.alarm,
+              ),
+            ),
+          ),
+        ],
+      ],
     );
   }
 
@@ -250,18 +339,38 @@ class ModelDownloadRow extends StatelessWidget {
     final theme = Theme.of(context);
 
     return switch (state) {
-      null || ModelDownloadIdle() when model.residency == ModelResidency.available =>
+      null || ModelDownloadIdle()
+          when model.residency == ModelResidency.available =>
         FilledButton.icon(
           onPressed: onDownload,
           icon: const Icon(Icons.download_outlined, size: 18),
           label: const Text('Download'),
         ),
-      null || ModelDownloadIdle() =>
-        OutlinedButton.icon(
-          onPressed: onUnload,
-          icon: const Icon(Icons.delete_outline, size: 18),
-          label: const Text('Unload'),
+      null || ModelDownloadIdle()
+          when model.residency == ModelResidency.resident =>
+        Wrap(
+          spacing: 8,
+          runSpacing: 8,
+          children: [
+            if (onLoad != null)
+              OutlinedButton.icon(
+                key: Key('model_load_${model.id}'),
+                onPressed: onLoad,
+                icon: const Icon(Icons.memory_outlined, size: 18),
+                label: const Text('Load'),
+              ),
+            OutlinedButton.icon(
+              onPressed: onUnload,
+              icon: const Icon(Icons.delete_outline, size: 18),
+              label: const Text('Unload'),
+            ),
+          ],
         ),
+      null || ModelDownloadIdle() => OutlinedButton.icon(
+        onPressed: onUnload,
+        icon: const Icon(Icons.delete_outline, size: 18),
+        label: const Text('Unload'),
+      ),
       ModelDownloadCheckingStorage() => const Row(
         children: [
           SizedBox(
@@ -283,9 +392,7 @@ class ModelDownloadRow extends StatelessWidget {
       ModelDownloadPausedForMetered(:final received, :final total) => Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          LinearProgressIndicator(
-            value: total > 0 ? received / total : null,
-          ),
+          LinearProgressIndicator(value: total > 0 ? received / total : null),
           const SizedBox(height: 4),
           Semantics(
             liveRegion: true,
@@ -331,9 +438,7 @@ class ModelDownloadRow extends StatelessWidget {
           ),
           TextButton(
             onPressed: onDownload,
-            child: Text(
-              received > 0 ? 'Resume download' : 'Try again',
-            ),
+            child: Text(received > 0 ? 'Resume download' : 'Try again'),
           ),
         ],
       ),
@@ -353,10 +458,7 @@ class ModelDownloadRow extends StatelessWidget {
               ),
             ),
           ),
-          TextButton(
-            onPressed: onDownload,
-            child: const Text('Try again'),
-          ),
+          TextButton(onPressed: onDownload, child: const Text('Try again')),
         ],
       ),
     };
@@ -393,4 +495,25 @@ class _ResidencyBadge extends StatelessWidget {
       ),
     );
   }
+}
+
+enum _BenchPhase { running, measured, failed }
+
+class _BenchRowState {
+  const _BenchRowState.running()
+    : phase = _BenchPhase.running,
+      bench = null,
+      reason = null;
+
+  const _BenchRowState.measured(this.bench)
+    : phase = _BenchPhase.measured,
+      reason = null;
+
+  const _BenchRowState.failed(this.reason)
+    : phase = _BenchPhase.failed,
+      bench = null;
+
+  final _BenchPhase phase;
+  final ModelBench? bench;
+  final String? reason;
 }

--- a/packages/feature_mind/lib/src/runtime/rust/rust_mind_runtime.dart
+++ b/packages/feature_mind/lib/src/runtime/rust/rust_mind_runtime.dart
@@ -322,10 +322,12 @@ class _RustModels implements ModelPort {
   @override
   Future<void> load(String modelId) async {
     final engine = _engine;
-    if (engine == null) return _pending('ModelPort', _runtimeIssue);
+    if (engine == null) {
+      _pending('ModelPort', _runtimeIssue);
+    }
     final catalogModel = _findCatalogModel(modelId);
     if (catalogModel == null) {
-      return _pending(
+      _pending(
         'ModelPort',
         'unknown model id "$modelId" -- not in the catalog',
       );
@@ -335,7 +337,7 @@ class _RustModels implements ModelPort {
       model: catalogModel,
     );
     if (path == null) {
-      return _pending(
+      _pending(
         'ModelPort',
         'model "$modelId" is not on disk — download it before loading',
       );
@@ -343,19 +345,21 @@ class _RustModels implements ModelPort {
     try {
       await engine.load(catalogModel.copyWith(filePath: path));
     } on Object catch (error) {
-      return _pending('ModelPort', 'load failed — $_runtimeIssue ($error)');
+      _pending('ModelPort', 'load failed — $_runtimeIssue ($error)');
     }
   }
 
   @override
   Future<void> unload(String modelId) async {
     final engine = _engine;
-    if (engine == null) return _pending('ModelPort', _runtimeIssue);
+    if (engine == null) {
+      _pending('ModelPort', _runtimeIssue);
+    }
     if (engine.loadedModelId != modelId) return;
     try {
       await engine.unload();
     } on Object catch (error) {
-      return _pending('ModelPort', 'unload failed — $_runtimeIssue ($error)');
+      _pending('ModelPort', 'unload failed — $_runtimeIssue ($error)');
     }
   }
 

--- a/packages/feature_mind/lib/src/runtime/rust/rust_mind_runtime.dart
+++ b/packages/feature_mind/lib/src/runtime/rust/rust_mind_runtime.dart
@@ -23,6 +23,7 @@ import '../ports/portability_port.dart';
 import '../ports/projection_port.dart';
 import '../ports/vault_port.dart';
 import '../../model_bench/generation_bench_runner.dart';
+import '../../model_bench/generation_engine_controller.dart';
 import '../../model_bench/model_bench_protocol.dart';
 import 'rust_mind_runtime_vault.dart';
 
@@ -38,10 +39,11 @@ import 'rust_mind_runtime_vault.dart';
 class RustMindRuntime implements MindRuntime {
   RustMindRuntime({
     ModelPort? models,
+    GenerationBenchRunner? benchRunner,
+    GenerationEngineController? engine,
+    GenerationBenchMetadata? benchMetadata,
     @visibleForTesting core_ai.ModelDownloadService? downloadService,
     @visibleForTesting List<core_ai.OfflineModelInfo>? catalog,
-    @visibleForTesting GenerationBenchRunner? benchRunner,
-    @visibleForTesting GenerationBenchMetadata? benchMetadata,
     @visibleForTesting int? warmupIterations,
     @visibleForTesting int? timedIterations,
     @visibleForTesting Future<ThermalState> Function()? readThermal,
@@ -52,6 +54,7 @@ class RustMindRuntime implements MindRuntime {
              downloadService: downloadService,
              catalog: catalog,
              benchRunner: benchRunner,
+             engine: engine,
              benchMetadata: benchMetadata,
              warmupIterations: warmupIterations,
              timedIterations: timedIterations,
@@ -216,19 +219,20 @@ class _RustCapabilities implements CapabilityPort {
 /// on disk forever. [ModelManagementPanel] no longer has to run against
 /// [FixtureMindRuntime] to exercise that behavior.
 ///
-/// [load], [unload] still require a model running in real inference memory,
-/// which needs the Rust engine bindings tracked by #1628 (`LlmBackend` trait
-/// + llama.cpp GGUF backend) and #1638 (the Flutter plugin seam over that
-/// FFI) — neither has landed, so those two stay honest [MindPortUnavailable]
-/// stubs naming those issues. (The blanket "#1260" every method here used
-/// to cite is Vault/Operation-Log FFI, not model management -- it never
-/// actually gated this port; #1628/#1638 are the issues that do.)
+/// [load], [unload] stay [MindPortUnavailable] naming #1628/#1638 until a
+/// [GenerationEngineController] is injected — typically
+/// [LlamaGgufEngineController] over [LlamaGgufService]. With a controller,
+/// [load] hydrates the on-disk path and asks the GGUF adapter to put the
+/// model in inference memory; [all] then reports that id as
+/// [ModelResidency.loaded]. Without a controller those two stay honest
+/// stubs rather than pretending RAM residency.
 ///
 /// [benchmark] runs the generation-bench protocol (warmup, median, backend
 /// metadata including CUDA as a Windows seam) when a [GenerationBenchRunner]
-/// is injected — typically [BridgeGenerationBenchRunner] over a loaded llama
-/// engine. With no runner it still reports unavailable rather than inventing
-/// tok/s. [thermal] probes the device capability channel and emits on change.
+/// is injected — typically [LlamaGgufBenchRunner] or
+/// [BridgeGenerationBenchRunner] over a loaded llama engine. With no runner
+/// it still reports unavailable rather than inventing tok/s. [thermal]
+/// probes the device capability channel and emits on change.
 ///
 /// [ModelResidency] has three states -- `loaded` (in inference memory),
 /// `resident` (held on disk by a specific capability), and `available` (not
@@ -237,12 +241,14 @@ class _RustCapabilities implements CapabilityPort {
 /// this class can only tell the true two-state story disk access gives it:
 /// a downloaded, verified model reports as `resident` with an empty
 /// [MindModel.heldBy] (nothing artificially blocks unloading it), never as
-/// `loaded`.
+/// `loaded` — unless a [GenerationEngineController] reports that id as
+/// currently in inference memory.
 class _RustModels implements ModelPort {
   _RustModels({
     core_ai.ModelDownloadService? downloadService,
     List<core_ai.OfflineModelInfo>? catalog,
     GenerationBenchRunner? benchRunner,
+    GenerationEngineController? engine,
     GenerationBenchMetadata? benchMetadata,
     int? warmupIterations,
     int? timedIterations,
@@ -251,6 +257,7 @@ class _RustModels implements ModelPort {
   }) : _downloadService = downloadService ?? core_ai.ModelDownloadService(),
        _catalog = catalog ?? core_ai.ModelCatalog.bundledModels,
        _benchRunner = benchRunner,
+       _engine = engine,
        _benchMetadata = benchMetadata ?? const GenerationBenchMetadata(),
        _warmupIterations = warmupIterations ?? kModelBenchWarmupIterations,
        _timedIterations = timedIterations ?? kModelBenchTimedIterations,
@@ -263,6 +270,7 @@ class _RustModels implements ModelPort {
   final core_ai.ModelDownloadService _downloadService;
   final List<core_ai.OfflineModelInfo> _catalog;
   final GenerationBenchRunner? _benchRunner;
+  final GenerationEngineController? _engine;
   final GenerationBenchMetadata _benchMetadata;
   final int _warmupIterations;
   final int _timedIterations;
@@ -278,19 +286,23 @@ class _RustModels implements ModelPort {
 
   @override
   Future<List<MindModel>> all() async {
+    final loadedId = _engine?.loadedModelId;
     final results = await Future.wait(
       _catalog.map((model) async {
         final downloaded = await _downloadService.isModelDownloaded(
           model.id,
           model: model,
         );
+        final residency = loadedId == model.id
+            ? ModelResidency.loaded
+            : downloaded
+            ? ModelResidency.resident
+            : ModelResidency.available;
         return MindModel(
           id: model.id,
           name: model.name,
           sizeBytes: model.fileSizeBytes,
-          residency: downloaded
-              ? ModelResidency.resident
-              : ModelResidency.available,
+          residency: residency,
         );
       }),
     );
@@ -308,12 +320,44 @@ class _RustModels implements ModelPort {
   }
 
   @override
-  Future<void> load(String modelId) async =>
-      _pending('ModelPort', _runtimeIssue);
+  Future<void> load(String modelId) async {
+    final engine = _engine;
+    if (engine == null) return _pending('ModelPort', _runtimeIssue);
+    final catalogModel = _findCatalogModel(modelId);
+    if (catalogModel == null) {
+      return _pending(
+        'ModelPort',
+        'unknown model id "$modelId" -- not in the catalog',
+      );
+    }
+    final path = await _downloadService.resolveExistingModelPath(
+      catalogModel.id,
+      model: catalogModel,
+    );
+    if (path == null) {
+      return _pending(
+        'ModelPort',
+        'model "$modelId" is not on disk — download it before loading',
+      );
+    }
+    try {
+      await engine.load(catalogModel.copyWith(filePath: path));
+    } on Object catch (error) {
+      return _pending('ModelPort', 'load failed — $_runtimeIssue ($error)');
+    }
+  }
 
   @override
-  Future<void> unload(String modelId) async =>
-      _pending('ModelPort', _runtimeIssue);
+  Future<void> unload(String modelId) async {
+    final engine = _engine;
+    if (engine == null) return _pending('ModelPort', _runtimeIssue);
+    if (engine.loadedModelId != modelId) return;
+    try {
+      await engine.unload();
+    } on Object catch (error) {
+      return _pending('ModelPort', 'unload failed — $_runtimeIssue ($error)');
+    }
+  }
 
   @override
   Stream<({int received, int total})> download(String modelId) {

--- a/packages/feature_mind/lib/src/runtime/rust/rust_mind_runtime_ready.dart
+++ b/packages/feature_mind/lib/src/runtime/rust/rust_mind_runtime_ready.dart
@@ -31,7 +31,7 @@ BigInt mindRuntimeAppendScribeOp({
 
 BigInt mindRuntimeScribeOpCount() => rust.mindRuntimeScribeOpCount();
 
-List<MindOpWire> mindRuntimeScribeOpsRecent({
+List<rust.MindOpWire> mindRuntimeScribeOpsRecent({
   required BigInt offset,
   required BigInt limit,
 }) => rust.mindRuntimeScribeOpsRecent(offset: offset, limit: limit);

--- a/packages/feature_mind/lib/src/runtime/scribe_mind_runtime.dart
+++ b/packages/feature_mind/lib/src/runtime/scribe_mind_runtime.dart
@@ -10,7 +10,12 @@ import 'ports/projection_port.dart';
 import 'ports/vault_port.dart';
 import 'rust/rust_mind_runtime_vault.dart';
 
-/// Mind runtime for the standalone scribe shell: Rust vault + op log, fixture elsewhere.
+/// Mind runtime for the standalone scribe shell: Rust vault + op log, fixture
+/// elsewhere unless a [ModelPort] is injected.
+///
+/// Production (`mindRuntimeProvider`) injects `createProductionModelPort` so
+/// Model Bench and load/unload talk to the GGUF engine. Tests that omit
+/// [models] keep the fixture catalog (invented tok/s, no native load).
 ///
 /// [VaultPort] reads the vault opened when [MindService.initialize] boots the
 /// whisper library (`meetings::initialize` → `open_mind_runtime`). Contexts,
@@ -19,13 +24,16 @@ class ScribeMindRuntime implements MindRuntime {
   ScribeMindRuntime({
     required OperationLogPort log,
     VaultPort? vault,
+    ModelPort? models,
   }) : _inner = FixtureMindRuntime(),
        _log = log,
-       _vault = vault ?? const RustMindRuntimeVault();
+       _vault = vault ?? const RustMindRuntimeVault(),
+       _models = models;
 
   final FixtureMindRuntime _inner;
   final OperationLogPort _log;
   final VaultPort _vault;
+  final ModelPort? _models;
 
   @override
   VaultPort get vault => _vault;
@@ -46,7 +54,7 @@ class ScribeMindRuntime implements MindRuntime {
   CapabilityPort get capabilities => _inner.capabilities;
 
   @override
-  ModelPort get models => _inner.models;
+  ModelPort get models => _models ?? _inner.models;
 
   @override
   PortabilityPort get portability => _inner.portability;

--- a/packages/feature_mind/lib/src/services/desktop_gguf_backend.dart
+++ b/packages/feature_mind/lib/src/services/desktop_gguf_backend.dart
@@ -7,6 +7,7 @@ import 'package:path/path.dart' as p;
 
 import '../library_loader.dart';
 import '../llama/api/minutes.dart' as llama;
+import '../model_bench/model_bench_protocol.dart';
 import 'gguf_artifact_guard.dart';
 import 'gguf_load_outcome.dart';
 
@@ -141,5 +142,30 @@ class DesktopGgufBackend {
   Future<void> unload() async {
     if (!isLlamaLoaded) return;
     llama.unloadGeneration();
+  }
+
+  /// True when the Rust generation slot is initialised.
+  ///
+  /// Safe in tests that never called `RustLib.init` — FRB throws, and we
+  /// treat that as not ready rather than crashing the ModelPort.
+  bool get isEngineReady {
+    try {
+      return llama.isReady();
+    } on Object {
+      return false;
+    }
+  }
+
+  /// Stats from the most recently completed [generate] / `generateCompletion`.
+  GenerationBenchSample lastBenchSample() {
+    final s = llama.generationStats();
+    return GenerationBenchSample(
+      prefillMs: s.prefillMs.toInt(),
+      prefillTokens: s.prefillTokens,
+      generationMs: s.generationMs.toInt(),
+      generatedTokens: s.generatedTokens,
+      tokensPerSecond: s.tokensPerSecond,
+      peakRssBytes: s.peakRssBytes.toInt(),
+    );
   }
 }

--- a/packages/feature_mind/lib/src/services/llama_gguf_service.dart
+++ b/packages/feature_mind/lib/src/services/llama_gguf_service.dart
@@ -4,6 +4,7 @@ import 'package:flutter/foundation.dart';
 import 'package:llama_flutter_android/llama_flutter_android.dart';
 import 'package:core_ai/core_ai.dart';
 
+import '../model_bench/model_bench_protocol.dart';
 import 'desktop_gguf_backend.dart';
 import 'gguf_load_outcome.dart';
 
@@ -33,6 +34,13 @@ class LlamaGgufService {
       !kIsWeb && defaultTargetPlatform == TargetPlatform.android;
 
   bool get isDesktopGgufSupported => DesktopGgufBackend.isSupported;
+
+  /// True when this adapter (or the shared desktop llama slot) has a model.
+  bool get isLoaded {
+    if (_loaded) return true;
+    if (isDesktopGgufSupported) return _desktopBackend.isEngineReady;
+    return false;
+  }
 
   Future<bool> isAvailable() async {
     if (isPlatformSupported) {
@@ -114,7 +122,7 @@ class LlamaGgufService {
     double topP = 0.9,
     int topK = 40,
   }) {
-    if (!_loaded) {
+    if (!isLoaded) {
       return Stream<String>.error(StateError('gguf_model_not_loaded'));
     }
     if (isPlatformSupported) {
@@ -178,5 +186,58 @@ class LlamaGgufService {
     if (!isPlatformSupported) return;
     await _controller?.dispose();
     _controller = null;
+  }
+
+  /// One generate()+stats cycle for Model Bench.
+  ///
+  /// Desktop reads llama.cpp [RuntimeStats]. Android times the token stream:
+  /// TTFT is wall clock to the first chunk; tok/s is remaining chunks over
+  /// the rest of the stream. Peak RSS and prompt-token counts are unknown
+  /// on Android and stay zero rather than guessed.
+  Future<GenerationBenchSample> collectBenchSample({
+    String prompt = kModelBenchPrompt,
+    int maxOutputTokens = kModelBenchMaxOutputTokens,
+  }) async {
+    if (!isLoaded) {
+      throw StateError('gguf_model_not_loaded');
+    }
+    if (isDesktopGgufSupported) {
+      await generate(prompt: prompt, maxTokens: maxOutputTokens).drain<void>();
+      return _desktopBackend.lastBenchSample();
+    }
+    if (isPlatformSupported) {
+      return _wallClockSample(prompt: prompt, maxOutputTokens: maxOutputTokens);
+    }
+    throw StateError('gguf_backend_unavailable');
+  }
+
+  Future<GenerationBenchSample> _wallClockSample({
+    required String prompt,
+    required int maxOutputTokens,
+  }) async {
+    final sw = Stopwatch()..start();
+    var firstChunkMs = 0;
+    var chunks = 0;
+    await for (final _ in generate(
+      prompt: prompt,
+      maxTokens: maxOutputTokens,
+    )) {
+      chunks += 1;
+      if (chunks == 1) firstChunkMs = sw.elapsedMilliseconds;
+    }
+    final totalMs = sw.elapsedMilliseconds;
+    if (chunks == 0) {
+      throw StateError('benchmark produced no generated chunks');
+    }
+    final decodeMs = (totalMs - firstChunkMs).clamp(1, 1 << 30);
+    final decodeChunks = chunks > 1 ? chunks - 1 : chunks;
+    return GenerationBenchSample(
+      prefillMs: firstChunkMs,
+      prefillTokens: 0,
+      generationMs: decodeMs,
+      generatedTokens: chunks,
+      tokensPerSecond: decodeChunks * 1000.0 / decodeMs,
+      peakRssBytes: 0,
+    );
   }
 }

--- a/packages/feature_mind/test/model_bench/bridge_generation_bench_runner_test.dart
+++ b/packages/feature_mind/test/model_bench/bridge_generation_bench_runner_test.dart
@@ -1,0 +1,34 @@
+import 'package:feature_mind/src/bridges/mind_generation_bridge.dart';
+import 'package:feature_mind/src/model_bench/bridge_generation_bench_runner.dart';
+import 'package:feature_mind/src/model_bench/model_bench_protocol.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../support/fake_bridges.dart';
+
+void main() {
+  test('refuses to sample when the generation engine is not loaded', () async {
+    final runner = BridgeGenerationBenchRunner(FakeMindGenerationBridge());
+    await expectLater(runner.sample(), throwsStateError);
+  });
+
+  test('drains complete() and maps stats when the engine is loaded', () async {
+    final bridge = FakeMindGenerationBridge()
+      ..completeEvents = const []
+      ..statsValue = const GenerationStats(
+        prefillMs: 80,
+        prefillTokens: 8,
+        generationMs: 200,
+        generatedTokens: 16,
+        tokensPerSecond: 22.5,
+        peakRssBytes: 4096,
+      );
+    await bridge.ensureLoaded(modelsDir: '/tmp', memoryBudgetMb: 1024);
+
+    final sample = await BridgeGenerationBenchRunner(bridge).sample();
+
+    expect(sample.prefillMs, 80);
+    expect(sample.tokensPerSecond, 22.5);
+    expect(bridge.lastCompletePrompt, kModelBenchPrompt);
+    expect(bridge.lastCompleteMaxOutputTokens, kModelBenchMaxOutputTokens);
+  });
+}

--- a/packages/feature_mind/test/model_bench/bridge_speech_bench_runner_test.dart
+++ b/packages/feature_mind/test/model_bench/bridge_speech_bench_runner_test.dart
@@ -1,0 +1,52 @@
+import 'package:feature_mind/src/bridges/mind_speech_bridge.dart';
+import 'package:feature_mind/src/model_bench/bridge_speech_bench_runner.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../support/fake_bridges.dart';
+
+void main() {
+  test('refuses to sample when the speech engine is not loaded', () async {
+    final runner = BridgeSpeechBenchRunner(
+      FakeMindSpeechBridge(),
+      wavPath: '/tmp/clip.wav',
+      audioDurationMs: 1000,
+    );
+    await expectLater(runner.sample(), throwsStateError);
+  });
+
+  test('refuses a zero-duration clip rather than reporting RTFx 0', () async {
+    final bridge = FakeMindSpeechBridge();
+    await bridge.initialize(
+      modelsDir: '/tmp',
+      storePath: '/tmp/store',
+      memoryBudgetMb: 512,
+    );
+    final runner = BridgeSpeechBenchRunner(
+      bridge,
+      wavPath: '/tmp/clip.wav',
+      audioDurationMs: 0,
+    );
+    await expectLater(runner.sample(), throwsStateError);
+  });
+
+  test('times a drained transcribe when the engine is ready', () async {
+    final bridge = FakeMindSpeechBridge()
+      ..transcriptEvents = const [TranscriptEventCancelled()];
+    await bridge.initialize(
+      modelsDir: '/tmp',
+      storePath: '/tmp/store',
+      memoryBudgetMb: 512,
+    );
+
+    final sample = await BridgeSpeechBenchRunner(
+      bridge,
+      wavPath: '/tmp/clip.wav',
+      audioDurationMs: 2000,
+      language: 'en',
+    ).sample();
+
+    expect(sample.audioDurationMs, 2000);
+    expect(sample.wallMs, greaterThanOrEqualTo(0));
+    expect(bridge.transcribeLanguage, 'en');
+  });
+}

--- a/packages/feature_mind/test/model_bench/llama_gguf_bench_runner_test.dart
+++ b/packages/feature_mind/test/model_bench/llama_gguf_bench_runner_test.dart
@@ -1,0 +1,52 @@
+import 'package:feature_mind/src/model_bench/llama_gguf_bench_runner.dart';
+import 'package:feature_mind/src/model_bench/model_bench_protocol.dart';
+import 'package:feature_mind/src/services/llama_gguf_service.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test(
+    'LlamaGgufBenchRunner refuses to sample when the engine is not loaded',
+    () async {
+      final runner = LlamaGgufBenchRunner(_UnloadedGguf());
+      await expectLater(runner.sample(), throwsStateError);
+    },
+  );
+
+  test(
+    'LlamaGgufBenchRunner forwards collectBenchSample when loaded',
+    () async {
+      final gguf = _LoadedGguf();
+      final sample = await LlamaGgufBenchRunner(gguf).sample();
+      expect(sample.tokensPerSecond, 18);
+      expect(gguf.collectCalls, 1);
+    },
+  );
+}
+
+class _UnloadedGguf extends LlamaGgufService {
+  @override
+  bool get isLoaded => false;
+}
+
+class _LoadedGguf extends LlamaGgufService {
+  var collectCalls = 0;
+
+  @override
+  bool get isLoaded => true;
+
+  @override
+  Future<GenerationBenchSample> collectBenchSample({
+    String prompt = kModelBenchPrompt,
+    int maxOutputTokens = kModelBenchMaxOutputTokens,
+  }) async {
+    collectCalls += 1;
+    return const GenerationBenchSample(
+      prefillMs: 90,
+      prefillTokens: 8,
+      generationMs: 200,
+      generatedTokens: 16,
+      tokensPerSecond: 18,
+      peakRssBytes: 0,
+    );
+  }
+}

--- a/packages/feature_mind/test/model_bench/model_bench_protocol_test.dart
+++ b/packages/feature_mind/test/model_bench/model_bench_protocol_test.dart
@@ -132,6 +132,19 @@ void main() {
       );
     });
   });
+
+  group('productionGenerationBenchMetadata', () {
+    test('records unlocked clocks and a single supervisor thread', () {
+      final metadata = productionGenerationBenchMetadata();
+      expect(metadata.clockControl, GpuClockControl.unlocked);
+      expect(metadata.threadCount, 1);
+      expect(
+        metadata.backend,
+        isNot(InferenceAccelBackend.cuda),
+        reason: 'CUDA is a named seam, not a default Windows/Linux label',
+      );
+    });
+  });
 }
 
 GenerationBenchSample _sample({required int prefillMs, required double tokS}) =>

--- a/packages/feature_mind/test/model_bench/speech_bench_protocol_test.dart
+++ b/packages/feature_mind/test/model_bench/speech_bench_protocol_test.dart
@@ -1,0 +1,95 @@
+import 'package:feature_mind/src/model_bench/model_bench_protocol.dart';
+import 'package:feature_mind/src/model_bench/speech_bench_protocol.dart';
+import 'package:feature_mind/src/runtime/models/model_models.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('SpeechBenchSample.rtf', () {
+    test('is wall over audio, and zero duration is 0 not infinity', () {
+      expect(
+        const SpeechBenchSample(audioDurationMs: 1000, wallMs: 500).rtf,
+        0.5,
+      );
+      expect(const SpeechBenchSample(audioDurationMs: 0, wallMs: 500).rtf, 0);
+    });
+  });
+
+  group('aggregateSpeechBench', () {
+    test('rejects an empty timed set rather than returning zeros', () {
+      expect(
+        () => aggregateSpeechBench(
+          samples: const [],
+          warmupIterations: 3,
+          timedIterations: 5,
+        ),
+        throwsStateError,
+      );
+    });
+
+    test('reports median RTFx and keeps accelerator metadata', () {
+      final report = aggregateSpeechBench(
+        samples: const [
+          SpeechBenchSample(
+            audioDurationMs: 1000,
+            wallMs: 400,
+            peakRssBytes: 1000,
+          ),
+          SpeechBenchSample(
+            audioDurationMs: 1000,
+            wallMs: 600,
+            peakRssBytes: 2200,
+          ),
+          SpeechBenchSample(
+            audioDurationMs: 1000,
+            wallMs: 500,
+            peakRssBytes: 1800,
+          ),
+        ],
+        warmupIterations: 1,
+        timedIterations: 3,
+        metadata: const GenerationBenchMetadata(
+          backend: InferenceAccelBackend.metal,
+        ),
+      );
+
+      expect(report.medianWallMs, 500);
+      expect(report.medianRtf, 0.5);
+      expect(report.audioDurationMs, 1000);
+      expect(report.peakRssBytes, 2200);
+      expect(report.metadata.backend, InferenceAccelBackend.metal);
+    });
+  });
+
+  group('runSpeechBench', () {
+    test('discards warmup samples from the median', () async {
+      final samples = <SpeechBenchSample>[
+        const SpeechBenchSample(audioDurationMs: 1000, wallMs: 900),
+        const SpeechBenchSample(audioDurationMs: 1000, wallMs: 400),
+        const SpeechBenchSample(audioDurationMs: 1000, wallMs: 500),
+        const SpeechBenchSample(audioDurationMs: 1000, wallMs: 600),
+      ];
+      var i = 0;
+      final report = await runSpeechBench(
+        sample: () async => samples[i++],
+        warmupIterations: 1,
+        timedIterations: 3,
+      );
+
+      expect(i, 4);
+      expect(report.medianWallMs, 500);
+      expect(report.medianRtf, 0.5);
+    });
+
+    test('zero timed iterations is an error, not a zeroed RTFx', () async {
+      await expectLater(
+        runSpeechBench(
+          sample: () async =>
+              const SpeechBenchSample(audioDurationMs: 1000, wallMs: 500),
+          warmupIterations: 1,
+          timedIterations: 0,
+        ),
+        throwsStateError,
+      );
+    });
+  });
+}

--- a/packages/feature_mind/test/models/model_management_panel_test.dart
+++ b/packages/feature_mind/test/models/model_management_panel_test.dart
@@ -13,8 +13,11 @@ class _FakeModelPort implements ModelPort {
   List<MindModel> mindModels;
   ({int usedBytes, int budgetBytes}) storageResult;
   Object? unloadError;
+  Object? benchError;
+  ModelBench? nextBench;
 
-  final _downloadControllers = <String, StreamController<({int received, int total})>>{};
+  final _downloadControllers =
+      <String, StreamController<({int received, int total})>>{};
 
   StreamController<({int received, int total})> controllerFor(String id) =>
       _downloadControllers.putIfAbsent(
@@ -42,8 +45,11 @@ class _FakeModelPort implements ModelPort {
       controllerFor(modelId).stream;
 
   @override
-  Future<ModelBench> benchmark(String modelId) async =>
-      throw UnimplementedError();
+  Future<ModelBench> benchmark(String modelId) async {
+    final error = benchError;
+    if (error != null) throw error;
+    return nextBench ?? (throw UnimplementedError());
+  }
 
   @override
   Stream<ThermalState> thermal() => const Stream.empty();
@@ -158,15 +164,15 @@ void main() {
     expect(find.text('Download anyway'), findsOneWidget);
   });
 
-  testWidgets('an eviction that breaks a capability names it', (
-    tester,
-  ) async {
-    final port = _FakeModelPort(
-      mindModels: const [_residentModel],
-      storageResult: (usedBytes: 200, budgetBytes: 1000),
-    )..unloadError = StateError(
-        'Unloading Whisper base would break Audio Scribe.',
-      );
+  testWidgets('an eviction that breaks a capability names it', (tester) async {
+    final port =
+        _FakeModelPort(
+            mindModels: const [_residentModel],
+            storageResult: (usedBytes: 200, budgetBytes: 1000),
+          )
+          ..unloadError = StateError(
+            'Unloading Whisper base would break Audio Scribe.',
+          );
 
     await tester.pumpWidget(
       MaterialApp(
@@ -185,10 +191,7 @@ void main() {
     await tester.tap(find.text('Unload'));
     await tester.pumpAndSettle();
 
-    expect(
-      find.textContaining('would break Audio Scribe'),
-      findsOneWidget,
-    );
+    expect(find.textContaining('would break Audio Scribe'), findsOneWidget);
   });
 
   testWidgets('distinguishes loaded, resident, and available badges', (
@@ -221,4 +224,71 @@ void main() {
     expect(find.text('Resident'), findsOneWidget);
     expect(find.text('Available to download'), findsOneWidget);
   });
+
+  testWidgets('Run bench shows tok/s after ModelPort.benchmark resolves', (
+    tester,
+  ) async {
+    final port = _FakeModelPort(
+      mindModels: const [_residentModel],
+      storageResult: (usedBytes: 200, budgetBytes: 1000),
+    );
+    port.nextBench = ModelBench(
+      tokensPerSecond: 21.5,
+      firstTokenMs: 120,
+      residentBytes: 200,
+      batteryPercentPerHour: 0,
+      measuredUnder: ThermalState.nominal,
+      measuredAtMs: 1,
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: ModelManagementPanel(
+            models: port,
+            connectivity: _FakeConnectivity(),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Run bench'));
+    await tester.pump();
+    expect(find.text('Measuring…'), findsOneWidget);
+    await tester.pumpAndSettle();
+
+    expect(find.text('21.5 tok/s · 120 ms to first token'), findsOneWidget);
+  });
+
+  testWidgets(
+    'Run bench names an unavailable engine instead of inventing tok/s',
+    (tester) async {
+      final port = _FakeModelPort(
+        mindModels: const [_residentModel],
+        storageResult: (usedBytes: 200, budgetBytes: 1000),
+      )..benchError = StateError('generation engine is not loaded');
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: ModelManagementPanel(
+              models: port,
+              connectivity: _FakeConnectivity(),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Run bench'));
+      await tester.pumpAndSettle();
+
+      expect(find.textContaining('Bench unavailable:'), findsOneWidget);
+      expect(
+        find.textContaining('generation engine is not loaded'),
+        findsOneWidget,
+      );
+    },
+  );
 }

--- a/packages/feature_mind/test/models/model_management_panel_test.dart
+++ b/packages/feature_mind/test/models/model_management_panel_test.dart
@@ -15,6 +15,7 @@ class _FakeModelPort implements ModelPort {
   Object? unloadError;
   Object? benchError;
   ModelBench? nextBench;
+  Future<ModelBench>? pendingBench;
 
   final _downloadControllers =
       <String, StreamController<({int received, int total})>>{};
@@ -48,6 +49,8 @@ class _FakeModelPort implements ModelPort {
   Future<ModelBench> benchmark(String modelId) async {
     final error = benchError;
     if (error != null) throw error;
+    final pending = pendingBench;
+    if (pending != null) return pending;
     return nextBench ?? (throw UnimplementedError());
   }
 
@@ -228,18 +231,11 @@ void main() {
   testWidgets('Run bench shows tok/s after ModelPort.benchmark resolves', (
     tester,
   ) async {
+    final pending = Completer<ModelBench>();
     final port = _FakeModelPort(
       mindModels: const [_residentModel],
       storageResult: (usedBytes: 200, budgetBytes: 1000),
-    );
-    port.nextBench = ModelBench(
-      tokensPerSecond: 21.5,
-      firstTokenMs: 120,
-      residentBytes: 200,
-      batteryPercentPerHour: 0,
-      measuredUnder: ThermalState.nominal,
-      measuredAtMs: 1,
-    );
+    )..pendingBench = pending.future;
 
     await tester.pumpWidget(
       MaterialApp(
@@ -256,6 +252,17 @@ void main() {
     await tester.tap(find.text('Run bench'));
     await tester.pump();
     expect(find.text('Measuring…'), findsOneWidget);
+
+    pending.complete(
+      ModelBench(
+        tokensPerSecond: 21.5,
+        firstTokenMs: 120,
+        residentBytes: 200,
+        batteryPercentPerHour: 0,
+        measuredUnder: ThermalState.nominal,
+        measuredAtMs: 1,
+      ),
+    );
     await tester.pumpAndSettle();
 
     expect(find.text('21.5 tok/s · 120 ms to first token'), findsOneWidget);

--- a/packages/feature_mind/test/runtime/rust_mind_runtime_test.dart
+++ b/packages/feature_mind/test/runtime/rust_mind_runtime_test.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'package:core_ai/core_ai.dart' as core_ai;
 import 'package:feature_mind/feature_mind.dart';
 import 'package:feature_mind/src/model_bench/generation_bench_runner.dart';
+import 'package:feature_mind/src/model_bench/generation_engine_controller.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:path/path.dart' as path;
@@ -243,7 +244,9 @@ void main() {
         await File(
           path.join(modelsDir.path, '${catalogModel.id}.gguf'),
         ).writeAsBytes(List<int>.filled(catalogModel.fileSizeBytes, 0));
-        await Directory(path.join(tempDir.path, 'airo_mind')).create(recursive: true);
+        await Directory(
+          path.join(tempDir.path, 'airo_mind'),
+        ).create(recursive: true);
         await File(
           path.join(tempDir.path, 'airo_mind', 'mind_ops.jsonl'),
         ).writeAsString('');
@@ -279,6 +282,60 @@ void main() {
         expect(bench.residentBytes, catalogModel.fileSizeBytes);
       },
     );
+
+    test(
+      'load() hydrates the on-disk path and reports residency loaded',
+      () async {
+        final catalogModel = core_ai.ModelCatalog.bundledModels.firstWhere(
+          (m) => m.id == 'embeddinggemma-300m-tokenizer',
+        );
+        final modelsDir = Directory(path.join(tempDir.path, 'models'));
+        await modelsDir.create(recursive: true);
+        await File(
+          path.join(modelsDir.path, '${catalogModel.id}.gguf'),
+        ).writeAsBytes(List<int>.filled(catalogModel.fileSizeBytes, 0));
+
+        final engine = _FakeEngine();
+        final loadedRuntime = RustMindRuntime(engine: engine);
+
+        await loadedRuntime.models.load(catalogModel.id);
+
+        expect(engine.loadedPaths, hasLength(1));
+        expect(engine.loadedPaths.single, contains('${catalogModel.id}.gguf'));
+        expect(engine.loadedModelId, catalogModel.id);
+
+        final models = await loadedRuntime.models.all();
+        expect(
+          models.firstWhere((m) => m.id == catalogModel.id).residency,
+          ModelResidency.loaded,
+        );
+
+        await loadedRuntime.models.unload(catalogModel.id);
+        expect(engine.loadedModelId, isNull);
+        final after = await loadedRuntime.models.all();
+        expect(
+          after.firstWhere((m) => m.id == catalogModel.id).residency,
+          ModelResidency.resident,
+        );
+      },
+    );
+
+    test('load() of a catalog id not on disk reports unavailable', () async {
+      final catalogModel = core_ai.ModelCatalog.bundledModels.firstWhere(
+        (m) => m.id == 'embeddinggemma-300m-tokenizer',
+      );
+      final loadedRuntime = RustMindRuntime(engine: _FakeEngine());
+      await expectLater(
+        loadedRuntime.models.load(catalogModel.id),
+        throwsA(
+          isA<MindPortUnavailable>().having(
+            (e) => e.reason,
+            'reason',
+            contains('not on disk'),
+          ),
+        ),
+      );
+    });
   });
 }
 
@@ -300,4 +357,25 @@ class _ScriptedBenchRunner implements GenerationBenchRunner {
 
   @override
   Future<GenerationBenchSample> sample() async => _samples[_i++];
+}
+
+class _FakeEngine implements GenerationEngineController {
+  final loadedPaths = <String>[];
+
+  @override
+  bool get isLoaded => loadedModelId != null;
+
+  @override
+  String? loadedModelId;
+
+  @override
+  Future<void> load(core_ai.OfflineModelInfo model) async {
+    loadedPaths.add(model.filePath ?? '');
+    loadedModelId = model.id;
+  }
+
+  @override
+  Future<void> unload() async {
+    loadedModelId = null;
+  }
 }

--- a/packages/feature_mind/test/runtime/scribe_mind_runtime_test.dart
+++ b/packages/feature_mind/test/runtime/scribe_mind_runtime_test.dart
@@ -1,0 +1,60 @@
+import 'package:feature_mind/src/runtime/fixture/fixture_mind_runtime.dart';
+import 'package:feature_mind/src/runtime/models/model_models.dart';
+import 'package:feature_mind/src/runtime/ports/model_port.dart';
+import 'package:feature_mind/src/runtime/scribe_mind_runtime.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('uses injected ModelPort rather than fixture models', () async {
+    final injected = _FakeModelPort();
+    final runtime = ScribeMindRuntime(
+      log: FixtureMindRuntime().log,
+      models: injected,
+    );
+
+    expect(identical(runtime.models, injected), isTrue);
+    await expectLater(runtime.models.all(), completion(injected.mindModels));
+  });
+
+  test('falls back to fixture models when none are injected', () async {
+    final runtime = ScribeMindRuntime(log: FixtureMindRuntime().log);
+    final models = await runtime.models.all();
+    final fixture = await FixtureMindRuntime().models.all();
+    expect(models, fixture);
+  });
+}
+
+class _FakeModelPort implements ModelPort {
+  final mindModels = const [
+    MindModel(
+      id: 'injected',
+      name: 'Injected',
+      sizeBytes: 1,
+      residency: ModelResidency.resident,
+    ),
+  ];
+
+  @override
+  Future<List<MindModel>> all() async => mindModels;
+
+  @override
+  Future<({int budgetBytes, int usedBytes})> storage() async =>
+      (usedBytes: 0, budgetBytes: 1);
+
+  @override
+  Future<void> load(String modelId) async {}
+
+  @override
+  Future<void> unload(String modelId) async {}
+
+  @override
+  Stream<({int received, int total})> download(String modelId) =>
+      const Stream.empty();
+
+  @override
+  Future<ModelBench> benchmark(String modelId) async =>
+      throw StateError('not used');
+
+  @override
+  Stream<ThermalState> thermal() => const Stream.empty();
+}

--- a/packages/feature_mind/test/services/llama_gguf_service_test.dart
+++ b/packages/feature_mind/test/services/llama_gguf_service_test.dart
@@ -139,6 +139,42 @@ void main() {
 
     expect(disposed, isTrue);
   });
+
+  test('collectBenchSample times the Android token stream', () async {
+    debugDefaultTargetPlatformOverride = TargetPlatform.android;
+    _mockLlamaHost();
+    final controller = LlamaController(
+      binaryMessenger:
+          TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger,
+    );
+    final service = LlamaGgufService(nativeController: controller);
+    const model = OfflineModelInfo(
+      id: 'gguf-bench',
+      name: 'GGUF bench',
+      family: ModelFamily.llama,
+      fileSizeBytes: 1024,
+      filePath: '/models/bench.gguf',
+    );
+
+    await expectLater(service.loadModel(model), completion(isTrue));
+    expect(service.isLoaded, isTrue);
+
+    final sampleFuture = service.collectBenchSample(
+      prompt: 'bench',
+      maxOutputTokens: 8,
+    );
+    await Future<void>.delayed(Duration.zero);
+    controller.onToken('one');
+    controller.onToken(' two');
+    controller.onDone();
+    final sample = await sampleFuture;
+
+    expect(sample.generatedTokens, 2);
+    expect(sample.tokensPerSecond, greaterThan(0));
+    expect(sample.peakRssBytes, 0);
+    expect(sample.prefillTokens, 0);
+    await expectLater(service.unload(), completes);
+  });
 }
 
 typedef _ModelConfigSpy = void Function(ModelConfig config);

--- a/packages/feature_mind/test/support/fake_bridges.dart
+++ b/packages/feature_mind/test/support/fake_bridges.dart
@@ -130,6 +130,9 @@ class FakeMindGenerationBridge implements MindGenerationBridge {
   bool get isLoaded => _loaded;
 
   @override
+  bool get isEngineReady => _loaded;
+
+  @override
   Future<void> ensureLoaded({
     required String modelsDir,
     required int memoryBudgetMb,

--- a/rust/airo_mind_core/src/bench.rs
+++ b/rust/airo_mind_core/src/bench.rs
@@ -1,8 +1,8 @@
-//! Generation-engine benchmark protocol.
+//! On-device inference benchmark protocol (generation tok/s and speech RTFx).
 //!
 //! Backend-free: this crate links nothing native, so the protocol can sit in
-//! `airo_mind_core` and be shared by llama.cpp, a future CUDA Windows build,
-//! and tests that never load a model.
+//! `airo_mind_core` and be shared by llama.cpp, whisper.cpp, a future CUDA
+//! Windows build, and tests that never load a model.
 //!
 //! The methodology is the Jan.ai kernel-bench practices that survive contact
 //! with on-device inference, not a port of CUDA events / `ncu` / L2 flush:
@@ -20,8 +20,13 @@
 //! Absolute tok/s is still not a CI gate. Stochastic clocks (Jan §6) make
 //! wall-clock thresholds flaky; [`crate`] scaling tests stay the CI shape.
 
+use std::time::Instant;
+
 use crate::cancel::CancelToken;
-use crate::engine::{EngineError, GenerationEngine, GenerationRequest, RuntimeStats};
+use crate::engine::{
+    AudioInput, EngineError, GenerationEngine, GenerationRequest, RuntimeStats, SpeechEngine,
+    TranscriptSegment, TranscriptionOptions,
+};
 
 /// GPU / NPU / CPU accelerator the timed `generate()` actually used.
 ///
@@ -262,6 +267,153 @@ pub fn run_generation_bench(
     aggregate(&samples, protocol, metadata)
 }
 
+/// One timed `transcribe()` observation.
+///
+/// RTFx is `wall_ms / audio_duration_ms` (whisper.cpp's real-time factor).
+/// Values below 1.0 mean faster than real time. This is **not** tok/s:
+/// speech has no prefill/decode split on the whisper.cpp path we ship.
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+pub struct SpeechStats {
+    pub audio_duration_ms: u64,
+    pub wall_ms: u64,
+    /// Process-wide peak RSS when the caller measured it. `0` when unknown
+    /// — this crate stays std-only and does not call `getrusage`.
+    pub peak_rss_bytes: u64,
+}
+
+impl SpeechStats {
+    /// `wall_ms / audio_duration_ms`. `0.0` when duration is zero — callers
+    /// must not treat that as a real measurement; [`sample_speech_engine`]
+    /// rejects empty audio instead.
+    pub fn rtf(&self) -> f64 {
+        if self.audio_duration_ms == 0 {
+            0.0
+        } else {
+            self.wall_ms as f64 / self.audio_duration_ms as f64
+        }
+    }
+}
+
+/// Median-reduced result of a warmed speech bench.
+#[derive(Clone, Debug, PartialEq)]
+pub struct SpeechBenchReport {
+    pub median_rtf: f64,
+    pub median_wall_ms: u64,
+    pub audio_duration_ms: u64,
+    pub peak_rss_bytes: u64,
+    pub warmup_iterations: u32,
+    pub timed_iterations: u32,
+    pub metadata: BenchMetadata,
+}
+
+/// PCM duration in milliseconds. Channels and rate of `0` are treated as `1`
+/// so a malformed header cannot divide by zero; empty PCM still yields `0`.
+pub fn audio_duration_ms(audio: AudioInput<'_>) -> u64 {
+    let channels = u64::from(audio.channels.max(1));
+    let rate = u64::from(audio.sample_rate_hz.max(1));
+    (audio.samples.len() as u64).saturating_mul(1000) / rate.saturating_mul(channels)
+}
+
+/// Time one [`SpeechEngine::transcribe`] against [audio]. The protocol owns
+/// the wall clock so the engine trait does not grow a `stats()` method.
+pub fn sample_speech_engine(
+    engine: &dyn SpeechEngine,
+    audio: AudioInput<'_>,
+    options: &TranscriptionOptions,
+    cancel: &CancelToken,
+) -> Result<SpeechStats, EngineError> {
+    let audio_duration_ms = audio_duration_ms(audio);
+    if audio_duration_ms == 0 {
+        return Err(EngineError::InvalidInput("audio duration is zero".into()));
+    }
+    let start = Instant::now();
+    let mut sink = |_seg: TranscriptSegment| Ok(());
+    engine.transcribe(audio, options, cancel, &mut sink)?;
+    Ok(SpeechStats {
+        audio_duration_ms,
+        wall_ms: start.elapsed().as_millis() as u64,
+        peak_rss_bytes: 0,
+    })
+}
+
+/// Reduce timed [`SpeechStats`] samples. Empty → [`BenchError::NoSamples`].
+pub fn aggregate_speech(
+    samples: &[SpeechStats],
+    protocol: &BenchProtocol,
+    metadata: BenchMetadata,
+) -> Result<SpeechBenchReport, BenchError> {
+    if samples.is_empty() {
+        return Err(BenchError::NoSamples);
+    }
+    let rtf: Vec<f64> = samples.iter().map(SpeechStats::rtf).collect();
+    let wall: Vec<u64> = samples.iter().map(|s| s.wall_ms).collect();
+    let audio_duration_ms = samples
+        .iter()
+        .map(|s| s.audio_duration_ms)
+        .max()
+        .unwrap_or(0);
+    let peak_rss_bytes = samples.iter().map(|s| s.peak_rss_bytes).max().unwrap_or(0);
+    Ok(SpeechBenchReport {
+        median_rtf: median_f64(&rtf),
+        median_wall_ms: median_u64(&wall),
+        audio_duration_ms,
+        peak_rss_bytes,
+        warmup_iterations: protocol.warmup_iterations,
+        timed_iterations: protocol.timed_iterations,
+        metadata,
+    })
+}
+
+/// Warmup + timed `transcribe()` samples, then median RTFx.
+///
+/// Same iteration counts as [`run_generation_bench`]. The engine's model
+/// weights stay loaded between calls — warmup drops first-load mmap, not a
+/// GPU L2 flush.
+pub fn run_speech_bench<F>(
+    mut sample: F,
+    protocol: &BenchProtocol,
+    metadata: BenchMetadata,
+    cancel: &CancelToken,
+) -> Result<SpeechBenchReport, BenchError>
+where
+    F: FnMut() -> Result<SpeechStats, EngineError>,
+{
+    if protocol.timed_iterations == 0 {
+        return Err(BenchError::NoSamples);
+    }
+    for _ in 0..protocol.warmup_iterations {
+        if cancel.is_cancelled() {
+            return Err(BenchError::Engine(EngineError::Cancelled));
+        }
+        sample()?;
+    }
+    let mut samples = Vec::with_capacity(protocol.timed_iterations as usize);
+    for _ in 0..protocol.timed_iterations {
+        if cancel.is_cancelled() {
+            return Err(BenchError::Engine(EngineError::Cancelled));
+        }
+        samples.push(sample()?);
+    }
+    aggregate_speech(&samples, protocol, metadata)
+}
+
+/// [`run_speech_bench`] against a live [`SpeechEngine`] and one PCM clip.
+pub fn run_speech_engine_bench(
+    engine: &dyn SpeechEngine,
+    audio: AudioInput<'_>,
+    options: &TranscriptionOptions,
+    protocol: &BenchProtocol,
+    metadata: BenchMetadata,
+    cancel: &CancelToken,
+) -> Result<SpeechBenchReport, BenchError> {
+    run_speech_bench(
+        || sample_speech_engine(engine, audio, options, cancel),
+        protocol,
+        metadata,
+        cancel,
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -430,5 +582,140 @@ mod tests {
         )
         .expect_err("cancelled");
         assert_eq!(err, BenchError::Engine(EngineError::Cancelled));
+    }
+
+    fn speech(audio_ms: u64, wall_ms: u64) -> SpeechStats {
+        SpeechStats {
+            audio_duration_ms: audio_ms,
+            wall_ms,
+            peak_rss_bytes: 2_000,
+        }
+    }
+
+    #[test]
+    fn speech_rtf_is_wall_over_audio() {
+        assert_eq!(speech(1000, 500).rtf(), 0.5);
+        assert_eq!(speech(0, 500).rtf(), 0.0);
+    }
+
+    #[test]
+    fn pcm_duration_is_samples_over_rate() {
+        let samples = [0i16; 16_000];
+        let audio = AudioInput {
+            samples: &samples,
+            sample_rate_hz: 16_000,
+            channels: 1,
+        };
+        assert_eq!(audio_duration_ms(audio), 1_000);
+        let empty = AudioInput {
+            samples: &[],
+            sample_rate_hz: 16_000,
+            channels: 1,
+        };
+        assert_eq!(audio_duration_ms(empty), 0);
+    }
+
+    #[test]
+    fn aggregate_speech_rejects_an_empty_timed_set() {
+        assert_eq!(
+            aggregate_speech(&[], &BenchProtocol::default(), BenchMetadata::default()),
+            Err(BenchError::NoSamples)
+        );
+    }
+
+    #[test]
+    fn speech_warmup_samples_are_discarded_from_the_median() {
+        let remaining = Mutex::new(vec![
+            speech(1000, 900),
+            speech(1000, 400),
+            speech(1000, 500),
+            speech(1000, 600),
+        ]);
+        let calls = AtomicU32::new(0);
+        let protocol = BenchProtocol {
+            warmup_iterations: 1,
+            timed_iterations: 3,
+        };
+        let report = run_speech_bench(
+            || {
+                calls.fetch_add(1, Ordering::SeqCst);
+                let mut remaining = remaining.lock().expect("scripted speech mutex");
+                Ok(remaining.remove(0))
+            },
+            &protocol,
+            BenchMetadata {
+                backend: AccelBackend::Metal,
+                clock_control: GpuClockControl::Unlocked,
+                gpu_layers: 0,
+                thread_count: 1,
+                mode: BenchMode::Combined,
+            },
+            &CancelToken::new(),
+        )
+        .expect("scripted speech bench");
+
+        assert_eq!(calls.load(Ordering::SeqCst), 4);
+        assert_eq!(report.median_wall_ms, 500);
+        assert_eq!(report.median_rtf, 0.5);
+        assert_eq!(report.audio_duration_ms, 1000);
+        assert_eq!(report.warmup_iterations, 1);
+        assert_eq!(report.timed_iterations, 3);
+        assert_eq!(report.metadata.backend, AccelBackend::Metal);
+        assert_eq!(report.peak_rss_bytes, 2_000);
+    }
+
+    #[test]
+    fn speech_zero_timed_iterations_is_no_samples() {
+        let calls = AtomicU32::new(0);
+        let err = run_speech_bench(
+            || {
+                calls.fetch_add(1, Ordering::SeqCst);
+                Ok(speech(1000, 500))
+            },
+            &BenchProtocol {
+                warmup_iterations: 1,
+                timed_iterations: 0,
+            },
+            BenchMetadata::default(),
+            &CancelToken::new(),
+        )
+        .expect_err("zero timed");
+        assert_eq!(err, BenchError::NoSamples);
+        assert_eq!(calls.load(Ordering::SeqCst), 0);
+    }
+
+    struct EmptySpeech;
+
+    impl SpeechEngine for EmptySpeech {
+        fn resource_request(&self) -> ResourceRequest {
+            ResourceRequest::new(64)
+        }
+
+        fn transcribe(
+            &self,
+            _audio: AudioInput<'_>,
+            _options: &TranscriptionOptions,
+            _cancel: &CancelToken,
+            _sink: &mut dyn FnMut(TranscriptSegment) -> Result<(), EngineError>,
+        ) -> Result<(), EngineError> {
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn sample_speech_engine_rejects_zero_duration_audio() {
+        let audio = AudioInput {
+            samples: &[],
+            sample_rate_hz: 16_000,
+            channels: 1,
+        };
+        let err = sample_speech_engine(
+            &EmptySpeech,
+            audio,
+            &TranscriptionOptions::default(),
+            &CancelToken::new(),
+        )
+        .expect_err("empty pcm");
+        assert!(matches!(err, EngineError::InvalidInput(_)));
     }
 }

--- a/rust/airo_mind_core/src/lib.rs
+++ b/rust/airo_mind_core/src/lib.rs
@@ -130,8 +130,10 @@ pub mod verb;
 pub mod wav;
 
 pub use bench::{
-    aggregate, median_f64, median_u64, run_generation_bench, AccelBackend, BenchError,
-    BenchMetadata, BenchMode, BenchProtocol, BenchReport, GpuClockControl,
+    aggregate, aggregate_speech, audio_duration_ms, median_f64, median_u64, run_generation_bench,
+    run_speech_bench, run_speech_engine_bench, sample_speech_engine, AccelBackend, BenchError,
+    BenchMetadata, BenchMode, BenchProtocol, BenchReport, GpuClockControl, SpeechBenchReport,
+    SpeechStats,
 };
 pub use budget::{ResourceBudget, ResourceRequest};
 pub use cancel::CancelToken;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Follow-up to #1817 (generation bench protocol already on `main`). This branch adds:

- **Production Model Bench:** `mindRuntimeProvider` injects `createProductionModelPort` so Load / Run bench use a real GGUF engine instead of the fixture catalog. Unloaded engines stay `MindPortUnavailable` (no invented tok/s).
- **Speech RTFx:** same warmup + median as generation. Headline is `wall_ms / audio_duration_ms` (below 1.0 = faster than real time). Empty PCM fails; `SpeechEngine` is not widened with `stats()`.

This does **not** port CUDA events, L2 flush, dummy GEMMs, or `ncu`. CUDA remains a named Windows seam, not a linked default.

Rebased onto current `main` so the clippy `sort_by_key` fix and calendar/intelligence work are included.

Docs: [docs/features/airo-mind/GENERATION_BENCH_PROTOCOL.md](docs/features/airo-mind/GENERATION_BENCH_PROTOCOL.md)

## Test Plan

- [x] `cargo test -p airo_mind_core --lib bench` — 12 passed
- [x] `cd packages/feature_mind && flutter test test/model_bench` plus runtime/panel/GGUF tests — unique bench tests passed
- [x] Pre-existing on `main` (not introduced here): `module_contract_test` flags `rust_preferred_operation_log.dart`; thermal test can race with `LazyPersistentOperationLog` temp-dir teardown
- [ ] Manual device verification documented, or not applicable

**Verification environment:** Host-only (Linux cloud). CUDA link and device-rig verification are out of this environment.

## Agent Policy

- [x] Gap analysis first (no CUDA-kernel cargo-cult).
- [x] Cross-agent contract: framework owns protocol + `GpuBackend.cuda`; application consumes it. `ModelPort.benchmark()` signature unchanged. Speech RTFx does not widen `SpeechEngine`.
- [x] Android Emulator was not used.

## Council Review

- Rust Architect
- Chief Performance Officer
- Product Manager
- Framework Agent (`core_ai` `GpuBackend.cuda`)
- Chief QA Officer
- Chief UX Officer (Model Management Load / Run bench)

- [x] I checked the Decision Matrix and listed every required role above.
- [x] Every package touched has a `module.yaml`
- [x] `owner`/`reviewers` in touched `module.yaml` files were not changed

## User-Facing Documentation

- [x] No `docs/wiki` update is needed because Model Management Load/Run bench is an in-app runtime surface already covered by the internal protocol doc.

## Plugin and Size Impact

- [ ] This PR adds new dependencies
- [x] This PR adds or grows app/packages/plugins code
- [x] Size impact is documented below

No new dependencies. CUDA Cargo feature does not enable `llama-cpp-2/cuda` yet.

## Checklist

- [x] Code is formatted.
- [x] Tests or manual verification are included above.
- [x] Sensitive data, credentials, and signing artifacts are not committed.

## Release Notes

- [x] Model Management can load a resident GGUF and run an on-device generation bench (median tok/s and TTFT). Speech RTFx (`wall / audio`) is the matching whisper protocol. CUDA remains a Windows testing seam.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-95a55305-37f8-4847-aa62-a2cf7ba53319?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-95a55305-37f8-4847-aa62-a2cf7ba53319&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

