### PR TITLE
feat(mind): multilingual notebook with live capture, recap, and share

### DIFF
--- a/app/lib/core/mind/mind_processing_queue.dart
+++ b/app/lib/core/mind/mind_processing_queue.dart
@@ -28,6 +28,18 @@ List<Override> mindMeetingProcessingOverrides(MindService service) => [
       // Same live-read pattern for #1664 language mode → process(language:)
       // and ensureReady(speechLanguage:).
       languageMode: () => ref.read(speechLanguageModeProvider),
+      onProcessed: (job, last) async {
+        final capability = await openNotebookCapability();
+        await NotebookRepository(capability).ingestProcessed(
+          job: job,
+          transcript: last.transcript,
+          minutes: last.minutes,
+          meetingId: last.meetingId,
+          languageCode: ref
+              .read(speechLanguageModeProvider)
+              .processLanguageCode,
+        );
+      },
     );
     final queue = MeetingProcessingQueue(
       store: FileMeetingProcessingQueueStore(path),

--- a/docs/superpowers/specs/2026-08-20-airo-mind-notebook.md
+++ b/docs/superpowers/specs/2026-08-20-airo-mind-notebook.md
@@ -1,0 +1,91 @@
+# Airo Mind notebook — multilingual capture, recap, and organisation
+
+## Objective
+
+Make Airo Mind a notebook people can actually run their day on: record or
+import speech in many languages, get an accurate transcript plus an AI
+summary and key points, combine several notes into one Super Summary, keep
+the library searchable with labels and tags, and export / copy / share the
+result.
+
+**Target user**: someone who records meetings, lectures, voice memos, or
+podcasts on a phone or desktop and wants the notes to stay on-device.
+
+## What already existed
+
+- Live meeting capture (`MeetingCaptureScreen` / `MindService.startRecording`)
+  and the whisper.cpp pipeline (`MindService.process`).
+- Two transcription modes only: Auto (multilingual) and English-only (#1664).
+- Meeting minutes + Meeting IR (decisions, action items, metrics).
+- Meeting markdown export and share (#1663).
+- Semantic search over *meetings*, not notes.
+- Notes capability (`#1338`) as a runtime skeleton: `create` / `edit` /
+  `delete` of `id` + `title` + `body`. The Rust twin encodes those three
+  strings and nothing else.
+
+## What this spec adds
+
+1. **Multiple languages** — a real transcription-language catalog (Indic +
+   major world languages) on top of Auto / English, plus notebook UI copy in
+   several locales.
+2. **Live voice recording with accurate transcription** — the existing
+   whisper pipeline remains the accuracy path; finishing a recording also
+   writes a notebook note.
+3. **Podcasts and uploaded audio** — file picker and remote URL download
+   enqueue the same processing job as a live recording.
+4. **AI summary and key points** — derived from minutes, action items, and
+   transcript; stored on the note.
+5. **Super Summary** — select several notes and fold them into one recap
+   note, with an optional generation hook and a deterministic extractive
+   fallback when no model is available.
+6. **Labels, tags, and search** — first-class on the notebook document;
+   library filter is keyword + tag + label + language.
+7. **Export, copy, share** — markdown of one note or a Super Summary, via
+   clipboard, share sheet, or save-to-folder.
+
+## Architecture
+
+The Notes operation log stays the durability seam (`C5` / `I4`). Product
+fields are **opaque payload inside `body`**, so the Rust `note.create` /
+`note.edit` encoding does not change:
+
+```
+Note.title  → display title
+Note.body   → plaintext (legacy / simple notes)
+              OR JSON envelope `airo.mind.notebook.v1`
+```
+
+```
+Audio (live | file | podcast URL)
+        │
+        ▼
+MeetingProcessingQueue  →  MindService.process (whisper + minutes)
+        │
+        ▼
+NotebookIngest  →  NotesCapability.create/edit
+        │
+        ▼
+NotebookDocument (transcript, summary, key points, tags, labels, language)
+        │
+        ├─ search / tag filter
+        ├─ Super Summary (N notes → 1 recap note)
+        └─ export / copy / share markdown
+```
+
+Simple notes with only a title and body still store plaintext, so the
+`#1338` vertical-slice tests and any handwritten notes keep working.
+
+## Non-goals
+
+- Changing the Rust notes wire format or adding `note.tag` operations.
+- Shipping a new speech engine. Accuracy still comes from the installed
+  whisper weights and the language pin.
+- Cloud transcription. Capture stays on-device; a remote podcast URL is
+  downloaded then processed locally.
+- Replacing meeting search. Meetings keep their own FTS + semantic ranker.
+
+## Ownership
+
+Application work in `feature_mind` (Product Manager). Reviewers already on
+`module.yaml`: Chief Architect, Platform Architect, Chief Security Officer,
+Chief Cloud Officer, Chief QA Officer.

--- a/docs/wiki/3.-Navigating-Airo.md
+++ b/docs/wiki/3.-Navigating-Airo.md
@@ -31,6 +31,8 @@ includes:
 - Profile and **Intelligence** at `/mind/profile` and `/mind/models`.
   Intelligence is the task-first control center: pick a job (Chat, Scribe,
   Documents, Vision) and Airo selects the model.
+- Scribe **Notes** (`/scribe/notes` on the phone app, `/notes` in standalone
+  Airo Mind) for recordings, imported audio, Super Summary, tags, and share.
 - A Calendar destination at `/mind/calendar` (not a fifth bottom-nav tab)
   that lists today's events from every calendar the device already syncs.
 

--- a/docs/wiki/4.-Using-Core-Capabilities.md
+++ b/docs/wiki/4.-Using-Core-Capabilities.md
@@ -108,6 +108,36 @@ Saved meeting intelligence also generates structured local sections for summary,
 decisions, risks, open questions, follow-ups, blockers, dependencies, and next
 steps from final redacted transcript content.
 
+## Airo Mind notes
+
+The Airo Mind notebook is the local library for recordings, uploads, and
+written notes. Open it from Scribe (**Notes**) or the Mind runtime hub.
+
+- **Languages.** Profile → Meeting transcription language picks Auto
+  (mixed-language detect) or a pinned language (Hindi, Marathi, Spanish, and
+  the rest of the catalog). English-only still skips the multilingual speech
+  download. Notes language on the same Profile page localizes the notebook UI
+  (English, Hindi, Marathi, Spanish, French, German, Portuguese, Japanese,
+  Chinese, Arabic).
+- **Live recording.** Record from Scribe or Notes. Capture still goes through
+  the on-device whisper pipeline; when processing finishes, a notebook note is
+  created with transcript, summary, and key points.
+- **Uploaded audio and podcasts.** Notes can import a local audio file or a
+  podcast URL. The file is copied into Mind's recordings folder, queued, and
+  transcribed the same way as a live recording. Supported types include m4a,
+  mp3, wav, ogg, flac, and similar containers.
+- **Summary and key points.** Minutes and action items become a summary plus
+  a key-point list stored on the note.
+- **Super Summary.** Select two or more notes and combine them into one recap
+  note (tags, key points, and source titles folded together).
+- **Tags, labels, and search.** Edit a note to add comma-separated tags and
+  labels. The library search box matches title, body, transcript, summary,
+  tags, and labels; tag chips filter the list.
+- **Export, copy, share.** From a note, copy markdown, share it, or save it
+  as a `.md` file. Nothing leaves the device unless you share it.
+
+Audio stays on-device. A podcast URL is downloaded, then transcribed locally.
+
 ## Prompt Lab
 
 Prompt Lab is a controlled workspace for testing prompts before sending them to

--- a/packages/feature_mind/lib/feature_mind.dart
+++ b/packages/feature_mind/lib/feature_mind.dart
@@ -320,6 +320,27 @@ export 'src/notes/domain/notes_projection.dart';
 export 'src/notes/notes_capability.dart';
 export 'src/notes/presentation/notes_screen.dart';
 
+// Notebook product layer on top of the Notes capability: multilingual
+// capture, file/podcast import, summary + key points, Super Summary, tags,
+// search, and export/copy/share. Payload lives in Note.body so the runtime
+// skeleton encoding does not change.
+export 'src/notebook/domain/notebook_source.dart';
+export 'src/notebook/domain/notebook_document.dart';
+export 'src/notebook/domain/notebook_note.dart';
+export 'src/notebook/domain/key_points_extractor.dart';
+export 'src/notebook/domain/notebook_summary.dart';
+export 'src/notebook/domain/super_summary.dart';
+export 'src/notebook/domain/notebook_search.dart';
+export 'src/notebook/domain/notebook_export.dart';
+export 'src/notebook/domain/notebook_l10n.dart';
+export 'src/notebook/application/notebook_repository.dart';
+export 'src/notebook/application/audio_import_service.dart';
+export 'src/notebook/application/notebook_share_port.dart';
+export 'src/notebook/application/notebook_locale_preference.dart';
+export 'src/notebook/application/notebook_store.dart';
+export 'src/notebook/presentation/notebook_locale_settings_tile.dart';
+export 'src/notebook/presentation/notebook_host_screen.dart';
+
 // In-app meeting audio capture + resumable background processing (#1656).
 // Feeds `meetings.dart`'s `transcribeRecording`/`saveMeeting` (the ".m4a in"
 // pipeline) with a file this package now records itself, instead of only

--- a/packages/feature_mind/lib/src/agent_chat/presentation/screens/profile_screen.dart
+++ b/packages/feature_mind/lib/src/agent_chat/presentation/screens/profile_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import '../../../capture/presentation/audio_retention_settings_tile.dart';
 import '../../../capture/presentation/speech_language_settings_tile.dart';
+import '../../../notebook/presentation/notebook_locale_settings_tile.dart';
 import '../../../settings/indic_generation_settings_tile.dart';
 import '../../../settings/indic_speech_backend_settings_tile.dart';
 import '../../../host/assistant_host_adapter.dart';
@@ -82,6 +83,7 @@ class ProfileScreen extends ConsumerWidget {
             ),
             const AudioRetentionSettingsTile(),
             const SpeechLanguageSettingsTile(),
+            const NotebookLocaleSettingsTile(),
             const IndicGenerationSettingsTile(),
             const IndicSpeechBackendSettingsTile(),
 

--- a/packages/feature_mind/lib/src/capture/application/meeting_processing_job_runner.dart
+++ b/packages/feature_mind/lib/src/capture/application/meeting_processing_job_runner.dart
@@ -34,13 +34,16 @@ class MeetingProcessingJobRunner {
     required MindService mindService,
     required AudioRetentionPolicy Function() retentionPolicy,
     SpeechLanguageMode Function()? languageMode,
+    MeetingProcessedCallback? onProcessed,
   }) : _mindService = mindService,
        _retentionPolicy = retentionPolicy,
-       _languageMode = languageMode ?? (() => SpeechLanguageMode.fallback);
+       _languageMode = languageMode ?? (() => SpeechLanguageMode.fallback),
+       _onProcessed = onProcessed;
 
   final MindService _mindService;
   final AudioRetentionPolicy Function() _retentionPolicy;
   final SpeechLanguageMode Function() _languageMode;
+  final MeetingProcessedCallback? _onProcessed;
 
   Future<void> call(MeetingProcessingJob job) async {
     final mode = _languageMode();
@@ -48,7 +51,9 @@ class MeetingProcessingJobRunner {
       speechLanguage: mode.speechLanguage,
     );
     if (!ready.isReady) {
-      throw StateError(ready.detail.isNotEmpty ? ready.detail : 'Mind is not ready.');
+      throw StateError(
+        ready.detail.isNotEmpty ? ready.detail : 'Mind is not ready.',
+      );
     }
     MindProgress? last;
     await for (final progress in _mindService.process(
@@ -60,6 +65,10 @@ class MeetingProcessingJobRunner {
     }
     if (last == null || last.stage == MindStage.failed) {
       throw StateError(last?.error ?? 'Processing produced no result.');
+    }
+    final onProcessed = _onProcessed;
+    if (onProcessed != null) {
+      await onProcessed(job, last);
     }
     await _deleteAudioIfPolicySaysDelete(job);
   }
@@ -79,3 +88,9 @@ class MeetingProcessingJobRunner {
     }
   }
 }
+
+/// Called after a job's transcription + minutes pipeline succeeds, before
+/// retention cleanup. Notebook ingest hooks in here so a live recording, an
+/// uploaded file, and a podcast URL all become searchable notes.
+typedef MeetingProcessedCallback =
+    Future<void> Function(MeetingProcessingJob job, MindProgress last);

--- a/packages/feature_mind/lib/src/capture/application/speech_language_preference.dart
+++ b/packages/feature_mind/lib/src/capture/application/speech_language_preference.dart
@@ -34,10 +34,9 @@ class SpeechLanguageModeNotifier extends StateNotifier<SpeechLanguageMode> {
 
 /// Bridge mapping kept next to the preference so domain stays free of FRB types.
 extension SpeechLanguageModeBridge on SpeechLanguageMode {
-  rust.SpeechLanguage get speechLanguage => switch (this) {
-    SpeechLanguageMode.auto => rust.SpeechLanguage.multilingual,
-    SpeechLanguageMode.english => rust.SpeechLanguage.englishOnly,
-  };
+  rust.SpeechLanguage get speechLanguage => englishOnly
+      ? rust.SpeechLanguage.englishOnly
+      : rust.SpeechLanguage.multilingual;
 }
 
 /// Reads the persisted mode without Riverpod — used by shell composition

--- a/packages/feature_mind/lib/src/capture/domain/meeting_processing_job.dart
+++ b/packages/feature_mind/lib/src/capture/domain/meeting_processing_job.dart
@@ -29,6 +29,25 @@ enum MeetingProcessingStatus {
       this == MeetingProcessingStatus.failed;
 }
 
+/// Where the audio for a processing job came from.
+enum MeetingProcessingSource {
+  /// In-app microphone capture.
+  live,
+
+  /// A local file the person picked (voice memo, lecture recording, …).
+  upload,
+
+  /// A remote podcast / audio URL downloaded then queued.
+  podcast;
+
+  static MeetingProcessingSource fromName(String? name) {
+    return MeetingProcessingSource.values.firstWhere(
+      (value) => value.name == name,
+      orElse: () => MeetingProcessingSource.live,
+    );
+  }
+}
+
 /// One recording's trip through transcription + extraction.
 ///
 /// Everything here is plain data so it round-trips through JSON — the whole
@@ -43,6 +62,7 @@ class MeetingProcessingJob {
     this.status = MeetingProcessingStatus.queued,
     this.attempt = 0,
     this.lastError,
+    this.source = MeetingProcessingSource.live,
   });
 
   /// Stable id for this job — the recording session id it was enqueued from.
@@ -65,10 +85,15 @@ class MeetingProcessingJob {
 
   final String? lastError;
 
+  /// Live capture vs uploaded file vs podcast URL. Missing from older queue
+  /// files — [MeetingProcessingSource.fromName] treats that as [live].
+  final MeetingProcessingSource source;
+
   MeetingProcessingJob copyWith({
     MeetingProcessingStatus? status,
     int? attempt,
     String? lastError,
+    MeetingProcessingSource? source,
   }) {
     return MeetingProcessingJob(
       id: id,
@@ -78,6 +103,7 @@ class MeetingProcessingJob {
       status: status ?? this.status,
       attempt: attempt ?? this.attempt,
       lastError: lastError ?? this.lastError,
+      source: source ?? this.source,
     );
   }
 
@@ -89,6 +115,7 @@ class MeetingProcessingJob {
     'status': status.name,
     'attempt': attempt,
     'lastError': lastError,
+    'source': source.name,
   };
 
   static MeetingProcessingJob fromJson(Map<String, Object?> json) {
@@ -103,6 +130,7 @@ class MeetingProcessingJob {
       ),
       attempt: json['attempt'] as int? ?? 0,
       lastError: json['lastError'] as String?,
+      source: MeetingProcessingSource.fromName(json['source'] as String?),
     );
   }
 }

--- a/packages/feature_mind/lib/src/capture/domain/speech_language_mode.dart
+++ b/packages/feature_mind/lib/src/capture/domain/speech_language_mode.dart
@@ -1,46 +1,338 @@
-/// Transcription language mode for meeting capture (#1664 / #1774).
+/// Transcription language for meeting capture and notebook ingest (#1664 / #1774).
 ///
-/// Two product choices, not a full language picker:
-/// - [auto] — multilingual whisper weights and per-recording auto-detect
-///   (mixed Marathi / Hindi / English and similar code-switching).
-/// - [english] — English-only weights and a pinned `"en"` hint, so English-only
-///   users never have to download the multilingual model.
-///
-/// Maps to `MindService.initialize(speechLanguage:)` (which model loads) and
-/// `MindService.process(language:)` (whisper.cpp language pin / auto-detect).
+/// [auto] loads multilingual whisper weights and leaves per-recording
+/// auto-detect on — the right default for mixed Marathi / Hindi / English.
+/// [english] pins `"en"` and skips the multilingual download.
+/// Every other value loads the multilingual model and pins the whisper.cpp
+/// language code, so a Hindi lecture is not left to auto-detect.
 library;
 
 enum SpeechLanguageMode {
-  /// Multilingual model + auto-detect. Default for the Mind shell.
-  auto,
+  auto(
+    whisperCode: null,
+    englishOnly: false,
+    badgeLabel: 'Multilingual · auto-detect',
+    menuLabel: 'Auto (mixed)',
+  ),
+  english(
+    whisperCode: 'en',
+    englishOnly: true,
+    badgeLabel: 'English',
+    menuLabel: 'English',
+  ),
+  hindi(
+    whisperCode: 'hi',
+    englishOnly: false,
+    badgeLabel: 'Hindi',
+    menuLabel: 'Hindi · हिन्दी',
+  ),
+  marathi(
+    whisperCode: 'mr',
+    englishOnly: false,
+    badgeLabel: 'Marathi',
+    menuLabel: 'Marathi · मराठी',
+  ),
+  tamil(
+    whisperCode: 'ta',
+    englishOnly: false,
+    badgeLabel: 'Tamil',
+    menuLabel: 'Tamil · தமிழ்',
+  ),
+  telugu(
+    whisperCode: 'te',
+    englishOnly: false,
+    badgeLabel: 'Telugu',
+    menuLabel: 'Telugu · తెలుగు',
+  ),
+  bengali(
+    whisperCode: 'bn',
+    englishOnly: false,
+    badgeLabel: 'Bengali',
+    menuLabel: 'Bengali · বাংলা',
+  ),
+  gujarati(
+    whisperCode: 'gu',
+    englishOnly: false,
+    badgeLabel: 'Gujarati',
+    menuLabel: 'Gujarati · ગુજરાતી',
+  ),
+  kannada(
+    whisperCode: 'kn',
+    englishOnly: false,
+    badgeLabel: 'Kannada',
+    menuLabel: 'Kannada · ಕನ್ನಡ',
+  ),
+  malayalam(
+    whisperCode: 'ml',
+    englishOnly: false,
+    badgeLabel: 'Malayalam',
+    menuLabel: 'Malayalam · മലയാളം',
+  ),
+  punjabi(
+    whisperCode: 'pa',
+    englishOnly: false,
+    badgeLabel: 'Punjabi',
+    menuLabel: 'Punjabi · ਪੰਜਾਬੀ',
+  ),
+  urdu(
+    whisperCode: 'ur',
+    englishOnly: false,
+    badgeLabel: 'Urdu',
+    menuLabel: 'Urdu · اردو',
+  ),
+  sanskrit(
+    whisperCode: 'sa',
+    englishOnly: false,
+    badgeLabel: 'Sanskrit',
+    menuLabel: 'Sanskrit · संस्कृतम्',
+  ),
+  nepali(
+    whisperCode: 'ne',
+    englishOnly: false,
+    badgeLabel: 'Nepali',
+    menuLabel: 'Nepali · नेपाली',
+  ),
+  sinhala(
+    whisperCode: 'si',
+    englishOnly: false,
+    badgeLabel: 'Sinhala',
+    menuLabel: 'Sinhala · සිංහල',
+  ),
+  spanish(
+    whisperCode: 'es',
+    englishOnly: false,
+    badgeLabel: 'Spanish',
+    menuLabel: 'Spanish · Español',
+  ),
+  french(
+    whisperCode: 'fr',
+    englishOnly: false,
+    badgeLabel: 'French',
+    menuLabel: 'French · Français',
+  ),
+  german(
+    whisperCode: 'de',
+    englishOnly: false,
+    badgeLabel: 'German',
+    menuLabel: 'German · Deutsch',
+  ),
+  portuguese(
+    whisperCode: 'pt',
+    englishOnly: false,
+    badgeLabel: 'Portuguese',
+    menuLabel: 'Portuguese · Português',
+  ),
+  italian(
+    whisperCode: 'it',
+    englishOnly: false,
+    badgeLabel: 'Italian',
+    menuLabel: 'Italian · Italiano',
+  ),
+  dutch(
+    whisperCode: 'nl',
+    englishOnly: false,
+    badgeLabel: 'Dutch',
+    menuLabel: 'Dutch · Nederlands',
+  ),
+  russian(
+    whisperCode: 'ru',
+    englishOnly: false,
+    badgeLabel: 'Russian',
+    menuLabel: 'Russian · Русский',
+  ),
+  japanese(
+    whisperCode: 'ja',
+    englishOnly: false,
+    badgeLabel: 'Japanese',
+    menuLabel: 'Japanese · 日本語',
+  ),
+  korean(
+    whisperCode: 'ko',
+    englishOnly: false,
+    badgeLabel: 'Korean',
+    menuLabel: 'Korean · 한국어',
+  ),
+  chinese(
+    whisperCode: 'zh',
+    englishOnly: false,
+    badgeLabel: 'Chinese',
+    menuLabel: 'Chinese · 中文',
+  ),
+  arabic(
+    whisperCode: 'ar',
+    englishOnly: false,
+    badgeLabel: 'Arabic',
+    menuLabel: 'Arabic · العربية',
+  ),
+  turkish(
+    whisperCode: 'tr',
+    englishOnly: false,
+    badgeLabel: 'Turkish',
+    menuLabel: 'Turkish · Türkçe',
+  ),
+  polish(
+    whisperCode: 'pl',
+    englishOnly: false,
+    badgeLabel: 'Polish',
+    menuLabel: 'Polish · Polski',
+  ),
+  vietnamese(
+    whisperCode: 'vi',
+    englishOnly: false,
+    badgeLabel: 'Vietnamese',
+    menuLabel: 'Vietnamese · Tiếng Việt',
+  ),
+  indonesian(
+    whisperCode: 'id',
+    englishOnly: false,
+    badgeLabel: 'Indonesian',
+    menuLabel: 'Indonesian · Bahasa Indonesia',
+  ),
+  thai(
+    whisperCode: 'th',
+    englishOnly: false,
+    badgeLabel: 'Thai',
+    menuLabel: 'Thai · ไทย',
+  ),
+  ukrainian(
+    whisperCode: 'uk',
+    englishOnly: false,
+    badgeLabel: 'Ukrainian',
+    menuLabel: 'Ukrainian · Українська',
+  ),
+  swedish(
+    whisperCode: 'sv',
+    englishOnly: false,
+    badgeLabel: 'Swedish',
+    menuLabel: 'Swedish · Svenska',
+  ),
+  czech(
+    whisperCode: 'cs',
+    englishOnly: false,
+    badgeLabel: 'Czech',
+    menuLabel: 'Czech · Čeština',
+  ),
+  greek(
+    whisperCode: 'el',
+    englishOnly: false,
+    badgeLabel: 'Greek',
+    menuLabel: 'Greek · Ελληνικά',
+  ),
+  hebrew(
+    whisperCode: 'he',
+    englishOnly: false,
+    badgeLabel: 'Hebrew',
+    menuLabel: 'Hebrew · עברית',
+  ),
+  persian(
+    whisperCode: 'fa',
+    englishOnly: false,
+    badgeLabel: 'Persian',
+    menuLabel: 'Persian · فارسی',
+  ),
+  swahili(
+    whisperCode: 'sw',
+    englishOnly: false,
+    badgeLabel: 'Swahili',
+    menuLabel: 'Swahili · Kiswahili',
+  ),
+  filipino(
+    whisperCode: 'tl',
+    englishOnly: false,
+    badgeLabel: 'Filipino',
+    menuLabel: 'Filipino · Tagalog',
+  ),
+  malay(
+    whisperCode: 'ms',
+    englishOnly: false,
+    badgeLabel: 'Malay',
+    menuLabel: 'Malay · Bahasa Melayu',
+  ),
+  romanian(
+    whisperCode: 'ro',
+    englishOnly: false,
+    badgeLabel: 'Romanian',
+    menuLabel: 'Romanian · Română',
+  ),
+  hungarian(
+    whisperCode: 'hu',
+    englishOnly: false,
+    badgeLabel: 'Hungarian',
+    menuLabel: 'Hungarian · Magyar',
+  ),
+  finnish(
+    whisperCode: 'fi',
+    englishOnly: false,
+    badgeLabel: 'Finnish',
+    menuLabel: 'Finnish · Suomi',
+  ),
+  danish(
+    whisperCode: 'da',
+    englishOnly: false,
+    badgeLabel: 'Danish',
+    menuLabel: 'Danish · Dansk',
+  ),
+  norwegian(
+    whisperCode: 'no',
+    englishOnly: false,
+    badgeLabel: 'Norwegian',
+    menuLabel: 'Norwegian · Norsk',
+  );
 
-  /// English-only model + pin `en`. Opt-in to skip the multilingual download.
-  english;
+  const SpeechLanguageMode({
+    required this.whisperCode,
+    required this.englishOnly,
+    required this.badgeLabel,
+    required this.menuLabel,
+  });
+
+  /// Whisper.cpp language code, or `null` to leave auto-detect on.
+  final String? whisperCode;
+
+  /// When true, first-run download may skip multilingual speech weights.
+  final bool englishOnly;
+
+  /// Badge / chip label on record surfaces.
+  final String badgeLabel;
+
+  /// Settings dropdown row.
+  final String menuLabel;
 
   /// Product default: mixed-language meetings are first-class (#1629).
   static const SpeechLanguageMode fallback = SpeechLanguageMode.auto;
 
   String get storageValue => name;
 
-  /// Badge / chip label on record surfaces.
-  String get badgeLabel => switch (this) {
-    SpeechLanguageMode.auto => 'Multilingual · auto-detect',
-    SpeechLanguageMode.english => 'English',
-  };
-
   /// Whisper.cpp language code for [MindService.process], or `null` to leave
   /// auto-detect on.
-  String? get processLanguageCode => switch (this) {
-    SpeechLanguageMode.auto => null,
-    SpeechLanguageMode.english => 'en',
-  };
+  String? get processLanguageCode => whisperCode;
 
   /// Whether first-run download must include the multilingual speech weights.
-  bool get includesMultilingualModel => this == SpeechLanguageMode.auto;
+  bool get includesMultilingualModel => !englishOnly;
+
+  /// Copy under the Settings tile.
+  String get settingsSubtitle => switch (this) {
+    SpeechLanguageMode.auto =>
+      'Auto (mixed) — multilingual model, auto-detect per recording. '
+          'Best for Marathi / Hindi / English code-switching.',
+    SpeechLanguageMode.english =>
+      'English — English-only model. Skips the multilingual download.',
+    _ =>
+      'Pins transcription to $badgeLabel (${whisperCode ?? 'auto'}). '
+          'Uses the multilingual model.',
+  };
 
   static SpeechLanguageMode fromStorageValue(String? value) {
     return SpeechLanguageMode.values.firstWhere(
       (mode) => mode.storageValue == value,
+      orElse: () => fallback,
+    );
+  }
+
+  static SpeechLanguageMode fromWhisperCode(String? code) {
+    if (code == null || code.isEmpty) return fallback;
+    return SpeechLanguageMode.values.firstWhere(
+      (mode) => mode.whisperCode == code,
       orElse: () => fallback,
     );
   }

--- a/packages/feature_mind/lib/src/capture/presentation/meeting_capture_screen.dart
+++ b/packages/feature_mind/lib/src/capture/presentation/meeting_capture_screen.dart
@@ -120,6 +120,7 @@ class _MeetingCaptureScreenState extends ConsumerState<MeetingCaptureScreen> {
         audioPath: path,
         title: 'Meeting ${DateTime.now().toLocal()}',
         enqueuedAtMs: DateTime.now().millisecondsSinceEpoch,
+        source: MeetingProcessingSource.live,
       ),
     );
   }

--- a/packages/feature_mind/lib/src/capture/presentation/speech_language_settings_tile.dart
+++ b/packages/feature_mind/lib/src/capture/presentation/speech_language_settings_tile.dart
@@ -4,12 +4,13 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../application/speech_language_preference.dart';
 import '../domain/speech_language_mode.dart';
 
-/// Settings control for #1664 / #1774 — Primary language vs Auto (mixed).
+/// Settings control for #1664 / #1774 — a real language catalog, not only
+/// Auto vs English.
 ///
 /// Drop into the Mind Profile / capture settings surface next to
 /// [AudioRetentionSettingsTile]. Choosing English skips the multilingual
 /// whisper download on the next model acquisition; Auto keeps mixed-language
-/// auto-detect.
+/// auto-detect; every other row pins a whisper.cpp language code.
 class SpeechLanguageSettingsTile extends ConsumerWidget {
   const SpeechLanguageSettingsTile({super.key});
 
@@ -20,12 +21,7 @@ class SpeechLanguageSettingsTile extends ConsumerWidget {
     return ListTile(
       key: const Key('speech_language_settings_tile'),
       title: const Text('Meeting transcription language'),
-      subtitle: Text(
-        mode == SpeechLanguageMode.auto
-            ? 'Auto (mixed) — multilingual model, auto-detect per recording. '
-                  'Best for Marathi / Hindi / English code-switching.'
-            : 'English — English-only model. Skips the multilingual download.',
-      ),
+      subtitle: Text(mode.settingsSubtitle),
       trailing: DropdownButton<SpeechLanguageMode>(
         key: const Key('speech_language_settings_dropdown'),
         value: mode,
@@ -33,15 +29,9 @@ class SpeechLanguageSettingsTile extends ConsumerWidget {
           if (value == null) return;
           ref.read(speechLanguageModeProvider.notifier).select(value);
         },
-        items: const [
-          DropdownMenuItem(
-            value: SpeechLanguageMode.auto,
-            child: Text('Auto (mixed)'),
-          ),
-          DropdownMenuItem(
-            value: SpeechLanguageMode.english,
-            child: Text('English'),
-          ),
+        items: [
+          for (final item in SpeechLanguageMode.values)
+            DropdownMenuItem(value: item, child: Text(item.menuLabel)),
         ],
       ),
     );

--- a/packages/feature_mind/lib/src/mind_home_screen.dart
+++ b/packages/feature_mind/lib/src/mind_home_screen.dart
@@ -205,6 +205,13 @@ class _MindHomeScreenState extends State<MindHomeScreen> {
         actions: [
           if (status != null && status.isReady)
             IconButton(
+              key: const Key('mind_home_notes_button'),
+              tooltip: 'Notes',
+              icon: const Icon(Icons.edit_note),
+              onPressed: () => context.push('notes'),
+            ),
+          if (status != null && status.isReady)
+            IconButton(
               key: const Key('mind_home_record_meeting_button'),
               tooltip: 'Record a meeting',
               icon: const Icon(Icons.mic_none),

--- a/packages/feature_mind/lib/src/mind_module.dart
+++ b/packages/feature_mind/lib/src/mind_module.dart
@@ -26,6 +26,7 @@ import 'meeting_archive/meeting_archive_port.dart';
 import 'mind_home_screen.dart';
 import 'mind_service.dart';
 import 'routing/assistant_route_names.dart';
+import 'surfaces/mind_runtime_hub_screen.dart';
 import 'wellbeing/presentation/screens/wellbeing_screen.dart';
 
 /// Builds the host adapter for a shell, given that shell's Riverpod [Ref].
@@ -173,6 +174,17 @@ class MindModule extends AppModule {
             path: 'record',
             name: 'mind_meeting_capture',
             builder: (context, state) => const MeetingCaptureScreen(),
+          ),
+          GoRoute(
+            path: 'notes',
+            name: 'mind_notebook',
+            builder: (context, state) => MindRuntimeNotesScreen(
+              onRecordLive: () async {
+                await context.push(
+                  shell == ShellId.mind ? '/record' : '/scribe/record',
+                );
+              },
+            ),
           ),
         ],
       ),

--- a/packages/feature_mind/lib/src/notebook/application/audio_import_service.dart
+++ b/packages/feature_mind/lib/src/notebook/application/audio_import_service.dart
@@ -1,0 +1,128 @@
+import 'dart:io';
+
+import 'package:dio/dio.dart';
+import 'package:file_picker/file_picker.dart';
+import 'package:path/path.dart' as p;
+
+import '../../capture/domain/meeting_processing_job.dart';
+
+/// Picks a local audio file or downloads a podcast URL into a path the
+/// processing queue can transcribe.
+class AudioImportService {
+  AudioImportService({FilePickerPick? pickFile, AudioDownloader? downloader})
+    : _pickFile = pickFile ?? _defaultPick,
+      _downloader = downloader ?? _dioDownload;
+
+  final FilePickerPick _pickFile;
+  final AudioDownloader _downloader;
+
+  static const supportedExtensions = <String>{
+    'm4a',
+    'm4b',
+    'aac',
+    'wav',
+    'mp3',
+    'ogg',
+    'opus',
+    'flac',
+    'mp4',
+    'webm',
+    'wma',
+    'aiff',
+    'caf',
+  };
+
+  bool isSupportedPath(String path) {
+    final ext = p.extension(path).toLowerCase().replaceAll('.', '');
+    return supportedExtensions.contains(ext);
+  }
+
+  bool isHttpUrl(String value) {
+    final uri = Uri.tryParse(value.trim());
+    if (uri == null || !uri.hasScheme || !uri.hasAuthority) return false;
+    return uri.scheme == 'http' || uri.scheme == 'https';
+  }
+
+  String titleFromPath(String path) {
+    final name = p.basenameWithoutExtension(path).trim();
+    return name.isEmpty ? 'Imported audio' : name.replaceAll('_', ' ');
+  }
+
+  String titleFromUrl(String url) {
+    final uri = Uri.tryParse(url.trim());
+    final name = uri == null ? '' : p.basenameWithoutExtension(uri.path).trim();
+    if (name.isNotEmpty) return name.replaceAll('_', ' ');
+    return 'Podcast';
+  }
+
+  Future<String?> pickLocalAudio() async {
+    final file = await _pickFile(
+      type: FileType.custom,
+      allowedExtensions: supportedExtensions.toList()..sort(),
+    );
+    final path = file?.path;
+    if (path == null || path.isEmpty) return null;
+    if (!isSupportedPath(path)) {
+      throw StateError('Unsupported audio type: ${p.extension(path)}');
+    }
+    return path;
+  }
+
+  Future<String> downloadRemote({
+    required String url,
+    required String destPath,
+  }) async {
+    if (!isHttpUrl(url)) {
+      throw ArgumentError('Not an http(s) audio URL: $url');
+    }
+    final file = File(destPath);
+    await file.parent.create(recursive: true);
+    await _downloader(url.trim(), destPath);
+    if (!file.existsSync() || file.lengthSync() == 0) {
+      throw StateError('Download produced no audio at $destPath');
+    }
+    return destPath;
+  }
+
+  MeetingProcessingJob jobFor({
+    required String audioPath,
+    required String title,
+    required MeetingProcessingSource source,
+    required int enqueuedAtMs,
+    String? id,
+  }) {
+    return MeetingProcessingJob(
+      id: id ?? 'import-$enqueuedAtMs',
+      audioPath: audioPath,
+      title: title,
+      enqueuedAtMs: enqueuedAtMs,
+      source: source,
+    );
+  }
+}
+
+typedef FilePickerPick =
+    Future<PlatformFile?> Function({
+      FileType type,
+      List<String>? allowedExtensions,
+    });
+
+typedef AudioDownloader = Future<void> Function(String url, String destPath);
+
+Future<PlatformFile?> _defaultPick({
+  FileType type = FileType.any,
+  List<String>? allowedExtensions,
+}) {
+  return FilePicker.pickFile(type: type, allowedExtensions: allowedExtensions);
+}
+
+Future<void> _dioDownload(String url, String destPath) async {
+  final dio = Dio(
+    BaseOptions(
+      followRedirects: true,
+      maxRedirects: 5,
+      receiveTimeout: const Duration(minutes: 5),
+    ),
+  );
+  await dio.download(url, destPath);
+}

--- a/packages/feature_mind/lib/src/notebook/application/notebook_locale_preference.dart
+++ b/packages/feature_mind/lib/src/notebook/application/notebook_locale_preference.dart
@@ -1,0 +1,34 @@
+import 'package:flutter_riverpod/legacy.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../domain/notebook_l10n.dart';
+
+const String notebookUiLocaleKey = 'mind_notebook_ui_locale';
+
+final notebookUiLocaleProvider =
+    StateNotifierProvider<NotebookUiLocaleNotifier, String>(
+      (ref) => NotebookUiLocaleNotifier(),
+    );
+
+class NotebookUiLocaleNotifier extends StateNotifier<String> {
+  NotebookUiLocaleNotifier() : super('en') {
+    _load();
+  }
+
+  Future<void> _load() async {
+    final prefs = await SharedPreferences.getInstance();
+    state = NotebookL10n.of(prefs.getString(notebookUiLocaleKey)).locale;
+  }
+
+  Future<void> select(String locale) async {
+    final resolved = NotebookL10n.of(locale).locale;
+    state = resolved;
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(notebookUiLocaleKey, resolved);
+  }
+}
+
+Future<String> loadNotebookUiLocale() async {
+  final prefs = await SharedPreferences.getInstance();
+  return NotebookL10n.of(prefs.getString(notebookUiLocaleKey)).locale;
+}

--- a/packages/feature_mind/lib/src/notebook/application/notebook_repository.dart
+++ b/packages/feature_mind/lib/src/notebook/application/notebook_repository.dart
@@ -1,0 +1,146 @@
+import 'package:core_workers/core_workers.dart';
+
+import '../../capture/domain/meeting_processing_job.dart';
+import '../../notes/domain/note.dart';
+import '../../notes/notes_capability.dart';
+import '../domain/key_points_extractor.dart';
+import '../domain/notebook_document.dart';
+import '../domain/notebook_note.dart';
+import '../domain/notebook_source.dart';
+import '../domain/notebook_summary.dart';
+import '../domain/super_summary.dart';
+
+/// Application seam over [NotesCapability]: encode/decode notebook documents
+/// without giving the capability a second store (`C5` / `I4`).
+class NotebookRepository {
+  NotebookRepository(
+    this._capability, {
+    this.extractor = const KeyPointsExtractor(),
+    this.composer = const SuperSummaryComposer(),
+  });
+
+  final NotesCapability _capability;
+  final KeyPointsExtractor extractor;
+  final SuperSummaryComposer composer;
+
+  static const _offMainThresholdChars = 50 * 1024;
+
+  Future<List<NotebookNote>> all() async {
+    final projection = await _capability.notes();
+    return [for (final note in projection.all) await _read(note)];
+  }
+
+  Future<NotebookNote?> get(String id) async {
+    final projection = await _capability.notes();
+    final note = projection.get(id);
+    if (note == null) return null;
+    return _read(note);
+  }
+
+  Future<NotebookNote> save({
+    required String id,
+    required String title,
+    required NotebookDocument document,
+    required int recordedAtMs,
+    bool exists = false,
+  }) async {
+    final body = await _encode(document);
+    if (exists) {
+      await _capability.editNote(
+        id: id,
+        title: title,
+        body: body,
+        recordedAtMs: recordedAtMs,
+      );
+    } else {
+      await _capability.createNote(
+        id: id,
+        title: title,
+        body: body,
+        recordedAtMs: recordedAtMs,
+      );
+    }
+    return NotebookNote(
+      note: Note(id: id, title: title, body: body, updatedAtMs: recordedAtMs),
+      document: document,
+    );
+  }
+
+  Future<void> delete({required String id, required int recordedAtMs}) {
+    return _capability.deleteNote(id: id, recordedAtMs: recordedAtMs);
+  }
+
+  /// Turns a finished transcription job into a durable notebook note.
+  Future<NotebookNote> ingestProcessed({
+    required MeetingProcessingJob job,
+    required String transcript,
+    required String minutes,
+    String? meetingId,
+    String? languageCode,
+    List<String> actionItems = const [],
+    int? recordedAtMs,
+  }) {
+    final document = NotebookDocument(
+      transcript: transcript,
+      summary: NotebookSummary.fromMinutes(
+        minutes.trim().isNotEmpty ? minutes : transcript,
+      ),
+      keyPoints: extractor.extract(
+        minutes: minutes,
+        transcript: transcript,
+        actionItems: actionItems,
+      ),
+      languageCode: languageCode,
+      source: NotebookSource.fromProcessingSource(job.source.name),
+      meetingId: meetingId,
+      audioPath: job.audioPath,
+      labels: const ['transcript'],
+    );
+    final id = 'note_${meetingId ?? job.id}';
+    return save(
+      id: id,
+      title: job.title,
+      document: document,
+      recordedAtMs: recordedAtMs ?? job.enqueuedAtMs,
+    );
+  }
+
+  Future<NotebookNote> superSummary({
+    required List<NotebookNote> notes,
+    required int recordedAtMs,
+    String? generatedRecap,
+    String? title,
+  }) {
+    if (notes.length < 2) {
+      throw ArgumentError('Super Summary needs at least two notes');
+    }
+    final document = composer.compose(
+      notes: notes,
+      generatedRecap: generatedRecap,
+    );
+    return save(
+      id: 'note_super_$recordedAtMs',
+      title: title ?? composer.defaultTitle(notes),
+      document: document,
+      recordedAtMs: recordedAtMs,
+    );
+  }
+
+  Future<NotebookNote> _read(Note note) async {
+    if (note.body.length > _offMainThresholdChars) {
+      final document = await runOffMain(
+        () => NotebookDocument.decode(note.body),
+      );
+      return NotebookNote(note: note, document: document);
+    }
+    return NotebookNote.fromNote(note);
+  }
+
+  Future<String> _encode(NotebookDocument document) async {
+    final encoded = document.encode();
+    if (encoded.length > _offMainThresholdChars) {
+      return runOffMain(document.encode);
+    }
+    return encoded;
+  }
+}

--- a/packages/feature_mind/lib/src/notebook/application/notebook_share_port.dart
+++ b/packages/feature_mind/lib/src/notebook/application/notebook_share_port.dart
@@ -1,0 +1,108 @@
+import 'dart:convert';
+
+import 'package:file_picker/file_picker.dart';
+import 'package:flutter/foundation.dart' show kIsWeb;
+import 'package:flutter/services.dart';
+import 'package:share_plus/share_plus.dart';
+
+/// Copy / share / save a notebook markdown payload.
+abstract interface class NotebookSharePort {
+  Future<void> copyText(String text);
+  Future<bool> shareMarkdown({
+    required String filename,
+    required String markdown,
+  });
+  Future<bool> saveMarkdown({
+    required String filename,
+    required String markdown,
+  });
+}
+
+class PlatformNotebookSharePort implements NotebookSharePort {
+  const PlatformNotebookSharePort({this.clipboard, this.sharer, this.saver});
+
+  final Future<void> Function(String text)? clipboard;
+  final Future<bool> Function(String filename, String markdown)? sharer;
+  final Future<bool> Function(String filename, String markdown)? saver;
+
+  @override
+  Future<void> copyText(String text) {
+    if (clipboard != null) return clipboard!(text);
+    return Clipboard.setData(ClipboardData(text: text));
+  }
+
+  @override
+  Future<bool> shareMarkdown({
+    required String filename,
+    required String markdown,
+  }) {
+    if (sharer != null) return sharer!(filename, markdown);
+    return _share(filename, markdown);
+  }
+
+  @override
+  Future<bool> saveMarkdown({
+    required String filename,
+    required String markdown,
+  }) {
+    if (saver != null) return saver!(filename, markdown);
+    return _save(filename, markdown);
+  }
+
+  static Future<bool> _share(String filename, String markdown) async {
+    final result = await SharePlus.instance.share(
+      ShareParams(
+        subject: filename,
+        files: [
+          XFile.fromData(
+            Uint8List.fromList(utf8.encode(markdown)),
+            mimeType: 'text/markdown',
+            name: filename,
+          ),
+        ],
+      ),
+    );
+    return result.status != ShareResultStatus.unavailable;
+  }
+
+  static Future<bool> _save(String filename, String markdown) async {
+    final saved = await FilePicker.saveFile(
+      dialogTitle: 'Save $filename',
+      fileName: filename,
+      bytes: Uint8List.fromList(utf8.encode(markdown)),
+    );
+    return saved != null || kIsWeb;
+  }
+}
+
+class MemoryNotebookSharePort implements NotebookSharePort {
+  String? lastCopied;
+  String? lastShared;
+  String? lastSaved;
+  String? lastFilename;
+
+  @override
+  Future<void> copyText(String text) async {
+    lastCopied = text;
+  }
+
+  @override
+  Future<bool> shareMarkdown({
+    required String filename,
+    required String markdown,
+  }) async {
+    lastFilename = filename;
+    lastShared = markdown;
+    return true;
+  }
+
+  @override
+  Future<bool> saveMarkdown({
+    required String filename,
+    required String markdown,
+  }) async {
+    lastFilename = filename;
+    lastSaved = markdown;
+    return true;
+  }
+}

--- a/packages/feature_mind/lib/src/notebook/application/notebook_store.dart
+++ b/packages/feature_mind/lib/src/notebook/application/notebook_store.dart
@@ -1,0 +1,17 @@
+import 'package:path/path.dart' as p;
+import 'package:path_provider/path_provider.dart';
+
+import '../../notes/domain/notes_operation_log.dart';
+import '../../notes/notes_capability.dart';
+
+/// Same path [MindRuntimeNotesScreen] already uses, so ingest and the UI
+/// fold the same log.
+Future<String> notebookLogPath() async {
+  final base = await getApplicationSupportDirectory();
+  return p.join(base.path, 'airo_mind', 'notes.log');
+}
+
+Future<NotesCapability> openNotebookCapability() async {
+  final log = await NotesOperationLog.open(await notebookLogPath());
+  return NotesCapability.rustPreferred(log);
+}

--- a/packages/feature_mind/lib/src/notebook/domain/key_points_extractor.dart
+++ b/packages/feature_mind/lib/src/notebook/domain/key_points_extractor.dart
@@ -1,0 +1,101 @@
+/// Pulls key points out of minutes, action items, and transcript.
+///
+/// Prefers explicit bullets / numbered lists / action items over inventing
+/// sentences. When none of those exist, falls back to the first few
+/// transcript sentences so a recording still has something to scan.
+class KeyPointsExtractor {
+  const KeyPointsExtractor({this.limit = defaultLimit});
+
+  static const defaultLimit = 12;
+
+  final int limit;
+
+  List<String> extract({
+    String minutes = '',
+    String transcript = '',
+    List<String> actionItems = const [],
+  }) {
+    final collected = <String>[..._clean(actionItems), ..._bullets(minutes)];
+    final unique = _dedupe(collected);
+    if (unique.isNotEmpty) {
+      return unique.take(limit).toList(growable: false);
+    }
+    final fallback = transcript.trim().isNotEmpty ? transcript : minutes;
+    return _sentences(fallback).take(limit).toList(growable: false);
+  }
+
+  List<String> _bullets(String text) {
+    final points = <String>[];
+    var inKeySection = false;
+    for (final rawLine in text.split('\n')) {
+      final line = rawLine.trim();
+      if (line.isEmpty) {
+        inKeySection = false;
+        continue;
+      }
+      if (_isKeyHeading(line)) {
+        inKeySection = true;
+        continue;
+      }
+      final bullet = _bulletText(line);
+      if (bullet != null) {
+        points.add(bullet);
+        continue;
+      }
+      if (inKeySection && line.length >= 8 && !line.startsWith('#')) {
+        points.add(line);
+      }
+    }
+    return points;
+  }
+
+  bool _isKeyHeading(String line) {
+    final stripped = line
+        .replaceFirst(RegExp(r'^#+\s*'), '')
+        .trim()
+        .toLowerCase();
+    return stripped == 'key points' ||
+        stripped == 'key point' ||
+        stripped == 'highlights' ||
+        stripped == 'takeaways' ||
+        stripped == 'action items' ||
+        stripped == 'actions' ||
+        stripped == 'सार' ||
+        stripped == 'मुख्य बातें';
+  }
+
+  String? _bulletText(String line) {
+    final match = RegExp(
+      r'^(?:[-*•–]|\d+[.)]|\[\s*[xX ]\s*\])\s+(.+)$',
+    ).firstMatch(line);
+    if (match == null) return null;
+    final text = match.group(1)!.trim();
+    return text.length >= 3 ? text : null;
+  }
+
+  List<String> _sentences(String text) {
+    final compact = text.replaceAll(RegExp(r'\s+'), ' ').trim();
+    if (compact.isEmpty) return const [];
+    final parts = compact
+        .split(RegExp(r'(?<=[.!?।])\s+'))
+        .map((part) => part.trim())
+        .where((part) => part.length >= 12)
+        .toList();
+    return _dedupe(parts);
+  }
+
+  List<String> _clean(List<String> items) => [
+    for (final item in items)
+      if (item.trim().length >= 3) item.trim(),
+  ];
+
+  List<String> _dedupe(List<String> items) {
+    final seen = <String>{};
+    final out = <String>[];
+    for (final item in items) {
+      final key = item.toLowerCase();
+      if (seen.add(key)) out.add(item);
+    }
+    return out;
+  }
+}

--- a/packages/feature_mind/lib/src/notebook/domain/notebook_document.dart
+++ b/packages/feature_mind/lib/src/notebook/domain/notebook_document.dart
@@ -1,0 +1,202 @@
+import 'dart:convert';
+
+import 'notebook_source.dart';
+
+/// Structured notebook payload stored in [Note.body].
+///
+/// The Notes operation log still carries only `id` / `title` / `body`
+/// (`#1338`, lockstep with `airo_mind_core::notes`). Product fields — tags,
+/// summary, transcript, language — live inside this envelope so the runtime
+/// encoding does not change.
+///
+/// A note that is only a title and freeform body stores plaintext, not JSON,
+/// so handwritten notes and the vertical-slice tests stay readable.
+class NotebookDocument {
+  const NotebookDocument({
+    this.body = '',
+    this.transcript = '',
+    this.summary = '',
+    this.keyPoints = const [],
+    this.tags = const [],
+    this.labels = const [],
+    this.languageCode,
+    this.source = NotebookSource.manual,
+    this.sourceNoteIds = const [],
+    this.meetingId,
+    this.audioPath,
+  });
+
+  static const schemaId = 'airo.mind.notebook.v1';
+
+  /// Freeform notes the person typed, distinct from [transcript].
+  final String body;
+  final String transcript;
+  final String summary;
+  final List<String> keyPoints;
+  final List<String> tags;
+  final List<String> labels;
+
+  /// Whisper / UI language code (`hi`, `en`, …), or `null` for auto / unset.
+  final String? languageCode;
+  final NotebookSource source;
+
+  /// For [NotebookSource.superSummary], the notes that were folded in.
+  final List<String> sourceNoteIds;
+  final String? meetingId;
+  final String? audioPath;
+
+  bool get isPlain =>
+      transcript.isEmpty &&
+      summary.isEmpty &&
+      keyPoints.isEmpty &&
+      tags.isEmpty &&
+      labels.isEmpty &&
+      languageCode == null &&
+      source == NotebookSource.manual &&
+      sourceNoteIds.isEmpty &&
+      meetingId == null &&
+      audioPath == null;
+
+  String get preview {
+    if (summary.trim().isNotEmpty) return summary.trim();
+    if (body.trim().isNotEmpty) return body.trim();
+    if (transcript.trim().isNotEmpty) return transcript.trim();
+    if (keyPoints.isNotEmpty) return keyPoints.join(' · ');
+    return '';
+  }
+
+  NotebookDocument copyWith({
+    String? body,
+    String? transcript,
+    String? summary,
+    List<String>? keyPoints,
+    List<String>? tags,
+    List<String>? labels,
+    String? languageCode,
+    NotebookSource? source,
+    List<String>? sourceNoteIds,
+    String? meetingId,
+    String? audioPath,
+    bool clearLanguageCode = false,
+    bool clearMeetingId = false,
+    bool clearAudioPath = false,
+  }) {
+    return NotebookDocument(
+      body: body ?? this.body,
+      transcript: transcript ?? this.transcript,
+      summary: summary ?? this.summary,
+      keyPoints: keyPoints ?? this.keyPoints,
+      tags: tags ?? this.tags,
+      labels: labels ?? this.labels,
+      languageCode: clearLanguageCode
+          ? null
+          : languageCode ?? this.languageCode,
+      source: source ?? this.source,
+      sourceNoteIds: sourceNoteIds ?? this.sourceNoteIds,
+      meetingId: clearMeetingId ? null : meetingId ?? this.meetingId,
+      audioPath: clearAudioPath ? null : audioPath ?? this.audioPath,
+    );
+  }
+
+  /// Encodes for [Note.body]. Plain notes stay plaintext.
+  String encode() {
+    if (isPlain) return body;
+    return jsonEncode(toJson());
+  }
+
+  Map<String, Object?> toJson() => {
+    'schema': schemaId,
+    'body': body,
+    'transcript': transcript,
+    'summary': summary,
+    'keyPoints': keyPoints,
+    'tags': tags,
+    'labels': labels,
+    'languageCode': languageCode,
+    'source': source.name,
+    'sourceNoteIds': sourceNoteIds,
+    'meetingId': meetingId,
+    'audioPath': audioPath,
+  };
+
+  /// Reads a [Note.body]. Unknown JSON falls back to treating the string as
+  /// plaintext so a corrupt envelope never deletes the person's words.
+  static NotebookDocument decode(String raw) {
+    final trimmed = raw.trim();
+    if (trimmed.isEmpty) return const NotebookDocument();
+    if (!trimmed.startsWith('{')) {
+      return NotebookDocument(body: raw);
+    }
+    try {
+      final json = jsonDecode(trimmed);
+      if (json is! Map) return NotebookDocument(body: raw);
+      final map = Map<String, Object?>.from(json);
+      if (map['schema'] != schemaId) return NotebookDocument(body: raw);
+      return fromJson(map);
+    } on FormatException {
+      return NotebookDocument(body: raw);
+    }
+  }
+
+  static NotebookDocument fromJson(Map<String, Object?> json) {
+    return NotebookDocument(
+      body: json['body'] as String? ?? '',
+      transcript: json['transcript'] as String? ?? '',
+      summary: json['summary'] as String? ?? '',
+      keyPoints: _stringList(json['keyPoints']),
+      tags: _stringList(json['tags']),
+      labels: _stringList(json['labels']),
+      languageCode: json['languageCode'] as String?,
+      source: NotebookSource.fromName(json['source'] as String?),
+      sourceNoteIds: _stringList(json['sourceNoteIds']),
+      meetingId: json['meetingId'] as String?,
+      audioPath: json['audioPath'] as String?,
+    );
+  }
+
+  static List<String> _stringList(Object? raw) {
+    if (raw is! List) return const [];
+    return [
+      for (final item in raw)
+        if (item is String && item.trim().isNotEmpty) item.trim(),
+    ];
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      other is NotebookDocument &&
+      other.body == body &&
+      other.transcript == transcript &&
+      other.summary == summary &&
+      _listEq(other.keyPoints, keyPoints) &&
+      _listEq(other.tags, tags) &&
+      _listEq(other.labels, labels) &&
+      other.languageCode == languageCode &&
+      other.source == source &&
+      _listEq(other.sourceNoteIds, sourceNoteIds) &&
+      other.meetingId == meetingId &&
+      other.audioPath == audioPath;
+
+  @override
+  int get hashCode => Object.hash(
+    body,
+    transcript,
+    summary,
+    Object.hashAll(keyPoints),
+    Object.hashAll(tags),
+    Object.hashAll(labels),
+    languageCode,
+    source,
+    Object.hashAll(sourceNoteIds),
+    meetingId,
+    audioPath,
+  );
+}
+
+bool _listEq(List<String> a, List<String> b) {
+  if (a.length != b.length) return false;
+  for (var i = 0; i < a.length; i++) {
+    if (a[i] != b[i]) return false;
+  }
+  return true;
+}

--- a/packages/feature_mind/lib/src/notebook/domain/notebook_export.dart
+++ b/packages/feature_mind/lib/src/notebook/domain/notebook_export.dart
@@ -1,0 +1,73 @@
+import 'notebook_note.dart';
+import 'notebook_source.dart';
+
+/// Markdown for one notebook note — the export / copy / share payload.
+String renderNotebookMarkdown(NotebookNote note) {
+  final doc = note.document;
+  final recorded = DateTime.fromMillisecondsSinceEpoch(
+    note.updatedAtMs,
+    isUtc: true,
+  );
+  final buf = StringBuffer()
+    ..writeln('---')
+    ..writeln('title: "${_escapeYaml(note.title)}"')
+    ..writeln('date: ${recorded.toIso8601String()}')
+    ..writeln('source: ${doc.source.name}');
+  if (doc.languageCode != null && doc.languageCode!.isNotEmpty) {
+    buf.writeln('language: ${doc.languageCode}');
+  }
+  if (doc.tags.isNotEmpty) {
+    buf.writeln('tags: [${doc.tags.map(_escapeYaml).join(', ')}]');
+  }
+  if (doc.labels.isNotEmpty) {
+    buf.writeln('labels: [${doc.labels.map(_escapeYaml).join(', ')}]');
+  }
+  if (doc.source == NotebookSource.superSummary &&
+      doc.sourceNoteIds.isNotEmpty) {
+    buf.writeln('folded_from: [${doc.sourceNoteIds.join(', ')}]');
+  }
+  buf.writeln('---');
+  buf.writeln();
+  buf.writeln('# ${note.title}');
+  buf.writeln();
+
+  if (doc.summary.trim().isNotEmpty) {
+    buf.writeln('## Summary');
+    buf.writeln();
+    buf.writeln(doc.summary.trim());
+    buf.writeln();
+  }
+  if (doc.keyPoints.isNotEmpty) {
+    buf.writeln('## Key points');
+    buf.writeln();
+    for (final point in doc.keyPoints) {
+      buf.writeln('- $point');
+    }
+    buf.writeln();
+  }
+  if (doc.body.trim().isNotEmpty) {
+    buf.writeln('## Notes');
+    buf.writeln();
+    buf.writeln(doc.body.trim());
+    buf.writeln();
+  }
+  if (doc.transcript.trim().isNotEmpty) {
+    buf.writeln('## Transcript');
+    buf.writeln();
+    buf.writeln(doc.transcript.trim());
+    buf.writeln();
+  }
+  return '${buf.toString().trimRight()}\n';
+}
+
+String notebookExportFileName(NotebookNote note) {
+  final slug = note.title
+      .toLowerCase()
+      .replaceAll(RegExp(r'[^a-z0-9]+'), '-')
+      .replaceAll(RegExp(r'^-+|-+$'), '');
+  final safe = slug.isEmpty ? note.id : slug;
+  return '$safe.md';
+}
+
+String _escapeYaml(String value) =>
+    value.replaceAll('\\', r'\\').replaceAll('"', r'\"');

--- a/packages/feature_mind/lib/src/notebook/domain/notebook_l10n.dart
+++ b/packages/feature_mind/lib/src/notebook/domain/notebook_l10n.dart
@@ -1,0 +1,390 @@
+/// UI copy for the notebook surface. Transcription language is a separate
+/// setting ([SpeechLanguageMode]); this is the screens' own locale.
+class NotebookL10n {
+  const NotebookL10n._(this.locale, this._s);
+
+  final String locale;
+  final Map<String, String> _s;
+
+  static const supported = <String>[
+    'en',
+    'hi',
+    'mr',
+    'es',
+    'fr',
+    'de',
+    'pt',
+    'ja',
+    'zh',
+    'ar',
+  ];
+
+  static const fallback = NotebookL10n._('en', _en);
+
+  static NotebookL10n of(String? locale) {
+    final code = _normalize(locale);
+    final table = _tables[code];
+    if (table == null) return fallback;
+    return NotebookL10n._(code, table);
+  }
+
+  static String _normalize(String? locale) {
+    if (locale == null || locale.isEmpty) return 'en';
+    final lower = locale.toLowerCase().replaceAll('_', '-');
+    final primary = lower.split('-').first;
+    return supported.contains(primary) ? primary : 'en';
+  }
+
+  String t(String key) => _s[key] ?? _en[key] ?? key;
+
+  String get notesTitle => t('notesTitle');
+  String get noNotesYet => t('noNotesYet');
+  String get noMatchingNotes => t('noMatchingNotes');
+  String get newNote => t('newNote');
+  String get editNote => t('editNote');
+  String get title => t('title');
+  String get body => t('body');
+  String get tags => t('tags');
+  String get labels => t('labels');
+  String get tagsHint => t('tagsHint');
+  String get labelsHint => t('labelsHint');
+  String get save => t('save');
+  String get cancel => t('cancel');
+  String get search => t('search');
+  String get superSummary => t('superSummary');
+  String get record => t('record');
+  String get importAudio => t('importAudio');
+  String get importPodcast => t('importPodcast');
+  String get podcastUrl => t('podcastUrl');
+  String get export => t('export');
+  String get copy => t('copy');
+  String get share => t('share');
+  String get keyPoints => t('keyPoints');
+  String get summary => t('summary');
+  String get language => t('language');
+  String get selectNotes => t('selectNotes');
+  String get combineSelected => t('combineSelected');
+  String get copied => t('copied');
+  String get shared => t('shared');
+  String get saved => t('saved');
+  String get delete => t('delete');
+  String get uiLanguage => t('uiLanguage');
+  String get needsTwoNotes => t('needsTwoNotes');
+
+  static const _en = {
+    'notesTitle': 'Notes',
+    'noNotesYet': 'No notes yet',
+    'noMatchingNotes': 'No matching notes',
+    'newNote': 'New note',
+    'editNote': 'Edit note',
+    'title': 'Title',
+    'body': 'Body',
+    'tags': 'Tags',
+    'labels': 'Labels',
+    'tagsHint': 'work, standup',
+    'labelsHint': 'meeting, lecture',
+    'save': 'Save',
+    'cancel': 'Cancel',
+    'search': 'Search notes',
+    'superSummary': 'Super summary',
+    'record': 'Record',
+    'importAudio': 'Import audio',
+    'importPodcast': 'Import podcast',
+    'podcastUrl': 'Podcast or audio URL',
+    'export': 'Export',
+    'copy': 'Copy',
+    'share': 'Share',
+    'keyPoints': 'Key points',
+    'summary': 'Summary',
+    'language': 'Language',
+    'selectNotes': 'Select notes',
+    'combineSelected': 'Combine selected',
+    'copied': 'Copied to clipboard',
+    'shared': 'Shared',
+    'saved': 'Saved',
+    'delete': 'Delete',
+    'uiLanguage': 'Notes language',
+    'needsTwoNotes': 'Select at least two notes to combine',
+  };
+
+  static const _hi = {
+    'notesTitle': 'नोट्स',
+    'noNotesYet': 'अभी कोई नोट नहीं',
+    'noMatchingNotes': 'कोई मेल खाता नोट नहीं',
+    'newNote': 'नया नोट',
+    'editNote': 'नोट संपादित करें',
+    'title': 'शीर्षक',
+    'body': 'विषय',
+    'tags': 'टैग',
+    'labels': 'लेबल',
+    'tagsHint': 'काम, स्टैंडअप',
+    'labelsHint': 'मीटिंग, व्याख्यान',
+    'save': 'सहेजें',
+    'cancel': 'रद्द करें',
+    'search': 'नोट खोजें',
+    'superSummary': 'सुपर सारांश',
+    'record': 'रिकॉर्ड',
+    'importAudio': 'ऑडियो आयात करें',
+    'importPodcast': 'पॉडकास्ट आयात करें',
+    'podcastUrl': 'पॉडकास्ट या ऑडियो URL',
+    'export': 'निर्यात',
+    'copy': 'कॉपी',
+    'share': 'साझा करें',
+    'keyPoints': 'मुख्य बातें',
+    'summary': 'सारांश',
+    'language': 'भाषा',
+    'selectNotes': 'नोट चुनें',
+    'combineSelected': 'चयनित जोड़ें',
+    'copied': 'क्लिपबोर्ड पर कॉपी हुआ',
+    'shared': 'साझा किया गया',
+    'saved': 'सहेजा गया',
+    'delete': 'हटाएँ',
+    'uiLanguage': 'नोट्स की भाषा',
+    'needsTwoNotes': 'जोड़ने के लिए कम से कम दो नोट चुनें',
+  };
+
+  static const _es = {
+    'notesTitle': 'Notas',
+    'noNotesYet': 'Aún no hay notas',
+    'noMatchingNotes': 'No hay notas coincidentes',
+    'newNote': 'Nota nueva',
+    'editNote': 'Editar nota',
+    'title': 'Título',
+    'body': 'Cuerpo',
+    'tags': 'Etiquetas',
+    'labels': 'Rótulos',
+    'save': 'Guardar',
+    'cancel': 'Cancelar',
+    'search': 'Buscar notas',
+    'superSummary': 'Súper resumen',
+    'record': 'Grabar',
+    'importAudio': 'Importar audio',
+    'importPodcast': 'Importar podcast',
+    'export': 'Exportar',
+    'copy': 'Copiar',
+    'share': 'Compartir',
+    'keyPoints': 'Puntos clave',
+    'summary': 'Resumen',
+    'language': 'Idioma',
+    'copied': 'Copiado al portapapeles',
+    'delete': 'Eliminar',
+    'uiLanguage': 'Idioma de las notas',
+    'needsTwoNotes': 'Selecciona al menos dos notas para combinar',
+  };
+
+  static const _fr = {
+    'notesTitle': 'Notes',
+    'noNotesYet': 'Aucune note pour l’instant',
+    'noMatchingNotes': 'Aucune note correspondante',
+    'newNote': 'Nouvelle note',
+    'editNote': 'Modifier la note',
+    'title': 'Titre',
+    'body': 'Corps',
+    'tags': 'Tags',
+    'labels': 'Libellés',
+    'save': 'Enregistrer',
+    'cancel': 'Annuler',
+    'search': 'Rechercher des notes',
+    'superSummary': 'Super résumé',
+    'record': 'Enregistrer',
+    'importAudio': 'Importer un audio',
+    'importPodcast': 'Importer un podcast',
+    'export': 'Exporter',
+    'copy': 'Copier',
+    'share': 'Partager',
+    'keyPoints': 'Points clés',
+    'summary': 'Résumé',
+    'language': 'Langue',
+    'copied': 'Copié dans le presse-papiers',
+    'delete': 'Supprimer',
+    'uiLanguage': 'Langue des notes',
+    'needsTwoNotes': 'Sélectionnez au moins deux notes à fusionner',
+  };
+
+  static const _de = {
+    'notesTitle': 'Notizen',
+    'noNotesYet': 'Noch keine Notizen',
+    'noMatchingNotes': 'Keine passenden Notizen',
+    'newNote': 'Neue Notiz',
+    'editNote': 'Notiz bearbeiten',
+    'title': 'Titel',
+    'body': 'Text',
+    'tags': 'Tags',
+    'labels': 'Labels',
+    'save': 'Speichern',
+    'cancel': 'Abbrechen',
+    'search': 'Notizen suchen',
+    'superSummary': 'Super-Zusammenfassung',
+    'record': 'Aufnehmen',
+    'importAudio': 'Audio importieren',
+    'importPodcast': 'Podcast importieren',
+    'export': 'Exportieren',
+    'copy': 'Kopieren',
+    'share': 'Teilen',
+    'keyPoints': 'Kernpunkte',
+    'summary': 'Zusammenfassung',
+    'language': 'Sprache',
+    'copied': 'In die Zwischenablage kopiert',
+    'delete': 'Löschen',
+    'uiLanguage': 'Notizsprache',
+    'needsTwoNotes': 'Wähle mindestens zwei Notizen zum Kombinieren',
+  };
+
+  static const _pt = {
+    'notesTitle': 'Notas',
+    'noNotesYet': 'Ainda não há notas',
+    'noMatchingNotes': 'Nenhuma nota correspondente',
+    'newNote': 'Nova nota',
+    'editNote': 'Editar nota',
+    'title': 'Título',
+    'body': 'Corpo',
+    'tags': 'Tags',
+    'labels': 'Rótulos',
+    'save': 'Salvar',
+    'cancel': 'Cancelar',
+    'search': 'Pesquisar notas',
+    'superSummary': 'Super resumo',
+    'record': 'Gravar',
+    'importAudio': 'Importar áudio',
+    'importPodcast': 'Importar podcast',
+    'export': 'Exportar',
+    'copy': 'Copiar',
+    'share': 'Compartilhar',
+    'keyPoints': 'Pontos-chave',
+    'summary': 'Resumo',
+    'language': 'Idioma',
+    'copied': 'Copiado para a área de transferência',
+    'delete': 'Excluir',
+    'uiLanguage': 'Idioma das notas',
+    'needsTwoNotes': 'Selecione pelo menos duas notas para combinar',
+  };
+
+  static const _ja = {
+    'notesTitle': 'メモ',
+    'noNotesYet': 'まだメモがありません',
+    'noMatchingNotes': '一致するメモがありません',
+    'newNote': '新しいメモ',
+    'editNote': 'メモを編集',
+    'title': 'タイトル',
+    'body': '本文',
+    'tags': 'タグ',
+    'labels': 'ラベル',
+    'save': '保存',
+    'cancel': 'キャンセル',
+    'search': 'メモを検索',
+    'superSummary': 'スーパー要約',
+    'record': '録音',
+    'importAudio': '音声を読み込む',
+    'importPodcast': 'ポッドキャストを読み込む',
+    'export': '書き出す',
+    'copy': 'コピー',
+    'share': '共有',
+    'keyPoints': '要点',
+    'summary': '要約',
+    'language': '言語',
+    'copied': 'クリップボードにコピーしました',
+    'delete': '削除',
+    'uiLanguage': 'メモの言語',
+    'needsTwoNotes': '結合するにはメモを2件以上選んでください',
+  };
+
+  static const _zh = {
+    'notesTitle': '笔记',
+    'noNotesYet': '还没有笔记',
+    'noMatchingNotes': '没有匹配的笔记',
+    'newNote': '新建笔记',
+    'editNote': '编辑笔记',
+    'title': '标题',
+    'body': '正文',
+    'tags': '标签',
+    'labels': '分类',
+    'save': '保存',
+    'cancel': '取消',
+    'search': '搜索笔记',
+    'superSummary': '超级摘要',
+    'record': '录音',
+    'importAudio': '导入音频',
+    'importPodcast': '导入播客',
+    'export': '导出',
+    'copy': '复制',
+    'share': '分享',
+    'keyPoints': '要点',
+    'summary': '摘要',
+    'language': '语言',
+    'copied': '已复制到剪贴板',
+    'delete': '删除',
+    'uiLanguage': '笔记语言',
+    'needsTwoNotes': '请至少选择两条笔记进行合并',
+  };
+
+  static const _ar = {
+    'notesTitle': 'الملاحظات',
+    'noNotesYet': 'لا توجد ملاحظات بعد',
+    'noMatchingNotes': 'لا توجد ملاحظات مطابقة',
+    'newNote': 'ملاحظة جديدة',
+    'editNote': 'تحرير الملاحظة',
+    'title': 'العنوان',
+    'body': 'النص',
+    'tags': 'الوسوم',
+    'labels': 'التصنيفات',
+    'save': 'حفظ',
+    'cancel': 'إلغاء',
+    'search': 'بحث في الملاحظات',
+    'superSummary': 'الملخص الشامل',
+    'record': 'تسجيل',
+    'importAudio': 'استيراد صوت',
+    'importPodcast': 'استيراد بودكاست',
+    'export': 'تصدير',
+    'copy': 'نسخ',
+    'share': 'مشاركة',
+    'keyPoints': 'النقاط الأساسية',
+    'summary': 'الملخص',
+    'language': 'اللغة',
+    'copied': 'تم النسخ إلى الحافظة',
+    'delete': 'حذف',
+    'uiLanguage': 'لغة الملاحظات',
+    'needsTwoNotes': 'اختر ملاحظتين على الأقل للدمج',
+  };
+
+  static const _mr = {
+    'notesTitle': 'नोट्स',
+    'noNotesYet': 'अजून नोट्स नाहीत',
+    'noMatchingNotes': 'जुळणारे नोट्स नाहीत',
+    'newNote': 'नवीन नोट',
+    'editNote': 'नोट संपादित करा',
+    'title': 'शीर्षक',
+    'body': 'मजकूर',
+    'tags': 'टॅग',
+    'labels': 'लेबल्स',
+    'save': 'जतन करा',
+    'cancel': 'रद्द करा',
+    'search': 'नोट शोधा',
+    'superSummary': 'सुपर सारांश',
+    'record': 'रेकॉर्ड',
+    'importAudio': 'ऑडिओ आयात करा',
+    'importPodcast': 'पॉडकास्ट आयात करा',
+    'export': 'निर्यात',
+    'copy': 'कॉपी',
+    'share': 'शेअर',
+    'keyPoints': 'मुख्य मुद्दे',
+    'summary': 'सारांश',
+    'language': 'भाषा',
+    'copied': 'क्लिपबोर्डवर कॉपी झाले',
+    'delete': 'हटवा',
+    'uiLanguage': 'नोट्सची भाषा',
+    'needsTwoNotes': 'एकत्र करण्यासाठी किमान दोन नोट्स निवडा',
+  };
+
+  static const _tables = <String, Map<String, String>>{
+    'en': _en,
+    'hi': _hi,
+    'mr': _mr,
+    'es': _es,
+    'fr': _fr,
+    'de': _de,
+    'pt': _pt,
+    'ja': _ja,
+    'zh': _zh,
+    'ar': _ar,
+  };
+}

--- a/packages/feature_mind/lib/src/notebook/domain/notebook_note.dart
+++ b/packages/feature_mind/lib/src/notebook/domain/notebook_note.dart
@@ -1,0 +1,18 @@
+import '../../notes/domain/note.dart';
+import 'notebook_document.dart';
+
+/// A [Note] plus its decoded [NotebookDocument].
+class NotebookNote {
+  const NotebookNote({required this.note, required this.document});
+
+  factory NotebookNote.fromNote(Note note) =>
+      NotebookNote(note: note, document: NotebookDocument.decode(note.body));
+
+  final Note note;
+  final NotebookDocument document;
+
+  String get id => note.id;
+  String get title => note.title;
+  int get updatedAtMs => note.updatedAtMs;
+  String get preview => document.preview;
+}

--- a/packages/feature_mind/lib/src/notebook/domain/notebook_search.dart
+++ b/packages/feature_mind/lib/src/notebook/domain/notebook_search.dart
@@ -1,0 +1,78 @@
+import 'notebook_note.dart';
+
+/// Keyword + tag + label + language filter over notebook notes.
+///
+/// Deliberately not semantic search — meetings already have that ranker.
+/// Notes need something that works with no embedding model and stays honest
+/// about tags the person actually set.
+class NotebookSearch {
+  const NotebookSearch();
+
+  List<NotebookNote> filter({
+    required List<NotebookNote> notes,
+    String query = '',
+    Set<String> tags = const {},
+    Set<String> labels = const {},
+    String? languageCode,
+  }) {
+    final needle = query.trim().toLowerCase();
+    final tagNeedles = {for (final tag in tags) tag.trim().toLowerCase()}
+      ..removeWhere((tag) => tag.isEmpty);
+    final labelNeedles = {
+      for (final label in labels) label.trim().toLowerCase(),
+    }..removeWhere((label) => label.isEmpty);
+
+    return [
+      for (final note in notes)
+        if (_matches(
+          note,
+          needle: needle,
+          tags: tagNeedles,
+          labels: labelNeedles,
+          languageCode: languageCode,
+        ))
+          note,
+    ];
+  }
+
+  bool _matches(
+    NotebookNote note, {
+    required String needle,
+    required Set<String> tags,
+    required Set<String> labels,
+    required String? languageCode,
+  }) {
+    if (languageCode != null &&
+        languageCode.isNotEmpty &&
+        note.document.languageCode != languageCode) {
+      return false;
+    }
+    if (tags.isNotEmpty) {
+      final have = {for (final tag in note.document.tags) tag.toLowerCase()};
+      if (!tags.every(have.contains)) return false;
+    }
+    if (labels.isNotEmpty) {
+      final have = {
+        for (final label in note.document.labels) label.toLowerCase(),
+      };
+      if (!labels.every(have.contains)) return false;
+    }
+    if (needle.isEmpty) return true;
+    return _haystack(note).contains(needle);
+  }
+
+  String _haystack(NotebookNote note) {
+    final doc = note.document;
+    return [
+      note.title,
+      doc.body,
+      doc.transcript,
+      doc.summary,
+      ...doc.keyPoints,
+      ...doc.tags,
+      ...doc.labels,
+      doc.languageCode ?? '',
+      doc.source.name,
+    ].join('\n').toLowerCase();
+  }
+}

--- a/packages/feature_mind/lib/src/notebook/domain/notebook_source.dart
+++ b/packages/feature_mind/lib/src/notebook/domain/notebook_source.dart
@@ -1,0 +1,33 @@
+/// How a notebook note was captured.
+enum NotebookSource {
+  /// Typed by the person.
+  manual,
+
+  /// In-app microphone capture, then whisper.
+  live,
+
+  /// A local audio file they picked.
+  upload,
+
+  /// A podcast / remote audio URL downloaded then transcribed.
+  podcast,
+
+  /// Folded from several other notes.
+  superSummary;
+
+  static NotebookSource fromName(String? name) {
+    return NotebookSource.values.firstWhere(
+      (value) => value.name == name,
+      orElse: () => NotebookSource.manual,
+    );
+  }
+
+  static NotebookSource fromProcessingSource(String name) {
+    return switch (name) {
+      'live' => NotebookSource.live,
+      'upload' => NotebookSource.upload,
+      'podcast' => NotebookSource.podcast,
+      _ => NotebookSource.manual,
+    };
+  }
+}

--- a/packages/feature_mind/lib/src/notebook/domain/notebook_summary.dart
+++ b/packages/feature_mind/lib/src/notebook/domain/notebook_summary.dart
@@ -1,0 +1,51 @@
+/// First-paragraph / named-section summary of minutes or a transcript.
+class NotebookSummary {
+  static const maxChars = 600;
+
+  /// Prefer an explicit Summary / Overview / Recap section; otherwise the
+  /// first paragraph, clipped so a list row stays readable.
+  static String fromMinutes(String minutes) {
+    final trimmed = minutes.trim();
+    if (trimmed.isEmpty) return '';
+    final section = _namedSection(trimmed, const [
+      'summary',
+      'overview',
+      'recap',
+      'abstract',
+      'सारांश',
+      'सार',
+    ]);
+    if (section != null && section.isNotEmpty) return _clip(section);
+    final paragraph = trimmed.split(RegExp(r'\n\s*\n')).first.trim();
+    return _clip(paragraph);
+  }
+
+  static String? _namedSection(String text, List<String> headings) {
+    final lines = text.split('\n');
+    final wanted = headings.map((h) => h.toLowerCase()).toSet();
+    final buf = StringBuffer();
+    var capturing = false;
+    for (final raw in lines) {
+      final line = raw.trim();
+      final heading = line.replaceFirst(RegExp(r'^#+\s*'), '').toLowerCase();
+      if (wanted.contains(heading)) {
+        if (capturing) break;
+        capturing = true;
+        continue;
+      }
+      if (capturing) {
+        if (line.startsWith('#') && line.length < 80) break;
+        if (buf.isNotEmpty) buf.writeln();
+        buf.write(raw);
+      }
+    }
+    final captured = buf.toString().trim();
+    return captured.isEmpty ? null : captured;
+  }
+
+  static String _clip(String text) {
+    final compact = text.replaceAll(RegExp(r'\s+'), ' ').trim();
+    if (compact.length <= maxChars) return compact;
+    return '${compact.substring(0, maxChars).trimRight()}…';
+  }
+}

--- a/packages/feature_mind/lib/src/notebook/domain/super_summary.dart
+++ b/packages/feature_mind/lib/src/notebook/domain/super_summary.dart
@@ -1,0 +1,121 @@
+import 'key_points_extractor.dart';
+import 'notebook_document.dart';
+import 'notebook_note.dart';
+import 'notebook_source.dart';
+import 'notebook_summary.dart';
+
+/// Folds several notebook notes into one Super Summary document.
+///
+/// When [generatedRecap] is supplied (on-device LLM), that text is the
+/// summary and its bullets become key points. Otherwise the composer builds
+/// a deterministic extractive recap so Super Summary still works with no
+/// model loaded.
+class SuperSummaryComposer {
+  const SuperSummaryComposer({this.extractor = const KeyPointsExtractor()});
+
+  final KeyPointsExtractor extractor;
+
+  NotebookDocument compose({
+    required List<NotebookNote> notes,
+    String? generatedRecap,
+  }) {
+    if (notes.isEmpty) {
+      throw ArgumentError('Super Summary needs at least one note');
+    }
+    final tags = _unique([for (final note in notes) ...note.document.tags]);
+    final labels = _unique([
+      for (final note in notes) ...note.document.labels,
+      'super-summary',
+    ]);
+    final mergedPoints = extractor.extract(
+      minutes: [
+        for (final note in notes)
+          if (note.document.summary.isNotEmpty) note.document.summary,
+        for (final note in notes) ...note.document.keyPoints,
+      ].join('\n- '),
+      transcript: [
+        for (final note in notes)
+          if (note.document.transcript.isNotEmpty) note.document.transcript,
+      ].join('\n\n'),
+      actionItems: [for (final note in notes) ...note.document.keyPoints],
+    );
+    final extractiveSummary = _extractiveSummary(notes);
+    final recap = generatedRecap?.trim();
+    final summary = (recap != null && recap.isNotEmpty)
+        ? NotebookSummary.fromMinutes(recap)
+        : extractiveSummary;
+    final recapPoints = recap == null || recap.isEmpty
+        ? const <String>[]
+        : extractor.extract(minutes: recap);
+    final keyPoints = recapPoints.isNotEmpty ? recapPoints : mergedPoints;
+    final language = _sharedLanguage(notes);
+
+    return NotebookDocument(
+      body: _sourceIndex(notes),
+      transcript: [
+        for (final note in notes)
+          if (note.document.transcript.trim().isNotEmpty)
+            '### ${note.title}\n${note.document.transcript.trim()}',
+      ].join('\n\n'),
+      summary: summary,
+      keyPoints: keyPoints,
+      tags: tags,
+      labels: labels,
+      languageCode: language,
+      source: NotebookSource.superSummary,
+      sourceNoteIds: [for (final note in notes) note.id],
+    );
+  }
+
+  String defaultTitle(List<NotebookNote> notes) {
+    if (notes.length == 1) return 'Super summary · ${notes.single.title}';
+    return 'Super summary · ${notes.length} notes';
+  }
+
+  String _extractiveSummary(List<NotebookNote> notes) {
+    final parts = <String>[
+      'Combined recap of ${notes.length} notes: '
+          '${notes.map((n) => n.title).join(', ')}.',
+      for (final note in notes)
+        if (note.document.summary.trim().isNotEmpty)
+          '${note.title}: ${note.document.summary.trim()}',
+    ];
+    if (parts.length == 1) {
+      for (final note in notes) {
+        final preview = note.preview;
+        if (preview.isNotEmpty) {
+          parts.add('${note.title}: ${NotebookSummary.fromMinutes(preview)}');
+        }
+      }
+    }
+    return NotebookSummary.fromMinutes(parts.join('\n\n'));
+  }
+
+  String _sourceIndex(List<NotebookNote> notes) {
+    final buf = StringBuffer('Folded from:\n');
+    for (final note in notes) {
+      buf.writeln('- ${note.title}');
+    }
+    return buf.toString().trimRight();
+  }
+
+  String? _sharedLanguage(List<NotebookNote> notes) {
+    final codes = {
+      for (final note in notes)
+        if (note.document.languageCode != null) note.document.languageCode!,
+    };
+    if (codes.length == 1) return codes.single;
+    return null;
+  }
+
+  List<String> _unique(List<String> items) {
+    final seen = <String>{};
+    final out = <String>[];
+    for (final item in items) {
+      final trimmed = item.trim();
+      if (trimmed.isEmpty) continue;
+      if (seen.add(trimmed.toLowerCase())) out.add(trimmed);
+    }
+    return out;
+  }
+}

--- a/packages/feature_mind/lib/src/notebook/presentation/notebook_host_screen.dart
+++ b/packages/feature_mind/lib/src/notebook/presentation/notebook_host_screen.dart
@@ -1,0 +1,179 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:path/path.dart' as p;
+import 'package:path_provider/path_provider.dart';
+
+import '../application/audio_import_service.dart';
+import '../application/notebook_locale_preference.dart';
+import '../application/notebook_share_port.dart';
+import '../application/notebook_store.dart';
+import '../../capture/application/meeting_capture_providers.dart';
+import '../../capture/domain/meeting_processing_job.dart';
+import '../../notes/notes_capability.dart';
+import '../../notes/presentation/notes_screen.dart';
+import '../domain/notebook_l10n.dart';
+
+/// Loads the notes log and wires live record / file / podcast import.
+class NotebookHostScreen extends ConsumerStatefulWidget {
+  const NotebookHostScreen({
+    super.key,
+    this.onRecordLive,
+    this.importer,
+    this.sharePort,
+  });
+
+  final Future<void> Function()? onRecordLive;
+  final AudioImportService? importer;
+  final NotebookSharePort? sharePort;
+
+  @override
+  ConsumerState<NotebookHostScreen> createState() => _NotebookHostScreenState();
+}
+
+class _NotebookHostScreenState extends ConsumerState<NotebookHostScreen> {
+  NotesCapability? _capability;
+  Object? _error;
+  late final AudioImportService _importer =
+      widget.importer ?? AudioImportService();
+  late final NotebookSharePort _sharePort =
+      widget.sharePort ?? const PlatformNotebookSharePort();
+
+  @override
+  void initState() {
+    super.initState();
+    unawaited(_open());
+  }
+
+  Future<void> _open() async {
+    try {
+      final capability = await openNotebookCapability();
+      if (!mounted) return;
+      setState(() => _capability = capability);
+    } on Object catch (error) {
+      if (!mounted) return;
+      setState(() => _error = error);
+    }
+  }
+
+  Future<String> _stagingPath(String sourcePath) async {
+    final dir = await getApplicationSupportDirectory();
+    final recordingsDir = Directory(p.join(dir.path, 'mind_recordings'));
+    await recordingsDir.create(recursive: true);
+    final stamp = DateTime.now().millisecondsSinceEpoch;
+    final ext = p.extension(sourcePath);
+    final safeExt = ext.isEmpty ? '.m4a' : ext;
+    return p.join(recordingsDir.path, 'import-$stamp$safeExt');
+  }
+
+  Future<void> _enqueue({
+    required String audioPath,
+    required String title,
+    required MeetingProcessingSource source,
+  }) async {
+    final queue = await ref.read(meetingProcessingQueueProvider.future);
+    await queue.enqueue(
+      _importer.jobFor(
+        audioPath: audioPath,
+        title: title,
+        source: source,
+        enqueuedAtMs: DateTime.now().millisecondsSinceEpoch,
+      ),
+    );
+    if (!mounted) return;
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(content: Text('Queued "$title" for transcription')),
+    );
+  }
+
+  Future<void> _importAudio() async {
+    try {
+      final picked = await _importer.pickLocalAudio();
+      if (picked == null) return;
+      final dest = await _stagingPath(picked);
+      await File(picked).copy(dest);
+      await _enqueue(
+        audioPath: dest,
+        title: _importer.titleFromPath(picked),
+        source: MeetingProcessingSource.upload,
+      );
+    } on Object catch (error) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(SnackBar(content: Text('Import failed: $error')));
+    }
+  }
+
+  Future<void> _importPodcast() async {
+    final l10n = NotebookL10n.of(ref.read(notebookUiLocaleProvider));
+    final controller = TextEditingController();
+    final url = await showDialog<String>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: Text(l10n.importPodcast),
+        content: TextField(
+          key: const Key('notes_screen_podcast_url_field'),
+          controller: controller,
+          decoration: InputDecoration(labelText: l10n.podcastUrl),
+          keyboardType: TextInputType.url,
+          autofocus: true,
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(),
+            child: Text(l10n.cancel),
+          ),
+          FilledButton(
+            key: const Key('notes_screen_podcast_import_confirm'),
+            onPressed: () => Navigator.of(context).pop(controller.text.trim()),
+            child: Text(l10n.importPodcast),
+          ),
+        ],
+      ),
+    );
+    if (url == null || url.isEmpty) return;
+    try {
+      final guessedExt = p.extension(Uri.tryParse(url)?.path ?? '');
+      final dest = await _stagingPath(
+        guessedExt.isEmpty ? 'podcast.mp3' : 'podcast$guessedExt',
+      );
+      await _importer.downloadRemote(url: url, destPath: dest);
+      await _enqueue(
+        audioPath: dest,
+        title: _importer.titleFromUrl(url),
+        source: MeetingProcessingSource.podcast,
+      );
+    } on Object catch (error) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(SnackBar(content: Text('Podcast import failed: $error')));
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (_error != null) {
+      return Scaffold(
+        appBar: AppBar(title: const Text('Notes')),
+        body: Center(child: Text('Could not open notes log: $_error')),
+      );
+    }
+    if (_capability == null) {
+      return const Scaffold(body: Center(child: CircularProgressIndicator()));
+    }
+    final locale = ref.watch(notebookUiLocaleProvider);
+    return NotesScreen(
+      capability: _capability!,
+      sharePort: _sharePort,
+      localeCode: locale,
+      onBack: () => Navigator.of(context).maybePop(),
+      onRecordLive: widget.onRecordLive,
+      onImportAudio: _importAudio,
+      onImportPodcast: _importPodcast,
+    );
+  }
+}

--- a/packages/feature_mind/lib/src/notebook/presentation/notebook_locale_settings_tile.dart
+++ b/packages/feature_mind/lib/src/notebook/presentation/notebook_locale_settings_tile.dart
@@ -1,0 +1,47 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../application/notebook_locale_preference.dart';
+import '../domain/notebook_l10n.dart';
+
+/// Profile control for notebook UI language (separate from transcription).
+class NotebookLocaleSettingsTile extends ConsumerWidget {
+  const NotebookLocaleSettingsTile({super.key});
+
+  static const _labels = <String, String>{
+    'en': 'English',
+    'hi': 'Hindi · हिन्दी',
+    'mr': 'Marathi · मराठी',
+    'es': 'Spanish · Español',
+    'fr': 'French · Français',
+    'de': 'German · Deutsch',
+    'pt': 'Portuguese · Português',
+    'ja': 'Japanese · 日本語',
+    'zh': 'Chinese · 中文',
+    'ar': 'Arabic · العربية',
+  };
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final locale = ref.watch(notebookUiLocaleProvider);
+    final l10n = NotebookL10n.of(locale);
+
+    return ListTile(
+      key: const Key('notebook_locale_settings_tile'),
+      title: Text(l10n.uiLanguage),
+      subtitle: Text(_labels[locale] ?? locale),
+      trailing: DropdownButton<String>(
+        key: const Key('notebook_locale_settings_dropdown'),
+        value: locale,
+        onChanged: (value) {
+          if (value == null) return;
+          ref.read(notebookUiLocaleProvider.notifier).select(value);
+        },
+        items: [
+          for (final code in NotebookL10n.supported)
+            DropdownMenuItem(value: code, child: Text(_labels[code] ?? code)),
+        ],
+      ),
+    );
+  }
+}

--- a/packages/feature_mind/lib/src/notes/presentation/notes_screen.dart
+++ b/packages/feature_mind/lib/src/notes/presentation/notes_screen.dart
@@ -1,30 +1,56 @@
 import 'package:flutter/material.dart';
 
+import '../../notebook/application/notebook_repository.dart';
+import '../../notebook/application/notebook_share_port.dart';
+import '../../notebook/domain/notebook_document.dart';
+import '../../notebook/domain/notebook_export.dart';
+import '../../notebook/domain/notebook_l10n.dart';
+import '../../notebook/domain/notebook_note.dart';
+import '../../notebook/domain/notebook_search.dart';
 import '../domain/note.dart';
-import '../domain/notes_projection.dart';
 import '../notes_capability.dart';
 
-/// The minimal Notes screen: list + create/edit. `#1338`'s UI leg of the
-/// runtime skeleton.
-///
-/// Renders from [NotesProjection], never from the operation log directly --
-/// this widget never imports [NotesOperationLog]; the only way it sees
-/// durable state is through [NotesCapability.notes]. Every mutation
-/// (`create`/`edit`/`delete`) goes back through [NotesCapability] and the
-/// screen reloads the projection afterward, rather than mutating local
-/// widget state as if it were the source of truth.
+/// Notebook surface: list, search, tags, live/import actions, Super Summary,
+/// and export / copy / share. Mutations still go through [NotesCapability]
+/// (`#1338`); the extra fields live in the notebook document envelope.
 class NotesScreen extends StatefulWidget {
-  const NotesScreen({super.key, required this.capability});
+  const NotesScreen({
+    super.key,
+    required this.capability,
+    this.sharePort,
+    this.onRecordLive,
+    this.onImportAudio,
+    this.onImportPodcast,
+    this.onBack,
+    this.localeCode = 'en',
+  });
 
   final NotesCapability capability;
+  final NotebookSharePort? sharePort;
+  final Future<void> Function()? onRecordLive;
+  final Future<void> Function()? onImportAudio;
+  final Future<void> Function()? onImportPodcast;
+  final VoidCallback? onBack;
+  final String localeCode;
 
   @override
   State<NotesScreen> createState() => _NotesScreenState();
 }
 
 class _NotesScreenState extends State<NotesScreen> {
-  NotesProjection _projection = NotesProjection.empty;
+  late final NotebookRepository _repository = NotebookRepository(
+    widget.capability,
+  );
+  final _search = NotebookSearch();
+  final _query = TextEditingController();
+
+  List<NotebookNote> _notes = const [];
   bool _loading = true;
+  bool _selecting = false;
+  final Set<String> _selected = {};
+  String? _tagFilter;
+
+  NotebookL10n get _l10n => NotebookL10n.of(widget.localeCode);
 
   @override
   void initState() {
@@ -32,48 +58,143 @@ class _NotesScreenState extends State<NotesScreen> {
     _reload();
   }
 
+  @override
+  void dispose() {
+    _query.dispose();
+    super.dispose();
+  }
+
   Future<void> _reload() async {
-    final projection = await widget.capability.notes();
+    final notes = await _repository.all();
     if (!mounted) return;
     setState(() {
-      _projection = projection;
+      _notes = notes;
       _loading = false;
+      _selected.removeWhere((id) => notes.every((note) => note.id != id));
     });
   }
 
-  Future<void> _openEditor({Note? existing}) async {
-    final titleController = TextEditingController(text: existing?.title ?? '');
-    final bodyController = TextEditingController(text: existing?.body ?? '');
+  List<NotebookNote> get _visible {
+    return _search.filter(
+      notes: _notes,
+      query: _query.text,
+      tags: {?_tagFilter},
+    );
+  }
+
+  List<String> get _allTags {
+    final seen = <String>{};
+    final tags = <String>[];
+    for (final note in _notes) {
+      for (final tag in note.document.tags) {
+        if (seen.add(tag.toLowerCase())) tags.add(tag);
+      }
+    }
+    tags.sort((a, b) => a.toLowerCase().compareTo(b.toLowerCase()));
+    return tags;
+  }
+
+  Future<void> _openEditor({NotebookNote? existing, Note? legacy}) async {
+    final l10n = _l10n;
+    final current =
+        existing ?? (legacy == null ? null : NotebookNote.fromNote(legacy));
+    final titleController = TextEditingController(text: current?.title ?? '');
+    final bodyController = TextEditingController(
+      text: current?.document.body ?? '',
+    );
+    final tagsController = TextEditingController(
+      text: current?.document.tags.join(', ') ?? '',
+    );
+    final labelsController = TextEditingController(
+      text: current?.document.labels.join(', ') ?? '',
+    );
 
     final saved = await showDialog<bool>(
       context: context,
       builder: (context) => AlertDialog(
-        title: Text(existing == null ? 'New note' : 'Edit note'),
-        content: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            TextField(
-              controller: titleController,
-              key: const Key('notes_screen_title_field'),
-              decoration: const InputDecoration(labelText: 'Title'),
-            ),
-            TextField(
-              controller: bodyController,
-              key: const Key('notes_screen_body_field'),
-              decoration: const InputDecoration(labelText: 'Body'),
-              maxLines: 3,
-            ),
-          ],
+        title: Text(current == null ? l10n.newNote : l10n.editNote),
+        content: SingleChildScrollView(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              TextField(
+                controller: titleController,
+                key: const Key('notes_screen_title_field'),
+                decoration: InputDecoration(labelText: l10n.title),
+              ),
+              TextField(
+                controller: bodyController,
+                key: const Key('notes_screen_body_field'),
+                decoration: InputDecoration(labelText: l10n.body),
+                maxLines: 3,
+              ),
+              TextField(
+                controller: tagsController,
+                key: const Key('notes_screen_tags_field'),
+                decoration: InputDecoration(
+                  labelText: l10n.tags,
+                  hintText: l10n.tagsHint,
+                ),
+              ),
+              TextField(
+                controller: labelsController,
+                key: const Key('notes_screen_labels_field'),
+                decoration: InputDecoration(
+                  labelText: l10n.labels,
+                  hintText: l10n.labelsHint,
+                ),
+              ),
+              if (current != null && current.document.summary.isNotEmpty) ...[
+                const SizedBox(height: 12),
+                Text(
+                  l10n.summary,
+                  style: Theme.of(context).textTheme.titleSmall,
+                ),
+                Text(current.document.summary),
+              ],
+              if (current != null && current.document.keyPoints.isNotEmpty) ...[
+                const SizedBox(height: 12),
+                Text(
+                  l10n.keyPoints,
+                  style: Theme.of(context).textTheme.titleSmall,
+                ),
+                for (final point in current.document.keyPoints)
+                  Text('• $point'),
+              ],
+            ],
+          ),
         ),
         actions: [
+          if (current != null && widget.sharePort != null)
+            IconButton(
+              key: const Key('notes_screen_copy_button'),
+              tooltip: l10n.copy,
+              onPressed: () => _copy(current),
+              icon: const Icon(Icons.copy_outlined),
+            ),
+          if (current != null && widget.sharePort != null)
+            IconButton(
+              key: const Key('notes_screen_share_button'),
+              tooltip: l10n.share,
+              onPressed: () => _share(current),
+              icon: const Icon(Icons.ios_share),
+            ),
+          if (current != null && widget.sharePort != null)
+            IconButton(
+              key: const Key('notes_screen_export_button'),
+              tooltip: l10n.export,
+              onPressed: () => _export(current),
+              icon: const Icon(Icons.save_alt),
+            ),
           TextButton(
             onPressed: () => Navigator.of(context).pop(false),
-            child: const Text('Cancel'),
+            child: Text(l10n.cancel),
           ),
           FilledButton(
             key: const Key('notes_screen_save_button'),
             onPressed: () => Navigator.of(context).pop(true),
-            child: const Text('Save'),
+            child: Text(l10n.save),
           ),
         ],
       ),
@@ -82,61 +203,277 @@ class _NotesScreenState extends State<NotesScreen> {
     if (saved != true) return;
 
     final now = DateTime.now().millisecondsSinceEpoch;
-    if (existing == null) {
-      await widget.capability.createNote(
-        id: 'note_$now',
-        title: titleController.text,
-        body: bodyController.text,
-        recordedAtMs: now,
-      );
-    } else {
-      await widget.capability.editNote(
-        id: existing.id,
-        title: titleController.text,
-        body: bodyController.text,
-        recordedAtMs: now,
-      );
-    }
+    final document = (current?.document ?? const NotebookDocument()).copyWith(
+      body: bodyController.text,
+      tags: _csv(tagsController.text),
+      labels: _csv(labelsController.text),
+    );
+    await _repository.save(
+      id: current?.id ?? 'note_$now',
+      title: titleController.text,
+      document: document,
+      recordedAtMs: now,
+      exists: current != null,
+    );
     await _reload();
   }
 
-  Future<void> _delete(Note note) async {
-    await widget.capability.deleteNote(
+  List<String> _csv(String raw) => [
+    for (final part in raw.split(','))
+      if (part.trim().isNotEmpty) part.trim(),
+  ];
+
+  Future<void> _delete(NotebookNote note) async {
+    await _repository.delete(
       id: note.id,
       recordedAtMs: DateTime.now().millisecondsSinceEpoch,
     );
     await _reload();
   }
 
+  Future<void> _copy(NotebookNote note) async {
+    final port = widget.sharePort;
+    if (port == null) return;
+    await port.copyText(renderNotebookMarkdown(note));
+    if (!mounted) return;
+    ScaffoldMessenger.of(
+      context,
+    ).showSnackBar(SnackBar(content: Text(_l10n.copied)));
+  }
+
+  Future<void> _share(NotebookNote note) async {
+    final port = widget.sharePort;
+    if (port == null) return;
+    final ok = await port.shareMarkdown(
+      filename: notebookExportFileName(note),
+      markdown: renderNotebookMarkdown(note),
+    );
+    if (!mounted || !ok) return;
+    ScaffoldMessenger.of(
+      context,
+    ).showSnackBar(SnackBar(content: Text(_l10n.shared)));
+  }
+
+  Future<void> _export(NotebookNote note) async {
+    final port = widget.sharePort;
+    if (port == null) return;
+    final ok = await port.saveMarkdown(
+      filename: notebookExportFileName(note),
+      markdown: renderNotebookMarkdown(note),
+    );
+    if (!mounted || !ok) return;
+    ScaffoldMessenger.of(
+      context,
+    ).showSnackBar(SnackBar(content: Text(_l10n.saved)));
+  }
+
+  Future<void> _combineSelected() async {
+    final selected = [
+      for (final note in _notes)
+        if (_selected.contains(note.id)) note,
+    ];
+    if (selected.length < 2) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(SnackBar(content: Text(_l10n.needsTwoNotes)));
+      return;
+    }
+    await _repository.superSummary(
+      notes: selected,
+      recordedAtMs: DateTime.now().millisecondsSinceEpoch,
+    );
+    if (!mounted) return;
+    setState(() {
+      _selecting = false;
+      _selected.clear();
+    });
+    await _reload();
+  }
+
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(title: const Text('Notes')),
-      body: _loading
-          ? const Center(child: CircularProgressIndicator())
-          : _projection.isEmpty
-          ? const Center(child: Text('No notes yet'))
-          : ListView.builder(
-              itemCount: _projection.all.length,
-              itemBuilder: (context, index) {
-                final note = _projection.all[index];
-                return ListTile(
-                  key: Key('notes_screen_note_${note.id}'),
-                  title: Text(note.title),
-                  subtitle: Text(note.body),
-                  onTap: () => _openEditor(existing: note),
-                  trailing: IconButton(
-                    icon: const Icon(Icons.delete_outline),
-                    onPressed: () => _delete(note),
-                  ),
-                );
+    final l10n = _l10n;
+    final visible = _visible;
+    final rtl = widget.localeCode == 'ar';
+
+    return Directionality(
+      textDirection: rtl ? TextDirection.rtl : TextDirection.ltr,
+      child: Scaffold(
+        appBar: AppBar(
+          title: Text(l10n.notesTitle),
+          leading: widget.onBack == null
+              ? null
+              : IconButton(
+                  icon: const Icon(Icons.arrow_back),
+                  onPressed: widget.onBack,
+                ),
+          actions: [
+            if (widget.onRecordLive != null)
+              IconButton(
+                key: const Key('notes_screen_record_button'),
+                tooltip: l10n.record,
+                onPressed: widget.onRecordLive,
+                icon: const Icon(Icons.mic_none),
+              ),
+            if (widget.onImportAudio != null)
+              IconButton(
+                key: const Key('notes_screen_import_audio_button'),
+                tooltip: l10n.importAudio,
+                onPressed: widget.onImportAudio,
+                icon: const Icon(Icons.upload_file),
+              ),
+            if (widget.onImportPodcast != null)
+              IconButton(
+                key: const Key('notes_screen_import_podcast_button'),
+                tooltip: l10n.importPodcast,
+                onPressed: widget.onImportPodcast,
+                icon: const Icon(Icons.podcasts),
+              ),
+            IconButton(
+              key: const Key('notes_screen_super_summary_button'),
+              tooltip: l10n.superSummary,
+              onPressed: () {
+                setState(() {
+                  _selecting = !_selecting;
+                  if (!_selecting) _selected.clear();
+                });
               },
+              icon: Icon(_selecting ? Icons.close : Icons.auto_awesome),
             ),
-      floatingActionButton: FloatingActionButton(
-        key: const Key('notes_screen_create_button'),
-        onPressed: () => _openEditor(),
-        child: const Icon(Icons.add),
+            if (_selecting)
+              IconButton(
+                key: const Key('notes_screen_combine_button'),
+                tooltip: l10n.combineSelected,
+                onPressed: _combineSelected,
+                icon: const Icon(Icons.merge_type),
+              ),
+          ],
+        ),
+        body: _loading
+            ? const Center(child: CircularProgressIndicator())
+            : Column(
+                children: [
+                  Padding(
+                    padding: const EdgeInsets.fromLTRB(16, 8, 16, 0),
+                    child: TextField(
+                      key: const Key('notes_screen_search_field'),
+                      controller: _query,
+                      decoration: InputDecoration(
+                        prefixIcon: const Icon(Icons.search),
+                        hintText: l10n.search,
+                        border: const OutlineInputBorder(),
+                        isDense: true,
+                      ),
+                      onChanged: (_) => setState(() {}),
+                    ),
+                  ),
+                  if (_allTags.isNotEmpty)
+                    SizedBox(
+                      height: 44,
+                      child: ListView(
+                        key: const Key('notes_screen_tag_filter'),
+                        scrollDirection: Axis.horizontal,
+                        padding: const EdgeInsets.fromLTRB(12, 8, 12, 0),
+                        children: [
+                          for (final tag in _allTags)
+                            Padding(
+                              padding: const EdgeInsets.only(right: 8),
+                              child: FilterChip(
+                                key: Key('notes_screen_tag_chip_$tag'),
+                                label: Text(tag),
+                                selected: _tagFilter == tag,
+                                onSelected: (selected) {
+                                  setState(
+                                    () => _tagFilter = selected ? tag : null,
+                                  );
+                                },
+                              ),
+                            ),
+                        ],
+                      ),
+                    ),
+                  Expanded(
+                    child: _notes.isEmpty
+                        ? Center(child: Text(l10n.noNotesYet))
+                        : visible.isEmpty
+                        ? Center(child: Text(l10n.noMatchingNotes))
+                        : ListView.builder(
+                            itemCount: visible.length,
+                            itemBuilder: (context, index) {
+                              final note = visible[index];
+                              final selected = _selected.contains(note.id);
+                              return ListTile(
+                                key: Key('notes_screen_note_${note.id}'),
+                                leading: _selecting
+                                    ? Checkbox(
+                                        value: selected,
+                                        onChanged: (value) {
+                                          setState(() {
+                                            if (value ?? false) {
+                                              _selected.add(note.id);
+                                            } else {
+                                              _selected.remove(note.id);
+                                            }
+                                          });
+                                        },
+                                      )
+                                    : null,
+                                title: Text(note.title),
+                                subtitle: _subtitle(note),
+                                onTap: () {
+                                  if (_selecting) {
+                                    setState(() {
+                                      if (selected) {
+                                        _selected.remove(note.id);
+                                      } else {
+                                        _selected.add(note.id);
+                                      }
+                                    });
+                                    return;
+                                  }
+                                  _openEditor(existing: note);
+                                },
+                                trailing: IconButton(
+                                  icon: const Icon(Icons.delete_outline),
+                                  tooltip: l10n.delete,
+                                  onPressed: () => _delete(note),
+                                ),
+                              );
+                            },
+                          ),
+                  ),
+                ],
+              ),
+        floatingActionButton: FloatingActionButton(
+          key: const Key('notes_screen_create_button'),
+          onPressed: () => _openEditor(),
+          child: const Icon(Icons.add),
+        ),
       ),
+    );
+  }
+
+  Widget _subtitle(NotebookNote note) {
+    final preview = note.preview;
+    final chips = [...note.document.tags, ...note.document.labels];
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        if (preview.isNotEmpty) Text(preview, maxLines: 2),
+        if (chips.isNotEmpty)
+          Wrap(
+            spacing: 4,
+            children: [
+              for (final chip in chips.take(4))
+                Chip(
+                  label: Text(chip),
+                  visualDensity: VisualDensity.compact,
+                  materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                ),
+            ],
+          ),
+      ],
     );
   }
 }

--- a/packages/feature_mind/lib/src/surfaces/mind_runtime_hub_screen.dart
+++ b/packages/feature_mind/lib/src/surfaces/mind_runtime_hub_screen.dart
@@ -3,13 +3,9 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
-import 'package:path/path.dart' as p;
-import 'package:path_provider/path_provider.dart';
 
 import '../assistant/consent/mind_runtime_provider.dart';
-import '../notes/domain/notes_operation_log.dart';
-import '../notes/notes_capability.dart';
-import '../notes/presentation/notes_screen.dart';
+import '../notebook/presentation/notebook_host_screen.dart';
 import '../runtime_console/runtime_console_controller.dart';
 import '../runtime_console/runtime_console_table.dart';
 import 'devices_surface.dart';
@@ -36,7 +32,9 @@ class MindRuntimeHubScreen extends ConsumerWidget {
           ListTile(
             leading: const Icon(Icons.edit_note),
             title: const Text('Notes'),
-            subtitle: const Text('Rust notes log + restart persistence'),
+            subtitle: const Text(
+              'Record, import, summarise, tag, search, and share',
+            ),
             onTap: () => context.push('/runtime/notes'),
           ),
           ListTile(
@@ -66,62 +64,15 @@ class MindRuntimeDevicesScreen extends ConsumerWidget {
   }
 }
 
-/// Notes with Rust preferred path when Mind has booted.
-class MindRuntimeNotesScreen extends StatefulWidget {
-  const MindRuntimeNotesScreen({super.key});
+/// Notes host used by the runtime hub and the scribe `/notes` route.
+class MindRuntimeNotesScreen extends StatelessWidget {
+  const MindRuntimeNotesScreen({super.key, this.onRecordLive});
 
-  @override
-  State<MindRuntimeNotesScreen> createState() => _MindRuntimeNotesScreenState();
-}
-
-class _MindRuntimeNotesScreenState extends State<MindRuntimeNotesScreen> {
-  NotesCapability? _capability;
-  Object? _error;
-
-  @override
-  void initState() {
-    super.initState();
-    unawaited(_open());
-  }
-
-  Future<void> _open() async {
-    try {
-      final base = await getApplicationSupportDirectory();
-      final path = p.join(base.path, 'airo_mind', 'notes.log');
-      final log = await NotesOperationLog.open(path);
-      if (!mounted) return;
-      setState(
-        () => _capability = NotesCapability.rustPreferred(log),
-      );
-    } on Object catch (error) {
-      if (!mounted) return;
-      setState(() => _error = error);
-    }
-  }
+  final Future<void> Function()? onRecordLive;
 
   @override
   Widget build(BuildContext context) {
-    if (_error != null) {
-      return Scaffold(
-        appBar: AppBar(title: const Text('Notes')),
-        body: Center(child: Text('Could not open notes log: $_error')),
-      );
-    }
-    if (_capability == null) {
-      return const Scaffold(
-        body: Center(child: CircularProgressIndicator()),
-      );
-    }
-    return Scaffold(
-      appBar: AppBar(
-        title: const Text('Notes'),
-        leading: IconButton(
-          icon: const Icon(Icons.arrow_back),
-          onPressed: () => Navigator.of(context).maybePop(),
-        ),
-      ),
-      body: NotesScreen(capability: _capability!),
-    );
+    return NotebookHostScreen(onRecordLive: onRecordLive);
   }
 }
 
@@ -159,9 +110,7 @@ class _MindRuntimeConsoleScreenState
   Widget build(BuildContext context) {
     final controller = _controller;
     if (controller == null) {
-      return const Scaffold(
-        body: Center(child: CircularProgressIndicator()),
-      );
+      return const Scaffold(body: Center(child: CircularProgressIndicator()));
     }
     return Scaffold(
       appBar: AppBar(

--- a/packages/feature_mind/test/capture/application/meeting_processing_job_runner_test.dart
+++ b/packages/feature_mind/test/capture/application/meeting_processing_job_runner_test.dart
@@ -279,11 +279,54 @@ void main() {
 
       // ensureReady now re-inits when Settings picks a new speechLanguage;
       // with FakeReadyModelProvider that reaches the fake bridge.
-      expect(
-        speech.initializedSpeechLanguage,
-        rust.SpeechLanguage.englishOnly,
-      );
+      expect(speech.initializedSpeechLanguage, rust.SpeechLanguage.englishOnly);
       expect(speech.transcribeLanguage, 'en');
+    },
+  );
+
+  test(
+    'onProcessed runs after a successful pipeline and before retention delete',
+    () async {
+      speech.transcriptEvents = const [
+        TranscriptEventTranscriptReady('hello world', [
+          TranscriptSegment(
+            id: 's0',
+            startMs: 0,
+            endMs: 500,
+            text: 'hello world',
+          ),
+        ]),
+      ];
+      generation.meetingIntelligenceEvents = const [
+        MeetingIntelligenceEventMinutesReady('Minutes.'),
+      ];
+      final audioFile = File('${tempDir.path}/meeting.wav')
+        ..writeAsStringSync('audio');
+      MeetingProcessingJob? seenJob;
+      MindProgress? seenProgress;
+      final runner = MeetingProcessingJobRunner(
+        mindService: mindService,
+        retentionPolicy: () => AudioRetentionPolicy.deleteAfterTranscript,
+        onProcessed: (job, last) async {
+          seenJob = job;
+          seenProgress = last;
+          expect(audioFile.existsSync(), isTrue);
+        },
+      );
+
+      await runner.call(
+        MeetingProcessingJob(
+          id: 'm1',
+          audioPath: audioFile.path,
+          title: 'Standup',
+          enqueuedAtMs: 0,
+          source: MeetingProcessingSource.upload,
+        ),
+      );
+
+      expect(seenJob?.source, MeetingProcessingSource.upload);
+      expect(seenProgress?.stage, MindStage.done);
+      expect(audioFile.existsSync(), isFalse);
     },
   );
 }

--- a/packages/feature_mind/test/capture/domain/meeting_processing_job_test.dart
+++ b/packages/feature_mind/test/capture/domain/meeting_processing_job_test.dart
@@ -22,6 +22,30 @@ void main() {
     expect(decoded.status, job.status);
     expect(decoded.attempt, job.attempt);
     expect(decoded.lastError, job.lastError);
+    expect(decoded.source, MeetingProcessingSource.live);
+  });
+
+  test('source round-trips and missing source defaults to live', () {
+    const job = MeetingProcessingJob(
+      id: 'p1',
+      audioPath: '/tmp/pod.mp3',
+      title: 'Podcast',
+      enqueuedAtMs: 1,
+      source: MeetingProcessingSource.podcast,
+    );
+    expect(
+      MeetingProcessingJob.fromJson(job.toJson()).source,
+      MeetingProcessingSource.podcast,
+    );
+
+    final legacy = MeetingProcessingJob.fromJson({
+      'id': 'm1',
+      'audioPath': '/tmp/m1.m4a',
+      'title': 'Standup',
+      'enqueuedAtMs': 1,
+      'status': 'queued',
+    });
+    expect(legacy.source, MeetingProcessingSource.live);
   });
 
   test('an unrecognised status in storage falls back to queued', () {

--- a/packages/feature_mind/test/capture/domain/speech_language_mode_test.dart
+++ b/packages/feature_mind/test/capture/domain/speech_language_mode_test.dart
@@ -14,4 +14,37 @@ void main() {
     expect(SpeechLanguageMode.english.processLanguageCode, 'en');
     expect(SpeechLanguageMode.english.badgeLabel, 'English');
   });
+
+  test('pinned languages load multilingual weights and pin whisper codes', () {
+    expect(SpeechLanguageMode.hindi.includesMultilingualModel, isTrue);
+    expect(SpeechLanguageMode.hindi.processLanguageCode, 'hi');
+    expect(SpeechLanguageMode.marathi.processLanguageCode, 'mr');
+    expect(SpeechLanguageMode.spanish.processLanguageCode, 'es');
+    expect(SpeechLanguageMode.japanese.processLanguageCode, 'ja');
+    expect(SpeechLanguageMode.arabic.processLanguageCode, 'ar');
+  });
+
+  test('fromStorageValue and fromWhisperCode round-trip the catalog', () {
+    expect(
+      SpeechLanguageMode.fromStorageValue('hindi'),
+      SpeechLanguageMode.hindi,
+    );
+    expect(
+      SpeechLanguageMode.fromWhisperCode('pt'),
+      SpeechLanguageMode.portuguese,
+    );
+    expect(
+      SpeechLanguageMode.fromStorageValue('not-a-language'),
+      SpeechLanguageMode.auto,
+    );
+    expect(SpeechLanguageMode.fromWhisperCode(null), SpeechLanguageMode.auto);
+  });
+
+  test('the catalog covers Indic and major world languages', () {
+    expect(SpeechLanguageMode.values.length, greaterThanOrEqualTo(40));
+    expect(
+      SpeechLanguageMode.values.map((mode) => mode.whisperCode),
+      containsAll(['hi', 'mr', 'ta', 'es', 'fr', 'de', 'zh', 'ar']),
+    );
+  });
 }

--- a/packages/feature_mind/test/notebook/audio_import_service_test.dart
+++ b/packages/feature_mind/test/notebook/audio_import_service_test.dart
@@ -1,0 +1,75 @@
+import 'dart:io';
+
+import 'package:feature_mind/src/capture/domain/meeting_processing_job.dart';
+import 'package:feature_mind/src/notebook/application/audio_import_service.dart';
+import 'package:file_picker/file_picker.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  late Directory tempDir;
+
+  setUp(() async {
+    tempDir = await Directory.systemTemp.createTemp('audio_import_');
+  });
+
+  tearDown(() async {
+    if (await tempDir.exists()) await tempDir.delete(recursive: true);
+  });
+
+  test('accepts podcast and recording extensions, rejects documents', () {
+    final real = AudioImportService();
+    expect(real.isSupportedPath('/tmp/show.m4a'), isTrue);
+    expect(real.isSupportedPath('/tmp/show.mp3'), isTrue);
+    expect(real.isSupportedPath('/tmp/show.wav'), isTrue);
+    expect(real.isSupportedPath('/tmp/notes.pdf'), isFalse);
+    expect(real.titleFromPath('/tmp/deep_work.mp3'), 'deep work');
+    expect(
+      real.titleFromUrl('https://cdn.example.com/episodes/q3-review.mp3'),
+      'q3-review',
+    );
+    expect(real.isHttpUrl('https://example.com/a.mp3'), isTrue);
+    expect(real.isHttpUrl('file:///tmp/a.mp3'), isFalse);
+  });
+
+  test('pickLocalAudio returns the chosen supported path', () async {
+    final chosen = '${tempDir.path}/lecture.wav';
+    File(chosen).writeAsStringSync('audio');
+    final service = AudioImportService(
+      pickFile: ({type = FileType.any, allowedExtensions}) async {
+        expect(type, FileType.custom);
+        expect(allowedExtensions, contains('mp3'));
+        return PlatformFile(path: chosen, name: 'lecture.wav', size: 5);
+      },
+    );
+
+    expect(await service.pickLocalAudio(), chosen);
+  });
+
+  test('downloadRemote writes bytes through the injected downloader', () async {
+    final dest = '${tempDir.path}/pod.mp3';
+    final service = AudioImportService(
+      downloader: (url, path) async {
+        expect(url, 'https://example.com/pod.mp3');
+        await File(path).writeAsBytes([1, 2, 3], flush: true);
+      },
+    );
+
+    await service.downloadRemote(
+      url: 'https://example.com/pod.mp3',
+      destPath: dest,
+    );
+    expect(File(dest).lengthSync(), 3);
+  });
+
+  test('jobFor stamps upload vs podcast source', () {
+    final service = AudioImportService();
+    final job = service.jobFor(
+      audioPath: '/tmp/a.mp3',
+      title: 'Show',
+      source: MeetingProcessingSource.podcast,
+      enqueuedAtMs: 9,
+    );
+    expect(job.source, MeetingProcessingSource.podcast);
+    expect(job.title, 'Show');
+  });
+}

--- a/packages/feature_mind/test/notebook/key_points_extractor_test.dart
+++ b/packages/feature_mind/test/notebook/key_points_extractor_test.dart
@@ -1,0 +1,58 @@
+import 'package:feature_mind/src/notebook/domain/key_points_extractor.dart';
+import 'package:feature_mind/src/notebook/domain/notebook_summary.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  const extractor = KeyPointsExtractor();
+
+  test('prefers action items and markdown bullets over raw transcript', () {
+    final points = extractor.extract(
+      minutes: '''
+# Summary
+A long meeting.
+
+## Key points
+- Adopt Kubernetes for staging
+- Freeze hiring until April
+
+## Notes
+More prose that is not a bullet.
+''',
+      transcript: 'This sentence should not win because bullets exist.',
+      actionItems: ['Ping design about the banner'],
+    );
+
+    expect(points, [
+      'Ping design about the banner',
+      'Adopt Kubernetes for staging',
+      'Freeze hiring until April',
+    ]);
+  });
+
+  test('falls back to transcript sentences when minutes have no lists', () {
+    final points = extractor.extract(
+      transcript:
+          'We will launch on Tuesday. Priya owns the checklist. The budget is frozen.',
+    );
+
+    expect(points.first, contains('launch on Tuesday'));
+    expect(points, isNot(isEmpty));
+  });
+
+  test('summary reads an explicit Summary section then clips', () {
+    expect(
+      NotebookSummary.fromMinutes('''
+# Summary
+Ship the notebook this week.
+
+# Transcript
+ignored
+'''),
+      'Ship the notebook this week.',
+    );
+    expect(
+      NotebookSummary.fromMinutes('Just one paragraph about shipping.'),
+      'Just one paragraph about shipping.',
+    );
+  });
+}

--- a/packages/feature_mind/test/notebook/notebook_document_test.dart
+++ b/packages/feature_mind/test/notebook/notebook_document_test.dart
@@ -1,0 +1,49 @@
+import 'package:feature_mind/src/notebook/domain/notebook_document.dart';
+import 'package:feature_mind/src/notebook/domain/notebook_source.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('simple notes encode as plaintext so the skeleton stays readable', () {
+    const doc = NotebookDocument(body: 'milk, eggs');
+    expect(doc.isPlain, isTrue);
+    expect(doc.encode(), 'milk, eggs');
+    expect(NotebookDocument.decode('milk, eggs').body, 'milk, eggs');
+  });
+
+  test('tagged notes round-trip through the v1 envelope', () {
+    const doc = NotebookDocument(
+      body: 'follow up',
+      transcript: 'we should ship friday',
+      summary: 'Ship on Friday.',
+      keyPoints: ['Ship Friday', 'Tell Priya'],
+      tags: ['work'],
+      labels: ['meeting'],
+      languageCode: 'hi',
+      source: NotebookSource.live,
+      meetingId: 'm1',
+    );
+
+    final decoded = NotebookDocument.decode(doc.encode());
+    expect(decoded, doc);
+    expect(decoded.encode(), contains('airo.mind.notebook.v1'));
+  });
+
+  test('unknown JSON and torn envelopes fall back to plaintext', () {
+    expect(NotebookDocument.decode('{"no":"schema"}').body, '{"no":"schema"}');
+    expect(NotebookDocument.decode('{not-json').body, '{not-json');
+    expect(NotebookDocument.decode('').body, isEmpty);
+  });
+
+  test('preview prefers summary then body then transcript', () {
+    expect(
+      const NotebookDocument(
+        summary: 'Recap',
+        body: 'notes',
+        transcript: 'talk',
+      ).preview,
+      'Recap',
+    );
+    expect(const NotebookDocument(body: 'notes').preview, 'notes');
+    expect(const NotebookDocument(transcript: 'talk').preview, 'talk');
+  });
+}

--- a/packages/feature_mind/test/notebook/notebook_export_l10n_test.dart
+++ b/packages/feature_mind/test/notebook/notebook_export_l10n_test.dart
@@ -1,0 +1,52 @@
+import 'package:feature_mind/src/notebook/domain/notebook_document.dart';
+import 'package:feature_mind/src/notebook/domain/notebook_export.dart';
+import 'package:feature_mind/src/notebook/domain/notebook_l10n.dart';
+import 'package:feature_mind/src/notebook/domain/notebook_note.dart';
+import 'package:feature_mind/src/notebook/domain/notebook_source.dart';
+import 'package:feature_mind/src/notes/domain/note.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test(
+    'markdown export includes summary, key points, tags, and transcript',
+    () {
+      final note = NotebookNote(
+        note: const Note(
+          id: 'n1',
+          title: 'Standup',
+          body: '',
+          updatedAtMs: 1_700_000_000_000,
+        ),
+        document: const NotebookDocument(
+          body: 'follow up with Priya',
+          transcript: 'We ship Friday.',
+          summary: 'Ship Friday.',
+          keyPoints: ['Ship Friday'],
+          tags: ['work'],
+          labels: ['meeting'],
+          languageCode: 'en',
+          source: NotebookSource.live,
+        ),
+      );
+
+      final md = renderNotebookMarkdown(note);
+      expect(md, contains('title: "Standup"'));
+      expect(md, contains('tags: [work]'));
+      expect(md, contains('## Summary'));
+      expect(md, contains('## Key points'));
+      expect(md, contains('- Ship Friday'));
+      expect(md, contains('## Transcript'));
+      expect(notebookExportFileName(note), 'standup.md');
+    },
+  );
+
+  test('notebook UI copy is localized and falls back to English', () {
+    expect(NotebookL10n.of('en').noNotesYet, 'No notes yet');
+    expect(NotebookL10n.of('hi').noNotesYet, isNot('No notes yet'));
+    expect(NotebookL10n.of('hi').notesTitle, 'नोट्स');
+    expect(NotebookL10n.of('es').share, 'Compartir');
+    expect(NotebookL10n.of('ar').superSummary, isNotEmpty);
+    expect(NotebookL10n.of('xx-ZZ').locale, 'en');
+    expect(NotebookL10n.of('pt-BR').locale, 'pt');
+  });
+}

--- a/packages/feature_mind/test/notebook/notebook_locale_settings_tile_test.dart
+++ b/packages/feature_mind/test/notebook/notebook_locale_settings_tile_test.dart
@@ -1,0 +1,34 @@
+import 'package:feature_mind/src/notebook/presentation/notebook_locale_settings_tile.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  testWidgets('defaults to English and persists Hindi', (tester) async {
+    SharedPreferences.setMockInitialValues({});
+
+    await tester.pumpWidget(
+      const ProviderScope(
+        child: MaterialApp(home: Scaffold(body: NotebookLocaleSettingsTile())),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(
+      find.byKey(const Key('notebook_locale_settings_tile')),
+      findsOneWidget,
+    );
+    expect(find.text('English'), findsWidgets);
+
+    await tester.tap(
+      find.byKey(const Key('notebook_locale_settings_dropdown')),
+    );
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Hindi · हिन्दी').last);
+    await tester.pumpAndSettle();
+
+    final prefs = await SharedPreferences.getInstance();
+    expect(prefs.getString('mind_notebook_ui_locale'), 'hi');
+  });
+}

--- a/packages/feature_mind/test/notebook/notebook_repository_test.dart
+++ b/packages/feature_mind/test/notebook/notebook_repository_test.dart
@@ -1,0 +1,107 @@
+import 'dart:io';
+
+import 'package:feature_mind/src/capture/domain/meeting_processing_job.dart';
+import 'package:feature_mind/src/notebook/application/notebook_repository.dart';
+import 'package:feature_mind/src/notebook/domain/notebook_document.dart';
+import 'package:feature_mind/src/notebook/domain/notebook_source.dart';
+import 'package:feature_mind/src/notes/domain/notes_operation_log.dart';
+import 'package:feature_mind/src/notes/notes_capability.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  late Directory tempDir;
+  late NotebookRepository repo;
+
+  setUp(() async {
+    tempDir = await Directory.systemTemp.createTemp('notebook_repo_');
+    final log = await NotesOperationLog.open('${tempDir.path}/notes.log');
+    repo = NotebookRepository(NotesCapability(log));
+  });
+
+  tearDown(() async {
+    if (await tempDir.exists()) await tempDir.delete(recursive: true);
+  });
+
+  test('save then all() round-trips tags through the notes log', () async {
+    await repo.save(
+      id: 'n1',
+      title: 'Standup',
+      document: const NotebookDocument(
+        body: 'pods',
+        tags: ['work'],
+        labels: ['meeting'],
+      ),
+      recordedAtMs: 1,
+    );
+
+    final notes = await repo.all();
+    expect(notes, hasLength(1));
+    expect(notes.single.document.tags, ['work']);
+    expect(notes.single.document.labels, ['meeting']);
+    expect(notes.single.preview, 'pods');
+  });
+
+  test('ingestProcessed writes transcript, summary, and key points', () async {
+    final note = await repo.ingestProcessed(
+      job: const MeetingProcessingJob(
+        id: 'job1',
+        audioPath: '/tmp/a.m4a',
+        title: 'Podcast episode',
+        enqueuedAtMs: 10,
+        source: MeetingProcessingSource.podcast,
+      ),
+      transcript: 'We should launch on Tuesday.',
+      minutes: '''
+# Summary
+Launch Tuesday.
+
+## Key points
+- Launch on Tuesday
+''',
+      meetingId: 'm9',
+      languageCode: 'en',
+    );
+
+    expect(note.document.source, NotebookSource.podcast);
+    expect(note.document.meetingId, 'm9');
+    expect(note.document.languageCode, 'en');
+    expect(note.document.summary, contains('Launch Tuesday'));
+    expect(note.document.keyPoints, contains('Launch on Tuesday'));
+    expect(note.document.transcript, contains('launch on Tuesday'));
+    expect((await repo.all()).single.id, 'note_m9');
+  });
+
+  test('superSummary folds two notes into one recap note', () async {
+    await repo.save(
+      id: 'a',
+      title: 'One',
+      document: const NotebookDocument(
+        summary: 'First thread.',
+        keyPoints: ['Do A'],
+        tags: ['alpha'],
+      ),
+      recordedAtMs: 1,
+    );
+    await repo.save(
+      id: 'b',
+      title: 'Two',
+      document: const NotebookDocument(
+        summary: 'Second thread.',
+        keyPoints: ['Do B'],
+        tags: ['beta'],
+      ),
+      recordedAtMs: 2,
+    );
+
+    final recap = await repo.superSummary(
+      notes: await repo.all(),
+      recordedAtMs: 3,
+    );
+
+    expect(recap.title, 'Super summary · 2 notes');
+    expect(recap.document.source, NotebookSource.superSummary);
+    expect(recap.document.sourceNoteIds, ['a', 'b']);
+    expect(recap.document.tags, containsAll(['alpha', 'beta']));
+    expect((await repo.all()), hasLength(3));
+  });
+}

--- a/packages/feature_mind/test/notebook/notebook_search_test.dart
+++ b/packages/feature_mind/test/notebook/notebook_search_test.dart
@@ -1,0 +1,66 @@
+import 'package:feature_mind/src/notebook/domain/notebook_document.dart';
+import 'package:feature_mind/src/notebook/domain/notebook_note.dart';
+import 'package:feature_mind/src/notebook/domain/notebook_search.dart';
+import 'package:feature_mind/src/notes/domain/note.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+NotebookNote _note({
+  required String id,
+  required String title,
+  NotebookDocument? document,
+  String body = '',
+}) {
+  final doc = document ?? NotebookDocument(body: body);
+  return NotebookNote(
+    note: Note(id: id, title: title, body: doc.encode(), updatedAtMs: 1),
+    document: doc,
+  );
+}
+
+void main() {
+  const search = NotebookSearch();
+
+  final notes = [
+    _note(
+      id: '1',
+      title: 'Standup',
+      document: const NotebookDocument(
+        body: 'pods',
+        tags: ['work'],
+        labels: ['meeting'],
+        languageCode: 'en',
+        summary: 'Adopt Kubernetes',
+      ),
+    ),
+    _note(
+      id: '2',
+      title: 'Lecture',
+      document: const NotebookDocument(
+        transcript: 'backpropagation',
+        tags: ['study'],
+        languageCode: 'hi',
+      ),
+    ),
+  ];
+
+  test('query matches title, summary, tags, and transcript', () {
+    expect(search.filter(notes: notes, query: 'kubernetes').single.id, '1');
+    expect(search.filter(notes: notes, query: 'backprop').single.id, '2');
+    expect(search.filter(notes: notes, query: 'work').single.id, '1');
+  });
+
+  test('tag, label, and language filters are conjunctive', () {
+    expect(
+      search
+          .filter(notes: notes, tags: {'work'}, labels: {'meeting'})
+          .single
+          .id,
+      '1',
+    );
+    expect(search.filter(notes: notes, languageCode: 'hi').single.id, '2');
+    expect(
+      search.filter(notes: notes, tags: {'work'}, languageCode: 'hi'),
+      isEmpty,
+    );
+  });
+}

--- a/packages/feature_mind/test/notebook/super_summary_test.dart
+++ b/packages/feature_mind/test/notebook/super_summary_test.dart
@@ -1,0 +1,85 @@
+import 'package:feature_mind/src/notebook/domain/notebook_document.dart';
+import 'package:feature_mind/src/notebook/domain/notebook_note.dart';
+import 'package:feature_mind/src/notebook/domain/super_summary.dart';
+import 'package:feature_mind/src/notes/domain/note.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+NotebookNote _note({
+  required String id,
+  required String title,
+  NotebookDocument document = const NotebookDocument(),
+}) {
+  return NotebookNote(
+    note: Note(id: id, title: title, body: document.encode(), updatedAtMs: 1),
+    document: document,
+  );
+}
+
+void main() {
+  const composer = SuperSummaryComposer();
+
+  test('extractive Super Summary merges key points, tags, and titles', () {
+    final a = _note(
+      id: 'a',
+      title: 'Standup',
+      document: const NotebookDocument(
+        summary: 'Ship Friday.',
+        keyPoints: ['Ship Friday'],
+        tags: ['work'],
+        transcript: 'We ship Friday.',
+      ),
+    );
+    final b = _note(
+      id: 'b',
+      title: 'Lecture',
+      document: const NotebookDocument(
+        summary: 'Gradient descent recap.',
+        keyPoints: ['Use a smaller learning rate'],
+        tags: ['study'],
+        languageCode: 'en',
+      ),
+    );
+
+    final recap = composer.compose(notes: [a, b]);
+
+    expect(recap.source.name, 'superSummary');
+    expect(recap.sourceNoteIds, ['a', 'b']);
+    expect(recap.tags, containsAll(['work', 'study']));
+    expect(recap.labels, contains('super-summary'));
+    expect(recap.summary, contains('Standup'));
+    expect(recap.summary, contains('Lecture'));
+    expect(recap.keyPoints, contains('Ship Friday'));
+    expect(recap.keyPoints, contains('Use a smaller learning rate'));
+    expect(composer.defaultTitle([a, b]), 'Super summary · 2 notes');
+  });
+
+  test('generated recap wins over extractive summary', () {
+    final notes = [
+      _note(
+        id: 'a',
+        title: 'One',
+        document: const NotebookDocument(body: 'aaa'),
+      ),
+      _note(
+        id: 'b',
+        title: 'Two',
+        document: const NotebookDocument(body: 'bbb'),
+      ),
+    ];
+
+    final recap = composer.compose(
+      notes: notes,
+      generatedRecap: '''
+# Summary
+Both threads agree to delay the launch.
+
+# Key points
+- Delay the launch
+- Tell the customer first
+''',
+    );
+
+    expect(recap.summary, contains('delay the launch'));
+    expect(recap.keyPoints.first, contains('Delay the launch'));
+  });
+}

--- a/packages/feature_mind/test/notes/notes_screen_test.dart
+++ b/packages/feature_mind/test/notes/notes_screen_test.dart
@@ -1,6 +1,10 @@
 import 'dart:io';
 
-import 'package:feature_mind/feature_mind.dart';
+import 'package:feature_mind/src/notebook/application/notebook_share_port.dart';
+import 'package:feature_mind/src/notebook/domain/notebook_document.dart';
+import 'package:feature_mind/src/notes/domain/notes_operation_log.dart';
+import 'package:feature_mind/src/notes/notes_capability.dart';
+import 'package:feature_mind/src/notes/presentation/notes_screen.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -161,5 +165,130 @@ void main() {
 
     final projection = await directly(tester, capability.notes);
     expect(projection.isEmpty, isTrue);
+  });
+
+  testWidgets('search and tag chips filter the library', (tester) async {
+    await directly(tester, () async {
+      await capability.createNote(
+        id: 'n1',
+        title: 'Standup',
+        body: const NotebookDocument(
+          body: 'pods',
+          tags: ['work'],
+          summary: 'Adopt Kubernetes',
+        ).encode(),
+        recordedAtMs: 1,
+      );
+      await capability.createNote(
+        id: 'n2',
+        title: 'Lecture',
+        body: const NotebookDocument(
+          transcript: 'backpropagation',
+          tags: ['study'],
+        ).encode(),
+        recordedAtMs: 2,
+      );
+    });
+
+    await tester.pumpWidget(wrap(NotesScreen(capability: capability)));
+    await settle(tester);
+
+    expect(find.text('Standup'), findsOneWidget);
+    expect(find.text('Lecture'), findsOneWidget);
+
+    await tester.enterText(
+      find.byKey(const Key('notes_screen_search_field')),
+      'kubernetes',
+    );
+    await tester.pump();
+    expect(find.text('Standup'), findsOneWidget);
+    expect(find.text('Lecture'), findsNothing);
+
+    await tester.enterText(
+      find.byKey(const Key('notes_screen_search_field')),
+      '',
+    );
+    await tester.pump();
+    await tester.tap(find.byKey(const Key('notes_screen_tag_chip_study')));
+    await tester.pump();
+    expect(find.text('Lecture'), findsOneWidget);
+    expect(find.text('Standup'), findsNothing);
+  });
+
+  testWidgets('Super Summary combines two selected notes', (tester) async {
+    await directly(tester, () async {
+      await capability.createNote(
+        id: 'a',
+        title: 'One',
+        body: const NotebookDocument(
+          summary: 'First',
+          keyPoints: ['Do A'],
+        ).encode(),
+        recordedAtMs: 1,
+      );
+      await capability.createNote(
+        id: 'b',
+        title: 'Two',
+        body: const NotebookDocument(
+          summary: 'Second',
+          keyPoints: ['Do B'],
+        ).encode(),
+        recordedAtMs: 2,
+      );
+    });
+
+    await tester.pumpWidget(wrap(NotesScreen(capability: capability)));
+    await settle(tester);
+
+    await tester.tap(
+      find.byKey(const Key('notes_screen_super_summary_button')),
+    );
+    await tester.pump();
+    await tester.tap(find.text('One'));
+    await tester.tap(find.text('Two'));
+    await tester.tap(find.byKey(const Key('notes_screen_combine_button')));
+    await settle(tester);
+
+    expect(find.text('Super summary · 2 notes'), findsOneWidget);
+    final projection = await directly(tester, capability.notes);
+    expect(projection.length, 3);
+  });
+
+  testWidgets('copy writes markdown through the share port', (tester) async {
+    final share = MemoryNotebookSharePort();
+    await directly(
+      tester,
+      () => capability.createNote(
+        id: 'n1',
+        title: 'Standup',
+        body: const NotebookDocument(
+          summary: 'Ship Friday.',
+          keyPoints: ['Ship Friday'],
+        ).encode(),
+        recordedAtMs: 1,
+      ),
+    );
+
+    await tester.pumpWidget(
+      wrap(NotesScreen(capability: capability, sharePort: share)),
+    );
+    await settle(tester);
+    await tester.tap(find.text('Standup'));
+    await settle(tester);
+    await tester.tap(find.byKey(const Key('notes_screen_copy_button')));
+    await tester.pump();
+
+    expect(share.lastCopied, contains('# Standup'));
+    expect(share.lastCopied, contains('Ship Friday'));
+  });
+
+  testWidgets('Hindi locale localizes the empty state', (tester) async {
+    await tester.pumpWidget(
+      wrap(NotesScreen(capability: capability, localeCode: 'hi')),
+    );
+    await settle(tester);
+
+    expect(find.text('नोट्स'), findsOneWidget);
+    expect(find.text('अभी कोई नोट नहीं'), findsOneWidget);
   });
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Rebased onto latest `origin/main` (Mind 0.0.7-preview) so this change set no longer carries the old full-app `app/pubspec.yaml`.

Airo Mind notes now cover the product loop people asked for: record or import speech in many languages, keep an on-device transcript with an AI summary and key points, combine several notes into a Super Summary, stay organized with tags/labels/search, and export, copy, or share.

The Notes operation log is unchanged (`create` / `edit` / `delete` of title + body). Extra fields live in an `airo.mind.notebook.v1` JSON envelope inside `body`, so the Rust notes encoding stays in lockstep. Simple handwritten notes still store plaintext.

- **Languages.** Transcription catalog beyond Auto/English (Indic + major world languages). Notes UI copy in en, hi, mr, es, fr, de, pt, ja, zh, ar.
- **Live recording.** Existing whisper pipeline; a finished job also writes a notebook note.
- **Uploads and podcasts.** File picker or HTTP(S) URL → staging copy → same processing queue.
- **Summary and key points.** Derived from minutes, action items, and transcript.
- **Super Summary.** Select two or more notes and fold them into one recap note (extractive fallback when no model is loaded).
- **Tags, labels, search.** First-class on the document; library filter is keyword + tag + language.
- **Export / copy / share.** Markdown via clipboard, share sheet, or save-to-folder.

Spec: `docs/superpowers/specs/2026-08-20-airo-mind-notebook.md`

## Test Plan

- [x] Rebased onto `origin/main`; `scripts/check-build-profiles.py` now matches current main (full-profile `airo` package gap is pre-existing on main)
- [x] `flutter test` in `packages/feature_mind` after rebase:
  - `test/notebook/`
  - `test/notes/`
  - capture domain + job-runner tests included in the same run (50 passed)

**Verification environment:** Host-only

## Agent Policy

- [x] Feature Packet: `docs/superpowers/specs/2026-08-20-airo-mind-notebook.md`
- [x] Application-layer work in `feature_mind`; Notes runtime encoding is not changed
- [x] Deterministic tests cover encode/decode, ingest, Super Summary, search, export, languages, and Notes UI
- [x] Android Emulator was not used

## Council Review

- Product Manager (owner of `feature_mind`)
- Chief Architect (notes payload vs runtime encoding)
- Chief QA Officer (notebook + capture tests)
- Chief Security Officer (local-only transcription; podcast URL is download-then-process)

- [x] I checked the Decision Matrix and listed required roles above.
- [x] Touched package already has `module.yaml`
- [x] `owner`/`reviewers` in `feature_mind/module.yaml` unchanged

## User-Facing Documentation

- [x] Updated `docs/wiki/4.-Using-Core-Capabilities.md` (Airo Mind notes)
- [x] Updated `docs/wiki/3.-Navigating-Airo.md` (Notes route)

## Plugin and Size Impact

- [ ] This PR adds new dependencies
- [x] This PR adds or grows app/packages/plugins code (`feature_mind` notebook layer)
- [x] Size impact is documented below

Size impact / plugin justification: Dart-only notebook layer in `feature_mind`. No new packages. Reuses `file_picker`, `share_plus`, and `dio` already on the Mind pubspec.

## Checklist

- [x] Code is formatted.
- [x] Tests or manual verification are included above.
- [x] Sensitive data, credentials, and signing artifacts are not committed.

## Release Notes

- [x] User-facing change documented in the wiki

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3c16b9cd-23c2-40c9-89ef-7ab839050edb?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3c16b9cd-23c2-40c9-89ef-7ab839050edb&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

