### PR TITLE
feat(mind): envelope few-shots on standard/deep with PD-PERF-002 cap

### DIFF
--- a/packages/core_ai/lib/src/reliability/prompt_registry.dart
+++ b/packages/core_ai/lib/src/reliability/prompt_registry.dart
@@ -183,6 +183,7 @@ abstract final class ChatTurnReliability {
     RegisteredPrompt definition = AiroPromptRegistry.chatAssistant,
     PrefixCacheCapability prefixCache = PrefixCacheCapability.unsupported,
     int cacheablePrefixTokens = 0,
+    int fewShotCount = 0,
   }) {
     final gate = PromptQualityGate.inspectUserTurn(
       userText: userText,
@@ -192,6 +193,7 @@ abstract final class ChatTurnReliability {
       outputBudget: outputBudget,
       prefixCache: prefixCache,
       cacheablePrefixTokens: cacheablePrefixTokens,
+      fewShotCount: fewShotCount,
     );
     final rebuild = gate.decision == PromptGateDecision.rebuildContext;
     return ChatTurnPlan(

--- a/packages/core_ai/lib/src/reliability/prompt_reliability.dart
+++ b/packages/core_ai/lib/src/reliability/prompt_reliability.dart
@@ -112,6 +112,7 @@ abstract final class PromptQualityGate {
     'book that one',
   };
 
+  static const maxFewShots = 2;
   static const prefixCacheWarnTokens = 256;
 
   static PromptGateReport inspectUserTurn({
@@ -124,6 +125,7 @@ abstract final class PromptQualityGate {
     String outputContract = '',
     PrefixCacheCapability prefixCache = PrefixCacheCapability.unsupported,
     int cacheablePrefixTokens = 0,
+    int fewShotCount = 0,
   }) {
     final normalized = _normalize(userText);
     final defects = <PromptDefect>[];
@@ -150,6 +152,9 @@ abstract final class PromptQualityGate {
     if (prefixCache == PrefixCacheCapability.unsupported &&
         cacheablePrefixTokens > prefixCacheWarnTokens) {
       defects.add(PromptDefect.perf003NoPrefixCache);
+    }
+    if (fewShotCount > maxFewShots) {
+      defects.add(PromptDefect.perf002InefficientFewShot);
     }
     if (_hasUnsatisfiablePolarity(userText)) {
       defects.add(PromptDefect.spec003ConflictingInstructions);

--- a/packages/core_ai/test/reliability/reasoning_reliability_test.dart
+++ b/packages/core_ai/test/reliability/reasoning_reliability_test.dart
@@ -175,6 +175,22 @@ void main() {
     expect(cached.defects, isNot(contains(PromptDefect.perf003NoPrefixCache)));
   });
 
+  test('more than two few-shots is PD-PERF-002 and still allowed', () {
+    final report = PromptQualityGate.inspectUserTurn(
+      userText: 'Summarize the last meeting decision on pricing.',
+      fewShotCount: 5,
+    );
+    expect(report.defects, contains(PromptDefect.perf002InefficientFewShot));
+    expect(report.decision, PromptGateDecision.allow);
+    expect(report.blocksInference, isFalse);
+
+    final ok = PromptQualityGate.inspectUserTurn(
+      userText: 'Summarize the last meeting decision on pricing.',
+      fewShotCount: PromptQualityGate.maxFewShots,
+    );
+    expect(ok.defects, isNot(contains(PromptDefect.perf002InefficientFewShot)));
+  });
+
   test('recovery engine aborts after the skill JSON retry budget', () {
     final engine = RecoveryEngine(RecoveryPolicy.skillJson);
     expect(engine.select(RecoveryAction.retry), RecoveryDecision.execute);

--- a/rust/airo_mind_reasoning/src/lib.rs
+++ b/rust/airo_mind_reasoning/src/lib.rs
@@ -34,6 +34,7 @@ pub use grammar::RESULT_GRAMMAR;
 pub use intent::ClassifiedIntent;
 pub use level::ReasoningLevel;
 pub use policy::{HeuristicReasoningPolicy, ReasoningPolicy};
+pub use prompt::MAX_ENVELOPE_SHOTS;
 pub use request::{ReasoningRequest, ToolDefinition};
 pub use result::{ReasoningResult, ToolCall};
 pub use tools::{ToolExecutor, MAX_TOOL_ITERATIONS};

--- a/rust/airo_mind_reasoning/src/prompt.rs
+++ b/rust/airo_mind_reasoning/src/prompt.rs
@@ -5,6 +5,12 @@ use crate::grammar::ENVELOPE_OPEN;
 use crate::level::ReasoningLevel;
 use crate::request::ReasoningRequest;
 
+/// PD-PERF-002: never more than two envelope shots. `none`/`light` take zero.
+pub const MAX_ENVELOPE_SHOTS: usize = 2;
+
+const DIRECT_USER: &str = "Why does ice float?";
+const DIRECT_ENVELOPE: &str = r#"{"answer":"Ice is less dense than liquid water.","reasoning_summary":"Used density.","confidence":0.92}"#;
+
 pub fn build_prompt(
     request: &ReasoningRequest,
     level: ReasoningLevel,
@@ -14,6 +20,7 @@ pub fn build_prompt(
     let mut out = String::new();
     out.push_str(system_for(level));
     out.push_str("\n\n");
+    append_shots(&mut out, request, level, limits, packed.total_chars());
     append_section(&mut out, "Context", &packed);
     out.push_str("User request:\n");
     out.push_str(&request.user_query);
@@ -44,6 +51,54 @@ Do not invent tools. Do not include a thoughts field.\nJSON:\n",
     }
     out.push_str(ENVELOPE_OPEN);
     out
+}
+
+fn append_shots(
+    out: &mut String,
+    request: &ReasoningRequest,
+    level: ReasoningLevel,
+    limits: ContextLimits,
+    packed_chars: usize,
+) {
+    if !matches!(level, ReasoningLevel::Standard | ReasoningLevel::Deep) {
+        return;
+    }
+    let remaining = limits.max_chars.saturating_sub(packed_chars);
+    let mut shots = vec![render_shot(DIRECT_USER, DIRECT_ENVELOPE)];
+    if let Some(tool) = request.available_tools.first() {
+        shots.push(render_shot(
+            "What is on my calendar tomorrow?",
+            &tool_envelope(&tool.name),
+        ));
+    }
+    shots.truncate(MAX_ENVELOPE_SHOTS);
+    const HEADER: &str =
+        "Examples (match this envelope; reason privately; do not emit thoughts):\n";
+    while !shots.is_empty() {
+        let used: usize = HEADER.len() + shots.iter().map(String::len).sum::<usize>();
+        if used <= remaining {
+            break;
+        }
+        shots.pop();
+    }
+    if shots.is_empty() {
+        return;
+    }
+    out.push_str(HEADER);
+    for shot in &shots {
+        out.push_str(shot);
+    }
+    out.push('\n');
+}
+
+fn render_shot(user: &str, envelope: &str) -> String {
+    format!("User request:\n{user}\nJSON:\n{envelope}\n\n")
+}
+
+fn tool_envelope(name: &str) -> String {
+    format!(
+        r#"{{"answer":"","reasoning_summary":"Need listed tool.","confidence":0.80,"tool_calls":[{{"name":"{name}","arguments_json":"{{\"day\":\"tomorrow\"}}"}}]}}"#
+    )
 }
 
 fn system_for(level: ReasoningLevel) -> &'static str {
@@ -160,5 +215,76 @@ mod tests {
         }
         assert!(!standard.contains("systematically"));
         assert!(deep.contains("systematically"));
+    }
+
+    #[test]
+    fn none_and_light_do_not_pay_for_few_shots() {
+        let req = ReasoningRequest::fixture("time_query", 0.0);
+        for level in [ReasoningLevel::None, ReasoningLevel::Light] {
+            let prompt = build_prompt(&req, level, ContextLimits::default());
+            assert!(
+                !prompt.contains("Examples"),
+                "{level:?} must stay zero-shot: {prompt}"
+            );
+            assert!(!prompt.contains("Why does ice float?"));
+        }
+    }
+
+    #[test]
+    fn standard_and_deep_include_an_envelope_shot_without_a_thoughts_field() {
+        let req = ReasoningRequest::fixture("planning", 0.8);
+        for level in [ReasoningLevel::Standard, ReasoningLevel::Deep] {
+            let prompt = build_prompt(&req, level, ContextLimits::default());
+            assert!(prompt.contains("Examples"), "{level:?}: {prompt}");
+            assert!(prompt.contains("Why does ice float?"), "{level:?}");
+            assert!(prompt.contains(r#""answer":"Ice is less dense than liquid water.""#));
+            assert!(!prompt.contains("\"thoughts\""));
+            assert!(!prompt.contains("\"scratchpad\""));
+            assert!(
+                prompt.find("Examples").unwrap() < prompt.find("User request:").unwrap(),
+                "shots belong in the cacheable prefix before the live turn"
+            );
+        }
+    }
+
+    #[test]
+    fn tools_add_a_tool_call_shot_and_cap_at_two() {
+        let mut req = ReasoningRequest::fixture("calendar_retrieval", 0.4);
+        req.available_tools = vec![crate::request::ToolDefinition {
+            name: "read_calendar_events".into(),
+            description: "List events for a day.".into(),
+        }];
+        let prompt = build_prompt(&req, ReasoningLevel::Standard, ContextLimits::default());
+        assert!(prompt.contains("Why does ice float?"));
+        assert!(prompt.contains("read_calendar_events"));
+        assert!(prompt.contains("\"tool_calls\""));
+        let examples = prompt.matches("JSON:\n{").count();
+        assert!(
+            examples <= MAX_ENVELOPE_SHOTS + 1,
+            "at most {MAX_ENVELOPE_SHOTS} shots plus the live JSON header, got {examples}: {prompt}"
+        );
+    }
+
+    #[test]
+    fn tight_context_budget_drops_shots_pd_perf_002() {
+        let mut req = ReasoningRequest::fixture("planning", 0.8);
+        req.user_query = "Plan the week.".into();
+        req.context.history = vec![crate::context::ContextItem {
+            source: "chat".into(),
+            text: "word ".repeat(80),
+        }];
+        let prompt = build_prompt(
+            &req,
+            ReasoningLevel::Standard,
+            ContextLimits {
+                max_chars: 200,
+                ..ContextLimits::default()
+            },
+        );
+        assert!(
+            !prompt.contains("Why does ice float?"),
+            "PD-PERF-002: drop shots when they would crowd the live turn: {prompt}"
+        );
+        assert!(prompt.contains("Plan the week."));
     }
 }

--- a/rust/airo_mind_reliability/src/prompt_gate.rs
+++ b/rust/airo_mind_reliability/src/prompt_gate.rs
@@ -99,6 +99,8 @@ pub struct PromptInspection<'a> {
     pub prefix_cache: PrefixCacheCapability,
     pub history_empty: bool,
     pub requires_structured_output: bool,
+    /// Envelope / I-O exemplars already in the compiled prompt. PD-PERF-002.
+    pub few_shot_count: u32,
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -223,6 +225,14 @@ impl PromptQualityGate {
             push_unique(
                 &mut findings,
                 PromptDefect::Perf003NoPrefixCache,
+                PromptFindingSeverity::Warning,
+            );
+        }
+
+        if input.few_shot_count > 2 {
+            push_unique(
+                &mut findings,
+                PromptDefect::Perf002InefficientFewShot,
                 PromptFindingSeverity::Warning,
             );
         }

--- a/rust/airo_mind_reliability/tests/prompt_defects.rs
+++ b/rust/airo_mind_reliability/tests/prompt_defects.rs
@@ -90,6 +90,7 @@ fn ambiguous_improve_request_asks_user_before_inference() {
         budget: budget_ok(),
         definition: Some(&def),
         prefix_cache: PrefixCacheCapability::Unsupported,
+        few_shot_count: 0,
         history_empty: true,
         requires_structured_output: false,
     });
@@ -116,6 +117,7 @@ fn specific_request_is_allowed() {
         budget: budget_ok(),
         definition: Some(&def),
         prefix_cache: PrefixCacheCapability::Unsupported,
+        few_shot_count: 0,
         history_empty: true,
         requires_structured_output: false,
     });
@@ -138,6 +140,7 @@ fn injection_aborts_before_the_model() {
         budget: budget_ok(),
         definition: Some(&def),
         prefix_cache: PrefixCacheCapability::Unsupported,
+        few_shot_count: 0,
         history_empty: true,
         requires_structured_output: false,
     });
@@ -172,6 +175,7 @@ fn unsatisfiable_same_layer_instructions_abort() {
         budget: budget_ok(),
         definition: Some(&def),
         prefix_cache: PrefixCacheCapability::Unsupported,
+        few_shot_count: 0,
         history_empty: true,
         requires_structured_output: false,
     });
@@ -202,6 +206,7 @@ fn over_budget_rebuilds_context_instead_of_calling_the_model() {
         },
         definition: Some(&def),
         prefix_cache: PrefixCacheCapability::Unsupported,
+        few_shot_count: 0,
         history_empty: false,
         requires_structured_output: false,
     });
@@ -238,6 +243,7 @@ fn missing_output_contract_blocks_structured_tasks() {
         budget: budget_ok(),
         definition: Some(&def),
         prefix_cache: PrefixCacheCapability::Unsupported,
+        few_shot_count: 0,
         history_empty: true,
         requires_structured_output: true,
     });
@@ -274,6 +280,7 @@ fn schema_mismatch_is_an_engineering_defect_not_pm04() {
         budget: budget_ok(),
         definition: Some(&def),
         prefix_cache: PrefixCacheCapability::Unsupported,
+        few_shot_count: 0,
         history_empty: true,
         requires_structured_output: true,
     });
@@ -283,6 +290,33 @@ fn schema_mismatch_is_an_engineering_defect_not_pm04() {
         .iter()
         .any(|f| f.defect == PromptDefect::Eng005IntegrationMismatch));
     assert!(FailureMode::from_id("PD-ENG-005").is_none());
+}
+
+#[test]
+fn more_than_two_few_shots_is_pd_perf_002_and_does_not_block() {
+    let (task, instructions, prompt) = empty_task(
+        "rename locals",
+        "Rename locals in parse_config for readability.",
+    );
+    let def = registered();
+    let report = PromptQualityGate::inspect(PromptInspection {
+        task: &task,
+        instructions: &instructions,
+        prompt: &prompt,
+        context: None,
+        budget: budget_ok(),
+        definition: Some(&def),
+        prefix_cache: PrefixCacheCapability::Unsupported,
+        few_shot_count: 5,
+        history_empty: true,
+        requires_structured_output: false,
+    });
+    assert_eq!(report.decision, PromptGateDecision::Allow);
+    assert!(!report.blocks_inference());
+    assert!(report
+        .findings
+        .iter()
+        .any(|f| f.defect == PromptDefect::Perf002InefficientFewShot));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- `standard` / `deep` prompts now include at most two JSON-envelope few-shots (direct answer, plus a tool-call shot when tools are listed). `none` / `light` stay zero-shot.
- Shots sit in the cacheable prefix, contain no `thoughts` / `scratchpad` keys, and are dropped when they would crowd the live turn (PD-PERF-002).
- Prompt quality gate warns (does not block) when `few_shot_count > 2`.

Epic: #1827.

## Test plan
- [x] `cargo test -p airo_mind_reasoning --manifest-path rust/Cargo.toml --offline`
- [x] `cargo clippy -p airo_mind_reasoning --manifest-path rust/Cargo.toml --offline -- -D warnings`
- [x] `cargo test -p airo_mind_reliability --manifest-path rust/Cargo.toml --offline --test prompt_defects`
- [x] `cd packages/core_ai && flutter test test/reliability/reasoning_reliability_test.dart test/reliability/prompt_eval_suite_test.dart`


Made with [Cursor](https://cursor.com)