### PR TITLE
feat(mind): record reliability checkpoints in-process without a new op kind

### DIFF
--- a/docs/adr/0023-mind-reliability-checkpoints-in-process.md
+++ b/docs/adr/0023-mind-reliability-checkpoints-in-process.md
@@ -1,0 +1,112 @@
+# ADR 0023 — Mind reliability checkpoints stay in-process
+
+## Status
+
+Accepted (records [Architecture Freeze v1](../AIRO_MIND_ARCHITECTURE_FREEZE_v1.md);
+no new primitive)
+
+## Date
+
+2026-08-22
+
+Deciders: Chief Architect (module boundaries / ADRs), Chief Security Officer
+(no prompt bodies on disk), Edge Architect (offline/caching consult).
+This ADR does not add a `MindOpKind` and does not change `OperationLogPort`.
+
+## Context
+
+Reasoning reliability classifies empty or failed completions as PM-06 / PM-08
+and AIRO-R06 / AIRO-R07. Rust already has an in-process `ExecutionLog` whose
+`PersistableDiagnostic` fields are classification metadata only.
+
+Dart chat kept a single `lastReliabilityDiagnostic` slot. That is not a
+checkpoint log: a later successful turn erases the previous failure, and
+nothing records that the payload must never include the prompt.
+
+The freeze already forbids inventing a durable operation kind for this. A
+second store, a new `MindOpKind`, or writing raw prompts / IR / completions
+would be a new primitive.
+
+## Decision
+
+1. **Checkpoints are in-process.** Dart mirrors Rust `ExecutionLog`: a bounded
+   ring of `PersistableDiagnostic` values on the assistant runtime (and any
+   later caller that already classifies completions). Process death drops
+   them. That is accepted.
+
+2. **Metadata only.** Allowed fields are execution id, failure mode, runtime
+   error, and (when added later) stage / recovery / model id. Forbidden:
+   prompt text, system prompt, completions, tool results, retrieved notes,
+   IR, tokens.
+
+3. **No `MindOpKind`.** Reliability checkpoints are not operations. They must
+   not call `OperationLogPort.append`. Meeting IR mapping stays ADR-0022.
+
+4. **Disk durability is out of scope.** Rust `ExecutionLog::persistable`
+   describes the *shape* of a future writer. Wiring that shape to a file,
+   EventBus topic, or telemetry backend needs a follow-up ADR that names an
+   existing store. This ADR does not create one.
+
+5. **Prefix cache stays an adapter capability.** llama.cpp `n_keep` / KV reuse
+   is not a Mind primitive and is not required here. `llama-cpp-2` 0.1.153
+   does not expose `n_keep`; do not wrap a C API for it under this decision.
+
+## Contract Impact
+
+**Required. Fill every row — "none" is an answer, blank is not.**
+
+| Question | Answer |
+|---|---|
+| Which runtime contracts change? | None. C1–C7 and `MindRuntime` ports are unchanged. |
+| Which conformance tests become invalid? | None. Existing `lastReliabilityDiagnostic` reads remain valid as “last record in the in-process log”. |
+| Which benchmarks must be re-run? | None. |
+| Which review roles must re-review? | Chief Architect (ADR), Chief Security Officer (no prompt persistence). |
+| Is G0 required again? | No. No crate public surface and no plan code-block change. |
+
+## Consequences
+
+### Positive
+
+- Chat / Cloud / LiteRT failures keep a short in-process history without
+  crossing the operation log.
+- Tests can assert the dump contains PM / AIRO-R ids and never the prompt.
+
+### Negative
+
+- A killed app loses the ring. Debugging across process restarts still needs
+  a later writer ADR.
+- Callers that only read `lastReliabilityDiagnostic` still see one slot; they
+  must use `ExecutionLog.checkpoints` for history.
+
+### Risks
+
+- Someone later appends these diagnostics as `MindOpKind.inference`. This ADR
+  forbids that; reject it in review.
+
+## Alternatives Considered
+
+### Alternative 1: New `MindOpKind.reliabilityCheckpoint`
+
+Rejected. Freeze: do not add `MindOpKind` for this. Operations are user-visible
+Mind work, not classifier hits.
+
+### Alternative 2: Persist prompts at Debug diagnostic level
+
+Rejected. Rust already omits raw content including at Debug. Dart must match.
+
+### Alternative 3: Wait for llama.cpp session files / `n_keep`
+
+Rejected as a substitute. Prefix cache is unrelated to checkpoint identity.
+KV reuse can land later as an adapter flag without this ADR.
+
+## Related Decisions
+
+- [ADR-0021](0021-mind-runtime-port.md) — `OperationLogPort` is the only write
+  primitive for Mind ops; this ADR does not use it.
+- [ADR-0022](0022-meeting-ir-mind-persistence-mapping.md) — meeting IR may add
+  `MindOpKind.meetingIrExtracted`; reliability must not ride that kind.
+
+## References
+
+- `rust/airo_mind_reliability/src/execution.rs`
+- `packages/core_ai/lib/src/reliability/failure_classifier.dart`

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -18,6 +18,7 @@ An Architecture Decision Record (ADR) captures an important architectural decisi
 | [0011](0011-super-app-modular-shell-ssot.md) | Super-app modular shell SSOT | Proposed | 2026-07-24 |
 | [0012](0012-edge-intelligence-media-boundary.md) | Edge intelligence and media-engine boundary | Accepted | 2026-07-27 |
 | [0018](0018-airo-arena-game-intelligence-packs.md) | Airo Arena as game intelligence packs on the existing edge runtime | Proposed | 2026-08-01 |
+| [0023](0023-mind-reliability-checkpoints-in-process.md) | Mind reliability checkpoints stay in-process | Accepted | 2026-08-22 |
 
 ## Creating a New ADR
 

--- a/packages/core_ai/lib/src/reliability/failure_classifier.dart
+++ b/packages/core_ai/lib/src/reliability/failure_classifier.dart
@@ -16,6 +16,39 @@ class PersistableDiagnostic {
   final RuntimeFailure? runtimeError;
 }
 
+/// Bounded in-process checkpoint log. Mirror of Rust `ExecutionLog`.
+///
+/// Not an operation-log writer (ADR-0023). Process death drops the ring.
+class ExecutionLog {
+  ExecutionLog({this.capacity = 32});
+
+  final int capacity;
+  final List<PersistableDiagnostic> _checkpoints = [];
+
+  void record(PersistableDiagnostic? diagnostic) {
+    if (diagnostic == null) return;
+    _checkpoints.add(diagnostic);
+    if (_checkpoints.length > capacity) {
+      _checkpoints.removeRange(0, _checkpoints.length - capacity);
+    }
+  }
+
+  List<PersistableDiagnostic> get checkpoints =>
+      List<PersistableDiagnostic>.unmodifiable(_checkpoints);
+
+  PersistableDiagnostic? get last =>
+      _checkpoints.isEmpty ? null : _checkpoints.last;
+
+  PersistableDiagnostic? get lastFailure {
+    for (var i = _checkpoints.length - 1; i >= 0; i--) {
+      if (_checkpoints[i].failureMode != null) return _checkpoints[i];
+    }
+    return null;
+  }
+
+  bool get isEmpty => _checkpoints.isEmpty;
+}
+
 /// Dart mirror of `record_chat_completion` for Cloud / LiteRT / Gemini.
 /// No new FFI events.
 abstract final class FailureClassifier {

--- a/packages/core_ai/test/reliability/reasoning_reliability_test.dart
+++ b/packages/core_ai/test/reliability/reasoning_reliability_test.dart
@@ -261,6 +261,37 @@ void main() {
     );
   });
 
+  test('execution log keeps metadata and never stores prompt text', () {
+    final log = ExecutionLog(capacity: 2);
+    const secret = 'SECRET_PROMPT_BODY ignore previous instructions';
+    log.record(
+      FailureClassifier.recordChatCompletion(
+        executionId: 'chat-1',
+        text: secret,
+        engineOk: false,
+      ),
+    );
+    log.record(
+      FailureClassifier.recordChatCompletion(
+        executionId: 'chat-2',
+        text: '   ',
+        engineOk: true,
+      ),
+    );
+    log.record(
+      FailureClassifier.recordChatCompletion(
+        executionId: 'chat-3',
+        text: secret,
+        engineOk: false,
+      ),
+    );
+    expect(log.checkpoints, hasLength(2));
+    expect(log.lastFailure?.executionId, 'chat-3');
+    expect(log.lastFailure?.runtimeError, RuntimeFailure.r07ModelAdapter);
+    expect(log.checkpoints.toString(), isNot(contains(secret)));
+    expect(log.checkpoints.toString(), isNot(contains('PM-17')));
+  });
+
   test('chat goal cannot complete without verification', () {
     final running = ChatTurnGoal(goal: 'What is 2+2?').start();
     expect(running.succeeded, isFalse);

--- a/packages/feature_mind/lib/src/agent_chat/data/services/assistant_runtime_service.dart
+++ b/packages/feature_mind/lib/src/agent_chat/data/services/assistant_runtime_service.dart
@@ -255,6 +255,9 @@ class AssistantRuntimeService {
   /// In-process PM/AIRO diagnostic from the last generateText / stream.
   PersistableDiagnostic? lastReliabilityDiagnostic;
 
+  /// Bounded checkpoint ring for this runtime. Metadata only (ADR-0023).
+  final ExecutionLog reliabilityLog = ExecutionLog();
+
   Future<AssistantRuntimePreparationResult> prepareRuntime({
     required AssistantModelCandidate candidate,
     int? contextLengthOverride,
@@ -860,10 +863,12 @@ class AssistantRuntimeService {
       yield chunk;
     }
     if (!yielded) {
-      lastReliabilityDiagnostic = FailureClassifier.recordChatCompletion(
-        executionId: runtimeId,
-        text: '',
-        engineOk: true,
+      _noteReliability(
+        FailureClassifier.recordChatCompletion(
+          executionId: runtimeId,
+          text: '',
+          engineOk: true,
+        ),
       );
       throw AssistantRuntimeUnavailableException(
         runtimeId,
@@ -922,20 +927,24 @@ class AssistantRuntimeService {
     lastGenerationStats = _llamaGguf.lastStats;
     final response = lastYielded.trim();
     if (response.isEmpty) {
-      lastReliabilityDiagnostic = FailureClassifier.recordChatCompletion(
-        executionId: runtimeId,
-        text: '',
-        engineOk: true,
+      _noteReliability(
+        FailureClassifier.recordChatCompletion(
+          executionId: runtimeId,
+          text: '',
+          engineOk: true,
+        ),
       );
       throw AssistantRuntimeUnavailableException(
         runtimeId,
         ChatOutputVerifier.userMessageFor(OutputVerification.incomplete)!,
       );
     }
-    lastReliabilityDiagnostic = FailureClassifier.recordChatCompletion(
-      executionId: runtimeId,
-      text: response,
-      engineOk: true,
+    _noteReliability(
+      FailureClassifier.recordChatCompletion(
+        executionId: runtimeId,
+        text: response,
+        engineOk: true,
+      ),
     );
     _emitResponseTrace(runtimeId, response, detail: package.id);
   }
@@ -1033,15 +1042,22 @@ class AssistantRuntimeService {
     }
   }
 
+  void _noteReliability(PersistableDiagnostic? diagnostic) {
+    lastReliabilityDiagnostic = diagnostic;
+    reliabilityLog.record(diagnostic);
+  }
+
   String _nonEmptyOrUnavailable(
     String runtimeId,
     String? text,
     String message,
   ) {
-    lastReliabilityDiagnostic = FailureClassifier.recordChatCompletion(
-      executionId: runtimeId,
-      text: text ?? '',
-      engineOk: text != null,
+    _noteReliability(
+      FailureClassifier.recordChatCompletion(
+        executionId: runtimeId,
+        text: text ?? '',
+        engineOk: text != null,
+      ),
     );
     if (text == null) {
       throw AssistantRuntimeUnavailableException(runtimeId, message);

--- a/packages/feature_mind/test/agent_chat/data/services/assistant_runtime_service_test.dart
+++ b/packages/feature_mind/test/agent_chat/data/services/assistant_runtime_service_test.dart
@@ -1204,6 +1204,15 @@ void main() {
         emptyService.lastReliabilityDiagnostic?.failureMode,
         FailureMode.pm06LogicCollapse,
       );
+      expect(emptyService.reliabilityLog.checkpoints, hasLength(1));
+      expect(
+        emptyService.reliabilityLog.lastFailure?.runtimeError,
+        RuntimeFailure.r06VerificationFailure,
+      );
+      expect(
+        emptyService.reliabilityLog.checkpoints.toString(),
+        isNot(contains('hello')),
+      );
     });
 
     test('cancels preparation before runtime work starts', () async {


### PR DESCRIPTION
## Summary
- ADR-0023 records the freeze: reliability checkpoints are in-process metadata only. No new `MindOpKind`, no `OperationLogPort` writes, no prompt/IR/completion bodies.
- Dart `ExecutionLog` (bounded ring) mirrors Rust. `AssistantRuntimeService` appends classifier hits; `lastReliabilityDiagnostic` is still the latest slot.
- llama.cpp `n_keep` stays out of this decision (`llama-cpp-2` 0.1.153 does not expose it). Prefix cache remains an adapter flag.

## Test plan
- [x] `cd packages/core_ai && flutter test test/reliability/reasoning_reliability_test.dart`
- [x] `cd packages/feature_mind && flutter test test/agent_chat/data/services/assistant_runtime_service_test.dart --name "trims cloud responses"`
- [ ] Host: empty Cloud/LiteRT reply still fails closed; the in-process log dump does not contain the user prompt


Made with [Cursor](https://cursor.com)