### PR TITLE
fix(mind): route diet through skill.execute, not a diet capability

### DIFF
--- a/docs/architecture/ADR-airo-mind-classified-intent.md
+++ b/docs/architecture/ADR-airo-mind-classified-intent.md
@@ -46,9 +46,11 @@ the gate, or invoke tools.
    and the registry — never the user string.
 3. **Three-way gate:** `classified` / `needs_clarification` / `rejected`.
    Underspecified action requests ask one focused question. Clear requests
-   (diet plan, explicit calendar create) proceed.
+   (explicit calendar create, a selected skill) proceed.
 4. **Capability registry is the source of truth.** Analyzers select from it.
-   They must not invent ids.
+   They must not invent ids. **Product plugins are not registry domains.**
+   Diet, coins, and similar journeys are skills: they route through
+   `skill.execute` and run in `feature_mind` / `AgentSkillOrchestrator`.
 5. **Classifier backends are replaceable.** Phase 1 hydrates the contract from
    the legacy kind adapter. Later analyzers (`GenerationEngine` structured
    output, then a local SLM) must emit the same schema. Do not add a
@@ -75,12 +77,15 @@ confirmation is not required. Otherwise ask.
 - Document ingestion, cost/latency routers, shadow-mode dual-run, FRB
   `classify()` — later phases against this same schema.
 - Treating LLM-emitted `0.93` as calibrated probability.
+- First-class product domains (`diet.*`, coins, games) in the intent
+  registry. Those are skills/plugins.
 
 ## Consequences
 
 - `airo_mind_reasoning::ClassifiedIntent` becomes the v1 contract (legacy
   `kind` / `complexity` remain compatibility fields).
-- Diet maps to `diet.plan`, not `planning`.
+- Application plugins (diet meal plans, etc.) map to `skill.execute`, never
+  a `diet.*` capability.
 - Analyzer coverage replaces the keyword parser; the parser is deleted only
   after evals say so.
 

--- a/packages/feature_mind/lib/src/reasoning/chat_reasoning_request.dart
+++ b/packages/feature_mind/lib/src/reasoning/chat_reasoning_request.dart
@@ -24,7 +24,8 @@ bool shouldUseOnDeviceReasoning({
 ///
 /// Dart must not grow new routing rules here. The registry in
 /// `airo_mind_intent` owns capabilities; this map may only emit kinds the
-/// Rust legacy adapter already understands. Diet is `diet`, not `planning`.
+/// Rust legacy adapter already understands. Product plugins (diet) are
+/// `skill`, not a framework domain.
 String reasoningIntentKind(IntentType type) {
   return switch (type) {
     IntentType.playMusic ||
@@ -45,7 +46,7 @@ String reasoningIntentKind(IntentType type) {
     IntentType.openMeetingScribe ||
     IntentType.modelManagement ||
     IntentType.mobileActions => 'navigation',
-    IntentType.createDietPlan => 'diet',
+    IntentType.createDietPlan => 'skill',
     IntentType.createRoutine => 'planning',
     IntentType.searchMeetings ||
     IntentType.getMeetingMom ||

--- a/packages/feature_mind/test/reasoning/chat_reasoning_request_test.dart
+++ b/packages/feature_mind/test/reasoning/chat_reasoning_request_test.dart
@@ -44,7 +44,7 @@ void main() {
       type: IntentType.createDietPlan,
       originalText: 'Write a plan for the week',
     );
-    expect(reasoningIntentKind(planning.type), 'diet');
+    expect(reasoningIntentKind(planning.type), 'skill');
     expect(reasoningIntentComplexity(planning), 0.85);
 
     const routine = Intent(

--- a/rust/airo_mind_intent/src/ambiguity.rs
+++ b/rust/airo_mind_intent/src/ambiguity.rs
@@ -42,11 +42,11 @@ pub fn apply_legacy_gate(intent: &mut ClassifiedIntent, user_query: &str) {
             candidates: vec![
                 "planning.create".into(),
                 "calendar.retrieve".into(),
-                "diet.plan".into(),
+                "skill.execute".into(),
             ],
             reason: Some("domain_ambiguity".into()),
             clarification: Some(
-                "Do you mean planning your day, scheduling something on your calendar, or preparing a diet/meal plan?".into(),
+                "Do you mean planning your day, scheduling something on your calendar, or running a skill such as a meal plan?".into(),
             ),
         };
         return;
@@ -84,7 +84,7 @@ mod tests {
             .clarification
             .as_deref()
             .unwrap()
-            .contains("diet/meal plan"));
+            .contains("skill"));
     }
 
     #[test]

--- a/rust/airo_mind_intent/src/capability.rs
+++ b/rust/airo_mind_intent/src/capability.rs
@@ -102,15 +102,15 @@ impl CapabilityRegistry {
                     false,
                 ),
                 cap(
-                    "diet.plan",
-                    "diet",
-                    "meal_plan",
-                    "create",
-                    "diet",
-                    "reasoning",
+                    "skill.execute",
+                    "skill",
+                    "invoke",
+                    "execute",
+                    "skill",
+                    "fast-structured",
                     false,
                     true,
-                    false,
+                    true,
                 ),
                 cap(
                     "document.summarize",
@@ -181,16 +181,17 @@ mod tests {
     use super::*;
 
     #[test]
-    fn registry_ids_are_unique_and_include_diet() {
+    fn registry_ids_are_unique_and_exclude_product_plugins() {
         let registry = CapabilityRegistry::builtin();
         let mut ids: Vec<_> = registry.ids().collect();
         let before = ids.len();
         ids.sort();
         ids.dedup();
         assert_eq!(ids.len(), before);
-        assert!(registry.contains("diet.plan"));
+        assert!(registry.contains("skill.execute"));
         assert!(registry.contains("planning.create"));
         assert!(registry.contains("research.deep"));
+        assert!(!registry.contains("diet.plan"));
         assert!(!registry.contains("document.magic_analysis"));
     }
 }

--- a/rust/airo_mind_intent/src/legacy.rs
+++ b/rust/airo_mind_intent/src/legacy.rs
@@ -51,8 +51,14 @@ const LEGACY: &[LegacyMap] = &[
         complexity: 0.85,
     },
     LegacyMap {
+        kind: "skill",
+        capability: "skill.execute",
+        complexity: 0.85,
+    },
+    // Temporary kind alias from ADR-0003 Phase 1. Not a framework capability.
+    LegacyMap {
         kind: "diet",
-        capability: "diet.plan",
+        capability: "skill.execute",
         complexity: 0.85,
     },
     LegacyMap {
@@ -107,7 +113,9 @@ pub fn from_legacy(kind: &str, complexity: f32, user_query: &str) -> ClassifiedI
         action_readiness: ActionReadiness::execute(),
         ambiguity: Ambiguity::default(),
         model_profile: cap.model_profile.into(),
-        kind: if mapped.is_some() {
+        kind: if kind == "diet" {
+            "skill".into()
+        } else if mapped.is_some() {
             kind.into()
         } else {
             "conversation".into()
@@ -116,6 +124,11 @@ pub fn from_legacy(kind: &str, complexity: f32, user_query: &str) -> ClassifiedI
         source: IntentSource::LegacyFallback,
     };
     crate::ambiguity::apply_legacy_gate(&mut intent, user_query);
+    if kind == "diet" {
+        intent
+            .entities
+            .insert("skill_id".into(), "diet_plan".into());
+    }
     intent
 }
 
@@ -133,11 +146,24 @@ mod tests {
     }
 
     #[test]
-    fn diet_is_not_planning() {
-        let intent = from_legacy("diet", 0.85, "Create a 7-day vegetarian meal plan.");
-        assert_eq!(intent.capability, "diet.plan");
-        assert_eq!(intent.domain, "diet");
+    fn product_plugin_uses_generic_skill_not_a_diet_capability() {
+        let intent = from_legacy("skill", 0.85, "Create a 7-day vegetarian meal plan.");
+        assert_eq!(intent.capability, "skill.execute");
+        assert_eq!(intent.domain, "skill");
+        assert_eq!(intent.kind, "skill");
         assert_eq!(intent.status, IntentStatus::Classified);
         assert!(intent.action_readiness.ready);
+        assert!(!CapabilityRegistry::builtin().contains("diet.plan"));
+    }
+
+    #[test]
+    fn leftover_diet_kind_aliases_to_skill_execute() {
+        let intent = from_legacy("diet", 0.85, "veg plan");
+        assert_eq!(intent.capability, "skill.execute");
+        assert_eq!(intent.kind, "skill");
+        assert_eq!(
+            intent.entities.get("skill_id").map(String::as_str),
+            Some("diet_plan")
+        );
     }
 }

--- a/rust/airo_mind_intent/src/readiness.rs
+++ b/rust/airo_mind_intent/src/readiness.rs
@@ -52,8 +52,8 @@ mod tests {
     use crate::legacy::from_legacy;
 
     #[test]
-    fn clear_diet_plan_is_ready() {
-        let mut intent = from_legacy("diet", 0.85, "Create a 7-day vegetarian meal plan.");
+    fn clear_skill_plugin_is_ready() {
+        let mut intent = from_legacy("skill", 0.85, "Create a 7-day vegetarian meal plan.");
         apply_readiness(&mut intent);
         assert_eq!(intent.status, IntentStatus::Classified);
         assert!(intent.action_readiness.ready);

--- a/rust/airo_mind_intent/src/validator.rs
+++ b/rust/airo_mind_intent/src/validator.rs
@@ -52,6 +52,19 @@ mod tests {
     }
 
     #[test]
+    fn diet_plan_is_not_a_framework_capability() {
+        let mut intent = from_legacy("skill", 0.85, "veg plan");
+        intent.capability = "diet.plan".into();
+        intent.domain = "diet".into();
+        intent.intent = "meal_plan".into();
+        intent.action = "create".into();
+        assert_eq!(
+            validate_intent(&intent),
+            Err(ValidationError::UnknownCapability)
+        );
+    }
+
+    #[test]
     fn legacy_cannot_emit_research_deep() {
         let mut intent = from_legacy("conversation", 0.2, "hi");
         intent.capability = "research.deep".into();

--- a/rust/airo_mind_intent/tests/pipeline.rs
+++ b/rust/airo_mind_intent/tests/pipeline.rs
@@ -6,19 +6,20 @@ use airo_mind_intent::{
 };
 
 #[test]
-fn diet_plan_routes_to_diet_not_planning() {
+fn skill_plugin_routes_to_skill_execute_not_a_diet_domain() {
     let decision = classify(ClassifyRequest {
         user_query: "Create a 7-day vegetarian meal plan.".into(),
-        legacy_kind: Some("diet".into()),
+        legacy_kind: Some("skill".into()),
         legacy_complexity: Some(0.85),
         proposal: None,
     });
     assert_eq!(decision.status, IntentStatus::Classified);
-    let route = decision.route.expect("ready diet plan");
-    assert_eq!(route.capability, "diet.plan");
-    assert_eq!(route.orchestrator, "diet");
+    let route = decision.route.expect("ready skill");
+    assert_eq!(route.capability, "skill.execute");
+    assert_eq!(route.orchestrator, "skill");
     assert_eq!(decision.intent.schema_version, SCHEMA_VERSION);
     assert_eq!(decision.intent.source, IntentSource::LegacyFallback);
+    assert!(!CapabilityRegistry::builtin().contains("diet.plan"));
 }
 
 #[test]
@@ -35,7 +36,7 @@ fn prepare_for_tomorrow_asks_instead_of_acting() {
         .intent
         .ambiguity
         .candidates
-        .contains(&"diet.plan".to_string()));
+        .contains(&"skill.execute".to_string()));
     assert!(decision
         .intent
         .ambiguity
@@ -107,7 +108,8 @@ fn sky_blue_is_chat_and_ready() {
 }
 
 #[test]
-fn validate_accepts_legacy_diet() {
-    let intent = from_legacy("diet", 0.85, "veg plan");
+fn validate_accepts_legacy_skill() {
+    let intent = from_legacy("skill", 0.85, "veg plan");
     assert!(validate_intent(&intent).is_ok());
+    assert_eq!(intent.capability, "skill.execute");
 }


### PR DESCRIPTION
## Summary
- Diet, coins, and similar product journeys are plugins/skills, not framework domains. The intent registry now exposes generic `skill.execute` instead of `diet.plan`.
- Legacy `diet` kind aliases to `skill.execute` with `entities.skill_id = diet_plan`. Dart `IntentType.createDietPlan` hydrates as `'skill'`.
- Ambiguity copy talks about "a skill such as a meal plan". `AiroPromptRegistry.dietPlan` stays as the plugin prompt artifact.

Closes nothing on its own — continues [#1827](https://github.com/DevelopersCoffee/airo/issues/1827). Amends ADR-0003 Phase 1.

## Test plan
- [x] `cargo test -p airo_mind_intent --manifest-path rust/Cargo.toml --offline`
- [x] `cargo test -p airo_mind_reasoning --manifest-path rust/Cargo.toml --offline`
- [x] `cargo clippy -p airo_mind_intent -p airo_mind_reasoning --manifest-path rust/Cargo.toml --offline --no-deps -- -D warnings`
- [x] `cd packages/feature_mind && flutter test test/reasoning/chat_reasoning_request_test.dart`


Made with [Cursor](https://cursor.com)