### PR TITLE
feat(mind): complete on-device NER types and pipeline

### DIFF
--- a/packages/feature_mind/lib/src/provenance/domain/models/extracted_entity.dart
+++ b/packages/feature_mind/lib/src/provenance/domain/models/extracted_entity.dart
@@ -14,6 +14,9 @@ enum EntityType {
   money,
   identifier,
   document,
+  product,
+  event,
+  title,
 }
 
 /// One entity pulled out of an op's title and detail text.

--- a/packages/feature_mind/lib/src/provenance/domain/services/entity_extractor.dart
+++ b/packages/feature_mind/lib/src/provenance/domain/services/entity_extractor.dart
@@ -53,6 +53,33 @@ class RuleBasedEntityExtractor implements EntityExtractor {
     r'\b[A-Z]{2,}[-/][A-Z0-9]{2,}(?:[-/][A-Z0-9]+)*\b',
   );
 
+  static final RegExp _phone = RegExp(
+    r'(?:\+?\d{1,3}[\s.-])?(?:\(\d{3}\)|\d{3})[\s.-]\d{3}[\s.-]\d{4}\b',
+  );
+
+  static final RegExp _relativeDate = RegExp(
+    r'\b(?:today|yesterday|tomorrow)\b',
+    caseSensitive: false,
+  );
+
+  static final RegExp _productNamed = RegExp(
+    r'\b(?:iPhone|iPad|iMac|MacBook|iPod|AirPods|Pixel|Galaxy|Kindle)'
+    r'[A-Za-z0-9]*\b',
+  );
+
+  static final RegExp _productSuffixed = RegExp(
+    r'\b[A-Z][A-Za-z0-9]+ (?:Cloud|Watch|Phone)\b',
+  );
+
+  static final RegExp _eventNamed = RegExp(
+    r'\b(?:Olympic Games|FIFA World Cup|World War (?:[IVX]+|\d+))\b',
+  );
+
+  static final RegExp _eventSuffixed = RegExp(
+    r'\b[A-Z][A-Za-z]+(?:\s+[A-Z][A-Za-z]+)? '
+    r'(?:Games|Conference|Festival|Cup|Summit)\b',
+  );
+
   static final RegExp _money = RegExp(
     r'(?:\$|\b(?:USD|INR|EUR|GBP|Rs\.?)\b)\s*\d[\d,]*(?:\.\d+)?'
     r'(?:\s*(?:million|billion|thousand|hundred))?\b',
@@ -147,6 +174,44 @@ class RuleBasedEntityExtractor implements EntityExtractor {
     'Judge',
   };
 
+  static const Set<String> _notFamilyNames = {
+    'Brace',
+    'Plan',
+    'Note',
+    'Dose',
+    'Round',
+    'Street',
+    'Drive',
+    'Avenue',
+    'City',
+    'Games',
+    'War',
+    'Cup',
+    'Cloud',
+    'Phone',
+    'Watch',
+    'Conference',
+    'Festival',
+  };
+
+  static const Set<String> _notGivenNames = {
+    'New',
+    'North',
+    'South',
+    'East',
+    'West',
+    'United',
+    'National',
+    'International',
+    'Lake',
+    'Mount',
+    'San',
+    'Los',
+    'Las',
+    'Saint',
+    'Knee',
+  };
+
   static const Set<String> _monthWords = {
     'Jan',
     'January',
@@ -205,15 +270,21 @@ class RuleBasedEntityExtractor implements EntityExtractor {
     // Most specific patterns claim first so the capitalised-phrase pass
     // never fragments "Dr. Rao", "$5 million", or "Optimist Corp.".
     take(_email.allMatches(text), EntityType.identifier);
+    take(_phone.allMatches(text), EntityType.identifier);
     take(_identifier.allMatches(text), EntityType.identifier);
     take(_money.allMatches(text), EntityType.money);
     take(_percent.allMatches(text), EntityType.money);
     take(_isoDate.allMatches(text), EntityType.date);
     take(_dayMonthDate.allMatches(text), EntityType.date);
     take(_monthDayDate.allMatches(text), EntityType.date);
+    take(_relativeDate.allMatches(text), EntityType.date);
     take(_honorific.allMatches(text), EntityType.person);
     take(_titledPerson.allMatches(text), EntityType.person, group: 1);
     take(_organization.allMatches(text), EntityType.organization);
+    take(_productNamed.allMatches(text), EntityType.product);
+    take(_productSuffixed.allMatches(text), EntityType.product);
+    take(_eventNamed.allMatches(text), EntityType.event);
+    take(_eventSuffixed.allMatches(text), EntityType.event);
     _takeLocations(text, claimed, positioned);
     _takeCapitalisedPhrases(text, claimed, positioned);
 
@@ -304,10 +375,16 @@ class RuleBasedEntityExtractor implements EntityExtractor {
       }
 
       final phrase = text.substring(token.start, end);
-      if (_roleTitles.contains(phrase) || _monthWords.contains(phrase)) {
+      if (_monthWords.contains(phrase)) {
         i = j;
         continue;
       }
+
+      final type = _roleTitles.contains(phrase)
+          ? EntityType.title
+          : _isUntitledPerson(phrase)
+          ? EntityType.person
+          : EntityType.term;
 
       final phraseSpan = _Span(token.start, end);
       claimed.add(phraseSpan);
@@ -315,8 +392,8 @@ class RuleBasedEntityExtractor implements EntityExtractor {
         _Positioned(
           token.start,
           ExtractedEntity(
-            text: text.substring(token.start, end),
-            type: EntityType.term,
+            text: phrase,
+            type: type,
             start: token.start,
             end: end,
           ),
@@ -324,6 +401,23 @@ class RuleBasedEntityExtractor implements EntityExtractor {
       );
       i = j;
     }
+  }
+
+  static final RegExp _nameWord = RegExp(r'^[A-Z][a-z]{2,}$');
+
+  static bool _isUntitledPerson(String phrase) {
+    final parts = phrase.split(RegExp(r'\s+'));
+    if (parts.length != 2) return false;
+    if (!_nameWord.hasMatch(parts[0]) || !_nameWord.hasMatch(parts[1])) {
+      return false;
+    }
+    if (_notGivenNames.contains(parts[0])) return false;
+    if (_notFamilyNames.contains(parts[1])) return false;
+    if (_leadingStopwords.contains(parts[0])) return false;
+    if (_monthWords.contains(parts[0]) || _monthWords.contains(parts[1])) {
+      return false;
+    }
+    return true;
   }
 }
 

--- a/packages/feature_mind/lib/src/provenance/domain/services/entity_relation_extractor.dart
+++ b/packages/feature_mind/lib/src/provenance/domain/services/entity_relation_extractor.dart
@@ -109,3 +109,19 @@ class EntityRelationExtractor {
     return gap <= nearWindow;
   }
 }
+
+/// One on-device pass: identify, classify, then relate.
+///
+/// This is the public workflow from text to a structured graph. Callers
+/// that only need mentions can still use [EntityExtractor] directly.
+class EntityExtractionPipeline {
+  const EntityExtractionPipeline({
+    this.extractor = const RuleBasedEntityExtractor(),
+  });
+
+  final EntityExtractor extractor;
+
+  EntityRelationGraph run(String text) {
+    return EntityRelationExtractor(entities: extractor).extract(text);
+  }
+}

--- a/packages/feature_mind/test/agent_chat/domain/services/chat_entity_linker_test.dart
+++ b/packages/feature_mind/test/agent_chat/domain/services/chat_entity_linker_test.dart
@@ -71,7 +71,7 @@ void main() {
       contains(
         const ChatGraphEdge(
           fromId: 'identifier:9001001',
-          toId: 'term:city-hospital',
+          toId: 'organization:city-hospital',
           predicate: ChatEntityRelation.relatedTo,
         ),
       ),

--- a/packages/feature_mind/test/provenance/domain/services/entity_extractor_test.dart
+++ b/packages/feature_mind/test/provenance/domain/services/entity_extractor_test.dart
@@ -63,6 +63,7 @@ void main() {
           type: EntityType.organization,
         ),
         const ExtractedEntity(text: 'Chicago', type: EntityType.location),
+        const ExtractedEntity(text: 'CEO', type: EntityType.title),
         const ExtractedEntity(text: 'Brad Doe', type: EntityType.person),
         const ExtractedEntity(text: '\$5 million', type: EntityType.money),
       ]);
@@ -70,6 +71,7 @@ void main() {
         'date': ['Aug 29th, 2024'],
         'organization': ['Optimist Corp.'],
         'location': ['Chicago'],
+        'title': ['CEO'],
         'person': ['Brad Doe'],
         'money': ['\$5 million'],
       });
@@ -141,6 +143,35 @@ void main() {
       ]);
     });
 
+    test('untitled people, products, events, phones, and relative dates', () {
+      final entities = extractor.extract(
+        'Sundar Pichai said Google Cloud ships before the Olympic Games. '
+        'Call +1 415-555-0100 tomorrow.',
+      );
+
+      expect(
+        entities,
+        containsAll([
+          const ExtractedEntity(text: 'Sundar Pichai', type: EntityType.person),
+          const ExtractedEntity(text: 'Google Cloud', type: EntityType.product),
+          const ExtractedEntity(text: 'Olympic Games', type: EntityType.event),
+          const ExtractedEntity(
+            text: '+1 415-555-0100',
+            type: EntityType.identifier,
+          ),
+          const ExtractedEntity(text: 'tomorrow', type: EntityType.date),
+        ]),
+      );
+      expect(
+        entities,
+        isNot(
+          contains(
+            const ExtractedEntity(text: 'Knee Brace', type: EntityType.person),
+          ),
+        ),
+      );
+    });
+
     test('serializes extracted entities to JSON with spans', () {
       final json = extractor.extract('Dr. Rao on 14 Aug.').toJson();
 
@@ -152,7 +183,7 @@ void main() {
 
     // Non-happy: no entities found.
     test('plain lower-case text with no dates yields no entities', () {
-      expect(extractor.extract('the appointment went fine today'), isEmpty);
+      expect(extractor.extract('the appointment went fine'), isEmpty);
     });
 
     // Non-happy: no entities found.

--- a/packages/feature_mind/test/provenance/domain/services/entity_relation_extractor_test.dart
+++ b/packages/feature_mind/test/provenance/domain/services/entity_relation_extractor_test.dart
@@ -88,4 +88,27 @@ void main() {
       expect(extractor.extract('   ').entities, isEmpty);
     });
   });
+
+  group('EntityExtractionPipeline', () {
+    test('runs identify, classify, and relate in one pass', () {
+      const pipeline = EntityExtractionPipeline();
+      final graph = pipeline.run(
+        'On Aug 29th, 2024, Optimist Corp. announced in Chicago that '
+        'its CEO, Brad Doe, would be stepping down after a successful '
+        '\$5 million funding round.',
+      );
+
+      expect(graph.entities.toStructuredMap()['person'], ['Brad Doe']);
+      expect(graph.relations, isNotEmpty);
+      expect(
+        graph.relations.map((r) => r.kind),
+        containsAll([
+          EntityRelationKind.worksAt,
+          EntityRelationKind.locatedIn,
+          EntityRelationKind.announcedOn,
+          EntityRelationKind.valuedAt,
+        ]),
+      );
+    });
+  });
 }


### PR DESCRIPTION
## Summary
- Finishes the on-device entity-extraction goal after #1840 and #1843.
- Adds untitled people, products, events, phones, relative dates, and job titles.
- `EntityExtractionPipeline` is the one call from text to a typed relation graph.
- City Hospital is now an organization, matching the NER type set.

## Test plan
- [x] `cd packages/feature_mind && flutter test test/provenance test/agent_chat/domain/services/chat_entity_linker_test.dart` (39 passed)
- [ ] Provenance inspector still chips a discharge note
- [ ] A sentence with Sundar Pichai / Google Cloud / Olympic Games / a phone / tomorrow classifies those types


Made with [Cursor](https://cursor.com)