### PR TITLE
feat(mind): shadow-compare IntentParser leftovers against ClassifiedIntent

### DIFF
--- a/docs/architecture/ADR-airo-mind-classified-intent.md
+++ b/docs/architecture/ADR-airo-mind-classified-intent.md
@@ -75,9 +75,11 @@ confirmation is not required. Otherwise ask.
 - DeBERTa, finance/health/legal verticals, keyword routing as the primary
   classifier.
 - LLM-direct tool execution, raw CoT as a contract, provider lock-in.
-- Document ingestion, cost/latency routers, shadow-mode dual-run, deleting
-  `IntentParser` — later phases against this same schema. FRB `classify()` as
-  its own method is optional; `reason()` already classifies.
+- Document ingestion, cost/latency routers, deleting `IntentParser` —
+  later phases against this same schema. Shadow-mode dual-run logs the
+  leftover parser kind against `classify()` without changing the route;
+  the parser is not deleted until evals say so. FRB `classify()` as its
+  own method is optional; `reason()` already classifies.
 - Treating LLM-emitted `0.93` as calibrated probability.
 - First-class product domains (`diet.*`, coins, games) in the intent
   registry. Those are skills/plugins.
@@ -89,7 +91,10 @@ confirmation is not required. Otherwise ask.
 - Application plugins (diet meal plans, etc.) map to `skill.execute`, never
   a `diet.*` capability.
 - Analyzer coverage replaces the keyword parser; the parser is deleted only
-  after evals say so.
+  after evals say so. Until then, `reason()` emits a `shadow:` compare of
+  the leftover parser kind against ClassifiedIntent. Routing still follows
+  `classify()`. Product intercepts (diet plugin, skills) still use
+  `IntentParser`.
 
 ## Related
 

--- a/packages/feature_mind/lib/src/reasoning/reasoning_models.dart
+++ b/packages/feature_mind/lib/src/reasoning/reasoning_models.dart
@@ -210,6 +210,7 @@ class ReasoningStreamFold {
   final List<String> clarificationCandidates = [];
   final List<ReasoningProgressStep> steps = [];
   final List<MindReasoningToolCall> toolCalls = [];
+  IntentParserShadowCompare? shadowCompare;
 
   void add(MindReasoningEvent event) {
     switch (event) {
@@ -220,6 +221,13 @@ class ReasoningStreamFold {
         steps.add(ReasoningProgressStep(label: labelForReasoningStage(stage)));
       case MindReasoningProgress(:final message):
         if (message.startsWith('level=')) return;
+        if (message.startsWith(shadowProgressPrefix)) {
+          shadowCompare = parseShadowProgress(message);
+          if (kDebugMode) {
+            debugPrint('IntentParser shadow: $message');
+          }
+          return;
+        }
         if (message.startsWith(clarifyProgressPrefix)) {
           clarificationCandidates
             ..clear()
@@ -279,6 +287,46 @@ String labelForReasoningStage(MindReasoningStage stage) {
 
 /// Progress payload from Rust when classify() asks instead of generating.
 const clarifyProgressPrefix = 'clarify:';
+
+/// Log-only leftover IntentParser kind vs ClassifiedIntent. Never a step.
+const shadowProgressPrefix = 'shadow:';
+
+/// Dual-run compare of the Dart leftover kind against the gated contract.
+///
+/// Does not route. Product intercepts keep using IntentParser; `reason()`
+/// still follows `classify()`.
+@immutable
+class IntentParserShadowCompare {
+  const IntentParserShadowCompare({
+    required this.parserKind,
+    required this.parserCapability,
+    required this.classifiedKind,
+    required this.classifiedCapability,
+    required this.status,
+    required this.capabilitiesMatch,
+  });
+
+  final String parserKind;
+  final String parserCapability;
+  final String classifiedKind;
+  final String classifiedCapability;
+  final String status;
+  final bool capabilitiesMatch;
+}
+
+IntentParserShadowCompare? parseShadowProgress(String message) {
+  if (!message.startsWith(shadowProgressPrefix)) return null;
+  final parts = message.substring(shadowProgressPrefix.length).split('|');
+  if (parts.length != 6) return null;
+  return IntentParserShadowCompare(
+    parserKind: parts[0],
+    parserCapability: parts[1],
+    classifiedKind: parts[2],
+    classifiedCapability: parts[3],
+    status: parts[4],
+    capabilitiesMatch: parts[5] == '1',
+  );
+}
 
 String labelForClarificationCapability(String id) {
   return switch (id) {

--- a/packages/feature_mind/test/reasoning/intent_parser_shadow_eval_test.dart
+++ b/packages/feature_mind/test/reasoning/intent_parser_shadow_eval_test.dart
@@ -1,0 +1,119 @@
+import 'package:feature_mind/src/agent_chat/domain/services/intent_parser.dart';
+import 'package:feature_mind/src/reasoning/chat_reasoning_request.dart';
+import 'package:feature_mind/src/reasoning/reasoning_models.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test(
+    'IntentParser leftovers hydrate only kinds Rust already understands',
+    () {
+      const leftovers = <String, String>{
+        'I need to prepare for tomorrow.': 'conversation',
+        'Why is the sky blue?': 'conversation',
+        'Make me a 7 day vegetarian diet plan': 'skill',
+        'Create a meal plan': 'skill',
+        'plan my budget': 'navigation',
+      };
+      const allowed = {
+        'calendar_retrieval',
+        'time_query',
+        'date_query',
+        'play_media',
+        'toggle_setting',
+        'navigation',
+        'planning',
+        'skill',
+        'diet',
+        'summarization',
+        'conversation',
+      };
+      leftovers.forEach((prompt, kind) {
+        final parsed = IntentParser.parse(prompt);
+        expect(reasoningIntentKind(parsed.type), kind, reason: prompt);
+        expect(allowed, contains(kind), reason: prompt);
+        expect(kind, isNot('diet.plan'));
+      });
+    },
+  );
+
+  test('diet leftover is skill.execute, not a diet domain', () {
+    final parsed = IntentParser.parse('Make me a 7 day vegetarian diet plan');
+    expect(parsed.type, IntentType.createDietPlan);
+    expect(reasoningIntentKind(parsed.type), 'skill');
+    expect(reasoningIntentKind(parsed.type), isNot('diet'));
+  });
+
+  test('plan my budget leftover stays navigation until classify wins', () {
+    final parsed = IntentParser.parse('plan my budget');
+    expect(parsed.type, IntentType.openBudget);
+    expect(reasoningIntentKind(parsed.type), 'navigation');
+  });
+
+  test('shadow progress records a leftover mismatch without becoming a step', () {
+    final fold = ReasoningStreamFold();
+    fold.add(const MindReasoningStageChanged(MindReasoningStage.understanding));
+    fold.add(
+      const MindReasoningProgress(
+        'shadow:navigation|general.navigate|planning|planning.create|classified|0',
+      ),
+    );
+    fold.add(const MindReasoningProgress('level=Standard'));
+    fold.add(
+      const MindReasoningCompleted(
+        answer: 'Split income and bills.',
+        reasoningSummary: 'A budget plan.',
+        level: MindReasoningLevel.standard,
+      ),
+    );
+
+    expect(fold.shadowCompare, isNotNull);
+    expect(fold.shadowCompare!.parserKind, 'navigation');
+    expect(fold.shadowCompare!.parserCapability, 'general.navigate');
+    expect(fold.shadowCompare!.classifiedKind, 'planning');
+    expect(fold.shadowCompare!.classifiedCapability, 'planning.create');
+    expect(fold.shadowCompare!.status, 'classified');
+    expect(fold.shadowCompare!.capabilitiesMatch, isFalse);
+    expect(fold.answer, 'Split income and bills.');
+    expect(fold.steps, [
+      const ReasoningProgressStep(label: 'Reading your request'),
+    ]);
+    expect(fold.steps.any((s) => s.label.startsWith('shadow:')), isFalse);
+    expect(fold.steps.any((s) => s.label.contains('navigation')), isFalse);
+  });
+
+  test('underspecified prepare-for-tomorrow shadow still asks, not execute', () {
+    final fold = ReasoningStreamFold();
+    fold.add(
+      const MindReasoningProgress(
+        'shadow:conversation|general.chat|conversation|general.chat|needs_clarification|1',
+      ),
+    );
+    fold.add(
+      const MindReasoningProgress(
+        'clarify:planning.create|calendar.retrieve|skill.execute',
+      ),
+    );
+    fold.add(
+      const MindReasoningError(
+        'Do you mean planning your day, scheduling something on your calendar, or running a skill such as a meal plan?',
+      ),
+    );
+    expect(fold.shadowCompare!.capabilitiesMatch, isTrue);
+    expect(fold.shadowCompare!.status, 'needs_clarification');
+    expect(fold.shadowCompare!.classifiedCapability, isNot('diet.plan'));
+    expect(fold.clarificationCandidates, isNotEmpty);
+    expect(fold.steps, isEmpty);
+  });
+
+  test('sky blue leftover compares as general.chat', () {
+    final parsed = IntentParser.parse('Why is the sky blue?');
+    expect(parsed.type, IntentType.unknown);
+    expect(reasoningIntentKind(parsed.type), 'conversation');
+    final compare = parseShadowProgress(
+      'shadow:conversation|general.chat|conversation|general.chat|classified|1',
+    )!;
+    expect(compare.parserKind, reasoningIntentKind(parsed.type));
+    expect(compare.classifiedCapability, 'general.chat');
+    expect(compare.capabilitiesMatch, isTrue);
+  });
+}

--- a/rust/airo_mind_intent/module.yaml
+++ b/rust/airo_mind_intent/module.yaml
@@ -6,3 +6,5 @@ description: >
   Airo Mind ClassifiedIntent contract — versioned schema, capability
   registry, validation, action-readiness, and intent routing. Keyword
   IntentParser is a legacy adapter that may only emit this contract.
+  Shadow mode compares leftover parser kinds against classify() and
+  does not route.

--- a/rust/airo_mind_intent/src/legacy.rs
+++ b/rust/airo_mind_intent/src/legacy.rs
@@ -73,13 +73,20 @@ const LEGACY: &[LegacyMap] = &[
     },
 ];
 
+/// Registry id the leftover parser kind would hydrate. Unknown kinds chat.
+pub fn capability_for_legacy_kind(kind: &str) -> &'static str {
+    LEGACY
+        .iter()
+        .find(|row| row.kind == kind)
+        .map(|row| row.capability)
+        .unwrap_or("general.chat")
+}
+
 pub fn from_legacy(kind: &str, complexity: f32, user_query: &str) -> ClassifiedIntent {
     let registry = CapabilityRegistry::builtin();
     let mapped = LEGACY.iter().find(|row| row.kind == kind);
-    let (capability_id, default_complexity) = match mapped {
-        Some(row) => (row.capability, row.complexity),
-        None => ("general.chat", 0.25),
-    };
+    let capability_id = capability_for_legacy_kind(kind);
+    let default_complexity = mapped.map(|row| row.complexity).unwrap_or(0.25);
     let cap = registry
         .get(capability_id)
         .expect("legacy map only names registered capabilities");

--- a/rust/airo_mind_intent/src/lib.rs
+++ b/rust/airo_mind_intent/src/lib.rs
@@ -11,6 +11,7 @@ pub mod engine;
 pub mod legacy;
 pub mod readiness;
 pub mod router;
+pub mod shadow;
 pub mod validator;
 
 pub use capability::{Capability, CapabilityRegistry};
@@ -19,6 +20,7 @@ pub use classified::{
     IntentStatus, Requirements, SCHEMA_VERSION,
 };
 pub use engine::{classify, ClassifyRequest, RouteDecision};
-pub use legacy::{from_capability, from_legacy};
+pub use legacy::{capability_for_legacy_kind, from_capability, from_legacy};
 pub use router::route;
+pub use shadow::{compare_shadow, ShadowCompare, SHADOW_PROGRESS_PREFIX};
 pub use validator::validate_intent;

--- a/rust/airo_mind_intent/src/shadow.rs
+++ b/rust/airo_mind_intent/src/shadow.rs
@@ -1,0 +1,74 @@
+//! Shadow-mode dual-run: leftover IntentParser kind vs ClassifiedIntent.
+//!
+//! Compare never routes. The parser stays until evals say otherwise.
+
+use crate::classified::{ClassifiedIntent, IntentStatus};
+use crate::legacy::capability_for_legacy_kind;
+
+/// Folded by Flutter into telemetry, never a thinking step.
+pub const SHADOW_PROGRESS_PREFIX: &str = "shadow:";
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ShadowCompare {
+    pub parser_kind: String,
+    pub parser_capability: String,
+    pub classified_kind: String,
+    pub classified_capability: String,
+    pub classified_status: IntentStatus,
+    pub kinds_match: bool,
+    pub capabilities_match: bool,
+}
+
+/// Log-only. Inspects the leftover kind and the gated contract — never the
+/// user string, and never changes [`crate::classify`].
+pub fn compare_shadow(parser_kind: &str, classified: &ClassifiedIntent) -> ShadowCompare {
+    let parser_capability = capability_for_legacy_kind(parser_kind);
+    ShadowCompare {
+        parser_kind: parser_kind.to_string(),
+        parser_capability: parser_capability.to_string(),
+        classified_kind: classified.kind.clone(),
+        classified_capability: classified.capability.clone(),
+        classified_status: classified.status,
+        kinds_match: parser_kind == classified.kind,
+        capabilities_match: parser_capability == classified.capability,
+    }
+}
+
+impl ShadowCompare {
+    pub fn encode_progress(&self) -> String {
+        let match_bit = if self.capabilities_match { "1" } else { "0" };
+        format!(
+            "{SHADOW_PROGRESS_PREFIX}{}|{}|{}|{}|{}|{match_bit}",
+            self.parser_kind,
+            self.parser_capability,
+            self.classified_kind,
+            self.classified_capability,
+            status_token(self.classified_status),
+        )
+    }
+}
+
+fn status_token(status: IntentStatus) -> &'static str {
+    match status {
+        IntentStatus::Classified => "classified",
+        IntentStatus::NeedsClarification => "needs_clarification",
+        IntentStatus::Rejected => "rejected",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::legacy::from_legacy;
+
+    #[test]
+    fn encode_round_trips_the_leftover_without_a_user_string() {
+        let classified = from_legacy("conversation", 0.3, "Why is the sky blue?");
+        let shadow = compare_shadow("conversation", &classified);
+        assert!(shadow.capabilities_match);
+        assert_eq!(
+            shadow.encode_progress(),
+            "shadow:conversation|general.chat|conversation|general.chat|classified|1"
+        );
+    }
+}

--- a/rust/airo_mind_intent/tests/shadow.rs
+++ b/rust/airo_mind_intent/tests/shadow.rs
@@ -1,0 +1,169 @@
+//! Shadow-mode eval: leftover IntentParser kinds vs ClassifiedIntent.
+//!
+//! Dual-run only. Compare never routes, never invents capabilities, and never
+//! deletes the parser. Product plugins stay `skill.execute`.
+
+use airo_mind_intent::{
+    classify, compare_shadow, from_capability, CapabilityRegistry, ClassifyRequest, IntentStatus,
+    SHADOW_PROGRESS_PREFIX,
+};
+
+struct Case {
+    prompt: &'static str,
+    parser_kind: &'static str,
+    parser_complexity: f32,
+    analyzer_capability: Option<&'static str>,
+    expect_status: IntentStatus,
+    expect_capability: &'static str,
+    expect_parser_capability: &'static str,
+    expect_capabilities_match: bool,
+}
+
+fn cases() -> Vec<Case> {
+    vec![
+        Case {
+            prompt: "I need to prepare for tomorrow.",
+            parser_kind: "conversation",
+            parser_complexity: 0.25,
+            analyzer_capability: None,
+            expect_status: IntentStatus::NeedsClarification,
+            expect_capability: "general.chat",
+            expect_parser_capability: "general.chat",
+            expect_capabilities_match: true,
+        },
+        Case {
+            prompt: "Why is the sky blue?",
+            parser_kind: "conversation",
+            parser_complexity: 0.3,
+            analyzer_capability: None,
+            expect_status: IntentStatus::Classified,
+            expect_capability: "general.chat",
+            expect_parser_capability: "general.chat",
+            expect_capabilities_match: true,
+        },
+        Case {
+            prompt: "Make me a 7 day vegetarian diet plan",
+            parser_kind: "skill",
+            parser_complexity: 0.85,
+            analyzer_capability: None,
+            expect_status: IntentStatus::Classified,
+            expect_capability: "skill.execute",
+            expect_parser_capability: "skill.execute",
+            expect_capabilities_match: true,
+        },
+        Case {
+            prompt: "Create a meal plan",
+            parser_kind: "skill",
+            parser_complexity: 0.85,
+            analyzer_capability: None,
+            expect_status: IntentStatus::Classified,
+            expect_capability: "skill.execute",
+            expect_parser_capability: "skill.execute",
+            expect_capabilities_match: true,
+        },
+        Case {
+            prompt: "plan my budget",
+            parser_kind: "navigation",
+            parser_complexity: 0.2,
+            analyzer_capability: None,
+            expect_status: IntentStatus::Classified,
+            expect_capability: "general.navigate",
+            expect_parser_capability: "general.navigate",
+            expect_capabilities_match: true,
+        },
+        Case {
+            prompt: "plan my budget",
+            parser_kind: "navigation",
+            parser_complexity: 0.2,
+            analyzer_capability: Some("planning.create"),
+            expect_status: IntentStatus::Classified,
+            expect_capability: "planning.create",
+            expect_parser_capability: "general.navigate",
+            expect_capabilities_match: false,
+        },
+    ]
+}
+
+#[test]
+fn leftover_parser_kinds_are_compared_not_rerouted() {
+    for case in cases() {
+        let proposal = case
+            .analyzer_capability
+            .and_then(|id| from_capability(id, case.prompt, 0.88));
+        let decision = classify(ClassifyRequest {
+            user_query: case.prompt.into(),
+            legacy_kind: Some(case.parser_kind.into()),
+            legacy_complexity: Some(case.parser_complexity),
+            proposal,
+        });
+        assert_eq!(
+            decision.status, case.expect_status,
+            "status for {:?}",
+            case.prompt
+        );
+        assert_eq!(
+            decision.intent.capability, case.expect_capability,
+            "classified capability for {:?}",
+            case.prompt
+        );
+        assert_ne!(
+            decision.intent.capability, "diet.plan",
+            "product plugins are not registry domains: {:?}",
+            case.prompt
+        );
+        assert!(!CapabilityRegistry::builtin().contains("diet.plan"));
+
+        let shadow = compare_shadow(case.parser_kind, &decision.intent);
+        assert_eq!(shadow.parser_kind, case.parser_kind);
+        assert_eq!(shadow.parser_capability, case.expect_parser_capability);
+        assert_eq!(shadow.classified_capability, case.expect_capability);
+        assert_eq!(shadow.classified_status, case.expect_status);
+        assert_eq!(
+            shadow.capabilities_match, case.expect_capabilities_match,
+            "match for {:?}",
+            case.prompt
+        );
+        assert_eq!(
+            decision.intent.capability, case.expect_capability,
+            "shadow must not change the classify route for {:?}",
+            case.prompt
+        );
+
+        let encoded = shadow.encode_progress();
+        assert!(encoded.starts_with(SHADOW_PROGRESS_PREFIX), "{encoded}");
+        assert!(encoded.contains(case.parser_kind), "{encoded}");
+        assert!(encoded.contains(case.expect_capability), "{encoded}");
+        assert!(!encoded.contains("diet.plan"), "{encoded}");
+        assert!(!encoded.contains("thoughts"), "{encoded}");
+    }
+}
+
+#[test]
+fn leftover_diet_kind_aliases_to_skill_execute_in_shadow() {
+    let decision = classify(ClassifyRequest {
+        user_query: "veg plan".into(),
+        legacy_kind: Some("diet".into()),
+        legacy_complexity: Some(0.85),
+        proposal: None,
+    });
+    let shadow = compare_shadow("diet", &decision.intent);
+    assert_eq!(shadow.parser_capability, "skill.execute");
+    assert_eq!(shadow.classified_capability, "skill.execute");
+    assert_eq!(shadow.classified_kind, "skill");
+    assert!(shadow.capabilities_match);
+    assert!(!shadow.kinds_match);
+}
+
+#[test]
+fn invented_diet_plan_proposal_does_not_win_shadow_or_route() {
+    let decision = classify(ClassifyRequest {
+        user_query: "Create a meal plan".into(),
+        legacy_kind: Some("skill".into()),
+        legacy_complexity: Some(0.85),
+        proposal: from_capability("diet.plan", "Create a meal plan", 0.99),
+    });
+    assert_eq!(decision.intent.capability, "skill.execute");
+    let shadow = compare_shadow("skill", &decision.intent);
+    assert!(shadow.capabilities_match);
+    assert_eq!(shadow.classified_capability, "skill.execute");
+}

--- a/rust/airo_mind_reasoning/src/engine.rs
+++ b/rust/airo_mind_reasoning/src/engine.rs
@@ -18,7 +18,7 @@ use crate::request::ReasoningRequest;
 use crate::result::ReasoningResult;
 use crate::tools::{ToolExecutor, MAX_TOOL_ITERATIONS};
 use crate::validator::validate_result;
-use airo_mind_intent::{classify, ClassifyRequest, IntentStatus};
+use airo_mind_intent::{classify, compare_shadow, ClassifyRequest, IntentStatus};
 
 pub struct ReasoningTimings {
     pub policy_ms: u128,
@@ -89,6 +89,9 @@ impl<P: ReasoningPolicy> ReasoningEngine<P> {
             legacy_complexity: Some(request.intent.complexity),
             proposal,
         });
+        emit(ReasoningEvent::Progress {
+            message: compare_shadow(&request.intent.kind, &decision.intent).encode_progress(),
+        })?;
         if decision.status == IntentStatus::NeedsClarification {
             let message = decision
                 .intent

--- a/rust/airo_mind_reasoning/src/lib.rs
+++ b/rust/airo_mind_reasoning/src/lib.rs
@@ -26,6 +26,7 @@ pub mod result;
 pub mod tools;
 pub mod validator;
 
+pub use airo_mind_intent::SHADOW_PROGRESS_PREFIX;
 pub use analyzer::CLARIFY_PROGRESS_PREFIX;
 pub use context::{ContextItem, ContextLimits, ReasoningContext};
 pub use device::DeviceInferenceProfile;

--- a/rust/airo_mind_reasoning/tests/engine_fake.rs
+++ b/rust/airo_mind_reasoning/tests/engine_fake.rs
@@ -10,7 +10,7 @@ use airo_mind_core::{
 use airo_mind_reasoning::{
     DeviceInferenceProfile, ReasoningEngine, ReasoningError, ReasoningEvent, ReasoningLevel,
     ReasoningRequest, ReasoningStage, ToolCall, ToolDefinition, ToolExecutor,
-    CLARIFY_PROGRESS_PREFIX, MAX_TOOL_ITERATIONS,
+    CLARIFY_PROGRESS_PREFIX, MAX_TOOL_ITERATIONS, SHADOW_PROGRESS_PREFIX,
 };
 
 struct ScriptedEngine {
@@ -216,6 +216,15 @@ fn collect_with_tools(
         tools,
     )?;
     Ok(events)
+}
+
+fn shadow_progress(events: &[ReasoningEvent]) -> Option<&str> {
+    events.iter().find_map(|event| match event {
+        ReasoningEvent::Progress { message } if message.starts_with(SHADOW_PROGRESS_PREFIX) => {
+            Some(message.as_str())
+        }
+        _ => None,
+    })
 }
 
 fn completed(events: &[ReasoningEvent]) -> &airo_mind_reasoning::ReasoningResult {
@@ -453,6 +462,15 @@ fn underspecified_action_asks_instead_of_generating() {
         ReasoningEvent::Progress { message } if message.starts_with(CLARIFY_PROGRESS_PREFIX)
             && message.contains("skill.execute")
     )));
+    let shadow = shadow_progress(&events).expect("shadow compare on reason()");
+    assert!(
+        shadow.contains("conversation") && shadow.contains("general.chat"),
+        "{shadow}"
+    );
+    assert!(
+        shadow.contains("needs_clarification"),
+        "underspecified leftover must still ask: {shadow}"
+    );
     assert!(events
         .iter()
         .all(|e| !matches!(e, ReasoningEvent::Completed { .. })));
@@ -550,6 +568,15 @@ fn analyzer_proposal_beats_a_wrong_legacy_kind() {
     let events = collect(&gen, req, &CancelToken::new()).unwrap();
     assert_eq!(completed(&events).answer, "A budget plan.");
     assert_eq!(gen.calls(), 2);
+    let shadow = shadow_progress(&events).expect("shadow compare on reason()");
+    assert!(
+        shadow.contains("navigation") && shadow.contains("planning.create"),
+        "leftover parser kind must be compared, not discarded: {shadow}"
+    );
+    assert!(
+        shadow.ends_with("|0"),
+        "analyzer vs navigation leftover is a mismatch: {shadow}"
+    );
     let prompts = gen.prompts();
     assert!(
         prompts[0].contains("Pick exactly one capability"),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Dual-run on `reason()`: leftover keyword `IntentParser` kind is compared to `classify()` / analyzer `ClassifiedIntent` and emitted as `shadow:` progress.
- Compare never routes. Product intercepts (diet plugin, skills) still use `IntentParser`. Parser is not deleted.
- Narrow eval fixtures: underspecified “prepare for tomorrow” asks; “why is the sky blue?” is `general.chat`; diet/meal-plan is `skill.execute` not `diet.plan`; “plan my budget” leftover `navigation` must not stay navigation when the analyzer proposes `planning.create`.
- Flutter still hydrates only kinds the Rust legacy adapter already understands. The fold hides `shadow:` from the thinking UI.

Continues [#1827](https://github.com/DevelopersCoffee/airo/issues/1827). Amends ADR-0003: shadow-mode dual-run is in progress; deleting `IntentParser` stays later.

## Test plan
- [x] `cargo test -p airo_mind_intent --manifest-path rust/Cargo.toml --offline`
- [x] `cargo test -p airo_mind_reasoning --manifest-path rust/Cargo.toml --offline`
- [x] `cargo clippy -p airo_mind_intent -p airo_mind_reasoning --manifest-path rust/Cargo.toml --offline --no-deps -- -D warnings`
- [x] `cd packages/feature_mind && flutter test test/reasoning test/agent_chat/presentation/screens/chat_screen_reasoning_test.dart`

**Verification environment:** Host-only. Do not squash-merge until SonarQube is green.

## Agent Policy
- [x] Linked issue includes a Critical Agent Gate.
- [x] Linked issue includes a Feature Packet.
- [x] Cross-agent contract is ADR-0003 (`ClassifiedIntent`); this PR does not change routing.
- [x] Eval fixtures live in `rust/airo_mind_intent/tests/shadow.rs` and `packages/feature_mind/test/reasoning/intent_parser_shadow_eval_test.dart`.
- [x] Android Emulator was not used.

## Council Review
Required for this Rust + `feature_mind` contract slice: Rust Architect (owner of `airo_mind_intent`), Chief Architect, Platform Architect, Chief Performance Officer, Chief Security Officer, Chief QA Officer, Product Manager (`feature_mind`), Chief Documentation Officer (ADR amendment).

- [x] Every package touched has a `module.yaml`.
- [x] No `docs/wiki` update: no user-visible chat behavior change (shadow compare is log-only).

## Plugin and Size Impact
- [ ] This PR adds new dependencies
- [x] This PR adds or grows app/packages/plugins code
- [x] Size impact is documented below
- [x] Any module over 3 MB is a plugin or has an explicit plugin marker
- [x] Any plugin over 5 MB has cache-management documentation

Size impact / plugin justification:

`packages/feature_mind` is 2.37 MB bundled (Always Ship on phone/tablet). That is under the 3 MB plugin threshold; the 1–3 MB band only needs this note. This PR adds a thin `shadow:` fold parser in `reasoning_models.dart`. Eval fixtures live under `test/` and are excluded from the size gate. No new dependencies.

## User-Facing Documentation
- [x] No `docs/wiki` update is needed because this PR has no user-visible behavior or documentation impact.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e8a046d0-b18a-475e-beed-8b3c6b8ca0c2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e8a046d0-b18a-475e-beed-8b3c6b8ca0c2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

