### PR TITLE
feat(mind): add Deep Research privacy control

### DIFF
--- a/packages/feature_mind/lib/src/agent_chat/presentation/screens/chat_screen.dart
+++ b/packages/feature_mind/lib/src/agent_chat/presentation/screens/chat_screen.dart
@@ -319,6 +319,7 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
   bool _isGenerating = false;
   bool _isCapturingVoice = false;
   bool _deepResearchEnabled = false;
+  PrivacyProfile _researchPrivacy = PrivacyProfile.balanced;
   ResearchSession? _researchSession;
   int _researchEpoch = 0;
   ResearchControl? _researchControl;
@@ -1025,84 +1026,131 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
                           top: BorderSide(color: colorScheme.outlineVariant),
                         ),
                       ),
-                      child: Row(
+                      child: Column(
+                        mainAxisSize: MainAxisSize.min,
+                        crossAxisAlignment: CrossAxisAlignment.start,
                         children: [
-                          OutlinedButton.icon(
-                            key: const Key('agent_chat_skills_button'),
-                            focusNode: _skillsButtonFocusNode,
-                            onPressed: _showManageSkills,
-                            icon: const Icon(Icons.auto_fix_high, size: 18),
-                            label: const Text('Skills'),
-                          ),
-                          IconButton(
-                            key: const Key('agent_chat_deep_research_button'),
-                            tooltip: _deepResearchEnabled
-                                ? 'Deep Research on'
-                                : 'Deep Research',
-                            isSelected: _deepResearchEnabled,
-                            selectedIcon: const Icon(
-                              Icons.travel_explore,
-                              color: MindPalette.local,
+                          if (_deepResearchEnabled) ...[
+                            Semantics(
+                              container: true,
+                              label: 'Research privacy profile',
+                              child: Wrap(
+                                spacing: 8,
+                                runSpacing: 4,
+                                crossAxisAlignment: WrapCrossAlignment.center,
+                                children: [
+                                  for (final profile in PrivacyProfile.values)
+                                    ChoiceChip(
+                                      key: Key(
+                                        'agent_chat_research_privacy_'
+                                        '${profile.name}',
+                                      ),
+                                      label: Text(_privacyLabel(profile)),
+                                      selected: _researchPrivacy == profile,
+                                      onSelected: _isGenerating
+                                          ? null
+                                          : (_) {
+                                              setState(() {
+                                                _researchPrivacy = profile;
+                                              });
+                                            },
+                                    ),
+                                  Text(
+                                    _privacyDescription(_researchPrivacy),
+                                    style: Theme.of(context).textTheme.bodySmall
+                                        ?.copyWith(
+                                          color: colorScheme.onSurfaceVariant,
+                                        ),
+                                  ),
+                                ],
+                              ),
                             ),
-                            onPressed: _isGenerating
-                                ? null
-                                : () {
-                                    setState(() {
-                                      _deepResearchEnabled =
-                                          !_deepResearchEnabled;
-                                    });
+                            const SizedBox(height: 8),
+                          ],
+                          Row(
+                            children: [
+                              OutlinedButton.icon(
+                                key: const Key('agent_chat_skills_button'),
+                                focusNode: _skillsButtonFocusNode,
+                                onPressed: _showManageSkills,
+                                icon: const Icon(Icons.auto_fix_high, size: 18),
+                                label: const Text('Skills'),
+                              ),
+                              IconButton(
+                                key: const Key(
+                                  'agent_chat_deep_research_button',
+                                ),
+                                tooltip: _deepResearchEnabled
+                                    ? 'Deep Research on'
+                                    : 'Deep Research',
+                                isSelected: _deepResearchEnabled,
+                                selectedIcon: const Icon(
+                                  Icons.travel_explore,
+                                  color: MindPalette.local,
+                                ),
+                                onPressed: _isGenerating
+                                    ? null
+                                    : () {
+                                        setState(() {
+                                          _deepResearchEnabled =
+                                              !_deepResearchEnabled;
+                                        });
+                                      },
+                                icon: const Icon(Icons.travel_explore_outlined),
+                              ),
+                              Semantics(
+                                button: true,
+                                label: _isCapturingVoice
+                                    ? 'Stop voice input'
+                                    : 'Speak message',
+                                child: IconButton(
+                                  key: const Key('agent_chat_voice_button'),
+                                  tooltip: _isCapturingVoice
+                                      ? 'Stop voice input'
+                                      : 'Speak message',
+                                  onPressed: _captureVoice,
+                                  icon: Icon(
+                                    _isCapturingVoice
+                                        ? Icons.stop
+                                        : Icons.mic_none,
+                                  ),
+                                ),
+                              ),
+                              const SizedBox(width: 8),
+                              Expanded(
+                                child: TextField(
+                                  key: const Key('agent_chat_input'),
+                                  focusNode: _messageInputFocusNode,
+                                  controller: _messageController,
+                                  autofocus: true,
+                                  decoration: InputDecoration(
+                                    hintText: _deepResearchEnabled
+                                        ? 'Ask a research question...'
+                                        : 'Type a message...',
+                                    border: OutlineInputBorder(
+                                      borderRadius: BorderRadius.circular(0),
+                                    ),
+                                    contentPadding: const EdgeInsets.symmetric(
+                                      horizontal: 16,
+                                      vertical: 12,
+                                    ),
+                                  ),
+                                  maxLines: null,
+                                  textInputAction: TextInputAction.send,
+                                  onSubmitted: (_) {
+                                    _sendMessage();
+                                    _restoreComposerFocus();
                                   },
-                            icon: const Icon(Icons.travel_explore_outlined),
-                          ),
-                          Semantics(
-                            button: true,
-                            label: _isCapturingVoice
-                                ? 'Stop voice input'
-                                : 'Speak message',
-                            child: IconButton(
-                              key: const Key('agent_chat_voice_button'),
-                              tooltip: _isCapturingVoice
-                                  ? 'Stop voice input'
-                                  : 'Speak message',
-                              onPressed: _captureVoice,
-                              icon: Icon(
-                                _isCapturingVoice ? Icons.stop : Icons.mic_none,
-                              ),
-                            ),
-                          ),
-                          const SizedBox(width: 8),
-                          Expanded(
-                            child: TextField(
-                              key: const Key('agent_chat_input'),
-                              focusNode: _messageInputFocusNode,
-                              controller: _messageController,
-                              autofocus: true,
-                              decoration: InputDecoration(
-                                hintText: _deepResearchEnabled
-                                    ? 'Ask a research question...'
-                                    : 'Type a message...',
-                                border: OutlineInputBorder(
-                                  borderRadius: BorderRadius.circular(0),
-                                ),
-                                contentPadding: const EdgeInsets.symmetric(
-                                  horizontal: 16,
-                                  vertical: 12,
                                 ),
                               ),
-                              maxLines: null,
-                              textInputAction: TextInputAction.send,
-                              onSubmitted: (_) {
-                                _sendMessage();
-                                _restoreComposerFocus();
-                              },
-                            ),
-                          ),
-                          const SizedBox(width: 8),
-                          IconButton.filled(
-                            key: const Key('agent_chat_send_button'),
-                            focusNode: _sendButtonFocusNode,
-                            onPressed: canSend ? _sendMessage : null,
-                            icon: const Icon(Icons.send),
+                              const SizedBox(width: 8),
+                              IconButton.filled(
+                                key: const Key('agent_chat_send_button'),
+                                focusNode: _sendButtonFocusNode,
+                                onPressed: canSend ? _sendMessage : null,
+                                icon: const Icon(Icons.send),
+                              ),
+                            ],
                           ),
                         ],
                       ),
@@ -2083,11 +2131,29 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
     unawaited(_runDeepResearch(checkpoint.question, resumeFrom: checkpoint));
   }
 
+  String _privacyLabel(PrivacyProfile profile) => switch (profile) {
+    PrivacyProfile.private => 'Private',
+    PrivacyProfile.balanced => 'Balanced',
+    PrivacyProfile.cloud => 'Cloud',
+  };
+
+  String _privacyDescription(PrivacyProfile profile) => switch (profile) {
+    PrivacyProfile.private =>
+      'On-device plus Wikipedia and optional self-hosted SearXNG.',
+    PrivacyProfile.balanced =>
+      'Wikipedia, arXiv, and Semantic Scholar with local orchestration.',
+    PrivacyProfile.cloud =>
+      'Remote allowlisted APIs: arXiv and Semantic Scholar.',
+  };
+
   Future<void> _runDeepResearch(
     String question, {
     ResearchCheckpoint? resumeFrom,
   }) async {
-    final request = ResearchRequest(question: question);
+    final request = ResearchRequest(
+      question: question,
+      privacy: _researchPrivacy,
+    );
     final known =
         (await latestLibraryEntryFor(
           _operationLogPort,

--- a/packages/feature_mind/test/agent_chat/presentation/screens/chat_screen_deep_research_test.dart
+++ b/packages/feature_mind/test/agent_chat/presentation/screens/chat_screen_deep_research_test.dart
@@ -61,6 +61,43 @@ void main() {
     expect(find.textContaining('I think'), findsNothing);
   });
 
+  testWidgets('Private selection is carried by the research request', (
+    tester,
+  ) async {
+    final engine = _RecordingLibraryEngine();
+    await _pumpChatScreen(tester, deepResearchEngine: engine);
+
+    await tester.tap(find.byKey(const Key('agent_chat_deep_research_button')));
+    await tester.pump();
+
+    expect(
+      find.byKey(const Key('agent_chat_research_privacy_balanced')),
+      findsOneWidget,
+    );
+    await tester.tap(
+      find.byKey(const Key('agent_chat_research_privacy_private')),
+    );
+    await tester.pump();
+    expect(
+      find.text('On-device plus Wikipedia and optional self-hosted SearXNG.'),
+      findsOneWidget,
+    );
+
+    await tester.enterText(
+      find.byKey(const Key('agent_chat_input')),
+      'What is private research?',
+    );
+    await tester.ensureVisible(find.byKey(const Key('agent_chat_send_button')));
+    await tester.tap(find.byKey(const Key('agent_chat_send_button')));
+    await tester.pumpAndSettle();
+
+    expect(engine.request?.privacy, PrivacyProfile.private);
+    expect(
+      engine.request!.privacy.engineIds,
+      isNot(contains('semantic_scholar')),
+    );
+  });
+
   testWidgets('new chat dismisses the research progress banner', (
     tester,
   ) async {
@@ -162,6 +199,7 @@ void main() {
 
 class _RecordingLibraryEngine implements DeepResearchEngine {
   List<String> knownSourceUrls = const [];
+  ResearchRequest? request;
 
   @override
   Stream<ResearchEvent> run(
@@ -172,6 +210,7 @@ class _RecordingLibraryEngine implements DeepResearchEngine {
     List<String> knownSourceUrls = const [],
     void Function(ResearchLibraryEntry entry)? onLibrary,
   }) async* {
+    this.request = request;
     this.knownSourceUrls = knownSourceUrls;
     onLibrary?.call(
       ResearchLibraryEntry.fromQuestion(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add Private / Balanced / Cloud chips to Chat’s Deep Research path; Balanced remains the default and the selected profile supplies both `privacy` and `policy` on `ResearchRequest`.
- Preserve mode/policy across process restart with a Dart/Rust `v2` checkpoint record; legacy `v1` records decode as Deep/Balanced. A resumed Private job cannot widen to Balanced providers.
- Describe active routes precisely and associate provider descriptions with each chip’s semantics.
- Keep the composer usable at 320px by adapting action rows with `LayoutBuilder`; use Airo spacing tokens.

Task 2 of the post A–J Deep Research follow-through. SearXNG HTTP remains Task 3.

## Test Plan
- [x] `cargo test -p airo_mind_core --lib research` (46 passed)
- [x] `flutter test test/agent_chat/domain/services/research test/agent_chat/domain/services/deep_research_engine_test.dart test/agent_chat/presentation/screens/chat_screen_deep_research_test.dart --dart-define=APP_VARIANT=mind` (includes v1/v2 checkpoint, Private restart, semantics, and 320px coverage)
- [x] `flutter analyze` on touched Dart files (only one pre-existing style info at `chat_screen.dart:454`; no warnings/errors after stale import cleanup)
- [x] Manual device verification not applicable; host-only widget coverage

**Verification environment:** Host-only

## Agent Policy
- [x] Uses the locked Deep Research privacy and operation-log contracts.
- [x] Checkpoint schema remains backward compatible; no sidecar storage.
- [x] No model chain-of-thought or provider selection in UI.
- [x] Android Emulator was not used.

## Council Review
- Product / Flutter / UX / QA reviews identified route-copy, restart escalation, request-policy, responsive, semantics, and token issues; addressed in `594e0baf` and `ae229af3` with regression coverage.
- Architecture / performance / security / open-source / docs focused reviews requested before merge.
- [x] Touched package has `module.yaml`; ownership unchanged.

## User-Facing Documentation
- [x] Contextual copy and release note document the user-visible behavior; no route/install/wiki page changes.

## Plugin and Size Impact
- [x] No dependencies or plugins added.
- [x] Small bundled Dart/Rust source change; no binary assets.

## Checklist
- [x] Code is formatted.
- [x] Tests included above.
- [x] Sensitive data, credentials, and signing artifacts are not committed.

## Release Notes
- [x] Deep Research now exposes Private, Balanced, and Cloud privacy profiles in Chat and preserves them safely when paused jobs resume.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0d1a1368-352c-43c3-b66e-d4ae3a878dd5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0d1a1368-352c-43c3-b66e-d4ae3a878dd5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

