### PR TITLE
fix(mind): preserve Deep Research privacy across restart

### DIFF
--- a/docs/superpowers/specs/2026-08-22-airo-deep-research-engine-design.md
+++ b/docs/superpowers/specs/2026-08-22-airo-deep-research-engine-design.md
@@ -92,11 +92,12 @@ Shipped as **contracts and a thin live slice**, not the full production engine:
 15. Semantic Scholar search/acquisition alongside Wikipedia and arXiv.
 16. Pause/resume/cancel and operation-log checkpoints. The `v2` record
     preserves mode and policy; ambiguous `v1` records fail closed to
-    Deep/LocalOnly (zero remote engines). Chat can reattach a paused job after
+    Quick/LocalOnly (zero remote engines). Chat can reattach a paused job after
     process restart and waits for the user to resume it. The Rust
     `ResearchCheckpoint` public struct now carries `mode` and `policy`; external
     struct-literal callers must supply those fields or migrate to `from_job` /
-    `from_record`.
+    `from_record`. The future FRB surface must use its own versioned checkpoint
+    DTO rather than exporting this core struct directly.
 17. Operation-log research library, incremental URL delta, cited comparison
     matrix, and contested-row decisions.
 18. User-facing Private / Balanced / Cloud profiles, observability metrics,

--- a/docs/superpowers/specs/2026-08-22-airo-deep-research-engine-design.md
+++ b/docs/superpowers/specs/2026-08-22-airo-deep-research-engine-design.md
@@ -92,10 +92,11 @@ Shipped as **contracts and a thin live slice**, not the full production engine:
 15. Semantic Scholar search/acquisition alongside Wikipedia and arXiv.
 16. Pause/resume/cancel and operation-log checkpoints. The `v2` record
     preserves mode and policy; ambiguous `v1` records fail closed to
-    Deep/Private. Chat can reattach a paused job after process restart and waits
-    for the user to resume it. The Rust `ResearchCheckpoint` public struct now
-    carries `mode` and `policy`; external struct-literal callers must supply
-    those fields or migrate to `from_job` / `from_record`.
+    Deep/LocalOnly (zero remote engines). Chat can reattach a paused job after
+    process restart and waits for the user to resume it. The Rust
+    `ResearchCheckpoint` public struct now carries `mode` and `policy`; external
+    struct-literal callers must supply those fields or migrate to `from_job` /
+    `from_record`.
 17. Operation-log research library, incremental URL delta, cited comparison
     matrix, and contested-row decisions.
 18. User-facing Private / Balanced / Cloud profiles, observability metrics,

--- a/docs/superpowers/specs/2026-08-22-airo-deep-research-engine-design.md
+++ b/docs/superpowers/specs/2026-08-22-airo-deep-research-engine-design.md
@@ -89,17 +89,24 @@ Shipped as **contracts and a thin live slice**, not the full production engine:
 12. Orchestrator: interpret → plan → breadth → gaps → depth → optional counter-research → citation report.
 13. Source manager: fetch → HTML extract (nav/script stripped) → freshness/credibility → cache. Hits are not evidence. One fetch failure does not kill the job.
 14. Claims from acquired paragraphs; citations are unverified unless the excerpt appears in the acquired source.
-15. User-facing Private / Balanced / Cloud profiles select typed search policy.
-    Private currently routes to Wikipedia only; the SearXNG engine id remains
-    policy-only until a user configures the adapter in a later phase.
+15. Semantic Scholar search/acquisition alongside Wikipedia and arXiv.
+16. Pause/resume/cancel and operation-log checkpoints. The `v2` record
+    preserves mode and policy; ambiguous `v1` records fail closed to
+    Deep/Private. Chat can reattach a paused job after process restart and waits
+    for the user to resume it.
+17. Operation-log research library, incremental URL delta, cited comparison
+    matrix, and contested-row decisions.
+18. User-facing Private / Balanced / Cloud profiles, observability metrics,
+    and abstract cost ceilings. Private currently routes to Wikipedia only;
+    the SearXNG adapter and configuration support are not implemented.
 
 Not shipped (locked below, do not pretend they exist):
 
-- Google / Bing / Brave / DuckDuckGo / SearXNG / Tavily / PubMed / Semantic Scholar / GitHub / news APIs
+- Google / Bing / Brave / DuckDuckGo / SearXNG HTTP / Tavily / PubMed / GitHub / news APIs
 - HTML/PDF tables-from-scanned-pages, PDF binary extraction
 - Claim-level citation validation, contradiction explanations, confidence scores
-- HTTP cache, job resumability across process death, `ResearchService` FFI
-- Research library / incremental delta research / comparison matrices / decision weights
+- HTTP cache, automatic continuation without user reattachment, `ResearchService` FFI
+- Weighted decision scoring beyond contested-row flags
 
 ## 5. Locked production scope (do not drop)
 

--- a/docs/superpowers/specs/2026-08-22-airo-deep-research-engine-design.md
+++ b/docs/superpowers/specs/2026-08-22-airo-deep-research-engine-design.md
@@ -89,6 +89,9 @@ Shipped as **contracts and a thin live slice**, not the full production engine:
 12. Orchestrator: interpret → plan → breadth → gaps → depth → optional counter-research → citation report.
 13. Source manager: fetch → HTML extract (nav/script stripped) → freshness/credibility → cache. Hits are not evidence. One fetch failure does not kill the job.
 14. Claims from acquired paragraphs; citations are unverified unless the excerpt appears in the acquired source.
+15. User-facing Private / Balanced / Cloud profiles select typed search policy.
+    Private currently routes to Wikipedia only; the SearXNG engine id remains
+    policy-only until a user configures the adapter in a later phase.
 
 Not shipped (locked below, do not pretend they exist):
 
@@ -97,7 +100,6 @@ Not shipped (locked below, do not pretend they exist):
 - Claim-level citation validation, contradiction explanations, confidence scores
 - HTTP cache, job resumability across process death, `ResearchService` FFI
 - Research library / incremental delta research / comparison matrices / decision weights
-- Privacy modes as a user-facing control (policy enum exists; PRIVATE/CLOUD profiles do not)
 
 ## 5. Locked production scope (do not drop)
 

--- a/docs/superpowers/specs/2026-08-22-airo-deep-research-engine-design.md
+++ b/docs/superpowers/specs/2026-08-22-airo-deep-research-engine-design.md
@@ -93,7 +93,9 @@ Shipped as **contracts and a thin live slice**, not the full production engine:
 16. Pause/resume/cancel and operation-log checkpoints. The `v2` record
     preserves mode and policy; ambiguous `v1` records fail closed to
     Deep/Private. Chat can reattach a paused job after process restart and waits
-    for the user to resume it.
+    for the user to resume it. The Rust `ResearchCheckpoint` public struct now
+    carries `mode` and `policy`; external struct-literal callers must supply
+    those fields or migrate to `from_job` / `from_record`.
 17. Operation-log research library, incremental URL delta, cited comparison
     matrix, and contested-row decisions.
 18. User-facing Private / Balanced / Cloud profiles, observability metrics,

--- a/docs/wiki/5.-AI-and-Model-Management.md
+++ b/docs/wiki/5.-AI-and-Model-Management.md
@@ -32,6 +32,22 @@ device. Customize a slot only when you want to override Automatic. Browse
 community packages from Intelligence → Library, not from the first-run Chat
 gate.
 
+## Deep Research Privacy
+
+Turn on **Deep Research** in Chat to choose a privacy profile before sending a
+research question:
+
+- **Private** currently searches Wikipedia only. Self-hosted SearXNG support is
+  not configured yet.
+- **Balanced** uses Wikipedia, arXiv, and Semantic Scholar with local
+  orchestration.
+- **Cloud** currently uses the same three remote sources as Balanced. It does
+  not imply Google or another commercial search provider.
+
+Balanced is the default. A paused job records its selected mode and search
+policy in the operation log, so restarting the app does not widen a Private
+job to Balanced sources. The UI shows the restored profile before you resume.
+
 ## Intelligence
 
 Standalone Airo Mind keeps three working destinations plus Wellbeing:

--- a/packages/feature_mind/lib/src/agent_chat/domain/services/research/research_checkpoint.dart
+++ b/packages/feature_mind/lib/src/agent_chat/domain/services/research/research_checkpoint.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/foundation.dart';
 
 import '../../models/research_event.dart';
+import '../../models/research_request.dart';
 
 /// Durable job snapshot. Payload for the operation log — not a sidecar DB.
 @immutable
@@ -13,6 +14,8 @@ class ResearchCheckpoint {
     required this.searchesUsed,
     required this.iterationsUsed,
     this.completedNodeIds = const [],
+    this.mode = ResearchMode.deep,
+    this.policy = SearchPolicy.balanced,
   });
 
   final String jobId;
@@ -22,6 +25,15 @@ class ResearchCheckpoint {
   final int searchesUsed;
   final int iterationsUsed;
   final List<String> completedNodeIds;
+  final ResearchMode mode;
+  final SearchPolicy policy;
+
+  PrivacyProfile get privacy => switch (policy) {
+    SearchPolicy.localOnly ||
+    SearchPolicy.privacyFirst => PrivacyProfile.private,
+    SearchPolicy.maximumQuality => PrivacyProfile.cloud,
+    SearchPolicy.balanced || SearchPolicy.academic => PrivacyProfile.balanced,
+  };
 
   bool get isTerminal =>
       state == ResearchPhase.completed ||
@@ -34,6 +46,8 @@ class ResearchCheckpoint {
     int? searchesUsed,
     int? iterationsUsed,
     List<String>? completedNodeIds,
+    ResearchMode? mode,
+    SearchPolicy? policy,
   }) {
     return ResearchCheckpoint(
       jobId: jobId,
@@ -43,12 +57,14 @@ class ResearchCheckpoint {
       searchesUsed: searchesUsed ?? this.searchesUsed,
       iterationsUsed: iterationsUsed ?? this.iterationsUsed,
       completedNodeIds: completedNodeIds ?? this.completedNodeIds,
+      mode: mode ?? this.mode,
+      policy: policy ?? this.policy,
     );
   }
 
   String toRecord() {
     return [
-      'v1',
+      'v2',
       jobId,
       question.replaceAll('\u{1f}', ' '),
       researchPhaseWire(state),
@@ -56,12 +72,16 @@ class ResearchCheckpoint {
       '$searchesUsed',
       '$iterationsUsed',
       completedNodeIds.join(','),
+      mode.name,
+      researchPolicyWire(policy),
     ].join('\u{1f}');
   }
 
   factory ResearchCheckpoint.fromRecord(String record) {
     final parts = record.split('\u{1f}');
-    if (parts.length != 8 || parts[0] != 'v1') {
+    final legacy = parts.length == 8 && parts[0] == 'v1';
+    final current = parts.length == 10 && parts[0] == 'v2';
+    if (!legacy && !current) {
       throw const FormatException('invalid research checkpoint');
     }
     final state = parseResearchPhase(parts[3]);
@@ -69,6 +89,13 @@ class ResearchCheckpoint {
       throw const FormatException('invalid research checkpoint state');
     }
     final pausedFrom = parts[4].isEmpty ? null : parseResearchPhase(parts[4]);
+    final mode = legacy ? ResearchMode.deep : parseResearchMode(parts[8]);
+    final policy = legacy
+        ? SearchPolicy.balanced
+        : parseResearchPolicy(parts[9]);
+    if (mode == null || policy == null) {
+      throw const FormatException('invalid research checkpoint policy');
+    }
     return ResearchCheckpoint(
       jobId: parts[1],
       question: parts[2],
@@ -77,6 +104,8 @@ class ResearchCheckpoint {
       searchesUsed: int.parse(parts[5]),
       iterationsUsed: int.parse(parts[6]),
       completedNodeIds: parts[7].isEmpty ? const [] : parts[7].split(','),
+      mode: mode,
+      policy: policy,
     );
   }
 
@@ -89,6 +118,8 @@ class ResearchCheckpoint {
       other.pausedFrom == pausedFrom &&
       other.searchesUsed == searchesUsed &&
       other.iterationsUsed == iterationsUsed &&
+      other.mode == mode &&
+      other.policy == policy &&
       listEquals(other.completedNodeIds, completedNodeIds);
 
   @override
@@ -99,9 +130,37 @@ class ResearchCheckpoint {
     pausedFrom,
     searchesUsed,
     iterationsUsed,
+    mode,
+    policy,
     Object.hashAll(completedNodeIds),
   );
 }
+
+String researchPolicyWire(SearchPolicy policy) => switch (policy) {
+  SearchPolicy.localOnly => 'local_only',
+  SearchPolicy.privacyFirst => 'privacy_first',
+  SearchPolicy.balanced => 'balanced',
+  SearchPolicy.maximumQuality => 'maximum_quality',
+  SearchPolicy.academic => 'academic',
+};
+
+ResearchMode? parseResearchMode(String value) {
+  for (final mode in ResearchMode.values) {
+    if (mode.name == value) {
+      return mode;
+    }
+  }
+  return null;
+}
+
+SearchPolicy? parseResearchPolicy(String value) => switch (value) {
+  'local_only' => SearchPolicy.localOnly,
+  'privacy_first' => SearchPolicy.privacyFirst,
+  'balanced' => SearchPolicy.balanced,
+  'maximum_quality' => SearchPolicy.maximumQuality,
+  'academic' => SearchPolicy.academic,
+  _ => null,
+};
 
 String researchPhaseWire(ResearchPhase phase) {
   switch (phase) {

--- a/packages/feature_mind/lib/src/agent_chat/domain/services/research/research_checkpoint.dart
+++ b/packages/feature_mind/lib/src/agent_chat/domain/services/research/research_checkpoint.dart
@@ -89,7 +89,10 @@ class ResearchCheckpoint {
       throw const FormatException('invalid research checkpoint state');
     }
     final pausedFrom = parts[4].isEmpty ? null : parseResearchPhase(parts[4]);
-    final mode = legacy ? ResearchMode.deep : parseResearchMode(parts[8]);
+    if (parts[4].isNotEmpty && pausedFrom == null) {
+      throw const FormatException('invalid research checkpoint paused state');
+    }
+    final mode = legacy ? ResearchMode.quick : parseResearchMode(parts[8]);
     final policy = legacy
         ? SearchPolicy.localOnly
         : parseResearchPolicy(parts[9]);
@@ -101,8 +104,8 @@ class ResearchCheckpoint {
       question: parts[2],
       state: state,
       pausedFrom: pausedFrom,
-      searchesUsed: int.parse(parts[5]),
-      iterationsUsed: int.parse(parts[6]),
+      searchesUsed: parseResearchCounter(parts[5]),
+      iterationsUsed: parseResearchCounter(parts[6]),
       completedNodeIds: parts[7].isEmpty ? const [] : parts[7].split(','),
       mode: mode,
       policy: policy,
@@ -134,6 +137,14 @@ class ResearchCheckpoint {
     policy,
     Object.hashAll(completedNodeIds),
   );
+}
+
+int parseResearchCounter(String value) {
+  final parsed = int.tryParse(value);
+  if (parsed == null || parsed < 0 || parsed > 0xffffffff) {
+    throw const FormatException('invalid research checkpoint counter');
+  }
+  return parsed;
 }
 
 String researchPolicyWire(SearchPolicy policy) => switch (policy) {

--- a/packages/feature_mind/lib/src/agent_chat/domain/services/research/research_checkpoint.dart
+++ b/packages/feature_mind/lib/src/agent_chat/domain/services/research/research_checkpoint.dart
@@ -91,7 +91,7 @@ class ResearchCheckpoint {
     final pausedFrom = parts[4].isEmpty ? null : parseResearchPhase(parts[4]);
     final mode = legacy ? ResearchMode.deep : parseResearchMode(parts[8]);
     final policy = legacy
-        ? SearchPolicy.privacyFirst
+        ? SearchPolicy.localOnly
         : parseResearchPolicy(parts[9]);
     if (mode == null || policy == null) {
       throw const FormatException('invalid research checkpoint policy');

--- a/packages/feature_mind/lib/src/agent_chat/domain/services/research/research_checkpoint.dart
+++ b/packages/feature_mind/lib/src/agent_chat/domain/services/research/research_checkpoint.dart
@@ -91,7 +91,7 @@ class ResearchCheckpoint {
     final pausedFrom = parts[4].isEmpty ? null : parseResearchPhase(parts[4]);
     final mode = legacy ? ResearchMode.deep : parseResearchMode(parts[8]);
     final policy = legacy
-        ? SearchPolicy.balanced
+        ? SearchPolicy.privacyFirst
         : parseResearchPolicy(parts[9]);
     if (mode == null || policy == null) {
       throw const FormatException('invalid research checkpoint policy');

--- a/packages/feature_mind/lib/src/agent_chat/domain/services/research/research_checkpoint_log.dart
+++ b/packages/feature_mind/lib/src/agent_chat/domain/services/research/research_checkpoint_log.dart
@@ -31,12 +31,16 @@ Future<ResearchCheckpoint?> latestResumableResearchCheckpoint(
     }
     final limit = count < 200 ? count : 200;
     final ops = await log.range(offset: 0, limit: limit);
+    final seenJobIds = <String>{};
     for (final op in ops) {
       if (op.kind != MindOpKind.researchCheckpoint || op.detail.isEmpty) {
         continue;
       }
       try {
         final checkpoint = ResearchCheckpoint.fromRecord(op.detail);
+        if (!seenJobIds.add(checkpoint.jobId)) {
+          continue;
+        }
         if (!checkpoint.isTerminal) {
           return checkpoint;
         }

--- a/packages/feature_mind/lib/src/agent_chat/domain/services/research/research_orchestrator.dart
+++ b/packages/feature_mind/lib/src/agent_chat/domain/services/research/research_orchestrator.dart
@@ -87,9 +87,7 @@ class ResearchOrchestrator {
     var iterationsUsed = resumeFrom?.iterationsUsed ?? 0;
     final completed = {...?resumeFrom?.completedNodeIds};
     final collected = <ResearchHit>[];
-    final allowedIds = request.privacy == PrivacyProfile.balanced
-        ? SearchRouter.engineIds(request.policy)
-        : SearchRouter.engineIdsFor(request.privacy);
+    final allowedIds = SearchRouter.engineIds(request.policy);
     final routed = engines
         .where((engine) => allowedIds.contains(engine.id))
         .toList(growable: false);

--- a/packages/feature_mind/lib/src/agent_chat/domain/services/research/research_orchestrator.dart
+++ b/packages/feature_mind/lib/src/agent_chat/domain/services/research/research_orchestrator.dart
@@ -105,6 +105,8 @@ class ResearchOrchestrator {
           searchesUsed: searchesUsed,
           iterationsUsed: iterationsUsed,
           completedNodeIds: completed.toList(growable: false),
+          mode: request.mode,
+          policy: request.policy,
         ),
       );
     }

--- a/packages/feature_mind/lib/src/agent_chat/presentation/screens/chat_screen.dart
+++ b/packages/feature_mind/lib/src/agent_chat/presentation/screens/chat_screen.dart
@@ -324,6 +324,9 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
   ResearchControl? _researchControl;
   ResearchCheckpoint? _resumableCheckpoint;
 
+  bool get _canChangeResearchPrivacy =>
+      !_isGenerating && !(_resumableCheckpoint?.isTerminal == false);
+
   final FocusNode _selectedModelBarFocusNode = FocusNode();
   final FocusNode _skillsButtonFocusNode = FocusNode();
   final FocusNode _messageInputFocusNode = FocusNode();
@@ -1064,14 +1067,15 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
                                               ),
                                               selected:
                                                   _researchPrivacy == profile,
-                                              onSelected: _isGenerating
-                                                  ? null
-                                                  : (_) {
+                                              onSelected:
+                                                  _canChangeResearchPrivacy
+                                                  ? (_) {
                                                       setState(() {
                                                         _researchPrivacy =
                                                             profile;
                                                       });
-                                                    },
+                                                    }
+                                                  : null,
                                             ),
                                           ),
                                         ),

--- a/packages/feature_mind/lib/src/agent_chat/presentation/screens/chat_screen.dart
+++ b/packages/feature_mind/lib/src/agent_chat/presentation/screens/chat_screen.dart
@@ -56,7 +56,6 @@ import '../../../agent_chat/domain/services/deep_research_engine.dart';
 import '../../../agent_chat/domain/services/research/research_checkpoint.dart';
 import '../../../agent_chat/domain/services/research/research_checkpoint_log.dart';
 import '../../../agent_chat/domain/services/research/research_control.dart';
-import '../../../agent_chat/domain/services/research/research_library.dart';
 import '../../../agent_chat/domain/services/research/research_library_log.dart';
 import '../../../agent_chat/domain/services/remote_agent_skill_installer.dart';
 import '../../../agent_chat/domain/services/agent_tool_interceptor.dart';

--- a/packages/feature_mind/lib/src/agent_chat/presentation/screens/chat_screen.dart
+++ b/packages/feature_mind/lib/src/agent_chat/presentation/screens/chat_screen.dart
@@ -327,6 +327,11 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
   bool get _canChangeResearchPrivacy =>
       !_isGenerating && !(_resumableCheckpoint?.isTerminal == false);
 
+  String get _selectedResearchPrivacyDescription =>
+      _resumableCheckpoint?.policy == SearchPolicy.localOnly
+      ? 'Restored local-only job: no remote sources.'
+      : _privacyDescription(_researchPrivacy);
+
   final FocusNode _selectedModelBarFocusNode = FocusNode();
   final FocusNode _skillsButtonFocusNode = FocusNode();
   final FocusNode _messageInputFocusNode = FocusNode();
@@ -1083,7 +1088,7 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
                                   ),
                                   const SizedBox(height: AiroSpacing.xs),
                                   Text(
-                                    _privacyDescription(_researchPrivacy),
+                                    _selectedResearchPrivacyDescription,
                                     style: Theme.of(context).textTheme.bodySmall
                                         ?.copyWith(
                                           color: colorScheme.onSurfaceVariant,

--- a/packages/feature_mind/lib/src/agent_chat/presentation/screens/chat_screen.dart
+++ b/packages/feature_mind/lib/src/agent_chat/presentation/screens/chat_screen.dart
@@ -332,6 +332,14 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
       ? 'Restored local-only job: no remote sources.'
       : _privacyDescription(_researchPrivacy);
 
+  String _privacySemanticsDescription(PrivacyProfile profile) {
+    if (profile == _researchPrivacy &&
+        _resumableCheckpoint?.policy == SearchPolicy.localOnly) {
+      return _selectedResearchPrivacyDescription;
+    }
+    return _privacyDescription(profile);
+  }
+
   final FocusNode _selectedModelBarFocusNode = FocusNode();
   final FocusNode _skillsButtonFocusNode = FocusNode();
   final FocusNode _messageInputFocusNode = FocusNode();
@@ -1061,7 +1069,9 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
                                           in PrivacyProfile.values)
                                         MergeSemantics(
                                           child: Semantics(
-                                            hint: _privacyDescription(profile),
+                                            hint: _privacySemanticsDescription(
+                                              profile,
+                                            ),
                                             child: ChoiceChip(
                                               key: Key(
                                                 'agent_chat_research_privacy_'

--- a/packages/feature_mind/lib/src/agent_chat/presentation/screens/chat_screen.dart
+++ b/packages/feature_mind/lib/src/agent_chat/presentation/screens/chat_screen.dart
@@ -1019,7 +1019,7 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
                         onCancel: _researchControl?.cancel,
                       ),
                     Container(
-                      padding: const EdgeInsets.all(16),
+                      padding: AiroSpacing.paddingMd,
                       decoration: BoxDecoration(
                         color: colorScheme.surface.withValues(alpha: 0.34),
                         border: Border(
@@ -1034,27 +1034,51 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
                             Semantics(
                               container: true,
                               label: 'Research privacy profile',
-                              child: Wrap(
-                                spacing: 8,
-                                runSpacing: 4,
-                                crossAxisAlignment: WrapCrossAlignment.center,
+                              child: Column(
+                                crossAxisAlignment: CrossAxisAlignment.start,
                                 children: [
-                                  for (final profile in PrivacyProfile.values)
-                                    ChoiceChip(
-                                      key: Key(
-                                        'agent_chat_research_privacy_'
-                                        '${profile.name}',
-                                      ),
-                                      label: Text(_privacyLabel(profile)),
-                                      selected: _researchPrivacy == profile,
-                                      onSelected: _isGenerating
-                                          ? null
-                                          : (_) {
-                                              setState(() {
-                                                _researchPrivacy = profile;
-                                              });
-                                            },
-                                    ),
+                                  Text(
+                                    'Research privacy',
+                                    style: Theme.of(
+                                      context,
+                                    ).textTheme.labelMedium,
+                                  ),
+                                  const SizedBox(height: AiroSpacing.xs),
+                                  Wrap(
+                                    spacing: AiroSpacing.sm,
+                                    runSpacing: AiroSpacing.xs,
+                                    crossAxisAlignment:
+                                        WrapCrossAlignment.center,
+                                    children: [
+                                      for (final profile
+                                          in PrivacyProfile.values)
+                                        MergeSemantics(
+                                          child: Semantics(
+                                            hint: _privacyDescription(profile),
+                                            child: ChoiceChip(
+                                              key: Key(
+                                                'agent_chat_research_privacy_'
+                                                '${profile.name}',
+                                              ),
+                                              label: Text(
+                                                _privacyLabel(profile),
+                                              ),
+                                              selected:
+                                                  _researchPrivacy == profile,
+                                              onSelected: _isGenerating
+                                                  ? null
+                                                  : (_) {
+                                                      setState(() {
+                                                        _researchPrivacy =
+                                                            profile;
+                                                      });
+                                                    },
+                                            ),
+                                          ),
+                                        ),
+                                    ],
+                                  ),
+                                  const SizedBox(height: AiroSpacing.xs),
                                   Text(
                                     _privacyDescription(_researchPrivacy),
                                     style: Theme.of(context).textTheme.bodySmall
@@ -1065,93 +1089,9 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
                                 ],
                               ),
                             ),
-                            const SizedBox(height: 8),
+                            const SizedBox(height: AiroSpacing.sm),
                           ],
-                          Row(
-                            children: [
-                              OutlinedButton.icon(
-                                key: const Key('agent_chat_skills_button'),
-                                focusNode: _skillsButtonFocusNode,
-                                onPressed: _showManageSkills,
-                                icon: const Icon(Icons.auto_fix_high, size: 18),
-                                label: const Text('Skills'),
-                              ),
-                              IconButton(
-                                key: const Key(
-                                  'agent_chat_deep_research_button',
-                                ),
-                                tooltip: _deepResearchEnabled
-                                    ? 'Deep Research on'
-                                    : 'Deep Research',
-                                isSelected: _deepResearchEnabled,
-                                selectedIcon: const Icon(
-                                  Icons.travel_explore,
-                                  color: MindPalette.local,
-                                ),
-                                onPressed: _isGenerating
-                                    ? null
-                                    : () {
-                                        setState(() {
-                                          _deepResearchEnabled =
-                                              !_deepResearchEnabled;
-                                        });
-                                      },
-                                icon: const Icon(Icons.travel_explore_outlined),
-                              ),
-                              Semantics(
-                                button: true,
-                                label: _isCapturingVoice
-                                    ? 'Stop voice input'
-                                    : 'Speak message',
-                                child: IconButton(
-                                  key: const Key('agent_chat_voice_button'),
-                                  tooltip: _isCapturingVoice
-                                      ? 'Stop voice input'
-                                      : 'Speak message',
-                                  onPressed: _captureVoice,
-                                  icon: Icon(
-                                    _isCapturingVoice
-                                        ? Icons.stop
-                                        : Icons.mic_none,
-                                  ),
-                                ),
-                              ),
-                              const SizedBox(width: 8),
-                              Expanded(
-                                child: TextField(
-                                  key: const Key('agent_chat_input'),
-                                  focusNode: _messageInputFocusNode,
-                                  controller: _messageController,
-                                  autofocus: true,
-                                  decoration: InputDecoration(
-                                    hintText: _deepResearchEnabled
-                                        ? 'Ask a research question...'
-                                        : 'Type a message...',
-                                    border: OutlineInputBorder(
-                                      borderRadius: BorderRadius.circular(0),
-                                    ),
-                                    contentPadding: const EdgeInsets.symmetric(
-                                      horizontal: 16,
-                                      vertical: 12,
-                                    ),
-                                  ),
-                                  maxLines: null,
-                                  textInputAction: TextInputAction.send,
-                                  onSubmitted: (_) {
-                                    _sendMessage();
-                                    _restoreComposerFocus();
-                                  },
-                                ),
-                              ),
-                              const SizedBox(width: 8),
-                              IconButton.filled(
-                                key: const Key('agent_chat_send_button'),
-                                focusNode: _sendButtonFocusNode,
-                                onPressed: canSend ? _sendMessage : null,
-                                icon: const Icon(Icons.send),
-                              ),
-                            ],
-                          ),
+                          _buildComposerControls(canSend),
                         ],
                       ),
                     ),
@@ -1318,94 +1258,92 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
             crossAxisAlignment: CrossAxisAlignment.stretch,
             mainAxisSize: MainAxisSize.min,
             children: [
-              Row(
-                children: [
-                  MindPresencePip(isLocal: isLocal),
-                  const SizedBox(width: 10),
-                  Expanded(
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      mainAxisSize: MainAxisSize.min,
+              LayoutBuilder(
+                builder: (context, constraints) {
+                  final identity = Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Text('AUTOMATIC', style: IntelligenceTypography.status()),
+                      Text(
+                        label,
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                        style: Theme.of(context).textTheme.labelLarge?.copyWith(
+                          color: MindPalette.ink,
+                          letterSpacing: 0.8,
+                        ),
+                      ),
+                      Text(
+                        statusLine,
+                        maxLines: 2,
+                        overflow: TextOverflow.ellipsis,
+                        style: Theme.of(context).textTheme.labelSmall?.copyWith(
+                          color: MindPalette.local,
+                          letterSpacing: 1.2,
+                        ),
+                      ),
+                    ],
+                  );
+                  final actions = Wrap(
+                    alignment: WrapAlignment.end,
+                    children: [
+                      IconButton(
+                        key: const Key('agent_chat_assistants_button'),
+                        tooltip: _personaSession.pinned?.name ?? 'Assistants',
+                        onPressed: _showPickAssistant,
+                        icon: Icon(
+                          _personaSession.isPinned
+                              ? Icons.badge
+                              : Icons.badge_outlined,
+                          size: 20,
+                        ),
+                      ),
+                      IconButton(
+                        focusNode: _selectedModelBarFocusNode,
+                        tooltip: 'Customize',
+                        onPressed: _openChatCustomize,
+                        icon: const Icon(Icons.tune, size: 20),
+                      ),
+                      IconButton(
+                        key: const Key('agent_chat_copy_transcript_button'),
+                        tooltip: 'Copy transcript',
+                        onPressed: _messages.isEmpty ? null : _copyTranscript,
+                        icon: const Icon(Icons.ios_share_outlined, size: 20),
+                      ),
+                      IconButton(
+                        key: const Key('agent_chat_clear_conversation_button'),
+                        tooltip: 'Clear chat',
+                        onPressed: _messages.isEmpty || _isGenerating
+                            ? null
+                            : _confirmClearConversation,
+                        icon: const Icon(Icons.delete_sweep_outlined, size: 20),
+                      ),
+                    ],
+                  );
+                  final identityRow = Row(
+                    children: [
+                      MindPresencePip(isLocal: isLocal),
+                      const SizedBox(width: AiroSpacing.sm),
+                      Expanded(child: identity),
+                    ],
+                  );
+                  if (constraints.maxWidth < 600) {
+                    return Column(
+                      crossAxisAlignment: CrossAxisAlignment.stretch,
                       children: [
-                        Text(
-                          'AUTOMATIC',
-                          style: IntelligenceTypography.status(),
-                        ),
-                        Text(
-                          label,
-                          maxLines: 1,
-                          overflow: TextOverflow.ellipsis,
-                          style: Theme.of(context).textTheme.labelLarge
-                              ?.copyWith(
-                                color: MindPalette.ink,
-                                letterSpacing: 0.8,
-                              ),
-                        ),
-                        Text(
-                          statusLine,
-                          maxLines: 2,
-                          overflow: TextOverflow.ellipsis,
-                          style: Theme.of(context).textTheme.labelSmall
-                              ?.copyWith(
-                                color: MindPalette.local,
-                                letterSpacing: 1.2,
-                              ),
-                        ),
+                        identityRow,
+                        Align(alignment: Alignment.centerRight, child: actions),
                       ],
-                    ),
-                  ),
-                  IconButton(
-                    key: const Key('agent_chat_assistants_button'),
-                    tooltip: _personaSession.pinned?.name ?? 'Assistants',
-                    onPressed: _showPickAssistant,
-                    constraints: const BoxConstraints.tightFor(
-                      width: 36,
-                      height: 36,
-                    ),
-                    padding: EdgeInsets.zero,
-                    icon: Icon(
-                      _personaSession.isPinned
-                          ? Icons.badge
-                          : Icons.badge_outlined,
-                      size: 20,
-                    ),
-                  ),
-                  IconButton(
-                    focusNode: _selectedModelBarFocusNode,
-                    tooltip: 'Customize',
-                    onPressed: _openChatCustomize,
-                    constraints: const BoxConstraints.tightFor(
-                      width: 36,
-                      height: 36,
-                    ),
-                    padding: EdgeInsets.zero,
-                    icon: const Icon(Icons.tune, size: 20),
-                  ),
-                  IconButton(
-                    key: const Key('agent_chat_copy_transcript_button'),
-                    tooltip: 'Copy transcript',
-                    onPressed: _messages.isEmpty ? null : _copyTranscript,
-                    constraints: const BoxConstraints.tightFor(
-                      width: 36,
-                      height: 36,
-                    ),
-                    padding: EdgeInsets.zero,
-                    icon: const Icon(Icons.ios_share_outlined, size: 20),
-                  ),
-                  IconButton(
-                    key: const Key('agent_chat_clear_conversation_button'),
-                    tooltip: 'Clear chat',
-                    onPressed: _messages.isEmpty || _isGenerating
-                        ? null
-                        : _confirmClearConversation,
-                    constraints: const BoxConstraints.tightFor(
-                      width: 36,
-                      height: 36,
-                    ),
-                    padding: EdgeInsets.zero,
-                    icon: const Icon(Icons.delete_sweep_outlined, size: 20),
-                  ),
-                ],
+                    );
+                  }
+                  return Row(
+                    children: [
+                      Expanded(child: identityRow),
+                      actions,
+                    ],
+                  );
+                },
               ),
               if (!readiness.canSend && readiness.progress > 0) ...[
                 const SizedBox(height: 6),
@@ -2131,6 +2069,114 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
     unawaited(_runDeepResearch(checkpoint.question, resumeFrom: checkpoint));
   }
 
+  Widget _buildComposerControls(bool canSend) {
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final actions = Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            OutlinedButton.icon(
+              key: const Key('agent_chat_skills_button'),
+              focusNode: _skillsButtonFocusNode,
+              onPressed: _showManageSkills,
+              icon: const Icon(Icons.auto_fix_high, size: 18),
+              label: const Text('Skills'),
+            ),
+            IconButton(
+              key: const Key('agent_chat_deep_research_button'),
+              tooltip: _deepResearchEnabled
+                  ? 'Deep Research on'
+                  : 'Deep Research',
+              isSelected: _deepResearchEnabled,
+              selectedIcon: const Icon(
+                Icons.travel_explore,
+                color: MindPalette.local,
+              ),
+              onPressed: _isGenerating
+                  ? null
+                  : () {
+                      setState(() {
+                        _deepResearchEnabled = !_deepResearchEnabled;
+                      });
+                    },
+              icon: const Icon(Icons.travel_explore_outlined),
+            ),
+            Semantics(
+              button: true,
+              label: _isCapturingVoice ? 'Stop voice input' : 'Speak message',
+              child: IconButton(
+                key: const Key('agent_chat_voice_button'),
+                tooltip: _isCapturingVoice
+                    ? 'Stop voice input'
+                    : 'Speak message',
+                onPressed: _captureVoice,
+                icon: Icon(_isCapturingVoice ? Icons.stop : Icons.mic_none),
+              ),
+            ),
+          ],
+        );
+        final input = Expanded(
+          child: TextField(
+            key: const Key('agent_chat_input'),
+            focusNode: _messageInputFocusNode,
+            controller: _messageController,
+            autofocus: true,
+            decoration: InputDecoration(
+              hintText: _deepResearchEnabled
+                  ? 'Ask a research question...'
+                  : 'Type a message...',
+              border: OutlineInputBorder(
+                borderRadius: BorderRadius.circular(0),
+              ),
+              contentPadding: const EdgeInsets.symmetric(
+                horizontal: AiroSpacing.md,
+                vertical: 12,
+              ),
+            ),
+            maxLines: null,
+            textInputAction: TextInputAction.send,
+            onSubmitted: (_) {
+              _sendMessage();
+              _restoreComposerFocus();
+            },
+          ),
+        );
+        final send = IconButton.filled(
+          key: const Key('agent_chat_send_button'),
+          focusNode: _sendButtonFocusNode,
+          onPressed: canSend ? _sendMessage : null,
+          icon: const Icon(Icons.send),
+        );
+
+        if (constraints.maxWidth < 600) {
+          return Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              actions,
+              const SizedBox(height: AiroSpacing.sm),
+              Row(
+                children: [
+                  input,
+                  const SizedBox(width: AiroSpacing.sm),
+                  send,
+                ],
+              ),
+            ],
+          );
+        }
+        return Row(
+          children: [
+            actions,
+            const SizedBox(width: AiroSpacing.sm),
+            input,
+            const SizedBox(width: AiroSpacing.sm),
+            send,
+          ],
+        );
+      },
+    );
+  }
+
   String _privacyLabel(PrivacyProfile profile) => switch (profile) {
     PrivacyProfile.private => 'Private',
     PrivacyProfile.balanced => 'Balanced',
@@ -2151,9 +2197,12 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
     String question, {
     ResearchCheckpoint? resumeFrom,
   }) async {
+    final privacy = resumeFrom?.privacy ?? _researchPrivacy;
     final request = ResearchRequest(
       question: question,
-      privacy: _researchPrivacy,
+      mode: resumeFrom?.mode ?? ResearchMode.deep,
+      policy: resumeFrom?.policy ?? privacy.searchPolicy,
+      privacy: privacy,
     );
     final known =
         (await latestLibraryEntryFor(
@@ -2167,6 +2216,7 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
     final epoch = ++_researchEpoch;
     final control = ResearchControl();
     setState(() {
+      _researchPrivacy = privacy;
       _researchControl = control;
       _researchSession = ResearchSession(request: request);
       _isGenerating = true;

--- a/packages/feature_mind/lib/src/agent_chat/presentation/screens/chat_screen.dart
+++ b/packages/feature_mind/lib/src/agent_chat/presentation/screens/chat_screen.dart
@@ -2036,11 +2036,18 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
     if (!mounted || checkpoint == null) {
       return;
     }
+    final privacy = checkpoint.privacy;
     setState(() {
       _resumableCheckpoint = checkpoint;
       _deepResearchEnabled = true;
+      _researchPrivacy = privacy;
       _researchSession = ResearchSession(
-        request: ResearchRequest(question: checkpoint.question),
+        request: ResearchRequest(
+          question: checkpoint.question,
+          mode: checkpoint.mode,
+          policy: checkpoint.policy,
+          privacy: privacy,
+        ),
         events: [
           const ResearchEvent(
             kind: ResearchEventKind.planningStarted,
@@ -2184,12 +2191,12 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
 
   String _privacyDescription(PrivacyProfile profile) => switch (profile) {
     PrivacyProfile.private =>
-      'On-device orchestration with Wikipedia. '
-          'Self-hosted SearXNG is used when configured.',
+      'Private routing currently uses Wikipedia only. '
+          'Self-hosted SearXNG support is not configured yet.',
     PrivacyProfile.balanced =>
       'Wikipedia, arXiv, and Semantic Scholar with local orchestration.',
     PrivacyProfile.cloud =>
-      'Remote allowlisted sources: Wikipedia, arXiv, and Semantic Scholar.',
+      'Remote sources: Wikipedia, arXiv, and Semantic Scholar.',
   };
 
   Future<void> _runDeepResearch(

--- a/packages/feature_mind/lib/src/agent_chat/presentation/screens/chat_screen.dart
+++ b/packages/feature_mind/lib/src/agent_chat/presentation/screens/chat_screen.dart
@@ -2139,11 +2139,12 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
 
   String _privacyDescription(PrivacyProfile profile) => switch (profile) {
     PrivacyProfile.private =>
-      'On-device plus Wikipedia and optional self-hosted SearXNG.',
+      'On-device orchestration with Wikipedia. '
+          'Self-hosted SearXNG is used when configured.',
     PrivacyProfile.balanced =>
       'Wikipedia, arXiv, and Semantic Scholar with local orchestration.',
     PrivacyProfile.cloud =>
-      'Remote allowlisted APIs: arXiv and Semantic Scholar.',
+      'Remote allowlisted sources: Wikipedia, arXiv, and Semantic Scholar.',
   };
 
   Future<void> _runDeepResearch(

--- a/packages/feature_mind/test/agent_chat/domain/services/research/research_checkpoint_log_test.dart
+++ b/packages/feature_mind/test/agent_chat/domain/services/research/research_checkpoint_log_test.dart
@@ -75,4 +75,34 @@ void main() {
     expect(latest?.question, 'What is Qwen?');
     expect(latest?.completedNodeIds, ['root']);
   });
+
+  test(
+    'newest terminal checkpoint hides older paused state for that job',
+    () async {
+      final log = RecordingOperationLog();
+      await appendResearchCheckpointOp(
+        log: log,
+        checkpoint: const ResearchCheckpoint(
+          jobId: 'job-finished',
+          question: 'Finished question',
+          state: ResearchPhase.paused,
+          pausedFrom: ResearchPhase.searching,
+          searchesUsed: 1,
+          iterationsUsed: 1,
+        ),
+      );
+      await appendResearchCheckpointOp(
+        log: log,
+        checkpoint: const ResearchCheckpoint(
+          jobId: 'job-finished',
+          question: 'Finished question',
+          state: ResearchPhase.completed,
+          searchesUsed: 2,
+          iterationsUsed: 1,
+        ),
+      );
+
+      expect(await latestResumableResearchCheckpoint(log), isNull);
+    },
+  );
 }

--- a/packages/feature_mind/test/agent_chat/domain/services/research/research_checkpoint_test.dart
+++ b/packages/feature_mind/test/agent_chat/domain/services/research/research_checkpoint_test.dart
@@ -30,14 +30,14 @@ void main() {
     },
   );
 
-  test('legacy v1 checkpoint fails closed as deep Private research', () {
+  test('legacy v1 checkpoint fails closed as deep local-only research', () {
     final restored = ResearchCheckpoint.fromRecord(
       'v1\u{1f}job-1\u{1f}Legacy\u{1f}paused\u{1f}searching'
       '\u{1f}2\u{1f}1\u{1f}n1',
     );
 
     expect(restored.mode, ResearchMode.deep);
-    expect(restored.policy, SearchPolicy.privacyFirst);
+    expect(restored.policy, SearchPolicy.localOnly);
     expect(restored.privacy, PrivacyProfile.private);
   });
 }

--- a/packages/feature_mind/test/agent_chat/domain/services/research/research_checkpoint_test.dart
+++ b/packages/feature_mind/test/agent_chat/domain/services/research/research_checkpoint_test.dart
@@ -1,24 +1,43 @@
 import 'package:feature_mind/src/agent_chat/domain/models/research_event.dart';
+import 'package:feature_mind/src/agent_chat/domain/models/research_request.dart';
 import 'package:feature_mind/src/agent_chat/domain/services/research/research_checkpoint.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
-  test('checkpoint record matches the rust v1 operation-log payload', () {
-    const checkpoint = ResearchCheckpoint(
-      jobId: 'job-1',
-      question: 'Pixel 9 offline LLM',
-      state: ResearchPhase.paused,
-      pausedFrom: ResearchPhase.analyzing,
-      searchesUsed: 2,
-      iterationsUsed: 1,
-      completedNodeIds: ['n1', 'n2'],
+  test(
+    'checkpoint record preserves mode and privacy policy across restart',
+    () {
+      const checkpoint = ResearchCheckpoint(
+        jobId: 'job-1',
+        question: 'Pixel 9 offline LLM',
+        state: ResearchPhase.paused,
+        pausedFrom: ResearchPhase.analyzing,
+        searchesUsed: 2,
+        iterationsUsed: 1,
+        completedNodeIds: ['n1', 'n2'],
+        mode: ResearchMode.quick,
+        policy: SearchPolicy.privacyFirst,
+      );
+
+      final restored = ResearchCheckpoint.fromRecord(checkpoint.toRecord());
+      expect(restored, checkpoint);
+      expect(
+        checkpoint.toRecord(),
+        'v2\u{1f}job-1\u{1f}Pixel 9 offline LLM\u{1f}paused\u{1f}analyzing'
+        '\u{1f}2\u{1f}1\u{1f}n1,n2\u{1f}quick\u{1f}privacy_first',
+      );
+      expect(restored.privacy, PrivacyProfile.private);
+    },
+  );
+
+  test('legacy v1 checkpoint decodes as deep Balanced research', () {
+    final restored = ResearchCheckpoint.fromRecord(
+      'v1\u{1f}job-1\u{1f}Legacy\u{1f}paused\u{1f}searching'
+      '\u{1f}2\u{1f}1\u{1f}n1',
     );
 
-    final restored = ResearchCheckpoint.fromRecord(checkpoint.toRecord());
-    expect(restored, checkpoint);
-    expect(
-      checkpoint.toRecord(),
-      'v1\u{1f}job-1\u{1f}Pixel 9 offline LLM\u{1f}paused\u{1f}analyzing\u{1f}2\u{1f}1\u{1f}n1,n2',
-    );
+    expect(restored.mode, ResearchMode.deep);
+    expect(restored.policy, SearchPolicy.balanced);
+    expect(restored.privacy, PrivacyProfile.balanced);
   });
 }

--- a/packages/feature_mind/test/agent_chat/domain/services/research/research_checkpoint_test.dart
+++ b/packages/feature_mind/test/agent_chat/domain/services/research/research_checkpoint_test.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:feature_mind/src/agent_chat/domain/models/research_event.dart';
 import 'package:feature_mind/src/agent_chat/domain/models/research_request.dart';
 import 'package:feature_mind/src/agent_chat/domain/services/research/research_checkpoint.dart';
@@ -30,14 +32,40 @@ void main() {
     },
   );
 
-  test('legacy v1 checkpoint fails closed as deep local-only research', () {
+  test('legacy v1 checkpoint fails closed as quick local-only research', () {
     final restored = ResearchCheckpoint.fromRecord(
       'v1\u{1f}job-1\u{1f}Legacy\u{1f}paused\u{1f}searching'
       '\u{1f}2\u{1f}1\u{1f}n1',
     );
 
-    expect(restored.mode, ResearchMode.deep);
+    expect(restored.mode, ResearchMode.quick);
     expect(restored.policy, SearchPolicy.localOnly);
     expect(restored.privacy, PrivacyProfile.private);
+  });
+
+  test('Dart decoder matches shared valid and corrupt fixtures', () {
+    final lines = File('../../test_fixtures/research_checkpoint_records.txt')
+        .readAsLinesSync()
+        .where((line) => line.isNotEmpty && !line.startsWith('#'));
+
+    for (final line in lines) {
+      final parts = line.split('|');
+      final kind = parts[0];
+      final name = parts[1];
+      final record = parts.sublist(2).join('|').replaceAll(r'\x1f', '\u{1f}');
+      if (kind == 'valid') {
+        expect(
+          () => ResearchCheckpoint.fromRecord(record),
+          returnsNormally,
+          reason: name,
+        );
+      } else {
+        expect(
+          () => ResearchCheckpoint.fromRecord(record),
+          throwsFormatException,
+          reason: name,
+        );
+      }
+    }
   });
 }

--- a/packages/feature_mind/test/agent_chat/domain/services/research/research_checkpoint_test.dart
+++ b/packages/feature_mind/test/agent_chat/domain/services/research/research_checkpoint_test.dart
@@ -30,14 +30,14 @@ void main() {
     },
   );
 
-  test('legacy v1 checkpoint decodes as deep Balanced research', () {
+  test('legacy v1 checkpoint fails closed as deep Private research', () {
     final restored = ResearchCheckpoint.fromRecord(
       'v1\u{1f}job-1\u{1f}Legacy\u{1f}paused\u{1f}searching'
       '\u{1f}2\u{1f}1\u{1f}n1',
     );
 
     expect(restored.mode, ResearchMode.deep);
-    expect(restored.policy, SearchPolicy.balanced);
-    expect(restored.privacy, PrivacyProfile.balanced);
+    expect(restored.policy, SearchPolicy.privacyFirst);
+    expect(restored.privacy, PrivacyProfile.private);
   });
 }

--- a/packages/feature_mind/test/agent_chat/domain/services/research/research_orchestrator_test.dart
+++ b/packages/feature_mind/test/agent_chat/domain/services/research/research_orchestrator_test.dart
@@ -236,6 +236,36 @@ void main() {
       expect(events.last.detail, contains('wiki/Large_language_model'));
     },
   );
+
+  test(
+    'local-only policy stays authoritative for a restored Private UI',
+    () async {
+      var searches = 0;
+      final engine = ResearchOrchestrator(
+        engines: [
+          _CountingEngine(
+            id: 'wikipedia',
+            onSearch: () => searches++,
+            hitsFor: (_) => const [],
+          ),
+        ],
+      );
+
+      final events = await engine
+          .run(
+            const ResearchRequest(
+              question: 'Use only local research',
+              mode: ResearchMode.quick,
+              policy: SearchPolicy.localOnly,
+              privacy: PrivacyProfile.private,
+            ),
+          )
+          .toList();
+
+      expect(events.last.kind, ResearchEventKind.researchCompleted);
+      expect(searches, 0);
+    },
+  );
 }
 
 String _article({required String title, required String paragraph}) {

--- a/packages/feature_mind/test/agent_chat/presentation/screens/chat_screen_deep_research_test.dart
+++ b/packages/feature_mind/test/agent_chat/presentation/screens/chat_screen_deep_research_test.dart
@@ -1,6 +1,4 @@
-import 'package:core_ai/core_ai.dart';
 import 'package:feature_mind/src/agent_chat/application/assistant_model_preferences.dart';
-import 'package:feature_mind/src/agent_chat/domain/models/agent_skill.dart';
 import 'package:feature_mind/src/agent_chat/domain/models/assistant_runtime_ids.dart';
 import 'package:feature_mind/src/agent_chat/domain/models/research_event.dart';
 import 'package:feature_mind/src/agent_chat/domain/models/research_request.dart';

--- a/packages/feature_mind/test/agent_chat/presentation/screens/chat_screen_deep_research_test.dart
+++ b/packages/feature_mind/test/agent_chat/presentation/screens/chat_screen_deep_research_test.dart
@@ -95,10 +95,17 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(engine.request?.privacy, PrivacyProfile.private);
+    expect(engine.request?.policy, SearchPolicy.privacyFirst);
     expect(
       engine.request!.privacy.engineIds,
       isNot(contains('semantic_scholar')),
     );
+    final semantics = tester
+        .getSemantics(
+          find.byKey(const Key('agent_chat_research_privacy_private')),
+        )
+        .getSemanticsData();
+    expect(semantics.hint, contains('Self-hosted SearXNG'));
   });
 
   testWidgets('Cloud copy names every currently routed remote source', (
@@ -218,6 +225,52 @@ void main() {
       findsOneWidget,
     );
   });
+
+  testWidgets('resumes a Private checkpoint without widening its policy', (
+    tester,
+  ) async {
+    final log = RecordingOperationLog();
+    await appendResearchCheckpointOp(
+      log: log,
+      checkpoint: const ResearchCheckpoint(
+        jobId: 'job-private',
+        question: 'What is Qwen?',
+        state: ResearchPhase.paused,
+        pausedFrom: ResearchPhase.searching,
+        searchesUsed: 1,
+        iterationsUsed: 1,
+        completedNodeIds: ['root'],
+        policy: SearchPolicy.privacyFirst,
+      ),
+    );
+    final engine = _RecordingLibraryEngine();
+
+    await _pumpChatScreen(
+      tester,
+      operationLogPort: log,
+      deepResearchEngine: engine,
+    );
+    await tester.tap(find.byKey(const Key('agent_chat_deep_research_resume')));
+    await tester.pumpAndSettle();
+
+    expect(engine.request?.privacy, PrivacyProfile.private);
+    expect(engine.request?.policy, SearchPolicy.privacyFirst);
+  });
+
+  testWidgets('privacy controls leave a usable input at 320px', (tester) async {
+    await _pumpChatScreen(tester, physicalSize: const Size(320, 1000));
+    expect(tester.takeException(), isNull);
+
+    await tester.tap(find.byKey(const Key('agent_chat_deep_research_button')));
+    await tester.pump();
+
+    expect(find.text('Research privacy'), findsOneWidget);
+    expect(
+      tester.getSize(find.byKey(const Key('agent_chat_input'))).width,
+      greaterThanOrEqualTo(200),
+    );
+    expect(tester.takeException(), isNull);
+  });
 }
 
 class _RecordingLibraryEngine implements DeepResearchEngine {
@@ -294,9 +347,10 @@ Future<void> _pumpChatScreen(
   WidgetTester tester, {
   OperationLogPort? operationLogPort,
   DeepResearchEngine? deepResearchEngine,
+  Size physicalSize = const Size(1200, 1000),
 }) async {
   tester.view.devicePixelRatio = 1.0;
-  tester.view.physicalSize = const Size(1200, 1000);
+  tester.view.physicalSize = physicalSize;
   addTearDown(() {
     tester.view.resetDevicePixelRatio();
     tester.view.resetPhysicalSize();

--- a/packages/feature_mind/test/agent_chat/presentation/screens/chat_screen_deep_research_test.dart
+++ b/packages/feature_mind/test/agent_chat/presentation/screens/chat_screen_deep_research_test.dart
@@ -79,7 +79,10 @@ void main() {
     );
     await tester.pump();
     expect(
-      find.text('On-device plus Wikipedia and optional self-hosted SearXNG.'),
+      find.text(
+        'On-device orchestration with Wikipedia. '
+        'Self-hosted SearXNG is used when configured.',
+      ),
       findsOneWidget,
     );
 
@@ -95,6 +98,26 @@ void main() {
     expect(
       engine.request!.privacy.engineIds,
       isNot(contains('semantic_scholar')),
+    );
+  });
+
+  testWidgets('Cloud copy names every currently routed remote source', (
+    tester,
+  ) async {
+    await _pumpChatScreen(tester);
+
+    await tester.tap(find.byKey(const Key('agent_chat_deep_research_button')));
+    await tester.pump();
+    await tester.tap(
+      find.byKey(const Key('agent_chat_research_privacy_cloud')),
+    );
+    await tester.pump();
+
+    expect(
+      find.text(
+        'Remote allowlisted sources: Wikipedia, arXiv, and Semantic Scholar.',
+      ),
+      findsOneWidget,
     );
   });
 

--- a/packages/feature_mind/test/agent_chat/presentation/screens/chat_screen_deep_research_test.dart
+++ b/packages/feature_mind/test/agent_chat/presentation/screens/chat_screen_deep_research_test.dart
@@ -78,8 +78,8 @@ void main() {
     await tester.pump();
     expect(
       find.text(
-        'On-device orchestration with Wikipedia. '
-        'Self-hosted SearXNG is used when configured.',
+        'Private routing currently uses Wikipedia only. '
+        'Self-hosted SearXNG support is not configured yet.',
       ),
       findsOneWidget,
     );
@@ -106,9 +106,7 @@ void main() {
     expect(semantics.hint, contains('Self-hosted SearXNG'));
   });
 
-  testWidgets('Cloud copy names every currently routed remote source', (
-    tester,
-  ) async {
+  testWidgets('Cloud copy names every currently routed source', (tester) async {
     await _pumpChatScreen(tester);
 
     await tester.tap(find.byKey(const Key('agent_chat_deep_research_button')));
@@ -119,9 +117,7 @@ void main() {
     await tester.pump();
 
     expect(
-      find.text(
-        'Remote allowlisted sources: Wikipedia, arXiv, and Semantic Scholar.',
-      ),
+      find.text('Remote sources: Wikipedia, arXiv, and Semantic Scholar.'),
       findsOneWidget,
     );
   });
@@ -248,6 +244,31 @@ void main() {
       operationLogPort: log,
       deepResearchEngine: engine,
     );
+    expect(
+      tester
+          .widget<ChoiceChip>(
+            find.byKey(const Key('agent_chat_research_privacy_private')),
+          )
+          .selected,
+      isTrue,
+    );
+    expect(
+      tester
+          .widget<ChoiceChip>(
+            find.byKey(const Key('agent_chat_research_privacy_balanced')),
+          )
+          .selected,
+      isFalse,
+    );
+    expect(
+      find.text(
+        'Private routing currently uses Wikipedia only. '
+        'Self-hosted SearXNG support is not configured yet.',
+      ),
+      findsOneWidget,
+    );
+    expect(engine.request, isNull);
+
     await tester.tap(find.byKey(const Key('agent_chat_deep_research_resume')));
     await tester.pumpAndSettle();
 

--- a/packages/feature_mind/test/agent_chat/presentation/screens/chat_screen_deep_research_test.dart
+++ b/packages/feature_mind/test/agent_chat/presentation/screens/chat_screen_deep_research_test.dart
@@ -255,6 +255,14 @@ void main() {
     expect(
       tester
           .widget<ChoiceChip>(
+            find.byKey(const Key('agent_chat_research_privacy_private')),
+          )
+          .onSelected,
+      isNull,
+    );
+    expect(
+      tester
+          .widget<ChoiceChip>(
             find.byKey(const Key('agent_chat_research_privacy_balanced')),
           )
           .selected,
@@ -274,6 +282,35 @@ void main() {
 
     expect(engine.request?.privacy, PrivacyProfile.private);
     expect(engine.request?.policy, SearchPolicy.privacyFirst);
+  });
+
+  testWidgets('resumed local-only checkpoint performs no policy widening', (
+    tester,
+  ) async {
+    final log = RecordingOperationLog();
+    await appendResearchCheckpointOp(
+      log: log,
+      checkpoint: const ResearchCheckpoint(
+        jobId: 'job-local-only',
+        question: 'Use only local research',
+        state: ResearchPhase.paused,
+        pausedFrom: ResearchPhase.searching,
+        searchesUsed: 0,
+        iterationsUsed: 0,
+        policy: SearchPolicy.localOnly,
+      ),
+    );
+    final engine = _RecordingLibraryEngine();
+
+    await _pumpChatScreen(
+      tester,
+      operationLogPort: log,
+      deepResearchEngine: engine,
+    );
+    await tester.tap(find.byKey(const Key('agent_chat_deep_research_resume')));
+    await tester.pumpAndSettle();
+
+    expect(engine.request?.policy, SearchPolicy.localOnly);
   });
 
   testWidgets('privacy controls leave a usable input at 320px', (tester) async {

--- a/packages/feature_mind/test/agent_chat/presentation/screens/chat_screen_deep_research_test.dart
+++ b/packages/feature_mind/test/agent_chat/presentation/screens/chat_screen_deep_research_test.dart
@@ -307,6 +307,10 @@ void main() {
       operationLogPort: log,
       deepResearchEngine: engine,
     );
+    expect(
+      find.text('Restored local-only job: no remote sources.'),
+      findsOneWidget,
+    );
     await tester.tap(find.byKey(const Key('agent_chat_deep_research_resume')));
     await tester.pumpAndSettle();
 

--- a/packages/feature_mind/test/agent_chat/presentation/screens/chat_screen_deep_research_test.dart
+++ b/packages/feature_mind/test/agent_chat/presentation/screens/chat_screen_deep_research_test.dart
@@ -311,6 +311,13 @@ void main() {
       find.text('Restored local-only job: no remote sources.'),
       findsOneWidget,
     );
+    final privateSemantics = tester
+        .getSemantics(
+          find.byKey(const Key('agent_chat_research_privacy_private')),
+        )
+        .getSemanticsData();
+    expect(privateSemantics.hint, contains('no remote sources'));
+    expect(privateSemantics.hint, isNot(contains('Wikipedia')));
     await tester.tap(find.byKey(const Key('agent_chat_deep_research_resume')));
     await tester.pumpAndSettle();
 

--- a/rust/airo_mind_core/src/research/request.rs
+++ b/rust/airo_mind_core/src/research/request.rs
@@ -9,6 +9,27 @@ pub enum ResearchMode {
     Exhaustive,
 }
 
+impl ResearchMode {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Quick => "quick",
+            Self::Standard => "standard",
+            Self::Deep => "deep",
+            Self::Exhaustive => "exhaustive",
+        }
+    }
+
+    pub fn parse(value: &str) -> Option<Self> {
+        match value {
+            "quick" => Some(Self::Quick),
+            "standard" => Some(Self::Standard),
+            "deep" => Some(Self::Deep),
+            "exhaustive" => Some(Self::Exhaustive),
+            _ => None,
+        }
+    }
+}
+
 /// Which search providers a job may use. The model does not pick this.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum SearchPolicy {
@@ -17,6 +38,29 @@ pub enum SearchPolicy {
     Balanced,
     MaximumQuality,
     Academic,
+}
+
+impl SearchPolicy {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::LocalOnly => "local_only",
+            Self::PrivacyFirst => "privacy_first",
+            Self::Balanced => "balanced",
+            Self::MaximumQuality => "maximum_quality",
+            Self::Academic => "academic",
+        }
+    }
+
+    pub fn parse(value: &str) -> Option<Self> {
+        match value {
+            "local_only" => Some(Self::LocalOnly),
+            "privacy_first" => Some(Self::PrivacyFirst),
+            "balanced" => Some(Self::Balanced),
+            "maximum_quality" => Some(Self::MaximumQuality),
+            "academic" => Some(Self::Academic),
+            _ => None,
+        }
+    }
 }
 
 /// Hard caps for one research job. Sufficiency can stop the job earlier.

--- a/rust/airo_mind_core/src/research/state.rs
+++ b/rust/airo_mind_core/src/research/state.rs
@@ -290,7 +290,7 @@ impl ResearchCheckpoint {
                 ResearchMode::parse(parts[8]).ok_or(ResearchStateError::InvalidCheckpoint)?
             },
             policy: if legacy {
-                SearchPolicy::Balanced
+                SearchPolicy::PrivacyFirst
             } else {
                 SearchPolicy::parse(parts[9]).ok_or(ResearchStateError::InvalidCheckpoint)?
             },
@@ -457,13 +457,13 @@ mod tests {
     }
 
     #[test]
-    fn legacy_v1_checkpoint_defaults_to_deep_balanced() {
+    fn legacy_v1_checkpoint_fails_closed_to_deep_private() {
         let restored = ResearchCheckpoint::from_record(
             "v1\u{1f}job-1\u{1f}Legacy\u{1f}paused\u{1f}searching\u{1f}2\u{1f}1\u{1f}n1",
         )
         .unwrap();
         assert_eq!(restored.mode, ResearchMode::Deep);
-        assert_eq!(restored.policy, SearchPolicy::Balanced);
+        assert_eq!(restored.policy, SearchPolicy::PrivacyFirst);
     }
 
     #[test]

--- a/rust/airo_mind_core/src/research/state.rs
+++ b/rust/airo_mind_core/src/research/state.rs
@@ -290,7 +290,7 @@ impl ResearchCheckpoint {
                 ResearchMode::parse(parts[8]).ok_or(ResearchStateError::InvalidCheckpoint)?
             },
             policy: if legacy {
-                SearchPolicy::PrivacyFirst
+                SearchPolicy::LocalOnly
             } else {
                 SearchPolicy::parse(parts[9]).ok_or(ResearchStateError::InvalidCheckpoint)?
             },
@@ -457,13 +457,13 @@ mod tests {
     }
 
     #[test]
-    fn legacy_v1_checkpoint_fails_closed_to_deep_private() {
+    fn legacy_v1_checkpoint_fails_closed_to_deep_local_only() {
         let restored = ResearchCheckpoint::from_record(
             "v1\u{1f}job-1\u{1f}Legacy\u{1f}paused\u{1f}searching\u{1f}2\u{1f}1\u{1f}n1",
         )
         .unwrap();
         assert_eq!(restored.mode, ResearchMode::Deep);
-        assert_eq!(restored.policy, SearchPolicy::PrivacyFirst);
+        assert_eq!(restored.policy, SearchPolicy::LocalOnly);
     }
 
     #[test]

--- a/rust/airo_mind_core/src/research/state.rs
+++ b/rust/airo_mind_core/src/research/state.rs
@@ -285,7 +285,7 @@ impl ResearchCheckpoint {
                 parts[7].split(',').map(str::to_string).collect()
             },
             mode: if legacy {
-                ResearchMode::Deep
+                ResearchMode::Quick
             } else {
                 ResearchMode::parse(parts[8]).ok_or(ResearchStateError::InvalidCheckpoint)?
             },
@@ -324,8 +324,13 @@ impl InMemoryResearchService {
     }
 
     pub fn start(&mut self, request: ResearchRequest) -> String {
-        self.next_id = self.next_id.saturating_add(1);
-        let id = format!("job-{}", self.next_id);
+        let id = loop {
+            self.next_id = self.next_id.saturating_add(1);
+            let candidate = format!("job-{}", self.next_id);
+            if !self.jobs.contains_key(&candidate) {
+                break candidate;
+            }
+        };
         self.jobs
             .insert(id.clone(), (ResearchJob::new(request), Vec::new()));
         id
@@ -370,6 +375,12 @@ impl InMemoryResearchService {
 
     pub fn restore(&mut self, checkpoint: ResearchCheckpoint) -> Result<(), ResearchStateError> {
         let id = checkpoint.job_id.clone();
+        if let Some(sequence) = id
+            .strip_prefix("job-")
+            .and_then(|value| value.parse::<u64>().ok())
+        {
+            self.next_id = self.next_id.max(sequence);
+        }
         let nodes = checkpoint.completed_node_ids.clone();
         self.jobs.insert(id, (checkpoint.into_job(), nodes));
         Ok(())
@@ -457,13 +468,33 @@ mod tests {
     }
 
     #[test]
-    fn legacy_v1_checkpoint_fails_closed_to_deep_local_only() {
+    fn legacy_v1_checkpoint_fails_closed_to_quick_local_only() {
         let restored = ResearchCheckpoint::from_record(
             "v1\u{1f}job-1\u{1f}Legacy\u{1f}paused\u{1f}searching\u{1f}2\u{1f}1\u{1f}n1",
         )
         .unwrap();
-        assert_eq!(restored.mode, ResearchMode::Deep);
+        assert_eq!(restored.mode, ResearchMode::Quick);
         assert_eq!(restored.policy, SearchPolicy::LocalOnly);
+    }
+
+    #[test]
+    fn rust_decoder_matches_shared_valid_and_corrupt_fixtures() {
+        let fixtures = include_str!("../../../../test_fixtures/research_checkpoint_records.txt");
+        for line in fixtures
+            .lines()
+            .filter(|line| !line.is_empty() && !line.starts_with('#'))
+        {
+            let mut parts = line.splitn(3, '|');
+            let kind = parts.next().unwrap();
+            let name = parts.next().unwrap();
+            let record = parts.next().unwrap().replace("\\x1f", "\u{1f}");
+            let parsed = ResearchCheckpoint::from_record(&record);
+            match kind {
+                "valid" => assert!(parsed.is_ok(), "{name} must be accepted"),
+                "invalid" => assert!(parsed.is_err(), "{name} must be rejected"),
+                other => panic!("unknown fixture kind {other}"),
+            }
+        }
     }
 
     #[test]
@@ -489,5 +520,28 @@ mod tests {
         assert_eq!(revived.job(&id).unwrap().request.mode, ResearchMode::Quick);
         revived.resume(&id).unwrap();
         assert_eq!(revived.status(&id), Some(ResearchJobState::Planning));
+    }
+
+    #[test]
+    fn restored_job_id_is_not_reused_by_the_next_start() {
+        let restored = ResearchCheckpoint {
+            job_id: "job-1".into(),
+            question: "Restored".into(),
+            state: ResearchJobState::Paused,
+            paused_from: Some(ResearchJobState::Searching),
+            searches_used: 0,
+            iterations_used: 0,
+            completed_node_ids: Vec::new(),
+            mode: ResearchMode::Quick,
+            policy: SearchPolicy::LocalOnly,
+        };
+        let mut service = InMemoryResearchService::new();
+        service.restore(restored).unwrap();
+
+        let next = service.start(ResearchRequest::new("New"));
+
+        assert_eq!(next, "job-2");
+        assert!(service.job("job-1").is_some());
+        assert!(service.job("job-2").is_some());
     }
 }

--- a/rust/airo_mind_core/src/research/state.rs
+++ b/rust/airo_mind_core/src/research/state.rs
@@ -1,6 +1,6 @@
 //! Explicit job state. Flutter reconnects to this, not to a model scratchpad.
 
-use super::request::ResearchRequest;
+use super::request::{ResearchMode, ResearchRequest, SearchPolicy};
 
 /// Where a research job is. Long-running: the UI must be able to reattach.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -216,6 +216,8 @@ pub struct ResearchCheckpoint {
     pub searches_used: u32,
     pub iterations_used: u32,
     pub completed_node_ids: Vec<String>,
+    pub mode: ResearchMode,
+    pub policy: SearchPolicy,
 }
 
 impl ResearchCheckpoint {
@@ -232,12 +234,14 @@ impl ResearchCheckpoint {
             searches_used: job.searches_used,
             iterations_used: job.iterations_used,
             completed_node_ids,
+            mode: job.request.mode,
+            policy: job.request.policy,
         }
     }
 
     pub fn to_record(&self) -> String {
         format!(
-            "v1\u{1f}{}\u{1f}{}\u{1f}{}\u{1f}{}\u{1f}{}\u{1f}{}\u{1f}{}",
+            "v2\u{1f}{}\u{1f}{}\u{1f}{}\u{1f}{}\u{1f}{}\u{1f}{}\u{1f}{}\u{1f}{}\u{1f}{}",
             self.job_id,
             self.question.replace('\u{1f}', " "),
             self.state.as_str(),
@@ -245,12 +249,16 @@ impl ResearchCheckpoint {
             self.searches_used,
             self.iterations_used,
             self.completed_node_ids.join(","),
+            self.mode.as_str(),
+            self.policy.as_str(),
         )
     }
 
     pub fn from_record(record: &str) -> Result<Self, ResearchStateError> {
         let parts: Vec<&str> = record.split('\u{1f}').collect();
-        if parts.len() != 8 || parts[0] != "v1" {
+        let legacy = parts.len() == 8 && parts[0] == "v1";
+        let current = parts.len() == 10 && parts[0] == "v2";
+        if !legacy && !current {
             return Err(ResearchStateError::InvalidCheckpoint);
         }
         let state =
@@ -276,12 +284,25 @@ impl ResearchCheckpoint {
             } else {
                 parts[7].split(',').map(str::to_string).collect()
             },
+            mode: if legacy {
+                ResearchMode::Deep
+            } else {
+                ResearchMode::parse(parts[8]).ok_or(ResearchStateError::InvalidCheckpoint)?
+            },
+            policy: if legacy {
+                SearchPolicy::Balanced
+            } else {
+                SearchPolicy::parse(parts[9]).ok_or(ResearchStateError::InvalidCheckpoint)?
+            },
         })
     }
 
     pub fn into_job(self) -> ResearchJob {
+        let mut request = ResearchRequest::new(self.question);
+        request.mode = self.mode;
+        request.policy = self.policy;
         ResearchJob {
-            request: ResearchRequest::new(self.question),
+            request,
             state: self.state,
             paused_from: self.paused_from,
             searches_used: self.searches_used,
@@ -358,7 +379,6 @@ impl InMemoryResearchService {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::research::request::ResearchRequest;
 
     #[test]
     fn the_quality_loop_can_return_to_search_from_gaps() {
@@ -428,6 +448,8 @@ mod tests {
             searches_used: 2,
             iterations_used: 1,
             completed_node_ids: vec!["n1".into(), "n2".into()],
+            mode: ResearchMode::Quick,
+            policy: SearchPolicy::PrivacyFirst,
         };
         let restored = ResearchCheckpoint::from_record(&checkpoint.to_record())
             .expect("checkpoint record must roundtrip");
@@ -435,9 +457,22 @@ mod tests {
     }
 
     #[test]
+    fn legacy_v1_checkpoint_defaults_to_deep_balanced() {
+        let restored = ResearchCheckpoint::from_record(
+            "v1\u{1f}job-1\u{1f}Legacy\u{1f}paused\u{1f}searching\u{1f}2\u{1f}1\u{1f}n1",
+        )
+        .unwrap();
+        assert_eq!(restored.mode, ResearchMode::Deep);
+        assert_eq!(restored.policy, SearchPolicy::Balanced);
+    }
+
+    #[test]
     fn restore_rebuilds_the_job_after_process_death() {
         let mut live = InMemoryResearchService::new();
-        let id = live.start(ResearchRequest::new("Pixel 9 offline LLM"));
+        let mut request = ResearchRequest::new("Pixel 9 offline LLM");
+        request.mode = ResearchMode::Quick;
+        request.policy = SearchPolicy::PrivacyFirst;
+        let id = live.start(request);
         live.apply(&id, ResearchCommand::StartPlanning).unwrap();
         live.pause(&id).unwrap();
         let record = live.checkpoint(&id).unwrap().to_record();
@@ -447,6 +482,11 @@ mod tests {
             .restore(ResearchCheckpoint::from_record(&record).unwrap())
             .unwrap();
         assert_eq!(revived.status(&id), Some(ResearchJobState::Paused));
+        assert_eq!(
+            revived.job(&id).unwrap().request.policy,
+            SearchPolicy::PrivacyFirst
+        );
+        assert_eq!(revived.job(&id).unwrap().request.mode, ResearchMode::Quick);
         revived.resume(&id).unwrap();
         assert_eq!(revived.status(&id), Some(ResearchJobState::Planning));
     }

--- a/test_fixtures/research_checkpoint_records.txt
+++ b/test_fixtures/research_checkpoint_records.txt
@@ -1,0 +1,5 @@
+# kind|name|record, with \x1f representing the operation-log field separator
+valid|v2-private|v2\x1fjob-1\x1fPixel 9 offline LLM\x1fpaused\x1fsearching\x1f2\x1f1\x1fn1,n2\x1fquick\x1fprivacy_first
+invalid|invalid-paused-phase|v2\x1fjob-1\x1fQuestion\x1fpaused\x1fnot_a_phase\x1f2\x1f1\x1fn1\x1fquick\x1fprivacy_first
+invalid|negative-search-count|v2\x1fjob-1\x1fQuestion\x1fpaused\x1fsearching\x1f-1\x1f1\x1fn1\x1fquick\x1fprivacy_first
+invalid|overflow-search-count|v2\x1fjob-1\x1fQuestion\x1fpaused\x1fsearching\x1f4294967296\x1f1\x1fn1\x1fquick\x1fprivacy_first


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Version Deep Research checkpoints to `v2`; ambiguous `v1` records fail closed as Quick/LocalOnly (zero remote engines).
- Align Dart/Rust decoding with shared valid/corrupt fixtures, strict paused-state/u32 validation, and documented bridge DTO/API compatibility.
- Prevent terminal-log replay from resurrecting older paused checkpoints and prevent restored `job-N` ID reuse.
- Restore/lock selected privacy before Resume, make `SearchPolicy` authoritative, support 320px Chat, and update source copy/docs.

Safety follow-up to prematurely merged #1860. No SearXNG adapter/configuration is claimed; that remains Task 3.

## Test Plan
- [x] `cargo fmt --check`
- [x] `cargo test -p airo_mind_core --lib research` — 48 passed at `38abe039`
- [x] Full Flutter Deep Research domain/service/widget suite — 76 passed at `38abe039`
- [x] Shared fixture covers valid v2, invalid paused phase, negative counter, and u32 overflow in both languages
- [x] Replay, restored-ID, zero-network legacy/local-only, Private restart, semantics, and 320px regressions
- [x] Host-only; no emulator/device required

**Verification environment:** Host-only

## Agent Policy
- [x] Operation-log durability remains the only persistence path.
- [x] Dart/Rust schemas and decoder validity rules match.
- [x] v1 fallback is Quick/LocalOnly fail-closed.
- [x] Android Emulator was not used.

## Council Review
Review session is linked by the PR footer metadata.

- Product Manager: approved at merge-ready `a5d9dd12`.
- Flutter Architect: approved; 320px layout, state, semantics, and routing verified.
- Chief Architect: approved at `0b755266`.
- Chief QA Officer: approved at `0b755266`.
- Chief Security Officer: approved; final local-only fallback is stricter than reviewed baseline.
- Chief Performance Officer: approved at merge-ready `a5d9dd12`.
- Chief UX Officer: approved at `1bc1113f`.
- Chief Documentation Officer: approved; size/review evidence included.
- Chief Open Source Officer: approved; no dependency/vendored/asset/license impact.
- Rust Architect and Platform Architect requested stricter legacy/decoder/replay/ID handling; fixed in `7f531211` and `38abe039`, exact-head re-review requested.

## User-Facing Documentation
- [x] Updated public AI/model wiki and locked Deep Research spec.
- [x] Documented public Rust checkpoint-struct migration and required versioned FRB DTO.

## Plugin and Size Impact
- [x] No dependency, plugin, asset, or vendored code changes.
- [x] `feature_mind` is 2.40 MB and remains bundled because it owns Airo Mind/Chat; this safety-only source/test/docs change cannot be split without breaking the core journey and adds no material size.

## Checklist
- [x] Code is formatted.
- [x] Tests included above.
- [x] Sensitive data, credentials, and signing artifacts are not committed.

## Release Notes
- [x] Paused research preserves exact routing after restart; legacy checkpoints restore with zero remote sources, corrupt checkpoints are rejected consistently, and terminal jobs stay terminal.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0d1a1368-352c-43c3-b66e-d4ae3a878dd5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0d1a1368-352c-43c3-b66e-d4ae3a878dd5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

