### PR TITLE
feat(mind): add configured SearXNG search adapter

### DIFF
--- a/docs/superpowers/specs/2026-08-22-airo-deep-research-engine-design.md
+++ b/docs/superpowers/specs/2026-08-22-airo-deep-research-engine-design.md
@@ -101,12 +101,14 @@ Shipped as **contracts and a thin live slice**, not the full production engine:
 17. Operation-log research library, incremental URL delta, cited comparison
     matrix, and contested-row decisions.
 18. User-facing Private / Balanced / Cloud profiles, observability metrics,
-    and abstract cost ceilings. Private currently routes to Wikipedia only;
-    the SearXNG adapter and configuration support are not implemented.
+    and abstract cost ceilings. Private routes to Wikipedia by default and can
+    use the SearXNG adapter only when the host injects an explicit self-hosted
+    HTTPS base URI. Airo has no default/public SearXNG endpoint.
 
 Not shipped (locked below, do not pretend they exist):
 
-- Google / Bing / Brave / DuckDuckGo / SearXNG HTTP / Tavily / PubMed / GitHub / news APIs
+- Google / Bing / Brave / DuckDuckGo / Tavily / PubMed / GitHub / news APIs
+- SearXNG endpoint settings UI and persisted endpoint configuration
 - HTML/PDF tables-from-scanned-pages, PDF binary extraction
 - Claim-level citation validation, contradiction explanations, confidence scores
 - HTTP cache, automatic continuation without user reattachment, `ResearchService` FFI

--- a/docs/wiki/5.-AI-and-Model-Management.md
+++ b/docs/wiki/5.-AI-and-Model-Management.md
@@ -37,8 +37,9 @@ gate.
 Turn on **Deep Research** in Chat to choose a privacy profile before sending a
 research question:
 
-- **Private** currently searches Wikipedia only. Self-hosted SearXNG support is
-  not configured yet.
+- **Private** searches Wikipedia by default. In development builds, the host can
+  inject an explicit self-hosted SearXNG HTTPS endpoint. Airo ships no public
+  SearXNG endpoint, and Chat does not yet provide endpoint settings.
 - **Balanced** uses Wikipedia, arXiv, and Semantic Scholar with local
   orchestration.
 - **Cloud** currently uses the same three remote sources as Balanced. It does

--- a/packages/feature_mind/lib/src/agent_chat/domain/services/research/research_http.dart
+++ b/packages/feature_mind/lib/src/agent_chat/domain/services/research/research_http.dart
@@ -16,6 +16,7 @@ class ResearchHttpClient {
     this.allowedHosts = defaultAllowedHosts,
     this.maxBytes = 256 * 1024,
     this.timeout = const Duration(seconds: 8),
+    this.maxRedirects = 3,
   });
 
   static const defaultAllowedHosts = {
@@ -29,6 +30,7 @@ class ResearchHttpClient {
   final Set<String> allowedHosts;
   final int maxBytes;
   final Duration timeout;
+  final int maxRedirects;
 
   void validate(Uri uri) {
     if (uri.scheme != 'https') {
@@ -48,20 +50,54 @@ class ResearchHttpClient {
     return _fetch(uri);
   }
 
+  Uri resolveRedirect(Uri from, String location) {
+    if (location.trim().isEmpty) {
+      throw const ResearchHttpException(
+        'Research redirect did not include a destination.',
+      );
+    }
+    final target = from.resolve(location);
+    validate(target);
+    return target;
+  }
+
   Future<String> _fetch(Uri uri) async {
     final client = HttpClient()..connectionTimeout = timeout;
     try {
-      final request = await client.getUrl(uri);
-      final response = await request.close().timeout(timeout);
-      final bytes = await response.fold<List<int>>(<int>[], (buffer, chunk) {
-        if (buffer.length + chunk.length > maxBytes) {
-          throw const ResearchHttpException(
-            'Research response exceeded size limit.',
+      var current = uri;
+      for (var redirects = 0; ; redirects++) {
+        final request = await client.getUrl(current);
+        request.followRedirects = false;
+        final response = await request.close().timeout(timeout);
+        if (response.isRedirect) {
+          if (redirects >= maxRedirects) {
+            await response.drain<void>();
+            throw const ResearchHttpException(
+              'Research response exceeded redirect limit.',
+            );
+          }
+          final location = response.headers.value(HttpHeaders.locationHeader);
+          await response.drain<void>();
+          current = resolveRedirect(current, location ?? '');
+          continue;
+        }
+        if (response.statusCode < HttpStatus.ok ||
+            response.statusCode >= HttpStatus.multipleChoices) {
+          await response.drain<void>();
+          throw ResearchHttpException(
+            'Research provider returned HTTP ${response.statusCode}.',
           );
         }
-        return buffer..addAll(chunk);
-      });
-      return utf8.decode(bytes);
+        final bytes = await response.fold<List<int>>(<int>[], (buffer, chunk) {
+          if (buffer.length + chunk.length > maxBytes) {
+            throw const ResearchHttpException(
+              'Research response exceeded size limit.',
+            );
+          }
+          return buffer..addAll(chunk);
+        });
+        return utf8.decode(bytes);
+      }
     } finally {
       client.close(force: true);
     }

--- a/packages/feature_mind/lib/src/agent_chat/domain/services/research/research_service.dart
+++ b/packages/feature_mind/lib/src/agent_chat/domain/services/research/research_service.dart
@@ -6,6 +6,7 @@ import 'research_control.dart';
 import 'research_http.dart';
 import 'research_library.dart';
 import 'research_orchestrator.dart';
+import 'searxng_search_engine.dart';
 import 'semantic_scholar_search_engine.dart';
 import 'source_manager.dart';
 import 'wikipedia_search_engine.dart';
@@ -30,21 +31,36 @@ abstract class ResearchService {
 /// orchestrator. Replaced by FFI once the llama `api` surface exposes
 /// `ResearchEngine`.
 class LocalResearchService implements ResearchService {
-  LocalResearchService({ResearchOrchestrator? orchestrator})
-    : _orchestrator =
-          orchestrator ??
-          ResearchOrchestrator(
-            engines: [
-              WikipediaSearchEngine(),
-              ArxivSearchEngine(),
-              SemanticScholarSearchEngine(),
-            ],
-            sourceManager: SourceManager(
-              fetcher: const ResearchHttpClient().get,
-            ),
-          );
+  factory LocalResearchService({
+    ResearchOrchestrator? orchestrator,
+    Uri? searxngBaseUri,
+  }) {
+    if (orchestrator != null && searxngBaseUri != null) {
+      throw ArgumentError(
+        'Inject either an orchestrator or a SearXNG base URI, not both.',
+      );
+    }
+    return LocalResearchService._(
+      orchestrator ?? _defaultOrchestrator(searxngBaseUri),
+    );
+  }
+
+  const LocalResearchService._(this._orchestrator);
 
   final ResearchOrchestrator _orchestrator;
+
+  static ResearchOrchestrator _defaultOrchestrator(Uri? searxngBaseUri) {
+    return ResearchOrchestrator(
+      engines: [
+        WikipediaSearchEngine(),
+        ArxivSearchEngine(),
+        SemanticScholarSearchEngine(),
+        if (searxngBaseUri != null)
+          SearxngSearchEngine(baseUri: searxngBaseUri),
+      ],
+      sourceManager: SourceManager(fetcher: const ResearchHttpClient().get),
+    );
+  }
 
   @override
   Stream<ResearchEvent> start(

--- a/packages/feature_mind/lib/src/agent_chat/domain/services/research/searxng_search_engine.dart
+++ b/packages/feature_mind/lib/src/agent_chat/domain/services/research/searxng_search_engine.dart
@@ -1,0 +1,110 @@
+import 'dart:convert';
+
+import 'package:core_workers/core_workers.dart';
+
+import 'research_http.dart';
+import 'research_search.dart';
+
+/// Search adapter for an explicitly configured self-hosted SearXNG instance.
+///
+/// SearXNG results are candidates, not evidence. The configured API host is
+/// added only to this adapter's HTTP allowlist; there is no default public host.
+class SearxngSearchEngine implements ResearchSearchEngine {
+  factory SearxngSearchEngine({
+    required Uri baseUri,
+    ResearchHttpClient? http,
+  }) {
+    if (baseUri.scheme != 'https' ||
+        baseUri.host.isEmpty ||
+        baseUri.hasQuery ||
+        baseUri.hasFragment ||
+        baseUri.userInfo.isNotEmpty) {
+      throw const ResearchHttpException(
+        'SearXNG requires an HTTPS base URI without credentials, query, or fragment.',
+      );
+    }
+    final client =
+        http ??
+        ResearchHttpClient(
+          allowedHosts: {
+            ...ResearchHttpClient.defaultAllowedHosts,
+            baseUri.host,
+          },
+        );
+    client.validate(baseUri);
+    return SearxngSearchEngine._(baseUri: baseUri, http: client);
+  }
+
+  const SearxngSearchEngine._({required this.baseUri, required this.http});
+
+  static const _offMainThreshold = 50 * 1024;
+
+  final Uri baseUri;
+  final ResearchHttpClient http;
+
+  @override
+  String get id => 'searxng';
+
+  static List<ResearchHit> parseSearchJson(String body) {
+    final decoded = jsonDecode(body);
+    if (decoded is! Map) {
+      return const [];
+    }
+    final results = decoded['results'];
+    if (results is! List) {
+      return const [];
+    }
+    final hits = <ResearchHit>[];
+    for (final row in results) {
+      if (row is! Map) {
+        continue;
+      }
+      final url = Uri.tryParse('${row['url'] ?? ''}'.trim());
+      final title = _stripHtml('${row['title'] ?? ''}');
+      if (url == null || url.scheme != 'https' || title.isEmpty) {
+        continue;
+      }
+      hits.add(
+        ResearchHit(
+          engineId: 'searxng',
+          url: url.toString(),
+          title: title,
+          snippet: _stripHtml('${row['content'] ?? ''}'),
+          trustLevel: SourceTrust.untrusted,
+        ),
+      );
+    }
+    return hits;
+  }
+
+  @override
+  Future<List<ResearchHit>> search(String query, {int maxResults = 5}) async {
+    if (query.trim().isEmpty || maxResults <= 0) {
+      return const [];
+    }
+    final basePath = baseUri.path.endsWith('/')
+        ? baseUri.path
+        : '${baseUri.path}/';
+    final uri = baseUri.replace(
+      path: '${basePath}search',
+      queryParameters: {'q': query, 'format': 'json', 'categories': 'general'},
+    );
+    final body = await http.get(uri);
+    final hits = body.length > _offMainThreshold
+        ? await runOffMain(() => parseSearchJson(body))
+        : parseSearchJson(body);
+    return hits.take(maxResults).toList(growable: false);
+  }
+
+  static String _stripHtml(String raw) {
+    return raw
+        .replaceAll(RegExp(r'<[^>]+>'), '')
+        .replaceAll('&quot;', '"')
+        .replaceAll('&amp;', '&')
+        .replaceAll('&#39;', "'")
+        .replaceAll('&lt;', '<')
+        .replaceAll('&gt;', '>')
+        .replaceAll(RegExp(r'\s+'), ' ')
+        .trim();
+  }
+}

--- a/packages/feature_mind/test/agent_chat/domain/services/research/searxng_search_engine_test.dart
+++ b/packages/feature_mind/test/agent_chat/domain/services/research/searxng_search_engine_test.dart
@@ -1,0 +1,150 @@
+import 'package:feature_mind/src/agent_chat/domain/models/research_event.dart';
+import 'package:feature_mind/src/agent_chat/domain/models/research_request.dart';
+import 'package:feature_mind/src/agent_chat/domain/services/research/research_http.dart';
+import 'package:feature_mind/src/agent_chat/domain/services/research/research_orchestrator.dart';
+import 'package:feature_mind/src/agent_chat/domain/services/research/research_search.dart';
+import 'package:feature_mind/src/agent_chat/domain/services/research/research_service.dart';
+import 'package:feature_mind/src/agent_chat/domain/services/research/searxng_search_engine.dart';
+import 'package:feature_mind/src/agent_chat/domain/services/research/source_manager.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  const body = '''
+{
+  "results": [
+    {
+      "url": "https://en.wikipedia.org/wiki/Qwen",
+      "title": "Qwen",
+      "content": "A <b>family</b> of language models."
+    },
+    {
+      "url": "http://insecure.example/result",
+      "title": "Insecure result",
+      "content": "Must not become a candidate."
+    }
+  ]
+}
+''';
+
+  test('parser maps SearXNG results to untrusted candidate hits', () {
+    final hits = SearxngSearchEngine.parseSearchJson(body);
+
+    expect(hits, hasLength(1));
+    expect(hits.single.engineId, 'searxng');
+    expect(hits.single.url, 'https://en.wikipedia.org/wiki/Qwen');
+    expect(hits.single.title, 'Qwen');
+    expect(hits.single.snippet, 'A family of language models.');
+    expect(hits.single.trustLevel, SourceTrust.untrusted);
+  });
+
+  test(
+    'large SearXNG JSON remains parseable across the worker boundary',
+    () async {
+      final padding = List.filled(55 * 1024, 'x').join();
+      final largeBody = body.replaceFirst('\n}', ',\n"padding":"$padding"\n}');
+      final baseUri = Uri.parse('https://search.home.example/');
+      final http = _FakeHttp(baseUri: baseUri, body: largeBody);
+      final engine = SearxngSearchEngine(baseUri: baseUri, http: http);
+
+      final hits = await engine.search('Qwen');
+
+      expect(hits, hasLength(1));
+      expect(hits.single.trustLevel, SourceTrust.untrusted);
+    },
+  );
+
+  test('configured client accepts only HTTPS and the configured host', () {
+    final baseUri = Uri.parse('https://search.home.example/searx/');
+    final engine = SearxngSearchEngine(baseUri: baseUri);
+
+    expect(engine.http.allowedHosts, contains('search.home.example'));
+    expect(
+      ResearchHttpClient.defaultAllowedHosts,
+      isNot(contains('search.home.example')),
+    );
+    expect(
+      () =>
+          SearxngSearchEngine(baseUri: Uri.parse('http://search.home.example')),
+      throwsA(isA<ResearchHttpException>()),
+    );
+    expect(
+      () => const ResearchHttpClient().get(baseUri),
+      throwsA(isA<ResearchHttpException>()),
+    );
+    expect(
+      () => engine.http.resolveRedirect(
+        baseUri,
+        'https://evil.example/redirected',
+      ),
+      throwsA(isA<ResearchHttpException>()),
+    );
+    expect(
+      engine.http.resolveRedirect(baseUri, '../login').host,
+      'search.home.example',
+    );
+    expect(
+      () => LocalResearchService(searxngBaseUri: baseUri),
+      returnsNormally,
+    );
+    expect(
+      () => LocalResearchService(
+        searxngBaseUri: Uri.parse('http://search.home.example'),
+      ),
+      throwsA(isA<ResearchHttpException>()),
+    );
+  });
+
+  test(
+    'Private profile uses SearXNG when the configured engine is injected',
+    () async {
+      final baseUri = Uri.parse('https://search.home.example/searx/');
+      final http = _FakeHttp(baseUri: baseUri, body: body);
+      final orchestrator = ResearchOrchestrator(
+        engines: [SearxngSearchEngine(baseUri: baseUri, http: http)],
+        sourceManager: SourceManager(
+          fetcher: (_) async =>
+              '<article><h1>Qwen</h1><p>Qwen is a family of language models.</p></article>',
+        ),
+      );
+
+      final events = await orchestrator
+          .run(
+            const ResearchRequest(
+              question: 'What is Qwen?',
+              mode: ResearchMode.quick,
+              policy: SearchPolicy.privacyFirst,
+              privacy: PrivacyProfile.private,
+            ),
+          )
+          .toList();
+
+      expect(http.requested, isNotEmpty);
+      expect(http.requested.single.host, 'search.home.example');
+      expect(http.requested.single.path, '/searx/search');
+      expect(http.requested.single.queryParameters['format'], 'json');
+      expect(events.last.kind, ResearchEventKind.researchCompleted);
+      expect(
+        SearchRouter.engineIdsFor(PrivacyProfile.private),
+        isNot(contains('google')),
+      );
+    },
+  );
+}
+
+class _FakeHttp extends ResearchHttpClient {
+  _FakeHttp({required this.baseUri, required this.body})
+    : super(
+        allowedHosts: {...ResearchHttpClient.defaultAllowedHosts, baseUri.host},
+      );
+
+  final Uri baseUri;
+  final String body;
+  final List<Uri> requested = [];
+
+  @override
+  Future<String> get(Uri uri) {
+    validate(uri);
+    requested.add(uri);
+    return Future.value(body);
+  }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add `SearxngSearchEngine` for an explicitly configured self-hosted HTTPS origin; no public/default endpoint.
- Export a supported `LocalDeepResearchEngine(searxngBaseUri:)` host seam while default routing remains unchanged.
- Pin SearXNG to exact scheme/host/effective port, validate redirects, force-close redirect/error bodies, and cap total body time/size.
- Keep arbitrary results candidate-only behind the independent acquisition allowlist; filter insecure/hostless/credential URLs.
- Offload any JSON that could exceed ~50 KiB UTF-8 using a conservative code-unit threshold; isolate provider failures so successful providers survive.

Task 3 of post A–J follow-through. No Google/commercial provider.

## Test Plan
- [x] Full Flutter Deep Research domain/service suite — 77 passed at `a0043d5d`
- [x] Full touched analyzer — no issues
- [x] HTTP transport tests: cross-origin/missing/excessive redirects, total body timeout, size cap
- [x] Adapter tests: parser, multibyte worker threshold, URL filtering, exact origin/port, candidate acquisition boundary, default/config/conflict seams, Private routing
- [x] Provider failure isolation regression
- [x] Public-page branding audit passed

**Verification environment:** Host-only

## Agent Policy
- [x] HTTP remains outside std-only `airo_mind_core`.
- [x] No default endpoint/phone-home behavior.
- [x] Hits remain untrusted candidates, not evidence.
- [x] Large JSON uses `runOffMain`.

## Council Review
- Chief Open Source Officer: approved; no dependency/license impact.
- Chief Documentation Officer: approved initial claims; candidate-only/origin details now added.
- Media Intelligence initial blockers fixed in `68317a0e`; exact-head re-review running.
- Platform, QA, Security, Performance, Architecture exact-head re-reviews running.
- Flutter Architect and Product Manager reviews running.
- Session linked in PR footer metadata.

## User-Facing Documentation
- [x] Public wiki uses development-only wording, no public endpoint/settings claim, and states candidate acquisition boundary.
- [x] Locked spec updated.

## Plugin and Size Impact
- [x] No dependencies/plugins/assets/vendored code.
- [x] Small source-only adapter/test in product-owned bundled Mind/Chat module.

## Checklist
- [x] Code formatted and tested.
- [x] No sensitive endpoint, credentials, or signing artifacts committed.

## Release Notes
- [x] Development hosts can inject an origin-isolated self-hosted SearXNG endpoint for Private Deep Research; Airo ships no public endpoint.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0d1a1368-352c-43c3-b66e-d4ae3a878dd5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0d1a1368-352c-43c3-b66e-d4ae3a878dd5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

