### PR TITLE
fix(mind): isolate and bound configured SearXNG

### DIFF
--- a/docs/superpowers/specs/2026-08-22-airo-deep-research-engine-design.md
+++ b/docs/superpowers/specs/2026-08-22-airo-deep-research-engine-design.md
@@ -103,7 +103,9 @@ Shipped as **contracts and a thin live slice**, not the full production engine:
 18. User-facing Private / Balanced / Cloud profiles, observability metrics,
     and abstract cost ceilings. Private routes to Wikipedia by default and can
     use the SearXNG adapter only when the host injects an explicit self-hosted
-    HTTPS base URI. Airo has no default/public SearXNG endpoint.
+    HTTPS base URI. Airo has no default/public SearXNG endpoint. The adapter is
+    origin-isolated and candidate-only: result URLs do not expand the separate
+    source-acquisition allowlist.
 
 Not shipped (locked below, do not pretend they exist):
 

--- a/docs/superpowers/specs/2026-08-22-airo-deep-research-engine-design.md
+++ b/docs/superpowers/specs/2026-08-22-airo-deep-research-engine-design.md
@@ -105,7 +105,10 @@ Shipped as **contracts and a thin live slice**, not the full production engine:
     use the SearXNG adapter only when the host injects an explicit self-hosted
     HTTPS base URI. Airo has no default/public SearXNG endpoint. The adapter is
     origin-isolated and candidate-only: result URLs do not expand the separate
-    source-acquisition allowlist.
+    source-acquisition allowlist. Shells inject it through
+    `MindModule.deepResearchEngineFactory` and
+    `createLocalDeepResearchEngine(searxngBaseUri: ...)`; both Chat routes use
+    that host-owned engine.
 
 Not shipped (locked below, do not pretend they exist):
 

--- a/docs/wiki/5.-AI-and-Model-Management.md
+++ b/docs/wiki/5.-AI-and-Model-Management.md
@@ -39,7 +39,9 @@ research question:
 
 - **Private** searches Wikipedia by default. In development builds, the host can
   inject an explicit self-hosted SearXNG HTTPS endpoint. Airo ships no public
-  SearXNG endpoint, and Chat does not yet provide endpoint settings.
+  SearXNG endpoint, and Chat does not yet provide endpoint settings. SearXNG
+  returns candidates only; their pages are fetched only when they already pass
+  Airo's separate source-acquisition policy.
 - **Balanced** uses Wikipedia, arXiv, and Semantic Scholar with local
   orchestration.
 - **Cloud** currently uses the same three remote sources as Balanced. It does

--- a/packages/feature_mind/lib/feature_mind.dart
+++ b/packages/feature_mind/lib/feature_mind.dart
@@ -116,9 +116,17 @@ export 'src/agent_chat/domain/models/assistant_model_selection.dart';
 export 'src/agent_chat/domain/models/assistant_runtime_ids.dart';
 export 'src/agent_chat/domain/models/chat_models.dart';
 export 'src/agent_chat/domain/models/chat_response_metadata.dart';
+export 'src/agent_chat/domain/models/research_event.dart';
+export 'src/agent_chat/domain/models/research_request.dart';
 export 'src/agent_chat/domain/services/agent_skill_registry.dart';
 export 'src/agent_chat/domain/services/deep_research_engine.dart'
-    show DeepResearchEngine, LocalDeepResearchEngine;
+    show
+        createLocalDeepResearchEngine,
+        DeepResearchEngine,
+        DeepResearchEngineFactory;
+export 'src/agent_chat/domain/services/research/research_checkpoint.dart';
+export 'src/agent_chat/domain/services/research/research_control.dart';
+export 'src/agent_chat/domain/services/research/research_library.dart';
 export 'src/agent_chat/presentation/screens/agent_skills_screen.dart';
 export 'src/agent_chat/presentation/screens/chat_screen.dart';
 export 'src/agent_chat/presentation/screens/device_capability_report_screen.dart';

--- a/packages/feature_mind/lib/feature_mind.dart
+++ b/packages/feature_mind/lib/feature_mind.dart
@@ -117,6 +117,8 @@ export 'src/agent_chat/domain/models/assistant_runtime_ids.dart';
 export 'src/agent_chat/domain/models/chat_models.dart';
 export 'src/agent_chat/domain/models/chat_response_metadata.dart';
 export 'src/agent_chat/domain/services/agent_skill_registry.dart';
+export 'src/agent_chat/domain/services/deep_research_engine.dart'
+    show DeepResearchEngine, LocalDeepResearchEngine;
 export 'src/agent_chat/presentation/screens/agent_skills_screen.dart';
 export 'src/agent_chat/presentation/screens/chat_screen.dart';
 export 'src/agent_chat/presentation/screens/device_capability_report_screen.dart';

--- a/packages/feature_mind/lib/src/agent_chat/domain/services/deep_research_engine.dart
+++ b/packages/feature_mind/lib/src/agent_chat/domain/services/deep_research_engine.dart
@@ -21,6 +21,12 @@ abstract class DeepResearchEngine {
   });
 }
 
+typedef DeepResearchEngineFactory = DeepResearchEngine Function();
+
+DeepResearchEngine createLocalDeepResearchEngine({Uri? searxngBaseUri}) {
+  return LocalDeepResearchEngine(searxngBaseUri: searxngBaseUri);
+}
+
 /// Shim: Chat talks to [ResearchService], never to a research prompt.
 class LocalDeepResearchEngine implements DeepResearchEngine {
   factory LocalDeepResearchEngine({

--- a/packages/feature_mind/lib/src/agent_chat/domain/services/deep_research_engine.dart
+++ b/packages/feature_mind/lib/src/agent_chat/domain/services/deep_research_engine.dart
@@ -23,10 +23,26 @@ abstract class DeepResearchEngine {
 
 /// Shim: Chat talks to [ResearchService], never to a research prompt.
 class LocalDeepResearchEngine implements DeepResearchEngine {
-  LocalDeepResearchEngine({
+  factory LocalDeepResearchEngine({
     ResearchService? service,
     ResearchOrchestrator? orchestrator,
-  }) : _service = service ?? LocalResearchService(orchestrator: orchestrator);
+    Uri? searxngBaseUri,
+  }) {
+    if (service != null && (orchestrator != null || searxngBaseUri != null)) {
+      throw ArgumentError(
+        'Inject a service or engine configuration, not both.',
+      );
+    }
+    return LocalDeepResearchEngine._(
+      service ??
+          LocalResearchService(
+            orchestrator: orchestrator,
+            searxngBaseUri: searxngBaseUri,
+          ),
+    );
+  }
+
+  const LocalDeepResearchEngine._(this._service);
 
   final ResearchService _service;
 

--- a/packages/feature_mind/lib/src/agent_chat/domain/services/research/research_http.dart
+++ b/packages/feature_mind/lib/src/agent_chat/domain/services/research/research_http.dart
@@ -9,6 +9,54 @@ class ResearchHttpException implements Exception {
   String toString() => message;
 }
 
+typedef ResearchHttpTransport =
+    Future<ResearchHttpTransportResponse> Function(Uri uri, Duration timeout);
+
+class ResearchHttpTransportResponse {
+  const ResearchHttpTransportResponse({
+    required this.statusCode,
+    required this.chunks,
+    this.location,
+    this.close = _noop,
+  });
+
+  final int statusCode;
+  final Stream<List<int>> chunks;
+  final String? location;
+  final void Function() close;
+
+  bool get isRedirect => const {
+    HttpStatus.movedPermanently,
+    HttpStatus.found,
+    HttpStatus.seeOther,
+    HttpStatus.temporaryRedirect,
+    HttpStatus.permanentRedirect,
+  }.contains(statusCode);
+}
+
+void _noop() {}
+
+Future<ResearchHttpTransportResponse> _ioResearchHttpTransport(
+  Uri uri,
+  Duration timeout,
+) async {
+  final client = HttpClient()..connectionTimeout = timeout;
+  try {
+    final request = await client.getUrl(uri);
+    request.followRedirects = false;
+    final response = await request.close().timeout(timeout);
+    return ResearchHttpTransportResponse(
+      statusCode: response.statusCode,
+      location: response.headers.value(HttpHeaders.locationHeader),
+      chunks: response,
+      close: () => client.close(force: true),
+    );
+  } catch (_) {
+    client.close(force: true);
+    rethrow;
+  }
+}
+
 /// HTTPS + host allowlist + size/timeout caps. Retrieved pages are content,
 /// never tool endpoints.
 class ResearchHttpClient {
@@ -18,6 +66,7 @@ class ResearchHttpClient {
     this.maxBytes = 256 * 1024,
     this.timeout = const Duration(seconds: 8),
     this.maxRedirects = 3,
+    this.transport = _ioResearchHttpTransport,
   });
 
   static const defaultAllowedHosts = {
@@ -33,6 +82,7 @@ class ResearchHttpClient {
   final int maxBytes;
   final Duration timeout;
   final int maxRedirects;
+  final ResearchHttpTransport transport;
 
   void validate(Uri uri) {
     if (uri.scheme != 'https') {
@@ -69,44 +119,39 @@ class ResearchHttpClient {
   }
 
   Future<String> _fetch(Uri uri) async {
-    final client = HttpClient()..connectionTimeout = timeout;
-    try {
-      var current = uri;
-      for (var redirects = 0; ; redirects++) {
-        final request = await client.getUrl(current);
-        request.followRedirects = false;
-        final response = await request.close().timeout(timeout);
+    var current = uri;
+    for (var redirects = 0; ; redirects++) {
+      final response = await transport(current, timeout).timeout(timeout);
+      try {
         if (response.isRedirect) {
           if (redirects >= maxRedirects) {
-            await response.drain<void>();
             throw const ResearchHttpException(
               'Research response exceeded redirect limit.',
             );
           }
-          final location = response.headers.value(HttpHeaders.locationHeader);
-          await response.drain<void>();
-          current = resolveRedirect(current, location ?? '');
+          current = resolveRedirect(current, response.location ?? '');
           continue;
         }
         if (response.statusCode < HttpStatus.ok ||
             response.statusCode >= HttpStatus.multipleChoices) {
-          await response.drain<void>();
           throw ResearchHttpException(
             'Research provider returned HTTP ${response.statusCode}.',
           );
         }
-        final bytes = await response.fold<List<int>>(<int>[], (buffer, chunk) {
-          if (buffer.length + chunk.length > maxBytes) {
-            throw const ResearchHttpException(
-              'Research response exceeded size limit.',
-            );
-          }
-          return buffer..addAll(chunk);
-        });
+        final bytes = await response.chunks
+            .fold<List<int>>(<int>[], (buffer, chunk) {
+              if (buffer.length + chunk.length > maxBytes) {
+                throw const ResearchHttpException(
+                  'Research response exceeded size limit.',
+                );
+              }
+              return buffer..addAll(chunk);
+            })
+            .timeout(timeout);
         return utf8.decode(bytes);
+      } finally {
+        response.close();
       }
-    } finally {
-      client.close(force: true);
     }
   }
 }

--- a/packages/feature_mind/lib/src/agent_chat/domain/services/research/research_http.dart
+++ b/packages/feature_mind/lib/src/agent_chat/domain/services/research/research_http.dart
@@ -14,6 +14,7 @@ class ResearchHttpException implements Exception {
 class ResearchHttpClient {
   const ResearchHttpClient({
     this.allowedHosts = defaultAllowedHosts,
+    this.allowedOrigins = const {},
     this.maxBytes = 256 * 1024,
     this.timeout = const Duration(seconds: 8),
     this.maxRedirects = 3,
@@ -28,6 +29,7 @@ class ResearchHttpClient {
   };
 
   final Set<String> allowedHosts;
+  final Set<String> allowedOrigins;
   final int maxBytes;
   final Duration timeout;
   final int maxRedirects;
@@ -41,6 +43,11 @@ class ResearchHttpClient {
     if (!allowedHosts.contains(uri.host)) {
       throw ResearchHttpException(
         'Host ${uri.host} is not an allowed research provider.',
+      );
+    }
+    if (allowedOrigins.isNotEmpty && !allowedOrigins.contains(uri.origin)) {
+      throw ResearchHttpException(
+        'Origin ${uri.origin} is not an allowed research provider.',
       );
     }
   }

--- a/packages/feature_mind/lib/src/agent_chat/domain/services/research/research_orchestrator.dart
+++ b/packages/feature_mind/lib/src/agent_chat/domain/services/research/research_orchestrator.dart
@@ -140,10 +140,16 @@ class ResearchOrchestrator {
         final batch = routed.take(remaining).toList(growable: false);
         final query = queries.queriesFor(node.question).primary;
         final results = await Future.wait(
-          batch.map(
-            (engine) =>
-                engine.search(query, maxResults: budget.maxSources.clamp(1, 8)),
-          ),
+          batch.map((engine) async {
+            try {
+              return await engine.search(
+                query,
+                maxResults: budget.maxSources.clamp(1, 8),
+              );
+            } catch (_) {
+              return const <ResearchHit>[];
+            }
+          }),
         );
         searchesUsed += batch.length;
         completed.add(node.id);

--- a/packages/feature_mind/lib/src/agent_chat/domain/services/research/research_service.dart
+++ b/packages/feature_mind/lib/src/agent_chat/domain/services/research/research_service.dart
@@ -42,12 +42,17 @@ class LocalResearchService implements ResearchService {
     }
     return LocalResearchService._(
       orchestrator ?? _defaultOrchestrator(searxngBaseUri),
+      hasConfiguredSearxng: searxngBaseUri != null,
     );
   }
 
-  const LocalResearchService._(this._orchestrator);
+  const LocalResearchService._(
+    this._orchestrator, {
+    required this.hasConfiguredSearxng,
+  });
 
   final ResearchOrchestrator _orchestrator;
+  final bool hasConfiguredSearxng;
 
   static ResearchOrchestrator _defaultOrchestrator(Uri? searxngBaseUri) {
     return ResearchOrchestrator(

--- a/packages/feature_mind/lib/src/agent_chat/domain/services/research/searxng_search_engine.dart
+++ b/packages/feature_mind/lib/src/agent_chat/domain/services/research/searxng_search_engine.dart
@@ -8,7 +8,9 @@ import 'research_search.dart';
 /// Search adapter for an explicitly configured self-hosted SearXNG instance.
 ///
 /// SearXNG results are candidates, not evidence. The configured API host is
-/// added only to this adapter's HTTP allowlist; there is no default public host.
+/// isolated to this adapter's HTTP origin; there is no default public host.
+/// Candidate URLs still pass through the independent source-acquisition
+/// allowlist, which this adapter never expands.
 class SearxngSearchEngine implements ResearchSearchEngine {
   factory SearxngSearchEngine({
     required Uri baseUri,
@@ -26,11 +28,17 @@ class SearxngSearchEngine implements ResearchSearchEngine {
     final client =
         http ??
         ResearchHttpClient(
-          allowedHosts: {
-            ...ResearchHttpClient.defaultAllowedHosts,
-            baseUri.host,
-          },
+          allowedHosts: {baseUri.host},
+          allowedOrigins: {baseUri.origin},
         );
+    if (client.allowedHosts.length != 1 ||
+        !client.allowedHosts.contains(baseUri.host) ||
+        client.allowedOrigins.length != 1 ||
+        !client.allowedOrigins.contains(baseUri.origin)) {
+      throw const ResearchHttpException(
+        'SearXNG HTTP access must be isolated to its configured origin.',
+      );
+    }
     client.validate(baseUri);
     return SearxngSearchEngine._(baseUri: baseUri, http: client);
   }

--- a/packages/feature_mind/lib/src/agent_chat/domain/services/research/searxng_search_engine.dart
+++ b/packages/feature_mind/lib/src/agent_chat/domain/services/research/searxng_search_engine.dart
@@ -45,7 +45,10 @@ class SearxngSearchEngine implements ResearchSearchEngine {
 
   const SearxngSearchEngine._({required this.baseUri, required this.http});
 
-  static const _offMainThreshold = 50 * 1024;
+  // UTF-8 can use up to three bytes per UTF-16 code unit for non-surrogate
+  // text. Offloading above 16 Ki code units guarantees any JSON that could
+  // exceed ~50 KiB never reaches jsonDecode on the main isolate.
+  static const _offMainCodeUnitThreshold = 16 * 1024;
 
   final Uri baseUri;
   final ResearchHttpClient http;
@@ -69,7 +72,11 @@ class SearxngSearchEngine implements ResearchSearchEngine {
       }
       final url = Uri.tryParse('${row['url'] ?? ''}'.trim());
       final title = _stripHtml('${row['title'] ?? ''}');
-      if (url == null || url.scheme != 'https' || title.isEmpty) {
+      if (url == null ||
+          url.scheme != 'https' ||
+          url.host.isEmpty ||
+          url.userInfo.isNotEmpty ||
+          title.isEmpty) {
         continue;
       }
       hits.add(
@@ -98,7 +105,7 @@ class SearxngSearchEngine implements ResearchSearchEngine {
       queryParameters: {'q': query, 'format': 'json', 'categories': 'general'},
     );
     final body = await http.get(uri);
-    final hits = body.length > _offMainThreshold
+    final hits = body.length > _offMainCodeUnitThreshold
         ? await runOffMain(() => parseSearchJson(body))
         : parseSearchJson(body);
     return hits.take(maxResults).toList(growable: false);

--- a/packages/feature_mind/lib/src/mind_module.dart
+++ b/packages/feature_mind/lib/src/mind_module.dart
@@ -5,6 +5,7 @@ import 'package:flutter_riverpod/misc.dart' show Override;
 import 'package:go_router/go_router.dart';
 
 import 'agent_chat/domain/services/tool_registry.dart';
+import 'agent_chat/domain/services/deep_research_engine.dart';
 import 'agent_chat/presentation/screens/agent_skills_screen.dart';
 import 'agent_chat/presentation/screens/chat_screen.dart';
 import 'agent_chat/presentation/screens/device_capability_report_screen.dart';
@@ -73,6 +74,7 @@ class MindModule extends AppModule {
   MindModule({
     required this.hostAdapterBuilder,
     this.createService,
+    this.deepResearchEngineFactory,
     this.scribeOverrides,
   });
 
@@ -97,12 +99,26 @@ class MindModule extends AppModule {
   /// [service] is never touched. Which app ships the scribe route is a shell
   /// composition decision, not something this module defaults.
   final MindService Function()? createService;
+  final DeepResearchEngineFactory? deepResearchEngineFactory;
 
   MindService? _service;
+  DeepResearchEngine? _deepResearchEngine;
 
   /// The scribe's service, created on first use and torn down by [dispose].
   /// Only valid to call when [createService] was supplied.
   MindService get service => _service ??= createService!();
+
+  DeepResearchEngine? get deepResearchEngine =>
+      deepResearchEngineFactory == null
+      ? null
+      : _deepResearchEngine ??= deepResearchEngineFactory!();
+
+  ChatScreen buildChatScreen({String? initialDraft}) {
+    return ChatScreen(
+      initialDraft: initialDraft,
+      deepResearchEngine: deepResearchEngine,
+    );
+  }
 
   @override
   String get id => 'mind';
@@ -145,6 +161,7 @@ class MindModule extends AppModule {
   Future<void> dispose() async {
     await _service?.dispose();
     _service = null;
+    _deepResearchEngine = null;
   }
 
   @override
@@ -207,7 +224,9 @@ class MindModule extends AppModule {
       name: AssistantRouteNames.assistantName,
       builder: (context, state) {
         if (shell == ShellId.mind) {
-          return ChatScreen(initialDraft: state.uri.queryParameters['prefill']);
+          return buildChatScreen(
+            initialDraft: state.uri.queryParameters['prefill'],
+          );
         }
         return const AssistantScreen();
       },
@@ -215,8 +234,9 @@ class MindModule extends AppModule {
         GoRoute(
           path: AssistantRouteNames.chatSegment,
           name: AssistantRouteNames.chatName,
-          builder: (context, state) =>
-              ChatScreen(initialDraft: state.uri.queryParameters['prefill']),
+          builder: (context, state) => buildChatScreen(
+            initialDraft: state.uri.queryParameters['prefill'],
+          ),
         ),
         GoRoute(
           path: AssistantRouteNames.notificationsSegment,

--- a/packages/feature_mind/test/agent_chat/domain/services/deep_research_engine_test.dart
+++ b/packages/feature_mind/test/agent_chat/domain/services/deep_research_engine_test.dart
@@ -3,6 +3,7 @@ import 'package:feature_mind/src/agent_chat/domain/models/research_request.dart'
 import 'package:feature_mind/src/agent_chat/domain/services/deep_research_engine.dart';
 import 'package:feature_mind/src/agent_chat/domain/services/research/research_checkpoint.dart';
 import 'package:feature_mind/src/agent_chat/domain/services/research/research_control.dart';
+import 'package:feature_mind/src/agent_chat/domain/services/research/research_http.dart';
 import 'package:feature_mind/src/agent_chat/domain/services/research/research_library.dart';
 import 'package:feature_mind/src/agent_chat/domain/services/research/research_orchestrator.dart';
 import 'package:feature_mind/src/agent_chat/domain/services/research/research_service.dart';
@@ -51,6 +52,28 @@ void main() {
 
     expect(service.knownSourceUrls, ['https://en.wikipedia.org/wiki/Qwen']);
     expect(service.onLibrary, same(onLibrary));
+  });
+
+  test('the public engine seam forwards explicit SearXNG configuration', () {
+    expect(
+      () => LocalDeepResearchEngine(
+        searxngBaseUri: Uri.parse('https://search.home.example/'),
+      ),
+      returnsNormally,
+    );
+    expect(
+      () => LocalDeepResearchEngine(
+        searxngBaseUri: Uri.parse('http://search.home.example/'),
+      ),
+      throwsA(isA<ResearchHttpException>()),
+    );
+    expect(
+      () => LocalDeepResearchEngine(
+        service: _RecordingService(),
+        searxngBaseUri: Uri.parse('https://search.home.example/'),
+      ),
+      throwsArgumentError,
+    );
   });
 }
 

--- a/packages/feature_mind/test/agent_chat/domain/services/research/research_http_test.dart
+++ b/packages/feature_mind/test/agent_chat/domain/services/research/research_http_test.dart
@@ -1,0 +1,125 @@
+import 'dart:async';
+
+import 'package:feature_mind/src/agent_chat/domain/services/research/research_http.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  final baseUri = Uri.parse('https://search.home.example/search');
+
+  test('fetch rejects a redirect outside the configured origin', () async {
+    final transport = _SequenceTransport([
+      _response(statusCode: 302, location: 'https://evil.example/redirected'),
+    ]);
+    final client = _configuredClient(baseUri, transport: transport.call);
+
+    await expectLater(
+      client.get(baseUri),
+      throwsA(isA<ResearchHttpException>()),
+    );
+    expect(transport.requested, [baseUri]);
+  });
+
+  test(
+    'fetch rejects redirects without location and excessive chains',
+    () async {
+      final missing = _SequenceTransport([_response(statusCode: 302)]);
+      await expectLater(
+        _configuredClient(baseUri, transport: missing.call).get(baseUri),
+        throwsA(isA<ResearchHttpException>()),
+      );
+
+      final repeated = _SequenceTransport([
+        _response(statusCode: 302, location: '/again'),
+        _response(statusCode: 302, location: '/again'),
+      ]);
+      await expectLater(
+        _configuredClient(
+          baseUri,
+          transport: repeated.call,
+          maxRedirects: 1,
+        ).get(baseUri),
+        throwsA(isA<ResearchHttpException>()),
+      );
+      expect(repeated.requested, hasLength(2));
+    },
+  );
+
+  test('body streaming is bounded by timeout and size', () async {
+    final slow = _SequenceTransport([
+      ResearchHttpTransportResponse(
+        statusCode: 200,
+        chunks: Stream<List<int>>.periodic(
+          const Duration(milliseconds: 50),
+          (_) => [1],
+        ).take(2),
+      ),
+    ]);
+    await expectLater(
+      _configuredClient(
+        baseUri,
+        transport: slow.call,
+        timeout: const Duration(milliseconds: 10),
+      ).get(baseUri),
+      throwsA(isA<TimeoutException>()),
+    );
+
+    final large = _SequenceTransport([
+      _response(
+        statusCode: 200,
+        chunks: const [
+          [1, 2],
+          [3, 4],
+        ],
+      ),
+    ]);
+    await expectLater(
+      _configuredClient(
+        baseUri,
+        transport: large.call,
+        maxBytes: 3,
+      ).get(baseUri),
+      throwsA(isA<ResearchHttpException>()),
+    );
+  });
+}
+
+ResearchHttpClient _configuredClient(
+  Uri uri, {
+  required ResearchHttpTransport transport,
+  int maxBytes = 256 * 1024,
+  int maxRedirects = 3,
+  Duration timeout = const Duration(seconds: 8),
+}) {
+  return ResearchHttpClient(
+    allowedHosts: {uri.host},
+    allowedOrigins: {uri.origin},
+    maxBytes: maxBytes,
+    maxRedirects: maxRedirects,
+    timeout: timeout,
+    transport: transport,
+  );
+}
+
+ResearchHttpTransportResponse _response({
+  required int statusCode,
+  String? location,
+  List<List<int>> chunks = const [],
+}) {
+  return ResearchHttpTransportResponse(
+    statusCode: statusCode,
+    location: location,
+    chunks: Stream.fromIterable(chunks),
+  );
+}
+
+class _SequenceTransport {
+  _SequenceTransport(this.responses);
+
+  final List<ResearchHttpTransportResponse> responses;
+  final List<Uri> requested = [];
+
+  Future<ResearchHttpTransportResponse> call(Uri uri, Duration timeout) async {
+    requested.add(uri);
+    return responses.removeAt(0);
+  }
+}

--- a/packages/feature_mind/test/agent_chat/domain/services/research/research_orchestrator_test.dart
+++ b/packages/feature_mind/test/agent_chat/domain/services/research/research_orchestrator_test.dart
@@ -266,6 +266,46 @@ void main() {
       expect(searches, 0);
     },
   );
+
+  test(
+    'one search provider failure does not discard successful providers',
+    () async {
+      final orchestrator = ResearchOrchestrator(
+        engines: [
+          const _FakeSearchEngine(
+            id: 'wikipedia',
+            hits: [
+              ResearchHit(
+                engineId: 'wikipedia',
+                url: 'https://en.wikipedia.org/wiki/Qwen',
+                title: 'Qwen',
+                snippet: 'Candidate',
+              ),
+            ],
+          ),
+          const _ThrowingSearchEngine('searxng'),
+        ],
+        sourceManager: SourceManager(
+          fetcher: (_) async =>
+              '<article><h1>Qwen</h1><p>Qwen is a family of language models.</p></article>',
+        ),
+      );
+
+      final events = await orchestrator
+          .run(
+            const ResearchRequest(
+              question: 'What is Qwen?',
+              mode: ResearchMode.quick,
+              policy: SearchPolicy.privacyFirst,
+              privacy: PrivacyProfile.private,
+            ),
+          )
+          .toList();
+
+      expect(events.last.kind, ResearchEventKind.researchCompleted);
+      expect(events.last.detail, contains('Qwen is a family'));
+    },
+  );
 }
 
 String _article({required String title, required String paragraph}) {
@@ -302,5 +342,17 @@ class _CountingEngine implements ResearchSearchEngine {
   Future<List<ResearchHit>> search(String query, {int maxResults = 5}) async {
     onSearch();
     return hitsFor(query);
+  }
+}
+
+class _ThrowingSearchEngine implements ResearchSearchEngine {
+  const _ThrowingSearchEngine(this.id);
+
+  @override
+  final String id;
+
+  @override
+  Future<List<ResearchHit>> search(String query, {int maxResults = 5}) {
+    throw StateError('$id unavailable');
   }
 }

--- a/packages/feature_mind/test/agent_chat/domain/services/research/searxng_search_engine_test.dart
+++ b/packages/feature_mind/test/agent_chat/domain/services/research/searxng_search_engine_test.dart
@@ -57,7 +57,8 @@ void main() {
     final baseUri = Uri.parse('https://search.home.example/searx/');
     final engine = SearxngSearchEngine(baseUri: baseUri);
 
-    expect(engine.http.allowedHosts, contains('search.home.example'));
+    expect(engine.http.allowedHosts, {'search.home.example'});
+    expect(engine.http.allowedOrigins, {baseUri.origin});
     expect(
       ResearchHttpClient.defaultAllowedHosts,
       isNot(contains('search.home.example')),
@@ -83,6 +84,13 @@ void main() {
       'search.home.example',
     );
     expect(
+      () => engine.http.resolveRedirect(
+        baseUri,
+        'https://search.home.example:8443/redirected',
+      ),
+      throwsA(isA<ResearchHttpException>()),
+    );
+    expect(
       () => LocalResearchService(searxngBaseUri: baseUri),
       returnsNormally,
     );
@@ -94,16 +102,30 @@ void main() {
     );
   });
 
+  test('arbitrary SearXNG candidates do not expand acquisition hosts', () {
+    const arbitraryBody = '''
+{"results":[{"url":"https://unknown.example/page","title":"Unknown","content":"Candidate"}]}
+''';
+    final hit = SearxngSearchEngine.parseSearchJson(arbitraryBody).single;
+
+    expect(
+      () => const ResearchHttpClient().get(Uri.parse(hit.url)),
+      throwsA(isA<ResearchHttpException>()),
+    );
+  });
+
   test(
-    'Private profile uses SearXNG when the configured engine is injected',
+    'Private uses injected SearXNG while source policy owns acquisition',
     () async {
       final baseUri = Uri.parse('https://search.home.example/searx/');
       final http = _FakeHttp(baseUri: baseUri, body: body);
       final orchestrator = ResearchOrchestrator(
         engines: [SearxngSearchEngine(baseUri: baseUri, http: http)],
         sourceManager: SourceManager(
-          fetcher: (_) async =>
-              '<article><h1>Qwen</h1><p>Qwen is a family of language models.</p></article>',
+          fetcher: (uri) async {
+            expect(uri.host, 'en.wikipedia.org');
+            return '<article><h1>Qwen</h1><p>Qwen is a family of language models.</p></article>';
+          },
         ),
       );
 
@@ -133,9 +155,7 @@ void main() {
 
 class _FakeHttp extends ResearchHttpClient {
   _FakeHttp({required this.baseUri, required this.body})
-    : super(
-        allowedHosts: {...ResearchHttpClient.defaultAllowedHosts, baseUri.host},
-      );
+    : super(allowedHosts: {baseUri.host}, allowedOrigins: {baseUri.origin});
 
   final Uri baseUri;
   final String body;

--- a/packages/feature_mind/test/agent_chat/domain/services/research/searxng_search_engine_test.dart
+++ b/packages/feature_mind/test/agent_chat/domain/services/research/searxng_search_engine_test.dart
@@ -21,6 +21,16 @@ void main() {
       "url": "http://insecure.example/result",
       "title": "Insecure result",
       "content": "Must not become a candidate."
+    },
+    {
+      "url": "https:///hostless",
+      "title": "Hostless result",
+      "content": "Must not become a candidate."
+    },
+    {
+      "url": "https://user:secret@example.com/result",
+      "title": "Credential result",
+      "content": "Must not become a candidate."
     }
   ]
 }
@@ -40,7 +50,7 @@ void main() {
   test(
     'large SearXNG JSON remains parseable across the worker boundary',
     () async {
-      final padding = List.filled(55 * 1024, 'x').join();
+      final padding = List.filled(18 * 1024, '界').join();
       final largeBody = body.replaceFirst('\n}', ',\n"padding":"$padding"\n}');
       final baseUri = Uri.parse('https://search.home.example/');
       final http = _FakeHttp(baseUri: baseUri, body: largeBody);
@@ -93,6 +103,18 @@ void main() {
     expect(
       () => LocalResearchService(searxngBaseUri: baseUri),
       returnsNormally,
+    );
+    expect(LocalResearchService().hasConfiguredSearxng, isFalse);
+    expect(
+      LocalResearchService(searxngBaseUri: baseUri).hasConfiguredSearxng,
+      isTrue,
+    );
+    expect(
+      () => LocalResearchService(
+        orchestrator: const ResearchOrchestrator(engines: []),
+        searxngBaseUri: baseUri,
+      ),
+      throwsArgumentError,
     );
     expect(
       () => LocalResearchService(

--- a/packages/feature_mind/test/mind_module_test.dart
+++ b/packages/feature_mind/test/mind_module_test.dart
@@ -84,6 +84,25 @@ void main() {
     expect(mind.path, mobile.path);
   });
 
+  test('both chat routes share the host-owned Deep Research engine', () {
+    var creates = 0;
+    final engine = _NoopDeepResearchEngine();
+    final module = MindModule(
+      hostAdapterBuilder: (ref) => FakeAssistantHostAdapter(),
+      deepResearchEngineFactory: () {
+        creates += 1;
+        return engine;
+      },
+    );
+
+    final rootChat = module.buildChatScreen(initialDraft: 'root');
+    final nestedChat = module.buildChatScreen(initialDraft: 'nested');
+
+    expect(rootChat.deepResearchEngine, same(engine));
+    expect(nestedChat.deepResearchEngine, same(engine));
+    expect(creates, 1);
+  });
+
   test('declared mount points match the paths the package navigates to', () {
     // The hub tiles, tool registry, and notification payloads all push
     // absolute `/assistant/...` locations, so the declared routes have to
@@ -190,4 +209,16 @@ void main() {
       await module.dispose();
     });
   });
+}
+
+class _NoopDeepResearchEngine implements DeepResearchEngine {
+  @override
+  Stream<ResearchEvent> run(
+    ResearchRequest request, {
+    ResearchControl? control,
+    ResearchCheckpoint? resumeFrom,
+    void Function(ResearchCheckpoint checkpoint)? onCheckpoint,
+    List<String> knownSourceUrls = const [],
+    void Function(ResearchLibraryEntry entry)? onLibrary,
+  }) => const Stream.empty();
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Safety follow-up to prematurely merged #1862: exact-origin/candidate-only SearXNG, bounded HTTP transport, provider failure isolation, URL validation, and byte-safe worker routing.
- Export a complete public Deep Research engine contract plus `createLocalDeepResearchEngine`.
- Add a host-owned `MindModule.deepResearchEngineFactory`; both root and nested Chat routes share the configured engine.

## Test Plan
- [x] Full Deep Research + MindModule suite — 92 passed at `48757f92`
- [x] Full touched analyzer — no issues
- [x] HTTP redirect/body timeout/size, multibyte worker, URL filtering, candidate boundary, provider failure, and public API/factory/both-route tests
- [x] Public-page branding audit passed

**Verification environment:** Host-only

## Agent Policy
- [x] Networking remains Dart-side; Rust core stays std-only.
- [x] No public/default endpoint or hidden network behavior.
- [x] Search candidates do not expand acquisition authority.
- [x] Both production Chat routes receive the host-owned engine.

## Council Review
- Platform Architect: approved `a0043d5d`; #1864 contains that tree plus host composition.
- Chief QA Officer: approved `a0043d5d` (77 research tests); final host test raises suite to 92.
- Chief Security Officer: approved `a0043d5d`.
- Product, Architecture, Performance, Open Source, and Documentation approved reviewed behavior/claims.
- Media Intelligence approved `68317a0e`; exact-head follow-up requested after reliability/composition.
- Flutter exact-head re-review requested after `48757f92`.
- Session linked in footer metadata.

## User-Facing Documentation
- [x] Wiki/spec state development-only injection, no public endpoint/settings, exact-origin/candidate-only behavior, and host factory composition.

## Plugin and Size Impact
- [x] No dependencies/plugins/assets/vendored code.
- [x] Source/test-only safety follow-up in bundled Mind/Chat module.

## Checklist
- [x] Code formatted and tested.
- [x] No endpoints, credentials, or signing artifacts committed.

## Release Notes
- [x] Configured self-hosted SearXNG is exact-origin isolated, bounded, candidate-only, failure-isolated, and composable through both Chat routes.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0d1a1368-352c-43c3-b66e-d4ae3a878dd5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0d1a1368-352c-43c3-b66e-d4ae3a878dd5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

