### PR TITLE
feat(mind): Stage 1 native live STT pipeline (ring, VAD, stabilizer)

### DIFF
--- a/rust/airo_mind_audio/src/lib.rs
+++ b/rust/airo_mind_audio/src/lib.rs
@@ -8,13 +8,22 @@
 #![deny(unsafe_code)]
 
 mod decode;
+mod live;
 mod resample;
+mod ring;
+mod stabilizer;
+mod vad;
 
 pub use airo_mind_core::wav;
 pub use airo_mind_core::wav::Pcm;
 
 pub const TARGET_SAMPLE_RATE: u32 = 16_000;
 pub const TARGET_CHANNELS: u16 = 1;
+
+pub use live::{LiveSpeechConfig, LiveSpeechPipeline, LiveStepReport};
+pub use ring::{PcmRingBuffer, RingPushReport};
+pub use stabilizer::TranscriptStabilizer;
+pub use vad::{EnergyVad, VadState};
 
 /// Read [path] and return whisper-ready PCM.
 pub fn preprocess_path(path: &std::path::Path) -> Result<Pcm, String> {

--- a/rust/airo_mind_audio/src/live.rs
+++ b/rust/airo_mind_audio/src/live.rs
@@ -1,0 +1,237 @@
+//! Live speech orchestration above [`SpeechEngine`] — ring, VAD, stabilizer.
+
+use airo_mind_core::cancel::CancelToken;
+use airo_mind_core::engine::{
+    AudioInput, EngineError, SpeechEngine, TranscriptSegment, TranscriptionOptions,
+};
+
+use crate::ring::{PcmRingBuffer, RingPushReport};
+use crate::stabilizer::TranscriptStabilizer;
+use crate::vad::{EnergyVad, VadState};
+use crate::TARGET_SAMPLE_RATE;
+
+/// Configuration for a live session pipeline.
+#[derive(Clone, Debug)]
+pub struct LiveSpeechConfig {
+    /// Ring capacity in samples (~1–2 s of speech at 16 kHz is a starting point).
+    pub ring_capacity_samples: usize,
+    /// Inference window taken from the ring tail when speech is active.
+    pub window_samples: usize,
+    /// RMS energy threshold for [`EnergyVad`].
+    pub vad_energy_threshold: f32,
+    /// Silence duration (ms) that ends an utterance for stabilizer commit.
+    pub vad_silence_ms: u64,
+}
+
+impl Default for LiveSpeechConfig {
+    fn default() -> Self {
+        Self {
+            ring_capacity_samples: TARGET_SAMPLE_RATE as usize * 2,
+            window_samples: TARGET_SAMPLE_RATE as usize / 2,
+            vad_energy_threshold: 0.01,
+            vad_silence_ms: 400,
+        }
+    }
+}
+
+/// Outcome of one [`LiveSpeechPipeline::step`].
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct LiveStepReport {
+    pub ring_push: RingPushReport,
+    pub degraded: bool,
+    pub vad_state: VadState,
+}
+
+/// Native-owned PCM path: ring → VAD → bounded window → engine → stabilizer.
+pub struct LiveSpeechPipeline {
+    config: LiveSpeechConfig,
+    ring: PcmRingBuffer,
+    vad: EnergyVad,
+    stabilizer: TranscriptStabilizer,
+    elapsed_samples: u64,
+}
+
+impl LiveSpeechPipeline {
+    pub fn new(config: LiveSpeechConfig) -> Self {
+        let vad = EnergyVad::new(
+            config.vad_energy_threshold,
+            config.vad_silence_ms,
+            TARGET_SAMPLE_RATE,
+        );
+        Self {
+            ring: PcmRingBuffer::with_capacity_samples(config.ring_capacity_samples),
+            vad,
+            stabilizer: TranscriptStabilizer::new(),
+            config,
+            elapsed_samples: 0,
+        }
+    }
+
+    pub fn push_pcm(&mut self, samples: &[i16]) -> RingPushReport {
+        self.elapsed_samples += samples.len() as u64;
+        self.ring.push(samples)
+    }
+
+    pub fn ring_dropped_samples(&self) -> u64 {
+        self.ring.dropped_samples()
+    }
+
+    pub fn stabilizer(&self) -> &TranscriptStabilizer {
+        &self.stabilizer
+    }
+
+    /// Run one pipeline tick: VAD on the latest window, optional engine pass,
+    /// stabilizer events through `sink`.
+    pub fn step(
+        &mut self,
+        engine: &dyn SpeechEngine,
+        options: &TranscriptionOptions,
+        cancel: &CancelToken,
+        sink: &mut dyn FnMut(TranscriptSegment) -> Result<(), EngineError>,
+    ) -> Result<LiveStepReport, EngineError> {
+        if cancel.is_cancelled() {
+            return Err(EngineError::Cancelled);
+        }
+
+        let window = self.ring.tail(self.config.window_samples);
+        let vad_state = self.vad.process(&window);
+        let ring_push = RingPushReport {
+            accepted: 0,
+            dropped: 0,
+        };
+
+        if vad_state == VadState::Speech && window.len() >= self.config.window_samples / 4 {
+            let offset_ms = self.elapsed_samples.saturating_sub(window.len() as u64) * 1000
+                / TARGET_SAMPLE_RATE as u64;
+            engine.transcribe(
+                AudioInput {
+                    samples: &window,
+                    sample_rate_hz: TARGET_SAMPLE_RATE,
+                    channels: 1,
+                },
+                options,
+                cancel,
+                &mut |seg| {
+                    let adjusted = TranscriptSegment::new(
+                        offset_ms + seg.start_ms,
+                        offset_ms + seg.end_ms,
+                        seg.text,
+                        seg.state,
+                    );
+                    for event in self.stabilizer.on_engine_segment(adjusted) {
+                        sink(event)?;
+                    }
+                    Ok(())
+                },
+            )?;
+        }
+
+        if vad_state == VadState::SpeechEnded {
+            for event in self.stabilizer.on_speech_ended() {
+                sink(event)?;
+            }
+        }
+
+        Ok(LiveStepReport {
+            ring_push,
+            degraded: self.ring.dropped_samples() > 0,
+            vad_state,
+        })
+    }
+
+    /// Flush remaining hypothesis and emit [`Final`] segments.
+    pub fn finish(
+        &mut self,
+        sink: &mut dyn FnMut(TranscriptSegment) -> Result<(), EngineError>,
+    ) -> Result<(), EngineError> {
+        for event in self.stabilizer.finalize() {
+            sink(event)?;
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use airo_mind_core::budget::ResourceRequest;
+    use airo_mind_core::engine::TranscriptSegmentState;
+
+    struct WindowSpeech;
+
+    impl SpeechEngine for WindowSpeech {
+        fn resource_request(&self) -> ResourceRequest {
+            ResourceRequest::new(512)
+        }
+
+        fn transcribe(
+            &self,
+            audio: AudioInput<'_>,
+            _options: &TranscriptionOptions,
+            _cancel: &CancelToken,
+            sink: &mut dyn FnMut(TranscriptSegment) -> Result<(), EngineError>,
+        ) -> Result<(), EngineError> {
+            if audio.samples.is_empty() {
+                return Ok(());
+            }
+            sink(TranscriptSegment::final_text(0, 100, "live".into()))?;
+            Ok(())
+        }
+    }
+
+    fn loud_pcm(n: usize) -> Vec<i16> {
+        vec![12_000; n]
+    }
+
+    fn silent_pcm(n: usize) -> Vec<i16> {
+        vec![0; n]
+    }
+
+    #[test]
+    fn pipeline_emits_partial_then_stable_on_silence() {
+        let config = LiveSpeechConfig {
+            ring_capacity_samples: 16_000,
+            window_samples: 4_800,
+            vad_energy_threshold: 0.01,
+            vad_silence_ms: 300,
+        };
+        let mut pipe = LiveSpeechPipeline::new(config);
+        let engine = WindowSpeech;
+        let cancel = CancelToken::new();
+        let mut events = Vec::new();
+
+        pipe.push_pcm(&loud_pcm(8_000));
+        pipe.step(
+            &engine,
+            &TranscriptionOptions::default(),
+            &cancel,
+            &mut |seg| {
+                events.push(seg);
+                Ok(())
+            },
+        )
+        .unwrap();
+
+        assert!(
+            events.iter().any(|s| s.state == TranscriptSegmentState::Partial),
+            "expected partial from engine window"
+        );
+
+        pipe.push_pcm(&silent_pcm(8_000));
+        pipe.step(
+            &engine,
+            &TranscriptionOptions::default(),
+            &cancel,
+            &mut |seg| {
+                events.push(seg);
+                Ok(())
+            },
+        )
+        .unwrap();
+
+        assert!(
+            events.iter().any(|s| s.state == TranscriptSegmentState::Stable),
+            "expected stable after silence boundary"
+        );
+    }
+}

--- a/rust/airo_mind_audio/src/ring.rs
+++ b/rust/airo_mind_audio/src/ring.rs
@@ -1,0 +1,125 @@
+//! Bounded PCM ring for live speech ingestion (`ZC-3`).
+
+use crate::TARGET_SAMPLE_RATE;
+
+/// A fixed-capacity ring of `i16` PCM samples. When full, the oldest samples
+/// are dropped (drop-oldest), never unbounded growth.
+pub struct PcmRingBuffer {
+    data: Vec<i16>,
+    head: usize,
+    len: usize,
+    dropped_samples: u64,
+}
+
+/// Result of pushing samples into the ring.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct RingPushReport {
+    pub accepted: usize,
+    pub dropped: usize,
+}
+
+impl PcmRingBuffer {
+    pub fn with_capacity_samples(capacity: usize) -> Self {
+        Self {
+            data: vec![0; capacity.max(1)],
+            head: 0,
+            len: 0,
+            dropped_samples: 0,
+        }
+    }
+
+    /// Capacity in samples (not bytes).
+    pub fn capacity(&self) -> usize {
+        self.data.len()
+    }
+
+    pub fn len(&self) -> usize {
+        self.len
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len == 0
+    }
+
+    pub fn dropped_samples(&self) -> u64 {
+        self.dropped_samples
+    }
+
+    pub fn push(&mut self, samples: &[i16]) -> RingPushReport {
+        let mut accepted = 0;
+        let mut dropped = 0;
+        for sample in samples {
+            if self.len == self.data.len() {
+                self.head = (self.head + 1) % self.data.len();
+                self.len -= 1;
+                self.dropped_samples += 1;
+                dropped += 1;
+            }
+            let tail = (self.head + self.len) % self.data.len();
+            self.data[tail] = *sample;
+            self.len += 1;
+            accepted += 1;
+        }
+        RingPushReport { accepted, dropped }
+    }
+
+    /// Oldest-to-newest view of the retained samples.
+    pub fn contiguous(&self) -> Vec<i16> {
+        if self.len == 0 {
+            return Vec::new();
+        }
+        let mut out = Vec::with_capacity(self.len);
+        for i in 0..self.len {
+            let idx = (self.head + i) % self.data.len();
+            out.push(self.data[idx]);
+        }
+        out
+    }
+
+    /// Last `max_samples` retained, oldest-to-newest within that tail.
+    pub fn tail(&self, max_samples: usize) -> Vec<i16> {
+        let take = max_samples.min(self.len);
+        if take == 0 {
+            return Vec::new();
+        }
+        let start = self.len - take;
+        let mut out = Vec::with_capacity(take);
+        for i in start..self.len {
+            let idx = (self.head + i) % self.data.len();
+            out.push(self.data[idx]);
+        }
+        out
+    }
+
+    pub fn clear(&mut self) {
+        self.head = 0;
+        self.len = 0;
+    }
+
+    /// Duration of retained audio in milliseconds at 16 kHz.
+    pub fn retained_ms(&self) -> u64 {
+        self.len as u64 * 1000 / TARGET_SAMPLE_RATE as u64
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn push_and_tail_returns_latest_samples() {
+        let mut ring = PcmRingBuffer::with_capacity_samples(8);
+        ring.push(&[1, 2, 3, 4]);
+        assert_eq!(ring.tail(2), vec![3, 4]);
+        assert_eq!(ring.contiguous(), vec![1, 2, 3, 4]);
+    }
+
+    #[test]
+    fn overflow_drops_oldest_and_counts_drops() {
+        let mut ring = PcmRingBuffer::with_capacity_samples(4);
+        let report = ring.push(&[1, 2, 3, 4, 5, 6]);
+        assert_eq!(report.dropped, 2);
+        assert_eq!(ring.dropped_samples(), 2);
+        assert_eq!(ring.contiguous(), vec![3, 4, 5, 6]);
+    }
+}

--- a/rust/airo_mind_audio/src/stabilizer.rs
+++ b/rust/airo_mind_audio/src/stabilizer.rs
@@ -1,0 +1,117 @@
+//! Transcript stabilizer: PARTIAL → STABLE → FINAL without UI flicker.
+
+use airo_mind_core::engine::{TranscriptSegment, TranscriptSegmentState};
+
+/// Tracks committed vs hypothesis text for one live session.
+pub struct TranscriptStabilizer {
+    segment_index: usize,
+    committed: Vec<TranscriptSegment>,
+    hypothesis: Option<TranscriptSegment>,
+}
+
+impl TranscriptStabilizer {
+    pub fn new() -> Self {
+        Self {
+            segment_index: 0,
+            committed: Vec::new(),
+            hypothesis: None,
+        }
+    }
+
+    pub fn committed(&self) -> &[TranscriptSegment] {
+        &self.committed
+    }
+
+    pub fn hypothesis(&self) -> Option<&TranscriptSegment> {
+        self.hypothesis.as_ref()
+    }
+
+    /// A new engine window produced text. Emits [`Partial`] updates for the
+    /// active tail; does not rewrite already-stable text.
+    pub fn on_engine_segment(&mut self, segment: TranscriptSegment) -> Vec<TranscriptSegment> {
+        let partial = TranscriptSegment::new(
+            segment.start_ms,
+            segment.end_ms,
+            segment.text,
+            TranscriptSegmentState::Partial,
+        );
+        self.hypothesis = Some(partial.clone());
+        vec![partial]
+    }
+
+    /// Silence boundary: promote the current hypothesis to [`Stable`].
+    pub fn on_speech_ended(&mut self) -> Vec<TranscriptSegment> {
+        let Some(hyp) = self.hypothesis.take() else {
+            return Vec::new();
+        };
+        let stable = TranscriptSegment::new(
+            hyp.start_ms,
+            hyp.end_ms,
+            hyp.text,
+            TranscriptSegmentState::Stable,
+        );
+        self.committed.push(stable.clone());
+        self.segment_index += 1;
+        vec![stable]
+    }
+
+    /// Session close: promote every [`Stable`] segment to [`Final`].
+    pub fn finalize(&mut self) -> Vec<TranscriptSegment> {
+        let mut out = Vec::new();
+        if let Some(hyp) = self.hypothesis.take() {
+            let stable = TranscriptSegment::new(
+                hyp.start_ms,
+                hyp.end_ms,
+                hyp.text,
+                TranscriptSegmentState::Stable,
+            );
+            self.committed.push(stable);
+            self.segment_index += 1;
+        }
+        for seg in &self.committed {
+            if seg.state == TranscriptSegmentState::Stable {
+                out.push(TranscriptSegment::new(
+                    seg.start_ms,
+                    seg.end_ms,
+                    seg.text.clone(),
+                    TranscriptSegmentState::Final,
+                ));
+            }
+        }
+        for seg in &mut self.committed {
+            if seg.state == TranscriptSegmentState::Stable {
+                seg.state = TranscriptSegmentState::Final;
+            }
+        }
+        out
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn partial_then_stable_on_speech_end() {
+        let mut s = TranscriptStabilizer::new();
+        let partials = s.on_engine_segment(TranscriptSegment::final_text(0, 500, "hello".into()));
+        assert_eq!(partials.len(), 1);
+        assert_eq!(partials[0].state, TranscriptSegmentState::Partial);
+
+        let stable = s.on_speech_ended();
+        assert_eq!(stable.len(), 1);
+        assert_eq!(stable[0].state, TranscriptSegmentState::Stable);
+        assert_eq!(s.committed().len(), 1);
+    }
+
+    #[test]
+    fn finalize_promotes_stable_to_final() {
+        let mut s = TranscriptStabilizer::new();
+        s.on_engine_segment(TranscriptSegment::final_text(0, 500, "done".into()));
+        s.on_speech_ended();
+        let finals = s.finalize();
+        assert_eq!(finals.len(), 1);
+        assert_eq!(finals[0].state, TranscriptSegmentState::Final);
+        assert_eq!(s.committed()[0].state, TranscriptSegmentState::Final);
+    }
+}

--- a/rust/airo_mind_audio/src/vad.rs
+++ b/rust/airo_mind_audio/src/vad.rs
@@ -1,0 +1,103 @@
+//! Lightweight energy VAD for live speech gating.
+
+/// Voice-activity state after processing one PCM chunk.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum VadState {
+    Silence,
+    Speech,
+    /// Speech ended after a silence run long enough to commit a clause.
+    SpeechEnded,
+}
+
+/// RMS energy gate with hysteresis via a silence-run counter.
+pub struct EnergyVad {
+    threshold: f32,
+    silence_samples_required: usize,
+    speech_active: bool,
+    silence_run: usize,
+}
+
+impl EnergyVad {
+    pub fn new(threshold: f32, silence_ms: u64, sample_rate_hz: u32) -> Self {
+        let silence_samples_required =
+            (sample_rate_hz as u64 * silence_ms / 1000).max(1) as usize;
+        Self {
+            threshold,
+            silence_samples_required,
+            speech_active: false,
+            silence_run: 0,
+        }
+    }
+
+    pub fn speech_active(&self) -> bool {
+        self.speech_active
+    }
+
+    pub fn process(&mut self, samples: &[i16]) -> VadState {
+        if samples.is_empty() {
+            return VadState::Silence;
+        }
+        let energy = rms_energy(samples);
+        if energy >= self.threshold {
+            self.speech_active = true;
+            self.silence_run = 0;
+            return VadState::Speech;
+        }
+
+        if self.speech_active {
+            self.silence_run += samples.len();
+            if self.silence_run >= self.silence_samples_required {
+                self.speech_active = false;
+                self.silence_run = 0;
+                return VadState::SpeechEnded;
+            }
+            return VadState::Speech;
+        }
+
+        VadState::Silence
+    }
+}
+
+fn rms_energy(samples: &[i16]) -> f32 {
+    if samples.is_empty() {
+        return 0.0;
+    }
+    let sum: f64 = samples
+        .iter()
+        .map(|s| {
+            let v = f64::from(*s) / 32_768.0;
+            v * v
+        })
+        .sum();
+    (sum / samples.len() as f64).sqrt() as f32
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn loud_chunk() -> Vec<i16> {
+        vec![10_000; 320]
+    }
+
+    fn silent_chunk() -> Vec<i16> {
+        vec![0; 320]
+    }
+
+    #[test]
+    fn silence_then_speech_then_end() {
+        let mut vad = EnergyVad::new(0.01, 300, 16_000);
+        assert_eq!(vad.process(&silent_chunk()), VadState::Silence);
+        assert_eq!(vad.process(&loud_chunk()), VadState::Speech);
+        // 300 ms silence at 16 kHz needs 4_800 samples; keep feeding silence until end.
+        let mut state = VadState::Speech;
+        for _ in 0..20 {
+            state = vad.process(&silent_chunk());
+            if state == VadState::SpeechEnded {
+                break;
+            }
+        }
+        assert_eq!(state, VadState::SpeechEnded);
+        assert!(!vad.speech_active());
+    }
+}

--- a/rust/airo_mind_core/src/engine.rs
+++ b/rust/airo_mind_core/src/engine.rs
@@ -48,6 +48,22 @@ pub struct AudioInput<'a> {
     pub channels: u16,
 }
 
+/// How far a transcript segment has progressed toward persistence.
+///
+/// File-path `transcribe` yields only [`Final`] segments. Live paths may emit
+/// [`Partial`] and [`Stable`] before promotion — ADR-0025.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum TranscriptSegmentState {
+    /// Revisable hypothesis for the current utterance tail.
+    Partial,
+    /// Committed to the on-screen log; must not flicker without a later
+    /// [`Final`] correction naming the same segment id.
+    Stable,
+    /// Persisted and evidence-eligible.
+    #[default]
+    Final,
+}
+
 /// One piece of transcript. `I7`: engines yield these, never a whole
 /// transcript, because a two-hour meeting does not fit that assumption.
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -55,6 +71,28 @@ pub struct TranscriptSegment {
     pub start_ms: u64,
     pub end_ms: u64,
     pub text: String,
+    pub state: TranscriptSegmentState,
+}
+
+impl TranscriptSegment {
+    pub fn new(
+        start_ms: u64,
+        end_ms: u64,
+        text: String,
+        state: TranscriptSegmentState,
+    ) -> Self {
+        Self {
+            start_ms,
+            end_ms,
+            text,
+            state,
+        }
+    }
+
+    /// A completed segment from batch/file transcription.
+    pub fn final_text(start_ms: u64, end_ms: u64, text: String) -> Self {
+        Self::new(start_ms, end_ms, text, TranscriptSegmentState::Final)
+    }
 }
 
 /// A prompt the **capability** built. The runtime knows no domains, so there is

--- a/rust/airo_mind_core/src/lib.rs
+++ b/rust/airo_mind_core/src/lib.rs
@@ -160,7 +160,7 @@ pub use dsl::{
 };
 pub use engine::{
     AudioInput, EngineError, GenerationChunk, GenerationEngine, GenerationRequest, RuntimeStats,
-    SpeechEngine, TranscriptSegment, TranscriptionOptions,
+    SpeechEngine, TranscriptSegment, TranscriptSegmentState, TranscriptionOptions,
 };
 pub use event::{CapabilityEvent, EventBus};
 pub use lifecycle::{

--- a/rust/airo_mind_core/src/supervisor.rs
+++ b/rust/airo_mind_core/src/supervisor.rs
@@ -341,11 +341,11 @@ mod tests {
                 if cancel.is_cancelled() {
                     return Err(EngineError::Cancelled);
                 }
-                sink(TranscriptSegment {
-                    start_ms: (i as u64) * 1000,
-                    end_ms: (i as u64 + 1) * 1000,
-                    text: format!("segment {i}"),
-                })?;
+                sink(TranscriptSegment::final_text(
+                    (i as u64) * 1000,
+                    (i as u64 + 1) * 1000,
+                    format!("segment {i}"),
+                ))?;
             }
             Ok(())
         }
@@ -447,11 +447,7 @@ mod tests {
                 sink: &mut dyn FnMut(TranscriptSegment) -> Result<(), EngineError>,
             ) -> Result<(), EngineError> {
                 *self.observed.lock().unwrap() = Some(options.clone());
-                sink(TranscriptSegment {
-                    start_ms: 0,
-                    end_ms: 100,
-                    text: "hi".into(),
-                })
+                sink(TranscriptSegment::final_text(0, 100, "hi".into()))
             }
         }
         s.register_speech(Box::new(ObservingSpeech {

--- a/rust/airo_mind_core/tests/supervisor_conformance.rs
+++ b/rust/airo_mind_core/tests/supervisor_conformance.rs
@@ -92,11 +92,7 @@ impl airo_mind_core::SpeechEngine for BlockingSpeech {
         if let Some(barrier) = &self.barrier {
             barrier.wait();
         }
-        sink(TranscriptSegment {
-            start_ms: 0,
-            end_ms: 1000,
-            text: "one segment".into(),
-        })
+        sink(TranscriptSegment::final_text(0, 1000, "one segment".into()))
     }
 }
 

--- a/rust/airo_mind_whisper/src/api/meetings.rs
+++ b/rust/airo_mind_whisper/src/api/meetings.rs
@@ -977,21 +977,9 @@ mod tests {
     #[test]
     fn transcript_segment_record_preserves_timestamps_text_and_order() {
         let raw = [
-            TranscriptSegment {
-                start_ms: 0,
-                end_ms: 1_200,
-                text: "  the deploy is blocked  ".into(),
-            },
-            TranscriptSegment {
-                start_ms: 1_200,
-                end_ms: 3_450,
-                text: "on the migration".into(),
-            },
-            TranscriptSegment {
-                start_ms: 3_450,
-                end_ms: 5_000,
-                text: "Raj is looking at it".into(),
-            },
+            TranscriptSegment::final_text(0, 1_200, "  the deploy is blocked  ".into()),
+            TranscriptSegment::final_text(1_200, 3_450, "on the migration".into()),
+            TranscriptSegment::final_text(3_450, 5_000, "Raj is looking at it".into()),
         ];
 
         let records: Vec<TranscriptSegmentRecord> = raw
@@ -1034,11 +1022,7 @@ mod tests {
     fn transcript_segment_record_handles_a_single_segment_recording() {
         let record = transcript_segment_record(
             0,
-            &TranscriptSegment {
-                start_ms: 0,
-                end_ms: 900,
-                text: "hello".into(),
-            },
+            &TranscriptSegment::final_text(0, 900, "hello".into()),
         );
         assert_eq!(record.id, "s0");
         assert_eq!(record.start_ms, 0);

--- a/rust/airo_mind_whisper/src/whisper.rs
+++ b/rust/airo_mind_whisper/src/whisper.rs
@@ -104,11 +104,7 @@ impl WhisperSpeechEngine {
             // whisper reports centiseconds.
             let start_ms = offset_ms + segment.start_timestamp().max(0) as u64 * 10;
             let end_ms = offset_ms + segment.end_timestamp().max(0) as u64 * 10;
-            out.push(TranscriptSegment {
-                start_ms,
-                end_ms,
-                text,
-            });
+            out.push(TranscriptSegment::final_text(start_ms, end_ms, text));
         }
         Ok(out)
     }
@@ -303,21 +299,9 @@ mod tests {
     #[test]
     fn consecutive_duplicate_segments_collapse_to_one_span() {
         let input = vec![
-            TranscriptSegment {
-                start_ms: 0,
-                end_ms: 1000,
-                text: "hello".into(),
-            },
-            TranscriptSegment {
-                start_ms: 1000,
-                end_ms: 2000,
-                text: "hello".into(),
-            },
-            TranscriptSegment {
-                start_ms: 2000,
-                end_ms: 3000,
-                text: "other".into(),
-            },
+            TranscriptSegment::final_text(0, 1000, "hello".into()),
+            TranscriptSegment::final_text(1000, 2000, "hello".into()),
+            TranscriptSegment::final_text(2000, 3000, "other".into()),
         ];
         let out = collapse_consecutive_duplicate_text(input);
         assert_eq!(out.len(), 2);
@@ -330,17 +314,17 @@ mod tests {
     fn repetition_loop_stops_after_five_repeats_in_sixty_seconds() {
         let mut input = Vec::new();
         for i in 0..7 {
-            input.push(TranscriptSegment {
-                start_ms: i * 10_000,
-                end_ms: (i + 1) * 10_000,
-                text: "I have to go under the insert.".into(),
-            });
+            input.push(TranscriptSegment::final_text(
+                i * 10_000,
+                (i + 1) * 10_000,
+                "I have to go under the insert.".into(),
+            ));
         }
-        input.push(TranscriptSegment {
-            start_ms: 70_000,
-            end_ms: 71_000,
-            text: "different phrase after the loop".into(),
-        });
+        input.push(TranscriptSegment::final_text(
+            70_000,
+            71_000,
+            "different phrase after the loop".into(),
+        ));
         let out = suppress_repetition_loops(input);
         assert_eq!(
             out.len(),
@@ -354,31 +338,11 @@ mod tests {
     #[test]
     fn short_repeated_phrases_do_not_trigger_the_loop_guard() {
         let input = vec![
-            TranscriptSegment {
-                start_ms: 0,
-                end_ms: 1000,
-                text: "sounds good to me".into(),
-            },
-            TranscriptSegment {
-                start_ms: 1000,
-                end_ms: 2000,
-                text: "sounds good to me".into(),
-            },
-            TranscriptSegment {
-                start_ms: 2000,
-                end_ms: 3000,
-                text: "sounds good to me".into(),
-            },
-            TranscriptSegment {
-                start_ms: 3000,
-                end_ms: 4000,
-                text: "sounds good to me".into(),
-            },
-            TranscriptSegment {
-                start_ms: 4000,
-                end_ms: 5000,
-                text: "different follow-up point".into(),
-            },
+            TranscriptSegment::final_text(0, 1000, "sounds good to me".into()),
+            TranscriptSegment::final_text(1000, 2000, "sounds good to me".into()),
+            TranscriptSegment::final_text(2000, 3000, "sounds good to me".into()),
+            TranscriptSegment::final_text(3000, 4000, "sounds good to me".into()),
+            TranscriptSegment::final_text(4000, 5000, "different follow-up point".into()),
         ];
         let out = suppress_repetition_loops(input);
         assert_eq!(out.len(), 2, "four repeats then a different phrase stays");


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements **Stage 1** of the streaming STT / zero-copy design (qualification merged in #1863): native-owned PCM orchestration above the existing `SpeechEngine::transcribe` boundary, without changing the public Dart API yet.

### Changes

**`airo_mind_core`**
- `TranscriptSegmentState`: `Partial`, `Stable`, `Final`
- `TranscriptSegment::new()` / `final_text()` for batch vs live segments
- Supervisor fakes updated to emit `Final` segments

**`airo_mind_audio`**
- `PcmRingBuffer` — bounded ring, drop-oldest under pressure
- `EnergyVad` — RMS energy gate + silence boundary for utterance commit
- `TranscriptStabilizer` — PARTIAL → STABLE → FINAL without rewriting stable text
- `LiveSpeechPipeline` — ring → VAD → bounded window → engine → stabilizer

**`airo_mind_whisper`**
- Batch `decode_segments` and tests use `TranscriptSegment::final_text`

### Verification

```
cargo test -p airo_mind_core -p airo_mind_audio
```
All pass (296 core + 8 audio unit tests).

### Follow-ups (separate PRs)

- FRB: `start_live_session` / `stop_live_session` / `TranscriptDelta`
- Dart: `TranscriptionMode` preference + live transcript UI
- Platform capture fan-out (durable file + native PCM ring)
- RTF-aware live model cap in registry
- Mark ADR-0025 Accepted after review
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6db2c21f-f02a-4df9-92b2-e0797ee40b7b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6db2c21f-f02a-4df9-92b2-e0797ee40b7b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

