### PR TITLE
docs(mind): add-on framework design + Increment 1 contracts

### DIFF
--- a/docs/superpowers/plans/2026-08-22-airo-mind-addon-framework-increment-1.md
+++ b/docs/superpowers/plans/2026-08-22-airo-mind-addon-framework-increment-1.md
@@ -1,0 +1,122 @@
+# Airo Mind Add-on Framework — Increment 1 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Introduce neutral add-on and graph contracts in `core_domain`/`core_ai`, freeze current Diet/insurance/hospital/property behavior as characterization fixtures, and prove synthetic generative and graph-workflow add-ons run through the registry without host ID switches.
+
+**Architecture:** `core_domain` owns data contracts (`AddonManifest`, graph DTOs, workflow projections, ports). `core_ai` owns validation, registry, adapter interfaces, and dispatch with zero business vocabulary. `feature_mind` keeps existing linker/projector/pending for now but adds JSON characterization fixtures and a bridge mapping `ChatEntityGraph` ↔ neutral `EntityGraph`. Production chat is not rerouted in this increment.
+
+**Tech Stack:** Dart 3.12, Flutter test, melos workspace packages `core_domain`, `core_ai`, `feature_mind`.
+
+## Global Constraints
+
+- Spec: `docs/superpowers/specs/2026-08-22-airo-mind-addon-framework-design.md`
+- `core_domain` has `allowed_dependencies: []` — no new third-party deps.
+- `core_ai` may depend only on `core_domain`, `core_native`, `core_workers`, `platform_downloads`.
+- Framework production code and framework tests use neutral identifiers (`sample-addon`, `subject`, `related_to`). Domain vocabulary lives in `feature_mind` characterization fixtures only.
+- Serialized graph JSON shape is unchanged: `nodes`, `edges`, `recent_node_ids`; node `type` remains a string key (`person`, `organization`, …).
+- Parsing above 50 KB uses worker boundary in later increments; fixtures stay small.
+- Verify: `cd packages/core_domain && flutter test`, `cd packages/core_ai && flutter test`, `cd packages/feature_mind && flutter test test/agent_chat/fixtures/ test/agent_chat/domain/services/chat_entity_* test/addons/`
+
+---
+
+### Task 1: Neutral graph DTOs in `core_domain`
+
+**Files:**
+- Create: `packages/core_domain/lib/src/graph/entity_graph_node.dart`
+- Create: `packages/core_domain/lib/src/graph/entity_graph_edge.dart`
+- Create: `packages/core_domain/lib/src/graph/entity_graph.dart`
+- Create: `packages/core_domain/lib/src/graph/entity_graph_patch.dart`
+- Create: `packages/core_domain/lib/src/graph/graph_provenance.dart`
+- Modify: `packages/core_domain/lib/core_domain.dart`
+- Test: `packages/core_domain/test/graph/entity_graph_test.dart`
+
+**Interfaces:**
+- Produces: `EntityGraphNode`, `EntityGraphEdge`, `EntityGraph`, `EntityGraphPatch`, `GraphProvenanceRef` with `fromJson`/`toJson` matching existing chat graph JSON.
+
+- [ ] **Step 1:** Write failing round-trip JSON test for a sample node/edge/graph.
+- [ ] **Step 2:** Implement DTOs with string `typeKey` (not `EntityType` enum).
+- [ ] **Step 3:** Export from `core_domain.dart` and run `flutter test test/graph/`.
+
+---
+
+### Task 2: Add-on manifest and workflow contracts in `core_domain`
+
+**Files:**
+- Create: `packages/core_domain/lib/src/addons/addon_id.dart`
+- Create: `packages/core_domain/lib/src/addons/addon_identity.dart`
+- Create: `packages/core_domain/lib/src/addons/addon_behavior_kind.dart`
+- Create: `packages/core_domain/lib/src/addons/addon_manifest.dart`
+- Create: `packages/core_domain/lib/src/workflow/offer_decision.dart`
+- Create: `packages/core_domain/lib/src/workflow/workflow_projection.dart`
+- Create: `packages/core_domain/lib/src/workflow/pending_assessment.dart`
+- Create: `packages/core_domain/lib/src/addons/addon_registry_port.dart`
+- Test: `packages/core_domain/test/addons/addon_manifest_test.dart`
+
+- [ ] **Step 1:** Failing test parsing a minimal `addon.json` shape from the spec.
+- [ ] **Step 2:** Implement manifest + workflow types.
+- [ ] **Step 3:** Run `flutter test test/addons/`.
+
+---
+
+### Task 3: Manifest validation and registry in `core_ai`
+
+**Files:**
+- Create: `packages/core_ai/lib/src/addons/addon_manifest_validator.dart`
+- Create: `packages/core_ai/lib/src/addons/addon_registry.dart`
+- Create: `packages/core_ai/lib/src/addons/generative_addon_adapter.dart`
+- Create: `packages/core_ai/lib/src/addons/graph_workflow_addon_adapter.dart`
+- Create: `packages/core_ai/lib/src/addons/addon_conversation.dart`
+- Create: `packages/core_ai/lib/src/addons/addon_prompt.dart`
+- Create: `packages/core_ai/lib/src/addons/addon_evaluation.dart`
+- Create: `packages/core_ai/lib/src/addons/graph_ingest_context.dart`
+- Create: `packages/core_ai/lib/src/addons/addon_eligibility.dart`
+- Modify: `packages/core_ai/lib/core_ai.dart`
+- Test: `packages/core_ai/test/addons/addon_manifest_validator_test.dart`
+- Test: `packages/core_ai/test/addons/addon_registry_test.dart`
+
+- [ ] **Step 1:** Failing validator tests (unknown schema, duplicate ID, undeclared tool).
+- [ ] **Step 2:** Implement validator + registry with enabled/pinned/granted flags.
+- [ ] **Step 3:** Failing registry tests for ordering and zero calls when disabled.
+- [ ] **Step 4:** Run `flutter test test/addons/`.
+
+---
+
+### Task 4: Synthetic adapters proving no host switch
+
+**Files:**
+- Create: `packages/core_ai/test/addons/synthetic_generative_adapter.dart`
+- Create: `packages/core_ai/test/addons/synthetic_graph_workflow_adapter.dart`
+- Test: `packages/core_ai/test/addons/synthetic_addon_dispatch_test.dart`
+
+- [ ] **Step 1:** Synthetic generative adapter returns prompt when message contains `sample-trigger`.
+- [ ] **Step 2:** Synthetic graph adapter patches a `subject` node when message contains `sample-extract`.
+- [ ] **Step 3:** Registry dispatch test proves both behaviors without referencing real add-on IDs in `core_ai` production code.
+- [ ] **Step 4:** Spy test: disabled add-on receives zero adapter calls.
+
+---
+
+### Task 5: Characterization fixtures in `feature_mind`
+
+**Files:**
+- Create: `packages/feature_mind/test/agent_chat/fixtures/characterization/*.json`
+- Create: `packages/feature_mind/test/agent_chat/fixtures/characterization_test.dart`
+- Create: `packages/feature_mind/lib/src/agent_chat/domain/models/entity_graph_bridge.dart`
+
+- [ ] **Step 1:** Capture JSON for insurance-only, claim+hospital, property-only linker graphs.
+- [ ] **Step 2:** Capture diet constraint lines and model prompt substrings as JSON.
+- [ ] **Step 3:** Characterization test compares live linker/projector/pending/diet output to fixtures.
+- [ ] **Step 4:** Bridge test: `ChatEntityGraph` ↔ `EntityGraph` round-trip preserves JSON.
+
+---
+
+### Task 6: Host dispatch smoke test
+
+**Files:**
+- Create: `packages/feature_mind/test/addons/addon_host_dispatch_test.dart`
+- Create: `packages/feature_mind/lib/src/addons/addon_host_dispatch.dart`
+
+- [ ] **Step 1:** Thin host wrapper calls `AddonRegistry` with synthetic adapters only.
+- [ ] **Step 2:** Test proves generative and graph paths return typed results without `if (addonId == …)` in host code.
+
+---

--- a/docs/superpowers/specs/2026-08-22-airo-mind-addon-framework-design.md
+++ b/docs/superpowers/specs/2026-08-22-airo-mind-addon-framework-design.md
@@ -1,8 +1,8 @@
 # Airo Mind Add-on Framework
 
 **Date:** 2026-08-22  
-**Status:** Approved product direction; security and QA gates incorporated;
-implementation plan pending user review  
+**Status:** Approved; Increment 1 contracts and characterization landed on
+`cursor/mind-addon-framework-design-45dd`; implementation continues increment-by-increment  
 **Owners:** Framework Agent + Product Manager (Airo Mind)  
 **Required reviewers:** Product Manager, Framework Agent, AI/Brain Agent,
 Memory Agent, Chief Architect, Platform Architect, Flutter Architect, Edge

--- a/packages/core_ai/lib/core_ai.dart
+++ b/packages/core_ai/lib/core_ai.dart
@@ -99,6 +99,17 @@ export 'src/skills/skill_permission_engine.dart';
 export 'src/skills/skill_schema.dart';
 export 'src/skills/skill_trigger_eval.dart';
 
+// Add-on framework (manifest validation, registry, adapter contracts)
+export 'src/addons/addon_manifest_validator.dart';
+export 'src/addons/addon_registry.dart';
+export 'src/addons/addon_eligibility.dart';
+export 'src/addons/addon_conversation.dart';
+export 'src/addons/addon_prompt.dart';
+export 'src/addons/addon_evaluation.dart';
+export 'src/addons/graph_ingest_context.dart';
+export 'src/addons/generative_addon_adapter.dart';
+export 'src/addons/graph_workflow_addon_adapter.dart';
+
 // Prompt Management
 export 'src/prompts/prompt.dart';
 export 'src/prompts/prompt_template.dart';

--- a/packages/core_ai/lib/src/addons/addon_conversation.dart
+++ b/packages/core_ai/lib/src/addons/addon_conversation.dart
@@ -1,0 +1,27 @@
+import 'package:meta/meta.dart';
+
+@immutable
+class AddonConversationMessage {
+  const AddonConversationMessage({
+    required this.text,
+    required this.isUser,
+  });
+
+  final String text;
+  final bool isUser;
+}
+
+@immutable
+class AddonConversation {
+  const AddonConversation({
+    required this.currentPrompt,
+    this.history = const [],
+    this.threadId = '',
+    this.turnRevision = '',
+  });
+
+  final String currentPrompt;
+  final List<AddonConversationMessage> history;
+  final String threadId;
+  final String turnRevision;
+}

--- a/packages/core_ai/lib/src/addons/addon_eligibility.dart
+++ b/packages/core_ai/lib/src/addons/addon_eligibility.dart
@@ -1,0 +1,37 @@
+import 'package:meta/meta.dart';
+
+@immutable
+class AddonEligibility {
+  const AddonEligibility({
+    this.enabled = false,
+    this.pinned = false,
+    this.grantedScopes = const {},
+    this.quarantined = false,
+    this.revoked = false,
+  });
+
+  final bool enabled;
+  final bool pinned;
+  final Set<String> grantedScopes;
+  final bool quarantined;
+  final bool revoked;
+
+  bool get isEligible =>
+      enabled && !quarantined && !revoked && grantedScopes.isNotEmpty;
+
+  bool hasScope(String scope) => grantedScopes.contains(scope);
+
+  AddonEligibility copyWith({
+    bool? enabled,
+    bool? pinned,
+    Set<String>? grantedScopes,
+    bool? quarantined,
+    bool? revoked,
+  }) => AddonEligibility(
+    enabled: enabled ?? this.enabled,
+    pinned: pinned ?? this.pinned,
+    grantedScopes: grantedScopes ?? this.grantedScopes,
+    quarantined: quarantined ?? this.quarantined,
+    revoked: revoked ?? this.revoked,
+  );
+}

--- a/packages/core_ai/lib/src/addons/addon_evaluation.dart
+++ b/packages/core_ai/lib/src/addons/addon_evaluation.dart
@@ -1,0 +1,25 @@
+import 'package:meta/meta.dart';
+
+enum AddonEvaluationKind {
+  valid,
+  invalid,
+  retry,
+  clarificationRequired,
+  modelUnavailable,
+}
+
+@immutable
+class AddonEvaluation {
+  const AddonEvaluation({
+    required this.kind,
+    this.reason = '',
+    this.safeCopy = '',
+  });
+
+  final AddonEvaluationKind kind;
+  final String reason;
+  final String safeCopy;
+
+  bool get isValid => kind == AddonEvaluationKind.valid;
+  bool get wantsRetry => kind == AddonEvaluationKind.retry;
+}

--- a/packages/core_ai/lib/src/addons/addon_manifest_validator.dart
+++ b/packages/core_ai/lib/src/addons/addon_manifest_validator.dart
@@ -1,0 +1,133 @@
+import 'package:core_domain/core_domain.dart';
+import 'package:meta/meta.dart';
+
+@immutable
+class AddonManifestValidationResult {
+  const AddonManifestValidationResult._(this.errors);
+
+  const AddonManifestValidationResult.valid() : this._(const []);
+
+  const AddonManifestValidationResult.invalid(List<String> errors)
+    : this._(errors);
+
+  final List<String> errors;
+
+  bool get isValid => errors.isEmpty;
+}
+
+const Set<String> kKnownAddonCapabilities = {
+  'conversation.process',
+  'conversation.current_turn',
+  'conversation.thread_history',
+  'lifetrack.read',
+  'lifetrack.write',
+  'memory.read',
+  'graph.addon_scope.read',
+};
+
+const Set<String> kKnownAddonTools = {
+  'query_entity_graph',
+  'record_lifetrack_facts',
+  'query_lifetrack_status',
+};
+
+const Set<String> kKnownSafetyClasses = {
+  'general',
+  'health',
+  'financial',
+  'identity',
+  'education',
+};
+
+class AddonManifestValidator {
+  const AddonManifestValidator();
+
+  AddonManifestValidationResult validate(Map<String, dynamic> json) {
+    final errors = <String>[];
+
+    final schemaVersion = json['schema_version'];
+    if (schemaVersion != kAddonManifestSchemaVersion) {
+      errors.add('unsupported schema_version: $schemaVersion');
+    }
+
+    final id = json['id'];
+    if (id is! String || id.trim().isEmpty) {
+      errors.add('id is required');
+    }
+
+    final version = json['version'];
+    if (version is! String || version.trim().isEmpty) {
+      errors.add('version is required');
+    }
+
+    final behaviors = json['behaviors'];
+    if (behaviors is! List || behaviors.isEmpty) {
+      errors.add('behaviors must be a non-empty list');
+    } else {
+      for (final behavior in behaviors) {
+        try {
+          AddonBehaviorKind.fromJson(behavior as String);
+        } on ArgumentError {
+          errors.add('unknown behavior: $behavior');
+        }
+      }
+    }
+
+    final capabilities = json['capabilities'];
+    if (capabilities is! List) {
+      errors.add('capabilities must be a list');
+    } else {
+      for (final capability in capabilities) {
+        if (!kKnownAddonCapabilities.contains(capability)) {
+          errors.add('undeclared capability: $capability');
+        }
+      }
+      if (capabilities.contains('memory.write')) {
+        errors.add('memory.write is unsupported in this migration');
+      }
+    }
+
+    final tools = json['tools'];
+    if (tools is! List) {
+      errors.add('tools must be a list');
+    } else {
+      for (final tool in tools) {
+        if (!kKnownAddonTools.contains(tool)) {
+          errors.add('undeclared tool: $tool');
+        }
+      }
+    }
+
+    final safetyClass = json['safety_class'] as String? ?? 'general';
+    if (!kKnownSafetyClasses.contains(safetyClass)) {
+      errors.add('unknown safety_class: $safetyClass');
+    }
+
+    final adapter = json['adapter'] as Map<String, dynamic>?;
+    if (adapter != null) {
+      final kind = adapter['kind'] as String?;
+      if (kind != null && kind != 'required_built_in') {
+        errors.add('adapter.kind must be required_built_in when present');
+      }
+      final contract = adapter['contract'] as String?;
+      if (contract != null &&
+          contract != 'graph_workflow_v1' &&
+          contract != 'generative_v1') {
+        errors.add('unknown adapter contract: $contract');
+      }
+    }
+
+    if (behaviors is List &&
+        behaviors.contains('graph_workflow') &&
+        json['workflow'] == null) {
+      errors.add('graph_workflow behavior requires workflow block');
+    }
+
+    return errors.isEmpty
+        ? const AddonManifestValidationResult.valid()
+        : AddonManifestValidationResult.invalid(errors);
+  }
+
+  AddonManifestValidationResult validateManifest(AddonManifest manifest) =>
+      validate(manifest.toJson());
+}

--- a/packages/core_ai/lib/src/addons/addon_prompt.dart
+++ b/packages/core_ai/lib/src/addons/addon_prompt.dart
@@ -1,0 +1,16 @@
+import 'package:meta/meta.dart';
+
+@immutable
+class AddonPrompt {
+  const AddonPrompt({
+    required this.systemInstruction,
+    required this.userPrompt,
+    this.metadata = const {},
+  });
+
+  final String systemInstruction;
+  final String userPrompt;
+  final Map<String, String> metadata;
+
+  bool get isEmpty => systemInstruction.isEmpty && userPrompt.isEmpty;
+}

--- a/packages/core_ai/lib/src/addons/addon_registry.dart
+++ b/packages/core_ai/lib/src/addons/addon_registry.dart
@@ -1,0 +1,152 @@
+import 'package:core_domain/core_domain.dart';
+
+import 'addon_eligibility.dart';
+import 'addon_manifest_validator.dart';
+import 'generative_addon_adapter.dart';
+import 'graph_workflow_addon_adapter.dart';
+
+class AddonRegistrationException implements Exception {
+  AddonRegistrationException(this.message);
+
+  final String message;
+
+  @override
+  String toString() => 'AddonRegistrationException: $message';
+}
+
+class AddonRegistry implements AddonRegistryPort {
+  AddonRegistry({AddonManifestValidator? validator})
+    : _validator = validator ?? const AddonManifestValidator();
+
+  final AddonManifestValidator _validator;
+  final Map<String, AddonManifest> _manifests = {};
+  final Map<String, GenerativeAddonAdapter> _generativeAdapters = {};
+  final Map<String, GraphWorkflowAddonAdapter> _graphAdapters = {};
+  final Map<String, AddonEligibility> _eligibility = {};
+
+  List<AddonManifest> get manifests =>
+      _manifests.values.toList(growable: false);
+
+  void registerBuiltIn({
+    required AddonManifest manifest,
+    GenerativeAddonAdapter? generativeAdapter,
+    GraphWorkflowAddonAdapter? graphAdapter,
+  }) {
+    final validation = _validator.validateManifest(manifest);
+    if (!validation.isValid) {
+      throw AddonRegistrationException(validation.errors.join('; '));
+    }
+
+    if (manifest.hasBehavior(AddonBehaviorKind.generative) &&
+        generativeAdapter == null) {
+      throw AddonRegistrationException(
+        'generative behavior requires a built-in adapter',
+      );
+    }
+    if (manifest.hasBehavior(AddonBehaviorKind.graphWorkflow) &&
+        graphAdapter == null) {
+      throw AddonRegistrationException(
+        'graph_workflow behavior requires a built-in adapter',
+      );
+    }
+
+    final id = manifest.id.value;
+    if (_manifests.containsKey(id)) {
+      throw AddonRegistrationException('duplicate add-on id: $id');
+    }
+
+    _manifests[id] = manifest;
+    if (generativeAdapter != null) {
+      _generativeAdapters[id] = generativeAdapter;
+    }
+    if (graphAdapter != null) {
+      _graphAdapters[id] = graphAdapter;
+    }
+    _eligibility.putIfAbsent(id, () => const AddonEligibility());
+  }
+
+  @override
+  AddonManifest? manifestFor(String addonId) => _manifests[addonId];
+
+  @override
+  bool isEnabled(String addonId) => _eligibility[addonId]?.enabled ?? false;
+
+  @override
+  bool isPinned(String addonId) => _eligibility[addonId]?.pinned ?? false;
+
+  @override
+  bool hasGrant(String addonId, String scope) =>
+      _eligibility[addonId]?.hasScope(scope) ?? false;
+
+  void setEligibility(String addonId, AddonEligibility eligibility) {
+    if (!_manifests.containsKey(addonId)) {
+      throw AddonRegistrationException('unknown add-on: $addonId');
+    }
+    _eligibility[addonId] = eligibility;
+  }
+
+  AddonEligibility eligibilityFor(String addonId) =>
+      _eligibility[addonId] ?? const AddonEligibility();
+
+  List<AddonManifest> eligibleManifests({
+    AddonBehaviorKind? behavior,
+    String requiredScope = 'conversation.current_turn',
+  }) {
+    final candidates = _manifests.values.where((manifest) {
+      if (behavior != null && !manifest.hasBehavior(behavior)) {
+        return false;
+      }
+      final state = _eligibility[manifest.id.value];
+      return state != null &&
+          state.isEligible &&
+          state.hasScope(requiredScope);
+    }).toList(growable: false);
+
+    final pinnedList = candidates
+        .where((manifest) => _eligibility[manifest.id.value]!.pinned)
+        .toList(growable: false);
+    final unpinnedList = candidates
+        .where((manifest) => !_eligibility[manifest.id.value]!.pinned)
+        .toList(growable: false);
+
+    pinnedList.sort(_comparePriority);
+    unpinnedList.sort(_comparePriority);
+    return [...pinnedList, ...unpinnedList];
+  }
+
+  int _comparePriority(AddonManifest a, AddonManifest b) {
+    final priorityCompare = b.builtInPriority.compareTo(a.builtInPriority);
+    if (priorityCompare != 0) return priorityCompare;
+    return a.id.value.compareTo(b.id.value);
+  }
+
+  List<GenerativeAddonAdapter> eligibleGenerativeAdapters({
+    String requiredScope = 'conversation.current_turn',
+  }) {
+    return eligibleManifests(
+      behavior: AddonBehaviorKind.generative,
+      requiredScope: requiredScope,
+    )
+        .map((manifest) => _generativeAdapters[manifest.id.value])
+        .whereType<GenerativeAddonAdapter>()
+        .toList(growable: false);
+  }
+
+  List<GraphWorkflowAddonAdapter> eligibleGraphAdapters({
+    String requiredScope = 'conversation.current_turn',
+  }) {
+    return eligibleManifests(
+      behavior: AddonBehaviorKind.graphWorkflow,
+      requiredScope: requiredScope,
+    )
+        .map((manifest) => _graphAdapters[manifest.id.value])
+        .whereType<GraphWorkflowAddonAdapter>()
+        .toList(growable: false);
+  }
+
+  GenerativeAddonAdapter? generativeAdapterFor(String addonId) =>
+      _generativeAdapters[addonId];
+
+  GraphWorkflowAddonAdapter? graphAdapterFor(String addonId) =>
+      _graphAdapters[addonId];
+}

--- a/packages/core_ai/lib/src/addons/generative_addon_adapter.dart
+++ b/packages/core_ai/lib/src/addons/generative_addon_adapter.dart
@@ -1,0 +1,15 @@
+import 'package:core_domain/core_domain.dart';
+
+import 'addon_conversation.dart';
+import 'addon_evaluation.dart';
+import 'addon_prompt.dart';
+
+abstract interface class GenerativeAddonAdapter {
+  AddonIdentity get identity;
+
+  bool accepts(AddonConversation input);
+
+  AddonPrompt buildPrompt(AddonConversation input);
+
+  AddonEvaluation evaluate(String output);
+}

--- a/packages/core_ai/lib/src/addons/graph_ingest_context.dart
+++ b/packages/core_ai/lib/src/addons/graph_ingest_context.dart
@@ -1,0 +1,17 @@
+import 'package:core_domain/core_domain.dart';
+import 'package:meta/meta.dart';
+
+@immutable
+class GraphIngestContext {
+  const GraphIngestContext({
+    required this.text,
+    required this.graph,
+    this.threadId = '',
+    this.turnRevision = '',
+  });
+
+  final String text;
+  final EntityGraph graph;
+  final String threadId;
+  final String turnRevision;
+}

--- a/packages/core_ai/lib/src/addons/graph_workflow_addon_adapter.dart
+++ b/packages/core_ai/lib/src/addons/graph_workflow_addon_adapter.dart
@@ -1,0 +1,18 @@
+import 'package:core_domain/core_domain.dart';
+
+import 'graph_ingest_context.dart';
+
+abstract interface class GraphWorkflowAddonAdapter {
+  AddonIdentity get identity;
+
+  bool accepts(GraphIngestContext input);
+
+  Future<EntityGraphPatch> extract(GraphIngestContext input);
+
+  Iterable<WorkflowProjection> project(EntityGraph graph);
+
+  PendingAssessment assessPending(
+    EntityGraph graph,
+    WorkflowProjection projection,
+  );
+}

--- a/packages/core_ai/test/addons/addon_manifest_validator_test.dart
+++ b/packages/core_ai/test/addons/addon_manifest_validator_test.dart
@@ -1,0 +1,45 @@
+import 'package:core_ai/core_ai.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  const validator = AddonManifestValidator();
+
+  test('rejects unknown schema version', () {
+    final result = validator.validate({
+      'schema_version': '9.9',
+      'id': 'sample-addon',
+      'version': '1.0.0',
+      'behaviors': ['generative'],
+      'capabilities': ['conversation.current_turn'],
+      'tools': [],
+    });
+    expect(result.isValid, isFalse);
+    expect(result.errors, contains(startsWith('unsupported schema_version')));
+  });
+
+  test('rejects undeclared tool', () {
+    final result = validator.validate({
+      'schema_version': '1.0',
+      'id': 'sample-addon',
+      'version': '1.0.0',
+      'behaviors': ['generative'],
+      'capabilities': ['conversation.current_turn'],
+      'tools': ['unknown_tool'],
+    });
+    expect(result.isValid, isFalse);
+    expect(result.errors, contains('undeclared tool: unknown_tool'));
+  });
+
+  test('rejects memory.write capability', () {
+    final result = validator.validate({
+      'schema_version': '1.0',
+      'id': 'sample-addon',
+      'version': '1.0.0',
+      'behaviors': ['generative'],
+      'capabilities': ['memory.write'],
+      'tools': [],
+    });
+    expect(result.isValid, isFalse);
+    expect(result.errors, contains('memory.write is unsupported in this migration'));
+  });
+}

--- a/packages/core_ai/test/addons/addon_registry_test.dart
+++ b/packages/core_ai/test/addons/addon_registry_test.dart
@@ -1,0 +1,185 @@
+import 'package:core_ai/core_ai.dart';
+import 'package:core_domain/core_domain.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+AddonManifest _sampleGenerativeManifest() => AddonManifest.fromJson({
+  'schema_version': '1.0',
+  'id': 'sample-generative',
+  'version': '1.0.0',
+  'behaviors': ['generative'],
+  'capabilities': ['conversation.current_turn'],
+  'tools': [],
+  'adapter': {'kind': 'required_built_in', 'contract': 'generative_v1'},
+});
+
+AddonManifest _sampleGraphManifest({int priority = 0}) =>
+    AddonManifest.fromJson({
+      'schema_version': '1.0',
+      'id': 'sample-graph',
+      'version': '1.0.0',
+      'behaviors': ['graph_workflow'],
+      'capabilities': ['conversation.current_turn', 'graph.addon_scope.read'],
+      'tools': ['query_entity_graph'],
+      'adapter': {
+        'kind': 'required_built_in',
+        'contract': 'graph_workflow_v1',
+      },
+      'workflow': {
+        'template_asset': 'template.json',
+        'subject_kind': 'subject',
+      },
+      if (priority != 0) 'built_in_priority': priority,
+    });
+
+class _SpyGenerativeAdapter implements GenerativeAddonAdapter {
+  _SpyGenerativeAdapter(this.id, {this.onAccepts, this.onBuild});
+
+  final AddonId id;
+  int acceptsCalls = 0;
+  int buildCalls = 0;
+  bool Function(AddonConversation input)? onAccepts;
+  AddonPrompt Function(AddonConversation input)? onBuild;
+
+  @override
+  AddonIdentity get identity => AddonIdentity(id: id, version: '1.0.0');
+
+  @override
+  bool accepts(AddonConversation input) {
+    acceptsCalls++;
+    return onAccepts?.call(input) ?? false;
+  }
+
+  @override
+  AddonPrompt buildPrompt(AddonConversation input) {
+    buildCalls++;
+    return onBuild?.call(input) ??
+        const AddonPrompt(systemInstruction: 'sys', userPrompt: 'user');
+  }
+
+  @override
+  AddonEvaluation evaluate(String output) =>
+      const AddonEvaluation(kind: AddonEvaluationKind.valid);
+}
+
+class _SpyGraphAdapter implements GraphWorkflowAddonAdapter {
+  _SpyGraphAdapter(this.id, {this.onAccepts});
+
+  final AddonId id;
+  int acceptsCalls = 0;
+  bool Function(GraphIngestContext input)? onAccepts;
+
+  @override
+  AddonIdentity get identity => AddonIdentity(id: id, version: '1.0.0');
+
+  @override
+  bool accepts(GraphIngestContext input) {
+    acceptsCalls++;
+    return onAccepts?.call(input) ?? false;
+  }
+
+  @override
+  Future<EntityGraphPatch> extract(GraphIngestContext input) async =>
+      const EntityGraphPatch();
+
+  @override
+  Iterable<WorkflowProjection> project(EntityGraph graph) => const [];
+
+  @override
+  PendingAssessment assessPending(
+    EntityGraph graph,
+    WorkflowProjection projection,
+  ) => PendingAssessment(
+    identity: identity,
+    subjectNodeId: projection.subjectNodeId,
+    storedFacts: {},
+    missingRequired: [],
+    missingOptional: [],
+  );
+}
+
+void main() {
+  test('duplicate registration fails closed', () {
+    final registry = AddonRegistry();
+    final manifest = _sampleGenerativeManifest();
+    final adapter = _SpyGenerativeAdapter(manifest.id);
+
+    registry.registerBuiltIn(
+      manifest: manifest,
+      generativeAdapter: adapter,
+    );
+
+    expect(
+      () => registry.registerBuiltIn(
+        manifest: manifest,
+        generativeAdapter: adapter,
+      ),
+      throwsA(isA<AddonRegistrationException>()),
+    );
+  });
+
+  test('pinned add-on is ordered before unpinned with same priority', () {
+    final registry = AddonRegistry();
+    final low = _sampleGraphManifest();
+    final high = AddonManifest.fromJson({
+      'schema_version': '1.0',
+      'id': 'sample-graph-b',
+      'version': '1.0.0',
+      'behaviors': ['graph_workflow'],
+      'capabilities': ['conversation.current_turn'],
+      'tools': ['query_entity_graph'],
+      'workflow': {'subject_kind': 'subject'},
+    });
+
+    registry.registerBuiltIn(
+      manifest: low,
+      graphAdapter: _SpyGraphAdapter(low.id),
+    );
+    registry.registerBuiltIn(
+      manifest: high,
+      graphAdapter: _SpyGraphAdapter(high.id),
+    );
+
+    registry.setEligibility(
+      low.id.value,
+      const AddonEligibility(
+        enabled: true,
+        grantedScopes: {'conversation.current_turn'},
+      ),
+    );
+    registry.setEligibility(
+      high.id.value,
+      const AddonEligibility(
+        enabled: true,
+        pinned: true,
+        grantedScopes: {'conversation.current_turn'},
+      ),
+    );
+
+    final ordered = registry.eligibleManifests(
+      behavior: AddonBehaviorKind.graphWorkflow,
+    );
+    expect(ordered.first.id.value, 'sample-graph-b');
+  });
+
+  test('disabled add-on receives zero adapter calls', () {
+    final registry = AddonRegistry();
+    final manifest = _sampleGenerativeManifest();
+    final spy = _SpyGenerativeAdapter(
+      manifest.id,
+      onAccepts: (_) => true,
+    );
+
+    registry.registerBuiltIn(
+      manifest: manifest,
+      generativeAdapter: spy,
+    );
+    registry.setEligibility(
+      manifest.id.value,
+      const AddonEligibility(enabled: false),
+    );
+
+    final adapters = registry.eligibleGenerativeAdapters();
+    expect(adapters, isEmpty);
+    expect(spy.acceptsCalls, 0);
+  });
+}

--- a/packages/core_ai/test/addons/synthetic_addon_dispatch_test.dart
+++ b/packages/core_ai/test/addons/synthetic_addon_dispatch_test.dart
@@ -1,0 +1,108 @@
+import 'package:core_ai/core_ai.dart';
+import 'package:core_domain/core_domain.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'synthetic_generative_adapter.dart';
+import 'synthetic_graph_workflow_adapter.dart';
+
+AddonManifest _generativeManifest() => AddonManifest.fromJson({
+  'schema_version': '1.0',
+  'id': 'sample-generative',
+  'version': '1.0.0',
+  'behaviors': ['generative'],
+  'capabilities': ['conversation.current_turn'],
+  'tools': [],
+  'adapter': {'kind': 'required_built_in', 'contract': 'generative_v1'},
+});
+
+AddonManifest _graphManifest() => AddonManifest.fromJson({
+  'schema_version': '1.0',
+  'id': 'sample-graph',
+  'version': '1.0.0',
+  'behaviors': ['graph_workflow'],
+  'capabilities': ['conversation.current_turn', 'graph.addon_scope.read'],
+  'tools': ['query_entity_graph'],
+  'adapter': {'kind': 'required_built_in', 'contract': 'graph_workflow_v1'},
+  'workflow': {'subject_kind': 'subject'},
+});
+
+void main() {
+  test('synthetic generative adapter routes through registry without host switch',
+      () {
+    final registry = AddonRegistry();
+    final generative = SyntheticGenerativeAdapter();
+    final manifest = _generativeManifest();
+
+    registry.registerBuiltIn(
+      manifest: manifest,
+      generativeAdapter: generative,
+    );
+    registry.setEligibility(
+      manifest.id.value,
+      const AddonEligibility(
+        enabled: true,
+        grantedScopes: {'conversation.current_turn'},
+      ),
+    );
+
+    final conversation = const AddonConversation(
+      currentPrompt: 'please sample-trigger now',
+    );
+
+    final accepting = registry
+        .eligibleGenerativeAdapters()
+        .where((adapter) => adapter.accepts(conversation))
+        .toList(growable: false);
+
+    expect(accepting, hasLength(1));
+    final prompt = accepting.single.buildPrompt(conversation);
+    expect(prompt.userPrompt, contains('sample-trigger'));
+    expect(prompt.systemInstruction, 'sample-system');
+  });
+
+  test('synthetic graph adapter extracts and projects through registry', () async {
+    final registry = AddonRegistry();
+    final graphAdapter = SyntheticGraphWorkflowAdapter();
+    final manifest = _graphManifest();
+
+    registry.registerBuiltIn(
+      manifest: manifest,
+      graphAdapter: graphAdapter,
+    );
+    registry.setEligibility(
+      manifest.id.value,
+      const AddonEligibility(
+        enabled: true,
+        grantedScopes: {'conversation.current_turn'},
+      ),
+    );
+
+    final context = GraphIngestContext(
+      text: 'please sample-extract subject',
+      graph: EntityGraph.empty,
+      turnRevision: 'turn-1',
+    );
+
+    final adapters = registry.eligibleGraphAdapters();
+    final accepting = adapters.where((adapter) => adapter.accepts(context));
+    expect(accepting, hasLength(1));
+
+    final patch = await accepting.single.extract(context);
+    final merged = context.graph.upsert(
+      incomingNodes: patch.nodes,
+      incomingEdges: patch.edges,
+      mentionedIds: patch.mentionedNodeIds,
+    );
+
+    final projections = accepting.single.project(merged).toList(growable: false);
+    expect(projections, hasLength(1));
+    expect(projections.single.templateId, 'sample-template');
+    expect(projections.single.isOfferable, isTrue);
+
+    final pending = accepting.single.assessPending(
+      merged,
+      projections.single,
+    );
+    expect(pending.missingRequired, ['field_b']);
+  });
+}

--- a/packages/core_ai/test/addons/synthetic_generative_adapter.dart
+++ b/packages/core_ai/test/addons/synthetic_generative_adapter.dart
@@ -1,0 +1,33 @@
+import 'package:core_ai/core_ai.dart';
+import 'package:core_domain/core_domain.dart';
+
+class SyntheticGenerativeAdapter implements GenerativeAddonAdapter {
+  SyntheticGenerativeAdapter({this.trigger = 'sample-trigger'});
+
+  final String trigger;
+
+  @override
+  AddonIdentity get identity =>
+      const AddonIdentity(id: AddonId('sample-generative'), version: '1.0.0');
+
+  @override
+  bool accepts(AddonConversation input) =>
+      input.currentPrompt.contains(trigger);
+
+  @override
+  AddonPrompt buildPrompt(AddonConversation input) => AddonPrompt(
+    systemInstruction: 'sample-system',
+    userPrompt: 'prompt:${input.currentPrompt}',
+  );
+
+  @override
+  AddonEvaluation evaluate(String output) {
+    if (output.contains('invalid')) {
+      return const AddonEvaluation(
+        kind: AddonEvaluationKind.invalid,
+        safeCopy: 'sample-safe-copy',
+      );
+    }
+    return const AddonEvaluation(kind: AddonEvaluationKind.valid);
+  }
+}

--- a/packages/core_ai/test/addons/synthetic_graph_workflow_adapter.dart
+++ b/packages/core_ai/test/addons/synthetic_graph_workflow_adapter.dart
@@ -1,0 +1,71 @@
+import 'package:core_ai/core_ai.dart';
+import 'package:core_domain/core_domain.dart';
+
+class SyntheticGraphWorkflowAdapter implements GraphWorkflowAddonAdapter {
+  SyntheticGraphWorkflowAdapter({this.trigger = 'sample-extract'});
+
+  final String trigger;
+
+  @override
+  AddonIdentity get identity =>
+      const AddonIdentity(id: AddonId('sample-graph'), version: '1.0.0');
+
+  @override
+  bool accepts(GraphIngestContext input) => input.text.contains(trigger);
+
+  @override
+  Future<EntityGraphPatch> extract(GraphIngestContext input) async {
+    return EntityGraphPatch(
+      nodes: [
+        EntityGraphNode(
+          id: 'identifier:subject-1',
+          typeKey: 'identifier',
+          name: 'subject',
+          attributes: {'kind': 'subject'},
+        ),
+      ],
+      mentionedNodeIds: ['identifier:subject-1'],
+      provenance: [
+        GraphProvenanceRef(
+          sourceMessageRevision: input.turnRevision,
+          manifestDigest: 'sample-manifest',
+          adapterDigest: 'sample-adapter',
+          extractionContractVersion: 'graph_workflow_v1',
+        ),
+      ],
+    );
+  }
+
+  @override
+  Iterable<WorkflowProjection> project(EntityGraph graph) {
+    final subject = graph.nodes.where(
+      (node) => node.attributes['kind'] == 'subject',
+    );
+    return subject.map(
+      (node) => WorkflowProjection(
+        identity: identity,
+        subjectNodeId: node.id,
+        destinationKind: 'lifetrack',
+        templateId: 'sample-template',
+        templateVersion: '1',
+        title: 'Sample subject',
+        factsByFieldId: {'field_a': 'value_a'},
+        identityKey: node.id,
+        offer: const OfferDecision(kind: OfferDecisionKind.offerable),
+      ),
+    );
+  }
+
+  @override
+  PendingAssessment assessPending(
+    EntityGraph graph,
+    WorkflowProjection projection,
+  ) => PendingAssessment(
+    identity: identity,
+    subjectNodeId: projection.subjectNodeId,
+    storedFacts: projection.factsByFieldId,
+    missingRequired: const ['field_b'],
+    missingOptional: const [],
+    summary: 'missing field_b',
+  );
+}

--- a/packages/core_domain/lib/core_domain.dart
+++ b/packages/core_domain/lib/core_domain.dart
@@ -36,6 +36,25 @@ export 'src/state/async_state.dart';
 export 'src/state/paginated_state.dart';
 export 'src/state/track_state_machine.dart';
 
+// Graph contracts (neutral entity graph DTOs)
+export 'src/graph/entity_graph_node.dart';
+export 'src/graph/entity_graph_edge.dart';
+export 'src/graph/entity_graph.dart';
+export 'src/graph/entity_graph_patch.dart';
+export 'src/graph/graph_provenance.dart';
+
+// Add-on contracts
+export 'src/addons/addon_id.dart';
+export 'src/addons/addon_identity.dart';
+export 'src/addons/addon_behavior_kind.dart';
+export 'src/addons/addon_manifest.dart';
+export 'src/addons/addon_registry_port.dart';
+
+// Workflow projection contracts
+export 'src/workflow/offer_decision.dart';
+export 'src/workflow/workflow_projection.dart';
+export 'src/workflow/pending_assessment.dart';
+
 // Plugin System
 export 'src/plugins/plugin_manifest.dart';
 export 'src/plugins/manifest_validator.dart';

--- a/packages/core_domain/lib/src/addons/addon_behavior_kind.dart
+++ b/packages/core_domain/lib/src/addons/addon_behavior_kind.dart
@@ -1,0 +1,24 @@
+enum AddonBehaviorKind {
+  generative,
+  graphWorkflow;
+
+  static AddonBehaviorKind fromJson(String value) {
+    switch (value) {
+      case 'generative':
+        return AddonBehaviorKind.generative;
+      case 'graph_workflow':
+        return AddonBehaviorKind.graphWorkflow;
+      default:
+        throw ArgumentError('Unknown add-on behavior: $value');
+    }
+  }
+
+  String toJson() {
+    switch (this) {
+      case AddonBehaviorKind.generative:
+        return 'generative';
+      case AddonBehaviorKind.graphWorkflow:
+        return 'graph_workflow';
+    }
+  }
+}

--- a/packages/core_domain/lib/src/addons/addon_id.dart
+++ b/packages/core_domain/lib/src/addons/addon_id.dart
@@ -1,0 +1,18 @@
+import 'package:meta/meta.dart';
+
+@immutable
+class AddonId {
+  const AddonId(this.value);
+
+  final String value;
+
+  @override
+  bool operator ==(Object other) =>
+      other is AddonId && other.value == value;
+
+  @override
+  int get hashCode => value.hashCode;
+
+  @override
+  String toString() => value;
+}

--- a/packages/core_domain/lib/src/addons/addon_identity.dart
+++ b/packages/core_domain/lib/src/addons/addon_identity.dart
@@ -1,0 +1,32 @@
+import 'package:meta/meta.dart';
+
+import 'addon_id.dart';
+
+@immutable
+class AddonIdentity {
+  const AddonIdentity({
+    required this.id,
+    required this.version,
+    this.manifestDigest = '',
+    this.adapterDigest = '',
+  });
+
+  final AddonId id;
+  final String version;
+  final String manifestDigest;
+  final String adapterDigest;
+
+  @override
+  bool operator ==(Object other) =>
+      other is AddonIdentity &&
+      other.id == id &&
+      other.version == version &&
+      other.manifestDigest == manifestDigest &&
+      other.adapterDigest == adapterDigest;
+
+  @override
+  int get hashCode => Object.hash(id, version, manifestDigest, adapterDigest);
+
+  @override
+  String toString() => '${id.value}@$version';
+}

--- a/packages/core_domain/lib/src/addons/addon_manifest.dart
+++ b/packages/core_domain/lib/src/addons/addon_manifest.dart
@@ -1,0 +1,97 @@
+import 'package:meta/meta.dart';
+
+import 'addon_behavior_kind.dart';
+import 'addon_id.dart';
+
+const String kAddonManifestSchemaVersion = '1.0';
+
+/// Validated add-on manifest. Supersedes executable plugin entry points.
+@immutable
+class AddonManifest {
+  const AddonManifest({
+    required this.schemaVersion,
+    required this.id,
+    required this.version,
+    required this.behaviors,
+    required this.capabilities,
+    required this.tools,
+    this.safetyClass = 'general',
+    this.adapterKind,
+    this.adapterContract,
+    this.workflowTemplateAsset,
+    this.workflowSubjectKind,
+    this.builtInPriority = 0,
+  });
+
+  final String schemaVersion;
+  final AddonId id;
+  final String version;
+  final List<AddonBehaviorKind> behaviors;
+  final List<String> capabilities;
+  final List<String> tools;
+  final String safetyClass;
+  final String? adapterKind;
+  final String? adapterContract;
+  final String? workflowTemplateAsset;
+  final String? workflowSubjectKind;
+  final int builtInPriority;
+
+  bool hasBehavior(AddonBehaviorKind kind) => behaviors.contains(kind);
+
+  factory AddonManifest.fromJson(Map<String, dynamic> json) {
+    final adapter = json['adapter'] as Map<String, dynamic>?;
+    final workflow = json['workflow'] as Map<String, dynamic>?;
+    return AddonManifest(
+      schemaVersion: json['schema_version'] as String,
+      id: AddonId(json['id'] as String),
+      version: json['version'] as String,
+      behaviors: ((json['behaviors'] as List?) ?? const [])
+          .map((item) => AddonBehaviorKind.fromJson(item as String))
+          .toList(growable: false),
+      capabilities: ((json['capabilities'] as List?) ?? const [])
+          .map((item) => item as String)
+          .toList(growable: false),
+      tools: ((json['tools'] as List?) ?? const [])
+          .map((item) => item as String)
+          .toList(growable: false),
+      safetyClass: json['safety_class'] as String? ?? 'general',
+      adapterKind: adapter?['kind'] as String?,
+      adapterContract: adapter?['contract'] as String?,
+      workflowTemplateAsset: workflow?['template_asset'] as String?,
+      workflowSubjectKind: workflow?['subject_kind'] as String?,
+      builtInPriority: (json['built_in_priority'] as int?) ?? 0,
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+    'schema_version': schemaVersion,
+    'id': id.value,
+    'version': version,
+    'behaviors': behaviors.map((kind) => kind.toJson()).toList(growable: false),
+    'capabilities': capabilities,
+    'tools': tools,
+    'safety_class': safetyClass,
+    if (adapterKind != null || adapterContract != null)
+      'adapter': {
+        if (adapterKind != null) 'kind': adapterKind,
+        if (adapterContract != null) 'contract': adapterContract,
+      },
+    if (workflowTemplateAsset != null || workflowSubjectKind != null)
+      'workflow': {
+        if (workflowTemplateAsset != null)
+          'template_asset': workflowTemplateAsset,
+        if (workflowSubjectKind != null) 'subject_kind': workflowSubjectKind,
+      },
+    if (builtInPriority != 0) 'built_in_priority': builtInPriority,
+  };
+
+  @override
+  bool operator ==(Object other) =>
+      other is AddonManifest && other.id == id && other.version == version;
+
+  @override
+  int get hashCode => Object.hash(id, version);
+
+  @override
+  String toString() => 'AddonManifest(${id.value}@$version)';
+}

--- a/packages/core_domain/lib/src/addons/addon_registry_port.dart
+++ b/packages/core_domain/lib/src/addons/addon_registry_port.dart
@@ -1,0 +1,12 @@
+import '../addons/addon_manifest.dart';
+
+/// Port for add-on registration lookup. Implemented by `core_ai` registry.
+abstract interface class AddonRegistryPort {
+  AddonManifest? manifestFor(String addonId);
+
+  bool isEnabled(String addonId);
+
+  bool isPinned(String addonId);
+
+  bool hasGrant(String addonId, String scope);
+}

--- a/packages/core_domain/lib/src/graph/entity_graph.dart
+++ b/packages/core_domain/lib/src/graph/entity_graph.dart
@@ -1,0 +1,97 @@
+import 'package:meta/meta.dart';
+
+import 'entity_graph_edge.dart';
+import 'entity_graph_node.dart';
+
+/// Immutable graph snapshot. JSON shape matches the chat entity graph store.
+@immutable
+class EntityGraph {
+  const EntityGraph({
+    this.nodes = const [],
+    this.edges = const [],
+    this.recentNodeIds = const [],
+  });
+
+  final List<EntityGraphNode> nodes;
+  final List<EntityGraphEdge> edges;
+  final List<String> recentNodeIds;
+
+  static const empty = EntityGraph();
+
+  EntityGraphNode? nodeById(String id) {
+    for (final node in nodes) {
+      if (node.id == id) return node;
+    }
+    return null;
+  }
+
+  EntityGraph merge(EntityGraph other) => upsert(
+    incomingNodes: other.nodes,
+    incomingEdges: other.edges,
+    mentionedIds: other.recentNodeIds,
+  );
+
+  EntityGraph upsert({
+    required List<EntityGraphNode> incomingNodes,
+    required List<EntityGraphEdge> incomingEdges,
+    required List<String> mentionedIds,
+  }) {
+    final byId = {for (final node in nodes) node.id: node};
+    for (final node in incomingNodes) {
+      final existing = byId[node.id];
+      byId[node.id] = existing == null ? node : existing.merge(node);
+    }
+    final edgeSet = {...edges, ...incomingEdges};
+    final recent = [
+      ...mentionedIds,
+      ...recentNodeIds,
+    ].where(byId.containsKey).toSet().toList(growable: false);
+    return EntityGraph(
+      nodes: byId.values.toList(growable: false),
+      edges: edgeSet.toList(growable: false),
+      recentNodeIds: recent.take(12).toList(growable: false),
+    );
+  }
+
+  factory EntityGraph.fromJson(Map<String, dynamic> json) => EntityGraph(
+    nodes: ((json['nodes'] as List?) ?? const [])
+        .map((item) => EntityGraphNode.fromJson(item as Map<String, dynamic>))
+        .toList(growable: false),
+    edges: ((json['edges'] as List?) ?? const [])
+        .map((item) => EntityGraphEdge.fromJson(item as Map<String, dynamic>))
+        .toList(growable: false),
+    recentNodeIds: ((json['recent_node_ids'] as List?) ?? const [])
+        .map((item) => item.toString())
+        .toList(growable: false),
+  );
+
+  Map<String, dynamic> toJson() => {
+    'nodes': nodes.map((node) => node.toJson()).toList(growable: false),
+    'edges': edges.map((edge) => edge.toJson()).toList(growable: false),
+    'recent_node_ids': recentNodeIds,
+  };
+
+  EntityGraph withNodeAttribute(String nodeId, String key, String value) {
+    final updated = nodes
+        .map((node) {
+          if (node.id != nodeId) return node;
+          return node.merge(
+            EntityGraphNode(
+              id: node.id,
+              typeKey: node.typeKey,
+              name: node.name,
+              attributes: {key: value},
+            ),
+          );
+        })
+        .toList(growable: false);
+    return EntityGraph(
+      nodes: updated,
+      edges: edges,
+      recentNodeIds: recentNodeIds,
+    );
+  }
+
+  Iterable<EntityGraphEdge> edgesFor(String nodeId) =>
+      edges.where((edge) => edge.fromId == nodeId || edge.toId == nodeId);
+}

--- a/packages/core_domain/lib/src/graph/entity_graph_edge.dart
+++ b/packages/core_domain/lib/src/graph/entity_graph_edge.dart
@@ -1,0 +1,37 @@
+import 'package:meta/meta.dart';
+
+@immutable
+class EntityGraphEdge {
+  const EntityGraphEdge({
+    required this.fromId,
+    required this.toId,
+    required this.predicate,
+  });
+
+  final String fromId;
+  final String toId;
+  final String predicate;
+
+  factory EntityGraphEdge.fromJson(Map<String, dynamic> json) =>
+      EntityGraphEdge(
+        fromId: json['from_id'] as String,
+        toId: json['to_id'] as String,
+        predicate: json['predicate'] as String,
+      );
+
+  Map<String, dynamic> toJson() => {
+    'from_id': fromId,
+    'to_id': toId,
+    'predicate': predicate,
+  };
+
+  @override
+  bool operator ==(Object other) =>
+      other is EntityGraphEdge &&
+      other.fromId == fromId &&
+      other.toId == toId &&
+      other.predicate == predicate;
+
+  @override
+  int get hashCode => Object.hash(fromId, toId, predicate);
+}

--- a/packages/core_domain/lib/src/graph/entity_graph_node.dart
+++ b/packages/core_domain/lib/src/graph/entity_graph_node.dart
@@ -1,0 +1,63 @@
+import 'package:meta/meta.dart';
+
+/// Neutral graph node contract. [typeKey] is an opaque validated string
+/// (`person`, `organization`, `identifier`, …) — not a framework enum.
+@immutable
+class EntityGraphNode {
+  const EntityGraphNode({
+    required this.id,
+    required this.typeKey,
+    required this.name,
+    this.attributes = const {},
+  });
+
+  final String id;
+  final String typeKey;
+  final String name;
+  final Map<String, String> attributes;
+
+  EntityGraphNode merge(EntityGraphNode other) {
+    if (id != other.id) return this;
+    return EntityGraphNode(
+      id: id,
+      typeKey: typeKey,
+      name: other.name.length > name.length ? other.name : name,
+      attributes: {...attributes, ...other.attributes},
+    );
+  }
+
+  factory EntityGraphNode.fromJson(Map<String, dynamic> json) => EntityGraphNode(
+    id: json['id'] as String,
+    typeKey: json['type'] as String,
+    name: json['name'] as String,
+    attributes: ((json['attributes'] as Map?) ?? const {}).map(
+      (key, value) => MapEntry(key.toString(), value.toString()),
+    ),
+  );
+
+  Map<String, dynamic> toJson() => {
+    'id': id,
+    'type': typeKey,
+    'name': name,
+    'attributes': attributes,
+  };
+
+  @override
+  bool operator ==(Object other) =>
+      other is EntityGraphNode &&
+      other.id == id &&
+      other.typeKey == typeKey &&
+      other.name == name &&
+      _mapEquals(other.attributes, attributes);
+
+  @override
+  int get hashCode => Object.hash(id, typeKey, name);
+
+  static bool _mapEquals(Map<String, String> a, Map<String, String> b) {
+    if (a.length != b.length) return false;
+    for (final key in a.keys) {
+      if (a[key] != b[key]) return false;
+    }
+    return true;
+  }
+}

--- a/packages/core_domain/lib/src/graph/entity_graph_patch.dart
+++ b/packages/core_domain/lib/src/graph/entity_graph_patch.dart
@@ -1,0 +1,54 @@
+import 'package:meta/meta.dart';
+
+import 'entity_graph_edge.dart';
+import 'entity_graph_node.dart';
+import 'graph_provenance.dart';
+
+/// Validated patch returned by a graph-workflow adapter before merge.
+@immutable
+class EntityGraphPatch {
+  const EntityGraphPatch({
+    this.nodes = const [],
+    this.edges = const [],
+    this.mentionedNodeIds = const [],
+    this.provenance = const [],
+  });
+
+  final List<EntityGraphNode> nodes;
+  final List<EntityGraphEdge> edges;
+  final List<String> mentionedNodeIds;
+  final List<GraphProvenanceRef> provenance;
+
+  bool get isEmpty =>
+      nodes.isEmpty && edges.isEmpty && mentionedNodeIds.isEmpty;
+
+  factory EntityGraphPatch.fromJson(Map<String, dynamic> json) =>
+      EntityGraphPatch(
+        nodes: ((json['nodes'] as List?) ?? const [])
+            .map(
+              (item) => EntityGraphNode.fromJson(item as Map<String, dynamic>),
+            )
+            .toList(growable: false),
+        edges: ((json['edges'] as List?) ?? const [])
+            .map(
+              (item) => EntityGraphEdge.fromJson(item as Map<String, dynamic>),
+            )
+            .toList(growable: false),
+        mentionedNodeIds: ((json['mentioned_node_ids'] as List?) ?? const [])
+            .map((item) => item.toString())
+            .toList(growable: false),
+        provenance: ((json['provenance'] as List?) ?? const [])
+            .map(
+              (item) =>
+                  GraphProvenanceRef.fromJson(item as Map<String, dynamic>),
+            )
+            .toList(growable: false),
+      );
+
+  Map<String, dynamic> toJson() => {
+    'nodes': nodes.map((node) => node.toJson()).toList(growable: false),
+    'edges': edges.map((edge) => edge.toJson()).toList(growable: false),
+    'mentioned_node_ids': mentionedNodeIds,
+    'provenance': provenance.map((ref) => ref.toJson()).toList(growable: false),
+  };
+}

--- a/packages/core_domain/lib/src/graph/graph_provenance.dart
+++ b/packages/core_domain/lib/src/graph/graph_provenance.dart
@@ -1,0 +1,49 @@
+import 'package:meta/meta.dart';
+
+/// Framework-minted provenance handle referenced by extracted facts.
+@immutable
+class GraphProvenanceRef {
+  const GraphProvenanceRef({
+    required this.sourceMessageRevision,
+    required this.manifestDigest,
+    required this.adapterDigest,
+    required this.extractionContractVersion,
+  });
+
+  final String sourceMessageRevision;
+  final String manifestDigest;
+  final String adapterDigest;
+  final String extractionContractVersion;
+
+  factory GraphProvenanceRef.fromJson(Map<String, dynamic> json) =>
+      GraphProvenanceRef(
+        sourceMessageRevision: json['source_message_revision'] as String,
+        manifestDigest: json['manifest_digest'] as String,
+        adapterDigest: json['adapter_digest'] as String,
+        extractionContractVersion:
+            json['extraction_contract_version'] as String,
+      );
+
+  Map<String, dynamic> toJson() => {
+    'source_message_revision': sourceMessageRevision,
+    'manifest_digest': manifestDigest,
+    'adapter_digest': adapterDigest,
+    'extraction_contract_version': extractionContractVersion,
+  };
+
+  @override
+  bool operator ==(Object other) =>
+      other is GraphProvenanceRef &&
+      other.sourceMessageRevision == sourceMessageRevision &&
+      other.manifestDigest == manifestDigest &&
+      other.adapterDigest == adapterDigest &&
+      other.extractionContractVersion == extractionContractVersion;
+
+  @override
+  int get hashCode => Object.hash(
+    sourceMessageRevision,
+    manifestDigest,
+    adapterDigest,
+    extractionContractVersion,
+  );
+}

--- a/packages/core_domain/lib/src/workflow/offer_decision.dart
+++ b/packages/core_domain/lib/src/workflow/offer_decision.dart
@@ -1,0 +1,54 @@
+import 'package:meta/meta.dart';
+
+enum OfferDecisionKind {
+  offerable,
+  notOfferable,
+  alreadyOffered;
+
+  static OfferDecisionKind fromJson(String value) {
+    switch (value) {
+      case 'offerable':
+        return OfferDecisionKind.offerable;
+      case 'not_offerable':
+        return OfferDecisionKind.notOfferable;
+      case 'already_offered':
+        return OfferDecisionKind.alreadyOffered;
+      default:
+        throw ArgumentError('Unknown offer decision: $value');
+    }
+  }
+
+  String toJson() {
+    switch (this) {
+      case OfferDecisionKind.offerable:
+        return 'offerable';
+      case OfferDecisionKind.notOfferable:
+        return 'not_offerable';
+      case OfferDecisionKind.alreadyOffered:
+        return 'already_offered';
+    }
+  }
+}
+
+@immutable
+class OfferDecision {
+  const OfferDecision({
+    required this.kind,
+    this.reason = '',
+  });
+
+  final OfferDecisionKind kind;
+  final String reason;
+
+  bool get isOfferable => kind == OfferDecisionKind.offerable;
+
+  factory OfferDecision.fromJson(Map<String, dynamic> json) => OfferDecision(
+    kind: OfferDecisionKind.fromJson(json['kind'] as String),
+    reason: json['reason'] as String? ?? '',
+  );
+
+  Map<String, dynamic> toJson() => {
+    'kind': kind.toJson(),
+    if (reason.isNotEmpty) 'reason': reason,
+  };
+}

--- a/packages/core_domain/lib/src/workflow/pending_assessment.dart
+++ b/packages/core_domain/lib/src/workflow/pending_assessment.dart
@@ -1,0 +1,58 @@
+import 'package:meta/meta.dart';
+
+import '../addons/addon_id.dart';
+import '../addons/addon_identity.dart';
+
+@immutable
+class PendingAssessment {
+  const PendingAssessment({
+    required this.identity,
+    required this.subjectNodeId,
+    required this.storedFacts,
+    required this.missingRequired,
+    required this.missingOptional,
+    this.crossLinks = const [],
+    this.summary = '',
+  });
+
+  final AddonIdentity identity;
+  final String subjectNodeId;
+  final Map<String, String> storedFacts;
+  final List<String> missingRequired;
+  final List<String> missingOptional;
+  final List<String> crossLinks;
+  final String summary;
+
+  factory PendingAssessment.fromJson(Map<String, dynamic> json) =>
+      PendingAssessment(
+        identity: AddonIdentity(
+          id: AddonId(json['addon_id'] as String),
+          version: json['addon_version'] as String,
+        ),
+        subjectNodeId: json['subject_node_id'] as String,
+        storedFacts: ((json['stored_facts'] as Map?) ?? const {}).map(
+          (key, value) => MapEntry(key.toString(), value.toString()),
+        ),
+        missingRequired: ((json['missing_required'] as List?) ?? const [])
+            .map((item) => item.toString())
+            .toList(growable: false),
+        missingOptional: ((json['missing_optional'] as List?) ?? const [])
+            .map((item) => item.toString())
+            .toList(growable: false),
+        crossLinks: ((json['cross_links'] as List?) ?? const [])
+            .map((item) => item.toString())
+            .toList(growable: false),
+        summary: json['summary'] as String? ?? '',
+      );
+
+  Map<String, dynamic> toJson() => {
+    'addon_id': identity.id.value,
+    'addon_version': identity.version,
+    'subject_node_id': subjectNodeId,
+    'stored_facts': storedFacts,
+    'missing_required': missingRequired,
+    'missing_optional': missingOptional,
+    if (crossLinks.isNotEmpty) 'cross_links': crossLinks,
+    if (summary.isNotEmpty) 'summary': summary,
+  };
+}

--- a/packages/core_domain/lib/src/workflow/workflow_projection.dart
+++ b/packages/core_domain/lib/src/workflow/workflow_projection.dart
@@ -1,0 +1,75 @@
+import 'package:meta/meta.dart';
+
+import '../addons/addon_id.dart';
+import '../addons/addon_identity.dart';
+import 'offer_decision.dart';
+
+@immutable
+class WorkflowProjection {
+  const WorkflowProjection({
+    required this.identity,
+    required this.subjectNodeId,
+    required this.destinationKind,
+    required this.templateId,
+    required this.templateVersion,
+    required this.title,
+    required this.factsByFieldId,
+    required this.identityKey,
+    required this.offer,
+    this.displayFacts = const {},
+  });
+
+  final AddonIdentity identity;
+  final String subjectNodeId;
+  final String destinationKind;
+  final String templateId;
+  final String templateVersion;
+  final String title;
+  final Map<String, String> factsByFieldId;
+  final Map<String, String> displayFacts;
+  final String identityKey;
+  final OfferDecision offer;
+
+  bool get isOfferable => offer.isOfferable;
+
+  factory WorkflowProjection.fromJson(Map<String, dynamic> json) =>
+      WorkflowProjection(
+        identity: AddonIdentity(
+          id: AddonId(json['addon_id'] as String),
+          version: json['addon_version'] as String,
+          manifestDigest: json['manifest_digest'] as String? ?? '',
+          adapterDigest: json['adapter_digest'] as String? ?? '',
+        ),
+        subjectNodeId: json['subject_node_id'] as String,
+        destinationKind: json['destination_kind'] as String,
+        templateId: json['template_id'] as String,
+        templateVersion: json['template_version'] as String? ?? '1',
+        title: json['title'] as String,
+        factsByFieldId: ((json['facts_by_field_id'] as Map?) ?? const {}).map(
+          (key, value) => MapEntry(key.toString(), value.toString()),
+        ),
+        displayFacts: ((json['display_facts'] as Map?) ?? const {}).map(
+          (key, value) => MapEntry(key.toString(), value.toString()),
+        ),
+        identityKey: json['identity_key'] as String,
+        offer: OfferDecision.fromJson(json['offer'] as Map<String, dynamic>),
+      );
+
+  Map<String, dynamic> toJson() => {
+    'addon_id': identity.id.value,
+    'addon_version': identity.version,
+    if (identity.manifestDigest.isNotEmpty)
+      'manifest_digest': identity.manifestDigest,
+    if (identity.adapterDigest.isNotEmpty)
+      'adapter_digest': identity.adapterDigest,
+    'subject_node_id': subjectNodeId,
+    'destination_kind': destinationKind,
+    'template_id': templateId,
+    'template_version': templateVersion,
+    'title': title,
+    'facts_by_field_id': factsByFieldId,
+    if (displayFacts.isNotEmpty) 'display_facts': displayFacts,
+    'identity_key': identityKey,
+    'offer': offer.toJson(),
+  };
+}

--- a/packages/core_domain/test/addons/addon_manifest_test.dart
+++ b/packages/core_domain/test/addons/addon_manifest_test.dart
@@ -1,0 +1,33 @@
+import 'package:core_domain/core_domain.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('AddonManifest parses spec example shape', () {
+    final manifest = AddonManifest.fromJson({
+      'schema_version': '1.0',
+      'id': 'sample-addon',
+      'version': '1.0.0',
+      'behaviors': ['graph_workflow'],
+      'capabilities': [
+        'conversation.process',
+        'lifetrack.read',
+        'lifetrack.write',
+      ],
+      'tools': ['query_entity_graph', 'record_lifetrack_facts'],
+      'safety_class': 'financial',
+      'adapter': {
+        'kind': 'required_built_in',
+        'contract': 'graph_workflow_v1',
+      },
+      'workflow': {
+        'template_asset': 'lifetrack_template.json',
+        'subject_kind': 'subject',
+      },
+    });
+
+    expect(manifest.id.value, 'sample-addon');
+    expect(manifest.hasBehavior(AddonBehaviorKind.graphWorkflow), isTrue);
+    expect(manifest.workflowSubjectKind, 'subject');
+    expect(manifest.toJson()['id'], 'sample-addon');
+  });
+}

--- a/packages/core_domain/test/graph/entity_graph_test.dart
+++ b/packages/core_domain/test/graph/entity_graph_test.dart
@@ -1,0 +1,58 @@
+import 'package:core_domain/core_domain.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('EntityGraph round-trips chat graph JSON shape', () {
+    final json = {
+      'nodes': [
+        {
+          'id': 'organization:niva-bupa',
+          'type': 'organization',
+          'name': 'Niva Bupa',
+          'attributes': {},
+        },
+        {
+          'id': 'identifier:9001001',
+          'type': 'identifier',
+          'name': '9001001',
+          'attributes': {'kind': 'claim'},
+        },
+      ],
+      'edges': [
+        {
+          'from_id': 'identifier:9001001',
+          'to_id': 'organization:niva-bupa',
+          'predicate': 'insured_by',
+        },
+      ],
+      'recent_node_ids': ['identifier:9001001'],
+    };
+
+    final graph = EntityGraph.fromJson(json);
+    expect(graph.toJson(), json);
+  });
+
+  test('EntityGraphPatch preserves provenance refs', () {
+    final patch = EntityGraphPatch(
+      nodes: [
+        const EntityGraphNode(
+          id: 'identifier:subject-1',
+          typeKey: 'identifier',
+          name: 'subject',
+          attributes: {'kind': 'subject'},
+        ),
+      ],
+      provenance: [
+        const GraphProvenanceRef(
+          sourceMessageRevision: 'rev-1',
+          manifestDigest: 'manifest-sha',
+          adapterDigest: 'adapter-sha',
+          extractionContractVersion: 'graph_workflow_v1',
+        ),
+      ],
+    );
+
+    final restored = EntityGraphPatch.fromJson(patch.toJson());
+    expect(restored.provenance.single.manifestDigest, 'manifest-sha');
+  });
+}

--- a/packages/feature_mind/lib/src/addons/addon_host_dispatch.dart
+++ b/packages/feature_mind/lib/src/addons/addon_host_dispatch.dart
@@ -1,0 +1,36 @@
+import 'package:core_ai/core_ai.dart';
+import 'package:core_domain/core_domain.dart';
+
+/// Thin host wrapper that routes add-on behavior through the registry without
+/// switching on add-on IDs. Production chat will adopt this in later increments.
+class AddonHostDispatch {
+  AddonHostDispatch(this._registry);
+
+  final AddonRegistry _registry;
+
+  AddonPrompt? buildGenerativePrompt(AddonConversation conversation) {
+    for (final adapter in _registry.eligibleGenerativeAdapters()) {
+      if (adapter.accepts(conversation)) {
+        return adapter.buildPrompt(conversation);
+      }
+    }
+    return null;
+  }
+
+  Future<EntityGraphPatch?> extractGraphPatch(GraphIngestContext context) async {
+    for (final adapter in _registry.eligibleGraphAdapters()) {
+      if (adapter.accepts(context)) {
+        return adapter.extract(context);
+      }
+    }
+    return null;
+  }
+
+  List<WorkflowProjection> projectGraph(EntityGraph graph) {
+    final projections = <WorkflowProjection>[];
+    for (final adapter in _registry.eligibleGraphAdapters()) {
+      projections.addAll(adapter.project(graph));
+    }
+    return projections;
+  }
+}

--- a/packages/feature_mind/lib/src/agent_chat/domain/models/entity_graph_bridge.dart
+++ b/packages/feature_mind/lib/src/agent_chat/domain/models/entity_graph_bridge.dart
@@ -1,0 +1,56 @@
+import 'package:core_domain/core_domain.dart';
+
+import 'chat_entity_graph.dart';
+import '../../../provenance/domain/models/extracted_entity.dart';
+
+/// Maps between chat-local graph types and neutral `core_domain` contracts.
+extension ChatEntityGraphBridge on ChatEntityGraph {
+  EntityGraph toEntityGraph() => EntityGraph(
+    nodes: nodes.map((node) => node.toEntityGraphNode()).toList(growable: false),
+    edges: edges
+        .map(
+          (edge) => EntityGraphEdge(
+            fromId: edge.fromId,
+            toId: edge.toId,
+            predicate: edge.predicate,
+          ),
+        )
+        .toList(growable: false),
+    recentNodeIds: recentNodeIds,
+  );
+
+  static ChatEntityGraph fromEntityGraph(EntityGraph graph) => ChatEntityGraph(
+    nodes: graph.nodes
+        .map(ChatGraphNodeBridge.fromEntityGraphNode)
+        .toList(growable: false),
+    edges: graph.edges
+        .map(
+          (edge) => ChatGraphEdge(
+            fromId: edge.fromId,
+            toId: edge.toId,
+            predicate: edge.predicate,
+          ),
+        )
+        .toList(growable: false),
+    recentNodeIds: graph.recentNodeIds,
+  );
+}
+
+extension ChatGraphNodeBridge on ChatGraphNode {
+  EntityGraphNode toEntityGraphNode() => EntityGraphNode(
+    id: id,
+    typeKey: type.name,
+    name: name,
+    attributes: attributes,
+  );
+
+  static ChatGraphNode fromEntityGraphNode(EntityGraphNode node) => ChatGraphNode(
+    id: node.id,
+    type: EntityType.values.firstWhere(
+      (item) => item.name == node.typeKey,
+      orElse: () => EntityType.term,
+    ),
+    name: node.name,
+    attributes: node.attributes,
+  );
+}

--- a/packages/feature_mind/test/addons/addon_host_dispatch_test.dart
+++ b/packages/feature_mind/test/addons/addon_host_dispatch_test.dart
@@ -1,0 +1,140 @@
+import 'package:core_ai/core_ai.dart';
+import 'package:core_domain/core_domain.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:feature_mind/src/addons/addon_host_dispatch.dart';
+
+class _HostGenerativeAdapter implements GenerativeAddonAdapter {
+  @override
+  AddonIdentity get identity =>
+      const AddonIdentity(id: AddonId('sample-generative'), version: '1.0.0');
+
+  @override
+  bool accepts(AddonConversation input) =>
+      input.currentPrompt.contains('sample-trigger');
+
+  @override
+  AddonPrompt buildPrompt(AddonConversation input) => AddonPrompt(
+    systemInstruction: 'host-system',
+    userPrompt: input.currentPrompt,
+  );
+
+  @override
+  AddonEvaluation evaluate(String output) =>
+      const AddonEvaluation(kind: AddonEvaluationKind.valid);
+}
+
+class _HostGraphAdapter implements GraphWorkflowAddonAdapter {
+  @override
+  AddonIdentity get identity =>
+      const AddonIdentity(id: AddonId('sample-graph'), version: '1.0.0');
+
+  @override
+  bool accepts(GraphIngestContext input) =>
+      input.text.contains('sample-extract');
+
+  @override
+  Future<EntityGraphPatch> extract(GraphIngestContext input) async =>
+      EntityGraphPatch(
+        nodes: [
+          EntityGraphNode(
+            id: 'identifier:subject-host',
+            typeKey: 'identifier',
+            name: 'subject',
+            attributes: {'kind': 'subject'},
+          ),
+        ],
+      );
+
+  @override
+  Iterable<WorkflowProjection> project(EntityGraph graph) {
+    return graph.nodes.map(
+      (node) => WorkflowProjection(
+        identity: identity,
+        subjectNodeId: node.id,
+        destinationKind: 'lifetrack',
+        templateId: 'sample-template',
+        templateVersion: '1',
+        title: 'host projection',
+        factsByFieldId: {},
+        identityKey: node.id,
+        offer: const OfferDecision(kind: OfferDecisionKind.offerable),
+      ),
+    );
+  }
+
+  @override
+  PendingAssessment assessPending(
+    EntityGraph graph,
+    WorkflowProjection projection,
+  ) => PendingAssessment(
+    identity: identity,
+    subjectNodeId: projection.subjectNodeId,
+    storedFacts: {},
+    missingRequired: [],
+    missingOptional: [],
+  );
+}
+
+void main() {
+  test('AddonHostDispatch routes generative and graph paths without ID switches',
+      () async {
+    final registry = AddonRegistry();
+    registry.registerBuiltIn(
+      manifest: AddonManifest.fromJson({
+        'schema_version': '1.0',
+        'id': 'sample-generative',
+        'version': '1.0.0',
+        'behaviors': ['generative'],
+        'capabilities': ['conversation.current_turn'],
+        'tools': [],
+      }),
+      generativeAdapter: _HostGenerativeAdapter(),
+    );
+    registry.registerBuiltIn(
+      manifest: AddonManifest.fromJson({
+        'schema_version': '1.0',
+        'id': 'sample-graph',
+        'version': '1.0.0',
+        'behaviors': ['graph_workflow'],
+        'capabilities': ['conversation.current_turn'],
+        'tools': ['query_entity_graph'],
+        'workflow': {'subject_kind': 'subject'},
+      }),
+      graphAdapter: _HostGraphAdapter(),
+    );
+
+    for (final id in ['sample-generative', 'sample-graph']) {
+      registry.setEligibility(
+        id,
+        const AddonEligibility(
+          enabled: true,
+          grantedScopes: {'conversation.current_turn'},
+        ),
+      );
+    }
+
+    final dispatch = AddonHostDispatch(registry);
+
+    final prompt = dispatch.buildGenerativePrompt(
+      const AddonConversation(currentPrompt: 'please sample-trigger'),
+    );
+    expect(prompt?.systemInstruction, 'host-system');
+
+    final patch = await dispatch.extractGraphPatch(
+      GraphIngestContext(
+        text: 'please sample-extract',
+        graph: EntityGraph.empty,
+      ),
+    );
+    expect(patch?.nodes.single.id, 'identifier:subject-host');
+
+    final merged = EntityGraph.empty.upsert(
+      incomingNodes: patch!.nodes,
+      incomingEdges: patch.edges,
+      mentionedIds: patch.mentionedNodeIds,
+    );
+    final projections = dispatch.projectGraph(merged);
+    expect(projections.single.title, 'host projection');
+  });
+}

--- a/packages/feature_mind/test/agent_chat/fixtures/characterization/claim_plus_hospital_graph.json
+++ b/packages/feature_mind/test/agent_chat/fixtures/characterization/claim_plus_hospital_graph.json
@@ -1,0 +1,68 @@
+{
+  "nodes": [
+    {
+      "id": "identifier:9001001",
+      "type": "identifier",
+      "name": "Claim 9001001",
+      "attributes": {
+        "kind": "claim",
+        "value": "9001001"
+      }
+    },
+    {
+      "id": "organization:niva-bupa",
+      "type": "organization",
+      "name": "Niva Bupa",
+      "attributes": {
+        "role": "insurer"
+      }
+    },
+    {
+      "id": "organization:city-hospital",
+      "type": "organization",
+      "name": "City Hospital",
+      "attributes": {
+        "role": "hospital"
+      }
+    },
+    {
+      "id": "identifier:hospital-stay-city-hospital",
+      "type": "identifier",
+      "name": "City Hospital surgery",
+      "attributes": {
+        "kind": "hospital_stay",
+        "hospital": "City Hospital"
+      }
+    },
+    {
+      "id": "term:niva-bupa-claim",
+      "type": "term",
+      "name": "Niva Bupa Claim",
+      "attributes": {}
+    }
+  ],
+  "edges": [
+    {
+      "from_id": "identifier:9001001",
+      "to_id": "organization:niva-bupa",
+      "predicate": "insured_by"
+    },
+    {
+      "from_id": "identifier:hospital-stay-city-hospital",
+      "to_id": "organization:city-hospital",
+      "predicate": "related_to"
+    },
+    {
+      "from_id": "identifier:9001001",
+      "to_id": "organization:city-hospital",
+      "predicate": "related_to"
+    }
+  ],
+  "recent_node_ids": [
+    "identifier:9001001",
+    "organization:niva-bupa",
+    "organization:city-hospital",
+    "identifier:hospital-stay-city-hospital",
+    "term:niva-bupa-claim"
+  ]
+}

--- a/packages/feature_mind/test/agent_chat/fixtures/characterization/claim_plus_hospital_journeys.json
+++ b/packages/feature_mind/test/agent_chat/fixtures/characterization/claim_plus_hospital_journeys.json
@@ -1,0 +1,20 @@
+[
+  {
+    "template_id": "insurance_claim_v1",
+    "facts": {
+      "Claim ID": "9001001",
+      "Claim Submission Reference": "9001001",
+      "Insurer": "Niva Bupa"
+    },
+    "is_offerable": true,
+    "title": "Niva Bupa claim 9001001"
+  },
+  {
+    "template_id": "medical_surgery_v1",
+    "facts": {
+      "Hospital": "City Hospital"
+    },
+    "is_offerable": true,
+    "title": "City Hospital surgery"
+  }
+]

--- a/packages/feature_mind/test/agent_chat/fixtures/characterization/diet_constraints.json
+++ b/packages/feature_mind/test/agent_chat/fixtures/characterization/diet_constraints.json
@@ -1,0 +1,12 @@
+{
+  "constraints": [
+    "Make me a 7 day diet plan",
+    "i want some indian menu only",
+    "veg only"
+  ],
+  "prompt_checks": {
+    "duration_7_days": true,
+    "indian_menu": true,
+    "veg_only": true
+  }
+}

--- a/packages/feature_mind/test/agent_chat/fixtures/characterization/insurance_claim_graph.json
+++ b/packages/feature_mind/test/agent_chat/fixtures/characterization/insurance_claim_graph.json
@@ -1,0 +1,75 @@
+{
+  "nodes": [
+    {
+      "id": "identifier:9001001",
+      "type": "identifier",
+      "name": "Claim 9001001",
+      "attributes": {
+        "kind": "claim",
+        "value": "9001001",
+        "follow_up": "Broker confirmed documents received."
+      }
+    },
+    {
+      "id": "organization:niva-bupa",
+      "type": "organization",
+      "name": "Niva Bupa",
+      "attributes": {
+        "role": "insurer"
+      }
+    },
+    {
+      "id": "organization:policybazaar",
+      "type": "organization",
+      "name": "Policybazaar",
+      "attributes": {
+        "role": "broker"
+      }
+    },
+    {
+      "id": "document:claim-documents",
+      "type": "document",
+      "name": "Claim documents",
+      "attributes": {
+        "status": "received"
+      }
+    },
+    {
+      "id": "term:claim",
+      "type": "term",
+      "name": "Claim",
+      "attributes": {}
+    },
+    {
+      "id": "term:all",
+      "type": "term",
+      "name": "All",
+      "attributes": {}
+    }
+  ],
+  "edges": [
+    {
+      "from_id": "identifier:9001001",
+      "to_id": "organization:niva-bupa",
+      "predicate": "insured_by"
+    },
+    {
+      "from_id": "identifier:9001001",
+      "to_id": "organization:policybazaar",
+      "predicate": "filed_via"
+    },
+    {
+      "from_id": "identifier:9001001",
+      "to_id": "document:claim-documents",
+      "predicate": "has_document"
+    }
+  ],
+  "recent_node_ids": [
+    "identifier:9001001",
+    "organization:niva-bupa",
+    "organization:policybazaar",
+    "document:claim-documents",
+    "term:claim",
+    "term:all"
+  ]
+}

--- a/packages/feature_mind/test/agent_chat/fixtures/characterization/property_purchase_graph.json
+++ b/packages/feature_mind/test/agent_chat/fixtures/characterization/property_purchase_graph.json
@@ -1,0 +1,76 @@
+{
+  "nodes": [
+    {
+      "id": "identifier:property-p52100012345",
+      "type": "identifier",
+      "name": "Prestige Tower B",
+      "attributes": {
+        "kind": "property",
+        "rera": "P52100012345",
+        "builder": "Prestige",
+        "project": "Tower B",
+        "floor": "14"
+      }
+    },
+    {
+      "id": "identifier:p52100012345",
+      "type": "identifier",
+      "name": "RERA P52100012345",
+      "attributes": {
+        "kind": "rera",
+        "value": "P52100012345"
+      }
+    },
+    {
+      "id": "organization:prestige",
+      "type": "organization",
+      "name": "Prestige",
+      "attributes": {
+        "role": "builder"
+      }
+    },
+    {
+      "id": "term:tower-b",
+      "type": "term",
+      "name": "Tower B",
+      "attributes": {}
+    },
+    {
+      "id": "term:tower",
+      "type": "term",
+      "name": "Tower",
+      "attributes": {}
+    },
+    {
+      "id": "term:rera",
+      "type": "term",
+      "name": "RERA",
+      "attributes": {}
+    }
+  ],
+  "edges": [
+    {
+      "from_id": "identifier:property-p52100012345",
+      "to_id": "identifier:p52100012345",
+      "predicate": "related_to"
+    },
+    {
+      "from_id": "identifier:property-p52100012345",
+      "to_id": "organization:prestige",
+      "predicate": "related_to"
+    },
+    {
+      "from_id": "identifier:property-p52100012345",
+      "to_id": "term:tower-b",
+      "predicate": "related_to"
+    }
+  ],
+  "recent_node_ids": [
+    "identifier:property-p52100012345",
+    "identifier:p52100012345",
+    "organization:prestige",
+    "term:tower-b",
+    "term:tower",
+    "term:rera"
+  ]
+}

--- a/packages/feature_mind/test/agent_chat/fixtures/characterization/property_purchase_journey.json
+++ b/packages/feature_mind/test/agent_chat/fixtures/characterization/property_purchase_journey.json
@@ -1,0 +1,11 @@
+{
+  "template_id": "real_estate_under_construction_v1",
+  "facts": {
+    "RERA Registration Number": "P52100012345",
+    "Builder": "Prestige",
+    "Builder Track Record Notes": "Prestige",
+    "Project": "Tower B",
+    "Your Target Floor": "14"
+  },
+  "is_offerable": true
+}

--- a/packages/feature_mind/test/agent_chat/fixtures/characterization_generate_test.dart
+++ b/packages/feature_mind/test/agent_chat/fixtures/characterization_generate_test.dart
@@ -1,0 +1,106 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:feature_mind/src/agent_chat/data/services/assistant_chat_context_builder.dart';
+import 'package:feature_mind/src/agent_chat/data/services/diet_plan_plugin_prompt.dart';
+import 'package:feature_mind/src/agent_chat/domain/models/chat_entity_graph.dart';
+import 'package:feature_mind/src/agent_chat/domain/services/chat_entity_graph_projector.dart';
+import 'package:feature_mind/src/agent_chat/domain/services/chat_entity_linker.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// Run with GENERATE_FIXTURES=1 to refresh characterization JSON.
+void main() {
+  test('generate characterization fixtures', () {
+    if (Platform.environment['GENERATE_FIXTURES'] != '1') return;
+
+    const linker = ChatEntityLinker();
+    const projector = ChatEntityGraphProjector();
+    final outDir = Directory('test/agent_chat/fixtures/characterization');
+    outDir.createSync(recursive: true);
+
+    void write(String name, Object data) {
+      File('${outDir.path}/$name.json').writeAsStringSync(
+        const JsonEncoder.withIndent('  ').convert(data),
+      );
+    }
+
+    final insurance = linker.ingest(
+      ChatEntityGraph.empty,
+      'Niva Bupa reimbursement Claim ID 9001001 via Policybazaar. '
+      'All documents received.',
+    );
+    write('insurance_claim_graph', insurance.toJson());
+
+    final dual = linker.ingest(
+      ChatEntityGraph.empty,
+      'Niva Bupa Claim ID 9001001 after surgery at City Hospital.',
+    );
+    write('claim_plus_hospital_graph', dual.toJson());
+    write(
+      'claim_plus_hospital_journeys',
+      projector
+          .project(dual)
+          .map(
+            (journey) => {
+              'template_id': journey.templateId,
+              'facts': journey.facts,
+              'is_offerable': journey.isOfferable,
+              'title': journey.title,
+            },
+          )
+          .toList(growable: false),
+    );
+
+    final property = linker.ingest(
+      ChatEntityGraph.empty,
+      'buying Tower B floor 14 from Prestige, RERA P52100012345',
+    );
+    write('property_purchase_graph', property.toJson());
+    final propertyJourney = projector.project(property).single;
+    write(
+      'property_purchase_journey',
+      {
+        'template_id': propertyJourney.templateId,
+        'facts': propertyJourney.facts,
+        'is_offerable': propertyJourney.isOfferable,
+      },
+    );
+
+    final history = [
+      const AssistantChatContextMessage(
+        text: 'Make me a 7 day diet plan',
+        isUser: true,
+      ),
+      const AssistantChatContextMessage(text: 'Day 1 menu', isUser: false),
+      const AssistantChatContextMessage(
+        text: 'i want some indian menu only',
+        isUser: true,
+      ),
+      const AssistantChatContextMessage(text: 'Day 1 indian', isUser: false),
+    ];
+    const current = 'veg only';
+    write(
+      'diet_constraints',
+      {
+        'constraints': DietPlanPluginPrompt.userConstraintLines(
+          currentPrompt: current,
+          history: history,
+        ),
+        'prompt_checks': {
+          'duration_7_days': DietPlanPluginPrompt.modelUserPrompt(
+            currentPrompt: current,
+            history: history,
+          ).contains('Duration: 7 days'),
+          'indian_menu': DietPlanPluginPrompt.modelUserPrompt(
+            currentPrompt: current,
+            history: history,
+          ).contains('indian menu only'),
+          'veg_only': DietPlanPluginPrompt.modelUserPrompt(
+            currentPrompt: current,
+            history: history,
+          ).contains('veg only'),
+        },
+      },
+    );
+  });
+}

--- a/packages/feature_mind/test/agent_chat/fixtures/characterization_test.dart
+++ b/packages/feature_mind/test/agent_chat/fixtures/characterization_test.dart
@@ -1,0 +1,118 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:feature_mind/src/agent_chat/data/services/assistant_chat_context_builder.dart';
+import 'package:feature_mind/src/agent_chat/data/services/diet_plan_plugin_prompt.dart';
+import 'package:feature_mind/src/agent_chat/domain/models/chat_entity_graph.dart';
+import 'package:feature_mind/src/agent_chat/domain/models/entity_graph_bridge.dart';
+import 'package:feature_mind/src/agent_chat/domain/services/chat_entity_graph_projector.dart';
+import 'package:feature_mind/src/agent_chat/domain/services/chat_entity_linker.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+Map<String, dynamic> _readFixture(String name) {
+  final file = File('test/agent_chat/fixtures/characterization/$name.json');
+  return jsonDecode(file.readAsStringSync()) as Map<String, dynamic>;
+}
+
+dynamic _readFixtureRaw(String name) {
+  final file = File('test/agent_chat/fixtures/characterization/$name.json');
+  return jsonDecode(file.readAsStringSync());
+}
+
+void main() {
+  const linker = ChatEntityLinker();
+  const projector = ChatEntityGraphProjector();
+
+  test('insurance claim graph matches frozen characterization fixture', () {
+    final graph = linker.ingest(
+      ChatEntityGraph.empty,
+      'Niva Bupa reimbursement Claim ID 9001001 via Policybazaar. '
+      'All documents received.',
+    );
+    expect(graph.toJson(), _readFixture('insurance_claim_graph'));
+  });
+
+  test('claim plus hospital graph matches frozen characterization fixture', () {
+    final graph = linker.ingest(
+      ChatEntityGraph.empty,
+      'Niva Bupa Claim ID 9001001 after surgery at City Hospital.',
+    );
+    expect(graph.toJson(), _readFixture('claim_plus_hospital_graph'));
+
+    final journeys = projector.project(graph);
+    final fixtureJourneys = (_readFixtureRaw('claim_plus_hospital_journeys') as List)
+        .cast<Map<String, dynamic>>();
+    expect(
+      journeys
+          .map(
+            (journey) => {
+              'template_id': journey.templateId,
+              'facts': journey.facts,
+              'is_offerable': journey.isOfferable,
+              'title': journey.title,
+            },
+          )
+          .toList(growable: false),
+      fixtureJourneys,
+    );
+  });
+
+  test('property purchase graph matches frozen characterization fixture', () {
+    final graph = linker.ingest(
+      ChatEntityGraph.empty,
+      'buying Tower B floor 14 from Prestige, RERA P52100012345',
+    );
+    expect(graph.toJson(), _readFixture('property_purchase_graph'));
+
+    final journey = projector.project(graph).single;
+    final fixture = _readFixture('property_purchase_journey');
+    expect(journey.templateId, fixture['template_id']);
+    expect(journey.facts, fixture['facts']);
+    expect(journey.isOfferable, fixture['is_offerable']);
+  });
+
+  test('diet constraints match frozen characterization fixture', () {
+    final fixture = _readFixture('diet_constraints');
+    final history = [
+      const AssistantChatContextMessage(
+        text: 'Make me a 7 day diet plan',
+        isUser: true,
+      ),
+      const AssistantChatContextMessage(text: 'Day 1 menu', isUser: false),
+      const AssistantChatContextMessage(
+        text: 'i want some indian menu only',
+        isUser: true,
+      ),
+      const AssistantChatContextMessage(text: 'Day 1 indian', isUser: false),
+    ];
+    const current = 'veg only';
+
+    expect(
+      DietPlanPluginPrompt.userConstraintLines(
+        currentPrompt: current,
+        history: history,
+      ),
+      fixture['constraints'],
+    );
+
+    final prompt = DietPlanPluginPrompt.modelUserPrompt(
+      currentPrompt: current,
+      history: history,
+    );
+    final checks = fixture['prompt_checks'] as Map<String, dynamic>;
+    expect(prompt.contains('Duration: 7 days'), checks['duration_7_days']);
+    expect(prompt.contains('indian menu only'), checks['indian_menu']);
+    expect(prompt.contains('veg only'), checks['veg_only']);
+  });
+
+  test('ChatEntityGraph bridge round-trips neutral EntityGraph JSON', () {
+    final graph = linker.ingest(
+      ChatEntityGraph.empty,
+      'Niva Bupa Claim ID 9001001',
+    );
+    final neutral = graph.toEntityGraph();
+    final restored = ChatEntityGraphBridge.fromEntityGraph(neutral);
+    expect(restored.toJson(), graph.toJson());
+    expect(neutral.toJson(), graph.toEntityGraph().toJson());
+  });
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds **Increment 1** of the approved add-on framework design: neutral contracts, characterization fixtures, and synthetic adapter proof — without rerouting production chat yet.

### Design (prior commits on branch)
- Approved add-on framework spec with security/QA gates (`docs/superpowers/specs/2026-08-22-airo-mind-addon-framework-design.md`)

### Increment 1 (this commit)
- **`core_domain`**: `AddonManifest`, graph DTOs (`EntityGraph`, patch/snapshot/provenance), workflow projection/pending contracts, registry port
- **`core_ai`**: manifest validator, `AddonRegistry`, generative/graph adapter interfaces, eligibility + pinned ordering, synthetic adapter dispatch tests
- **`feature_mind`**: frozen JSON characterization fixtures (insurance, hospital+claim, property, diet), bridge `ChatEntityGraph` ↔ `EntityGraph`, `AddonHostDispatch` smoke test

### Docs
- Implementation plan: `docs/superpowers/plans/2026-08-22-airo-mind-addon-framework-increment-1.md`

### Verification
```bash
cd packages/core_domain && flutter test
cd packages/core_ai && flutter test test/addons/
cd packages/feature_mind && flutter test test/agent_chat/fixtures/ test/addons/
cd packages/feature_mind && flutter test test/agent_chat/domain/services/chat_entity_*
```

### Next
Increment 2: encrypted LifeTrack destination + idempotent confirmation redemption (per spec §11).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3cb72c1f-40c3-40b6-938b-70e7592345dd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3cb72c1f-40c3-40b6-938b-70e7592345dd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

