### PR TITLE
feat(mind): add PubMed SearchEngine adapter (Task 5a)

### DIFF
--- a/packages/feature_mind/lib/src/agent_chat/domain/services/research/pubmed_search_engine.dart
+++ b/packages/feature_mind/lib/src/agent_chat/domain/services/research/pubmed_search_engine.dart
@@ -1,0 +1,117 @@
+import 'dart:convert';
+
+import 'research_http.dart';
+import 'research_search.dart';
+
+/// PubMed search via NCBI E-utilities. Hits are candidates, not evidence.
+class PubMedSearchEngine implements ResearchSearchEngine {
+  PubMedSearchEngine({
+    this.http = const ResearchHttpClient(),
+    this.tool = 'airo_mind',
+    this.email = 'noreply@local',
+  });
+
+  final ResearchHttpClient http;
+  final String tool;
+  final String email;
+
+  @override
+  String get id => 'pubmed';
+
+  static List<String> parseEsearchIds(String body) {
+    final decoded = jsonDecode(body);
+    if (decoded is! Map) {
+      return const [];
+    }
+    final result = decoded['esearchresult'];
+    if (result is! Map) {
+      return const [];
+    }
+    final ids = result['idlist'];
+    if (ids is! List) {
+      return const [];
+    }
+    return [
+      for (final id in ids)
+        if ('$id'.trim().isNotEmpty) '$id'.trim(),
+    ];
+  }
+
+  static List<ResearchHit> parseEsummaryJson(String body) {
+    final decoded = jsonDecode(body);
+    if (decoded is! Map) {
+      return const [];
+    }
+    final result = decoded['result'];
+    if (result is! Map) {
+      return const [];
+    }
+    final uids = result['uids'];
+    if (uids is! List) {
+      return const [];
+    }
+    final hits = <ResearchHit>[];
+    for (final uid in uids) {
+      final pmid = '$uid'.trim();
+      if (pmid.isEmpty) {
+        continue;
+      }
+      final row = result[pmid];
+      if (row is! Map) {
+        continue;
+      }
+      final title = '${row['title'] ?? ''}'.trim();
+      if (title.isEmpty) {
+        continue;
+      }
+      final source = '${row['source'] ?? ''}'.trim();
+      final pubdate = '${row['pubdate'] ?? ''}'.trim();
+      final snippet = [source, pubdate].where((part) => part.isNotEmpty).join(
+        ' · ',
+      );
+      hits.add(
+        ResearchHit(
+          engineId: 'pubmed',
+          url: 'https://pubmed.ncbi.nlm.nih.gov/$pmid/',
+          title: title,
+          snippet: snippet,
+        ),
+      );
+    }
+    return hits;
+  }
+
+  Map<String, String> _eutilsParams({
+    required String db,
+    required Map<String, String> extra,
+  }) {
+    return {'db': db, 'retmode': 'json', 'tool': tool, 'email': email, ...extra};
+  }
+
+  @override
+  Future<List<ResearchHit>> search(String query, {int maxResults = 5}) async {
+    if (query.trim().isEmpty) {
+      return const [];
+    }
+    final searchUri = Uri.https(
+      'eutils.ncbi.nlm.nih.gov',
+      '/entrez/eutils/esearch.fcgi',
+      _eutilsParams(
+        db: 'pubmed',
+        extra: {'term': query, 'retmax': '$maxResults'},
+      ),
+    );
+    final searchBody = await http.get(searchUri);
+    final ids = parseEsearchIds(searchBody);
+    if (ids.isEmpty) {
+      return const [];
+    }
+    final summaryUri = Uri.https(
+      'eutils.ncbi.nlm.nih.gov',
+      '/entrez/eutils/esummary.fcgi',
+      _eutilsParams(db: 'pubmed', extra: {'id': ids.join(',')}),
+    );
+    final summaryBody = await http.get(summaryUri);
+    return parseEsummaryJson(summaryBody);
+  }
+}

--- a/packages/feature_mind/lib/src/agent_chat/domain/services/research/research_http.dart
+++ b/packages/feature_mind/lib/src/agent_chat/domain/services/research/research_http.dart
@@ -75,6 +75,8 @@ class ResearchHttpClient {
     'arxiv.org',
     'api.semanticscholar.org',
     'www.semanticscholar.org',
+    'eutils.ncbi.nlm.nih.gov',
+    'pubmed.ncbi.nlm.nih.gov',
   };
 
   final Set<String> allowedHosts;

--- a/packages/feature_mind/lib/src/agent_chat/domain/services/research/research_search.dart
+++ b/packages/feature_mind/lib/src/agent_chat/domain/services/research/research_search.dart
@@ -38,7 +38,7 @@ class SearchRouter {
       case SearchPolicy.maximumQuality:
         return const ['wikipedia', 'arxiv', 'semantic_scholar'];
       case SearchPolicy.academic:
-        return const ['arxiv', 'semantic_scholar'];
+        return const ['arxiv', 'semantic_scholar', 'pubmed'];
     }
   }
 

--- a/packages/feature_mind/lib/src/agent_chat/domain/services/research/research_service.dart
+++ b/packages/feature_mind/lib/src/agent_chat/domain/services/research/research_service.dart
@@ -1,6 +1,7 @@
 import '../../models/research_event.dart';
 import '../../models/research_request.dart';
 import 'arxiv_search_engine.dart';
+import 'pubmed_search_engine.dart';
 import 'research_checkpoint.dart';
 import 'research_control.dart';
 import 'research_http.dart';
@@ -60,6 +61,7 @@ class LocalResearchService implements ResearchService {
         WikipediaSearchEngine(),
         ArxivSearchEngine(),
         SemanticScholarSearchEngine(),
+        PubMedSearchEngine(),
         if (searxngBaseUri != null)
           SearxngSearchEngine(baseUri: searxngBaseUri),
       ],

--- a/packages/feature_mind/test/agent_chat/domain/services/research/pubmed_search_engine_test.dart
+++ b/packages/feature_mind/test/agent_chat/domain/services/research/pubmed_search_engine_test.dart
@@ -1,0 +1,55 @@
+import 'package:feature_mind/src/agent_chat/domain/services/research/pubmed_search_engine.dart';
+import 'package:feature_mind/src/agent_chat/domain/services/research/research_http.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('esearch parser extracts pmids', () {
+    const body = '''
+{
+  "esearchresult": {
+    "count": "2",
+    "idlist": ["12345", "67890"]
+  }
+}
+''';
+    expect(PubMedSearchEngine.parseEsearchIds(body), ['12345', '67890']);
+  });
+
+  test('esummary parser maps pmids to pubmed urls and titles', () {
+    const body = '''
+{
+  "result": {
+    "uids": ["12345"],
+    "12345": {
+      "uid": "12345",
+      "title": "Qwen on device",
+      "source": "Nature",
+      "pubdate": "2024 Jan"
+    }
+  }
+}
+''';
+    final hits = PubMedSearchEngine.parseEsummaryJson(body);
+    expect(hits, hasLength(1));
+    expect(hits.single.engineId, 'pubmed');
+    expect(hits.single.title, 'Qwen on device');
+    expect(hits.single.url, 'https://pubmed.ncbi.nlm.nih.gov/12345/');
+    expect(hits.single.snippet, contains('Nature'));
+  });
+
+  test('research http allows pubmed eutils and rejects google', () {
+    const client = ResearchHttpClient();
+    expect(
+      () => client.validate(
+        Uri.parse(
+          'https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi',
+        ),
+      ),
+      returnsNormally,
+    );
+    expect(
+      () => client.get(Uri.parse('https://www.google.com/search?q=qwen')),
+      throwsA(isA<ResearchHttpException>()),
+    );
+  });
+}

--- a/packages/feature_mind/test/agent_chat/domain/services/research/search_router_test.dart
+++ b/packages/feature_mind/test/agent_chat/domain/services/research/search_router_test.dart
@@ -11,7 +11,7 @@ void main() {
 
   test('academic policy prefers papers', () {
     final ids = SearchRouter.engineIds(SearchPolicy.academic);
-    expect(ids, containsAll(['arxiv', 'semantic_scholar']));
+    expect(ids, containsAll(['arxiv', 'semantic_scholar', 'pubmed']));
     expect(ids, isNot(contains('google')));
   });
 

--- a/rust/airo_mind_core/src/research/engine.rs
+++ b/rust/airo_mind_core/src/research/engine.rs
@@ -402,7 +402,9 @@ fn engine_allowed(policy: SearchPolicy, id: &str) -> bool {
     match policy {
         SearchPolicy::LocalOnly => false,
         SearchPolicy::PrivacyFirst => id == "wikipedia" || id == "searxng",
-        SearchPolicy::Academic => id == "arxiv" || id == "semantic_scholar",
+        SearchPolicy::Academic => {
+            id == "arxiv" || id == "semantic_scholar" || id == "pubmed"
+        }
         SearchPolicy::Balanced | SearchPolicy::MaximumQuality => {
             id != "google" && id != "bing" && id != "tavily" && id != "duckduckgo"
         }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a PubMed `SearchEngine` adapter for Deep Research academic queries.

- `PubMedSearchEngine` calls NCBI E-utilities (`esearch` → `esummary`) with tool/email parameters.
- Allowlists `eutils.ncbi.nlm.nih.gov` and `pubmed.ncbi.nlm.nih.gov`.
- Routes `pubmed` through `SearchPolicy.academic` and registers the engine in `LocalResearchService`.
- Mirrors routing in Rust `engine_allowed` for the academic policy.

## Test plan

- [x] `flutter test test/agent_chat/domain/services/research/pubmed_search_engine_test.dart`
- [x] `flutter test test/agent_chat/domain/services/research/search_router_test.dart`
- [x] `cargo test -p airo_mind_core --lib research::engine::tests::privacy_first`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0d1a1368-352c-43c3-b66e-d4ae3a878dd5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0d1a1368-352c-43c3-b66e-d4ae3a878dd5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

