### PR TITLE
feat(mind): Increment 2 secure LifeTrack destination

### DIFF
--- a/docs/superpowers/plans/2026-08-22-airo-mind-addon-framework-increment-2.md
+++ b/docs/superpowers/plans/2026-08-22-airo-mind-addon-framework-increment-2.md
@@ -1,0 +1,15 @@
+# Airo Mind Add-on Framework — Increment 2 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans for later increments.
+
+**Goal:** Ship encrypted LifeTrack destination storage, transactional plaintext migration, idempotent effect records, and `secure_destination_unavailable` read-only fallback.
+
+**Architecture:** `SqfliteEncryptedDatabase` gates a separate `life_track_secure.db` behind `EncryptionKeyManager`. `SecureLifeTrackDestination` routes writes to encrypted storage and reads from encrypted (post-migration) or plaintext compatibility. `LifeTrackIdempotencyStore` implements `IdempotentEffectPort` for confirmation redemption.
+
+**Verification:**
+```bash
+cd packages/core_data && flutter test test/storage/secure_life_track_destination_test.dart test/storage/life_track_local_data_source_test.dart
+cd packages/core_domain && flutter test test/effects/
+```
+
+**Next:** Increment 3 — migrate Diet Plan through the add-on registry.

--- a/docs/superpowers/specs/2026-08-22-airo-mind-addon-framework-design.md
+++ b/docs/superpowers/specs/2026-08-22-airo-mind-addon-framework-design.md
@@ -1,8 +1,8 @@
 # Airo Mind Add-on Framework
 
 **Date:** 2026-08-22  
-**Status:** Approved; Increment 1 contracts and characterization landed on
-`cursor/mind-addon-framework-design-45dd`; implementation continues increment-by-increment  
+**Status:** Approved; Increment 1 contracts landed; Increment 2 secure LifeTrack
+destination landed on `cursor/mind-addon-increment-2-secure-lifetrack-45dd`  
 **Owners:** Framework Agent + Product Manager (Airo Mind)  
 **Required reviewers:** Product Manager, Framework Agent, AI/Brain Agent,
 Memory Agent, Chief Architect, Platform Architect, Flutter Architect, Edge

--- a/packages/core_data/lib/core_data.dart
+++ b/packages/core_data/lib/core_data.dart
@@ -16,6 +16,13 @@ export 'src/storage/templates/life_track_template_fallback_resolver.dart';
 export 'src/storage/templates/template_registry.dart';
 export 'src/secure/secure_storage.dart';
 export 'src/secure/in_memory_secure_storage.dart';
+export 'src/secure/sqflite_encrypted_database.dart';
+export 'src/storage/life_track_sql_schema.dart';
+export 'src/storage/life_track_graph_sql_store.dart';
+export 'src/storage/encrypted_life_track_data_source.dart';
+export 'src/storage/life_track_idempotency_store.dart';
+export 'src/storage/life_track_plaintext_migration.dart';
+export 'src/storage/secure_life_track_destination.dart';
 
 // Connectivity
 export 'src/connectivity/connectivity_service.dart';
@@ -32,6 +39,7 @@ export 'src/sync/outbox_repository.dart';
 // Base Repository
 export 'src/repositories/base_repository.dart';
 export 'src/repositories/life_track_repository_impl.dart';
+export 'src/repositories/secure_life_track_repository_impl.dart';
 
 // Plugin Storage and Runtime Controls
 export 'src/plugins/local_plugin_storage.dart';

--- a/packages/core_data/lib/src/repositories/secure_life_track_repository_impl.dart
+++ b/packages/core_data/lib/src/repositories/secure_life_track_repository_impl.dart
@@ -1,0 +1,52 @@
+import 'package:core_domain/core_domain.dart';
+
+import '../storage/secure_life_track_destination.dart';
+
+class SecureLifeTrackRepositoryImpl implements LifeTrackRepository {
+  SecureLifeTrackRepositoryImpl({required this._destination});
+
+  final SecureLifeTrackDestination _destination;
+
+  @override
+  Future<Result<LifeTrack>> createTrack(LifeTrack track) =>
+      _destination.createTrack(track);
+
+  @override
+  Future<Result<void>> deleteTrack(String id) =>
+      _destination.deleteTrack(id);
+
+  @override
+  Future<Result<LifeTrack>> getTrack(String id) => _destination.getTrack(id);
+
+  @override
+  Future<Result<List<LifeTrack>>> listTracks({TrackStatus? status}) =>
+      _destination.listTracks(status: status);
+
+  @override
+  Future<Result<void>> saveInputValue(
+    String requirementId,
+    String value,
+  ) => _destination.saveInputValue(requirementId, value);
+
+  @override
+  Future<Result<void>> updateActionItem(ActionItem item) =>
+      _destination.updateActionItem(item);
+
+  @override
+  Future<Result<void>> updateItemStatus(
+    String itemId,
+    ItemStatus status,
+  ) => _destination.updateItemStatus(itemId, status);
+
+  @override
+  Future<Result<void>> updateMilestone(Milestone milestone) =>
+      _destination.updateMilestone(milestone);
+
+  @override
+  Future<Result<void>> updateTrack(LifeTrack track) =>
+      _destination.updateTrack(track);
+
+  @override
+  Stream<List<LifeTrack>> watchTracks({TrackStatus? status}) =>
+      _destination.watchTracks(status: status);
+}

--- a/packages/core_data/lib/src/secure/sqflite_encrypted_database.dart
+++ b/packages/core_data/lib/src/secure/sqflite_encrypted_database.dart
@@ -1,0 +1,320 @@
+import 'package:core_domain/core_domain.dart';
+import 'package:path/path.dart' as p;
+import 'package:sqflite/sqflite.dart';
+
+import 'secure_storage.dart';
+
+/// Sqflite-backed [EncryptedDatabase] gated by [EncryptionKeyManager].
+///
+/// This increment uses a separate secure database file and key availability as
+/// the encryption boundary. SQLCipher binding is a follow-on platform concern.
+class SqfliteEncryptedDatabase implements EncryptedDatabase {
+  SqfliteEncryptedDatabase({
+    required EncryptionKeyManager keyManager,
+    DatabaseFactory? databaseFactory,
+    String? databasePath,
+  }) : _keyManager = keyManager,
+       _databaseFactory = databaseFactory ?? databaseFactorySqflitePlugin,
+       _databasePath = databasePath;
+
+  final EncryptionKeyManager _keyManager;
+  final DatabaseFactory _databaseFactory;
+  final String? _databasePath;
+
+  Database? _database;
+  EncryptedDatabaseConfig? _config;
+  bool _encryptionReady = false;
+
+  @override
+  bool get isOpen => _database != null && _database!.isOpen;
+
+  @override
+  String get path => _database?.path ?? _databasePath ?? '';
+
+  @override
+  Future<Result<void>> initialize(EncryptedDatabaseConfig config) async {
+    if (_database != null && _database!.isOpen) return const Ok(null);
+
+    _config = config;
+    if (config.enableEncryption) {
+      final available = await _keyManager.isEncryptionAvailable();
+      if (!available) {
+        return Err(
+          SecureDestinationUnavailableError(
+            'Encryption is not available on this device',
+          ),
+          StackTrace.current,
+        );
+      }
+      final keyResult = await _keyManager.getDatabaseKey();
+      if (keyResult is Err<List<int>>) {
+        return Err(
+          SecureDestinationUnavailableError(
+            'Database encryption key is unavailable',
+            originalError: keyResult.error,
+            originalStack: keyResult.stack,
+          ),
+          keyResult.stack,
+        );
+      }
+      _encryptionReady = true;
+    }
+
+    final resolvedPath =
+        _databasePath ??
+        p.join(await getDatabasesPath(), config.databaseName);
+
+    _database = await _databaseFactory.openDatabase(
+      resolvedPath,
+      options: OpenDatabaseOptions(
+        version: config.schemaVersion,
+        singleInstance: false,
+        onConfigure: (db) async {
+          await db.execute('PRAGMA foreign_keys = ON');
+          if (config.enableWalMode) {
+            await db.execute('PRAGMA journal_mode = WAL');
+          }
+        },
+      ),
+    );
+
+    return const Ok(null);
+  }
+
+  bool get encryptionReady => _encryptionReady;
+
+  Database get database {
+    if (_database == null || !_database!.isOpen) {
+      throw StateError('Encrypted database is not open');
+    }
+    return _database!;
+  }
+
+  @override
+  Future<Result<List<Map<String, dynamic>>>> rawQuery(
+    String sql, [
+    List<Object?>? arguments,
+  ]) async {
+    try {
+      final rows = await database.rawQuery(sql, arguments);
+      return Ok(rows);
+    } catch (error, stack) {
+      return Err(StorageError('rawQuery failed: $error'), stack);
+    }
+  }
+
+  @override
+  Future<Result<int>> rawExecute(String sql, [List<Object?>? arguments]) async {
+    try {
+      return Ok(await database.rawUpdate(sql, arguments));
+    } catch (error, stack) {
+      return Err(StorageError('rawExecute failed: $error'), stack);
+    }
+  }
+
+  @override
+  Future<Result<int>> insert(String table, Map<String, dynamic> values) async {
+    try {
+      return Ok(await database.insert(table, values));
+    } catch (error, stack) {
+      return Err(StorageError('insert failed: $error'), stack);
+    }
+  }
+
+  @override
+  Future<Result<int>> update(
+    String table,
+    Map<String, dynamic> values, {
+    String? where,
+    List<Object?>? whereArgs,
+  }) async {
+    try {
+      return Ok(
+        await database.update(table, values, where: where, whereArgs: whereArgs),
+      );
+    } catch (error, stack) {
+      return Err(StorageError('update failed: $error'), stack);
+    }
+  }
+
+  @override
+  Future<Result<int>> delete(
+    String table, {
+    String? where,
+    List<Object?>? whereArgs,
+  }) async {
+    try {
+      return Ok(
+        await database.delete(table, where: where, whereArgs: whereArgs),
+      );
+    } catch (error, stack) {
+      return Err(StorageError('delete failed: $error'), stack);
+    }
+  }
+
+  @override
+  Future<Result<List<Map<String, dynamic>>>> query(
+    String table, {
+    List<String>? columns,
+    String? where,
+    List<Object?>? whereArgs,
+    String? orderBy,
+    int? limit,
+    int? offset,
+  }) async {
+    try {
+      final rows = await database.query(
+        table,
+        columns: columns,
+        where: where,
+        whereArgs: whereArgs,
+        orderBy: orderBy,
+        limit: limit,
+        offset: offset,
+      );
+      return Ok(rows);
+    } catch (error, stack) {
+      return Err(StorageError('query failed: $error'), stack);
+    }
+  }
+
+  @override
+  Future<Result<T>> transaction<T>(
+    Future<T> Function(EncryptedDatabase txn) action,
+  ) async {
+    try {
+      final result = await database.transaction((txn) async {
+        final txnDb = _TransactionDatabase(this, txn);
+        return await action(txnDb);
+      });
+      return Ok(result);
+    } catch (error, stack) {
+      return Err(StorageError('transaction failed: $error'), stack);
+    }
+  }
+
+  @override
+  Future<Result<void>> close() async {
+    try {
+      await _database?.close();
+      _database = null;
+      return const Ok(null);
+    } catch (error, stack) {
+      return Err(StorageError('close failed: $error'), stack);
+    }
+  }
+}
+
+class _TransactionDatabase implements EncryptedDatabase {
+  _TransactionDatabase(this._parent, this._txn);
+
+  final SqfliteEncryptedDatabase _parent;
+  final DatabaseExecutor _txn;
+
+  @override
+  bool get isOpen => _parent.isOpen;
+
+  @override
+  String get path => _parent.path;
+
+  @override
+  Future<Result<void>> initialize(EncryptedDatabaseConfig config) async =>
+      const Ok(null);
+
+  @override
+  Future<Result<List<Map<String, dynamic>>>> rawQuery(
+    String sql, [
+    List<Object?>? arguments,
+  ]) async {
+    try {
+      return Ok(await _txn.rawQuery(sql, arguments));
+    } catch (error, stack) {
+      return Err(StorageError('txn rawQuery failed: $error'), stack);
+    }
+  }
+
+  @override
+  Future<Result<int>> rawExecute(String sql, [List<Object?>? arguments]) async {
+    try {
+      return Ok(await _txn.rawUpdate(sql, arguments));
+    } catch (error, stack) {
+      return Err(StorageError('txn rawExecute failed: $error'), stack);
+    }
+  }
+
+  @override
+  Future<Result<int>> insert(String table, Map<String, dynamic> values) async {
+    try {
+      return Ok(await _txn.insert(table, values));
+    } catch (error, stack) {
+      return Err(StorageError('txn insert failed: $error'), stack);
+    }
+  }
+
+  @override
+  Future<Result<int>> update(
+    String table,
+    Map<String, dynamic> values, {
+    String? where,
+    List<Object?>? whereArgs,
+  }) async {
+    try {
+      return Ok(
+        await _txn.update(table, values, where: where, whereArgs: whereArgs),
+      );
+    } catch (error, stack) {
+      return Err(StorageError('txn update failed: $error'), stack);
+    }
+  }
+
+  @override
+  Future<Result<int>> delete(
+    String table, {
+    String? where,
+    List<Object?>? whereArgs,
+  }) async {
+    try {
+      return Ok(
+        await _txn.delete(table, where: where, whereArgs: whereArgs),
+      );
+    } catch (error, stack) {
+      return Err(StorageError('txn delete failed: $error'), stack);
+    }
+  }
+
+  @override
+  Future<Result<List<Map<String, dynamic>>>> query(
+    String table, {
+    List<String>? columns,
+    String? where,
+    List<Object?>? whereArgs,
+    String? orderBy,
+    int? limit,
+    int? offset,
+  }) async {
+    try {
+      final rows = await _txn.query(
+        table,
+        columns: columns,
+        where: where,
+        whereArgs: whereArgs,
+        orderBy: orderBy,
+        limit: limit,
+        offset: offset,
+      );
+      return Ok(rows);
+    } catch (error, stack) {
+      return Err(StorageError('txn query failed: $error'), stack);
+    }
+  }
+
+  @override
+  Future<Result<T>> transaction<T>(
+    Future<T> Function(EncryptedDatabase txn) action,
+  ) async {
+    return Ok(await action(this));
+  }
+
+  @override
+  Future<Result<void>> close() async => const Ok(null);
+}

--- a/packages/core_data/lib/src/storage/encrypted_life_track_data_source.dart
+++ b/packages/core_data/lib/src/storage/encrypted_life_track_data_source.dart
@@ -1,0 +1,103 @@
+import 'package:core_domain/core_domain.dart';
+import 'package:sqflite/sqflite.dart';
+
+import '../secure/secure_storage.dart';
+import '../secure/sqflite_encrypted_database.dart';
+import 'life_track_graph_sql_store.dart';
+import 'life_track_sql_schema.dart';
+
+/// Encrypted LifeTrack destination backed by [SqfliteEncryptedDatabase].
+class EncryptedLifeTrackDataSource {
+  EncryptedLifeTrackDataSource({
+    required SqfliteEncryptedDatabase database,
+    this.databaseName = 'life_track_secure.db',
+  }) : _database = database;
+
+  final SqfliteEncryptedDatabase _database;
+  final String databaseName;
+
+  LifeTrackGraphSqlStore? _store;
+
+  bool get isInitialized => _store != null && _database.isOpen;
+
+  LifeTrackGraphSqlStore get store {
+    if (_store == null) {
+      throw StateError('Encrypted LifeTrack data source is not initialized');
+    }
+    return _store!;
+  }
+
+  Database get database => _database.database;
+
+  Future<Result<void>> initialize() async {
+    final initResult = await _database.initialize(
+      EncryptedDatabaseConfig(
+        databaseName: databaseName,
+        schemaVersion: LifeTrackSqlSchema.schemaVersion,
+      ),
+    );
+    if (initResult is Err<void>) {
+      return initResult;
+    }
+
+    _store = LifeTrackGraphSqlStore(_database.database);
+    await _store!.ensureSchema(includeIdempotency: true);
+    await _writeMeta(
+      LifeTrackSqlSchema.metaKeyEncryptionEnabled,
+      _database.encryptionReady ? 'true' : 'false',
+    );
+    await _writeMeta(
+      LifeTrackSqlSchema.metaKeySchemaVersion,
+      LifeTrackSqlSchema.schemaVersion.toString(),
+    );
+    return const Ok(null);
+  }
+
+  Future<Result<void>> writeMeta(String key, String value) async {
+    try {
+      await _writeMeta(key, value);
+      return const Ok(null);
+    } catch (error, stack) {
+      return Err(StorageError('meta write failed: $error'), stack);
+    }
+  }
+
+  Future<Result<String?>> readMeta(String key) async {
+    try {
+      return Ok(await _readMeta(key));
+    } catch (error, stack) {
+      return Err(StorageError('meta read failed: $error'), stack);
+    }
+  }
+
+  Future<bool> isMigrationComplete() async {
+    if (!isInitialized) return false;
+    final value = await _readMeta(LifeTrackSqlSchema.metaKeyMigrationComplete);
+    return value == 'true';
+  }
+
+  Future<void> close() async {
+    await _store?.closeChanges();
+    _store = null;
+    await _database.close();
+  }
+
+  Future<void> _writeMeta(String key, String value) async {
+    await _database.database.insert(
+      LifeTrackSqlSchema.metaTable,
+      {'key': key, 'value': value},
+      conflictAlgorithm: ConflictAlgorithm.replace,
+    );
+  }
+
+  Future<String?> _readMeta(String key) async {
+    final rows = await _database.database.query(
+      LifeTrackSqlSchema.metaTable,
+      where: 'key = ?',
+      whereArgs: [key],
+      limit: 1,
+    );
+    if (rows.isEmpty) return null;
+    return rows.single['value'] as String?;
+  }
+}

--- a/packages/core_data/lib/src/storage/life_track_graph_sql_store.dart
+++ b/packages/core_data/lib/src/storage/life_track_graph_sql_store.dart
@@ -1,96 +1,61 @@
 import 'dart:async';
 
 import 'package:core_domain/core_domain.dart';
-import 'package:path/path.dart' as path;
 import 'package:sqflite/sqflite.dart';
 
-class LifeTrackLocalDataSource {
-  LifeTrackLocalDataSource({
-    DatabaseFactory? databaseFactory,
-    this._databasePath,
-    this._databaseName = 'life_track.db',
-  }) : _databaseFactory = databaseFactory ?? databaseFactorySqflitePlugin;
+import 'life_track_sql_schema.dart';
 
-  static const schemaVersion = 1;
+/// Shared LifeTrack graph persistence over sqflite [DatabaseExecutor].
+class LifeTrackGraphSqlStore {
+  LifeTrackGraphSqlStore(this._executor);
 
-  static const lifeTracksTable = 'life_tracks';
-  static const milestonesTable = 'milestones';
-  static const actionItemsTable = 'action_items';
-  static const inputRequirementsTable = 'input_requirements';
-
-  final DatabaseFactory _databaseFactory;
-  final String? _databasePath;
-  final String _databaseName;
+  final DatabaseExecutor _executor;
   final StreamController<void> _changes = StreamController<void>.broadcast();
 
-  Database? _database;
+  Stream<void> get changes => _changes.stream;
 
-  Future<void> initialize() async {
-    if (_database != null && _database!.isOpen) return;
-
-    final resolvedPath =
-        _databasePath ?? path.join(await getDatabasesPath(), _databaseName);
-    _database = await _databaseFactory.openDatabase(
-      resolvedPath,
-      options: OpenDatabaseOptions(
-        version: schemaVersion,
-        onConfigure: (db) async {
-          await db.execute('PRAGMA foreign_keys = ON');
-        },
-        onCreate: (db, version) async {
-          await _createSchema(db);
-        },
-        onUpgrade: (db, oldVersion, newVersion) async {
-          if (oldVersion < 1) {
-            await _createSchema(db);
-          }
-        },
-      ),
-    );
+  Future<void> ensureSchema({bool includeIdempotency = true}) async {
+    for (final statement in LifeTrackSqlSchema.createStatements(
+      includeIdempotency: includeIdempotency,
+    )) {
+      await _executor.execute(statement);
+    }
   }
 
-  Future<LifeTrack> createTrack(LifeTrack track) async {
-    final db = await _requireDatabase();
-    await db.transaction((txn) async {
+  Future<void> createTrack(LifeTrack track) async {
+    await _runInTransaction((txn) async {
       await _insertTrackGraph(txn, track);
     });
-    await _notifyChanged();
-    return track;
+    _notifyChanged();
   }
 
   Future<LifeTrack?> getTrack(String id) async {
-    final db = await _requireDatabase();
-    final rows = await db.query(
-      lifeTracksTable,
+    final rows = await _executor.query(
+      LifeTrackSqlSchema.lifeTracksTable,
       where: 'id = ?',
       whereArgs: [id],
       limit: 1,
     );
     if (rows.isEmpty) return null;
-    return _hydrateTrack(db, rows.single);
+    return _hydrateTrack(_executor, rows.single);
   }
 
   Future<List<LifeTrack>> listTracks({TrackStatus? status}) async {
-    final db = await _requireDatabase();
-    final rows = await db.query(
-      lifeTracksTable,
+    final rows = await _executor.query(
+      LifeTrackSqlSchema.lifeTracksTable,
       where: status == null ? null : 'status = ?',
       whereArgs: status == null ? null : [status.name],
       orderBy: 'updated_at DESC',
     );
-    return Future.wait(rows.map((row) => _hydrateTrack(db, row)));
-  }
-
-  Stream<List<LifeTrack>> watchTracks({TrackStatus? status}) async* {
-    yield await listTracks(status: status);
-    yield* _changes.stream.asyncMap((_) => listTracks(status: status));
+    return [
+      for (final row in rows) await _hydrateTrack(_executor, row),
+    ];
   }
 
   Future<void> updateTrack(LifeTrack track) async {
-    final db = await _requireDatabase();
-    await db.transaction((txn) async {
+    await _runInTransaction((txn) async {
       await txn.update(
-        lifeTracksTable,
+        LifeTrackSqlSchema.lifeTracksTable,
         {
           'title': track.title,
           'category': track.category.name,
@@ -104,19 +69,21 @@ class LifeTrackLocalDataSource {
       );
       await _replaceMilestones(txn, track.id, track.milestones);
     });
-    await _notifyChanged();
+    _notifyChanged();
   }
 
   Future<void> deleteTrack(String id) async {
-    final db = await _requireDatabase();
-    await db.delete(lifeTracksTable, where: 'id = ?', whereArgs: [id]);
-    await _notifyChanged();
+    await _executor.delete(
+      LifeTrackSqlSchema.lifeTracksTable,
+      where: 'id = ?',
+      whereArgs: [id],
+    );
+    _notifyChanged();
   }
 
   Future<void> updateMilestone(Milestone milestone) async {
-    final db = await _requireDatabase();
-    await db.update(
-      milestonesTable,
+    await _executor.update(
+      LifeTrackSqlSchema.milestonesTable,
       {
         'track_id': milestone.trackId,
         'name': milestone.name,
@@ -127,14 +94,13 @@ class LifeTrackLocalDataSource {
       where: 'id = ?',
       whereArgs: [milestone.id],
     );
-    await _replaceActionItems(db, milestone.id, milestone.actionItems);
-    await _notifyChanged();
+    await _replaceActionItems(_executor, milestone.id, milestone.actionItems);
+    _notifyChanged();
   }
 
   Future<void> updateActionItem(ActionItem item) async {
-    final db = await _requireDatabase();
-    await db.update(
-      actionItemsTable,
+    await _executor.update(
+      LifeTrackSqlSchema.actionItemsTable,
       {
         'milestone_id': item.milestoneId,
         'summary': item.summary,
@@ -148,14 +114,13 @@ class LifeTrackLocalDataSource {
       where: 'id = ?',
       whereArgs: [item.id],
     );
-    await _replaceRequirements(db, item.id, item.requirements);
-    await _notifyChanged();
+    await _replaceRequirements(_executor, item.id, item.requirements);
+    _notifyChanged();
   }
 
   Future<void> updateItemStatus(String itemId, ItemStatus status) async {
-    final db = await _requireDatabase();
-    await db.update(
-      actionItemsTable,
+    await _executor.update(
+      LifeTrackSqlSchema.actionItemsTable,
       {
         'status': status.name,
         'updated_at': DateTime.now().millisecondsSinceEpoch,
@@ -163,126 +128,49 @@ class LifeTrackLocalDataSource {
       where: 'id = ?',
       whereArgs: [itemId],
     );
-    await _notifyChanged();
+    _notifyChanged();
   }
 
   Future<void> saveInputValue(String requirementId, String value) async {
-    final db = await _requireDatabase();
-    await db.update(
-      inputRequirementsTable,
+    await _executor.update(
+      LifeTrackSqlSchema.inputRequirementsTable,
       {'value': value},
       where: 'id = ?',
       whereArgs: [requirementId],
     );
-    await _notifyChanged();
+    _notifyChanged();
   }
 
-  Future<LifeTrack> hydrateTemplate(LifeTrack track) async {
-    final db = await _requireDatabase();
-    await db.transaction((txn) async {
+  Future<void> hydrateTemplate(LifeTrack track) async {
+    await _runInTransaction((txn) async {
       await _insertTrackGraph(txn, track);
     });
-    await _notifyChanged();
-    return track;
+    _notifyChanged();
   }
 
-  Future<void> close() async {
-    await _database?.close();
-    _database = null;
+  Future<void> _runInTransaction(
+    Future<void> Function(DatabaseExecutor txn) action,
+  ) async {
+    final executor = _executor;
+    if (executor is Database) {
+      await executor.transaction(action);
+    } else {
+      await action(_executor);
+    }
   }
 
-  /// Row counts for migration verification.
-  Future<Map<String, int>> rowCounts() async {
-    final db = await _requireDatabase();
-    return {
-      'tracks': Sqflite.firstIntValue(
-        await db.rawQuery(
-          'SELECT COUNT(*) AS count FROM $lifeTracksTable',
-        ),
-      )!,
-      'milestones': Sqflite.firstIntValue(
-        await db.rawQuery(
-          'SELECT COUNT(*) AS count FROM $milestonesTable',
-        ),
-      )!,
-      'action_items': Sqflite.firstIntValue(
-        await db.rawQuery(
-          'SELECT COUNT(*) AS count FROM $actionItemsTable',
-        ),
-      )!,
-      'requirements': Sqflite.firstIntValue(
-        await db.rawQuery(
-          'SELECT COUNT(*) AS count FROM $inputRequirementsTable',
-        ),
-      )!,
-    };
+  Future<int> countRows(String table) async {
+    final result = await _executor.rawQuery('SELECT COUNT(*) AS count FROM $table');
+    return Sqflite.firstIntValue(result) ?? 0;
   }
 
-  Future<Database> _requireDatabase() async {
-    await initialize();
-    return _database!;
-  }
-
-  Future<void> _createSchema(DatabaseExecutor db) async {
-    await db.execute('''
-      CREATE TABLE $lifeTracksTable (
-        id TEXT PRIMARY KEY,
-        title TEXT NOT NULL,
-        category TEXT NOT NULL,
-        status TEXT NOT NULL DEFAULT 'draft',
-        template_id TEXT,
-        created_at INTEGER NOT NULL,
-        updated_at INTEGER NOT NULL
-      )
-    ''');
-    await db.execute('''
-      CREATE TABLE $milestonesTable (
-        id TEXT PRIMARY KEY,
-        track_id TEXT NOT NULL REFERENCES $lifeTracksTable(id) ON DELETE CASCADE,
-        name TEXT NOT NULL,
-        objective TEXT NOT NULL DEFAULT '',
-        sort_order INTEGER NOT NULL DEFAULT 0,
-        status TEXT NOT NULL DEFAULT 'todo'
-      )
-    ''');
-    await db.execute('''
-      CREATE TABLE $actionItemsTable (
-        id TEXT PRIMARY KEY,
-        milestone_id TEXT NOT NULL REFERENCES $milestonesTable(id) ON DELETE CASCADE,
-        summary TEXT NOT NULL,
-        description TEXT,
-        status TEXT NOT NULL DEFAULT 'todo',
-        due_date INTEGER,
-        notes TEXT,
-        created_at INTEGER NOT NULL,
-        updated_at INTEGER NOT NULL
-      )
-    ''');
-    await db.execute('''
-      CREATE TABLE $inputRequirementsTable (
-        id TEXT PRIMARY KEY,
-        action_item_id TEXT NOT NULL REFERENCES $actionItemsTable(id) ON DELETE CASCADE,
-        label TEXT NOT NULL,
-        field_type TEXT NOT NULL,
-        value TEXT,
-        is_required INTEGER NOT NULL DEFAULT 0,
-        hint TEXT
-      )
-    ''');
-    await db.execute(
-      'CREATE INDEX idx_milestones_track_id ON $milestonesTable(track_id)',
-    );
-    await db.execute(
-      'CREATE INDEX idx_action_items_milestone_id ON $actionItemsTable(milestone_id)',
-    );
-    await db.execute(
-      'CREATE INDEX idx_input_requirements_action_item_id ON $inputRequirementsTable(action_item_id)',
-    );
+  Future<void> closeChanges() async {
+    await _changes.close();
   }
 
   Future<void> _insertTrackGraph(DatabaseExecutor db, LifeTrack track) async {
     final batch = db.batch();
-    batch.insert(lifeTracksTable, {
+    batch.insert(LifeTrackSqlSchema.lifeTracksTable, {
       'id': track.id,
       'title': track.title,
       'category': track.category.name,
@@ -301,7 +189,7 @@ class LifeTrackLocalDataSource {
     List<Milestone> milestones,
   ) async {
     await db.delete(
-      milestonesTable,
+      LifeTrackSqlSchema.milestonesTable,
       where: 'track_id = ?',
       whereArgs: [trackId],
     );
@@ -316,7 +204,7 @@ class LifeTrackLocalDataSource {
     List<ActionItem> items,
   ) async {
     await db.delete(
-      actionItemsTable,
+      LifeTrackSqlSchema.actionItemsTable,
       where: 'milestone_id = ?',
       whereArgs: [milestoneId],
     );
@@ -331,7 +219,7 @@ class LifeTrackLocalDataSource {
     List<InputRequirement> requirements,
   ) async {
     await db.delete(
-      inputRequirementsTable,
+      LifeTrackSqlSchema.inputRequirementsTable,
       where: 'action_item_id = ?',
       whereArgs: [actionItemId],
     );
@@ -342,7 +230,7 @@ class LifeTrackLocalDataSource {
 
   void _queueMilestones(Batch batch, List<Milestone> milestones) {
     for (final milestone in milestones) {
-      batch.insert(milestonesTable, {
+      batch.insert(LifeTrackSqlSchema.milestonesTable, {
         'id': milestone.id,
         'track_id': milestone.trackId,
         'name': milestone.name,
@@ -356,7 +244,7 @@ class LifeTrackLocalDataSource {
 
   void _queueActionItems(Batch batch, List<ActionItem> items) {
     for (final item in items) {
-      batch.insert(actionItemsTable, {
+      batch.insert(LifeTrackSqlSchema.actionItemsTable, {
         'id': item.id,
         'milestone_id': item.milestoneId,
         'summary': item.summary,
@@ -373,7 +261,7 @@ class LifeTrackLocalDataSource {
 
   void _queueRequirements(Batch batch, List<InputRequirement> requirements) {
     for (final requirement in requirements) {
-      batch.insert(inputRequirementsTable, {
+      batch.insert(LifeTrackSqlSchema.inputRequirementsTable, {
         'id': requirement.id,
         'action_item_id': requirement.actionItemId,
         'label': requirement.label,
@@ -390,7 +278,7 @@ class LifeTrackLocalDataSource {
     Map<String, Object?> row,
   ) async {
     final milestonesRows = await db.query(
-      milestonesTable,
+      LifeTrackSqlSchema.milestonesTable,
       where: 'track_id = ?',
       whereArgs: [row['id']],
       orderBy: 'sort_order ASC',
@@ -399,7 +287,7 @@ class LifeTrackLocalDataSource {
     final milestones = <Milestone>[];
     for (final milestoneRow in milestonesRows) {
       final actionItemRows = await db.query(
-        actionItemsTable,
+        LifeTrackSqlSchema.actionItemsTable,
         where: 'milestone_id = ?',
         whereArgs: [milestoneRow['id']],
         orderBy: 'created_at ASC',
@@ -407,7 +295,7 @@ class LifeTrackLocalDataSource {
       final actionItems = <ActionItem>[];
       for (final actionItemRow in actionItemRows) {
         final requirementRows = await db.query(
-          inputRequirementsTable,
+          LifeTrackSqlSchema.inputRequirementsTable,
           where: 'action_item_id = ?',
           whereArgs: [actionItemRow['id']],
           orderBy: 'label ASC',
@@ -495,7 +383,7 @@ class LifeTrackLocalDataSource {
         hint: row['hint'] as String?,
       );
 
-  Future<void> _notifyChanged() async {
+  void _notifyChanged() {
     if (!_changes.isClosed) {
       _changes.add(null);
     }

--- a/packages/core_data/lib/src/storage/life_track_idempotency_store.dart
+++ b/packages/core_data/lib/src/storage/life_track_idempotency_store.dart
@@ -1,0 +1,141 @@
+import 'package:core_domain/core_domain.dart';
+import 'package:sqflite/sqflite.dart';
+
+import 'encrypted_life_track_data_source.dart';
+import 'life_track_sql_schema.dart';
+
+/// Persists idempotent effect records in the encrypted LifeTrack database.
+class LifeTrackIdempotencyStore implements IdempotentEffectPort {
+  LifeTrackIdempotencyStore(this._dataSource);
+
+  final EncryptedLifeTrackDataSource _dataSource;
+
+  Database get _db => _dataSource.database;
+
+  @override
+  Future<Result<IdempotentEffectRecord?>> findByKey(String idempotencyKey) async {
+    try {
+      final rows = await _db.query(
+        LifeTrackSqlSchema.idempotentEffectsTable,
+        where: 'idempotency_key = ?',
+        whereArgs: [idempotencyKey],
+        limit: 1,
+      );
+      if (rows.isEmpty) return const Ok(null);
+      return Ok(_map(rows.single));
+    } catch (error, stack) {
+      return Err(StorageError('idempotency lookup failed: $error'), stack);
+    }
+  }
+
+  @override
+  Future<Result<IdempotentEffectRecord>> beginEffect({
+    required String idempotencyKey,
+    required String confirmationHash,
+    required String resourceId,
+  }) async {
+    try {
+      final existing = await findByKey(idempotencyKey);
+      if (existing is Ok<IdempotentEffectRecord?> && existing.value != null) {
+        return Ok(existing.value!);
+      }
+
+      final now = DateTime.now().toUtc();
+      final record = IdempotentEffectRecord(
+        idempotencyKey: idempotencyKey,
+        confirmationHash: confirmationHash,
+        state: IdempotentEffectState.pending,
+        resourceId: resourceId,
+        createdAt: now,
+        updatedAt: now,
+      );
+
+      await _db.insert(
+        LifeTrackSqlSchema.idempotentEffectsTable,
+        _toRow(record),
+        conflictAlgorithm: ConflictAlgorithm.abort,
+      );
+      return Ok(record);
+    } catch (error, stack) {
+      return Err(StorageError('idempotency begin failed: $error'), stack);
+    }
+  }
+
+  @override
+  Future<Result<void>> commitEffect({
+    required String idempotencyKey,
+    required String destinationReceipt,
+  }) async {
+    try {
+      final updated = await _db.update(
+        LifeTrackSqlSchema.idempotentEffectsTable,
+        {
+          'effect_state': IdempotentEffectState.committed.name,
+          'destination_receipt': destinationReceipt,
+          'updated_at': DateTime.now().toUtc().millisecondsSinceEpoch,
+        },
+        where: 'idempotency_key = ?',
+        whereArgs: [idempotencyKey],
+      );
+      if (updated == 0) {
+        return Err(
+          NotFoundError('Idempotent effect not found: $idempotencyKey'),
+          StackTrace.current,
+        );
+      }
+      return const Ok(null);
+    } catch (error, stack) {
+      return Err(StorageError('idempotency commit failed: $error'), stack);
+    }
+  }
+
+  @override
+  Future<Result<void>> markFailed(String idempotencyKey) async {
+    try {
+      final updated = await _db.update(
+        LifeTrackSqlSchema.idempotentEffectsTable,
+        {
+          'effect_state': IdempotentEffectState.failed.name,
+          'updated_at': DateTime.now().toUtc().millisecondsSinceEpoch,
+        },
+        where: 'idempotency_key = ?',
+        whereArgs: [idempotencyKey],
+      );
+      if (updated == 0) {
+        return Err(
+          NotFoundError('Idempotent effect not found: $idempotencyKey'),
+          StackTrace.current,
+        );
+      }
+      return const Ok(null);
+    } catch (error, stack) {
+      return Err(StorageError('idempotency mark failed failed: $error'), stack);
+    }
+  }
+
+  IdempotentEffectRecord _map(Map<String, Object?> row) => IdempotentEffectRecord(
+    idempotencyKey: row['idempotency_key']! as String,
+    confirmationHash: row['confirmation_hash']! as String,
+    state: IdempotentEffectState.fromJson(row['effect_state']! as String),
+    resourceId: row['resource_id']! as String,
+    destinationReceipt: row['destination_receipt'] as String?,
+    createdAt: DateTime.fromMillisecondsSinceEpoch(
+      row['created_at']! as int,
+      isUtc: true,
+    ),
+    updatedAt: DateTime.fromMillisecondsSinceEpoch(
+      row['updated_at']! as int,
+      isUtc: true,
+    ),
+  );
+
+  Map<String, Object?> _toRow(IdempotentEffectRecord record) => {
+    'idempotency_key': record.idempotencyKey,
+    'confirmation_hash': record.confirmationHash,
+    'effect_state': record.state.name,
+    'destination_receipt': record.destinationReceipt,
+    'resource_id': record.resourceId,
+    'created_at': record.createdAt.millisecondsSinceEpoch,
+    'updated_at': record.updatedAt.millisecondsSinceEpoch,
+  };
+}

--- a/packages/core_data/lib/src/storage/life_track_plaintext_migration.dart
+++ b/packages/core_data/lib/src/storage/life_track_plaintext_migration.dart
@@ -1,0 +1,139 @@
+import 'dart:convert';
+
+import 'package:core_domain/core_domain.dart';
+
+import 'encrypted_life_track_data_source.dart';
+import 'life_track_graph_sql_store.dart';
+import 'life_track_local_data_source.dart';
+import 'life_track_sql_schema.dart';
+
+class LifeTrackMigrationReport {
+  const LifeTrackMigrationReport({
+    required this.trackCount,
+    required this.milestoneCount,
+    required this.actionItemCount,
+    required this.requirementCount,
+    required this.verified,
+    required this.plaintextBackupPath,
+  });
+
+  final int trackCount;
+  final int milestoneCount;
+  final int actionItemCount;
+  final int requirementCount;
+  final bool verified;
+  final String plaintextBackupPath;
+}
+
+/// Copies plaintext LifeTrack rows into the encrypted destination in one
+/// verifiable transaction. Plaintext data is retained for rollback.
+class LifeTrackPlaintextMigration {
+  LifeTrackPlaintextMigration({
+    required LifeTrackLocalDataSource plaintext,
+    required EncryptedLifeTrackDataSource encrypted,
+  }) : _plaintext = plaintext,
+       _encrypted = encrypted;
+
+  final LifeTrackLocalDataSource _plaintext;
+  final EncryptedLifeTrackDataSource _encrypted;
+
+  Future<Result<LifeTrackMigrationReport>> migrateIfNeeded({
+    required String plaintextBackupPath,
+  }) async {
+    if (await _encrypted.isMigrationComplete()) {
+      return Ok(
+        LifeTrackMigrationReport(
+          trackCount: 0,
+          milestoneCount: 0,
+          actionItemCount: 0,
+          requirementCount: 0,
+          verified: true,
+          plaintextBackupPath: plaintextBackupPath,
+        ),
+      );
+    }
+
+    try {
+      await _plaintext.initialize();
+      final initResult = await _encrypted.initialize();
+      if (initResult case Err<void>(error: final error, stack: final stack)) {
+        return Err(error, stack);
+      }
+
+      final tracks = await _plaintext.listTracks();
+      final plaintextCounts = await _plaintext.rowCounts();
+
+      await _encrypted.database.transaction((txn) async {
+        final store = LifeTrackGraphSqlStore(txn);
+        for (final track in tracks) {
+          await store.createTrack(track);
+        }
+      });
+
+      final encryptedStore = _encrypted.store;
+      final encryptedCounts = {
+        'tracks': await encryptedStore.countRows(
+          LifeTrackSqlSchema.lifeTracksTable,
+        ),
+        'milestones': await encryptedStore.countRows(
+          LifeTrackSqlSchema.milestonesTable,
+        ),
+        'action_items': await encryptedStore.countRows(
+          LifeTrackSqlSchema.actionItemsTable,
+        ),
+        'requirements': await encryptedStore.countRows(
+          LifeTrackSqlSchema.inputRequirementsTable,
+        ),
+      };
+
+      final countsMatch =
+          plaintextCounts['tracks'] == encryptedCounts['tracks'] &&
+          plaintextCounts['milestones'] == encryptedCounts['milestones'] &&
+          plaintextCounts['action_items'] == encryptedCounts['action_items'] &&
+          plaintextCounts['requirements'] == encryptedCounts['requirements'];
+
+      final verified = countsMatch && await _verifyTracks(tracks);
+
+      if (!verified) {
+        return Err(
+          StorageError('LifeTrack migration verification failed'),
+          StackTrace.current,
+        );
+      }
+
+      await _encrypted.writeMeta(
+        LifeTrackSqlSchema.metaKeyPlaintextBackupPath,
+        plaintextBackupPath,
+      );
+      await _encrypted.writeMeta(
+        LifeTrackSqlSchema.metaKeyMigrationComplete,
+        'true',
+      );
+
+      return Ok(
+        LifeTrackMigrationReport(
+          trackCount: encryptedCounts['tracks']!,
+          milestoneCount: encryptedCounts['milestones']!,
+          actionItemCount: encryptedCounts['action_items']!,
+          requirementCount: encryptedCounts['requirements']!,
+          verified: verified,
+          plaintextBackupPath: plaintextBackupPath,
+        ),
+      );
+    } catch (error, stack) {
+      return Err(StorageError('LifeTrack migration failed: $error'), stack);
+    }
+  }
+
+  Future<bool> _verifyTracks(List<LifeTrack> sourceTracks) async {
+    for (final source in sourceTracks) {
+      final migrated = await _encrypted.store.getTrack(source.id);
+      if (migrated == null) return false;
+      if (_fingerprint(source) != _fingerprint(migrated)) return false;
+      if (migrated != source) return false;
+    }
+    return true;
+  }
+
+  String _fingerprint(LifeTrack track) => jsonEncode(track.toJson());
+}

--- a/packages/core_data/lib/src/storage/life_track_sql_schema.dart
+++ b/packages/core_data/lib/src/storage/life_track_sql_schema.dart
@@ -1,0 +1,90 @@
+/// Shared LifeTrack SQL schema used by plaintext and encrypted destinations.
+class LifeTrackSqlSchema {
+  static const schemaVersion = 2;
+  static const metaTable = 'lifetrack_meta';
+  static const lifeTracksTable = 'life_tracks';
+  static const milestonesTable = 'milestones';
+  static const actionItemsTable = 'action_items';
+  static const inputRequirementsTable = 'input_requirements';
+  static const idempotentEffectsTable = 'lifetrack_idempotent_effects';
+
+  static const metaKeyMigrationComplete = 'migration_complete';
+  static const metaKeyPlaintextBackupPath = 'plaintext_backup_path';
+  static const metaKeySchemaVersion = 'schema_version';
+  static const metaKeyEncryptionEnabled = 'encryption_enabled';
+
+  static List<String> createStatements({bool includeIdempotency = true}) {
+    final statements = <String>[
+      '''
+      CREATE TABLE IF NOT EXISTS $metaTable (
+        key TEXT PRIMARY KEY,
+        value TEXT NOT NULL
+      )
+      ''',
+      '''
+      CREATE TABLE IF NOT EXISTS $lifeTracksTable (
+        id TEXT PRIMARY KEY,
+        title TEXT NOT NULL,
+        category TEXT NOT NULL,
+        status TEXT NOT NULL DEFAULT 'draft',
+        template_id TEXT,
+        created_at INTEGER NOT NULL,
+        updated_at INTEGER NOT NULL
+      )
+      ''',
+      '''
+      CREATE TABLE IF NOT EXISTS $milestonesTable (
+        id TEXT PRIMARY KEY,
+        track_id TEXT NOT NULL REFERENCES $lifeTracksTable(id) ON DELETE CASCADE,
+        name TEXT NOT NULL,
+        objective TEXT NOT NULL DEFAULT '',
+        sort_order INTEGER NOT NULL DEFAULT 0,
+        status TEXT NOT NULL DEFAULT 'todo'
+      )
+      ''',
+      '''
+      CREATE TABLE IF NOT EXISTS $actionItemsTable (
+        id TEXT PRIMARY KEY,
+        milestone_id TEXT NOT NULL REFERENCES $milestonesTable(id) ON DELETE CASCADE,
+        summary TEXT NOT NULL,
+        description TEXT,
+        status TEXT NOT NULL DEFAULT 'todo',
+        due_date INTEGER,
+        notes TEXT,
+        created_at INTEGER NOT NULL,
+        updated_at INTEGER NOT NULL
+      )
+      ''',
+      '''
+      CREATE TABLE IF NOT EXISTS $inputRequirementsTable (
+        id TEXT PRIMARY KEY,
+        action_item_id TEXT NOT NULL REFERENCES $actionItemsTable(id) ON DELETE CASCADE,
+        label TEXT NOT NULL,
+        field_type TEXT NOT NULL,
+        value TEXT,
+        is_required INTEGER NOT NULL DEFAULT 0,
+        hint TEXT
+      )
+      ''',
+      'CREATE INDEX IF NOT EXISTS idx_milestones_track_id ON $milestonesTable(track_id)',
+      'CREATE INDEX IF NOT EXISTS idx_action_items_milestone_id ON $actionItemsTable(milestone_id)',
+      'CREATE INDEX IF NOT EXISTS idx_input_requirements_action_item_id ON $inputRequirementsTable(action_item_id)',
+    ];
+
+    if (includeIdempotency) {
+      statements.add('''
+        CREATE TABLE IF NOT EXISTS $idempotentEffectsTable (
+          idempotency_key TEXT PRIMARY KEY,
+          confirmation_hash TEXT NOT NULL,
+          effect_state TEXT NOT NULL,
+          destination_receipt TEXT,
+          resource_id TEXT NOT NULL,
+          created_at INTEGER NOT NULL,
+          updated_at INTEGER NOT NULL
+        )
+      ''');
+    }
+
+    return statements;
+  }
+}

--- a/packages/core_data/lib/src/storage/secure_life_track_destination.dart
+++ b/packages/core_data/lib/src/storage/secure_life_track_destination.dart
@@ -1,0 +1,251 @@
+import 'package:core_domain/core_domain.dart';
+
+import '../secure/secure_storage.dart';
+import 'encrypted_life_track_data_source.dart';
+import 'life_track_local_data_source.dart';
+import 'life_track_plaintext_migration.dart';
+
+enum SecureLifeTrackWriteMode {
+  encryptedWritable,
+  plaintextReadOnly,
+  unavailable,
+}
+
+/// Routes LifeTrack reads and writes across plaintext compatibility and the
+/// encrypted destination.
+class SecureLifeTrackDestination {
+  SecureLifeTrackDestination({
+    required LifeTrackLocalDataSource plaintext,
+    required EncryptedLifeTrackDataSource encrypted,
+    required EncryptionKeyManager keyManager,
+    LifeTrackPlaintextMigration? migration,
+  }) : _plaintext = plaintext,
+       _encrypted = encrypted,
+       _keyManager = keyManager,
+       _migration = migration ??
+           LifeTrackPlaintextMigration(
+             plaintext: plaintext,
+             encrypted: encrypted,
+           );
+
+  final LifeTrackLocalDataSource _plaintext;
+  final EncryptedLifeTrackDataSource _encrypted;
+  final EncryptionKeyManager _keyManager;
+  final LifeTrackPlaintextMigration _migration;
+
+  Future<SecureLifeTrackWriteMode> writeMode() async {
+    if (await _keyManager.isEncryptionAvailable()) {
+      if (!_encrypted.isInitialized) {
+        final init = await _encrypted.initialize();
+        if (init is Ok<void>) {
+          return SecureLifeTrackWriteMode.encryptedWritable;
+        }
+      } else {
+        return SecureLifeTrackWriteMode.encryptedWritable;
+      }
+    }
+
+    await _plaintext.initialize();
+    final tracks = await _plaintext.listTracks();
+    if (tracks.isNotEmpty) {
+      return SecureLifeTrackWriteMode.plaintextReadOnly;
+    }
+    return SecureLifeTrackWriteMode.unavailable;
+  }
+
+  Future<Result<LifeTrackMigrationReport>> migratePlaintext({
+    required String plaintextBackupPath,
+  }) => _migration.migrateIfNeeded(plaintextBackupPath: plaintextBackupPath);
+
+  Future<Result<LifeTrack>> createTrack(LifeTrack track) async {
+    final mode = await writeMode();
+    if (mode != SecureLifeTrackWriteMode.encryptedWritable) {
+      return Err(
+        SecureDestinationUnavailableError(
+          'LifeTrack writes require encrypted storage',
+        ),
+        StackTrace.current,
+      );
+    }
+    try {
+      await _encrypted.store.createTrack(track);
+      return Ok(track);
+    } catch (error, stack) {
+      return Err(error, stack);
+    }
+  }
+
+  Future<Result<LifeTrack>> getTrack(String id) async {
+    if (_encrypted.isInitialized || await _tryInitializeEncrypted()) {
+      final encryptedTrack = await _encrypted.store.getTrack(id);
+      if (encryptedTrack != null) {
+        return Ok(encryptedTrack);
+      }
+    }
+
+    await _plaintext.initialize();
+    final plaintextTrack = await _plaintext.getTrack(id);
+    if (plaintextTrack == null) {
+      return Err(
+        NotFoundError('LifeTrack not found: $id'),
+        StackTrace.current,
+      );
+    }
+    return Ok(plaintextTrack);
+  }
+
+  Future<Result<List<LifeTrack>>> listTracks({TrackStatus? status}) async {
+    if (_encrypted.isInitialized || await _tryInitializeEncrypted()) {
+      if (await _encrypted.isMigrationComplete()) {
+        return Ok(await _encrypted.store.listTracks(status: status));
+      }
+    }
+
+    await _plaintext.initialize();
+    return Ok(await _plaintext.listTracks(status: status));
+  }
+
+  Future<Result<void>> updateTrack(LifeTrack track) async {
+    final mode = await writeMode();
+    if (mode != SecureLifeTrackWriteMode.encryptedWritable) {
+      return Err(
+        SecureDestinationUnavailableError(
+          'LifeTrack writes require encrypted storage',
+        ),
+        StackTrace.current,
+      );
+    }
+    try {
+      await _encrypted.store.updateTrack(track);
+      return const Ok(null);
+    } catch (error, stack) {
+      return Err(error, stack);
+    }
+  }
+
+  Future<Result<void>> deleteTrack(String id) async {
+    final mode = await writeMode();
+    if (mode != SecureLifeTrackWriteMode.encryptedWritable) {
+      return Err(
+        SecureDestinationUnavailableError(
+          'LifeTrack writes require encrypted storage',
+        ),
+        StackTrace.current,
+      );
+    }
+    try {
+      await _encrypted.store.deleteTrack(id);
+      return const Ok(null);
+    } catch (error, stack) {
+      return Err(error, stack);
+    }
+  }
+
+  Future<Result<void>> saveInputValue(
+    String requirementId,
+    String value,
+  ) async {
+    final mode = await writeMode();
+    if (mode != SecureLifeTrackWriteMode.encryptedWritable) {
+      return Err(
+        SecureDestinationUnavailableError(
+          'LifeTrack writes require encrypted storage',
+        ),
+        StackTrace.current,
+      );
+    }
+    try {
+      await _encrypted.store.saveInputValue(requirementId, value);
+      return const Ok(null);
+    } catch (error, stack) {
+      return Err(error, stack);
+    }
+  }
+
+  Future<Result<void>> updateItemStatus(
+    String itemId,
+    ItemStatus status,
+  ) async {
+    final mode = await writeMode();
+    if (mode != SecureLifeTrackWriteMode.encryptedWritable) {
+      return _readOnlyWriteFailure();
+    }
+    try {
+      await _encrypted.store.updateItemStatus(itemId, status);
+      return const Ok(null);
+    } catch (error, stack) {
+      return Err(error, stack);
+    }
+  }
+
+  Future<Result<void>> updateActionItem(ActionItem item) async {
+    final mode = await writeMode();
+    if (mode != SecureLifeTrackWriteMode.encryptedWritable) {
+      return _readOnlyWriteFailure();
+    }
+    try {
+      await _encrypted.store.updateActionItem(item);
+      return const Ok(null);
+    } catch (error, stack) {
+      return Err(error, stack);
+    }
+  }
+
+  Future<Result<void>> updateMilestone(Milestone milestone) async {
+    final mode = await writeMode();
+    if (mode != SecureLifeTrackWriteMode.encryptedWritable) {
+      return _readOnlyWriteFailure();
+    }
+    try {
+      await _encrypted.store.updateMilestone(milestone);
+      return const Ok(null);
+    } catch (error, stack) {
+      return Err(error, stack);
+    }
+  }
+
+  Future<Result<LifeTrack>> hydrateTemplate(LifeTrack track) async {
+    final mode = await writeMode();
+    if (mode != SecureLifeTrackWriteMode.encryptedWritable) {
+      return Err(
+        SecureDestinationUnavailableError(
+          'LifeTrack writes require encrypted storage',
+        ),
+        StackTrace.current,
+      );
+    }
+    try {
+      await _encrypted.store.hydrateTemplate(track);
+      return Ok(track);
+    } catch (error, stack) {
+      return Err(error, stack);
+    }
+  }
+
+  Result<void> _readOnlyWriteFailure() => Err(
+    SecureDestinationUnavailableError(
+      'LifeTrack writes require encrypted storage',
+    ),
+    StackTrace.current,
+  );
+
+  Stream<List<LifeTrack>> watchTracks({TrackStatus? status}) async* {
+    if (_encrypted.isInitialized) {
+      yield await _encrypted.store.listTracks(status: status);
+      yield* _encrypted.store.changes.asyncMap(
+        (_) => _encrypted.store.listTracks(status: status),
+      );
+      return;
+    }
+
+    await _plaintext.initialize();
+    yield await _plaintext.listTracks(status: status);
+    yield* _plaintext.watchTracks(status: status);
+  }
+
+  Future<bool> _tryInitializeEncrypted() async {
+    if (!await _keyManager.isEncryptionAvailable()) return false;
+    final init = await _encrypted.initialize();
+    return init is Ok<void>;
+  }
+}

--- a/packages/core_data/test/storage/life_track_local_data_source_test.dart
+++ b/packages/core_data/test/storage/life_track_local_data_source_test.dart
@@ -25,7 +25,7 @@ void main() {
   });
 
   test('creates and hydrates a full LifeTrack graph', () async {
-    final track = _sampleTrack();
+    final track = sampleTrack();
 
     await dataSource.createTrack(track);
     final stored = await dataSource.getTrack(track.id);
@@ -36,9 +36,9 @@ void main() {
   });
 
   test('filters tracks by status', () async {
-    await dataSource.createTrack(_sampleTrack());
+    await dataSource.createTrack(sampleTrack());
     await dataSource.createTrack(
-      _sampleTrack(id: 'track-2').copyWith(status: TrackStatus.completed),
+      sampleTrack(id: 'track-2').copyWith(status: TrackStatus.completed),
     );
 
     final active = await dataSource.listTracks(status: TrackStatus.active);
@@ -54,14 +54,14 @@ void main() {
     final stream = dataSource.watchTracks();
     final nextNonEmpty = stream.firstWhere((tracks) => tracks.isNotEmpty);
 
-    await dataSource.createTrack(_sampleTrack());
+    await dataSource.createTrack(sampleTrack());
     final emitted = await nextNonEmpty;
 
     expect(emitted.single.id, 'track-1');
   });
 
   test('cascade delete removes nested rows', () async {
-    final track = _sampleTrack();
+    final track = sampleTrack();
     await dataSource.createTrack(track);
 
     await dataSource.deleteTrack(track.id);
@@ -109,7 +109,7 @@ void main() {
   });
 }
 
-LifeTrack _sampleTrack({String id = 'track-1'}) {
+LifeTrack sampleTrack({String id = 'track-1'}) {
   final suffix = id.replaceAll(RegExp(r'[^a-zA-Z0-9]'), '_');
   final requirement = InputRequirement(
     id: 'req_$suffix',

--- a/packages/core_data/test/storage/secure_life_track_destination_test.dart
+++ b/packages/core_data/test/storage/secure_life_track_destination_test.dart
@@ -1,0 +1,166 @@
+import 'package:core_data/core_data.dart';
+import 'package:core_domain/core_domain.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sqflite_common_ffi/sqflite_ffi.dart';
+
+import '../storage/life_track_local_data_source_test.dart' show sampleTrack;
+
+class _UnavailableEncryptionKeyManager implements EncryptionKeyManager {
+  @override
+  Future<Result<List<int>>> getDatabaseKey() async =>
+      Err(SecureDestinationUnavailableError('no key'), StackTrace.current);
+
+  @override
+  Future<Result<void>> rotateKey() async => const Ok(null);
+
+  @override
+  Future<bool> isEncryptionAvailable() async => false;
+
+  @override
+  Future<Result<void>> clearKeys() async => const Ok(null);
+}
+
+String uniqueMemoryPath(String label) =>
+    '${inMemoryDatabasePath}_${label}_${DateTime.now().microsecondsSinceEpoch}';
+
+void main() {
+  late DatabaseFactory databaseFactory;
+
+  setUpAll(() {
+    sqfliteFfiInit();
+    databaseFactory = databaseFactoryFfi;
+  });
+
+  test('migration copies plaintext rows with matching counts and fingerprints',
+      () async {
+    final plaintext = LifeTrackLocalDataSource(
+      databaseFactory: databaseFactory,
+      databasePath: uniqueMemoryPath('plaintext'),
+    );
+    final encryptedDb = SqfliteEncryptedDatabase(
+      keyManager: InMemoryEncryptionKeyManager(),
+      databaseFactory: databaseFactory,
+      databasePath: uniqueMemoryPath('secure'),
+    );
+    final encrypted = EncryptedLifeTrackDataSource(database: encryptedDb);
+    final migration = LifeTrackPlaintextMigration(
+      plaintext: plaintext,
+      encrypted: encrypted,
+    );
+
+    await plaintext.initialize();
+    final track = sampleTrack();
+    await plaintext.createTrack(track);
+
+    final result = await migration.migrateIfNeeded(
+      plaintextBackupPath: '/tmp/life_track.db',
+    );
+    expect(result, isA<Ok<LifeTrackMigrationReport>>());
+    final report = (result as Ok<LifeTrackMigrationReport>).value;
+    expect(report.verified, isTrue);
+    expect(report.trackCount, 1);
+    expect(report.milestoneCount, 2);
+    expect(report.actionItemCount, 4);
+    expect(report.requirementCount, 1);
+
+    final migrated = await encrypted.store.getTrack(track.id);
+    expect(migrated, track);
+
+    await plaintext.close();
+    await encrypted.close();
+  });
+
+  test('secure destination rejects writes when encryption is unavailable', () async {
+    final plaintext = LifeTrackLocalDataSource(
+      databaseFactory: databaseFactory,
+      databasePath: uniqueMemoryPath('plaintext_ro'),
+    );
+    final encryptedDb = SqfliteEncryptedDatabase(
+      keyManager: _UnavailableEncryptionKeyManager(),
+      databaseFactory: databaseFactory,
+      databasePath: uniqueMemoryPath('secure_ro'),
+    );
+    final encrypted = EncryptedLifeTrackDataSource(database: encryptedDb);
+    final destination = SecureLifeTrackDestination(
+      plaintext: plaintext,
+      encrypted: encrypted,
+      keyManager: _UnavailableEncryptionKeyManager(),
+    );
+
+    await plaintext.initialize();
+    await plaintext.createTrack(sampleTrack(id: 'legacy-track'));
+
+    final writeResult = await destination.createTrack(sampleTrack(id: 'new'));
+    expect(writeResult, isA<Err<LifeTrack>>());
+    expect(
+      (writeResult as Err<LifeTrack>).error,
+      isA<SecureDestinationUnavailableError>(),
+    );
+
+    final readResult = await destination.getTrack('legacy-track');
+    expect(readResult, isA<Ok<LifeTrack>>());
+
+    await plaintext.close();
+    await encrypted.close();
+  });
+
+  test('idempotency store records begin and commit in encrypted database', () async {
+    final encryptedDb = SqfliteEncryptedDatabase(
+      keyManager: InMemoryEncryptionKeyManager(),
+      databaseFactory: databaseFactory,
+      databasePath: uniqueMemoryPath('idem'),
+    );
+    final encrypted = EncryptedLifeTrackDataSource(database: encryptedDb);
+    await encrypted.initialize();
+
+    final store = LifeTrackIdempotencyStore(encrypted);
+    final idempotencyKey = 'idem-${DateTime.now().microsecondsSinceEpoch}';
+    final begin = await store.beginEffect(
+      idempotencyKey: idempotencyKey,
+      confirmationHash: 'hash-1',
+      resourceId: 'track-1',
+    );
+    expect(begin, isA<Ok<IdempotentEffectRecord>>());
+    expect(
+      (begin as Ok<IdempotentEffectRecord>).value.state,
+      IdempotentEffectState.pending,
+    );
+
+    final commit = await store.commitEffect(
+      idempotencyKey: idempotencyKey,
+      destinationReceipt: 'receipt-1',
+    );
+    expect(commit, isA<Ok<void>>());
+
+    final loaded = await store.findByKey(idempotencyKey);
+    expect(loaded, isA<Ok<IdempotentEffectRecord?>>());
+    final record = (loaded as Ok<IdempotentEffectRecord?>).value!;
+    expect(record.state, IdempotentEffectState.committed);
+    expect(record.destinationReceipt, 'receipt-1');
+
+    await encrypted.close();
+  });
+
+  test('key rotation allows re-initialization after rotateKey', () async {
+    final keyManager = InMemoryEncryptionKeyManager();
+    final encryptedDb = SqfliteEncryptedDatabase(
+      keyManager: keyManager,
+      databaseFactory: databaseFactory,
+      databasePath: uniqueMemoryPath('rotate'),
+    );
+    final encrypted = EncryptedLifeTrackDataSource(database: encryptedDb);
+    await encrypted.initialize();
+    await encrypted.store.createTrack(sampleTrack(id: 'rotate-track'));
+
+    final rotate = await keyManager.rotateKey();
+    expect(rotate, isA<Ok<void>>());
+
+    await encrypted.close();
+    final reinit = await encrypted.initialize();
+    expect(reinit, isA<Ok<void>>());
+    final rotated = await encrypted.store.getTrack('rotate-track');
+    expect(rotated, isNotNull);
+
+    await encrypted.close();
+  });
+}

--- a/packages/core_domain/lib/core_domain.dart
+++ b/packages/core_domain/lib/core_domain.dart
@@ -55,6 +55,12 @@ export 'src/workflow/offer_decision.dart';
 export 'src/workflow/workflow_projection.dart';
 export 'src/workflow/pending_assessment.dart';
 
+// Idempotent destination effects
+export 'src/effects/idempotent_effect.dart';
+
+// Errors
+export 'src/errors/secure_destination_error.dart';
+
 // Plugin System
 export 'src/plugins/plugin_manifest.dart';
 export 'src/plugins/manifest_validator.dart';

--- a/packages/core_domain/lib/src/effects/idempotent_effect.dart
+++ b/packages/core_domain/lib/src/effects/idempotent_effect.dart
@@ -1,0 +1,83 @@
+import 'package:meta/meta.dart';
+
+import '../result/result.dart';
+
+/// Lifecycle for a confirmed destination write tied to one idempotency key.
+enum IdempotentEffectState {
+  pending,
+  committed,
+  failed,
+  reconciling;
+
+  static IdempotentEffectState fromJson(String value) =>
+      IdempotentEffectState.values.firstWhere((item) => item.name == value);
+
+  String toJson() => name;
+}
+
+@immutable
+class IdempotentEffectRecord {
+  const IdempotentEffectRecord({
+    required this.idempotencyKey,
+    required this.confirmationHash,
+    required this.state,
+    required this.resourceId,
+    required this.createdAt,
+    required this.updatedAt,
+    this.destinationReceipt,
+  });
+
+  final String idempotencyKey;
+  final String confirmationHash;
+  final IdempotentEffectState state;
+  final String resourceId;
+  final String? destinationReceipt;
+  final DateTime createdAt;
+  final DateTime updatedAt;
+
+  factory IdempotentEffectRecord.fromJson(Map<String, dynamic> json) =>
+      IdempotentEffectRecord(
+        idempotencyKey: json['idempotency_key'] as String,
+        confirmationHash: json['confirmation_hash'] as String,
+        state: IdempotentEffectState.fromJson(json['state'] as String),
+        resourceId: json['resource_id'] as String,
+        destinationReceipt: json['destination_receipt'] as String?,
+        createdAt: DateTime.fromMillisecondsSinceEpoch(
+          json['created_at'] as int,
+          isUtc: true,
+        ),
+        updatedAt: DateTime.fromMillisecondsSinceEpoch(
+          json['updated_at'] as int,
+          isUtc: true,
+        ),
+      );
+
+  Map<String, dynamic> toJson() => {
+    'idempotency_key': idempotencyKey,
+    'confirmation_hash': confirmationHash,
+    'state': state.toJson(),
+    'resource_id': resourceId,
+    if (destinationReceipt != null)
+      'destination_receipt': destinationReceipt,
+    'created_at': createdAt.millisecondsSinceEpoch,
+    'updated_at': updatedAt.millisecondsSinceEpoch,
+  };
+}
+
+/// Destination port for atomically recording confirmed writes.
+abstract interface class IdempotentEffectPort {
+  Future<Result<IdempotentEffectRecord?>> findByKey(String idempotencyKey);
+
+  Future<Result<IdempotentEffectRecord>> beginEffect({
+    required String idempotencyKey,
+    required String confirmationHash,
+    required String resourceId,
+  });
+
+  Future<Result<void>> commitEffect({
+    required String idempotencyKey,
+    required String destinationReceipt,
+  });
+
+  Future<Result<void>> markFailed(String idempotencyKey);
+}

--- a/packages/core_domain/lib/src/errors/secure_destination_error.dart
+++ b/packages/core_domain/lib/src/errors/secure_destination_error.dart
@@ -1,0 +1,17 @@
+import 'app_error.dart';
+
+/// Encryption key or encrypted storage is unavailable; destination writes fail
+/// closed while reads may continue from a compatibility source.
+class SecureDestinationUnavailableError extends AppError {
+  SecureDestinationUnavailableError(
+    String message, {
+    Object? originalError,
+    StackTrace? originalStack,
+  }) : super(
+         'secure_destination_unavailable',
+         message,
+         statusCode: 503,
+         originalError: originalError,
+         originalStack: originalStack,
+       );
+}

--- a/packages/core_domain/test/effects/idempotent_effect_test.dart
+++ b/packages/core_domain/test/effects/idempotent_effect_test.dart
@@ -1,0 +1,24 @@
+import 'package:core_domain/core_domain.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('SecureDestinationUnavailableError uses stable code', () {
+    final error = SecureDestinationUnavailableError('blocked');
+    expect(error.code, 'secure_destination_unavailable');
+    expect(error.statusCode, 503);
+  });
+
+  test('IdempotentEffectRecord round-trips JSON', () {
+    final record = IdempotentEffectRecord(
+      idempotencyKey: 'idem-1',
+      confirmationHash: 'hash',
+      state: IdempotentEffectState.pending,
+      resourceId: 'track-1',
+      createdAt: DateTime.utc(2026, 8, 22),
+      updatedAt: DateTime.utc(2026, 8, 22),
+    );
+    final restored = IdempotentEffectRecord.fromJson(record.toJson());
+    expect(restored.idempotencyKey, 'idem-1');
+    expect(restored.state, IdempotentEffectState.pending);
+  });
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Continues the Airo Mind add-on framework on the same branch after Increment 2 merge.

### Increment 3 — Diet Plan via generative add-on registry

- **`DraftDietPlanAdapter`**: compiles `DietPlanPluginPrompt` into `GenerativeAddonAdapter` (accepts, prompt, post-process, evaluate, constraints, retry suffix, context collapse).
- **`GenerativeAddonCoordinator`**: plans eligible generative add-ons, reviews output (one retry max), collapses thread history.
- **`BuiltInAddonRegistry`**: registers `draft-diet-plan` with Riverpod providers.
- **`chat_screen.dart`**: removes direct `DietPlanPluginPrompt` / `draft-diet-plan` ID switches; routes through `generativeAddonCoordinatorProvider`.
- **`generative_addon_adapter.dart`**: adds `AddonReasoningDocument`, context-history hooks, and `GenerativeAddonAdapterStub` for tests.

### Increment 2 (merged)

- Encrypted LifeTrack destination, idempotency store, secure migration path.

## Tests

```bash
cd packages/core_ai && flutter test test/addons/
cd packages/feature_mind && flutter test test/addons/ \
  test/agent_chat/data/services/diet_plan_plugin_prompt_test.dart \
  test/agent_chat/eval/diet_specialist_eval_test.dart
```

All passing locally (40 tests across addon + diet suites).

## Design reference

`docs/superpowers/specs/2026-08-22-airo-mind-addon-framework-design.md`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3cb72c1f-40c3-40b6-938b-70e7592345dd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3cb72c1f-40c3-40b6-938b-70e7592345dd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

