### PR TITLE
feat(mind): add Crossref SearchEngine adapter (Task 5c)

### DIFF
--- a/packages/feature_mind/lib/src/agent_chat/domain/services/research/crossref_search_engine.dart
+++ b/packages/feature_mind/lib/src/agent_chat/domain/services/research/crossref_search_engine.dart
@@ -1,0 +1,137 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'research_http.dart';
+import 'research_search.dart';
+
+Future<ResearchHttpTransportResponse> _crossrefTransport(
+  Uri uri,
+  Duration timeout,
+) async {
+  final client = HttpClient()..connectionTimeout = timeout;
+  try {
+    final request = await client.getUrl(uri);
+    request.followRedirects = false;
+    request.headers.set(
+      HttpHeaders.userAgentHeader,
+      'Airo-Mind-Research/1.0 (mailto:noreply@local)',
+    );
+    final response = await request.close().timeout(timeout);
+    return ResearchHttpTransportResponse(
+      statusCode: response.statusCode,
+      location: response.headers.value(HttpHeaders.locationHeader),
+      chunks: response,
+      close: () => client.close(force: true),
+    );
+  } catch (_) {
+    client.close(force: true);
+    rethrow;
+  }
+}
+
+/// Crossref scholarly metadata search. Hits are candidates, not evidence.
+class CrossrefSearchEngine implements ResearchSearchEngine {
+  CrossrefSearchEngine({ResearchHttpClient? http})
+    : http =
+          http ??
+          const ResearchHttpClient(
+            allowedHosts: {'api.crossref.org', 'doi.org'},
+            transport: _crossrefTransport,
+          );
+
+  final ResearchHttpClient http;
+
+  @override
+  String get id => 'crossref';
+
+  static List<ResearchHit> parseSearchJson(String body) {
+    final decoded = jsonDecode(body);
+    if (decoded is! Map) {
+      return const [];
+    }
+    final message = decoded['message'];
+    if (message is! Map) {
+      return const [];
+    }
+    final items = message['items'];
+    if (items is! List) {
+      return const [];
+    }
+    final hits = <ResearchHit>[];
+    for (final row in items) {
+      if (row is! Map) {
+        continue;
+      }
+      final titleField = row['title'];
+      final title = titleField is List && titleField.isNotEmpty
+          ? '${titleField.first}'.trim()
+          : '${titleField ?? ''}'.trim();
+      if (title.isEmpty) {
+        continue;
+      }
+      final url = _workUrl(row);
+      if (url == null) {
+        continue;
+      }
+      hits.add(
+        ResearchHit(
+          engineId: 'crossref',
+          url: url,
+          title: title,
+          snippet: _snippet(row),
+        ),
+      );
+    }
+    return hits;
+  }
+
+  static String? _workUrl(Map<dynamic, dynamic> row) {
+    final raw = '${row['URL'] ?? ''}'.trim();
+    final parsed = Uri.tryParse(raw);
+    if (parsed != null &&
+        parsed.scheme == 'https' &&
+        parsed.host.isNotEmpty &&
+        parsed.userInfo.isEmpty) {
+      return parsed.toString();
+    }
+    final doi = '${row['DOI'] ?? ''}'.trim();
+    if (doi.isEmpty) {
+      return null;
+    }
+    return 'https://doi.org/$doi';
+  }
+
+  static String _snippet(Map<dynamic, dynamic> row) {
+    final abstract = '${row['abstract'] ?? ''}'.trim();
+    if (abstract.isNotEmpty) {
+      return abstract;
+    }
+    final publisher = '${row['publisher'] ?? ''}'.trim();
+    final issued = row['issued'];
+    if (issued is Map) {
+      final parts = issued['date-parts'];
+      if (parts is List && parts.isNotEmpty && parts.first is List) {
+        final dateParts = parts.first as List;
+        if (dateParts.isNotEmpty) {
+          return [publisher, dateParts.join('-')]
+              .where((part) => part.isNotEmpty)
+              .join(' · ');
+        }
+      }
+    }
+    return publisher;
+  }
+
+  @override
+  Future<List<ResearchHit>> search(String query, {int maxResults = 5}) async {
+    if (query.trim().isEmpty) {
+      return const [];
+    }
+    final uri = Uri.https('api.crossref.org', '/works', {
+      'query': query,
+      'rows': '$maxResults',
+    });
+    final body = await http.get(uri);
+    return parseSearchJson(body);
+  }
+}

--- a/packages/feature_mind/lib/src/agent_chat/domain/services/research/research_http.dart
+++ b/packages/feature_mind/lib/src/agent_chat/domain/services/research/research_http.dart
@@ -75,6 +75,8 @@ class ResearchHttpClient {
     'arxiv.org',
     'api.semanticscholar.org',
     'www.semanticscholar.org',
+    'api.crossref.org',
+    'doi.org',
   };
 
   final Set<String> allowedHosts;

--- a/packages/feature_mind/lib/src/agent_chat/domain/services/research/research_search.dart
+++ b/packages/feature_mind/lib/src/agent_chat/domain/services/research/research_search.dart
@@ -38,7 +38,7 @@ class SearchRouter {
       case SearchPolicy.maximumQuality:
         return const ['wikipedia', 'arxiv', 'semantic_scholar'];
       case SearchPolicy.academic:
-        return const ['arxiv', 'semantic_scholar'];
+        return const ['arxiv', 'semantic_scholar', 'crossref'];
     }
   }
 

--- a/packages/feature_mind/lib/src/agent_chat/domain/services/research/research_service.dart
+++ b/packages/feature_mind/lib/src/agent_chat/domain/services/research/research_service.dart
@@ -1,6 +1,7 @@
 import '../../models/research_event.dart';
 import '../../models/research_request.dart';
 import 'arxiv_search_engine.dart';
+import 'crossref_search_engine.dart';
 import 'research_checkpoint.dart';
 import 'research_control.dart';
 import 'research_http.dart';
@@ -60,6 +61,7 @@ class LocalResearchService implements ResearchService {
         WikipediaSearchEngine(),
         ArxivSearchEngine(),
         SemanticScholarSearchEngine(),
+        CrossrefSearchEngine(),
         if (searxngBaseUri != null)
           SearxngSearchEngine(baseUri: searxngBaseUri),
       ],

--- a/packages/feature_mind/test/agent_chat/domain/services/research/crossref_search_engine_test.dart
+++ b/packages/feature_mind/test/agent_chat/domain/services/research/crossref_search_engine_test.dart
@@ -1,0 +1,57 @@
+import 'package:feature_mind/src/agent_chat/domain/services/research/crossref_search_engine.dart';
+import 'package:feature_mind/src/agent_chat/domain/services/research/research_http.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('maps crossref works to doi urls and titles', () {
+    const body = '''
+{
+  "message": {
+    "items": [
+      {
+        "DOI": "10.1038/nature12373",
+        "title": ["Qwen on device"],
+        "abstract": "A study of on-device inference.",
+        "URL": "https://doi.org/10.1038/nature12373"
+      }
+    ]
+  }
+}
+''';
+    final hits = CrossrefSearchEngine.parseSearchJson(body);
+    expect(hits, hasLength(1));
+    expect(hits.single.engineId, 'crossref');
+    expect(hits.single.title, 'Qwen on device');
+    expect(hits.single.url, 'https://doi.org/10.1038/nature12373');
+    expect(hits.single.snippet, 'A study of on-device inference.');
+  });
+
+  test('falls back to doi.org when crossref omits url', () {
+    const body = '''
+{
+  "message": {
+    "items": [
+      {
+        "DOI": "10.5555/12345",
+        "title": ["Fallback paper"]
+      }
+    ]
+  }
+}
+''';
+    final hits = CrossrefSearchEngine.parseSearchJson(body);
+    expect(hits.single.url, 'https://doi.org/10.5555/12345');
+  });
+
+  test('research http allows crossref api and rejects google', () {
+    const client = ResearchHttpClient();
+    expect(
+      () => client.validate(Uri.parse('https://api.crossref.org/works')),
+      returnsNormally,
+    );
+    expect(
+      () => client.get(Uri.parse('https://www.google.com/search?q=qwen')),
+      throwsA(isA<ResearchHttpException>()),
+    );
+  });
+}

--- a/packages/feature_mind/test/agent_chat/domain/services/research/search_router_test.dart
+++ b/packages/feature_mind/test/agent_chat/domain/services/research/search_router_test.dart
@@ -11,7 +11,7 @@ void main() {
 
   test('academic policy prefers papers', () {
     final ids = SearchRouter.engineIds(SearchPolicy.academic);
-    expect(ids, containsAll(['arxiv', 'semantic_scholar']));
+    expect(ids, containsAll(['arxiv', 'semantic_scholar', 'crossref']));
     expect(ids, isNot(contains('google')));
   });
 

--- a/rust/airo_mind_core/src/research/engine.rs
+++ b/rust/airo_mind_core/src/research/engine.rs
@@ -402,7 +402,9 @@ fn engine_allowed(policy: SearchPolicy, id: &str) -> bool {
     match policy {
         SearchPolicy::LocalOnly => false,
         SearchPolicy::PrivacyFirst => id == "wikipedia" || id == "searxng",
-        SearchPolicy::Academic => id == "arxiv" || id == "semantic_scholar",
+        SearchPolicy::Academic => {
+            id == "arxiv" || id == "semantic_scholar" || id == "crossref"
+        }
         SearchPolicy::Balanced | SearchPolicy::MaximumQuality => {
             id != "google" && id != "bing" && id != "tavily" && id != "duckduckgo"
         }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a Crossref scholarly metadata search adapter.

- `CrossrefSearchEngine` queries `api.crossref.org/works` with a polite `User-Agent`.
- Maps works to `https://doi.org/...` URLs with title/abstract snippets.
- Allowlists `api.crossref.org` and `doi.org`.
- Routes `crossref` through the academic policy and registers the engine in `LocalResearchService`.
- Mirrors academic routing in Rust `engine_allowed`.

## Test plan

- [x] `flutter test test/agent_chat/domain/services/research/crossref_search_engine_test.dart`
- [x] `flutter test test/agent_chat/domain/services/research/search_router_test.dart`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0d1a1368-352c-43c3-b66e-d4ae3a878dd5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0d1a1368-352c-43c3-b66e-d4ae3a878dd5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

