### PR TITLE
feat(mind): add local memory SearchEngine adapter (Task 5d)

### DIFF
--- a/packages/feature_mind/lib/src/agent_chat/domain/services/deep_research_engine.dart
+++ b/packages/feature_mind/lib/src/agent_chat/domain/services/deep_research_engine.dart
@@ -5,6 +5,7 @@ import 'research/research_control.dart';
 import 'research/research_library.dart';
 import 'research/research_orchestrator.dart';
 import 'research/research_service.dart';
+import '../../../runtime/ports/operation_log_port.dart';
 
 /// Runs a Deep Research job. Implementations own orchestration, not prompts.
 ///
@@ -23,8 +24,14 @@ abstract class DeepResearchEngine {
 
 typedef DeepResearchEngineFactory = DeepResearchEngine Function();
 
-DeepResearchEngine createLocalDeepResearchEngine({Uri? searxngBaseUri}) {
-  return LocalDeepResearchEngine(searxngBaseUri: searxngBaseUri);
+DeepResearchEngine createLocalDeepResearchEngine({
+  Uri? searxngBaseUri,
+  OperationLogPort? operationLogPort,
+}) {
+  return LocalDeepResearchEngine(
+    searxngBaseUri: searxngBaseUri,
+    operationLogPort: operationLogPort,
+  );
 }
 
 /// Shim: Chat talks to [ResearchService], never to a research prompt.
@@ -33,8 +40,12 @@ class LocalDeepResearchEngine implements DeepResearchEngine {
     ResearchService? service,
     ResearchOrchestrator? orchestrator,
     Uri? searxngBaseUri,
+    OperationLogPort? operationLogPort,
   }) {
-    if (service != null && (orchestrator != null || searxngBaseUri != null)) {
+    if (service != null &&
+        (orchestrator != null ||
+            searxngBaseUri != null ||
+            operationLogPort != null)) {
       throw ArgumentError(
         'Inject a service or engine configuration, not both.',
       );
@@ -44,6 +55,7 @@ class LocalDeepResearchEngine implements DeepResearchEngine {
           LocalResearchService(
             orchestrator: orchestrator,
             searxngBaseUri: searxngBaseUri,
+            operationLogPort: operationLogPort,
           ),
     );
   }

--- a/packages/feature_mind/lib/src/agent_chat/domain/services/research/local_memory_search_engine.dart
+++ b/packages/feature_mind/lib/src/agent_chat/domain/services/research/local_memory_search_engine.dart
@@ -1,0 +1,94 @@
+import '../../../../runtime/models/log_models.dart';
+import '../../../../runtime/ports/operation_log_port.dart';
+import 'research_library.dart';
+import 'research_library_log.dart';
+import 'research_search.dart';
+
+/// Searches the durable research library in the operation log.
+class LocalMemorySearchEngine implements ResearchSearchEngine {
+  LocalMemorySearchEngine({required OperationLogPort operationLog})
+    : _operationLog = operationLog;
+
+  final OperationLogPort _operationLog;
+
+  @override
+  String get id => 'local_memory';
+
+  static List<ResearchHit> hitsFor({
+    required String query,
+    required List<ResearchLibraryEntry> entries,
+    int maxResults = 5,
+  }) {
+    if (query.trim().isEmpty) {
+      return const [];
+    }
+    final key = topicKeyFor(query);
+    final normalized = query.trim().toLowerCase();
+    final hits = <ResearchHit>[];
+    for (final entry in entries) {
+      if (!_matches(entry, key, normalized)) {
+        continue;
+      }
+      if (entry.sourceUrls.isEmpty) {
+        continue;
+      }
+      hits.add(
+        ResearchHit(
+          engineId: 'local_memory',
+          url: entry.sourceUrls.first,
+          title: entry.question,
+          snippet: entry.findings.isNotEmpty
+              ? entry.findings.first
+              : entry.question,
+          trustLevel: SourceTrust.system,
+        ),
+      );
+      if (hits.length >= maxResults) {
+        break;
+      }
+    }
+    return hits;
+  }
+
+  static bool _matches(
+    ResearchLibraryEntry entry,
+    String topicKey,
+    String normalizedQuery,
+  ) {
+    if (entry.topicKey == topicKey) {
+      return true;
+    }
+    return entry.question.toLowerCase().contains(normalizedQuery);
+  }
+
+  @override
+  Future<List<ResearchHit>> search(String query, {int maxResults = 5}) async {
+    final entries = await _loadEntries();
+    return hitsFor(query: query, entries: entries, maxResults: maxResults);
+  }
+
+  Future<List<ResearchLibraryEntry>> _loadEntries() async {
+    final entries = <ResearchLibraryEntry>[];
+    try {
+      final count = await _operationLog.count();
+      if (count == 0) {
+        return entries;
+      }
+      final limit = count < 200 ? count : 200;
+      final ops = await _operationLog.range(offset: 0, limit: limit);
+      for (final op in ops) {
+        if (op.kind != MindOpKind.researchLibrary || op.detail.isEmpty) {
+          continue;
+        }
+        try {
+          entries.add(ResearchLibraryEntry.fromRecord(op.detail));
+        } on FormatException {
+          continue;
+        }
+      }
+    } on Object {
+      return const [];
+    }
+    return entries;
+  }
+}

--- a/packages/feature_mind/lib/src/agent_chat/domain/services/research/research_search.dart
+++ b/packages/feature_mind/lib/src/agent_chat/domain/services/research/research_search.dart
@@ -31,7 +31,7 @@ class SearchRouter {
   static List<String> engineIds(SearchPolicy policy) {
     switch (policy) {
       case SearchPolicy.localOnly:
-        return const [];
+        return const ['local_memory'];
       case SearchPolicy.privacyFirst:
         return const ['wikipedia', 'searxng'];
       case SearchPolicy.balanced:

--- a/packages/feature_mind/lib/src/agent_chat/domain/services/research/research_service.dart
+++ b/packages/feature_mind/lib/src/agent_chat/domain/services/research/research_service.dart
@@ -1,6 +1,7 @@
 import '../../models/research_event.dart';
 import '../../models/research_request.dart';
 import 'arxiv_search_engine.dart';
+import 'local_memory_search_engine.dart';
 import 'research_checkpoint.dart';
 import 'research_control.dart';
 import 'research_http.dart';
@@ -10,6 +11,7 @@ import 'searxng_search_engine.dart';
 import 'semantic_scholar_search_engine.dart';
 import 'source_manager.dart';
 import 'wikipedia_search_engine.dart';
+import '../../../runtime/ports/operation_log_port.dart';
 
 /// Flutter-facing Deep Research API. The model does not own this workflow.
 ///
@@ -34,14 +36,20 @@ class LocalResearchService implements ResearchService {
   factory LocalResearchService({
     ResearchOrchestrator? orchestrator,
     Uri? searxngBaseUri,
+    OperationLogPort? operationLogPort,
   }) {
-    if (orchestrator != null && searxngBaseUri != null) {
+    if (orchestrator != null &&
+        (searxngBaseUri != null || operationLogPort != null)) {
       throw ArgumentError(
-        'Inject either an orchestrator or a SearXNG base URI, not both.',
+        'Inject either an orchestrator or engine configuration, not both.',
       );
     }
     return LocalResearchService._(
-      orchestrator ?? _defaultOrchestrator(searxngBaseUri),
+      orchestrator ??
+          _defaultOrchestrator(
+            searxngBaseUri: searxngBaseUri,
+            operationLogPort: operationLogPort,
+          ),
       hasConfiguredSearxng: searxngBaseUri != null,
     );
   }
@@ -54,12 +62,17 @@ class LocalResearchService implements ResearchService {
   final ResearchOrchestrator _orchestrator;
   final bool hasConfiguredSearxng;
 
-  static ResearchOrchestrator _defaultOrchestrator(Uri? searxngBaseUri) {
+  static ResearchOrchestrator _defaultOrchestrator({
+    Uri? searxngBaseUri,
+    OperationLogPort? operationLogPort,
+  }) {
     return ResearchOrchestrator(
       engines: [
         WikipediaSearchEngine(),
         ArxivSearchEngine(),
         SemanticScholarSearchEngine(),
+        if (operationLogPort != null)
+          LocalMemorySearchEngine(operationLog: operationLogPort),
         if (searxngBaseUri != null)
           SearxngSearchEngine(baseUri: searxngBaseUri),
       ],

--- a/packages/feature_mind/test/agent_chat/domain/services/research/local_memory_search_engine_test.dart
+++ b/packages/feature_mind/test/agent_chat/domain/services/research/local_memory_search_engine_test.dart
@@ -1,0 +1,64 @@
+import 'package:feature_mind/src/agent_chat/domain/services/research/local_memory_search_engine.dart';
+import 'package:feature_mind/src/agent_chat/domain/services/research/research_library.dart';
+import 'package:feature_mind/src/agent_chat/domain/services/research/research_library_log.dart';
+import 'package:feature_mind/src/runtime/models/log_models.dart';
+import '../../../../support/recording_operation_log.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('matches prior library entries by topic key', () {
+    final hits = LocalMemorySearchEngine.hitsFor(
+      query: 'What is Qwen?',
+      entries: [
+        ResearchLibraryEntry.fromQuestion(
+          question: 'What is Qwen?',
+          retrievedAt: '2026-08-22T00:00:00Z',
+          sourceUrls: const ['https://en.wikipedia.org/wiki/Qwen'],
+          findings: const ['Qwen is a family of large language models.'],
+        ),
+        ResearchLibraryEntry.fromQuestion(
+          question: 'Pixel 9 battery life',
+          retrievedAt: '2026-08-22T01:00:00Z',
+          sourceUrls: const ['https://example.com/pixel'],
+          findings: const ['All-day battery.'],
+        ),
+      ],
+    );
+    expect(hits, hasLength(1));
+    expect(hits.single.engineId, 'local_memory');
+    expect(hits.single.url, 'https://en.wikipedia.org/wiki/Qwen');
+    expect(hits.single.snippet, contains('family of large language models'));
+  });
+
+  test('skips library entries without acquirable source urls', () {
+    final hits = LocalMemorySearchEngine.hitsFor(
+      query: 'orphan topic',
+      entries: [
+        ResearchLibraryEntry.fromQuestion(
+          question: 'orphan topic',
+          retrievedAt: '2026-08-22T00:00:00Z',
+          sourceUrls: const [],
+          findings: const ['Finding without a url.'],
+        ),
+      ],
+    );
+    expect(hits, isEmpty);
+  });
+
+  test('loads matching entries from the operation log', () async {
+    final log = RecordingOperationLog();
+    await appendResearchLibraryOp(
+      log: log,
+      entry: ResearchLibraryEntry.fromQuestion(
+        question: 'What is Qwen?',
+        retrievedAt: '2026-08-22T00:00:00Z',
+        sourceUrls: const ['https://en.wikipedia.org/wiki/Qwen'],
+        findings: const ['Qwen is a family of large language models.'],
+      ),
+    );
+    final engine = LocalMemorySearchEngine(operationLog: log);
+    final hits = await engine.search('What is Qwen?');
+    expect(hits, hasLength(1));
+    expect(hits.single.engineId, 'local_memory');
+  });
+}

--- a/packages/feature_mind/test/agent_chat/domain/services/research/search_router_test.dart
+++ b/packages/feature_mind/test/agent_chat/domain/services/research/search_router_test.dart
@@ -30,7 +30,10 @@ void main() {
     expect(ids, isNot(contains('semantic_scholar')));
   });
 
-  test('local-only uses no remote engines', () {
-    expect(SearchRouter.engineIds(SearchPolicy.localOnly), isEmpty);
+  test('local-only uses the research library engine', () {
+    expect(
+      SearchRouter.engineIds(SearchPolicy.localOnly),
+      ['local_memory'],
+    );
   });
 }

--- a/rust/airo_mind_core/src/research/engine.rs
+++ b/rust/airo_mind_core/src/research/engine.rs
@@ -400,7 +400,7 @@ fn event(
 
 fn engine_allowed(policy: SearchPolicy, id: &str) -> bool {
     match policy {
-        SearchPolicy::LocalOnly => false,
+        SearchPolicy::LocalOnly => id == "local_memory",
         SearchPolicy::PrivacyFirst => id == "wikipedia" || id == "searxng",
         SearchPolicy::Academic => id == "arxiv" || id == "semantic_scholar",
         SearchPolicy::Balanced | SearchPolicy::MaximumQuality => {
@@ -647,6 +647,12 @@ mod tests {
             Some(ResearchEventKind::Completed)
         );
         assert!(engine.report(&job_id).unwrap().contains("[1]"));
+    }
+
+    #[test]
+    fn local_only_allows_research_library_memory() {
+        assert!(engine_allowed(SearchPolicy::LocalOnly, "local_memory"));
+        assert!(!engine_allowed(SearchPolicy::LocalOnly, "wikipedia"));
     }
 
     #[test]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a local memory search adapter that reuses prior Deep Research library entries.

- `LocalMemorySearchEngine` scans recent `researchLibrary` operations from an injected `OperationLogPort`.
- Matches by topic key or question overlap; emits system-trusted hits with prior source URLs.
- Routes `local_memory` through `SearchPolicy.localOnly`.
- Threads optional `operationLogPort` through `LocalResearchService` and `createLocalDeepResearchEngine`.
- Mirrors local-only routing in Rust `engine_allowed`.

## Test plan

- [x] `flutter test test/agent_chat/domain/services/research/local_memory_search_engine_test.dart`
- [x] `flutter test test/agent_chat/domain/services/research/search_router_test.dart`
- [x] `cargo test -p airo_mind_core --lib local_only_allows`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0d1a1368-352c-43c3-b66e-d4ae3a878dd5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0d1a1368-352c-43c3-b66e-d4ae3a878dd5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

