### PR TITLE
feat(mind): FRB production parity for Deep Research (Task 6)

### DIFF
--- a/packages/feature_mind/lib/src/agent_chat/domain/services/research/rust_research_mapping.dart
+++ b/packages/feature_mind/lib/src/agent_chat/domain/services/research/rust_research_mapping.dart
@@ -1,6 +1,7 @@
 import '../../models/research_event.dart';
 import '../../models/research_request.dart';
 import '../../../../llama/api/research.dart' as frb;
+import 'research_checkpoint.dart';
 
 ResearchEvent mapFrbResearchEvent(frb.FrbResearchEvent event) {
   return ResearchEvent(
@@ -48,6 +49,10 @@ ResearchEventKind mapFrbResearchEventKind(frb.FrbResearchEventKind kind) {
     case frb.FrbResearchEventKind.cancelled:
       return ResearchEventKind.researchCancelled;
   }
+}
+
+frb.FrbResearchCheckpoint mapResearchCheckpoint(ResearchCheckpoint checkpoint) {
+  return frb.FrbResearchCheckpoint(record: checkpoint.toRecord());
 }
 
 frb.FrbResearchRequest mapResearchRequest(ResearchRequest request) {

--- a/packages/feature_mind/lib/src/agent_chat/domain/services/research/rust_research_service.dart
+++ b/packages/feature_mind/lib/src/agent_chat/domain/services/research/rust_research_service.dart
@@ -77,10 +77,17 @@ class RustResearchService implements ResearchService {
       fetch: (url) => _fetch(Uri.parse(url)),
     );
 
-    final jobId = frb.researchStart(
-      handle: handle,
-      request: mapResearchRequest(request),
-    );
+    final jobId = resumeFrom?.jobId ??
+        frb.researchStart(
+          handle: handle,
+          request: mapResearchRequest(request),
+        );
+    if (resumeFrom != null) {
+      frb.researchRestore(
+        handle: handle,
+        checkpoint: mapResearchCheckpoint(resumeFrom),
+      );
+    }
 
     Timer? controlTimer;
     if (control != null) {
@@ -100,9 +107,42 @@ class RustResearchService implements ResearchService {
       });
     }
 
+    final fetchedUrls = <String>[];
+    final findings = <String>[];
+
     try {
-      await for (final event in frb.researchRun(handle: handle, jobId: jobId)) {
-        yield mapFrbResearchEvent(event);
+      await for (final event in frb.researchRun(
+        handle: handle,
+        jobId: jobId,
+        knownSourceUrls: knownSourceUrls,
+      )) {
+        final mapped = mapFrbResearchEvent(event);
+        if (mapped.kind == ResearchEventKind.sourceFetched) {
+          fetchedUrls.add(mapped.detail);
+        } else if (mapped.kind == ResearchEventKind.claimCreated &&
+            mapped.detail.startsWith('supported: ')) {
+          findings.add(mapped.detail.substring('supported: '.length));
+        } else if (mapped.kind == ResearchEventKind.researchPaused) {
+          final checkpoint = frb.researchCheckpoint(
+            handle: handle,
+            jobId: jobId,
+          );
+          if (checkpoint != null) {
+            onCheckpoint?.call(
+              ResearchCheckpoint.fromRecord(checkpoint.record),
+            );
+          }
+        } else if (mapped.kind == ResearchEventKind.researchCompleted) {
+          onLibrary?.call(
+            ResearchLibraryEntry.fromQuestion(
+              question: request.question,
+              retrievedAt: DateTime.now().toUtc().toIso8601String(),
+              sourceUrls: fetchedUrls,
+              findings: findings,
+            ),
+          );
+        }
+        yield mapped;
       }
     } finally {
       controlTimer?.cancel();

--- a/packages/feature_mind/lib/src/agent_chat/presentation/screens/chat_screen.dart
+++ b/packages/feature_mind/lib/src/agent_chat/presentation/screens/chat_screen.dart
@@ -374,7 +374,8 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
           isGenerationActive: () => _isGenerating,
         );
     _deepResearchEngine =
-        widget.deepResearchEngine ?? LocalDeepResearchEngine();
+        widget.deepResearchEngine ??
+        LocalDeepResearchEngine(operationLogPort: _operationLogPort);
     _skillOrchestrator =
         widget.skillOrchestrator ?? _buildSkillOrchestrator(_skillRegistry);
     if (widget.skillOrchestrator == null) {

--- a/packages/feature_mind/lib/src/llama/api/research.dart
+++ b/packages/feature_mind/lib/src/llama/api/research.dart
@@ -62,6 +62,22 @@ void researchCancel({
   jobId: jobId,
 );
 
+FrbResearchCheckpoint? researchCheckpoint({
+  required ResearchServiceHandle handle,
+  required String jobId,
+}) => RustLib.instance.api.crateApiResearchResearchCheckpoint(
+  handle: handle,
+  jobId: jobId,
+);
+
+void researchRestore({
+  required ResearchServiceHandle handle,
+  required FrbResearchCheckpoint checkpoint,
+}) => RustLib.instance.api.crateApiResearchResearchRestore(
+  handle: handle,
+  checkpoint: checkpoint,
+);
+
 String? researchReport({
   required ResearchServiceHandle handle,
   required String jobId,
@@ -74,13 +90,31 @@ String? researchReport({
 Stream<FrbResearchEvent> researchRun({
   required ResearchServiceHandle handle,
   required String jobId,
+  required List<String> knownSourceUrls,
 }) => RustLib.instance.api.crateApiResearchResearchRun(
   handle: handle,
   jobId: jobId,
+  knownSourceUrls: knownSourceUrls,
 );
 
 // Rust type: RustOpaqueMoi<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<ResearchServiceHandle>>
 abstract class ResearchServiceHandle implements RustOpaqueInterface {}
+
+class FrbResearchCheckpoint {
+  final String record;
+
+  const FrbResearchCheckpoint({required this.record});
+
+  @override
+  int get hashCode => record.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is FrbResearchCheckpoint &&
+          runtimeType == other.runtimeType &&
+          record == other.record;
+}
 
 class FrbResearchEvent {
   final FrbResearchEventKind kind;

--- a/packages/feature_mind/lib/src/llama/frb_generated.dart
+++ b/packages/feature_mind/lib/src/llama/frb_generated.dart
@@ -67,7 +67,7 @@ class RustLib extends BaseEntrypoint<RustLibApi, RustLibApiImpl, RustLibWire> {
   String get codegenVersion => '2.11.1';
 
   @override
-  int get rustContentHash => -1730392733;
+  int get rustContentHash => -1641887784;
 
   static const kDefaultExternalLibraryLoaderConfig =
       ExternalLibraryLoaderConfig(
@@ -126,6 +126,11 @@ abstract class RustLibApi extends BaseApi {
     required String jobId,
   });
 
+  FrbResearchCheckpoint? crateApiResearchResearchCheckpoint({
+    required ResearchServiceHandle handle,
+    required String jobId,
+  });
+
   void crateApiResearchResearchPause({
     required ResearchServiceHandle handle,
     required String jobId,
@@ -136,6 +141,11 @@ abstract class RustLibApi extends BaseApi {
     required String jobId,
   });
 
+  void crateApiResearchResearchRestore({
+    required ResearchServiceHandle handle,
+    required FrbResearchCheckpoint checkpoint,
+  });
+
   void crateApiResearchResearchResume({
     required ResearchServiceHandle handle,
     required String jobId,
@@ -144,6 +154,7 @@ abstract class RustLibApi extends BaseApi {
   Stream<FrbResearchEvent> crateApiResearchResearchRun({
     required ResearchServiceHandle handle,
     required String jobId,
+    required List<String> knownSourceUrls,
   });
 
   String crateApiResearchResearchStart({
@@ -585,7 +596,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       );
 
   @override
-  void crateApiResearchResearchPause({
+  FrbResearchCheckpoint? crateApiResearchResearchCheckpoint({
     required ResearchServiceHandle handle,
     required String jobId,
   }) {
@@ -599,6 +610,39 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           );
           sse_encode_String(jobId, serializer);
           return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 14)!;
+        },
+        codec: SseCodec(
+          decodeSuccessData: sse_decode_opt_box_autoadd_frb_research_checkpoint,
+          decodeErrorData: null,
+        ),
+        constMeta: kCrateApiResearchResearchCheckpointConstMeta,
+        argValues: [handle, jobId],
+        apiImpl: this,
+      ),
+    );
+  }
+
+  TaskConstMeta get kCrateApiResearchResearchCheckpointConstMeta =>
+      const TaskConstMeta(
+        debugName: "research_checkpoint",
+        argNames: ["handle", "jobId"],
+      );
+
+  @override
+  void crateApiResearchResearchPause({
+    required ResearchServiceHandle handle,
+    required String jobId,
+  }) {
+    return handler.executeSync(
+      SyncTask(
+        callFfi: () {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerResearchServiceHandle(
+            handle,
+            serializer,
+          );
+          sse_encode_String(jobId, serializer);
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 15)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -631,7 +675,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             serializer,
           );
           sse_encode_String(jobId, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 15)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 16)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_opt_String,
@@ -651,6 +695,42 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       );
 
   @override
+  void crateApiResearchResearchRestore({
+    required ResearchServiceHandle handle,
+    required FrbResearchCheckpoint checkpoint,
+  }) {
+    return handler.executeSync(
+      SyncTask(
+        callFfi: () {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerResearchServiceHandle(
+            handle,
+            serializer,
+          );
+          sse_encode_box_autoadd_frb_research_checkpoint(
+            checkpoint,
+            serializer,
+          );
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 17)!;
+        },
+        codec: SseCodec(
+          decodeSuccessData: sse_decode_unit,
+          decodeErrorData: sse_decode_String,
+        ),
+        constMeta: kCrateApiResearchResearchRestoreConstMeta,
+        argValues: [handle, checkpoint],
+        apiImpl: this,
+      ),
+    );
+  }
+
+  TaskConstMeta get kCrateApiResearchResearchRestoreConstMeta =>
+      const TaskConstMeta(
+        debugName: "research_restore",
+        argNames: ["handle", "checkpoint"],
+      );
+
+  @override
   void crateApiResearchResearchResume({
     required ResearchServiceHandle handle,
     required String jobId,
@@ -664,7 +744,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             serializer,
           );
           sse_encode_String(jobId, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 16)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 18)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -687,6 +767,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   Stream<FrbResearchEvent> crateApiResearchResearchRun({
     required ResearchServiceHandle handle,
     required String jobId,
+    required List<String> knownSourceUrls,
   }) {
     final sink = RustStreamSink<FrbResearchEvent>();
     unawaited(
@@ -699,11 +780,12 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
               serializer,
             );
             sse_encode_String(jobId, serializer);
+            sse_encode_list_String(knownSourceUrls, serializer);
             sse_encode_StreamSink_frb_research_event_Sse(sink, serializer);
             pdeCallFfi(
               generalizedFrbRustBinding,
               serializer,
-              funcId: 17,
+              funcId: 19,
               port: port_,
             );
           },
@@ -712,7 +794,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             decodeErrorData: sse_decode_String,
           ),
           constMeta: kCrateApiResearchResearchRunConstMeta,
-          argValues: [handle, jobId, sink],
+          argValues: [handle, jobId, knownSourceUrls, sink],
           apiImpl: this,
         ),
       ),
@@ -723,7 +805,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   TaskConstMeta get kCrateApiResearchResearchRunConstMeta =>
       const TaskConstMeta(
         debugName: "research_run",
-        argNames: ["handle", "jobId", "sink"],
+        argNames: ["handle", "jobId", "knownSourceUrls", "sink"],
       );
 
   @override
@@ -740,7 +822,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             serializer,
           );
           sse_encode_box_autoadd_frb_research_request(request, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 18)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 20)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_String,
@@ -773,7 +855,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             serializer,
           );
           sse_encode_String(jobId, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 19)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 21)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_opt_box_autoadd_frb_research_job_state,
@@ -798,7 +880,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       SyncTask(
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 20)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 22)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -998,6 +1080,14 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  FrbResearchCheckpoint dco_decode_box_autoadd_frb_research_checkpoint(
+    dynamic raw,
+  ) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return dco_decode_frb_research_checkpoint(raw);
+  }
+
+  @protected
   FrbResearchJobState dco_decode_box_autoadd_frb_research_job_state(
     dynamic raw,
   ) {
@@ -1039,6 +1129,15 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   double dco_decode_f_64(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return raw as double;
+  }
+
+  @protected
+  FrbResearchCheckpoint dco_decode_frb_research_checkpoint(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    final arr = raw as List<dynamic>;
+    if (arr.length != 1)
+      throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
+    return FrbResearchCheckpoint(record: dco_decode_String(arr[0]));
   }
 
   @protected
@@ -1371,6 +1470,16 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  FrbResearchCheckpoint? dco_decode_opt_box_autoadd_frb_research_checkpoint(
+    dynamic raw,
+  ) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return raw == null
+        ? null
+        : dco_decode_box_autoadd_frb_research_checkpoint(raw);
+  }
+
+  @protected
   FrbResearchJobState? dco_decode_opt_box_autoadd_frb_research_job_state(
     dynamic raw,
   ) {
@@ -1615,6 +1724,14 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  FrbResearchCheckpoint sse_decode_box_autoadd_frb_research_checkpoint(
+    SseDeserializer deserializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    return (sse_decode_frb_research_checkpoint(deserializer));
+  }
+
+  @protected
   FrbResearchJobState sse_decode_box_autoadd_frb_research_job_state(
     SseDeserializer deserializer,
   ) {
@@ -1664,6 +1781,15 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   double sse_decode_f_64(SseDeserializer deserializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     return deserializer.buffer.getFloat64();
+  }
+
+  @protected
+  FrbResearchCheckpoint sse_decode_frb_research_checkpoint(
+    SseDeserializer deserializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    var var_record = sse_decode_String(deserializer);
+    return FrbResearchCheckpoint(record: var_record);
   }
 
   @protected
@@ -2088,6 +2214,19 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  FrbResearchCheckpoint? sse_decode_opt_box_autoadd_frb_research_checkpoint(
+    SseDeserializer deserializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+
+    if (sse_decode_bool(deserializer)) {
+      return (sse_decode_box_autoadd_frb_research_checkpoint(deserializer));
+    } else {
+      return null;
+    }
+  }
+
+  @protected
   FrbResearchJobState? sse_decode_opt_box_autoadd_frb_research_job_state(
     SseDeserializer deserializer,
   ) {
@@ -2438,6 +2577,15 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  void sse_encode_box_autoadd_frb_research_checkpoint(
+    FrbResearchCheckpoint self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_frb_research_checkpoint(self, serializer);
+  }
+
+  @protected
   void sse_encode_box_autoadd_frb_research_job_state(
     FrbResearchJobState self,
     SseSerializer serializer,
@@ -2492,6 +2640,15 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   void sse_encode_f_64(double self, SseSerializer serializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     serializer.buffer.putFloat64(self);
+  }
+
+  @protected
+  void sse_encode_frb_research_checkpoint(
+    FrbResearchCheckpoint self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_String(self.record, serializer);
   }
 
   @protected
@@ -2855,6 +3012,19 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     sse_encode_bool(self != null, serializer);
     if (self != null) {
       sse_encode_box_autoadd_f_32(self, serializer);
+    }
+  }
+
+  @protected
+  void sse_encode_opt_box_autoadd_frb_research_checkpoint(
+    FrbResearchCheckpoint? self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+
+    sse_encode_bool(self != null, serializer);
+    if (self != null) {
+      sse_encode_box_autoadd_frb_research_checkpoint(self, serializer);
     }
   }
 

--- a/packages/feature_mind/lib/src/llama/frb_generated.io.dart
+++ b/packages/feature_mind/lib/src/llama/frb_generated.io.dart
@@ -88,6 +88,11 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   double dco_decode_box_autoadd_f_32(dynamic raw);
 
   @protected
+  FrbResearchCheckpoint dco_decode_box_autoadd_frb_research_checkpoint(
+    dynamic raw,
+  );
+
+  @protected
   FrbResearchJobState dco_decode_box_autoadd_frb_research_job_state(
     dynamic raw,
   );
@@ -109,6 +114,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   double dco_decode_f_64(dynamic raw);
+
+  @protected
+  FrbResearchCheckpoint dco_decode_frb_research_checkpoint(dynamic raw);
 
   @protected
   FrbResearchEvent dco_decode_frb_research_event(dynamic raw);
@@ -217,6 +225,11 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   double? dco_decode_opt_box_autoadd_f_32(dynamic raw);
 
   @protected
+  FrbResearchCheckpoint? dco_decode_opt_box_autoadd_frb_research_checkpoint(
+    dynamic raw,
+  );
+
+  @protected
   FrbResearchJobState? dco_decode_opt_box_autoadd_frb_research_job_state(
     dynamic raw,
   );
@@ -312,6 +325,11 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   double sse_decode_box_autoadd_f_32(SseDeserializer deserializer);
 
   @protected
+  FrbResearchCheckpoint sse_decode_box_autoadd_frb_research_checkpoint(
+    SseDeserializer deserializer,
+  );
+
+  @protected
   FrbResearchJobState sse_decode_box_autoadd_frb_research_job_state(
     SseDeserializer deserializer,
   );
@@ -341,6 +359,11 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   double sse_decode_f_64(SseDeserializer deserializer);
+
+  @protected
+  FrbResearchCheckpoint sse_decode_frb_research_checkpoint(
+    SseDeserializer deserializer,
+  );
 
   @protected
   FrbResearchEvent sse_decode_frb_research_event(SseDeserializer deserializer);
@@ -475,6 +498,11 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   double? sse_decode_opt_box_autoadd_f_32(SseDeserializer deserializer);
 
   @protected
+  FrbResearchCheckpoint? sse_decode_opt_box_autoadd_frb_research_checkpoint(
+    SseDeserializer deserializer,
+  );
+
+  @protected
   FrbResearchJobState? sse_decode_opt_box_autoadd_frb_research_job_state(
     SseDeserializer deserializer,
   );
@@ -598,6 +626,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   void sse_encode_box_autoadd_f_32(double self, SseSerializer serializer);
 
   @protected
+  void sse_encode_box_autoadd_frb_research_checkpoint(
+    FrbResearchCheckpoint self,
+    SseSerializer serializer,
+  );
+
+  @protected
   void sse_encode_box_autoadd_frb_research_job_state(
     FrbResearchJobState self,
     SseSerializer serializer,
@@ -632,6 +666,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   void sse_encode_f_64(double self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_frb_research_checkpoint(
+    FrbResearchCheckpoint self,
+    SseSerializer serializer,
+  );
 
   @protected
   void sse_encode_frb_research_event(
@@ -806,6 +846,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   void sse_encode_opt_box_autoadd_f_32(double? self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_opt_box_autoadd_frb_research_checkpoint(
+    FrbResearchCheckpoint? self,
+    SseSerializer serializer,
+  );
 
   @protected
   void sse_encode_opt_box_autoadd_frb_research_job_state(

--- a/packages/feature_mind/lib/src/llama/frb_generated.web.dart
+++ b/packages/feature_mind/lib/src/llama/frb_generated.web.dart
@@ -90,6 +90,11 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   double dco_decode_box_autoadd_f_32(dynamic raw);
 
   @protected
+  FrbResearchCheckpoint dco_decode_box_autoadd_frb_research_checkpoint(
+    dynamic raw,
+  );
+
+  @protected
   FrbResearchJobState dco_decode_box_autoadd_frb_research_job_state(
     dynamic raw,
   );
@@ -111,6 +116,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   double dco_decode_f_64(dynamic raw);
+
+  @protected
+  FrbResearchCheckpoint dco_decode_frb_research_checkpoint(dynamic raw);
 
   @protected
   FrbResearchEvent dco_decode_frb_research_event(dynamic raw);
@@ -219,6 +227,11 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   double? dco_decode_opt_box_autoadd_f_32(dynamic raw);
 
   @protected
+  FrbResearchCheckpoint? dco_decode_opt_box_autoadd_frb_research_checkpoint(
+    dynamic raw,
+  );
+
+  @protected
   FrbResearchJobState? dco_decode_opt_box_autoadd_frb_research_job_state(
     dynamic raw,
   );
@@ -314,6 +327,11 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   double sse_decode_box_autoadd_f_32(SseDeserializer deserializer);
 
   @protected
+  FrbResearchCheckpoint sse_decode_box_autoadd_frb_research_checkpoint(
+    SseDeserializer deserializer,
+  );
+
+  @protected
   FrbResearchJobState sse_decode_box_autoadd_frb_research_job_state(
     SseDeserializer deserializer,
   );
@@ -343,6 +361,11 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   double sse_decode_f_64(SseDeserializer deserializer);
+
+  @protected
+  FrbResearchCheckpoint sse_decode_frb_research_checkpoint(
+    SseDeserializer deserializer,
+  );
 
   @protected
   FrbResearchEvent sse_decode_frb_research_event(SseDeserializer deserializer);
@@ -477,6 +500,11 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   double? sse_decode_opt_box_autoadd_f_32(SseDeserializer deserializer);
 
   @protected
+  FrbResearchCheckpoint? sse_decode_opt_box_autoadd_frb_research_checkpoint(
+    SseDeserializer deserializer,
+  );
+
+  @protected
   FrbResearchJobState? sse_decode_opt_box_autoadd_frb_research_job_state(
     SseDeserializer deserializer,
   );
@@ -600,6 +628,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   void sse_encode_box_autoadd_f_32(double self, SseSerializer serializer);
 
   @protected
+  void sse_encode_box_autoadd_frb_research_checkpoint(
+    FrbResearchCheckpoint self,
+    SseSerializer serializer,
+  );
+
+  @protected
   void sse_encode_box_autoadd_frb_research_job_state(
     FrbResearchJobState self,
     SseSerializer serializer,
@@ -634,6 +668,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   void sse_encode_f_64(double self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_frb_research_checkpoint(
+    FrbResearchCheckpoint self,
+    SseSerializer serializer,
+  );
 
   @protected
   void sse_encode_frb_research_event(
@@ -808,6 +848,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   void sse_encode_opt_box_autoadd_f_32(double? self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_opt_box_autoadd_frb_research_checkpoint(
+    FrbResearchCheckpoint? self,
+    SseSerializer serializer,
+  );
 
   @protected
   void sse_encode_opt_box_autoadd_frb_research_job_state(

--- a/packages/feature_mind/lib/src/services/voice_search_desktop.dart
+++ b/packages/feature_mind/lib/src/services/voice_search_desktop.dart
@@ -46,6 +46,8 @@ Future<String> _transcribeWithWhisper(String path) async {
       case whisper.TranscriptEvent_TranscriptReady(:final text):
         return text.trim();
       case whisper.TranscriptEvent_Transcribing():
+      case whisper.TranscriptEvent_Delta():
+      case whisper.TranscriptEvent_Degraded():
       case whisper.TranscriptEvent_Cancelled():
         break;
     }

--- a/packages/feature_mind/pubspec.lock
+++ b/packages/feature_mind/pubspec.lock
@@ -827,10 +827,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "31bd099b47c10cd1aeb55146a2d46ce0277630ecef3f7dae54ad7873f36696cd"
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.20"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
@@ -843,10 +843,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "307249ce4ff29d58a18e97f6345f539382eb9c9c29ecda628900f31de0443dd9"
+      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
       url: "https://pub.dev"
     source: hosted
-    version: "1.19.0"
+    version: "1.18.0"
   mime:
     dependency: transitive
     description:
@@ -1372,26 +1372,26 @@ packages:
     dependency: transitive
     description:
       name: test
-      sha256: ca578dc12bb8b2f40b67b7d3bd2fac4f31c01a6ff7130a14e2597b919934507f
+      sha256: "8d9ceddbab833f180fbefed08afa76d7c03513dfdba87ffcec2718b02bbcbf20"
       url: "https://pub.dev"
     source: hosted
-    version: "1.31.1"
+    version: "1.31.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "2a122cbe059f8b610d3a5415f42e255b6c17b1f21eee1d960f31080237fb4f11"
+      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.12"
+    version: "0.7.11"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: d2e98ec12998368dc59ddd47ab709f2cd55acd6b66dc7db764455a44082f4bc5
+      sha256: "1991d4cfe85d5043241acac92962c3977c8d2f2add1ee73130c7b286417d1d34"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.18"
+    version: "0.6.17"
   timezone:
     dependency: "direct main"
     description:
@@ -1484,10 +1484,10 @@ packages:
     dependency: transitive
     description:
       name: vector_math
-      sha256: f36f9f3be64c6198714492bb455c11056e33e2f85d9a0b676a48301e44fdcf47
+      sha256: d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.2"
+    version: "2.2.0"
   vm_service:
     dependency: transitive
     description:

--- a/packages/feature_mind/test/agent_chat/domain/services/research/rust_research_mapping_test.dart
+++ b/packages/feature_mind/test/agent_chat/domain/services/research/rust_research_mapping_test.dart
@@ -1,5 +1,6 @@
 import 'package:feature_mind/src/agent_chat/domain/models/research_event.dart';
 import 'package:feature_mind/src/agent_chat/domain/models/research_request.dart';
+import 'package:feature_mind/src/agent_chat/domain/services/research/research_checkpoint.dart';
 import 'package:feature_mind/src/agent_chat/domain/services/research/rust_research_mapping.dart';
 import 'package:feature_mind/src/llama/api/research.dart' as frb;
 import 'package:flutter_test/flutter_test.dart';
@@ -28,5 +29,22 @@ void main() {
     );
     expect(frbRequest.mode, frb.FrbResearchMode.quick);
     expect(frbRequest.policy, frb.FrbSearchPolicy.privacyFirst);
+  });
+
+  test('research checkpoint maps to FRB record wire', () {
+    const checkpoint = ResearchCheckpoint(
+      jobId: 'job-42',
+      question: 'What is Qwen?',
+      state: ResearchPhase.searching,
+      searchesUsed: 2,
+      iterationsUsed: 1,
+      mode: ResearchMode.deep,
+      policy: SearchPolicy.balanced,
+    );
+    final mapped = mapResearchCheckpoint(checkpoint);
+    expect(
+      ResearchCheckpoint.fromRecord(mapped.record),
+      checkpoint,
+    );
   });
 }

--- a/rust/airo_mind_core/src/research/engine.rs
+++ b/rust/airo_mind_core/src/research/engine.rs
@@ -13,7 +13,8 @@ use super::query::queries_for;
 use super::request::{ResearchRequest, SearchPolicy};
 use super::search::{SearchEngine, SearchHit, SearchRequest};
 use super::state::{
-    InMemoryResearchService, ResearchCommand, ResearchJobState, ResearchStateError,
+    InMemoryResearchService, ResearchCheckpoint, ResearchCommand, ResearchJobState,
+    ResearchStateError,
 };
 use super::stopping::{EvidenceSufficiencyPolicy, ResearchProgress, StopDecision, StoppingPolicy};
 
@@ -97,7 +98,19 @@ impl ResearchEngine {
         self.reports.get(job_id).map(String::as_str)
     }
 
-    pub fn run(&mut self, job_id: &str) -> Result<Vec<ResearchEvent>, ResearchStateError> {
+    pub fn checkpoint(&self, job_id: &str) -> Option<ResearchCheckpoint> {
+        self.service.checkpoint(job_id)
+    }
+
+    pub fn restore(&mut self, checkpoint: ResearchCheckpoint) -> Result<(), ResearchStateError> {
+        self.service.restore(checkpoint)
+    }
+
+    pub fn run(
+        &mut self,
+        job_id: &str,
+        known_source_urls: &[String],
+    ) -> Result<Vec<ResearchEvent>, ResearchStateError> {
         let checkpoint = self
             .service
             .checkpoint(job_id)
@@ -214,7 +227,10 @@ impl ResearchEngine {
             &mut searches_used,
             &mut hits,
         );
-        let mut unique = super::search::dedupe_hits(hits.clone());
+        let mut unique = filter_known_hits(
+            super::search::dedupe_hits(hits.clone()),
+            known_source_urls,
+        );
         let progress = ResearchProgress {
             searches_used,
             max_searches: budget.max_searches,
@@ -239,7 +255,7 @@ impl ResearchEngine {
                 &mut searches_used,
                 &mut hits,
             );
-            unique = super::search::dedupe_hits(hits);
+            unique = filter_known_hits(super::search::dedupe_hits(hits), known_source_urls);
         }
         self.service
             .apply(job_id, ResearchCommand::SearchFinished)?;
@@ -385,6 +401,18 @@ struct Acquired {
     paragraphs: Vec<String>,
     tables: Vec<String>,
     class: super::document::SourceClassification,
+}
+
+fn filter_known_hits(mut hits: Vec<SearchHit>, known_source_urls: &[String]) -> Vec<SearchHit> {
+    if known_source_urls.is_empty() {
+        return hits;
+    }
+    let skip: std::collections::BTreeSet<String> = known_source_urls
+        .iter()
+        .map(|url| super::search::canonicalize_url(url))
+        .collect();
+    hits.retain(|hit| !skip.contains(&super::search::canonicalize_url(&hit.url)));
+    hits
 }
 
 fn event(
@@ -565,7 +593,7 @@ mod tests {
         let mut engine =
             ResearchEngine::new(vec![Box::new(search)], Box::new(fetch));
         let job_id = engine.start(quick("   "));
-        let events = engine.run(&job_id).expect("empty questions still admit");
+        let events = engine.run(&job_id, &[]).expect("empty questions still admit");
         assert_eq!(
             events.last().map(|e| e.kind),
             Some(ResearchEventKind::Failed)
@@ -585,7 +613,7 @@ mod tests {
             ResearchEngine::new(vec![Box::new(search)], Box::new(fetch));
         let job_id = engine.start(quick("What is Qwen?"));
         assert_eq!(engine.status(&job_id), Some(ResearchJobState::Created));
-        let events = engine.run(&job_id).expect("run");
+        let events = engine.run(&job_id, &[]).expect("run");
         assert_eq!(
             events.last().map(|e| e.kind),
             Some(ResearchEventKind::Completed)
@@ -620,7 +648,7 @@ mod tests {
         let job_id = engine.start(quick("What is Qwen?"));
         engine.cancel(&job_id).unwrap();
         let events = engine
-            .run(&job_id)
+            .run(&job_id, &[])
             .expect("cancelled jobs still run to a terminal event");
         assert!(events
             .iter()
@@ -644,13 +672,13 @@ mod tests {
             ResearchEngine::new(vec![Box::new(search)], Box::new(fetch));
         let job_id = engine.start(quick("What is Qwen?"));
         engine.pause(&job_id).unwrap();
-        let paused = engine.run(&job_id).unwrap();
+        let paused = engine.run(&job_id, &[]).unwrap();
         assert!(paused.iter().any(|e| e.kind == ResearchEventKind::Paused));
         assert!(!paused
             .iter()
             .any(|e| e.kind == ResearchEventKind::Completed));
         engine.resume(&job_id).unwrap();
-        let events = engine.run(&job_id).unwrap();
+        let events = engine.run(&job_id, &[]).unwrap();
         assert_eq!(
             events.last().map(|e| e.kind),
             Some(ResearchEventKind::Completed)
@@ -662,6 +690,28 @@ mod tests {
     fn local_only_allows_research_library_memory() {
         assert!(engine_allowed(SearchPolicy::LocalOnly, "local_memory"));
         assert!(!engine_allowed(SearchPolicy::LocalOnly, "wikipedia"));
+    }
+
+    #[test]
+    fn known_library_urls_skip_re_fetch() {
+        let search = FakeSearch {
+            id: "wikipedia",
+            url: "https://en.wikipedia.org/wiki/Qwen",
+            snippet: "SEARCH SNIPPET ONLY",
+        };
+        let fetch = FakeFetch { body: PAGE };
+        let mut engine =
+            ResearchEngine::new(vec![Box::new(search)], Box::new(fetch));
+        let job_id = engine.start(quick("What is Qwen?"));
+        let events = engine
+            .run(
+                &job_id,
+                &["https://en.wikipedia.org/wiki/Qwen".to_string()],
+            )
+            .expect("run");
+        assert!(!events
+            .iter()
+            .any(|event| event.kind == ResearchEventKind::SourceFetched));
     }
 
     #[test]

--- a/rust/airo_mind_llama/src/api/research.rs
+++ b/rust/airo_mind_llama/src/api/research.rs
@@ -8,7 +8,7 @@ use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use airo_mind_core::research::{
-    ResearchEngine, ResearchEvent as CoreEvent, ResearchEventKind as CoreKind,
+    ResearchCheckpoint, ResearchEngine, ResearchEvent as CoreEvent, ResearchEventKind as CoreKind,
     ResearchJobState as CoreJobState, ResearchRequest as CoreRequest, ResearchMode,
     SearchEngine, SearchError, SearchHit, SearchPolicy, SearchRequest, SearchResponse,
     SourceFetcher,
@@ -258,6 +258,36 @@ pub fn research_cancel(handle: &ResearchServiceHandle, job_id: String) -> Result
         .map_err(|error| error.to_string())
 }
 
+pub struct FrbResearchCheckpoint {
+    pub record: String,
+}
+
+#[frb(sync)]
+pub fn research_checkpoint(
+    handle: &ResearchServiceHandle,
+    job_id: String,
+) -> Option<FrbResearchCheckpoint> {
+    let engine = handle.engine.lock().expect("research engine lock");
+    engine.checkpoint(&job_id).map(|checkpoint| FrbResearchCheckpoint {
+        record: checkpoint.to_record(),
+    })
+}
+
+#[frb(sync)]
+pub fn research_restore(
+    handle: &ResearchServiceHandle,
+    checkpoint: FrbResearchCheckpoint,
+) -> Result<(), String> {
+    let checkpoint = ResearchCheckpoint::from_record(&checkpoint.record)
+        .map_err(|error| error.to_string())?;
+    handle
+        .engine
+        .lock()
+        .expect("research engine lock")
+        .restore(checkpoint)
+        .map_err(|error| error.to_string())
+}
+
 #[frb(sync)]
 pub fn research_report(handle: &ResearchServiceHandle, job_id: String) -> Option<String> {
     let engine = handle.engine.lock().expect("research engine lock");
@@ -268,6 +298,7 @@ pub fn research_report(handle: &ResearchServiceHandle, job_id: String) -> Option
 pub async fn research_run(
     handle: &ResearchServiceHandle,
     job_id: String,
+    known_source_urls: Vec<String>,
     sink: StreamSink<FrbResearchEvent>,
 ) -> Result<(), String> {
     let engine = Arc::clone(&handle.engine);
@@ -277,7 +308,7 @@ pub async fn research_run(
     std::thread::spawn(move || {
         let result = {
             let mut engine = engine.lock().expect("research engine lock");
-            engine.run(&job_id_for_thread)
+            engine.run(&job_id_for_thread, &known_source_urls)
         };
         let _ = done_tx.send(result);
     });

--- a/rust/airo_mind_llama/src/frb_generated.rs
+++ b/rust/airo_mind_llama/src/frb_generated.rs
@@ -38,7 +38,7 @@ flutter_rust_bridge::frb_generated_boilerplate!(
     default_rust_auto_opaque = RustAutoOpaqueMoi,
 );
 pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_VERSION: &str = "2.11.1";
-pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = -1730392733;
+pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = -1641887784;
 
 // Section: executor
 
@@ -497,6 +497,58 @@ fn wire__crate__api__research__research_cancel_impl(
         },
     )
 }
+fn wire__crate__api__research__research_checkpoint_impl(
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) -> flutter_rust_bridge::for_generated::WireSyncRust2DartSse {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_sync::<flutter_rust_bridge::for_generated::SseCodec, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "research_checkpoint",
+            port: None,
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Sync,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_handle = <RustOpaqueMoi<
+                flutter_rust_bridge::for_generated::RustAutoOpaqueInner<ResearchServiceHandle>,
+            >>::sse_decode(&mut deserializer);
+            let api_job_id = <String>::sse_decode(&mut deserializer);
+            deserializer.end();
+            transform_result_sse::<_, ()>((move || {
+                let mut api_handle_guard = None;
+                let decode_indices_ =
+                    flutter_rust_bridge::for_generated::lockable_compute_decode_order(vec![
+                        flutter_rust_bridge::for_generated::LockableOrderInfo::new(
+                            &api_handle,
+                            0,
+                            false,
+                        ),
+                    ]);
+                for i in decode_indices_ {
+                    match i {
+                        0 => api_handle_guard = Some(api_handle.lockable_decode_sync_ref()),
+                        _ => unreachable!(),
+                    }
+                }
+                let api_handle_guard = api_handle_guard.unwrap();
+                let output_ok = Result::<_, ()>::Ok(crate::api::research::research_checkpoint(
+                    &*api_handle_guard,
+                    api_job_id,
+                ))?;
+                Ok(output_ok)
+            })())
+        },
+    )
+}
 fn wire__crate__api__research__research_pause_impl(
     ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
     rust_vec_len_: i32,
@@ -599,6 +651,57 @@ fn wire__crate__api__research__research_report_impl(
         },
     )
 }
+fn wire__crate__api__research__research_restore_impl(
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) -> flutter_rust_bridge::for_generated::WireSyncRust2DartSse {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_sync::<flutter_rust_bridge::for_generated::SseCodec, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "research_restore",
+            port: None,
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Sync,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_handle = <RustOpaqueMoi<
+                flutter_rust_bridge::for_generated::RustAutoOpaqueInner<ResearchServiceHandle>,
+            >>::sse_decode(&mut deserializer);
+            let api_checkpoint =
+                <crate::api::research::FrbResearchCheckpoint>::sse_decode(&mut deserializer);
+            deserializer.end();
+            transform_result_sse::<_, String>((move || {
+                let mut api_handle_guard = None;
+                let decode_indices_ =
+                    flutter_rust_bridge::for_generated::lockable_compute_decode_order(vec![
+                        flutter_rust_bridge::for_generated::LockableOrderInfo::new(
+                            &api_handle,
+                            0,
+                            false,
+                        ),
+                    ]);
+                for i in decode_indices_ {
+                    match i {
+                        0 => api_handle_guard = Some(api_handle.lockable_decode_sync_ref()),
+                        _ => unreachable!(),
+                    }
+                }
+                let api_handle_guard = api_handle_guard.unwrap();
+                let output_ok =
+                    crate::api::research::research_restore(&*api_handle_guard, api_checkpoint)?;
+                Ok(output_ok)
+            })())
+        },
+    )
+}
 fn wire__crate__api__research__research_resume_impl(
     ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
     rust_vec_len_: i32,
@@ -675,6 +778,7 @@ fn wire__crate__api__research__research_run_impl(
                 flutter_rust_bridge::for_generated::RustAutoOpaqueInner<ResearchServiceHandle>,
             >>::sse_decode(&mut deserializer);
             let api_job_id = <String>::sse_decode(&mut deserializer);
+            let api_known_source_urls = <Vec<String>>::sse_decode(&mut deserializer);
             let api_sink = <StreamSink<
                 crate::api::research::FrbResearchEvent,
                 flutter_rust_bridge::for_generated::SseCodec,
@@ -705,6 +809,7 @@ fn wire__crate__api__research__research_run_impl(
                         let output_ok = crate::api::research::research_run(
                             &*api_handle_guard,
                             api_job_id,
+                            api_known_source_urls,
                             api_sink,
                         )
                         .await?;
@@ -1054,6 +1159,14 @@ impl SseDecode for f64 {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
         deserializer.cursor.read_f64::<NativeEndian>().unwrap()
+    }
+}
+
+impl SseDecode for crate::api::research::FrbResearchCheckpoint {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut var_record = <String>::sse_decode(deserializer);
+        return crate::api::research::FrbResearchCheckpoint { record: var_record };
     }
 }
 
@@ -1572,6 +1685,19 @@ impl SseDecode for Option<f32> {
     }
 }
 
+impl SseDecode for Option<crate::api::research::FrbResearchCheckpoint> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        if (<bool>::sse_decode(deserializer)) {
+            return Some(<crate::api::research::FrbResearchCheckpoint>::sse_decode(
+                deserializer,
+            ));
+        } else {
+            return None;
+        }
+    }
+}
+
 impl SseDecode for Option<crate::api::research::FrbResearchJobState> {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
@@ -1818,7 +1944,7 @@ fn pde_ffi_dispatcher_primary_impl(
             data_len,
         ),
         12 => wire__crate__api__reasoning__reason_impl(port, ptr, rust_vec_len, data_len),
-        17 => wire__crate__api__research__research_run_impl(port, ptr, rust_vec_len, data_len),
+        19 => wire__crate__api__research__research_run_impl(port, ptr, rust_vec_len, data_len),
         _ => unreachable!(),
     }
 }
@@ -1842,12 +1968,14 @@ fn pde_ffi_dispatcher_sync_impl(
         8 => wire__crate__api__minutes__generation_stats_impl(ptr, rust_vec_len, data_len),
         10 => wire__crate__api__minutes__is_ready_impl(ptr, rust_vec_len, data_len),
         13 => wire__crate__api__research__research_cancel_impl(ptr, rust_vec_len, data_len),
-        14 => wire__crate__api__research__research_pause_impl(ptr, rust_vec_len, data_len),
-        15 => wire__crate__api__research__research_report_impl(ptr, rust_vec_len, data_len),
-        16 => wire__crate__api__research__research_resume_impl(ptr, rust_vec_len, data_len),
-        18 => wire__crate__api__research__research_start_impl(ptr, rust_vec_len, data_len),
-        19 => wire__crate__api__research__research_status_impl(ptr, rust_vec_len, data_len),
-        20 => wire__crate__api__minutes__unload_generation_impl(ptr, rust_vec_len, data_len),
+        14 => wire__crate__api__research__research_checkpoint_impl(ptr, rust_vec_len, data_len),
+        15 => wire__crate__api__research__research_pause_impl(ptr, rust_vec_len, data_len),
+        16 => wire__crate__api__research__research_report_impl(ptr, rust_vec_len, data_len),
+        17 => wire__crate__api__research__research_restore_impl(ptr, rust_vec_len, data_len),
+        18 => wire__crate__api__research__research_resume_impl(ptr, rust_vec_len, data_len),
+        20 => wire__crate__api__research__research_start_impl(ptr, rust_vec_len, data_len),
+        21 => wire__crate__api__research__research_status_impl(ptr, rust_vec_len, data_len),
+        22 => wire__crate__api__minutes__unload_generation_impl(ptr, rust_vec_len, data_len),
         _ => unreachable!(),
     }
 }
@@ -1874,6 +2002,23 @@ impl flutter_rust_bridge::IntoIntoDart<FrbWrapper<ResearchServiceHandle>>
     }
 }
 
+// Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for crate::api::research::FrbResearchCheckpoint {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        [self.record.into_into_dart().into_dart()].into_dart()
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
+    for crate::api::research::FrbResearchCheckpoint
+{
+}
+impl flutter_rust_bridge::IntoIntoDart<crate::api::research::FrbResearchCheckpoint>
+    for crate::api::research::FrbResearchCheckpoint
+{
+    fn into_into_dart(self) -> crate::api::research::FrbResearchCheckpoint {
+        self
+    }
+}
 // Codec=Dco (DartCObject based), see doc to use other codecs
 impl flutter_rust_bridge::IntoDart for crate::api::research::FrbResearchEvent {
     fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
@@ -2658,6 +2803,13 @@ impl SseEncode for f64 {
     }
 }
 
+impl SseEncode for crate::api::research::FrbResearchCheckpoint {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <String>::sse_encode(self.record, serializer);
+    }
+}
+
 impl SseEncode for crate::api::research::FrbResearchEvent {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
@@ -3095,6 +3247,16 @@ impl SseEncode for Option<f32> {
         <bool>::sse_encode(self.is_some(), serializer);
         if let Some(value) = self {
             <f32>::sse_encode(value, serializer);
+        }
+    }
+}
+
+impl SseEncode for Option<crate::api::research::FrbResearchCheckpoint> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <bool>::sse_encode(self.is_some(), serializer);
+        if let Some(value) = self {
+            <crate::api::research::FrbResearchCheckpoint>::sse_encode(value, serializer);
         }
     }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Task 6 closes the production gap between the Dart orchestrator and the Rust `ResearchService` FRB path.

- **Checkpoint restore:** `research_checkpoint` / `research_restore` FRB APIs using the shared v2 operation-log record wire format
- **Library delta:** `research_run` accepts `knownSourceUrls`; Rust engine skips re-fetching canonical URLs already in the research library
- **Dart shim parity:** `RustResearchService` restores paused jobs, emits `onCheckpoint` on pause, calls `onLibrary` on completion, and forwards known URLs
- **Production wiring:** `ChatScreen` passes `operationLogPort` into the default `LocalDeepResearchEngine`, enabling the local-memory search adapter without custom host injection

## Test plan

- [x] `cargo test -p airo_mind_core --lib research::engine::tests` (7 tests, including `known_library_urls_skip_re_fetch`)
- [x] `flutter test` on rust research mapping/service, deep research engine, and chat deep research screen tests (18 tests)
- [x] Regenerated llama FRB bindings via `scripts/regenerate-mind-llama-frb.sh`

## Follow-ups (still not shipped per design spec)

- HTTP response cache
- Automatic continuation without user reattachment after process restart
- Full event-stream parity for gap analysis / validation phases
- Weighted decision scoring beyond contested-row flags
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0d1a1368-352c-43c3-b66e-d4ae3a878dd5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0d1a1368-352c-43c3-b66e-d4ae3a878dd5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

