### PR TITLE
feat(mind): live transcript UX, vocabulary intelligence, and speaker activity

### DIFF
--- a/docs/superpowers/specs/2026-08-22-live-transcript-ux-vocabulary-design.md
+++ b/docs/superpowers/specs/2026-08-22-live-transcript-ux-vocabulary-design.md
@@ -20,7 +20,7 @@ post-hoc normalize pass, not part of the live understanding pipeline.
 | LIVE + timer in app bar | `meeting_capture_live_badge` |
 | Speaker labels | `Speaker 1` / `spN` → `Speaker N+1` (no invented names) |
 | Follow live + jump to live | `LiveTranscriptView` + `Follow live` chip |
-| Secondary waveform | `_AudioActivityBar` (decorative, not hero) |
+| Secondary waveform | `AudioAmplitudeMeter` (live RMS, not hero) |
 | Focused capture mode | Pre-start vs active body split; nav de-emphasized via full-screen transcript |
 | Pause / stop / timer | `LiveCaptureControls` |
 
@@ -28,11 +28,35 @@ post-hoc normalize pass, not part of the live understanding pipeline.
 
 | Requirement | Status |
 |---|---|
+| **Live speaker activity** (provisional lanes, reconciled after recording) | ✓ `SpeakerActivityTracker` + `SpeakerActivityTimeline` |
+| Live amplitude meter (not speaker-colored bars) | ✓ `AudioAmplitudeMeter` from PCM shim RMS |
 | Collapsible live insights rail | `LiveInsightsRail` stub |
 | Live entity / decision / action detection | Not in this PR |
 | Search during recording | Not in this PR |
-| Speaker name resolution | Not in this PR |
+| Speaker name resolution (persona mapping) | P2 — not in this PR |
+| Voice enrollment / recognition | P2 — not in this PR |
 | More menu (mic, language, …) | Not in this PR |
+
+### P1 — Live speaker activity
+
+During recording, Airo Mind provides **provisional** speaker activity on short
+rolling windows and exposes the active speaker to the live visualization and
+transcript. Live speaker assignments are **not** persona recognition — they are
+`Speaker 0` / `Speaker 1` turn-taking heuristics on VAD utterance boundaries.
+Post-recording diarization may reconcile live labels with the final speaker model.
+
+Architecture:
+
+```text
+Mic → Audio stream
+        ├──────────────→ Amplitude → AudioAmplitudeMeter
+        └──────────────→ Streaming VAD → Speaker activity → Speaker timeline
+```
+
+- Rust: `airo_mind_audio::SpeakerActivityTracker` (long-gap turn toggle)
+- Rust: `meetings.rs` assigns `sp{N}` on STABLE; PARTIAL uses active lane
+- Dart: `SpeakerActivityTimeline` — per-speaker lanes, not colored amplitude bars
+- Dart: `MeetingLiveSessionCoordinator.speakerActivitySpans` from stable segments
 
 ## Vocabulary Intelligence — P0
 
@@ -64,7 +88,7 @@ User spec items:
 2. Compact privacy banner — ✓ P0
 3. Live transcript states — ✓ P0
 4. Live indicator — ✓ P0
-5. Speaker identification — ✓ P0 (generic labels)
+5. Speaker identification — ✓ P0 (generic labels); P1 live activity lanes
 6. Intelligence rail — stub P1
 7. Bottom controls — ✓ P0
 8. Transcript navigation / jump to live — ✓ P0
@@ -81,5 +105,7 @@ User spec items:
 ## Tests
 
 - `airo_mind_transcript` vocabulary unit tests
+- `airo_mind_audio` `SpeakerActivityTracker` unit tests
 - `live_speaker_label` / coordinator line mapping (Dart)
+- `speaker_activity_timeline` / `audio_amplitude_meter` widget tests (Dart)
 - Capture screen pre-start tests updated for compact trust bar

--- a/docs/superpowers/specs/2026-08-22-live-transcript-ux-vocabulary-design.md
+++ b/docs/superpowers/specs/2026-08-22-live-transcript-ux-vocabulary-design.md
@@ -1,0 +1,85 @@
+# Live transcript UX + Vocabulary Intelligence
+
+Status: **Accepted** (implementation in progress)
+Date: 2026-08-22
+Companion: [`2026-08-22-streaming-stt-zero-copy-design.md`](./2026-08-22-streaming-stt-zero-copy-design.md), ADR-0025
+
+## Problem
+
+Meeting capture reads as a **recorder** (timer + empty space) rather than an
+**intelligent live transcription** surface. Vocabulary correction was a
+post-hoc normalize pass, not part of the live understanding pipeline.
+
+## UX — P0 (this change)
+
+| Requirement | Implementation |
+|---|---|
+| Live transcript primary (~65–75% height) | `LiveTranscriptView` in active capture layout |
+| Compact privacy bar | `CompactTrustStatusBar` + detail bottom sheet |
+| PARTIAL / STABLE / FINAL rendering | Partial tail with `▌`; stable committed text |
+| LIVE + timer in app bar | `meeting_capture_live_badge` |
+| Speaker labels | `Speaker 1` / `spN` → `Speaker N+1` (no invented names) |
+| Follow live + jump to live | `LiveTranscriptView` + `Follow live` chip |
+| Secondary waveform | `_AudioActivityBar` (decorative, not hero) |
+| Focused capture mode | Pre-start vs active body split; nav de-emphasized via full-screen transcript |
+| Pause / stop / timer | `LiveCaptureControls` |
+
+## UX — P1 (stub / follow-up)
+
+| Requirement | Status |
+|---|---|
+| Collapsible live insights rail | `LiveInsightsRail` stub |
+| Live entity / decision / action detection | Not in this PR |
+| Search during recording | Not in this PR |
+| Speaker name resolution | Not in this PR |
+| More menu (mic, language, …) | Not in this PR |
+
+## Vocabulary Intelligence — P0
+
+Pipeline position:
+
+```text
+STT → Transcript Stabilizer → Vocabulary Intelligence → Live UI / IR
+```
+
+- Module: `rust/airo_mind_transcript/src/vocabulary.rs`
+- Types: `VocabularyContext`, `VocabularyEntry`, `VocabularyIntelligence`
+- Matching order: exact/phrase (aliases) → technical `normalize` → fuzzy word (Levenshtein ≤2, confidence ≥0.85)
+- Runs on **STABLE/FINAL** live segments only (`meetings.rs` `emit_live_delta`)
+- Preserves `original_text` in `CorrectionResult`; provenance list in Rust (FRB/IR wire follow-up)
+- **No LLM** on the hot path
+
+### P1 vocabulary (documented, not this PR)
+
+- User / project / domain / conversation layers populated from settings
+- Phonetic index beyond alias tables
+- Learning from user corrections
+- Full Conversation IR provenance JSON on save
+
+## Requirement traceability
+
+User spec items:
+
+1. Transcript primary — ✓ P0
+2. Compact privacy banner — ✓ P0
+3. Live transcript states — ✓ P0
+4. Live indicator — ✓ P0
+5. Speaker identification — ✓ P0 (generic labels)
+6. Intelligence rail — stub P1
+7. Bottom controls — ✓ P0
+8. Transcript navigation / jump to live — ✓ P0
+9. Simplified nav during recording — ✓ P0 (layout)
+10. Follow speaker — ✓ P0 (`Follow live`)
+11. Vocabulary two-path (not only post-stop) — ✓ P0 on stable live path
+12. Not blind Levenshtein — layered matching + confidence threshold
+13. Vocabulary context layers — types + global defaults; population P1
+14. Confidence-based correction — ✓
+15. Preserve raw transcript — ✓ in `CorrectionResult`
+16. Stable-only correction for UI stability — ✓
+17. No LLM in core vocabulary path — ✓
+
+## Tests
+
+- `airo_mind_transcript` vocabulary unit tests
+- `live_speaker_label` / coordinator line mapping (Dart)
+- Capture screen pre-start tests updated for compact trust bar

--- a/docs/superpowers/specs/2026-08-22-live-transcript-ux-vocabulary-design.md
+++ b/docs/superpowers/specs/2026-08-22-live-transcript-ux-vocabulary-design.md
@@ -57,6 +57,8 @@ Mic → Audio stream
 - Rust: `meetings.rs` assigns `sp{N}` on STABLE; PARTIAL uses active lane
 - Dart: `SpeakerActivityTimeline` — per-speaker lanes, not colored amplitude bars
 - Dart: `MeetingLiveSessionCoordinator.speakerActivitySpans` from stable segments
+- Pause/resume stops interim PCM shim ingestion and skips ring push while paused (`push_live_pcm`)
+- `TranscriptEvent::Degraded` surfaced in capture UI (`meeting_capture_live_degraded`)
 
 ## Vocabulary Intelligence — P0
 

--- a/packages/feature_mind/lib/src/capture/application/live_pcm_shim_port.dart
+++ b/packages/feature_mind/lib/src/capture/application/live_pcm_shim_port.dart
@@ -1,0 +1,17 @@
+/// PCM fan-out shim for live STT — interim desktop until native capture lands.
+abstract interface class LivePcmShimPort {
+  /// Normalized RMS (0–1) for the live amplitude meter — not speaker identity.
+  void Function(double normalizedRms)? onAmplitude;
+
+  Future<void> start({required String sessionId});
+
+  /// Stops ingesting PCM without tearing down the recorder instance.
+  Future<void> pause();
+
+  /// Resumes PCM ingestion after [pause].
+  Future<void> resume({required String sessionId});
+
+  Future<void> stop();
+
+  Future<void> dispose();
+}

--- a/packages/feature_mind/lib/src/capture/application/meeting_live_pcm_shim.dart
+++ b/packages/feature_mind/lib/src/capture/application/meeting_live_pcm_shim.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:math' show sqrt;
 import 'dart:typed_data';
 
 import 'package:record/record.dart';
@@ -17,6 +18,9 @@ class MeetingLivePcmShim {
   final AudioRecorder _recorder;
   StreamSubscription<Uint8List>? _subscription;
 
+  /// Normalized RMS (0–1) for the live amplitude meter — not speaker identity.
+  void Function(double normalizedRms)? onAmplitude;
+
   static const _streamConfig = RecordConfig(
     encoder: AudioEncoder.pcm16bits,
     sampleRate: 16000,
@@ -28,6 +32,8 @@ class MeetingLivePcmShim {
     _subscription = stream.listen((chunk) {
       if (chunk.isEmpty) return;
       final samples = _bytesToInt16(chunk);
+      final rms = _rmsEnergy(samples);
+      onAmplitude?.call(_normalizeRms(rms));
       rust.pushLivePcm(sessionId: sessionId, samples: samples);
     });
   }
@@ -50,4 +56,17 @@ class MeetingLivePcmShim {
     }
     return out;
   }
+
+  double _rmsEnergy(List<int> samples) {
+    if (samples.isEmpty) return 0;
+    var sum = 0.0;
+    for (final sample in samples) {
+      final v = sample / 32768.0;
+      sum += v * v;
+    }
+    return sqrt(sum / samples.length);
+  }
+
+  /// Maps typical speech RMS (~0.01–0.15) into 0–1 for the meter.
+  double _normalizeRms(double rms) => (rms / 0.15).clamp(0.0, 1.0);
 }

--- a/packages/feature_mind/lib/src/capture/application/meeting_live_pcm_shim.dart
+++ b/packages/feature_mind/lib/src/capture/application/meeting_live_pcm_shim.dart
@@ -5,20 +5,22 @@ import 'dart:typed_data';
 import 'package:record/record.dart';
 
 import '../../whisper/api/meetings.dart' as rust;
+import 'live_pcm_shim_port.dart';
 
 /// Interim desktop shim: `record.startStream` → `push_live_pcm`.
 ///
 /// Documented violation of ZC-1 in `LIVE_CAPTURE_FAN_OUT.md` §Interim shim.
 /// Uses a second [AudioRecorder] beside the file encoder until native fan-out
 /// lands on this platform.
-class MeetingLivePcmShim {
+class MeetingLivePcmShim implements LivePcmShimPort {
   MeetingLivePcmShim({AudioRecorder? streamRecorder})
     : _recorder = streamRecorder ?? AudioRecorder();
 
   final AudioRecorder _recorder;
   StreamSubscription<Uint8List>? _subscription;
+  bool _paused = false;
 
-  /// Normalized RMS (0–1) for the live amplitude meter — not speaker identity.
+  @override
   void Function(double normalizedRms)? onAmplitude;
 
   static const _streamConfig = RecordConfig(
@@ -27,24 +29,45 @@ class MeetingLivePcmShim {
     numChannels: 1,
   );
 
+  @override
   Future<void> start({required String sessionId}) async {
+    _paused = false;
     final stream = await _recorder.startStream(_streamConfig);
-    _subscription = stream.listen((chunk) {
-      if (chunk.isEmpty) return;
-      final samples = _bytesToInt16(chunk);
-      final rms = _rmsEnergy(samples);
-      onAmplitude?.call(_normalizeRms(rms));
-      rust.pushLivePcm(sessionId: sessionId, samples: samples);
-    });
+    _subscription = stream.listen((chunk) => _onChunk(sessionId, chunk));
   }
 
-  Future<void> stop() async {
+  @override
+  Future<void> pause() async {
+    _paused = true;
     await _subscription?.cancel();
     _subscription = null;
     await _recorder.stop();
   }
 
+  @override
+  Future<void> resume({required String sessionId}) async {
+    if (!_paused) return;
+    await start(sessionId: sessionId);
+  }
+
+  @override
+  Future<void> stop() async {
+    _paused = false;
+    await _subscription?.cancel();
+    _subscription = null;
+    await _recorder.stop();
+  }
+
+  @override
   Future<void> dispose() => _recorder.dispose();
+
+  void _onChunk(String sessionId, Uint8List chunk) {
+    if (_paused || chunk.isEmpty) return;
+    final samples = _bytesToInt16(chunk);
+    final rms = _rmsEnergy(samples);
+    onAmplitude?.call(_normalizeRms(rms));
+    rust.pushLivePcm(sessionId: sessionId, samples: samples);
+  }
 
   List<int> _bytesToInt16(Uint8List bytes) {
     final aligned = bytes.length.isEven ? bytes : bytes.sublist(0, bytes.length - 1);

--- a/packages/feature_mind/lib/src/capture/application/meeting_live_session_coordinator.dart
+++ b/packages/feature_mind/lib/src/capture/application/meeting_live_session_coordinator.dart
@@ -4,6 +4,7 @@ import '../../bridges/mind_speech_bridge.dart';
 import '../../whisper/api/meetings.dart' as rust;
 import '../domain/live_speaker_label.dart';
 import '../domain/live_transcript_line.dart';
+import '../domain/speaker_activity_span.dart';
 import 'meeting_live_pcm_shim.dart';
 
 /// Result of a completed live STT session.
@@ -38,6 +39,30 @@ class MeetingLiveSessionCoordinator {
   List<TranscriptSegment> get stableSegments =>
       List<TranscriptSegment>.unmodifiable(_stableSegments);
 
+  /// Recent normalized amplitude samples for the live meter (oldest first).
+  List<double> get amplitudeSamples =>
+      List<double>.unmodifiable(_amplitudeSamples);
+
+  /// Provisional speaker lanes derived from stable utterances (`P1`).
+  List<SpeakerActivitySpan> get speakerActivitySpans {
+    return [
+      for (final segment in _stableSegments)
+        if (parseLiveSpeakerIndex(segment.speakerLabel) != null)
+          SpeakerActivitySpan(
+            speakerIndex: parseLiveSpeakerIndex(segment.speakerLabel)!,
+            startMs: segment.startMs,
+            endMs: segment.endMs,
+          ),
+    ];
+  }
+
+  int get speakerTimelineEndMs {
+    if (_stableSegments.isEmpty) return 0;
+    return _stableSegments.last.endMs;
+  }
+
+  int? get activeSpeakerIndex => _activeSpeakerIndex;
+
   /// Rows for the live transcript UI (stable + optional partial tail).
   List<LiveTranscriptLine> get transcriptLines {
     final lines = <LiveTranscriptLine>[
@@ -51,7 +76,9 @@ class MeetingLiveSessionCoordinator {
         ),
     ];
     if (_partialText != null && _partialText!.isNotEmpty) {
-      final tailSpeaker = _stableSegments.isNotEmpty
+      final tailSpeaker = _activeSpeakerLabel != null
+          ? formatLiveSpeakerLabel(_activeSpeakerLabel)
+          : _stableSegments.isNotEmpty
           ? formatLiveSpeakerLabel(_stableSegments.last.speakerLabel)
           : formatLiveSpeakerLabel(null);
       final tailStart = _stableSegments.isNotEmpty
@@ -71,7 +98,10 @@ class MeetingLiveSessionCoordinator {
   }
 
   String? _partialText;
+  String? _activeSpeakerLabel;
+  int? _activeSpeakerIndex;
   final List<TranscriptSegment> _stableSegments = [];
+  final List<double> _amplitudeSamples = [];
 
   Future<void> start({
     required String meetingId,
@@ -80,7 +110,12 @@ class MeetingLiveSessionCoordinator {
     _sessionId = meetingId;
     _readyCompleter = Completer<MeetingLiveSessionResult>();
     _partialText = null;
+    _activeSpeakerLabel = null;
+    _activeSpeakerIndex = null;
     _stableSegments.clear();
+    _amplitudeSamples.clear();
+
+    _pcmShim.onAmplitude = _onAmplitude;
 
     final stream = _speech.startLiveSession(
       meetingId: meetingId,
@@ -126,11 +161,21 @@ class MeetingLiveSessionCoordinator {
     await _eventsSub?.cancel();
     _eventsSub = null;
     _sessionId = null;
+    _pcmShim.onAmplitude = null;
   }
 
   Future<void> dispose() async {
     await cancel();
     await _pcmShim.dispose();
+  }
+
+  void _onAmplitude(double normalizedRms) {
+    _amplitudeSamples.add(normalizedRms);
+    const maxSamples = 12;
+    if (_amplitudeSamples.length > maxSamples) {
+      _amplitudeSamples.removeAt(0);
+    }
+    onTranscriptChanged?.call();
   }
 
   void _onEvent(TranscriptEvent event) {
@@ -139,8 +184,14 @@ class MeetingLiveSessionCoordinator {
         switch (delta.state) {
           case rust.TranscriptSegmentStateWire.partial:
             _partialText = delta.text;
+            if (delta.speakerLabel != null) {
+              _activeSpeakerLabel = delta.speakerLabel;
+              _activeSpeakerIndex = parseLiveSpeakerIndex(delta.speakerLabel);
+            }
           case rust.TranscriptSegmentStateWire.stable:
             _partialText = null;
+            _activeSpeakerLabel = delta.speakerLabel;
+            _activeSpeakerIndex = parseLiveSpeakerIndex(delta.speakerLabel);
             _stableSegments.add(
               TranscriptSegment(
                 id: delta.segmentId,
@@ -160,6 +211,8 @@ class MeetingLiveSessionCoordinator {
                 text: delta.text,
                 speakerLabel: delta.speakerLabel,
               );
+              _activeSpeakerLabel = delta.speakerLabel;
+              _activeSpeakerIndex = parseLiveSpeakerIndex(delta.speakerLabel);
             }
         }
       case TranscriptEventTranscriptReady(:final text, :final segments):

--- a/packages/feature_mind/lib/src/capture/application/meeting_live_session_coordinator.dart
+++ b/packages/feature_mind/lib/src/capture/application/meeting_live_session_coordinator.dart
@@ -5,6 +5,7 @@ import '../../whisper/api/meetings.dart' as rust;
 import '../domain/live_speaker_label.dart';
 import '../domain/live_transcript_line.dart';
 import '../domain/speaker_activity_span.dart';
+import 'live_pcm_shim_port.dart';
 import 'meeting_live_pcm_shim.dart';
 
 /// Result of a completed live STT session.
@@ -22,13 +23,13 @@ class MeetingLiveSessionResult {
 class MeetingLiveSessionCoordinator {
   MeetingLiveSessionCoordinator({
     MindSpeechBridge? speechBridge,
-    MeetingLivePcmShim? pcmShim,
+    LivePcmShimPort? pcmShim,
     this.onTranscriptChanged,
   }) : _speech = speechBridge ?? const RustMindSpeechBridge(),
        _pcmShim = pcmShim ?? MeetingLivePcmShim();
 
   final MindSpeechBridge _speech;
-  final MeetingLivePcmShim _pcmShim;
+  final LivePcmShimPort _pcmShim;
   final void Function()? onTranscriptChanged;
 
   StreamSubscription<TranscriptEvent>? _eventsSub;
@@ -62,6 +63,9 @@ class MeetingLiveSessionCoordinator {
   }
 
   int? get activeSpeakerIndex => _activeSpeakerIndex;
+
+  /// Recoverable degradation notice from the native live session (ring overflow, etc.).
+  String? get degradedMessage => _degradedMessage;
 
   /// Rows for the live transcript UI (stable + optional partial tail).
   List<LiveTranscriptLine> get transcriptLines {
@@ -100,6 +104,7 @@ class MeetingLiveSessionCoordinator {
   String? _partialText;
   String? _activeSpeakerLabel;
   int? _activeSpeakerIndex;
+  String? _degradedMessage;
   final List<TranscriptSegment> _stableSegments = [];
   final List<double> _amplitudeSamples = [];
 
@@ -112,6 +117,7 @@ class MeetingLiveSessionCoordinator {
     _partialText = null;
     _activeSpeakerLabel = null;
     _activeSpeakerIndex = null;
+    _degradedMessage = null;
     _stableSegments.clear();
     _amplitudeSamples.clear();
 
@@ -130,16 +136,18 @@ class MeetingLiveSessionCoordinator {
     await _pcmShim.start(sessionId: meetingId);
   }
 
-  void pause() {
+  Future<void> pause() async {
     final id = _sessionId;
     if (id == null) return;
+    await _pcmShim.pause();
     _speech.pauseLiveSession(sessionId: id);
   }
 
-  void resume() {
+  Future<void> resume() async {
     final id = _sessionId;
     if (id == null) return;
     _speech.resumeLiveSession(sessionId: id);
+    await _pcmShim.resume(sessionId: id);
   }
 
   Future<MeetingLiveSessionResult> finish() async {
@@ -223,7 +231,9 @@ class MeetingLiveSessionCoordinator {
         }
       case TranscriptEventTranscribing():
       case TranscriptEventCancelled():
-      case TranscriptEventDegraded():
+        break;
+      case TranscriptEventDegraded(:final message):
+        _degradedMessage = message;
         break;
       case TranscriptEventDegraded(:final message):
         _partialText = message;

--- a/packages/feature_mind/lib/src/capture/application/meeting_live_session_coordinator.dart
+++ b/packages/feature_mind/lib/src/capture/application/meeting_live_session_coordinator.dart
@@ -2,6 +2,8 @@ import 'dart:async';
 
 import '../../bridges/mind_speech_bridge.dart';
 import '../../whisper/api/meetings.dart' as rust;
+import '../domain/live_speaker_label.dart';
+import '../domain/live_transcript_line.dart';
 import 'meeting_live_pcm_shim.dart';
 
 /// Result of a completed live STT session.
@@ -35,6 +37,38 @@ class MeetingLiveSessionCoordinator {
   String? get partialText => _partialText;
   List<TranscriptSegment> get stableSegments =>
       List<TranscriptSegment>.unmodifiable(_stableSegments);
+
+  /// Rows for the live transcript UI (stable + optional partial tail).
+  List<LiveTranscriptLine> get transcriptLines {
+    final lines = <LiveTranscriptLine>[
+      for (final segment in _stableSegments)
+        LiveTranscriptLine(
+          segmentId: segment.id,
+          speakerLabel: formatLiveSpeakerLabel(segment.speakerLabel),
+          text: segment.text,
+          startMs: segment.startMs,
+          isPartial: false,
+        ),
+    ];
+    if (_partialText != null && _partialText!.isNotEmpty) {
+      final tailSpeaker = _stableSegments.isNotEmpty
+          ? formatLiveSpeakerLabel(_stableSegments.last.speakerLabel)
+          : formatLiveSpeakerLabel(null);
+      final tailStart = _stableSegments.isNotEmpty
+          ? _stableSegments.last.endMs
+          : 0;
+      lines.add(
+        LiveTranscriptLine(
+          segmentId: 'partial',
+          speakerLabel: tailSpeaker,
+          text: _partialText!,
+          startMs: tailStart,
+          isPartial: true,
+        ),
+      );
+    }
+    return lines;
+  }
 
   String? _partialText;
   final List<TranscriptSegment> _stableSegments = [];
@@ -136,6 +170,7 @@ class MeetingLiveSessionCoordinator {
         }
       case TranscriptEventTranscribing():
       case TranscriptEventCancelled():
+      case TranscriptEventDegraded():
         break;
       case TranscriptEventDegraded(:final message):
         _partialText = message;

--- a/packages/feature_mind/lib/src/capture/application/meeting_live_session_coordinator.dart
+++ b/packages/feature_mind/lib/src/capture/application/meeting_live_session_coordinator.dart
@@ -48,18 +48,13 @@ class MeetingLiveSessionCoordinator {
   List<SpeakerActivitySpan> get speakerActivitySpans {
     return [
       for (final segment in _stableSegments)
-        if (parseLiveSpeakerIndex(segment.speakerLabel) != null)
+        if (parseLiveSpeakerIndex(segment.speakerLabel) case final index?)
           SpeakerActivitySpan(
-            speakerIndex: parseLiveSpeakerIndex(segment.speakerLabel)!,
+            speakerIndex: index,
             startMs: segment.startMs,
             endMs: segment.endMs,
           ),
     ];
-  }
-
-  int get speakerTimelineEndMs {
-    if (_stableSegments.isEmpty) return 0;
-    return _stableSegments.last.endMs;
   }
 
   int? get activeSpeakerIndex => _activeSpeakerIndex;

--- a/packages/feature_mind/lib/src/capture/domain/live_speaker_label.dart
+++ b/packages/feature_mind/lib/src/capture/domain/live_speaker_label.dart
@@ -1,0 +1,21 @@
+/// Display label for a live transcript speaker (`P0`: no invented names).
+String formatLiveSpeakerLabel(String? speakerLabel) {
+  if (speakerLabel == null || speakerLabel.isEmpty) {
+    return 'Speaker 1';
+  }
+  if (speakerLabel.startsWith('sp')) {
+    final index = int.tryParse(speakerLabel.substring(2));
+    if (index != null) {
+      return 'Speaker ${index + 1}';
+    }
+  }
+  return speakerLabel;
+}
+
+String formatLiveSegmentClock(int startMs) {
+  final totalSeconds = startMs ~/ 1000;
+  final minutes = totalSeconds ~/ 60;
+  final seconds = totalSeconds % 60;
+  return '${minutes.toString().padLeft(2, '0')}:'
+      '${seconds.toString().padLeft(2, '0')}';
+}

--- a/packages/feature_mind/lib/src/capture/domain/live_speaker_label.dart
+++ b/packages/feature_mind/lib/src/capture/domain/live_speaker_label.dart
@@ -1,3 +1,11 @@
+/// Parses `sp0` / `sp1` wire labels into a zero-based speaker index.
+int? parseLiveSpeakerIndex(String? speakerLabel) {
+  if (speakerLabel == null || !speakerLabel.startsWith('sp')) {
+    return null;
+  }
+  return int.tryParse(speakerLabel.substring(2));
+}
+
 /// Display label for a live transcript speaker (`P0`: no invented names).
 String formatLiveSpeakerLabel(String? speakerLabel) {
   if (speakerLabel == null || speakerLabel.isEmpty) {

--- a/packages/feature_mind/lib/src/capture/domain/live_transcript_line.dart
+++ b/packages/feature_mind/lib/src/capture/domain/live_transcript_line.dart
@@ -1,0 +1,16 @@
+/// One rendered row in the live transcript surface.
+class LiveTranscriptLine {
+  const LiveTranscriptLine({
+    required this.segmentId,
+    required this.speakerLabel,
+    required this.text,
+    required this.startMs,
+    required this.isPartial,
+  });
+
+  final String segmentId;
+  final String speakerLabel;
+  final String text;
+  final int startMs;
+  final bool isPartial;
+}

--- a/packages/feature_mind/lib/src/capture/domain/speaker_activity_span.dart
+++ b/packages/feature_mind/lib/src/capture/domain/speaker_activity_span.dart
@@ -1,0 +1,12 @@
+/// One provisional speaker-activity interval for the live timeline (`P1`).
+class SpeakerActivitySpan {
+  const SpeakerActivitySpan({
+    required this.speakerIndex,
+    required this.startMs,
+    required this.endMs,
+  });
+
+  final int speakerIndex;
+  final int startMs;
+  final int endMs;
+}

--- a/packages/feature_mind/lib/src/capture/presentation/audio_amplitude_meter.dart
+++ b/packages/feature_mind/lib/src/capture/presentation/audio_amplitude_meter.dart
@@ -1,0 +1,62 @@
+import 'package:flutter/material.dart';
+
+/// Live amplitude meter — recording energy only, not speaker identity (`P0`).
+class AudioAmplitudeMeter extends StatelessWidget {
+  const AudioAmplitudeMeter({
+    required this.samples,
+    required this.isPaused,
+    super.key,
+  });
+
+  /// Recent normalized RMS samples (0–1), oldest first.
+  final List<double> samples;
+  final bool isPaused;
+
+  static const _barCount = 12;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final color = theme.colorScheme.primary.withValues(
+      alpha: isPaused ? 0.25 : 0.75,
+    );
+    final levels = _normalizedLevels(samples);
+
+    return SizedBox(
+      key: const Key('meeting_capture_amplitude_meter'),
+      height: 24,
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: List.generate(_barCount, (index) {
+          final level = isPaused ? 0.0 : levels[index];
+          final height = 4.0 + level * 18.0;
+          return Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 2),
+            child: AnimatedContainer(
+              duration: const Duration(milliseconds: 120),
+              curve: Curves.easeOut,
+              width: 4,
+              height: height,
+              decoration: BoxDecoration(
+                color: color,
+                borderRadius: BorderRadius.circular(2),
+              ),
+            ),
+          );
+        }),
+      ),
+    );
+  }
+
+  List<double> _normalizedLevels(List<double> samples) {
+    if (samples.isEmpty) {
+      return List<double>.filled(_barCount, 0);
+    }
+    final padded = List<double>.filled(_barCount, 0);
+    final start = _barCount - samples.length;
+    for (var i = 0; i < samples.length; i++) {
+      padded[start + i] = samples[i].clamp(0.0, 1.0);
+    }
+    return padded;
+  }
+}

--- a/packages/feature_mind/lib/src/capture/presentation/compact_trust_status_bar.dart
+++ b/packages/feature_mind/lib/src/capture/presentation/compact_trust_status_bar.dart
@@ -1,0 +1,119 @@
+import 'package:flutter/material.dart';
+
+import '../../trust/scribe_trust_state.dart';
+import '../../widgets/mind_palette.dart';
+
+/// Compact on-device / language status for active capture (`P0`).
+class CompactTrustStatusBar extends StatelessWidget {
+  const CompactTrustStatusBar({
+    required this.state,
+    super.key,
+  });
+
+  final ScribeTrustState state;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return InkWell(
+      key: const Key('meeting_capture_compact_trust_bar'),
+      onTap: () => _showDetails(context),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+        child: Row(
+          children: [
+            Icon(
+              Icons.circle,
+              size: 10,
+              color: state.processingOnDevice
+                  ? MindPalette.local
+                  : MindPalette.remote,
+            ),
+            const SizedBox(width: 6),
+            Text(
+              state.processingOnDevice ? 'On this device' : 'Network model',
+              style: theme.textTheme.labelLarge?.copyWith(
+                color: MindPalette.local,
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+            const SizedBox(width: 12),
+            Expanded(
+              child: Text(
+                state.languageBadgeLabel,
+                style: theme.textTheme.bodySmall?.copyWith(
+                  color: theme.colorScheme.onSurface.withValues(alpha: 0.75),
+                ),
+                overflow: TextOverflow.ellipsis,
+              ),
+            ),
+            Icon(
+              Icons.info_outline,
+              size: 18,
+              color: theme.colorScheme.onSurface.withValues(alpha: 0.5),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  void _showDetails(BuildContext context) {
+    showModalBottomSheet<void>(
+      context: context,
+      showDragHandle: true,
+      builder: (context) {
+        return Padding(
+          padding: const EdgeInsets.fromLTRB(20, 8, 20, 28),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Text('Transcription', style: Theme.of(context).textTheme.titleMedium),
+              const SizedBox(height: 12),
+              _DetailRow(
+                label: 'Processing',
+                value: state.processingOnDevice
+                    ? 'Running on this device'
+                    : 'May use a networked model',
+              ),
+              const _DetailRow(label: 'Audio upload', value: 'No audio uploaded'),
+              _DetailRow(label: 'Language', value: state.languageBadgeLabel),
+              const _DetailRow(label: 'Translation', value: 'Off unless you ask'),
+              if (state.honestyNote != null) ...[
+                const SizedBox(height: 8),
+                Text(
+                  state.honestyNote!,
+                  style: Theme.of(context).textTheme.bodySmall,
+                ),
+              ],
+            ],
+          ),
+        );
+      },
+    );
+  }
+}
+
+class _DetailRow extends StatelessWidget {
+  const _DetailRow({required this.label, required this.value});
+
+  final String label;
+  final String value;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 6),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const Text('✓ '),
+          Expanded(
+            child: Text('$label: $value'),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/packages/feature_mind/lib/src/capture/presentation/live_capture_controls.dart
+++ b/packages/feature_mind/lib/src/capture/presentation/live_capture_controls.dart
@@ -58,11 +58,13 @@ class LiveCaptureControls extends StatelessWidget {
                   style: theme.textTheme.labelLarge,
                 ),
                 const Spacer(),
-                FilterChip(
-                  key: const Key('meeting_capture_follow_live'),
-                  label: Text(followLive ? 'Follow live ✓' : 'Follow live'),
-                  selected: followLive,
-                  onSelected: onFollowLiveChanged,
+                Flexible(
+                  child: FilterChip(
+                    key: const Key('meeting_capture_follow_live'),
+                    label: Text(followLive ? 'Follow live ✓' : 'Follow live'),
+                    selected: followLive,
+                    onSelected: onFollowLiveChanged,
+                  ),
                 ),
               ],
             ),

--- a/packages/feature_mind/lib/src/capture/presentation/live_capture_controls.dart
+++ b/packages/feature_mind/lib/src/capture/presentation/live_capture_controls.dart
@@ -2,6 +2,10 @@ import 'dart:ui' show FontFeature;
 
 import 'package:flutter/material.dart';
 
+import '../domain/speaker_activity_span.dart';
+import 'audio_amplitude_meter.dart';
+import 'speaker_activity_timeline.dart';
+
 /// Bottom capture controls — timer, listening state, pause/stop (`P0`).
 class LiveCaptureControls extends StatelessWidget {
   const LiveCaptureControls({
@@ -12,6 +16,10 @@ class LiveCaptureControls extends StatelessWidget {
     required this.onPause,
     required this.onResume,
     required this.onStop,
+    required this.amplitudeSamples,
+    this.speakerActivitySpans = const [],
+    this.speakerTimelineEndMs = 0,
+    this.activeSpeakerIndex,
     super.key,
   });
 
@@ -22,6 +30,10 @@ class LiveCaptureControls extends StatelessWidget {
   final VoidCallback onPause;
   final VoidCallback onResume;
   final VoidCallback onStop;
+  final List<double> amplitudeSamples;
+  final List<SpeakerActivitySpan> speakerActivitySpans;
+  final int speakerTimelineEndMs;
+  final int? activeSpeakerIndex;
 
   @override
   Widget build(BuildContext context) {
@@ -55,7 +67,18 @@ class LiveCaptureControls extends StatelessWidget {
               ],
             ),
             const SizedBox(height: 8),
-            _AudioActivityBar(isPaused: isPaused),
+            AudioAmplitudeMeter(
+              samples: amplitudeSamples,
+              isPaused: isPaused,
+            ),
+            if (speakerActivitySpans.isNotEmpty) ...[
+              const SizedBox(height: 10),
+              SpeakerActivityTimeline(
+                spans: speakerActivitySpans,
+                timelineEndMs: speakerTimelineEndMs,
+                activeSpeakerIndex: activeSpeakerIndex,
+              ),
+            ],
             const SizedBox(height: 12),
             Text(
               elapsedLabel,
@@ -93,40 +116,6 @@ class LiveCaptureControls extends StatelessWidget {
             ),
           ],
         ),
-      ),
-    );
-  }
-}
-
-class _AudioActivityBar extends StatelessWidget {
-  const _AudioActivityBar({required this.isPaused});
-
-  final bool isPaused;
-
-  @override
-  Widget build(BuildContext context) {
-    final color = Theme.of(context).colorScheme.primary.withValues(
-      alpha: isPaused ? 0.25 : 0.7,
-    );
-    return SizedBox(
-      height: 24,
-      child: Row(
-        mainAxisAlignment: MainAxisAlignment.center,
-        children: List.generate(12, (index) {
-          final height = isPaused ? 4.0 : 6.0 + (index % 4) * 4.0;
-          return Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 2),
-            child: AnimatedContainer(
-              duration: const Duration(milliseconds: 300),
-              width: 4,
-              height: height,
-              decoration: BoxDecoration(
-                color: color,
-                borderRadius: BorderRadius.circular(2),
-              ),
-            ),
-          );
-        }),
       ),
     );
   }

--- a/packages/feature_mind/lib/src/capture/presentation/live_capture_controls.dart
+++ b/packages/feature_mind/lib/src/capture/presentation/live_capture_controls.dart
@@ -1,0 +1,133 @@
+import 'dart:ui' show FontFeature;
+
+import 'package:flutter/material.dart';
+
+/// Bottom capture controls — timer, listening state, pause/stop (`P0`).
+class LiveCaptureControls extends StatelessWidget {
+  const LiveCaptureControls({
+    required this.elapsedLabel,
+    required this.isPaused,
+    required this.followLive,
+    required this.onFollowLiveChanged,
+    required this.onPause,
+    required this.onResume,
+    required this.onStop,
+    super.key,
+  });
+
+  final String elapsedLabel;
+  final bool isPaused;
+  final bool followLive;
+  final ValueChanged<bool> onFollowLiveChanged;
+  final VoidCallback onPause;
+  final VoidCallback onResume;
+  final VoidCallback onStop;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Material(
+      elevation: 4,
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(16, 12, 16, 20),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Row(
+              children: [
+                Icon(
+                  isPaused ? Icons.pause_circle_outline : Icons.graphic_eq,
+                  size: 18,
+                  color: theme.colorScheme.primary,
+                ),
+                const SizedBox(width: 6),
+                Text(
+                  isPaused ? 'Paused' : 'Listening',
+                  style: theme.textTheme.labelLarge,
+                ),
+                const Spacer(),
+                FilterChip(
+                  key: const Key('meeting_capture_follow_live'),
+                  label: Text(followLive ? 'Follow live ✓' : 'Follow live'),
+                  selected: followLive,
+                  onSelected: onFollowLiveChanged,
+                ),
+              ],
+            ),
+            const SizedBox(height: 8),
+            _AudioActivityBar(isPaused: isPaused),
+            const SizedBox(height: 12),
+            Text(
+              elapsedLabel,
+              key: const Key('meeting_capture_elapsed'),
+              style: theme.textTheme.headlineSmall?.copyWith(
+                fontFeatures: const [FontFeature.tabularFigures()],
+              ),
+            ),
+            const SizedBox(height: 12),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                if (!isPaused)
+                  OutlinedButton.icon(
+                    key: const Key('meeting_capture_pause_button'),
+                    onPressed: onPause,
+                    icon: const Icon(Icons.pause),
+                    label: const Text('Pause'),
+                  )
+                else
+                  OutlinedButton.icon(
+                    key: const Key('meeting_capture_resume_button'),
+                    onPressed: onResume,
+                    icon: const Icon(Icons.play_arrow),
+                    label: const Text('Resume'),
+                  ),
+                const SizedBox(width: 12),
+                FilledButton.icon(
+                  key: const Key('meeting_capture_stop_button'),
+                  onPressed: onStop,
+                  icon: const Icon(Icons.stop),
+                  label: const Text('Stop'),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _AudioActivityBar extends StatelessWidget {
+  const _AudioActivityBar({required this.isPaused});
+
+  final bool isPaused;
+
+  @override
+  Widget build(BuildContext context) {
+    final color = Theme.of(context).colorScheme.primary.withValues(
+      alpha: isPaused ? 0.25 : 0.7,
+    );
+    return SizedBox(
+      height: 24,
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: List.generate(12, (index) {
+          final height = isPaused ? 4.0 : 6.0 + (index % 4) * 4.0;
+          return Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 2),
+            child: AnimatedContainer(
+              duration: const Duration(milliseconds: 300),
+              width: 4,
+              height: height,
+              decoration: BoxDecoration(
+                color: color,
+                borderRadius: BorderRadius.circular(2),
+              ),
+            ),
+          );
+        }),
+      ),
+    );
+  }
+}

--- a/packages/feature_mind/lib/src/capture/presentation/live_insights_rail.dart
+++ b/packages/feature_mind/lib/src/capture/presentation/live_insights_rail.dart
@@ -1,0 +1,71 @@
+import 'package:flutter/material.dart';
+
+/// Collapsible live insights rail (`P1` stub — structure only).
+class LiveInsightsRail extends StatelessWidget {
+  const LiveInsightsRail({
+    required this.expanded,
+    required this.onToggle,
+    super.key,
+  });
+
+  final bool expanded;
+  final VoidCallback onToggle;
+
+  @override
+  Widget build(BuildContext context) {
+    if (!expanded) {
+      return Align(
+        alignment: Alignment.topRight,
+        child: IconButton(
+          key: const Key('meeting_capture_insights_expand'),
+          tooltip: 'Live insights',
+          onPressed: onToggle,
+          icon: const Icon(Icons.insights_outlined),
+        ),
+      );
+    }
+    return Container(
+      width: 220,
+      decoration: BoxDecoration(
+        border: Border(
+          left: BorderSide(color: Theme.of(context).dividerColor),
+        ),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Padding(
+            padding: const EdgeInsets.all(12),
+            child: Row(
+              children: [
+                const Expanded(
+                  child: Text(
+                    'LIVE INSIGHTS',
+                    style: TextStyle(
+                      fontSize: 11,
+                      letterSpacing: 1.1,
+                      fontWeight: FontWeight.w700,
+                    ),
+                  ),
+                ),
+                IconButton(
+                  key: const Key('meeting_capture_insights_collapse'),
+                  onPressed: onToggle,
+                  icon: const Icon(Icons.close, size: 18),
+                ),
+              ],
+            ),
+          ),
+          const Padding(
+            padding: EdgeInsets.symmetric(horizontal: 12),
+            child: Text(
+              'Decisions, actions, and topics will appear here as '
+              'Airo understands the meeting.',
+              style: TextStyle(fontSize: 13),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/packages/feature_mind/lib/src/capture/presentation/live_transcript_view.dart
+++ b/packages/feature_mind/lib/src/capture/presentation/live_transcript_view.dart
@@ -153,6 +153,18 @@ class _TranscriptLineTile extends StatelessWidget {
         children: [
           Row(
             children: [
+              Icon(
+                Icons.circle,
+                size: 10,
+                color: theme.colorScheme.primary,
+              ),
+              const SizedBox(width: 6),
+              Text(
+                line.speakerLabel,
+                key: Key('live_speaker_${line.segmentId}'),
+                style: speakerStyle,
+              ),
+              const Spacer(),
               Text(
                 formatLiveSegmentClock(line.startMs),
                 key: Key('live_time_${line.segmentId}'),
@@ -160,29 +172,26 @@ class _TranscriptLineTile extends StatelessWidget {
                   color: theme.colorScheme.outline,
                 ),
               ),
-              const SizedBox(width: 8),
-              Text(
-                line.speakerLabel,
-                key: Key('live_speaker_${line.segmentId}'),
-                style: speakerStyle,
-              ),
             ],
           ),
           const SizedBox(height: 4),
-          Text.rich(
-            TextSpan(
-              children: [
-                TextSpan(text: line.text, style: bodyStyle),
-                if (line.isPartial)
-                  TextSpan(
-                    text: ' ▌',
-                    style: bodyStyle?.copyWith(
-                      color: theme.colorScheme.primary,
+          Padding(
+            padding: const EdgeInsets.only(left: 16),
+            child: Text.rich(
+              TextSpan(
+                children: [
+                  TextSpan(text: line.text, style: bodyStyle),
+                  if (line.isPartial)
+                    TextSpan(
+                      text: ' ▌',
+                      style: bodyStyle?.copyWith(
+                        color: theme.colorScheme.primary,
+                      ),
                     ),
-                  ),
-              ],
+                ],
+              ),
+              key: Key('live_text_${line.segmentId}'),
             ),
-            key: Key('live_text_${line.segmentId}'),
           ),
         ],
       ),

--- a/packages/feature_mind/lib/src/capture/presentation/live_transcript_view.dart
+++ b/packages/feature_mind/lib/src/capture/presentation/live_transcript_view.dart
@@ -1,0 +1,191 @@
+import 'package:flutter/material.dart';
+
+import '../domain/live_transcript_line.dart';
+import '../domain/live_speaker_label.dart';
+
+/// Primary live transcript surface — scroll, follow-live, jump-to-live (`P0`).
+class LiveTranscriptView extends StatefulWidget {
+  const LiveTranscriptView({
+    required this.lines,
+    required this.followLive,
+    required this.onFollowLiveChanged,
+    super.key,
+  });
+
+  final List<LiveTranscriptLine> lines;
+  final bool followLive;
+  final ValueChanged<bool> onFollowLiveChanged;
+
+  @override
+  State<LiveTranscriptView> createState() => _LiveTranscriptViewState();
+}
+
+class _LiveTranscriptViewState extends State<LiveTranscriptView> {
+  final _scrollController = ScrollController();
+  bool _showJumpToLive = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _scrollController.addListener(_onScroll);
+  }
+
+  @override
+  void didUpdateWidget(covariant LiveTranscriptView oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.followLive && widget.lines.length != oldWidget.lines.length) {
+      WidgetsBinding.instance.addPostFrameCallback((_) => _scrollToBottom());
+    }
+  }
+
+  @override
+  void dispose() {
+    _scrollController.dispose();
+    super.dispose();
+  }
+
+  void _onScroll() {
+    if (!_scrollController.hasClients) return;
+    final atBottom = _scrollController.position.pixels >=
+        _scrollController.position.maxScrollExtent - 48;
+    if (!atBottom && widget.followLive) {
+      widget.onFollowLiveChanged(false);
+    }
+    setState(() => _showJumpToLive = !atBottom);
+  }
+
+  void _scrollToBottom() {
+    if (!_scrollController.hasClients) return;
+    _scrollController.animateTo(
+      _scrollController.position.maxScrollExtent,
+      duration: const Duration(milliseconds: 200),
+      curve: Curves.easeOut,
+    );
+  }
+
+  void _jumpToLive() {
+    widget.onFollowLiveChanged(true);
+    _scrollToBottom();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Stack(
+      children: [
+        Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Padding(
+              padding: const EdgeInsets.fromLTRB(16, 8, 16, 4),
+              child: Text(
+                'LIVE TRANSCRIPT',
+                style: theme.textTheme.labelSmall?.copyWith(
+                  letterSpacing: 1.2,
+                  fontWeight: FontWeight.w700,
+                ),
+              ),
+            ),
+            Expanded(
+              child: widget.lines.isEmpty
+                  ? Center(
+                      key: const Key('meeting_capture_live_listening'),
+                      child: Text(
+                        'Listening…',
+                        style: theme.textTheme.bodyLarge?.copyWith(
+                          color: theme.colorScheme.outline,
+                        ),
+                      ),
+                    )
+                  : ListView.builder(
+                      key: const Key('meeting_capture_live_transcript'),
+                      controller: _scrollController,
+                      padding: const EdgeInsets.fromLTRB(16, 0, 16, 16),
+                      itemCount: widget.lines.length,
+                      itemBuilder: (context, index) {
+                        final line = widget.lines[index];
+                        return _TranscriptLineTile(line: line);
+                      },
+                    ),
+            ),
+          ],
+        ),
+        if (_showJumpToLive && !widget.followLive)
+          Positioned(
+            bottom: 12,
+            left: 0,
+            right: 0,
+            child: Center(
+              child: FilledButton.tonalIcon(
+                key: const Key('meeting_capture_jump_to_live'),
+                onPressed: _jumpToLive,
+                icon: const Icon(Icons.arrow_downward),
+                label: const Text('Jump to live'),
+              ),
+            ),
+          ),
+      ],
+    );
+  }
+}
+
+class _TranscriptLineTile extends StatelessWidget {
+  const _TranscriptLineTile({required this.line});
+
+  final LiveTranscriptLine line;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final speakerStyle = theme.textTheme.titleSmall?.copyWith(
+      fontWeight: FontWeight.w700,
+    );
+    final bodyStyle = line.isPartial
+        ? theme.textTheme.bodyLarge?.copyWith(
+            color: theme.colorScheme.onSurface.withValues(alpha: 0.65),
+          )
+        : theme.textTheme.bodyLarge;
+
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 16),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Text(
+                formatLiveSegmentClock(line.startMs),
+                key: Key('live_time_${line.segmentId}'),
+                style: theme.textTheme.labelSmall?.copyWith(
+                  color: theme.colorScheme.outline,
+                ),
+              ),
+              const SizedBox(width: 8),
+              Text(
+                line.speakerLabel,
+                key: Key('live_speaker_${line.segmentId}'),
+                style: speakerStyle,
+              ),
+            ],
+          ),
+          const SizedBox(height: 4),
+          Text.rich(
+            TextSpan(
+              children: [
+                TextSpan(text: line.text, style: bodyStyle),
+                if (line.isPartial)
+                  TextSpan(
+                    text: ' ▌',
+                    style: bodyStyle?.copyWith(
+                      color: theme.colorScheme.primary,
+                    ),
+                  ),
+              ],
+            ),
+            key: Key('live_text_${line.segmentId}'),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/packages/feature_mind/lib/src/capture/presentation/meeting_capture_screen.dart
+++ b/packages/feature_mind/lib/src/capture/presentation/meeting_capture_screen.dart
@@ -7,7 +7,6 @@ import '../../assistant/consent/audio_scribe_consent_gate.dart';
 import '../../assistant/consent/jurisdiction_consent_rules.dart';
 import '../../assistant/consent/mind_runtime_provider.dart';
 import '../../assistant/consent/recording_consent_prompt.dart';
-import '../../trust/scribe_trust_signals.dart';
 import '../../trust/scribe_trust_state.dart';
 import '../application/meeting_capture_controller.dart';
 import '../application/meeting_capture_providers.dart';
@@ -17,29 +16,17 @@ import '../application/transcription_mode_preference.dart';
 import '../domain/meeting_processing_job.dart';
 import '../domain/meeting_recording_state.dart';
 import '../domain/transcription_mode.dart';
+import 'compact_trust_status_bar.dart';
+import 'live_capture_controls.dart';
+import 'live_insights_rail.dart';
+import 'live_transcript_view.dart';
 import 'meeting_recording_visualizer.dart';
 
-/// In-app meeting capture (#1656 AC1, AC6).
+/// In-app meeting capture (#1656 AC1, AC6) with live-transcript-first layout
+/// while recording.
 ///
 /// Reuses `AudioScribeConsentGate` — the same gate `AudioScribeScreen` uses
-/// for live dictation — as the one door to the encoder, per that gate's own
-/// doc: "a screen that wants to record audio has no other route to the
-/// encoder available to it". This screen's [MeetingCaptureController] is
-/// only ever started from inside [AudioScribeConsentGate.startRecording], the
-/// same shape `AudioScribeScreen._capture` already uses for the streaming
-/// path.
-///
-/// AC6's "explicit recording-consent UX copy" lives in [_ConsentReminder]
-/// below: a plain-language reminder that recording consent law varies by
-/// where the meeting happens, and that checking it is the person's
-/// responsibility — this screen shows a jurisdiction picker and (for
-/// two-party jurisdictions) blocks on an "I notified everyone" acknowledgment
-/// before starting, but it is not a legal gate; nothing here verifies the
-/// acknowledgment is true.
-///
-/// That picker is behind [recordingConsentPromptProvider], off by default. With
-/// it off the gate is still the only door to the encoder; consent is granted up
-/// front under [implicitConsentJurisdiction] so Start works on arrival.
+/// for live dictation — as the one door to the encoder.
 class MeetingCaptureScreen extends ConsumerStatefulWidget {
   const MeetingCaptureScreen({super.key});
 
@@ -57,9 +44,6 @@ class _MeetingCaptureScreenState extends ConsumerState<MeetingCaptureScreen> {
   bool _consentBusy = false;
   String? _consentError;
 
-  /// Set when the up-front grant (prompt disabled) could not write its op.
-  /// Falls back to showing the picker rather than leaving Start dead with no
-  /// explanation.
   bool _implicitConsentFailed = false;
 
   StreamSubscription<MeetingRecordingSnapshot>? _snapshotSub;
@@ -70,11 +54,9 @@ class _MeetingCaptureScreenState extends ConsumerState<MeetingCaptureScreen> {
   MeetingRecordingSnapshot _snapshot = MeetingRecordingSnapshot.idle;
   String? _startError;
   String? _liveWarning;
+  bool _followLive = true;
+  bool _insightsExpanded = false;
 
-  /// The job this session enqueued, while it is still in the queue. Non-null
-  /// means "transcribing" — the screen stays put and reports progress instead
-  /// of dropping the person back into a library that will not list the meeting
-  /// for another few minutes.
   MeetingProcessingJob? _processing;
   bool _processed = false;
   String? _processingError;
@@ -95,9 +77,6 @@ class _MeetingCaptureScreenState extends ConsumerState<MeetingCaptureScreen> {
     super.dispose();
   }
 
-  /// Records consent without asking, for when [recordingConsentPromptProvider]
-  /// is off. Still goes through [AudioScribeConsentGate.grant], so the op log
-  /// carries a consent entry for every recording exactly as before.
   Future<void> _grantImplicitConsent() async {
     try {
       await _consentGate.grant(
@@ -146,6 +125,7 @@ class _MeetingCaptureScreenState extends ConsumerState<MeetingCaptureScreen> {
     setState(() {
       _startError = null;
       _liveWarning = null;
+      _followLive = true;
     });
     final controller = ref.read(meetingCaptureControllerProvider);
     _controller = controller;
@@ -204,12 +184,12 @@ class _MeetingCaptureScreenState extends ConsumerState<MeetingCaptureScreen> {
 
   Future<void> _pause() async {
     await _controller?.pause();
-    _liveCoordinator?.pause();
+    await _liveCoordinator?.pause();
   }
 
   Future<void> _resume() async {
     await _controller?.resume();
-    _liveCoordinator?.resume();
+    await _liveCoordinator?.resume();
   }
 
   Future<void> _stop() async {
@@ -295,160 +275,200 @@ class _MeetingCaptureScreenState extends ConsumerState<MeetingCaptureScreen> {
     final active = recording || paused;
     final languageMode = ref.watch(speechLanguageModeProvider);
     final transcriptionMode = ref.watch(transcriptionModeProvider);
-    final showLiveTranscript =
-        active && transcriptionMode.usesLivePipeline && _liveCoordinator != null;
+    final trustState = ScribeTrustState.fromSpeechLanguageMode(languageMode);
+    final showLive =
+        active &&
+        transcriptionMode.usesLivePipeline &&
+        _liveCoordinator != null;
 
     return Scaffold(
-      appBar: AppBar(title: const Text('Record meeting')),
-      body: Column(
-        children: [
-          Expanded(
-            child: ListView(
-              padding: const EdgeInsets.fromLTRB(16, 12, 16, 32),
-              children: [
-                if (showConsentUi) ...[
-                  const _ConsentReminder(),
-                  const SizedBox(height: 12),
-                ],
-                ScribeTrustSignals(
-                  state: ScribeTrustState.fromSpeechLanguageMode(languageMode),
-                ),
-                const SizedBox(height: 12),
-                if (showConsentUi)
-                  _ConsentJurisdictionPicker(
-                    jurisdiction: _jurisdiction,
-                    allPartiesAck: _allPartiesAck,
-                    granted: consentGranted,
-                    busy: _consentBusy,
-                    error: _consentError,
-                    onJurisdictionChanged: (jurisdiction) => setState(() {
-                      _jurisdiction = jurisdiction;
-                      if (!jurisdiction.requiresAllPartyNotification) {
-                        _allPartiesAck = false;
-                      }
-                    }),
-                    onAllPartiesAckChanged: (value) =>
-                        setState(() => _allPartiesAck = value),
-                    onConfirm: _confirmConsent,
+      appBar: AppBar(
+        title: const Text('Record meeting'),
+        actions: active
+            ? [
+                Padding(
+                  padding: const EdgeInsets.only(right: 12),
+                  child: Row(
+                    children: [
+                      Icon(
+                        Icons.circle,
+                        size: 10,
+                        color: paused
+                            ? Theme.of(context).colorScheme.outline
+                            : Theme.of(context).colorScheme.error,
+                      ),
+                      const SizedBox(width: 6),
+                      Text(
+                        paused ? 'PAUSED' : 'LIVE',
+                        key: const Key('meeting_capture_live_badge'),
+                        style: Theme.of(context).textTheme.labelLarge?.copyWith(
+                          fontWeight: FontWeight.w700,
+                        ),
+                      ),
+                      const SizedBox(width: 8),
+                      Text(
+                        _formatElapsed(_snapshot.elapsedMs),
+                        style: Theme.of(context).textTheme.titleMedium,
+                      ),
+                    ],
                   ),
-                _ProcessingStatus(
-                  job: _processing,
-                  processed: _processed,
-                  error: _processingError,
-                  onOpenLibrary: () => Navigator.of(context).maybePop(),
                 ),
-                if (showLiveTranscript) ...[
-                  const SizedBox(height: 16),
-                  _LiveTranscriptPanel(coordinator: _liveCoordinator!),
-                ],
+              ]
+            : null,
+      ),
+      body: active
+          ? Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
                 if (paused && _snapshot.pausedByOs)
                   const Padding(
-                    padding: EdgeInsets.only(top: 20),
+                    padding: EdgeInsets.fromLTRB(16, 8, 16, 0),
                     child: Text(
                       key: Key('meeting_capture_os_pause_notice'),
                       'Paused automatically — a call or Siri interrupted the '
                       'microphone. Recording will resume when it ends.',
                     ),
                   ),
-                if (_liveWarning != null) ...[
-                  const SizedBox(height: 12),
-                  Text(
-                    _liveWarning!,
-                    key: const Key('meeting_capture_live_warning'),
-                    style: TextStyle(
-                      color: Theme.of(context).colorScheme.tertiary,
+                CompactTrustStatusBar(state: trustState),
+                if (_liveWarning != null)
+                  Padding(
+                    padding: const EdgeInsets.symmetric(horizontal: 16),
+                    child: Text(
+                      _liveWarning!,
+                      key: const Key('meeting_capture_live_warning'),
+                      style: TextStyle(
+                        color: Theme.of(context).colorScheme.tertiary,
+                      ),
                     ),
                   ),
-                ],
-              ],
-            ),
-          ),
-          Material(
-            elevation: 8,
-            child: Padding(
-              padding: const EdgeInsets.fromLTRB(16, 12, 16, 24),
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  MeetingRecordingVisualizer(
-                    recording: recording,
-                    amplitude: _snapshot.amplitude,
-                  ),
-                  const SizedBox(height: 8),
-                  Row(
-                    crossAxisAlignment: CrossAxisAlignment.baseline,
-                    textBaseline: TextBaseline.alphabetic,
+                Expanded(
+                  child: Row(
+                    crossAxisAlignment: CrossAxisAlignment.stretch,
                     children: [
-                      if (active)
-                        Padding(
-                          padding: const EdgeInsets.only(right: 10),
-                          child: Icon(
-                            paused
-                                ? Icons.pause_circle_filled
-                                : Icons.fiber_manual_record,
-                            color: Theme.of(context).colorScheme.error,
-                            size: 18,
+                      Expanded(
+                        flex: showLive ? 7 : 1,
+                        child: showLive
+                            ? LiveTranscriptView(
+                                lines: _liveCoordinator!.transcriptLines,
+                                followLive: _followLive,
+                                onFollowLiveChanged: (value) =>
+                                    setState(() => _followLive = value),
+                              )
+                            : const Center(
+                                child: Text('Recording — transcript after stop'),
+                              ),
+                      ),
+                      if (showLive)
+                        LiveInsightsRail(
+                          expanded: _insightsExpanded,
+                          onToggle: () => setState(
+                            () => _insightsExpanded = !_insightsExpanded,
                           ),
                         ),
-                      Text(
-                        _formatElapsed(_snapshot.elapsedMs),
-                        key: const Key('meeting_capture_elapsed'),
-                        style: Theme.of(context).textTheme.displaySmall,
+                    ],
+                  ),
+                ),
+                LiveCaptureControls(
+                  elapsedLabel: _formatElapsed(_snapshot.elapsedMs),
+                  isPaused: paused,
+                  followLive: _followLive,
+                  onFollowLiveChanged: (value) =>
+                      setState(() => _followLive = value),
+                  onPause: _pause,
+                  onResume: _resume,
+                  onStop: _stop,
+                  amplitudeSamples: showLive
+                      ? _liveCoordinator!.amplitudeSamples
+                      : const [],
+                  speakerActivitySpans: showLive
+                      ? _liveCoordinator!.speakerActivitySpans
+                      : const [],
+                  speakerTimelineEndMs: _snapshot.elapsedMs,
+                  activeSpeakerIndex: showLive
+                      ? _liveCoordinator!.activeSpeakerIndex
+                      : null,
+                ),
+              ],
+            )
+          : Column(
+              children: [
+                Expanded(
+                  child: ListView(
+                    padding: const EdgeInsets.fromLTRB(16, 12, 16, 32),
+                    children: [
+                      if (showConsentUi) ...[
+                        const _ConsentReminder(),
+                        const SizedBox(height: 12),
+                      ],
+                      CompactTrustStatusBar(state: trustState),
+                      const SizedBox(height: 12),
+                      if (showConsentUi)
+                        _ConsentJurisdictionPicker(
+                          jurisdiction: _jurisdiction,
+                          allPartiesAck: _allPartiesAck,
+                          granted: consentGranted,
+                          busy: _consentBusy,
+                          error: _consentError,
+                          onJurisdictionChanged: (jurisdiction) => setState(() {
+                            _jurisdiction = jurisdiction;
+                            if (!jurisdiction.requiresAllPartyNotification) {
+                              _allPartiesAck = false;
+                            }
+                          }),
+                          onAllPartiesAckChanged: (value) =>
+                              setState(() => _allPartiesAck = value),
+                          onConfirm: _confirmConsent,
+                        ),
+                      _ProcessingStatus(
+                        job: _processing,
+                        processed: _processed,
+                        error: _processingError,
+                        onOpenLibrary: () => Navigator.of(context).maybePop(),
                       ),
                     ],
                   ),
-                  const SizedBox(height: 12),
-                  Wrap(
-                    spacing: 12,
-                    runSpacing: 8,
-                    children: [
-                      if (!active)
+                ),
+                Material(
+                  elevation: 8,
+                  child: Padding(
+                    padding: const EdgeInsets.fromLTRB(16, 12, 16, 24),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        MeetingRecordingVisualizer(
+                          recording: recording,
+                          amplitude: _snapshot.amplitude,
+                        ),
+                        const SizedBox(height: 8),
+                        Text(
+                          _formatElapsed(_snapshot.elapsedMs),
+                          key: const Key('meeting_capture_elapsed'),
+                          style: Theme.of(context).textTheme.displaySmall,
+                        ),
+                        const SizedBox(height: 12),
                         FilledButton.icon(
                           key: const Key('meeting_capture_start_button'),
                           onPressed: consentGranted ? _start : null,
                           icon: const Icon(Icons.mic),
                           label: const Text('Start recording'),
                         ),
-                      if (recording)
-                        OutlinedButton.icon(
-                          key: const Key('meeting_capture_pause_button'),
-                          onPressed: _pause,
-                          icon: const Icon(Icons.pause),
-                          label: const Text('Pause'),
-                        ),
-                      if (paused && !_snapshot.pausedByOs)
-                        OutlinedButton.icon(
-                          key: const Key('meeting_capture_resume_button'),
-                          onPressed: _resume,
-                          icon: const Icon(Icons.play_arrow),
-                          label: const Text('Resume'),
-                        ),
-                      if (active)
-                        FilledButton.icon(
-                          key: const Key('meeting_capture_stop_button'),
-                          onPressed: _stop,
-                          icon: const Icon(Icons.stop),
-                          label: const Text('Stop'),
-                        ),
-                    ],
-                  ),
-                  if (_startError != null) ...[
-                    const SizedBox(height: 12),
-                    Text(
-                      _startError!,
-                      key: const Key('meeting_capture_error'),
-                      style: TextStyle(
-                        color: Theme.of(context).colorScheme.error,
-                      ),
+                        if (_startError != null) ...[
+                          const SizedBox(height: 12),
+                          Text(
+                            _startError!,
+                            key: const Key('meeting_capture_error'),
+                            style: TextStyle(
+                              color: Theme.of(context).colorScheme.error,
+                            ),
+                          ),
+                        ],
+                      ],
                     ),
-                  ],
-                ],
-              ),
+                  ),
+                ),
+              ],
             ),
-          ),
-        ],
-      ),
     );
   }
 
@@ -457,48 +477,6 @@ class _MeetingCaptureScreenState extends ConsumerState<MeetingCaptureScreen> {
     final minutes = seconds ~/ 60;
     final remSeconds = seconds % 60;
     return '${minutes.toString().padLeft(2, '0')}:${remSeconds.toString().padLeft(2, '0')}';
-  }
-}
-
-class _LiveTranscriptPanel extends StatelessWidget {
-  const _LiveTranscriptPanel({required this.coordinator});
-
-  final MeetingLiveSessionCoordinator coordinator;
-
-  @override
-  Widget build(BuildContext context) {
-    final stable = coordinator.stableSegments;
-    final partial = coordinator.partialText;
-    return Card(
-      key: const Key('meeting_capture_live_transcript'),
-      child: Padding(
-        padding: const EdgeInsets.all(16),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Text(
-              'Live transcript',
-              style: Theme.of(context).textTheme.titleMedium,
-            ),
-            const SizedBox(height: 8),
-            if (stable.isEmpty && partial == null)
-              const Text('Listening…')
-            else ...[
-              for (final segment in stable)
-                Text(segment.text, key: Key('live_stable_${segment.id}')),
-              if (partial != null)
-                Text(
-                  partial,
-                  key: const Key('meeting_capture_live_partial'),
-                  style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                    color: Theme.of(context).colorScheme.outline,
-                  ),
-                ),
-            ],
-          ],
-        ),
-      ),
-    );
   }
 }
 

--- a/packages/feature_mind/lib/src/capture/presentation/meeting_capture_screen.dart
+++ b/packages/feature_mind/lib/src/capture/presentation/meeting_capture_screen.dart
@@ -341,6 +341,17 @@ class _MeetingCaptureScreenState extends ConsumerState<MeetingCaptureScreen> {
                       ),
                     ),
                   ),
+                if (showLive && _liveCoordinator!.degradedMessage != null)
+                  Padding(
+                    padding: const EdgeInsets.fromLTRB(16, 4, 16, 0),
+                    child: Text(
+                      _liveCoordinator!.degradedMessage!,
+                      key: const Key('meeting_capture_live_degraded'),
+                      style: TextStyle(
+                        color: Theme.of(context).colorScheme.error,
+                      ),
+                    ),
+                  ),
                 Expanded(
                   child: Row(
                     crossAxisAlignment: CrossAxisAlignment.stretch,

--- a/packages/feature_mind/lib/src/capture/presentation/speaker_activity_timeline.dart
+++ b/packages/feature_mind/lib/src/capture/presentation/speaker_activity_timeline.dart
@@ -1,0 +1,166 @@
+import 'package:flutter/material.dart';
+
+import '../domain/live_speaker_label.dart';
+import '../domain/speaker_activity_span.dart';
+
+/// Per-speaker activity lanes for provisional live diarization (`P1`).
+///
+/// Does not color amplitude bars — separate lanes only. Assignments may be
+/// reconciled after recording by final diarization.
+class SpeakerActivityTimeline extends StatelessWidget {
+  const SpeakerActivityTimeline({
+    required this.spans,
+    required this.timelineEndMs,
+    this.windowMs = 30000,
+    this.activeSpeakerIndex,
+    super.key,
+  });
+
+  final List<SpeakerActivitySpan> spans;
+  final int timelineEndMs;
+  final int windowMs;
+  final int? activeSpeakerIndex;
+
+  @override
+  Widget build(BuildContext context) {
+    if (spans.isEmpty && activeSpeakerIndex == null) {
+      return const SizedBox.shrink();
+    }
+
+    final theme = Theme.of(context);
+    final windowStart = timelineEndMs > windowMs ? timelineEndMs - windowMs : 0;
+    final speakerIndices = _laneIndices(spans, activeSpeakerIndex);
+
+    return Column(
+      key: const Key('meeting_capture_speaker_activity'),
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Text(
+          'Speaker activity',
+          style: theme.textTheme.labelSmall?.copyWith(
+            letterSpacing: 1.1,
+            fontWeight: FontWeight.w700,
+          ),
+        ),
+        const SizedBox(height: 6),
+        for (final index in speakerIndices)
+          _SpeakerLane(
+            speakerIndex: index,
+            spans: spans,
+            windowStartMs: windowStart,
+            windowEndMs: timelineEndMs,
+            isActive: activeSpeakerIndex == index,
+          ),
+      ],
+    );
+  }
+
+  List<int> _laneIndices(
+    List<SpeakerActivitySpan> spans,
+    int? activeSpeakerIndex,
+  ) {
+    final indices = <int>{};
+    for (final span in spans) {
+      indices.add(span.speakerIndex);
+    }
+    if (activeSpeakerIndex != null) {
+      indices.add(activeSpeakerIndex);
+    }
+    final sorted = indices.toList()..sort();
+    return sorted;
+  }
+}
+
+class _SpeakerLane extends StatelessWidget {
+  const _SpeakerLane({
+    required this.speakerIndex,
+    required this.spans,
+    required this.windowStartMs,
+    required this.windowEndMs,
+    required this.isActive,
+  });
+
+  final int speakerIndex;
+  final List<SpeakerActivitySpan> spans;
+  final int windowStartMs;
+  final int windowEndMs;
+  final bool isActive;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final laneSpans = spans
+        .where((span) => span.speakerIndex == speakerIndex)
+        .where((span) => span.endMs > windowStartMs)
+        .toList();
+    final windowWidth = (windowEndMs - windowStartMs).clamp(1, 1 << 30);
+    final label = formatLiveSpeakerLabel('sp$speakerIndex');
+    final laneColor = theme.colorScheme.primary;
+
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 6),
+      child: Row(
+        children: [
+          Expanded(
+            child: LayoutBuilder(
+              builder: (context, constraints) {
+                final width = constraints.maxWidth;
+                return SizedBox(
+                  height: 14,
+                  child: Stack(
+                    clipBehavior: Clip.none,
+                    children: [
+                      for (final span in laneSpans)
+                        Positioned(
+                          left: _fraction(span.startMs, windowStartMs, windowWidth) * width,
+                          width: _spanWidth(span, windowStartMs, windowWidth, width),
+                          top: 3,
+                          height: 8,
+                          child: DecoratedBox(
+                            decoration: BoxDecoration(
+                              color: laneColor.withValues(
+                                alpha: isActive ? 0.85 : 0.55,
+                              ),
+                              borderRadius: BorderRadius.circular(2),
+                            ),
+                          ),
+                        ),
+                    ],
+                  ),
+                );
+              },
+            ),
+          ),
+          const SizedBox(width: 8),
+          Text(
+            label,
+            key: Key('speaker_lane_label_$speakerIndex'),
+            style: theme.textTheme.labelSmall?.copyWith(
+              fontWeight: isActive ? FontWeight.w700 : FontWeight.w500,
+              color: isActive
+                  ? theme.colorScheme.onSurface
+                  : theme.colorScheme.outline,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  double _fraction(int ms, int windowStartMs, int windowWidth) {
+    final clamped = ms.clamp(windowStartMs, windowStartMs + windowWidth);
+    return (clamped - windowStartMs) / windowWidth;
+  }
+
+  double _spanWidth(
+    SpeakerActivitySpan span,
+    int windowStartMs,
+    int windowWidth,
+    double laneWidth,
+  ) {
+    final start = span.startMs.clamp(windowStartMs, windowStartMs + windowWidth);
+    final end = span.endMs.clamp(windowStartMs, windowStartMs + windowWidth);
+    final fraction = (end - start) / windowWidth;
+    return (fraction * laneWidth).clamp(4.0, laneWidth);
+  }
+}

--- a/packages/feature_mind/test/capture/application/meeting_live_session_coordinator_test.dart
+++ b/packages/feature_mind/test/capture/application/meeting_live_session_coordinator_test.dart
@@ -1,0 +1,238 @@
+import 'dart:async';
+
+import 'package:feature_mind/src/bridges/mind_speech_bridge.dart';
+import 'package:feature_mind/src/capture/application/meeting_live_session_coordinator.dart';
+import 'package:feature_mind/src/whisper/api/meetings.dart' as rust;
+import 'package:flutter_test/flutter_test.dart';
+
+import '../../support/fake_bridges.dart';
+import '../../support/fake_live_pcm_shim.dart';
+
+void main() {
+  test('stable segments accumulate and partial tail clears on stable', () async {
+    final bridge = FakeMindSpeechBridge();
+    final shim = FakeLivePcmShim();
+    final controller = StreamController<TranscriptEvent>();
+    bridge.transcriptEvents = [];
+
+    final coordinator = MeetingLiveSessionCoordinator(
+      speechBridge: _LiveSessionBridge(bridge, controller),
+      pcmShim: shim,
+    );
+
+    unawaited(coordinator.start(meetingId: 'm1'));
+
+    controller.add(
+      TranscriptEventDelta(
+        TranscriptDelta(
+          sessionId: 'm1',
+          segmentId: 's0',
+          text: 'hello',
+          startMs: 0,
+          endMs: 1000,
+          state: rust.TranscriptSegmentStateWire.partial,
+          speakerLabel: 'sp0',
+        ),
+      ),
+    );
+    await pumpEventQueue();
+
+    expect(coordinator.partialText, 'hello');
+    expect(coordinator.transcriptLines.length, 1);
+    expect(coordinator.transcriptLines.first.isPartial, isTrue);
+    expect(coordinator.activeSpeakerIndex, 0);
+
+    controller.add(
+      TranscriptEventDelta(
+        TranscriptDelta(
+          sessionId: 'm1',
+          segmentId: 's0',
+          text: 'hello there',
+          startMs: 0,
+          endMs: 1200,
+          state: rust.TranscriptSegmentStateWire.stable,
+          speakerLabel: 'sp0',
+        ),
+      ),
+    );
+    await pumpEventQueue();
+
+    expect(coordinator.partialText, isNull);
+    expect(coordinator.stableSegments.length, 1);
+    expect(coordinator.stableSegments.first.text, 'hello there');
+    expect(coordinator.speakerActivitySpans.length, 1);
+    expect(coordinator.speakerActivitySpans.first.speakerIndex, 0);
+
+    await coordinator.cancel();
+    await controller.close();
+  });
+
+  test('degraded message is retained for UI surfacing', () async {
+    final bridge = FakeMindSpeechBridge();
+    final shim = FakeLivePcmShim();
+    final controller = StreamController<TranscriptEvent>();
+
+    final coordinator = MeetingLiveSessionCoordinator(
+      speechBridge: _LiveSessionBridge(bridge, controller),
+      pcmShim: shim,
+    );
+
+    unawaited(coordinator.start(meetingId: 'm2'));
+    controller.add(
+      const TranscriptEventDegraded('Live transcript quality reduced'),
+    );
+    await pumpEventQueue();
+
+    expect(coordinator.degradedMessage, 'Live transcript quality reduced');
+
+    await coordinator.cancel();
+    await controller.close();
+  });
+
+  test('pause and resume gate the PCM shim', () async {
+    final bridge = FakeMindSpeechBridge();
+    final shim = FakeLivePcmShim();
+    final controller = StreamController<TranscriptEvent>();
+
+    final coordinator = MeetingLiveSessionCoordinator(
+      speechBridge: _LiveSessionBridge(bridge, controller),
+      pcmShim: shim,
+    );
+
+    await coordinator.start(meetingId: 'm3');
+    expect(shim.startCalls, 1);
+
+    await coordinator.pause();
+    expect(shim.pauseCalls, 1);
+    expect(shim.paused, isTrue);
+
+    await coordinator.resume();
+    expect(shim.resumeCalls, 1);
+    expect(shim.paused, isFalse);
+
+    await coordinator.cancel();
+    await controller.close();
+  });
+
+  test('amplitude samples ring buffers recent levels', () async {
+    final bridge = FakeMindSpeechBridge();
+    final shim = FakeLivePcmShim();
+    final controller = StreamController<TranscriptEvent>();
+
+    final coordinator = MeetingLiveSessionCoordinator(
+      speechBridge: _LiveSessionBridge(bridge, controller),
+      pcmShim: shim,
+    );
+
+    await coordinator.start(meetingId: 'm4');
+    for (var i = 0; i < 15; i++) {
+      shim.emitAmplitude(i / 15.0);
+    }
+    await pumpEventQueue();
+
+    expect(coordinator.amplitudeSamples.length, 12);
+    expect(coordinator.amplitudeSamples.last, greaterThan(0.8));
+
+    await coordinator.cancel();
+    await controller.close();
+  });
+}
+
+/// Routes [startLiveSession] to a controllable stream for tests.
+class _LiveSessionBridge implements MindSpeechBridge {
+  _LiveSessionBridge(this._inner, this._liveStream);
+
+  final FakeMindSpeechBridge _inner;
+  final StreamController<TranscriptEvent> _liveStream;
+
+  @override
+  Future<void> loadLibrary() => _inner.loadLibrary();
+
+  @override
+  bool isReady() => _inner.isReady();
+
+  @override
+  Future<void> initialize({
+    required String modelsDir,
+    required String storePath,
+    required int memoryBudgetMb,
+    rust.SpeechLanguage speechLanguage = rust.SpeechLanguage.englishOnly,
+  }) =>
+      _inner.initialize(
+        modelsDir: modelsDir,
+        storePath: storePath,
+        memoryBudgetMb: memoryBudgetMb,
+        speechLanguage: speechLanguage,
+      );
+
+  @override
+  Stream<TranscriptEvent> transcribe({
+    required String wavPath,
+    String? language,
+  }) =>
+      _inner.transcribe(wavPath: wavPath, language: language);
+
+  @override
+  Stream<TranscriptEvent> startLiveSession({
+    required String meetingId,
+    String? language,
+  }) =>
+      _liveStream.stream;
+
+  @override
+  void pushLivePcm({required String sessionId, required List<int> samples}) {}
+
+  @override
+  void pauseLiveSession({required String sessionId}) {}
+
+  @override
+  void resumeLiveSession({required String sessionId}) {}
+
+  @override
+  Future<void> stopLiveSession({required String sessionId}) async {}
+
+  @override
+  void cancelLiveSession({required String sessionId}) {}
+
+  @override
+  Future<String> save({
+    required String title,
+    required int recordedAtMs,
+    required String transcript,
+    required String minutes,
+    required String model,
+    required List<TranscriptSegment> segments,
+    required String wavPath,
+    List<rust.MeetingDecisionRecord> decisions = const [],
+    List<rust.MeetingActionItemRecord> actionItems = const [],
+    List<rust.MeetingMetricRecord> metrics = const [],
+  }) =>
+      _inner.save(
+        title: title,
+        recordedAtMs: recordedAtMs,
+        transcript: transcript,
+        minutes: minutes,
+        model: model,
+        segments: segments,
+        wavPath: wavPath,
+        decisions: decisions,
+        actionItems: actionItems,
+        metrics: metrics,
+      );
+
+  @override
+  Future<rust.TranscriptDocumentRecord?> getTranscript(String meetingId) =>
+      _inner.getTranscript(meetingId);
+
+  @override
+  void cancel() => _inner.cancel();
+
+  @override
+  Future<List<rust.MeetingRecord>> meetings() => _inner.meetings();
+
+  @override
+  Future<List<rust.SearchHit>> search(String query) => _inner.search(query);
+
+  @override
+  Future<rust.MeetingRecord?> meeting(String id) => _inner.meeting(id);
+}

--- a/packages/feature_mind/test/capture/domain/live_speaker_label_test.dart
+++ b/packages/feature_mind/test/capture/domain/live_speaker_label_test.dart
@@ -1,0 +1,23 @@
+import 'package:feature_mind/src/capture/domain/live_speaker_label.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('maps sp labels to Speaker N', () {
+    expect(formatLiveSpeakerLabel('sp0'), 'Speaker 1');
+    expect(formatLiveSpeakerLabel('sp1'), 'Speaker 2');
+  });
+
+  test('defaults to Speaker 1 when unknown', () {
+    expect(formatLiveSpeakerLabel(null), 'Speaker 1');
+    expect(formatLiveSpeakerLabel(''), 'Speaker 1');
+  });
+
+  test('preserves resolved display names', () {
+    expect(formatLiveSpeakerLabel('Rahul'), 'Rahul');
+  });
+
+  test('formats segment clock from start ms', () {
+    expect(formatLiveSegmentClock(0), '00:00');
+    expect(formatLiveSegmentClock(65000), '01:05');
+  });
+}

--- a/packages/feature_mind/test/capture/domain/live_speaker_label_test.dart
+++ b/packages/feature_mind/test/capture/domain/live_speaker_label_test.dart
@@ -7,6 +7,13 @@ void main() {
     expect(formatLiveSpeakerLabel('sp1'), 'Speaker 2');
   });
 
+  test('parses sp labels to zero-based index', () {
+    expect(parseLiveSpeakerIndex('sp0'), 0);
+    expect(parseLiveSpeakerIndex('sp1'), 1);
+    expect(parseLiveSpeakerIndex(null), isNull);
+    expect(parseLiveSpeakerIndex('Rahul'), isNull);
+  });
+
   test('defaults to Speaker 1 when unknown', () {
     expect(formatLiveSpeakerLabel(null), 'Speaker 1');
     expect(formatLiveSpeakerLabel(''), 'Speaker 1');

--- a/packages/feature_mind/test/capture/presentation/audio_amplitude_meter_test.dart
+++ b/packages/feature_mind/test/capture/presentation/audio_amplitude_meter_test.dart
@@ -1,0 +1,35 @@
+import 'package:feature_mind/src/capture/presentation/audio_amplitude_meter.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('renders amplitude bars from recent samples', (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: AudioAmplitudeMeter(
+            samples: [0.1, 0.3, 0.5, 0.8],
+            isPaused: false,
+          ),
+        ),
+      ),
+    );
+
+    expect(find.byKey(const Key('meeting_capture_amplitude_meter')), findsOneWidget);
+  });
+
+  testWidgets('shows flat bars when paused', (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: AudioAmplitudeMeter(
+            samples: [0.9, 0.9, 0.9],
+            isPaused: true,
+          ),
+        ),
+      ),
+    );
+
+    expect(find.byKey(const Key('meeting_capture_amplitude_meter')), findsOneWidget);
+  });
+}

--- a/packages/feature_mind/test/capture/presentation/live_transcript_view_test.dart
+++ b/packages/feature_mind/test/capture/presentation/live_transcript_view_test.dart
@@ -1,0 +1,60 @@
+import 'package:feature_mind/src/capture/domain/live_transcript_line.dart';
+import 'package:feature_mind/src/capture/presentation/live_transcript_view.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('renders speaker bullet rows and partial cursor', (tester) async {
+    final lines = [
+      const LiveTranscriptLine(
+        segmentId: 's0',
+        speakerLabel: 'Speaker 1',
+        text: 'We need to finish the migration',
+        startMs: 5000,
+        isPartial: false,
+      ),
+      const LiveTranscriptLine(
+        segmentId: 'partial',
+        speakerLabel: 'Speaker 2',
+        text: 'Okay I will take',
+        startMs: 12000,
+        isPartial: true,
+      ),
+    ];
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: LiveTranscriptView(
+            lines: lines,
+            followLive: true,
+            onFollowLiveChanged: (_) {},
+          ),
+        ),
+      ),
+    );
+
+    expect(find.byKey(const Key('meeting_capture_live_transcript')), findsOneWidget);
+    expect(find.text('Speaker 1'), findsOneWidget);
+    expect(find.text('Speaker 2'), findsOneWidget);
+    expect(find.textContaining('We need to finish'), findsOneWidget);
+    expect(find.textContaining('Okay I will take ▌'), findsOneWidget);
+    expect(find.byIcon(Icons.circle), findsNWidgets(2));
+  });
+
+  testWidgets('shows listening placeholder when empty', (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: LiveTranscriptView(
+            lines: const [],
+            followLive: true,
+            onFollowLiveChanged: (_) {},
+          ),
+        ),
+      ),
+    );
+
+    expect(find.byKey(const Key('meeting_capture_live_listening')), findsOneWidget);
+  });
+}

--- a/packages/feature_mind/test/capture/presentation/meeting_capture_screen_test.dart
+++ b/packages/feature_mind/test/capture/presentation/meeting_capture_screen_test.dart
@@ -256,7 +256,10 @@ void main() {
       recorder.calls.where((call) => call.startsWith('start:')),
       isNotEmpty,
     );
-    expect(find.byKey(const Key('meeting_capture_visualizer')), findsOneWidget);
+    expect(
+      find.byKey(const Key('meeting_capture_amplitude_meter')),
+      findsOneWidget,
+    );
     expect(
       find.byKey(const Key('meeting_capture_pause_button')),
       findsOneWidget,

--- a/packages/feature_mind/test/capture/presentation/meeting_capture_screen_test.dart
+++ b/packages/feature_mind/test/capture/presentation/meeting_capture_screen_test.dart
@@ -76,25 +76,16 @@ void main() {
   );
 
   testWidgets(
-    'shows Multilingual · auto-detect badge and offline copy by default (#1774)',
+    'shows compact trust bar with language and on-device copy (#1774)',
     (tester) async {
       await pumpScreen(tester);
 
-      expect(find.byKey(const Key('scribe_trust_signals')), findsOneWidget);
       expect(
-        find.byKey(const Key('scribe_trust_language_badge')),
+        find.byKey(const Key('meeting_capture_compact_trust_bar')),
         findsOneWidget,
       );
       expect(find.text('Multilingual · auto-detect'), findsOneWidget);
       expect(find.text('On this device'), findsOneWidget);
-      expect(
-        find.byKey(const Key('scribe_trust_offline_copy')),
-        findsOneWidget,
-      );
-      expect(
-        find.textContaining('Sharing is always an explicit'),
-        findsOneWidget,
-      );
     },
   );
 

--- a/packages/feature_mind/test/capture/presentation/speaker_activity_timeline_test.dart
+++ b/packages/feature_mind/test/capture/presentation/speaker_activity_timeline_test.dart
@@ -1,0 +1,55 @@
+import 'package:feature_mind/src/capture/domain/speaker_activity_span.dart';
+import 'package:feature_mind/src/capture/presentation/speaker_activity_timeline.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('renders speaker lanes for provisional spans', (tester) async {
+    final spans = [
+      const SpeakerActivitySpan(
+        speakerIndex: 0,
+        startMs: 0,
+        endMs: 4000,
+      ),
+      const SpeakerActivitySpan(
+        speakerIndex: 1,
+        startMs: 5000,
+        endMs: 8000,
+      ),
+    ];
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: SpeakerActivityTimeline(
+            spans: spans,
+            timelineEndMs: 10000,
+            activeSpeakerIndex: 1,
+          ),
+        ),
+      ),
+    );
+
+    expect(find.byKey(const Key('meeting_capture_speaker_activity')), findsOneWidget);
+    expect(find.text('Speaker 1'), findsOneWidget);
+    expect(find.text('Speaker 2'), findsOneWidget);
+    expect(find.byKey(const Key('speaker_lane_label_1')), findsOneWidget);
+  });
+
+  testWidgets('hides when there are no spans and no active speaker', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: SpeakerActivityTimeline(
+            spans: const [],
+            timelineEndMs: 0,
+          ),
+        ),
+      ),
+    );
+
+    expect(find.byKey(const Key('meeting_capture_speaker_activity')), findsNothing);
+  });
+}

--- a/packages/feature_mind/test/support/fake_live_pcm_shim.dart
+++ b/packages/feature_mind/test/support/fake_live_pcm_shim.dart
@@ -1,0 +1,47 @@
+import 'package:feature_mind/src/capture/application/live_pcm_shim_port.dart';
+
+/// Test double for [LivePcmShimPort] — no microphone.
+class FakeLivePcmShim implements LivePcmShimPort {
+  @override
+  void Function(double normalizedRms)? onAmplitude;
+
+  var startCalls = 0;
+  var pauseCalls = 0;
+  var resumeCalls = 0;
+  var stopCalls = 0;
+  String? lastSessionId;
+  bool paused = false;
+
+  @override
+  Future<void> start({required String sessionId}) async {
+    startCalls++;
+    lastSessionId = sessionId;
+    paused = false;
+  }
+
+  @override
+  Future<void> pause() async {
+    pauseCalls++;
+    paused = true;
+  }
+
+  @override
+  Future<void> resume({required String sessionId}) async {
+    resumeCalls++;
+    lastSessionId = sessionId;
+    paused = false;
+  }
+
+  @override
+  Future<void> stop() async {
+    stopCalls++;
+    paused = false;
+  }
+
+  @override
+  Future<void> dispose() async {}
+
+  void emitAmplitude(double level) {
+    onAmplitude?.call(level);
+  }
+}

--- a/rust/airo_mind_audio/src/lib.rs
+++ b/rust/airo_mind_audio/src/lib.rs
@@ -25,7 +25,7 @@ pub use live::{LiveSpeechConfig, LiveSpeechPipeline, LiveStepReport};
 pub use ring::{PcmRingBuffer, RingPushReport};
 pub use speaker_activity::{SpeakerActivitySlice, SpeakerActivityTracker};
 pub use stabilizer::TranscriptStabilizer;
-pub use vad::{EnergyVad, VadState, rms_energy};
+pub use vad::{rms_energy, EnergyVad, VadState};
 
 /// Read [path] and return whisper-ready PCM.
 pub fn preprocess_path(path: &std::path::Path) -> Result<Pcm, String> {

--- a/rust/airo_mind_audio/src/lib.rs
+++ b/rust/airo_mind_audio/src/lib.rs
@@ -11,6 +11,7 @@ mod decode;
 mod live;
 mod resample;
 mod ring;
+mod speaker_activity;
 mod stabilizer;
 mod vad;
 
@@ -22,8 +23,9 @@ pub const TARGET_CHANNELS: u16 = 1;
 
 pub use live::{LiveSpeechConfig, LiveSpeechPipeline, LiveStepReport};
 pub use ring::{PcmRingBuffer, RingPushReport};
+pub use speaker_activity::{SpeakerActivitySlice, SpeakerActivityTracker};
 pub use stabilizer::TranscriptStabilizer;
-pub use vad::{EnergyVad, VadState};
+pub use vad::{EnergyVad, VadState, rms_energy};
 
 /// Read [path] and return whisper-ready PCM.
 pub fn preprocess_path(path: &std::path::Path) -> Result<Pcm, String> {

--- a/rust/airo_mind_audio/src/live.rs
+++ b/rust/airo_mind_audio/src/live.rs
@@ -7,7 +7,7 @@ use airo_mind_core::engine::{
 
 use crate::ring::{PcmRingBuffer, RingPushReport};
 use crate::stabilizer::TranscriptStabilizer;
-use crate::vad::{EnergyVad, VadState, rms_energy};
+use crate::vad::{rms_energy, EnergyVad, VadState};
 use crate::TARGET_SAMPLE_RATE;
 
 /// Configuration for a live session pipeline.
@@ -283,7 +283,9 @@ mod tests {
         .unwrap();
 
         assert!(
-            events.iter().any(|s| s.state == TranscriptSegmentState::Partial),
+            events
+                .iter()
+                .any(|s| s.state == TranscriptSegmentState::Partial),
             "expected partial from engine window"
         );
 
@@ -300,7 +302,9 @@ mod tests {
         .unwrap();
 
         assert!(
-            events.iter().any(|s| s.state == TranscriptSegmentState::Stable),
+            events
+                .iter()
+                .any(|s| s.state == TranscriptSegmentState::Stable),
             "expected stable after silence boundary"
         );
     }

--- a/rust/airo_mind_audio/src/live.rs
+++ b/rust/airo_mind_audio/src/live.rs
@@ -7,7 +7,7 @@ use airo_mind_core::engine::{
 
 use crate::ring::{PcmRingBuffer, RingPushReport};
 use crate::stabilizer::TranscriptStabilizer;
-use crate::vad::{EnergyVad, VadState};
+use crate::vad::{EnergyVad, VadState, rms_energy};
 use crate::TARGET_SAMPLE_RATE;
 
 /// Configuration for a live session pipeline.
@@ -35,11 +35,13 @@ impl Default for LiveSpeechConfig {
 }
 
 /// Outcome of one [`LiveSpeechPipeline::step`].
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub struct LiveStepReport {
     pub ring_push: RingPushReport,
     pub degraded: bool,
     pub vad_state: VadState,
+    /// RMS energy of the inference window used this tick.
+    pub window_energy: f32,
 }
 
 /// Native-owned PCM path: ring → VAD → bounded window → engine → stabilizer.
@@ -99,6 +101,7 @@ impl LiveSpeechPipeline {
         }
 
         let window = self.ring.tail(self.config.window_samples);
+        let window_energy = rms_energy(&window);
         let vad_state = self.vad.process(&window);
         let ring_push = RingPushReport {
             accepted: 0,
@@ -141,6 +144,7 @@ impl LiveSpeechPipeline {
             ring_push,
             degraded: self.ring.dropped_samples() > 0,
             vad_state,
+            window_energy,
         })
     }
 
@@ -158,6 +162,7 @@ impl LiveSpeechPipeline {
         }
 
         let window = self.ring.tail(self.config.window_samples);
+        let window_energy = rms_energy(&window);
         let vad_state = self.vad.process(&window);
         let ring_push = RingPushReport {
             accepted: 0,
@@ -200,6 +205,7 @@ impl LiveSpeechPipeline {
             ring_push,
             degraded: self.ring.dropped_samples() > 0,
             vad_state,
+            window_energy,
         })
     }
 

--- a/rust/airo_mind_audio/src/speaker_activity.rs
+++ b/rust/airo_mind_audio/src/speaker_activity.rs
@@ -40,12 +40,7 @@ impl SpeakerActivityTracker {
     }
 
     /// Commits one stable utterance and returns the provisional speaker index.
-    pub fn on_utterance(
-        &mut self,
-        start_ms: u64,
-        end_ms: u64,
-        peak_energy: f32,
-    ) -> u8 {
+    pub fn on_utterance(&mut self, start_ms: u64, end_ms: u64, peak_energy: f32) -> u8 {
         if self.last_utterance_end_ms > 0 {
             let gap = start_ms.saturating_sub(self.last_utterance_end_ms);
             if gap >= self.long_gap_ms {

--- a/rust/airo_mind_audio/src/speaker_activity.rs
+++ b/rust/airo_mind_audio/src/speaker_activity.rs
@@ -1,0 +1,84 @@
+//! Provisional live speaker activity for visualization (`P1`).
+//!
+//! Turn-taking heuristic on VAD utterance boundaries — not persona recognition.
+//! Post-recording diarization may reconcile assignments.
+
+/// One contiguous speech span attributed to a provisional speaker index.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct SpeakerActivitySlice {
+    pub speaker_index: u8,
+    pub start_ms: u64,
+    pub end_ms: u64,
+    pub peak_energy: f32,
+}
+
+/// Tracks provisional speaker lanes for the live activity timeline.
+#[derive(Clone, Debug, Default)]
+pub struct SpeakerActivityTracker {
+    slices: Vec<SpeakerActivitySlice>,
+    active_speaker: u8,
+    last_utterance_end_ms: u64,
+    long_gap_ms: u64,
+}
+
+impl SpeakerActivityTracker {
+    pub fn new(long_gap_ms: u64) -> Self {
+        Self {
+            slices: Vec::new(),
+            active_speaker: 0,
+            last_utterance_end_ms: 0,
+            long_gap_ms,
+        }
+    }
+
+    pub fn slices(&self) -> &[SpeakerActivitySlice] {
+        &self.slices
+    }
+
+    pub fn active_speaker_index(&self) -> u8 {
+        self.active_speaker
+    }
+
+    /// Commits one stable utterance and returns the provisional speaker index.
+    pub fn on_utterance(
+        &mut self,
+        start_ms: u64,
+        end_ms: u64,
+        peak_energy: f32,
+    ) -> u8 {
+        if self.last_utterance_end_ms > 0 {
+            let gap = start_ms.saturating_sub(self.last_utterance_end_ms);
+            if gap >= self.long_gap_ms {
+                self.active_speaker = (self.active_speaker + 1) % 2;
+            }
+        }
+        let speaker = self.active_speaker;
+        self.slices.push(SpeakerActivitySlice {
+            speaker_index: speaker,
+            start_ms,
+            end_ms,
+            peak_energy,
+        });
+        self.last_utterance_end_ms = end_ms;
+        speaker
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn first_utterance_is_speaker_zero() {
+        let mut tracker = SpeakerActivityTracker::new(1200);
+        assert_eq!(tracker.on_utterance(0, 1000, 0.2), 0);
+    }
+
+    #[test]
+    fn long_gap_toggles_speaker_for_turn_taking() {
+        let mut tracker = SpeakerActivityTracker::new(500);
+        assert_eq!(tracker.on_utterance(0, 1000, 0.2), 0);
+        assert_eq!(tracker.on_utterance(2000, 3000, 0.3), 1);
+        assert_eq!(tracker.on_utterance(5000, 6000, 0.25), 0);
+    }
+}

--- a/rust/airo_mind_audio/src/stabilizer.rs
+++ b/rust/airo_mind_audio/src/stabilizer.rs
@@ -9,6 +9,12 @@ pub struct TranscriptStabilizer {
     hypothesis: Option<TranscriptSegment>,
 }
 
+impl Default for TranscriptStabilizer {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl TranscriptStabilizer {
     pub fn new() -> Self {
         Self {

--- a/rust/airo_mind_audio/src/vad.rs
+++ b/rust/airo_mind_audio/src/vad.rs
@@ -19,8 +19,7 @@ pub struct EnergyVad {
 
 impl EnergyVad {
     pub fn new(threshold: f32, silence_ms: u64, sample_rate_hz: u32) -> Self {
-        let silence_samples_required =
-            (sample_rate_hz as u64 * silence_ms / 1000).max(1) as usize;
+        let silence_samples_required = (sample_rate_hz as u64 * silence_ms / 1000).max(1) as usize;
         Self {
             threshold,
             silence_samples_required,

--- a/rust/airo_mind_audio/src/vad.rs
+++ b/rust/airo_mind_audio/src/vad.rs
@@ -58,7 +58,7 @@ impl EnergyVad {
     }
 }
 
-fn rms_energy(samples: &[i16]) -> f32 {
+pub fn rms_energy(samples: &[i16]) -> f32 {
     if samples.is_empty() {
         return 0.0;
     }

--- a/rust/airo_mind_core/src/engine.rs
+++ b/rust/airo_mind_core/src/engine.rs
@@ -75,12 +75,7 @@ pub struct TranscriptSegment {
 }
 
 impl TranscriptSegment {
-    pub fn new(
-        start_ms: u64,
-        end_ms: u64,
-        text: String,
-        state: TranscriptSegmentState,
-    ) -> Self {
+    pub fn new(start_ms: u64, end_ms: u64, text: String, state: TranscriptSegmentState) -> Self {
         Self {
             start_ms,
             end_ms,

--- a/rust/airo_mind_core/src/models.rs
+++ b/rust/airo_mind_core/src/models.rs
@@ -104,10 +104,7 @@ pub struct ModelRequirement {
 }
 
 /// File/batch transcription: highest quality tier that fits the memory budget.
-pub fn speech_file_requirement(
-    memory_budget_mb: u32,
-    language: ModelLanguage,
-) -> ModelRequirement {
+pub fn speech_file_requirement(memory_budget_mb: u32, language: ModelLanguage) -> ModelRequirement {
     ModelRequirement {
         task: ModelTask::Speech,
         memory_budget_mb,
@@ -119,10 +116,7 @@ pub fn speech_file_requirement(
 
 /// Live sessions: interim cap at Draft until real-time-factor resolution lands
 /// (design spec §6.7 option 1).
-pub fn speech_live_requirement(
-    memory_budget_mb: u32,
-    language: ModelLanguage,
-) -> ModelRequirement {
+pub fn speech_live_requirement(memory_budget_mb: u32, language: ModelLanguage) -> ModelRequirement {
     ModelRequirement {
         task: ModelTask::Speech,
         memory_budget_mb,

--- a/rust/airo_mind_core/src/research/engine.rs
+++ b/rust/airo_mind_core/src/research/engine.rs
@@ -65,10 +65,7 @@ pub struct ResearchEngine {
 }
 
 impl ResearchEngine {
-    pub fn new(
-        engines: Vec<Box<dyn SearchEngine>>,
-        fetcher: Box<dyn SourceFetcher>,
-    ) -> Self {
+    pub fn new(engines: Vec<Box<dyn SearchEngine>>, fetcher: Box<dyn SourceFetcher>) -> Self {
         Self {
             engines,
             fetcher,
@@ -230,10 +227,8 @@ impl ResearchEngine {
             &mut searches_used,
             &mut hits,
         );
-        let mut unique = filter_known_hits(
-            super::search::dedupe_hits(hits.clone()),
-            known_source_urls,
-        );
+        let mut unique =
+            filter_known_hits(super::search::dedupe_hits(hits.clone()), known_source_urls);
         let progress = ResearchProgress {
             searches_used,
             max_searches: budget.max_searches,
@@ -372,8 +367,7 @@ impl ResearchEngine {
         let mut conflicts = 0u32;
         for i in 0..claims.len() {
             for j in (i + 1)..claims.len() {
-                let reasons =
-                    super::evidence::contradiction_reasons(&claims[i].0, &claims[j].0);
+                let reasons = super::evidence::contradiction_reasons(&claims[i].0, &claims[j].0);
                 if reasons.is_empty() {
                     continue;
                 }
@@ -659,10 +653,11 @@ mod tests {
             snippet: "SEARCH SNIPPET ONLY",
         };
         let fetch = FakeFetch { body: PAGE };
-        let mut engine =
-            ResearchEngine::new(vec![Box::new(search)], Box::new(fetch));
+        let mut engine = ResearchEngine::new(vec![Box::new(search)], Box::new(fetch));
         let job_id = engine.start(quick("   "));
-        let events = engine.run(&job_id, &[]).expect("empty questions still admit");
+        let events = engine
+            .run(&job_id, &[])
+            .expect("empty questions still admit");
         assert_eq!(
             events.last().map(|e| e.kind),
             Some(ResearchEventKind::Failed)
@@ -678,8 +673,7 @@ mod tests {
             snippet: "SEARCH SNIPPET ONLY",
         };
         let fetch = FakeFetch { body: PAGE };
-        let mut engine =
-            ResearchEngine::new(vec![Box::new(search)], Box::new(fetch));
+        let mut engine = ResearchEngine::new(vec![Box::new(search)], Box::new(fetch));
         let job_id = engine.start(quick("What is Qwen?"));
         assert_eq!(engine.status(&job_id), Some(ResearchJobState::Created));
         let events = engine.run(&job_id, &[]).expect("run");
@@ -712,8 +706,7 @@ mod tests {
             snippet: "SEARCH SNIPPET ONLY",
         };
         let fetch = FakeFetch { body: PAGE };
-        let mut engine =
-            ResearchEngine::new(vec![Box::new(search)], Box::new(fetch));
+        let mut engine = ResearchEngine::new(vec![Box::new(search)], Box::new(fetch));
         let job_id = engine.start(quick("What is Qwen?"));
         engine.cancel(&job_id).unwrap();
         let events = engine
@@ -737,8 +730,7 @@ mod tests {
             snippet: "SEARCH SNIPPET ONLY",
         };
         let fetch = FakeFetch { body: PAGE };
-        let mut engine =
-            ResearchEngine::new(vec![Box::new(search)], Box::new(fetch));
+        let mut engine = ResearchEngine::new(vec![Box::new(search)], Box::new(fetch));
         let job_id = engine.start(quick("What is Qwen?"));
         engine.pause(&job_id).unwrap();
         let paused = engine.run(&job_id, &[]).unwrap();
@@ -769,14 +761,10 @@ mod tests {
             snippet: "SEARCH SNIPPET ONLY",
         };
         let fetch = FakeFetch { body: PAGE };
-        let mut engine =
-            ResearchEngine::new(vec![Box::new(search)], Box::new(fetch));
+        let mut engine = ResearchEngine::new(vec![Box::new(search)], Box::new(fetch));
         let job_id = engine.start(quick("What is Qwen?"));
         let events = engine
-            .run(
-                &job_id,
-                &["https://en.wikipedia.org/wiki/Qwen".to_string()],
-            )
+            .run(&job_id, &["https://en.wikipedia.org/wiki/Qwen".to_string()])
             .expect("run");
         assert!(!events
             .iter()

--- a/rust/airo_mind_core/src/supervisor.rs
+++ b/rust/airo_mind_core/src/supervisor.rs
@@ -192,10 +192,9 @@ impl Supervisor {
     /// Callers must still route work through [`Self::run_speech`] when they need
     /// admission and concurrency enforcement per window.
     pub fn speech_engine(&self) -> Result<&dyn SpeechEngine, RuntimeError> {
-        Ok(self
-            .speech
+        self.speech
             .as_deref()
-            .ok_or(RuntimeError::NoEngine("speech"))?)
+            .ok_or(RuntimeError::NoEngine("speech"))
     }
 
     /// Runs one generation job.

--- a/rust/airo_mind_llama/src/api/research.rs
+++ b/rust/airo_mind_llama/src/api/research.rs
@@ -9,9 +9,8 @@ use std::time::Duration;
 
 use airo_mind_core::research::{
     ResearchCheckpoint, ResearchEngine, ResearchEvent as CoreEvent, ResearchEventKind as CoreKind,
-    ResearchJobState as CoreJobState, ResearchRequest as CoreRequest, ResearchMode,
-    SearchEngine, SearchError, SearchHit, SearchPolicy, SearchRequest, SearchResponse,
-    SourceFetcher,
+    ResearchJobState as CoreJobState, ResearchMode, ResearchRequest as CoreRequest, SearchEngine,
+    SearchError, SearchHit, SearchPolicy, SearchRequest, SearchResponse, SourceFetcher,
 };
 use flutter_rust_bridge::{frb, DartFnFuture};
 
@@ -144,8 +143,7 @@ impl SearchEngine for ChannelSearchEngine {
                 respond_to: tx,
             })
             .map_err(|_| SearchError::Unavailable(self.id))?;
-        rx.recv()
-            .map_err(|_| SearchError::Unavailable(self.id))?
+        rx.recv().map_err(|_| SearchError::Unavailable(self.id))?
     }
 }
 
@@ -174,9 +172,8 @@ fn leak_engine_id(id: String) -> &'static str {
 // Handle
 // ---------------------------------------------------------------------------
 
-type SearchCallback = Arc<
-    dyn Fn(String, FrbSearchRequest) -> DartFnFuture<FrbSearchResponse> + Send + Sync,
->;
+type SearchCallback =
+    Arc<dyn Fn(String, FrbSearchRequest) -> DartFnFuture<FrbSearchResponse> + Send + Sync>;
 type FetchCallback = Arc<dyn Fn(String) -> DartFnFuture<String> + Send + Sync>;
 
 #[frb(opaque)]
@@ -190,10 +187,7 @@ pub struct ResearchServiceHandle {
 /// Create a research service with Dart-injected search/fetch adapters.
 pub fn create_research_service(
     engine_ids: Vec<String>,
-    search: impl Fn(String, FrbSearchRequest) -> DartFnFuture<FrbSearchResponse>
-        + Send
-        + Sync
-        + 'static,
+    search: impl Fn(String, FrbSearchRequest) -> DartFnFuture<FrbSearchResponse> + Send + Sync + 'static,
     fetch: impl Fn(String) -> DartFnFuture<String> + Send + Sync + 'static,
 ) -> ResearchServiceHandle {
     let (io_tx, io_rx) = mpsc::channel();
@@ -271,9 +265,11 @@ pub fn research_checkpoint(
     job_id: String,
 ) -> Option<FrbResearchCheckpoint> {
     let engine = handle.engine.lock().expect("research engine lock");
-    engine.checkpoint(&job_id).map(|checkpoint| FrbResearchCheckpoint {
-        record: checkpoint.to_record(),
-    })
+    engine
+        .checkpoint(&job_id)
+        .map(|checkpoint| FrbResearchCheckpoint {
+            record: checkpoint.to_record(),
+        })
 }
 
 #[frb(sync)]
@@ -281,8 +277,8 @@ pub fn research_restore(
     handle: &ResearchServiceHandle,
     checkpoint: FrbResearchCheckpoint,
 ) -> Result<(), String> {
-    let checkpoint = ResearchCheckpoint::from_record(&checkpoint.record)
-        .map_err(|error| error.to_string())?;
+    let checkpoint =
+        ResearchCheckpoint::from_record(&checkpoint.record).map_err(|error| error.to_string())?;
     handle
         .engine
         .lock()
@@ -351,8 +347,7 @@ pub async fn research_run(
         if let Ok(result) = done_rx.try_recv() {
             let events = result.map_err(|error| error.to_string())?;
             for event in events {
-                sink.add(event.into())
-                    .map_err(|error| error.to_string())?;
+                sink.add(event.into()).map_err(|error| error.to_string())?;
             }
             return Ok(());
         }

--- a/rust/airo_mind_transcript/src/lib.rs
+++ b/rust/airo_mind_transcript/src/lib.rs
@@ -37,8 +37,8 @@ pub use chunk::{Chunk, ChunkConfig, ChunkInput};
 pub use normalize::{NormalizationResult, NumberNormalization, TermCorrection};
 pub use segment::Segment;
 pub use vocabulary::{
-    CorrectionResult, VocabularyCategory, VocabularyContext, VocabularyCorrection,
-    VocabularyEntry, VocabularyIntelligence, VocabularySource,
+    CorrectionResult, VocabularyCategory, VocabularyContext, VocabularyCorrection, VocabularyEntry,
+    VocabularyIntelligence, VocabularySource,
 };
 
 /// One segment's raw and normalized text side by side, with its timestamps

--- a/rust/airo_mind_transcript/src/lib.rs
+++ b/rust/airo_mind_transcript/src/lib.rs
@@ -31,10 +31,15 @@
 pub mod chunk;
 pub mod normalize;
 pub mod segment;
+pub mod vocabulary;
 
 pub use chunk::{Chunk, ChunkConfig, ChunkInput};
 pub use normalize::{NormalizationResult, NumberNormalization, TermCorrection};
 pub use segment::Segment;
+pub use vocabulary::{
+    CorrectionResult, VocabularyCategory, VocabularyContext, VocabularyCorrection,
+    VocabularyEntry, VocabularyIntelligence, VocabularySource,
+};
 
 /// One segment's raw and normalized text side by side, with its timestamps
 /// and id carried through unchanged.

--- a/rust/airo_mind_transcript/src/vocabulary.rs
+++ b/rust/airo_mind_transcript/src/vocabulary.rs
@@ -145,7 +145,12 @@ impl VocabularyIntelligence {
             }
         }
 
-        working = correct_fuzzy_words(&working, &self.context, &mut corrections, self.min_confidence);
+        working = correct_fuzzy_words(
+            &working,
+            &self.context,
+            &mut corrections,
+            self.min_confidence,
+        );
 
         let confidence = if corrections.is_empty() {
             1.0
@@ -295,9 +300,16 @@ fn replace_phrase_ci(
 }
 
 fn word_boundary_match(text: &str, start: usize, end: usize) -> bool {
-    let before_ok = start == 0 || !text[..start].chars().last().is_some_and(|c| c.is_alphanumeric());
+    let before_ok = start == 0
+        || !text[..start]
+            .chars()
+            .last()
+            .is_some_and(|c| c.is_alphanumeric());
     let after_ok = end >= text.len()
-        || !text[end..].chars().next().is_some_and(|c| c.is_alphanumeric());
+        || !text[end..]
+            .chars()
+            .next()
+            .is_some_and(|c| c.is_alphanumeric());
     before_ok && after_ok
 }
 
@@ -399,9 +411,7 @@ fn levenshtein(a: &str, b: &str) -> usize {
         cur[0] = i + 1;
         for (j, bc) in b_chars.iter().enumerate() {
             let cost = if ac == bc { 0 } else { 1 };
-            cur[j + 1] = (cur[j] + 1)
-                .min(prev[j + 1] + 1)
-                .min(prev[j] + cost);
+            cur[j + 1] = (cur[j] + 1).min(prev[j + 1] + 1).min(prev[j] + cost);
         }
         prev.clone_from_slice(&cur);
     }
@@ -418,7 +428,10 @@ mod tests {
         let result = intel.correct("we need to update arrow mind");
         assert_eq!(result.corrected_text, "we need to update Airo Mind");
         assert_eq!(result.original_text, "we need to update arrow mind");
-        assert!(result.corrections.iter().any(|c| c.original == "arrow mind"));
+        assert!(result
+            .corrections
+            .iter()
+            .any(|c| c.original == "arrow mind"));
         assert!(result.confidence >= 0.85);
     }
 

--- a/rust/airo_mind_transcript/src/vocabulary.rs
+++ b/rust/airo_mind_transcript/src/vocabulary.rs
@@ -72,7 +72,7 @@ impl VocabularyContext {
             .chain(&self.domain)
             .chain(&self.conversation)
             .collect();
-        entries.sort_by(|a, b| b.priority.cmp(&a.priority));
+        entries.sort_by_key(|a| std::cmp::Reverse(a.priority));
         entries
     }
 }
@@ -337,10 +337,8 @@ fn correct_fuzzy_words(
                 continue;
             }
             let score = *base * (1.0 - dist as f32 * 0.15);
-            if score >= min_confidence {
-                if best.map(|(_, s)| score > s).unwrap_or(true) {
-                    best = Some((entry, score));
-                }
+            if score >= min_confidence && best.map(|(_, s)| score > s).unwrap_or(true) {
+                best = Some((entry, score));
             }
         }
         if let Some((entry, score)) = best {

--- a/rust/airo_mind_transcript/src/vocabulary.rs
+++ b/rust/airo_mind_transcript/src/vocabulary.rs
@@ -1,0 +1,443 @@
+//! Vocabulary Intelligence — confidence-based correction on stable transcript text.
+//!
+//! Runs after the transcript stabilizer commits [`Stable`] segments, not on
+//! every partial token. Preserves raw STT output alongside corrections for
+//! provenance (`ADR-0022` / Conversation IR).
+
+use std::collections::HashMap;
+
+use crate::normalize::normalize;
+
+/// Layer in the vocabulary stack.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum VocabularyCategory {
+    Product,
+    Technical,
+    Person,
+    Organization,
+    Domain,
+    User,
+}
+
+/// Where an entry came from.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum VocabularySource {
+    Global,
+    UserDefined,
+    Project,
+    DomainPack,
+    Conversation,
+    RecentMemory,
+}
+
+/// One canonical term and its known mis-hearings.
+#[derive(Clone, Debug, PartialEq)]
+pub struct VocabularyEntry {
+    pub canonical: String,
+    pub aliases: Vec<String>,
+    pub phonetic_forms: Vec<String>,
+    pub category: VocabularyCategory,
+    pub source: VocabularySource,
+    pub priority: u8,
+    pub confidence: f32,
+}
+
+/// Named vocabulary layers merged at correction time.
+#[derive(Clone, Debug, Default)]
+pub struct VocabularyContext {
+    pub global: Vec<VocabularyEntry>,
+    pub user: Vec<VocabularyEntry>,
+    pub project: Vec<VocabularyEntry>,
+    pub domain: Vec<VocabularyEntry>,
+    pub conversation: Vec<VocabularyEntry>,
+}
+
+impl VocabularyContext {
+    pub fn with_defaults() -> Self {
+        Self {
+            global: default_global_entries(),
+            user: Vec::new(),
+            project: Vec::new(),
+            domain: Vec::new(),
+            conversation: Vec::new(),
+        }
+    }
+
+    pub fn all_entries(&self) -> Vec<&VocabularyEntry> {
+        let mut entries: Vec<&VocabularyEntry> = self
+            .global
+            .iter()
+            .chain(&self.user)
+            .chain(&self.project)
+            .chain(&self.domain)
+            .chain(&self.conversation)
+            .collect();
+        entries.sort_by(|a, b| b.priority.cmp(&a.priority));
+        entries
+    }
+}
+
+/// One applied substitution with audit metadata.
+#[derive(Clone, Debug, PartialEq)]
+pub struct VocabularyCorrection {
+    pub original: String,
+    pub replacement: String,
+    pub confidence: f32,
+    pub source: VocabularySource,
+}
+
+/// Outcome of correcting one stable segment.
+#[derive(Clone, Debug, PartialEq)]
+pub struct CorrectionResult {
+    pub original_text: String,
+    pub corrected_text: String,
+    pub corrections: Vec<VocabularyCorrection>,
+    pub confidence: f32,
+}
+
+/// Deterministic + phonetic/fuzzy vocabulary corrector (no LLM on the hot path).
+pub struct VocabularyIntelligence {
+    context: VocabularyContext,
+    min_confidence: f32,
+}
+
+impl VocabularyIntelligence {
+    pub fn new(context: VocabularyContext) -> Self {
+        Self {
+            context,
+            min_confidence: 0.85,
+        }
+    }
+
+    pub fn with_defaults() -> Self {
+        Self::new(VocabularyContext::with_defaults())
+    }
+
+    pub fn correct(&self, text: &str) -> CorrectionResult {
+        let original_text = text.to_string();
+        let norm = normalize(text);
+        let mut working = norm.normalized;
+        let mut corrections: Vec<VocabularyCorrection> = norm
+            .terms_corrected
+            .into_iter()
+            .map(|t| VocabularyCorrection {
+                original: t.raw,
+                replacement: t.corrected,
+                confidence: 0.98,
+                source: VocabularySource::Global,
+            })
+            .collect();
+
+        for entry in self.context.all_entries() {
+            for alias in entry.aliases.iter().chain(&entry.phonetic_forms) {
+                if alias.is_empty() {
+                    continue;
+                }
+                let replaced = replace_ci_record(
+                    &working,
+                    alias,
+                    &entry.canonical,
+                    entry.confidence,
+                    entry.source,
+                    &mut corrections,
+                );
+                working = replaced;
+            }
+        }
+
+        working = correct_fuzzy_words(&working, &self.context, &mut corrections, self.min_confidence);
+
+        let confidence = if corrections.is_empty() {
+            1.0
+        } else {
+            corrections.iter().map(|c| c.confidence).fold(1.0, f32::min)
+        };
+
+        CorrectionResult {
+            original_text,
+            corrected_text: working,
+            corrections,
+            confidence,
+        }
+    }
+}
+
+fn default_global_entries() -> Vec<VocabularyEntry> {
+    vec![
+        entry(
+            "Airo Mind",
+            &[
+                "arrow mind",
+                "aero mind",
+                "airo mine",
+                "iro mind",
+                "airomind",
+            ],
+            &["ero mnd", "aro mnd"],
+            VocabularyCategory::Product,
+            VocabularySource::Global,
+            100,
+            0.96,
+        ),
+        entry(
+            "Flutter",
+            &["flatter", "fluter"],
+            &[],
+            VocabularyCategory::Technical,
+            VocabularySource::Global,
+            80,
+            0.9,
+        ),
+        entry(
+            "llama.cpp",
+            &["llama cpp", "llamaCP"],
+            &[],
+            VocabularyCategory::Technical,
+            VocabularySource::Global,
+            80,
+            0.9,
+        ),
+    ]
+}
+
+fn entry(
+    canonical: &str,
+    aliases: &[&str],
+    phonetic: &[&str],
+    category: VocabularyCategory,
+    source: VocabularySource,
+    priority: u8,
+    confidence: f32,
+) -> VocabularyEntry {
+    VocabularyEntry {
+        canonical: canonical.to_string(),
+        aliases: aliases.iter().map(|s| s.to_string()).collect(),
+        phonetic_forms: phonetic.iter().map(|s| s.to_string()).collect(),
+        category,
+        source,
+        priority,
+        confidence,
+    }
+}
+
+fn replace_ci_record(
+    text: &str,
+    needle: &str,
+    replacement: &str,
+    confidence: f32,
+    source: VocabularySource,
+    corrections: &mut Vec<VocabularyCorrection>,
+) -> String {
+    if needle.is_empty() {
+        return text.to_string();
+    }
+    if needle.contains(' ') {
+        return replace_phrase_ci(text, needle, replacement, confidence, source, corrections);
+    }
+    let lower_text = text.to_lowercase();
+    let lower_needle = needle.to_lowercase();
+    let mut result = String::with_capacity(text.len());
+    let mut i = 0usize;
+    while let Some(pos) = lower_text[i..].find(&lower_needle) {
+        let start = i + pos;
+        let end = start + lower_needle.len();
+        if !word_boundary_match(text, start, end) {
+            result.push_str(&text[i..start + 1]);
+            i = start + 1;
+            continue;
+        }
+        result.push_str(&text[i..start]);
+        result.push_str(replacement);
+        corrections.push(VocabularyCorrection {
+            original: text[start..end].to_string(),
+            replacement: replacement.to_string(),
+            confidence,
+            source,
+        });
+        i = end;
+    }
+    result.push_str(&text[i..]);
+    result
+}
+
+fn replace_phrase_ci(
+    text: &str,
+    needle: &str,
+    replacement: &str,
+    confidence: f32,
+    source: VocabularySource,
+    corrections: &mut Vec<VocabularyCorrection>,
+) -> String {
+    let lower_text = text.to_lowercase();
+    let lower_needle = needle.to_lowercase();
+    let mut result = String::with_capacity(text.len());
+    let mut i = 0usize;
+    while let Some(pos) = lower_text[i..].find(&lower_needle) {
+        let start = i + pos;
+        let end = start + lower_needle.len();
+        if !word_boundary_match(text, start, end) {
+            result.push_str(&text[i..start + 1]);
+            i = start + 1;
+            continue;
+        }
+        result.push_str(&text[i..start]);
+        result.push_str(replacement);
+        corrections.push(VocabularyCorrection {
+            original: text[start..end].to_string(),
+            replacement: replacement.to_string(),
+            confidence,
+            source,
+        });
+        i = end;
+    }
+    result.push_str(&text[i..]);
+    result
+}
+
+fn word_boundary_match(text: &str, start: usize, end: usize) -> bool {
+    let before_ok = start == 0 || !text[..start].chars().last().is_some_and(|c| c.is_alphanumeric());
+    let after_ok = end >= text.len()
+        || !text[end..].chars().next().is_some_and(|c| c.is_alphanumeric());
+    before_ok && after_ok
+}
+
+fn correct_fuzzy_words(
+    text: &str,
+    context: &VocabularyContext,
+    corrections: &mut Vec<VocabularyCorrection>,
+    min_confidence: f32,
+) -> String {
+    let dict: HashMap<String, (&VocabularyEntry, f32)> = context
+        .all_entries()
+        .into_iter()
+        .flat_map(|e| {
+            let key = normalize_token(&e.canonical);
+            vec![(key, (e, e.confidence))]
+        })
+        .collect();
+
+    let mut out = String::with_capacity(text.len());
+    for (is_word, piece) in tokenize_words(text) {
+        if !is_word {
+            out.push_str(&piece);
+            continue;
+        }
+        let token = normalize_token(&piece);
+        if dict.contains_key(&token) {
+            out.push_str(&piece);
+            continue;
+        }
+        let mut best: Option<(&VocabularyEntry, f32)> = None;
+        for (canonical_key, (entry, base)) in &dict {
+            let dist = levenshtein(&token, canonical_key);
+            if dist == 0 {
+                continue;
+            }
+            if dist > 2 {
+                continue;
+            }
+            let score = *base * (1.0 - dist as f32 * 0.15);
+            if score >= min_confidence {
+                if best.map(|(_, s)| score > s).unwrap_or(true) {
+                    best = Some((entry, score));
+                }
+            }
+        }
+        if let Some((entry, score)) = best {
+            corrections.push(VocabularyCorrection {
+                original: piece.clone(),
+                replacement: entry.canonical.clone(),
+                confidence: score,
+                source: entry.source,
+            });
+            out.push_str(&entry.canonical);
+        } else {
+            out.push_str(&piece);
+        }
+    }
+    out
+}
+
+fn normalize_token(token: &str) -> String {
+    token
+        .chars()
+        .filter(|c| c.is_ascii_alphanumeric())
+        .collect::<String>()
+        .to_lowercase()
+}
+
+fn tokenize_words(text: &str) -> Vec<(bool, String)> {
+    let mut pieces = Vec::new();
+    let mut current = String::new();
+    let mut current_is_word: Option<bool> = None;
+    for ch in text.chars() {
+        let is_word = ch.is_alphanumeric();
+        match current_is_word {
+            Some(w) if w == is_word => current.push(ch),
+            _ => {
+                if !current.is_empty() {
+                    pieces.push((current_is_word.unwrap(), std::mem::take(&mut current)));
+                }
+                current.push(ch);
+                current_is_word = Some(is_word);
+            }
+        }
+    }
+    if !current.is_empty() {
+        pieces.push((current_is_word.unwrap(), current));
+    }
+    pieces
+}
+
+fn levenshtein(a: &str, b: &str) -> usize {
+    if a == b {
+        return 0;
+    }
+    let a_chars: Vec<char> = a.chars().collect();
+    let b_chars: Vec<char> = b.chars().collect();
+    let mut prev: Vec<usize> = (0..=b_chars.len()).collect();
+    let mut cur = vec![0; b_chars.len() + 1];
+    for (i, ac) in a_chars.iter().enumerate() {
+        cur[0] = i + 1;
+        for (j, bc) in b_chars.iter().enumerate() {
+            let cost = if ac == bc { 0 } else { 1 };
+            cur[j + 1] = (cur[j] + 1)
+                .min(prev[j + 1] + 1)
+                .min(prev[j] + cost);
+        }
+        prev.clone_from_slice(&cur);
+    }
+    prev[b_chars.len()]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn corrects_arrow_mind_to_airo_mind_with_provenance() {
+        let intel = VocabularyIntelligence::with_defaults();
+        let result = intel.correct("we need to update arrow mind");
+        assert_eq!(result.corrected_text, "we need to update Airo Mind");
+        assert_eq!(result.original_text, "we need to update arrow mind");
+        assert!(result.corrections.iter().any(|c| c.original == "arrow mind"));
+        assert!(result.confidence >= 0.85);
+    }
+
+    #[test]
+    fn low_confidence_candidate_is_not_applied() {
+        let intel = VocabularyIntelligence::with_defaults();
+        let result = intel.correct("we will deploy this to arrow");
+        assert_eq!(result.corrected_text, "we will deploy this to arrow");
+    }
+
+    #[test]
+    fn preserves_raw_when_nothing_matches() {
+        let intel = VocabularyIntelligence::with_defaults();
+        let raw = "plain transcript with no hits";
+        let result = intel.correct(raw);
+        assert_eq!(result.original_text, raw);
+        assert_eq!(result.corrected_text, raw);
+        assert!(result.corrections.is_empty());
+    }
+}

--- a/rust/airo_mind_whisper/src/api/meetings.rs
+++ b/rust/airo_mind_whisper/src/api/meetings.rs
@@ -990,6 +990,9 @@ pub fn push_live_pcm(session_id: String, samples: Vec<i16>) -> Result<(), String
     let session = sessions
         .get_mut(&session_id)
         .ok_or_else(|| format!("unknown live session {session_id}"))?;
+    if session.paused {
+        return Ok(());
+    }
     let push_report = session.pipeline.push_pcm(&samples);
     session.last_window_energy = rms_energy(&samples);
     if push_report.dropped > 0 {
@@ -997,9 +1000,6 @@ pub fn push_live_pcm(session_id: String, samples: Vec<i16>) -> Result<(), String
             session,
             "Live transcript quality reduced — audio ring overflow.",
         )?;
-    }
-    if session.paused {
-        return Ok(());
     }
     let session_id = session_id.clone();
     drop(sessions);

--- a/rust/airo_mind_whisper/src/api/meetings.rs
+++ b/rust/airo_mind_whisper/src/api/meetings.rs
@@ -45,17 +45,15 @@ use crate::frb_generated::StreamSink;
 
 use crate::transcript_store;
 use crate::WhisperSpeechEngine;
+use airo_mind_audio::{rms_energy, LiveSpeechConfig, LiveSpeechPipeline, SpeakerActivityTracker};
+use airo_mind_core::engine::TranscriptSegmentState;
 use airo_mind_core::models;
 use airo_mind_core::wav::Pcm;
 use airo_mind_core::{
     ActionStatus, AudioInput, CancelToken, DecisionStatus, EngineError, Meeting, MeetingActionItem,
-    MeetingDecision, MeetingMetric, MeetingStore, ResourceBudget, SearchIndex,
-    Supervisor, TranscriptSegment, TranscriptionOptions,
+    MeetingDecision, MeetingMetric, MeetingStore, ResourceBudget, SearchIndex, Supervisor,
+    TranscriptSegment, TranscriptionOptions,
 };
-use airo_mind_audio::{
-    LiveSpeechConfig, LiveSpeechPipeline, SpeakerActivityTracker, rms_energy,
-};
-use airo_mind_core::engine::TranscriptSegmentState;
 use airo_mind_diarize::{
     diarize_segments, product_diarization_strategy, resolve_embedder, DiarizationStrategy,
     SpeakerEmbedder, SpeakerEnrollmentStore,
@@ -552,8 +550,8 @@ fn ensure_speech_engine_for_requirement(
         .clone()
         .ok_or_else(|| "Airo Mind is not initialised".to_string())?;
 
-    let speech_model = models::resolve(&requirement, &models_dir, &[], false)
-        .map_err(|e| e.to_string())?;
+    let speech_model =
+        models::resolve(&requirement, &models_dir, &[], false).map_err(|e| e.to_string())?;
 
     if lock(&LOADED_SPEECH_PATH).as_deref() == Some(&speech_model.path) {
         return Ok(());
@@ -620,9 +618,10 @@ pub fn initialize(config: MindConfig) -> Result<(), String> {
     *lock(&INITIALIZED_SPEECH_LANGUAGE) = Some(config.speech_language);
     *lock(&LIBRARY) = Some(Library { store, index });
 
-    ensure_speech_engine_for_requirement(
-        models::speech_file_requirement(config.memory_budget_mb, config.speech_language.into()),
-    )?;
+    ensure_speech_engine_for_requirement(models::speech_file_requirement(
+        config.memory_budget_mb,
+        config.speech_language.into(),
+    ))?;
     crate::mind_runtime_state::open_mind_runtime(&config.models_dir)?;
     // Metal device globals are C++ function-local statics. Register after
     // load so this handler runs *before* ggml's unique_ptr destructor.
@@ -814,9 +813,9 @@ fn emit_live_delta(
     };
 
     let speaker_label = match segment.state {
-        TranscriptSegmentState::Partial => {
-            Some(provisional_speaker_label(session.speaker_activity.active_speaker_index()))
-        }
+        TranscriptSegmentState::Partial => Some(provisional_speaker_label(
+            session.speaker_activity.active_speaker_index(),
+        )),
         TranscriptSegmentState::Stable => {
             let index = session.speaker_activity.on_utterance(
                 segment.start_ms,
@@ -1463,10 +1462,8 @@ mod tests {
 
     #[test]
     fn transcript_segment_record_handles_a_single_segment_recording() {
-        let record = transcript_segment_record(
-            0,
-            &TranscriptSegment::final_text(0, 900, "hello".into()),
-        );
+        let record =
+            transcript_segment_record(0, &TranscriptSegment::final_text(0, 900, "hello".into()));
         assert_eq!(record.id, "s0");
         assert_eq!(record.start_ms, 0);
         assert_eq!(record.end_ms, 900);

--- a/rust/airo_mind_whisper/src/api/meetings.rs
+++ b/rust/airo_mind_whisper/src/api/meetings.rs
@@ -59,6 +59,7 @@ use airo_mind_diarize::{
     SpeakerEmbedder, SpeakerEnrollmentStore,
 };
 use airo_mind_transcript::Segment;
+use airo_mind_transcript::VocabularyIntelligence;
 
 // ---------------------------------------------------------------------------
 // Wire types
@@ -505,6 +506,9 @@ struct LiveSessionState {
 static LIVE_SESSIONS: LazyLock<Mutex<HashMap<String, LiveSessionState>>> =
     LazyLock::new(|| Mutex::new(HashMap::new()));
 
+static LIVE_VOCABULARY: LazyLock<VocabularyIntelligence> =
+    LazyLock::new(VocabularyIntelligence::with_defaults);
+
 /// Cross-meeting speaker enrollment profiles synced from Dart (#504).
 static SPEAKER_ENROLLMENT: LazyLock<Mutex<SpeakerEnrollmentStore>> =
     LazyLock::new(|| Mutex::new(SpeakerEnrollmentStore::new()));
@@ -783,16 +787,34 @@ pub fn transcribe_recording(
     })
 }
 
+fn vocabulary_correct_stable(text: &str) -> String {
+    LIVE_VOCABULARY.correct(text).corrected_text
+}
+
 fn emit_live_delta(
     session: &mut LiveSessionState,
     session_id: &str,
     segment: TranscriptSegment,
 ) -> Result<(), String> {
+    let raw_text = segment.text.trim().to_string();
+    let display_text = match segment.state {
+        TranscriptSegmentState::Partial => raw_text.clone(),
+        TranscriptSegmentState::Stable | TranscriptSegmentState::Final => {
+            vocabulary_correct_stable(&raw_text)
+        }
+    };
+
     let segment_id = match segment.state {
         TranscriptSegmentState::Partial => format!("s{}", session.segment_index),
         TranscriptSegmentState::Stable => {
             let id = format!("s{}", session.segment_index);
-            let record = transcript_segment_record(session.segments.len(), &segment);
+            let mut corrected_segment = TranscriptSegment::new(
+                segment.start_ms,
+                segment.end_ms,
+                display_text.clone(),
+                segment.state,
+            );
+            let record = transcript_segment_record(session.segments.len(), &corrected_segment);
             let record = TranscriptSegmentRecord {
                 id: id.clone(),
                 start_ms: record.start_ms,
@@ -810,13 +832,18 @@ fn emit_live_delta(
         }
         TranscriptSegmentState::Final => {
             if let Some(record) = session.segments.last_mut() {
-                let trimmed = segment.text.trim();
-                record.text = trimmed.to_string();
+                record.text = display_text.clone();
                 record.end_ms = segment.end_ms;
                 record.start_ms = segment.start_ms;
                 record.id.clone()
             } else {
-                let record = transcript_segment_record(session.segments.len(), &segment);
+                let mut corrected_segment = TranscriptSegment::new(
+                    segment.start_ms,
+                    segment.end_ms,
+                    display_text.clone(),
+                    segment.state,
+                );
+                let record = transcript_segment_record(session.segments.len(), &corrected_segment);
                 session.segments.push(record.clone());
                 record.id
             }
@@ -827,7 +854,7 @@ fn emit_live_delta(
         session_id: session_id.to_string(),
         segment_id,
         speaker_label: None,
-        text: segment.text.trim().to_string(),
+        text: display_text,
         start_ms: segment.start_ms,
         end_ms: segment.end_ms,
         state: TranscriptSegmentStateWire::from(segment.state),

--- a/rust/airo_mind_whisper/src/api/meetings.rs
+++ b/rust/airo_mind_whisper/src/api/meetings.rs
@@ -52,7 +52,9 @@ use airo_mind_core::{
     MeetingDecision, MeetingMetric, MeetingStore, ResourceBudget, SearchIndex,
     Supervisor, TranscriptSegment, TranscriptionOptions,
 };
-use airo_mind_audio::{LiveSpeechConfig, LiveSpeechPipeline};
+use airo_mind_audio::{
+    LiveSpeechConfig, LiveSpeechPipeline, SpeakerActivityTracker, rms_energy,
+};
 use airo_mind_core::engine::TranscriptSegmentState;
 use airo_mind_diarize::{
     diarize_segments, product_diarization_strategy, resolve_embedder, DiarizationStrategy,
@@ -501,6 +503,9 @@ struct LiveSessionState {
     sink: StreamSink<TranscriptEvent>,
     /// One degradation notice per session — ring overflow can drop many frames.
     degraded_notified: bool,
+    /// Provisional live speaker lanes (`P1`); reconciled after recording.
+    speaker_activity: SpeakerActivityTracker,
+    last_window_energy: f32,
 }
 
 static LIVE_SESSIONS: LazyLock<Mutex<HashMap<String, LiveSessionState>>> =
@@ -791,6 +796,10 @@ fn vocabulary_correct_stable(text: &str) -> String {
     LIVE_VOCABULARY.correct(text).corrected_text
 }
 
+fn provisional_speaker_label(index: u8) -> String {
+    format!("sp{index}")
+}
+
 fn emit_live_delta(
     session: &mut LiveSessionState,
     session_id: &str,
@@ -802,6 +811,24 @@ fn emit_live_delta(
         TranscriptSegmentState::Stable | TranscriptSegmentState::Final => {
             vocabulary_correct_stable(&raw_text)
         }
+    };
+
+    let speaker_label = match segment.state {
+        TranscriptSegmentState::Partial => {
+            Some(provisional_speaker_label(session.speaker_activity.active_speaker_index()))
+        }
+        TranscriptSegmentState::Stable => {
+            let index = session.speaker_activity.on_utterance(
+                segment.start_ms,
+                segment.end_ms,
+                session.last_window_energy,
+            );
+            Some(provisional_speaker_label(index))
+        }
+        TranscriptSegmentState::Final => session
+            .segments
+            .last()
+            .and_then(|record| record.speaker_label.clone()),
     };
 
     let segment_id = match segment.state {
@@ -820,7 +847,7 @@ fn emit_live_delta(
                 start_ms: record.start_ms,
                 end_ms: record.end_ms,
                 text: record.text,
-                speaker_label: None,
+                speaker_label: speaker_label.clone(),
             };
             if !session.transcript.is_empty() {
                 session.transcript.push(' ');
@@ -853,7 +880,7 @@ fn emit_live_delta(
     let delta = TranscriptDeltaRecord {
         session_id: session_id.to_string(),
         segment_id,
-        speaker_label: None,
+        speaker_label,
         text: display_text,
         start_ms: segment.start_ms,
         end_ms: segment.end_ms,
@@ -906,6 +933,7 @@ fn run_live_pipeline_step(session_id: &str) -> Result<(), String> {
             "Live transcript quality reduced — audio ring overflow.",
         )?;
     }
+    session.last_window_energy = report.window_energy;
 
     for segment in produced {
         emit_live_delta(session, session_id, segment)?;
@@ -946,6 +974,8 @@ pub fn start_live_session(
         transcript: String::new(),
         sink,
         degraded_notified: false,
+        speaker_activity: SpeakerActivityTracker::new(1200),
+        last_window_energy: 0.0,
     };
 
     lock(&LIVE_SESSIONS).insert(session_id.clone(), session);
@@ -961,6 +991,7 @@ pub fn push_live_pcm(session_id: String, samples: Vec<i16>) -> Result<(), String
         .get_mut(&session_id)
         .ok_or_else(|| format!("unknown live session {session_id}"))?;
     let push_report = session.pipeline.push_pcm(&samples);
+    session.last_window_energy = rms_energy(&samples);
     if push_report.dropped > 0 {
         maybe_emit_live_degraded(
             session,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements the live-transcript-first capture experience for Airo Mind and adds P1 provisional live speaker activity visualization aligned with the recommended architecture: amplitude and speaker lanes are separate surfaces, and live speaker assignments remain provisional until post-recording diarization reconciles them.

## P0 — Live transcript UX

- Transcript-primary active capture layout (~70% height)
- `LIVE` badge + timer in app bar
- PARTIAL / STABLE / FINAL rendering with follow-live and jump-to-live
- Compact on-device trust bar with detail bottom sheet
- Generic speaker labels with bullet rows (`● Speaker N`)
- **DEGRADED** quality banner when ring overflow occurs
- Pause/resume gates interim PCM shim (no ring advance while paused)

## P0 — Vocabulary Intelligence

- `VocabularyIntelligence` in `airo_mind_transcript` (phrase/alias, normalize, fuzzy with confidence threshold)
- Wired on STABLE/FINAL live deltas in `meetings.rs`
- No LLM on the hot path

## P1 — Live speaker activity

- **Rust:** `SpeakerActivityTracker` — turn-taking heuristic on VAD utterance boundaries
- **Rust:** provisional `sp{N}` labels on STABLE; PARTIAL uses active lane
- **Dart:** `SpeakerActivityTimeline` — per-speaker lanes (not speaker-colored amplitude bars)
- **Dart:** `AudioAmplitudeMeter` — live RMS from PCM shim

## Tests (74 passing in `test/capture/`)

- Coordinator: stable/partial, degraded, pause/resume shim gating, amplitude ring
- `live_transcript_view`, speaker timeline, amplitude meter, vocabulary (Rust)
- Capture screen pre-start consent/trust tests

## Known scope for collective testing

- **Desktop:** interim dual-recorder shim (`MeetingLivePcmShim`) — documented ZC-1 violation
- **Android/iOS:** native capture fan-out (Stage 2) not in this PR — test live on desktop first
- **P2:** persona mapping, voice enrollment, live insights rail content

## Spec

- `docs/superpowers/specs/2026-08-22-live-transcript-ux-vocabulary-design.md`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6db2c21f-f02a-4df9-92b2-e0797ee40b7b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6db2c21f-f02a-4df9-92b2-e0797ee40b7b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

