### PR TITLE
fix(test): initialize binding for agent skill orchestrator tests

### DIFF
--- a/packages/feature_mind/test/agent_chat/domain/services/agent_skill_orchestrator_test.dart
+++ b/packages/feature_mind/test/agent_chat/domain/services/agent_skill_orchestrator_test.dart
@@ -37,6 +37,9 @@ final propertyPurchasePersona = loadPluginSkillFixture(
 );
 
 void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  SharedPreferences.setMockInitialValues({});
+
   group('AgentSkillOrchestrator', () {
     test('parses selected skill ids from json and rejects malformed input', () {
       expect(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes CI `test-core` and PR `tests` failures unrelated to live scribe work.

`LegacyChatEntityGraphImporter` reads SharedPreferences when the entity graph connector runs. Four pinned persona tests in `agent_skill_orchestrator_test.dart` failed with "Binding has not yet been initialized."

## Fix

Initialize `TestWidgetsFlutterBinding` and mock `SharedPreferences` at the start of the orchestrator test `main()` — same pattern used elsewhere in `feature_mind` tests.

## Test plan

- [x] `flutter test test/agent_chat/domain/services/agent_skill_orchestrator_test.dart` — 45 passing
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6db2c21f-f02a-4df9-92b2-e0797ee40b7b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6db2c21f-f02a-4df9-92b2-e0797ee40b7b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

