### PR TITLE
fix(mind): restore live DEGRADED handling after merge regression

### DIFF
--- a/docs/features/airo-mind/LIVE_CAPTURE_FAN_OUT.md
+++ b/docs/features/airo-mind/LIVE_CAPTURE_FAN_OUT.md
@@ -102,8 +102,9 @@ of the following:
 4. It does not change the file path: the encoded file is still written by the
    platform recorder, so durability never depends on the shim.
 
-No shim is in place today. This section exists so that adding one is a
-documented decision rather than a discovery made later during profiling.
+No shim is in place today on Android/iOS. Desktop uses the interim shim below.
+This section exists so adding one elsewhere is a documented decision rather than
+a discovery made later during profiling.
 
 | Platform | Shim | Tracking |
 |---|---|---|
@@ -114,13 +115,13 @@ documented decision rather than a discovery made later during profiling.
 These are the checks that make the rule enforceable rather than aspirational.
 They belong with Stage 2, alongside the code that first fans out.
 
-| Check | Where |
-|---|---|
-| A crash during a live session leaves a file that `transcribe_recording` accepts | Integration test per platform |
-| Live session start on an over-budget device is refused before the mic opens | Host test against `Supervisor` admission |
-| Ring overflow emits DEGRADED and does not grow memory | Host test, fixture PCM, forced stall |
-| No PCM-shaped type crosses the FRB surface | Reviewable in the generated bridge; candidate for a `scripts/check-*` guard once the surface exists |
-| Live transcript UI never rewrites STABLE text | Dart test with scripted event sequences |
+| Check | Where | Status |
+|---|---|---|
+| A crash during a live session leaves a file that `transcribe_recording` accepts | Integration test per platform | Open |
+| Live session start on an over-budget device is refused before the mic opens | Host test against `Supervisor` admission | Open |
+| Ring overflow emits DEGRADED and does not grow memory | `rust/airo_mind_audio/src/live.rs` (`ring_overflow_marks_step_degraded`) + Dart degraded banner test | **Done** (host + UI) |
+| No PCM-shaped type crosses the FRB surface | Reviewable in the generated bridge; candidate for a `scripts/check-*` guard once the surface exists | Open (interim `push_live_pcm` shim documented) |
+| Live transcript UI never rewrites STABLE text | `meeting_live_session_coordinator_test.dart` (stable accumulation) | **Done** (Dart) |
 
 ## References
 

--- a/packages/feature_mind/lib/src/agent_chat/presentation/screens/chat_screen.dart
+++ b/packages/feature_mind/lib/src/agent_chat/presentation/screens/chat_screen.dart
@@ -2368,11 +2368,7 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
               result.message ??
               (result.isError
                   ? 'I could not save that journey locally.'
-<<<<<<< HEAD
-                  : 'Saved the journey on this device.'),
-=======
                   : 'Saved this journey on this device.'),
->>>>>>> 62f329d0 (fix(mind): Route journey offers through adapter projections)
           isUser: false,
           traces: [
             AgentActionTrace(

--- a/packages/feature_mind/lib/src/capture/application/meeting_live_session_coordinator.dart
+++ b/packages/feature_mind/lib/src/capture/application/meeting_live_session_coordinator.dart
@@ -226,13 +226,9 @@ class MeetingLiveSessionCoordinator {
         }
       case TranscriptEventTranscribing():
       case TranscriptEventCancelled():
-      case TranscriptEventDegraded():
         break;
       case TranscriptEventDegraded(:final message):
         _degradedMessage = message;
-        break;
-      case TranscriptEventDegraded(:final message):
-        _partialText = message;
         break;
     }
     onTranscriptChanged?.call();

--- a/packages/feature_mind/pubspec.lock
+++ b/packages/feature_mind/pubspec.lock
@@ -883,10 +883,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
+      sha256: "31bd099b47c10cd1aeb55146a2d46ce0277630ecef3f7dae54ad7873f36696cd"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.19"
+    version: "0.12.20"
   material_color_utilities:
     dependency: transitive
     description:
@@ -899,10 +899,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
+      sha256: "307249ce4ff29d58a18e97f6345f539382eb9c9c29ecda628900f31de0443dd9"
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.0"
+    version: "1.19.0"
   mime:
     dependency: transitive
     description:
@@ -1428,26 +1428,26 @@ packages:
     dependency: transitive
     description:
       name: test
-      sha256: "8d9ceddbab833f180fbefed08afa76d7c03513dfdba87ffcec2718b02bbcbf20"
+      sha256: ca578dc12bb8b2f40b67b7d3bd2fac4f31c01a6ff7130a14e2597b919934507f
       url: "https://pub.dev"
     source: hosted
-    version: "1.31.0"
+    version: "1.31.1"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
+      sha256: "2a122cbe059f8b610d3a5415f42e255b6c17b1f21eee1d960f31080237fb4f11"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.11"
+    version: "0.7.12"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "1991d4cfe85d5043241acac92962c3977c8d2f2add1ee73130c7b286417d1d34"
+      sha256: d2e98ec12998368dc59ddd47ab709f2cd55acd6b66dc7db764455a44082f4bc5
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.17"
+    version: "0.6.18"
   timezone:
     dependency: "direct main"
     description:
@@ -1540,10 +1540,10 @@ packages:
     dependency: transitive
     description:
       name: vector_math
-      sha256: d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b
+      sha256: f36f9f3be64c6198714492bb455c11056e33e2f85d9a0b676a48301e44fdcf47
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.0"
+    version: "2.4.2"
   vm_service:
     dependency: transitive
     description:

--- a/packages/feature_mind/test/capture/presentation/transcription_mode_settings_tile_test.dart
+++ b/packages/feature_mind/test/capture/presentation/transcription_mode_settings_tile_test.dart
@@ -1,0 +1,66 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:feature_mind/src/capture/application/transcription_mode_preference.dart';
+import 'package:feature_mind/src/capture/domain/transcription_mode.dart';
+import 'package:feature_mind/src/capture/presentation/transcription_mode_settings_tile.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('mobile host shows only After recording in dropdown', (tester) async {
+    SharedPreferences.setMockInitialValues({});
+    debugDefaultTargetPlatformOverride = TargetPlatform.android;
+
+    await tester.pumpWidget(
+      ProviderScope(
+        child: MaterialApp(
+          home: Scaffold(
+            body: ListView(
+              children: const [TranscriptionModeSettingsTile()],
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('After recording'), findsOneWidget);
+    expect(find.text('Live'), findsNothing);
+    expect(find.text('Live + refine'), findsNothing);
+    expect(find.textContaining('desktop-only'), findsOneWidget);
+
+    debugDefaultTargetPlatformOverride = null;
+  });
+
+  testWidgets('desktop host lists all transcription modes', (tester) async {
+    SharedPreferences.setMockInitialValues({});
+    debugDefaultTargetPlatformOverride = TargetPlatform.linux;
+
+    await tester.pumpWidget(
+      ProviderScope(
+        child: MaterialApp(
+          home: Scaffold(
+            body: ListView(
+              children: const [TranscriptionModeSettingsTile()],
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(const Key('transcription_mode_settings_dropdown')));
+    await tester.pumpAndSettle();
+
+    expect(find.text('After recording'), findsWidgets);
+    expect(find.text('Live'), findsOneWidget);
+    expect(find.text('Live + refine'), findsOneWidget);
+    expect(find.textContaining('Preview on desktop'), findsOneWidget);
+
+    debugDefaultTargetPlatformOverride = null;
+  });
+}

--- a/packages/feature_mind/test/capture/presentation/transcription_mode_settings_tile_test.dart
+++ b/packages/feature_mind/test/capture/presentation/transcription_mode_settings_tile_test.dart
@@ -4,8 +4,6 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
-import 'package:feature_mind/src/capture/application/transcription_mode_preference.dart';
-import 'package:feature_mind/src/capture/domain/transcription_mode.dart';
 import 'package:feature_mind/src/capture/presentation/transcription_mode_settings_tile.dart';
 
 void main() {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes a merge regression from #1881 that broke live scribe DEGRADED banner surfacing.

`MeetingLiveSessionCoordinator._onEvent` had duplicate `TranscriptEventDegraded` cases — the first empty match swallowed events before `_degradedMessage` could be set; a third case incorrectly wrote degraded text into `_partialText`.

Also:
- Updates `LIVE_CAPTURE_FAN_OUT.md` conformance table (ring overflow + stable immutability marked done)
- Adds widget tests for mobile/desktop transcription mode settings gating

## Test plan

- [x] `flutter test test/capture/` — 83 tests passing
- [x] `flutter test test/capture/presentation/transcription_mode_settings_tile_test.dart`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6db2c21f-f02a-4df9-92b2-e0797ee40b7b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6db2c21f-f02a-4df9-92b2-e0797ee40b7b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

