### PR TITLE
feat(mind): Addon framework GA gates — tokens, workflow policy, spy coverage

### DIFF
--- a/packages/feature_mind/lib/src/addons/graph_workflow/car_purchase_graph_adapter.dart
+++ b/packages/feature_mind/lib/src/addons/graph_workflow/car_purchase_graph_adapter.dart
@@ -8,8 +8,8 @@ import '../../agent_chat/domain/services/chat_entity_graph_pending.dart';
 /// Graph-workflow adapter for the Car Purchase built-in add-on.
 class CarPurchaseGraphAdapter implements GraphWorkflowAddonAdapter {
   CarPurchaseGraphAdapter({
-    ChatEntityGraphPending pending = const ChatEntityGraphPending(),
-  }) : _pending = pending;
+    ChatEntityGraphPending? pending,
+  }) : _pending = pending ?? ChatEntityGraphPending();
 
   static const addonId = 'car-purchase-planner';
   static const templateId = 'car_purchase_v1';

--- a/packages/feature_mind/lib/src/addons/graph_workflow/graph_workflow_coordinator.dart
+++ b/packages/feature_mind/lib/src/addons/graph_workflow/graph_workflow_coordinator.dart
@@ -16,10 +16,10 @@ class GraphWorkflowCoordinator {
     LegacyChatEntityLinker linker = const LegacyChatEntityLinker(),
     GraphWorkflowProjectionBridge projectionBridge =
         const GraphWorkflowProjectionBridge(),
-    ChatEntityGraphPending pending = const ChatEntityGraphPending(),
+    ChatEntityGraphPending? pending,
   }) : _legacyLinker = linker,
        _projectionBridge = projectionBridge,
-       _pending = pending;
+       _pending = pending ?? ChatEntityGraphPending();
 
   final AddonRegistry _registry;
   final LegacyChatEntityLinker _legacyLinker;

--- a/packages/feature_mind/lib/src/addons/graph_workflow/hospital_recovery_graph_adapter.dart
+++ b/packages/feature_mind/lib/src/addons/graph_workflow/hospital_recovery_graph_adapter.dart
@@ -15,10 +15,10 @@ class HospitalRecoveryGraphAdapter implements GraphWorkflowAddonAdapter {
   HospitalRecoveryGraphAdapter({
     LifeTrackFactExtractor facts = const LifeTrackFactExtractor(),
     LegacyChatEntityLinker linker = const LegacyChatEntityLinker(),
-    ChatEntityGraphPending pending = const ChatEntityGraphPending(),
+    ChatEntityGraphPending? pending,
   }) : _facts = facts,
        _linker = linker,
-       _pending = pending;
+       _pending = pending ?? ChatEntityGraphPending();
 
   static const addonId = 'hospital-recovery-planner';
   static const templateId = 'medical_surgery_v1';

--- a/packages/feature_mind/lib/src/addons/graph_workflow/insurance_planner_graph_adapter.dart
+++ b/packages/feature_mind/lib/src/addons/graph_workflow/insurance_planner_graph_adapter.dart
@@ -16,10 +16,10 @@ class InsurancePlannerGraphAdapter implements GraphWorkflowAddonAdapter {
   InsurancePlannerGraphAdapter({
     LifeTrackFactExtractor facts = const LifeTrackFactExtractor(),
     LegacyChatEntityLinker linker = const LegacyChatEntityLinker(),
-    ChatEntityGraphPending pending = const ChatEntityGraphPending(),
+    ChatEntityGraphPending? pending,
   }) : _facts = facts,
        _linker = linker,
-       _pending = pending;
+       _pending = pending ?? ChatEntityGraphPending();
 
   static const addonId = 'insurance-planner';
   static const templateId = 'insurance_claim_v1';

--- a/packages/feature_mind/lib/src/addons/graph_workflow/property_purchase_graph_adapter.dart
+++ b/packages/feature_mind/lib/src/addons/graph_workflow/property_purchase_graph_adapter.dart
@@ -15,10 +15,10 @@ class PropertyPurchaseGraphAdapter implements GraphWorkflowAddonAdapter {
   PropertyPurchaseGraphAdapter({
     LifeTrackFactExtractor facts = const LifeTrackFactExtractor(),
     LegacyChatEntityLinker linker = const LegacyChatEntityLinker(),
-    ChatEntityGraphPending pending = const ChatEntityGraphPending(),
+    ChatEntityGraphPending? pending,
   }) : _facts = facts,
        _linker = linker,
-       _pending = pending;
+       _pending = pending ?? ChatEntityGraphPending();
 
   static const addonId = 'property-purchase-planner';
   static const templateId = 'real_estate_under_construction_v1';

--- a/packages/feature_mind/lib/src/addons/graph_workflow/university_admission_graph_adapter.dart
+++ b/packages/feature_mind/lib/src/addons/graph_workflow/university_admission_graph_adapter.dart
@@ -8,8 +8,8 @@ import '../../agent_chat/domain/services/chat_entity_graph_pending.dart';
 /// Graph-workflow adapter for the University Admission built-in add-on.
 class UniversityAdmissionGraphAdapter implements GraphWorkflowAddonAdapter {
   UniversityAdmissionGraphAdapter({
-    ChatEntityGraphPending pending = const ChatEntityGraphPending(),
-  }) : _pending = pending;
+    ChatEntityGraphPending? pending,
+  }) : _pending = pending ?? ChatEntityGraphPending();
 
   static const addonId = 'university-admission-planner';
   static const templateId = 'university_admission_v1';

--- a/packages/feature_mind/lib/src/addons/templates/addon_template_catalog.dart
+++ b/packages/feature_mind/lib/src/addons/templates/addon_template_catalog.dart
@@ -26,10 +26,12 @@ class AddonTemplateCatalog {
   AddonTemplateCatalog._({
     required this.templates,
     required this.metadataByTemplateId,
+    required this.workflowBlocksByAddonId,
   });
 
   final List<LifeTrackTemplate> templates;
   final Map<String, LifeTrackTemplateAddonMetadata> metadataByTemplateId;
+  final Map<String, Map<String, dynamic>> workflowBlocksByAddonId;
 
   static const bundledJsonlAsset =
       'packages/feature_mind/addons/bundled_workflow_templates.jsonl';
@@ -61,6 +63,7 @@ class AddonTemplateCatalog {
     }
 
     final metadataByTemplateId = <String, LifeTrackTemplateAddonMetadata>{};
+    final workflowBlocksByAddonId = <String, Map<String, dynamic>>{};
     for (final assetPath in bundledManifestAssets) {
       final rawManifest = await assetBundle.loadString(assetPath);
       final decoded = jsonDecode(rawManifest);
@@ -68,6 +71,7 @@ class AddonTemplateCatalog {
       final manifest = AddonManifest.fromJson(decoded);
       final workflow = decoded['workflow'] as Map<String, dynamic>?;
       if (workflow == null) continue;
+      workflowBlocksByAddonId[manifest.id.value] = workflow;
       final templateId = workflow['template_id'] as String?;
       if (templateId == null || templateId.trim().isEmpty) continue;
       metadataByTemplateId[templateId] = LifeTrackTemplateAddonMetadata(
@@ -82,6 +86,7 @@ class AddonTemplateCatalog {
     return AddonTemplateCatalog._(
       templates: List.unmodifiable(templates),
       metadataByTemplateId: metadataByTemplateId,
+      workflowBlocksByAddonId: workflowBlocksByAddonId,
     );
   }
 

--- a/packages/feature_mind/lib/src/addons/workflow/addon_workflow_fact_service.dart
+++ b/packages/feature_mind/lib/src/addons/workflow/addon_workflow_fact_service.dart
@@ -1,0 +1,59 @@
+import '../../agent_chat/domain/services/life_track_fact_extractor.dart';
+import 'addon_workflow_policy.dart';
+
+/// Add-on-owned fact extraction and clarification copy for LifeTrack records.
+class AddonWorkflowFactService {
+  AddonWorkflowFactService({
+    this.facts = const LifeTrackFactExtractor(),
+    AddonWorkflowPolicy? policy,
+  }) : policy = policy ?? AddonWorkflowPolicy.defaults();
+
+  final LifeTrackFactExtractor facts;
+  final AddonWorkflowPolicy policy;
+
+  ExtractedLifeTrackFacts extract(String templateId, String prompt) {
+    switch (templateId) {
+      case 'study_progress_v1':
+        return facts.extractStudyProgress(prompt);
+      case 'medical_surgery_v1':
+        return facts.extractMedicalSurgery(prompt);
+      case 'real_estate_under_construction_v1':
+        return facts.extractPropertyPurchase(prompt);
+      case 'insurance_claim_v1':
+        return facts.extractInsuranceClaim(prompt);
+      default:
+        return facts.extractInsuranceClaim(prompt);
+    }
+  }
+
+  String clarificationHint(String templateId) {
+    final configured = policy.forTemplate(templateId)?.recordClarificationHint;
+    if (configured != null && configured.trim().isNotEmpty) {
+      return configured.trim();
+    }
+    return 'I can store this journey on this device. Paste the key facts you '
+        'already have and I will keep them locally.';
+  }
+
+  bool wantsRecord(AgentSkillRecordContext context) {
+    if (context.skillId == 'record-study-progress') return true;
+    if (!context.skillTools.contains('record_lifetrack_facts')) return false;
+    return facts.wantsRecord(context.prompt) ||
+        facts.wantsStudyRecord(context.prompt);
+  }
+}
+
+/// Minimal skill context for record routing without host template switches.
+class AgentSkillRecordContext {
+  const AgentSkillRecordContext({
+    required this.skillId,
+    required this.skillTools,
+    required this.templateId,
+    required this.prompt,
+  });
+
+  final String skillId;
+  final List<String> skillTools;
+  final String templateId;
+  final String prompt;
+}

--- a/packages/feature_mind/lib/src/addons/workflow/addon_workflow_policy.dart
+++ b/packages/feature_mind/lib/src/addons/workflow/addon_workflow_policy.dart
@@ -1,0 +1,219 @@
+import '../templates/addon_template_catalog.dart';
+
+/// Per-template workflow policy owned by add-on bundles (keywords, pending copy).
+class AddonWorkflowTemplatePolicy {
+  const AddonWorkflowTemplatePolicy({
+    required this.templateId,
+    this.recordClarificationHint = '',
+    this.pendingKeywords = const [],
+    this.pendingUsualOptionalFields = const [],
+    this.pendingEmptyMessage = '',
+    this.pendingSubjectLabel = 'journey',
+  });
+
+  final String templateId;
+  final String recordClarificationHint;
+  final List<String> pendingKeywords;
+  final List<String> pendingUsualOptionalFields;
+  final String pendingEmptyMessage;
+  final String pendingSubjectLabel;
+
+  factory AddonWorkflowTemplatePolicy.fromMetadata(
+    LifeTrackTemplateAddonMetadata metadata,
+    Map<String, dynamic> workflow,
+  ) {
+    return AddonWorkflowTemplatePolicy(
+      templateId: metadata.templateId,
+      recordClarificationHint:
+          workflow['record_clarification_hint'] as String? ?? '',
+      pendingKeywords: _stringList(workflow['pending_keywords']),
+      pendingUsualOptionalFields:
+          _stringList(workflow['pending_usual_optional_fields']),
+      pendingEmptyMessage: workflow['pending_empty_message'] as String? ?? '',
+      pendingSubjectLabel:
+          workflow['pending_subject_label'] as String? ?? 'journey',
+    );
+  }
+
+  static List<String> _stringList(Object? raw) {
+    if (raw is! List) return const [];
+    return raw
+        .map((item) => item.toString().trim())
+        .where((item) => item.isNotEmpty)
+        .toList(growable: false);
+  }
+}
+
+/// Resolves add-on-owned workflow policy for templates and personas.
+class AddonWorkflowPolicy {
+  AddonWorkflowPolicy._(this._byTemplateId);
+
+  final Map<String, AddonWorkflowTemplatePolicy> _byTemplateId;
+
+  AddonWorkflowTemplatePolicy? forTemplate(String templateId) =>
+      _byTemplateId[templateId];
+
+  bool queryMatchesTemplate(String lowerQuery, String templateId) {
+    final policy = forTemplate(templateId);
+    if (policy == null || policy.pendingKeywords.isEmpty) return false;
+    return policy.pendingKeywords.any(lowerQuery.contains);
+  }
+
+  factory AddonWorkflowPolicy.fromCatalog(AddonTemplateCatalog catalog) {
+    final byTemplateId = <String, AddonWorkflowTemplatePolicy>{};
+    for (final template in catalog.templates) {
+      final metadata = catalog.metadataFor(template.templateId);
+      if (metadata == null) continue;
+      final workflow = _workflowForAddon(catalog, metadata.addonId);
+      byTemplateId[template.templateId] = AddonWorkflowTemplatePolicy.fromMetadata(
+        metadata,
+        workflow,
+      );
+    }
+    return AddonWorkflowPolicy._(byTemplateId);
+  }
+
+  static Map<String, dynamic> _workflowForAddon(
+    AddonTemplateCatalog catalog,
+    String addonId,
+  ) {
+    // Metadata is keyed by template; workflow extras are loaded with manifests.
+    return catalog.workflowBlocksByAddonId[addonId] ?? const {};
+  }
+
+  /// Built-in fallbacks when catalog assets are not loaded (unit tests).
+  factory AddonWorkflowPolicy.defaults() {
+    return AddonWorkflowPolicy._({
+      'insurance_claim_v1': const AddonWorkflowTemplatePolicy(
+        templateId: 'insurance_claim_v1',
+        recordClarificationHint:
+            'I can store this claim on this device. Paste the insurer, claim '
+            'ID or broker reference, policy number if you have it, and whether '
+            'documents were received. I will not file the claim or read your email.',
+        pendingKeywords: [
+          'claim',
+          'insurance',
+          'insurer',
+          'document',
+          'reimbursement',
+          'policy',
+        ],
+        pendingUsualOptionalFields: [
+          'Insurer',
+          'Broker / Intermediary',
+          'Policy Number',
+          'Follow-up Log',
+          'Settlement Notes',
+        ],
+        pendingEmptyMessage:
+            'I have no stored claim entities yet. Paste the insurer, claim ID, '
+            'and whether documents were received — I will extract them from this chat.',
+        pendingSubjectLabel: 'claim',
+      ),
+      'medical_surgery_v1': const AddonWorkflowTemplatePolicy(
+        templateId: 'medical_surgery_v1',
+        recordClarificationHint:
+            'I can store this hospital stay on this device. Paste the hospital, '
+            'date, pre-op tests, and authorization reference if you have them. '
+            'I will not diagnose or change a care plan.',
+        pendingKeywords: [
+          'hospital',
+          'surgery',
+          'recovery',
+          'pre-op',
+          'operation',
+          'medical',
+        ],
+        pendingUsualOptionalFields: [
+          'Required Tests List',
+          'Insurance Authorization Reference',
+          'Hospital Checklist',
+          'Recovery Notes',
+        ],
+        pendingEmptyMessage:
+            'I have no stored hospital or surgery entities yet. Paste the '
+            'hospital, surgery date, required tests, and authorization reference '
+            '— I will extract them from this chat.',
+        pendingSubjectLabel: 'hospital',
+      ),
+      'real_estate_under_construction_v1': const AddonWorkflowTemplatePolicy(
+        templateId: 'real_estate_under_construction_v1',
+        recordClarificationHint:
+            'I can store this purchase on this device. Paste the builder, '
+            'project, floor, and RERA number if you have them. I will not '
+            'give legal advice.',
+        pendingKeywords: [
+          'flat',
+          'rera',
+          'property',
+          'builder',
+          'tower',
+          'apartment',
+        ],
+        pendingUsualOptionalFields: [
+          'RERA Registration Number',
+          'Builder Track Record Notes',
+          'Your Target Floor',
+          'Promised Amenities List',
+        ],
+        pendingEmptyMessage:
+            'I have no stored property entities yet. Paste the RERA number, '
+            'builder, project, and floor — I will extract them from this chat.',
+        pendingSubjectLabel: 'property',
+      ),
+      'study_progress_v1': const AddonWorkflowTemplatePolicy(
+        templateId: 'study_progress_v1',
+        recordClarificationHint:
+            'I store study progress as a local LifeTrack — not a notes app. '
+            'Tell me the subject, last topic, and exam date if you have one.',
+        pendingKeywords: ['study', 'subject', 'exam', 'topic', 'course'],
+        pendingUsualOptionalFields: [
+          'Current Topic',
+          'Exam or Goal Date',
+          'Next Session Plan',
+        ],
+        pendingEmptyMessage:
+            'I have no stored study entities yet. Paste the subject and what '
+            'you are working on — I will extract them from this chat.',
+        pendingSubjectLabel: 'study track',
+      ),
+      'car_purchase_v1': const AddonWorkflowTemplatePolicy(
+        templateId: 'car_purchase_v1',
+        recordClarificationHint:
+            'I can store a car purchase decision on this device. Paste the '
+            'vehicle, budget, and test-drive notes if you have them.',
+        pendingKeywords: ['car', 'vehicle', 'budget', 'test drive', 'parking'],
+        pendingUsualOptionalFields: [
+          'Shortlisted Cars',
+          'Test Drive Notes',
+          'Budget Range',
+          'Loan Offers',
+        ],
+        pendingEmptyMessage:
+            'I have no stored vehicle purchase entities yet.',
+        pendingSubjectLabel: 'car purchase',
+      ),
+      'university_admission_v1': const AddonWorkflowTemplatePolicy(
+        templateId: 'university_admission_v1',
+        recordClarificationHint:
+            'I can store an admission cycle on this device. Paste the '
+            'university, program, and intake term if you have them.',
+        pendingKeywords: [
+          'university',
+          'admission',
+          'apply',
+          'application',
+          'program',
+        ],
+        pendingUsualOptionalFields: [
+          'University Shortlist',
+          'Document Checklist',
+          'Submitted Programs',
+        ],
+        pendingEmptyMessage:
+            'I have no stored admission entities yet.',
+        pendingSubjectLabel: 'admission cycle',
+      ),
+    });
+  }
+}

--- a/packages/feature_mind/lib/src/agent_chat/data/connectors/chat_entity_graph_connector.dart
+++ b/packages/feature_mind/lib/src/agent_chat/data/connectors/chat_entity_graph_connector.dart
@@ -51,7 +51,7 @@ class ChatEntityGraphConnector implements AgentConnector {
     required String query,
     bool pending = false,
   }) {
-    const pendingFormatter = ChatEntityGraphPending();
+    final pendingFormatter = ChatEntityGraphPending();
     if (pending || pendingFormatter.wantsPending(query)) {
       return pendingFormatter.format(graph: graph, query: query);
     }

--- a/packages/feature_mind/lib/src/agent_chat/data/connectors/life_track_record_connector.dart
+++ b/packages/feature_mind/lib/src/agent_chat/data/connectors/life_track_record_connector.dart
@@ -3,6 +3,7 @@ import 'package:core_domain/core_domain.dart';
 import '../../../addons/templates/addon_life_track_record_policy.dart';
 import '../../domain/models/agent_skill.dart';
 import '../../domain/services/agent_connector.dart';
+import '../../domain/services/lifetrack_confirmation_token_service.dart';
 
 class LifeTrackRecordConnector implements AgentConnector {
   LifeTrackRecordConnector({
@@ -15,13 +16,20 @@ class LifeTrackRecordConnector implements AgentConnector {
     LifeTrackFactPatch patch = const LifeTrackFactPatch(),
     String Function(String templateId)? followUpHint,
     List<String> Function(String templateId)? dedupeFieldLabels,
+    LifeTrackConfirmationTokenService? confirmationTokens,
+    Future<bool> Function()? writeGate,
+    IdempotentEffectPort? idempotencyPort,
   }) : _repository = repository,
        _resolveTemplate = resolveTemplate,
        _now = now ?? DateTime.now,
        _newTrackId = newTrackId ?? _defaultTrackId,
        _patch = patch,
        _followUpHint = followUpHint ?? _defaultFollowUpHint,
-       _dedupeFieldLabels = dedupeFieldLabels ?? _defaultDedupeFieldLabels;
+       _dedupeFieldLabels = dedupeFieldLabels ?? _defaultDedupeFieldLabels,
+       _confirmationTokens =
+           confirmationTokens ?? LifeTrackConfirmationTokenService(),
+       _writeGate = writeGate,
+       _idempotencyPort = idempotencyPort;
 
   final LifeTrackRepository _repository;
   final Future<LifeTrackTemplate?> Function(String templateId) _resolveTemplate;
@@ -31,6 +39,9 @@ class LifeTrackRecordConnector implements AgentConnector {
   final LifeTrackFactPatch _patch;
   final String Function(String templateId) _followUpHint;
   final List<String> Function(String templateId) _dedupeFieldLabels;
+  final LifeTrackConfirmationTokenService _confirmationTokens;
+  final Future<bool> Function()? _writeGate;
+  final IdempotentEffectPort? _idempotencyPort;
 
   static String _defaultFollowUpHint(String templateId) {
     if (templateId == 'study_progress_v1') {
@@ -70,27 +81,62 @@ class LifeTrackRecordConnector implements AgentConnector {
 
     await ensureInitialized?.call();
 
+    if (_writeGate != null && !await _writeGate!()) {
+      return const ConnectorResult.error(
+        code: 'addon_write_failed',
+        message:
+            'LifeTrack writes require encrypted storage on this device. '
+            'Open Settings to finish secure storage setup, then try again.',
+      );
+    }
+
+    final payload = {
+      'title': title,
+      'template_id': templateId,
+      'facts': facts,
+    };
+
     final preview = _preview(
       title: title,
       templateId: templateId,
       facts: facts,
     );
-    final confirmed =
+
+    final token = arguments['confirmation_token'] as String?;
+    final legacyConfirmed =
         arguments['confirmed'] == true && arguments['source'] == 'user_confirm';
-    if (!confirmed) {
+    if (token == null && !legacyConfirmed) {
+      final issued = _confirmationTokens.issue(
+        destinationTool: name,
+        payload: payload,
+      );
       return ConnectorResult.error(
         code: 'confirmation_required',
         message: '$preview\n\nReply yes to save this journey on this device.',
         data: {
           'pending': {
-            'title': title,
-            'template_id': templateId,
-            'facts': facts,
+            ...payload,
             'confirmed': true,
             'source': 'user_confirm',
           },
+          'confirmation_token': issued,
         },
       );
+    }
+
+    if (token != null) {
+      final tokenError = _confirmationTokens.validateAndConsume(
+        token: token,
+        destinationTool: name,
+        payload: payload,
+      );
+      if (tokenError != null) {
+        return ConnectorResult.error(
+          code: tokenError,
+          message: 'That save confirmation expired or no longer matches. '
+              'Ask me to save again and confirm the new preview.',
+        );
+      }
     }
 
     final template = await _resolveTemplate(templateId);
@@ -126,9 +172,58 @@ class LifeTrackRecordConnector implements AgentConnector {
       now: now,
     );
 
+    final idempotencyKey =
+        arguments['idempotency_key'] as String? ??
+        'lifetrack:${updated.id}:${_confirmationTokens.confirmationHashFor(
+          destinationTool: name,
+          payload: payload,
+        )}';
+    final confirmationHash = _confirmationTokens.confirmationHashFor(
+      destinationTool: name,
+      payload: payload,
+    );
+
+    if (_idempotencyPort != null) {
+      final existingEffect = await _idempotencyPort!.findByKey(idempotencyKey);
+      if (existingEffect case Ok<IdempotentEffectRecord?>(value: final record)) {
+        if (record != null &&
+            record.state == IdempotentEffectState.committed) {
+          final trackResult = await _repository.getTrack(updated.id);
+          if (trackResult case Ok<LifeTrack>(value: final track)) {
+            return ConnectorResult(
+              data: {
+                'source': 'local_lifetrack_repository',
+                'created': created,
+                'track_id': track.id,
+                'title': track.title,
+                'template_id': track.templateId,
+                'markdown': _savedMessage(track, created: created),
+                'idempotent_replay': true,
+              },
+              message: _savedMessage(track, created: created),
+            );
+          }
+        }
+      }
+      final begin = await _idempotencyPort!.beginEffect(
+        idempotencyKey: idempotencyKey,
+        confirmationHash: confirmationHash,
+        resourceId: updated.id,
+      );
+      if (begin case Err<IdempotentEffectRecord>(error: final error)) {
+        return ConnectorResult.error(
+          code: 'addon_write_failed',
+          message: error.toString(),
+        );
+      }
+    }
+
     if (created) {
       final createResult = await _repository.createTrack(updated);
       if (createResult case Err<LifeTrack>(error: final error)) {
+        if (_idempotencyPort != null) {
+          await _idempotencyPort!.markFailed(idempotencyKey);
+        }
         return ConnectorResult.error(
           code: 'lifetrack_write_failed',
           message: error.toString(),
@@ -137,11 +232,21 @@ class LifeTrackRecordConnector implements AgentConnector {
     } else {
       final updateResult = await _repository.updateTrack(updated);
       if (updateResult case Err<void>(error: final error)) {
+        if (_idempotencyPort != null) {
+          await _idempotencyPort!.markFailed(idempotencyKey);
+        }
         return ConnectorResult.error(
           code: 'lifetrack_write_failed',
           message: error.toString(),
         );
       }
+    }
+
+    if (_idempotencyPort != null) {
+      await _idempotencyPort!.commitEffect(
+        idempotencyKey: idempotencyKey,
+        destinationReceipt: updated.id,
+      );
     }
 
     return ConnectorResult(

--- a/packages/feature_mind/lib/src/agent_chat/domain/services/agent_skill_orchestrator.dart
+++ b/packages/feature_mind/lib/src/agent_chat/domain/services/agent_skill_orchestrator.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 
 import 'package:core_ai/core_ai.dart';
 
+import '../../../addons/workflow/addon_workflow_fact_service.dart';
 import '../../../runtime/models/capability_models.dart';
 import '../../../runtime/models/log_models.dart';
 import '../../../runtime/ports/operation_log_port.dart';
@@ -92,9 +93,15 @@ abstract interface class AgentSkillModelClient {
 }
 
 class RuleBasedAgentSkillModelClient implements AgentSkillModelClient {
+  RuleBasedAgentSkillModelClient({
+    AddonWorkflowFactService? factService,
+    ChatEntityGraphPending? graphPending,
+  }) : _factService = factService ?? AddonWorkflowFactService(),
+       _graphPending = graphPending ?? ChatEntityGraphPending();
+
   static const _reminderParser = ReminderRequestParser();
-  static const _lifeTrackFacts = LifeTrackFactExtractor();
-  static const _graphPending = ChatEntityGraphPending();
+  final AddonWorkflowFactService _factService;
+  final ChatEntityGraphPending _graphPending;
 
   @override
   Future<String?> selectSkill({
@@ -111,7 +118,7 @@ class RuleBasedAgentSkillModelClient implements AgentSkillModelClient {
         enabledSkills.any((skill) => skill.id == 'wellbeing-check-in')) {
       return 'wellbeing-check-in';
     }
-    if (_lifeTrackFacts.wantsStudyRecord(prompt) &&
+    if (_factService.facts.wantsStudyRecord(prompt) &&
         enabledSkills.any((skill) => skill.id == 'record-study-progress')) {
       return 'record-study-progress';
     }
@@ -152,14 +159,19 @@ class RuleBasedAgentSkillModelClient implements AgentSkillModelClient {
     }
 
     final lower = prompt.toLowerCase();
-    if (skill.tools.contains('record_lifetrack_facts') &&
-        (_lifeTrackFacts.wantsRecord(prompt) ||
-            _lifeTrackFacts.wantsStudyRecord(prompt) ||
-            skill.id == 'record-study-progress')) {
+    final templateId = skill.lifeTrackTemplateId ?? 'insurance_claim_v1';
+    if (_factService.wantsRecord(
+      AgentSkillRecordContext(
+        skillId: skill.id,
+        skillTools: skill.tools,
+        templateId: templateId,
+        prompt: prompt,
+      ),
+    )) {
       return _nextRecordLifeTrackAction(
         prompt: prompt,
         toolResults: toolResults,
-        templateId: skill.lifeTrackTemplateId ?? 'insurance_claim_v1',
+        templateId: templateId,
       );
     }
     if (skill.tools.contains('query_entity_graph') &&
@@ -423,32 +435,11 @@ class RuleBasedAgentSkillModelClient implements AgentSkillModelClient {
       );
     }
 
-    final extracted = switch (templateId) {
-      'study_progress_v1' => _lifeTrackFacts.extractStudyProgress(prompt),
-      'medical_surgery_v1' => _lifeTrackFacts.extractMedicalSurgery(prompt),
-      'real_estate_under_construction_v1' =>
-        _lifeTrackFacts.extractPropertyPurchase(prompt),
-      _ => _lifeTrackFacts.extractInsuranceClaim(prompt),
-    };
+    final extracted = _factService.extract(templateId, prompt);
     if (extracted.isEmpty) {
-      return SkillModelAction.finalAnswer(switch (templateId) {
-        'study_progress_v1' =>
-          'I store study progress as a local LifeTrack — not a notes app. '
-              'Tell me the subject, last topic, and exam date if you have one.',
-        'medical_surgery_v1' =>
-          'I can store this hospital stay on this device. Paste the hospital, '
-              'date, pre-op tests, and authorization reference if you have them. '
-              'I will not diagnose or change a care plan.',
-        'real_estate_under_construction_v1' =>
-          'I can store this purchase on this device. Paste the builder, '
-              'project, floor, and RERA number if you have them. I will not '
-              'give legal advice.',
-        _ =>
-          'I can store this claim on this device. Paste the insurer, claim '
-              'ID or broker reference, policy number if you have it, and '
-              'whether documents were received. I will not file the claim '
-              'or read your email.',
-      });
+      return SkillModelAction.finalAnswer(
+        _factService.clarificationHint(templateId),
+      );
     }
 
     return SkillModelAction.toolCall(
@@ -978,7 +969,7 @@ class AgentSkillOrchestrator {
             handled: true,
             message: result.message ?? 'Confirm to save this locally.',
             traces: traces,
-            pendingLifeTrackWrite: _pendingMap(result.data['pending']),
+            pendingLifeTrackWrite: _pendingLifeTrackPayload(result.data),
             groundingState: GroundingState.ungrounded,
             safetyClass: safetyClass,
           );
@@ -1019,6 +1010,16 @@ class AgentSkillOrchestrator {
   Map<String, dynamic>? _pendingMap(Object? raw) {
     if (raw is! Map) return null;
     return raw.map((key, value) => MapEntry(key.toString(), value));
+  }
+
+  Map<String, dynamic>? _pendingLifeTrackPayload(Map<String, dynamic> data) {
+    final pending = _pendingMap(data['pending']);
+    if (pending == null) return null;
+    final token = data['confirmation_token'];
+    if (token is String && token.trim().isNotEmpty) {
+      return {...pending, 'confirmation_token': token.trim()};
+    }
+    return pending;
   }
 
   /// Measures how much data a connector call actually moved.

--- a/packages/feature_mind/lib/src/agent_chat/domain/services/chat_entity_graph_pending.dart
+++ b/packages/feature_mind/lib/src/agent_chat/domain/services/chat_entity_graph_pending.dart
@@ -1,5 +1,6 @@
 import 'package:core_domain/core_domain.dart';
 
+import '../../../addons/workflow/addon_workflow_policy.dart';
 import '../../../provenance/domain/models/extracted_entity.dart';
 import '../models/chat_entity_graph.dart';
 import 'chat_entity_graph_projector.dart';
@@ -11,23 +12,11 @@ import 'projected_chat_journey.dart';
 /// template fields are still absent, including cross-links (hospital, policy)
 /// so a bill can sit on more than one journey at once.
 class ChatEntityGraphPending {
-  const ChatEntityGraphPending();
+  ChatEntityGraphPending({AddonWorkflowPolicy? policy})
+    : _policy = policy ?? AddonWorkflowPolicy.defaults();
 
+  final AddonWorkflowPolicy _policy;
   static const _projector = ChatEntityGraphProjector();
-
-  static const _hospitalUsual = [
-    'Required Tests List',
-    'Insurance Authorization Reference',
-    'Hospital Checklist',
-    'Recovery Notes',
-  ];
-
-  static const _propertyUsual = [
-    'RERA Registration Number',
-    'Builder Track Record Notes',
-    'Your Target Floor',
-    'Promised Amenities List',
-  ];
 
   bool wantsPending(String query) {
     final lower = query.toLowerCase();
@@ -39,9 +28,21 @@ class ChatEntityGraphPending {
         lower.contains("what's next") ||
         lower.contains('whats next');
     if (!asks) return false;
-    return _looksInsurance(lower) ||
-        _looksHospital(lower) ||
-        _looksProperty(lower);
+    for (final policy in _policyTemplates()) {
+      if (_policy.queryMatchesTemplate(lower, policy.templateId)) return true;
+    }
+    return false;
+  }
+
+  Iterable<AddonWorkflowTemplatePolicy> _policyTemplates() {
+    return [
+      _policy.forTemplate('insurance_claim_v1'),
+      _policy.forTemplate('medical_surgery_v1'),
+      _policy.forTemplate('real_estate_under_construction_v1'),
+      _policy.forTemplate('study_progress_v1'),
+      _policy.forTemplate('car_purchase_v1'),
+      _policy.forTemplate('university_admission_v1'),
+    ].whereType<AddonWorkflowTemplatePolicy>();
   }
 
   String format({required ChatEntityGraph graph, required String query}) {
@@ -78,25 +79,18 @@ class ChatEntityGraphPending {
         if (entry.key.startsWith('_')) continue;
         buffer.writeln('- ${entry.key}: ${entry.value}');
       }
-
-      final missing = _missing(journey);
-      buffer.writeln();
-      if (missing.isEmpty) {
-        buffer.writeln(
-          'No usual ${_usualName(journey.templateId)} fields are missing from the graph.',
-        );
-      } else {
-        buffer.writeln('Not on the graph yet');
-        for (final item in missing) {
-          buffer.writeln('- $item');
+      final missing = missingFieldsFor(journey);
+      if (missing.isNotEmpty) {
+        buffer.writeln();
+        for (final line in missing) {
+          buffer.writeln('Not on the graph yet: $line');
         }
       }
-
-      final linked = _crossLinks(graph, journey.subjectNodeId);
-      if (linked.isNotEmpty) {
+      final crossLinks = crossLinksFor(graph, journey.subjectNodeId);
+      if (crossLinks.isNotEmpty) {
         buffer.writeln();
-        buffer.writeln('Also linked');
-        for (final line in linked) {
+        buffer.writeln('Also linked in this chat:');
+        for (final line in crossLinks) {
           buffer.writeln('- $line');
         }
       }
@@ -107,93 +101,39 @@ class ChatEntityGraphPending {
 
   bool _matchesQuery(ProjectedChatJourney journey, String needle) {
     if (needle.trim().isEmpty) return true;
-    switch (journey.templateId) {
-      case 'insurance_claim_v1':
-        return _looksInsurance(needle) ||
-            _containsFact(needle, journey, 'Claim ID') ||
-            _containsFact(needle, journey, 'Insurer');
-      case 'medical_surgery_v1':
-        return _looksHospital(needle) ||
-            _containsFact(needle, journey, 'Hospital');
-      case 'real_estate_under_construction_v1':
-        return _looksProperty(needle) ||
-            _containsFact(needle, journey, 'RERA Registration Number') ||
-            _containsFact(needle, journey, 'Project');
-      default:
-        return true;
+    final policy = _policy.forTemplate(journey.templateId);
+    if (policy != null && _policy.queryMatchesTemplate(needle, journey.templateId)) {
+      return true;
     }
+    return journey.facts.entries.any(
+      (entry) =>
+          entry.value.isNotEmpty && needle.contains(entry.value.toLowerCase()),
+    );
   }
-
-  bool _containsFact(String needle, ProjectedChatJourney journey, String key) {
-    final value = (journey.facts[key] ?? '').toLowerCase();
-    return value.isNotEmpty && needle.contains(value);
-  }
-
-  bool _looksInsurance(String lower) =>
-      lower.contains('claim') ||
-      lower.contains('insurance') ||
-      lower.contains('insurer') ||
-      lower.contains('document') ||
-      lower.contains('reimbursement') ||
-      lower.contains('policy');
-
-  bool _looksHospital(String lower) =>
-      lower.contains('hospital') ||
-      lower.contains('surgery') ||
-      lower.contains('recovery') ||
-      lower.contains('pre-op') ||
-      lower.contains('operation') ||
-      lower.contains('medical');
-
-  bool _looksProperty(String lower) =>
-      lower.contains('flat') ||
-      lower.contains('rera') ||
-      lower.contains('property') ||
-      lower.contains('builder') ||
-      lower.contains('tower') ||
-      lower.contains('apartment');
 
   String _emptyMessage(String query) {
     final lower = query.toLowerCase();
-    if (_looksHospital(lower)) {
-      return 'I have no stored hospital or surgery entities yet. Paste the '
-          'hospital, surgery date, required tests, and authorization reference '
-          '— I will extract them from this chat.';
+    for (final policy in _policyTemplates()) {
+      if (_policy.queryMatchesTemplate(lower, policy.templateId) &&
+          policy.pendingEmptyMessage.trim().isNotEmpty) {
+        return policy.pendingEmptyMessage.trim();
+      }
     }
-    if (_looksProperty(lower)) {
-      return 'I have no stored property entities yet. Paste the RERA number, '
-          'builder, project, and floor — I will extract them from this chat.';
-    }
-    return 'I have no stored claim entities yet. Paste the insurer, claim ID, '
-        'and whether documents were received — I will extract them from this chat.';
+    return 'I have no stored workflow entities yet for that question.';
   }
 
-  String _usualName(String templateId) {
-    switch (templateId) {
-      case 'medical_surgery_v1':
-        return 'hospital';
-      case 'real_estate_under_construction_v1':
-        return 'property';
-      default:
-        return 'claim';
+  List<String> missingFieldsFor(ProjectedChatJourney journey) {
+    if (journey.templateId == 'insurance_claim_v1') {
+      return _missingClaim(journey);
     }
-  }
-
-  List<String> _missing(ProjectedChatJourney journey) {
-    switch (journey.templateId) {
-      case 'medical_surgery_v1':
-        return [
-          for (final label in _hospitalUsual)
-            if (!journey.facts.containsKey(label)) label,
-        ];
-      case 'real_estate_under_construction_v1':
-        return [
-          for (final label in _propertyUsual)
-            if (!journey.facts.containsKey(label)) label,
-        ];
-      default:
-        return _missingClaim(journey);
+    final policy = _policy.forTemplate(journey.templateId);
+    if (policy != null && policy.pendingUsualOptionalFields.isNotEmpty) {
+      return [
+        for (final label in policy.pendingUsualOptionalFields)
+          if (!journey.facts.containsKey(label)) label,
+      ];
     }
+    return _missingClaim(journey);
   }
 
   List<String> _missingClaim(ProjectedChatJourney journey) {
@@ -218,7 +158,7 @@ class ChatEntityGraphPending {
     return missing;
   }
 
-  List<String> _crossLinks(ChatEntityGraph graph, String claimId) {
+  List<String> crossLinksFor(ChatEntityGraph graph, String claimId) {
     final lines = <String>[];
     for (final edge in graph.edgesFor(claimId)) {
       if (edge.predicate != ChatEntityRelation.relatedTo) continue;
@@ -231,14 +171,15 @@ class ChatEntityGraphPending {
     return lines;
   }
 
-  bool looksInsurance(String text) => _looksInsurance(text.toLowerCase());
+  bool looksInsurance(String text) =>
+      _policy.queryMatchesTemplate(text.toLowerCase(), 'insurance_claim_v1');
 
-  bool looksHospital(String text) => _looksHospital(text.toLowerCase());
+  bool looksHospital(String text) =>
+      _policy.queryMatchesTemplate(text.toLowerCase(), 'medical_surgery_v1');
 
-  bool looksProperty(String text) => _looksProperty(text.toLowerCase());
-
-  List<String> missingFieldsFor(ProjectedChatJourney journey) => _missing(journey);
-
-  List<String> crossLinksFor(ChatEntityGraph graph, String subjectNodeId) =>
-      _crossLinks(graph, subjectNodeId);
+  bool looksProperty(String text) =>
+      _policy.queryMatchesTemplate(
+        text.toLowerCase(),
+        'real_estate_under_construction_v1',
+      );
 }

--- a/packages/feature_mind/lib/src/agent_chat/domain/services/lifetrack_confirmation_token_service.dart
+++ b/packages/feature_mind/lib/src/agent_chat/domain/services/lifetrack_confirmation_token_service.dart
@@ -1,0 +1,140 @@
+import 'dart:convert';
+import 'dart:math';
+
+import 'package:crypto/crypto.dart';
+
+/// One-use confirmation tokens for LifeTrack writes (§9 framework gate).
+class LifeTrackConfirmationTokenService {
+  LifeTrackConfirmationTokenService({
+    DateTime Function()? now,
+    Duration ttl = const Duration(minutes: 15),
+  }) : _now = now ?? DateTime.now,
+       _ttl = ttl;
+
+  final DateTime Function() _now;
+  final Duration _ttl;
+  final Map<String, _IssuedToken> _issued = {};
+  final Set<String> _consumed = {};
+
+  String issue({
+    required String destinationTool,
+    required Map<String, dynamic> payload,
+    String actorId = 'local_user',
+  }) {
+    final expiresAt = _now().toUtc().add(_ttl);
+    final payloadHash = _payloadHash(payload);
+    final record = {
+      'schema': 'airo-confirmation-v1',
+      'actor_id': actorId,
+      'destination_tool': destinationTool,
+      'payload_hash': payloadHash,
+      'expires_at_ms': expiresAt.millisecondsSinceEpoch,
+    };
+    final confirmationHash = _confirmationHash(record);
+    final token = _randomToken();
+    _issued[token] = _IssuedToken(
+      destinationTool: destinationTool,
+      payloadHash: payloadHash,
+      confirmationHash: confirmationHash,
+      expiresAt: expiresAt,
+    );
+    return token;
+  }
+
+  String? validateAndConsume({
+    required String token,
+    required String destinationTool,
+    required Map<String, dynamic> payload,
+  }) {
+    if (_consumed.contains(token)) return 'confirmation_consumed';
+    final issued = _issued[token];
+    if (issued == null) return 'confirmation_invalid';
+    if (issued.destinationTool != destinationTool) {
+      return 'confirmation_invalid';
+    }
+    if (_now().toUtc().isAfter(issued.expiresAt)) {
+      _issued.remove(token);
+      return 'confirmation_expired';
+    }
+    if (issued.payloadHash != _payloadHash(payload)) {
+      return 'confirmation_invalid';
+    }
+    _issued.remove(token);
+    _consumed.add(token);
+    return null;
+  }
+
+  String confirmationHashFor({
+    required String destinationTool,
+    required Map<String, dynamic> payload,
+    String actorId = 'local_user',
+  }) {
+    final record = {
+      'schema': 'airo-confirmation-v1',
+      'actor_id': actorId,
+      'destination_tool': destinationTool,
+      'payload_hash': _payloadHash(payload),
+    };
+    return _confirmationHash(record);
+  }
+
+  static String _payloadHash(Map<String, dynamic> payload) =>
+      sha256.convert(utf8.encode(_canonicalJson(payload))).toString();
+
+  static String _confirmationHash(Map<String, dynamic> record) {
+    final canonical = _canonicalJson(record);
+    final bytes = utf8.encode('airo-confirmation-v1\n$canonical');
+    return sha256.convert(bytes).toString();
+  }
+
+  static String _canonicalJson(Object? value) {
+    if (value is Map) {
+      final keys = value.keys.map((key) => key.toString()).toList()
+        ..sort();
+      final ordered = <String, Object?>{};
+      for (final key in keys) {
+        ordered[key] = _canonicalize(value[key]);
+      }
+      return jsonEncode(ordered);
+    }
+    if (value is List) {
+      return jsonEncode(value.map(_canonicalize).toList());
+    }
+    return jsonEncode(value);
+  }
+
+  static Object? _canonicalize(Object? value) {
+    if (value is Map) {
+      final keys = value.keys.map((key) => key.toString()).toList()..sort();
+      final ordered = <String, Object?>{};
+      for (final key in keys) {
+        ordered[key] = _canonicalize(value[key]);
+      }
+      return ordered;
+    }
+    if (value is List) {
+      return value.map(_canonicalize).toList();
+    }
+    return value;
+  }
+
+  static String _randomToken() {
+    final random = Random.secure();
+    final bytes = List<int>.generate(32, (_) => random.nextInt(256));
+    return base64Url.encode(bytes).replaceAll('=', '');
+  }
+}
+
+class _IssuedToken {
+  const _IssuedToken({
+    required this.destinationTool,
+    required this.payloadHash,
+    required this.confirmationHash,
+    required this.expiresAt,
+  });
+
+  final String destinationTool;
+  final String payloadHash;
+  final String confirmationHash;
+  final DateTime expiresAt;
+}

--- a/packages/feature_mind/pubspec.lock
+++ b/packages/feature_mind/pubspec.lock
@@ -313,7 +313,7 @@ packages:
     source: hosted
     version: "0.3.5+4"
   crypto:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: crypto
       sha256: c8ea0233063ba03258fbcf2ca4d6dadfefe14f02fab57702265467a19f27fadf

--- a/packages/feature_mind/pubspec.yaml
+++ b/packages/feature_mind/pubspec.yaml
@@ -58,6 +58,7 @@ dependencies:
   # same package and version core_data, platform_player and feature_iptv
   # already use for the same purpose.
   connectivity_plus: ^7.2.0
+  crypto: ^3.0.3
   # Markdown export (#1663): rendering the transcript body runs off the main
   # isolate once it crosses ~50 KB, per the repo's own parsing rule.
   core_workers:

--- a/packages/feature_mind/test/addons/addon_production_verification_test.dart
+++ b/packages/feature_mind/test/addons/addon_production_verification_test.dart
@@ -4,6 +4,7 @@ import 'package:feature_mind/src/addons/built_in_addon_registry.dart';
 import 'package:feature_mind/src/addons/graph_workflow/insurance_planner_graph_adapter.dart';
 import 'package:feature_mind/src/agent_chat/data/connectors/life_track_record_connector.dart';
 import 'package:feature_mind/src/agent_chat/domain/models/chat_entity_graph.dart';
+import 'package:feature_mind/src/agent_chat/domain/services/lifetrack_confirmation_token_service.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 
@@ -49,6 +50,21 @@ class _SpyGraphAdapter implements GraphWorkflowAddonAdapter {
 class _MockLifeTrackRepository extends Mock implements LifeTrackRepository {}
 
 void main() {
+  setUpAll(() {
+    registerFallbackValue(
+      LifeTrack(
+        id: 'fallback',
+        title: 'fallback',
+        category: LifeTrackCategory.insurance,
+        status: TrackStatus.active,
+        milestones: const [],
+        createdAt: DateTime.utc(2026),
+        updatedAt: DateTime.utc(2026),
+        templateId: 'insurance_claim_v1',
+      ),
+    );
+  });
+
   test('disabled graph add-on receives zero eligible adapter calls', () {
     final registry = AddonRegistry();
     final spy = _SpyGraphAdapter(AddonId('spy-graph'));
@@ -76,6 +92,70 @@ void main() {
     expect(registry.eligibleGraphAdapters(), isEmpty);
     expect(spy.acceptsCalls, 0);
     expect(spy.extractCalls, 0);
+  });
+
+  test('quarantined graph add-on receives zero eligible adapter calls', () {
+    final registry = AddonRegistry();
+    final spy = _SpyGraphAdapter(AddonId('spy-quarantine'));
+    registry.registerBuiltIn(
+      manifest: AddonManifest.fromJson({
+        'schema_version': '1.0',
+        'id': 'spy-quarantine',
+        'version': '1.0.0',
+        'behaviors': ['graph_workflow'],
+        'capabilities': ['conversation.current_turn'],
+        'tools': [],
+        'adapter': {'kind': 'required_built_in', 'contract': 'graph_workflow_v1'},
+        'workflow': {
+          'subject_kind': 'spy',
+          'template_id': 'spy_template_v1',
+        },
+      }),
+      graphAdapter: spy,
+    );
+    registry.setEligibility(
+      'spy-quarantine',
+      const AddonEligibility(
+        enabled: true,
+        grantedScopes: {'conversation.current_turn'},
+        quarantined: true,
+      ),
+    );
+
+    expect(registry.eligibleGraphAdapters(), isEmpty);
+    expect(spy.acceptsCalls, 0);
+  });
+
+  test('revoked graph add-on receives zero eligible adapter calls', () {
+    final registry = AddonRegistry();
+    final spy = _SpyGraphAdapter(AddonId('spy-revoked'));
+    registry.registerBuiltIn(
+      manifest: AddonManifest.fromJson({
+        'schema_version': '1.0',
+        'id': 'spy-revoked',
+        'version': '1.0.0',
+        'behaviors': ['graph_workflow'],
+        'capabilities': ['conversation.current_turn'],
+        'tools': [],
+        'adapter': {'kind': 'required_built_in', 'contract': 'graph_workflow_v1'},
+        'workflow': {
+          'subject_kind': 'spy',
+          'template_id': 'spy_template_v1',
+        },
+      }),
+      graphAdapter: spy,
+    );
+    registry.setEligibility(
+      'spy-revoked',
+      const AddonEligibility(
+        enabled: true,
+        grantedScopes: {'conversation.current_turn'},
+        revoked: true,
+      ),
+    );
+
+    expect(registry.eligibleGraphAdapters(), isEmpty);
+    expect(spy.acceptsCalls, 0);
   });
 
   test('graph workflow ingest is deterministic without model or network',
@@ -110,6 +190,7 @@ void main() {
 
     expect(result.isError, isTrue);
     expect(result.errorCode, 'confirmation_required');
+    expect(result.data['confirmation_token'], isNotNull);
   });
 
   test('record connector rejects confirmed with wrong source token', () async {
@@ -129,4 +210,85 @@ void main() {
     expect(result.isError, isTrue);
     expect(result.errorCode, 'confirmation_required');
   });
+
+  test('record connector accepts one-use confirmation token', () async {
+    final repository = _MockLifeTrackRepository();
+    when(() => repository.listTracks()).thenAnswer(
+      (_) async => const Ok(<LifeTrack>[]),
+    );
+    when(() => repository.createTrack(any())).thenAnswer(
+      (invocation) async => Ok(invocation.positionalArguments[0] as LifeTrack),
+    );
+
+    final tokens = LifeTrackConfirmationTokenService();
+    final connector = LifeTrackRecordConnector(
+      repository: repository,
+      resolveTemplate: (_) async => _template,
+      confirmationTokens: tokens,
+      now: () => DateTime.utc(2026, 8, 22),
+      newTrackId: () => 'lt-token-1',
+    );
+
+    final preview = await connector.execute({
+      'title': 'Niva claim',
+      'template_id': 'insurance_claim_v1',
+      'facts': {'Claim ID': 'ABC123'},
+    });
+    final token = preview.data['confirmation_token'] as String;
+
+    final result = await connector.execute({
+      'title': 'Niva claim',
+      'template_id': 'insurance_claim_v1',
+      'facts': {'Claim ID': 'ABC123'},
+      'confirmation_token': token,
+    });
+
+    expect(result.isError, isFalse);
+    verify(() => repository.createTrack(any())).called(1);
+  });
+
+  test('record connector rejects writes when write gate is closed', () async {
+    final connector = LifeTrackRecordConnector(
+      repository: _MockLifeTrackRepository(),
+      resolveTemplate: (_) async => null,
+      writeGate: () async => false,
+    );
+
+    final result = await connector.execute({
+      'title': 'Test journey',
+      'template_id': 'insurance_claim_v1',
+      'facts': {'Claim ID': 'ABC123'},
+      'confirmed': true,
+      'source': 'user_confirm',
+    });
+
+    expect(result.isError, isTrue);
+    expect(result.errorCode, 'addon_write_failed');
+  });
 }
+
+const _template = LifeTrackTemplate(
+  templateId: 'insurance_claim_v1',
+  title: 'Insurance Claim Tracking Template',
+  description: 'Test',
+  category: LifeTrackCategory.insurance,
+  version: '1.1',
+  milestones: [
+    MilestoneTemplate(
+      name: 'Phase 1',
+      objective: 'Record',
+      tasks: [
+        ActionItemTemplate(
+          summary: 'Record claim',
+          requirements: [
+            InputRequirementTemplate(
+              label: 'Claim ID',
+              type: FieldType.text,
+              isRequired: true,
+            ),
+          ],
+        ),
+      ],
+    ),
+  ],
+);

--- a/packages/feature_mind/test/agent_chat/domain/services/chat_entity_graph_pending_test.dart
+++ b/packages/feature_mind/test/agent_chat/domain/services/chat_entity_graph_pending_test.dart
@@ -5,7 +5,7 @@ import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   const linker = ChatEntityLinker();
-  const pending = ChatEntityGraphPending();
+  final pending = ChatEntityGraphPending();
 
   test('matches claim pending questions without the word track', () {
     expect(pending.wantsPending("What's pending on my claim?"), isTrue);

--- a/packages/feature_mind/test/agent_chat/domain/services/lifetrack_confirmation_token_test.dart
+++ b/packages/feature_mind/test/agent_chat/domain/services/lifetrack_confirmation_token_test.dart
@@ -1,0 +1,80 @@
+import 'package:feature_mind/src/agent_chat/domain/services/lifetrack_confirmation_token_service.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('token is one-use and rejects payload mutation', () {
+    final service = LifeTrackConfirmationTokenService(
+      now: () => DateTime.utc(2026, 8, 22, 12),
+    );
+    final payload = {
+      'title': 'Niva claim',
+      'template_id': 'insurance_claim_v1',
+      'facts': {'Claim ID': '9001001'},
+    };
+    final token = service.issue(
+      destinationTool: 'record_lifetrack_facts',
+      payload: payload,
+    );
+
+    expect(
+      service.validateAndConsume(
+        token: token,
+        destinationTool: 'record_lifetrack_facts',
+        payload: payload,
+      ),
+      isNull,
+    );
+    expect(
+      service.validateAndConsume(
+        token: token,
+        destinationTool: 'record_lifetrack_facts',
+        payload: payload,
+      ),
+      'confirmation_consumed',
+    );
+
+    final token2 = service.issue(
+      destinationTool: 'record_lifetrack_facts',
+      payload: payload,
+    );
+    final mutated = {
+      'title': 'Niva claim',
+      'template_id': 'insurance_claim_v1',
+      'facts': {'Claim ID': '9001002'},
+    };
+    expect(
+      service.validateAndConsume(
+        token: token2,
+        destinationTool: 'record_lifetrack_facts',
+        payload: mutated,
+      ),
+      'confirmation_invalid',
+    );
+  });
+
+  test('token expires after ttl', () {
+    var now = DateTime.utc(2026, 8, 22, 12);
+    final service = LifeTrackConfirmationTokenService(
+      now: () => now,
+      ttl: const Duration(minutes: 1),
+    );
+    final payload = {
+      'title': 'Test',
+      'template_id': 'insurance_claim_v1',
+      'facts': {'Claim ID': 'A'},
+    };
+    final token = service.issue(
+      destinationTool: 'record_lifetrack_facts',
+      payload: payload,
+    );
+    now = now.add(const Duration(minutes: 2));
+    expect(
+      service.validateAndConsume(
+        token: token,
+        destinationTool: 'record_lifetrack_facts',
+        payload: payload,
+      ),
+      'confirmation_expired',
+    );
+  });
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Completes the post-#1881 pending tasks for Airo Mind add-on framework **GA hardening**.

### Orchestrator / pending (no template switches in host)
- `AddonWorkflowPolicy` + `AddonWorkflowFactService` own clarification copy and record routing
- `RuleBasedAgentSkillModelClient` delegates fact extraction and hints to add-on layer
- `ChatEntityGraphPending` uses add-on policy keywords and optional-field lists (defaults mirror bundle metadata)

### Confirmation tokens (§9 / §13)
- `LifeTrackConfirmationTokenService`: CSPRNG token, canonical payload hash, expiry, one-use consume
- `LifeTrackRecordConnector` issues token on preview; accepts `confirmation_token` or legacy `user_confirm` for graph journey confirms
- Idempotency port hook + write-gate hook on connector (gate tested; factory still uses plaintext repo until app wires `SecureLifeTrackRepositoryImpl`)

### Verification
- Expanded `addon_production_verification_test`: quarantined/revoked spy adapters, token redemption, write gate closed
- `lifetrack_confirmation_token_test`: one-use, mutation rejection, expiry

## Production judge update

| Gate | Status |
|------|--------|
| Orchestrator template switches removed | ✅ |
| Pending vocabulary from add-on policy | ✅ |
| Confirmation tokens (one-use, hash-bound) | ✅ partial — no secure token store yet |
| Encrypted LifeTrack write gate in app factory | ⚠️ hook only; app must wire secure repo |
| Disable/quarantine/revoke spy coverage | ✅ expanded |

**Verdict:** Ready for **beta → staging** with encrypted destination wiring as the remaining app-integration step for full §14.14.

## Tests (local)

- `test/addons/` — all pass (including 8 production verification cases)
- Pinned orchestrator + characterization + pending + connector tests — pass
- `scripts/check-mind-projection-routes.sh` — OK
- `scripts/check-mind-private-devices.sh` — OK
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3cb72c1f-40c3-40b6-938b-70e7592345dd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3cb72c1f-40c3-40b6-938b-70e7592345dd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

