### PR TITLE
test(app): cover EPG reminder paths for Sonar new-code coverage gate

### DIFF
--- a/app/test/features/iptv/epg_reminder_notification_gateway_test.dart
+++ b/app/test/features/iptv/epg_reminder_notification_gateway_test.dart
@@ -112,6 +112,84 @@ void main() {
     );
   });
 
+  test('Android permission request goes through the Android plugin', () async {
+    debugDefaultTargetPlatformOverride = TargetPlatform.android;
+    AndroidFlutterLocalNotificationsPlugin.registerWith();
+    final gateway = FlutterLocalNotificationsEpgReminderGateway();
+
+    expect(await gateway.requestPermission(), isTrue);
+    expect(
+      methodCalls.map((call) => call.method),
+      containsAllInOrder(['initialize', 'requestNotificationsPermission']),
+      reason: 'the plugin has to be initialized before it can be asked',
+    );
+  });
+
+  test('iOS permission request asks for alert, badge, and sound', () async {
+    debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+    IOSFlutterLocalNotificationsPlugin.registerWith();
+    final gateway = FlutterLocalNotificationsEpgReminderGateway();
+
+    expect(await gateway.requestPermission(), isTrue);
+
+    final request = methodCalls.singleWhere(
+      (call) => call.method == 'requestPermissions',
+    );
+    expect(request.arguments, containsPair('alert', true));
+    expect(request.arguments, containsPair('badge', true));
+    expect(request.arguments, containsPair('sound', true));
+  });
+
+  test('a permission request on a vanished plugin fails closed', () async {
+    debugDefaultTargetPlatformOverride = TargetPlatform.android;
+    AndroidFlutterLocalNotificationsPlugin.registerWith();
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(notificationsChannel, null);
+    final gateway = FlutterLocalNotificationsEpgReminderGateway();
+
+    await expectLater(
+      gateway.requestPermission(),
+      throwsA(isA<EpgReminderGatewayUnavailableException>()),
+    );
+  });
+
+  test('a plugin that vanishes after initialize fails closed', () async {
+    debugDefaultTargetPlatformOverride = TargetPlatform.android;
+    AndroidFlutterLocalNotificationsPlugin.registerWith();
+    final gateway = FlutterLocalNotificationsEpgReminderGateway();
+
+    await gateway.initialize();
+    expect(gateway.isAvailable, isTrue);
+
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(notificationsChannel, null);
+
+    await expectLater(
+      gateway.schedule(
+        notificationId: 9,
+        title: 'Late Show',
+        body: 'Starting now',
+        at: DateTime.now().toUtc().add(const Duration(hours: 1)),
+        payloadChannelId: 'channel-2',
+      ),
+      throwsA(isA<EpgReminderGatewayUnavailableException>()),
+    );
+    expect(gateway.isAvailable, isFalse);
+  });
+
+  test('cancel forwards the notification id to the plugin', () async {
+    debugDefaultTargetPlatformOverride = TargetPlatform.android;
+    AndroidFlutterLocalNotificationsPlugin.registerWith();
+    final gateway = FlutterLocalNotificationsEpgReminderGateway();
+
+    await gateway.cancel(7);
+
+    final cancelCall = methodCalls.singleWhere(
+      (call) => call.method == 'cancel',
+    );
+    expect(cancelCall.arguments, containsPair('id', 7));
+  });
+
   test('missing plugin marks gateway unavailable', () async {
     debugDefaultTargetPlatformOverride = TargetPlatform.android;
     AndroidFlutterLocalNotificationsPlugin.registerWith();


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

SonarCloud quality gate on `main` failed with **new code coverage 75.9%** (threshold **80%**). The gap is in recently added EPG reminder notification paths that lacked permission/failure tests.

## Fix

Add five tests to `epg_reminder_notification_gateway_test.dart` covering:
- Android `requestNotificationsPermission` after initialize
- iOS alert/badge/sound permission request
- Vanished plugin on permission request (fail closed)
- Vanished plugin after initialize during schedule
- `cancel` forwarding notification id

Cherry-picked from the earlier `fix/sonar-new-code-coverage` branch work, scoped to the minimal diff needed for the gate.

## Test plan

- [x] `flutter test test/features/iptv/epg_reminder_notification_gateway_test.dart` — 11 passing
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6db2c21f-f02a-4df9-92b2-e0797ee40b7b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6db2c21f-f02a-4df9-92b2-e0797ee40b7b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

