### PR TITLE
test(app): cover desktop phone media picker for Sonar new-code gate

### DIFF
--- a/app/test/core/portability/airo_portability_codec_test.dart
+++ b/app/test/core/portability/airo_portability_codec_test.dart
@@ -28,6 +28,8 @@ void main() {
       'returns null for missing, malformed, or incompatible history',
       () async {
         expect(await AiroPortabilityCodec.decodeChatHistory(null), isNull);
+        expect(await AiroPortabilityCodec.decodeChatHistory(''), isNull);
+        expect(await AiroPortabilityCodec.decodeChatHistory('   '), isNull);
         expect(await AiroPortabilityCodec.decodeChatHistory('{broken'), isNull);
         expect(
           await AiroPortabilityCodec.decodeChatHistory(

--- a/app/test/features/iptv/phone_media_local_picker_test.dart
+++ b/app/test/features/iptv/phone_media_local_picker_test.dart
@@ -1,8 +1,14 @@
+import 'dart:io';
+
 import 'package:airo_app/features/iptv/phone_media_local_picker.dart';
+import 'package:file_picker/file_picker.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:platform_media/platform_media.dart';
 import 'package:platform_player/platform_player.dart';
+// Transitive via file_picker; direct import keeps the test helper typed.
+// ignore: depend_on_referenced_packages
+import 'package:cross_file/cross_file.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -13,6 +19,7 @@ void main() {
 
   tearDown(() {
     messenger.setMockMethodCallHandler(channel, null);
+    FilePickerPlatform.instance = MethodChannelFilePicker();
   });
 
   test(
@@ -149,6 +156,139 @@ void main() {
     expect(await pickAndroidPhoneLocalMediaForTv(channel: channel), isNull);
     expect(calls.map((call) => call.method), ['pickVideo', 'release']);
   });
+
+  test('platform exception during Android pick returns null', () async {
+    messenger.setMockMethodCallHandler(channel, (call) async {
+      throw PlatformException(code: 'cancel');
+    });
+
+    expect(await pickAndroidPhoneLocalMediaForTv(channel: channel), isNull);
+  });
+
+  test('uses default analyzer when none is supplied', () async {
+    messenger.setMockMethodCallHandler(channel, (call) async {
+      if (call.method == 'pickVideo') {
+        return <String, Object?>{
+          'token': 'lease-4',
+          'descriptor': 44,
+          'filePath': '/proc/self/fd/44',
+          'title': 'clip.mp4',
+          'size': 2048,
+        };
+      }
+      return null;
+    });
+
+    final item = await pickAndroidPhoneLocalMediaForTv(
+      channel: channel,
+      analyzer: const _UnsupportedAnalyzer(),
+    );
+
+    expect(item, isNotNull);
+    expect(item!.container, 'mp4');
+  });
+
+  test('descriptor source exposes byte ranges until released', () async {
+    messenger.setMockMethodCallHandler(channel, (call) async {
+      if (call.method == 'pickVideo') {
+        return <String, Object?>{
+          'token': 'lease-5',
+          'descriptor': 45,
+          'filePath': '/proc/self/fd/45',
+          'title': 'clip.mp4',
+          'size': 16,
+        };
+      }
+      return null;
+    });
+    final item = await pickAndroidPhoneLocalMediaForTv(
+      channel: channel,
+      analyzer: const _UnsupportedAnalyzer(),
+    );
+
+    expect(item!.source!.isAvailable, isTrue);
+    await item.sourceLease!.release();
+    expect(item.source!.isAvailable, isFalse);
+  });
+
+  test('desktop file picker path maps analyzed media metadata', () async {
+    const analyzerChannel = MethodChannel('com.airo.media_asset_analyzer');
+    HostPlatformMediaAssetAnalyzer.debugSetMethodChannel(analyzerChannel);
+    messenger.setMockMethodCallHandler(analyzerChannel, (call) async {
+      if (call.method == 'analyze') {
+        return {
+          'status': 'complete',
+          'profile': {
+            'schemaVersion': '1.0.0',
+            'assetId': 'sample.mov',
+            'container': 'mov',
+            'durationMs': 120000,
+            'fileSizeBytes': 4,
+            'videoTracks': [
+              {
+                'id': 'video-0',
+                'codec': 'h264',
+                'width': 1920,
+                'height': 1080,
+                'dynamicRange': 'sdr',
+                'confidence': 'exact',
+              },
+            ],
+            'audioTracks': [
+              {
+                'id': 'audio-0',
+                'codec': 'aac',
+                'confidence': 'exact',
+              },
+            ],
+            'subtitleTracks': [],
+            'warnings': [],
+          },
+          'diagnostics': {
+            'elapsedMs': 1,
+            'didUseMetadataProbe': true,
+            'fileSizeBytes': 4,
+          },
+        };
+      }
+      return null;
+    });
+
+    final tempDir = await Directory.systemTemp.createTemp('phone-media');
+    final file = File('${tempDir.path}/sample.mov');
+    await file.writeAsBytes([0, 1, 2, 3]);
+    FilePickerPlatform.instance = _FakeFilePickerPlatform(
+      _TestPlatformFile(path: file.path, name: 'sample.mov', size: 4),
+    );
+
+    final item = await pickPhoneLocalMediaForTv();
+
+    expect(item, isNotNull);
+    expect(item!.title, 'sample.mov');
+    expect(item.container, 'mov');
+    expect(item.videoCodec, 'h264');
+    expect(item.audioCodec, 'aac');
+    await tempDir.delete(recursive: true);
+  });
+
+  test('desktop file picker cancel returns null', () async {
+    FilePickerPlatform.instance = _FakeFilePickerPlatform(null);
+
+    expect(await pickPhoneLocalMediaForTv(), isNull);
+  });
+
+  test('desktop file picker without a local path returns null', () async {
+    FilePickerPlatform.instance = _FakeFilePickerPlatform(
+      _TestPlatformFile(
+        path: null,
+        name: 'remote.mov',
+        size: 4,
+        uri: Uri.parse('content://media/external/video/1'),
+      ),
+    );
+
+    expect(await pickPhoneLocalMediaForTv(), isNull);
+  });
 }
 
 class _RecordingAnalyzer implements LocalMediaAssetAnalyzer {
@@ -180,5 +320,63 @@ class _UnsupportedAnalyzer implements LocalMediaAssetAnalyzer {
         didUseMetadataProbe: false,
       ),
     );
+  }
+}
+
+final class _TestPlatformFile extends PlatformFile {
+  _TestPlatformFile({
+    required this.name,
+    required this.size,
+    String? path,
+    Uri? uri,
+  }) : _path = path,
+       _uri = uri ?? Uri.file(path!);
+
+  final String? _path;
+  final Uri _uri;
+
+  @override
+  String? get path => _path ?? (_uri.scheme == 'file' ? _uri.toFilePath() : null);
+
+  @override
+  final String name;
+
+  final int size;
+
+  @override
+  Uri get uri => _uri;
+
+  @override
+  Future<int> length() async => size;
+
+  @override
+  Stream<Uint8List> readAsByteStream() => const Stream.empty();
+
+  @override
+  Future<Uint8List> readAsBytes() async => Uint8List(0);
+
+  @override
+  XFile get xFile => XFile(uri.toString(), name: name, length: size);
+}
+
+class _FakeFilePickerPlatform extends FilePickerPlatform {
+  _FakeFilePickerPlatform(this.file);
+
+  final PlatformFile? file;
+
+  @override
+  Future<PlatformFile?> pickFile({
+    String? dialogTitle,
+    String? initialDirectory,
+    FileType type = FileType.any,
+    List<String>? allowedExtensions,
+    Function(FilePickerStatus)? onFileLoading,
+    int compressionQuality = 0,
+    AndroidOptions androidOptions = const AndroidOptions(),
+    WindowsOptions windowsOptions = const WindowsOptions(),
+    LinuxOptions linuxOptions = const LinuxOptions(),
+    WebOptions webOptions = const WebOptions(),
+  }) async {
+    return file;
   }
 }

--- a/app/test/features/iptv/phone_media_local_picker_test.dart
+++ b/app/test/features/iptv/phone_media_local_picker_test.dart
@@ -235,11 +235,7 @@ void main() {
               },
             ],
             'audioTracks': [
-              {
-                'id': 'audio-0',
-                'codec': 'aac',
-                'confidence': 'exact',
-              },
+              {'id': 'audio-0', 'codec': 'aac', 'confidence': 'exact'},
             ],
             'subtitleTracks': [],
             'warnings': [],
@@ -336,7 +332,8 @@ final class _TestPlatformFile extends PlatformFile {
   final Uri _uri;
 
   @override
-  String? get path => _path ?? (_uri.scheme == 'file' ? _uri.toFilePath() : null);
+  String? get path =>
+      _path ?? (_uri.scheme == 'file' ? _uri.toFilePath() : null);
 
   @override
   final String name;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

SonarCloud `new_coverage` on `main` is still below the 80% quality gate (76.4% after #1885). This adds tests for the largest remaining uncovered **new** `app/lib` surface:

- **Desktop/Linux `pickPhoneLocalMediaForTv()` path** — FilePicker success, cancel, and missing-local-path branches, with mocked `FilePickerPlatform` and `HostPlatformMediaAssetAnalyzer` channel responses so CI does not hang on `VideoPlayerController`.
- **`AiroPortabilityCodec.decodeChatHistory`** — empty and whitespace-only inputs.

## Test plan

- [x] `flutter test test/features/iptv/phone_media_local_picker_test.dart`
- [x] `flutter test test/core/portability/airo_portability_codec_test.dart`
- [ ] CI `sonarcloud-scan` on merge — expect `new_coverage` ≥ 80%
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6db2c21f-f02a-4df9-92b2-e0797ee40b7b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6db2c21f-f02a-4df9-92b2-e0797ee40b7b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

