### PR TITLE
ci(app): merge test_mind coverage for Sonar new-code gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -419,6 +419,17 @@ jobs:
         run: |
           cd app
           flutter test --coverage --reporter=compact
+          # Mind-shell tests (`test_mind/`) exercise `lib/core/mind/**`, which is
+          # excluded from the default analyzer graph but still ships in app/lib
+          # and counts toward Sonar new-code coverage. Merge their lcov trace so
+          # Sonar sees the same lines the airo-mind-shell job already proves.
+          cp coverage/lcov.info coverage/lcov.base.info
+          if ! command -v lcov >/dev/null; then
+            sudo apt-get update
+            sudo apt-get install -y lcov
+          fi
+          flutter test test_mind/ --coverage --merge-coverage \
+            --reporter=compact --dart-define=APP_VARIANT=mind
 
       - name: Convert coverage to SonarQube generic format
         if: always() && github.event_name == 'push'


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sonar `new_coverage` on `main` is still **76.9%** after #1886 because `lib/core/mind/**` tests live in `test_mind/` and run only in `airo-mind-shell` — **without coverage**. The `test-app` job uploads `lcov.info` to Sonar, so ~68 uncovered new lines in `mind_model_catalog.dart` never counted.

This merges `test_mind/` coverage into the same `lcov.info` after the main `app/test` suite (`--merge-coverage` + `lcov.base.info`).

## Test plan

- [ ] CI `test-app` passes with merged lcov
- [ ] Post-merge `sonarcloud-scan` on `main` ≥ 80% `new_coverage`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6db2c21f-f02a-4df9-92b2-e0797ee40b7b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6db2c21f-f02a-4df9-92b2-e0797ee40b7b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

