### PR TITLE
test(app): mind shell wiring tests for Sonar new-code gate

### DIFF
--- a/app/test/features/iptv/iptv_feature_module_test.dart
+++ b/app/test/features/iptv/iptv_feature_module_test.dart
@@ -1,0 +1,26 @@
+import 'package:airo_app/features/iptv/iptv_feature_module.dart';
+import 'package:core_product_shell/core_product_shell.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+
+void main() {
+  test('IPTV module exposes mobile and TV route tables', () {
+    final module = IptvFeatureModule();
+
+    expect(module.id, 'iptv');
+    expect(module.supportedShells, {ShellId.mobile, ShellId.tv});
+
+    final mobileRoutes = module.routesFor(ShellId.mobile);
+    expect(mobileRoutes.whereType<GoRoute>().map((route) => route.path), [
+      '/iptv',
+      '/iptv/player',
+      '/vod',
+    ]);
+
+    final tvRoutes = module.routesFor(ShellId.tv);
+    expect(tvRoutes.whereType<GoRoute>().map((route) => route.path), [
+      '/iptv',
+      '/iptv/player',
+    ]);
+  });
+}

--- a/app/test_mind/mind_shell_wiring_test.dart
+++ b/app/test_mind/mind_shell_wiring_test.dart
@@ -1,0 +1,134 @@
+import 'dart:io';
+
+import 'package:airo_app/core/mind/mind_processing_queue.dart';
+import 'package:airo_app/core/mind/mind_provider_overrides.dart';
+import 'package:airo_app/main_mind.dart';
+import 'package:airo_pro_bootstrap/airo_pro_bootstrap.dart' as pro_bootstrap;
+import 'package:core_ai/core_ai.dart';
+import 'package:core_product_shell/core_product_shell.dart';
+import 'package:feature_iptv/feature_iptv.dart';
+import 'package:feature_mind/feature_mind.dart';
+import 'package:feature_mind/src/bridges/mind_generation_bridge.dart';
+import 'package:feature_mind/src/bridges/mind_speech_bridge.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+import 'package:path/path.dart' as p;
+import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
+import 'package:plugin_platform_interface/plugin_platform_interface.dart';
+import 'package:record/record.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class _MockAudioRecorder extends Mock implements AudioRecorder {}
+
+class _FakeSpeechBridge implements MindSpeechBridge {
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _FakeGenerationBridge implements MindGenerationBridge {
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _FakeReadyModelProvider implements ModelProvider {
+  @override
+  bool get acquiresWithoutNetwork => true;
+
+  @override
+  Future<List<RequiredModel>> requiredModels() async => const [];
+
+  @override
+  Future<List<RequiredModel>> missingModels(Directory modelsDir) async =>
+      const [];
+
+  @override
+  Future<bool> isInstalled(Directory modelsDir) async => true;
+
+  @override
+  Stream<ModelAcquisitionEvent> acquire(Directory modelsDir) async* {}
+
+  @override
+  Future<List<InstalledModel>> verify(Directory modelsDir) async => const [];
+
+  @override
+  Future<void> dispose() async {}
+}
+
+class _FakePathProviderPlatform extends PathProviderPlatform
+    with MockPlatformInterfaceMixin {
+  _FakePathProviderPlatform(this.basePath);
+
+  final String basePath;
+
+  @override
+  Future<String?> getApplicationSupportPath() async => basePath;
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late Directory tempDir;
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({'speech_language_mode': 'auto'});
+    tempDir = Directory.systemTemp.createTempSync('mind_shell_wiring_');
+    PathProviderPlatform.instance = _FakePathProviderPlatform(tempDir.path);
+  });
+
+  tearDown(() {
+    if (tempDir.existsSync()) tempDir.deleteSync(recursive: true);
+  });
+
+  test(
+    'buildMindProviderOverrides wires prefs entitlements and module overrides',
+    () async {
+      final prefs = await SharedPreferences.getInstance();
+      final registry = buildMindModuleRegistry();
+      final overrides = buildMindProviderOverrides(
+        prefs: prefs,
+        registry: registry,
+      );
+
+      expect(overrides.length, greaterThan(3));
+
+      final container = ProviderContainer(overrides: overrides);
+      addTearDown(container.dispose);
+
+      expect(container.read(sharedPreferencesProvider), prefs);
+      expect(
+        container.read(mindEntitlementsProvider),
+        pro_bootstrap.createEntitlements(),
+      );
+    },
+  );
+
+  test(
+    'mindMeetingProcessingOverrides restores an empty queue store',
+    () async {
+      final mindService = MindService(
+        recorder: _MockAudioRecorder(),
+        modelProvider: _FakeReadyModelProvider(),
+        speechBridge: _FakeSpeechBridge(),
+        generationBridge: _FakeGenerationBridge(),
+      );
+
+      final container = ProviderContainer(
+        overrides: mindMeetingProcessingOverrides(mindService),
+      );
+      addTearDown(container.dispose);
+
+      final queue = await container.read(meetingProcessingQueueProvider.future);
+      expect(queue, isA<MeetingProcessingQueue>());
+
+      final queuePath = p.join(
+        tempDir.path,
+        'mind_recordings',
+        'processing_queue.json',
+      );
+      expect(File(queuePath).existsSync(), isTrue);
+    },
+  );
+}

--- a/app/test_mind/mind_shell_wiring_test.dart
+++ b/app/test_mind/mind_shell_wiring_test.dart
@@ -9,13 +9,15 @@ import 'package:feature_iptv/feature_iptv.dart';
 import 'package:feature_mind/feature_mind.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:mocktail/mocktail.dart';
 import 'package:path/path.dart' as p;
 import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
 import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
-class _MockMindService extends Mock implements MindService {}
+class _FakeMindService implements MindService {
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
 
 class _FakePathProviderPlatform extends PathProviderPlatform
     with MockPlatformInterfaceMixin {
@@ -66,7 +68,7 @@ void main() {
   );
 
   test('mindMeetingProcessingOverrides restores an empty queue store', () async {
-    final mindService = _MockMindService();
+    final mindService = _FakeMindService();
 
     final container = ProviderContainer(
       overrides: mindMeetingProcessingOverrides(mindService),

--- a/app/test_mind/mind_shell_wiring_test.dart
+++ b/app/test_mind/mind_shell_wiring_test.dart
@@ -4,58 +4,18 @@ import 'package:airo_app/core/mind/mind_processing_queue.dart';
 import 'package:airo_app/core/mind/mind_provider_overrides.dart';
 import 'package:airo_app/main_mind.dart';
 import 'package:airo_pro_bootstrap/airo_pro_bootstrap.dart' as pro_bootstrap;
-import 'package:core_ai/core_ai.dart';
 import 'package:core_product_shell/core_product_shell.dart';
 import 'package:feature_iptv/feature_iptv.dart';
 import 'package:feature_mind/feature_mind.dart';
-import 'package:feature_mind/src/bridges/mind_generation_bridge.dart';
-import 'package:feature_mind/src/bridges/mind_speech_bridge.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
-
 import 'package:path/path.dart' as p;
 import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
 import 'package:plugin_platform_interface/plugin_platform_interface.dart';
-import 'package:record/record.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
-class _MockAudioRecorder extends Mock implements AudioRecorder {}
-
-class _FakeSpeechBridge implements MindSpeechBridge {
-  @override
-  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
-}
-
-class _FakeGenerationBridge implements MindGenerationBridge {
-  @override
-  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
-}
-
-class _FakeReadyModelProvider implements ModelProvider {
-  @override
-  bool get acquiresWithoutNetwork => true;
-
-  @override
-  Future<List<RequiredModel>> requiredModels() async => const [];
-
-  @override
-  Future<List<RequiredModel>> missingModels(Directory modelsDir) async =>
-      const [];
-
-  @override
-  Future<bool> isInstalled(Directory modelsDir) async => true;
-
-  @override
-  Stream<ModelAcquisitionEvent> acquire(Directory modelsDir) async* {}
-
-  @override
-  Future<List<InstalledModel>> verify(Directory modelsDir) async => const [];
-
-  @override
-  Future<void> dispose() async {}
-}
+class _MockMindService extends Mock implements MindService {}
 
 class _FakePathProviderPlatform extends PathProviderPlatform
     with MockPlatformInterfaceMixin {
@@ -105,30 +65,22 @@ void main() {
     },
   );
 
-  test(
-    'mindMeetingProcessingOverrides restores an empty queue store',
-    () async {
-      final mindService = MindService(
-        recorder: _MockAudioRecorder(),
-        modelProvider: _FakeReadyModelProvider(),
-        speechBridge: _FakeSpeechBridge(),
-        generationBridge: _FakeGenerationBridge(),
-      );
+  test('mindMeetingProcessingOverrides restores an empty queue store', () async {
+    final mindService = _MockMindService();
 
-      final container = ProviderContainer(
-        overrides: mindMeetingProcessingOverrides(mindService),
-      );
-      addTearDown(container.dispose);
+    final container = ProviderContainer(
+      overrides: mindMeetingProcessingOverrides(mindService),
+    );
+    addTearDown(container.dispose);
 
-      final queue = await container.read(meetingProcessingQueueProvider.future);
-      expect(queue, isA<MeetingProcessingQueue>());
+    final queue = await container.read(meetingProcessingQueueProvider.future);
+    expect(queue, isA<MeetingProcessingQueue>());
 
-      final queuePath = p.join(
-        tempDir.path,
-        'mind_recordings',
-        'processing_queue.json',
-      );
-      expect(File(queuePath).existsSync(), isTrue);
-    },
-  );
+    final queuePath = p.join(
+      tempDir.path,
+      'mind_recordings',
+      'processing_queue.json',
+    );
+    expect(File(queuePath).existsSync(), isTrue);
+  });
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sonar `new_coverage` on `main` is **78.3%** after #1887 (test_mind lcov merge). This adds tests for the next-largest unit-testable gaps:

- `mind_provider_overrides.dart` + `mind_processing_queue.dart` (`test_mind/mind_shell_wiring_test.dart`)
- `iptv_feature_module.dart` route tables (`app/test/features/iptv/iptv_feature_module_test.dart`)

## Test plan

- [x] `flutter test test_mind/mind_shell_wiring_test.dart --dart-define=APP_VARIANT=mind`
- [x] `flutter test test/features/iptv/iptv_feature_module_test.dart`
- [ ] Post-merge `sonarcloud-scan` ≥ 80%
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6db2c21f-f02a-4df9-92b2-e0797ee40b7b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6db2c21f-f02a-4df9-92b2-e0797ee40b7b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

