### PR TITLE
test(app): stabilize EPG warmup deferred-task timing on CI

### DIFF
--- a/app/test/main_tv_debug_playlist_test.dart
+++ b/app/test/main_tv_debug_playlist_test.dart
@@ -412,13 +412,13 @@ https://cdn.example.com/live/news.m3u8
 
     try {
       frameCallback!(Duration.zero);
-      for (var attempt = 0; attempt < 20; attempt++) {
+      for (var attempt = 0; attempt < 100; attempt++) {
         if (logs.contains(
           '✅ Deferred startup task completed: tv_debug_epg_warmup',
         )) {
           break;
         }
-        await Future<void>.delayed(const Duration(milliseconds: 10));
+        await Future<void>.delayed(const Duration(milliseconds: 25));
       }
 
       expect(parser.fetchCalls, 1);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`test-app` on `main` failed because `schedules DEBUG_IPTV_EPG_URL warmup after frame` timed out waiting for the deferred startup log (20×10ms). That blocked lcov upload and left Sonar at stale 76.9% coverage.

Widen the wait window to 100×25ms (2.5s) so slow CI runners can finish the warmup.

## Test plan

- [ ] CI `test-app` green on merge → `sonarcloud-scan` picks up merged lcov (78%+ expected)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6db2c21f-f02a-4df9-92b2-e0797ee40b7b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6db2c21f-f02a-4df9-92b2-e0797ee40b7b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

