### PR TITLE
Wire encrypted LifeTrack destination in Mind connector factory

### DIFF
--- a/packages/core_data/lib/core_data.dart
+++ b/packages/core_data/lib/core_data.dart
@@ -11,6 +11,8 @@ export 'src/storage/key_value_store.dart';
 export 'src/storage/preferences_store.dart';
 export 'src/storage/secure_store.dart';
 export 'src/storage/flutter_secure_store.dart';
+export 'src/storage/life_track_encryption_key_manager.dart';
+export 'src/storage/life_track_secure_stack.dart';
 export 'src/storage/life_track_local_data_source.dart';
 export 'src/storage/templates/life_track_template_fallback_resolver.dart';
 export 'src/storage/templates/template_registry.dart';

--- a/packages/core_data/lib/src/storage/life_track_encryption_key_manager.dart
+++ b/packages/core_data/lib/src/storage/life_track_encryption_key_manager.dart
@@ -1,0 +1,98 @@
+import 'dart:convert';
+import 'dart:math';
+
+import 'package:core_domain/core_domain.dart';
+
+import '../secure/secure_storage.dart';
+import 'flutter_secure_store.dart';
+import 'secure_store.dart';
+
+/// Platform secure-storage backed key manager for the encrypted LifeTrack DB.
+class LifeTrackEncryptionKeyManager implements EncryptionKeyManager {
+  LifeTrackEncryptionKeyManager({SecureStore? secureStore})
+    : _secureStore = secureStore ?? SecureStoreFactory.createSecure();
+
+  static const _storageKey = 'airo_lifetrack_db_encryption_key_v1';
+
+  final SecureStore _secureStore;
+  List<int>? _cachedKey;
+
+  @override
+  Future<Result<List<int>>> getDatabaseKey() async {
+    if (_cachedKey != null) {
+      return Ok(List<int>.from(_cachedKey!));
+    }
+
+    try {
+      final stored = await _secureStore.read(key: _storageKey);
+      if (stored != null && stored.isNotEmpty) {
+        _cachedKey = base64Url.decode(stored);
+        return Ok(List<int>.from(_cachedKey!));
+      }
+
+      final random = Random.secure();
+      final newKey = List<int>.generate(32, (_) => random.nextInt(256));
+      await _secureStore.write(
+        key: _storageKey,
+        value: base64Url.encode(newKey),
+      );
+      _cachedKey = newKey;
+      return Ok(List<int>.from(newKey));
+    } catch (error, stack) {
+      return Err(
+        SecureDestinationUnavailableError(
+          'LifeTrack encryption key unavailable',
+          originalError: error,
+          originalStack: stack,
+        ),
+        stack,
+      );
+    }
+  }
+
+  @override
+  Future<Result<void>> rotateKey() async {
+    try {
+      final random = Random.secure();
+      final newKey = List<int>.generate(32, (_) => random.nextInt(256));
+      await _secureStore.write(
+        key: _storageKey,
+        value: base64Url.encode(newKey),
+      );
+      _cachedKey = newKey;
+      return const Ok(null);
+    } catch (error, stack) {
+      return Err(
+        SecureDestinationUnavailableError(
+          'LifeTrack encryption key rotation failed',
+          originalError: error,
+          originalStack: stack,
+        ),
+        stack,
+      );
+    }
+  }
+
+  @override
+  Future<bool> isEncryptionAvailable() async {
+    try {
+      const probeKey = 'airo_lifetrack_secure_probe';
+      await _secureStore.write(key: probeKey, value: 'ok');
+      await _secureStore.delete(key: probeKey);
+      return true;
+    } catch (_) {
+      return false;
+    }
+  }
+
+  @override
+  Future<Result<void>> clearKeys() async {
+    try {
+      await _secureStore.delete(key: _storageKey);
+      _cachedKey = null;
+      return const Ok(null);
+    } catch (error, stack) {
+      return Err(error, stack);
+    }
+  }
+}

--- a/packages/core_data/lib/src/storage/life_track_secure_stack.dart
+++ b/packages/core_data/lib/src/storage/life_track_secure_stack.dart
@@ -1,0 +1,95 @@
+import 'package:core_domain/core_domain.dart';
+import 'package:path/path.dart' as p;
+import 'package:path_provider/path_provider.dart';
+import 'package:sqflite/sqflite.dart';
+
+import '../repositories/secure_life_track_repository_impl.dart';
+import '../secure/secure_storage.dart';
+import '../secure/sqflite_encrypted_database.dart';
+import 'encrypted_life_track_data_source.dart';
+import 'life_track_encryption_key_manager.dart';
+import 'life_track_idempotency_store.dart';
+import 'life_track_local_data_source.dart';
+import 'life_track_plaintext_migration.dart';
+import 'secure_life_track_destination.dart';
+
+/// Opens the encrypted LifeTrack destination and optional idempotency store.
+class LifeTrackSecureStack {
+  LifeTrackSecureStack._({
+    required this.destination,
+    required this.repository,
+    required this.plaintext,
+    required this.encrypted,
+    this.idempotencyPort,
+  });
+
+  final SecureLifeTrackDestination destination;
+  final LifeTrackRepository repository;
+  final LifeTrackLocalDataSource plaintext;
+  final EncryptedLifeTrackDataSource encrypted;
+  final IdempotentEffectPort? idempotencyPort;
+
+  static Future<LifeTrackSecureStack> open({
+    LifeTrackLocalDataSource? plaintext,
+    EncryptionKeyManager? keyManager,
+    DatabaseFactory? databaseFactory,
+    String? encryptedDatabasePath,
+    String? plaintextBackupPath,
+  }) async {
+    final plain =
+        plaintext ??
+        LifeTrackLocalDataSource(databaseFactory: databaseFactory);
+    final manager = keyManager ?? LifeTrackEncryptionKeyManager();
+    final encDb = SqfliteEncryptedDatabase(
+      keyManager: manager,
+      databaseFactory: databaseFactory,
+      databasePath: encryptedDatabasePath,
+    );
+    final encrypted = EncryptedLifeTrackDataSource(database: encDb);
+    final destination = SecureLifeTrackDestination(
+      plaintext: plain,
+      encrypted: encrypted,
+      keyManager: manager,
+    );
+
+    final mode = await destination.writeMode();
+    IdempotentEffectPort? idempotencyPort;
+    if (mode == SecureLifeTrackWriteMode.encryptedWritable) {
+      final init = await encrypted.initialize();
+      if (init is Ok<void>) {
+        final backup =
+            plaintextBackupPath ?? await _defaultPlaintextBackupPath();
+        final migration = await destination.migratePlaintext(
+          plaintextBackupPath: backup,
+        );
+        if (migration is Ok<LifeTrackMigrationReport>) {
+          idempotencyPort = LifeTrackIdempotencyStore(encrypted);
+        }
+      }
+    } else {
+      await plain.initialize();
+    }
+
+    return LifeTrackSecureStack._(
+      destination: destination,
+      repository: SecureLifeTrackRepositoryImpl(destination: destination),
+      plaintext: plain,
+      encrypted: encrypted,
+      idempotencyPort: idempotencyPort,
+    );
+  }
+
+  Future<bool> canWrite() async =>
+      (await destination.writeMode()) ==
+      SecureLifeTrackWriteMode.encryptedWritable;
+
+  Future<void> close() async {
+    await encrypted.close();
+    await plaintext.close();
+  }
+
+  static Future<String> _defaultPlaintextBackupPath() async {
+    final dir = await getApplicationDocumentsDirectory();
+    return p.join(dir.path, 'life_track_plaintext_backup.marker');
+  }
+}

--- a/packages/core_data/test/storage/life_track_encryption_key_manager_test.dart
+++ b/packages/core_data/test/storage/life_track_encryption_key_manager_test.dart
@@ -1,0 +1,35 @@
+import 'package:core_data/core_data.dart';
+import 'package:core_domain/core_domain.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('generates and reuses a stable database key', () async {
+    final store = InMemorySecureStore();
+    final manager = LifeTrackEncryptionKeyManager(secureStore: store);
+
+    final first = await manager.getDatabaseKey();
+    expect(first, isA<Ok<List<int>>>());
+    expect((first as Ok<List<int>>).value.length, 32);
+
+    final second = await manager.getDatabaseKey();
+    expect((second as Ok<List<int>>).value, (first as Ok<List<int>>).value);
+  });
+
+  test('rotateKey replaces the cached key', () async {
+    final store = InMemorySecureStore();
+    final manager = LifeTrackEncryptionKeyManager(secureStore: store);
+
+    final before = (await manager.getDatabaseKey() as Ok<List<int>>).value;
+    await manager.rotateKey();
+    final after = (await manager.getDatabaseKey() as Ok<List<int>>).value;
+
+    expect(after, isNot(equals(before)));
+  });
+
+  test('isEncryptionAvailable probes secure store', () async {
+    final manager = LifeTrackEncryptionKeyManager(
+      secureStore: InMemorySecureStore(),
+    );
+    expect(await manager.isEncryptionAvailable(), isTrue);
+  });
+}

--- a/packages/core_data/test/storage/life_track_secure_stack_test.dart
+++ b/packages/core_data/test/storage/life_track_secure_stack_test.dart
@@ -1,0 +1,76 @@
+import 'package:core_data/core_data.dart';
+import 'package:core_domain/core_domain.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sqflite_common_ffi/sqflite_ffi.dart';
+
+import '../storage/life_track_local_data_source_test.dart' show sampleTrack;
+import 'secure_life_track_destination_test.dart' show uniqueMemoryPath;
+
+class _UnavailableEncryptionKeyManager implements EncryptionKeyManager {
+  @override
+  Future<Result<List<int>>> getDatabaseKey() async =>
+      Err(SecureDestinationUnavailableError('no key'), StackTrace.current);
+
+  @override
+  Future<Result<void>> rotateKey() async => const Ok(null);
+
+  @override
+  Future<bool> isEncryptionAvailable() async => false;
+
+  @override
+  Future<Result<void>> clearKeys() async => const Ok(null);
+}
+
+void main() {
+  late DatabaseFactory databaseFactory;
+
+  setUpAll(() {
+    sqfliteFfiInit();
+    databaseFactory = databaseFactoryFfi;
+  });
+
+  test('open enables encrypted writes and idempotency', () async {
+    final plaintext = LifeTrackLocalDataSource(
+      databaseFactory: databaseFactory,
+      databasePath: uniqueMemoryPath('stack-plain'),
+    );
+    final stack = await LifeTrackSecureStack.open(
+      plaintext: plaintext,
+      keyManager: InMemoryEncryptionKeyManager(),
+      databaseFactory: databaseFactory,
+      encryptedDatabasePath: uniqueMemoryPath('stack-enc'),
+      plaintextBackupPath: uniqueMemoryPath('stack-backup'),
+    );
+
+    expect(await stack.canWrite(), isTrue);
+    expect(stack.idempotencyPort, isNotNull);
+
+    final track = sampleTrack();
+    final created = await stack.repository.createTrack(track);
+    expect(created, isA<Ok<LifeTrack>>());
+
+    await stack.close();
+  });
+
+  test('open without encryption fails closed for writes', () async {
+    final plaintext = LifeTrackLocalDataSource(
+      databaseFactory: databaseFactory,
+      databasePath: uniqueMemoryPath('stack-plain-ro'),
+    );
+    final stack = await LifeTrackSecureStack.open(
+      plaintext: plaintext,
+      keyManager: _UnavailableEncryptionKeyManager(),
+      databaseFactory: databaseFactory,
+      encryptedDatabasePath: uniqueMemoryPath('stack-enc-ro'),
+      plaintextBackupPath: uniqueMemoryPath('stack-backup-ro'),
+    );
+
+    expect(await stack.canWrite(), isFalse);
+    expect(stack.idempotencyPort, isNull);
+
+    final result = await stack.repository.createTrack(sampleTrack());
+    expect(result, isA<Err<LifeTrack>>());
+
+    await stack.close();
+  });
+}

--- a/packages/feature_mind/lib/src/agent_chat/data/connectors/life_track_repository_holder.dart
+++ b/packages/feature_mind/lib/src/agent_chat/data/connectors/life_track_repository_holder.dart
@@ -1,0 +1,125 @@
+import 'package:core_domain/core_domain.dart';
+
+/// Delegates LifeTrack repository calls after secure stack initialization.
+class DelegatingLifeTrackRepository implements LifeTrackRepository {
+  DelegatingLifeTrackRepository(this._delegate);
+
+  LifeTrackRepository _delegate;
+
+  void adopt(LifeTrackRepository repository) {
+    _delegate = repository;
+  }
+
+  @override
+  Future<Result<LifeTrack>> createTrack(LifeTrack track) =>
+      _delegate.createTrack(track);
+
+  @override
+  Future<Result<void>> deleteTrack(String id) => _delegate.deleteTrack(id);
+
+  @override
+  Future<Result<LifeTrack>> getTrack(String id) => _delegate.getTrack(id);
+
+  @override
+  Future<Result<List<LifeTrack>>> listTracks({TrackStatus? status}) =>
+      _delegate.listTracks(status: status);
+
+  @override
+  Future<Result<void>> saveInputValue(
+    String requirementId,
+    String value,
+  ) => _delegate.saveInputValue(requirementId, value);
+
+  @override
+  Future<Result<void>> updateActionItem(ActionItem item) =>
+      _delegate.updateActionItem(item);
+
+  @override
+  Future<Result<void>> updateItemStatus(
+    String itemId,
+    ItemStatus status,
+  ) => _delegate.updateItemStatus(itemId, status);
+
+  @override
+  Future<Result<void>> updateMilestone(Milestone milestone) =>
+      _delegate.updateMilestone(milestone);
+
+  @override
+  Future<Result<void>> updateTrack(LifeTrack track) =>
+      _delegate.updateTrack(track);
+
+  @override
+  Stream<List<LifeTrack>> watchTracks({TrackStatus? status}) =>
+      _delegate.watchTracks(status: status);
+}
+
+/// Idempotency port that activates when the encrypted stack is ready.
+class DelegatingIdempotentEffectPort implements IdempotentEffectPort {
+  IdempotentEffectPort? _delegate;
+
+  void adopt(IdempotentEffectPort port) => _delegate = port;
+
+  @override
+  Future<Result<IdempotentEffectRecord?>> findByKey(String idempotencyKey) {
+    final delegate = _delegate;
+    if (delegate == null) {
+      return Future.value(const Ok(null));
+    }
+    return delegate.findByKey(idempotencyKey);
+  }
+
+  @override
+  Future<Result<IdempotentEffectRecord>> beginEffect({
+    required String idempotencyKey,
+    required String confirmationHash,
+    required String resourceId,
+  }) {
+    final delegate = _delegate;
+    if (delegate == null) {
+      return Future.value(
+        Err(
+          SecureDestinationUnavailableError(
+            'LifeTrack idempotency requires encrypted storage',
+          ),
+          StackTrace.current,
+        ),
+      );
+    }
+    return delegate.beginEffect(
+      idempotencyKey: idempotencyKey,
+      confirmationHash: confirmationHash,
+      resourceId: resourceId,
+    );
+  }
+
+  @override
+  Future<Result<void>> commitEffect({
+    required String idempotencyKey,
+    required String destinationReceipt,
+  }) {
+    final delegate = _delegate;
+    if (delegate == null) {
+      return Future.value(
+        Err(
+          SecureDestinationUnavailableError(
+            'LifeTrack idempotency requires encrypted storage',
+          ),
+          StackTrace.current,
+        ),
+      );
+    }
+    return delegate.commitEffect(
+      idempotencyKey: idempotencyKey,
+      destinationReceipt: destinationReceipt,
+    );
+  }
+
+  @override
+  Future<Result<void>> markFailed(String idempotencyKey) {
+    final delegate = _delegate;
+    if (delegate == null) {
+      return Future.value(const Ok(null));
+    }
+    return delegate.markFailed(idempotencyKey);
+  }
+}

--- a/packages/feature_mind/lib/src/agent_chat/data/connectors/life_track_status_connector_factory_io.dart
+++ b/packages/feature_mind/lib/src/agent_chat/data/connectors/life_track_status_connector_factory_io.dart
@@ -5,13 +5,18 @@ import '../../../addons/templates/addon_life_track_record_policy.dart';
 import '../../../addons/templates/addon_template_catalog.dart';
 import '../../domain/services/agent_connector.dart';
 import 'life_track_record_connector.dart';
+import 'life_track_repository_holder.dart';
 import 'life_track_status_connector.dart';
 
-final LifeTrackLocalDataSource _lifeTrackDataSource =
+final LifeTrackLocalDataSource _lifeTrackPlaintextDataSource =
     LifeTrackLocalDataSource();
-final LifeTrackRepositoryImpl _lifeTrackRepository = LifeTrackRepositoryImpl(
-  localDataSource: _lifeTrackDataSource,
+final _lifeTrackRepositoryHolder = DelegatingLifeTrackRepository(
+  LifeTrackRepositoryImpl(localDataSource: _lifeTrackPlaintextDataSource),
 );
+final _idempotencyPortHolder = DelegatingIdempotentEffectPort();
+
+LifeTrackSecureStack? _secureStack;
+Future<void>? _secureStackFuture;
 
 final MindTemplateRegistryLoader _templateLoader =
     MindTemplateRegistryLoader();
@@ -27,16 +32,37 @@ Future<void> _ensureTemplateCatalog() async {
   _templateRegistry ??= await _templateLoader.load();
 }
 
+Future<void> _ensureSecureStack() {
+  _secureStackFuture ??= _openSecureStack();
+  return _secureStackFuture!;
+}
+
+Future<void> _openSecureStack() async {
+  try {
+    final stack = await LifeTrackSecureStack.open(
+      plaintext: _lifeTrackPlaintextDataSource,
+    );
+    _secureStack = stack;
+    _lifeTrackRepositoryHolder.adopt(stack.repository);
+    if (stack.idempotencyPort != null) {
+      _idempotencyPortHolder.adopt(stack.idempotencyPort!);
+    }
+  } catch (error, stack) {
+    debugPrint('LifeTrack secure stack unavailable: $error\n$stack');
+    await _lifeTrackPlaintextDataSource.initialize();
+  }
+}
+
 AgentConnector createLifeTrackStatusConnector() {
   return LifeTrackStatusConnector(
-    repository: _lifeTrackRepository,
+    repository: _lifeTrackRepositoryHolder,
     ensureInitialized: initializeLifeTrackStatusConnector,
   );
 }
 
 AgentConnector createLifeTrackRecordConnector() {
   return LifeTrackRecordConnector(
-    repository: _lifeTrackRepository,
+    repository: _lifeTrackRepositoryHolder,
     resolveTemplate: (templateId) async {
       await _ensureTemplateCatalog();
       return _templateRegistry!.getById(templateId);
@@ -50,19 +76,34 @@ AgentConnector createLifeTrackRecordConnector() {
           AddonLifeTrackRecordPolicy.defaultDedupeFields;
     },
     ensureInitialized: initializeLifeTrackStatusConnector,
+    writeGate: () async {
+      await _ensureSecureStack();
+      final stack = _secureStack;
+      if (stack == null) return false;
+      return await stack.canWrite();
+    },
+    idempotencyPort: _idempotencyPortHolder,
   );
 }
 
 Future<void> initializeLifeTrackStatusConnector() async {
   try {
     await _ensureTemplateCatalog();
-    await _lifeTrackDataSource.initialize();
+    await _ensureSecureStack();
   } catch (error) {
-    debugPrint('LifeTrack local data source unavailable: $error');
+    debugPrint('LifeTrack connector initialization failed: $error');
   }
 }
 
-Future<void> closeLifeTrackStatusConnector() => _lifeTrackDataSource.close();
+Future<void> closeLifeTrackStatusConnector() async {
+  if (_secureStack != null) {
+    await _secureStack!.close();
+    _secureStack = null;
+    _secureStackFuture = null;
+  } else {
+    await _lifeTrackPlaintextDataSource.close();
+  }
+}
 
 Future<TemplateRegistry> loadMindTemplateRegistry() async {
   await _ensureTemplateCatalog();


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Completes the encrypted LifeTrack write path for Mind add-on record flows after #1884 landed the connector hooks.

- **`LifeTrackEncryptionKeyManager`** — platform `SecureStore`-backed DB key lifecycle (generate, rotate, probe).
- **`LifeTrackSecureStack`** — opens `SecureLifeTrackDestination`, runs plaintext migration, exposes `SecureLifeTrackRepositoryImpl` and optional `LifeTrackIdempotencyStore`.
- **Mind IO factory** — lazy secure stack init; `DelegatingLifeTrackRepository` / `DelegatingIdempotentEffectPort` adopt encrypted delegates when ready; `writeGate` fails closed until `canWrite()` is true.

## Production judge (increment 8 follow-up)

| Criterion | Status |
|-----------|--------|
| Orchestrator / pending off template switches | ✅ (#1884) |
| Confirmation tokens | ✅ in-memory |
| Disable / quarantine / revoke spies | ✅ |
| **Encrypted write gate in app factory** | ✅ this PR |
| Persisted confirmation tokens | follow-up |

## Test plan

- [x] `flutter test packages/core_data/test/storage/life_track_encryption_key_manager_test.dart`
- [x] `flutter test packages/core_data/test/storage/life_track_secure_stack_test.dart`
- [x] `flutter test packages/core_data/test/storage/secure_life_track_destination_test.dart`
- [x] `flutter test packages/feature_mind/test/addons/addon_production_verification_test.dart`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3cb72c1f-40c3-40b6-938b-70e7592345dd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3cb72c1f-40c3-40b6-938b-70e7592345dd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

