### PR TITLE
test: cover IPTV routes, mind host adapter, catalog overrides for Sonar 80%

### DIFF
--- a/app/test/features/iptv/iptv_feature_module_test.dart
+++ b/app/test/features/iptv/iptv_feature_module_test.dart
@@ -1,9 +1,76 @@
+import 'dart:typed_data';
+
 import 'package:airo_app/features/iptv/iptv_feature_module.dart';
 import 'package:core_product_shell/core_product_shell.dart';
+import 'package:feature_iptv/feature_iptv.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_riverpod/misc.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
+import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
+import 'package:plugin_platform_interface/plugin_platform_interface.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class _RecordingStreamingService extends VideoPlayerStreamingService {
+  _RecordingStreamingService() : super(engine: FakeAiroPlaybackEngine());
+}
+
+class _FakePathProviderPlatform extends PathProviderPlatform
+    with MockPlatformInterfaceMixin {
+  @override
+  Future<String?> getTemporaryPath() async => '/tmp';
+}
 
 void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const shareChannel = MethodChannel('dev.fluttercommunity.plus/share');
+
+  setUp(() {
+    PathProviderPlatform.instance = _FakePathProviderPlatform();
+  });
+
+  List<Override> iptvOverrides(SharedPreferences prefs) => [
+    sharedPreferencesProvider.overrideWithValue(prefs),
+    iptvChannelsProvider.overrideWith((ref) async => const []),
+    recentlyWatchedChannelsProvider.overrideWith((ref) async => const []),
+    streamingStateProvider.overrideWith(
+      (ref) => Stream.value(
+        StreamingState(playbackState: PlaybackState.idle, isLiveStream: true),
+      ),
+    ),
+    iptvStreamingServiceProvider.overrideWith((ref) {
+      final service = _RecordingStreamingService();
+      ref.onDispose(service.dispose);
+      return service;
+    }),
+  ];
+
+  Future<void> pumpIptvRouter(
+    WidgetTester tester, {
+    required List<RouteBase> routes,
+    required String initialLocation,
+  }) async {
+    SharedPreferences.setMockInitialValues({});
+    final prefs = await SharedPreferences.getInstance();
+    final router = GoRouter(routes: routes, initialLocation: initialLocation);
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: iptvOverrides(prefs),
+        child: MaterialApp.router(routerConfig: router),
+      ),
+    );
+    await tester.pump();
+  }
+
+  tearDown(() {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(shareChannel, null);
+  });
+
   test('IPTV module exposes mobile and TV route tables', () {
     final module = IptvFeatureModule();
 
@@ -22,5 +89,75 @@ void main() {
       '/iptv',
       '/iptv/player',
     ]);
+  });
+
+  testWidgets('mobile IPTV route wires share callbacks', (tester) async {
+    final module = IptvFeatureModule();
+    final calls = <MethodCall>[];
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(shareChannel, (call) async {
+          calls.add(call);
+          return 'success';
+        });
+
+    await pumpIptvRouter(
+      tester,
+      routes: module.routesFor(ShellId.mobile),
+      initialLocation: '/iptv',
+    );
+
+    final iptvScreen = tester.widget<IPTVScreen>(find.byType(IPTVScreen));
+    expect(iptvScreen.onShareVideoFrame, isNotNull);
+    expect(iptvScreen.onPickLocalMediaForTv, isNull);
+
+    await tester.runAsync(() async {
+      await iptvScreen.onShareVideoFrame!(
+        Uint8List.fromList([0x89, 0x50, 0x4e, 0x47]),
+      );
+    });
+    expect(calls.map((call) => call.method), ['share']);
+  });
+
+  testWidgets('mobile IPTV route opens VOD and player routes', (tester) async {
+    final module = IptvFeatureModule();
+
+    await pumpIptvRouter(
+      tester,
+      routes: module.routesFor(ShellId.mobile),
+      initialLocation: '/iptv',
+    );
+
+    final iptvScreen = tester.widget<IPTVScreen>(find.byType(IPTVScreen));
+    iptvScreen.onOpenVod?.call();
+    await tester.pumpAndSettle();
+    expect(find.byType(VodScreen), findsOneWidget);
+
+    final router = GoRouter.of(tester.element(find.byType(VodScreen)));
+    router.go('/iptv/player?channelId=news-1');
+    await tester.pumpAndSettle();
+
+    final playerScreen = tester.widget<IPTVScreen>(find.byType(IPTVScreen));
+    expect(playerScreen.key, const ValueKey<String>('news-1'));
+  });
+
+  testWidgets('TV IPTV routes build screens and honor channel keys', (
+    tester,
+  ) async {
+    final module = IptvFeatureModule();
+
+    await pumpIptvRouter(
+      tester,
+      routes: module.routesFor(ShellId.tv),
+      initialLocation: '/iptv',
+    );
+
+    expect(find.byType(IPTVScreen), findsOneWidget);
+
+    final router = GoRouter.of(tester.element(find.byType(IPTVScreen)));
+    router.go('/iptv/player?channelId=stream-news');
+    await tester.pumpAndSettle();
+
+    final iptvScreen = tester.widget<IPTVScreen>(find.byType(IPTVScreen));
+    expect(iptvScreen.key, const ValueKey<String>('stream-news'));
   });
 }

--- a/app/test/features/settings/application/intelligence_live_catalog_overrides_test.dart
+++ b/app/test/features/settings/application/intelligence_live_catalog_overrides_test.dart
@@ -1,0 +1,31 @@
+import 'package:airo_app/features/settings/application/ai_model_management.dart';
+import 'package:core_ai/core_ai.dart';
+import 'package:feature_mind/feature_mind.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('intelligenceLiveCatalogOverrides mirrors the model registry', () {
+    final registry = ModelRegistry();
+    addTearDown(registry.dispose);
+    registry.registerModel(
+      const OfflineModelInfo(
+        id: 'catalog-model',
+        name: 'Catalog model',
+        family: ModelFamily.qwen,
+        fileSizeBytes: 1024,
+        provider: AIProvider.custom,
+      ),
+    );
+
+    final container = ProviderContainer(
+      overrides: [
+        modelRegistryProvider.overrideWithValue(registry),
+        ...intelligenceLiveCatalogOverrides(),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    expect(container.read(intelligenceCatalogProvider), registry.allModels);
+  });
+}

--- a/app/test_mind/mind_assistant_host_adapter_test.dart
+++ b/app/test_mind/mind_assistant_host_adapter_test.dart
@@ -1,0 +1,137 @@
+import 'package:airo_app/core/assistant/mind_assistant_host_adapter.dart';
+import 'package:airo_app/features/settings/application/ai_model_management.dart';
+import 'package:core_ai/core_ai.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+
+final mindAssistantAdapterProvider = Provider<MindAssistantHostAdapter>(
+  (ref) => MindAssistantHostAdapter(ref),
+);
+
+void main() {
+  testWidgets('openModelManager navigates to the models route', (tester) async {
+    final router = GoRouter(
+      initialLocation: '/',
+      routes: [
+        GoRoute(
+          path: '/',
+          builder: (context, state) => Consumer(
+            builder: (context, ref, _) {
+              final adapter = ref.read(mindAssistantAdapterProvider);
+              return ElevatedButton(
+                onPressed: () => adapter.openModelManager(context),
+                child: const Text('open models'),
+              );
+            },
+          ),
+        ),
+        GoRoute(
+          path: '/models',
+          builder: (context, state) =>
+              const Scaffold(body: Text('models surface')),
+        ),
+      ],
+    );
+
+    await tester.pumpWidget(
+      ProviderScope(child: MaterialApp.router(routerConfig: router)),
+    );
+    await tester.tap(find.text('open models'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('models surface'), findsOneWidget);
+  });
+
+  testWidgets('openHostSettings navigates to the settings route', (
+    tester,
+  ) async {
+    final router = GoRouter(
+      initialLocation: '/',
+      routes: [
+        GoRoute(
+          path: '/',
+          builder: (context, state) => Consumer(
+            builder: (context, ref, _) {
+              final adapter = ref.read(mindAssistantAdapterProvider);
+              return ElevatedButton(
+                onPressed: () => adapter.openHostSettings(context),
+                child: const Text('open settings'),
+              );
+            },
+          ),
+        ),
+        GoRoute(
+          path: '/settings',
+          builder: (context, state) =>
+              const Scaffold(body: Text('settings surface')),
+        ),
+      ],
+    );
+
+    await tester.pumpWidget(
+      ProviderScope(child: MaterialApp.router(routerConfig: router)),
+    );
+    await tester.tap(find.text('open settings'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('settings surface'), findsOneWidget);
+  });
+
+  test(
+    'loadAssistantDownloadedModels returns only downloaded gguf chat models',
+    () async {
+      final registry = ModelRegistry();
+      addTearDown(registry.dispose);
+      registry.registerModel(
+        const OfflineModelInfo(
+          id: 'chat-gguf',
+          name: 'Chat GGUF',
+          family: ModelFamily.qwen,
+          fileSizeBytes: 1024,
+          provider: AIProvider.custom,
+          capabilities: [ModelCapability.chat],
+          filePath: '/tmp/chat.gguf',
+        ),
+      );
+      registry.registerModel(
+        const OfflineModelInfo(
+          id: 'speech-whisper',
+          name: 'Whisper',
+          family: ModelFamily.other,
+          fileSizeBytes: 2048,
+          provider: AIProvider.custom,
+          capabilities: [ModelCapability.audioUnderstanding],
+          filePath: '/tmp/whisper.bin',
+        ),
+      );
+      registry.registerModel(
+        const OfflineModelInfo(
+          id: 'chat-no-path',
+          name: 'Chat no path',
+          family: ModelFamily.qwen,
+          fileSizeBytes: 512,
+          provider: AIProvider.custom,
+          capabilities: [ModelCapability.chat],
+        ),
+      );
+
+      final container = ProviderContainer(
+        overrides: [
+          modelRegistryProvider.overrideWithValue(registry),
+          mindAssistantAdapterProvider.overrideWith(
+            (ref) => MindAssistantHostAdapter(ref),
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      final models = await container
+          .read(mindAssistantAdapterProvider)
+          .loadAssistantDownloadedModels();
+
+      expect(models.map((model) => model.id), ['chat-gguf']);
+    },
+  );
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Pushes Sonar `new_coverage` toward the 80% gate by covering the remaining unit-testable gaps in three small app-layer files instead of large settings/UI screens.

## Changes

### `iptv_feature_module.dart`
- Widget tests exercise mobile and TV route builders: `onShareVideoFrame`, `onOpenVod`, `ValueKey` channel routing, and `VodScreen` navigation.
- Uses recording streaming service override (avoids real player init hangs), fake path provider, mocked `share_plus` channel, and `tester.runAsync` for the share callback.

### `mind_assistant_host_adapter.dart`
- Widget tests for `openModelManager` → `/models` and `openHostSettings` → `/settings`.
- Unit test for `loadAssistantDownloadedModels()` filtering downloaded `.gguf` chat models.
- Uses a `Provider<MindAssistantHostAdapter>` seam because Riverpod 3 `WidgetRef` is not assignable to `Ref`.

### `mind_provider_overrides.dart`
- `intelligence_live_catalog_overrides_test.dart` covers `intelligenceLiveCatalogOverrides()` mirroring `modelRegistryProvider`.
- `buildMindProviderOverrides()` line coverage already exercised by `mind_shell_wiring_test.dart`.

## Verification

```bash
flutter test test/features/iptv/iptv_feature_module_test.dart
flutter test test_mind/mind_assistant_host_adapter_test.dart --dart-define=APP_VARIANT=mind
flutter test test/features/settings/application/intelligence_live_catalog_overrides_test.dart
flutter test test_mind/mind_shell_wiring_test.dart --dart-define=APP_VARIANT=mind
```

All pass locally.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6db2c21f-f02a-4df9-92b2-e0797ee40b7b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6db2c21f-f02a-4df9-92b2-e0797ee40b7b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

