### PR TITLE
feat(mind): native live capture fan-out with failure isolation

### DIFF
--- a/docs/features/airo-mind/LIVE_CAPTURE_FAN_OUT.md
+++ b/docs/features/airo-mind/LIVE_CAPTURE_FAN_OUT.md
@@ -108,7 +108,7 @@ a discovery made later during profiling.
 
 | Platform | Shim | Tracking |
 |---|---|---|
-| macOS / Linux / Windows (interim) | `record.startStream` (PCM16) → `push_live_pcm` via `MeetingLivePcmShim` | Stage 2 — remove when native fan-out lands |
+| macOS / Linux / Windows (interim) | `record.startStream` (PCM16) → `push_live_pcm` via `MeetingLivePcmShim`. Native `CaptureFanout` writes the WAV; Dart does **not** open a second file encoder. | Stage 2 — remove when cpal (or equivalent) capture starts inside `start_live_session` |
 
 ## Conformance
 
@@ -117,11 +117,12 @@ They belong with Stage 2, alongside the code that first fans out.
 
 | Check | Where | Status |
 |---|---|---|
-| A crash during a live session leaves a file that `transcribe_recording` accepts | Integration test per platform | Open |
-| Live session start on an over-budget device is refused before the mic opens | Host test against `Supervisor` admission | Open |
+| A crash during a live session leaves a file that `transcribe_recording` accepts | `rust/airo_mind_audio/tests/fanout_crash_recovery.rs` (host: drop live consumer + `preprocess_path`) | **Done** (host). Per-platform process-kill still open |
+| Live session start on an over-budget device is refused before the mic opens | `Supervisor::check_speech_admission` + Dart `meeting_capture_live_warning` | **Done** (host + UI) |
 | Ring overflow emits DEGRADED and does not grow memory | `rust/airo_mind_audio/src/live.rs` (`ring_overflow_marks_step_degraded`) + Dart degraded banner test | **Done** (host + UI) |
-| No PCM-shaped type crosses the FRB surface | Reviewable in the generated bridge; candidate for a `scripts/check-*` guard once the surface exists | Open (interim `push_live_pcm` shim documented) |
+| No PCM-shaped type crosses the FRB surface | Reviewable in the generated bridge; candidate for a `scripts/check-*` guard once the surface exists | Open (interim `push_live_pcm` shim; file no longer uses a second mic) |
 | Live transcript UI never rewrites STABLE text | `meeting_live_session_coordinator_test.dart` (stable accumulation) | **Done** (Dart) |
+| Live inference failure does not corrupt the recording | `fanout_crash_recovery.rs` + `live_failed` in `LiveSpeechPipeline` | **Done** (host) |
 
 ## References
 

--- a/docs/features/airo-mind/LIVE_SCRIBE_DESKTOP_PREVIEW_QUALIFICATION.md
+++ b/docs/features/airo-mind/LIVE_SCRIBE_DESKTOP_PREVIEW_QUALIFICATION.md
@@ -76,13 +76,14 @@ Use an external audio source so the mic captures system/room audio (user runs th
 
 ## CI evidence (dev)
 
-- `packages/feature_mind/test/capture/` — capture coordinator, vocabulary, speaker UI.
-- `rust/airo_mind_audio` — ring overflow → degraded step report.
+- `packages/feature_mind/test/capture/` — capture coordinator, vocabulary, speaker UI, fan-out recorder, admission warning.
+- `rust/airo_mind_audio` — ring overflow → degraded; fan-out crash isolation; governor; latency harness.
 - `rust/airo_mind_whisper` — diarization label assignment tests.
+- `rust/airo_mind_meeting` — incremental Conversation IR (stable-sentence extractor).
 
 ## Open for Stage 2 (not blocking preview sign-off)
 
-- Native capture fan-out (Android/iOS).
-- Crash-during-live → file transcribes (per-platform integration).
-- Live RTF / time-to-first-partial SLO in release gates.
+- In-process native capture (cpal / AudioRecord / AVAudioEngine) so `push_live_pcm` leaves the FRB surface.
+- Crash-during-live → file transcribes (per-platform process kill; host fan-out test is done).
+- Live RTF / time-to-first-partial SLO in release gates on real weights.
 - Persona mapping / voice enrollment (P2).

--- a/docs/features/airo-mind/evaluation-results.md
+++ b/docs/features/airo-mind/evaluation-results.md
@@ -1,0 +1,24 @@
+# Evaluation results
+
+Status: **Incomplete.** Date: 2026-08-23
+Verdict: [NOT PRODUCTION QUALIFIED](./production-qualification.md)
+
+## Automated (this pass)
+
+| Suite | Result |
+|---|---|
+| `airo_mind_audio` fan-out + isolation + governor + latency harness | Run locally in this change |
+| `airo_mind_meeting` incremental Conversation IR | Run locally in this change |
+| `airo_mind_core` `check_speech_admission` | Run locally in this change |
+| `feature_mind` fan-out port, live admission, capture screen warning | Run locally in this change |
+
+## Golden conversations (not collected)
+
+The production spec requires English / Hindi / Hinglish, technical, 2- and
+4-speaker, overlap, noise, and proper-noun fixtures with WER, speaker error,
+entity/action/decision accuracy. **None of those golden scores are claimed
+here.** Existing `airo_mind_meeting` IR goldens remain post-recording only.
+
+## Remaining blockers
+
+See [production-qualification.md](./production-qualification.md) §Still open.

--- a/docs/features/airo-mind/evaluation-results.md
+++ b/docs/features/airo-mind/evaluation-results.md
@@ -10,7 +10,7 @@ Verdict: [NOT PRODUCTION QUALIFIED](./production-qualification.md)
 | `airo_mind_audio` fan-out + isolation + governor + latency harness | Run locally in this change |
 | `airo_mind_meeting` incremental Conversation IR | Run locally in this change |
 | `airo_mind_core` `check_speech_admission` | Run locally in this change |
-| `feature_mind` fan-out port, live admission, capture screen warning | Run locally in this change |
+| `feature_mind` fan-out port, live admission, capture screen warning | Added; Flutter SDK was not available in this agent environment |
 
 ## Golden conversations (not collected)
 

--- a/docs/features/airo-mind/latency-benchmarks.md
+++ b/docs/features/airo-mind/latency-benchmarks.md
@@ -1,0 +1,28 @@
+# Live latency benchmarks
+
+Status: **Harness only.** Date: 2026-08-23
+Targets (not claims): partial &lt; 500 ms, stable &lt; 1 s.
+
+## What is measured
+
+`LiveSpeechPipeline` with a fake `SpeechEngine` that returns immediately:
+
+- **Partial latency:** time from `push_pcm` + `step` until a `Partial` event.
+- **Stable latency:** time from the silence window `step` until a `Stable` event.
+
+Test: `airo_mind_audio` `fake_engine_partial_and_stable_latencies_are_measurable`.
+
+This proves the pipeline can *record* those intervals and that the fake engine
+path is well under the targets. It is **not** evidence about whisper.cpp on a
+device.
+
+## Not yet a release gate
+
+A CI gate on real weights needs:
+
+1. A pinned speech fixture and model (see `speech_offline.rs` / tiny.en).
+2. Repeatable wall-clock budgets with machine-class exemptions.
+3. Explicit fail thresholds after a measured baseline, not these targets copied
+   as if they were already met.
+
+Until that exists, live latency remains **Preview**.

--- a/docs/features/airo-mind/platform-capability-matrix.md
+++ b/docs/features/airo-mind/platform-capability-matrix.md
@@ -1,0 +1,22 @@
+# Platform capability matrix
+
+Status: **QA evidence, not marketing.** Date: 2026-08-23
+States: `UNSUPPORTED` · `EXPERIMENTAL` · `PREVIEW` · `PRODUCTION`
+
+A cell is PRODUCTION only when implementation **and** tests exist for that
+host. Compilation alone is not enough.
+
+| Capability | Desktop | Android | iOS | Web |
+|---|---|---|---|---|
+| Recording | PRODUCTION (`package:record` AAC after-recording; live WAV fan-out) | PRODUCTION (foreground service + MediaRecorder) | PREVIEW (engine build gated #1546) | PRODUCTION (after-recording where the recorder plugin works) |
+| Offline STT (file) | PRODUCTION | PREVIEW (weights + FFI) | UNSUPPORTED (#1546) | UNSUPPORTED (no FFI) |
+| Live STT | PREVIEW (fan-out + worker; PCM still via FRB shim) | UNSUPPORTED | UNSUPPORTED | UNSUPPORTED |
+| Stabilization | PREVIEW (host unit tests) | UNSUPPORTED | UNSUPPORTED | UNSUPPORTED |
+| Vocabulary (stable/final) | PREVIEW | UNSUPPORTED | UNSUPPORTED | UNSUPPORTED |
+| Live speaker activity | PREVIEW (provisional lanes) | UNSUPPORTED | UNSUPPORTED | UNSUPPORTED |
+| Final diarization | PREVIEW (post-stop on file) | PREVIEW | UNSUPPORTED | UNSUPPORTED |
+| Live Conversation IR | EXPERIMENTAL (Rust extractor; not on FRB/UI) | UNSUPPORTED | UNSUPPORTED | UNSUPPORTED |
+| Live insights | EXPERIMENTAL (UI stub) | UNSUPPORTED | UNSUPPORTED | UNSUPPORTED |
+| Post-recording IR | PREVIEW (`airo_mind_meeting` two-pass) | PREVIEW | UNSUPPORTED | UNSUPPORTED |
+| Search | PRODUCTION (meeting library) | PREVIEW | UNSUPPORTED | UNSUPPORTED |
+| Memory | PREVIEW (vault / notes) | PREVIEW | UNSUPPORTED | UNSUPPORTED |

--- a/docs/features/airo-mind/production-qualification.md
+++ b/docs/features/airo-mind/production-qualification.md
@@ -1,0 +1,61 @@
+# Airo Mind — production qualification
+
+Status: **NOT PRODUCTION QUALIFIED**
+Date: 2026-08-23
+Evidence: [platform-capability-matrix.md](./platform-capability-matrix.md),
+[latency-benchmarks.md](./latency-benchmarks.md),
+[evaluation-results.md](./evaluation-results.md),
+[LIVE_SCRIBE_DESKTOP_PREVIEW_QUALIFICATION.md](./LIVE_SCRIBE_DESKTOP_PREVIEW_QUALIFICATION.md)
+
+## Verdict
+
+```text
+NOT PRODUCTION QUALIFIED
+```
+
+Desktop live scribe remains **Preview**. Default mode for every platform is
+**After recording**. Live modes stay gated off on Android, iOS, and web.
+
+This document does not lower gates. Remaining P0 items are listed below.
+
+## What this pass closed
+
+| Gate | Evidence |
+|---|---|
+| Unified fan-out (file + live, live never blocks file) | `rust/airo_mind_audio` `CaptureFanout` + `IncrementalWavWriter` |
+| Live inference failure does not corrupt the file | `tests/fanout_crash_recovery.rs` |
+| Dead live consumer mid-session leaves a transcribable WAV | same |
+| Pipeline isolates STT backend errors | `live.rs` `live_failed` |
+| Admission refuses over-budget live STT | `Supervisor::check_speech_admission` tests + Dart warning path |
+| Resource/thermal/battery policy (pure) | `ResourceGovernor` unit tests |
+| In-process partial/stable latency harness | `fake_engine_partial_and_stable_latencies_are_measurable` |
+| Incremental Conversation IR (no live LLM) | `airo_mind_meeting::live_ir` |
+| Desktop one-mic (no second `AudioRecorder` file encoder) | `FanoutBackedAudioRecorderPort` |
+
+## Still open (blocks PRODUCTION)
+
+1. Native microphone capture inside Rust (cpal / platform AudioRecord) so PCM
+   no longer crosses FRB (`push_live_pcm` / ZC-1).
+2. Measured live latency on real whisper weights (partial &lt; 500 ms, stable
+   &lt; 1 s) as a release gate, not only the in-process fake-engine harness.
+3. Golden conversation suite (WER/CER, speakers, entities) on representative
+   recordings.
+4. Conversation IR events on the FRB/UI surface (insights rail is still a stub).
+5. Runtime thermal/battery probes wired into the live session (policy types
+   exist; OS probes do not).
+6. Android / iOS native capture lifecycle and device qualification.
+7. Speaker timeline reconciliation beyond provisional live lanes + post-stop
+   diarization (already present when `audio_path` is passed to
+   `stop_live_session`).
+
+## Product states
+
+| Surface | State |
+|---|---|
+| Desktop live STT | **PREVIEW** |
+| Desktop after-recording STT | **PRODUCTION** (unchanged file path) |
+| Android / iOS live | **UNSUPPORTED** (settings gated) |
+| Web live | **UNSUPPORTED** |
+
+Do not show "Production" for live intelligence until this file's verdict
+changes on the basis of new test evidence.

--- a/docs/features/airo-mind/real-time-architecture.md
+++ b/docs/features/airo-mind/real-time-architecture.md
@@ -1,0 +1,67 @@
+# Real-time conversation architecture
+
+Status: **Implemented core (desktop fan-out + isolation). Not production-qualified.**
+Date: 2026-08-23
+Owner: Rust Architect + Platform Architect
+
+Companion: [LIVE_CAPTURE_FAN_OUT.md](./LIVE_CAPTURE_FAN_OUT.md),
+[production-qualification.md](./production-qualification.md),
+[ADR-0025](../../adr/0025-streaming-speech-engine-boundary.md).
+
+## Ownership
+
+| Concern | Owner |
+|---|---|
+| Microphone consent, session start/pause/resume/stop | Dart (`MeetingCaptureController`) |
+| Authoritative capture ingest | Native `CaptureFanout` (`airo_mind_audio`) |
+| Encoded/WAV file (durability, crash recovery) | `IncrementalWavWriter` via fan-out |
+| Live PCM ring, VAD, windowing, stabilizer | `LiveSpeechPipeline` |
+| Speech inference | `SpeechEngine` behind `Supervisor::run_speech` |
+| Transcript events | Native → Dart (`TranscriptEvent`) |
+| UI | Flutter |
+
+Live intelligence is an optional consumer of the recording stream. The file is
+the recovery artifact. STT, vocabulary, IR, and LLM failure must not stop
+capture.
+
+## Desktop live path (this change)
+
+```text
+Consent → start_live_session (admission)
+        → one record.startStream (PCM16 16 kHz)
+        → push_live_pcm
+              ├─ CaptureFanout → incremental WAV  (never waits on STT)
+              └─ bounded channel → live worker
+                    → ring → VAD → SpeechEngine → stabilizer → events
+```
+
+`FanoutBackedAudioRecorderPort` drives the capture controller timer without
+opening a second microphone. After-recording mode still uses `package:record`
+AAC as before.
+
+`push_live_pcm` remains an interim FRB ingest (ZC-1). Removing it requires
+in-process native capture (cpal / AudioRecord / AVAudioEngine) behind the
+same session API.
+
+## Failure isolation
+
+```text
+LIVE ENGINE ERROR / worker panic / channel overflow
+        ↓
+Mark live intelligence degraded
+        ↓
+Continue writing the WAV
+        ↓
+Stop → post-recording transcribe_recording
+```
+
+The UI already surfaces `TranscriptEvent::Degraded` and a start-time warning
+when admission refuses live STT.
+
+## Incremental Conversation IR
+
+`airo_mind_meeting::IncrementalConversationIr` consumes **stable sentences**
+and emits structured events (segment, entity, action, decision, question,
+topic) without an LLM. It is not yet on the FRB event surface — live UI still
+reads transcript events. Deep Meeting IR remains the post-recording two-pass
+pipeline.

--- a/packages/feature_mind/lib/src/capture/application/live_pcm_shim_port.dart
+++ b/packages/feature_mind/lib/src/capture/application/live_pcm_shim_port.dart
@@ -1,4 +1,7 @@
-/// PCM fan-out shim for live STT — interim desktop until native capture lands.
+/// PCM ingest for live STT. Desktop uses one `startStream` into native
+/// `CaptureFanout` (file + ring). Not a second `AudioRecorder` beside a
+/// file encoder — `FanoutBackedAudioRecorderPort` owns the controller
+/// lifecycle while this port owns the single microphone stream.
 abstract interface class LivePcmShimPort {
   /// Normalized RMS (0–1) for the live amplitude meter — not speaker identity.
   void Function(double normalizedRms)? onAmplitude;

--- a/packages/feature_mind/lib/src/capture/application/meeting_capture_providers.dart
+++ b/packages/feature_mind/lib/src/capture/application/meeting_capture_providers.dart
@@ -17,6 +17,7 @@ import '../data/meeting_processing_queue_store.dart';
 import '../data/meeting_recording_service_gateway.dart';
 import '../domain/meeting_processing_job.dart';
 import 'meeting_capture_controller.dart';
+import 'meeting_live_session_coordinator.dart';
 import 'meeting_processing_queue.dart';
 
 /// Factory for one microphone encoder per capture session. Widget tests
@@ -62,6 +63,28 @@ Future<String> nextMeetingRecordingPath() async {
   final stamp = DateTime.now().millisecondsSinceEpoch;
   return p.join(recordingsDir.path, 'meeting-$stamp.m4a');
 }
+
+/// WAV path the native live fan-out writes. Must stay in lock-step with
+/// `airo_mind_whisper::api::meetings::live_fanout_path`:
+/// `{store_path.parent}/mind_recordings/{meetingId}.wav`.
+Future<String> nextLiveFanoutRecordingPath(String meetingId) async {
+  final dir = await getApplicationSupportDirectory();
+  final recordingsDir = Directory(p.join(dir.path, 'mind_recordings'));
+  await recordingsDir.create(recursive: true);
+  return p.join(recordingsDir.path, '$meetingId.wav');
+}
+
+final liveFanoutRecordingPathProvider =
+    Provider<Future<String> Function(String)>(
+      (ref) => nextLiveFanoutRecordingPath,
+    );
+
+/// Builds a live STT coordinator. Tests replace this to simulate admission
+/// refusal without loading the whisper cdylib.
+final meetingLiveSessionCoordinatorFactoryProvider =
+    Provider<MeetingLiveSessionCoordinator Function()>(
+      (ref) => () => MeetingLiveSessionCoordinator(),
+    );
 
 Future<String> _processingQueuePath() async {
   final dir = await getApplicationSupportDirectory();

--- a/packages/feature_mind/lib/src/capture/application/meeting_live_pcm_shim.dart
+++ b/packages/feature_mind/lib/src/capture/application/meeting_live_pcm_shim.dart
@@ -7,11 +7,12 @@ import 'package:record/record.dart';
 import '../../whisper/api/meetings.dart' as rust;
 import 'live_pcm_shim_port.dart';
 
-/// Interim desktop shim: `record.startStream` → `push_live_pcm`.
+/// Desktop live ingest: one `record.startStream` → `push_live_pcm`.
 ///
-/// Documented violation of ZC-1 in `LIVE_CAPTURE_FAN_OUT.md` §Interim shim.
-/// Uses a second [AudioRecorder] beside the file encoder until native fan-out
-/// lands on this platform.
+/// Native `CaptureFanout` writes the WAV and feeds the live worker. This is
+/// still a ZC-1 interim (PCM crosses FRB) until cpal capture starts inside
+/// `start_live_session` without a Dart sample array. It is **not** a second
+/// microphone beside `package:record`'s file encoder.
 class MeetingLivePcmShim implements LivePcmShimPort {
   MeetingLivePcmShim({AudioRecorder? streamRecorder})
     : _recorder = streamRecorder ?? AudioRecorder();

--- a/packages/feature_mind/lib/src/capture/application/meeting_live_session_coordinator.dart
+++ b/packages/feature_mind/lib/src/capture/application/meeting_live_session_coordinator.dart
@@ -30,7 +30,7 @@ class MeetingLiveSessionCoordinator {
 
   final MindSpeechBridge _speech;
   final LivePcmShimPort _pcmShim;
-  final void Function()? onTranscriptChanged;
+  void Function()? onTranscriptChanged;
 
   StreamSubscription<TranscriptEvent>? _eventsSub;
   Completer<MeetingLiveSessionResult>? _readyCompleter;

--- a/packages/feature_mind/lib/src/capture/data/fanout_backed_audio_recorder_port.dart
+++ b/packages/feature_mind/lib/src/capture/data/fanout_backed_audio_recorder_port.dart
@@ -1,0 +1,41 @@
+/// Timer-only recorder used when native fan-out already owns the capture file.
+///
+/// Live desktop sessions write `{appSupport}/mind_recordings/{meetingId}.wav`
+/// from Rust (`CaptureFanout`). Opening `package:record` as well would be a
+/// second microphone. This port keeps `MeetingCaptureController`'s start →
+/// pause → stop lifecycle without a second encoder.
+library;
+
+import 'dart:async';
+
+import 'audio_recorder_port.dart';
+
+class FanoutBackedAudioRecorderPort implements AudioRecorderPort {
+  FanoutBackedAudioRecorderPort({required this.path});
+
+  final String path;
+
+  @override
+  Future<bool> hasPermission() async => true;
+
+  @override
+  Future<void> start(String _) async {}
+
+  @override
+  Future<void> pause() async {}
+
+  @override
+  Future<void> resume() async {}
+
+  @override
+  Future<String?> stop() async => path;
+
+  @override
+  Stream<RecorderOsEvent> get osEvents => const Stream.empty();
+
+  @override
+  Stream<double> get levels => const Stream.empty();
+
+  @override
+  Future<void> dispose() async {}
+}

--- a/packages/feature_mind/lib/src/capture/domain/live_transcription_support.dart
+++ b/packages/feature_mind/lib/src/capture/domain/live_transcription_support.dart
@@ -2,8 +2,9 @@ import 'package:flutter/foundation.dart';
 
 /// Whether live STT preview is supported on this host (ADR-0025 / fan-out §Web).
 ///
-/// Desktop: interim `MeetingLivePcmShim` → `push_live_pcm`. Web and mobile
-/// native fan-out are not on the contract path yet — live modes are gated off.
+/// Desktop: one `record.startStream` ingest into native `CaptureFanout`
+/// (file + live worker). Web and mobile native fan-out are not on the
+/// contract path yet — live modes are gated off.
 bool liveTranscriptionPreviewSupported({TargetPlatform? platform}) {
   if (kIsWeb) return false;
   final host = platform ?? defaultTargetPlatform;

--- a/packages/feature_mind/lib/src/capture/presentation/meeting_capture_screen.dart
+++ b/packages/feature_mind/lib/src/capture/presentation/meeting_capture_screen.dart
@@ -13,6 +13,7 @@ import '../application/meeting_capture_providers.dart';
 import '../application/meeting_live_session_coordinator.dart';
 import '../application/speech_language_preference.dart';
 import '../application/transcription_mode_preference.dart';
+import '../data/fanout_backed_audio_recorder_port.dart';
 import '../domain/live_transcription_support.dart';
 import '../domain/meeting_processing_job.dart';
 import '../domain/meeting_recording_state.dart';
@@ -73,6 +74,7 @@ class _MeetingCaptureScreenState extends ConsumerState<MeetingCaptureScreen> {
   @override
   void dispose() {
     _liveCoordinator?.dispose();
+    unawaited(_controller?.dispose());
     _snapshotSub?.cancel();
     _jobsSub?.cancel();
     super.dispose();
@@ -128,28 +130,27 @@ class _MeetingCaptureScreenState extends ConsumerState<MeetingCaptureScreen> {
       _liveWarning = null;
       _followLive = true;
     });
-    final controller = ref.read(meetingCaptureControllerProvider);
-    _controller = controller;
-    await _snapshotSub?.cancel();
-    _snapshotSub = controller.snapshots.listen((snapshot) {
-      if (mounted) setState(() => _snapshot = snapshot);
-    });
-
     final meetingId = 'meeting-${DateTime.now().millisecondsSinceEpoch}';
     _meetingId = meetingId;
     final transcriptionMode = ref.read(transcriptionModeProvider);
     final languageMode = ref.read(speechLanguageModeProvider);
-    if (transcriptionMode.usesLivePipeline && liveTranscriptionPreviewSupported()) {
-      _liveCoordinator = MeetingLiveSessionCoordinator(
-        onTranscriptChanged: () {
-          if (mounted) setState(() {});
-        },
-      );
+    var useFanoutRecorder = false;
+    var path = await ref.read(meetingRecordingPathProvider)();
+    if (transcriptionMode.usesLivePipeline &&
+        liveTranscriptionPreviewSupported()) {
+      _liveCoordinator = ref.read(
+        meetingLiveSessionCoordinatorFactoryProvider,
+      )();
+      _liveCoordinator!.onTranscriptChanged = () {
+        if (mounted) setState(() {});
+      };
       try {
         await _liveCoordinator!.start(
           meetingId: meetingId,
           language: languageMode.processLanguageCode,
         );
+        path = await ref.read(liveFanoutRecordingPathProvider)(meetingId);
+        useFanoutRecorder = true;
       } on Object catch (error) {
         if (!mounted) return;
         setState(() {
@@ -162,8 +163,20 @@ class _MeetingCaptureScreenState extends ConsumerState<MeetingCaptureScreen> {
       }
     }
 
+    final recorder = useFanoutRecorder
+        ? FanoutBackedAudioRecorderPort(path: path)
+        : ref.read(audioRecorderPortProvider)();
+    final controller = MeetingCaptureController(
+      recorder: recorder,
+      serviceGateway: ref.read(meetingRecordingServiceGatewayProvider),
+    );
+    _controller = controller;
+    await _snapshotSub?.cancel();
+    _snapshotSub = controller.snapshots.listen((snapshot) {
+      if (mounted) setState(() => _snapshot = snapshot);
+    });
+
     try {
-      final path = await ref.read(meetingRecordingPathProvider)();
       await _consentGate.startRecording(() => controller.start(path));
     } on ConsentRequiredException catch (error) {
       if (!mounted) return;
@@ -266,7 +279,6 @@ class _MeetingCaptureScreenState extends ConsumerState<MeetingCaptureScreen> {
 
   @override
   Widget build(BuildContext context) {
-    ref.watch(meetingCaptureControllerProvider);
     final showConsentUi =
         ref.watch(recordingConsentPromptProvider) || _implicitConsentFailed;
     final consentGranted = _consentGate.isGranted;

--- a/packages/feature_mind/test/capture/application/meeting_live_session_coordinator_test.dart
+++ b/packages/feature_mind/test/capture/application/meeting_live_session_coordinator_test.dart
@@ -136,6 +136,22 @@ void main() {
     await coordinator.cancel();
     await controller.close();
   });
+
+  test('start surfaces live admission errors to the caller', () async {
+    final bridge = FakeMindSpeechBridge()
+      ..liveStartError = StateError('OverBudget needs_mb=4096 budget_mb=512');
+    final shim = FakeLivePcmShim();
+    final coordinator = MeetingLiveSessionCoordinator(
+      speechBridge: bridge,
+      pcmShim: shim,
+    );
+
+    await expectLater(
+      coordinator.start(meetingId: 'm-admit'),
+      throwsA(isA<StateError>()),
+    );
+    expect(shim.startCalls, 0);
+  });
 }
 
 /// Routes [startLiveSession] to a controllable stream for tests.

--- a/packages/feature_mind/test/capture/data/fanout_backed_audio_recorder_port_test.dart
+++ b/packages/feature_mind/test/capture/data/fanout_backed_audio_recorder_port_test.dart
@@ -1,0 +1,16 @@
+import 'package:feature_mind/src/capture/data/audio_recorder_port.dart';
+import 'package:feature_mind/src/capture/data/fanout_backed_audio_recorder_port.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('fan-out port never opens a second encoder', () async {
+    final port = FanoutBackedAudioRecorderPort(path: '/tmp/meeting-1.wav');
+    expect(await port.hasPermission(), isTrue);
+    await port.start('/tmp/meeting-1.wav');
+    await port.pause();
+    await port.resume();
+    expect(await port.stop(), '/tmp/meeting-1.wav');
+    expect(port.osEvents, isA<Stream<RecorderOsEvent>>());
+    await port.dispose();
+  });
+}

--- a/packages/feature_mind/test/capture/presentation/meeting_capture_screen_test.dart
+++ b/packages/feature_mind/test/capture/presentation/meeting_capture_screen_test.dart
@@ -3,8 +3,12 @@ import 'dart:io';
 import 'package:feature_mind/src/assistant/consent/mind_runtime_provider.dart';
 import 'package:feature_mind/src/assistant/consent/recording_consent_prompt.dart';
 import 'package:feature_mind/src/capture/application/meeting_capture_providers.dart';
+import 'package:feature_mind/src/capture/application/meeting_live_session_coordinator.dart';
+import 'package:feature_mind/src/capture/application/transcription_mode_preference.dart';
 import 'package:feature_mind/src/capture/data/meeting_recording_service_gateway.dart';
+import 'package:feature_mind/src/capture/domain/transcription_mode.dart';
 import 'package:feature_mind/src/capture/presentation/meeting_capture_screen.dart';
+import 'package:flutter/foundation.dart';
 import 'package:feature_mind/src/runtime/models/log_models.dart';
 import 'package:feature_mind/src/runtime/ports/operation_log_port.dart';
 import 'package:feature_mind/src/runtime/scribe_mind_runtime.dart';
@@ -16,6 +20,8 @@ import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import '../support/fake_audio_recorder_port.dart';
+import '../../support/fake_bridges.dart';
+import '../../support/fake_live_pcm_shim.dart';
 
 void main() {
   Future<void> pumpScreen(
@@ -269,6 +275,71 @@ void main() {
       findsOneWidget,
     );
   });
+
+  testWidgets(
+    'live admission failure warns and still starts file recording',
+    (tester) async {
+      SharedPreferences.setMockInitialValues({
+        transcriptionModeKey: TranscriptionMode.live.storageValue,
+      });
+      debugDefaultTargetPlatformOverride = TargetPlatform.linux;
+      addTearDown(() => debugDefaultTargetPlatformOverride = null);
+
+      final tempDir = Directory.systemTemp.createTempSync(
+        'meeting_capture_live_',
+      );
+      addTearDown(() {
+        if (tempDir.existsSync()) tempDir.deleteSync(recursive: true);
+      });
+      PathProviderPlatform.instance = _FakePathProvider(tempDir.path);
+      final recorder = FakeAudioRecorderPort();
+      await tester.binding.setSurfaceSize(const Size(400, 1400));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            mindRuntimeProvider.overrideWith(
+              (ref) => ScribeMindRuntime(log: _MemoryLog()),
+            ),
+            recordingConsentPromptProvider.overrideWithValue(false),
+            audioRecorderPortProvider.overrideWith(
+              (ref) =>
+                  () => recorder,
+            ),
+            meetingRecordingPathProvider.overrideWith(
+              (ref) =>
+                  () async => '${tempDir.path}/meeting.m4a',
+            ),
+            meetingRecordingServiceGatewayProvider.overrideWith(
+              (ref) => const NoopMeetingRecordingServiceGateway(),
+            ),
+            meetingLiveSessionCoordinatorFactoryProvider.overrideWithValue(
+              () => MeetingLiveSessionCoordinator(
+                speechBridge: FakeMindSpeechBridge()
+                  ..liveStartError = StateError('OverBudget'),
+                pcmShim: FakeLivePcmShim(),
+              ),
+            ),
+          ],
+          child: const MaterialApp(home: MeetingCaptureScreen()),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byKey(const Key('meeting_capture_start_button')));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 50));
+
+      expect(
+        find.byKey(const Key('meeting_capture_live_warning')),
+        findsOneWidget,
+      );
+      expect(
+        recorder.calls.where((call) => call.startsWith('start:')),
+        isNotEmpty,
+      );
+    },
+  );
 }
 
 class _FakePathProvider extends PathProviderPlatform

--- a/packages/feature_mind/test/support/fake_bridges.dart
+++ b/packages/feature_mind/test/support/fake_bridges.dart
@@ -25,6 +25,9 @@ class FakeMindSpeechBridge implements MindSpeechBridge {
   rust.SpeechLanguage? initializedSpeechLanguage;
   rust.TranscriptDocumentRecord? transcriptDocumentToReturn;
 
+  /// When set, [startLiveSession] throws — admission refusal / missing engine.
+  Object? liveStartError;
+
   /// `#1664`: what the last `transcribe` call was asked to pin, so a test can
   /// assert a Settings-chosen language reaches the bridge unchanged.
   String? transcribeLanguage;
@@ -98,8 +101,13 @@ class FakeMindSpeechBridge implements MindSpeechBridge {
   Stream<TranscriptEvent> startLiveSession({
     required String meetingId,
     String? language,
-  }) =>
-      Stream.fromIterable(transcriptEvents);
+  }) {
+    final error = liveStartError;
+    if (error != null) {
+      throw error;
+    }
+    return Stream.fromIterable(transcriptEvents);
+  }
 
   @override
   void pushLivePcm({required String sessionId, required List<int> samples}) {}

--- a/rust/airo_mind_audio/src/fanout.rs
+++ b/rust/airo_mind_audio/src/fanout.rs
@@ -1,0 +1,126 @@
+//! One capture stream → durable file + optional live consumer.
+//!
+//! Live processing is a bounded, drop-newest (when the channel is full)
+//! consumer of the same samples the file writer just accepted. Ingest never
+//! waits on inference. A dead live consumer does not stop the file.
+
+use std::path::{Path, PathBuf};
+use std::sync::mpsc::{self, Receiver, SyncSender, TrySendError};
+
+use crate::wav_write::IncrementalWavWriter;
+
+/// Outcome of one [`CaptureFanout::ingest`].
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct FanoutReport {
+    pub file_samples: u64,
+    pub live_accepted: bool,
+    pub live_dropped: bool,
+}
+
+/// Authoritative capture fan-out: file is durability, live is optional.
+pub struct CaptureFanout {
+    path: PathBuf,
+    wav: IncrementalWavWriter,
+    live: Option<SyncSender<Vec<i16>>>,
+}
+
+impl CaptureFanout {
+    /// Opens the WAV at [path]. Live consumer is attached with [`Self::with_live`].
+    pub fn create_file(path: impl AsRef<Path>) -> Result<Self, String> {
+        let path = path.as_ref().to_path_buf();
+        let wav = IncrementalWavWriter::create(&path)?;
+        Ok(Self {
+            path,
+            wav,
+            live: None,
+        })
+    }
+
+    /// Bounded live consumer. Capacity is in *chunks*, not samples — keep it
+    /// small so a stuck STT worker cannot retain unbounded PCM.
+    pub fn with_bounded_live(self, chunk_capacity: usize) -> (Self, Receiver<Vec<i16>>) {
+        let (tx, rx) = mpsc::sync_channel(chunk_capacity.max(1));
+        (self.with_live(tx), rx)
+    }
+
+    pub fn with_live(mut self, tx: SyncSender<Vec<i16>>) -> Self {
+        self.live = Some(tx);
+        self
+    }
+
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    /// Writes samples to the file first, then non-blocking-sends to live.
+    ///
+    /// A full or disconnected live channel is reported, never a `Err` — the
+    /// file is the recovery artifact.
+    pub fn ingest(&mut self, samples: &[i16]) -> Result<FanoutReport, String> {
+        self.wav.write_samples(samples)?;
+        let mut live_accepted = false;
+        let mut live_dropped = false;
+        if let Some(tx) = &self.live {
+            match tx.try_send(samples.to_vec()) {
+                Ok(()) => live_accepted = true,
+                Err(TrySendError::Full(_)) | Err(TrySendError::Disconnected(_)) => {
+                    live_dropped = true;
+                }
+            }
+        }
+        Ok(FanoutReport {
+            file_samples: self.wav.sample_count(),
+            live_accepted,
+            live_dropped,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::preprocess_path;
+
+    fn temp_wav(name: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!("airo-fanout-{}-{}", name, std::process::id()));
+        dir.join("capture.wav")
+    }
+
+    fn cleanup(path: &Path) {
+        if let Some(dir) = path.parent() {
+            let _ = std::fs::remove_dir_all(dir);
+        }
+    }
+
+    #[test]
+    fn ingest_writes_file_even_when_live_is_disconnected() {
+        let path = temp_wav("dead-live");
+        let (tx, rx) = mpsc::sync_channel(1);
+        drop(rx);
+        let mut fanout = CaptureFanout::create_file(&path).unwrap().with_live(tx);
+        let report = fanout.ingest(&[12_000; 320]).unwrap();
+        assert!(report.live_dropped);
+        assert_eq!(report.file_samples, 320);
+        drop(fanout);
+        let pcm = preprocess_path(&path).unwrap();
+        assert_eq!(pcm.samples.len(), 320);
+        cleanup(&path);
+    }
+
+    #[test]
+    fn full_live_channel_does_not_block_or_lose_the_file() {
+        let path = temp_wav("full-live");
+        let mut fanout = CaptureFanout::create_file(&path).unwrap();
+        let (fanout_with_live, _rx) = fanout.with_bounded_live(1);
+        fanout = fanout_with_live;
+        let first = fanout.ingest(&[1; 16]).unwrap();
+        assert!(first.live_accepted);
+        let second = fanout.ingest(&[2; 16]).unwrap();
+        assert!(second.live_dropped);
+        assert_eq!(second.file_samples, 32);
+        drop(fanout);
+        let pcm = preprocess_path(&path).unwrap();
+        assert_eq!(pcm.samples.len(), 32);
+        cleanup(&path);
+    }
+}

--- a/rust/airo_mind_audio/src/governor.rs
+++ b/rust/airo_mind_audio/src/governor.rs
@@ -1,0 +1,185 @@
+//! Runtime resource / thermal / battery governor for live intelligence.
+//!
+//! Recording is never refused by this governor. Live STT and deeper
+//! intelligence are.
+
+/// Thermal band derived from platform probes (Dart fills the snapshot).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ThermalBand {
+    Normal,
+    Warm,
+    Hot,
+    Critical,
+}
+
+/// Battery band. Thresholds match the production-qualification contract.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum BatteryBand {
+    Normal,
+    /// Below 20%.
+    Low,
+    /// Below 10%.
+    Critical,
+}
+
+/// What live intelligence is allowed to do under the current snapshot.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum IntelligencePolicy {
+    Full,
+    ReduceFrequency,
+    DisableDeep,
+    CaptureAndSttOnly,
+}
+
+/// Why live STT must not start. File recording is still allowed.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum LiveAdmission {
+    Allowed,
+    Rejected { needs_mb: u32, available_mb: u32 },
+}
+
+/// Point-in-time view. Total RAM is classification-only; admission uses
+/// available RAM plus a reserved headroom for the Flutter UI.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ResourceSnapshot {
+    pub total_ram_mb: u32,
+    pub available_ram_mb: u32,
+    pub stt_model_mb: u32,
+    /// Flutter / app reserve that must remain after the STT model loads.
+    pub app_headroom_mb: u32,
+    pub thermal: ThermalBand,
+    pub battery_percent: u8,
+}
+
+impl ResourceSnapshot {
+    pub fn unconstrained(stt_model_mb: u32) -> Self {
+        Self {
+            total_ram_mb: 16_384,
+            available_ram_mb: 8_192,
+            stt_model_mb,
+            app_headroom_mb: 512,
+            thermal: ThermalBand::Normal,
+            battery_percent: 80,
+        }
+    }
+
+    pub fn battery_band(&self) -> BatteryBand {
+        if self.battery_percent < 10 {
+            BatteryBand::Critical
+        } else if self.battery_percent < 20 {
+            BatteryBand::Low
+        } else {
+            BatteryBand::Normal
+        }
+    }
+}
+
+/// Stateless policy. Callers supply a fresh snapshot each decision.
+pub struct ResourceGovernor;
+
+impl ResourceGovernor {
+    /// Live STT is refused when available RAM cannot hold the model plus
+    /// application headroom. Total RAM is ignored on purpose.
+    pub fn admit_live_stt(snapshot: &ResourceSnapshot) -> LiveAdmission {
+        let needs = snapshot
+            .stt_model_mb
+            .saturating_add(snapshot.app_headroom_mb);
+        if snapshot.available_ram_mb < needs {
+            LiveAdmission::Rejected {
+                needs_mb: needs,
+                available_mb: snapshot.available_ram_mb,
+            }
+        } else {
+            LiveAdmission::Allowed
+        }
+    }
+
+    pub fn policy(snapshot: &ResourceSnapshot) -> IntelligencePolicy {
+        if snapshot.thermal == ThermalBand::Critical
+            || snapshot.battery_band() == BatteryBand::Critical
+        {
+            return IntelligencePolicy::CaptureAndSttOnly;
+        }
+        if snapshot.thermal == ThermalBand::Hot {
+            return IntelligencePolicy::DisableDeep;
+        }
+        if snapshot.thermal == ThermalBand::Warm || snapshot.battery_band() == BatteryBand::Low {
+            return IntelligencePolicy::ReduceFrequency;
+        }
+        IntelligencePolicy::Full
+    }
+
+    /// Intelligence may degrade; capture must not.
+    pub const fn recording_must_continue() -> bool {
+        true
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn live_stt_uses_available_ram_not_total() {
+        let mut snap = ResourceSnapshot::unconstrained(512);
+        snap.total_ram_mb = 16_384;
+        snap.available_ram_mb = 256;
+        snap.stt_model_mb = 512;
+        snap.app_headroom_mb = 512;
+        assert!(matches!(
+            ResourceGovernor::admit_live_stt(&snap),
+            LiveAdmission::Rejected { .. }
+        ));
+    }
+
+    #[test]
+    fn live_stt_allowed_when_headroom_fits() {
+        let snap = ResourceSnapshot::unconstrained(512);
+        assert_eq!(
+            ResourceGovernor::admit_live_stt(&snap),
+            LiveAdmission::Allowed
+        );
+    }
+
+    #[test]
+    fn thermal_and_battery_map_to_policy() {
+        let mut snap = ResourceSnapshot::unconstrained(512);
+        assert_eq!(ResourceGovernor::policy(&snap), IntelligencePolicy::Full);
+
+        snap.thermal = ThermalBand::Warm;
+        assert_eq!(
+            ResourceGovernor::policy(&snap),
+            IntelligencePolicy::ReduceFrequency
+        );
+
+        snap.thermal = ThermalBand::Hot;
+        assert_eq!(
+            ResourceGovernor::policy(&snap),
+            IntelligencePolicy::DisableDeep
+        );
+
+        snap.thermal = ThermalBand::Critical;
+        assert_eq!(
+            ResourceGovernor::policy(&snap),
+            IntelligencePolicy::CaptureAndSttOnly
+        );
+
+        snap.thermal = ThermalBand::Normal;
+        snap.battery_percent = 15;
+        assert_eq!(
+            ResourceGovernor::policy(&snap),
+            IntelligencePolicy::ReduceFrequency
+        );
+
+        snap.battery_percent = 5;
+        assert_eq!(
+            ResourceGovernor::policy(&snap),
+            IntelligencePolicy::CaptureAndSttOnly
+        );
+    }
+
+    #[test]
+    fn recording_survives_every_intelligence_policy() {
+        assert!(ResourceGovernor::recording_must_continue());
+    }
+}

--- a/rust/airo_mind_audio/src/lib.rs
+++ b/rust/airo_mind_audio/src/lib.rs
@@ -8,12 +8,15 @@
 #![deny(unsafe_code)]
 
 mod decode;
+mod fanout;
+mod governor;
 mod live;
 mod resample;
 mod ring;
 mod speaker_activity;
 mod stabilizer;
 mod vad;
+mod wav_write;
 
 pub use airo_mind_core::wav;
 pub use airo_mind_core::wav::Pcm;
@@ -21,11 +24,16 @@ pub use airo_mind_core::wav::Pcm;
 pub const TARGET_SAMPLE_RATE: u32 = 16_000;
 pub const TARGET_CHANNELS: u16 = 1;
 
+pub use fanout::{CaptureFanout, FanoutReport};
+pub use governor::{
+    BatteryBand, IntelligencePolicy, LiveAdmission, ResourceGovernor, ResourceSnapshot, ThermalBand,
+};
 pub use live::{LiveSpeechConfig, LiveSpeechPipeline, LiveStepReport};
 pub use ring::{PcmRingBuffer, RingPushReport};
 pub use speaker_activity::{SpeakerActivitySlice, SpeakerActivityTracker};
 pub use stabilizer::TranscriptStabilizer;
 pub use vad::{rms_energy, EnergyVad, VadState};
+pub use wav_write::IncrementalWavWriter;
 
 /// Read [path] and return whisper-ready PCM.
 pub fn preprocess_path(path: &std::path::Path) -> Result<Pcm, String> {

--- a/rust/airo_mind_audio/src/live.rs
+++ b/rust/airo_mind_audio/src/live.rs
@@ -42,6 +42,8 @@ pub struct LiveStepReport {
     pub vad_state: VadState,
     /// RMS energy of the inference window used this tick.
     pub window_energy: f32,
+    /// Live inference failed this tick; the caller must keep recording.
+    pub live_failed: bool,
 }
 
 /// Native-owned PCM path: ring → VAD → bounded window → engine → stabilizer.
@@ -108,10 +110,11 @@ impl LiveSpeechPipeline {
             dropped: 0,
         };
 
+        let mut live_failed = false;
         if vad_state == VadState::Speech && window.len() >= self.config.window_samples / 4 {
             let offset_ms = self.elapsed_samples.saturating_sub(window.len() as u64) * 1000
                 / TARGET_SAMPLE_RATE as u64;
-            transcribe(
+            match transcribe(
                 AudioInput {
                     samples: &window,
                     sample_rate_hz: TARGET_SAMPLE_RATE,
@@ -131,7 +134,11 @@ impl LiveSpeechPipeline {
                     }
                     Ok(())
                 },
-            )?;
+            ) {
+                Ok(()) => {}
+                Err(EngineError::Cancelled) => return Err(EngineError::Cancelled),
+                Err(_) => live_failed = true,
+            }
         }
 
         if vad_state == VadState::SpeechEnded {
@@ -145,6 +152,7 @@ impl LiveSpeechPipeline {
             degraded: self.ring.dropped_samples() > 0,
             vad_state,
             window_energy,
+            live_failed,
         })
     }
 
@@ -169,10 +177,11 @@ impl LiveSpeechPipeline {
             dropped: 0,
         };
 
+        let mut live_failed = false;
         if vad_state == VadState::Speech && window.len() >= self.config.window_samples / 4 {
             let offset_ms = self.elapsed_samples.saturating_sub(window.len() as u64) * 1000
                 / TARGET_SAMPLE_RATE as u64;
-            engine.transcribe(
+            match engine.transcribe(
                 AudioInput {
                     samples: &window,
                     sample_rate_hz: TARGET_SAMPLE_RATE,
@@ -192,7 +201,11 @@ impl LiveSpeechPipeline {
                     }
                     Ok(())
                 },
-            )?;
+            ) {
+                Ok(()) => {}
+                Err(EngineError::Cancelled) => return Err(EngineError::Cancelled),
+                Err(_) => live_failed = true,
+            }
         }
 
         if vad_state == VadState::SpeechEnded {
@@ -206,6 +219,7 @@ impl LiveSpeechPipeline {
             degraded: self.ring.dropped_samples() > 0,
             vad_state,
             window_energy,
+            live_failed,
         })
     }
 
@@ -333,5 +347,116 @@ mod tests {
             )
             .unwrap();
         assert!(report.degraded, "overflow should mark step degraded");
+        assert!(!report.live_failed);
+    }
+
+    struct FailingSpeech;
+
+    impl SpeechEngine for FailingSpeech {
+        fn resource_request(&self) -> ResourceRequest {
+            ResourceRequest::new(512)
+        }
+
+        fn transcribe(
+            &self,
+            _audio: AudioInput<'_>,
+            _options: &TranscriptionOptions,
+            _cancel: &CancelToken,
+            _sink: &mut dyn FnMut(TranscriptSegment) -> Result<(), EngineError>,
+        ) -> Result<(), EngineError> {
+            Err(EngineError::Backend("stt crashed".into()))
+        }
+    }
+
+    #[test]
+    fn inference_failure_marks_live_failed_and_does_not_abort_the_pipeline() {
+        let config = LiveSpeechConfig {
+            ring_capacity_samples: 16_000,
+            window_samples: 4_800,
+            vad_energy_threshold: 0.01,
+            vad_silence_ms: 300,
+        };
+        let mut pipe = LiveSpeechPipeline::new(config);
+        pipe.push_pcm(&loud_pcm(8_000));
+        let report = pipe
+            .step(
+                &FailingSpeech,
+                &TranscriptionOptions::default(),
+                &CancelToken::new(),
+                &mut |_| Ok(()),
+            )
+            .expect("live failure must not surface as a pipeline error");
+        assert!(report.live_failed);
+        pipe.push_pcm(&loud_pcm(8_000));
+        let again = pipe
+            .step(
+                &FailingSpeech,
+                &TranscriptionOptions::default(),
+                &CancelToken::new(),
+                &mut |_| Ok(()),
+            )
+            .unwrap();
+        assert!(again.live_failed);
+    }
+
+    #[test]
+    fn fake_engine_partial_and_stable_latencies_are_measurable() {
+        let config = LiveSpeechConfig {
+            ring_capacity_samples: 16_000,
+            window_samples: 4_800,
+            vad_energy_threshold: 0.01,
+            vad_silence_ms: 300,
+        };
+        let mut pipe = LiveSpeechPipeline::new(config);
+        let engine = WindowSpeech;
+        let cancel = CancelToken::new();
+        let mut events = Vec::new();
+
+        let t0 = std::time::Instant::now();
+        pipe.push_pcm(&loud_pcm(8_000));
+        pipe.step(
+            &engine,
+            &TranscriptionOptions::default(),
+            &cancel,
+            &mut |seg| {
+                events.push((seg, t0.elapsed()));
+                Ok(())
+            },
+        )
+        .unwrap();
+        let partial_latency = events
+            .iter()
+            .find(|(s, _)| s.state == TranscriptSegmentState::Partial)
+            .map(|(_, d)| *d)
+            .expect("partial");
+        assert!(
+            partial_latency.as_millis() < 500,
+            "in-process fake engine partial was {:?}",
+            partial_latency
+        );
+
+        pipe.push_pcm(&silent_pcm(8_000));
+        let t1 = std::time::Instant::now();
+        pipe.step(
+            &engine,
+            &TranscriptionOptions::default(),
+            &cancel,
+            &mut |seg| {
+                events.push((seg, t1.elapsed()));
+                Ok(())
+            },
+        )
+        .unwrap();
+        let stable_latency = events
+            .iter()
+            .rev()
+            .find(|(s, _)| s.state == TranscriptSegmentState::Stable)
+            .map(|(_, d)| *d)
+            .expect("stable");
+        assert!(
+            stable_latency.as_millis() < 1_000,
+            "in-process fake engine stable was {:?}",
+            stable_latency
+        );
     }
 }

--- a/rust/airo_mind_audio/src/wav_write.rs
+++ b/rust/airo_mind_audio/src/wav_write.rs
@@ -1,0 +1,146 @@
+//! Incremental 16 kHz mono PCM WAV writer.
+//!
+//! Header sizes are rewritten after every sample write so a process kill
+//! still leaves a file [`crate::preprocess_path`] can decode. `wav::decode`
+//! already accepts a truncated final chunk; stale *zero* sizes would look
+//! like silence, so this writer never leaves `data` size at 0 once audio
+//! has been accepted.
+
+use std::fs::{File, OpenOptions};
+use std::io::{Seek, SeekFrom, Write};
+use std::path::Path;
+
+use crate::TARGET_CHANNELS;
+use crate::TARGET_SAMPLE_RATE;
+
+/// Append-only 16-bit PCM WAVE file with crash-durable size fields.
+pub struct IncrementalWavWriter {
+    file: File,
+    data_bytes: u32,
+}
+
+impl IncrementalWavWriter {
+    /// Creates or truncates [path] and writes a valid empty WAVE header.
+    pub fn create(path: impl AsRef<Path>) -> Result<Self, String> {
+        let path = path.as_ref();
+        if let Some(dir) = path.parent() {
+            std::fs::create_dir_all(dir).map_err(|e| format!("creating {}: {e}", dir.display()))?;
+        }
+        let mut file = OpenOptions::new()
+            .create(true)
+            .write(true)
+            .truncate(true)
+            .open(path)
+            .map_err(|e| format!("opening {}: {e}", path.display()))?;
+        file.write_all(&wav_header(0))
+            .map_err(|e| format!("writing WAVE header: {e}"))?;
+        file.flush()
+            .map_err(|e| format!("flushing WAVE header: {e}"))?;
+        Ok(Self {
+            file,
+            data_bytes: 0,
+        })
+    }
+
+    /// Appends samples and updates RIFF/`data` sizes before returning.
+    pub fn write_samples(&mut self, samples: &[i16]) -> Result<(), String> {
+        if samples.is_empty() {
+            return Ok(());
+        }
+        for sample in samples {
+            self.file
+                .write_all(&sample.to_le_bytes())
+                .map_err(|e| format!("writing PCM: {e}"))?;
+        }
+        let added = (samples.len() * 2) as u32;
+        self.data_bytes = self.data_bytes.saturating_add(added);
+        self.sync_sizes()?;
+        self.file
+            .seek(SeekFrom::End(0))
+            .map_err(|e| format!("seeking WAVE end: {e}"))?;
+        Ok(())
+    }
+
+    pub fn data_bytes(&self) -> u32 {
+        self.data_bytes
+    }
+
+    pub fn sample_count(&self) -> u64 {
+        u64::from(self.data_bytes) / 2
+    }
+
+    fn sync_sizes(&mut self) -> Result<(), String> {
+        let riff_size = 36u32.saturating_add(self.data_bytes);
+        self.file
+            .seek(SeekFrom::Start(4))
+            .map_err(|e| format!("seeking RIFF size: {e}"))?;
+        self.file
+            .write_all(&riff_size.to_le_bytes())
+            .map_err(|e| format!("writing RIFF size: {e}"))?;
+        self.file
+            .seek(SeekFrom::Start(40))
+            .map_err(|e| format!("seeking data size: {e}"))?;
+        self.file
+            .write_all(&self.data_bytes.to_le_bytes())
+            .map_err(|e| format!("writing data size: {e}"))?;
+        self.file
+            .flush()
+            .map_err(|e| format!("flushing WAVE sizes: {e}"))?;
+        Ok(())
+    }
+}
+
+impl Drop for IncrementalWavWriter {
+    fn drop(&mut self) {
+        let _ = self.sync_sizes();
+    }
+}
+
+fn wav_header(data_bytes: u32) -> [u8; 44] {
+    let mut header = [0u8; 44];
+    header[0..4].copy_from_slice(b"RIFF");
+    header[4..8].copy_from_slice(&(36u32 + data_bytes).to_le_bytes());
+    header[8..12].copy_from_slice(b"WAVE");
+    header[12..16].copy_from_slice(b"fmt ");
+    header[16..20].copy_from_slice(&16u32.to_le_bytes());
+    header[20..22].copy_from_slice(&1u16.to_le_bytes());
+    header[22..24].copy_from_slice(&TARGET_CHANNELS.to_le_bytes());
+    header[24..28].copy_from_slice(&TARGET_SAMPLE_RATE.to_le_bytes());
+    let byte_rate = TARGET_SAMPLE_RATE * u32::from(TARGET_CHANNELS) * 2;
+    header[28..32].copy_from_slice(&byte_rate.to_le_bytes());
+    header[32..34].copy_from_slice(&(TARGET_CHANNELS * 2).to_le_bytes());
+    header[34..36].copy_from_slice(&16u16.to_le_bytes());
+    header[36..40].copy_from_slice(b"data");
+    header[40..44].copy_from_slice(&data_bytes.to_le_bytes());
+    header
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::preprocess_path;
+
+    #[test]
+    fn empty_file_is_a_valid_wav() {
+        let dir = std::env::temp_dir().join(format!("airo-wav-empty-{}", std::process::id()));
+        let path = dir.join("empty.wav");
+        let writer = IncrementalWavWriter::create(&path).unwrap();
+        drop(writer);
+        let pcm = preprocess_path(&path).unwrap();
+        assert!(pcm.samples.is_empty());
+        assert_eq!(pcm.sample_rate_hz, TARGET_SAMPLE_RATE);
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn samples_round_trip_through_preprocess() {
+        let dir = std::env::temp_dir().join(format!("airo-wav-rt-{}", std::process::id()));
+        let path = dir.join("speech.wav");
+        let mut writer = IncrementalWavWriter::create(&path).unwrap();
+        writer.write_samples(&[1, -2, 3, -4]).unwrap();
+        drop(writer);
+        let pcm = preprocess_path(&path).unwrap();
+        assert_eq!(pcm.samples, vec![1, -2, 3, -4]);
+        let _ = std::fs::remove_dir_all(dir);
+    }
+}

--- a/rust/airo_mind_audio/tests/fanout_crash_recovery.rs
+++ b/rust/airo_mind_audio/tests/fanout_crash_recovery.rs
@@ -1,0 +1,156 @@
+//! Mandatory fan-out isolation: live inference death must not kill the file.
+//!
+//! This is the LIVE_CAPTURE_FAN_OUT crash / failure-isolation conformance test.
+//! It does not open a microphone.
+
+use std::sync::mpsc;
+use std::thread;
+use std::time::{Duration, Instant};
+
+use airo_mind_audio::{
+    preprocess_path, CaptureFanout, LiveSpeechConfig, LiveSpeechPipeline, TARGET_SAMPLE_RATE,
+};
+use airo_mind_core::budget::ResourceRequest;
+use airo_mind_core::cancel::CancelToken;
+use airo_mind_core::engine::{
+    AudioInput, EngineError, SpeechEngine, TranscriptSegment, TranscriptionOptions,
+};
+
+struct FailingSpeech;
+
+impl SpeechEngine for FailingSpeech {
+    fn resource_request(&self) -> ResourceRequest {
+        ResourceRequest::new(512)
+    }
+
+    fn transcribe(
+        &self,
+        _audio: AudioInput<'_>,
+        _options: &TranscriptionOptions,
+        _cancel: &CancelToken,
+        _sink: &mut dyn FnMut(TranscriptSegment) -> Result<(), EngineError>,
+    ) -> Result<(), EngineError> {
+        Err(EngineError::Backend("forced live inference failure".into()))
+    }
+}
+
+struct OkSpeech;
+
+impl SpeechEngine for OkSpeech {
+    fn resource_request(&self) -> ResourceRequest {
+        ResourceRequest::new(512)
+    }
+
+    fn transcribe(
+        &self,
+        audio: AudioInput<'_>,
+        _options: &TranscriptionOptions,
+        _cancel: &CancelToken,
+        sink: &mut dyn FnMut(TranscriptSegment) -> Result<(), EngineError>,
+    ) -> Result<(), EngineError> {
+        if audio.samples.is_empty() {
+            return Ok(());
+        }
+        sink(TranscriptSegment::final_text(0, 100, "recovered".into()))?;
+        Ok(())
+    }
+}
+
+fn loud(n: usize) -> Vec<i16> {
+    vec![12_000; n]
+}
+
+fn temp_wav(tag: &str) -> std::path::PathBuf {
+    let dir = std::env::temp_dir().join(format!(
+        "airo-fanout-iso-{}-{}-{}",
+        tag,
+        std::process::id(),
+        Instant::now().elapsed().as_nanos()
+    ));
+    dir.join("session.wav")
+}
+
+fn cleanup(path: &std::path::Path) {
+    if let Some(dir) = path.parent() {
+        let _ = std::fs::remove_dir_all(dir);
+    }
+}
+
+#[test]
+fn live_inference_failure_does_not_corrupt_the_recording() {
+    let path = temp_wav("infer-fail");
+    let mut fanout = CaptureFanout::create_file(&path).unwrap();
+    let (fanout_live, rx) = fanout.with_bounded_live(8);
+    fanout = fanout_live;
+
+    let worker = thread::spawn(move || {
+        let mut pipeline = LiveSpeechPipeline::new(LiveSpeechConfig::default());
+        let engine = FailingSpeech;
+        let cancel = CancelToken::new();
+        while let Ok(chunk) = rx.recv_timeout(Duration::from_millis(200)) {
+            pipeline.push_pcm(&chunk);
+            let _ = pipeline.step(
+                &engine,
+                &TranscriptionOptions::default(),
+                &cancel,
+                &mut |_| Ok(()),
+            );
+        }
+    });
+
+    fanout
+        .ingest(&loud(TARGET_SAMPLE_RATE as usize / 2))
+        .unwrap();
+    fanout
+        .ingest(&loud(TARGET_SAMPLE_RATE as usize / 2))
+        .unwrap();
+    drop(fanout);
+    let _ = worker.join();
+
+    let pcm = preprocess_path(&path).expect("recorded file must remain valid");
+    assert!(
+        pcm.samples.len() >= TARGET_SAMPLE_RATE as usize,
+        "expected a full second of PCM, got {}",
+        pcm.samples.len()
+    );
+
+    let engine = OkSpeech;
+    let mut text = String::new();
+    engine
+        .transcribe(
+            AudioInput {
+                samples: &pcm.samples,
+                sample_rate_hz: pcm.sample_rate_hz,
+                channels: pcm.channels,
+            },
+            &TranscriptionOptions::default(),
+            &CancelToken::new(),
+            &mut |seg| {
+                text.push_str(&seg.text);
+                Ok(())
+            },
+        )
+        .unwrap();
+    assert_eq!(text, "recovered");
+    cleanup(&path);
+}
+
+#[test]
+fn dropping_the_live_consumer_mid_session_leaves_a_transcribable_file() {
+    let path = temp_wav("crash-live");
+    let (tx, rx) = mpsc::sync_channel(4);
+    let mut fanout = CaptureFanout::create_file(&path).unwrap().with_live(tx);
+
+    fanout.ingest(&loud(800)).unwrap();
+    drop(rx);
+
+    let report = fanout
+        .ingest(&loud(800))
+        .expect("file ingest must survive a dead live consumer");
+    assert!(report.live_dropped);
+    drop(fanout);
+
+    let pcm = preprocess_path(&path).expect("crash-durable WAV");
+    assert_eq!(pcm.samples.len(), 1_600);
+    cleanup(&path);
+}

--- a/rust/airo_mind_core/src/supervisor.rs
+++ b/rust/airo_mind_core/src/supervisor.rs
@@ -589,6 +589,23 @@ mod tests {
     }
 
     #[test]
+    fn check_speech_admission_refuses_an_over_budget_engine() {
+        let s = supervisor(512, 4096);
+        assert_eq!(
+            s.check_speech_admission(),
+            Err(RuntimeError::OverBudget {
+                needs_mb: 4096,
+                budget_mb: 512
+            })
+        );
+    }
+
+    #[test]
+    fn check_speech_admission_allows_an_in_budget_engine() {
+        assert!(supervisor(2048, 512).check_speech_admission().is_ok());
+    }
+
+    #[test]
     fn an_unregistered_engine_is_a_refusal_not_a_panic() {
         let samples = audio();
         let s = Supervisor::new(ResourceBudget::new(2048));

--- a/rust/airo_mind_meeting/src/lib.rs
+++ b/rust/airo_mind_meeting/src/lib.rs
@@ -48,6 +48,7 @@ pub mod dedup;
 pub mod diagnostics;
 mod fact;
 pub mod ir;
+pub mod live_ir;
 pub mod mom;
 mod mom_prompt;
 pub mod pass1;
@@ -67,6 +68,7 @@ pub use ir::{
     ActionItem, ActionStatus, ChunkIr, Decision, DecisionStatus, Facts, Meeting, MeetingIr, Metric,
     NextStep, Observation, Question, Risk, Topic, IR_SCHEMA_VERSION,
 };
+pub use live_ir::{ConversationIrEvent, IncrementalConversationIr, LiveEntityKind};
 pub use mom::{
     generate_mom, render_action_items_table, render_decisions_table, render_next_steps, MomError,
 };

--- a/rust/airo_mind_meeting/src/live_ir.rs
+++ b/rust/airo_mind_meeting/src/live_ir.rs
@@ -1,0 +1,275 @@
+//! Incremental Conversation IR — event-driven, no live LLM.
+//!
+//! Stable sentences are the boundary. Deep summary stays post-recording
+//! (`pass1` / `pass2`). This module extracts high-confidence surface facts
+//! that the live UI may show; speculative claims are not emitted.
+
+use serde::{Deserialize, Serialize};
+
+/// Kind of a named entity spotted on a stable sentence.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum LiveEntityKind {
+    Person,
+    Date,
+    Project,
+}
+
+/// One incremental IR event. Evidence is a segment id, never a raw snippet
+/// copy of `secret`-class audio (ADR-0022).
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum ConversationIrEvent {
+    Segment {
+        segment_id: String,
+        speaker_id: Option<String>,
+        text: String,
+        start_ms: u64,
+        end_ms: u64,
+    },
+    Entity {
+        kind: LiveEntityKind,
+        text: String,
+        evidence: String,
+        confidence: f32,
+    },
+    Action {
+        text: String,
+        evidence: String,
+        confidence: f32,
+    },
+    Decision {
+        text: String,
+        evidence: String,
+        confidence: f32,
+    },
+    Question {
+        text: String,
+        evidence: String,
+    },
+    Topic {
+        title: String,
+        evidence: String,
+    },
+}
+
+/// Rolling Conversation IR built from stable sentences only.
+#[derive(Clone, Debug, Default)]
+pub struct IncrementalConversationIr {
+    events: Vec<ConversationIrEvent>,
+}
+
+impl IncrementalConversationIr {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn events(&self) -> &[ConversationIrEvent] {
+        &self.events
+    }
+
+    /// Process one stabilizer-committed sentence. Never runs an LLM.
+    pub fn on_stable_sentence(
+        &mut self,
+        segment_id: impl Into<String>,
+        speaker_id: Option<String>,
+        text: &str,
+        start_ms: u64,
+        end_ms: u64,
+    ) -> Vec<ConversationIrEvent> {
+        let segment_id = segment_id.into();
+        let trimmed = text.trim();
+        if trimmed.is_empty() {
+            return Vec::new();
+        }
+
+        let mut produced = Vec::new();
+        produced.push(ConversationIrEvent::Segment {
+            segment_id: segment_id.clone(),
+            speaker_id,
+            text: trimmed.to_string(),
+            start_ms,
+            end_ms,
+        });
+
+        if trimmed.ends_with('?') {
+            produced.push(ConversationIrEvent::Question {
+                text: trimmed.to_string(),
+                evidence: segment_id.clone(),
+            });
+        }
+
+        if looks_like_decision(trimmed) {
+            produced.push(ConversationIrEvent::Decision {
+                text: trimmed.to_string(),
+                evidence: segment_id.clone(),
+                confidence: 0.86,
+            });
+        }
+
+        if looks_like_action(trimmed) {
+            produced.push(ConversationIrEvent::Action {
+                text: trimmed.to_string(),
+                evidence: segment_id.clone(),
+                confidence: 0.84,
+            });
+        }
+
+        if let Some(date) = extract_date(trimmed) {
+            produced.push(ConversationIrEvent::Entity {
+                kind: LiveEntityKind::Date,
+                text: date,
+                evidence: segment_id.clone(),
+                confidence: 0.9,
+            });
+        }
+
+        if let Some(person) = extract_person(trimmed) {
+            produced.push(ConversationIrEvent::Entity {
+                kind: LiveEntityKind::Person,
+                text: person,
+                evidence: segment_id.clone(),
+                confidence: 0.8,
+            });
+        }
+
+        if let Some(topic) = extract_topic(trimmed) {
+            produced.push(ConversationIrEvent::Topic {
+                title: topic,
+                evidence: segment_id,
+            });
+        }
+
+        self.events.extend(produced.iter().cloned());
+        produced
+    }
+}
+
+fn looks_like_decision(text: &str) -> bool {
+    let lower = text.to_ascii_lowercase();
+    lower.contains("we decided")
+        || lower.contains("we agreed")
+        || lower.contains("decision is")
+        || lower.contains("let's go with")
+        || lower.contains("lets go with")
+}
+
+fn looks_like_action(text: &str) -> bool {
+    let lower = text.to_ascii_lowercase();
+    lower.contains("will ")
+        || lower.contains("please ")
+        || lower.contains("need to ")
+        || lower.contains("i'll ")
+        || lower.contains("i will ")
+        || lower.starts_with("action:")
+}
+
+fn extract_date(text: &str) -> Option<String> {
+    const DAYS: [&str; 7] = [
+        "monday",
+        "tuesday",
+        "wednesday",
+        "thursday",
+        "friday",
+        "saturday",
+        "sunday",
+    ];
+    let lower = text.to_ascii_lowercase();
+    for day in DAYS {
+        if lower.contains(day) {
+            return Some(day[..1].to_uppercase() + &day[1..]);
+        }
+    }
+    None
+}
+
+fn extract_person(text: &str) -> Option<String> {
+    // High-confidence only: "X will" / "X, please" with a capitalized token.
+    let words: Vec<&str> = text.split_whitespace().collect();
+    for window in words.windows(2) {
+        let name = window[0].trim_matches(|c: char| !c.is_ascii_alphabetic());
+        let next = window[1].to_ascii_lowercase();
+        if name.len() > 1
+            && name.chars().next().is_some_and(|c| c.is_uppercase())
+            && (next.starts_with("will") || next.starts_with("please"))
+        {
+            return Some(name.to_string());
+        }
+    }
+    None
+}
+
+fn extract_topic(text: &str) -> Option<String> {
+    let lower = text.to_ascii_lowercase();
+    if lower.contains("migrat") {
+        return Some("Migration".into());
+    }
+    if lower.contains("database") {
+        return Some("Database".into());
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn stable_sentence_emits_segment_and_high_confidence_facts() {
+        let mut ir = IncrementalConversationIr::new();
+        let events = ir.on_stable_sentence(
+            "s0",
+            Some("sp0".into()),
+            "Uday will own database changes by Friday. We decided the migration deadline is Friday.",
+            0,
+            4_000,
+        );
+        assert!(events.iter().any(
+            |e| matches!(e, ConversationIrEvent::Segment { segment_id, .. } if segment_id == "s0")
+        ));
+        assert!(events
+            .iter()
+            .any(|e| matches!(e, ConversationIrEvent::Action { .. })));
+        assert!(events
+            .iter()
+            .any(|e| matches!(e, ConversationIrEvent::Decision { .. })));
+        assert!(events.iter().any(|e| matches!(
+            e,
+            ConversationIrEvent::Entity {
+                kind: LiveEntityKind::Date,
+                ..
+            }
+        )));
+        assert!(events.iter().any(|e| matches!(
+            e,
+            ConversationIrEvent::Entity {
+                kind: LiveEntityKind::Person,
+                text,
+                ..
+            } if text == "Uday"
+        )));
+        assert!(events.iter().any(|e| matches!(e, ConversationIrEvent::Topic { title, .. } if title == "Migration" || title == "Database")));
+    }
+
+    #[test]
+    fn questions_are_detected_without_an_llm() {
+        let mut ir = IncrementalConversationIr::new();
+        let events = ir.on_stable_sentence("s1", None, "Can we ship on Thursday?", 10, 20);
+        assert!(events
+            .iter()
+            .any(|e| matches!(e, ConversationIrEvent::Question { .. })));
+        assert!(events.iter().any(|e| matches!(
+            e,
+            ConversationIrEvent::Entity {
+                kind: LiveEntityKind::Date,
+                ..
+            }
+        )));
+    }
+
+    #[test]
+    fn empty_text_emits_nothing() {
+        let mut ir = IncrementalConversationIr::new();
+        assert!(ir.on_stable_sentence("s2", None, "   ", 0, 1).is_empty());
+    }
+}

--- a/rust/airo_mind_whisper/src/api/meetings.rs
+++ b/rust/airo_mind_whisper/src/api/meetings.rs
@@ -34,7 +34,9 @@
 
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
+use std::sync::mpsc::{self, Receiver, SyncSender};
 use std::sync::{LazyLock, Mutex};
+use std::thread::JoinHandle;
 
 use flutter_rust_bridge::frb;
 
@@ -45,7 +47,9 @@ use crate::frb_generated::StreamSink;
 
 use crate::transcript_store;
 use crate::WhisperSpeechEngine;
-use airo_mind_audio::{rms_energy, LiveSpeechConfig, LiveSpeechPipeline, SpeakerActivityTracker};
+use airo_mind_audio::{
+    rms_energy, CaptureFanout, LiveSpeechConfig, LiveSpeechPipeline, SpeakerActivityTracker,
+};
 use airo_mind_core::engine::TranscriptSegmentState;
 use airo_mind_core::models;
 use airo_mind_core::wav::Pcm;
@@ -479,6 +483,11 @@ static LIBRARY: Mutex<Option<Library>> = Mutex::new(None);
 /// diarization strategy (ECAPA optional weights).
 static MODELS_DIR: Mutex<Option<PathBuf>> = Mutex::new(None);
 
+/// Parent of `MindConfig.store_path` — live fan-out WAVs live in
+/// `{parent}/mind_recordings/{meeting_id}.wav`, matching Dart's app-support
+/// layout (`mind_service` store + `nextMeetingRecordingPath`).
+static STORE_PARENT_DIR: Mutex<Option<PathBuf>> = Mutex::new(None);
+
 static SPEECH_MEMORY_BUDGET_MB: Mutex<Option<u32>> = Mutex::new(None);
 
 static INITIALIZED_SPEECH_LANGUAGE: Mutex<Option<SpeechLanguage>> = Mutex::new(None);
@@ -504,9 +513,15 @@ struct LiveSessionState {
     /// Provisional live speaker lanes (`P1`); reconciled after recording.
     speaker_activity: SpeakerActivityTracker,
     last_window_energy: f32,
+    /// Authoritative file writer. Live STT consumes a bounded channel, not this handle.
+    fanout: Option<CaptureFanout>,
+    live_tx: Option<SyncSender<Vec<i16>>>,
 }
 
 static LIVE_SESSIONS: LazyLock<Mutex<HashMap<String, LiveSessionState>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
+
+static LIVE_WORKERS: LazyLock<Mutex<HashMap<String, JoinHandle<()>>>> =
     LazyLock::new(|| Mutex::new(HashMap::new()));
 
 static LIVE_VOCABULARY: LazyLock<VocabularyIntelligence> =
@@ -595,6 +610,77 @@ fn maybe_emit_live_degraded(session: &mut LiveSessionState, message: &str) -> Re
         .map_err(|e| e.to_string())
 }
 
+fn sanitize_meeting_id(meeting_id: &str) -> String {
+    let safe: String = meeting_id
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '-' || c == '_' || c == '.' {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect();
+    if safe.is_empty() {
+        "meeting".into()
+    } else {
+        safe
+    }
+}
+
+fn live_fanout_path(meeting_id: &str) -> Option<PathBuf> {
+    let parent = lock(&STORE_PARENT_DIR).clone()?;
+    Some(
+        parent
+            .join("mind_recordings")
+            .join(format!("{}.wav", sanitize_meeting_id(meeting_id))),
+    )
+}
+
+fn spawn_live_worker(session_id: String, rx: Receiver<Vec<i16>>) {
+    let worker_id = session_id.clone();
+    let spawned = std::thread::Builder::new()
+        .name(format!("airo-live-{session_id}"))
+        .spawn(move || loop {
+            let chunk = match rx.recv() {
+                Ok(samples) => samples,
+                Err(_) => break,
+            };
+            let panicked = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                {
+                    let mut sessions = lock(&LIVE_SESSIONS);
+                    let Some(session) = sessions.get_mut(&worker_id) else {
+                        return;
+                    };
+                    if session.paused {
+                        return;
+                    }
+                    session.pipeline.push_pcm(&chunk);
+                    session.last_window_energy = rms_energy(&chunk);
+                }
+                let _ = run_live_pipeline_step(&worker_id);
+            }));
+            if panicked.is_err() {
+                let mut sessions = lock(&LIVE_SESSIONS);
+                if let Some(session) = sessions.get_mut(&worker_id) {
+                    let _ = maybe_emit_live_degraded(
+                        session,
+                        "Live intelligence degraded — native worker recovered. Recording continues.",
+                    );
+                }
+            }
+        });
+    if let Ok(handle) = spawned {
+        lock(&LIVE_WORKERS).insert(session_id, handle);
+    }
+}
+
+fn stop_live_worker(session_id: &str) {
+    if let Some(handle) = lock(&LIVE_WORKERS).remove(session_id) {
+        let _ = handle.join();
+    }
+}
+
 // ---------------------------------------------------------------------------
 // The capability surface
 // ---------------------------------------------------------------------------
@@ -617,6 +703,10 @@ pub fn initialize(config: MindConfig) -> Result<(), String> {
     *lock(&SPEECH_MEMORY_BUDGET_MB) = Some(config.memory_budget_mb);
     *lock(&INITIALIZED_SPEECH_LANGUAGE) = Some(config.speech_language);
     *lock(&LIBRARY) = Some(Library { store, index });
+    *lock(&STORE_PARENT_DIR) = PathBuf::from(&config.store_path)
+        .parent()
+        .map(|p| p.to_path_buf())
+        .or_else(|| Some(PathBuf::from(".")));
 
     ensure_speech_engine_for_requirement(models::speech_file_requirement(
         config.memory_budget_mb,
@@ -932,6 +1022,12 @@ fn run_live_pipeline_step(session_id: &str) -> Result<(), String> {
             "Live transcript quality reduced — audio ring overflow.",
         )?;
     }
+    if report.live_failed {
+        maybe_emit_live_degraded(
+            session,
+            "Live intelligence degraded — inference failed. Recording continues.",
+        )?;
+    }
     session.last_window_energy = report.window_energy;
 
     for segment in produced {
@@ -962,6 +1058,11 @@ pub fn start_live_session(
     let cancel = CancelToken::new();
     *lock(&CANCEL) = Some(cancel.clone());
 
+    let (tx, rx) = mpsc::sync_channel::<Vec<i16>>(8);
+    spawn_live_worker(session_id.clone(), rx);
+    let fanout =
+        live_fanout_path(&meeting_id).and_then(|path| CaptureFanout::create_file(path).ok());
+
     let session = LiveSessionState {
         meeting_id,
         pipeline: LiveSpeechPipeline::new(LiveSpeechConfig::default()),
@@ -975,9 +1076,11 @@ pub fn start_live_session(
         degraded_notified: false,
         speaker_activity: SpeakerActivityTracker::new(1200),
         last_window_energy: 0.0,
+        fanout,
+        live_tx: Some(tx),
     };
 
-    lock(&LIVE_SESSIONS).insert(session_id.clone(), session);
+    lock(&LIVE_SESSIONS).insert(session_id, session);
     Ok(())
 }
 
@@ -992,17 +1095,26 @@ pub fn push_live_pcm(session_id: String, samples: Vec<i16>) -> Result<(), String
     if session.paused {
         return Ok(());
     }
-    let push_report = session.pipeline.push_pcm(&samples);
+    if let Some(fanout) = session.fanout.as_mut() {
+        if let Err(error) = fanout.ingest(&samples) {
+            maybe_emit_live_degraded(
+                session,
+                &format!("Live transcript quality reduced — recording write failed ({error})."),
+            )?;
+        }
+    }
     session.last_window_energy = rms_energy(&samples);
-    if push_report.dropped > 0 {
+    let live_busy = session
+        .live_tx
+        .as_ref()
+        .map(|tx| tx.try_send(samples).is_err())
+        .unwrap_or(true);
+    if live_busy {
         maybe_emit_live_degraded(
             session,
-            "Live transcript quality reduced — audio ring overflow.",
+            "Live transcript quality reduced — live worker backpressure.",
         )?;
     }
-    let session_id = session_id.clone();
-    drop(sessions);
-    run_live_pipeline_step(&session_id)?;
     Ok(())
 }
 
@@ -1035,6 +1147,9 @@ pub fn stop_live_session(session_id: String, audio_path: Option<String>) -> Resu
     let mut session = lock(&LIVE_SESSIONS)
         .remove(&session_id)
         .ok_or_else(|| format!("unknown live session {session_id}"))?;
+    session.live_tx = None;
+    session.fanout = None;
+    stop_live_worker(&session_id);
 
     let mut finals = Vec::new();
     session
@@ -1092,9 +1207,12 @@ pub fn stop_live_session(session_id: String, audio_path: Option<String>) -> Resu
 /// Aborts a live session without persisting transcript output.
 #[frb(sync)]
 pub fn cancel_live_session(session_id: String) -> Result<(), String> {
-    let session = lock(&LIVE_SESSIONS)
+    let mut session = lock(&LIVE_SESSIONS)
         .remove(&session_id)
         .ok_or_else(|| format!("unknown live session {session_id}"))?;
+    session.live_tx = None;
+    session.fanout = None;
+    stop_live_worker(&session_id);
     session.cancel.cancel();
     session
         .sink


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Closes the **LIVE_CAPTURE_FAN_OUT** host conformance that blocked an honest “production live” conversation, without claiming production qualification.

- **One ingest, two consumers:** `CaptureFanout` writes a crash-durable 16 kHz WAV first, then non-blocking-sends PCM to a bounded live worker. Live STT never blocks or corrupts the file.
- **Failure isolation:** STT backend errors and a dead live consumer mark live intelligence **degraded** and keep recording. Host test: `rust/airo_mind_audio/tests/fanout_crash_recovery.rs`.
- **Desktop one-mic:** live sessions use `FanoutBackedAudioRecorderPort` so `package:record` is not opened as a second encoder. PCM still crosses FRB via `push_live_pcm` (ZC-1 remaining).
- **Admission:** over-budget live STT is refused (`check_speech_admission`); the capture screen warns and continues file recording.
- **Incremental Conversation IR:** rule-based stable-sentence extractor in `airo_mind_meeting` (no live LLM, not on the FRB/UI surface yet).
- **Resource/thermal governor:** pure policy types + tests. OS probes are not wired.

**Verdict: NOT PRODUCTION QUALIFIED.** Desktop live remains **Preview**. Default remains After recording everywhere.

Docs: `docs/features/airo-mind/production-qualification.md`, `real-time-architecture.md`, `platform-capability-matrix.md`.

Do not reopen Sonar badge/README work (#1892).

## Test Plan

- [x] `cargo test` for `airo_mind_audio` (fan-out, crash isolation, latency harness, governor)
- [x] `cargo test -p airo_mind_core check_speech_admission`
- [x] `cargo test -p airo_mind_meeting --lib live_ir`
- [ ] `cd packages/feature_mind && dart format && dart analyze && flutter test test/capture` — **not run here** (no Flutter SDK in this environment)
- [ ] Manual device verification documented, or not applicable

**Verification environment:** Host-only (Rust unit/integration). Flutter package tests need a local Flutter SDK.

## Agent Policy

- [x] Spec is the production-qualification closure pack (fan-out / crash / latency first). Feature packet already exists in `LIVE_CAPTURE_FAN_OUT.md` + ADR-0025.
- [x] Cross-agent contract: native owns PCM/file/live worker; Flutter owns consent, lifecycle UI, and the remaining FRB ingest shim.
- [ ] Linked GitHub issue Critical Agent Gate — this PR implements the delegated B package from the live-scribe thread close.

## Council Review

- Rust Architect (owns `airo_mind_audio` / live session)
- Platform Architect (capture fan-out, desktop recorder seam)
- Chief Performance Officer (required on every Rust change)
- Chief Security Officer (mic entry; still behind consent gate; PCM still `secret`-class)
- Chief QA Officer (user-visible capture warning / degraded copy)
- Chief Documentation Officer (qualification docs)

- [x] I checked the Decision Matrix and listed every required role above.
- [x] Every package touched has a `module.yaml`.
- [x] `owner`/`reviewers` in touched `module.yaml` unchanged.

## User-Facing Documentation

- [x] Product qualification docs updated under `docs/features/airo-mind/` (Preview, not Production).
- [x] No `docs/wiki` update: live remains desktop Preview; no new user-facing production claim.

## Plugin and Size Impact

- [ ] This PR adds new dependencies
- [x] This PR adds or grows app/packages/plugins code
- [x] Size impact is documented below

Size impact / plugin justification: small Rust modules (`fanout`, `wav_write`, `governor`, `live_ir`) and a Dart recorder port. No new crates.io dependencies.

## Checklist

- [x] Rust formatted (`rustfmt`).
- [x] Tests included for fan-out isolation, admission, governor, IR.
- [x] Sensitive data, credentials, and signing artifacts are not committed.

## Release Notes

- [x] Not user-facing as Production. Desktop Preview live scribe now records through native fan-out; After recording remains the default.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-deeea9f1-edbc-404e-a72e-66fa255a9ceb?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-deeea9f1-edbc-404e-a72e-66fa255a9ceb&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

