### PR TITLE
test(mind): reset platform override before Flutter leak check

### DIFF
--- a/packages/feature_mind/test/capture/presentation/meeting_capture_screen_test.dart
+++ b/packages/feature_mind/test/capture/presentation/meeting_capture_screen_test.dart
@@ -282,62 +282,66 @@ void main() {
       SharedPreferences.setMockInitialValues({
         transcriptionModeKey: TranscriptionMode.live.storageValue,
       });
+      // Reset before the callback returns — Flutter asserts foundation debug
+      // vars before package:test tearDowns run.
       debugDefaultTargetPlatformOverride = TargetPlatform.linux;
-      addTearDown(() => debugDefaultTargetPlatformOverride = null);
-
-      final tempDir = Directory.systemTemp.createTempSync(
-        'meeting_capture_live_',
-      );
-      addTearDown(() {
-        if (tempDir.existsSync()) tempDir.deleteSync(recursive: true);
-      });
-      PathProviderPlatform.instance = _FakePathProvider(tempDir.path);
-      final recorder = FakeAudioRecorderPort();
-      await tester.binding.setSurfaceSize(const Size(400, 1400));
-      addTearDown(() => tester.binding.setSurfaceSize(null));
-      await tester.pumpWidget(
-        ProviderScope(
-          overrides: [
-            mindRuntimeProvider.overrideWith(
-              (ref) => ScribeMindRuntime(log: _MemoryLog()),
-            ),
-            recordingConsentPromptProvider.overrideWithValue(false),
-            audioRecorderPortProvider.overrideWith(
-              (ref) =>
-                  () => recorder,
-            ),
-            meetingRecordingPathProvider.overrideWith(
-              (ref) =>
-                  () async => '${tempDir.path}/meeting.m4a',
-            ),
-            meetingRecordingServiceGatewayProvider.overrideWith(
-              (ref) => const NoopMeetingRecordingServiceGateway(),
-            ),
-            meetingLiveSessionCoordinatorFactoryProvider.overrideWithValue(
-              () => MeetingLiveSessionCoordinator(
-                speechBridge: FakeMindSpeechBridge()
-                  ..liveStartError = StateError('OverBudget'),
-                pcmShim: FakeLivePcmShim(),
+      try {
+        final tempDir = Directory.systemTemp.createTempSync(
+          'meeting_capture_live_',
+        );
+        addTearDown(() {
+          if (tempDir.existsSync()) tempDir.deleteSync(recursive: true);
+        });
+        PathProviderPlatform.instance = _FakePathProvider(tempDir.path);
+        final recorder = FakeAudioRecorderPort();
+        await tester.binding.setSurfaceSize(const Size(400, 1400));
+        addTearDown(() => tester.binding.setSurfaceSize(null));
+        await tester.pumpWidget(
+          ProviderScope(
+            overrides: [
+              mindRuntimeProvider.overrideWith(
+                (ref) => ScribeMindRuntime(log: _MemoryLog()),
               ),
-            ),
-          ],
-          child: const MaterialApp(home: MeetingCaptureScreen()),
-        ),
-      );
-      await tester.pumpAndSettle();
+              recordingConsentPromptProvider.overrideWithValue(false),
+              audioRecorderPortProvider.overrideWith(
+                (ref) =>
+                    () => recorder,
+              ),
+              meetingRecordingPathProvider.overrideWith(
+                (ref) =>
+                    () async => '${tempDir.path}/meeting.m4a',
+              ),
+              meetingRecordingServiceGatewayProvider.overrideWith(
+                (ref) => const NoopMeetingRecordingServiceGateway(),
+              ),
+              meetingLiveSessionCoordinatorFactoryProvider.overrideWithValue(
+                () => MeetingLiveSessionCoordinator(
+                  speechBridge: FakeMindSpeechBridge()
+                    ..liveStartError = StateError('OverBudget'),
+                  pcmShim: FakeLivePcmShim(),
+                ),
+              ),
+            ],
+            child: const MaterialApp(home: MeetingCaptureScreen()),
+          ),
+        );
+        await tester.pumpAndSettle();
 
-      await tester.tap(find.byKey(const Key('meeting_capture_start_button')));
-      await tester.pump();
-      await tester.pump(const Duration(milliseconds: 50));
+        await tester.tap(find.byKey(const Key('meeting_capture_start_button')));
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 50));
 
-      expect(
-        find.byKey(const Key('meeting_capture_live_warning')),
-        findsOneWidget,
-      );
-      expect(
-        recorder.calls.where((call) => call.startsWith('start:')),
-        isNotEmpty,
-      );
+        expect(
+          find.byKey(const Key('meeting_capture_live_warning')),
+          findsOneWidget,
+        );
+        expect(
+          recorder.calls.where((call) => call.startsWith('start:')),
+          isNotEmpty,
+        );
+      } finally {
+        debugDefaultTargetPlatformOverride = null;
+      }
     },
   );
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

#1895 merged with one red widget test: `live admission failure warns and still starts file recording`.

The test set `debugDefaultTargetPlatformOverride = TargetPlatform.linux` and restored it in `addTearDown`. Flutter 3.44 asserts foundation debug vars **before** package:test tearDowns, so the leak checker failed even when the assertions passed.

This PR resets the override in a `try/finally` inside the `testWidgets` callback — the same pattern as `mind_command_palette_scope_test.dart` `onPlatform()`.

No product behavior change. Desktop live remains **Preview** / **NOT PRODUCTION QUALIFIED**.

## Test Plan

- [x] Narrow contract: reset `debugDefaultTargetPlatformOverride` before the widget-test callback returns
- [ ] `flutter test packages/feature_mind/test/capture/presentation/meeting_capture_screen_test.dart` — no Flutter SDK in this cloud agent; CI `test-core` / `PR Checks / tests` is the proof
- [x] Manual device verification not applicable (test-only)

**Verification environment:** Host-only (CI)

## Agent Policy

- Follow-up to merged #1895 (known CI failure). Test-only; no Feature Packet.
- No framework/application contract change.

## Council Review

- Chief QA Officer: test-lifecycle fix only
- [x] I checked the Decision Matrix — test-only, no module.yaml roster change
- [x] Touched package already has `module.yaml`

## User-Facing Documentation

- [x] No `docs/wiki` update is needed because this PR has no user-visible behavior or documentation impact.

## Plugin and Size Impact

- No new dependencies, no size impact

## Checklist

- [x] Sensitive data, credentials, and signing artifacts are not committed
- [x] Tests included above

## Release Notes

- [x] Not applicable (test-only)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-deeea9f1-edbc-404e-a72e-66fa255a9ceb?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-deeea9f1-edbc-404e-a72e-66fa255a9ceb&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

