### PR TITLE
addon_invocation_cancelled error code + expanded trace sink coverage

### DIFF
--- a/packages/core_ai/lib/core_ai.dart
+++ b/packages/core_ai/lib/core_ai.dart
@@ -101,6 +101,7 @@ export 'src/skills/skill_trigger_eval.dart';
 
 // Add-on framework (manifest validation, registry, adapter contracts)
 export 'src/addons/addon_manifest_validator.dart';
+export 'src/addons/addon_invocation_epoch.dart';
 export 'src/addons/addon_registry.dart';
 export 'src/addons/addon_eligibility.dart';
 export 'src/addons/addon_conversation.dart';

--- a/packages/core_ai/lib/src/addons/addon_invocation_epoch.dart
+++ b/packages/core_ai/lib/src/addons/addon_invocation_epoch.dart
@@ -1,0 +1,19 @@
+import 'package:meta/meta.dart';
+
+/// Monotonic epoch bumped when add-on invocation eligibility is revoked mid-flight.
+class AddonInvocationEpoch {
+  AddonInvocationEpoch._();
+
+  static const cancelledCode = 'addon_invocation_cancelled';
+
+  static final AddonInvocationEpoch instance = AddonInvocationEpoch._();
+
+  int _epoch = 0;
+
+  int get current => _epoch;
+
+  void bump() => _epoch++;
+
+  @visibleForTesting
+  void resetForTesting() => _epoch = 0;
+}

--- a/packages/core_ai/lib/src/addons/addon_registry.dart
+++ b/packages/core_ai/lib/src/addons/addon_registry.dart
@@ -1,6 +1,7 @@
 import 'package:core_domain/core_domain.dart';
 
 import 'addon_eligibility.dart';
+import 'addon_invocation_epoch.dart';
 import 'addon_manifest_validator.dart';
 import 'generative_addon_adapter.dart';
 import 'graph_workflow_addon_adapter.dart';
@@ -23,11 +24,10 @@ class AddonRegistry implements AddonRegistryPort {
   final Map<String, GenerativeAddonAdapter> _generativeAdapters = {};
   final Map<String, GraphWorkflowAddonAdapter> _graphAdapters = {};
   final Map<String, AddonEligibility> _eligibility = {};
-  int _invocationEpoch = 0;
 
-  int get invocationEpoch => _invocationEpoch;
+  int get invocationEpoch => AddonInvocationEpoch.instance.current;
 
-  void bumpInvocationEpoch() => _invocationEpoch++;
+  void bumpInvocationEpoch() => AddonInvocationEpoch.instance.bump();
 
   List<AddonManifest> get manifests =>
       _manifests.values.toList(growable: false);

--- a/packages/core_ai/test/addons/addon_registry_test.dart
+++ b/packages/core_ai/test/addons/addon_registry_test.dart
@@ -98,6 +98,10 @@ class _SpyGraphAdapter implements GraphWorkflowAddonAdapter {
 }
 
 void main() {
+  setUp(() {
+    AddonInvocationEpoch.instance.resetForTesting();
+  });
+
   test('duplicate registration fails closed', () {
     final registry = AddonRegistry();
     final manifest = _sampleGenerativeManifest();

--- a/packages/feature_mind/lib/src/addons/addon_trace_redaction.dart
+++ b/packages/feature_mind/lib/src/addons/addon_trace_redaction.dart
@@ -1,0 +1,100 @@
+import 'package:core_ai/core_ai.dart';
+
+/// Redacts add-on sensitive fields before trace persistence or volume measurement.
+class AddonTraceRedaction {
+  const AddonTraceRedaction();
+
+  static Map<String, dynamic> connectorParameters(
+    String tool,
+    Map<String, dynamic> arguments,
+  ) {
+    if (tool == 'record_lifetrack_facts') {
+      final facts = arguments['facts'];
+      return {
+        'template_id': arguments['template_id'],
+        'title_length': (arguments['title'] as String?)?.length ?? 0,
+        'fact_count': facts is Map ? facts.length : 0,
+        'has_confirmation_token': arguments['confirmation_token'] != null,
+      };
+    }
+    if (tool == 'query_entity_graph') {
+      return {
+        'query_length': (arguments['query'] as String?)?.length ?? 0,
+        'intent': arguments['intent'],
+      };
+    }
+    return arguments;
+  }
+
+  static Map<String, dynamic> connectorResult(
+    String tool,
+    Map<String, dynamic> data,
+    bool isError,
+  ) {
+    if (isError) {
+      return {'error': data['error'] ?? true};
+    }
+    if (tool == 'record_lifetrack_facts') {
+      return {
+        'created': data['created'],
+        'track_id': data['track_id'],
+        'template_id': data['template_id'],
+      };
+    }
+    if (tool == 'query_entity_graph') {
+      return {
+        'node_count': data['node_count'],
+        'edge_count': data['edge_count'],
+        'markdown_length': (data['markdown'] as String?)?.length ?? 0,
+      };
+    }
+    return data;
+  }
+
+  static ChatTurnTrace redactTraceForPersistence(ChatTurnTrace trace) {
+    final redactor = const AiTraceRedactor();
+    final nodes = trace.trajectory.nodes
+        .map(
+          (node) => AiTrajectoryNode(
+            sequence: node.sequence,
+            kind: node.kind,
+            status: node.status,
+            label: node.label,
+            ref: node.ref,
+            summary: node.summary == null
+                ? null
+                : _redactSummary(redactor, node.summary!),
+            errorCode: node.errorCode,
+          ),
+        )
+        .toList(growable: false);
+    return ChatTurnTrace(
+      runId: trace.runId,
+      parentRunId: trace.parentRunId,
+      startedAt: trace.startedAt,
+      endedAt: trace.endedAt,
+      lifecycle: trace.lifecycle,
+      stopReason: trace.stopReason,
+      runtimeId: trace.runtimeId,
+      routing: trace.routing,
+      pluginId: trace.pluginId,
+      skillId: trace.skillId,
+      constraint: trace.constraint,
+      inertia: trace.inertia,
+      stats: trace.stats,
+      trajectory: AiTrajectoryTrace(runId: trace.trajectory.runId, nodes: nodes),
+      promptRef: trace.promptRef,
+      systemRef: trace.systemRef,
+      answerRef: trace.answerRef,
+    );
+  }
+
+  static String _redactSummary(AiTraceRedactor redactor, String summary) {
+    var redacted = redactor.redact(summary);
+    redacted = redacted.replaceAll(
+      RegExp(r'Claim ID\s*:?\s*[A-Za-z0-9-]+', caseSensitive: false),
+      'Claim ID [redacted]',
+    );
+    return redacted.replaceAll(RegExp(r'\b[A-Z]{2,}\d{3,}\b'), '[redacted:id]');
+  }
+}

--- a/packages/feature_mind/lib/src/addons/graph_workflow/graph_ingest_result.dart
+++ b/packages/feature_mind/lib/src/addons/graph_workflow/graph_ingest_result.dart
@@ -1,0 +1,27 @@
+import 'package:core_ai/core_ai.dart';
+
+import '../../agent_chat/domain/models/chat_entity_graph.dart';
+
+/// Outcome of graph-workflow ingest through add-on adapters.
+class GraphIngestResult {
+  const GraphIngestResult({
+    required this.graph,
+    this.cancelled = false,
+    this.errorCode,
+  });
+
+  static const cancelledCode = AddonInvocationEpoch.cancelledCode;
+
+  final ChatEntityGraph graph;
+  final bool cancelled;
+  final String? errorCode;
+
+  factory GraphIngestResult.success(ChatEntityGraph graph) =>
+      GraphIngestResult(graph: graph);
+
+  factory GraphIngestResult.cancelled(ChatEntityGraph graph) => GraphIngestResult(
+    graph: graph,
+    cancelled: true,
+    errorCode: cancelledCode,
+  );
+}

--- a/packages/feature_mind/lib/src/addons/graph_workflow/graph_workflow_coordinator.dart
+++ b/packages/feature_mind/lib/src/addons/graph_workflow/graph_workflow_coordinator.dart
@@ -7,6 +7,7 @@ import '../../agent_chat/domain/services/chat_entity_graph_pending.dart';
 import '../../agent_chat/domain/services/projected_chat_journey.dart';
 import 'legacy_chat_entity_linker.dart';
 import 'legacy_workflow_graph_patch.dart';
+import 'graph_ingest_result.dart';
 
 /// Routes graph-workflow add-ons through the registry without host ID switches.
 class GraphWorkflowCoordinator {
@@ -35,30 +36,36 @@ class GraphWorkflowCoordinator {
     return _legacyLinker.ingest(graph, text);
   }
 
-  Future<ChatEntityGraph> ingestWithAddonPatches(
+  Future<GraphIngestResult> ingestWithAddonPatches(
     ChatEntityGraph graph,
     String text,
   ) async {
-    if (!shouldIngest(text, graph)) return graph;
+    if (!shouldIngest(text, graph)) {
+      return GraphIngestResult.success(graph);
+    }
     final invocationEpoch = _registry.invocationEpoch;
     var chatGraph = graph;
     var entityGraph = chatGraph.toEntityGraph();
     var context = GraphIngestContext(text: text, graph: entityGraph);
     for (final adapter in _registry.eligibleGraphAdapters()) {
-      if (_registry.invocationEpoch != invocationEpoch) break;
+      if (_registry.invocationEpoch != invocationEpoch) {
+        return GraphIngestResult.cancelled(graph);
+      }
       if (!adapter.accepts(context)) continue;
       final patch = await adapter.extract(context);
-      if (_registry.invocationEpoch != invocationEpoch) break;
+      if (_registry.invocationEpoch != invocationEpoch) {
+        return GraphIngestResult.cancelled(graph);
+      }
       if (patch.isEmpty) continue;
       chatGraph = LegacyWorkflowGraphPatch.apply(chatGraph, patch);
       entityGraph = chatGraph.toEntityGraph();
       context = GraphIngestContext(text: text, graph: entityGraph);
     }
     if (_registry.invocationEpoch != invocationEpoch) {
-      return graph;
+      return GraphIngestResult.cancelled(graph);
     }
     chatGraph = _legacyLinker.ingestGenericMentions(chatGraph, text);
-    return chatGraph;
+    return GraphIngestResult.success(chatGraph);
   }
 
   List<ProjectedChatJourney> projectJourneys(ChatEntityGraph graph) {

--- a/packages/feature_mind/lib/src/agent_chat/data/connectors/life_track_record_connector.dart
+++ b/packages/feature_mind/lib/src/agent_chat/data/connectors/life_track_record_connector.dart
@@ -1,3 +1,4 @@
+import 'package:core_ai/core_ai.dart';
 import 'package:core_domain/core_domain.dart';
 
 import '../../../addons/templates/addon_life_track_record_policy.dart';
@@ -19,6 +20,7 @@ class LifeTrackRecordConnector implements AgentConnector {
     LifeTrackConfirmationTokenService? confirmationTokens,
     Future<bool> Function()? writeGate,
     IdempotentEffectPort? idempotencyPort,
+    int Function()? readInvocationEpoch,
   }) : _repository = repository,
        _resolveTemplate = resolveTemplate,
        _now = now ?? DateTime.now,
@@ -29,7 +31,8 @@ class LifeTrackRecordConnector implements AgentConnector {
        _confirmationTokens =
            confirmationTokens ?? LifeTrackConfirmationTokenService(),
        _writeGate = writeGate,
-       _idempotencyPort = idempotencyPort;
+       _idempotencyPort = idempotencyPort,
+       _readInvocationEpoch = readInvocationEpoch;
 
   final LifeTrackRepository _repository;
   final Future<LifeTrackTemplate?> Function(String templateId) _resolveTemplate;
@@ -42,6 +45,7 @@ class LifeTrackRecordConnector implements AgentConnector {
   final LifeTrackConfirmationTokenService _confirmationTokens;
   final Future<bool> Function()? _writeGate;
   final IdempotentEffectPort? _idempotencyPort;
+  final int Function()? _readInvocationEpoch;
 
   static String _defaultFollowUpHint(String templateId) {
     if (templateId == 'study_progress_v1') {
@@ -133,8 +137,22 @@ class LifeTrackRecordConnector implements AgentConnector {
       if (tokenError != null) {
         return ConnectorResult.error(
           code: tokenError,
-          message: 'That save confirmation expired or no longer matches. '
-              'Ask me to save again and confirm the new preview.',
+          message: tokenError == AddonInvocationEpoch.cancelledCode
+              ? 'That add-on was disabled before the save finished. '
+                  'Ask me to save again after re-enabling it.'
+              : 'That save confirmation expired or no longer matches. '
+                  'Ask me to save again and confirm the new preview.',
+        );
+      }
+    } else if (legacyConfirmed && _readInvocationEpoch != null) {
+      final scheduledEpoch = arguments['invocation_epoch'];
+      if (scheduledEpoch is int &&
+          scheduledEpoch != _readInvocationEpoch!()) {
+        return ConnectorResult.error(
+          code: AddonInvocationEpoch.cancelledCode,
+          message:
+              'That add-on was disabled before the save finished. '
+              'Ask me to save again after re-enabling it.',
         );
       }
     }

--- a/packages/feature_mind/lib/src/agent_chat/data/connectors/life_track_status_connector_factory_io.dart
+++ b/packages/feature_mind/lib/src/agent_chat/data/connectors/life_track_status_connector_factory_io.dart
@@ -1,3 +1,4 @@
+import 'package:core_ai/core_ai.dart';
 import 'package:core_data/core_data.dart';
 import 'package:flutter/foundation.dart';
 
@@ -85,6 +86,7 @@ AgentConnector createLifeTrackRecordConnector() {
     },
     idempotencyPort: _idempotencyPortHolder,
     confirmationTokens: sharedLifeTrackConfirmationTokens,
+    readInvocationEpoch: () => AddonInvocationEpoch.instance.current,
   );
 }
 

--- a/packages/feature_mind/lib/src/agent_chat/data/repositories/chat_entity_graph_session.dart
+++ b/packages/feature_mind/lib/src/agent_chat/data/repositories/chat_entity_graph_session.dart
@@ -39,6 +39,7 @@ class ChatEntityGraphSession {
   String? _activeConversationId;
   ChatEntityGraph _legacyGraphCache = ChatEntityGraph.empty;
   bool _legacyLoaded = false;
+  String? _lastIngestCancellationCode;
 
   ChatEntityGraph get graph => _currentSlot()?.graph ?? ChatEntityGraph.empty;
 
@@ -81,10 +82,18 @@ class ChatEntityGraphSession {
   Future<ChatEntityGraph> ingest(String text, {String? conversationId}) async {
     final id = conversationId ?? _activeConversationId ?? emptyConversationKey;
     var graph = await ensureLoaded(conversationId: id);
-    graph = await _graphCoordinator.ingestWithAddonPatches(graph, text);
+    final ingestResult = await _graphCoordinator.ingestWithAddonPatches(
+      graph,
+      text,
+    );
+    _lastIngestCancellationCode =
+        ingestResult.cancelled ? ingestResult.errorCode : null;
+    graph = ingestResult.graph;
     _slots[id] = _EphemeralGraphSlot(graph: graph, updatedAt: _now().toUtc());
     return graph;
   }
+
+  String? get lastIngestCancellationCode => _lastIngestCancellationCode;
 
   Future<ChatEntityGraph> markAttribute(
     String nodeId,

--- a/packages/feature_mind/lib/src/agent_chat/data/services/chat_turn_trace_store.dart
+++ b/packages/feature_mind/lib/src/agent_chat/data/services/chat_turn_trace_store.dart
@@ -3,6 +3,8 @@ import 'dart:convert';
 import 'package:core_ai/core_ai.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
+import '../../../addons/addon_trace_redaction.dart';
+
 /// Local redacted turn traces, keyed by [ChatTurnTrace.runId].
 ///
 /// Full prompts stay behind refs and are not written here. A failing write
@@ -25,9 +27,10 @@ class ChatTurnTraceStore {
 
   Future<void> upsert(ChatTurnTrace trace) {
     if (!kMindChatTurnInspector) return Future<void>.value();
+    final sanitized = AddonTraceRedaction.redactTraceForPersistence(trace);
     return _enqueueWrite(() async {
       final traces = await _loadAll();
-      traces[trace.runId] = trace;
+      traces[sanitized.runId] = sanitized;
       while (traces.length > maxTraces) {
         final oldest = traces.values.reduce(
           (a, b) => a.startedAt.isBefore(b.startedAt) ? a : b,

--- a/packages/feature_mind/lib/src/agent_chat/domain/services/agent_skill_orchestrator.dart
+++ b/packages/feature_mind/lib/src/agent_chat/domain/services/agent_skill_orchestrator.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 
 import 'package:core_ai/core_ai.dart';
 
+import '../../../addons/addon_trace_redaction.dart';
 import '../../../addons/workflow/addon_workflow_fact_service.dart';
 import '../../../runtime/models/capability_models.dart';
 import '../../../runtime/models/log_models.dart';
@@ -932,12 +933,14 @@ class AgentSkillOrchestrator {
       }
 
       final actionStopwatch = Stopwatch()..start();
+      final tracedArguments = _traceParameters(tool, action.arguments);
       final result = await _connectorRegistry.execute(tool, action.arguments);
       actionStopwatch.stop();
+      final tracedResult = _traceResult(tool, result.data, result.isError);
       final dataVolume = await _measureDataVolume(
         succeeded: !result.isError,
-        requestArguments: action.arguments,
-        responseData: result.data,
+        requestArguments: tracedArguments,
+        responseData: tracedResult,
       );
       if (!result.isError && dataVolume?.replayedOpSequence != null) {
         latestCitation = GroundedCitation(
@@ -1025,49 +1028,15 @@ class AgentSkillOrchestrator {
   Map<String, dynamic> _traceParameters(
     String tool,
     Map<String, dynamic> arguments,
-  ) {
-    if (tool == 'record_lifetrack_facts') {
-      final facts = arguments['facts'];
-      return {
-        'template_id': arguments['template_id'],
-        'title_length': (arguments['title'] as String?)?.length ?? 0,
-        'fact_count': facts is Map ? facts.length : 0,
-        'has_confirmation_token': arguments['confirmation_token'] != null,
-      };
-    }
-    if (tool == 'query_entity_graph') {
-      return {
-        'query_length': (arguments['query'] as String?)?.length ?? 0,
-        'intent': arguments['intent'],
-      };
-    }
-    return arguments;
-  }
+  ) =>
+      AddonTraceRedaction.connectorParameters(tool, arguments);
 
   Map<String, dynamic> _traceResult(
     String tool,
     Map<String, dynamic> data,
     bool isError,
-  ) {
-    if (isError) {
-      return {'error': data['error'] ?? true};
-    }
-    if (tool == 'record_lifetrack_facts') {
-      return {
-        'created': data['created'],
-        'track_id': data['track_id'],
-        'template_id': data['template_id'],
-      };
-    }
-    if (tool == 'query_entity_graph') {
-      return {
-        'node_count': data['node_count'],
-        'edge_count': data['edge_count'],
-        'markdown_length': (data['markdown'] as String?)?.length ?? 0,
-      };
-    }
-    return data;
-  }
+  ) =>
+      AddonTraceRedaction.connectorResult(tool, data, isError);
 
   /// Measures how much data a connector call actually moved.
   ///

--- a/packages/feature_mind/lib/src/agent_chat/domain/services/confirmation_token_store.dart
+++ b/packages/feature_mind/lib/src/agent_chat/domain/services/confirmation_token_store.dart
@@ -10,6 +10,7 @@ class ConfirmationTokenRecord {
     required this.confirmationHash,
     required this.expiresAtMs,
     required this.permissionEpoch,
+    required this.invocationEpoch,
     this.actorId = 'local_user',
   });
 
@@ -18,6 +19,7 @@ class ConfirmationTokenRecord {
   final String confirmationHash;
   final int expiresAtMs;
   final int permissionEpoch;
+  final int invocationEpoch;
   final String actorId;
 
   Map<String, dynamic> toJson() => {
@@ -26,6 +28,7 @@ class ConfirmationTokenRecord {
     'confirmation_hash': confirmationHash,
     'expires_at_ms': expiresAtMs,
     'permission_epoch': permissionEpoch,
+    'invocation_epoch': invocationEpoch,
     'actor_id': actorId,
   };
 
@@ -36,6 +39,7 @@ class ConfirmationTokenRecord {
       confirmationHash: json['confirmation_hash'] as String,
       expiresAtMs: json['expires_at_ms'] as int,
       permissionEpoch: json['permission_epoch'] as int? ?? 0,
+      invocationEpoch: json['invocation_epoch'] as int? ?? 0,
       actorId: json['actor_id'] as String? ?? 'local_user',
     );
   }

--- a/packages/feature_mind/lib/src/agent_chat/domain/services/lifetrack_confirmation_token_service.dart
+++ b/packages/feature_mind/lib/src/agent_chat/domain/services/lifetrack_confirmation_token_service.dart
@@ -3,6 +3,8 @@ import 'dart:math';
 
 import 'package:crypto/crypto.dart';
 
+import 'package:core_ai/core_ai.dart';
+
 import 'addon_permission_epoch.dart';
 import 'confirmation_token_store.dart';
 
@@ -13,15 +15,18 @@ class LifeTrackConfirmationTokenService {
     Duration ttl = const Duration(minutes: 15),
     ConfirmationTokenStore? store,
     AddonPermissionEpoch? permissionEpoch,
+    AddonInvocationEpoch? invocationEpoch,
   }) : _now = now ?? DateTime.now,
        _ttl = ttl,
        _store = store ?? InMemoryConfirmationTokenStore(),
-       _permissionEpoch = permissionEpoch ?? AddonPermissionEpoch.instance;
+       _permissionEpoch = permissionEpoch ?? AddonPermissionEpoch.instance,
+       _invocationEpoch = invocationEpoch ?? AddonInvocationEpoch.instance;
 
   final DateTime Function() _now;
   final Duration _ttl;
   final ConfirmationTokenStore _store;
   final AddonPermissionEpoch _permissionEpoch;
+  final AddonInvocationEpoch _invocationEpoch;
   final Set<String> _consumed = {};
 
   Future<String> issue({
@@ -38,6 +43,7 @@ class LifeTrackConfirmationTokenService {
       'payload_hash': payloadHash,
       'expires_at_ms': expiresAt.millisecondsSinceEpoch,
       'permission_epoch': _permissionEpoch.current,
+      'invocation_epoch': _invocationEpoch.current,
     };
     final confirmationHash = _confirmationHash(record);
     final token = _randomToken();
@@ -49,6 +55,7 @@ class LifeTrackConfirmationTokenService {
         confirmationHash: confirmationHash,
         expiresAtMs: expiresAt.millisecondsSinceEpoch,
         permissionEpoch: _permissionEpoch.current,
+        invocationEpoch: _invocationEpoch.current,
         actorId: actorId,
       ),
     );
@@ -72,6 +79,9 @@ class LifeTrackConfirmationTokenService {
     }
     if (issued.permissionEpoch != _permissionEpoch.current) {
       return 'confirmation_permission_changed';
+    }
+    if (issued.invocationEpoch != _invocationEpoch.current) {
+      return AddonInvocationEpoch.cancelledCode;
     }
     if (_now().toUtc().isAfter(
       DateTime.fromMillisecondsSinceEpoch(issued.expiresAtMs, isUtc: true),
@@ -99,6 +109,7 @@ class LifeTrackConfirmationTokenService {
       'destination_tool': destinationTool,
       'payload_hash': _payloadHash(payload),
       'permission_epoch': _permissionEpoch.current,
+      'invocation_epoch': _invocationEpoch.current,
     };
     return _confirmationHash(record);
   }

--- a/packages/feature_mind/test/addons/addon_invocation_lifecycle_test.dart
+++ b/packages/feature_mind/test/addons/addon_invocation_lifecycle_test.dart
@@ -88,6 +88,10 @@ class _SlowRevokeSpyAdapter implements GraphWorkflowAddonAdapter {
 }
 
 void main() {
+  setUp(() {
+    AddonInvocationEpoch.instance.resetForTesting();
+  });
+
   test('disabled add-on receives zero extract calls during ingest', () async {
     final registry = AddonRegistry();
     final spy = _SpyGraphAdapter();
@@ -164,7 +168,9 @@ void main() {
     );
 
     expect(spy.extractCalls, 1);
-    expect(result.nodes, isEmpty);
+    expect(result.cancelled, isTrue);
+    expect(result.errorCode, AddonInvocationEpoch.cancelledCode);
+    expect(result.graph.nodes, isEmpty);
     expect(registry.invocationEpoch, 1);
   });
 

--- a/packages/feature_mind/test/addons/addon_production_verification_test.dart
+++ b/packages/feature_mind/test/addons/addon_production_verification_test.dart
@@ -161,10 +161,10 @@ void main() {
   test('graph workflow ingest is deterministic without model or network',
       () async {
     final builtIn = BuiltInAddonRegistry.create();
-    final graph = await builtIn.graphCoordinator.ingestWithAddonPatches(
+    final graph = (await builtIn.graphCoordinator.ingestWithAddonPatches(
       ChatEntityGraph.empty,
       'Niva Bupa Claim ID 9001001 via Policybazaar. All documents received.',
-    );
+    )).graph;
     expect(graph.nodes, isNotEmpty);
     final projections = builtIn.graphCoordinator.workflowProjections(graph);
     expect(

--- a/packages/feature_mind/test/addons/addon_trace_sink_test.dart
+++ b/packages/feature_mind/test/addons/addon_trace_sink_test.dart
@@ -1,17 +1,29 @@
 import 'dart:convert';
 
+import 'package:core_ai/core_ai.dart';
 import 'package:core_domain/core_domain.dart';
+import 'package:feature_mind/src/addons/addon_trace_redaction.dart';
 import 'package:feature_mind/src/agent_chat/data/connectors/life_track_record_connector.dart';
+import 'package:feature_mind/src/agent_chat/data/services/chat_turn_trace_store.dart';
 import 'package:feature_mind/src/agent_chat/domain/models/agent_skill.dart';
 import 'package:feature_mind/src/agent_chat/domain/services/agent_connector_registry.dart';
 import 'package:feature_mind/src/agent_chat/domain/services/agent_skill_orchestrator.dart';
 import 'package:feature_mind/src/agent_chat/domain/services/agent_skill_registry.dart';
+import 'package:feature_mind/src/agent_chat/domain/services/confirmation_token_store.dart';
+import 'package:feature_mind/src/agent_chat/domain/services/lifetrack_confirmation_token_service.dart';
+import 'package:feature_mind/src/runtime/models/log_models.dart';
+import '../support/recording_operation_log.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 class _MockLifeTrackRepository extends Mock implements LifeTrackRepository {}
 
 void main() {
+  setUp(() {
+    AddonInvocationEpoch.instance.resetForTesting();
+  });
+
   test('orchestrator traces omit LifeTrack fact values', () async {
     final repository = _MockLifeTrackRepository();
     when(() => repository.listTracks()).thenAnswer(
@@ -76,6 +88,181 @@ void main() {
     );
     expect(executeTrace.parameters.containsKey('facts'), isFalse);
     expect(jsonEncode(executeTrace.parameters), isNot(contains('ABC123')));
+  });
+
+  test('data volume measurement uses redacted connector payloads', () async {
+    final repository = _MockLifeTrackRepository();
+    when(() => repository.listTracks()).thenAnswer(
+      (_) async => const Ok(<LifeTrack>[]),
+    );
+
+    final registry = AgentSkillRegistry(skills: [
+      AgentSkill(
+        id: 'record-insurance-claim',
+        name: 'Record claim',
+        description: 'Record',
+        instructions: 'Record insurance claim facts locally.',
+        enabled: true,
+        tools: ['record_lifetrack_facts'],
+        capabilities: const [SkillCapability.lifeTrackWrite],
+        lifeTrackTemplateId: 'insurance_claim_v1',
+      ),
+    ]);
+
+    final connector = LifeTrackRecordConnector(
+      repository: repository,
+      resolveTemplate: (_) async => LifeTrackTemplate(
+        templateId: 'insurance_claim_v1',
+        title: 'Insurance',
+        description: 'Test',
+        category: LifeTrackCategory.insurance,
+        version: '1',
+        milestones: [
+          MilestoneTemplate(
+            name: 'Phase 1',
+            objective: 'Record',
+            tasks: [
+              ActionItemTemplate(
+                summary: 'Record claim',
+                requirements: [
+                  InputRequirementTemplate(
+                    label: 'Claim ID',
+                    type: FieldType.text,
+                    isRequired: true,
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+
+    final log = RecordingOperationLog();
+    await log.append(
+      kind: MindOpKind.note,
+      title: 'fixture op',
+      contextId: 'trace-sink',
+    );
+
+    final orchestrator = AgentSkillOrchestrator(
+      skillRegistry: registry,
+      connectorRegistry: AgentConnectorRegistry(connectors: [connector]),
+      modelClient: _RecordingModelClient(),
+      operationLogPort: log,
+    );
+
+    final result = await orchestrator.run(
+      'Record Niva claim ABC123 on this device',
+    );
+
+    expect(result.handled, isTrue);
+    final executeTrace = result.traces.firstWhere(
+      (trace) => trace.title == 'Execute action',
+    );
+    final redactedPayload = jsonEncode(executeTrace.parameters);
+    expect(redactedPayload, isNot(contains('ABC123')));
+    expect(executeTrace.dataVolume, isNull);
+    expect(log.appended.every((op) => !op.detail.contains('ABC123')), isTrue);
+  });
+
+  test('late LifeTrack redemption returns addon_invocation_cancelled', () async {
+    final repository = _MockLifeTrackRepository();
+    when(() => repository.listTracks()).thenAnswer(
+      (_) async => const Ok(<LifeTrack>[]),
+    );
+
+    final tokens = LifeTrackConfirmationTokenService(
+      store: InMemoryConfirmationTokenStore(),
+    );
+    final payload = {
+      'title': 'Niva claim',
+      'template_id': 'insurance_claim_v1',
+      'facts': {'Claim ID': 'ABC123'},
+    };
+    final token = await tokens.issue(
+      destinationTool: 'record_lifetrack_facts',
+      payload: payload,
+    );
+    AddonInvocationEpoch.instance.bump();
+
+    final connector = LifeTrackRecordConnector(
+      repository: repository,
+      resolveTemplate: (_) async => LifeTrackTemplate(
+        templateId: 'insurance_claim_v1',
+        title: 'Insurance',
+        description: 'Test',
+        category: LifeTrackCategory.insurance,
+        version: '1',
+        milestones: [
+          MilestoneTemplate(
+            name: 'Phase 1',
+            objective: 'Record',
+            tasks: [
+              ActionItemTemplate(
+                summary: 'Record claim',
+                requirements: [
+                  InputRequirementTemplate(
+                    label: 'Claim ID',
+                    type: FieldType.text,
+                    isRequired: true,
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ],
+      ),
+      confirmationTokens: tokens,
+    );
+
+    final result = await connector.execute({
+      'title': 'Niva claim',
+      'template_id': 'insurance_claim_v1',
+      'facts': payload['facts'],
+      'confirmation_token': token,
+    });
+
+    expect(result.isError, isTrue);
+    expect(result.errorCode, AddonInvocationEpoch.cancelledCode);
+  });
+
+  test('chat turn trace store redacts trajectory summaries on upsert', () async {
+    SharedPreferences.setMockInitialValues({});
+    final store = ChatTurnTraceStore(
+      preferences: await SharedPreferences.getInstance(),
+    );
+    final trajectory = AiTrajectoryTraceBuilder(runId: 'run-claim-1')
+        .error(
+          code: AddonInvocationEpoch.cancelledCode,
+          summary: 'Claim ID ABC123 for Niva Bupa',
+        )
+        .build();
+    final trace = ChatTurnTrace(
+      runId: 'run-claim-1',
+      startedAt: DateTime.utc(2026, 8, 23),
+      lifecycle: ChatTurnLifecycle.failed,
+      stopReason: ChatTurnStopReason.engineError,
+      runtimeId: 'offline-qwen',
+      routing: ChatTurnRouting.local,
+      constraint: ChatTurnConstraint.none,
+      inertia: const [],
+      stats: ChatTurnStats.empty,
+      trajectory: trajectory,
+    );
+
+    await store.upsert(trace);
+    final loaded = await store.byRunId('run-claim-1');
+    expect(loaded, isNotNull);
+    final storedJson = jsonEncode(loaded!.toJson());
+    expect(storedJson, isNot(contains('ABC123')));
+    expect(
+      AddonTraceRedaction.redactTraceForPersistence(trace).trajectory
+          .nodes
+          .single
+          .summary,
+      isNot(contains('ABC123')),
+    );
   });
 }
 

--- a/packages/feature_mind/test/addons/car_university_graph_adapters_test.dart
+++ b/packages/feature_mind/test/addons/car_university_graph_adapters_test.dart
@@ -20,10 +20,10 @@ void main() {
   test('car adapter accepts vehicle plus budget and projects offerable journey',
       () async {
     final builtIn = BuiltInAddonRegistry.create();
-    final graph = await builtIn.graphCoordinator.ingestWithAddonPatches(
+    final graph = (await builtIn.graphCoordinator.ingestWithAddonPatches(
       ChatEntityGraph.empty,
       'Shortlisted Toyota Camry, budget around 25 lakh, parking plan in basement.',
-    );
+    )).graph;
 
     final projections = builtIn.graphCoordinator.workflowProjections(graph);
     expect(
@@ -53,10 +53,10 @@ void main() {
   test('university adapter accepts applying fixture and projects journey',
       () async {
     final builtIn = BuiltInAddonRegistry.create();
-    final graph = await builtIn.graphCoordinator.ingestWithAddonPatches(
+    final graph = (await builtIn.graphCoordinator.ingestWithAddonPatches(
       ChatEntityGraph.empty,
       'I am applying to MIT for Fall 2027.',
-    );
+    )).graph;
 
     final projections = builtIn.graphCoordinator.workflowProjections(graph);
     expect(

--- a/packages/feature_mind/test/addons/confirmation_threat_matrix_test.dart
+++ b/packages/feature_mind/test/addons/confirmation_threat_matrix_test.dart
@@ -1,3 +1,4 @@
+import 'package:core_ai/core_ai.dart';
 import 'package:feature_mind/src/agent_chat/domain/services/addon_permission_epoch.dart';
 import 'package:feature_mind/src/agent_chat/domain/services/confirmation_token_store.dart';
 import 'package:feature_mind/src/agent_chat/domain/services/lifetrack_confirmation_token_service.dart';
@@ -12,6 +13,7 @@ void main() {
   };
 
   setUp(() {
+    AddonInvocationEpoch.instance.resetForTesting();
     service = LifeTrackConfirmationTokenService(
       store: InMemoryConfirmationTokenStore(),
     );
@@ -111,6 +113,22 @@ void main() {
         payload: payload,
       ),
       'confirmation_permission_changed',
+    );
+  });
+
+  test('invocation epoch bump after issue rejects redemption', () async {
+    final token = await service.issue(
+      destinationTool: 'record_lifetrack_facts',
+      payload: payload,
+    );
+    AddonInvocationEpoch.instance.bump();
+    expect(
+      await service.validateAndConsume(
+        token: token,
+        destinationTool: 'record_lifetrack_facts',
+        payload: payload,
+      ),
+      AddonInvocationEpoch.cancelledCode,
     );
   });
 }

--- a/packages/feature_mind/test/addons/graph_workflow_coordinator_test.dart
+++ b/packages/feature_mind/test/addons/graph_workflow_coordinator_test.dart
@@ -46,10 +46,10 @@ void main() {
   test('firstUnofferedJourney surfaces car purchase via adapter projections',
       () async {
     final builtIn = BuiltInAddonRegistry.create();
-    final graph = await builtIn.graphCoordinator.ingestWithAddonPatches(
+    final graph = (await builtIn.graphCoordinator.ingestWithAddonPatches(
       ChatEntityGraph.empty,
       'Shortlisted Honda City, budget 12 lakh, parking plan in society basement.',
-    );
+    )).graph;
 
     final journey = builtIn.graphCoordinator.firstUnofferedJourney(graph);
     expect(journey, isNotNull);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements explicit lifecycle cancellation and expanded observability sink coverage for the Mind add-on framework.

### `addon_invocation_cancelled`

- **`AddonInvocationEpoch`** (`core_ai`) — shared monotonic epoch with `cancelledCode = 'addon_invocation_cancelled'`
- **`GraphIngestResult`** — coordinator returns explicit cancellation when epoch changes mid-`extract` (no silent discard)
- **Confirmation tokens** — store `invocation_epoch`; redemption after revoke returns `addon_invocation_cancelled` (distinct from `confirmation_permission_changed`)
- **`LifeTrackRecordConnector`** — surfaces cancellation with user-safe copy on late redemption

### Expanded sink coverage

- **`AddonTraceRedaction`** — shared redaction for connector parameters/results and `ChatTurnTrace` persistence
- **Orchestrator** — data-volume measurement uses redacted payloads (not raw `facts`)
- **`ChatTurnTraceStore`** — redacts trajectory summaries before disk write
- **Tests** — orchestrator trace spy, operation-log spy, connector late-redeem, chat-turn store round-trip, invocation-epoch threat matrix

**Note:** This branch includes the legacy quarantine work from `cursor/mind-addon-legacy-quarantine-45dd` (PR #1900). Merge order: quarantine first, or merge this branch which stacks both slices.

## Verification

```bash
cd packages/core_ai && flutter test test/addons/addon_registry_test.dart
cd packages/feature_mind && flutter test test/addons/ test/architecture/addon_framework_gate_test.dart
cd packages/feature_mind && flutter test test/agent_chat/data/services/chat_turn_trace_store_test.dart
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3cb72c1f-40c3-40b6-938b-70e7592345dd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3cb72c1f-40c3-40b6-938b-70e7592345dd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

