### PR TITLE
feat(mind): macOS and Windows live resource probes

### DIFF
--- a/docs/features/airo-mind/LIVE_SCRIBE_DESKTOP_PREVIEW_QUALIFICATION.md
+++ b/docs/features/airo-mind/LIVE_SCRIBE_DESKTOP_PREVIEW_QUALIFICATION.md
@@ -77,7 +77,7 @@ Use an external audio source so the mic captures system/room audio (user runs th
 ## CI evidence (dev)
 
 - `packages/feature_mind/test/capture/` — capture coordinator, vocabulary, speaker UI, fan-out recorder, admission warning, live IR rail.
-- `rust/airo_mind_audio` — ring overflow → degraded; fan-out crash isolation; governor; Linux probes; latency harness.
+- `rust/airo_mind_audio` — ring overflow → degraded; fan-out crash isolation; governor; Linux/macOS/Windows RAM probes (thermal Linux-only); latency harness.
 - `rust/airo_mind_whisper` — diarization label assignment tests; live IR emit on stable.
 - `rust/airo_mind_meeting` — incremental Conversation IR (stable-sentence extractor).
 

--- a/docs/features/airo-mind/evaluation-results.md
+++ b/docs/features/airo-mind/evaluation-results.md
@@ -9,7 +9,7 @@ Verdict: [NOT PRODUCTION QUALIFIED](./production-qualification.md)
 |---|---|
 | `airo_mind_audio` fan-out + isolation + governor + latency harness | Run locally in this change |
 | `airo_mind_meeting` incremental Conversation IR | Run locally in this change |
-| `airo_mind_audio` Linux resource probes | Run locally in this change |
+| `airo_mind_audio` Linux / macOS / Windows resource probes | Parser tests on every host; live command path on matching OS |
 | `airo_mind_core` `check_speech_admission` | Run locally in this change |
 | `feature_mind` live IR rail + JSON parser | Added; Flutter SDK was not available in this agent environment |
 

--- a/docs/features/airo-mind/production-qualification.md
+++ b/docs/features/airo-mind/production-qualification.md
@@ -32,7 +32,7 @@ This document does not lower gates. Remaining P0 items are listed below.
 | Incremental Conversation IR (no live LLM) | `airo_mind_meeting::live_ir` |
 | Desktop one-mic (no second `AudioRecorder` file encoder) | `FanoutBackedAudioRecorderPort` |
 | Conversation IR on FRB/UI | `TranscriptEvent::ConversationIr` + insights rail |
-| Runtime thermal/battery probes | Linux sysfs/proc → `ResourceGovernor` at live start |
+| Runtime thermal/battery probes | Linux sysfs/proc; macOS `sysctl`/`vm_stat`/`pmset`; Windows `wmic` → `ResourceGovernor` at live start. Thermal still Linux-only. |
 
 ## Still open (blocks PRODUCTION)
 
@@ -46,7 +46,7 @@ This document does not lower gates. Remaining P0 items are listed below.
 5. Speaker timeline reconciliation beyond provisional live lanes + post-stop
    diarization (already present when `audio_path` is passed to
    `stop_live_session`).
-6. Non-Linux OS probes (macOS/Windows still use an unconstrained snapshot).
+6. Thermal probes on macOS/Windows (RAM + battery when the host reports them; thermal stays Linux-only).
 
 ## Product states
 

--- a/rust/airo_mind_audio/src/lib.rs
+++ b/rust/airo_mind_audio/src/lib.rs
@@ -30,7 +30,11 @@ pub use governor::{
     BatteryBand, IntelligencePolicy, LiveAdmission, ResourceGovernor, ResourceSnapshot, ThermalBand,
 };
 pub use live::{LiveSpeechConfig, LiveSpeechPipeline, LiveStepReport};
-pub use probes::{parse_meminfo_mb, probe_resource_snapshot, thermal_from_millideg_c};
+pub use probes::{
+    parse_meminfo_mb, parse_pmset_battery_percent, parse_sysctl_memsize_mb,
+    parse_vm_stat_available_mb, parse_wmic_battery_percent, parse_wmic_memory_mb,
+    probe_resource_snapshot, thermal_from_millideg_c,
+};
 pub use ring::{PcmRingBuffer, RingPushReport};
 pub use speaker_activity::{SpeakerActivitySlice, SpeakerActivityTracker};
 pub use stabilizer::TranscriptStabilizer;

--- a/rust/airo_mind_audio/src/probes.rs
+++ b/rust/airo_mind_audio/src/probes.rs
@@ -1,31 +1,50 @@
 //! Best-effort OS probes for [`ResourceSnapshot`].
 //!
-//! Missing files or unsupported hosts return an unconstrained snapshot.
-//! Recording is never refused by a failed probe.
+//! Missing files, failed commands, or unsupported hosts leave that field on
+//! the unconstrained snapshot. Recording is never refused by a failed probe.
+//! No `unsafe` — `airo_mind_audio` denies it; hosts are read via files or
+//! stock OS commands.
 
 use crate::governor::{ResourceSnapshot, ThermalBand};
 
 /// Flutter / UI reserve that must remain after the STT model loads.
 const APP_HEADROOM_MB: u32 = 512;
 
-/// Read a point-in-time snapshot. Linux fills RAM / battery / thermal when
-/// the usual sysfs and proc files exist; every other host is unconstrained.
+/// Read a point-in-time snapshot.
+///
+/// - Linux: `/proc/meminfo`, sysfs battery + thermal
+/// - macOS: `sysctl` / `vm_stat` RAM, `pmset` battery when present
+/// - Windows: `wmic` RAM + battery when present
+/// - Thermal stays Linux-only (no stock command without extra crates)
 pub fn probe_resource_snapshot(stt_model_mb: u32) -> ResourceSnapshot {
     #[cfg(target_os = "linux")]
     {
         linux_snapshot(stt_model_mb)
     }
-    #[cfg(not(target_os = "linux"))]
+    #[cfg(target_os = "macos")]
+    {
+        macos_snapshot(stt_model_mb)
+    }
+    #[cfg(target_os = "windows")]
+    {
+        windows_snapshot(stt_model_mb)
+    }
+    #[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "windows")))]
     {
         ResourceSnapshot::unconstrained(stt_model_mb)
     }
 }
 
-#[cfg(target_os = "linux")]
-fn linux_snapshot(stt_model_mb: u32) -> ResourceSnapshot {
+fn base_snapshot(stt_model_mb: u32) -> ResourceSnapshot {
     let mut snap = ResourceSnapshot::unconstrained(stt_model_mb);
     snap.app_headroom_mb = APP_HEADROOM_MB;
     snap.stt_model_mb = stt_model_mb;
+    snap
+}
+
+#[cfg(target_os = "linux")]
+fn linux_snapshot(stt_model_mb: u32) -> ResourceSnapshot {
+    let mut snap = base_snapshot(stt_model_mb);
     if let Ok(meminfo) = std::fs::read_to_string("/proc/meminfo") {
         if let Some((total, available)) = parse_meminfo_mb(&meminfo) {
             snap.total_ram_mb = total;
@@ -39,6 +58,73 @@ fn linux_snapshot(stt_model_mb: u32) -> ResourceSnapshot {
         snap.thermal = thermal;
     }
     snap
+}
+
+#[cfg(target_os = "macos")]
+fn macos_snapshot(stt_model_mb: u32) -> ResourceSnapshot {
+    let mut snap = base_snapshot(stt_model_mb);
+    if let Some(total) =
+        run_text("sysctl", &["-n", "hw.memsize"]).and_then(|raw| parse_sysctl_memsize_mb(&raw))
+    {
+        snap.total_ram_mb = total;
+    }
+    if let Some(available) =
+        run_text("vm_stat", &[]).and_then(|raw| parse_vm_stat_available_mb(&raw))
+    {
+        snap.available_ram_mb = available;
+    }
+    if let Some(percent) =
+        run_text("pmset", &["-g", "batt"]).and_then(|raw| parse_pmset_battery_percent(&raw))
+    {
+        snap.battery_percent = percent;
+    }
+    snap
+}
+
+#[cfg(target_os = "windows")]
+fn windows_snapshot(stt_model_mb: u32) -> ResourceSnapshot {
+    let mut snap = base_snapshot(stt_model_mb);
+    if let Some((total, available)) = run_text(
+        "wmic",
+        &[
+            "OS",
+            "get",
+            "FreePhysicalMemory,TotalVisibleMemorySize",
+            "/Value",
+        ],
+    )
+    .and_then(|raw| parse_wmic_memory_mb(&raw))
+    {
+        snap.total_ram_mb = total;
+        snap.available_ram_mb = available;
+    }
+    if let Some(percent) = run_text(
+        "wmic",
+        &[
+            "path",
+            "Win32_Battery",
+            "get",
+            "EstimatedChargeRemaining",
+            "/Value",
+        ],
+    )
+    .and_then(|raw| parse_wmic_battery_percent(&raw))
+    {
+        snap.battery_percent = percent;
+    }
+    snap
+}
+
+#[cfg(any(target_os = "macos", target_os = "windows"))]
+fn run_text(program: &str, args: &[&str]) -> Option<String> {
+    let output = std::process::Command::new(program)
+        .args(args)
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    String::from_utf8(output.stdout).ok()
 }
 
 /// Parse `/proc/meminfo` into `(total_mb, available_mb)`.
@@ -55,6 +141,90 @@ pub fn parse_meminfo_mb(contents: &str) -> Option<(u32, u32)> {
     Some((kb_to_mb(total_kb?), kb_to_mb(available_kb?)))
 }
 
+/// `sysctl -n hw.memsize` prints total RAM in bytes.
+pub fn parse_sysctl_memsize_mb(raw: &str) -> Option<u32> {
+    let bytes: u64 = raw.trim().parse().ok()?;
+    Some(bytes_to_mb(bytes))
+}
+
+/// `vm_stat` free + inactive + speculative pages → available MB.
+pub fn parse_vm_stat_available_mb(raw: &str) -> Option<u32> {
+    let page_size = parse_vm_stat_page_size(raw)?;
+    let free = pages_after_label(raw, "Pages free:")?;
+    let inactive = pages_after_label(raw, "Pages inactive:").unwrap_or(0);
+    let speculative = pages_after_label(raw, "Pages speculative:").unwrap_or(0);
+    let bytes = free
+        .saturating_add(inactive)
+        .saturating_add(speculative)
+        .saturating_mul(page_size);
+    Some(bytes_to_mb(bytes))
+}
+
+/// `pmset -g batt` line such as `87%; discharging`.
+pub fn parse_pmset_battery_percent(raw: &str) -> Option<u8> {
+    for token in raw.split(|c: char| matches!(c, ' ' | '\t' | ';' | '\n' | '\r')) {
+        let trimmed = token.trim();
+        let Some(digits) = trimmed.strip_suffix('%') else {
+            continue;
+        };
+        if let Ok(percent) = digits.parse::<u8>() {
+            return Some(percent.min(100));
+        }
+    }
+    None
+}
+
+/// `wmic OS get FreePhysicalMemory,TotalVisibleMemorySize /Value` (KB).
+pub fn parse_wmic_memory_mb(raw: &str) -> Option<(u32, u32)> {
+    let total = wmic_u64(raw, "TotalVisibleMemorySize")?;
+    let available = wmic_u64(raw, "FreePhysicalMemory")?;
+    Some((kb_to_mb(total), kb_to_mb(available)))
+}
+
+/// `wmic path Win32_Battery get EstimatedChargeRemaining /Value`.
+pub fn parse_wmic_battery_percent(raw: &str) -> Option<u8> {
+    let value = wmic_u64(raw, "EstimatedChargeRemaining")?;
+    if value > 100 {
+        return None;
+    }
+    Some(value as u8)
+}
+
+fn parse_vm_stat_page_size(raw: &str) -> Option<u64> {
+    let key = "page size of ";
+    let start = raw.find(key)? + key.len();
+    let rest = raw[start..].split_whitespace().next()?;
+    rest.parse().ok()
+}
+
+fn pages_after_label(raw: &str, label: &str) -> Option<u64> {
+    for line in raw.lines() {
+        let Some(rest) = line.trim().strip_prefix(label) else {
+            continue;
+        };
+        let digits = rest.trim().trim_end_matches('.').replace(',', "");
+        if let Ok(n) = digits.parse::<u64>() {
+            return Some(n);
+        }
+    }
+    None
+}
+
+fn wmic_u64(raw: &str, key: &str) -> Option<u64> {
+    let prefix = format!("{key}=");
+    for line in raw.lines() {
+        let line = line.trim().trim_start_matches('\u{feff}');
+        if let Some(value) = line.strip_prefix(&prefix) {
+            let value = value.trim();
+            if value.is_empty() {
+                return None;
+            }
+            return value.parse().ok();
+        }
+    }
+    None
+}
+
 fn kb_after_label(line: &str, label: &str) -> Option<u64> {
     let rest = line.strip_prefix(label)?.trim();
     let digits = rest.split_whitespace().next()?;
@@ -63,6 +233,10 @@ fn kb_after_label(line: &str, label: &str) -> Option<u64> {
 
 fn kb_to_mb(kb: u64) -> u32 {
     (kb / 1024).min(u64::from(u32::MAX)) as u32
+}
+
+fn bytes_to_mb(bytes: u64) -> u32 {
+    (bytes / 1024 / 1024).min(u64::from(u32::MAX)) as u32
 }
 
 /// Map millidegree thermal-zone readings to a policy band.
@@ -132,6 +306,62 @@ MemAvailable:    8192000 kB
         assert_eq!(thermal_from_millideg_c(60_000), ThermalBand::Warm);
         assert_eq!(thermal_from_millideg_c(75_000), ThermalBand::Hot);
         assert_eq!(thermal_from_millideg_c(90_000), ThermalBand::Critical);
+    }
+
+    #[test]
+    fn sysctl_memsize_parses_bytes() {
+        assert_eq!(parse_sysctl_memsize_mb("17179869184\n"), Some(16_384));
+        assert_eq!(parse_sysctl_memsize_mb("not-a-number"), None);
+    }
+
+    #[test]
+    fn vm_stat_sums_reclaimable_pages() {
+        let sample = "\
+Mach Virtual Memory Statistics: (page size of 16384 bytes)
+Pages free:                                65536.
+Pages active:                             100000.
+Pages inactive:                            32768.
+Pages speculative:                          4096.
+Pages wired down:                          20000.
+";
+        // (65536 + 32768 + 4096) * 16384 / 1024 / 1024 = 1600
+        assert_eq!(parse_vm_stat_available_mb(sample), Some(1_600));
+    }
+
+    #[test]
+    fn pmset_reads_internal_battery_percent() {
+        let sample = "\
+Now drawing from 'Battery Power'
+ -InternalBattery-0 (id=123)	87%; discharging; 3:45 remaining present: true
+";
+        assert_eq!(parse_pmset_battery_percent(sample), Some(87));
+        assert_eq!(parse_pmset_battery_percent("no battery listed"), None);
+    }
+
+    #[test]
+    fn wmic_memory_parses_kb_fields() {
+        let sample = "\
+FreePhysicalMemory=8388608\r
+TotalVisibleMemorySize=16777216\r
+";
+        assert_eq!(parse_wmic_memory_mb(sample), Some((16_384, 8_192)));
+        assert_eq!(parse_wmic_memory_mb("FreePhysicalMemory=\n"), None);
+    }
+
+    #[test]
+    fn wmic_battery_parses_charge() {
+        assert_eq!(
+            parse_wmic_battery_percent("EstimatedChargeRemaining=42\r\n"),
+            Some(42)
+        );
+        assert_eq!(
+            parse_wmic_battery_percent("EstimatedChargeRemaining=\r\n"),
+            None
+        );
+        assert_eq!(
+            parse_wmic_battery_percent("EstimatedChargeRemaining=250\r\n"),
+            None
+        );
     }
 
     #[test]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

#1902 (live settings) is already on `main`. This is the last **host-only** leftover from that thread: macOS and Windows no longer use a fully unconstrained `ResourceSnapshot`.

| Host | RAM | Battery | Thermal |
|---|---|---|---|
| Linux | `/proc/meminfo` | sysfs `BAT*` | sysfs zone0 |
| macOS | `sysctl hw.memsize` + `vm_stat` | `pmset -g batt` when present | unconstrained (Normal) |
| Windows | `wmic` OS memory | `Win32_Battery` when present | unconstrained (Normal) |

- No new crates.io deps. No `unsafe` (`airo_mind_audio` denies it).
- Failed commands leave that field unconstrained. Recording is never refused.
- User settings from #1902 (`prefer_full` / `insights_off`) still apply on top.

**Live remains Preview. This PR does not claim production.**

### What this thread cannot close from this environment

These still block PRODUCTION and need devices, real weights, or a new native capture crate:

1. Drop `push_live_pcm` (ZC-1 / cpal) — no new crates.io deps
2. Real-weight latency gate (partial &lt; 500 ms, stable &lt; 1 s)
3. Golden WER / conversation suite
4. Android / iOS live qualification
5. Speaker timeline beyond post-stop diarization
6. Thermal probes on macOS/Windows (RAM/battery only here)

## Test Plan

- [x] `cargo test -p airo_mind_audio probes --lib` — 9 passed (meminfo, sysctl, vm_stat, pmset, wmic, live probe)
- [x] `rustfmt --check` on edited Rust files
- [ ] Rust Core CI on macOS/Windows will exercise the real `sysctl`/`wmic` path
- [ ] Manual desktop device verification — user tests separately

**Verification environment:** Host-only (Linux). macOS/Windows command paths are parser-tested here and live-tested in Rust CI.

## Agent Policy

- [x] Continues the #1899/#1902 governor/settings seam. No new issue.
- [x] No framework/application boundary contract change.
- [x] Android Emulator was not used.

## Council Review

Touched: `rust/airo_mind_audio` (probes only).

- Rust Architect: stock-command probes, no unsafe, no new deps
- Chief Performance Officer: one-shot commands at `start_live_session` only
- Chief QA Officer: parser tests

## User-Facing Documentation

- [x] Updated qualification docs. No wiki change — no new user setting.

## Plugin and Size Impact

- [ ] This PR adds new dependencies
- [x] Small Rust/docs growth only

## Release Notes

- Desktop Preview: live intelligence now reads RAM (and battery when reported) on macOS and Windows. Thermal remains Linux-only. Not production qualified.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-deeea9f1-edbc-404e-a72e-66fa255a9ceb?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-deeea9f1-edbc-404e-a72e-66fa255a9ceb&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

