### PR TITLE
Mind add-on GA finish: barrier lifecycle, pipeline integration, wiring

### DIFF
--- a/packages/feature_mind/lib/src/addons/addon_lifecycle_gate.dart
+++ b/packages/feature_mind/lib/src/addons/addon_lifecycle_gate.dart
@@ -20,6 +20,9 @@ class AddonLifecycleGate {
 
   void onEligibilityChanged(AddonEligibility eligibility) {
     if (eligibility.isEligible) return;
+    if (eligibility.revoked) {
+      AddonInvocationEpoch.instance.bump();
+    }
     AddonPermissionEpoch.instance.bump();
     unawaited(
       (_confirmationTokens ?? sharedLifeTrackConfirmationTokens).invalidateAll(),

--- a/packages/feature_mind/lib/src/addons/generative_addon_coordinator.dart
+++ b/packages/feature_mind/lib/src/addons/generative_addon_coordinator.dart
@@ -8,11 +8,13 @@ class GenerativeAddonRunPlan {
     required this.adapter,
     required this.prompt,
     required this.conversation,
+    required this.invocationEpoch,
   });
 
   final GenerativeAddonAdapter adapter;
   final AddonPrompt prompt;
   final AddonConversation conversation;
+  final int invocationEpoch;
 
   AddonIdentity get identity => adapter.identity;
 
@@ -86,6 +88,7 @@ class GenerativeAddonCoordinator {
     required String currentPrompt,
     required List<AssistantChatContextMessage> history,
   }) {
+    final invocationEpoch = _registry.invocationEpoch;
     final conversation = AddonConversation(
       currentPrompt: currentPrompt,
       history: [
@@ -94,11 +97,14 @@ class GenerativeAddonCoordinator {
       ],
     );
     for (final adapter in _registry.eligibleGenerativeAdapters()) {
+      if (_registry.invocationEpoch != invocationEpoch) return null;
       if (adapter.accepts(conversation)) {
+        if (_registry.invocationEpoch != invocationEpoch) return null;
         return GenerativeAddonRunPlan(
           adapter: adapter,
           prompt: adapter.buildPrompt(conversation),
           conversation: conversation,
+          invocationEpoch: invocationEpoch,
         );
       }
     }
@@ -110,6 +116,15 @@ class GenerativeAddonCoordinator {
     required String output,
     required bool alreadyRetried,
   }) {
+    if (plan.invocationEpoch != _registry.invocationEpoch) {
+      return GenerativeAddonReview(
+        output:
+            'That add-on was disabled before generation finished. '
+            'Ask again after re-enabling it.',
+        shouldRetry: false,
+        invalid: true,
+      );
+    }
     var processed = plan.adapter.postProcessOutput(plan.conversation, output);
     final evaluation = plan.adapter.evaluate(plan.conversation, processed);
 

--- a/packages/feature_mind/lib/src/addons/graph_workflow/graph_workflow_coordinator.dart
+++ b/packages/feature_mind/lib/src/addons/graph_workflow/graph_workflow_coordinator.dart
@@ -85,19 +85,24 @@ class GraphWorkflowCoordinator {
   }
 
   List<WorkflowProjection> workflowProjections(ChatEntityGraph graph) {
+    final invocationEpoch = _registry.invocationEpoch;
     final entityGraph = graph.toEntityGraph();
     final projections = <WorkflowProjection>[];
     for (final adapter in _registry.eligibleGraphAdapters()) {
+      if (_registry.invocationEpoch != invocationEpoch) break;
       projections.addAll(adapter.project(entityGraph));
     }
     return projections;
   }
 
   Map<String, PendingAssessment> pendingAssessments(ChatEntityGraph graph) {
+    final invocationEpoch = _registry.invocationEpoch;
     final entityGraph = graph.toEntityGraph();
     final assessments = <String, PendingAssessment>{};
     for (final adapter in _registry.eligibleGraphAdapters()) {
+      if (_registry.invocationEpoch != invocationEpoch) break;
       for (final projection in adapter.project(entityGraph)) {
+        if (_registry.invocationEpoch != invocationEpoch) break;
         assessments[projection.subjectNodeId] = adapter.assessPending(
           entityGraph,
           projection,

--- a/packages/feature_mind/lib/src/agent_chat/domain/services/lifetrack_confirmation_token_service.dart
+++ b/packages/feature_mind/lib/src/agent_chat/domain/services/lifetrack_confirmation_token_service.dart
@@ -28,6 +28,7 @@ class LifeTrackConfirmationTokenService {
   final AddonPermissionEpoch _permissionEpoch;
   final AddonInvocationEpoch _invocationEpoch;
   final Set<String> _consumed = {};
+  bool _redeemInFlight = false;
 
   Future<String> issue({
     required String destinationTool,
@@ -69,33 +70,39 @@ class LifeTrackConfirmationTokenService {
     String actorId = 'local_user',
   }) async {
     if (_consumed.contains(token)) return 'confirmation_consumed';
-    final issued = await _store.read(token);
-    if (issued == null) return 'confirmation_invalid';
-    if (issued.destinationTool != destinationTool) {
-      return 'confirmation_invalid';
-    }
-    if (issued.actorId != actorId) {
-      return 'confirmation_invalid';
-    }
-    if (issued.permissionEpoch != _permissionEpoch.current) {
-      return 'confirmation_permission_changed';
-    }
-    if (issued.invocationEpoch != _invocationEpoch.current) {
-      return AddonInvocationEpoch.cancelledCode;
-    }
-    if (_now().toUtc().isAfter(
-      DateTime.fromMillisecondsSinceEpoch(issued.expiresAtMs, isUtc: true),
-    )) {
+    if (_redeemInFlight) return 'confirmation_consumed';
+    _redeemInFlight = true;
+    try {
+      final issued = await _store.read(token);
+      if (issued == null) return 'confirmation_invalid';
+      if (issued.destinationTool != destinationTool) {
+        return 'confirmation_invalid';
+      }
+      if (issued.actorId != actorId) {
+        return 'confirmation_invalid';
+      }
+      if (issued.permissionEpoch != _permissionEpoch.current) {
+        return 'confirmation_permission_changed';
+      }
+      if (issued.invocationEpoch != _invocationEpoch.current) {
+        return AddonInvocationEpoch.cancelledCode;
+      }
+      if (_now().toUtc().isAfter(
+        DateTime.fromMillisecondsSinceEpoch(issued.expiresAtMs, isUtc: true),
+      )) {
+        await _store.delete(token);
+        return 'confirmation_expired';
+      }
+      final payloadHash = _payloadHash(payload);
+      if (issued.payloadHash != payloadHash) {
+        return 'confirmation_invalid';
+      }
       await _store.delete(token);
-      return 'confirmation_expired';
+      _consumed.add(token);
+      return null;
+    } finally {
+      _redeemInFlight = false;
     }
-    final payloadHash = _payloadHash(payload);
-    if (issued.payloadHash != payloadHash) {
-      return 'confirmation_invalid';
-    }
-    await _store.delete(token);
-    _consumed.add(token);
-    return null;
   }
 
   String confirmationHashFor({

--- a/packages/feature_mind/test/addons/addon_barrier_lifecycle_test.dart
+++ b/packages/feature_mind/test/addons/addon_barrier_lifecycle_test.dart
@@ -1,0 +1,328 @@
+import 'package:core_ai/core_ai.dart';
+import 'package:core_domain/core_domain.dart';
+import 'package:feature_mind/src/addons/addon_lifecycle_gate.dart';
+import 'package:feature_mind/src/addons/built_in_addon_registry.dart';
+import 'package:feature_mind/src/addons/draft_diet_plan/draft_diet_plan_adapter.dart';
+import 'package:feature_mind/src/addons/graph_workflow/graph_workflow_coordinator.dart';
+import 'package:feature_mind/src/addons/graph_workflow/insurance_planner_graph_adapter.dart';
+import 'package:feature_mind/src/agent_chat/data/connectors/life_track_record_connector.dart';
+import 'package:feature_mind/src/agent_chat/data/repositories/chat_entity_graph_session.dart';
+import 'package:feature_mind/src/agent_chat/domain/models/chat_entity_graph.dart';
+import 'package:feature_mind/src/agent_chat/data/services/assistant_chat_context_builder.dart';
+import 'package:feature_mind/src/agent_chat/domain/services/lifetrack_confirmation_token_service.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+class _MockLifeTrackRepository extends Mock implements LifeTrackRepository {}
+
+class _ProjectionSpyAdapter implements GraphWorkflowAddonAdapter {
+  _ProjectionSpyAdapter(
+    this.id, {
+    this.onProject,
+    this.onAssess,
+  });
+
+  final AddonId id;
+  final void Function()? onProject;
+  final void Function()? onAssess;
+  int projectCalls = 0;
+  int assessCalls = 0;
+
+  @override
+  AddonIdentity get identity => AddonIdentity(id: id, version: '1.0.0');
+
+  @override
+  bool accepts(GraphIngestContext input) => true;
+
+  @override
+  Future<EntityGraphPatch> extract(GraphIngestContext input) async =>
+      const EntityGraphPatch();
+
+  @override
+  Iterable<WorkflowProjection> project(EntityGraph graph) {
+    projectCalls++;
+    onProject?.call();
+    return [
+      WorkflowProjection(
+        identity: identity,
+        subjectNodeId: 'node-${id.value}',
+        destinationKind: 'lifetrack',
+        templateId: 'spy_template_v1',
+        templateVersion: '1',
+        title: 'Spy journey',
+        factsByFieldId: {},
+        identityKey: 'spy-${id.value}',
+        offer: const OfferDecision(
+          kind: OfferDecisionKind.offerable,
+          reason: 'test',
+        ),
+      ),
+    ];
+  }
+
+  @override
+  PendingAssessment assessPending(
+    EntityGraph graph,
+    WorkflowProjection projection,
+  ) {
+    assessCalls++;
+    onAssess?.call();
+    return PendingAssessment(
+      identity: identity,
+      subjectNodeId: projection.subjectNodeId,
+      storedFacts: {},
+      missingRequired: ['Claim ID'],
+      missingOptional: [],
+    );
+  }
+}
+
+void main() {
+  setUpAll(() {
+    registerFallbackValue(
+      LifeTrack(
+        id: 'fallback',
+        title: 'fallback',
+        category: LifeTrackCategory.insurance,
+        status: TrackStatus.active,
+        milestones: const [],
+        createdAt: DateTime.utc(2026),
+        updatedAt: DateTime.utc(2026),
+        templateId: 'insurance_claim_v1',
+      ),
+    );
+  });
+
+  setUp(() {
+    AddonInvocationEpoch.instance.resetForTesting();
+  });
+
+  test('revoke during projection skips remaining adapters', () {
+    final registry = AddonRegistry();
+    final first = _ProjectionSpyAdapter(
+      AddonId('projection-first'),
+      onProject: () => AddonInvocationEpoch.instance.bump(),
+    );
+    final second = _ProjectionSpyAdapter(AddonId('projection-second'));
+    for (final spy in [first, second]) {
+      registry.registerBuiltIn(
+        manifest: AddonManifest.fromJson({
+          'schema_version': '1.0',
+          'id': spy.identity.id.value,
+          'version': '1.0.0',
+          'behaviors': ['graph_workflow'],
+          'capabilities': ['conversation.current_turn'],
+          'tools': [],
+          'adapter': {
+            'kind': 'required_built_in',
+            'contract': 'graph_workflow_v1',
+          },
+          'workflow': {'subject_kind': 'spy'},
+        }),
+        graphAdapter: spy,
+      );
+      BuiltInAddonRegistry.updateEligibility(
+        registry,
+        spy.identity.id.value,
+        const AddonEligibility(
+          enabled: true,
+          grantedScopes: {'conversation.current_turn'},
+        ),
+      );
+    }
+
+    final coordinator = GraphWorkflowCoordinator(registry);
+    final projections = coordinator.workflowProjections(ChatEntityGraph.empty);
+
+    expect(first.projectCalls, 1);
+    expect(second.projectCalls, 0);
+    expect(projections.length, 1);
+  });
+
+  test('revoke during pending assessment skips remaining adapters', () {
+    final registry = AddonRegistry();
+    final first = _ProjectionSpyAdapter(
+      AddonId('pending-first'),
+      onAssess: () => AddonInvocationEpoch.instance.bump(),
+    );
+    final second = _ProjectionSpyAdapter(AddonId('pending-second'));
+    for (final spy in [first, second]) {
+      registry.registerBuiltIn(
+        manifest: AddonManifest.fromJson({
+          'schema_version': '1.0',
+          'id': spy.identity.id.value,
+          'version': '1.0.0',
+          'behaviors': ['graph_workflow'],
+          'capabilities': ['conversation.current_turn'],
+          'tools': [],
+          'adapter': {
+            'kind': 'required_built_in',
+            'contract': 'graph_workflow_v1',
+          },
+          'workflow': {'subject_kind': 'spy'},
+        }),
+        graphAdapter: spy,
+      );
+      BuiltInAddonRegistry.updateEligibility(
+        registry,
+        spy.identity.id.value,
+        const AddonEligibility(
+          enabled: true,
+          grantedScopes: {'conversation.current_turn'},
+        ),
+      );
+    }
+
+    final coordinator = GraphWorkflowCoordinator(registry);
+    final assessments = coordinator.pendingAssessments(ChatEntityGraph.empty);
+
+    expect(first.assessCalls, 1);
+    expect(second.assessCalls, 0);
+    expect(assessments.length, 1);
+  });
+
+  test('revoked generative add-on returns no plan and cancels stale review',
+      () {
+    final builtIn = BuiltInAddonRegistry.create();
+    final history = [
+      const AssistantChatContextMessage(
+        text: 'Make me a 7 day vegetarian diet plan',
+        isUser: true,
+      ),
+    ];
+    final plan = builtIn.coordinator.planFor(
+      currentPrompt: 'Make me a 7 day vegetarian diet plan',
+      history: history,
+    );
+    expect(plan, isNotNull);
+
+    BuiltInAddonRegistry.updateEligibility(
+      builtIn.registry,
+      DraftDietPlanAdapter.addonId,
+      const AddonEligibility(enabled: false),
+    );
+
+    expect(
+      builtIn.coordinator.planFor(
+        currentPrompt: 'Make me a 7 day vegetarian diet plan',
+        history: history,
+      ),
+      isNull,
+    );
+
+    final review = builtIn.coordinator.reviewOutput(
+      plan: plan!,
+      output: "Day 1: oats",
+      alreadyRetried: false,
+    );
+    expect(review.invalid, isTrue);
+    expect(review.output, contains('disabled'));
+  });
+
+  test('revoke clears session graph and blocks new ingest projections', () async {
+    final builtIn = BuiltInAddonRegistry.create();
+    final session = ChatEntityGraphSession(
+      graphCoordinator: builtIn.graphCoordinator,
+    );
+    session.bindConversation('chat-revoke');
+    await session.ingest(
+      'Niva Bupa Claim ID 9001001 via Policybazaar. All documents received.',
+    );
+    expect((await session.ensureLoaded()).nodes, isNotEmpty);
+
+    BuiltInAddonRegistry.updateEligibility(
+      builtIn.registry,
+      InsurancePlannerGraphAdapter.addonId,
+      const AddonEligibility(enabled: false, revoked: true),
+    );
+    AddonLifecycleGate(graphSession: session).onEligibilityChanged(
+      const AddonEligibility(enabled: false, revoked: true),
+    );
+
+    expect(session.graph.nodes, isEmpty);
+    await session.ingest('Another claim ABC999');
+    expect(builtIn.graphCoordinator.workflowProjections(session.graph), isEmpty);
+  });
+
+  test('insurance pipeline ingest projection pending confirm save', () async {
+    final builtIn = BuiltInAddonRegistry.create();
+    final ingest = await builtIn.graphCoordinator.ingestWithAddonPatches(
+      ChatEntityGraph.empty,
+      'Niva Bupa Claim ID 9001001 via Policybazaar. All documents received.',
+    );
+    expect(ingest.cancelled, isFalse);
+    expect(ingest.graph.nodes, isNotEmpty);
+
+    final projections = builtIn.graphCoordinator.workflowProjections(
+      ingest.graph,
+    );
+    expect(projections, isNotEmpty);
+
+    final pending = builtIn.graphCoordinator.formatPending(
+      graph: ingest.graph,
+      query: 'what is still missing on my claim?',
+    );
+    expect(pending.toLowerCase(), contains('not on the graph yet'));
+
+    final repository = _MockLifeTrackRepository();
+    when(() => repository.listTracks()).thenAnswer(
+      (_) async => const Ok(<LifeTrack>[]),
+    );
+    when(() => repository.createTrack(any())).thenAnswer(
+      (invocation) async => Ok(invocation.positionalArguments[0] as LifeTrack),
+    );
+
+    final tokens = LifeTrackConfirmationTokenService(
+      now: () => DateTime.utc(2026, 8, 22),
+    );
+    final connector = LifeTrackRecordConnector(
+      repository: repository,
+      resolveTemplate: (_) async => _pipelineTemplate,
+      confirmationTokens: tokens,
+      newTrackId: () => 'lt-pipeline-1',
+    );
+
+    final preview = await connector.execute({
+      'title': 'Niva claim',
+      'template_id': 'insurance_claim_v1',
+      'facts': {'Claim ID': '9001001'},
+    });
+    expect(preview.errorCode, 'confirmation_required');
+    final token = preview.data['confirmation_token'] as String;
+
+    final saved = await connector.execute({
+      'title': 'Niva claim',
+      'template_id': 'insurance_claim_v1',
+      'facts': {'Claim ID': '9001001'},
+      'confirmation_token': token,
+    });
+    expect(saved.isError, isFalse);
+    verify(() => repository.createTrack(any())).called(1);
+  });
+}
+
+const _pipelineTemplate = LifeTrackTemplate(
+  templateId: 'insurance_claim_v1',
+  title: 'Insurance Claim Tracking Template',
+  description: 'Test',
+  category: LifeTrackCategory.insurance,
+  version: '1.1',
+  milestones: [
+    MilestoneTemplate(
+      name: 'Phase 1',
+      objective: 'Record',
+      tasks: [
+        ActionItemTemplate(
+          summary: 'Record claim',
+          requirements: [
+            InputRequirementTemplate(
+              label: 'Claim ID',
+              type: FieldType.text,
+              isRequired: true,
+            ),
+          ],
+        ),
+      ],
+    ),
+  ],
+);

--- a/packages/feature_mind/test/addons/confirmation_threat_matrix_test.dart
+++ b/packages/feature_mind/test/addons/confirmation_threat_matrix_test.dart
@@ -131,4 +131,55 @@ void main() {
       AddonInvocationEpoch.cancelledCode,
     );
   });
+
+  test('expiry boundary rejects redemption after ttl', () async {
+    final now = DateTime.utc(2026, 8, 22, 12, 0);
+    final sharedStore = InMemoryConfirmationTokenStore();
+    final issuer = LifeTrackConfirmationTokenService(
+      store: sharedStore,
+      now: () => now,
+      ttl: const Duration(minutes: 15),
+    );
+    final edgeToken = await issuer.issue(
+      destinationTool: 'record_lifetrack_facts',
+      payload: payload,
+    );
+    final redeemer = LifeTrackConfirmationTokenService(
+      store: sharedStore,
+      now: () => now.add(const Duration(minutes: 15, seconds: 1)),
+      ttl: const Duration(minutes: 15),
+    );
+    expect(
+      await redeemer.validateAndConsume(
+        token: edgeToken,
+        destinationTool: 'record_lifetrack_facts',
+        payload: payload,
+      ),
+      'confirmation_expired',
+    );
+  });
+
+  test('concurrent redemption allows only one success', () async {
+    final token = await service.issue(
+      destinationTool: 'record_lifetrack_facts',
+      payload: payload,
+    );
+    final results = await Future.wait([
+      service.validateAndConsume(
+        token: token,
+        destinationTool: 'record_lifetrack_facts',
+        payload: payload,
+      ),
+      service.validateAndConsume(
+        token: token,
+        destinationTool: 'record_lifetrack_facts',
+        payload: payload,
+      ),
+    ]);
+    expect(results.where((code) => code == null).length, 1);
+    expect(
+      results.where((code) => code == 'confirmation_consumed').length,
+      1,
+    );
+  });
 }

--- a/packages/feature_mind/test/agent_chat/domain/services/chat_entity_graph_projector_test.dart
+++ b/packages/feature_mind/test/agent_chat/domain/services/chat_entity_graph_projector_test.dart
@@ -1,5 +1,5 @@
 import 'package:feature_mind/src/agent_chat/domain/models/chat_entity_graph.dart';
-import 'package:feature_mind/src/agent_chat/domain/services/chat_entity_graph_projector.dart';
+import 'package:feature_mind/src/addons/graph_workflow/legacy_chat_entity_graph_projector.dart';
 import 'package:feature_mind/src/agent_chat/domain/services/chat_entity_linker.dart';
 import 'package:flutter_test/flutter_test.dart';
 

--- a/packages/feature_mind/test/agent_chat/fixtures/characterization_generate_test.dart
+++ b/packages/feature_mind/test/agent_chat/fixtures/characterization_generate_test.dart
@@ -4,7 +4,7 @@ import 'dart:io';
 import 'package:feature_mind/src/agent_chat/data/services/assistant_chat_context_builder.dart';
 import 'package:feature_mind/src/agent_chat/data/services/diet_plan_plugin_prompt.dart';
 import 'package:feature_mind/src/agent_chat/domain/models/chat_entity_graph.dart';
-import 'package:feature_mind/src/agent_chat/domain/services/chat_entity_graph_projector.dart';
+import 'package:feature_mind/src/addons/graph_workflow/legacy_chat_entity_graph_projector.dart';
 import 'package:feature_mind/src/agent_chat/domain/services/chat_entity_linker.dart';
 import 'package:flutter_test/flutter_test.dart';
 

--- a/packages/feature_mind/test/agent_chat/fixtures/characterization_test.dart
+++ b/packages/feature_mind/test/agent_chat/fixtures/characterization_test.dart
@@ -5,7 +5,7 @@ import 'package:feature_mind/src/agent_chat/data/services/assistant_chat_context
 import 'package:feature_mind/src/agent_chat/data/services/diet_plan_plugin_prompt.dart';
 import 'package:feature_mind/src/agent_chat/domain/models/chat_entity_graph.dart';
 import 'package:feature_mind/src/agent_chat/domain/models/entity_graph_bridge.dart';
-import 'package:feature_mind/src/agent_chat/domain/services/chat_entity_graph_projector.dart';
+import 'package:feature_mind/src/addons/graph_workflow/legacy_chat_entity_graph_projector.dart';
 import 'package:feature_mind/src/agent_chat/domain/services/chat_entity_linker.dart';
 import 'package:flutter_test/flutter_test.dart';
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Final add-on framework slice to close the GA thread: barrier lifecycle coverage, application wiring, and pipeline integration tests.

### Lifecycle wiring (application paths)

- **`GraphWorkflowCoordinator`** — invocation-epoch guards on projection and pending assessment loops
- **`GenerativeAddonCoordinator`** — snapshots epoch on `planFor`; `reviewOutput` rejects stale plans after revoke
- **`AddonLifecycleGate`** — bumps invocation epoch on explicit `revoked` eligibility
- **`LifeTrackConfirmationTokenService`** — in-flight guard so concurrent redemption yields exactly one success

### Tests (48 addon tests passing)

- **`addon_barrier_lifecycle_test.dart`** — projection/pending epoch races, generative revoke, session clear, full insurance pipeline (ingest → projection → pending → confirm → save)
- **`confirmation_threat_matrix_test.dart`** — TTL expiry boundary, concurrent redemption
- Characterization tests import `legacy_chat_entity_graph_projector` directly

### Verification

```bash
cd packages/feature_mind && flutter test test/addons/
cd packages/feature_mind && flutter test test/architecture/addon_framework_gate_test.dart
cd packages/feature_mind && flutter test test/agent_chat/fixtures/characterization_test.dart
```

### Still manual (post-merge dev testing)

- Host UI walkthrough per behavior family (install/enable/pin/confirm/disable)
- Car/university/diet golden matrices beyond current characterization fixtures
- Widget-level preview/confirmation a11y (orchestrator + connector paths covered in unit tests)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3cb72c1f-40c3-40b6-938b-70e7592345dd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3cb72c1f-40c3-40b6-938b-70e7592345dd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

