### PR TITLE
fix(tv): make BACK dismiss shell overlays and close them on playback

### DIFF
--- a/app/lib/core/app/tv_shell.dart
+++ b/app/lib/core/app/tv_shell.dart
@@ -143,14 +143,33 @@ class _TvShellState extends ConsumerState<TvShell> {
       ],
     );
 
-    return Scaffold(
-      body: isPlayerFullscreen
-          ? body
-          : Padding(
-              key: const Key('tv-title-safe-inset'),
-              padding: tvTitleSafeInsets(MediaQuery.sizeOf(context)),
-              child: body,
-            ),
+    // BACK must return to the previous screen, which for an overlay means
+    // dismissing it — both store review guidelines require this. Without
+    // this gate the key falls through to `IPTVScreen.didPopRoute`, which
+    // either closes the app outright or (in ten-foot mode after any prior
+    // fullscreen session) swallows it, stranding the user in Settings with
+    // only D-pad LEFT to the rail as an escape.
+    //
+    // Fullscreen playback is deliberately exempt: there BACK means "leave
+    // fullscreen", which is `IPTVScreen`'s job, and the overlay is not
+    // painted anyway.
+    final overlayHandlesBack = _overlay != null && !isPlayerFullscreen;
+
+    return PopScope(
+      canPop: !overlayHandlesBack,
+      onPopInvokedWithResult: (didPop, _) {
+        if (didPop) return;
+        _closeOverlay();
+      },
+      child: Scaffold(
+        body: isPlayerFullscreen
+            ? body
+            : Padding(
+                key: const Key('tv-title-safe-inset'),
+                padding: tvTitleSafeInsets(MediaQuery.sizeOf(context)),
+                child: body,
+              ),
+      ),
     );
   }
 
@@ -234,8 +253,13 @@ class _TvShellState extends ConsumerState<TvShell> {
         overrideFormFactor: AiroFormFactor.tv,
         onChannelSelected: _closeOverlay,
       ),
-      _TvOverlayScreen.vod => const VodTvScreen(),
-      _TvOverlayScreen.favorites => const TvFavoritesScreen(),
+      // Both start playback on the retained live surface underneath, so they
+      // have to dismiss themselves the same way the guide does — otherwise
+      // the user hears audio start while still staring at the grid.
+      _TvOverlayScreen.vod => VodTvScreen(onItemSelected: _closeOverlay),
+      _TvOverlayScreen.favorites => TvFavoritesScreen(
+        onChannelSelected: _closeOverlay,
+      ),
       _TvOverlayScreen.settings => const TvSettingsScreen(),
     };
   }

--- a/app/test/core/app/tv_shell_test.dart
+++ b/app/test/core/app/tv_shell_test.dart
@@ -163,4 +163,76 @@ void main() {
       expect(liveActivations, 0);
     },
   );
+
+  testWidgets('BACK dismisses an overlay instead of closing the app', (
+    tester,
+  ) async {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: const MaterialApp(
+          home: TvShell(child: SizedBox.expand(child: Text('Live surface'))),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    final settingsRailItem = tester.widget<TvFocusable>(
+      find.ancestor(
+        of: find.text('Settings'),
+        matching: find.byType(TvFocusable),
+      ),
+    );
+    settingsRailItem.focusNode!.requestFocus();
+    await tester.pump();
+    await tester.sendKeyEvent(LogicalKeyboardKey.select);
+    await tester.pumpAndSettle();
+
+    expect(find.text('Theme'), findsOneWidget);
+
+    // `true` means the shell consumed BACK. Were it `false`, the key would
+    // fall through to IPTVScreen.didPopRoute and ultimately SystemNavigator
+    // .pop() — the store-rejecting "BACK exits the app" behaviour.
+    expect(await tester.binding.handlePopRoute(), isTrue);
+    await tester.pumpAndSettle();
+
+    expect(find.text('Theme'), findsNothing);
+    expect(find.text('Live surface'), findsOneWidget);
+    expect(container.read(tvNavigationIndexProvider), 0);
+  });
+
+  testWidgets('BACK is left to the player while fullscreen', (tester) async {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: const MaterialApp(home: TvShell(child: SizedBox.expand())),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    final settingsRailItem = tester.widget<TvFocusable>(
+      find.ancestor(
+        of: find.text('Settings'),
+        matching: find.byType(TvFocusable),
+      ),
+    );
+    settingsRailItem.focusNode!.requestFocus();
+    await tester.pump();
+    await tester.sendKeyEvent(LogicalKeyboardKey.select);
+    await tester.pumpAndSettle();
+
+    container.read(isFullscreenModeProvider.notifier).state = true;
+    await tester.pumpAndSettle();
+
+    // In fullscreen BACK means "leave fullscreen", which IPTVScreen owns.
+    // The shell must not swallow it, or exiting fullscreen would take two
+    // presses on a real remote.
+    expect(await tester.binding.handlePopRoute(), isFalse);
+  });
 }

--- a/packages/feature_iptv/lib/presentation/tv/tv_favorites_screen.dart
+++ b/packages/feature_iptv/lib/presentation/tv/tv_favorites_screen.dart
@@ -14,7 +14,12 @@ import '../widgets/channel_load_error_view.dart';
 /// Lists channels the user has favorited on TV, with a way to unfavorite
 /// and jump straight into playback. See CV-021 / issue #826.
 class TvFavoritesScreen extends ConsumerWidget {
-  const TvFavoritesScreen({super.key});
+  const TvFavoritesScreen({super.key, this.onChannelSelected});
+
+  /// Invoked after a favorite starts playing, so a shell that paints this
+  /// screen as an overlay on top of retained playback can dismiss itself
+  /// and reveal the video. Null when the screen owns the whole route.
+  final VoidCallback? onChannelSelected;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -22,9 +27,15 @@ class TvFavoritesScreen extends ConsumerWidget {
     final currentChannel = ref.watch(currentChannelProvider);
     final colorScheme = Theme.of(context).colorScheme;
 
-    return Padding(
+    // An opaque background is load-bearing, not decoration: TvShell stacks
+    // this screen over the still-mounted live channel grid, so a bare Column
+    // renders both layers' text on top of each other.
+    return AiroResponsiveScaffold(
+      overrideFormFactor: AiroFormFactor.tv,
+      useResponsiveCenter: false,
+      backgroundColor: colorScheme.surface,
       padding: const EdgeInsets.fromLTRB(32, 24, 32, 24),
-      child: Column(
+      body: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           Row(
@@ -105,6 +116,7 @@ class TvFavoritesScreen extends ConsumerWidget {
                         ref
                             .read(iptvStreamingServiceProvider)
                             .playChannel(channel);
+                        onChannelSelected?.call();
                       },
                       onSecondaryAction: () {
                         ref.read(channelFavoriteTogglerProvider)(channel.id);

--- a/packages/feature_iptv/lib/presentation/tv/vod_tv_screen.dart
+++ b/packages/feature_iptv/lib/presentation/tv/vod_tv_screen.dart
@@ -13,7 +13,12 @@ import '../widgets/vod_grid.dart';
 /// path's dark, full-bleed layout (`AiroTvShell` in `tv_ux/`) since both
 /// screens live in the same TV shell.
 class VodTvScreen extends ConsumerWidget {
-  const VodTvScreen({super.key});
+  const VodTvScreen({super.key, this.onItemSelected});
+
+  /// Invoked after an item starts playing, so a shell that paints this
+  /// screen as an overlay on top of retained playback can dismiss itself
+  /// and reveal the video. Null when the screen owns the whole route.
+  final VoidCallback? onItemSelected;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -83,6 +88,7 @@ class VodTvScreen extends ConsumerWidget {
     );
     ref.read(pendingVodHistoryItemProvider.notifier).state = item;
     ref.read(iptvStreamingServiceProvider).playChannel(syntheticChannel);
+    onItemSelected?.call();
   }
 }
 

--- a/packages/feature_iptv/test/iptv/presentation/tv/tv_favorites_screen_test.dart
+++ b/packages/feature_iptv/test/iptv/presentation/tv/tv_favorites_screen_test.dart
@@ -1,3 +1,4 @@
+import 'package:leak_tracker_flutter_testing/leak_tracker_flutter_testing.dart';
 import 'package:feature_iptv/feature_iptv.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -78,4 +79,46 @@ void main() {
 
     expect(find.textContaining('looks like'), findsNothing);
   });
+
+  testWidgets(
+    'selecting a favorite plays it and calls onChannelSelected',
+    (tester) async {
+      SharedPreferences.setMockInitialValues({});
+      final prefs = await SharedPreferences.getInstance();
+      final container = ProviderContainer(
+        overrides: [
+          sharedPreferencesProvider.overrideWithValue(prefs),
+          iptvChannelsProvider.overrideWith((ref) async => const [oldChannel]),
+          favoriteChannelsProvider.overrideWith(
+            (ref) async => const [oldChannel],
+          ),
+          streamingStateProvider.overrideWith(
+            (ref) => Stream.value(StreamingState()),
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      var closed = 0;
+      await tester.pumpWidget(
+        UncontrolledProviderScope(
+          container: container,
+          child: MaterialApp(
+            home: TvFavoritesScreen(onChannelSelected: () => closed++),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('BBC One HD'));
+      await tester.pump();
+
+      // Without this the shell keeps the favorites grid painted over the
+      // retained live surface, so playback starts behind an opaque overlay.
+      expect(closed, 1);
+    },
+    experimentalLeakTesting: LeakTesting.settings.withIgnored(
+      notDisposed: {'VideoPlayerController': null},
+    ),
+  );
 }

--- a/packages/feature_iptv/test/iptv/presentation/tv/vod_tv_screen_test.dart
+++ b/packages/feature_iptv/test/iptv/presentation/tv/vod_tv_screen_test.dart
@@ -1,3 +1,4 @@
+import 'package:leak_tracker_flutter_testing/leak_tracker_flutter_testing.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -106,5 +107,35 @@ void main() {
       );
       expect(find.text('Example Movie'), findsOneWidget);
     },
+  );
+
+  testWidgets(
+    'selecting an item plays it and calls onItemSelected',
+    (tester) async {
+      final prefs = await SharedPreferences.getInstance();
+      var closed = 0;
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            sharedPreferencesProvider.overrideWithValue(prefs),
+            iptvChannelsProvider.overrideWith((ref) async => [movie]),
+          ],
+          child: MaterialApp(home: VodTvScreen(onItemSelected: () => closed++)),
+        ),
+      );
+      await tester.pump();
+      await tester.pump();
+
+      await tester.tap(find.text('Example Movie'));
+      await tester.pump();
+
+      // Without this the shell keeps the VOD grid painted over the retained
+      // live surface, so playback starts behind an opaque overlay.
+      expect(closed, 1);
+    },
+    experimentalLeakTesting: LeakTesting.settings.withIgnored(
+      notDisposed: {'VideoPlayerController': null},
+    ),
   );
 }


### PR DESCRIPTION
## Why

Pre-release audit of the Airo TV flavor (traced from `main_tv.dart` through the reachable route/overlay graph) found three defects in the TV shell's overlay system. All three are reachable on a real Fire TV / Android TV device.

## What broke

**BACK exited the app instead of returning.** `tv_shell.dart` had no `PopScope`, `didPopRoute`, or back-key handler anywhere. The key fell through to `IPTVScreen.didPopRoute`, which either returns `false` — closing the app outright — or, in ten-foot mode after any prior fullscreen session, swallows it so BACK is simply dead. From Settings/Favorites/Movies the only escape was D-pad LEFT to the rail. **Both Amazon and Google TV review require BACK to return to the previous screen.**

**Selecting content started playback behind the overlay.** `_closeOverlay()` was wired to exactly one call site — the guide's `onChannelSelected`. `TvFavoritesScreen` and `VodTvScreen` called `playChannel(...)` and then did nothing, so the user heard audio start while still staring at the grid.

**Favorites rendered transparent.** `TvFavoritesScreen` returned a bare `Padding`/`Column` with no `Scaffold` or background. As a route it inherited `TvShell`'s Scaffold and looked fine, but as the overlay it stacked over the still-mounted live channel grid and both layers' text rendered on top of each other.

## What changed

- `TvShell` wraps its Scaffold in a `PopScope` that consumes BACK while an overlay is open. Fullscreen playback is deliberately exempt — there BACK means "leave fullscreen", which `IPTVScreen` owns, and swallowing it would cost the user two presses.
- `TvFavoritesScreen` and `VodTvScreen` take the same optional close callback `IptvGuideScreen` already had, and `TvShell` passes `_closeOverlay` to both.
- `TvFavoritesScreen` uses `AiroResponsiveScaffold` with an opaque surface, matching `VodTvScreen` and `IptvGuideScreen`.

The callbacks are optional, so the existing `/vod` and `/favorites` routes in `TvRouter` keep working unchanged.

## Tests

Four new tests. The BACK test was verified to fail without the fix (`Expected: true, Actual: <false>` — the app-exit path), and a companion test pins the fullscreen exemption so the fix can't over-reach.

- `app/test/core/app/tv_shell_test.dart` — BACK dismisses an overlay; BACK is left to the player while fullscreen
- `tv_favorites_screen_test.dart` / `vod_tv_screen_test.dart` — selecting an item plays it and fires the close callback

Green: 27 app TV tests, 35 `feature_iptv` TV tests, clean `flutter analyze` on all touched files.

> Unrelated pre-existing breakage: `app/test/core/routing/` and the `app_shell_*` suites fail to compile on a clean tree too (340 errors — `just_audio` stub missing `AudioPlayer`, stale `feature_mind` FRB codegen). Neither package is in `pubspec_tv.yaml`; not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)