### PR TITLE
fix(tv): stop reporting success for backups that were never written

### DIFF
--- a/packages/feature_iptv/lib/application/platform_backup_document_gateway.dart
+++ b/packages/feature_iptv/lib/application/platform_backup_document_gateway.dart
@@ -7,9 +7,9 @@ import 'package:platform_worker_jobs/platform_worker_jobs.dart';
 import 'package:share_plus/share_plus.dart';
 
 typedef BackupDocumentSaver =
-    Future<void> Function(AiroBackupDocument document);
+    Future<bool> Function(AiroBackupDocument document);
 typedef BackupDocumentSharer =
-    Future<void> Function(AiroBackupDocument document);
+    Future<bool> Function(AiroBackupDocument document);
 typedef BackupDocumentPicker = Future<AiroBackupDocument?> Function();
 
 class PlatformBackupDocumentGateway implements AiroBackupDocumentGateway {
@@ -24,26 +24,32 @@ class PlatformBackupDocumentGateway implements AiroBackupDocumentGateway {
   final BackupDocumentPicker picker;
 
   @override
-  Future<void> save(AiroBackupDocument document) => saver(document);
+  Future<bool> save(AiroBackupDocument document) => saver(document);
 
   @override
-  Future<void> share(AiroBackupDocument document) => sharer(document);
+  Future<bool> share(AiroBackupDocument document) => sharer(document);
 
   @override
   Future<AiroBackupDocument?> pick() => picker();
 
-  static Future<void> _save(AiroBackupDocument document) async {
-    await FilePicker.saveFile(
+  static Future<bool> _save(AiroBackupDocument document) async {
+    // A null destination means the dialog was cancelled, or — on TV, where
+    // `file_picker` is dependency-overridden to a stub — that there was
+    // never a dialog at all. Either way nothing reached disk.
+    final destination = await FilePicker.saveFile(
       dialogTitle: 'Save Airo TV backup',
       fileName: document.fileName,
       type: FileType.custom,
       allowedExtensions: const ['json'],
       bytes: Uint8List.fromList(utf8.encode(document.contents)),
     );
+    return destination != null;
   }
 
-  static Future<void> _share(AiroBackupDocument document) async {
-    await SharePlus.instance.share(
+  static Future<bool> _share(AiroBackupDocument document) async {
+    // `dismissed` and `unavailable` (the TV stub's only answer) both mean
+    // the document was not handed off.
+    final result = await SharePlus.instance.share(
       ShareParams(
         subject: 'Airo TV backup',
         files: [
@@ -55,6 +61,7 @@ class PlatformBackupDocumentGateway implements AiroBackupDocumentGateway {
         ],
       ),
     );
+    return result.status == ShareResultStatus.success;
   }
 
   static Future<AiroBackupDocument?> _pick() async {

--- a/packages/feature_iptv/lib/presentation/widgets/backup_restore_section.dart
+++ b/packages/feature_iptv/lib/presentation/widgets/backup_restore_section.dart
@@ -70,19 +70,33 @@ class _BackupRestoreSectionState extends ConsumerState<BackupRestoreSection> {
   }
 
   Future<void> _save() async {
-    await ref.read(iptvBackupDocumentControllerProvider).saveBackup();
-    _announce('Backup file saved.');
+    final saved = await ref
+        .read(iptvBackupDocumentControllerProvider)
+        .saveBackup();
+    // Never claim a write that did not happen: on TV `file_picker` is
+    // stubbed, so this always comes back false and the old unconditional
+    // success message sent users away believing they had a backup.
+    _announce(saved ? 'Backup file saved.' : 'No backup file was saved.');
   }
 
   Future<void> _share() async {
-    await ref.read(iptvBackupDocumentControllerProvider).shareBackup();
+    final shared = await ref
+        .read(iptvBackupDocumentControllerProvider)
+        .shareBackup();
+    // The share sheet is its own confirmation when it works; only the
+    // silent-failure case needs saying out loud.
+    if (!shared) _announce('The backup was not shared.');
   }
 
   Future<void> _import() async {
     final preview = await ref
         .read(iptvBackupDocumentControllerProvider)
         .pickAndPreview();
-    if (preview == null || !mounted) return;
+    if (preview == null) {
+      _announce('No backup file was selected.');
+      return;
+    }
+    if (!mounted) return;
     final confirmed = await showDialog<bool>(
       context: context,
       builder: (context) => _BackupPreviewDialog(preview: preview),

--- a/packages/feature_iptv/lib/presentation/widgets/favorites_backup_menu.dart
+++ b/packages/feature_iptv/lib/presentation/widgets/favorites_backup_menu.dart
@@ -54,7 +54,7 @@ class FavoritesBackupMenu extends ConsumerWidget {
               group: channel.group,
             ),
         ]);
-        await ref
+        final shared = await ref
             .read(iptvBackupDocumentGatewayProvider)
             .share(
               AiroBackupDocument(
@@ -63,6 +63,15 @@ class FavoritesBackupMenu extends ConsumerWidget {
                 contents: contents,
               ),
             );
+        // Silent on success — the share sheet already confirmed. On TV
+        // `share_plus` is stubbed, so without this the menu item looks
+        // like a dead control.
+        if (shared || !context.mounted) return;
+        ScaffoldMessenger.of(context)
+          ..hideCurrentSnackBar()
+          ..showSnackBar(
+            const SnackBar(content: Text('Favorites were not shared.')),
+          );
         return;
       case _FavoritesBackupAction.backupRestore:
         if (!context.mounted) return;

--- a/packages/feature_iptv/test/application/platform_backup_document_gateway_test.dart
+++ b/packages/feature_iptv/test/application/platform_backup_document_gateway_test.dart
@@ -16,16 +16,22 @@ void main() {
       final shared = <AiroBackupDocument>[];
       var pickCount = 0;
       final gateway = PlatformBackupDocumentGateway(
-        saver: (value) async => saved.add(value),
-        sharer: (value) async => shared.add(value),
+        saver: (value) async {
+          saved.add(value);
+          return true;
+        },
+        sharer: (value) async {
+          shared.add(value);
+          return true;
+        },
         picker: () async {
           pickCount++;
           return pickCount == 1 ? document : null;
         },
       );
 
-      await gateway.save(document);
-      await gateway.share(document);
+      expect(await gateway.save(document), isTrue);
+      expect(await gateway.share(document), isTrue);
 
       expect(await gateway.pick(), same(document));
       expect(await gateway.pick(), isNull);
@@ -33,4 +39,18 @@ void main() {
       expect(shared, [document]);
     },
   );
+
+  test('reports failure when the platform writes nothing', () async {
+    // The shape TV always takes: `file_picker` and `share_plus` are
+    // dependency-overridden to stubs, so neither ever completes.
+    const gateway = PlatformBackupDocumentGateway(
+      saver: _refuse,
+      sharer: _refuse,
+    );
+
+    expect(await gateway.save(document), isFalse);
+    expect(await gateway.share(document), isFalse);
+  });
 }
+
+Future<bool> _refuse(AiroBackupDocument document) async => false;

--- a/packages/feature_iptv/test/presentation/widgets/backup_restore_section_test.dart
+++ b/packages/feature_iptv/test/presentation/widgets/backup_restore_section_test.dart
@@ -107,6 +107,78 @@ void main() {
 
     expect(state.atomicWrites, 0);
     expect(find.byType(AlertDialog), findsNothing);
+    expect(find.text('No backup file was selected.'), findsOneWidget);
+  });
+
+  testWidgets('save does not claim success when nothing was written', (
+    tester,
+  ) async {
+    final state = _FakeStateStore(
+      AiroBackupSnapshot(
+        playlistSources: const [],
+        favorites: const [],
+        epgSources: const [],
+        settings: const {},
+      ),
+    );
+    final service = AiroBackupService(store: state);
+    final controller = AiroBackupDocumentController(
+      service: service,
+      // The TV build: `file_picker` is stubbed, so no file is ever written.
+      documents: _FakeDocumentGateway(null, succeeds: false),
+    );
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          iptvBackupServiceProvider.overrideWithValue(service),
+          iptvBackupDocumentControllerProvider.overrideWithValue(controller),
+        ],
+        child: const MaterialApp(home: Scaffold(body: BackupRestoreSection())),
+      ),
+    );
+
+    await tester.tap(find.byKey(const ValueKey('backup-save-button')));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Backup file saved.'), findsNothing);
+    expect(find.text('No backup file was saved.'), findsOneWidget);
+
+    await tester.tap(find.byKey(const ValueKey('backup-share-button')));
+    await tester.pumpAndSettle();
+
+    expect(find.text('The backup was not shared.'), findsOneWidget);
+  });
+
+  testWidgets('save reports success when a file really was written', (
+    tester,
+  ) async {
+    final state = _FakeStateStore(
+      AiroBackupSnapshot(
+        playlistSources: const [],
+        favorites: const [],
+        epgSources: const [],
+        settings: const {},
+      ),
+    );
+    final service = AiroBackupService(store: state);
+    final controller = AiroBackupDocumentController(
+      service: service,
+      documents: _FakeDocumentGateway(null),
+    );
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          iptvBackupServiceProvider.overrideWithValue(service),
+          iptvBackupDocumentControllerProvider.overrideWithValue(controller),
+        ],
+        child: const MaterialApp(home: Scaffold(body: BackupRestoreSection())),
+      ),
+    );
+
+    await tester.tap(find.byKey(const ValueKey('backup-save-button')));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Backup file saved.'), findsOneWidget);
   });
 
   testWidgets('favorites overflow shares a portable M3U document', (
@@ -160,19 +232,24 @@ class _FakeStateStore implements AiroBackupStateStore {
 }
 
 class _FakeDocumentGateway implements AiroBackupDocumentGateway {
-  _FakeDocumentGateway(this.document);
+  _FakeDocumentGateway(this.document, {this.succeeds = true});
 
   final AiroBackupDocument? document;
+
+  /// False models the TV build, where `file_picker` and `share_plus` are
+  /// stubbed and neither operation ever completes.
+  final bool succeeds;
   final List<AiroBackupDocument> shared = [];
 
   @override
   Future<AiroBackupDocument?> pick() async => document;
 
   @override
-  Future<void> save(AiroBackupDocument document) async {}
+  Future<bool> save(AiroBackupDocument document) async => succeeds;
 
   @override
-  Future<void> share(AiroBackupDocument document) async {
+  Future<bool> share(AiroBackupDocument document) async {
     shared.add(document);
+    return succeeds;
   }
 }

--- a/packages/platform_playlist_export/lib/src/backup_archive.dart
+++ b/packages/platform_playlist_export/lib/src/backup_archive.dart
@@ -261,11 +261,19 @@ class AiroBackupDocument {
 }
 
 abstract interface class AiroBackupDocumentGateway {
-  Future<void> save(AiroBackupDocument document);
+  /// Returns false when nothing was written, either because the user
+  /// cancelled the save dialog or because the host platform has none at
+  /// all — Android TV and Fire TV ship a stubbed `file_picker`. Callers
+  /// must not report success without checking: a backup the user believes
+  /// exists but does not is worse than a failed export.
+  Future<bool> save(AiroBackupDocument document);
 
-  Future<void> share(AiroBackupDocument document);
+  /// Returns false when the document was not handed off, either because
+  /// the user dismissed the share sheet or because the host platform has
+  /// none (TV ships a stubbed `share_plus`).
+  Future<bool> share(AiroBackupDocument document);
 
-  /// Returns null when the platform picker is cancelled.
+  /// Returns null when the platform picker is cancelled or unavailable.
   Future<AiroBackupDocument?> pick();
 }
 
@@ -278,13 +286,12 @@ class AiroBackupDocumentController {
   final AiroBackupService service;
   final AiroBackupDocumentGateway documents;
 
-  Future<void> saveBackup() async {
-    await documents.save(await _backupDocument());
-  }
+  /// False when no file was written. See [AiroBackupDocumentGateway.save].
+  Future<bool> saveBackup() async => documents.save(await _backupDocument());
 
-  Future<void> shareBackup() async {
-    await documents.share(await _backupDocument());
-  }
+  /// False when the document was not handed off. See
+  /// [AiroBackupDocumentGateway.share].
+  Future<bool> shareBackup() async => documents.share(await _backupDocument());
 
   Future<AiroBackupPreview?> pickAndPreview() async {
     final document = await documents.pick();


### PR DESCRIPTION
## Why

Second fix from the pre-release Airo TV audit. Blocker: the backup flow told users their data was saved when nothing had been written.

## What broke

`AiroBackupDocumentGateway.save` and `.share` returned `Future<void>`, so neither the controller nor the UI could distinguish a completed write from one that never happened. `BackupRestoreSection._save` announced `"Backup file saved."` unconditionally.

On TV that message is **always** a lie. `file_picker` and `share_plus` are both dependency-overridden to stubs in `app/pubspec_tv.yaml`, so `FilePicker.saveFile` returns `null` and `SharePlus.share` returns `ShareResultStatus.unavailable`. The flow is fully reachable on a real device — Favorites → overflow → "Backup and restore" — and it sent users away believing they had a backup file that does not exist. Share and Import gave no feedback whatsoever, so both read as dead controls.

The same bug affects **phone** builds on a plain cancel: dismissing the save dialog also reported success.

## What changed

- `save` and `share` now return whether the document actually reached its destination. `AiroBackupDocumentController.saveBackup`/`shareBackup` propagate it.
- `BackupRestoreSection` reports `"No backup file was saved."` instead of claiming a write, says so when a share doesn't go through, and no longer returns silently when the picker yields nothing.
- The favorites overflow's "Share favorites as M3U" reports the same way instead of being a silent no-op.

## Tests

- `save does not claim success when nothing was written` — models the TV build (gateway refuses); asserts the old message is **absent** and the honest one present, for both save and share.
- `save reports success when a file really was written` — pins the success path so the fix can't collapse into always reporting failure.
- `picker cancellation` now also asserts the user is told.
- Gateway-level `reports failure when the platform writes nothing`.

Green: 868 `feature_iptv` tests, 11 `platform_playlist_export` tests, clean analyze on both packages.

## Note

Wording is deliberately neutral ("No backup file was saved") rather than "not supported on this device": `file_picker` gives no signal that distinguishes a stub from a user cancellation. Telling TV users the feature will never work there is a follow-up — it needs a capability flag on the gateway, which is a wider change than a release-cut fix should carry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)