### PR TITLE
fix(tv): report the real build version in TV settings

### DIFF
--- a/app/test/core/tv_stub_version_test.dart
+++ b/app/test/core/tv_stub_version_test.dart
@@ -1,0 +1,81 @@
+@TestOn('vm')
+library;
+
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// Airo TV overrides `package_info_plus` with a stub (see the
+/// `dependency_overrides` block in `app/pubspec_tv.yaml`), so on TV the
+/// "App version" row is served by hardcoded constants rather than the real
+/// `versionName`/`versionCode` Gradle stamps into the APK.
+///
+/// Gradle takes both from whichever pubspec Flutter was pointed at
+/// (`versionCode = flutter.versionCode` in `app/android/app/build.gradle.kts`),
+/// so the stub is only truthful while its fallbacks equal `pubspec_tv.yaml`.
+/// They did not: the stub said `0.0.2 (2)` against a real `0.0.7-preview+12`
+/// build, which is exactly the value support would triage against.
+///
+/// This test reads both files as text rather than importing the stub —
+/// the app package resolves `package_info_plus` to the real plugin, so the
+/// stub is not importable from here.
+void main() {
+  test('TV package_info stub reports the version pubspec_tv.yaml ships', () {
+    final pubspec = File('pubspec_tv.yaml');
+    final stub = File(
+      '../packages/stubs/package_info_plus_stub/lib/package_info_plus.dart',
+    );
+    expect(
+      pubspec.existsSync() && stub.existsSync(),
+      isTrue,
+      reason:
+          'Run from the app/ package root. Looked for ${pubspec.absolute.path} '
+          'and ${stub.absolute.path}.',
+    );
+
+    // e.g. `version: 0.0.7-preview+12`
+    final declared = RegExp(
+      r'^version:\s*(\S+?)\+(\S+)\s*$',
+      multiLine: true,
+    ).firstMatch(pubspec.readAsStringSync());
+    expect(
+      declared,
+      isNotNull,
+      reason:
+          'pubspec_tv.yaml has no `version: <name>+<build>` line to check '
+          'the stub against.',
+    );
+
+    final source = stub.readAsStringSync();
+    String constant(String name) {
+      final match = RegExp(
+        "const String $name = '([^']*)';",
+      ).firstMatch(source);
+      expect(
+        match,
+        isNotNull,
+        reason:
+            'Could not find $name in the stub. If its shape changed, update '
+            'this test rather than deleting it — it is the only thing keeping '
+            'the TV version string honest.',
+      );
+      return match!.group(1)!;
+    }
+
+    expect(
+      constant('_stubVersion'),
+      declared!.group(1),
+      reason:
+          'pubspec_tv.yaml ships version ${declared.group(1)} but the TV '
+          'package_info stub reports a different one, so Settings -> App '
+          'version will mislead support.',
+    );
+    expect(
+      constant('_stubBuildNumber'),
+      declared.group(2),
+      reason:
+          'pubspec_tv.yaml ships build ${declared.group(2)} but the TV '
+          'package_info stub reports a different one.',
+    );
+  });
+}

--- a/packages/stubs/package_info_plus_stub/lib/package_info_plus.dart
+++ b/packages/stubs/package_info_plus_stub/lib/package_info_plus.dart
@@ -1,5 +1,21 @@
 /// Stub implementation of package_info_plus for lean TV builds.
+///
+/// This stub has no platform channel, so it cannot read the real
+/// `versionName`/`versionCode` Gradle stamps into the APK. It reports what
+/// the build *would* have stamped instead, which only stays true if these
+/// values track `app/pubspec_tv.yaml` — Gradle takes `versionCode` and
+/// `versionName` straight from the pubspec Flutter was pointed at.
+///
+/// Drift here is not cosmetic: the only consumer is `AppInfoTile`, whose
+/// entire purpose is telling support which build a user is on. It reported
+/// `0.0.2 (2)` against a real `0.0.7-preview+12` APK until this was fixed.
+/// `app/test/core/tv_stub_version_test.dart` fails if they diverge again.
 library;
+
+/// Kept equal to the `version:` field of `app/pubspec_tv.yaml`, which is
+/// `<_stubVersion>+<_stubBuildNumber>`.
+const String _stubVersion = '0.0.7-preview';
+const String _stubBuildNumber = '12';
 
 class PackageInfo {
   PackageInfo({
@@ -19,9 +35,11 @@ class PackageInfo {
     return _fromPlatform ??
         PackageInfo(
           appName: 'Airo TV',
+          // Matches `variantApplicationId` for the "tv" variant in
+          // app/android/app/build.gradle.kts.
           packageName: 'io.airo.app.tv',
-          version: '0.0.2',
-          buildNumber: '2',
+          version: _stubVersion,
+          buildNumber: _stubBuildNumber,
         );
   }
 


### PR DESCRIPTION
## Why

Third fix from the pre-release Airo TV audit. Settings → **App version** showed `0.0.2 (2)` on a build that actually ships `0.0.7-preview+12`.

## What broke

Airo TV overrides `package_info_plus` with a stub (`app/pubspec_tv.yaml` `dependency_overrides`). The stub has no platform channel, so it cannot read the `versionName`/`versionCode` that Gradle stamps into the APK — it returns hardcoded constants instead, and those had drifted.

Gradle takes both fields straight from whichever pubspec Flutter was pointed at:

```kotlin
versionCode = flutter.versionCode
versionName = flutter.versionName
```

…so the stub's constants are only truthful while they track `pubspec_tv.yaml`. Nothing enforced that, and they diverged.

`AppInfoTile`'s docstring states its purpose plainly — *"useful when a user is reporting a bug and support needs to know exactly which build they're on."* A wrong value there is worse than no value, and worst at a release cut with several builds in flight.

## What changed

- Corrected the constants to `0.0.7-preview` / `12`, and named them so the link to `pubspec_tv.yaml` is explicit.
- Added `app/test/core/tv_stub_version_test.dart`, which parses `pubspec_tv.yaml` and the stub source and fails if they diverge again. **Verified by re-introducing the old `0.0.2` value** — the test catches it with a message naming the consequence.
- Documented that `packageName: 'io.airo.app.tv'` matches `variantApplicationId` for the `tv` variant in `build.gradle.kts` (this part was already correct).

The test reads both files as text rather than importing the stub: the app package resolves `package_info_plus` to the real plugin, so the stub isn't importable from an app test.

## Not done here

**Not un-stubbing the plugin.** That would fix the class of bug rather than the instance, but the neighbouring `wakelock_plus` override is documented as a *"KGP-free Android implementation"*, which suggests these overrides may be load-bearing for the TV Gradle setup. Swapping a native plugin back into a release candidate isn't a release-cut change — worth revisiting after the cut.

**No `--dart-define` injection.** I drafted the constants as `String.fromEnvironment` so a build could inject real values, but the repo lints `do_not_use_environment`, and no build passes such a define today. Dropped it as speculative; the drift test is the real guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)