### PR TITLE
fix(tv): hide the guide reminder button where it cannot work

### DIFF
--- a/packages/feature_iptv/lib/presentation/tv/iptv_guide_screen.dart
+++ b/packages/feature_iptv/lib/presentation/tv/iptv_guide_screen.dart
@@ -163,7 +163,13 @@ class _IptvGuideScreenState extends ConsumerState<IptvGuideScreen> {
             ),
           );
         case EpgReminderOutcome.unavailable:
-          break;
+          // Unreachable while the button is gated on the gateway above, but
+          // a reminder that cannot be set must never fail silently.
+          ScaffoldMessenger.of(context).showSnackBar(
+            const SnackBar(
+              content: Text('Reminders are not available on this device.'),
+            ),
+          );
       }
     } finally {
       _reminderOperationsInFlight.remove(programId);
@@ -176,6 +182,15 @@ class _IptvGuideScreenState extends ConsumerState<IptvGuideScreen> {
     required VoidCallback onWatchNow,
   }) async {
     final scheduler = ref.read(epgReminderSchedulerProvider);
+    // Without a notification gateway `scheduleReminder` can only answer
+    // `unavailable`, so the button would be a control that silently does
+    // nothing. That is the permanent state on TV: `main_tv.dart` never
+    // overrides `epgReminderNotificationGatewayProvider` (only the phone
+    // entrypoint does), and the TV flavor stubs `flutter_local_notifications`
+    // anyway, so there is nothing to wire it to.
+    final canScheduleReminders = ref
+        .read(epgReminderNotificationGatewayProvider)
+        .isAvailable;
     final isReminded = await scheduler.isReminded(program.programId);
     if (!mounted) return;
     await showDialog<void>(
@@ -188,7 +203,9 @@ class _IptvGuideScreenState extends ConsumerState<IptvGuideScreen> {
           Navigator.of(dialogContext).pop();
           onWatchNow();
         },
-        onToggleReminder: program.startsAt.isAfter(DateTime.now().toUtc())
+        onToggleReminder:
+            canScheduleReminders &&
+                program.startsAt.isAfter(DateTime.now().toUtc())
             ? () {
                 Navigator.of(dialogContext).pop();
                 unawaited(_toggleReminder(channel, program));

--- a/packages/feature_iptv/test/iptv/presentation/tv/iptv_guide_screen_test.dart
+++ b/packages/feature_iptv/test/iptv/presentation/tv/iptv_guide_screen_test.dart
@@ -1,6 +1,8 @@
 import 'package:leak_tracker_flutter_testing/leak_tracker_flutter_testing.dart';
 import 'package:core_entitlements/core_entitlements.dart';
 import 'package:core_ui/core_ui.dart';
+import 'package:feature_iptv/application/epg_reminder_scheduler.dart';
+import 'package:feature_iptv/application/providers/epg_reminder_providers.dart';
 import 'package:feature_iptv/application/providers/guide_providers.dart';
 import 'package:feature_iptv/application/providers/iptv_providers.dart';
 import 'package:feature_iptv/application/providers/richer_context_providers.dart';
@@ -43,6 +45,7 @@ void main() {
     TextScaler textScaler = TextScaler.noScaling,
     CompactEpgProgram? guideProgram,
     RicherContextProvider? richerContextProvider,
+    bool remindersAvailable = false,
   }) async {
     if (richerContextProvider != null) {
       SharedPreferences.setMockInitialValues({
@@ -59,6 +62,10 @@ void main() {
       ProviderScope(
         overrides: [
           sharedPreferencesProvider.overrideWithValue(prefs),
+          if (remindersAvailable)
+            epgReminderNotificationGatewayProvider.overrideWithValue(
+              const _AvailableReminderGateway(),
+            ),
           if (richerContextProvider != null) ...[
             richerContextEntitlementsProvider.overrideWithValue(
               const LaunchPromoEntitlements(),
@@ -183,8 +190,34 @@ void main() {
     expect(find.text('Rating: PG'), findsOneWidget);
     expect(find.text('NEW'), findsOneWidget);
     expect(find.text('Watch now'), findsOneWidget);
-    expect(find.text('Set reminder'), findsOneWidget);
     expect(find.text('City News Live'), findsOneWidget);
+
+    // No notification gateway is wired here, which is the permanent state on
+    // TV. Offering the button anyway gave users a control that silently did
+    // nothing: `scheduleReminder` can only answer `unavailable`.
+    expect(find.text('Set reminder'), findsNothing);
+  });
+
+  testWidgets('programme details offer a reminder once a gateway exists', (
+    tester,
+  ) async {
+    final start = DateTime.now().toUtc().add(const Duration(hours: 1));
+    await pumpScreen(
+      tester,
+      overrideFormFactor: AiroFormFactor.tv,
+      remindersAvailable: true,
+      guideProgram: CompactEpgProgram(
+        programId: 'rich-program',
+        title: 'The Big Match',
+        startsAt: start,
+        endsAt: start.add(const Duration(hours: 1)),
+      ),
+    );
+
+    await tester.tap(find.text('The Big Match'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Set reminder'), findsOneWidget);
   });
 
   testWidgets('programme enrichment is lazy and appears in details', (
@@ -340,4 +373,28 @@ final class _RecordingRicherContextProvider implements RicherContextProvider {
   Future<AttributedSportsDeskRow?> fetchSportsFixtures(
     SportsFixturesRequest request,
   ) async => null;
+}
+
+/// Stands in for the platform notification gateway the phone entrypoint
+/// wires up, so the reminder button's enabled path stays covered.
+class _AvailableReminderGateway implements EpgReminderNotificationGateway {
+  const _AvailableReminderGateway();
+
+  @override
+  bool get isAvailable => true;
+
+  @override
+  Future<bool> requestPermission() async => true;
+
+  @override
+  Future<void> schedule({
+    required int notificationId,
+    required String title,
+    required String body,
+    required DateTime at,
+    required String payloadChannelId,
+  }) async {}
+
+  @override
+  Future<void> cancel(int notificationId) async {}
 }


### PR DESCRIPTION
## Why

Fourth fix from the pre-release Airo TV audit. The guide's **Set reminder** button is reachable on TV and does nothing at all.

## What broke

Programme details offered "Set reminder" for any future programme. Scheduling one requires a notification gateway; without it `EpgReminderScheduler.scheduleReminder` can only return `EpgReminderOutcome.unavailable`, which the screen handled with a bare `break` — no snackbar, no state change, nothing.

That's the permanent state on TV:

- only `app/lib/core/app/main_provider_overrides.dart` (the phone entrypoint) overrides `epgReminderNotificationGatewayProvider`; `main_tv.dart` never does, so it falls back to `UnavailableEpgReminderNotificationGateway`
- the TV flavor stubs `flutter_local_notifications` anyway, so there is nothing to wire it to

The button is fully reachable there from `EpgTimelineGrid.onProgramSelect`, so a TV user pressing OK on it got no feedback whatsoever.

## What changed

`ProgrammeDetailsDialog` already hid the action when `onToggleReminder` was null, so the fix is to pass null when the gateway reports unavailable — alongside the existing "programme already started" case.

Also replaced the `unavailable` no-op with a message. It's unreachable while the button is gated, but a reminder that can't be set must not fail silently if another caller appears.

**Hiding rather than wiring** is deliberate: with `flutter_local_notifications` stubbed there is no gateway to wire, and swapping a native plugin into the TV build isn't a release-cut change.

## Tests

The existing `TV programme selection opens rich details before playback` asserted `find.text('Set reminder')` was present — it had encoded the bug, and failed against this fix. It now asserts the button is **absent** when no gateway exists.

Added `programme details offer a reminder once a gateway exists`, which pumps through a fake available gateway, so the fix can't collapse into hiding the button unconditionally and break the phone path.

Green: 866 `feature_iptv` tests, clean analyze.

🤖 Generated with [Claude Code](https://claude.com/claude-code)