### PR TITLE
docs(release): stable v0.0.7 freeze spec and cut plan

### DIFF
--- a/docs/superpowers/plans/2026-08-30-airo-0.0.7-release.md
+++ b/docs/superpowers/plans/2026-08-30-airo-0.0.7-release.md
@@ -1,0 +1,469 @@
+# Airo v0.0.7 Stable Release — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans
+> (this is a release cut, not a feature TDD loop). Follow the checkboxes in
+> order. Do not tag until Task 6 passes.
+
+**Goal:** Publish one aggregate GitHub Release `v0.0.7` (Airo TV, full app,
+optional Coins, unsigned macOS TV) to GitHub + APKPure from a freeze of
+`origin/main`, after restoring the full-app pubspec and passing Fire TV Stick
++ Pixel 9 evidence on the dry-run artifacts.
+
+**Architecture:** Same release orchestrator as `v0.0.6`
+(`.github/workflows/release-orchestrator.yml`). VersionName becomes `0.0.7`
+(not `0.0.7-preview`). Device qualification is a hard gate on checksummed
+dry-run APKs. Coins is a removable leg.
+
+**Tech Stack:** GitHub Actions Release Orchestrator, dogfood Android signing,
+Fire TV Stick 4K, Pixel 9, APKPure listing, `docs/release/` + branding audit.
+
+**Spec:** `docs/superpowers/specs/2026-08-30-airo-0.0.7-release-design.md`
+
+---
+
+## File structure
+
+Modify (version / identity):
+
+- `app/pubspec.yaml` — restore full/phone profile from `734484b8`, then set
+  `version: 0.0.7+12`. Must not equal `app/pubspec_mind.yaml`.
+- `app/pubspec_tv.yaml` — `version: 0.0.7+12`
+- `app/pubspec_coins.yaml` — `version: 0.0.7+12`
+- `.github/workflows/release-orchestrator.yml` — defaults `v0.0.7`,
+  `0.0.7`, `release/v0.0.7`
+- `CHANGELOG.md` — retitle unreleased `v0.0.7-preview` to `v0.0.7`
+- `docs/release/AIRO_v0.0.7.md` — create from preview notes + spec claims
+- `docs/release/AIRO_v0.0.7-preview.md` — replace with a stub pointing at
+  `AIRO_v0.0.7.md` (preview was never tagged)
+- `docs/release/README.md`, `VERSION_LINES.md`, `AIRO_TV_FEATURE_MATRIX.md`,
+  `RELEASE_DEVICE_QUALIFICATION.md`, `V2_HUMAN_IN_LOOP_BLOCKERS.md` — next
+  line is `v0.0.7`
+
+Do not modify: `app/pubspec_mind.yaml` (stays `0.0.1+1`), Play track inputs
+(stay `none`), notarization flag (stay `false`).
+
+---
+
+### Task 1: Restore the full/phone pubspec
+
+**Files:**
+
+- Modify: `app/pubspec.yaml`
+- Do not modify: `app/pubspec_mind.yaml`
+
+- [ ] **Step 1: Confirm the bug is still present**
+
+```bash
+cmp -s app/pubspec.yaml app/pubspec_mind.yaml && echo IDENTICAL || echo DIFFER
+git show 734484b8:app/pubspec.yaml | head -20
+```
+
+Expected: `IDENTICAL`, and `734484b8` header says `Airo - AI-powered super app`
+and `version: 0.0.7-preview+12`.
+
+- [ ] **Step 2: Restore then bump versionName**
+
+```bash
+git show 734484b8:app/pubspec.yaml > app/pubspec.yaml
+python3 - <<'PY'
+from pathlib import Path
+p = Path("app/pubspec.yaml")
+text = p.read_text()
+text = text.replace("version: 0.0.7-preview+12", "version: 0.0.7+12", 1)
+if "Airo - AI-powered super app" not in text:
+    raise SystemExit("restore did not yield the full-app description")
+if text.splitlines()[0:5] == Path("app/pubspec_mind.yaml").read_text().splitlines()[0:5]:
+    raise SystemExit("pubspec.yaml still looks like Mind")
+p.write_text(text)
+PY
+```
+
+- [ ] **Step 3: Replay post-restore full-app deps if needed**
+
+```bash
+git log --oneline 734484b8..origin/main -- app/pubspec.yaml
+```
+
+Inspect any commit after `734484b8` other than `d169a491` that intended a
+**phone** dependency change. Apply those edits onto the restored file. Leave
+Mind-only deps in `app/pubspec_mind.yaml`.
+
+- [ ] **Step 4: Prove the files diverged**
+
+```bash
+cmp -s app/pubspec.yaml app/pubspec_mind.yaml && echo FAIL_STILL_IDENTICAL && exit 1
+rg -n '^version:|^description:' app/pubspec.yaml app/pubspec_mind.yaml
+cd app && dart pub get
+```
+
+Expected: versions `0.0.7+12` vs `0.0.1+1`; `pub get` succeeds.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/pubspec.yaml
+git commit -m "$(cat <<'EOF'
+fix(app): restore full-app pubspec for the 0.0.7 cut
+
+d169a491 left app/pubspec.yaml identical to the Mind profile, so the
+orchestrator full leg would have shipped a Mind APK as io.airo.app.
+
+docs-not-needed
+EOF
+)"
+```
+
+---
+
+### Task 2: Rename preview → stable 0.0.7 in flavors and orchestrator
+
+**Files:**
+
+- Modify: `app/pubspec_tv.yaml`, `app/pubspec_coins.yaml`,
+  `.github/workflows/release-orchestrator.yml`
+
+- [ ] **Step 1: Bump flavor versions**
+
+In `app/pubspec_tv.yaml` and `app/pubspec_coins.yaml` replace
+
+```yaml
+version: 0.0.7-preview+12
+```
+
+with
+
+```yaml
+version: 0.0.7+12
+```
+
+- [ ] **Step 2: Retarget orchestrator defaults**
+
+In `.github/workflows/release-orchestrator.yml` set:
+
+```yaml
+        default: 'v0.0.7'
+```
+
+for `version`,
+
+```yaml
+        default: '0.0.7'
+```
+
+for `build_name`,
+
+```yaml
+        default: 'release/v0.0.7'
+```
+
+for `release_branch`.
+
+Also replace `DEFAULT_VERSION: v0.0.7-preview` with `DEFAULT_VERSION: v0.0.7`
+and `DEFAULT_BUILD_NAME: 0.0.7-preview` with `DEFAULT_BUILD_NAME: 0.0.7`.
+Leave `DEFAULT_BUILD_NUMBER: '12'`.
+
+Leave `dry_run` default `true`, `publish_github_release` default `false`,
+`github_release_mode` default `draft`, Play/Firebase `none`,
+`macos_require_notarization` false.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/pubspec_tv.yaml app/pubspec_coins.yaml .github/workflows/release-orchestrator.yml
+git commit -m "$(cat <<'EOF'
+chore(release): version 0.0.7+12 and orchestrator defaults
+
+Skip the untagged 0.0.7-preview line. versionCode stays 12 so Android
+upgrades over 0.0.6+10 and Coins dogfood +11.
+EOF
+)"
+```
+
+Do **not** use `[skip ci]` — this touches workflows and pubspecs.
+
+---
+
+### Task 3: Rewrite release notes and indexes
+
+**Files:**
+
+- Create: `docs/release/AIRO_v0.0.7.md`
+- Modify: `docs/release/AIRO_v0.0.7-preview.md`, `docs/release/README.md`,
+  `docs/release/VERSION_LINES.md`, `docs/release/AIRO_TV_FEATURE_MATRIX.md`,
+  `docs/release/RELEASE_DEVICE_QUALIFICATION.md`,
+  `docs/release/V2_HUMAN_IN_LOOP_BLOCKERS.md`, `CHANGELOG.md`
+
+- [ ] **Step 1: Write `docs/release/AIRO_v0.0.7.md`**
+
+Copy structure from `docs/release/AIRO_v0.0.6.md` and
+`docs/release/AIRO_v0.0.7-preview.md`. Required content:
+
+- Status line: stable cut, GitHub + APKPure, dogfood signing.
+- Four-SKU table with `0.0.7+12` names; Coins row notes “omitted if #1240
+  fails Pixel 9”.
+- Claim table matching the spec (BACK and playlist merge Available only after
+  the device gate; new Mind not advertised; Cast splice Under qualification).
+- What is new since `v0.0.6` (TV BACK #1430, overlay BACK dismiss #1917,
+  playlist merge, #1918 honest backup copy, bootstrap/provider purge, Coins
+  embeddings if SKU ships).
+- Known issues: #1243, #1023, rust ggml ODR. Do not list #1240 if Coins is
+  dropped.
+- Freeze dispatch block:
+
+```text
+version:                 v0.0.7
+build_name:              0.0.7
+build_number:            12
+release_ref:             <freeze SHA>
+release_branch:          release/v0.0.7
+dry_run:                 true first, then false
+publish_github_release:  false first, then true
+github_release_mode:     draft
+production_signing:      false
+mobile_profile:          full-and-coins
+macos_profile:           tv
+macos_require_notarization: false
+tv_play_track:           none
+mobile_play_track:       none
+firebase_distribution:   none
+```
+
+- [ ] **Step 2: Stub the preview doc**
+
+Replace `docs/release/AIRO_v0.0.7-preview.md` body with:
+
+```markdown
+# Airo v0.0.7-preview — not tagged
+
+This preview line was prepared in-tree and never published. The public cut is
+[Airo v0.0.7](./AIRO_v0.0.7.md).
+```
+
+- [ ] **Step 3: Indexes**
+
+In `docs/release/README.md`, `VERSION_LINES.md`, `AIRO_TV_FEATURE_MATRIX.md`,
+`RELEASE_DEVICE_QUALIFICATION.md`, and `V2_HUMAN_IN_LOOP_BLOCKERS.md`, change
+the next-candidate / current-line sentences from `v0.0.7-preview` to
+`v0.0.7`. Feature matrix: playlist merge becomes Available **only after**
+Task 6 evidence exists; until then keep “Under qualification” in the working
+copy and flip it in the same commit that attaches Stick evidence.
+
+In `CHANGELOG.md` retitle `## v0.0.7-preview — unreleased` to
+`## v0.0.7 — unreleased` and point at `AIRO_v0.0.7.md`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/release CHANGELOG.md
+git commit -m "$(cat <<'EOF'
+docs(release): re-home 0.0.7-preview notes onto stable v0.0.7
+
+docs-not-needed
+[skip ci]
+EOF
+)"
+```
+
+---
+
+### Task 4: Host-only sanity on the restored full profile
+
+**Files:** none new.
+
+- [ ] **Step 1: Analyze the app with the restored pubspec**
+
+```bash
+cd app
+cp pubspec.yaml pubspec.yaml.release-check
+# pubspec.yaml is already the full profile
+flutter analyze --no-fatal-infos
+```
+
+Expected: no new errors in app/lib entry `lib/main.dart`.
+
+- [ ] **Step 2: Confirm TV and Coins pubspecs still resolve**
+
+```bash
+cd app
+cp pubspec.yaml pubspec.yaml.full.bak
+cp pubspec_tv.yaml pubspec.yaml
+dart pub get
+cp pubspec.yaml.full.bak pubspec.yaml
+cp pubspec_coins.yaml pubspec.yaml
+dart pub get
+mv pubspec.yaml.full.bak pubspec.yaml
+dart pub get
+```
+
+Expected: each `pub get` succeeds; working tree `app/pubspec.yaml` is the
+full profile again.
+
+- [ ] **Step 3: Native-media TV contract (host)**
+
+```bash
+scripts/test-check-android-tv-native-media.sh
+```
+
+Expected: pass. This does not replace Fire TV evidence.
+
+- [ ] **Step 4: Commit only if Task 4 produced fixes**; otherwise continue.
+
+---
+
+### Task 5: Freeze SHA and dry-run orchestrator
+
+**Files:** none in git until freeze is chosen.
+
+- [ ] **Step 1: Merge Tasks 1–3 to `origin/main` through review.** Do not tag.
+
+- [ ] **Step 2: Wait for green** `Rust Core CI` and `Continuous Integration`
+  on the merge SHA. Record it:
+
+```bash
+FREEZE=$(git rev-parse origin/main)
+echo "$FREEZE"
+```
+
+- [ ] **Step 3: Create the release branch**
+
+```bash
+git fetch origin main
+git branch release/v0.0.7 "$FREEZE"
+git push -u origin release/v0.0.7
+```
+
+- [ ] **Step 4: Dispatch dry-run**
+
+In GitHub Actions → Release Orchestrator → Run workflow:
+
+| Input | Value |
+| --- | --- |
+| version | `v0.0.7` |
+| build_name | `0.0.7` |
+| build_number | `12` |
+| release_ref | `$FREEZE` |
+| release_branch | `release/v0.0.7` |
+| dry_run | `true` |
+| publish_github_release | `false` |
+| github_release_mode | `draft` |
+| production_signing | `false` |
+| mobile_profile | `full-and-coins` |
+| macos_profile | `tv` |
+| macos_require_notarization | `false` |
+| tv_play_track | `none` |
+| mobile_play_track | `none` |
+| firebase_distribution | `none` |
+
+- [ ] **Step 5: Download artifacts and record SHA256** from
+  `SHA256SUMS` / `Airo-v0.0.7-Release-Manifest.json`. These hashes are the
+  qualification identity. Do not install a locally rebuilt APK for Task 6.
+
+---
+
+### Task 6: Device gate (blocks the tag)
+
+**Environment:** Fire TV Stick 4K + Pixel 9. No emulator.
+
+- [ ] **Step 1: Fire TV Stick — install + Leanback**
+
+```bash
+adb connect "$AIRO_TV_DEVICE"
+adb -s "$AIRO_TV_DEVICE" install -r Airo-TV-0.0.7.apk
+adb -s "$AIRO_TV_DEVICE" shell monkey -p io.airo.app.tv -c android.intent.category.LEANBACK_LAUNCHER 1
+```
+
+Expected: Leanback banner launches the TV shell.
+
+- [ ] **Step 2: Fire TV — BACK after playback (#1430)**
+
+Play a channel from the browse grid, press BACK. Expected: focus returns to
+the channel-browse grid; BACK is not swallowed. Open a shell overlay
+(settings/help) and press BACK: overlay dismisses (#1917). Capture a short
+note + device model/OS in
+`docs/release/evidence/AIRO_TV_V0.0.7_QUALIFICATION.md`.
+
+- [ ] **Step 3: Fire TV — playlist-merge smoke (#1605)**
+
+Add one authorized M3U, one Xtream, and one Stalker live source. Expected:
+one combined live browse list (not three exclusive silos). No bundled
+channels. Record pass/fail in the same evidence file.
+
+- [ ] **Step 4: Pixel 9 — full APK**
+
+Install `Airo-0.0.7-12-arm64.apk`. Expected: super-app home (not Mind-only
+shell). Demo login is acceptable.
+
+- [ ] **Step 5: Pixel 9 — Coins APK**
+
+Install `AiroCoins-0.0.7-12-arm64.apk`. Expected: Coins home renders.
+
+If #1240 still reproduces: **stop Coins**. Re-run Task 5 Step 4 with
+`mobile_profile: full` only. Do not publish a Coins APK. Update
+`AIRO_v0.0.7.md` SKU table to “Coins omitted this wave (#1240)”.
+
+If Step 2, 3, or 4 fails: **do not tag**. File/fix, new freeze SHA, new
+dry-run.
+
+- [ ] **Step 6: Optional macOS TV** — app opens. #1023 may remain.
+
+- [ ] **Step 7: Commit evidence**
+
+```bash
+git add docs/release/evidence/AIRO_TV_V0.0.7_QUALIFICATION.md docs/release/AIRO_v0.0.7.md docs/release/AIRO_TV_FEATURE_MATRIX.md
+git commit -m "$(cat <<'EOF'
+docs(release): attach v0.0.7 Fire TV and Pixel 9 qualification evidence
+
+docs-not-needed
+[skip ci]
+EOF
+)"
+```
+
+Flip playlist merge + BACK to Available in the feature matrix only in this
+commit.
+
+---
+
+### Task 7: Publish GitHub Release, then APKPure
+
+- [ ] **Step 1: Re-dispatch orchestrator** with the same freeze SHA and
+  hashes, `dry_run: false`, `publish_github_release: true`,
+  `github_release_mode: draft`. Confirm asset SHA256 matches Task 5.
+
+- [ ] **Step 2: Human publishes the GitHub Release** (latest, not
+  prerelease). Do not mark prerelease; this is stable `v0.0.7`.
+
+- [ ] **Step 3: APKPure** — upload the same TV (and full/Coins if shipped)
+  APKs. Do not upload a rebuilt binary.
+
+- [ ] **Step 4: Branding** — follow
+  `.agents/skills/airo-release-branding/SKILL.md`. Run
+
+```bash
+python3 .agents/skills/airo-release-branding/scripts/audit_public_page.py
+```
+
+Do not claim Cast splice, 3-tile, fold, or new Mind surfaces as Available.
+
+- [ ] **Step 5: Changelog date**
+
+Set `CHANGELOG.md` heading to `## v0.0.7 — YYYY-MM-DD` and commit with
+`[skip ci]`.
+
+---
+
+### Task 8: Rollback (only if published bits are bad)
+
+- [ ] Unpublish the GitHub Release `v0.0.7`.
+- [ ] Leave `v0.0.6` as latest.
+- [ ] Do not reuse versionCode 12. Next attempt is `0.0.7+13`.
+- [ ] Follow `docs/release/ROLLBACK_PROCEDURE.md` for APKPure listing revert.
+
+---
+
+## Self-review
+
+- Spec coverage: pubspec P0, version 0.0.7+12, four-SKU with Coins drop,
+  hard device gate, claims, out-of-wave stores, rollback — each has a task.
+- No preview tag, no Play upload, no notarization requirement.
+- Orchestrator dry-run before tag; publish only after checksum match.

--- a/docs/superpowers/specs/2026-08-30-airo-0.0.7-release-design.md
+++ b/docs/superpowers/specs/2026-08-30-airo-0.0.7-release-design.md
@@ -1,0 +1,154 @@
+# Airo v0.0.7 Stable Release — Design
+
+Date: 2026-08-30
+Status: Approved (product decisions recorded with Developers; this document is
+the freeze contract)
+Base: `origin/main` at planning time (`2eb1ca7b`, includes #1917 BACK
+overlay dismiss and #1918 honest backup copy)
+
+## Problem
+
+`v0.0.6` (3 Aug 2026) is the last public aggregate ship (TV, full, Coins,
+macOS TV). `origin/main` is 519+ commits ahead. Flavor files already say
+`0.0.7-preview+12`, and `docs/release/AIRO_v0.0.7-preview.md` is prepared but
+**not tagged**. Developers asked to plan **stable 0.0.7**, not another public
+preview tag.
+
+## Product decisions (locked)
+
+| Decision | Choice |
+| --- | --- |
+| Cut | Stable `v0.0.7`. Do not mint `v0.0.7-preview` or `airo-tv-v0.0.7`. |
+| SKUs | Intended four-SKU wave: TV + full + Coins + macOS TV. |
+| Distribution | GitHub Releases + APKPure / direct download. No Play, no Firebase testers, no notarized macOS. |
+| Freeze gate | Hard device evidence **before tag**: Fire TV Stick (install + Leanback + BACK after playback + playlist-merge smoke) **and** Pixel 9 (full-app launch + Coins home). |
+| Coins #1240 | If Pixel 9 Coins home still blacks out, **drop the Coins SKU** from this wave and rebuild with `mobile_profile: full`. Do not hold TV+full, and do not ship Coins as a known-broken SKU. |
+| Signing | Dogfood keystore (`production_signing=false`). Upgrades over `v0.0.6`, not over production-signed builds. |
+
+CI green on the freeze SHA is necessary and **not sufficient**. Dry-run
+artifacts exist so the device gate can run on the bits that will be published;
+the public tag waits on that gate.
+
+## P0 pre-freeze: full-app pubspec is Mind
+
+On current `origin/main`, `app/pubspec.yaml` is **byte-identical** to
+`app/pubspec_mind.yaml` (`description` is the Mind product; `version` is
+`0.0.1+1`).
+
+The last restored full/phone profile is commit `734484b8`
+(`fix(ci): restore phone pubspec so analyze and reachability pass`), with
+`description: "Airo - AI-powered super app…"` and `version: 0.0.7-preview+12`.
+`d169a491` overwrote it again with the Mind profile.
+
+`.github/workflows/airo-mobile-tablet-release.yml` builds the **full** profile
+from `app/pubspec.yaml`. A freeze of current main would publish a Mind APK
+under `io.airo.app` / `Airo-0.0.7-*` names.
+
+**Required before any orchestrator dry-run:** restore the full/phone pubspec
+from `734484b8:app/pubspec.yaml`, replay any later full-app dependency changes
+that belong on the phone profile, keep Mind exclusively in
+`app/pubspec_mind.yaml`, bump the full profile to `0.0.7+12`, and prove
+`flutter build apk -t lib/main.dart` is not the Mind entry/dependency set.
+
+TV (`app/pubspec_tv.yaml`) and Coins (`app/pubspec_coins.yaml`) already carry
+`0.0.7-preview+12` and only need the versionName rename to `0.0.7`.
+
+## Version and artifacts
+
+| Field | Value |
+| --- | --- |
+| Tag | `v0.0.7` |
+| Branch | `release/v0.0.7` cut from the freeze SHA |
+| `versionName` / `build_name` | `0.0.7` |
+| `versionCode` / `build_number` | `12` (preview was never tagged; `v0.0.6` was `+10`, Coins dogfood `+11`) |
+| TV APK | `Airo-TV-0.0.7.apk` + ABI splits + `Airo-TV-0.0.7-Play-Store.aab` (AAB built, not uploaded) |
+| Full APK | `Airo-0.0.7-12-arm64.apk` + Play Store AAB (not uploaded) |
+| Coins APK | `AiroCoins-0.0.7-12-arm64.apk` + AAB, **omitted** if #1240 fails Pixel 9 |
+| macOS TV | zip / dmg / Homebrew metadata, unsigned, `macos_require_notarization: false` |
+
+If a published 0.0.7 build must be replaced, do **not** reuse versionCode 12.
+Cut `0.0.7+13`.
+
+## SKU matrix
+
+| Profile | Package | This wave |
+| --- | --- | --- |
+| Android TV | `io.airo.app.tv` | Required |
+| Full app | `io.airo.app` | Required after pubspec restore |
+| Airo Coins | `io.airo.app.coins` | Ship only if Pixel 9 home is green |
+| macOS TV | `com.developerscoffee.airo.tv` | Required as unsigned/unnotarized (same policy as 0.0.6; #803 open) |
+| Standalone Mind | `io.airo.app.mind` | Not adopted (`ciBuild: false`, stays `0.0.1+1`) |
+
+## Sequence
+
+1. **Align versions and docs** on a short-lived branch from `origin/main`: restore full pubspec; `0.0.7-preview+12` → `0.0.7+12` in TV/Coins/full; retarget orchestrator defaults, `CHANGELOG.md`, `docs/release/README.md`, `VERSION_LINES.md`, feature matrix; replace `AIRO_v0.0.7-preview.md` with `AIRO_v0.0.7.md`.
+2. **Freeze SHA** after Rust Core CI and Continuous Integration are green on that merge.
+3. **Branch** `release/v0.0.7` from the freeze SHA.
+4. **Dry-run orchestrator** (`dry_run: true`, `publish_github_release: false`, `github_release_mode: draft`, Play/Firebase `none`, `production_signing: false`, `macos_require_notarization: false`). `mobile_profile` starts as `full-and-coins`.
+5. **Device gate on those checksums** (see below). Coins-only failure → drop Coins, set `mobile_profile: full`, dry-run again, re-check Pixel 9 full launch only.
+6. **Publish** orchestrator with `dry_run: false`, `publish_github_release: true`, still `github_release_mode: draft` first. Confirm SHA256 match. Then mark the GitHub Release latest (not prerelease).
+7. **APKPure + public site** using the airo-release-branding skill. Claims only for surfaces that passed step 5.
+
+## Device gate (blocking)
+
+Run against the **dry-run artifacts**, not a local debug build.
+
+**Fire TV Stick 4K** (`make run-firetv` / install the TV APK over adb):
+
+- Install and Leanback launcher entry (`io.airo.app.tv`).
+- BACK returns from playback to the channel-browse grid without swallowing the key (#1430).
+- Playlist-merge smoke: one M3U, one Xtream, and one Stalker live source appear in a single browse list (#1605). User-supplied authorized playlists only.
+
+**Pixel 9**:
+
+- Full-app APK launches to the super-app shell (not a Mind-only home).
+- Coins APK opens a usable home (not the #1240 black screen). Failure here drops Coins from the wave; it does not waive the full-app launch check.
+
+**Waive in writing if timeboxed:** iPad soak (#716 / #1601). macOS TV: app opens is enough; #1023 (mini-player Watch) stays a known issue.
+
+## Public claims
+
+Merged code is not Available. After the device gate:
+
+| Surface | Claim |
+| --- | --- |
+| TV BACK after playback (#1430) | **Available** (on the hard gate) |
+| Unified live playlist merge | **Available** (on the hard gate) |
+| Honest TV backup failure copy (#1918) | **Available** (no extra device row; covered by TV install) |
+| BACK dismisses shell overlays (#1917) | **Available** (exercise with #1430 on Stick) |
+| Cast splice-on-keyframe, 3-tile, fold crease | **Under qualification** (#1603 / #1601 / #1588 stay open) |
+| Design-system pass | **Under qualification** (visual, not a listing claim) |
+| Meeting Intelligence (0.0.6 set) | **Available** (unchanged) |
+| New Mind (IR / MoM / speaker / Indic / chat-over-meetings) | In the full binary; **do not advertise** (#1592 open) |
+| Coins embeddings / recurrence / anomaly | Advertise only if Coins SKU ships; still qualify #1240 as closed on Pixel 9 |
+| Play / notarized macOS / Firebase / standalone Mind | **Deferred** / **Not adopted** |
+
+## Out of this wave
+
+Play upload (#576, #585), notarized macOS (#803), Firebase Android clients for remaining profiles (#756), Firebase testers (#682), iOS/iPadOS SPM, Linux/Windows desktop, standalone Mind APK, a second `airo-tv-v*` tag.
+
+## Known issues to carry if still true at freeze
+
+| Issue | Handling |
+| --- | --- |
+| #1243 | Keep: Fire TV vendor property-denial spam; playback unaffected |
+| #1023 | Keep: macOS mini-player Watch |
+| #1240 | Do not list as a shipped Coins known issue; dropping the SKU is the mitigation |
+| #1025 | Closed in tree; drop from notes once TV chrome is seen on Stick |
+| Rust ggml ODR | Keep as developer note (`airo_mind_cli` excluded from Linux workspace CI) |
+
+## Rollback
+
+- Keep the GitHub Release **draft** until APKPure.
+- If a published build is bad: unpublish `v0.0.7`, leave `v0.0.6` as latest, do not reuse versionCode 12, cut `0.0.7+13`.
+- Dogfood-signed 0.0.7 upgrades over dogfood 0.0.6 only.
+
+## Related
+
+- Execution plan: `docs/superpowers/plans/2026-08-30-airo-0.0.7-release.md`
+- Current prepared notes (to be replaced): `docs/release/AIRO_v0.0.7-preview.md`
+- Last stable: `docs/release/AIRO_v0.0.6.md`
+- Orchestrator: `docs/release/V2_RELEASE_ORCHESTRATOR.md`
+- Qualification: `docs/release/V2_RELEASE_QUALIFICATION.md`
+- Human blockers: `docs/release/V2_HUMAN_IN_LOOP_BLOCKERS.md`
+- Epic: #674


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Planning artifacts for a **stable `v0.0.7`** cut from `origin/main`. This does not bump versions, restore the pubspec, tag, or dispatch the orchestrator — that is Task 1+ of the plan.

Locked product decisions:

- Skip `v0.0.7-preview` (never tagged) and skip a new `airo-tv-v*` tag
- GitHub + APKPure only (no Play, no notarized macOS, no Firebase testers)
- Hard Fire TV Stick + Pixel 9 gate **before** the public tag
- Drop the Coins SKU if #1240 still blacks out on Pixel 9

P0 called out in the spec: `app/pubspec.yaml` is currently identical to the Mind profile, so a freeze of today’s main would ship a Mind APK as `io.airo.app`.

- Spec: `docs/superpowers/specs/2026-08-30-airo-0.0.7-release-design.md`
- Plan: `docs/superpowers/plans/2026-08-30-airo-0.0.7-release.md`
- Related epic: #674

## Test Plan

- [x] Documents are internally consistent with the locked decisions (no preview tag, versionCode 12, Coins drop path, dry-run before tag)
- [ ] `flutter analyze` — not applicable (docs only)
- [ ] `flutter test` — not applicable
- [x] Manual device verification — not applicable on this PR; Task 6 of the plan is the device gate

**Verification environment:** Host-only (docs review)

## Agent Policy

- [x] Feature Packet not required: this is a release-cut contract, not a new product capability. Lifecycle gates for the cut itself live in the spec (freeze SHA, device evidence, claims).
- [x] No framework/application boundary code change in this PR.

## Council Review

- Chief Release/DevOps Officer: requested (versioning, orchestrator dispatch, signing)
- Chief Documentation Officer: requested (release notes / claim state)
- TV Experience / QA: device-gate rows in the plan

- [x] I checked the Decision Matrix for a docs-only release-process change.
- [x] No `module.yaml` packages touched.
- [x] No `docs/wiki` update: no user-visible product change until the cut executes.

## Plugin and Size Impact

- [ ] This PR adds new dependencies
- [ ] This PR adds or grows app/packages/plugins code

Size impact / plugin justification: none.

## Checklist

- [x] Sensitive data, credentials, and signing artifacts are not committed.
- [x] User-facing change documented, or not applicable

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b9708016-aab4-40ea-a243-9c7143bc62d9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b9708016-aab4-40ea-a243-9c7143bc62d9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

