### PR TITLE
fix(tv): stop offering a multiview toggle TV cannot render

### DIFF
--- a/packages/feature_iptv/lib/presentation/tv_ux/airo_tv_shell.dart
+++ b/packages/feature_iptv/lib/presentation/tv_ux/airo_tv_shell.dart
@@ -144,7 +144,15 @@ class _AiroTvShellState extends ConsumerState<AiroTvShell> {
       multiviewChannelIds: {
         for (final session in multiview.sessions) session.id,
       },
-      onMultiviewToggle: (channel) => _toggleMultiview(context, channel),
+      // [MultiviewStage] is built inside `videoStage`, which is only mounted
+      // when `showVideoStage` is true — and TV passes false. Wiring the
+      // toggle regardless meant the remote's menu key answered "X added to
+      // multiview" for a stage that never appears. `ChannelLibraryGrid`
+      // treats a null callback as "this device has no multiview", so it also
+      // drops the menu-key binding and the per-tile button.
+      onMultiviewToggle: widget.showVideoStage
+          ? (channel) => _toggleMultiview(context, channel)
+          : null,
     );
     final infoBar = ChannelInfoBar(
       channel: widget.currentChannel,

--- a/packages/feature_iptv/test/iptv/presentation/tv_ux/airo_tv_shell_test.dart
+++ b/packages/feature_iptv/test/iptv/presentation/tv_ux/airo_tv_shell_test.dart
@@ -5,6 +5,7 @@ import 'package:feature_iptv/application/providers/connectivity_provider.dart';
 import 'package:feature_iptv/application/providers/iptv_providers.dart';
 import 'package:feature_iptv/application/services/wifi_settings_launcher.dart';
 import 'package:feature_iptv/presentation/tv_ux/airo_tv_shell.dart';
+import 'package:feature_iptv/presentation/tv_ux/sections/channel_library_grid.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
@@ -341,6 +342,34 @@ void main() {
   testWidgets('TV-sized layout keeps channel rows focusable', (tester) async {
     await pumpAt(tester, 1280);
     expect(find.byType(Focus), findsWidgets);
+  });
+
+  testWidgets('no multiview toggle is offered without a video stage', (
+    tester,
+  ) async {
+    // MultiviewStage is built inside videoStage, so with the stage hidden
+    // the remote's menu key confirmed "X added to multiview" against
+    // something that never renders. A null callback also tells
+    // ChannelLibraryGrid to drop the binding and the per-tile button.
+    await pumpAt(tester, 1280, showVideoStage: false);
+    expect(
+      tester
+          .widget<ChannelLibraryGrid>(find.byType(ChannelLibraryGrid))
+          .onMultiviewToggle,
+      isNull,
+    );
+  });
+
+  testWidgets('multiview toggle stays wired where the stage does render', (
+    tester,
+  ) async {
+    await pumpAt(tester, 1280);
+    expect(
+      tester
+          .widget<ChannelLibraryGrid>(find.byType(ChannelLibraryGrid))
+          .onMultiviewToggle,
+      isNotNull,
+    );
   });
 
   testWidgets('first TV launch asks for country once', (tester) async {


### PR DESCRIPTION
## Why

Fifth fix from the pre-release Airo TV audit. The remote's menu key confirmed an action against a surface that never renders on TV.

## What broke

`AiroTvShell` wired `onMultiviewToggle` unconditionally:

```dart
onMultiviewToggle: (channel) => _toggleMultiview(context, channel),
```

The tile binds it to the remote's menu key (`ChannelLibraryGrid` → `MediaCard.onLongPress` → `TvFocusable.onSecondaryAction`), so pressing it answered **"X added to multiview"**.

But `MultiviewStage` is built inside `videoStage`, which is only mounted `if (widget.showVideoStage)` — and TV passes `showVideoStage: false` (`iptv_screen.dart`, since `playlistSourceInInfoBar` is true). The state really was updated; there was simply nowhere for it to appear. The user got a success confirmation and no visible change.

## What changed

Gates the callback on `showVideoStage`. `ChannelLibraryGrid` already treats a null callback as "this device has no multiview", so the menu-key binding **and** the per-tile button both disappear with it, rather than staying present and inert.

**Removing the affordance, not rendering the stage.** Making multiview work in the grid-first TV layout is a layout feature; the release-cut fix is to stop claiming it works.

## Tests

- `no multiview toggle is offered without a video stage` — verified to fail against the old code (`Expected: null, Actual: <Closure: (IPTVChannel) => void>`).
- `multiview toggle stays wired where the stage does render` — pins the enabled path so the gate can't silently become unconditional and take multiview away from layouts that do render it.

Green: 86 `tv_ux` tests, clean analyze.

🤖 Generated with [Claude Code](https://claude.com/claude-code)