### PR TITLE
fix(tv): explain an empty browse grid instead of rendering blank

### DIFF
--- a/packages/feature_iptv/lib/presentation/tv_ux/airo_tv_shell.dart
+++ b/packages/feature_iptv/lib/presentation/tv_ux/airo_tv_shell.dart
@@ -153,6 +153,7 @@ class _AiroTvShellState extends ConsumerState<AiroTvShell> {
       onMultiviewToggle: widget.showVideoStage
           ? (channel) => _toggleMultiview(context, channel)
           : null,
+      onClearFilters: () => ref.read(channelFiltersProvider.notifier).clear(),
     );
     final infoBar = ChannelInfoBar(
       channel: widget.currentChannel,

--- a/packages/feature_iptv/lib/presentation/tv_ux/sections/channel_library_grid.dart
+++ b/packages/feature_iptv/lib/presentation/tv_ux/sections/channel_library_grid.dart
@@ -30,6 +30,7 @@ class ChannelLibraryGrid extends StatefulWidget {
     this.onVisibleChannelsChanged,
     this.multiviewChannelIds = const {},
     this.onMultiviewToggle,
+    this.onClearFilters,
   });
 
   final List<IPTVChannel> channels;
@@ -42,6 +43,10 @@ class ChannelLibraryGrid extends StatefulWidget {
   final ValueChanged<List<IPTVChannel>>? onVisibleChannelsChanged;
   final Set<String> multiviewChannelIds;
   final ValueChanged<IPTVChannel>? onMultiviewToggle;
+
+  /// Resets every filter from the "no matches" state. Null hides that
+  /// action, leaving the explanation without a shortcut.
+  final VoidCallback? onClearFilters;
 
   @override
   State<ChannelLibraryGrid> createState() => _ChannelLibraryGridState();
@@ -129,52 +134,130 @@ class _ChannelLibraryGridState extends State<ChannelLibraryGrid> {
             SliverToBoxAdapter(
               child: _LibrarySortRow(sort: widget.sort, onSort: widget.onSort),
             ),
-            SliverPadding(
-              padding: const EdgeInsets.fromLTRB(12, 4, 12, _gridSpacing),
-              sliver: SliverGrid(
-                gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
-                  crossAxisCount: columns,
-                  mainAxisExtent: _cardHeight,
-                  crossAxisSpacing: _gridSpacing,
-                  mainAxisSpacing: _gridSpacing,
-                ),
-                delegate: SliverChildBuilderDelegate(
-                  (context, index) {
-                    final channel = widget.channels[index];
-                    return RepaintBoundary(
-                      key: ValueKey('channel-tile-${channel.id}'),
-                      child: _ChannelTile(
-                        channel: channel,
-                        metadata: widget.metadataByChannelId[channel.id],
-                        availability:
-                            widget.availabilityByChannelId[channel.id],
-                        onSelected: widget.onChannelSelected,
-                        focusPlayDelay: widget.focusPlayDelay,
-                        inMultiview: widget.multiviewChannelIds.contains(
-                          channel.id,
+            // The shell only builds this grid once the unfiltered library is
+            // non-empty (an empty library gets the onboarding view instead),
+            // so zero channels here always means the filters excluded them
+            // all. Without this the panel just rendered blank below the sort
+            // row, which the first-run country prompt makes easy to hit: it
+            // sets a country filter that a playlist may have nothing for.
+            if (widget.channels.isEmpty)
+              SliverFillRemaining(
+                hasScrollBody: false,
+                child: _NoMatchesView(onClearFilters: widget.onClearFilters),
+              )
+            else
+              SliverPadding(
+                padding: const EdgeInsets.fromLTRB(12, 4, 12, _gridSpacing),
+                sliver: SliverGrid(
+                  gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+                    crossAxisCount: columns,
+                    mainAxisExtent: _cardHeight,
+                    crossAxisSpacing: _gridSpacing,
+                    mainAxisSpacing: _gridSpacing,
+                  ),
+                  delegate: SliverChildBuilderDelegate(
+                    (context, index) {
+                      final channel = widget.channels[index];
+                      return RepaintBoundary(
+                        key: ValueKey('channel-tile-${channel.id}'),
+                        child: _ChannelTile(
+                          channel: channel,
+                          metadata: widget.metadataByChannelId[channel.id],
+                          availability:
+                              widget.availabilityByChannelId[channel.id],
+                          onSelected: widget.onChannelSelected,
+                          focusPlayDelay: widget.focusPlayDelay,
+                          inMultiview: widget.multiviewChannelIds.contains(
+                            channel.id,
+                          ),
+                          onMultiviewToggle: widget.onMultiviewToggle,
                         ),
-                        onMultiviewToggle: widget.onMultiviewToggle,
-                      ),
-                    );
-                  },
-                  childCount: widget.channels.length,
-                  addAutomaticKeepAlives: false,
-                  findChildIndexCallback: (key) {
-                    if (key is! ValueKey<String>) return null;
-                    final value = key.value;
-                    if (!value.startsWith('channel-tile-')) return null;
-                    final channelId = value.substring('channel-tile-'.length);
-                    final index = widget.channels.indexWhere(
-                      (channel) => channel.id == channelId,
-                    );
-                    return index < 0 ? null : index;
-                  },
+                      );
+                    },
+                    childCount: widget.channels.length,
+                    addAutomaticKeepAlives: false,
+                    findChildIndexCallback: (key) {
+                      if (key is! ValueKey<String>) return null;
+                      final value = key.value;
+                      if (!value.startsWith('channel-tile-')) return null;
+                      final channelId = value.substring('channel-tile-'.length);
+                      final index = widget.channels.indexWhere(
+                        (channel) => channel.id == channelId,
+                      );
+                      return index < 0 ? null : index;
+                    },
+                  ),
+                ),
+              ),
+          ],
+        );
+      },
+    );
+  }
+}
+
+/// Shown when the active filters exclude every channel. On TV the filter
+/// chips are a D-pad journey away, so this offers a focusable way back to
+/// the full library rather than only naming the problem.
+class _NoMatchesView extends StatelessWidget {
+  const _NoMatchesView({required this.onClearFilters});
+
+  final VoidCallback? onClearFilters;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).colorScheme;
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 40),
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Icon(Icons.filter_alt_off, size: 48, color: colors.onSurfaceVariant),
+          const SizedBox(height: 16),
+          Text(
+            'No channels match your filters',
+            textAlign: TextAlign.center,
+            style: Theme.of(context).textTheme.titleMedium,
+          ),
+          const SizedBox(height: 8),
+          Text(
+            'This playlist has channels, but none of them match every filter '
+            'you have applied.',
+            textAlign: TextAlign.center,
+            style: Theme.of(
+              context,
+            ).textTheme.bodyMedium?.copyWith(color: colors.onSurfaceVariant),
+          ),
+          if (onClearFilters != null) ...[
+            const SizedBox(height: 20),
+            TvFocusable(
+              autofocus: true,
+              onSelect: onClearFilters!,
+              semanticLabel: 'Clear all filters',
+              semanticButton: true,
+              borderRadius: 10,
+              child: Container(
+                padding: const EdgeInsets.symmetric(
+                  horizontal: 20,
+                  vertical: 12,
+                ),
+                decoration: BoxDecoration(
+                  color: colors.primaryContainer,
+                  borderRadius: BorderRadius.circular(10),
+                ),
+                child: Text(
+                  'Clear filters',
+                  style: TextStyle(
+                    color: colors.onPrimaryContainer,
+                    fontWeight: FontWeight.w600,
+                  ),
                 ),
               ),
             ),
           ],
-        );
-      },
+        ],
+      ),
     );
   }
 }

--- a/packages/feature_iptv/test/iptv/presentation/tv_ux/channel_library_grid_test.dart
+++ b/packages/feature_iptv/test/iptv/presentation/tv_ux/channel_library_grid_test.dart
@@ -59,6 +59,57 @@ void main() {
     expect(tester.takeException(), isNull);
   });
 
+  testWidgets('filtered-to-empty explains itself and offers a way back', (
+    tester,
+  ) async {
+    // The shell only builds this grid once the unfiltered library is
+    // non-empty, so zero channels means the filters excluded everything.
+    // It used to render a blank panel under the sort row.
+    var cleared = 0;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: SizedBox(
+            width: 800,
+            height: 600,
+            child: ChannelLibraryGrid(
+              channels: const [],
+              metadataByChannelId: const {},
+              onClearFilters: () => cleared++,
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('No channels match your filters'), findsOneWidget);
+
+    await tester.tap(find.text('Clear filters'));
+    await tester.pump();
+    expect(cleared, 1);
+  });
+
+  testWidgets('filtered-to-empty omits the action when it cannot clear', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(
+          body: SizedBox(
+            width: 800,
+            height: 600,
+            child: ChannelLibraryGrid(channels: [], metadataByChannelId: {}),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('No channels match your filters'), findsOneWidget);
+    expect(find.text('Clear filters'), findsNothing);
+  });
+
   testWidgets('tapping a tile invokes onChannelSelected', (tester) async {
     IPTVChannel? tapped;
     await tester.pumpWidget(


### PR DESCRIPTION
## Why

Sixth fix from the pre-release Airo TV audit. A first-run user can land on a completely blank browse panel with no explanation and no obvious way out.

## What broke

`ChannelLibraryGrid` had no `isEmpty` branch. With zero channels it built the sort row and an empty `SliverGrid` — a blank panel.

That state is reachable, and specifically reachable on **first run**: the country prompt sets a country filter, so a user whose playlist carries nothing for their country sees an empty panel the first time they open the app. `_StreamTabContent` only shows the onboarding view when the *unfiltered* list is empty, so this case falls through to the grid.

Recovery existed only through the filter chips' own per-chip clear — a D-pad journey away, and not discoverable from a panel that says nothing.

## What changed

Because the shell only builds this grid once the unfiltered library is non-empty, zero channels here always means the filters excluded them all — so the empty state can name the cause rather than guess:

> **No channels match your filters**
> This playlist has channels, but none of them match every filter you have applied.
>
> [ Clear filters ]

The action is a `TvFocusable` (autofocus, so a D-pad user lands on it) wired to the existing `ChannelFiltersNotifier.clear()`. It's optional — the grid still renders the explanation for callers with no filter state to reset.

## Tests

- `filtered-to-empty explains itself and offers a way back` — asserts the message and that the action fires the callback.
- `filtered-to-empty omits the action when it cannot clear` — pins the null-callback path so the button can't become unconditional.

Green: 88 `tv_ux` tests, 872 `feature_iptv` tests, clean analyze.

🤖 Generated with [Claude Code](https://claude.com/claude-code)