### PR TITLE
fix(tv): stop shipping touch-only player chrome to the remote

### DIFF
--- a/packages/feature_iptv/lib/presentation/screens/iptv_screen.dart
+++ b/packages/feature_iptv/lib/presentation/screens/iptv_screen.dart
@@ -825,6 +825,7 @@ class _IPTVScreenState extends ConsumerState<IPTVScreen>
           body: VideoPlayerWidget(
             showControls: true,
             initiallyFullscreen: true,
+            enableTouchGestures: !widget.tenFootMode,
             onFullscreenToggle: _toggleFullscreen,
           ),
         ),
@@ -936,6 +937,9 @@ class _IPTVScreenState extends ConsumerState<IPTVScreen>
               showControls: true,
               initiallyFullscreen: true,
               handleNativeFullscreen: false,
+              // Brightness/volume drag zones and the lock button are
+              // touch-only concepts with no remote equivalent.
+              enableTouchGestures: !widget.tenFootMode,
               // Only the ten-foot host hands BACK to the player, because only
               // Fire OS duplicates the platform half. On touch, guardRouteBack
               // below answers that pop; letting the player answer it too would
@@ -1489,6 +1493,11 @@ class _StreamTabContent extends ConsumerWidget {
                     showControls: true,
                     enableSwipeChannelChange: true,
                     handleNativeFullscreen: false,
+                    // `playlistSourceInInfoBar` is this widget's ten-foot
+                    // signal — it is what it forwards as `tenFootMode`
+                    // below. Brightness/volume drag zones and the lock
+                    // button have no remote equivalent.
+                    enableTouchGestures: !playlistSourceInInfoBar,
                     onFullscreenToggle: onFullscreenToggle,
                     showPictureInPicture: !playlistSourceInInfoBar,
                     // This screen already renders its own persistent

--- a/packages/feature_iptv/test/iptv/presentation/screens/iptv_screen_test.dart
+++ b/packages/feature_iptv/test/iptv/presentation/screens/iptv_screen_test.dart
@@ -1,3 +1,4 @@
+import 'package:leak_tracker_flutter_testing/leak_tracker_flutter_testing.dart';
 import "package:feature_iptv/application/channel_metadata_enrichment.dart";
 import "package:feature_iptv/feature_iptv.dart";
 import 'package:core_ui/core_ui.dart';
@@ -42,6 +43,7 @@ void main() {
     Map<String, Object> initialPreferences = const {},
     List<IPTVChannel> Function()? channelLoader,
     List<Override> extraOverrides = const [],
+    bool tenFootMode = false,
   }) {
     SharedPreferences.setMockInitialValues(initialPreferences);
     return FutureBuilder<SharedPreferences>(
@@ -82,6 +84,7 @@ void main() {
               onOpenVod: onOpenVod,
               onSettings: onSettings,
               onPickLocalMediaForTv: onPickLocalMediaForTv,
+              tenFootMode: tenFootMode,
             ),
           ),
         );
@@ -218,6 +221,34 @@ void main() {
 
     expect(find.byType(AppBar), findsOneWidget);
   });
+
+  testWidgets(
+    'ten-foot mode suppresses touch-only player chrome',
+    (tester) async {
+      // Brightness/volume drag zones and the lock button are touch concepts
+      // with no remote equivalent. VideoPlayerWidget already hides them when
+      // enableTouchGestures is false, and its doc comment cited "TV/remote
+      // input" as the reason — but nothing in production ever passed false, so
+      // every Fire TV build shipped the touch chrome anyway.
+      await tester.pumpWidget(createWidget(tenFootMode: true));
+      await tester.pumpAndSettle();
+
+      // A player only mounts once something is playing.
+      await tester.tap(find.text('City News Live').first);
+      await tester.pumpAndSettle();
+
+      final players = tester.widgetList<VideoPlayerWidget>(
+        find.byType(VideoPlayerWidget),
+      );
+      expect(players, isNotEmpty, reason: 'expected a player to be mounted');
+      for (final player in players) {
+        expect(player.enableTouchGestures, isFalse);
+      }
+    },
+    experimentalLeakTesting: LeakTesting.settings.withIgnored(
+      notDisposed: {'VideoPlayerController': null},
+    ),
+  );
 
   testWidgets('browse preview exposes a full player entry point', (
     tester,


### PR DESCRIPTION
## Why

Ninth fix from the pre-release Airo TV audit. The player mounted touch-only affordances on a device with no touchscreen — and a comment in the code claimed it didn't.

## What broke

`VideoPlayerWidget.enableTouchGestures` gates the brightness/volume drag zones (`PlayerGestureOverlay`) and the lock button. The widget's own comment names the reason:

```dart
// Lock button: touch-only concept, hidden entirely when
// enableTouchGestures is false (e.g. TV/remote input).
```

The flag defaults to `true`, and **nothing in production ever passed `false`** — only tests did. So the comment described an intent the wiring never carried out, and every Fire TV build shipped both controls.

Neither has a remote equivalent: the drag zones respond to a gesture arena a D-pad cannot enter, and the lock button guards against pocket taps that can't happen on a TV.

## What changed

Passes `enableTouchGestures: !tenFootMode` at the three reachable player call sites in `IPTVScreen`, reusing the same ten-foot signal the screen already uses for `showCast`. In `_StreamTabContent` that signal is `playlistSourceInInfoBar` — which is exactly what it already forwards as `tenFootMode`.

## Two call sites deliberately untouched

- **The Picture-in-Picture branch** is unreachable on TV (PiP is itself `!tenFootMode`-gated at the capability check) and stays `const`.
- **The one inside `IPTVScreenBody`** is dead code: that widget is declared but never constructed anywhere in the repo — the only four references are its own declaration, constructor, `createState`, and its State's type argument. Attempting to wire it is what surfaced this; flagging rather than deleting a ~280-line class during a release cut.

## Tests

`ten-foot mode suppresses touch-only player chrome` — pumps the screen with `tenFootMode: true`, plays a channel, and asserts every mounted `VideoPlayerWidget` has `enableTouchGestures == false`. Verified to fail against the old code (`Expected: false, Actual: <true>`).

The touch side stays pinned by the existing `enableTouchGestures defaults to true, preserving lock button and gesture surface` in `video_player_widget_test.dart`. I tried a screen-level touch counterpart too, but the embedded preview needs live streaming state the fixture doesn't drive, so it was fragile without adding coverage the widget test doesn't already give.

Green: 874 `feature_iptv` tests, clean analyze.

🤖 Generated with [Claude Code](https://claude.com/claude-code)