### PR TITLE
fix(tv): hide controls and promotions that cannot work on a remote

### DIFF
--- a/app/lib/features/settings/presentation/screens/settings_hub_screen.dart
+++ b/app/lib/features/settings/presentation/screens/settings_hub_screen.dart
@@ -182,14 +182,18 @@ class SettingsHubScreen extends ConsumerWidget {
               onTap: () => showXmltvSourceSheet(context),
             ),
 
-            const SizedBox(height: 24),
-
-            Text(
-              'More Airo Apps',
-              style: Theme.of(context).textTheme.titleMedium,
-            ),
-            const SizedBox(height: 8),
-            for (final app in siblingAppsFor(shellId)) SiblingAppCard(app: app),
+            // Hidden entirely while no listing is live: a heading over three
+            // inert "Coming soon" cards promotes nothing.
+            if (publishedSiblingAppsFor(shellId).isNotEmpty) ...[
+              const SizedBox(height: 24),
+              Text(
+                'More Airo Apps',
+                style: Theme.of(context).textTheme.titleMedium,
+              ),
+              const SizedBox(height: 8),
+              for (final app in publishedSiblingAppsFor(shellId))
+                SiblingAppCard(app: app),
+            ],
 
             const SizedBox(height: 24),
 

--- a/app/lib/features/settings/presentation/tv/tv_settings_screen.dart
+++ b/app/lib/features/settings/presentation/tv/tv_settings_screen.dart
@@ -33,6 +33,19 @@ class _TvSettingsScreenState extends ConsumerState<TvSettingsScreen> {
   /// rather than added as a manifest section.
   bool _isAiroAppsSelected = false;
 
+  /// The cross-app cards worth showing. Empty until a store listing goes
+  /// live, since a card with no listing renders an inert "Coming soon".
+  static final _publishedSiblings = publishedSiblingAppsFor(ShellId.tv);
+
+  /// With no sibling cards this pane holds only the build-version tile, so
+  /// promising "More Airo Apps" would be a rail stop that shows no apps.
+  static final String _airoAppsLabel = _publishedSiblings.isEmpty
+      ? 'About'
+      : 'More Airo Apps';
+  static final IconData _airoAppsIcon = _publishedSiblings.isEmpty
+      ? Icons.info_outline
+      : Icons.apps;
+
   /// The sections this screen renders, in shared-manifest order, filtered to
   /// those declared visible on the TV shell.
   static final _sections = iptvSettingsSections
@@ -135,7 +148,7 @@ class _TvSettingsScreenState extends ConsumerState<TvSettingsScreen> {
                       focusNode: _airoAppsFocusNode,
                       onSelect: () =>
                           setState(() => _isAiroAppsSelected = true),
-                      semanticLabel: 'More Airo Apps',
+                      semanticLabel: _airoAppsLabel,
                       semanticButton: true,
                       child: DecoratedBox(
                         decoration: BoxDecoration(
@@ -148,11 +161,11 @@ class _TvSettingsScreenState extends ConsumerState<TvSettingsScreen> {
                           padding: const EdgeInsets.all(12),
                           child: Row(
                             children: [
-                              Icon(Icons.apps, color: colorScheme.onSurface),
+                              Icon(_airoAppsIcon, color: colorScheme.onSurface),
                               const SizedBox(width: 12),
                               Expanded(
                                 child: Text(
-                                  'More Airo Apps',
+                                  _airoAppsLabel,
                                   overflow: TextOverflow.ellipsis,
                                   style: TextStyle(
                                     color: colorScheme.onSurface,
@@ -186,8 +199,7 @@ class _TvSettingsScreenState extends ConsumerState<TvSettingsScreen> {
       return ListView(
         key: const ValueKey('tv_settings_section_airo_apps'),
         children: [
-          for (final app in siblingAppsFor(ShellId.tv))
-            SiblingAppCard(app: app),
+          for (final app in _publishedSiblings) SiblingAppCard(app: app),
           const SizedBox(height: 24),
           const AppInfoTile(),
         ],

--- a/app/test/features/settings/presentation/screens/settings_hub_screen_test.dart
+++ b/app/test/features/settings/presentation/screens/settings_hub_screen_test.dart
@@ -72,14 +72,16 @@ void main() {
     expect(find.text('Playlist Source'), findsOneWidget);
     expect(find.text('EPG Guide Source'), findsOneWidget);
     expect(find.text('Picture-in-picture'), findsNothing);
-    expect(find.text('More Airo Apps'), findsOneWidget);
-    expect(find.text('Airo TV'), findsOneWidget);
-    expect(find.text('Airo Coins'), findsOneWidget);
-    expect(find.text('Airo Mind'), findsOneWidget);
-    expect(find.text('Airo'), findsNothing);
+    // No sibling listing is live yet, so the section would be a heading over
+    // three inert "Coming soon" cards. Registry-level coverage for which
+    // apps qualify lives in sibling_app_registry_test.dart.
+    expect(find.text('More Airo Apps'), findsNothing);
+    expect(find.text('Airo TV'), findsNothing);
+    expect(find.text('Airo Coins'), findsNothing);
+    expect(find.text('Airo Mind'), findsNothing);
   });
 
-  testWidgets('a non-default shellId excludes itself, not mobile', (
+  testWidgets('an unpublished sibling roster renders no promotion section', (
     tester,
   ) async {
     await tester.binding.setSurfaceSize(const Size(400, 1600));
@@ -98,7 +100,10 @@ void main() {
     );
     await tester.pump();
 
-    expect(find.text('Airo'), findsOneWidget);
+    // Self-exclusion still holds — it is just no longer observable through
+    // this screen, because nothing is published. See
+    // `publishedSiblingAppsFor` tests in core_product_shell.
+    expect(find.text('More Airo Apps'), findsNothing);
     expect(find.text('Airo TV'), findsNothing);
   });
 

--- a/app/test/features/settings/presentation/tv/tv_settings_screen_test.dart
+++ b/app/test/features/settings/presentation/tv/tv_settings_screen_test.dart
@@ -1,4 +1,5 @@
 import 'package:airo_app/features/settings/presentation/tv/tv_settings_screen.dart';
+import 'package:airo_app/features/settings/presentation/widgets/app_info_tile.dart';
 import 'package:core_data/core_data.dart';
 import 'package:feature_iptv/feature_iptv.dart';
 import 'package:flutter/material.dart';
@@ -102,17 +103,31 @@ void main() {
   });
 
   testWidgets(
-    'tapping More Airo Apps shows sibling cards and app info, self excluded',
+    'the cross-app rail entry shows build info, not unpublished apps',
     (tester) async {
       await pumpScreen(tester);
 
-      await tester.tap(find.text('More Airo Apps'));
-      await tester.pump();
+      // No sibling listing is live yet (every `isPublished*` flag in
+      // `siblingApps` is still a placeholder), so promoting them would mean
+      // three inert "Coming soon" cards under a "More Airo Apps" heading.
+      // The entry keeps its other job — the build-version tile support
+      // triages against — and is named for what it actually shows.
+      expect(find.text('More Airo Apps'), findsNothing);
 
-      expect(find.text('Airo'), findsOneWidget);
-      expect(find.text('Airo Coins'), findsOneWidget);
-      expect(find.text('Airo Mind'), findsOneWidget);
+      await tester.tap(find.text('About'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Airo Coins'), findsNothing);
+      expect(find.text('Airo Mind'), findsNothing);
       expect(find.text('Airo TV'), findsNothing);
+      // AppInfoTile renders empty until its platform channel answers, which
+      // it never does under flutter_test — assert it is mounted, and let
+      // app/test/core/tv_stub_version_test.dart pin the value it shows.
+      expect(
+        find.byKey(const ValueKey('tv_settings_section_airo_apps')),
+        findsOneWidget,
+      );
+      expect(find.byType(AppInfoTile), findsOneWidget);
       expect(
         find.byKey(const ValueKey('tv_settings_section_theme')),
         findsNothing,

--- a/packages/core_product_shell/lib/src/sibling_apps/sibling_app.dart
+++ b/packages/core_product_shell/lib/src/sibling_apps/sibling_app.dart
@@ -43,6 +43,14 @@ class SiblingApp {
   final bool isPublishedAndroid;
   final bool isPublishedIos;
 
+  /// Whether this app has a live listing on any platform.
+  ///
+  /// Used to decide whether a "More Airo Apps" section is worth rendering at
+  /// all. A card whose listing is live on one platform still renders its
+  /// "Coming soon" state on the other — that per-platform choice stays in
+  /// `SiblingAppCard`, which is the only place that may read `dart:io`.
+  bool get isPublishedAnywhere => isPublishedAndroid || isPublishedIos;
+
   /// Reserved for future deep-link-if-installed support. Unused in v1.
   final String? deepLinkScheme;
 

--- a/packages/core_product_shell/lib/src/sibling_apps/sibling_app_registry.dart
+++ b/packages/core_product_shell/lib/src/sibling_apps/sibling_app_registry.dart
@@ -57,6 +57,17 @@ final siblingApps = <SiblingApp>[
 List<SiblingApp> siblingAppsFor(ShellId current) =>
     siblingApps.where((app) => app.id != current).toList(growable: false);
 
+/// [siblingAppsFor], minus anything with no live listing yet.
+///
+/// Settings screens render their "More Airo Apps" section from this, so a
+/// section where every card would be an inert "Coming soon" is not shown at
+/// all. Today that is every entry — the `isPublished*` flags above are still
+/// placeholders — so the section is hidden everywhere until a flag is
+/// flipped, at which point it appears on its own with no other change.
+List<SiblingApp> publishedSiblingAppsFor(ShellId current) => siblingAppsFor(
+  current,
+).where((app) => app.isPublishedAnywhere).toList(growable: false);
+
 Uri _playStoreUrl(String packageId) =>
     Uri.parse('https://play.google.com/store/apps/details?id=$packageId');
 

--- a/packages/core_product_shell/test/sibling_apps/sibling_app_registry_test.dart
+++ b/packages/core_product_shell/test/sibling_apps/sibling_app_registry_test.dart
@@ -12,11 +12,10 @@ void main() {
     test('returns the other three shipped apps for a known shell', () {
       final result = siblingAppsFor(ShellId.tv);
 
-      expect(result.map((app) => app.id), containsAll(const [
-        ShellId.mobile,
-        ShellId.coins,
-        ShellId.mind,
-      ]));
+      expect(
+        result.map((app) => app.id),
+        containsAll(const [ShellId.mobile, ShellId.coins, ShellId.mind]),
+      );
       expect(result, hasLength(3));
     });
 
@@ -33,6 +32,51 @@ void main() {
 
       expect(ids, {ShellId.mobile, ShellId.tv, ShellId.coins, ShellId.mind});
       expect(siblingApps, hasLength(4));
+    });
+  });
+
+  group('publishedSiblingAppsFor', () {
+    test('is empty while every listing flag is still a placeholder', () {
+      // Settings screens hide their "More Airo Apps" section when this is
+      // empty, so a section of inert "Coming soon" cards is never rendered.
+      // Flipping an isPublished* flag in the registry is the only change
+      // needed to bring the section back.
+      expect(publishedSiblingAppsFor(ShellId.tv), isEmpty);
+      expect(publishedSiblingAppsFor(ShellId.mobile), isEmpty);
+    });
+
+    test('never includes the current shell', () {
+      for (final shell in const [
+        ShellId.mobile,
+        ShellId.tv,
+        ShellId.coins,
+        ShellId.mind,
+      ]) {
+        expect(
+          publishedSiblingAppsFor(shell).any((app) => app.id == shell),
+          isFalse,
+        );
+      }
+    });
+  });
+
+  group('SiblingApp.isPublishedAnywhere', () {
+    SiblingApp appWith({required bool android, required bool ios}) =>
+        SiblingApp(
+          id: ShellId.coins,
+          name: 'Airo Coins',
+          pitch: 'pitch',
+          iconAsset: 'asset.png',
+          androidStoreUrl: Uri.parse('https://play.google.com/store'),
+          iosStoreUrl: Uri.parse('https://apps.apple.com/app'),
+          isPublishedAndroid: android,
+          isPublishedIos: ios,
+        );
+
+    test('is false only when neither store listing is live', () {
+      expect(appWith(android: false, ios: false).isPublishedAnywhere, isFalse);
+      expect(appWith(android: true, ios: false).isPublishedAnywhere, isTrue);
+      expect(appWith(android: false, ios: true).isPublishedAnywhere, isTrue);
     });
   });
 }

--- a/packages/feature_iptv/lib/presentation/tv_ux/airo_tv_shell.dart
+++ b/packages/feature_iptv/lib/presentation/tv_ux/airo_tv_shell.dart
@@ -157,6 +157,10 @@ class _AiroTvShellState extends ConsumerState<AiroTvShell> {
     );
     final infoBar = ChannelInfoBar(
       channel: widget.currentChannel,
+      // Same grid-first signal `onHelpTap` keys off: no video stage means
+      // the ten-foot layout, where `share_plus` is stubbed and the share
+      // falls back to a clipboard a remote cannot reach.
+      showShareAction: widget.showVideoStage,
       onHelpTap: widget.showVideoStage
           ? null
           : () => showAiroTvShellHelpDialog(context),

--- a/packages/feature_iptv/lib/presentation/tv_ux/sections/channel_info_bar.dart
+++ b/packages/feature_iptv/lib/presentation/tv_ux/sections/channel_info_bar.dart
@@ -18,6 +18,7 @@ class ChannelInfoBar extends ConsumerWidget {
     this.onPlaylistSourceTap,
     this.onWaysToWatchTap,
     this.onScreenshotTap,
+    this.showShareAction = true,
   });
 
   final IPTVChannel? channel;
@@ -25,6 +26,14 @@ class ChannelInfoBar extends ConsumerWidget {
   /// Opens Airo TV help when the video stage (and its overlay actions) is
   /// hidden by a grid-first TV layout. Null hides the button.
   final VoidCallback? onHelpTap;
+
+  /// Whether sharing can actually reach somewhere the viewer can use.
+  ///
+  /// False on the ten-foot layout: `share_plus` is stubbed there, so
+  /// [_copyShareDetails] always falls through to the clipboard — and a
+  /// remote has nowhere to paste it. The button reported "share message
+  /// copied" for a clipboard the user could never open.
+  final bool showShareAction;
 
   /// Opens the playlist-source sheet. Wired on TV where the phone app bar
   /// (the usual home of this action) is suppressed; null hides the button.
@@ -91,20 +100,21 @@ class ChannelInfoBar extends ConsumerWidget {
               icon: Icon(isFavorite ? Icons.favorite : Icons.favorite_border),
             ),
           ),
-          TvFocusable(
-            semanticLabel: 'Share',
-            enabled: channel != null,
-            onSelect: channel == null
-                ? null
-                : () => _copyShareDetails(context, ref, channel!),
-            child: IconButton(
-              onPressed: channel == null
+          if (showShareAction)
+            TvFocusable(
+              semanticLabel: 'Share',
+              enabled: channel != null,
+              onSelect: channel == null
                   ? null
                   : () => _copyShareDetails(context, ref, channel!),
-              tooltip: 'Share',
-              icon: const Icon(Icons.share_outlined),
+              child: IconButton(
+                onPressed: channel == null
+                    ? null
+                    : () => _copyShareDetails(context, ref, channel!),
+                tooltip: 'Share',
+                icon: const Icon(Icons.share_outlined),
+              ),
             ),
-          ),
           if (onScreenshotTap != null)
             TvFocusable(
               key: const ValueKey('channel-info-screenshot'),

--- a/packages/feature_iptv/test/iptv/presentation/tv_ux/airo_tv_shell_test.dart
+++ b/packages/feature_iptv/test/iptv/presentation/tv_ux/airo_tv_shell_test.dart
@@ -5,6 +5,7 @@ import 'package:feature_iptv/application/providers/connectivity_provider.dart';
 import 'package:feature_iptv/application/providers/iptv_providers.dart';
 import 'package:feature_iptv/application/services/wifi_settings_launcher.dart';
 import 'package:feature_iptv/presentation/tv_ux/airo_tv_shell.dart';
+import 'package:feature_iptv/presentation/tv_ux/sections/channel_info_bar.dart';
 import 'package:feature_iptv/presentation/tv_ux/sections/channel_library_grid.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
@@ -357,6 +358,33 @@ void main() {
           .widget<ChannelLibraryGrid>(find.byType(ChannelLibraryGrid))
           .onMultiviewToggle,
       isNull,
+    );
+  });
+
+  testWidgets('grid-first TV layout hides the unusable Share action', (
+    tester,
+  ) async {
+    // share_plus is stubbed on TV, so the share always fell back to the
+    // clipboard and announced "share message copied" — for a clipboard a
+    // remote has no way to open.
+    await pumpAt(tester, 1280, showVideoStage: false);
+    expect(
+      tester
+          .widget<ChannelInfoBar>(find.byType(ChannelInfoBar))
+          .showShareAction,
+      isFalse,
+    );
+  });
+
+  testWidgets('Share stays available where the share sheet works', (
+    tester,
+  ) async {
+    await pumpAt(tester, 1280);
+    expect(
+      tester
+          .widget<ChannelInfoBar>(find.byType(ChannelInfoBar))
+          .showShareAction,
+      isTrue,
     );
   });
 


### PR DESCRIPTION
## Why

Final two items from the pre-release Airo TV audit, both the same shape as the earlier fixes: a control that presents as working over something that isn't there. Both decisions were confirmed with @udaychauhan before changing.

## Share falls back to a clipboard nobody can open

`share_plus` is dependency-overridden to a stub on TV, so `channelShareGatewayProvider.share()` never succeeds and `_copyShareDetails` always takes the clipboard path — then reports:

> **Watch City News Live share message copied**

A remote user has nowhere to paste that. The action is now hidden on the grid-first layout, keyed off the same `showVideoStage` signal `ChannelInfoBar` already uses to decide whether to surface its own help button.

## "More Airo Apps" promoted three disabled cards

Every `isPublished*` flag in `siblingApps` is still a placeholder pending confirmed listing status, so all three cards rendered an inert "Coming soon". A heading over three dead cards promotes nothing.

Adds `publishedSiblingAppsFor`, which drops entries with no live listing, backed by `SiblingApp.isPublishedAnywhere`. Both settings screens (TV rail and phone hub) render from it, so the section disappears while nothing is published and **returns on its own the moment a flag is flipped** — exactly the contract the registry comment already promised:

> *"flip the flag when a listing goes live, no other code changes needed"*

The per-platform choice stays in `SiblingAppCard`, the only place that may read `dart:io`.

### The version tile had to survive

The TV rail entry does double duty: it also hosts `AppInfoTile`, the build-version row support triages against (fixed in #1919). Deleting the entry would have taken the version with it, so it's renamed to **"About"** while it has no apps to list.

## Tests

- `grid-first TV layout hides the unusable Share action` — verified to fail against the old code (`Expected: false, Actual: <true>`); paired with `Share stays available where the share sheet works` so the gate can't become unconditional.
- `publishedSiblingAppsFor` is empty today and never includes the current shell; `isPublishedAnywhere` is false only when neither listing is live — this is what pins the "flip one flag and it comes back" behaviour.
- Self-exclusion is no longer observable through either settings screen, so that coverage **moved** to the registry tests rather than being dropped.

Green: 875 `feature_iptv`, 31 `core_product_shell`, 15 app settings tests; clean analyze.

🤖 Generated with [Claude Code](https://claude.com/claude-code)