### PR TITLE
fix(app): fake FilePickerPlatform.pickFile missing darwinOptions param

### DIFF
--- a/app/test/features/iptv/phone_media_local_picker_test.dart
+++ b/app/test/features/iptv/phone_media_local_picker_test.dart
@@ -370,6 +370,7 @@ class _FakeFilePickerPlatform extends FilePickerPlatform {
     Function(FilePickerStatus)? onFileLoading,
     int compressionQuality = 0,
     AndroidOptions androidOptions = const AndroidOptions(),
+    DarwinOptions darwinOptions = const DarwinOptions(),
     WindowsOptions windowsOptions = const WindowsOptions(),
     LinuxOptions linuxOptions = const LinuxOptions(),
     WebOptions webOptions = const WebOptions(),


### PR DESCRIPTION
## Summary

#1924 merged before this fix landed — `analyze`/`code-quality` on `main` are red because of it. The full-app pubspec (restored in #1924) resolves `file_picker_platform_interface` 3.2.0, whose `FilePickerPlatform.pickFile` gained a `DarwinOptions darwinOptions` parameter. `_FakeFilePickerPlatform` in the test predates that, so `flutter analyze` fails with `invalid_override`.

## Fix

Add the missing `DarwinOptions darwinOptions = const DarwinOptions()` param to `_FakeFilePickerPlatform.pickFile` in `app/test/features/iptv/phone_media_local_picker_test.dart`.

## Test plan
- [x] `flutter analyze --no-fatal-infos --no-fatal-warnings` in `app/` — 3 pre-existing infos, 0 errors (verification environment: host-only)

Note: `airo-mind-shell` / `test-core` / `tests` are still red on `main` independent of this fix — pre-existing `packages/feature_mind` Rust bridge drift (`TranscriptEvent_ConversationIr` isn't a type, missing `audioPath` param in `lib/src/bridges/mind_speech_bridge.dart`), out of scope for the 0.0.7 pubspec/release-doc work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)