### PR TITLE
fix(app): relabel Assistant nav tab to Mind

### DIFF
--- a/app/lib/core/providers/navigation_provider.dart
+++ b/app/lib/core/providers/navigation_provider.dart
@@ -28,7 +28,7 @@ enum AppNavigationTab {
     selectedIcon: Icons.monetization_on,
   ),
   assistant(
-    label: 'Assistant',
+    label: 'Mind',
     path: AssistantRouteNames.assistant,
     icon: Icons.psychology_outlined,
     selectedIcon: Icons.psychology,

--- a/app/lib/features/home/screens/home_screen.dart
+++ b/app/lib/features/home/screens/home_screen.dart
@@ -45,7 +45,7 @@ class HomeScreen extends StatelessWidget {
             child: _AdaptiveDestinationGrid(
               destinations: [
                 _HomeDestination(
-                  title: 'Assistant',
+                  title: 'Mind',
                   description: 'Think, write, and work with your local AI.',
                   icon: Icons.psychology_outlined,
                   route: AssistantRouteNames.assistant,

--- a/app/test/core/app/app_shell_header_ownership_test.dart
+++ b/app/test/core/app/app_shell_header_ownership_test.dart
@@ -105,7 +105,7 @@ void main() {
     await pumpShellRoute(tester, initialLocation: '/assistant');
 
     expect(find.byType(AppBar), findsOneWidget);
-    expect(find.widgetWithText(AppBar, 'Assistant'), findsOneWidget);
+    expect(find.widgetWithText(AppBar, 'Mind'), findsOneWidget);
     expect(find.byKey(const ValueKey('app_shell_home_button')), findsOneWidget);
     expect(
       find.byKey(const ValueKey('app_shell_notifications_button')),

--- a/app/test/core/providers/navigation_provider_test.dart
+++ b/app/test/core/providers/navigation_provider_test.dart
@@ -7,7 +7,7 @@ void main() {
     test('uses the seven-tab information architecture order', () {
       expect(AppNavigationTab.values.map((tab) => tab.label), [
         'Coins',
-        'Assistant',
+        'Mind',
         'Beats',
         'Live',
         'Arena',
@@ -113,7 +113,7 @@ void main() {
 
       expect(phoneTabs.map((t) => t.label).toList(), [
         'Coins',
-        'Assistant',
+        'Mind',
         'Beats',
         'Live',
       ]);
@@ -139,7 +139,7 @@ void main() {
       expect(policy.compactWidthBreakpoint, 600);
       expect(wideLayout.persistentTabs.map((t) => t.label).toList(), [
         'Coins',
-        'Assistant',
+        'Mind',
         'Beats',
         'Live',
         'Arena',


### PR DESCRIPTION
## Summary

User-reported: the Mind tab is "missing" from the Airo super app. It isn't missing — the top-level tab that routes to `/mind` (the Airo Mind hub: AI chat, Meeting Scribe, etc.) still carries the pre-milestone-22 label "Assistant" from before `feature_mind` claimed the `/mind` route and the "Mind" name. Relabels it.

- `app/lib/core/providers/navigation_provider.dart` — `AppNavigationTab.assistant.label`: `'Assistant'` → `'Mind'`
- `app/lib/features/home/screens/home_screen.dart` — matching "Continue" destination card on the Home dashboard, same rename for consistency
- Route name / go_router name (`AssistantRouteNames.assistant`) is **unchanged** — deep links and notification payloads resolve on it (see `app/test/assistant_route_parity_test.dart`'s comment on why that name must not drift)
- Enum member identifier `assistant` is **unchanged** — only the display label moved, so no index-based references break

## Test plan
- [x] `flutter analyze --no-fatal-infos --no-fatal-warnings` — 3 pre-existing infos, 0 errors (host-only)
- [ ] `flutter test` — **could not run**: `packages/feature_mind`'s Rust bridge (`mind_speech_bridge.dart`) currently fails to compile against its generated bindings (`TranscriptEvent_ConversationIr` isn't a type; `stopLiveSession` missing `audioPath` param), which blocks every test that transitively imports `feature_mind` — including `navigation_provider_test.dart` and `app_shell_header_ownership_test.dart`, both updated here to expect `'Mind'`. This is pre-existing on `main`, unrelated to this change (also seen failing `airo-mind-shell`/`test-core`/`tests` CI jobs on #1924/#1929).

Updated test expectations by hand for the same reason they'd otherwise fail:
- `app/test/core/providers/navigation_provider_test.dart` (3 label assertions)
- `app/test/core/app/app_shell_header_ownership_test.dart` (AppBar title assertion)

🤖 Generated with [Claude Code](https://claude.com/claude-code)