### PR TITLE
fix(macos): restore the TV product name in the shared Runner config

### DIFF
--- a/app/macos/Runner/Configs/AppInfo.xcconfig
+++ b/app/macos/Runner/Configs/AppInfo.xcconfig
@@ -5,7 +5,12 @@
 // 'flutter create' template.
 
 // The application's name. By default this is also the title of the Flutter window.
-PRODUCT_NAME = Airo Mind
+//
+// This is the TV shell's name: the macOS release workflow builds only the `tv`
+// profile against this one Runner target. Do not commit another flavour's name
+// here — `app/tool/run_mind_macos.sh` rewrites this line for a local Mind run
+// and restores it on exit, so a stray value means that restore was skipped.
+PRODUCT_NAME = Airo TV
 
 // The application's bundle identifier
 PRODUCT_BUNDLE_IDENTIFIER = com.developerscoffee.airo.tv

--- a/app/test/core/macos_product_name_test.dart
+++ b/app/test/core/macos_product_name_test.dart
@@ -1,0 +1,54 @@
+@TestOn('vm')
+library;
+
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// Every macOS flavour shares one Runner target, so `AppInfo.xcconfig` is the
+/// single place the shipped app's name comes from — and
+/// `.github/workflows/airo-macos-release.yml` builds only the `tv` profile
+/// against it, overriding nothing.
+///
+/// `app/tool/run_mind_macos.sh` rewrites `PRODUCT_NAME` for a local Mind run
+/// and restores it through a trap on exit. When that restore is skipped, the
+/// mutation is committable — and it was: `69aa847c` shipped
+/// `PRODUCT_NAME = Airo Mind` into the TV release config, so the macOS TV
+/// build produced an app named "Airo Mind".
+void main() {
+  test('macOS AppInfo.xcconfig still names the TV shell', () {
+    final config = File('macos/Runner/Configs/AppInfo.xcconfig');
+    expect(
+      config.existsSync(),
+      isTrue,
+      reason:
+          'Run from the app/ package root. Looked for ${config.absolute.path}.',
+    );
+
+    String value(String key) {
+      final match = RegExp(
+        '^$key\\s*=\\s*(.+?)\\s*\$',
+        multiLine: true,
+      ).firstMatch(config.readAsStringSync());
+      expect(match, isNotNull, reason: 'No `$key` line in AppInfo.xcconfig.');
+      return match!.group(1)!;
+    }
+
+    expect(
+      value('PRODUCT_NAME'),
+      'Airo TV',
+      reason:
+          'The macOS release builds the tv profile against this file. A '
+          'different flavour name here means run_mind_macos.sh (or a similar '
+          'script) rewrote it and the restore was skipped — revert the line '
+          'rather than updating this test.',
+    );
+    expect(
+      value('PRODUCT_BUNDLE_IDENTIFIER'),
+      'com.developerscoffee.airo.tv',
+      reason:
+          'Changing the bundle identifier changes app identity for every '
+          'already-installed macOS user.',
+    );
+  });
+}


### PR DESCRIPTION
## Why

**The Airo TV macOS release currently ships an app named "Airo Mind."** Found while auditing Mind; it affects the TV release in flight, so it's split out first.

## What broke

`app/macos/Runner/Configs/AppInfo.xcconfig` is committed as:

```
PRODUCT_NAME = Airo Mind
PRODUCT_BUNDLE_IDENTIFIER = com.developerscoffee.airo.tv
```

Every macOS flavour shares one Runner target, and `airo-macos-release.yml` states it *"only ever builds the `tv` profile"* — it sets no `PRODUCT_NAME` override. So the TV macOS build takes that name verbatim.

`app/tool/run_mind_macos.sh:29-30` rewrites the line for a local Mind run and restores it through an exit trap:

```bash
cp "$APP_INFO_XCCONFIG" "$APP_INFO_BACKUP"
sed -i '' 's/^PRODUCT_NAME = .*/PRODUCT_NAME = Airo Mind/' "$APP_INFO_XCCONFIG"
```

The restore was skipped and the mutation committed in `69aa847c`.

## What changed

Restores `PRODUCT_NAME = Airo TV`, and adds a comment saying why a stray flavour name here means a skipped restore rather than an intentional edit.

Adds `app/test/core/macos_product_name_test.dart`, which reads the xcconfig and fails if the product name **or** the bundle identifier drifts. Verified by re-introducing `Airo Mind` — the test catches it with a message telling the next person to revert the line rather than update the test.

The bundle identifier is pinned too because changing it changes app identity for every already-installed macOS user.

## Not addressed here

Mind and TV still share one bundle identifier and one Runner target, so they can't be installed side by side on a Mac — which is why `run_mind_macos.sh` stages Mind's model weights into `~/Library/Containers/com.developerscoffee.airo.tv/`. That's a flavour-separation change, not a release-cut fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)