### PR TITLE
fix(macos): grant the sandbox capabilities shipped journeys already use

### DIFF
--- a/app/macos/Runner/DebugProfile.entitlements
+++ b/app/macos/Runner/DebugProfile.entitlements
@@ -10,7 +10,9 @@
 	<true/>
 	<key>com.apple.security.app-sandbox</key>
 	<true/>
-	<key>com.apple.security.files.user-selected.read-only</key>
+	<!-- Kept in step with Release.entitlements: meeting export and notebook
+	     share write into a user-picked location, which read-only denies. -->
+	<key>com.apple.security.files.user-selected.read-write</key>
 	<true/>
 	<key>com.apple.security.cs.allow-jit</key>
 	<true/>

--- a/app/macos/Runner/Release.entitlements
+++ b/app/macos/Runner/Release.entitlements
@@ -10,9 +10,21 @@
 	<true/>
 	<key>com.apple.security.app-sandbox</key>
 	<true/>
-	<key>com.apple.security.files.user-selected.read-only</key>
+	<!-- Read-write, not read-only: meeting export creates a folder and writes
+	     files into a directory the user picked
+	     (feature_mind meeting_export_gateway.dart), and notebook share writes
+	     a file through FilePicker.saveFile. Both are user-initiated saves into
+	     a location the user chose in the panel; read-only silently failed
+	     them in Release while dev builds appeared to work. -->
+	<key>com.apple.security.files.user-selected.read-write</key>
 	<true/>
 	<key>com.apple.security.network.client</key>
+	<true/>
+	<!-- Settings -> Backup and restore -> "Create LAN share" binds a local
+	     HTTP server to hand an encrypted backup to another device on the same
+	     network. This was present in DebugProfile.entitlements only, so the
+	     feature worked when run locally and failed in the shipped build. -->
+	<key>com.apple.security.network.server</key>
 	<true/>
 </dict>
 </plist>

--- a/app/test/core/macos_entitlements_test.dart
+++ b/app/test/core/macos_entitlements_test.dart
@@ -1,0 +1,64 @@
+@TestOn('vm')
+library;
+
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// macOS ships sandboxed, so a capability the code uses but the entitlement
+/// file does not grant fails silently at runtime — and only in the profile
+/// whose entitlement is missing. Both real cases behaved that way: meeting
+/// export was granted `user-selected.read-only` while it creates directories
+/// and writes files, and `network.server` was in DebugProfile only, so the
+/// LAN share worked when run locally and failed in the shipped build.
+void main() {
+  final profiles = {
+    'Release': File('macos/Runner/Release.entitlements'),
+    'DebugProfile': File('macos/Runner/DebugProfile.entitlements'),
+  };
+
+  /// Capabilities every profile must grant, and the journey that needs each.
+  const required = {
+    'com.apple.security.device.audio-input': 'meeting recording',
+    'com.apple.security.files.user-selected.read-write':
+        'meeting export and notebook share write into a user-picked folder',
+    'com.apple.security.network.client': 'model download',
+    'com.apple.security.network.server': 'Backup and restore LAN share',
+  };
+
+  for (final entry in profiles.entries) {
+    group('${entry.key}.entitlements', () {
+      test('grants every capability a shipped journey depends on', () {
+        final file = entry.value;
+        expect(
+          file.existsSync(),
+          isTrue,
+          reason:
+              'Run from the app/ package root. Looked for '
+              '${file.absolute.path}.',
+        );
+        final contents = file.readAsStringSync();
+
+        for (final capability in required.entries) {
+          expect(
+            contents,
+            contains('<key>${capability.key}</key>'),
+            reason:
+                'Missing ${capability.key}, which ${capability.value} needs. '
+                'Under App Sandbox this fails silently at runtime rather '
+                'than at build time.',
+          );
+        }
+      });
+
+      test('does not keep the read-only variant alongside read-write', () {
+        // Both keys present is not an error to macOS, but it hides which one
+        // the build is actually relying on.
+        expect(
+          entry.value.readAsStringSync(),
+          isNot(contains('com.apple.security.files.user-selected.read-only')),
+        );
+      });
+    });
+  }
+}


### PR DESCRIPTION
## Why

From the Airo Mind macOS audit. Two features are written against sandbox capabilities the entitlement files don't grant. Under App Sandbox that fails **at runtime, silently** — no build-time signal — and one of them fails only in the profile that ships.

## Meeting export could never write

`packages/feature_mind/lib/src/export/data/meeting_export_gateway.dart:73-88` picks a folder, then creates directories and writes files into it:

```dart
final root = await FilePicker.getDirectoryPath(...);
final dir = Directory(p.join(root, bundle.folderName));
await dir.create(recursive: true);
await File(p.join(dir.path, entry.key)).writeAsString(entry.value);
```

Both profiles granted `files.user-selected.read-**only**`. Same gap hits `notebook_share_port.dart:69` (`FilePicker.saveFile`). Broken in dev *and* release. Reachable from the Scribe library's export-all and per-meeting export.

## LAN share worked in dev, failed when shipped

Settings → Backup and restore → **Create LAN share** binds a local HTTP server (`airo_portability_screen.dart:130`). Routed from both `main_mind.dart:286` and `app_router.dart:146`, ungated — a real shipped feature.

`com.apple.security.network.server` was in `DebugProfile.entitlements` only. So it passed every local test and failed for users.

## What changed

- `files.user-selected.read-only` → `read-write` in **both** profiles (they had drifted; export was broken in dev too).
- `network.server` added to Release.
- Each key carries a comment naming the journey that needs it, so the next reader can tell a deliberate grant from a copy-paste.

These are the narrowest capabilities that make the existing features work — both file writes are user-initiated saves into a location the user chose in the panel.

## Tests

`app/test/core/macos_entitlements_test.dart` asserts every required capability is present in **both** profiles, and that the superseded read-only key is gone (having both isn't an error to macOS, but it hides which one the build relies on). Verified by removing `network.server` — the failure names the journey that breaks.

Both plists pass `plutil -lint`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)