### PR TITLE
fix(tv): TV version stub drift + rustfmt drift left over from #1931

### DIFF
--- a/packages/stubs/package_info_plus_stub/lib/package_info_plus.dart
+++ b/packages/stubs/package_info_plus_stub/lib/package_info_plus.dart
@@ -14,7 +14,7 @@ library;
 
 /// Kept equal to the `version:` field of `app/pubspec_tv.yaml`, which is
 /// `<_stubVersion>+<_stubBuildNumber>`.
-const String _stubVersion = '0.0.7-preview';
+const String _stubVersion = '0.0.7';
 const String _stubBuildNumber = '12';
 
 class PackageInfo {

--- a/rust/airo_mind_core/src/models.rs
+++ b/rust/airo_mind_core/src/models.rs
@@ -104,10 +104,7 @@ pub struct ModelRequirement {
 }
 
 /// File/batch transcription: highest quality tier that fits the memory budget.
-pub fn speech_file_requirement(
-    memory_budget_mb: u32,
-    language: ModelLanguage,
-) -> ModelRequirement {
+pub fn speech_file_requirement(memory_budget_mb: u32, language: ModelLanguage) -> ModelRequirement {
     speech_final_requirement(
         memory_budget_mb,
         language,
@@ -135,9 +132,7 @@ pub fn speech_final_requirement(
 ) -> ModelRequirement {
     let (minimum_quality, maximum_quality) = match profile {
         FinalProcessingProfile::Fast => (ModelQuality::Draft, Some(ModelQuality::Draft)),
-        FinalProcessingProfile::Balanced => {
-            (ModelQuality::Standard, Some(ModelQuality::Standard))
-        }
+        FinalProcessingProfile::Balanced => (ModelQuality::Standard, Some(ModelQuality::Standard)),
         FinalProcessingProfile::MaximumQuality => (ModelQuality::Standard, None),
     };
     ModelRequirement {

--- a/rust/airo_mind_diarize/src/cluster.rs
+++ b/rust/airo_mind_diarize/src/cluster.rs
@@ -183,11 +183,8 @@ pub fn cluster_embeddings_product(
     join_threshold: f32,
     enrollment_hints: &[Option<String>],
 ) -> (Vec<ClusterAssignment>, bool) {
-    let greedy = cluster_embeddings_greedy_with_enrollment(
-        embeddings,
-        join_threshold,
-        enrollment_hints,
-    );
+    let greedy =
+        cluster_embeddings_greedy_with_enrollment(embeddings, join_threshold, enrollment_hints);
     if should_use_adjacent_turn(embeddings, &greedy) {
         apply_adjacent_turn_refinement(embeddings, &greedy)
     } else {

--- a/rust/airo_mind_diarize/src/pcm_slice.rs
+++ b/rust/airo_mind_diarize/src/pcm_slice.rs
@@ -19,17 +19,12 @@ pub fn slice_segment_pcm(pcm: &Pcm, start_ms: u64, end_ms: u64) -> Vec<i16> {
 }
 
 /// Segment slice with symmetric context padding for stabler speaker embeddings.
-pub fn slice_segment_pcm_padded(
-    pcm: &Pcm,
-    start_ms: u64,
-    end_ms: u64,
-    pad_ms: u64,
-) -> Vec<i16> {
+pub fn slice_segment_pcm_padded(pcm: &Pcm, start_ms: u64, end_ms: u64, pad_ms: u64) -> Vec<i16> {
     if pcm.sample_rate_hz == 0 || pcm.samples.is_empty() {
         return Vec::new();
     }
-    let audio_end_ms = (pcm.samples.len() as u64 * 1000)
-        / (pcm.sample_rate_hz as u64 * pcm.channels as u64);
+    let audio_end_ms =
+        (pcm.samples.len() as u64 * 1000) / (pcm.sample_rate_hz as u64 * pcm.channels as u64);
     let padded_start = start_ms.saturating_sub(pad_ms);
     let padded_end = (end_ms + pad_ms).min(audio_end_ms);
     slice_segment_pcm(pcm, padded_start, padded_end)


### PR DESCRIPTION
## Summary

#1931 merged (regen stale whisper FRB bindings) before its own CI was fully green — two follow-up fixes were pushed after the merge and never landed. Picking those up here, off current `main`.

### 1. TV package_info stub still said 0.0.7-preview
`app/pubspec_tv.yaml` moved `0.0.7-preview+12` → `0.0.7+12` in #1924, but `packages/stubs/package_info_plus_stub` (the lean TV `package_info_plus` stub — no platform channel, so it can't read the real Gradle stamp) still hardcoded the old preview string. Support would see `0.0.7-preview (12)` in Settings against a real `0.0.7+12` APK. `app/test/core/tv_stub_version_test.dart` exists specifically to catch this drift, and it did — it was the sole failure in #1931's `test-app` CI job.

### 2. rustfmt drift on `airo_mind_core`/`airo_mind_diarize`
#1931's `Rust Core CI` job (`Rust test + clippy (host)`) failed on `cargo fmt --check` drift in `models.rs`, `cluster.rs`, `pcm_slice.rs` — pre-existing, unrelated to that PR's own diff. A fix was pushed as a follow-up commit, but #1931 had already been merged at that point without it, so the drift is still on `main`.

## Test plan (host-only)
- [x] `flutter test test/core/tv_stub_version_test.dart` — passes
- [x] `cargo fmt --manifest-path rust/Cargo.toml --all --check` — clean
- [x] `cargo clippy -p airo_mind_diarize --lib` — clean (no warnings for this crate; unrelated `chunks_exact_to_as_chunks` unknown-lint noise from local rustc/clippy version drift in `airo_mind_core`, not from this diff)

🤖 Generated with [Claude Code](https://claude.com/claude-code)