### PR TITLE
fix(mind): point the live fan-out paths at the directory Rust actually uses

### DIFF
--- a/packages/feature_mind/lib/src/capture/application/live_capture_preferences.dart
+++ b/packages/feature_mind/lib/src/capture/application/live_capture_preferences.dart
@@ -2,10 +2,10 @@ import 'dart:io';
 
 import 'package:flutter_riverpod/legacy.dart';
 import 'package:path/path.dart' as p;
-import 'package:path_provider/path_provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import '../domain/live_intelligence_mode.dart';
+import '../../mind_store_paths.dart';
 
 const String liveInsightsEnabledKey = 'mind_live_insights_enabled';
 const String liveInsightsAutoExpandKey = 'mind_live_insights_auto_expand';
@@ -82,11 +82,16 @@ class LiveIntelligenceModeNotifier extends StateNotifier<LiveIntelligenceMode> {
 }
 
 /// Sidecar Rust reads at `start_live_session` (store parent).
+///
+/// That parent is `{applicationSupport}/airo_mind`, not application support
+/// itself — see [mindStoreParentDirectory]. This wrote one segment short, so
+/// `read_live_intelligence_mode` never found the file and silently fell back
+/// to "automatic", making the setting inert.
 Future<void> persistLiveIntelligenceModeToNative(
   LiveIntelligenceMode mode,
 ) async {
   try {
-    final dir = await getApplicationSupportDirectory();
+    final dir = await mindStoreParentDirectory();
     File(
       p.join(dir.path, 'mind_live_intelligence_mode'),
     ).writeAsStringSync(mode.storageValue);

--- a/packages/feature_mind/lib/src/capture/application/meeting_capture_providers.dart
+++ b/packages/feature_mind/lib/src/capture/application/meeting_capture_providers.dart
@@ -19,6 +19,7 @@ import '../domain/meeting_processing_job.dart';
 import 'meeting_capture_controller.dart';
 import 'meeting_live_session_coordinator.dart';
 import 'meeting_processing_queue.dart';
+import '../../mind_store_paths.dart';
 
 /// Factory for one microphone encoder per capture session. Widget tests
 /// return the same fake every call so Start can be asserted.
@@ -75,8 +76,13 @@ Future<String> nextMeetingRecordingPath() async {
 /// WAV path the native live fan-out writes. Must stay in lock-step with
 /// `airo_mind_whisper::api::meetings::live_fanout_path`:
 /// `{store_path.parent}/mind_recordings/{meetingId}.wav`.
+///
+/// That parent is `{applicationSupport}/airo_mind`, not application support
+/// itself — see [mindStoreParentDirectory]. This resolved against plain
+/// application support, one segment short, so every live session handed the
+/// processing queue a path Rust had never written to.
 Future<String> nextLiveFanoutRecordingPath(String meetingId) async {
-  final dir = await getApplicationSupportDirectory();
+  final dir = await mindStoreParentDirectory();
   final recordingsDir = Directory(p.join(dir.path, 'mind_recordings'));
   await recordingsDir.create(recursive: true);
   return p.join(recordingsDir.path, '$meetingId.wav');
@@ -91,7 +97,8 @@ final liveFanoutRecordingPathProvider =
 /// refusal without loading the whisper cdylib.
 final meetingLiveSessionCoordinatorFactoryProvider =
     Provider<MeetingLiveSessionCoordinator Function()>(
-      (ref) => () => MeetingLiveSessionCoordinator(),
+      (ref) =>
+          () => MeetingLiveSessionCoordinator(),
     );
 
 Future<String> _processingQueuePath() async {

--- a/packages/feature_mind/lib/src/mind_store_paths.dart
+++ b/packages/feature_mind/lib/src/mind_store_paths.dart
@@ -1,0 +1,32 @@
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+import 'package:path_provider/path_provider.dart';
+
+/// The directory Rust calls `STORE_PARENT_DIR`.
+///
+/// Rust derives it once, in `airo_mind_whisper::api::meetings::initialize`, as
+/// `dirname(config.store_path)` — and Dart passes
+/// `{applicationSupport}/airo_mind/meetings.log` as that store path
+/// (`MindService.modelsDirectory` + `storePath:`). So the shared root both
+/// sides must agree on is `{applicationSupport}/airo_mind`, **not**
+/// `{applicationSupport}`.
+///
+/// Getting this wrong is silent in both directions: Rust writes the live
+/// fan-out WAV somewhere Dart never looks, and reads a settings sidecar Dart
+/// never wrote. Neither throws. Every Dart path that has to line up with a
+/// Rust-side path resolves through here so the two cannot drift apart again.
+///
+/// Paths that are Dart's alone — the `.m4a` the recorder writes and reads
+/// back, and the processing queue — deliberately do not use this. Moving
+/// those would relocate files that already exist on users' machines, which is
+/// a migration rather than a fix.
+Future<Directory> mindStoreParentDirectory() async {
+  final base = await getApplicationSupportDirectory();
+  final dir = Directory(p.join(base.path, mindStoreDirectoryName));
+  if (!dir.existsSync()) dir.createSync(recursive: true);
+  return dir;
+}
+
+/// The one segment that separates `STORE_PARENT_DIR` from application support.
+const String mindStoreDirectoryName = 'airo_mind';

--- a/packages/feature_mind/test/capture/live_fanout_path_contract_test.dart
+++ b/packages/feature_mind/test/capture/live_fanout_path_contract_test.dart
@@ -1,0 +1,116 @@
+@TestOn('vm')
+library;
+
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// The Dart↔Rust path contract, asserted against the Rust source itself.
+///
+/// Rust derives `STORE_PARENT_DIR` once, in
+/// `airo_mind_whisper::api::meetings::initialize`, as
+/// `dirname(config.store_path)`. Dart passes
+/// `{applicationSupport}/airo_mind/meetings.log` as that store path, so the
+/// shared root is `{applicationSupport}/airo_mind`.
+///
+/// Both Dart sides had resolved against plain application support instead —
+/// one segment short. Nothing threw: the live fan-out WAV was written by Rust
+/// somewhere Dart never looked, and the live-intelligence sidecar was written
+/// by Dart somewhere Rust never read, so the setting was permanently inert.
+///
+/// A unit test cannot catch that (each side is self-consistent), so this
+/// compares the two sources of truth directly.
+void main() {
+  File rustSource() {
+    for (final candidate in [
+      // From packages/feature_mind (package test run).
+      '../../rust/airo_mind_whisper/src/api/meetings.rs',
+      // From the repo root (melos / IDE run).
+      'rust/airo_mind_whisper/src/api/meetings.rs',
+    ]) {
+      final file = File(candidate);
+      if (file.existsSync()) return file;
+    }
+    fail(
+      'Could not locate airo_mind_whisper meetings.rs from ${Directory.current.path}',
+    );
+  }
+
+  test('Rust still derives its store parent from the store path', () {
+    // If this changes shape, `mindStoreParentDirectory` needs rereading — the
+    // whole contract rests on the parent being dirname(store_path).
+    expect(
+      rustSource().readAsStringSync(),
+      contains('*lock(&STORE_PARENT_DIR) = PathBuf::from(&config.store_path)'),
+      reason:
+          'STORE_PARENT_DIR is no longer derived from config.store_path, so '
+          'mind_store_paths.dart may now point somewhere Rust does not use.',
+    );
+  });
+
+  test('Rust still joins mind_recordings under the store parent', () {
+    expect(
+      rustSource().readAsStringSync(),
+      contains('.join("mind_recordings")'),
+      reason:
+          'live_fanout_path changed; nextLiveFanoutRecordingPath must follow.',
+    );
+  });
+
+  test(
+    'Rust still reads the live-intelligence sidecar from the store parent',
+    () {
+      expect(
+        rustSource().readAsStringSync(),
+        contains('parent.join("mind_live_intelligence_mode")'),
+        reason:
+            'persistLiveIntelligenceModeToNative writes this file; if Rust '
+            'moved it, the setting goes silently inert again.',
+      );
+    },
+  );
+
+  test('Dart resolves both Rust-coupled paths through the store parent', () {
+    // Anchored on each function's *declaration*, not its name: the name also
+    // appears at call sites, and the bug lived in the body.
+    const coupled = {
+      'lib/src/capture/application/meeting_capture_providers.dart':
+          'Future<String> nextLiveFanoutRecordingPath(String meetingId) async {',
+      'lib/src/capture/application/live_capture_preferences.dart':
+          'Future<void> persistLiveIntelligenceModeToNative(',
+    };
+
+    for (final entry in coupled.entries) {
+      final file = File(entry.key).existsSync()
+          ? File(entry.key)
+          : File('packages/feature_mind/${entry.key}');
+      expect(file.existsSync(), isTrue, reason: 'Missing ${entry.key}');
+
+      final source = file.readAsStringSync();
+      final start = source.indexOf(entry.value);
+      expect(
+        start,
+        isNonNegative,
+        reason: 'Declaration moved or was renamed in ${entry.key}.',
+      );
+      final body = source.substring(start, source.indexOf('\n}', start));
+
+      expect(
+        body,
+        contains('mindStoreParentDirectory()'),
+        reason:
+            'This path must land under {applicationSupport}/airo_mind to '
+            'match Rust STORE_PARENT_DIR.',
+      );
+      // The Dart-only .m4a and processing-queue paths still use plain
+      // application support legitimately, so this is scoped to these bodies.
+      expect(
+        body,
+        isNot(contains('getApplicationSupportDirectory()')),
+        reason:
+            'Resolving against plain application support is one segment short '
+            'of the directory Rust uses, and fails silently.',
+      );
+    }
+  });
+}


### PR DESCRIPTION
## Why

From the Airo Mind macOS audit. Two Dart paths are one directory segment short of where Rust reads and writes. Neither fails loudly.

## The contract

Rust derives `STORE_PARENT_DIR` once, in `airo_mind_whisper::api::meetings::initialize`:

```rust
*lock(&STORE_PARENT_DIR) = PathBuf::from(&config.store_path).parent()...
```

Dart passes `{applicationSupport}/airo_mind/meetings.log` as that store path, so the shared root is **`{applicationSupport}/airo_mind`** — not `{applicationSupport}`.

## Two places got it wrong

**1. Live recordings were handed to the queue as a path that never existed.**
`nextLiveFanoutRecordingPath` returned `{applicationSupport}/mind_recordings/{id}.wav`; Rust's `live_fanout_path` joins `mind_recordings` under `STORE_PARENT_DIR`. `FanoutBackedAudioRecorderPort.stop()` returns the path unconditionally and `meeting_capture_screen.dart:219` treats non-null as success — so every live session queued a job pointing at nothing. Desktop is the **only** host gated into this path (`live_transcription_support.dart:8-13`), and it's the flagship desktop feature.

Its own doc comment already stated the correct contract (`{store_path.parent}/mind_recordings/…`); the code didn't match it.

**2. The Live Intelligence setting was inert.**
`persistLiveIntelligenceModeToNative` wrote to `{applicationSupport}/mind_live_intelligence_mode`; `read_live_intelligence_mode` reads `parent.join("mind_live_intelligence_mode")`. Rust never found it and fell back to `"automatic"` every time.

## What changed

Adds `mind_store_paths.dart` with a single `mindStoreParentDirectory()` that both call sites resolve through, documenting why application support alone is the wrong root.

Dart-only paths — the `.m4a` the recorder writes and reads back, and the processing queue — **deliberately keep** using plain application support. Moving those would relocate files that already exist on users' machines, which is a migration, not a fix.

**No migration needed here:** Rust already writes to the correct location, so this only corrects where Dart looks. Any stray file at the old path is inert.

## Tests

A unit test can't catch this — each side is self-consistent alone — so `test/capture/live_fanout_path_contract_test.dart` compares the two sources of truth directly:

- Rust still derives the parent from `config.store_path`
- Rust still joins `mind_recordings` and `mind_live_intelligence_mode` under it
- Both Dart **declarations** (anchored on the signature, since the names also appear at call sites) resolve through the shared helper and no longer call `getApplicationSupportDirectory()` directly

Verified by reverting each side in turn. Green: 103 `feature_mind` capture tests, 0 analyzer errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)