### PR TITLE
fix(mind): restate the Android declarations the variant manifest dropped

### DIFF
--- a/app/android/app/src/mind/AndroidManifest.xml
+++ b/app/android/app/src/mind/AndroidManifest.xml
@@ -11,8 +11,21 @@
     <!-- Scribe records meetings on device. -->
     <uses-permission android:name="android.permission.RECORD_AUDIO"/>
 
-    <!-- Bug-report attachments (image_picker). -->
+    <!-- Bug-report attachments (image_picker). Declared not-required so Play
+         does not filter Airo Mind off camera-less devices — nothing in Mind
+         needs a camera to work, and the picker falls back to the gallery. -->
     <uses-permission android:name="android.permission.CAMERA"/>
+    <uses-feature
+        android:name="android.hardware.camera"
+        android:required="false"/>
+    <uses-feature
+        android:name="android.hardware.camera.autofocus"
+        android:required="false"/>
+
+    <!-- flutter_local_notifications reschedules across reboot; without this
+         (and the receivers below) every scheduled agent notification is lost
+         on restart. -->
+    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED"/>
 
     <!-- audio_service: MainActivity extends AudioServiceFragmentActivity and
          pubspec_mind.yaml keeps the plugin real, so the service below must be
@@ -33,7 +46,15 @@
         android:label="${appLabel}"
         android:name="${applicationName}"
         android:icon="@mipmap/ic_launcher"
-        android:networkSecurityConfig="@xml/network_security_config">
+        android:networkSecurityConfig="@xml/network_security_config"
+        android:allowBackup="false"><!--
+        allowBackup is off deliberately. Airo Mind's whole claim is that
+        meetings, transcripts and the vault stay on the device; Android Auto
+        Backup would copy that database and its preferences to the user's
+        Google Drive without them ever asking. The product ships its own
+        explicit transfer paths instead (Settings -> Backup and restore:
+        encrypted file export and LAN share), so nothing is lost by turning
+        the implicit one off. -->
         <activity
             android:name=".MainActivity"
             android:exported="true"
@@ -99,6 +120,26 @@
             android:name=".MeetingRecordingService"
             android:foregroundServiceType="microphone"
             android:exported="false" />
+
+        <!-- flutter_local_notifications: persist scheduled agent
+             notifications across process death and restore them after
+             reboot. This manifest replaces src/main rather than merging with
+             it, and the plugin's own AAR manifest declares neither receiver,
+             so without these two entries `zonedSchedule` succeeds and the
+             notification simply never arrives. -->
+        <receiver
+            android:name="com.dexterous.flutterlocalnotifications.ScheduledNotificationReceiver"
+            android:exported="false" />
+        <receiver
+            android:name="com.dexterous.flutterlocalnotifications.ScheduledNotificationBootReceiver"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="android.intent.action.BOOT_COMPLETED" />
+                <action android:name="android.intent.action.MY_PACKAGE_REPLACED" />
+                <action android:name="android.intent.action.QUICKBOOT_POWERON" />
+                <action android:name="com.htc.intent.action.QUICKBOOT_POWERON" />
+            </intent-filter>
+        </receiver>
     </application>
 
     <!-- Required to query activities that can process text, see:

--- a/app/test/core/mind_android_manifest_test.dart
+++ b/app/test/core/mind_android_manifest_test.dart
@@ -1,0 +1,106 @@
+@TestOn('vm')
+library;
+
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// `app/android/app/build.gradle.kts` points the `main` source set at
+/// `src/mind/AndroidManifest.xml` when `APP_VARIANT=mind`. That **replaces**
+/// `src/main/AndroidManifest.xml` rather than merging with it, so anything the
+/// full app declares and Mind still needs has to be restated here — and
+/// nothing warns when it is not.
+///
+/// That is how scheduled agent notifications came to be silently dead on
+/// Android: `zonedSchedule` succeeded, and the notification never arrived,
+/// because neither `flutter_local_notifications` receiver was declared (the
+/// plugin's own AAR manifest declares only VIBRATE and POST_NOTIFICATIONS).
+///
+/// CI builds no Mind APK, so no Gradle manifest merge ever runs against this
+/// file. This test is the only thing standing in for that.
+void main() {
+  late String manifest;
+
+  /// Comment-free copy: the header comment names the IPTV deep links it
+  /// deliberately drops, which a naive substring check would read as a
+  /// declaration.
+  late String declarations;
+
+  setUpAll(() {
+    final file = File('android/app/src/mind/AndroidManifest.xml');
+    expect(
+      file.existsSync(),
+      isTrue,
+      reason:
+          'Run from the app/ package root. Looked for ${file.absolute.path}.',
+    );
+    manifest = file.readAsStringSync();
+    declarations = manifest.replaceAll(RegExp(r'<!--.*?-->', dotAll: true), '');
+  });
+
+  /// Declarations Mind's own code depends on, and what silently breaks
+  /// without each. Deliberately curated rather than diffed against
+  /// `src/main`: Mind drops the IPTV deep links and picture-in-picture on
+  /// purpose, so a blanket comparison would be noise.
+  const required = {
+    'com.dexterous.flutterlocalnotifications.ScheduledNotificationReceiver':
+        'scheduled agent notifications fire',
+    'com.dexterous.flutterlocalnotifications.ScheduledNotificationBootReceiver':
+        'scheduled notifications survive a reboot',
+    'android.permission.RECEIVE_BOOT_COMPLETED':
+        'the boot receiver is allowed to run',
+    'android.permission.RECORD_AUDIO': 'meeting capture can open the mic',
+    'android.permission.FOREGROUND_SERVICE_MICROPHONE':
+        'the capture service starts on Android 14+',
+    'android.permission.POST_NOTIFICATIONS':
+        'the recording notification can be shown',
+    '.MeetingRecordingService': 'capture survives backgrounding',
+  };
+
+  test('declares everything Mind depends on', () {
+    for (final entry in required.entries) {
+      expect(
+        manifest,
+        contains(entry.key),
+        reason:
+            'Missing ${entry.key}, without which ${entry.value}. This manifest '
+            'replaces src/main, so the declaration must be restated here.',
+      );
+    }
+  });
+
+  test('keeps Auto Backup off', () {
+    // Airo Mind's claim is that meetings and the vault stay on the device.
+    // Auto Backup would copy that database to the user's Google Drive.
+    expect(
+      manifest,
+      contains('android:allowBackup="false"'),
+      reason:
+          'Auto Backup would upload on-device meeting data to Google Drive, '
+          'contradicting the product promise. Explicit transfer already '
+          'exists in Settings -> Backup and restore.',
+    );
+  });
+
+  test('does not let optional hardware filter the Play listing', () {
+    // CAMERA is only used for bug-report attachments, which fall back to the
+    // gallery. Declaring the permission without the feature opt-out makes
+    // Play treat a camera as required.
+    expect(
+      manifest,
+      contains('android:name="android.hardware.camera"'),
+      reason:
+          'CAMERA is declared, so android.hardware.camera must be declared '
+          'android:required="false" or Play hides Mind from camera-less '
+          'devices.',
+    );
+    expect(manifest, contains('android:required="false"'));
+  });
+
+  test('does not claim the IPTV deep links', () {
+    // The reason this variant manifest exists at all.
+    expect(declarations, isNot(contains('airo://iptv')));
+    expect(declarations, isNot(contains('/airo/iptv')));
+    expect(declarations, isNot(contains('supportsPictureInPicture')));
+  });
+}


### PR DESCRIPTION
## Why

From the Airo Mind mobile audit. Scheduled agent notifications are silently dead on Android.

## The mechanism

`build.gradle.kts:215-223` points the `main` source set at `src/mind/AndroidManifest.xml` when `APP_VARIANT=mind`. That **replaces** `src/main/AndroidManifest.xml` — it does not merge with it. So anything the full app declares and Mind still needs must be restated, and nothing warns when it isn't.

CI builds no Mind APK (only `flutter build bundle`), so no Gradle manifest merge ever runs against this file either.

## What broke

`src/main` declares both `flutter_local_notifications` receivers; the Mind manifest restated neither, and also dropped `RECEIVE_BOOT_COMPLETED`. The plugin's own AAR manifest declares only VIBRATE and POST_NOTIFICATIONS (checked in pub-cache), so the receivers were genuinely absent.

`zonedSchedule` succeeds. The notification never arrives. No crash, no log. Reachable from `/assistant/notifications`.

## Also in this PR

**Auto Backup turned off.** Mind's claim is that meetings, transcripts and the vault stay on the device — Android Auto Backup would copy that database and its preferences to the user's Google Drive without being asked. Explicit transfer already exists (Settings → Backup and restore: encrypted file export and LAN share), so nothing is lost. Safe to change *now* precisely because Mind has no release pipeline yet, so no installed base depends on the old behaviour.

**`android.hardware.camera` declared not-required.** CAMERA is only used for bug-report attachments, which fall back to the gallery — but declaring the permission without the feature opt-out makes Play treat a camera as a hardware requirement and hide Mind from devices without one.

## Tests

`app/test/core/mind_android_manifest_test.dart` stands in for the Gradle merge CI never runs. It asserts each declaration Mind's code depends on and **names what silently breaks without it**, keeps Auto Backup off, and checks the IPTV deep links this variant exists to drop are still absent.

The negative assertions run against a comment-stripped copy — the manifest's own header names the deep links it drops, which a naive substring check reads as a declaration (it caught me first).

Verified by removing a receiver and the backup flag. Manifest validates as XML.

## Not fixed here

**Mind still installs with the Airo super-app launcher icon.** There is no Mind icon anywhere in the repo — `src/tv/res` carries only drawables, and no `*mind*icon*` asset exists — so this needs a design asset, not a code change. It's a store-submission blocker whenever Mind is listed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)