### PR TITLE
fix(mind): delete meetings through the generated binding, not a global symbol

### DIFF
--- a/packages/feature_mind/lib/src/library_loader.dart
+++ b/packages/feature_mind/lib/src/library_loader.dart
@@ -218,5 +218,3 @@ Future<void> initializeLlamaBridge() =>
 ///
 /// Exposed for the test that asserts a transcribe-only run does not load it.
 bool get isLlamaLoaded => _llamaInitialized;
-
-bool deleteWhisperMeeting(String id) => platform.deleteWhisperMeeting(id);

--- a/packages/feature_mind/lib/src/library_loader_io.dart
+++ b/packages/feature_mind/lib/src/library_loader_io.dart
@@ -76,21 +76,3 @@ void unloadWhisperSpeech() {
       .asFunction<void Function()>();
   fn();
 }
-
-/// Drops one meeting from the on-device store. `true` when a record was
-/// removed. Hidden ggml / FRB symbols stay unexported; this matches
-/// [unloadWhisperSpeech].
-bool deleteWhisperMeeting(String id) {
-  final native = DynamicLibrary.process();
-  final fn = native
-      .lookup<NativeFunction<Int32 Function(Pointer<Utf8>)>>(
-        'airo_mind_whisper_delete_meeting',
-      )
-      .asFunction<int Function(Pointer<Utf8>)>();
-  final encoded = id.toNativeUtf8();
-  try {
-    return fn(encoded) == 0;
-  } finally {
-    malloc.free(encoded);
-  }
-}

--- a/packages/feature_mind/lib/src/library_loader_stub.dart
+++ b/packages/feature_mind/lib/src/library_loader_stub.dart
@@ -11,5 +11,3 @@ Future<ExternalLibrary?> resolveEngineLibrary(String stem) async => null;
 void listenForQuitSignals(void Function() onQuit) {}
 
 void unloadWhisperSpeech() {}
-
-bool deleteWhisperMeeting(String id) => false;

--- a/packages/feature_mind/lib/src/mind_service.dart
+++ b/packages/feature_mind/lib/src/mind_service.dart
@@ -33,7 +33,6 @@ import 'speaker/global_speaker_enrollment_store.dart';
 import 'trust/scribe_trust_state.dart';
 import 'whisper/api/meetings.dart' as rust;
 import 'whisper/meeting_ir_op_log.dart';
-import 'library_loader.dart';
 
 /// Why Airo Mind cannot start. Each case is one the user can act on, which is
 /// the reason this is a type and not a string.
@@ -1066,9 +1065,17 @@ class MindService {
     _speech,
   ).updateTitle(meeting: meeting, title: title);
 
-  Future<bool> deleteMeeting(String id) async {
-    return deleteWhisperMeeting(id);
-  }
+  /// Goes through the generated binding rather than
+  /// `library_loader`'s `deleteWhisperMeeting`, which resolves
+  /// `airo_mind_whisper_delete_meeting` off `DynamicLibrary.process()`. That
+  /// only finds a symbol the loader published globally, and the engine is not
+  /// loaded that way on every host — on Android the generated loader `dlopen`s
+  /// the `.so` by name, so the symbol need not be in the process table at all
+  /// and the lookup throws `ArgumentError` instead of deleting anything.
+  ///
+  /// The FRB call reuses the library instance FRB already holds, so it makes
+  /// no assumption about global symbol visibility on any platform.
+  Future<bool> deleteMeeting(String id) => rust.deleteMeeting(id: id);
 
   /// Releases the microphone and the model provider. The provider matters
   /// because the download-backed one holds a subscription to the platform


### PR DESCRIPTION
## Why

From the Airo Mind mobile audit. Deleting a meeting resolves a native symbol in a way that isn't guaranteed to be present.

## What broke

`MindService.deleteMeeting` called `library_loader`'s `deleteWhisperMeeting`:

```dart
final native = DynamicLibrary.process();
final fn = native.lookup<...>('airo_mind_whisper_delete_meeting')
```

`DynamicLibrary.process()` only finds symbols the loader published into the **global** table. The engine isn't loaded that way on every host — on Android the generated loader `dlopen`s the `.so` by name, so the symbol need not be in the process table at all, and the lookup throws `ArgumentError` rather than deleting anything.

Reachable from both single and bulk delete in the meeting library (`mind_home_screen.dart:394`, `:474`), with no guard around it.

## What changed

A generated binding for exactly this already existed and was unused — `whisper/api/meetings.dart:222`:

```dart
Future<bool> deleteMeeting({required String id}) =>
    RustLib.instance.api.crateApiMeetingsDeleteMeeting(id: id);
```

It reuses the library instance FRB already holds, so it makes **no assumption about global symbol visibility on any platform**.

**On confidence:** I can't reproduce the Android failure without a device, so this is argued from the loading mechanism rather than from a repro. The FRB path removes the assumption entirely, which makes it the right call regardless of how `process()` happens to behave on a given host.

## Cleanup

`deleteWhisperMeeting` had no other caller, so it's removed from the loader, its web stub, and the re-export.

`unloadWhisperSpeech` deliberately **keeps** the process-lookup shape: it exists to drop the whisper supervisor while Metal is still valid during app teardown, and has no binding equivalent.

Green: 0 analyzer errors, `feature_mind` journey tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)