### PR TITLE
fix(mind): request POST_NOTIFICATIONS before the capture service starts

### DIFF
--- a/packages/feature_mind/lib/src/capture/data/meeting_recording_service_gateway.dart
+++ b/packages/feature_mind/lib/src/capture/data/meeting_recording_service_gateway.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 
 /// Starts/stops the Android mic-use foreground notification (#1656 AC2).
 ///
@@ -33,8 +34,11 @@ abstract interface class MeetingRecordingServiceGateway {
 
 class PlatformMeetingRecordingServiceGateway
     implements MeetingRecordingServiceGateway {
-  const PlatformMeetingRecordingServiceGateway({MethodChannel? channel})
-    : _channel = channel ?? _defaultChannel;
+  const PlatformMeetingRecordingServiceGateway({
+    MethodChannel? channel,
+    FlutterLocalNotificationsPlugin? notifications,
+  }) : _channel = channel ?? _defaultChannel,
+       _notifications = notifications;
 
   static const MethodChannel _defaultChannel = MethodChannel(
     'com.airo.meeting_recording',
@@ -42,16 +46,46 @@ class PlatformMeetingRecordingServiceGateway
 
   final MethodChannel _channel;
 
+  /// Injected only by tests; production resolves the plugin lazily so
+  /// constructing this gateway never touches a platform channel.
+  final FlutterLocalNotificationsPlugin? _notifications;
+
   @override
   Future<void> start({
     required String notificationTitle,
     String? notificationText,
   }) async {
     if (!(defaultTargetPlatform == TargetPlatform.android)) return;
+    await _ensureNotificationPermission();
     await _channel.invokeMethod<void>('start', {
       'title': notificationTitle,
       'text': notificationText,
     });
+  }
+
+  /// Asks for `POST_NOTIFICATIONS` before the service starts.
+  ///
+  /// The permission is declared in the manifest but was never requested on
+  /// this path — the mic gate above asks for `RECORD_AUDIO` and nothing asked
+  /// for this. On Android 13+ that leaves the foreground service running with
+  /// its notification suppressed, so the user gets no recording indicator and
+  /// no way to tap back into the app (#1656 AC2).
+  ///
+  /// Deliberately does not gate the service on the answer: a declined
+  /// notification costs the indicator, not the recording, and refusing to
+  /// record would be a worse trade for the user than recording quietly.
+  Future<void> _ensureNotificationPermission() async {
+    try {
+      final plugin = _notifications ?? FlutterLocalNotificationsPlugin();
+      await plugin
+          .resolvePlatformSpecificImplementation<
+            AndroidFlutterLocalNotificationsPlugin
+          >()
+          ?.requestNotificationsPermission();
+    } on Object {
+      // A host without the plugin channel (widget tests) must not stop a
+      // recording from starting.
+    }
   }
 
   @override

--- a/packages/feature_mind/test/capture/data/meeting_recording_service_gateway_test.dart
+++ b/packages/feature_mind/test/capture/data/meeting_recording_service_gateway_test.dart
@@ -1,0 +1,64 @@
+import 'package:feature_mind/src/capture/data/meeting_recording_service_gateway.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const channel = MethodChannel('com.airo.meeting_recording');
+  late List<MethodCall> calls;
+
+  setUp(() {
+    calls = [];
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, (call) async {
+          calls.add(call);
+          return null;
+        });
+  });
+
+  tearDown(() {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, null);
+    debugDefaultTargetPlatformOverride = null;
+  });
+
+  test('starts the service on Android', () async {
+    debugDefaultTargetPlatformOverride = TargetPlatform.android;
+
+    await const PlatformMeetingRecordingServiceGateway().start(
+      notificationTitle: 'Recording meeting audio',
+      notificationText: 'Tap to return',
+    );
+
+    // The permission request runs first and is allowed to fail on a host with
+    // no plugin channel — what must not happen is the service being skipped
+    // because of it.
+    expect(calls.map((call) => call.method), ['start']);
+    expect(calls.single.arguments, {
+      'title': 'Recording meeting audio',
+      'text': 'Tap to return',
+    });
+  });
+
+  test('does nothing off Android', () async {
+    debugDefaultTargetPlatformOverride = TargetPlatform.macOS;
+
+    final gateway = const PlatformMeetingRecordingServiceGateway();
+    await gateway.start(notificationTitle: 'Recording meeting audio');
+    await gateway.stop();
+
+    expect(calls, isEmpty);
+  });
+
+  test('stop is idempotent and reaches the service', () async {
+    debugDefaultTargetPlatformOverride = TargetPlatform.android;
+
+    final gateway = const PlatformMeetingRecordingServiceGateway();
+    await gateway.stop();
+    await gateway.stop();
+
+    expect(calls.map((call) => call.method), ['stop', 'stop']);
+  });
+}


### PR DESCRIPTION
## Why

From the Airo Mind mobile audit. A meeting could be recording with no visible indicator and no way back into the app.

## What broke

`MeetingCaptureController.start` gates on the mic:

```dart
final granted = await _recorder.hasPermission();
if (!granted) { ...fail... }
await _serviceGateway.start(
  notificationTitle: 'Recording meeting audio',
  notificationText: 'Airo Mind is recording. Tap to return to the app.',
);
```

…then starts the microphone foreground service, whose entire purpose is that persistent notification (#1656 AC2). **Nothing ever asked for `POST_NOTIFICATIONS`.**

It's declared in the manifest, but on Android 13+ a declared-and-unrequested notification permission is denied by default. So the service ran with its notification suppressed: no recording indicator, and no way to tap back into the app mid-meeting.

## What changed

The request goes in `PlatformMeetingRecordingServiceGateway` — already the Android-only seam, and the thing that actually needs the notification. `MeetingCaptureController` stays platform-agnostic, and the Noop gateway other platforms get is untouched.

Uses `flutter_local_notifications` (already a real dependency of this package, not stubbed in the Mind flavour), matching how `agent_notification_scheduler.dart:489` asks for the same permission.

## Two deliberate choices

**The service is not gated on the answer.** A declined notification costs the indicator, not the recording — refusing to record would be a worse trade for the user than recording quietly.

**The request is wrapped in a catch.** A host without the plugin channel (widget tests) must not be able to stop a recording from starting.

## Tests

`test/capture/data/meeting_recording_service_gateway_test.dart` — asserts the service still starts with its arguments intact on Android (i.e. the new permission step doesn't swallow it), does nothing off Android, and that `stop` stays idempotent.

Green: 106 `feature_mind` capture tests, 0 analyzer errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)