### PR TITLE
fix(ai): stop "App managed" model storage throwing off Android

### DIFF
--- a/packages/core_ai/lib/src/storage/model_storage_manager.dart
+++ b/packages/core_ai/lib/src/storage/model_storage_manager.dart
@@ -62,8 +62,25 @@ class ModelStorageManager {
   Future<Directory> _storageRootDirectory() async {
     switch (location) {
       case ModelStorageLocation.applicationExternal:
-        final external = await getExternalStorageDirectory();
-        if (external != null) return external;
+        // App-scoped external storage is Android-only. Everywhere else
+        // path_provider registers no `getExternalStoragePath`, so the
+        // platform interface's default *throws* rather than returning null —
+        // which made the `external != null` fallback below unreachable and
+        // turned this option into a trap: picking "App managed" on macOS
+        // broke every model download and Clear Model Cache until it was
+        // changed back.
+        //
+        // Falling through to documents keeps the option's documented
+        // behaviour ("uses app-scoped external storage when available")
+        // honest on hosts that have no such thing.
+        try {
+          final external = await getExternalStorageDirectory();
+          if (external != null) return external;
+        } on UnimplementedError {
+          // No implementation registered for this platform.
+        } on UnsupportedError {
+          // Some implementations reject the call rather than omitting it.
+        }
         return getApplicationDocumentsDirectory();
       case ModelStorageLocation.applicationSupport:
         return getApplicationSupportDirectory();

--- a/packages/core_ai/test/storage/model_storage_manager_test.dart
+++ b/packages/core_ai/test/storage/model_storage_manager_test.dart
@@ -398,4 +398,22 @@ void main() {
       expect(await staging.exists(), isTrue);
     });
   });
+
+  test('applicationExternal falls back to documents where there is no external '
+      'storage', () async {
+    // getExternalStorageDirectory is Android-only: everywhere else
+    // path_provider registers no implementation and the platform
+    // interface's default throws, so this used to propagate out of every
+    // model download and Clear Model Cache instead of taking the fallback
+    // the option already documented.
+    final external = ModelStorageManager(
+      downloads: downloads,
+      location: ModelStorageLocation.applicationExternal,
+    );
+
+    final dir = await external.getModelsDirectory();
+
+    expect(dir.path, path.join(tempDir.path, 'models'));
+    expect(dir.existsSync(), isTrue);
+  });
 }


### PR DESCRIPTION
## Why

From the Airo Mind macOS audit. Settings → **Download Location → "App managed"** breaks every model download on macOS.

## What broke

```dart
case ModelStorageLocation.applicationExternal:
  final external = await getExternalStorageDirectory();
  if (external != null) return external;   // <- never reached off Android
  return getApplicationDocumentsDirectory();
```

App-scoped external storage is an Android concept. `path_provider_foundation` registers no `getExternalStoragePath`, so the call lands on the platform interface's default:

```dart
Future<String?> getExternalStoragePath() {
  throw UnimplementedError('getExternalStoragePath() has not been implemented.');
}
```

It **throws** rather than returning null — so the null check was unreachable and the exception propagated out of every caller. On macOS, picking "App managed" broke model downloads and Clear Model Cache until the user changed it back.

The default is `internal`, so this is a self-inflicted trap rather than a first-run failure — but `ai_preferences_section.dart:184-193` offers the dropdown unconditionally, and nothing in the UI suggests the option is Android-only.

## What changed

Catches the two error types path_provider can raise here and falls through to documents — which is what the code already intended, and what the option's own help text describes: *"uses app-scoped external storage **when available**."*

This lives in `core_ai`, so Coins and the main app get the same fix.

## Tests

`applicationExternal falls back to documents where there is no external storage` asserts the fallback resolves to the documents-backed models directory.

Worth noting how it works: the existing suite mocks the `path_provider` **method channel**, but leaves `PathProviderPlatform.instance` real — which is exactly why the throw reproduces under `flutter test` on macOS. Verified by reverting the fix (`+16 -1`).

Green: 17 `core_ai` storage tests, clean analyze.

🤖 Generated with [Claude Code](https://claude.com/claude-code)