### PR TITLE
fix(mind): make the macOS menu bar's dead items work, or not exist

### DIFF
--- a/app/lib/main_mind.dart
+++ b/app/lib/main_mind.dart
@@ -326,9 +326,21 @@ class _AiroMindAppState extends ConsumerState<AiroMindApp> {
   @override
   void initState() {
     super.initState();
+    // Every callback the macOS menu bar reads has to be assigned here or the
+    // menu item it backs is dead — a null one renders greyed out, and the two
+    // that are invoked through `?.call()` render *enabled* and do nothing.
+    // `MindNativeMenuBarBindings` in feature_mind is the list this must cover.
     MindRuntimeNavigation.openHub = () => _router.go('/runtime');
     MindRuntimeNavigation.openIntelligence = () => _router.go('/models');
     MindRuntimeNavigation.openSettings = () => _router.go(RouteNames.settings);
+    MindRuntimeNavigation.openNewChat = () =>
+        _router.go(AssistantRouteNames.chat);
+    MindRuntimeNavigation.openModelLibrary = () =>
+        _router.go(AssistantRouteNames.models);
+    MindRuntimeNavigation.openDeviceCapabilities = () =>
+        _router.go(AssistantRouteNames.deviceCapabilities);
+    MindRuntimeNavigation.openPromptLab = () =>
+        _router.go(AssistantRouteNames.promptLab);
     WidgetsBinding.instance.addPostFrameCallback((_) {
       // Restore and keep the post-meeting queue alive for the whole session.
       unawaited(ref.read(meetingProcessingQueueProvider.future));
@@ -340,6 +352,10 @@ class _AiroMindAppState extends ConsumerState<AiroMindApp> {
     MindRuntimeNavigation.openHub = null;
     MindRuntimeNavigation.openIntelligence = null;
     MindRuntimeNavigation.openSettings = null;
+    MindRuntimeNavigation.openNewChat = null;
+    MindRuntimeNavigation.openModelLibrary = null;
+    MindRuntimeNavigation.openDeviceCapabilities = null;
+    MindRuntimeNavigation.openPromptLab = null;
     // The registry owns module teardown, and MindModule's is real work: it
     // releases the microphone and the loaded models. `State.dispose` cannot
     // await, so this is fire-and-forget — the shell is going away either way.

--- a/packages/feature_mind/lib/src/widgets/mind_native_menu_bar.dart
+++ b/packages/feature_mind/lib/src/widgets/mind_native_menu_bar.dart
@@ -16,11 +16,9 @@ abstract final class MindRuntimeNavigation {
   static void Function()? openIntelligence;
   static void Function()? openNewChat;
   static void Function()? openSettings;
-  static void Function()? openModelManager;
   static void Function()? openModelLibrary;
   static void Function()? openDeviceCapabilities;
   static void Function()? openPromptLab;
-  static void Function()? closeWindow;
   static void Function()? openLogs;
 }
 
@@ -158,14 +156,14 @@ class MindNativeMenuBar extends StatelessWidget {
                 ),
               ],
             ),
-            PlatformMenuItem(
-              label: 'Close Window',
-              shortcut: const SingleActivator(
-                LogicalKeyboardKey.keyW,
-                meta: true,
-              ),
-              onSelected: MindRuntimeNavigation.closeWindow,
-            ),
+            // No "Close Window" item. Nothing here can close the window:
+            // there is no window-management plugin and its callback was
+            // never assigned, so it rendered permanently greyed out with a
+            // Cmd-W that did nothing. Implementing it needs more care than a
+            // channel call, too — this is a single-window app whose
+            // `MainFlutterWindow` has no reopen path, so a real close would
+            // leave a running process with no window and no way back. The
+            // window's own close button still works.
           ],
         ),
         PlatformMenu(

--- a/packages/feature_mind/test/widgets/mind_native_menu_bar_test.dart
+++ b/packages/feature_mind/test/widgets/mind_native_menu_bar_test.dart
@@ -75,4 +75,113 @@ void main() {
     final after = await runtime.log.count();
     expect(after, before + 1);
   });
+
+  testWidgets('every menu item resolves to something that can run', (
+    tester,
+  ) async {
+    // The macOS menu bar reads static hooks the shell assigns. Any hook left
+    // unassigned produces a dead item, and the failure mode differs by how
+    // the item is wired: `onSelected: Hook.x` renders greyed out, while
+    // `onSelected: () => Hook.x?.call()` renders *enabled* and silently does
+    // nothing. Five items shipped in one of those two states.
+    var opened = <String>[];
+    MindRuntimeNavigation.openNewChat = () => opened.add('newChat');
+    MindRuntimeNavigation.openModelLibrary = () => opened.add('modelLibrary');
+    MindRuntimeNavigation.openDeviceCapabilities = () =>
+        opened.add('deviceCapabilities');
+    MindRuntimeNavigation.openPromptLab = () => opened.add('promptLab');
+    MindRuntimeNavigation.openIntelligence = () => opened.add('intelligence');
+    MindRuntimeNavigation.openSettings = () => opened.add('settings');
+    addTearDown(() {
+      MindRuntimeNavigation.openNewChat = null;
+      MindRuntimeNavigation.openModelLibrary = null;
+      MindRuntimeNavigation.openDeviceCapabilities = null;
+      MindRuntimeNavigation.openPromptLab = null;
+      MindRuntimeNavigation.openIntelligence = null;
+      MindRuntimeNavigation.openSettings = null;
+    });
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: MindNativeMenuBar(
+          runtime: FixtureMindRuntime(),
+          onOpenEverythingBrowser: () {},
+          child: const Scaffold(body: SizedBox()),
+        ),
+      ),
+    );
+
+    final bar = tester.widget<PlatformMenuBar>(find.byType(PlatformMenuBar));
+    final actions = MindNativeMenuBar.collectActions(bar);
+
+    // Scoped to the items backed by MindRuntimeNavigation, which the shell
+    // is responsible for assigning. Others are contextually null by design:
+    // Export/Clear Chat come from MindChatMenuActions only while the chat
+    // chrome is mounted, Toggle Sidebar and About are widget parameters, and
+    // Troubleshooting / Logs is assigned by MindMacosRoot.
+    const shellAssigned = [
+      'Settings…',
+      'Intelligence',
+      'New Chat',
+      'Model Library',
+      'Device & Acceleration…',
+      'Prompt Lab / Persona',
+    ];
+    final dead = shellAssigned
+        .where((label) => actions[label] == null)
+        .toList();
+    expect(
+      dead,
+      isEmpty,
+      reason:
+          'These items are backed by MindRuntimeNavigation hooks the shell '
+          'assigns, so a null here renders them permanently greyed out.',
+    );
+
+    // And the ones routed through the navigation hooks must actually reach
+    // them once the shell has assigned them.
+    for (final label in const [
+      'New Chat',
+      'Model Library',
+      'Device & Acceleration…',
+      'Prompt Lab / Persona',
+    ]) {
+      expect(
+        actions.containsKey(label),
+        isTrue,
+        reason: 'Menu item "$label" disappeared.',
+      );
+      opened = [];
+      actions[label]!.call();
+      expect(
+        opened,
+        isNotEmpty,
+        reason:
+            '"$label" ran without reaching MindRuntimeNavigation, so it does '
+            'nothing on a real Mac.',
+      );
+    }
+  });
+
+  testWidgets('offers no Close Window item it cannot honour', (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: MindNativeMenuBar(
+          runtime: FixtureMindRuntime(),
+          onOpenEverythingBrowser: () {},
+          child: const Scaffold(body: SizedBox()),
+        ),
+      ),
+    );
+
+    final bar = tester.widget<PlatformMenuBar>(find.byType(PlatformMenuBar));
+    expect(
+      MindNativeMenuBar.collectActions(bar).containsKey('Close Window'),
+      isFalse,
+      reason:
+          'Nothing can close the window — no window-management plugin, and a '
+          'single-window app with no reopen path. Restore the item only '
+          'alongside a real implementation.',
+    );
+  });
 }


### PR DESCRIPTION
## Why

From the Airo Mind macOS audit. Five menu items did nothing — in two different ways.

## The mechanism

`MindNativeMenuBar` reads static hooks on `MindRuntimeNavigation` that the shell assigns. `main_mind.dart` assigned three (`openHub`, `openIntelligence`, `openSettings`). Five items were left on hooks nobody ever set, and the failure mode depends on how each item happened to be wired:

| Wiring | Result |
|---|---|
| `onSelected: MindRuntimeNavigation.openPromptLab` | null → renders **greyed out** |
| `onSelected: () => MindRuntimeNavigation.openModelLibrary?.call()` | non-null closure → renders **enabled and does nothing** |

So Intelligence → *Device & Acceleration…* and *Prompt Lab / Persona* were greyed out; *Model Library* and *New Chat* looked live and did nothing; ⌘W did nothing at all.

## Four are now wired

All four already had real routes — they just weren't connected:

- **New Chat** → `AssistantRouteNames.chat`
- **Model Library** → `AssistantRouteNames.models`
- **Device & Acceleration…** → `AssistantRouteNames.deviceCapabilities`
- **Prompt Lab / Persona** → `AssistantRouteNames.promptLab`

New Chat keeps its existing `MindChatMenuActions.newChat` call, which only fires while the chat chrome is mounted — the route hook is what makes the item work from anywhere else.

## Close Window is removed, not implemented

Nothing in the app can close the window: there's no window-management plugin. And a real implementation needs more care than a channel call — this is a single-window app whose `MainFlutterWindow` has no reopen path, so closing it would leave a running process with no window and no way back. A greyed-out ⌘W and a ⌘W that strands the user are both worse than no item. The window's own close button still works.

Restoring it belongs with a real implementation; the test says so.

## Also

Drops `MindRuntimeNavigation.openModelManager` — neither assigned nor read. (The `openModelManager` used throughout the app is `AssistantHostAdapter`'s method, which is unrelated.)

## Tests

`every menu item resolves to something that can run` asserts each shell-assigned item is live and that the four route-backed ones actually reach `MindRuntimeNavigation` when invoked. Verified by un-assigning a hook.

It's **scoped to those hooks deliberately.** My first version asserted no item may be null and failed on correct code: Export/Clear Chat come from `MindChatMenuActions` only while the chat chrome is mounted, Toggle Sidebar and About are widget parameters, and Troubleshooting / Logs is assigned by `MindMacosRoot`. All are contextually null by design.

Green: 43 `feature_mind` widget tests, clean analyze.

🤖 Generated with [Claude Code](https://claude.com/claude-code)