### PR TITLE
feat(tv): rebrand Airo TV to Midas Stream for Play Store

### DIFF
--- a/.github/airo-build-profiles.json
+++ b/.github/airo-build-profiles.json
@@ -49,9 +49,9 @@
       "description": "Android TV and Fire TV IPTV profile.",
       "entrypoint": "app/lib/main_tv.dart",
       "pubspec": "app/pubspec_tv.yaml",
-      "appId": "io.airo.app.tv",
+      "appId": "com.developerscoffee.tv.midas",
       "platformAppIds": {
-        "android": "io.airo.app.tv",
+        "android": "com.developerscoffee.tv.midas",
         "macos": "com.developerscoffee.airo.tv"
       },
       "appVariant": "tv",

--- a/.github/airo-publish-targets.json
+++ b/.github/airo-publish-targets.json
@@ -57,7 +57,7 @@
       "_note": "Enable once GOOGLE_PLAY_SERVICE_ACCOUNT_JSON is provisioned for the TV listing.",
       "profiles": {
         "tv": {
-          "packageId": "io.airo.app.tv",
+          "packageId": "com.developerscoffee.tv.midas",
           "artifactSelector": {
             "artifactType": [
               "aab"
@@ -84,7 +84,7 @@
       "_note": "APKPure models one APK per version -- each version row carries a single Architecture field and the per-ABI splits all share versionCode 10, so they cannot coexist as variants of 0.0.6. The universal APK already contains arm64-v8a, armeabi-v7a and x86_64, so it is the correct upload; the splits stay on the GitHub release for people who want a smaller download. The pipeline still supports multiple APKs per profile if a store ever accepts them. io.airo.app and io.airo.app.coins have no APKPure listing, so their profiles stay disabled until someone registers them by hand.",
       "profiles": {
         "tv": {
-          "packageId": "io.airo.app.tv",
+          "packageId": "com.developerscoffee.tv.midas",
           "artifactSelector": {
             "artifactType": [
               "apk"
@@ -167,7 +167,7 @@
       "enabled": false,
       "profiles": {
         "tv": {
-          "packageId": "io.airo.app.tv",
+          "packageId": "com.developerscoffee.tv.midas",
           "artifactSelector": {
             "artifactType": [
               "apk"
@@ -190,7 +190,7 @@
       "enabled": false,
       "profiles": {
         "tv": {
-          "packageId": "io.airo.app.tv",
+          "packageId": "com.developerscoffee.tv.midas",
           "artifactSelector": {
             "artifactType": [
               "apk"
@@ -213,7 +213,7 @@
       "enabled": false,
       "profiles": {
         "tv": {
-          "packageId": "io.airo.app.tv",
+          "packageId": "com.developerscoffee.tv.midas",
           "artifactSelector": {
             "artifactType": [
               "apk"

--- a/.github/workflows/airo-tv-release.yml
+++ b/.github/workflows/airo-tv-release.yml
@@ -320,7 +320,7 @@ jobs:
                 "client_info": {
                   "mobilesdk_app_id": "1:000000000000:android:0000000000000000000000",
                   "android_client_info": {
-                    "package_name": "io.airo.app.tv"
+                    "package_name": "com.developerscoffee.tv.midas"
                   }
                 },
                 "oauth_client": [],
@@ -343,13 +343,13 @@ jobs:
 
           if [[ -n "$GOOGLE_SERVICES_JSON" ]]; then
             echo "$GOOGLE_SERVICES_JSON" | base64 -d > android/app/google-services.json
-            if grep -q '"package_name"[[:space:]]*:[[:space:]]*"io.airo.app.tv"' android/app/google-services.json; then
-              echo "Using GOOGLE_SERVICES_JSON for io.airo.app.tv."
+            if grep -q '"package_name"[[:space:]]*:[[:space:]]*"com.developerscoffee.tv.midas"' android/app/google-services.json; then
+              echo "Using GOOGLE_SERVICES_JSON for com.developerscoffee.tv.midas."
             elif [[ "$PRODUCTION_SIGNING" == "true" ]]; then
-              echo "::error::GOOGLE_SERVICES_JSON must include a Firebase Android client for io.airo.app.tv."
+              echo "::error::GOOGLE_SERVICES_JSON must include a Firebase Android client for com.developerscoffee.tv.midas."
               exit 1
             else
-              echo "::warning::GOOGLE_SERVICES_JSON does not include io.airo.app.tv; using auth-free TV placeholder Firebase config."
+              echo "::warning::GOOGLE_SERVICES_JSON does not include com.developerscoffee.tv.midas; using auth-free TV placeholder Firebase config."
               write_placeholder_config
             fi
           elif [[ "$PRODUCTION_SIGNING" == "true" ]]; then
@@ -668,7 +668,7 @@ jobs:
         working-directory: app/android
         env:
           PLAY_TRACK: ${{ inputs.play_track || github.event.inputs.play_track }}
-          SUPPLY_PACKAGE_NAME: io.airo.app.tv
+          SUPPLY_PACKAGE_NAME: com.developerscoffee.tv.midas
           SUPPLY_JSON_KEY: play-store-credentials.json
         run: |
           if [[ -z "$SUPPLY_PACKAGE_NAME" ]]; then
@@ -814,7 +814,7 @@ jobs:
             echo ""
             echo "| Field | Value |"
             echo "| --- | --- |"
-            echo "| Package | io.airo.app.tv |"
+            echo "| Package | com.developerscoffee.tv.midas |"
             echo "| Firebase app | $FIREBASE_APP_ID |"
             echo "| Tester groups | $FIREBASE_TESTER_GROUPS |"
             echo "| APK | $apk_name |"
@@ -887,7 +887,7 @@ jobs:
 
           ### Android TV
 
-          - Supports package io.airo.app.tv.
+          - Supports package com.developerscoffee.tv.midas.
           - Supports standard launcher and Leanback launcher entry points.
           - Maintains Pixel/mobile fallback layout coverage.
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -588,7 +588,7 @@ jobs:
           cd app
           case "${{ matrix.platform.variant }}" in
             full) package_name="io.airo.app" ;;
-            tv) package_name="io.airo.app.tv" ;;
+            tv) package_name="com.developerscoffee.tv.midas" ;;
             coins) package_name="io.airo.app.coins" ;;
             *)
               echo "::error::Unknown Android variant: ${{ matrix.platform.variant }}"

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ interactions in a real shipping app, not a demo.
 
 | Module | What it does | Status |
 |---|---|---|
-| 📺 **Airo TV** | Bring-your-own-playlist IPTV player for Android TV | **Available — [v0.0.6](https://github.com/DevelopersCoffee/airo/releases/tag/v0.0.6)** |
+| 📺 **Midas Stream** | Bring-your-own-playlist player for Android TV / Google TV | **Play listing in progress** — see [Midas Stream Play Store gate](docs/release/MIDAS_STREAM_PLAY_STORE_GATE.md) |
 | ⭐ **Airo TV Pro** | Import intelligence, resilient playback, guide intelligence | In testing |
 | 🤖 **Airo AI** | On-device AI chat (Gemini Nano), model management, agent skills | In development |
 | 💰 **AiroMoney** | Personal finance tracking and money workflows | In development |
@@ -80,11 +80,12 @@ private provider data or bundled content.
 [View the product story](https://developerscoffee.github.io/airo/tv/#touch-playlists)
 · [Download the 1080×1920 store PNG](https://developerscoffee.github.io/airo/store-assets/airo-tv/05-mobile-multiple-playlist-sources-1080x1920.png)
 
-Airo TV is the focused Android TV build of Airo's media module
-(`io.airo.app.tv`). TV-first channel grid, search, and playback for your own
-M3U/M3U8 playlists.
+Airo TV is the focused Android TV build of Airo's media module. The first
+Google Play listing ships that product as **Midas Stream**
+(`com.developerscoffee.tv.midas`). GitHub v0.0.6 APKs remain `io.airo.app.tv`.
+TV-first channel grid, search, and playback for your own M3U/M3U8 playlists.
 
-- **Bring your own playlist** — Airo TV ships no IPTV content and no bundled channels.
+- **Bring your own playlist** — Midas Stream ships no IPTV content and no bundled channels.
 - **Google Cast support** — requires `_googlecast._tcp` discovery and port `8009` on the local network.
 - **Verifiable releases** — APK, Play Store AAB, macOS preview, and SHA256 checksums on every release.
 - **Honest device support** — Android TV available, Fire TV experimental, mobile partial, macOS preview, iPad verified; see [device paths](https://developerscoffee.github.io/airo/).
@@ -97,7 +98,8 @@ release carrying every product line.
 
 | Product | Package | Download |
 |---|---|---|
-| 📺 **Airo TV** (Android TV / Fire TV) | `io.airo.app.tv` | [Airo-TV-0.0.6.apk](https://github.com/DevelopersCoffee/airo/releases/download/v0.0.6/Airo-TV-0.0.6.apk) · [arm64-v8a](https://github.com/DevelopersCoffee/airo/releases/download/v0.0.6/Airo-TV-0.0.6-arm64-v8a.apk) · [armeabi-v7a](https://github.com/DevelopersCoffee/airo/releases/download/v0.0.6/Airo-TV-0.0.6-armeabi-v7a.apk) · [x86_64](https://github.com/DevelopersCoffee/airo/releases/download/v0.0.6/Airo-TV-0.0.6-x86_64.apk) |
+| 📺 **Airo TV** (GitHub v0.0.6) | `io.airo.app.tv` | [Airo-TV-0.0.6.apk](https://github.com/DevelopersCoffee/airo/releases/download/v0.0.6/Airo-TV-0.0.6.apk) · [arm64-v8a](https://github.com/DevelopersCoffee/airo/releases/download/v0.0.6/Airo-TV-0.0.6-arm64-v8a.apk) · [armeabi-v7a](https://github.com/DevelopersCoffee/airo/releases/download/v0.0.6/Airo-TV-0.0.6-armeabi-v7a.apk) · [x86_64](https://github.com/DevelopersCoffee/airo/releases/download/v0.0.6/Airo-TV-0.0.6-x86_64.apk) |
+| 📺 **Midas Stream** (Play Store, first listing) | `com.developerscoffee.tv.midas` | AAB from the TV profile after Pixel qualification — not a rename of the v0.0.6 APK |
 | 🤖 **Airo** (phone / tablet) | `io.airo.app` | [Airo-0.0.6-10-arm64.apk](https://github.com/DevelopersCoffee/airo/releases/download/v0.0.6/Airo-0.0.6-10-arm64.apk) |
 | 🪙 **Airo Coins** | `io.airo.app.coins` | [AiroCoins-0.0.6-10-arm64.apk](https://github.com/DevelopersCoffee/airo/releases/download/v0.0.6/AiroCoins-0.0.6-10-arm64.apk) |
 | 🖥️ **Airo TV for macOS** | — | [DMG](https://github.com/DevelopersCoffee/airo/releases/download/v0.0.6/Airo-TV-0.0.6-macOS.dmg) · [ZIP](https://github.com/DevelopersCoffee/airo/releases/download/v0.0.6/Airo-TV-0.0.6-macOS.zip) |

--- a/app/android/app/build.gradle.kts
+++ b/app/android/app/build.gradle.kts
@@ -44,13 +44,13 @@ val isTvVariant = appVariant == "tv"
 val isCoinsVariant = appVariant == "coins"
 val isMindVariant = appVariant == "mind"
 val variantApplicationId = when (appVariant) {
-    "tv" -> "io.airo.app.tv"
+    "tv" -> "com.developerscoffee.tv.midas"
     "coins" -> "io.airo.app.coins"
     "mind" -> "io.airo.app.mind"
     else -> "io.airo.app"
 }
 val variantAppLabel = when (appVariant) {
-    "tv" -> "Airo TV"
+    "tv" -> "Midas Stream"
     "coins" -> "Airo Coins"
     "mind" -> "Airo Mind"
     else -> "Airo"

--- a/app/android/app/src/tv/AndroidManifest.xml
+++ b/app/android/app/src/tv/AndroidManifest.xml
@@ -9,6 +9,7 @@
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED"/>
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE"/>
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK"/>
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC"/>
     <uses-permission android:name="android.permission.WAKE_LOCK"/>
     <uses-permission
         android:name="android.permission.USE_BIOMETRIC"

--- a/app/android/fastlane/Appfile
+++ b/app/android/fastlane/Appfile
@@ -5,7 +5,7 @@
 # maintainers can override both values without editing this tracked file:
 #
 #   SUPPLY_JSON_KEY=/path/to/play-store-credentials.json
-#   SUPPLY_PACKAGE_NAME=io.airo.app.tv
+#   SUPPLY_PACKAGE_NAME=com.developerscoffee.tv.midas
 
 play_json_key = ENV.fetch(
   "SUPPLY_JSON_KEY_FILE",
@@ -13,4 +13,4 @@ play_json_key = ENV.fetch(
 )
 
 json_key_file(play_json_key)
-package_name(ENV.fetch("SUPPLY_PACKAGE_NAME", "io.airo.app.tv"))
+package_name(ENV.fetch("SUPPLY_PACKAGE_NAME", "com.developerscoffee.tv.midas"))

--- a/app/lib/core/app/airo_tv_app.dart
+++ b/app/lib/core/app/airo_tv_app.dart
@@ -45,7 +45,7 @@ class _AiroTvAppState extends ConsumerState<AiroTvApp> {
     final selectedTheme = ref.watch(appThemeDefinitionProvider);
 
     return MaterialApp.router(
-      title: 'Airo TV',
+      title: 'Midas Stream',
       theme: _buildTvTheme(context, selectedTheme.lightTheme),
       darkTheme: _buildTvTheme(context, selectedTheme.darkTheme),
       themeMode: selectedTheme.themeMode,

--- a/app/lib/core/app/tv_shell.dart
+++ b/app/lib/core/app/tv_shell.dart
@@ -337,7 +337,7 @@ class _TvSidebarLogo extends StatelessWidget {
 
     return TvFocusable(
       onSelect: onSelect,
-      semanticLabel: 'Airo TV home',
+      semanticLabel: 'Midas Stream home',
       semanticButton: true,
       child: Column(
         children: [

--- a/app/lib/core/audio/tv_audio_service.dart
+++ b/app/lib/core/audio/tv_audio_service.dart
@@ -264,8 +264,8 @@ Future<TvAudioHandler> initTvAudioService() async {
   _tvAudioHandler = await AudioService.init(
     builder: () => TvAudioHandler(),
     config: AudioServiceConfig(
-      androidNotificationChannelId: 'com.airo.app.tv.audio',
-      androidNotificationChannelName: 'Airo TV',
+      androidNotificationChannelId: 'com.developerscoffee.tv.midas.audio',
+      androidNotificationChannelName: 'Midas Stream',
       // Keep the foreground service (and its notification) alive on pause —
       // live-TV users pause for long stretches and must keep lock-screen
       // controls. androidNotificationOngoing stays false: audio_service

--- a/app/lib/features/iptv/iptv_feature_module.dart
+++ b/app/lib/features/iptv/iptv_feature_module.dart
@@ -84,7 +84,7 @@ Future<void> _shareIptvVideoFrame(Uint8List pngBytes) async {
           name: 'airo-tv-frame.png',
         ),
       ],
-      subject: 'Airo TV video frame',
+      subject: 'Midas Stream video frame',
     ),
   );
 }

--- a/app/lib/firebase_options.dart
+++ b/app/lib/firebase_options.dart
@@ -7,7 +7,7 @@
 // Do not commit real Firebase keys into this file.
 //
 // Supports: Mobile Full (io.airo.app), Mobile Streaming
-// (io.airo.app.streaming), Android TV (io.airo.app.tv), Airo Mind
+// (io.airo.app.streaming), Android TV (com.developerscoffee.tv.midas), Airo Mind
 // (io.airo.app.mind)
 
 import 'package:firebase_core/firebase_core.dart' show FirebaseOptions;
@@ -19,7 +19,7 @@ import 'package:flutter/foundation.dart'
 enum AppVariant {
   full, // io.airo.app - All features
   streaming, // io.airo.app.streaming - Music + IPTV
-  tv, // io.airo.app.tv - IPTV only
+  tv, // com.developerscoffee.tv.midas - IPTV only
   mind, // io.airo.app.mind - Airo Mind standalone shell
 }
 
@@ -150,7 +150,7 @@ class DefaultFirebaseOptions {
     storageBucket: 'YOUR_PROJECT_ID.firebasestorage.app',
   );
 
-  /// Android TV - io.airo.app.tv
+  /// Android TV - com.developerscoffee.tv.midas
   static const FirebaseOptions androidTv = FirebaseOptions(
     apiKey: 'YOUR_ANDROID_TV_API_KEY',
     appId: 'YOUR_ANDROID_TV_APP_ID',

--- a/app/lib/firebase_options.dart.template
+++ b/app/lib/firebase_options.dart.template
@@ -1,6 +1,6 @@
 // Firebase configuration with multi-platform variant support
 // Supports: Mobile Full (io.airo.app), Mobile Streaming
-// (io.airo.app.streaming), Android TV (io.airo.app.tv), Airo Mind
+// (io.airo.app.streaming), Android TV (com.developerscoffee.tv.midas), Airo Mind
 // (io.airo.app.mind)
 //
 // This is a TEMPLATE. To use:
@@ -30,7 +30,7 @@ import 'package:flutter/foundation.dart'
 enum AppVariant {
   full, // io.airo.app - All features
   streaming, // io.airo.app.streaming - Music + IPTV
-  tv, // io.airo.app.tv - IPTV only
+  tv, // com.developerscoffee.tv.midas - IPTV only
   mind, // io.airo.app.mind - Airo Mind standalone shell
 }
 
@@ -161,7 +161,7 @@ class DefaultFirebaseOptions {
     storageBucket: 'YOUR_PROJECT_ID.firebasestorage.app',
   );
 
-  /// Android TV - io.airo.app.tv
+  /// Android TV - com.developerscoffee.tv.midas
   static const FirebaseOptions androidTv = FirebaseOptions(
     apiKey: 'YOUR_ANDROID_TV_API_KEY',
     appId: 'YOUR_ANDROID_TV_APP_ID',

--- a/app/lib/main_tv.dart
+++ b/app/lib/main_tv.dart
@@ -91,7 +91,7 @@ void main() {
     composeApp: () async {
       await configureTvSystemChrome();
 
-      debugPrint('🖥️ Starting Airo TV (${PlatformFeatures.platformName})');
+      debugPrint('🖥️ Starting Midas Stream (${PlatformFeatures.platformName})');
       debugPrint(
         '📺 Features: '
         '${PlatformFeatures.enabledFeatures.map((f) => f.name).join(', ')}',

--- a/app/lib/main_tv.dart
+++ b/app/lib/main_tv.dart
@@ -91,7 +91,9 @@ void main() {
     composeApp: () async {
       await configureTvSystemChrome();
 
-      debugPrint('🖥️ Starting Midas Stream (${PlatformFeatures.platformName})');
+      debugPrint(
+        '🖥️ Starting Midas Stream (${PlatformFeatures.platformName})',
+      );
       debugPrint(
         '📺 Features: '
         '${PlatformFeatures.enabledFeatures.map((f) => f.name).join(', ')}',

--- a/app/pubspec_tv.yaml
+++ b/app/pubspec_tv.yaml
@@ -9,7 +9,7 @@
 # - chess: 0.8.1 (requires stockfish)
 
 name: airo_app
-description: "Airo TV - IPTV streaming for Android TV"
+description: "Midas Stream - bring-your-own-playlist player for Android TV"
 publish_to: 'none'
 version: 0.0.7+12
 

--- a/docs/architecture/AIRO_TV_ARCHITECTURE.md
+++ b/docs/architecture/AIRO_TV_ARCHITECTURE.md
@@ -1,6 +1,8 @@
-# Airo TV Architecture
+# Airo TV / Midas Stream Architecture
 
-Airo TV is the Android TV variant of Airo. It is built from the v2 release line with package name `io.airo.app.tv`.
+The Android TV player is the TV variant of Airo. The first Google Play listing
+ships it as **Midas Stream** with package name `com.developerscoffee.tv.midas`.
+GitHub v0.0.6 artifacts were published as Airo TV (`io.airo.app.tv`).
 
 ## High-Level Flow
 

--- a/docs/deployment/SHARED_CHANNEL_APP_LINKS.md
+++ b/docs/deployment/SHARED_CHANNEL_APP_LINKS.md
@@ -15,7 +15,7 @@ directory cannot satisfy that root-domain requirement. The owner of the
 Publish Digital Asset Links entries for:
 
 - `io.airo.app`
-- `io.airo.app.tv`
+- `com.developerscoffee.tv.midas`
 
 Each entry uses
 `delegate_permission/common.handle_all_urls` and the real SHA-256 fingerprint

--- a/docs/legal/privacy-policy/index.html
+++ b/docs/legal/privacy-policy/index.html
@@ -3,8 +3,8 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Privacy Policy — Airo TV | DevelopersCoffee</title>
-  <meta name="description" content="Privacy Policy for Airo TV — a local-first IPTV player by DevelopersCoffee. We collect no personal data.">
+  <title>Privacy Policy — Midas Stream | DevelopersCoffee</title>
+  <meta name="description" content="Privacy Policy for Midas Stream — a local-first IPTV player by DevelopersCoffee. We collect no personal data.">
 
   <!-- AI Agent & LLM Auto-Discovery -->
   <link rel="llms-txt" type="text/markdown" href="../../llms.txt">
@@ -13,8 +13,8 @@
   <meta name="theme-color" content="#071010">
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://developerscoffee.github.io/airo/legal/privacy-policy/">
-  <meta property="og:title" content="Privacy Policy — Airo TV">
-  <meta property="og:description" content="Airo TV collects no personal data. All playlist and preference data stays on your device.">
+  <meta property="og:title" content="Privacy Policy — Midas Stream">
+  <meta property="og:description" content="Midas Stream collects no personal data. All playlist and preference data stays on your device.">
   <link rel="icon" type="image/svg+xml" href="../../assets/airo-tv/airo-icon.svg">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -180,7 +180,7 @@
         <a href="../../#community">Community</a>
         <a href="../../#roadmap">Roadmap</a>
         <a class="button button-discord" href="https://discord.gg/62r67VcMzM" target="_blank" rel="noopener noreferrer"><svg aria-hidden="true" width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M20.317 4.37a19.791 19.791 0 0 0-4.885-1.515.074.074 0 0 0-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 0 0-5.487 0 12.64 12.64 0 0 0-.617-1.25.077.077 0 0 0-.079-.037A19.736 19.736 0 0 0 3.677 4.37a.07.07 0 0 0-.032.027C.533 9.046-.32 13.58.099 18.057a.082.082 0 0 0 .031.057 19.9 19.9 0 0 0 5.993 3.03.078.078 0 0 0 .084-.028 14.09 14.09 0 0 0 1.226-1.994.076.076 0 0 0-.041-.106 13.107 13.107 0 0 1-1.872-.892.077.077 0 0 1-.008-.128 10.2 10.2 0 0 0 .372-.292.074.074 0 0 1 .077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 0 1 .078.01c.12.098.246.198.373.292a.077.077 0 0 1-.006.127 12.299 12.299 0 0 1-1.873.892.077.077 0 0 0-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.028 19.839 19.839 0 0 0 6.002-3.03.077.077 0 0 0 .032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 0 0-.031-.03z"/></svg> Discord</a>
-        <a class="button button-primary" href="../../tv/">Explore Airo TV <i data-lucide="arrow-right" aria-hidden="true"></i></a>
+        <a class="button button-primary" href="../../tv/">Explore Midas Stream <i data-lucide="arrow-right" aria-hidden="true"></i></a>
       </nav>
     </div>
   </header>
@@ -191,7 +191,7 @@
       <div class="container">
         <p class="eyebrow">Legal</p>
         <h1>Privacy Policy</h1>
-        <p class="meta">Last updated: <time datetime="2026-07-26">July 26, 2026</time> &nbsp;·&nbsp; Airo TV by DevelopersCoffee</p>
+        <p class="meta">Last updated: <time datetime="2026-09-01">September 1, 2026</time> &nbsp;·&nbsp; Midas Stream by DevelopersCoffee</p>
       </div>
     </div>
 
@@ -230,14 +230,14 @@
 
             <section id="introduction">
               <h2>Introduction</h2>
-              <p>Airo TV is built by <strong>DevelopersCoffee</strong> as a free application provided at no cost and intended for use "as is".</p>
+              <p>Midas Stream is built by <strong>DevelopersCoffee</strong> as a free application provided at no cost and intended for use "as is".</p>
               <p>This page informs you of our policies regarding the collection, use, and disclosure of personal information when you use our service. If you choose to use our service you agree to the collection and use of information in relation to this policy. The terms used here have the same meanings as in our <a href="../terms-conditions/">Terms and Conditions</a> unless otherwise defined.</p>
             </section>
 
             <section id="data-collection">
               <h2>Information We Collect</h2>
               <div class="callout">
-                <p><strong>Short version:</strong> All data Airo TV stores stays on your device. We collect nothing on our servers.</p>
+                <p><strong>Short version:</strong> All data Midas Stream stores stays on your device. We collect nothing on our servers.</p>
               </div>
               <p>For a better experience while using our service, the app may store certain data locally on your device. The information that we store is <strong>not collected by us</strong> in any way.</p>
 
@@ -260,15 +260,15 @@
                 <li>Viewing habits, watch history, or analytics sent to external servers</li>
                 <li>Advertising identifiers</li>
               </ul>
-              <p>Airo TV integrates no advertising, analytics, or attribution SDK of any kind. There is no Google Analytics, Firebase Analytics, or Crashlytics in the application.</p>
+              <p>Midas Stream integrates no advertising, analytics, or attribution SDK of any kind. There is no Google Analytics, Firebase Analytics, or Crashlytics in the application.</p>
 
               <h3>Permissions requested</h3>
-              <p>The Airo TV build requests only what a network media player requires: internet and network-state access, multicast (for local network stream discovery), foreground-service and wake-lock (to keep playback alive), notification posting (for playback controls), and boot-completed. It does <strong>not</strong> request contacts, calendar, location, camera, microphone, or device storage access.</p>
+              <p>The Midas Stream build requests only what a network media player requires: internet and network-state access, multicast (for local network stream discovery), foreground-service and wake-lock (to keep playback alive), notification posting (for playback controls), and boot-completed. It does <strong>not</strong> request contacts, calendar, location, camera, microphone, or device storage access.</p>
             </section>
 
             <section id="on-device">
               <h2>On-Device Processing</h2>
-              <p>Airo TV processes all data locally on your device:</p>
+              <p>Midas Stream processes all data locally on your device:</p>
               <ul>
                 <li><strong>IPTV playlist parsing</strong> is performed entirely on-device.</li>
                 <li><strong>Channel matching and enrichment</strong> is performed entirely on-device.</li>
@@ -280,26 +280,26 @@
 
             <section id="network">
               <h2>Network Connections</h2>
-              <p>Airo TV contacts the following hosts. We list them so you know exactly what the app talks to and what is — and is not — sent.</p>
+              <p>Midas Stream contacts the following hosts. We list them so you know exactly what the app talks to and what is — and is not — sent.</p>
 
               <h3>Servers you choose</h3>
-              <p>The M3U playlist URL and the XMLTV program-guide URL you enter are requested directly by your device, along with the stream URLs those playlists contain. Airo TV does not proxy, mirror, or inspect this traffic, and it is not routed through DevelopersCoffee. The operators of those servers will see your IP address, as they would with any media player.</p>
+              <p>The M3U playlist URL and the XMLTV program-guide URL you enter are requested directly by your device, along with the stream URLs those playlists contain. Midas Stream does not proxy, mirror, or inspect this traffic, and it is not routed through DevelopersCoffee. The operators of those servers will see your IP address, as they would with any media player.</p>
 
-              <h3><code>iptv-org.github.io</code></h3>
-              <p>To display channel names, countries, and languages, Airo TV downloads three public catalogue files from the community-maintained iptv-org project. This is a plain download of public data. <strong>Your playlist is not uploaded and your channel list is not sent anywhere</strong> — the catalogue is fetched in full and matched against your channels entirely on your own device.</p>
+              <h3>No public channel catalogue</h3>
+              <p>Midas Stream does not download a public IPTV catalogue. Channel names come from the playlist you add. <strong>Your playlist is not uploaded and your channel list is not sent anywhere.</strong></p>
 
               <h3>Google Firebase</h3>
-              <p>Airo TV includes the Firebase core library so the app can initialise at startup. It does <strong>not</strong> include Firebase Analytics, Crashlytics, or Cloud Messaging, so no usage data, crash data, or push tokens are gathered through Firebase. Where Firebase generates a <strong>Firebase installation ID</strong>, that is a random, per-installation identifier that is not linked to you, not tied to any account, and reset when you uninstall the app or clear its data. It is never combined with your playlist data and is never used for advertising or cross-app tracking. Google's handling of it is governed by the <a href="https://policies.google.com/privacy" target="_blank" rel="noopener noreferrer">Google Privacy Policy</a>. Airo TV generates and shares no other identifier.</p>
+              <p>Midas Stream includes the Firebase core library so the app can initialise at startup. It does <strong>not</strong> include Firebase Analytics, Crashlytics, or Cloud Messaging, so no usage data, crash data, or push tokens are gathered through Firebase. Where Firebase generates a <strong>Firebase installation ID</strong>, that is a random, per-installation identifier that is not linked to you, not tied to any account, and reset when you uninstall the app or clear its data. It is never combined with your playlist data and is never used for advertising or cross-app tracking. Google's handling of it is governed by the <a href="https://policies.google.com/privacy" target="_blank" rel="noopener noreferrer">Google Privacy Policy</a>. Midas Stream generates and shares no other identifier.</p>
             </section>
 
             <section id="content-disclaimer">
               <h2>IPTV Content Disclaimer</h2>
               <div class="callout callout-warn">
-                <p>Airo TV is a <strong>media player only</strong>. It does <strong>not</strong> provide, host, or distribute any content, channels, playlists, or streams.</p>
+                <p>Midas Stream is a <strong>media player only</strong>. It does <strong>not</strong> provide, host, or distribute any content, channels, playlists, or streams.</p>
               </div>
               <ul>
-                <li>All content displayed in Airo TV is <strong>added by the user</strong>.</li>
-                <li>Users are solely responsible for ensuring that the content they access through Airo TV is legal in their jurisdiction.</li>
+                <li>All content displayed in Midas Stream is <strong>added by the user</strong>.</li>
+                <li>Users are solely responsible for ensuring that the content they access through Midas Stream is legal in their jurisdiction.</li>
                 <li>DevelopersCoffee does <strong>not</strong> endorse, promote, or facilitate the streaming of copyright-protected material without proper authorisation from the rights holder.</li>
               </ul>
             </section>
@@ -317,12 +317,12 @@
             <section id="service-providers">
               <h2>Service Providers</h2>
               <p>We do not employ third parties to process personal data on our behalf, and no third party receives personal information about you from us.</p>
-              <p>The only external services Airo TV interacts with are named under <a href="#network">Network Connections</a> above: Google Firebase (core library only, no analytics or crash reporting), the public iptv-org catalogue, and whatever playlist, program-guide, and stream servers you configure.</p>
+              <p>The only external services Midas Stream interacts with are named under <a href="#network">Network Connections</a> above: Google Firebase (core library only, no analytics or crash reporting) and whatever playlist, program-guide, and stream servers you configure.</p>
             </section>
 
             <section id="data-retention">
               <h2>Data Retention</h2>
-              <p>Because Airo TV keeps your data on your device rather than on our servers, retention is under your control:</p>
+              <p>Because Midas Stream keeps your data on your device rather than on our servers, retention is under your control:</p>
               <ul>
                 <li><strong>Preferences, playlist URLs, favourites, and filter selections</strong> are kept until you change them, clear the app's storage, or uninstall the app.</li>
                 <li><strong>Playlist and EPG caches</strong> are kept until refreshed or superseded, and are removed with the app's storage.</li>
@@ -334,14 +334,14 @@
             <section id="your-rights">
               <h2>Your Privacy Rights</h2>
               <p>Rights such as access, correction, deletion, portability, restriction, and objection under the GDPR, and the rights to know, delete, correct, and opt out of sale or sharing under the CCPA/CPRA, generally apply to data a company holds about you.</p>
-              <p><strong>DevelopersCoffee does not collect, receive, or store personal data about Airo TV users</strong>, so there is no profile for us to disclose, export, correct, or erase. We do not sell or share personal information, and we never have.</p>
-              <p>You can exercise the practical equivalent of these rights directly: clear the app's storage or uninstall Airo TV to erase everything it holds, and edit or remove your playlist and EPG sources in Settings. If you believe we nonetheless hold information about you, contact us at the address below and we will respond within 30 days. Users in the EU/EEA and the UK also have the right to lodge a complaint with their local supervisory authority.</p>
+              <p><strong>DevelopersCoffee does not collect, receive, or store personal data about Midas Stream users</strong>, so there is no profile for us to disclose, export, correct, or erase. We do not sell or share personal information, and we never have.</p>
+              <p>You can exercise the practical equivalent of these rights directly: clear the app's storage or uninstall Midas Stream to erase everything it holds, and edit or remove your playlist and EPG sources in Settings. If you believe we nonetheless hold information about you, contact us at the address below and we will respond within 30 days. Users in the EU/EEA and the UK also have the right to lodge a complaint with their local supervisory authority.</p>
             </section>
 
             <section id="security">
               <h2>Security</h2>
               <p>We value your trust and strive to use commercially acceptable means of protecting your information. Remember that no method of transmission over the internet, or method of electronic storage, is 100% secure and reliable.</p>
-              <p>One point worth understanding about stream security: many real-world IPTV providers serve playlists and streams over plain, unencrypted HTTP. Airo TV permits cleartext connections so those sources remain playable. This means that <strong>if the playlist or stream URL you supply uses <code>http://</code> rather than <code>https://</code>, that traffic is not encrypted</strong> and may be visible to your network operator or internet provider. Airo TV's own connections use HTTPS. Prefer <code>https://</code> sources where your provider offers them.</p>
+              <p>One point worth understanding about stream security: many real-world IPTV providers serve playlists and streams over plain, unencrypted HTTP. Midas Stream permits cleartext connections so those sources remain playable. This means that <strong>if the playlist or stream URL you supply uses <code>http://</code> rather than <code>https://</code>, that traffic is not encrypted</strong> and may be visible to your network operator or internet provider. Midas Stream's own connections use HTTPS. Prefer <code>https://</code> sources where your provider offers them.</p>
             </section>
 
             <section id="children">
@@ -378,6 +378,6 @@
 
   </main>
 
-  <footer class="site-footer"><div class="container"><div class="footer-grid"><div><a class="brand" href="../../"><img src="../../assets/airo-tv/airo-icon.svg" alt=""><span>Airo</span></a><h2>Focused experiences. Shared foundations.</h2><p>Airo TV is the first focused product in the Airo ecosystem.</p></div><div class="footer-col"><h3>Platform</h3><a href="../../#architecture">Architecture</a><a href="../../#foundations">Foundations</a><a href="../../#modules">Modules</a></div><div class="footer-col"><h3>Explore</h3><a href="../../tv/">Airo TV</a><a href="../../#community">Community</a><a href="../../#roadmap">Roadmap</a><a href="https://discord.gg/62r67VcMzM" target="_blank" rel="noopener noreferrer">Discord ↗</a></div><div class="footer-col"><h3>Trust</h3><a href="../privacy-policy/">Privacy</a><a href="../terms-conditions/">Terms</a><a href="mailto:coffee.devloper@gmail.com">Support</a></div></div><div class="footer-bottom"><span>&copy; <span data-current-year>2026</span> DevelopersCoffee</span><span>Airo is built in public. Roadmap scope may change as evidence changes.</span></div></div></footer>
+  <footer class="site-footer"><div class="container"><div class="footer-grid"><div><a class="brand" href="../../"><img src="../../assets/airo-tv/airo-icon.svg" alt=""><span>Airo</span></a><h2>Focused experiences. Shared foundations.</h2><p>Midas Stream is the first focused product in the Airo ecosystem.</p></div><div class="footer-col"><h3>Platform</h3><a href="../../#architecture">Architecture</a><a href="../../#foundations">Foundations</a><a href="../../#modules">Modules</a></div><div class="footer-col"><h3>Explore</h3><a href="../../tv/">Midas Stream</a><a href="../../#community">Community</a><a href="../../#roadmap">Roadmap</a><a href="https://discord.gg/62r67VcMzM" target="_blank" rel="noopener noreferrer">Discord ↗</a></div><div class="footer-col"><h3>Trust</h3><a href="../privacy-policy/">Privacy</a><a href="../terms-conditions/">Terms</a><a href="mailto:coffee.devloper@gmail.com">Support</a></div></div><div class="footer-bottom"><span>&copy; <span data-current-year>2026</span> DevelopersCoffee</span><span>Airo is built in public. Roadmap scope may change as evidence changes.</span></div></div></footer>
 </body>
 </html>

--- a/docs/legal/terms-conditions/index.html
+++ b/docs/legal/terms-conditions/index.html
@@ -3,8 +3,8 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Terms &amp; Conditions — Airo TV | DevelopersCoffee</title>
-  <meta name="description" content="Terms and Conditions for Airo TV — a local-first IPTV player by DevelopersCoffee.">
+  <title>Terms &amp; Conditions — Midas Stream | DevelopersCoffee</title>
+  <meta name="description" content="Terms and Conditions for Midas Stream — a local-first IPTV player by DevelopersCoffee.">
 
   <!-- AI Agent & LLM Auto-Discovery -->
   <link rel="llms-txt" type="text/markdown" href="../../llms.txt">
@@ -13,8 +13,8 @@
   <meta name="theme-color" content="#071010">
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://developerscoffee.github.io/airo/legal/terms-conditions/">
-  <meta property="og:title" content="Terms &amp; Conditions — Airo TV">
-  <meta property="og:description" content="Terms and Conditions for Airo TV by DevelopersCoffee.">
+  <meta property="og:title" content="Terms &amp; Conditions — Midas Stream">
+  <meta property="og:description" content="Terms and Conditions for Midas Stream by DevelopersCoffee.">
   <link rel="icon" type="image/svg+xml" href="../../assets/airo-tv/airo-icon.svg">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -159,7 +159,7 @@
         <a href="../../#community">Community</a>
         <a href="../../#roadmap">Roadmap</a>
         <a class="button button-discord" href="https://discord.gg/62r67VcMzM" target="_blank" rel="noopener noreferrer"><svg aria-hidden="true" width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M20.317 4.37a19.791 19.791 0 0 0-4.885-1.515.074.074 0 0 0-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 0 0-5.487 0 12.64 12.64 0 0 0-.617-1.25.077.077 0 0 0-.079-.037A19.736 19.736 0 0 0 3.677 4.37a.07.07 0 0 0-.032.027C.533 9.046-.32 13.58.099 18.057a.082.082 0 0 0 .031.057 19.9 19.9 0 0 0 5.993 3.03.078.078 0 0 0 .084-.028 14.09 14.09 0 0 0 1.226-1.994.076.076 0 0 0-.041-.106 13.107 13.107 0 0 1-1.872-.892.077.077 0 0 1-.008-.128 10.2 10.2 0 0 0 .372-.292.074.074 0 0 1 .077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 0 1 .078.01c.12.098.246.198.373.292a.077.077 0 0 1-.006.127 12.299 12.299 0 0 1-1.873.892.077.077 0 0 0-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.028 19.839 19.839 0 0 0 6.002-3.03.077.077 0 0 0 .032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 0 0-.031-.03z"/></svg> Discord</a>
-        <a class="button button-primary" href="../../tv/">Explore Airo TV <i data-lucide="arrow-right" aria-hidden="true"></i></a>
+        <a class="button button-primary" href="../../tv/">Explore Midas Stream <i data-lucide="arrow-right" aria-hidden="true"></i></a>
       </nav>
     </div>
   </header>
@@ -170,7 +170,7 @@
       <div class="container">
         <p class="eyebrow">Legal</p>
         <h1>Terms &amp; Conditions</h1>
-        <p class="meta">Last updated: <time datetime="2026-07-13">July 13, 2026</time> &nbsp;·&nbsp; Airo TV by DevelopersCoffee</p>
+        <p class="meta">Last updated: <time datetime="2026-09-01">September 1, 2026</time> &nbsp;·&nbsp; Midas Stream by DevelopersCoffee</p>
       </div>
     </div>
 
@@ -206,10 +206,10 @@
             <section id="disclaimer">
               <h2>⚠️ Important — Content Disclaimer</h2>
               <div class="callout callout-warn">
-                <p>Airo TV <strong>only displays content added by the user</strong>. The application does <strong>NOT</strong> provide, host, supply, or distribute any content, channels, playlists, or streams of any kind.</p>
+                <p>Midas Stream <strong>only displays content added by the user</strong>. The application does <strong>NOT</strong> provide, host, supply, or distribute any content, channels, playlists, or streams of any kind.</p>
               </div>
-              <p>Airo TV is designed to be used with your own created content or playlists that contain content you are legally authorised to access. DevelopersCoffee does <strong>not</strong> endorse, promote, or facilitate the streaming of copyright-protected material without proper authorisation from the rights holder.</p>
-              <p><strong>You are solely responsible for ensuring that all content you access through Airo TV is legal in your jurisdiction.</strong></p>
+              <p>Midas Stream is designed to be used with your own created content or playlists that contain content you are legally authorised to access. DevelopersCoffee does <strong>not</strong> endorse, promote, or facilitate the streaming of copyright-protected material without proper authorisation from the rights holder.</p>
+              <p><strong>You are solely responsible for ensuring that all content you access through Midas Stream is legal in your jurisdiction.</strong></p>
             </section>
 
             <section id="terms-of-use">
@@ -230,13 +230,13 @@
 
             <section id="capabilities">
               <h2>Current Release Capabilities</h2>
-              <p>Airo TV supports the current release capabilities documented in the <a href="https://github.com/DevelopersCoffee/airo/releases" target="_blank" rel="noopener noreferrer">release notes</a>.</p>
+              <p>Midas Stream supports the current release capabilities documented in the <a href="https://github.com/DevelopersCoffee/airo/releases" target="_blank" rel="noopener noreferrer">release notes</a>.</p>
 
               <h3>Playlist Formats</h3>
               <ul><li>M3U / M3U8</li></ul>
 
               <h3>Playback</h3>
-              <p>Playback depends on the stream URL, protocol, codec support, and capabilities of your Android TV, Google TV, or compatible device. Airo TV does not guarantee that every third-party playlist or stream URL will play.</p>
+              <p>Playback depends on the stream URL, protocol, codec support, and capabilities of your Android TV, Google TV, or compatible device. Midas Stream does not guarantee that every third-party playlist or stream URL will play.</p>
 
               <h3>Additional Features</h3>
               <ul>
@@ -254,7 +254,7 @@
 
             <section id="security">
               <h2>Security and Your Data</h2>
-              <p>Airo TV stores and processes personal data that you have provided to us in order to provide our service. It is your responsibility to keep your device and access to the app secure. We recommend that you do not jailbreak or root your phone, as this may make your device vulnerable to malware/viruses/malicious programs, compromise your device's security features, and could mean that the Airo TV app will not work properly or at all.</p>
+              <p>Midas Stream stores and processes personal data that you have provided to us in order to provide our service. It is your responsibility to keep your device and access to the app secure. We recommend that you do not jailbreak or root your phone, as this may make your device vulnerable to malware/viruses/malicious programs, compromise your device's security features, and could mean that the Midas Stream app will not work properly or at all.</p>
             </section>
 
             <section id="connectivity">
@@ -309,6 +309,6 @@
 
   </main>
 
-  <footer class="site-footer"><div class="container"><div class="footer-grid"><div><a class="brand" href="../../"><img src="../../assets/airo-tv/airo-icon.svg" alt=""><span>Airo</span></a><h2>Focused experiences. Shared foundations.</h2><p>Airo TV is the first focused product in the Airo ecosystem.</p></div><div class="footer-col"><h3>Platform</h3><a href="../../#architecture">Architecture</a><a href="../../#foundations">Foundations</a><a href="../../#modules">Modules</a></div><div class="footer-col"><h3>Explore</h3><a href="../../tv/">Airo TV</a><a href="../../#community">Community</a><a href="../../#roadmap">Roadmap</a><a href="https://discord.gg/62r67VcMzM" target="_blank" rel="noopener noreferrer">Discord ↗</a></div><div class="footer-col"><h3>Trust</h3><a href="../privacy-policy/">Privacy</a><a href="../terms-conditions/">Terms</a><a href="mailto:coffee.devloper@gmail.com">Support</a></div></div><div class="footer-bottom"><span>&copy; <span data-current-year>2026</span> DevelopersCoffee</span><span>Airo is built in public. Roadmap scope may change as evidence changes.</span></div></div></footer>
+  <footer class="site-footer"><div class="container"><div class="footer-grid"><div><a class="brand" href="../../"><img src="../../assets/airo-tv/airo-icon.svg" alt=""><span>Airo</span></a><h2>Focused experiences. Shared foundations.</h2><p>Midas Stream is the first focused product in the Airo ecosystem.</p></div><div class="footer-col"><h3>Platform</h3><a href="../../#architecture">Architecture</a><a href="../../#foundations">Foundations</a><a href="../../#modules">Modules</a></div><div class="footer-col"><h3>Explore</h3><a href="../../tv/">Midas Stream</a><a href="../../#community">Community</a><a href="../../#roadmap">Roadmap</a><a href="https://discord.gg/62r67VcMzM" target="_blank" rel="noopener noreferrer">Discord ↗</a></div><div class="footer-col"><h3>Trust</h3><a href="../privacy-policy/">Privacy</a><a href="../terms-conditions/">Terms</a><a href="mailto:coffee.devloper@gmail.com">Support</a></div></div><div class="footer-bottom"><span>&copy; <span data-current-year>2026</span> DevelopersCoffee</span><span>Airo is built in public. Roadmap scope may change as evidence changes.</span></div></div></footer>
 </body>
 </html>

--- a/docs/release/AIRO_TV_CONTENT_RATING.md
+++ b/docs/release/AIRO_TV_CONTENT_RATING.md
@@ -9,8 +9,8 @@ must be saved by a maintainer with console access.
 
 | Field | Value |
 | --- | --- |
-| Product | Airo TV |
-| Android package ID | `io.airo.app.tv` |
+| Product | Midas Stream |
+| Android package ID | `com.developerscoffee.tv.midas` |
 | Entrypoint | `app/lib/main_tv.dart` |
 | Current release | v0.0.5 |
 | Privacy minimum age posture | Not directed to children under 16 |
@@ -24,7 +24,7 @@ must be saved by a maintainer with console access.
 | App Store Connect | 12+ or stricter if questionnaire output requires it | Future iOS/tvOS scope would allow user-provided streaming URLs. |
 | Target audience | 16+ | Aligns with the current Privacy Policy children's privacy posture. |
 
-Do not market Airo TV as child-directed. Do not select a lower age target
+Do not market Midas Stream as child-directed. Do not select a lower age target
 unless legal/privacy copy is changed first.
 
 ## Questionnaire Answers
@@ -51,7 +51,7 @@ unless legal/privacy copy is changed first.
 Recommended note for internal review:
 
 ```text
-Airo TV is a media player for user-provided IPTV playlist and stream URLs. The
+Midas Stream is a media player for user-provided playlist and stream URLs. The
 app does not provide channels, subscriptions, playlists, streams, ads, gambling,
 chat, purchases, or app-hosted mature content. Because users can enter external
 media URLs, choose the questionnaire option that best represents unrestricted
@@ -73,7 +73,7 @@ store-assigned rating.
 
 ## Human Console Actions
 
-- Complete the Google Play IARC questionnaire for `io.airo.app.tv`.
+- Complete the Google Play IARC questionnaire for `com.developerscoffee.tv.midas`.
 - Save the resulting Play rating certificate or console screenshot.
 - Complete App Store Connect age rating only if iOS/tvOS enters release scope.
 - Attach rating evidence back to #584 before closing the issue.

--- a/docs/release/AIRO_TV_DATA_SAFETY.md
+++ b/docs/release/AIRO_TV_DATA_SAFETY.md
@@ -9,8 +9,8 @@ access.
 
 | Field | Value |
 | --- | --- |
-| Product | Airo TV |
-| Android package ID | `io.airo.app.tv` |
+| Product | Midas Stream |
+| Android package ID | `com.developerscoffee.tv.midas` |
 | Entrypoint | `app/lib/main_tv.dart` |
 | Privacy Policy URL | `https://developerscoffee.github.io/airo/legal/privacy-policy/` |
 | Terms URL | `https://developerscoffee.github.io/airo/legal/terms-conditions/` |
@@ -30,8 +30,8 @@ This declaration is based on the current v2 TV release behavior:
   may be generated and sent to Google; this is declared under "Device or other
   IDs" below.
 - Playlist and program-guide requests go directly from the device to the
-  servers the user configured, and the public iptv-org catalogue is downloaded
-  and matched on-device. The user's playlist is never uploaded anywhere.
+  servers the user configured. The app does not download a public IPTV
+  catalogue. The user's playlist is never uploaded anywhere.
 
 ## Google Play Data Safety
 
@@ -49,7 +49,7 @@ This declaration is based on the current v2 TV release behavior:
 | Health and fitness | No | No | Not applicable | Not used. |
 | Messages | No | No | Not applicable | Not used. |
 | App activity | No app-owned external collection | No | App functionality | Preferences and playlist state are stored on device. |
-| Web browsing | No | No | Not applicable | Airo TV does not provide a browser. |
+| Web browsing | No | No | Not applicable | Midas Stream does not provide a browser. |
 | App info and performance | No app-owned external collection | No | Diagnostics only if user shares logs manually | Crashlytics is not included in the TV pubspec. |
 | Device or other IDs | **Yes — collected by Firebase SDK, not by the developer** | No | App functionality | `firebase_core` is in `app/pubspec_tv.yaml`. Where Firebase generates a Firebase installation ID (FID), it is sent to Google under Google's own privacy policy. It is not received by DevelopersCoffee, not linked to a user or account, not used for advertising or cross-app tracking, and reset on uninstall or clear-data. No advertising ID permission or analytics SDK is enabled. |
 | IPTV playlist URLs | Local only | No | App functionality | User-provided playlist URLs are stored on device and used to fetch user-selected content. |

--- a/docs/release/AIRO_TV_FEATURE_MATRIX.md
+++ b/docs/release/AIRO_TV_FEATURE_MATRIX.md
@@ -8,7 +8,7 @@ Next candidate: [`v0.0.7`](./AIRO_v0.0.7.md) (prepared, not tagged).
 | M3U playlists | Supported | User supplies authorized playlist URLs. |
 | M3U8 streams | Supported | Playback depends on the stream URL and codec support on the device. |
 | Local channel and guide search | Supported | Deterministic search across user-imported channels and available XMLTV guide data; no cloud or LLM query is required. |
-| Android TV | Supported | Package `io.airo.app.tv`; Leanback launcher enabled. |
+| Android TV | Supported | Package `com.developerscoffee.tv.midas`; Leanback launcher enabled. |
 | Pixel/mobile fallback | Supported | Used for smoke testing and responsive layout coverage. |
 | Chromecast controls | Supported | Discovery, play, pause, stop, reload, new session, volume. |
 | Favorites | Supported | Mark/unmark channels from browse and player flows; stored locally. |

--- a/docs/release/AIRO_TV_STORE_LISTING.md
+++ b/docs/release/AIRO_TV_STORE_LISTING.md
@@ -1,21 +1,23 @@
-# Airo TV Store Listing Metadata
+# Midas Stream Store Listing Metadata
 
-Canonical listing metadata for the Airo TV v2 Android TV release profile.
-This copy is scoped to the shipped v0.0.5 feature set in
-[Airo TV Feature Matrix](./AIRO_TV_FEATURE_MATRIX.md). Do not claim planned
-features such as recording, cloud playlists, or bundled channels until the
-feature matrix marks them supported.
+Canonical listing metadata for the first Google Play Android TV listing of
+Midas Stream (`com.developerscoffee.tv.midas`). Feature claims stay inside
+[Airo TV Feature Matrix](./AIRO_TV_FEATURE_MATRIX.md). Do not claim recording,
+cloud playlists, bundled channels, or a public IPTV catalogue.
+
+See [Midas Stream Play Store gate](./MIDAS_STREAM_PLAY_STORE_GATE.md) for the
+package-ID cutover and human console actions.
 
 ## Release Scope
 
 | Field | Value |
 | --- | --- |
-| Product | Airo TV |
-| Android package ID | `io.airo.app.tv` |
+| Product | Midas Stream |
+| Android package ID | `com.developerscoffee.tv.midas` |
 | Entrypoint | `app/lib/main_tv.dart` |
 | Device class | Android TV, Google TV, Fire TV-compatible APK testing |
-| First v2 wave | Android TV / Google Play TV track |
-| iOS / App Store | Deferred from the first v2 Android publishing wave |
+| First Play wave | Android TV / Google Play TV track |
+| iOS / App Store | Deferred from the first Android publishing wave |
 | Privacy Policy URL | `https://developerscoffee.github.io/airo/legal/privacy-policy/` |
 | Terms URL | `https://developerscoffee.github.io/airo/legal/terms-conditions/` |
 
@@ -23,44 +25,45 @@ feature matrix marks them supported.
 
 | Field | Final metadata |
 | --- | --- |
-| App name | `Airo TV - IPTV Player` |
-| Short description | `Play your own IPTV playlists on Android TV with Cast support.` |
-| Category | Entertainment / Video Players & Editors |
-| Tags / keywords | IPTV, M3U, M3U8, streaming, live TV, playlist, Android TV, Google TV, Chromecast, Cast |
+| App name | `Midas Stream` |
+| Short description | `Play your own authorized playlists on Android TV.` |
+| Category | Video Players & Editors |
+| Tags / keywords | M3U, M3U8, playlist player, Android TV, Google TV, Chromecast, Cast, HLS |
 | Privacy Policy URL | `https://developerscoffee.github.io/airo/legal/privacy-policy/` |
 | Content rating | Complete the IARC questionnaire in Play Console before submission. |
 
-Short description length: 61/80 characters.
+Short description length: 51/80 characters.
 
 ### Full Description
 
 ```text
-Airo TV is an IPTV player for Android TV, Google TV, and compatible TV devices.
-Bring your own authorized M3U or M3U8 playlist and watch live streams in a
-clean, remote-friendly interface built for the living room.
+Midas Stream is a media player for Android TV, Google TV, and compatible TV
+devices. Bring your own authorized M3U or M3U8 playlist and watch it in a
+clean, remote-friendly living-room interface.
+
+This app does not include channels, playlists, or subscriptions. You add the
+sources you already have the right to use.
 
 Key features:
 - Import your own M3U/M3U8 playlist URL
-- Browse and search channels by name
-- Add XMLTV guide sources, favorites, and user-authorized provider sources
-- See local channel status signals while browsing supported playlists
+- Browse and search entries by name
+- Add XMLTV guide sources and favorites for playlists you configured
 - Play supported HLS and media streams on TV devices
 - Use Chromecast/Cast controls where supported by your device and network
-- Keep playlists local unless you choose to load a remote playlist URL
+- Keep playlist URLs on the device unless you choose a remote URL
 - Use a TV-focused interface designed for remote navigation
 
 Important content notice:
-Airo TV is a media player only. It does not provide, host, sell, endorse,
+Midas Stream is a media player only. It does not provide, host, sell, endorse,
 verify, or distribute channels, playlists, streams, subscriptions, or IPTV
-services. You must supply your own legal content sources and ensure that you
+services. You must supply your own lawful content sources and ensure that you
 have the rights to access every stream you load.
 
 Supported playlist formats:
 M3U and M3U8.
 
 Playback support depends on the stream format, codec, device capability, and
-network connection. Some planned features, including recording and cloud
-playlists, are not included in this release.
+network connection. Recording and cloud playlists are not included.
 ```
 
 Full description length: 1,122/4,000 characters.

--- a/docs/release/FASTLANE_CREDENTIALS.md
+++ b/docs/release/FASTLANE_CREDENTIALS.md
@@ -13,7 +13,7 @@ It reads:
 | Variable | Default | Purpose |
 | --- | --- | --- |
 | `SUPPLY_JSON_KEY` or `SUPPLY_JSON_KEY_FILE` | `play-store-credentials.json` | Path to the Google Play service account JSON file used by Fastlane Supply. |
-| `SUPPLY_PACKAGE_NAME` | `io.airo.app.tv` | Package ID to upload. Override for mobile/tablet profiles. |
+| `SUPPLY_PACKAGE_NAME` | `com.developerscoffee.tv.midas` | Package ID to upload. Override for mobile/tablet profiles. |
 
 Release workflows already write the Play service account JSON from
 `GOOGLE_PLAY_SERVICE_ACCOUNT_JSON` to
@@ -23,7 +23,7 @@ Use these package values for v2 Android profiles:
 
 | Profile | `SUPPLY_PACKAGE_NAME` |
 | --- | --- |
-| `tv` | `io.airo.app.tv` |
+| `tv` | `com.developerscoffee.tv.midas` |
 | `full` | `io.airo.app` |
 
 Human setup still required:
@@ -46,7 +46,7 @@ Local smoke check after credentials are available:
 
 ```bash
 cd app/android
-SUPPLY_PACKAGE_NAME=io.airo.app.tv \
+SUPPLY_PACKAGE_NAME=com.developerscoffee.tv.midas \
 SUPPLY_JSON_KEY=play-store-credentials.json \
 bundle exec fastlane supply init
 ```

--- a/docs/release/MIDAS_STREAM_PLAY_STORE_GATE.md
+++ b/docs/release/MIDAS_STREAM_PLAY_STORE_GATE.md
@@ -1,0 +1,72 @@
+# Midas Stream — first Play Store gate
+
+Release-engineer scan of `origin/main` (`c23c8a23`) before the identity
+refactor, plus the decisions that make the first Play listing friction-free.
+
+This document is the working gate for `com.developerscoffee.tv.midas`. It does
+not rewrite historical Airo TV evidence under `docs/release/evidence/`.
+
+## Scan findings (main)
+
+| Surface | On `main` | First-release decision |
+| --- | --- | --- |
+| Android TV `applicationId` | `io.airo.app.tv` | **New listing** `com.developerscoffee.tv.midas`. Package IDs cannot be renamed in Play Console. |
+| Gradle `namespace` | `io.airo.app` | Keep. Play cares about `applicationId`; moving Kotlin sources is out of scope. |
+| Launcher label | `Airo TV` | `Midas Stream` |
+| macOS bundle ID | `com.developerscoffee.airo.tv` | Unchanged this wave. Not a Play Store artifact. |
+| Store listing / legal URLs | Airo TV copy | Relabeled to Midas Stream; same GitHub Pages paths. |
+| iptv-org one-tap presets | Shipped in the playlist manager | **Removed.** One-tap public playlists are a Play intellectual-property rejection. |
+| iptv-org catalogue fetch | `channels.json` / `feeds.json` / `streams.json` on browse | **Disabled.** `streams.json` is a public stream URL catalogue. |
+| Empty-state disclaimer | Present, said "Airo" | Kept; product name is Midas Stream. |
+| TV manifest `usesCleartextTraffic` | `false`, but network-security-config permits HTTP | Honest BYOC playback tradeoff; disclosed in privacy policy. |
+| `RECEIVE_BOOT_COMPLETED` | Declared | Keep for WorkManager restore; justify in Play declarations. |
+| `FOREGROUND_SERVICE_DATA_SYNC` | Missing on TV while WorkManager declares `dataSync` | **Added** so Android 14+ does not crash a foreground WorkManager job. |
+| Firebase Android client | Registered for `io.airo.app.tv` | **Human:** register `com.developerscoffee.tv.midas` and refresh `GOOGLE_SERVICES_JSON`. |
+| Digital Asset Links | `io.airo.app.tv` | **Human:** publish SHA-256 for the new package on `developerscoffee.github.io`. |
+
+## Product identity
+
+| Field | Value |
+| --- | --- |
+| App name | Midas Stream |
+| Android package | `com.developerscoffee.tv.midas` |
+| Entrypoint | `app/lib/main_tv.dart` |
+| Pubspec | `app/pubspec_tv.yaml` |
+| Category | Video Players & Editors |
+| Content model | Media player for user-supplied M3U/M3U8 URLs only |
+| Privacy Policy | `https://developerscoffee.github.io/airo/legal/privacy-policy/` |
+| Terms | `https://developerscoffee.github.io/airo/legal/terms-conditions/` |
+
+## Play policy posture
+
+Midas Stream is a **bring-your-own-content player**. It does not provide,
+host, sell, or recommend channels, playlists, or streams. The first listing
+must not:
+
+- ship or one-tap a public IPTV index (including iptv-org);
+- claim "free live TV", "channels included", or a bundled catalogue;
+- download a third-party stream URL database for enrichment;
+- target children (privacy minimum age remains 16+).
+
+Users paste an authorized playlist URL. Tests may still use iptv-org URLs as
+**fixtures the test itself supplies**, which is not the same as shipping a
+preset in production UI.
+
+## Human console actions (not code)
+
+These still block upload even after this branch is green:
+
+1. Create a **new** Play Console app for `com.developerscoffee.tv.midas`.
+2. Register a Firebase Android app for that package and update secrets.
+3. Confirm the production upload keystore and Play App Signing.
+4. Complete IARC / Data Safety using the worksheets in this folder.
+5. Export a 512×512 high-res icon and TV screenshots under the Midas Stream name.
+6. Pixel-line install and smoke (user-owned next step).
+
+## Out of scope this wave
+
+- Renaming the Airo super-app, Coins, or Mind packages.
+- macOS bundle ID / Homebrew cask rename.
+- Rewriting historical qualification evidence.
+- Changing GitHub artifact filenames (`Airo-TV-*.apk`); Play uploads the AAB
+  `applicationId`, not the GitHub file name.

--- a/docs/release/README.md
+++ b/docs/release/README.md
@@ -73,6 +73,7 @@ Next candidate: [Airo v0.0.7](./AIRO_v0.0.7.md) (prepared, not tagged).
 | [Airo TV Release Template](./AIRO_TV_RELEASE_TEMPLATE.md) | Stable release format for future Airo TV versions |
 | [Airo TV Feature Matrix](./AIRO_TV_FEATURE_MATRIX.md) | Supported, planned, and unsupported features |
 | [Airo TV Media Assets](./AIRO_TV_MEDIA_ASSETS.md) | Screenshot and demo-video release checklist |
+| [Midas Stream Play Store gate](./MIDAS_STREAM_PLAY_STORE_GATE.md) | First Play listing identity, package ID, and policy posture |
 | [Airo TV Store Listing Metadata](./AIRO_TV_STORE_LISTING.md) | Final Play listing copy and future App Store draft metadata |
 | [Airo TV Data Safety](./AIRO_TV_DATA_SAFETY.md) | Play Data Safety and future App Privacy declaration worksheet |
 | [Airo TV Content Rating](./AIRO_TV_CONTENT_RATING.md) | IARC and future App Store age rating questionnaire worksheet |

--- a/docs/release/STORE_COMPLIANCE.md
+++ b/docs/release/STORE_COMPLIANCE.md
@@ -27,7 +27,7 @@ The current v2 profile matrix is maintained in
 
 | Profile | Package ID | Device class | Entrypoint | Store status |
 | --- | --- | --- | --- | --- |
-| `tv` | `io.airo.app.tv` | Android TV, Google TV, Fire TV-compatible APK testing | `app/lib/main_tv.dart` | TV release workflow builds APK and Play AAB; real Play upload needs #585/#681 setup |
+| `tv` | `com.developerscoffee.tv.midas` | Android TV, Google TV, Fire TV-compatible APK testing | `app/lib/main_tv.dart` | TV release workflow builds APK and Play AAB; real Play upload needs #585/#681 setup |
 | `full` | `io.airo.app` | Airo phone and tablet builds | `app/lib/main.dart` | Mobile/tablet release workflow builds APK and Play AAB; real publish setup needs #585/#681/#682 |
 | `ios-spm` | `com.developerscoffee.airo` | iOS/iPadOS validation profile | `app/lib/main.dart` | Deferred from the first v2 Android publishing wave |
 
@@ -44,10 +44,10 @@ The Android Gradle config currently uses:
 
 | Field | Current value | Status |
 | --- | --- | --- |
-| App name | `Airo TV - IPTV Player` | Ready in [Airo TV Store Listing Metadata](./AIRO_TV_STORE_LISTING.md) |
-| Package ID | `io.airo.app.tv` | Registered |
-| Category | Entertainment / Video Players & Editors | Ready in [Airo TV Store Listing Metadata](./AIRO_TV_STORE_LISTING.md) |
-| Short description | `Play your own IPTV playlists on Android TV with Cast support.` | Ready in [Airo TV Store Listing Metadata](./AIRO_TV_STORE_LISTING.md) |
+| App name | `Midas Stream` | Ready in [Airo TV Store Listing Metadata](./AIRO_TV_STORE_LISTING.md) |
+| Package ID | `com.developerscoffee.tv.midas` | New Play listing — create the Console app before first upload |
+| Category | Video Players & Editors | Ready in [Airo TV Store Listing Metadata](./AIRO_TV_STORE_LISTING.md) |
+| Short description | `Play your own authorized playlists on Android TV.` | Ready in [Airo TV Store Listing Metadata](./AIRO_TV_STORE_LISTING.md) |
 | Full description | Final copy in [Airo TV Store Listing Metadata](./AIRO_TV_STORE_LISTING.md) | Ready pending stakeholder approval |
 | Privacy Policy URL | `https://developerscoffee.github.io/airo/legal/privacy-policy/` | Ready |
 | Terms URL | `https://developerscoffee.github.io/airo/legal/terms-conditions/` | Ready |
@@ -71,6 +71,7 @@ The TV manifest is `app/android/app/src/tv/AndroidManifest.xml`.
 | `RECEIVE_BOOT_COMPLETED` | WorkManager/plugin compatibility for scheduled/background work | Review before public TV submission |
 | `FOREGROUND_SERVICE` | Foreground playback/service support | Required |
 | `FOREGROUND_SERVICE_MEDIA_PLAYBACK` | Android media playback foreground service declaration | Required |
+| `FOREGROUND_SERVICE_DATA_SYNC` | WorkManager foreground service type on Android 14+ | Required |
 | `WAKE_LOCK` | Keep playback/session work stable during media use | Required |
 
 The TV manifest explicitly removes biometric/fingerprint, Google Services read,
@@ -114,7 +115,7 @@ iOS to the release scope.
 
 ## IPTV Content Disclaimer
 
-Airo TV is a media player for user-provided playlists and streams. It does not
+Airo TV / Midas Stream is a media player for user-provided playlists and streams. It does not
 provide, host, endorse, verify, or distribute channels, playlists, or streams.
 Users are responsible for ensuring that every content source they load is legal
 in their jurisdiction and that they have the required rights to access it.

--- a/docs/release/V2_DISTRIBUTION_MATRIX.md
+++ b/docs/release/V2_DISTRIBUTION_MATRIX.md
@@ -15,7 +15,7 @@ that platform contract aligned before changing release workflows.
 | Profile | Package ID | Entrypoint | Pubspec | Device class | Release artifacts | Distribution |
 | --- | --- | --- | --- | --- | --- | --- |
 | `full` | `io.airo.app` | `app/lib/main.dart` | `app/pubspec.yaml` | Airo phone and tablet builds | APK, Play Store AAB | GitHub Release evidence, Firebase App Distribution, Play track after credentials |
-| `tv` | `io.airo.app.tv` | `app/lib/main_tv.dart` | `app/pubspec_tv.yaml` | Android TV, Google TV, Fire TV-compatible APK testing | APK, Play Store AAB | GitHub Release, Firebase App Distribution where supported, Play TV track after credentials |
+| `tv` | `com.developerscoffee.tv.midas` | `app/lib/main_tv.dart` | `app/pubspec_tv.yaml` | Android TV, Google TV, Fire TV-compatible APK testing | APK, Play Store AAB | GitHub Release, Firebase App Distribution where supported, Play TV track after credentials |
 | `tv` | `com.developerscoffee.airo.tv` | `app/lib/main_tv.dart` | `app/pubspec_tv.yaml` | macOS Airo TV IPTV build | ZIP, DMG, Homebrew Cask metadata | GitHub Release direct download, Homebrew Cask after notarization |
 | `coins` | `io.airo.app.coins` | `app/lib/main_coins.dart` | `app/pubspec_coins.yaml` | Focused Android phone architecture/size qualification; macOS excluded | APK | Local Android validation only; public distribution deferred |
 | `mind` | `io.airo.app.mind` | `app/lib/main_mind.dart` | `app/pubspec_mind.yaml` | Airo Mind on-device scribe; Android phone, arm64 only (the Rust runtime does not cross-compile to armv7) | APK | Not building yet; local Android validation only once it does, public distribution deferred |

--- a/docs/release/V2_HUMAN_IN_LOOP_BLOCKERS.md
+++ b/docs/release/V2_HUMAN_IN_LOOP_BLOCKERS.md
@@ -27,7 +27,8 @@ exports, playlist URLs, local IP addresses, or private device logs.
 
 | Issue | Setup | Verification |
 | --- | --- | --- |
-| #574 | Firebase Android client for TV | Closed. Verified `io.airo.app.tv` in the local ignored Android Firebase config and in public Flutter Firebase options with app ID `1:906799550225:android:dfa957aac3a2fdc62206b0`. The `GOOGLE_SERVICES_JSON` GitHub secret exists and was updated; GitHub does not allow reading secret contents back for direct comparison. |
+| #574 | Firebase Android client for Airo TV (`io.airo.app.tv`) | Closed for the previous listing. Does **not** cover Midas Stream. |
+| — | Firebase Android client for Midas Stream | **Open.** Register `com.developerscoffee.tv.midas` in Firebase, regenerate `google-services.json` / `GOOGLE_SERVICES_JSON`, and confirm the Play/Firebase package match before the first AAB upload. |
 
 ### Exact Secret And Input Names
 
@@ -47,7 +48,7 @@ release or distribution run is intentionally started.
 | Dogfood/RC key alias | Secret: `DOGFOOD_KEY_ALIAS` | — |
 | Dogfood/RC key password | Secret: `DOGFOOD_KEY_PASSWORD` | — |
 | Google Play upload service account | Secret: `GOOGLE_PLAY_SERVICE_ACCOUNT_JSON` | #585 |
-| Play package selection | Fastlane/env value: `SUPPLY_PACKAGE_NAME`; use `io.airo.app` or `io.airo.app.tv` | #585 |
+| Play package selection | Fastlane/env value: `SUPPLY_PACKAGE_NAME`; use `io.airo.app` or `com.developerscoffee.tv.midas` | #585 |
 | Firebase App Distribution service account | Secret: `FIREBASE_SERVICE_ACCOUNT_JSON` | #682 |
 | Firebase App Distribution app IDs | Workflow inputs: `firebase_app_id`, `mobile_firebase_app_id`, `tv_firebase_app_id` depending on release workflow | #682 |
 | Firebase App Distribution tester groups | Workflow inputs: `firebase_tester_groups`, `mobile_firebase_tester_groups`, `tv_firebase_tester_groups` depending on release workflow | #682 |

--- a/docs/release/V2_PUBLISHING_HUMAN_SETUP.md
+++ b/docs/release/V2_PUBLISHING_HUMAN_SETUP.md
@@ -15,9 +15,11 @@ see [V2 Human-In-Loop Blocker Index](./V2_HUMAN_IN_LOOP_BLOCKERS.md).
 
 Related issues: #681, #585, #657.
 
-- [ ] Create or confirm the Play Console app for each public v2 package ID.
-- [x] Confirm package IDs for Airo and Airo TV: `io.airo.app` and
-      `io.airo.app.tv`.
+- [ ] Create or confirm the Play Console app for each public v2 package ID,
+      including a **new** listing for Midas Stream (`com.developerscoffee.tv.midas`).
+      This is not a rename of `io.airo.app.tv`.
+- [x] Confirm the Airo mobile package ID: `io.airo.app`.
+- [x] Confirm the Midas Stream Android TV package ID: `com.developerscoffee.tv.midas`.
 - [ ] Decide whether mobile and tablet share one adaptive listing or use
       separate listings.
 - [ ] Create a Play service account for release automation.
@@ -41,8 +43,10 @@ Related issues: #682, #574, #756.
 
 - [ ] Create or confirm Firebase apps for each package ID that should receive
       internal APKs.
-- [x] Confirm the TV Firebase Android client for `io.airo.app.tv` is
-      registered and represented in public Flutter Firebase options.
+- [ ] Register a Firebase Android client for Midas Stream
+      (`com.developerscoffee.tv.midas`) and represent it in Flutter Firebase
+      options / `GOOGLE_SERVICES_JSON`. The closed #574 client was
+      `io.airo.app.tv` and does not apply to this package.
 - [x] Confirm `GOOGLE_SERVICES_JSON` exists as a GitHub secret. Secret contents
       cannot be read back from GitHub; compare against the local ignored config
       before publishing.

--- a/docs/wiki/2.-Getting-Started.md
+++ b/docs/wiki/2.-Getting-Started.md
@@ -7,7 +7,8 @@ one release carrying every product line.
 
 | Product | Package | Download |
 |---|---|---|
-| Airo TV (Android TV / Fire TV) | `io.airo.app.tv` | [Airo-TV-0.0.6.apk](https://github.com/DevelopersCoffee/airo/releases/download/v0.0.6/Airo-TV-0.0.6.apk) |
+| Airo TV (GitHub v0.0.6) | `io.airo.app.tv` | [Airo-TV-0.0.6.apk](https://github.com/DevelopersCoffee/airo/releases/download/v0.0.6/Airo-TV-0.0.6.apk) |
+| Midas Stream (Play Store, first listing) | `com.developerscoffee.tv.midas` | Not published yet — Pixel qualification next. See [Midas Stream Play Store gate](../release/MIDAS_STREAM_PLAY_STORE_GATE.md). |
 | Airo (phone / tablet) | `io.airo.app` | [Airo-0.0.6-10-arm64.apk](https://github.com/DevelopersCoffee/airo/releases/download/v0.0.6/Airo-0.0.6-10-arm64.apk) |
 | Airo Coins | `io.airo.app.coins` | [AiroCoins-0.0.6-10-arm64.apk](https://github.com/DevelopersCoffee/airo/releases/download/v0.0.6/AiroCoins-0.0.6-10-arm64.apk) |
 | Airo TV for macOS | — | [DMG](https://github.com/DevelopersCoffee/airo/releases/download/v0.0.6/Airo-TV-0.0.6-macOS.dmg) · [ZIP](https://github.com/DevelopersCoffee/airo/releases/download/v0.0.6/Airo-TV-0.0.6-macOS.zip) |

--- a/melos.yaml
+++ b/melos.yaml
@@ -134,7 +134,7 @@ scripts:
       cd packages/platform_benchmarks
       flutter pub get
       dart run tool/run_airo_tv_playback_soak.dart \
-        --package "${AIRO_TV_PACKAGE:-io.airo.app.tv}" \
+        --package "${AIRO_TV_PACKAGE:-com.developerscoffee.tv.midas}" \
         --device "${AIRO_TV_DEVICE:-}" \
         --duration-seconds "${AIRO_TV_SOAK_DURATION_SECONDS:-1800}" \
         --interval-seconds "${AIRO_TV_SOAK_INTERVAL_SECONDS:-30}" \

--- a/packages/core_app_shell/lib/src/platform_features.dart
+++ b/packages/core_app_shell/lib/src/platform_features.dart
@@ -25,7 +25,7 @@ enum AppPlatform {
   mobileFull,
 
   /// Android TV / Fire TV - IPTV only
-  /// Package: io.airo.app.tv
+  /// Package: com.developerscoffee.tv.midas
   androidTv,
 
   /// iPad - streaming with tablet-optimized UI

--- a/packages/core_product_shell/lib/src/sibling_apps/sibling_app_registry.dart
+++ b/packages/core_product_shell/lib/src/sibling_apps/sibling_app_registry.dart
@@ -27,10 +27,10 @@ final siblingApps = <SiblingApp>[
   ),
   SiblingApp(
     id: ShellId.tv,
-    name: 'Airo TV',
-    pitch: 'Live TV and IPTV built for the big screen.',
+    name: 'Midas Stream',
+    pitch: 'Bring your own authorized playlists to Android TV.',
     iconAsset: _placeholderIconAsset,
-    androidStoreUrl: _playStoreUrl('com.airo.tv'),
+    androidStoreUrl: _playStoreUrl('com.developerscoffee.tv.midas'),
     iosStoreUrl: _appStoreUrl('com.airo.tv'),
   ),
   SiblingApp(

--- a/packages/core_release/lib/src/content_rating_preflight.dart
+++ b/packages/core_release/lib/src/content_rating_preflight.dart
@@ -441,7 +441,7 @@ class AiroContentRatingPreflightRunner {
       AiroContentRatingQuestionAnswer(
         topic: 'App-hosted mature content',
         answer: yesNo(request.hasAppHostedMatureContent),
-        note: 'Airo TV is a media player and does not host media content.',
+        note: 'Midas Stream is a media player and does not host media content.',
       ),
       AiroContentRatingQuestionAnswer(
         topic: 'Violence in app UI',
@@ -462,7 +462,7 @@ class AiroContentRatingPreflightRunner {
         topic: 'Content disclaimer',
         answer: 'Yes',
         note:
-            'Airo TV is a media player only; users are responsible for their '
+            'Midas Stream is a media player only; users are responsible for their '
             'own lawful content sources.',
       ),
     ];

--- a/packages/core_release/lib/src/fastlane_credentials_preflight.dart
+++ b/packages/core_release/lib/src/fastlane_credentials_preflight.dart
@@ -56,7 +56,7 @@ class AiroFastlaneCredentialsPreflightRequest extends Equatable {
   const AiroFastlaneCredentialsPreflightRequest({
     required this.profileId,
     this.environment = const {},
-    this.defaultAndroidPackageName = 'io.airo.app.tv',
+    this.defaultAndroidPackageName = 'com.developerscoffee.tv.midas',
     this.defaultAndroidCredentialPath =
         'app/android/play-store-credentials.json',
     this.googlePlayCredentialFileExists = false,

--- a/packages/core_release/lib/src/release_matrix.dart
+++ b/packages/core_release/lib/src/release_matrix.dart
@@ -453,12 +453,12 @@ class AiroReleaseMatrix extends Equatable {
         ),
         AiroReleaseProfile(
           id: 'tv',
-          displayName: 'Airo TV',
+          displayName: 'Midas Stream',
           artifactNamePart: 'TV',
           releaseLine: AiroReleaseLine.v2,
-          packageId: 'io.airo.app.tv',
+          packageId: 'com.developerscoffee.tv.midas',
           platformPackageIds: const {
-            'android': 'io.airo.app.tv',
+            'android': 'com.developerscoffee.tv.midas',
             'macos': 'com.developerscoffee.airo.tv',
           },
           entrypoint: 'app/lib/main_tv.dart',

--- a/packages/core_release/test/content_rating_preflight_test.dart
+++ b/packages/core_release/test/content_rating_preflight_test.dart
@@ -40,7 +40,7 @@ void main() {
 
       expect(preflight.readyForConsoleEntry, isTrue);
       expect(preflight.profileId, 'tv');
-      expect(preflight.packageId, 'io.airo.app.tv');
+      expect(preflight.packageId, 'com.developerscoffee.tv.midas');
       expect(preflight.googlePlayExpectedRating, contains('Teen / 12+'));
       expect(preflight.appStoreExpectedRating, contains('12+'));
       expect(

--- a/packages/core_release/test/data_safety_preflight_test.dart
+++ b/packages/core_release/test/data_safety_preflight_test.dart
@@ -38,7 +38,7 @@ void main() {
 
       expect(preflight.readyForConsoleEntry, isTrue);
       expect(preflight.profileId, 'tv');
-      expect(preflight.packageId, 'io.airo.app.tv');
+      expect(preflight.packageId, 'com.developerscoffee.tv.midas');
       expect(preflight.analyticsSdkPresent, isFalse);
       expect(preflight.crashlyticsSdkPresent, isFalse);
       expect(preflight.advertisingSdkPresent, isFalse);
@@ -178,7 +178,7 @@ void main() {
       () {
         final output = run().toPublicMap();
 
-        expect(output['packageId'], 'io.airo.app.tv');
+        expect(output['packageId'], 'com.developerscoffee.tv.midas');
         expect(
           (output['googlePlayDataSafety']!
               as Map<String, Object?>)['consoleSubmissionRequired'],

--- a/packages/core_release/test/fastlane_credentials_preflight_test.dart
+++ b/packages/core_release/test/fastlane_credentials_preflight_test.dart
@@ -24,15 +24,15 @@ void main() {
     test('accepts TV Play setup when package and credential are present', () {
       final preflight = run(
         environment: const {
-          'SUPPLY_PACKAGE_NAME': 'io.airo.app.tv',
+          'SUPPLY_PACKAGE_NAME': 'com.developerscoffee.tv.midas',
           'GOOGLE_PLAY_SERVICE_ACCOUNT_JSON': 'fixture-google-payload',
         },
       );
 
       expect(preflight.googlePlayReady, isTrue);
       expect(preflight.appStoreConnectReady, isFalse);
-      expect(preflight.expectedAndroidPackageName, 'io.airo.app.tv');
-      expect(preflight.androidPackageName, 'io.airo.app.tv');
+      expect(preflight.expectedAndroidPackageName, 'com.developerscoffee.tv.midas');
+      expect(preflight.androidPackageName, 'com.developerscoffee.tv.midas');
       expect(
         preflight.googlePlayCredentialSource,
         'env:GOOGLE_PLAY_SERVICE_ACCOUNT_JSON',
@@ -63,7 +63,7 @@ void main() {
 
       expect(preflight.googlePlayReady, isFalse);
       expect(preflight.expectedAndroidPackageName, 'io.airo.app');
-      expect(preflight.androidPackageName, 'io.airo.app.tv');
+      expect(preflight.androidPackageName, 'com.developerscoffee.tv.midas');
       expect(
         preflight.findings.map((finding) => finding.code),
         contains(AiroFastlaneCredentialFindingCode.packageNameMismatch),
@@ -73,13 +73,13 @@ void main() {
     test('blocks App Store Connect only when iOS upload is in scope', () {
       final deferred = run(
         environment: const {
-          'SUPPLY_PACKAGE_NAME': 'io.airo.app.tv',
+          'SUPPLY_PACKAGE_NAME': 'com.developerscoffee.tv.midas',
           'PLAY_STORE_CREDENTIALS': 'fixture-play-payload',
         },
       );
       final inScope = run(
         environment: const {
-          'SUPPLY_PACKAGE_NAME': 'io.airo.app.tv',
+          'SUPPLY_PACKAGE_NAME': 'com.developerscoffee.tv.midas',
           'PLAY_STORE_CREDENTIALS': 'fixture-play-payload',
         },
         iosUploadInScope: true,
@@ -118,7 +118,7 @@ void main() {
       () {
         final preflight = run(
           environment: const {
-            'SUPPLY_PACKAGE_NAME': 'io.airo.app.tv',
+            'SUPPLY_PACKAGE_NAME': 'com.developerscoffee.tv.midas',
             'GOOGLE_PLAY_SERVICE_ACCOUNT_JSON': 'fixture-google-payload',
             'MATCH_PASSWORD': 'fixture-match-value',
             'ASC_KEY_ID': 'key-id',
@@ -139,7 +139,7 @@ void main() {
     test('public output never exposes credential material', () {
       final output = run(
         environment: const {
-          'SUPPLY_PACKAGE_NAME': 'io.airo.app.tv',
+          'SUPPLY_PACKAGE_NAME': 'com.developerscoffee.tv.midas',
           'GOOGLE_PLAY_SERVICE_ACCOUNT_JSON': 'fixture-google-payload',
           'MATCH_PASSWORD': 'fixture-match-value',
           'ASC_KEY_ID': 'key-id',

--- a/packages/core_release/test/firebase_android_client_preflight_test.dart
+++ b/packages/core_release/test/firebase_android_client_preflight_test.dart
@@ -87,7 +87,7 @@ void main() {
 
         expect(expected.map((client) => client.packageName), [
           'io.airo.app',
-          'io.airo.app.tv',
+          'com.developerscoffee.tv.midas',
         ]);
         expect(expected.map((client) => client.firebaseOptionsName), [
           'android',

--- a/packages/core_release/test/firebase_distribution_preflight_test.dart
+++ b/packages/core_release/test/firebase_distribution_preflight_test.dart
@@ -32,7 +32,7 @@ void main() {
 
         expect(preflight.ready, isTrue);
         expect(preflight.findings, isEmpty);
-        expect(preflight.targets.single.packageId, 'io.airo.app.tv');
+        expect(preflight.targets.single.packageId, 'com.developerscoffee.tv.midas');
         expect(
           preflight.targets.single.toPublicMap(),
           containsPair('testerGroupCount', 1),

--- a/packages/core_release/test/play_upload_plan_test.dart
+++ b/packages/core_release/test/play_upload_plan_test.dart
@@ -30,7 +30,7 @@ void main() {
       expect(uploadPlan.mode, AiroPlayUploadMode.noUpload);
       expect(uploadPlan.uploadRequested, isFalse);
       expect(uploadPlan.canUpload, isFalse);
-      expect(uploadPlan.packageId, 'io.airo.app.tv');
+      expect(uploadPlan.packageId, 'com.developerscoffee.tv.midas');
       expect(
         uploadPlan.expectedAabFileName,
         'Airo-TV-2.0.0-200-Play-Store.aab',
@@ -144,7 +144,7 @@ void main() {
         serviceAccountAvailable: true,
       ).toPublicMap().toString();
 
-      expect(publicMap, contains('io.airo.app.tv'));
+      expect(publicMap, contains('com.developerscoffee.tv.midas'));
       expect(publicMap, contains('Play-Store.aab'));
       expect(publicMap, isNot(contains('private_key')));
       expect(publicMap, isNot(contains('client_email')));

--- a/packages/core_release/test/release_matrix_test.dart
+++ b/packages/core_release/test/release_matrix_test.dart
@@ -14,6 +14,11 @@ void main() {
       expect(matrix.profileById('full').packageId, 'io.airo.app');
       expect(matrix.profileById('full').entrypoint, 'app/lib/main.dart');
       expect(
+        matrix.profileById('tv').packageId,
+        'com.developerscoffee.tv.midas',
+      );
+      expect(matrix.profileById('tv').displayName, 'Midas Stream');
+      expect(
         matrix.profileById('tv').platformPackageIds['macos'],
         'com.developerscoffee.airo.tv',
       );
@@ -166,7 +171,7 @@ void main() {
     test('public maps omit private signing and debug material', () {
       final publicMap = AiroReleaseMatrix.v2Default().toPublicMap().toString();
 
-      expect(publicMap, contains('io.airo.app.tv'));
+      expect(publicMap, contains('com.developerscoffee.tv.midas'));
       expect(publicMap, contains('com.developerscoffee.airo.tv'));
       expect(publicMap, isNot(contains('keystore')));
       expect(publicMap, isNot(contains('signing')));

--- a/packages/core_release/test/release_qualification_preflight_test.dart
+++ b/packages/core_release/test/release_qualification_preflight_test.dart
@@ -10,7 +10,7 @@ void main() {
     }) {
       return AiroReleaseArtifactEvidence(
         profileId: 'tv',
-        packageId: 'io.airo.app.tv',
+        packageId: 'com.developerscoffee.tv.midas',
         filename: filename,
         artifactType: 'apk',
         sha256: sha256,

--- a/packages/feature_iptv/lib/application/channel_metadata_enrichment.dart
+++ b/packages/feature_iptv/lib/application/channel_metadata_enrichment.dart
@@ -11,10 +11,22 @@ const _channelsUrl = 'https://iptv-org.github.io/api/channels.json';
 const _feedsUrl = 'https://iptv-org.github.io/api/feeds.json';
 const _streamsUrl = 'https://iptv-org.github.io/api/streams.json';
 
-/// Fetches public metadata only. Parsing happens off the UI isolate; failure
-/// deliberately yields no extra metadata rather than blocking playlist browse.
+/// Optional public-catalogue matcher. Production Play builds return no extra
+/// metadata: downloading iptv-org `streams.json` would ship a third-party
+/// stream URL catalogue, which is not allowed for the first listing.
+///
+/// Parsing still happens off the UI isolate when a test or private overlay
+/// opts in with [enablePublicIptvOrgCatalog].
+const bool enablePublicIptvOrgCatalog = bool.fromEnvironment(
+  'AIRO_ENABLE_IPTV_ORG_CATALOG',
+  defaultValue: false,
+);
+
 final channelBrowseMetadataProvider =
     FutureProvider<Map<String, ChannelBrowseMetadata>>((ref) async {
+      if (!enablePublicIptvOrgCatalog) {
+        return const {};
+      }
       try {
         final dio = ref.watch(dioProvider);
         final responses = await Future.wait([

--- a/packages/feature_iptv/lib/application/platform_backup_document_gateway.dart
+++ b/packages/feature_iptv/lib/application/platform_backup_document_gateway.dart
@@ -37,7 +37,7 @@ class PlatformBackupDocumentGateway implements AiroBackupDocumentGateway {
     // `file_picker` is dependency-overridden to a stub — that there was
     // never a dialog at all. Either way nothing reached disk.
     final destination = await FilePicker.saveFile(
-      dialogTitle: 'Save Airo TV backup',
+      dialogTitle: 'Save Midas Stream backup',
       fileName: document.fileName,
       type: FileType.custom,
       allowedExtensions: const ['json'],
@@ -51,7 +51,7 @@ class PlatformBackupDocumentGateway implements AiroBackupDocumentGateway {
     // the document was not handed off.
     final result = await SharePlus.instance.share(
       ShareParams(
-        subject: 'Airo TV backup',
+        subject: 'Midas Stream backup',
         files: [
           XFile.fromData(
             Uint8List.fromList(utf8.encode(document.contents)),
@@ -66,7 +66,7 @@ class PlatformBackupDocumentGateway implements AiroBackupDocumentGateway {
 
   static Future<AiroBackupDocument?> _pick() async {
     final file = await FilePicker.pickFile(
-      dialogTitle: 'Choose an Airo TV backup',
+      dialogTitle: 'Choose a Midas Stream backup',
       type: FileType.custom,
       allowedExtensions: const ['json'],
     );

--- a/packages/feature_iptv/lib/application/services/airo_macos_update_service.dart
+++ b/packages/feature_iptv/lib/application/services/airo_macos_update_service.dart
@@ -53,7 +53,7 @@ class AiroMacosUpdateService {
         availability: AiroMacosUpdateAvailability.unavailable,
         currentVersion: currentVersion,
         latestVersion: null,
-        releaseName: 'Airo TV',
+        releaseName: 'Midas Stream',
         releaseUrl: Uri.parse(kAiroMacosReleasesUrl),
         detail: 'Update checks are available in the macOS app.',
       );
@@ -84,7 +84,7 @@ class AiroMacosUpdateService {
   }) {
     final tagName = payload['tag_name'] as String?;
     final releaseName =
-        payload['name'] as String? ?? tagName ?? 'Latest Airo TV release';
+        payload['name'] as String? ?? tagName ?? 'Latest Midas Stream release';
     final releaseUrl =
         _absoluteUri(payload['html_url'] as String?) ??
         Uri.parse(kAiroMacosReleasesUrl);

--- a/packages/feature_iptv/lib/application/services/tv_playlist_pairing_server.dart
+++ b/packages/feature_iptv/lib/application/services/tv_playlist_pairing_server.dart
@@ -228,7 +228,7 @@ const _formHtml = '''
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>Add playlist to Airo TV</title>
+<title>Add playlist to Midas Stream</title>
 <style>
 body{font-family:sans-serif;max-width:480px;margin:48px auto;padding:0 20px;color:#1a1a1a}
 h1{font-size:20px}

--- a/packages/feature_iptv/lib/feature_iptv.dart
+++ b/packages/feature_iptv/lib/feature_iptv.dart
@@ -1,5 +1,6 @@
 library;
 
+export "product_identity.dart";
 export "src/iptv.dart";
 export "domain/iptv_navigation_manifest.dart";
 export "domain/iptv_settings_manifest.dart";

--- a/packages/feature_iptv/lib/presentation/screens/iptv_screen.dart
+++ b/packages/feature_iptv/lib/presentation/screens/iptv_screen.dart
@@ -996,7 +996,7 @@ class _IPTVScreenState extends ConsumerState<IPTVScreen>
               : _playLocalFileOnTv,
         ),
         appBar: AppBar(
-          title: const Text('Airo TV'),
+          title: const Text('Midas Stream'),
           actions: [
             IconButton(
               icon: const Icon(Icons.search),
@@ -1604,7 +1604,7 @@ class _BringYourOwnPlaylistView extends ConsumerWidget {
           ),
           const SizedBox(height: 8),
           Text(
-            'Airo is a media player. It does not provide channels, playlists, or program guide data. Add an M3U URL for media you own or are authorized to watch.',
+            'Midas Stream is a media player. It does not provide channels, playlists, or program guide data. Add an M3U URL for media you own or are authorized to watch.',
             style: theme.textTheme.bodyMedium,
           ),
           const SizedBox(height: 16),

--- a/packages/feature_iptv/lib/presentation/tv_ux/airo_tv_shell.dart
+++ b/packages/feature_iptv/lib/presentation/tv_ux/airo_tv_shell.dart
@@ -506,7 +506,7 @@ class _VideoStageWithActions extends StatelessWidget {
               _StageAction(
                 key: const ValueKey('airo-tv-shell-help-action'),
                 icon: Icons.help_outline,
-                tooltip: 'Airo TV Help',
+                tooltip: 'Midas Stream Help',
                 onPressed: onHelp,
               ),
               const SizedBox(width: 4),

--- a/packages/feature_iptv/lib/presentation/tv_ux/iptv_resume_splash.dart
+++ b/packages/feature_iptv/lib/presentation/tv_ux/iptv_resume_splash.dart
@@ -85,7 +85,7 @@ class _IptvResumeSplashState extends State<IptvResumeSplash> {
               mainAxisSize: MainAxisSize.min,
               children: [
                 Text(
-                  'Airo TV',
+                  'Midas Stream',
                   style: Theme.of(context).textTheme.headlineLarge?.copyWith(
                     color: Colors.white,
                     fontWeight: FontWeight.w700,

--- a/packages/feature_iptv/lib/presentation/tv_ux/sections/channel_info_bar.dart
+++ b/packages/feature_iptv/lib/presentation/tv_ux/sections/channel_info_bar.dart
@@ -68,11 +68,11 @@ class ChannelInfoBar extends ConsumerWidget {
           if (onHelpTap != null)
             TvFocusable(
               key: const ValueKey('airo-tv-shell-help-action'),
-              semanticLabel: 'Airo TV Help',
+              semanticLabel: 'Midas Stream Help',
               onSelect: onHelpTap,
               child: IconButton(
                 onPressed: onHelpTap,
-                tooltip: 'Airo TV Help',
+                tooltip: 'Midas Stream Help',
                 icon: const Icon(Icons.help_outline),
               ),
             ),

--- a/packages/feature_iptv/lib/presentation/tv_ux/sections/shell_help_dialog.dart
+++ b/packages/feature_iptv/lib/presentation/tv_ux/sections/shell_help_dialog.dart
@@ -53,7 +53,7 @@ class AiroTvShellHelpDialog extends StatelessWidget {
   Widget build(BuildContext context) {
     return AlertDialog(
       key: const ValueKey('airo-tv-shell-help-dialog'),
-      title: const Text('Airo TV Help'),
+      title: const Text('Midas Stream Help'),
       content: ConstrainedBox(
         constraints: const BoxConstraints(maxWidth: 520),
         child: SingleChildScrollView(

--- a/packages/feature_iptv/lib/presentation/tv_ux/sections/ways_to_watch_dialog.dart
+++ b/packages/feature_iptv/lib/presentation/tv_ux/sections/ways_to_watch_dialog.dart
@@ -37,7 +37,7 @@ class WaysToWatchDialog extends StatelessWidget {
               key: const ValueKey('ways-to-watch-fit'),
               icon: Icons.fit_screen_outlined,
               title: 'Fit Screen',
-              description: 'Keep video fitted inside the Airo TV window.',
+              description: 'Keep video fitted inside the Midas Stream window.',
               autofocus: true,
               onSelect: onFitScreen,
             ),

--- a/packages/feature_iptv/lib/presentation/widgets/playlist_source_manager_sheet.dart
+++ b/packages/feature_iptv/lib/presentation/widgets/playlist_source_manager_sheet.dart
@@ -1,5 +1,3 @@
-import 'dart:async';
-
 import 'package:core_ui/core_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -8,32 +6,6 @@ import 'package:platform_playlist/platform_playlist.dart';
 import '../../application/content_source_store.dart';
 import '../../application/providers/content_source_management_providers.dart';
 import '../../application/providers/iptv_providers.dart';
-
-class IptvOrgPlaylistPreset {
-  const IptvOrgPlaylistPreset({required this.label, required this.url});
-
-  final String label;
-  final String url;
-}
-
-const iptvOrgPlaylistPresets = <IptvOrgPlaylistPreset>[
-  IptvOrgPlaylistPreset(
-    label: 'All channels',
-    url: 'https://iptv-org.github.io/iptv/index.m3u',
-  ),
-  IptvOrgPlaylistPreset(
-    label: 'By category',
-    url: 'https://iptv-org.github.io/iptv/index.category.m3u',
-  ),
-  IptvOrgPlaylistPreset(
-    label: 'By language',
-    url: 'https://iptv-org.github.io/iptv/index.language.m3u',
-  ),
-  IptvOrgPlaylistPreset(
-    label: 'By country',
-    url: 'https://iptv-org.github.io/iptv/index.country.m3u',
-  ),
-];
 
 /// Touch-first playlist manager for phone and tablet surfaces.
 ///
@@ -59,8 +31,6 @@ class _PlaylistSourceManagerSheetState
   final _urlFocusNode = FocusNode(debugLabel: 'playlist source URL');
   final _cancelFocusNode = FocusNode(debugLabel: 'playlist source cancel');
   final _saveFocusNode = FocusNode(debugLabel: 'playlist source save');
-  late final List<FocusNode> _presetFocusNodes;
-  Timer? _presetSaveFocusTimer;
   bool _showAddForm = false;
   bool _isSaving = false;
   bool _initialTvFocusScheduled = false;
@@ -74,10 +44,6 @@ class _PlaylistSourceManagerSheetState
     super.initState();
     _labelFocusNode.addListener(_handleTextFieldFocusChanged);
     _urlFocusNode.addListener(_handleTextFieldFocusChanged);
-    _presetFocusNodes = [
-      for (final preset in iptvOrgPlaylistPresets)
-        FocusNode(debugLabel: 'playlist preset ${preset.label}'),
-    ];
     final initialUrl = widget.initialUrl?.trim();
     if (initialUrl != null && initialUrl.isNotEmpty) {
       _showAddForm = true;
@@ -90,14 +56,11 @@ class _PlaylistSourceManagerSheetState
     super.didChangeDependencies();
     if (_initialTvFocusScheduled || !_isTenFootMode) return;
     _initialTvFocusScheduled = true;
-    _requestTvFocus(
-      _showAddForm ? _presetFocusNodes.first : _addSourceFocusNode,
-    );
+    _requestTvFocus(_showAddForm ? _labelFocusNode : _addSourceFocusNode);
   }
 
   @override
   void dispose() {
-    _presetSaveFocusTimer?.cancel();
     _labelFocusNode.removeListener(_handleTextFieldFocusChanged);
     _urlFocusNode.removeListener(_handleTextFieldFocusChanged);
     _labelController.dispose();
@@ -107,9 +70,6 @@ class _PlaylistSourceManagerSheetState
     _urlFocusNode.dispose();
     _cancelFocusNode.dispose();
     _saveFocusNode.dispose();
-    for (final focusNode in _presetFocusNodes) {
-      focusNode.dispose();
-    }
     super.dispose();
   }
 
@@ -120,7 +80,7 @@ class _PlaylistSourceManagerSheetState
       _urlError = null;
       _submitError = null;
     });
-    _requestTvFocus(_presetFocusNodes.first);
+    _requestTvFocus(_labelFocusNode);
   }
 
   void _closeAddForm() {
@@ -184,26 +144,6 @@ class _PlaylistSourceManagerSheetState
       semanticButton: true,
       child: ExcludeFocus(child: child),
     );
-  }
-
-  void _selectPreset(IptvOrgPlaylistPreset preset) {
-    setState(() {
-      _showAddForm = true;
-      _labelController.text = 'IPTV.org · ${preset.label}';
-      _urlController.text = preset.url;
-      _labelError = null;
-      _urlError = null;
-      _submitError = null;
-    });
-    // A preset is already complete. On TV, move straight to the save action
-    // instead of making the viewer traverse two populated text fields and
-    // unnecessarily opening the platform keyboard.
-    _requestTvFocus(_saveFocusNode, preserveTextFieldFocus: false);
-    _presetSaveFocusTimer?.cancel();
-    _presetSaveFocusTimer = Timer(const Duration(milliseconds: 250), () {
-      if (!mounted || !_saveFocusNode.canRequestFocus) return;
-      _saveFocusNode.requestFocus();
-    });
   }
 
   String? _validateUrl(String value) {
@@ -478,52 +418,16 @@ class _PlaylistSourceManagerSheetState
             ),
             const SizedBox(height: 8),
             const Text(
-              'Paste any M3U URL, including category, language, country, '
-              'region, city, or source playlists from IPTV.org.',
-            ),
-            const SizedBox(height: 12),
-            Text(
-              'IPTV.org quick choices',
-              style: Theme.of(context).textTheme.labelLarge,
-            ),
-            const SizedBox(height: 8),
-            Wrap(
-              spacing: 8,
-              runSpacing: 8,
-              children: [
-                for (
-                  var index = 0;
-                  index < iptvOrgPlaylistPresets.length;
-                  index++
-                )
-                  _adaptiveAction(
-                    tenFootMode: tenFootMode,
-                    focusNode: _presetFocusNodes[index],
-                    autofocus:
-                        tenFootMode &&
-                        index == 0 &&
-                        (widget.initialUrl?.trim().isEmpty ?? true),
-                    onSelect: _isSaving
-                        ? null
-                        : () => _selectPreset(iptvOrgPlaylistPresets[index]),
-                    semanticLabel: iptvOrgPlaylistPresets[index].label,
-                    child: ActionChip(
-                      label: Text(iptvOrgPlaylistPresets[index].label),
-                      onPressed: _isSaving
-                          ? null
-                          : () => _selectPreset(iptvOrgPlaylistPresets[index]),
-                    ),
-                  ),
-              ],
+              'Paste an M3U or M3U8 URL for playlists you own or are '
+              'authorized to use. Midas Stream does not provide channels, '
+              'playlists, or streams.',
             ),
             const SizedBox(height: 12),
             TextField(
               key: const ValueKey('playlist-source-label-field'),
               controller: _labelController,
               focusNode: _labelFocusNode,
-              autofocus:
-                  tenFootMode &&
-                  (widget.initialUrl?.trim().isNotEmpty ?? false),
+              autofocus: tenFootMode,
               enabled: !_isSaving,
               textInputAction: TextInputAction.next,
               decoration: InputDecoration(

--- a/packages/feature_iptv/lib/product_identity.dart
+++ b/packages/feature_iptv/lib/product_identity.dart
@@ -1,0 +1,11 @@
+/// Canonical Play Store identity for the Android TV product.
+///
+/// Gradle `applicationId`, store listing copy, and user-visible chrome must
+/// stay aligned with these constants. Historical GitHub APKs published as
+/// `io.airo.app.tv` / "Airo TV" are a different listing and must not be
+/// described as this package.
+abstract final class TvStoreProduct {
+  static const displayName = 'Midas Stream';
+  static const androidPackageId = 'com.developerscoffee.tv.midas';
+  static const publisher = 'DevelopersCoffee';
+}

--- a/packages/feature_iptv/test/iptv/presentation/screens/iptv_screen_test.dart
+++ b/packages/feature_iptv/test/iptv/presentation/screens/iptv_screen_test.dart
@@ -196,7 +196,7 @@ void main() {
       await tester.pumpWidget(createWidget());
       await tester.pumpAndSettle();
 
-      expect(find.text('Airo TV'), findsOneWidget);
+      expect(find.text('Midas Stream'), findsOneWidget);
       expect(find.byTooltip('Cast'), findsNothing);
     } finally {
       debugDefaultTargetPlatformOverride = null;
@@ -213,7 +213,7 @@ void main() {
     await tester.pump();
 
     expect(find.byType(AppBar), findsNothing);
-    expect(find.text('Airo TV'), findsNothing);
+    expect(find.text('Midas Stream'), findsNothing);
     expect(find.byType(VideoPlayerWidget), findsOneWidget);
 
     AiroNativePictureInPicture.debugNotifyStateChanged(false);
@@ -513,7 +513,7 @@ void main() {
     await tester.pump(const Duration(milliseconds: 300));
 
     expect(handled, isTrue);
-    expect(find.text('Airo TV'), findsOneWidget);
+    expect(find.text('Midas Stream'), findsOneWidget);
     expect(
       find.byKey(const ValueKey('iptv-preview-fullscreen-button')),
       findsOneWidget,
@@ -663,8 +663,14 @@ void main() {
     await activateAppBarAction(tester, 'Playlist source');
     await tester.tap(find.byKey(const ValueKey('playlist-source-add-button')));
     await tester.pump();
-    await tester.tap(find.text('By country'));
-    await tester.pump();
+    await tester.enterText(
+      find.byKey(const ValueKey('playlist-source-label-field')),
+      'Country list',
+    );
+    await tester.enterText(
+      find.byKey(const ValueKey('playlist-source-url-field')),
+      'https://example.com/country.m3u',
+    );
     final saveButton = find.byKey(
       const ValueKey('playlist-source-save-button'),
     );
@@ -690,7 +696,7 @@ void main() {
     await tester.pumpWidget(createEmptyWidget());
     await tester.pumpAndSettle();
 
-    expect(find.text('Airo TV'), findsOneWidget);
+    expect(find.text('Midas Stream'), findsOneWidget);
     expect(find.byTooltip('Playlist source'), findsOneWidget);
     expect(find.text('Add your playlist'), findsOneWidget);
     expect(

--- a/packages/feature_iptv/test/iptv/presentation/tv_ux/airo_tv_shell_test.dart
+++ b/packages/feature_iptv/test/iptv/presentation/tv_ux/airo_tv_shell_test.dart
@@ -146,7 +146,7 @@ void main() {
       find.byKey(const ValueKey('airo-tv-shell-help-dialog')),
       findsOneWidget,
     );
-    expect(find.text('Airo TV Help'), findsOneWidget);
+    expect(find.text('Midas Stream Help'), findsOneWidget);
 
     await tester.sendKeyEvent(LogicalKeyboardKey.escape);
     await tester.pumpAndSettle();

--- a/packages/feature_iptv/test/iptv/presentation/widgets/playlist_source_manager_sheet_test.dart
+++ b/packages/feature_iptv/test/iptv/presentation/widgets/playlist_source_manager_sheet_test.dart
@@ -221,32 +221,29 @@ void main() {
     expect(removeTarget.height, greaterThanOrEqualTo(48));
   });
 
-  testWidgets(
-    'TV dialog owns focus and CENTER opens the add-playlist form',
-    (tester) async {
-      final container = await buildContainer();
-      addTearDown(container.dispose);
-      await pumpTvManagerDialog(tester, container);
+  testWidgets('TV dialog owns focus and CENTER opens the add-playlist form', (
+    tester,
+  ) async {
+    final container = await buildContainer();
+    addTearDown(container.dispose);
+    await pumpTvManagerDialog(tester, container);
 
-      final addButton = find.byKey(
-        const ValueKey('playlist-source-add-button'),
-      );
-      final addFocusable = tester.widget<TvFocusable>(
-        find.ancestor(of: addButton, matching: find.byType(TvFocusable)),
-      );
-      expect(addFocusable.focusNode?.hasPrimaryFocus, isTrue);
+    final addButton = find.byKey(const ValueKey('playlist-source-add-button'));
+    final addFocusable = tester.widget<TvFocusable>(
+      find.ancestor(of: addButton, matching: find.byType(TvFocusable)),
+    );
+    expect(addFocusable.focusNode?.hasPrimaryFocus, isTrue);
 
-      await tester.sendKeyEvent(LogicalKeyboardKey.select);
-      await tester.pumpAndSettle();
+    await tester.sendKeyEvent(LogicalKeyboardKey.select);
+    await tester.pumpAndSettle();
 
-      expect(find.text('Add playlist'), findsOneWidget);
-      expect(find.byType(ActionChip), findsNothing);
-      final labelField = tester.widget<TextField>(
-        find.byKey(const ValueKey('playlist-source-label-field')),
-      );
-      expect(labelField.focusNode?.hasPrimaryFocus, isTrue);
-    },
-  );
+    expect(find.text('Add playlist'), findsOneWidget);
+    expect(find.byType(ActionChip), findsNothing);
+    final labelField = tester.widget<TextField>(
+      find.byKey(const ValueKey('playlist-source-label-field')),
+    );
+    expect(labelField.focusNode?.hasPrimaryFocus, isTrue);
+  });
 
   testWidgets(
     'Fire TV BACK leaves the playlist form after dismissing its keyboard',

--- a/packages/feature_iptv/test/iptv/presentation/widgets/playlist_source_manager_sheet_test.dart
+++ b/packages/feature_iptv/test/iptv/presentation/widgets/playlist_source_manager_sheet_test.dart
@@ -105,9 +105,7 @@ void main() {
     expect(find.text('iptv-org.github.io/iptv/index.m3u'), findsOneWidget);
   });
 
-  testWidgets('adds a second IPTV.org playlist from a touch preset', (
-    tester,
-  ) async {
+  testWidgets('adds a second playlist from a typed URL', (tester) async {
     final container = await buildContainer(
       preferences: const {
         'iptv_user_playlist_url': 'https://iptv-org.github.io/iptv/index.m3u',
@@ -118,14 +116,20 @@ void main() {
 
     await tester.tap(find.byKey(const ValueKey('playlist-source-add-button')));
     await tester.pump();
-    await tester.tap(find.text('By country'));
-    await tester.pump();
+    await tester.enterText(
+      find.byKey(const ValueKey('playlist-source-label-field')),
+      'Country list',
+    );
+    await tester.enterText(
+      find.byKey(const ValueKey('playlist-source-url-field')),
+      'https://example.com/country.m3u',
+    );
     await tester.tap(find.byKey(const ValueKey('playlist-source-save-button')));
     await tester.pumpAndSettle();
 
     expect(find.text('2 playlist sources'), findsOneWidget);
     expect(find.text('IPTV.org'), findsOneWidget);
-    expect(find.text('IPTV.org · By country'), findsOneWidget);
+    expect(find.text('Country list'), findsOneWidget);
     final sources = await container.read(
       configuredContentSourcesProvider.future,
     );
@@ -218,7 +222,7 @@ void main() {
   });
 
   testWidgets(
-    'TV dialog owns focus and CENTER opens the form and selects a preset',
+    'TV dialog owns focus and CENTER opens the add-playlist form',
     (tester) async {
       final container = await buildContainer();
       addTearDown(container.dispose);
@@ -236,68 +240,13 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.text('Add playlist'), findsOneWidget);
-      final allChannelsChip = find.widgetWithText(ActionChip, 'All channels');
-      final presetFocusable = tester.widget<TvFocusable>(
-        find.ancestor(of: allChannelsChip, matching: find.byType(TvFocusable)),
-      );
-      expect(presetFocusable.focusNode?.hasPrimaryFocus, isTrue);
-
-      await tester.sendKeyEvent(LogicalKeyboardKey.select);
-      await tester.pump();
-
+      expect(find.byType(ActionChip), findsNothing);
       final labelField = tester.widget<TextField>(
         find.byKey(const ValueKey('playlist-source-label-field')),
       );
-      final urlField = tester.widget<TextField>(
-        find.byKey(const ValueKey('playlist-source-url-field')),
-      );
-      expect(labelField.controller?.text, 'IPTV.org · All channels');
-      expect(
-        urlField.controller?.text,
-        'https://iptv-org.github.io/iptv/index.m3u',
-      );
-      final saveButton = find.byKey(
-        const ValueKey('playlist-source-save-button'),
-      );
-      final saveFocusable = tester.widget<TvFocusable>(
-        find.ancestor(of: saveButton, matching: find.byType(TvFocusable)),
-      );
-      expect(saveFocusable.focusNode?.hasPrimaryFocus, isTrue);
+      expect(labelField.focusNode?.hasPrimaryFocus, isTrue);
     },
   );
-  testWidgets('TV preset takes save focus back from a stale text field', (
-    tester,
-  ) async {
-    final container = await buildContainer();
-    addTearDown(container.dispose);
-    await pumpTvManagerDialog(tester, container);
-
-    await tester.sendKeyEvent(LogicalKeyboardKey.select);
-    await tester.pumpAndSettle();
-
-    final labelField = tester.widget<TextField>(
-      find.byKey(const ValueKey('playlist-source-label-field')),
-    );
-    labelField.focusNode?.requestFocus();
-    await tester.pump();
-    expect(labelField.focusNode?.hasPrimaryFocus, isTrue);
-
-    await tester.tap(find.widgetWithText(ActionChip, 'All channels'));
-    await tester.pump(const Duration(milliseconds: 100));
-    // Fire OS can restore the field after Flutter's immediate post-frame
-    // requests. The delayed preset reassertion must still win.
-    labelField.focusNode?.requestFocus();
-    await tester.pump(const Duration(milliseconds: 200));
-    await tester.pumpAndSettle();
-
-    final saveButton = find.byKey(
-      const ValueKey('playlist-source-save-button'),
-    );
-    final saveFocusable = tester.widget<TvFocusable>(
-      find.ancestor(of: saveButton, matching: find.byType(TvFocusable)),
-    );
-    expect(saveFocusable.focusNode?.hasPrimaryFocus, isTrue);
-  });
 
   testWidgets(
     'Fire TV BACK leaves the playlist form after dismissing its keyboard',

--- a/packages/platform_benchmarks/README.md
+++ b/packages/platform_benchmarks/README.md
@@ -58,7 +58,7 @@ Use the playback soak runner when a physical Android TV device or 1 GB profile
 is connected and the app is installed:
 
 ```bash
-AIRO_TV_PACKAGE=io.airo.app.tv \
+AIRO_TV_PACKAGE=com.developerscoffee.tv.midas \
 AIRO_TV_DEVICE=<adb-serial> \
 AIRO_TV_SOAK_DART_HEAP_START_MB=42 \
 AIRO_TV_SOAK_DART_HEAP_END_MB=42 \

--- a/packages/platform_benchmarks/test/airo_tv_playback_soak_runner_test.dart
+++ b/packages/platform_benchmarks/test/airo_tv_playback_soak_runner_test.dart
@@ -38,7 +38,7 @@ void main() {
 
     final report = await runner.run(
       const AiroTvPlaybackSoakConfig(
-        packageName: 'io.airo.app.tv',
+        packageName: 'com.developerscoffee.tv.midas',
         deviceSerial: 'pixel-9',
         duration: Duration(seconds: 60),
         sampleInterval: Duration(seconds: 30),
@@ -64,7 +64,7 @@ void main() {
         'shell',
         'monkey',
         '-p',
-        'io.airo.app.tv',
+        'com.developerscoffee.tv.midas',
         '-c',
         'android.intent.category.LAUNCHER',
         '1',
@@ -98,7 +98,7 @@ void main() {
 
       final report = await runner.run(
         const AiroTvPlaybackSoakConfig(
-          packageName: 'io.airo.app.tv',
+          packageName: 'com.developerscoffee.tv.midas',
           duration: Duration(minutes: 30),
           sampleInterval: Duration(minutes: 15),
           dartHeapStartMb: 40,
@@ -130,7 +130,7 @@ void main() {
     expect(
       () => runner.run(
         const AiroTvPlaybackSoakConfig(
-          packageName: 'io.airo.app.tv',
+          packageName: 'com.developerscoffee.tv.midas',
           duration: Duration(seconds: 30),
           sampleInterval: Duration(seconds: 30),
         ),
@@ -162,7 +162,7 @@ void main() {
 
     await runner.write(
       AiroTvPlaybackSoakConfig(
-        packageName: 'io.airo.app.tv',
+        packageName: 'com.developerscoffee.tv.midas',
         duration: const Duration(seconds: 1),
         sampleInterval: const Duration(seconds: 1),
         dartHeapStartMb: 41,
@@ -176,7 +176,7 @@ void main() {
     final markdown = await File('${directory.path}/soak.md').readAsString();
 
     expect(json, contains('"reportId": "airo-tv-playback-soak"'));
-    expect(json, isNot(contains('io.airo.app.tv')));
+    expect(json, isNot(contains('com.developerscoffee.tv.midas')));
     expect(markdown, contains('# Airo Runtime Memory Timeline'));
   });
 }

--- a/packages/platform_benchmarks/tool/run_airo_tv_playback_soak.dart
+++ b/packages/platform_benchmarks/tool/run_airo_tv_playback_soak.dart
@@ -169,7 +169,7 @@ class _CliOptions {
     stderr.writeln('''
 Usage:
   dart run tool/run_airo_tv_playback_soak.dart \\
-    --package io.airo.app.tv \\
+    --package com.developerscoffee.tv.midas \\
     --device <adb-serial> \\
     --duration-minutes 30 \\
     --interval-seconds 30 \\

--- a/packages/stubs/package_info_plus_stub/lib/package_info_plus.dart
+++ b/packages/stubs/package_info_plus_stub/lib/package_info_plus.dart
@@ -34,10 +34,10 @@ class PackageInfo {
   static Future<PackageInfo> fromPlatform({String? baseUrl}) async {
     return _fromPlatform ??
         PackageInfo(
-          appName: 'Airo TV',
+          appName: 'Midas Stream',
           // Matches `variantApplicationId` for the "tv" variant in
           // app/android/app/build.gradle.kts.
-          packageName: 'io.airo.app.tv',
+          packageName: 'com.developerscoffee.tv.midas',
           version: _stubVersion,
           buildNumber: _stubBuildNumber,
         );

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -137,7 +137,7 @@ melos:
         cd packages/platform_benchmarks
         flutter pub get
         dart run tool/run_airo_tv_playback_soak.dart \
-          --package "${AIRO_TV_PACKAGE:-io.airo.app.tv}" \
+          --package "${AIRO_TV_PACKAGE:-com.developerscoffee.tv.midas}" \
           --device "${AIRO_TV_DEVICE:-}" \
           --duration-seconds "${AIRO_TV_SOAK_DURATION_SECONDS:-1800}" \
           --interval-seconds "${AIRO_TV_SOAK_INTERVAL_SECONDS:-30}" \

--- a/scripts/check-android-tv-release.sh
+++ b/scripts/check-android-tv-release.sh
@@ -9,7 +9,7 @@ TV_PUBSPEC="$ROOT_DIR/app/pubspec_tv.yaml"
 RESOURCE_KEEP_FILE="${AIRO_TV_RESOURCE_KEEP_FILE:-$ROOT_DIR/app/android/app/src/main/res/raw/keep.xml}"
 PLUGIN_REGISTRANT="${AIRO_TV_PLUGIN_REGISTRANT:-$ROOT_DIR/app/android/app/src/main/java/io/flutter/plugins/GeneratedPluginRegistrant.java}"
 MIN_TARGET_SDK="${AIRO_TV_MIN_TARGET_SDK:-34}"
-TV_PACKAGE_NAME="${AIRO_TV_PACKAGE_NAME:-io.airo.app.tv}"
+TV_PACKAGE_NAME="${AIRO_TV_PACKAGE_NAME:-com.developerscoffee.tv.midas}"
 
 fail() {
   local message="$1"

--- a/scripts/check-fire-tv-playback-logs.sh
+++ b/scripts/check-fire-tv-playback-logs.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-PACKAGE_NAME="${AIRO_ANDROID_TV_PACKAGE:-io.airo.app.tv}"
+PACKAGE_NAME="${AIRO_ANDROID_TV_PACKAGE:-com.developerscoffee.tv.midas}"
 DURATION_SECONDS="${AIRO_FIRE_TV_LOG_DURATION_SECONDS:-5}"
 OUTPUT_FILE="${AIRO_FIRE_TV_LOG_REPORT:-$ROOT_DIR/artifacts/release-qualification/fire-tv-playback-log-report.md}"
 INPUT_FILE=""
@@ -64,7 +64,7 @@ else
     1 >/dev/null
   pid="$(adb -s "$device" shell pidof "$PACKAGE_NAME" | tr -d '\r')"
   if [[ -z "$pid" ]]; then
-    echo "Airo TV process is not running after launcher start" >&2
+    echo "Midas Stream process is not running after launcher start" >&2
     exit 1
   fi
   adb -s "$device" logcat -c
@@ -92,7 +92,8 @@ grep -vF \
   -e 'ioctl c0044901 failed with code -1: Invalid argument' \
   "$normalized_sample" > "$tmp_dir/actionable.log" || true
 actionable_count="$(grep -c . "$tmp_dir/actionable.log" || true)"
-fatal_count="$(grep -Ec 'FATAL EXCEPTION|AndroidRuntime|Process: io\.airo\.app\.tv' "$tmp_dir/actionable.log" || true)"
+escaped_package="${PACKAGE_NAME//./\\.}"
+fatal_count="$(grep -Ec "FATAL EXCEPTION|AndroidRuntime|Process: ${escaped_package}" "$tmp_dir/actionable.log" || true)"
 
 status="PASS"
 if [[ "$actionable_count" -gt 0 ]]; then

--- a/scripts/release-artifact-smoke.sh
+++ b/scripts/release-artifact-smoke.sh
@@ -5,7 +5,7 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 ARTIFACT_DIR="${AIRO_RELEASE_ARTIFACT_DIR:-$ROOT_DIR/release-artifacts}"
 OUTPUT_DIR="${AIRO_RELEASE_QUALIFICATION_DIR:-$ROOT_DIR/artifacts/release-qualification/$(date -u +%Y%m%dT%H%M%SZ)}"
 PACKAGE_NAME="${AIRO_ANDROID_PACKAGE:-io.airo.app}"
-TV_PACKAGE_NAME="${AIRO_ANDROID_TV_PACKAGE:-io.airo.app.tv}"
+TV_PACKAGE_NAME="${AIRO_ANDROID_TV_PACKAGE:-com.developerscoffee.tv.midas}"
 REQUIRE_ARTIFACTS="${AIRO_REQUIRE_RELEASE_ARTIFACTS:-false}"
 RUN_DEVICE_SMOKE="${AIRO_RUN_DEVICE_SMOKE:-false}"
 RUN_WEB_SMOKE="${AIRO_RUN_WEB_SMOKE:-false}"
@@ -19,7 +19,7 @@ device/web smoke checks.
 
 Environment:
   AIRO_ANDROID_PACKAGE              Android package to launch, default io.airo.app
-  AIRO_ANDROID_TV_PACKAGE           Android TV package, default io.airo.app.tv
+  AIRO_ANDROID_TV_PACKAGE           Android TV package, default com.developerscoffee.tv.midas
   AIRO_REQUIRE_RELEASE_ARTIFACTS    true to fail when no artifacts are found
   AIRO_RUN_DEVICE_SMOKE             true to install/launch APKs through adb
   AIRO_RUN_WEB_SMOKE                true to serve web zip and run Playwright

--- a/scripts/test-generate-release-manifest.sh
+++ b/scripts/test-generate-release-manifest.sh
@@ -52,7 +52,7 @@ aab = artifacts["Airo-TV-v2.0.0-Play-Store.aab"]
 macos_zip = artifacts["Airo-TV-v2.0.0-macOS.zip"]
 macos_dmg = artifacts["Airo-TV-v2.0.0-macOS.dmg"]
 assert apk["profileId"] == "tv"
-assert apk["packageId"] == "io.airo.app.tv"
+assert apk["packageId"] == "com.developerscoffee.tv.midas"
 assert apk["artifactType"] == "apk"
 assert apk["distributionChannel"] == "direct-apk"
 assert apk["abi"] == "android-arm64"
@@ -132,11 +132,11 @@ manifest = json.load(open(sys.argv[1], encoding="utf-8"))
 byname = {a["filename"]: a for a in manifest["artifacts"]}
 
 expected_profile = {
-    "Airo-TV-0.0.6.apk": ("tv", "io.airo.app.tv"),
-    "Airo-TV-0.0.6-arm64-v8a.apk": ("tv", "io.airo.app.tv"),
-    "Airo-TV-0.0.6-armeabi-v7a.apk": ("tv", "io.airo.app.tv"),
-    "Airo-TV-0.0.6-x86_64.apk": ("tv", "io.airo.app.tv"),
-    "Airo-TV-0.0.6-Play-Store.aab": ("tv", "io.airo.app.tv"),
+    "Airo-TV-0.0.6.apk": ("tv", "com.developerscoffee.tv.midas"),
+    "Airo-TV-0.0.6-arm64-v8a.apk": ("tv", "com.developerscoffee.tv.midas"),
+    "Airo-TV-0.0.6-armeabi-v7a.apk": ("tv", "com.developerscoffee.tv.midas"),
+    "Airo-TV-0.0.6-x86_64.apk": ("tv", "com.developerscoffee.tv.midas"),
+    "Airo-TV-0.0.6-Play-Store.aab": ("tv", "com.developerscoffee.tv.midas"),
     "Airo-0.0.6-10-arm64.apk": ("full", "io.airo.app"),
     "Airo-0.0.6-10-Play-Store.aab": ("full", "io.airo.app"),
     "AiroCoins-0.0.6-10-arm64.apk": ("coins", "io.airo.app.coins"),

--- a/scripts/test-generate-release-qualification-report.sh
+++ b/scripts/test-generate-release-qualification-report.sh
@@ -25,7 +25,7 @@ cat >"$manifest" <<'JSON'
     {
       "filename": "Airo-TV-v2.0.0.apk",
       "profileId": "tv",
-      "packageId": "io.airo.app.tv",
+      "packageId": "com.developerscoffee.tv.midas",
       "artifactType": "apk",
       "sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
     }

--- a/scripts/tests/test_publish_framework.py
+++ b/scripts/tests/test_publish_framework.py
@@ -80,7 +80,7 @@ def write_release(root: Path, *, corrupt: bool = False) -> Path:
             {
                 "filename": filename,
                 "profileId": "tv",
-                "packageId": "io.airo.app.tv",
+                "packageId": "com.developerscoffee.tv.midas",
                 "version": "0.0.6",
                 "buildNumber": "12",
                 "artifactType": artifact_type,
@@ -130,7 +130,7 @@ def website_target(output_path: str = "docs/_data/downloads_tv.json") -> dict:
         "enabled": True,
         "profiles": {
             "tv": {
-                "packageId": "io.airo.app.tv",
+                "packageId": "com.developerscoffee.tv.midas",
                 "artifactSelector": {"artifactType": ["apk"], "minCount": 1, "maxCount": 1},
                 "releaseNotes": {"source": "inline", "text": "Fixes and polish."},
                 "options": {
@@ -370,7 +370,7 @@ class RunnerTests(unittest.TestCase):
                     "enabled": True,
                     "profiles": {
                         "tv": {
-                            "packageId": "io.airo.app.tv",
+                            "packageId": "com.developerscoffee.tv.midas",
                             "artifactSelector": {"artifactType": ["apk"]},
                             "releaseNotes": {"source": "inline", "text": "Notes."},
                         }
@@ -396,7 +396,7 @@ class RunnerTests(unittest.TestCase):
                     "enabled": True,
                     "profiles": {
                         "tv": {
-                            "packageId": "io.airo.app.tv",
+                            "packageId": "com.developerscoffee.tv.midas",
                             "artifactSelector": {"artifactType": ["apk"], "maxCount": 1},
                             "releaseNotes": {"source": "inline", "text": "Notes."},
                         }
@@ -502,7 +502,7 @@ class SubmitGatingTests(unittest.TestCase):
                         "enabled": True,
                         "profiles": {
                             "tv": {
-                                "packageId": "io.airo.app.tv",
+                                "packageId": "com.developerscoffee.tv.midas",
                                 "artifactSelector": {"artifactType": ["aab"], "maxCount": 1},
                                 "releaseNotes": {"source": "inline", "text": "Notes."},
                                 "options": {"track": "internal"},
@@ -548,7 +548,7 @@ class SubmitGatingTests(unittest.TestCase):
                             "enabled": True,
                             "profiles": {
                                 "tv": {
-                                    "packageId": "io.airo.app.tv",
+                                    "packageId": "com.developerscoffee.tv.midas",
                                     "artifactSelector": {"artifactType": ["apk"], "maxCount": 1},
                                     "releaseNotes": {"source": "inline", "text": "Notes."},
                                     "options": {"track": "internal"},
@@ -583,7 +583,7 @@ class SubmitGatingTests(unittest.TestCase):
                             "enabled": True,
                             "profiles": {
                                 "tv": {
-                                    "packageId": "io.airo.app.tv",
+                                    "packageId": "com.developerscoffee.tv.midas",
                                     "artifactSelector": {"artifactType": ["aab"], "maxCount": 1},
                                     "releaseNotes": {"source": "inline", "text": "Notes."},
                                     "options": {"track": "everyone"},
@@ -678,7 +678,7 @@ class BrowserModeTests(unittest.TestCase):
                         "enabled": True,
                         "profiles": {
                             "tv": {
-                                "packageId": "io.airo.app.tv",
+                                "packageId": "com.developerscoffee.tv.midas",
                                 "artifactSelector": {"artifactType": ["apk"], "maxCount": 1},
                                 "releaseNotes": {"source": "inline", "text": "Notes."},
                                 "options": options,
@@ -730,7 +730,7 @@ class BrowserOptionPrecedenceTests(unittest.TestCase):
                         "enabled": True,
                         "profiles": {
                             "tv": {
-                                "packageId": "io.airo.app.tv",
+                                "packageId": "com.developerscoffee.tv.midas",
                                 "artifactSelector": {"artifactType": ["apk"], "maxCount": 1},
                                 "releaseNotes": {"source": "inline", "text": "Notes."},
                                 "options": config_options,
@@ -828,7 +828,7 @@ class FilenamePreferenceTests(unittest.TestCase):
         from tools.publish.models import Artifact
         return [
             Artifact(
-                filename=n, profile_id="tv", package_id="io.airo.app.tv", version="0.0.6",
+                filename=n, profile_id="tv", package_id="com.developerscoffee.tv.midas", version="0.0.6",
                 build_number="10", artifact_type="apk", abi="android-arm64",
                 distribution_channel="direct-apk", size_bytes=1, sha256="x", path=Path(n),
             )
@@ -959,7 +959,7 @@ class ManifestIndexTests(unittest.TestCase):
                         {
                             "filename": filename,
                             "profileId": profile_id,
-                            "packageId": "io.airo.app.tv",
+                            "packageId": "com.developerscoffee.tv.midas",
                             "version": "0.0.6",
                             "buildNumber": "10",
                             "artifactType": "apk",
@@ -1043,7 +1043,7 @@ class CliTests(unittest.TestCase):
             payload = json.loads(result.stdout)
             self.assertEqual(payload["release"]["version"], "0.0.6")
             self.assertEqual(payload["plan"][0]["target"], "github")
-            self.assertEqual(payload["plan"][0]["packageId"], "io.airo.app.tv")
+            self.assertEqual(payload["plan"][0]["packageId"], "com.developerscoffee.tv.midas")
 
     def test_missing_manifest_exits_with_the_manifest_code(self) -> None:
         result = self.run_cli("plan", "--manifest", "/nonexistent/Release-Manifest.json")

--- a/tools/publish/README.md
+++ b/tools/publish/README.md
@@ -112,7 +112,7 @@ gets. Adding a listing is a config change, not a code change.
   "enabled": false,
   "profiles": {
     "tv": {
-      "packageId": "io.airo.app.tv",
+      "packageId": "com.developerscoffee.tv.midas",
       "artifactSelector": {
         "artifactType": ["apk"],
         "filenamePattern": "^Airo-TV-{version}\\.apk$",
@@ -222,7 +222,7 @@ console flow but have **not** been recorded against the live DOM. Before the
 first real run:
 
 ```bash
-python3 -m tools.publish doctor apkpure --package-id io.airo.app.tv
+python3 -m tools.publish doctor apkpure --package-id com.developerscoffee.tv.midas
 ```
 
 It reports which selector keys matched nothing, dumps the page HTML and

--- a/tools/publish/apkpure/selectors.py
+++ b/tools/publish/apkpure/selectors.py
@@ -9,7 +9,7 @@ nobody controls but APKPure. Every selector below is therefore:
   broken release can be unblocked without a code change and a PR.
 
 **Status: recorded against the live console on 2026-08-04** for
-io.airo.app.tv, signed in, via CDP. The navigation, upload-form, release-notes,
+com.developerscoffee.tv.midas, signed in, via CDP. The navigation, upload-form, release-notes,
 and publish selectors were read off the real DOM. Three could not be recorded
 because they only appear mid-upload -- ``upload_complete_marker``,
 ``upload_error_marker`` and ``submit_success_marker`` remain heuristics, and the
@@ -38,7 +38,7 @@ CONSOLE_URL_TEMPLATE = f"{CONSOLE_ORIGIN}/console/{{package_id}}"
 #: class-name chains.
 #: Logical step -> ordered candidate selectors, tried in order.
 #:
-#: Recorded against the live console on 2026-08-04 for io.airo.app.tv. The
+#: Recorded against the live console on 2026-08-04 for com.developerscoffee.tv.midas. The
 #: console is a Materialize CSS app: the version table and the upload form both
 #: live on /console/<package>/versions, and there is no separate "new version"
 #: dialog. Ids (#file, #textarea1) come first because they are what the page

--- a/tools/publish/cli.py
+++ b/tools/publish/cli.py
@@ -5,7 +5,7 @@
     python3 -m tools.publish plan   --tag v0.0.6 --profile tv --target apkpure
     python3 -m tools.publish run    --tag v0.0.6 --profile tv --target apkpure --submit
     python3 -m tools.publish login  apkpure
-    python3 -m tools.publish doctor apkpure --package-id io.airo.app.tv
+    python3 -m tools.publish doctor apkpure --package-id com.developerscoffee.tv.midas
 
 Artifacts always come from a published GitHub Release (`--tag`), never a local
 build; `--manifest` exists only for an already-downloaded release directory.
@@ -125,7 +125,7 @@ def build_parser() -> argparse.ArgumentParser:
 
     doctor = sub.add_parser("doctor", help="Dump a store console page so selectors can be re-mapped.")
     doctor.add_argument("target", choices=["apkpure"])
-    doctor.add_argument("--package-id", default="io.airo.app.tv")
+    doctor.add_argument("--package-id", default="com.developerscoffee.tv.midas")
     doctor.add_argument("--storage-state", type=Path, default=None)
     doctor.add_argument("--evidence-dir", type=Path, default=DEFAULT_EVIDENCE_DIR)
     doctor.add_argument("--headed", action="store_true")


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

First Play Store identity cutover for the Android TV player.

`origin/main` was scanned as a release engineer before this branch. The TV flavor still shipped as **Airo TV** / `io.airo.app.tv`, and the playlist manager one-tapped public iptv-org playlists. Both would block a friction-free first listing: Play cannot rename a package ID, and one-tap public IPTV indexes are an intellectual-property rejection.

This branch creates the **Midas Stream** listing identity:

| Field | Value |
| --- | --- |
| App name | Midas Stream |
| Android `applicationId` | `com.developerscoffee.tv.midas` |
| Gradle `namespace` | `io.airo.app` (unchanged — Play uses `applicationId`) |
| macOS bundle ID | `com.developerscoffee.airo.tv` (out of scope this wave) |

Play policy hardening in the same change:

- Removed iptv-org one-tap presets from production UI.
- Disabled the production iptv-org catalogue fetch (`streams.json` is a public stream URL database).
- Empty-state and add-playlist copy now say the app provides no channels or playlists.
- Privacy/terms, Data Safety, content rating, and store listing copy match Midas Stream.
- TV manifest now declares `FOREGROUND_SERVICE_DATA_SYNC` for WorkManager on Android 14+.

Working gate: `docs/release/MIDAS_STREAM_PLAY_STORE_GATE.md`.

This is a **new Play Console app**, not an update of `io.airo.app.tv`.

## Test Plan

- [x] `scripts/test-generate-release-manifest.sh`
- [x] `scripts/test-generate-release-qualification-report.sh`
- [x] `scripts/test-check-fire-tv-playback-logs.sh`
- [x] `python3 -m unittest scripts.tests.test_publish_framework`
- [x] `flutter test` in `packages/core_release` (89 tests)
- [x] `flutter test` playlist manager, IPTV screen, and TV shell suites in `packages/feature_iptv` (57 tests)
- [ ] Pixel-line install of `com.developerscoffee.tv.midas` (user-owned next step)

**Verification environment:** Host-only. Pixel 9 / emulator not available on this agent.

## Agent Policy

- Release/DevEx primary owner. Flutter Architect + Chief Security Officer + Product Manager are required reviewers (user-visible rebrand + store/legal).
- Feature packet: `docs/release/MIDAS_STREAM_PLAY_STORE_GATE.md`.
- No new framework/application contract; identity and policy only.

## Council Review

- Flutter Architect: user-visible TV chrome and playlist manager
- Chief Security Officer / privacy: legal pages, Data Safety, catalogue fetch removed
- Chief Release/DevOps Officer: package ID, Fastlane, workflows, preflights
- Product Manager: Midas Stream listing copy
- Chief Documentation Officer: store worksheets + wiki/architecture

## Human console actions still required

1. Create the Play Console app for `com.developerscoffee.tv.midas`.
2. Register a Firebase Android client for that package (closed #574 was `io.airo.app.tv`).
3. Confirm upload keystore / Play App Signing.
4. Complete IARC and Data Safety from the updated worksheets.
5. Export 512×512 icon and TV screenshots under the Midas Stream name.
6. Pixel smoke, then first internal-track AAB.

## User-Facing Documentation

- [x] `docs/wiki/2.-Getting-Started.md` distinguishes GitHub v0.0.6 (`io.airo.app.tv`) from the new Play listing.
- [x] Privacy policy and terms relabeled; public catalogue download claim removed.

## Plugin and Size Impact

No new dependencies. Playlist preset UI was removed (net smaller).

## Release Notes

Midas Stream is the Play Store name for the Android TV player. Users add their own authorized M3U/M3U8 playlists. The app does not include channels or a public IPTV catalogue.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2333a747-930c-467d-90c7-62322cef6553?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2333a747-930c-467d-90c7-62322cef6553&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

