### PR TITLE
fix(tv): say Aika Stream in What's New changelog

### DIFF
--- a/packages/feature_iptv/CHANGELOG.md
+++ b/packages/feature_iptv/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 - Added the offline Intent Engine v1 adapter, contract validation, confidence
   fallback, and local playlist/EPG/history execution boundary.
-- Added the responsive Airo TV Explorer shell with persistent channel filters,
+- Added the responsive Aika Stream Explorer shell with persistent channel filters,
   saved filters, hotbar shortcuts, and resume-last-channel behavior.
 - Added Ways to Watch for fitted, fullscreen, supported floating-window, and
   Cast playback.
@@ -14,7 +14,7 @@
   track/subtitle/quality selection.
 - Limited concurrent multiview decoders to two on web and mobile and four on
   desktop, with a hard ceiling of four and clear capacity feedback.
-- Changed channel sharing to copy versioned Airo TV deep links that can restore
+- Changed channel sharing to copy versioned Aika Stream deep links that can restore
   the active Explorer filters and tune the channel without exposing stream
   URLs.
 - Added video-frame sharing from a capture boundary that excludes Explorer


### PR DESCRIPTION
## Summary
- The What's New dialog inside Aika Stream's Help screen parses the latest `## 0.0.1` section of `packages/feature_iptv/CHANGELOG.md`, which still had two leftover "Airo TV" bullets from before the Midas Stream -> Aika Stream rename. This was found in a device UAT pass.
- Updated "Airo TV Explorer shell" -> "Aika Stream Explorer shell" and "Airo TV deep links" -> "Aika Stream deep links".
- Settings > Appearance theme names ("Airo Living Console", "Airo Classic", "Airo TV") are a deliberately separate naming scope tied to the "Airo" platform brand and were left unchanged.
- Package id `com.developerscoffee.tv.midas` is unchanged.

## Test plan
- [x] `rg -n "Airo TV Explorer|Airo TV deep links" packages/feature_iptv/CHANGELOG.md` returns zero hits
- [x] `flutter test packages/feature_iptv/test/iptv/presentation/tv_ux/shell_help_dialog_test.dart` passes (2 tests)
- [x] Confirmed help dialog title source still reads "Aika Stream Help"
- [x] Confirmed package id `com.developerscoffee.tv.midas` is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)
